### PR TITLE
fix(python): add missing ucan_token param to py_mcp_serve stub

### DIFF
--- a/bindings/python/scp_sdk/_scp_core.pyi
+++ b/bindings/python/scp_sdk/_scp_core.pyi
@@ -1002,6 +1002,7 @@ def py_mcp_serve(
     identity_did: str,
     context_ids: list[str],
     transport: str,
+    ucan_token: str | None = None,
 ) -> str:
     """Start an MCP server exposing SCP contexts.
 
@@ -1012,6 +1013,9 @@ def py_mcp_serve(
         identity_did: The DID of the serving identity.
         context_ids: List of context IDs to expose via MCP.
         transport: Transport mode -- ``"stdio"`` or ``"sse"``.
+        ucan_token: Optional UCAN token (JWT) authorizing the server
+            to act on behalf of the identity. Passed through to the
+            MCP server provider for tool invocation authorization.
 
     Returns:
         An opaque server handle string.


### PR DESCRIPTION
## Summary
- Adds the missing `ucan_token: str | None = None` parameter to the `py_mcp_serve` function stub in `bindings/python/scp_sdk/_scp_core.pyi`
- Adds docstring documentation for the parameter
- Aligns the stub with the Rust PyO3 bridge signature in `crates/scp-ffi/src/mcp.rs`

Identified during post-merge review of PR #766.

## Test plan
- [x] `ruff check` passes
- [x] `ruff format` passes (no changes)
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)