### PR TITLE
fix(uniffi): add missing ucan_validate parameters

### DIFF
--- a/crates/scp-ffi/uniffi/src/bridge.rs
+++ b/crates/scp-ffi/uniffi/src/bridge.rs
@@ -1586,6 +1586,11 @@ pub async fn transport_status(manager: Arc<TransportManager>) -> Result<Transpor
 /// * `token` — The encoded UCAN token string (JWT format).
 /// * `capability` — The required capability URI (e.g.,
 ///   `"scp:ctx:abc123/messages:write"`).
+/// * `presenting_agent_did` — Optional DID of the agent presenting the
+///   token. Falls back to the token's audience field if `None`. Required
+///   for ADR-016 step 5 (audience verification).
+/// * `proof_tokens` — Optional list of encoded UCAN proof tokens for
+///   delegation chain traversal (ADR-016 step 3).
 ///
 /// # Errors
 ///
@@ -1597,10 +1602,18 @@ pub async fn ucan_validate(
     handle: Arc<ContextHandle>,
     token: String,
     capability: String,
+    presenting_agent_did: Option<String>,
+    proof_tokens: Option<Vec<String>>,
 ) -> Result<(), ScpError> {
     runtime()
         .spawn(async move {
-            let _ = (handle, token, capability);
+            let _ = (
+                handle,
+                token,
+                capability,
+                presenting_agent_did,
+                proof_tokens,
+            );
             Err(ScpError::Permission {
                 message: "not yet connected to runtime — UCAN validation requires a live context"
                     .to_owned(),


### PR DESCRIPTION
## Summary
- Adds missing `presenting_agent_did: Option<String>` and `proof_tokens: Option<Vec<String>>` parameters to the UniFFI `ucan_validate` function signature, aligning it with PyO3/NAPI/WASM bridges
- Stub body unchanged — parameters are consumed via `let _ = (...)` to suppress unused warnings
- Prevents a future breaking change for Swift and Kotlin consumers since UniFFI generates typed function signatures

closes #130

🤖 Generated with [Claude Code](https://claude.com/claude-code)