### PR TITLE
feat(ffi): expose provenance privacy functions across all 4 bridges (closes #585)

### DIFF
--- a/crates/scp-ffi/napi/src/provenance.rs
+++ b/crates/scp-ffi/napi/src/provenance.rs
@@ -1,12 +1,18 @@
 //! napi-rs bridge for provenance operations.
 //!
-//! Exposes SCP provenance quality evaluation to Node.js/Bun:
+//! Exposes SCP provenance quality evaluation and privacy operations to
+//! Node.js/Bun:
 //!
 //! - [`evaluate_provenance_quality`] -- Evaluate the provenance quality tier.
 //! - [`provenance_attach`] -- Attach provenance metadata at cross-context
 //!   boundaries.
 //! - [`provenance_check_chain_depth`] -- Check whether a provenance chain
 //!   depth is within the allowed limit.
+//! - [`provenance_redact_counterparties`] -- Remove counterparty DIDs (§24.3.5).
+//! - [`provenance_pseudonymize_counterparties`] -- Replace DIDs with
+//!   pseudonyms (§24.3.5).
+//! - [`provenance_update_source_type`] -- Update source type for state
+//!   changes (ADR-019 AC5).
 //!
 //! See spec section 24 (Provenance System) and ADR-019.
 
@@ -15,8 +21,9 @@ use napi_derive::napi;
 use scp_core::context::MemoryScope;
 use scp_core::provenance::attach::{
     DEFAULT_MAX_CHAIN_DEPTH, SourceContextInfo, attach_provenance, check_chain_depth,
+    pseudonymize_counterparties, redact_counterparties,
 };
-use scp_core::provenance::evaluate::{SourceContextState, evaluate_quality};
+use scp_core::provenance::evaluate::{SourceContextState, evaluate_quality, update_source_type};
 use scp_core::provenance::{DataProvenance, DiscoveryMethod, SourceType};
 
 use crate::error::ScpNapiError;
@@ -179,6 +186,95 @@ pub fn provenance_check_chain_depth(chain_depth: u32, max_depth: Option<u32>) ->
         payment_receipt_id: None,
     };
     check_chain_depth(&prov, max).is_ok()
+}
+
+/// Redacts counterparties from a provenance record (§24.3.5).
+///
+/// Accepts a JSON-serialized provenance record, removes all counterparty DIDs,
+/// and returns the modified record as a JSON string.
+#[napi]
+#[allow(clippy::needless_pass_by_value)]
+pub fn provenance_redact_counterparties(provenance_json: String) -> napi::Result<String> {
+    let mut prov: DataProvenance = serde_json::from_str(&provenance_json).map_err(|e| {
+        napi::Error::from(ScpNapiError::Validation {
+            message: format!("invalid provenance JSON: {e}"),
+            code: "SCP-VALID-7050".to_owned(),
+        })
+    })?;
+
+    redact_counterparties(&mut prov);
+
+    serde_json::to_string(&prov).map_err(|e| {
+        napi::Error::from(ScpNapiError::Validation {
+            message: format!("failed to serialize provenance: {e}"),
+            code: "SCP-VALID-7051".to_owned(),
+        })
+    })
+}
+
+/// Pseudonymizes counterparties in a provenance record (§24.3.5).
+///
+/// Accepts a JSON-serialized provenance record and a hex-encoded pseudonym key.
+/// Replaces real counterparty DIDs with deterministic context-scoped pseudonyms.
+/// Returns the modified record as a JSON string.
+#[napi]
+#[allow(clippy::needless_pass_by_value)]
+pub fn provenance_pseudonymize_counterparties(
+    provenance_json: String,
+    pseudonym_key_hex: String,
+) -> napi::Result<String> {
+    let mut prov: DataProvenance = serde_json::from_str(&provenance_json).map_err(|e| {
+        napi::Error::from(ScpNapiError::Validation {
+            message: format!("invalid provenance JSON: {e}"),
+            code: "SCP-VALID-7050".to_owned(),
+        })
+    })?;
+
+    let key = hex::decode(&pseudonym_key_hex).map_err(|e| {
+        napi::Error::from(ScpNapiError::Validation {
+            message: format!("invalid pseudonym_key_hex: {e}"),
+            code: "SCP-VALID-7052".to_owned(),
+        })
+    })?;
+
+    pseudonymize_counterparties(&mut prov, &key);
+
+    serde_json::to_string(&prov).map_err(|e| {
+        napi::Error::from(ScpNapiError::Validation {
+            message: format!("failed to serialize provenance: {e}"),
+            code: "SCP-VALID-7051".to_owned(),
+        })
+    })
+}
+
+/// Updates the source type of a provenance record to reflect a new context
+/// state (ADR-019 AC5).
+///
+/// Accepts a JSON-serialized provenance record and a context state string.
+/// Returns the modified record as a JSON string.
+#[napi]
+#[allow(clippy::needless_pass_by_value)]
+pub fn provenance_update_source_type(
+    provenance_json: String,
+    new_state: String,
+) -> napi::Result<String> {
+    let mut prov: DataProvenance = serde_json::from_str(&provenance_json).map_err(|e| {
+        napi::Error::from(ScpNapiError::Validation {
+            message: format!("invalid provenance JSON: {e}"),
+            code: "SCP-VALID-7050".to_owned(),
+        })
+    })?;
+
+    let state = parse_context_state(&new_state)?;
+
+    update_source_type(&mut prov, &state);
+
+    serde_json::to_string(&prov).map_err(|e| {
+        napi::Error::from(ScpNapiError::Validation {
+            message: format!("failed to serialize provenance: {e}"),
+            code: "SCP-VALID-7051".to_owned(),
+        })
+    })
 }
 
 // ---------------------------------------------------------------------------
@@ -358,5 +454,127 @@ mod tests {
 
         let none = parse_discovery_method(None).unwrap();
         assert!(matches!(none, DiscoveryMethod::OutOfBand));
+    }
+
+    #[test]
+    fn redact_counterparties_removes_dids() {
+        let prov_json = serde_json::json!({
+            "source_context": "ctx-test",
+            "source_type": "Persistent",
+            "counterparties": ["did:dht:z6MkAlice", "did:dht:z6MkBob"],
+            "purpose": null,
+            "discovery_method": "OutOfBand",
+            "age": { "secs": 0, "nanos": 0 },
+            "memory_scope": "Full",
+            "chain_depth": 0,
+            "chain_path": null,
+            "payment_amount": null,
+            "payment_adapter": null,
+            "payment_receipt_id": null
+        });
+        let result = provenance_redact_counterparties(prov_json.to_string()).unwrap();
+        let parsed: serde_json::Value = serde_json::from_str(&result).unwrap();
+        assert_eq!(parsed["counterparties"], serde_json::json!([]));
+        assert_eq!(parsed["source_context"], "ctx-test");
+    }
+
+    #[test]
+    fn pseudonymize_counterparties_deterministic() {
+        let prov_json = serde_json::json!({
+            "source_context": "ctx-test",
+            "source_type": "Persistent",
+            "counterparties": ["did:dht:z6MkAlice"],
+            "purpose": null,
+            "discovery_method": "OutOfBand",
+            "age": { "secs": 0, "nanos": 0 },
+            "memory_scope": "Full",
+            "chain_depth": 0,
+            "chain_path": null,
+            "payment_amount": null,
+            "payment_adapter": null,
+            "payment_receipt_id": null
+        });
+        let key_hex = hex::encode(b"test-key");
+        let result1 =
+            provenance_pseudonymize_counterparties(prov_json.to_string(), key_hex.clone()).unwrap();
+        let result2 =
+            provenance_pseudonymize_counterparties(prov_json.to_string(), key_hex).unwrap();
+        assert_eq!(result1, result2);
+
+        let parsed: serde_json::Value = serde_json::from_str(&result1).unwrap();
+        let parties = parsed["counterparties"].as_array().unwrap();
+        assert_eq!(parties.len(), 1);
+        assert!(parties[0].as_str().unwrap().starts_with("did:pseudo:"));
+    }
+
+    #[test]
+    fn update_source_type_changes_type() {
+        let prov_json = serde_json::json!({
+            "source_context": "ctx-test",
+            "source_type": "Persistent",
+            "counterparties": [],
+            "purpose": null,
+            "discovery_method": "OutOfBand",
+            "age": { "secs": 0, "nanos": 0 },
+            "memory_scope": "Full",
+            "chain_depth": 0,
+            "chain_path": null,
+            "payment_amount": null,
+            "payment_adapter": null,
+            "payment_receipt_id": null
+        });
+        let result =
+            provenance_update_source_type(prov_json.to_string(), "closed_ephemeral".to_owned())
+                .unwrap();
+        let parsed: serde_json::Value = serde_json::from_str(&result).unwrap();
+        assert_eq!(parsed["source_type"], "Ephemeral");
+    }
+
+    #[test]
+    fn redact_counterparties_invalid_json_fails() {
+        assert!(provenance_redact_counterparties("not json".to_owned()).is_err());
+    }
+
+    #[test]
+    fn pseudonymize_counterparties_invalid_hex_fails() {
+        let prov_json = serde_json::json!({
+            "source_context": "ctx-test",
+            "source_type": "Persistent",
+            "counterparties": ["did:dht:z6MkAlice"],
+            "purpose": null,
+            "discovery_method": "OutOfBand",
+            "age": { "secs": 0, "nanos": 0 },
+            "memory_scope": "Full",
+            "chain_depth": 0,
+            "chain_path": null,
+            "payment_amount": null,
+            "payment_adapter": null,
+            "payment_receipt_id": null
+        });
+        assert!(
+            provenance_pseudonymize_counterparties(prov_json.to_string(), "not-hex-zz".to_owned())
+                .is_err()
+        );
+    }
+
+    #[test]
+    fn update_source_type_invalid_state_fails() {
+        let prov_json = serde_json::json!({
+            "source_context": "ctx-test",
+            "source_type": "Persistent",
+            "counterparties": [],
+            "purpose": null,
+            "discovery_method": "OutOfBand",
+            "age": { "secs": 0, "nanos": 0 },
+            "memory_scope": "Full",
+            "chain_depth": 0,
+            "chain_path": null,
+            "payment_amount": null,
+            "payment_adapter": null,
+            "payment_receipt_id": null
+        });
+        assert!(
+            provenance_update_source_type(prov_json.to_string(), "invalid".to_owned()).is_err()
+        );
     }
 }

--- a/crates/scp-ffi/src/provenance.rs
+++ b/crates/scp-ffi/src/provenance.rs
@@ -1,6 +1,7 @@
 //! `PyO3` bridge functions for provenance operations.
 //!
-//! Exposes SCP provenance types and quality evaluation to Python:
+//! Exposes SCP provenance types, quality evaluation, and privacy operations
+//! to Python:
 //!
 //! - [`py_evaluate_provenance_quality`] -- Evaluate the provenance quality tier
 //!   for a given provenance record and source context state.
@@ -8,6 +9,11 @@
 //!   boundaries.
 //! - [`py_provenance_check_chain_depth`] -- Check whether a provenance chain
 //!   depth is within the allowed limit.
+//! - [`py_provenance_redact_counterparties`] -- Remove counterparty DIDs (§24.3.5).
+//! - [`py_provenance_pseudonymize_counterparties`] -- Replace DIDs with
+//!   pseudonyms (§24.3.5).
+//! - [`py_provenance_update_source_type`] -- Update source type for state
+//!   changes (ADR-019 AC5).
 //!
 //! See spec section 24 (Provenance System) and ADR-019.
 
@@ -17,8 +23,9 @@ use pyo3::types::PyDict;
 use scp_core::context::MemoryScope;
 use scp_core::provenance::attach::{
     DEFAULT_MAX_CHAIN_DEPTH, SourceContextInfo, attach_provenance, check_chain_depth,
+    pseudonymize_counterparties, redact_counterparties,
 };
-use scp_core::provenance::evaluate::{SourceContextState, evaluate_quality};
+use scp_core::provenance::evaluate::{SourceContextState, evaluate_quality, update_source_type};
 use scp_core::provenance::{DataProvenance, DiscoveryMethod, SourceType};
 
 use crate::error::ScpPyError;
@@ -155,6 +162,112 @@ pub fn py_provenance_check_chain_depth(chain_depth: u8, max_depth: Option<u8>) -
     check_chain_depth(&prov, max).is_ok()
 }
 
+/// Redacts counterparties from a provenance record (§24.3.5).
+///
+/// Accepts a JSON-serialized provenance record, removes all counterparty DIDs,
+/// and returns the modified record as a JSON string.
+///
+/// # Errors
+///
+/// Raises `ValidationError` if `provenance_json` is not valid JSON or cannot
+/// be deserialized as a `DataProvenance` record.
+#[pyfunction]
+#[pyo3(name = "provenance_redact_counterparties")]
+pub fn py_provenance_redact_counterparties(provenance_json: &str) -> PyResult<String> {
+    let mut prov: DataProvenance =
+        serde_json::from_str(provenance_json).map_err(|e| ScpPyError::ValidationError {
+            message: format!("invalid provenance JSON: {e}"),
+            code: "SCP-VALID-7050".to_string(),
+        })?;
+
+    redact_counterparties(&mut prov);
+
+    serde_json::to_string(&prov).map_err(|e| {
+        ScpPyError::ValidationError {
+            message: format!("failed to serialize provenance: {e}"),
+            code: "SCP-VALID-7051".to_string(),
+        }
+        .into()
+    })
+}
+
+/// Pseudonymizes counterparties in a provenance record (§24.3.5).
+///
+/// Accepts a JSON-serialized provenance record and a pseudonym key (as a
+/// hex-encoded string). Replaces real counterparty DIDs with deterministic
+/// context-scoped pseudonyms derived from the key. Returns the modified
+/// record as a JSON string.
+///
+/// # Errors
+///
+/// Raises `ValidationError` if `provenance_json` is not valid JSON, cannot
+/// be deserialized as a `DataProvenance` record, or if `pseudonym_key_hex`
+/// is not valid hex.
+#[pyfunction]
+#[pyo3(name = "provenance_pseudonymize_counterparties")]
+pub fn py_provenance_pseudonymize_counterparties(
+    provenance_json: &str,
+    pseudonym_key_hex: &str,
+) -> PyResult<String> {
+    let mut prov: DataProvenance =
+        serde_json::from_str(provenance_json).map_err(|e| ScpPyError::ValidationError {
+            message: format!("invalid provenance JSON: {e}"),
+            code: "SCP-VALID-7050".to_string(),
+        })?;
+
+    let key = hex::decode(pseudonym_key_hex).map_err(|e| ScpPyError::ValidationError {
+        message: format!("invalid pseudonym_key_hex: {e}"),
+        code: "SCP-VALID-7052".to_string(),
+    })?;
+
+    pseudonymize_counterparties(&mut prov, &key);
+
+    serde_json::to_string(&prov).map_err(|e| {
+        ScpPyError::ValidationError {
+            message: format!("failed to serialize provenance: {e}"),
+            code: "SCP-VALID-7051".to_string(),
+        }
+        .into()
+    })
+}
+
+/// Updates the source type of a provenance record to reflect a new context
+/// state (ADR-019 AC5).
+///
+/// Accepts a JSON-serialized provenance record and a context state string.
+/// Updates the `source_type` field to match the new state and returns the
+/// modified record as a JSON string.
+///
+/// # Errors
+///
+/// Raises `ValidationError` if `provenance_json` is not valid JSON, cannot
+/// be deserialized as a `DataProvenance` record, or if `new_state` is not
+/// a recognized context state value.
+#[pyfunction]
+#[pyo3(name = "provenance_update_source_type")]
+pub fn py_provenance_update_source_type(
+    provenance_json: &str,
+    new_state: &str,
+) -> PyResult<String> {
+    let mut prov: DataProvenance =
+        serde_json::from_str(provenance_json).map_err(|e| ScpPyError::ValidationError {
+            message: format!("invalid provenance JSON: {e}"),
+            code: "SCP-VALID-7050".to_string(),
+        })?;
+
+    let state = parse_context_state(new_state)?;
+
+    update_source_type(&mut prov, &state);
+
+    serde_json::to_string(&prov).map_err(|e| {
+        ScpPyError::ValidationError {
+            message: format!("failed to serialize provenance: {e}"),
+            code: "SCP-VALID-7051".to_string(),
+        }
+        .into()
+    })
+}
+
 // ---------------------------------------------------------------------------
 // Internal helpers
 // ---------------------------------------------------------------------------
@@ -243,6 +356,12 @@ pub fn register_provenance(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(py_evaluate_provenance_quality, m)?)?;
     m.add_function(wrap_pyfunction!(py_provenance_attach, m)?)?;
     m.add_function(wrap_pyfunction!(py_provenance_check_chain_depth, m)?)?;
+    m.add_function(wrap_pyfunction!(py_provenance_redact_counterparties, m)?)?;
+    m.add_function(wrap_pyfunction!(
+        py_provenance_pseudonymize_counterparties,
+        m
+    )?)?;
+    m.add_function(wrap_pyfunction!(py_provenance_update_source_type, m)?)?;
     Ok(())
 }
 
@@ -331,5 +450,147 @@ mod tests {
     fn check_chain_depth_exceeds_limit() {
         assert!(!py_provenance_check_chain_depth(4, None));
         assert!(!py_provenance_check_chain_depth(2, Some(1)));
+    }
+
+    #[test]
+    fn redact_counterparties_removes_dids() {
+        let prov_json = serde_json::json!({
+            "source_context": "ctx-test",
+            "source_type": "Persistent",
+            "counterparties": ["did:dht:z6MkAlice", "did:dht:z6MkBob"],
+            "purpose": null,
+            "discovery_method": "OutOfBand",
+            "age": { "secs": 0, "nanos": 0 },
+            "memory_scope": "Full",
+            "chain_depth": 0,
+            "chain_path": null,
+            "payment_amount": null,
+            "payment_adapter": null,
+            "payment_receipt_id": null
+        });
+        let result = py_provenance_redact_counterparties(&prov_json.to_string()).unwrap();
+        let parsed: serde_json::Value = serde_json::from_str(&result).unwrap();
+        assert_eq!(parsed["counterparties"], serde_json::json!([]));
+        assert_eq!(parsed["source_context"], "ctx-test");
+    }
+
+    #[test]
+    fn pseudonymize_counterparties_produces_deterministic_pseudonyms() {
+        let prov_json = serde_json::json!({
+            "source_context": "ctx-test",
+            "source_type": "Persistent",
+            "counterparties": ["did:dht:z6MkAlice"],
+            "purpose": null,
+            "discovery_method": "OutOfBand",
+            "age": { "secs": 0, "nanos": 0 },
+            "memory_scope": "Full",
+            "chain_depth": 0,
+            "chain_path": null,
+            "payment_amount": null,
+            "payment_adapter": null,
+            "payment_receipt_id": null
+        });
+        let key_hex = hex::encode(b"test-key");
+        let result1 =
+            py_provenance_pseudonymize_counterparties(&prov_json.to_string(), &key_hex).unwrap();
+        let result2 =
+            py_provenance_pseudonymize_counterparties(&prov_json.to_string(), &key_hex).unwrap();
+
+        // Deterministic: same input → same output
+        assert_eq!(result1, result2);
+
+        let parsed: serde_json::Value = serde_json::from_str(&result1).unwrap();
+        let parties = parsed["counterparties"].as_array().unwrap();
+        assert_eq!(parties.len(), 1);
+        assert!(parties[0].as_str().unwrap().starts_with("did:pseudo:"));
+    }
+
+    #[test]
+    fn update_source_type_changes_type() {
+        let prov_json = serde_json::json!({
+            "source_context": "ctx-test",
+            "source_type": "Persistent",
+            "counterparties": [],
+            "purpose": null,
+            "discovery_method": "OutOfBand",
+            "age": { "secs": 0, "nanos": 0 },
+            "memory_scope": "Full",
+            "chain_depth": 0,
+            "chain_path": null,
+            "payment_amount": null,
+            "payment_adapter": null,
+            "payment_receipt_id": null
+        });
+        let result =
+            py_provenance_update_source_type(&prov_json.to_string(), "closed_ephemeral").unwrap();
+        let parsed: serde_json::Value = serde_json::from_str(&result).unwrap();
+        assert_eq!(parsed["source_type"], "Ephemeral");
+    }
+
+    #[test]
+    fn update_source_type_preserves_on_unknown() {
+        let prov_json = serde_json::json!({
+            "source_context": "ctx-test",
+            "source_type": "Summary",
+            "counterparties": [],
+            "purpose": null,
+            "discovery_method": "OutOfBand",
+            "age": { "secs": 0, "nanos": 0 },
+            "memory_scope": "Full",
+            "chain_depth": 0,
+            "chain_path": null,
+            "payment_amount": null,
+            "payment_adapter": null,
+            "payment_receipt_id": null
+        });
+        let result = py_provenance_update_source_type(&prov_json.to_string(), "unknown").unwrap();
+        let parsed: serde_json::Value = serde_json::from_str(&result).unwrap();
+        assert_eq!(parsed["source_type"], "Summary");
+    }
+
+    #[test]
+    fn redact_counterparties_invalid_json_fails() {
+        assert!(py_provenance_redact_counterparties("not json").is_err());
+    }
+
+    #[test]
+    fn pseudonymize_counterparties_invalid_hex_fails() {
+        let prov_json = serde_json::json!({
+            "source_context": "ctx-test",
+            "source_type": "Persistent",
+            "counterparties": ["did:dht:z6MkAlice"],
+            "purpose": null,
+            "discovery_method": "OutOfBand",
+            "age": { "secs": 0, "nanos": 0 },
+            "memory_scope": "Full",
+            "chain_depth": 0,
+            "chain_path": null,
+            "payment_amount": null,
+            "payment_adapter": null,
+            "payment_receipt_id": null
+        });
+        assert!(
+            py_provenance_pseudonymize_counterparties(&prov_json.to_string(), "not-hex-zz")
+                .is_err()
+        );
+    }
+
+    #[test]
+    fn update_source_type_invalid_state_fails() {
+        let prov_json = serde_json::json!({
+            "source_context": "ctx-test",
+            "source_type": "Persistent",
+            "counterparties": [],
+            "purpose": null,
+            "discovery_method": "OutOfBand",
+            "age": { "secs": 0, "nanos": 0 },
+            "memory_scope": "Full",
+            "chain_depth": 0,
+            "chain_path": null,
+            "payment_amount": null,
+            "payment_adapter": null,
+            "payment_receipt_id": null
+        });
+        assert!(py_provenance_update_source_type(&prov_json.to_string(), "invalid_state").is_err());
     }
 }

--- a/crates/scp-ffi/uniffi/src/bridge.rs
+++ b/crates/scp-ffi/uniffi/src/bridge.rs
@@ -6693,6 +6693,123 @@ pub fn provenance_check_chain_depth(chain_depth: u8, max_depth: Option<u8>) -> b
     scp_core::provenance::attach::check_chain_depth(&prov, max).is_ok()
 }
 
+/// Redacts counterparties from a provenance record (§24.3.5).
+///
+/// Accepts a JSON-serialized provenance record, removes all counterparty DIDs,
+/// and returns the modified record as a JSON string.
+///
+/// # Errors
+///
+/// Returns [`ScpError::Validation`] if the JSON is invalid or cannot be
+/// deserialized as a provenance record.
+#[uniffi::export]
+#[allow(clippy::needless_pass_by_value)] // UniFFI requires owned String parameters
+pub fn provenance_redact_counterparties(provenance_json: String) -> Result<String, ScpError> {
+    let mut prov: scp_core::provenance::DataProvenance = serde_json::from_str(&provenance_json)
+        .map_err(|e| ScpError::Validation {
+            msg: format!("invalid provenance JSON: {e}"),
+            code: "SCP-VALID-7050".to_owned(),
+        })?;
+
+    scp_core::provenance::attach::redact_counterparties(&mut prov);
+
+    serde_json::to_string(&prov).map_err(|e| ScpError::Validation {
+        msg: format!("failed to serialize provenance: {e}"),
+        code: "SCP-VALID-7051".to_owned(),
+    })
+}
+
+/// Pseudonymizes counterparties in a provenance record (§24.3.5).
+///
+/// Accepts a JSON-serialized provenance record and a hex-encoded pseudonym key.
+/// Replaces real counterparty DIDs with deterministic context-scoped pseudonyms.
+/// Returns the modified record as a JSON string.
+///
+/// # Errors
+///
+/// Returns [`ScpError::Validation`] if the JSON is invalid, cannot be
+/// deserialized as a provenance record, or if `pseudonym_key_hex` is not
+/// valid hex.
+#[uniffi::export]
+#[allow(clippy::needless_pass_by_value)] // UniFFI requires owned String parameters
+pub fn provenance_pseudonymize_counterparties(
+    provenance_json: String,
+    pseudonym_key_hex: String,
+) -> Result<String, ScpError> {
+    let mut prov: scp_core::provenance::DataProvenance = serde_json::from_str(&provenance_json)
+        .map_err(|e| ScpError::Validation {
+            msg: format!("invalid provenance JSON: {e}"),
+            code: "SCP-VALID-7050".to_owned(),
+        })?;
+
+    let key = hex::decode(&pseudonym_key_hex).map_err(|e| ScpError::Validation {
+        msg: format!("invalid pseudonym_key_hex: {e}"),
+        code: "SCP-VALID-7052".to_owned(),
+    })?;
+
+    scp_core::provenance::attach::pseudonymize_counterparties(&mut prov, &key);
+
+    serde_json::to_string(&prov).map_err(|e| ScpError::Validation {
+        msg: format!("failed to serialize provenance: {e}"),
+        code: "SCP-VALID-7051".to_owned(),
+    })
+}
+
+/// Updates the source type of a provenance record to reflect a new context
+/// state (ADR-019 AC5).
+///
+/// Accepts a JSON-serialized provenance record and a context state string.
+/// Returns the modified record as a JSON string.
+///
+/// # Errors
+///
+/// Returns [`ScpError::Validation`] if the JSON is invalid, cannot be
+/// deserialized as a provenance record, or if `new_state` is not a
+/// recognized context state value.
+#[uniffi::export]
+#[allow(clippy::needless_pass_by_value)] // UniFFI requires owned String parameters
+pub fn provenance_update_source_type(
+    provenance_json: String,
+    new_state: String,
+) -> Result<String, ScpError> {
+    use scp_core::provenance::evaluate::{SourceContextState, update_source_type};
+
+    let mut prov: scp_core::provenance::DataProvenance = serde_json::from_str(&provenance_json)
+        .map_err(|e| ScpError::Validation {
+            msg: format!("invalid provenance JSON: {e}"),
+            code: "SCP-VALID-7050".to_owned(),
+        })?;
+
+    let state = match new_state.as_str() {
+        "active" => SourceContextState::Active,
+        "closed_with_summary_verified" => SourceContextState::ClosedWithSummary {
+            summary_verified: true,
+        },
+        "closed_with_summary_unverified" => SourceContextState::ClosedWithSummary {
+            summary_verified: false,
+        },
+        "closed_ephemeral" => SourceContextState::ClosedEphemeral,
+        "unknown" => SourceContextState::Unknown,
+        other => {
+            return Err(ScpError::Validation {
+                msg: format!(
+                    "invalid context_state '{other}': expected 'active', \
+                     'closed_with_summary_verified', 'closed_with_summary_unverified', \
+                     'closed_ephemeral', or 'unknown'"
+                ),
+                code: "SCP-VALID-7053".to_owned(),
+            });
+        }
+    };
+
+    update_source_type(&mut prov, &state);
+
+    serde_json::to_string(&prov).map_err(|e| ScpError::Validation {
+        msg: format!("failed to serialize provenance: {e}"),
+        code: "SCP-VALID-7051".to_owned(),
+    })
+}
+
 // ---------------------------------------------------------------------------
 // Media — session lifecycle and signaling (#597)
 // ---------------------------------------------------------------------------
@@ -9881,6 +9998,109 @@ mod tests {
         );
     }
 
+    // -- provenance privacy functions (#585) ---------------------------------
+
+    #[test]
+    fn provenance_redact_counterparties_removes_dids() {
+        let prov_json = serde_json::json!({
+            "source_context": "ctx-test",
+            "source_type": "Persistent",
+            "counterparties": ["did:dht:z6MkAlice", "did:dht:z6MkBob"],
+            "purpose": null,
+            "discovery_method": "OutOfBand",
+            "age": { "secs": 0, "nanos": 0 },
+            "memory_scope": "Full",
+            "chain_depth": 0,
+            "chain_path": null,
+            "payment_amount": null,
+            "payment_adapter": null,
+            "payment_receipt_id": null
+        });
+        let result = provenance_redact_counterparties(prov_json.to_string()).unwrap();
+        let parsed: serde_json::Value = serde_json::from_str(&result).unwrap();
+        assert_eq!(parsed["counterparties"], serde_json::json!([]));
+        assert_eq!(parsed["source_context"], "ctx-test");
+    }
+
+    #[test]
+    fn provenance_pseudonymize_counterparties_deterministic() {
+        let prov_json = serde_json::json!({
+            "source_context": "ctx-test",
+            "source_type": "Persistent",
+            "counterparties": ["did:dht:z6MkAlice"],
+            "purpose": null,
+            "discovery_method": "OutOfBand",
+            "age": { "secs": 0, "nanos": 0 },
+            "memory_scope": "Full",
+            "chain_depth": 0,
+            "chain_path": null,
+            "payment_amount": null,
+            "payment_adapter": null,
+            "payment_receipt_id": null
+        });
+        let key_hex = hex::encode(b"test-key");
+        let result1 =
+            provenance_pseudonymize_counterparties(prov_json.to_string(), key_hex.clone()).unwrap();
+        let result2 =
+            provenance_pseudonymize_counterparties(prov_json.to_string(), key_hex).unwrap();
+        assert_eq!(result1, result2);
+
+        let parsed: serde_json::Value = serde_json::from_str(&result1).unwrap();
+        let parties = parsed["counterparties"].as_array().unwrap();
+        assert_eq!(parties.len(), 1);
+        assert!(parties[0].as_str().unwrap().starts_with("did:pseudo:"));
+    }
+
+    #[test]
+    fn provenance_update_source_type_changes_type() {
+        let prov_json = serde_json::json!({
+            "source_context": "ctx-test",
+            "source_type": "Persistent",
+            "counterparties": [],
+            "purpose": null,
+            "discovery_method": "OutOfBand",
+            "age": { "secs": 0, "nanos": 0 },
+            "memory_scope": "Full",
+            "chain_depth": 0,
+            "chain_path": null,
+            "payment_amount": null,
+            "payment_adapter": null,
+            "payment_receipt_id": null
+        });
+        let result =
+            provenance_update_source_type(prov_json.to_string(), "closed_ephemeral".to_owned())
+                .unwrap();
+        let parsed: serde_json::Value = serde_json::from_str(&result).unwrap();
+        assert_eq!(parsed["source_type"], "Ephemeral");
+    }
+
+    #[test]
+    fn provenance_redact_counterparties_invalid_json_fails() {
+        assert!(provenance_redact_counterparties("not json".to_owned()).is_err());
+    }
+
+    #[test]
+    fn provenance_pseudonymize_counterparties_invalid_hex_fails() {
+        let prov_json = serde_json::json!({
+            "source_context": "ctx-test",
+            "source_type": "Persistent",
+            "counterparties": ["did:dht:z6MkAlice"],
+            "purpose": null,
+            "discovery_method": "OutOfBand",
+            "age": { "secs": 0, "nanos": 0 },
+            "memory_scope": "Full",
+            "chain_depth": 0,
+            "chain_path": null,
+            "payment_amount": null,
+            "payment_adapter": null,
+            "payment_receipt_id": null
+        });
+        assert!(
+            provenance_pseudonymize_counterparties(prov_json.to_string(), "not-hex-zz".to_owned())
+                .is_err()
+        );
+    }
+
     #[test]
     fn media_verify_sender_attribution_mismatch() {
         let (_, msg) = scp_media::signaling::create_offer(
@@ -9895,5 +10115,26 @@ mod tests {
         let result =
             media_verify_sender_attribution(json, "did:dht:zEve".to_owned());
         assert!(result.is_err());
+    }
+
+    #[test]
+    fn provenance_update_source_type_invalid_state_fails() {
+        let prov_json = serde_json::json!({
+            "source_context": "ctx-test",
+            "source_type": "Persistent",
+            "counterparties": [],
+            "purpose": null,
+            "discovery_method": "OutOfBand",
+            "age": { "secs": 0, "nanos": 0 },
+            "memory_scope": "Full",
+            "chain_depth": 0,
+            "chain_path": null,
+            "payment_amount": null,
+            "payment_adapter": null,
+            "payment_receipt_id": null
+        });
+        assert!(
+            provenance_update_source_type(prov_json.to_string(), "invalid".to_owned()).is_err()
+        );
     }
 }

--- a/crates/scp-ffi/wasm/src/provenance.rs
+++ b/crates/scp-ffi/wasm/src/provenance.rs
@@ -1,10 +1,14 @@
 //! `wasm-bindgen` bridge for provenance operations.
 //!
-//! Exposes provenance evaluation and attachment to JavaScript (browser target):
+//! Exposes provenance evaluation, attachment, and privacy operations to
+//! JavaScript (browser target):
 //!
 //! - `provenance_check_chain_depth` — Check if chain depth is within limits.
 //! - `evaluate_provenance_quality` — Evaluate provenance quality tier.
 //! - `provenance_attach` — Attach provenance metadata for cross-context data flow.
+//! - `provenance_redact_counterparties` — Remove counterparty DIDs (§24.3.5).
+//! - `provenance_pseudonymize_counterparties` — Replace DIDs with pseudonyms (§24.3.5).
+//! - `provenance_update_source_type` — Update source type for state changes (ADR-019 AC5).
 //!
 //! # WASM constraints
 //!
@@ -375,6 +379,172 @@ pub fn provenance_attach(
     });
 
     Ok(result.to_string())
+}
+
+// ---------------------------------------------------------------------------
+// provenance_redact_counterparties
+// ---------------------------------------------------------------------------
+
+/// Redacts counterparties from a provenance record (§24.3.5).
+///
+/// Accepts a JSON-serialized provenance record, removes all counterparty DIDs,
+/// and returns the modified record as a JSON string.
+///
+/// # Errors
+///
+/// Returns `JsError` if `provenance_json` is not valid JSON.
+///
+/// # JS usage
+///
+/// ```js
+/// const redacted = provenance_redact_counterparties(provenanceJson);
+/// console.log(JSON.parse(redacted).counterparties); // []
+/// ```
+#[wasm_bindgen]
+pub fn provenance_redact_counterparties(provenance_json: String) -> Result<String, JsError> {
+    let mut parsed: serde_json::Value = serde_json::from_str(&provenance_json)
+        .map_err(|e| JsError::new(&format!("[SCP-VALID-7050] invalid provenance JSON: {e}")))?;
+
+    if let Some(obj) = parsed.as_object_mut() {
+        obj.insert(
+            "counterparties".to_owned(),
+            serde_json::Value::Array(vec![]),
+        );
+    }
+
+    Ok(parsed.to_string())
+}
+
+// ---------------------------------------------------------------------------
+// provenance_pseudonymize_counterparties
+// ---------------------------------------------------------------------------
+
+/// Pseudonymizes counterparties in a provenance record (§24.3.5).
+///
+/// Accepts a JSON-serialized provenance record and a hex-encoded pseudonym key.
+/// Replaces real counterparty DIDs with deterministic context-scoped pseudonyms.
+/// Returns the modified record as a JSON string.
+///
+/// The pseudonym derivation is algorithm-identical to scp-core's
+/// `pseudonymize_did`: `SHA-256("SCP-PSEUDONYM-V1:" || len(key) || key ||
+/// len(context_id) || context_id || len(did) || did)` with each length as
+/// 4-byte big-endian.
+///
+/// # Errors
+///
+/// Returns `JsError` if `provenance_json` is not valid JSON or if
+/// `pseudonym_key_hex` is not valid hex.
+///
+/// # JS usage
+///
+/// ```js
+/// const pseudo = provenance_pseudonymize_counterparties(provenanceJson, keyHex);
+/// ```
+#[wasm_bindgen]
+pub fn provenance_pseudonymize_counterparties(
+    provenance_json: String,
+    pseudonym_key_hex: String,
+) -> Result<String, JsError> {
+    use sha2::{Digest, Sha256};
+
+    let mut parsed: serde_json::Value = serde_json::from_str(&provenance_json)
+        .map_err(|e| JsError::new(&format!("[SCP-VALID-7050] invalid provenance JSON: {e}")))?;
+
+    let key = hex::decode(&pseudonym_key_hex)
+        .map_err(|e| JsError::new(&format!("[SCP-VALID-7052] invalid pseudonym_key_hex: {e}")))?;
+
+    let context_id = parsed
+        .get("source_context")
+        .and_then(|v| v.as_str())
+        .unwrap_or("")
+        .to_owned();
+
+    if let Some(parties) = parsed
+        .get_mut("counterparties")
+        .and_then(|v| v.as_array_mut())
+    {
+        #[allow(clippy::cast_possible_truncation)] // String/key lengths never exceed u32
+        let pseudonymized: Vec<serde_json::Value> = parties
+            .iter()
+            .map(|did_val| {
+                let did_str = did_val.as_str().unwrap_or("");
+                let did_bytes = did_str.as_bytes();
+                let mut hasher = Sha256::new();
+                hasher.update(b"SCP-PSEUDONYM-V1:");
+                hasher.update((key.len() as u32).to_be_bytes());
+                hasher.update(&key);
+                hasher.update((context_id.len() as u32).to_be_bytes());
+                hasher.update(context_id.as_bytes());
+                hasher.update((did_bytes.len() as u32).to_be_bytes());
+                hasher.update(did_bytes);
+                let hash = hasher.finalize();
+                serde_json::Value::String(format!("did:pseudo:{}", hex::encode(hash)))
+            })
+            .collect();
+        parsed["counterparties"] = serde_json::Value::Array(pseudonymized);
+    }
+
+    Ok(parsed.to_string())
+}
+
+// ---------------------------------------------------------------------------
+// provenance_update_source_type
+// ---------------------------------------------------------------------------
+
+/// Updates the source type of a provenance record to reflect a new context
+/// state (ADR-019 AC5).
+///
+/// Accepts a JSON-serialized provenance record and a context state string.
+/// Returns the modified record as a JSON string.
+///
+/// State-to-source-type mapping (mirrors scp-core `update_source_type`):
+/// - `"active"` → `"Persistent"`
+/// - `"closed_with_summary_verified"` / `"closed_with_summary_unverified"` → `"Summary"`
+/// - `"closed_ephemeral"` → `"Ephemeral"`
+/// - `"unknown"` → no change (preserves existing source type)
+///
+/// # Errors
+///
+/// Returns `JsError` if `provenance_json` is not valid JSON or if
+/// `new_state` is not a recognized context state value.
+///
+/// # JS usage
+///
+/// ```js
+/// const updated = provenance_update_source_type(provenanceJson, "closed_ephemeral");
+/// ```
+#[wasm_bindgen]
+pub fn provenance_update_source_type(
+    provenance_json: String,
+    new_state: String,
+) -> Result<String, JsError> {
+    let mut parsed: serde_json::Value = serde_json::from_str(&provenance_json)
+        .map_err(|e| JsError::new(&format!("[SCP-VALID-7050] invalid provenance JSON: {e}")))?;
+
+    let new_source_type = match new_state.as_str() {
+        "active" => Some("Persistent"),
+        "closed_with_summary_verified" | "closed_with_summary_unverified" => Some("Summary"),
+        "closed_ephemeral" => Some("Ephemeral"),
+        "unknown" => None, // preserve existing
+        other => {
+            return Err(JsError::new(&format!(
+                "[SCP-VALID-7053] invalid context_state '{other}': expected 'active', \
+                 'closed_with_summary_verified', 'closed_with_summary_unverified', \
+                 'closed_ephemeral', or 'unknown'"
+            )));
+        }
+    };
+
+    if let Some(st) = new_source_type
+        && let Some(obj) = parsed.as_object_mut()
+    {
+        obj.insert(
+            "source_type".to_owned(),
+            serde_json::Value::String(st.to_owned()),
+        );
+    }
+
+    Ok(parsed.to_string())
 }
 
 /// Parses a discovery method string into a JSON value (§24.2.3).
@@ -882,6 +1052,114 @@ mod tests {
         let json: serde_json::Value = serde_json::from_str(&result).unwrap();
         assert_eq!(json["source_type"], "Summary");
         assert_eq!(json["memory_scope"], "Ephemeral");
+    }
+
+    // -- provenance privacy functions (#585) --
+
+    #[test]
+    fn redact_counterparties_removes_dids() {
+        let prov_json = serde_json::json!({
+            "source_context": "ctx-test",
+            "source_type": "Persistent",
+            "counterparties": ["did:dht:z6MkAlice", "did:dht:z6MkBob"],
+            "chain_depth": 0
+        });
+        let result = provenance_redact_counterparties(prov_json.to_string()).unwrap();
+        let parsed: serde_json::Value = serde_json::from_str(&result).unwrap();
+        assert_eq!(parsed["counterparties"], serde_json::json!([]));
+        assert_eq!(parsed["source_context"], "ctx-test");
+    }
+
+    #[test]
+    fn pseudonymize_counterparties_deterministic() {
+        let prov_json = serde_json::json!({
+            "source_context": "ctx-test",
+            "source_type": "Persistent",
+            "counterparties": ["did:dht:z6MkAlice"]
+        });
+        let key_hex = hex::encode(b"test-key");
+        let result1 =
+            provenance_pseudonymize_counterparties(prov_json.to_string(), key_hex.clone()).unwrap();
+        let result2 =
+            provenance_pseudonymize_counterparties(prov_json.to_string(), key_hex).unwrap();
+        assert_eq!(result1, result2);
+
+        let parsed: serde_json::Value = serde_json::from_str(&result1).unwrap();
+        let parties = parsed["counterparties"].as_array().unwrap();
+        assert_eq!(parties.len(), 1);
+        assert!(parties[0].as_str().unwrap().starts_with("did:pseudo:"));
+    }
+
+    #[test]
+    fn update_source_type_to_ephemeral() {
+        let prov_json = serde_json::json!({
+            "source_context": "ctx-test",
+            "source_type": "Persistent",
+            "counterparties": []
+        });
+        let result =
+            provenance_update_source_type(prov_json.to_string(), "closed_ephemeral".to_owned())
+                .unwrap();
+        let parsed: serde_json::Value = serde_json::from_str(&result).unwrap();
+        assert_eq!(parsed["source_type"], "Ephemeral");
+    }
+
+    #[test]
+    fn update_source_type_preserves_on_unknown() {
+        let prov_json = serde_json::json!({
+            "source_context": "ctx-test",
+            "source_type": "Summary",
+            "counterparties": []
+        });
+        let result =
+            provenance_update_source_type(prov_json.to_string(), "unknown".to_owned()).unwrap();
+        let parsed: serde_json::Value = serde_json::from_str(&result).unwrap();
+        assert_eq!(parsed["source_type"], "Summary");
+    }
+
+    #[test]
+    fn update_source_type_to_summary() {
+        let prov_json = serde_json::json!({
+            "source_context": "ctx-test",
+            "source_type": "Persistent",
+            "counterparties": []
+        });
+        let result = provenance_update_source_type(
+            prov_json.to_string(),
+            "closed_with_summary_verified".to_owned(),
+        )
+        .unwrap();
+        let parsed: serde_json::Value = serde_json::from_str(&result).unwrap();
+        assert_eq!(parsed["source_type"], "Summary");
+    }
+
+    #[test]
+    fn update_source_type_invalid_state_fails() {
+        let prov_json = serde_json::json!({
+            "source_context": "ctx-test",
+            "source_type": "Persistent",
+            "counterparties": []
+        });
+        assert!(
+            provenance_update_source_type(prov_json.to_string(), "invalid".to_owned()).is_err()
+        );
+    }
+
+    #[test]
+    fn redact_counterparties_invalid_json_fails() {
+        assert!(provenance_redact_counterparties("not json".to_owned()).is_err());
+    }
+
+    #[test]
+    fn pseudonymize_counterparties_invalid_hex_fails() {
+        let prov_json = serde_json::json!({
+            "source_context": "ctx-test",
+            "counterparties": ["did:dht:z6MkAlice"]
+        });
+        assert!(
+            provenance_pseudonymize_counterparties(prov_json.to_string(), "not-hex-zz".to_owned())
+                .is_err()
+        );
     }
 }
 


### PR DESCRIPTION
Closes #585

## Summary
- Expose `redact_counterparties`, `pseudonymize_counterparties`, `update_source_type` through PyO3, NAPI, UniFFI, and WASM bridges
- WASM re-implements algorithms locally per ADR-034 (identical domain separator + field ordering)
- Error codes: SCP-VALID-7050 (invalid JSON), 7051 (serialization), 7052 (invalid hex key), 7053 (invalid state)
- 27 tests across 4 bridges covering happy paths and error paths

## Review Cycles
- Cycles: 1
- Converged: core feature correct, WASM algorithm verified identical
- Filed #1161 for pre-existing error code inconsistency in state parsing helpers

🤖 Generated with [Claude Code](https://claude.com/claude-code)