### PR TITLE
fix(security): gate hex DID format to test-only

### DIFF
--- a/crates/scp-ffi/Cargo.toml
+++ b/crates/scp-ffi/Cargo.toml
@@ -41,6 +41,7 @@ tracing = { workspace = true }
 [dev-dependencies]
 pyo3 = { version = "0.23", features = ["auto-initialize"] }
 tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }
+scp-ffi-common = { path = "common", features = ["testing"] }
 
 [lints]
 workspace = true

--- a/crates/scp-ffi/common/Cargo.toml
+++ b/crates/scp-ffi/common/Cargo.toml
@@ -6,6 +6,11 @@ edition.workspace = true
 repository.workspace = true
 license.workspace = true
 
+[features]
+# Enables the did:key:{hex} DID format in BridgeDidResolver. This is a
+# non-standard test convenience — production builds must resolve via did:dht:z.
+testing = []
+
 [dependencies]
 scp-core = { path = "../../scp-core" }
 hex = { workspace = true }

--- a/crates/scp-ffi/common/src/lib.rs
+++ b/crates/scp-ffi/common/src/lib.rs
@@ -21,7 +21,7 @@ use scp_core::identity::cache::Clock;
 ///
 /// Supports:
 /// - `did:dht:z{z-base-32-encoded-pubkey}` -- production format.
-/// - `did:key:{hex-encoded-pubkey}` -- testing format.
+/// - `did:key:{hex-encoded-pubkey}` -- testing only (requires `testing` feature).
 ///
 /// This resolver operates in-memory with no network calls. `did:dht:` DIDs
 /// encode the public key directly in the DID string using z-base-32, so
@@ -43,6 +43,10 @@ impl DidResolver for BridgeDidResolver {
             return Ok(bytes);
         }
 
+        // did:key:{hex} is a non-standard test convenience. Gated behind the
+        // `testing` feature (or #[cfg(test)]) to prevent acceptance in release
+        // builds. See: https://github.com/limn-works/scp/issues/128
+        #[cfg(any(test, feature = "testing"))]
         if let Some(hex_str) = did.strip_prefix("did:key:") {
             let bytes = hex::decode(hex_str).map_err(|e| {
                 CoreUcanError::MalformedToken(format!("hex decode failed for did:key DID: {e}"))
@@ -57,7 +61,7 @@ impl DidResolver for BridgeDidResolver {
         }
 
         Err(CoreUcanError::MalformedToken(format!(
-            "unsupported DID method: {did} (expected did:dht: or did:key:)"
+            "unsupported DID method: {did} (expected did:dht:)"
         )))
     }
 }

--- a/crates/scp-ffi/napi/Cargo.toml
+++ b/crates/scp-ffi/napi/Cargo.toml
@@ -26,6 +26,9 @@ scp-core = { path = "../../scp-core" }
 scp-ffi-common = { path = "../common" }
 scp-platform = { path = "../../scp-platform", features = ["software_platform"] }
 
+[dev-dependencies]
+scp-ffi-common = { path = "../common", features = ["testing"] }
+
 [build-dependencies]
 napi-build = "2"
 

--- a/crates/scp-ffi/wasm/Cargo.toml
+++ b/crates/scp-ffi/wasm/Cargo.toml
@@ -9,6 +9,11 @@ license.workspace = true
 [lib]
 crate-type = ["cdylib"]
 
+[features]
+# Enables the did:key:{hex} DID format in resolve_public_key. This is a
+# non-standard test convenience — production builds must resolve via did:dht:z.
+testing = []
+
 [dependencies]
 wasm-bindgen = "0.2"
 wasm-bindgen-futures = "0.4"

--- a/crates/scp-ffi/wasm/src/ucan.rs
+++ b/crates/scp-ffi/wasm/src/ucan.rs
@@ -270,7 +270,10 @@ fn resolve_public_key(did: &str) -> Result<[u8; 32], String> {
         return Ok(bytes);
     }
 
-    // did:key:{hex-encoded-pubkey} (testing format)
+    // did:key:{hex} is a non-standard test convenience. Gated behind the
+    // `testing` feature (or #[cfg(test)]) to prevent acceptance in release
+    // builds. See: https://github.com/limn-works/scp/issues/128
+    #[cfg(any(test, feature = "testing"))]
     if let Some(hex_str) = did.strip_prefix("did:key:") {
         let bytes =
             decode_hex(hex_str).map_err(|e| format!("hex decode failed for did:key DID: {e}"))?;
@@ -280,9 +283,7 @@ fn resolve_public_key(did: &str) -> Result<[u8; 32], String> {
         return Ok(pk);
     }
 
-    Err(format!(
-        "unsupported DID method: {did} (expected did:dht: or did:key:)"
-    ))
+    Err(format!("unsupported DID method: {did} (expected did:dht:)"))
 }
 
 /// Verifies the Ed25519 signature over `base64url(header).base64url(payload)`.
@@ -315,6 +316,7 @@ fn verify_signature(token: &ParsedUcanToken) -> Result<(), String> {
 // Hex / zbase32 helpers
 // ---------------------------------------------------------------------------
 
+#[cfg(any(test, feature = "testing"))]
 fn decode_hex(hex: &str) -> Result<Vec<u8>, String> {
     if !hex.len().is_multiple_of(2) {
         return Err(format!("hex string has odd length: {}", hex.len()));


### PR DESCRIPTION
## Summary
- Gates `did:key:{hex}` DID format acceptance behind `#[cfg(any(test, feature = "testing"))]` in both `scp-ffi-common` (`BridgeDidResolver`) and `scp-ffi-wasm` (`resolve_public_key`)
- Adds a `testing` feature flag to `scp-ffi-common` and `scp-ffi-wasm`
- Consuming crates (`scp-ffi`, `scp-ffi-napi`) add `scp-ffi-common` with `features = ["testing"]` in `[dev-dependencies]` so their existing `did:key:` tests continue to pass
- Updates error messages to only advertise `did:dht:` as the supported DID method in production

## Test plan
- [x] `cargo clippy --workspace --all-targets` — passes clean
- [x] `cargo clippy -p scp-ffi-wasm --target wasm32-unknown-unknown` — passes clean
- [x] `cargo test --workspace` — all 3,410+ tests pass
- [x] `cargo fmt --all -- --check` — passes clean
- [x] `cargo check -p scp-ffi-common` (without `testing` feature) — compiles without `did:key:` support
- [x] `cargo check -p scp-ffi-wasm --target wasm32-unknown-unknown` — no dead code warnings

closes #128

🤖 Generated with [Claude Code](https://claude.com/claude-code)