### PR TITLE
fix(napi): use PascalCase for ResolutionLayer values per §22.11.3 (#726)

### DIFF
--- a/bindings/typescript/src/types.ts
+++ b/bindings/typescript/src/types.ts
@@ -447,11 +447,16 @@ export type TrustLevel =
 /**
  * The resolution layer that produced an address resolution result.
  *
- * Exactly four values per §22.7 `ResolutionPath.layer`. Uses spec snake_case.
+ * Five variants per §22.11.3 `ResolutionLayer`. Uses spec PascalCase serde tags.
  *
- * See §22.7 Resolution Path.
+ * See §22.11.3 Address Resolution.
  */
-export type ResolutionLayer = "petname" | "discovery_context" | "attestation" | "domain";
+export type ResolutionLayer =
+  | "Petname"
+  | "DiscoveryContext"
+  | "Attestation"
+  | "Domain"
+  | "MultiLayerCorroborated";
 
 /**
  * Structured metadata recording which layer resolved an address.

--- a/crates/scp-ffi/napi/src/discovery.rs
+++ b/crates/scp-ffi/napi/src/discovery.rs
@@ -128,25 +128,25 @@ fn discovery_result_to_json(
     let (source_str, trust_level_kind, resolution_layer, resolution_source, resolution_source_id) =
         match &result.discovery_source {
             scp_core::discovery::ContextDiscoverySource::DhtDidDocument => {
-                ("dht_did_document", "DomainVerified", "domain", "dht", None)
+                ("dht_did_document", "DomainVerified", "Domain", "dht", None)
             }
             scp_core::discovery::ContextDiscoverySource::WellKnown => {
-                ("well_known", "DomainVerified", "domain", "well-known", None)
+                ("well_known", "DomainVerified", "Domain", "well-known", None)
             }
             scp_core::discovery::ContextDiscoverySource::DiscoveryContext { context_id } => (
                 "discovery_context",
                 "DiscoveryContextVerified",
-                "discovery_context",
+                "DiscoveryContext",
                 "discovery_context",
                 Some(context_id.as_str()),
             ),
             // §22.7: An scp:// URI is shared out-of-band, so the trust level is
-            // DirectExchange and the resolution layer is "domain" (closest match
+            // DirectExchange and the resolution layer is "Domain" (closest match
             // for URI-based resolution — no discovery context is involved).
             scp_core::discovery::ContextDiscoverySource::ContextUri => (
                 "context_uri",
                 "DirectExchange",
-                "domain",
+                "Domain",
                 "context_uri",
                 None,
             ),
@@ -315,10 +315,10 @@ mod tests {
         assert_eq!(json["context_id"], "abc123");
         assert_eq!(json["discovery_source"], "dht_did_document");
         assert_eq!(json["mode"], "broadcast");
-        // §22.7: trust_level is a discriminated union object; resolution_path
-        // uses spec snake_case layer values.
+        // §22.11.3: trust_level is a discriminated union object; resolution_path
+        // uses spec PascalCase layer values.
         assert_eq!(json["trust_level"]["kind"], "DomainVerified");
-        assert_eq!(json["resolution_path"]["layer"], "domain");
+        assert_eq!(json["resolution_path"]["layer"], "Domain");
         assert_eq!(json["resolution_path"]["source"], "dht");
         assert!(json["resolution_path"]["resolved_at"].as_u64().unwrap() > 0);
     }
@@ -338,7 +338,7 @@ mod tests {
 
         let json = discovery_result_to_json(&result);
         assert_eq!(json["trust_level"]["kind"], "DiscoveryContextVerified");
-        assert_eq!(json["resolution_path"]["layer"], "discovery_context");
+        assert_eq!(json["resolution_path"]["layer"], "DiscoveryContext");
         assert_eq!(json["resolution_path"]["source"], "discovery_context");
         assert_eq!(json["resolution_path"]["source_id"], "disc-ctx-1");
         assert_eq!(json["discovery_context_id"], "disc-ctx-1");


### PR DESCRIPTION
## Summary

- Changes `ResolutionLayer` values in NAPI `discovery_result_to_json` from snake_case to PascalCase per spec §22.11.3: `"domain"` → `"Domain"`, `"discovery_context"` → `"DiscoveryContext"`
- Updates TypeScript `ResolutionLayer` type to PascalCase and adds missing `"MultiLayerCorroborated"` variant (spec defines 5 variants, code had 4)

Follow-up to #737 which fixed ParsedAddress tags but missed ResolutionLayer values.

Closes #726

## Test plan

- [x] `cargo clippy` with all feature flags passes
- [x] `cargo fmt --check` passes
- [x] `bun run check` and `bun run lint` pass
- [x] Test assertions updated to match PascalCase values

🤖 Generated with [Claude Code](https://claude.com/claude-code)