### PR TITLE
fix(typescript): preserve broadcast state in mock contextImport (closes #1007)

### DIFF
--- a/bindings/typescript/tests/integration.test.ts
+++ b/bindings/typescript/tests/integration.test.ts
@@ -985,6 +985,62 @@ describe("Context export/import (mock bridge)", () => {
       mockBridge.contextImport(new TextEncoder().encode(JSON.stringify({}))),
     ).rejects.toThrow(/SCP-CTX-2032/);
   });
+
+  it("round-trips broadcast context with subscribers and blocked list", async () => {
+    const identity = await mockBridge.identityCreate("in_memory");
+    const ctx = await mockBridge.contextCreate(identity, JSON.stringify({ mode: "Broadcast" }));
+
+    // Add subscribers and block one
+    const sub1 = await mockBridge.identityCreate("in_memory");
+    const sub2 = await mockBridge.identityCreate("in_memory");
+    const blocked = await mockBridge.identityCreate("in_memory");
+
+    await mockBridge.broadcastSubscribe(ctx, sub1.did);
+    await mockBridge.broadcastSubscribe(ctx, sub2.did);
+    await mockBridge.broadcastSubscribe(ctx, blocked.did);
+    await mockBridge.broadcastBlockSubscriber(ctx, blocked.did, identity.did);
+
+    // Verify pre-export state
+    const original = mockBridge._contexts.get(ctx.contextId);
+    expect(original?.mode).toBe("Broadcast");
+    expect(original?.broadcastSubscribers.size).toBe(2);
+    expect(original?.broadcastBlockedSubscribers.has(blocked.did)).toBe(true);
+    expect(original?.broadcastAdmission).toBe("Open");
+
+    // Export and re-import
+    const exported = await mockBridge.contextExport(ctx);
+    // Remove the original so import creates a fresh entry
+    mockBridge._contexts.delete(ctx.contextId);
+
+    const importedId = await mockBridge.contextImport(exported);
+    expect(importedId).toBe(ctx.contextId);
+
+    const imported = mockBridge._contexts.get(importedId);
+    expect(imported?.mode).toBe("Broadcast");
+    expect(imported?.broadcastSubscribers.size).toBe(2);
+    expect(imported?.broadcastSubscribers.has(sub1.did)).toBe(true);
+    expect(imported?.broadcastSubscribers.has(sub2.did)).toBe(true);
+    expect(imported?.broadcastBlockedSubscribers.has(blocked.did)).toBe(true);
+    expect(imported?.broadcastAdmission).toBe("Open");
+  });
+
+  it("round-trips encrypted context preserving mode", async () => {
+    const identity = await mockBridge.identityCreate("in_memory");
+    const ctx = await mockBridge.contextCreate(
+      identity,
+      JSON.stringify({ ceiling: ["messages:read"] }),
+    );
+
+    const exported = await mockBridge.contextExport(ctx);
+    mockBridge._contexts.delete(ctx.contextId);
+
+    const importedId = await mockBridge.contextImport(exported);
+    const imported = mockBridge._contexts.get(importedId);
+    expect(imported?.mode).toBe("Encrypted");
+    expect(imported?.broadcastSubscribers.size).toBe(0);
+    expect(imported?.broadcastBlockedSubscribers.size).toBe(0);
+    expect(imported?.broadcastAdmission).toBeNull();
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/bindings/typescript/tests/mock-bridge.ts
+++ b/bindings/typescript/tests/mock-bridge.ts
@@ -716,6 +716,10 @@ export function createMockBridge(): Bridge & {
           state: ctx.state,
           members: [...ctx.members],
           event_count: ctx.eventLog.length,
+          mode: ctx.mode,
+          broadcast_subscribers: [...ctx.broadcastSubscribers],
+          broadcast_blocked_subscribers: [...ctx.broadcastBlockedSubscribers],
+          broadcast_admission: ctx.broadcastAdmission,
         },
       };
       return new TextEncoder().encode(JSON.stringify(exportData));
@@ -723,7 +727,17 @@ export function createMockBridge(): Bridge & {
 
     async contextImport(data: Uint8Array): Promise<string> {
       const json = new TextDecoder().decode(data);
-      let parsed: { snapshot?: { context_id?: string; creator_did?: string; members?: string[] } };
+      let parsed: {
+        snapshot?: {
+          context_id?: string;
+          creator_did?: string;
+          members?: string[];
+          mode?: string;
+          broadcast_subscribers?: string[];
+          broadcast_blocked_subscribers?: string[];
+          broadcast_admission?: BroadcastAdmissionPolicy | null;
+        };
+      };
       try {
         parsed = JSON.parse(json) as typeof parsed;
       } catch {
@@ -736,6 +750,7 @@ export function createMockBridge(): Bridge & {
       const contextId = snapshot.context_id;
       const creatorDid = snapshot.creator_did ?? "did:dht:unknown";
       const members = snapshot.members ?? [creatorDid];
+      const mode = snapshot.mode ?? "Encrypted";
       const ctx: MockContext = {
         contextId,
         state: "active",
@@ -749,10 +764,10 @@ export function createMockBridge(): Bridge & {
         revokedTokens: new Set(),
         economicPolicy: null,
         ttlSecs: null,
-        mode: "Encrypted",
-        broadcastSubscribers: new Set(),
-        broadcastBlockedSubscribers: new Set(),
-        broadcastAdmission: null,
+        mode,
+        broadcastSubscribers: new Set(snapshot.broadcast_subscribers ?? []),
+        broadcastBlockedSubscribers: new Set(snapshot.broadcast_blocked_subscribers ?? []),
+        broadcastAdmission: snapshot.broadcast_admission ?? (mode === "Broadcast" ? "Open" : null),
       };
       const importedEvent: Event = {
         eventType: "ContextImported",


### PR DESCRIPTION
Closes #1007

## Summary
- Fixed contextExport to serialize mode + broadcast fields (subscribers, blocked, admission)
- Fixed contextImport to parse broadcast state from snapshot with sensible defaults
- Added 2 round-trip tests: Broadcast mode (with subscribers/blocked) and Encrypted mode

## Review Cycles
- Cycles: 1
- Findings resolved: 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)