### PR TITLE
fix(wasm): return validation errors for missing attestation token fields (closes #511)

### DIFF
--- a/crates/scp-ffi/wasm/src/identity.rs
+++ b/crates/scp-ffi/wasm/src/identity.rs
@@ -1510,7 +1510,7 @@ pub fn identity_load(did: String) -> Promise {
 // ---------------------------------------------------------------------------
 
 #[cfg(test)]
-#[allow(clippy::unwrap_used)]
+#[allow(clippy::unwrap_used, clippy::panic)]
 mod tests {
     use super::*;
 


### PR DESCRIPTION
## Summary
- Replaces `unwrap_or` silent fallbacks in WASM identity `verify_device_attestation` with proper validation errors
- Missing required token fields now return `SCP-VALID-7xxx` errors instead of silently using defaults
- Adds tests for the validation error paths

## Test plan
- [x] `cargo clippy -p scp-ffi-wasm --target wasm32-unknown-unknown -- -D warnings`
- [ ] Verify CI passes
- [ ] `cargo test -p scp-core --test wasm_conformance`

🤖 Generated with [Claude Code](https://claude.com/claude-code)