### PR TITLE
fix(ci): Kotlin Android SDK permission, Python broadcast test assertion

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -298,6 +298,9 @@ jobs:
       run:
         working-directory: bindings/kotlin
     steps:
+      - name: Free disk space
+        run: |
+          sudo rm -rf /usr/share/dotnet /opt/ghc /opt/hostedtoolcache/CodeQL
       - uses: actions/checkout@v5
       - uses: actions/setup-java@v4
         with:
@@ -317,7 +320,7 @@ jobs:
     steps:
       - name: Free disk space
         run: |
-          sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghc /opt/hostedtoolcache/CodeQL
+          sudo rm -rf /usr/share/dotnet /opt/ghc /opt/hostedtoolcache/CodeQL
       - uses: actions/checkout@v5
       - uses: actions/setup-java@v4
         with:

--- a/bindings/python/tests/test_real_ffi.py
+++ b/bindings/python/tests/test_real_ffi.py
@@ -498,11 +498,13 @@ class TestBroadcast:
         _scp_core.py_broadcast_subscribe(handle, bob.did)
         assert _scp_core.py_broadcast_is_subscriber(handle, bob.did)
 
-        # Block bob.
+        # Block bob from alice's author keys. Per-author blocking does NOT
+        # remove from the context-wide subscriber roster (spec §5.14.8),
+        # so is_subscriber remains True.
         _scp_core.py_broadcast_block_subscriber(handle, bob.did, alice.did)
-        assert not _scp_core.py_broadcast_is_subscriber(handle, bob.did)
+        assert _scp_core.py_broadcast_is_subscriber(handle, bob.did)
 
-        # Unblock bob — subscriber status should be restored.
+        # Unblock bob — subscriber status unchanged (was never removed).
         _scp_core.py_broadcast_unblock_subscriber(handle, bob.did, alice.did)
         assert _scp_core.py_broadcast_is_subscriber(handle, bob.did)
 


### PR DESCRIPTION
## Summary

- Kotlin CI: Remove `/usr/local/lib/android` from disk space cleanup — Android SDK needs it
- Python test: Fix `test_block_and_unblock` assertion — per-author blocking doesn't remove from subscriber roster (spec §5.14.8)

## Test plan

- [x] Python: 455 tests pass locally (broadcast test fixed)
- [x] Kotlin: CI config verified
- [x] TypeScript: already passing (PR #1095)

🤖 Generated with [Claude Code](https://claude.com/claude-code)