### PR TITLE
fix(napi): make NapiContextHandle.memberCount delegate to ContextManager (#567)

### DIFF
--- a/crates/scp-ffi/napi/src/context.rs
+++ b/crates/scp-ffi/napi/src/context.rs
@@ -173,7 +173,7 @@ impl NapiContextHandle {
     ///
     /// # Errors
     ///
-    /// Returns an error if the tokio runtime cannot be accessed.
+    /// The `Result` return type is required by napi-rs. This getter is infallible.
     #[napi(getter, js_name = "memberCount")]
     pub fn member_count(&self) -> napi::Result<u64> {
         let manager = context_manager();
@@ -660,11 +660,10 @@ pub fn context_subscribe(
 ///
 /// This function is infallible. The `Result` return type is required by napi-rs.
 #[napi(js_name = "contextMemberCount")]
-pub async fn context_member_count(handle: &NapiContextHandle) -> napi::Result<u32> {
+pub async fn context_member_count(handle: &NapiContextHandle) -> napi::Result<u64> {
     let manager = context_manager();
     let count = manager.member_count(&handle.context_id).await.unwrap_or(0);
-    #[allow(clippy::cast_possible_truncation)]
-    Ok(count as u32)
+    Ok(count as u64)
 }
 
 /// Returns whether a DID is a member of the context.


### PR DESCRIPTION
Closes #567

## Summary
- Remove stale `member_count: u64` field from `NapiContextHandle`
- Getter now delegates to `ContextManager::member_count()` via `crate::runtime().block_on()` for live data
- Both access patterns (getter and free function) now return correct, live count

## Review Cycles
- Cycles: 1
- Findings resolved: 0
- Findings dismissed: 7 (WASM same bug is separate issue, rest are pre-existing design or scope creep)

🤖 Generated with [Loom](https://github.com/alecmarcus/loom)