### PR TITLE
docs: fix remaining stale scp-ffi path references

### DIFF
--- a/.docs/architecture.md
+++ b/.docs/architecture.md
@@ -874,7 +874,7 @@ agent.invoke({"input": "Schedule a meeting with Bob"})
 **PyO3 bridge layer:**
 
 ```
-Python (scp_sdk/)              PyO3 (scp-ffi/pyo3/)         Rust (scp-core/)
+Python (scp_sdk/)              PyO3 (crates/scp-ffi/pyo3/)  Rust (scp-core/)
 
 scp.Identity.create()    →    py_identity_create()     →    Identity::create()
 scp.Context.create()     →    py_context_create()      →    ContextManager::create()
@@ -1025,7 +1025,7 @@ Deliverable: Two devices with full context lifecycle over real SCP relays.
 
 ```
 Build:
-  • scp-ffi/pyo3/ — PyO3 bridge layer
+  • crates/scp-ffi/pyo3/ — PyO3 bridge layer
   • bindings/python/ — Pythonic wrappers, async, type hints
   • scp-mcp/server.rs — SCP agent as MCP server
   • scp-mcp/client.rs — SCP agent as MCP client
@@ -1058,7 +1058,7 @@ Build:
   • scp-core/context/ — advanced memory scope policies (basic TTL enforcement is Phase 2)
   • scp-core/discovery/ — tool-interface discovery (§6.2.2)
   • scp-core/provenance/ — data provenance tagging
-  • scp-ffi/uniffi/ — UniFFI definitions (prepares Swift/Kotlin)
+  • crates/scp-ffi/uniffi/ — UniFFI definitions (prepares Swift/Kotlin)
   • bindings/typescript/ — TypeScript SDK (wasm-bindgen for browser, napi-rs for Node)
 
 Test:

--- a/.docs/scaffold/rust.md
+++ b/.docs/scaffold/rust.md
@@ -197,11 +197,11 @@ redb = "2"
 | `async-trait` | latest | scp-transport, scp-testing | Async trait support (BlobStore, TransportAdapter) |
 | `proptest` | 1.x | all crates (dev) | Property-based testing |
 | `scp-testing` | path | all crates (dev) | Network simulation harness, trait conformance macros (§16) |
-| `pyo3` | 0.23+ | scp-ffi/pyo3 | Python FFI |
-| `uniffi` | latest | scp-ffi/uniffi | Swift/Kotlin FFI |
-| `cbindgen` | latest | scp-ffi/cbindgen | C header generation |
-| `wasm-bindgen` | latest | scp-ffi/wasm | Browser WASM FFI |
-| `napi` | latest | scp-ffi/napi | Node/Bun native addon |
+| `pyo3` | 0.23+ | crates/scp-ffi/pyo3 | Python FFI |
+| `uniffi` | latest | crates/scp-ffi/uniffi | Swift/Kotlin FFI |
+| `cbindgen` | latest | crates/scp-ffi/cbindgen | C header generation |
+| `wasm-bindgen` | latest | crates/scp-ffi/wasm | Browser WASM FFI |
+| `napi` | latest | crates/scp-ffi/napi | Node/Bun native addon |
 
 ## Error Types
 

--- a/.docs/scaffold/shared.md
+++ b/.docs/scaffold/shared.md
@@ -36,7 +36,7 @@ bindings/
 | `scp-transport` | Transport trait + adapters. Native relay server/client. Multi-transport routing | tokio, tokio-tungstenite, futures |
 | `scp-platform` | Platform abstraction traits + in-memory testing adapters | ed25519-dalek, rand |
 | `scp-mcp` | MCP JSON-RPC server/client for tool exposition | serde_json, tokio, axum |
-| `scp-ffi/*` | Language-specific FFI bridges. Thin translation layers only — zero protocol logic | pyo3, uniffi, cbindgen, wasm-bindgen, napi-rs |
+| `crates/scp-ffi/*` | Language-specific FFI bridges. Thin translation layers only — zero protocol logic | pyo3, uniffi, cbindgen, wasm-bindgen, napi-rs |
 
 ## FFI Bridge Strategy
 
@@ -44,11 +44,11 @@ Three bridges serve eight languages:
 
 | Bridge | Crate | Target languages | Mechanism |
 |--------|-------|------------------|-----------|
-| **PyO3** | `scp-ffi/pyo3` | Python | Direct Rust-Python interop via `#[pyfunction]`/`#[pyclass]` |
-| **UniFFI** | `scp-ffi/uniffi` | Swift, Kotlin | Single UDL definition generates Swift + Kotlin bindings |
-| **cbindgen** | `scp-ffi/cbindgen` | Go, C#, Java | C ABI header → cgo, P/Invoke, JNA |
-| **wasm-bindgen** | `scp-ffi/wasm` | TypeScript (browser) | WASM module loaded in browser |
-| **napi-rs** | `scp-ffi/napi` | TypeScript (Bun/Node) | Native addon for server-side JS runtimes |
+| **PyO3** | `crates/scp-ffi/pyo3` | Python | Direct Rust-Python interop via `#[pyfunction]`/`#[pyclass]` |
+| **UniFFI** | `crates/scp-ffi/uniffi` | Swift, Kotlin | Single UDL definition generates Swift + Kotlin bindings |
+| **cbindgen** | `crates/scp-ffi/cbindgen` | Go, C#, Java | C ABI header → cgo, P/Invoke, JNA |
+| **wasm-bindgen** | `crates/scp-ffi/wasm` | TypeScript (browser) | WASM module loaded in browser |
+| **napi-rs** | `crates/scp-ffi/napi` | TypeScript (Bun/Node) | Native addon for server-side JS runtimes |
 
 Every FFI bridge crate:
 - Depends on `scp-core`, `scp-transport`, `scp-platform`

--- a/README.md
+++ b/README.md
@@ -398,13 +398,14 @@ Chain depth is capped at 3 hops (protocol default) to bound amplification. The a
 ### Crate architecture (Rust core)
 
 ```
-scp-core/          — Protocol engine (context, identity, trust, discovery managers)
-  store/           — ProtocolStore layer (thick), Storage trait (thin, 6 methods)
-scp-crypto/        — MLS (OpenMLS), UCAN (native impl), Merkle trees, HPKE, HKDF
-scp-transport/     — Transport adapter trait + SCP native relay adapter
-scp-relay/         — Reference relay implementation
-scp-ffi/           — UniFFI bindings (Swift, Kotlin), PyO3 (Python), wasm-bindgen (TS)
-scp-mcp/           — MCP server adapter (exposes SCP contexts as MCP tool surfaces)
+crates/
+  scp-core/          — Protocol engine (context, identity, trust, discovery managers)
+    store/           — ProtocolStore layer (thick), Storage trait (thin, 6 methods)
+  scp-crypto/        — MLS (OpenMLS), UCAN (native impl), Merkle trees, HPKE, HKDF
+  scp-transport/     — Transport adapter trait + SCP native relay adapter
+  scp-relay/         — Reference relay implementation
+  scp-ffi/           — UniFFI bindings (Swift, Kotlin), PyO3 (Python), wasm-bindgen (TS)
+  scp-mcp/           — MCP server adapter (exposes SCP contexts as MCP tool surfaces)
 ```
 
 **Storage:** MessagePack serialization with version envelopes. SQLite (bundled-sqlcipher) as universal default. BlobStore backends: SQLite, redb, PostgreSQL, S3-compatible.


### PR DESCRIPTION
## Summary
- Follow-up to #204, which fixed stale `scp-ffi/` paths in ADR files
- Fixes the same issue in `architecture.md`, `scaffold/shared.md`, `scaffold/rust.md`, and `README.md`
- Adds `crates/` prefix to all standalone `scp-ffi/` path references (inline text, table cells, build phase listings)
- Restructures the README crate architecture tree to show `crates/` as the root directory, matching the actual filesystem layout

## Files changed
- **README.md** — crate tree now rooted at `crates/` instead of bare crate names
- **.docs/architecture.md** — 3 inline path references fixed (PyO3 bridge diagram, Phase 3 build list, Phase 4 build list)
- **.docs/scaffold/shared.md** — 6 table cell references fixed (Crate Responsibilities + FFI Bridge Strategy tables)
- **.docs/scaffold/rust.md** — 5 table cell references fixed (Key Dependencies table)

## Test plan
- [x] Verified no stale standalone `scp-ffi/` references remain (only tree-structure entries correctly nested under `crates/` parent)
- [x] Verified all markdown table formatting is preserved

🤖 Generated with [Claude Code](https://claude.com/claude-code)