### PR TITLE
fix(ci): add .docs/ to review scope and fix force-push mode fallback

### DIFF
--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -8,6 +8,7 @@ on:
       - 'bindings/**'
       - 'tests/**'
       - 'scripts/**'
+      - '.docs/**'
       - 'Cargo.toml'
       - 'Cargo.lock'
 
@@ -54,10 +55,16 @@ jobs:
           echo "diff_head=$DIFF_HEAD" >> "$GITHUB_OUTPUT"
 
           # Write raw file list, then filter to in-scope paths
-          git diff --name-only "$DIFF_BASE".."$DIFF_HEAD" > /tmp/all-changed-files.txt || \
+          if ! git diff --name-only "$DIFF_BASE".."$DIFF_HEAD" > /tmp/all-changed-files.txt 2>/dev/null; then
+            # BEFORE sha is unreachable (force push) — fall back to full PR diff
+            MODE="full"
+            DIFF_BASE="$PR_BASE"
+            DIFF_HEAD="$HEAD"
+            echo "mode=$MODE" >> "$GITHUB_OUTPUT"
             gh pr view ${{ github.event.pull_request.number }} --json files --jq '.files[].path' > /tmp/all-changed-files.txt
+          fi
 
-          grep -E '^(crates/|bindings/|tests/|scripts/|Cargo\.(toml|lock)$)' /tmp/all-changed-files.txt > /tmp/changed-files.txt || true
+          grep -E '^(crates/|bindings/|tests/|scripts/|\.docs/|Cargo\.(toml|lock)$)' /tmp/all-changed-files.txt > /tmp/changed-files.txt || true
 
           FILE_COUNT=$(wc -l < /tmp/changed-files.txt | tr -d ' ')
           echo "file_count=$FILE_COUNT" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/spec-drift.yml
+++ b/.github/workflows/spec-drift.yml
@@ -8,6 +8,7 @@ on:
       - 'bindings/**'
       - 'tests/**'
       - 'scripts/**'
+      - '.docs/**'
       - 'Cargo.toml'
       - 'Cargo.lock'
 
@@ -51,10 +52,16 @@ jobs:
           echo "mode=$MODE" >> "$GITHUB_OUTPUT"
 
           # Write raw file list, then filter to in-scope paths
-          git diff --name-only "$DIFF_BASE".."$DIFF_HEAD" > /tmp/all-changed-files.txt || \
+          if ! git diff --name-only "$DIFF_BASE".."$DIFF_HEAD" > /tmp/all-changed-files.txt 2>/dev/null; then
+            # BEFORE sha is unreachable (force push) — fall back to full PR diff
+            MODE="full"
+            DIFF_BASE="$PR_BASE"
+            DIFF_HEAD="$HEAD"
+            echo "mode=$MODE" >> "$GITHUB_OUTPUT"
             gh pr view ${{ github.event.pull_request.number }} --json files --jq '.files[].path' > /tmp/all-changed-files.txt
+          fi
 
-          grep -E '^(crates/|bindings/|tests/|scripts/|Cargo\.(toml|lock)$)' /tmp/all-changed-files.txt > /tmp/changed-files.txt || true
+          grep -E '^(crates/|bindings/|tests/|scripts/|\.docs/|Cargo\.(toml|lock)$)' /tmp/all-changed-files.txt > /tmp/changed-files.txt || true
 
           FILE_COUNT=$(wc -l < /tmp/changed-files.txt | tr -d ' ')
           echo "file_count=$FILE_COUNT" >> "$GITHUB_OUTPUT"
@@ -142,7 +149,12 @@ jobs:
             - `**/governance/**` → `.docs/specs/13-governance.md`
             - `**/storage/**`, `**/persist/**` → `.docs/specs/17-persistence-and-storage.md`
 
-            Skip files that don't map to any spec (Cargo.toml, Cargo.lock, .docs/*, tests, etc.).
+            Skip files that don't map to any spec (Cargo.toml, Cargo.lock, tests, etc.).
+
+            **When `.docs/specs/` or `.docs/prds/` files are changed**: The source of truth itself
+            changed. Re-check the most relevant source files (in `crates/` or `bindings/`) against
+            the updated spec/PRD content, even if those source files are not in the diff. Focus on
+            sections that were modified in the spec change.
 
             ## Step 2: Check each spec area (batched)
 


### PR DESCRIPTION
## Summary

- **Bug 1: `.docs/` excluded from scope** — spec-drift and pr-review workflows only triggered on `crates/`, `bindings/`, `tests/`, `scripts/`, `Cargo.toml/lock`. Changes to `.docs/specs/`, `.docs/prds/`, `.docs/standards/` (the source of truth) did not trigger drift re-evaluation. Added `.docs/**` to both the `paths:` trigger filter and the in-scope grep filter in both workflows.

- **Bug 2: Force push → silent full check** — when a force push makes `BEFORE` sha unreachable, `git diff` fails. The fallback fetched all PR files via `gh pr view` but kept `MODE=incremental`. Since incremental mode exits silently when no new drift is found, the check appeared to run but posted nothing. Now resets `MODE=full` and restores `DIFF_BASE/DIFF_HEAD` to `PR_BASE..HEAD` on fallback so the check runs and posts as a full review.

- **Prompt update** — spec-drift prompt now instructs Claude to re-check source files against updated specs when `.docs/` files change (even if the source files aren't in the diff).

## Test plan

- [x] Verify both workflows have `.docs/**` in `paths:` trigger
- [x] Verify grep filter includes `\.docs/` prefix
- [x] Verify force-push fallback resets MODE, DIFF_BASE, DIFF_HEAD
- [x] Verify spec-drift prompt handles `.docs/` changes
- [ ] Push a `.docs/`-only commit to a PR and verify workflow triggers

🤖 Generated with [Claude Code](https://claude.com/claude-code)