### PR TITLE
fix(kotlin): align bridge signatures with UniFFI exports (closes #562)

### DIFF
--- a/bindings/kotlin/scp-kt-android/src/main/kotlin/works/limn/scp/android/ScpViewModel.kt
+++ b/bindings/kotlin/scp-kt-android/src/main/kotlin/works/limn/scp/android/ScpViewModel.kt
@@ -22,14 +22,16 @@ import kotlinx.coroutines.sync.withLock
  * Resource handle for an active SCP context tracked by [ScpViewModel].
  *
  * Encapsulates the opaque context handle returned by [CoroutineBridge.ContextBridge.create]
- * or [CoroutineBridge.ContextBridge.join], along with the bridge needed to call [leave] on
- * cleanup.
+ * or [CoroutineBridge.ContextBridge.join], the identity handle of the member, and the bridge
+ * needed to call [leave] on cleanup.
  *
  * @property handle Opaque context handle from the FFI layer.
+ * @property identityHandle Opaque identity handle for the member in this context.
  * @property bridge The [CoroutineBridge] used to dispatch cleanup operations.
  */
 data class TrackedContext(
     val handle: Long,
+    val identityHandle: Long,
     val bridge: CoroutineBridge,
 )
 
@@ -53,7 +55,7 @@ data class TrackedContext(
  *     private val contextHandle = ...
  *
  *     init {
- *         trackContext(TrackedContext(contextHandle, bridge))
+ *         trackContext(TrackedContext(contextHandle, identityHandle, bridge))
  *     }
  *
  *     val messages: StateFlow<List<String>> = bridge.context
@@ -116,7 +118,7 @@ abstract class ScpViewModel : ViewModel() {
                 snapshot
             }
             for (ctx in contexts) {
-                runCatching { ctx.bridge.context.leave(ctx.handle) }
+                runCatching { ctx.bridge.context.leave(ctx.handle, ctx.identityHandle) }
             }
         }
         cleanupScope.cancel()

--- a/bindings/kotlin/scp-kt-android/src/test/kotlin/works/limn/scp/android/ScpViewModelTest.kt
+++ b/bindings/kotlin/scp-kt-android/src/test/kotlin/works/limn/scp/android/ScpViewModelTest.kt
@@ -52,8 +52,8 @@ class ScpViewModelTest {
     @Test
     fun `onCleared calls leave on all tracked contexts`() = runTest(testDispatcher) {
         val viewModel = TestScpViewModel()
-        val ctx1 = TrackedContext(handle = 1L, bridge = bridge)
-        val ctx2 = TrackedContext(handle = 2L, bridge = bridge)
+        val ctx1 = TrackedContext(handle = 1L, identityHandle = 1L, bridge = bridge)
+        val ctx2 = TrackedContext(handle = 2L, identityHandle = 2L, bridge = bridge)
 
         viewModel.trackContext(ctx1)
         viewModel.trackContext(ctx2)
@@ -72,8 +72,8 @@ class ScpViewModelTest {
         stubBindings.leaveThrowsForHandle = 1L
 
         val viewModel = TestScpViewModel()
-        viewModel.trackContext(TrackedContext(handle = 1L, bridge = bridge))
-        viewModel.trackContext(TrackedContext(handle = 2L, bridge = bridge))
+        viewModel.trackContext(TrackedContext(handle = 1L, identityHandle = 1L, bridge = bridge))
+        viewModel.trackContext(TrackedContext(handle = 2L, identityHandle = 2L, bridge = bridge))
         advanceUntilIdle()
 
         viewModel.callOnCleared()
@@ -86,7 +86,7 @@ class ScpViewModelTest {
     @Test
     fun `untrackContext prevents leave on cleared`() = runTest(testDispatcher) {
         val viewModel = TestScpViewModel()
-        val ctx = TrackedContext(handle = 1L, bridge = bridge)
+        val ctx = TrackedContext(handle = 1L, identityHandle = 1L, bridge = bridge)
 
         viewModel.trackContext(ctx)
         advanceUntilIdle()
@@ -111,7 +111,7 @@ class ScpViewModelTest {
     @Test
     fun `trackContext returns the same context for chaining`() = runTest(testDispatcher) {
         val viewModel = TestScpViewModel()
-        val ctx = TrackedContext(handle = 42L, bridge = bridge)
+        val ctx = TrackedContext(handle = 42L, identityHandle = 1L, bridge = bridge)
         val returned = viewModel.trackContext(ctx)
         assertEquals(ctx, returned)
     }
@@ -119,7 +119,7 @@ class ScpViewModelTest {
     @Test
     fun `onCleared clears the active contexts list`() = runTest(testDispatcher) {
         val viewModel = TestScpViewModel()
-        viewModel.trackContext(TrackedContext(handle = 1L, bridge = bridge))
+        viewModel.trackContext(TrackedContext(handle = 1L, identityHandle = 1L, bridge = bridge))
         advanceUntilIdle()
 
         viewModel.callOnCleared()
@@ -151,7 +151,7 @@ private class TestNativeBindings : NativeBindings {
     val leaveCalledHandles = mutableListOf<Long>()
     var leaveThrowsForHandle: Long? = null
 
-    override fun contextLeave(contextHandle: Long) {
+    override fun contextLeave(contextHandle: Long, identityHandle: Long) {
         leaveCalledHandles.add(contextHandle)
         if (contextHandle == leaveThrowsForHandle) {
             throw ScpLeaveException("leave failed for handle $contextHandle")
@@ -162,9 +162,9 @@ private class TestNativeBindings : NativeBindings {
     override fun identityLoad(did: String): Long = 0L
     override fun identityResolve(did: String): String = ""
     override fun contextCreate(identityHandle: Long, paramsJson: String): Long = 0L
-    override fun contextJoin(identityHandle: Long, contextId: String): Long = 0L
-    override fun contextClose(contextHandle: Long) { /* no-op */ }
-    override fun contextSend(contextHandle: Long, payload: ByteArray) { /* no-op */ }
+    override fun contextJoin(contextHandle: Long, identityHandle: Long) { /* no-op */ }
+    override fun contextClose(contextHandle: Long, identityHandle: Long) { /* no-op */ }
+    override fun contextSend(contextHandle: Long, identityHandle: Long, payload: ByteArray) { /* no-op */ }
     override fun contextSubscribe(contextHandle: Long, callback: MessageCallback): Long = 0L
     override fun contextUnsubscribe(subscriptionHandle: Long) { /* no-op */ }
     override fun contextSetEconomicPolicy(contextHandle: Long, policyJson: String) { /* no-op */ }
@@ -193,7 +193,7 @@ private class TestNativeBindings : NativeBindings {
     // BroadcastBindings
     override fun broadcastSubscribe(contextHandle: Long, subscriberDid: String) = Unit
     override fun broadcastUnsubscribe(contextHandle: Long, subscriberDid: String, rotateKeys: Boolean) = Unit
-    override fun broadcastPublish(contextHandle: Long, authorDid: String, payload: ByteArray) = Unit
+    override fun broadcastPublish(contextHandle: Long, identityHandle: Long, payload: ByteArray) = Unit
     override fun broadcastBlockSubscriber(contextHandle: Long, subscriberDid: String, blockerDid: String) = Unit
     override fun broadcastUnblockSubscriber(contextHandle: Long, subscriberDid: String, unblockerDid: String) = Unit
     override fun broadcastHandleKeyRequest(contextHandle: Long, authorDid: String, requesterDid: String): String = "{}"
@@ -202,11 +202,25 @@ private class TestNativeBindings : NativeBindings {
     override fun broadcastAdmission(contextHandle: Long): String? = null
 
     override fun toolRegister(contextHandle: Long, definitionJson: String): String = ""
-    override fun toolInvoke(contextHandle: Long, toolId: String, inputJson: String): String = ""
-    override fun toolVerify(toolId: String, inputJson: String, outputJson: String): Boolean = false
-    override fun ucanValidate(token: String, capability: String, contextId: String) { /* no-op */ }
-    override fun ucanMint(identityHandle: Long, memberDid: String, capabilitiesJson: String): String = ""
-    override fun ucanRevoke(identityHandle: Long, token: String) { /* no-op */ }
+    override fun toolInvoke(
+        contextHandle: Long,
+        toolId: String,
+        inputJson: String,
+        identityHandle: Long,
+        ucanToken: String?,
+        proofTokens: List<String>?,
+    ): String = ""
+    override fun toolVerify(contextHandle: Long, toolId: String): String =
+        """{"tool_id":"$toolId","passed":false,"failures":[]}"""
+    override fun ucanValidate(
+        contextHandle: Long,
+        token: String,
+        capability: String,
+        presentingAgentDid: String?,
+        proofTokens: List<String>?,
+    ) { /* no-op */ }
+    override fun ucanMint(contextHandle: Long, memberDid: String, capabilitiesJson: String): String = ""
+    override fun ucanRevoke(contextHandle: Long, token: String) { /* no-op */ }
     override fun ucanDelegate(
         contextHandle: Long,
         delegatorDid: String,

--- a/bindings/kotlin/scp-kt/src/main/kotlin/works/limn/scp/bridge/CoroutineBridge.kt
+++ b/bindings/kotlin/scp-kt/src/main/kotlin/works/limn/scp/bridge/CoroutineBridge.kt
@@ -165,23 +165,22 @@ interface ContextBindings {
     ): Long
 
     /**
-     * Joins an existing SCP context by context ID.
+     * Joins an existing SCP context.
      *
      * The context must be in `Active` state. Delegates to `ContextManager`
      * which validates version compatibility and adds the member with a
      * key package.
      *
+     * @param contextHandle Opaque handle from [contextCreate].
      * @param identityHandle Opaque handle from [IdentityBindings.identityCreate]
      *   or [IdentityBindings.identityLoad].
-     * @param contextId The unique identifier of the context to join.
-     * @return Opaque context handle.
      * @throws BridgeException with `SCP-CTX-2013` if the context is not
      *   in active state, or with `SCP-VALID-7000` if the DID is malformed.
      */
     fun contextJoin(
+        contextHandle: Long,
         identityHandle: Long,
-        contextId: String,
-    ): Long
+    )
 
     /**
      * Leaves an SCP context gracefully (member-initiated).
@@ -190,9 +189,14 @@ interface ContextBindings {
      * The context remains active for other members.
      *
      * @param contextHandle Opaque handle from [contextCreate] or [contextJoin].
+     * @param identityHandle Opaque handle from [IdentityBindings.identityCreate]
+     *   or [IdentityBindings.identityLoad].
      * @throws BridgeException with `SCP-CTX-2001` if the leave operation fails.
      */
-    fun contextLeave(contextHandle: Long)
+    fun contextLeave(
+        contextHandle: Long,
+        identityHandle: Long,
+    )
 
     /**
      * Closes an SCP context (admin action).
@@ -201,10 +205,15 @@ interface ContextBindings {
      * by the `ContextManager` via the `ContextClose` capability check.
      *
      * @param contextHandle Opaque handle from [contextCreate].
+     * @param identityHandle Opaque handle from [IdentityBindings.identityCreate]
+     *   or [IdentityBindings.identityLoad].
      * @throws BridgeException with `SCP-CTX-2001` if the close operation
      *   fails or the caller lacks the `ContextClose` capability.
      */
-    fun contextClose(contextHandle: Long)
+    fun contextClose(
+        contextHandle: Long,
+        identityHandle: Long,
+    )
 
     /**
      * Sends a message to an SCP context.
@@ -214,12 +223,15 @@ interface ContextBindings {
      * provider. The context must be in `Active` state.
      *
      * @param contextHandle Opaque handle from [contextCreate] or [contextJoin].
+     * @param identityHandle Opaque handle from [IdentityBindings.identityCreate]
+     *   or [IdentityBindings.identityLoad].
      * @param payload Raw message bytes (application content).
      * @throws BridgeException with `SCP-CTX-2019` if the context is not
      *   active, or with `SCP-CRYPTO-4001` if inner envelope signing fails.
      */
     fun contextSend(
         contextHandle: Long,
+        identityHandle: Long,
         payload: ByteArray,
     )
 
@@ -492,14 +504,15 @@ interface BroadcastBindings {
      * active subscribers can decrypt it.
      *
      * @param contextHandle Opaque handle from context create or join.
-     * @param authorDid DID of the author publishing the message.
+     * @param identityHandle Opaque handle from [IdentityBindings.identityCreate]
+     *   or [IdentityBindings.identityLoad] for the publishing author.
      * @param payload Raw message bytes to broadcast.
      * @throws BridgeException if publishing fails (e.g., author is not
      *   the broadcast owner, context not active).
      */
     fun broadcastPublish(
         contextHandle: Long,
-        authorDid: String,
+        identityHandle: Long,
         payload: ByteArray,
     )
 
@@ -622,42 +635,53 @@ interface ToolBindings {
      * Invokes a registered tool in an SCP context.
      *
      * Validates the input against the tool's JSON schema, checks UCAN
-     * authorization, and dispatches to the tool handler if one is
-     * registered. The context must be in `Active` state.
+     * authorization via the full 11-step ADR-016 pipeline, and dispatches
+     * to the tool handler if one is registered. The context must be in
+     * `Active` state.
      *
      * @param contextHandle Opaque handle from context create or join.
      * @param toolId The tool's assigned ID from [toolRegister].
      * @param inputJson JSON-encoded tool input matching the tool's
      *   input schema.
+     * @param identityHandle Opaque handle for the invoker's identity
+     *   (used for capability checking).
+     * @param ucanToken Optional JWT-encoded UCAN token authorizing the
+     *   invocation. Must contain `tool_invoke:{tool_id}` or
+     *   `tool_invoke:*` capability.
+     * @param proofTokens Optional list of encoded parent UCAN tokens
+     *   for delegation chain traversal (ADR-016 step 3).
      * @return JSON-encoded tool output.
      * @throws BridgeException with `SCP-TOOL-6005` if the context is not
      *   active, with `SCP-TOOL-6002` if invocation fails, or with
      *   `SCP-PERM-3001` if UCAN authorization fails.
      */
+    @Suppress("LongParameterList") // FFI bridge — must match UniFFI export signature
     fun toolInvoke(
         contextHandle: Long,
         toolId: String,
         inputJson: String,
+        identityHandle: Long,
+        ucanToken: String?,
+        proofTokens: List<String>?,
     ): String
 
     /**
-     * Verifies a tool invocation's input/output pair against test vectors.
+     * Verifies a tool's registration status in an SCP context.
      *
-     * Checks that the given input produces the expected output according
-     * to the tool's registered test vectors.
+     * Checks that the tool is registered and returns its verification
+     * result including whether it passed and any failure details.
      *
+     * @param contextHandle Opaque handle from context create or join.
      * @param toolId The tool's assigned ID.
-     * @param inputJson JSON-encoded tool input.
-     * @param outputJson JSON-encoded tool output to verify.
-     * @return `true` if verification passes (all test vectors satisfied).
+     * @return JSON-encoded verification result with `tool_id`, `passed`,
+     *   and `failures` fields.
      * @throws BridgeException with `SCP-TOOL-6007` if the context is not
      *   active or verification encounters an error.
      */
     fun toolVerify(
+        contextHandle: Long,
         toolId: String,
-        inputJson: String,
-        outputJson: String,
-    ): Boolean
+    ): String
 }
 
 /**
@@ -674,18 +698,24 @@ interface UcanBindings {
      * prevention, revocation checking, delegation chain traversal, and
      * capability ceiling enforcement.
      *
+     * @param contextHandle Opaque handle from context create or join.
      * @param token The UCAN token string (JWT-encoded).
      * @param capability The capability URI to validate against (e.g.,
      *   `"scp:ctx:abc123/messages:write"`).
-     * @param contextId The context ID for scoping the validation.
+     * @param presentingAgentDid Optional DID of the presenting agent
+     *   for delegation chain verification.
+     * @param proofTokens Optional list of encoded parent UCAN tokens
+     *   for delegation chain traversal (ADR-016 step 3).
      * @throws BridgeException with `SCP-PERM-3002` if validation fails
      *   (malformed token, expired, revoked, nonce replay, insufficient
      *   capability, or invalid signature).
      */
     fun ucanValidate(
+        contextHandle: Long,
         token: String,
         capability: String,
-        contextId: String,
+        presentingAgentDid: String?,
+        proofTokens: List<String>?,
     )
 
     /**
@@ -696,7 +726,7 @@ interface UcanBindings {
      * `scp_core::crypto::ucan::mint::mint_ucan`. Capabilities are
      * automatically scoped to the context. Enforces ceiling constraints.
      *
-     * @param identityHandle Opaque handle from identity create or load.
+     * @param contextHandle Opaque handle from context create or join.
      * @param memberDid The DID of the member receiving the token.
      * @param capabilitiesJson JSON-encoded list of capability URI strings
      *   to grant (e.g., `["messages:write", "tool_invoke:*"]`).
@@ -706,7 +736,7 @@ interface UcanBindings {
      *   custody for signing.
      */
     fun ucanMint(
-        identityHandle: Long,
+        contextHandle: Long,
         memberDid: String,
         capabilitiesJson: String,
     ): String
@@ -719,12 +749,12 @@ interface UcanBindings {
      * idempotent: revoking a non-existent or already-revoked token
      * succeeds silently.
      *
-     * @param identityHandle Opaque handle from identity create or load.
+     * @param contextHandle Opaque handle from context create or join.
      * @param token The full encoded JWT string of the token to revoke.
      * @throws BridgeException if the revocation operation fails.
      */
     fun ucanRevoke(
-        identityHandle: Long,
+        contextHandle: Long,
         token: String,
     )
 
@@ -1137,41 +1167,50 @@ class ContextBridge internal constructor(
     ): Long = bridge.ffiCall { bindings.contextCreate(identityHandle, paramsJson) }
 
     /**
-     * Join an existing context by ID.
+     * Join an existing context.
      *
+     * @param contextHandle Handle from context create.
      * @param identityHandle Handle from identity create or load.
-     * @param contextId The context ID to join.
-     * @return Opaque context handle.
      */
     suspend fun join(
+        contextHandle: Long,
         identityHandle: Long,
-        contextId: String,
-    ): Long = bridge.ffiCall { bindings.contextJoin(identityHandle, contextId) }
+    ): Unit = bridge.ffiCall { bindings.contextJoin(contextHandle, identityHandle) }
 
     /**
      * Leave a context gracefully (member action).
      *
      * @param contextHandle Handle from context create or join.
+     * @param identityHandle Handle from identity create or load.
      */
-    suspend fun leave(contextHandle: Long): Unit = bridge.ffiCall { bindings.contextLeave(contextHandle) }
+    suspend fun leave(
+        contextHandle: Long,
+        identityHandle: Long,
+    ): Unit = bridge.ffiCall { bindings.contextLeave(contextHandle, identityHandle) }
 
     /**
      * Close a context (admin action). Terminates the context for all members.
      *
      * @param contextHandle Handle from context create.
+     * @param identityHandle Handle from identity create or load.
      */
-    suspend fun close(contextHandle: Long): Unit = bridge.ffiCall { bindings.contextClose(contextHandle) }
+    suspend fun close(
+        contextHandle: Long,
+        identityHandle: Long,
+    ): Unit = bridge.ffiCall { bindings.contextClose(contextHandle, identityHandle) }
 
     /**
      * Send a message to a context.
      *
      * @param contextHandle Handle from context create or join.
+     * @param identityHandle Handle from identity create or load.
      * @param payload Raw message bytes.
      */
     suspend fun send(
         contextHandle: Long,
+        identityHandle: Long,
         payload: ByteArray,
-    ): Unit = bridge.ffiCall { bindings.contextSend(contextHandle, payload) }
+    ): Unit = bridge.ffiCall { bindings.contextSend(contextHandle, identityHandle, payload) }
 
     /**
      * Set the economic policy for a context (§19.3).
@@ -1275,27 +1314,41 @@ class ToolBridge internal constructor(
      * @param contextHandle Handle from context create or join.
      * @param toolId The tool's assigned ID.
      * @param inputJson JSON-encoded tool input.
+     * @param identityHandle Handle for the invoker's identity.
+     * @param ucanToken Optional UCAN token authorizing the invocation.
+     * @param proofTokens Optional parent UCAN tokens for delegation chain.
      * @return JSON-encoded tool output.
      */
+    @Suppress("LongParameterList") // FFI bridge — must match UniFFI export signature
     suspend fun invoke(
         contextHandle: Long,
         toolId: String,
         inputJson: String,
-    ): String = bridge.ffiCall { bindings.toolInvoke(contextHandle, toolId, inputJson) }
+        identityHandle: Long,
+        ucanToken: String?,
+        proofTokens: List<String>? = null,
+    ): String = bridge.ffiCall {
+        bindings.toolInvoke(
+            contextHandle,
+            toolId,
+            inputJson,
+            identityHandle,
+            ucanToken,
+            proofTokens,
+        )
+    }
 
     /**
-     * Verify a tool invocation's input/output pair.
+     * Verify a tool's registration status in a context.
      *
+     * @param contextHandle Handle from context create or join.
      * @param toolId The tool's ID.
-     * @param inputJson JSON-encoded tool input.
-     * @param outputJson JSON-encoded tool output.
-     * @return true if the verification passes.
+     * @return JSON-encoded verification result.
      */
     suspend fun verify(
+        contextHandle: Long,
         toolId: String,
-        inputJson: String,
-        outputJson: String,
-    ): Boolean = bridge.ffiCall { bindings.toolVerify(toolId, inputJson, outputJson) }
+    ): String = bridge.ffiCall { bindings.toolVerify(contextHandle, toolId) }
 }
 
 /**
@@ -1308,41 +1361,47 @@ class UcanBridge internal constructor(
     /**
      * Validate a UCAN token for a capability in a context.
      *
+     * @param contextHandle Handle from context create or join.
      * @param token The UCAN token string.
      * @param capability The capability to validate.
-     * @param contextId The context ID.
+     * @param presentingAgentDid Optional DID of the presenting agent.
+     * @param proofTokens Optional parent UCAN tokens for delegation chain.
      * @throws BridgeException if validation fails.
      */
     suspend fun validate(
+        contextHandle: Long,
         token: String,
         capability: String,
-        contextId: String,
-    ): Unit = bridge.ffiCall { bindings.ucanValidate(token, capability, contextId) }
+        presentingAgentDid: String? = null,
+        proofTokens: List<String>? = null,
+    ): Unit = bridge.ffiCall {
+        bindings.ucanValidate(contextHandle, token, capability, presentingAgentDid, proofTokens)
+    }
 
     /**
      * Mint a UCAN token delegating capabilities to a member DID.
      *
-     * @param identityHandle Handle from identity create or load.
+     * @param contextHandle Handle from context create or join.
      * @param memberDid The DID to delegate capabilities to.
      * @param capabilitiesJson JSON-encoded list of capabilities.
      * @return The minted UCAN token string.
      */
     suspend fun mint(
-        identityHandle: Long,
+        contextHandle: Long,
         memberDid: String,
         capabilitiesJson: String,
-    ): String = bridge.ffiCall { bindings.ucanMint(identityHandle, memberDid, capabilitiesJson) }
+    ): String = bridge.ffiCall { bindings.ucanMint(contextHandle, memberDid, capabilitiesJson) }
 
     /**
      * Revoke a previously minted UCAN token.
      *
-     * @param identityHandle Handle from identity create or load.
+     * @param contextHandle Handle from context create or join.
      * @param token The full encoded JWT string of the token to revoke.
      */
     suspend fun revoke(
-        identityHandle: Long,
+        contextHandle: Long,
         token: String,
-    ): Unit = bridge.ffiCall { bindings.ucanRevoke(identityHandle, token) }
+    ): Unit = bridge.ffiCall { bindings.ucanRevoke(contextHandle, token) }
 
     /**
      * Delegate a UCAN token to another entity with attenuated capabilities.
@@ -1577,14 +1636,15 @@ class BroadcastBridgeOps internal constructor(
      * Publish a message to a broadcast context.
      *
      * @param contextHandle Handle from context create or join.
-     * @param authorDid The DID of the author publishing the message.
+     * @param identityHandle Handle from identity create or load for the
+     *   publishing author.
      * @param payload Raw message bytes.
      */
     suspend fun publish(
         contextHandle: Long,
-        authorDid: String,
+        identityHandle: Long,
         payload: ByteArray,
-    ): Unit = bridge.ffiCall { bindings.broadcastPublish(contextHandle, authorDid, payload) }
+    ): Unit = bridge.ffiCall { bindings.broadcastPublish(contextHandle, identityHandle, payload) }
 
     /**
      * Block a subscriber's read access in a broadcast context.

--- a/bindings/kotlin/scp-kt/src/test/kotlin/works/limn/scp/bridge/CoroutineBridgeTest.kt
+++ b/bindings/kotlin/scp-kt/src/test/kotlin/works/limn/scp/bridge/CoroutineBridgeTest.kt
@@ -102,30 +102,28 @@ class CoroutineBridgeTest {
         @Test
         fun `contextJoin dispatches on IO`() =
             runTest(ioDispatcher) {
-                stubBindings.contextJoinResult = 11L
-                val result = bridge.context.join(1L, "ctx-123")
-                assertEquals(11L, result)
+                bridge.context.join(10L, 1L)
             }
 
         @Test
         fun `contextSend dispatches on IO`() =
             runTest(ioDispatcher) {
                 val payload = "hello".toByteArray()
-                bridge.context.send(10L, payload)
+                bridge.context.send(10L, 1L, payload)
                 assertTrue(stubBindings.contextSendCalled)
             }
 
         @Test
         fun `contextLeave dispatches on IO`() =
             runTest(ioDispatcher) {
-                bridge.context.leave(10L)
+                bridge.context.leave(10L, 1L)
                 assertTrue(stubBindings.contextLeaveCalled)
             }
 
         @Test
         fun `contextClose dispatches on IO`() =
             runTest(ioDispatcher) {
-                bridge.context.close(10L)
+                bridge.context.close(10L, 1L)
                 assertTrue(stubBindings.contextCloseCalled)
             }
     }
@@ -148,7 +146,7 @@ class CoroutineBridgeTest {
         fun `toolInvoke dispatches on IO`() =
             runTest(ioDispatcher) {
                 stubBindings.toolInvokeResult = """{"output":"ok"}"""
-                val result = bridge.tools.invoke(10L, "tool-001", """{"input":"data"}""")
+                val result = bridge.tools.invoke(10L, "tool-001", """{"input":"data"}""", 1L, "ucan.token.sig")
                 assertEquals("""{"output":"ok"}""", result)
             }
 
@@ -156,14 +154,14 @@ class CoroutineBridgeTest {
         fun `toolVerify dispatches on IO`() =
             runTest(ioDispatcher) {
                 stubBindings.toolVerifyResult = true
-                val result = bridge.tools.verify("tool-001", """{"in":"x"}""", """{"out":"y"}""")
-                assertTrue(result)
+                val result = bridge.tools.verify(10L, "tool-001")
+                assertTrue(result.contains("\"passed\":true"))
             }
 
         @Test
         fun `ucanValidate dispatches on IO`() =
             runTest(ioDispatcher) {
-                bridge.ucan.validate("token", "read", "ctx-1")
+                bridge.ucan.validate(10L, "token", "read")
                 assertTrue(stubBindings.ucanValidateCalled)
             }
 
@@ -171,14 +169,14 @@ class CoroutineBridgeTest {
         fun `ucanMint dispatches on IO`() =
             runTest(ioDispatcher) {
                 stubBindings.ucanMintResult = "minted-token"
-                val result = bridge.ucan.mint(1L, "did:dht:member", """["read","write"]""")
+                val result = bridge.ucan.mint(10L, "did:dht:member", """["read","write"]""")
                 assertEquals("minted-token", result)
             }
 
         @Test
         fun `ucanRevoke dispatches on IO`() =
             runTest(ioDispatcher) {
-                bridge.ucan.revoke(1L, "header.payload.signature")
+                bridge.ucan.revoke(10L, "header.payload.signature")
                 assertTrue(stubBindings.ucanRevokeCalled)
             }
 
@@ -593,20 +591,29 @@ class StubNativeBindings : NativeBindings {
     ): Long = contextCreateResult
 
     override fun contextJoin(
+        contextHandle: Long,
         identityHandle: Long,
-        contextId: String,
-    ): Long = contextJoinResult
+    ) {
+        // no-op
+    }
 
-    override fun contextLeave(contextHandle: Long) {
+    override fun contextLeave(
+        contextHandle: Long,
+        identityHandle: Long,
+    ) {
         contextLeaveCalled = true
     }
 
-    override fun contextClose(contextHandle: Long) {
+    override fun contextClose(
+        contextHandle: Long,
+        identityHandle: Long,
+    ) {
         contextCloseCalled = true
     }
 
     override fun contextSend(
         contextHandle: Long,
+        identityHandle: Long,
         payload: ByteArray,
     ) {
         contextSendCalled = true
@@ -662,7 +669,7 @@ class StubNativeBindings : NativeBindings {
     var broadcastUnblockThrows: Exception? = null
     override fun broadcastSubscribe(contextHandle: Long, subscriberDid: String) = Unit
     override fun broadcastUnsubscribe(contextHandle: Long, subscriberDid: String, rotateKeys: Boolean) = Unit
-    override fun broadcastPublish(contextHandle: Long, authorDid: String, payload: ByteArray) = Unit
+    override fun broadcastPublish(contextHandle: Long, identityHandle: Long, payload: ByteArray) = Unit
     override fun broadcastBlockSubscriber(contextHandle: Long, subscriberDid: String, blockerDid: String) {
         broadcastBlockCalled = true
         lastBlockSubscriberDid = subscriberDid
@@ -689,30 +696,34 @@ class StubNativeBindings : NativeBindings {
         contextHandle: Long,
         toolId: String,
         inputJson: String,
+        identityHandle: Long,
+        ucanToken: String?,
+        proofTokens: List<String>?,
     ): String = toolInvokeResult
 
     override fun toolVerify(
+        contextHandle: Long,
         toolId: String,
-        inputJson: String,
-        outputJson: String,
-    ): Boolean = toolVerifyResult
+    ): String = """{"tool_id":"$toolId","passed":$toolVerifyResult,"failures":[]}"""
 
     override fun ucanValidate(
+        contextHandle: Long,
         token: String,
         capability: String,
-        contextId: String,
+        presentingAgentDid: String?,
+        proofTokens: List<String>?,
     ) {
         ucanValidateCalled = true
     }
 
     override fun ucanMint(
-        identityHandle: Long,
+        contextHandle: Long,
         memberDid: String,
         capabilitiesJson: String,
     ): String = ucanMintResult
 
     override fun ucanRevoke(
-        identityHandle: Long,
+        contextHandle: Long,
         token: String,
     ) {
         ucanRevokeCalled = true

--- a/bindings/kotlin/scp-kt/src/test/kotlin/works/limn/scp/conformance/ConformanceDispatcher.kt
+++ b/bindings/kotlin/scp-kt/src/test/kotlin/works/limn/scp/conformance/ConformanceDispatcher.kt
@@ -95,17 +95,18 @@ class ConformanceDispatcher(
     private suspend fun dispatchContextJoin(
         input: Map<String, String>,
     ): Map<String, String> = catchBridge {
+        val contextHandle = input["context_handle"]?.toLongOrNull() ?: 0L
         val identityHandle = input["identity_handle"]?.toLongOrNull() ?: 0L
-        val contextId = input["context_id"] ?: ""
-        val handle = bridge.context.join(identityHandle, contextId)
-        mapOf("handle" to handle.toString())
+        bridge.context.join(contextHandle, identityHandle)
+        mapOf("status" to "joined")
     }
 
     private suspend fun dispatchContextLeave(
         input: Map<String, String>,
     ): Map<String, String> = catchBridge {
         val contextHandle = input["context_handle"]?.toLongOrNull() ?: 0L
-        bridge.context.leave(contextHandle)
+        val identityHandle = input["identity_handle"]?.toLongOrNull() ?: 0L
+        bridge.context.leave(contextHandle, identityHandle)
         mapOf("status" to "left")
     }
 
@@ -113,7 +114,8 @@ class ConformanceDispatcher(
         input: Map<String, String>,
     ): Map<String, String> = catchBridge {
         val contextHandle = input["context_handle"]?.toLongOrNull() ?: 0L
-        bridge.context.close(contextHandle)
+        val identityHandle = input["identity_handle"]?.toLongOrNull() ?: 0L
+        bridge.context.close(contextHandle, identityHandle)
         mapOf("status" to "closed")
     }
 
@@ -121,8 +123,9 @@ class ConformanceDispatcher(
         input: Map<String, String>,
     ): Map<String, String> = catchBridge {
         val contextHandle = input["context_handle"]?.toLongOrNull() ?: 0L
+        val identityHandle = input["identity_handle"]?.toLongOrNull() ?: 0L
         val payload = (input["payload"] ?: "").toByteArray()
-        bridge.context.send(contextHandle, payload)
+        bridge.context.send(contextHandle, identityHandle, payload)
         mapOf("status" to "sent")
     }
 
@@ -141,37 +144,48 @@ class ConformanceDispatcher(
         val contextHandle = input["context_handle"]?.toLongOrNull() ?: 0L
         val toolId = input["tool_id"] ?: ""
         val toolInput = input["input"] ?: "{}"
-        val output = bridge.tools.invoke(contextHandle, toolId, toolInput)
+        val identityHandle = input["identity_handle"]?.toLongOrNull() ?: 0L
+        val ucanToken = input["ucan_token"]
+        val proofTokens = input["proof_tokens"]?.let { listOf(it) }
+        val output = bridge.tools.invoke(
+            contextHandle,
+            toolId,
+            toolInput,
+            identityHandle,
+            ucanToken,
+            proofTokens,
+        )
         mapOf("output" to output)
     }
 
     private suspend fun dispatchToolVerify(
         input: Map<String, String>,
     ): Map<String, String> = catchBridge {
+        val contextHandle = input["context_handle"]?.toLongOrNull() ?: 0L
         val toolId = input["tool_id"] ?: ""
-        val toolInput = input["input"] ?: "{}"
-        val toolOutput = input["output"] ?: "{}"
-        val valid = bridge.tools.verify(toolId, toolInput, toolOutput)
-        mapOf("is_valid" to valid.toString())
+        val resultJson = bridge.tools.verify(contextHandle, toolId)
+        mapOf("result" to resultJson)
     }
 
     private suspend fun dispatchUcanValidate(
         input: Map<String, String>,
     ): Map<String, String> = catchBridge {
+        val contextHandle = input["context_handle"]?.toLongOrNull() ?: 0L
         val token = input["encoded"] ?: input["token"] ?: ""
         val capability = input["capability"] ?: ""
-        val contextId = input["context_id"] ?: ""
-        bridge.ucan.validate(token, capability, contextId)
+        val presentingAgentDid = input["presenting_agent_did"]
+        val proofTokens = input["proof_tokens"]?.let { listOf(it) }
+        bridge.ucan.validate(contextHandle, token, capability, presentingAgentDid, proofTokens)
         mapOf("status" to "valid")
     }
 
     private suspend fun dispatchUcanMint(
         input: Map<String, String>,
     ): Map<String, String> = catchBridge {
-        val identityHandle = input["identity_handle"]?.toLongOrNull() ?: 0L
+        val contextHandle = input["context_handle"]?.toLongOrNull() ?: 0L
         val memberDid = input["audience_did"] ?: input["member_did"] ?: ""
         val capabilities = input["capabilities"] ?: "[]"
-        val token = bridge.ucan.mint(identityHandle, memberDid, capabilities)
+        val token = bridge.ucan.mint(contextHandle, memberDid, capabilities)
         mapOf("token" to token)
     }
 
@@ -196,9 +210,9 @@ class ConformanceDispatcher(
     private suspend fun dispatchUcanRevoke(
         input: Map<String, String>,
     ): Map<String, String> = catchBridge {
-        val identityHandle = input["identity_handle"]?.toLongOrNull() ?: 0L
+        val contextHandle = input["context_handle"]?.toLongOrNull() ?: 0L
         val token = input["token"] ?: input["encoded"] ?: ""
-        bridge.ucan.revoke(identityHandle, token)
+        bridge.ucan.revoke(contextHandle, token)
         mapOf("status" to "revoked")
     }
 

--- a/bindings/kotlin/scp-kt/src/test/kotlin/works/limn/scp/conformance/ConformanceStubBindings.kt
+++ b/bindings/kotlin/scp-kt/src/test/kotlin/works/limn/scp/conformance/ConformanceStubBindings.kt
@@ -54,7 +54,7 @@ class ConformanceStubBindings : NativeBindings {
     var toolRegisterError: BridgeException? = null
     var toolInvokeResult: String = """{"output":"ok"}"""
     var toolInvokeError: BridgeException? = null
-    var toolVerifyResult: Boolean = true
+    var toolVerifyResult: Boolean = true // kept as Boolean, serialized to JSON in toolVerify()
     var toolVerifyError: BridgeException? = null
 
     var ucanValidateError: BridgeException? = null
@@ -106,24 +106,33 @@ class ConformanceStubBindings : NativeBindings {
     }
 
     override fun contextJoin(
+        contextHandle: Long,
         identityHandle: Long,
-        contextId: String,
-    ): Long {
+    ) {
         contextJoinError?.let { throw it }
-        return contextJoinResult
     }
 
-    override fun contextLeave(contextHandle: Long) {
+    override fun contextLeave(
+        contextHandle: Long,
+        identityHandle: Long,
+    ) {
         contextLeaveCalled = true
         contextLeaveError?.let { throw it }
     }
 
-    override fun contextClose(contextHandle: Long) {
+    override fun contextClose(
+        contextHandle: Long,
+        identityHandle: Long,
+    ) {
         contextCloseCalled = true
         contextCloseError?.let { throw it }
     }
 
-    override fun contextSend(contextHandle: Long, payload: ByteArray) {
+    override fun contextSend(
+        contextHandle: Long,
+        identityHandle: Long,
+        payload: ByteArray,
+    ) {
         contextSendCalled = true
         contextSendPayload = payload
         contextSendError?.let { throw it }
@@ -165,7 +174,7 @@ class ConformanceStubBindings : NativeBindings {
     // BroadcastBindings
     override fun broadcastSubscribe(contextHandle: Long, subscriberDid: String) = Unit
     override fun broadcastUnsubscribe(contextHandle: Long, subscriberDid: String, rotateKeys: Boolean) = Unit
-    override fun broadcastPublish(contextHandle: Long, authorDid: String, payload: ByteArray) = Unit
+    override fun broadcastPublish(contextHandle: Long, identityHandle: Long, payload: ByteArray) = Unit
     override fun broadcastBlockSubscriber(contextHandle: Long, subscriberDid: String, blockerDid: String) = Unit
     override fun broadcastUnblockSubscriber(contextHandle: Long, subscriberDid: String, unblockerDid: String) = Unit
     override fun broadcastHandleKeyRequest(contextHandle: Long, authorDid: String, requesterDid: String): String =
@@ -186,30 +195,35 @@ class ConformanceStubBindings : NativeBindings {
         contextHandle: Long,
         toolId: String,
         inputJson: String,
+        identityHandle: Long,
+        ucanToken: String?,
+        proofTokens: List<String>?,
     ): String {
         toolInvokeError?.let { throw it }
         return toolInvokeResult
     }
 
     override fun toolVerify(
+        contextHandle: Long,
         toolId: String,
-        inputJson: String,
-        outputJson: String,
-    ): Boolean {
+    ): String {
         toolVerifyError?.let { throw it }
-        return toolVerifyResult
+        @Suppress("MaxLineLength")
+        return """{"tool_id":"$toolId","passed":$toolVerifyResult,"failures":[]}"""
     }
 
     override fun ucanValidate(
+        contextHandle: Long,
         token: String,
         capability: String,
-        contextId: String,
+        presentingAgentDid: String?,
+        proofTokens: List<String>?,
     ) {
         ucanValidateError?.let { throw it }
     }
 
     override fun ucanMint(
-        identityHandle: Long,
+        contextHandle: Long,
         memberDid: String,
         capabilitiesJson: String,
     ): String {
@@ -218,7 +232,7 @@ class ConformanceStubBindings : NativeBindings {
     }
 
     override fun ucanRevoke(
-        identityHandle: Long,
+        contextHandle: Long,
         token: String,
     ) {
         ucanRevokeError?.let { throw it }

--- a/bindings/kotlin/scp-kt/src/test/kotlin/works/limn/scp/conformance/ContextConformanceTest.kt
+++ b/bindings/kotlin/scp-kt/src/test/kotlin/works/limn/scp/conformance/ContextConformanceTest.kt
@@ -92,14 +92,13 @@ class ContextConformanceTest {
     @Nested
     inner class ContextJoin {
         @Test
-        fun `context_join returns handle for valid context ID`() =
+        fun `context_join succeeds for valid context`() =
             runTest(testDispatcher) {
-                stubBindings.contextJoinResult = 200L
                 val result = dispatcher.dispatch(
                     "context_join",
-                    mapOf("identity_handle" to "1", "context_id" to "ctx-abc"),
+                    mapOf("context_handle" to "10", "identity_handle" to "1"),
                 )
-                assertEquals("200", result["handle"])
+                assertEquals("joined", result["status"])
             }
 
         @Test
@@ -109,7 +108,7 @@ class ContextConformanceTest {
                     BridgeException("Context not found", "SCP-CTX-2002")
                 val result = dispatcher.dispatch(
                     "context_join",
-                    mapOf("identity_handle" to "1", "context_id" to "ctx-none"),
+                    mapOf("context_handle" to "10", "identity_handle" to "1"),
                 )
                 assertEquals("SCP-CTX-2002", result["error"])
             }
@@ -122,7 +121,7 @@ class ContextConformanceTest {
             runTest(testDispatcher) {
                 val result = dispatcher.dispatch(
                     "context_leave",
-                    mapOf("context_handle" to "10"),
+                    mapOf("context_handle" to "10", "identity_handle" to "1"),
                 )
                 assertEquals("left", result["status"])
                 assertTrue(stubBindings.contextLeaveCalled)
@@ -135,7 +134,7 @@ class ContextConformanceTest {
                     BridgeException("Not a member", "SCP-CTX-2003")
                 val result = dispatcher.dispatch(
                     "context_leave",
-                    mapOf("context_handle" to "10"),
+                    mapOf("context_handle" to "10", "identity_handle" to "1"),
                 )
                 assertEquals("SCP-CTX-2003", result["error"])
             }
@@ -147,7 +146,7 @@ class ContextConformanceTest {
         fun `context_close succeeds for admin`() = runTest(testDispatcher) {
             val result = dispatcher.dispatch(
                 "context_close",
-                mapOf("context_handle" to "10"),
+                mapOf("context_handle" to "10", "identity_handle" to "1"),
             )
             assertEquals("closed", result["status"])
             assertTrue(stubBindings.contextCloseCalled)
@@ -160,7 +159,7 @@ class ContextConformanceTest {
                     BridgeException("Not authorized", "SCP-PERM-3001")
                 val result = dispatcher.dispatch(
                     "context_close",
-                    mapOf("context_handle" to "10"),
+                    mapOf("context_handle" to "10", "identity_handle" to "1"),
                 )
                 assertEquals("SCP-PERM-3001", result["error"])
             }
@@ -180,7 +179,7 @@ class ContextConformanceTest {
 
                 val leaveResult = dispatcher.dispatch(
                     "context_leave",
-                    mapOf("context_handle" to "10"),
+                    mapOf("context_handle" to "10", "identity_handle" to "1"),
                 )
                 assertEquals("left", leaveResult["status"])
             }
@@ -188,16 +187,15 @@ class ContextConformanceTest {
         @Test
         fun `context lifecycle - join then close`() =
             runTest(testDispatcher) {
-                stubBindings.contextJoinResult = 20L
                 val joinResult = dispatcher.dispatch(
                     "context_join",
-                    mapOf("identity_handle" to "1", "context_id" to "ctx-1"),
+                    mapOf("context_handle" to "20", "identity_handle" to "1"),
                 )
-                assertEquals("20", joinResult["handle"])
+                assertEquals("joined", joinResult["status"])
 
                 val closeResult = dispatcher.dispatch(
                     "context_close",
-                    mapOf("context_handle" to "20"),
+                    mapOf("context_handle" to "20", "identity_handle" to "1"),
                 )
                 assertEquals("closed", closeResult["status"])
             }

--- a/bindings/kotlin/scp-kt/src/test/kotlin/works/limn/scp/conformance/GovernanceConformanceTest.kt
+++ b/bindings/kotlin/scp-kt/src/test/kotlin/works/limn/scp/conformance/GovernanceConformanceTest.kt
@@ -53,7 +53,7 @@ class GovernanceConformanceTest {
                     BridgeException("Write capability required", "SCP-PERM-3020")
                 val result = dispatcher.dispatch(
                     "context_send",
-                    mapOf("context_handle" to "10", "payload" to "hello"),
+                    mapOf("context_handle" to "10", "identity_handle" to "1", "payload" to "hello"),
                 )
                 assertEquals("SCP-PERM-3020", result["error"])
             }
@@ -65,7 +65,7 @@ class GovernanceConformanceTest {
                     BridgeException("Admin capability required", "SCP-PERM-3021")
                 val result = dispatcher.dispatch(
                     "context_close",
-                    mapOf("context_handle" to "10"),
+                    mapOf("context_handle" to "10", "identity_handle" to "1"),
                 )
                 assertEquals("SCP-PERM-3021", result["error"])
             }
@@ -93,7 +93,7 @@ class GovernanceConformanceTest {
                 val result = dispatcher.dispatch(
                     "ucan_mint",
                     mapOf(
-                        "identity_handle" to "1",
+                        "context_handle" to "10",
                         "audience_did" to "did:dht:z6MkMember",
                         "capabilities" to """["admin"]""",
                     ),
@@ -109,9 +109,9 @@ class GovernanceConformanceTest {
                 val result = dispatcher.dispatch(
                     "ucan_validate",
                     mapOf(
+                        "context_handle" to "10",
                         "encoded" to "overcapped.token",
                         "capability" to "admin",
-                        "context_id" to "ctx-limited",
                     ),
                 )
                 assertEquals("SCP-PERM-3013", result["error"])
@@ -151,7 +151,7 @@ class GovernanceConformanceTest {
                     BridgeException("test", "SCP-PERM-3001")
                 val result = dispatcher.dispatch(
                     "ucan_validate",
-                    mapOf("encoded" to "t"),
+                    mapOf("context_handle" to "10", "encoded" to "t"),
                 )
                 assertEquals("SCP-PERM-3001", result["error"])
             }

--- a/bindings/kotlin/scp-kt/src/test/kotlin/works/limn/scp/conformance/MessagingConformanceTest.kt
+++ b/bindings/kotlin/scp-kt/src/test/kotlin/works/limn/scp/conformance/MessagingConformanceTest.kt
@@ -57,7 +57,7 @@ class MessagingConformanceTest {
             runTest(testDispatcher) {
                 val result = dispatcher.dispatch(
                     "context_send",
-                    mapOf("context_handle" to "10", "payload" to "hello"),
+                    mapOf("context_handle" to "10", "identity_handle" to "1", "payload" to "hello"),
                 )
                 assertEquals("sent", result["status"])
                 assertTrue(stubBindings.contextSendCalled)
@@ -68,7 +68,7 @@ class MessagingConformanceTest {
             runTest(testDispatcher) {
                 dispatcher.dispatch(
                     "context_send",
-                    mapOf("context_handle" to "10", "payload" to "test message"),
+                    mapOf("context_handle" to "10", "identity_handle" to "1", "payload" to "test message"),
                 )
                 assertEquals(
                     "test message",
@@ -83,7 +83,7 @@ class MessagingConformanceTest {
                     BridgeException("Context closed", "SCP-CTX-2010")
                 val result = dispatcher.dispatch(
                     "context_send",
-                    mapOf("context_handle" to "10", "payload" to "hello"),
+                    mapOf("context_handle" to "10", "identity_handle" to "1", "payload" to "hello"),
                 )
                 assertEquals("SCP-CTX-2010", result["error"])
             }
@@ -203,6 +203,7 @@ class MessagingConformanceTest {
                     operation = "context_send",
                     input = mapOf(
                         "context_handle" to "10",
+                        "identity_handle" to "1",
                         "payload" to "hello world",
                     ),
                     expected = mapOf("status" to "sent"),

--- a/bindings/kotlin/scp-kt/src/test/kotlin/works/limn/scp/conformance/ToolsConformanceTest.kt
+++ b/bindings/kotlin/scp-kt/src/test/kotlin/works/limn/scp/conformance/ToolsConformanceTest.kt
@@ -106,33 +106,31 @@ class ToolsConformanceTest {
     @Nested
     inner class ToolVerify {
         @Test
-        fun `tool_verify returns true for valid test vector`() =
+        fun `tool_verify returns result for registered tool`() =
             runTest(testDispatcher) {
                 stubBindings.toolVerifyResult = true
                 val result = dispatcher.dispatch(
                     "tool_verify",
                     mapOf(
+                        "context_handle" to "10",
                         "tool_id" to "tool-calc-001",
-                        "input" to """{"a":1,"b":2}""",
-                        "output" to """{"result":3}""",
                     ),
                 )
-                assertEquals("true", result["is_valid"])
+                assertTrue(result["result"]?.contains("\"passed\":true") == true)
             }
 
         @Test
-        fun `tool_verify returns false for invalid test vector`() =
+        fun `tool_verify returns failed result`() =
             runTest(testDispatcher) {
                 stubBindings.toolVerifyResult = false
                 val result = dispatcher.dispatch(
                     "tool_verify",
                     mapOf(
+                        "context_handle" to "10",
                         "tool_id" to "tool-calc-001",
-                        "input" to """{"a":1,"b":2}""",
-                        "output" to """{"result":999}""",
                     ),
                 )
-                assertEquals("false", result["is_valid"])
+                assertTrue(result["result"]?.contains("\"passed\":false") == true)
             }
 
         @Test
@@ -143,9 +141,8 @@ class ToolsConformanceTest {
                 val result = dispatcher.dispatch(
                     "tool_verify",
                     mapOf(
+                        "context_handle" to "10",
                         "tool_id" to "tool-calc-001",
-                        "input" to "{}",
-                        "output" to "{}",
                     ),
                 )
                 assertEquals("SCP-TOOL-6003", result["error"])

--- a/bindings/kotlin/scp-kt/src/test/kotlin/works/limn/scp/conformance/UcanConformanceTest.kt
+++ b/bindings/kotlin/scp-kt/src/test/kotlin/works/limn/scp/conformance/UcanConformanceTest.kt
@@ -51,9 +51,9 @@ class UcanConformanceTest {
                 val result = dispatcher.dispatch(
                     "ucan_validate",
                     mapOf(
+                        "context_handle" to "10",
                         "encoded" to "test.token.sig",
                         "capability" to "read",
-                        "context_id" to "ctx-1",
                     ),
                 )
                 assertEquals("valid", result["status"])
@@ -67,9 +67,9 @@ class UcanConformanceTest {
                 val result = dispatcher.dispatch(
                     "ucan_validate",
                     mapOf(
+                        "context_handle" to "10",
                         "encoded" to "bad.token",
                         "capability" to "write",
-                        "context_id" to "ctx-1",
                     ),
                 )
                 assertEquals("SCP-PERM-3001", result["error"])
@@ -83,9 +83,9 @@ class UcanConformanceTest {
                 val result = dispatcher.dispatch(
                     "ucan_validate",
                     mapOf(
+                        "context_handle" to "10",
                         "encoded" to "expired.token.sig",
                         "capability" to "read",
-                        "context_id" to "ctx-1",
                     ),
                 )
                 assertEquals("SCP-PERM-3010", result["error"])
@@ -99,9 +99,9 @@ class UcanConformanceTest {
                 val result = dispatcher.dispatch(
                     "ucan_validate",
                     mapOf(
+                        "context_handle" to "10",
                         "encoded" to "replayed.token.sig",
                         "capability" to "read",
-                        "context_id" to "ctx-1",
                     ),
                 )
                 assertEquals("SCP-PERM-3011", result["error"])
@@ -116,7 +116,7 @@ class UcanConformanceTest {
             val result = dispatcher.dispatch(
                 "ucan_mint",
                 mapOf(
-                    "identity_handle" to "1",
+                    "context_handle" to "10",
                     "audience_did" to "did:dht:z6MkAudience",
                     "capabilities" to """["read","write"]""",
                 ),
@@ -131,7 +131,7 @@ class UcanConformanceTest {
             val result = dispatcher.dispatch(
                 "ucan_mint",
                 mapOf(
-                    "identity_handle" to "1",
+                    "context_handle" to "10",
                     "audience_did" to "did:dht:z6MkAudience",
                 ),
             )
@@ -146,7 +146,7 @@ class UcanConformanceTest {
                 val result = dispatcher.dispatch(
                     "ucan_mint",
                     mapOf(
-                        "identity_handle" to "1",
+                        "context_handle" to "10",
                         "audience_did" to "did:dht:z6MkAudience",
                         "capabilities" to """["admin"]""",
                     ),
@@ -197,7 +197,7 @@ class UcanConformanceTest {
             val mintResult = dispatcher.dispatch(
                 "ucan_mint",
                 mapOf(
-                    "identity_handle" to "1",
+                    "context_handle" to "10",
                     "audience_did" to "did:dht:z6MkDelegator",
                     "capabilities" to """["read","write"]""",
                 ),
@@ -226,7 +226,7 @@ class UcanConformanceTest {
         fun `ucan_revoke succeeds`() = runTest(testDispatcher) {
             val result = dispatcher.dispatch(
                 "ucan_revoke",
-                mapOf("identity_handle" to "1", "token" to "header.payload.signature"),
+                mapOf("context_handle" to "10", "token" to "header.payload.signature"),
             )
             assertEquals("revoked", result["status"])
         }
@@ -237,7 +237,7 @@ class UcanConformanceTest {
                 BridgeException("Not authorized to revoke", "SCP-PERM-3003")
             val result = dispatcher.dispatch(
                 "ucan_revoke",
-                mapOf("identity_handle" to "1", "token" to "header.payload.signature"),
+                mapOf("context_handle" to "10", "token" to "header.payload.signature"),
             )
             assertEquals("SCP-PERM-3003", result["error"])
         }
@@ -256,8 +256,8 @@ class UcanConformanceTest {
                     description = "Validate a UCAN token (stub returns error)",
                     operation = "ucan_validate",
                     input = mapOf(
+                        "context_handle" to "10",
                         "encoded" to "test.token.sig",
-                        "context_id" to "ctx-1",
                     ),
                     expected = mapOf("error" to "SCP-PERM-3001"),
                 )

--- a/bindings/kotlin/scp-kt/src/test/kotlin/works/limn/scp/stream/StreamsTest.kt
+++ b/bindings/kotlin/scp-kt/src/test/kotlin/works/limn/scp/stream/StreamsTest.kt
@@ -461,17 +461,19 @@ class StubEventContextBindings : EventContextBindings {
 
     override fun contextCreate(identityHandle: Long, paramsJson: String): Long = contextCreateResult
 
-    override fun contextJoin(identityHandle: Long, contextId: String): Long = contextJoinResult
+    override fun contextJoin(contextHandle: Long, identityHandle: Long) {
+        // no-op
+    }
 
-    override fun contextLeave(contextHandle: Long) {
+    override fun contextLeave(contextHandle: Long, identityHandle: Long) {
         contextLeaveCalled = true
     }
 
-    override fun contextClose(contextHandle: Long) {
+    override fun contextClose(contextHandle: Long, identityHandle: Long) {
         contextCloseCalled = true
     }
 
-    override fun contextSend(contextHandle: Long, payload: ByteArray) {
+    override fun contextSend(contextHandle: Long, identityHandle: Long, payload: ByteArray) {
         contextSendCalled = true
     }
 


### PR DESCRIPTION
Closes #562

## Summary
- Aligned all 10 Kotlin bridge interface signatures with their UniFFI exports in `crates/scp-ffi/uniffi/src/bridge.rs`
- Context operations (join/leave/close/send) now take `identityHandle` parameter for provenance tracking
- `toolInvoke` adds `identityHandle`, `ucanToken`, `proofTokens` params for UCAN authorization
- `toolVerify` changes to `(contextHandle, toolId) -> String` matching UniFFI's `ToolVerificationResult`
- `ucanValidate` adds `contextHandle`, `presentingAgentDid`, `proofTokens` (removes `contextId`)
- `ucanMint`/`ucanRevoke` change from `identityHandle` to `contextHandle`
- `broadcastPublish` changes from `authorDid: String` to `identityHandle: Long`
- Updated all 12 files: interfaces, bridge classes, 3 stub binding implementations, conformance dispatcher, ViewModel, and test files

## Review Cycles
- Cycles: 1
- Findings resolved: 0
- Findings dismissed: 1 (non-issue noted for completeness)