### PR TITLE
test(ffi): add broadcastIsSubscriber assertion after unblock

### DIFF
--- a/bindings/python/tests/test_real_ffi.py
+++ b/bindings/python/tests/test_real_ffi.py
@@ -504,6 +504,7 @@ class TestBroadcast:
 
         # Unblock bob — subscriber status should be restored.
         _scp_core.py_broadcast_unblock_subscriber(handle, bob.did, alice.did)
+        assert _scp_core.py_broadcast_is_subscriber(handle, bob.did)
 
     async def test_unblock_not_blocked_raises(self):
         alice = await Identity.create(CustodyType.IN_MEMORY)

--- a/bindings/typescript/tests/real-napi.test.ts
+++ b/bindings/typescript/tests/real-napi.test.ts
@@ -1084,6 +1084,7 @@ if (bridge === null) {
       expect(await napi.broadcastIsSubscriber(ctx, subscriber.did)).toBe(false);
 
       await napi.broadcastUnblockSubscriber(ctx, subscriber.did, identity.did);
+      expect(await napi.broadcastIsSubscriber(ctx, subscriber.did)).toBe(true);
     });
 
     test("unblock non-blocked subscriber throws", async () => {


### PR DESCRIPTION
## Summary
- Adds missing `broadcastIsSubscriber` assertion after `broadcast_unblock` in both Python and TypeScript FFI integration tests
- Python: asserts `py_broadcast_is_subscriber` returns `True` after unblock (line 507 of `test_real_ffi.py`)
- TypeScript: asserts `broadcastIsSubscriber` returns `true` after unblock (line 1088 of `real-napi.test.ts`)

Closes #718

## Test plan
- [ ] Python broadcast tests pass: `cd bindings/python && python3.12 -m pytest tests/ -v -k broadcast`
- [ ] TypeScript NAPI tests pass: `cd bindings/typescript && bun test`
- [ ] Rust clippy clean (no Rust changes, but verified)

🤖 Generated with [Claude Code](https://claude.com/claude-code)