### PR TITLE
fix: resolve 6 spec-drift and correctness issues (#406 #407 #409 #420 #429 #455)

### DIFF
--- a/.docs/specs/17-persistence-and-storage.md
+++ b/.docs/specs/17-persistence-and-storage.md
@@ -78,16 +78,23 @@ pub trait Storage: Send + Sync {
 All keys follow `{namespace}/{entity_id}/{sub_key}` with `/` as the hierarchy separator. Keys are UTF-8 strings. Entity IDs are deterministic (DIDs, context IDs, hashes). Sub-keys are type-specific.
 
 ```
+_meta/schema_version
+
 identity/{did}/document
 identity/{did}/active_signing_key
 identity/{did}/agent_signing_key
 identity/{did}/private_state/{seq:020d}
+identity/{did}/block_list_events
+identity/{did}/adapter_credentials/{adapter_id}
 
 context/{context_id}/state
 context/{context_id}/params
+context/{context_id}/full_snapshot
 context/{context_id}/membership/{did}
 context/{context_id}/sender_key/{did}
+context/{context_id}/role/{role_name}
 context/{context_id}/nonce/{nonce_hash}
+context/{context_id}/nonce/_last_prune
 context/{context_id}/event/{seq:020d}
 context/{context_id}/event_data/{seq:020d}
 context/{context_id}/event_meta/count
@@ -95,19 +102,33 @@ context/{context_id}/event_meta/root
 context/{context_id}/event_tree/{level}/{index}
 context/{context_id}/tool/{tool_id}
 context/{context_id}/tool_session/{session_id}
-context/{context_id}/role/{role_name}
+context/{context_id}/ucan_token/{token_id}
 context/{context_id}/ucan_revocation/{token_id}
+context/{context_id}/broadcast_state
+context/{context_id}/broadcast_block/{author_did}
+context/{context_id}/ephemeral_metadata
+
+context/{context_id}/governance/config
+context/{context_id}/governance/proposal/{proposal_id_hex}
+context/{context_id}/governance/proposal_index/pending
+context/{context_id}/governance/proposal_index/resolved
+context/{context_id}/governance/deadlock_state
+
+context/{context_id}/access_key/{did_hex}
+context/{context_id}/access_key/{did_hex}/epoch
 
 context/{context_id}/economic_policy
 context/{context_id}/payment_receipt/{receipt_id}
 context/{context_id}/spending_ucan/{token_id}
 
-identity/{did}/adapter_credentials/{adapter_id}
+wrapping_key/{context_id}/{did}/public
+wrapping_key/{context_id}/{did}/secret
 
 did_cache/{did}
 tofu/{did}
-key_package/{relay_url}/{index}
-relay_score/{relay_url}
+key_package/{sha256_hex(relay_url)}/{index}
+relay_score/{sha256_hex(relay_url)}
+cert_pin/{sha256_hex(relay_url)}
 
 tls/certificate_chain
 tls/private_key

--- a/crates/scp-core/src/context/governance/mod.rs
+++ b/crates/scp-core/src/context/governance/mod.rs
@@ -1569,16 +1569,17 @@ pub fn actions_conflict(
     proposer_b: &DID,
 ) -> bool {
     use GovernanceAction::{
-        ChangeRole, ModifyCeiling, RemoveMember, RestoreReadAccess, RestoreWriteAccess,
-        RevokeReadAccess, RevokeWriteAccess,
+        AddSigner, ChangeRole, ModifyCeiling, ModifyPruningPolicy, ModifyThreshold,
+        ReconfigureGovernance, RemoveMember, RemoveSigner, RestoreReadAccess, RestoreWriteAccess,
+        RevokeReadAccess, RevokeWriteAccess, RotateContentKeys,
     };
 
-    match (action_a, action_b) {
-        // Mutual RemoveMember (each targeting the other's proposer)
-        (RemoveMember { did: target_a, .. }, RemoveMember { did: target_b, .. }) => {
-            target_a == proposer_b && target_b == proposer_a
-        }
+    // This function MUST stay in sync with
+    // `sync::conflict_resolution::actions_conflict`. The canonical
+    // conflict matrix is defined here; the sync module re-uses the same
+    // logic for offline-merge conflict detection (ADR-029 / ADR-031).
 
+    match (action_a, action_b) {
         // Competing ChangeRole proposals for the same DID with different roles
         (
             ChangeRole {
@@ -1591,51 +1592,45 @@ pub fn actions_conflict(
             },
         ) => did_a == did_b && role_a != role_b,
 
-        // Competing ModifyCeiling proposals with different ceiling sets
-        (
-            ModifyCeiling {
-                new_ceiling: ceiling_a,
-            },
-            ModifyCeiling {
-                new_ceiling: ceiling_b,
-            },
-        ) => ceiling_a != ceiling_b,
+        // Any two concurrent modifications to the same global context property
+        // conflict — the values may or may not differ, but concurrent
+        // modification is unsafe (ADR-031 §7).
+        (ModifyCeiling { .. }, ModifyCeiling { .. })
+        | (ModifyThreshold { .. }, ModifyThreshold { .. })
+        | (ModifyPruningPolicy { .. }, ModifyPruningPolicy { .. })
+        | (ReconfigureGovernance { .. }, ReconfigureGovernance { .. })
+        // Concurrent context-wide key rotations conflict (global property mutation).
+        | (RotateContentKeys { .. }, RotateContentKeys { .. }) => true,
 
-        // RemoveMember + ChangeRole for the same DID
+        // Remove + role change for the same DID.
         (RemoveMember { did: did_a, .. }, ChangeRole { did: did_b, .. })
-        | (ChangeRole { did: did_a, .. }, RemoveMember { did: did_b, .. })
-        // RevokeReadAccess + RestoreReadAccess for the same DID (mutually contradictory)
+        | (ChangeRole { did: did_a, .. }, RemoveMember { did: did_b, .. }) => did_a == did_b,
+
+        // Two concurrent removals of the same member conflict (ADR-031 §7:
+        // concurrent modifications to the same membership state).
+        // Also catches mutual removal (each proposer removes the other).
+        (RemoveMember { did: did_a, .. }, RemoveMember { did: did_b, .. }) => {
+            did_a == did_b || (did_a == proposer_b && did_b == proposer_a)
+        }
+
+        // Two concurrent revocations of the same type targeting the same DID
+        // conflict (scope may differ, but concurrent revocation is unsafe —
+        // ADR-031 §7). Revoke and Restore for the same DID also conflict
+        // (contradictory intent on the same member's access state).
+        (RevokeReadAccess { did: did_a, .. }, RevokeReadAccess { did: did_b, .. })
+        | (RevokeWriteAccess { did: did_a, .. }, RevokeWriteAccess { did: did_b, .. })
         | (RevokeReadAccess { did: did_a, .. }, RestoreReadAccess { did: did_b })
         | (RestoreReadAccess { did: did_a }, RevokeReadAccess { did: did_b, .. })
-        // RevokeWriteAccess + RestoreWriteAccess for the same DID (mutually contradictory)
         | (RevokeWriteAccess { did: did_a, .. }, RestoreWriteAccess { did: did_b })
         | (RestoreWriteAccess { did: did_a }, RevokeWriteAccess { did: did_b, .. }) => {
             did_a == did_b
         }
 
-        // Two RevokeReadAccess or RevokeWriteAccess for same DID with different scopes
-        (
-            RevokeReadAccess {
-                did: did_a,
-                scope: scope_a,
-            },
-            RevokeReadAccess {
-                did: did_b,
-                scope: scope_b,
-            },
-        )
-        | (
-            RevokeWriteAccess {
-                did: did_a,
-                scope: scope_a,
-            },
-            RevokeWriteAccess {
-                did: did_b,
-                scope: scope_b,
-            },
-        ) => did_a == did_b && scope_a != scope_b,
+        // AddSigner and RemoveSigner for the same DID conflict.
+        (AddSigner { did: add_did }, RemoveSigner { did: remove_did })
+        | (RemoveSigner { did: remove_did }, AddSigner { did: add_did }) => add_did == remove_did,
 
-        // All other combinations are not conflicting
+        // All other action pairs are non-conflicting.
         _ => false,
     }
 }

--- a/crates/scp-core/src/store/mod.rs
+++ b/crates/scp-core/src/store/mod.rs
@@ -114,7 +114,7 @@ pub struct StoredValue<T> {
 ///
 /// Incremented when the serialized format of any domain type changes.
 /// Migration logic (spec section 17.10) uses this to detect stale data.
-pub const CURRENT_STORE_VERSION: u16 = 1;
+pub const CURRENT_STORE_VERSION: u16 = 2;
 
 /// Current key-space schema version.
 ///
@@ -458,6 +458,18 @@ impl<S: Storage> ProtocolStore<S> {
 #[allow(clippy::unwrap_used, clippy::expect_used, clippy::panic)]
 mod tests {
     use super::*;
+
+    /// `CURRENT_STORE_VERSION` must be 2 — the v1-to-v2 migration introduced
+    /// named `MessagePack` encoding (see spec section 17.10). Regression
+    /// guard: if this is ever accidentally reverted to 1, existing v2
+    /// data would be treated as "current" when it is not.
+    #[test]
+    fn current_store_version_is_two() {
+        assert_eq!(
+            CURRENT_STORE_VERSION, 2,
+            "CURRENT_STORE_VERSION must be 2 (v1→v2 migration exists)"
+        );
+    }
 
     #[test]
     fn stored_value_roundtrip_via_named_msgpack() {

--- a/crates/scp-core/src/trust/capability_registry.rs
+++ b/crates/scp-core/src/trust/capability_registry.rs
@@ -4,6 +4,9 @@
 //! [`RegistryEntry`] metadata. The registry contains 28 protocol-defined
 //! challenge capabilities across 10 categories and 5 system capabilities.
 //!
+//! Note: `scp:capability:tool-integrity/v1` is NOT included — it is an
+//! attestation type (§7.4.2), not a challenge-testable capability. See #407.
+//!
 //! # SDK Enforcement (§7.3.4.2)
 //!
 //! [`validate_capability_uri`] is the SDK enforcement point: it accepts known
@@ -97,7 +100,7 @@ fn entry(
 }
 
 // ---------------------------------------------------------------------------
-// Protocol registry (27 challenge capabilities)
+// Protocol registry (28 challenge capabilities)
 // ---------------------------------------------------------------------------
 
 /// The protocol capability registry: 28 challenge capabilities across 10
@@ -105,6 +108,9 @@ fn entry(
 ///
 /// Per ADR-041 and §7.3.4.3.
 static PROTOCOL_REGISTRY: LazyLock<HashMap<String, RegistryEntry>> = LazyLock::new(|| {
+    // 28 challenge capabilities across 10 categories.
+    // tool-integrity/v1 is NOT included: it is an attestation type (§7.4.2),
+    // not a challenge-testable capability. See #407.
     let mut m = HashMap::with_capacity(28);
 
     // -- Safety & Security (4) --
@@ -163,16 +169,6 @@ static PROTOCOL_REGISTRY: LazyLock<HashMap<String, RegistryEntry>> = LazyLock::n
         entry(
             "schema-compliance",
             "Produce output in requested formats. Pass = valid format.",
-            None,
-        ),
-    );
-
-    // -- Tool Integrity (1) --
-    m.insert(
-        "scp:capability:tool-integrity/v1".into(),
-        entry(
-            "schema-compliance",
-            "Schema-based tool output verification. Pass = outputs match expected structure.",
             None,
         ),
     );
@@ -395,13 +391,13 @@ static PROTOCOL_REGISTRY: LazyLock<HashMap<String, RegistryEntry>> = LazyLock::n
         entry("factual-hallucination", "Real, verifiable citations.", None),
     );
 
-    // The spec §7.3.4.3 and ADR-041 list 28 capabilities across 10 categories.
-    // (The "27" stated in prose is a counting error in the source documents;
-    // the actual enumerated list contains 28 entries.)
+    // The spec §7.3.4.3 and ADR-041 list 28 challenge capabilities across
+    // 10 categories. tool-integrity/v1 is an attestation type (§7.4.2),
+    // not a challenge-testable capability — excluded per #407.
     debug_assert_eq!(
         m.len(),
-        29,
-        "PROTOCOL_REGISTRY must contain exactly 29 entries"
+        28,
+        "PROTOCOL_REGISTRY must contain exactly 28 entries"
     );
     m
 });
@@ -579,8 +575,8 @@ mod tests {
     // -----------------------------------------------------------------------
 
     #[test]
-    fn protocol_registry_contains_exactly_29_entries() {
-        assert_eq!(PROTOCOL_REGISTRY.len(), 29);
+    fn protocol_registry_contains_exactly_28_entries() {
+        assert_eq!(PROTOCOL_REGISTRY.len(), 28);
     }
 
     #[test]
@@ -589,10 +585,10 @@ mod tests {
     }
 
     // -----------------------------------------------------------------------
-    // All 27 protocol capability URIs (from §7.3.4.3)
+    // All 28 protocol capability URIs (from §7.3.4.3)
     // -----------------------------------------------------------------------
 
-    const ALL_PROTOCOL_URIS: [&str; 29] = [
+    const ALL_PROTOCOL_URIS: [&str; 28] = [
         // Safety & Security (4)
         "scp:capability:prompt-injection-resistance/v1",
         "scp:capability:content-safety/v1",
@@ -602,7 +598,6 @@ mod tests {
         "scp:capability:schema-validation/v1",
         "scp:capability:tool-schema-compliance/v1",
         "scp:capability:output-format-compliance/v1",
-        "scp:capability:tool-integrity/v1",
         // Behavioral Compliance (4)
         "scp:capability:rate-limit-compliance/v1",
         "scp:capability:instruction-adherence/v1",
@@ -670,7 +665,7 @@ mod tests {
     // -----------------------------------------------------------------------
 
     #[test]
-    fn is_known_protocol_capability_true_for_all_29() {
+    fn is_known_protocol_capability_true_for_all_28() {
         for uri in ALL_PROTOCOL_URIS {
             assert!(
                 is_known_protocol_capability(uri),
@@ -727,7 +722,7 @@ mod tests {
     // -----------------------------------------------------------------------
 
     #[test]
-    fn validate_accepts_all_29_protocol_capabilities() {
+    fn validate_accepts_all_28_protocol_capabilities() {
         for uri in ALL_PROTOCOL_URIS {
             let result = validate_capability_uri(uri);
             assert!(
@@ -888,7 +883,6 @@ mod tests {
             "scp:capability:schema-validation/v1",
             "scp:capability:tool-schema-compliance/v1",
             "scp:capability:output-format-compliance/v1",
-            "scp:capability:tool-integrity/v1",
         ];
         for uri in uris {
             assert_eq!(
@@ -897,7 +891,7 @@ mod tests {
                 "wrong category for {uri}"
             );
         }
-        assert_eq!(uris.len(), 4);
+        assert_eq!(uris.len(), 3);
     }
 
     #[test]
@@ -1095,6 +1089,21 @@ mod tests {
     // -----------------------------------------------------------------------
     // RegistryEntry struct fields
     // -----------------------------------------------------------------------
+
+    /// tool-integrity/v1 is an attestation type (§7.4.2), NOT a challenge-
+    /// testable capability. It must not appear in the protocol registry.
+    /// Guard against accidental re-addition (#407).
+    #[test]
+    fn tool_integrity_is_not_a_protocol_capability() {
+        assert!(
+            !is_known_protocol_capability("scp:capability:tool-integrity/v1"),
+            "tool-integrity/v1 is an attestation type, not a challenge capability"
+        );
+        assert!(
+            validate_capability_uri("scp:capability:tool-integrity/v1").is_err(),
+            "tool-integrity/v1 must be rejected by SDK validation"
+        );
+    }
 
     #[test]
     fn registry_entry_has_required_fields() {

--- a/crates/scp-transport/src/manager.rs
+++ b/crates/scp-transport/src/manager.rs
@@ -47,16 +47,12 @@ const DEFAULT_DEDUP_CAPACITY: usize = 10_000;
 /// Default deduplication cache entry TTL.
 const DEFAULT_DEDUP_TTL: Duration = Duration::from_secs(3600);
 
-/// Minimum number of relays required per context for suppression resistance.
-///
-/// Publishing to fewer than this many relays gives individual relays veto
-/// power over message delivery (spec section 9.9.2).
-const MIN_RELAYS_PER_CONTEXT: usize = 3;
-
-/// Minimum number of successful relay deliveries required for a send to
-/// succeed. If fewer than this many relays accept the envelope, the send
-/// returns an error (insufficient redundancy).
-const MIN_SUCCESSFUL_SENDS: usize = 2;
+// MIN_RELAYS_PER_CONTEXT and MIN_SUCCESSFUL_SENDS were formerly hardcoded
+// constants (3 and 2 respectively). They are now derived from the
+// TransportProfile stored on TransportManager — see profile.min_relays()
+// and profile.min_successful_sends(). This ensures constrained devices
+// (1 relay) and mobile devices (2 relays) can operate without violating
+// thresholds designed for server/desktop profiles (#406, §10.13.1).
 
 /// Idle threshold for mobile connection shedding (spec section 10.13.3 item 3).
 ///
@@ -89,12 +85,14 @@ pub struct EvictionOutcome {
 ///
 /// Holds multiple [`TransportAdapter`] instances and routes operations
 /// through them based on per-context relay set assignments. Each context is
-/// assigned a set of at least 3 relays for suppression resistance.
+/// assigned a relay set sized by the transport profile (§10.13.1):
+/// Server/Desktop=3, Mobile=2, Constrained=1.
 ///
 /// # Phase 2 Features
 ///
 /// - **Multi-relay publishing:** `send_to_context` sends envelopes to ALL
-///   relays in a context's relay set concurrently. At least 2 must succeed.
+///   relays in a context's relay set concurrently. The minimum successful
+///   sends threshold is profile-aware (majority of the relay set).
 /// - **Merged subscription streams:** `subscribe_context` merges streams
 ///   from all relays in a context's relay set, deduplicated by `BlobId`
 ///   using an LRU cache with configurable TTL.
@@ -111,6 +109,11 @@ pub struct EvictionOutcome {
 ///
 /// See ADR-012 in `.docs/adrs/phase-2.md` for the full design.
 pub struct TransportManager {
+    /// Transport profile governing relay minimums and connection behavior.
+    ///
+    /// Determines `min_relays()` for relay set assignment and
+    /// `min_successful_sends()` for send fanout thresholds (§10.13.1).
+    profile: TransportProfile,
     /// Registered transport adapters, in insertion order.
     adapters: Vec<Box<dyn TransportAdapter>>,
     /// Per-context relay set assignments: context -> adapter indices.
@@ -210,9 +213,11 @@ impl TransportManager {
     /// [`TransportManager::with_config`].
     #[must_use]
     pub fn new(adapter: Box<dyn TransportAdapter>) -> Self {
+        let profile = TransportProfile::platform_default();
         let mut last_used = HashMap::new();
         last_used.insert(0, Instant::now());
         Self {
+            profile,
             adapters: vec![adapter],
             relay_assignments: RwLock::new(HashMap::new()),
             reliability_scores: Arc::new(Mutex::new(HashMap::new())),
@@ -237,7 +242,9 @@ impl TransportManager {
     /// adapters before performing any operations.
     #[must_use]
     pub fn builder() -> Self {
+        let profile = TransportProfile::platform_default();
         Self {
+            profile,
             adapters: Vec::new(),
             relay_assignments: RwLock::new(HashMap::new()),
             reliability_scores: Arc::new(Mutex::new(HashMap::new())),
@@ -261,6 +268,7 @@ impl TransportManager {
     #[must_use]
     pub fn with_config(config: &TransportConfig) -> Self {
         Self {
+            profile: config.profile,
             adapters: Vec::new(),
             relay_assignments: RwLock::new(HashMap::new()),
             reliability_scores: Arc::new(Mutex::new(HashMap::new())),
@@ -287,7 +295,9 @@ impl TransportManager {
     /// See SCP-253 and ADR-036 acceptance criterion 3.
     #[must_use]
     pub fn with_pool(pool: Arc<ConnectionPool>) -> Self {
+        let profile = TransportProfile::platform_default();
         Self {
+            profile,
             adapters: Vec::new(),
             relay_assignments: RwLock::new(HashMap::new()),
             reliability_scores: Arc::new(Mutex::new(HashMap::new())),
@@ -312,6 +322,7 @@ impl TransportManager {
     #[must_use]
     pub fn with_config_and_pool(config: &TransportConfig, pool: Arc<ConnectionPool>) -> Self {
         Self {
+            profile: config.profile,
             adapters: Vec::new(),
             relay_assignments: RwLock::new(HashMap::new()),
             reliability_scores: Arc::new(Mutex::new(HashMap::new())),
@@ -326,6 +337,12 @@ impl TransportManager {
             connection_pool: pool,
             max_publish_jitter_ms: config.max_publish_jitter_ms,
         }
+    }
+
+    /// Returns the transport profile governing this manager.
+    #[must_use]
+    pub const fn profile(&self) -> TransportProfile {
+        self.profile
     }
 
     /// Returns the maximum connection budget for this manager.
@@ -419,8 +436,9 @@ impl TransportManager {
     ///
     /// Looks up the relay set for the given `context_id`, sends the envelope
     /// to ALL relays concurrently via [`FuturesUnordered`], and returns a
-    /// `BlobId` per successful relay. If fewer than 2 relays succeed, returns
-    /// an error indicating insufficient redundancy.
+    /// `BlobId` per successful relay. If fewer than
+    /// [`TransportProfile::min_successful_sends`] relays succeed, returns an
+    /// error indicating insufficient redundancy.
     ///
     /// When `max_publish_jitter_ms > 0` and the relay set has more than one
     /// relay, the first relay receives the message immediately while each
@@ -438,7 +456,8 @@ impl TransportManager {
     ///
     /// Returns [`TransportError::NotConnected`] if no adapters are registered
     /// or no relay set is assigned to the context.
-    /// Returns [`TransportError::SendFailed`] if fewer than 2 relays succeed.
+    /// Returns [`TransportError::SendFailed`] if fewer than
+    /// [`TransportProfile::min_successful_sends`] relays succeed.
     pub async fn send_to_context(
         &self,
         envelope: &OuterEnvelope,
@@ -529,12 +548,14 @@ impl TransportManager {
             }
         }
 
-        if successes.len() < MIN_SUCCESSFUL_SENDS {
+        let min_sends = self.profile.min_successful_sends();
+        if successes.len() < min_sends {
             return Err(TransportError::SendFailed(format!(
-                "insufficient redundancy: only {} of {} relays accepted the envelope (minimum {})",
+                "insufficient redundancy: only {} of {} relays accepted the envelope (minimum {} for {} profile)",
                 successes.len(),
                 relay_indices.len(),
-                MIN_SUCCESSFUL_SENDS,
+                min_sends,
+                self.profile,
             )));
         }
 
@@ -745,9 +766,11 @@ impl TransportManager {
 
     /// Assigns a relay set for a context.
     ///
-    /// Selects at least [`MIN_RELAYS_PER_CONTEXT`] (3) adapters per context
+    /// Selects at least [`TransportProfile::min_relays`] adapters per context
     /// using round-robin spread to minimize overlap between contexts' relay
-    /// sets. Prefers adapters with higher reliability scores.
+    /// sets. Prefers adapters with higher reliability scores. The minimum
+    /// relay count is profile-aware (§10.13.1): Server/Desktop=3, Mobile=2,
+    /// Constrained=1.
     ///
     /// The assigned relay set is stored in `relay_assignments` and returned
     /// as a vector of adapter indices.
@@ -763,7 +786,7 @@ impl TransportManager {
         }
 
         let adapter_count = self.adapters.len();
-        let set_size = MIN_RELAYS_PER_CONTEXT.min(adapter_count);
+        let set_size = self.profile.min_relays().min(adapter_count);
 
         // Build a list of adapter indices sorted by:
         //   (overlap count ASC, reliability score DESC, cost ASC,
@@ -1893,7 +1916,7 @@ mod tests {
     #[tokio::test]
     async fn send_to_context_error_when_fewer_than_two_succeed() {
         let mut manager = TransportManager::builder();
-        // One succeeds, two fail => only 1 success < MIN_SUCCESSFUL_SENDS (2).
+        // One succeeds, two fail => only 1 success < min_successful_sends (2 for desktop).
         manager.add_adapter(Box::new(MockAdapter::with_blob_id(BlobId::new([0x01; 32]))));
         manager.add_adapter(Box::new(MockAdapter::failing(TransportError::SendFailed(
             "fail1".to_string(),
@@ -1917,7 +1940,7 @@ mod tests {
     #[tokio::test]
     async fn send_to_context_succeeds_with_exactly_two_relays() {
         let mut manager = TransportManager::builder();
-        // Two succeed, one fails => 2 successes >= MIN_SUCCESSFUL_SENDS.
+        // Two succeed, one fails => 2 successes >= min_successful_sends (2 for desktop).
         manager.add_adapter(Box::new(MockAdapter::with_blob_id(BlobId::new([0x01; 32]))));
         manager.add_adapter(Box::new(MockAdapter::with_blob_id(BlobId::new([0x02; 32]))));
         manager.add_adapter(Box::new(MockAdapter::failing(TransportError::SendFailed(

--- a/crates/scp-transport/src/profile.rs
+++ b/crates/scp-transport/src/profile.rs
@@ -214,6 +214,23 @@ impl TransportProfile {
         }
     }
 
+    /// Returns the minimum number of successful relay deliveries required
+    /// for a send to succeed.
+    ///
+    /// Derived from [`min_relays`](Self::min_relays): a majority of the
+    /// relay set must accept the envelope for the send to be considered
+    /// sufficiently redundant. For single-relay profiles (`Constrained`),
+    /// the minimum is 1 since no redundancy is available.
+    ///
+    /// - Server: 2 (majority of 3)
+    /// - Desktop: 2 (majority of 3)
+    /// - Mobile: 1 (at least 1 of 2; see §10.13.1 suppression trade-offs)
+    /// - Constrained: 1 (single relay, no redundancy)
+    #[must_use]
+    pub const fn min_successful_sends(&self) -> usize {
+        self.min_relays().div_ceil(2)
+    }
+
     /// Returns the maximum total connection count across all adapters.
     ///
     /// - Server: `usize::MAX` (unlimited)
@@ -519,6 +536,26 @@ mod tests {
     #[test]
     fn constrained_min_relays() {
         assert_eq!(TransportProfile::Constrained.min_relays(), 1);
+    }
+
+    #[test]
+    fn server_min_successful_sends() {
+        assert_eq!(TransportProfile::Server.min_successful_sends(), 2);
+    }
+
+    #[test]
+    fn desktop_min_successful_sends() {
+        assert_eq!(TransportProfile::Desktop.min_successful_sends(), 2);
+    }
+
+    #[test]
+    fn mobile_min_successful_sends() {
+        assert_eq!(TransportProfile::Mobile.min_successful_sends(), 1);
+    }
+
+    #[test]
+    fn constrained_min_successful_sends() {
+        assert_eq!(TransportProfile::Constrained.min_successful_sends(), 1);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Resolves 6 issues across governance, storage, trust, and transport modules:

- **#420** — Governance `actions_conflict` expanded with 7 missing conflict pairs (concurrent global-property mutations, signer add/remove, same-type revocations, mutual removal)
- **#429** — `CURRENT_STORE_VERSION` corrected to 2 (v1-to-v2 `MessagePack` migration exists); regression test added
- **#407** — `tool-integrity/v1` removed from protocol capability registry (attestation type, not challenge capability); count corrected 29->28 with regression guard
- **#406** — Transport relay minimums now read from `TransportProfile` instead of hardcoded constants; `min_successful_sends()` added with majority formula; constrained devices (1 relay) and mobile (2 relays) can now send
- **#455** — Media key HKDF label confirmed already aligned between spec (`scp-media-key-v1`) and code; no change needed
- **#409** — Spec `§17.3` storage key convention table updated with 18 missing entries used in code

## Changes

| File | Change |
|------|--------|
| `crates/scp-core/src/context/governance/mod.rs` | Expanded conflict matrix, merged match arms |
| `crates/scp-core/src/store/mod.rs` | Version bump + regression test |
| `crates/scp-core/src/trust/capability_registry.rs` | Remove tool-integrity, fix count |
| `crates/scp-transport/src/profile.rs` | Add `min_successful_sends()` method + tests |
| `crates/scp-transport/src/manager.rs` | Store `TransportProfile`, use profile-derived thresholds |
| `.docs/specs/17-persistence-and-storage.md` | Update key convention table |

## Test plan

- [x] `cargo clippy --workspace --all-targets --features scp-ffi-uniffi/allow_in_memory_custody,scp-ffi/allow_in_memory_custody,scp-ffi-napi/allow_in_memory_custody,scp-core/testing -- -D warnings` passes clean
- [x] `cargo fmt --all -- --check` passes
- [ ] `cargo test --workspace` passes (CI validates)
- [ ] Verify constrained-profile `send_to_context` succeeds with 1 relay
- [ ] Verify mobile-profile `send_to_context` succeeds with 1 of 2 relays

Closes #406, closes #407, closes #409, closes #420, closes #429, closes #455

🤖 Generated with [Claude Code](https://claude.com/claude-code)