### PR TITLE
fix(transport): constant-time SSE bearer token comparison

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3625,6 +3625,7 @@ dependencies = [
  "scp-core",
  "serde",
  "serde_json",
+ "subtle",
  "thiserror 2.0.18",
  "tokio",
  "tokio-stream",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -55,6 +55,7 @@ hex = "0.4"
 axum = "0.8"
 tokio-stream = { version = "0.1", features = ["sync"] }
 tokio-util = "0.7"
+subtle = "2"
 
 [workspace.lints.clippy]
 all = { level = "warn", priority = -1 }

--- a/crates/scp-mcp/Cargo.toml
+++ b/crates/scp-mcp/Cargo.toml
@@ -16,6 +16,7 @@ tokio-util = { workspace = true }
 axum = { workspace = true }
 tokio-stream = { workspace = true }
 tracing = { workspace = true }
+subtle = { workspace = true }
 
 [dev-dependencies]
 serde_json = { workspace = true }

--- a/crates/scp-mcp/src/sse.rs
+++ b/crates/scp-mcp/src/sse.rs
@@ -50,6 +50,7 @@ use axum::middleware::{self, Next};
 use axum::response::IntoResponse;
 use axum::response::sse::{Event, KeepAlive, Sse};
 use axum::routing::{get, post};
+use subtle::ConstantTimeEq;
 use tokio::sync::{Mutex, RwLock, broadcast};
 use tokio_stream::StreamExt;
 use tokio_stream::wrappers::BroadcastStream;
@@ -293,7 +294,7 @@ async fn bearer_auth_middleware(
     match auth_header {
         Some(value) if value.starts_with("Bearer ") => {
             let provided = &value["Bearer ".len()..];
-            if provided == expected_token {
+            if bool::from(provided.as_bytes().ct_eq(expected_token.as_bytes())) {
                 next.run(req).await.into_response()
             } else {
                 StatusCode::UNAUTHORIZED.into_response()


### PR DESCRIPTION
## Summary
- Fixes timing side-channel in SSE bearer token validation by switching to constant-time comparison via `subtle::ConstantTimeEq`
- Adds `subtle` crate (v2) as a workspace dependency

## Test plan
- [x] `cargo test -p scp-mcp` — all 199 tests pass
- [x] `cargo clippy -p scp-mcp --all-targets` — zero warnings
- [x] `cargo fmt --all -- --check` — clean

closes #142

🤖 Generated with [Claude Code](https://claude.com/claude-code)