### PR TITLE
fix(core): implement PaymentVerifier with receipt verification safety (closes #493)

### DIFF
--- a/crates/scp-core/src/economy/mod.rs
+++ b/crates/scp-core/src/economy/mod.rs
@@ -60,7 +60,8 @@ pub use pricing::{
 };
 pub use receipt::{
     PaymentVerifier, PaymentVerifierDyn, ReceiptFilter, ReceiptVerification,
-    ReceiptVerificationError, payment_history, verify_receipts, verify_receipts_dyn,
+    ReceiptVerificationError, all_receipts_valid, payment_history, verify_receipts,
+    verify_receipts_dyn,
 };
 pub use types::{
     Amount, COEFFICIENT_SCALE, Coefficient, CostSchedule, CurrencyCode, EconomicPolicy,

--- a/crates/scp-core/src/economy/receipt.rs
+++ b/crates/scp-core/src/economy/receipt.rs
@@ -6,7 +6,8 @@
 //! [`payment_history`] function for retrieving receipts from a context's
 //! event log.
 //!
-//! See spec section 19.6 (Payment Receipts and Provenance) and ADR-033.
+//! See spec section 19.2.1 (Adapter Trait), 19.6 (Payment Receipts and
+//! Provenance), and ADR-033.
 
 use serde::{Deserialize, Serialize};
 
@@ -25,7 +26,7 @@ use scp_event_log::{Event, EventType};
 /// consumers that do not need the full [`super::adapter::PaymentAdapter`]
 /// trait.
 ///
-/// See spec section 19.6.
+/// See spec section 19.2.1 (Adapter Trait).
 pub trait PaymentVerifier: Send + Sync {
     /// Returns the adapter identifier this verifier handles.
     fn adapter_id(&self) -> &str;
@@ -72,7 +73,7 @@ impl<T: PaymentAdapter> PaymentVerifier for T {
 ///
 /// Distinguishes between adapter-level verification failures and the absence
 /// of a verifier for a receipt's adapter.
-#[derive(Clone, Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub enum ReceiptVerificationError {
     /// No verifier registered for this receipt's `adapter_id`.
     NoVerifierForAdapter {
@@ -122,7 +123,27 @@ pub struct ReceiptVerification {
     /// The receipt that was verified.
     pub receipt_id: [u8; 32],
     /// The verification result from the adapter.
+    ///
+    /// **Important:** A successful verification (`Ok`) does NOT guarantee
+    /// the receipt is valid. You MUST check [`VerificationResult::valid`]
+    /// to determine whether the payment proof actually verified against the
+    /// payment rail. `Ok` only means the adapter was found and did not
+    /// return a transport/protocol error.
     pub result: VerificationResult,
+}
+
+/// Returns `true` if every result in the slice is `Ok` with
+/// [`VerificationResult::valid`] == `true`.
+///
+/// Returns `false` if any result is `Err` or has `valid == false`.
+/// Returns `true` for an empty slice (vacuously).
+#[must_use]
+pub fn all_receipts_valid(
+    results: &[Result<ReceiptVerification, ReceiptVerificationError>],
+) -> bool {
+    results
+        .iter()
+        .all(|r| r.as_ref().is_ok_and(|v| v.result.valid))
 }
 
 // ---------------------------------------------------------------------------
@@ -132,30 +153,23 @@ pub struct ReceiptVerification {
 /// Verifies a batch of payment receipts against registered verifiers.
 ///
 /// For each receipt, selects the verifier whose `adapter_id()` matches the
-/// receipt's `adapter_id` field, then calls `verify()`. Receipts without a
-/// matching verifier produce a [`ReceiptVerificationError::NoVerifierForAdapter`]
-/// error. Adapter-level failures produce
-/// [`ReceiptVerificationError::VerificationFailed`].
+/// receipt's `adapter_id` field, then calls `verify()`. Returns a
+/// per-receipt `Result` so that individual failures do not prevent other
+/// receipts from being verified (no fail-fast).
 ///
-/// Returns `Ok` with a [`ReceiptVerification`] for each successfully verified
-/// receipt. On any failure, returns the first error encountered.
+/// **Important:** An `Ok` result does NOT mean the receipt is valid.
+/// You MUST check [`VerificationResult::valid`] on each successful result.
+/// Use [`all_receipts_valid`] as a convenience check across the full batch.
 ///
 /// This function wires [`PaymentVerifier`] into the receipt verification
 /// flow, enabling receipt consumers to verify receipts from
 /// [`payment_history`] without needing a full [`PaymentAdapter`].
 ///
-/// # Errors
-///
-/// Returns [`ReceiptVerificationError::NoVerifierForAdapter`] if a receipt's
-/// `adapter_id` does not match any verifier. Returns
-/// [`ReceiptVerificationError::VerificationFailed`] if a verifier returns an
-/// error.
-///
-/// See spec section 19.6.
+/// See spec section 19.2.1 (Adapter Trait).
 pub async fn verify_receipts<V: PaymentVerifier>(
     verifiers: &[&V],
     receipts: &[PaymentReceipt],
-) -> Result<Vec<ReceiptVerification>, ReceiptVerificationError> {
+) -> Vec<Result<ReceiptVerification, ReceiptVerificationError>> {
     let mut results = Vec::with_capacity(receipts.len());
 
     for receipt in receipts {
@@ -165,47 +179,46 @@ pub async fn verify_receipts<V: PaymentVerifier>(
 
         match verifier {
             None => {
-                return Err(ReceiptVerificationError::NoVerifierForAdapter {
+                results.push(Err(ReceiptVerificationError::NoVerifierForAdapter {
                     receipt_id: receipt.receipt_id,
                     adapter_id: receipt.adapter_id.clone(),
-                });
+                }));
             }
-            Some(v) => {
-                let result = v.verify(receipt).await.map_err(|e| {
-                    ReceiptVerificationError::VerificationFailed {
+            Some(v) => match v.verify(receipt).await {
+                Ok(result) => {
+                    results.push(Ok(ReceiptVerification {
+                        receipt_id: receipt.receipt_id,
+                        result,
+                    }));
+                }
+                Err(e) => {
+                    results.push(Err(ReceiptVerificationError::VerificationFailed {
                         receipt_id: receipt.receipt_id,
                         error: e,
-                    }
-                })?;
-                results.push(ReceiptVerification {
-                    receipt_id: receipt.receipt_id,
-                    result,
-                });
-            }
+                    }));
+                }
+            },
         }
     }
 
-    Ok(results)
+    results
 }
 
 /// Verifies a batch of payment receipts against heterogeneous verifiers.
 ///
 /// Like [`verify_receipts`], but accepts verifiers as trait objects
 /// (`&dyn PaymentVerifierDyn`), allowing different verifier types for
-/// different adapters.
+/// different adapters. Returns per-receipt results (no fail-fast).
 ///
-/// # Errors
+/// **Important:** An `Ok` result does NOT mean the receipt is valid.
+/// You MUST check [`VerificationResult::valid`] on each successful result.
+/// Use [`all_receipts_valid`] as a convenience check across the full batch.
 ///
-/// Returns [`ReceiptVerificationError::NoVerifierForAdapter`] if a receipt's
-/// `adapter_id` does not match any verifier. Returns
-/// [`ReceiptVerificationError::VerificationFailed`] if a verifier returns an
-/// error.
-///
-/// See spec section 19.6.
+/// See spec section 19.2.1 (Adapter Trait).
 pub async fn verify_receipts_dyn(
     verifiers: &[&dyn PaymentVerifierDyn],
     receipts: &[PaymentReceipt],
-) -> Result<Vec<ReceiptVerification>, ReceiptVerificationError> {
+) -> Vec<Result<ReceiptVerification, ReceiptVerificationError>> {
     let mut results = Vec::with_capacity(receipts.len());
 
     for receipt in receipts {
@@ -215,27 +228,29 @@ pub async fn verify_receipts_dyn(
 
         match verifier {
             None => {
-                return Err(ReceiptVerificationError::NoVerifierForAdapter {
+                results.push(Err(ReceiptVerificationError::NoVerifierForAdapter {
                     receipt_id: receipt.receipt_id,
                     adapter_id: receipt.adapter_id.clone(),
-                });
+                }));
             }
-            Some(v) => {
-                let result = v.verify_dyn(receipt).await.map_err(|e| {
-                    ReceiptVerificationError::VerificationFailed {
+            Some(v) => match v.verify_dyn(receipt).await {
+                Ok(result) => {
+                    results.push(Ok(ReceiptVerification {
+                        receipt_id: receipt.receipt_id,
+                        result,
+                    }));
+                }
+                Err(e) => {
+                    results.push(Err(ReceiptVerificationError::VerificationFailed {
                         receipt_id: receipt.receipt_id,
                         error: e,
-                    }
-                })?;
-                results.push(ReceiptVerification {
-                    receipt_id: receipt.receipt_id,
-                    result,
-                });
-            }
+                    }));
+                }
+            },
         }
     }
 
-    Ok(results)
+    results
 }
 
 // ---------------------------------------------------------------------------
@@ -375,10 +390,16 @@ mod tests {
     use scp_event_log::{EventPayload, EventType};
     use scp_identity::DID;
 
-    /// Creates a test `PaymentReceipt`.
-    fn make_receipt(payer: &str, payee: &str, amount: u64, timestamp: u64) -> PaymentReceipt {
+    /// Creates a test `PaymentReceipt` with a configurable `receipt_id`.
+    fn make_receipt_with_id(
+        receipt_id: [u8; 32],
+        payer: &str,
+        payee: &str,
+        amount: u64,
+        timestamp: u64,
+    ) -> PaymentReceipt {
         PaymentReceipt {
-            receipt_id: [0xAA; 32],
+            receipt_id,
             payer: DID::from(payer),
             payee: DID::from(payee),
             amount: Amount::new(amount),
@@ -390,6 +411,11 @@ mod tests {
             timestamp,
             signature: vec![0xFF; 64],
         }
+    }
+
+    /// Creates a test `PaymentReceipt` with the default `receipt_id` `[0xAA; 32]`.
+    fn make_receipt(payer: &str, payee: &str, amount: u64, timestamp: u64) -> PaymentReceipt {
+        make_receipt_with_id([0xAA; 32], payer, payee, amount, timestamp)
     }
 
     /// Creates an `Event` with a `PaymentReceived` type carrying a serialized
@@ -735,13 +761,23 @@ mod tests {
         AdapterCapabilities, PaymentAuthorization, PaymentMetadata, RefundConfirmation,
     };
 
+    /// Controls the verification behavior of [`StubAdapter`].
+    #[derive(Clone, Copy)]
+    enum StubVerifyMode {
+        /// `verify` returns `Ok(VerificationResult { valid: true, .. })`.
+        ValidTrue,
+        /// `verify` returns `Ok(VerificationResult { valid: false, .. })`.
+        ValidFalse,
+        /// `verify` returns `Err(PaymentError::InvalidReceipt(..))`.
+        Error,
+    }
+
     /// Minimal test adapter that implements `PaymentAdapter` (and therefore
     /// `PaymentVerifier` via the blanket impl).
     struct StubAdapter {
         id: &'static str,
-        /// When `true`, `verify` returns `valid: true`. When `false`,
-        /// returns an error.
-        succeed: bool,
+        /// Controls verify behavior.
+        verify_mode: StubVerifyMode,
     }
 
     impl PaymentAdapter for StubAdapter {
@@ -795,16 +831,22 @@ mod tests {
             &self,
             receipt: &PaymentReceipt,
         ) -> Result<VerificationResult, PaymentError> {
-            if self.succeed {
-                Ok(VerificationResult {
+            match self.verify_mode {
+                StubVerifyMode::ValidTrue => Ok(VerificationResult {
                     valid: true,
                     adapter_id: self.id.to_string(),
                     verified_amount: receipt.amount,
                     verified_currency: receipt.currency,
                     verification_timestamp: receipt.timestamp,
-                })
-            } else {
-                Err(PaymentError::InvalidReceipt("stub failure".into()))
+                }),
+                StubVerifyMode::ValidFalse => Ok(VerificationResult {
+                    valid: false,
+                    adapter_id: self.id.to_string(),
+                    verified_amount: receipt.amount,
+                    verified_currency: receipt.currency,
+                    verification_timestamp: receipt.timestamp,
+                }),
+                StubVerifyMode::Error => Err(PaymentError::InvalidReceipt("stub failure".into())),
             }
         }
 
@@ -825,7 +867,7 @@ mod tests {
     fn blanket_payment_verifier_adapter_id() {
         let adapter = StubAdapter {
             id: "test-rail",
-            succeed: true,
+            verify_mode: StubVerifyMode::ValidTrue,
         };
         let verifier: &dyn PaymentVerifierDyn = &adapter;
         assert_eq!(verifier.adapter_id(), "test-rail");
@@ -839,61 +881,199 @@ mod tests {
     async fn verify_receipts_single_success() {
         let adapter = StubAdapter {
             id: "test",
-            succeed: true,
+            verify_mode: StubVerifyMode::ValidTrue,
         };
         let receipt = make_receipt("did:dht:z6MkAlice", "did:dht:z6MkBob", 500, 1_000_000);
 
-        let results = verify_receipts(&[&adapter], &[receipt]).await.unwrap();
+        let results = verify_receipts(&[&adapter], &[receipt]).await;
         assert_eq!(results.len(), 1);
-        assert!(results[0].result.valid);
-        assert_eq!(results[0].receipt_id, [0xAA; 32]);
+        let v = results[0].as_ref().unwrap();
+        assert!(v.result.valid);
+        assert_eq!(v.receipt_id, [0xAA; 32]);
     }
 
     // -------------------------------------------------------------------
-    // verify_receipts: no matching verifier → NoVerifierForAdapter
+    // verify_receipts: no matching verifier → per-receipt error
     // -------------------------------------------------------------------
 
     #[tokio::test]
     async fn verify_receipts_no_matching_verifier() {
         let adapter = StubAdapter {
             id: "lightning",
-            succeed: true,
+            verify_mode: StubVerifyMode::ValidTrue,
         };
         // Receipt has adapter_id "test", but our verifier is "lightning".
         let receipt = make_receipt("did:dht:z6MkAlice", "did:dht:z6MkBob", 500, 1_000_000);
 
-        let err = verify_receipts(&[&adapter], &[receipt]).await.unwrap_err();
-        match err {
-            ReceiptVerificationError::NoVerifierForAdapter { adapter_id, .. } => {
+        let results = verify_receipts(&[&adapter], &[receipt]).await;
+        assert_eq!(results.len(), 1);
+        match &results[0] {
+            Err(ReceiptVerificationError::NoVerifierForAdapter { adapter_id, .. }) => {
                 assert_eq!(adapter_id, "test");
             }
-            ReceiptVerificationError::VerificationFailed { .. } => {
-                panic!("expected NoVerifierForAdapter, got VerificationFailed")
-            }
+            other => panic!("expected NoVerifierForAdapter, got: {other:?}"),
         }
     }
 
     // -------------------------------------------------------------------
-    // verify_receipts: adapter verify fails → VerificationFailed
+    // verify_receipts: adapter verify error → per-receipt error
     // -------------------------------------------------------------------
 
     #[tokio::test]
-    async fn verify_receipts_verification_failed() {
+    async fn verify_receipts_verification_error() {
         let adapter = StubAdapter {
             id: "test",
-            succeed: false,
+            verify_mode: StubVerifyMode::Error,
         };
         let receipt = make_receipt("did:dht:z6MkAlice", "did:dht:z6MkBob", 500, 1_000_000);
 
-        let err = verify_receipts(&[&adapter], &[receipt]).await.unwrap_err();
-        match err {
-            ReceiptVerificationError::VerificationFailed { receipt_id, .. } => {
-                assert_eq!(receipt_id, [0xAA; 32]);
+        let results = verify_receipts(&[&adapter], &[receipt]).await;
+        assert_eq!(results.len(), 1);
+        match &results[0] {
+            Err(ReceiptVerificationError::VerificationFailed { receipt_id, .. }) => {
+                assert_eq!(*receipt_id, [0xAA; 32]);
             }
-            ReceiptVerificationError::NoVerifierForAdapter { .. } => {
-                panic!("expected VerificationFailed, got NoVerifierForAdapter")
-            }
+            other => panic!("expected VerificationFailed, got: {other:?}"),
         }
+    }
+
+    // -------------------------------------------------------------------
+    // verify_receipts: valid=false path (F-03)
+    // -------------------------------------------------------------------
+
+    #[tokio::test]
+    async fn verify_receipts_valid_false_is_ok_but_not_valid() {
+        let adapter = StubAdapter {
+            id: "test",
+            verify_mode: StubVerifyMode::ValidFalse,
+        };
+        let receipt = make_receipt_with_id(
+            [0x11; 32],
+            "did:dht:z6MkAlice",
+            "did:dht:z6MkBob",
+            500,
+            1_000_000,
+        );
+
+        let results = verify_receipts(&[&adapter], &[receipt]).await;
+        assert_eq!(results.len(), 1);
+        // Ok does NOT mean valid — callers must check result.valid.
+        let v = results[0].as_ref().unwrap();
+        assert!(!v.result.valid);
+        assert_eq!(v.receipt_id, [0x11; 32]);
+    }
+
+    // -------------------------------------------------------------------
+    // verify_receipts: batch does not fail-fast (F-06)
+    // -------------------------------------------------------------------
+
+    #[tokio::test]
+    async fn verify_receipts_batch_no_fail_fast() {
+        // First receipt has no matching verifier, second succeeds.
+        let adapter = StubAdapter {
+            id: "lightning",
+            verify_mode: StubVerifyMode::ValidTrue,
+        };
+        let receipt_no_match = make_receipt_with_id(
+            [0x01; 32],
+            "did:dht:z6MkAlice",
+            "did:dht:z6MkBob",
+            100,
+            1_000_000,
+        );
+        let mut receipt_match = make_receipt_with_id(
+            [0x02; 32],
+            "did:dht:z6MkAlice",
+            "did:dht:z6MkBob",
+            200,
+            1_000_001,
+        );
+        receipt_match.adapter_id = "lightning".to_string();
+
+        let results = verify_receipts(&[&adapter], &[receipt_no_match, receipt_match]).await;
+        assert_eq!(results.len(), 2);
+        // First receipt: error (no verifier).
+        assert!(results[0].is_err());
+        // Second receipt: success despite first failing.
+        let v = results[1].as_ref().unwrap();
+        assert!(v.result.valid);
+        assert_eq!(v.receipt_id, [0x02; 32]);
+    }
+
+    // -------------------------------------------------------------------
+    // all_receipts_valid: convenience check
+    // -------------------------------------------------------------------
+
+    #[tokio::test]
+    async fn all_receipts_valid_returns_true_when_all_valid() {
+        let adapter = StubAdapter {
+            id: "test",
+            verify_mode: StubVerifyMode::ValidTrue,
+        };
+        let r1 = make_receipt_with_id(
+            [0x01; 32],
+            "did:dht:z6MkAlice",
+            "did:dht:z6MkBob",
+            100,
+            1_000_000,
+        );
+        let r2 = make_receipt_with_id(
+            [0x02; 32],
+            "did:dht:z6MkAlice",
+            "did:dht:z6MkBob",
+            200,
+            1_000_001,
+        );
+        let results = verify_receipts(&[&adapter], &[r1, r2]).await;
+        assert!(all_receipts_valid(&results));
+    }
+
+    #[tokio::test]
+    async fn all_receipts_valid_returns_false_when_one_invalid() {
+        let valid_adapter = StubAdapter {
+            id: "test",
+            verify_mode: StubVerifyMode::ValidTrue,
+        };
+        let invalid_adapter = StubAdapter {
+            id: "bad",
+            verify_mode: StubVerifyMode::ValidFalse,
+        };
+
+        let r1 = make_receipt_with_id(
+            [0x01; 32],
+            "did:dht:z6MkAlice",
+            "did:dht:z6MkBob",
+            100,
+            1_000_000,
+        );
+        let mut r2 = make_receipt_with_id(
+            [0x02; 32],
+            "did:dht:z6MkAlice",
+            "did:dht:z6MkBob",
+            200,
+            1_000_001,
+        );
+        r2.adapter_id = "bad".to_string();
+
+        let verifiers: Vec<&dyn PaymentVerifierDyn> = vec![&valid_adapter, &invalid_adapter];
+        let results = verify_receipts_dyn(&verifiers, &[r1, r2]).await;
+        assert!(!all_receipts_valid(&results));
+    }
+
+    #[test]
+    fn all_receipts_valid_returns_false_on_error() {
+        let results: Vec<Result<ReceiptVerification, ReceiptVerificationError>> =
+            vec![Err(ReceiptVerificationError::NoVerifierForAdapter {
+                receipt_id: [0xAA; 32],
+                adapter_id: "missing".to_string(),
+            })];
+        assert!(!all_receipts_valid(&results));
+    }
+
+    #[test]
+    fn all_receipts_valid_empty_is_vacuously_true() {
+        let results: Vec<Result<ReceiptVerification, ReceiptVerificationError>> = vec![];
+        assert!(all_receipts_valid(&results));
     }
 
     // -------------------------------------------------------------------
@@ -904,67 +1084,125 @@ mod tests {
     async fn verify_receipts_empty_receipts() {
         let adapter = StubAdapter {
             id: "test",
-            succeed: true,
+            verify_mode: StubVerifyMode::ValidTrue,
         };
-        let results = verify_receipts(&[&adapter], &[]).await.unwrap();
+        let results = verify_receipts(&[&adapter], &[]).await;
         assert!(results.is_empty());
     }
 
     // -------------------------------------------------------------------
-    // verify_receipts_dyn: heterogeneous verifiers
+    // verify_receipts_dyn: heterogeneous verifiers with distinct IDs
     // -------------------------------------------------------------------
 
     #[tokio::test]
     async fn verify_receipts_dyn_heterogeneous() {
         let adapter_a = StubAdapter {
             id: "test",
-            succeed: true,
+            verify_mode: StubVerifyMode::ValidTrue,
         };
         let adapter_b = StubAdapter {
             id: "lightning",
-            succeed: true,
+            verify_mode: StubVerifyMode::ValidTrue,
         };
 
-        let mut receipt_a = make_receipt("did:dht:z6MkAlice", "did:dht:z6MkBob", 100, 1_000_000);
+        let mut receipt_a = make_receipt_with_id(
+            [0x01; 32],
+            "did:dht:z6MkAlice",
+            "did:dht:z6MkBob",
+            100,
+            1_000_000,
+        );
         receipt_a.adapter_id = "test".to_string();
 
-        let mut receipt_b = make_receipt("did:dht:z6MkAlice", "did:dht:z6MkBob", 200, 1_000_001);
+        let mut receipt_b = make_receipt_with_id(
+            [0x02; 32],
+            "did:dht:z6MkAlice",
+            "did:dht:z6MkBob",
+            200,
+            1_000_001,
+        );
         receipt_b.adapter_id = "lightning".to_string();
 
         let verifiers: Vec<&dyn PaymentVerifierDyn> = vec![&adapter_a, &adapter_b];
-        let results = verify_receipts_dyn(&verifiers, &[receipt_a, receipt_b])
-            .await
-            .unwrap();
+        let results = verify_receipts_dyn(&verifiers, &[receipt_a, receipt_b]).await;
         assert_eq!(results.len(), 2);
-        assert!(results[0].result.valid);
-        assert!(results[1].result.valid);
-        assert_eq!(results[1].result.adapter_id, "lightning");
+        let v0 = results[0].as_ref().unwrap();
+        let v1 = results[1].as_ref().unwrap();
+        assert!(v0.result.valid);
+        assert!(v1.result.valid);
+        assert_eq!(v1.result.adapter_id, "lightning");
     }
 
     // -------------------------------------------------------------------
-    // verify_receipts_dyn: no matching verifier → error
+    // verify_receipts_dyn: no matching verifier → per-receipt error
     // -------------------------------------------------------------------
 
     #[tokio::test]
     async fn verify_receipts_dyn_no_verifier() {
         let adapter = StubAdapter {
             id: "x402",
-            succeed: true,
+            verify_mode: StubVerifyMode::ValidTrue,
         };
         let receipt = make_receipt("did:dht:z6MkAlice", "did:dht:z6MkBob", 500, 1_000_000);
 
         let verifiers: Vec<&dyn PaymentVerifierDyn> = vec![&adapter];
-        let err = verify_receipts_dyn(&verifiers, &[receipt])
-            .await
-            .unwrap_err();
-        match err {
-            ReceiptVerificationError::NoVerifierForAdapter { adapter_id, .. } => {
+        let results = verify_receipts_dyn(&verifiers, &[receipt]).await;
+        assert_eq!(results.len(), 1);
+        match &results[0] {
+            Err(ReceiptVerificationError::NoVerifierForAdapter { adapter_id, .. }) => {
                 assert_eq!(adapter_id, "test");
             }
-            ReceiptVerificationError::VerificationFailed { .. } => {
-                panic!("expected NoVerifierForAdapter, got VerificationFailed")
-            }
+            other => panic!("expected NoVerifierForAdapter, got: {other:?}"),
         }
+    }
+
+    // -------------------------------------------------------------------
+    // verify_receipts_dyn: valid=false path (F-03)
+    // -------------------------------------------------------------------
+
+    #[tokio::test]
+    async fn verify_receipts_dyn_valid_false() {
+        let adapter = StubAdapter {
+            id: "test",
+            verify_mode: StubVerifyMode::ValidFalse,
+        };
+        let receipt = make_receipt_with_id(
+            [0x22; 32],
+            "did:dht:z6MkAlice",
+            "did:dht:z6MkBob",
+            500,
+            1_000_000,
+        );
+
+        let verifiers: Vec<&dyn PaymentVerifierDyn> = vec![&adapter];
+        let results = verify_receipts_dyn(&verifiers, &[receipt]).await;
+        assert_eq!(results.len(), 1);
+        let v = results[0].as_ref().unwrap();
+        assert!(!v.result.valid);
+        assert_eq!(v.receipt_id, [0x22; 32]);
+    }
+
+    // -------------------------------------------------------------------
+    // ReceiptVerificationError serde roundtrip (F-05)
+    // -------------------------------------------------------------------
+
+    #[test]
+    fn receipt_verification_error_serde_roundtrip() {
+        let err = ReceiptVerificationError::NoVerifierForAdapter {
+            receipt_id: [0xAA; 32],
+            adapter_id: "x402".to_string(),
+        };
+        let json = serde_json::to_string(&err).unwrap();
+        let deserialized: ReceiptVerificationError = serde_json::from_str(&json).unwrap();
+        assert_eq!(err, deserialized);
+
+        let err2 = ReceiptVerificationError::VerificationFailed {
+            receipt_id: [0xBB; 32],
+            error: PaymentError::InvalidReceipt("bad proof".into()),
+        };
+        let json2 = serde_json::to_string(&err2).unwrap();
+        let deserialized2: ReceiptVerificationError = serde_json::from_str(&json2).unwrap();
+        assert_eq!(err2, deserialized2);
     }
 
     // -------------------------------------------------------------------


### PR DESCRIPTION
Closes #493

## Summary
- Implemented `PaymentVerifier` trait with blanket impl from `PaymentAdapter`
- Added `verify_receipts` and `verify_receipts_dyn` batch verification functions
- Added `PaymentVerifierDyn` object-safe variant for heterogeneous verifiers
- Added `all_receipts_valid()` safety function with `#[must_use]`
- Added `ReceiptVerificationError` with Serialize/Deserialize
- 29 tests covering all verification paths including valid=false security path

## Review Cycles
- Cycles: 2
- Findings resolved: 6 (security: valid=false safety, test coverage, serde, batch semantics, doc refs, test IDs)
- Findings dismissed: 3 (monomorphic API design, mixed-id test, code duplication)

🤖 Generated with [Claude Code](https://claude.com/claude-code)