### PR TITLE
test(wasm): add UCAN nonce format validation conformance tests (closes #785)

### DIFF
--- a/crates/scp-core/tests/wasm_conformance.rs
+++ b/crates/scp-core/tests/wasm_conformance.rs
@@ -4749,8 +4749,12 @@ fn nonce_conformance_format_table_driven() {
             make_nonce_str(now_ms, "AaBbCcDd11223344aAbBcCdD11223344"),
             true,
         ),
-        // Multiple dashes (first split captures timestamp, rest is suffix).
-        (format!("{now_ms}-aabb-ccdd11223344aabbccdd11223"), false),
+        // Multiple dashes — hex_part is exactly 32 chars but contains a dash (non-hex).
+        // split_once('-') yields hex_part "aabbccdd1122334-aabbccdd1122334" (32 chars, dash at pos 15).
+        (
+            make_nonce_str(now_ms, "aabbccdd1122334-aabbccdd1122334"),
+            false,
+        ),
     ];
 
     for (i, (nonce, expected_ok)) in test_vectors.iter().enumerate() {


### PR DESCRIPTION
## Summary
- Adds 18 conformance tests cross-validating WASM and scp-core nonce validation
- Covers format validation (8 tests), freshness boundary conditions (8 tests), and edge cases (2 tests)
- Includes `wasm_nonce_mirror` module mirroring the WASM bridge's `validate_nonce_format_and_freshness`
- Table-driven test with 14 test vectors for comprehensive format coverage

## Test plan
- [x] All 78 wasm_conformance tests pass (`cargo test -p scp-core --test wasm_conformance --features scp-core/testing`)
- [x] Workspace clippy clean with all feature flags
- [x] `cargo fmt --all` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)