### PR TITLE
feat(core): implement sync tiers 1-3 — ReconnectionCoordinator, DeltaSyncEngine, ReJoinExecutor (closes #495)

### DIFF
--- a/crates/scp-core/src/sync/days_offline.rs
+++ b/crates/scp-core/src/sync/days_offline.rs
@@ -731,7 +731,7 @@ pub fn apply_delta(
     local_state.tool_names.sort();
 
     // Advance event log state
-    local_state.event_count += delta.events_added;
+    local_state.event_count = local_state.event_count.saturating_add(delta.events_added);
     local_state.event_log_merkle_root = delta.new_merkle_root;
 
     // Advance epoch and snapshot sequence
@@ -756,10 +756,7 @@ pub fn apply_delta(
 ///
 /// See ADR-029 section 3 (MLS Epoch Catch-Up).
 #[must_use]
-pub const fn determine_mls_recovery(
-    delta: &SnapshotDelta,
-    policy: &SyncPolicy,
-) -> MlsRecoveryAction {
+pub fn determine_mls_recovery(delta: &SnapshotDelta, policy: &SyncPolicy) -> MlsRecoveryAction {
     match (delta.from_epoch, delta.to_epoch) {
         (Some(from), Some(to)) if from == to => MlsRecoveryAction::NoAction,
         (Some(from), Some(to)) => {
@@ -776,9 +773,20 @@ pub const fn determine_mls_recovery(
                 }
             }
         }
-        // (None, None) = broadcast context, or mismatched None/Some —
-        // anomalous state; treat as no action (caller handles).
-        _ => MlsRecoveryAction::NoAction,
+        // (None, None) = broadcast context — no MLS epoch to reconcile.
+        (None, None) => MlsRecoveryAction::NoAction,
+        // Mismatched None/Some — anomalous state (one snapshot has an MLS
+        // epoch and the other does not). Log a warning and fall through to
+        // NoAction; the caller is responsible for handling the mismatch.
+        (from, to) => {
+            tracing::warn!(
+                context_id = %delta.context_id,
+                from_epoch = ?from,
+                to_epoch = ?to,
+                "anomalous MLS epoch state in delta: mismatched None/Some pair"
+            );
+            MlsRecoveryAction::NoAction
+        }
     }
 }
 

--- a/crates/scp-core/src/sync/hours_offline.rs
+++ b/crates/scp-core/src/sync/hours_offline.rs
@@ -919,7 +919,7 @@ impl ReconnectionCoordinator {
                     events_recovered: 0,
                     messages_unrecoverable: 0,
                     mls_update_issued: false,
-                    outcome: SyncOutcome::FullyCaughtUp, // Placeholder until sync runs.
+                    outcome: SyncOutcome::Pending,
                     sync_events: Vec::new(),
                 }
             })

--- a/crates/scp-core/src/sync/mod.rs
+++ b/crates/scp-core/src/sync/mod.rs
@@ -652,6 +652,9 @@ pub enum CatchUpStatus {
 /// Per-context outcome of the reconnection protocol. See ADR-029.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub enum SyncOutcome {
+    /// Sync has not yet executed. Returned by planning methods; replaced by
+    /// a concrete outcome after [`ReconnectionCoordinator::execute`] runs.
+    Pending,
     /// All epochs and events caught up via sequential processing.
     FullyCaughtUp,
     /// Caught up via Welcome-based fast-forward (some epochs skipped).

--- a/crates/scp-core/src/sync/weeks_offline.rs
+++ b/crates/scp-core/src/sync/weeks_offline.rs
@@ -790,6 +790,10 @@ pub struct BilateralRecoveryParams<'a> {
     pub local_epoch: u64,
     /// Current group epoch.
     pub current_epoch: u64,
+    /// Number of messages queued by the online member during the offline
+    /// period. The caller obtains this from the outbound queue length for
+    /// this context in the online member's `ProtocolRepository`.
+    pub online_member_queued_messages: u64,
 }
 
 /// Assesses recovery for a bilateral (2-person) context.
@@ -815,7 +819,7 @@ pub fn assess_bilateral_recovery(params: &BilateralRecoveryParams<'_>) -> Bilate
         online_member_can_reset: params.online_can_reset,
         last_known_epoch: params.local_epoch,
         current_epoch: params.current_epoch,
-        online_member_queued_messages: 0,
+        online_member_queued_messages: params.online_member_queued_messages,
         assessment,
     }
 }
@@ -1671,6 +1675,7 @@ mod tests {
             now: BASE_TIMESTAMP + FOURTEEN_DAYS_SECS,
             local_epoch: 50,
             current_epoch: 200,
+            online_member_queued_messages: 5,
         });
 
         assert_eq!(recovery.context_id, "ctx-bilateral");
@@ -1679,6 +1684,7 @@ mod tests {
         assert!(recovery.online_member_can_reset);
         assert_eq!(recovery.last_known_epoch, 50);
         assert_eq!(recovery.current_epoch, 200);
+        assert_eq!(recovery.online_member_queued_messages, 5);
         assert!(matches!(
             recovery.assessment,
             OfflineAssessment::ForceReJoinRequired { .. }
@@ -1696,6 +1702,7 @@ mod tests {
             now: BASE_TIMESTAMP + THREE_DAYS_SECS,
             local_epoch: 50,
             current_epoch: 60,
+            online_member_queued_messages: 0,
         });
 
         assert!(matches!(
@@ -1715,6 +1722,7 @@ mod tests {
             now: BASE_TIMESTAMP + FOURTEEN_DAYS_SECS,
             local_epoch: 50,
             current_epoch: 200,
+            online_member_queued_messages: 0,
         });
 
         assert!(!recovery.online_member_can_reset);
@@ -1955,6 +1963,7 @@ mod tests {
             now: BASE_TIMESTAMP + THIRTY_DAYS_SECS,
             local_epoch: 10,
             current_epoch: 3_000,
+            online_member_queued_messages: 42,
         });
         assert!(matches!(
             recovery.assessment,


### PR DESCRIPTION
Closes #495

## Summary
- **Tier 1 (hours offline):** `ReconnectionCoordinator::execute()` with full 6-phase protocol (relay catch-up, MLS epoch reconciliation, event log sync, sender key re-acquisition, MLS Update, queue drain)
- **Tier 2 (days offline):** `RelayBackedDeltaSyncEngine` implementing `DeltaSyncEngine` via `SnapshotTransport` (fetch_snapshot, fetch_delta, publish_snapshot)
- **Tier 3 (weeks offline):** `RelayBackedReJoinExecutor` implementing `ReJoinExecutor` via `ResetTransport` (publish_reset_request, process_reset, await_welcome)
- Anti-replay validation with nonce dedup, freshness checking, RAII NonceGuard
- `SyncOutcome::Pending` variant replacing hardcoded `FullyCaughtUp` placeholder
- 224+ sync tests, all passing

## Review Cycles
- RC1: 8 findings accepted (3 CRITICAL missing impls, 1 HIGH placeholder, 4 LOW/MEDIUM)
- RC2: 0 findings — converged