### PR TITLE
fix(uniffi): align DataProvenance with spec — 12 fields (closes #587)

### DIFF
--- a/bindings/swift/Sources/SCP/Internal/ScpBindings.swift
+++ b/bindings/swift/Sources/SCP/Internal/ScpBindings.swift
@@ -2388,48 +2388,123 @@ public func FfiConverterTypeDIDDocument_lower(_ value: DidDocument) -> RustBuffe
 
 
 /**
- * Provenance metadata for cross-context data transfer.
+ * Provenance metadata for cross-context data transfer (spec §7.7.1).
  *
  * Every message or tool output that crosses a context boundary carries
- * provenance metadata tracing it back to its origin. See spec §12 (Provenance).
+ * provenance metadata tracing it back to its origin. Records the full
+ * lineage: where data came from, who was involved, how it was discovered,
+ * and how many context hops it has traversed.
+ *
+ * See ADR-019 and spec §24 (Provenance System).
  */
 public struct DataProvenance {
     /**
-     * DID of the original data source.
+     * The context from which this data originated.
      */
-    public var sourceDid: String
+    public var sourceContext: String
     /**
-     * Context ID where this data originated.
+     * Current data availability status of the source context.
+     * One of `"Persistent"`, `"Ephemeral"`, or `"Summary"`.
      */
-    public var originContextId: String
+    public var sourceType: String
     /**
-     * Depth of cross-context hops (0 = direct, 1 = one hop, etc.).
+     * DIDs of the parties involved in the source context at the time of
+     * data flow.
      */
-    public var chainDepth: UInt32
+    public var counterparties: [String]
     /**
-     * Ed25519 signature bytes over the provenance record.
+     * Optional human-readable purpose description for this data flow.
      */
-    public var signature: Data
+    public var purpose: String?
+    /**
+     * How the data source was discovered. Serialized as:
+     * - `"None"` -- no protocol-level discovery path
+     * - `"SharedContext:<context_id>"` -- shared membership
+     * - `"Registry:<context_id>"` -- discovery registry
+     */
+    public var discoveryMethod: String
+    /**
+     * Age of the data in seconds at the time provenance was attached.
+     */
+    public var ageSecs: UInt64
+    /**
+     * Memory scope of the source context: `"Full"`, `"Summary"`, or
+     * `"Ephemeral"`.
+     */
+    public var memoryScope: String
+    /**
+     * Number of cross-context hops this data has traversed. Protocol
+     * default maximum is 3.
+     */
+    public var chainDepth: UInt8
+    /**
+     * Ordered list of intermediary context IDs when `chainDepth > 0`.
+     */
+    public var chainPath: [String]?
+    /**
+     * Cost of producing this data as a u64 amount, if any (spec §19.6).
+     */
+    public var paymentAmount: UInt64?
+    /**
+     * Payment adapter used for the payment, if any (spec §19.6).
+     */
+    public var paymentAdapter: String?
+    /**
+     * Hex-encoded receipt ID for verification of the payment, if any.
+     */
+    public var paymentReceiptId: String?
 
     // Default memberwise initializers are never public by default, so we
     // declare one manually.
     public init(
         /**
-         * DID of the original data source.
-         */sourceDid: String, 
+         * The context from which this data originated.
+         */sourceContext: String,
         /**
-         * Context ID where this data originated.
-         */originContextId: String, 
+         * Current data availability status of the source context.
+         */sourceType: String,
         /**
-         * Depth of cross-context hops (0 = direct, 1 = one hop, etc.).
-         */chainDepth: UInt32, 
+         * DIDs of the parties involved in the source context.
+         */counterparties: [String],
         /**
-         * Ed25519 signature bytes over the provenance record.
-         */signature: Data) {
-        self.sourceDid = sourceDid
-        self.originContextId = originContextId
+         * Optional human-readable purpose description.
+         */purpose: String?,
+        /**
+         * How the data source was discovered.
+         */discoveryMethod: String,
+        /**
+         * Age of the data in seconds.
+         */ageSecs: UInt64,
+        /**
+         * Memory scope of the source context.
+         */memoryScope: String,
+        /**
+         * Number of cross-context hops.
+         */chainDepth: UInt8,
+        /**
+         * Ordered list of intermediary context IDs.
+         */chainPath: [String]?,
+        /**
+         * Cost of producing this data.
+         */paymentAmount: UInt64?,
+        /**
+         * Payment adapter used.
+         */paymentAdapter: String?,
+        /**
+         * Hex-encoded receipt ID.
+         */paymentReceiptId: String?) {
+        self.sourceContext = sourceContext
+        self.sourceType = sourceType
+        self.counterparties = counterparties
+        self.purpose = purpose
+        self.discoveryMethod = discoveryMethod
+        self.ageSecs = ageSecs
+        self.memoryScope = memoryScope
         self.chainDepth = chainDepth
-        self.signature = signature
+        self.chainPath = chainPath
+        self.paymentAmount = paymentAmount
+        self.paymentAdapter = paymentAdapter
+        self.paymentReceiptId = paymentReceiptId
     }
 }
 
@@ -2440,26 +2515,58 @@ extension DataProvenance: Sendable {}
 
 extension DataProvenance: Equatable, Hashable {
     public static func ==(lhs: DataProvenance, rhs: DataProvenance) -> Bool {
-        if lhs.sourceDid != rhs.sourceDid {
+        if lhs.sourceContext != rhs.sourceContext {
             return false
         }
-        if lhs.originContextId != rhs.originContextId {
+        if lhs.sourceType != rhs.sourceType {
+            return false
+        }
+        if lhs.counterparties != rhs.counterparties {
+            return false
+        }
+        if lhs.purpose != rhs.purpose {
+            return false
+        }
+        if lhs.discoveryMethod != rhs.discoveryMethod {
+            return false
+        }
+        if lhs.ageSecs != rhs.ageSecs {
+            return false
+        }
+        if lhs.memoryScope != rhs.memoryScope {
             return false
         }
         if lhs.chainDepth != rhs.chainDepth {
             return false
         }
-        if lhs.signature != rhs.signature {
+        if lhs.chainPath != rhs.chainPath {
+            return false
+        }
+        if lhs.paymentAmount != rhs.paymentAmount {
+            return false
+        }
+        if lhs.paymentAdapter != rhs.paymentAdapter {
+            return false
+        }
+        if lhs.paymentReceiptId != rhs.paymentReceiptId {
             return false
         }
         return true
     }
 
     public func hash(into hasher: inout Hasher) {
-        hasher.combine(sourceDid)
-        hasher.combine(originContextId)
+        hasher.combine(sourceContext)
+        hasher.combine(sourceType)
+        hasher.combine(counterparties)
+        hasher.combine(purpose)
+        hasher.combine(discoveryMethod)
+        hasher.combine(ageSecs)
+        hasher.combine(memoryScope)
         hasher.combine(chainDepth)
-        hasher.combine(signature)
+        hasher.combine(chainPath)
+        hasher.combine(paymentAmount)
+        hasher.combine(paymentAdapter)
+        hasher.combine(paymentReceiptId)
     }
 }
 
@@ -2472,18 +2579,34 @@ public struct FfiConverterTypeDataProvenance: FfiConverterRustBuffer {
     public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> DataProvenance {
         return
             try DataProvenance(
-                sourceDid: FfiConverterString.read(from: &buf), 
-                originContextId: FfiConverterString.read(from: &buf), 
-                chainDepth: FfiConverterUInt32.read(from: &buf), 
-                signature: FfiConverterData.read(from: &buf)
+                sourceContext: FfiConverterString.read(from: &buf),
+                sourceType: FfiConverterString.read(from: &buf),
+                counterparties: FfiConverterSequenceString.read(from: &buf),
+                purpose: FfiConverterOptionString.read(from: &buf),
+                discoveryMethod: FfiConverterString.read(from: &buf),
+                ageSecs: FfiConverterUInt64.read(from: &buf),
+                memoryScope: FfiConverterString.read(from: &buf),
+                chainDepth: FfiConverterUInt8.read(from: &buf),
+                chainPath: FfiConverterOptionSequenceString.read(from: &buf),
+                paymentAmount: FfiConverterOptionUInt64.read(from: &buf),
+                paymentAdapter: FfiConverterOptionString.read(from: &buf),
+                paymentReceiptId: FfiConverterOptionString.read(from: &buf)
         )
     }
 
     public static func write(_ value: DataProvenance, into buf: inout [UInt8]) {
-        FfiConverterString.write(value.sourceDid, into: &buf)
-        FfiConverterString.write(value.originContextId, into: &buf)
-        FfiConverterUInt32.write(value.chainDepth, into: &buf)
-        FfiConverterData.write(value.signature, into: &buf)
+        FfiConverterString.write(value.sourceContext, into: &buf)
+        FfiConverterString.write(value.sourceType, into: &buf)
+        FfiConverterSequenceString.write(value.counterparties, into: &buf)
+        FfiConverterOptionString.write(value.purpose, into: &buf)
+        FfiConverterString.write(value.discoveryMethod, into: &buf)
+        FfiConverterUInt64.write(value.ageSecs, into: &buf)
+        FfiConverterString.write(value.memoryScope, into: &buf)
+        FfiConverterUInt8.write(value.chainDepth, into: &buf)
+        FfiConverterOptionSequenceString.write(value.chainPath, into: &buf)
+        FfiConverterOptionUInt64.write(value.paymentAmount, into: &buf)
+        FfiConverterOptionString.write(value.paymentAdapter, into: &buf)
+        FfiConverterOptionString.write(value.paymentReceiptId, into: &buf)
     }
 }
 

--- a/bindings/swift/Tests/SCPTests/ContextTests.swift
+++ b/bindings/swift/Tests/SCPTests/ContextTests.swift
@@ -253,10 +253,18 @@ struct ContextTests {
             sequence: 2,
             contextId: "test-context-001",
             provenance: DataProvenance(
-                sourceDid: "did:dht:bob",
-                originContextId: "other-ctx",
+                sourceContext: "other-ctx",
+                sourceType: "Persistent",
+                counterparties: ["did:dht:bob"],
+                purpose: nil,
+                discoveryMethod: "None",
+                ageSecs: 0,
+                memoryScope: "Full",
                 chainDepth: 1,
-                signature: Data(repeating: 0x00, count: 64)
+                chainPath: nil,
+                paymentAmount: nil,
+                paymentAdapter: nil,
+                paymentReceiptId: nil
             )
         )
 
@@ -273,7 +281,7 @@ struct ContextTests {
         #expect(received[0].senderDid == "did:dht:alice")
         #expect(received[0].sequence == 1)
         #expect(received[1].senderDid == "did:dht:bob")
-        #expect(received[1].provenance?.originContextId == "other-ctx")
+        #expect(received[1].provenance?.sourceContext == "other-ctx")
     }
 
     @Test("messages stream finishes on error")

--- a/bindings/swift/Tests/SCPTests/RealFFITests.swift
+++ b/bindings/swift/Tests/SCPTests/RealFFITests.swift
@@ -1552,10 +1552,18 @@ struct RealFFITypeShapeTests {
             sequence: 42,
             contextId: "ctx-test",
             provenance: DataProvenance(
-                sourceDid: "did:dht:z6MkBob",
-                originContextId: "ctx-origin",
+                sourceContext: "ctx-origin",
+                sourceType: "Persistent",
+                counterparties: ["did:dht:z6MkBob"],
+                purpose: nil,
+                discoveryMethod: "None",
+                ageSecs: 60,
+                memoryScope: "Full",
                 chainDepth: 1,
-                signature: Data(repeating: 0xAB, count: 64)
+                chainPath: ["ctx-hop"],
+                paymentAmount: nil,
+                paymentAdapter: nil,
+                paymentReceiptId: nil
             )
         )
         #expect(msg.senderDid == "did:dht:z6MkAlice")
@@ -1563,8 +1571,8 @@ struct RealFFITypeShapeTests {
         #expect(msg.timestamp == 1_700_000_000)
         #expect(msg.sequence == 42)
         #expect(msg.contextId == "ctx-test")
-        #expect(msg.provenance?.sourceDid == "did:dht:z6MkBob")
-        #expect(msg.provenance?.originContextId == "ctx-origin")
+        #expect(msg.provenance?.sourceContext == "ctx-origin")
+        #expect(msg.provenance?.sourceType == "Persistent")
         #expect(msg.provenance?.chainDepth == 1)
     }
 
@@ -1734,17 +1742,33 @@ struct RealFFITypeShapeTests {
         #expect(session.sessionId == "sess-001")
     }
 
-    @Test("FFI: DataProvenance struct construction")
+    @Test("FFI: DataProvenance struct construction — 12 fields per spec §7.7.1")
     func ffiDataProvenanceConstruction() {
         let prov = DataProvenance(
-            sourceDid: "did:dht:z6MkSource",
-            originContextId: "ctx-origin",
+            sourceContext: "ctx-origin",
+            sourceType: "Persistent",
+            counterparties: ["did:dht:z6MkAlice", "did:dht:z6MkBob"],
+            purpose: "recipe sharing",
+            discoveryMethod: "SharedContext:ctx-shared",
+            ageSecs: 300,
+            memoryScope: "Full",
             chainDepth: 2,
-            signature: Data(repeating: 0xCC, count: 64)
+            chainPath: ["ctx-hop-1", "ctx-hop-2"],
+            paymentAmount: 100,
+            paymentAdapter: "lightning",
+            paymentReceiptId: "abcdef0123456789"
         )
-        #expect(prov.sourceDid == "did:dht:z6MkSource")
-        #expect(prov.originContextId == "ctx-origin")
+        #expect(prov.sourceContext == "ctx-origin")
+        #expect(prov.sourceType == "Persistent")
+        #expect(prov.counterparties.count == 2)
+        #expect(prov.purpose == "recipe sharing")
+        #expect(prov.discoveryMethod == "SharedContext:ctx-shared")
+        #expect(prov.ageSecs == 300)
+        #expect(prov.memoryScope == "Full")
         #expect(prov.chainDepth == 2)
-        #expect(prov.signature.count == 64)
+        #expect(prov.chainPath?.count == 2)
+        #expect(prov.paymentAmount == 100)
+        #expect(prov.paymentAdapter == "lightning")
+        #expect(prov.paymentReceiptId == "abcdef0123456789")
     }
 }

--- a/crates/scp-ffi/uniffi/src/bridge.rs
+++ b/crates/scp-ffi/uniffi/src/bridge.rs
@@ -764,20 +764,47 @@ pub struct Message {
     pub provenance: Option<DataProvenance>,
 }
 
-/// Provenance metadata for cross-context data transfer.
+/// Provenance metadata for cross-context data transfer (spec §7.7.1).
 ///
 /// Every message or tool output that crosses a context boundary carries
-/// provenance metadata tracing it back to its origin. See spec §12 (Provenance).
+/// provenance metadata tracing it back to its origin. Records the full
+/// lineage: where data came from, who was involved, how it was discovered,
+/// and how many context hops it has traversed.
+///
+/// See ADR-019 and spec §24 (Provenance System).
 #[derive(Debug, Clone, uniffi::Record)]
 pub struct DataProvenance {
-    /// DID of the original data source.
-    pub source_did: String,
-    /// Context ID where this data originated.
-    pub origin_context_id: String,
-    /// Depth of cross-context hops (0 = direct, 1 = one hop, etc.).
-    pub chain_depth: u32,
-    /// Ed25519 signature bytes over the provenance record.
-    pub signature: Vec<u8>,
+    /// The context from which this data originated.
+    pub source_context: String,
+    /// Current data availability status of the source context.
+    /// One of `"Persistent"`, `"Ephemeral"`, or `"Summary"`.
+    pub source_type: String,
+    /// DIDs of the parties involved in the source context at the time of
+    /// data flow.
+    pub counterparties: Vec<String>,
+    /// Optional human-readable purpose description for this data flow.
+    pub purpose: Option<String>,
+    /// How the data source was discovered. Serialized as:
+    /// - `"None"` -- no protocol-level discovery path
+    /// - `"SharedContext:<context_id>"` -- shared membership
+    /// - `"Registry:<context_id>"` -- discovery registry
+    pub discovery_method: String,
+    /// Age of the data in seconds at the time provenance was attached.
+    pub age_secs: u64,
+    /// Memory scope of the source context: `"Full"`, `"Summary"`, or
+    /// `"Ephemeral"`.
+    pub memory_scope: String,
+    /// Number of cross-context hops this data has traversed. Protocol
+    /// default maximum is 3.
+    pub chain_depth: u8,
+    /// Ordered list of intermediary context IDs when `chain_depth > 0`.
+    pub chain_path: Option<Vec<String>>,
+    /// Cost of producing this data as a u64 amount, if any (spec §19.6).
+    pub payment_amount: Option<u64>,
+    /// Payment adapter used for the payment, if any (spec §19.6).
+    pub payment_adapter: Option<String>,
+    /// Hex-encoded receipt ID for verification of the payment, if any.
+    pub payment_receipt_id: Option<String>,
 }
 
 /// Tool definition for registration in a context.
@@ -5771,6 +5798,16 @@ pub fn provenance_attach(
         None,
     );
 
+    let discovery_method_json = match &prov.discovery_method {
+        scp_core::provenance::DiscoveryMethod::SharedContext(ctx_id) => {
+            serde_json::json!({"SharedContext": ctx_id})
+        }
+        scp_core::provenance::DiscoveryMethod::Registry(ctx_id) => {
+            serde_json::json!({"Registry": ctx_id})
+        }
+        scp_core::provenance::DiscoveryMethod::None => serde_json::json!("None"),
+    };
+
     let result = serde_json::json!({
         "source_context": prov.source_context,
         "source_type": format!("{:?}", prov.source_type),
@@ -5780,6 +5817,10 @@ pub fn provenance_attach(
         "memory_scope": format!("{:?}", prov.memory_scope),
         "chain_path": prov.chain_path,
         "purpose": prov.purpose,
+        "discovery_method": discovery_method_json,
+        "payment_amount": prov.payment_amount.map(|a| a.0),
+        "payment_adapter": prov.payment_adapter,
+        "payment_receipt_id": prov.payment_receipt_id.map(hex::encode),
     });
 
     serde_json::to_string(&result).map_err(|e| ScpError::Validation {

--- a/crates/scp-ffi/uniffi/tests/e2e_bridge.rs
+++ b/crates/scp-ffi/uniffi/tests/e2e_bridge.rs
@@ -23,6 +23,7 @@
 use scp_ffi_uniffi::{
     // Types
     ContextParams,
+    DataProvenance,
     GovernanceModel,
     MemoryScope,
     ToolDefinition,
@@ -667,6 +668,102 @@ async fn evaluate_provenance_quality_rejects_invalid_source_type() {
     let result =
         evaluate_provenance_quality(None, "invalid_type".to_owned(), "active".to_owned(), vec![]);
     assert!(result.is_err(), "Invalid source type should be rejected");
+}
+
+#[tokio::test]
+async fn data_provenance_record_has_all_12_fields() {
+    // Construct a DataProvenance with all 12 fields to verify the struct is
+    // fully aligned with spec §7.7.1.
+    let prov = DataProvenance {
+        source_context: "ctx-origin-001".to_owned(),
+        source_type: "Persistent".to_owned(),
+        counterparties: vec!["did:dht:z6MkAlice".to_owned(), "did:dht:z6MkBob".to_owned()],
+        purpose: Some("data sharing".to_owned()),
+        discovery_method: "SharedContext:ctx-shared".to_owned(),
+        age_secs: 300,
+        memory_scope: "Full".to_owned(),
+        chain_depth: 1,
+        chain_path: Some(vec!["ctx-hop-1".to_owned()]),
+        payment_amount: Some(100),
+        payment_adapter: Some("lightning".to_owned()),
+        payment_receipt_id: Some("ab".repeat(32)),
+    };
+
+    assert_eq!(prov.source_context, "ctx-origin-001");
+    assert_eq!(prov.source_type, "Persistent");
+    assert_eq!(prov.counterparties.len(), 2);
+    assert_eq!(prov.purpose.as_deref(), Some("data sharing"));
+    assert_eq!(prov.discovery_method, "SharedContext:ctx-shared");
+    assert_eq!(prov.age_secs, 300);
+    assert_eq!(prov.memory_scope, "Full");
+    assert_eq!(prov.chain_depth, 1);
+    assert_eq!(prov.chain_path.as_ref().map(Vec::len), Some(1));
+    assert_eq!(prov.payment_amount, Some(100));
+    assert_eq!(prov.payment_adapter.as_deref(), Some("lightning"));
+    assert!(prov.payment_receipt_id.is_some());
+}
+
+#[tokio::test]
+async fn data_provenance_record_optional_fields_can_be_none() {
+    let prov = DataProvenance {
+        source_context: "ctx-minimal".to_owned(),
+        source_type: "Ephemeral".to_owned(),
+        counterparties: vec![],
+        purpose: None,
+        discovery_method: "None".to_owned(),
+        age_secs: 0,
+        memory_scope: "Ephemeral".to_owned(),
+        chain_depth: 0,
+        chain_path: None,
+        payment_amount: None,
+        payment_adapter: None,
+        payment_receipt_id: None,
+    };
+
+    assert!(prov.purpose.is_none());
+    assert!(prov.chain_path.is_none());
+    assert!(prov.payment_amount.is_none());
+    assert!(prov.payment_adapter.is_none());
+    assert!(prov.payment_receipt_id.is_none());
+}
+
+#[tokio::test]
+async fn provenance_attach_json_contains_all_12_fields() {
+    let result = provenance_attach(
+        "ctx-source".to_owned(),
+        "persistent".to_owned(),
+        "full".to_owned(),
+        vec!["did:dht:z6MkAlice".to_owned()],
+        "ctx-target".to_owned(),
+        None,
+    )
+    .unwrap();
+
+    let parsed: serde_json::Value = serde_json::from_str(&result).unwrap();
+    let obj = parsed.as_object().unwrap();
+
+    // All 12 fields must be present in the JSON output
+    assert!(obj.contains_key("source_context"), "missing source_context");
+    assert!(obj.contains_key("source_type"), "missing source_type");
+    assert!(obj.contains_key("counterparties"), "missing counterparties");
+    assert!(obj.contains_key("purpose"), "missing purpose");
+    assert!(
+        obj.contains_key("discovery_method"),
+        "missing discovery_method"
+    );
+    assert!(obj.contains_key("age_secs"), "missing age_secs");
+    assert!(obj.contains_key("memory_scope"), "missing memory_scope");
+    assert!(obj.contains_key("chain_depth"), "missing chain_depth");
+    assert!(obj.contains_key("chain_path"), "missing chain_path");
+    assert!(obj.contains_key("payment_amount"), "missing payment_amount");
+    assert!(
+        obj.contains_key("payment_adapter"),
+        "missing payment_adapter"
+    );
+    assert!(
+        obj.contains_key("payment_receipt_id"),
+        "missing payment_receipt_id"
+    );
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Replace the UniFFI bridge's 4-field `DataProvenance` record (`source_did`, `origin_context_id`, `chain_depth: u32`, `signature`) with the correct 12 fields from `scp-core::provenance::DataProvenance` per spec §7.7.1
- Add 4 missing fields to `provenance_attach` JSON output (`discovery_method`, `payment_amount`, `payment_adapter`, `payment_receipt_id`), matching the NAPI reference bridge
- Update Swift `ScpBindings.swift` (generated bindings) and all Swift tests to use the new 12-field struct

## Test plan

- [x] `cargo clippy --workspace --all-targets --features scp-ffi-uniffi/allow_in_memory_custody,scp-ffi/allow_in_memory_custody,scp-ffi-napi/allow_in_memory_custody,scp-core/testing -- -D warnings` — clean
- [x] `cargo fmt --all -- --check` — clean
- [x] `cargo test -p scp-ffi-uniffi --test e2e_bridge --features allow_in_memory_custody` — 42/42 pass
- [x] New test `data_provenance_record_has_all_12_fields` — validates all 12 fields construct and roundtrip
- [x] New test `data_provenance_record_optional_fields_can_be_none` — validates optional fields accept None
- [x] New test `provenance_attach_json_contains_all_12_fields` — validates JSON output contains all expected keys

🤖 Generated with [Claude Code](https://claude.com/claude-code)