### PR TITLE
feat(ffi): clock drift tolerance for UCAN validation

### DIFF
--- a/crates/scp-core/src/context/broadcast.rs
+++ b/crates/scp-core/src/context/broadcast.rs
@@ -464,7 +464,8 @@ mod tests {
     use super::*;
     use crate::crypto::sender_keys::{decrypt_sender_layer, encrypt_sender_layer};
     use crate::crypto::ucan::validate::{
-        InMemoryDidResolver, InMemoryNonceTracker, InMemoryProofResolver, InMemoryRevocationChecker,
+        DEFAULT_CLOCK_SKEW_TOLERANCE_SECS, InMemoryDidResolver, InMemoryNonceTracker,
+        InMemoryProofResolver, InMemoryRevocationChecker,
     };
     use crate::crypto::ucan::{Attenuation, UcanHeader, UcanPayload};
     use std::collections::HashMap as StdHashMap;
@@ -739,6 +740,7 @@ mod tests {
             ceiling: &setup.ceiling,
             context_creator_did: &setup.issuer_did,
             presenting_agent_did: "did:example:bob",
+            clock_skew_tolerance_secs: DEFAULT_CLOCK_SKEW_TOLERANCE_SECS,
         };
 
         let result = ctx
@@ -765,6 +767,7 @@ mod tests {
             ceiling: &setup.ceiling,
             context_creator_did: &setup.issuer_did,
             presenting_agent_did: "did:example:bob",
+            clock_skew_tolerance_secs: DEFAULT_CLOCK_SKEW_TOLERANCE_SECS,
         };
 
         let result = ctx.subscribe("did:example:bob", Some(&ucan), 1000, Some(&mut val_ctx));
@@ -834,6 +837,7 @@ mod tests {
             ceiling: &setup.ceiling,
             context_creator_did: &setup.issuer_did,
             presenting_agent_did: "did:example:bob",
+            clock_skew_tolerance_secs: DEFAULT_CLOCK_SKEW_TOLERANCE_SECS,
         };
 
         let result = ctx.subscribe("did:example:bob", Some(&ucan), 1000, Some(&mut val_ctx));
@@ -856,6 +860,7 @@ mod tests {
             ceiling: &setup.ceiling,
             context_creator_did: &setup.issuer_did,
             presenting_agent_did: "did:example:bob",
+            clock_skew_tolerance_secs: DEFAULT_CLOCK_SKEW_TOLERANCE_SECS,
         };
 
         let result = ctx.subscribe("did:example:bob", Some(&ucan), 1000, Some(&mut val_ctx));
@@ -1049,6 +1054,7 @@ mod tests {
             ceiling: &setup.ceiling,
             context_creator_did: &setup.issuer_did,
             presenting_agent_did: "did:example:sub1",
+            clock_skew_tolerance_secs: DEFAULT_CLOCK_SKEW_TOLERANCE_SECS,
         };
         ctx.subscribe("did:example:sub1", Some(&ucan), 1000, Some(&mut val_ctx))
             .unwrap();
@@ -1149,6 +1155,7 @@ mod tests {
             ceiling: &setup.ceiling,
             context_creator_did: &setup.issuer_did,
             presenting_agent_did: "did:example:bob",
+            clock_skew_tolerance_secs: DEFAULT_CLOCK_SKEW_TOLERANCE_SECS,
         };
 
         // With full validation, a properly signed wildcard UCAN from the
@@ -1224,6 +1231,7 @@ mod tests {
             ceiling: &setup.ceiling,
             context_creator_did: &setup.issuer_did,
             presenting_agent_did: "did:example:bob",
+            clock_skew_tolerance_secs: DEFAULT_CLOCK_SKEW_TOLERANCE_SECS,
         };
 
         let result = ctx.subscribe("did:example:bob", Some(&ucan), 1000, Some(&mut val_ctx));

--- a/crates/scp-core/src/crypto/ucan/validate.rs
+++ b/crates/scp-core/src/crypto/ucan/validate.rs
@@ -33,6 +33,13 @@ use super::{UcanError, UcanHeader, UcanPayload, UcanToken};
 /// Maximum token lifetime: 24 hours in seconds (spec section 9.5).
 const MAX_EXPIRY_SECS: u64 = 24 * 60 * 60;
 
+/// Default clock skew tolerance: 5 minutes in seconds (spec section 9.14).
+///
+/// Applied to `exp` and `nbf` checks in [`verify_expiry`] to accommodate
+/// NTP desynchronization between issuer and validator in distributed
+/// deployments.
+pub const DEFAULT_CLOCK_SKEW_TOLERANCE_SECS: u64 = 5 * 60;
+
 /// Nonce freshness tolerance: 5 minutes in milliseconds (spec section 9.14).
 #[cfg(test)]
 const NONCE_FRESHNESS_TOLERANCE_MS: u128 = 5 * 60 * 1000;
@@ -340,6 +347,16 @@ pub struct ValidationContext<'a, D, N, R, P, S: BuildHasher> {
     pub context_creator_did: &'a str,
     /// Presenting agent's DID (step 5 — audience verification).
     pub presenting_agent_did: &'a str,
+    /// Clock skew tolerance in seconds for `exp`/`nbf` checks (step 11).
+    ///
+    /// Accommodates NTP desynchronization between issuer and validator in
+    /// distributed deployments. Defaults to
+    /// [`DEFAULT_CLOCK_SKEW_TOLERANCE_SECS`] (5 minutes, per spec section
+    /// 9.14).
+    ///
+    /// - `exp` check: token accepted if `exp + tolerance >= now`
+    /// - `nbf` check: token accepted if `nbf - tolerance <= now`
+    pub clock_skew_tolerance_secs: u64,
 }
 
 // ---------------------------------------------------------------------------
@@ -407,6 +424,7 @@ where
         ctx.did_resolver,
         ctx.proof_resolver,
         ctx.revocation_checker,
+        ctx.clock_skew_tolerance_secs,
     )?;
 
     // Step 4: Root issuer — verify root token's iss is context creator.
@@ -463,8 +481,9 @@ where
         return Err(UcanError::TokenRevoked(revocation_cid));
     }
 
-    // Step 11: Expiry — verify exp > now and nbf <= now.
-    verify_expiry(token)?;
+    // Step 11: Expiry — verify exp > now and nbf <= now (with clock skew
+    // tolerance).
+    verify_expiry(token, ctx.clock_skew_tolerance_secs)?;
 
     Ok(())
 }
@@ -536,8 +555,8 @@ where
     // Step 8: Ceiling.
     verify_ceiling_compliance(std::slice::from_ref(required_capability), ceiling)?;
 
-    // Step 11: Expiry.
-    verify_expiry(token)?;
+    // Step 11: Expiry (with default clock skew tolerance).
+    verify_expiry(token, DEFAULT_CLOCK_SKEW_TOLERANCE_SECS)?;
 
     Ok(())
 }
@@ -604,6 +623,7 @@ fn verify_delegation_chain(
     did_resolver: &impl DidResolver,
     proof_resolver: &impl ProofResolver,
     revocation_checker: &impl RevocationChecker,
+    clock_skew_tolerance_secs: u64,
 ) -> Result<String, UcanError> {
     if token.payload.prf.is_empty() {
         return Ok(token.payload.iss.clone());
@@ -618,6 +638,7 @@ fn verify_delegation_chain(
         revocation_checker,
         0,
         &mut seen_issuers,
+        clock_skew_tolerance_secs,
     )
 }
 
@@ -640,6 +661,7 @@ fn verify_chain_recursive(
     revocation_checker: &impl RevocationChecker,
     depth: usize,
     seen_issuers: &mut HashSet<String>,
+    clock_skew_tolerance_secs: u64,
 ) -> Result<String, UcanError> {
     if depth > MAX_CHAIN_DEPTH {
         return Err(UcanError::DelegationChainBroken(
@@ -679,7 +701,7 @@ fn verify_chain_recursive(
         verify_signature(&parent, did_resolver)?;
 
         // Verify parent token has not expired (spec 7.2).
-        verify_expiry(&parent)?;
+        verify_expiry(&parent, clock_skew_tolerance_secs)?;
 
         // Verify parent token has not been revoked (spec 7.2).
         let parent_revocation_cid = compute_revocation_cid(&parent.payload);
@@ -695,6 +717,7 @@ fn verify_chain_recursive(
             revocation_checker,
             depth + 1,
             seen_issuers,
+            clock_skew_tolerance_secs,
         )?;
 
         // All proof chains must converge to the same root issuer.
@@ -764,23 +787,32 @@ fn verify_attenuation(
     Ok(())
 }
 
-/// Step 11: Verify token expiry.
+/// Step 11: Verify token expiry with clock skew tolerance.
 ///
 /// Checks that:
 /// - `nbf < exp` (if present, the time range is valid)
-/// - `exp > now` (not expired)
-/// - `exp <= now + 24h` (not too far in the future)
-/// - `nbf <= now` (if present, the token is already valid)
+/// - `exp + tolerance > now` (not expired, accounting for clock drift)
+/// - `exp <= now + 24h` (not too far in the future -- tolerance not applied)
+/// - `nbf - tolerance <= now` (if present, the token is already valid,
+///   accounting for clock drift)
+///
+/// The `clock_skew_tolerance_secs` parameter accommodates NTP
+/// desynchronization between issuer and validator in distributed deployments
+/// (spec section 9.14). A tolerance of 0 disables clock drift handling.
+///
+/// Note: The `ExpiryTooFar` check does NOT include tolerance. Tolerance is
+/// only applied to the leniency direction (accepting slightly expired or
+/// slightly future tokens), not to extending the maximum allowed lifetime.
 ///
 /// # Errors
 ///
 /// Returns [`UcanError::InvalidTimeRange`] if `nbf >= exp`.
-/// Returns [`UcanError::TokenExpired`] if the token has expired.
+/// Returns [`UcanError::TokenExpired`] if the token has expired beyond tolerance.
 /// Returns [`UcanError::ExpiryTooFar`] if `exp` exceeds now + 24 hours.
-/// Returns [`UcanError::TokenNotYetValid`] if `nbf > now`.
-fn verify_expiry(token: &UcanToken) -> Result<(), UcanError> {
+/// Returns [`UcanError::TokenNotYetValid`] if `nbf > now + tolerance`.
+fn verify_expiry(token: &UcanToken, clock_skew_tolerance_secs: u64) -> Result<(), UcanError> {
     // Check nbf < exp first — a token with nbf >= exp is inherently invalid
-    // regardless of the current time.
+    // regardless of the current time or tolerance.
     if let Some(nbf) = token.payload.nbf
         && nbf >= token.payload.exp
     {
@@ -792,16 +824,24 @@ fn verify_expiry(token: &UcanToken) -> Result<(), UcanError> {
 
     let now = now_secs()?;
 
-    if token.payload.exp <= now {
+    // exp check with tolerance: allow tokens that expired within the
+    // tolerance window. `exp + tolerance > now` is equivalent to
+    // `exp > now - tolerance` but avoids underflow when now < tolerance.
+    if token.payload.exp + clock_skew_tolerance_secs <= now {
         return Err(UcanError::TokenExpired);
     }
 
+    // ExpiryTooFar check — no tolerance applied. This bounds the maximum
+    // token lifetime; clock drift doesn't justify longer-lived tokens.
     if token.payload.exp > now + MAX_EXPIRY_SECS {
         return Err(UcanError::ExpiryTooFar(token.payload.exp));
     }
 
+    // nbf check with tolerance: allow tokens whose not-before is slightly
+    // in the future (within tolerance). Uses saturating subtraction to avoid
+    // underflow when nbf < tolerance.
     if let Some(nbf) = token.payload.nbf
-        && nbf > now
+        && nbf.saturating_sub(clock_skew_tolerance_secs) > now
     {
         return Err(UcanError::TokenNotYetValid);
     }
@@ -862,6 +902,7 @@ mod tests {
             ceiling,
             context_creator_did,
             presenting_agent_did,
+            clock_skew_tolerance_secs: DEFAULT_CLOCK_SKEW_TOLERANCE_SECS,
         }
     }
 
@@ -1872,6 +1913,8 @@ mod tests {
             &issuer_did,
             "did:dht:z6MkMember",
         );
+        // Use zero tolerance so the 2-second expiry is detected.
+        ctx.clock_skew_tolerance_secs = 0;
 
         let result = validate_ucan(&token, &required_cap, &mut ctx);
         assert!(
@@ -1899,7 +1942,7 @@ mod tests {
             encoded: String::new(),
         };
 
-        let result = verify_expiry(&token);
+        let result = verify_expiry(&token, 0);
         assert!(
             matches!(result, Err(UcanError::ExpiryTooFar(_))),
             "exp beyond 24h must be rejected: {result:?}"
@@ -1924,7 +1967,7 @@ mod tests {
             encoded: String::new(),
         };
 
-        let result = verify_expiry(&token);
+        let result = verify_expiry(&token, 0);
         assert!(matches!(result, Err(UcanError::TokenExpired)));
     }
 
@@ -1947,7 +1990,7 @@ mod tests {
             encoded: String::new(),
         };
 
-        let result = verify_expiry(&token);
+        let result = verify_expiry(&token, 0);
         assert!(matches!(result, Err(UcanError::TokenNotYetValid)));
     }
 
@@ -1970,7 +2013,7 @@ mod tests {
             encoded: String::new(),
         };
 
-        assert!(verify_expiry(&token).is_ok());
+        assert!(verify_expiry(&token, 0).is_ok());
     }
 
     #[test]
@@ -1992,7 +2035,7 @@ mod tests {
             encoded: String::new(),
         };
 
-        let result = verify_expiry(&token);
+        let result = verify_expiry(&token, 0);
         assert!(
             matches!(result, Err(UcanError::InvalidTimeRange { nbf, exp }) if nbf == now + 7200 && exp == now + 3600),
             "nbf > exp must return InvalidTimeRange: {result:?}"
@@ -2019,7 +2062,7 @@ mod tests {
             encoded: String::new(),
         };
 
-        let result = verify_expiry(&token);
+        let result = verify_expiry(&token, 0);
         assert!(
             matches!(result, Err(UcanError::InvalidTimeRange { .. })),
             "nbf == exp must return InvalidTimeRange: {result:?}"
@@ -2046,7 +2089,7 @@ mod tests {
         };
 
         assert!(
-            verify_expiry(&token).is_ok(),
+            verify_expiry(&token, 0).is_ok(),
             "nbf < exp must pass time range validation"
         );
     }
@@ -2383,7 +2426,7 @@ mod tests {
             encoded: String::new(),
         };
 
-        let result = verify_expiry(&token);
+        let result = verify_expiry(&token, 0);
         // nbf == exp triggers InvalidTimeRange before TokenExpired.
         assert!(
             matches!(result, Err(UcanError::InvalidTimeRange { nbf: 0, exp: 0 })),
@@ -2414,7 +2457,7 @@ mod tests {
             encoded: String::new(),
         };
 
-        let result = verify_expiry(&token);
+        let result = verify_expiry(&token, 0);
         assert!(
             matches!(result, Err(UcanError::TokenExpired)),
             "near-epoch token (exp=1) must be rejected: {result:?}"
@@ -2539,6 +2582,7 @@ mod tests {
             &resolver,
             &proof_resolver,
             &revocation_checker,
+            DEFAULT_CLOCK_SKEW_TOLERANCE_SECS,
         );
         assert!(
             matches!(result, Err(UcanError::CircularDelegation(_))),
@@ -2610,6 +2654,7 @@ mod tests {
             &resolver,
             &proof_resolver,
             &revocation_checker,
+            DEFAULT_CLOCK_SKEW_TOLERANCE_SECS,
         );
         assert!(result.is_ok(), "linear chain A->B->C must pass: {result:?}");
         assert_eq!(result.unwrap(), did_a);
@@ -2671,6 +2716,7 @@ mod tests {
             &resolver,
             &proof_resolver,
             &revocation_checker,
+            DEFAULT_CLOCK_SKEW_TOLERANCE_SECS,
         );
         assert!(
             matches!(result, Err(UcanError::CircularDelegation(_))),
@@ -2711,6 +2757,7 @@ mod tests {
             &revocation_checker,
             MAX_CHAIN_DEPTH + 1,
             &mut seen,
+            DEFAULT_CLOCK_SKEW_TOLERANCE_SECS,
         );
 
         assert!(
@@ -2729,5 +2776,240 @@ mod tests {
             err.to_string(),
             "circular delegation detected: issuer 'did:dht:z6MkA' appears multiple times"
         );
+    }
+
+    // -----------------------------------------------------------------------
+    // Clock drift tolerance tests (issue #107)
+    // -----------------------------------------------------------------------
+
+    /// A token that expired 30 seconds ago should be accepted with the default
+    /// 5-minute tolerance (300 seconds).
+    #[test]
+    fn verify_expiry_tolerates_recently_expired_token() {
+        let now = now_secs().unwrap();
+        let token = UcanToken {
+            header: UcanHeader::new(),
+            payload: UcanPayload {
+                iss: "did:dht:z6MkCreator".into(),
+                aud: "did:dht:z6MkMember".into(),
+                exp: now - 30, // Expired 30 seconds ago.
+                nbf: None,
+                nnc: "1234567890000-aabbccdd11223344aabbccdd11223344".to_owned(),
+                att: vec![],
+                prf: vec![],
+                fct: None,
+            },
+            signature: vec![0u8; 64],
+            encoded: String::new(),
+        };
+
+        // With 300s tolerance: exp (now - 30) + 300 = now + 270 > now. Accepted.
+        assert!(
+            verify_expiry(&token, DEFAULT_CLOCK_SKEW_TOLERANCE_SECS).is_ok(),
+            "token expired 30s ago must be accepted with 5-min tolerance"
+        );
+
+        // With 0 tolerance: exp (now - 30) + 0 <= now. Rejected.
+        assert!(
+            matches!(verify_expiry(&token, 0), Err(UcanError::TokenExpired)),
+            "token expired 30s ago must be rejected with 0 tolerance"
+        );
+    }
+
+    /// A token that expired 6 minutes ago should be rejected even with the
+    /// default 5-minute tolerance.
+    #[test]
+    fn verify_expiry_rejects_token_expired_beyond_tolerance() {
+        let now = now_secs().unwrap();
+        let token = UcanToken {
+            header: UcanHeader::new(),
+            payload: UcanPayload {
+                iss: "did:dht:z6MkCreator".into(),
+                aud: "did:dht:z6MkMember".into(),
+                exp: now - 360, // Expired 6 minutes ago.
+                nbf: None,
+                nnc: "1234567890000-aabbccdd11223344aabbccdd11223344".to_owned(),
+                att: vec![],
+                prf: vec![],
+                fct: None,
+            },
+            signature: vec![0u8; 64],
+            encoded: String::new(),
+        };
+
+        // exp (now - 360) + 300 = now - 60 <= now. Rejected.
+        assert!(
+            matches!(
+                verify_expiry(&token, DEFAULT_CLOCK_SKEW_TOLERANCE_SECS),
+                Err(UcanError::TokenExpired)
+            ),
+            "token expired 6 min ago must be rejected even with 5-min tolerance"
+        );
+    }
+
+    /// A token with nbf 30 seconds in the future should be accepted with the
+    /// default 5-minute tolerance.
+    #[test]
+    fn verify_expiry_tolerates_slightly_future_nbf() {
+        let now = now_secs().unwrap();
+        let token = UcanToken {
+            header: UcanHeader::new(),
+            payload: UcanPayload {
+                iss: "did:dht:z6MkCreator".into(),
+                aud: "did:dht:z6MkMember".into(),
+                exp: now + 3600,
+                nbf: Some(now + 30), // nbf 30 seconds from now.
+                nnc: "1234567890000-aabbccdd11223344aabbccdd11223344".to_owned(),
+                att: vec![],
+                prf: vec![],
+                fct: None,
+            },
+            signature: vec![0u8; 64],
+            encoded: String::new(),
+        };
+
+        // With 300s tolerance: nbf (now + 30) - 300 = now - 270 <= now. Accepted.
+        assert!(
+            verify_expiry(&token, DEFAULT_CLOCK_SKEW_TOLERANCE_SECS).is_ok(),
+            "nbf 30s in the future must be accepted with 5-min tolerance"
+        );
+
+        // With 0 tolerance: nbf (now + 30) - 0 = now + 30 > now. Rejected.
+        assert!(
+            matches!(verify_expiry(&token, 0), Err(UcanError::TokenNotYetValid)),
+            "nbf 30s in the future must be rejected with 0 tolerance"
+        );
+    }
+
+    /// A token with nbf 6 minutes in the future should be rejected even with
+    /// the default 5-minute tolerance.
+    #[test]
+    fn verify_expiry_rejects_nbf_beyond_tolerance() {
+        let now = now_secs().unwrap();
+        let token = UcanToken {
+            header: UcanHeader::new(),
+            payload: UcanPayload {
+                iss: "did:dht:z6MkCreator".into(),
+                aud: "did:dht:z6MkMember".into(),
+                exp: now + 7200,
+                nbf: Some(now + 360), // nbf 6 minutes from now.
+                nnc: "1234567890000-aabbccdd11223344aabbccdd11223344".to_owned(),
+                att: vec![],
+                prf: vec![],
+                fct: None,
+            },
+            signature: vec![0u8; 64],
+            encoded: String::new(),
+        };
+
+        // nbf (now + 360) - 300 = now + 60 > now. Rejected.
+        assert!(
+            matches!(
+                verify_expiry(&token, DEFAULT_CLOCK_SKEW_TOLERANCE_SECS),
+                Err(UcanError::TokenNotYetValid)
+            ),
+            "nbf 6 min in the future must be rejected even with 5-min tolerance"
+        );
+    }
+
+    /// The expiry-too-far check must NOT include tolerance. A token with exp
+    /// exactly at the 24h limit is valid; tolerance doesn't extend this bound.
+    #[test]
+    fn verify_expiry_too_far_ignores_tolerance() {
+        let now = now_secs().unwrap();
+        let token = UcanToken {
+            header: UcanHeader::new(),
+            payload: UcanPayload {
+                iss: "did:dht:z6MkCreator".into(),
+                aud: "did:dht:z6MkMember".into(),
+                exp: now + MAX_EXPIRY_SECS + 1, // 1 second beyond 24h limit.
+                nbf: None,
+                nnc: "1234567890000-aabbccdd11223344aabbccdd11223344".to_owned(),
+                att: vec![],
+                prf: vec![],
+                fct: None,
+            },
+            signature: vec![0u8; 64],
+            encoded: String::new(),
+        };
+
+        // Even with large tolerance, ExpiryTooFar is not affected.
+        assert!(
+            matches!(
+                verify_expiry(&token, DEFAULT_CLOCK_SKEW_TOLERANCE_SECS),
+                Err(UcanError::ExpiryTooFar(_))
+            ),
+            "exp beyond 24h must be rejected regardless of tolerance"
+        );
+    }
+
+    /// The `InvalidTimeRange` check (nbf >= exp) must be independent of
+    /// tolerance. It is a structural token error, not a clock drift issue.
+    #[test]
+    fn verify_expiry_invalid_time_range_ignores_tolerance() {
+        let now = now_secs().unwrap();
+        let token = UcanToken {
+            header: UcanHeader::new(),
+            payload: UcanPayload {
+                iss: "did:dht:z6MkCreator".into(),
+                aud: "did:dht:z6MkMember".into(),
+                exp: now + 3600,
+                nbf: Some(now + 7200), // nbf > exp -- structural error.
+                nnc: "1234567890000-aabbccdd11223344aabbccdd11223344".to_owned(),
+                att: vec![],
+                prf: vec![],
+                fct: None,
+            },
+            signature: vec![0u8; 64],
+            encoded: String::new(),
+        };
+
+        // Even with large tolerance, InvalidTimeRange fires first.
+        assert!(
+            matches!(
+                verify_expiry(&token, DEFAULT_CLOCK_SKEW_TOLERANCE_SECS),
+                Err(UcanError::InvalidTimeRange { .. })
+            ),
+            "nbf > exp must return InvalidTimeRange regardless of tolerance"
+        );
+    }
+
+    /// Verify that a token exactly at the tolerance boundary for expiry is
+    /// rejected. `exp + tolerance == now` means `exp + tolerance <= now`, so
+    /// it's expired.
+    #[test]
+    fn verify_expiry_boundary_expired_at_exact_tolerance() {
+        let now = now_secs().unwrap();
+        let tolerance = 60u64;
+        let token = UcanToken {
+            header: UcanHeader::new(),
+            payload: UcanPayload {
+                iss: "did:dht:z6MkCreator".into(),
+                aud: "did:dht:z6MkMember".into(),
+                exp: now - tolerance, // exp + tolerance == now.
+                nbf: None,
+                nnc: "1234567890000-aabbccdd11223344aabbccdd11223344".to_owned(),
+                att: vec![],
+                prf: vec![],
+                fct: None,
+            },
+            signature: vec![0u8; 64],
+            encoded: String::new(),
+        };
+
+        // exp + tolerance == now. Uses `<=` so this is rejected.
+        assert!(
+            matches!(
+                verify_expiry(&token, tolerance),
+                Err(UcanError::TokenExpired)
+            ),
+            "token at exact tolerance boundary must be rejected"
+        );
+    }
+
+    /// Verify that the default constant matches the expected 5-minute value.
+    #[test]
+    fn default_clock_skew_tolerance_is_five_minutes() {
+        assert_eq!(DEFAULT_CLOCK_SKEW_TOLERANCE_SECS, 300);
     }
 }

--- a/crates/scp-ffi/napi/src/ucan.rs
+++ b/crates/scp-ffi/napi/src/ucan.rs
@@ -34,7 +34,9 @@ use scp_core::crypto::ucan::mint::{MintParams, mint_ucan};
 use scp_core::crypto::ucan::UcanError as CoreUcanError;
 
 use scp_core::crypto::ucan::capability::CapabilityUri;
-use scp_core::crypto::ucan::validate::{ValidationContext, parse_ucan, validate_ucan};
+use scp_core::crypto::ucan::validate::{
+    DEFAULT_CLOCK_SKEW_TOLERANCE_SECS, ValidationContext, parse_ucan, validate_ucan,
+};
 
 use scp_ffi_common::{
     BridgeDidResolver, BridgeNonceTracker, BridgeProofResolver, BridgeRevocationChecker,
@@ -243,6 +245,7 @@ pub async fn ucan_validate(
         ceiling: &ceiling,
         context_creator_did: &creator_did,
         presenting_agent_did: agent_did,
+        clock_skew_tolerance_secs: DEFAULT_CLOCK_SKEW_TOLERANCE_SECS,
     };
 
     // Execute the full 11-step validation pipeline.

--- a/crates/scp-ffi/src/ucan.rs
+++ b/crates/scp-ffi/src/ucan.rs
@@ -41,7 +41,9 @@ use scp_core::crypto::ucan::UcanError as CoreUcanError;
 use scp_core::crypto::ucan::capability::CapabilityUri;
 use scp_core::crypto::ucan::mint::{DelegateParams, MintParams, delegate_ucan, mint_ucan};
 use scp_core::crypto::ucan::revoke::compute_revocation_cid;
-use scp_core::crypto::ucan::validate::{ValidationContext, parse_ucan, validate_ucan};
+use scp_core::crypto::ucan::validate::{
+    DEFAULT_CLOCK_SKEW_TOLERANCE_SECS, ValidationContext, parse_ucan, validate_ucan,
+};
 
 use crate::bridge_adapters::{
     BridgeDidResolver, BridgeNonceTracker, BridgeProofResolver, BridgeRevocationChecker,
@@ -185,6 +187,7 @@ pub fn py_ucan_validate(
             ceiling: &rt.ceiling_strings,
             context_creator_did: &rt.creator_did,
             presenting_agent_did: agent_did,
+            clock_skew_tolerance_secs: DEFAULT_CLOCK_SKEW_TOLERANCE_SECS,
         };
 
         validate_ucan(&parsed_token, &required_cap, &mut ctx).map_err(ScpPyError::from)


### PR DESCRIPTION
## Summary
- Adds configurable `clock_skew_tolerance_secs` field to `ValidationContext` in scp-core (default: 300s / 5 minutes, per spec section 9.14)
- `exp` check tolerates recently expired tokens: `exp + tolerance > now`
- `nbf` check tolerates slightly future tokens: `nbf - tolerance <= now`
- `ExpiryTooFar` and `InvalidTimeRange` checks are tolerance-independent (structural/safety bounds)
- Both FFI bridges (PyO3 and napi-rs) and all internal callers use the default tolerance
- 8 new unit tests covering acceptance within tolerance, rejection beyond tolerance, boundary conditions, and independence from structural checks

## Test plan
- [x] All 3,418 workspace tests pass (`cargo test --workspace`)
- [x] Zero clippy warnings (`cargo clippy --workspace --all-targets`)
- [x] `cargo fmt --all` clean
- [x] New tests: `verify_expiry_tolerates_recently_expired_token`, `verify_expiry_rejects_token_expired_beyond_tolerance`, `verify_expiry_tolerates_slightly_future_nbf`, `verify_expiry_rejects_nbf_beyond_tolerance`, `verify_expiry_too_far_ignores_tolerance`, `verify_expiry_invalid_time_range_ignores_tolerance`, `verify_expiry_boundary_expired_at_exact_tolerance`, `default_clock_skew_tolerance_is_five_minutes`

closes #107

🤖 Generated with [Claude Code](https://claude.com/claude-code)