### PR TITLE
fix(wasm): address spec-drift findings in discovery and bridge (#555)

### DIFF
--- a/crates/scp-ffi/wasm/src/bridge.rs
+++ b/crates/scp-ffi/wasm/src/bridge.rs
@@ -85,6 +85,7 @@ pub struct WasmShadowIdentity {
     shadow_id: String,
     platform_handle: String,
     bridge_id: String,
+    context_id: String,
     attributed_role: String,
     provenance_status: String,
 }
@@ -107,6 +108,12 @@ impl WasmShadowIdentity {
     #[wasm_bindgen(getter, js_name = "bridge_id")]
     pub fn bridge_id(&self) -> String {
         self.bridge_id.clone()
+    }
+
+    #[must_use]
+    #[wasm_bindgen(getter, js_name = "context_id")]
+    pub fn context_id(&self) -> String {
+        self.context_id.clone()
     }
 
     #[must_use]
@@ -329,10 +336,31 @@ pub fn bridge_register(
 
     let bridge_mode = BridgeMode::from_str(&mode).map_err(ScpWasmError::into_js)?;
 
-    // Deterministic bridge ID: "bridge-{platform}-{context_id_prefix}"
-    // Mirrors the NAPI bridge's ID generation logic.
-    let ctx_prefix: String = context_id.chars().take(8).collect();
-    let bridge_id = format!("bridge-{platform}-{ctx_prefix}");
+    // Bridge ID per spec §12.2.1: SHA-256(context_id || operator_did || platform || timestamp).
+    // Uses current timestamp for uniqueness. Hex-encoded for readability.
+    #[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
+    let now_secs = {
+        #[cfg(target_arch = "wasm32")]
+        {
+            (js_sys::Date::now() / 1000.0) as u64
+        }
+        #[cfg(not(target_arch = "wasm32"))]
+        {
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .map(|d| d.as_secs())
+                .unwrap_or(0)
+        }
+    };
+    let bridge_id = {
+        use sha2::{Digest, Sha256};
+        let mut hasher = Sha256::new();
+        hasher.update(context_id.as_bytes());
+        hasher.update(operator_did.as_bytes());
+        hasher.update(platform.as_bytes());
+        hasher.update(now_secs.to_be_bytes());
+        hex::encode(hasher.finalize())
+    };
 
     Ok(WasmBridgeRegistration {
         bridge_id,
@@ -402,7 +430,7 @@ pub fn bridge_create_shadow(
 
     // Default to "ctx-shadow" when context_id is None, matching the NAPI
     // bridge's `context_id.unwrap_or_else(|| "ctx-shadow".to_string())`.
-    let _ctx_id = context_id.unwrap_or_else(|| "ctx-shadow".to_owned());
+    let ctx_id = context_id.unwrap_or_else(|| "ctx-shadow".to_owned());
 
     // Deterministic shadow ID: "shadow-{bridge_id}-{handle_sans_at}"
     // Mirrors the NAPI bridge's ID generation logic.
@@ -413,6 +441,7 @@ pub fn bridge_create_shadow(
         shadow_id,
         platform_handle,
         bridge_id,
+        context_id: ctx_id,
         attributed_role: "observer".to_owned(),
         provenance_status: ShadowProvenanceStatus::Shadow.as_str().to_owned(),
     })

--- a/crates/scp-ffi/wasm/src/discovery.rs
+++ b/crates/scp-ffi/wasm/src/discovery.rs
@@ -99,19 +99,18 @@ fn validate_scope(scope: &str) -> Result<(), String> {
     Ok(())
 }
 
-/// Determines the address type from the scope part.
+/// Determines the address type from the scope part per spec §22.2.
 ///
-/// - Scope contains `.` => `"DomainHandle"` (e.g., `alice@example.com`)
-/// - Scope starts with `did:` => `"AttestationHandle"` (e.g., `alice@did:key:z6Mk...`)
-/// - Scope is `_` => `"Unscoped"` (e.g., `alice@_`)
-/// - Otherwise => `"DiscoveryHandle"` (e.g., `alice@photography`)
+/// - Scope contains `.` => `"domain_handle"` (e.g., `alice@example.com`)
+/// - Otherwise => `"discovery_handle"` (e.g., `alice@photography`)
+///
+/// Note: `Unscoped` (bare name, no `@`) and `AttestationHandle` (platform-
+/// prefixed) are distinguished at the address parsing level in scp-core,
+/// not by scope string inspection. The WASM bridge only handles the two
+/// scope-based types that the spec's §22.2 disambiguation table defines.
 fn classify_scope(scope: &str) -> &'static str {
-    if scope == "_" {
-        "unscoped"
-    } else if scope.contains('.') {
+    if scope.contains('.') {
         "domain_handle"
-    } else if scope.starts_with("did:") {
-        "attestation_handle"
     } else {
         "discovery_handle"
     }
@@ -406,25 +405,13 @@ fn parse_scp_uri(uri_str: &str) -> Result<String, String> {
 
     // Timestamp: js_sys is not available in non-wasm test builds, so use a
     // seconds-since-epoch value. In wasm32, js_sys::Date::now() provides
-    // milliseconds; for native test builds, fall back to std::time.
-    #[cfg(target_arch = "wasm32")]
-    #[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
-    let now_secs = (js_sys::Date::now() / 1000.0) as u64;
-
-    #[cfg(not(target_arch = "wasm32"))]
-    let now_secs = std::time::SystemTime::now()
-        .duration_since(std::time::UNIX_EPOCH)
-        .map(|d| d.as_secs())
-        .unwrap_or(0);
-
     // Build a single ContextDiscoveryResult matching the NAPI bridge's
-    // discovery_result_to_json output format, including trust_level and
-    // resolution_path per §22.2.1.
+    // discovery_result_to_json output format, including trust_level per §22.2.1.
     //
     // An scp:// URI is shared out-of-band, so the trust level is
-    // DirectExchange and the resolution layer is "domain" (closest match
-    // for URI-based resolution — no discovery context is involved).
-    // See NAPI bridge: ContextDiscoverySource::ContextUri mapping.
+    // DirectExchange. resolution_path is null because no spec-defined
+    // ResolutionPath.layer value (§22.7: petname/discovery_context/
+    // attestation/domain) applies to direct URI dereference.
     let result = serde_json::json!([{
         "context_id": context_id,
         "relay_urls": relay_urls,
@@ -435,12 +422,7 @@ fn parse_scp_uri(uri_str: &str) -> Result<String, String> {
         "trust_level": {
             "kind": "DirectExchange",
         },
-        "resolution_path": {
-            "layer": "domain",
-            "source": "context_uri",
-            "source_id": null,
-            "resolved_at": now_secs,
-        },
+        "resolution_path": null,
     }]);
 
     Ok(result.to_string())
@@ -573,10 +555,12 @@ mod tests {
 
     #[test]
     fn classify_scope_types() {
-        assert_eq!(classify_scope("_"), "unscoped");
+        // Only two scope-based types per spec §22.2: domain (has `.`) or discovery
         assert_eq!(classify_scope("example.com"), "domain_handle");
-        assert_eq!(classify_scope("did:key:z6MkTest"), "attestation_handle");
         assert_eq!(classify_scope("photography"), "discovery_handle");
+        // "_" and "did:" scopes are regular scopes — not special-cased
+        assert_eq!(classify_scope("_"), "discovery_handle");
+        assert_eq!(classify_scope("did:key:z6MkTest"), "discovery_handle");
     }
 
     // -- scp:// URI parsing tests -------------------------------------------
@@ -593,12 +577,9 @@ mod tests {
         assert_eq!(arr[0]["relay_urls"][0], "wss://relay.example.com/scp/v1");
         assert_eq!(arr[0]["discovery_source"], "context_uri");
         assert_eq!(arr[0]["mode"], "broadcast");
-        // §22.7: trust_level and resolution_path must be present
+        // §22.7: trust_level present, resolution_path null (no spec layer fits URI dereference)
         assert_eq!(arr[0]["trust_level"]["kind"], "DirectExchange");
-        assert_eq!(arr[0]["resolution_path"]["layer"], "domain");
-        assert_eq!(arr[0]["resolution_path"]["source"], "context_uri");
-        assert!(arr[0]["resolution_path"]["source_id"].is_null());
-        assert!(arr[0]["resolution_path"]["resolved_at"].as_u64().unwrap() > 0);
+        assert!(arr[0]["resolution_path"].is_null());
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Follow-up to #732 (merged). Addresses 4 spec-drift findings from the post-merge bot run:

1. **classify_scope**: Remove non-spec `"unscoped"` (`_` scope) and `"attestation_handle"` (`did:` scope) branches — only domain (has `.`) vs discovery per §22.2 disambiguation table
2. **parse_scp_uri**: Set `resolution_path` to `null` — no spec-defined `ResolutionPath.layer` value (§22.7) applies to direct scp:// URI dereference
3. **bridge_register**: Use `SHA-256(context_id || operator_did || platform || timestamp)` per spec §12.2.1 instead of simplified prefix-based ID
4. **WasmShadowIdentity**: Add `context_id` field and wire computed value through — callers need context association per §12.3

Closes #555

## Test plan

- [x] `cargo clippy -p scp-ffi-wasm --target wasm32-unknown-unknown -- -D warnings` passes
- [x] `cargo test -p scp-ffi-wasm --lib` — 91 tests pass
- [x] `cargo fmt --all -- --check` passes
- [x] Test assertions updated for classify_scope and parse_scp_uri changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)