### PR TITLE
docs(ffi): complete validate_did doc comments and remove stale release refs (closes #946, closes #949)

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -108,5 +108,5 @@ The `release.yml` workflow enforces a 7-step checklist:
 3. Version tags created (`scp-core@{version}`, per-SDK tags)
 4. Build all artifacts via `build-matrix.yml` (workflow_call)
 5. Sign artifacts per platform requirements
-6. Publish to registries (crates.io, PyPI, npm, SPM, Maven Central, NuGet, Go proxy)
+6. Publish to registries (crates.io, PyPI, npm, SPM, Maven Central)
 7. GitHub Release with binary attachments

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,7 +27,6 @@
 #   GPG_PASSPHRASE         — Passphrase for GPG private key
 #   MAVEN_USERNAME         — Sonatype OSSRH username (Maven Central)
 #   MAVEN_PASSWORD         — Sonatype OSSRH password
-#   NUGET_API_KEY          — NuGet.org API key for Limn.Scp
 #
 # Required repository variables:
 #   (none — all configuration is derived from the version input)

--- a/crates/scp-ffi/common/src/validate.rs
+++ b/crates/scp-ffi/common/src/validate.rs
@@ -168,16 +168,17 @@ pub fn validate_context_id(context_id: &str) -> Result<(), ValidationError> {
 /// DIDs must match the `did:{method}:{id}` format per the W3C DID Core
 /// specification. Validation enforces:
 /// - Non-empty
-/// - Length <= [`MAX_DID_LEN`]
+/// - Length <= [`MAX_DID_LEN`] (512 bytes)
 /// - Starts with `did:`
 /// - Contains at least two `:` separators (method + id)
+/// - Method is non-empty lowercase alphanumeric
 /// - No control characters
 ///
 /// # Errors
 ///
-/// Returns [`ValidationError`] if the DID is empty, too long,
-/// missing the `did:` prefix, missing the method or ID, or contains
-/// control characters.
+/// Returns [`ValidationError`] if the DID is empty, exceeds 512 bytes,
+/// missing the `did:` prefix, missing the method or ID, method is not
+/// lowercase alphanumeric, or contains control characters.
 pub fn validate_did(did: &str) -> Result<(), ValidationError> {
     validate_non_empty(did, "DID", MAX_DID_LEN)?;
     reject_control_chars(did, "DID")?;

--- a/crates/scp-ffi/napi/src/bridge_connector.rs
+++ b/crates/scp-ffi/napi/src/bridge_connector.rs
@@ -130,8 +130,9 @@ pub fn bridge_evaluate_trust(
 /// # Errors
 ///
 /// Returns a validation error if `operator_did` or `governance_did` is not a
-/// valid DID string (empty, missing `did:{method}:{id}` structure, or
-/// contains control characters), or if `mode` is not a recognized bridge mode.
+/// valid DID string (empty, exceeds 512 bytes, missing `did:{method}:{id}`
+/// structure, method not lowercase alphanumeric, or contains control
+/// characters), or if `mode` is not a recognized bridge mode.
 /// Returns a context error if the governance DID matches the operator DID
 /// (self-approval) or if registration fails.
 #[napi]

--- a/crates/scp-ffi/src/bridge_connector.rs
+++ b/crates/scp-ffi/src/bridge_connector.rs
@@ -51,8 +51,9 @@ use crate::error::ScpPyError;
 /// # Errors
 ///
 /// Raises `ValidationError` if `operator_did` or `governance_did` is not a
-/// valid DID string (empty, missing `did:{method}:{id}` structure, or
-/// contains control characters), or if `mode` is not recognized.
+/// valid DID string (empty, exceeds 512 bytes, missing `did:{method}:{id}`
+/// structure, method not lowercase alphanumeric, or contains control
+/// characters), or if `mode` is not recognized.
 /// Raises `ContextError` if the governance DID matches the operator DID
 /// (self-approval) or if registration fails.
 #[pyfunction]

--- a/crates/scp-ffi/uniffi/src/bridge.rs
+++ b/crates/scp-ffi/uniffi/src/bridge.rs
@@ -3905,7 +3905,8 @@ pub async fn ucan_validate(
 /// # Errors
 ///
 /// Returns `ScpError::Validation` if `member_did` is not a valid DID string
-/// (empty, missing `did:{method}:{id}` structure, or contains control characters).
+/// (empty, exceeds 512 bytes, missing `did:{method}:{id}` structure, method
+/// not lowercase alphanumeric, or contains control characters).
 ///
 /// Returns `ScpError::Permission` if the context does not have key custody
 /// (created from an `identity_load` handle without key material) or if
@@ -4081,7 +4082,8 @@ pub async fn ucan_revoke(handle: Arc<ContextHandle>, token: String) -> Result<()
 /// # Errors
 ///
 /// Returns `ScpError::Validation` if `delegator_did` or `delegatee_did` is
-/// not a valid DID string (empty, missing `did:{method}:{id}` structure, or
+/// not a valid DID string (empty, exceeds 512 bytes, missing
+/// `did:{method}:{id}` structure, method not lowercase alphanumeric, or
 /// contains control characters), if `parent_token` is empty or contains
 /// control characters, or if any capability URI in `capabilities` is empty
 /// or contains control characters.
@@ -7529,8 +7531,9 @@ pub struct ShadowIdentityResult {
 /// # Errors
 ///
 /// Returns `ScpError::Validation` if `operator_did` or `governance_did`
-/// is not a valid DID string (empty, missing `did:{method}:{id}` structure,
-/// or contains control characters), or if `mode` is not recognized. Returns
+/// is not a valid DID string (empty, exceeds 512 bytes, missing
+/// `did:{method}:{id}` structure, method not lowercase alphanumeric, or
+/// contains control characters), or if `mode` is not recognized. Returns
 /// `ScpError::Context` if registration or approval fails (including
 /// self-approval).
 ///

--- a/crates/scp-ffi/wasm/src/bridge.rs
+++ b/crates/scp-ffi/wasm/src/bridge.rs
@@ -315,8 +315,9 @@ pub fn bridge_evaluate_trust(
 /// # Errors
 ///
 /// Returns `JsError` if `operator_did` or `governance_did` is not a valid
-/// DID string (empty, missing `did:{method}:{id}` structure, or contains
-/// control characters), if `mode` is invalid, if other inputs are empty, or
+/// DID string (empty, exceeds 512 bytes, missing `did:{method}:{id}`
+/// structure, method not lowercase alphanumeric, or contains control
+/// characters), if `mode` is invalid, if other inputs are empty, or
 /// if `governance_did` equals `operator_did` (self-approval).
 ///
 /// # JS usage


### PR DESCRIPTION
## Summary

- Add missing "exceeds 512 bytes" and "method not lowercase alphanumeric" checks to `validate_did` doc comments across all 4 FFI bridges (PyO3, NAPI, UniFFI, WASM) and the shared `validate.rs`
- Remove NuGet and Go proxy from `README.md` release pipeline registry list (no corresponding `release.yml` steps exist)
- Remove stale `NUGET_API_KEY` secret reference from `release.yml`

## Test plan

- [x] Doc-only changes — no functional code changes
- [x] Updated doc comments match the actual 6-check validation logic in `common/src/validate.rs`

Closes #946
Closes #949

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>