### PR TITLE
fix(crypto): prevent partial state on mutex poison in MLS restore_crypto_state

### DIFF
--- a/crates/scp-core/src/crypto/mls/provider.rs
+++ b/crates/scp-core/src/crypto/mls/provider.rs
@@ -958,10 +958,24 @@ impl ContextCryptoProvider for MlsCryptoProvider {
             SenderKey::from_bytes([0u8; 32]),
         );
 
+        let crypto_state = ContextCryptoState {
+            mls_group: scp_group,
+            sender_key: local_sender_key,
+            sender_key_store,
+            sender_key_epoch: snapshot.sender_key_epoch,
+            pending_distributions: Vec::new(),
+            nonce_dedup: NonceDedup::new(),
+            member_wrapping_keys,
+        };
+
         // Restore the provider-level X25519 wrapping keypair BEFORE inserting
-        // the context state, so that a lock-poisoned error here does not leave
-        // the context map in an inconsistent state (context inserted but
-        // wrapping keys mismatched).
+        // into the contexts map. This prevents partial state: if any lock is
+        // poisoned the function returns early without modifying either the
+        // contexts map or the wrapping keys.
+        //
+        // Both wrapping key locks are acquired before either is written. This
+        // ensures that a poison on the second lock cannot leave the first key
+        // updated while the second retains its old value.
         //
         // Legacy snapshots (pre-wrapping-key persistence) have default
         // [0u8; 32] — skip restore in that case to keep the fresh keypair.
@@ -974,11 +988,11 @@ impl ContextCryptoProvider for MlsCryptoProvider {
             let mut pub_guard = self.wrapping_public_key.lock().map_err(|e| {
                 ContextError::CryptoFailed(format!("wrapping key lock poisoned: {e}"))
             })?;
-            *pub_guard = snapshot.wrapping_public_key;
-
             let mut secret_guard = self.wrapping_secret_key.lock().map_err(|e| {
                 ContextError::CryptoFailed(format!("wrapping key lock poisoned: {e}"))
             })?;
+
+            *pub_guard = snapshot.wrapping_public_key;
             *secret_guard = Zeroizing::new(*secret);
         }
 
@@ -987,16 +1001,6 @@ impl ContextCryptoProvider for MlsCryptoProvider {
         // above (or skipped for legacy snapshots), so this intermediate Vec
         // should not retain raw X25519 secret key material.
         snapshot.wrapping_secret_key.zeroize();
-
-        let crypto_state = ContextCryptoState {
-            mls_group: scp_group,
-            sender_key: local_sender_key,
-            sender_key_store,
-            sender_key_epoch: snapshot.sender_key_epoch,
-            pending_distributions: Vec::new(),
-            nonce_dedup: NonceDedup::new(),
-            member_wrapping_keys,
-        };
 
         let mut contexts = self
             .contexts


### PR DESCRIPTION
## Summary

- Reorders `restore_crypto_state` so wrapping keypair restoration happens **before** inserting into the contexts map, preventing stale context entries on lock failure
- Acquires both wrapping key locks (public and secret) before writing to either, preventing partial key updates if the second lock is poisoned
- On any lock failure the function returns early with zero mutations to shared state

Closes #712

## Test plan

- [x] `cargo clippy --workspace --all-targets` with all features — clean
- [x] `cargo fmt --all` — clean
- [x] `cargo test --workspace` with all features — all tests pass
- [x] Existing `export_restore_crypto_state_roundtrip` test validates the success path is unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)