### PR TITLE
docs(event-log): fix misleading leaf hash claim in append_unsigned_event

### DIFF
--- a/crates/scp-core/src/event_log/tree.rs
+++ b/crates/scp-core/src/event_log/tree.rs
@@ -112,9 +112,10 @@ pub fn append(log: &mut EventLog, event: &Event) -> Result<u64, EventLogError> {
 ///   index, preventing out-of-order insertion.
 /// - **Hash chain integrity**: `prev_hash` must match the last leaf hash (or
 ///   the genesis sentinel for the first event), preserving append-only ordering.
-/// - **Merkle commitment**: the event is serialized and hashed with the RFC 6962
-///   `0x00` leaf domain prefix, producing the same leaf hash as a signed event
-///   with identical content would. The event is committed to the Merkle tree.
+/// - **Merkle commitment**: the event is serialized and hashed with the same
+///   RFC 6962 `0x00` leaf domain prefix mechanism used by [`append`], but the
+///   empty signature means leaf hashes will differ from equivalent signed
+///   events. The event is committed to the Merkle tree.
 ///
 /// # Security limitation
 ///


### PR DESCRIPTION
## Summary

- Corrects wording in the `append_unsigned_event` doc comment that incorrectly claimed unsigned and signed events produce identical leaf hashes
- The `serialize_event_for_hashing` function includes the signature field in rmp_serde serialization, so an empty signature (`Vec::new()`) produces different serialized bytes than a 64-byte Ed25519 signature
- Updated to accurately state that the same RFC 6962 hashing **mechanism** is used, but leaf hashes will differ

## Test plan

- [x] `cargo clippy -p scp-core --all-targets` passes cleanly
- Doc-only change; no behavioral impact

🤖 Generated with [Claude Code](https://claude.com/claude-code)