### PR TITLE
test(wasm): reference #717 in protocol version conformance test

### DIFF
--- a/crates/scp-core/tests/wasm_conformance.rs
+++ b/crates/scp-core/tests/wasm_conformance.rs
@@ -2968,7 +2968,7 @@ fn wasm_and_core_revocation_cid_match_after_jwt_roundtrip() {
 }
 
 // ===========================================================================
-// SCP_PROTOCOL_VERSION constant sync conformance (#707)
+// SCP_PROTOCOL_VERSION constant sync conformance (#717)
 //
 // The WASM bridge defines its own SCP_PROTOCOL_VERSION constant because it
 // cannot depend on scp-core (ADR-034). This test ensures both values match.


### PR DESCRIPTION
## Summary
- The WASM `SCP_PROTOCOL_VERSION` conformance test already exists (added in PR #724 for #707) but its comment referenced the wrong issue
- Updates the comment to reference #717, the dedicated tracking issue for this specific test
- The test asserts `WASM_SCP_PROTOCOL_VERSION == scp_core::envelope::SCP_PROTOCOL_VERSION` and verifies encode/decode parity

Closes #717

## Test plan
- [x] `cargo test -p scp-core --test wasm_conformance --features scp-core/testing -- scp_protocol_version` passes (1 test)
- [x] `cargo fmt --all` clean
- [x] `cargo clippy --workspace --all-targets --features scp-ffi-uniffi/allow_in_memory_custody,scp-ffi/allow_in_memory_custody,scp-ffi-napi/allow_in_memory_custody,scp-core/testing -- -D warnings` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)