### PR TITLE
fix(wasm): delegate tool_invoke to WasmContextManager (#564)

### DIFF
--- a/crates/scp-ffi/wasm/src/tools.rs
+++ b/crates/scp-ffi/wasm/src/tools.rs
@@ -215,8 +215,6 @@ pub fn tool_invoke(
             }
         }
 
-        // WASM operates in echo mode — no external handler dispatch.
-        // Returns a validated-status result.
         let parsed_input: serde_json::Value = serde_json::from_str(&input_json).map_err(|e| {
             ScpWasmError::Validation {
                 message: format!("input_json is not valid JSON: {e}"),
@@ -224,11 +222,11 @@ pub fn tool_invoke(
             }
             .into_js()
         })?;
-        let result = serde_json::json!({
-            "status": "validated",
-            "tool_id": tool_id,
-            "input": parsed_input,
-        });
+
+        let result = with_manager(|mgr| {
+            mgr.invoke_tool(&context_id, &tool_id, &parsed_input, &identity_did)
+        })
+        .map_err(ScpWasmError::into_js)?;
 
         let json_str = serde_json::to_string(&result).map_err(|e| {
             ScpWasmError::Tool {


### PR DESCRIPTION
## Summary

- Wires `tool_invoke` in `crates/scp-ffi/wasm/src/tools.rs` to call `WasmContextManager::invoke_tool()` instead of returning a hardcoded echo JSON response
- This enables schema validation against the tool's registered input schema, handler dispatch when a handler is registered, and `ToolInvoked` event log recording — all of which were previously bypassed
- UCAN authorization remains unchanged (validated before manager dispatch)

## Test plan

- [x] `cargo check --target wasm32-unknown-unknown -p scp-ffi-wasm` passes
- [x] `cargo clippy -p scp-ffi-wasm --target wasm32-unknown-unknown -- -D warnings` passes
- [x] `cargo fmt --all` — no changes needed
- [ ] CI validates full workspace

Closes #564

🤖 Generated with [Claude Code](https://claude.com/claude-code)