### PR TITLE
fix(ffi): harmonize bridge operation error codes across PyO3/UniFFI/NAPI/WASM (closes #537)

### DIFF
--- a/crates/scp-ffi/napi/src/bridge_connector.rs
+++ b/crates/scp-ffi/napi/src/bridge_connector.rs
@@ -163,7 +163,7 @@ pub fn bridge_register(
             <[u8; 32]>::try_from(k.as_slice()).map_err(|_| {
                 napi::Error::from(ScpNapiError::Validation {
                     message: format!("platform_key must be exactly 32 bytes, got {}", k.len()),
-                    code: "SCP-VALID-7012".to_owned(),
+                    code: "SCP-VALID-7052".to_owned(),
                 })
             })
         })
@@ -244,9 +244,9 @@ pub fn bridge_create_shadow(
     let mut sender_key_store = scp_core::crypto::sender_keys::SenderKeyStore::new();
     let (shadow, _event) = create_shadow(&mut shadow_registry, &mut sender_key_store, &params)
         .map_err(|e| {
-            napi::Error::from(ScpNapiError::Validation {
+            napi::Error::from(ScpNapiError::Context {
                 message: format!("shadow creation failed: {e}"),
-                code: "SCP-VALID-7014".to_owned(),
+                code: "SCP-CTX-2102".to_owned(),
             })
         })?;
 
@@ -273,7 +273,7 @@ fn parse_bridge_mode(s: &str) -> napi::Result<BridgeMode> {
             message: format!(
                 "invalid bridge mode '{other}': expected 'relay', 'puppet', 'api', or 'cooperative'"
             ),
-            code: "SCP-VALID-7010".to_owned(),
+            code: "SCP-VALID-7050".to_owned(),
         }
         .into()),
     }
@@ -285,7 +285,7 @@ fn parse_shadow_status(s: &str) -> napi::Result<ShadowProvenanceStatus> {
         "claimed" => Ok(ShadowProvenanceStatus::Claimed),
         other => Err(ScpNapiError::Validation {
             message: format!("invalid shadow_status '{other}': expected 'shadow' or 'claimed'"),
-            code: "SCP-VALID-7011".to_owned(),
+            code: "SCP-VALID-7051".to_owned(),
         }
         .into()),
     }

--- a/crates/scp-ffi/uniffi/src/bridge.rs
+++ b/crates/scp-ffi/uniffi/src/bridge.rs
@@ -7317,7 +7317,7 @@ pub fn bridge_evaluate_trust(
         other => {
             return Err(ScpError::Validation {
                 msg: format!("invalid shadow_status '{other}': expected 'shadow' or 'claimed'"),
-                code: "SCP-VALID-7043".to_owned(),
+                code: "SCP-VALID-7051".to_owned(),
             });
         }
     };

--- a/crates/scp-ffi/wasm/src/bridge.rs
+++ b/crates/scp-ffi/wasm/src/bridge.rs
@@ -173,7 +173,7 @@ impl BridgeMode {
                 message: format!(
                     "invalid bridge mode '{other}': expected 'relay', 'puppet', 'api', or 'cooperative'"
                 ),
-                code: "SCP-VALID-7010".to_owned(),
+                code: "SCP-VALID-7050".to_owned(),
             }),
         }
     }
@@ -204,7 +204,7 @@ impl ShadowProvenanceStatus {
             "claimed" => Ok(Self::Claimed),
             other => Err(ScpWasmError::Validation {
                 message: format!("invalid shadow_status '{other}': expected 'shadow' or 'claimed'"),
-                code: "SCP-VALID-7011".to_owned(),
+                code: "SCP-VALID-7051".to_owned(),
             }),
         }
     }
@@ -338,7 +338,7 @@ pub fn bridge_register(
     if context_id.is_empty() {
         return Err(ScpWasmError::Validation {
             message: "context_id must not be empty".to_owned(),
-            code: "SCP-VALID-7012".to_owned(),
+            code: "SCP-VALID-7053".to_owned(),
         }
         .into_js());
     }
@@ -351,7 +351,7 @@ pub fn bridge_register(
     if platform.is_empty() {
         return Err(ScpWasmError::Validation {
             message: "platform must not be empty".to_owned(),
-            code: "SCP-VALID-7012".to_owned(),
+            code: "SCP-VALID-7054".to_owned(),
         }
         .into_js());
     }
@@ -444,14 +444,14 @@ pub fn bridge_create_shadow(
     if bridge_id.is_empty() {
         return Err(ScpWasmError::Validation {
             message: "bridge_id must not be empty".to_owned(),
-            code: "SCP-VALID-7014".to_owned(),
+            code: "SCP-VALID-7055".to_owned(),
         }
         .into_js());
     }
     if platform_handle.is_empty() {
         return Err(ScpWasmError::Validation {
             message: "platform_handle must not be empty".to_owned(),
-            code: "SCP-VALID-7014".to_owned(),
+            code: "SCP-VALID-7056".to_owned(),
         }
         .into_js());
     }


### PR DESCRIPTION
Closes #537

## Summary
- Harmonized error codes across NAPI, UniFFI, and WASM bridges to match PyO3 (reference bridge)
- NAPI: 7010→7050, 7011→7051, 7012→7052, 7014→CTX-2102
- UniFFI: 7043→7051
- WASM: 7010→7050, 7011→7051, deduplicated shared codes into distinct 7053-7056
- `check-error-codes.sh` passes

## Review Cycles
- Cycles: 1
- Findings resolved: 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)