### PR TITLE
feat(economy): implement 24h notification period for economic policy changes (closes #728)

### DIFF
--- a/crates/scp-core/src/context/export_import.rs
+++ b/crates/scp-core/src/context/export_import.rs
@@ -293,6 +293,7 @@ fn strip_snapshot_for_public(snapshot: &ContextSnapshot) -> ContextSnapshot {
         approved_proposals: HashMap::new(),
         governance_freeze: None,
         pending_ceiling_modification: None,
+        pending_economic_policy_change: None,
         mls_epoch: 0,
         // Epoch coordination records are stripped in public scope —
         // they are auditable but internal governance state.
@@ -399,6 +400,7 @@ mod tests {
             approved_proposals: HashMap::new(),
             governance_freeze: None,
             pending_ceiling_modification: None,
+            pending_economic_policy_change: None,
             mls_epoch: 0,
             epoch_coordination_records: Vec::new(),
             grace_entries: Vec::new(),

--- a/crates/scp-core/src/context/manager.rs
+++ b/crates/scp-core/src/context/manager.rs
@@ -108,6 +108,48 @@ impl PendingCeilingModification {
     }
 }
 
+/// Default economic policy change notification period in seconds (§19.3).
+///
+/// When a governed context's economic policy is changed, the new policy is
+/// pending for this duration before taking effect. Members are notified and
+/// may leave before the new pricing applies.
+///
+/// Spec §19.3: "economic policy changes MUST NOT take effect sooner than
+/// 24 hours after the `EconomicPolicyChanged` event."
+const ECONOMIC_POLICY_NOTIFICATION_PERIOD_SECS: u64 = 86_400; // 24 hours
+
+// ---------------------------------------------------------------------------
+// PendingEconomicPolicyChange (§19.3)
+// ---------------------------------------------------------------------------
+
+/// A pending economic policy change awaiting notification period expiry (§19.3).
+///
+/// When a `SetEconomicPolicy` governance action is approved, the new policy
+/// is not applied immediately. Instead, it enters a 24-hour notification
+/// period during which the previous policy remains in effect. Members may
+/// leave before the new pricing applies.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PendingEconomicPolicyChange {
+    /// The proposed new economic policy.
+    pub new_policy: EconomicPolicy,
+    /// Unix timestamp (seconds) when the notification period started.
+    pub notified_at: u64,
+    /// Unix timestamp (seconds) when the notification period expires and
+    /// the new policy can be applied.
+    pub effective_at: u64,
+    /// The governance proposal ID that approved this change.
+    pub proposal_id: ProposalId,
+}
+
+impl PendingEconomicPolicyChange {
+    /// Returns `true` if the notification period has expired and the
+    /// new policy can be applied.
+    #[must_use]
+    pub const fn is_effective(&self, current_timestamp: u64) -> bool {
+        current_timestamp >= self.effective_at
+    }
+}
+
 // GovernanceActionResult
 // ---------------------------------------------------------------------------
 
@@ -351,6 +393,14 @@ pub struct ContextSnapshot {
     /// Format: `(new_ceiling_capabilities, notification_timestamp, proposal_id)`.
     #[serde(default)]
     pub pending_ceiling_modification: Option<PendingCeilingModification>,
+    /// Pending economic policy change (§19.3 notification period).
+    ///
+    /// When a `SetEconomicPolicy` governance action is approved, the new
+    /// policy is stored here with the notification timestamp. Members are
+    /// notified and the previous policy remains in effect until the 24-hour
+    /// notification period expires.
+    #[serde(default)]
+    pub pending_economic_policy_change: Option<PendingEconomicPolicyChange>,
     /// Monotonic MLS epoch counter. Tracks epoch advances from membership-
     /// mutating governance actions (`AddMember`, `RemoveMember`,
     /// `RevokeReadAccess`, `ResetMember`).
@@ -549,6 +599,8 @@ struct PerContextState {
     pending_epoch_resets: Vec<DID>,
     /// Pending ceiling modification awaiting notification period (M7, §5.3.2).
     pending_ceiling_modification: Option<PendingCeilingModification>,
+    /// Pending economic policy change awaiting notification period (§19.3).
+    pending_economic_policy_change: Option<PendingEconomicPolicyChange>,
     /// Monotonic MLS epoch counter. Incremented each time a governance action
     /// triggers an MLS membership change (`AddMember`, `RemoveMember`,
     /// `RevokeReadAccess`, `ResetMember`). Used to populate
@@ -1448,6 +1500,7 @@ impl ContextManager {
             approved_proposals: ctx.approved_proposals.clone(),
             governance_freeze: ctx.governance_freeze,
             pending_ceiling_modification: ctx.pending_ceiling_modification.clone(),
+            pending_economic_policy_change: ctx.pending_economic_policy_change.clone(),
             mls_epoch: ctx.mls_epoch,
             epoch_coordination_records: ctx.epoch_coordinator.records().to_vec(),
             grace_entries,
@@ -1594,6 +1647,7 @@ impl ContextManager {
             last_known_members: initial_members,
             pending_epoch_resets: Vec::new(),
             pending_ceiling_modification: ctx_snapshot.pending_ceiling_modification,
+            pending_economic_policy_change: ctx_snapshot.pending_economic_policy_change,
             mls_epoch: ctx_snapshot.mls_epoch,
             epoch_coordinator: EpochCoordinator::from_records(
                 ctx_snapshot.epoch_coordination_records,
@@ -2018,6 +2072,7 @@ impl ContextManager {
             last_known_members: initial_members,
             pending_epoch_resets: Vec::new(),
             pending_ceiling_modification: export.snapshot.pending_ceiling_modification,
+            pending_economic_policy_change: export.snapshot.pending_economic_policy_change,
             mls_epoch: export.snapshot.mls_epoch,
             epoch_coordinator: EpochCoordinator::from_records(
                 export.snapshot.epoch_coordination_records,
@@ -2161,6 +2216,7 @@ impl ContextManager {
             last_known_members: initial_members,
             pending_epoch_resets: Vec::new(),
             pending_ceiling_modification: None,
+            pending_economic_policy_change: None,
             mls_epoch: 0,
             epoch_coordinator: EpochCoordinator::new(),
             grace_store: crate::crypto::mls::epoch_grace::EpochGraceStore::new(),
@@ -2418,6 +2474,7 @@ impl ContextManager {
             last_known_members: HashSet::new(),
             pending_epoch_resets: Vec::new(),
             pending_ceiling_modification: None,
+            pending_economic_policy_change: None,
             mls_epoch: 0,
             epoch_coordinator: EpochCoordinator::new(),
             grace_store: crate::crypto::mls::epoch_grace::EpochGraceStore::new(),
@@ -6151,21 +6208,28 @@ impl ContextManager {
         Ok(())
     }
 
-    /// Sets or updates the economic policy for a context (§19.3, ADR-033).
+    /// Stages an economic policy change with a 24-hour notification period
+    /// (§19.3, ADR-033).
     ///
-    /// If the existing policy is locked, rejects the change. If the new policy
-    /// has `locked: true`, it becomes immutable after this action.
+    /// The new policy is NOT applied immediately. Instead, it enters a
+    /// notification period during which the previous policy remains in effect.
+    /// Members are notified via [`ContextEvent::EconomicPolicyChangeNotification`]
+    /// and may leave before the new pricing applies.
+    ///
+    /// Call [`apply_pending_economic_policy_change`](Self::apply_pending_economic_policy_change)
+    /// after the notification period expires to apply the change.
     ///
     /// # Errors
     ///
-    /// - [`ContextError::PermissionDenied`] if the existing policy is locked.
+    /// - [`ContextError::PermissionDenied`] if the existing policy is locked
+    ///   or an economic policy change is already pending.
     /// - [`ContextError::MembershipFailed`] if the context is not registered.
     /// - [`ContextError::ContextNotActive`] if the context is not active.
     async fn execute_set_economic_policy(
         &self,
         context_id: &str,
         policy: &EconomicPolicy,
-        _proposal_id: ProposalId,
+        proposal_id: ProposalId,
     ) -> Result<(), ContextError> {
         let context_id_bytes = context_id_to_bytes(context_id);
 
@@ -6185,7 +6249,32 @@ impl ContextManager {
                 ));
             }
 
-            ctx.economic_policy = Some(policy.clone());
+            // Reject if an economic policy change is already pending.
+            if ctx.pending_economic_policy_change.is_some() {
+                return Err(ContextError::PermissionDenied(
+                    "an economic policy change is already pending notification period".to_owned(),
+                ));
+            }
+
+            // §19.3: Stage the change with a 24-hour notification period.
+            let now = crate::time::now_secs()
+                .map_err(|e| ContextError::PermissionDenied(format!("clock error: {e}")))?;
+            let effective_at = now + ECONOMIC_POLICY_NOTIFICATION_PERIOD_SECS;
+            ctx.pending_economic_policy_change = Some(PendingEconomicPolicyChange {
+                new_policy: policy.clone(),
+                notified_at: now,
+                effective_at,
+                proposal_id,
+            });
+
+            // §19.3: Notify all members of the pending change.
+            ctx.receive_buffer
+                .push(ContextEvent::EconomicPolicyChangeNotification {
+                    notified_at: now,
+                    effective_at,
+                    proposal_id,
+                });
+
             if self.has_persistence() {
                 Some(Self::snapshot_context(ctx))
             } else {
@@ -6199,6 +6288,57 @@ impl ContextManager {
         self.event_log
             .append_context_event(&context_id_bytes, "EconomicPolicyChanged")?;
         Ok(())
+    }
+
+    /// Applies a pending economic policy change if its notification period
+    /// has expired (§19.3).
+    ///
+    /// Returns `true` if the pending change was applied, `false` if there
+    /// was no pending change or the notification period has not yet expired.
+    ///
+    /// # Errors
+    ///
+    /// Returns `ContextError` if the context is not found or is not active.
+    pub async fn apply_pending_economic_policy_change(
+        &self,
+        context_id: &str,
+        current_timestamp: u64,
+    ) -> Result<bool, ContextError> {
+        let context_id_bytes = context_id_to_bytes(context_id);
+
+        let (applied, snapshot) = {
+            let mut contexts = self.contexts.lock().await;
+            let ctx = contexts
+                .get_mut(context_id)
+                .ok_or_else(|| ContextError::MembershipFailed("context not registered".into()))?;
+            require_active(&ctx.handle)?;
+
+            let pending = match &ctx.pending_economic_policy_change {
+                Some(p) if p.is_effective(current_timestamp) => p.clone(),
+                _ => return Ok(false),
+            };
+
+            // Apply the pending policy.
+            ctx.economic_policy = Some(pending.new_policy);
+            ctx.pending_economic_policy_change = None;
+
+            let snap = if self.has_persistence() {
+                Some(Self::snapshot_context(ctx))
+            } else {
+                None
+            };
+            (true, snap)
+        };
+
+        if applied {
+            if let Some(snapshot) = snapshot {
+                self.persist_context_snapshot(context_id, snapshot);
+            }
+            self.event_log
+                .append_context_event(&context_id_bytes, "EconomicPolicyApplied")?;
+        }
+
+        Ok(applied)
     }
 
     /// Approves a spending authorization for a member (§19.5, ADR-033).
@@ -11469,6 +11609,7 @@ mod tests {
             approved_proposals: HashMap::new(),
             governance_freeze: None,
             pending_ceiling_modification: None,
+            pending_economic_policy_change: None,
             mls_epoch: 0,
             epoch_coordination_records: Vec::new(),
             grace_entries: Vec::new(),
@@ -11572,6 +11713,7 @@ mod tests {
             approved_proposals: HashMap::new(),
             governance_freeze: None,
             pending_ceiling_modification: None,
+            pending_economic_policy_change: None,
             mls_epoch: 0,
             epoch_coordination_records: Vec::new(),
             grace_entries: Vec::new(),
@@ -11663,6 +11805,7 @@ mod tests {
             approved_proposals: HashMap::new(),
             governance_freeze: None,
             pending_ceiling_modification: None,
+            pending_economic_policy_change: None,
             mls_epoch: 0,
             epoch_coordination_records: Vec::new(),
             grace_entries: Vec::new(),
@@ -11733,6 +11876,7 @@ mod tests {
                 approved_proposals: HashMap::new(),
                 governance_freeze: None,
                 pending_ceiling_modification: None,
+                pending_economic_policy_change: None,
                 mls_epoch: 0,
                 epoch_coordination_records: Vec::new(),
                 grace_entries: Vec::new(),
@@ -11802,6 +11946,7 @@ mod tests {
             approved_proposals: HashMap::new(),
             governance_freeze: None,
             pending_ceiling_modification: None,
+            pending_economic_policy_change: None,
             mls_epoch: 0,
             epoch_coordination_records: Vec::new(),
             grace_entries: Vec::new(),
@@ -11890,6 +12035,7 @@ mod tests {
             approved_proposals: HashMap::new(),
             governance_freeze: None,
             pending_ceiling_modification: None,
+            pending_economic_policy_change: None,
             mls_epoch: 3,
             epoch_coordination_records: Vec::new(),
             grace_entries: vec![GraceEntry {
@@ -11988,6 +12134,7 @@ mod tests {
             approved_proposals: HashMap::new(),
             governance_freeze: None,
             pending_ceiling_modification: None,
+            pending_economic_policy_change: None,
             mls_epoch: 3,
             epoch_coordination_records: Vec::new(),
             grace_entries: vec![GraceEntry {
@@ -12075,6 +12222,7 @@ mod tests {
             approved_proposals: HashMap::new(),
             governance_freeze: None,
             pending_ceiling_modification: None,
+            pending_economic_policy_change: None,
             mls_epoch,
             grace_entries: grace,
             needs_reconnect: false,
@@ -12137,7 +12285,7 @@ mod tests {
 
         let result = manager
             .prepare_reconnection(
-                scp_identity::DID::from("did:dht:z6MkAlice"),
+                DID::from("did:dht:z6MkAlice"),
                 std::collections::HashMap::new(),
             )
             .await;
@@ -13303,6 +13451,7 @@ mod tests {
             approved_proposals: HashMap::new(),
             governance_freeze: None,
             pending_ceiling_modification: None,
+            pending_economic_policy_change: None,
             mls_epoch: 0,
             epoch_coordination_records: Vec::new(),
             grace_entries: Vec::new(),
@@ -16895,6 +17044,373 @@ mod tests {
                 "notification effective_at must be notified_at + 72h"
             );
         }
+    }
+
+    // -----------------------------------------------------------------------
+    // Economic policy notification period tests (§19.3, #728)
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn pending_economic_policy_change_effective_at_equals_notified_at_plus_86400() {
+        let notified_at = 1_000_000u64;
+        let pending = PendingEconomicPolicyChange {
+            new_policy: crate::economy::types::EconomicPolicy {
+                locked: false,
+                cost_schedule: crate::economy::types::CostSchedule {
+                    currency: crate::economy::types::CurrencyCode([85, 83, 68, 0]),
+                    per_message: None,
+                    per_tool_invoke: None,
+                    per_join: None,
+                    per_period: None,
+                    per_byte_stored: None,
+                },
+                payment_adapters: vec![],
+                pricing_formula: None,
+                payee: DID::from("did:dht:z6MkPayee"),
+            },
+            notified_at,
+            effective_at: notified_at + ECONOMIC_POLICY_NOTIFICATION_PERIOD_SECS,
+            proposal_id: [0u8; 32],
+        };
+        assert_eq!(
+            pending.effective_at,
+            notified_at + 86_400,
+            "effective_at must be notified_at + 24h (86,400s)"
+        );
+    }
+
+    #[test]
+    fn pending_economic_policy_is_effective_false_before_period_expires() {
+        let notified_at = 1_000_000u64;
+        let pending = PendingEconomicPolicyChange {
+            new_policy: crate::economy::types::EconomicPolicy {
+                locked: false,
+                cost_schedule: crate::economy::types::CostSchedule {
+                    currency: crate::economy::types::CurrencyCode([85, 83, 68, 0]),
+                    per_message: None,
+                    per_tool_invoke: None,
+                    per_join: None,
+                    per_period: None,
+                    per_byte_stored: None,
+                },
+                payment_adapters: vec![],
+                pricing_formula: None,
+                payee: DID::from("did:dht:z6MkPayee"),
+            },
+            notified_at,
+            effective_at: notified_at + ECONOMIC_POLICY_NOTIFICATION_PERIOD_SECS,
+            proposal_id: [0u8; 32],
+        };
+        assert!(
+            !pending.is_effective(pending.effective_at - 1),
+            "is_effective must return false before the notification period expires"
+        );
+    }
+
+    #[test]
+    fn pending_economic_policy_is_effective_true_after_period_expires() {
+        let notified_at = 1_000_000u64;
+        let pending = PendingEconomicPolicyChange {
+            new_policy: crate::economy::types::EconomicPolicy {
+                locked: false,
+                cost_schedule: crate::economy::types::CostSchedule {
+                    currency: crate::economy::types::CurrencyCode([85, 83, 68, 0]),
+                    per_message: None,
+                    per_tool_invoke: None,
+                    per_join: None,
+                    per_period: None,
+                    per_byte_stored: None,
+                },
+                payment_adapters: vec![],
+                pricing_formula: None,
+                payee: DID::from("did:dht:z6MkPayee"),
+            },
+            notified_at,
+            effective_at: notified_at + ECONOMIC_POLICY_NOTIFICATION_PERIOD_SECS,
+            proposal_id: [0u8; 32],
+        };
+        assert!(
+            pending.is_effective(pending.effective_at),
+            "is_effective must return true at exactly effective_at"
+        );
+    }
+
+    #[tokio::test]
+    async fn execute_set_economic_policy_stages_with_24h_delay() {
+        use super::super::governance::GovernanceAction;
+        use crate::economy::types::{CostSchedule, EconomicPolicy};
+
+        let manager = ContextManager::new(
+            Box::new(MockCrypto::default()),
+            Box::new(MockTransport::connected()),
+            Box::new(MockEventLog::default()),
+            mock_key_resolver(),
+        );
+
+        let alice: DID = "did:dht:z6MkAlice".into();
+        let key_a = signing_key_for_did(&alice);
+
+        let params = ContextParams {
+            governance: super::super::params::GovernanceModel::SingleAdmin,
+            ..ContextParams::default()
+        };
+
+        let _handle = manager
+            .create_context("ctx-econ-delay".into(), params, alice.clone())
+            .await
+            .unwrap();
+
+        let policy = EconomicPolicy {
+            locked: false,
+            cost_schedule: CostSchedule {
+                currency: crate::economy::types::CurrencyCode([85, 83, 68, 0]),
+                per_message: None,
+                per_tool_invoke: None,
+                per_join: None,
+                per_period: None,
+                per_byte_stored: None,
+            },
+            payment_adapters: vec![],
+            pricing_formula: None,
+            payee: DID::from("did:dht:z6MkPayee"),
+        };
+        let action = GovernanceAction::SetEconomicPolicy {
+            policy: policy.clone(),
+        };
+
+        let (_proposal, _events) = manager
+            .propose_governance_action("ctx-econ-delay", &alice, action, &key_a)
+            .await
+            .unwrap();
+
+        let contexts = manager.contexts.lock().await;
+        let ctx = contexts.get("ctx-econ-delay").unwrap();
+        let pending = ctx
+            .pending_economic_policy_change
+            .as_ref()
+            .expect("pending economic policy change should exist");
+        assert_eq!(pending.new_policy, policy);
+        assert_eq!(
+            pending.effective_at,
+            pending.notified_at + 86_400,
+            "effective_at must be notified_at + 24h"
+        );
+        assert!(
+            ctx.economic_policy.is_none(),
+            "economic policy should not be applied yet (still in notification period)"
+        );
+    }
+
+    #[tokio::test]
+    async fn apply_pending_economic_policy_change_respects_notification_period() {
+        use super::super::governance::GovernanceAction;
+        use crate::economy::types::{CostSchedule, EconomicPolicy};
+
+        let manager = ContextManager::new(
+            Box::new(MockCrypto::default()),
+            Box::new(MockTransport::connected()),
+            Box::new(MockEventLog::default()),
+            mock_key_resolver(),
+        );
+
+        let alice: DID = "did:dht:z6MkAlice".into();
+        let key_a = signing_key_for_did(&alice);
+
+        let params = ContextParams {
+            governance: super::super::params::GovernanceModel::SingleAdmin,
+            ..ContextParams::default()
+        };
+
+        let _handle = manager
+            .create_context("ctx-econ-apply".into(), params, alice.clone())
+            .await
+            .unwrap();
+
+        let policy = EconomicPolicy {
+            locked: false,
+            cost_schedule: CostSchedule {
+                currency: crate::economy::types::CurrencyCode([85, 83, 68, 0]),
+                per_message: None,
+                per_tool_invoke: None,
+                per_join: None,
+                per_period: None,
+                per_byte_stored: None,
+            },
+            payment_adapters: vec![],
+            pricing_formula: None,
+            payee: DID::from("did:dht:z6MkPayee"),
+        };
+        let action = GovernanceAction::SetEconomicPolicy {
+            policy: policy.clone(),
+        };
+
+        let (_proposal, _events) = manager
+            .propose_governance_action("ctx-econ-apply", &alice, action, &key_a)
+            .await
+            .unwrap();
+
+        let notified_at = {
+            let contexts = manager.contexts.lock().await;
+            let ctx = contexts.get("ctx-econ-apply").unwrap();
+            ctx.pending_economic_policy_change
+                .as_ref()
+                .unwrap()
+                .notified_at
+        };
+
+        let applied = manager
+            .apply_pending_economic_policy_change("ctx-econ-apply", notified_at + 86_399)
+            .await
+            .unwrap();
+        assert!(
+            !applied,
+            "should not apply before notification period expires"
+        );
+
+        let applied = manager
+            .apply_pending_economic_policy_change("ctx-econ-apply", notified_at + 86_400)
+            .await
+            .unwrap();
+        assert!(applied, "should apply at exactly effective_at");
+
+        let contexts = manager.contexts.lock().await;
+        let ctx = contexts.get("ctx-econ-apply").unwrap();
+        assert!(
+            ctx.pending_economic_policy_change.is_none(),
+            "pending change should be cleared after apply"
+        );
+        assert_eq!(
+            ctx.economic_policy.as_ref(),
+            Some(&policy),
+            "economic policy should now be set after apply"
+        );
+    }
+
+    #[tokio::test]
+    async fn execute_set_economic_policy_emits_notification_event() {
+        use super::super::governance::GovernanceAction;
+        use crate::context::membership::ContextEvent;
+        use crate::economy::types::{CostSchedule, EconomicPolicy};
+
+        let manager = ContextManager::new(
+            Box::new(MockCrypto::default()),
+            Box::new(MockTransport::connected()),
+            Box::new(MockEventLog::default()),
+            mock_key_resolver(),
+        );
+
+        let alice: DID = "did:dht:z6MkAlice".into();
+        let key_a = signing_key_for_did(&alice);
+
+        let params = ContextParams {
+            governance: super::super::params::GovernanceModel::SingleAdmin,
+            ..ContextParams::default()
+        };
+
+        let _handle = manager
+            .create_context("ctx-econ-notify".into(), params, alice.clone())
+            .await
+            .unwrap();
+
+        let policy = EconomicPolicy {
+            locked: false,
+            cost_schedule: CostSchedule {
+                currency: crate::economy::types::CurrencyCode([85, 83, 68, 0]),
+                per_message: None,
+                per_tool_invoke: None,
+                per_join: None,
+                per_period: None,
+                per_byte_stored: None,
+            },
+            payment_adapters: vec![],
+            pricing_formula: None,
+            payee: DID::from("did:dht:z6MkPayee"),
+        };
+        let action = GovernanceAction::SetEconomicPolicy { policy };
+
+        let (_proposal, _events) = manager
+            .propose_governance_action("ctx-econ-notify", &alice, action, &key_a)
+            .await
+            .unwrap();
+
+        let events = manager.drain_events("ctx-econ-notify").await;
+        let notification = events
+            .iter()
+            .find(|e| matches!(e, ContextEvent::EconomicPolicyChangeNotification { .. }));
+        assert!(
+            notification.is_some(),
+            "EconomicPolicyChangeNotification event should be emitted"
+        );
+        if let Some(ContextEvent::EconomicPolicyChangeNotification {
+            notified_at,
+            effective_at,
+            ..
+        }) = notification
+        {
+            assert_eq!(
+                *effective_at,
+                *notified_at + 86_400,
+                "notification effective_at must be notified_at + 24h"
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn execute_set_economic_policy_rejects_when_already_pending() {
+        use super::super::governance::GovernanceAction;
+        use crate::economy::types::{CostSchedule, EconomicPolicy};
+
+        let manager = ContextManager::new(
+            Box::new(MockCrypto::default()),
+            Box::new(MockTransport::connected()),
+            Box::new(MockEventLog::default()),
+            mock_key_resolver(),
+        );
+
+        let alice: DID = "did:dht:z6MkAlice".into();
+        let key_a = signing_key_for_did(&alice);
+
+        let params = ContextParams {
+            governance: super::super::params::GovernanceModel::SingleAdmin,
+            ..ContextParams::default()
+        };
+
+        let _handle = manager
+            .create_context("ctx-econ-dup".into(), params, alice.clone())
+            .await
+            .unwrap();
+
+        let policy = EconomicPolicy {
+            locked: false,
+            cost_schedule: CostSchedule {
+                currency: crate::economy::types::CurrencyCode([85, 83, 68, 0]),
+                per_message: None,
+                per_tool_invoke: None,
+                per_join: None,
+                per_period: None,
+                per_byte_stored: None,
+            },
+            payment_adapters: vec![],
+            pricing_formula: None,
+            payee: DID::from("did:dht:z6MkPayee"),
+        };
+
+        let action1 = GovernanceAction::SetEconomicPolicy {
+            policy: policy.clone(),
+        };
+        let _ = manager
+            .propose_governance_action("ctx-econ-dup", &alice, action1, &key_a)
+            .await
+            .unwrap();
+
+        let action2 = GovernanceAction::SetEconomicPolicy { policy };
+        let result = manager
+            .propose_governance_action("ctx-econ-dup", &alice, action2, &key_a)
+            .await;
+        assert!(
+            result.is_err(),
+            "second SetEconomicPolicy should fail while one is already pending"
+        );
     }
 
     // -----------------------------------------------------------------------

--- a/crates/scp-core/src/context/membership.rs
+++ b/crates/scp-core/src/context/membership.rs
@@ -372,6 +372,20 @@ pub enum ContextEvent {
         /// The governance proposal ID that approved this modification.
         proposal_id: [u8; 32],
     },
+    /// An economic policy change notification was emitted (§19.3).
+    ///
+    /// All current members receive this when a `SetEconomicPolicy` governance
+    /// action is approved. The notification period (minimum 24 hours) must
+    /// expire before the new policy takes effect. Members may leave during
+    /// the notification period if they disagree with the proposed pricing.
+    EconomicPolicyChangeNotification {
+        /// Unix timestamp (seconds) when the notification period started.
+        notified_at: u64,
+        /// Unix timestamp (seconds) when the new policy takes effect.
+        effective_at: u64,
+        /// The governance proposal ID that approved this change.
+        proposal_id: [u8; 32],
+    },
     /// The context expired due to TTL.
     ///
     /// Replaces the former sentinel DID string `"__ttl_expiry_notification"`.

--- a/crates/scp-core/src/context/providers/persistence.rs
+++ b/crates/scp-core/src/context/providers/persistence.rs
@@ -188,6 +188,7 @@ mod tests {
             approved_proposals: std::collections::HashMap::new(),
             governance_freeze: None,
             pending_ceiling_modification: None,
+            pending_economic_policy_change: None,
             mls_epoch: 0,
             epoch_coordination_records: Vec::new(),
             grace_entries: Vec::new(),

--- a/crates/scp-core/src/store/context.rs
+++ b/crates/scp-core/src/store/context.rs
@@ -1733,6 +1733,7 @@ mod tests {
             approved_proposals: std::collections::HashMap::new(),
             governance_freeze: None,
             pending_ceiling_modification: None,
+            pending_economic_policy_change: None,
             mls_epoch: 0,
             epoch_coordination_records: Vec::new(),
             grace_entries: Vec::new(),

--- a/crates/scp-core/tests/economy_integration.rs
+++ b/crates/scp-core/tests/economy_integration.rs
@@ -356,6 +356,7 @@ fn signed_event(
         EventType::MediaSessionEnded => 20,
         EventType::PaymentReceived => 21,
         EventType::EconomicPolicyChanged => 22,
+        EventType::EconomicPolicyApplied => 33,
         EventType::SpendingUcanGranted => 23,
         EventType::SpendingUcanRevoked => 24,
         // Governance event types (ADR-031 §8)
@@ -1745,6 +1746,7 @@ fn integration_economic_event_types() {
     let event_types = [
         EventType::PaymentReceived,
         EventType::EconomicPolicyChanged,
+        EventType::EconomicPolicyApplied,
         EventType::SpendingUcanGranted,
         EventType::SpendingUcanRevoked,
     ];

--- a/crates/scp-core/tests/phase2_integration.rs
+++ b/crates/scp-core/tests/phase2_integration.rs
@@ -121,6 +121,7 @@ const fn event_type_tag(event_type: &EventType) -> u16 {
         EventType::MediaSessionEnded => 20,
         EventType::PaymentReceived => 21,
         EventType::EconomicPolicyChanged => 22,
+        EventType::EconomicPolicyApplied => 33,
         EventType::SpendingUcanGranted => 23,
         EventType::SpendingUcanRevoked => 24,
         // Governance event types (ADR-031 §8)

--- a/crates/scp-core/tests/phase5_integration.rs
+++ b/crates/scp-core/tests/phase5_integration.rs
@@ -133,6 +133,7 @@ const fn event_type_tag(event_type: &EventType) -> u16 {
         EventType::MediaSessionEnded => 20,
         EventType::PaymentReceived => 21,
         EventType::EconomicPolicyChanged => 22,
+        EventType::EconomicPolicyApplied => 33,
         EventType::SpendingUcanGranted => 23,
         EventType::SpendingUcanRevoked => 24,
         // Governance event types (ADR-031 §8)

--- a/crates/scp-core/tests/wasm_conformance.rs
+++ b/crates/scp-core/tests/wasm_conformance.rs
@@ -439,6 +439,7 @@ const fn event_type_tag(event_type: &EventType) -> u16 {
         EventType::MediaSessionEnded => 20,
         EventType::PaymentReceived => 21,
         EventType::EconomicPolicyChanged => 22,
+        EventType::EconomicPolicyApplied => 33,
         EventType::SpendingUcanGranted => 23,
         EventType::SpendingUcanRevoked => 24,
         // Governance event types (ADR-031 §8)

--- a/crates/scp-event-log/src/lib.rs
+++ b/crates/scp-event-log/src/lib.rs
@@ -146,8 +146,13 @@ pub enum EventType {
     /// A payment was received and captured (spec section 19.6.1).
     PaymentReceived,
     /// The context's economic policy was changed through governance
-    /// (spec section 19.6.1).
+    /// (spec section 19.6.1). This event marks the START of the 24-hour
+    /// notification period (§19.3). The policy is not yet in effect.
     EconomicPolicyChanged,
+    /// A pending economic policy change was applied after the 24-hour
+    /// notification period expired (spec section 19.3). The new policy
+    /// is now in effect.
+    EconomicPolicyApplied,
     /// A spending UCAN was granted to an agent (spec section 19.6.1).
     SpendingUcanGranted,
     /// A spending UCAN was revoked (spec section 19.6.1).
@@ -474,6 +479,7 @@ mod tests {
             EventType::MediaSessionEnded,
             EventType::PaymentReceived,
             EventType::EconomicPolicyChanged,
+            EventType::EconomicPolicyApplied,
             EventType::SpendingUcanGranted,
             EventType::SpendingUcanRevoked,
             // Governance event types (ADR-031 §8)
@@ -487,10 +493,10 @@ mod tests {
             EventType::GovernanceActionExecuted,
         ];
 
-        // Verify all 33 variants are covered.
+        // Verify all 34 variants are covered.
         assert_eq!(
             event_types.len(),
-            33,
+            34,
             "all EventType variants must be tested"
         );
 

--- a/crates/scp-event-log/src/pruning.rs
+++ b/crates/scp-event-log/src/pruning.rs
@@ -538,6 +538,7 @@ mod tests {
             EventType::MediaSessionEnded => 20,
             EventType::PaymentReceived => 21,
             EventType::EconomicPolicyChanged => 22,
+            EventType::EconomicPolicyApplied => 33,
             EventType::SpendingUcanGranted => 23,
             EventType::SpendingUcanRevoked => 24,
             // Governance event types (ADR-031 §8)

--- a/crates/scp-event-log/src/tiered_storage.rs
+++ b/crates/scp-event-log/src/tiered_storage.rs
@@ -692,6 +692,7 @@ mod tests {
             EventType::MediaSessionEnded => 20,
             EventType::PaymentReceived => 21,
             EventType::EconomicPolicyChanged => 22,
+            EventType::EconomicPolicyApplied => 33,
             EventType::SpendingUcanGranted => 23,
             EventType::SpendingUcanRevoked => 24,
             // Governance event types (ADR-031 §8)

--- a/crates/scp-event-log/src/tree.rs
+++ b/crates/scp-event-log/src/tree.rs
@@ -410,6 +410,7 @@ pub(crate) const fn event_type_tag(event_type: &EventType) -> u16 {
         EventType::MediaSessionEnded => 20,
         EventType::PaymentReceived => 21,
         EventType::EconomicPolicyChanged => 22,
+        EventType::EconomicPolicyApplied => 33,
         EventType::SpendingUcanGranted => 23,
         EventType::SpendingUcanRevoked => 24,
         // Governance event types (ADR-031 §8)
@@ -964,6 +965,7 @@ mod tests {
             EventType::MediaSessionEnded,
             EventType::PaymentReceived,
             EventType::EconomicPolicyChanged,
+            EventType::EconomicPolicyApplied,
             EventType::SpendingUcanGranted,
             EventType::SpendingUcanRevoked,
         ];
@@ -987,7 +989,7 @@ mod tests {
             prev_hash = leaf_hash;
         }
 
-        assert_eq!(event_count(&log), 25);
+        assert_eq!(event_count(&log), 26);
     }
 
     // -----------------------------------------------------------------------

--- a/crates/scp-ffi/napi/src/context.rs
+++ b/crates/scp-ffi/napi/src/context.rs
@@ -1729,51 +1729,29 @@ pub async fn context_import(data: Vec<u8>) -> napi::Result<String> {
 // Economic policy bridge (§19.3, ADR-033)
 // ---------------------------------------------------------------------------
 
-/// Sets the economic policy on a context handle (§19.3).
+/// Rejects direct economic policy mutation — use governance flow instead
+/// (§19.3, #728).
 ///
-/// Validates the JSON against the `EconomicPolicy` schema before storing.
-/// If the existing policy has `locked: true`, the mutation is rejected —
-/// matching the `ContextManager::execute_set_economic_policy` behaviour
-/// in scp-core.
-///
-/// # Warning
-///
-/// This is a low-level FFI function that directly overwrites the economic
-/// policy. It does **not** go through governance — no event logging, no
-/// 24-hour notification period, no proposal flow. Governance enforcement
-/// is the SDK / application layer's responsibility.
+/// Economic policy changes MUST go through the governance proposal flow
+/// (`SetEconomicPolicy` action) to ensure event logging and the mandatory
+/// 24-hour notification period. Direct setters bypass these controls.
 ///
 /// # Errors
 ///
-/// - NAPI error if the JSON is invalid or does not parse as `EconomicPolicy`.
-/// - NAPI error if the existing economic policy is locked.
+/// Always returns an error directing the caller to use governance.
 #[napi(js_name = "contextSetEconomicPolicy")]
 #[allow(clippy::needless_pass_by_value)] // napi-rs requires owned String
 pub fn context_set_economic_policy(
-    handle: &mut NapiContextHandle,
-    policy_json: String,
+    _handle: &mut NapiContextHandle,
+    _policy_json: String,
 ) -> napi::Result<()> {
-    // Check whether the existing policy is locked (§19.3).
-    if let Some(ref existing_json) = handle.economic_policy
-        && let Ok(existing) =
-            serde_json::from_str::<scp_core::economy::types::EconomicPolicy>(existing_json)
-        && existing.locked
-    {
-        return Err(NapiError::from(ScpNapiError::Context {
-            message: "economic policy is locked and cannot be changed".to_owned(),
-            code: "SCP-CTX-2013".to_owned(),
-        }));
-    }
-
-    let _policy: scp_core::economy::types::EconomicPolicy = serde_json::from_str(&policy_json)
-        .map_err(|e| {
-            NapiError::from(ScpNapiError::Validation {
-                message: format!("invalid economic policy JSON: {e}"),
-                code: "SCP-VALID-7001".to_owned(),
-            })
-        })?;
-    handle.economic_policy = Some(policy_json);
-    Ok(())
+    Err(NapiError::from(ScpNapiError::Permission {
+        message: "economic policy changes must go through governance \
+                  (propose SetEconomicPolicy action). Direct mutation is \
+                  not permitted — see spec §19.3"
+            .to_owned(),
+        code: "SCP-CTX-2013".to_owned(),
+    }))
 }
 
 /// Returns the economic policy for a context as a JSON string, or `null`.
@@ -1936,50 +1914,15 @@ mod tests {
         // Initially None.
         assert!(context_get_economic_policy(&handle).is_none());
 
-        // Set valid policy.
+        // Direct set always rejects — must use governance (#728).
         let json = r#"{"locked":false,"cost_schedule":{"currency":[85,83,68,0],"per_message":null,"per_tool_invoke":100,"per_join":null,"per_period":null,"per_byte_stored":null},"payment_adapters":[],"pricing_formula":null,"payee":"did:dht:z6MkTest"}"#;
-        context_set_economic_policy(&mut handle, json.to_owned()).unwrap();
-        assert_eq!(context_get_economic_policy(&handle).as_deref(), Some(json));
-
-        // Invalid JSON is rejected.
-        let bad = context_set_economic_policy(&mut handle, "not json".to_owned());
-        assert!(bad.is_err());
-        // Original policy unchanged after rejected set.
-        assert_eq!(context_get_economic_policy(&handle).as_deref(), Some(json));
-    }
-
-    /// Verifies that setting economic policy on a locked policy is rejected.
-    #[test]
-    fn set_economic_policy_rejects_when_locked() {
-        use super::*;
-        use std::sync::Mutex;
-
-        let locked_json = r#"{"locked":true,"cost_schedule":{"currency":[85,83,68,0],"per_message":null,"per_tool_invoke":100,"per_join":null,"per_period":null,"per_byte_stored":null},"payment_adapters":[],"pricing_formula":null,"payee":"did:dht:z6MkTest"}"#;
-        let mut handle = NapiContextHandle {
-            context_id: "test-ctx-econ-locked".to_owned(),
-            state: Mutex::new(ContextState::Active),
-            creator_did: "did:key:z6MkTest".to_owned(),
-            mode: "Encrypted".to_owned(),
-            ceiling: vec![],
-            ceiling_policy: "immutable".to_owned(),
-            ttl_seconds: None,
-            promotion_policy: None,
-            governance: "single_admin".to_owned(),
-            economic_policy: Some(locked_json.to_owned()),
-            #[cfg(feature = "allow_in_memory_custody")]
-            in_memory_custody: None,
-            signing_key: None,
-            core_handle: None,
-        };
-
-        let new_json = r#"{"locked":false,"cost_schedule":{"currency":[85,83,68,0],"per_message":2,"per_tool_invoke":null,"per_join":null,"per_period":null,"per_byte_stored":null},"payment_adapters":[],"pricing_formula":null,"payee":"did:dht:z6MkTest"}"#;
-        let result = context_set_economic_policy(&mut handle, new_json.to_owned());
-        assert!(result.is_err());
-        // Original locked policy should be unchanged.
-        assert_eq!(
-            context_get_economic_policy(&handle).as_deref(),
-            Some(locked_json)
+        let result = context_set_economic_policy(&mut handle, json.to_owned());
+        assert!(
+            result.is_err(),
+            "direct set must be rejected — use governance"
         );
+        // Policy should remain unchanged.
+        assert!(context_get_economic_policy(&handle).is_none());
     }
 
     // -----------------------------------------------------------------------

--- a/crates/scp-ffi/src/context.rs
+++ b/crates/scp-ffi/src/context.rs
@@ -1449,47 +1449,25 @@ fn build_core_context_params(py_params: &PyContextParams) -> scp_core::context::
 // Economic policy bridge (§19.3, ADR-033)
 // ---------------------------------------------------------------------------
 
-/// Sets the economic policy for a context (§19.3).
+/// Rejects direct economic policy mutation — use governance flow instead
+/// (§19.3, #728).
 ///
-/// Accepts the economic policy as a JSON string. Validates the JSON against
-/// the `EconomicPolicy` schema before storing. If the existing policy has
-/// `locked: true`, the mutation is rejected — matching the
-/// `ContextManager::execute_set_economic_policy` behaviour in scp-core.
-///
-/// # Warning
-///
-/// This is a low-level FFI function that directly overwrites the economic
-/// policy on the context handle. It does **not** go through governance —
-/// there is no event logging, no 24-hour notification period, and no
-/// proposal flow. Governance enforcement is the SDK / application layer's
-/// responsibility. See spec §19.3 and ADR-033 for the full governance
-/// requirements around economic policy changes.
+/// Economic policy changes MUST go through the governance proposal flow
+/// (`SetEconomicPolicy` action) to ensure event logging and the mandatory
+/// 24-hour notification period. Direct setters bypass these controls.
 ///
 /// # Errors
 ///
-/// - `ValueError` if the JSON is invalid or does not parse as `EconomicPolicy`.
-/// - `PermissionError` if the existing economic policy is locked.
-/// - `ScpContextError` if the context handle is not valid.
+/// Always returns `PermissionError` directing the caller to use governance.
 #[pyfunction]
 #[pyo3(signature = (handle, policy_json))]
 fn py_set_economic_policy(handle: &mut PyContextHandle, policy_json: &str) -> PyResult<()> {
-    // Check whether the existing policy is locked (§19.3).
-    if let Some(ref existing_json) = handle.params.economic_policy
-        && let Ok(existing) =
-            serde_json::from_str::<scp_core::economy::types::EconomicPolicy>(existing_json)
-        && existing.locked
-    {
-        return Err(pyo3::exceptions::PyPermissionError::new_err(
-            "economic policy is locked and cannot be changed",
-        ));
-    }
-
-    let _policy: scp_core::economy::types::EconomicPolicy = serde_json::from_str(policy_json)
-        .map_err(|e| {
-            pyo3::exceptions::PyValueError::new_err(format!("invalid economic policy JSON: {e}"))
-        })?;
-    handle.params.economic_policy = Some(policy_json.to_owned());
-    Ok(())
+    let _ = (handle, policy_json);
+    Err(pyo3::exceptions::PyPermissionError::new_err(
+        "economic policy changes must go through governance \
+         (propose SetEconomicPolicy action). Direct mutation is \
+         not permitted — see spec §19.3",
+    ))
 }
 
 /// Returns the economic policy for a context as a JSON string, or `None`.
@@ -3196,30 +3174,19 @@ mod tests {
     // -----------------------------------------------------------------------
 
     #[test]
-    fn set_economic_policy_valid_json() {
+    fn set_economic_policy_always_rejects_requires_governance() {
         let mut handle = PyContextHandle::new(
             "ctx-econ-1".to_owned(),
             "did:test:creator".to_owned(),
             default_params(),
         );
-        assert!(handle.params.economic_policy.is_none());
 
         let json = r#"{"locked":false,"cost_schedule":{"currency":[85,83,68,0],"per_message":1,"per_tool_invoke":null,"per_join":null,"per_period":null,"per_byte_stored":null},"payment_adapters":[],"pricing_formula":null,"payee":"did:dht:z6MkPayee"}"#;
-        py_set_economic_policy(&mut handle, json).unwrap();
-        assert_eq!(handle.params.economic_policy.as_deref(), Some(json));
-    }
-
-    #[test]
-    fn set_economic_policy_invalid_json_rejects() {
-        let mut handle = PyContextHandle::new(
-            "ctx-econ-2".to_owned(),
-            "did:test:creator".to_owned(),
-            default_params(),
+        let result = py_set_economic_policy(&mut handle, json);
+        assert!(
+            result.is_err(),
+            "direct set must be rejected — use governance"
         );
-
-        let result = py_set_economic_policy(&mut handle, "not valid json");
-        assert!(result.is_err());
-        // Original value should be unchanged.
         assert!(handle.params.economic_policy.is_none());
     }
 
@@ -3247,42 +3214,6 @@ mod tests {
         );
         let result = py_get_economic_policy(&handle);
         assert_eq!(result.as_deref(), Some(json));
-    }
-
-    #[test]
-    fn set_economic_policy_rejects_when_locked() {
-        let locked_json = r#"{"locked":true,"cost_schedule":{"currency":[85,83,68,0],"per_message":1,"per_tool_invoke":null,"per_join":null,"per_period":null,"per_byte_stored":null},"payment_adapters":[],"pricing_formula":null,"payee":"did:dht:z6MkPayee"}"#;
-        let mut handle = PyContextHandle::new(
-            "ctx-econ-locked".to_owned(),
-            "did:test:creator".to_owned(),
-            PyContextParams {
-                economic_policy: Some(locked_json.to_owned()),
-                ..default_params()
-            },
-        );
-
-        let new_json = r#"{"locked":false,"cost_schedule":{"currency":[85,83,68,0],"per_message":2,"per_tool_invoke":null,"per_join":null,"per_period":null,"per_byte_stored":null},"payment_adapters":[],"pricing_formula":null,"payee":"did:dht:z6MkPayee"}"#;
-        let result = py_set_economic_policy(&mut handle, new_json);
-        assert!(result.is_err());
-        // Original locked policy should be unchanged.
-        assert_eq!(handle.params.economic_policy.as_deref(), Some(locked_json));
-    }
-
-    #[test]
-    fn set_economic_policy_allows_when_unlocked() {
-        let unlocked_json = r#"{"locked":false,"cost_schedule":{"currency":[85,83,68,0],"per_message":1,"per_tool_invoke":null,"per_join":null,"per_period":null,"per_byte_stored":null},"payment_adapters":[],"pricing_formula":null,"payee":"did:dht:z6MkPayee"}"#;
-        let mut handle = PyContextHandle::new(
-            "ctx-econ-unlocked".to_owned(),
-            "did:test:creator".to_owned(),
-            PyContextParams {
-                economic_policy: Some(unlocked_json.to_owned()),
-                ..default_params()
-            },
-        );
-
-        let new_json = r#"{"locked":false,"cost_schedule":{"currency":[85,83,68,0],"per_message":2,"per_tool_invoke":null,"per_join":null,"per_period":null,"per_byte_stored":null},"payment_adapters":[],"pricing_formula":null,"payee":"did:dht:z6MkPayee"}"#;
-        py_set_economic_policy(&mut handle, new_json).unwrap();
-        assert_eq!(handle.params.economic_policy.as_deref(), Some(new_json));
     }
 
     // -----------------------------------------------------------------------

--- a/crates/scp-ffi/uniffi/src/bridge.rs
+++ b/crates/scp-ffi/uniffi/src/bridge.rs
@@ -6114,59 +6114,30 @@ pub fn verify_participation_requirements(
 
 /// Sets the economic policy for a context (§19.3).
 ///
-/// Accepts the economic policy as a JSON string. Validates the JSON against
-/// the `EconomicPolicy` schema before storing. If the existing policy has
-/// `locked: true`, the mutation is rejected — matching the
-/// `ContextManager::execute_set_economic_policy` behaviour in scp-core.
+/// Rejects direct economic policy mutation — use governance flow instead
+/// (§19.3, #728).
 ///
-/// # Warning
-///
-/// This is a low-level FFI function that directly overwrites the economic
-/// policy. It does **not** go through governance — no event logging, no
-/// 24-hour notification period, no proposal flow. Governance enforcement
-/// is the SDK / application layer's responsibility.
+/// Economic policy changes MUST go through the governance proposal flow
+/// (`SetEconomicPolicy` action) to ensure event logging and the mandatory
+/// 24-hour notification period. Direct setters bypass these controls.
 ///
 /// # Errors
 ///
-/// - `ScpError::Validation` if the JSON is invalid or does not parse as
-///   `EconomicPolicy`.
-/// - `ScpError::Permission` if the existing economic policy is locked.
+/// Always returns `ScpError::Permission` directing the caller to use governance.
 #[uniffi::export]
 #[allow(clippy::needless_pass_by_value)] // UniFFI requires owned String parameters
 pub fn set_economic_policy(
     handle: Arc<ContextHandle>,
     policy_json: String,
 ) -> Result<(), ScpError> {
-    // Hold the mutex for the entire check-validate-store sequence to prevent
-    // TOCTOU races (another thread bypassing the lock between check and store).
-    let mut guard = handle
-        .economic_policy
-        .lock()
-        .map_err(|_| ScpError::Context {
-            msg: "economic_policy lock is poisoned".to_owned(),
-            code: "SCP-CTX-2012".to_owned(),
-        })?;
-
-    // Check whether the existing policy is locked (§19.3).
-    if let Some(ref existing_json) = *guard
-        && let Ok(existing) =
-            serde_json::from_str::<scp_core::economy::types::EconomicPolicy>(existing_json)
-        && existing.locked
-    {
-        return Err(ScpError::Permission {
-            msg: "economic policy is locked and cannot be changed".to_owned(),
-            code: "SCP-CTX-2013".to_owned(),
-        });
-    }
-
-    let _policy: scp_core::economy::types::EconomicPolicy = serde_json::from_str(&policy_json)
-        .map_err(|e| ScpError::Validation {
-            msg: format!("invalid economic policy JSON: {e}"),
-            code: "SCP-VALID-7001".to_owned(),
-        })?;
-
-    *guard = Some(policy_json);
-    Ok(())
+    let _ = (handle, policy_json);
+    Err(ScpError::Permission {
+        msg: "economic policy changes must go through governance \
+              (propose SetEconomicPolicy action). Direct mutation is \
+              not permitted — see spec §19.3"
+            .to_owned(),
+        code: "SCP-CTX-2013".to_owned(),
+    })
 }
 
 /// Returns the economic policy for a context as a JSON string, or `None`.
@@ -7972,48 +7943,26 @@ mod tests {
         }
     }
 
-    /// Roundtrip set / get for economic policy on the `UniFFI` `ContextHandle`.
+    /// Direct `set_economic_policy` always rejects — must use governance (#728).
     #[test]
-    fn set_get_economic_policy_roundtrip() {
+    fn set_economic_policy_always_rejects_requires_governance() {
         let handle = test_handle();
 
         // Initially None.
         let result = get_economic_policy(Arc::clone(&handle)).unwrap();
         assert!(result.is_none());
 
-        // Set valid policy.
+        // Direct set always rejects.
         let json = r#"{"locked":false,"cost_schedule":{"currency":[85,83,68,0],"per_message":null,"per_tool_invoke":100,"per_join":null,"per_period":null,"per_byte_stored":null},"payment_adapters":[],"pricing_formula":null,"payee":"did:dht:z6MkTest"}"#;
-        set_economic_policy(Arc::clone(&handle), json.to_owned()).unwrap();
+        let result = set_economic_policy(Arc::clone(&handle), json.to_owned());
+        assert!(
+            result.is_err(),
+            "direct set must be rejected — use governance"
+        );
 
-        let result = get_economic_policy(Arc::clone(&handle)).unwrap();
-        assert_eq!(result.as_deref(), Some(json));
-
-        // Invalid JSON is rejected.
-        let err = set_economic_policy(Arc::clone(&handle), "not json".to_owned());
-        assert!(err.is_err());
-
-        // Original policy unchanged after rejected set.
+        // Policy should remain None.
         let result = get_economic_policy(handle).unwrap();
-        assert_eq!(result.as_deref(), Some(json));
-    }
-
-    /// Verifies that setting economic policy on a locked policy is rejected.
-    #[test]
-    fn set_economic_policy_rejects_when_locked() {
-        let handle = test_handle();
-
-        // Set a locked policy.
-        let locked_json = r#"{"locked":true,"cost_schedule":{"currency":[85,83,68,0],"per_message":null,"per_tool_invoke":100,"per_join":null,"per_period":null,"per_byte_stored":null},"payment_adapters":[],"pricing_formula":null,"payee":"did:dht:z6MkTest"}"#;
-        set_economic_policy(Arc::clone(&handle), locked_json.to_owned()).unwrap();
-
-        // Attempting to overwrite should fail.
-        let new_json = r#"{"locked":false,"cost_schedule":{"currency":[85,83,68,0],"per_message":2,"per_tool_invoke":null,"per_join":null,"per_period":null,"per_byte_stored":null},"payment_adapters":[],"pricing_formula":null,"payee":"did:dht:z6MkTest"}"#;
-        let result = set_economic_policy(Arc::clone(&handle), new_json.to_owned());
-        assert!(result.is_err());
-
-        // Locked policy should be unchanged.
-        let result = get_economic_policy(handle).unwrap();
-        assert_eq!(result.as_deref(), Some(locked_json));
+        assert!(result.is_none());
     }
 
     #[test]

--- a/crates/scp-ffi/wasm/src/context.rs
+++ b/crates/scp-ffi/wasm/src/context.rs
@@ -960,36 +960,29 @@ pub fn broadcast_handle_key_request(
 // Economic policy bridge (§19.3, ADR-033)
 // ---------------------------------------------------------------------------
 
-/// Sets the economic policy on a context (§19.3).
+/// Rejects direct economic policy mutation — use governance flow instead
+/// (§19.3, #728).
 ///
-/// Validates the JSON string before storing. Does not go through
-/// governance — this is a direct setter for local state matching the
-/// `PyO3` `py_set_economic_policy` pattern.
+/// Economic policy changes MUST go through the governance proposal flow
+/// (`SetEconomicPolicy` action) to ensure event logging and the mandatory
+/// 24-hour notification period.
 ///
 /// # Errors
 ///
-/// Returns a `JsError` if the JSON is invalid.
+/// Always returns a `JsError` directing the caller to use governance.
 #[wasm_bindgen]
 pub fn context_set_economic_policy(
-    handle: &WasmContextHandle,
-    policy_json: String,
+    _handle: &WasmContextHandle,
+    _policy_json: String,
 ) -> Result<(), JsError> {
-    // Validate JSON is well-formed and parses as a generic JSON value.
-    // WASM cannot import scp-core's EconomicPolicy (ADR-034), so we
-    // validate that the JSON is syntactically valid. Schema validation
-    // is the SDK wrapper's responsibility in the WASM path.
-    let _val: serde_json::Value = serde_json::from_str(&policy_json).map_err(|e| {
-        ScpWasmError::Validation {
-            message: format!("invalid economic policy JSON: {e}"),
-            code: "SCP-VALID-7001".to_owned(),
-        }
-        .into_js()
-    })?;
-
-    let context_id = handle.context_id();
-    with_manager(|mgr| mgr.set_economic_policy(&context_id, policy_json))
-        .map_err(ScpWasmError::into_js)?;
-    Ok(())
+    Err(ScpWasmError::Permission {
+        message: "economic policy changes must go through governance \
+                  (propose SetEconomicPolicy action). Direct mutation is \
+                  not permitted — see spec §19.3"
+            .to_owned(),
+        code: "SCP-CTX-2013".to_owned(),
+    }
+    .into_js())
 }
 
 /// Returns the economic policy for a context as a JSON string, or `null`.

--- a/crates/scp-ffi/wasm/src/manager.rs
+++ b/crates/scp-ffi/wasm/src/manager.rs
@@ -3468,44 +3468,28 @@ impl WasmContextManager {
 
     /// Sets the economic policy for a context by direct mutation.
     ///
-    /// This is the standalone setter matching the `PyO3` bridge pattern.
-    /// Does not go through governance actions. If the existing policy has
-    /// `locked: true`, the mutation is rejected — matching the
-    /// `ContextManager::execute_set_economic_policy` behaviour in scp-core.
+    /// Rejects direct economic policy mutation — use governance flow instead
+    /// (§19.3, #728).
     ///
-    /// # Warning
-    ///
-    /// This function directly overwrites the policy without governance
-    /// checks. No event logging, no 24-hour notification period, no
-    /// proposal flow. Governance enforcement is the SDK / application
-    /// layer's responsibility.
+    /// Economic policy changes MUST go through the governance proposal flow
+    /// (`SetEconomicPolicy` action) to ensure event logging and the mandatory
+    /// 24-hour notification period. Direct setters bypass these controls.
     ///
     /// # Errors
     ///
-    /// Returns an error if the context is not active or the existing policy
-    /// is locked.
+    /// Always returns an error directing the caller to use governance.
     pub fn set_economic_policy(
         &mut self,
-        context_id: &str,
-        policy_json: String,
+        _context_id: &str,
+        _policy_json: String,
     ) -> Result<(), ScpWasmError> {
-        let ctx = self.require_active_context_mut(context_id)?;
-
-        // Check whether the existing policy is locked (§19.3).
-        // Best-effort parse: WASM cannot import scp-core's EconomicPolicy
-        // (ADR-034), so we check the `locked` field via generic JSON.
-        if let Some(ref existing_json) = ctx.economic_policy
-            && let Ok(obj) = serde_json::from_str::<serde_json::Value>(existing_json)
-            && obj.get("locked") == Some(&serde_json::Value::Bool(true))
-        {
-            return Err(ScpWasmError::Context {
-                message: "economic policy is locked and cannot be changed".to_owned(),
-                code: "SCP-CTX-2013".to_owned(),
-            });
-        }
-
-        ctx.economic_policy = Some(policy_json);
-        Ok(())
+        Err(ScpWasmError::Permission {
+            message: "economic policy changes must go through governance \
+                      (propose SetEconomicPolicy action). Direct mutation is \
+                      not permitted — see spec §19.3"
+                .to_owned(),
+            code: "SCP-CTX-2013".to_owned(),
+        })
     }
 
     /// Returns the economic policy for a context, or `None`.

--- a/crates/scp-ffi/wasm/src/runtime.rs
+++ b/crates/scp-ffi/wasm/src/runtime.rs
@@ -442,6 +442,7 @@ pub fn wasm_event_type_tag(event_type: &str) -> u16 {
         "MediaSessionEnded" => 20,
         "PaymentReceived" => 21,
         "EconomicPolicyChanged" => 22,
+        "EconomicPolicyApplied" => 33,
         "SpendingUcanGranted" => 23,
         "SpendingUcanRevoked" => 24,
         "GovernanceProposalCreated" => 25,


### PR DESCRIPTION
Closes #728

## Summary
- Add `PendingEconomicPolicyChange` with 24h staging delay per spec §19.3 — policy changes no longer take effect immediately
- `execute_set_economic_policy` stages changes with `effective_at = now + 86400`
- `apply_pending_economic_policy_change` applies after notification period expires
- `EconomicPolicyChangeNotification` event emitted on staging, `EconomicPolicyApplied` on application
- All 4 FFI bridges reject direct `set_economic_policy` — callers must use governance proposal flow
- 8 tests: staging, timing boundaries, event emission, duplicate rejection, FFI rejection

## Review Cycles
- Cycles: 1
- Findings: 0 actionable (3 non-blocking observations: configurable period not wired, event omits policy content, unrelated rename bundled)
- Converged

🤖 Generated with [Claude Code](https://claude.com/claude-code)