### PR TITLE
fix(python): add recursion depth limit to JSON converters

### DIFF
--- a/crates/scp-ffi/src/types.rs
+++ b/crates/scp-ffi/src/types.rs
@@ -67,6 +67,13 @@ pub(crate) fn generate_random_id(prefix: &str) -> String {
 // Python dict -> serde_json::Value
 // ---------------------------------------------------------------------------
 
+/// Maximum nesting depth for Python-to-JSON conversion.
+///
+/// Prevents stack overflow from deeply nested Python structures. 64 levels
+/// is generous for any legitimate use case while providing defense-in-depth
+/// independent of Python's own `sys.getrecursionlimit()`.
+const MAX_NESTING_DEPTH: usize = 64;
+
 /// Converts a Python `dict` to a [`serde_json::Value`].
 ///
 /// Recursively walks the dict, converting:
@@ -79,9 +86,20 @@ pub(crate) fn generate_random_id(prefix: &str) -> String {
 ///
 /// # Errors
 ///
-/// Returns `ScpPyError::ValidationError` if a dict value has an unsupported
-/// Python type (e.g., custom objects, bytes, sets).
+/// Returns `ScpPyError::ValidationError` if:
+/// - a dict value has an unsupported Python type (e.g., custom objects, bytes, sets)
+/// - nesting depth exceeds [`MAX_NESTING_DEPTH`] (64 levels)
 pub fn py_dict_to_json(dict: &Bound<'_, PyDict>) -> Result<Value, ScpPyError> {
+    py_dict_to_json_depth(dict, 0)
+}
+
+/// Depth-tracked implementation of [`py_dict_to_json`].
+fn py_dict_to_json_depth(dict: &Bound<'_, PyDict>, depth: usize) -> Result<Value, ScpPyError> {
+    if depth >= MAX_NESTING_DEPTH {
+        return Err(ScpPyError::ValidationError(format!(
+            "maximum nesting depth ({MAX_NESTING_DEPTH}) exceeded in Python-to-JSON conversion"
+        )));
+    }
     let mut map = serde_json::Map::new();
     for (key, value) in dict.iter() {
         let key_str: String = key.extract().map_err(|e| {
@@ -91,7 +109,7 @@ pub fn py_dict_to_json(dict: &Bound<'_, PyDict>) -> Result<Value, ScpPyError> {
                 .map_or_else(|_| "<unknown>".to_owned(), |n| n.to_string());
             ScpPyError::ValidationError(format!("dict key must be a string, got {type_name}: {e}",))
         })?;
-        let json_value = py_any_to_json(&value)?;
+        let json_value = py_any_to_json(&value, depth + 1)?;
         map.insert(key_str, json_value);
     }
     Ok(Value::Object(map))
@@ -100,8 +118,10 @@ pub fn py_dict_to_json(dict: &Bound<'_, PyDict>) -> Result<Value, ScpPyError> {
 /// Converts an arbitrary Python object to a [`serde_json::Value`].
 ///
 /// This is the recursive workhorse called by [`py_dict_to_json`] for nested
-/// structures.
-fn py_any_to_json(obj: &Bound<'_, PyAny>) -> Result<Value, ScpPyError> {
+/// structures. The `depth` parameter tracks the current nesting level;
+/// conversion fails with `ScpPyError::ValidationError` when it exceeds
+/// [`MAX_NESTING_DEPTH`].
+fn py_any_to_json(obj: &Bound<'_, PyAny>, depth: usize) -> Result<Value, ScpPyError> {
     // Check bool BEFORE int — in Python, `bool` is a subclass of `int`.
     if obj.is_instance_of::<PyBool>() {
         let b: bool = obj
@@ -144,16 +164,21 @@ fn py_any_to_json(obj: &Bound<'_, PyAny>) -> Result<Value, ScpPyError> {
         let dict = obj
             .downcast::<PyDict>()
             .map_err(|e| ScpPyError::ValidationError(format!("failed to downcast to dict: {e}")))?;
-        return py_dict_to_json(dict);
+        return py_dict_to_json_depth(dict, depth);
     }
 
     if obj.is_instance_of::<PyList>() {
+        if depth >= MAX_NESTING_DEPTH {
+            return Err(ScpPyError::ValidationError(format!(
+                "maximum nesting depth ({MAX_NESTING_DEPTH}) exceeded in Python-to-JSON conversion"
+            )));
+        }
         let list = obj
             .downcast::<PyList>()
             .map_err(|e| ScpPyError::ValidationError(format!("failed to downcast to list: {e}")))?;
         let mut arr = Vec::with_capacity(list.len());
         for item in list.iter() {
-            arr.push(py_any_to_json(&item)?);
+            arr.push(py_any_to_json(&item, depth + 1)?);
         }
         return Ok(Value::Array(arr));
     }
@@ -231,5 +256,195 @@ fn json_value_to_py(py: Python<'_>, value: &Value) -> PyResult<PyObject> {
             }
             Ok(dict.into_any().unbind())
         }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used)]
+mod tests {
+    use super::*;
+
+    /// Helper: build a Python dict nested to `depth` levels.
+    ///
+    /// Produces `{"k": {"k": { ... {"k": "v"} ... }}}` with `depth` dict layers.
+    fn build_nested_dict(py: Python<'_>, depth: usize) -> Bound<'_, PyDict> {
+        let innermost = PyDict::new(py);
+        innermost
+            .set_item("k", "v")
+            .expect("set_item should succeed");
+        let mut current: PyObject = innermost.into_any().unbind();
+        for _ in 1..depth {
+            let wrapper = PyDict::new(py);
+            wrapper
+                .set_item("k", &current)
+                .expect("set_item should succeed");
+            current = wrapper.into_any().unbind();
+        }
+        current
+            .downcast_bound::<PyDict>(py)
+            .expect("should be a dict")
+            .clone()
+    }
+
+    /// Helper: build a Python list nested to `depth` levels.
+    ///
+    /// Produces `[["v"]]` style nesting with `depth` list layers.
+    fn build_nested_list(py: Python<'_>, depth: usize) -> Bound<'_, PyDict> {
+        let innermost = PyList::new(py, ["v"]).expect("list creation should succeed");
+        let mut current: PyObject = innermost.into_any().unbind();
+        for _ in 1..depth {
+            let wrapper = PyList::empty(py);
+            wrapper.append(&current).expect("append should succeed");
+            current = wrapper.into_any().unbind();
+        }
+        // Wrap in a dict so we can call py_dict_to_json
+        let dict = PyDict::new(py);
+        dict.set_item("data", &current)
+            .expect("set_item should succeed");
+        dict
+    }
+
+    #[test]
+    fn shallow_dict_converts_successfully() {
+        pyo3::prepare_freethreaded_python();
+        Python::with_gil(|py| {
+            let dict = PyDict::new(py);
+            dict.set_item("a", "b").unwrap();
+            dict.set_item("n", 42).unwrap();
+            let result = py_dict_to_json(&dict);
+            assert!(result.is_ok());
+            let val = result.unwrap();
+            assert_eq!(val["a"], "b");
+            assert_eq!(val["n"], 42);
+        });
+    }
+
+    #[test]
+    fn nested_dict_within_limit_succeeds() {
+        pyo3::prepare_freethreaded_python();
+        Python::with_gil(|py| {
+            // 63 levels of nesting — just under the limit (depth 0..62 = 63 dicts,
+            // plus the leaf value, totalling 63 recursive calls which is < 64).
+            let dict = build_nested_dict(py, MAX_NESTING_DEPTH);
+            let result = py_dict_to_json(&dict);
+            assert!(
+                result.is_ok(),
+                "should succeed at exactly MAX_NESTING_DEPTH levels"
+            );
+        });
+    }
+
+    #[test]
+    fn nested_dict_exceeding_limit_fails() {
+        pyo3::prepare_freethreaded_python();
+        Python::with_gil(|py| {
+            let dict = build_nested_dict(py, MAX_NESTING_DEPTH + 1);
+            let result = py_dict_to_json(&dict);
+            assert!(
+                result.is_err(),
+                "should fail when exceeding MAX_NESTING_DEPTH"
+            );
+            let err_msg = format!("{}", result.unwrap_err());
+            assert!(
+                err_msg.contains("maximum nesting depth"),
+                "error should mention nesting depth, got: {err_msg}"
+            );
+        });
+    }
+
+    #[test]
+    fn nested_list_exceeding_limit_fails() {
+        pyo3::prepare_freethreaded_python();
+        Python::with_gil(|py| {
+            let dict = build_nested_list(py, MAX_NESTING_DEPTH + 1);
+            let result = py_dict_to_json(&dict);
+            assert!(
+                result.is_err(),
+                "should fail when list nesting exceeds MAX_NESTING_DEPTH"
+            );
+            let err_msg = format!("{}", result.unwrap_err());
+            assert!(
+                err_msg.contains("maximum nesting depth"),
+                "error should mention nesting depth, got: {err_msg}"
+            );
+        });
+    }
+
+    #[test]
+    fn nested_list_within_limit_succeeds() {
+        pyo3::prepare_freethreaded_python();
+        Python::with_gil(|py| {
+            // MAX_NESTING_DEPTH - 1 list levels because the outer dict wrapper
+            // already consumes one level of depth.
+            let dict = build_nested_list(py, MAX_NESTING_DEPTH - 1);
+            let result = py_dict_to_json(&dict);
+            assert!(
+                result.is_ok(),
+                "should succeed within MAX_NESTING_DEPTH list levels"
+            );
+        });
+    }
+
+    #[test]
+    fn mixed_nesting_dict_and_list_exceeding_limit_fails() {
+        pyo3::prepare_freethreaded_python();
+        Python::with_gil(|py| {
+            // Build alternating dict/list nesting that exceeds the limit.
+            let leaf = PyDict::new(py);
+            leaf.set_item("leaf", true).unwrap();
+            let mut current: PyObject = leaf.into_any().unbind();
+
+            for i in 0..=MAX_NESTING_DEPTH {
+                if i % 2 == 0 {
+                    let list = PyList::empty(py);
+                    list.append(&current).unwrap();
+                    current = list.into_any().unbind();
+                } else {
+                    let dict = PyDict::new(py);
+                    dict.set_item("k", &current).unwrap();
+                    current = dict.into_any().unbind();
+                }
+            }
+
+            // Wrap in a top-level dict
+            let top = PyDict::new(py);
+            top.set_item("root", &current).unwrap();
+
+            let result = py_dict_to_json(&top);
+            assert!(result.is_err(), "mixed nesting exceeding limit should fail");
+        });
+    }
+
+    #[test]
+    fn flat_dict_with_many_keys_succeeds() {
+        pyo3::prepare_freethreaded_python();
+        Python::with_gil(|py| {
+            // Wide (many keys) but shallow — should always succeed.
+            let dict = PyDict::new(py);
+            for i in 0..1000 {
+                dict.set_item(format!("key_{i}"), i).unwrap();
+            }
+            let result = py_dict_to_json(&dict);
+            assert!(result.is_ok());
+            assert_eq!(result.unwrap().as_object().unwrap().len(), 1000);
+        });
+    }
+
+    #[test]
+    fn error_message_includes_limit_value() {
+        pyo3::prepare_freethreaded_python();
+        Python::with_gil(|py| {
+            let dict = build_nested_dict(py, MAX_NESTING_DEPTH + 1);
+            let result = py_dict_to_json(&dict);
+            let err_msg = format!("{}", result.unwrap_err());
+            assert!(
+                err_msg.contains(&MAX_NESTING_DEPTH.to_string()),
+                "error should include the numeric limit ({MAX_NESTING_DEPTH}), got: {err_msg}"
+            );
+        });
     }
 }


### PR DESCRIPTION
## Summary
- Adds `MAX_NESTING_DEPTH` (64) constant and depth tracking to `py_dict_to_json` and `py_any_to_json` in `crates/scp-ffi/src/types.rs`
- Returns `ScpPyError::ValidationError` when nesting exceeds the limit, preventing stack overflow on deeply nested Python structures
- Defense-in-depth independent of Python's `sys.getrecursionlimit()`

## Test plan
- [x] 8 new unit tests covering dict nesting, list nesting, mixed nesting, boundary conditions, and error messages
- [x] `cargo clippy --workspace --all-targets` passes clean
- [x] `cargo test --workspace` passes (all existing + new tests)
- [x] `cargo fmt --all -- --check` passes

closes #110

🤖 Generated with [Claude Code](https://claude.com/claude-code)