### PR TITLE
fix(kotlin): align unblock_subscriber error message in test with scp-core

### DIFF
--- a/bindings/kotlin/scp-kt/src/test/kotlin/works/limn/scp/bridge/CoroutineBridgeTest.kt
+++ b/bindings/kotlin/scp-kt/src/test/kotlin/works/limn/scp/bridge/CoroutineBridgeTest.kt
@@ -460,6 +460,10 @@ class CoroutineBridgeTest {
                     }
 
                 assertEquals("SCP-CTX-2001", exception.code)
+                assertEquals(
+                    "subscriber did:dht:z6MkSub not blocked by author did:dht:z6MkAdmin",
+                    exception.message,
+                )
             }
     }
 


### PR DESCRIPTION
Closes #932

## Summary
- Updated Kotlin `CoroutineBridgeTest` `BridgeException` message from `"subscriber not blocked"` to `"subscriber did:dht:z6MkSub not blocked by author did:dht:z6MkAdmin"` matching scp-core's `broadcast.rs:883` format
- Added `assertEquals` on `exception.message` to verify the full error string (not just error code)

## Review Cycles
- Cycles: 2
- Findings resolved: 1
- Findings dismissed: 0