### PR TITLE
fix(wasm): add 3 economic governance variants and replace catch-all handlers (#634)

### DIFF
--- a/crates/scp-ffi/wasm/src/manager.rs
+++ b/crates/scp-ffi/wasm/src/manager.rs
@@ -1819,7 +1819,7 @@ impl WasmContextManager {
                 ctx.write_revoked_members.insert(did.clone());
                 ctx.push_event(WasmContextEvent::WriteAccessRevoked { did: did.clone() });
                 Ok(
-                    serde_json::json!({"action": "WriteAccessRevoked", "did": did, "scope": "Full", "reason": reason}),
+                    serde_json::json!({"action": "WriteAccessRevoked", "did": did, "scope": "full", "reason": reason}),
                 )
             }
             WasmGovernanceAction::RevokeReadAccess { did, scope } => {


### PR DESCRIPTION
Closes #634

## Summary
- Added 3 missing economic governance variants to `WasmGovernanceAction`: `SetEconomicPolicy`, `ApproveSpend`, `LockEconomicPolicy` — now mirrors all 28 core `GovernanceAction` variants
- Replaced all `_ =>` wildcard catch-all handlers with exhaustive explicit variant listings across 4 dispatch methods (`dispatch_governance_action`, `dispatch_governance_action_ext`, `dispatch_governance_action_structural`, `dispatch_governance_action_remaining`, `dispatch_governance_action_economic`)
- Added 6 state fields to `PerContextState` for threshold governance, tool interfaces, governance freeze, pruning policy, and economic policy lock — with full export/import support
- Added comprehensive tests: 28 serde roundtrip tests, variant count exhaustiveness test, 3 JS deserialization tests (41 total tests passing)

## Review Cycles
- Cycles: 2
- Findings resolved: 1 (wildcard catchalls → explicit variant listings)
- Findings dismissed: 8 (pre-existing gaps outside scope, style observations)

🤖 Generated with [Loom](https://github.com/alecmarcus/loom)