### PR TITLE
fix(kotlin): remove dead contextJoinResult fields and update stale CLAUDE.md (closes #977)

### DIFF
--- a/bindings/kotlin/scp-kt-android/CLAUDE.md
+++ b/bindings/kotlin/scp-kt-android/CLAUDE.md
@@ -106,7 +106,7 @@ override fun onCleared() {
             snapshot
         }
         for (ctx in contexts) {
-            runCatching { ctx.bridge.context.leave(ctx.handle) }
+            runCatching { ctx.bridge.context.leave(ctx.handle, ctx.identityHandle) }
         }
         cleanupScope.cancel()
     }

--- a/bindings/kotlin/scp-kt/src/test/kotlin/works/limn/scp/bridge/CoroutineBridgeTest.kt
+++ b/bindings/kotlin/scp-kt/src/test/kotlin/works/limn/scp/bridge/CoroutineBridgeTest.kt
@@ -554,7 +554,6 @@ class StubNativeBindings : NativeBindings {
     var identityLoadResult = 0L
     var identityResolveResult = ""
     var contextCreateResult = 0L
-    var contextJoinResult = 0L
     var contextSubscribeResult = 0L
     var toolRegisterResult = ""
     var toolInvokeResult = ""

--- a/bindings/kotlin/scp-kt/src/test/kotlin/works/limn/scp/conformance/ConformanceStubBindings.kt
+++ b/bindings/kotlin/scp-kt/src/test/kotlin/works/limn/scp/conformance/ConformanceStubBindings.kt
@@ -36,7 +36,6 @@ class ConformanceStubBindings : NativeBindings {
 
     var contextCreateResult: Long = 10L
     var contextCreateError: BridgeException? = null
-    var contextJoinResult: Long = 11L
     var contextJoinError: BridgeException? = null
 
     var contextLeaveCalled = false
@@ -303,7 +302,6 @@ class ConformanceStubBindings : NativeBindings {
         identityResolveError = null
         contextCreateResult = 10L
         contextCreateError = null
-        contextJoinResult = 11L
         contextJoinError = null
         contextLeaveCalled = false
         contextLeaveError = null

--- a/bindings/kotlin/scp-kt/src/test/kotlin/works/limn/scp/stream/StreamsTest.kt
+++ b/bindings/kotlin/scp-kt/src/test/kotlin/works/limn/scp/stream/StreamsTest.kt
@@ -444,7 +444,6 @@ class StubEventContextBindings : EventContextBindings {
     var contextSubscribeResult = 0L
     var contextSubscribeEventsResult = 0L
     var contextCreateResult = 0L
-    var contextJoinResult = 0L
     var contextUnsubscribeCalled = false
     var eventUnsubscribeCalled = false
     var contextLeaveCalled = false


### PR DESCRIPTION
Closes #977

## Summary
- Removed dead `contextJoinResult` field from 3 test stub classes after PR #976 changed `contextJoin` to return `Unit`
- Updated stale code sample in `scp-kt-android/CLAUDE.md` to use 2-arg `leave(handle, identityHandle)` form

## Review Cycles
- Cycles: 1
- Findings resolved: 0
- Findings dismissed: 0