### PR TITLE
fix(wasm,typescript): wire sequence field through WasmMessage instead of hardcoding 0 (closes #548)

### DIFF
--- a/bindings/typescript/src/internal/wasm-types.d.ts
+++ b/bindings/typescript/src/internal/wasm-types.d.ts
@@ -47,6 +47,7 @@ declare module "@limn-works/scp-ts-wasm" {
         payloadBase64: string;
         timestamp: number;
         contextId: string;
+        sequence: number;
       }) => void;
       onComplete: () => void;
     },

--- a/bindings/typescript/src/internal/wasm.ts
+++ b/bindings/typescript/src/internal/wasm.ts
@@ -76,6 +76,7 @@ interface WasmModule {
         payloadBase64: string;
         timestamp: number;
         contextId: string;
+        sequence: number;
       }) => void;
       onComplete: () => void;
     },
@@ -591,7 +592,7 @@ export function createWasmBridge(): Bridge {
             senderDid: msg.senderDid,
             content: base64ToUint8(msg.payloadBase64),
             timestamp: msg.timestamp,
-            sequence: 0,
+            sequence: msg.sequence,
             contextId: msg.contextId,
           });
         },

--- a/crates/scp-ffi/wasm/src/context.rs
+++ b/crates/scp-ffi/wasm/src/context.rs
@@ -195,6 +195,7 @@ pub struct WasmMessage {
     payload_base64: String,
     timestamp: f64,
     context_id: String,
+    sequence: u64,
 }
 
 #[wasm_bindgen]
@@ -225,6 +226,13 @@ impl WasmMessage {
     #[wasm_bindgen(getter, js_name = "contextId")]
     pub fn context_id(&self) -> String {
         self.context_id.clone()
+    }
+
+    /// Returns the per-sender sequence number for this message.
+    #[must_use]
+    #[wasm_bindgen(getter)]
+    pub fn sequence(&self) -> u64 {
+        self.sequence
     }
 }
 


### PR DESCRIPTION
Closes #548

## Summary
- Added `sequence: u64` field + getter to `WasmMessage` struct in WASM bridge
- Updated wasm.ts to read `msg.sequence` instead of hardcoding `0`
- Updated wasm-types.d.ts ambient declaration

## Review Cycles
- Cycles: 1
- Findings resolved: 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)