### PR TITLE
fix(docs): backtick tech terms in scp-transport README for clippy

### DIFF
--- a/crates/scp-transport/README.md
+++ b/crates/scp-transport/README.md
@@ -2,7 +2,7 @@
 
 Transport abstraction layer for [SCP](https://github.com/limn/scp) (Shared Context Protocol).
 
-Native relay client (WebSocket), blob storage adapters (SQLite, redb, Postgres, S3), and optional protocol adapters (QUIC, HTTP/3, UDP, CoAP, Nostr, WebRTC, WebTransport).
+Native relay client (`WebSocket`), blob storage adapters (`SQLite`, `redb`, Postgres, S3), and optional protocol adapters (QUIC, HTTP/3, UDP, `CoAP`, Nostr, `WebRTC`, `WebTransport`).
 
 ## License
 


### PR DESCRIPTION
## Summary
- Backtick `WebSocket`, `SQLite`, `redb`, `CoAP`, `WebRTC`, `WebTransport` in `scp-transport/README.md`
- Fixes `clippy::doc_markdown` error introduced by `32002379` which added `#![doc = include_str!("../README.md")]`
- **Blocks all PR CI** — main clippy is red

## Test plan
- [ ] `cargo clippy --workspace --all-targets` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)