### PR TITLE
docs(spec): align CeilingPolicy::Governed narrowing restriction

### DIFF
--- a/.docs/adrs/phase-2.md
+++ b/.docs/adrs/phase-2.md
@@ -203,10 +203,11 @@ pub enum CeilingPolicy {
     /// security-conservative choice — members see the ceiling before
     /// joining, and it cannot change (no bait-and-switch).
     Immutable,
-    /// Ceiling can be modified through the context's governance model.
-    /// Changes require governance approval (e.g., unanimous consent,
-    /// admin decision). Ceiling can only be narrowed (capabilities
-    /// removed), never expanded beyond the original creation ceiling.
+    /// Ceiling can be modified through the context's governance model
+    /// (admin, multi-sig, consensus). Changes are logged in the event
+    /// log and visible to all members before taking effect. Members who
+    /// joined under a narrower ceiling are notified and may leave before
+    /// an expansion takes effect. See spec section 5.3.
     Governed,
 }
 

--- a/crates/scp-core/src/context/params.rs
+++ b/crates/scp-core/src/context/params.rs
@@ -93,10 +93,11 @@ pub enum CeilingPolicy {
     /// joining, and it cannot change (no bait-and-switch).
     #[default]
     Immutable,
-    /// Ceiling can be modified through the context's governance model.
-    /// Changes require governance approval (e.g., unanimous consent,
-    /// admin decision). Ceiling can only be narrowed (capabilities
-    /// removed), never expanded beyond the original creation ceiling.
+    /// Ceiling can be modified through the context's governance model
+    /// (admin, multi-sig, consensus). Changes are logged in the event
+    /// log and visible to all members before taking effect. Members who
+    /// joined under a narrower ceiling are notified and may leave before
+    /// an expansion takes effect. See spec section 5.3.
     Governed,
 }
 


### PR DESCRIPTION
## Summary
- Aligns `CeilingPolicy::Governed` doc comments in `params.rs` and the phase-2 ADR with the spec (section 5.3)
- The code/ADR said ceiling could only be narrowed; the spec explicitly allows governed expansion with member notification and a leave window
- Per the artifact flow invariant (specs govern code, not the reverse), the code and ADR doc comments are updated to match the spec

## Changes
- `crates/scp-core/src/context/params.rs`: Updated `Governed` variant doc comment to match spec section 5.3
- `.docs/adrs/phase-2.md`: Updated `Governed` variant doc comment to match spec section 5.3

## Rationale
The spec (section 5.3) explicitly contemplates ceiling expansion through governance: "Members who joined under a narrower ceiling are notified and may leave before the expansion takes effect." Section 5.13 also references expansion scenarios for governed ceilings. The narrowing-only restriction in the code was an undocumented deviation that contradicted the upstream spec.

closes #98

🤖 Generated with [Claude Code](https://claude.com/claude-code)