### PR TITLE
docs: update remaining stale rs-ucan references

### DIFF
--- a/.docs/adrs/phase-2.md
+++ b/.docs/adrs/phase-2.md
@@ -315,7 +315,7 @@ Implement UCAN-based capability enforcement in `scp-core/context/` and `scp-core
 ### Implementation
 
 - **Language:** Rust
-- **Library:** `rs-ucan` crate (or `ucan` crate — evaluate for UCAN 0.10+ spec compliance)
+- **Library:** `rs-ucan` crate (or `ucan` crate — evaluate for UCAN 0.10+ spec compliance) [Note: replaced by native impl in scp-core/src/crypto/ucan/]
 - **Crate:** `scp-core`
 - **Modules:** `scp-core/context/roles.rs` (role definitions, assignment), `scp-core/crypto/ucan/` (UCAN wrapper, validation, revocation)
 - **Nonce tracking:** In-memory set of seen nonces per context, persisted to storage.
@@ -325,7 +325,7 @@ Implement UCAN-based capability enforcement in `scp-core/context/` and `scp-core
 
 - **ADR-008 (Context):** Roles exist within contexts. Role assignment happens on member join. The capability ceiling is a context parameter.
 - **ADR-003 (DID):** UCAN tokens are signed by DIDs. Delegation chains reference DIDs. Validation requires DID resolution for public key lookup.
-- **rs-ucan library:** Third-party UCAN implementation. Must support UCAN 0.10+ spec with mandatory nonce field.
+- **rs-ucan library:** Third-party UCAN implementation. Must support UCAN 0.10+ spec with mandatory nonce field. [Note: replaced by native impl in scp-core/src/crypto/ucan/]
 
 ### Acceptance Criteria
 

--- a/.docs/adrs/phase-3.md
+++ b/.docs/adrs/phase-3.md
@@ -682,7 +682,7 @@ Implement comprehensive UCAN validation in `scp-core/crypto/ucan/` (Rust, buildi
 ### Implementation
 
 - **Language:** Rust
-- **Library:** `rs-ucan` crate (or `ucan` crate — must support UCAN 0.10+ with mandatory nonce field). If no crate supports mandatory nonces, implement UCAN parsing and validation directly using `serde_json`, `ed25519-dalek`, and `base64`.
+- **Library:** `rs-ucan` crate (or `ucan` crate — must support UCAN 0.10+ with mandatory nonce field). If no crate supports mandatory nonces, implement UCAN parsing and validation directly using `serde_json`, `ed25519-dalek`, and `base64`. [Note: replaced by native impl in scp-core/src/crypto/ucan/]
 - **Crate:** `scp-core`
 - **Module:** `scp-core/crypto/ucan/` (extends the ADR-009 structure)
 - **Nonce storage:** In-memory `HashSet<String>` per context with 24-hour pruning, backed by `scp-platform` Storage trait for persistence across restarts.

--- a/.docs/planning-sessions/planning-session-04.md
+++ b/.docs/planning-sessions/planning-session-04.md
@@ -205,7 +205,7 @@ scp:identity:{did}/attestations       → create, revoke
 
 **Delegation chain:** Human DID → Agent → Context-scoped token. Every token traces back to the human who authorized it. Revocation is per-token — revoke one capability in one context without affecting others.
 
-**Libraries:** ucanto (TypeScript), rs-ucan (Rust), ucan-wasm.
+**Libraries:** ucanto (TypeScript), rs-ucan (Rust), ucan-wasm. [Note: rs-ucan replaced by native impl in scp-core/src/crypto/ucan/]
 
 ---
 
@@ -260,7 +260,7 @@ SCP.App.declare(manifest)             Merkle tree event logs
 │  ┌───────┴──────────────────┴───────────────────┴───────┐            │
 │  │ CRYPTO LAYER                                          │            │
 │  │                                                       │            │
-│  │  MLS (OpenMLS)     UCAN (rs-ucan)     Merkle Trees   │            │
+│  │  MLS (OpenMLS)     UCAN (rs-ucan*)    Merkle Trees   │            │
 │  │  - group mgmt      - token create     - event log    │            │
 │  │  - key rotation     - chain validate  - proofs       │            │
 │  │  - encrypt/decrypt  - revocation      - integrity    │            │
@@ -278,6 +278,8 @@ SCP.App.declare(manifest)             Merkle tree event logs
 │                                                                       │
 └─────────────────────────────────────────────────────────────────────┘
 ```
+
+*rs-ucan was replaced by a native implementation in scp-core/src/crypto/ucan/.
 
 ### Tech Stack
 
@@ -911,7 +913,7 @@ If this works, everything else is elaboration. If this doesn't work, the spec is
 | Transport architecture | Abstraction + bindings (option 2 from session 02) | Pick one transport (option 3), define relay protocol (option 1) |
 | Core language | Rust | Go (weaker crypto ecosystem), TypeScript (performance), Swift (not cross-platform) |
 | Cross-platform bindings | UniFFI (Mozilla) | Manual FFI (fragile), cbindgen (C-only) |
-| UCAN library | rs-ucan (Rust) | ucanto (TypeScript only) |
+| UCAN library | rs-ucan (Rust) [Note: replaced by native impl in scp-core/src/crypto/ucan/] | ucanto (TypeScript only) |
 
 ---
 

--- a/.docs/prds/main.json
+++ b/.docs/prds/main.json
@@ -1698,7 +1698,7 @@
         "Create `crates/scp-core/crypto/ucan/mod.rs` with UcanToken types, UcanError enum, module re-exports",
         "Implement `mint_ucan` in `crates/scp-core/crypto/ucan/mint.rs`: token creation with proper iss/aud/att/nnc/exp fields, delegation chain construction, nonce generation in required format",
         "Implement `validate_ucan` in `crates/scp-core/crypto/ucan/validate.rs` with all 11 validation steps per ADR-016 criterion 2",
-        "Integrate with rs-ucan crate (evaluate for UCAN 0.10+ spec compliance)",
+        "Integrate native UCAN implementation in scp-core/src/crypto/ucan/ (UCAN 0.10+ spec compliant)",
         "Write comprehensive unit tests for all validation checks and failure modes"
       ],
       "blockedBy": [
@@ -1714,7 +1714,7 @@
       ],
       "details": {
         "Validation pipeline note": "Implements the full 11-step validation pipeline from ADR-016 criterion 2. All 11 steps are built from the start (ADR-016 is normative, not a future extension). Phase 2 integration tests exercise steps 1\u20132, 4\u20136, 8, 10\u201311 (8 steps not requiring delegation chain depth > 1). Phase 3 adds integration tests for steps 3 (chain verification), 7 (attenuation), and 9 (structured nonce validation).",
-        "Implementation notes": "Language: Rust. Library: rs-ucan crate (or ucan crate \u2014 evaluate for UCAN 0.10+ spec compliance). Crate: scp-core. Modules: scp-core/crypto/ucan/ (UCAN wrapper, validation, revocation). Nonce tracking: In-memory set of seen nonces per context, persisted to storage. Revocation: Revocation list per context, distributed as MLS application messages."
+        "Implementation notes": "Language: Rust. Library: native UCAN implementation in scp-core/src/crypto/ucan/ (UCAN 0.10+ spec compliant). Crate: scp-core. Modules: scp-core/crypto/ucan/ (UCAN wrapper, validation, revocation). Nonce tracking: In-memory set of seen nonces per context, persisted to storage. Revocation: Revocation list per context, distributed as MLS application messages."
       },
       "result": "UCAN minting (mint.rs) and 11-step validation pipeline (validate.rs). 28 new tests. Ed25519 signing via KeyCustody trait."
     },

--- a/README.md
+++ b/README.md
@@ -400,7 +400,7 @@ Chain depth is capped at 3 hops (protocol default) to bound amplification. The a
 ```
 scp-core/          — Protocol engine (context, identity, trust, discovery managers)
   store/           — ProtocolStore layer (thick), Storage trait (thin, 6 methods)
-scp-crypto/        — MLS (OpenMLS), UCAN (rs-ucan), Merkle trees, HPKE, HKDF
+scp-crypto/        — MLS (OpenMLS), UCAN (native impl), Merkle trees, HPKE, HKDF
 scp-transport/     — Transport adapter trait + SCP native relay adapter
 scp-relay/         — Reference relay implementation
 scp-ffi/           — UniFFI bindings (Swift, Kotlin), PyO3 (Python), wasm-bindgen (TS)


### PR DESCRIPTION
## Summary
- Updates 5 remaining stale rs-ucan references found during #158 review
- Historical documents get bracketed notes; current-facing docs get corrected

closes #74

🤖 Generated with [Claude Code](https://claude.com/claude-code)