### PR TITLE
fix(wasm): pass blocker/unblocker DID through broadcast block/unblock

### DIFF
--- a/bindings/typescript/src/internal/wasm.ts
+++ b/bindings/typescript/src/internal/wasm.ts
@@ -213,8 +213,16 @@ interface WasmModule {
     authorDid: string,
     payloadBase64: string,
   ) => Promise<void>;
-  broadcast_block: (handle: BridgeContextHandle, subscriberDid: string) => Promise<void>;
-  broadcast_unblock: (handle: BridgeContextHandle, subscriberDid: string) => Promise<void>;
+  broadcast_block: (
+    handle: BridgeContextHandle,
+    subscriberDid: string,
+    blockerDid: string,
+  ) => Promise<void>;
+  broadcast_unblock: (
+    handle: BridgeContextHandle,
+    subscriberDid: string,
+    unblockerDid: string,
+  ) => Promise<void>;
   broadcast_subscriber_count: (handle: BridgeContextHandle) => number | null;
   broadcast_is_subscriber: (handle: BridgeContextHandle, did: string) => boolean;
   broadcast_admission: (handle: BridgeContextHandle) => string | null;
@@ -562,21 +570,19 @@ export function createWasmBridge(): Bridge {
     async broadcastBlockSubscriber(
       handle: BridgeContextHandle,
       subscriberDid: string,
-      _blockerDid: string,
+      blockerDid: string,
     ): Promise<void> {
       const wasm = getWasm();
-      // WASM bridge only takes the subscriber DID; blockerDid is ignored.
-      await wasm.broadcast_block(handle, subscriberDid);
+      await wasm.broadcast_block(handle, subscriberDid, blockerDid);
     },
 
     async broadcastUnblockSubscriber(
       handle: BridgeContextHandle,
       subscriberDid: string,
-      _unblockerDid: string,
+      unblockerDid: string,
     ): Promise<void> {
       const wasm = getWasm();
-      // WASM bridge only takes the subscriber DID; unblockerDid is ignored.
-      await wasm.broadcast_unblock(handle, subscriberDid);
+      await wasm.broadcast_unblock(handle, subscriberDid, unblockerDid);
     },
 
     async broadcastHandleKeyRequest(

--- a/crates/scp-ffi/wasm/src/context.rs
+++ b/crates/scp-ffi/wasm/src/context.rs
@@ -551,15 +551,24 @@ pub fn broadcast_unsubscribe(handle: &WasmContextHandle, subscriber_did: String)
 ///
 /// Delegates to `WasmContextManager::block_broadcast_subscriber`.
 #[wasm_bindgen]
-pub fn broadcast_block(handle: &WasmContextHandle, subscriber_did: String) -> Promise {
+pub fn broadcast_block(
+    handle: &WasmContextHandle,
+    subscriber_did: String,
+    blocker_did: String,
+) -> Promise {
     if let Err(e) = validate_did(&subscriber_did) {
+        return future_to_promise(async move { Err(ScpWasmError::from(e).into_js().into()) });
+    }
+    if let Err(e) = validate_did(&blocker_did) {
         return future_to_promise(async move { Err(ScpWasmError::from(e).into_js().into()) });
     }
     let context_id = handle.context_id();
 
     future_to_promise(async move {
-        with_manager(|mgr| mgr.block_broadcast_subscriber(&context_id, &subscriber_did))
-            .map_err(ScpWasmError::into_js)?;
+        with_manager(|mgr| {
+            mgr.block_broadcast_subscriber(&context_id, &subscriber_did, &blocker_did)
+        })
+        .map_err(ScpWasmError::into_js)?;
         Ok(JsValue::UNDEFINED)
     })
 }
@@ -571,15 +580,24 @@ pub fn broadcast_block(handle: &WasmContextHandle, subscriber_did: String) -> Pr
 ///
 /// Delegates to `WasmContextManager::unblock_broadcast_subscriber`.
 #[wasm_bindgen]
-pub fn broadcast_unblock(handle: &WasmContextHandle, subscriber_did: String) -> Promise {
+pub fn broadcast_unblock(
+    handle: &WasmContextHandle,
+    subscriber_did: String,
+    unblocker_did: String,
+) -> Promise {
     if let Err(e) = validate_did(&subscriber_did) {
+        return future_to_promise(async move { Err(ScpWasmError::from(e).into_js().into()) });
+    }
+    if let Err(e) = validate_did(&unblocker_did) {
         return future_to_promise(async move { Err(ScpWasmError::from(e).into_js().into()) });
     }
     let context_id = handle.context_id();
 
     future_to_promise(async move {
-        with_manager(|mgr| mgr.unblock_broadcast_subscriber(&context_id, &subscriber_did))
-            .map_err(ScpWasmError::into_js)?;
+        with_manager(|mgr| {
+            mgr.unblock_broadcast_subscriber(&context_id, &subscriber_did, &unblocker_did)
+        })
+        .map_err(ScpWasmError::into_js)?;
         Ok(JsValue::UNDEFINED)
     })
 }

--- a/crates/scp-ffi/wasm/src/manager.rs
+++ b/crates/scp-ffi/wasm/src/manager.rs
@@ -2522,10 +2522,9 @@ impl WasmContextManager {
         &mut self,
         context_id: &str,
         subscriber_did: &str,
+        blocker_did: &str,
     ) -> Result<(), ScpWasmError> {
         let ctx = self.require_active_context_mut(context_id)?;
-
-        let author_did = ctx.creator_did.clone();
 
         {
             let bc = ctx
@@ -2542,7 +2541,7 @@ impl WasmContextManager {
 
         ctx.push_event(WasmContextEvent::MemberBlocked {
             blocked_did: subscriber_did.to_owned(),
-            author_did,
+            author_did: blocker_did.to_owned(),
         });
 
         Ok(())
@@ -2564,10 +2563,9 @@ impl WasmContextManager {
         &mut self,
         context_id: &str,
         subscriber_did: &str,
+        unblocker_did: &str,
     ) -> Result<(), ScpWasmError> {
         let ctx = self.require_active_context_mut(context_id)?;
-
-        let author_did = ctx.creator_did.clone();
 
         {
             let bc = ctx
@@ -2593,7 +2591,7 @@ impl WasmContextManager {
 
         ctx.push_event(WasmContextEvent::MemberUnblocked {
             unblocked_did: subscriber_did.to_owned(),
-            author_did,
+            author_did: unblocker_did.to_owned(),
         });
 
         Ok(())


### PR DESCRIPTION
## Summary
- WASM Rust bridge `block_broadcast_subscriber` and `unblock_broadcast_subscriber` were missing the `blocker_did`/`unblocker_did` parameter, hardcoding the context creator DID as the author for event attribution
- TypeScript WASM adapter silently dropped the `blockerDid`/`unblockerDid` parameters because the underlying Rust export didn't accept them
- Added `blocker_did`/`unblocker_did` parameters to both WASM Rust exports with `validate_did` validation, and wired them through the TypeScript WASM adapter

Closes #568
Closes #549

## Test plan
- [x] `cargo clippy -p scp-ffi-wasm --target wasm32-unknown-unknown -- -D warnings` passes
- [x] `cargo fmt --all` clean
- [x] `tsc --noEmit` passes for TypeScript bindings

🤖 Generated with [Claude Code](https://claude.com/claude-code)