### PR TITLE
fix(transport): escape technical terms in README for clippy doc_markdown (#887)

### DIFF
--- a/crates/scp-transport/README.md
+++ b/crates/scp-transport/README.md
@@ -2,7 +2,7 @@
 
 Transport abstraction layer for [SCP](https://github.com/limn/scp) (Shared Context Protocol).
 
-Native relay client (WebSocket), blob storage adapters (SQLite, redb, Postgres, S3), and optional protocol adapters (QUIC, HTTP/3, UDP, CoAP, Nostr, WebRTC, WebTransport).
+Native relay client (`WebSocket`), blob storage adapters (`SQLite`, `redb`, `Postgres`, S3), and optional protocol adapters (`QUIC`, HTTP/3, UDP, `CoAP`, `Nostr`, `WebRTC`, `WebTransport`).
 
 ## License
 


### PR DESCRIPTION
## Summary
- Wraps technical terms (`WebSocket`, `SQLite`, `CoAP`, `WebRTC`, `WebTransport`, `redb`, `Postgres`, `QUIC`) in backticks in `crates/scp-transport/README.md` to satisfy `clippy::doc_markdown`
- This pre-existing lint failure (introduced in commit 32002379) was blocking CI for all open PRs

## Review Cycle
- **Round 1**: Reviewer found 0 correctness/completeness issues. 1 minor style finding (QUIC/UDP naming). Arbiter rejected it (QUIC is a proper name per IETF RFC 9000). **Converged: 0 accepted findings.**

## Test plan
- [x] `cargo clippy --workspace --all-targets` passes clean (verified locally)
- [x] Two-dot diff shows only 1 file, 1 line changed — no reversions

Closes #887

🤖 Generated with [Claude Code](https://claude.com/claude-code)