### PR TITLE
fix(wasm): enforce block list cap on governance ban, bump export version

### DIFF
--- a/crates/scp-ffi/wasm/src/manager.rs
+++ b/crates/scp-ffi/wasm/src/manager.rs
@@ -4260,42 +4260,93 @@ mod tests {
         assert_eq!(json["epoch"], 42);
     }
 
+    /// Helper: builds a `WasmContextManager` containing a single Broadcast
+    /// context with the given authors and subscribers pre-populated.
+    fn make_manager_with_broadcast(
+        context_id: &str,
+        creator_did: &str,
+        authors: &[&str],
+        subscribers: &[&str],
+    ) -> WasmContextManager {
+        let mut bc = make_broadcast(authors, subscribers);
+        // Ensure the creator is always an author (mirrors create_context).
+        if !bc.authors.contains_key(creator_did) {
+            bc.authors.insert(creator_did.to_owned(), HashSet::new());
+        }
+
+        let mut members = HashMap::new();
+        members.insert(
+            creator_did.to_owned(),
+            MemberEntry {
+                did: creator_did.to_owned(),
+                role: "admin".to_owned(),
+                sequence_number: 0,
+            },
+        );
+
+        let ctx = PerContextState {
+            state: "active".to_owned(),
+            params_json: serde_json::json!({"mode": "Broadcast"}),
+            creator_did: creator_did.to_owned(),
+            mode: "Broadcast".to_owned(),
+            ceiling_strings: HashSet::new(),
+            ceiling_policy: "immutable".to_owned(),
+            ttl_seconds: None,
+            promotion_policy: None,
+            governance: "single_admin".to_owned(),
+            economic_policy: None,
+            tool_registry: ToolRegistry::new(),
+            tool_handlers: HashMap::new(),
+            event_log: WasmEventLog::new(context_id.to_owned()),
+            revoked_tokens: HashSet::new(),
+            seen_nonces: HashMap::new(),
+            members,
+            event_buffer: VecDeque::new(),
+            executed_proposals: HashMap::new(),
+            write_revoked_members: HashSet::new(),
+            read_revoked_members: HashSet::new(),
+            read_exclusion_list: HashSet::new(),
+            broadcast: Some(bc),
+            sessions: HashMap::new(),
+            threshold_signers: Vec::new(),
+            threshold_value: 0,
+            tool_interfaces: Vec::new(),
+            governance_freeze: false,
+            pruning_policy: None,
+            economic_policy_locked: false,
+        };
+
+        let mut mgr = WasmContextManager::new();
+        mgr.contexts.insert(context_id.to_owned(), ctx);
+        mgr
+    }
+
     #[test]
     fn governance_ban_enforces_block_list_cap() {
-        let mut bc = make_broadcast(&["author-a", "author-b"], &[]);
+        let mut mgr =
+            make_manager_with_broadcast("ctx-1", "author-a", &["author-a", "author-b"], &[]);
 
         // Fill author-a's block list to exactly WASM_BLOCK_LIST_CAP.
-        for i in 0..WASM_BLOCK_LIST_CAP {
-            bc.authors
-                .get_mut("author-a")
-                .unwrap()
-                .insert(format!("did:dht:zfiller{i}"));
-        }
-        assert_eq!(bc.authors["author-a"].len(), WASM_BLOCK_LIST_CAP);
-        // author-b is still empty.
-        assert!(bc.authors["author-b"].is_empty());
-
-        // Simulate governance ban with cap enforcement (mirrors
-        // dispatch_revoke_read_access). The ban should fail because
-        // author-a's block list is at capacity.
-        let result: Result<(), ScpWasmError> = (|| {
-            for (author_did, block_list) in &mut bc.authors {
-                if block_list.len() >= WASM_BLOCK_LIST_CAP {
-                    return Err(ScpWasmError::Validation {
-                        message: format!(
-                            "per-author block list has reached capacity ({WASM_BLOCK_LIST_CAP}) \
-                             for author '{author_did}' during governance ban"
-                        ),
-                        code: "SCP-VALID-7301".to_owned(),
-                    });
-                }
-                block_list.insert("did:dht:zbanned".to_owned());
+        {
+            let ctx = mgr.contexts.get_mut("ctx-1").unwrap();
+            let bc = ctx.broadcast.as_mut().unwrap();
+            for i in 0..WASM_BLOCK_LIST_CAP {
+                bc.authors
+                    .get_mut("author-a")
+                    .unwrap()
+                    .insert(format!("did:dht:zfiller{i}"));
             }
-            Ok(())
-        })();
+            assert_eq!(bc.authors["author-a"].len(), WASM_BLOCK_LIST_CAP);
+            // author-b is still empty.
+            assert!(bc.authors["author-b"].is_empty());
+        }
 
-        assert!(result.is_err());
-        let err = result.unwrap_err();
+        // Call the real dispatch method — it should fail because author-a's
+        // block list is at capacity (pre-validation rejects before any mutation).
+        let err = mgr
+            .dispatch_revoke_read_access("ctx-1", "did:dht:zbanned", "full")
+            .unwrap_err();
+
         match &err {
             ScpWasmError::Validation { code, message } => {
                 assert_eq!(code, "SCP-VALID-7301");
@@ -4306,6 +4357,14 @@ mod tests {
             }
             other => panic!("expected Validation error, got: {other:?}"),
         }
+
+        // Verify no mutation occurred — author-b's block list must still be
+        // empty (pre-validation prevented partial writes).
+        let bc = mgr.contexts["ctx-1"].broadcast.as_ref().unwrap();
+        assert!(
+            bc.authors["author-b"].is_empty(),
+            "author-b's block list should be empty — pre-validation must prevent partial mutation"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- **Bug 1 (MEDIUM):** `dispatch_revoke_read_access` (governance ban path) inserted banned DIDs into all authors' block lists without checking `WASM_BLOCK_LIST_CAP`. The individual blocking path (`block_broadcast_subscriber`) correctly enforced the cap. Now both paths enforce the same cap with error code `SCP-VALID-7301`.
- **Bug 2 (MEDIUM):** PR #767 changed `WasmExportBroadcast` fields from flat `authors: Vec<String>` + `blocked_subscribers` to per-author `author_block_lists: HashMap<String, Vec<String>>`, but `WASM_EXPORT_VERSION` was not bumped from 1. Bumped to 2 and added `#[serde(default)]` on `author_block_lists` so v1 exports (which lack per-author blocking) deserialize gracefully with an empty map.

Both bugs found in post-merge review of #767.

## Test plan
- [x] New test `governance_ban_enforces_block_list_cap` — fills one author's block list to cap, verifies governance ban returns `SCP-VALID-7301`
- [x] New test `export_broadcast_defaults_missing_author_block_lists` — verifies v1 JSON without `author_block_lists` deserializes to empty map
- [x] New test `export_version_is_two` — asserts `WASM_EXPORT_VERSION == 2`
- [x] `cargo clippy -p scp-ffi-wasm --target wasm32-unknown-unknown -- -D warnings` passes
- [x] `cargo test -p scp-ffi-wasm` — all 119 tests pass
- [x] `bash scripts/check-error-codes.sh` — all 1717 error codes conform

🤖 Generated with [Claude Code](https://claude.com/claude-code)