### PR TITLE
fix(sdk): wire Python delegate() and TypeScript delegateUcan() to real bridge functions

### DIFF
--- a/bindings/python/scp_sdk/ucan.py
+++ b/bindings/python/scp_sdk/ucan.py
@@ -208,13 +208,14 @@ async def delegate(
     delegatee: str,
     capabilities: Sequence[str],
     context: str,
+    *,
+    encoded_parent: str,
 ) -> UcanToken:
     """Create a delegated UCAN from a parent token.
 
-    Verifies that the delegator matches the parent token's audience and
-    that the requested capabilities are a subset of the parent's
-    capabilities (attenuation -- never widening).  Mints a new token
-    with the parent as proof.
+    Delegates to ``_scp_core.ucan_delegate`` which performs real Ed25519
+    signing via the delegator's retained ``KeyCustody`` and enforces
+    attenuation (capabilities can only narrow, never widen).
 
     Args:
         parent_token: The parent :class:`UcanToken` to delegate from.
@@ -224,6 +225,9 @@ async def delegate(
         capabilities: Capability URIs to grant (must be a subset of the
             parent token's capabilities).
         context: The context ID to scope the delegated token to.
+        encoded_parent: The full encoded JWT string of the parent token.
+            Required for the Rust bridge to parse and verify the parent's
+            signature and delegation chain.
 
     Returns:
         A new :class:`UcanToken` representing the delegated token.
@@ -231,37 +235,20 @@ async def delegate(
     Raises:
         UcanPermissionError: If delegation fails -- delegator does not
             match the parent's audience, capabilities exceed the parent's
-            capabilities, etc.
+            capabilities, signing fails, etc.
     """
-    # Verify delegator matches the parent token's audience.
-    if delegator != parent_token.audience:
-        raise UcanPermissionError(
-            f"Delegator DID {delegator!r} does not match parent token "
-            f"audience {parent_token.audience!r}",
-            code="SCP-PERM-3001",
+    try:
+        bridge_token = await asyncio.to_thread(
+            _scp_core.ucan_delegate,
+            context,
+            delegator,
+            delegatee,
+            encoded_parent,
+            list(capabilities),
         )
-
-    # Verify attenuation: requested capabilities must be a subset of the
-    # parent's capabilities (never widening).
-    parent_caps = set(parent_token.capabilities)
-    requested_caps = set(capabilities)
-    excess = requested_caps - parent_caps
-    if excess:
-        raise UcanPermissionError(
-            f"Cannot delegate capabilities not present in parent token: {sorted(excess)}",
-            code="SCP-PERM-3002",
-        )
-
-    # Delegate by minting a new token from the delegator to the delegatee
-    # with the attenuated capabilities.  The parent token's ID is included
-    # in the proof chain so that validators can verify the delegation chain
-    # back to the root token.
-    return await mint(
-        audience=delegatee,
-        capabilities=list(capabilities),
-        context=context,
-        proofs=[parent_token.token_id],
-    )
+    except Exception as exc:
+        raise UcanPermissionError(str(exc)) from exc
+    return UcanToken._from_bridge(bridge_token)
 
 
 __all__ = [

--- a/bindings/typescript/src/index.d.ts
+++ b/bindings/typescript/src/index.d.ts
@@ -220,6 +220,7 @@ export declare function revokeUcan(ctx: Context, token: string): Promise<void>;
 export declare function delegateUcan(
   ctx: Context,
   originalToken: UcanToken,
+  delegatorDid: string,
   targetDid: string,
   capabilities: readonly string[],
 ): Promise<UcanToken>;

--- a/bindings/typescript/src/ucan.ts
+++ b/bindings/typescript/src/ucan.ts
@@ -87,11 +87,17 @@ export async function revokeUcan(ctx: Context, token: string): Promise<void> {
  * Delegates a UCAN token to another member.
  *
  * Creates a new UCAN token that delegates a subset of the original token's
- * capabilities to another member. Attenuation rules ensure the delegated
- * token cannot exceed the original's scope.
+ * capabilities to another member. The delegator must be the audience of the
+ * original token (iss/aud chain linkage). Attenuation rules ensure the
+ * delegated token cannot exceed the original's scope.
+ *
+ * Delegates to the real `bridge.ucanDelegate()` which performs Ed25519
+ * signing via the delegator's retained `KeyCustody` and enforces
+ * attenuation, iss/aud chain validation, and ceiling compliance.
  *
  * @param ctx - The context to delegate within.
- * @param originalToken - The original token to delegate from.
+ * @param originalToken - The original token to delegate from (must include `encoded` JWT).
+ * @param delegatorDid - The DID of the entity delegating (must match originalToken.audience).
  * @param targetDid - The DID of the delegation target.
  * @param capabilities - Capability URIs to delegate (must be a subset of the original).
  * @returns The delegated UCAN token.
@@ -100,15 +106,19 @@ export async function revokeUcan(ctx: Context, token: string): Promise<void> {
 export async function delegateUcan(
   ctx: Context,
   originalToken: UcanToken,
+  delegatorDid: string,
   targetDid: string,
   capabilities: readonly string[],
 ): Promise<UcanToken> {
-  // Delegation is implemented as minting with the original token as proof.
-  // The bridge layer validates attenuation rules.
   try {
     const bridge = await getBridge();
-    const _ = originalToken; // Used for delegation chain in full runtime.
-    return await bridge.ucanMint(ctx._handle, targetDid, capabilities);
+    return await bridge.ucanDelegate(
+      ctx._handle,
+      delegatorDid,
+      targetDid,
+      originalToken.encoded,
+      capabilities,
+    );
   } catch (error) {
     throw mapBridgeError(error);
   }

--- a/bindings/typescript/tests/mock-bridge.ts
+++ b/bindings/typescript/tests/mock-bridge.ts
@@ -502,6 +502,67 @@ export function createMockBridge(): Bridge & {
       ctx.revokedTokens.add(token);
     },
 
+    async ucanDelegate(
+      handle: BridgeContextHandle,
+      delegatorDid: string,
+      delegateeDid: string,
+      parentToken: string,
+      capabilities: readonly string[],
+    ): Promise<UcanToken> {
+      const ctx = getContext(handle);
+
+      // Find the parent token by encoded string
+      let parentUcan: UcanToken | undefined;
+      for (const [_id, ucan] of ctx.ucans) {
+        if (ucan.encoded === parentToken) {
+          parentUcan = ucan;
+          break;
+        }
+      }
+      if (parentUcan === undefined) {
+        throw new Error("[SCP-PERM-3000] Parent token not recognized in context");
+      }
+
+      // Verify delegator matches parent audience (iss/aud chain linkage)
+      if (parentUcan.audience !== delegatorDid) {
+        throw new Error(
+          `[SCP-PERM-3000] Delegator DID '${delegatorDid}' does not match parent token audience '${parentUcan.audience}'`,
+        );
+      }
+
+      // Verify attenuation: requested capabilities must be subset of parent
+      const parentCaps = new Set(parentUcan.capabilities);
+      for (const cap of capabilities) {
+        if (!parentCaps.has(cap)) {
+          throw new Error(`[SCP-PERM-3000] Cannot delegate capability not in parent: ${cap}`);
+        }
+      }
+
+      // Mint the delegated token
+      const tokenId = generateId("ucan");
+      const encoded = `eyJ0eXAiOiJKV1QiLCJhbGciOiJFZERTQSJ9.${Buffer.from(
+        JSON.stringify({
+          iss: delegatorDid,
+          aud: delegateeDid,
+          cap: capabilities,
+          prf: [parentUcan.id],
+          exp: Math.floor(Date.now() / 1000) + 3600,
+        }),
+      ).toString("base64url")}.mock-signature-${tokenId}`;
+
+      const token: UcanToken = {
+        id: tokenId,
+        encoded,
+        issuer: delegatorDid,
+        audience: delegateeDid,
+        capabilities: [...capabilities],
+        expiresAt: Math.floor(Date.now() / 1000) + 3600,
+      };
+
+      ctx.ucans.set(tokenId, token);
+      return token;
+    },
+
     // Event Log
     async eventLogQuery(
       handle: BridgeContextHandle,


### PR DESCRIPTION
## Summary

Closes #635.

- **Python `delegate()`**: Replaced local `mint()` call and manual attenuation checks with `_scp_core.ucan_delegate`, which performs real Ed25519 signing via the delegator's retained `KeyCustody` and enforces iss/aud chain validation and attenuation.
- **TypeScript `delegateUcan()`**: Replaced `bridge.ucanMint()` (which discarded the original token) with `bridge.ucanDelegate()`, passing `delegatorDid` and `originalToken.encoded` to the bridge for proper delegation chain formation.
- **`index.d.ts`**: Updated `delegateUcan` declaration to include the new `delegatorDid` parameter.
- **Mock bridge**: Added `ucanDelegate` implementation with iss/aud chain linkage validation and attenuation enforcement for integration testing.

The `ScpBridge` interface, NAPI native adapter, and WASM adapter already had `ucanDelegate` wired to real implementations.

## Test plan

- [x] `cargo clippy --workspace --all-targets --features ...` passes clean
- [x] `cargo clippy -p scp-ffi-wasm --target wasm32-unknown-unknown` passes clean
- [x] `bun run check && bun run lint && bun test` all pass (141 tests)
- [x] `python3.12 -m ruff check . && python3.12 -m ruff format --check .` passes clean
- [x] NAPI integration tests for `ucanDelegate` already exist in `real-napi.test.ts`

🤖 Generated with [Claude Code](https://claude.com/claude-code)