### PR TITLE
fix(ffi): validate ucan_mint proofs and fix control char error message

### DIFF
--- a/crates/scp-ffi/src/ucan.rs
+++ b/crates/scp-ffi/src/ucan.rs
@@ -246,6 +246,11 @@ pub fn py_ucan_mint(
     for cap in &capabilities {
         validate::validate_capability_uri(cap)?;
     }
+    if let Some(ref tokens) = proofs {
+        for t in tokens {
+            validate::validate_ucan_token(t)?;
+        }
+    }
     // Look up the context to get the creator DID (issuer).
     let creator_did = crate::runtime::with_context(context_id, |rt| Ok(rt.creator_did.clone()))?;
 

--- a/crates/scp-ffi/src/validate.rs
+++ b/crates/scp-ffi/src/validate.rs
@@ -78,7 +78,7 @@ fn validate_non_empty(value: &str, field_name: &str, max_len: usize) -> Result<(
 fn reject_control_chars(value: &str, field_name: &str) -> Result<(), ScpPyError> {
     if let Some(pos) = value.chars().position(char::is_control) {
         return Err(ScpPyError::ValidationError(format!(
-            "{field_name} contains control character at byte position {pos}"
+            "{field_name} contains control character at position {pos}"
         )));
     }
     Ok(())


### PR DESCRIPTION
## Summary
- Adds `validate_ucan_token` to each proof string in `py_ucan_mint` for consistency with `py_ucan_validate`
- Fixes "byte position" → "position" in `reject_control_chars` error message (`.chars().position()` returns character index, not byte offset)

Follow-up from PR #168 review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)