### PR TITLE
docs(event-log): fix incorrect serialize_event_for_hashing doc comment

### DIFF
--- a/crates/scp-event-log/src/tree.rs
+++ b/crates/scp-event-log/src/tree.rs
@@ -255,12 +255,11 @@ pub(crate) fn recompute_raw(log: &mut EventLog) {
 // Internal helpers
 // ---------------------------------------------------------------------------
 
-/// Serializes an event for hashing. The signature field is excluded from
-/// the hash computation to avoid circular dependency (the signature covers
-/// the serialized content, and the hash covers the serialized event).
+/// Serializes the full event (including signature) for Merkle leaf hashing.
 ///
-/// We serialize all fields except `signature` to produce a deterministic
-/// byte sequence for hashing.
+/// The leaf hash is a commitment to the complete, signed event. This is
+/// distinct from [`compute_event_canonical_hash`], which excludes the
+/// signature field to produce the message that gets signed.
 fn serialize_event_for_hashing(event: &Event) -> Result<Vec<u8>, EventLogError> {
     // We serialize the full event including signature for the leaf hash.
     // The leaf hash is a commitment to the complete event (including its


### PR DESCRIPTION
## Summary

- The doc comment on `serialize_event_for_hashing` in `crates/scp-event-log/src/tree.rs` claimed the signature field is excluded from hashing, but the implementation calls `rmp_serde::to_vec(event)` which serializes the full `Event` struct including the signature field.
- Rewrote the doc comment to accurately describe the behavior: the leaf hash is a commitment to the complete signed event. Added a cross-reference to `compute_event_canonical_hash`, which is the function that actually excludes the signature (for signing purposes).
- Pre-existing documentation bug found during PR #199 review.

## Test plan

- [x] `cargo clippy -p scp-event-log --all-targets` passes clean
- [ ] No behavioral change -- doc-only fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)