### PR TITLE
fix(ffi): resolve error code collision and align schema validation

### DIFF
--- a/bindings/python/scp_sdk/context.py
+++ b/bindings/python/scp_sdk/context.py
@@ -412,6 +412,17 @@ class Context:
         ``tool_invoke:*`` capability scoped to this context.  See
         spec section 6.2, section 8, and ADR-016 for UCAN enforcement.
 
+        .. versionchanged:: 0.2.0
+            ``ucan_token`` is now a required positional parameter
+            (previously tool invocation did not require UCAN
+            authorization).  This is a **breaking change** -- callers
+            that previously used ``Context.invoke(tool, input)`` or
+            ``Context.invoke(tool, input, identity=...)`` must now
+            pass the UCAN token as the third positional argument:
+            ``Context.invoke(tool, input, ucan_token)``.
+            ``proof_tokens`` was also added as an optional keyword
+            argument for delegation chain resolution.
+
         Args:
             tool: The tool identifier.
             input: Input data as a JSON-compatible dict.

--- a/crates/scp-ffi/napi/src/tools.rs
+++ b/crates/scp-ffi/napi/src/tools.rs
@@ -106,12 +106,12 @@ pub struct NapiToolVerificationResult {
 
 /// Validates and parses a JSON schema string.
 ///
-/// Returns an `SCP-VALID-7031` error for `input_schema_json` or
-/// `SCP-VALID-7032` for `output_schema_json` when the JSON is malformed.
+/// Returns an `SCP-VALID-7035` error for `input_schema_json` or
+/// `SCP-VALID-7036` for `output_schema_json` when the JSON is malformed.
 fn validate_schema_json(json: &str, field_name: &str) -> napi::Result<serde_json::Value> {
     let code = match field_name {
-        "input_schema_json" => "SCP-VALID-7031",
-        _ => "SCP-VALID-7032",
+        "input_schema_json" => "SCP-VALID-7035",
+        _ => "SCP-VALID-7036",
     };
     serde_json::from_str(json).map_err(|e| {
         napi::Error::from(ScpNapiError::Validation {
@@ -124,7 +124,7 @@ fn validate_schema_json(json: &str, field_name: &str) -> napi::Result<serde_json
 /// Validates and parses optional test vectors JSON.
 ///
 /// `None` is acceptable (no test vectors). A `Some` value that is not valid
-/// JSON returns `SCP-VALID-7033`.
+/// JSON returns `SCP-VALID-7037`.
 fn validate_test_vectors_json(
     json: Option<&str>,
 ) -> napi::Result<Vec<scp_core::context::tools::TestVector>> {
@@ -134,7 +134,7 @@ fn validate_test_vectors_json(
             serde_json::from_str(s).map_err(|e| {
                 napi::Error::from(ScpNapiError::Validation {
                     message: format!("invalid test_vectors_json: {e}"),
-                    code: "SCP-VALID-7033".to_owned(),
+                    code: "SCP-VALID-7037".to_owned(),
                 })
             })
         },
@@ -144,7 +144,7 @@ fn validate_test_vectors_json(
 /// Validates an optional implementation hash.
 ///
 /// `None` is acceptable (defaults to zeroed hash). A `Some` value that is not
-/// exactly 32 bytes returns `SCP-VALID-7034`.
+/// exactly 32 bytes returns `SCP-VALID-7038`.
 fn validate_implementation_hash(bytes: Option<&[u8]>) -> napi::Result<[u8; 32]> {
     bytes.map_or_else(
         || Ok([0u8; 32]),
@@ -155,7 +155,7 @@ fn validate_implementation_hash(bytes: Option<&[u8]>) -> napi::Result<[u8; 32]> 
                         "implementation_hash must be exactly 32 bytes, got {}",
                         b.len()
                     ),
-                    code: "SCP-VALID-7034".to_owned(),
+                    code: "SCP-VALID-7038".to_owned(),
                 })
             })
         },
@@ -181,10 +181,10 @@ fn validate_implementation_hash(bytes: Option<&[u8]>) -> napi::Result<[u8; 32]> 
 /// # Errors
 ///
 /// - Rejects with `SCP-TOOL-6003` if the context is not `"active"`.
-/// - Rejects with `SCP-VALID-7031` if `input_schema_json` is not valid JSON.
-/// - Rejects with `SCP-VALID-7032` if `output_schema_json` is not valid JSON.
-/// - Rejects with `SCP-VALID-7033` if `test_vectors_json` is provided but not valid JSON.
-/// - Rejects with `SCP-VALID-7034` if `implementation_hash` is provided but not exactly 32 bytes.
+/// - Rejects with `SCP-VALID-7035` if `input_schema_json` is not valid JSON.
+/// - Rejects with `SCP-VALID-7036` if `output_schema_json` is not valid JSON.
+/// - Rejects with `SCP-VALID-7037` if `test_vectors_json` is provided but not valid JSON.
+/// - Rejects with `SCP-VALID-7038` if `implementation_hash` is provided but not exactly 32 bytes.
 /// - Rejects with `SCP-TOOL-6001` if registration fails (permission denied,
 ///   schema invalid, duplicate name, etc.) in the full runtime.
 #[napi]
@@ -910,8 +910,8 @@ mod tests {
         assert!(result.is_err());
         let msg = format!("{}", result.unwrap_err());
         assert!(
-            msg.contains("SCP-VALID-7031"),
-            "error should contain SCP-VALID-7031, got: {msg}"
+            msg.contains("SCP-VALID-7035"),
+            "error should contain SCP-VALID-7035, got: {msg}"
         );
         assert!(
             msg.contains("invalid input_schema_json"),
@@ -925,8 +925,8 @@ mod tests {
         assert!(result.is_err());
         let msg = format!("{}", result.unwrap_err());
         assert!(
-            msg.contains("SCP-VALID-7032"),
-            "error should contain SCP-VALID-7032, got: {msg}"
+            msg.contains("SCP-VALID-7036"),
+            "error should contain SCP-VALID-7036, got: {msg}"
         );
         assert!(
             msg.contains("invalid output_schema_json"),
@@ -939,7 +939,7 @@ mod tests {
         let result = validate_schema_json("", "input_schema_json");
         assert!(result.is_err());
         let msg = format!("{}", result.unwrap_err());
-        assert!(msg.contains("SCP-VALID-7031"));
+        assert!(msg.contains("SCP-VALID-7035"));
     }
 
     // -----------------------------------------------------------------------
@@ -966,8 +966,8 @@ mod tests {
         assert!(result.is_err());
         let msg = format!("{}", result.unwrap_err());
         assert!(
-            msg.contains("SCP-VALID-7033"),
-            "error should contain SCP-VALID-7033, got: {msg}"
+            msg.contains("SCP-VALID-7037"),
+            "error should contain SCP-VALID-7037, got: {msg}"
         );
         assert!(
             msg.contains("invalid test_vectors_json"),
@@ -981,7 +981,7 @@ mod tests {
         let result = validate_test_vectors_json(Some(r#"{"not": "an array"}"#));
         assert!(result.is_err());
         let msg = format!("{}", result.unwrap_err());
-        assert!(msg.contains("SCP-VALID-7033"));
+        assert!(msg.contains("SCP-VALID-7037"));
     }
 
     // -----------------------------------------------------------------------
@@ -1010,8 +1010,8 @@ mod tests {
         assert!(result.is_err());
         let msg = format!("{}", result.unwrap_err());
         assert!(
-            msg.contains("SCP-VALID-7034"),
-            "error should contain SCP-VALID-7034, got: {msg}"
+            msg.contains("SCP-VALID-7038"),
+            "error should contain SCP-VALID-7038, got: {msg}"
         );
         assert!(
             msg.contains("got 16"),
@@ -1025,7 +1025,7 @@ mod tests {
         let result = validate_implementation_hash(Some(&hash));
         assert!(result.is_err());
         let msg = format!("{}", result.unwrap_err());
-        assert!(msg.contains("SCP-VALID-7034"));
+        assert!(msg.contains("SCP-VALID-7038"));
         assert!(
             msg.contains("got 64"),
             "error should report actual length, got: {msg}"
@@ -1037,7 +1037,7 @@ mod tests {
         let result = validate_implementation_hash(Some(&[]));
         assert!(result.is_err());
         let msg = format!("{}", result.unwrap_err());
-        assert!(msg.contains("SCP-VALID-7034"));
+        assert!(msg.contains("SCP-VALID-7038"));
         assert!(msg.contains("got 0"));
     }
 }

--- a/crates/scp-ffi/src/tools.rs
+++ b/crates/scp-ffi/src/tools.rs
@@ -181,14 +181,38 @@ pub fn py_tool_register(context_id: &str, registration: &Bound<'_, PyDict>) -> P
         .downcast::<PyDict>()
         .map_err(|_| ScpPyError::validation("'schema' must be a dict".to_owned()))?;
     let schema_json = py_dict_to_json(schema_dict)?;
-    let input_schema = schema_json
-        .get("input_schema")
-        .cloned()
-        .unwrap_or_else(|| serde_json::json!({"type": "object"}));
-    let output_schema = schema_json
-        .get("output_schema")
-        .cloned()
-        .unwrap_or_else(|| serde_json::json!({"type": "object"}));
+    let input_schema = schema_json.get("input_schema").cloned().ok_or_else(|| {
+        ScpPyError::ValidationError {
+            message: "missing 'input_schema' in schema dict — both 'input_schema' and 'output_schema' are required".to_owned(),
+            code: "SCP-VALID-7035".to_owned(),
+        }
+    })?;
+    if !input_schema.is_object() {
+        return Err(ScpPyError::ValidationError {
+            message: format!(
+                "invalid 'input_schema': expected a JSON object, got {}",
+                value_type_name(&input_schema)
+            ),
+            code: "SCP-VALID-7035".to_owned(),
+        }
+        .into());
+    }
+    let output_schema = schema_json.get("output_schema").cloned().ok_or_else(|| {
+        ScpPyError::ValidationError {
+            message: "missing 'output_schema' in schema dict — both 'input_schema' and 'output_schema' are required".to_owned(),
+            code: "SCP-VALID-7036".to_owned(),
+        }
+    })?;
+    if !output_schema.is_object() {
+        return Err(ScpPyError::ValidationError {
+            message: format!(
+                "invalid 'output_schema': expected a JSON object, got {}",
+                value_type_name(&output_schema)
+            ),
+            code: "SCP-VALID-7036".to_owned(),
+        }
+        .into());
+    }
 
     // Extract test vectors (optional).
     let test_vectors = extract_test_vectors(registration)?;
@@ -656,6 +680,18 @@ fn extract_test_vectors(
     Ok(result)
 }
 
+/// Returns a human-readable type name for a `serde_json::Value`.
+const fn value_type_name(v: &serde_json::Value) -> &'static str {
+    match v {
+        serde_json::Value::Null => "null",
+        serde_json::Value::Bool(_) => "boolean",
+        serde_json::Value::Number(_) => "number",
+        serde_json::Value::String(_) => "string",
+        serde_json::Value::Array(_) => "array",
+        serde_json::Value::Object(_) => "object",
+    }
+}
+
 // ---------------------------------------------------------------------------
 // Cross-context tool invocation
 // ---------------------------------------------------------------------------
@@ -1079,4 +1115,145 @@ pub fn register_tools(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(py_tool_session_invoke, m)?)?;
     m.add_function(wrap_pyfunction!(py_tool_session_close, m)?)?;
     Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn value_type_name_covers_all_variants() {
+        assert_eq!(value_type_name(&serde_json::Value::Null), "null");
+        assert_eq!(value_type_name(&serde_json::Value::Bool(true)), "boolean");
+        assert_eq!(value_type_name(&serde_json::json!(42)), "number");
+        assert_eq!(value_type_name(&serde_json::json!("hello")), "string");
+        assert_eq!(value_type_name(&serde_json::json!([1, 2])), "array");
+        assert_eq!(value_type_name(&serde_json::json!({"a": 1})), "object");
+    }
+
+    /// Schema validation rejects missing `input_schema` with `SCP-VALID-7035`.
+    #[test]
+    fn schema_validation_rejects_missing_input_schema() {
+        pyo3::prepare_freethreaded_python();
+        Python::with_gil(|py| {
+            let dict = PyDict::new(py);
+            dict.set_item("name", "test-tool").unwrap();
+            dict.set_item("description", "a test").unwrap();
+            dict.set_item("operator_did", "did:dht:test123456789abcdefghij")
+                .unwrap();
+
+            // Schema dict with only output_schema, missing input_schema.
+            let schema = PyDict::new(py);
+            schema.set_item("output_schema", PyDict::new(py)).unwrap();
+            dict.set_item("schema", schema).unwrap();
+
+            let result = py_tool_register("ctx-test-id-000000", &dict.as_borrowed());
+            assert!(result.is_err(), "should reject missing input_schema");
+            let err_str = format!("{}", result.unwrap_err());
+            assert!(
+                err_str.contains("SCP-VALID-7035"),
+                "error should contain SCP-VALID-7035, got: {err_str}"
+            );
+            assert!(
+                err_str.contains("input_schema"),
+                "error should mention input_schema, got: {err_str}"
+            );
+        });
+    }
+
+    /// Schema validation rejects missing `output_schema` with `SCP-VALID-7036`.
+    #[test]
+    fn schema_validation_rejects_missing_output_schema() {
+        pyo3::prepare_freethreaded_python();
+        Python::with_gil(|py| {
+            let dict = PyDict::new(py);
+            dict.set_item("name", "test-tool").unwrap();
+            dict.set_item("description", "a test").unwrap();
+            dict.set_item("operator_did", "did:dht:test123456789abcdefghij")
+                .unwrap();
+
+            // Schema dict with only input_schema, missing output_schema.
+            let schema = PyDict::new(py);
+            let inner = PyDict::new(py);
+            inner.set_item("type", "object").unwrap();
+            schema.set_item("input_schema", inner).unwrap();
+            dict.set_item("schema", schema).unwrap();
+
+            let result = py_tool_register("ctx-test-id-000000", &dict.as_borrowed());
+            assert!(result.is_err(), "should reject missing output_schema");
+            let err_str = format!("{}", result.unwrap_err());
+            assert!(
+                err_str.contains("SCP-VALID-7036"),
+                "error should contain SCP-VALID-7036, got: {err_str}"
+            );
+            assert!(
+                err_str.contains("output_schema"),
+                "error should mention output_schema, got: {err_str}"
+            );
+        });
+    }
+
+    /// Schema validation rejects non-object `input_schema` with `SCP-VALID-7035`.
+    #[test]
+    fn schema_validation_rejects_non_object_input_schema() {
+        pyo3::prepare_freethreaded_python();
+        Python::with_gil(|py| {
+            let dict = PyDict::new(py);
+            dict.set_item("name", "test-tool").unwrap();
+            dict.set_item("description", "a test").unwrap();
+            dict.set_item("operator_did", "did:dht:test123456789abcdefghij")
+                .unwrap();
+
+            // Schema dict with input_schema as a string, not an object.
+            let schema = PyDict::new(py);
+            schema.set_item("input_schema", "not-an-object").unwrap();
+            let output = PyDict::new(py);
+            output.set_item("type", "object").unwrap();
+            schema.set_item("output_schema", output).unwrap();
+            dict.set_item("schema", schema).unwrap();
+
+            let result = py_tool_register("ctx-test-id-000000", &dict.as_borrowed());
+            assert!(result.is_err(), "should reject non-object input_schema");
+            let err_str = format!("{}", result.unwrap_err());
+            assert!(
+                err_str.contains("SCP-VALID-7035"),
+                "error should contain SCP-VALID-7035, got: {err_str}"
+            );
+        });
+    }
+
+    /// Schema validation rejects non-object `output_schema` with `SCP-VALID-7036`.
+    #[test]
+    fn schema_validation_rejects_non_object_output_schema() {
+        pyo3::prepare_freethreaded_python();
+        Python::with_gil(|py| {
+            let dict = PyDict::new(py);
+            dict.set_item("name", "test-tool").unwrap();
+            dict.set_item("description", "a test").unwrap();
+            dict.set_item("operator_did", "did:dht:test123456789abcdefghij")
+                .unwrap();
+
+            // Schema dict with output_schema as an array, not an object.
+            let schema = PyDict::new(py);
+            let input = PyDict::new(py);
+            input.set_item("type", "object").unwrap();
+            schema.set_item("input_schema", input).unwrap();
+            let output_list = pyo3::types::PyList::new(py, [1, 2, 3]).unwrap();
+            schema.set_item("output_schema", output_list).unwrap();
+            dict.set_item("schema", schema).unwrap();
+
+            let result = py_tool_register("ctx-test-id-000000", &dict.as_borrowed());
+            assert!(result.is_err(), "should reject non-object output_schema");
+            let err_str = format!("{}", result.unwrap_err());
+            assert!(
+                err_str.contains("SCP-VALID-7036"),
+                "error should contain SCP-VALID-7036, got: {err_str}"
+            );
+        });
+    }
 }


### PR DESCRIPTION
## Summary

Fixes 3 accepted findings from post-merge reviews of PR #760 and #761:

- **W5** (Context.invoke breaking change): Added `.. versionchanged::` directive documenting that `ucan_token` is now a required positional parameter in `Context.invoke()`. No CHANGELOG file exists in the project.
- **W7** (Error code collision): Renumbered NAPI tool validation codes from `SCP-VALID-7031/7032/7033/7034` to `SCP-VALID-7035/7036/7037/7038` to resolve collision with UniFFI `bridge.rs` which uses `7031/7032` for participation requirements/profiles JSON parsing. Updated all 14 test assertions.
- **W8** (Silent schema fallback): PyO3 `tool_register` now rejects missing or non-object `input_schema`/`output_schema` with explicit `SCP-VALID-7035`/`SCP-VALID-7036` validation errors instead of silently falling back to `{"type": "object"}`. Aligns with the NAPI validation pattern. Added 5 new tests.

## Test plan

- [x] `cargo clippy -p scp-ffi-napi --all-targets --features allow_in_memory_custody -- -D warnings` (clean)
- [x] `cargo clippy -p scp-ffi --all-targets --features allow_in_memory_custody -- -D warnings` (clean)
- [x] `cargo test -p scp-ffi --features allow_in_memory_custody` (200 unit + 52 e2e pass)
- [x] `cargo test -p scp-ffi-napi` (99 tests pass)
- [x] `cargo fmt --all --check` (clean)

🤖 Generated with [Claude Code](https://claude.com/claude-code)