### PR TITLE
fix(ci): add virtualenv for Python maturin in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -223,14 +223,19 @@ jobs:
           python-version: "3.12"
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
-      - name: Install Python dependencies
-        run: pip install pytest pytest-asyncio maturin
+      - name: Create virtualenv and install dependencies
+        run: |
+          python -m venv .venv
+          source .venv/bin/activate
+          pip install pytest pytest-asyncio maturin
       - name: Build PyO3 native module
         run: |
+          source .venv/bin/activate
           cd bindings/python
           maturin develop --release --features allow_in_memory_custody
       - name: Run tests (including real FFI)
         run: |
+          source .venv/bin/activate
           cd bindings/python
           PYTHONPATH=. pytest tests/ -v
 


### PR DESCRIPTION
## Summary

- Adds virtualenv creation (`python -m venv .venv`) and activation before maturin develop in Python CI job
- maturin requires an active virtualenv to install the built wheel

## Test plan

- [x] Local CI passes (Rust tests, clippy, fmt)
- [x] CI config change only — no code changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)