### PR TITLE
fix(security): gate did:key hex format in scp-core to test-only

### DIFF
--- a/.github/workflows/build-matrix.yml
+++ b/.github/workflows/build-matrix.yml
@@ -83,7 +83,7 @@ jobs:
       - name: Run tests (native targets only)
         if: >-
           matrix.target != 'aarch64-unknown-linux-gnu'
-        run: cargo test --release --target ${{ matrix.target }}
+        run: cargo test --release --target ${{ matrix.target }} --features scp-core/testing
 
       - name: Upload Rust artifacts
         uses: actions/upload-artifact@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,7 +51,7 @@ jobs:
           # in-memory custody code paths are lint-checked. Mobile production
           # builds (iOS XCFramework, Android .aar) MUST NOT enable this
           # feature. See GitHub issue #88.
-          cargo clippy --workspace --all-targets --features scp-ffi-uniffi/allow_in_memory_custody -- -D warnings
+          cargo clippy --workspace --all-targets --features scp-ffi-uniffi/allow_in_memory_custody,scp-core/testing -- -D warnings
 
   rust-test:
     needs: check-draft
@@ -81,7 +81,7 @@ jobs:
           # in-memory custody tests run. Mobile production builds (iOS
           # XCFramework, Android .aar) MUST NOT enable this feature.
           # See GitHub issue #88.
-          cargo nextest run --workspace --features scp-ffi-uniffi/allow_in_memory_custody
+          cargo nextest run --workspace --features scp-ffi-uniffi/allow_in_memory_custody,scp-core/testing
 
   rust-doc:
     needs: check-draft
@@ -97,8 +97,8 @@ jobs:
       - name: Run doc tests and build docs
         run: |
           export LD_LIBRARY_PATH="$(python3 -c 'import sysconfig; print(sysconfig.get_config_var("LIBDIR"))')${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}"
-          cargo test --workspace --doc --features scp-ffi-uniffi/allow_in_memory_custody
-          cargo doc --workspace --no-deps --features scp-ffi-uniffi/allow_in_memory_custody
+          cargo test --workspace --doc --features scp-ffi-uniffi/allow_in_memory_custody,scp-core/testing
+          cargo doc --workspace --no-deps --features scp-ffi-uniffi/allow_in_memory_custody,scp-core/testing
 
   rust-deny:
     needs: check-draft

--- a/crates/scp-core/Cargo.toml
+++ b/crates/scp-core/Cargo.toml
@@ -6,6 +6,12 @@ edition.workspace = true
 repository.workspace = true
 license.workspace = true
 
+[features]
+# Enables non-standard did:key:{hex} DID format acceptance. Only for
+# integration tests that run outside `#[cfg(test)]`. Production builds
+# must never enable this feature. See issue #128.
+testing = []
+
 [dependencies]
 openmls = { workspace = true }
 openmls_traits = { workspace = true }
@@ -41,6 +47,22 @@ scp-platform = { path = "../scp-platform", features = ["testing"] }
 openmls_basic_credential = { workspace = true, features = ["test-utils"] }
 proptest = "1"
 scp-media = { path = "../scp-media" }
+
+[[test]]
+name = "economy_integration"
+required-features = ["testing"]
+
+[[test]]
+name = "phase2_integration"
+required-features = ["testing"]
+
+[[test]]
+name = "phase5_integration"
+required-features = ["testing"]
+
+[[test]]
+name = "wasm_conformance"
+required-features = ["testing"]
 
 [lints]
 workspace = true

--- a/crates/scp-core/src/bridge/claiming.rs
+++ b/crates/scp-core/src/bridge/claiming.rs
@@ -171,9 +171,10 @@ pub struct ShadowClaimEvent {
 
 /// Extracts the Ed25519 public key bytes from a DID string.
 ///
-/// Supports:
-/// - `did:dht:z<z-base-32>` format (production).
-/// - `did:key:<hex>` format (testing).
+/// Supports `did:dht:z<z-base-32>` format (production). The `did:key:<hex>`
+/// test convenience format is only accepted when compiled with `#[cfg(test)]`
+/// or the `testing` feature to prevent non-standard DID acceptance in release
+/// builds. See: <https://github.com/limn-works/scp/issues/128>
 fn extract_public_key_from_did(did: &str) -> Result<[u8; 32], String> {
     // Support did:dht:z<z-base-32> format.
     if let Some(suffix) = did.strip_prefix("did:dht:z") {
@@ -185,7 +186,10 @@ fn extract_public_key_from_did(did: &str) -> Result<[u8; 32], String> {
         return Ok(bytes);
     }
 
-    // Support did:key:<hex> format for testing.
+    // did:key:{hex} is a non-standard test convenience. Gated behind the
+    // `testing` feature (or #[cfg(test)]) to prevent acceptance in release
+    // builds. See: https://github.com/limn-works/scp/issues/128
+    #[cfg(any(test, feature = "testing"))]
     if let Some(hex_str) = did.strip_prefix("did:key:") {
         let decoded = hex::decode(hex_str).map_err(|e| format!("hex decode error: {e}"))?;
         let bytes: [u8; 32] = decoded

--- a/crates/scp-core/src/event_log/tree.rs
+++ b/crates/scp-core/src/event_log/tree.rs
@@ -317,9 +317,10 @@ const fn event_type_tag(event_type: &EventType) -> u16 {
 
 /// Extracts the Ed25519 public key bytes from a DID string.
 ///
-/// For `did:dht:z<z-base-32>`, decodes the z-base-32 suffix. For test DIDs
-/// that embed raw hex (`did:key:<hex>`), decodes the hex. Returns an error
-/// if the DID format is unrecognized or decoding fails.
+/// Supports `did:dht:z<z-base-32>` format (production). The `did:key:<hex>`
+/// test convenience format is only accepted when compiled with `#[cfg(test)]`
+/// or the `testing` feature to prevent non-standard DID acceptance in release
+/// builds. See: <https://github.com/limn-works/scp/issues/128>
 fn extract_public_key_from_did(did: &str) -> Result<[u8; 32], String> {
     // Support did:dht:z<z-base-32> format.
     if let Some(suffix) = did.strip_prefix("did:dht:z") {
@@ -331,7 +332,10 @@ fn extract_public_key_from_did(did: &str) -> Result<[u8; 32], String> {
         return Ok(bytes);
     }
 
-    // Support did:key:<hex> format for testing.
+    // did:key:{hex} is a non-standard test convenience. Gated behind the
+    // `testing` feature (or #[cfg(test)]) to prevent acceptance in release
+    // builds. See: https://github.com/limn-works/scp/issues/128
+    #[cfg(any(test, feature = "testing"))]
     if let Some(hex_str) = did.strip_prefix("did:key:") {
         let decoded = hex::decode(hex_str).map_err(|e| format!("hex decode error: {e}"))?;
         let bytes: [u8; 32] = decoded


### PR DESCRIPTION
## Summary

- Gate `did:key:<hex>` DID acceptance in `scp-core`'s two `extract_public_key_from_did` functions behind `#[cfg(any(test, feature = "testing"))]`, matching the pattern already applied in `scp-ffi-common` by #179
- Add `testing` feature to `scp-core/Cargo.toml` with `required-features` on all four integration test targets (`economy_integration`, `phase2_integration`, `phase5_integration`, `wasm_conformance`)
- Update CI workflows (`ci.yml`, `build-matrix.yml`) to pass `scp-core/testing` feature during test, clippy, and doc-test runs

## Motivation

PR #179 gated `did:key:<hex>` acceptance in the FFI bridge layer (`scp-ffi-common`), but the underlying `scp-core` library functions still accepted the non-standard format unconditionally. An attacker using the Rust API directly (bypassing FFI) could present `did:key:` DIDs that would be accepted in production builds. This follow-up closes the remaining gap.

## Files changed

| File | Change |
|------|--------|
| `crates/scp-core/src/bridge/claiming.rs` | `#[cfg(any(test, feature = "testing"))]` on `did:key:` branch |
| `crates/scp-core/src/event_log/tree.rs` | `#[cfg(any(test, feature = "testing"))]` on `did:key:` branch |
| `crates/scp-core/Cargo.toml` | Add `[features] testing = []` + `[[test]] required-features` |
| `.github/workflows/ci.yml` | Add `scp-core/testing` to `--features` in clippy, nextest, doc-test |
| `.github/workflows/build-matrix.yml` | Add `scp-core/testing` to `--features` in release tests |

## Test plan

- [x] `cargo build -p scp-core --release` compiles without `testing` feature (production path rejects `did:key:`)
- [x] `cargo test --workspace --features scp-core/testing` passes all 3,602 tests
- [x] `cargo clippy -p scp-core --all-targets --features scp-core/testing -- -D warnings` clean
- [x] `cargo fmt --all -- --check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)