### PR TITLE
security(core): bind author_did and key_epoch as AAD in BroadcastEnvelope AES-256-GCM

### DIFF
--- a/crates/scp-core/src/crypto/sender_keys/broadcast.rs
+++ b/crates/scp-core/src/crypto/sender_keys/broadcast.rs
@@ -382,7 +382,11 @@ pub fn open_broadcast(
 // ---------------------------------------------------------------------------
 
 #[cfg(test)]
-#[allow(clippy::unwrap_used, clippy::expect_used, clippy::cast_possible_truncation)]
+#[allow(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    clippy::cast_possible_truncation
+)]
 mod tests {
     use super::*;
     use proptest::prelude::*;


### PR DESCRIPTION
## Summary

Binds `author_did` and `key_epoch` as Additional Authenticated Data (AAD) in the AES-256-GCM construction for `BroadcastEnvelope` (closes #228).

**Security fix:** Without AAD binding, a context member who possesses the broadcast key could forge attribution by swapping `author_did`/`key_epoch` fields on an encrypted envelope without detection. The AEAD tag now covers these cleartext metadata fields.

### AAD format

Length-prefixed binary: `[4-byte DID length (BE)][DID bytes][8-byte epoch (BE)]`

This canonical format avoids ambiguity from colons in DID strings (e.g., `did:dht:abc123`).

### Breaking change

This is a **breaking wire format change** — envelopes sealed before this commit cannot be opened after it. Acceptable for pre-1.0 protocol.

### Changes

- `build_broadcast_aad(author_did, key_epoch)` — constructs deterministic AAD bytes
- `seal_broadcast` — passes AAD to `Aes256Gcm::encrypt` via `Payload`
- `open_broadcast` — passes AAD to `Aes256Gcm::decrypt` via `Payload`
- Tests: tampered author_did, tampered key_epoch, both tampered, empty DID, colon-heavy DID, binary layout verification

closes #228