### PR TITLE
feat(kotlin): add event_log_checkpoint wrapper (#571)

### DIFF
--- a/bindings/kotlin/scp-kt-android/src/test/kotlin/works/limn/scp/android/ScpViewModelTest.kt
+++ b/bindings/kotlin/scp-kt-android/src/test/kotlin/works/limn/scp/android/ScpViewModelTest.kt
@@ -216,6 +216,7 @@ private class TestNativeBindings : NativeBindings {
     ): String = ""
     override fun eventLogQuery(contextId: String, filterJson: String): String = ""
     override fun eventLogVerify(contextId: String, proofJson: String): Boolean = false
+    override fun eventLogCheckpoint(contextHandle: Long, identityHandle: Long, epoch: Long): String = ""
     override fun transportConnect(configJson: String, cancellationHandle: CancellationHandle?): Long = 0L
     override fun transportStatus(transportHandle: Long): String = ""
     override fun transportDisconnect(transportHandle: Long) { /* no-op */ }

--- a/bindings/kotlin/scp-kt/src/main/kotlin/works/limn/scp/bridge/CoroutineBridge.kt
+++ b/bindings/kotlin/scp-kt/src/main/kotlin/works/limn/scp/bridge/CoroutineBridge.kt
@@ -332,6 +332,12 @@ interface InfraBindings {
         proofJson: String,
     ): Boolean
 
+    fun eventLogCheckpoint(
+        contextHandle: Long,
+        identityHandle: Long,
+        epoch: Long,
+    ): String
+
     fun transportConnect(
         configJson: String,
         cancellationHandle: CancellationHandle?,
@@ -1164,6 +1170,31 @@ class InfraBridge internal constructor(
         contextId: String,
         proofJson: String,
     ): Boolean = bridge.ffiCall { bindings.eventLogVerify(contextId, proofJson) }
+
+    /**
+     * Generate a signed consistency checkpoint for equivocation detection.
+     *
+     * Creates a signed snapshot of the event log's Merkle root at the given
+     * epoch. Members exchange checkpoints to detect relay equivocation: if
+     * two members have different Merkle roots for the same event count, the
+     * relay is showing different histories to different members.
+     *
+     * @param contextHandle Handle from context create or join.
+     * @param identityHandle Handle from identity create or load.
+     * @param epoch The MLS epoch to checkpoint at.
+     * @return JSON-encoded [Checkpoint] containing context_id, sender_did,
+     *   event_count, merkle_root, epoch, signature, and timestamp.
+     * @see <a href="https://github.com/limn-works/scp/blob/main/.docs/adrs/phase-2.md">ADR-011</a>
+     *   acceptance criterion 8
+     * @see <a href="https://github.com/limn-works/scp/blob/main/.docs/adrs/phase-4.md">ADR-030</a>
+     */
+    suspend fun eventLogCheckpoint(
+        contextHandle: Long,
+        identityHandle: Long,
+        epoch: Long,
+    ): String = bridge.ffiCall {
+        bindings.eventLogCheckpoint(contextHandle, identityHandle, epoch)
+    }
 
     /**
      * Connect to a transport relay.

--- a/bindings/kotlin/scp-kt/src/test/kotlin/works/limn/scp/bridge/CoroutineBridgeTest.kt
+++ b/bindings/kotlin/scp-kt/src/test/kotlin/works/limn/scp/bridge/CoroutineBridgeTest.kt
@@ -214,6 +214,17 @@ class CoroutineBridgeTest {
             }
 
         @Test
+        fun `eventLogCheckpoint dispatches on IO`() =
+            runTest(ioDispatcher) {
+                @Suppress("MaxLineLength")
+                val checkpointJson =
+                    """{"context_id":"ctx-1","sender_did":"did:dht:z6Mk","event_count":10,"merkle_root":"abcdef","epoch":5}"""
+                stubBindings.eventLogCheckpointResult = checkpointJson
+                val result = bridge.infra.eventLogCheckpoint(1L, 2L, 5L)
+                assertEquals(checkpointJson, result)
+            }
+
+        @Test
         fun `transportConnect dispatches on IO`() =
             runTest(ioDispatcher) {
                 stubBindings.transportConnectResult = 99L
@@ -547,6 +558,7 @@ class StubNativeBindings : NativeBindings {
     var ucanDelegateResult = ""
     var eventLogQueryResult = ""
     var eventLogVerifyResult = false
+    var eventLogCheckpointResult = ""
     var transportConnectResult = 0L
     var transportConnectBlocking = false
     var transportStatusResult = ""
@@ -719,6 +731,12 @@ class StubNativeBindings : NativeBindings {
         contextId: String,
         proofJson: String,
     ): Boolean = eventLogVerifyResult
+
+    override fun eventLogCheckpoint(
+        contextHandle: Long,
+        identityHandle: Long,
+        epoch: Long,
+    ): String = eventLogCheckpointResult
 
     override fun transportConnect(
         configJson: String,

--- a/bindings/kotlin/scp-kt/src/test/kotlin/works/limn/scp/conformance/ConformanceDispatcher.kt
+++ b/bindings/kotlin/scp-kt/src/test/kotlin/works/limn/scp/conformance/ConformanceDispatcher.kt
@@ -55,6 +55,7 @@ class ConformanceDispatcher(
         "transport_status" -> dispatchTransportStatus(input)
         "event_log_query" -> dispatchEventLogQuery(input)
         "event_log_verify" -> dispatchEventLogVerify(input)
+        "event_log_checkpoint" -> dispatchEventLogCheckpoint(input)
         else -> mapOf("error" to "unsupported_operation")
     }
 
@@ -242,6 +243,16 @@ class ConformanceDispatcher(
         val proof = input["proof"] ?: "{}"
         val valid = bridge.infra.eventLogVerify(contextId, proof)
         mapOf("is_valid" to valid.toString())
+    }
+
+    private suspend fun dispatchEventLogCheckpoint(
+        input: Map<String, String>,
+    ): Map<String, String> = catchBridge {
+        val contextHandle = input["context_handle"]?.toLongOrNull() ?: 0L
+        val identityHandle = input["identity_handle"]?.toLongOrNull() ?: 0L
+        val epoch = input["epoch"]?.toLongOrNull() ?: 0L
+        val result = bridge.infra.eventLogCheckpoint(contextHandle, identityHandle, epoch)
+        mapOf("checkpoint" to result)
     }
 
     private suspend fun catchBridge(

--- a/bindings/kotlin/scp-kt/src/test/kotlin/works/limn/scp/conformance/ConformanceStubBindings.kt
+++ b/bindings/kotlin/scp-kt/src/test/kotlin/works/limn/scp/conformance/ConformanceStubBindings.kt
@@ -68,6 +68,10 @@ class ConformanceStubBindings : NativeBindings {
     var eventLogQueryError: BridgeException? = null
     var eventLogVerifyResult: Boolean = true
     var eventLogVerifyError: BridgeException? = null
+    @Suppress("MaxLineLength")
+    var eventLogCheckpointResult: String =
+        """{"context_id":"ctx-1","sender_did":"did:dht:stub","event_count":10,"merkle_root":"abcdef","epoch":5}"""
+    var eventLogCheckpointError: BridgeException? = null
 
     var transportConnectResult: Long = 99L
     var transportConnectError: BridgeException? = null
@@ -247,6 +251,15 @@ class ConformanceStubBindings : NativeBindings {
         return eventLogVerifyResult
     }
 
+    override fun eventLogCheckpoint(
+        contextHandle: Long,
+        identityHandle: Long,
+        epoch: Long,
+    ): String {
+        eventLogCheckpointError?.let { throw it }
+        return eventLogCheckpointResult
+    }
+
     override fun transportConnect(
         configJson: String,
         cancellationHandle: CancellationHandle?,
@@ -303,6 +316,10 @@ class ConformanceStubBindings : NativeBindings {
         eventLogQueryError = null
         eventLogVerifyResult = true
         eventLogVerifyError = null
+        @Suppress("MaxLineLength")
+        eventLogCheckpointResult =
+            """{"context_id":"ctx-1","sender_did":"did:dht:stub","event_count":10,"merkle_root":"abcdef","epoch":5}"""
+        eventLogCheckpointError = null
         transportConnectResult = 99L
         transportConnectError = null
         transportStatusResult = """{"connected":true}"""

--- a/bindings/kotlin/scp-kt/src/test/kotlin/works/limn/scp/conformance/EventLogConformanceTest.kt
+++ b/bindings/kotlin/scp-kt/src/test/kotlin/works/limn/scp/conformance/EventLogConformanceTest.kt
@@ -138,6 +138,54 @@ class EventLogConformanceTest {
     }
 
     @Nested
+    inner class EventLogCheckpoint {
+        @Test
+        fun `event_log_checkpoint returns signed checkpoint`() =
+            runTest(testDispatcher) {
+                @Suppress("MaxLineLength")
+                stubBindings.eventLogCheckpointResult =
+                    """{"context_id":"ctx-1","sender_did":"did:dht:z6Mk","event_count":10,"merkle_root":"abcdef","epoch":5}"""
+                val result = dispatcher.dispatch(
+                    "event_log_checkpoint",
+                    mapOf(
+                        "context_handle" to "1",
+                        "identity_handle" to "2",
+                        "epoch" to "5",
+                    ),
+                )
+                assertTrue(result["checkpoint"]?.contains("merkle_root") == true)
+                assertTrue(result["checkpoint"]?.contains("ctx-1") == true)
+            }
+
+        @Test
+        fun `event_log_checkpoint propagates error`() =
+            runTest(testDispatcher) {
+                stubBindings.eventLogCheckpointError =
+                    BridgeException("Key custody unavailable", "SCP-CTX-2028")
+                val result = dispatcher.dispatch(
+                    "event_log_checkpoint",
+                    mapOf(
+                        "context_handle" to "1",
+                        "identity_handle" to "2",
+                        "epoch" to "5",
+                    ),
+                )
+                assertEquals("SCP-CTX-2028", result["error"])
+            }
+
+        @Test
+        fun `event_log_checkpoint via direct bridge call`() =
+            runTest(testDispatcher) {
+                @Suppress("MaxLineLength")
+                stubBindings.eventLogCheckpointResult =
+                    """{"context_id":"ctx-1","sender_did":"did:dht:z6Mk","event_count":10,"merkle_root":"abcdef","epoch":5}"""
+                val result = bridge.infra.eventLogCheckpoint(1L, 2L, 5L)
+                assertTrue(result.contains("merkle_root"))
+                assertTrue(result.contains("event_count"))
+            }
+    }
+
+    @Nested
     inner class FixtureIntegration {
         @Test
         fun `event log query fixture matches dispatcher result`() =

--- a/bindings/kotlin/scp-kt/src/test/kotlin/works/limn/scp/stream/StreamsTest.kt
+++ b/bindings/kotlin/scp-kt/src/test/kotlin/works/limn/scp/stream/StreamsTest.kt
@@ -519,6 +519,12 @@ class StubInfraBindings : works.limn.scp.bridge.InfraBindings {
 
     override fun eventLogVerify(contextId: String, proofJson: String): Boolean = eventLogVerifyResult
 
+    override fun eventLogCheckpoint(
+        contextHandle: Long,
+        identityHandle: Long,
+        epoch: Long,
+    ): String = """{"context_id":"ctx-stub","sender_did":"did:dht:stub","event_count":0,"merkle_root":"00","epoch":0}"""
+
     override fun transportConnect(
         configJson: String,
         cancellationHandle: CancellationHandle?,


### PR DESCRIPTION
Closes #571

## Summary
- Added `eventLogCheckpoint(contextHandle, identityHandle, epoch)` to `InfraBindings` interface and `InfraBridge`
- Follows existing event log wrapper pattern with `bridge.ffiCall` on IO dispatcher
- Updated all 4 NativeBindings implementors (StubNativeBindings, ConformanceStubBindings, TestNativeBindings, StubInfraBindings)
- Added conformance dispatcher case and 3 conformance tests (success, error propagation, direct bridge call)
- Added delegation dispatch test in CoroutineBridgeTest

## Review Cycles
- Cycles: 1
- Findings resolved: 0
- Findings dismissed: 0
- Related issues filed: #820 (eventLogQuery/eventLogVerify param inconsistency), #821 (checkpoint stub JSON completeness)