### PR TITLE
fix(typescript): improve mock bridge fidelity for drain/TTL/dead code (closes #969)

### DIFF
--- a/bindings/typescript/tests/integration.test.ts
+++ b/bindings/typescript/tests/integration.test.ts
@@ -924,7 +924,7 @@ describe("TTL operations (mock bridge)", () => {
     expect(mockBridge._contexts.get(ctx.contextId)?.ttlSecs).toBe(420);
   });
 
-  it("proposeTtlExtension returns false for multi-member context", async () => {
+  it("proposeTtlExtension returns false for multi-member context and does not change TTL", async () => {
     const alice = await mockBridge.identityCreate("in_memory");
     const bob = await mockBridge.identityCreate("in_memory");
     const ctx = await mockBridge.contextCreate(
@@ -935,6 +935,8 @@ describe("TTL operations (mock bridge)", () => {
 
     const approved = await mockBridge.contextProposeTtlExtension(ctx, alice.did, 120);
     expect(approved).toBe(false);
+    // TTL must remain unchanged when proposal is rejected
+    expect(mockBridge._contexts.get(ctx.contextId)?.ttlSecs).toBe(300);
   });
 
   it("resetTtlTimer replaces TTL with new duration", async () => {
@@ -1008,6 +1010,22 @@ describe("Drain events (mock bridge)", () => {
       const parsed = JSON.parse(e);
       expect(parsed.eventType).toBeTruthy();
     }
+  });
+
+  it("second drain returns empty after first drain consumes events", async () => {
+    const identity = await mockBridge.identityCreate("in_memory");
+    const ctx = await mockBridge.contextCreate(
+      identity,
+      JSON.stringify({ ceiling: ["messages:read", "messages:write"] }),
+    );
+
+    await mockBridge.contextSend(ctx, identity.did, new TextEncoder().encode("msg"));
+
+    const first = await mockBridge.contextDrainEvents(ctx);
+    expect(first.length).toBe(2); // ContextCreated + MessageSent
+
+    const second = await mockBridge.contextDrainEvents(ctx);
+    expect(second.length).toBe(0);
   });
 });
 

--- a/bindings/typescript/tests/mock-bridge.ts
+++ b/bindings/typescript/tests/mock-bridge.ts
@@ -50,7 +50,6 @@ interface MockContext {
   revokedTokens: Set<string>;
   economicPolicy: string | null;
   ttlSecs: number | null;
-  drainedEvents: string[];
 }
 
 interface MockTransport {
@@ -226,7 +225,6 @@ export function createMockBridge(): Bridge & {
         revokedTokens: new Set(),
         economicPolicy: null,
         ttlSecs: params.ttlSeconds ?? null,
-        drainedEvents: [],
       };
 
       // Record ContextCreated event
@@ -666,10 +664,11 @@ export function createMockBridge(): Bridge & {
     ): Promise<boolean> {
       const ctx = getContext(handle);
       // In the mock, single-member contexts auto-approve
-      if (ctx.ttlSecs !== null) {
+      const approved = ctx.members.size <= 1;
+      if (approved && ctx.ttlSecs !== null) {
         ctx.ttlSecs += extensionSecs;
       }
-      return ctx.members.size <= 1;
+      return approved;
     },
 
     async contextResetTtlTimer(
@@ -721,7 +720,6 @@ export function createMockBridge(): Bridge & {
         revokedTokens: new Set(),
         economicPolicy: null,
         ttlSecs: null,
-        drainedEvents: [],
       };
       ctx.events.push({
         eventType: "ContextImported",
@@ -737,6 +735,7 @@ export function createMockBridge(): Bridge & {
     async contextDrainEvents(handle: BridgeContextHandle): Promise<readonly string[]> {
       const ctx = getContext(handle);
       const events = ctx.events.map((e) => JSON.stringify(e));
+      ctx.events.length = 0;
       return events;
     },
 


### PR DESCRIPTION
Closes #969

## Summary
- `contextDrainEvents` now clears `ctx.events` after reading (matching real drain semantics)
- `contextProposeTtlExtension` only applies `extensionSecs` when returning `true` (approved)
- Removed unused `drainedEvents` field from `MockContext`
- Added test verifying second `drainEvents()` call returns empty array

## Review Cycles
- Cycles: 1
- Findings resolved: 0
- Findings reframed: 1 (pre-existing mock architecture gap filed as #971)
- Findings dismissed: 0