### PR TITLE
security(node): move bridge secret from query param to Authorization header

### DIFF
--- a/crates/scp-node/src/http.rs
+++ b/crates/scp-node/src/http.rs
@@ -68,9 +68,11 @@ pub struct NodeState<B: BlobStorage = InMemoryBlobStorage> {
     pub(crate) relay_addr: SocketAddr,
     /// Shared secret for authenticating internal bridge connections.
     ///
-    /// Generated at startup and included as a query parameter when the
-    /// axum handler connects to the internal relay. The relay validates
-    /// this token during the WebSocket handshake (defense-in-depth, #85).
+    /// Generated at startup and included as an `Authorization: Bearer`
+    /// header when the axum handler connects to the internal relay. The
+    /// relay validates this token during the WebSocket handshake
+    /// (defense-in-depth, #85). Moved from query parameter to header to
+    /// prevent leakage via server logs or error messages (#225).
     pub(crate) bridge_secret: [u8; 32],
     /// Bearer token for the dev API (`scp_local_token_<32 hex chars>`).
     ///
@@ -233,19 +235,44 @@ async fn ws_upgrade_handler<B: BlobStorage + 'static>(
 /// Bridges an axum WebSocket to the internal relay server.
 ///
 /// Connects to the relay at `relay_addr` with the bridge secret included
-/// as a `token` query parameter, then forwards frames in both directions
-/// until either side closes or the connection is idle for
+/// as an `Authorization: Bearer <hex>` header, then forwards frames in
+/// both directions until either side closes or the connection is idle for
 /// [`BRIDGE_IDLE_TIMEOUT`]. Sends explicit WebSocket close frames on
 /// both sides when the bridge terminates.
+///
+/// The secret is transmitted via HTTP header rather than query parameter
+/// to prevent leakage through server logs, error messages, or debug
+/// output (#225).
 ///
 /// The idle timeout resets only on data frames (Text/Binary), not on
 /// Ping/Pong control frames. This prevents an attacker from keeping
 /// connections alive indefinitely by sending pings without real data
 /// (#229).
 async fn relay_bridge(axum_ws: WebSocket, relay_addr: SocketAddr, bridge_secret: [u8; 32]) {
+    use tokio_tungstenite::tungstenite::client::IntoClientRequest;
+
     let token_hex = scp_transport::native::server::hex_encode_32(&bridge_secret);
-    let url = format!("ws://{relay_addr}/?token={token_hex}");
-    let relay_conn = tokio_tungstenite::connect_async(&url).await;
+    let url = format!("ws://{relay_addr}/");
+    let mut request = match url.into_client_request() {
+        Ok(r) => r,
+        Err(e) => {
+            tracing::error!(
+                addr = %relay_addr,
+                error = %e,
+                "failed to build WebSocket request for internal relay bridge"
+            );
+            return;
+        }
+    };
+    // Safety: the token is a 64-char lowercase hex string — always valid
+    // as an HTTP header value. `parse()` only fails on non-visible ASCII
+    // or control characters, which hex digits never contain.
+    let Ok(header_value) = format!("Bearer {token_hex}").parse() else {
+        tracing::error!("bridge token produced invalid HTTP header value");
+        return;
+    };
+    request.headers_mut().insert("Authorization", header_value);
+    let relay_conn = tokio_tungstenite::connect_async(request).await;
 
     let Ok((relay_ws, _)) = relay_conn else {
         tracing::error!(

--- a/crates/scp-node/src/lib.rs
+++ b/crates/scp-node/src/lib.rs
@@ -247,9 +247,10 @@ impl<S: Storage, B: BlobStorage> ApplicationNode<S, B> {
 
     /// Returns the hex-encoded bridge secret for the internal relay.
     ///
-    /// This is the token that must be included as a `token` query parameter
-    /// when connecting directly to the relay's bound address. Used by tests
-    /// that bypass the axum bridge layer.
+    /// This is the token that must be included as an
+    /// `Authorization: Bearer <hex>` header when connecting directly to
+    /// the relay's bound address. Used by tests that bypass the axum
+    /// bridge layer.
     ///
     /// **Security:** This value is a secret. Do not log or expose it.
     #[must_use]
@@ -1929,6 +1930,8 @@ mod tests {
 
     #[tokio::test]
     async fn relay_accepts_connections_with_valid_bridge_token() {
+        use tokio_tungstenite::tungstenite::client::IntoClientRequest;
+
         let node = test_builder()
             .bind_addr(SocketAddr::from(([127, 0, 0, 1], 0)))
             .build()
@@ -1938,9 +1941,13 @@ mod tests {
         let addr = node.relay().bound_addr();
         let token = node.bridge_token_hex();
 
-        // Connect with the bridge token (explicit `/` path before query).
-        let url = format!("ws://{addr}/?token={token}");
-        let connect_result = tokio_tungstenite::connect_async(&url).await;
+        // Connect with the bridge token in the Authorization header (#225).
+        let url = format!("ws://{addr}/");
+        let mut request = url.into_client_request().unwrap();
+        request
+            .headers_mut()
+            .insert("Authorization", format!("Bearer {token}").parse().unwrap());
+        let connect_result = tokio_tungstenite::connect_async(request).await;
 
         assert!(
             connect_result.is_ok(),
@@ -1959,8 +1966,8 @@ mod tests {
 
         let addr = node.relay().bound_addr();
 
-        // Connect without the bridge token — should be rejected.
-        let url = format!("ws://{addr}");
+        // Connect without the Authorization header — should be rejected.
+        let url = format!("ws://{addr}/");
         let connect_result = tokio_tungstenite::connect_async(&url).await;
 
         assert!(

--- a/crates/scp-node/tests/integration.rs
+++ b/crates/scp-node/tests/integration.rs
@@ -27,6 +27,24 @@ use scp_identity::{DidCache, DidMethod};
 use scp_node::{ApplicationNodeBuilder, TlsProvider};
 use scp_platform::testing::{InMemoryKeyCustody, InMemoryStorage};
 use scp_transport::native::protocol::{ClientMessage, RelayMessage};
+use tokio_tungstenite::tungstenite::client::IntoClientRequest;
+
+/// Builds a WebSocket client request to the relay with the bridge secret
+/// in an `Authorization: Bearer` header (instead of a query parameter).
+fn relay_request(
+    addr: SocketAddr,
+    token: &str,
+) -> tokio_tungstenite::tungstenite::http::Request<()> {
+    let url = format!("ws://{addr}/");
+    let mut request = url.into_client_request().expect("valid WS URL");
+    request.headers_mut().insert(
+        "Authorization",
+        format!("Bearer {token}")
+            .parse()
+            .expect("valid header value"),
+    );
+    request
+}
 
 /// Mock TLS provider that succeeds with a self-signed certificate.
 ///
@@ -131,8 +149,7 @@ async fn scenario1_node_build_publishes_did_and_serves_well_known() {
     // --- Assert: relay accepts WebSocket connections with bridge token ---
     let addr = node.relay().bound_addr();
     let token = node.bridge_token_hex();
-    let url = format!("ws://{addr}/?token={token}");
-    let (ws_stream, _) = tokio_tungstenite::connect_async(&url)
+    let (ws_stream, _) = tokio_tungstenite::connect_async(relay_request(addr, &token))
         .await
         .expect("relay should accept WebSocket connections with valid token");
     drop(ws_stream);
@@ -167,11 +184,10 @@ async fn scenario2_client_discovers_relay_via_well_known_and_subscribes() {
     // --- Step 2: Client connects to the relay ---
     // In a real scenario, the client would connect to the wss:// relay URL
     // from .well-known/scp. In tests, we connect to the local bound address
-    // with the bridge token.
+    // with the bridge token in the Authorization header.
     let relay_addr = node.relay().bound_addr();
     let token = node.bridge_token_hex();
-    let url = format!("ws://{relay_addr}/?token={token}");
-    let (ws_stream, _) = tokio_tungstenite::connect_async(&url)
+    let (ws_stream, _) = tokio_tungstenite::connect_async(relay_request(relay_addr, &token))
         .await
         .expect("should connect to relay");
     let (mut ws_sink, mut ws_source) = ws_stream.split();
@@ -210,8 +226,8 @@ async fn scenario2_client_discovers_relay_via_well_known_and_subscribes() {
     }
 
     // --- Step 5: Publish a message to the same routing_id ---
-    // Use a second WebSocket connection to publish (reuses the same token URL).
-    let (pub_stream, _) = tokio_tungstenite::connect_async(&url)
+    // Use a second WebSocket connection to publish.
+    let (pub_stream, _) = tokio_tungstenite::connect_async(relay_request(relay_addr, &token))
         .await
         .expect("publisher should connect with valid token");
     let (mut pub_sink, mut pub_source) = pub_stream.split();
@@ -301,11 +317,11 @@ async fn scenario3_client_discovers_relay_via_did_resolution() {
 
     // --- Step 3: Connect to the relay ---
     // In production the client would connect to the wss:// URL from the DID
-    // document. In tests we use the local relay address with the bridge token.
+    // document. In tests we use the local relay address with the bridge token
+    // in the Authorization header.
     let relay_addr = node.relay().bound_addr();
     let token = node.bridge_token_hex();
-    let url = format!("ws://{relay_addr}/?token={token}");
-    let (ws_stream, _) = tokio_tungstenite::connect_async(&url)
+    let (ws_stream, _) = tokio_tungstenite::connect_async(relay_request(relay_addr, &token))
         .await
         .expect("should connect to relay discovered via DID resolution");
     drop(ws_stream);
@@ -409,35 +425,32 @@ async fn scenario5_relay_rejects_connection_without_bridge_token() {
     let (node, _dht_client) = build_test_node().await;
     let addr = node.relay().bound_addr();
 
-    // Attempt 1: No token at all — should be rejected.
-    let url_no_token = format!("ws://{addr}");
+    // Attempt 1: No Authorization header at all — should be rejected.
+    let url_no_token = format!("ws://{addr}/");
     let result = tokio_tungstenite::connect_async(&url_no_token).await;
     assert!(
         result.is_err(),
         "relay should reject connections without a bridge token"
     );
 
-    // Attempt 2: Wrong token — should be rejected.
+    // Attempt 2: Wrong token in Authorization header — should be rejected.
     let wrong_token = "00".repeat(32);
-    let url_wrong_token = format!("ws://{addr}/?token={wrong_token}");
-    let result = tokio_tungstenite::connect_async(&url_wrong_token).await;
+    let result = tokio_tungstenite::connect_async(relay_request(addr, &wrong_token)).await;
     assert!(
         result.is_err(),
         "relay should reject connections with an invalid bridge token"
     );
 
-    // Attempt 3: Malformed token (too short) — should be rejected.
-    let url_short_token = format!("ws://{addr}/?token=abcd");
-    let result = tokio_tungstenite::connect_async(&url_short_token).await;
+    // Attempt 3: Malformed token (too short) in header — should be rejected.
+    let result = tokio_tungstenite::connect_async(relay_request(addr, "abcd")).await;
     assert!(
         result.is_err(),
         "relay should reject connections with a malformed bridge token"
     );
 
-    // Attempt 4: Correct token — should succeed.
+    // Attempt 4: Correct token in Authorization header — should succeed.
     let token = node.bridge_token_hex();
-    let url_valid = format!("ws://{addr}/?token={token}");
-    let (ws_stream, _) = tokio_tungstenite::connect_async(&url_valid)
+    let (ws_stream, _) = tokio_tungstenite::connect_async(relay_request(addr, &token))
         .await
         .expect("relay should accept connections with valid bridge token");
     drop(ws_stream);

--- a/crates/scp-transport/src/native/server.rs
+++ b/crates/scp-transport/src/native/server.rs
@@ -87,12 +87,14 @@ pub struct RelayConfig {
     pub delivery_jitter_ms: u64,
     /// Optional shared secret for authenticating internal bridge connections.
     ///
-    /// When set, the relay rejects any WebSocket upgrade whose URI does not
-    /// include a `token` query parameter matching this value (hex-encoded,
-    /// constant-time comparison). Used by [`ApplicationNode`] to prevent
-    /// unauthorized connections to the internal relay port.
+    /// When set, the relay rejects any WebSocket upgrade whose
+    /// `Authorization: Bearer <hex>` header does not match this value
+    /// (hex-encoded, constant-time comparison). Used by
+    /// [`ApplicationNode`] to prevent unauthorized connections to the
+    /// internal relay port.
     ///
-    /// See GitHub issue #85 for the threat model.
+    /// See GitHub issue #85 for the threat model and #225 for the
+    /// migration from query parameter to header.
     pub bridge_secret: Option<[u8; 32]>,
     /// Whether this relay supports the BRIDGE operation for symmetric NAT
     /// fallback (spec section 10.12.4). When `true`, the relay accepts
@@ -549,11 +551,14 @@ async fn check_publish_rate_limit(
 
 /// Callback for `accept_hdr_async` that validates the bridge secret.
 ///
-/// Extracts the `token` query parameter from the WebSocket upgrade URI,
+/// Extracts the token from the `Authorization: Bearer <hex>` header,
 /// hex-decodes it, and performs a constant-time comparison against the
 /// expected secret. Returns HTTP 403 on mismatch or missing token.
 ///
-/// The token is never included in error messages or logs to prevent leakage.
+/// The token is transmitted via HTTP header rather than query parameter
+/// to prevent leakage through server logs, error messages, or debug
+/// output (#225). The token value is never included in error messages
+/// or logs.
 struct BridgeSecretCallback {
     expected: [u8; 32],
 }
@@ -562,17 +567,16 @@ impl Callback for BridgeSecretCallback {
     fn on_request(self, request: &Request, response: Response) -> Result<Response, ErrorResponse> {
         use tokio_tungstenite::tungstenite::http::StatusCode;
 
-        let uri = request.uri();
-        let query = uri.query().unwrap_or("");
+        // Extract the `Authorization: Bearer <hex>` header.
+        let auth_header = request
+            .headers()
+            .get("Authorization")
+            .and_then(|v| v.to_str().ok());
 
-        // Parse the `token` parameter from the query string.
-        let provided_token = query.split('&').find_map(|pair| {
-            let (key, value) = pair.split_once('=')?;
-            if key == "token" { Some(value) } else { None }
-        });
+        let hex_token = auth_header.and_then(|v| v.strip_prefix("Bearer "));
 
-        let Some(hex_token) = provided_token else {
-            tracing::warn!("bridge connection rejected: missing token");
+        let Some(hex_token) = hex_token else {
+            tracing::warn!("bridge connection rejected: missing or malformed Authorization header");
             let mut err = ErrorResponse::new(None);
             *err.status_mut() = StatusCode::FORBIDDEN;
             return Err(err);
@@ -642,9 +646,10 @@ pub fn hex_encode_32(bytes: &[u8; 32]) -> String {
 /// Handles a single WebSocket connection.
 ///
 /// When `config.bridge_secret` is set, the WebSocket upgrade request must
-/// include a `token` query parameter whose hex-decoded value matches the
-/// secret (constant-time comparison). Connections without a valid token are
-/// rejected during the handshake — no protocol messages are exchanged.
+/// include an `Authorization: Bearer <hex>` header whose hex-decoded value
+/// matches the secret (constant-time comparison). Connections without a
+/// valid token are rejected during the handshake — no protocol messages
+/// are exchanged.
 // Relay handler passes through connection state; bundling into a struct
 // would add allocation overhead per-message with no readability gain.
 #[allow(clippy::too_many_arguments)]


### PR DESCRIPTION
## Summary

- Moves the bridge secret from a `?token=<hex>` WebSocket query parameter to an `Authorization: Bearer <hex>` HTTP header during the upgrade handshake
- Updates the relay-side `BridgeSecretCallback` to extract the token from the `Authorization` header instead of the URI query string
- Updates all tests (integration + unit) to use header-based authentication

## Motivation

Query parameters can leak through server access logs, error messages from tokio-tungstenite, and debug output. While the bridge is localhost-only (low risk), defense-in-depth dictates that secrets should not appear in URLs. HTTP headers are not logged by default and are not included in referrer headers or browser history.

## Changes

| File | Change |
|------|--------|
| `crates/scp-node/src/http.rs` | `relay_bridge()` builds an HTTP request with `Authorization: Bearer` header instead of `?token=` URL |
| `crates/scp-transport/src/native/server.rs` | `BridgeSecretCallback` reads `Authorization` header instead of query string |
| `crates/scp-node/src/lib.rs` | Updated doc comments + unit test |
| `crates/scp-node/tests/integration.rs` | Added `relay_request()` helper; updated all 6 test call sites |

## Test plan

- [x] All 377 tests pass (`cargo test -p scp-node -p scp-transport`)
- [x] Clippy clean (`cargo clippy -p scp-node -p scp-transport --all-targets -- -D warnings`)
- [x] `cargo fmt --all` applied
- [x] Scenario 5 test validates: no header rejected, wrong token rejected, malformed token rejected, valid token accepted

closes #225

:robot: Generated with [Claude Code](https://claude.com/claude-code)