### PR TITLE
fix(spec): align TestVector.description to required String (closes #916)

### DIFF
--- a/.docs/specs/05-contexts.md
+++ b/.docs/specs/05-contexts.md
@@ -154,7 +154,7 @@ TestVector {
   input:            Value,           // MessagePack value matching the input schema.
   expected_output:  Value,           // MessagePack value. Verification uses structural comparison,
                                      // not byte equality (§7.3.3).
-  description:      Option<String>,  // Optional human-readable description of what this tests.
+  description:      String,          // Human-readable description of what this tests. Max 4096 UTF-8 bytes.
 }
 
 ToolCost {


### PR DESCRIPTION
Closes #916

## Summary
- Updated spec §5.4.1 `TestVector.description` from `Option<String>` to `String`
- All implementations (scp-core, WASM, NAPI, TypeScript, Python, UniFFI) already use required `String`
- Added "Max 4096 UTF-8 bytes" constraint matching `ToolRegistration.description`

## Review Cycles
- Cycles: 1
- Findings resolved: 0 (spec-only, no code changes)
- Findings dismissed: 5 (informational)
- Filed #1096 for Swift/Kotlin TestVector gaps discovered during review

🤖 Generated with [Claude Code](https://claude.com/claude-code)