### PR TITLE
fix(ts): upgrade typedoc to ^0.28.0 for plugin compatibility

### DIFF
--- a/bindings/typescript/package.json
+++ b/bindings/typescript/package.json
@@ -42,8 +42,8 @@
     "@biomejs/biome": "latest",
     "@types/node": "^25.3.2",
     "tsup": "latest",
-    "typedoc": "^0.27.0",
-    "typedoc-plugin-markdown": "^4.0.0",
+    "typedoc": "^0.28.0",
+    "typedoc-plugin-markdown": "^4.10.0",
     "typescript": "^5.7.0"
   }
 }


### PR DESCRIPTION
## Summary

- Upgrades `typedoc` from `^0.27.0` to `^0.28.0` in `bindings/typescript/package.json`
- Upgrades `typedoc-plugin-markdown` from `^4.0.0` to `^4.10.0`
- Fixes CI docs.yml failure: `typedoc-plugin-markdown` 4.10.0 has `peerDependencies: { typedoc: "0.28.x" }`, causing `SyntaxError: does not provide an export named 'CategoryRouter'` when paired with typedoc 0.27.x

## Test plan

- [x] `bunx typedoc` succeeds locally with updated versions
- [x] Generated markdown docs output correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)