### PR TITLE
fix(core): include author DID in unblock_subscriber error message (#873)

### DIFF
--- a/crates/scp-core/src/context/broadcast.rs
+++ b/crates/scp-core/src/context/broadcast.rs
@@ -880,7 +880,7 @@ impl BroadcastContext {
 
         if !author.block_list.remove(unblocked_did) {
             return Err(ContextError::InvalidState(format!(
-                "subscriber not blocked: {unblocked_did}"
+                "subscriber {unblocked_did} not blocked by author {author_did}"
             )));
         }
 


### PR DESCRIPTION
## Summary
- Changes `unblock_subscriber` error in `crates/scp-core/src/context/broadcast.rs` from `"subscriber not blocked: {did}"` to `"subscriber {did} not blocked by author {author_did}"`
- Aligns scp-core with the format #837 will apply to WASM bridge (PR #874)

## Review Cycle
- **Round 1**: Reviewer found 1 finding — WASM bridge at `manager.rs:3342` still has old format. This is out-of-scope: WASM bridge is issue #837 (PR #874). Core fix is complete per AC #1. AC #2 (format match) will be satisfied when #874 merges. **Converged: 0 in-scope findings.**

## Test plan
- [x] One-line error message change — no behavioral changes
- [x] WASM divergence is tracked by separate issue #837 / PR #874
- [x] Two-dot diff shows 1 file, 1 line changed — no reversions

Closes #873

🤖 Generated with [Claude Code](https://claude.com/claude-code)