### PR TITLE
test(typescript): assert concrete values in real-napi event log verify test (closes #1015)

### DIFF
--- a/bindings/typescript/tests/real-napi.test.ts
+++ b/bindings/typescript/tests/real-napi.test.ts
@@ -489,8 +489,8 @@ if (bridge === null) {
       );
 
       const proof = await napi.eventLogVerify(ctx, { type: "inclusion", leafIndex: 0 });
-      expect(typeof proof.verified).toBe("boolean");
-      expect(typeof proof.proofType).toBe("string");
+      expect(proof.verified).toBe(true);
+      expect(proof.proofType).toBe("inclusion");
     });
 
     test.skip("creates a checkpoint (NapiIdentity class required — #1144)", async () => {


### PR DESCRIPTION
Closes #1015

## Summary
- Changed `typeof proof.verified` assertion to `expect(proof.verified).toBe(true)`
- Changed `typeof proof.proofType` assertion to `expect(proof.proofType).toBe("inclusion")`
- NAPI bridge performs real Merkle inclusion proofs — concrete assertions catch regressions

## Review Cycles
- Cycles: 1
- Findings resolved: 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)