### PR TITLE
test(typescript): add broadcastUnsubscribe rotateKeys and WASM rejection tests (closes #1008)

### DIFF
--- a/bindings/typescript/tests/bridge.test.ts
+++ b/bindings/typescript/tests/bridge.test.ts
@@ -9,7 +9,9 @@
  */
 
 import { describe, expect, it } from "bun:test";
+import { TransportError } from "../src/errors";
 import { BRIDGE_TARGET } from "../src/internal/bridge";
+import { createWasmBridge } from "../src/internal/wasm";
 
 describe("bridge selection", () => {
   it("detects native bridge target in Node.js/Bun", () => {
@@ -20,5 +22,61 @@ describe("bridge selection", () => {
   it("BRIDGE_TARGET is a string literal type", () => {
     expect(typeof BRIDGE_TARGET).toBe("string");
     expect(["native", "wasm"]).toContain(BRIDGE_TARGET);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// WASM bridge rejection paths
+// ---------------------------------------------------------------------------
+
+describe("WASM bridge rejection paths", () => {
+  it("broadcastUnsubscribe with rotateKeys=true throws SCP-TRANS-5003", async () => {
+    // The WASM bridge rejects rotateKeys=true before any WASM call,
+    // so this test works without WASM module initialization.
+    const wasmBridge = createWasmBridge();
+    const fakeHandle = { contextId: "ctx-fake", state: "active", creatorDid: "did:dht:fake" };
+
+    await expect(
+      wasmBridge.broadcastUnsubscribe(fakeHandle, "did:dht:subscriber", true),
+    ).rejects.toThrow(TransportError);
+
+    try {
+      await wasmBridge.broadcastUnsubscribe(fakeHandle, "did:dht:subscriber", true);
+    } catch (err) {
+      expect(err).toBeInstanceOf(TransportError);
+      const transportErr = err as TransportError;
+      expect(transportErr.code).toBe("SCP-TRANS-5003");
+      expect(transportErr.message).toContain("WASM bridge does not support key rotation");
+      expect(transportErr.message).toContain("napi-rs");
+    }
+  });
+
+  it("broadcastUnsubscribe with rotateKeys=false does not throw SCP-TRANS-5003", async () => {
+    // With rotateKeys=false (or undefined), the WASM bridge should proceed to
+    // the actual WASM call — which will fail because WASM is not initialized.
+    // The important thing is it does NOT throw a SCP-TRANS-5003 error.
+    const wasmBridge = createWasmBridge();
+    const fakeHandle = { contextId: "ctx-fake", state: "active", creatorDid: "did:dht:fake" };
+
+    try {
+      await wasmBridge.broadcastUnsubscribe(fakeHandle, "did:dht:subscriber", false);
+    } catch (err) {
+      // Should fail with WASM-not-initialized (SCP-TRANS-5002), not SCP-TRANS-5003.
+      expect(err).toBeInstanceOf(TransportError);
+      expect((err as TransportError).code).toBe("SCP-TRANS-5002");
+    }
+  });
+
+  it("broadcastUnsubscribe with rotateKeys=undefined does not throw SCP-TRANS-5003", async () => {
+    const wasmBridge = createWasmBridge();
+    const fakeHandle = { contextId: "ctx-fake", state: "active", creatorDid: "did:dht:fake" };
+
+    try {
+      await wasmBridge.broadcastUnsubscribe(fakeHandle, "did:dht:subscriber", undefined);
+    } catch (err) {
+      // Should fail with WASM-not-initialized (SCP-TRANS-5002), not SCP-TRANS-5003.
+      expect(err).toBeInstanceOf(TransportError);
+      expect((err as TransportError).code).toBe("SCP-TRANS-5002");
+    }
   });
 });

--- a/bindings/typescript/tests/integration.test.ts
+++ b/bindings/typescript/tests/integration.test.ts
@@ -1287,6 +1287,40 @@ describe("Broadcast mutation operations (mock bridge)", () => {
     expect(await ctx.broadcastSubscriberCount()).toBe(0);
   });
 
+  it("broadcastUnsubscribe with rotateKeys=false does not trigger key rotation", async () => {
+    const { ctx, handle } = await createBroadcastContext();
+    const subscriber = await mockBridge.identityCreate("in_memory");
+
+    await ctx.broadcastSubscribe(subscriber.did);
+    await ctx.broadcastUnsubscribe(subscriber.did, false);
+
+    expect(await ctx.broadcastIsSubscriber(subscriber.did)).toBe(false);
+    // No BroadcastKeyRotated event should be emitted when rotateKeys is false.
+    const mockCtx = mockBridge._contexts.get(handle.contextId);
+    expect(mockCtx).toBeDefined();
+    const rotateEvents =
+      mockCtx?.eventLog.filter((e) => e.eventType === "BroadcastKeyRotated") ?? [];
+    expect(rotateEvents.length).toBe(0);
+  });
+
+  it("broadcastUnsubscribe with rotateKeys=true triggers key rotation", async () => {
+    const { ctx, handle } = await createBroadcastContext();
+    const subscriber = await mockBridge.identityCreate("in_memory");
+
+    await ctx.broadcastSubscribe(subscriber.did);
+    await ctx.broadcastUnsubscribe(subscriber.did, true);
+
+    expect(await ctx.broadcastIsSubscriber(subscriber.did)).toBe(false);
+    // A BroadcastKeyRotated event should be emitted when rotateKeys is true.
+    const mockCtx = mockBridge._contexts.get(handle.contextId);
+    expect(mockCtx).toBeDefined();
+    const rotateEvents =
+      mockCtx?.eventLog.filter((e) => e.eventType === "BroadcastKeyRotated") ?? [];
+    expect(rotateEvents.length).toBe(1);
+    expect(rotateEvents[0].payload.reason).toBe("subscriber_removed");
+    expect(rotateEvents[0].payload.subscriberDid).toBe(subscriber.did);
+  });
+
   it("broadcastPublish succeeds for context member", async () => {
     const { ctx, identity } = await createBroadcastContext();
     const payload = new Uint8Array([1, 2, 3]);

--- a/bindings/typescript/tests/mock-bridge.ts
+++ b/bindings/typescript/tests/mock-bridge.ts
@@ -800,13 +800,25 @@ export function createMockBridge(): Bridge & {
     async broadcastUnsubscribe(
       handle: BridgeContextHandle,
       subscriberDid: string,
-      _rotateKeys?: boolean,
+      rotateKeys?: boolean,
     ): Promise<void> {
       const ctx = getContext(handle);
       if (ctx.mode !== "Broadcast") {
         throw new Error("[SCP-CTX-2001] Context is not a broadcast context");
       }
       ctx.broadcastSubscribers.delete(subscriberDid);
+      if (rotateKeys === true) {
+        // Record a key rotation event so tests can verify the parameter was observed.
+        const rotateEvent: Event = {
+          eventType: "BroadcastKeyRotated",
+          actorDid: handle.creatorDid,
+          timestamp: Math.floor(Date.now() / 1000),
+          payload: { reason: "subscriber_removed", subscriberDid },
+          sequence: ctx.eventLog.length,
+        };
+        ctx.receiveBuffer.push(rotateEvent);
+        ctx.eventLog.push(rotateEvent);
+      }
     },
 
     async broadcastPublish(


### PR DESCRIPTION
Closes #1008

## Summary
- Mock broadcastUnsubscribe now observes rotateKeys parameter (emits BroadcastKeyRotated event)
- 2 integration tests: rotateKeys=false (no event) and rotateKeys=true (event emitted)
- 3 WASM bridge tests: rotateKeys=true rejection (SCP-TRANS-5003), false/undefined passthrough

## Review Cycles
- Cycles: 1
- Findings resolved: 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)