### PR TITLE
fix(event-log): address PR #664 review findings

### DIFF
--- a/crates/scp-core/tests/wasm_conformance.rs
+++ b/crates/scp-core/tests/wasm_conformance.rs
@@ -542,7 +542,7 @@ fn merkle_roots_identical_at_each_step() {
     let mut core_log = EventLog::new("ctx-conformance".to_owned());
     let mut wasm_log = wasm_mirror::WasmEventLog::new();
 
-    // Both empty logs should return the same zero root.
+    // Both empty logs should return the same root: SHA-256("") per spec §25.8.
     assert_eq!(
         core_tree::root(&core_log),
         wasm_log.root(),

--- a/crates/scp-event-log/src/checkpoint.rs
+++ b/crates/scp-event-log/src/checkpoint.rs
@@ -1074,11 +1074,7 @@ fn recompute_tree_from_leaves(leaves: &[[u8; 32]]) -> Vec<Vec<[u8; 32]>> {
 /// Returns `SHA-256("")` for an empty set (spec §25.8 Vector 15).
 fn compute_root_from_leaves(leaves: &[[u8; 32]]) -> [u8; 32] {
     if leaves.is_empty() {
-        // SHA-256("") per spec §25.8 Vector 15.
-        let hash = Sha256::digest(b"");
-        let mut out = [0u8; 32];
-        out.copy_from_slice(&hash);
-        return out;
+        return crate::tree::empty_tree_root();
     }
     if leaves.len() == 1 {
         return leaves[0];
@@ -1091,7 +1087,7 @@ fn compute_root_from_leaves(leaves: &[[u8; 32]]) -> [u8; 32] {
         return top[0];
     }
 
-    [0u8; 32]
+    unreachable!("recompute_tree_from_leaves always produces a single root for non-empty input")
 }
 
 /// Computes `SHA-256(0x01 || left || right)` for an interior node.


### PR DESCRIPTION
## Summary
- Replace inline SHA-256("") in checkpoint.rs with `tree::empty_tree_root()` call — the original bug was caused by duplicated sentinel logic across files
- Replace unreachable `[0u8; 32]` fallback with `unreachable!()` to surface future bugs
- Fix stale comment "zero root" → "SHA-256(\"\")" in wasm_conformance.rs

## Review Cycles
- Cycles: 1
- Findings resolved: 3
- Findings dismissed: 0

🤖 Generated with [Loom](https://github.com/alecmarcus/loom)