### PR TITLE
fix(security): consistent key sanitization in ProtocolStore

### DIFF
--- a/crates/scp-core/src/store/context.rs
+++ b/crates/scp-core/src/store/context.rs
@@ -36,61 +36,72 @@ type ContextId = String;
 ///
 /// Format: `context/{context_id}/state`
 /// See spec section 17.3.
-fn context_state_key(context_id: &str) -> String {
-    format!("context/{context_id}/state")
+fn context_state_key(context_id: &str) -> Result<String, super::StoreError> {
+    let ctx = super::sanitize_key_component(context_id)?;
+    Ok(format!("context/{ctx}/state"))
 }
 
 /// Builds the storage key for context params.
 ///
 /// Format: `context/{context_id}/params`
 /// See spec section 17.3.
-fn context_params_key(context_id: &str) -> String {
-    format!("context/{context_id}/params")
+fn context_params_key(context_id: &str) -> Result<String, super::StoreError> {
+    let ctx = super::sanitize_key_component(context_id)?;
+    Ok(format!("context/{ctx}/params"))
 }
 
 /// Builds the storage key for a member's membership record.
 ///
 /// Format: `context/{context_id}/membership/{did}`
 /// See spec section 17.3.
-fn membership_key(context_id: &str, did: &DID) -> String {
-    format!("context/{context_id}/membership/{did}")
+fn membership_key(context_id: &str, did: &DID) -> Result<String, super::StoreError> {
+    let ctx = super::sanitize_key_component(context_id)?;
+    let did_str = super::sanitize_key_component(did.as_ref())?;
+    Ok(format!("context/{ctx}/membership/{did_str}"))
 }
 
 /// Builds the prefix for listing all memberships in a context.
 ///
 /// Format: `context/{context_id}/membership/`
-fn membership_prefix(context_id: &str) -> String {
-    format!("context/{context_id}/membership/")
+fn membership_prefix(context_id: &str) -> Result<String, super::StoreError> {
+    let ctx = super::sanitize_key_component(context_id)?;
+    Ok(format!("context/{ctx}/membership/"))
 }
 
 /// Builds the storage key for a role definition within a context.
 ///
 /// Format: `context/{context_id}/role/{role_name}`
 /// See spec section 17.3.
-fn role_key(context_id: &str, role_name: &str) -> String {
-    format!("context/{context_id}/role/{role_name}")
+fn role_key(context_id: &str, role_name: &str) -> Result<String, super::StoreError> {
+    let ctx = super::sanitize_key_component(context_id)?;
+    let role = super::sanitize_key_component(role_name)?;
+    Ok(format!("context/{ctx}/role/{role}"))
 }
 
 /// Builds the prefix for listing all roles in a context.
 ///
 /// Format: `context/{context_id}/role/`
-fn roles_prefix(context_id: &str) -> String {
-    format!("context/{context_id}/role/")
+fn roles_prefix(context_id: &str) -> Result<String, super::StoreError> {
+    let ctx = super::sanitize_key_component(context_id)?;
+    Ok(format!("context/{ctx}/role/"))
 }
 
 /// Builds the storage key for an author's broadcast block list.
 ///
 /// Format: `context/{context_id}/broadcast_block/{author_did}`
 /// See spec section 5.14.8.
-fn broadcast_block_key(context_id: &str, author_did: &str) -> String {
-    format!("context/{context_id}/broadcast_block/{author_did}")
+fn broadcast_block_key(context_id: &str, author_did: &str) -> Result<String, super::StoreError> {
+    let ctx = super::sanitize_key_component(context_id)?;
+    let author = super::sanitize_key_component(author_did)?;
+    Ok(format!("context/{ctx}/broadcast_block/{author}"))
 }
 
 /// Builds the prefix for all keys belonging to a context.
 ///
 /// Format: `context/{context_id}/`
-fn context_prefix(context_id: &str) -> String {
-    format!("context/{context_id}/")
+fn context_prefix(context_id: &str) -> Result<String, super::StoreError> {
+    let ctx = super::sanitize_key_component(context_id)?;
+    Ok(format!("context/{ctx}/"))
 }
 
 // ---------------------------------------------------------------------------
@@ -112,7 +123,7 @@ impl<S: Storage> ProtocolStore<S> {
         context_id: &str,
         state: &[u8],
     ) -> Result<(), StoreError> {
-        let key = context_state_key(context_id);
+        let key = context_state_key(context_id)?;
         self.store_value(&key, &state.to_vec()).await
     }
 
@@ -128,7 +139,7 @@ impl<S: Storage> ProtocolStore<S> {
         &self,
         context_id: &str,
     ) -> Result<Option<Vec<u8>>, StoreError> {
-        let key = context_state_key(context_id);
+        let key = context_state_key(context_id)?;
         self.load_value(&key).await
     }
 
@@ -146,7 +157,7 @@ impl<S: Storage> ProtocolStore<S> {
         context_id: &str,
         params: &[u8],
     ) -> Result<(), StoreError> {
-        let key = context_params_key(context_id);
+        let key = context_params_key(context_id)?;
         self.store_value(&key, &params.to_vec()).await
     }
 
@@ -162,7 +173,7 @@ impl<S: Storage> ProtocolStore<S> {
         &self,
         context_id: &str,
     ) -> Result<Option<Vec<u8>>, StoreError> {
-        let key = context_params_key(context_id);
+        let key = context_params_key(context_id)?;
         self.load_value(&key).await
     }
 
@@ -178,7 +189,7 @@ impl<S: Storage> ProtocolStore<S> {
     ///
     /// Returns [`StoreError::Storage`] if the underlying storage operation fails.
     pub async fn delete_context(&self, context_id: &str) -> Result<u64, StoreError> {
-        let prefix = context_prefix(context_id);
+        let prefix = context_prefix(context_id)?;
         Ok(self.storage.delete_prefix(&prefix).await?)
     }
 
@@ -224,7 +235,7 @@ impl<S: Storage> ProtocolStore<S> {
         did: &DID,
         role: &str,
     ) -> Result<(), StoreError> {
-        let key = membership_key(context_id, did);
+        let key = membership_key(context_id, did)?;
         self.store_value(&key, &role.to_owned()).await
     }
 
@@ -241,7 +252,7 @@ impl<S: Storage> ProtocolStore<S> {
         context_id: &str,
         did: &DID,
     ) -> Result<Option<String>, StoreError> {
-        let key = membership_key(context_id, did);
+        let key = membership_key(context_id, did)?;
         self.load_value(&key).await
     }
 
@@ -255,7 +266,7 @@ impl<S: Storage> ProtocolStore<S> {
     /// Returns [`StoreError::DeserializationFailed`] if any member record fails
     /// to deserialize.
     pub async fn list_members(&self, context_id: &str) -> Result<Vec<(DID, String)>, StoreError> {
-        let prefix = membership_prefix(context_id);
+        let prefix = membership_prefix(context_id)?;
         let keys = self.storage.list_keys(&prefix).await?;
         let mut members = Vec::with_capacity(keys.len());
         for key in keys {
@@ -277,7 +288,7 @@ impl<S: Storage> ProtocolStore<S> {
     ///
     /// Returns [`StoreError::Storage`] if the underlying storage delete fails.
     pub async fn remove_membership(&self, context_id: &str, did: &DID) -> Result<(), StoreError> {
-        let key = membership_key(context_id, did);
+        let key = membership_key(context_id, did)?;
         self.storage.delete(&key).await?;
         Ok(())
     }
@@ -297,7 +308,7 @@ impl<S: Storage> ProtocolStore<S> {
         role_name: &str,
         role_data: &[u8],
     ) -> Result<(), StoreError> {
-        let key = role_key(context_id, role_name);
+        let key = role_key(context_id, role_name)?;
         self.store_value(&key, &role_data.to_vec()).await
     }
 
@@ -314,7 +325,7 @@ impl<S: Storage> ProtocolStore<S> {
         context_id: &str,
         role_name: &str,
     ) -> Result<Option<Vec<u8>>, StoreError> {
-        let key = role_key(context_id, role_name);
+        let key = role_key(context_id, role_name)?;
         self.load_value(&key).await
     }
 
@@ -326,7 +337,7 @@ impl<S: Storage> ProtocolStore<S> {
     ///
     /// Returns [`StoreError::Storage`] if the underlying storage operation fails.
     pub async fn list_roles(&self, context_id: &str) -> Result<Vec<String>, StoreError> {
-        let prefix = roles_prefix(context_id);
+        let prefix = roles_prefix(context_id)?;
         let keys = self.storage.list_keys(&prefix).await?;
         let role_names: Vec<String> = keys
             .into_iter()
@@ -355,7 +366,7 @@ impl<S: Storage> ProtocolStore<S> {
         author_did: &str,
         block_list: &HashSet<String>,
     ) -> Result<(), StoreError> {
-        let key = broadcast_block_key(context_id, author_did);
+        let key = broadcast_block_key(context_id, author_did)?;
         self.store_value(&key, block_list).await
     }
 
@@ -376,7 +387,7 @@ impl<S: Storage> ProtocolStore<S> {
         context_id: &str,
         author_did: &str,
     ) -> Result<Option<HashSet<String>>, StoreError> {
-        let key = broadcast_block_key(context_id, author_did);
+        let key = broadcast_block_key(context_id, author_did)?;
         self.load_value(&key).await
     }
 }
@@ -613,32 +624,41 @@ mod tests {
 
     #[test]
     fn context_state_key_follows_convention() {
-        assert_eq!(context_state_key("ctx-123"), "context/ctx-123/state");
+        assert_eq!(
+            context_state_key("ctx-123").unwrap(),
+            "context/ctx-123/state"
+        );
     }
 
     #[test]
     fn context_params_key_follows_convention() {
-        assert_eq!(context_params_key("ctx-123"), "context/ctx-123/params");
+        assert_eq!(
+            context_params_key("ctx-123").unwrap(),
+            "context/ctx-123/params"
+        );
     }
 
     #[test]
     fn membership_key_follows_convention() {
         let did = DID::from("did:dht:z6MkTest");
         assert_eq!(
-            membership_key("ctx-123", &did),
+            membership_key("ctx-123", &did).unwrap(),
             "context/ctx-123/membership/did:dht:z6MkTest"
         );
     }
 
     #[test]
     fn role_key_follows_convention() {
-        assert_eq!(role_key("ctx-123", "admin"), "context/ctx-123/role/admin");
+        assert_eq!(
+            role_key("ctx-123", "admin").unwrap(),
+            "context/ctx-123/role/admin"
+        );
     }
 
     #[test]
     fn broadcast_block_key_follows_convention() {
         assert_eq!(
-            broadcast_block_key("ctx-123", "did:dht:z6MkAuthor"),
+            broadcast_block_key("ctx-123", "did:dht:z6MkAuthor").unwrap(),
             "context/ctx-123/broadcast_block/did:dht:z6MkAuthor"
         );
     }

--- a/crates/scp-core/src/store/economy.rs
+++ b/crates/scp-core/src/store/economy.rs
@@ -28,15 +28,18 @@ use super::{ProtocolStore, StoreError};
 ///
 /// Format: `identity/{did}/adapter_credentials/{adapter_id}`
 /// See spec section 17.3.
-fn adapter_credential_key(did: &DID, adapter_id: &str) -> String {
-    format!("identity/{did}/adapter_credentials/{adapter_id}")
+fn adapter_credential_key(did: &DID, adapter_id: &str) -> Result<String, super::StoreError> {
+    let did_str = super::sanitize_key_component(did.as_ref())?;
+    let adapter = super::sanitize_key_component(adapter_id)?;
+    Ok(format!("identity/{did_str}/adapter_credentials/{adapter}"))
 }
 
 /// Builds the prefix for listing all adapter credentials for an identity.
 ///
 /// Format: `identity/{did}/adapter_credentials/`
-fn adapter_credentials_prefix(did: &DID) -> String {
-    format!("identity/{did}/adapter_credentials/")
+fn adapter_credentials_prefix(did: &DID) -> Result<String, super::StoreError> {
+    let did_str = super::sanitize_key_component(did.as_ref())?;
+    Ok(format!("identity/{did_str}/adapter_credentials/"))
 }
 
 // ---------------------------------------------------------------------------
@@ -60,7 +63,7 @@ impl<S: Storage> ProtocolStore<S> {
         adapter_id: &str,
         credentials: &[u8],
     ) -> Result<(), StoreError> {
-        let key = adapter_credential_key(did, adapter_id);
+        let key = adapter_credential_key(did, adapter_id)?;
         self.store_value(&key, &credentials).await
     }
 
@@ -76,7 +79,7 @@ impl<S: Storage> ProtocolStore<S> {
         did: &DID,
         adapter_id: &str,
     ) -> Result<Option<Vec<u8>>, StoreError> {
-        let key = adapter_credential_key(did, adapter_id);
+        let key = adapter_credential_key(did, adapter_id)?;
         self.load_value(&key).await
     }
 
@@ -88,7 +91,7 @@ impl<S: Storage> ProtocolStore<S> {
     ///
     /// Returns [`StoreError::Storage`] if the underlying storage list fails.
     pub async fn list_adapter_credentials(&self, did: &DID) -> Result<Vec<String>, StoreError> {
-        let prefix = adapter_credentials_prefix(did);
+        let prefix = adapter_credentials_prefix(did)?;
         let keys = self.storage.list_keys(&prefix).await?;
         let adapter_ids: Vec<String> = keys
             .into_iter()
@@ -109,7 +112,7 @@ impl<S: Storage> ProtocolStore<S> {
         did: &DID,
         adapter_id: &str,
     ) -> Result<(), StoreError> {
-        let key = adapter_credential_key(did, adapter_id);
+        let key = adapter_credential_key(did, adapter_id)?;
         self.storage.delete(&key).await?;
         Ok(())
     }
@@ -404,14 +407,14 @@ mod tests {
     #[test]
     fn adapter_credential_key_follows_convention() {
         let did = DID::from("did:dht:z6MkTest");
-        let key = adapter_credential_key(&did, "x402");
+        let key = adapter_credential_key(&did, "x402").unwrap();
         assert_eq!(key, "identity/did:dht:z6MkTest/adapter_credentials/x402");
     }
 
     #[test]
     fn adapter_credentials_prefix_follows_convention() {
         let did = DID::from("did:dht:z6MkTest");
-        let prefix = adapter_credentials_prefix(&did);
+        let prefix = adapter_credentials_prefix(&did).unwrap();
         assert_eq!(prefix, "identity/did:dht:z6MkTest/adapter_credentials/");
     }
 }

--- a/crates/scp-core/src/store/identity.rs
+++ b/crates/scp-core/src/store/identity.rs
@@ -25,16 +25,18 @@ use super::{ProtocolStore, StoreError};
 ///
 /// Format: `identity/{did}/document`
 /// See spec section 17.3.
-fn identity_document_key(did: &DID) -> String {
-    format!("identity/{did}/document")
+fn identity_document_key(did: &DID) -> Result<String, super::StoreError> {
+    let did_str = super::sanitize_key_component(did.as_ref())?;
+    Ok(format!("identity/{did_str}/document"))
 }
 
 /// Builds the storage key for the active signing key handle.
 ///
 /// Format: `identity/{did}/active_signing_key`
 /// See spec section 17.3.
-fn active_signing_key_key(did: &DID) -> String {
-    format!("identity/{did}/active_signing_key")
+fn active_signing_key_key(did: &DID) -> Result<String, super::StoreError> {
+    let did_str = super::sanitize_key_component(did.as_ref())?;
+    Ok(format!("identity/{did_str}/active_signing_key"))
 }
 
 /// Builds the storage key for identity private state at a sequence number.
@@ -42,15 +44,17 @@ fn active_signing_key_key(did: &DID) -> String {
 /// Format: `identity/{did}/private_state/{seq:020d}`
 /// Uses 20-digit zero-padding for lexicographic ordering.
 /// See spec section 17.3.
-fn identity_private_state_key(did: &DID, seq: u64) -> String {
-    format!("identity/{did}/private_state/{seq:020}")
+fn identity_private_state_key(did: &DID, seq: u64) -> Result<String, super::StoreError> {
+    let did_str = super::sanitize_key_component(did.as_ref())?;
+    Ok(format!("identity/{did_str}/private_state/{seq:020}"))
 }
 
 /// Builds the prefix for listing all identity keys.
 ///
 /// Format: `identity/{did}/`
-fn identity_prefix(did: &DID) -> String {
-    format!("identity/{did}/")
+fn identity_prefix(did: &DID) -> Result<String, super::StoreError> {
+    let did_str = super::sanitize_key_component(did.as_ref())?;
+    Ok(format!("identity/{did_str}/"))
 }
 
 // ---------------------------------------------------------------------------
@@ -68,7 +72,7 @@ impl<S: Storage> ProtocolStore<S> {
     /// Returns [`StoreError::SerializationFailed`] if serialization fails.
     /// Returns [`StoreError::Storage`] if the underlying storage write fails.
     pub async fn store_identity_document(&self, did: &DID, doc: &[u8]) -> Result<(), StoreError> {
-        let key = identity_document_key(did);
+        let key = identity_document_key(did)?;
         self.store_value(&key, &doc.to_vec()).await
     }
 
@@ -81,7 +85,7 @@ impl<S: Storage> ProtocolStore<S> {
     /// Returns [`StoreError::DeserializationFailed`] if deserialization fails.
     /// Returns [`StoreError::Storage`] if the underlying storage read fails.
     pub async fn load_identity_document(&self, did: &DID) -> Result<Option<Vec<u8>>, StoreError> {
-        let key = identity_document_key(did);
+        let key = identity_document_key(did)?;
         self.load_value(&key).await
     }
 
@@ -99,7 +103,7 @@ impl<S: Storage> ProtocolStore<S> {
         did: &DID,
         key_data: &[u8],
     ) -> Result<(), StoreError> {
-        let key = active_signing_key_key(did);
+        let key = active_signing_key_key(did)?;
         self.store_value(&key, &key_data.to_vec()).await
     }
 
@@ -112,7 +116,7 @@ impl<S: Storage> ProtocolStore<S> {
     /// Returns [`StoreError::DeserializationFailed`] if deserialization fails.
     /// Returns [`StoreError::Storage`] if the underlying storage read fails.
     pub async fn load_active_signing_key(&self, did: &DID) -> Result<Option<Vec<u8>>, StoreError> {
-        let key = active_signing_key_key(did);
+        let key = active_signing_key_key(did)?;
         self.load_value(&key).await
     }
 
@@ -130,7 +134,7 @@ impl<S: Storage> ProtocolStore<S> {
         seq: u64,
         state: &[u8],
     ) -> Result<(), StoreError> {
-        let key = identity_private_state_key(did, seq);
+        let key = identity_private_state_key(did, seq)?;
         self.store_value(&key, &state.to_vec()).await
     }
 
@@ -147,7 +151,7 @@ impl<S: Storage> ProtocolStore<S> {
         did: &DID,
         seq: u64,
     ) -> Result<Option<Vec<u8>>, StoreError> {
-        let key = identity_private_state_key(did, seq);
+        let key = identity_private_state_key(did, seq)?;
         self.load_value(&key).await
     }
 
@@ -161,7 +165,7 @@ impl<S: Storage> ProtocolStore<S> {
     ///
     /// Returns [`StoreError::Storage`] if the underlying storage operation fails.
     pub async fn delete_identity(&self, did: &DID) -> Result<u64, StoreError> {
-        let prefix = identity_prefix(did);
+        let prefix = identity_prefix(did)?;
         Ok(self.storage.delete_prefix(&prefix).await?)
     }
 }
@@ -276,7 +280,7 @@ mod tests {
     fn identity_document_key_follows_convention() {
         let did = DID::from("did:dht:z6MkTest");
         assert_eq!(
-            identity_document_key(&did),
+            identity_document_key(&did).unwrap(),
             "identity/did:dht:z6MkTest/document"
         );
     }
@@ -285,7 +289,7 @@ mod tests {
     fn active_signing_key_key_follows_convention() {
         let did = DID::from("did:dht:z6MkTest");
         assert_eq!(
-            active_signing_key_key(&did),
+            active_signing_key_key(&did).unwrap(),
             "identity/did:dht:z6MkTest/active_signing_key"
         );
     }
@@ -294,7 +298,7 @@ mod tests {
     fn identity_private_state_key_uses_zero_padding() {
         let did = DID::from("did:dht:z6MkTest");
         assert_eq!(
-            identity_private_state_key(&did, 42),
+            identity_private_state_key(&did, 42).unwrap(),
             "identity/did:dht:z6MkTest/private_state/00000000000000000042"
         );
     }

--- a/crates/scp-core/src/store/mod.rs
+++ b/crates/scp-core/src/store/mod.rs
@@ -250,4 +250,144 @@ mod tests {
         let loaded: Option<String> = store.load_value("nonexistent").await.unwrap();
         assert!(loaded.is_none());
     }
+
+    // -------------------------------------------------------------------
+    // sanitize_key_component unit tests
+    // -------------------------------------------------------------------
+
+    #[test]
+    fn sanitize_rejects_forward_slash() {
+        let result = sanitize_key_component("../identity/victim");
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn sanitize_rejects_backslash() {
+        let result = sanitize_key_component("evil\\path");
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn sanitize_rejects_dot_dot() {
+        let result = sanitize_key_component("foo..bar");
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn sanitize_rejects_null_byte() {
+        let result = sanitize_key_component("evil\0id");
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn sanitize_accepts_well_formed_identifiers() {
+        assert!(sanitize_key_component("ctx-123").is_ok());
+        assert!(sanitize_key_component("did:dht:z6MkTest").is_ok());
+        assert!(sanitize_key_component("tok-abc-def").is_ok());
+        assert!(sanitize_key_component("x402").is_ok());
+    }
+
+    // -------------------------------------------------------------------
+    // Cross-domain key traversal rejection tests
+    // -------------------------------------------------------------------
+
+    #[tokio::test]
+    async fn context_store_rejects_traversal_context_id() {
+        let store = ProtocolStore::new(scp_platform::testing::InMemoryStorage::new());
+        let result = store
+            .store_context_state("../identity/victim", b"bad")
+            .await;
+        assert!(result.is_err());
+    }
+
+    #[tokio::test]
+    async fn context_store_rejects_null_byte_context_id() {
+        let store = ProtocolStore::new(scp_platform::testing::InMemoryStorage::new());
+        let result = store.store_context_state("evil\0ctx", b"bad").await;
+        assert!(result.is_err());
+    }
+
+    #[tokio::test]
+    async fn identity_store_rejects_traversal_did() {
+        let store = ProtocolStore::new(scp_platform::testing::InMemoryStorage::new());
+        let malicious_did = crate::identity::DID::from("../context/victim");
+        let result = store.store_identity_document(&malicious_did, b"bad").await;
+        assert!(result.is_err());
+    }
+
+    #[tokio::test]
+    async fn identity_store_rejects_backslash_did() {
+        let store = ProtocolStore::new(scp_platform::testing::InMemoryStorage::new());
+        let malicious_did = crate::identity::DID::from("evil\\did");
+        let result = store.store_identity_document(&malicious_did, b"bad").await;
+        assert!(result.is_err());
+    }
+
+    #[tokio::test]
+    async fn tool_store_rejects_traversal_tool_id() {
+        let store = ProtocolStore::new(scp_platform::testing::InMemoryStorage::new());
+        let result = store
+            .store_tool("ctx-1", "../ucan_token/steal", b"bad")
+            .await;
+        assert!(result.is_err());
+    }
+
+    #[tokio::test]
+    async fn tool_store_rejects_null_byte_session_id() {
+        let store = ProtocolStore::new(scp_platform::testing::InMemoryStorage::new());
+        let result = store.store_tool_session("ctx-1", "sess\0ion", b"bad").await;
+        assert!(result.is_err());
+    }
+
+    #[tokio::test]
+    async fn economy_store_rejects_traversal_adapter_id() {
+        let store = ProtocolStore::new(scp_platform::testing::InMemoryStorage::new());
+        let did = crate::identity::DID::from("did:dht:z6MkTest");
+        let result = store
+            .store_adapter_credentials(&did, "../document", b"bad")
+            .await;
+        assert!(result.is_err());
+    }
+
+    #[tokio::test]
+    async fn ucan_store_rejects_traversal_context_id() {
+        let store = ProtocolStore::new(scp_platform::testing::InMemoryStorage::new());
+        let result = store
+            .store_ucan_token("../identity/victim", "tok-1", b"bad")
+            .await;
+        assert!(result.is_err());
+    }
+
+    #[tokio::test]
+    async fn well_formed_identifiers_succeed_across_all_domains() {
+        let store = ProtocolStore::new(scp_platform::testing::InMemoryStorage::new());
+        let did = crate::identity::DID::from("did:dht:z6MkTest");
+
+        // Context domain
+        store
+            .store_context_state("ctx-valid", b"state")
+            .await
+            .unwrap();
+
+        // Identity domain
+        store.store_identity_document(&did, b"doc").await.unwrap();
+
+        // Tools domain
+        store
+            .store_tool("ctx-valid", "tool-ok", b"reg")
+            .await
+            .unwrap();
+
+        // Economy domain
+        store
+            .store_adapter_credentials(&did, "x402", b"cred")
+            .await
+            .unwrap();
+
+        // UCAN domain
+        store
+            .store_ucan_token("ctx-valid", "tok-ok", b"token")
+            .await
+            .unwrap();
+    }
 }

--- a/crates/scp-core/src/store/tools.rs
+++ b/crates/scp-core/src/store/tools.rs
@@ -30,23 +30,28 @@ type ToolId = String;
 ///
 /// Format: `context/{context_id}/tool/{tool_id}`
 /// See spec section 17.3.
-fn tool_key(context_id: &str, tool_id: &str) -> String {
-    format!("context/{context_id}/tool/{tool_id}")
+fn tool_key(context_id: &str, tool_id: &str) -> Result<String, super::StoreError> {
+    let ctx = super::sanitize_key_component(context_id)?;
+    let tool = super::sanitize_key_component(tool_id)?;
+    Ok(format!("context/{ctx}/tool/{tool}"))
 }
 
 /// Builds the prefix for listing all tools in a context.
 ///
 /// Format: `context/{context_id}/tool/`
-fn tools_prefix(context_id: &str) -> String {
-    format!("context/{context_id}/tool/")
+fn tools_prefix(context_id: &str) -> Result<String, super::StoreError> {
+    let ctx = super::sanitize_key_component(context_id)?;
+    Ok(format!("context/{ctx}/tool/"))
 }
 
 /// Builds the storage key for a tool session.
 ///
 /// Format: `context/{context_id}/tool_session/{session_id}`
 /// See spec section 17.3.
-fn tool_session_key(context_id: &str, session_id: &str) -> String {
-    format!("context/{context_id}/tool_session/{session_id}")
+fn tool_session_key(context_id: &str, session_id: &str) -> Result<String, super::StoreError> {
+    let ctx = super::sanitize_key_component(context_id)?;
+    let sess = super::sanitize_key_component(session_id)?;
+    Ok(format!("context/{ctx}/tool_session/{sess}"))
 }
 
 // ---------------------------------------------------------------------------
@@ -69,7 +74,7 @@ impl<S: Storage> ProtocolStore<S> {
         tool_id: &str,
         registration: &[u8],
     ) -> Result<(), StoreError> {
-        let key = tool_key(context_id, tool_id);
+        let key = tool_key(context_id, tool_id)?;
         self.store_value(&key, &registration.to_vec()).await
     }
 
@@ -86,7 +91,7 @@ impl<S: Storage> ProtocolStore<S> {
         context_id: &str,
         tool_id: &str,
     ) -> Result<Option<Vec<u8>>, StoreError> {
-        let key = tool_key(context_id, tool_id);
+        let key = tool_key(context_id, tool_id)?;
         self.load_value(&key).await
     }
 
@@ -98,7 +103,7 @@ impl<S: Storage> ProtocolStore<S> {
     ///
     /// Returns [`StoreError::Storage`] if the underlying storage operation fails.
     pub async fn list_tools(&self, context_id: &str) -> Result<Vec<ToolId>, StoreError> {
-        let prefix = tools_prefix(context_id);
+        let prefix = tools_prefix(context_id)?;
         let keys = self.storage.list_keys(&prefix).await?;
         let tool_ids: Vec<ToolId> = keys
             .into_iter()
@@ -115,7 +120,7 @@ impl<S: Storage> ProtocolStore<S> {
     ///
     /// Returns [`StoreError::Storage`] if the underlying storage delete fails.
     pub async fn delete_tool(&self, context_id: &str, tool_id: &str) -> Result<(), StoreError> {
-        let key = tool_key(context_id, tool_id);
+        let key = tool_key(context_id, tool_id)?;
         self.storage.delete(&key).await?;
         Ok(())
     }
@@ -135,7 +140,7 @@ impl<S: Storage> ProtocolStore<S> {
         session_id: &str,
         session: &[u8],
     ) -> Result<(), StoreError> {
-        let key = tool_session_key(context_id, session_id);
+        let key = tool_session_key(context_id, session_id)?;
         self.store_value(&key, &session.to_vec()).await
     }
 
@@ -152,7 +157,7 @@ impl<S: Storage> ProtocolStore<S> {
         context_id: &str,
         session_id: &str,
     ) -> Result<Option<Vec<u8>>, StoreError> {
-        let key = tool_session_key(context_id, session_id);
+        let key = tool_session_key(context_id, session_id)?;
         self.load_value(&key).await
     }
 
@@ -168,7 +173,7 @@ impl<S: Storage> ProtocolStore<S> {
         context_id: &str,
         session_id: &str,
     ) -> Result<(), StoreError> {
-        let key = tool_session_key(context_id, session_id);
+        let key = tool_session_key(context_id, session_id)?;
         self.storage.delete(&key).await?;
         Ok(())
     }
@@ -318,7 +323,7 @@ mod tests {
     #[test]
     fn tool_key_follows_convention() {
         assert_eq!(
-            tool_key("ctx-123", "tool-abc"),
+            tool_key("ctx-123", "tool-abc").unwrap(),
             "context/ctx-123/tool/tool-abc"
         );
     }
@@ -326,7 +331,7 @@ mod tests {
     #[test]
     fn tool_session_key_follows_convention() {
         assert_eq!(
-            tool_session_key("ctx-123", "sess-456"),
+            tool_session_key("ctx-123", "sess-456").unwrap(),
             "context/ctx-123/tool_session/sess-456"
         );
     }

--- a/crates/scp-core/src/store/ucan.rs
+++ b/crates/scp-core/src/store/ucan.rs
@@ -74,16 +74,18 @@ fn revocation_key(context_id: &str, token_id: &str) -> Result<String, super::Sto
 ///
 /// Format: `context/{context_id}/nonce/{nonce_hash_hex}`
 /// The nonce hash is encoded as lowercase hex. See spec section 17.3.
-fn nonce_key(context_id: &str, nonce_hash: &[u8; 32]) -> String {
+fn nonce_key(context_id: &str, nonce_hash: &[u8; 32]) -> Result<String, super::StoreError> {
+    let ctx = super::sanitize_key_component(context_id)?;
     let hex_str = hex::encode(nonce_hash);
-    format!("context/{context_id}/nonce/{hex_str}")
+    Ok(format!("context/{ctx}/nonce/{hex_str}"))
 }
 
 /// Builds the prefix for listing all nonces in a context.
 ///
 /// Format: `context/{context_id}/nonce/`
-fn nonce_prefix(context_id: &str) -> String {
-    format!("context/{context_id}/nonce/")
+fn nonce_prefix(context_id: &str) -> Result<String, super::StoreError> {
+    let ctx = super::sanitize_key_component(context_id)?;
+    Ok(format!("context/{ctx}/nonce/"))
 }
 
 // ---------------------------------------------------------------------------
@@ -234,7 +236,7 @@ impl<S: Storage> ProtocolStore<S> {
         first_seen: u64,
         token_expiry: u64,
     ) -> Result<bool, StoreError> {
-        let key = nonce_key(context_id, nonce_hash);
+        let key = nonce_key(context_id, nonce_hash)?;
 
         // If a record already exists, reject immediately without
         // overwriting the existing record's timestamps.
@@ -277,7 +279,7 @@ impl<S: Storage> ProtocolStore<S> {
         context_id: &str,
         now: u64,
     ) -> Result<u64, StoreError> {
-        let prefix = nonce_prefix(context_id);
+        let prefix = nonce_prefix(context_id)?;
         let keys = self.storage.list_keys(&prefix).await?;
         let mut pruned = 0u64;
         for key in keys {
@@ -605,7 +607,7 @@ mod tests {
     fn nonce_key_uses_hex_encoded_hash() {
         let mut h = [0u8; 32];
         h[0] = 0xFF;
-        let key = nonce_key("ctx-1", &h);
+        let key = nonce_key("ctx-1", &h).unwrap();
         assert!(key.starts_with("context/ctx-1/nonce/"));
         assert!(key.ends_with("00"));
         assert!(key.contains("ff"));


### PR DESCRIPTION
## Summary
- `sanitize_key_component` was only used in the UCAN store module; context, identity, tools, and economy modules embedded raw user-supplied identifiers directly in key strings
- Applied `sanitize_key_component` to every key-building helper across all five store domains, rejecting `/`, `\`, `..`, and null bytes
- Fixed two nonce helpers in `ucan.rs` that were also missing `context_id` sanitization
- Added 14 new tests covering path traversal rejection and well-formed identifier acceptance across all domains

## Test plan
- [x] `cargo test -p scp-core` passes (2,695 tests, 0 failures)
- [x] `cargo clippy -p scp-core --all-targets` clean
- [x] `cargo fmt --all -- --check` clean
- [x] New test: store with context_id `"../identity/victim"` returns `StoreError`
- [x] New test: store with tool_id containing `../` returns `StoreError`
- [x] New test: store with DID containing `\` returns `StoreError`
- [x] New test: store with null byte in session_id returns `StoreError`
- [x] New test: store with well-formed identifiers succeeds across all domains
- [x] All 118 pre-existing store tests still pass

closes #140

🤖 Generated with [Claude Code](https://claude.com/claude-code)