### PR TITLE
fix(store): outbound queue ordering and bound enforcement tests (#709)

### DIFF
--- a/crates/scp-core/src/store/queue.rs
+++ b/crates/scp-core/src/store/queue.rs
@@ -997,11 +997,13 @@ mod tests {
         // Total real entries: 1000 + 5 = 1005.
         assert_eq!(store.queue_global_count().await.unwrap(), 1005);
 
-        // Artificially inflate the global count to MAX_QUEUE_GLOBAL so the
-        // next enqueue puts us at MAX_QUEUE_GLOBAL + 1 AND triggers
-        // per-context overflow.
+        // Artificially inflate the global count to MAX_QUEUE_GLOBAL + 5.
+        // After enqueue (+1) and per-context enforcement (-1), the global
+        // count is still above MAX_QUEUE_GLOBAL, so enforce_global_bound
+        // must actually run.  Without the +5 headroom the count lands
+        // exactly at MAX_QUEUE_GLOBAL and the `>` check is never true.
         store
-            .store_value(QUEUE_GLOBAL_COUNT_KEY, &MAX_QUEUE_GLOBAL)
+            .store_value(QUEUE_GLOBAL_COUNT_KEY, &(MAX_QUEUE_GLOBAL + 5))
             .await
             .unwrap();
 


### PR DESCRIPTION
## Summary

- Adds regression test proving global bound eviction uses `queued_at` timestamp ordering (not lexicographic context ID ordering)
- Adds regression test proving both per-context and global bounds are enforced consistently (per-context overflow does not skip global enforcement)

Both fixes were already applied in the PR #688 squash merge but lacked dedicated tests. The two review threads remained unresolved because no test proved the behaviors correct.

closes #709

## Test plan

- [x] `global_bound_evicts_by_timestamp_not_context_id_order` — enqueues entries in "zzz-old" (timestamps 100-102) and "aaa-new" (timestamps 900-902), artificially inflates global count, calls `enforce_global_bound`, asserts "zzz-old" lost 2 entries while "aaa-new" retained all 3
- [x] `both_per_context_and_global_bounds_enforced` — fills one context to capacity, inflates global count to limit, enqueues one more to trigger simultaneous per-context and global overflow, asserts both bounds are enforced
- [x] All 24 queue store tests pass
- [x] Full workspace clippy clean (with all features)
- [x] Full workspace tests pass (4154+ tests, only pre-existing NAPI handle_count failure)

🤖 Generated with [Claude Code](https://claude.com/claude-code)