### PR TITLE
fix(ffi): add validate_did to UniFFI bridge_register

### DIFF
--- a/crates/scp-ffi/uniffi/src/bridge.rs
+++ b/crates/scp-ffi/uniffi/src/bridge.rs
@@ -6530,6 +6530,9 @@ pub fn bridge_register(
     platform: String,
     mode: String,
 ) -> Result<BridgeRegistrationResult, ScpError> {
+    validate_did(&operator_did)?;
+    validate_did(&governance_did)?;
+
     let bridge_mode = match mode.as_str() {
         "relay" => scp_core::bridge::BridgeMode::Relay,
         "puppet" => scp_core::bridge::BridgeMode::Puppet,


### PR DESCRIPTION
## Summary

- Add missing `validate_did()` calls for `operator_did` and `governance_did` in the UniFFI bridge's `bridge_register` function
- The PyO3, NAPI, and WASM bridges already had these validation calls; only UniFFI was missing them

Closes #797

## Test plan

- [x] `cargo fmt --all` passes
- [x] `cargo clippy --workspace --all-targets` with all feature flags passes clean
- [x] `cargo test -p scp-ffi -p scp-ffi-napi -p scp-ffi-uniffi -p scp-ffi-wasm` all pass (116 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)