### PR TITLE
fix(wasm): allow idempotent ucan_revoke at capacity

### DIFF
--- a/crates/scp-ffi/wasm/src/manager.rs
+++ b/crates/scp-ffi/wasm/src/manager.rs
@@ -5149,8 +5149,7 @@ mod tests {
             .collect();
         assert_eq!(revoked.len(), WASM_REVOKED_TOKENS_CAP);
 
-        let mut mgr =
-            make_manager_with_revoked_tokens("ctx-1", "did:dht:zcreator", revoked);
+        let mut mgr = make_manager_with_revoked_tokens("ctx-1", "did:dht:zcreator", revoked);
 
         // Revoking a genuinely new token at capacity must fail.
         let err = mgr.ucan_revoke("ctx-1", "cid-brand-new").unwrap_err();


### PR DESCRIPTION
## Summary
- Adds `!ctx.revoked_tokens.contains(token_cid)` guard to the capacity check in `WasmContextManager::ucan_revoke`, so re-revoking an already-revoked token succeeds even when the revocation set is at `WASM_REVOKED_TOKENS_CAP` (100K)
- Adds 2 tests: capacity guard allows existing token (unit logic test), new token at capacity fails (integration error test)
- Updates docstring to document idempotent behavior

Closes #895

## Test plan
- [x] `cargo test -p scp-ffi-wasm -- ucan_revoke` — 2 tests pass
- [x] `cargo clippy -p scp-ffi-wasm --target wasm32-unknown-unknown -- -D warnings` — clean
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)