### PR TITLE
refactor(core): consolidate hex encode/decode implementations

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3703,6 +3703,7 @@ name = "scp-testing"
 version = "0.1.0"
 dependencies = [
  "futures",
+ "hex",
  "openmls",
  "rmp-serde",
  "scp-core",
@@ -3717,6 +3718,7 @@ name = "scp-transport"
 version = "0.1.0"
 dependencies = [
  "futures",
+ "hex",
  "lru",
  "rand 0.8.5",
  "rmp-serde",

--- a/crates/scp-core/src/bridge/claiming.rs
+++ b/crates/scp-core/src/bridge/claiming.rs
@@ -211,7 +211,7 @@ fn extract_public_key_from_did(did: &str) -> Result<[u8; 32], String> {
 
     // Support did:key:<hex> format for testing.
     if let Some(hex_str) = did.strip_prefix("did:key:") {
-        let decoded = hex_decode(hex_str)?;
+        let decoded = hex::decode(hex_str).map_err(|e| format!("hex decode error: {e}"))?;
         let bytes: [u8; 32] = decoded
             .try_into()
             .map_err(|v: Vec<u8>| format!("DID public key must be 32 bytes, got {}", v.len()))?;
@@ -219,22 +219,6 @@ fn extract_public_key_from_did(did: &str) -> Result<[u8; 32], String> {
     }
 
     Err(format!("unsupported DID format: {did}"))
-}
-
-/// Decodes a hexadecimal string to bytes.
-fn hex_decode(hex: &str) -> Result<Vec<u8>, String> {
-    if !hex.len().is_multiple_of(2) {
-        return Err(format!("hex string has odd length: {}", hex.len()));
-    }
-
-    let mut bytes = Vec::with_capacity(hex.len() / 2);
-    for i in (0..hex.len()).step_by(2) {
-        let byte_str = &hex[i..i + 2];
-        let byte =
-            u8::from_str_radix(byte_str, 16).map_err(|e| format!("hex decode error: {e}"))?;
-        bytes.push(byte);
-    }
-    Ok(bytes)
 }
 
 /// Computes the canonical SHA-256 hash of a claim request's content

--- a/crates/scp-core/src/context/governance/majority.rs
+++ b/crates/scp-core/src/context/governance/majority.rs
@@ -31,7 +31,7 @@ use std::collections::HashMap;
 use super::{
     GovernanceAction, GovernanceContext, GovernanceEngine, GovernanceError, GovernanceEvent,
     GovernanceModelConfig, GovernanceProposal, ProposalId, ProposalStatus, RejectionReason,
-    VoteType, compute_proposal_id, hex_encode, sign_vote,
+    VoteType, compute_proposal_id, sign_vote,
 };
 use crate::identity::DID;
 
@@ -145,7 +145,7 @@ impl MajorityVoteEngine {
 
         let proposal = self.proposals.get_mut(proposal_id).ok_or_else(|| {
             GovernanceError::ProposalNotFound {
-                id: hex_encode(proposal_id),
+                id: hex::encode(proposal_id),
             }
         })?;
 
@@ -208,7 +208,7 @@ impl MajorityVoteEngine {
     ) -> Result<(ProposalStatus, Vec<GovernanceEvent>), GovernanceError> {
         let proposal = self.proposals.get_mut(proposal_id).ok_or_else(|| {
             GovernanceError::ProposalNotFound {
-                id: hex_encode(proposal_id),
+                id: hex::encode(proposal_id),
             }
         })?;
 
@@ -332,7 +332,7 @@ impl GovernanceEngine for MajorityVoteEngine {
 
         // Reject duplicate proposals.
         if self.proposals.contains_key(&proposal_id) {
-            return Err(GovernanceError::DuplicateProposal(hex_encode(&proposal_id)));
+            return Err(GovernanceError::DuplicateProposal(hex::encode(proposal_id)));
         }
 
         let voting_deadline = context.now + self.voting_window_secs;
@@ -382,7 +382,7 @@ impl GovernanceEngine for MajorityVoteEngine {
         let past_deadline = {
             let proposal = self.proposals.get(proposal_id).ok_or_else(|| {
                 GovernanceError::ProposalNotFound {
-                    id: hex_encode(proposal_id),
+                    id: hex::encode(proposal_id),
                 }
             })?;
 
@@ -415,7 +415,7 @@ impl GovernanceEngine for MajorityVoteEngine {
 
         let proposal = self.proposals.get_mut(proposal_id).ok_or_else(|| {
             GovernanceError::ProposalNotFound {
-                id: hex_encode(proposal_id),
+                id: hex::encode(proposal_id),
             }
         })?;
 
@@ -462,7 +462,7 @@ impl GovernanceEngine for MajorityVoteEngine {
         let past_deadline = {
             let proposal = self.proposals.get(proposal_id).ok_or_else(|| {
                 GovernanceError::ProposalNotFound {
-                    id: hex_encode(proposal_id),
+                    id: hex::encode(proposal_id),
                 }
             })?;
 
@@ -495,7 +495,7 @@ impl GovernanceEngine for MajorityVoteEngine {
 
         let proposal = self.proposals.get_mut(proposal_id).ok_or_else(|| {
             GovernanceError::ProposalNotFound {
-                id: hex_encode(proposal_id),
+                id: hex::encode(proposal_id),
             }
         })?;
 

--- a/crates/scp-core/src/context/governance/mod.rs
+++ b/crates/scp-core/src/context/governance/mod.rs
@@ -762,7 +762,7 @@ impl GovernanceEngine for SingleAdminEngine {
 
         // Reject duplicate proposals before constructing events.
         if self.proposals.contains_key(&proposal_id) {
-            return Err(GovernanceError::DuplicateProposal(hex_encode(&proposal_id)));
+            return Err(GovernanceError::DuplicateProposal(hex::encode(proposal_id)));
         }
 
         // Sign the proposer's implicit approval vote.
@@ -822,7 +822,7 @@ impl GovernanceEngine for SingleAdminEngine {
             self.proposals
                 .get(proposal_id)
                 .ok_or_else(|| GovernanceError::ProposalNotFound {
-                    id: hex_encode(proposal_id),
+                    id: hex::encode(proposal_id),
                 })?;
 
         // In single-admin mode, only the admin can interact.
@@ -847,7 +847,7 @@ impl GovernanceEngine for SingleAdminEngine {
             self.proposals
                 .get(proposal_id)
                 .ok_or_else(|| GovernanceError::ProposalNotFound {
-                    id: hex_encode(proposal_id),
+                    id: hex::encode(proposal_id),
                 })?;
 
         // In single-admin mode, only the admin can interact.
@@ -874,21 +874,6 @@ impl GovernanceEngine for SingleAdminEngine {
     fn get_proposal(&self, proposal_id: &ProposalId) -> Option<&GovernanceProposal> {
         self.proposals.get(proposal_id)
     }
-}
-
-// ---------------------------------------------------------------------------
-// Hex encoding helper
-// ---------------------------------------------------------------------------
-
-/// Encode bytes as lowercase hex string for error messages.
-pub(crate) fn hex_encode(bytes: &[u8]) -> String {
-    use std::fmt::Write;
-    bytes
-        .iter()
-        .fold(String::with_capacity(bytes.len() * 2), |mut acc, b| {
-            let _ = write!(acc, "{b:02x}");
-            acc
-        })
 }
 
 // ---------------------------------------------------------------------------
@@ -1736,17 +1721,6 @@ mod tests {
         assert_eq!(deserialized.created_at, proposal.created_at);
         assert_eq!(deserialized.voting_deadline, proposal.voting_deadline);
         assert_eq!(deserialized.created_at_epoch, proposal.created_at_epoch);
-    }
-
-    // -----------------------------------------------------------------------
-    // hex encoding helper
-    // -----------------------------------------------------------------------
-
-    #[test]
-    fn hex_encode_produces_correct_output() {
-        assert_eq!(hex_encode(&[0x00, 0xff, 0x0a]), "00ff0a");
-        assert_eq!(hex_encode(&[]), "");
-        assert_eq!(hex_encode(&[0xde, 0xad, 0xbe, 0xef]), "deadbeef");
     }
 
     // -----------------------------------------------------------------------

--- a/crates/scp-core/src/context/governance/multisig.rs
+++ b/crates/scp-core/src/context/governance/multisig.rs
@@ -26,7 +26,7 @@ use std::collections::HashMap;
 use super::{
     GovernanceAction, GovernanceContext, GovernanceEngine, GovernanceError, GovernanceEvent,
     GovernanceModelConfig, GovernanceProposal, ProposalId, ProposalStatus, RejectionReason,
-    VoteType, compute_proposal_id, hex_encode, sign_vote,
+    VoteType, compute_proposal_id, sign_vote,
 };
 use crate::identity::DID;
 
@@ -172,7 +172,7 @@ impl ThresholdEngine {
             self.proposals
                 .get(proposal_id)
                 .ok_or_else(|| GovernanceError::ProposalNotFound {
-                    id: hex_encode(proposal_id),
+                    id: hex::encode(proposal_id),
                 })?;
 
         // Already terminal -- nothing to do.
@@ -228,7 +228,7 @@ impl GovernanceEngine for ThresholdEngine {
 
         // Reject duplicate proposals.
         if self.proposals.contains_key(&proposal_id) {
-            return Err(GovernanceError::DuplicateProposal(hex_encode(&proposal_id)));
+            return Err(GovernanceError::DuplicateProposal(hex::encode(proposal_id)));
         }
 
         let voting_deadline = context.now + self.voting_window_secs;
@@ -279,7 +279,7 @@ impl GovernanceEngine for ThresholdEngine {
         // present because we inserted it above and hold `&mut self`.
         let Some(proposal) = self.proposals.get(&proposal_id).cloned() else {
             return Err(GovernanceError::ProposalNotFound {
-                id: hex_encode(&proposal_id),
+                id: hex::encode(proposal_id),
             });
         };
 
@@ -310,7 +310,7 @@ impl GovernanceEngine for ThresholdEngine {
             self.proposals
                 .get(proposal_id)
                 .ok_or_else(|| GovernanceError::ProposalNotFound {
-                    id: hex_encode(proposal_id),
+                    id: hex::encode(proposal_id),
                 })?;
 
         // Must be pending.
@@ -323,7 +323,7 @@ impl GovernanceEngine for ThresholdEngine {
         // Bug 1 fix: deadline guard -- reject votes after the voting window.
         if context.now >= proposal.voting_deadline {
             return Err(GovernanceError::VotingWindowExpired {
-                id: hex_encode(proposal_id),
+                id: hex::encode(proposal_id),
             });
         }
 
@@ -377,7 +377,7 @@ impl GovernanceEngine for ThresholdEngine {
             self.proposals
                 .get(proposal_id)
                 .ok_or_else(|| GovernanceError::ProposalNotFound {
-                    id: hex_encode(proposal_id),
+                    id: hex::encode(proposal_id),
                 })?;
 
         // Must be pending.
@@ -390,7 +390,7 @@ impl GovernanceEngine for ThresholdEngine {
         // Bug 1 fix: deadline guard -- reject votes after the voting window.
         if context.now >= proposal.voting_deadline {
             return Err(GovernanceError::VotingWindowExpired {
-                id: hex_encode(proposal_id),
+                id: hex::encode(proposal_id),
             });
         }
 
@@ -443,7 +443,7 @@ impl GovernanceEngine for ThresholdEngine {
             self.proposals
                 .get(proposal_id)
                 .ok_or_else(|| GovernanceError::ProposalNotFound {
-                    id: hex_encode(proposal_id),
+                    id: hex::encode(proposal_id),
                 })?;
 
         // Must be pending.
@@ -456,7 +456,7 @@ impl GovernanceEngine for ThresholdEngine {
         // Deadline guard: cannot withdraw after voting window.
         if context.now >= proposal.voting_deadline {
             return Err(GovernanceError::VotingWindowExpired {
-                id: hex_encode(proposal_id),
+                id: hex::encode(proposal_id),
             });
         }
 

--- a/crates/scp-core/src/context/governance/unanimity.rs
+++ b/crates/scp-core/src/context/governance/unanimity.rs
@@ -30,7 +30,7 @@ use std::collections::HashMap;
 use super::{
     GovernanceAction, GovernanceContext, GovernanceEngine, GovernanceError, GovernanceEvent,
     GovernanceModelConfig, GovernanceProposal, ProposalId, ProposalStatus, RejectionReason,
-    VoteType, compute_proposal_id, hex_encode, sign_vote,
+    VoteType, compute_proposal_id, sign_vote,
 };
 use crate::identity::DID;
 
@@ -153,7 +153,7 @@ impl UnanimityEngine {
             self.proposals
                 .get(proposal_id)
                 .ok_or_else(|| GovernanceError::ProposalNotFound {
-                    id: hex_encode(proposal_id),
+                    id: hex::encode(proposal_id),
                 })?;
 
         // Already terminal -- nothing to do.
@@ -209,7 +209,7 @@ impl GovernanceEngine for UnanimityEngine {
 
         // Reject duplicate proposals.
         if self.proposals.contains_key(&proposal_id) {
-            return Err(GovernanceError::DuplicateProposal(hex_encode(&proposal_id)));
+            return Err(GovernanceError::DuplicateProposal(hex::encode(proposal_id)));
         }
 
         let voting_deadline = context.now + self.voting_window_secs;
@@ -260,7 +260,7 @@ impl GovernanceEngine for UnanimityEngine {
         // present because we inserted it above and hold `&mut self`.
         let Some(proposal) = self.proposals.get(&proposal_id).cloned() else {
             return Err(GovernanceError::ProposalNotFound {
-                id: hex_encode(&proposal_id),
+                id: hex::encode(proposal_id),
             });
         };
 
@@ -290,7 +290,7 @@ impl GovernanceEngine for UnanimityEngine {
             self.proposals
                 .get(proposal_id)
                 .ok_or_else(|| GovernanceError::ProposalNotFound {
-                    id: hex_encode(proposal_id),
+                    id: hex::encode(proposal_id),
                 })?;
 
         // Must be pending.
@@ -303,7 +303,7 @@ impl GovernanceEngine for UnanimityEngine {
         // Deadline guard -- reject votes after the voting window.
         if context.now >= proposal.voting_deadline {
             return Err(GovernanceError::VotingWindowExpired {
-                id: hex_encode(proposal_id),
+                id: hex::encode(proposal_id),
             });
         }
 
@@ -357,7 +357,7 @@ impl GovernanceEngine for UnanimityEngine {
             self.proposals
                 .get(proposal_id)
                 .ok_or_else(|| GovernanceError::ProposalNotFound {
-                    id: hex_encode(proposal_id),
+                    id: hex::encode(proposal_id),
                 })?;
 
         // Must be pending.
@@ -370,7 +370,7 @@ impl GovernanceEngine for UnanimityEngine {
         // Deadline guard -- reject votes after the voting window.
         if context.now >= proposal.voting_deadline {
             return Err(GovernanceError::VotingWindowExpired {
-                id: hex_encode(proposal_id),
+                id: hex::encode(proposal_id),
             });
         }
 
@@ -423,7 +423,7 @@ impl GovernanceEngine for UnanimityEngine {
             self.proposals
                 .get(proposal_id)
                 .ok_or_else(|| GovernanceError::ProposalNotFound {
-                    id: hex_encode(proposal_id),
+                    id: hex::encode(proposal_id),
                 })?;
 
         // Must be pending.
@@ -436,7 +436,7 @@ impl GovernanceEngine for UnanimityEngine {
         // Deadline guard: cannot withdraw after voting window.
         if context.now >= proposal.voting_deadline {
             return Err(GovernanceError::VotingWindowExpired {
-                id: hex_encode(proposal_id),
+                id: hex::encode(proposal_id),
             });
         }
 

--- a/crates/scp-core/src/context/standing.rs
+++ b/crates/scp-core/src/context/standing.rs
@@ -306,21 +306,6 @@ fn generate_standing_channel_id(local_did: &DID, peer_did: &DID) -> String {
     format!("standing-{}", hex::encode(&hash[..8]))
 }
 
-/// Minimal hex encoding for context ID generation.
-mod hex {
-    use std::fmt::Write;
-
-    /// Encodes bytes as a lowercase hex string.
-    pub fn encode(bytes: &[u8]) -> String {
-        bytes
-            .iter()
-            .fold(String::with_capacity(bytes.len() * 2), |mut s, b| {
-                let _ = write!(s, "{b:02x}");
-                s
-            })
-    }
-}
-
 // Compile-time assertion that `StandingChannelManager` is `Send + Sync`.
 const fn _assert_send_sync() {
     const fn assert_send_sync<T: Send + Sync>() {}

--- a/crates/scp-core/src/context/tools/lifecycle.rs
+++ b/crates/scp-core/src/context/tools/lifecycle.rs
@@ -302,17 +302,7 @@ pub fn sha256_json(value: &serde_json::Value) -> String {
     // empty string.
     let bytes = serde_json::to_string(value).unwrap_or_default();
     let hash = Sha256::digest(bytes.as_bytes());
-    hex_encode(&hash)
-}
-
-/// Encodes a byte slice as a lowercase hex string.
-fn hex_encode(bytes: &[u8]) -> String {
-    let mut s = String::with_capacity(bytes.len() * 2);
-    for byte in bytes {
-        use std::fmt::Write;
-        let _ = write!(s, "{byte:02x}");
-    }
-    s
+    hex::encode(hash)
 }
 
 // ---------------------------------------------------------------------------

--- a/crates/scp-core/src/event_log/tree.rs
+++ b/crates/scp-core/src/event_log/tree.rs
@@ -281,7 +281,7 @@ fn extract_public_key_from_did(did: &str) -> Result<[u8; 32], String> {
 
     // Support did:key:<hex> format for testing.
     if let Some(hex_str) = did.strip_prefix("did:key:") {
-        let decoded = hex_decode(hex_str)?;
+        let decoded = hex::decode(hex_str).map_err(|e| format!("hex decode error: {e}"))?;
         let bytes: [u8; 32] = decoded
             .try_into()
             .map_err(|v: Vec<u8>| format!("DID public key must be 32 bytes, got {}", v.len()))?;
@@ -289,22 +289,6 @@ fn extract_public_key_from_did(did: &str) -> Result<[u8; 32], String> {
     }
 
     Err(format!("unsupported DID format: {did}"))
-}
-
-/// Decodes a hexadecimal string to bytes.
-fn hex_decode(hex: &str) -> Result<Vec<u8>, String> {
-    if !hex.len().is_multiple_of(2) {
-        return Err(format!("hex string has odd length: {}", hex.len()));
-    }
-
-    let mut bytes = Vec::with_capacity(hex.len() / 2);
-    for i in (0..hex.len()).step_by(2) {
-        let byte_str = &hex[i..i + 2];
-        let byte =
-            u8::from_str_radix(byte_str, 16).map_err(|e| format!("hex decode error: {e}"))?;
-        bytes.push(byte);
-    }
-    Ok(bytes)
 }
 
 /// Recomputes the entire interior tree from the leaf layer.

--- a/crates/scp-core/src/identity/dht.rs
+++ b/crates/scp-core/src/identity/dht.rs
@@ -698,9 +698,15 @@ impl<D: DhtClient, C: Clock> DidDht<D, C> {
             return Ok(None);
         };
 
-        let commitment = hex_decode(hex_str).map_err(|e| {
+        let commitment_vec = hex::decode(hex_str).map_err(|e| {
             IdentityError::KeyRotationFailed(format!(
                 "failed to decode pre-rotation commitment: {e}"
+            ))
+        })?;
+        let commitment: [u8; 32] = commitment_vec.try_into().map_err(|v: Vec<u8>| {
+            IdentityError::KeyRotationFailed(format!(
+                "pre-rotation commitment must be 32 bytes, got {}",
+                v.len()
             ))
         })?;
         let new_identity_bytes: [u8; 32] =
@@ -1012,37 +1018,6 @@ pub fn verify_migration(
     }
 
     Ok(true)
-}
-
-/// Decodes a lowercase hexadecimal string to bytes.
-///
-/// # Errors
-///
-/// Returns an error if the string length is odd or contains non-hex characters.
-fn hex_decode(hex: &str) -> Result<[u8; 32], String> {
-    if hex.len() != 64 {
-        return Err(format!("expected 64 hex chars, got {}", hex.len()));
-    }
-
-    let mut result = [0u8; 32];
-    for (i, chunk) in hex.as_bytes().chunks(2).enumerate() {
-        let hi = hex_nibble(chunk[0])
-            .ok_or_else(|| format!("invalid hex character: {}", chunk[0] as char))?;
-        let lo = hex_nibble(chunk[1])
-            .ok_or_else(|| format!("invalid hex character: {}", chunk[1] as char))?;
-        result[i] = (hi << 4) | lo;
-    }
-    Ok(result)
-}
-
-/// Converts a single hex ASCII byte to its numeric value (0-15).
-const fn hex_nibble(b: u8) -> Option<u8> {
-    match b {
-        b'0'..=b'9' => Some(b - b'0'),
-        b'a'..=b'f' => Some(b - b'a' + 10),
-        b'A'..=b'F' => Some(b - b'A' + 10),
-        _ => None,
-    }
 }
 
 #[cfg(test)]
@@ -2156,31 +2131,6 @@ mod tests {
         let json = serde_json::to_string(&event).unwrap();
         let parsed: DidRotationEvent = serde_json::from_str(&json).unwrap();
         assert_eq!(event, parsed);
-    }
-
-    // -----------------------------------------------------------------------
-    // SCP-008 tests — hex_decode helper
-    // -----------------------------------------------------------------------
-
-    #[test]
-    fn hex_decode_valid() {
-        let hex_str = "deadbeef00112233445566778899aabbccddeeff00112233445566778899aabb";
-        let decoded = hex_decode(hex_str).unwrap();
-        assert_eq!(decoded[0], 0xDE);
-        assert_eq!(decoded[1], 0xAD);
-    }
-
-    #[test]
-    fn hex_decode_rejects_wrong_length() {
-        let result = hex_decode("abcdef");
-        assert!(result.is_err());
-    }
-
-    #[test]
-    fn hex_decode_rejects_invalid_characters() {
-        let hex_str = "zzzzzzzz00112233445566778899aabbccddeeff00112233445566778899aabb";
-        let result = hex_decode(hex_str);
-        assert!(result.is_err());
     }
 
     // -----------------------------------------------------------------------

--- a/crates/scp-core/src/identity/document.rs
+++ b/crates/scp-core/src/identity/document.rs
@@ -188,7 +188,7 @@ impl DidDocument {
         let pre_rotation_service = Service {
             id: format!("{did}#pre-rotation"),
             service_type: "PreRotationCommitment".to_owned(),
-            service_endpoint: format!("sha256:{}", hex_encode(pre_rotation_commitment)),
+            service_endpoint: format!("sha256:{}", hex::encode(pre_rotation_commitment)),
         };
 
         Self {
@@ -451,17 +451,6 @@ fn multibase_encode(bytes: &[u8]) -> String {
     format!("z{}", base58btc_encode(bytes))
 }
 
-/// Encodes bytes as lowercase hexadecimal.
-fn hex_encode(bytes: &[u8]) -> String {
-    bytes.iter().fold(String::new(), |mut acc, b| {
-        use std::fmt::Write;
-        // write! to a String is infallible, but we must handle the Result
-        // to satisfy clippy. The error case is unreachable for String.
-        let _ = write!(acc, "{b:02x}");
-        acc
-    })
-}
-
 /// Base58btc encoding (Bitcoin alphabet) via the `bs58` crate.
 fn base58btc_encode(input: &[u8]) -> String {
     bs58::encode(input).into_string()
@@ -523,12 +512,6 @@ mod tests {
         let parsed = DidDocument::from_json(&json).unwrap();
 
         assert_eq!(doc, parsed);
-    }
-
-    #[test]
-    fn hex_encode_produces_lowercase_hex() {
-        let bytes = [0xDE, 0xAD, 0xBE, 0xEF];
-        assert_eq!(hex_encode(&bytes), "deadbeef");
     }
 
     #[test]

--- a/crates/scp-core/src/store/ucan.rs
+++ b/crates/scp-core/src/store/ucan.rs
@@ -75,8 +75,8 @@ fn revocation_key(context_id: &str, token_id: &str) -> Result<String, super::Sto
 /// Format: `context/{context_id}/nonce/{nonce_hash_hex}`
 /// The nonce hash is encoded as lowercase hex. See spec section 17.3.
 fn nonce_key(context_id: &str, nonce_hash: &[u8; 32]) -> String {
-    let hex = hex_encode(nonce_hash);
-    format!("context/{context_id}/nonce/{hex}")
+    let hex_str = hex::encode(nonce_hash);
+    format!("context/{context_id}/nonce/{hex_str}")
 }
 
 /// Builds the prefix for listing all nonces in a context.
@@ -84,17 +84,6 @@ fn nonce_key(context_id: &str, nonce_hash: &[u8; 32]) -> String {
 /// Format: `context/{context_id}/nonce/`
 fn nonce_prefix(context_id: &str) -> String {
     format!("context/{context_id}/nonce/")
-}
-
-/// Encodes a byte slice as lowercase hexadecimal.
-fn hex_encode(bytes: &[u8]) -> String {
-    bytes
-        .iter()
-        .fold(String::with_capacity(bytes.len() * 2), |mut s, b| {
-            use std::fmt::Write;
-            let _ = write!(s, "{b:02x}");
-            s
-        })
 }
 
 // ---------------------------------------------------------------------------

--- a/crates/scp-testing/Cargo.toml
+++ b/crates/scp-testing/Cargo.toml
@@ -20,6 +20,7 @@ scp-transport = { path = "../scp-transport" }
 scp-platform = { path = "../scp-platform", features = ["software_platform"] }
 tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }
 futures = "0.3"
+hex = { workspace = true }
 openmls = { workspace = true }
 serde_json = { workspace = true }
 rmp-serde = { workspace = true }

--- a/crates/scp-testing/tests/integration/phase1.rs
+++ b/crates/scp-testing/tests/integration/phase1.rs
@@ -29,7 +29,6 @@
 #![allow(clippy::unwrap_used, clippy::expect_used, clippy::panic)]
 
 use std::collections::HashSet;
-use std::fmt::Write;
 use std::net::SocketAddr;
 
 use futures::StreamExt;
@@ -414,7 +413,7 @@ async fn phase1_alice_bob_encrypted_message_via_relay() {
     // context ID — unlinkable to Alice's DID without the identity key material.
 
     // Verify the routing_id is NOT Alice's DID or any recognizable identifier.
-    let routing_hex = hex_encode(&received_outer.routing_id);
+    let routing_hex = hex::encode(&received_outer.routing_id);
     assert!(
         !routing_hex.contains(&alice_id.did),
         "routing_id must not contain Alice's DID"
@@ -481,16 +480,6 @@ async fn native_relay_adapter_send_receive_roundtrip() {
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
-
-/// Hex-encodes bytes for assertion messages.
-fn hex_encode(bytes: &[u8]) -> String {
-    bytes
-        .iter()
-        .fold(String::with_capacity(bytes.len() * 2), |mut acc, b| {
-            let _ = write!(acc, "{b:02x}");
-            acc
-        })
-}
 
 /// Checks if `haystack` contains `needle` as a contiguous subsequence.
 fn contains_subsequence(haystack: &[u8], needle: &[u8]) -> bool {

--- a/crates/scp-transport/Cargo.toml
+++ b/crates/scp-transport/Cargo.toml
@@ -13,6 +13,7 @@ tokio = { workspace = true }
 tokio-tungstenite = { version = "0.24", features = ["connect"] }
 futures = "0.3"
 sha2 = { workspace = true }
+hex = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 serde_bytes = { workspace = true }

--- a/crates/scp-transport/src/native/client.rs
+++ b/crates/scp-transport/src/native/client.rs
@@ -313,8 +313,8 @@ impl NativeRelayClient {
                 // Verify blob integrity: SHA-256(blob) must match relay-provided blob_id.
                 let computed_hash: [u8; 32] = Sha256::digest(blob).into();
                 if computed_hash != *blob_id {
-                    let expected = hex_encode(blob_id);
-                    let actual = hex_encode(&computed_hash);
+                    let expected = hex::encode(blob_id);
+                    let actual = hex::encode(computed_hash);
                     tracing::warn!(
                         expected = %expected,
                         actual = %actual,
@@ -830,17 +830,6 @@ impl NativeRelayClient {
     }
 }
 
-/// Hex-encodes a byte slice into a lowercase hex string.
-fn hex_encode(bytes: &[u8]) -> String {
-    use std::fmt::Write;
-    bytes
-        .iter()
-        .fold(String::with_capacity(bytes.len() * 2), |mut s, b| {
-            let _ = write!(s, "{b:02x}");
-            s
-        })
-}
-
 /// Assigns a `ref_id` to a [`ClientMessage`] for request-response correlation.
 fn assign_ref_id(msg: &mut ClientMessage, ref_id: &str) {
     match msg {
@@ -1062,17 +1051,6 @@ mod tests {
         );
 
         assert!(inner.read().await.seen_blob_ids.contains(&correct_blob_id));
-    }
-
-    #[test]
-    fn hex_encode_produces_lowercase_hex() {
-        let bytes = [0xAB, 0xCD, 0xEF, 0x01];
-        assert_eq!(hex_encode(&bytes), "abcdef01");
-    }
-
-    #[test]
-    fn hex_encode_empty_is_empty() {
-        assert_eq!(hex_encode(&[]), "");
     }
 
     // -----------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Replaces 9+ hand-rolled hex encode/decode implementations across 3 crates with the `hex` crate (already a workspace dependency)
- Removes the `mod hex` shadow module in `standing.rs` that blocked future `hex` crate imports
- Removes `hex_nibble` helper in `dht.rs` and all duplicate unit tests
- Adds `hex` dependency to `scp-transport` and `scp-testing` (dev) Cargo.toml files
- Net: **-190 lines** across 16 files

## Acceptance criteria (from #83)
- [x] `rg "fn hex_decode" crates/` — zero hand-rolled implementations
- [x] `rg "fn hex_encode" crates/` — zero hand-rolled implementations
- [x] `rg "fn hex_nibble" crates/` — zero matches
- [x] `rg "mod hex" crates/` — zero shadow modules
- [x] `cargo build --all-targets` passes
- [x] `cargo test --workspace` passes (3100+ tests, 0 failures)
- [x] `cargo clippy --workspace --all-targets` clean

## Test plan
- [x] All existing tests pass without modification (removed tests were duplicates of hex crate behavior)
- [x] Clippy clean after auto-fix of needless borrows (`hex::encode` takes `AsRef<[u8]>`)

closes #83

🤖 Generated with [Claude Code](https://claude.com/claude-code)