### PR TITLE
test(event-log): add Ed25519 verification tests to prevent divergence

### DIFF
--- a/crates/scp-event-log/src/crypto.rs
+++ b/crates/scp-event-log/src/crypto.rs
@@ -35,3 +35,122 @@ pub fn verify_ed25519_signature(
         .verify(message, &sig)
         .map_err(|e| format!("signature verification failed: {e}"))
 }
+
+// ---------------------------------------------------------------------------
+// Tests — mirrors scp-core::crypto::ed25519 tests to prevent silent divergence
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used, clippy::panic)]
+mod tests {
+    use ed25519_dalek::Signer;
+
+    use super::*;
+
+    fn test_keypair() -> (ed25519_dalek::VerifyingKey, ed25519_dalek::SigningKey) {
+        let mut rng = rand::thread_rng();
+        let signing_key = ed25519_dalek::SigningKey::generate(&mut rng);
+        let verifying_key = signing_key.verifying_key();
+        (verifying_key, signing_key)
+    }
+
+    #[test]
+    fn valid_signature_verifies() {
+        let (vk, sk) = test_keypair();
+        let message = b"hello SCP";
+        let sig = sk.sign(message);
+
+        let result = verify_ed25519_signature(vk.as_bytes(), message, &sig.to_bytes());
+        assert!(result.is_ok(), "expected Ok, got {result:?}");
+    }
+
+    #[test]
+    fn tampered_signature_rejected() {
+        let (vk, sk) = test_keypair();
+        let message = b"hello SCP";
+        let sig = sk.sign(message);
+        let mut sig_bytes = sig.to_bytes();
+        sig_bytes[0] ^= 0xff;
+
+        let result = verify_ed25519_signature(vk.as_bytes(), message, &sig_bytes);
+        assert!(result.is_err());
+        assert!(
+            result
+                .unwrap_err()
+                .contains("signature verification failed"),
+            "unexpected error message"
+        );
+    }
+
+    #[test]
+    fn wrong_key_rejected() {
+        let (_, sk) = test_keypair();
+        let (other_vk, _) = test_keypair();
+        let message = b"hello SCP";
+        let sig = sk.sign(message);
+
+        let result = verify_ed25519_signature(other_vk.as_bytes(), message, &sig.to_bytes());
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn wrong_message_rejected() {
+        let (vk, sk) = test_keypair();
+        let sig = sk.sign(b"original message");
+
+        let result =
+            verify_ed25519_signature(vk.as_bytes(), b"different message", &sig.to_bytes());
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn short_public_key_rejected() {
+        let result = verify_ed25519_signature(&[0u8; 16], b"msg", &[0u8; 64]);
+        assert!(result.is_err());
+        assert!(
+            result.unwrap_err().contains("public key must be 32 bytes"),
+            "unexpected error message"
+        );
+    }
+
+    #[test]
+    fn short_signature_rejected() {
+        let (vk, _) = test_keypair();
+        let result = verify_ed25519_signature(vk.as_bytes(), b"msg", &[0u8; 32]);
+        assert!(result.is_err());
+        assert!(
+            result.unwrap_err().contains("signature must be 64 bytes"),
+            "unexpected error message"
+        );
+    }
+
+    #[test]
+    fn empty_public_key_rejected() {
+        let result = verify_ed25519_signature(&[], b"msg", &[0u8; 64]);
+        assert!(result.is_err());
+        assert!(
+            result.unwrap_err().contains("public key must be 32 bytes"),
+            "unexpected error message"
+        );
+    }
+
+    #[test]
+    fn empty_signature_rejected() {
+        let (vk, _) = test_keypair();
+        let result = verify_ed25519_signature(vk.as_bytes(), b"msg", &[]);
+        assert!(result.is_err());
+        assert!(
+            result.unwrap_err().contains("signature must be 64 bytes"),
+            "unexpected error message"
+        );
+    }
+
+    #[test]
+    fn empty_message_works() {
+        let (vk, sk) = test_keypair();
+        let sig = sk.sign(b"");
+
+        let result = verify_ed25519_signature(vk.as_bytes(), b"", &sig.to_bytes());
+        assert!(result.is_ok());
+    }
+}


### PR DESCRIPTION
## Summary
- The duplicated `verify_ed25519_signature` in `scp-event-log/src/crypto.rs` had **zero tests** while the original in `scp-core/src/crypto/ed25519.rs` has 7
- Adds 9 tests mirroring the scp-core test suite plus two additional edge cases (empty key, empty signature)
- Prevents silent behavioral divergence between the two copies

## Tests added
| Test | What it covers |
|------|---------------|
| `valid_signature_verifies` | Happy path — sign and verify |
| `tampered_signature_rejected` | Flipped bit in signature bytes |
| `wrong_key_rejected` | Valid sig, wrong verifying key |
| `wrong_message_rejected` | Valid sig, different message |
| `short_public_key_rejected` | 16-byte key → error message check |
| `short_signature_rejected` | 32-byte sig → error message check |
| `empty_public_key_rejected` | 0-byte key → error message check |
| `empty_signature_rejected` | 0-byte sig → error message check |
| `empty_message_works` | Empty message signs and verifies |

## Test plan
- [x] `cargo test -p scp-event-log` — 156 tests pass (was 147)
- [x] `cargo clippy -p scp-event-log --all-targets` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)