### PR TITLE
fix(kotlin): change toolVerifyResult from Boolean to String (closes #1010)

### DIFF
--- a/bindings/kotlin/scp-kt/src/test/kotlin/works/limn/scp/bridge/CoroutineBridgeTest.kt
+++ b/bindings/kotlin/scp-kt/src/test/kotlin/works/limn/scp/bridge/CoroutineBridgeTest.kt
@@ -178,7 +178,7 @@ class CoroutineBridgeTest {
         @Test
         fun `toolVerify dispatches on IO`() =
             runTest(ioDispatcher) {
-                stubBindings.toolVerifyResult = true
+                stubBindings.toolVerifyResult = """{"tool_id":"tool-001","passed":true,"failures":[]}"""
                 val result = bridge.tools.verify(10L, "tool-001")
                 assertTrue(result.contains("\"passed\":true"))
             }
@@ -587,7 +587,7 @@ class StubNativeBindings : NativeBindings {
     var contextSubscribeResult = 0L
     var toolRegisterResult = ""
     var toolInvokeResult = ""
-    var toolVerifyResult = false
+    var toolVerifyResult = """{"tool_id":"stub","passed":true,"failures":[]}"""
     var ucanMintResult = ""
     var ucanDelegateResult = ""
     var eventLogQueryResult = ""
@@ -738,7 +738,7 @@ class StubNativeBindings : NativeBindings {
     override fun toolVerify(
         contextHandle: Long,
         toolId: String,
-    ): String = """{"tool_id":"$toolId","passed":$toolVerifyResult,"failures":[]}"""
+    ): String = toolVerifyResult
 
     override fun ucanValidate(
         contextHandle: Long,

--- a/bindings/kotlin/scp-kt/src/test/kotlin/works/limn/scp/conformance/ConformanceStubBindings.kt
+++ b/bindings/kotlin/scp-kt/src/test/kotlin/works/limn/scp/conformance/ConformanceStubBindings.kt
@@ -53,7 +53,7 @@ class ConformanceStubBindings : NativeBindings {
     var toolRegisterError: BridgeException? = null
     var toolInvokeResult: String = """{"output":"ok"}"""
     var toolInvokeError: BridgeException? = null
-    var toolVerifyResult: Boolean = true // kept as Boolean, serialized to JSON in toolVerify()
+    var toolVerifyResult: String = """{"tool_id":"stub","passed":true,"failures":[]}"""
     var toolVerifyError: BridgeException? = null
 
     var ucanValidateError: BridgeException? = null
@@ -207,8 +207,7 @@ class ConformanceStubBindings : NativeBindings {
         toolId: String,
     ): String {
         toolVerifyError?.let { throw it }
-        @Suppress("MaxLineLength")
-        return """{"tool_id":"$toolId","passed":$toolVerifyResult,"failures":[]}"""
+        return toolVerifyResult
     }
 
     override fun ucanValidate(
@@ -316,7 +315,7 @@ class ConformanceStubBindings : NativeBindings {
         toolRegisterError = null
         toolInvokeResult = """{"output":"ok"}"""
         toolInvokeError = null
-        toolVerifyResult = true
+        toolVerifyResult = """{"tool_id":"stub","passed":true,"failures":[]}"""
         toolVerifyError = null
         ucanValidateError = null
         ucanMintResult = "minted-token"

--- a/bindings/kotlin/scp-kt/src/test/kotlin/works/limn/scp/conformance/ToolsConformanceTest.kt
+++ b/bindings/kotlin/scp-kt/src/test/kotlin/works/limn/scp/conformance/ToolsConformanceTest.kt
@@ -108,7 +108,7 @@ class ToolsConformanceTest {
         @Test
         fun `tool_verify returns result for registered tool`() =
             runTest(testDispatcher) {
-                stubBindings.toolVerifyResult = true
+                stubBindings.toolVerifyResult = """{"tool_id":"tool-calc-001","passed":true,"failures":[]}"""
                 val result = dispatcher.dispatch(
                     "tool_verify",
                     mapOf(
@@ -122,7 +122,9 @@ class ToolsConformanceTest {
         @Test
         fun `tool_verify returns failed result`() =
             runTest(testDispatcher) {
-                stubBindings.toolVerifyResult = false
+                @Suppress("MaxLineLength")
+                stubBindings.toolVerifyResult =
+                    """{"tool_id":"tool-calc-001","passed":false,"failures":["signature mismatch"]}"""
                 val result = dispatcher.dispatch(
                     "tool_verify",
                     mapOf(


### PR DESCRIPTION
Closes #1010

## Summary
- Changed `toolVerifyResult` from `Boolean` to `String` in StubNativeBindings and ConformanceStubBindings
- `toolVerify()` now returns the String directly (no interpolation)
- Updated `reset()` and 2 test cases in ToolsConformanceTest

## Review Cycles
- Cycles: 1
- Findings resolved: 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)