### PR TITLE
fix(testing): add sync_classify_offline_custom to FFI conformance test list (#815)

### DIFF
--- a/crates/scp-testing/tests/integration/ffi_conformance.rs
+++ b/crates/scp-testing/tests/integration/ffi_conformance.rs
@@ -139,6 +139,7 @@ const PARITY_OPERATIONS: &[(&str, &str, bool)] = &[
     ("trust", "verify_participation_requirements", true),
     // Sync
     ("sync", "sync_classify_offline", true),
+    ("sync", "sync_classify_offline_custom", true),
     ("sync", "sync_get_policy", true),
     // Discovery
     ("discovery", "discovery_parse_address", true),


### PR DESCRIPTION
Closes #815

## Summary
- Adds `sync_classify_offline_custom` to the `PARITY_OPERATIONS` conformance test list in `ffi_conformance.rs`
- All 4 bridges (PyO3, NAPI, UniFFI, WASM) already export this function — the conformance list was simply missing it

## Review Cycles
- Cycles: 1
- Findings resolved: 0
- Findings dismissed: 0