### PR TITLE
fix(python): set CapabilityValidation fields independently per UCAN validation step (closes #556)

### DIFF
--- a/bindings/python/scp_sdk/trust.py
+++ b/bindings/python/scp_sdk/trust.py
@@ -81,7 +81,13 @@ _SIGNATURE_CHAIN_PREFIXES: tuple[str, ...] = (
     "key scope mismatch:",
     "self-delegation",
     "Category A violation:",
+    # DID resolution failures (step 2) — all ResolutionError variants become
+    # MalformedToken("...") via From<ResolutionError> for UcanError.
+    # See crates/scp-ffi/common/src/resolvers.rs.
     "malformed token: DID not found",
+    "malformed token: invalid DID document",
+    "malformed token: network unavailable",
+    "malformed token: DID revoked/downgraded",
 )
 
 # Error message prefixes that indicate a capability ceiling/scope failure.
@@ -436,7 +442,7 @@ async def evaluate_trust(
         for token in capability_tokens:
             try:
                 bridge.ucan_validate(context_id, token, "*")
-            except Exception as exc:
+            except bridge.UcanError as exc:
                 error_msg = str(exc)
                 failed_category = _classify_ucan_error(error_msg)
                 passed = _PASSED_BEFORE.get(failed_category, set())

--- a/bindings/python/tests/test_trust.py
+++ b/bindings/python/tests/test_trust.py
@@ -125,6 +125,21 @@ class TestClassifyUcanError:
         msg = "malformed token: DID not found: did:dht:z6MkMissing"
         assert _classify_ucan_error(msg) == "signatures"
 
+    def test_invalid_did_document(self) -> None:
+        """MalformedToken from invalid DID document (step 2) → signatures."""
+        msg = "malformed token: invalid DID document: BEP44 signature invalid"
+        assert _classify_ucan_error(msg) == "signatures"
+
+    def test_network_unavailable(self) -> None:
+        """MalformedToken from network unavailable (step 2) → signatures."""
+        msg = "malformed token: network unavailable: all resolvers timed out"
+        assert _classify_ucan_error(msg) == "signatures"
+
+    def test_did_revoked_downgraded(self) -> None:
+        """MalformedToken from DID revoked/downgraded (step 2) → signatures."""
+        msg = "malformed token: DID revoked/downgraded: stale sequence for did:dht:zTest"
+        assert _classify_ucan_error(msg) == "signatures"
+
     # -- Capability/ceiling errors (steps 6, 8) --
 
     def test_capability_outside_ceiling(self) -> None:
@@ -253,10 +268,17 @@ class TestCapabilityValidationFieldIndependence:
     field-setting logic in evaluate_trust.
     """
 
+    # Sentinel exception class that simulates _scp_core.UcanError for
+    # tests.  The production code catches ``bridge.UcanError``; the mock
+    # bridge exposes this class so the except clause can match it.
+    class _MockUcanError(Exception):
+        pass
+
     def _run(self, error_msg: str) -> CapabilityValidation:
         """Helper: mock bridge.ucan_validate to raise with given message."""
         mock_bridge = MagicMock()
-        mock_bridge.ucan_validate.side_effect = Exception(error_msg)
+        mock_bridge.UcanError = self._MockUcanError
+        mock_bridge.ucan_validate.side_effect = self._MockUcanError(error_msg)
 
         with patch("scp_sdk.trust._bridge", return_value=mock_bridge):
             result = asyncio.run(
@@ -270,6 +292,7 @@ class TestCapabilityValidationFieldIndependence:
 
     def test_all_pass_when_validation_succeeds(self) -> None:
         mock_bridge = MagicMock()
+        mock_bridge.UcanError = self._MockUcanError
         mock_bridge.ucan_validate.return_value = None
 
         with patch("scp_sdk.trust._bridge", return_value=mock_bridge):
@@ -344,6 +367,7 @@ class TestCapabilityValidationFieldIndependence:
     def test_no_tokens_all_default_false(self) -> None:
         """When no tokens are provided, all fields stay at default (False)."""
         mock_bridge = MagicMock()
+        mock_bridge.UcanError = self._MockUcanError
 
         with patch("scp_sdk.trust._bridge", return_value=mock_bridge):
             result = asyncio.run(
@@ -379,6 +403,30 @@ class TestCapabilityValidationFieldIndependence:
         assert cv.within_ceiling is False
         assert cv.not_revoked is False
 
+    def test_invalid_did_document_classified_as_signature(self) -> None:
+        """Invalid DID document (step 2) → tokens_valid=True, signatures_valid=False."""
+        cv = self._run("malformed token: invalid DID document: BEP44 signature invalid")
+        assert cv.tokens_valid is True
+        assert cv.signatures_valid is False
+        assert cv.within_ceiling is False
+        assert cv.not_revoked is False
+
+    def test_network_unavailable_classified_as_signature(self) -> None:
+        """Network unavailable (step 2) → tokens_valid=True, signatures_valid=False."""
+        cv = self._run("malformed token: network unavailable: all resolvers timed out")
+        assert cv.tokens_valid is True
+        assert cv.signatures_valid is False
+        assert cv.within_ceiling is False
+        assert cv.not_revoked is False
+
+    def test_did_revoked_downgraded_classified_as_signature(self) -> None:
+        """DID revoked/downgraded (step 2) → tokens_valid=True, signatures_valid=False."""
+        cv = self._run("malformed token: DID revoked/downgraded: stale sequence")
+        assert cv.tokens_valid is True
+        assert cv.signatures_valid is False
+        assert cv.within_ceiling is False
+        assert cv.not_revoked is False
+
     def test_unparseable_capability_classified_as_ceiling(self) -> None:
         """Capability URI parse failure (step 6) → tokens+sigs valid, ceiling=False."""
         cv = self._run("malformed token: unparseable capability URI in attestation: bad://uri")
@@ -394,6 +442,28 @@ class TestCapabilityValidationFieldIndependence:
         assert cv.signatures_valid is False
         assert cv.within_ceiling is False
         assert cv.not_revoked is False
+
+    def test_non_ucan_exception_propagates(self) -> None:
+        """Non-UcanError exceptions (e.g. ValidationError) are NOT silently caught."""
+        mock_bridge = MagicMock()
+        mock_bridge.UcanError = self._MockUcanError
+        # Raise a plain Exception — this should NOT be caught by
+        # ``except bridge.UcanError``, and must propagate to the caller.
+        mock_bridge.ucan_validate.side_effect = RuntimeError(
+            "[SCP-VALID-7001] validation error: context_id contains control characters"
+        )
+
+        import pytest
+
+        with patch("scp_sdk.trust._bridge", return_value=mock_bridge):
+            with pytest.raises(RuntimeError, match="control characters"):
+                asyncio.run(
+                    evaluate_trust(
+                        subject_did="did:dht:z6MkBob",
+                        context_id="ctx\x00bad",
+                        capability_tokens=["fake-token"],
+                    )
+                )
 
 
 # -----------------------------------------------------------------------


### PR DESCRIPTION
Closes #556

## Summary
- Rewrote Layer 1 UCAN validation in `evaluate_trust()` to set each `CapabilityValidation` field independently based on which pipeline step failed
- Added `_classify_ucan_error()` with prefix matching against all 28+ `UcanError` variants, mapping to 7 pipeline stages
- Added `_PASSED_BEFORE` dict encoding the sequential 11-step pipeline ordering
- Correctly handles `MalformedToken` sub-patterns: DID resolution errors (4 variants) route to "signatures", capability URI errors route to "ceiling"
- Narrowed exception catch from bare `Exception` to `bridge.UcanError` to avoid swallowing input validation errors
- 670 lines of tests covering classification, field independence, dataclass construction, and participation requirements

## Review Cycles
- Cycles: 3
- Findings resolved: 7
- Findings dismissed: 1 (design limitation: nonce/revocation produce identical output due to 4-field model)