### PR TITLE
fix(ffi): unify ucan_revoke identifier type across bridges

### DIFF
--- a/bindings/kotlin/scp-sdk-kotlin-android/src/test/kotlin/com/limn/scp/android/ScpViewModelTest.kt
+++ b/bindings/kotlin/scp-sdk-kotlin-android/src/test/kotlin/com/limn/scp/android/ScpViewModelTest.kt
@@ -172,7 +172,7 @@ private class TestNativeBindings : NativeBindings {
     override fun toolVerify(toolId: String, inputJson: String, outputJson: String): Boolean = false
     override fun ucanValidate(token: String, capability: String, contextId: String) {}
     override fun ucanMint(identityHandle: Long, memberDid: String, capabilitiesJson: String): String = ""
-    override fun ucanRevoke(identityHandle: Long, tokenId: String) {}
+    override fun ucanRevoke(identityHandle: Long, token: String) {}
     override fun eventLogQuery(contextId: String, filterJson: String): String = ""
     override fun eventLogVerify(contextId: String, proofJson: String): Boolean = false
     override fun transportConnect(configJson: String, cancellationHandle: CancellationHandle?): Long = 0L

--- a/bindings/kotlin/scp-sdk-kotlin/src/main/kotlin/com/limn/scp/bridge/CoroutineBridge.kt
+++ b/bindings/kotlin/scp-sdk-kotlin/src/main/kotlin/com/limn/scp/bridge/CoroutineBridge.kt
@@ -166,7 +166,7 @@ interface UcanBindings {
 
     fun ucanRevoke(
         identityHandle: Long,
-        tokenId: String,
+        token: String,
     )
 }
 
@@ -566,12 +566,12 @@ class UcanBridge internal constructor(
      * Revoke a previously minted UCAN token.
      *
      * @param identityHandle Handle from identity create or load.
-     * @param tokenId The token ID to revoke.
+     * @param token The full encoded JWT string of the token to revoke.
      */
     suspend fun revoke(
         identityHandle: Long,
-        tokenId: String,
-    ): Unit = bridge.ffiCall { bindings.ucanRevoke(identityHandle, tokenId) }
+        token: String,
+    ): Unit = bridge.ffiCall { bindings.ucanRevoke(identityHandle, token) }
 }
 
 /**

--- a/bindings/kotlin/scp-sdk-kotlin/src/test/kotlin/com/limn/scp/bridge/CoroutineBridgeTest.kt
+++ b/bindings/kotlin/scp-sdk-kotlin/src/test/kotlin/com/limn/scp/bridge/CoroutineBridgeTest.kt
@@ -178,7 +178,7 @@ class CoroutineBridgeTest {
         @Test
         fun `ucanRevoke dispatches on IO`() =
             runTest(ioDispatcher) {
-                bridge.ucan.revoke(1L, "token-id")
+                bridge.ucan.revoke(1L, "header.payload.signature")
                 assertTrue(stubBindings.ucanRevokeCalled)
             }
 
@@ -552,7 +552,7 @@ class StubNativeBindings : NativeBindings {
 
     override fun ucanRevoke(
         identityHandle: Long,
-        tokenId: String,
+        token: String,
     ) {
         ucanRevokeCalled = true
     }

--- a/bindings/kotlin/scp-sdk-kotlin/src/test/kotlin/com/limn/scp/conformance/ConformanceDispatcher.kt
+++ b/bindings/kotlin/scp-sdk-kotlin/src/test/kotlin/com/limn/scp/conformance/ConformanceDispatcher.kt
@@ -176,8 +176,8 @@ class ConformanceDispatcher(
         input: Map<String, String>,
     ): Map<String, String> = catchBridge {
         val identityHandle = input["identity_handle"]?.toLongOrNull() ?: 0L
-        val tokenId = input["token_id"] ?: input["encoded"] ?: ""
-        bridge.ucan.revoke(identityHandle, tokenId)
+        val token = input["token"] ?: input["encoded"] ?: ""
+        bridge.ucan.revoke(identityHandle, token)
         mapOf("status" to "revoked")
     }
 

--- a/bindings/kotlin/scp-sdk-kotlin/src/test/kotlin/com/limn/scp/conformance/ConformanceStubBindings.kt
+++ b/bindings/kotlin/scp-sdk-kotlin/src/test/kotlin/com/limn/scp/conformance/ConformanceStubBindings.kt
@@ -176,7 +176,7 @@ class ConformanceStubBindings : NativeBindings {
 
     override fun ucanRevoke(
         identityHandle: Long,
-        tokenId: String,
+        token: String,
     ) {
         ucanRevokeError?.let { throw it }
     }

--- a/bindings/kotlin/scp-sdk-kotlin/src/test/kotlin/com/limn/scp/conformance/UcanConformanceTest.kt
+++ b/bindings/kotlin/scp-sdk-kotlin/src/test/kotlin/com/limn/scp/conformance/UcanConformanceTest.kt
@@ -161,7 +161,7 @@ class UcanConformanceTest {
         fun `ucan_revoke succeeds`() = runTest(testDispatcher) {
             val result = dispatcher.dispatch(
                 "ucan_revoke",
-                mapOf("identity_handle" to "1", "token_id" to "tok-001"),
+                mapOf("identity_handle" to "1", "token" to "header.payload.signature"),
             )
             assertEquals("revoked", result["status"])
         }
@@ -172,7 +172,7 @@ class UcanConformanceTest {
                 BridgeException("Not authorized to revoke", "SCP-PERM-3003")
             val result = dispatcher.dispatch(
                 "ucan_revoke",
-                mapOf("identity_handle" to "1", "token_id" to "tok-001"),
+                mapOf("identity_handle" to "1", "token" to "header.payload.signature"),
             )
             assertEquals("SCP-PERM-3003", result["error"])
         }

--- a/bindings/python/scp_sdk/ucan.py
+++ b/bindings/python/scp_sdk/ucan.py
@@ -190,7 +190,7 @@ async def revoke(context: str, token: str) -> None:
 
     Args:
         context: The context ID the token belongs to.
-        token: The unique token ID (or CID) to revoke.
+        token: The full encoded JWT string of the token to revoke.
 
     Raises:
         UcanPermissionError: If revocation fails (token not found, revoker

--- a/bindings/swift/Sources/SCP/Ucan.swift
+++ b/bindings/swift/Sources/SCP/Ucan.swift
@@ -79,7 +79,7 @@ internal enum UcanBridge {
     /// Revoke a UCAN token. Maps to ``ucanRevoke`` in ScpBindings.
     internal typealias RevokeFn = @Sendable (
         _ handle: ContextHandle,
-        _ tokenId: String
+        _ token: String
     ) async throws -> Void
 
     /// Default validate function that delegates to the UniFFI-generated binding.
@@ -93,8 +93,8 @@ internal enum UcanBridge {
     }
 
     /// Default revoke function that delegates to the UniFFI-generated binding.
-    internal static let defaultRevoke: RevokeFn = { handle, tokenId in
-        try await ucanRevoke(handle: handle, tokenId: tokenId)
+    internal static let defaultRevoke: RevokeFn = { handle, token in
+        try await ucanRevoke(handle: handle, tokenId: token)
     }
 }
 
@@ -158,7 +158,7 @@ public func mintUcanToken(
 ///
 /// - Parameters:
 ///   - handle: The ``ContextHandle`` for the context.
-///   - tokenId: The ID of the token to revoke.
+///   - token: The full encoded JWT string of the token to revoke.
 ///   - revokeFn: Bridge function override for testing.
 /// - Throws: ``ScpError/Permission(message:code:)`` if revocation fails.
 ///
@@ -169,10 +169,10 @@ public func mintUcanToken(
 /// - Story SCP-221
 public func revokeUcanToken(
     handle: ContextHandle,
-    tokenId: String,
+    token: String,
     revokeFn: UcanBridge.RevokeFn = UcanBridge.defaultRevoke
 ) async throws {
-    try await revokeFn(handle, tokenId)
+    try await revokeFn(handle, token)
 }
 
 // MARK: - Legacy API (backward compatibility)
@@ -230,7 +230,7 @@ public func mint(
 /// Revokes a UCAN token.
 ///
 /// Legacy wrapper that creates a ``ContextHandle`` placeholder and delegates
-/// to ``revokeUcanToken(handle:tokenId:revokeFn:)``. Prefer the
+/// to ``revokeUcanToken(handle:token:revokeFn:)``. Prefer the
 /// handle-based API for production use.
 ///
 /// ## Provenance

--- a/bindings/swift/Tests/SCPTests/UcanTests.swift
+++ b/bindings/swift/Tests/SCPTests/UcanTests.swift
@@ -220,19 +220,19 @@ struct UcanTests {
     @Test("revokeUcanToken calls bridge successfully")
     func revokeRoundtrip() async throws {
         let handle = ContextHandle(noPointer: .init())
-        var revokedTokenId: String?
+        var revokedToken: String?
 
-        let mockRevoke: UcanBridge.RevokeFn = { _, tokenId in
-            revokedTokenId = tokenId
+        let mockRevoke: UcanBridge.RevokeFn = { _, token in
+            revokedToken = token
         }
 
         try await revokeUcanToken(
             handle: handle,
-            tokenId: "token-to-revoke",
+            token: "header.payload.signature",
             revokeFn: mockRevoke
         )
 
-        #expect(revokedTokenId == "token-to-revoke")
+        #expect(revokedToken == "header.payload.signature")
     }
 
     // MARK: - Legacy API

--- a/bindings/typescript/src/index.d.ts
+++ b/bindings/typescript/src/index.d.ts
@@ -203,7 +203,7 @@ export declare function validate(
   capability: string,
 ): Promise<void>;
 
-export declare function revoke(contextId: string, tokenId: string): Promise<void>;
+export declare function revoke(contextId: string, token: string): Promise<void>;
 
 export declare function delegate(options: {
   issuer: Identity;

--- a/bindings/typescript/src/internal/bridge.ts
+++ b/bindings/typescript/src/internal/bridge.ts
@@ -98,7 +98,7 @@ export interface Bridge {
     memberDid: string,
     capabilities: readonly string[],
   ): Promise<UcanToken>;
-  ucanRevoke(handle: BridgeContextHandle, tokenId: string): Promise<void>;
+  ucanRevoke(handle: BridgeContextHandle, token: string): Promise<void>;
 
   // Event Log
   eventLogQuery(

--- a/bindings/typescript/src/internal/native.ts
+++ b/bindings/typescript/src/internal/native.ts
@@ -303,10 +303,10 @@ export function createNativeBridge(): Bridge {
       return token;
     },
 
-    async ucanRevoke(handle: BridgeContextHandle, tokenId: string): Promise<void> {
+    async ucanRevoke(handle: BridgeContextHandle, token: string): Promise<void> {
       await (addon.ucanRevoke as (h: BridgeContextHandle, t: string) => Promise<void>)(
         handle,
-        tokenId,
+        token,
       );
     },
 

--- a/bindings/typescript/src/internal/wasm.ts
+++ b/bindings/typescript/src/internal/wasm.ts
@@ -337,7 +337,7 @@ export function createWasmBridge(): Bridge {
       );
     },
 
-    async ucanRevoke(_handle: BridgeContextHandle, _tokenId: string): Promise<void> {
+    async ucanRevoke(_handle: BridgeContextHandle, _token: string): Promise<void> {
       throw new TransportError(
         "UCAN revocation in the WASM bridge requires runtime wiring",
         "SCP-PERM-3003",

--- a/bindings/typescript/src/ucan.ts
+++ b/bindings/typescript/src/ucan.ts
@@ -71,13 +71,13 @@ export async function mintUcan(
  * members.
  *
  * @param ctx - The context the token belongs to.
- * @param tokenId - The unique ID of the token to revoke.
+ * @param token - The full encoded JWT string of the token to revoke.
  * @throws {UcanPermissionError} If revocation fails.
  */
-export async function revokeUcan(ctx: Context, tokenId: string): Promise<void> {
+export async function revokeUcan(ctx: Context, token: string): Promise<void> {
   try {
     const bridge = await getBridge();
-    await bridge.ucanRevoke(ctx._handle, tokenId);
+    await bridge.ucanRevoke(ctx._handle, token);
   } catch (error) {
     throw mapBridgeError(error);
   }

--- a/crates/scp-ffi/napi/CLAUDE.md
+++ b/crates/scp-ffi/napi/CLAUDE.md
@@ -88,9 +88,9 @@ The NAPI bridge uses `rand::rngs::OsRng.fill_bytes` directly (no wrapper). Forma
 
 ## Gotchas
 
-- `NapiUcanToken.encoded` is `#[allow(dead_code)]` because `ucan_revoke` takes `token_id: String`
-  (not the full token). When revocation is wired to the runtime, the NAPI bridge will need a way
-  to look up the encoded token by ID (e.g., a handle registry or passing the full token to revoke).
+- `NapiUcanToken.encoded` is `#[allow(dead_code)]` because `ucan_revoke` currently returns a stub
+  error. When revocation is wired to the runtime, the bridge will parse the full JWT `token`
+  parameter to compute the revocation CID (matching the PyO3 bridge pattern).
 
 - Bridge functions returning `Err(...)` immediately without constructing the output type leave
   `encoded` / other fields unset. Always construct the output struct before the feature is

--- a/crates/scp-ffi/napi/src/ucan.rs
+++ b/crates/scp-ffi/napi/src/ucan.rs
@@ -357,7 +357,7 @@ pub async fn ucan_mint(
 /// # Arguments
 ///
 /// * `handle` — The context the token belongs to.
-/// * `token_id` — The unique ID of the token to revoke.
+/// * `token` — The full encoded JWT string of the token to revoke.
 ///
 /// # Errors
 ///
@@ -366,8 +366,8 @@ pub async fn ucan_mint(
 #[napi]
 #[allow(clippy::unused_async)] // napi-rs requires async for Promise return
 #[allow(clippy::needless_pass_by_value)] // napi-rs requires owned String
-pub async fn ucan_revoke(handle: &NapiContextHandle, token_id: String) -> napi::Result<()> {
-    let _ = (handle, token_id);
+pub async fn ucan_revoke(handle: &NapiContextHandle, token: String) -> napi::Result<()> {
+    let _ = (handle, token);
     Err(ScpNapiError::Permission {
         message: "not yet connected to runtime — UCAN revocation requires a live context"
             .to_owned(),

--- a/crates/scp-ffi/uniffi/src/bridge.rs
+++ b/crates/scp-ffi/uniffi/src/bridge.rs
@@ -1712,17 +1712,17 @@ pub async fn ucan_mint(
 /// # Arguments
 ///
 /// * `handle` — The context the token belongs to.
-/// * `token_id` — The unique ID of the token to revoke.
+/// * `token` — The full encoded JWT string of the token to revoke.
 ///
 /// # Errors
 ///
 /// Returns `ScpError::Permission` if revocation fails (token not found,
 /// revoker not authorized — must be the token's issuer or context creator).
 #[uniffi::export]
-pub async fn ucan_revoke(handle: Arc<ContextHandle>, token_id: String) -> Result<(), ScpError> {
+pub async fn ucan_revoke(handle: Arc<ContextHandle>, token: String) -> Result<(), ScpError> {
     runtime()
         .spawn(async move {
-            let _ = (handle, token_id);
+            let _ = (handle, token);
             Err(ScpError::Permission {
                 message: "not yet connected to runtime — UCAN revocation requires a live context"
                     .to_owned(),

--- a/crates/scp-ffi/wasm/CLAUDE.md
+++ b/crates/scp-ffi/wasm/CLAUDE.md
@@ -58,7 +58,7 @@ Do NOT claim "full validation" in docstrings until all steps are implemented. Se
 
 ## UCAN Revocation — CID Consistency
 
-`ucan_revoke` and `ucan_validate` MUST hash the same input to compute the revocation CID. **Both must call `compute_token_cid` on the full JWT string** — not the token_id nonce, not the payload struct. Any deviation silently breaks revocation. See `.docs/lessons/wasm-cid-consistency.md`.
+`ucan_revoke` and `ucan_validate` MUST hash the same input to compute the revocation CID. **Both must call `compute_token_cid` on the full JWT string** — not a nonce-derived ID, not the payload struct. Any deviation silently breaks revocation. See `.docs/lessons/wasm-cid-consistency.md`.
 
 `ucan_revoke` parameter: full encoded JWT string (same as PyO3 `py_ucan_revoke`).
 `ucan_validate` revocation check: `compute_token_cid(&token)` where `token` is the full JWT parameter.

--- a/crates/scp-ffi/wasm/src/ucan.rs
+++ b/crates/scp-ffi/wasm/src/ucan.rs
@@ -1038,7 +1038,7 @@ pub fn ucan_mint(
 /// # Arguments
 ///
 /// * `context` -- The context handle the token belongs to.
-/// * `token_id` -- The unique ID of the token to revoke.
+/// * `token` -- The full encoded JWT string of the token to revoke.
 ///
 /// # Returns
 ///
@@ -1051,10 +1051,10 @@ pub fn ucan_mint(
 ///
 /// See ADR-022 acceptance criterion 1.
 #[wasm_bindgen]
-pub fn ucan_revoke(context: &WasmContextHandle, token_id: String) -> Promise {
+pub fn ucan_revoke(context: &WasmContextHandle, token: String) -> Promise {
     let context_id = context.context_id();
     future_to_promise(async move {
-        let _ = (context_id, token_id);
+        let _ = (context_id, token);
 
         Err(ScpWasmError::Permission {
             message:


### PR DESCRIPTION
## Summary
- Renames `token_id`/`tokenId` parameter to `token` in `ucan_revoke` across NAPI, UniFFI, and WASM bridges to match PyO3's full JWT string parameter
- Updates all downstream bindings (TypeScript, Swift, Kotlin, Python docstring) and their tests
- Updates CLAUDE.md documentation in NAPI and WASM bridge crates

All bridges now accept the encoded JWT string required to compute the revocation CID via `compute_revocation_cid`, preventing the silent revocation failure where nonce-derived IDs would never match CID-based lookups during validation.

## Test plan
- [x] `cargo clippy --workspace --all-targets` passes
- [x] `cargo clippy -p scp-ffi-wasm --target wasm32-unknown-unknown` passes
- [x] `cargo test --workspace` passes
- [x] `bun run check` (TypeScript tsc) passes
- [x] `bun run lint` (TypeScript biome) passes
- [x] Kotlin conformance tests updated with JWT-format test values
- [x] Swift unit test updated with new parameter name and JWT-format test value

closes #129

🤖 Generated with [Claude Code](https://claude.com/claude-code)