### PR TITLE
docs: Local HTTP Control API and HTTP Broadcast Projection

### DIFF
--- a/.docs/adrs/phase-2.md
+++ b/.docs/adrs/phase-2.md
@@ -1088,3 +1088,102 @@ Implement a complete addressability and deployment layer as specified in §18:
 | `Cargo.toml` | Add scp-node workspace member |
 
 **Estimated functions:** ~30-35 public functions, ~20-25 internal helpers across all files.
+
+---
+
+## ADR-035: Local HTTP Control API and Broadcast Projection
+
+> **Note:** ADR-035 is numbered non-sequentially (same pattern as ADR-032). Both features are `ApplicationNode`-scope extensions that depend on Phase 2 ADRs and live in the `scp-node` crate. They are application-layer conveniences, not protocol changes.
+
+**Status:** Decided
+
+### Context
+
+SCP's core transport is MessagePack-over-WebSocket with encrypted blobs — deliberately opaque to intermediaries (§9.9.1). This is architecturally correct (relays are dumb pipes), but it means:
+
+1. **No dev tooling interop.** Standard HTTP tools (curl, Postman, OpenAPI) cannot inspect node state or relay status. Operators debugging a deployment must write Rust code or use the SDK CLI.
+2. **No HTTP distribution for broadcast content.** Broadcast contexts (§5.14) produce content intended for broad audiences, but that content is only accessible to SCP clients with broadcast keys. CDNs, web browsers, RSS readers, and search crawlers are excluded.
+
+Both gaps are recoverable at the application layer without compromising the wire protocol.
+
+### Decision
+
+Implement two `ApplicationNode` features in the `scp-node` crate:
+
+#### 1. Local HTTP Control API (§18.10)
+
+- **Separate port.** Dev API listens on `127.0.0.1:<port>`, distinct from the public HTTPS listener. Prevents accidental exposure through reverse proxy misconfiguration.
+- **Bearer token authentication.** Token format: `scp_local_token_<32 random hex>`. Generated at startup, logged at INFO. All `/scp/dev/v1/*` requests require `Authorization: Bearer <token>`. 401 on missing/wrong token.
+- **Seven endpoints.** Health, identity, relay status, context list/get/create/delete. All JSON. Read-only for node state; context management via POST/DELETE.
+- **Opt-in.** Enabled via `.local_api(addr)` on the builder. Production default: disabled (zero additional attack surface).
+
+#### 2. HTTP Broadcast Projection (§18.11)
+
+- **Public HTTPS port.** Projection endpoints serve on the same listener as `.well-known/scp` and `/scp/v1`. Content is public by design (§5.14).
+- **Author-side only.** The relay cannot decrypt (§9.9.1). The author's `ApplicationNode` holds the broadcast keys and decrypts its own content for HTTP serving. Subscriber-side projection is deliberately unsupported.
+- **Feed endpoint.** `GET /scp/broadcast/<routing_id>/feed` — paginated JSON with 30s cache TTL and ETag.
+- **Per-message endpoint.** `GET /scp/broadcast/<routing_id>/messages/<blob_id>` — immutable individual messages with 1-year cache TTL and conditional GET (304).
+- **Opt-in per context.** `enable_broadcast_projection(context_id, broadcast_key)` activates projection. `disable_broadcast_projection(context_id)` deactivates.
+
+#### 3. Shared BlobStorage via Arc
+
+`RelayServer::new` currently takes an owned `B: BlobStorage`, wrapping it in `Arc<B>` internally. Broadcast projection needs to query the same `BlobStorage` instance that the relay writes to. The change: the `ApplicationNode` builder creates `Arc<B>`, passing `Arc::clone` to both `RelayServer` and `NodeState`. This requires `RelayServer::new` to accept `Arc<B>` instead of owned `B`.
+
+### Rationale
+
+- **Separate port for dev API:** A reverse proxy forwarding `*` to the public HTTPS port is a common deployment pattern. If the dev API shared the public port, every such proxy would expose it. Separate port requires explicit, intentional proxy configuration. The trade-off (two listeners) is negligible.
+- **Projection is public because broadcast content is public:** §5.14 defines broadcast contexts as unlimited-audience, per-author keyed content. Making this content accessible via HTTP is consistent with its design intent. Adding authentication would be contradictory — the content is already available to anyone with the broadcast key, and broadcast keys are distributed freely.
+- **Author-side only:** Subscriber-side projection would let any subscriber redistribute content via HTTP without the author's control or knowledge. Author-side projection means the author explicitly opts in.
+- **`routing_id` in URLs is not new disclosure:** `routing_id = SHA-256(context_id)` is already visible to every relay handling the broadcast context (§5.14.6). Using it in HTTP URLs reveals nothing beyond what relays already observe.
+- **`Arc<dyn BlobStorage>` sharing over IPC:** A separate `scp-broadcast-proxy` process would require IPC (Unix socket, shared memory) to access blobs. The keys and blobs are already in-process in the `ApplicationNode`. `Arc` sharing is zero-copy, zero-overhead.
+
+### Rejected Alternatives
+
+1. **Relay-side projection.** Relays cannot decrypt broadcast content (§9.9.1). Giving relays broadcast keys would violate the untrusted-relay invariant and expand the trust boundary.
+2. **Separate `scp-broadcast-proxy` process.** Adds IPC complexity for zero benefit — keys and blobs are already in the `ApplicationNode` process. If operators want a separate process, they can run a second `ApplicationNode` with projection enabled.
+3. **UNIX socket for dev API.** Not portable across deployment modes (containers, Windows). TCP on localhost is universally supported.
+4. **Dev API on the public port with path-based routing.** Accidental exposure risk through reverse proxy misconfiguration outweighs the convenience of a single port.
+
+### Dependencies
+
+- **ADR-032 (Addressability and Deployment):** `ApplicationNode` builder, `NodeState`, `serve()`, axum Router composition.
+- **ADR-007 (BroadcastKey):** `BroadcastKey` type, `BroadcastEnvelope` seal/open operations. Key epoch management.
+- **ADR-004 (Native Relay):** `RelayServer`, `BlobStorage` trait, `query(routing_id, since, limit)` interface. `Arc<B>` change to `RelayServer::new`.
+
+### Acceptance Criteria
+
+1. **Dev API bearer token** generated at startup, logged at INFO, available via `node.dev_token()`.
+2. **Dev API bound to localhost** on a separate port from the public HTTPS listener.
+3. **`GET /scp/dev/v1/health`** returns uptime, relay connection count, and storage status.
+4. **`GET /scp/dev/v1/identity`** returns DID string and DID document.
+5. **`GET /scp/dev/v1/relay/status`** returns bound address, active connections, and blob count.
+6. **`GET /scp/dev/v1/contexts`** returns list of registered broadcast contexts.
+7. **`GET /scp/dev/v1/contexts/:id`** returns single context details. 404 for unknown ID.
+8. **`POST /scp/dev/v1/contexts`** registers a broadcast context. 201 on success.
+9. **`DELETE /scp/dev/v1/contexts/:id`** deregisters a context. 204 on success. 404 for unknown ID.
+10. **Bearer token middleware** returns 401 for missing or invalid token on all dev API endpoints.
+11. **`enable_broadcast_projection`** activates HTTP projection for a broadcast context.
+12. **Feed endpoint** returns paginated JSON with `Cache-Control: public, max-age=30, stale-while-revalidate=300` and `ETag`.
+13. **Per-message endpoint** returns single message JSON with `Cache-Control: public, immutable, max-age=31536000` and `ETag`.
+14. **Conditional GET** on per-message endpoint: `If-None-Match` with matching ETag returns 304.
+15. **`ProjectedContext` registry** maps `routing_id → BroadcastKey` per epoch. Decryption uses epoch-matched key.
+16. **`RelayServer::new` accepts `Arc<B>`** so the same `BlobStorage` instance is shared between relay and projection handlers.
+
+### Scope
+
+**New files:**
+
+| File | Purpose |
+|------|---------|
+| `crates/scp-node/src/dev_api.rs` | Dev API handlers + bearer auth middleware |
+| `crates/scp-node/src/projection.rs` | `ProjectedContext` type + broadcast projection handlers |
+
+**Modified files:**
+
+| File | Change |
+|------|--------|
+| `crates/scp-node/src/lib.rs` | `NodeState` extensions (dev token, dev bind addr, projected contexts, `Arc<dyn BlobStorage>`), new builder methods, new `ApplicationNode` methods |
+| `crates/scp-node/src/http.rs` | Wire `dev_router()` and `broadcast_projection_router()` into `serve()`, add dev API listener |
+| `crates/scp-transport/src/native/server.rs` | `RelayServer::new` accepts `Arc<B>` instead of owned `B` |
+
+**Estimated functions:** ~15-20 public functions, ~10-15 internal helpers across new and modified files.

--- a/.docs/prds/http-features.json
+++ b/.docs/prds/http-features.json
@@ -1,0 +1,460 @@
+{
+  "project": "scp",
+  "description": "Local HTTP control API for debugging and operator tooling, plus HTTP broadcast projection for CDN distribution, web readers, and search engine crawlability.",
+  "gates": [
+    {
+      "id": "gate-http-1",
+      "name": "Local HTTP Control API",
+      "priority": "P1",
+      "status": "pending",
+      "stories": [
+        "SCP-242",
+        "SCP-243",
+        "SCP-244",
+        "SCP-245"
+      ]
+    },
+    {
+      "id": "gate-http-2",
+      "name": "HTTP Broadcast Projection",
+      "priority": "P1",
+      "status": "pending",
+      "stories": [
+        "SCP-246",
+        "SCP-247",
+        "SCP-248",
+        "SCP-249"
+      ]
+    }
+  ],
+  "stories": [
+    {
+      "id": "SCP-242",
+      "title": "Extend NodeState with dev token, dev bind addr, projected contexts registry, and Arc<dyn BlobStorage>",
+      "gate": "gate-http-1",
+      "priority": "P0",
+      "severity": "critical",
+      "status": "pending",
+      "files": [
+        "crates/scp-node/src/lib.rs",
+        "crates/scp-node/src/http.rs",
+        "crates/scp-transport/src/native/server.rs"
+      ],
+      "description": "Extend NodeState with fields required by both the dev API and broadcast projection: dev_token (Option<String>), dev_bind_addr (Option<SocketAddr>), projected_contexts (RwLock<HashMap<RoutingId, ProjectedContext>>), and blob_storage (Arc<dyn BlobStorage>). Change RelayServer::new to accept Arc<B> instead of owned B so the same BlobStorage instance can be shared between the relay server and projection handlers. Update ApplicationNodeBuilder with .local_api(addr) method and wire the new fields through build(). Generate the bearer token (scp_local_token_<32 random hex>) at build time when local_api is configured. This is the shared foundation for both gate-http-1 and gate-http-2.",
+      "acceptanceCriteria": [
+        "NodeState has dev_token: Option<String> field",
+        "NodeState has dev_bind_addr: Option<SocketAddr> field",
+        "NodeState has projected_contexts: RwLock<HashMap<[u8; 32], ProjectedContext>> field",
+        "NodeState has blob_storage: Arc<dyn BlobStorage> field",
+        "RelayServer::new accepts Arc<B> where B: BlobStorage instead of owned B",
+        "Existing RelayServer callers updated to pass Arc<B>",
+        "ApplicationNodeBuilder has .local_api(addr: SocketAddr) method",
+        "Bearer token generated as scp_local_token_<32 random hex chars> when local_api is set",
+        "Bearer token logged at INFO level during build()",
+        "node.dev_token() returns Option<&str> (Some when local_api set, None otherwise)",
+        "All existing tests continue to pass after RelayServer::new signature change",
+        "All public items have rustdoc"
+      ],
+      "actionItems": [
+        "Add dev_token, dev_bind_addr, projected_contexts, and blob_storage fields to NodeState",
+        "Define ProjectedContext struct (routing_id, context_id, keys: HashMap<u64, BroadcastKey>)",
+        "Change RelayServer::new signature from B to Arc<B>",
+        "Update all RelayServer::new call sites to pass Arc::clone",
+        "Add .local_api(addr) to ApplicationNodeBuilder",
+        "Generate bearer token using rand::thread_rng() and hex encoding",
+        "Add dev_token() accessor to ApplicationNode",
+        "Log token at INFO in build() when local_api is configured",
+        "Update existing tests for new RelayServer::new signature"
+      ],
+      "blockedBy": [],
+      "sources": [
+        {
+          "file": ".docs/specs/18-addressability-and-deployment.md",
+          "section": "### 18.10.2 Binding and Authentication"
+        },
+        {
+          "file": ".docs/specs/18-addressability-and-deployment.md",
+          "section": "### 18.10.5 SDK Surface"
+        },
+        {
+          "file": ".docs/specs/18-addressability-and-deployment.md",
+          "section": "### 18.11.5 Decryption Architecture"
+        },
+        {
+          "file": ".docs/adrs/phase-2.md",
+          "section": "## ADR-035: Local HTTP Control API and Broadcast Projection"
+        }
+      ],
+      "details": {
+        "phase": 2,
+        "crate": "scp-node"
+      }
+    },
+    {
+      "id": "SCP-243",
+      "title": "Implement dev API handlers (health, identity, relay status) with bearer token middleware",
+      "gate": "gate-http-1",
+      "priority": "P0",
+      "severity": "critical",
+      "status": "pending",
+      "files": [
+        "crates/scp-node/src/dev_api.rs",
+        "crates/scp-node/src/lib.rs"
+      ],
+      "description": "Create dev_api.rs with bearer token authentication middleware and three read-only handlers: GET /scp/dev/v1/health (uptime, relay connection count, storage status), GET /scp/dev/v1/identity (DID string and DID document), GET /scp/dev/v1/relay/status (bound address, active connections, blob count). The middleware extracts the Authorization header, compares against NodeState.dev_token using constant-time comparison, and returns 401 with {\"error\": \"unauthorized\", \"code\": \"UNAUTHORIZED\"} on mismatch. All responses are JSON. Follow the well_known_handler pattern (axum State + Json response).",
+      "acceptanceCriteria": [
+        "Bearer token middleware extracts Authorization header and validates against NodeState.dev_token",
+        "Constant-time comparison used for token validation (no timing side-channel)",
+        "Missing Authorization header returns 401 with {\"error\": \"unauthorized\", \"code\": \"UNAUTHORIZED\"}",
+        "Invalid token returns 401 with {\"error\": \"unauthorized\", \"code\": \"UNAUTHORIZED\"}",
+        "GET /scp/dev/v1/health returns JSON with uptime_seconds, relay_connections, and storage_status fields",
+        "GET /scp/dev/v1/identity returns JSON with did and document fields",
+        "GET /scp/dev/v1/relay/status returns JSON with bound_addr, active_connections, and blob_count fields",
+        "All responses have Content-Type: application/json",
+        "dev_api module declared as pub mod in lib.rs",
+        "All public items have rustdoc"
+      ],
+      "actionItems": [
+        "Create crates/scp-node/src/dev_api.rs",
+        "Implement bearer_auth_layer as axum middleware (extract Authorization header, constant-time compare)",
+        "Implement health_handler returning uptime, connections, storage status",
+        "Implement identity_handler returning DID string and document",
+        "Implement relay_status_handler returning bound addr, connections, blob count",
+        "Define JSON response structs with serde::Serialize",
+        "Define error response struct with error and code fields",
+        "Add pub mod dev_api to lib.rs",
+        "Add unit tests for middleware (valid token, invalid token, missing header)"
+      ],
+      "blockedBy": [
+        "SCP-242"
+      ],
+      "sources": [
+        {
+          "file": ".docs/specs/18-addressability-and-deployment.md",
+          "section": "### 18.10.2 Binding and Authentication"
+        },
+        {
+          "file": ".docs/specs/18-addressability-and-deployment.md",
+          "section": "### 18.10.3 Endpoint Catalog"
+        },
+        {
+          "file": ".docs/specs/18-addressability-and-deployment.md",
+          "section": "### 18.10.4 Response Format"
+        }
+      ],
+      "details": {
+        "phase": 2,
+        "crate": "scp-node"
+      }
+    },
+    {
+      "id": "SCP-244",
+      "title": "Implement dev API context management endpoints (list, get, register, deregister)",
+      "gate": "gate-http-1",
+      "priority": "P0",
+      "severity": "critical",
+      "status": "pending",
+      "files": [
+        "crates/scp-node/src/dev_api.rs"
+      ],
+      "description": "Add four context management handlers to dev_api.rs: GET /scp/dev/v1/contexts (list all registered broadcast contexts), GET /scp/dev/v1/contexts/:id (single context details — id, name, mode, subscriber count), POST /scp/dev/v1/contexts (register a broadcast context, returns 201), DELETE /scp/dev/v1/contexts/:id (deregister, returns 204). Unknown context IDs return 404 with {\"error\": \"context not found\", \"code\": \"NOT_FOUND\"}. All endpoints use the bearer token middleware from SCP-243. Context registration modifies NodeState.broadcast_contexts (same list used by .well-known/scp).",
+      "acceptanceCriteria": [
+        "GET /scp/dev/v1/contexts returns JSON array of all registered broadcast contexts",
+        "GET /scp/dev/v1/contexts/:id returns JSON with id, name, mode, and subscriber_count fields",
+        "GET /scp/dev/v1/contexts/:id returns 404 for unknown context ID",
+        "POST /scp/dev/v1/contexts accepts JSON body with id and optional name fields",
+        "POST /scp/dev/v1/contexts returns 201 Created on success",
+        "DELETE /scp/dev/v1/contexts/:id returns 204 No Content on success",
+        "DELETE /scp/dev/v1/contexts/:id returns 404 for unknown context ID",
+        "All endpoints require valid bearer token (401 on missing/invalid)",
+        "All public items have rustdoc"
+      ],
+      "actionItems": [
+        "Implement list_contexts_handler returning all broadcast contexts",
+        "Implement get_context_handler with :id path parameter",
+        "Implement create_context_handler parsing JSON body",
+        "Implement delete_context_handler with :id path parameter",
+        "Define request/response structs for context CRUD",
+        "Wire handlers into dev API router with appropriate HTTP methods",
+        "Add unit tests for each endpoint (success and error cases)"
+      ],
+      "blockedBy": [
+        "SCP-243"
+      ],
+      "sources": [
+        {
+          "file": ".docs/specs/18-addressability-and-deployment.md",
+          "section": "### 18.10.3 Endpoint Catalog"
+        },
+        {
+          "file": ".docs/specs/18-addressability-and-deployment.md",
+          "section": "### 18.10.4 Response Format"
+        }
+      ],
+      "details": {
+        "phase": 2,
+        "crate": "scp-node"
+      }
+    },
+    {
+      "id": "SCP-245",
+      "title": "Wire dev_router() into ApplicationNode and serve() with separate listener",
+      "gate": "gate-http-1",
+      "priority": "P0",
+      "severity": "critical",
+      "status": "pending",
+      "files": [
+        "crates/scp-node/src/lib.rs",
+        "crates/scp-node/src/http.rs"
+      ],
+      "description": "Add dev_router() method to ApplicationNode that composes all dev API routes (from SCP-243 and SCP-244) with the bearer token middleware into a single axum::Router. Modify serve() to spawn a separate tokio task binding the dev API router to the configured dev_bind_addr (localhost) when local_api was set on the builder. The dev API listener runs concurrently with the public HTTPS listener. If local_api was not configured, serve() behaves identically to before (no dev listener). Log the dev API address at INFO when it starts.",
+      "acceptanceCriteria": [
+        "ApplicationNode::dev_router() returns axum::Router with all /scp/dev/v1/* routes",
+        "dev_router() includes bearer token middleware on all routes",
+        "serve() spawns separate tokio task for dev API listener when local_api was configured",
+        "Dev API listener binds to the configured SocketAddr (default 127.0.0.1)",
+        "Dev API listener runs concurrently with public HTTPS listener",
+        "serve() behavior unchanged when local_api was not configured (no dev listener spawned)",
+        "Dev API address logged at INFO when listener starts",
+        "Integration test: dev API reachable on localhost while public server runs on separate port",
+        "All public items have rustdoc"
+      ],
+      "actionItems": [
+        "Add dev_router() method to ApplicationNode returning composed Router",
+        "Modify serve() to optionally spawn dev API listener task",
+        "Bind dev API to NodeState.dev_bind_addr when present",
+        "Log dev API address and token at INFO on startup",
+        "Add integration test starting both listeners and verifying reachability",
+        "Ensure graceful shutdown of dev API listener alongside main server"
+      ],
+      "blockedBy": [
+        "SCP-244"
+      ],
+      "sources": [
+        {
+          "file": ".docs/specs/18-addressability-and-deployment.md",
+          "section": "### 18.10.5 SDK Surface"
+        },
+        {
+          "file": ".docs/specs/18-addressability-and-deployment.md",
+          "section": "### 18.10.6 Security Properties"
+        },
+        {
+          "file": ".docs/adrs/phase-2.md",
+          "section": "## ADR-035: Local HTTP Control API and Broadcast Projection"
+        }
+      ],
+      "details": {
+        "phase": 2,
+        "crate": "scp-node"
+      }
+    },
+    {
+      "id": "SCP-246",
+      "title": "Implement ProjectedContext type with per-epoch BroadcastKey management",
+      "gate": "gate-http-2",
+      "priority": "P0",
+      "severity": "critical",
+      "status": "pending",
+      "files": [
+        "crates/scp-node/src/projection.rs",
+        "crates/scp-node/src/lib.rs"
+      ],
+      "description": "Create projection.rs with the ProjectedContext type that maps routing_id to per-epoch BroadcastKeys for broadcast projection decryption. ProjectedContext stores context_id, routing_id (SHA-256(context_id)), and a HashMap<u64, BroadcastKey> of epoch-keyed broadcast keys. Add enable_broadcast_projection(context_id, broadcast_key) and disable_broadcast_projection(context_id) methods to ApplicationNode. enable_broadcast_projection computes routing_id, inserts into NodeState.projected_contexts. disable_broadcast_projection removes the entry. Keys are retained per epoch for the blob TTL window.",
+      "acceptanceCriteria": [
+        "ProjectedContext struct has context_id, routing_id, and keys (HashMap<u64, BroadcastKey>) fields",
+        "routing_id computed as SHA-256(context_id) matching §5.14.6",
+        "enable_broadcast_projection(context_id, broadcast_key) inserts into projected_contexts registry",
+        "disable_broadcast_projection(context_id) removes from projected_contexts registry",
+        "Multiple epochs supported: different keys for different key_epoch values",
+        "Key epochs retained for blob TTL window (not pruned on epoch advance)",
+        "projection module declared as pub mod in lib.rs",
+        "Unit test: enable then disable roundtrip",
+        "Unit test: multiple epochs stored and retrievable by epoch number",
+        "All public items have rustdoc"
+      ],
+      "actionItems": [
+        "Create crates/scp-node/src/projection.rs",
+        "Define ProjectedContext struct with context_id, routing_id, and keys fields",
+        "Implement routing_id computation as SHA-256(context_id)",
+        "Add enable_broadcast_projection to ApplicationNode",
+        "Add disable_broadcast_projection to ApplicationNode",
+        "Add pub mod projection to lib.rs",
+        "Add unit tests for enable/disable and multi-epoch key storage"
+      ],
+      "blockedBy": [
+        "SCP-242"
+      ],
+      "sources": [
+        {
+          "file": ".docs/specs/18-addressability-and-deployment.md",
+          "section": "### 18.11.2 Activation"
+        },
+        {
+          "file": ".docs/specs/18-addressability-and-deployment.md",
+          "section": "### 18.11.5 Decryption Architecture"
+        },
+        {
+          "file": ".docs/specs/18-addressability-and-deployment.md",
+          "section": "### 18.11.8 SDK Surface"
+        }
+      ],
+      "details": {
+        "phase": 2,
+        "crate": "scp-node"
+      }
+    },
+    {
+      "id": "SCP-247",
+      "title": "Implement broadcast projection feed endpoint with caching headers",
+      "gate": "gate-http-2",
+      "priority": "P0",
+      "severity": "critical",
+      "status": "pending",
+      "files": [
+        "crates/scp-node/src/projection.rs"
+      ],
+      "description": "Implement GET /scp/broadcast/<routing_id>/feed handler. On request: look up routing_id in ProjectedContext registry, query BlobStorage for recent blobs using query(routing_id, since, limit), deserialize each as BroadcastEnvelope, open with epoch-matched BroadcastKey, return decrypted content as JSON. Response includes context_id, author_did, and messages array (each with id, author_did, key_epoch, published_at, content as base64). Query params: ?since=<blob_id> (messages after this ID), ?limit=N (default 20, max 100). Headers: Cache-Control: public, max-age=30, stale-while-revalidate=300 and ETag set to latest blob_id.",
+      "acceptanceCriteria": [
+        "GET /scp/broadcast/<routing_id>/feed returns JSON with context_id, author_did, and messages array",
+        "Each message has id, author_did, key_epoch, published_at, and content (base64) fields",
+        "?since=<blob_id> returns only messages after the specified blob ID",
+        "?limit=N limits response to N messages (default 20, max 100)",
+        "Unknown routing_id returns 404",
+        "BroadcastEnvelope deserialized and decrypted with epoch-matched BroadcastKey",
+        "Decryption failure for a blob is logged and that blob is skipped (not a 500)",
+        "Cache-Control header set to public, max-age=30, stale-while-revalidate=300",
+        "ETag header set to latest blob_id in the response",
+        "All public items have rustdoc"
+      ],
+      "actionItems": [
+        "Implement feed_handler axum handler with routing_id path parameter",
+        "Parse since and limit query parameters with defaults",
+        "Query BlobStorage via Arc<dyn BlobStorage> from NodeState",
+        "Deserialize blobs as BroadcastEnvelope and decrypt with ProjectedContext keys",
+        "Construct JSON response with decrypted content as base64",
+        "Set Cache-Control and ETag response headers",
+        "Handle unknown routing_id with 404",
+        "Handle decryption failures gracefully (skip, log warning)",
+        "Add unit tests with mock BlobStorage"
+      ],
+      "blockedBy": [
+        "SCP-246"
+      ],
+      "sources": [
+        {
+          "file": ".docs/specs/18-addressability-and-deployment.md",
+          "section": "### 18.11.3 Feed Endpoint"
+        },
+        {
+          "file": ".docs/specs/18-addressability-and-deployment.md",
+          "section": "### 18.11.5 Decryption Architecture"
+        }
+      ],
+      "details": {
+        "phase": 2,
+        "crate": "scp-node"
+      }
+    },
+    {
+      "id": "SCP-248",
+      "title": "Implement broadcast projection per-message endpoint with conditional GET",
+      "gate": "gate-http-2",
+      "priority": "P0",
+      "severity": "critical",
+      "status": "pending",
+      "files": [
+        "crates/scp-node/src/projection.rs"
+      ],
+      "description": "Implement GET /scp/broadcast/<routing_id>/messages/<blob_id> handler. Looks up routing_id in ProjectedContext registry, fetches single blob from BlobStorage by blob_id, deserializes as BroadcastEnvelope, decrypts with epoch-matched key, returns single message JSON (id, author_did, key_epoch, published_at, content as base64). Headers: Cache-Control: public, immutable, max-age=31536000 and ETag set to blob_id. Conditional GET: if If-None-Match header matches blob_id, return 304 Not Modified with no body. Unknown routing_id or blob_id returns 404.",
+      "acceptanceCriteria": [
+        "GET /scp/broadcast/<routing_id>/messages/<blob_id> returns single message JSON",
+        "Message has id, author_did, key_epoch, published_at, and content (base64) fields",
+        "Unknown routing_id returns 404",
+        "Unknown blob_id returns 404",
+        "Cache-Control header set to public, immutable, max-age=31536000",
+        "ETag header set to blob_id",
+        "If-None-Match header matching blob_id returns 304 Not Modified with no body",
+        "If-None-Match header not matching returns 200 with full response",
+        "Decryption failure returns 500 with error JSON",
+        "All public items have rustdoc"
+      ],
+      "actionItems": [
+        "Implement message_handler axum handler with routing_id and blob_id path parameters",
+        "Fetch single blob from BlobStorage by blob_id",
+        "Check If-None-Match header against blob_id for conditional GET",
+        "Deserialize blob as BroadcastEnvelope and decrypt",
+        "Construct single message JSON response",
+        "Set Cache-Control and ETag response headers",
+        "Return 304 for matching If-None-Match",
+        "Handle unknown routing_id and blob_id with 404",
+        "Add unit tests including conditional GET scenarios"
+      ],
+      "blockedBy": [
+        "SCP-247"
+      ],
+      "sources": [
+        {
+          "file": ".docs/specs/18-addressability-and-deployment.md",
+          "section": "### 18.11.4 Per-Message Endpoint"
+        },
+        {
+          "file": ".docs/specs/18-addressability-and-deployment.md",
+          "section": "### 18.11.5 Decryption Architecture"
+        }
+      ],
+      "details": {
+        "phase": 2,
+        "crate": "scp-node"
+      }
+    },
+    {
+      "id": "SCP-249",
+      "title": "Wire broadcast_projection_router() into ApplicationNode and serve()",
+      "gate": "gate-http-2",
+      "priority": "P0",
+      "severity": "critical",
+      "status": "pending",
+      "files": [
+        "crates/scp-node/src/lib.rs",
+        "crates/scp-node/src/http.rs"
+      ],
+      "description": "Add broadcast_projection_router() method to ApplicationNode that composes the feed and per-message handlers from SCP-247 and SCP-248 into a single axum::Router. Modify serve() to merge the projection router into the public HTTPS listener alongside .well-known/scp and /scp/v1. The projection router has no authentication (content is public per §5.14). The router is only included when at least one projected context is registered. Log projection endpoint availability at INFO on startup.",
+      "acceptanceCriteria": [
+        "ApplicationNode::broadcast_projection_router() returns axum::Router with /scp/broadcast/* routes",
+        "Projection router includes feed endpoint at /scp/broadcast/<routing_id>/feed",
+        "Projection router includes message endpoint at /scp/broadcast/<routing_id>/messages/<blob_id>",
+        "Projection router has no authentication middleware (public endpoints)",
+        "serve() merges projection router into public HTTPS listener",
+        "Projection endpoints coexist with .well-known/scp and /scp/v1 on the same listener",
+        "Integration test: projection endpoints reachable alongside .well-known/scp",
+        "All public items have rustdoc"
+      ],
+      "actionItems": [
+        "Add broadcast_projection_router() method to ApplicationNode",
+        "Compose feed and message handlers into Router with path parameters",
+        "Merge projection router into serve() alongside existing routers",
+        "Log projection availability at INFO on startup",
+        "Add integration test for combined routing",
+        "Verify no route conflicts with existing /scp/* paths"
+      ],
+      "blockedBy": [
+        "SCP-248"
+      ],
+      "sources": [
+        {
+          "file": ".docs/specs/18-addressability-and-deployment.md",
+          "section": "### 18.11.8 SDK Surface"
+        },
+        {
+          "file": ".docs/adrs/phase-2.md",
+          "section": "## ADR-035: Local HTTP Control API and Broadcast Projection"
+        }
+      ],
+      "details": {
+        "phase": 2,
+        "crate": "scp-node"
+      }
+    }
+  ]
+}

--- a/.docs/specs/18-addressability-and-deployment.md
+++ b/.docs/specs/18-addressability-and-deployment.md
@@ -451,3 +451,203 @@ End-to-end deployment of an SCP-enabled agent on a dedicated machine:
 | HTTP server (`.well-known` + relay upgrade) | Phase 2 | Required for web discovery and WebSocket relay. |
 
 The `scp-node` crate is added to the workspace as a new top-level crate at `crates/scp-node/`, depending on `scp-core`, `scp-transport`, and `scp-platform`.
+
+## 18.10 Local HTTP Control API
+
+SCP's core transport is MessagePack-over-WebSocket with encrypted blobs — deliberately opaque to intermediaries (§9.9.1). Standard HTTP dev tooling (curl, Postman, OpenAPI) cannot interact with this wire protocol. The local HTTP control API recovers HTTP-ecosystem usefulness for debugging and local integration without exposing any protocol endpoints.
+
+### 18.10.1 Design Rationale
+
+The dev API is **not a protocol endpoint**. It is a local control plane bound to the operator's machine. No SCP peer ever interacts with it — it exists solely for:
+
+- **Debugging:** Inspecting node state, relay status, and registered contexts via curl or browser.
+- **Local integration:** Non-Rust applications on the same machine can query node state over HTTP.
+- **Tooling:** OpenAPI-compatible surface for Postman collections, monitoring dashboards, and health checks.
+
+The dev API is a convenience projection of the SDK surface — all operations are also available directly via `ApplicationNode` methods in Rust. No functionality is exclusive to the HTTP API. It exists for tooling and non-Rust local integrations that cannot call Rust methods directly.
+
+### 18.10.2 Binding and Authentication
+
+The dev API listens on a **separate port** from the public HTTPS listener, bound to `127.0.0.1:<port>` by default. This separation prevents accidental exposure through reverse proxy misconfiguration — a reverse proxy forwarding to the public HTTPS port never sees the dev API.
+
+Authentication uses a bearer token generated at startup:
+
+- Token format: `scp_local_token_<32 random hex characters>` (e.g., `scp_local_token_a1b2c3...`).
+- The token is logged at `INFO` level on startup and available via `node.dev_token()`.
+- All requests to `/scp/dev/v1/*` require `Authorization: Bearer <token>`.
+- Missing or invalid token returns `401 Unauthorized` with `{ "error": "unauthorized", "code": "UNAUTHORIZED" }`.
+
+### 18.10.3 Endpoint Catalog
+
+All endpoints are prefixed with `/scp/dev/v1/`.
+
+| Method | Path | Description |
+|--------|------|-------------|
+| `GET` | `/scp/dev/v1/health` | Uptime, relay connection count, storage status |
+| `GET` | `/scp/dev/v1/identity` | DID string and DID document |
+| `GET` | `/scp/dev/v1/relay/status` | Bound address, active connections, blob count |
+| `GET` | `/scp/dev/v1/contexts` | List registered broadcast contexts |
+| `GET` | `/scp/dev/v1/contexts/:id` | Single context (id, name, mode, subscriber count) |
+| `POST` | `/scp/dev/v1/contexts` | Register a broadcast context |
+| `DELETE` | `/scp/dev/v1/contexts/:id` | Deregister a broadcast context |
+
+### 18.10.4 Response Format
+
+All responses are JSON (`Content-Type: application/json`).
+
+Success responses return the resource directly. Error responses use:
+
+```json
+{
+  "error": "human-readable message",
+  "code": "MACHINE_READABLE_CODE"
+}
+```
+
+Standard HTTP status codes: `200` (success), `201` (created), `204` (deleted), `400` (bad request), `401` (unauthorized), `404` (not found), `500` (internal error).
+
+### 18.10.5 SDK Surface
+
+- `ApplicationNodeBuilder::local_api(addr: SocketAddr)` — enables the dev API on the specified address. Not called = dev API disabled (production default).
+- `ApplicationNode::dev_router() -> axum::Router` — returns the dev API router for composition. Only available when `local_api()` was called on the builder.
+- `ApplicationNode::dev_token() -> Option<&str>` — returns the bearer token if the dev API is enabled. `None` if disabled.
+
+### 18.10.6 Security Properties
+
+- **Localhost binding** prevents remote access. Combined with bearer token authentication, this provides defense-in-depth against SSRF attacks (a compromised service on the same machine still needs the token).
+- **No private key material** is exposed through any endpoint. The identity endpoint returns the DID string and DID document (public information).
+- **No message content** is exposed. The relay status endpoint shows connection and blob counts, not blob contents.
+- **Production default: disabled.** The dev API is opt-in via `local_api()`. Deployments that do not call this method have zero additional attack surface.
+- **Separate port** from the public HTTPS listener. Reverse proxy configurations that forward to the public port never accidentally expose the dev API.
+
+## 18.11 HTTP Broadcast Projection
+
+Broadcast contexts (§5.14) distribute content to unlimited audiences using per-author AES-256 keys instead of MLS group encryption. The content is encrypted on the wire but intended for broad consumption — subscribers decrypt using the author's broadcast key. HTTP broadcast projection decrypts and re-serves this content over standard HTTP, enabling CDN distribution, web readers, RSS aggregation, search engine crawling, and monitoring dashboards.
+
+### 18.11.1 Design Rationale
+
+Projection is **author-side only**. The relay cannot decrypt broadcast content (§9.9.1 — relays are untrusted dumb pipes that see only encrypted blobs). The author's `ApplicationNode` holds the broadcast keys and is the only entity that can decrypt its own broadcast content for HTTP serving.
+
+Use cases:
+
+- **Web readers:** Standard browsers render broadcast content without SCP client software.
+- **CDN distribution:** Immutable per-message endpoints are CDN-friendly (infinite cache TTL).
+- **RSS/Atom feeds:** Feed readers poll the feed endpoint.
+- **Search engine crawling:** Crawlers index projected content.
+- **Monitoring:** HTTP health checks and content verification dashboards.
+
+Subscriber-side projection is deliberately not supported — it would allow subscribers to redistribute content via HTTP without the author's control or knowledge.
+
+### 18.11.2 Activation
+
+Projection is opt-in per context:
+
+```rust
+node.enable_broadcast_projection(context_id, broadcast_key).await;
+```
+
+Projected content is served at:
+
+- **Feed:** `GET /scp/broadcast/<routing_id_hex>/feed`
+- **Per-message:** `GET /scp/broadcast/<routing_id_hex>/messages/<blob_id_hex>`
+
+Where `routing_id = SHA-256(context_id)` — this value is already public per §5.14.6 (used as the relay routing key for broadcast contexts). Exposing it in the URL path discloses no new information.
+
+Projection is disabled per context via:
+
+```rust
+node.disable_broadcast_projection(context_id).await;
+```
+
+### 18.11.3 Feed Endpoint
+
+`GET /scp/broadcast/<routing_id>/feed`
+
+Returns the most recent messages in the broadcast context, decrypted and serialized as JSON:
+
+```json
+{
+  "context_id": "<hex>",
+  "author_did": "did:dht:...",
+  "messages": [
+    {
+      "id": "<blob_id_hex>",
+      "author_did": "did:dht:...",
+      "key_epoch": 42,
+      "published_at": "2025-01-15T10:30:00Z",
+      "content": "<base64-encoded decrypted content>"
+    }
+  ]
+}
+```
+
+Query parameters:
+
+- `?since=<blob_id>` — return messages after the specified blob ID (exclusive).
+- `?limit=N` — maximum number of messages to return. Default: 20, maximum: 100.
+
+Caching headers:
+
+- `Cache-Control: public, max-age=30, stale-while-revalidate=300` — content is public and changes as new messages arrive. 30-second freshness with 5-minute stale-while-revalidate gives CDNs useful cacheability without excessive staleness.
+- `ETag: "<latest_blob_id>"` — the ETag is the most recent blob ID in the response.
+
+### 18.11.4 Per-Message Endpoint
+
+`GET /scp/broadcast/<routing_id>/messages/<blob_id>`
+
+Returns a single decrypted message:
+
+```json
+{
+  "id": "<blob_id_hex>",
+  "author_did": "did:dht:...",
+  "key_epoch": 42,
+  "published_at": "2025-01-15T10:30:00Z",
+  "content": "<base64-encoded decrypted content>"
+}
+```
+
+Caching headers:
+
+- `Cache-Control: public, immutable, max-age=31536000` — individual messages are immutable once published. Aggressive CDN caching with 1-year TTL.
+- `ETag: "<blob_id>"` — the blob ID itself serves as a stable ETag.
+
+Conditional GET: if the client sends `If-None-Match: "<blob_id>"`, the server returns `304 Not Modified` with no body.
+
+### 18.11.5 Decryption Architecture
+
+A `ProjectedContext` registry maps `routing_id → BroadcastKey` (per epoch):
+
+1. On request: look up `routing_id` in the registry.
+2. Query `BlobStorage` for the requested blob(s) using the existing `query(routing_id, since, limit)` interface.
+3. Deserialize each blob as a `BroadcastEnvelope` (§5.14).
+4. Open with the epoch-matched `BroadcastKey` from the registry.
+5. Return decrypted content in the JSON response.
+
+The `BlobStorage` instance is shared between the relay server and the projection handlers via `Arc<dyn BlobStorage>`. This requires `RelayServer::new` to accept `Arc<B>` so the same storage instance can be passed to both the relay and the `NodeState` (see ADR-035 for the architectural change).
+
+Keys are retained per epoch for the blob TTL window. When a key epoch advances, the previous epoch's key remains available to decrypt blobs published under the old epoch until those blobs expire.
+
+### 18.11.6 Security Properties
+
+- **Author's own keys only.** The node holds the broadcast keys it created. It cannot project contexts it merely subscribes to.
+- **Read-only.** Projection endpoints serve content; they do not accept writes. The write path remains the SCP protocol (MLS or broadcast envelope).
+- **Public endpoint.** Broadcast content was intended for broad distribution (§5.14 design). The projection makes already-public content accessible via HTTP without requiring SCP client software.
+- **No authentication on projection endpoints.** The content is public by design. Operators wanting access control can place a reverse proxy with authentication in front of the projection endpoints.
+- **`routing_id` is not new disclosure.** The `routing_id = SHA-256(context_id)` is already visible to relays (§5.14.6). Using it in URL paths reveals nothing beyond what relays already observe.
+
+### 18.11.7 `scp://` URI Integration
+
+When broadcast projection is enabled for a context, the `scp://` URI (§18.4) gains an optional `projection` query parameter pointing to the HTTP feed URL:
+
+```
+scp://context/<context_id_hex>?relay=wss://example.com/scp/v1&projection=https://example.com/scp/broadcast/<routing_id_hex>/feed
+```
+
+This allows URI consumers to choose between the native SCP path (relay + broadcast key) and the HTTP projection path (standard GET request). The `projection` parameter is advisory — clients that support native SCP ignore it.
+
+### 18.11.8 SDK Surface
+
+- `ApplicationNode::enable_broadcast_projection(context_id, broadcast_key)` — activates HTTP projection for the specified broadcast context. Registers the context and key in the `ProjectedContext` registry.
+- `ApplicationNode::disable_broadcast_projection(context_id)` — deactivates HTTP projection for the specified context. Removes it from the registry. Existing CDN caches may continue serving stale content per their cache headers.
+- `ApplicationNode::broadcast_projection_router() -> axum::Router` — returns the projection router for composition. Served on the public HTTPS port alongside `.well-known/scp` and `/scp/v1`.


### PR DESCRIPTION
## Summary

- **§18.10 Local HTTP Control API** — localhost-bound REST API on `ApplicationNode` for debugging and local app integration. Bearer token auth, 7 endpoints under `/scp/dev/v1/`, separate port from public HTTPS.
- **§18.11 HTTP Broadcast Projection** — author-side decryption of broadcast content served over HTTP with CDN-friendly caching. Feed endpoint (30s TTL) + per-message endpoint (immutable, 1-year TTL, conditional GET).
- **ADR-035** — architectural decisions for both features, rejected alternatives, 16 acceptance criteria.
- **PRD `http-features.json`** — 2 gates, 8 stories (SCP-242 through SCP-249) with full dependency graph.

## Test plan

- [x] `python3.12 scripts/validate-prd.py` passes (3 files, 203 stories)
- [x] Story IDs SCP-242–SCP-249 are globally unique (no conflicts with main.json or reachability.json)
- [x] All spec cross-references (§ and ADR-) point to real headings
- [x] All PRD sources reference existing files and section headings
- [x] No circular dependencies in story graph

🤖 Generated with [Claude Code](https://claude.com/claude-code)