### PR TITLE
fix(wasm): validate minProtocolVersion in context_create

### DIFF
--- a/crates/scp-ffi/wasm/src/context.rs
+++ b/crates/scp-ffi/wasm/src/context.rs
@@ -979,90 +979,108 @@ mod tests {
     #[test]
     fn validate_min_protocol_version_rejects_string() {
         let params = serde_json::json!({ "minProtocolVersion": "1.0" });
-        let err = validate_min_protocol_version(&params).unwrap_err();
         assert!(
-            matches!(err, ScpWasmError::Validation { ref code, .. } if code == "SCP-VALID-7002"),
-            "expected SCP-VALID-7002, got: {err:?}"
+            matches!(
+                validate_min_protocol_version(&params),
+                Err(ScpWasmError::Validation { ref code, .. }) if code == "SCP-VALID-7002"
+            ),
+            "expected SCP-VALID-7002 validation error"
         );
     }
 
     #[test]
     fn validate_min_protocol_version_rejects_number() {
         let params = serde_json::json!({ "minProtocolVersion": 42 });
-        let err = validate_min_protocol_version(&params).unwrap_err();
         assert!(
-            matches!(err, ScpWasmError::Validation { ref code, .. } if code == "SCP-VALID-7002"),
-            "expected SCP-VALID-7002, got: {err:?}"
+            matches!(
+                validate_min_protocol_version(&params),
+                Err(ScpWasmError::Validation { ref code, .. }) if code == "SCP-VALID-7002"
+            ),
+            "expected SCP-VALID-7002 validation error"
         );
     }
 
     #[test]
     fn validate_min_protocol_version_rejects_short_array() {
         let params = serde_json::json!({ "minProtocolVersion": [1] });
-        let err = validate_min_protocol_version(&params).unwrap_err();
         assert!(
-            matches!(err, ScpWasmError::Validation { ref code, .. } if code == "SCP-VALID-7002"),
-            "expected SCP-VALID-7002, got: {err:?}"
+            matches!(
+                validate_min_protocol_version(&params),
+                Err(ScpWasmError::Validation { ref code, .. }) if code == "SCP-VALID-7002"
+            ),
+            "expected SCP-VALID-7002 validation error"
         );
     }
 
     #[test]
     fn validate_min_protocol_version_rejects_empty_array() {
         let params = serde_json::json!({ "minProtocolVersion": [] });
-        let err = validate_min_protocol_version(&params).unwrap_err();
         assert!(
-            matches!(err, ScpWasmError::Validation { ref code, .. } if code == "SCP-VALID-7002"),
-            "expected SCP-VALID-7002, got: {err:?}"
+            matches!(
+                validate_min_protocol_version(&params),
+                Err(ScpWasmError::Validation { ref code, .. }) if code == "SCP-VALID-7002"
+            ),
+            "expected SCP-VALID-7002 validation error"
         );
     }
 
     #[test]
     fn validate_min_protocol_version_rejects_string_elements() {
         let params = serde_json::json!({ "minProtocolVersion": ["1", "0"] });
-        let err = validate_min_protocol_version(&params).unwrap_err();
         assert!(
-            matches!(err, ScpWasmError::Validation { ref code, .. } if code == "SCP-VALID-7002"),
-            "expected SCP-VALID-7002, got: {err:?}"
+            matches!(
+                validate_min_protocol_version(&params),
+                Err(ScpWasmError::Validation { ref code, .. }) if code == "SCP-VALID-7002"
+            ),
+            "expected SCP-VALID-7002 validation error"
         );
     }
 
     #[test]
     fn validate_min_protocol_version_rejects_string_minor() {
         let params = serde_json::json!({ "minProtocolVersion": [1, "0"] });
-        let err = validate_min_protocol_version(&params).unwrap_err();
         assert!(
-            matches!(err, ScpWasmError::Validation { ref code, .. } if code == "SCP-VALID-7002"),
-            "expected SCP-VALID-7002, got: {err:?}"
+            matches!(
+                validate_min_protocol_version(&params),
+                Err(ScpWasmError::Validation { ref code, .. }) if code == "SCP-VALID-7002"
+            ),
+            "expected SCP-VALID-7002 validation error"
         );
     }
 
     #[test]
     fn validate_min_protocol_version_rejects_major_overflow() {
         let params = serde_json::json!({ "minProtocolVersion": [256, 0] });
-        let err = validate_min_protocol_version(&params).unwrap_err();
         assert!(
-            matches!(err, ScpWasmError::Validation { ref code, .. } if code == "SCP-VALID-7002"),
-            "expected SCP-VALID-7002, got: {err:?}"
+            matches!(
+                validate_min_protocol_version(&params),
+                Err(ScpWasmError::Validation { ref code, .. }) if code == "SCP-VALID-7002"
+            ),
+            "expected SCP-VALID-7002 validation error"
         );
     }
 
     #[test]
     fn validate_min_protocol_version_rejects_minor_overflow() {
         let params = serde_json::json!({ "minProtocolVersion": [1, 256] });
-        let err = validate_min_protocol_version(&params).unwrap_err();
         assert!(
-            matches!(err, ScpWasmError::Validation { ref code, .. } if code == "SCP-VALID-7002"),
-            "expected SCP-VALID-7002, got: {err:?}"
+            matches!(
+                validate_min_protocol_version(&params),
+                Err(ScpWasmError::Validation { ref code, .. }) if code == "SCP-VALID-7002"
+            ),
+            "expected SCP-VALID-7002 validation error"
         );
     }
 
     #[test]
     fn validate_min_protocol_version_rejects_negative() {
         let params = serde_json::json!({ "minProtocolVersion": [-1, 0] });
-        let err = validate_min_protocol_version(&params).unwrap_err();
         assert!(
-            matches!(err, ScpWasmError::Validation { ref code, .. } if code == "SCP-VALID-7002"),
-            "expected SCP-VALID-7002, got: {err:?}"
+            matches!(
+                validate_min_protocol_version(&params),
+                Err(ScpWasmError::Validation { ref code, .. }) if code == "SCP-VALID-7002"
+            ),
+            "expected SCP-VALID-7002 validation error"
         );
     }
 }


### PR DESCRIPTION
## Summary

- Adds bridge-level structural validation of `minProtocolVersion` in the WASM `context_create` function, matching the NAPI bridge's explicit parsing pattern (spec §13.4)
- The `WasmContextManager` already validates version compatibility, but this defense-in-depth layer catches malformed input (non-array types, short arrays, non-numeric elements, u8 overflow) before any state mutation
- 13 unit tests cover all acceptance and rejection cases

Closes #716

## Test plan

- [x] `cargo check --target wasm32-unknown-unknown -p scp-ffi-wasm` passes
- [x] `cargo clippy -p scp-ffi-wasm --target wasm32-unknown-unknown -- -D warnings` passes clean
- [x] `cargo fmt --all` passes
- [x] 13 new unit tests pass (`cargo test -p scp-ffi-wasm --lib -- context::tests`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)