### PR TITLE
fix(kotlin): persist Ed25519 keys to EncryptedSharedPreferences

### DIFF
--- a/bindings/kotlin/scp-sdk-kotlin-android/src/main/kotlin/com/limn/scp/android/platform/AndroidKeyCustody.kt
+++ b/bindings/kotlin/scp-sdk-kotlin-android/src/main/kotlin/com/limn/scp/android/platform/AndroidKeyCustody.kt
@@ -5,19 +5,27 @@
 // Bouncy Castle. StrongBox is explicitly NOT used due to 10-100x latency penalty that
 // is incompatible with SCP's frequent signing operations.
 //
+// Software Ed25519 keys (API 26-32 fallback) are persisted to EncryptedSharedPreferences
+// (Jetpack Security) per ADR-027 requirement. Keys are restored from EncryptedSharedPreferences
+// on initialization to survive process death. Private key byte arrays are zeroed after writing
+// to storage.
+//
 // Private keys never cross the custody boundary — all signing and DH operations happen
 // inside this class. The Rust engine calls through UniFFI callback interfaces with data
 // to sign and receives signatures back. Raw private key bytes stay inside the Kotlin adapter.
 //
 // Provenance: ADR-027 (Android Platform Adapter), ADR-006 (Platform Abstraction Layer),
 // ADR-025 (Apple Platform Adapter — parallel reference), section 9.12 (Compromise Recovery),
-// section 9.15 (Key Destruction Verification).
+// section 9.15 (Key Destruction Verification), GitHub issue #119.
 
 package com.limn.scp.android.platform
 
+import android.content.Context
 import android.os.Build
 import android.security.keystore.KeyGenParameterSpec
 import android.security.keystore.KeyProperties
+import androidx.security.crypto.EncryptedSharedPreferences
+import androidx.security.crypto.MasterKey
 import java.security.KeyPairGenerator
 import java.security.KeyStore
 import java.security.Signature
@@ -31,12 +39,146 @@ import org.bouncycastle.crypto.agreement.X25519Agreement
 import org.bouncycastle.crypto.generators.Ed25519KeyPairGenerator
 import org.bouncycastle.crypto.generators.X25519KeyPairGenerator
 import org.bouncycastle.crypto.params.Ed25519KeyGenerationParameters
+import org.bouncycastle.crypto.params.Ed25519PrivateKeyParameters
 import org.bouncycastle.crypto.params.Ed25519PublicKeyParameters
 import org.bouncycastle.crypto.params.X25519KeyGenerationParameters
 import org.bouncycastle.crypto.params.X25519PublicKeyParameters
 import org.bouncycastle.crypto.signers.Ed25519Signer
 import org.bouncycastle.crypto.prng.FixedSecureRandom
 import java.security.SecureRandom
+
+/**
+ * Persistence interface for software-backed Ed25519 keys.
+ *
+ * Abstracts the storage mechanism for software Ed25519 keys so that the production
+ * implementation ([EncryptedPrefsKeyStore]) uses EncryptedSharedPreferences while
+ * unit tests ([InMemoryKeyStore]) avoid Android framework dependencies.
+ *
+ * Only Ed25519 identity keys are persisted — X25519 wrapping keys and pseudonym keys
+ * are session-scoped and do not require persistence.
+ */
+internal interface SoftwareKeyStore {
+    /**
+     * Persist a software Ed25519 private key.
+     *
+     * @param keyId The unique key identifier (UUID string).
+     * @param privateKeyBytes The 32-byte Ed25519 private key seed.
+     * @param publicKeyBytes The 32-byte Ed25519 public key.
+     */
+    fun persist(keyId: String, privateKeyBytes: ByteArray, publicKeyBytes: ByteArray)
+
+    /**
+     * Remove a persisted software Ed25519 key.
+     *
+     * @param keyId The unique key identifier to remove.
+     */
+    fun remove(keyId: String)
+
+    /**
+     * Restore all persisted software Ed25519 keys.
+     *
+     * @return Map of key ID to (privateKeyBytes, publicKeyBytes) pairs.
+     */
+    fun restoreAll(): Map<String, Pair<ByteArray, ByteArray>>
+}
+
+/**
+ * EncryptedSharedPreferences-backed key store for software Ed25519 keys.
+ *
+ * Uses Jetpack Security's [EncryptedSharedPreferences] with an AES-256 MasterKey
+ * backed by Android Keystore. This provides at-rest encryption for software Ed25519
+ * private key material per ADR-027 requirements.
+ *
+ * Key naming convention in SharedPreferences:
+ * - `scp.ed25519.priv.{keyId}` — Base64-encoded 32-byte private key seed
+ * - `scp.ed25519.pub.{keyId}` — Base64-encoded 32-byte public key
+ * - `scp.ed25519.keys` — Set of persisted key IDs
+ *
+ * @param context Android application context for EncryptedSharedPreferences creation.
+ */
+internal class EncryptedPrefsKeyStore(context: Context) : SoftwareKeyStore {
+
+    private val prefs = EncryptedSharedPreferences.create(
+        context,
+        PREFS_FILE_NAME,
+        MasterKey.Builder(context)
+            .setKeyScheme(MasterKey.KeyScheme.AES256_GCM)
+            .build(),
+        EncryptedSharedPreferences.PrefKeyEncryptionScheme.AES256_SIV,
+        EncryptedSharedPreferences.PrefValueEncryptionScheme.AES256_GCM,
+    )
+
+    override fun persist(keyId: String, privateKeyBytes: ByteArray, publicKeyBytes: ByteArray) {
+        val keyIds = getKeyIdSet().toMutableSet()
+        keyIds.add(keyId)
+        prefs.edit()
+            .putString(privKey(keyId), android.util.Base64.encodeToString(privateKeyBytes, BASE64_FLAGS))
+            .putString(pubKey(keyId), android.util.Base64.encodeToString(publicKeyBytes, BASE64_FLAGS))
+            .putStringSet(KEY_INDEX, keyIds)
+            .apply()
+    }
+
+    override fun remove(keyId: String) {
+        val keyIds = getKeyIdSet().toMutableSet()
+        keyIds.remove(keyId)
+        prefs.edit()
+            .remove(privKey(keyId))
+            .remove(pubKey(keyId))
+            .putStringSet(KEY_INDEX, keyIds)
+            .apply()
+    }
+
+    override fun restoreAll(): Map<String, Pair<ByteArray, ByteArray>> {
+        val keyIds = getKeyIdSet()
+        return keyIds.mapNotNull { keyId -> restoreKey(keyId) }.toMap()
+    }
+
+    private fun restoreKey(keyId: String): Pair<String, Pair<ByteArray, ByteArray>>? {
+        val privB64 = prefs.getString(privKey(keyId), null) ?: return null
+        val pubB64 = prefs.getString(pubKey(keyId), null) ?: return null
+        val privBytes = android.util.Base64.decode(privB64, BASE64_FLAGS)
+        val pubBytes = android.util.Base64.decode(pubB64, BASE64_FLAGS)
+        if (privBytes.size != RAW_ED25519_KEY_SIZE || pubBytes.size != RAW_ED25519_KEY_SIZE) {
+            return null
+        }
+        return keyId to Pair(privBytes, pubBytes)
+    }
+
+    private fun getKeyIdSet(): Set<String> = prefs.getStringSet(KEY_INDEX, emptySet()) ?: emptySet()
+
+    private fun privKey(keyId: String): String = "$PRIV_PREFIX$keyId"
+    private fun pubKey(keyId: String): String = "$PUB_PREFIX$keyId"
+
+    companion object {
+        private const val PREFS_FILE_NAME = "scp_ed25519_keys"
+        private const val KEY_INDEX = "scp.ed25519.keys"
+        private const val PRIV_PREFIX = "scp.ed25519.priv."
+        private const val PUB_PREFIX = "scp.ed25519.pub."
+        private const val BASE64_FLAGS = android.util.Base64.NO_WRAP
+        private const val RAW_ED25519_KEY_SIZE = 32
+    }
+}
+
+/**
+ * In-memory key store for unit tests.
+ *
+ * Provides the same interface as [EncryptedPrefsKeyStore] without requiring
+ * Android framework classes, allowing JVM-based unit tests to exercise the
+ * full key lifecycle including persistence callbacks.
+ */
+internal class InMemoryKeyStore : SoftwareKeyStore {
+    private val store = ConcurrentHashMap<String, Pair<ByteArray, ByteArray>>()
+
+    override fun persist(keyId: String, privateKeyBytes: ByteArray, publicKeyBytes: ByteArray) {
+        store[keyId] = Pair(privateKeyBytes.copyOf(), publicKeyBytes.copyOf())
+    }
+
+    override fun remove(keyId: String) {
+        store.remove(keyId)
+    }
+
+    override fun restoreAll(): Map<String, Pair<ByteArray, ByteArray>> = store.toMap()
+}
 
 /**
  * Android Keystore-backed key custody provider for SCP Ed25519 and X25519 keys.
@@ -54,12 +196,14 @@ import java.security.SecureRandom
  *   Apple's Secure Enclave (which only supports P-256). [CustodyType.HARDWARE] is reported.
  *
  * - **Ed25519 on API 26-32:** `EdDSA` is not available in Android Keystore on these API
- *   levels. Bouncy Castle provides software Ed25519. Keys are stored in [softwareKeys]
- *   in-memory. [CustodyType.SOFTWARE] is reported.
+ *   levels. Bouncy Castle provides software Ed25519. Keys are persisted to
+ *   [EncryptedSharedPreferences] and restored on initialization to survive process death
+ *   (ADR-027 requirement, GitHub issue #119). [CustodyType.SOFTWARE] is reported.
  *
  * - **X25519 (all API levels):** X25519 key agreement is not supported by Android Keystore
  *   at any API level. All X25519 wrapping keys are software-managed via Bouncy Castle,
- *   stored in [softwareKeys]. [CustodyType.SOFTWARE] is reported.
+ *   stored in [softwareKeys]. X25519 wrapping keys are session-scoped and NOT persisted.
+ *   [CustodyType.SOFTWARE] is reported.
  *
  * ## TEE vs StrongBox
  *
@@ -83,8 +227,24 @@ import java.security.SecureRandom
  *   6. Destroy compromised key via [destroyKey]
  *
  * See ADR-027 for the full Android platform adapter design.
+ *
+ * @param keyStore Persistence layer for software Ed25519 keys. Production code uses
+ *   [EncryptedPrefsKeyStore]; tests use [InMemoryKeyStore].
  */
-class AndroidKeyCustody : KeyCustodyProvider {
+class AndroidKeyCustody internal constructor(
+    private val keyStore: SoftwareKeyStore,
+) : KeyCustodyProvider {
+
+    /**
+     * Constructs an [AndroidKeyCustody] with EncryptedSharedPreferences persistence.
+     *
+     * This is the primary constructor used by [AndroidPlatformAdapter.make] in production.
+     * Software Ed25519 keys are persisted to EncryptedSharedPreferences and restored
+     * on initialization per ADR-027.
+     *
+     * @param context Android application context for EncryptedSharedPreferences creation.
+     */
+    constructor(context: Context) : this(EncryptedPrefsKeyStore(context))
 
     // -----------------------------------------------------------------------
     // Software key storage — used for API 26-32 Ed25519 and all X25519 keys
@@ -99,6 +259,8 @@ class AndroidKeyCustody : KeyCustodyProvider {
      * This map is only used for keys that cannot be stored in Android Keystore:
      * - Ed25519 keys on API 26-32 (no Keystore EdDSA support)
      * - X25519 keys on all API levels (no Keystore X25519 support)
+     *
+     * Ed25519 keys are also persisted to [keyStore] for survival across process death.
      */
     internal val softwareKeys = ConcurrentHashMap<String, AsymmetricCipherKeyPair>()
 
@@ -108,6 +270,10 @@ class AndroidKeyCustody : KeyCustodyProvider {
      * Used to enforce type safety in [sign] and [dhAgree] operations.
      */
     private val softwareKeyTypes = ConcurrentHashMap<String, KeyType>()
+
+    init {
+        restorePersistedKeys()
+    }
 
     // -----------------------------------------------------------------------
     // KeyCustodyProvider implementation
@@ -192,7 +358,8 @@ class AndroidKeyCustody : KeyCustodyProvider {
      * For hardware-backed keys: deletes the entry from Android Keystore and performs
      * a re-fetch to confirm deletion (section 9.15 key destruction verification).
      *
-     * For software-backed keys: removes the entry from the [softwareKeys] map.
+     * For software-backed keys: removes the entry from the [softwareKeys] map and
+     * the persistent [keyStore].
      *
      * After this call, all subsequent operations with the same handle will throw
      * [ScpException] with code `SCP-CRYPTO-4001`.
@@ -438,7 +605,12 @@ class AndroidKeyCustody : KeyCustodyProvider {
      * Generates a software-backed Ed25519 keypair using Bouncy Castle.
      *
      * Used as fallback on API 26-32 where Android Keystore does not support EdDSA.
-     * The key pair is stored in [softwareKeys] and tracked in [softwareKeyTypes].
+     * The key pair is stored in [softwareKeys], tracked in [softwareKeyTypes], and
+     * persisted to [keyStore] (EncryptedSharedPreferences in production) so the key
+     * survives process death (ADR-027, GitHub issue #119).
+     *
+     * Private key bytes are zeroed after writing to the key store to minimize the
+     * window of exposure in memory.
      */
     private fun generateSoftwareEd25519(keyId: String): KeyHandle {
         val keyPair = Ed25519KeyPairGenerator().apply {
@@ -446,6 +618,17 @@ class AndroidKeyCustody : KeyCustodyProvider {
         }.generateKeyPair()
         softwareKeys[keyId] = keyPair
         softwareKeyTypes[keyId] = KeyType.ED25519
+
+        // Persist to EncryptedSharedPreferences and zero the extracted private bytes
+        val privParams = keyPair.private as Ed25519PrivateKeyParameters
+        val pubParams = keyPair.public as Ed25519PublicKeyParameters
+        val privBytes = privParams.encoded
+        try {
+            keyStore.persist(keyId, privBytes, pubParams.encoded)
+        } finally {
+            privBytes.fill(0)
+        }
+
         return KeyHandle(id = keyId, custodyType = CustodyType.SOFTWARE)
     }
 
@@ -514,7 +697,8 @@ class AndroidKeyCustody : KeyCustodyProvider {
     }
 
     /**
-     * Destroys a software-backed key by removing it from the in-memory map.
+     * Destroys a software-backed key by removing it from the in-memory map and
+     * the persistent key store (EncryptedSharedPreferences in production).
      *
      * Returns [DestructionMethod.SOFTWARE_ONLY] because the key material was stored
      * in software (Bouncy Castle in-memory) without hardware protection.
@@ -530,6 +714,9 @@ class AndroidKeyCustody : KeyCustodyProvider {
             )
         }
 
+        // Remove from persistent storage (no-op if key was X25519/pseudonym)
+        keyStore.remove(keyHandle.id)
+
         // Verify removal — key should no longer be in the map
         if (softwareKeys.containsKey(keyHandle.id)) {
             throw ScpException(
@@ -542,6 +729,35 @@ class AndroidKeyCustody : KeyCustodyProvider {
             method = DestructionMethod.SOFTWARE_ONLY,
             confirmed = true,
         )
+    }
+
+    // -----------------------------------------------------------------------
+    // Private: Persistence — restore keys from EncryptedSharedPreferences
+    // -----------------------------------------------------------------------
+
+    /**
+     * Restores previously persisted software Ed25519 keys from the [keyStore]
+     * into [softwareKeys] and [softwareKeyTypes].
+     *
+     * Called during [init] to recover identity keys that survived process death.
+     * Each restored key is reconstructed as a Bouncy Castle [AsymmetricCipherKeyPair]
+     * from the persisted private and public key bytes. Private key bytes from the
+     * persistence layer are zeroed after reconstruction.
+     */
+    private fun restorePersistedKeys() {
+        val persisted = keyStore.restoreAll()
+        for ((keyId, keyBytes) in persisted) {
+            val (privBytes, pubBytes) = keyBytes
+            try {
+                val privParams = Ed25519PrivateKeyParameters(privBytes, 0)
+                val pubParams = Ed25519PublicKeyParameters(pubBytes, 0)
+                val keyPair = AsymmetricCipherKeyPair(pubParams, privParams)
+                softwareKeys[keyId] = keyPair
+                softwareKeyTypes[keyId] = KeyType.ED25519
+            } finally {
+                privBytes.fill(0)
+            }
+        }
     }
 
     companion object {

--- a/bindings/kotlin/scp-sdk-kotlin-android/src/main/kotlin/com/limn/scp/android/platform/PlatformAdapter.kt
+++ b/bindings/kotlin/scp-sdk-kotlin-android/src/main/kotlin/com/limn/scp/android/platform/PlatformAdapter.kt
@@ -47,7 +47,8 @@ data class AndroidPlatformAdapterImpl(
  *
  * ## Provider construction
  *
- * - [AndroidKeyCustody] requires no context (Android Keystore is a system service).
+ * - [AndroidKeyCustody] requires context for EncryptedSharedPreferences (software Ed25519
+ *   key persistence per ADR-027, GitHub issue #119).
  * - [AndroidDeviceAttestation] requires context for Play Integrity API access.
  * - [AndroidPushProvider] requires context for FCM token retrieval.
  * - [AndroidStorage] requires context for database file and Keystore access.
@@ -65,7 +66,7 @@ object AndroidPlatformAdapter {
      */
     fun make(context: Context): AndroidPlatformAdapterImpl {
         return AndroidPlatformAdapterImpl(
-            keyCustody = AndroidKeyCustody(),
+            keyCustody = AndroidKeyCustody(context),
             deviceAttestation = AndroidDeviceAttestation(context),
             push = AndroidPushProvider(context),
             storage = AndroidStorage(context),

--- a/bindings/kotlin/scp-sdk-kotlin-android/src/test/kotlin/com/limn/scp/android/platform/AndroidKeyCustodyTest.kt
+++ b/bindings/kotlin/scp-sdk-kotlin-android/src/test/kotlin/com/limn/scp/android/platform/AndroidKeyCustodyTest.kt
@@ -4,8 +4,12 @@
 // is not available in JVM unit tests. The Keystore path (API 33+, CustodyType.HARDWARE)
 // requires an Android device or emulator and is tested via instrumented tests.
 //
+// Persistence tests verify that software Ed25519 keys are persisted to and restored from
+// the SoftwareKeyStore (InMemoryKeyStore in tests, EncryptedSharedPreferences in production).
+// See GitHub issue #119 and ADR-027.
+//
 // Provenance: ADR-027 (Android Platform Adapter), ADR-006 (Platform Abstraction Layer),
-// SCP-110 (Implement Android Keystore KeyCustody trait).
+// SCP-110 (Implement Android Keystore KeyCustody trait), GitHub issue #119.
 
 package com.limn.scp.android.platform
 
@@ -30,17 +34,21 @@ import org.junit.jupiter.api.assertThrows
  * - Pseudonym derivation determinism
  * - Key destruction
  * - Error handling (key not found, wrong key type)
+ * - Ed25519 key persistence to SoftwareKeyStore (issue #119)
+ * - Key restoration from SoftwareKeyStore on initialization
  *
  * The Build.VERSION.SDK_INT in JVM tests defaults to 0, which is below
  * API 33 (TIRAMISU), so all Ed25519 keys will use the software path.
  */
 class AndroidKeyCustodyTest {
 
+    private lateinit var keyStore: InMemoryKeyStore
     private lateinit var custody: AndroidKeyCustody
 
     @BeforeEach
     fun setUp() {
-        custody = AndroidKeyCustody()
+        keyStore = InMemoryKeyStore()
+        custody = AndroidKeyCustody(keyStore)
     }
 
     // -------------------------------------------------------------------
@@ -569,6 +577,133 @@ class AndroidKeyCustodyTest {
             assertThrows<ScpException> {
                 custody.sign(handle1, data)
             }
+        }
+    }
+
+    // -------------------------------------------------------------------
+    // Ed25519 key persistence (GitHub issue #119, ADR-027)
+    // -------------------------------------------------------------------
+
+    @Nested
+    inner class Ed25519Persistence {
+
+        @Test
+        fun `generateKeypair ED25519 persists key to SoftwareKeyStore`() {
+            val handle = custody.generateKeypair(KeyType.ED25519)
+            val persisted = keyStore.restoreAll()
+            assertTrue(persisted.containsKey(handle.id))
+            val (privBytes, pubBytes) = persisted[handle.id]!!
+            assertEquals(32, privBytes.size)
+            assertEquals(32, pubBytes.size)
+        }
+
+        @Test
+        fun `generateKeypair X25519 does NOT persist to SoftwareKeyStore`() {
+            val handle = custody.generateKeypair(KeyType.X25519)
+            val persisted = keyStore.restoreAll()
+            assertTrue(!persisted.containsKey(handle.id))
+        }
+
+        @Test
+        fun `persisted public key matches in-memory public key`() {
+            val handle = custody.generateKeypair(KeyType.ED25519)
+            val inMemoryPubKey = custody.publicKey(handle)
+            val persisted = keyStore.restoreAll()
+            val (_, pubBytes) = persisted[handle.id]!!
+            assertArrayEquals(inMemoryPubKey, pubBytes)
+        }
+
+        @Test
+        fun `destroyKey removes from SoftwareKeyStore`() {
+            val handle = custody.generateKeypair(KeyType.ED25519)
+            assertTrue(keyStore.restoreAll().containsKey(handle.id))
+
+            custody.destroyKey(handle)
+            assertTrue(!keyStore.restoreAll().containsKey(handle.id))
+        }
+
+        @Test
+        fun `new instance restores Ed25519 keys from SoftwareKeyStore`() {
+            // Generate a key with the first custody instance
+            val handle = custody.generateKeypair(KeyType.ED25519)
+            val originalPubKey = custody.publicKey(handle)
+            val data = "persistence test".toByteArray(Charsets.UTF_8)
+
+            // Create a new custody instance with the SAME key store (simulates process restart)
+            val restoredCustody = AndroidKeyCustody(keyStore)
+
+            // The restored instance should have the key available
+            assertTrue(restoredCustody.softwareKeys.containsKey(handle.id))
+
+            // Public key should be identical
+            val restoredPubKey = restoredCustody.publicKey(handle)
+            assertArrayEquals(originalPubKey, restoredPubKey)
+
+            // Signing should produce verifiable signatures
+            val restoredSig = restoredCustody.sign(handle, data)
+            assertEquals(64, restoredSig.size)
+
+            // Verify the restored key's signature
+            val pubKeyParams = Ed25519PublicKeyParameters(restoredPubKey, 0)
+            val verifier = Ed25519Signer()
+            verifier.init(false, pubKeyParams)
+            verifier.update(data, 0, data.size)
+            assertTrue(verifier.verifySignature(restoredSig))
+        }
+
+        @Test
+        fun `restored key produces same signatures as original (Ed25519 determinism)`() {
+            val handle = custody.generateKeypair(KeyType.ED25519)
+            val data = "deterministic signing".toByteArray(Charsets.UTF_8)
+            val originalSig = custody.sign(handle, data)
+
+            // Simulate process restart
+            val restoredCustody = AndroidKeyCustody(keyStore)
+            val restoredSig = restoredCustody.sign(handle, data)
+
+            // Ed25519 is deterministic — same key + same data = same signature
+            assertArrayEquals(originalSig, restoredSig)
+        }
+
+        @Test
+        fun `multiple Ed25519 keys all persist and restore`() {
+            val handles = (1..5).map { custody.generateKeypair(KeyType.ED25519) }
+            val pubKeys = handles.map { custody.publicKey(it) }
+
+            // Verify all persisted
+            val persisted = keyStore.restoreAll()
+            assertEquals(5, persisted.size)
+            handles.forEach { assertTrue(persisted.containsKey(it.id)) }
+
+            // Simulate process restart
+            val restoredCustody = AndroidKeyCustody(keyStore)
+            assertEquals(5, restoredCustody.softwareKeys.size)
+
+            // Verify all public keys match
+            handles.forEachIndexed { i, handle ->
+                assertArrayEquals(pubKeys[i], restoredCustody.publicKey(handle))
+            }
+        }
+
+        @Test
+        fun `destroying key before restart prevents restoration`() {
+            val handle = custody.generateKeypair(KeyType.ED25519)
+            custody.destroyKey(handle)
+
+            // Simulate process restart — key should NOT be restored
+            val restoredCustody = AndroidKeyCustody(keyStore)
+            assertTrue(!restoredCustody.softwareKeys.containsKey(handle.id))
+        }
+
+        @Test
+        fun `pseudonym keys are NOT persisted`() {
+            val identity = custody.generateKeypair(KeyType.ED25519)
+            val pseudonym = custody.derivePseudonym(identity, "ctx".toByteArray())
+            val persisted = keyStore.restoreAll()
+
+            // Only the identity key should be persisted, not the pseudonym
+            assertTrue(persisted.containsKey(identity.id))
+            assertTrue(!persisted.containsKey(pseudonym.id))
         }
     }
 }


### PR DESCRIPTION
## Summary
- Persists Android software Ed25519 keys (API 26-32 fallback) to EncryptedSharedPreferences per ADR-027
- Adds `SoftwareKeyStore` interface with `EncryptedPrefsKeyStore` (production) and `InMemoryKeyStore` (tests)
- Keys restored from EncryptedSharedPreferences on initialization, surviving process death
- Private key byte arrays zeroed after writing to storage
- `destroySoftwareKey()` removes from both in-memory map and persistent store
- X25519 wrapping keys and pseudonym keys are NOT persisted (session-scoped)
- 9 new persistence-specific tests covering persist/restore/destroy/cross-instance recovery

## Test plan
- [x] All existing `AndroidKeyCustodyTest` tests pass (software Ed25519/X25519, signing, DH, pseudonym, destruction)
- [x] New `Ed25519Persistence` tests pass (persist on generate, restore on init, destroy removes, cross-instance recovery, deterministic signatures after restore, pseudonyms not persisted, X25519 not persisted)
- [x] Detekt issue count unchanged (24 weighted issues, same as baseline)
- [ ] Manual verification on API 26-32 device: generate key, kill process, restart, verify key survives

closes #119

🤖 Generated with [Claude Code](https://claude.com/claude-code)