### PR TITLE
fix(context): use stored params for early version check in join_context (closes #738)

### DIFF
--- a/crates/scp-core/src/context/manager.rs
+++ b/crates/scp-core/src/context/manager.rs
@@ -1855,6 +1855,21 @@ impl ContextManager {
     ///
     /// Returns [`ContextCreationError`] if any validation or execution step
     /// fails.
+    /// Replaces the stored context's handle with a new one carrying the given
+    /// params. Used by tests to simulate a context whose `min_protocol_version`
+    /// was set by a different SDK version or received via sync.
+    #[cfg(test)]
+    pub(crate) async fn replace_stored_params(&self, context_id: &str, new_params: ContextParams) {
+        let mut contexts = self.contexts.lock().await;
+        if let Some(ctx) = contexts.get_mut(context_id) {
+            let new_handle = ContextHandle::new(context_id.to_owned(), new_params);
+            // Preserve the current state.
+            let current_state = ctx.handle.state().await;
+            let _ = new_handle.transition_to(&current_state).await;
+            ctx.handle = new_handle;
+        }
+    }
+
     #[cfg(test)]
     pub(crate) async fn create_context_bare(
         &self,
@@ -2090,12 +2105,19 @@ impl ContextManager {
         let member_did = key_package.owner_did.clone();
 
         // Fast-fail: reject obviously incompatible versions before expensive
-        // crypto ops (MLS group join, sender key derivation). Uses the caller's
-        // handle params for the early check; the authoritative check against
-        // the stored context params still runs inside the lock below.
-        handle
-            .params()
-            .check_version_compatibility(crate::envelope::SCP_PROTOCOL_VERSION)?;
+        // crypto ops (MLS group join, sender key derivation). Looks up the
+        // stored context's params (not the caller-supplied handle params)
+        // so this check is authoritative even when the caller passes an
+        // ephemeral handle with default params (e.g. UniFFI bridge).
+        {
+            let contexts = self.contexts.lock().await;
+            let ctx = contexts
+                .get(&context_id)
+                .ok_or_else(|| ContextError::MembershipFailed("context not registered".into()))?;
+            ctx.handle
+                .params()
+                .check_version_compatibility(crate::envelope::SCP_PROTOCOL_VERSION)?;
+        }
 
         // Crypto operations -- no lock held, no TOCTOU concern for these
         // provider calls since they are idempotent or externally consistent.
@@ -2144,10 +2166,11 @@ impl ContextManager {
             // State check inside lock -- eliminates TOCTOU race.
             require_active(&ctx.handle)?;
 
-            // Version compatibility check (spec §13.4): reject join if the
-            // context requires a protocol version higher than this SDK supports.
-            // Uses the stored context's params (not the caller's handle params)
-            // to ensure the check reflects the actual context configuration.
+            // Defense-in-depth: re-check version compatibility under the
+            // mutation lock. The early check above uses a separate lock
+            // acquisition, so governance could theoretically change the
+            // min_protocol_version between the two. This eliminates that
+            // TOCTOU window.
             ctx.handle
                 .params()
                 .check_version_compatibility(crate::envelope::SCP_PROTOCOL_VERSION)?;
@@ -7258,31 +7281,40 @@ mod tests {
         ));
     }
 
-    /// Regression test for #715: version check must run BEFORE crypto ops.
-    /// When the handle's `min_protocol_version` is incompatible, `join_context`
-    /// must reject without calling `add_member` (no orphaned MLS state).
+    /// Regression test for #715 / #738: version check must run BEFORE crypto
+    /// ops. When the *stored* context's `min_protocol_version` is incompatible,
+    /// `join_context` must reject without calling `add_member` (no orphaned MLS
+    /// state). The check uses the stored context's params, not the caller-
+    /// supplied handle, so the `UniFFI` bridge's ephemeral default-params handle is safe.
     #[tokio::test]
     async fn join_version_check_rejects_before_crypto_ops() {
         let (manager, _handle) = setup_active_context().await;
 
-        // Build a handle whose params require major version 2 — incompatible
-        // with SCP_PROTOCOL_VERSION (1.0). The context "test-ctx" already
-        // exists in the manager with compatible params; the fast-fail check
-        // uses handle.params(), which is the *caller-supplied* handle, not
-        // the stored one.
-        let incompatible_params = ContextParams {
-            min_protocol_version: Some((2, 0)),
-            ..ContextParams::default()
-        };
-        let bad_handle = ContextHandle::new("test-ctx".into(), incompatible_params);
-        // Transition to Active so require_active() would pass if reached.
-        bad_handle
+        // Simulate a context whose stored params require major version 2 —
+        // incompatible with SCP_PROTOCOL_VERSION (1.0). We create with
+        // compatible params then replace, because create_context itself
+        // (correctly) rejects incompatible min_protocol_version.
+        manager
+            .replace_stored_params(
+                "test-ctx",
+                ContextParams {
+                    min_protocol_version: Some((2, 0)),
+                    ..ContextParams::default()
+                },
+            )
+            .await;
+
+        // Build an ephemeral handle with default params (mimics UniFFI bridge).
+        // The early check must still reject because it reads the *stored*
+        // context's params, not this handle's params.
+        let ephemeral_handle = ContextHandle::new("test-ctx".into(), ContextParams::default());
+        ephemeral_handle
             .transition_to(&ContextState::Active)
             .await
             .unwrap();
 
         let kp = KeyPackage::mock("did:key:bob".into());
-        let result = manager.join_context(&bad_handle, kp).await;
+        let result = manager.join_context(&ephemeral_handle, kp).await;
 
         // Must fail with VersionIncompatible — the early check rejects
         // before any crypto operations (validate_key_package, add_member,

--- a/crates/scp-ffi/uniffi/src/bridge.rs
+++ b/crates/scp-ffi/uniffi/src/bridge.rs
@@ -2239,10 +2239,9 @@ pub async fn context_join(
             // Delegate to the shared ContextManager. Build a core ContextHandle
             // to pass the context_id, then join via the manager.
             //
-            // This ephemeral ContextHandle is a placeholder: UniFFI's
-            // join_context doesn't use the handle's params — the
-            // ContextManager performs its own version compatibility check
-            // using the params already stored on the managed context.
+            // This ephemeral ContextHandle carries default params — the
+            // ContextManager ignores them, performing version compatibility
+            // checks against the stored context's params instead.
             let manager = crate::runtime::context_manager();
             let core_handle = scp_core::context::ContextHandle::new(
                 handle.context_id.clone(),


### PR DESCRIPTION
## Summary

- The early version check in `join_context` (from PR #734) used `handle.params()` from the caller-supplied handle, but the UniFFI bridge creates ephemeral `ContextHandle`s with `ContextParams::default()` (`min_protocol_version: None`, effective `(1,0)`), making the check a no-op for Swift/Kotlin callers
- Now the early check acquires the contexts lock, reads the **stored** context's params, and checks against those — authoritative regardless of which bridge calls it
- The second check inside the mutation lock is retained as defense-in-depth against TOCTOU (governance could change `min_protocol_version` between the two lock acquisitions)
- Updated the regression test to verify the fix: creates a context, replaces stored params to incompatible via `replace_stored_params` test helper, then confirms an ephemeral default-params handle (mimicking UniFFI) is correctly rejected

## Files changed

- `crates/scp-core/src/context/manager.rs` — early version check now reads stored params; added `replace_stored_params` test helper; updated regression test
- `crates/scp-ffi/uniffi/src/bridge.rs` — updated comment on ephemeral handle to reflect the fix

## Test plan

- [x] `cargo fmt --all -- --check` passes
- [x] `cargo clippy --workspace --all-targets --features scp-ffi-uniffi/allow_in_memory_custody,scp-ffi/allow_in_memory_custody,scp-ffi-napi/allow_in_memory_custody,scp-core/testing -- -D warnings` passes
- [x] `cargo test -p scp-core` — 4216 tests pass including updated regression test
- [x] `cargo test -p scp-ffi-uniffi` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)