### PR TITLE
fix(ffi): init ContextManager in context_join and context_import (closes #1073)

### DIFF
--- a/crates/scp-ffi/napi/src/context.rs
+++ b/crates/scp-ffi/napi/src/context.rs
@@ -474,6 +474,11 @@ pub async fn context_join(handle: &NapiContextHandle, identity_did: String) -> n
         .into());
     }
 
+    // Ensure the ContextManager is initialized — context_join is a valid
+    // first operation (e.g. a device joining a context without creating one).
+    // init_context_manager is idempotent (OnceLock — first call wins). #1073
+    crate::runtime::init_context_manager();
+
     let core_handle = handle.require_core_handle().map_err(NapiError::from)?;
     let key_package = scp_core::context::membership::KeyPackage {
         owner_did: DID(identity_did.clone()),
@@ -1706,6 +1711,12 @@ pub async fn context_import(data: Vec<u8>) -> napi::Result<String> {
         })
     })?;
     let context_id = export.snapshot.context_id.clone();
+
+    // Ensure the ContextManager is initialized — context_import is a valid
+    // first operation (e.g. a device receiving exported context data).
+    // init_context_manager is idempotent (OnceLock — first call wins). #1073
+    crate::runtime::init_context_manager();
+
     let manager = context_manager()?;
     manager
         .import_context(export)

--- a/crates/scp-ffi/napi/src/runtime.rs
+++ b/crates/scp-ffi/napi/src/runtime.rs
@@ -110,8 +110,8 @@ fn not_configured_key_resolver() -> scp_core::context::governance::KeyResolver {
 pub fn context_manager() -> napi::Result<&'static Arc<ContextManager>> {
     CONTEXT_MANAGER.get().ok_or_else(|| {
         napi::Error::from(ScpNapiError::Context {
-            message: "ContextManager not initialized — call context_create or \
-                      init_context_manager first"
+            message: "ContextManager not initialized — call context_create, \
+                      context_join, context_import, or init_context_manager first"
                 .to_owned(),
             code: "SCP-CTX-2000".to_owned(),
         })

--- a/crates/scp-ffi/src/context.rs
+++ b/crates/scp-ffi/src/context.rs
@@ -874,6 +874,14 @@ fn py_context_join(handle: &PyContextHandle, identity_did: &str) -> PyResult<()>
     }
     drop(state);
 
+    // Ensure the ContextManager is initialized — context_join is a valid
+    // first operation (e.g. a device joining a context without creating one).
+    // init_context_manager is idempotent (OnceLock — first call wins). #1073
+    #[cfg(test)]
+    crate::runtime::init_context_manager_for_test();
+    #[cfg(not(test))]
+    crate::runtime::init_context_manager();
+
     // Delegate join to the shared ContextManager for membership tracking.
     {
         let context_id = handle.context_id.clone();
@@ -1569,6 +1577,14 @@ fn py_context_import(data: &[u8]) -> PyResult<String> {
     })?;
 
     let context_id = export.snapshot.context_id.clone();
+
+    // Ensure the ContextManager is initialized — context_import is a valid
+    // first operation (e.g. a device receiving exported context data).
+    // init_context_manager is idempotent (OnceLock — first call wins). #1073
+    #[cfg(test)]
+    crate::runtime::init_context_manager_for_test();
+    #[cfg(not(test))]
+    crate::runtime::init_context_manager();
 
     let rt = crate::runtime()?;
     let mgr =

--- a/crates/scp-ffi/src/runtime.rs
+++ b/crates/scp-ffi/src/runtime.rs
@@ -115,8 +115,8 @@ static CONTEXT_MANAGER: OnceLock<Arc<ContextManager>> = OnceLock::new();
 pub fn context_manager() -> Result<&'static Arc<ContextManager>, ScpPyError> {
     CONTEXT_MANAGER.get().ok_or_else(|| {
         ScpPyError::context(
-            "ContextManager not initialized — call py_context_create or \
-             init_context_manager first"
+            "ContextManager not initialized — call py_context_create, \
+             py_context_join, py_context_import, or init_context_manager first"
                 .to_owned(),
         )
     })

--- a/crates/scp-ffi/uniffi/src/bridge.rs
+++ b/crates/scp-ffi/uniffi/src/bridge.rs
@@ -2416,6 +2416,11 @@ pub async fn context_join(
             }
             drop(state);
 
+            // Ensure the ContextManager is initialized — context_join is a valid
+            // first operation (e.g. a device joining a context without creating
+            // one). init_context_manager is idempotent (OnceLock). #1073
+            crate::runtime::init_context_manager();
+
             // Delegate to the shared ContextManager. Build a core ContextHandle
             // to pass the context_id, then join via the manager.
             //
@@ -6262,6 +6267,12 @@ pub async fn context_import(data: Vec<u8>) -> Result<String, ScpError> {
                     }
                 })?;
             let context_id = export.snapshot.context_id.clone();
+
+            // Ensure the ContextManager is initialized — context_import is a
+            // valid first operation (e.g. a device receiving exported context
+            // data). init_context_manager is idempotent (OnceLock). #1073
+            crate::runtime::init_context_manager();
+
             let manager = crate::runtime::context_manager()?;
             manager
                 .import_context(export)

--- a/crates/scp-ffi/uniffi/src/runtime.rs
+++ b/crates/scp-ffi/uniffi/src/runtime.rs
@@ -116,8 +116,8 @@ pub fn context_manager() -> Result<&'static Arc<ContextManager>, crate::ScpError
     CONTEXT_MANAGER
         .get()
         .ok_or_else(|| crate::ScpError::Context {
-            message: "ContextManager not initialized — call context_create or \
-                  init_context_manager first"
+            message: "ContextManager not initialized — call context_create, \
+                  context_join, context_import, or init_context_manager first"
                 .to_owned(),
             code: "SCP-CTX-2000".to_owned(),
         })


### PR DESCRIPTION
Closes #1073

## Summary
- Added idempotent `init_context_manager()` calls to `context_join` and `context_import` in all 3 non-WASM FFI bridges (PyO3, NAPI, UniFFI)
- Devices can now join or import contexts as first operations without prior `context_create`
- Error messages updated to list all valid initializer entry points

## Review Cycles
- RC1: 0 findings — converged