### PR TITLE
refactor(identity): simplify claim_shadow return type

### DIFF
--- a/.docs/adrs/phase-5.md
+++ b/.docs/adrs/phase-5.md
@@ -112,10 +112,7 @@ pub struct ClaimRequest {
     pub signature: Ed25519Signature,
 }
 
-pub enum ClaimResult {
-    Success { shadow_id: String, claimant_did: DID },
-    Failed { reason: ClaimError },
-}
+// claim_shadow returns Result<ShadowClaimEvent, ClaimError>
 
 pub enum ClaimError {
     HandleMismatch,
@@ -183,7 +180,7 @@ pub enum ClaimError {
 | `mod.rs` | Module root, `BridgeConnector`, `BridgeMode`, `ShadowIdentity`, re-exports |
 | `registration.rs` | Bridge registration, governance approval, context metadata integration |
 | `shadow.rs` | Shadow identity creation, role management, provenance status |
-| `claiming.rs` | `ClaimRequest`, `ClaimResult`, attestation verification, retroattribution |
+| `claiming.rs` | `ClaimRequest`, `ClaimError`, attestation verification, retroattribution |
 | `provenance.rs` | `BridgeProvenance`, provenance marking for bridged content |
 
 Per-platform implementations (`scp-bridge/x/`, `scp-bridge/bluesky/`) are separate crates built on these primitives.

--- a/.docs/prds/main.json
+++ b/.docs/prds/main.json
@@ -1,6 +1,6 @@
 {
   "project": "scp",
-  "description": "Shareable Context Protocol — cryptographic identity, governed contexts, encrypted communication, capability-based auth, and transparent provenance for AI agent infrastructure.",
+  "description": "Shareable Context Protocol \u2014 cryptographic identity, governed contexts, encrypted communication, capability-based auth, and transparent provenance for AI agent infrastructure.",
   "gates": [
     {
       "id": "gate-1",
@@ -317,7 +317,7 @@
         "Create crates/scp-platform/src/lib.rs with crate root (#![forbid(unsafe_code)]), module declarations, re-exports",
         "Define KeyType enum with Ed25519 and X25519 variants in traits.rs",
         "Define KeyHandle, PublicKey, Signature, SharedSecret, PseudonymKeypair, CustodyType types",
-        "Define KeyCustody trait with all 7 methods as specified in ADR-006 acceptance criteria §5",
+        "Define KeyCustody trait with all 7 methods as specified in ADR-006 acceptance criteria \u00a75",
         "Define DeviceAttestation trait with attest() and verify() methods",
         "Define Push trait with register() and handle_notification() methods",
         "Define Storage trait with store(), retrieve(), delete(), list_keys(), delete_prefix(), exists() methods",
@@ -336,7 +336,7 @@
         "traitDefinitions": "```rust\npub enum KeyType {\n    Ed25519,\n    X25519,\n}\n\npub trait KeyCustody: Send + Sync {\n    async fn generate_keypair(&self, key_type: KeyType) -> Result<KeyHandle, PlatformError>;\n    async fn sign(&self, key: &KeyHandle, data: &[u8]) -> Result<Signature, PlatformError>;\n    async fn public_key(&self, key: &KeyHandle) -> Result<PublicKey, PlatformError>;\n    async fn destroy_key(&self, key: &KeyHandle) -> Result<(), PlatformError>;\n    async fn dh_agree(&self, key: &KeyHandle, peer_public: &[u8; 32]) -> Result<SharedSecret, PlatformError>;\n    async fn derive_pseudonym(&self, key: &KeyHandle, context_id: &[u8]) -> Result<PseudonymKeypair, PlatformError>;\n    fn custody_type(&self, key: &KeyHandle) -> CustodyType;\n}\n\npub trait DeviceAttestation: Send + Sync {\n    async fn attest(&self) -> Result<DeviceAttestationToken, PlatformError>;\n    async fn verify(&self, token: &DeviceAttestationToken) -> Result<bool, PlatformError>;\n}\n\npub trait Push: Send + Sync {\n    async fn register(&self) -> Result<PushToken, PlatformError>;\n    async fn handle_notification(&self, payload: &[u8]) -> Result<WakeSignal, PlatformError>;\n}\n\npub trait Storage: Send + Sync {\n    async fn store(&self, key: &str, data: &[u8]) -> Result<(), PlatformError>;\n    async fn retrieve(&self, key: &str) -> Result<Option<Vec<u8>>, PlatformError>;\n    async fn delete(&self, key: &str) -> Result<(), PlatformError>;\n    async fn list_keys(&self, prefix: &str) -> Result<Vec<String>, PlatformError>;\n    async fn delete_prefix(&self, prefix: &str) -> Result<u64, PlatformError>;\n    async fn exists(&self, key: &str) -> Result<bool, PlatformError>;\n}\n```",
         "derive_pseudonym_algorithm": "Algorithm (all implementations MUST produce identical output):\n  1. seed = HMAC-SHA256(identity_key_material, context_id || \"scp-pseudonym\")\n  2. pseudonym_keypair = Ed25519_keygen(seed[0..32])\n\nFor hardware-backed keys: the HMAC is computed inside the HSM using an associated symmetric key derived during generate_keypair.\nFor software keys: the HMAC uses the raw Ed25519 private key bytes.\n\nThe returned PseudonymKeypair is always software-managed (derived output).\nReturns an error if the key handle refers to an X25519 key.",
         "dh_agree_note": "Perform X25519 Diffie-Hellman key agreement. Returns the 32-byte shared secret. The private key never leaves the custody boundary (scalar multiplication happens inside the adapter). Returns an error if the key handle refers to an Ed25519 key.",
-        "conformanceMacros": "Trait conformance macros (key_custody_conformance!(), storage_conformance!(), attestation_conformance!(), push_conformance!()) verify that every adapter implementation — in-memory and production — satisfies the same contract."
+        "conformanceMacros": "Trait conformance macros (key_custody_conformance!(), storage_conformance!(), attestation_conformance!(), push_conformance!()) verify that every adapter implementation \u2014 in-memory and production \u2014 satisfies the same contract."
       },
       "result": "Workspace root created (Cargo.toml, rustfmt.toml, .clippy.toml). scp-platform crate created with 4 platform traits (KeyCustody, DeviceAttestation, Push, Storage), 10 supporting types, PlatformError enum. Build + clippy green."
     },
@@ -354,7 +354,7 @@
         "crates/scp-platform/src/testing/attestation.rs",
         "crates/scp-platform/src/testing/push.rs"
       ],
-      "description": "Implement in-memory versions of all four platform traits: KeyCustody, DeviceAttestation, Push, Storage. These are used exclusively for testing and development. They provide identical API surfaces to production adapters but store everything in memory. Unblocks all other Phase 1 work — every component that touches keys, storage, or attestations depends on platform adapters.",
+      "description": "Implement in-memory versions of all four platform traits: KeyCustody, DeviceAttestation, Push, Storage. These are used exclusively for testing and development. They provide identical API surfaces to production adapters but store everything in memory. Unblocks all other Phase 1 work \u2014 every component that touches keys, storage, or attestations depends on platform adapters.",
       "acceptanceCriteria": [
         "InMemoryKeyCustody implements KeyCustody trait",
         "InMemoryKeyCustody.generate_keypair(key_type) generates Ed25519 or X25519 keypair in memory, returns opaque KeyHandle (integer ID), private key stored in internal HashMap<u64, SigningKey> (Ed25519) or HashMap<u64, StaticSecret> (X25519)",
@@ -400,7 +400,7 @@
       ],
       "details": {
         "dependencies": "ed25519-dalek for key generation, rand for randomness (with seedable RNG for determinism), hmac + sha2 for pseudonym derivation, x25519-dalek for ECDH, uuid for push tokens",
-        "testingHarness": "These in-memory adapters are consumed by the scp-testing crate (§16), which composes them into a full network simulation harness: SimulatedIdentity wraps a real Identity with InMemoryKeyCustody + InMemoryStorage + InMemoryTransport instances."
+        "testingHarness": "These in-memory adapters are consumed by the scp-testing crate (\u00a716), which composes them into a full network simulation harness: SimulatedIdentity wraps a real Identity with InMemoryKeyCustody + InMemoryStorage + InMemoryTransport instances."
       },
       "result": "All 4 in-memory platform adapters implemented with 44 unit tests. Feature-gated behind testing flag."
     },
@@ -467,7 +467,7 @@
         }
       ],
       "details": {
-        "ciphersuite": "MLS_128_DHKEMX25519_AES128GCM_SHA256_Ed25519 — X25519 for key exchange, AES-128-GCM for encryption, SHA-256 for hashing, Ed25519 for signing. This is MLS's recommended baseline ciphersuite.",
+        "ciphersuite": "MLS_128_DHKEMX25519_AES128GCM_SHA256_Ed25519 \u2014 X25519 for key exchange, AES-128-GCM for encryption, SHA-256 for hashing, Ed25519 for signing. This is MLS's recommended baseline ciphersuite.",
         "openmlsRationale": "OpenMLS over mls-rs: OpenMLS is the most mature MLS implementation in Rust (more production usage, more contributors). mls-rs (by Wire) is a viable fallback if OpenMLS proves insufficient.",
         "wrapperDesign": "Wrapper, not fork: SCP does not modify MLS behavior. The wrapper translates between SCP concepts (context, agent, epoch) and MLS concepts (group, member, epoch) per the mapping in spec section 9.7.1.",
         "fileLayout": "mod.rs (module root, re-exports), group.rs (ScpMlsGroup wrapper, create/add/remove/destroy), credential.rs (SCP credential type), storage.rs (StorageProvider bridge), error.rs (MLS-specific errors)",
@@ -491,8 +491,8 @@
         "The ciphertext includes a membership_tag HMAC proving the sender is a group member with correct epoch secrets (spec section 9.8.1, inner check)",
         "MLS assigns a generation number automatically (spec section 9.8.2, layer a)",
         "decrypt(group, ciphertext) -> Plaintext decrypts an MLS PrivateMessage",
-        "decrypt verifies the membership_tag — rejects if sender is not a valid group member",
-        "decrypt verifies the generation number — rejects if less than or equal to highest seen for this sender in this epoch (replay prevention, spec section 9.8.2)",
+        "decrypt verifies the membership_tag \u2014 rejects if sender is not a valid group member",
+        "decrypt verifies the generation number \u2014 rejects if less than or equal to highest seen for this sender in this epoch (replay prevention, spec section 9.8.2)",
         "decrypt returns the decrypted plaintext",
         "Proptest: encrypt/decrypt roundtrip for arbitrary plaintext produces identical output",
         "Test: decrypt rejects ciphertext with invalid membership_tag",
@@ -537,14 +537,14 @@
       "description": "Implement MLS epoch ratcheting with grace window key management, post-compromise security via Update proposals, and KeyPackage generation with buffer management. The epoch grace store provides in-memory-only retention of old epoch keys during the transition window, with automatic purge after 30 seconds or when all members have sent in the new epoch.",
       "acceptanceCriteria": [
         "ratchet(group, commit) processes a Commit message, advancing the group to a new epoch",
-        "Old epoch key material enters a grace window after new epoch is established — in-memory only, never persisted to disk, used exclusively for decrypting in-flight messages encrypted under old epoch",
+        "Old epoch key material enters a grace window after new epoch is established \u2014 in-memory only, never persisted to disk, used exclusively for decrypting in-flight messages encrypted under old epoch",
         "Grace window duration: shorter of (a) all members have sent at least one message or ACK in new epoch, or (b) 30 seconds from local Commit processing time. 30-second hard ceiling is not configurable",
         "EpochGraceStore is (1) in-memory only, (2) indexed by epoch number, (3) automatically purged when grace window closes",
         "EpochGraceStore MUST NOT be accessible to any code path other than decrypt() with a matching epoch number",
         "After grace window closes, old epoch secrets, application key schedules, and ratchet tree states for past epochs are destroyed and MUST NOT be recoverable (forward secrecy, spec section 9.7.2)",
-        "Messages arriving after grace window closes referencing old epochs are unrecoverable — SDK MUST log a warning and emit a StaleEpochMessage event with sender DID and epoch number",
+        "Messages arriving after grace window closes referencing old epochs are unrecoverable \u2014 SDK MUST log a warning and emit a StaleEpochMessage event with sender DID and epoch number",
         "update(group) -> (UpdateProposal, Commit) issues an MLS Update proposal generating fresh HPKE key pair and ratcheting sender's path in the tree",
-        "update provides post-compromise security (spec section 9.7.3) — recommended interval: every 24 hours for active contexts",
+        "update provides post-compromise security (spec section 9.7.3) \u2014 recommended interval: every 24 hours for active contexts",
         "After Update + Commit processed by all members, any prior compromise of sender's state becomes useless for future messages",
         "generate_key_package(identity) -> KeyPackage generates a single-use KeyPackage for offline member addition",
         "KeyPackage signed by the identity's Ed25519 key",
@@ -553,13 +553,13 @@
         "No unwrap() or expect() in library code"
       ],
       "actionItems": [
-        "Implement EpochGraceStore in epoch_grace.rs — in-memory old epoch key retention with timer-based purge, per-epoch indexing",
+        "Implement EpochGraceStore in epoch_grace.rs \u2014 in-memory old epoch key retention with timer-based purge, per-epoch indexing",
         "Implement automatic grace window closure: 30-second tokio timer AND member-activity tracking",
         "Implement StaleEpochMessage event emission for messages arriving after grace window",
-        "Implement ratchet function in ratchet.rs — processes Commit, moves old keys to EpochGraceStore, establishes new epoch",
-        "Implement update function in ratchet.rs — generates Update proposal + Commit for PCS",
-        "Implement generate_key_package in key_package.rs — single-use KeyPackage generation signed by identity Ed25519 key",
-        "Implement KeyPackage buffer management — maintain 10 unused per identity, replenish at 5",
+        "Implement ratchet function in ratchet.rs \u2014 processes Commit, moves old keys to EpochGraceStore, establishes new epoch",
+        "Implement update function in ratchet.rs \u2014 generates Update proposal + Commit for PCS",
+        "Implement generate_key_package in key_package.rs \u2014 single-use KeyPackage generation signed by identity Ed25519 key",
+        "Implement KeyPackage buffer management \u2014 maintain 10 unused per identity, replenish at 5",
         "Write tests for grace window timing (30s hard ceiling)",
         "Write tests for grace window activity-based closure",
         "Write tests for StaleEpochMessage event on post-grace messages",
@@ -614,8 +614,8 @@
         "Define ScpIdentity struct with identity_key, active_signing_key, pre_rotation_commitment, did fields",
         "Define DidMethod trait with create, publish, resolve, rotate, verify methods",
         "Implement DidDht struct in dht.rs with create_identity using pkarr (v5.0.3+) and z-base-32",
-        "Implement verify_did in dht.rs — local z-base-32 decode and comparison",
-        "Implement DID Document construction in document.rs — W3C JSON-LD format, verification methods, PreRotationCommitment service",
+        "Implement verify_did in dht.rs \u2014 local z-base-32 decode and comparison",
+        "Implement DID Document construction in document.rs \u2014 W3C JSON-LD format, verification methods, PreRotationCommitment service",
         "Add dependencies to scp-core/Cargo.toml: pkarr, z-base-32, simple-dns, serde_json",
         "Write unit tests for create_identity verifying three keypairs, DID string format, document structure",
         "Write unit tests for verify_did with valid and invalid keys",
@@ -633,7 +633,7 @@
       "details": {
         "scpIdentityStruct": "```rust\npub struct ScpIdentity {\n    /// did:dht Identity Key. Derives the DID string. Stored in highest-security\n    /// custody (Secure Enclave, HSM). Used ONLY for DID document updates and\n    /// signing pre-rotation commitments. NEVER for MLS, envelopes, or UCANs.\n    pub identity_key: KeyHandle,\n\n    /// Current Active Signing Key. A verification method in the DID document.\n    /// Used for MLS credentials, inner envelope signatures, UCAN issuance.\n    /// Rotatable via rotate_active_key (DID string stays the same).\n    pub active_signing_key: KeyHandle,\n\n    /// SHA-256 hash of the next Identity Key's public key.\n    /// Published in DID document as a PreRotationCommitment service.\n    pub pre_rotation_commitment: [u8; 32],\n\n    /// The DID string: did:dht:z<z-base-32(identity_key.public)>\n    pub did: String,\n}\n```",
         "didDhtRationale": "did:dht over did:web: No server dependency. Self-certifying (DID = public key). Key rotation via DHT record update with BEP44 signed mutable items. No TLS pinning, TOFU, or key-change alerting infrastructure needed.\n\ndid:dht over did:key: did:key cannot rotate keys (the key IS the identity). Key loss = identity loss. Recovery (spec section 3.3) requires key rotation, which did:key cannot do.",
-        "libraries": "pkarr (v5.0.3+) as primary dependency — provides Ed25519 keypair management, BEP44 signed mutable items, DNS packet construction via simple-dns, and Mainline DHT publish/resolve via mainline crate (v6.1.1+). z-base-32 for DID string encoding. SCP implements did:dht-specific DID Document to DNS resource record encoding (~300 lines) as a thin layer on top of pkarr."
+        "libraries": "pkarr (v5.0.3+) as primary dependency \u2014 provides Ed25519 keypair management, BEP44 signed mutable items, DNS packet construction via simple-dns, and Mainline DHT publish/resolve via mainline crate (v6.1.1+). z-base-32 for DID string encoding. SCP implements did:dht-specific DID Document to DNS resource record encoding (~300 lines) as a thin layer on top of pkarr."
       }
     },
     {
@@ -698,8 +698,8 @@
         }
       ],
       "details": {
-        "republishStrategy": "DIDs published via did:dht require periodic republishing to remain resolvable — Mainline DHT records expire if not refreshed. Republish interval: every 2 hours. Failure handling: exponential backoff 30s, 1m, 2m, 4m, 8m, 16m, capped at 30m. Each retry re-resolves DHT bootstrap nodes. After 6 consecutive failures, emit DhtPublishDegraded warning. Automatic lifecycle: starts on identity load, stops on unload/shutdown. Startup: immediate republish for all persisted active identities.",
-        "cacheStrategy": "Resolution cache — TTL-based, 24h active / 7d inactive refresh, BEP44 sequence number comparison for staleness",
+        "republishStrategy": "DIDs published via did:dht require periodic republishing to remain resolvable \u2014 Mainline DHT records expire if not refreshed. Republish interval: every 2 hours. Failure handling: exponential backoff 30s, 1m, 2m, 4m, 8m, 16m, capped at 30m. Each retry re-resolves DHT bootstrap nodes. After 6 consecutive failures, emit DhtPublishDegraded warning. Automatic lifecycle: starts on identity load, stops on unload/shutdown. Startup: immediate republish for all persisted active identities.",
+        "cacheStrategy": "Resolution cache \u2014 TTL-based, 24h active / 7d inactive refresh, BEP44 sequence number comparison for staleness",
         "stalenessIndicator": "When resolve_did returns a cached result not refreshed within expected republish window (2 hours + 30 minute grace), result includes staleness indicator. Callers SHOULD treat stale results as valid but degraded. Critical operations (UCAN validation, MLS credential verification) SHOULD attempt fresh DHT resolution before rejecting stale result."
       },
       "result": "Implemented DID publish/resolve with BEP44 signing, DhtClient trait abstraction, InMemoryDhtClient for testing, DidCache with TTL-based staleness detection (24h active/7d inactive), RepublishManager with exponential backoff. 40 new tests."
@@ -715,7 +715,7 @@
         "crates/scp-core/src/identity/dht.rs",
         "crates/scp-core/src/identity/document.rs"
       ],
-      "description": "Implement the three-layer key rotation architecture for did:dht. Layer 1 (rotate_active_key) is the common case — rotates the Active Signing Key while preserving the DID string. Layer 2 (migrate_identity) is rare planned migration to a new DID. Layer 3 (verify_migration) verifies migration proofs. did:dht's Identity Key is non-rotatable (DID string bound to initial public key), so SCP separates Identity Key from Active Signing Key.",
+      "description": "Implement the three-layer key rotation architecture for did:dht. Layer 1 (rotate_active_key) is the common case \u2014 rotates the Active Signing Key while preserving the DID string. Layer 2 (migrate_identity) is rare planned migration to a new DID. Layer 3 (verify_migration) verifies migration proofs. did:dht's Identity Key is non-rotatable (DID string bound to initial public key), so SCP separates Identity Key from Active Signing Key.",
       "acceptanceCriteria": [
         "rotate_active_key(identity, key_custody) -> Identity generates new Ed25519 keypair as new Active Signing Key",
         "rotate_active_key updates DID document: adds new key as verification method, moves authentication and assertionMethod references to new key, retains old key as #retired-{sequence}",
@@ -740,9 +740,9 @@
         "No unwrap() or expect() in library code"
       ],
       "actionItems": [
-        "Implement rotate_active_key in dht.rs — generate new keypair, update DID document verification methods, sign with Identity Key, publish to DHT",
+        "Implement rotate_active_key in dht.rs \u2014 generate new keypair, update DID document verification methods, sign with Identity Key, publish to DHT",
         "Implement verification method retirement (#retired-{sequence}) in document.rs",
-        "Implement migrate_identity in dht.rs — create new DID, update old document with alsoKnownAs, sign linkage, publish both",
+        "Implement migrate_identity in dht.rs \u2014 create new DID, update old document with alsoKnownAs, sign linkage, publish both",
         "Define DidRotationEvent struct with old_did, new_did, migration_proof, pre_rotation_proof, rotated_at",
         "Define MigrationProof struct with signature (Ed25519 of SHA-256(old_did || new_did || rotated_at) signed by old Identity Key) and old_public_key",
         "Define PreRotationProof struct with commitment and revealed_key",
@@ -763,7 +763,7 @@
       ],
       "details": {
         "didRotationEvent": "```rust\npub struct DidRotationEvent {\n    pub old_did: String,\n    pub new_did: String,\n    pub migration_proof: MigrationProof,\n    pub pre_rotation_proof: Option<PreRotationProof>,\n    pub rotated_at: u64,\n}\n\npub struct MigrationProof {\n    /// Ed25519 signature of SHA-256(old_did || new_did || rotated_at)\n    /// signed by the old Identity Key.\n    pub signature: [u8; 64],\n    pub old_public_key: [u8; 32],\n}\n\npub struct PreRotationProof {\n    /// The commitment published in the old DID document.\n    pub commitment: [u8; 32],\n    /// The new Identity Key public bytes. SHA-256(this) must equal commitment.\n    pub revealed_key: [u8; 32],\n}\n```",
-        "postRotationRequirements": "After rotation, the caller MUST issue MLS Update proposals in all active contexts (PCS, spec §9.7.3) and revoke/reissue UCAN tokens signed by the old active key.",
+        "postRotationRequirements": "After rotation, the caller MUST issue MLS Update proposals in all active contexts (PCS, spec \u00a79.7.3) and revoke/reissue UCAN tokens signed by the old active key.",
         "threeLayerSummary": "Layer 1 (rotate_active_key): common case, DID string unchanged. Layer 2 (migrate_identity): rare planned migration, DID string changes. Layer 3 (verify_migration): verification of migration proofs."
       },
       "result": "Three-layer key rotation: rotate_active_key, migrate_identity, verify_migration. 28 new tests. All passing."
@@ -790,7 +790,7 @@
         "Uses HMAC-SHA256(identity_key_material, context_id || \"scp-pseudonym\") then Ed25519_keygen(seed[0..32])",
         "The pseudonym keypair's public key is the routing identifier used in outer envelopes",
         "create_inner_envelope(context_id, sender_did, epoch, generation, sequence, timestamp, payload, provenance, signing_key) -> InnerEnvelope",
-        "create_inner_envelope computes payload_hash = SHA256(payload) — hash of original plaintext BEFORE padding",
+        "create_inner_envelope computes payload_hash = SHA256(payload) \u2014 hash of original plaintext BEFORE padding",
         "create_inner_envelope computes provenance_hash = SHA256(serialize(provenance)) if present, or SHA256(0x00) if absent",
         "create_inner_envelope computes signature = Ed25519_sign(SHA256(context_id || sender_did || epoch || generation || sequence || timestamp || payload_hash || provenance_hash))",
         "create_inner_envelope pads payload to next bucket boundary (256B, 1KB, 4KB, 16KB, 64KB, 256KB) AFTER signing",
@@ -798,7 +798,7 @@
         "create_outer_envelope(routing_id, recipient_hint, blob_ttl, encrypted_blob) -> OuterEnvelope constructs minimal outer envelope and serializes to binary",
         "verify_inner_signature(inner_envelope, sender_public_key) -> bool recomputes SHA256(context_id || sender_did || epoch || generation || sequence || timestamp || payload_hash || provenance_hash) and verifies Ed25519 signature",
         "verify_inner_signature computes provenance_hash correctly for present and absent provenance",
-        "A mismatch indicates payload or provenance tampering — both MUST be rejected",
+        "A mismatch indicates payload or provenance tampering \u2014 both MUST be rejected",
         "strip_padding(padded_payload) -> Payload removes bucket padding. Format: payload bytes + padding bytes + 4-byte big-endian length of original payload at end",
         "pad_to_bucket(payload) pads to fixed buckets: 256B, 1KB, 4KB, 16KB, 64KB, 256KB",
         "Proptest: pad then strip roundtrip for arbitrary payloads produces identical output",
@@ -856,7 +856,7 @@
         "seal_envelope is the primary send-path function",
         "open_envelope(outer_envelope, mls_group) -> InnerEnvelope decrypts outer envelope's blob via MLS, deserializes inner envelope, verifies inner signature",
         "open_envelope rejects if inner signature verification fails",
-        "open_envelope after decryption and padding removal verifies payload_hash == SHA256(stripped_payload) — rejects on content integrity failure",
+        "open_envelope after decryption and padding removal verifies payload_hash == SHA256(stripped_payload) \u2014 rejects on content integrity failure",
         "open_envelope rejects if generation number violates replay prevention (delegates to MLS layer)",
         "open_envelope returns the verified inner envelope",
         "Integration test: seal then open roundtrip produces original inner envelope content",
@@ -865,8 +865,8 @@
         "No unwrap() or expect() in library code"
       ],
       "actionItems": [
-        "Implement seal_envelope in outer.rs — serialize inner envelope via rmp-serde, encrypt via mls.encrypt(), construct outer envelope",
-        "Implement open_envelope in outer.rs — decrypt via mls.decrypt(), deserialize inner envelope, strip padding, verify payload_hash, verify inner signature",
+        "Implement seal_envelope in outer.rs \u2014 serialize inner envelope via rmp-serde, encrypt via mls.encrypt(), construct outer envelope",
+        "Implement open_envelope in outer.rs \u2014 decrypt via mls.decrypt(), deserialize inner envelope, strip padding, verify payload_hash, verify inner signature",
         "Wire up payload_hash integrity check: SHA256(stripped_payload) == inner_envelope.payload_hash",
         "Wire up generation number replay prevention delegation to MLS layer",
         "Write roundtrip integration test for seal then open",
@@ -904,7 +904,7 @@
         "crates/scp-transport/src/error.rs",
         "crates/scp-transport/Cargo.toml"
       ],
-      "description": "Define the TransportAdapter trait that all transport adapters implement, along with supporting types (BlobId, RoutingId, TransportError, TransportEvent) and the TransportManager struct for multi-adapter routing. The trait is deliberately thin: 5 core methods covering send, subscribe, unsubscribe, query, and delete. SCP is transport-independent — no single transport is primary. Phase 1 implements single adapter support; multi-adapter routing is Phase 2+.",
+      "description": "Define the TransportAdapter trait that all transport adapters implement, along with supporting types (BlobId, RoutingId, TransportError, TransportEvent) and the TransportManager struct for multi-adapter routing. The trait is deliberately thin: 5 core methods covering send, subscribe, unsubscribe, query, and delete. SCP is transport-independent \u2014 no single transport is primary. Phase 1 implements single adapter support; multi-adapter routing is Phase 2+.",
       "acceptanceCriteria": [
         "TransportAdapter trait defined with 5 async methods: send, subscribe, unsubscribe, query, delete",
         "TransportAdapter trait is Send + Sync",
@@ -913,8 +913,8 @@
         "unsubscribe(&self, routing_id: &RoutingId) -> Result<(), TransportError>",
         "query(&self, routing_id: &RoutingId, since: Option<u64>) -> Result<Vec<OuterEnvelope>, TransportError>",
         "delete(&self, blob_id: &BlobId) -> Result<(), TransportError>",
-        "BlobId([u8; 32]) type defined — opaque blob identifier (SHA-256 hash of blob)",
-        "RoutingId(pub [u8; 32]) type defined — per-context pseudonym used for routing",
+        "BlobId([u8; 32]) type defined \u2014 opaque blob identifier (SHA-256 hash of blob)",
+        "RoutingId(pub [u8; 32]) type defined \u2014 per-context pseudonym used for routing",
         "TransportError enum defined with variants: ConnectionFailed, SendFailed, SubscriptionFailed, NotConnected, Timeout, ProtocolError",
         "TransportEvent enum defined with variants: Envelope(OuterEnvelope), Error(TransportError), BackfillComplete, Reconnected, Terminated { reason: String }",
         "TransportManager struct holds multiple Box<dyn TransportAdapter> instances",
@@ -970,7 +970,7 @@
         "encrypt_sender_layer generates a random 12-byte nonce per encryption",
         "encrypt_sender_layer returns (nonce || ciphertext || auth_tag)",
         "decrypt_sender_layer(sender_key, sender_ciphertext) -> Plaintext decrypts AES-256-GCM ciphertext",
-        "decrypt_sender_layer verifies authentication tag — rejects if verification fails",
+        "decrypt_sender_layer verifies authentication tag \u2014 rejects if verification fails",
         "decrypt_sender_layer returns the plaintext",
         "SenderKeyStore stores sender keys per (context_id, sender_did)",
         "SenderKeyStore.get(context_id, sender_did) -> Option<SenderKey> retrieves sender's current key",
@@ -987,8 +987,8 @@
         "Implement generate_sender_key using random 32 bytes",
         "Implement SenderKeyStore with HashMap-based storage keyed by (context_id, sender_did)",
         "Implement SenderKeyStore.get, set, remove, get_all methods",
-        "Implement encrypt_sender_layer in encrypt.rs using aes-gcm crate — random 12-byte nonce, AES-256-GCM encryption, output format: nonce || ciphertext || auth_tag",
-        "Implement decrypt_sender_layer in encrypt.rs — parse nonce from prefix, AES-256-GCM decryption with auth tag verification",
+        "Implement encrypt_sender_layer in encrypt.rs using aes-gcm crate \u2014 random 12-byte nonce, AES-256-GCM encryption, output format: nonce || ciphertext || auth_tag",
+        "Implement decrypt_sender_layer in encrypt.rs \u2014 parse nonce from prefix, AES-256-GCM decryption with auth tag verification",
         "Add aes-gcm dependency to scp-core/Cargo.toml",
         "Write proptest for encrypt/decrypt roundtrip with arbitrary plaintext",
         "Write test for auth tag rejection on tampered ciphertext",
@@ -1005,7 +1005,7 @@
       ],
       "details": {
         "encryptionOrder": "Sender-first encryption order: plaintext encrypted with sender's AES-256 key first, then result encrypted with MLS. A blocked party decrypts MLS layer (still group member) but gets opaque AES-256 ciphertext from blocker.",
-        "keyRetention": "Sender key rotation only on block, NOT on MLS epoch advances. Old sender keys retained for historical message decryption. Forward secrecy for sender keys is not a goal — MLS provides forward secrecy at group level.",
+        "keyRetention": "Sender key rotation only on block, NOT on MLS epoch advances. Old sender keys retained for historical message decryption. Forward secrecy for sender keys is not a goal \u2014 MLS provides forward secrecy at group level.",
         "aesGcmParams": "AES-256-GCM: 32-byte key, random 12-byte nonce per encryption, 16-byte authentication tag. Output format: (nonce || ciphertext || auth_tag)."
       }
     },
@@ -1021,14 +1021,14 @@
       ],
       "description": "Implement the pull-based sender key distribution protocol (SenderKeyEpochAdvance, SenderKeyRequest, SenderKeyResponse), the block notification mechanism with mutual key rotation, and the rotate_sender_key_for_block operation. When a sender generates or rotates a key, they publish a lightweight epoch advance notification. Members request the actual key material on demand via HPKE-encrypted request/response.",
       "acceptanceCriteria": [
-        "SenderKeyEpochAdvance struct defined with sender_did, epoch, signature — signs context_id || sender_did || \"key_epoch\" || epoch",
+        "SenderKeyEpochAdvance struct defined with sender_did, epoch, signature \u2014 signs context_id || sender_did || \"key_epoch\" || epoch",
         "SenderKeyRequest struct defined with requester_did, sender_did, epoch, wrapping_pubkey (X25519), signature",
         "SenderKeyResponse struct defined with sender_did, epoch, hpke_sealed_key, ephemeral_pubkey (X25519)",
-        "publish_sender_key_epoch_advance(key_custody, mls_group, context_id, sender_did, epoch) -> MlsMessage constructs signed SenderKeyEpochAdvance and sends as MLS application message — O(1) cost",
+        "publish_sender_key_epoch_advance(key_custody, mls_group, context_id, sender_did, epoch) -> MlsMessage constructs signed SenderKeyEpochAdvance and sends as MLS application message \u2014 O(1) cost",
         "handle_sender_key_request(key_custody, mls_group, request, block_list) -> Option<MlsMessage> verifies request signature, checks block list, HPKE-encrypts sender key to requester's wrapping_pubkey if not blocked",
         "handle_sender_key_request returns None if requester_did is blocked (no response, requester cannot obtain key)",
         "HPKE assembly: (1) generate ephemeral X25519 keypair, (2) ECDH between ephemeral secret and requester wrapping pubkey, (3) HKDF to derive encryption key, (4) AES-128-GCM encrypt sender key. Ephemeral public key included in response",
-        "request_sender_key(key_custody, mls_group, sender_did, epoch) -> MlsMessage constructs SenderKeyRequest with fresh ephemeral X25519 wrapping keypair, signed by requester's Active Signing Key — O(1) cost",
+        "request_sender_key(key_custody, mls_group, sender_did, epoch) -> MlsMessage constructs SenderKeyRequest with fresh ephemeral X25519 wrapping keypair, signed by requester's Active Signing Key \u2014 O(1) cost",
         "HPKE open (recipient-side): uses key_custody.dh_agree(wrapping_key_handle, ephemeral_pk) inside custody boundary, then KDF + AEAD in software to recover sender key",
         "rotate_sender_key_for_block(mls_group, blocked_did) -> SenderKey generates new sender key, increments sender_key_epoch, publishes SenderKeyEpochAdvance, adds blocked_did to block list",
         "Non-blocked members observe epoch advance, send SenderKeyRequest, receive new key. Blocked party sends SenderKeyRequest but receives no response",
@@ -1046,13 +1046,13 @@
       ],
       "actionItems": [
         "Define SenderKeyEpochAdvance, SenderKeyRequest, SenderKeyResponse structs in key_protocol.rs",
-        "Implement publish_sender_key_epoch_advance — sign with Active Signing Key, construct MLS application message",
-        "Implement request_sender_key — generate ephemeral X25519 wrapping keypair, sign request, send via MLS",
-        "Implement handle_sender_key_request — verify signature, check block list, HPKE encrypt sender key to wrapping pubkey",
+        "Implement publish_sender_key_epoch_advance \u2014 sign with Active Signing Key, construct MLS application message",
+        "Implement request_sender_key \u2014 generate ephemeral X25519 wrapping keypair, sign request, send via MLS",
+        "Implement handle_sender_key_request \u2014 verify signature, check block list, HPKE encrypt sender key to wrapping pubkey",
         "Implement HPKE seal: ephemeral X25519 keypair generation, ECDH, HKDF, AES-128-GCM encryption",
         "Implement HPKE open: dh_agree via key_custody, KDF + AEAD decryption in software",
-        "Implement rotate_sender_key_for_block — generate new key, increment epoch, publish advance, update block list",
-        "Implement send_block_notification — sign block notification, send as MLS message",
+        "Implement rotate_sender_key_for_block \u2014 generate new key, increment epoch, publish advance, update block list",
+        "Implement send_block_notification \u2014 sign block notification, send as MLS message",
         "Implement block notification verification on receipt",
         "Add 30-second grace period for old sender key acceptance after epoch advance",
         "Write tests for epoch advance publish and verification",
@@ -1094,14 +1094,14 @@
       ],
       "description": "Define the SCP native relay protocol message types (ClientMessage, RelayMessage) and MessagePack serialization over WebSocket binary frames. The relay protocol has exactly 6 client operations (PUBLISH, SUBSCRIBE, UNSUBSCRIBE, QUERY, DELETE, ACK) plus PING, and 5 relay response types (OK, ERR, BLOB, EVENT, PONG) with defined error codes.",
       "acceptanceCriteria": [
-        "ClientMessage enum defined with variants: Publish, Subscribe, Unsubscribe, Query, Delete, Ack, Ping — matching reference Rust types",
-        "RelayMessage enum defined with variants: Ok, Err, Blob, Event, Pong — matching reference Rust types",
+        "ClientMessage enum defined with variants: Publish, Subscribe, Unsubscribe, Query, Delete, Ack, Ping \u2014 matching reference Rust types",
+        "RelayMessage enum defined with variants: Ok, Err, Blob, Event, Pong \u2014 matching reference Rust types",
         "All messages serialized via serde with rmp-serde over WebSocket binary frames",
         "op field is string, handled by tagged enum representation",
         "All binary fields use MessagePack native bin type (not hex/base64 strings)",
         "routing_id, recipient_hint, blob_id are exactly 32 bytes (bin32)",
         "ref field: client-assigned request ID (optional, echoed in response, max 64 bytes)",
-        "Constraints enforced: blob_ttl 1–604800 (7 days), blob 1–262144 bytes (256KB)",
+        "Constraints enforced: blob_ttl 1\u2013604800 (7 days), blob 1\u2013262144 bytes (256KB)",
         "QUERY defaults: limit default 100, max 1000",
         "Error codes defined: client errors 4000-4021, server errors 5000-5002",
         "Serialization/deserialization roundtrip tests for all message types",
@@ -1135,7 +1135,7 @@
         "errorCodes": "Client errors (4xxx): 4000 INVALID_MESSAGE, 4001 UNKNOWN_OP, 4002 MISSING_FIELD, 4003 INVALID_FIELD, 4010 BLOB_TOO_LARGE, 4011 TTL_TOO_LONG, 4012 LIMIT_EXCEEDED, 4020 RATE_LIMITED, 4021 TOO_MANY_SUBSCRIPTIONS. Server errors (5xxx): 5000 INTERNAL_ERROR, 5001 STORAGE_FULL, 5002 SHUTTING_DOWN. Unknown codes by category: 4xxx = do not retry, 5xxx = retry with backoff or switch relay.",
         "wireFormat": "MessagePack (via rmp-serde) over WebSocket binary frames. Native binary support eliminates Base64 overhead (~33% savings). Every message is a MessagePack map with required op field (string) plus operation-specific fields.",
         "keepalive": "Client MUST send PING every 30 seconds. Relay MAY close idle connections after 90 seconds. WebSocket-level pings (opcode 0x9) are independent TCP-level liveness checks.",
-        "connectionUrl": "wss://<host>/scp/v1. TLS 1.3 required (§9.13). URL path encodes protocol version — no in-band version negotiation. Relay returns HTTP 404 for unsupported versions.",
+        "connectionUrl": "wss://<host>/scp/v1. TLS 1.3 required (\u00a79.13). URL path encodes protocol version \u2014 no in-band version negotiation. Relay returns HTTP 404 for unsupported versions.",
         "backfillOrdering": "Oldest-first (ascending relay receipt timestamp). Enables incremental processing, natural stream transition from backfill to real-time, gets at-risk (expiring) messages to clients first."
       },
       "result": "Implemented native relay protocol types: ClientMessage (7 variants), RelayMessage (5 variants), MessagePack serde, error codes, validation. 48 tests."
@@ -1151,7 +1151,7 @@
         "crates/scp-transport/src/native/server.rs",
         "crates/scp-transport/src/native/storage.rs"
       ],
-      "description": "Implement the SCP native relay server: a WebSocket-based store-and-forward relay that accepts opaque blobs, holds them for a TTL, delivers to subscribers, and deletes on expiry or request. The relay is a dumb pipe — it cannot read, forge, or modify encrypted content. No client authentication. Phase 1 uses in-memory blob storage.",
+      "description": "Implement the SCP native relay server: a WebSocket-based store-and-forward relay that accepts opaque blobs, holds them for a TTL, delivers to subscribers, and deletes on expiry or request. The relay is a dumb pipe \u2014 it cannot read, forge, or modify encrypted content. No client authentication. Phase 1 uses in-memory blob storage.",
       "acceptanceCriteria": [
         "Relay server listens for WebSocket connections",
         "PUBLISH: accepts opaque blob with routing_id, stores for blob_ttl seconds, returns blob_id (SHA-256 hash of blob), delivers immediately to active subscribers of routing_id",
@@ -1205,7 +1205,7 @@
       ],
       "details": {
         "relayOperatorConfig": "Published out-of-band. Defaults: max_blob_size 262144, max_blob_ttl 604800, max_subscriptions_per_connection 100, max_query_limit 1000, rate_limit_publish 60/min, rate_limit_subscribe 20/min, idle_timeout 90s.",
-        "contextMetadata": "Contexts publish parameters to publicly derivable routing ID: metadata_routing_id = SHA-256(context_id || \"scp-metadata\"). Any participant can SUBSCRIBE or QUERY to inspect context parameters before joining. Metadata blob is signed, unencrypted envelope containing ContextParameters struct (spec §5.3). Enables legibility-before-opt-in tenet.",
+        "contextMetadata": "Contexts publish parameters to publicly derivable routing ID: metadata_routing_id = SHA-256(context_id || \"scp-metadata\"). Any participant can SUBSCRIBE or QUERY to inspect context parameters before joining. Metadata blob is signed, unencrypted envelope containing ContextParameters struct (spec \u00a75.3). Enables legibility-before-opt-in tenet.",
         "connectionRecovery": "Client-side: reconnect with exponential backoff (1s, 2s, 4s, 8s, 16s, 30s cap). Re-issue SUBSCRIBE with since = last received stored_at minus 5-second overlap. Deduplicate via blob_id. Relay maintains no per-client state across connections."
       },
       "result": "Implemented relay server (storage.rs + server.rs) with WebSocket handling, subscription registry, TTL expiry, backfill, PING/PONG. 30 tests."
@@ -1235,7 +1235,7 @@
         "Reconnection with exponential backoff: 1s, 2s, 4s, 8s, 16s, 30s cap",
         "On reconnect, re-issues SUBSCRIBE for each routing_id with since = last received stored_at minus 5-second overlap",
         "Client deduplicates via blob_id on reconnect",
-        "Relay maintains no per-client state across connections — recovery is entirely client-driven",
+        "Relay maintains no per-client state across connections \u2014 recovery is entirely client-driven",
         "No unwrap() or expect() in library code"
       ],
       "actionItems": [
@@ -1265,8 +1265,8 @@
         }
       ],
       "details": {
-        "connectionUrl": "wss://<host>/scp/v1. TLS 1.3 required (§9.13). URL path encodes protocol version.",
-        "reconnectionStrategy": "Exponential backoff: 1s, 2s, 4s, 8s, 16s, 30s cap. On reconnect, re-issue SUBSCRIBE for each routing_id with since = last received stored_at minus 5-second overlap. Deduplicate via blob_id per §9.8.2 layer (b). Relay maintains no per-client state across connections — recovery entirely client-driven.",
+        "connectionUrl": "wss://<host>/scp/v1. TLS 1.3 required (\u00a79.13). URL path encodes protocol version.",
+        "reconnectionStrategy": "Exponential backoff: 1s, 2s, 4s, 8s, 16s, 30s cap. On reconnect, re-issue SUBSCRIBE for each routing_id with since = last received stored_at minus 5-second overlap. Deduplicate via blob_id per \u00a79.8.2 layer (b). Relay maintains no per-client state across connections \u2014 recovery entirely client-driven.",
         "adapterMapping": "send(envelope) -> PUBLISH, subscribe(routing_id) -> SUBSCRIBE + stream, unsubscribe(routing_id) -> UNSUBSCRIBE, query(routing_id, since) -> QUERY, delete(blob_id) -> DELETE"
       }
     },
@@ -1281,7 +1281,7 @@
         "crates/scp-testing/tests/integration/phase1.rs",
         "crates/scp-testing/Cargo.toml"
       ],
-      "description": "The ultimate acceptance criterion for Phase 1: a single integration test that exercises all 7 ADRs together. Alice and Bob exchange encrypted messages through the SCP native relay. The relay sees nothing — no DIDs, no context IDs, no message content, only routing pseudonyms and blob TTLs. This test proves: identity works, encryption works, the envelope format works, sender keys work, the relay is a dumb pipe, and the transport abstraction is functional.",
+      "description": "The ultimate acceptance criterion for Phase 1: a single integration test that exercises all 7 ADRs together. Alice and Bob exchange encrypted messages through the SCP native relay. The relay sees nothing \u2014 no DIDs, no context IDs, no message content, only routing pseudonyms and blob TTLs. This test proves: identity works, encryption works, the envelope format works, sender keys work, the relay is a dumb pipe, and the transport abstraction is functional.",
       "acceptanceCriteria": [
         "Alice creates a did:dht identity (ADR-003) using in-memory key custody (ADR-006)",
         "Bob creates a did:dht identity (ADR-003) using in-memory key custody (ADR-006)",
@@ -1294,7 +1294,7 @@
         "Alice sends the outer envelope via the native relay (ADR-004) using the transport trait (ADR-005)",
         "Bob receives the outer envelope via relay subscription (ADR-004, ADR-005)",
         "Bob decrypts MLS layer (ADR-001), decrypts sender key layer (ADR-007), verifies inner envelope signature (ADR-002)",
-        "Bob reads Alice's message — content matches original",
+        "Bob reads Alice's message \u2014 content matches original",
         "The relay never saw: Alice's DID, Bob's DID, the context ID, the message content, or any metadata beyond the routing pseudonym and blob TTL",
         "Integration tests: native relay adapter send/receive through relay server roundtrip"
       ],
@@ -1313,7 +1313,7 @@
         "Step 10: Bob subscribes and receives outer envelope via NativeRelayAdapter",
         "Step 11: Bob opens envelope: MLS decrypt, sender key decrypt, verify inner signature",
         "Step 12: Assert Bob's decrypted message matches Alice's original",
-        "Step 13: Assert relay state contains no DIDs, no context IDs, no plaintext — only routing pseudonyms and blob TTLs"
+        "Step 13: Assert relay state contains no DIDs, no context IDs, no plaintext \u2014 only routing pseudonyms and blob TTLs"
       ],
       "blockedBy": [
         "SCP-001",
@@ -1359,20 +1359,20 @@
       ],
       "description": "Implement the context lifecycle as a five-state finite state machine in `scp-core/context/`. Each context transitions through: `Creating -> Active -> Closing -> Closed`, with an additional `Expired` terminal state reachable from `Active` when TTL elapses. The Context Manager owns all state transitions, and every transition is recorded in the context's verifiable event log (ADR-011). The MLS group is created during the `Creating -> Active` transition and destroyed during the `Closing -> Closed` transition. This story covers the foundational types: `ContextState`, `ContextHandle`, `ContextParams`, `ContextMode`, `CeilingPolicy`, `PromotionPolicy`, `MemoryScope`, `GovernanceModel`, and the state transition validation logic.",
       "acceptanceCriteria": [
-        "`ContextState` enum with variants: `Creating`, `Active`, `Closing`, `Closed`, `Expired` — derives Debug, Clone, PartialEq, Eq, Serialize, Deserialize",
+        "`ContextState` enum with variants: `Creating`, `Active`, `Closing`, `Closed`, `Expired` \u2014 derives Debug, Clone, PartialEq, Eq, Serialize, Deserialize",
         "Valid transitions enforced: `Creating -> Active` (MLS group formed, initial parameters committed, context published), `Active -> Closing` (close initiated by admin or close-capable role), `Active -> Expired` (TTL elapsed, automatic, no governance override), `Closing -> Closed` (all members processed final events, summary generated if applicable, keys destroyed)",
         "Invalid transitions return error: `Closed -> *` (terminal), `Expired -> *` (terminal), `Creating -> Closing` (never active, just drop), `Closing -> Active` (no re-opening)",
         "`ContextParams` struct with fields: mode (ContextMode), ceiling (Vec<Capability>), ceiling_policy (CeilingPolicy), promotion_policy (PromotionPolicy), roles (Vec<RoleDefinition>), tools (Vec<ToolRegistration>), ttl (Option<Duration>), memory_scope (MemoryScope), governance (GovernanceModel), template_id (Option<TemplateId>)",
         "`CeilingPolicy` enum: `Immutable` (default, ceiling fixed at creation, any attempt to modify returns `ContextError::CeilingImmutable`), `Governed` (ceiling can be modified through governance, can only be narrowed never expanded beyond original creation ceiling)",
         "`PromotionPolicy` enum: `NoPromotion` (context cannot be promoted, immutable lifecycle constraints), `Promotable` (context can be promoted through governance approval)",
-        "`ContextMode` enum: `Encrypted` (MLS-backed, sender-side keys, full forward secrecy, default), `Broadcast` (per-author broadcast keys, no MLS, mandatory subscriber registration §5.14) — immutable after creation",
+        "`ContextMode` enum: `Encrypted` (MLS-backed, sender-side keys, full forward secrecy, default), `Broadcast` (per-author broadcast keys, no MLS, mandatory subscriber registration \u00a75.14) \u2014 immutable after creation",
         "`MemoryScope` enum: `Ephemeral`, `Summary`, `Full`",
         "`TemplateId` enum: `BilateralEphemeral`, `BilateralPersistent`, `Coordination`, `GroupDiscussion`, `PublicBroadcast`, `GatedBroadcast`",
         "Broadcast mode: when `mode == Broadcast`, no MLS group is created; context uses per-author AES-256-GCM broadcast keys; subscriber count is unlimited; routing_id is derived as SHA-256(context_id); authors hold MessagesWrite capability; subscribers hold MessagesRead capability and receive broadcast keys via HPKE-wrapped key distribution",
         "Unit tests for all valid state transitions succeed",
         "Unit tests for all invalid state transitions return appropriate ContextError variants",
-        "All public handle types (`ContextHandle`, `ContextState`, `ContextParams`) are `Send + Sync` — safe to share across threads and tokio tasks. No SDK user should ever need an external lock to use SCP types safely.",
-        "Individual operations on shared handles are serialized internally — concurrent sends on the same context are safe and ordered"
+        "All public handle types (`ContextHandle`, `ContextState`, `ContextParams`) are `Send + Sync` \u2014 safe to share across threads and tokio tasks. No SDK user should ever need an external lock to use SCP types safely.",
+        "Individual operations on shared handles are serialized internally \u2014 concurrent sends on the same context are safe and ordered"
       ],
       "actionItems": [
         "Create `crates/scp-core/context/mod.rs` with `ContextHandle` struct (holds context_id, state reference), `ContextState` enum, module re-exports",
@@ -1398,15 +1398,15 @@
         }
       ],
       "details": {
-        "State machine definition": "```rust\n#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]\npub enum ContextState {\n    Creating,\n    Active,\n    Closing,\n    Closed,\n    Expired,\n}\n```\n\nValid transitions:\n- `Creating -> Active` — MLS group formed, initial parameters committed, context published.\n- `Active -> Closing` — Close initiated by admin (governance) or close-capable role.\n- `Active -> Expired` — TTL elapsed. Automatic. No governance override.\n- `Closing -> Closed` — All members processed final events, summary generated (if applicable), keys destroyed.\n\nInvalid transitions (must return error):\n- `Closed -> *` (terminal)\n- `Expired -> *` (terminal)\n- `Creating -> Closing` (never active, just drop)\n- `Closing -> Active` (no re-opening)",
+        "State machine definition": "```rust\n#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]\npub enum ContextState {\n    Creating,\n    Active,\n    Closing,\n    Closed,\n    Expired,\n}\n```\n\nValid transitions:\n- `Creating -> Active` \u2014 MLS group formed, initial parameters committed, context published.\n- `Active -> Closing` \u2014 Close initiated by admin (governance) or close-capable role.\n- `Active -> Expired` \u2014 TTL elapsed. Automatic. No governance override.\n- `Closing -> Closed` \u2014 All members processed final events, summary generated (if applicable), keys destroyed.\n\nInvalid transitions (must return error):\n- `Closed -> *` (terminal)\n- `Expired -> *` (terminal)\n- `Creating -> Closing` (never active, just drop)\n- `Closing -> Active` (no re-opening)",
         "ContextParams struct": "```rust\npub struct ContextParams {\n    pub mode: ContextMode,\n    pub ceiling: Vec<Capability>,\n    pub ceiling_policy: CeilingPolicy,\n    pub promotion_policy: PromotionPolicy,\n    pub roles: Vec<RoleDefinition>,\n    pub tools: Vec<ToolRegistration>,\n    pub ttl: Option<Duration>,\n    pub memory_scope: MemoryScope,\n    pub governance: GovernanceModel,\n    pub template_id: Option<TemplateId>,\n}\n```",
         "CeilingPolicy enum": "```rust\npub enum CeilingPolicy {\n    Immutable,\n    Governed,\n}\n```\nImmutable: Ceiling is fixed at creation. Any attempt to modify returns `ContextError::CeilingImmutable`. Default and security-conservative choice.\nGoverned: Ceiling can be modified through governance model. Can only be narrowed (capabilities removed), never expanded beyond the original creation ceiling.",
         "PromotionPolicy enum": "```rust\npub enum PromotionPolicy {\n    NoPromotion,\n    Promotable,\n}\n```",
-        "ContextMode enum": "```rust\npub enum ContextMode {\n    Encrypted,\n    Broadcast,\n}\n```\nEncrypted: MLS-backed, sender-side keys, full forward secrecy (default).\nBroadcast: Per-author broadcast keys, no MLS, mandatory subscriber registration (§5.14).",
-        "Broadcast mode acceptance criteria": "When `mode == Broadcast`:\n- No MLS group is created. Context uses per-author AES-256-GCM broadcast keys instead of MLS group keys.\n- Subscriber count is unlimited (no MLS group size bound).\n- The context's public `routing_id` is derived as `SHA-256(context_id)` — deterministic and discoverable by any agent that knows the context_id.\n- Authors are bounded participants who hold `MessagesWrite` capability. Each author maintains their own broadcast key with independent epoch rotation.\n- Subscribers hold `MessagesRead` capability and receive broadcast keys via HPKE-wrapped key distribution (no MLS Welcome messages).\n- `create_context` skips MLS group creation (step 2) and instead initializes the creator's broadcast key at epoch 0.\n- `join_context` for subscribers registers DID-authenticated subscription without MLS add_member.\n- `send_message` encrypts with the author's current broadcast key, wraps in `BroadcastEnvelope` (§5.14.5), and publishes to the public routing_id.\n- All other context lifecycle operations (close, expire, TTL, event log) operate identically regardless of mode.",
-        "TemplateId enum": "```rust\npub enum TemplateId {\n    BilateralEphemeral,\n    BilateralPersistent,\n    Coordination,\n    GroupDiscussion,\n    PublicBroadcast,\n    GatedBroadcast,\n}\n```\nTemplates are protocol constants — not user-extensible. When present, all other ContextParams fields must match the template definition exactly.",
-        "Implementation notes": "Language: Rust. Crate: scp-core. Module: scp-core/context/. Async runtime: tokio (TTL timers, MLS operations, transport). State persistence: Via ProtocolStore (§17.4), which wraps the scp-platform Storage trait with typed domain methods. Context state is serialized and persisted on every transition so contexts survive process restarts. Key convention follows §17.3.",
-        "Concurrency model": "All public handle types (Identity, Context, TransportManager) are safe to share across threads/tasks. In Rust: Send + Sync. In Python: safe to use from any asyncio task on the same event loop. In Swift: Sendable. In Go: safe for concurrent use. In Kotlin: safe across coroutines. Individual operations are serialized internally — concurrent sends on the same context are safe and ordered. No SDK user should ever need an external lock to use SCP types safely."
+        "ContextMode enum": "```rust\npub enum ContextMode {\n    Encrypted,\n    Broadcast,\n}\n```\nEncrypted: MLS-backed, sender-side keys, full forward secrecy (default).\nBroadcast: Per-author broadcast keys, no MLS, mandatory subscriber registration (\u00a75.14).",
+        "Broadcast mode acceptance criteria": "When `mode == Broadcast`:\n- No MLS group is created. Context uses per-author AES-256-GCM broadcast keys instead of MLS group keys.\n- Subscriber count is unlimited (no MLS group size bound).\n- The context's public `routing_id` is derived as `SHA-256(context_id)` \u2014 deterministic and discoverable by any agent that knows the context_id.\n- Authors are bounded participants who hold `MessagesWrite` capability. Each author maintains their own broadcast key with independent epoch rotation.\n- Subscribers hold `MessagesRead` capability and receive broadcast keys via HPKE-wrapped key distribution (no MLS Welcome messages).\n- `create_context` skips MLS group creation (step 2) and instead initializes the creator's broadcast key at epoch 0.\n- `join_context` for subscribers registers DID-authenticated subscription without MLS add_member.\n- `send_message` encrypts with the author's current broadcast key, wraps in `BroadcastEnvelope` (\u00a75.14.5), and publishes to the public routing_id.\n- All other context lifecycle operations (close, expire, TTL, event log) operate identically regardless of mode.",
+        "TemplateId enum": "```rust\npub enum TemplateId {\n    BilateralEphemeral,\n    BilateralPersistent,\n    Coordination,\n    GroupDiscussion,\n    PublicBroadcast,\n    GatedBroadcast,\n}\n```\nTemplates are protocol constants \u2014 not user-extensible. When present, all other ContextParams fields must match the template definition exactly.",
+        "Implementation notes": "Language: Rust. Crate: scp-core. Module: scp-core/context/. Async runtime: tokio (TTL timers, MLS operations, transport). State persistence: Via ProtocolStore (\u00a717.4), which wraps the scp-platform Storage trait with typed domain methods. Context state is serialized and persisted on every transition so contexts survive process restarts. Key convention follows \u00a717.3.",
+        "Concurrency model": "All public handle types (Identity, Context, TransportManager) are safe to share across threads/tasks. In Rust: Send + Sync. In Python: safe to use from any asyncio task on the same event loop. In Swift: Sendable. In Go: safe for concurrent use. In Kotlin: safe across coroutines. Individual operations are serialized internally \u2014 concurrent sends on the same context are safe and ordered. No SDK user should ever need an external lock to use SCP types safely."
       },
       "result": "Implemented context types: ContextState FSM, ContextHandle, ContextParams, all parameter enums. 52 tests."
     },
@@ -1424,8 +1424,8 @@
       "description": "Implement `create_context(params: ContextParams) -> Result<ContextHandle, ContextError>` with a two-phase commit pattern: validate all preconditions (no side effects), then execute with ordered rollback on failure. Each step records its completion in a `CreationReceipt` struct. On failure at any step, all previously completed steps are rolled back in reverse order. After a failed `create_context` call, no MLS group state, no sender key material, and no event log state persists. The operation is atomic from the caller's perspective.",
       "acceptanceCriteria": [
         "`create_context(params: ContextParams) -> Result<ContextHandle, ContextError>` implemented with two-phase commit pattern",
-        "Phase 1 — Validate (no side effects): validates ContextParams (ceiling, roles, tools, TTL, memory scope, governance model); if template_id is present, validates all params match the template definition exactly; validates the creator's identity is valid and the signing key is accessible; validates transport is connected and at least one relay is reachable; if any validation fails, returns ContextError immediately with no state created",
-        "Phase 2 — Execute (with ordered rollback): Step 1: transition state to Creating; Step 2: if mode == Encrypted create MLS group via ADR-001 create_group(), if mode == Broadcast initialize creator's broadcast key (epoch 0) — no MLS group, on failure drop Creating state and return error; Step 3: if mode == Encrypted generate creator's sender key via ADR-007 generate_sender_key(), if mode == Broadcast broadcast key already initialized in step 2, on failure destroy MLS group and return error; Step 4: initialize empty event log (ADR-011), on failure destroy sender key and MLS group and return error; Step 5: publish context to transport, on failure drop event log, destroy sender key, destroy MLS group, and return error; Step 6: transition state to Active; Step 7: append ContextCreated event to event log; Step 8: return ContextHandle",
+        "Phase 1 \u2014 Validate (no side effects): validates ContextParams (ceiling, roles, tools, TTL, memory scope, governance model); if template_id is present, validates all params match the template definition exactly; validates the creator's identity is valid and the signing key is accessible; validates transport is connected and at least one relay is reachable; if any validation fails, returns ContextError immediately with no state created",
+        "Phase 2 \u2014 Execute (with ordered rollback): Step 1: transition state to Creating; Step 2: if mode == Encrypted create MLS group via ADR-001 create_group(), if mode == Broadcast initialize creator's broadcast key (epoch 0) \u2014 no MLS group, on failure drop Creating state and return error; Step 3: if mode == Encrypted generate creator's sender key via ADR-007 generate_sender_key(), if mode == Broadcast broadcast key already initialized in step 2, on failure destroy MLS group and return error; Step 4: initialize empty event log (ADR-011), on failure destroy sender key and MLS group and return error; Step 5: publish context to transport, on failure drop event log, destroy sender key, destroy MLS group, and return error; Step 6: transition state to Active; Step 7: append ContextCreated event to event log; Step 8: return ContextHandle",
         "`CreationReceipt` struct tracks: mls_group (Option<MlsGroup>, None for Broadcast mode), sender_key (Option<SenderKey>), event_log (Option<EventLog>), published (bool)",
         "Rollback guarantees: after a failed create_context call, no MLS group state, no sender key material, and no event log state persists",
         "Transport publication failure: if the context was partially published (e.g., sent to 1 of 3 relays before failure), the rollback issues DELETE requests for any published blobs; DELETE is best-effort but orphaned blobs are encrypted with destroyed keys and cannot be used",
@@ -1458,7 +1458,7 @@
       ],
       "details": {
         "CreationReceipt struct": "```rust\nstruct CreationReceipt {\n    mls_group: Option<MlsGroup>,       // None for Broadcast mode\n    sender_key: Option<SenderKey>,      // Sender key (Encrypted) or broadcast key (Broadcast)\n    event_log: Option<EventLog>,\n    published: bool,\n}\n```",
-        "Two-phase commit steps": "Phase 1 — Validate (no side effects):\n- Validates ContextParams: ceiling, roles, tools, TTL, memory scope, governance model.\n- If template_id is present, validates all params match the template definition exactly.\n- Validates the creator's identity is valid and the signing key is accessible.\n- Validates transport is connected and at least one relay is reachable.\n- If any validation fails, returns ContextError immediately. No state has been created.\n\nPhase 2 — Execute (with ordered rollback):\n1. Transition state to Creating.\n2. If mode == Encrypted: Create MLS group via ADR-001 create_group(). If mode == Broadcast: Initialize creator's broadcast key (epoch 0) — no MLS group. On failure: drop Creating state, return error.\n3. If mode == Encrypted: Generate creator's sender key via ADR-007 generate_sender_key(). If mode == Broadcast: Broadcast key already initialized in step 2. On failure: destroy MLS group, return error.\n4. Initialize empty event log (ADR-011). On failure: destroy sender key, destroy MLS group, return error.\n5. Publish context to transport. On failure: drop event log, destroy sender key, destroy MLS group, return error.\n6. Transition state to Active.\n7. Append ContextCreated event to event log.\n8. Return ContextHandle."
+        "Two-phase commit steps": "Phase 1 \u2014 Validate (no side effects):\n- Validates ContextParams: ceiling, roles, tools, TTL, memory scope, governance model.\n- If template_id is present, validates all params match the template definition exactly.\n- Validates the creator's identity is valid and the signing key is accessible.\n- Validates transport is connected and at least one relay is reachable.\n- If any validation fails, returns ContextError immediately. No state has been created.\n\nPhase 2 \u2014 Execute (with ordered rollback):\n1. Transition state to Creating.\n2. If mode == Encrypted: Create MLS group via ADR-001 create_group(). If mode == Broadcast: Initialize creator's broadcast key (epoch 0) \u2014 no MLS group. On failure: drop Creating state, return error.\n3. If mode == Encrypted: Generate creator's sender key via ADR-007 generate_sender_key(). If mode == Broadcast: Broadcast key already initialized in step 2. On failure: destroy MLS group, return error.\n4. Initialize empty event log (ADR-011). On failure: destroy sender key, destroy MLS group, return error.\n5. Publish context to transport. On failure: drop event log, destroy sender key, destroy MLS group, return error.\n6. Transition state to Active.\n7. Append ContextCreated event to event log.\n8. Return ContextHandle."
       },
       "result": "Two-phase commit with identity validation, opaque handle receipt types, and partial publication rollback"
     },
@@ -1580,9 +1580,9 @@
       "files": [
         "crates/scp-core/context/templates.rs"
       ],
-      "description": "Implement well-known context templates (spec §5.12.1). Templates are protocol constants — not user-extensible. When template_id is present, all ContextParams fields must match the template definition exactly. Context nesting (§5.13) is NOT in Phase 2 scope — see SCP-134.",
+      "description": "Implement well-known context templates (spec \u00a75.12.1). Templates are protocol constants \u2014 not user-extensible. When template_id is present, all ContextParams fields must match the template definition exactly. Context nesting (\u00a75.13) is NOT in Phase 2 scope \u2014 see SCP-134.",
       "acceptanceCriteria": [
-        "Well-known template definitions for all 6 templates: BilateralEphemeral (messaging-only, ephemeral, TTL required), BilateralPersistent (messaging-only, full memory, no TTL), Coordination (messaging + tools, summary memory, TTL required), GroupDiscussion (messaging + invites, full memory, optional TTL), PublicBroadcast (broadcast mode, open subscriber registration §5.14), GatedBroadcast (broadcast mode, UCAN-gated subscriber access §5.14)",
+        "Well-known template definitions for all 6 templates: BilateralEphemeral (messaging-only, ephemeral, TTL required), BilateralPersistent (messaging-only, full memory, no TTL), Coordination (messaging + tools, summary memory, TTL required), GroupDiscussion (messaging + invites, full memory, optional TTL), PublicBroadcast (broadcast mode, open subscriber registration \u00a75.14), GatedBroadcast (broadcast mode, UCAN-gated subscriber access \u00a75.14)",
         "Template validation: when template_id is present, all ContextParams fields must match the template definition exactly; mismatch returns ContextError",
         "Template-based ContextParams construction: given a TemplateId, produce a ContextParams with all required fields pre-filled",
         "Unit test: each template produces valid ContextParams",
@@ -1605,7 +1605,7 @@
       ],
       "details": {
         "Scope files": "| File | Purpose |\n|------|---------||\n| `templates.rs` | Well-known template definitions, template validation (params match template), template-based ContextParams construction |",
-        "Nesting deferral": "Context nesting (§5.13) was originally in this story but is NOT Phase 2 scope. See SCP-134 for the nesting story."
+        "Nesting deferral": "Context nesting (\u00a75.13) was originally in this story but is NOT Phase 2 scope. See SCP-134 for the nesting story."
       },
       "result": "All 6 templates spec-aligned, from_template constructor, roles/tools validation added"
     },
@@ -1619,15 +1619,15 @@
       "files": [
         "crates/scp-core/context/roles.rs"
       ],
-      "description": "Implement UCAN-based capability ceiling enforcement and role assignment in scp-core/context/roles.rs. The capability ceiling is declared at context creation and is immutable (spec section 5.3) — it bounds the maximum set of operations possible in the context. Roles (spec section 5.5) define subsets of the ceiling that specific agents can exercise. Every action requires a valid UCAN capability token, verified mechanically. No action proceeds on identity or reputation alone.",
+      "description": "Implement UCAN-based capability ceiling enforcement and role assignment in scp-core/context/roles.rs. The capability ceiling is declared at context creation and is immutable (spec section 5.3) \u2014 it bounds the maximum set of operations possible in the context. Roles (spec section 5.5) define subsets of the ceiling that specific agents can exercise. Every action requires a valid UCAN capability token, verified mechanically. No action proceeds on identity or reputation alone.",
       "acceptanceCriteria": [
         "`CapabilityCeiling` struct with `capabilities: HashSet<Capability>`",
-        "`Capability` enum with variants: MessagesRead, MessagesWrite, ToolInvoke(ToolId), ToolInvokeAll, ToolRegister, MemberInvite, MemberRemove, RoleAssign, GovernancePropose, GovernanceVote, ContextClose, ChildContextCreate, Custom(String) — derives Debug, Clone, Hash, PartialEq, Eq",
+        "`Capability` enum with variants: MessagesRead, MessagesWrite, ToolInvoke(ToolId), ToolInvokeAll, ToolRegister, MemberInvite, MemberRemove, RoleAssign, GovernancePropose, GovernanceVote, ContextClose, ChildContextCreate, Custom(String) \u2014 derives Debug, Clone, Hash, PartialEq, Eq",
         "Mode-agnostic capabilities: MessagesRead and MessagesWrite apply to both Encrypted and Broadcast modes; ContextMode determines processing, not authorization; no new capability variants needed for broadcast mode",
-        "Ceiling is set at context creation via ContextParams.ceiling; ceiling is immutable, any attempt to modify returns ContextError::CeilingImmutable; role permission sets are validated against the ceiling at role definition time — a role cannot grant capabilities outside the ceiling",
+        "Ceiling is set at context creation via ContextParams.ceiling; ceiling is immutable, any attempt to modify returns ContextError::CeilingImmutable; role permission sets are validated against the ceiling at role definition time \u2014 a role cannot grant capabilities outside the ceiling",
         "`RoleDefinition` struct with `name: String` and `capabilities: HashSet<Capability>`",
         "Built-in roles always available: `admin` (all capabilities in the ceiling), `member` (MessagesRead, MessagesWrite, ToolInvokeAll), `observer` (MessagesRead only)",
-        "Broadcast-specific roles: `author` (MessagesWrite, MessagesRead, ToolInvokeAll — authors are bounded, added via RoleAssigned event), `subscriber` (MessagesRead only — in open broadcast contexts auto-granted on DID-authenticated registration following discovery context reader-tier pattern, in gated broadcast contexts requires explicit admin-issued UCAN)",
+        "Broadcast-specific roles: `author` (MessagesWrite, MessagesRead, ToolInvokeAll \u2014 authors are bounded, added via RoleAssigned event), `subscriber` (MessagesRead only \u2014 in open broadcast contexts auto-granted on DID-authenticated registration following discovery context reader-tier pattern, in gated broadcast contexts requires explicit admin-issued UCAN)",
         "Custom roles defined at context creation with arbitrary capability subsets of the ceiling",
         "`assign_role(context: &ContextHandle, member_did: &DID, role: &str, assigner_did: &DID) -> Result<Vec<UcanToken>, ContextError>` verifies assigner has RoleAssign capability via UCAN validation; validates role exists in context's role definitions; mints UCAN tokens for each capability in the role's permission set; each token has iss = context creator DID, aud = member DID, att = [{ \"with\": \"scp:ctx:{context_id}/{capability}\", \"can\": \"invoke\" }], nnc = unique nonce; distributes tokens to member via MLS application message; revokes any previous tokens for this member (role change); appends RoleAssigned event to event log; returns the minted tokens",
         "`check_ceiling(ceiling: &CapabilityCeiling, capability: &Capability) -> bool` returns true if the capability is within the ceiling; called as part of every UCAN validation; called at role definition time to validate role permission sets",
@@ -1635,7 +1635,7 @@
         "Unit test: assign_role rejects assigner without RoleAssign capability",
         "Unit test: assign_role revokes previous tokens on role change",
         "Unit test: check_ceiling returns false for capability outside ceiling",
-        "Economic policy is orthogonal to capability ceiling (§19.3): ceiling governs what CAN happen, economic policy governs what it COSTS. No new capability category for economics — Spending UCAN (§19.5) is a separate UCAN type, not a ceiling capability"
+        "Economic policy is orthogonal to capability ceiling (\u00a719.3): ceiling governs what CAN happen, economic policy governs what it COSTS. No new capability category for economics \u2014 Spending UCAN (\u00a719.5) is a separate UCAN type, not a ceiling capability"
       ],
       "actionItems": [
         "Create `crates/scp-core/context/roles.rs` with CapabilityCeiling, Capability enum, RoleDefinition, built-in role constructors",
@@ -1663,7 +1663,7 @@
       "details": {
         "CapabilityCeiling type": "```rust\npub struct CapabilityCeiling {\n    pub capabilities: HashSet<Capability>,\n}\n\n#[derive(Debug, Clone, Hash, PartialEq, Eq)]\npub enum Capability {\n    MessagesRead,\n    MessagesWrite,\n    ToolInvoke(ToolId),\n    ToolInvokeAll,\n    ToolRegister,\n    MemberInvite,\n    MemberRemove,\n    RoleAssign,\n    GovernancePropose,\n    GovernanceVote,\n    ContextClose,\n    ChildContextCreate,\n    Custom(String),\n}\n```",
         "RoleDefinition type": "```rust\npub struct RoleDefinition {\n    pub name: String,\n    pub capabilities: HashSet<Capability>,\n}\n```",
-        "Built-in roles": "- `admin` — all capabilities in the ceiling.\n- `member` — MessagesRead, MessagesWrite, ToolInvokeAll.\n- `observer` — MessagesRead only.\n\nBroadcast-specific roles:\n- `author` — MessagesWrite, MessagesRead, ToolInvokeAll. Authors are bounded. Added via RoleAssigned event.\n- `subscriber` — MessagesRead only. In open broadcast contexts (public-broadcast template), MessagesRead is auto-granted on DID-authenticated registration, following the discovery context reader-tier pattern (§6.2.2B). In gated broadcast contexts (gated-broadcast template), MessagesRead requires an explicit admin-issued UCAN.",
+        "Built-in roles": "- `admin` \u2014 all capabilities in the ceiling.\n- `member` \u2014 MessagesRead, MessagesWrite, ToolInvokeAll.\n- `observer` \u2014 MessagesRead only.\n\nBroadcast-specific roles:\n- `author` \u2014 MessagesWrite, MessagesRead, ToolInvokeAll. Authors are bounded. Added via RoleAssigned event.\n- `subscriber` \u2014 MessagesRead only. In open broadcast contexts (public-broadcast template), MessagesRead is auto-granted on DID-authenticated registration, following the discovery context reader-tier pattern (\u00a76.2.2B). In gated broadcast contexts (gated-broadcast template), MessagesRead requires an explicit admin-issued UCAN.",
         "UCAN token format": "Each token: iss = context creator DID, aud = member DID, att = [{ \"with\": \"scp:ctx:{context_id}/{capability}\", \"can\": \"invoke\" }], nnc = unique nonce."
       },
       "result": "Already implemented in prior iteration (SCP-018 remediation). 54 tests, all acceptance criteria met."
@@ -1680,12 +1680,12 @@
         "crates/scp-core/crypto/ucan/mint.rs",
         "crates/scp-core/crypto/ucan/validate.rs"
       ],
-      "description": "Implement UCAN token minting and the 11-step validation pipeline (ADR-016 normative) in scp-core/crypto/ucan/. UCAN tokens are bearer tokens with cryptographic delegation chains — self-contained (no server roundtrip), independently verifiable, and independently revocable. The validation pipeline implements all 11 steps from ADR-016 criterion 2: (1) parse, (2) signature verification, (3) chain verification, (4) root issuer, (5) audience, (6) capability match, (7) attenuation, (8) ceiling, (9) nonce, (10) revocation, (11) expiry. Phase 2 integration tests exercise steps 1–2, 4–6, 8, 10–11 (the 8 steps not requiring delegation chain depth > 1). Phase 3 adds integration tests for steps 3, 7, 9.",
+      "description": "Implement UCAN token minting and the 11-step validation pipeline (ADR-016 normative) in scp-core/crypto/ucan/. UCAN tokens are bearer tokens with cryptographic delegation chains \u2014 self-contained (no server roundtrip), independently verifiable, and independently revocable. The validation pipeline implements all 11 steps from ADR-016 criterion 2: (1) parse, (2) signature verification, (3) chain verification, (4) root issuer, (5) audience, (6) capability match, (7) attenuation, (8) ceiling, (9) nonce, (10) revocation, (11) expiry. Phase 2 integration tests exercise steps 1\u20132, 4\u20136, 8, 10\u201311 (the 8 steps not requiring delegation chain depth > 1). Phase 3 adds integration tests for steps 3, 7, 9.",
       "acceptanceCriteria": [
         "UCAN token types defined in `scp-core/crypto/ucan/mod.rs`: UcanToken struct, module re-exports",
-        "`mint_ucan` in mint.rs: creates UCAN token with iss (context creator DID), aud (member DID), att (capability attestation with format scp:ctx:{context_id}/{capability}), nnc (unique nonce in format {unix_millis_timestamp}-{16_random_bytes_hex}), exp (expiry, must not exceed now + 24 hours per spec §9.5), delegation chain construction",
-        "`validate_ucan(context: &ContextHandle, token: &UcanToken, required_capability: &Capability) -> Result<(), UcanError>` implements the 11-step validation pipeline from ADR-016 criterion 2: (1) parse JWT-format UCAN token, (2) verify Ed25519 signature, (3) chain verification — for each proof CID in prf resolve parent UCAN and verify delegation chain integrity, (4) verify root issuer is context creator DID, (5) verify audience matches presenting agent DID, (6) verify token att includes required capability, (7) attenuation — verify each delegation narrows or preserves capabilities, (8) verify capability is within context ceiling, (9) nonce — validate format/freshness/uniqueness and record in tracker, (10) verify token CID not in revocation list, (11) verify exp > now and nbf <= now. Returns Ok(()) if all 11 checks pass, returns specific UcanError variant on failure. Phase 2 integration tests exercise steps 1–2, 4–6, 8, 10–11; Phase 3 adds integration tests for steps 3, 7, 9",
-        "UCAN token expiry constraint (spec §9.5): UCAN token exp MUST NOT exceed now + 24 hours; tokens with exp beyond 24 hours from issuance are rejected at validation time",
+        "`mint_ucan` in mint.rs: creates UCAN token with iss (context creator DID), aud (member DID), att (capability attestation with format scp:ctx:{context_id}/{capability}), nnc (unique nonce in format {unix_millis_timestamp}-{16_random_bytes_hex}), exp (expiry, must not exceed now + 24 hours per spec \u00a79.5), delegation chain construction",
+        "`validate_ucan(context: &ContextHandle, token: &UcanToken, required_capability: &Capability) -> Result<(), UcanError>` implements the 11-step validation pipeline from ADR-016 criterion 2: (1) parse JWT-format UCAN token, (2) verify Ed25519 signature, (3) chain verification \u2014 for each proof CID in prf resolve parent UCAN and verify delegation chain integrity, (4) verify root issuer is context creator DID, (5) verify audience matches presenting agent DID, (6) verify token att includes required capability, (7) attenuation \u2014 verify each delegation narrows or preserves capabilities, (8) verify capability is within context ceiling, (9) nonce \u2014 validate format/freshness/uniqueness and record in tracker, (10) verify token CID not in revocation list, (11) verify exp > now and nbf <= now. Returns Ok(()) if all 11 checks pass, returns specific UcanError variant on failure. Phase 2 integration tests exercise steps 1\u20132, 4\u20136, 8, 10\u201311; Phase 3 adds integration tests for steps 3, 7, 9",
+        "UCAN token expiry constraint (spec \u00a79.5): UCAN token exp MUST NOT exceed now + 24 hours; tokens with exp beyond 24 hours from issuance are rejected at validation time",
         "UcanError variants for each failure mode: InvalidSignature, InvalidIssuer, AudienceMismatch, CapabilityNotGranted, CapabilityOutsideCeiling, NonceReused, NonceTooOld, NonceFuture, NonceMalformed, TokenRevoked, TokenExpired, ExpiryTooFar",
         "Unit test: minted tokens pass validation",
         "Unit test: signature chain validation catches tampering",
@@ -1713,8 +1713,8 @@
         }
       ],
       "details": {
-        "Validation pipeline note": "Implements the full 11-step validation pipeline from ADR-016 criterion 2. All 11 steps are built from the start (ADR-016 is normative, not a future extension). Phase 2 integration tests exercise steps 1–2, 4–6, 8, 10–11 (8 steps not requiring delegation chain depth > 1). Phase 3 adds integration tests for steps 3 (chain verification), 7 (attenuation), and 9 (structured nonce validation).",
-        "Implementation notes": "Language: Rust. Library: rs-ucan crate (or ucan crate — evaluate for UCAN 0.10+ spec compliance). Crate: scp-core. Modules: scp-core/crypto/ucan/ (UCAN wrapper, validation, revocation). Nonce tracking: In-memory set of seen nonces per context, persisted to storage. Revocation: Revocation list per context, distributed as MLS application messages."
+        "Validation pipeline note": "Implements the full 11-step validation pipeline from ADR-016 criterion 2. All 11 steps are built from the start (ADR-016 is normative, not a future extension). Phase 2 integration tests exercise steps 1\u20132, 4\u20136, 8, 10\u201311 (8 steps not requiring delegation chain depth > 1). Phase 3 adds integration tests for steps 3 (chain verification), 7 (attenuation), and 9 (structured nonce validation).",
+        "Implementation notes": "Language: Rust. Library: rs-ucan crate (or ucan crate \u2014 evaluate for UCAN 0.10+ spec compliance). Crate: scp-core. Modules: scp-core/crypto/ucan/ (UCAN wrapper, validation, revocation). Nonce tracking: In-memory set of seen nonces per context, persisted to storage. Revocation: Revocation list per context, distributed as MLS application messages."
       },
       "result": "UCAN minting (mint.rs) and 11-step validation pipeline (validate.rs). 28 new tests. Ed25519 signing via KeyCustody trait."
     },
@@ -1733,13 +1733,13 @@
       "acceptanceCriteria": [
         "`revoke_ucan(context: &ContextHandle, token_id: &str, revoker_did: &DID) -> Result<(), UcanError>` verifies revoker has authority (must be the token issuer or the context creator); adds token to the context's revocation list; distributes revocation as MLS application message to all members; appends TokenRevoked event to event log",
         "`NonceTracker` struct with `seen: HashMap<String, (u64, u64)>` (nonce -> (first_seen_timestamp, token_expiry_timestamp), both timestamps Unix seconds) and `context_id: ContextId`",
-        "Nonce format: `{unix_millis_timestamp}-{16_random_bytes_hex}` (example: `1708646400000-a3f2b1c9d4e5f6071829`); timestamp prefix enables efficient pruning; random suffix ensures uniqueness; implementations MUST validate nonce format on receipt — malformed nonces are rejected",
-        "Nonce freshness check: timestamp prefix in the nonce MUST be within now - 5 minutes to now + 5 minutes (matching clock skew tolerance from spec §9.14); nonce with timestamp outside this window is rejected as UcanError::NonceTooOld or UcanError::NonceFuture",
+        "Nonce format: `{unix_millis_timestamp}-{16_random_bytes_hex}` (example: `1708646400000-a3f2b1c9d4e5f6071829`); timestamp prefix enables efficient pruning; random suffix ensures uniqueness; implementations MUST validate nonce format on receipt \u2014 malformed nonces are rejected",
+        "Nonce freshness check: timestamp prefix in the nonce MUST be within now - 5 minutes to now + 5 minutes (matching clock skew tolerance from spec \u00a79.14); nonce with timestamp outside this window is rejected as UcanError::NonceTooOld or UcanError::NonceFuture",
         "Replay window: nonce is retained in tracker until max(token_expiry + 5 minutes, first_seen + 24 hours); 5-minute buffer after token expiry accounts for clock skew; 24-hour floor provides safety net for tokens with very short expiry",
         "Pruning: prune() removes entries where now > max(token_expiry + 300, first_seen + 86400); pruning runs every 1000 check_and_record calls or every 10 minutes, whichever comes first",
         "`check_and_record(nonce: &str, token_expiry: u64) -> Result<(), UcanError>` validates nonce format, validates freshness, returns UcanError::NonceReused if seen before, records (now, token_expiry) if new",
         "NonceTracker backed by HashMap per context, persisted to scp-platform Storage for crash recovery",
-        "UCAN token expiry constraint (spec §9.5): UCAN token exp MUST NOT exceed now + 24 hours; tokens with exp beyond 24 hours from issuance are rejected at validation time",
+        "UCAN token expiry constraint (spec \u00a79.5): UCAN token exp MUST NOT exceed now + 24 hours; tokens with exp beyond 24 hours from issuance are rejected at validation time",
         "Unit test: revoking a token causes subsequent validation to fail with TokenRevoked",
         "Unit test: revocation distributed to all members",
         "Unit test: nonce replay rejected",
@@ -1769,8 +1769,8 @@
       ],
       "details": {
         "NonceTracker struct": "```rust\npub struct NonceTracker {\n    /// Map of nonce -> (first_seen_timestamp, token_expiry_timestamp).\n    /// Both timestamps are Unix seconds.\n    seen: HashMap<String, (u64, u64)>,\n    context_id: ContextId,\n}\n```",
-        "Nonce format": "{unix_millis_timestamp}-{16_random_bytes_hex}. Example: 1708646400000-a3f2b1c9d4e5f6071829. The timestamp prefix enables efficient pruning; the random suffix ensures uniqueness. Implementations MUST validate the nonce format on receipt — malformed nonces are rejected.",
-        "Nonce freshness check": "The timestamp prefix in the nonce MUST be within now - 5 minutes to now + 5 minutes (matching the clock skew tolerance from spec §9.14). A nonce with a timestamp outside this window is rejected as UcanError::NonceTooOld or UcanError::NonceFuture.",
+        "Nonce format": "{unix_millis_timestamp}-{16_random_bytes_hex}. Example: 1708646400000-a3f2b1c9d4e5f6071829. The timestamp prefix enables efficient pruning; the random suffix ensures uniqueness. Implementations MUST validate the nonce format on receipt \u2014 malformed nonces are rejected.",
+        "Nonce freshness check": "The timestamp prefix in the nonce MUST be within now - 5 minutes to now + 5 minutes (matching the clock skew tolerance from spec \u00a79.14). A nonce with a timestamp outside this window is rejected as UcanError::NonceTooOld or UcanError::NonceFuture.",
         "Replay window": "A nonce is retained in the tracker until max(token_expiry + 5 minutes, first_seen + 24 hours). The 5-minute buffer after token expiry accounts for clock skew. The 24-hour floor provides a safety net for tokens with very short expiry.",
         "Pruning": "prune() removes entries where now > max(token_expiry + 300, first_seen + 86400). Pruning runs every 1000 check_and_record calls or every 10 minutes, whichever comes first."
       }
@@ -1787,10 +1787,10 @@
         "crates/scp-core/context/tools/registry.rs",
         "crates/scp-core/context/tools/schema.rs"
       ],
-      "description": "Implement tool registration and schema validation in scp-core/context/tools/. Tools are stateless functions scoped to a context (spec section 5.4). They have MCP-compatible JSON Schema interfaces (spec section 8.5), making them interoperable with existing MCP tooling. Every tool registration includes schema, implementation hash, test vectors, and operator DID — providing verifiable integrity (spec section 7.3.3).",
+      "description": "Implement tool registration and schema validation in scp-core/context/tools/. Tools are stateless functions scoped to a context (spec section 5.4). They have MCP-compatible JSON Schema interfaces (spec section 8.5), making them interoperable with existing MCP tooling. Every tool registration includes schema, implementation hash, test vectors, and operator DID \u2014 providing verifiable integrity (spec section 7.3.3).",
       "acceptanceCriteria": [
-        "`ToolRegistration` struct with fields: tool_id (ToolId), name (String), description (String), schema (ToolSchema — MCP-compatible JSON Schema), implementation_hash ([u8; 32] — SHA-256 of implementation), test_vectors (Vec<TestVector> — known input-output pairs), operator_did (DID — accountable identity)",
-        "`ToolSchema` struct with fields: input_schema (serde_json::Value — JSON Schema for input), output_schema (serde_json::Value — JSON Schema for output)",
+        "`ToolRegistration` struct with fields: tool_id (ToolId), name (String), description (String), schema (ToolSchema \u2014 MCP-compatible JSON Schema), implementation_hash ([u8; 32] \u2014 SHA-256 of implementation), test_vectors (Vec<TestVector> \u2014 known input-output pairs), operator_did (DID \u2014 accountable identity)",
+        "`ToolSchema` struct with fields: input_schema (serde_json::Value \u2014 JSON Schema for input), output_schema (serde_json::Value \u2014 JSON Schema for output)",
         "`TestVector` struct with fields: input (serde_json::Value), expected_output (serde_json::Value), description (String)",
         "`register_tool(context: &ContextHandle, registration: ToolRegistration, registrant_did: &DID) -> Result<ToolId, ToolError>` validates registrant has ToolRegister capability via UCAN (ADR-009); validates input and output schemas are valid JSON Schema; validates implementation hash is 32 bytes; validates operator DID is resolvable; stores the tool registration in the context's tool registry; appends ToolRegistered event to event log with full registration metadata; returns the tool ID",
         "`update_tool(context: &ContextHandle, tool_id: &ToolId, new_registration: ToolRegistration, updater_did: &DID) -> Result<(), ToolError>` validates updater is the tool's operator DID or has admin role; records old and new implementation hashes; updates the tool registration; appends ToolUpdated event to event log (includes old hash, new hash, all changed fields); tool mutations are visible to all context members",
@@ -1800,7 +1800,7 @@
         "Unit test: register_tool rejects registrant without ToolRegister capability",
         "Unit test: update_tool logs old and new hashes",
         "Unit test: verify_tool returns correct pass/fail per test vector",
-        "Optional `ToolEconomicMetadata` in tool registration (§19.3): cost_per_invoke (Amount), cost_formula (Option<PricingFormula>), payee (DID, may differ from context payee). Tool-level costs are additive with context costs"
+        "Optional `ToolEconomicMetadata` in tool registration (\u00a719.3): cost_per_invoke (Amount), cost_formula (Option<PricingFormula>), payee (DID, may differ from context payee). Tool-level costs are additive with context costs"
       ],
       "actionItems": [
         "Create `crates/scp-core/context/tools/mod.rs` with ToolId type, module re-exports",
@@ -1844,14 +1844,14 @@
       "description": "Implement tool invocation with the full execution lifecycle: request/response protocol, timeout handling, cancellation, error propagation, and event log recording. Every tool invocation follows a defined lifecycle with explicit states, timeouts, and error handling. Tool execution errors are returned in ToolResponse.error, not as protocol-level errors. Schema validation failures are caught by the SDK, not the tool.",
       "acceptanceCriteria": [
         "`invoke_tool(context: &ContextHandle, tool_id: &ToolId, input: serde_json::Value, invoker_did: &DID) -> Result<serde_json::Value, ToolError>` validates context state is Active; validates invoker has ToolInvoke(tool_id) or ToolInvokeAll capability via UCAN; validates input against the tool's input schema; calls the tool implementation; validates output against the tool's output schema; appends ToolInvoked event to event log (includes tool_id, invoker_did, input hash, output hash); returns the tool output",
-        "`ToolRequest` struct with fields: request_id (String — UUID v4, unique per invocation), tool_id (ToolId), invoker_did (DID), input (serde_json::Value), timeout_ms (u32 — caller-specified timeout, max: context ceiling, default: 30_000), session_id (Option<String> — for stateful sessions §6.2.1), chain_depth (u8 — cross-context chain depth, 0 for direct calls), timestamp (u64)",
-        "`ToolResponse` struct with fields: request_id (String — matches the request), status (ToolStatus), output (Option<serde_json::Value>), error (Option<ToolExecutionError>), execution_time_ms (u64), provenance (Provenance)",
+        "`ToolRequest` struct with fields: request_id (String \u2014 UUID v4, unique per invocation), tool_id (ToolId), invoker_did (DID), input (serde_json::Value), timeout_ms (u32 \u2014 caller-specified timeout, max: context ceiling, default: 30_000), session_id (Option<String> \u2014 for stateful sessions \u00a76.2.1), chain_depth (u8 \u2014 cross-context chain depth, 0 for direct calls), timestamp (u64)",
+        "`ToolResponse` struct with fields: request_id (String \u2014 matches the request), status (ToolStatus), output (Option<serde_json::Value>), error (Option<ToolExecutionError>), execution_time_ms (u64), provenance (Provenance)",
         "`ToolStatus` enum: Success, Error, Timeout, Cancelled",
         "`ToolExecutionError` struct with fields: code (ToolErrorCode), message (String), retryable (bool)",
         "`ToolErrorCode` enum: InputValidationFailed, OutputValidationFailed, ExecutionFailed, Timeout, Cancelled, RateLimited, ToolNotFound, PermissionDenied, InternalError",
         "Timeout handling: every invocation has a timeout; callers specify timeout_ms in the request (default: 30,000ms, maximum: configurable per-context, hard protocol maximum: 300,000ms / 5 minutes); invoking SDK starts timer on request submission; if no ToolResponse arrives before timer fires, SDK synthesizes ToolResponse with status: Timeout; timeout is client-side contract, not server-side enforcement",
-        "Cancellation protocol: invoker MAY send ToolCancel { request_id, invoker_did, timestamp } referencing the request_id; on receiving ToolCancel the tool's execution environment SHOULD terminate the invocation and respond with status: Cancelled; cancellation is best-effort — if tool responds with Success before cancel is processed, success takes precedence",
-        "Error propagation: tool execution errors returned in ToolResponse.error, not as protocol-level errors; schema validation failures caught by SDK not tool — SDK rejects invalid input before invoking tool and rejects invalid output before delivering response; retryable field indicates whether caller should retry",
+        "Cancellation protocol: invoker MAY send ToolCancel { request_id, invoker_did, timestamp } referencing the request_id; on receiving ToolCancel the tool's execution environment SHOULD terminate the invocation and respond with status: Cancelled; cancellation is best-effort \u2014 if tool responds with Success before cancel is processed, success takes precedence",
+        "Error propagation: tool execution errors returned in ToolResponse.error, not as protocol-level errors; schema validation failures caught by SDK not tool \u2014 SDK rejects invalid input before invoking tool and rejects invalid output before delivering response; retryable field indicates whether caller should retry",
         "Event log recording: both ToolRequest and ToolResponse recorded as events in context's event log (ADR-011); event includes request_id, tool_id, invoker_did, status, execution_time_ms, SHA256(input), SHA256(output); full input/output NOT recorded (may be large), only content hashes stored",
         "Unit test: invoke_tool rejects when context not Active",
         "Unit test: invoke_tool rejects invoker without ToolInvoke capability",
@@ -1901,7 +1901,7 @@
       ],
       "description": "Implement cross-context tool interfaces (spec section 6.2) that allow structured interaction across context boundaries with bidirectional consent. The context governs the tool call, not the agent. An agent in Context A requests a tool call to Context B. Context A's governance decides whether to permit the outbound call. Context B's governance decides whether to permit the inbound call. The agent never directly touches the other context. Rate limiting is enforced per interface.",
       "acceptanceCriteria": [
-        "`ToolInterface` struct with fields: source_context (ContextId — context exposing the tool), target_context (ContextId — context consuming the tool), tool_id (ToolId — which tool is exposed), rate_limit (Option<RateLimit> — calls per time window), approved_by_source (bool — source context opted in), approved_by_target (bool — target context opted in)",
+        "`ToolInterface` struct with fields: source_context (ContextId \u2014 context exposing the tool), target_context (ContextId \u2014 context consuming the tool), tool_id (ToolId \u2014 which tool is exposed), rate_limit (Option<RateLimit> \u2014 calls per time window), approved_by_source (bool \u2014 source context opted in), approved_by_target (bool \u2014 target context opted in)",
         "`expose_tool(context: &ContextHandle, tool_id: &ToolId, to_context: &ContextId) -> Result<ToolInterface, ToolError>` initiates a tool interface proposal from the source context; requires admin capability",
         "`accept_tool_interface(context: &ContextHandle, interface: &ToolInterface) -> Result<(), ToolError>` target context accepts the interface; requires admin capability; both approved_by_source and approved_by_target must be true before calls are permitted",
         "`invoke_cross_context(source_context: &ContextHandle, interface: &ToolInterface, input: serde_json::Value, invoker_did: &DID) -> Result<serde_json::Value, ToolError>` invokes a tool across context boundaries; source context governance checks outbound; target context governance checks inbound; both event logs record the call with provenance",
@@ -1948,7 +1948,7 @@
       ],
       "description": "Implement stateful tool sessions (spec section 6.2.1) that enable multi-turn workflows via session IDs, TTLs, and per-call governance. Session state lives in the tool's context, not the caller's. Each call in a session is individually governed. Sessions have TTLs to prevent resource leaks. Background task removes sessions past their TTL.",
       "acceptanceCriteria": [
-        "`ToolSession` struct with fields: session_id (String), tool_id (ToolId), source_context (ContextId), state (serde_json::Value — opaque session state), created_at (u64), ttl (Duration), call_count (u64)",
+        "`ToolSession` struct with fields: session_id (String), tool_id (ToolId), source_context (ContextId), state (serde_json::Value \u2014 opaque session state), created_at (u64), ttl (Duration), call_count (u64)",
         "`create_session(context: &ContextHandle, tool_id: &ToolId, source_context: &ContextId, ttl: Duration) -> Result<String, ToolError>` creates a new session; returns session ID",
         "`invoke_session(context: &ContextHandle, session_id: &str, input: serde_json::Value) -> Result<serde_json::Value, ToolError>` invokes a tool within an active session; each call is individually governed; session state is updated by the tool",
         "Session cleanup: background task removes sessions past their TTL; session state is internal to the tool's context",
@@ -1992,11 +1992,11 @@
       ],
       "description": "Implement an append-only Merkle tree per context in scp-core/event_log/. The tree uses SHA-256 hashing following the Certificate Transparency (RFC 6962) structure: leaf nodes are SHA-256 hashes of events, and interior nodes are SHA-256 hashes of their children's concatenated hashes. This story implements the core data structures (EventLog, Event, EventType, EventPayload) and the append/root/event_count operations. The Merkle tree is the foundation for behavioral validation, behavioral records, the Relay Consistency Protocol, and equivocation detection.",
       "acceptanceCriteria": [
-        "`EventLog` struct with fields: leaves (Vec<[u8; 32]> — SHA-256 hashes of events), tree (Vec<Vec<[u8; 32]>> — interior node layers), context_id (ContextId)",
-        "`Event` struct with fields: event_type (EventType), actor_did (DID), timestamp (u64), sequence (u64 — monotonic event sequence within this log), payload (EventPayload — type-specific data), prev_hash ([u8; 32] — hash of the previous event for hash chain), signature (Ed25519Signature)",
+        "`EventLog` struct with fields: leaves (Vec<[u8; 32]> \u2014 SHA-256 hashes of events), tree (Vec<Vec<[u8; 32]>> \u2014 interior node layers), context_id (ContextId)",
+        "`Event` struct with fields: event_type (EventType), actor_did (DID), timestamp (u64), sequence (u64 \u2014 monotonic event sequence within this log), payload (EventPayload \u2014 type-specific data), prev_hash ([u8; 32] \u2014 hash of the previous event for hash chain), signature (Ed25519Signature)",
         "`EventType` enum with all 18 variants: ContextCreated, ContextClosing, ContextClosed, ContextExpired, MemberJoined, MemberLeft, RoleAssigned, TokenRevoked, MessageSent, ToolRegistered, ToolUpdated, ToolInvoked, ToolVerified, ToolInterfaceEstablished, GovernanceAction, ConsistencyCheckpoint, AbsenceProofRequested, MemberBlocked (ADR-007: signed block notification), KeyEpochAdvance (ADR-007: sender key epoch rotation, shared across Encrypted and Broadcast modes)",
         "`append(log: &mut EventLog, event: Event) -> Result<u64, EventLogError>` computes leaf_hash = SHA256(serialize(event)); verifies event.prev_hash matches the hash of the last leaf (hash chain integrity); verifies event signature against event.actor_did; appends leaf hash to the tree; recomputes affected interior nodes; returns the leaf index (position in the log)",
-        "`root(log: &EventLog) -> [u8; 32]` returns the current Merkle root hash of the log; O(1) — the root is always maintained as the log is appended to",
+        "`root(log: &EventLog) -> [u8; 32]` returns the current Merkle root hash of the log; O(1) \u2014 the root is always maintained as the log is appended to",
         "`event_count(log: &EventLog) -> u64` returns the number of events in the log",
         "Merkle tree follows Certificate Transparency (RFC 6962) structure: interior nodes are SHA-256 hashes of their children's concatenated hashes",
         "Sorted index of leaf hashes maintained alongside append-order tree (BTreeSet<([u8; 32], u64)>) for absence proof support",
@@ -2029,7 +2029,7 @@
         "EventLog struct": "```rust\npub struct EventLog {\n    leaves: Vec<[u8; 32]>,\n    tree: Vec<Vec<[u8; 32]>>,\n    context_id: ContextId,\n}\n```",
         "Event struct": "```rust\n#[derive(Debug, Clone, Serialize, Deserialize)]\npub struct Event {\n    pub event_type: EventType,\n    pub actor_did: DID,\n    pub timestamp: u64,\n    pub sequence: u64,\n    pub payload: EventPayload,\n    pub prev_hash: [u8; 32],\n    pub signature: Ed25519Signature,\n}\n```",
         "EventType enum": "```rust\n#[derive(Debug, Clone, Serialize, Deserialize)]\npub enum EventType {\n    ContextCreated,\n    ContextClosing,\n    ContextClosed,\n    ContextExpired,\n    MemberJoined,\n    MemberLeft,\n    RoleAssigned,\n    TokenRevoked,\n    MessageSent,\n    ToolRegistered,\n    ToolUpdated,\n    ToolInvoked,\n    ToolVerified,\n    ToolInterfaceEstablished,\n    GovernanceAction,\n    ConsistencyCheckpoint,\n    AbsenceProofRequested,\n    MemberBlocked,\n    KeyEpochAdvance,\n}\n```",
-        "Implementation notes": "Language: Rust. Hashing: SHA-256 via sha2 crate. Storage: In-memory for Phase 2 initial development, backed by ProtocolStore (§17.4) for persistence. Event log keys follow convention in §17.3: context/{context_id}/event/{seq:020d} for events, context/{context_id}/event_tree/{level}/{index} for Merkle tree nodes. Crate: scp-core. Module: scp-core/event_log/. Proof format: Binary serialization of inclusion proof paths (sibling hashes + left/right indicators)."
+        "Implementation notes": "Language: Rust. Hashing: SHA-256 via sha2 crate. Storage: In-memory for Phase 2 initial development, backed by ProtocolStore (\u00a717.4) for persistence. Event log keys follow convention in \u00a717.3: context/{context_id}/event/{seq:020d} for events, context/{context_id}/event_tree/{level}/{index} for Merkle tree nodes. Crate: scp-core. Module: scp-core/event_log/. Proof format: Binary serialization of inclusion proof paths (sibling hashes + left/right indicators)."
       }
     },
     {
@@ -2042,15 +2042,15 @@
       "files": [
         "crates/scp-core/event_log/proof.rs"
       ],
-      "description": "Implement inclusion proofs, absence proofs, and proof verification for the Merkle event log. Inclusion proofs return the Merkle path from leaf to root with O(log n) proof size. Absence proofs use a sorted leaf hash approach with a documented privacy trade-off, revealing exactly two leaf hashes. Verification is a pure function — any third party can verify without access to the log.",
+      "description": "Implement inclusion proofs, absence proofs, and proof verification for the Merkle event log. Inclusion proofs return the Merkle path from leaf to root with O(log n) proof size. Absence proofs use a sorted leaf hash approach with a documented privacy trade-off, revealing exactly two leaf hashes. Verification is a pure function \u2014 any third party can verify without access to the log.",
       "acceptanceCriteria": [
         "`prove_inclusion(log: &EventLog, leaf_index: u64) -> Result<InclusionProof, EventLogError>` returns the Merkle path from the leaf to the root; proof consists of sibling hashes at each tree level and left/right direction indicators; proof size is O(log n) hashes where n is the number of leaves",
         "`InclusionProof` struct with fields: leaf_index (u64), leaf_hash ([u8; 32]), path (Vec<ProofStep>), root ([u8; 32])",
-        "`ProofStep` struct with fields: sibling_hash ([u8; 32]), direction (Direction — is sibling Left or Right of our path)",
+        "`ProofStep` struct with fields: sibling_hash ([u8; 32]), direction (Direction \u2014 is sibling Left or Right of our path)",
         "`prove_absence(log: &EventLog, event_hash: &[u8; 32]) -> Result<AbsenceProof, EventLogError>` uses sorted leaf hash approach: maintains sorted index of leaf hashes alongside append-order tree (BTreeSet<([u8; 32], u64)>); finds two adjacent entries that bracket query_hash; generates inclusion proofs for both; privacy analysis: reveals exactly two leaf hashes (neighbors of query point), does NOT require disclosing full leaf hash set",
-        "`AbsenceProof` struct with fields: query_hash ([u8; 32] — the event hash being proven absent), lower (Option<LeafWithProof> — adjacent leaf hash below query_hash in sorted order, None if query_hash < all leaves), upper (Option<LeafWithProof> — adjacent leaf hash above query_hash, None if query_hash > all leaves), root ([u8; 32] — Merkle root at time of proof), leaf_count (u64 — total number of leaves in log)",
+        "`AbsenceProof` struct with fields: query_hash ([u8; 32] \u2014 the event hash being proven absent), lower (Option<LeafWithProof> \u2014 adjacent leaf hash below query_hash in sorted order, None if query_hash < all leaves), upper (Option<LeafWithProof> \u2014 adjacent leaf hash above query_hash, None if query_hash > all leaves), root ([u8; 32] \u2014 Merkle root at time of proof), leaf_count (u64 \u2014 total number of leaves in log)",
         "`LeafWithProof` struct with fields: leaf_hash ([u8; 32]), leaf_index (u64), inclusion_proof (InclusionProof)",
-        "`verify_inclusion(proof: &InclusionProof) -> bool` recomputes the root hash from the leaf hash and proof path; returns true if computed root matches the proof's stated root; pure function — no access to the log needed, any third party can verify",
+        "`verify_inclusion(proof: &InclusionProof) -> bool` recomputes the root hash from the leaf hash and proof path; returns true if computed root matches the proof's stated root; pure function \u2014 no access to the log needed, any third party can verify",
         "Residual privacy risk mitigation: absence proof requests are rate-limited (maximum 10 per member per hour per context) and logged as AbsenceProofRequested events; context governance can restrict which roles may request absence proofs (default: admin only)",
         "Unit test: inclusion proof for first, middle, and last leaf all verify",
         "Unit test: inclusion proof with tampered sibling hash fails verification",
@@ -2094,12 +2094,12 @@
       ],
       "description": "Implement consistency checkpoints (spec section 9.9.3) for detecting relay equivocation. Members periodically exchange signed Merkle roots. If two members have different roots for the same event count, the relay is equivocating (showing different histories to different members). Detection requires only two honest members. Checkpoints are generated every 50 events or every 10 minutes, whichever comes first, and sent as regular MLS application messages.",
       "acceptanceCriteria": [
-        "`ConsistencyCheckpoint` struct with fields: context_id (ContextId), sender_did (DID), event_count (u64), merkle_root ([u8; 32]), epoch (Option<u64> — current MLS epoch, None for Broadcast contexts), timestamp (u64), signature (Ed25519Signature)",
+        "`ConsistencyCheckpoint` struct with fields: context_id (ContextId), sender_did (DID), event_count (u64), merkle_root ([u8; 32]), epoch (Option<u64> \u2014 current MLS epoch, None for Broadcast contexts), timestamp (u64), signature (Ed25519Signature)",
         "`generate_checkpoint(log: &EventLog, sender_did: &DID, epoch: u64, signing_key: &KeyHandle) -> Result<ConsistencyCheckpoint, EventLogError>` creates and signs a checkpoint from the current log state",
         "`compare_checkpoint(local_log: &EventLog, remote_checkpoint: &ConsistencyCheckpoint) -> CheckpointComparison` compares a received checkpoint against local state; returns Consistent, Divergent { first_divergent_event: Option<u64> }, Behind { missing_events: u64 }, or Ahead { extra_events: u64 }",
         "Checkpoints generated every 50 events or every 10 minutes, whichever comes first (spec section 9.9.3)",
         "Checkpoints sent as regular MLS application messages",
-        "Divergent Merkle roots for the same event count indicate equivocation — trigger alert and divergence resolution",
+        "Divergent Merkle roots for the same event count indicate equivocation \u2014 trigger alert and divergence resolution",
         "Unit test: generate_checkpoint creates valid signed checkpoint",
         "Unit test: compare_checkpoint returns Consistent for matching roots",
         "Unit test: compare_checkpoint returns Divergent for mismatched roots at same event count",
@@ -2126,7 +2126,7 @@
       "details": {
         "ConsistencyCheckpoint struct": "```rust\npub struct ConsistencyCheckpoint {\n    pub context_id: ContextId,\n    pub sender_did: DID,\n    pub event_count: u64,\n    pub merkle_root: [u8; 32],\n    pub epoch: Option<u64>,\n    pub timestamp: u64,\n    pub signature: Ed25519Signature,\n}\n```",
         "CheckpointComparison enum": "Returns: Consistent, Divergent { first_divergent_event: Option<u64> }, Behind { missing_events: u64 }, or Ahead { extra_events: u64 }.",
-        "Scheduling": "Checkpoints are generated every 50 events or every 10 minutes, whichever comes first (spec section 9.9.3). Checkpoints are sent as regular MLS application messages. Divergent Merkle roots for the same event count indicate equivocation — trigger alert and divergence resolution."
+        "Scheduling": "Checkpoints are generated every 50 events or every 10 minutes, whichever comes first (spec section 9.9.3). Checkpoints are sent as regular MLS application messages. Divergent Merkle roots for the same event count indicate equivocation \u2014 trigger alert and divergence resolution."
       },
       "result": "ConsistencyCheckpoint struct, generate_checkpoint (async signing), compare_checkpoint, CheckpointScheduler (50 events/10min). 13 tests."
     },
@@ -2140,12 +2140,12 @@
       "files": [
         "crates/scp-transport/manager.rs"
       ],
-      "description": "Complete the TransportManager (stubbed in Phase 1 ADR-005) with multi-adapter routing, per-context relay set assignment, suppression-resistant multi-relay publishing (3+ relays per context), and deduplicated merged subscription streams. The TransportManager is the single entry point for all transport operations — the context layer never interacts with individual adapters directly.",
+      "description": "Complete the TransportManager (stubbed in Phase 1 ADR-005) with multi-adapter routing, per-context relay set assignment, suppression-resistant multi-relay publishing (3+ relays per context), and deduplicated merged subscription streams. The TransportManager is the single entry point for all transport operations \u2014 the context layer never interacts with individual adapters directly.",
       "acceptanceCriteria": [
-        "`TransportManager` struct with fields: adapters (Vec<Box<dyn TransportAdapter>>), relay_assignments (HashMap<ContextId, Vec<usize>> — context to adapter indices), reliability_scores (HashMap<String, ReliabilityScore>), dedup_cache (LruCache<BlobId, Instant> — seen blob IDs with insertion time), dedup_ttl (Duration — time-based expiry, default 1 hour, configurable)",
+        "`TransportManager` struct with fields: adapters (Vec<Box<dyn TransportAdapter>>), relay_assignments (HashMap<ContextId, Vec<usize>> \u2014 context to adapter indices), reliability_scores (HashMap<String, ReliabilityScore>), dedup_cache (LruCache<BlobId, Instant> \u2014 seen blob IDs with insertion time), dedup_ttl (Duration \u2014 time-based expiry, default 1 hour, configurable)",
         "`send(manager: &TransportManager, envelope: &OuterEnvelope, context_id: &ContextId) -> Result<Vec<BlobId>, TransportError>` looks up relay set for this context; sends envelope to ALL relays in context's relay set (minimum 3, spec section 9.9.2); fanout is concurrent (tokio::join or FuturesUnordered); returns BlobId per successful relay; if fewer than 2 relays succeed returns error (insufficient redundancy); records delivery success/failure per relay for reliability scoring",
-        "`subscribe(manager: &TransportManager, routing_id: &RoutingId, context_id: &ContextId, since: Option<u64>) -> Result<Pin<Box<dyn Stream<Item = TransportEvent> + Send>>, TransportError>` subscribes to routing_id on all relays in context's relay set; for broadcast contexts routing_id is public SHA-256(context_id) — any subscriber knowing context_id can derive routing_id and subscribe without prior membership negotiation; merges streams from all relays into single deduplicated stream; deduplication on TransportEvent::Envelope variants with same blob_id (SHA-256 of blob) delivered only once; dedup cache uses LRU eviction with 10,000-entry capacity and time-based expiry (1hr default, configurable); entries older than TTL are evicted even if capacity not reached; returns merged deduplicated stream",
-        "`assign_relay_set(manager: &mut TransportManager, context_id: &ContextId) -> Vec<usize>` assigns relay set for new context; minimizes overlap with existing context relay sets (Decision 10: relay set partitioning); algorithm is round-robin with spread — distribute contexts across adapters to minimize maximum overlap between any two contexts' relay sets; selects at least 3 relays per context; prefers relays with higher reliability scores",
+        "`subscribe(manager: &TransportManager, routing_id: &RoutingId, context_id: &ContextId, since: Option<u64>) -> Result<Pin<Box<dyn Stream<Item = TransportEvent> + Send>>, TransportError>` subscribes to routing_id on all relays in context's relay set; for broadcast contexts routing_id is public SHA-256(context_id) \u2014 any subscriber knowing context_id can derive routing_id and subscribe without prior membership negotiation; merges streams from all relays into single deduplicated stream; deduplication on TransportEvent::Envelope variants with same blob_id (SHA-256 of blob) delivered only once; dedup cache uses LRU eviction with 10,000-entry capacity and time-based expiry (1hr default, configurable); entries older than TTL are evicted even if capacity not reached; returns merged deduplicated stream",
+        "`assign_relay_set(manager: &mut TransportManager, context_id: &ContextId) -> Vec<usize>` assigns relay set for new context; minimizes overlap with existing context relay sets (Decision 10: relay set partitioning); algorithm is round-robin with spread \u2014 distribute contexts across adapters to minimize maximum overlap between any two contexts' relay sets; selects at least 3 relays per context; prefers relays with higher reliability scores",
         "Unit test: send fans out to all assigned relays concurrently",
         "Unit test: send returns error when fewer than 2 relays succeed",
         "Unit test: subscribe merges and deduplicates streams from multiple relays",
@@ -2174,7 +2174,7 @@
       "details": {
         "TransportManager struct": "```rust\npub struct TransportManager {\n    adapters: Vec<Box<dyn TransportAdapter>>,\n    relay_assignments: HashMap<ContextId, Vec<usize>>,\n    reliability_scores: HashMap<String, ReliabilityScore>,\n    dedup_cache: LruCache<BlobId, Instant>,  // Insertion time for TTL eviction\n    dedup_ttl: Duration,                      // Default: 1 hour, configurable\n}\n```",
         "Implementation notes": "Language: Rust. Async runtime: tokio (multi-relay fanout, stream merging, timer-based scoring). Stream merging: tokio-stream or futures for merging subscription streams from multiple adapters with deduplication. Crate: scp-transport. Module: scp-transport/manager.rs (completing the stub from ADR-005). Relay discovery: Relay lists are published in DID documents (spec section 9.10.2). The TransportManager reads relay lists from resolved DID documents for recipients.",
-        "Testing notes": "The scp-testing crate (§16) provides InMemoryTransport — a TransportAdapter implementation backed by InMemoryRelay instances — enabling deterministic testing of TransportManager routing logic without network I/O. The transport_conformance!() macro (§16.12.1) verifies that every TransportAdapter implementation satisfies the trait contract; the InMemoryTransport is the reference, and the native relay adapter must pass the same suite. Multi-relay fault scenarios (suppression, equivocation, delay, replay) are tested via BehaviorMode configurations on InMemoryRelay (§16.4.4)."
+        "Testing notes": "The scp-testing crate (\u00a716) provides InMemoryTransport \u2014 a TransportAdapter implementation backed by InMemoryRelay instances \u2014 enabling deterministic testing of TransportManager routing logic without network I/O. The transport_conformance!() macro (\u00a716.12.1) verifies that every TransportAdapter implementation satisfies the trait contract; the InMemoryTransport is the reference, and the native relay adapter must pass the same suite. Multi-relay fault scenarios (suppression, equivocation, delay, replay) are tested via BehaviorMode configurations on InMemoryRelay (\u00a716.4.4)."
       },
       "result": "TransportManager with multi-relay routing, LRU dedup, reliability scoring. 19+ tests."
     },
@@ -2244,11 +2244,11 @@
         "Step 5: Alice sends a message. UCAN is validated. Envelope is created, multi-relay published (ADR-012). Event is logged in the Merkle tree (ADR-011).",
         "Step 6: Bob receives the message via merged subscription stream (ADR-012). Bob's SDK deduplicates across relays.",
         "Step 7: Bob invokes the 'calculator' tool with input {\"operation\": \"add\", \"a\": 1, \"b\": 2} (ADR-010). UCAN validates Bob has tool_invoke capability. Tool returns {\"result\": 3}. Invocation is logged (ADR-011).",
-        "Step 8: Bob attempts to assign a role (he's a member, not admin). UCAN validation rejects — Bob lacks RoleAssign capability (ADR-009). Action is denied.",
+        "Step 8: Bob attempts to assign a role (he's a member, not admin). UCAN validation rejects \u2014 Bob lacks RoleAssign capability (ADR-009). Action is denied.",
         "Step 9: Both Alice and Bob generate consistency checkpoints (ADR-011). Merkle roots match.",
         "Step 10: TTL expires. Context transitions to Expired (ADR-008). MLS group and sender keys are destroyed. Relay deletion requests are sent for all context blobs.",
-        "Step 11: The event log's Merkle tree remains — the structure (hashes, proofs) survives even though the encrypted content is now unreadable.",
-        "Step 12: Throughout — relay reliability is tracked, and relay sets are partitioned across contexts."
+        "Step 11: The event log's Merkle tree remains \u2014 the structure (hashes, proofs) survives even though the encrypted content is now unreadable.",
+        "Step 12: Throughout \u2014 relay reliability is tracked, and relay sets are partitioned across contexts."
       ],
       "actionItems": [
         "Create `crates/scp-core/tests/phase2_integration.rs` with full end-to-end integration test",
@@ -2290,7 +2290,7 @@
         }
       ],
       "details": {
-        "Full test scenario": "1. Alice creates an identity (ADR-003) and a context with ceiling [messaging, tool_invoke], roles [admin, member], one tool \"calculator\", TTL 5 minutes, memory scope ephemeral (ADR-008)\n2. The context is assigned to 3 relays via TransportManager (ADR-012)\n3. Bob creates an identity, discovers the context, and joins (ADR-008)\n4. Bob is assigned the \"member\" role with UCAN tokens for messages:read, messages:write, tool_invoke_all (ADR-009)\n5. Alice sends a message. UCAN is validated. Envelope is created, multi-relay published (ADR-012). Event is logged in the Merkle tree (ADR-011).\n6. Bob receives the message via merged subscription stream (ADR-012). Bob's SDK deduplicates across relays.\n7. Bob invokes the \"calculator\" tool with input {\"operation\": \"add\", \"a\": 1, \"b\": 2} (ADR-010). UCAN validates Bob has tool_invoke capability. Tool returns {\"result\": 3}. Invocation is logged (ADR-011).\n8. Bob attempts to assign a role (he's a member, not admin). UCAN validation rejects — Bob lacks RoleAssign capability (ADR-009). Action is denied.\n9. Both Alice and Bob generate consistency checkpoints (ADR-011). Merkle roots match.\n10. TTL expires. Context transitions to Expired (ADR-008). MLS group and sender keys are destroyed. Relay deletion requests are sent for all context blobs.\n11. The event log's Merkle tree remains — the structure (hashes, proofs) survives even though the encrypted content is now unreadable.\n12. Throughout: relay reliability is tracked, and relay sets are partitioned across contexts.",
+        "Full test scenario": "1. Alice creates an identity (ADR-003) and a context with ceiling [messaging, tool_invoke], roles [admin, member], one tool \"calculator\", TTL 5 minutes, memory scope ephemeral (ADR-008)\n2. The context is assigned to 3 relays via TransportManager (ADR-012)\n3. Bob creates an identity, discovers the context, and joins (ADR-008)\n4. Bob is assigned the \"member\" role with UCAN tokens for messages:read, messages:write, tool_invoke_all (ADR-009)\n5. Alice sends a message. UCAN is validated. Envelope is created, multi-relay published (ADR-012). Event is logged in the Merkle tree (ADR-011).\n6. Bob receives the message via merged subscription stream (ADR-012). Bob's SDK deduplicates across relays.\n7. Bob invokes the \"calculator\" tool with input {\"operation\": \"add\", \"a\": 1, \"b\": 2} (ADR-010). UCAN validates Bob has tool_invoke capability. Tool returns {\"result\": 3}. Invocation is logged (ADR-011).\n8. Bob attempts to assign a role (he's a member, not admin). UCAN validation rejects \u2014 Bob lacks RoleAssign capability (ADR-009). Action is denied.\n9. Both Alice and Bob generate consistency checkpoints (ADR-011). Merkle roots match.\n10. TTL expires. Context transitions to Expired (ADR-008). MLS group and sender keys are destroyed. Relay deletion requests are sent for all context blobs.\n11. The event log's Merkle tree remains \u2014 the structure (hashes, proofs) survives even though the encrypted content is now unreadable.\n12. Throughout: relay reliability is tracked, and relay sets are partitioned across contexts.",
         "What this proves": "Context lifecycle works, roles enforce, tools invoke, event logs verify, multi-transport routes, TTL enforces, metadata privacy measures are active, and everything composes cleanly on top of Phase 1's crypto stack."
       },
       "result": "Phase 2 integration test created at crates/scp-core/tests/phase2_integration.rs. Exercises 12-step scenario: identity creation, context lifecycle, UCAN role enforcement, tool invocation, event logging, checkpoint consistency, TTL expiry, and multi-relay transport simulation. All tests pass."
@@ -2361,7 +2361,7 @@
           "pyo3 (0.22+)",
           "maturin (build tool)"
         ],
-        "FFI async risks (PyO3)": "Risk 1: tokio runtime must never block on Python GIL acquisition. If a tokio task calls Python::with_gil() while another task holds the GIL and is awaiting a tokio future, deadlock occurs. Rule: Use PyO3 native async which releases the GIL during await. Risk 4: Shutdown ordering — Python cleanup (GC, __del__, atexit) must complete before Rust runtime drop. Module finalization sequence: (1) cancel pending Rust tasks, (2) allow Python GC to run, (3) drop the Runtime."
+        "FFI async risks (PyO3)": "Risk 1: tokio runtime must never block on Python GIL acquisition. If a tokio task calls Python::with_gil() while another task holds the GIL and is awaiting a tokio future, deadlock occurs. Rule: Use PyO3 native async which releases the GIL during await. Risk 4: Shutdown ordering \u2014 Python cleanup (GC, __del__, atexit) must complete before Rust runtime drop. Module finalization sequence: (1) cancel pending Rust tasks, (2) allow Python GC to run, (3) drop the Runtime."
       }
     },
     {
@@ -2416,12 +2416,12 @@
       "files": [
         "crates/scp-ffi/pyo3/identity.rs"
       ],
-      "description": "Implement PyO3 bridge functions for identity operations. The bridge exposes `PyIdentity` and `PyDIDDocument` as opaque Python objects with attribute access — no raw structs, no Rust generics, no lifetime markers visible to Python. All async functions use PyO3's native async support (`#[pyfunction] async fn`).",
+      "description": "Implement PyO3 bridge functions for identity operations. The bridge exposes `PyIdentity` and `PyDIDDocument` as opaque Python objects with attribute access \u2014 no raw structs, no Rust generics, no lifetime markers visible to Python. All async functions use PyO3's native async support (`#[pyfunction] async fn`).",
       "acceptanceCriteria": [
-        "`py_identity_create(custody) -> PyIdentity` — creates a new DID identity. `custody` is a string: `\"platform\"`, `\"in_memory\"`.",
-        "`py_identity_load(did) -> PyIdentity` — loads an existing identity from storage.",
-        "`py_identity_resolve(did) -> PyDIDDocument` — resolves a DID to its document.",
-        "`py_identity_rotate_key(identity) -> PyIdentity` — rotates the identity's key.",
+        "`py_identity_create(custody) -> PyIdentity` \u2014 creates a new DID identity. `custody` is a string: `\"platform\"`, `\"in_memory\"`.",
+        "`py_identity_load(did) -> PyIdentity` \u2014 loads an existing identity from storage.",
+        "`py_identity_resolve(did) -> PyDIDDocument` \u2014 resolves a DID to its document.",
+        "`py_identity_rotate_key(identity) -> PyIdentity` \u2014 rotates the identity's key.",
         "PyIdentity and PyDIDDocument are opaque Python objects with getter methods for safe fields (DID string, custody type, state) and no access to internal key material."
       ],
       "actionItems": [
@@ -2459,12 +2459,12 @@
       ],
       "description": "Implement PyO3 bridge functions for context lifecycle and messaging operations. Context types (ContextHandle, ContextParams) are exposed as opaque PyO3 classes. `py_context_receive` returns a `PyAsyncIterator` of incoming messages.",
       "acceptanceCriteria": [
-        "`py_context_create(identity, params) -> PyContextHandle` — creates a context. `params` is a Python dict converted to `ContextParams`.",
-        "`py_context_join(handle, identity) -> None` — joins a context.",
-        "`py_context_leave(handle, identity) -> None` — leaves a context.",
-        "`py_context_close(handle, identity) -> None` — closes a context.",
-        "`py_context_send(handle, identity, payload) -> None` — sends a message.",
-        "`py_context_receive(handle) -> PyAsyncIterator` — returns an async iterator of incoming messages."
+        "`py_context_create(identity, params) -> PyContextHandle` \u2014 creates a context. `params` is a Python dict converted to `ContextParams`.",
+        "`py_context_join(handle, identity) -> None` \u2014 joins a context.",
+        "`py_context_leave(handle, identity) -> None` \u2014 leaves a context.",
+        "`py_context_close(handle, identity) -> None` \u2014 closes a context.",
+        "`py_context_send(handle, identity, payload) -> None` \u2014 sends a message.",
+        "`py_context_receive(handle) -> PyAsyncIterator` \u2014 returns an async iterator of incoming messages."
       ],
       "actionItems": [
         "Create `scp-ffi/pyo3/context.rs` with `PyContextHandle` and `PyContextParams` pyclass definitions.",
@@ -2504,16 +2504,16 @@
       ],
       "description": "Implement PyO3 bridge functions for tool registration/invocation, transport connection, UCAN token management, and event log queries. Each function maps directly to one scp-core function. Types exposed as opaque PyO3 classes with attribute access.",
       "acceptanceCriteria": [
-        "`py_tool_register(handle, registration) -> str` — registers a tool (returns tool ID).",
-        "`py_tool_invoke(handle, tool_id, input, identity) -> PyObject` — invokes a tool (returns JSON-compatible output).",
-        "`py_tool_verify(handle, tool_id) -> PyToolVerificationResult` — verifies a tool against test vectors.",
-        "`py_transport_connect(relay_url) -> None` — connects to an SCP relay.",
-        "`py_transport_status() -> PyTransportStatus` — returns transport connection status.",
-        "`py_ucan_validate(handle, token, capability) -> None` — validates a UCAN token (raises exception on failure).",
-        "`py_ucan_mint(handle, member_did, capabilities) -> PyUcanToken` — mints UCAN tokens.",
-        "`py_ucan_revoke(handle, token_id) -> None` — revokes a UCAN token.",
-        "`py_event_log_query(handle, filter) -> list[PyEvent]` — queries the context event log.",
-        "`py_event_log_verify(handle, claim) -> PyProof` — verifies a claim against the event log."
+        "`py_tool_register(handle, registration) -> str` \u2014 registers a tool (returns tool ID).",
+        "`py_tool_invoke(handle, tool_id, input, identity) -> PyObject` \u2014 invokes a tool (returns JSON-compatible output).",
+        "`py_tool_verify(handle, tool_id) -> PyToolVerificationResult` \u2014 verifies a tool against test vectors.",
+        "`py_transport_connect(relay_url) -> None` \u2014 connects to an SCP relay.",
+        "`py_transport_status() -> PyTransportStatus` \u2014 returns transport connection status.",
+        "`py_ucan_validate(handle, token, capability) -> None` \u2014 validates a UCAN token (raises exception on failure).",
+        "`py_ucan_mint(handle, member_did, capabilities) -> PyUcanToken` \u2014 mints UCAN tokens.",
+        "`py_ucan_revoke(handle, token_id) -> None` \u2014 revokes a UCAN token.",
+        "`py_event_log_query(handle, filter) -> list[PyEvent]` \u2014 queries the context event log.",
+        "`py_event_log_verify(handle, claim) -> PyProof` \u2014 verifies a claim against the event log."
       ],
       "actionItems": [
         "Create `scp-ffi/pyo3/tools.rs` with `PyToolRegistration`, `PyToolVerificationResult` pyclass definitions and bridge functions `py_tool_register`, `py_tool_invoke`, `py_tool_verify`.",
@@ -2583,7 +2583,7 @@
         "bindings/python/scp_sdk/identity.py",
         "bindings/python/scp_sdk/sync.py"
       ],
-      "description": "Implement the Python SDK `Identity` class as a pure Python wrapper over the `_scp_core` bridge. Async-first — all network operations are `async def` methods using asyncio. Synchronous convenience wrappers provided for simple scripts and REPL usage via a dedicated background event loop. Implement `run_sync()` helper that is safe in ALL contexts: plain scripts, Jupyter notebooks, inside async functions, inside other frameworks' event loops.",
+      "description": "Implement the Python SDK `Identity` class as a pure Python wrapper over the `_scp_core` bridge. Async-first \u2014 all network operations are `async def` methods using asyncio. Synchronous convenience wrappers provided for simple scripts and REPL usage via a dedicated background event loop. Implement `run_sync()` helper that is safe in ALL contexts: plain scripts, Jupyter notebooks, inside async functions, inside other frameworks' event loops.",
       "acceptanceCriteria": [
         "`Identity.create()` is the entry point. Custody parameter defaults to `\"platform\"`.",
         "All `Identity` instances expose `.did` (string), `.custody_type` (string).",
@@ -2628,9 +2628,9 @@
       "files": [
         "bindings/python/scp_sdk/context.py"
       ],
-      "description": "Implement the Python SDK `Context` class with async context manager support (`async with`). Resource lifecycle managed via async context managers. The class accepts Pythonic parameters — lists of strings for ceiling, dicts for roles. `receive()` returns an `AsyncIterator[Message]` for streaming incoming messages.",
+      "description": "Implement the Python SDK `Context` class with async context manager support (`async with`). Resource lifecycle managed via async context managers. The class accepts Pythonic parameters \u2014 lists of strings for ceiling, dicts for roles. `receive()` returns an `AsyncIterator[Message]` for streaming incoming messages.",
       "acceptanceCriteria": [
-        "`Context.create()` accepts Pythonic parameters — lists of strings for ceiling, dicts for roles.",
+        "`Context.create()` accepts Pythonic parameters \u2014 lists of strings for ceiling, dicts for roles.",
         "Async context manager ensures cleanup (leave context if still active on `__aexit__`).",
         "`send()` and `invoke()` optionally accept an identity parameter (defaults to the creator if a single identity is active).",
         "`receive()` returns an `AsyncIterator[Message]` for streaming incoming messages.",
@@ -2691,13 +2691,13 @@
         "ToolDefinition dataclass: `name: str`, `description: str`, `input_schema: dict`, `output_schema: dict`, `operator: Identity | str`, `test_vectors: list[TestVector] | None = None`, `implementation_hash: bytes | None = None`.",
         "Message dataclass: `sender_did: str`, `content: str | bytes`, `timestamp: float`, `sequence: int`, `context_id: str`, `provenance: Provenance | None = None`.",
         "Exception hierarchy rooted at `ScpError(Exception)`.",
-        "`IdentityError(ScpError)` — Identity creation, resolution, or key management failure.",
-        "`ContextError(ScpError)` — Context lifecycle errors (create, join, leave, close).",
-        "`PermissionError(ScpError)` — UCAN capability validation failure.",
-        "`CryptoError(ScpError)` — Encryption, decryption, or signature failure.",
-        "`TransportError(ScpError)` — Network or relay communication failure.",
-        "`ToolError(ScpError)` — Tool registration, invocation, or verification failure.",
-        "`ValidationError(ScpError)` — Input validation failure (schema, parameters).",
+        "`IdentityError(ScpError)` \u2014 Identity creation, resolution, or key management failure.",
+        "`ContextError(ScpError)` \u2014 Context lifecycle errors (create, join, leave, close).",
+        "`PermissionError(ScpError)` \u2014 UCAN capability validation failure.",
+        "`CryptoError(ScpError)` \u2014 Encryption, decryption, or signature failure.",
+        "`TransportError(ScpError)` \u2014 Network or relay communication failure.",
+        "`ToolError(ScpError)` \u2014 Tool registration, invocation, or verification failure.",
+        "`ValidationError(ScpError)` \u2014 Input validation failure (schema, parameters).",
         "Every exception includes a human-readable message and machine-readable error code.",
         "Exceptions wrap the corresponding bridge-level `ScpPyError` variants."
       ],
@@ -2788,7 +2788,7 @@
         "`py.typed` PEP 561 marker file exists.",
         "`pyproject.toml` declares package metadata, version, Python >=3.10 constraint, optional dependencies `[langchain]` and `[mcp]`.",
         "maturin builds the `_scp_core` extension into the `scp_sdk` package directory.",
-        "Users install with `pip install scp-sdk` — no Rust toolchain required.",
+        "Users install with `pip install scp-sdk` \u2014 no Rust toolchain required.",
         "Full PEP 484 type hints throughout all modules."
       ],
       "actionItems": [
@@ -3110,32 +3110,32 @@
       ],
       "description": "Implement `validate_ucan(context, token, required_capability) -> Result<(), UcanError>` with the full 11-step validation pipeline: parse, signature verification, chain verification, root issuer check, audience check, capability match, attenuation verification, ceiling check, nonce validation, revocation check, and expiry verification. Returns `Ok(())` if all 11 checks pass. Returns a specific `UcanError` variant indicating which check failed.",
       "acceptanceCriteria": [
-        "Step 1 — Parse: Decode the JWT-format UCAN token. Reject malformed tokens.",
-        "Step 2 — Signature verification: Verify the Ed25519 signature on the token. The signature covers `base64url(header).base64url(payload)`.",
-        "Step 3 — Chain verification: For each proof CID in `prf`, resolve the parent UCAN, verify its signature, and verify the parent's `aud` matches this token's `iss` (delegation chain integrity). Recurse until reaching a root token (empty `prf`).",
-        "Step 4 — Root issuer: Verify the root token's `iss` is the context creator's DID.",
-        "Step 5 — Audience: Verify the token's `aud` matches the presenting agent's DID.",
-        "Step 6 — Capability match: Verify the token's `att` includes the `required_capability`. Capability matching supports wildcards (`scp:ctx:*/messages:write` matches any context).",
-        "Step 7 — Attenuation: Verify each delegation in the chain narrows or preserves capabilities (never widens). A child token cannot grant capabilities its parent does not have.",
-        "Step 8 — Ceiling: Verify the `required_capability` is within the context's immutable capability ceiling.",
-        "Step 9 — Nonce: Validate nonce format (`{unix_millis}-{hex16}`). Validate nonce freshness (timestamp within +/- 5 minutes of now). Verify `nnc` has not been seen before in this context. Record the nonce with the token's `exp` in the context's nonce tracker.",
-        "Step 10 — Revocation: Verify the token's CID is not in the context's revocation list.",
-        "Step 11 — Expiry: Verify `exp > now` and `nbf <= now` (if present).",
+        "Step 1 \u2014 Parse: Decode the JWT-format UCAN token. Reject malformed tokens.",
+        "Step 2 \u2014 Signature verification: Verify the Ed25519 signature on the token. The signature covers `base64url(header).base64url(payload)`.",
+        "Step 3 \u2014 Chain verification: For each proof CID in `prf`, resolve the parent UCAN, verify its signature, and verify the parent's `aud` matches this token's `iss` (delegation chain integrity). Recurse until reaching a root token (empty `prf`).",
+        "Step 4 \u2014 Root issuer: Verify the root token's `iss` is the context creator's DID.",
+        "Step 5 \u2014 Audience: Verify the token's `aud` matches the presenting agent's DID.",
+        "Step 6 \u2014 Capability match: Verify the token's `att` includes the `required_capability`. Capability matching supports wildcards (`scp:ctx:*/messages:write` matches any context).",
+        "Step 7 \u2014 Attenuation: Verify each delegation in the chain narrows or preserves capabilities (never widens). A child token cannot grant capabilities its parent does not have.",
+        "Step 8 \u2014 Ceiling: Verify the `required_capability` is within the context's immutable capability ceiling.",
+        "Step 9 \u2014 Nonce: Validate nonce format (`{unix_millis}-{hex16}`). Validate nonce freshness (timestamp within +/- 5 minutes of now). Verify `nnc` has not been seen before in this context. Record the nonce with the token's `exp` in the context's nonce tracker.",
+        "Step 10 \u2014 Revocation: Verify the token's CID is not in the context's revocation list.",
+        "Step 11 \u2014 Expiry: Verify `exp > now` and `nbf <= now` (if present).",
         "Returns `Ok(())` if all 11 checks pass. Returns a specific `UcanError` variant indicating which check failed."
       ],
       "actionItems": [
         "Create `crates/scp-core/crypto/ucan/validate.rs` with `validate_ucan(context, token, required_capability) -> Result<(), UcanError>`.",
         "Implement Step 1: JWT parsing with base64url decoding of header and payload, JSON deserialization.",
         "Implement Step 2: Ed25519 signature verification using `ed25519-dalek`, verifying signature over `base64url(header).base64url(payload)`.",
-        "Implement Step 3: Recursive chain verification — resolve parent UCANs by CID, verify signatures, verify `aud`/`iss` chain integrity.",
-        "Implement Step 4: Root issuer verification — root token's `iss` must be context creator's DID.",
-        "Implement Step 5: Audience verification — token's `aud` must match presenting agent's DID.",
+        "Implement Step 3: Recursive chain verification \u2014 resolve parent UCANs by CID, verify signatures, verify `aud`/`iss` chain integrity.",
+        "Implement Step 4: Root issuer verification \u2014 root token's `iss` must be context creator's DID.",
+        "Implement Step 5: Audience verification \u2014 token's `aud` must match presenting agent's DID.",
         "Implement Step 6: Capability matching using the capability module (SCP-076), with wildcard support.",
-        "Implement Step 7: Attenuation chain verification — each child's capabilities must be subset of parent's.",
+        "Implement Step 7: Attenuation chain verification \u2014 each child's capabilities must be subset of parent's.",
         "Implement Step 8: Ceiling check using capability module's ceiling intersection.",
         "Implement Step 9: Nonce validation delegating to NonceTracker (SCP-078).",
         "Implement Step 10: Revocation check delegating to RevocationList (SCP-079).",
-        "Implement Step 11: Expiry check — `exp > now` and `nbf <= now` (if present).",
+        "Implement Step 11: Expiry check \u2014 `exp > now` and `nbf <= now` (if present).",
         "Define `UcanError` enum with specific variants for each validation failure."
       ],
       "blockedBy": [
@@ -3206,12 +3206,12 @@
       "files": [
         "crates/scp-core/crypto/ucan/revoke.rs"
       ],
-      "description": "Implement per-context RevocationList and `revoke_ucan()` function. Revocations are distributed as MLS application messages so all members maintain consistent revocation lists. `merge()` is union-only (revocations are append-only — a token cannot be un-revoked). Revocation verification: revoker must be the token's issuer or the context creator. Appends `TokenRevoked` event to context's event log.",
+      "description": "Implement per-context RevocationList and `revoke_ucan()` function. Revocations are distributed as MLS application messages so all members maintain consistent revocation lists. `merge()` is union-only (revocations are append-only \u2014 a token cannot be un-revoked). Revocation verification: revoker must be the token's issuer or the context creator. Appends `TokenRevoked` event to context's event log.",
       "acceptanceCriteria": [
         "RevocationList struct with `revoked: HashSet<String>` (set of revoked token CIDs) and `context_id: ContextId`.",
         "`is_revoked(token_cid) -> bool` checks if a token CID is in the revocation list.",
         "`revoke(token_cid)` adds a token CID to the revocation list.",
-        "`merge(remote)` merges remote revocation list (union-only, append-only — a token cannot be un-revoked).",
+        "`merge(remote)` merges remote revocation list (union-only, append-only \u2014 a token cannot be un-revoked).",
         "`revoke_ucan(context, token_cid, revoker) -> Result<(), UcanError>` verifies the revoker is the token's issuer or the context creator.",
         "`revoke_ucan` adds the token CID to the context's revocation list.",
         "`revoke_ucan` distributes the revocation as an MLS application message to all context members.",
@@ -3343,10 +3343,10 @@
         "Alice creates an identity in Python: `alice = await scp.Identity.create(custody=\"in_memory\")`. Calls through: Python wrapper (ADR-014) -> PyO3 bridge (ADR-013) -> scp-core Identity::create.",
         "Alice creates a context with tools: `ctx = await scp.Context.create(creator=alice, ceiling=[\"messaging\", \"tool_invoke\"], tools=[scp.ToolDefinition(name=\"calculator\", ...)])`. Context creation mints admin UCAN tokens for Alice (ADR-016). UCAN nonce is generated and tracked. Capability ceiling is set and immutable.",
         "Bob creates an identity and joins the context: `bob = await scp.Identity.create(custody=\"in_memory\")`, `membership = await ctx.join(bob)`. Bob receives member-role UCAN tokens (ADR-016). Tokens are scoped to messages:read, messages:write, tool_invoke_all. UCAN signature chain traces to Alice (context creator) as root authority.",
-        "Alice sends a message — UCAN validated: `await ctx.send(\"Hello from Python\", identity=alice)`. Internally: validate_ucan(ctx, alice_token, \"messages:write\") passes (ADR-016). Message flows through scp-core: sender key encrypt -> MLS encrypt -> envelope -> multi-relay publish. All via PyO3 bridge (ADR-013).",
+        "Alice sends a message \u2014 UCAN validated: `await ctx.send(\"Hello from Python\", identity=alice)`. Internally: validate_ucan(ctx, alice_token, \"messages:write\") passes (ADR-016). Message flows through scp-core: sender key encrypt -> MLS encrypt -> envelope -> multi-relay publish. All via PyO3 bridge (ADR-013).",
         "Bob receives the message via async iterator: `async for msg in ctx.receive(): print(msg.content)`. Async iterator bridges tokio stream -> Python asyncio via PyO3 native async (ADR-013).",
         "Bob invokes the calculator tool: `result = await ctx.invoke(\"calculator\", {\"operation\": \"add\", \"a\": 1, \"b\": 2})`, `assert result == {\"result\": 3}`. UCAN validates Bob has tool_invoke capability (ADR-016). Tool invocation is logged in the Merkle event log.",
-        "Bob attempts an admin action — UCAN rejects: `await ctx.close(identity=bob)` raises `scp.PermissionError`. Bob lacks context:close capability. UCAN validation failed (ADR-016).",
+        "Bob attempts an admin action \u2014 UCAN rejects: `await ctx.close(identity=bob)` raises `scp.PermissionError`. Bob lacks context:close capability. UCAN validation failed (ADR-016).",
         "Start an MCP server exposing Alice's SCP contexts (ADR-015): `server = await scp.mcp.serve_mcp(identity=alice, contexts=[ctx], transport=\"stdio\")`. tools/list returns namespaced tools. Admin tools visible because Alice is admin. Member tools only visible for member-role agent.",
         "MCP client invokes a tool: `tools/call(\"ctx_123/calculator\", {\"operation\": \"multiply\", \"a\": 3, \"b\": 7})` returns `{\"result\": 21}`. MCP adapter parses context namespace, validates UCAN, routes through scp-core tool invocation, returns result via JSON-RPC. The model never saw a DID, UCAN token, MLS group, or relay.",
         "Verify event log from Python: `events = await ctx.event_log.query(event_type=\"tool_invoked\")`, `proof = await ctx.event_log.verify({\"event_exists\": events[0].id})`, `assert proof.valid`. Merkle proof verification runs in Rust, result returned to Python (ADR-013).",
@@ -3367,7 +3367,7 @@
         "Test MCP tool invocation routing through SCP context.",
         "Test event log query and Merkle proof verification from Python.",
         "Test UCAN revocation and immediate enforcement on subsequent operations.",
-        "Verify no Rust concepts leak — all Python types, exceptions, and PEP 484 hints."
+        "Verify no Rust concepts leak \u2014 all Python types, exceptions, and PEP 484 hints."
       ],
       "blockedBy": [
         "SCP-036",
@@ -3513,14 +3513,14 @@
         "crates/scp-core/trust/mod.rs",
         "crates/scp-core/trust/behavioral.rs"
       ],
-      "description": "Implement `scp-core/trust/` module root with `TrustInput` struct and re-exports, plus `BehavioralRecord` and `compute_behavioral_record` in behavioral.rs. Behavioral records are computed locally from event logs (not stored centrally) — any agent computes from accessible logs. Two agents may compute different records from different event log views — this is correct behavior, not a bug. The trust engine provides validated inputs for agent-level evaluation — it does not produce trust 'scores.'",
+      "description": "Implement `scp-core/trust/` module root with `TrustInput` struct and re-exports, plus `BehavioralRecord` and `compute_behavioral_record` in behavioral.rs. Behavioral records are computed locally from event logs (not stored centrally) \u2014 any agent computes from accessible logs. Two agents may compute different records from different event log views \u2014 this is correct behavior, not a bug. The trust engine provides validated inputs for agent-level evaluation \u2014 it does not produce trust 'scores.'",
       "acceptanceCriteria": [
         "TrustInput struct defined with fields: verified_attestations (Vec<Attestation>), behavioral_record (BehavioralRecord), challenge_results (Vec<(ChallengeRequest, ChallengeResponse)>), consequence_structure (Vec<ConsequenceRule>), threshold_counts (HashMap<AttestationType, (u32, u32)>)",
         "BehavioralRecord struct defined with fields: subject_did (DID), context_id (ContextId), participation_count (u64), participation_duration_seconds (u64), tool_invocations (HashMap<ToolId, u64>), governance_actions_by (Vec<GovernanceActionSummary>), governance_actions_against (Vec<GovernanceActionSummary>), role_history (Vec<RoleTransition>), attestation_history (Vec<AttestationReference>), context_creation_count (u64), computed_at (u64), event_log_root ([u8; 32])",
         "compute_behavioral_record(event_log, subject_did) -> Result<BehavioralRecord, TrustError> scans event log entries for the subject DID",
         "compute_behavioral_record computes: participation count/duration, tool invocations by type/frequency, governance actions against/by identity, role progression, attestation history, context creation history",
         "compute_behavioral_record captures the Merkle root at computation time for verifiability",
-        "compute_behavioral_record is pure computation — no side effects, no storage",
+        "compute_behavioral_record is pure computation \u2014 no side effects, no storage",
         "Module root re-exports all public types from submodules"
       ],
       "actionItems": [
@@ -3565,7 +3565,7 @@
       "files": [
         "crates/scp-core/trust/attestation.rs"
       ],
-      "description": "Implement attestation types and verification logic. Common attestation envelope (§7.4.1) enables generic verification logic and interoperable attestation exchange. Attestation freshness evaluates renewal interval — stale attestations (past renewal interval but not expired) are degraded, not revoked. Threshold attestation checks N-of-M requirements with independence scoring.",
+      "description": "Implement attestation types and verification logic. Common attestation envelope (\u00a77.4.1) enables generic verification logic and interoperable attestation exchange. Attestation freshness evaluates renewal interval \u2014 stale attestations (past renewal interval but not expired) are degraded, not revoked. Threshold attestation checks N-of-M requirements with independence scoring.",
       "acceptanceCriteria": [
         "Attestation struct defined with fields: id (String), attestation_type (AttestationType), issuer (DID), subject (DID), claim (serde_json::Value), evidence (Option<AttestationEvidence>), issued_at (u64), expires_at (Option<u64>), renewal_interval (Option<Duration>), revocation_status (RevocationStatus), signature (Ed25519Signature)",
         "AttestationType enum with variants: IdentityLink, CapabilityDelegation, ToolIntegrity, AgentCapability, Endorsement, RoleAssignment, ContextEndorsement, BehavioralWitness",
@@ -3576,7 +3576,7 @@
         "verify_attestation checks revocation: queries revocation status",
         "verify_attestation returns specific error variant on failure",
         "check_attestation_freshness(attestation) -> FreshnessStatus returns Fresh, Stale { since }, or Expired",
-        "check_attestation_freshness evaluates renewal interval — stale attestations (past renewal interval but not expired) are degraded, not revoked",
+        "check_attestation_freshness evaluates renewal interval \u2014 stale attestations (past renewal interval but not expired) are degraded, not revoked",
         "check_threshold_attestation(attestation_type, attestors, requirement) -> ThresholdResult counts attestations of the given type from the attestor set",
         "check_threshold_attestation verifies independence: shared context memberships and mutual endorsements reduce independence score",
         "check_threshold_attestation returns whether the N-of-M threshold is met with sufficient independence"
@@ -3678,7 +3678,7 @@
       "files": [
         "crates/scp-core/trust/consequence.rs"
       ],
-      "description": "Implement consequence rules that are declared at context creation and protocol-enforced. Consequences are part of the opt-in contract — visible before joining, protocol-enforced, verifiable. No hidden penalties. Consequence rules check trigger conditions against event log data within the rule's time window.",
+      "description": "Implement consequence rules that are declared at context creation and protocol-enforced. Consequences are part of the opt-in contract \u2014 visible before joining, protocol-enforced, verifiable. No hidden penalties. Consequence rules check trigger conditions against event log data within the rule's time window.",
       "acceptanceCriteria": [
         "ConsequenceRule struct defined with fields: trigger (ConsequenceTrigger), action (ConsequenceAction), threshold (u64), window (Duration)",
         "ConsequenceTrigger enum with variants: MessageVelocity, ToolRateExceeded, WarningCount, Custom(String)",
@@ -3783,11 +3783,11 @@
       "files": [
         "crates/scp-core/context/ttl.rs"
       ],
-      "description": "Implement TTL tracking per-context via ProtocolStore. TTL is checked against Clock trait (§16.3) on every context action. TTL expiry triggers context close. Timer spawned at context creation via tokio, fires at expiry and calls handle_ttl_expiry(). Extension requires consent (all-member for bilateral, governance for multi-party) and is recorded as a context event in the Merkle log.",
+      "description": "Implement TTL tracking per-context via ProtocolStore. TTL is checked against Clock trait (\u00a716.3) on every context action. TTL expiry triggers context close. Timer spawned at context creation via tokio, fires at expiry and calls handle_ttl_expiry(). Extension requires consent (all-member for bilateral, governance for multi-party) and is recorded as a context event in the Merkle log.",
       "acceptanceCriteria": [
         "TtlPolicy enum defined with variants: None, Finite(Duration)",
-        "TTL checked against Clock trait (§16.3) on every context action",
-        "TTL expiry triggers context close — no new actions accepted after expiry",
+        "TTL checked against Clock trait (\u00a716.3) on every context action",
+        "TTL expiry triggers context close \u2014 no new actions accepted after expiry",
         "TTL timer spawned at context creation via tokio; timer fires at expiry and calls handle_ttl_expiry()",
         "Timer cancelled if context closes before TTL",
         "Bilateral contexts require all-member consent for TTL extension",
@@ -3797,7 +3797,7 @@
       ],
       "actionItems": [
         "Create crates/scp-core/context/ttl.rs with TtlPolicy enum",
-        "Implement TTL checking function using Clock trait (§16.3) for testable time",
+        "Implement TTL checking function using Clock trait (\u00a716.3) for testable time",
         "Implement handle_ttl_expiry() that triggers context close",
         "Implement tokio timer task spawning at context creation for Finite TTL",
         "Implement timer cancellation on early context close",
@@ -3845,12 +3845,12 @@
         "Ephemeral close: destroy MLS group state (tree secrets, all epoch key schedules, application key material) via MLS wrapper (ADR-001 destroy_group)",
         "Ephemeral close: destroy all sender keys for this context (ADR-007)",
         "Ephemeral close: issue RelayDeletionRequest for all encrypted event data",
-        "Key destruction verification: platform provides attestation per KeyDestructionLevel (§9.15)",
-        "Verification level is metadata recorded in the close event — not a gate",
+        "Key destruction verification: platform provides attestation per KeyDestructionLevel (\u00a79.15)",
+        "Verification level is metadata recorded in the close event \u2014 not a gate",
         "Relay deletion tracking: relay responses to deletion requests tracked",
         "Non-compliant relays deprioritized for future context creation (feeds into relay reliability scoring, ADR-012 ReliabilityScore.deletion_compliance_rate)",
         "Broadcast context restriction: MemoryScope::Full only for broadcast contexts",
-        "Reject Ephemeral or Summary for broadcast at creation time — return ContextError::InvalidMemoryScopeForBroadcast"
+        "Reject Ephemeral or Summary for broadcast at creation time \u2014 return ContextError::InvalidMemoryScopeForBroadcast"
       ],
       "actionItems": [
         "Create crates/scp-core/context/memory_scope.rs with MemoryScope, KeyDestructionLevel, RelayDeletionRequest types",
@@ -3897,7 +3897,7 @@
       "files": [
         "crates/scp-core/context/promotion.rs"
       ],
-      "description": "Implement promotion as a governed state transition from ephemeral to persistent requiring unanimous consent. Promotion changes the opt-in contract — unanimous consent (not just governance majority) is required because the original scope was part of the opt-in contract visible before joining. On promotion: TTL removed, memory scope transitions to Full, existing event log and key material preserved.",
+      "description": "Implement promotion as a governed state transition from ephemeral to persistent requiring unanimous consent. Promotion changes the opt-in contract \u2014 unanimous consent (not just governance majority) is required because the original scope was part of the opt-in contract visible before joining. On promotion: TTL removed, memory scope transitions to Full, existing event log and key material preserved.",
       "acceptanceCriteria": [
         "PromotionPolicy enum defined with variants: NoPromotion, Promotable",
         "Only promotable contexts can be promoted; no_promotion contexts reject promotion proposals",
@@ -3994,7 +3994,7 @@
       "files": [
         "crates/scp-core/provenance/mod.rs"
       ],
-      "description": "Implement `scp-core/provenance/` module root with all provenance types. Provenance is a core protocol principle (§1, tenet 1): 'All non-private data carries verifiable origin metadata.' DataProvenance struct is attached automatically on cross-context data flows. ProvenanceQuality is evaluable but policy decisions are agent-level. The absence of provenance is itself a signal.",
+      "description": "Implement `scp-core/provenance/` module root with all provenance types. Provenance is a core protocol principle (\u00a71, tenet 1): 'All non-private data carries verifiable origin metadata.' DataProvenance struct is attached automatically on cross-context data flows. ProvenanceQuality is evaluable but policy decisions are agent-level. The absence of provenance is itself a signal.",
       "acceptanceCriteria": [
         "DataProvenance struct defined with fields: source_context (ContextId), source_type (SourceType), counterparties (Vec<DID>), purpose (Option<String>), discovery_method (DiscoveryMethod), age (Duration), memory_scope (MemoryScope), chain_depth (u8), chain_path (Option<Vec<ContextId>>)",
         "SourceType enum defined with variants: Persistent (source context still open and verifiable), Ephemeral (source context closed, keys destroyed), Summary (source context closed, summary available)",
@@ -4008,7 +4008,7 @@
         "Implement PartialOrd/Ord ordering for ProvenanceQuality: NoProvenance < EphemeralKnownParties < SummaryVerified < PersistentVerifiable",
         "Define ProvenanceError enum with ChainDepthExceeded and other variants",
         "Add re-exports for attach.rs and evaluate.rs public types",
-        "Implement serde serialization via StoredValue<T> version envelope (§17.5) when persisted",
+        "Implement serde serialization via StoredValue<T> version envelope (\u00a717.5) when persisted",
         "Write unit tests for type construction and quality ordering"
       ],
       "blockedBy": [
@@ -4022,7 +4022,7 @@
       ],
       "details": {
         "module": "scp-core/provenance/",
-        "serialization": "MessagePack with StoredValue<T> version envelope (§17.5)",
+        "serialization": "MessagePack with StoredValue<T> version envelope (\u00a717.5)",
         "rustTypes": {
           "DataProvenance": "pub struct DataProvenance { pub source_context: ContextId, pub source_type: SourceType, pub counterparties: Vec<DID>, pub purpose: Option<String>, pub discovery_method: DiscoveryMethod, pub age: Duration, pub memory_scope: MemoryScope, pub chain_depth: u8, pub chain_path: Option<Vec<ContextId>> }",
           "SourceType": "pub enum SourceType { Persistent, Ephemeral, Summary }",
@@ -4042,7 +4042,7 @@
       "files": [
         "crates/scp-core/provenance/attach.rs"
       ],
-      "description": "Implement automatic provenance attachment on cross-context data flows and chain depth enforcement. Provenance is attached automatically by the protocol when data crosses context boundaries through protocol mechanisms (tool interfaces §6.2, structured messages). Chain depth is tracked and limited to prevent unbounded cross-context traversal (default max: 3 hops).",
+      "description": "Implement automatic provenance attachment on cross-context data flows and chain depth enforcement. Provenance is attached automatically by the protocol when data crosses context boundaries through protocol mechanisms (tool interfaces \u00a76.2, structured messages). Chain depth is tracked and limited to prevent unbounded cross-context traversal (default max: 3 hops).",
       "acceptanceCriteria": [
         "attach_provenance(source_context, target_context, data) -> DataProvenance called automatically on cross-context tool interface calls",
         "attach_provenance populates all fields from source context state",
@@ -4094,7 +4094,7 @@
       "files": [
         "crates/scp-core/provenance/evaluate.rs"
       ],
-      "description": "Implement provenance quality evaluation tiers (§7.7.2) and source type updates. Quality tiers over binary trust: PersistentVerifiable > SummaryVerified > EphemeralKnownParties > NoProvenance. Source type reflects current operational state, not creation-time setting. Data introduced without protocol-level origin tracking evaluates as NoProvenance — agents are informed of absence (lowest quality tier, not an error).",
+      "description": "Implement provenance quality evaluation tiers (\u00a77.7.2) and source type updates. Quality tiers over binary trust: PersistentVerifiable > SummaryVerified > EphemeralKnownParties > NoProvenance. Source type reflects current operational state, not creation-time setting. Data introduced without protocol-level origin tracking evaluates as NoProvenance \u2014 agents are informed of absence (lowest quality tier, not an error).",
       "acceptanceCriteria": [
         "evaluate_quality(provenance) -> ProvenanceQuality returns PersistentVerifiable when source context is Persistent and still Active",
         "evaluate_quality returns SummaryVerified when source context closed with Summary scope and summary verified",
@@ -4141,7 +4141,7 @@
         "crates/scp-core/discovery/mod.rs",
         "crates/scp-core/discovery/did_capabilities.rs"
       ],
-      "description": "Implement `scp-core/discovery/` module root with all discovery types and DID document capability resolution. DID documents contain a SCPCapabilities service entry that lists an agent's capabilities — resolvable by anyone who knows the DID. Any agent can publish capabilities in their DID document — zero setup, zero registration, zero dependency on discovery contexts.",
+      "description": "Implement `scp-core/discovery/` module root with all discovery types and DID document capability resolution. DID documents contain a SCPCapabilities service entry that lists an agent's capabilities \u2014 resolvable by anyone who knows the DID. Any agent can publish capabilities in their DID document \u2014 zero setup, zero registration, zero dependency on discovery contexts.",
       "acceptanceCriteria": [
         "CapabilityEntry struct defined with fields: did (DID), capabilities (Vec<String>), service_endpoints (Vec<String>), resolved_at (u64)",
         "DiscoveryQuery struct defined with fields: capability_filter (Option<Vec<String>>), keywords (Option<Vec<String>>), min_history (Option<Duration>)",
@@ -4382,7 +4382,7 @@
       ],
       "details": {
         "stubADR": true,
-        "note": "ADR not yet fully written — story derived from expected decisions and optimal approach",
+        "note": "ADR not yet fully written \u2014 story derived from expected decisions and optimal approach",
         "module": "scp-ffi/uniffi/",
         "references": [
           "scaffold/shared.md",
@@ -4441,7 +4441,7 @@
       ],
       "details": {
         "stubADR": true,
-        "note": "ADR not yet fully written — story derived from expected decisions and optimal approach",
+        "note": "ADR not yet fully written \u2014 story derived from expected decisions and optimal approach",
         "module": "scp-ffi/uniffi/",
         "asyncStrategy": "UniFFI polling futures",
         "FFI async risks (UniFFI)": "Risk 2: UniFFI callbacks execute on Rust threads. Swift/Kotlin code receiving callbacks must not assume main-thread execution. Swift: no UIKit/SwiftUI calls in callbacks without DispatchQueue.main.async. Kotlin: no Looper-dependent operations without withContext(Dispatchers.Main)."
@@ -4460,13 +4460,13 @@
         "crates/scp-ffi-wasm/src/lib.rs",
         "crates/scp-ffi-wasm/Cargo.toml"
       ],
-      "description": "Implement the WASM bridge using wasm-bindgen for browser target. WASM-specific constraints (no filesystem, no threads in main thread) may require API adjustments. Browser-specific: WebCrypto for key operations, wa-sqlite for storage (OPFSCoopSyncVFS from §17.6), IndexedDB fallback. Build WASM bridge first (narrower API surface due to WASM constraints).",
+      "description": "Implement the WASM bridge using wasm-bindgen for browser target. WASM-specific constraints (no filesystem, no threads in main thread) may require API adjustments. Browser-specific: WebCrypto for key operations, wa-sqlite for storage (OPFSCoopSyncVFS from \u00a717.6), IndexedDB fallback. Build WASM bridge first (narrower API surface due to WASM constraints).",
       "acceptanceCriteria": [
         "wasm-bindgen bridge exposes all scp-core public API types that are WASM-compatible",
         "Async operations bridged via wasm-bindgen-futures",
         "Error mapping: Rust Result maps to typed JavaScript exceptions",
         "WebCrypto integration for key operations in browser context",
-        "wa-sqlite + OPFSCoopSyncVFS (§17.6) for browser storage",
+        "wa-sqlite + OPFSCoopSyncVFS (\u00a717.6) for browser storage",
         "IndexedDB fallback when OPFS unavailable",
         "wasm-pack build produces valid npm package"
       ],
@@ -4477,7 +4477,7 @@
         "Implement async bridging via wasm-bindgen-futures",
         "Implement error mapping to JavaScript exceptions with ScpError hierarchy",
         "Implement WebCrypto adapter for key operations",
-        "Implement wa-sqlite + OPFSCoopSyncVFS storage adapter (§17.6)",
+        "Implement wa-sqlite + OPFSCoopSyncVFS storage adapter (\u00a717.6)",
         "Implement IndexedDB fallback storage adapter",
         "Configure wasm-pack build for npm package output",
         "Write browser integration tests"
@@ -4498,14 +4498,14 @@
       ],
       "details": {
         "stubADR": true,
-        "note": "ADR not yet fully written — story derived from expected decisions and optimal approach",
+        "note": "ADR not yet fully written \u2014 story derived from expected decisions and optimal approach",
         "module": "scp-ffi-wasm/",
         "references": [
           "scaffold/typescript.md",
           "standards/typescript.md",
           "scaffold/shared.md"
         ],
-        "browserStorage": "wa-sqlite + OPFSCoopSyncVFS (§17.6), IndexedDB fallback",
+        "browserStorage": "wa-sqlite + OPFSCoopSyncVFS (\u00a717.6), IndexedDB fallback",
         "browserCrypto": "WebCrypto"
       },
       "result": "WASM bridge crate created at crates/scp-ffi/wasm/ with wasm-bindgen. Full type/function surface mirroring UniFFI. No scp-core dep (tokio wasm32 incompatibility). All workspace tests pass.",
@@ -4561,7 +4561,7 @@
       ],
       "details": {
         "stubADR": true,
-        "note": "ADR not yet fully written — story derived from expected decisions and optimal approach",
+        "note": "ADR not yet fully written \u2014 story derived from expected decisions and optimal approach",
         "module": "scp-ffi-napi/",
         "references": [
           "scaffold/typescript.md",
@@ -4633,7 +4633,7 @@
       ],
       "details": {
         "stubADR": true,
-        "note": "ADR not yet fully written — story derived from expected decisions and optimal approach",
+        "note": "ADR not yet fully written \u2014 story derived from expected decisions and optimal approach",
         "module": "bindings/typescript/",
         "references": [
           "scaffold/typescript.md",
@@ -4764,7 +4764,7 @@
       "files": [
         "crates/scp-core/src/bridge/mod.rs"
       ],
-      "description": "Create the `scp-core/bridge/` module root with all bridge protocol types from ADR-023. Bridge connector as registered protocol entity with accountable operator DID. Shadow identities as restricted participants (observer default). Four operating modes (Relay, Puppet, Api, Cooperative). All bridged content carries full provenance chain.\n\nKey types:\n\n```rust\npub struct BridgeConnector {\n    pub bridge_id: String,\n    pub operator_did: DID,\n    pub platform: String,\n    pub mode: BridgeMode,\n    pub status: BridgeStatus,\n    pub registration_context: ContextId,\n    pub registered_at: u64,\n}\n\npub enum BridgeMode {\n    Relay,        // Read-only mirroring from external platform\n    Puppet,       // Bridge acts on behalf of external users\n    Api,          // Platform API integration\n    Cooperative,  // Native SCP support on external platform\n}\n\npub enum BridgeStatus {\n    Active,\n    Suspended,\n    Revoked,\n}\n\npub struct ShadowIdentity {\n    pub shadow_id: String,\n    pub platform_handle: String,\n    pub bridge_id: String,\n    pub attributed_role: String,     // Default: \"observer\"\n    pub provenance_status: ShadowProvenanceStatus,\n    pub created_at: u64,\n}\n\npub enum ShadowProvenanceStatus {\n    Shadow,   // Unclaimed — attributed via bridge\n    Claimed,  // Bound to a DID via identity attestation\n}\n```\n\nModule declares `pub mod registration; pub mod shadow; pub mod claiming; pub mod provenance;` and re-exports all public types.",
+      "description": "Create the `scp-core/bridge/` module root with all bridge protocol types from ADR-023. Bridge connector as registered protocol entity with accountable operator DID. Shadow identities as restricted participants (observer default). Four operating modes (Relay, Puppet, Api, Cooperative). All bridged content carries full provenance chain.\n\nKey types:\n\n```rust\npub struct BridgeConnector {\n    pub bridge_id: String,\n    pub operator_did: DID,\n    pub platform: String,\n    pub mode: BridgeMode,\n    pub status: BridgeStatus,\n    pub registration_context: ContextId,\n    pub registered_at: u64,\n}\n\npub enum BridgeMode {\n    Relay,        // Read-only mirroring from external platform\n    Puppet,       // Bridge acts on behalf of external users\n    Api,          // Platform API integration\n    Cooperative,  // Native SCP support on external platform\n}\n\npub enum BridgeStatus {\n    Active,\n    Suspended,\n    Revoked,\n}\n\npub struct ShadowIdentity {\n    pub shadow_id: String,\n    pub platform_handle: String,\n    pub bridge_id: String,\n    pub attributed_role: String,     // Default: \"observer\"\n    pub provenance_status: ShadowProvenanceStatus,\n    pub created_at: u64,\n}\n\npub enum ShadowProvenanceStatus {\n    Shadow,   // Unclaimed \u2014 attributed via bridge\n    Claimed,  // Bound to a DID via identity attestation\n}\n```\n\nModule declares `pub mod registration; pub mod shadow; pub mod claiming; pub mod provenance;` and re-exports all public types.",
       "acceptanceCriteria": [
         "`cargo build -p scp-core` succeeds with zero warnings",
         "BridgeConnector struct has fields: bridge_id (String), operator_did (DID), platform (String), mode (BridgeMode), status (BridgeStatus), registration_context (ContextId), registered_at (u64)",
@@ -4792,7 +4792,7 @@
       ],
       "details": {
         "adr": "ADR-023",
-        "protocolSection": "§12",
+        "protocolSection": "\u00a712",
         "keyTypes": {
           "BridgeConnector": "bridge_id, operator_did, platform, mode, status, registration_context, registered_at",
           "BridgeMode": "Relay | Puppet | Api | Cooperative",
@@ -4834,7 +4834,7 @@
         "Implement revoke_bridge(bridge_id, governance_action) -> Result<(), BridgeError>",
         "Implement list_bridges(context_id) -> Vec<BridgeConnector> for context metadata visibility",
         "Emit context events for registration and revocation into event log",
-        "Enforce context isolation — bridge instance scoped to single context",
+        "Enforce context isolation \u2014 bridge instance scoped to single context",
         "Write unit tests for registration, approval, rejection, revocation, context isolation"
       ],
       "blockedBy": [
@@ -4925,7 +4925,7 @@
       "files": [
         "crates/scp-core/src/bridge/provenance.rs"
       ],
-      "description": "Implement BridgeProvenance and provenance marking for all bridged content in `scp-core/bridge/provenance.rs`.\n\nAll actions/content attributed to shadow identities carry `BridgeProvenance`. `BridgeProvenance` includes: originating platform, bridge connector ID, operator DID, operating mode, shadow/claimed status. No shadow action mistakable for native SCP action.\n\nTrust hierarchy (two axes per §12.5):\n- Native identity + native transport (strongest).\n- Native identity + bridged transport.\n- Claimed shadow + historical bridged.\n- Shadow + bridged (weakest).\n- Both identity confidence and transport confidence factor into evaluation.\n\nKey type:\n\n```rust\n/// Extension of DataProvenance for bridged content.\npub struct BridgeProvenance {\n    pub base: DataProvenance,\n    pub originating_platform: String,\n    pub bridge_connector_id: String,\n    pub operator_did: DID,\n    pub bridge_mode: BridgeMode,\n    pub shadow_status: ShadowProvenanceStatus,\n}\n```",
+      "description": "Implement BridgeProvenance and provenance marking for all bridged content in `scp-core/bridge/provenance.rs`.\n\nAll actions/content attributed to shadow identities carry `BridgeProvenance`. `BridgeProvenance` includes: originating platform, bridge connector ID, operator DID, operating mode, shadow/claimed status. No shadow action mistakable for native SCP action.\n\nTrust hierarchy (two axes per \u00a712.5):\n- Native identity + native transport (strongest).\n- Native identity + bridged transport.\n- Claimed shadow + historical bridged.\n- Shadow + bridged (weakest).\n- Both identity confidence and transport confidence factor into evaluation.\n\nKey type:\n\n```rust\n/// Extension of DataProvenance for bridged content.\npub struct BridgeProvenance {\n    pub base: DataProvenance,\n    pub originating_platform: String,\n    pub bridge_connector_id: String,\n    pub operator_did: DID,\n    pub bridge_mode: BridgeMode,\n    pub shadow_status: ShadowProvenanceStatus,\n}\n```",
       "acceptanceCriteria": [
         "BridgeProvenance struct extends DataProvenance with fields: originating_platform, bridge_connector_id, operator_did, bridge_mode, shadow_status",
         "All actions/content attributed to shadow identities carry BridgeProvenance",
@@ -4979,12 +4979,12 @@
       "files": [
         "crates/scp-core/src/bridge/claiming.rs"
       ],
-      "description": "Implement shadow claiming via identity attestation in `scp-core/bridge/claiming.rs`. Shadow claiming via identity attestation (§3.5) is one-way and irreversible.\n\nClaimant publishes identity attestation (§3.5) binding external handle to DID. Protocol verifies attestation matches shadow's platform handle. Shadow retired, historical actions retroattributed to claimant DID.\n\nClaiming is one-way and irreversible: claimed shadow cannot be unclaimed. Claimed shadow cannot be re-assigned to a different DID.\n\nClaiming is a context event in the Merkle log.\n\nKey types:\n\n```rust\npub struct ClaimRequest {\n    pub shadow_id: String,\n    pub claimant_did: DID,\n    pub platform_handle: String,\n    pub identity_attestation: Attestation,  // §3.5 attestation binding handle to DID\n    pub timestamp: u64,\n    pub signature: Ed25519Signature,\n}\n\npub enum ClaimResult {\n    Success { shadow_id: String, claimant_did: DID },\n    Failed { reason: ClaimError },\n}\n\npub enum ClaimError {\n    HandleMismatch,\n    AttestationInvalid,\n    AlreadyClaimed,\n    ShadowNotFound,\n}\n```",
+      "description": "Implement shadow claiming via identity attestation in `scp-core/bridge/claiming.rs`. Shadow claiming via identity attestation (\u00a73.5) is one-way and irreversible.\n\nClaimant publishes identity attestation (\u00a73.5) binding external handle to DID. Protocol verifies attestation matches shadow's platform handle. Shadow retired, historical actions retroattributed to claimant DID.\n\nClaiming is one-way and irreversible: claimed shadow cannot be unclaimed. Claimed shadow cannot be re-assigned to a different DID.\n\nClaiming is a context event in the Merkle log.\n\nKey types:\n\n```rust\npub struct ClaimRequest {\n    pub shadow_id: String,\n    pub claimant_did: DID,\n    pub platform_handle: String,\n    pub identity_attestation: Attestation,  // \u00a73.5 attestation binding handle to DID\n    pub timestamp: u64,\n    pub signature: Ed25519Signature,\n}\n\n// claim_shadow returns Result<ShadowClaimEvent, ClaimError>\n\npub enum ClaimError {\n    HandleMismatch,\n    AttestationInvalid,\n    AlreadyClaimed,\n    ShadowNotFound,\n}\n```",
       "acceptanceCriteria": [
-        "ClaimRequest struct has fields: shadow_id, claimant_did, platform_handle, identity_attestation (Attestation per §3.5), timestamp, signature (Ed25519Signature)",
-        "ClaimResult enum has variants: Success { shadow_id, claimant_did }, Failed { reason: ClaimError }",
+        "ClaimRequest struct has fields: shadow_id, claimant_did, platform_handle, identity_attestation (Attestation per \u00a73.5), timestamp, signature (Ed25519Signature)",
+        "claim_shadow returns Result<ShadowClaimEvent, ClaimError>",
         "ClaimError enum has variants: HandleMismatch, AttestationInvalid, AlreadyClaimed, ShadowNotFound",
-        "Claimant publishes identity attestation (§3.5) binding external handle to DID",
+        "Claimant publishes identity attestation (\u00a73.5) binding external handle to DID",
         "Protocol verifies attestation matches shadow's platform handle",
         "Shadow retired, historical actions retroattributed to claimant DID",
         "Claimed shadow cannot be unclaimed (one-way)",
@@ -4993,8 +4993,8 @@
         "`cargo test -p scp-core` passes all shadow claiming tests"
       ],
       "actionItems": [
-        "Implement ClaimRequest, ClaimResult, ClaimError types",
-        "Implement claim_shadow(request: ClaimRequest) -> ClaimResult",
+        "Implement ClaimRequest, ClaimError types",
+        "Implement claim_shadow(registry, request: ClaimRequest) -> Result<ShadowClaimEvent, ClaimError>",
         "Verify attestation matches shadow's platform handle",
         "Implement retroattribute_actions(shadow_id, claimant_did) to retroattribute historical actions",
         "Enforce one-way irreversibility: reject unclaim and re-assignment attempts",
@@ -5020,11 +5020,11 @@
           "8. Claiming is one-way and irreversible"
         ],
         "dependencies": {
-          "ADR-003": "Shadow claiming uses identity attestation (§3.5) to bind external handle to DID.",
+          "ADR-003": "Shadow claiming uses identity attestation (\u00a73.5) to bind external handle to DID.",
           "ADR-011": "Claiming is a context event."
         }
       },
-      "result": "Created crates/scp-core/src/bridge/claiming.rs with ClaimRequest, ClaimResult, ClaimError types and claim_shadow() function. One-way irreversible claiming with attestation verification."
+      "result": "Created crates/scp-core/src/bridge/claiming.rs with ClaimRequest, ClaimError types and claim_shadow() function. One-way irreversible claiming with attestation verification."
     },
     {
       "id": "SCP-089",
@@ -5041,7 +5041,7 @@
       "acceptanceCriteria": [
         "`cargo build -p scp-media` succeeds with zero warnings",
         "MediaSession struct has fields: session_id (String), context_id (ContextId), participants (Vec<DID>), capabilities (Vec<MediaCapability>), state (MediaSessionState), started_at (u64)",
-        "MediaCapability enum has variants: Voice, Video, ScreenShare — mapping to ceiling entries media.voice, media.video, media.screenShare",
+        "MediaCapability enum has variants: Voice, Video, ScreenShare \u2014 mapping to ceiling entries media.voice, media.video, media.screenShare",
         "MediaSessionState enum has variants: Initiating, Active, Ended",
         "SignalingMessage enum has variants: Offer(SessionDescription), Answer(SessionDescription), IceCandidate(Candidate), SessionEnd",
         "SessionDescription struct has fields: sdp (String), sender_did (DID)",
@@ -5068,7 +5068,7 @@
       ],
       "details": {
         "adr": "ADR-024",
-        "protocolSection": "§10.9.1",
+        "protocolSection": "\u00a710.9.1",
         "keyTypes": {
           "MediaSession": "session_id, context_id, participants, capabilities, state, started_at",
           "MediaCapability": "Voice | Video | ScreenShare",
@@ -5091,10 +5091,10 @@
       "files": [
         "crates/scp-media/src/keys.rs"
       ],
-      "description": "Implement MLS key export for media session keys in `scp-media/keys.rs`. Derive media session keys via MLS exporter (RFC 9420 §8, spec §10.9.1). Keys are bound to context group state — only current epoch members can derive.\n\nEpoch-based key invalidation: only current MLS group members can derive media keys. Member removal triggers MLS epoch advance which invalidates prior media keys. Receivers must re-derive keys after each epoch advance.\n\nFunction signature: `export_media_keys(mls_group, label, context, length) -> MediaKeyMaterial`.",
+      "description": "Implement MLS key export for media session keys in `scp-media/keys.rs`. Derive media session keys via MLS exporter (RFC 9420 \u00a78, spec \u00a710.9.1). Keys are bound to context group state \u2014 only current epoch members can derive.\n\nEpoch-based key invalidation: only current MLS group members can derive media keys. Member removal triggers MLS epoch advance which invalidates prior media keys. Receivers must re-derive keys after each epoch advance.\n\nFunction signature: `export_media_keys(mls_group, label, context, length) -> MediaKeyMaterial`.",
       "acceptanceCriteria": [
-        "Derive media session keys via MLS exporter (RFC 9420 §8, spec §10.9.1)",
-        "Keys are bound to context group state — only current epoch members can derive",
+        "Derive media session keys via MLS exporter (RFC 9420 \u00a78, spec \u00a710.9.1)",
+        "Keys are bound to context group state \u2014 only current epoch members can derive",
         "`export_media_keys(mls_group, label, context, length) -> MediaKeyMaterial` function exists and works",
         "Only current MLS group members can derive media keys",
         "Member removal triggers MLS epoch advance which invalidates prior media keys",
@@ -5104,8 +5104,8 @@
       ],
       "actionItems": [
         "Implement export_media_keys(mls_group, label, context, length) -> Result<MediaKeyMaterial, MediaError>",
-        "Use MLS exporter API (RFC 9420 §8) to derive DTLS-SRTP keys from group state",
-        "Bind exported keys to current epoch — store epoch number in MediaKeyMaterial",
+        "Use MLS exporter API (RFC 9420 \u00a78) to derive DTLS-SRTP keys from group state",
+        "Bind exported keys to current epoch \u2014 store epoch number in MediaKeyMaterial",
         "Implement key re-derivation on epoch advance",
         "Implement validation that only current group members can call export",
         "Write unit tests for key export, epoch binding, member removal invalidation, re-derivation after epoch advance"
@@ -5127,9 +5127,9 @@
           "3. Epoch-based key invalidation"
         ],
         "dependencies": {
-          "ADR-001": "MLS key export (RFC 9420 §8) derives media session keys."
+          "ADR-001": "MLS key export (RFC 9420 \u00a78) derives media session keys."
         },
-        "rfcRef": "RFC 9420 §8"
+        "rfcRef": "RFC 9420 \u00a78"
       }
     },
     {
@@ -5150,7 +5150,7 @@
         "Member removal from context invalidates their media session keys via MLS epoch advance",
         "Explicit `SessionEnd` message for graceful teardown",
         "`end_media_session(session_id) -> Result<(), MediaError>` exists and works",
-        "Media frames flow peer-to-peer or through WebRTC SFU — no media through SCP relays",
+        "Media frames flow peer-to-peer or through WebRTC SFU \u2014 no media through SCP relays",
         "SCP relays handle only signaling messages (small, infrequent)",
         "Participants, start time, end time, capabilities used recorded in context event log",
         "Session metadata used for behavioral record derivation (ADR-017)",
@@ -5202,14 +5202,14 @@
       "files": [
         "crates/scp-media/src/signaling.rs"
       ],
-      "description": "Implement signaling message construction and routing in `scp-media/signaling.rs`. SDP offers/answers and ICE candidates flow as standard SCP messages. Encrypted, authenticated, governed by context, recorded in event log. Signaling messages use a dedicated `MessageType::Signaling` variant.\n\nNo media data touches SCP relays — only signaling messages (small, infrequent) flow through the protocol transport.",
+      "description": "Implement signaling message construction and routing in `scp-media/signaling.rs`. SDP offers/answers and ICE candidates flow as standard SCP messages. Encrypted, authenticated, governed by context, recorded in event log. Signaling messages use a dedicated `MessageType::Signaling` variant.\n\nNo media data touches SCP relays \u2014 only signaling messages (small, infrequent) flow through the protocol transport.",
       "acceptanceCriteria": [
         "SDP offers/answers and ICE candidates flow as standard SCP messages",
         "Signaling messages are encrypted, authenticated, governed by context, recorded in event log",
         "Signaling messages use a dedicated `MessageType::Signaling` variant",
         "SessionDescription contains sdp (String) and sender_did (DID)",
         "Candidate contains candidate (String), sdp_mid (Option<String>), sdp_mline_index (Option<u16>), sender_did (DID)",
-        "Only signaling messages flow through SCP relays — no media data",
+        "Only signaling messages flow through SCP relays \u2014 no media data",
         "`cargo test -p scp-media` passes all signaling tests"
       ],
       "actionItems": [
@@ -5253,15 +5253,15 @@
       "files": [
         "bindings/swift/Sources/SCP/Platform/AppleKeyCustody.swift"
       ],
-      "description": "Implement Apple Secure Enclave key custody adapter in `scp-platform/apple/secure_enclave.rs`. Implements the `KeyCustody` trait for Apple platforms.\n\nSecure Enclave usage pattern: P-256 signing for attestation uses Secure Enclave. Ed25519 identity keys and X25519 key agreement use software-backed Keychain (Secure Enclave only supports P-256).\n\nPer §17.8 platform-specific key custody table: Secure Enclave for P-256, Keychain for Ed25519. Per §9.12 compromise recovery protocol (6 steps including Secure Enclave verification). Per §9.15 key destruction verification — hardware-attested is the strongest trust level.\n\nThis is a stub ADR (ADR-025) — implementation details will be refined when the full ADR is written after Phase 2 stabilization.",
+      "description": "Implement Apple Secure Enclave key custody adapter in `scp-platform/apple/secure_enclave.rs`. Implements the `KeyCustody` trait for Apple platforms.\n\nSecure Enclave usage pattern: P-256 signing for attestation uses Secure Enclave. Ed25519 identity keys and X25519 key agreement use software-backed Keychain (Secure Enclave only supports P-256).\n\nPer \u00a717.8 platform-specific key custody table: Secure Enclave for P-256, Keychain for Ed25519. Per \u00a79.12 compromise recovery protocol (6 steps including Secure Enclave verification). Per \u00a79.15 key destruction verification \u2014 hardware-attested is the strongest trust level.\n\nThis is a stub ADR (ADR-025) \u2014 implementation details will be refined when the full ADR is written after Phase 2 stabilization.",
       "acceptanceCriteria": [
         "Implements KeyCustody trait for Apple platforms",
         "P-256 signing operations use Secure Enclave hardware",
         "Ed25519 identity keys use software-backed Apple Keychain",
         "X25519 key agreement uses software-backed Apple Keychain",
         "Key generation returns appropriate KeyHandle for each key type",
-        "Key destruction follows §9.15 verification — hardware-attested strongest trust level",
-        "Compromise recovery integrates with §9.12 Secure Enclave verification step",
+        "Key destruction follows \u00a79.15 verification \u2014 hardware-attested strongest trust level",
+        "Compromise recovery integrates with \u00a79.12 Secure Enclave verification step",
         "All operations async-compatible through KeyCustody trait",
         "Tests pass on macOS (Secure Enclave available on Apple Silicon)"
       ],
@@ -5288,16 +5288,16 @@
         "stubADR": true,
         "adr": "ADR-025",
         "protocolSections": [
-          "§17.8",
-          "§9.12",
-          "§9.15"
+          "\u00a717.8",
+          "\u00a79.12",
+          "\u00a79.15"
         ],
         "expectedDecisions": {
           "secureEnclavePattern": "P-256 signing for attestation uses SE; Ed25519/X25519 use Keychain",
-          "keyDestruction": "Hardware-attested strongest trust level per §9.15"
+          "keyDestruction": "Hardware-attested strongest trust level per \u00a79.15"
         },
         "blockers": [
-          "Phase 1-2 Rust core must be implemented — platform adapters implement traits defined in scp-platform/",
+          "Phase 1-2 Rust core must be implemented \u2014 platform adapters implement traits defined in scp-platform/",
           "ADR-021 (UniFFI) must define the FFI bridge",
           "ADR-006 platform trait definitions must be finalized (KeyCustody, PushProvider, DeviceAttestation)"
         ]
@@ -5313,7 +5313,7 @@
       "files": [
         "bindings/swift/Sources/SCP/Platform/AppleStorage.swift"
       ],
-      "description": "Implement Apple Keychain integration in `scp-platform/apple/keychain.rs`. Keychain access groups and protection classes for SCP key storage.\n\nKeychain stores Ed25519 identity keys and X25519 key agreement keys (software-backed, not Secure Enclave). Protection classes control when keys are accessible.\n\nNSFileProtection level for SQLite database: `completeUntilFirstUserAuthentication` (allows background processing) vs `complete` (stronger but breaks background refresh). Selection impacts background context processing.\n\nThis is a stub ADR (ADR-025) — implementation details will be refined when the full ADR is written.",
+      "description": "Implement Apple Keychain integration in `scp-platform/apple/keychain.rs`. Keychain access groups and protection classes for SCP key storage.\n\nKeychain stores Ed25519 identity keys and X25519 key agreement keys (software-backed, not Secure Enclave). Protection classes control when keys are accessible.\n\nNSFileProtection level for SQLite database: `completeUntilFirstUserAuthentication` (allows background processing) vs `complete` (stronger but breaks background refresh). Selection impacts background context processing.\n\nThis is a stub ADR (ADR-025) \u2014 implementation details will be refined when the full ADR is written.",
       "acceptanceCriteria": [
         "Keychain stores Ed25519 identity keys with appropriate access group",
         "Keychain stores X25519 key agreement keys with appropriate access group",
@@ -5360,7 +5360,7 @@
       "files": [
         "bindings/swift/Sources/SCP/Platform/AppleDeviceAttestation.swift"
       ],
-      "description": "Implement Apple App Attest device attestation adapter in `scp-platform/apple/app_attest.rs`. Implements the `DeviceAttestation` trait for Apple platforms.\n\nApp Attest integration: attestation flow, server-side verification, fraud metric handling. App Attest provides hardware-backed device attestation that can be verified server-side.\n\nPer §9.15 key destruction verification: hardware-attested is the strongest trust level. App Attest provides the attestation primitive for this.\n\nThis is a stub ADR (ADR-025) — implementation details will be refined when the full ADR is written.",
+      "description": "Implement Apple App Attest device attestation adapter in `scp-platform/apple/app_attest.rs`. Implements the `DeviceAttestation` trait for Apple platforms.\n\nApp Attest integration: attestation flow, server-side verification, fraud metric handling. App Attest provides hardware-backed device attestation that can be verified server-side.\n\nPer \u00a79.15 key destruction verification: hardware-attested is the strongest trust level. App Attest provides the attestation primitive for this.\n\nThis is a stub ADR (ADR-025) \u2014 implementation details will be refined when the full ADR is written.",
       "acceptanceCriteria": [
         "Implements DeviceAttestation trait for Apple platforms",
         "Attestation request generates App Attest attestation object",
@@ -5391,7 +5391,7 @@
         "stubADR": true,
         "adr": "ADR-025",
         "protocolSections": [
-          "§9.15"
+          "\u00a79.15"
         ],
         "expectedDecisions": {
           "appAttest": "Attestation flow, server-side verification, fraud metric handling"
@@ -5408,10 +5408,10 @@
       "files": [
         "bindings/swift/Sources/SCP/Platform/ApplePushProvider.swift"
       ],
-      "description": "Implement Apple Push Notification service (APNs) adapter in `scp-platform/apple/apns.rs`. Implements the `PushProvider` trait for Apple platforms.\n\nAPNs payload format: must satisfy §10.7 opacity requirement while triggering the right notification behavior. Push notifications carry opaque payloads — relay sees notification metadata but not message content. Token registration and refresh lifecycle.\n\nThis is a stub ADR (ADR-025) — implementation details will be refined when the full ADR is written.",
+      "description": "Implement Apple Push Notification service (APNs) adapter in `scp-platform/apple/apns.rs`. Implements the `PushProvider` trait for Apple platforms.\n\nAPNs payload format: must satisfy \u00a710.7 opacity requirement while triggering the right notification behavior. Push notifications carry opaque payloads \u2014 relay sees notification metadata but not message content. Token registration and refresh lifecycle.\n\nThis is a stub ADR (ADR-025) \u2014 implementation details will be refined when the full ADR is written.",
       "acceptanceCriteria": [
         "Implements PushProvider trait for Apple platforms",
-        "APNs payload satisfies §10.7 opacity requirement — relay sees metadata but not message content",
+        "APNs payload satisfies \u00a710.7 opacity requirement \u2014 relay sees metadata but not message content",
         "Token registration with APNs service succeeds",
         "Token refresh lifecycle handles token invalidation and renewal",
         "Push notification triggers correct notification behavior on device",
@@ -5421,7 +5421,7 @@
       "actionItems": [
         "Implement PushProvider::register() for APNs device token registration",
         "Implement PushProvider::handle_notification() for processing incoming push payloads",
-        "Design opaque APNs payload format satisfying §10.7 (encrypted context_id + wake signal, no plaintext content)",
+        "Design opaque APNs payload format satisfying \u00a710.7 (encrypted context_id + wake signal, no plaintext content)",
         "Implement token refresh on invalidation callback",
         "Handle APNs payload size limits (4KB for standard, 5KB for VoIP)",
         "Write integration tests using APNs sandbox"
@@ -5440,10 +5440,10 @@
         "stubADR": true,
         "adr": "ADR-025",
         "protocolSections": [
-          "§10.7"
+          "\u00a710.7"
         ],
         "expectedDecisions": {
-          "apnsPayload": "Opaque payload satisfying §10.7 while triggering correct notification behavior",
+          "apnsPayload": "Opaque payload satisfying \u00a710.7 while triggering correct notification behavior",
           "payloadSizeLimits": "4KB standard, 5KB VoIP"
         }
       }
@@ -5458,7 +5458,7 @@
       "files": [
         "bindings/swift/Sources/SCP/Platform/"
       ],
-      "description": "Apple platform module root and re-exports. ADR-025 specifies Swift implementation with UniFFI callback interface injection — Apple platform adapters live in bindings/swift/Sources/SCP/Platform/, not crates/scp-platform/apple/. Acceptance criteria satisfied by existing Swift Package organization and PlatformAdapter aggregator.",
+      "description": "Apple platform module root and re-exports. ADR-025 specifies Swift implementation with UniFFI callback interface injection \u2014 Apple platform adapters live in bindings/swift/Sources/SCP/Platform/, not crates/scp-platform/apple/. Acceptance criteria satisfied by existing Swift Package organization and PlatformAdapter aggregator.",
       "acceptanceCriteria": [
         "mod.rs declares pub mod for secure_enclave, keychain, app_attest, apns",
         "All Apple adapter types re-exported from mod.rs",
@@ -5490,7 +5490,7 @@
       "details": {
         "stubADR": true,
         "adr": "ADR-025",
-        "scope": "scp-platform/apple/ — ~5 files, ~20 functions"
+        "scope": "scp-platform/apple/ \u2014 ~5 files, ~20 functions"
       }
     },
     {
@@ -5506,14 +5506,14 @@
         "bindings/swift/Sources/SCP/Errors.swift",
         "bindings/swift/Sources/SCP/Types.swift"
       ],
-      "description": "Bootstrap the Swift SDK package structure per `.docs/scaffold/swift.md`. Create Package.swift with SPM configuration, internal UniFFI-generated bindings placeholder, error hierarchy, and shared types.\n\nPackage.swift: swift-tools-version 6.2, platforms iOS 17+ and macOS 14+, binary target for ScpFFI XCFramework.\n\nError hierarchy: `ScpError` enum with associated values per `.docs/scaffold/swift.md`.\n\nShared types: `Message`, `Provenance`, `Capability` per `.docs/scaffold/swift.md`.\n\nFollow the Python SDK pattern (ADR-014): flat FFI bridge -> idiomatic language wrapper. Per `.docs/standards/swift.md`: Swift 6 strict concurrency, `@MainActor` default, `nonisolated` DTOs.\n\nThis is a stub ADR (ADR-026) — implementation details will be refined when the full ADR is written.",
+      "description": "Bootstrap the Swift SDK package structure per `.docs/scaffold/swift.md`. Create Package.swift with SPM configuration, internal UniFFI-generated bindings placeholder, error hierarchy, and shared types.\n\nPackage.swift: swift-tools-version 6.2, platforms iOS 17+ and macOS 14+, binary target for ScpFFI XCFramework.\n\nError hierarchy: `ScpError` enum with associated values per `.docs/scaffold/swift.md`.\n\nShared types: `Message`, `Provenance`, `Capability` per `.docs/scaffold/swift.md`.\n\nFollow the Python SDK pattern (ADR-014): flat FFI bridge -> idiomatic language wrapper. Per `.docs/standards/swift.md`: Swift 6 strict concurrency, `@MainActor` default, `nonisolated` DTOs.\n\nThis is a stub ADR (ADR-026) \u2014 implementation details will be refined when the full ADR is written.",
       "acceptanceCriteria": [
         "Package.swift uses swift-tools-version: 6.2",
         "Platforms: .iOS(.v17), .macOS(.v14)",
         "Binary target ScpFFI configured for XCFramework",
         "Library target SCP depends on ScpFFI",
         "Test target SCPTests depends on SCP",
-        "ScpError enum has variants: identity, context, permission, crypto, transport, tool, validation — all with (message: String, code: String)",
+        "ScpError enum has variants: identity, context, permission, crypto, transport, tool, validation \u2014 all with (message: String, code: String)",
         "ScpError conforms to Error, Sendable, LocalizedError",
         "Message struct is nonisolated and Sendable with fields: senderDid, content, timestamp, sequence, contextId, provenance",
         "Directory structure matches scaffold/swift.md layout",
@@ -5568,7 +5568,7 @@
       "files": [
         "bindings/swift/Sources/SCP/Identity.swift"
       ],
-      "description": "Implement the Swift `Identity` class wrapping UniFFI-generated identity bindings. Per `.docs/scaffold/swift.md`:\n\n```swift\npublic struct Identity: Sendable {\n    public let did: String\n    public let custodyType: String\n    private let handle: IdentityHandle\n    public static func create(custody: String = \"platform\") async throws -> Identity\n    public static func load(did: String) async throws -> Identity\n    public func rotateKey() async throws -> Identity\n}\n```\n\nUse `async/await` for all asynchronous work per `.docs/standards/swift.md`. Use `CheckedContinuation` for bridging UniFFI callbacks to Swift concurrency. Identity is a Sendable struct.\n\nFollow cross-language naming from `.docs/scaffold/shared.md`: `Identity.create()`, `Identity.load()`.\n\nThis is a stub ADR (ADR-026) — implementation details will be refined when the full ADR is written.",
+      "description": "Implement the Swift `Identity` class wrapping UniFFI-generated identity bindings. Per `.docs/scaffold/swift.md`:\n\n```swift\npublic struct Identity: Sendable {\n    public let did: String\n    public let custodyType: String\n    private let handle: IdentityHandle\n    public static func create(custody: String = \"platform\") async throws -> Identity\n    public static func load(did: String) async throws -> Identity\n    public func rotateKey() async throws -> Identity\n}\n```\n\nUse `async/await` for all asynchronous work per `.docs/standards/swift.md`. Use `CheckedContinuation` for bridging UniFFI callbacks to Swift concurrency. Identity is a Sendable struct.\n\nFollow cross-language naming from `.docs/scaffold/shared.md`: `Identity.create()`, `Identity.load()`.\n\nThis is a stub ADR (ADR-026) \u2014 implementation details will be refined when the full ADR is written.",
       "acceptanceCriteria": [
         "Identity struct is Sendable",
         "Identity.create(custody:) is async throws and returns Identity",
@@ -5623,7 +5623,7 @@
       "files": [
         "bindings/swift/Sources/SCP/Context.swift"
       ],
-      "description": "Implement the Swift `Context` actor wrapping UniFFI-generated context bindings. Per `.docs/scaffold/swift.md`:\n\n```swift\npublic actor Context {\n    private let handle: ContextHandle\n    public func send(_ payload: Data) async throws\n    public var messages: AsyncStream<Message>\n}\n```\n\nContext is an actor for thread-safe mutable state. Uses `AsyncStream` for message streaming (preferred per Swift 6, per `.docs/standards/swift.md`).\n\nCross-language naming from `.docs/scaffold/shared.md`: `Context.create()`, `ctx.send()`, `ctx.messages` (receive), `ctx.leave()`, `ctx.close()`.\n\nResource management: `deinit` + explicit `close()` pattern for crypto state cleanup.\n\nThis is a stub ADR (ADR-026) — implementation details will be refined when the full ADR is written.",
+      "description": "Implement the Swift `Context` actor wrapping UniFFI-generated context bindings. Per `.docs/scaffold/swift.md`:\n\n```swift\npublic actor Context {\n    private let handle: ContextHandle\n    public func send(_ payload: Data) async throws\n    public var messages: AsyncStream<Message>\n}\n```\n\nContext is an actor for thread-safe mutable state. Uses `AsyncStream` for message streaming (preferred per Swift 6, per `.docs/standards/swift.md`).\n\nCross-language naming from `.docs/scaffold/shared.md`: `Context.create()`, `ctx.send()`, `ctx.messages` (receive), `ctx.leave()`, `ctx.close()`.\n\nResource management: `deinit` + explicit `close()` pattern for crypto state cleanup.\n\nThis is a stub ADR (ADR-026) \u2014 implementation details will be refined when the full ADR is written.",
       "acceptanceCriteria": [
         "Context is an actor (thread-safe mutable state)",
         "ctx.send(_:) is async throws",
@@ -5692,7 +5692,7 @@
         "bindings/swift/Sources/SCP/Ucan.swift",
         "bindings/swift/Sources/SCP/Mcp.swift"
       ],
-      "description": "Implement remaining Swift SDK wrapper modules per `.docs/scaffold/swift.md` package layout:\n\n- `Trust.swift` — `evaluateTrust()`, `TrustEvaluation` wrapping UniFFI trust evaluation\n- `Tools.swift` — `ToolDefinition`, `TestVector` structs, tool invocation via `ctx.invokeTool()`\n- `EventLog.swift` — `EventLog` class, `Event`, `Proof`, `Checkpoint` types\n- `Transport.swift` — `TransportConfig`, relay connection management\n- `Ucan.swift` — UCAN `validate()`, `mint()`, `revoke()` wrapping UniFFI UCAN bridge\n- `Mcp.swift` — `serveMcp()`, `McpClient` wrapping UniFFI MCP bridge\n\nAll types follow Swift 6 concurrency: DTOs are `nonisolated struct` (Sendable), stateful types use actors. Cross-language naming from `.docs/scaffold/shared.md`.\n\nThis is a stub ADR (ADR-026) — implementation details will be refined when the full ADR is written.",
+      "description": "Implement remaining Swift SDK wrapper modules per `.docs/scaffold/swift.md` package layout:\n\n- `Trust.swift` \u2014 `evaluateTrust()`, `TrustEvaluation` wrapping UniFFI trust evaluation\n- `Tools.swift` \u2014 `ToolDefinition`, `TestVector` structs, tool invocation via `ctx.invokeTool()`\n- `EventLog.swift` \u2014 `EventLog` class, `Event`, `Proof`, `Checkpoint` types\n- `Transport.swift` \u2014 `TransportConfig`, relay connection management\n- `Ucan.swift` \u2014 UCAN `validate()`, `mint()`, `revoke()` wrapping UniFFI UCAN bridge\n- `Mcp.swift` \u2014 `serveMcp()`, `McpClient` wrapping UniFFI MCP bridge\n\nAll types follow Swift 6 concurrency: DTOs are `nonisolated struct` (Sendable), stateful types use actors. Cross-language naming from `.docs/scaffold/shared.md`.\n\nThis is a stub ADR (ADR-026) \u2014 implementation details will be refined when the full ADR is written.",
       "acceptanceCriteria": [
         "Trust.swift exports evaluateTrust() and TrustEvaluation type",
         "Tools.swift exports ToolDefinition and TestVector as nonisolated Sendable structs",
@@ -5754,9 +5754,9 @@
         "bindings/swift/Tests/SCPTests/McpTests.swift",
         "bindings/swift/Tests/SCPTests/Conformance/ConformanceTests.swift"
       ],
-      "description": "Implement Swift SDK test suite per `.docs/scaffold/swift.md` and `.docs/standards/swift.md`. Uses Swift Testing framework (`@Test`, `#expect`).\n\nConformance tests load JSON fixtures from `tests/conformance/` (shared across all SDKs per `.docs/scaffold/shared.md`). Per-module tests cover Identity, Context, Tools, UCAN, Transport, EventLog, MCP.\n\nPer `.docs/standards/swift.md`: use Swift Testing, not XCTest. Tests are async (`async throws`). Parameterized tests use `@Test(arguments:)`.\n\nCI gate: no SDK release proceeds without 100% conformance test pass rate.\n\nThis is a stub ADR (ADR-026) — implementation details will be refined when the full ADR is written.",
+      "description": "Implement Swift SDK test suite per `.docs/scaffold/swift.md` and `.docs/standards/swift.md`. Uses Swift Testing framework (`@Test`, `#expect`).\n\nConformance tests load JSON fixtures from `tests/conformance/` (shared across all SDKs per `.docs/scaffold/shared.md`). Per-module tests cover Identity, Context, Tools, UCAN, Transport, EventLog, MCP.\n\nPer `.docs/standards/swift.md`: use Swift Testing, not XCTest. Tests are async (`async throws`). Parameterized tests use `@Test(arguments:)`.\n\nCI gate: no SDK release proceeds without 100% conformance test pass rate.\n\nThis is a stub ADR (ADR-026) \u2014 implementation details will be refined when the full ADR is written.",
       "acceptanceCriteria": [
-        "All test files use Swift Testing framework (@Test, #expect) — not XCTest",
+        "All test files use Swift Testing framework (@Test, #expect) \u2014 not XCTest",
         "IdentityTests covers create, load, rotate key, DID format validation",
         "ContextTests covers create, join, leave, close, send, receive",
         "ToolsTests covers tool definition, invocation, test vector verification",
@@ -5826,7 +5826,7 @@
         "bindings/swift/.gitignore",
         ".github/workflows/build-matrix.yml"
       ],
-      "description": "Build XCFramework and configure SPM distribution per `.docs/scaffold/swift.md`. The first pass created build-xcframework.sh (218 lines) and Package.swift with a binary target, but the pipeline does not work end-to-end.\n\n**What exists:**\n- `bindings/swift/build-xcframework.sh` — 218-line build script (compiles targets, lipo, xcodebuild)\n- `bindings/swift/Package.swift` — SPM manifest with `ScpFFI` binary target\n- `crates/scp-ffi/uniffi/` — FFI crate with proc-macro exports, compiles successfully\n- Host build verified: `cargo build -p scp-ffi-uniffi --release --target aarch64-apple-darwin` produces both `.a` and `.dylib`\n\n**What is missing (pipeline blockers):**\n1. No `uniffi-bindgen` CLI binary — the crate has no `[[bin]]` target and the `uniffi` dependency lacks the `cli` feature\n2. No header generation step in build script — lines 103-134 check for pre-existing headers but never generate them\n3. No `--dev` flag for macOS-only fast local builds\n4. No `.gitignore` in `bindings/swift/` for build artifacts\n5. CI workflow (`.github/workflows/build-matrix.yml` line 315) has incorrect `--` separator for `uniffi-bindgen` invocations\n6. Only `aarch64-apple-darwin` Rust target is installed; 4 others need `rustup target add`\n7. `Sources/SCP/Internal/ScpBindings.swift` contains a placeholder, not real UniFFI-generated bindings",
+      "description": "Build XCFramework and configure SPM distribution per `.docs/scaffold/swift.md`. The first pass created build-xcframework.sh (218 lines) and Package.swift with a binary target, but the pipeline does not work end-to-end.\n\n**What exists:**\n- `bindings/swift/build-xcframework.sh` \u2014 218-line build script (compiles targets, lipo, xcodebuild)\n- `bindings/swift/Package.swift` \u2014 SPM manifest with `ScpFFI` binary target\n- `crates/scp-ffi/uniffi/` \u2014 FFI crate with proc-macro exports, compiles successfully\n- Host build verified: `cargo build -p scp-ffi-uniffi --release --target aarch64-apple-darwin` produces both `.a` and `.dylib`\n\n**What is missing (pipeline blockers):**\n1. No `uniffi-bindgen` CLI binary \u2014 the crate has no `[[bin]]` target and the `uniffi` dependency lacks the `cli` feature\n2. No header generation step in build script \u2014 lines 103-134 check for pre-existing headers but never generate them\n3. No `--dev` flag for macOS-only fast local builds\n4. No `.gitignore` in `bindings/swift/` for build artifacts\n5. CI workflow (`.github/workflows/build-matrix.yml` line 315) has incorrect `--` separator for `uniffi-bindgen` invocations\n6. Only `aarch64-apple-darwin` Rust target is installed; 4 others need `rustup target add`\n7. `Sources/SCP/Internal/ScpBindings.swift` contains a placeholder, not real UniFFI-generated bindings",
       "acceptanceCriteria": [
         "`cargo run -p scp-ffi-uniffi --bin uniffi-bindgen -- --help` exits 0 (uniffi-bindgen binary exists and runs)",
         "`build-xcframework.sh` is self-contained: generates headers + bindings without manual prereqs",
@@ -5839,11 +5839,11 @@
         "CI workflow has correct `--` separator for `uniffi-bindgen` invocations"
       ],
       "actionItems": [
-        "Add `[[bin]]` section to `crates/scp-ffi/uniffi/Cargo.toml` — name = \"uniffi-bindgen\", path = \"src/bin/uniffi-bindgen.rs\"",
+        "Add `[[bin]]` section to `crates/scp-ffi/uniffi/Cargo.toml` \u2014 name = \"uniffi-bindgen\", path = \"src/bin/uniffi-bindgen.rs\"",
         "Add `\"cli\"` to the `uniffi` dependency features in `[dependencies]` (not `[build-dependencies]`)",
         "Create `crates/scp-ffi/uniffi/src/bin/uniffi-bindgen.rs` with `fn main() { uniffi::uniffi_bindgen_main() }`",
-        "Update `build-xcframework.sh`: replace header prerequisite check (lines 103-134) with generation step — build host dylib, run `cargo run -p scp-ffi-uniffi --bin uniffi-bindgen -- generate --library target/aarch64-apple-darwin/release/libscp_ffi_uniffi.dylib --language swift --out-dir <tmpdir>`, copy outputs to correct locations (rename to match project conventions: ScpFFI.h, ScpBindings.swift)",
-        "Add `--dev` flag to `build-xcframework.sh` — when set, skip iOS targets and lipo, create single-slice XCFramework with just `aarch64-apple-darwin`",
+        "Update `build-xcframework.sh`: replace header prerequisite check (lines 103-134) with generation step \u2014 build host dylib, run `cargo run -p scp-ffi-uniffi --bin uniffi-bindgen -- generate --library target/aarch64-apple-darwin/release/libscp_ffi_uniffi.dylib --language swift --out-dir <tmpdir>`, copy outputs to correct locations (rename to match project conventions: ScpFFI.h, ScpBindings.swift)",
+        "Add `--dev` flag to `build-xcframework.sh` \u2014 when set, skip iOS targets and lipo, create single-slice XCFramework with just `aarch64-apple-darwin`",
         "Create `bindings/swift/.gitignore` excluding `ScpFFI.xcframework/`, `Headers/`, `.build-xcframework/`",
         "Fix `--` separator in `.github/workflows/build-matrix.yml` line 315 for `uniffi-bindgen` invocations",
         "Install missing Rust targets: `rustup target add aarch64-apple-ios aarch64-apple-ios-sim x86_64-apple-ios x86_64-apple-darwin`",
@@ -5912,7 +5912,7 @@
       "files": [
         "tests/phase5_integration.rs"
       ],
-      "description": "Phase 5 end-to-end integration test validating all four ADRs work together. Tests the full bridge-to-media-to-platform-to-SDK pipeline:\n\n1. **Bridge (ADR-023):** Register bridge, create shadow identity, bridge message with provenance, claim shadow, verify retroattribution.\n2. **Media (ADR-024):** Initiate media session with capability ceiling check, export MLS keys, exchange signaling messages, end session, verify event log.\n3. **Apple Platform (ADR-025):** Key custody operations through Secure Enclave/Keychain adapters, App Attest attestation, APNs push registration.\n4. **Swift SDK (ADR-026):** Identity create/load, context create/join/send/receive/leave, tool invocation, UCAN validation — all through Swift wrapper layer.\n\nThis test validates that Phase 5 components integrate with Phase 1-4 foundation (MLS, envelope, DID, context, UCAN, transport, event log, provenance, UniFFI).",
+      "description": "Phase 5 end-to-end integration test validating all four ADRs work together. Tests the full bridge-to-media-to-platform-to-SDK pipeline:\n\n1. **Bridge (ADR-023):** Register bridge, create shadow identity, bridge message with provenance, claim shadow, verify retroattribution.\n2. **Media (ADR-024):** Initiate media session with capability ceiling check, export MLS keys, exchange signaling messages, end session, verify event log.\n3. **Apple Platform (ADR-025):** Key custody operations through Secure Enclave/Keychain adapters, App Attest attestation, APNs push registration.\n4. **Swift SDK (ADR-026):** Identity create/load, context create/join/send/receive/leave, tool invocation, UCAN validation \u2014 all through Swift wrapper layer.\n\nThis test validates that Phase 5 components integrate with Phase 1-4 foundation (MLS, envelope, DID, context, UCAN, transport, event log, provenance, UniFFI).",
       "acceptanceCriteria": [
         "Bridge registration, shadow creation, provenance marking, and claiming all succeed end-to-end",
         "Media session initiation with ceiling check, MLS key export, signaling exchange, and teardown all succeed end-to-end",
@@ -5958,7 +5958,7 @@
       "sources": [
         {
           "file": ".docs/adrs/phase-5.md",
-          "section": "# Phase 5 Architecture Decision Records — Bridges, Media, Apple Platform, Swift SDK"
+          "section": "# Phase 5 Architecture Decision Records \u2014 Bridges, Media, Apple Platform, Swift SDK"
         }
       ],
       "details": {
@@ -6114,7 +6114,7 @@
       ],
       "details": {
         "adrCompletionStory": true,
-        "note": "This story writes the ADR itself. Described as 'the hardest problem' — requires resolving open questions before implementation can begin."
+        "note": "This story writes the ADR itself. Described as 'the hardest problem' \u2014 requires resolving open questions before implementation can begin."
       },
       "result": "ADR-029 Offline/Sync Strategy fully written. Three-tier strategy (short/medium/long offline), client-side queue, six-phase reconnection, MLS epoch catch-up with 100-commit limit, group state reset, conflict resolution via Merkle log authority. All open questions resolved."
     },
@@ -6215,14 +6215,14 @@
       "files": [
         "bindings/kotlin/scp-sdk-kotlin-android/src/main/kotlin/com/limn/scp/android/platform/AndroidKeyCustody.kt"
       ],
-      "description": "Implement the KeyCustody platform trait for Android Keystore. Android Keystore provides TEE-backed key custody; Ed25519 support requires API 33+ (Android 13+). StrongBox is available but dramatically slower than TEE-backed operations. Must decide minimum API level (API 33+ for Ed25519 Keystore, or software fallback for older devices) and TEE vs StrongBox policy (performance vs security tradeoff). Mirrors the Apple adapter structure from ADR-025. Emulator Keystore behavior differs from hardware — test on physical devices.",
+      "description": "Implement the KeyCustody platform trait for Android Keystore. Android Keystore provides TEE-backed key custody; Ed25519 support requires API 33+ (Android 13+). StrongBox is available but dramatically slower than TEE-backed operations. Must decide minimum API level (API 33+ for Ed25519 Keystore, or software fallback for older devices) and TEE vs StrongBox policy (performance vs security tradeoff). Mirrors the Apple adapter structure from ADR-025. Emulator Keystore behavior differs from hardware \u2014 test on physical devices.",
       "acceptanceCriteria": [
         "KeyCustody trait implemented for Android Keystore matching the same platform trait signatures as ADR-025",
         "Ed25519 key generation uses Android Keystore on API 33+ devices",
         "Software fallback path exists for devices below API 33",
         "TEE-backed key operations used exclusively; StrongBox is not offered due to prohibitive latency for SCP's frequent signing operations (ADR-027)",
-        "Key destruction verification via Android Keystore attestation per §9.15",
-        "Compromise recovery follows same 6 steps from §9.12 with Android-specific key rotation",
+        "Key destruction verification via Android Keystore attestation per \u00a79.15",
+        "Compromise recovery follows same 6 steps from \u00a79.12 with Android-specific key rotation",
         "Unit tests pass on both emulator and physical device targets"
       ],
       "actionItems": [
@@ -6231,9 +6231,9 @@
         "Implement software fallback key generation for API < 33",
         "Implement TEE-backed signing and verification operations",
         "Add StrongBox policy configuration (opt-in, document performance tradeoff)",
-        "Implement key destruction with attestation per §9.15",
-        "Implement compromise recovery key rotation per §9.12",
-        "Test on physical Android device — emulator Keystore behavior differs from hardware"
+        "Implement key destruction with attestation per \u00a79.15",
+        "Implement compromise recovery key rotation per \u00a79.12",
+        "Test on physical Android device \u2014 emulator Keystore behavior differs from hardware"
       ],
       "blockedBy": [
         "SCP-094",
@@ -6249,16 +6249,16 @@
       ],
       "details": {
         "stubADR": true,
-        "note": "ADR not yet fully written — story derived from expected approach and known constraints",
+        "note": "ADR not yet fully written \u2014 story derived from expected approach and known constraints",
         "expectedDecisions": {
           "minimumApiLevel": "API 33+ for Ed25519 Keystore, or software fallback for older devices",
-          "teeVsStrongBox": "StrongBox excluded — 10-100x latency penalty is incompatible with SCP's per-message signing. TEE is the only option (ADR-027)"
+          "teeVsStrongBox": "StrongBox excluded \u2014 10-100x latency penalty is incompatible with SCP's per-message signing. TEE is the only option (ADR-027)"
         },
         "references": [
-          "§17.8 — Android Keystore: TEE-backed, API 33+ for Ed25519",
-          "§9.12 — Compromise recovery",
-          "§9.15 — Key destruction verification",
-          "ADR-025 — Apple adapter as parallel reference"
+          "\u00a717.8 \u2014 Android Keystore: TEE-backed, API 33+ for Ed25519",
+          "\u00a79.12 \u2014 Compromise recovery",
+          "\u00a79.15 \u2014 Key destruction verification",
+          "ADR-025 \u2014 Apple adapter as parallel reference"
         ]
       },
       "result": "AndroidKeyCustody.kt + Types.kt implemented. TEE-backed Ed25519 on API 33+, Bouncy Castle fallback for API 26-32, software X25519. 32 JVM unit tests. Commits: 77f48a0, 87fc586."
@@ -6302,12 +6302,12 @@
       ],
       "details": {
         "stubADR": true,
-        "note": "ADR not yet fully written — story derived from expected approach and known constraints",
+        "note": "ADR not yet fully written \u2014 story derived from expected approach and known constraints",
         "expectedDecisions": {
           "playIntegrityLevel": "Standard requests vs classic attestation"
         },
         "references": [
-          "ADR-025 — Apple adapter as parallel reference"
+          "ADR-025 \u2014 Apple adapter as parallel reference"
         ]
       },
       "result": "AndroidDeviceAttestation.kt implemented. Play Integrity Standard API, SHA-256 nonce, JWT token return. 14 JVM unit tests. Commits: bd4e2f7, 87fc586."
@@ -6322,10 +6322,10 @@
       "files": [
         "bindings/kotlin/scp-sdk-kotlin-android/src/main/kotlin/com/limn/scp/android/platform/AndroidPushProvider.kt"
       ],
-      "description": "Implement the PushProvider platform trait for Android using Firebase Cloud Messaging (FCM). FCM payload format must parallel the APNs opacity decision in ADR-025 — payloads must be opaque to the push infrastructure. FCM payload constraints and opacity requirements must be respected.",
+      "description": "Implement the PushProvider platform trait for Android using Firebase Cloud Messaging (FCM). FCM payload format must parallel the APNs opacity decision in ADR-025 \u2014 payloads must be opaque to the push infrastructure. FCM payload constraints and opacity requirements must be respected.",
       "acceptanceCriteria": [
         "PushProvider trait implemented for Android using FCM matching ADR-025 trait signatures",
-        "FCM payload format is opaque — no plaintext protocol data exposed to push infrastructure",
+        "FCM payload format is opaque \u2014 no plaintext protocol data exposed to push infrastructure",
         "Push notification delivery triggers SCP message fetch",
         "FCM token registration and refresh handled",
         "Integration tests verify push delivery flow"
@@ -6351,12 +6351,12 @@
       ],
       "details": {
         "stubADR": true,
-        "note": "ADR not yet fully written — story derived from expected approach and known constraints",
+        "note": "ADR not yet fully written \u2014 story derived from expected approach and known constraints",
         "expectedDecisions": {
           "fcmPayloadFormat": "Parallel to APNs opacity decision in ADR-025"
         },
         "references": [
-          "ADR-025 — Apple adapter as parallel reference"
+          "ADR-025 \u2014 Apple adapter as parallel reference"
         ]
       },
       "result": "AndroidPushProvider.kt implemented. FCM data-only opaque payload, SCP-PUSH-5001/5002 error codes. 10 JVM unit tests. Commits: b37d2f0, 87fc586."
@@ -6401,13 +6401,13 @@
       ],
       "details": {
         "stubADR": true,
-        "note": "ADR not yet fully written — story derived from expected approach and known constraints",
+        "note": "ADR not yet fully written \u2014 story derived from expected approach and known constraints",
         "expectedDecisions": {
           "sqlCipherKeyDerivation": "TEE-backed key derivation for database encryption key"
         },
         "references": [
-          "§17.8 — Android Keystore",
-          "ADR-025 — Apple adapter as parallel reference"
+          "\u00a717.8 \u2014 Android Keystore",
+          "ADR-025 \u2014 Apple adapter as parallel reference"
         ]
       },
       "result": "AndroidStorage.kt implemented with TEE-backed AES-256 key derivation via Android Keystore. InMemoryStorageProvider for testing. 548-line test suite. Commit 775403b."
@@ -6498,13 +6498,13 @@
       ],
       "details": {
         "stubADR": true,
-        "note": "ADR not yet fully written — story derived from expected approach and known constraints",
+        "note": "ADR not yet fully written \u2014 story derived from expected approach and known constraints",
         "expectedDecisions": {
           "dispatcherStrategy": "Which operations run on Dispatchers.IO vs Dispatchers.Default"
         },
         "references": [
-          "scaffold/kotlin.md — coroutine patterns",
-          "standards/kotlin.md — kotlinx.coroutines, Dispatchers.IO for FFI, JVM 11+",
+          "scaffold/kotlin.md \u2014 coroutine patterns",
+          "standards/kotlin.md \u2014 kotlinx.coroutines, Dispatchers.IO for FFI, JVM 11+",
           "ADR-026 (Swift SDK) as parallel reference"
         ]
       },
@@ -6548,13 +6548,13 @@
       ],
       "details": {
         "stubADR": true,
-        "note": "ADR not yet fully written — story derived from expected approach and known constraints",
+        "note": "ADR not yet fully written \u2014 story derived from expected approach and known constraints",
         "expectedDecisions": {
           "flowVsChannel": "Flow preferred for cold streams, Channel for hot"
         },
         "references": [
           "scaffold/kotlin.md",
-          "standards/kotlin.md — kotlinx.coroutines"
+          "standards/kotlin.md \u2014 kotlinx.coroutines"
         ]
       }
     },
@@ -6597,7 +6597,7 @@
       ],
       "details": {
         "stubADR": true,
-        "note": "ADR not yet fully written — story derived from expected approach and known constraints",
+        "note": "ADR not yet fully written \u2014 story derived from expected approach and known constraints",
         "expectedDecisions": {
           "lifecycleIntegration": "LifecycleOwner-aware cleanup of SCP resources"
         },
@@ -6646,7 +6646,7 @@
       ],
       "details": {
         "stubADR": true,
-        "note": "ADR not yet fully written — story derived from expected approach and known constraints",
+        "note": "ADR not yet fully written \u2014 story derived from expected approach and known constraints",
         "expectedDecisions": {
           "composeIntegration": "State holders, remember patterns"
         },
@@ -6696,13 +6696,13 @@
       ],
       "details": {
         "stubADR": true,
-        "note": "ADR not yet fully written — story derived from expected approach and known constraints",
+        "note": "ADR not yet fully written \u2014 story derived from expected approach and known constraints",
         "expectedDecisions": {
           "mavenCentralConfig": "com.limn:scp-sdk-kotlin"
         },
         "references": [
-          "scaffold/kotlin.md — Gradle/KTS build",
-          "standards/kotlin.md — ktlint + detekt, JVM 11+"
+          "scaffold/kotlin.md \u2014 Gradle/KTS build",
+          "standards/kotlin.md \u2014 ktlint + detekt, JVM 11+"
         ]
       }
     },
@@ -6745,9 +6745,9 @@
       ],
       "details": {
         "stubADR": true,
-        "note": "ADR not yet fully written — story derived from expected approach and known constraints",
+        "note": "ADR not yet fully written \u2014 story derived from expected approach and known constraints",
         "references": [
-          "scaffold/shared.md — cross-language naming, conformance tests",
+          "scaffold/shared.md \u2014 cross-language naming, conformance tests",
           "ADR-026 (Swift SDK) as parallel reference",
           "ADR-014 (Python SDK) as pattern"
         ]
@@ -6763,24 +6763,24 @@
       "files": [
         "crates/scp-core/sync/hours_offline.rs"
       ],
-      "description": "Implement hours-scale offline recovery: relay buffering + MLS catch-up. Devices are full protocol participants (§10.2), not thin clients. SDK SHOULD issue MLS Update after reconnecting (§9.12). 30-second gap timeout, 100-message buffer (§9.8.5 reorder buffer spec). Relays provide availability but are untrusted. SCP does not require synchronized clocks (§9.8.3). KeyPackages pre-published for offline member addition (§9.6). This is the baseline offline scenario that likely works with current design.",
+      "description": "Implement hours-scale offline recovery: relay buffering + MLS catch-up. Devices are full protocol participants (\u00a710.2), not thin clients. SDK SHOULD issue MLS Update after reconnecting (\u00a79.12). 30-second gap timeout, 100-message buffer (\u00a79.8.5 reorder buffer spec). Relays provide availability but are untrusted. SCP does not require synchronized clocks (\u00a79.8.3). KeyPackages pre-published for offline member addition (\u00a79.6). This is the baseline offline scenario that likely works with current design.",
       "acceptanceCriteria": [
         "Devices reconnecting after hours-scale offline retrieve buffered messages from relay",
         "MLS epoch catch-up processes all accumulated proposals in order",
-        "SDK issues MLS Update after reconnecting per §9.12",
-        "30-second gap timeout and 100-message reorder buffer per §9.8.5 respected",
-        "KeyPackages pre-published so offline members can be added per §9.6",
-        "No synchronized clock dependency per §9.8.3",
-        "Relays treated as untrusted — all verification client-side",
+        "SDK issues MLS Update after reconnecting per \u00a79.12",
+        "30-second gap timeout and 100-message reorder buffer per \u00a79.8.5 respected",
+        "KeyPackages pre-published so offline members can be added per \u00a79.6",
+        "No synchronized clock dependency per \u00a79.8.3",
+        "Relays treated as untrusted \u2014 all verification client-side",
         "NetworkSimulator stress tests with simulated hours-offline scenarios pass"
       ],
       "actionItems": [
         "Implement relay message buffer retrieval on reconnect",
         "Implement MLS epoch catch-up: process accumulated proposals sequentially",
-        "Implement automatic MLS Update issuance after reconnect per §9.12",
-        "Respect 30s gap timeout and 100-message reorder buffer per §9.8.5",
-        "Ensure KeyPackage pre-publication for offline member addition per §9.6",
-        "Add NetworkSimulator stress tests with partition topologies from §16.8",
+        "Implement automatic MLS Update issuance after reconnect per \u00a79.12",
+        "Respect 30s gap timeout and 100-message reorder buffer per \u00a79.8.5",
+        "Ensure KeyPackage pre-publication for offline member addition per \u00a79.6",
+        "Add NetworkSimulator stress tests with partition topologies from \u00a716.8",
         "Gather empirical data: MLS epoch accumulation rates, context state growth rates"
       ],
       "blockedBy": [
@@ -6797,23 +6797,23 @@
       ],
       "details": {
         "stubADR": true,
-        "note": "ADR not yet fully written — story derived from expected approach and known constraints. Architecture.md §6 explicitly flags offline MLS re-sync as 'the hardest unsolved problem.'",
+        "note": "ADR not yet fully written \u2014 story derived from expected approach and known constraints. Architecture.md \u00a76 explicitly flags offline MLS re-sync as 'the hardest unsolved problem.'",
         "knownConstraints": [
-          "Devices are full protocol participants (§10.2), not thin clients",
-          "SCP does not require synchronized clocks (§9.8.3)",
-          "KeyPackages pre-published for offline member addition (§9.6)",
-          "SDK SHOULD issue MLS Update after reconnecting (§9.12)",
-          "30-second gap timeout, 100-message buffer (§9.8.5 reorder buffer spec)",
+          "Devices are full protocol participants (\u00a710.2), not thin clients",
+          "SCP does not require synchronized clocks (\u00a79.8.3)",
+          "KeyPackages pre-published for offline member addition (\u00a79.6)",
+          "SDK SHOULD issue MLS Update after reconnecting (\u00a79.12)",
+          "30-second gap timeout, 100-message buffer (\u00a79.8.5 reorder buffer spec)",
           "Relays provide availability but are untrusted"
         ],
         "approachDirection": "Hours-scale offline: Relay buffering + MLS catch-up (likely works with current design)",
         "references": [
-          "§10.2 — Device as node design",
-          "§9.8.3 — Timestamp model",
-          "§9.8.5 — Message gap handling",
-          "§9.6 — KeyPackage pre-publication",
-          "§9.12 — Compromise recovery",
-          "§16.8 — NetworkSimulator"
+          "\u00a710.2 \u2014 Device as node design",
+          "\u00a79.8.3 \u2014 Timestamp model",
+          "\u00a79.8.5 \u2014 Message gap handling",
+          "\u00a79.6 \u2014 KeyPackage pre-publication",
+          "\u00a79.12 \u2014 Compromise recovery",
+          "\u00a716.8 \u2014 NetworkSimulator"
         ]
       },
       "result": "Hours-scale offline recovery implemented in sync/ module. ReorderBuffer (100-msg, 30s gap), MlsEpochCatchUp, ReconnectOrchestrator, KeyPackagePublisher. 56 tests pass."
@@ -6828,7 +6828,7 @@
       "files": [
         "crates/scp-core/sync/days_offline.rs"
       ],
-      "description": "Design and implement days-scale offline recovery: state snapshot + delta sync. This needs design beyond the current protocol — hours-scale relay buffering is insufficient for multi-day offline periods. Must handle accumulated MLS proposals, potentially stale group state, and context state divergence. Needs empirical data from Phase 1-2 implementation.",
+      "description": "Design and implement days-scale offline recovery: state snapshot + delta sync. This needs design beyond the current protocol \u2014 hours-scale relay buffering is insufficient for multi-day offline periods. Must handle accumulated MLS proposals, potentially stale group state, and context state divergence. Needs empirical data from Phase 1-2 implementation.",
       "acceptanceCriteria": [
         "State snapshot mechanism captures authoritative context state at a point in time",
         "Delta sync computes and applies differences between snapshot and current state",
@@ -6857,15 +6857,15 @@
       ],
       "details": {
         "stubADR": true,
-        "note": "ADR not yet fully written — story derived from expected approach and known constraints. This approach direction needs design — no current protocol mechanism.",
+        "note": "ADR not yet fully written \u2014 story derived from expected approach and known constraints. This approach direction needs design \u2014 no current protocol mechanism.",
         "approachDirection": "Days-scale offline: State snapshot + delta sync (needs design)",
         "openQuestions": [
           "Full state reconstruction semantics after extended offline (what's authoritative vs derivable)",
           "Standing bilateral context lifetime vs offline duration (weeks-offline scenario)"
         ],
         "references": [
-          "§10.2 — Device as node design",
-          "§9.8.3 — Timestamp model"
+          "\u00a710.2 \u2014 Device as node design",
+          "\u00a79.8.3 \u2014 Timestamp model"
         ]
       },
       "result": "days_offline.rs: ContextSnapshot, SnapshotDelta, DeltaSyncEngine trait, MLS rebuild, multi-device divergence detection. 29 tests."
@@ -6909,15 +6909,15 @@
       ],
       "details": {
         "stubADR": true,
-        "note": "ADR not yet fully written — story derived from expected approach and known constraints. MLS group state reset trigger conditions, initiation protocol, and context lifecycle during reset are all unspecified.",
+        "note": "ADR not yet fully written \u2014 story derived from expected approach and known constraints. MLS group state reset trigger conditions, initiation protocol, and context lifecycle during reset are all unspecified.",
         "approachDirection": "Weeks-scale offline: Forced re-join with state reset (needs design)",
         "openQuestions": [
           "MLS group state reset: trigger conditions, who initiates, what happens to in-flight messages",
           "Standing bilateral context lifetime vs offline duration (weeks-offline scenario)"
         ],
         "references": [
-          "§10.2 — Device as node design",
-          "§9.12 — Compromise recovery"
+          "\u00a710.2 \u2014 Device as node design",
+          "\u00a79.12 \u2014 Compromise recovery"
         ]
       },
       "result": "Implemented weeks-offline forced re-join in sync/weeks_offline.rs. OfflineAssessment with epoch drift and time thresholds (MAX_EPOCH_DRIFT=1000, MAX_OFFLINE_DURATION=14 days). ReJoinPlan with state preservation (membership, governance, event log continuity). InFlightMessageHandling with queue/re-request/discard strategies. BilateralContextRecovery for 2-person contexts. ReJoinExecutor trait for MLS operations. 29 unit tests."
@@ -6938,7 +6938,7 @@
         "Event ordering determined by Merkle tree position, not wall-clock time",
         "Concurrent governance proposals from multiple offline admins resolved deterministically",
         "Governance deadlock detected and triggers context fork",
-        "No synchronized clock dependency in conflict resolution per §9.8.3",
+        "No synchronized clock dependency in conflict resolution per \u00a79.8.3",
         "Tests verify conflict resolution for all concurrent offline scenarios"
       ],
       "actionItems": [
@@ -6946,7 +6946,7 @@
         "Implement Merkle tree-based event ordering for conflict resolution",
         "Define governance deadlock detection criteria",
         "Implement context fork mechanism for irreconcilable governance deadlocks",
-        "Ensure all resolution is clock-independent per §9.8.3",
+        "Ensure all resolution is clock-independent per \u00a79.8.3",
         "Add tests for concurrent offline governance conflict scenarios"
       ],
       "blockedBy": [
@@ -6963,14 +6963,14 @@
       ],
       "details": {
         "stubADR": true,
-        "note": "ADR not yet fully written — story derived from expected approach and known constraints",
+        "note": "ADR not yet fully written \u2014 story derived from expected approach and known constraints",
         "approachDirection": "Last-writer-wins for metadata, Merkle tree for event ordering, governance deadlock = context fork",
         "openQuestions": [
           "Conflict resolution for concurrent offline governance changes (two admins both offline, both propose role changes)"
         ],
         "references": [
-          "§9.8.3 — Timestamp model (no synchronized clocks)",
-          "§9.8.5 — Message gap handling"
+          "\u00a79.8.3 \u2014 Timestamp model (no synchronized clocks)",
+          "\u00a79.8.5 \u2014 Message gap handling"
         ]
       },
       "result": "conflict_resolution.rs: ConflictType/Resolution enums, Merkle-ordered resolution, deadlock detection, context fork. Tests pass."
@@ -6985,14 +6985,14 @@
       "files": [
         "crates/scp-core/event_log/checkpoint.rs"
       ],
-      "description": "Implement periodic checkpoint creation for append-only Merkle event logs (ADR-011). Checkpoints capture the Merkle root at a point in time, enabling pruning of older entries while preserving verifiability. The core tension: event logs are verifiable because they're append-only, but pruning breaks append-only. Protocol state footprint is deliberately minimal (§10.3).",
+      "description": "Implement periodic checkpoint creation for append-only Merkle event logs (ADR-011). Checkpoints capture the Merkle root at a point in time, enabling pruning of older entries while preserving verifiability. The core tension: event logs are verifiable because they're append-only, but pruning breaks append-only. Protocol state footprint is deliberately minimal (\u00a710.3).",
       "acceptanceCriteria": [
         "Checkpoint captures Merkle root snapshot at a configurable interval",
         "Checkpoint includes all state necessary to verify events after checkpoint point",
         "Checkpoint format supports inclusion proofs for post-checkpoint events",
         "Consistency verification works across checkpoint boundaries",
         "Checkpoint creation does not block ongoing event log appends",
-        "Behavioral validation (§7.3.1) continues to work with checkpointed logs",
+        "Behavioral validation (\u00a77.3.1) continues to work with checkpointed logs",
         "Tests verify checkpoint creation, proof generation, and consistency verification"
       ],
       "actionItems": [
@@ -7001,7 +7001,7 @@
         "Implement inclusion proof generation that works across checkpoint boundaries",
         "Implement consistency verification across checkpoints",
         "Ensure checkpoint creation is non-blocking for concurrent appends",
-        "Verify behavioral validation (§7.3.1) works with checkpointed logs",
+        "Verify behavioral validation (\u00a77.3.1) works with checkpointed logs",
         "Add tests for checkpoint creation, proof verification, and cross-boundary consistency"
       ],
       "blockedBy": [
@@ -7016,19 +7016,19 @@
       ],
       "details": {
         "stubADR": true,
-        "note": "ADR not yet fully written — story derived from expected approach and known constraints. The core tension: event logs are verifiable because they're append-only, pruning breaks append-only.",
+        "note": "ADR not yet fully written \u2014 story derived from expected approach and known constraints. The core tension: event logs are verifiable because they're append-only, pruning breaks append-only.",
         "coreTension": "Event logs are verifiable because they're append-only. Pruning breaks append-only. The protocol must balance verifiability (full history provable) with storage (unbounded growth unsustainable on mobile devices).",
         "knownConstraints": [
-          "Protocol state footprint is deliberately minimal (§10.3): membership, roles, tokens, tool registrations, governance, content hashes — NOT content itself",
+          "Protocol state footprint is deliberately minimal (\u00a710.3): membership, roles, tokens, tool registrations, governance, content hashes \u2014 NOT content itself",
           "Event logs are per-context Merkle trees with SHA-256 hash chain (ADR-011)",
           "Must support inclusion proofs and consistency verification",
-          "Behavioral validation (§7.3.1) depends on verifiable event logs"
+          "Behavioral validation (\u00a77.3.1) depends on verifiable event logs"
         ],
         "references": [
-          "ADR-011 — Event log design",
-          "§10.3 — Protocol state footprint",
-          "§7.3.1 — Verifiable event logs",
-          "§17.4 — ProtocolStore event log key convention"
+          "ADR-011 \u2014 Event log design",
+          "\u00a710.3 \u2014 Protocol state footprint",
+          "\u00a77.3.1 \u2014 Verifiable event logs",
+          "\u00a717.4 \u2014 ProtocolStore event log key convention"
         ]
       },
       "result": "CheckpointManager for periodic checkpoint creation. CheckpointedProof for post-checkpoint verification. TruncatedEventLog for pruned log operations. Cross-checkpoint consistency verification. ~40 tests."
@@ -7050,7 +7050,7 @@
         "Proof compaction reduces storage while preserving verifiability of pruned entries",
         "Pruning is configurable: retain last N checkpoints, or retain checkpoints within time window",
         "Storage reclamation measurable after pruning",
-        "Behavioral validation (§7.3.1) continues to work after pruning",
+        "Behavioral validation (\u00a77.3.1) continues to work after pruning",
         "Tests verify pruning, proof compaction, and storage reclamation"
       ],
       "actionItems": [
@@ -7073,12 +7073,12 @@
       ],
       "details": {
         "stubADR": true,
-        "note": "ADR not yet fully written — story derived from expected approach and known constraints",
-        "designSpaceOption": "Periodic checkpoints (Merkle root snapshots) + pruned older entries — compresses, complicates proof verification",
+        "note": "ADR not yet fully written \u2014 story derived from expected approach and known constraints",
+        "designSpaceOption": "Periodic checkpoints (Merkle root snapshots) + pruned older entries \u2014 compresses, complicates proof verification",
         "references": [
-          "ADR-011 — Event log design",
-          "§10.3 — Protocol state footprint",
-          "§7.3.1 — Verifiable event logs"
+          "ADR-011 \u2014 Event log design",
+          "\u00a710.3 \u2014 Protocol state footprint",
+          "\u00a77.3.1 \u2014 Verifiable event logs"
         ]
       },
       "result": "event_log/pruning.rs implements pruning with proof compaction. PruningConfig (retention by count/time). CompactProof for pruned events. Storage metrics. Behavioral validation works post-pruning. Comprehensive tests."
@@ -7093,7 +7093,7 @@
       "files": [
         "crates/scp-core/event_log/tiered_storage.rs"
       ],
-      "description": "Implement tiered storage for event logs: hot (recent, on-device) + cold (old, relay-hosted, proof-fetchable). Recent events stored locally for fast access; older events offloaded to relay storage with on-demand proof fetching. Relays are untrusted — all proofs must be cryptographically verifiable client-side.",
+      "description": "Implement tiered storage for event logs: hot (recent, on-device) + cold (old, relay-hosted, proof-fetchable). Recent events stored locally for fast access; older events offloaded to relay storage with on-demand proof fetching. Relays are untrusted \u2014 all proofs must be cryptographically verifiable client-side.",
       "acceptanceCriteria": [
         "Recent events stored on-device (hot tier) for fast access",
         "Older events offloaded to relay storage (cold tier)",
@@ -7104,7 +7104,7 @@
         "Tests verify tier migration, cold fetch, and proof verification"
       ],
       "actionItems": [
-        "Implement hot tier: recent events on-device with ProtocolStore key convention from §17.4",
+        "Implement hot tier: recent events on-device with ProtocolStore key convention from \u00a717.4",
         "Implement cold tier: event offloading to relay storage",
         "Implement on-demand proof fetching from cold tier",
         "Implement client-side cryptographic verification of all fetched proofs",
@@ -7123,11 +7123,11 @@
       ],
       "details": {
         "stubADR": true,
-        "note": "ADR not yet fully written — story derived from expected approach and known constraints",
+        "note": "ADR not yet fully written \u2014 story derived from expected approach and known constraints",
         "designSpaceOption": "Tiered storage: hot (recent, on-device) + cold (old, relay-hosted, proof-fetchable)",
         "references": [
-          "ADR-011 — Event log design",
-          "§17.4 — ProtocolStore event log key convention"
+          "ADR-011 \u2014 Event log design",
+          "\u00a717.4 \u2014 ProtocolStore event log key convention"
         ]
       },
       "result": "tiered_storage.rs: TieredEventLog, ColdTierProvider trait, TierConfig, hot/cold migration, proof verification. Tests pass."
@@ -7171,10 +7171,10 @@
       ],
       "details": {
         "stubADR": true,
-        "note": "ADR not yet fully written — story derived from expected approach and known constraints. Need empirical data: typical event log growth rates per context type, device storage constraints, proof verification frequency.",
+        "note": "ADR not yet fully written \u2014 story derived from expected approach and known constraints. Need empirical data: typical event log growth rates per context type, device storage constraints, proof verification frequency.",
         "references": [
-          "ADR-011 — Event log design",
-          "§10.3 — Protocol state footprint"
+          "ADR-011 \u2014 Event log design",
+          "\u00a710.3 \u2014 Protocol state footprint"
         ]
       },
       "result": "EventLogMetrics, GrowthSnapshot, ProofBenchmark types implemented with growth rate tracking, proof gen/verify profiling, storage consumption monitoring, JSON export, 19 unit tests passing"
@@ -7189,20 +7189,20 @@
       "files": [
         "crates/scp-core/src/context/governance/mod.rs"
       ],
-      "description": "Define the governance interface contract with typed proposals and propose/approve/reject lifecycle. Governance is a pluggable interface (§5.9): protocol defines propose/approve/reject, implementations vary. Context governance controls: role changes, membership, settings, ceiling expansion, interface decisions (§5.9). Governance actions are context events in the Merkle log — auditable and verifiable. Exit as veto: members can leave if governance makes unacceptable decisions (§9.2.1).",
+      "description": "Define the governance interface contract with typed proposals and propose/approve/reject lifecycle. Governance is a pluggable interface (\u00a75.9): protocol defines propose/approve/reject, implementations vary. Context governance controls: role changes, membership, settings, ceiling expansion, interface decisions (\u00a75.9). Governance actions are context events in the Merkle log \u2014 auditable and verifiable. Exit as veto: members can leave if governance makes unacceptable decisions (\u00a79.2.1).",
       "acceptanceCriteria": [
         "Governance trait defines propose/approve/reject with typed proposal variants",
-        "Proposal types cover: role changes, membership changes, settings changes, ceiling expansion, interface decisions per §5.9",
+        "Proposal types cover: role changes, membership changes, settings changes, ceiling expansion, interface decisions per \u00a75.9",
         "Proposal lifecycle: proposed -> voting -> approved/rejected with state machine enforcement",
         "All governance actions recorded as context events in Merkle log (auditable, verifiable)",
-        "Exit-as-veto mechanism preserved: members can leave during voting window per §9.2.1",
+        "Exit-as-veto mechanism preserved: members can leave during voting window per \u00a79.2.1",
         "Interface is pluggable: different governance models implement the same trait",
         "Single-admin governance (Phase 2 baseline from ADR-008) reimplemented as trait implementation",
         "Tests verify proposal lifecycle state machine and Merkle log recording"
       ],
       "actionItems": [
         "Define GovernanceModel trait with propose/approve/reject methods",
-        "Define typed proposal enum covering all governance actions from §5.9",
+        "Define typed proposal enum covering all governance actions from \u00a75.9",
         "Implement proposal lifecycle state machine (proposed -> voting -> approved/rejected)",
         "Implement Merkle log recording of all governance events",
         "Reimplement single-admin governance as GovernanceModel trait implementation",
@@ -7222,26 +7222,26 @@
       ],
       "details": {
         "stubADR": true,
-        "note": "ADR not yet fully written — story derived from expected approach and known constraints",
+        "note": "ADR not yet fully written \u2014 story derived from expected approach and known constraints",
         "knownConstraints": [
-          "Governance is a pluggable interface (§5.9): protocol defines propose/approve/reject, implementations vary",
-          "Context governance controls: role changes, membership, settings, ceiling expansion, interface decisions (§5.9)",
-          "Exit as veto: members can leave if governance makes unacceptable decisions (§9.2.1)",
-          "Governance actions are context events in the Merkle log — auditable and verifiable"
+          "Governance is a pluggable interface (\u00a75.9): protocol defines propose/approve/reject, implementations vary",
+          "Context governance controls: role changes, membership, settings, ceiling expansion, interface decisions (\u00a75.9)",
+          "Exit as veto: members can leave if governance makes unacceptable decisions (\u00a79.2.1)",
+          "Governance actions are context events in the Merkle log \u2014 auditable and verifiable"
         ],
         "openQuestions": [
           "Proposal message format (structured event type in Merkle log)",
           "Interaction with UCAN: who holds the governance UCAN? How is it delegated in multi-admin?"
         ],
         "references": [
-          "§5.9 — Context governance model",
-          "§9.2.1 — Security boundaries",
-          "ADR-008 — Context lifecycle state machine",
-          "ADR-009 — Role assignment and capability ceiling",
-          "ADR-016 — UCAN validation"
+          "\u00a75.9 \u2014 Context governance model",
+          "\u00a79.2.1 \u2014 Security boundaries",
+          "ADR-008 \u2014 Context lifecycle state machine",
+          "ADR-009 \u2014 Role assignment and capability ceiling",
+          "ADR-016 \u2014 UCAN validation"
         ]
       },
-      "result": "GovernanceEngine trait, GovernanceProposal lifecycle state machine, SingleAdminEngine baseline implementation, typed proposal variants for all §5.9 governance actions, GovernanceEvent for Merkle log recording, 34 unit tests passing"
+      "result": "GovernanceEngine trait, GovernanceProposal lifecycle state machine, SingleAdminEngine baseline implementation, typed proposal variants for all \u00a75.9 governance actions, GovernanceEvent for Merkle log recording, 34 unit tests passing"
     },
     {
       "id": "SCP-130",
@@ -7253,7 +7253,7 @@
       "files": [
         "crates/scp-core/context/governance/multisig.rs"
       ],
-      "description": "Implement multi-sig (M-of-N threshold) governance model. Simplest semantics, most useful, least ambiguous. A proposal passes when M of N designated signers approve. Start with this — most useful for the common case of '2-of-3 admins.' Must define: quorum rules, voting window duration, timeout handling, order-sensitive or order-independent signatures, withdrawal allowed or not.",
+      "description": "Implement multi-sig (M-of-N threshold) governance model. Simplest semantics, most useful, least ambiguous. A proposal passes when M of N designated signers approve. Start with this \u2014 most useful for the common case of '2-of-3 admins.' Must define: quorum rules, voting window duration, timeout handling, order-sensitive or order-independent signatures, withdrawal allowed or not.",
       "acceptanceCriteria": [
         "Multi-sig governance model implements GovernanceModel trait from SCP-129",
         "M-of-N threshold configurable at context creation (e.g. 2-of-3)",
@@ -7288,7 +7288,7 @@
       ],
       "details": {
         "stubADR": true,
-        "note": "ADR not yet fully written — story derived from expected approach and known constraints",
+        "note": "ADR not yet fully written \u2014 story derived from expected approach and known constraints",
         "openQuestions": [
           "Quorum rules per model type (majority? supermajority? unanimity for which actions?)",
           "Voting window duration and timeout handling",
@@ -7296,9 +7296,9 @@
           "Interaction with UCAN: who holds the governance UCAN? How is it delegated in multi-admin?"
         ],
         "references": [
-          "§5.9 — Context governance model",
-          "ADR-008 — Context lifecycle state machine",
-          "ADR-016 — UCAN validation"
+          "\u00a75.9 \u2014 Context governance model",
+          "ADR-008 \u2014 Context lifecycle state machine",
+          "ADR-016 \u2014 UCAN validation"
         ]
       },
       "result": "MultiSigEngine implementing GovernanceEngine trait. M-of-N threshold, configurable voting window, order-independent approvals, withdrawal support, timeout handling. 50 new tests."
@@ -7348,15 +7348,15 @@
       ],
       "details": {
         "stubADR": true,
-        "note": "ADR not yet fully written — story derived from expected approach and known constraints",
+        "note": "ADR not yet fully written \u2014 story derived from expected approach and known constraints",
         "openQuestions": [
           "Quorum rules per model type",
           "Voting window duration and timeout handling"
         ],
         "references": [
-          "§5.9 — Context governance model",
-          "ADR-008 — Context lifecycle state machine",
-          "ADR-016 — UCAN validation"
+          "\u00a75.9 \u2014 Context governance model",
+          "ADR-008 \u2014 Context lifecycle state machine",
+          "ADR-016 \u2014 UCAN validation"
         ]
       },
       "result": "MajorityVoteEngine implementing GovernanceEngine trait. Configurable quorum, >50% threshold on votes cast, deadline enforcement, vote withdrawal. 34 tests."
@@ -7371,7 +7371,7 @@
       "files": [
         "crates/scp-core/context/governance/unanimity.rs"
       ],
-      "description": "Implement unanimity (all members) governance model. Every member must approve. Suitable for high-stakes decisions (ceiling changes, context closure). Must handle the case where members are unavailable or offline — consensus deadlock recovery when N-of-M signers are unavailable.",
+      "description": "Implement unanimity (all members) governance model. Every member must approve. Suitable for high-stakes decisions (ceiling changes, context closure). Must handle the case where members are unavailable or offline \u2014 consensus deadlock recovery when N-of-M signers are unavailable.",
       "acceptanceCriteria": [
         "Unanimity governance model implements GovernanceModel trait from SCP-129",
         "Every member must approve for proposal to pass",
@@ -7408,16 +7408,16 @@
       ],
       "details": {
         "stubADR": true,
-        "note": "ADR not yet fully written — story derived from expected approach and known constraints",
+        "note": "ADR not yet fully written \u2014 story derived from expected approach and known constraints",
         "openQuestions": [
           "Consensus deadlock recovery: what if N-of-M signers are unavailable?",
           "Voting window duration and timeout handling"
         ],
         "references": [
-          "§5.9 — Context governance model",
-          "§9.2.1 — Security boundaries (exit as veto)",
-          "ADR-008 — Context lifecycle state machine",
-          "ADR-016 — UCAN validation"
+          "\u00a75.9 \u2014 Context governance model",
+          "\u00a79.2.1 \u2014 Security boundaries (exit as veto)",
+          "ADR-008 \u2014 Context lifecycle state machine",
+          "ADR-016 \u2014 UCAN validation"
         ]
       },
       "result": "UnanimityEngine implementing GovernanceEngine trait. All-must-approve with single-veto, deadline-based deadlock recovery, vote withdrawal. 35 tests."
@@ -7462,10 +7462,10 @@
       ],
       "details": {
         "stubADR": true,
-        "note": "ADR not yet fully written — story derived from blocker: 'Need to understand how governance proposals interact with MLS epoch advances and context state'",
+        "note": "ADR not yet fully written \u2014 story derived from blocker: 'Need to understand how governance proposals interact with MLS epoch advances and context state'",
         "references": [
-          "§5.9 — Context governance model",
-          "ADR-008 — Context lifecycle state machine"
+          "\u00a75.9 \u2014 Context governance model",
+          "ADR-008 \u2014 Context lifecycle state machine"
         ]
       },
       "result": "Governance-MLS epoch coordination implemented in mls_integration.rs. Classifies governance actions by MLS impact, coordinates epoch advances with proposal approval, consistency checks. 56 tests pass."
@@ -7480,7 +7480,7 @@
       "files": [
         "crates/scp-core/context/nesting.rs"
       ],
-      "description": "Implement parent-child context nesting (spec §5.13). Nesting manages parent-child relationships: ceiling intersection validation (child ceiling must be subset of parent), eligibility enforcement (members must be in at least one parent), lifecycle coupling (child bounded by parent lifecycle), ParentGovernanceConfig for governance inheritance, and MLS group_context extension construction (parent context IDs + governance config content hash). This was originally part of SCP-022 but is not Phase 2 scope — it requires a complete Phase 2 context system as foundation.",
+      "description": "Implement parent-child context nesting (spec \u00a75.13). Nesting manages parent-child relationships: ceiling intersection validation (child ceiling must be subset of parent), eligibility enforcement (members must be in at least one parent), lifecycle coupling (child bounded by parent lifecycle), ParentGovernanceConfig for governance inheritance, and MLS group_context extension construction (parent context IDs + governance config content hash). This was originally part of SCP-022 but is not Phase 2 scope \u2014 it requires a complete Phase 2 context system as foundation.",
       "acceptanceCriteria": [
         "Parent-child relationship management: ceiling intersection validation ensures child ceiling is subset of parent ceiling",
         "Eligibility enforcement: creator needs ChildContextCreate capability in at least one parent; additional parents approve independently via their own governance",
@@ -7490,8 +7490,8 @@
         "MLS group_context extension construction: includes parent context IDs + governance config content hash (cryptographically unforgeable lineage)",
         "Multi-parent children: governance approval from every parent required; creator needs creation rights in at least one parent",
         "Unit test: child ceiling intersection enforcement",
-        "Unit test: lifecycle coupling — child closes when parent closes",
-        "Unit test: eligibility — member loses access when removed from all parents",
+        "Unit test: lifecycle coupling \u2014 child closes when parent closes",
+        "Unit test: eligibility \u2014 member loses access when removed from all parents",
         "Unit test: multi-parent approval flow"
       ],
       "actionItems": [
@@ -7516,7 +7516,7 @@
       ],
       "details": {
         "Scope files": "| File | Purpose |\n|------|---------||\n| `nesting.rs` | Parent-child relationship management: ceiling intersection validation, eligibility enforcement, lifecycle coupling, ParentGovernanceConfig, MLS group_context extension construction (parent context IDs + governance config content hash) |",
-        "Origin": "Split from SCP-022. Context nesting (§5.13) requires a complete Phase 2 context system as foundation. Not Phase 2 scope."
+        "Origin": "Split from SCP-022. Context nesting (\u00a75.13) requires a complete Phase 2 context system as foundation. Not Phase 2 scope."
       },
       "result": "Created crates/scp-core/src/context/nesting.rs with ParentGovernanceConfig, ceiling intersection validation, eligibility enforcement, lifecycle coupling, multi-parent governance."
     },
@@ -7530,12 +7530,12 @@
       "files": [
         "crates/scp-core/src/context/policy.rs"
       ],
-      "description": "Implement auto-accept policy storage and retrieval. Auto-accept policies determine whether incoming context invitations are automatically accepted or require manual approval. Policies are stored locally via the SDK's Storage trait (same backend as protocol state), never transmitted over the wire. Each device configures independently — cross-device sync is not supported. Key convention: `policy/{identity_did}/auto_accept`.",
+      "description": "Implement auto-accept policy storage and retrieval. Auto-accept policies determine whether incoming context invitations are automatically accepted or require manual approval. Policies are stored locally via the SDK's Storage trait (same backend as protocol state), never transmitted over the wire. Each device configures independently \u2014 cross-device sync is not supported. Key convention: `policy/{identity_did}/auto_accept`.",
       "acceptanceCriteria": [
         "Auto-accept policies are persisted via the SDK's `Storage` trait (same backend as protocol state)",
         "Storage key convention: `policy/{identity_did}/auto_accept`",
         "Policies are device-local; they are never included in any wire message or sync protocol",
-        "Cross-device sync is explicitly not supported — each device configures its own auto-accept policy independently",
+        "Cross-device sync is explicitly not supported \u2014 each device configures its own auto-accept policy independently",
         "Policy CRUD: `set_auto_accept_policy(identity: &DID, policy: AutoAcceptPolicy) -> Result<(), StorageError>`",
         "Policy CRUD: `get_auto_accept_policy(identity: &DID) -> Result<Option<AutoAcceptPolicy>, StorageError>`",
         "Policy CRUD: `delete_auto_accept_policy(identity: &DID) -> Result<(), StorageError>`",
@@ -7543,7 +7543,7 @@
         "Unit test: policy persists across ProtocolStore re-initialization (survives restart)",
         "Unit test: absent policy returns None (opt-in model)",
         "On SDK initialization, policies are loaded from storage and applied to the invitation evaluation pipeline",
-        "Hard rule: auto-accept NEVER applies to contexts with economic policy requiring payment (§19.3, §19.14). This is non-overridable — no auto-accept policy configuration can bypass it. Agents never silently incur costs"
+        "Hard rule: auto-accept NEVER applies to contexts with economic policy requiring payment (\u00a719.3, \u00a719.14). This is non-overridable \u2014 no auto-accept policy configuration can bypass it. Agents never silently incur costs"
       ],
       "actionItems": [
         "Create `crates/scp-core/context/policy.rs` with `AutoAcceptPolicy` struct and associated types",
@@ -7582,7 +7582,7 @@
         ".github/workflows/release.yml",
         ".github/workflows/build-matrix.yml"
       ],
-      "description": "Implement the binary artifact build, sign, and distribute workflow for all SDK packages. The conformance gate (100% pass) is a prerequisite — no release without it. Covers: build matrix (Linux x86_64/aarch64, macOS universal2, Windows x86_64), artifact signing per platform, distribution to all 8 package registries, version pinning to scp-core, and the 7-step release checklist.",
+      "description": "Implement the binary artifact build, sign, and distribute workflow for all SDK packages. The conformance gate (100% pass) is a prerequisite \u2014 no release without it. Covers: build matrix (Linux x86_64/aarch64, macOS universal2, Windows x86_64), artifact signing per platform, distribution to all 8 package registries, version pinning to scp-core, and the 7-step release checklist.",
       "acceptanceCriteria": [
         "Build matrix: Linux (x86_64, aarch64) produces manylinux2014 wheels and .so; macOS (universal2) produces wheels, .dylib, .xcframework; Windows (x86_64) produces wheels and .dll",
         "Distribution channels: Rust (crates.io source crate), Python (PyPI maturin wheel), TypeScript browser (@scp/sdk npm WASM bundle), TypeScript Node/Bun (@scp/sdk-node npm napi-rs addon), Swift (SPM XCFramework), Kotlin (Maven Central AAR), Go (Go modules source + .so), C# (NuGet native runtime pack), Java (Maven Central JAR with natives)",
@@ -7642,11 +7642,11 @@
         "crates/scp-core/context/invitation.rs",
         "crates/scp-core/context/manager.rs"
       ],
-      "description": "When the SDK receives a context invitation, it evaluates in this order: (1) Template check — if the invitation includes a template ID, validate that the context params match the template exactly. Reject if params don't match (prevents template spoofing — claiming `bilateral-ephemeral` but including tool capabilities). (2) Auto-accept check — if a matching policy exists, evaluate trust requirement, TTL cap, and rate limit. If all pass, join automatically. (3) Agent prompt — if no auto-accept policy matches, surface the invitation to the agent/human for decision. The invitation includes full context metadata (§5.7) plus the template ID if present.",
+      "description": "When the SDK receives a context invitation, it evaluates in this order: (1) Template check \u2014 if the invitation includes a template ID, validate that the context params match the template exactly. Reject if params don't match (prevents template spoofing \u2014 claiming `bilateral-ephemeral` but including tool capabilities). (2) Auto-accept check \u2014 if a matching policy exists, evaluate trust requirement, TTL cap, and rate limit. If all pass, join automatically. (3) Agent prompt \u2014 if no auto-accept policy matches, surface the invitation to the agent/human for decision. The invitation includes full context metadata (\u00a75.7) plus the template ID if present.",
       "acceptanceCriteria": [
-        "Step 1 — Template check: if the invitation includes a template ID, validate that the context params match the template exactly. Reject if params don't match (prevents template spoofing — claiming `bilateral-ephemeral` but including tool capabilities)",
-        "Step 2 — Auto-accept check: if a matching auto-accept policy exists, evaluate trust requirement, TTL cap, and rate limit. If all conditions pass, join the context automatically",
-        "Step 3 — Agent prompt: if no auto-accept policy matches, surface the invitation to the agent/human for decision. The invitation includes full context metadata (§5.7) plus the template ID if present",
+        "Step 1 \u2014 Template check: if the invitation includes a template ID, validate that the context params match the template exactly. Reject if params don't match (prevents template spoofing \u2014 claiming `bilateral-ephemeral` but including tool capabilities)",
+        "Step 2 \u2014 Auto-accept check: if a matching auto-accept policy exists, evaluate trust requirement, TTL cap, and rate limit. If all conditions pass, join the context automatically",
+        "Step 3 \u2014 Agent prompt: if no auto-accept policy matches, surface the invitation to the agent/human for decision. The invitation includes full context metadata (\u00a75.7) plus the template ID if present",
         "Evaluation order is strictly sequential: template check before auto-accept, auto-accept before agent prompt",
         "Template spoofing rejection: an invitation claiming `bilateral-ephemeral` template but including tool capabilities is rejected at step 1",
         "Rate limiting: auto-accept evaluates a per-peer rate limit to prevent invitation flooding",
@@ -7680,7 +7680,7 @@
         }
       ],
       "details": {
-        "Evaluation pipeline": "1. Template check — validate params match template exactly. Reject spoofing.\n2. Auto-accept check — evaluate trust, TTL cap, rate limit. Join if all pass.\n3. Agent prompt — surface to agent/human for decision. Includes full context metadata (§5.7) + template ID."
+        "Evaluation pipeline": "1. Template check \u2014 validate params match template exactly. Reject spoofing.\n2. Auto-accept check \u2014 evaluate trust, TTL cap, rate limit. Join if all pass.\n3. Agent prompt \u2014 surface to agent/human for decision. Includes full context metadata (\u00a75.7) + template ID."
       },
       "result": "Invitation evaluation pipeline implemented with 3-step sequential evaluation (template check, auto-accept, agent prompt), economic policy guard, rate limiting, 10 unit tests passing"
     },
@@ -7695,14 +7695,14 @@
         "crates/scp-core/context/standing.rs",
         "crates/scp-core/context/manager.rs"
       ],
-      "description": "Standing bilateral contexts serve as the real-time communication primitive (spec §5.12.4). The SDK manages them as persistent infrastructure — the agent's contact list. `standing_channel(peer_did)` is a get-or-create operation that returns an existing bilateral-persistent context or creates one. Idempotent. On SDK initialization, reconnect transport for all standing channels — this is background work that begins receiving queued messages.",
+      "description": "Standing bilateral contexts serve as the real-time communication primitive (spec \u00a75.12.4). The SDK manages them as persistent infrastructure \u2014 the agent's contact list. `standing_channel(peer_did)` is a get-or-create operation that returns an existing bilateral-persistent context or creates one. Idempotent. On SDK initialization, reconnect transport for all standing channels \u2014 this is background work that begins receiving queued messages.",
       "acceptanceCriteria": [
-        "`standing_channel(peer_did: &DID) -> Result<ContextHandle, ContextError>` is idempotent — returns existing bilateral-persistent context if one exists with this peer",
+        "`standing_channel(peer_did: &DID) -> Result<ContextHandle, ContextError>` is idempotent \u2014 returns existing bilateral-persistent context if one exists with this peer",
         "Step 1: Check local state for an existing `bilateral-persistent` context with this peer DID",
-        "Step 2: If found and `Active`, return it. Zero network cost — instant",
+        "Step 2: If found and `Active`, return it. Zero network cost \u2014 instant",
         "Step 3: If not found, create one (`bilateral-persistent` template), send invitation, return the handle. First message queues until the peer joins",
         "Step 4: If found but peer has left, create a new one (re-invitation)",
-        "Startup reconnection: on SDK initialization, reconnect transport for all standing channels. This is background work — the SDK reconnects to relays for all active persistent contexts and begins receiving queued messages",
+        "Startup reconnection: on SDK initialization, reconnect transport for all standing channels. This is background work \u2014 the SDK reconnects to relays for all active persistent contexts and begins receiving queued messages",
         "Standing channels are available immediately after `sdk.init()` returns",
         "Unit test: standing_channel returns existing context without network call",
         "Unit test: standing_channel creates new bilateral-persistent context when none exists",
@@ -7729,8 +7729,8 @@
         }
       ],
       "details": {
-        "standing_channel semantics": "1. Check local state for an existing bilateral-persistent context with this peer DID.\n2. If found and Active, return it. Zero network cost — instant.\n3. If not found, create one (bilateral-persistent template), send invitation, return the handle. First message queues until the peer joins.\n4. If found but peer has left, create a new one (re-invitation).",
-        "Startup reconnection": "On SDK initialization, reconnect transport for all standing channels. This is background work — the SDK reconnects to relays for all active persistent contexts and begins receiving queued messages. Standing channels are available immediately after sdk.init() returns."
+        "standing_channel semantics": "1. Check local state for an existing bilateral-persistent context with this peer DID.\n2. If found and Active, return it. Zero network cost \u2014 instant.\n3. If not found, create one (bilateral-persistent template), send invitation, return the handle. First message queues until the peer joins.\n4. If found but peer has left, create a new one (re-invitation).",
+        "Startup reconnection": "On SDK initialization, reconnect transport for all standing channels. This is background work \u2014 the SDK reconnects to relays for all active persistent contexts and begins receiving queued messages. Standing channels are available immediately after sdk.init() returns."
       },
       "result": "Standing channels implemented at crates/scp-core/src/context/standing.rs. 4-step get-or-create logic, startup reconnection, idempotent standing_channel()."
     },
@@ -7750,7 +7750,7 @@
         "bindings/csharp/README.md",
         "bindings/java/README.md"
       ],
-      "description": "Every SDK ships with: (1) README.md — Quick start (install, create identity, create context, send message) in under 30 lines, (2) API reference — Generated from source (rustdoc, pydoc, typedoc, DocC, KDoc, godoc, xmldoc, javadoc), (3) Type stubs / declarations — For IDE autocompletion and static analysis (.pyi, .d.ts, etc.), (4) Examples directory — Runnable examples covering: basic messaging, tool invocation, MCP integration, multi-agent coordination.",
+      "description": "Every SDK ships with: (1) README.md \u2014 Quick start (install, create identity, create context, send message) in under 30 lines, (2) API reference \u2014 Generated from source (rustdoc, pydoc, typedoc, DocC, KDoc, godoc, xmldoc, javadoc), (3) Type stubs / declarations \u2014 For IDE autocompletion and static analysis (.pyi, .d.ts, etc.), (4) Examples directory \u2014 Runnable examples covering: basic messaging, tool invocation, MCP integration, multi-agent coordination.",
       "acceptanceCriteria": [
         "Every SDK ships a README.md with quick start (install, create identity, create context, send message) in under 30 lines of code",
         "Every SDK ships generated API reference documentation from source: Rust (rustdoc), Python (pydoc), TypeScript (typedoc), Swift (DocC), Kotlin (KDoc), Go (godoc), C# (xmldoc), Java (javadoc)",
@@ -7778,13 +7778,13 @@
         }
       ],
       "details": {
-        "Documentation deliverables": "1. README.md — Quick start in <30 lines.\n2. API reference — Generated from source (rustdoc, pydoc, typedoc, DocC, KDoc, godoc, xmldoc, javadoc).\n3. Type stubs — .pyi, .d.ts, etc.\n4. Examples directory — basic messaging, tool invocation, MCP integration, multi-agent coordination."
+        "Documentation deliverables": "1. README.md \u2014 Quick start in <30 lines.\n2. API reference \u2014 Generated from source (rustdoc, pydoc, typedoc, DocC, KDoc, godoc, xmldoc, javadoc).\n3. Type stubs \u2014 .pyi, .d.ts, etc.\n4. Examples directory \u2014 basic messaging, tool invocation, MCP integration, multi-agent coordination."
       },
       "result": "SDK documentation for all 7 language bindings: README.md with <30-line quick start, examples/ directory with 4 runnable examples each, TypeScript .d.ts type declarations, Python py.typed marker, sphinx docs config, typedoc config, and CI docs.yml workflow for API reference generation on release. Swift DocC generation moved from docs.yml to build-matrix.yml (swift-xcframework job) because DocC requires the compiled ScpFFI.xcframework binary target."
     },
     {
       "id": "SCP-140",
-      "title": "PATCH — Add SCPRelay service entry type to DidDocument",
+      "title": "PATCH \u2014 Add SCPRelay service entry type to DidDocument",
       "gate": "gate-addr",
       "priority": "P0",
       "severity": "critical",
@@ -7792,22 +7792,22 @@
       "files": [
         "crates/scp-core/src/identity/document.rs"
       ],
-      "description": "PATCH to SCP-006 (done). SCP-006 created DidDocument with only PreRotationCommitment service. §18.2 defines SCPRelay as a DID document service endpoint type for relay transport URLs — the endpoints where TransportManager (ADR-012) routes encrypted blobs to the identity. This story extends document.rs to support SCPRelay entries. This patch is considered more recent than SCP-006.\n\nThe SCPRelay service endpoint type declares transport-layer relay URLs. URL format: wss://<host>/scp/v1 (ADR-004). TLS 1.3 required (§9.13). Multiple entries allowed for suppression resistance (§9.9.2, ADR-012). Self-certified via BEP44 (§9.6.3). Sequence number monotonicity applies.\n\nSCPRelay is distinct from SCPCapabilities (ADR-020): SCPRelay = transport layer (where to send encrypted blobs, consumed by TransportManager), SCPCapabilities = application layer (what tools/capabilities an agent offers, consumed by Discovery Engine).",
+      "description": "PATCH to SCP-006 (done). SCP-006 created DidDocument with only PreRotationCommitment service. \u00a718.2 defines SCPRelay as a DID document service endpoint type for relay transport URLs \u2014 the endpoints where TransportManager (ADR-012) routes encrypted blobs to the identity. This story extends document.rs to support SCPRelay entries. This patch is considered more recent than SCP-006.\n\nThe SCPRelay service endpoint type declares transport-layer relay URLs. URL format: wss://<host>/scp/v1 (ADR-004). TLS 1.3 required (\u00a79.13). Multiple entries allowed for suppression resistance (\u00a79.9.2, ADR-012). Self-certified via BEP44 (\u00a79.6.3). Sequence number monotonicity applies.\n\nSCPRelay is distinct from SCPCapabilities (ADR-020): SCPRelay = transport layer (where to send encrypted blobs, consumed by TransportManager), SCPCapabilities = application layer (what tools/capabilities an agent offers, consumed by Discovery Engine).",
       "acceptanceCriteria": [
         "SCPRelay variant exists in service entry types in DidDocument",
         "add_relay_service(url: Url) method on DidDocument adds an SCPRelay service entry",
         "relay_service_urls() -> Vec<Url> accessor returns all SCPRelay URLs",
         "Serde roundtrip preserves SCPRelay entries alongside existing PreRotationCommitment and IdentityPrivateState service types",
         "SCPRelay entries use wss:// scheme and /scp/v1 path format",
-        "SCPRelay is structurally distinct from SCPCapabilities — different enum variant, different type string in serialized form",
+        "SCPRelay is structurally distinct from SCPCapabilities \u2014 different enum variant, different type string in serialized form",
         "Unit test: DidDocument with mixed service types (PreRotationCommitment + SCPRelay) serializes and deserializes correctly",
         "Unit test: relay_service_urls returns only SCPRelay entries, not other service types",
         "Unit test: add_relay_service with invalid URL (non-wss scheme) returns error",
-        "Multiple SCPRelay entries preserve insertion order (first entry = preferred relay per §18.2.3)"
+        "Multiple SCPRelay entries preserve insertion order (first entry = preferred relay per \u00a718.2.3)"
       ],
       "actionItems": [
         "Add SCPRelay variant to the service entry type enum in document.rs",
-        "Implement add_relay_service(url: Url) method on DidDocument — validates wss:// scheme, creates SCPRelay service entry with auto-generated ID",
+        "Implement add_relay_service(url: Url) method on DidDocument \u2014 validates wss:// scheme, creates SCPRelay service entry with auto-generated ID",
         "Implement relay_service_urls() -> Vec<Url> accessor that filters service entries by SCPRelay type",
         "Update Serde Serialize/Deserialize implementations to handle SCPRelay entries with type string \"SCPRelay\"",
         "Write unit tests for roundtrip serialization, URL filtering, and URL validation"
@@ -7834,13 +7834,13 @@
       "details": {
         "patchContext": "SCP-006 (done) created DidDocument with only PreRotationCommitment service. This story extends it with SCPRelay. This is a patch to SCP-006's behavior and is considered more recent.",
         "serviceEndpointFormat": "```json\n{\n  \"id\": \"#scp-relay-1\",\n  \"type\": \"SCPRelay\",\n  \"serviceEndpoint\": \"wss://relay.example.com/scp/v1\"\n}\n```",
-        "crossReferenceTable": "| Type | Purpose | Consumer |\n|------|---------|----------|\n| SCPRelay | Transport-layer relay URLs | TransportManager (ADR-012) |\n| SCPCapabilities | Application-layer capability endpoints | Discovery Engine (§6.2.2) |\n| IdentityPrivateState | Relay URLs storing identity private state | Identity Manager |\n| PreRotationCommitment | SHA-256 commitment for pre-rotation key | Identity Manager (§9.12) |\n| SCPBroadcastContext | Broadcast context ID + relay URLs | Discovery Engine |",
-        "multipleRelayEntries": "An identity SHOULD publish at least 3 SCPRelay entries for suppression resistance (§9.9.2). Relay entries are ordered by preference (first entry = preferred relay). Clients SHOULD respect ordering when selecting a subset. When adding or removing relays, the identity updates its DID document and publishes with an incremented BEP44 sequence number. Peers that re-resolve the DID document discover the updated relay list."
+        "crossReferenceTable": "| Type | Purpose | Consumer |\n|------|---------|----------|\n| SCPRelay | Transport-layer relay URLs | TransportManager (ADR-012) |\n| SCPCapabilities | Application-layer capability endpoints | Discovery Engine (\u00a76.2.2) |\n| IdentityPrivateState | Relay URLs storing identity private state | Identity Manager |\n| PreRotationCommitment | SHA-256 commitment for pre-rotation key | Identity Manager (\u00a79.12) |\n| SCPBroadcastContext | Broadcast context ID + relay URLs | Discovery Engine |",
+        "multipleRelayEntries": "An identity SHOULD publish at least 3 SCPRelay entries for suppression resistance (\u00a79.9.2). Relay entries are ordered by preference (first entry = preferred relay). Clients SHOULD respect ordering when selecting a subset. When adding or removing relays, the identity updates its DID document and publishes with an incremented BEP44 sequence number. Peers that re-resolve the DID document discover the updated relay list."
       }
     },
     {
       "id": "SCP-141",
-      "title": "PATCH — Wire relay URL publication into DID publish flow",
+      "title": "PATCH \u2014 Wire relay URL publication into DID publish flow",
       "gate": "gate-addr",
       "priority": "P0",
       "severity": "critical",
@@ -7848,13 +7848,13 @@
       "files": [
         "crates/scp-core/src/identity/dht.rs"
       ],
-      "description": "PATCH to SCP-007 (done). SCP-007 publishes DID documents without relay URL entries. §18.2 and §18.5 require relay URLs in published DID documents so peers can discover relays via DID resolution. This story extends the publish flow to accept optional relay_urls and include them as SCPRelay service entries before BEP44 publication. This patch is considered more recent than SCP-007.\n\nRelay URLs are added as SCPRelay service entries before BEP44 publication. Self-certified via BEP44 signature (existing §9.6.3 property — no new crypto needed). Sequence number monotonicity (§9.6.3) applies to relay list updates.",
+      "description": "PATCH to SCP-007 (done). SCP-007 publishes DID documents without relay URL entries. \u00a718.2 and \u00a718.5 require relay URLs in published DID documents so peers can discover relays via DID resolution. This story extends the publish flow to accept optional relay_urls and include them as SCPRelay service entries before BEP44 publication. This patch is considered more recent than SCP-007.\n\nRelay URLs are added as SCPRelay service entries before BEP44 publication. Self-certified via BEP44 signature (existing \u00a79.6.3 property \u2014 no new crypto needed). Sequence number monotonicity (\u00a79.6.3) applies to relay list updates.",
       "acceptanceCriteria": [
         "Identity creation flow accepts optional relay_urls: Vec<Url>",
         "DID document update flow accepts optional relay_urls: Vec<Url>",
         "When relay_urls provided, published DID documents include SCPRelay service entries for each URL",
-        "BEP44 signature covers the relay entries (no new crypto — existing §9.6.3 property)",
-        "Sequence number is incremented on relay list updates (§9.6.3 monotonicity)",
+        "BEP44 signature covers the relay entries (no new crypto \u2014 existing \u00a79.6.3 property)",
+        "Sequence number is incremented on relay list updates (\u00a79.6.3 monotonicity)",
         "DID resolution returns relay URLs from SCPRelay service entries",
         "Unit test: publish with relay_urls -> resolve -> relay_service_urls returns the published URLs",
         "Unit test: publish without relay_urls -> resolve -> relay_service_urls returns empty",
@@ -7886,7 +7886,7 @@
       ],
       "details": {
         "patchContext": "SCP-007 (done) publishes DID documents without relay URL entries. This story extends the publish flow. This is a patch to SCP-007's behavior and is considered more recent.",
-        "securityNote": "Self-certification comes from BEP44 — the entire DID document is signed by the identity's key. Adding SCPRelay entries to the document before signing means the relay URLs are covered by the same signature. No new cryptographic mechanism needed."
+        "securityNote": "Self-certification comes from BEP44 \u2014 the entire DID document is signed by the identity's key. Adding SCPRelay entries to the document before signing means the relay URLs are covered by the same signature. No new cryptographic mechanism needed."
       },
       "result": "Relay URL publication wired into DID publish flow. 10 new tests."
     },
@@ -7900,15 +7900,15 @@
       "files": [
         "crates/scp-core/src/uri.rs"
       ],
-      "description": "Implement the universal SCP context URI type as specified in §18.4. The ScpUri type represents context references that can be shared out-of-band (chat, email, QR codes). URIs are discovery-only — they point to a context's metadata routing ID (§5.7.1) for inspection. They do not embed key material or grant membership.\n\nUniversal format: scp://context/<context_id_hex>?relay=<url>[&relay=<url2>][&mode=<mode>][&name=<name>]\n\nLegacy format scp://broadcast/<context_id_hex>?relay=<url> is accepted as alias and normalized to the universal format with mode=broadcast.\n\nname parameter is advisory and unverified against context metadata. Percent-encoding per RFC 3986 for all parameter values.",
+      "description": "Implement the universal SCP context URI type as specified in \u00a718.4. The ScpUri type represents context references that can be shared out-of-band (chat, email, QR codes). URIs are discovery-only \u2014 they point to a context's metadata routing ID (\u00a75.7.1) for inspection. They do not embed key material or grant membership.\n\nUniversal format: scp://context/<context_id_hex>?relay=<url>[&relay=<url2>][&mode=<mode>][&name=<name>]\n\nLegacy format scp://broadcast/<context_id_hex>?relay=<url> is accepted as alias and normalized to the universal format with mode=broadcast.\n\nname parameter is advisory and unverified against context metadata. Percent-encoding per RFC 3986 for all parameter values.",
       "acceptanceCriteria": [
         "ScpUri enum with Context { context_id, relays: Vec<Url>, mode: Option<ContextMode>, name: Option<String> } variant",
         "Parse scp://context/<hex>?relay=<url> successfully",
         "Parse scp://context/<hex>?relay=<url1>&relay=<url2> with multiple relays",
         "Parse scp://context/<hex>?relay=<url>&mode=broadcast&name=Test+Name with all optional params",
-        "Parse legacy scp://broadcast/<hex>?relay=<url> as alias — normalized to Context variant with mode=broadcast",
-        "Relay URL parameters are validated to use the wss:// scheme — non-wss relay URLs produce a parse error",
-        "mode and name parameters are advisory — stored as-is without verification against context metadata",
+        "Parse legacy scp://broadcast/<hex>?relay=<url> as alias \u2014 normalized to Context variant with mode=broadcast",
+        "Relay URL parameters are validated to use the wss:// scheme \u2014 non-wss relay URLs produce a parse error",
+        "mode and name parameters are advisory \u2014 stored as-is without verification against context metadata",
         "Serialize to canonical universal format (scp://context/...)",
         "Percent-encoding per RFC 3986 for relay URLs and name parameter",
         "Invalid URIs return typed errors: wrong scheme, missing context path, invalid hex, missing relay param",
@@ -7922,8 +7922,8 @@
       "actionItems": [
         "Create crates/scp-core/src/uri.rs",
         "Define ScpUri enum with Context variant containing context_id (Vec<u8>), relays (Vec<Url>), mode (Option<ContextMode>), name (Option<String>)",
-        "Implement FromStr/TryFrom<&str> for parsing — handle both scp://context/ and scp://broadcast/ path prefixes",
-        "Implement Display for serialization — always serialize to canonical scp://context/ format",
+        "Implement FromStr/TryFrom<&str> for parsing \u2014 handle both scp://context/ and scp://broadcast/ path prefixes",
+        "Implement Display for serialization \u2014 always serialize to canonical scp://context/ format",
         "Implement percent-encoding/decoding for URL parameters per RFC 3986",
         "Define ScpUriError enum with variants for each parse failure mode",
         "Write comprehensive unit tests for parsing, serialization, roundtrip, legacy alias, and error cases"
@@ -7938,8 +7938,8 @@
       "details": {
         "universalFormat": "scp://context/<context_id_hex>?relay=<url>[&relay=<url2>][&mode=<mode>][&name=<name>]",
         "legacyAlias": "scp://broadcast/<context_id_hex>?relay=<url> is accepted and normalized to scp://context/<hex>?relay=<url>&mode=broadcast",
-        "designNote": "Context URIs are discovery-only — no embedded key= param. MLS membership is a separate flow. URIs point to metadata routing IDs for inspection.",
-        "useCases": "Out-of-band sharing: Share a context reference via any channel (chat, email, QR code). Recipient fetches metadata, evaluates, requests to join. | Agent bootstrap: An agent receiving an scp:// URI can resolve the context's metadata, evaluate governance and ceiling, and decide whether to participate — all without prior knowledge of the context. | Deep linking: Applications can register scp:// as a URI scheme. Clicking an scp:// link opens the app and navigates to the context's metadata view. | .well-known/scp integration: Broadcast contexts listed in .well-known/scp include their full scp:// URI for direct access."
+        "designNote": "Context URIs are discovery-only \u2014 no embedded key= param. MLS membership is a separate flow. URIs point to metadata routing IDs for inspection.",
+        "useCases": "Out-of-band sharing: Share a context reference via any channel (chat, email, QR code). Recipient fetches metadata, evaluates, requests to join. | Agent bootstrap: An agent receiving an scp:// URI can resolve the context's metadata, evaluate governance and ceiling, and decide whether to participate \u2014 all without prior knowledge of the context. | Deep linking: Applications can register scp:// as a URI scheme. Clicking an scp:// link opens the app and navigates to the context's metadata view. | .well-known/scp integration: Broadcast contexts listed in .well-known/scp include their full scp:// URI for direct access."
       }
     },
     {
@@ -7952,16 +7952,16 @@
       "files": [
         "crates/scp-core/src/well_known.rs"
       ],
-      "description": "Implement the .well-known/scp document type as specified in §18.3. This is the data type for the HTTP-accessible JSON document at https://<domain>/.well-known/scp that enables web-based discovery of SCP infrastructure.\n\nWellKnownScp struct: version (integer, currently 1), did (String), relay (String), contexts (optional Vec<WellKnownContext>), relay_config (optional RelayConfig).\n\nRelayConfig struct: max_blob_size, max_blob_ttl, rate_limit_publish, rate_limit_subscribe (all optional integers, mirroring ADR-004 configuration table).\n\nWellKnownContext struct: id (hex String), name (optional String), mode (optional String), uri (optional String — full scp:// URI).\n\nContexts list MUST NOT include encrypted context IDs — validation rejects them. Only broadcast context IDs (public by design, §5.14.6) may appear.\n\n.well-known/scp is NOT self-certifying — integrity depends on HTTPS. The did field enables partial verification via DHT resolution (§18.3.2).",
+      "description": "Implement the .well-known/scp document type as specified in \u00a718.3. This is the data type for the HTTP-accessible JSON document at https://<domain>/.well-known/scp that enables web-based discovery of SCP infrastructure.\n\nWellKnownScp struct: version (integer, currently 1), did (String), relay (String), contexts (optional Vec<WellKnownContext>), relay_config (optional RelayConfig).\n\nRelayConfig struct: max_blob_size, max_blob_ttl, rate_limit_publish, rate_limit_subscribe (all optional integers, mirroring ADR-004 configuration table).\n\nWellKnownContext struct: id (hex String), name (optional String), mode (optional String), uri (optional String \u2014 full scp:// URI).\n\nContexts list MUST NOT include encrypted context IDs \u2014 validation rejects them. Only broadcast context IDs (public by design, \u00a75.14.6) may appear.\n\n.well-known/scp is NOT self-certifying \u2014 integrity depends on HTTPS. The did field enables partial verification via DHT resolution (\u00a718.3.2).",
       "acceptanceCriteria": [
         "WellKnownScp struct with fields: version (u32), did (String), relay (String), contexts (Option<Vec<WellKnownContext>>), relay_config (Option<RelayConfig>)",
         "RelayConfig struct with fields: max_blob_size (Option<u64>), max_blob_ttl (Option<u64>), rate_limit_publish (Option<u32>), rate_limit_subscribe (Option<u32>)",
         "WellKnownContext struct with fields: id (String), name (Option<String>), mode (Option<String>), uri (Option<String>)",
-        "Serde JSON serialization produces the format specified in §18.3.1",
-        "Serde JSON deserialization accepts the format specified in §18.3.1",
+        "Serde JSON serialization produces the format specified in \u00a718.3.1",
+        "Serde JSON deserialization accepts the format specified in \u00a718.3.1",
         "All optional fields are correctly omitted from JSON when None (serde skip_serializing_if)",
         "Serialize/deserialize roundtrip preserves all fields",
-        "Validation function rejects WellKnownScp where contexts contains entries with mode != broadcast (encrypted context IDs must not be exposed per §9.10)",
+        "Validation function rejects WellKnownScp where contexts contains entries with mode != broadcast (encrypted context IDs must not be exposed per \u00a79.10)",
         "Unit test: full document with all fields serializes to expected JSON",
         "Unit test: minimal document (only required fields) serializes correctly",
         "Unit test: deserialization handles missing optional fields",
@@ -7971,7 +7971,7 @@
         "Create crates/scp-core/src/well_known.rs",
         "Define WellKnownScp, RelayConfig, and WellKnownContext structs with Serialize/Deserialize derives",
         "Add #[serde(skip_serializing_if = \"Option::is_none\")] to all optional fields",
-        "Implement validate() method on WellKnownScp that checks contexts entries — reject any with mode absent or mode == encrypted",
+        "Implement validate() method on WellKnownScp that checks contexts entries \u2014 reject any with mode absent or mode == encrypted",
         "Write unit tests for serialization, deserialization, roundtrip, and validation"
       ],
       "blockedBy": [],
@@ -7983,7 +7983,7 @@
       ],
       "details": {
         "documentFormat": "```json\n{\n  \"version\": 1,\n  \"did\": \"did:dht:z6Mk...\",\n  \"relay\": \"wss://relay.example.com/scp/v1\",\n  \"contexts\": [\n    {\n      \"id\": \"a1b2c3d4e5f6...\",\n      \"name\": \"Example Community\",\n      \"mode\": \"broadcast\",\n      \"uri\": \"scp://context/a1b2c3d4e5f6...?relay=wss://relay.example.com/scp/v1&mode=broadcast&name=Example+Community\"\n    }\n  ],\n  \"relay_config\": {\n    \"max_blob_size\": 262144,\n    \"max_blob_ttl\": 86400,\n    \"rate_limit_publish\": 100,\n    \"rate_limit_subscribe\": 50\n  }\n}\n```",
-        "securityNote": ".well-known/scp is NOT self-certifying. Integrity depends on HTTPS (DNS + TLS + server integrity). The did field enables partial verification via DHT resolution (§18.3.2). Clients MUST verify against DHT-resolved DID documents before trusting for protocol operations.",
+        "securityNote": ".well-known/scp is NOT self-certifying. Integrity depends on HTTPS (DNS + TLS + server integrity). The did field enables partial verification via DHT resolution (\u00a718.3.2). Clients MUST verify against DHT-resolved DID documents before trusting for protocol operations.",
         "privacyConstraints": "MUST NOT expose: encrypted context IDs, membership rosters, routing pseudonyms, subscriber lists. MAY expose: relay URLs, operator DID, protocol version, relay config, broadcast context IDs."
       }
     },
@@ -7998,12 +7998,12 @@
         "crates/scp-transport/src/config.rs",
         "crates/scp-transport/src/manager.rs"
       ],
-      "description": "Implement TransportConfig and the relay bootstrap resolution chain as specified in §18.5 and ADR-032. TransportConfig is the configuration struct passed to TransportManager at initialization, providing explicit relay URLs, optional bootstrap domain, and dedup configuration.\n\nThe ResolveRelays trait implements the bootstrap priority chain: explicit config → DID document → .well-known/scp → peer relay discovery → fallback relay list. This closes the relay discovery open question from §00.\n\nThis story modifies crates/scp-transport/src/manager.rs to accept TransportConfig at initialization. Both this story and SCP-033 modify manager.rs — SCP-033 adds multi-relay routing on top of the TransportConfig foundation laid here.",
+      "description": "Implement TransportConfig and the relay bootstrap resolution chain as specified in \u00a718.5 and ADR-032. TransportConfig is the configuration struct passed to TransportManager at initialization, providing explicit relay URLs, optional bootstrap domain, and dedup configuration.\n\nThe ResolveRelays trait implements the bootstrap priority chain: explicit config \u2192 DID document \u2192 .well-known/scp \u2192 peer relay discovery \u2192 fallback relay list. This closes the relay discovery open question from \u00a700.\n\nThis story modifies crates/scp-transport/src/manager.rs to accept TransportConfig at initialization. Both this story and SCP-033 modify manager.rs \u2014 SCP-033 adds multi-relay routing on top of the TransportConfig foundation laid here.",
       "acceptanceCriteria": [
         "TransportConfig struct with fields: relay_urls (Vec<Url>), bootstrap_domain (Option<String>), dedup_cache_size (usize, default 10_000), dedup_cache_ttl (Duration, default 1 hour)",
         "ResolveRelays trait with async method resolve() -> Result<Vec<Url>, TransportError>",
         "DefaultRelayResolver implements ResolveRelays with the priority chain: (1) explicit relay_urls from TransportConfig, (2) DID document SCPRelay entries, (3) .well-known/scp relay URL from bootstrap_domain, (4) peer relay discovery from shared contexts, (5) hardcoded fallback relay list",
-        "Each priority level is tried in order — first level yielding at least one reachable relay is used",
+        "Each priority level is tried in order \u2014 first level yielding at least one reachable relay is used",
         "TransportManager::new accepts TransportConfig parameter",
         "TransportManager uses resolved relays for its adapter pool",
         "TransportConfig's dedup_cache_size and dedup_cache_ttl are wired into TransportManager's dedup cache configuration",
@@ -8011,7 +8011,7 @@
         "Unit test: resolve with empty relay_urls falls through to DID document resolution",
         "Unit test: resolve with bootstrap_domain fetches .well-known/scp and extracts relay URL",
         "Unit test: TransportManager::new accepts TransportConfig and initializes correctly",
-        "SDK logs a warning when relay resolution falls through to the hardcoded fallback relay list (§18.5.1 SHOULD)"
+        "SDK logs a warning when relay resolution falls through to the hardcoded fallback relay list (\u00a718.5.1 SHOULD)"
       ],
       "actionItems": [
         "Create crates/scp-transport/src/config.rs with TransportConfig struct",
@@ -8041,7 +8041,7 @@
       ],
       "details": {
         "bootstrapPriorityChain": "1. Explicit configuration (relay_urls in TransportConfig)\n2. DID document resolution (SCPRelay service entries)\n3. .well-known/scp resolution (from bootstrap_domain)\n4. Peer relay discovery (overlapping relay sets from shared contexts)\n5. Fallback relay list (hardcoded community relays)",
-        "fileConflictNote": "Both SCP-144 and SCP-033 modify crates/scp-transport/src/manager.rs. SCP-144 adds TransportConfig acceptance; SCP-033 completes multi-relay routing on top. Sequential execution required — SCP-033 is blocked by SCP-144.",
+        "fileConflictNote": "Both SCP-144 and SCP-033 modify crates/scp-transport/src/manager.rs. SCP-144 adds TransportConfig acceptance; SCP-033 completes multi-relay routing on top. Sequential execution required \u2014 SCP-033 is blocked by SCP-144.",
         "implementationNotes": "Language: Rust. Async runtime: tokio. The ResolveRelays trait is async to support network operations (DHT resolution, HTTP fetch). The DefaultRelayResolver holds references to IdentityManager (for DID resolution) and an HTTP client (for .well-known/scp fetch)."
       }
     },
@@ -8057,7 +8057,7 @@
         "crates/scp-node/src/lib.rs",
         "Cargo.toml"
       ],
-      "description": "Create the scp-node crate and implement the ApplicationNode builder as specified in §18.6 and ADR-032. ApplicationNode is a concrete SDK type that composes an SCP relay, an identity, and an HTTP server into a single deployable unit — the 'one box' deployment pattern.\n\nApplicationNode is NOT an HTTP framework — it exposes axum Router instances for composition with existing application code. The builder pattern wires: relay server start, DID publication with SCPRelay entries, storage initialization.\n\nComponents: SCP Relay (ADR-004 at wss://<domain>/scp/v1), Identity (§3 with SCPRelay service entries), Storage (ProtocolStore §17.4 backed by SqliteStorage §17.6), HTTP Server (.well-known/scp + WebSocket upgrade), TLS (ACME §18.6.3).",
+      "description": "Create the scp-node crate and implement the ApplicationNode builder as specified in \u00a718.6 and ADR-032. ApplicationNode is a concrete SDK type that composes an SCP relay, an identity, and an HTTP server into a single deployable unit \u2014 the 'one box' deployment pattern.\n\nApplicationNode is NOT an HTTP framework \u2014 it exposes axum Router instances for composition with existing application code. The builder pattern wires: relay server start, DID publication with SCPRelay entries, storage initialization.\n\nComponents: SCP Relay (ADR-004 at wss://<domain>/scp/v1), Identity (\u00a73 with SCPRelay service entries), Storage (ProtocolStore \u00a717.4 backed by SqliteStorage \u00a717.6), HTTP Server (.well-known/scp + WebSocket upgrade), TLS (ACME \u00a718.6.3).",
       "acceptanceCriteria": [
         "New crate scp-node exists at crates/scp-node/ with Cargo.toml",
         "scp-node is listed as workspace member in root Cargo.toml",
@@ -8072,8 +8072,8 @@
         "Unit test: builder requires domain to be set before build",
         "Unit test: builder with generate_identity creates a new DID",
         "Unit test: builder with explicit identity uses the provided identity",
-        "DID publication happens once on .build() — no continuous re-publishing (§18.6.4)",
-        "Relay started by ApplicationNode accepts connections from any SCP client, not just the local identity (§18.6.4)"
+        "DID publication happens once on .build() \u2014 no continuous re-publishing (\u00a718.6.4)",
+        "Relay started by ApplicationNode accepts connections from any SCP client, not just the local identity (\u00a718.6.4)"
       ],
       "actionItems": [
         "Create crates/scp-node/ directory with Cargo.toml",
@@ -8102,7 +8102,7 @@
       "details": {
         "builderSDKSurface": "```rust\npub struct ApplicationNodeBuilder {\n    domain: Option<String>,\n    identity: Option<Identity>,\n    storage: Option<SqliteStorage>,\n    bind_addr: Option<SocketAddr>,\n    acme_email: Option<String>,\n}\n\nimpl ApplicationNodeBuilder {\n    pub fn domain(mut self, domain: &str) -> Self;\n    pub fn identity(mut self, identity: Identity) -> Self;\n    pub fn generate_identity(mut self) -> Self;\n    pub fn storage(mut self, storage: SqliteStorage) -> Self;\n    pub fn bind_addr(mut self, addr: SocketAddr) -> Self;\n    pub fn acme_email(mut self, email: &str) -> Self;\n    pub async fn build(self) -> Result<ApplicationNode, NodeError>;\n}\n```",
         "buildSequence": "1. Initialize storage (create if needed)\n2. Load or generate identity\n3. Start relay server at wss://<domain>/scp/v1\n4. Publish DID document with SCPRelay entry pointing to relay URL\n5. Return ApplicationNode with handles to all components",
-        "invariants": "DID publication happens once on .build() and on relay URL changes. The node does not continuously re-publish. The relay is a standard SCP relay (ADR-004) accepting connections from any SCP client. The node's identity is a full SCP identity — it can create contexts, join contexts, send messages — it is a protocol participant, not just infrastructure."
+        "invariants": "DID publication happens once on .build() and on relay URL changes. The node does not continuously re-publish. The relay is a standard SCP relay (ADR-004) accepting connections from any SCP client. The node's identity is a full SCP identity \u2014 it can create contexts, join contexts, send messages \u2014 it is a protocol participant, not just infrastructure."
       },
       "result": "scp-node crate with ApplicationNode builder, type-state generics, NoOp placeholders. 9 tests."
     },
@@ -8116,10 +8116,10 @@
       "files": [
         "crates/scp-node/src/tls.rs"
       ],
-      "description": "Implement ACME-based TLS provisioning for ApplicationNode as specified in §18.6.3. TLS certificates are provisioned automatically via Let's Encrypt ACME HTTP-01 challenges. Certificates are stored in SqliteStorage, auto-renewed 30 days before expiry. TLS 1.3 required per §9.13.\n\nACME HTTP-01 requires port 80 reachability. DNS-01 alternative noted for environments without port 80 (home networks behind NAT, shared hosting).",
+      "description": "Implement ACME-based TLS provisioning for ApplicationNode as specified in \u00a718.6.3. TLS certificates are provisioned automatically via Let's Encrypt ACME HTTP-01 challenges. Certificates are stored in SqliteStorage, auto-renewed 30 days before expiry. TLS 1.3 required per \u00a79.13.\n\nACME HTTP-01 requires port 80 reachability. DNS-01 alternative noted for environments without port 80 (home networks behind NAT, shared hosting).",
       "acceptanceCriteria": [
         "ACME HTTP-01 challenge handler serves challenge response at http://<domain>/.well-known/acme-challenge/<token>",
-        "Certificate and private key stored in SqliteStorage (§17.6), encrypted at rest",
+        "Certificate and private key stored in SqliteStorage (\u00a717.6), encrypted at rest",
         "Certificates are loaded from storage on restart (no re-provisioning needed)",
         "Auto-renewal triggers 30 days before certificate expiry",
         "Renewal is background and non-disruptive (existing connections continue with old cert)",
@@ -8154,7 +8154,7 @@
       ],
       "details": {
         "acmeNote": "ACME HTTP-01 needs port 80 reachable. DNS-01 alternative for environments without port 80 (NAT, shared hosting). The operator configures DNS TXT records manually or via DNS API.",
-        "rustlsConfig": "Use rustls with TLS 1.3 minimum version. No TLS 1.2 fallback for relay connections (§9.13 allows TLS 1.2 only as fallback when 1.3 unavailable — ApplicationNode controls its own TLS config and can enforce 1.3)."
+        "rustlsConfig": "Use rustls with TLS 1.3 minimum version. No TLS 1.2 fallback for relay connections (\u00a79.13 allows TLS 1.2 only as fallback when 1.3 unavailable \u2014 ApplicationNode controls its own TLS config and can enforce 1.3)."
       },
       "result": "ACME TLS provisioning with HTTP-01 challenge, certificate storage, auto-renewal, TLS 1.3 enforcement. 16 tests."
     },
@@ -8169,18 +8169,18 @@
         "crates/scp-node/src/http.rs",
         "crates/scp-node/src/well_known.rs"
       ],
-      "description": "Implement the HTTP server components for ApplicationNode as specified in §18.6.2 and §18.3. ApplicationNode exposes axum Router instances that serve .well-known/scp and handle WebSocket upgrade at /scp/v1.\n\nnode.well_known_router() returns an axum Router serving GET /.well-known/scp with dynamically generated content from node state (DID, relay URL, registered broadcast contexts).\n\nnode.relay_router() returns an axum Router handling WebSocket upgrade at /scp/v1 and connecting to the node's relay server.\n\nnode.serve(app_router) binds HTTPS, merges application routes + .well-known route + relay route.",
+      "description": "Implement the HTTP server components for ApplicationNode as specified in \u00a718.6.2 and \u00a718.3. ApplicationNode exposes axum Router instances that serve .well-known/scp and handle WebSocket upgrade at /scp/v1.\n\nnode.well_known_router() returns an axum Router serving GET /.well-known/scp with dynamically generated content from node state (DID, relay URL, registered broadcast contexts).\n\nnode.relay_router() returns an axum Router handling WebSocket upgrade at /scp/v1 and connecting to the node's relay server.\n\nnode.serve(app_router) binds HTTPS, merges application routes + .well-known route + relay route.",
       "acceptanceCriteria": [
         "node.well_known_router() returns axum Router serving GET /.well-known/scp",
         ".well-known/scp response is dynamically generated from node state: reads node's DID, relay URL, registered broadcast contexts",
-        ".well-known/scp response matches WellKnownScp format (§18.3.1)",
+        ".well-known/scp response matches WellKnownScp format (\u00a718.3.1)",
         ".well-known/scp response Content-Type is application/json",
         "node.relay_router() returns axum Router handling WebSocket upgrade at /scp/v1",
         "WebSocket upgrade at /scp/v1 connects to the node's relay server",
         "node.serve(app_router) binds HTTPS on configured address",
-        "node.serve merges application routes + .well-known route + relay route — all accessible on same HTTPS listener",
+        "node.serve merges application routes + .well-known route + relay route \u2014 all accessible on same HTTPS listener",
         "Custom application routes passed to serve() are accessible alongside SCP routes",
-        "Registering a broadcast context on the node causes it to appear in subsequent GET /.well-known/scp responses automatically (§18.6.4)",
+        "Registering a broadcast context on the node causes it to appear in subsequent GET /.well-known/scp responses automatically (\u00a718.6.4)",
         "Unit test: GET /.well-known/scp returns valid WellKnownScp JSON",
         "Unit test: WebSocket upgrade at /scp/v1 establishes connection",
         "Unit test: custom app routes merge correctly with SCP routes"
@@ -8188,9 +8188,9 @@
       "actionItems": [
         "Create crates/scp-node/src/http.rs for HTTP routing logic",
         "Create crates/scp-node/src/well_known.rs for .well-known/scp generation from node state",
-        "Implement well_known_router() — axum GET handler that constructs WellKnownScp from node's DID, relay URL, and registered contexts",
-        "Implement relay_router() — axum WebSocket upgrade handler at /scp/v1 that bridges to relay server",
-        "Implement serve(app_router) — merge routers, bind TLS listener, run axum server",
+        "Implement well_known_router() \u2014 axum GET handler that constructs WellKnownScp from node's DID, relay URL, and registered contexts",
+        "Implement relay_router() \u2014 axum WebSocket upgrade handler at /scp/v1 that bridges to relay server",
+        "Implement serve(app_router) \u2014 merge routers, bind TLS listener, run axum server",
         "Write unit and integration tests"
       ],
       "blockedBy": [
@@ -8208,7 +8208,7 @@
         }
       ],
       "details": {
-        "routeMerging": "node.serve(app_router) merges three routers:\n1. app_router — application-provided routes\n2. well_known_router — GET /.well-known/scp\n3. relay_router — WebSocket upgrade at /scp/v1\n\nSCP routes take precedence for /.well-known/scp and /scp/v1 paths. All other paths route to app_router.",
+        "routeMerging": "node.serve(app_router) merges three routers:\n1. app_router \u2014 application-provided routes\n2. well_known_router \u2014 GET /.well-known/scp\n3. relay_router \u2014 WebSocket upgrade at /scp/v1\n\nSCP routes take precedence for /.well-known/scp and /scp/v1 paths. All other paths route to app_router.",
         "dynamicGeneration": ".well-known/scp is generated on each request from current node state. Registering a broadcast context on the node automatically makes it appear in future .well-known/scp responses."
       },
       "result": "HTTP server with .well-known/scp and WebSocket relay upgrade at /scp/v1. Route merging with serve()."
@@ -8223,24 +8223,24 @@
       "files": [
         "crates/scp-node/tests/integration.rs"
       ],
-      "description": "End-to-end integration tests for the addressability and deployment layer as specified in §18.7, §18.8, and ADR-032.\n\nTest scenarios:\n1. ApplicationNode starts → DID published → .well-known/scp reachable → relay accepts connections\n2. Client discovers relay via .well-known/scp → connects → subscribes\n3. Client resolves operator DID → finds SCPRelay service entry → connects\n4. scp:// URI roundtrip through creation and parsing",
+      "description": "End-to-end integration tests for the addressability and deployment layer as specified in \u00a718.7, \u00a718.8, and ADR-032.\n\nTest scenarios:\n1. ApplicationNode starts \u2192 DID published \u2192 .well-known/scp reachable \u2192 relay accepts connections\n2. Client discovers relay via .well-known/scp \u2192 connects \u2192 subscribes\n3. Client resolves operator DID \u2192 finds SCPRelay service entry \u2192 connects\n4. scp:// URI roundtrip through creation and parsing",
       "acceptanceCriteria": [
         "Test: ApplicationNode::builder().domain(test_domain).generate_identity().build() succeeds",
         "Test: After build, DID is published and resolvable with SCPRelay service entries",
         "Test: After build, GET /.well-known/scp returns valid JSON with correct DID and relay URL",
         "Test: After build, WebSocket connection to /scp/v1 succeeds and relay accepts SUBSCRIBE",
-        "Test: Client fetches .well-known/scp → extracts relay URL → connects → subscribes to routing_id → receives published message",
-        "Test: Client resolves operator DID via DHT → extracts SCPRelay service entries → connects to relay URL",
-        "Test: ScpUri created for a context → serialized → parsed → all fields preserved",
+        "Test: Client fetches .well-known/scp \u2192 extracts relay URL \u2192 connects \u2192 subscribes to routing_id \u2192 receives published message",
+        "Test: Client resolves operator DID via DHT \u2192 extracts SCPRelay service entries \u2192 connects to relay URL",
+        "Test: ScpUri created for a context \u2192 serialized \u2192 parsed \u2192 all fields preserved",
         "All 4 test scenarios pass end-to-end"
       ],
       "actionItems": [
         "Create crates/scp-node/tests/integration.rs",
-        "Implement test 1: ApplicationNode full lifecycle (build → verify DID → verify .well-known → verify relay)",
+        "Implement test 1: ApplicationNode full lifecycle (build \u2192 verify DID \u2192 verify .well-known \u2192 verify relay)",
         "Implement test 2: Client discovery via .well-known/scp flow",
         "Implement test 3: Client discovery via DID resolution flow",
         "Implement test 4: ScpUri roundtrip test",
-        "Use scp-testing harness (§16) for in-memory relay and simulated DHT where needed"
+        "Use scp-testing harness (\u00a716) for in-memory relay and simulated DHT where needed"
       ],
       "blockedBy": [
         "SCP-145",
@@ -8263,8 +8263,8 @@
         }
       ],
       "details": {
-        "testInfrastructure": "Use scp-testing harness (§16) for deterministic testing. InMemoryRelay for relay operations, SimulatedClock for time control. Mock ACME server for TLS provisioning tests. Mock DHT for DID resolution tests.",
-        "testScenarios": "1. Full ApplicationNode lifecycle: build → DID published → .well-known reachable → relay accepts connections\n2. Client discovery via .well-known/scp: fetch → connect → subscribe\n3. Client discovery via DID resolution: resolve DID → extract SCPRelay → connect\n4. scp:// URI roundtrip: create → serialize → parse → verify fields"
+        "testInfrastructure": "Use scp-testing harness (\u00a716) for deterministic testing. InMemoryRelay for relay operations, SimulatedClock for time control. Mock ACME server for TLS provisioning tests. Mock DHT for DID resolution tests.",
+        "testScenarios": "1. Full ApplicationNode lifecycle: build \u2192 DID published \u2192 .well-known reachable \u2192 relay accepts connections\n2. Client discovery via .well-known/scp: fetch \u2192 connect \u2192 subscribe\n3. Client discovery via DID resolution: resolve DID \u2192 extract SCPRelay \u2192 connect\n4. scp:// URI roundtrip: create \u2192 serialize \u2192 parse \u2192 verify fields"
       },
       "result": "Addressability integration tests created at crates/scp-node/tests/integration.rs. 4 scenarios: ApplicationNode lifecycle, .well-known/scp discovery, DID resolution, scp:// URI roundtrip."
     },
@@ -8281,41 +8281,41 @@
         "crates/scp-core/src/context/params.rs",
         "crates/scp-core/src/context/mod.rs"
       ],
-      "description": "Add all core economic types from §19.1.1 and §19.3 to the economy module and wire them into context params.\n\n§19.1.1 Core Economic Types:\n```rust\n/// Amount in smallest currency unit. USD: cents (1 USD = 100). BTC: satoshis (1 BTC = 100_000_000).\n/// Always integer — no floating-point in economic calculations. Cross-party determinism guaranteed.\n/// Both payer and receiver evaluate the same Amount from the same inputs with identical results.\npub struct Amount(pub u64);\n\n/// ISO 4217 currency code (USD, EUR) or protocol-defined code (BTC, SAT, SOL, USDC).\npub struct CurrencyCode(pub [u8; 4]); // 3-4 character code, null-padded\n\n/// Fixed-point coefficient with 6 decimal places of precision.\n/// Value = raw / 1_000_000. Example: 1_500_000 = 1.5, 100 = 0.0001.\n/// Used in pricing formulas where fractional multipliers are needed.\n/// Both sides evaluate identically — no IEEE 754 variance.\npub struct Coefficient(pub i64);\n\n/// Subscription cost for recurring payments.\npub struct SubscriptionCost {\n    pub amount: Amount,\n    pub period: SubscriptionPeriod,\n    pub currency: CurrencyCode,\n}\n\npub enum SubscriptionPeriod {\n    Daily,\n    Weekly,\n    Monthly,\n    Custom { seconds: u64 },\n}\n```\n\n§19.3 Economic Policy:\n```rust\npub struct EconomicPolicy {\n    pub locked: bool,                              // true = immutable, false = governed (default)\n    pub cost_schedule: CostSchedule,\n    pub payment_adapters: Vec<PaymentAdapterRef>,  // accepted payment methods\n    pub pricing_formula: Option<PricingFormula>,    // for dynamic pricing (§19.4)\n    pub payee: DID,                                // who receives payments\n}\n\npub struct CostSchedule {\n    pub per_message: Option<Amount>,\n    pub per_tool_invoke: Option<Amount>,            // default for tools without own cost\n    pub per_join: Option<Amount>,                   // one-time membership cost\n    pub per_period: Option<SubscriptionCost>,       // recurring\n    pub per_byte_stored: Option<Amount>,            // storage costs\n}\n```\n\n§19.4 Dynamic Pricing types:\n```rust\npub struct PricingFormula {\n    pub base_cost: Amount,\n    pub variables: Vec<PricingVariable>,\n    pub cap: Option<Amount>,     // max cost regardless of formula\n    pub floor: Option<Amount>,   // min cost regardless of formula\n}\n\npub enum PricingVariable {\n    /// Linear multiplier: cost += (coefficient.0 * metric_value) / 1_000_000\n    Linear { metric: PricingMetric, coefficient: Coefficient },\n    /// Step function: cost += additional when metric_value exceeds threshold.\n    Step { metric: PricingMetric, thresholds: Vec<(u64, Amount)> },\n}\n\npub enum PricingMetric {\n    ContextMessageRate,    // messages/min in this context\n    MemberCount,           // current member count\n    RelayQueueDepth,       // relay-level only\n    TimeOfDay,             // UTC hour (0-23), enables off-peak pricing\n    SenderVelocity,        // sender's messages in sliding window (anti-spam)\n    StorageUsage,          // context storage in bytes\n}\n```\n\nContextParams extended with economic_policy: Option<EconomicPolicy>. Patches SCP-018 with economic governance support.",
+      "description": "Add all core economic types from \u00a719.1.1 and \u00a719.3 to the economy module and wire them into context params.\n\n\u00a719.1.1 Core Economic Types:\n```rust\n/// Amount in smallest currency unit. USD: cents (1 USD = 100). BTC: satoshis (1 BTC = 100_000_000).\n/// Always integer \u2014 no floating-point in economic calculations. Cross-party determinism guaranteed.\n/// Both payer and receiver evaluate the same Amount from the same inputs with identical results.\npub struct Amount(pub u64);\n\n/// ISO 4217 currency code (USD, EUR) or protocol-defined code (BTC, SAT, SOL, USDC).\npub struct CurrencyCode(pub [u8; 4]); // 3-4 character code, null-padded\n\n/// Fixed-point coefficient with 6 decimal places of precision.\n/// Value = raw / 1_000_000. Example: 1_500_000 = 1.5, 100 = 0.0001.\n/// Used in pricing formulas where fractional multipliers are needed.\n/// Both sides evaluate identically \u2014 no IEEE 754 variance.\npub struct Coefficient(pub i64);\n\n/// Subscription cost for recurring payments.\npub struct SubscriptionCost {\n    pub amount: Amount,\n    pub period: SubscriptionPeriod,\n    pub currency: CurrencyCode,\n}\n\npub enum SubscriptionPeriod {\n    Daily,\n    Weekly,\n    Monthly,\n    Custom { seconds: u64 },\n}\n```\n\n\u00a719.3 Economic Policy:\n```rust\npub struct EconomicPolicy {\n    pub locked: bool,                              // true = immutable, false = governed (default)\n    pub cost_schedule: CostSchedule,\n    pub payment_adapters: Vec<PaymentAdapterRef>,  // accepted payment methods\n    pub pricing_formula: Option<PricingFormula>,    // for dynamic pricing (\u00a719.4)\n    pub payee: DID,                                // who receives payments\n}\n\npub struct CostSchedule {\n    pub per_message: Option<Amount>,\n    pub per_tool_invoke: Option<Amount>,            // default for tools without own cost\n    pub per_join: Option<Amount>,                   // one-time membership cost\n    pub per_period: Option<SubscriptionCost>,       // recurring\n    pub per_byte_stored: Option<Amount>,            // storage costs\n}\n```\n\n\u00a719.4 Dynamic Pricing types:\n```rust\npub struct PricingFormula {\n    pub base_cost: Amount,\n    pub variables: Vec<PricingVariable>,\n    pub cap: Option<Amount>,     // max cost regardless of formula\n    pub floor: Option<Amount>,   // min cost regardless of formula\n}\n\npub enum PricingVariable {\n    /// Linear multiplier: cost += (coefficient.0 * metric_value) / 1_000_000\n    Linear { metric: PricingMetric, coefficient: Coefficient },\n    /// Step function: cost += additional when metric_value exceeds threshold.\n    Step { metric: PricingMetric, thresholds: Vec<(u64, Amount)> },\n}\n\npub enum PricingMetric {\n    ContextMessageRate,    // messages/min in this context\n    MemberCount,           // current member count\n    RelayQueueDepth,       // relay-level only\n    TimeOfDay,             // UTC hour (0-23), enables off-peak pricing\n    SenderVelocity,        // sender's messages in sliding window (anti-spam)\n    StorageUsage,          // context storage in bytes\n}\n```\n\nContextParams extended with economic_policy: Option<EconomicPolicy>. Patches SCP-018 with economic governance support.",
       "acceptanceCriteria": [
-        "Amount struct defined as Amount(pub u64) — smallest currency unit, integer-only",
-        "CurrencyCode struct defined as CurrencyCode(pub [u8; 4]) — 3-4 character code, null-padded",
-        "Coefficient struct defined as Coefficient(pub i64) — fixed-point with 6 decimal places, value = raw / 1_000_000",
+        "Amount struct defined as Amount(pub u64) \u2014 smallest currency unit, integer-only",
+        "CurrencyCode struct defined as CurrencyCode(pub [u8; 4]) \u2014 3-4 character code, null-padded",
+        "Coefficient struct defined as Coefficient(pub i64) \u2014 fixed-point with 6 decimal places, value = raw / 1_000_000",
         "SubscriptionCost struct defined with fields: amount (Amount), period (SubscriptionPeriod), currency (CurrencyCode)",
         "SubscriptionPeriod enum defined with variants: Daily, Weekly, Monthly, Custom { seconds: u64 }",
-        "EconomicPolicy struct defined with field: locked (bool) — true = immutable, false = governed (default)",
+        "EconomicPolicy struct defined with field: locked (bool) \u2014 true = immutable, false = governed (default)",
         "EconomicPolicy struct defined with field: cost_schedule (CostSchedule)",
         "EconomicPolicy struct defined with field: payment_adapters (Vec<PaymentAdapterRef>)",
         "EconomicPolicy struct defined with field: pricing_formula (Option<PricingFormula>)",
         "EconomicPolicy struct defined with field: payee (DID)",
         "CostSchedule struct defined with field: per_message (Option<Amount>)",
-        "CostSchedule struct defined with field: per_tool_invoke (Option<Amount>) — default for tools without own cost",
-        "CostSchedule struct defined with field: per_join (Option<Amount>) — one-time membership cost",
-        "CostSchedule struct defined with field: per_period (Option<SubscriptionCost>) — recurring",
-        "CostSchedule struct defined with field: per_byte_stored (Option<Amount>) — storage costs",
+        "CostSchedule struct defined with field: per_tool_invoke (Option<Amount>) \u2014 default for tools without own cost",
+        "CostSchedule struct defined with field: per_join (Option<Amount>) \u2014 one-time membership cost",
+        "CostSchedule struct defined with field: per_period (Option<SubscriptionCost>) \u2014 recurring",
+        "CostSchedule struct defined with field: per_byte_stored (Option<Amount>) \u2014 storage costs",
         "PricingFormula struct defined with field: base_cost (Amount)",
         "PricingFormula struct defined with field: variables (Vec<PricingVariable>)",
-        "PricingFormula struct defined with field: cap (Option<Amount>) — max cost regardless of formula",
-        "PricingFormula struct defined with field: floor (Option<Amount>) — min cost regardless of formula",
+        "PricingFormula struct defined with field: cap (Option<Amount>) \u2014 max cost regardless of formula",
+        "PricingFormula struct defined with field: floor (Option<Amount>) \u2014 min cost regardless of formula",
         "PricingVariable enum defined with variant: Linear { metric: PricingMetric, coefficient: Coefficient }",
         "PricingVariable enum defined with variant: Step { metric: PricingMetric, thresholds: Vec<(u64, Amount)> }",
-        "PricingMetric enum defined with variant: ContextMessageRate — messages/min in this context",
-        "PricingMetric enum defined with variant: MemberCount — current member count",
-        "PricingMetric enum defined with variant: RelayQueueDepth — relay-level only",
-        "PricingMetric enum defined with variant: TimeOfDay — UTC hour (0-23), enables off-peak pricing",
-        "PricingMetric enum defined with variant: SenderVelocity — sender's messages in sliding window (anti-spam)",
-        "PricingMetric enum defined with variant: StorageUsage — context storage in bytes",
+        "PricingMetric enum defined with variant: ContextMessageRate \u2014 messages/min in this context",
+        "PricingMetric enum defined with variant: MemberCount \u2014 current member count",
+        "PricingMetric enum defined with variant: RelayQueueDepth \u2014 relay-level only",
+        "PricingMetric enum defined with variant: TimeOfDay \u2014 UTC hour (0-23), enables off-peak pricing",
+        "PricingMetric enum defined with variant: SenderVelocity \u2014 sender's messages in sliding window (anti-spam)",
+        "PricingMetric enum defined with variant: StorageUsage \u2014 context storage in bytes",
         "PaymentAdapterRef type defined (string identifier for accepted payment adapter)",
         "ContextParams extended with economic_policy: Option<EconomicPolicy>",
         "All types derive Clone, Debug, Serialize, Deserialize",
-        "No f64 in any type — all economic types use integer arithmetic only",
+        "No f64 in any type \u2014 all economic types use integer arithmetic only",
         "Unit test: Amount arithmetic (addition, comparison)",
-        "Unit test: Coefficient evaluation — (coefficient.0 * metric_value) / 1_000_000 produces correct results",
+        "Unit test: Coefficient evaluation \u2014 (coefficient.0 * metric_value) / 1_000_000 produces correct results",
         "Unit test: ContextParams serialize/deserialize roundtrip with economic_policy present and absent",
         "Unit test: CurrencyCode from string (\"USD\\0\", \"BTC\\0\", \"USDC\") roundtrip"
       ],
@@ -8356,14 +8356,14 @@
       ],
       "details": {
         "Patches": "SCP-018",
-        "Integer arithmetic rationale": "IEEE 754 floating-point arithmetic is non-associative — (a + b) + c != a + (b + c) in general. When payer and receiver independently evaluate a pricing formula, f64 coefficients can produce different results depending on evaluation order, platform, or compiler optimizations. Integer arithmetic is deterministic across all platforms. This follows the pattern established by Stripe (amounts in cents), Bitcoin (amounts in satoshis), and Solana (amounts in lamports).",
+        "Integer arithmetic rationale": "IEEE 754 floating-point arithmetic is non-associative \u2014 (a + b) + c != a + (b + c) in general. When payer and receiver independently evaluate a pricing formula, f64 coefficients can produce different results depending on evaluation order, platform, or compiler optimizations. Integer arithmetic is deterministic across all platforms. This follows the pattern established by Stripe (amounts in cents), Bitcoin (amounts in satoshis), and Solana (amounts in lamports).",
         "Fixed-point coefficient rationale": "Pricing formulas need fractional multipliers (e.g., 'cost increases by 0.5x per 100 messages/min'). Coefficient provides 6 decimal places of precision using integer arithmetic. Evaluation: (coefficient.0 * metric_value) / 1_000_000. Both sides compute the same result."
       },
-      "result": "All economic types from §19.1.1, §19.3, §19.4 implemented. Integer-only arithmetic. ContextParams extended with economic_policy. 34 economy tests."
+      "result": "All economic types from \u00a719.1.1, \u00a719.3, \u00a719.4 implemented. Integer-only arithmetic. ContextParams extended with economic_policy. 34 economy tests."
     },
     {
       "id": "SCP-150",
-      "title": "Write §19 spec, ADR-033, cross-refs, and sketch additions",
+      "title": "Write \u00a719 spec, ADR-033, cross-refs, and sketch additions",
       "gate": "gate-econ",
       "priority": "P0",
       "severity": "critical",
@@ -8378,12 +8378,12 @@
         ".docs/specs/18-addressability-and-deployment.md",
         ".docs/specs/00-open-questions.md"
       ],
-      "description": "Write complete §19 Economic Governance spec, ADR-033, cross-references, and SCP.Economy.* sketch additions.",
+      "description": "Write complete \u00a719 Economic Governance spec, ADR-033, cross-references, and SCP.Economy.* sketch additions.",
       "acceptanceCriteria": [
-        "§19.1-§19.14 written",
+        "\u00a719.1-\u00a719.14 written",
         "ADR-033 appended",
         "SCP.Economy.* appended to sketch",
-        "Cross-references in §5/§7/§9/§18/§00"
+        "Cross-references in \u00a75/\u00a77/\u00a79/\u00a718/\u00a700"
       ],
       "actionItems": [
         "Create spec, ADR, sketch, cross-refs"
@@ -8410,7 +8410,7 @@
         "crates/scp-core/src/economy/mod.rs",
         "crates/scp-testing/src/conformance/payment.rs"
       ],
-      "description": "Implement the PaymentAdapter trait (§19.2.1), AdapterCapabilities, all supporting types, and the payment_adapter_conformance!() macro (§19.2.6).\n\n§19.2.1 Adapter Trait:\n```rust\n#[async_trait]\npub trait PaymentAdapter: Send + Sync {\n    fn adapter_id(&self) -> &str;\n    fn capabilities(&self) -> AdapterCapabilities;\n\n    async fn authorize(\n        &self,\n        payer: &DID,\n        payee: &DID,\n        amount: Amount,\n        currency: CurrencyCode,\n        metadata: PaymentMetadata,\n    ) -> Result<PaymentAuthorization, PaymentError>;\n\n    async fn capture(\n        &self,\n        auth: &PaymentAuthorization,\n    ) -> Result<PaymentReceipt, PaymentError>;\n\n    async fn void(\n        &self,\n        auth: &PaymentAuthorization,\n    ) -> Result<(), PaymentError>;\n\n    async fn verify(\n        &self,\n        receipt: &PaymentReceipt,\n    ) -> Result<VerificationResult, PaymentError>;\n\n    async fn refund(\n        &self,\n        receipt: &PaymentReceipt,\n        amount: Option<Amount>,\n    ) -> Result<RefundConfirmation, PaymentError>;\n}\n```\n\n§19.2.1 AdapterCapabilities:\n```rust\npub struct AdapterCapabilities {\n    pub supported_currencies: Vec<CurrencyCode>,\n    pub supports_streaming: bool,          // continuous payment (ILP/STREAM-style)\n    pub supports_batch_auth: bool,         // authorize N, capture incrementally\n    pub supports_single_step: bool,        // skip authorize, capture directly (low latency)\n    pub min_amount: Option<Amount>,\n    pub max_amount: Option<Amount>,\n    pub typical_settlement_ms: u64,        // expected settlement latency\n    pub requires_facilitator: bool,        // true for x402 (facilitator verifies/settles)\n}\n```\n\n§19.2.6 Conformance Testing:\npayment_adapter_conformance!() macro generates 8 test cases:\n1. Authorize/capture roundtrip\n2. Authorize/void roundtrip\n3. Double-capture rejection\n4. Insufficient balance handling\n5. Verify roundtrip (receipt -> verification)\n6. Currency mismatch rejection\n7. Concurrent authorization isolation\n8. Refund against captured receipt",
+      "description": "Implement the PaymentAdapter trait (\u00a719.2.1), AdapterCapabilities, all supporting types, and the payment_adapter_conformance!() macro (\u00a719.2.6).\n\n\u00a719.2.1 Adapter Trait:\n```rust\n#[async_trait]\npub trait PaymentAdapter: Send + Sync {\n    fn adapter_id(&self) -> &str;\n    fn capabilities(&self) -> AdapterCapabilities;\n\n    async fn authorize(\n        &self,\n        payer: &DID,\n        payee: &DID,\n        amount: Amount,\n        currency: CurrencyCode,\n        metadata: PaymentMetadata,\n    ) -> Result<PaymentAuthorization, PaymentError>;\n\n    async fn capture(\n        &self,\n        auth: &PaymentAuthorization,\n    ) -> Result<PaymentReceipt, PaymentError>;\n\n    async fn void(\n        &self,\n        auth: &PaymentAuthorization,\n    ) -> Result<(), PaymentError>;\n\n    async fn verify(\n        &self,\n        receipt: &PaymentReceipt,\n    ) -> Result<VerificationResult, PaymentError>;\n\n    async fn refund(\n        &self,\n        receipt: &PaymentReceipt,\n        amount: Option<Amount>,\n    ) -> Result<RefundConfirmation, PaymentError>;\n}\n```\n\n\u00a719.2.1 AdapterCapabilities:\n```rust\npub struct AdapterCapabilities {\n    pub supported_currencies: Vec<CurrencyCode>,\n    pub supports_streaming: bool,          // continuous payment (ILP/STREAM-style)\n    pub supports_batch_auth: bool,         // authorize N, capture incrementally\n    pub supports_single_step: bool,        // skip authorize, capture directly (low latency)\n    pub min_amount: Option<Amount>,\n    pub max_amount: Option<Amount>,\n    pub typical_settlement_ms: u64,        // expected settlement latency\n    pub requires_facilitator: bool,        // true for x402 (facilitator verifies/settles)\n}\n```\n\n\u00a719.2.6 Conformance Testing:\npayment_adapter_conformance!() macro generates 8 test cases:\n1. Authorize/capture roundtrip\n2. Authorize/void roundtrip\n3. Double-capture rejection\n4. Insufficient balance handling\n5. Verify roundtrip (receipt -> verification)\n6. Currency mismatch rejection\n7. Concurrent authorization isolation\n8. Refund against captured receipt",
       "acceptanceCriteria": [
         "PaymentAdapter trait defined with #[async_trait] and Send + Sync bounds",
         "PaymentAdapter::adapter_id(&self) -> &str method defined",
@@ -8421,33 +8421,33 @@
         "PaymentAdapter::verify(&self, receipt: &PaymentReceipt) -> Result<VerificationResult, PaymentError> method defined",
         "PaymentAdapter::refund(&self, receipt: &PaymentReceipt, amount: Option<Amount>) -> Result<RefundConfirmation, PaymentError> method defined",
         "AdapterCapabilities struct field: supported_currencies (Vec<CurrencyCode>)",
-        "AdapterCapabilities struct field: supports_streaming (bool) — continuous payment (ILP/STREAM-style)",
-        "AdapterCapabilities struct field: supports_batch_auth (bool) — authorize N, capture incrementally",
-        "AdapterCapabilities struct field: supports_single_step (bool) — skip authorize, capture directly",
+        "AdapterCapabilities struct field: supports_streaming (bool) \u2014 continuous payment (ILP/STREAM-style)",
+        "AdapterCapabilities struct field: supports_batch_auth (bool) \u2014 authorize N, capture incrementally",
+        "AdapterCapabilities struct field: supports_single_step (bool) \u2014 skip authorize, capture directly",
         "AdapterCapabilities struct field: min_amount (Option<Amount>)",
         "AdapterCapabilities struct field: max_amount (Option<Amount>)",
-        "AdapterCapabilities struct field: typical_settlement_ms (u64) — expected settlement latency",
-        "AdapterCapabilities struct field: requires_facilitator (bool) — true for x402",
+        "AdapterCapabilities struct field: typical_settlement_ms (u64) \u2014 expected settlement latency",
+        "AdapterCapabilities struct field: requires_facilitator (bool) \u2014 true for x402",
         "PaymentAuthorization type defined with authorization state for capture/void",
         "PaymentError enum defined with variants for insufficient balance, currency mismatch, authorization expired, double capture, adapter-specific errors",
         "VerificationResult type defined with verification outcome fields",
         "RefundConfirmation type defined with refund details",
         "PaymentMetadata type defined for action metadata passed to authorize",
         "payment_adapter_conformance!() macro defined in scp-testing crate",
-        "Conformance test 1: Authorize/capture roundtrip — authorize returns PaymentAuthorization, capture returns PaymentReceipt",
-        "Conformance test 2: Authorize/void roundtrip — authorize then void succeeds, subsequent capture fails",
-        "Conformance test 3: Double-capture rejection — second capture of same authorization returns error",
-        "Conformance test 4: Insufficient balance handling — authorize with amount exceeding balance returns appropriate PaymentError",
-        "Conformance test 5: Verify roundtrip — capture receipt then verify returns valid VerificationResult",
-        "Conformance test 6: Currency mismatch rejection — authorize with unsupported currency returns PaymentError",
-        "Conformance test 7: Concurrent authorization isolation — two concurrent authorizations do not interfere with each other",
-        "Conformance test 8: Refund against captured receipt — refund of captured receipt succeeds and verify reflects refund",
+        "Conformance test 1: Authorize/capture roundtrip \u2014 authorize returns PaymentAuthorization, capture returns PaymentReceipt",
+        "Conformance test 2: Authorize/void roundtrip \u2014 authorize then void succeeds, subsequent capture fails",
+        "Conformance test 3: Double-capture rejection \u2014 second capture of same authorization returns error",
+        "Conformance test 4: Insufficient balance handling \u2014 authorize with amount exceeding balance returns appropriate PaymentError",
+        "Conformance test 5: Verify roundtrip \u2014 capture receipt then verify returns valid VerificationResult",
+        "Conformance test 6: Currency mismatch rejection \u2014 authorize with unsupported currency returns PaymentError",
+        "Conformance test 7: Concurrent authorization isolation \u2014 two concurrent authorizations do not interfere with each other",
+        "Conformance test 8: Refund against captured receipt \u2014 refund of captured receipt succeeds and verify reflects refund",
         "All types Send + Sync",
         "No unwrap() or expect() in library code"
       ],
       "actionItems": [
         "Create crates/scp-core/src/economy/adapter.rs with PaymentAdapter trait definition",
-        "Define AdapterCapabilities struct with all 8 fields from §19.2.1",
+        "Define AdapterCapabilities struct with all 8 fields from \u00a719.2.1",
         "Define PaymentAuthorization type (opaque authorization handle with metadata)",
         "Define PaymentError enum with all variant types (InsufficientBalance, CurrencyMismatch, AuthorizationExpired, DoubleCaptureRejected, AdapterSpecific(String))",
         "Define VerificationResult type (valid/invalid with details)",
@@ -8484,9 +8484,9 @@
       ],
       "details": {
         "ADR-033 criterion 1": "PaymentAdapter trait compiles with 5 async methods: authorize, capture, void, verify, refund.",
-        "ADR-033 criterion 2": "AdapterCapabilities struct includes all fields from §19.2.1: supported_currencies, supports_streaming, supports_batch_auth, supports_single_step, min_amount, max_amount, typical_settlement_ms, requires_facilitator.",
-        "ADR-033 criterion 3": "payment_adapter_conformance!() macro generates 8 test cases matching §19.2.6: authorize/capture roundtrip, authorize/void roundtrip, double-capture rejection, insufficient balance, verify roundtrip, currency mismatch, concurrent isolation, refund.",
-        "Adapter pattern": "Follows the transport adapter pattern (ADR-005, §16.12.1): a trait that any payment rail can implement, a conformance macro that validates correctness, and a reference adapter for testing."
+        "ADR-033 criterion 2": "AdapterCapabilities struct includes all fields from \u00a719.2.1: supported_currencies, supports_streaming, supports_batch_auth, supports_single_step, min_amount, max_amount, typical_settlement_ms, requires_facilitator.",
+        "ADR-033 criterion 3": "payment_adapter_conformance!() macro generates 8 test cases matching \u00a719.2.6: authorize/capture roundtrip, authorize/void roundtrip, double-capture rejection, insufficient balance, verify roundtrip, currency mismatch, concurrent isolation, refund.",
+        "Adapter pattern": "Follows the transport adapter pattern (ADR-005, \u00a716.12.1): a trait that any payment rail can implement, a conformance macro that validates correctness, and a reference adapter for testing."
       },
       "result": "PaymentAdapter trait, AdapterCapabilities, and payment_adapter_conformance!() macro implemented. 8 conformance test cases. Files: economy/adapter.rs, scp-testing/conformance/payment.rs."
     },
@@ -8501,11 +8501,11 @@
         "crates/scp-testing/src/test_adapter.rs",
         "crates/scp-testing/src/lib.rs"
       ],
-      "description": "Implement TestAdapter — the in-memory reference payment adapter (§19.2.6). No real money. Ships with the SDK (in scp-testing crate), not with production adapters. Thread-safe (Arc<Mutex<...>> or similar). Must pass all 8 conformance tests from payment_adapter_conformance!().\n\nFrom §19.2.6:\nReference adapter: TestAdapter — in-memory ledger, no real money, ships with SDK. Protocol does NOT ship production adapters (payment rails are external dependencies with licensing/compliance considerations).\n\nTestAdapter behavior:\n- Maintains an in-memory ledger tracking balances per DID\n- authorize() checks payer balance >= amount, creates a hold (reserves funds)\n- capture() moves held funds from payer to payee, returns PaymentReceipt with adapter_proof (deterministic bytes for testing)\n- void() releases held funds back to payer\n- verify() checks that the receipt's adapter_proof matches the internal ledger record\n- refund() moves funds from payee back to payer (full or partial), updates ledger\n- Double-capture: second capture of same authorization returns PaymentError\n- Insufficient balance: authorize with amount > balance returns PaymentError\n- Currency mismatch: authorize with unsupported currency returns PaymentError\n- Concurrent authorization: multiple concurrent authorizations against same payer correctly track separate holds\n- Thread-safe: all operations safe to call from multiple threads (Arc<Mutex<Ledger>> or similar pattern)\n- Supports initial balance seeding for test setup (e.g., seed_balance(did, amount, currency))",
+      "description": "Implement TestAdapter \u2014 the in-memory reference payment adapter (\u00a719.2.6). No real money. Ships with the SDK (in scp-testing crate), not with production adapters. Thread-safe (Arc<Mutex<...>> or similar). Must pass all 8 conformance tests from payment_adapter_conformance!().\n\nFrom \u00a719.2.6:\nReference adapter: TestAdapter \u2014 in-memory ledger, no real money, ships with SDK. Protocol does NOT ship production adapters (payment rails are external dependencies with licensing/compliance considerations).\n\nTestAdapter behavior:\n- Maintains an in-memory ledger tracking balances per DID\n- authorize() checks payer balance >= amount, creates a hold (reserves funds)\n- capture() moves held funds from payer to payee, returns PaymentReceipt with adapter_proof (deterministic bytes for testing)\n- void() releases held funds back to payer\n- verify() checks that the receipt's adapter_proof matches the internal ledger record\n- refund() moves funds from payee back to payer (full or partial), updates ledger\n- Double-capture: second capture of same authorization returns PaymentError\n- Insufficient balance: authorize with amount > balance returns PaymentError\n- Currency mismatch: authorize with unsupported currency returns PaymentError\n- Concurrent authorization: multiple concurrent authorizations against same payer correctly track separate holds\n- Thread-safe: all operations safe to call from multiple threads (Arc<Mutex<Ledger>> or similar pattern)\n- Supports initial balance seeding for test setup (e.g., seed_balance(did, amount, currency))",
       "acceptanceCriteria": [
         "TestAdapter struct implements PaymentAdapter trait",
         "TestAdapter::new() creates adapter with empty ledger",
-        "TestAdapter::seed_balance(did, amount, currency) method for test setup — adds initial balance to a DID",
+        "TestAdapter::seed_balance(did, amount, currency) method for test setup \u2014 adds initial balance to a DID",
         "In-memory ledger tracks balances per (DID, CurrencyCode) pair",
         "authorize() checks payer balance >= amount, creates a hold reducing available balance",
         "authorize() returns PaymentError when payer balance < amount (insufficient balance)",
@@ -8520,11 +8520,11 @@
         "refund() with Some(amount) refunds partial amount from payee to payer",
         "refund() returns error when payee has insufficient balance for refund",
         "Concurrent authorizations against same payer track separate holds without interference",
-        "Thread-safe — all methods callable from multiple threads via Arc<Mutex<...>> or similar",
+        "Thread-safe \u2014 all methods callable from multiple threads via Arc<Mutex<...>> or similar",
         "adapter_id() returns \"test\" string",
         "capabilities() returns AdapterCapabilities with supports_streaming: false, supports_batch_auth: false, supports_single_step: false, requires_facilitator: false, typical_settlement_ms: 0",
         "Passes all 8 tests from payment_adapter_conformance!(TestAdapter)",
-        "No real money — purely in-memory simulation",
+        "No real money \u2014 purely in-memory simulation",
         "adapter_proof field in PaymentReceipt set to deterministic bytes derived from authorization ID for test assertions"
       ],
       "actionItems": [
@@ -8570,16 +8570,16 @@
         "crates/scp-core/src/crypto/ucan/validate.rs",
         "crates/scp-core/src/crypto/ucan/mod.rs"
       ],
-      "description": "Implement SpendingCapability UCAN type (§19.5) with AND-composition, delegation chain attenuation, revocation, and 24h max expiry.\n\n§19.5 Spending Capability (UCAN Extension):\n```rust\n/// UCAN capability for spending authorization.\n/// Resource URI: \"scp:spending:{context_id}\" or \"scp:spending:*\"\npub struct SpendingCapability {\n    pub max_per_action: Amount,        // max single-action spend\n    pub max_total: Amount,             // max total spend within time_window\n    pub currency: CurrencyCode,        // ISO 4217 or protocol-defined\n    pub time_window: Duration,         // rolling window for max_total\n    pub allowed_adapters: Vec<String>, // empty = any configured adapter\n}\n```\n\nAND composition: Action UCAN + spending UCAN both required for paid actions. Agent with messagesWrite but no spending UCAN cannot send paid messages. Agent with spending UCAN but no messagesWrite cannot spend on messages. Both capabilities are independently verified before any paid action proceeds.\n\nDelegation chain: Human root DID -> spending UCAN -> agent DID. Attenuation applies: sub-delegation must narrow, never widen. An agent granted $100/day can delegate $10/day to a sub-agent. UCAN standard attenuation rules (§7.2) apply unchanged.\n\nNo implicit spending: Protocol NEVER authorizes expenditure without explicit spending UCAN. Missing UCAN -> SpendingCapabilityRequired error. Agent can still perform free actions in the context.\n\n24-hour maximum expiry (§9.5): Spending UCANs follow existing UCAN expiry rules. Short-lived by design — limits blast radius of compromised agents.\n\nRevocation: Independent of other UCANs (§7.4.4). Human discovers overspending -> revoke spending UCAN -> agent retains other capabilities but cannot authorize payments.",
+      "description": "Implement SpendingCapability UCAN type (\u00a719.5) with AND-composition, delegation chain attenuation, revocation, and 24h max expiry.\n\n\u00a719.5 Spending Capability (UCAN Extension):\n```rust\n/// UCAN capability for spending authorization.\n/// Resource URI: \"scp:spending:{context_id}\" or \"scp:spending:*\"\npub struct SpendingCapability {\n    pub max_per_action: Amount,        // max single-action spend\n    pub max_total: Amount,             // max total spend within time_window\n    pub currency: CurrencyCode,        // ISO 4217 or protocol-defined\n    pub time_window: Duration,         // rolling window for max_total\n    pub allowed_adapters: Vec<String>, // empty = any configured adapter\n}\n```\n\nAND composition: Action UCAN + spending UCAN both required for paid actions. Agent with messagesWrite but no spending UCAN cannot send paid messages. Agent with spending UCAN but no messagesWrite cannot spend on messages. Both capabilities are independently verified before any paid action proceeds.\n\nDelegation chain: Human root DID -> spending UCAN -> agent DID. Attenuation applies: sub-delegation must narrow, never widen. An agent granted $100/day can delegate $10/day to a sub-agent. UCAN standard attenuation rules (\u00a77.2) apply unchanged.\n\nNo implicit spending: Protocol NEVER authorizes expenditure without explicit spending UCAN. Missing UCAN -> SpendingCapabilityRequired error. Agent can still perform free actions in the context.\n\n24-hour maximum expiry (\u00a79.5): Spending UCANs follow existing UCAN expiry rules. Short-lived by design \u2014 limits blast radius of compromised agents.\n\nRevocation: Independent of other UCANs (\u00a77.4.4). Human discovers overspending -> revoke spending UCAN -> agent retains other capabilities but cannot authorize payments.",
       "acceptanceCriteria": [
-        "SpendingCapability struct defined with field: max_per_action (Amount) — max single-action spend",
-        "SpendingCapability struct defined with field: max_total (Amount) — max total spend within time_window",
-        "SpendingCapability struct defined with field: currency (CurrencyCode) — ISO 4217 or protocol-defined",
-        "SpendingCapability struct defined with field: time_window (Duration) — rolling window for max_total",
-        "SpendingCapability struct defined with field: allowed_adapters (Vec<String>) — empty = any configured adapter",
+        "SpendingCapability struct defined with field: max_per_action (Amount) \u2014 max single-action spend",
+        "SpendingCapability struct defined with field: max_total (Amount) \u2014 max total spend within time_window",
+        "SpendingCapability struct defined with field: currency (CurrencyCode) \u2014 ISO 4217 or protocol-defined",
+        "SpendingCapability struct defined with field: time_window (Duration) \u2014 rolling window for max_total",
+        "SpendingCapability struct defined with field: allowed_adapters (Vec<String>) \u2014 empty = any configured adapter",
         "SpendingCapability is a valid UCAN capability type registered in the capability type system",
         "Resource URI format: \"scp:spending:{context_id}\" or \"scp:spending:*\" for global spending",
-        "AND-composition enforced: paid action requires BOTH action UCAN (e.g., messagesWrite) AND SpendingCapability — fails if either missing",
+        "AND-composition enforced: paid action requires BOTH action UCAN (e.g., messagesWrite) AND SpendingCapability \u2014 fails if either missing",
         "AND-composition test: agent with messagesWrite but no SpendingCapability cannot send paid messages",
         "AND-composition test: agent with SpendingCapability but no messagesWrite cannot spend on messages",
         "Attenuation validation: sub-delegated SpendingCapability must have max_per_action <= parent's max_per_action",
@@ -8589,8 +8589,8 @@
         "Attenuation validation: widening any field is rejected with error",
         "SpendingCapabilityRequired error returned when paid action attempted without spending UCAN",
         "Agent can still perform free actions in a paid context without spending UCAN",
-        "24-hour maximum expiry enforced — spending UCAN with expiry > 24h from issuance is rejected",
-        "Independent revocation: spending UCAN revocable via §7.4.4 without affecting other UCANs",
+        "24-hour maximum expiry enforced \u2014 spending UCAN with expiry > 24h from issuance is rejected",
+        "Independent revocation: spending UCAN revocable via \u00a77.4.4 without affecting other UCANs",
         "Revocation test: after revoking spending UCAN, agent retains other capabilities but cannot authorize payments",
         "Budget tracking: running total of spending within time_window, reject when max_total would be exceeded",
         "Per-action check: reject single action when amount > max_per_action",
@@ -8607,7 +8607,7 @@
         "Implement budget tracking (rolling window total per spending UCAN)",
         "Implement mint_spending_ucan(human_did, agent_did, capability, expiry) -> UcanToken",
         "Implement validate_spending_ucan(token, action_amount) -> Result<(), SpendingError>",
-        "Wire independent revocation through existing §7.4.4 revocation system",
+        "Wire independent revocation through existing \u00a77.4.4 revocation system",
         "Add SpendingCapability to UCAN capability enum/registry in mod.rs",
         "Write unit tests for AND-composition, attenuation, expiry, revocation, budget tracking"
       ],
@@ -8635,7 +8635,7 @@
       ],
       "details": {
         "ADR-033 criterion 5": "SpendingCapability is a valid UCAN capability type. AND-composition enforced: action requiring both messagesWrite and SpendingCapability fails if either is missing.",
-        "ADR-033 criterion 6": "UCAN attenuation: sub-delegated SpendingCapability must narrow (lower max_per_action, max_total) — widening is rejected.",
+        "ADR-033 criterion 6": "UCAN attenuation: sub-delegated SpendingCapability must narrow (lower max_per_action, max_total) \u2014 widening is rejected.",
         "Novel contribution": "No existing standard combines UCAN delegation chains with payment semantics. L402/Macaroons have spending caveats but not DID-based delegation. ILP/GNAP has payment authorization but not capability-chain attenuation. SCP bridges both."
       },
       "result": "Created crates/scp-core/src/crypto/ucan/spending.rs with SpendingCapability, AND-composition, attenuation validation, 24h expiry, BudgetTracker, mint/validate functions. 53 tests."
@@ -8652,7 +8652,7 @@
         "crates/scp-core/src/economy/estimate.rs",
         "crates/scp-core/src/economy/mod.rs"
       ],
-      "description": "Implement EconomicPolicy evaluation, CostSchedule lookup, formula evaluation, ObservableMetrics collection, CostInsufficient error with metric_snapshot, and estimate_cost SDK function.\n\n§19.3 Economic Policy:\nEconomic policy is a context setting governed through the context's governance model (§5.9). Mutable by default. Changes go through governance, are logged in the event log, visible to all members, take effect after a notification period. Optional immutability lock — creator MAY lock economic policy at creation (\"always free forever\" or \"price locked at $X forever\"). The lock is itself immutable (once locked, cannot unlock).\n\nEconomic policy is orthogonal to capability ceiling (§5.3). Ceiling governs what CAN happen; economic policy governs what it COSTS. Not a new ceiling category.\n\nChild context independence: Child contexts (§5.13) do NOT inherit parent economic policy — each child's pricing is independent.\n\nAuto-accept hard rule: Auto-accept (§5.12.2) NEVER applies to contexts with economic policy requiring payment. Agents never silently incur costs. This is a hard rule, not a default — no auto-accept policy configuration can override it.\n\n§19.4 CostInsufficient:\n```rust\n/// Returned when payer's authorized amount is less than receiver's computed cost.\n/// Includes metric snapshot so payer can see why costs diverged.\npub struct CostInsufficient {\n    pub expected: Amount,              // receiver's computed cost\n    pub provided: Amount,              // payer's authorized amount\n    pub currency: CurrencyCode,\n    pub metric_snapshot: Vec<(PricingMetric, u64)>,  // receiver's observed metric values\n}\n```\n\n§19.11 SDK Surface:\nSCP.Economy.estimateCost(context, action) -> Amount — evaluates the context's pricing formula against current observable metrics.",
+      "description": "Implement EconomicPolicy evaluation, CostSchedule lookup, formula evaluation, ObservableMetrics collection, CostInsufficient error with metric_snapshot, and estimate_cost SDK function.\n\n\u00a719.3 Economic Policy:\nEconomic policy is a context setting governed through the context's governance model (\u00a75.9). Mutable by default. Changes go through governance, are logged in the event log, visible to all members, take effect after a notification period. Optional immutability lock \u2014 creator MAY lock economic policy at creation (\"always free forever\" or \"price locked at $X forever\"). The lock is itself immutable (once locked, cannot unlock).\n\nEconomic policy is orthogonal to capability ceiling (\u00a75.3). Ceiling governs what CAN happen; economic policy governs what it COSTS. Not a new ceiling category.\n\nChild context independence: Child contexts (\u00a75.13) do NOT inherit parent economic policy \u2014 each child's pricing is independent.\n\nAuto-accept hard rule: Auto-accept (\u00a75.12.2) NEVER applies to contexts with economic policy requiring payment. Agents never silently incur costs. This is a hard rule, not a default \u2014 no auto-accept policy configuration can override it.\n\n\u00a719.4 CostInsufficient:\n```rust\n/// Returned when payer's authorized amount is less than receiver's computed cost.\n/// Includes metric snapshot so payer can see why costs diverged.\npub struct CostInsufficient {\n    pub expected: Amount,              // receiver's computed cost\n    pub provided: Amount,              // payer's authorized amount\n    pub currency: CurrencyCode,\n    pub metric_snapshot: Vec<(PricingMetric, u64)>,  // receiver's observed metric values\n}\n```\n\n\u00a719.11 SDK Surface:\nSCP.Economy.estimateCost(context, action) -> Amount \u2014 evaluates the context's pricing formula against current observable metrics.",
       "acceptanceCriteria": [
         "EconomicPolicy evaluation: given EconomicPolicy + action type, compute cost from CostSchedule",
         "CostSchedule lookup: per_message cost returned for message actions, per_tool_invoke for tool actions, per_join for join actions",
@@ -8666,7 +8666,7 @@
         "estimate_cost(context, action) -> Amount SDK function evaluates pricing formula against current observable metrics",
         "Policy locked check: if locked == true, reject any governance mutation of the economic policy",
         "Policy lock is itself immutable: once locked == true, cannot be set back to false",
-        "Orthogonality with capability ceiling: economic policy evaluation does not check or modify capability ceiling — separate concerns",
+        "Orthogonality with capability ceiling: economic policy evaluation does not check or modify capability ceiling \u2014 separate concerns",
         "Child context independence: evaluate_cost for child context uses child's own economic policy, not parent's",
         "Auto-accept guard: ContextInvitation with EconomicPolicy requiring payment (any non-zero cost in CostSchedule) is never auto-accepted",
         "Auto-accept guard is a hard rule: no auto-accept policy configuration can override it",
@@ -8685,8 +8685,8 @@
         "Implement ObservableMetrics collection from context state",
         "Define CostInsufficient error struct with expected, provided, currency, metric_snapshot fields",
         "Create crates/scp-core/src/economy/estimate.rs with estimate_cost(context, action) -> Amount function",
-        "Implement policy locked/governed logic — reject mutations when locked == true",
-        "Implement auto-accept guard — reject auto-accept for any context with non-zero CostSchedule",
+        "Implement policy locked/governed logic \u2014 reject mutations when locked == true",
+        "Implement auto-accept guard \u2014 reject auto-accept for any context with non-zero CostSchedule",
         "Wire governed changes through governance system with notification period",
         "Add unit tests for cost evaluation, CostInsufficient, locked policy, auto-accept guard, child independence",
         "Re-export from economy/mod.rs"
@@ -8716,7 +8716,7 @@
       ],
       "details": {
         "ADR-033 criterion 7": "EconomicPolicy stored in ContextParams. Contexts without EconomicPolicy are free (no payment required for any action).",
-        "ADR-033 criterion 8": "PricingFormula evaluation uses Amount(u64) and Coefficient(i64) exclusively — no f64 in any economic calculation path.",
+        "ADR-033 criterion 8": "PricingFormula evaluation uses Amount(u64) and Coefficient(i64) exclusively \u2014 no f64 in any economic calculation path.",
         "ADR-033 criterion 9": "CostInsufficient error includes receiver's metric_snapshot so payer can see why costs diverged.",
         "ADR-033 criterion 10": "Auto-accept guard: ContextInvitation with EconomicPolicy requiring payment is never auto-accepted regardless of auto-accept policy configuration.",
         "Orthogonality note": "Ceiling governs what CAN happen; economic policy governs what it COSTS. Not a new ceiling category. A context with toolInvocation in its ceiling and per_tool_invoke: $0.01 in its economic policy allows tool invocations that cost $0.01 each. Removing the cost doesn't expand capabilities; adding a cost doesn't restrict them."
@@ -8737,7 +8737,7 @@
         "crates/scp-core/src/events/types.rs",
         "crates/scp-core/src/provenance/mod.rs"
       ],
-      "description": "Implement PaymentReceipt type (§19.6), PaidActionType enum, all 4 economic event types (§19.6.1), DataProvenance extension (§7.7.1), and receipt verification via adapter.verify(receipt).\n\n§19.6 PaymentReceipt:\n```rust\npub struct PaymentReceipt {\n    pub receipt_id: [u8; 32],\n    pub payer: DID,\n    pub payee: DID,\n    pub amount: Amount,\n    pub currency: CurrencyCode,\n    pub action_type: PaidActionType,\n    pub context_id: Option<ContextId>,\n    pub adapter_id: String,\n    pub adapter_proof: Vec<u8>,       // adapter-specific proof:\n                                      //   x402: on-chain tx hash\n                                      //   Lightning: preimage\n                                      //   SPL: tx signature\n    pub timestamp: u64,\n    pub signature: Ed25519Signature,  // signed by payer\n}\n```\n\n§19.6.1 Event Types:\n| Event Type | Trigger | Payload |\n|---|---|---|\n| PaymentReceived | adapter.capture() succeeds | PaymentReceipt |\n| EconomicPolicyChanged | Governance updates economic policy | Old policy hash, new EconomicPolicy, governance justification |\n| SpendingUcanGranted | Human grants spending UCAN to agent | Agent DID, SpendingCapability summary (amounts, window), UCAN token ID |\n| SpendingUcanRevoked | Human revokes spending UCAN | UCAN token ID, revocation reason |\n\nDataProvenance (§7.7.1) extended with optional payment_amount, payment_adapter, payment_receipt_id. Receiving contexts see what data cost to produce — expensive computations carry economic provenance.\n\nVerification: Any party calls adapter.verify(receipt) — adapter checks proof against the payment rail (on-chain state, preimage hash, etc.).",
+      "description": "Implement PaymentReceipt type (\u00a719.6), PaidActionType enum, all 4 economic event types (\u00a719.6.1), DataProvenance extension (\u00a77.7.1), and receipt verification via adapter.verify(receipt).\n\n\u00a719.6 PaymentReceipt:\n```rust\npub struct PaymentReceipt {\n    pub receipt_id: [u8; 32],\n    pub payer: DID,\n    pub payee: DID,\n    pub amount: Amount,\n    pub currency: CurrencyCode,\n    pub action_type: PaidActionType,\n    pub context_id: Option<ContextId>,\n    pub adapter_id: String,\n    pub adapter_proof: Vec<u8>,       // adapter-specific proof:\n                                      //   x402: on-chain tx hash\n                                      //   Lightning: preimage\n                                      //   SPL: tx signature\n    pub timestamp: u64,\n    pub signature: Ed25519Signature,  // signed by payer\n}\n```\n\n\u00a719.6.1 Event Types:\n| Event Type | Trigger | Payload |\n|---|---|---|\n| PaymentReceived | adapter.capture() succeeds | PaymentReceipt |\n| EconomicPolicyChanged | Governance updates economic policy | Old policy hash, new EconomicPolicy, governance justification |\n| SpendingUcanGranted | Human grants spending UCAN to agent | Agent DID, SpendingCapability summary (amounts, window), UCAN token ID |\n| SpendingUcanRevoked | Human revokes spending UCAN | UCAN token ID, revocation reason |\n\nDataProvenance (\u00a77.7.1) extended with optional payment_amount, payment_adapter, payment_receipt_id. Receiving contexts see what data cost to produce \u2014 expensive computations carry economic provenance.\n\nVerification: Any party calls adapter.verify(receipt) \u2014 adapter checks proof against the payment rail (on-chain state, preimage hash, etc.).",
       "acceptanceCriteria": [
         "PaymentReceipt struct field: receipt_id ([u8; 32])",
         "PaymentReceipt struct field: payer (DID)",
@@ -8747,21 +8747,21 @@
         "PaymentReceipt struct field: action_type (PaidActionType)",
         "PaymentReceipt struct field: context_id (Option<ContextId>)",
         "PaymentReceipt struct field: adapter_id (String)",
-        "PaymentReceipt struct field: adapter_proof (Vec<u8>) — adapter-specific proof (tx hash, preimage, tx signature)",
+        "PaymentReceipt struct field: adapter_proof (Vec<u8>) \u2014 adapter-specific proof (tx hash, preimage, tx signature)",
         "PaymentReceipt struct field: timestamp (u64)",
-        "PaymentReceipt struct field: signature (Ed25519Signature) — signed by payer",
+        "PaymentReceipt struct field: signature (Ed25519Signature) \u2014 signed by payer",
         "PaidActionType enum defined with variants for message send, tool invocation, context join, subscription payment, storage, and other paid actions",
-        "EventType::PaymentReceived variant added — triggered on adapter.capture() success, payload is PaymentReceipt",
-        "EventType::EconomicPolicyChanged variant added — triggered on governance policy update, payload is old policy hash + new EconomicPolicy + governance justification",
-        "EventType::SpendingUcanGranted variant added — triggered when human grants spending UCAN, payload is agent DID + SpendingCapability summary + UCAN token ID",
-        "EventType::SpendingUcanRevoked variant added — triggered when human revokes spending UCAN, payload is UCAN token ID + revocation reason",
+        "EventType::PaymentReceived variant added \u2014 triggered on adapter.capture() success, payload is PaymentReceipt",
+        "EventType::EconomicPolicyChanged variant added \u2014 triggered on governance policy update, payload is old policy hash + new EconomicPolicy + governance justification",
+        "EventType::SpendingUcanGranted variant added \u2014 triggered when human grants spending UCAN, payload is agent DID + SpendingCapability summary + UCAN token ID",
+        "EventType::SpendingUcanRevoked variant added \u2014 triggered when human revokes spending UCAN, payload is UCAN token ID + revocation reason",
         "All 4 economic event types carry same Merkle-tree inclusion guarantees as other event types",
         "DataProvenance extended with optional field: payment_amount (Option<Amount>)",
         "DataProvenance extended with optional field: payment_adapter (Option<String>)",
         "DataProvenance extended with optional field: payment_receipt_id (Option<[u8; 32]>)",
         "payment_history(context) -> Vec<PaymentReceipt> query function retrieves receipts from context event log",
         "Receipt verification: adapter.verify(receipt) checks adapter_proof against payment rail",
-        "Payment data inside encrypted envelope — relays never see payment metadata for context-level economics",
+        "Payment data inside encrypted envelope \u2014 relays never see payment metadata for context-level economics",
         "Unit test: PaymentReceipt serialize/deserialize roundtrip",
         "Unit test: PaymentReceived event recorded in event log with Merkle inclusion proof",
         "Unit test: DataProvenance with payment fields roundtrip",
@@ -8803,8 +8803,8 @@
       ],
       "details": {
         "ADR-033 criterion 11": "PaymentReceipt events recorded in context event log with Merkle inclusion proofs.",
-        "Adapter-specific proofs": "x402: on-chain tx hash. Lightning: preimage. SPL: tx signature. The adapter_proof field is opaque bytes — each adapter defines its own proof format.",
-        "Cost provenance": "When data crosses context boundaries (§7.7), payment receipts are part of the provenance chain. Receiving contexts see what data cost to produce — expensive computations carry economic provenance."
+        "Adapter-specific proofs": "x402: on-chain tx hash. Lightning: preimage. SPL: tx signature. The adapter_proof field is opaque bytes \u2014 each adapter defines its own proof format.",
+        "Cost provenance": "When data crosses context boundaries (\u00a77.7), payment receipts are part of the provenance chain. Receiving contexts see what data cost to produce \u2014 expensive computations carry economic provenance."
       },
       "result": "PaymentReceipt type, PaidActionType enum, 4 economic event types, DataProvenance payment extension, PaymentVerifier trait, payment_history query. 25 tests."
     },
@@ -8820,7 +8820,7 @@
         "crates/scp-core/src/economy/mod.rs",
         "crates/scp-core/src/context/manager.rs"
       ],
-      "description": "Implement the full 9-step action-payment integration sequence (§19.2.2) with two flow patterns, void-on-failure, CostInsufficient error handling, and ContextManager integration.\n\n§19.2.2 Action-Payment Integration Sequence:\n```\n1. Agent SDK evaluates cost (economic policy + pricing formula + observable metrics)\n2. Agent SDK verifies spending UCAN covers this cost\n3. Agent SDK calls adapter.authorize(payer_did, payee_did, amount, currency, metadata)\n4. PaymentAuthorization attached to action envelope (inside encrypted payload)\n5. Receiving side verifies authorization via its own adapter instance (adapter.verify)\n6. Action is processed (message delivered, tool invoked, etc.)\n7. Receiving side calls adapter.capture(auth)\n8. PaymentReceipt recorded in context event log as provenance\n9. On failure at step 5-7: adapter.void(auth) — funds released\n```\n\nTwo primary flow patterns:\n\nAuthorize-then-capture (x402, Stripe): Funds are reserved on authorize, moved on capture. Supports void. The x402 12-step flow maps directly onto this.\n\nInvoice-then-preimage (Lightning BOLT 11/12, L402): Payee generates invoice with payment_hash, payer pays, preimage serves as cryptographic proof of payment. Preimage IS the receipt — SHA256(preimage) == payment_hash is unforgeable.\n\nPaymentAuthorization is attached to the action envelope inside the encrypted payload — relays never see payment data.\n\nCostInsufficient error: If payer's payment is insufficient (metrics diverged), action rejected with CostInsufficient containing receiver's computed cost and the metric values the receiver observed. Payer can retry with updated amount.",
+      "description": "Implement the full 9-step action-payment integration sequence (\u00a719.2.2) with two flow patterns, void-on-failure, CostInsufficient error handling, and ContextManager integration.\n\n\u00a719.2.2 Action-Payment Integration Sequence:\n```\n1. Agent SDK evaluates cost (economic policy + pricing formula + observable metrics)\n2. Agent SDK verifies spending UCAN covers this cost\n3. Agent SDK calls adapter.authorize(payer_did, payee_did, amount, currency, metadata)\n4. PaymentAuthorization attached to action envelope (inside encrypted payload)\n5. Receiving side verifies authorization via its own adapter instance (adapter.verify)\n6. Action is processed (message delivered, tool invoked, etc.)\n7. Receiving side calls adapter.capture(auth)\n8. PaymentReceipt recorded in context event log as provenance\n9. On failure at step 5-7: adapter.void(auth) \u2014 funds released\n```\n\nTwo primary flow patterns:\n\nAuthorize-then-capture (x402, Stripe): Funds are reserved on authorize, moved on capture. Supports void. The x402 12-step flow maps directly onto this.\n\nInvoice-then-preimage (Lightning BOLT 11/12, L402): Payee generates invoice with payment_hash, payer pays, preimage serves as cryptographic proof of payment. Preimage IS the receipt \u2014 SHA256(preimage) == payment_hash is unforgeable.\n\nPaymentAuthorization is attached to the action envelope inside the encrypted payload \u2014 relays never see payment data.\n\nCostInsufficient error: If payer's payment is insufficient (metrics diverged), action rejected with CostInsufficient containing receiver's computed cost and the metric values the receiver observed. Payer can retry with updated amount.",
       "acceptanceCriteria": [
         "Step 1: Agent SDK evaluates cost using EconomicPolicy + PricingFormula + ObservableMetrics",
         "Step 2: Agent SDK verifies spending UCAN covers computed cost (max_per_action >= cost, remaining budget in time_window sufficient)",
@@ -8837,9 +8837,9 @@
         "CostInsufficient includes metric_snapshot for payer to see why costs diverged and retry with updated amount",
         "ContextManager integration: paid actions routed through integration sequence before processing",
         "Free actions bypass payment sequence entirely (no adapter calls when no economic policy)",
-        "Unit test: full 9-step sequence with TestAdapter — authorize, attach, verify, process, capture, receipt in log",
-        "Unit test: void on failure — authorization voided when step 5 verification fails",
-        "Unit test: void on failure — authorization voided when step 6 action processing fails",
+        "Unit test: full 9-step sequence with TestAdapter \u2014 authorize, attach, verify, process, capture, receipt in log",
+        "Unit test: void on failure \u2014 authorization voided when step 5 verification fails",
+        "Unit test: void on failure \u2014 authorization voided when step 6 action processing fails",
         "Unit test: CostInsufficient returned with correct metric_snapshot when payment is insufficient",
         "Unit test: free action in paid context bypasses payment when action type has no cost in CostSchedule"
       ],
@@ -8879,8 +8879,8 @@
       ],
       "details": {
         "Flow patterns table": "| Pattern | authorize | capture | verify |\n|---------|-----------|---------|--------|\n| x402 | Sign EIP-3009 or Permit2 transfer | Facilitator submits on-chain | Check on-chain state |\n| Lightning | Generate invoice + receive preimage | No-op (preimage revelation IS capture) | Check SHA256(preimage) == payment_hash |\n| SPL | ApproveChecked (single delegate per account, spending cap) | TransferChecked using delegate authority | Check on-chain state |",
-        "Payment negotiation": "Stateless. No handshake. Payee declares terms, payer evaluates, match or reject. If multiple adapters overlap: payer selects (SDK applies preference ordering — cost, speed, privacy). If no overlap: NoCompatiblePaymentAdapter error.",
-        "Envelope placement": "PaymentAuthorization attached to action envelope inside encrypted payload. Fixed bucket padding (§9.10.3) prevents size-based inference of whether a message carries payment data."
+        "Payment negotiation": "Stateless. No handshake. Payee declares terms, payer evaluates, match or reject. If multiple adapters overlap: payer selects (SDK applies preference ordering \u2014 cost, speed, privacy). If no overlap: NoCompatiblePaymentAdapter error.",
+        "Envelope placement": "PaymentAuthorization attached to action envelope inside encrypted payload. Fixed bucket padding (\u00a79.10.3) prevents size-based inference of whether a message carries payment data."
       },
       "result": "economy/integration.rs implements full 9-step action-payment sequence. execute_paid_action() orchestrates authorize/verify/capture/void. Both authorize-then-capture and invoice-then-preimage flows. CostInsufficient with metric_snapshot. ContextManager integration. Comprehensive tests."
     },
@@ -8895,30 +8895,30 @@
         "crates/scp-core/src/economy/pricing.rs",
         "crates/scp-core/src/economy/mod.rs"
       ],
-      "description": "Implement PricingFormula evaluation engine using integer-only arithmetic (§19.4).\n\n§19.4 Dynamic Pricing:\n```rust\npub struct PricingFormula {\n    pub base_cost: Amount,\n    pub variables: Vec<PricingVariable>,\n    pub cap: Option<Amount>,     // max cost regardless of formula\n    pub floor: Option<Amount>,   // min cost regardless of formula\n}\n\npub enum PricingVariable {\n    /// Linear multiplier: cost += (coefficient.0 * metric_value) / 1_000_000\n    /// Coefficient is fixed-point with 6 decimal places (§19.1.1).\n    Linear { metric: PricingMetric, coefficient: Coefficient },\n    /// Step function: cost += additional when metric_value exceeds threshold.\n    /// Thresholds are integer metric values (messages/min, member count, bytes, etc.).\n    Step { metric: PricingMetric, thresholds: Vec<(u64, Amount)> },\n}\n\npub enum PricingMetric {\n    ContextMessageRate,    // messages/min in this context\n    MemberCount,           // current member count\n    RelayQueueDepth,       // relay-level only\n    TimeOfDay,             // UTC hour (0-23), enables off-peak pricing\n    SenderVelocity,        // sender's messages in sliding window (anti-spam)\n    StorageUsage,          // context storage in bytes\n}\n```\n\nEvaluation: Payer SDK computes cost from observable metrics, authorizes payment, submits action with authorization. Receiver independently evaluates formula. If payer's payment is insufficient (metrics diverged), action rejected with CostInsufficient containing receiver's computed cost and the metric values the receiver observed. Payer can retry with updated amount.\n\nCross-party determinism guarantee: Both payer and receiver evaluate the same formula with the same inputs and get identical results. No IEEE 754 variance. Integer arithmetic only.\n\nEIP-1559 analogy for relay pricing: Target 50% relay capacity. Below target: price decreases (capped at floor). Above target: price increases (capped at cap). Max change per evaluation period: configurable (e.g., 12.5% like EIP-1559).\n\nGoverned changes: Formula itself is a governed setting — governance can adjust coefficients, add/remove variables, change cap/floor. Changes logged, members notified, grace period before effect.",
+      "description": "Implement PricingFormula evaluation engine using integer-only arithmetic (\u00a719.4).\n\n\u00a719.4 Dynamic Pricing:\n```rust\npub struct PricingFormula {\n    pub base_cost: Amount,\n    pub variables: Vec<PricingVariable>,\n    pub cap: Option<Amount>,     // max cost regardless of formula\n    pub floor: Option<Amount>,   // min cost regardless of formula\n}\n\npub enum PricingVariable {\n    /// Linear multiplier: cost += (coefficient.0 * metric_value) / 1_000_000\n    /// Coefficient is fixed-point with 6 decimal places (\u00a719.1.1).\n    Linear { metric: PricingMetric, coefficient: Coefficient },\n    /// Step function: cost += additional when metric_value exceeds threshold.\n    /// Thresholds are integer metric values (messages/min, member count, bytes, etc.).\n    Step { metric: PricingMetric, thresholds: Vec<(u64, Amount)> },\n}\n\npub enum PricingMetric {\n    ContextMessageRate,    // messages/min in this context\n    MemberCount,           // current member count\n    RelayQueueDepth,       // relay-level only\n    TimeOfDay,             // UTC hour (0-23), enables off-peak pricing\n    SenderVelocity,        // sender's messages in sliding window (anti-spam)\n    StorageUsage,          // context storage in bytes\n}\n```\n\nEvaluation: Payer SDK computes cost from observable metrics, authorizes payment, submits action with authorization. Receiver independently evaluates formula. If payer's payment is insufficient (metrics diverged), action rejected with CostInsufficient containing receiver's computed cost and the metric values the receiver observed. Payer can retry with updated amount.\n\nCross-party determinism guarantee: Both payer and receiver evaluate the same formula with the same inputs and get identical results. No IEEE 754 variance. Integer arithmetic only.\n\nEIP-1559 analogy for relay pricing: Target 50% relay capacity. Below target: price decreases (capped at floor). Above target: price increases (capped at cap). Max change per evaluation period: configurable (e.g., 12.5% like EIP-1559).\n\nGoverned changes: Formula itself is a governed setting \u2014 governance can adjust coefficients, add/remove variables, change cap/floor. Changes logged, members notified, grace period before effect.",
       "acceptanceCriteria": [
         "evaluate_formula(formula: &PricingFormula, metrics: &ObservableMetrics) -> Amount function defined",
         "Evaluation starts with base_cost as initial amount",
-        "Linear variable evaluation: cost += (coefficient.0 * metric_value) / 1_000_000 — uses integer division only",
+        "Linear variable evaluation: cost += (coefficient.0 * metric_value) / 1_000_000 \u2014 uses integer division only",
         "Step variable evaluation: for each threshold (threshold_value, additional_amount), if metric_value >= threshold_value, cost += additional_amount",
-        "Step thresholds are cumulative — higher thresholds add their amount on top of lower thresholds",
+        "Step thresholds are cumulative \u2014 higher thresholds add their amount on top of lower thresholds",
         "Cap enforcement: if cap is Some and computed cost > cap, result is capped at cap value",
         "Floor enforcement: if floor is Some and computed cost < floor, result is raised to floor value",
         "Cap takes precedence over floor when cap < floor (degenerate configuration returns cap)",
-        "No f64 in any evaluation path — all arithmetic uses Amount(u64) and Coefficient(i64) exclusively",
+        "No f64 in any evaluation path \u2014 all arithmetic uses Amount(u64) and Coefficient(i64) exclusively",
         "Cross-party determinism: same formula + same metrics always produces same Amount on any platform",
         "Linear variable with negative Coefficient correctly reduces cost (but result never below 0)",
-        "Multiple variables are additive — each variable's contribution added sequentially",
+        "Multiple variables are additive \u2014 each variable's contribution added sequentially",
         "EIP-1559-style relay pricing: utilization-targeting formula with configurable max change per evaluation period",
         "Governed changes: formula modification goes through governance, logged in event log, grace period before effect",
         "Unit test: base_cost only (no variables) returns base_cost",
         "Unit test: Linear variable with Coefficient(1_500_000) and metric value 100 adds 150 to cost",
-        "Unit test: Step variable with thresholds [(10, Amount(1)), (50, Amount(10)), (200, Amount(100))] — metric=75 adds 11 (1+10)",
+        "Unit test: Step variable with thresholds [(10, Amount(1)), (50, Amount(10)), (200, Amount(100))] \u2014 metric=75 adds 11 (1+10)",
         "Unit test: cap enforcement clamps result",
         "Unit test: floor enforcement raises result",
         "Unit test: multiple variables are additive",
         "Unit test: negative Coefficient reduces cost without underflow (saturates at 0)",
-        "Unit test: cross-party determinism — same inputs produce byte-identical Amount"
+        "Unit test: cross-party determinism \u2014 same inputs produce byte-identical Amount"
       ],
       "actionItems": [
         "Create crates/scp-core/src/economy/pricing.rs with evaluate_formula function",
@@ -8951,7 +8951,7 @@
         }
       ],
       "details": {
-        "ADR-033 criterion 8": "PricingFormula evaluation uses Amount(u64) and Coefficient(i64) exclusively — no f64 in any economic calculation path.",
+        "ADR-033 criterion 8": "PricingFormula evaluation uses Amount(u64) and Coefficient(i64) exclusively \u2014 no f64 in any economic calculation path.",
         "Coefficient evaluation": "Value = raw / 1_000_000. Example: 1_500_000 = 1.5, 100 = 0.0001. Evaluation: (coefficient.0 * metric_value) / 1_000_000. Both sides compute the same result.",
         "EIP-1559 analogy": "For relay pricing specifically, a utilization-targeting formula makes sense: Target 50% relay capacity. Below target: price decreases (capped at floor). Above target: price increases (capped at cap). Max change per evaluation period: configurable (e.g., 12.5% like EIP-1559)."
       },
@@ -8969,14 +8969,14 @@
         "crates/scp-transport/src/relay/wellknown.rs",
         "crates/scp-transport/src/manager.rs"
       ],
-      "description": "Implement relay economic config extension to .well-known/scp (§19.8, §18.3.3) and cost-aware relay selection in TransportManager.\n\n§19.8 Relay Economic Config extends .well-known/scp (§18.3.3):\n```json\n{\n  \"relay_config\": {\n    \"max_blob_size\": 262144,\n    \"max_blob_ttl\": 86400,\n    \"rate_limit_publish\": 100,\n    \"economic\": {\n      \"currency\": \"USD\",\n      \"per_publish\": 10,\n      \"per_byte_stored\": 1,\n      \"payment_adapters\": [\"x402\", \"lightning\"],\n      \"payee\": \"did:dht:z6Mk...\"\n    }\n  }\n}\n```\n\nRelay economics are SEPARATE from context economics — different trust model. Relays are transport (dumb pipes, §9.9). Context pricing is application-level (inside encrypted envelope, invisible to relays).\n\nFree relays MUST exist. Bootstrap relay list (§18.5, priority level 5) MUST include free relays. Self-hosted relays (§10.2, §10.4), community relays, and bundled relays remain free. Economic config is optional. Absence = free.\n\nRelay selection: TransportManager (ADR-012) already selects by reliability + latency. Economic governance adds cost as a third criterion. Market pressure: agents prefer cheaper relays, creating competition.\n\nPayment flow: Agent evaluates relay config (visible before connecting) -> selects compatible adapter -> authorizes per-action -> relay verifies + captures.\n\nAmount values in .well-known/scp are serialized as JSON integers in the smallest currency unit specified by currency. Decimal string representations are NOT valid — all amounts are integers. The currency field determines the interpretation scale.",
+      "description": "Implement relay economic config extension to .well-known/scp (\u00a719.8, \u00a718.3.3) and cost-aware relay selection in TransportManager.\n\n\u00a719.8 Relay Economic Config extends .well-known/scp (\u00a718.3.3):\n```json\n{\n  \"relay_config\": {\n    \"max_blob_size\": 262144,\n    \"max_blob_ttl\": 86400,\n    \"rate_limit_publish\": 100,\n    \"economic\": {\n      \"currency\": \"USD\",\n      \"per_publish\": 10,\n      \"per_byte_stored\": 1,\n      \"payment_adapters\": [\"x402\", \"lightning\"],\n      \"payee\": \"did:dht:z6Mk...\"\n    }\n  }\n}\n```\n\nRelay economics are SEPARATE from context economics \u2014 different trust model. Relays are transport (dumb pipes, \u00a79.9). Context pricing is application-level (inside encrypted envelope, invisible to relays).\n\nFree relays MUST exist. Bootstrap relay list (\u00a718.5, priority level 5) MUST include free relays. Self-hosted relays (\u00a710.2, \u00a710.4), community relays, and bundled relays remain free. Economic config is optional. Absence = free.\n\nRelay selection: TransportManager (ADR-012) already selects by reliability + latency. Economic governance adds cost as a third criterion. Market pressure: agents prefer cheaper relays, creating competition.\n\nPayment flow: Agent evaluates relay config (visible before connecting) -> selects compatible adapter -> authorizes per-action -> relay verifies + captures.\n\nAmount values in .well-known/scp are serialized as JSON integers in the smallest currency unit specified by currency. Decimal string representations are NOT valid \u2014 all amounts are integers. The currency field determines the interpretation scale.",
       "acceptanceCriteria": [
-        "RelayEconomicConfig struct defined with field: per_publish (Option<Amount>) — cost per publish action",
-        "RelayEconomicConfig struct defined with field: per_byte_stored (Option<Amount>) — cost per byte stored",
-        "RelayEconomicConfig struct defined with field: currency (CurrencyCode) — currency for all Amount fields in this config",
+        "RelayEconomicConfig struct defined with field: per_publish (Option<Amount>) \u2014 cost per publish action",
+        "RelayEconomicConfig struct defined with field: per_byte_stored (Option<Amount>) \u2014 cost per byte stored",
+        "RelayEconomicConfig struct defined with field: currency (CurrencyCode) \u2014 currency for all Amount fields in this config",
         "JSON serialization: Amount values serialized as JSON integers in smallest currency unit; decimal string representations rejected",
-        "RelayEconomicConfig struct defined with field: payment_adapters (Vec<String>) — accepted adapter IDs",
-        "RelayEconomicConfig struct defined with field: payee (DID) — who receives relay payments",
+        "RelayEconomicConfig struct defined with field: payment_adapters (Vec<String>) \u2014 accepted adapter IDs",
+        "RelayEconomicConfig struct defined with field: payee (DID) \u2014 who receives relay payments",
         "relay_config in .well-known/scp extended with optional economic field (RelayEconomicConfig)",
         "Parsing: .well-known/scp JSON with economic field deserializes to RelayEconomicConfig correctly",
         "Parsing: .well-known/scp JSON without economic field treated as free relay (no error)",
@@ -8984,7 +8984,7 @@
         "TransportManager prefers cheaper relays when reliability and latency are comparable",
         "Free relay MUST exist check: SDK's fallback bootstrap relay list validated to include at least one free relay",
         "Free relay invariant: startup validation warns or errors if no free relay in bootstrap list",
-        "Relay economic terms visible before connecting — agent inspects .well-known/scp before selecting relay",
+        "Relay economic terms visible before connecting \u2014 agent inspects .well-known/scp before selecting relay",
         "Unit test: RelayEconomicConfig serialize/deserialize roundtrip",
         "Unit test: .well-known/scp parsing with economic field produces correct RelayEconomicConfig",
         "Unit test: .well-known/scp parsing without economic field produces None for economic config",
@@ -9022,8 +9022,8 @@
       ],
       "details": {
         "ADR-033 criterion 12": ".well-known/scp relay config parsing accepts optional economic object with per_publish, per_byte_stored, payment_adapters, payee fields.",
-        "ADR-033 criterion 14": "Free relays exist in the default bootstrap relay list — at least one relay in the SDK's fallback list has no economic config.",
-        "Relay trust model": "Paid relays remain untrusted — they see opaque blobs. Relay payment is for transport, not content access. Encryption-as-access-control (§9) unchanged. A relay that charges for storage cannot read what it stores.",
+        "ADR-033 criterion 14": "Free relays exist in the default bootstrap relay list \u2014 at least one relay in the SDK's fallback list has no economic config.",
+        "Relay trust model": "Paid relays remain untrusted \u2014 they see opaque blobs. Relay payment is for transport, not content access. Encryption-as-access-control (\u00a79) unchanged. A relay that charges for storage cannot read what it stores.",
         "JSON structure": "The economic field is nested inside relay_config. Fields: per_publish (amount+currency), per_byte_stored (amount+currency), payment_adapters (array of adapter ID strings), payee (DID string)."
       },
       "result": "Created RelayEconomicConfig, extended .well-known/scp parsing, added cost-aware relay selection to TransportManager, free relay bootstrap validation."
@@ -9039,18 +9039,18 @@
         "crates/scp-core/src/economy/antispam.rs",
         "crates/scp-core/src/economy/mod.rs"
       ],
-      "description": "Implement per-sender cost escalation via SenderVelocity metric (§19.7) with sliding window tracking.\n\n§19.7 Anti-Spam via Cost Escalation:\n\nStatic cost floor: Any non-zero cost eliminates economically irrational spam. $0.0001/message makes bulk spam a P&L decision.\n\nPer-sender escalation using SenderVelocity metric:\n```\nbase_cost: $0.001\nvariables:\n  - Step { metric: SenderVelocity, thresholds: [\n      (10/min,  +$0.001),     // elevated: $0.002/msg\n      (50/min,  +$0.01),      // high: $0.012/msg\n      (200/min, +$0.10),      // extreme: $0.112/msg\n    ]}\ncap: $1.00\n```\n\nNormal conversation (1-5 msg/min): negligible ($0.001). Spam rates (200+ msg/min): $0.112/msg = $1,344/hr. Self-limiting.\n\nComposes with consequence mechanisms (§7.3.7): Economic tier (cost escalation) and behavioral tier (warning -> suspension -> ejection) operate independently. Agent might exhaust spending UCAN before behavioral consequences trigger, or vice versa.\n\nSybil deterrent: N identities = N x cost. Each identity needs its own spending UCAN, own adapter credentials, own payment capacity. Compounds with device attestation (§9.3).\n\nDDoS inversion: DDoS against a priced relay is paying the operator to absorb the attack.",
+      "description": "Implement per-sender cost escalation via SenderVelocity metric (\u00a719.7) with sliding window tracking.\n\n\u00a719.7 Anti-Spam via Cost Escalation:\n\nStatic cost floor: Any non-zero cost eliminates economically irrational spam. $0.0001/message makes bulk spam a P&L decision.\n\nPer-sender escalation using SenderVelocity metric:\n```\nbase_cost: $0.001\nvariables:\n  - Step { metric: SenderVelocity, thresholds: [\n      (10/min,  +$0.001),     // elevated: $0.002/msg\n      (50/min,  +$0.01),      // high: $0.012/msg\n      (200/min, +$0.10),      // extreme: $0.112/msg\n    ]}\ncap: $1.00\n```\n\nNormal conversation (1-5 msg/min): negligible ($0.001). Spam rates (200+ msg/min): $0.112/msg = $1,344/hr. Self-limiting.\n\nComposes with consequence mechanisms (\u00a77.3.7): Economic tier (cost escalation) and behavioral tier (warning -> suspension -> ejection) operate independently. Agent might exhaust spending UCAN before behavioral consequences trigger, or vice versa.\n\nSybil deterrent: N identities = N x cost. Each identity needs its own spending UCAN, own adapter credentials, own payment capacity. Compounds with device attestation (\u00a79.3).\n\nDDoS inversion: DDoS against a priced relay is paying the operator to absorb the attack.",
       "acceptanceCriteria": [
-        "SenderVelocityTracker struct defined — tracks message count per sender in a sliding time window",
+        "SenderVelocityTracker struct defined \u2014 tracks message count per sender in a sliding time window",
         "Sliding window implementation: configurable window duration (e.g., 60 seconds), tracks timestamps of recent messages per sender DID",
         "record_message(sender_did, timestamp) method adds message to sender's window",
         "get_velocity(sender_did) -> u64 method returns count of messages in current window for sender",
         "Expired messages pruned from window on each query (lazy cleanup)",
-        "SenderVelocity metric integrates with PricingFormula evaluation — evaluate_formula reads velocity from tracker",
+        "SenderVelocity metric integrates with PricingFormula evaluation \u2014 evaluate_formula reads velocity from tracker",
         "Step-function escalation with SenderVelocity: cost increases at configured thresholds",
         "Example escalation: 10/min -> +$0.001, 50/min -> +$0.01, 200/min -> +$0.10 (thresholds cumulative)",
-        "Composition with consequence mechanisms (§7.3.7): economic escalation operates independently from behavioral consequences",
-        "Sybil deterrent: each DID tracked independently — N identities = N x cost",
+        "Composition with consequence mechanisms (\u00a77.3.7): economic escalation operates independently from behavioral consequences",
+        "Sybil deterrent: each DID tracked independently \u2014 N identities = N x cost",
         "Per-sender tracking: velocity computed per-sender, not aggregate across all senders",
         "Thread-safe: SenderVelocityTracker safe to access from multiple threads",
         "Unit test: velocity starts at 0 for unknown sender",
@@ -9085,7 +9085,7 @@
       ],
       "details": {
         "Cost escalation example": "base_cost: $0.001. Thresholds: (10/min, +$0.001), (50/min, +$0.01), (200/min, +$0.10). Cap: $1.00. Normal conversation (1-5 msg/min): negligible ($0.001). Spam rates (200+ msg/min): $0.112/msg = $1,344/hr. Self-limiting.",
-        "Sybil deterrent": "N identities = N x cost. Each identity needs its own spending UCAN, own adapter credentials, own payment capacity. Compounds with device attestation (§9.3) — Sybil attacks are expensive to create AND expensive to sustain.",
+        "Sybil deterrent": "N identities = N x cost. Each identity needs its own spending UCAN, own adapter credentials, own payment capacity. Compounds with device attestation (\u00a79.3) \u2014 Sybil attacks are expensive to create AND expensive to sustain.",
         "DDoS inversion": "DDoS against a priced relay is paying the operator to absorb the attack."
       },
       "result": "SenderVelocityTracker implemented with sliding window, step-function escalation integration with PricingFormula, thread-safe via Mutex, 12 unit tests passing"
@@ -9100,30 +9100,30 @@
       "files": [
         "crates/scp-core/tests/economy_integration.rs"
       ],
-      "description": "End-to-end integration test covering ALL 9 invariants from §19.14.\n\n§19.14 Invariants:\n1. Economic policy visible before opt-in (legibility). Economic terms are part of context metadata (§5.7), visible to any identity that inspects the context before joining.\n2. No implicit spending — spending UCAN always required. Protocol NEVER authorizes expenditure without an explicit, valid spending UCAN from the payer's delegation chain.\n3. Free operation is default — no economic policy = free. Contexts without EconomicPolicy are free. Relays without economic in relay_config are free. Tools without cost metadata are free.\n4. Receipts are provenance records — every payment is traceable and verifiable. Payment receipts are recorded in context event logs and participate in the provenance chain (§7.7).\n5. Payment adapters are substitutable — no single rail privileged. The PaymentAdapter trait treats all payment rails equally. Protocol correctness does not depend on any specific adapter.\n6. Economic policy mutable by default, optional immutability lock is voluntary. Unlike ceiling policy (immutable by default), economic policy is governed by default. Creators may voluntarily lock pricing at creation.\n7. Payment data inside encrypted envelope — relays never see payment metadata for context-level economics.\n8. Free relays MUST always exist in bootstrap list. The SDK's fallback relay list (§18.5) MUST include free relays. This is a protocol invariant that prevents economic gatekeeping of basic protocol operation.\n9. Auto-accept never applies to paid contexts. No auto-accept policy configuration (§5.12.2) can override this. Agents never silently incur costs.\n\nIntegration flow: create context with EconomicPolicy -> register tool with cost -> grant spending UCAN -> send paid message -> verify receipt in event log -> test auto-accept rejection -> test SpendingCapabilityRequired -> test dynamic pricing -> test anti-spam escalation -> verify free relay exists.",
+      "description": "End-to-end integration test covering ALL 9 invariants from \u00a719.14.\n\n\u00a719.14 Invariants:\n1. Economic policy visible before opt-in (legibility). Economic terms are part of context metadata (\u00a75.7), visible to any identity that inspects the context before joining.\n2. No implicit spending \u2014 spending UCAN always required. Protocol NEVER authorizes expenditure without an explicit, valid spending UCAN from the payer's delegation chain.\n3. Free operation is default \u2014 no economic policy = free. Contexts without EconomicPolicy are free. Relays without economic in relay_config are free. Tools without cost metadata are free.\n4. Receipts are provenance records \u2014 every payment is traceable and verifiable. Payment receipts are recorded in context event logs and participate in the provenance chain (\u00a77.7).\n5. Payment adapters are substitutable \u2014 no single rail privileged. The PaymentAdapter trait treats all payment rails equally. Protocol correctness does not depend on any specific adapter.\n6. Economic policy mutable by default, optional immutability lock is voluntary. Unlike ceiling policy (immutable by default), economic policy is governed by default. Creators may voluntarily lock pricing at creation.\n7. Payment data inside encrypted envelope \u2014 relays never see payment metadata for context-level economics.\n8. Free relays MUST always exist in bootstrap list. The SDK's fallback relay list (\u00a718.5) MUST include free relays. This is a protocol invariant that prevents economic gatekeeping of basic protocol operation.\n9. Auto-accept never applies to paid contexts. No auto-accept policy configuration (\u00a75.12.2) can override this. Agents never silently incur costs.\n\nIntegration flow: create context with EconomicPolicy -> register tool with cost -> grant spending UCAN -> send paid message -> verify receipt in event log -> test auto-accept rejection -> test SpendingCapabilityRequired -> test dynamic pricing -> test anti-spam escalation -> verify free relay exists.",
       "acceptanceCriteria": [
-        "Invariant 1 test: Create context with EconomicPolicy, inspect context metadata before joining — economic terms visible",
-        "Invariant 2 test: Attempt paid action without spending UCAN — SpendingCapabilityRequired error returned",
-        "Invariant 2 test: Grant spending UCAN, attempt paid action — action succeeds with payment",
-        "Invariant 3 test: Create context without EconomicPolicy, send message — no payment required, no adapter calls",
-        "Invariant 3 test: Create context without EconomicPolicy, invoke tool — free, no cost",
-        "Invariant 4 test: Complete paid action, query event log — PaymentReceipt present with Merkle inclusion proof",
+        "Invariant 1 test: Create context with EconomicPolicy, inspect context metadata before joining \u2014 economic terms visible",
+        "Invariant 2 test: Attempt paid action without spending UCAN \u2014 SpendingCapabilityRequired error returned",
+        "Invariant 2 test: Grant spending UCAN, attempt paid action \u2014 action succeeds with payment",
+        "Invariant 3 test: Create context without EconomicPolicy, send message \u2014 no payment required, no adapter calls",
+        "Invariant 3 test: Create context without EconomicPolicy, invoke tool \u2014 free, no cost",
+        "Invariant 4 test: Complete paid action, query event log \u2014 PaymentReceipt present with Merkle inclusion proof",
         "Invariant 4 test: PaymentReceipt fields match: payer, payee, amount, currency, adapter_id, action_type",
-        "Invariant 5 test: Replace TestAdapter with a second mock adapter — same flow works identically (adapter substitutability)",
-        "Invariant 6 test: Create context with locked: false, update economic policy via governance — succeeds",
-        "Invariant 6 test: Create context with locked: true, attempt economic policy update — rejected",
-        "Invariant 7 test: Complete paid action, inspect relay-visible data — no payment metadata leaked outside encrypted envelope",
+        "Invariant 5 test: Replace TestAdapter with a second mock adapter \u2014 same flow works identically (adapter substitutability)",
+        "Invariant 6 test: Create context with locked: false, update economic policy via governance \u2014 succeeds",
+        "Invariant 6 test: Create context with locked: true, attempt economic policy update \u2014 rejected",
+        "Invariant 7 test: Complete paid action, inspect relay-visible data \u2014 no payment metadata leaked outside encrypted envelope",
         "Invariant 8 test: Validate SDK's bootstrap relay list includes at least one free relay (no economic config)",
-        "Invariant 9 test: Create paid context, configure auto-accept policy, receive invitation — invitation NOT auto-accepted",
+        "Invariant 9 test: Create paid context, configure auto-accept policy, receive invitation \u2014 invitation NOT auto-accepted",
         "Integration flow: create context with EconomicPolicy including per_message cost and PricingFormula",
         "Integration flow: register tool with per-invocation cost in the context",
         "Integration flow: grant SpendingCapability UCAN from human DID to agent DID",
-        "Integration flow: send paid message — full 9-step sequence completes, receipt recorded",
-        "Integration flow: invoke paid tool — cost includes context + tool cost, receipt recorded",
-        "Integration flow: dynamic pricing — increase SenderVelocity, verify cost increases at threshold boundaries",
-        "Integration flow: anti-spam escalation — send messages at escalating rate, verify cost steps up per SenderVelocity thresholds",
+        "Integration flow: send paid message \u2014 full 9-step sequence completes, receipt recorded",
+        "Integration flow: invoke paid tool \u2014 cost includes context + tool cost, receipt recorded",
+        "Integration flow: dynamic pricing \u2014 increase SenderVelocity, verify cost increases at threshold boundaries",
+        "Integration flow: anti-spam escalation \u2014 send messages at escalating rate, verify cost steps up per SenderVelocity thresholds",
         "Integration flow: verify free relay exists in bootstrap list",
-        "All tests use TestAdapter — no real payment rails"
+        "All tests use TestAdapter \u2014 no real payment rails"
       ],
       "actionItems": [
         "Create crates/scp-core/tests/economy_integration.rs",
@@ -9163,10 +9163,10 @@
         }
       ],
       "details": {
-        "9 invariants from §19.14": "1. Economic policy visible before opt-in (legibility). 2. No implicit spending — spending UCAN always required. 3. Free operation is default — no economic policy = free. 4. Receipts are provenance records — every payment traceable and verifiable. 5. Payment adapters substitutable — no single rail privileged. 6. Economic policy mutable by default, optional immutability lock voluntary. 7. Payment data inside encrypted envelope — relays never see payment metadata. 8. Free relays MUST always exist in bootstrap list. 9. Auto-accept never applies to paid contexts.",
-        "TestAdapter usage": "All integration tests use TestAdapter — in-memory, no real money. seed_balance() for setup, payment_adapter_conformance!() already validates adapter correctness separately."
+        "9 invariants from \u00a719.14": "1. Economic policy visible before opt-in (legibility). 2. No implicit spending \u2014 spending UCAN always required. 3. Free operation is default \u2014 no economic policy = free. 4. Receipts are provenance records \u2014 every payment traceable and verifiable. 5. Payment adapters substitutable \u2014 no single rail privileged. 6. Economic policy mutable by default, optional immutability lock voluntary. 7. Payment data inside encrypted envelope \u2014 relays never see payment metadata. 8. Free relays MUST always exist in bootstrap list. 9. Auto-accept never applies to paid contexts.",
+        "TestAdapter usage": "All integration tests use TestAdapter \u2014 in-memory, no real money. seed_balance() for setup, payment_adapter_conformance!() already validates adapter correctness separately."
       },
-      "result": "40 integration tests covering all 9 invariants from §19.14. Tests cover: economic policy legibility, spending UCAN requirement, free-default operation, receipt provenance, adapter substitutability, policy mutability/lock, envelope privacy, free relay bootstrap, auto-accept rejection, dynamic pricing, anti-spam escalation."
+      "result": "40 integration tests covering all 9 invariants from \u00a719.14. Tests cover: economic policy legibility, spending UCAN requirement, free-default operation, receipt provenance, adapter substitutability, policy mutability/lock, envelope privacy, free relay bootstrap, auto-accept rejection, dynamic pricing, anti-spam escalation."
     },
     {
       "id": "SCP-161",
@@ -9178,31 +9178,31 @@
       "files": [
         "crates/scp-core/src/context/templates.rs"
       ],
-      "description": "Register two new well-known context templates for economic governance (§19.10) and add TemplateId variants.\n\n§19.10 Context Templates:\n\npaid-service (scp:template/paid-service): Tool invocation context with per-invoke cost. economic_policy.cost_schedule.per_tool_invoke required at creation. Single-admin governance. Extends scp:template/tool-interface.\n\nProperties:\n- Ceiling: messagesRead, messagesWrite, toolRegister, toolInvokeAll\n- Ceiling policy: immutable\n- Economic policy: required, per_tool_invoke must be set\n- Governance: single-admin\n- Memory scope: full (receipts are provenance)\n\npaid-broadcast (scp:template/paid-broadcast): Subscription-based broadcast context. economic_policy.cost_schedule.per_period required at creation. Gated subscriber registration — admin grants messagesRead UCAN after payment verification. Extends scp:template/gated-broadcast (§5.14.4).\n\nProperties:\n- Mode: Broadcast\n- Ceiling: messagesRead, messagesWrite\n- Ceiling policy: immutable\n- Economic policy: required, per_period must be set\n- Subscriber admission: gated (admin-issued messagesRead UCAN post-payment)\n- Memory scope: full",
+      "description": "Register two new well-known context templates for economic governance (\u00a719.10) and add TemplateId variants.\n\n\u00a719.10 Context Templates:\n\npaid-service (scp:template/paid-service): Tool invocation context with per-invoke cost. economic_policy.cost_schedule.per_tool_invoke required at creation. Single-admin governance. Extends scp:template/tool-interface.\n\nProperties:\n- Ceiling: messagesRead, messagesWrite, toolRegister, toolInvokeAll\n- Ceiling policy: immutable\n- Economic policy: required, per_tool_invoke must be set\n- Governance: single-admin\n- Memory scope: full (receipts are provenance)\n\npaid-broadcast (scp:template/paid-broadcast): Subscription-based broadcast context. economic_policy.cost_schedule.per_period required at creation. Gated subscriber registration \u2014 admin grants messagesRead UCAN after payment verification. Extends scp:template/gated-broadcast (\u00a75.14.4).\n\nProperties:\n- Mode: Broadcast\n- Ceiling: messagesRead, messagesWrite\n- Ceiling policy: immutable\n- Economic policy: required, per_period must be set\n- Subscriber admission: gated (admin-issued messagesRead UCAN post-payment)\n- Memory scope: full",
       "acceptanceCriteria": [
-        "TemplateId enum extended with PaidService variant — maps to \"scp:template/paid-service\"",
-        "TemplateId enum extended with PaidBroadcast variant — maps to \"scp:template/paid-broadcast\"",
+        "TemplateId enum extended with PaidService variant \u2014 maps to \"scp:template/paid-service\"",
+        "TemplateId enum extended with PaidBroadcast variant \u2014 maps to \"scp:template/paid-broadcast\"",
         "paid-service template registered with ceiling: [messagesRead, messagesWrite, toolRegister, toolInvokeAll]",
         "paid-service template registered with ceiling_policy: immutable",
         "paid-service template registered with governance: single-admin",
         "paid-service template registered with memory_scope: full",
         "paid-service template requires economic_policy at creation (validation error if absent)",
         "paid-service template requires economic_policy.cost_schedule.per_tool_invoke to be set (validation error if None)",
-        "paid-service template extends scp:template/tool-interface — inherits tool-interface base properties",
+        "paid-service template extends scp:template/tool-interface \u2014 inherits tool-interface base properties",
         "paid-broadcast template registered with mode: Broadcast",
         "paid-broadcast template registered with ceiling: [messagesRead, messagesWrite]",
         "paid-broadcast template registered with ceiling_policy: immutable",
         "paid-broadcast template registered with memory_scope: full",
         "paid-broadcast template requires economic_policy at creation (validation error if absent)",
         "paid-broadcast template requires economic_policy.cost_schedule.per_period to be set (validation error if None)",
-        "paid-broadcast template extends scp:template/gated-broadcast (§5.14.4) — inherits gated-broadcast base properties",
+        "paid-broadcast template extends scp:template/gated-broadcast (\u00a75.14.4) \u2014 inherits gated-broadcast base properties",
         "paid-broadcast subscriber admission: gated (admin-issued messagesRead UCAN post-payment verification)",
-        "Unit test: create context with paid-service template — valid when per_tool_invoke is set",
-        "Unit test: create context with paid-service template — rejected when economic_policy is absent",
-        "Unit test: create context with paid-service template — rejected when per_tool_invoke is None",
-        "Unit test: create context with paid-broadcast template — valid when per_period is set",
-        "Unit test: create context with paid-broadcast template — rejected when economic_policy is absent",
-        "Unit test: create context with paid-broadcast template — rejected when per_period is None",
+        "Unit test: create context with paid-service template \u2014 valid when per_tool_invoke is set",
+        "Unit test: create context with paid-service template \u2014 rejected when economic_policy is absent",
+        "Unit test: create context with paid-service template \u2014 rejected when per_tool_invoke is None",
+        "Unit test: create context with paid-broadcast template \u2014 valid when per_period is set",
+        "Unit test: create context with paid-broadcast template \u2014 rejected when economic_policy is absent",
+        "Unit test: create context with paid-broadcast template \u2014 rejected when per_period is None",
         "Unit test: TemplateId::PaidService serializes to \"scp:template/paid-service\"",
         "Unit test: TemplateId::PaidBroadcast serializes to \"scp:template/paid-broadcast\""
       ],
@@ -9231,7 +9231,7 @@
       ],
       "details": {
         "ADR-033 criterion 13": "paid-service and paid-broadcast context templates defined with required economic policy fields.",
-        "Template inheritance": "paid-service extends scp:template/tool-interface. paid-broadcast extends scp:template/gated-broadcast (§5.14.4).",
+        "Template inheritance": "paid-service extends scp:template/tool-interface. paid-broadcast extends scp:template/gated-broadcast (\u00a75.14.4).",
         "Receipts as provenance": "Both templates use memory_scope: full because payment receipts are provenance records that must be retained."
       },
       "result": "PaidService and PaidBroadcast TemplateId variants added. Validation enforces economic_policy presence and required cost fields (per_tool_invoke, per_period). Template inheritance wired. Unit tests for valid/invalid creation and serialization."
@@ -9248,19 +9248,19 @@
         "crates/scp-core/src/economy/mod.rs",
         "crates/scp-core/src/store/economy.rs"
       ],
-      "description": "Adapter credential management (§19.2.5): Each payment adapter requires credentials to operate (wallet private key, LND macaroon, Stripe API key, SPL delegate keypair). Credentials are distinct from spending UCANs. Spending UCAN = authorization ('you may spend $X'). Adapter credential = capability ('here's how to move money'). Both required for any payment. UCAN without credential = can't pay. Credential without UCAN = not authorized to pay. Credentials are bound to the human identity, not the agent. An agent never holds raw payment credentials — it holds a spending UCAN that authorizes the SDK (which holds the credential) to execute payments on its behalf. This separation is critical: revoking the spending UCAN instantly cuts off the agent's ability to spend, without needing to rotate the underlying payment credential. Credential rotation follows identity key rotation (§9.12). SPL-specific: human calls ApproveChecked granting agent's keypair delegate authority on their USDC ATA — single delegate per account, amount-capped. Also implements SCP.Identity.configureAdapter(adapter) SDK function (§19.11) and adapter discovery per identity (§19.2.4).",
+      "description": "Adapter credential management (\u00a719.2.5): Each payment adapter requires credentials to operate (wallet private key, LND macaroon, Stripe API key, SPL delegate keypair). Credentials are distinct from spending UCANs. Spending UCAN = authorization ('you may spend $X'). Adapter credential = capability ('here's how to move money'). Both required for any payment. UCAN without credential = can't pay. Credential without UCAN = not authorized to pay. Credentials are bound to the human identity, not the agent. An agent never holds raw payment credentials \u2014 it holds a spending UCAN that authorizes the SDK (which holds the credential) to execute payments on its behalf. This separation is critical: revoking the spending UCAN instantly cuts off the agent's ability to spend, without needing to rotate the underlying payment credential. Credential rotation follows identity key rotation (\u00a79.12). SPL-specific: human calls ApproveChecked granting agent's keypair delegate authority on their USDC ATA \u2014 single delegate per account, amount-capped. Also implements SCP.Identity.configureAdapter(adapter) SDK function (\u00a719.11) and adapter discovery per identity (\u00a719.2.4).",
       "acceptanceCriteria": [
-        "Adapter credentials stored as identity-private state (§3.7) — encrypted, stored alongside identity keys",
+        "Adapter credentials stored as identity-private state (\u00a73.7) \u2014 encrypted, stored alongside identity keys",
         "Adapter credentials never exposed to contexts or relays",
-        "Adapter credentials bound to human identity, not agent — agent never holds raw payment credentials",
+        "Adapter credentials bound to human identity, not agent \u2014 agent never holds raw payment credentials",
         "Agent holds spending UCAN that authorizes SDK (which holds credential) to execute payments on its behalf",
         "Revoking spending UCAN instantly cuts off agent's ability to spend without rotating underlying payment credential",
-        "Both spending UCAN and adapter credential required for any payment — UCAN without credential = can't pay, credential without UCAN = not authorized to pay",
-        "Credential rotation follows identity key rotation (§9.12)",
+        "Both spending UCAN and adapter credential required for any payment \u2014 UCAN without credential = can't pay, credential without UCAN = not authorized to pay",
+        "Credential rotation follows identity key rotation (\u00a79.12)",
         "Adapters configured per-identity in SDK (not per-context)",
         "Identity may have multiple adapters simultaneously (e.g., x402 + Lightning + SPL)",
         "SCP.Identity.configureAdapter(adapter) function registers a payment adapter with the identity's SDK instance",
-        "configureAdapter stores adapter credentials via ProtocolStore.store_adapter_credentials (§17.3)",
+        "configureAdapter stores adapter credentials via ProtocolStore.store_adapter_credentials (\u00a717.3)",
         "configureAdapter validates adapter implements PaymentAdapter trait before accepting",
         "Adapter credential retrieval via ProtocolStore.load_adapter_credentials for payment execution",
         "list_adapter_credentials returns all configured adapter IDs for an identity",
@@ -9303,8 +9303,8 @@
       ],
       "details": {
         "credentialSeparation": "Spending UCAN = authorization ('you may spend $X'). Adapter credential = capability ('here's how to move money'). Both required for any payment. UCAN without credential = can't pay. Credential without UCAN = not authorized to pay.",
-        "SPL-specific": "Human calls ApproveChecked granting agent's keypair delegate authority on their USDC ATA — single delegate per account, amount-capped.",
-        "protocolSection": "§19.2.4, §19.2.5, §19.11"
+        "SPL-specific": "Human calls ApproveChecked granting agent's keypair delegate authority on their USDC ATA \u2014 single delegate per account, amount-capped.",
+        "protocolSection": "\u00a719.2.4, \u00a719.2.5, \u00a719.11"
       },
       "result": "Implemented adapter credential management in economy/credentials.rs with AdapterCredential, CredentialStore trait, InMemoryCredentialStore, configure_adapter(), list_adapter_credentials(). Added store/ module with ProtocolStore trait and economy storage interface. 24 unit tests. Credentials bound to human identity, not agent."
     },
@@ -9322,7 +9322,7 @@
         "crates/scp-ffi/src/mcp.rs",
         "crates/scp-ffi/src/lib.rs"
       ],
-      "description": "Three PyO3 bridge files return `Err(\"not implemented\")` instead of delegating to real Rust implementations: `tools.rs`, `ucan.rs`, and `event_log.rs` in `crates/scp-ffi/src/`. Additionally, 9 MCP bridge functions called by `bindings/python/scp_sdk/mcp.py` (`py_mcp_serve`, `py_mcp_client_connect_stdio`, etc.) were never registered in the `#[pymodule]` in `crates/scp-ffi/src/lib.rs`. The Phase 3 integration test uses `MagicMock` for the bridge layer, masking these gaps — only 3 of 16 test methods attempt real bridge calls.\n\nThe underlying Rust implementations are solid (MCP crate: 158 tests, UCAN crate: 273 tests). The gap is exclusively in the PyO3 bridge wiring that connects them to the Python SDK.",
+      "description": "Three PyO3 bridge files return `Err(\"not implemented\")` instead of delegating to real Rust implementations: `tools.rs`, `ucan.rs`, and `event_log.rs` in `crates/scp-ffi/src/`. Additionally, 9 MCP bridge functions called by `bindings/python/scp_sdk/mcp.py` (`py_mcp_serve`, `py_mcp_client_connect_stdio`, etc.) were never registered in the `#[pymodule]` in `crates/scp-ffi/src/lib.rs`. The Phase 3 integration test uses `MagicMock` for the bridge layer, masking these gaps \u2014 only 3 of 16 test methods attempt real bridge calls.\n\nThe underlying Rust implementations are solid (MCP crate: 158 tests, UCAN crate: 273 tests). The gap is exclusively in the PyO3 bridge wiring that connects them to the Python SDK.",
       "acceptanceCriteria": [
         "`crates/scp-ffi/src/tools.rs` delegates to real `scp-core` tool registration, invocation, and verification functions (no `Err(\"not implemented\")`)",
         "`crates/scp-ffi/src/ucan.rs` delegates to real `scp-core` UCAN minting, validation, and revocation functions (no `Err(\"not implemented\")`)",
@@ -9330,14 +9330,14 @@
         "All 9 MCP bridge functions (`py_mcp_serve`, `py_mcp_client_connect_stdio`, etc.) are registered in the `#[pymodule]` in `lib.rs`",
         "`crates/scp-ffi/src/mcp.rs` exists and delegates to real `scp-mcp` crate functions",
         "`python -c \"from _scp_core import py_mcp_serve\"` does not raise `ImportError`",
-        "Phase 3 integration test (`tests/integration/phase3_integration_test.py`) passes without `MagicMock` for the bridge layer — real bridge calls succeed for all 16 test methods",
+        "Phase 3 integration test (`tests/integration/phase3_integration_test.py`) passes without `MagicMock` for the bridge layer \u2014 real bridge calls succeed for all 16 test methods",
         "No `\"not implemented\"` strings remain in any `crates/scp-ffi/src/*.rs` file"
       ],
       "actionItems": [
-        "Audit `crates/scp-ffi/src/tools.rs` — replace stub returns with real calls to `scp-core::context::tools` registration, invocation, and verification APIs",
-        "Audit `crates/scp-ffi/src/ucan.rs` — replace stub returns with real calls to `scp-core::crypto::ucan` minting, validation, and revocation APIs",
-        "Audit `crates/scp-ffi/src/event_log.rs` — replace stub returns with real calls to `scp-core::event_log` query, proof generation, and checkpoint APIs",
-        "Create `crates/scp-ffi/src/mcp.rs` — implement PyO3 bridge functions for MCP server and client operations, delegating to `scp-mcp` crate",
+        "Audit `crates/scp-ffi/src/tools.rs` \u2014 replace stub returns with real calls to `scp-core::context::tools` registration, invocation, and verification APIs",
+        "Audit `crates/scp-ffi/src/ucan.rs` \u2014 replace stub returns with real calls to `scp-core::crypto::ucan` minting, validation, and revocation APIs",
+        "Audit `crates/scp-ffi/src/event_log.rs` \u2014 replace stub returns with real calls to `scp-core::event_log` query, proof generation, and checkpoint APIs",
+        "Create `crates/scp-ffi/src/mcp.rs` \u2014 implement PyO3 bridge functions for MCP server and client operations, delegating to `scp-mcp` crate",
         "Register all MCP bridge functions in the `#[pymodule]` function in `crates/scp-ffi/src/lib.rs`",
         "Update `tests/integration/phase3_integration_test.py` to remove `MagicMock` usage for bridge calls and exercise real bridge functions",
         "Run `cargo test -p scp-ffi` and verify all FFI tests pass",
@@ -9356,9 +9356,9 @@
       ],
       "details": {
         "stubFiles": [
-          "crates/scp-ffi/src/tools.rs — returns Err(\"not implemented\")",
-          "crates/scp-ffi/src/ucan.rs — returns Err(\"not implemented\")",
-          "crates/scp-ffi/src/event_log.rs — returns Err(\"not implemented\")"
+          "crates/scp-ffi/src/tools.rs \u2014 returns Err(\"not implemented\")",
+          "crates/scp-ffi/src/ucan.rs \u2014 returns Err(\"not implemented\")",
+          "crates/scp-ffi/src/event_log.rs \u2014 returns Err(\"not implemented\")"
         ],
         "missingMcpFunctions": [
           "py_mcp_serve",
@@ -9371,8 +9371,8 @@
           "py_mcp_server_deregister_tool",
           "py_mcp_server_list_contexts"
         ],
-        "testGap": "Phase 3 integration test uses MagicMock for bridge layer — only 3 of 16 test methods attempt real bridge calls. All 16 must use real bridge after this story.",
-        "underlyingRustStatus": "MCP crate: 158 tests passing. UCAN crate: 273 tests passing. The Rust implementations are complete — only the PyO3 wiring is missing."
+        "testGap": "Phase 3 integration test uses MagicMock for bridge layer \u2014 only 3 of 16 test methods attempt real bridge calls. All 16 must use real bridge after this story.",
+        "underlyingRustStatus": "MCP crate: 158 tests passing. UCAN crate: 273 tests passing. The Rust implementations are complete \u2014 only the PyO3 wiring is missing."
       }
     },
     {
@@ -9386,13 +9386,13 @@
         "crates/scp-ffi/src/ucan.rs",
         "crates/scp-core/src/crypto/ucan.rs"
       ],
-      "description": "The PyO3 bridge UCAN validation (py_ucan_validate in ucan.rs) currently implements 5 of the 11 steps defined in ADR-016 §5. Missing steps: (1) Ed25519 signature verification via DID resolver, (2) proof chain traversal for delegated tokens, (3) delegation depth enforcement, (4) audience/issuer chain validation, (5) scope attenuation verification, (6) nonce uniqueness checking. Without Ed25519 signature verification, any actor can forge a UCAN token with arbitrary capabilities and it will pass validation. This is a protocol-breaking security gap: the entire UCAN authorization model depends on cryptographic non-forgeability.\n\nThe scp-core UCAN module has the full validation pipeline (273 tests passing). The gap is exclusively in the bridge layer not calling the complete validation chain. Requires a DID resolver that can map DIDs to Ed25519 public keys — this needs transport layer connectivity or an in-memory DID document cache.\n\nSee GitHub issue #105.",
+      "description": "The PyO3 bridge UCAN validation (py_ucan_validate in ucan.rs) currently implements 5 of the 11 steps defined in ADR-016 \u00a75. Missing steps: (1) Ed25519 signature verification via DID resolver, (2) proof chain traversal for delegated tokens, (3) delegation depth enforcement, (4) audience/issuer chain validation, (5) scope attenuation verification, (6) nonce uniqueness checking. Without Ed25519 signature verification, any actor can forge a UCAN token with arbitrary capabilities and it will pass validation. This is a protocol-breaking security gap: the entire UCAN authorization model depends on cryptographic non-forgeability.\n\nThe scp-core UCAN module has the full validation pipeline (273 tests passing). The gap is exclusively in the bridge layer not calling the complete validation chain. Requires a DID resolver that can map DIDs to Ed25519 public keys \u2014 this needs transport layer connectivity or an in-memory DID document cache.\n\nSee GitHub issue #105.",
       "acceptanceCriteria": [
-        "py_ucan_validate calls scp-core full 11-step validation pipeline (ADR-016 §5) — not partial bridge-layer validation",
-        "Ed25519 signature verification performed for every UCAN token — forged signatures rejected",
+        "py_ucan_validate calls scp-core full 11-step validation pipeline (ADR-016 \u00a75) \u2014 not partial bridge-layer validation",
+        "Ed25519 signature verification performed for every UCAN token \u2014 forged signatures rejected",
         "DID resolver integrated to retrieve public keys for signature verification",
         "Proof chain traversal validates parent tokens recursively for delegated UCANs",
-        "Delegation depth enforced per ADR-016 §5 maximum depth rules",
+        "Delegation depth enforced per ADR-016 \u00a75 maximum depth rules",
         "Audience/issuer chain validated: each tokens audience matches next tokens issuer",
         "Scope attenuation verified: child token capabilities are subset of parent capabilities",
         "Nonce uniqueness checked against replay prevention cache",
@@ -9419,7 +9419,7 @@
         }
       ],
       "details": {
-        "securityImpact": "CRITICAL — without Ed25519 signature verification, forged UCAN tokens pass validation. Any actor can claim any capability. The entire authorization model is bypassed.",
+        "securityImpact": "CRITICAL \u2014 without Ed25519 signature verification, forged UCAN tokens pass validation. Any actor can claim any capability. The entire authorization model is bypassed.",
         "currentState": "Bridge implements: JWT parsing, header validation, time bounds, capability string matching, revocation list check. Missing: signature verification, proof chains, delegation depth, audience/issuer chain, scope attenuation, nonce uniqueness.",
         "ADR-016 steps": "11 validation steps defined. Bridge implements steps 1-3 (parse), 4 (time bounds), 10 (capability match), 11 (revocation). Missing steps 5 (signature), 6 (proof chain), 7 (delegation depth), 8 (audience/issuer chain), 9 (scope attenuation), plus nonce uniqueness.",
         "DID resolver dependency": "Signature verification requires resolving DID to public key. In-memory DID document cache for bridge-layer testing; transport-backed resolver for production."
@@ -9449,7 +9449,7 @@
         "py_mcp_client_invoke sends a tools/call JSON-RPC request, receives the result, and wraps it with SCP provenance metadata",
         "py_mcp_client_disconnect gracefully closes the transport connection (terminates subprocess or closes HTTP)",
         "py_mcp_load_contexts queries the relay for active contexts (requires relay transport)",
-        "Test: start MCP server, connect client, list tools, invoke tool, stop server — full lifecycle",
+        "Test: start MCP server, connect client, list tools, invoke tool, stop server \u2014 full lifecycle",
         "Test: stdio client connects to subprocess and receives tool list",
         "Test: disconnected client raises TransportError on list_tools/invoke"
       ],
@@ -9489,7 +9489,7 @@
       "files": [
         "crates/scp-ffi/src/mcp.rs"
       ],
-      "description": "Residual stubs from SCP-165 / GitHub #106. The MCP bridge wiring is complete (SCP-165 done), but two FfiBridgeProvider trait methods remain stubbed: (1) validate_capability always returns Ok(()) — no capability checking at the MCP layer, relying solely on UCAN for authorization, (2) invoke_tool returns stub JSON — tool invocations are accepted but not executed. Additionally, py_mcp_load_contexts returns an empty list because relay transport is not yet wired for context discovery.\n\nUCAN (SCP-164) provides the primary authorization boundary, so these stubs are defense-in-depth gaps, not security-breaking. However, they should be completed for layered security and full MCP functionality.\n\nSee GitHub issue #106 (remaining acceptance criteria).",
+      "description": "Residual stubs from SCP-165 / GitHub #106. The MCP bridge wiring is complete (SCP-165 done), but two FfiBridgeProvider trait methods remain stubbed: (1) validate_capability always returns Ok(()) \u2014 no capability checking at the MCP layer, relying solely on UCAN for authorization, (2) invoke_tool returns stub JSON \u2014 tool invocations are accepted but not executed. Additionally, py_mcp_load_contexts returns an empty list because relay transport is not yet wired for context discovery.\n\nUCAN (SCP-164) provides the primary authorization boundary, so these stubs are defense-in-depth gaps, not security-breaking. However, they should be completed for layered security and full MCP functionality.\n\nSee GitHub issue #106 (remaining acceptance criteria).",
       "acceptanceCriteria": [
         "FfiBridgeProvider::validate_capability performs real capability checking against context role state and ceiling",
         "FfiBridgeProvider::invoke_tool executes real tool invocations via ToolRegistry and returns actual results",
@@ -9517,12 +9517,12 @@
         }
       ],
       "details": {
-        "securityImpact": "MEDIUM — defense-in-depth gap. UCAN layer (SCP-164) is the primary authorization boundary and is fully implemented. These stubs mean MCP layer does not independently verify capabilities, so a UCAN bypass would have no secondary check.",
+        "securityImpact": "MEDIUM \u2014 defense-in-depth gap. UCAN layer (SCP-164) is the primary authorization boundary and is fully implemented. These stubs mean MCP layer does not independently verify capabilities, so a UCAN bypass would have no secondary check.",
         "currentState": "validate_capability returns Ok(()) with TODO(#106). invoke_tool returns {\"status\": \"invoked\", \"tool\": name, \"note\": \"TODO(#106)...\"}. py_mcp_load_contexts returns empty Vec.",
         "transportDependency": "py_mcp_load_contexts requires relay transport (scp-transport) wiring. validate_capability and invoke_tool can be completed independently.",
         "relationship": "SCP-165 delivered the bridge wiring. This story completes the remaining stubs that SCP-165 deferred."
       },
-      "result": "validate_capability checks has_tool_invoke_capability against role state (generic wire-facing error, detailed server-side tracing::warn). invoke_tool validates input against JSON schema, returns status=validated (no handler dispatch — ToolRegistry is metadata-only). py_mcp_load_contexts returns local registry contexts via context_ids_for_member. dead_code annotations removed (added py_mcp_server_info/py_mcp_client_info introspection). All 41 scp-ffi tests pass. Residual architectural gaps tracked in #115 (invoke_tool handler dispatch) and #116 (relay-based context discovery)."
+      "result": "validate_capability checks has_tool_invoke_capability against role state (generic wire-facing error, detailed server-side tracing::warn). invoke_tool validates input against JSON schema, returns status=validated (no handler dispatch \u2014 ToolRegistry is metadata-only). py_mcp_load_contexts returns local registry contexts via context_ids_for_member. dead_code annotations removed (added py_mcp_server_info/py_mcp_client_info introspection). All 41 scp-ffi tests pass. Residual architectural gaps tracked in #115 (invoke_tool handler dispatch) and #116 (relay-based context discovery)."
     },
     {
       "id": "SCP-211",
@@ -9565,8 +9565,8 @@
       ],
       "details": {
         "references": [
-          "ADR-028 — Kotlin SDK layout and conventions",
-          "scaffold/kotlin.md — Build infrastructure blueprint"
+          "ADR-028 \u2014 Kotlin SDK layout and conventions",
+          "scaffold/kotlin.md \u2014 Build infrastructure blueprint"
         ]
       },
       "result": "Android module scaffold complete. Both :scp-sdk-kotlin:build and :scp-sdk-kotlin-android:build succeed. Commit 9c0ff7d."
@@ -9582,12 +9582,12 @@
         "crates/scp-ffi/src/mcp.rs",
         "crates/scp-core/src/context/tools/invoke.rs"
       ],
-      "description": "FfiBridgeProvider::invoke_tool validates input schema but cannot dispatch to actual tool handlers. ToolRegistry stores metadata only (no handler functions). The real invoke_tool in scp-core accepts an executor: F parameter injected by the caller. Need to design a handler registration mechanism at the FFI layer so Python callers can register callable tool handlers that Rust can dispatch to. Also need to handle the sync→async boundary (ContextProvider trait is sync, scp-core invoke is async).",
+      "description": "FfiBridgeProvider::invoke_tool validates input schema but cannot dispatch to actual tool handlers. ToolRegistry stores metadata only (no handler functions). The real invoke_tool in scp-core accepts an executor: F parameter injected by the caller. Need to design a handler registration mechanism at the FFI layer so Python callers can register callable tool handlers that Rust can dispatch to. Also need to handle the sync\u2192async boundary (ContextProvider trait is sync, scp-core invoke is async).",
       "acceptanceCriteria": [
         "Python tool handlers can be registered via PyO3 and stored in the runtime registry",
         "FfiBridgeProvider::invoke_tool dispatches through scp-core invoke with the registered handler",
         "invoke_tool response contains actual computed output, not echoed input",
-        "Sync→async boundary handled correctly (ContextProvider is sync)",
+        "Sync\u2192async boundary handled correctly (ContextProvider is sync)",
         "Test: registered Python handler is called and result returned via MCP"
       ],
       "actionItems": [
@@ -9620,7 +9620,7 @@
         "crates/scp-transport/src/native/protocol.rs",
         "crates/scp-ffi/src/transport.rs"
       ],
-      "description": "py_mcp_load_contexts returns local registry contexts only. The relay wire protocol (ClientMessage enum) has no ListContexts message type — the relay is a dumb blob store routing by RoutingId with no concept of identity-to-context membership. Need to design a context discovery mechanism (new relay protocol message or client-side probing), wire scp-transport initialization into FFI runtime, and implement relay-based discovery falling back to local registry.",
+      "description": "py_mcp_load_contexts returns local registry contexts only. The relay wire protocol (ClientMessage enum) has no ListContexts message type \u2014 the relay is a dumb blob store routing by RoutingId with no concept of identity-to-context membership. Need to design a context discovery mechanism (new relay protocol message or client-side probing), wire scp-transport initialization into FFI runtime, and implement relay-based discovery falling back to local registry.",
       "acceptanceCriteria": [
         "Context discovery protocol designed (relay message or client-side approach)",
         "scp-transport initialized in FFI runtime",
@@ -9669,7 +9669,7 @@
         "crates/scp-ffi/src/runtime.rs",
         ".docs/specs/09-security-model.md"
       ],
-      "description": "Wire platform-injected KeyCustodyProvider callbacks through all three FFI bridges (PyO3, UniFFI, WASM/NAPI) into scp-core crypto operations. Currently, all bridges use InMemoryKeyCustody unconditionally — platform custody (Secure Enclave, Android Keystore) is implemented (SCP-093, SCP-110) but unreachable from Rust. KeyHandle references are not retained across FFI boundaries, making all cryptographic operations impossible with real key material.\n\nWithout this wiring, 14 scp-core public functions that take &impl KeyCustody are unreachable from production FFI code:\n- Identity: DidMethod::create, DidMethod::rotate (trait methods called by FFI bridges)\n- Envelope: create_inner_envelope (message signing), derive_pseudonym (routing IDs)\n- Event log: CheckpointManager::maybe_create_checkpoint, CheckpointManager::force_create_checkpoint, generate_checkpoint (checkpoint signing)\n- UCAN: mint_ucan (token signing — py_ucan_mint is a stub that doesn't call scp-core yet), delegate_ucan (delegation chain signing — no FFI bridge function exists)\n- Sender keys: publish_sender_key_epoch_advance, request_sender_key, open_sender_key_response, send_block_notification, rotate_sender_key_for_block\n\nAdditionally, 5 internal functions (DidDht::make_sign_fn, rotate_active_key, create_new_identity_keys, build_migration_proof, generate_checkpoint_at) take KeyCustody but are called by the above — they don't need separate FFI wiring. One more public function, DidDht::migrate_identity, has no FFI bridge function yet and should be added in this story.\n\nseal_envelope takes a pre-computed routing_id: &[u8] parameter, so it does not take KeyCustody directly — but its two inputs (routing_id from derive_pseudonym and InnerEnvelope from create_inner_envelope) both require KeyCustody upstream. The entire message send path is blocked.\n\nAdditionally, the InMemoryKeyCustody implementation has a code bug: derive_pseudonym at key_custody.rs:333 uses signing_key.to_bytes() (private key bytes) as the HMAC key, but ADR-027 amendment requires public key bytes for cross-platform determinism with hardware TEE keys. This means pseudonym derivation will produce different results between InMemoryKeyCustody and platform adapters (AndroidKeyCustody, AppleKeyCustody) which correctly use public key bytes. The golden vector test at key_custody.rs:626 is keyed to the wrong (private-key) derivation.\n\nThis is a P0 blocker because:\n1. Routing IDs use a stub HMAC derivation (context.rs) instead of KeyCustody::derive_pseudonym — relay probes never match real envelopes\n2. InMemoryKeyCustody stores private keys in unprotected heap memory on mobile devices — the entire TEE/Secure Enclave security model is dead code\n3. Key rotation always errors (\"requires wired KeyCustodyProvider\")\n4. UniFFI KeyCustodyProvider callback interface is incomplete — missing derive_pseudonym and dh_agree methods vs the full KeyCustody trait (7 methods)\n5. Inner envelope signing, UCAN minting/delegation, checkpoint signing, and all sender key protocol operations are unreachable with platform key material\n6. py_ucan_mint (ucan.rs:320) is a stub that builds a local PyUcanToken without calling scp-core::mint_ucan — no real signing occurs\n7. No py_ucan_delegate or py_identity_migrate bridge functions exist despite scp-core implementations being complete (SCP-056, SCP-008)\n8. InMemoryKeyCustody uses private key bytes for pseudonym HMAC (key_custody.rs:333) but ADR-027 mandates public key bytes — cross-platform pseudonym determinism is broken\n\nThe architecture is fully specified in ADR-006, ADR-021, ADR-022, ADR-025, ADR-027. Platform adapters are implemented. Only the wiring is missing.",
+      "description": "Wire platform-injected KeyCustodyProvider callbacks through all three FFI bridges (PyO3, UniFFI, WASM/NAPI) into scp-core crypto operations. Currently, all bridges use InMemoryKeyCustody unconditionally \u2014 platform custody (Secure Enclave, Android Keystore) is implemented (SCP-093, SCP-110) but unreachable from Rust. KeyHandle references are not retained across FFI boundaries, making all cryptographic operations impossible with real key material.\n\nWithout this wiring, 14 scp-core public functions that take &impl KeyCustody are unreachable from production FFI code:\n- Identity: DidMethod::create, DidMethod::rotate (trait methods called by FFI bridges)\n- Envelope: create_inner_envelope (message signing), derive_pseudonym (routing IDs)\n- Event log: CheckpointManager::maybe_create_checkpoint, CheckpointManager::force_create_checkpoint, generate_checkpoint (checkpoint signing)\n- UCAN: mint_ucan (token signing \u2014 py_ucan_mint is a stub that doesn't call scp-core yet), delegate_ucan (delegation chain signing \u2014 no FFI bridge function exists)\n- Sender keys: publish_sender_key_epoch_advance, request_sender_key, open_sender_key_response, send_block_notification, rotate_sender_key_for_block\n\nAdditionally, 5 internal functions (DidDht::make_sign_fn, rotate_active_key, create_new_identity_keys, build_migration_proof, generate_checkpoint_at) take KeyCustody but are called by the above \u2014 they don't need separate FFI wiring. One more public function, DidDht::migrate_identity, has no FFI bridge function yet and should be added in this story.\n\nseal_envelope takes a pre-computed routing_id: &[u8] parameter, so it does not take KeyCustody directly \u2014 but its two inputs (routing_id from derive_pseudonym and InnerEnvelope from create_inner_envelope) both require KeyCustody upstream. The entire message send path is blocked.\n\nAdditionally, the InMemoryKeyCustody implementation has a code bug: derive_pseudonym at key_custody.rs:333 uses signing_key.to_bytes() (private key bytes) as the HMAC key, but ADR-027 amendment requires public key bytes for cross-platform determinism with hardware TEE keys. This means pseudonym derivation will produce different results between InMemoryKeyCustody and platform adapters (AndroidKeyCustody, AppleKeyCustody) which correctly use public key bytes. The golden vector test at key_custody.rs:626 is keyed to the wrong (private-key) derivation.\n\nThis is a P0 blocker because:\n1. Routing IDs use a stub HMAC derivation (context.rs) instead of KeyCustody::derive_pseudonym \u2014 relay probes never match real envelopes\n2. InMemoryKeyCustody stores private keys in unprotected heap memory on mobile devices \u2014 the entire TEE/Secure Enclave security model is dead code\n3. Key rotation always errors (\"requires wired KeyCustodyProvider\")\n4. UniFFI KeyCustodyProvider callback interface is incomplete \u2014 missing derive_pseudonym and dh_agree methods vs the full KeyCustody trait (7 methods)\n5. Inner envelope signing, UCAN minting/delegation, checkpoint signing, and all sender key protocol operations are unreachable with platform key material\n6. py_ucan_mint (ucan.rs:320) is a stub that builds a local PyUcanToken without calling scp-core::mint_ucan \u2014 no real signing occurs\n7. No py_ucan_delegate or py_identity_migrate bridge functions exist despite scp-core implementations being complete (SCP-056, SCP-008)\n8. InMemoryKeyCustody uses private key bytes for pseudonym HMAC (key_custody.rs:333) but ADR-027 mandates public key bytes \u2014 cross-platform pseudonym determinism is broken\n\nThe architecture is fully specified in ADR-006, ADR-021, ADR-022, ADR-025, ADR-027. Platform adapters are implemented. Only the wiring is missing.",
       "acceptanceCriteria": [
         "UniFFI KeyCustodyProvider callback interface includes all 7 KeyCustody trait methods: generate_keypair, sign, get_public_key, destroy_key, dh_agree, derive_pseudonym, custody_type",
         "UniFFI identity_create with CustodyMethod::Platform accepts an injected KeyCustodyProvider and creates identity using it",
@@ -9681,8 +9681,8 @@
         "New py_ucan_delegate bridge function added, calling scp-core::delegate_ucan with retained KeyCustody",
         "py_identity_rotate_key performs real key rotation via retained KeyCustodyProvider (calls DidMethod::rotate which delegates to DidDht::rotate_active_key internally)",
         "New py_identity_migrate bridge function added, calling DidDht::migrate_identity with retained KeyCustody for Layer 2 DID migration",
-        "InMemoryKeyCustody is only used when custody==\"in_memory\" — never as a fallback for platform custody",
-        "InMemoryKeyCustody::derive_pseudonym uses public key bytes (verifying_key.to_bytes()) as HMAC key, not private key bytes — matching ADR-027 amendment and platform adapter behavior",
+        "InMemoryKeyCustody is only used when custody==\"in_memory\" \u2014 never as a fallback for platform custody",
+        "InMemoryKeyCustody::derive_pseudonym uses public key bytes (verifying_key.to_bytes()) as HMAC key, not private key bytes \u2014 matching ADR-027 amendment and platform adapter behavior",
         "Golden vector test at key_custody.rs:626 updated to match public-key-based HMAC derivation",
         "Private key material never crosses any FFI boundary (invariant from ADR-006)",
         "All existing tests pass (cargo test --workspace --exclude scp-ffi)",
@@ -9701,8 +9701,8 @@
         "Wire pseudonym derivation into UniFFI and NAPI/WASM context creation paths",
         "Wire create_inner_envelope signing through retained KeyCustody in all bridge send paths",
         "Replace py_ucan_mint stub (ucan.rs:320) with real scp_core::mint_ucan call using retained KeyCustody",
-        "Add py_ucan_delegate bridge function (new) calling scp_core::delegate_ucan with retained KeyCustody — no bridge function exists today despite SCP-056/SCP-057 implementing scp-core and Python wrapper",
-        "Add py_identity_migrate bridge function (new) calling DidDht::migrate_identity with retained KeyCustody — no bridge function exists today despite SCP-008 implementing scp-core",
+        "Add py_ucan_delegate bridge function (new) calling scp_core::delegate_ucan with retained KeyCustody \u2014 no bridge function exists today despite SCP-056/SCP-057 implementing scp-core and Python wrapper",
+        "Add py_identity_migrate bridge function (new) calling DidDht::migrate_identity with retained KeyCustody \u2014 no bridge function exists today despite SCP-008 implementing scp-core",
         "Implement py_identity_rotate_key using retained KeyCustodyProvider (calls DidMethod::rotate trait method which delegates to DidDht::rotate_active_key internally)",
         "Fix InMemoryKeyCustody::derive_pseudonym (key_custody.rs:333): change signing_key.to_bytes() to verifying_key.to_bytes() so HMAC uses public key bytes per ADR-027 amendment",
         "Update golden vector test (key_custody.rs:626) expected values to match public-key-based HMAC derivation",
@@ -9738,24 +9738,24 @@
       ],
       "details": {
         "designInvariant": "Private key material MUST NOT cross any FFI boundary (ADR-006). All signing, pseudonym derivation, and DH agreement happens inside the custody boundary. FFI bridges pass data-to-sign across the boundary and receive signatures back. KeyHandle is an opaque u64 index into the custody provider's internal store.",
-        "adr027Amendment": "ADR-027 amended key_material for HMAC pseudonym derivation from private key bytes to public key bytes for cross-platform determinism (hardware TEE keys have no extractable private bytes). All adapters (Apple, Android, in-memory) MUST use publicKey(keyHandle) bytes as the HMAC key. Three doc inconsistencies were found and already fixed: (1) traits.rs:340, (2) wasm/custody.rs:97, (3) 09-security-model.md:530. One code bug remains: InMemoryKeyCustody at key_custody.rs:333 uses signing_key.to_bytes() (private key) — must change to verifying_key.to_bytes() (public key). Golden vector test at key_custody.rs:626 will need updated expected values.",
+        "adr027Amendment": "ADR-027 amended key_material for HMAC pseudonym derivation from private key bytes to public key bytes for cross-platform determinism (hardware TEE keys have no extractable private bytes). All adapters (Apple, Android, in-memory) MUST use publicKey(keyHandle) bytes as the HMAC key. Three doc inconsistencies were found and already fixed: (1) traits.rs:340, (2) wasm/custody.rs:97, (3) 09-security-model.md:530. One code bug remains: InMemoryKeyCustody at key_custody.rs:333 uses signing_key.to_bytes() (private key) \u2014 must change to verifying_key.to_bytes() (public key). Golden vector test at key_custody.rs:626 will need updated expected values.",
         "keyCustodyConsumers": {
           "identity": [
-            "DidMethod::create — trait method (identity/mod.rs:231) — called by all identity_create bridge functions",
-            "DidMethod::rotate — trait method (identity/mod.rs:277) — called by py_identity_rotate_key (currently errors)"
+            "DidMethod::create \u2014 trait method (identity/mod.rs:231) \u2014 called by all identity_create bridge functions",
+            "DidMethod::rotate \u2014 trait method (identity/mod.rs:277) \u2014 called by py_identity_rotate_key (currently errors)"
           ],
           "envelope": [
-            "create_inner_envelope (inner.rs:122) — message signing, called by context send paths",
-            "derive_pseudonym (pseudonym.rs:39) — routing ID derivation, called by context create paths"
+            "create_inner_envelope (inner.rs:122) \u2014 message signing, called by context send paths",
+            "derive_pseudonym (pseudonym.rs:39) \u2014 routing ID derivation, called by context create paths"
           ],
           "eventLog": [
-            "CheckpointManager::maybe_create_checkpoint (checkpoint.rs:319) — conditional checkpoint",
-            "CheckpointManager::force_create_checkpoint (checkpoint.rs:358) — unconditional checkpoint",
-            "generate_checkpoint (checkpoint.rs:794) — public free function"
+            "CheckpointManager::maybe_create_checkpoint (checkpoint.rs:319) \u2014 conditional checkpoint",
+            "CheckpointManager::force_create_checkpoint (checkpoint.rs:358) \u2014 unconditional checkpoint",
+            "generate_checkpoint (checkpoint.rs:794) \u2014 public free function"
           ],
           "ucan": [
-            "mint_ucan (mint.rs:129) — token signing (py_ucan_mint is a stub that doesn't call this yet)",
-            "delegate_ucan (mint.rs:292) — delegation chain signing (no FFI bridge function exists yet; SCP-056/SCP-057 defined the scp-core impl and Python wrapper but bridge wiring is missing)"
+            "mint_ucan (mint.rs:129) \u2014 token signing (py_ucan_mint is a stub that doesn't call this yet)",
+            "delegate_ucan (mint.rs:292) \u2014 delegation chain signing (no FFI bridge function exists yet; SCP-056/SCP-057 defined the scp-core impl and Python wrapper but bridge wiring is missing)"
           ],
           "senderKeys": [
             "publish_sender_key_epoch_advance (key_protocol.rs:205)",
@@ -9766,9 +9766,9 @@
           ]
         },
         "internalConsumers": "Functions that take KeyCustody but are called internally by the above (don't need separate FFI wiring): DidDht::make_sign_fn (dht.rs:155, captures Arc<K> for signing closure), DidDht::rotate_active_key (dht.rs:459, called by DidMethod::rotate at line 914), DidDht::create_new_identity_keys (dht.rs:597, called by migrate_identity), DidDht::build_migration_proof (dht.rs:646, called by migrate_identity), generate_checkpoint_at (checkpoint.rs:882, called by CheckpointManager methods).",
-        "notYetExposedViaFFI": "Two scp-core functions take KeyCustody but have no corresponding FFI bridge function: (1) delegate_ucan (mint.rs:292) — SCP-056 implemented the scp-core function and SCP-057 defined a Python wrapper, but no py_ucan_delegate bridge function exists in crates/scp-ffi/src/ucan.rs. (2) DidDht::migrate_identity (dht.rs:531) — SCP-008 implemented scp-core but no py_identity_migrate bridge function exists. This story should add bridge functions for both, since they require KeyCustody and are part of the complete FFI surface.",
+        "notYetExposedViaFFI": "Two scp-core functions take KeyCustody but have no corresponding FFI bridge function: (1) delegate_ucan (mint.rs:292) \u2014 SCP-056 implemented the scp-core function and SCP-057 defined a Python wrapper, but no py_ucan_delegate bridge function exists in crates/scp-ffi/src/ucan.rs. (2) DidDht::migrate_identity (dht.rs:531) \u2014 SCP-008 implemented scp-core but no py_identity_migrate bridge function exists. This story should add bridge functions for both, since they require KeyCustody and are part of the complete FFI surface.",
         "sealEnvelopeNote": "seal_envelope (outer.rs:169) takes routing_id: &[u8] and InnerEnvelope as pre-computed inputs. It does not take KeyCustody directly, but both inputs require KeyCustody upstream: routing_id comes from derive_pseudonym, and InnerEnvelope comes from create_inner_envelope which signs with KeyCustody. The entire message send path is blocked without this wiring.",
-        "inMemoryCodeBug": "InMemoryKeyCustody::derive_pseudonym at key_custody.rs:333 uses signing_key.to_bytes() (Ed25519 private/secret key bytes, 32 bytes) as the HMAC key. ADR-027 mandates verifying_key.to_bytes() (Ed25519 public key bytes, 32 bytes) for cross-platform determinism — hardware TEE keys (Android Keystore, Secure Enclave) cannot export private bytes. AndroidKeyCustody.kt correctly uses publicKey(keyHandle) at line 178. AppleKeyCustody.swift correctly uses publicKey(). InMemoryKeyCustody is the outlier. The golden vector test at key_custody.rs:626 will need updated expected values after the fix."
+        "inMemoryCodeBug": "InMemoryKeyCustody::derive_pseudonym at key_custody.rs:333 uses signing_key.to_bytes() (Ed25519 private/secret key bytes, 32 bytes) as the HMAC key. ADR-027 mandates verifying_key.to_bytes() (Ed25519 public key bytes, 32 bytes) for cross-platform determinism \u2014 hardware TEE keys (Android Keystore, Secure Enclave) cannot export private bytes. AndroidKeyCustody.kt correctly uses publicKey(keyHandle) at line 178. AppleKeyCustody.swift correctly uses publicKey(). InMemoryKeyCustody is the outlier. The golden vector test at key_custody.rs:626 will need updated expected values after the fix."
       }
     },
     {
@@ -9796,14 +9796,14 @@
       "description": "Audit and normalize every error code across all SDKs to conform to the SCP-{PREFIX}-{NUMBER} standard defined in .docs/standards/sdk-common.md.\n\nPR #118 agent review revealed systematic non-conformance: 18+ distinct prefixes in the codebase versus 9 defined ranges, three numbering conventions (bare 3-digit, correct 4-digit, wrong-range 4-digit), prefix spelling variants (PERM/PRM, VALID/VAL, TRANS/TRANSPORT/TXP), and an outright range swap in NAPI (TOOL codes in TRANS range and vice versa). Root cause: the standard existed (Feb 23) but implementing agents did not read it.\n\nAdditionally, SCP-MCP- codes (8001-8008 in Python mcp.py) now collide with the SCP-STORAGE- range (8000-8999) allocated during the PR #118 fix. SCP-MCP- needs its own range.",
       "acceptanceCriteria": [
         "Every SCP-{PREFIX}-{NUMBER} code in the codebase falls within its sdk-common.md allocated range",
-        "No two prefixes share a numeric range — each prefix has an exclusive range",
+        "No two prefixes share a numeric range \u2014 each prefix has an exclusive range",
         "SCP-MCP- has its own allocated range in sdk-common.md (not colliding with SCP-STORAGE- 8000-8999)",
         "Python mcp.py codes (SCP-MCP-8001..8008) updated to the new SCP-MCP- range",
-        "NAPI TOOL/TRANS range swap corrected — SCP-TOOL- codes are in 6000-6999, SCP-TRANS- codes are in 5000-5999",
+        "NAPI TOOL/TRANS range swap corrected \u2014 SCP-TOOL- codes are in 6000-6999, SCP-TRANS- codes are in 5000-5999",
         "All bare 3-digit codes normalized to 4-digit within their correct range",
         "Prefix spellings unified: PERM not PRM, VALID not VAL, TRANS not TRANSPORT or TXP",
-        "ADR phase-5.md code examples use conformant codes (SCP-CTX-001 → SCP-CTX-3001)",
-        "ADR phase-6.md code examples use conformant codes (SCP-PUSH- → SCP-TRANS-, SCP-IDENTITY- → SCP-IDENT-, SCP-CTX-001 → SCP-CTX-3001)",
+        "ADR phase-5.md code examples use conformant codes (SCP-CTX-001 \u2192 SCP-CTX-3001)",
+        "ADR phase-6.md code examples use conformant codes (SCP-PUSH- \u2192 SCP-TRANS-, SCP-IDENTITY- \u2192 SCP-IDENT-, SCP-CTX-001 \u2192 SCP-CTX-3001)",
         "CI conformance test (grep-based) prevents future drift from sdk-common.md ranges"
       ],
       "actionItems": [
@@ -9812,8 +9812,8 @@
         "Fix NAPI error codes: swap TOOL and TRANS codes back to correct ranges",
         "Normalize bare 3-digit codes to 4-digit in all SDKs",
         "Unify prefix spellings across all SDKs (PERM, VALID, TRANS)",
-        "Fix ADR phase-5.md examples: SCP-CTX-001 → SCP-CTX-3001 (2 occurrences)",
-        "Fix ADR phase-6.md examples: SCP-PUSH-5001/5002 → SCP-TRANS-5001/5002, SCP-IDENTITY-1001 → SCP-IDENT-1001, SCP-CTX-001 → SCP-CTX-3001",
+        "Fix ADR phase-5.md examples: SCP-CTX-001 \u2192 SCP-CTX-3001 (2 occurrences)",
+        "Fix ADR phase-6.md examples: SCP-PUSH-5001/5002 \u2192 SCP-TRANS-5001/5002, SCP-IDENTITY-1001 \u2192 SCP-IDENT-1001, SCP-CTX-001 \u2192 SCP-CTX-3001",
         "Add CI grep test that validates all SCP-{PREFIX}-{NUMBER} codes against sdk-common.md ranges"
       ],
       "blockedBy": [],
@@ -9845,7 +9845,7 @@
       "acceptanceCriteria": [
         "ADR-014 specifies receive() lifecycle: async channel receive (not sync try_recv), empty vs closed distinction, transport wiring, buffer overflow, shutdown triggers",
         "__anext__ uses async recv() and distinguishes empty channel (await more) from closed channel (StopAsyncIteration)",
-        "Sender handle (_tx) wired to transport adapter message delivery pipeline — not immediately dropped",
+        "Sender handle (_tx) wired to transport adapter message delivery pipeline \u2014 not immediately dropped",
         "Buffer capacity is 1000 events with oldest-drop overflow behavior per sketch.md",
         "BufferOverflow warning event emitted when buffer is full and oldest event is dropped",
         "Channel closes deterministically on leave(), eviction, or context close",
@@ -9913,8 +9913,8 @@
       ],
       "actionItems": [
         "Add StorageProvider injection to Python FFI initialization (py_init or module-level registration)",
-        "Implement identity persistence in py_identity_create — store DID, custody type, key handle references",
-        "Implement real py_identity_load — retrieve from StorageProvider, reconstruct PyIdentity with correct custody",
+        "Implement identity persistence in py_identity_create \u2014 store DID, custody type, key handle references",
+        "Implement real py_identity_load \u2014 retrieve from StorageProvider, reconstruct PyIdentity with correct custody",
         "Add error path for missing identity in storage",
         "Add integration test: create identity, restart (re-init bridge), load identity, verify DID matches"
       ],
@@ -9931,7 +9931,7 @@
         }
       ],
       "details": {
-        "currentStub": "py_identity_load at identity.rs:278-299 validates DID format (did:dht: prefix) then returns PyIdentity { did, custody: \"in_memory\" } without any storage interaction. The inline comment says \"See ADR-013 acceptance criterion 2\" — the criterion exists but was never wired.",
+        "currentStub": "py_identity_load at identity.rs:278-299 validates DID format (did:dht: prefix) then returns PyIdentity { did, custody: \"in_memory\" } without any storage interaction. The inline comment says \"See ADR-013 acceptance criterion 2\" \u2014 the criterion exists but was never wired.",
         "relationship": "This is the Storage analog of SCP-214 (KeyCustody wiring). SCP-214 wires KeyCustodyProvider for crypto operations; SCP-217 wires StorageProvider for identity persistence. Both are required for a production-ready Python FFI bridge."
       }
     },
@@ -10088,15 +10088,15 @@
         "crates/scp-core/src/store/mod.rs",
         "crates/scp-core/src/store/protocol_store.rs"
       ],
-      "description": "Spec §17.4 defines a ProtocolStore that provides typed domain methods (60+) wrapping the raw Storage trait (SCP-001). This is the persistence layer that all higher-level code uses. Currently not implemented — higher-level code works with in-memory state only. Note: SCP-135 (auto-accept policy persistence) is a consumer of Storage, not a prerequisite.",
+      "description": "Spec \u00a717.4 defines a ProtocolStore that provides typed domain methods (60+) wrapping the raw Storage trait (SCP-001). This is the persistence layer that all higher-level code uses. Currently not implemented \u2014 higher-level code works with in-memory state only. Note: SCP-135 (auto-accept policy persistence) is a consumer of Storage, not a prerequisite.",
       "acceptanceCriteria": [
         "ProtocolStore<S: Storage> struct wraps a generic Storage implementation with typed accessor methods",
         "Identity state CRUD: store/load/delete identity, key handles, DID documents",
         "Context state CRUD: store/load/delete context params, membership, roles, event log",
         "UCAN state: store/load/delete tokens, revocation lists, nonce tracker",
         "Tool state: store/load/delete registrations, schemas",
-        "Key convention follows §17.3 namespace pattern (e.g., identity/{did}/state)",
-        "StoredValue<T> version envelope per §17.5 for forward compatibility",
+        "Key convention follows \u00a717.3 namespace pattern (e.g., identity/{did}/state)",
+        "StoredValue<T> version envelope per \u00a717.5 for forward compatibility",
         "All methods use MessagePack serialization via rmp-serde"
       ],
       "priority": "P0",
@@ -10129,14 +10129,14 @@
         "crates/scp-core/src/discovery/petnames.rs",
         "crates/scp-core/src/discovery/mod.rs"
       ],
-      "description": "Spec §22 defines a human-readable addressing layer with 5 mechanisms: petnames (local), discovery context handles, attestation-backed handles, domain handles, and unified resolution. Currently zero implementation exists.",
+      "description": "Spec \u00a722 defines a human-readable addressing layer with 5 mechanisms: petnames (local), discovery context handles, attestation-backed handles, domain handles, and unified resolution. Currently zero implementation exists.",
       "acceptanceCriteria": [
-        "Address format types: Petname, DiscoveryHandle, AttestationHandle, DomainHandle per §22.2",
-        "TrustLevel enum: Self, Attestation, Context, Community per §22.7",
-        "handle_register, handle_lookup, handle_deregister discovery context tools per §22.5",
+        "Address format types: Petname, DiscoveryHandle, AttestationHandle, DomainHandle per \u00a722.2",
+        "TrustLevel enum: Self, Attestation, Context, Community per \u00a722.7",
+        "handle_register, handle_lookup, handle_deregister discovery context tools per \u00a722.5",
         "AddressResolver with resolve() returning results ranked by TrustLevel (Self > Attestation > Context > Community)",
-        "Petname storage in identity private state per §22.3",
-        "Resolution caching with TTL per §22.8",
+        "Petname storage in identity private state per \u00a722.3",
+        "Resolution caching with TTL per \u00a722.8",
         "Unit tests: at least one test per addressing mechanism (petname, discovery, attestation, domain, unified resolution)"
       ],
       "priority": "P2",
@@ -10168,14 +10168,14 @@
         "crates/scp-core/src/crypto/sender_keys/broadcast.rs",
         "crates/scp-core/src/crypto/sender_keys/mod.rs"
       ],
-      "description": "ContextMode::Broadcast is type-defined (SCP-018) but has no runtime behavior. This story implements the core crypto layer: per-author AES-256 broadcast keys (§5.14.2), BroadcastEnvelope seal/open (§5.14.5), and KeyEpochAdvance event type. Subscriber registration, blocking, and integration testing are SCP-227.",
+      "description": "ContextMode::Broadcast is type-defined (SCP-018) but has no runtime behavior. This story implements the core crypto layer: per-author AES-256 broadcast keys (\u00a75.14.2), BroadcastEnvelope seal/open (\u00a75.14.5), and KeyEpochAdvance event type. Subscriber registration, blocking, and integration testing are SCP-227.",
       "acceptanceCriteria": [
-        "generate_broadcast_key() creates per-author AES-256 key with epoch counter per §5.14.2",
+        "generate_broadcast_key() creates per-author AES-256 key with epoch counter per \u00a75.14.2",
         "rotate_broadcast_key() increments epoch, generates new key, emits KeyEpochAdvance event",
         "BroadcastEnvelope seal: encrypts payload with author's current broadcast key, includes epoch in header",
         "BroadcastEnvelope open: decrypts payload using author's broadcast key at the specified epoch",
         "KeyEpochAdvance event type defined and serializable",
-        "validate_memory_scope_for_broadcast rejects Ephemeral and Summary (only Full allowed per §5.14.10)",
+        "validate_memory_scope_for_broadcast rejects Ephemeral and Summary (only Full allowed per \u00a75.14.10)",
         "Unit tests: key generation, rotation, seal/open roundtrip, epoch mismatch rejected, memory scope validation"
       ],
       "priority": "P1",
@@ -10205,13 +10205,13 @@
         "crates/scp-transport/src/cover_traffic.rs",
         "crates/scp-transport/src/heartbeat.rs"
       ],
-      "description": "Spec §9.10.6 mandates constant-rate cover traffic on persistent connections. §9.9.2 specifies periodic heartbeat messages for relay suppression detection. Neither is implemented.",
+      "description": "Spec \u00a79.10.6 mandates constant-rate cover traffic on persistent connections. \u00a79.9.2 specifies periodic heartbeat messages for relay suppression detection. Neither is implemented.",
       "acceptanceCriteria": [
-        "CoverTrafficGenerator produces padded dummy messages at configurable interval (default 30s per §9.10.6)",
+        "CoverTrafficGenerator produces padded dummy messages at configurable interval (default 30s per \u00a79.10.6)",
         "Dummy messages are single-byte flag inside encrypted payload, indistinguishable from real messages after encryption",
         "Real messages replace dummy messages in the schedule (no double-send within a window)",
-        "Cover traffic rate is per relay connection, not per context — a single timer per connection (§9.10.6 item 4)",
-        "HeartbeatMonitor sends heartbeats at configurable interval (default 60s per §9.9.2)",
+        "Cover traffic rate is per relay connection, not per context \u2014 a single timer per connection (\u00a79.10.6 item 4)",
+        "HeartbeatMonitor sends heartbeats at configurable interval (default 60s per \u00a79.9.2)",
         "HeartbeatMonitor raises SuppressionSuspected event when expected heartbeats are missing for > 2x the heartbeat interval",
         "Cover traffic and heartbeats are independently configurable (enabled/disabled, interval)",
         "Unit tests verify: timing intervals, message format, real-replaces-dummy behavior, suppression detection threshold"
@@ -10240,7 +10240,7 @@
       "files": [
         "crates/scp-core/src/trust/renewal.rs"
       ],
-      "description": "The Attestation struct has renewed_at and renewal_interval fields, and check_attestation_freshness correctly uses renewed_at as base time (SCP-062). But no orchestration exists to perform renewals — no function updates renewed_at, and no scheduling mechanism triggers re-verification. Spec §7.3.6 specifies type-specific automated renewal: identity links re-verified via OAuth on interval, tool integrity checks on schedule, endorsements refreshed periodically. This story adds the renewal API and a platform-injectable scheduling trait.",
+      "description": "The Attestation struct has renewed_at and renewal_interval fields, and check_attestation_freshness correctly uses renewed_at as base time (SCP-062). But no orchestration exists to perform renewals \u2014 no function updates renewed_at, and no scheduling mechanism triggers re-verification. Spec \u00a77.3.6 specifies type-specific automated renewal: identity links re-verified via OAuth on interval, tool integrity checks on schedule, endorsements refreshed periodically. This story adds the renewal API and a platform-injectable scheduling trait.",
       "acceptanceCriteria": [
         "renew_attestation(attestation, clock) -> Attestation returns a new Attestation with renewed_at set to current time, all other fields preserved",
         "renew_attestation rejects attestations without renewal_interval (returns RenewalError::NotRenewable)",
@@ -10278,13 +10278,13 @@
         "crates/scp-core/src/context/broadcast.rs",
         "crates/scp-core/src/context/mod.rs"
       ],
-      "description": "With broadcast key lifecycle implemented (SCP-224), this story adds subscriber registration (§5.14.3), open vs. gated admission (§5.14.4), broadcast-specific blocking via sender key revocation (§5.14.8), broadcast capabilities and routing (§5.14.6, §5.14.9), and an integration test proving end-to-end: author publishes, N subscribers receive.",
+      "description": "With broadcast key lifecycle implemented (SCP-224), this story adds subscriber registration (\u00a75.14.3), open vs. gated admission (\u00a75.14.4), broadcast-specific blocking via sender key revocation (\u00a75.14.8), broadcast capabilities and routing (\u00a75.14.6, \u00a75.14.9), and an integration test proving end-to-end: author publishes, N subscribers receive.",
       "acceptanceCriteria": [
         "subscribe_broadcast(context_id, subscriber_did) registers subscriber and returns current author key epoch",
-        "Open broadcast: any DID can subscribe without UCAN per §5.14.4",
-        "Gated broadcast: subscription requires valid UCAN with MessagesRead capability per §5.14.4",
-        "block_broadcast_author(author_did) revokes sender key, preventing decryption of future messages per §5.14.8",
-        "Broadcast capabilities enforce MessagesWrite restricted to authors, MessagesRead open to subscribers per §5.14.9",
+        "Open broadcast: any DID can subscribe without UCAN per \u00a75.14.4",
+        "Gated broadcast: subscription requires valid UCAN with MessagesRead capability per \u00a75.14.4",
+        "block_broadcast_author(author_did) revokes sender key, preventing decryption of future messages per \u00a75.14.8",
+        "Broadcast capabilities enforce MessagesWrite restricted to authors, MessagesRead open to subscribers per \u00a75.14.9",
         "Integration test: author publishes message, 3 subscribers receive and decrypt successfully",
         "Integration test: blocked author's subsequent messages are undecryptable by subscribers"
       ],
@@ -10315,7 +10315,7 @@
         "crates/scp-core/src/store/event_log.rs",
         "crates/scp-core/src/store/mod.rs"
       ],
-      "description": "Spec §17.4 defines an event_log.rs submodule of ProtocolStore with 8 methods for event log persistence, Merkle tree nodes, and roots. SCP-222 establishes the ProtocolStore struct and key conventions; this story implements the event log domain methods as an impl block on ProtocolStore<S>. Each method translates to one or two Storage trait calls using the key convention from §17.3 (context/{context_id}/event/{seq:020d}, context/{context_id}/event_meta/count, context/{context_id}/event_meta/root, context/{context_id}/event_tree/{level}/{index}).",
+      "description": "Spec \u00a717.4 defines an event_log.rs submodule of ProtocolStore with 8 methods for event log persistence, Merkle tree nodes, and roots. SCP-222 establishes the ProtocolStore struct and key conventions; this story implements the event log domain methods as an impl block on ProtocolStore<S>. Each method translates to one or two Storage trait calls using the key convention from \u00a717.3 (context/{context_id}/event/{seq:020d}, context/{context_id}/event_meta/count, context/{context_id}/event_meta/root, context/{context_id}/event_tree/{level}/{index}).",
       "acceptanceCriteria": [
         "append_event(context_id, seq, event_hash) stores event data at context/{context_id}/event/{seq:020d}",
         "load_event(context_id, seq) retrieves event data by sequence number or returns None",
@@ -10349,7 +10349,7 @@
         "crates/scp-core/src/store/transport.rs",
         "crates/scp-core/src/store/mod.rs"
       ],
-      "description": "Spec §17.4 defines a transport.rs submodule of ProtocolStore with 6 methods for relay scores and key package persistence. SCP-222 establishes the ProtocolStore struct and key conventions; this story implements the transport domain methods as an impl block on ProtocolStore<S>. Each method translates to one or two Storage trait calls using the key convention from §17.3 (relay_score/{relay_url}, key_package/{relay_url}/{index}).",
+      "description": "Spec \u00a717.4 defines a transport.rs submodule of ProtocolStore with 6 methods for relay scores and key package persistence. SCP-222 establishes the ProtocolStore struct and key conventions; this story implements the transport domain methods as an impl block on ProtocolStore<S>. Each method translates to one or two Storage trait calls using the key convention from \u00a717.3 (relay_score/{relay_url}, key_package/{relay_url}/{index}).",
       "acceptanceCriteria": [
         "store_relay_score(relay_url, score) persists relay score data at relay_score/{relay_url}",
         "load_relay_score(relay_url) retrieves relay score data or returns None",

--- a/.docs/sketch.md
+++ b/.docs/sketch.md
@@ -799,10 +799,9 @@ SCP.Bridge.claimShadow(
   shadowID: shadowID,
   claimant: DID,
   attestation: Attestation        // identity_link matching the shadow's platform handle
-) → ClaimResult {
-  merged: Bool,                    // shadow retired, history attributed to claimant DID
-  historicalActions: Int           // retroactively attributed
-}
+) → Result<ShadowClaimEvent, ClaimError>
+// On success: shadow retired, history attributed to claimant DID
+// On error: ClaimError (HandleMismatch, AttestationInvalid, AlreadyClaimed, ShadowNotFound)
 ```
 
 ### Bridge Content Provenance

--- a/crates/scp-core/src/bridge/claiming.rs
+++ b/crates/scp-core/src/bridge/claiming.rs
@@ -133,30 +133,6 @@ pub struct ClaimRequest {
 }
 
 // ---------------------------------------------------------------------------
-// ClaimResult
-// ---------------------------------------------------------------------------
-
-/// Result of a shadow claiming operation.
-///
-/// See ADR-023 acceptance criteria 7-8.
-#[derive(Debug)]
-pub enum ClaimResult {
-    /// The shadow was successfully claimed and bound to the claimant DID.
-    Success {
-        /// The shadow identity that was claimed.
-        shadow_id: String,
-        /// The DID the shadow is now bound to.
-        claimant_did: DID,
-    },
-
-    /// The claiming operation failed.
-    Failed {
-        /// The reason for failure.
-        reason: ClaimError,
-    },
-}
-
-// ---------------------------------------------------------------------------
 // ShadowClaimEvent
 // ---------------------------------------------------------------------------
 
@@ -465,57 +441,37 @@ fn validate_claim_request(
 pub fn claim_shadow(
     registry: &mut ShadowRegistry,
     request: &ClaimRequest,
-) -> (ClaimResult, Option<ShadowClaimEvent>) {
+) -> Result<ShadowClaimEvent, ClaimError> {
     // 1. Verify the shadow exists.
     let Ok(shadow) = registry.find_shadow_mut(&request.shadow_id) else {
-        return (
-            ClaimResult::Failed {
-                reason: ClaimError::ShadowNotFound {
-                    shadow_id: request.shadow_id.clone(),
-                },
-            },
-            None,
-        );
+        return Err(ClaimError::ShadowNotFound {
+            shadow_id: request.shadow_id.clone(),
+        });
     };
 
     // 2. Verify the shadow is unclaimed (one-way: cannot re-claim).
     if shadow.provenance_status == ShadowProvenanceStatus::Claimed {
-        return (
-            ClaimResult::Failed {
-                reason: ClaimError::AlreadyClaimed {
-                    shadow_id: request.shadow_id.clone(),
-                },
-            },
-            None,
-        );
+        return Err(ClaimError::AlreadyClaimed {
+            shadow_id: request.shadow_id.clone(),
+        });
     }
 
     // 3-8. Validate attestation, handle match, and signatures.
-    if let Err(reason) = validate_claim_request(request, &shadow.platform_handle) {
-        return (ClaimResult::Failed { reason }, None);
-    }
+    validate_claim_request(request, &shadow.platform_handle)?;
 
     // 9. All verifications passed. Retire the shadow by transitioning its
     //    provenance status to Claimed. This is irreversible.
     shadow.provenance_status = ShadowProvenanceStatus::Claimed;
 
     // 10. Produce a ShadowClaimEvent for the Merkle log.
-    let event = ShadowClaimEvent {
+    Ok(ShadowClaimEvent {
         shadow_id: request.shadow_id.clone(),
         claimant_did: request.claimant_did.clone(),
         platform_handle: request.platform_handle.clone(),
         attestation_id: request.identity_attestation.id.clone(),
         context_id: registry.context_id().to_owned(),
         timestamp: request.timestamp,
-    };
-
-    (
-        ClaimResult::Success {
-            shadow_id: request.shadow_id.clone(),
-            claimant_did: request.claimant_did.clone(),
-        },
-        Some(event),
-    )
+    })
 }
 
 // ---------------------------------------------------------------------------
@@ -672,10 +628,9 @@ mod tests {
         create_test_shadow(&mut registry);
 
         let request = make_default_claim_request();
-        let (result, event) = claim_shadow(&mut registry, &request);
+        let result = claim_shadow(&mut registry, &request);
 
-        assert!(matches!(result, ClaimResult::Success { .. }));
-        assert!(event.is_some());
+        assert!(result.is_ok());
     }
 
     #[test]
@@ -687,18 +642,10 @@ mod tests {
         let did = did_from_pubkey(&verifying_key);
         let attestation = make_identity_attestation(&did, HANDLE, &signing_key);
         let request = make_claim_request(SHADOW_ID, &did, HANDLE, attestation, &signing_key);
-        let (result, _event) = claim_shadow(&mut registry, &request);
+        let event = claim_shadow(&mut registry, &request).unwrap();
 
-        match result {
-            ClaimResult::Success {
-                shadow_id,
-                claimant_did,
-            } => {
-                assert_eq!(shadow_id, SHADOW_ID);
-                assert_eq!(claimant_did, did.as_str());
-            }
-            ClaimResult::Failed { reason } => panic!("expected success, got: {reason}"),
-        }
+        assert_eq!(event.shadow_id, SHADOW_ID);
+        assert_eq!(event.claimant_did, did.as_str());
     }
 
     #[test]
@@ -713,8 +660,8 @@ mod tests {
         );
 
         let request = make_default_claim_request();
-        let (result, _) = claim_shadow(&mut registry, &request);
-        assert!(matches!(result, ClaimResult::Success { .. }));
+        let result = claim_shadow(&mut registry, &request);
+        assert!(result.is_ok());
 
         // After claiming: status is Claimed.
         assert_eq!(
@@ -732,9 +679,7 @@ mod tests {
         let did = did_from_pubkey(&verifying_key);
         let attestation = make_identity_attestation(&did, HANDLE, &signing_key);
         let request = make_claim_request(SHADOW_ID, &did, HANDLE, attestation, &signing_key);
-        let (_result, event) = claim_shadow(&mut registry, &request);
-
-        let event = event.expect("expected ShadowClaimEvent");
+        let event = claim_shadow(&mut registry, &request).unwrap();
         assert_eq!(event.shadow_id, SHADOW_ID);
         assert_eq!(event.claimant_did, did.as_str());
         assert_eq!(event.platform_handle, HANDLE);
@@ -753,15 +698,9 @@ mod tests {
         // No shadows created.
 
         let request = make_default_claim_request();
-        let (result, event) = claim_shadow(&mut registry, &request);
+        let err = claim_shadow(&mut registry, &request).unwrap_err();
 
-        assert!(event.is_none());
-        match result {
-            ClaimResult::Failed { reason } => {
-                assert!(matches!(reason, ClaimError::ShadowNotFound { .. }));
-            }
-            ClaimResult::Success { .. } => panic!("expected failure"),
-        }
+        assert!(matches!(err, ClaimError::ShadowNotFound { .. }));
     }
 
     #[test]
@@ -779,15 +718,9 @@ mod tests {
             attestation,
             &signing_key,
         );
-        let (result, event) = claim_shadow(&mut registry, &request);
+        let err = claim_shadow(&mut registry, &request).unwrap_err();
 
-        assert!(event.is_none());
-        assert!(matches!(
-            result,
-            ClaimResult::Failed {
-                reason: ClaimError::ShadowNotFound { .. }
-            }
-        ));
+        assert!(matches!(err, ClaimError::ShadowNotFound { .. }));
     }
 
     // -------------------------------------------------------------------
@@ -804,20 +737,13 @@ mod tests {
         let did = did_from_pubkey(&verifying_key);
         let attestation = make_identity_attestation(&did, HANDLE, &signing_key);
         let request = make_claim_request(SHADOW_ID, &did, HANDLE, attestation, &signing_key);
-        let (result, _) = claim_shadow(&mut registry, &request);
-        assert!(matches!(result, ClaimResult::Success { .. }));
+        assert!(claim_shadow(&mut registry, &request).is_ok());
 
         // Second claim fails with AlreadyClaimed.
         let attestation2 = make_identity_attestation(&did, HANDLE, &signing_key);
         let request2 = make_claim_request(SHADOW_ID, &did, HANDLE, attestation2, &signing_key);
-        let (result2, event2) = claim_shadow(&mut registry, &request2);
-        assert!(event2.is_none());
-        match result2 {
-            ClaimResult::Failed { reason } => {
-                assert!(matches!(reason, ClaimError::AlreadyClaimed { .. }));
-            }
-            ClaimResult::Success { .. } => panic!("expected AlreadyClaimed"),
-        }
+        let err = claim_shadow(&mut registry, &request2).unwrap_err();
+        assert!(matches!(err, ClaimError::AlreadyClaimed { .. }));
     }
 
     #[test]
@@ -830,22 +756,15 @@ mod tests {
         let alice_did = did_from_pubkey(&alice_vk);
         let attestation = make_identity_attestation(&alice_did, HANDLE, &alice_sk);
         let request = make_claim_request(SHADOW_ID, &alice_did, HANDLE, attestation, &alice_sk);
-        let (result, _) = claim_shadow(&mut registry, &request);
-        assert!(matches!(result, ClaimResult::Success { .. }));
+        assert!(claim_shadow(&mut registry, &request).is_ok());
 
         // Attempt to re-claim by Bob.
         let (bob_vk, bob_sk) = test_keypair();
         let bob_did = did_from_pubkey(&bob_vk);
         let attestation = make_identity_attestation(&bob_did, HANDLE, &bob_sk);
         let bob_request = make_claim_request(SHADOW_ID, &bob_did, HANDLE, attestation, &bob_sk);
-        let (result2, event2) = claim_shadow(&mut registry, &bob_request);
-        assert!(event2.is_none());
-        assert!(matches!(
-            result2,
-            ClaimResult::Failed {
-                reason: ClaimError::AlreadyClaimed { .. }
-            }
-        ));
+        let err = claim_shadow(&mut registry, &bob_request).unwrap_err();
+        assert!(matches!(err, ClaimError::AlreadyClaimed { .. }));
     }
 
     // -------------------------------------------------------------------
@@ -863,15 +782,9 @@ mod tests {
         let attestation = make_identity_attestation(&did, "@wrong_handle", &signing_key);
         let request =
             make_claim_request(SHADOW_ID, &did, "@wrong_handle", attestation, &signing_key);
-        let (result, event) = claim_shadow(&mut registry, &request);
+        let err = claim_shadow(&mut registry, &request).unwrap_err();
 
-        assert!(event.is_none());
-        assert!(matches!(
-            result,
-            ClaimResult::Failed {
-                reason: ClaimError::HandleMismatch
-            }
-        ));
+        assert!(matches!(err, ClaimError::HandleMismatch));
     }
 
     // -------------------------------------------------------------------
@@ -889,15 +802,9 @@ mod tests {
         attestation.attestation_type = AttestationType::Endorsement;
 
         let request = make_claim_request(SHADOW_ID, &did, HANDLE, attestation, &signing_key);
-        let (result, event) = claim_shadow(&mut registry, &request);
+        let err = claim_shadow(&mut registry, &request).unwrap_err();
 
-        assert!(event.is_none());
-        match result {
-            ClaimResult::Failed { reason } => {
-                assert!(matches!(reason, ClaimError::AttestationInvalid { .. }));
-            }
-            ClaimResult::Success { .. } => panic!("expected AttestationInvalid"),
-        }
+        assert!(matches!(err, ClaimError::AttestationInvalid { .. }));
     }
 
     #[test]
@@ -911,15 +818,9 @@ mod tests {
         attestation.attestation_type = AttestationType::CapabilityDelegation;
 
         let request = make_claim_request(SHADOW_ID, &did, HANDLE, attestation, &signing_key);
-        let (result, event) = claim_shadow(&mut registry, &request);
+        let err = claim_shadow(&mut registry, &request).unwrap_err();
 
-        assert!(event.is_none());
-        assert!(matches!(
-            result,
-            ClaimResult::Failed {
-                reason: ClaimError::AttestationInvalid { .. }
-            }
-        ));
+        assert!(matches!(err, ClaimError::AttestationInvalid { .. }));
     }
 
     // -------------------------------------------------------------------
@@ -940,15 +841,9 @@ mod tests {
         let attestation = make_identity_attestation(&other_did, HANDLE, &other_sk);
         let request =
             make_claim_request(SHADOW_ID, &claimant_did, HANDLE, attestation, &claimant_sk);
-        let (result, event) = claim_shadow(&mut registry, &request);
+        let err = claim_shadow(&mut registry, &request).unwrap_err();
 
-        assert!(event.is_none());
-        match result {
-            ClaimResult::Failed { reason } => {
-                assert!(matches!(reason, ClaimError::AttestationInvalid { .. }));
-            }
-            ClaimResult::Success { .. } => panic!("expected AttestationInvalid"),
-        }
+        assert!(matches!(err, ClaimError::AttestationInvalid { .. }));
     }
 
     // -------------------------------------------------------------------
@@ -969,15 +864,9 @@ mod tests {
         };
 
         let request = make_claim_request(SHADOW_ID, &did, HANDLE, attestation, &signing_key);
-        let (result, event) = claim_shadow(&mut registry, &request);
+        let err = claim_shadow(&mut registry, &request).unwrap_err();
 
-        assert!(event.is_none());
-        match result {
-            ClaimResult::Failed { reason } => {
-                assert!(matches!(reason, ClaimError::AttestationInvalid { .. }));
-            }
-            ClaimResult::Success { .. } => panic!("expected AttestationInvalid for revoked"),
-        }
+        assert!(matches!(err, ClaimError::AttestationInvalid { .. }));
     }
 
     // -------------------------------------------------------------------
@@ -995,17 +884,9 @@ mod tests {
         attestation.claim = serde_json::json!({"platform": "discord"});
 
         let request = make_claim_request(SHADOW_ID, &did, HANDLE, attestation, &signing_key);
-        let (result, event) = claim_shadow(&mut registry, &request);
+        let err = claim_shadow(&mut registry, &request).unwrap_err();
 
-        assert!(event.is_none());
-        match result {
-            ClaimResult::Failed { reason } => {
-                assert!(matches!(reason, ClaimError::AttestationInvalid { .. }));
-            }
-            ClaimResult::Success { .. } => {
-                panic!("expected AttestationInvalid for missing handle")
-            }
-        }
+        assert!(matches!(err, ClaimError::AttestationInvalid { .. }));
     }
 
     // -------------------------------------------------------------------
@@ -1025,20 +906,12 @@ mod tests {
         // Corrupt the claim request signature.
         request.signature = vec![0u8; 64];
 
-        let (result, event) = claim_shadow(&mut registry, &request);
+        let err = claim_shadow(&mut registry, &request).unwrap_err();
 
-        assert!(event.is_none());
-        match result {
-            ClaimResult::Failed { reason } => {
-                assert!(
-                    matches!(reason, ClaimError::InvalidClaimSignature { .. }),
-                    "expected InvalidClaimSignature, got: {reason}"
-                );
-            }
-            ClaimResult::Success { .. } => {
-                panic!("expected InvalidClaimSignature for corrupted signature")
-            }
-        }
+        assert!(
+            matches!(err, ClaimError::InvalidClaimSignature { .. }),
+            "expected InvalidClaimSignature, got: {err}"
+        );
     }
 
     // -------------------------------------------------------------------
@@ -1060,20 +933,12 @@ mod tests {
         // Re-sign the claim request (so only the attestation sig is bad).
         let request = make_claim_request(SHADOW_ID, &did, HANDLE, attestation, &signing_key);
 
-        let (result, event) = claim_shadow(&mut registry, &request);
+        let err = claim_shadow(&mut registry, &request).unwrap_err();
 
-        assert!(event.is_none());
-        match result {
-            ClaimResult::Failed { reason } => {
-                assert!(
-                    matches!(reason, ClaimError::InvalidAttestationSignature { .. }),
-                    "expected InvalidAttestationSignature, got: {reason}"
-                );
-            }
-            ClaimResult::Success { .. } => {
-                panic!("expected InvalidAttestationSignature for corrupted signature")
-            }
-        }
+        assert!(
+            matches!(err, ClaimError::InvalidAttestationSignature { .. }),
+            "expected InvalidAttestationSignature, got: {err}"
+        );
     }
 
     // -------------------------------------------------------------------
@@ -1098,16 +963,10 @@ mod tests {
         let wrong_sig = wrong_sk.sign(&canonical_hash);
         request.signature = wrong_sig.to_bytes().to_vec();
 
-        let (result, event) = claim_shadow(&mut registry, &request);
+        let err = claim_shadow(&mut registry, &request).unwrap_err();
 
-        assert!(event.is_none());
         assert!(
-            matches!(
-                result,
-                ClaimResult::Failed {
-                    reason: ClaimError::InvalidClaimSignature { .. }
-                }
-            ),
+            matches!(err, ClaimError::InvalidClaimSignature { .. }),
             "expected InvalidClaimSignature for wrong-key signature"
         );
     }
@@ -1201,8 +1060,7 @@ mod tests {
         let did = did_from_pubkey(&verifying_key);
         let attestation = make_identity_attestation(&did, "@alice", &signing_key);
         let request = make_claim_request("shadow-a", &did, "@alice", attestation, &signing_key);
-        let (result, _) = claim_shadow(&mut registry, &request);
-        assert!(matches!(result, ClaimResult::Success { .. }));
+        assert!(claim_shadow(&mut registry, &request).is_ok());
 
         // shadow-a is Claimed.
         assert_eq!(
@@ -1237,9 +1095,8 @@ mod tests {
         .unwrap();
 
         let request = make_default_claim_request();
-        let (_result, event) = claim_shadow(&mut registry, &request);
+        let event = claim_shadow(&mut registry, &request).unwrap();
 
-        let event = event.expect("expected event");
         assert_eq!(event.context_id, custom_ctx);
     }
 
@@ -1300,28 +1157,5 @@ mod tests {
         let msg = format!("{err}");
         assert!(msg.contains("attestation signature verification failed"));
         assert!(msg.contains("bad attest sig"));
-    }
-
-    // -------------------------------------------------------------------
-    // ClaimResult variants
-    // -------------------------------------------------------------------
-
-    #[test]
-    fn claim_result_success_variant_debug() {
-        let result = ClaimResult::Success {
-            shadow_id: "s-001".to_owned(),
-            claimant_did: "did:test".into(),
-        };
-        let debug = format!("{result:?}");
-        assert!(debug.contains("Success"));
-    }
-
-    #[test]
-    fn claim_result_failed_variant_debug() {
-        let result = ClaimResult::Failed {
-            reason: ClaimError::HandleMismatch,
-        };
-        let debug = format!("{result:?}");
-        assert!(debug.contains("Failed"));
     }
 }

--- a/crates/scp-core/tests/phase5_integration.rs
+++ b/crates/scp-core/tests/phase5_integration.rs
@@ -27,7 +27,7 @@ use std::time::Duration;
 use ed25519_dalek::Signer;
 use sha2::{Digest, Sha256};
 
-use scp_core::bridge::claiming::{ClaimRequest, ClaimResult, ShadowClaimEvent, claim_shadow};
+use scp_core::bridge::claiming::{ClaimRequest, claim_shadow};
 use scp_core::bridge::provenance::{
     BridgeTrustLevel, evaluate_bridge_trust_level, mark_bridge_provenance,
 };
@@ -377,22 +377,10 @@ fn bridge_registration_shadow_creation_provenance_and_claiming() {
         &claimant_sk,
     );
 
-    let (result, claim_event) = claim_shadow(&mut shadow_registry, &claim_request);
+    let claim_event =
+        claim_shadow(&mut shadow_registry, &claim_request).expect("claim should succeed");
 
-    // Verify claiming succeeded.
-    match &result {
-        ClaimResult::Success {
-            shadow_id: sid,
-            claimant_did: cdid,
-        } => {
-            assert_eq!(sid, shadow_id);
-            assert_eq!(*cdid, claimant_did);
-        }
-        ClaimResult::Failed { reason } => panic!("claim should succeed, got: {reason}"),
-    }
-
-    // Verify claim event was produced (retroattribution event).
-    let claim_event: ShadowClaimEvent = claim_event.expect("claim event must be produced");
+    // Verify claim event fields.
     assert_eq!(claim_event.shadow_id, shadow_id);
     assert_eq!(claim_event.claimant_did, claimant_did);
     assert_eq!(claim_event.platform_handle, platform_handle);


### PR DESCRIPTION
## Summary
- Deletes the `ClaimResult` enum entirely from `crates/scp-core/src/bridge/claiming.rs`
- Changes `claim_shadow()` return type from `(ClaimResult, Option<ShadowClaimEvent>)` to `Result<ShadowClaimEvent, ClaimError>`
- Updates all ~20 test functions to use idiomatic `Result` matching (`is_ok()`, `unwrap()`, `unwrap_err()`)
- Updates integration test in `phase5_integration.rs`
- Updates ADR, sketch, and PRD references

## Test plan
- [x] `grep -r 'ClaimResult' crates/` returns zero matches
- [x] `cargo clippy -p scp-core --all-targets -- -D warnings` passes
- [x] `cargo test -p scp-core` passes (all 182 tests)
- [x] `cargo fmt --all -- --check` passes

closes #80

🤖 Generated with [Claude Code](https://claude.com/claude-code)