### PR TITLE
fix(kotlin): update stale conformance test input maps after identity_handle addition (closes #1031)

### DIFF
--- a/bindings/kotlin/scp-kt/src/test/kotlin/works/limn/scp/conformance/ConformanceRunnerTest.kt
+++ b/bindings/kotlin/scp-kt/src/test/kotlin/works/limn/scp/conformance/ConformanceRunnerTest.kt
@@ -185,10 +185,22 @@ class ConformanceRunnerTest {
         fun `dispatcher handles all context operations`() =
             runTest(testDispatcher) {
                 assertDispatchSucceeds("context_create", mapOf("identity_handle" to "1"))
-                assertDispatchSucceeds("context_join", mapOf("identity_handle" to "1"))
-                assertDispatchSucceeds("context_leave", mapOf("context_handle" to "10"))
-                assertDispatchSucceeds("context_close", mapOf("context_handle" to "10"))
-                assertDispatchSucceeds("context_send", mapOf("context_handle" to "10"))
+                assertDispatchSucceeds(
+                    "context_join",
+                    mapOf("context_handle" to "10", "identity_handle" to "1"),
+                )
+                assertDispatchSucceeds(
+                    "context_leave",
+                    mapOf("context_handle" to "10", "identity_handle" to "1"),
+                )
+                assertDispatchSucceeds(
+                    "context_close",
+                    mapOf("context_handle" to "10", "identity_handle" to "1"),
+                )
+                assertDispatchSucceeds(
+                    "context_send",
+                    mapOf("context_handle" to "10", "identity_handle" to "1"),
+                )
             }
 
         @Test
@@ -196,15 +208,21 @@ class ConformanceRunnerTest {
             runTest(testDispatcher) {
                 assertDispatchSucceeds("tool_register", mapOf("context_handle" to "10"))
                 assertDispatchSucceeds("tool_invoke", mapOf("context_handle" to "10", "identity_handle" to "1"))
-                assertDispatchSucceeds("tool_verify", mapOf("tool_id" to "t"))
+                assertDispatchSucceeds(
+                    "tool_verify",
+                    mapOf("context_handle" to "10", "tool_id" to "t"),
+                )
             }
 
         @Test
         fun `dispatcher handles all ucan operations`() =
             runTest(testDispatcher) {
-                assertDispatchSucceeds("ucan_validate", mapOf("encoded" to "t"))
-                assertDispatchSucceeds("ucan_mint", mapOf("identity_handle" to "1"))
-                assertDispatchSucceeds("ucan_revoke", mapOf("identity_handle" to "1"))
+                assertDispatchSucceeds(
+                    "ucan_validate",
+                    mapOf("context_handle" to "10", "encoded" to "t"),
+                )
+                assertDispatchSucceeds("ucan_mint", mapOf("context_handle" to "10"))
+                assertDispatchSucceeds("ucan_revoke", mapOf("context_handle" to "10"))
             }
 
         @Test
@@ -255,7 +273,10 @@ class ConformanceRunnerTest {
                         category = "context",
                         description = "Leave context",
                         operation = "context_leave",
-                        input = mapOf("context_handle" to "10"),
+                        input = mapOf(
+                            "context_handle" to "10",
+                            "identity_handle" to "1",
+                        ),
                         expected = mapOf("status" to "left"),
                     ),
                     ConformanceFixture(
@@ -265,6 +286,7 @@ class ConformanceRunnerTest {
                         operation = "context_send",
                         input = mapOf(
                             "context_handle" to "10",
+                            "identity_handle" to "1",
                             "payload" to "hello",
                         ),
                         expected = mapOf("status" to "sent"),

--- a/bindings/kotlin/scp-kt/src/test/kotlin/works/limn/scp/conformance/EncryptionConformanceTest.kt
+++ b/bindings/kotlin/scp-kt/src/test/kotlin/works/limn/scp/conformance/EncryptionConformanceTest.kt
@@ -54,6 +54,7 @@ class EncryptionConformanceTest {
                     "context_send",
                     mapOf(
                         "context_handle" to "10",
+                        "identity_handle" to "1",
                         "payload" to "encrypted-content",
                     ),
                 )
@@ -71,7 +72,11 @@ class EncryptionConformanceTest {
                     BridgeException("MLS encryption failed", "SCP-CRYPTO-4001")
                 val result = dispatcher.dispatch(
                     "context_send",
-                    mapOf("context_handle" to "10", "payload" to "data"),
+                    mapOf(
+                        "context_handle" to "10",
+                        "identity_handle" to "1",
+                        "payload" to "data",
+                    ),
                 )
                 assertEquals("SCP-CRYPTO-4001", result["error"])
             }
@@ -86,7 +91,11 @@ class EncryptionConformanceTest {
                     BridgeException("Sender key expired", "SCP-CRYPTO-4010")
                 val result = dispatcher.dispatch(
                     "context_send",
-                    mapOf("context_handle" to "10", "payload" to "data"),
+                    mapOf(
+                        "context_handle" to "10",
+                        "identity_handle" to "1",
+                        "payload" to "data",
+                    ),
                 )
                 assertEquals("SCP-CRYPTO-4010", result["error"])
             }
@@ -97,7 +106,7 @@ class EncryptionConformanceTest {
                 BridgeException("Key cleanup failed", "SCP-CRYPTO-4011")
             val result = dispatcher.dispatch(
                 "context_leave",
-                mapOf("context_handle" to "10"),
+                mapOf("context_handle" to "10", "identity_handle" to "1"),
             )
             assertEquals("SCP-CRYPTO-4011", result["error"])
         }
@@ -112,7 +121,11 @@ class EncryptionConformanceTest {
                     BridgeException("Decryption failed", "SCP-CRYPTO-4002")
                 val result = dispatcher.dispatch(
                     "context_send",
-                    mapOf("context_handle" to "10", "payload" to "garbled"),
+                    mapOf(
+                        "context_handle" to "10",
+                        "identity_handle" to "1",
+                        "payload" to "garbled",
+                    ),
                 )
                 assertEquals("SCP-CRYPTO-4002", result["error"])
             }
@@ -130,6 +143,7 @@ class EncryptionConformanceTest {
                     operation = "context_send",
                     input = mapOf(
                         "context_handle" to "10",
+                        "identity_handle" to "1",
                         "payload" to "hello-encrypted",
                     ),
                     expected = mapOf("status" to "sent"),


### PR DESCRIPTION
Closes #1031

## Summary
- Add `identity_handle` to all `context_send`, `context_leave`, `context_close` dispatch inputs in EncryptionConformanceTest.kt
- Fix ConformanceRunnerTest.kt: add `context_handle` to `context_join`/`tool_verify`/`ucan_validate`, add `identity_handle` to `context_leave`/`close`/`send`, change `identity_handle` to `context_handle` for `ucan_mint`/`ucan_revoke`
- Fix fixture roundtrip tests to include `identity_handle`
- All 10 conformance files verified against ConformanceDispatcher expected keys

## Review Cycles
- Cycles: 1
- Findings resolved: 0
- Findings dismissed: 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)