### PR TITLE
test(wasm): add bidirectional CATEGORY_A_RESOURCES conformance check (closes #1013)

### DIFF
--- a/crates/scp-core/src/trust/custody_violation.rs
+++ b/crates/scp-core/src/trust/custody_violation.rs
@@ -90,6 +90,26 @@ const CATEGORY_A_RESOURCES: &[&str] = &[
     "key_management",
 ];
 
+/// Returns the closed set of Category A resource types.
+///
+/// These are the UCAN capability resource types that modify the DID document
+/// and therefore require human (`#active`) signing. Exposed for conformance
+/// testing against mirror implementations (e.g. WASM).
+///
+/// # Examples
+///
+/// ```
+/// use scp_core::trust::custody_violation::category_a_resources;
+///
+/// let resources = category_a_resources();
+/// assert!(resources.contains(&"did_document"));
+/// assert!(!resources.contains(&"messages"));
+/// ```
+#[must_use]
+pub const fn category_a_resources() -> &'static [&'static str] {
+    CATEGORY_A_RESOURCES
+}
+
 /// Classifies an action by its UCAN capability resource type.
 ///
 /// Returns [`ActionCategory::CategoryA`] if the resource type modifies the

--- a/crates/scp-core/src/trust/mod.rs
+++ b/crates/scp-core/src/trust/mod.rs
@@ -113,7 +113,8 @@ pub use consequence::{
 };
 pub use custody_violation::{
     ActionCategory, CounterAttestation, CustodyViolationError, CustodyViolationResult,
-    CustodyViolationType, ScpCustodyViolationAttestation, classify_action, enforce_category_a,
+    CustodyViolationType, ScpCustodyViolationAttestation, category_a_resources, classify_action,
+    enforce_category_a,
 };
 #[cfg(feature = "testing")]
 pub use participation::compute_participation_record;

--- a/crates/scp-core/tests/wasm_conformance.rs
+++ b/crates/scp-core/tests/wasm_conformance.rs
@@ -5367,6 +5367,18 @@ fn wasm_core_category_a_resources_match() {
 }
 
 #[test]
+fn core_wasm_category_a_resources_match() {
+    // Reverse direction: verify every core CATEGORY_A_RESOURCE exists in WASM's list
+    use scp_core::trust::custody_violation::category_a_resources;
+    for resource in category_a_resources() {
+        assert!(
+            wasm_ucan_mirror::CATEGORY_A_RESOURCES.contains(resource),
+            "Core CATEGORY_A_RESOURCES entry '{resource}' missing from WASM mirror"
+        );
+    }
+}
+
+#[test]
 fn wasm_core_category_a_agent_rejected() {
     let token = wasm_ucan_mirror::ParsedUcanToken {
         header: wasm_ucan_mirror::UcanHeader {


### PR DESCRIPTION
Closes #1013

## Summary
- Added `category_a_resources()` pub accessor in scp-core for conformance testing
- Added reverse test: core→WASM direction (existing test covered WASM→core)
- Together ensures both lists stay synchronized

## Review Cycles
- Cycles: 1
- Findings resolved: 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)