### PR TITLE
docs(security): document unsigned event limitation in MCP bridge

### DIFF
--- a/.docs/lessons/unsigned-event-mcp-bridge.md
+++ b/.docs/lessons/unsigned-event-mcp-bridge.md
@@ -1,0 +1,50 @@
+# Unsigned Events in MCP Bridge (PR #192 Follow-up)
+
+## Problem
+
+`FfiBridgeProvider::invoke_tool` in `crates/scp-ffi/src/mcp.rs` emits `ToolInvokedEvent` entries per ADR-010 criterion 3. These events are appended to the Merkle event log via `append_unsigned_event` — a variant that skips Ed25519 signature verification — because the signing key material is not accessible in the sync execution context.
+
+The root cause is a runtime constraint: `ContextProvider::invoke_tool` is called synchronously from within the tokio runtime. The `KeyCustody` signing trait is async. Calling `tokio::runtime::Runtime::block_on()` from inside a tokio worker thread panics with "Cannot block the current thread from within a runtime." There is no safe way to bridge from sync to async in this context without a dedicated signing thread or channel.
+
+## What Still Works
+
+Unsigned events still receive full chain validation:
+
+- **Sequence ordering** — the event's `sequence` must match the expected next index.
+- **Hash chain integrity** — `prev_hash` must match the last leaf hash (or genesis sentinel).
+- **Merkle commitment** — the event is serialized and hashed with the RFC 6962 `0x00` leaf domain prefix, producing the same leaf hash as a signed event with identical content.
+
+The event is durably committed to the append-only Merkle tree.
+
+## Security Limitation
+
+The `signature` field on these events is `Vec::new()` (empty). This means:
+
+- A compromised in-process attacker with write access to the `EventLog` could inject fabricated events (e.g., fake `ToolInvokedEvent` entries) that pass sequence and hash-chain validation but carry no cryptographic proof of origin.
+- External verifiers cannot distinguish between legitimate unsigned events and injected ones.
+- The threat surface is limited to in-process attackers because the `EventLog` is not network-accessible.
+
+## Current Mitigation
+
+- Only trusted in-process callers use `append_unsigned_event` (the MCP bridge and test code).
+- The call site in `mcp.rs` carries a `SECURITY: unsigned event` comment explaining the limitation.
+- The function's doc comment in `tree.rs` documents the threat model and migration plan.
+
+## Migration Plan (via SCP-214)
+
+When async FFI signing lands:
+
+1. Make `ContextProvider::invoke_tool` async, or introduce a signing channel/thread that can bridge sync-to-async without `block_on`.
+2. Obtain the actor's `KeyCustody` handle in the FFI bridge context.
+3. Sign the event via `KeyCustody::sign()` before appending.
+4. Replace `append_unsigned_event` call sites with `append` (the signed variant).
+5. Remove `append_unsigned_event` and its tests.
+
+## Files
+
+- `crates/scp-core/src/event_log/tree.rs` — `append_unsigned_event` function and doc comment
+- `crates/scp-ffi/src/mcp.rs` — `FfiBridgeProvider::invoke_tool`, Phase 3 (call site)
+
+## Lesson
+
+When an async signing interface meets a sync FFI boundary inside a tokio runtime, you cannot use `block_on` to bridge the gap. The options are: (a) make the FFI entry point async, (b) use a dedicated signing thread with a channel, or (c) skip signing with documented security trade-offs. Option (c) is acceptable as a temporary measure only when the threat model is limited to in-process attackers, the limitation is prominently documented, and a concrete migration path exists.

--- a/crates/scp-core/src/event_log/tree.rs
+++ b/crates/scp-core/src/event_log/tree.rs
@@ -95,16 +95,63 @@ pub fn append(log: &mut EventLog, event: &Event) -> Result<u64, EventLogError> {
     Ok(leaf_index)
 }
 
-/// Appends an event to the event log **without** signature verification.
+/// Appends an event to the event log **without** Ed25519 signature verification.
 ///
-/// Performs the same sequence and `prev_hash` checks as [`append`], but skips
-/// the Ed25519 signature verification step. Intended for trusted in-process
-/// callers (FFI bridge layers, testing) where the event source is the process
-/// itself and signing key material may not be available in the sync context.
+/// # Why this exists
 ///
-/// The event is still serialized and hashed with the RFC 6962 leaf domain
-/// prefix, so it produces the same leaf hash as a signed event with identical
-/// content would.
+/// The MCP FFI bridge (`crates/scp-ffi/src/mcp.rs`) calls
+/// `ContextProvider::invoke_tool` synchronously from within the tokio runtime.
+/// The `KeyCustody` signing trait is async, and calling `block_on` from inside
+/// the tokio runtime panics ("Cannot block the current thread from within a
+/// runtime"). Because signing key material cannot be accessed synchronously,
+/// events emitted from this path carry an empty signature (`Vec::new()`).
+///
+/// # What it still guarantees
+///
+/// - **Sequence ordering**: the event's `sequence` must match the expected next
+///   index, preventing out-of-order insertion.
+/// - **Hash chain integrity**: `prev_hash` must match the last leaf hash (or
+///   the genesis sentinel for the first event), preserving append-only ordering.
+/// - **Merkle commitment**: the event is serialized and hashed with the RFC 6962
+///   `0x00` leaf domain prefix, producing the same leaf hash as a signed event
+///   with identical content would. The event is committed to the Merkle tree.
+///
+/// # Security limitation
+///
+/// **Events appended through this function are NOT cryptographically signed.**
+/// The `signature` field is empty. This means:
+///
+/// - A compromised in-process attacker with write access to the `EventLog`
+///   could inject fabricated events (e.g., fake `ToolInvokedEvent` entries)
+///   that pass sequence and hash-chain validation but carry no proof of origin.
+/// - External verifiers cannot distinguish between legitimate unsigned events
+///   and injected ones — both have empty signatures.
+/// - The threat is limited to in-process attackers because the `EventLog` is
+///   not network-accessible and the calling code controls the event content.
+///
+/// # Threat model
+///
+/// Only **trusted in-process callers** should use this function. The caller
+/// must control the event content and the `EventLog` reference. Current
+/// legitimate callers:
+///
+/// - `FfiBridgeProvider::invoke_tool` in `crates/scp-ffi/src/mcp.rs`
+///   (emits `ToolInvokedEvent` per ADR-010 criterion 3)
+/// - Test code
+///
+/// # Migration plan
+///
+/// When async FFI is available (SCP-214 wires `KeyCustodyProvider` into all
+/// bridges), this function should be replaced by calls to [`append`] with
+/// properly signed events. The migration path:
+///
+/// 1. Make `ContextProvider::invoke_tool` async (or use a signing channel).
+/// 2. Obtain the actor's `KeyCustody` handle in the FFI bridge.
+/// 3. Sign the event via `KeyCustody::sign()` before appending.
+/// 4. Replace all `append_unsigned_event` call sites with [`append`].
+/// 5. Remove this function and its tests.
+///
+/// See `.docs/lessons/unsigned-event-mcp-bridge.md` for the full writeup.
 ///
 /// # Errors
 ///

--- a/crates/scp-ffi/src/mcp.rs
+++ b/crates/scp-ffi/src/mcp.rs
@@ -777,11 +777,16 @@ impl ContextProvider for FfiBridgeProvider {
         };
 
         // Phase 3: Append ToolInvokedEvent to the event log (ADR-010
-        // criterion 3). Uses append_unsigned_event because signing key
-        // material is not available in this sync context
-        // (ContextProvider::invoke_tool is called from within the tokio
-        // runtime, preventing block_on for async custody signing). The event
-        // is still recorded in the Merkle tree with full provenance metadata.
+        // criterion 3).
+        //
+        // SECURITY: unsigned event — uses `append_unsigned_event` because
+        // `KeyCustody::sign()` is async and we are inside the tokio runtime
+        // (block_on would panic). The event is chain-validated and Merkle-
+        // committed but carries an empty signature. A compromised in-process
+        // caller could inject fake ToolInvokedEvent entries. Migrate to signed
+        // events via `append` once async FFI signing lands (SCP-214).
+        // See: crates/scp-core/src/event_log/tree.rs::append_unsigned_event
+        // See: .docs/lessons/unsigned-event-mcp-bridge.md
         #[allow(clippy::cast_possible_truncation)]
         let elapsed_ms = {
             let millis = start.elapsed().as_millis();


### PR DESCRIPTION
## Summary

- Expands the doc comment on `append_unsigned_event` in `crates/scp-core/src/event_log/tree.rs` with comprehensive documentation: why it exists, the security limitation, threat model, and migration plan
- Adds `SECURITY: unsigned event` callout comment at the call site in `crates/scp-ffi/src/mcp.rs`
- Adds `.docs/lessons/unsigned-event-mcp-bridge.md` with full writeup of the limitation and resolution path

## Context

`append_unsigned_event` was introduced in PR #192 to emit `ToolInvokedEvent` entries from `FfiBridgeProvider::invoke_tool`. The function skips Ed25519 signatures because the MCP FFI context is sync — `KeyCustody::sign()` is async, and calling `block_on` from inside the tokio runtime panics. Events are chain-validated and Merkle-committed but carry empty signatures, meaning a compromised in-process attacker could inject fake entries.

The migration path is via SCP-214 (wire `KeyCustodyProvider` into all FFI bridges), which will enable signed events through `append`.

## Test plan

- [x] `cargo test -p scp-core --lib event_log::tree` — all 15 tests pass
- [x] `cargo check -p scp-ffi` — compiles clean
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)