### PR TITLE
feat(typescript): expose TTL, export/import, drain, delegate methods (closes #670)

### DIFF
--- a/bindings/typescript/src/context.ts
+++ b/bindings/typescript/src/context.ts
@@ -132,6 +132,15 @@ export class Context implements AsyncDisposable {
   }
 
   /**
+   * Constructs a Context from an existing bridge handle.
+   *
+   * @internal Testing only — not part of the public API.
+   */
+  static _fromHandle(handle: BridgeContextHandle, identityDid: string): Context {
+    return new Context(handle.contextId, handle, identityDid);
+  }
+
+  /**
    * Creates a new SCP context.
    *
    * The context is created in the `"active"` state. The creating identity
@@ -798,6 +807,142 @@ export class Context implements AsyncDisposable {
     try {
       const bridge = await getBridge();
       return await bridge.contextExtendTtl(this._handle, additionalSecs);
+    } catch (error) {
+      throw mapBridgeError(error);
+    }
+  }
+
+  /**
+   * Handles automatic TTL expiry for this context.
+   *
+   * Triggers the TTL expiry lifecycle: transitions the context to expired
+   * state and notifies members. Typically called by a timer or scheduler
+   * when the context's TTL has elapsed.
+   *
+   * @throws {ContextError} If the context is not active (SCP-CTX-2005).
+   */
+  async handleTtlExpiry(): Promise<void> {
+    this.assertActive();
+    try {
+      const bridge = await getBridge();
+      await bridge.contextHandleTtlExpiry(this._handle);
+    } catch (error) {
+      throw mapBridgeError(error);
+    }
+  }
+
+  /**
+   * Proposes a TTL extension for this context.
+   *
+   * Records consent from the given member for extending the context's TTL.
+   * Returns `true` if the extension was unanimously approved by all members.
+   *
+   * @param extensionSecs - Number of seconds to extend the TTL by. Must be greater than zero.
+   * @param proposerDid - DID of the proposer. Defaults to the context identity.
+   * @returns `true` if the extension was unanimously approved.
+   * @throws {ContextError} If the context is not active or the proposal fails (SCP-CTX-2005).
+   * @throws {ContextError} If `extensionSecs` is zero or negative.
+   */
+  async proposeTtlExtension(extensionSecs: number, proposerDid?: string): Promise<boolean> {
+    this.assertActive();
+    if (extensionSecs <= 0 || Number.isNaN(extensionSecs)) {
+      throw new ContextError("extensionSecs must be greater than zero", "SCP-CTX-2031");
+    }
+    try {
+      const bridge = await getBridge();
+      return await bridge.contextProposeTtlExtension(
+        this._handle,
+        proposerDid ?? this._identityDid,
+        extensionSecs,
+      );
+    } catch (error) {
+      throw mapBridgeError(error);
+    }
+  }
+
+  /**
+   * Resets the TTL timer for this context to a new duration.
+   *
+   * Replaces the current TTL countdown with a fresh timer of the specified
+   * duration. Requires a core context handle.
+   *
+   * @param newDurationSecs - The new TTL duration in seconds. Must be greater than zero.
+   * @throws {ContextError} If the context does not have a core handle (SCP-CTX-2024).
+   * @throws {ContextError} If `newDurationSecs` is zero or negative.
+   */
+  async resetTtlTimer(newDurationSecs: number): Promise<void> {
+    this.assertActive();
+    if (newDurationSecs <= 0 || Number.isNaN(newDurationSecs)) {
+      throw new ContextError("newDurationSecs must be greater than zero", "SCP-CTX-2031");
+    }
+    try {
+      const bridge = await getBridge();
+      await bridge.contextResetTtlTimer(this._handle, newDurationSecs);
+    } catch (error) {
+      throw mapBridgeError(error);
+    }
+  }
+
+  // ---------------------------------------------------------------------------
+  // Export / Import
+  // ---------------------------------------------------------------------------
+
+  /**
+   * Exports this context's full state as serialized bytes.
+   *
+   * Returns serialized `StoredValue<ContextExport>` bytes (spec section 17.5)
+   * suitable for backup, migration, or transfer to another node.
+   *
+   * @returns The serialized context export as a `Uint8Array`.
+   * @throws {ContextError} If the context has been disposed or export fails.
+   */
+  async export(): Promise<Uint8Array> {
+    this.assertActive();
+    try {
+      const bridge = await getBridge();
+      return await bridge.contextExport(this._handle);
+    } catch (error) {
+      throw mapBridgeError(error);
+    }
+  }
+
+  /**
+   * Imports a context from serialized bytes.
+   *
+   * The bytes must be a `StoredValue<ContextExport>` envelope (spec section
+   * 17.5), as produced by {@link Context.prototype.export}.
+   *
+   * @param data - The serialized context export bytes.
+   * @returns The context ID of the imported context.
+   * @throws {ContextError} If deserialization, validation, or import fails.
+   */
+  static async import(data: Uint8Array): Promise<string> {
+    try {
+      const bridge = await getBridge();
+      return await bridge.contextImport(data);
+    } catch (error) {
+      throw mapBridgeError(error);
+    }
+  }
+
+  // ---------------------------------------------------------------------------
+  // Drain events
+  // ---------------------------------------------------------------------------
+
+  /**
+   * Drains all pending events from this context's receive buffer.
+   *
+   * Returns events as an array of JSON strings. This is a non-blocking
+   * alternative to the streaming `receive()` generator for batch processing.
+   *
+   * @returns An array of event JSON strings.
+   * @throws {ContextError} If the context has been disposed.
+   */
+  async drainEvents(): Promise<readonly string[]> {
+    this.assertActive();
+    try {
+      const bridge = await getBridge();
+      return await bridge.contextDrainEvents(this._handle);
     } catch (error) {
       throw mapBridgeError(error);
     }

--- a/bindings/typescript/src/internal/bridge.ts
+++ b/bindings/typescript/src/internal/bridge.ts
@@ -447,3 +447,16 @@ export async function getBridge(): Promise<Bridge> {
 export function _resetBridge(): void {
   _bridge = null;
 }
+
+/**
+ * Injects a bridge instance for testing.
+ *
+ * This is intended for testing only — it allows tests to inject a mock bridge
+ * so that SDK classes (`Context`, `Identity`, etc.) use the mock instead of
+ * loading a native or WASM bridge.
+ *
+ * @internal
+ */
+export function _setBridge(bridge: Bridge): void {
+  _bridge = bridge;
+}

--- a/bindings/typescript/tests/integration.test.ts
+++ b/bindings/typescript/tests/integration.test.ts
@@ -10,11 +10,12 @@
  */
 
 import { afterEach, beforeEach, describe, expect, it } from "bun:test";
-import { _validateEconomicPolicyJson } from "../src/context";
-import { ValidationError } from "../src/errors";
-import { _resetBridge } from "../src/internal/bridge";
+import { _validateEconomicPolicyJson, Context } from "../src/context";
+import { ContextError, ValidationError } from "../src/errors";
+import { _resetBridge, _setBridge } from "../src/internal/bridge";
 import { defineToolDefinition } from "../src/tools";
 import { Transport } from "../src/transport";
+import { delegateUcan, mintUcan } from "../src/ucan";
 import { createMockBridge } from "./mock-bridge";
 
 // ---------------------------------------------------------------------------
@@ -891,5 +892,284 @@ describe("EconomicPolicy schema validation", () => {
   it("rejects missing payee", () => {
     const json = JSON.stringify({ locked: false, cost_schedule: {}, payment_adapters: [] });
     expect(() => _validateEconomicPolicyJson(json)).toThrow(/'payee' must be a string/);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 10. TTL expiry, proposal, and reset (bridge level)
+// ---------------------------------------------------------------------------
+
+describe("TTL operations (mock bridge)", () => {
+  it("handleTtlExpiry transitions context to expired", async () => {
+    const identity = await mockBridge.identityCreate("in_memory");
+    const ctx = await mockBridge.contextCreate(
+      identity,
+      JSON.stringify({ ceiling: ["messages:read"], ttlSeconds: 300 }),
+    );
+
+    await mockBridge.contextHandleTtlExpiry(ctx);
+    const ctxState = mockBridge._contexts.get(ctx.contextId);
+    expect(ctxState?.state).toBe("expired");
+  });
+
+  it("proposeTtlExtension returns true for single-member context", async () => {
+    const identity = await mockBridge.identityCreate("in_memory");
+    const ctx = await mockBridge.contextCreate(
+      identity,
+      JSON.stringify({ ceiling: ["messages:read"], ttlSeconds: 300 }),
+    );
+
+    const approved = await mockBridge.contextProposeTtlExtension(ctx, identity.did, 120);
+    expect(approved).toBe(true);
+    expect(mockBridge._contexts.get(ctx.contextId)?.ttlSecs).toBe(420);
+  });
+
+  it("proposeTtlExtension returns false for multi-member context", async () => {
+    const alice = await mockBridge.identityCreate("in_memory");
+    const bob = await mockBridge.identityCreate("in_memory");
+    const ctx = await mockBridge.contextCreate(
+      alice,
+      JSON.stringify({ ceiling: ["messages:read"], ttlSeconds: 300 }),
+    );
+    await mockBridge.contextJoin(ctx, bob.did);
+
+    const approved = await mockBridge.contextProposeTtlExtension(ctx, alice.did, 120);
+    expect(approved).toBe(false);
+  });
+
+  it("resetTtlTimer replaces TTL with new duration", async () => {
+    const identity = await mockBridge.identityCreate("in_memory");
+    const ctx = await mockBridge.contextCreate(
+      identity,
+      JSON.stringify({ ceiling: ["messages:read"], ttlSeconds: 300 }),
+    );
+
+    await mockBridge.contextResetTtlTimer(ctx, 600);
+    expect(mockBridge._contexts.get(ctx.contextId)?.ttlSecs).toBe(600);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 11. Context export/import (bridge level)
+// ---------------------------------------------------------------------------
+
+describe("Context export/import (mock bridge)", () => {
+  it("exports and re-imports a context", async () => {
+    const identity = await mockBridge.identityCreate("in_memory");
+    const ctx = await mockBridge.contextCreate(
+      identity,
+      JSON.stringify({ ceiling: ["messages:read", "messages:write"] }),
+    );
+
+    const exported = await mockBridge.contextExport(ctx);
+    expect(exported).toBeInstanceOf(Uint8Array);
+    expect(exported.length).toBeGreaterThan(0);
+
+    const importedId = await mockBridge.contextImport(exported);
+    expect(importedId).toBe(ctx.contextId);
+
+    // The imported context should be active
+    const importedCtx = mockBridge._contexts.get(importedId);
+    expect(importedCtx?.state).toBe("active");
+  });
+
+  it("import rejects malformed data", async () => {
+    await expect(mockBridge.contextImport(new TextEncoder().encode("not json{"))).rejects.toThrow(
+      /SCP-CTX-2032/,
+    );
+  });
+
+  it("import rejects missing snapshot", async () => {
+    await expect(
+      mockBridge.contextImport(new TextEncoder().encode(JSON.stringify({}))),
+    ).rejects.toThrow(/SCP-CTX-2032/);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 12. Drain events (bridge level)
+// ---------------------------------------------------------------------------
+
+describe("Drain events (mock bridge)", () => {
+  it("drains events from context", async () => {
+    const identity = await mockBridge.identityCreate("in_memory");
+    const ctx = await mockBridge.contextCreate(
+      identity,
+      JSON.stringify({ ceiling: ["messages:read", "messages:write"] }),
+    );
+
+    await mockBridge.contextSend(ctx, identity.did, new TextEncoder().encode("msg1"));
+    await mockBridge.contextSend(ctx, identity.did, new TextEncoder().encode("msg2"));
+
+    const events = await mockBridge.contextDrainEvents(ctx);
+    expect(events.length).toBe(3); // ContextCreated + 2 MessageSent
+    for (const e of events) {
+      expect(typeof e).toBe("string");
+      const parsed = JSON.parse(e);
+      expect(parsed.eventType).toBeTruthy();
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 13. SDK Context class: TTL, export/import, drain (SDK wrapper level)
+// ---------------------------------------------------------------------------
+
+describe("Context SDK wrapper — TTL, export/import, drain", () => {
+  beforeEach(() => {
+    _setBridge(mockBridge);
+  });
+
+  it("handleTtlExpiry delegates to bridge", async () => {
+    const identity = await mockBridge.identityCreate("in_memory");
+    const handle = await mockBridge.contextCreate(
+      identity,
+      JSON.stringify({ ceiling: ["messages:read"], ttlSeconds: 300 }),
+    );
+    const ctx = Context._fromHandle(handle, identity.did);
+
+    await ctx.handleTtlExpiry();
+    expect(mockBridge._contexts.get(handle.contextId)?.state).toBe("expired");
+  });
+
+  it("proposeTtlExtension delegates to bridge", async () => {
+    const identity = await mockBridge.identityCreate("in_memory");
+    const handle = await mockBridge.contextCreate(
+      identity,
+      JSON.stringify({ ceiling: ["messages:read"], ttlSeconds: 300 }),
+    );
+    const ctx = Context._fromHandle(handle, identity.did);
+
+    const approved = await ctx.proposeTtlExtension(120);
+    expect(approved).toBe(true);
+  });
+
+  it("proposeTtlExtension rejects zero or negative seconds", async () => {
+    const identity = await mockBridge.identityCreate("in_memory");
+    const handle = await mockBridge.contextCreate(
+      identity,
+      JSON.stringify({ ceiling: ["messages:read"], ttlSeconds: 300 }),
+    );
+    const ctx = Context._fromHandle(handle, identity.did);
+
+    await expect(ctx.proposeTtlExtension(0)).rejects.toThrow(ContextError);
+    await expect(ctx.proposeTtlExtension(-10)).rejects.toThrow(ContextError);
+  });
+
+  it("resetTtlTimer delegates to bridge", async () => {
+    const identity = await mockBridge.identityCreate("in_memory");
+    const handle = await mockBridge.contextCreate(
+      identity,
+      JSON.stringify({ ceiling: ["messages:read"], ttlSeconds: 300 }),
+    );
+    const ctx = Context._fromHandle(handle, identity.did);
+
+    await ctx.resetTtlTimer(600);
+    expect(mockBridge._contexts.get(handle.contextId)?.ttlSecs).toBe(600);
+  });
+
+  it("resetTtlTimer rejects zero or negative seconds", async () => {
+    const identity = await mockBridge.identityCreate("in_memory");
+    const handle = await mockBridge.contextCreate(
+      identity,
+      JSON.stringify({ ceiling: ["messages:read"], ttlSeconds: 300 }),
+    );
+    const ctx = Context._fromHandle(handle, identity.did);
+
+    await expect(ctx.resetTtlTimer(0)).rejects.toThrow(ContextError);
+    await expect(ctx.resetTtlTimer(-5)).rejects.toThrow(ContextError);
+  });
+
+  it("export returns Uint8Array", async () => {
+    const identity = await mockBridge.identityCreate("in_memory");
+    const handle = await mockBridge.contextCreate(
+      identity,
+      JSON.stringify({ ceiling: ["messages:read"] }),
+    );
+    const ctx = Context._fromHandle(handle, identity.did);
+
+    const exported = await ctx.export();
+    expect(exported).toBeInstanceOf(Uint8Array);
+    expect(exported.length).toBeGreaterThan(0);
+  });
+
+  it("static import returns context ID", async () => {
+    _setBridge(mockBridge);
+    const identity = await mockBridge.identityCreate("in_memory");
+    const handle = await mockBridge.contextCreate(
+      identity,
+      JSON.stringify({ ceiling: ["messages:read"] }),
+    );
+    const ctx = Context._fromHandle(handle, identity.did);
+
+    const exported = await ctx.export();
+    const importedId = await Context.import(exported);
+    expect(importedId).toBe(handle.contextId);
+  });
+
+  it("drainEvents returns event strings", async () => {
+    const identity = await mockBridge.identityCreate("in_memory");
+    const handle = await mockBridge.contextCreate(
+      identity,
+      JSON.stringify({ ceiling: ["messages:read", "messages:write"] }),
+    );
+    const ctx = Context._fromHandle(handle, identity.did);
+
+    await mockBridge.contextSend(handle, identity.did, new TextEncoder().encode("hello"));
+
+    const events = await ctx.drainEvents();
+    expect(events.length).toBe(2); // ContextCreated + MessageSent
+    for (const e of events) {
+      expect(typeof e).toBe("string");
+    }
+  });
+
+  it("methods throw on disposed context", async () => {
+    const identity = await mockBridge.identityCreate("in_memory");
+    const handle = await mockBridge.contextCreate(
+      identity,
+      JSON.stringify({ ceiling: ["messages:read"], ttlSeconds: 300 }),
+    );
+    const ctx = Context._fromHandle(handle, identity.did);
+
+    await ctx.leave();
+
+    await expect(ctx.handleTtlExpiry()).rejects.toThrow(ContextError);
+    await expect(ctx.proposeTtlExtension(120)).rejects.toThrow(ContextError);
+    await expect(ctx.resetTtlTimer(600)).rejects.toThrow(ContextError);
+    await expect(ctx.export()).rejects.toThrow(ContextError);
+    await expect(ctx.drainEvents()).rejects.toThrow(ContextError);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 14. UCAN delegation via SDK wrapper
+// ---------------------------------------------------------------------------
+
+describe("UCAN delegation (SDK wrapper)", () => {
+  beforeEach(() => {
+    _setBridge(mockBridge);
+  });
+
+  it("delegateUcan delegates to bridge and returns delegated token", async () => {
+    const admin = await mockBridge.identityCreate("in_memory");
+    const handle = await mockBridge.contextCreate(
+      admin,
+      JSON.stringify({ ceiling: ["messages:read", "messages:write"] }),
+    );
+    const ctx = Context._fromHandle(handle, admin.did);
+
+    const memberDid = (await mockBridge.identityCreate("in_memory")).did;
+    const parentToken = await mintUcan(ctx, memberDid, ["messages:read", "messages:write"]);
+
+    const delegateeDid = (await mockBridge.identityCreate("in_memory")).did;
+    const delegated = await delegateUcan(ctx, parentToken, memberDid, delegateeDid, [
+      "messages:read",
+    ]);
+
+    expect(delegated.issuer).toBe(memberDid);
+    expect(delegated.audience).toBe(delegateeDid);
+    expect(delegated.capabilities).toEqual(["messages:read"]);
+    expect(delegated.encoded).toBeTruthy();
   });
 });

--- a/bindings/typescript/tests/mock-bridge.ts
+++ b/bindings/typescript/tests/mock-bridge.ts
@@ -49,6 +49,8 @@ interface MockContext {
   ucans: Map<string, UcanToken>;
   revokedTokens: Set<string>;
   economicPolicy: string | null;
+  ttlSecs: number | null;
+  drainedEvents: string[];
 }
 
 interface MockTransport {
@@ -210,7 +212,7 @@ export function createMockBridge(): Bridge & {
       identity: BridgeIdentityHandle,
       paramsJson: string,
     ): Promise<BridgeContextHandle> {
-      const _params = JSON.parse(paramsJson);
+      const params = JSON.parse(paramsJson) as { ttlSeconds?: number };
       const contextId = generateId("ctx");
       const ctx: MockContext = {
         contextId,
@@ -223,6 +225,8 @@ export function createMockBridge(): Bridge & {
         ucans: new Map(),
         revokedTokens: new Set(),
         economicPolicy: null,
+        ttlSecs: params.ttlSeconds ?? null,
+        drainedEvents: [],
       };
 
       // Record ContextCreated event
@@ -632,11 +636,108 @@ export function createMockBridge(): Bridge & {
       return null;
     },
 
-    async contextExtendTtl(
-      _handle: BridgeContextHandle,
-      _additionalSecs: number,
-    ): Promise<boolean> {
+    async contextExtendTtl(handle: BridgeContextHandle, additionalSecs: number): Promise<boolean> {
+      const ctx = getContext(handle);
+      if (ctx.ttlSecs !== null) {
+        ctx.ttlSecs += additionalSecs;
+      }
       return true;
+    },
+
+    async contextHandleTtlExpiry(handle: BridgeContextHandle): Promise<void> {
+      const ctx = getContext(handle);
+      ctx.state = "expired";
+      ctx.events.push({
+        eventType: "TtlExpired",
+        actorDid: ctx.creatorDid,
+        timestamp: Math.floor(Date.now() / 1000),
+        payload: {},
+        sequence: ctx.events.length,
+      });
+      for (const sub of ctx.subscriptions) {
+        sub.onComplete();
+      }
+    },
+
+    async contextProposeTtlExtension(
+      handle: BridgeContextHandle,
+      _proposerDid: string,
+      extensionSecs: number,
+    ): Promise<boolean> {
+      const ctx = getContext(handle);
+      // In the mock, single-member contexts auto-approve
+      if (ctx.ttlSecs !== null) {
+        ctx.ttlSecs += extensionSecs;
+      }
+      return ctx.members.size <= 1;
+    },
+
+    async contextResetTtlTimer(
+      handle: BridgeContextHandle,
+      newDurationSecs: number,
+    ): Promise<void> {
+      const ctx = getContext(handle);
+      ctx.ttlSecs = newDurationSecs;
+    },
+
+    async contextExport(handle: BridgeContextHandle): Promise<Uint8Array> {
+      const ctx = getContext(handle);
+      const exportData = {
+        snapshot: {
+          context_id: ctx.contextId,
+          creator_did: ctx.creatorDid,
+          state: ctx.state,
+          members: [...ctx.members],
+          event_count: ctx.events.length,
+        },
+      };
+      return new TextEncoder().encode(JSON.stringify(exportData));
+    },
+
+    async contextImport(data: Uint8Array): Promise<string> {
+      const json = new TextDecoder().decode(data);
+      let parsed: { snapshot?: { context_id?: string; creator_did?: string; members?: string[] } };
+      try {
+        parsed = JSON.parse(json) as typeof parsed;
+      } catch {
+        throw new Error("[SCP-CTX-2032] Invalid export data: malformed JSON");
+      }
+      const snapshot = parsed.snapshot;
+      if (snapshot === undefined || snapshot.context_id === undefined) {
+        throw new Error("[SCP-CTX-2032] Invalid export data: missing snapshot");
+      }
+      const contextId = snapshot.context_id;
+      const creatorDid = snapshot.creator_did ?? "did:dht:unknown";
+      const members = snapshot.members ?? [creatorDid];
+      const ctx: MockContext = {
+        contextId,
+        state: "active",
+        creatorDid,
+        events: [],
+        tools: new Map(),
+        members: new Set(members),
+        subscriptions: [],
+        ucans: new Map(),
+        revokedTokens: new Set(),
+        economicPolicy: null,
+        ttlSecs: null,
+        drainedEvents: [],
+      };
+      ctx.events.push({
+        eventType: "ContextImported",
+        actorDid: creatorDid,
+        timestamp: Math.floor(Date.now() / 1000),
+        payload: { contextId },
+        sequence: 0,
+      });
+      contexts.set(contextId, ctx);
+      return contextId;
+    },
+
+    async contextDrainEvents(handle: BridgeContextHandle): Promise<readonly string[]> {
+      const ctx = getContext(handle);
+      const events = ctx.events.map((e) => JSON.stringify(e));
+      return events;
     },
 
     // Economic policy (§19.3)


### PR DESCRIPTION
## Summary
- Added 6 new public methods to the TypeScript `Context` class: `handleTtlExpiry`, `proposeTtlExtension`, `resetTtlTimer`, `export`, `static import`, `drainEvents`
- 7th method (`ucanDelegate`) was already exposed as `delegateUcan()` in `ucan.ts`
- Added `_setBridge()` for mock bridge injection in tests
- 18 new tests covering bridge-level and SDK-wrapper-level behavior

## Test plan
- [x] `tsc --noEmit` passes
- [x] `biome check` passes
- [x] `bun test` passes (160 tests, 0 failures)
- [x] Two-dot diff verified: only 4 TypeScript files changed

🤖 Generated with [Claude Code](https://claude.com/claude-code)