### PR TITLE
fix: add SCP-DID-AUTH-V1 domain separator and tool_invoke identity_handle

### DIFF
--- a/bindings/kotlin/scp-kt/src/test/kotlin/works/limn/scp/conformance/ConformanceRunnerTest.kt
+++ b/bindings/kotlin/scp-kt/src/test/kotlin/works/limn/scp/conformance/ConformanceRunnerTest.kt
@@ -195,7 +195,7 @@ class ConformanceRunnerTest {
         fun `dispatcher handles all tool operations`() =
             runTest(testDispatcher) {
                 assertDispatchSucceeds("tool_register", mapOf("context_handle" to "10"))
-                assertDispatchSucceeds("tool_invoke", mapOf("context_handle" to "10"))
+                assertDispatchSucceeds("tool_invoke", mapOf("context_handle" to "10", "identity_handle" to "1"))
                 assertDispatchSucceeds("tool_verify", mapOf("tool_id" to "t"))
             }
 

--- a/crates/scp-core/tests/test_vectors.rs
+++ b/crates/scp-core/tests/test_vectors.rs
@@ -1176,6 +1176,7 @@ fn domain_separators_are_all_unique() {
         "SCP-BLOCK-NOTIFICATION-V1:",
         "SCP-EPOCH-ADVANCE-V1:",
         "SCP-KEY-REQUEST-V1:",
+        "SCP-DID-AUTH-V1:",
     ];
 
     // HKDF/HMAC domain labels — used as info strings, salts, or trailing labels


### PR DESCRIPTION
## Summary
Fixes two review findings from merged/open PRs:

- **PR #1082 finding**: Add `SCP-DID-AUTH-V1:` to `hash_domains` in domain separator uniqueness test (spec §3.11.3, used at `scpid.rs:520`)
- **PR #1088 finding**: Add `identity_handle` to `tool_invoke` input map in Kotlin ConformanceRunnerTest (dispatcher reads it at `ConformanceDispatcher.kt:147`)

## Review Cycles
- Cycles: 1
- Findings: 0
- Converged immediately

🤖 Generated with [Claude Code](https://claude.com/claude-code)