### PR TITLE
fix(security): UniFFI UCAN enforcement + BroadcastEnvelope deny_unknown_fields

### DIFF
--- a/crates/scp-core/src/crypto/sender_keys/broadcast.rs
+++ b/crates/scp-core/src/crypto/sender_keys/broadcast.rs
@@ -166,6 +166,7 @@ pub struct BroadcastKeyEpochAdvance {
 ///
 /// [`encrypt_sender_layer`]: super::encrypt::encrypt_sender_layer
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct BroadcastEnvelope {
     /// Protocol version (§13.2.2). SCP/1.0 = `0x0100`.
     /// Part of the signature commitment.
@@ -1410,6 +1411,35 @@ mod tests {
         assert!(
             err.contains("exceeds"),
             "error should mention size limit: {err}"
+        );
+    }
+
+    // -----------------------------------------------------------------------
+    // deny_unknown_fields defense (#427 item 4)
+    // -----------------------------------------------------------------------
+
+    #[test]
+    #[allow(clippy::unwrap_used)]
+    fn broadcast_envelope_rejects_unknown_fields() {
+        // BroadcastEnvelope has #[serde(deny_unknown_fields)] (#427 item 4).
+        // Verify that injecting an unknown field into MessagePack is rejected
+        // during deserialization. We build a valid envelope, serialize it to
+        // a serde_json::Value map, inject the extra field, then deserialize
+        // back. JSON round-trips through the custom serde modules correctly.
+        let key = generate_broadcast_key("did:dht:deny-test");
+        let envelope = test_seal(&key, b"deny-test-payload");
+
+        // Serialize to JSON Value (all custom serde modules support JSON).
+        let mut map: serde_json::Map<String, serde_json::Value> =
+            serde_json::from_value(serde_json::to_value(&envelope).unwrap()).unwrap();
+        map.insert("evil_extra_field".into(), "malicious".into());
+
+        let result = serde_json::from_value::<BroadcastEnvelope>(serde_json::Value::Object(map));
+        assert!(result.is_err(), "deny_unknown_fields must reject unknown keys");
+        let err = result.unwrap_err().to_string();
+        assert!(
+            err.contains("unknown field"),
+            "error should mention unknown field: {err}"
         );
     }
 

--- a/crates/scp-ffi/uniffi/src/bridge.rs
+++ b/crates/scp-ffi/uniffi/src/bridge.rs
@@ -2518,9 +2518,17 @@ pub async fn tool_invoke(
         .spawn(async move {
             validate_tool_id(&tool_id)?;
             validate_did(&identity.did)?;
-            if let Some(ref token) = ucan_token {
-                validate_ucan_token(token)?;
-            }
+
+            // UCAN token is mandatory for tool invocation — all bridges
+            // enforce this. Reject early if missing (§6.2, ADR-016, #423).
+            let ucan_token = ucan_token.ok_or_else(|| ScpError::Permission {
+                message: "UCAN token is required for tool invocation — \
+                          pass a valid JWT-encoded UCAN with tool_invoke:{tool_id} \
+                          or tool_invoke:* capability"
+                    .to_owned(),
+                code: "SCP-PERM-3001".to_owned(),
+            })?;
+            validate_ucan_token(&ucan_token)?;
 
             let state = handle.state.lock().await;
 
@@ -2537,15 +2545,13 @@ pub async fn tool_invoke(
 
             // Primary authorization: UCAN token validation via the full 11-step
             // ADR-016 pipeline. See spec §6.2, §8, ADR-016, and issue #319.
-            if let Some(ref token) = ucan_token {
-                validate_tool_ucan_uniffi(
-                    &handle,
-                    &tool_id,
-                    token,
-                    &identity.did,
-                    proof_tokens.as_ref(),
-                )?;
-            }
+            validate_tool_ucan_uniffi(
+                &handle,
+                &tool_id,
+                &ucan_token,
+                &identity.did,
+                proof_tokens.as_ref(),
+            )?;
 
             let registry = handle.tool_registry.lock().await;
             let registration = registry.get(&tool_id).ok_or_else(|| ScpError::Tool {
@@ -5221,4 +5227,70 @@ pub fn discovery_create_query(
 #[must_use]
 pub fn discovery_normalize_address(address: String) -> String {
     scp_core::discovery::normalize_address(&address)
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used, clippy::panic)]
+mod tests {
+    use super::*;
+
+    fn test_handle() -> Arc<ContextHandle> {
+        Arc::new(ContextHandle {
+            context_id: "ctx-test".to_owned(),
+            state: tokio::sync::Mutex::new(ContextState::Active),
+            creator_did: "did:dht:z6MkTestUser".to_owned(),
+            #[cfg(feature = "allow_in_memory_custody")]
+            in_memory_custody: None,
+            callback_custody: None,
+            signing_key: None,
+            ceiling_strings: Vec::new(),
+            tool_registry: tokio::sync::Mutex::new(
+                scp_core::context::tools::ToolRegistry::new(),
+            ),
+            tool_handlers: tokio::sync::Mutex::new(std::collections::HashMap::new()),
+            session_store: tokio::sync::Mutex::new(
+                scp_core::context::tools::SessionStore::new(),
+            ),
+        })
+    }
+
+    fn test_identity() -> Arc<Identity> {
+        Arc::new(Identity {
+            did: "did:dht:z6MkTestUser".to_owned(),
+            custody_type: CustodyMethod::InMemory,
+            core_id: None,
+            core_document: None,
+            #[cfg(feature = "allow_in_memory_custody")]
+            in_memory_custody: None,
+            callback_custody: None,
+        })
+    }
+
+    /// `UniFFI` `tool_invoke` must reject `None` `ucan_token` with a
+    /// `Permission` error. Matches `PyO3`/NAPI behavior where the token
+    /// is a required non-optional parameter. See issue #423.
+    #[tokio::test]
+    async fn tool_invoke_rejects_none_ucan_token() {
+        let result = tool_invoke(
+            test_handle(),
+            "test-tool".to_owned(),
+            "{}".to_owned(),
+            test_identity(),
+            None, // No UCAN token
+            None,
+        )
+        .await;
+
+        let err = result.expect_err("None ucan_token must be rejected");
+        match err {
+            ScpError::Permission { ref code, .. } => {
+                assert_eq!(code, "SCP-PERM-3001");
+            }
+            other => panic!("expected ScpError::Permission, got {other:?}"),
+        }
+    }
 }


### PR DESCRIPTION
## Summary
- UniFFI `tool_invoke` now rejects `None` `ucan_token` with `ScpError::Permission` (SCP-PERM-3001), matching PyO3/NAPI behavior (§6.2, ADR-016)
- `BroadcastEnvelope` gains `#[serde(deny_unknown_fields)]` to reject injected fields during deserialization
- Tests for both: `tool_invoke_rejects_none_ucan_token` and `broadcast_envelope_rejects_unknown_fields`

## Issues
- Closes #423 (UniFFI tool_invoke must reject None ucan_token)
- Partially addresses #427 item 4 (deny_unknown_fields on BroadcastEnvelope)

## Test plan
- [x] `cargo test -p scp-core --lib crypto::sender_keys::broadcast::tests::broadcast_envelope_rejects_unknown_fields`
- [x] `cargo clippy --workspace --all-targets --features ...` clean
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)