### PR TITLE
docs(event-log): document pruning tolerance for first entry prev_hash (#849)

### DIFF
--- a/crates/scp-core/src/context/export_import.rs
+++ b/crates/scp-core/src/context/export_import.rs
@@ -140,6 +140,16 @@ pub fn deserialize_export(bytes: &[u8]) -> Result<ContextExport, ContextError> {
 ///
 /// Returns all zeros for empty data.
 ///
+/// # Pruning tolerance
+///
+/// The first entry's `prev_hash` linkage is **not** validated. If the log was
+/// pruned, `entries[0].prev_hash` references a discarded predecessor that
+/// cannot be checked. A non-genesis `prev_hash` on the first entry is therefore
+/// accepted — the log is treated as a pruned suffix. Hash-chain verification
+/// begins at the link between the first and second entries; each subsequent
+/// entry's `prev_hash` must match its predecessor's `hash`. Self-hash
+/// correctness is still verified for every entry, including the first.
+///
 /// # Errors
 ///
 /// Returns [`ContextError::EventLogFailed`] if deserialization fails or


### PR DESCRIPTION
## Summary
- Adds docstring section to `compute_event_log_hash()` in `crates/scp-core/src/context/export_import.rs` documenting the pruning tolerance behavior
- The first entry's `prev_hash` is not validated because it may reference a pruned predecessor — hash-chain verification starts at the link between entries 1 and 2

## Review Cycle
- **Round 1**: Reviewer found 0 findings — all acceptance criteria PASS. **Converged: 0 accepted findings.**

## Test plan
- [x] Docstring-only change — no code behavior changes
- [x] Two-dot diff shows only 1 file, 10 lines added — no reversions

Closes #849

🤖 Generated with [Claude Code](https://claude.com/claude-code)