### PR TITLE
feat(governance): GovernanceActionExecuted, BlockAuthor delegation, BridgeMetadata

### DIFF
--- a/crates/scp-core/src/context/manager.rs
+++ b/crates/scp-core/src/context/manager.rs
@@ -3003,7 +3003,7 @@ impl ContextManager {
     /// Used when appending governance events to the Merkle event log. Each
     /// variant maps to a deterministic string label so event consumers can
     /// filter by type without deserializing the full event.
-    fn governance_event_label(event: &GovernanceEvent) -> &'static str {
+    const fn governance_event_label(event: &GovernanceEvent) -> &'static str {
         match event {
             GovernanceEvent::ProposalCreated { .. } => "GovernanceProposalCreated",
             GovernanceEvent::VoteCast { .. } => "GovernanceVoteCast",
@@ -3554,10 +3554,9 @@ impl ContextManager {
 
         let context_id_bytes = context_id_to_bytes(context_id);
         for event in &events {
-            let _ = self.event_log.append_context_event(
-                &context_id_bytes,
-                Self::governance_event_label(event),
-            );
+            let _ = self
+                .event_log
+                .append_context_event(&context_id_bytes, Self::governance_event_label(event));
         }
 
         // Persist context state after withdrawal.

--- a/crates/scp-core/src/context/params.rs
+++ b/crates/scp-core/src/context/params.rs
@@ -378,10 +378,16 @@ pub enum BridgeDirectionality {
 
 /// Capabilities a bridge connector can exercise in a context (spec §5.7).
 ///
-/// These are the four protocol-defined bridge capabilities. A bridge's
-/// `capabilities` field declares which of these it exercises, providing
-/// legibility to prospective members before they join.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+/// The four protocol-defined bridge capabilities plus an extensibility
+/// variant. A bridge's `capabilities` field declares which of these it
+/// exercises, providing legibility to prospective members before they join.
+///
+/// # Serde
+///
+/// Protocol-defined variants serialize as lowercase `snake_case` strings.
+/// The `Custom` variant serializes as an arbitrary string, enabling
+/// forward-compatible extension without protocol changes.
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum BridgeCapability {
     /// Relay messages between SCP and the external platform.
@@ -392,6 +398,37 @@ pub enum BridgeCapability {
     AttestIdentities,
     /// Forward presence/typing indicators.
     ForwardPresence,
+    /// Platform-specific or experimental capability not yet standardized.
+    ///
+    /// The contained string is the capability identifier, e.g.,
+    /// `"custom_reactions"` or `"thread_sync"`. Implementations SHOULD
+    /// use `snake_case` identifiers to align with the serde convention
+    /// used by protocol-defined variants.
+    Custom(String),
+}
+
+impl std::fmt::Display for BridgeCapability {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::RelayMessages => f.write_str("relay_messages"),
+            Self::CreateShadows => f.write_str("create_shadows"),
+            Self::AttestIdentities => f.write_str("attest_identities"),
+            Self::ForwardPresence => f.write_str("forward_presence"),
+            Self::Custom(s) => f.write_str(s),
+        }
+    }
+}
+
+impl From<&str> for BridgeCapability {
+    fn from(s: &str) -> Self {
+        match s {
+            "relay_messages" => Self::RelayMessages,
+            "create_shadows" => Self::CreateShadows,
+            "attest_identities" => Self::AttestIdentities,
+            "forward_presence" => Self::ForwardPresence,
+            other => Self::Custom(other.to_owned()),
+        }
+    }
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- **#417**: Added `GovernanceActionExecuted` event variant to `GovernanceEvent` enum with `proposal_id`, `action`, `executor_did`, and `resulting_epoch` fields. Emitted after every successful governance action execution via the Merkle event log (ADR-031 §8, PRD SCP-269/SCP-270).
- **#425**: `BlockAuthor` handler now delegates to `execute_revoke_write_access` with `RevocationScope::Full` instead of using a standalone `block_broadcast_author_internal` function. Returns `WriteAccessRevoked` result. Removed dead `block_broadcast_author_internal` method (ADR-038).
- **#404** (remaining sub-items): Added `BridgeMetadata` struct and `BridgeDirectionality` enum per spec §5.7. Governance collection size limits (`threshold_signers: 64`, `registered_tools: 256`, `tool_interfaces: 256` with `LimitExceeded` error) were already implemented — verified in place.

Closes #417, closes #425, closes #404

## Test plan

- [x] All 3,984 scp-core tests pass (3,956 unit + 15 integration + 13 doc)
- [x] 9 block_author tests pass with new delegation path
- [x] 16 write_access tests pass
- [x] 385 governance tests pass including GovernanceActionExecuted event logging
- [x] Clippy clean with all 4 feature flags
- [x] Formatting verified via `cargo fmt --all --check`

🤖 Generated with [Claude Code](https://claude.com/claude-code)