### PR TITLE
fix(wasm): implement per-author block lists per §5.14.8 (closes #749)

### DIFF
--- a/crates/scp-ffi/wasm/src/manager.rs
+++ b/crates/scp-ffi/wasm/src/manager.rs
@@ -1923,6 +1923,7 @@ impl WasmContextManager {
                 let ctx = self.require_active_context_mut(context_id)?;
                 if let Some(ref mut bc) = ctx.broadcast {
                     bc.authors.remove(did);
+                    bc.key_epochs.remove(did);
                 }
                 ctx.write_revoked_members.insert(did.clone());
                 ctx.push_event(WasmContextEvent::WriteAccessRevoked { did: did.clone() });


### PR DESCRIPTION
## Summary

- `BroadcastState` replaced flat `blocked_subscribers: HashSet<String>` with per-author block lists: `authors: HashMap<String, HashSet<String>>` where each author DID maps to their individual block list
- `broadcast_block`/`broadcast_unblock` now operate on specific author's block list only
- `handle_broadcast_key_request` checks the requested author's block list, not a global set
- Governance `RevokeReadAccess`/`RestoreReadAccess` propagate to ALL authors' block lists
- Export/import updated to preserve per-author structure

## Test plan

- [x] `cargo clippy -p scp-ffi-wasm --target wasm32-unknown-unknown -- -D warnings` — clean
- [x] `cargo fmt --all -- --check` — clean
- [x] `cargo test -p scp-ffi-wasm --lib` — 108 tests pass
- [ ] Full CI
- [ ] Reviewer convergence

🤖 Generated with [Claude Code](https://claude.com/claude-code)