### PR TITLE
refactor(node): wire ApplicationNode::storage() through ProtocolStore

### DIFF
--- a/crates/scp-node/src/lib.rs
+++ b/crates/scp-node/src/lib.rs
@@ -22,6 +22,7 @@ use std::net::SocketAddr;
 use std::sync::Arc;
 use std::time::Duration;
 
+use scp_core::store::ProtocolStore;
 use scp_identity::document::DidDocument;
 use scp_identity::{DidMethod, IdentityError, ScpIdentity};
 use scp_platform::traits::{KeyCustody, Storage};
@@ -205,8 +206,8 @@ pub struct ApplicationNode<S: Storage> {
     relay: RelayHandle,
     /// Handle to the node's identity.
     identity: IdentityHandle,
-    /// The storage backend.
-    storage: Arc<S>,
+    /// The protocol store wrapping the storage backend.
+    storage: Arc<ProtocolStore<S>>,
     /// Shared state for HTTP handlers (`.well-known/scp`, relay bridge).
     state: Arc<http::NodeState>,
     /// Handle to the periodic tier re-evaluation background task (§10.12.1, SCP-243).
@@ -256,9 +257,9 @@ impl<S: Storage> ApplicationNode<S> {
         &self.identity
     }
 
-    /// Returns a reference to the storage backend.
+    /// Returns a reference to the protocol store.
     #[must_use]
-    pub fn storage(&self) -> &S {
+    pub fn storage(&self) -> &ProtocolStore<S> {
         &self.storage
     }
 
@@ -1072,7 +1073,7 @@ pub struct ApplicationNodeBuilder<
 > {
     domain: Option<String>,
     identity_source: Option<IdentitySource<K, D>>,
-    storage: Option<Arc<S>>,
+    storage: Option<S>,
     blob_storage: Option<BlobStorageBackend>,
     bind_addr: Option<SocketAddr>,
     acme_email: Option<String>,
@@ -1442,7 +1443,7 @@ impl<K: KeyCustody + 'static, D: DidMethod + 'static, Dom, Id>
     /// If not called, `.build()` uses a default no-op storage.
     pub fn storage<S2: Storage + 'static>(
         self,
-        storage: Arc<S2>,
+        storage: S2,
     ) -> ApplicationNodeBuilder<K, D, S2, Dom, Id> {
         ApplicationNodeBuilder {
             domain: self.domain,
@@ -1594,7 +1595,7 @@ impl<K: KeyCustody + 'static, D: DidMethod + 'static, S: Storage + Default + 'st
         let identity_source = self
             .identity_source
             .ok_or(NodeError::MissingField("identity"))?;
-        let storage = self.storage.unwrap_or_else(|| Arc::new(S::default()));
+        let protocol_store = Arc::new(ProtocolStore::new(self.storage.unwrap_or_default()));
 
         let (identity, document, did_method) = resolve_identity(identity_source).await?;
         let bridge_secret = generate_bridge_secret();
@@ -1619,7 +1620,7 @@ impl<K: KeyCustody + 'static, D: DidMethod + 'static, S: Storage + Default + 'st
         let tls_provider = resolve_tls(
             self.tls_provider,
             &domain,
-            &storage,
+            &protocol_store,
             self.acme_email.as_ref(),
         );
         match tls_provider.provision().await {
@@ -1629,7 +1630,7 @@ impl<K: KeyCustody + 'static, D: DidMethod + 'static, S: Storage + Default + 'st
                     identity,
                     document,
                     did_method,
-                    storage,
+                    protocol_store,
                     shutdown_handle,
                     bound_addr,
                     bridge_secret,
@@ -1663,7 +1664,7 @@ impl<K: KeyCustody + 'static, D: DidMethod + 'static, S: Storage + Default + 'st
                     identity,
                     document,
                     did_method,
-                    storage,
+                    protocol_store,
                     shutdown_handle,
                     bound_addr,
                     strategy,
@@ -1746,7 +1747,7 @@ fn generate_dev_token(addr: SocketAddr) -> String {
 fn resolve_tls<S: Storage + 'static>(
     provider: Option<Arc<dyn TlsProvider>>,
     domain: &str,
-    storage: &Arc<S>,
+    storage: &Arc<ProtocolStore<S>>,
     acme_email: Option<&String>,
 ) -> Arc<dyn TlsProvider> {
     provider.unwrap_or_else(|| {
@@ -1793,7 +1794,7 @@ async fn build_domain_inner<D: DidMethod + 'static, S: Storage + 'static>(
     identity: ScpIdentity,
     mut document: DidDocument,
     did_method: Arc<D>,
-    storage: Arc<S>,
+    storage: Arc<ProtocolStore<S>>,
     shutdown_handle: ShutdownHandle,
     bound_addr: SocketAddr,
     bridge_secret: Zeroizing<[u8; 32]>,
@@ -1871,7 +1872,7 @@ async fn build_no_domain_inner<D: DidMethod + 'static, S: Storage + 'static>(
     identity: ScpIdentity,
     mut document: DidDocument,
     did_method: Arc<D>,
-    storage: Arc<S>,
+    storage: Arc<ProtocolStore<S>>,
     shutdown_handle: ShutdownHandle,
     bound_addr: SocketAddr,
     nat_strategy: Arc<dyn NatStrategy>,
@@ -2019,7 +2020,7 @@ impl<K: KeyCustody + 'static, D: DidMethod + 'static, S: Storage + Default + 'st
             .identity_source
             .ok_or(NodeError::MissingField("identity"))?;
 
-        let storage = self.storage.unwrap_or_else(|| Arc::new(S::default()));
+        let protocol_store = Arc::new(ProtocolStore::new(self.storage.unwrap_or_default()));
         let (identity, document, did_method) = resolve_identity(identity_source).await?;
 
         // 3. Start relay server.
@@ -2056,7 +2057,7 @@ impl<K: KeyCustody + 'static, D: DidMethod + 'static, S: Storage + Default + 'st
             identity,
             document,
             did_method,
-            storage,
+            protocol_store,
             shutdown_handle,
             bound_addr,
             strategy,
@@ -2359,7 +2360,7 @@ mod tests {
         let custody = Arc::new(InMemoryKeyCustody::new());
         let did_method = Arc::new(make_test_dht(&custody));
         ApplicationNodeBuilder::new()
-            .storage(Arc::new(InMemoryStorage::new()))
+            .storage(InMemoryStorage::new())
             .domain("test.example.com")
             .tls_provider(Arc::new(SucceedingTlsProvider {
                 domain: "test.example.com".to_owned(),
@@ -2717,7 +2718,7 @@ mod tests {
 
     #[tokio::test]
     async fn builder_with_custom_storage() {
-        let custom_storage = Arc::new(InMemoryStorage::new());
+        let custom_storage = InMemoryStorage::new();
         let custody = Arc::new(InMemoryKeyCustody::new());
         let did_method = Arc::new(make_test_dht(&custody));
 
@@ -2800,7 +2801,7 @@ mod tests {
         let custody = Arc::new(InMemoryKeyCustody::new());
         let did_method = Arc::new(make_test_dht(&custody));
         ApplicationNodeBuilder::new()
-            .storage(Arc::new(InMemoryStorage::new()))
+            .storage(InMemoryStorage::new())
             .no_domain()
             .nat_strategy(Arc::new(MockNatStrategy { tier }))
             .generate_identity_with(custody, did_method)
@@ -3006,7 +3007,7 @@ mod tests {
         let did_method = Arc::new(make_test_dht(&custody));
 
         let node = ApplicationNodeBuilder::new()
-            .storage(Arc::new(InMemoryStorage::new()))
+            .storage(InMemoryStorage::new())
             .domain("fail.example.com")
             .tls_provider(Arc::new(FailingTlsProvider))
             .nat_strategy(Arc::new(RecordingNatStrategy {
@@ -3060,7 +3061,7 @@ mod tests {
         let did_method = Arc::new(make_test_dht(&custody));
 
         let result = ApplicationNodeBuilder::new()
-            .storage(Arc::new(InMemoryStorage::new()))
+            .storage(InMemoryStorage::new())
             .no_domain()
             .nat_strategy(Arc::new(FailingNatStrategy))
             .generate_identity_with(custody, did_method)
@@ -3140,7 +3141,7 @@ mod tests {
         };
 
         let _node = ApplicationNodeBuilder::new()
-            .storage(Arc::new(InMemoryStorage::new()))
+            .storage(InMemoryStorage::new())
             .no_domain()
             .nat_strategy(Arc::new(MockNatStrategy { tier }))
             .generate_identity_with(custody, counting_method)

--- a/crates/scp-node/src/main.rs
+++ b/crates/scp-node/src/main.rs
@@ -237,7 +237,7 @@ async fn run_full_node() {
     );
 
     let mut builder = ApplicationNodeBuilder::new()
-        .storage(Arc::new(InMemoryStorage::new()))
+        .storage(InMemoryStorage::new())
         .domain(&domain)
         .generate_identity_with(custody, did_method)
         .bind_addr(SocketAddr::from(([127, 0, 0, 1], 0)))

--- a/crates/scp-node/src/tls.rs
+++ b/crates/scp-node/src/tls.rs
@@ -19,6 +19,7 @@ use std::time::Duration;
 
 use rustls::server::ResolvesServerCert;
 use rustls::sign::CertifiedKey;
+use scp_core::store::ProtocolStore;
 use scp_platform::traits::Storage;
 use tokio::sync::RwLock;
 use zeroize::Zeroizing;
@@ -359,8 +360,8 @@ impl ResolvesServerCert for CertResolver {
 pub struct AcmeProvider<S: Storage> {
     /// The domain to provision a certificate for.
     domain: String,
-    /// Platform storage for certificate persistence.
-    storage: Arc<S>,
+    /// Protocol store wrapping the platform storage backend.
+    storage: Arc<ProtocolStore<S>>,
     /// Optional contact email for the ACME account.
     email: Option<String>,
     /// ACME directory URL (defaults to Let's Encrypt production).
@@ -385,7 +386,7 @@ impl<S: Storage + 'static> AcmeProvider<S> {
     /// Uses the Let's Encrypt production directory by default. Call
     /// [`with_directory_url`](Self::with_directory_url) to change.
     #[must_use]
-    pub fn new(domain: &str, storage: Arc<S>) -> Self {
+    pub fn new(domain: &str, storage: Arc<ProtocolStore<S>>) -> Self {
         Self {
             domain: domain.to_owned(),
             storage,
@@ -518,7 +519,7 @@ impl<S: Storage + 'static> AcmeProvider<S> {
         };
 
         // 8. Store in platform storage.
-        store_certificate(&*self.storage, &cert_data).await?;
+        store_certificate(self.storage.storage(), &cert_data).await?;
 
         tracing::info!(domain = %self.domain, "TLS certificate provisioned via ACME");
 
@@ -532,7 +533,7 @@ impl<S: Storage + 'static> AcmeProvider<S> {
     ///
     /// Returns [`TlsError`] if loading, provisioning, or storage fails.
     pub async fn load_or_provision(&self) -> Result<CertificateData, TlsError> {
-        if let Some(cert_data) = load_certificate(&*self.storage).await? {
+        if let Some(cert_data) = load_certificate(self.storage.storage()).await? {
             if !cert_data.needs_renewal()? {
                 tracing::info!(domain = %self.domain, "loaded existing TLS certificate from storage");
                 return Ok(cert_data);
@@ -557,7 +558,7 @@ impl<S: Storage + 'static> AcmeProvider<S> {
             loop {
                 tokio::time::sleep(RENEWAL_CHECK_INTERVAL).await;
 
-                match load_certificate(&*self.storage).await {
+                match load_certificate(self.storage.storage()).await {
                     Ok(Some(cert_data)) => match cert_data.needs_renewal() {
                         Ok(true) => {
                             tracing::info!(
@@ -1054,7 +1055,7 @@ mod tests {
 
     #[test]
     fn acme_provider_new_sets_defaults() {
-        let storage = Arc::new(InMemoryStorage::new());
+        let storage = Arc::new(ProtocolStore::new(InMemoryStorage::new()));
         let provider = AcmeProvider::new("example.com", storage);
 
         assert_eq!(provider.domain, "example.com");
@@ -1064,7 +1065,7 @@ mod tests {
 
     #[test]
     fn acme_provider_with_email() {
-        let storage = Arc::new(InMemoryStorage::new());
+        let storage = Arc::new(ProtocolStore::new(InMemoryStorage::new()));
         let provider = AcmeProvider::new("example.com", storage).with_email("admin@example.com");
 
         assert_eq!(provider.email.as_deref(), Some("admin@example.com"));
@@ -1072,7 +1073,7 @@ mod tests {
 
     #[test]
     fn acme_provider_with_directory_url() {
-        let storage = Arc::new(InMemoryStorage::new());
+        let storage = Arc::new(ProtocolStore::new(InMemoryStorage::new()));
         let provider = AcmeProvider::new("example.com", storage)
             .with_directory_url("https://acme-staging-v02.api.letsencrypt.org/directory");
 
@@ -1081,7 +1082,7 @@ mod tests {
 
     #[test]
     fn acme_provider_with_cert_resolver() {
-        let storage = Arc::new(InMemoryStorage::new());
+        let storage = Arc::new(ProtocolStore::new(InMemoryStorage::new()));
         let cert = generate_self_signed("example.com").unwrap();
         let certs = cert.certificate_chain_der().unwrap();
         let key = cert.private_key_der().unwrap();

--- a/crates/scp-node/tests/integration.rs
+++ b/crates/scp-node/tests/integration.rs
@@ -94,7 +94,7 @@ async fn build_test_node() -> (
     let (dht_client, did_dht) = make_shared_dht(&custody);
 
     let node = ApplicationNodeBuilder::new()
-        .storage(Arc::new(InMemoryStorage::new()))
+        .storage(InMemoryStorage::new())
         .domain("test.example.com")
         .tls_provider(Arc::new(SucceedingTlsProvider {
             domain: "test.example.com".to_owned(),
@@ -470,7 +470,7 @@ async fn build_test_node_with_dev_api() -> (
     let (dht_client, did_dht) = make_shared_dht(&custody);
 
     let node = ApplicationNodeBuilder::new()
-        .storage(Arc::new(InMemoryStorage::new()))
+        .storage(InMemoryStorage::new())
         .domain("test.example.com")
         .tls_provider(Arc::new(SucceedingTlsProvider {
             domain: "test.example.com".to_owned(),


### PR DESCRIPTION
## Summary

- `ApplicationNode` now holds `Arc<ProtocolStore<S>>` instead of `Arc<S>`
- Builder accepts `S` directly (not `Arc<S>`), wraps in `ProtocolStore::new()` at build time
- `ApplicationNode::storage()` returns `&ProtocolStore<S>`, exposing typed domain methods
- `AcmeProvider` follows the same pattern, accessing raw storage via `ProtocolStore::storage()`

## Motivation

PR #277 surfaced spec drift: the public API exposed `&S` (raw storage backend) but `ProtocolStore<S>` (spec §17.4, SCP-222) is fully implemented. Callers should get typed domain methods directly. The ownership restructure follows the standard Rust wrapper pattern (`BufReader<R>` owns `R`) — single `Arc` at the sharing boundary, no double-wrapping.

## Changes

| File | Change |
|------|--------|
| `crates/scp-node/src/lib.rs` | Builder field `Option<Arc<S>>` → `Option<S>`, node field `Arc<S>` → `Arc<ProtocolStore<S>>`, accessor returns `&ProtocolStore<S>`, both build paths updated |
| `crates/scp-node/src/tls.rs` | `AcmeProvider` field/constructor take `Arc<ProtocolStore<S>>`, raw access via `.storage()` |
| `crates/scp-node/src/main.rs` | Builder call site updated |
| `crates/scp-node/tests/integration.rs` | Test call sites updated |

## Test plan

- [x] `cargo test -p scp-node` — 149 tests pass (139 unit + 10 integration)
- [x] `cargo clippy --workspace --all-targets --features scp-ffi-uniffi/allow_in_memory_custody,scp-core/testing` — zero warnings
- [x] `cargo fmt --all -- --check` — clean

closes #280

🤖 Generated with [Claude Code](https://claude.com/claude-code)