### PR TITLE
feat(node): add ApplicationNode::dev() convenience constructor (closes #531)

### DIFF
--- a/crates/scp-node/src/lib.rs
+++ b/crates/scp-node/src/lib.rs
@@ -192,9 +192,13 @@ impl IdentityHandle {
 
 /// A complete SCP application node composing relay, identity, and storage.
 ///
-/// Created via [`ApplicationNodeBuilder`]. The node starts a relay server,
-/// publishes the identity's DID document with `SCPRelay` service entries,
-/// and provides accessors for each component.
+/// Created via [`ApplicationNodeBuilder`] for production use, or via
+/// [`ApplicationNode::dev`] for quick development/demo setups (requires the
+/// `allow_unencrypted_storage` feature).
+///
+/// The node starts a relay server, publishes the identity's DID document
+/// with `SCPRelay` service entries, and provides accessors for each
+/// component.
 ///
 /// The relay accepts connections from any SCP client, not just the local
 /// identity. DID publication happens once on `.build()`, not continuously
@@ -514,6 +518,73 @@ impl<S: Storage> ApplicationNode<S> {
                 projected.retain_only_epochs(&new_epochs);
             }
         }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Dev convenience constructor
+// ---------------------------------------------------------------------------
+
+/// Dev/demo convenience constructor for [`ApplicationNode`].
+///
+/// Requires the `allow_unencrypted_storage` feature flag (or `#[cfg(test)]`).
+/// **Not for production use.**
+#[cfg(any(test, feature = "allow_unencrypted_storage"))]
+impl ApplicationNode<scp_platform::testing::InMemoryStorage> {
+    /// Creates an `ApplicationNode` with sensible development defaults.
+    ///
+    /// Auto-wires:
+    /// - [`InMemoryKeyCustody`](scp_platform::testing::InMemoryKeyCustody)
+    /// - [`InMemoryStorage`](scp_platform::testing::InMemoryStorage)
+    /// - [`InMemoryDhtClient`](scp_identity::InMemoryDhtClient) (no real DHT network)
+    /// - [`SelfSignedTlsProvider`] (self-signed TLS certificate for `localhost`)
+    /// - Relay bound to `127.0.0.1:<port>`
+    /// - Domain set to `localhost`
+    ///
+    /// This is the zero-friction path for demos, prototyping, and integration
+    /// tests. For production deployments, use [`ApplicationNodeBuilder`] with
+    /// real key custody, encrypted storage, and ACME TLS.
+    ///
+    /// # Example
+    ///
+    /// ```rust,no_run
+    /// # async fn example() -> Result<(), scp_node::NodeError> {
+    /// let node = scp_node::ApplicationNode::dev(4000).await?;
+    /// println!("Relay at {}", node.relay().bound_addr());
+    /// println!("DID: {}", node.identity().did());
+    /// # Ok(())
+    /// # }
+    /// ```
+    ///
+    /// # Errors
+    ///
+    /// Returns [`NodeError`] if relay binding, identity generation, or TLS
+    /// provisioning fails.
+    pub async fn dev(port: u16) -> Result<Self, NodeError> {
+        use scp_identity::DidCache;
+        use scp_identity::InMemoryDhtClient;
+        use scp_identity::cache::SystemClock;
+        use scp_identity::dht::DidDht;
+        use scp_platform::testing::{InMemoryKeyCustody, InMemoryStorage};
+
+        type DevDidDht = DidDht<InMemoryDhtClient, SystemClock>;
+
+        let custody = Arc::new(InMemoryKeyCustody::new());
+        let dht_client = Arc::new(InMemoryDhtClient::new());
+        let cache = Arc::new(DidCache::new());
+        let sign_fn = DevDidDht::make_sign_fn(Arc::clone(&custody));
+        let did_method = Arc::new(DevDidDht::with_client_and_signer(
+            dht_client, cache, sign_fn,
+        ));
+
+        ApplicationNodeBuilder::new()
+            .storage(InMemoryStorage::new())
+            .domain("localhost")
+            .bind_addr(std::net::SocketAddr::from(([127, 0, 0, 1], port)))
+            .tls_provider(Arc::new(SelfSignedTlsProvider::new("localhost")))
+            .generate_identity_with(custody, did_method)
+            .build_for_testing()
+            .await
     }
 }
 
@@ -968,6 +1039,48 @@ impl<S: Storage + 'static> TlsProvider for tls::AcmeProvider<S> {
 
     fn needs_challenge_listener(&self) -> bool {
         true
+    }
+}
+
+/// TLS provider that generates a self-signed certificate for development.
+///
+/// Uses [`tls::generate_self_signed`] to create a certificate valid for the
+/// given domain. **Not for production use** — browsers and other TLS clients
+/// will reject the certificate unless configured to trust it.
+///
+/// This provider is used internally by [`ApplicationNode::dev`] and is also
+/// available for custom builder configurations during development.
+///
+/// Requires the `allow_unencrypted_storage` feature flag (or `#[cfg(test)]`).
+#[cfg(any(test, feature = "allow_unencrypted_storage"))]
+pub struct SelfSignedTlsProvider {
+    domain: String,
+}
+
+#[cfg(any(test, feature = "allow_unencrypted_storage"))]
+impl SelfSignedTlsProvider {
+    /// Creates a new self-signed TLS provider for the given domain.
+    #[must_use]
+    pub fn new(domain: &str) -> Self {
+        Self {
+            domain: domain.to_owned(),
+        }
+    }
+}
+
+#[cfg(any(test, feature = "allow_unencrypted_storage"))]
+impl TlsProvider for SelfSignedTlsProvider {
+    fn provision(
+        &self,
+    ) -> std::pin::Pin<
+        Box<
+            dyn std::future::Future<Output = Result<tls::CertificateData, tls::TlsError>>
+                + Send
+                + '_,
+        >,
+    > {
+        let domain = self.domain.clone();
+        Box::pin(async move { tls::generate_self_signed(&domain) })
     }
 }
 

--- a/crates/scp-node/tests/integration.rs
+++ b/crates/scp-node/tests/integration.rs
@@ -864,3 +864,45 @@ async fn scenario8_projection_endpoints_coexist_with_well_known() {
         "message endpoint should return 404 for unknown routing_id"
     );
 }
+
+// ---------------------------------------------------------------------------
+// ApplicationNode::dev() convenience constructor
+// ---------------------------------------------------------------------------
+
+/// Verifies that `ApplicationNode::dev(port)` creates a fully functional node
+/// with in-memory storage, auto-generated DID identity, self-signed TLS, and
+/// a relay bound to localhost.
+#[tokio::test]
+async fn dev_constructor_creates_working_node() {
+    use scp_node::ApplicationNode;
+
+    // Port 0 lets the OS assign an available port.
+    let node = ApplicationNode::dev(0).await.unwrap();
+
+    // Identity was auto-generated with did:dht method.
+    assert!(
+        node.identity().did().starts_with("did:dht:"),
+        "DID should start with did:dht:, got: {}",
+        node.identity().did()
+    );
+
+    // DID document has an SCPRelay service entry pointing to localhost.
+    let relay_urls = node.identity().document().relay_service_urls();
+    assert_eq!(relay_urls.len(), 1);
+    assert_eq!(relay_urls[0], "wss://localhost/scp/v1");
+
+    // Domain is "localhost".
+    assert_eq!(node.domain(), Some("localhost"));
+    assert_eq!(node.relay_url(), "wss://localhost/scp/v1");
+
+    // Relay is actually bound to a real port on localhost.
+    let addr = node.relay().bound_addr();
+    assert!(addr.ip().is_loopback(), "relay should be bound to loopback");
+    assert_ne!(addr.port(), 0, "relay should be bound to a real port");
+
+    // Storage is accessible.
+    let _storage = node.storage();
+
+    // Clean shutdown.
+    node.shutdown();
+}


### PR DESCRIPTION
Closes #531

## Summary
- Added `ApplicationNode::dev(port)` — one-line dev/demo node setup
- Auto-wires InMemoryKeyCustody, InMemoryStorage, InMemoryDhtClient, SelfSignedTlsProvider
- Added public `SelfSignedTlsProvider` (was duplicated as private in 3 places)
- Feature-gated behind `allow_unencrypted_storage`
- Integration test verifies identity, relay binding, and clean shutdown

## Review Cycles
- Cycles: 1
- Findings resolved: 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)