### PR TITLE
refactor(ffi): extract approved_proposal test helper (#861)

### DIFF
--- a/crates/scp-ffi/common/src/lib.rs
+++ b/crates/scp-ffi/common/src/lib.rs
@@ -20,3 +20,7 @@ mod resolvers;
 
 #[cfg(feature = "resolvers")]
 pub use resolvers::*;
+
+// Shared test helpers for FFI bridge tests (behind the `testing` feature).
+#[cfg(feature = "testing")]
+pub mod test_helpers;

--- a/crates/scp-ffi/common/src/test_helpers.rs
+++ b/crates/scp-ffi/common/src/test_helpers.rs
@@ -1,0 +1,39 @@
+//! Shared test fixtures for FFI bridge tests.
+//!
+//! Gated behind the `testing` feature so these helpers are available to all
+//! bridge crates (`scp-ffi`, `scp-ffi-napi`, `scp-ffi-uniffi`) via
+//! `[dev-dependencies] scp-ffi-common = { ..., features = ["testing"] }`.
+
+use scp_core::context::governance::{
+    GovernanceAction, GovernanceProposal, ProposalStatus, SignedVote, VoteType,
+};
+use scp_identity::DID;
+
+/// Build a [`GovernanceProposal`] in `Approved` status with a single approval
+/// vote.  Used across bridge test suites to drive governance execution without
+/// a full voting round-trip.
+#[must_use]
+pub fn approved_proposal(
+    pid: [u8; 32],
+    context_id: &str,
+    action: GovernanceAction,
+    approver_did: &str,
+) -> GovernanceProposal {
+    GovernanceProposal {
+        proposal_id: pid,
+        context_id: context_id.into(),
+        proposer_did: DID(approver_did.to_owned()),
+        action,
+        status: ProposalStatus::Approved,
+        created_at: 1000,
+        voting_deadline: 2000,
+        approvals: vec![SignedVote {
+            voter_did: DID(approver_did.to_owned()),
+            vote: VoteType::Approve,
+            timestamp: 1000,
+            signature: vec![0u8; 64],
+        }],
+        rejections: Vec::new(),
+        created_at_epoch: None,
+    }
+}

--- a/crates/scp-ffi/napi/src/context.rs
+++ b/crates/scp-ffi/napi/src/context.rs
@@ -1744,37 +1744,12 @@ pub fn context_get_economic_policy(handle: &NapiContextHandle) -> Option<String>
 mod tests {
     use crate::runtime::context_manager;
     use scp_core::context::ContextParams;
-    use scp_core::context::governance::{
-        GovernanceAction, GovernanceProposal, ProposalStatus, SignedVote, VoteType,
-    };
+    use scp_core::context::governance::GovernanceAction;
     use scp_core::context::membership::KeyPackage;
     use scp_core::context::params::Capability;
     use scp_identity::DID;
 
-    fn approved_proposal(
-        pid: [u8; 32],
-        context_id: &str,
-        action: GovernanceAction,
-        approver_did: &str,
-    ) -> GovernanceProposal {
-        GovernanceProposal {
-            proposal_id: pid,
-            context_id: context_id.into(),
-            proposer_did: DID(approver_did.to_owned()),
-            action,
-            status: ProposalStatus::Approved,
-            created_at: 1000,
-            voting_deadline: 2000,
-            approvals: vec![SignedVote {
-                voter_did: DID(approver_did.to_owned()),
-                vote: VoteType::Approve,
-                timestamp: 1000,
-                signature: vec![0u8; 64],
-            }],
-            rejections: Vec::new(),
-            created_at_epoch: None,
-        }
-    }
+    use scp_ffi_common::test_helpers::approved_proposal;
 
     /// Verifies that `ContextManager::member_count` returns the live member
     /// count — not a hardcoded value.  After creation the count is 1 (the

--- a/crates/scp-ffi/src/context.rs
+++ b/crates/scp-ffi/src/context.rs
@@ -3179,31 +3179,7 @@ mod tests {
     // Role state sync after governance (#560)
     // -----------------------------------------------------------------------
 
-    fn approved_proposal(
-        pid: [u8; 32],
-        context_id: &str,
-        action: scp_core::context::governance::GovernanceAction,
-        approver_did: &str,
-    ) -> scp_core::context::governance::GovernanceProposal {
-        use scp_core::context::governance::{SignedVote, VoteType};
-        scp_core::context::governance::GovernanceProposal {
-            proposal_id: pid,
-            context_id: context_id.into(),
-            proposer_did: scp_identity::DID(approver_did.to_owned()),
-            action,
-            status: scp_core::context::governance::ProposalStatus::Approved,
-            created_at: 1000,
-            voting_deadline: 2000,
-            approvals: vec![SignedVote {
-                voter_did: scp_identity::DID(approver_did.to_owned()),
-                vote: VoteType::Approve,
-                timestamp: 1000,
-                signature: vec![0u8; 64],
-            }],
-            rejections: Vec::new(),
-            created_at_epoch: None,
-        }
-    }
+    use scp_ffi_common::test_helpers::approved_proposal;
 
     #[test]
     fn role_state_syncs_after_change_role() {


### PR DESCRIPTION
## Summary
- Extract the duplicate `approved_proposal` governance test fixture from PyO3 (`crates/scp-ffi/src/context.rs`) and NAPI (`crates/scp-ffi/napi/src/context.rs`) bridge test modules into a shared `test_helpers` module in `scp-ffi-common`
- The new module is gated behind the `testing` feature flag, which both crates already enable in their `[dev-dependencies]`
- Cleans up unused governance type imports in the NAPI test module

Closes #861

## Test plan
- [x] `cargo clippy --workspace --all-targets --features scp-ffi-uniffi/allow_in_memory_custody,scp-ffi/allow_in_memory_custody,scp-ffi-napi/allow_in_memory_custody,scp-core/testing -- -D warnings` passes
- [x] `cargo fmt --all --check` passes
- [x] `cargo test -p scp-ffi -p scp-ffi-napi -p scp-ffi-common --features scp-ffi/allow_in_memory_custody,scp-ffi-napi/allow_in_memory_custody` — all `role_state_syncs_*` tests pass in both crates

🤖 Generated with [Claude Code](https://claude.com/claude-code)