### PR TITLE
fix(security): length prefixes in canonical hash functions

### DIFF
--- a/crates/scp-core/src/bridge/claiming.rs
+++ b/crates/scp-core/src/bridge/claiming.rs
@@ -240,12 +240,19 @@ fn hex_decode(hex: &str) -> Result<Vec<u8>, String> {
 /// Computes the canonical SHA-256 hash of a claim request's content
 /// (excluding the signature field).
 ///
-/// Fields hashed in order: `shadow_id`, `claimant_did`, `platform_handle`,
-/// `attestation_id`, `timestamp`. Variable-length fields are prefixed with
-/// their length as a 4-byte big-endian u32 to prevent field boundary
-/// ambiguity (e.g., `"abc" || "def"` vs `"abcd" || "ef"`).
+/// ```text
+/// SHA-256("SCP-CLAIM-V1:" || len(shadow_id) || shadow_id
+///         || len(claimant_did) || claimant_did
+///         || len(platform_handle) || platform_handle
+///         || len(attestation_id) || attestation_id || timestamp_BE)
+/// ```
+///
+/// Variable-length fields are prefixed with their length as a 4-byte
+/// big-endian u32 to prevent field boundary ambiguity. The domain separator
+/// prevents cross-protocol hash confusion.
 fn compute_claim_canonical_hash(request: &ClaimRequest) -> Vec<u8> {
     let mut hasher = Sha256::new();
+    hasher.update(b"SCP-CLAIM-V1:");
     // Length-prefix closure for variable-length fields. Field values (DIDs,
     // handles, IDs) are short strings; truncation is not a concern.
     #[allow(clippy::cast_possible_truncation)]

--- a/crates/scp-core/src/crypto/sender_keys/key_protocol.rs
+++ b/crates/scp-core/src/crypto/sender_keys/key_protocol.rs
@@ -740,17 +740,35 @@ fn aes128gcm_decrypt(key: &[u8; 16], sealed: &[u8]) -> Result<Vec<u8>, SenderKey
 // Hash helpers
 // ---------------------------------------------------------------------------
 
-/// Computes `SHA-256(context_id || sender_did || "key_epoch" || epoch_BE)`.
+/// Computes `SHA-256("SCP-EPOCH-ADVANCE-V1:" || len(context_id) || context_id
+///   || len(sender_did) || sender_did || "key_epoch" || epoch_BE)`.
+///
+/// Variable-length fields are prefixed with their length as a 4-byte
+/// big-endian u32 to prevent field-boundary ambiguity. The domain separator
+/// prevents cross-protocol hash confusion.
 fn compute_epoch_advance_hash(context_id: &str, sender_did: &str, epoch: u64) -> Vec<u8> {
     let mut hasher = Sha256::new();
-    hasher.update(context_id.as_bytes());
-    hasher.update(sender_did.as_bytes());
+    hasher.update(b"SCP-EPOCH-ADVANCE-V1:");
+    #[allow(clippy::cast_possible_truncation)]
+    let length_prefix = |hasher: &mut Sha256, bytes: &[u8]| {
+        hasher.update((bytes.len() as u32).to_be_bytes());
+        hasher.update(bytes);
+    };
+    length_prefix(&mut hasher, context_id.as_bytes());
+    length_prefix(&mut hasher, sender_did.as_bytes());
     hasher.update(b"key_epoch");
     hasher.update(epoch.to_be_bytes());
     hasher.finalize().to_vec()
 }
 
-/// Computes `SHA-256(requester_did || sender_did || epoch_BE || wrapping_pubkey)`.
+/// Computes `SHA-256("SCP-KEY-REQUEST-V1:" || len(requester_did) || requester_did
+///   || len(sender_did) || sender_did || epoch_BE || len(wrapping_pubkey)
+///   || wrapping_pubkey || nonce || timestamp_BE)`.
+///
+/// Variable-length fields are prefixed with their length as a 4-byte
+/// big-endian u32 to prevent field-boundary ambiguity. The domain separator
+/// prevents cross-protocol hash confusion. `nonce` is fixed-size
+/// (`REQUEST_NONCE_SIZE`) and needs no prefix.
 fn compute_request_hash(
     requester_did: &str,
     sender_did: &str,
@@ -760,16 +778,28 @@ fn compute_request_hash(
     timestamp: u64,
 ) -> Vec<u8> {
     let mut hasher = Sha256::new();
-    hasher.update(requester_did.as_bytes());
-    hasher.update(sender_did.as_bytes());
+    hasher.update(b"SCP-KEY-REQUEST-V1:");
+    #[allow(clippy::cast_possible_truncation)]
+    let length_prefix = |hasher: &mut Sha256, bytes: &[u8]| {
+        hasher.update((bytes.len() as u32).to_be_bytes());
+        hasher.update(bytes);
+    };
+    length_prefix(&mut hasher, requester_did.as_bytes());
+    length_prefix(&mut hasher, sender_did.as_bytes());
     hasher.update(epoch.to_be_bytes());
-    hasher.update(wrapping_pubkey);
+    length_prefix(&mut hasher, wrapping_pubkey);
     hasher.update(nonce);
     hasher.update(timestamp.to_be_bytes());
     hasher.finalize().to_vec()
 }
 
-/// Computes `SHA-256(context_id || "block" || blocker_did || blocked_did || timestamp_BE)`.
+/// Computes `SHA-256("SCP-BLOCK-NOTIFICATION-V1:" || len(context_id) || context_id
+///   || len(blocker_did) || blocker_did || len(blocked_did) || blocked_did
+///   || timestamp_BE)`.
+///
+/// Variable-length fields are prefixed with their length as a 4-byte
+/// big-endian u32 to prevent field-boundary ambiguity. The domain separator
+/// prevents cross-protocol hash confusion.
 #[allow(clippy::similar_names)] // blocker_did/blocked_did are domain terms
 fn compute_block_notification_hash(
     context_id: &str,
@@ -778,10 +808,15 @@ fn compute_block_notification_hash(
     timestamp: u64,
 ) -> Vec<u8> {
     let mut hasher = Sha256::new();
-    hasher.update(context_id.as_bytes());
-    hasher.update(b"block");
-    hasher.update(blocker_did.as_bytes());
-    hasher.update(blocked_did.as_bytes());
+    hasher.update(b"SCP-BLOCK-NOTIFICATION-V1:");
+    #[allow(clippy::cast_possible_truncation)]
+    let length_prefix = |hasher: &mut Sha256, bytes: &[u8]| {
+        hasher.update((bytes.len() as u32).to_be_bytes());
+        hasher.update(bytes);
+    };
+    length_prefix(&mut hasher, context_id.as_bytes());
+    length_prefix(&mut hasher, blocker_did.as_bytes());
+    length_prefix(&mut hasher, blocked_did.as_bytes());
     hasher.update(timestamp.to_be_bytes());
     hasher.finalize().to_vec()
 }
@@ -1588,6 +1623,41 @@ mod tests {
         assert_eq!(
             response.request_nonce, original_nonce,
             "response must echo the request nonce"
+        );
+    }
+
+    // -------------------------------------------------------------------
+    // length prefix prevents field boundary ambiguity
+    // -------------------------------------------------------------------
+
+    #[test]
+    fn epoch_advance_hash_boundary_shift_produces_different_hash() {
+        let hash_a = compute_epoch_advance_hash("ctx-AB", "did:key:CD", 1);
+        let hash_b = compute_epoch_advance_hash("ctx-ABC", "did:key:D", 1);
+        assert_ne!(
+            hash_a, hash_b,
+            "shifting bytes between context_id and sender_did must produce different hashes"
+        );
+    }
+
+    #[test]
+    fn request_hash_boundary_shift_produces_different_hash() {
+        let nonce = [0u8; REQUEST_NONCE_SIZE];
+        let hash_a = compute_request_hash("did:key:AB", "did:key:CD", 1, &[0xAA], &nonce, 100);
+        let hash_b = compute_request_hash("did:key:ABC", "did:key:D", 1, &[0xAA], &nonce, 100);
+        assert_ne!(
+            hash_a, hash_b,
+            "shifting bytes between requester_did and sender_did must produce different hashes"
+        );
+    }
+
+    #[test]
+    fn block_notification_hash_boundary_shift_produces_different_hash() {
+        let hash_a = compute_block_notification_hash("ctx-1", "did:key:AB", "did:key:CD", 100);
+        let hash_b = compute_block_notification_hash("ctx-1", "did:key:ABC", "did:key:D", 100);
+        assert_ne!(
+            hash_a, hash_b,
+            "shifting bytes between blocker_did and blocked_did must produce different hashes"
         );
     }
 }

--- a/crates/scp-core/src/envelope/inner.rs
+++ b/crates/scp-core/src/envelope/inner.rs
@@ -171,10 +171,10 @@ pub async fn create_inner_envelope(
     signing_key: &KeyHandle,
 ) -> Result<InnerEnvelope, EnvelopeError> {
     // 1. Hash original plaintext.
-    let payload_hash = Sha256::digest(params.payload).to_vec();
+    let payload_hash: [u8; 32] = Sha256::digest(params.payload).into();
 
     // 2. Hash provenance.
-    let provenance_hash = compute_provenance_hash(params.provenance.as_ref())?;
+    let provenance_hash: [u8; 32] = compute_provenance_hash(params.provenance.as_ref())?;
 
     // 3. Compute canonical hash for signing.
     let canonical_hash = compute_canonical_hash(params, &payload_hash, &provenance_hash);
@@ -196,10 +196,10 @@ pub async fn create_inner_envelope(
         generation: params.generation,
         sequence: params.sequence,
         timestamp: params.timestamp,
-        payload_hash,
+        payload_hash: payload_hash.to_vec(),
         payload: padded_payload,
         provenance: params.provenance.clone(),
-        provenance_hash,
+        provenance_hash: provenance_hash.to_vec(),
         signature: signature.into_bytes(),
     })
 }
@@ -261,7 +261,13 @@ pub fn verify_inner_signature(
     };
 
     // Recompute the canonical hash.
-    let canonical_hash = compute_canonical_hash(&params, &inner.payload_hash, &provenance_hash);
+    let payload_hash: &[u8; 32] = inner.payload_hash.as_slice().try_into().map_err(|_| {
+        EnvelopeError::VerificationFailed(format!(
+            "payload_hash must be 32 bytes, got {}",
+            inner.payload_hash.len()
+        ))
+    })?;
+    let canonical_hash = compute_canonical_hash(&params, payload_hash, &provenance_hash);
 
     // Verify.
     match verifying_key.verify_strict(&canonical_hash, &signature) {
@@ -282,15 +288,15 @@ pub fn verify_inner_signature(
 const DOMAIN_SEPARATOR: &[u8] = b"SCP-INNER-ENVELOPE-V1:";
 
 /// Computes `SHA-256(serialize(provenance))` if present, or `SHA-256(0x00)` if
-/// absent.
-fn compute_provenance_hash(provenance: Option<&Provenance>) -> Result<Vec<u8>, EnvelopeError> {
+/// absent. Returns a fixed-size 32-byte array (SHA-256 output).
+fn compute_provenance_hash(provenance: Option<&Provenance>) -> Result<[u8; 32], EnvelopeError> {
     match provenance {
         Some(p) => {
             let serialized = rmp_serde::to_vec(p)
                 .map_err(|e| EnvelopeError::SerializationFailed(e.to_string()))?;
-            Ok(Sha256::digest(&serialized).to_vec())
+            Ok(Sha256::digest(&serialized).into())
         }
-        None => Ok(Sha256::digest([0x00]).to_vec()),
+        None => Ok(Sha256::digest([0x00]).into()),
     }
 }
 
@@ -298,31 +304,26 @@ fn compute_provenance_hash(provenance: Option<&Provenance>) -> Result<Vec<u8>, E
 ///
 /// A domain separator ([`DOMAIN_SEPARATOR`]) is prepended to prevent
 /// cross-protocol signature confusion when the same Ed25519 key is reused
-/// across different signing contexts. Variable-length fields (`context_id`,
-/// `sender_did`) are prefixed with their length as a 4-byte big-endian u32 to
-/// prevent field-boundary ambiguity (e.g., `"abc" || "def"` vs `"abcd" || "ef"`).
+/// across different signing contexts.
 ///
-/// Fixed-width fields (`epoch`, `generation`, `sequence`, `timestamp` as u64 BE;
-/// `payload_hash` and `provenance_hash` as 32-byte SHA-256 outputs) need no
-/// length prefix.
+/// Variable-length fields (`context_id`, `sender_did`) are prefixed with
+/// their length as a 4-byte big-endian u32 to prevent field-boundary
+/// ambiguity. `payload_hash` and `provenance_hash` are typed as `&[u8; 32]`
+/// (SHA-256 outputs) and are also length-prefixed for defense in depth.
+/// Fixed-width u64 fields (`epoch`, `generation`, `sequence`, `timestamp`)
+/// need no length prefix.
 ///
 /// ```text
 /// SHA-256(DOMAIN_SEPARATOR || len(context_id) || context_id
 ///         || len(sender_did) || sender_did || epoch_BE
 ///         || generation_BE || sequence_BE || timestamp_BE
-///         || payload_hash || provenance_hash)
+///         || len(payload_hash) || payload_hash
+///         || len(provenance_hash) || provenance_hash)
 /// ```
-///
-/// Variable-length fields (`context_id`, `sender_did`, `payload_hash`,
-/// `provenance_hash`) are length-prefixed with a `u32` big-endian byte count
-/// to prevent field-boundary collision attacks (e.g., `context_id="ab"` +
-/// `sender_did="cd"` must hash differently from `context_id="abc"` +
-/// `sender_did="d"`). Fixed-width fields (`epoch`, `generation`, `sequence`,
-/// `timestamp`) need no length prefix.
 fn compute_canonical_hash(
     params: &InnerEnvelopeParams<'_>,
-    payload_hash: &[u8],
-    provenance_hash: &[u8],
+    payload_hash: &[u8; 32],
+    provenance_hash: &[u8; 32],
 ) -> Vec<u8> {
     let mut hasher = Sha256::new();
     hasher.update(DOMAIN_SEPARATOR);
@@ -560,7 +561,7 @@ mod tests {
     #[tokio::test]
     async fn provenance_hash_absent_uses_sentinel() {
         // Verify that SHA-256(0x00) is used for absent provenance.
-        let expected = Sha256::digest([0x00]).to_vec();
+        let expected: [u8; 32] = Sha256::digest([0x00]).into();
         let hash = compute_provenance_hash(None).unwrap();
         assert_eq!(hash, expected);
     }
@@ -623,8 +624,8 @@ mod tests {
 
     #[test]
     fn domain_separator_changes_canonical_hash() {
-        let payload_hash = Sha256::digest(b"test").to_vec();
-        let provenance_hash = Sha256::digest([0x00]).to_vec();
+        let payload_hash: [u8; 32] = Sha256::digest(b"test").into();
+        let provenance_hash: [u8; 32] = Sha256::digest([0x00]).into();
 
         // Hash with the real domain separator (via the production function).
         let params = InnerEnvelopeParams {
@@ -652,8 +653,8 @@ mod tests {
             h.update(0u64.to_be_bytes());
             h.update(1u64.to_be_bytes());
             h.update(1_700_000_000u64.to_be_bytes());
-            h.update(&payload_hash);
-            h.update(&provenance_hash);
+            h.update(payload_hash);
+            h.update(provenance_hash);
             h.finalize().to_vec()
         };
 
@@ -670,8 +671,8 @@ mod tests {
             h.update(0u64.to_be_bytes());
             h.update(1u64.to_be_bytes());
             h.update(1_700_000_000u64.to_be_bytes());
-            h.update(&payload_hash);
-            h.update(&provenance_hash);
+            h.update(payload_hash);
+            h.update(provenance_hash);
             h.finalize().to_vec()
         };
 

--- a/crates/scp-core/src/event_log/checkpoint.rs
+++ b/crates/scp-core/src/event_log/checkpoint.rs
@@ -1152,13 +1152,20 @@ mod tests {
     }
 
     /// Helper: compute the canonical hash for signing an event.
+    /// Must match the production `compute_event_canonical_hash` in `tree.rs`.
     fn compute_event_canonical_hash(event: &Event) -> Vec<u8> {
         let mut hasher = Sha256::new();
+        hasher.update(b"SCP-EVENT-V1:");
+        #[allow(clippy::cast_possible_truncation)]
+        let length_prefix = |hasher: &mut Sha256, bytes: &[u8]| {
+            hasher.update((bytes.len() as u32).to_be_bytes());
+            hasher.update(bytes);
+        };
         hasher.update(event_type_tag(&event.event_type).to_be_bytes());
-        hasher.update(event.actor_did.as_bytes());
+        length_prefix(&mut hasher, event.actor_did.as_bytes());
         hasher.update(event.timestamp.to_be_bytes());
         hasher.update(event.sequence.to_be_bytes());
-        hasher.update(&event.payload.data);
+        length_prefix(&mut hasher, &event.payload.data);
         hasher.update(event.prev_hash);
         hasher.finalize().to_vec()
     }

--- a/crates/scp-core/src/event_log/metrics.rs
+++ b/crates/scp-core/src/event_log/metrics.rs
@@ -555,13 +555,20 @@ mod tests {
         format!("did:key:{hex}")
     }
 
+    /// Must match the production `compute_event_canonical_hash` in `tree.rs`.
     fn compute_event_canonical_hash(event: &Event) -> Vec<u8> {
         let mut hasher = Sha256::new();
+        hasher.update(b"SCP-EVENT-V1:");
+        #[allow(clippy::cast_possible_truncation)]
+        let length_prefix = |hasher: &mut Sha256, bytes: &[u8]| {
+            hasher.update((bytes.len() as u32).to_be_bytes());
+            hasher.update(bytes);
+        };
         hasher.update(event_type_tag(&event.event_type).to_be_bytes());
-        hasher.update(event.actor_did.as_bytes());
+        length_prefix(&mut hasher, event.actor_did.as_bytes());
         hasher.update(event.timestamp.to_be_bytes());
         hasher.update(event.sequence.to_be_bytes());
-        hasher.update(&event.payload.data);
+        length_prefix(&mut hasher, &event.payload.data);
         hasher.update(event.prev_hash);
         hasher.finalize().to_vec()
     }

--- a/crates/scp-core/src/event_log/proof.rs
+++ b/crates/scp-core/src/event_log/proof.rs
@@ -373,13 +373,20 @@ mod tests {
     }
 
     /// Helper: compute the canonical hash for signing an event.
+    /// Must match the production `compute_event_canonical_hash` in `tree.rs`.
     fn compute_event_canonical_hash(event: &Event) -> Vec<u8> {
         let mut hasher = Sha256::new();
+        hasher.update(b"SCP-EVENT-V1:");
+        #[allow(clippy::cast_possible_truncation)]
+        let length_prefix = |hasher: &mut Sha256, bytes: &[u8]| {
+            hasher.update((bytes.len() as u32).to_be_bytes());
+            hasher.update(bytes);
+        };
         hasher.update(event_type_tag(&event.event_type).to_be_bytes());
-        hasher.update(event.actor_did.as_bytes());
+        length_prefix(&mut hasher, event.actor_did.as_bytes());
         hasher.update(event.timestamp.to_be_bytes());
         hasher.update(event.sequence.to_be_bytes());
-        hasher.update(&event.payload.data);
+        length_prefix(&mut hasher, &event.payload.data);
         hasher.update(event.prev_hash);
         hasher.finalize().to_vec()
     }

--- a/crates/scp-core/src/event_log/pruning.rs
+++ b/crates/scp-core/src/event_log/pruning.rs
@@ -495,13 +495,20 @@ mod tests {
         format!("did:key:{hex}")
     }
 
+    /// Must match the production `compute_event_canonical_hash` in `tree.rs`.
     fn compute_event_canonical_hash(event: &Event) -> Vec<u8> {
         let mut hasher = Sha256::new();
+        hasher.update(b"SCP-EVENT-V1:");
+        #[allow(clippy::cast_possible_truncation)]
+        let length_prefix = |hasher: &mut Sha256, bytes: &[u8]| {
+            hasher.update((bytes.len() as u32).to_be_bytes());
+            hasher.update(bytes);
+        };
         hasher.update(event_type_tag(&event.event_type).to_be_bytes());
-        hasher.update(event.actor_did.as_bytes());
+        length_prefix(&mut hasher, event.actor_did.as_bytes());
         hasher.update(event.timestamp.to_be_bytes());
         hasher.update(event.sequence.to_be_bytes());
-        hasher.update(&event.payload.data);
+        length_prefix(&mut hasher, &event.payload.data);
         hasher.update(event.prev_hash);
         hasher.finalize().to_vec()
     }

--- a/crates/scp-core/src/event_log/tiered_storage.rs
+++ b/crates/scp-core/src/event_log/tiered_storage.rs
@@ -647,13 +647,20 @@ mod tests {
         format!("did:key:{hex}")
     }
 
+    /// Must match the production `compute_event_canonical_hash` in `tree.rs`.
     fn compute_event_canonical_hash(event: &Event) -> Vec<u8> {
         let mut hasher = Sha256::new();
+        hasher.update(b"SCP-EVENT-V1:");
+        #[allow(clippy::cast_possible_truncation)]
+        let length_prefix = |hasher: &mut Sha256, bytes: &[u8]| {
+            hasher.update((bytes.len() as u32).to_be_bytes());
+            hasher.update(bytes);
+        };
         hasher.update(event_type_tag(&event.event_type).to_be_bytes());
-        hasher.update(event.actor_did.as_bytes());
+        length_prefix(&mut hasher, event.actor_did.as_bytes());
         hasher.update(event.timestamp.to_be_bytes());
         hasher.update(event.sequence.to_be_bytes());
-        hasher.update(&event.payload.data);
+        length_prefix(&mut hasher, &event.payload.data);
         hasher.update(event.prev_hash);
         hasher.finalize().to_vec()
     }

--- a/crates/scp-core/src/event_log/tree.rs
+++ b/crates/scp-core/src/event_log/tree.rs
@@ -212,19 +212,33 @@ fn verify_event_signature(event: &Event) -> Result<(), EventLogError> {
 /// Computes the canonical hash of an event for signature purposes.
 ///
 /// ```text
-/// SHA-256(event_type_tag || actor_did || timestamp_BE || sequence_BE
-///         || payload || prev_hash)
+/// SHA-256("SCP-EVENT-V1:" || event_type_tag || len(actor_did) || actor_did
+///         || timestamp_BE || sequence_BE || len(payload) || payload
+///         || prev_hash)
 /// ```
+///
+/// Variable-length fields (`actor_did`, `payload.data`) are prefixed with
+/// their length as a 4-byte big-endian u32 to prevent field-boundary
+/// ambiguity. The `SCP-EVENT-V1:` domain separator prevents cross-protocol
+/// hash confusion.
 fn compute_event_canonical_hash(event: &Event) -> Vec<u8> {
     let mut hasher = Sha256::new();
+    hasher.update(b"SCP-EVENT-V1:");
 
-    // Event type as a tag byte.
+    // Length-prefix closure for variable-length fields.
+    #[allow(clippy::cast_possible_truncation)]
+    let length_prefix = |hasher: &mut Sha256, bytes: &[u8]| {
+        hasher.update((bytes.len() as u32).to_be_bytes());
+        hasher.update(bytes);
+    };
+
+    // Event type as a tag byte (fixed-width u16).
     hasher.update(event_type_tag(&event.event_type).to_be_bytes());
-    hasher.update(event.actor_did.as_bytes());
+    length_prefix(&mut hasher, event.actor_did.as_bytes());
     hasher.update(event.timestamp.to_be_bytes());
     hasher.update(event.sequence.to_be_bytes());
-    hasher.update(&event.payload.data);
-    hasher.update(event.prev_hash);
+    length_prefix(&mut hasher, &event.payload.data);
+    hasher.update(event.prev_hash); // 32B fixed
 
     hasher.finalize().to_vec()
 }
@@ -865,5 +879,46 @@ mod tests {
             current = next;
         }
         current[0]
+    }
+
+    // -----------------------------------------------------------------------
+    // length prefix prevents field boundary ambiguity
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn length_prefix_prevents_field_boundary_ambiguity() {
+        // Two events that differ only by shifting bytes between actor_did
+        // and payload. Without length prefixes these would hash identically.
+        let event_a = Event {
+            event_type: EventType::MessageSent,
+            actor_did: "did:key:AB".into(),
+            timestamp: 1000,
+            sequence: 0,
+            payload: EventPayload {
+                data: b"CD".to_vec(),
+            },
+            prev_hash: [0u8; 32],
+            signature: Vec::new(),
+        };
+
+        let event_b = Event {
+            event_type: EventType::MessageSent,
+            actor_did: "did:key:ABC".into(),
+            timestamp: 1000,
+            sequence: 0,
+            payload: EventPayload {
+                data: b"D".to_vec(),
+            },
+            prev_hash: [0u8; 32],
+            signature: Vec::new(),
+        };
+
+        let hash_a = compute_event_canonical_hash(&event_a);
+        let hash_b = compute_event_canonical_hash(&event_b);
+
+        assert_ne!(
+            hash_a, hash_b,
+            "shifting bytes between actor_did and payload must produce different hashes"
+        );
     }
 }

--- a/crates/scp-core/src/trust/attestation.rs
+++ b/crates/scp-core/src/trust/attestation.rs
@@ -429,17 +429,36 @@ pub fn check_threshold_attestation(
 
 /// Computes the canonical byte representation of an attestation for signing.
 ///
-/// The canonical form includes: id, `attestation_type` (debug string), issuer,
-/// subject, claim (compact JSON), and `issued_at`. This deterministic
-/// representation is what the issuer signs and what the verifier checks.
+/// ```text
+/// "SCP-ATTESTATION-V1:" || len(id) || id || len(attestation_type) || attestation_type
+///     || len(issuer) || issuer || len(subject) || subject
+///     || len(claim_json) || claim_json || issued_at_BE
+/// ```
+///
+/// Variable-length fields are prefixed with their length as a 4-byte
+/// big-endian u32 to prevent field-boundary ambiguity. The domain separator
+/// prevents cross-protocol hash confusion. `issued_at` uses big-endian
+/// encoding, consistent with all other canonical hash functions.
 pub(crate) fn canonical_attestation_bytes(attestation: &Attestation) -> Vec<u8> {
     let mut bytes = Vec::new();
-    bytes.extend_from_slice(attestation.id.as_bytes());
-    bytes.extend_from_slice(format!("{:?}", attestation.attestation_type).as_bytes());
-    bytes.extend_from_slice(attestation.issuer.as_bytes());
-    bytes.extend_from_slice(attestation.subject.as_bytes());
-    bytes.extend_from_slice(attestation.claim.to_string().as_bytes());
-    bytes.extend_from_slice(&attestation.issued_at.to_le_bytes());
+    bytes.extend_from_slice(b"SCP-ATTESTATION-V1:");
+
+    // Length-prefix helper for variable-length fields.
+    #[allow(clippy::cast_possible_truncation)]
+    let length_prefix = |bytes: &mut Vec<u8>, data: &[u8]| {
+        bytes.extend_from_slice(&(data.len() as u32).to_be_bytes());
+        bytes.extend_from_slice(data);
+    };
+
+    length_prefix(&mut bytes, attestation.id.as_bytes());
+    length_prefix(
+        &mut bytes,
+        format!("{:?}", attestation.attestation_type).as_bytes(),
+    );
+    length_prefix(&mut bytes, attestation.issuer.as_bytes());
+    length_prefix(&mut bytes, attestation.subject.as_bytes());
+    length_prefix(&mut bytes, attestation.claim.to_string().as_bytes());
+    bytes.extend_from_slice(&attestation.issued_at.to_be_bytes()); // fixed-width, no prefix needed
     bytes
 }
 
@@ -1353,6 +1372,50 @@ mod tests {
             (result.independence_score - 0.6).abs() < 0.001,
             "expected ~0.6, got {}",
             result.independence_score
+        );
+    }
+
+    // -------------------------------------------------------------------
+    // length prefix prevents field boundary ambiguity
+    // -------------------------------------------------------------------
+
+    #[test]
+    fn canonical_attestation_boundary_shift_produces_different_bytes() {
+        let att_a = Attestation {
+            id: "att-AB".to_owned(),
+            attestation_type: AttestationType::Endorsement,
+            issuer: "did:key:CD".into(),
+            subject: "did:key:subj".into(),
+            claim: serde_json::json!({"x": 1}),
+            evidence: None,
+            issued_at: 1000,
+            expires_at: None,
+            renewal_interval: None,
+            renewed_at: None,
+            revocation_status: RevocationStatus::Active,
+            signature: vec![],
+        };
+
+        let att_b = Attestation {
+            id: "att-ABC".to_owned(),
+            attestation_type: AttestationType::Endorsement,
+            issuer: "did:key:D".into(),
+            subject: "did:key:subj".into(),
+            claim: serde_json::json!({"x": 1}),
+            evidence: None,
+            issued_at: 1000,
+            expires_at: None,
+            renewal_interval: None,
+            renewed_at: None,
+            revocation_status: RevocationStatus::Active,
+            signature: vec![],
+        };
+
+        let bytes_a = canonical_attestation_bytes(&att_a);
+        let bytes_b = canonical_attestation_bytes(&att_b);
+        assert_ne!(
+            bytes_a, bytes_b,
+            "shifting bytes between id and issuer must produce different canonical bytes"
         );
     }
 }

--- a/crates/scp-core/tests/economy_integration.rs
+++ b/crates/scp-core/tests/economy_integration.rs
@@ -364,11 +364,17 @@ fn signed_event(
     };
 
     let mut hasher = Sha256::new();
+    hasher.update(b"SCP-EVENT-V1:");
+    #[allow(clippy::cast_possible_truncation)]
+    let length_prefix = |hasher: &mut Sha256, bytes: &[u8]| {
+        hasher.update((bytes.len() as u32).to_be_bytes());
+        hasher.update(bytes);
+    };
     hasher.update(event_tag.to_be_bytes());
-    hasher.update(event.actor_did.as_bytes());
+    length_prefix(&mut hasher, event.actor_did.as_bytes());
     hasher.update(event.timestamp.to_be_bytes());
     hasher.update(event.sequence.to_be_bytes());
-    hasher.update(&event.payload.data);
+    length_prefix(&mut hasher, &event.payload.data);
     hasher.update(event.prev_hash);
     let canonical_hash = hasher.finalize().to_vec();
 

--- a/crates/scp-core/tests/phase2_integration.rs
+++ b/crates/scp-core/tests/phase2_integration.rs
@@ -76,11 +76,17 @@ fn did_from_pubkey(verifying_key: &ed25519_dalek::VerifyingKey) -> DID {
 /// Computes the canonical hash for signing an event (matches `tree.rs` internals).
 fn compute_event_canonical_hash(event: &Event) -> Vec<u8> {
     let mut hasher = Sha256::new();
+    hasher.update(b"SCP-EVENT-V1:");
+    #[allow(clippy::cast_possible_truncation)]
+    let length_prefix = |hasher: &mut Sha256, bytes: &[u8]| {
+        hasher.update((bytes.len() as u32).to_be_bytes());
+        hasher.update(bytes);
+    };
     hasher.update(event_type_tag(&event.event_type).to_be_bytes());
-    hasher.update(event.actor_did.as_bytes());
+    length_prefix(&mut hasher, event.actor_did.as_bytes());
     hasher.update(event.timestamp.to_be_bytes());
     hasher.update(event.sequence.to_be_bytes());
-    hasher.update(&event.payload.data);
+    length_prefix(&mut hasher, &event.payload.data);
     hasher.update(event.prev_hash);
     hasher.finalize().to_vec()
 }

--- a/crates/scp-core/tests/phase5_integration.rs
+++ b/crates/scp-core/tests/phase5_integration.rs
@@ -91,11 +91,17 @@ fn did_from_pubkey(verifying_key: &ed25519_dalek::VerifyingKey) -> DID {
 /// Computes the canonical hash for signing an event (matches `tree.rs` internals).
 fn compute_event_canonical_hash(event: &Event) -> Vec<u8> {
     let mut hasher = Sha256::new();
+    hasher.update(b"SCP-EVENT-V1:");
+    #[allow(clippy::cast_possible_truncation)]
+    let length_prefix = |hasher: &mut Sha256, bytes: &[u8]| {
+        hasher.update((bytes.len() as u32).to_be_bytes());
+        hasher.update(bytes);
+    };
     hasher.update(event_type_tag(&event.event_type).to_be_bytes());
-    hasher.update(event.actor_did.as_bytes());
+    length_prefix(&mut hasher, event.actor_did.as_bytes());
     hasher.update(event.timestamp.to_be_bytes());
     hasher.update(event.sequence.to_be_bytes());
-    hasher.update(&event.payload.data);
+    length_prefix(&mut hasher, &event.payload.data);
     hasher.update(event.prev_hash);
     hasher.finalize().to_vec()
 }
@@ -170,6 +176,7 @@ fn append_and_hash(log: &mut EventLog, event: &Event) -> [u8; 32] {
 /// (matching the internal `compute_claim_canonical_hash` in claiming.rs).
 fn compute_claim_hash(request: &ClaimRequest) -> Vec<u8> {
     let mut hasher = Sha256::new();
+    hasher.update(b"SCP-CLAIM-V1:");
     #[allow(clippy::cast_possible_truncation)]
     let length_prefix = |hasher: &mut Sha256, bytes: &[u8]| {
         hasher.update((bytes.len() as u32).to_be_bytes());
@@ -187,12 +194,21 @@ fn compute_claim_hash(request: &ClaimRequest) -> Vec<u8> {
 /// `pub(crate) canonical_attestation_bytes` in `trust/attestation.rs`).
 fn compute_attestation_canonical_bytes(attestation: &Attestation) -> Vec<u8> {
     let mut bytes = Vec::new();
-    bytes.extend_from_slice(attestation.id.as_bytes());
-    bytes.extend_from_slice(format!("{:?}", attestation.attestation_type).as_bytes());
-    bytes.extend_from_slice(attestation.issuer.as_bytes());
-    bytes.extend_from_slice(attestation.subject.as_bytes());
-    bytes.extend_from_slice(attestation.claim.to_string().as_bytes());
-    bytes.extend_from_slice(&attestation.issued_at.to_le_bytes());
+    bytes.extend_from_slice(b"SCP-ATTESTATION-V1:");
+    #[allow(clippy::cast_possible_truncation)]
+    let length_prefix = |bytes: &mut Vec<u8>, data: &[u8]| {
+        bytes.extend_from_slice(&(data.len() as u32).to_be_bytes());
+        bytes.extend_from_slice(data);
+    };
+    length_prefix(&mut bytes, attestation.id.as_bytes());
+    length_prefix(
+        &mut bytes,
+        format!("{:?}", attestation.attestation_type).as_bytes(),
+    );
+    length_prefix(&mut bytes, attestation.issuer.as_bytes());
+    length_prefix(&mut bytes, attestation.subject.as_bytes());
+    length_prefix(&mut bytes, attestation.claim.to_string().as_bytes());
+    bytes.extend_from_slice(&attestation.issued_at.to_be_bytes());
     bytes
 }
 

--- a/crates/scp-core/tests/wasm_conformance.rs
+++ b/crates/scp-core/tests/wasm_conformance.rs
@@ -399,11 +399,17 @@ fn did_from_pubkey(verifying_key: &ed25519_dalek::VerifyingKey) -> String {
 
 fn compute_event_canonical_hash(event: &Event) -> Vec<u8> {
     let mut hasher = Sha256::new();
+    hasher.update(b"SCP-EVENT-V1:");
+    #[allow(clippy::cast_possible_truncation)]
+    let length_prefix = |hasher: &mut Sha256, bytes: &[u8]| {
+        hasher.update((bytes.len() as u32).to_be_bytes());
+        hasher.update(bytes);
+    };
     hasher.update(event_type_tag(&event.event_type).to_be_bytes());
-    hasher.update(event.actor_did.as_bytes());
+    length_prefix(&mut hasher, event.actor_did.as_bytes());
     hasher.update(event.timestamp.to_be_bytes());
     hasher.update(event.sequence.to_be_bytes());
-    hasher.update(&event.payload.data);
+    length_prefix(&mut hasher, &event.payload.data);
     hasher.update(event.prev_hash);
     hasher.finalize().to_vec()
 }


### PR DESCRIPTION
## Summary
- Adds u32 big-endian length prefixes to all variable-length fields in canonical hash functions to prevent concatenation ambiguity / second-preimage attacks
- Adds domain separators (`SCP-*-V1:`) to all canonical hash functions that lacked them (`compute_event_canonical_hash`, `compute_claim_canonical_hash`, `canonical_attestation_bytes`, `compute_epoch_advance_hash`, `compute_request_hash`, `compute_block_notification_hash`)
- Fixes endianness divergence in `canonical_attestation_bytes` (`to_le_bytes` -> `to_be_bytes` for `issued_at`, matching all other canonical hash functions)
- Types `payload_hash` and `provenance_hash` parameters in `compute_canonical_hash` (inner.rs) as `&[u8; 32]` instead of `&[u8]` to enforce SHA-256 output size at the type level
- Updates all 8 test copies of `compute_event_canonical_hash` and 2 test copies in `phase5_integration.rs` to match production implementations
- Adds boundary-shift unit tests demonstrating that shifting bytes between adjacent variable-length fields produces different hashes

### Files changed (14)
| File | Change |
|------|--------|
| `crates/scp-core/src/event_log/tree.rs` | Domain separator + length prefixes + boundary-shift test |
| `crates/scp-core/src/trust/attestation.rs` | Domain separator + length prefixes + endianness fix + boundary-shift test |
| `crates/scp-core/src/bridge/claiming.rs` | Domain separator added (length prefixes were already present) |
| `crates/scp-core/src/crypto/sender_keys/key_protocol.rs` | Domain separators + length prefixes + 3 boundary-shift tests |
| `crates/scp-core/src/envelope/inner.rs` | `payload_hash`/`provenance_hash` typed as `&[u8; 32]` |
| `crates/scp-core/src/event_log/{checkpoint,metrics,proof,pruning,tiered_storage}.rs` | Test copy updates |
| `crates/scp-core/tests/{phase2,phase5,economy}_integration.rs` | Test copy updates |
| `crates/scp-core/tests/wasm_conformance.rs` | Test copy update |

## Test plan
- [x] All 2614 existing tests pass (hash values changed, test fixtures updated)
- [x] New boundary-shift tests verify length prefix effectiveness
- [x] `cargo clippy --workspace --all-targets` passes with no errors
- [x] `cargo fmt --all` applied
- [x] `generate_session_id` in scp-media (reference implementation) unchanged

closes #84

🤖 Generated with [Claude Code](https://claude.com/claude-code)