### PR TITLE
fix(wasm): trust_query_score returns real event counts

### DIFF
--- a/crates/scp-ffi/wasm/src/manager.rs
+++ b/crates/scp-ffi/wasm/src/manager.rs
@@ -955,6 +955,14 @@ impl WasmContextManager {
             .map(|m| m.role.clone())
     }
 
+    /// Returns the event log leaf count for a context, or `None` if not found.
+    #[must_use]
+    pub fn event_log_leaf_count(&self, context_id: &str) -> Option<usize> {
+        self.contexts
+            .get(context_id)
+            .map(|ctx| ctx.event_log.leaf_count())
+    }
+
     // -----------------------------------------------------------------------
     // Events
     // -----------------------------------------------------------------------

--- a/crates/scp-ffi/wasm/src/runtime.rs
+++ b/crates/scp-ffi/wasm/src/runtime.rs
@@ -751,11 +751,19 @@ pub fn decode_hex_hash(hex_str: &str) -> Result<[u8; 32], String> {
 ///
 /// Returns `(message_count, governance_count)` derived from the context's
 /// event log via [`WasmContextManager`]. Returns `(0, 0)` if context not found.
+///
+/// WASM bridge limitation: the event log is a Merkle tree of hashes only
+/// (no per-DID event attribution). Returns total leaf count as
+/// `message_count`; `governance_count` is always 0. Full per-DID scoring
+/// requires event payload storage (not available in the WASM bridge due
+/// to scp-core dependency constraint per ADR-034).
 #[must_use]
-pub fn query_trust_event_counts(_context_id: &str, _did: &str) -> (u64, u64) {
-    // WASM bridge: event log is a Merkle tree of hashes only (no per-DID
-    // event attribution). Return total leaf count as message_count.
-    // Full per-DID scoring requires event payload storage (not available
-    // in the WASM bridge due to scp-core dependency constraint).
-    (0, 0)
+pub fn query_trust_event_counts(context_id: &str, _did: &str) -> (u64, u64) {
+    crate::manager::with_manager(|mgr| {
+        let total = mgr
+            .event_log_leaf_count(context_id)
+            .map_or(0, |n| u64::try_from(n).unwrap_or(u64::MAX));
+        Ok((total, 0))
+    })
+    .unwrap_or((0, 0))
 }


### PR DESCRIPTION
## Summary
- `query_trust_event_counts` in the WASM bridge always returned `(0, 0)`, making trust scoring non-functional
- Now accesses the `WasmContextManager`'s event log leaf count via `with_manager()`, matching the NAPI bridge pattern
- Added `event_log_leaf_count()` method to `WasmContextManager` for clean access

## Changes
- `crates/scp-ffi/wasm/src/runtime.rs`: `query_trust_event_counts` uses `with_manager` to read actual leaf count
- `crates/scp-ffi/wasm/src/manager.rs`: Added `event_log_leaf_count(&self, context_id) -> Option<usize>`
- Uses `u64::try_from(n).unwrap_or(u64::MAX)` instead of `as u64` (project forbids `cast_possible_truncation`)

## Test plan
- [ ] `cargo clippy -p scp-ffi-wasm --target wasm32-unknown-unknown -- -D warnings` passes
- [ ] `cargo check -p scp-ffi-wasm --target wasm32-unknown-unknown` passes
- [ ] Trust score returns non-zero after events are appended to a context

Closes #524

🤖 Generated with [Claude Code](https://claude.com/claude-code)