### PR TITLE
fix(docs): update 50 PRD story statuses for implemented features (closes #638)

### DIFF
--- a/.docs/prds/bridge-cooperative.json
+++ b/.docs/prds/bridge-cooperative.json
@@ -6,7 +6,7 @@
       "id": "gate-bridge-http-binding",
       "name": "Cooperative Mode HTTP Binding Endpoints",
       "priority": "P1",
-      "status": "pending",
+      "status": "done",
       "stories": [
         "SCP-BCH-001",
         "SCP-BCH-002",
@@ -21,7 +21,7 @@
       "id": "gate-bridge-credential-lifecycle",
       "name": "Bridge Credential Lifecycle",
       "priority": "P1",
-      "status": "pending",
+      "status": "done",
       "stories": [
         "SCP-BCH-008",
         "SCP-BCH-009"
@@ -31,7 +31,7 @@
       "id": "gate-bridge-sender-key",
       "name": "Bridge Sender Key Encryption Model",
       "priority": "P1",
-      "status": "pending",
+      "status": "done",
       "stories": [
         "SCP-BCH-010",
         "SCP-BCH-011",
@@ -47,7 +47,7 @@
       "gate": "gate-bridge-http-binding",
       "priority": "P0",
       "severity": "critical",
-      "status": "pending",
+      "status": "done",
       "files": [
         "crates/scp-node/src/bridge_auth.rs",
         "crates/scp-node/src/lib.rs"
@@ -99,7 +99,7 @@
       "gate": "gate-bridge-http-binding",
       "priority": "P1",
       "severity": "critical",
-      "status": "pending",
+      "status": "done",
       "files": [
         "crates/scp-node/src/bridge_handlers.rs",
         "crates/scp-node/src/lib.rs"
@@ -144,7 +144,7 @@
       "gate": "gate-bridge-http-binding",
       "priority": "P1",
       "severity": "critical",
-      "status": "pending",
+      "status": "done",
       "files": [
         "crates/scp-node/src/bridge_handlers.rs"
       ],
@@ -188,7 +188,7 @@
       "gate": "gate-bridge-http-binding",
       "priority": "P1",
       "severity": "major",
-      "status": "pending",
+      "status": "done",
       "files": [
         "crates/scp-node/src/bridge_handlers.rs"
       ],
@@ -230,7 +230,7 @@
       "gate": "gate-bridge-http-binding",
       "priority": "P1",
       "severity": "major",
-      "status": "pending",
+      "status": "done",
       "files": [
         "crates/scp-node/src/bridge_handlers.rs"
       ],
@@ -275,7 +275,7 @@
       "gate": "gate-bridge-http-binding",
       "priority": "P1",
       "severity": "critical",
-      "status": "pending",
+      "status": "done",
       "files": [
         "crates/scp-node/src/bridge_handlers.rs",
         "crates/scp-node/src/bridge_webhook.rs",
@@ -325,7 +325,7 @@
       "gate": "gate-bridge-http-binding",
       "priority": "P1",
       "severity": "major",
-      "status": "pending",
+      "status": "done",
       "files": [
         "crates/scp-node/src/http.rs",
         "crates/scp-node/src/lib.rs",
@@ -378,7 +378,7 @@
       "gate": "gate-bridge-credential-lifecycle",
       "priority": "P1",
       "severity": "major",
-      "status": "pending",
+      "status": "done",
       "files": [
         "crates/scp-core/src/bridge/credentials.rs",
         "crates/scp-core/src/bridge/mod.rs"
@@ -430,7 +430,7 @@
       "gate": "gate-bridge-credential-lifecycle",
       "priority": "P1",
       "severity": "major",
-      "status": "pending",
+      "status": "done",
       "files": [
         "crates/scp-core/src/bridge/credentials.rs",
         "crates/scp-core/src/bridge/oauth.rs",
@@ -489,7 +489,7 @@
       "gate": "gate-bridge-sender-key",
       "priority": "P1",
       "severity": "critical",
-      "status": "pending",
+      "status": "done",
       "files": [
         "crates/scp-core/src/bridge/shadow.rs",
         "crates/scp-core/src/crypto/sender_keys/mod.rs"
@@ -528,7 +528,7 @@
       "gate": "gate-bridge-sender-key",
       "priority": "P1",
       "severity": "critical",
-      "status": "pending",
+      "status": "done",
       "files": [
         "crates/scp-core/src/crypto/sender_keys/key_protocol.rs",
         "crates/scp-core/src/bridge/mod.rs"
@@ -574,7 +574,7 @@
       "gate": "gate-bridge-sender-key",
       "priority": "P1",
       "severity": "critical",
-      "status": "pending",
+      "status": "done",
       "files": [
         "crates/scp-core/src/bridge/mod.rs",
         "crates/scp-core/src/envelope/inner.rs"
@@ -621,7 +621,7 @@
       "gate": "gate-bridge-sender-key",
       "priority": "P1",
       "severity": "critical",
-      "status": "pending",
+      "status": "done",
       "files": [
         "crates/scp-core/src/bridge/registration.rs",
         "crates/scp-core/src/context/params.rs"

--- a/.docs/prds/capability-registry.json
+++ b/.docs/prds/capability-registry.json
@@ -6,7 +6,7 @@
       "id": "gate-uri-parser",
       "name": "Capability URI Parser and Registry",
       "priority": "P0",
-      "status": "pending",
+      "status": "done",
       "stories": [
         "SCP-ACR-001",
         "SCP-ACR-002"
@@ -16,7 +16,7 @@
       "id": "gate-challenge-unification",
       "name": "ChallengeType URI Unification",
       "priority": "P0",
-      "status": "pending",
+      "status": "done",
       "stories": [
         "SCP-ACR-003",
         "SCP-ACR-004"
@@ -26,7 +26,7 @@
       "id": "gate-did-capabilities",
       "name": "DID Capability Entry Update",
       "priority": "P1",
-      "status": "pending",
+      "status": "done",
       "stories": [
         "SCP-ACR-005",
         "SCP-ACR-006"
@@ -36,7 +36,7 @@
       "id": "gate-admission",
       "name": "Context Admission Capability Requirements",
       "priority": "P1",
-      "status": "pending",
+      "status": "done",
       "stories": [
         "SCP-ACR-007"
       ]
@@ -49,7 +49,7 @@
       "gate": "gate-uri-parser",
       "priority": "P0",
       "severity": "critical",
-      "status": "pending",
+      "status": "done",
       "files": [
         "crates/scp-core/src/trust/capability_uri.rs",
         "crates/scp-core/src/trust/mod.rs"
@@ -98,7 +98,7 @@
       "gate": "gate-uri-parser",
       "priority": "P0",
       "severity": "critical",
-      "status": "pending",
+      "status": "done",
       "files": [
         "crates/scp-core/src/trust/capability_registry.rs",
         "crates/scp-core/src/trust/mod.rs"
@@ -151,7 +151,7 @@
       "gate": "gate-challenge-unification",
       "priority": "P0",
       "severity": "critical",
-      "status": "pending",
+      "status": "done",
       "files": [
         "crates/scp-core/src/trust/challenge.rs"
       ],
@@ -200,7 +200,7 @@
       "gate": "gate-challenge-unification",
       "priority": "P0",
       "severity": "major",
-      "status": "pending",
+      "status": "done",
       "files": [
         "crates/scp-core/src/trust/challenge.rs",
         "crates/scp-core/src/trust/capability_registry.rs"
@@ -245,7 +245,7 @@
       "gate": "gate-did-capabilities",
       "priority": "P1",
       "severity": "major",
-      "status": "pending",
+      "status": "done",
       "files": [
         "crates/scp-core/src/discovery/did_capabilities.rs"
       ],
@@ -289,7 +289,7 @@
       "gate": "gate-did-capabilities",
       "priority": "P1",
       "severity": "moderate",
-      "status": "pending",
+      "status": "done",
       "files": [
         "crates/scp-core/src/discovery/did_capabilities.rs"
       ],
@@ -328,7 +328,7 @@
       "gate": "gate-admission",
       "priority": "P1",
       "severity": "major",
-      "status": "pending",
+      "status": "done",
       "files": [
         "crates/scp-core/src/context/params.rs",
         "crates/scp-core/src/trust/capability_uri.rs"

--- a/.docs/prds/content-access.json
+++ b/.docs/prds/content-access.json
@@ -6,7 +6,7 @@
       "id": "gate-identity-blocking",
       "name": "Identity-Level Blocking Foundation",
       "priority": "P1",
-      "status": "pending",
+      "status": "done",
       "stories": [
         "SCP-CAC-001",
         "SCP-CAC-002",
@@ -17,7 +17,7 @@
       "id": "gate-access-key-layer",
       "name": "Content Access Key Layer (Layer 3)",
       "priority": "P1",
-      "status": "pending",
+      "status": "done",
       "stories": [
         "SCP-CAC-004",
         "SCP-CAC-005",
@@ -28,7 +28,7 @@
       "id": "gate-governance-content-access",
       "name": "Governance Content Access Actions",
       "priority": "P1",
-      "status": "pending",
+      "status": "done",
       "stories": [
         "SCP-CAC-007",
         "SCP-CAC-008"
@@ -38,7 +38,7 @@
       "id": "gate-integration",
       "name": "Content Access Integration Testing",
       "priority": "P1",
-      "status": "pending",
+      "status": "done",
       "stories": [
         "SCP-CAC-009",
         "SCP-CAC-010"
@@ -52,7 +52,7 @@
       "gate": "gate-identity-blocking",
       "priority": "P1",
       "severity": "critical",
-      "status": "pending",
+      "status": "done",
       "files": [
         "crates/scp-core/src/identity/block_list.rs",
         "crates/scp-core/src/identity/mod.rs",
@@ -101,7 +101,7 @@
       "gate": "gate-identity-blocking",
       "priority": "P1",
       "severity": "critical",
-      "status": "pending",
+      "status": "done",
       "files": [
         "crates/scp-core/src/identity/blocking.rs",
         "crates/scp-core/src/identity/mod.rs",
@@ -169,7 +169,7 @@
       "gate": "gate-identity-blocking",
       "priority": "P1",
       "severity": "critical",
-      "status": "pending",
+      "status": "done",
       "files": [
         "crates/scp-core/src/identity/blocking.rs",
         "crates/scp-core/src/identity/mod.rs"
@@ -216,7 +216,7 @@
       "gate": "gate-access-key-layer",
       "priority": "P1",
       "severity": "critical",
-      "status": "pending",
+      "status": "done",
       "files": [
         "crates/scp-core/src/crypto/access_keys/mod.rs",
         "crates/scp-core/src/crypto/access_keys/lifecycle.rs",
@@ -273,7 +273,7 @@
       "gate": "gate-access-key-layer",
       "priority": "P1",
       "severity": "critical",
-      "status": "pending",
+      "status": "done",
       "files": [
         "crates/scp-core/src/crypto/access_keys/wrapping.rs",
         "crates/scp-core/src/crypto/access_keys/mod.rs"
@@ -332,7 +332,7 @@
       "gate": "gate-access-key-layer",
       "priority": "P1",
       "severity": "critical",
-      "status": "pending",
+      "status": "done",
       "files": [
         "crates/scp-core/src/crypto/sender_keys/mod.rs",
         "crates/scp-core/src/crypto/access_keys/lifecycle.rs",
@@ -400,7 +400,7 @@
       "gate": "gate-governance-content-access",
       "priority": "P1",
       "severity": "critical",
-      "status": "pending",
+      "status": "done",
       "files": [
         "crates/scp-core/src/context/governance/mod.rs",
         "crates/scp-core/src/context/manager.rs",
@@ -465,7 +465,7 @@
       "gate": "gate-governance-content-access",
       "priority": "P1",
       "severity": "major",
-      "status": "pending",
+      "status": "done",
       "files": [
         "crates/scp-core/src/context/broadcast.rs",
         "crates/scp-core/src/context/manager.rs"
@@ -511,7 +511,7 @@
       "gate": "gate-integration",
       "priority": "P1",
       "severity": "major",
-      "status": "pending",
+      "status": "done",
       "files": [
         "crates/scp-core/tests/content_access_integration.rs"
       ],
@@ -564,7 +564,7 @@
       "gate": "gate-integration",
       "priority": "P1",
       "severity": "major",
-      "status": "pending",
+      "status": "done",
       "files": [
         "crates/scp-core/tests/content_access_governance_integration.rs"
       ],

--- a/.docs/prds/governance-gaps.json
+++ b/.docs/prds/governance-gaps.json
@@ -6,7 +6,7 @@
       "id": "gate-foundation-types",
       "name": "Foundation Types",
       "priority": "P0",
-      "status": "pending",
+      "status": "done",
       "stories": [
         "SCP-GG-001",
         "SCP-GG-002"
@@ -16,7 +16,7 @@
       "id": "gate-metadata-visibility",
       "name": "Metadata Visibility",
       "priority": "P1",
-      "status": "pending",
+      "status": "done",
       "stories": [
         "SCP-GG-003",
         "SCP-GG-004"
@@ -26,7 +26,7 @@
       "id": "gate-governance-bans",
       "name": "Governance Bans",
       "priority": "P1",
-      "status": "pending",
+      "status": "done",
       "stories": [
         "SCP-GG-005",
         "SCP-GG-006"
@@ -36,7 +36,7 @@
       "id": "gate-projection-auth",
       "name": "Projection Auth",
       "priority": "P1",
-      "status": "pending",
+      "status": "done",
       "stories": [
         "SCP-GG-007",
         "SCP-GG-008"
@@ -50,7 +50,7 @@
       "gate": "gate-foundation-types",
       "priority": "P0",
       "severity": "critical",
-      "status": "pending",
+      "status": "done",
       "files": [
         "crates/scp-core/src/context/roles.rs",
         "crates/scp-core/src/context/params.rs"
@@ -107,7 +107,7 @@
       "gate": "gate-foundation-types",
       "priority": "P0",
       "severity": "critical",
-      "status": "pending",
+      "status": "done",
       "files": [
         "crates/scp-core/src/context/governance/mod.rs",
         "crates/scp-core/src/context/governance/mls_integration.rs",
@@ -151,7 +151,7 @@
       "gate": "gate-metadata-visibility",
       "priority": "P0",
       "severity": "major",
-      "status": "pending",
+      "status": "done",
       "files": [
         "crates/scp-core/src/context/templates.rs"
       ],
@@ -199,7 +199,7 @@
       "gate": "gate-metadata-visibility",
       "priority": "P1",
       "severity": "major",
-      "status": "pending",
+      "status": "done",
       "files": [
         "crates/scp-core/src/context/params.rs"
       ],
@@ -239,7 +239,7 @@
       "gate": "gate-governance-bans",
       "priority": "P1",
       "severity": "major",
-      "status": "pending",
+      "status": "done",
       "files": [
         "crates/scp-core/src/context/broadcast.rs"
       ],
@@ -285,7 +285,7 @@
       "gate": "gate-governance-bans",
       "priority": "P1",
       "severity": "major",
-      "status": "pending",
+      "status": "done",
       "files": [
         "crates/scp-core/src/context/manager.rs"
       ],
@@ -333,7 +333,7 @@
       "gate": "gate-projection-auth",
       "priority": "P1",
       "severity": "major",
-      "status": "pending",
+      "status": "done",
       "files": [
         "crates/scp-node/src/projection.rs",
         "crates/scp-node/src/lib.rs"
@@ -376,7 +376,7 @@
       "gate": "gate-projection-auth",
       "priority": "P1",
       "severity": "critical",
-      "status": "pending",
+      "status": "done",
       "files": [
         "crates/scp-node/src/projection.rs"
       ],

--- a/.docs/prds/governance-integration.json
+++ b/.docs/prds/governance-integration.json
@@ -6,7 +6,7 @@
       "id": "gate-gov-wiring",
       "name": "Governance-Manager Wiring",
       "priority": "P1",
-      "status": "pending",
+      "status": "done",
       "stories": [
         "SCP-267",
         "SCP-268",
@@ -143,7 +143,7 @@
       "gate": "gate-gov-wiring",
       "priority": "P1",
       "severity": "critical",
-      "status": "pending",
+      "status": "done",
       "files": [
         "crates/scp-core/src/context/governance/mod.rs",
         "crates/scp-core/src/context/mod.rs",
@@ -213,7 +213,7 @@
       "gate": "gate-gov-wiring",
       "priority": "P1",
       "severity": "critical",
-      "status": "pending",
+      "status": "done",
       "files": [
         "crates/scp-core/src/context/manager.rs",
         "crates/scp-core/src/context/mod.rs"
@@ -280,7 +280,7 @@
       "gate": "gate-gov-wiring",
       "priority": "P1",
       "severity": "major",
-      "status": "pending",
+      "status": "done",
       "files": [
         "crates/scp-core/src/context/manager.rs",
         "crates/scp-core/src/context/governance/mod.rs"
@@ -344,7 +344,7 @@
       "gate": "gate-gov-wiring",
       "priority": "P1",
       "severity": "major",
-      "status": "pending",
+      "status": "done",
       "files": [
         "crates/scp-core/src/context/manager.rs",
         "crates/scp-core/src/context/governance/mod.rs"
@@ -395,7 +395,7 @@
       "gate": "gate-gov-wiring",
       "priority": "P1",
       "severity": "major",
-      "status": "pending",
+      "status": "done",
       "files": [
         "crates/scp-core/src/store/mod.rs",
         "crates/scp-core/src/context/governance/mod.rs"
@@ -443,7 +443,7 @@
       "gate": "gate-gov-wiring",
       "priority": "P1",
       "severity": "major",
-      "status": "pending",
+      "status": "done",
       "files": [
         "crates/scp-core/tests/governance_integration.rs"
       ],

--- a/.docs/prds/participation-admission.json
+++ b/.docs/prds/participation-admission.json
@@ -6,7 +6,7 @@
       "id": "gate-participation-admission-types",
       "name": "Participation Admission Types and Context Integration",
       "priority": "P1",
-      "status": "pending",
+      "status": "done",
       "stories": [
         "SCP-BA-001",
         "SCP-BA-002"
@@ -16,7 +16,7 @@
       "id": "gate-participation-admission-production",
       "name": "Context-Hosted Statement Production and Discovery",
       "priority": "P1",
-      "status": "pending",
+      "status": "done",
       "stories": [
         "SCP-BA-005",
         "SCP-BA-006"
@@ -26,7 +26,7 @@
       "id": "gate-participation-admission-verification",
       "name": "Participation Admission Verification and FFI",
       "priority": "P1",
-      "status": "pending",
+      "status": "done",
       "stories": [
         "SCP-BA-003",
         "SCP-BA-004"
@@ -40,7 +40,7 @@
       "gate": "gate-participation-admission-types",
       "priority": "P0",
       "severity": "critical",
-      "status": "pending",
+      "status": "done",
       "files": [
         "crates/scp-core/src/trust/participation.rs",
         "crates/scp-core/src/trust/mod.rs"
@@ -95,7 +95,7 @@
       "gate": "gate-participation-admission-types",
       "priority": "P0",
       "severity": "critical",
-      "status": "pending",
+      "status": "done",
       "files": [
         "crates/scp-core/src/context/params.rs",
         "crates/scp-core/src/context/mod.rs"
@@ -137,7 +137,7 @@
       "gate": "gate-participation-admission-verification",
       "priority": "P1",
       "severity": "critical",
-      "status": "pending",
+      "status": "done",
       "files": [
         "crates/scp-core/src/trust/participation.rs",
         "crates/scp-core/src/trust/mod.rs"
@@ -193,7 +193,7 @@
       "gate": "gate-participation-admission-verification",
       "priority": "P1",
       "severity": "major",
-      "status": "pending",
+      "status": "done",
       "files": [
         "bindings/python/src/trust.rs",
         "bindings/python/src/context.rs",
@@ -239,7 +239,7 @@
       "gate": "gate-participation-admission-production",
       "priority": "P1",
       "severity": "critical",
-      "status": "pending",
+      "status": "done",
       "files": [
         "crates/scp-core/src/trust/participation.rs",
         "crates/scp-core/src/trust/mod.rs",
@@ -297,7 +297,7 @@
       "gate": "gate-participation-admission-production",
       "priority": "P1",
       "severity": "critical",
-      "status": "pending",
+      "status": "done",
       "files": [
         "crates/scp-core/src/identity/did_document.rs",
         "crates/scp-core/src/identity/mod.rs"


### PR DESCRIPTION
Closes #638

## Summary
- Updated 50 PRD stories from "pending" to "done" across 6 PRD files
- Updated 19 parent gate statuses
- Each story verified against actual code before status change
- `validate-prd.py` passes (12 files, 348 stories)

### PRD files updated:
- bridge-cooperative.json: 13 stories (SCP-BCH-001–013)
- capability-registry.json: 7 stories (SCP-ACR-001–007)
- content-access.json: 10 stories (SCP-CAC-001–010)
- governance-gaps.json: 8 stories (SCP-GG-001–008)
- governance-integration.json: 6 stories (SCP-269–274)
- participation-admission.json: 6 stories (SCP-BA-001–006)

## Review Cycles
- Cycles: 1
- Findings resolved: 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)