### PR TITLE
fix(python): register _scp_core in sys.modules (closes #1033)

### DIFF
--- a/bindings/python/scp_sdk/__init__.py
+++ b/bindings/python/scp_sdk/__init__.py
@@ -18,6 +18,19 @@ See ``.docs/adrs/phase-3.md`` ADR-014 for the full SDK design.
 
 from __future__ import annotations
 
+import sys
+
+# Register the native extension under its bare name so that function-scoped
+# ``import _scp_core`` (used throughout the SDK) resolves correctly.  Maturin
+# installs the extension as ``scp_sdk._scp_core`` (see pyproject.toml
+# module-name), but every call-site does a bare ``import _scp_core``.
+try:
+    from scp_sdk import _scp_core
+
+    sys.modules["_scp_core"] = _scp_core
+except ImportError:
+    pass  # Native extension not available (pure-Python / mocked tests)
+
 from scp_sdk.bridge import (
     create_shadow,
 )

--- a/bindings/python/tests/test_real_ffi.py
+++ b/bindings/python/tests/test_real_ffi.py
@@ -20,7 +20,7 @@ import pytest
 # ---------------------------------------------------------------------------
 
 try:
-    import _scp_core
+    from scp_sdk import _scp_core  # installed as scp_sdk._scp_core by maturin
 except (ImportError, AttributeError):
     pytest.skip(
         "Native _scp_core extension not available — run maturin develop first",


### PR DESCRIPTION
## Summary

- Register `_scp_core` in `sys.modules` at package init so bare `import _scp_core` (used by ~57 call sites across 13 SDK modules) resolves correctly
- Fix `test_real_ffi.py` to use qualified import `from scp_sdk import _scp_core`

## Root cause

`pyproject.toml` sets `module-name = "scp_sdk._scp_core"`, so maturin installs the native extension as a submodule. But all SDK call sites do bare `import _scp_core` at function scope, causing `ModuleNotFoundError` on every real FFI operation. Tests never caught this because they mock `_scp_core`.

## Test plan

- [x] All 413 mock-based tests pass
- [x] ruff check/format clean
- [x] End-to-end: `maturin develop` + `Identity.create(custody='in_memory')` succeeds from clean venv
- [x] 39 real FFI tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)