### PR TITLE
feat(node): implement ScpDnsProvider for zero-config TLS via DNS subdomain (closes #642)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5061,6 +5061,7 @@ dependencies = [
  "percent-encoding",
  "rand 0.8.5",
  "rcgen 0.14.7",
+ "reqwest",
  "rmp-serde",
  "rustls 0.23.37",
  "rustls-pemfile",

--- a/crates/scp-node/Cargo.toml
+++ b/crates/scp-node/Cargo.toml
@@ -28,6 +28,7 @@ axum = { workspace = true, features = ["ws"] }
 ed25519-dalek = { workspace = true }
 instant-acme = "0.8"
 rcgen = "0.14"
+reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls"] }
 rustls = { version = "0.23", default-features = false, features = ["ring", "logging", "std"] }
 rustls-pemfile = "2"
 base64 = { workspace = true }

--- a/crates/scp-node/src/dns_provider.rs
+++ b/crates/scp-node/src/dns_provider.rs
@@ -1,0 +1,597 @@
+//! DNS subdomain-based TLS provisioning for zero-config self-hosted nodes.
+//!
+//! Provides [`ScpDnsProvider`], a [`TlsProvider`](crate::TlsProvider) that
+//! automatically provisions TLS certificates via the Limn DNS API at
+//! `dns.ctx.network`. The flow:
+//!
+//! 1. Derive a stable, deterministic subdomain from the node's DID
+//!    (SHA-256 → first 8 hex chars → `<hash>.scp.ctx.network`).
+//! 2. Register the subdomain + public IP with the DNS API
+//!    (`POST https://dns.ctx.network/register`).
+//! 3. The API creates an A record and handles the Let's Encrypt DNS-01
+//!    challenge, returning the signed certificate.
+//! 4. The node uses the returned certificate for TLS.
+//!
+//! **Fallback:** If the DNS API is unreachable (network partition, service
+//! outage, Limn disappears), the provider falls back to a self-signed
+//! certificate — the protocol still works (relays are untrusted dumb pipes;
+//! MLS provides real confidentiality).
+//!
+//! **Trust model:** Limn sees the node's public IP and node ID (minimal
+//! metadata). Limn cannot read messages (MLS/sender keys). DNS hijack risk
+//! is mitigated by MLS — the relay is untrusted by design. The service is
+//! optional; nodes can use their own domain via `.domain()`.
+//!
+//! See issue #642 and spec section 18.6.3.
+
+use std::net::IpAddr;
+use std::time::Duration;
+
+use sha2::{Digest, Sha256};
+use tokio::sync::RwLock;
+use zeroize::Zeroizing;
+
+use crate::tls::{CertificateData, TlsError};
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+/// Default DNS API base URL.
+const DEFAULT_DNS_API_URL: &str = "https://dns.ctx.network";
+
+/// Default base domain for auto-provisioned subdomains.
+const DEFAULT_BASE_DOMAIN: &str = "scp.ctx.network";
+
+/// HTTP request timeout for DNS API calls.
+const DNS_API_TIMEOUT: Duration = Duration::from_secs(30);
+
+/// Maximum number of registration retries before falling back to self-signed.
+const MAX_REGISTRATION_RETRIES: u32 = 3;
+
+/// Delay between registration retries.
+const RETRY_DELAY: Duration = Duration::from_secs(2);
+
+// ---------------------------------------------------------------------------
+// DNS API request/response types
+// ---------------------------------------------------------------------------
+
+/// Registration request sent to the DNS API.
+#[derive(Debug, serde::Serialize)]
+struct RegisterRequest<'a> {
+    /// Deterministic node ID derived from the DID (first 8 hex chars of SHA-256).
+    node_id: &'a str,
+    /// Node's public IP address.
+    ip: IpAddr,
+    /// Port the node listens on for HTTPS.
+    port: u16,
+}
+
+/// Registration response from the DNS API.
+#[derive(Debug, serde::Deserialize)]
+struct RegisterResponse {
+    /// The fully qualified domain name assigned to the node.
+    domain: String,
+    /// PEM-encoded certificate chain (leaf + intermediates).
+    certificate_chain_pem: String,
+    /// PEM-encoded private key.
+    private_key_pem: String,
+}
+
+/// Error response from the DNS API.
+#[derive(Debug, serde::Deserialize)]
+struct ErrorResponse {
+    /// Human-readable error message.
+    error: String,
+}
+
+// ---------------------------------------------------------------------------
+// DnsProviderConfig — deferred construction for the builder
+// ---------------------------------------------------------------------------
+
+/// Configuration for deferred [`ScpDnsProvider`] construction.
+///
+/// The builder stores this config and creates the actual [`ScpDnsProvider`]
+/// during `build()` after the DID is resolved. This solves the chicken-and-egg
+/// problem: the DNS provider needs the DID to derive the subdomain, but the
+/// DID is not known until identity resolution completes.
+///
+/// # Usage
+///
+/// ```ignore
+/// let config = DnsProviderConfig::new(public_ip, 8443);
+/// let builder = ApplicationNodeBuilder::new()
+///     .domain("placeholder.scp.ctx.network") // overridden during build
+///     .dns_provider(config)
+///     .generate_identity_with(custody, did_method);
+/// ```
+#[derive(Debug, Clone)]
+pub struct DnsProviderConfig {
+    /// Node's public IP address.
+    pub public_ip: IpAddr,
+    /// Port the node listens on for HTTPS.
+    pub port: u16,
+    /// Base domain override (default: `scp.ctx.network`).
+    pub base_domain: Option<String>,
+    /// DNS API URL override (default: `https://dns.ctx.network`).
+    pub api_url: Option<String>,
+}
+
+impl DnsProviderConfig {
+    /// Create a new config with the given public IP and port.
+    #[must_use]
+    pub const fn new(public_ip: IpAddr, port: u16) -> Self {
+        Self {
+            public_ip,
+            port,
+            base_domain: None,
+            api_url: None,
+        }
+    }
+
+    /// Override the base domain (default: `scp.ctx.network`).
+    #[must_use]
+    pub fn with_base_domain(mut self, domain: &str) -> Self {
+        self.base_domain = Some(domain.to_owned());
+        self
+    }
+
+    /// Override the DNS API URL (default: `https://dns.ctx.network`).
+    #[must_use]
+    pub fn with_api_url(mut self, url: &str) -> Self {
+        self.api_url = Some(url.to_owned());
+        self
+    }
+
+    /// Build the [`ScpDnsProvider`] and derived domain from the resolved DID.
+    ///
+    /// Returns `(provider, domain)` where `domain` is the fully qualified
+    /// subdomain (e.g., `a3f8b2c1.scp.ctx.network`).
+    #[must_use]
+    pub fn build(self, did: &str) -> (ScpDnsProvider, String) {
+        let mut provider = ScpDnsProvider::new(did, self.public_ip, self.port);
+        if let Some(base) = self.base_domain {
+            provider = provider.with_base_domain(&base);
+        }
+        if let Some(url) = self.api_url {
+            provider = provider.with_api_url(&url);
+        }
+        let domain = provider.subdomain();
+        (provider, domain)
+    }
+}
+
+// ---------------------------------------------------------------------------
+// ScpDnsProvider
+// ---------------------------------------------------------------------------
+
+/// DNS subdomain-based TLS provider for zero-config self-hosted nodes.
+///
+/// Implements [`TlsProvider`](crate::TlsProvider) by registering with the
+/// Limn DNS API to obtain a subdomain and Let's Encrypt certificate. Falls
+/// back to self-signed on failure.
+///
+/// # Construction
+///
+/// Use [`ScpDnsProvider::new`] for defaults, or the builder methods for
+/// customization:
+///
+/// ```ignore
+/// let provider = ScpDnsProvider::new("did:dht:abc123", ip, 8443)
+///     .with_base_domain("custom.example.com")
+///     .with_api_url("https://dns.custom.example.com");
+/// ```
+pub struct ScpDnsProvider {
+    /// DID string used to derive the deterministic node ID.
+    did: String,
+    /// Node's public IP address, reported to the DNS API.
+    public_ip: IpAddr,
+    /// Port the node listens on for HTTPS.
+    port: u16,
+    /// Base domain for subdomain generation (default: `scp.ctx.network`).
+    base_domain: String,
+    /// DNS API base URL (default: `https://dns.ctx.network`).
+    api_url: String,
+    /// The assigned domain after successful registration. Cached for
+    /// subsequent calls to `provision()` (avoids redundant API calls).
+    assigned_domain: RwLock<Option<String>>,
+    /// Cached certificate data from a successful registration.
+    cached_cert: RwLock<Option<CertificateData>>,
+}
+
+impl std::fmt::Debug for ScpDnsProvider {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("ScpDnsProvider")
+            .field("did", &self.did)
+            .field("public_ip", &self.public_ip)
+            .field("port", &self.port)
+            .field("base_domain", &self.base_domain)
+            .field("api_url", &self.api_url)
+            .finish_non_exhaustive()
+    }
+}
+
+impl ScpDnsProvider {
+    /// Create a new DNS provider for the given DID, public IP, and port.
+    ///
+    /// Uses the default DNS API at `dns.ctx.network` and base domain
+    /// `scp.ctx.network`.
+    #[must_use]
+    pub fn new(did: &str, public_ip: IpAddr, port: u16) -> Self {
+        Self {
+            did: did.to_owned(),
+            public_ip,
+            port,
+            base_domain: DEFAULT_BASE_DOMAIN.to_owned(),
+            api_url: DEFAULT_DNS_API_URL.to_owned(),
+            assigned_domain: RwLock::new(None),
+            cached_cert: RwLock::new(None),
+        }
+    }
+
+    /// Override the base domain (default: `scp.ctx.network`).
+    #[must_use]
+    pub fn with_base_domain(mut self, domain: &str) -> Self {
+        domain.clone_into(&mut self.base_domain);
+        self
+    }
+
+    /// Override the DNS API URL (default: `https://dns.ctx.network`).
+    #[must_use]
+    pub fn with_api_url(mut self, url: &str) -> Self {
+        url.clone_into(&mut self.api_url);
+        self
+    }
+
+    /// Derive a stable, deterministic node ID from the DID.
+    ///
+    /// Uses SHA-256 of the DID string, taking the first 8 hex characters.
+    /// This gives 32 bits of collision resistance — sufficient for DNS
+    /// subdomains where collisions are handled by the API (which checks
+    /// for DID ownership).
+    #[must_use]
+    pub fn node_id(&self) -> String {
+        let mut hasher = Sha256::new();
+        hasher.update(self.did.as_bytes());
+        let hash = hasher.finalize();
+        hex::encode(&hash[..4])
+    }
+
+    /// Returns the fully qualified domain name for this node.
+    ///
+    /// Format: `<node_id>.<base_domain>` (e.g., `a3f8b2c1.scp.ctx.network`).
+    #[must_use]
+    pub fn subdomain(&self) -> String {
+        format!("{}.{}", self.node_id(), self.base_domain)
+    }
+
+    /// Register with the DNS API and obtain a TLS certificate.
+    ///
+    /// Retries up to [`MAX_REGISTRATION_RETRIES`] times on transient failures.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`TlsError::Acme`] if registration fails after all retries.
+    async fn register(&self) -> Result<CertificateData, TlsError> {
+        let node_id = self.node_id();
+        let register_url = format!("{}/register", self.api_url);
+
+        let client = reqwest::Client::builder()
+            .timeout(DNS_API_TIMEOUT)
+            .build()
+            .map_err(|e| TlsError::Acme(format!("failed to build HTTP client: {e}")))?;
+
+        let request_body = RegisterRequest {
+            node_id: &node_id,
+            ip: self.public_ip,
+            port: self.port,
+        };
+
+        let mut last_error = String::new();
+
+        for attempt in 0..MAX_REGISTRATION_RETRIES {
+            if attempt > 0 {
+                tracing::debug!(
+                    attempt = attempt + 1,
+                    max = MAX_REGISTRATION_RETRIES,
+                    "retrying DNS API registration"
+                );
+                tokio::time::sleep(RETRY_DELAY).await;
+            }
+
+            let result = client.post(&register_url).json(&request_body).send().await;
+
+            match result {
+                Ok(response) => {
+                    let status = response.status();
+
+                    if status.is_success() {
+                        let body: RegisterResponse = response.json().await.map_err(|e| {
+                            TlsError::Acme(format!("failed to parse DNS API success response: {e}"))
+                        })?;
+
+                        tracing::info!(
+                            domain = %body.domain,
+                            node_id = %node_id,
+                            "registered with DNS API, certificate received"
+                        );
+
+                        // Cache the assigned domain.
+                        {
+                            let mut guard = self.assigned_domain.write().await;
+                            *guard = Some(body.domain);
+                        }
+
+                        let cert_data = CertificateData {
+                            certificate_chain_pem: body.certificate_chain_pem,
+                            private_key_pem: Zeroizing::new(body.private_key_pem),
+                        };
+
+                        // Cache the certificate.
+                        {
+                            let mut guard = self.cached_cert.write().await;
+                            *guard = Some(cert_data.clone());
+                        }
+
+                        return Ok(cert_data);
+                    }
+
+                    // Non-success status — parse error body if possible.
+                    let error_msg = match response.json::<ErrorResponse>().await {
+                        Ok(err_body) => err_body.error,
+                        Err(_) => format!("HTTP {status}"),
+                    };
+
+                    // 429 (rate limited) and 5xx are transient — retry.
+                    // 4xx (except 429) are permanent — fail immediately.
+                    if status.as_u16() == 429 || status.is_server_error() {
+                        last_error = error_msg;
+                        continue;
+                    }
+
+                    return Err(TlsError::Acme(format!(
+                        "DNS API registration failed: {error_msg}"
+                    )));
+                }
+                Err(e) => {
+                    // Network error — transient, retry.
+                    last_error = format!("network error: {e}");
+                }
+            }
+        }
+
+        Err(TlsError::Acme(format!(
+            "DNS API registration failed after {MAX_REGISTRATION_RETRIES} attempts: {last_error}"
+        )))
+    }
+
+    /// Provision a TLS certificate, falling back to self-signed on failure.
+    ///
+    /// 1. If a cached certificate exists and is not near expiry, return it.
+    /// 2. Otherwise, attempt registration with the DNS API.
+    /// 3. On DNS API failure, generate a self-signed certificate as fallback.
+    async fn provision_with_fallback(&self) -> Result<CertificateData, TlsError> {
+        // Check cache first.
+        {
+            let guard = self.cached_cert.read().await;
+            if let Some(ref cert) = *guard {
+                match cert.needs_renewal() {
+                    Ok(false) => {
+                        tracing::debug!("using cached DNS-provisioned certificate");
+                        return Ok(cert.clone());
+                    }
+                    Ok(true) => {
+                        tracing::info!("cached certificate needs renewal, re-registering");
+                    }
+                    Err(e) => {
+                        tracing::warn!(
+                            error = %e,
+                            "failed to check cached certificate expiry, re-registering"
+                        );
+                    }
+                }
+            }
+        }
+
+        // Attempt DNS API registration.
+        match self.register().await {
+            Ok(cert) => Ok(cert),
+            Err(e) => {
+                tracing::warn!(
+                    error = %e,
+                    "DNS API registration failed, falling back to self-signed certificate"
+                );
+
+                // Fallback: generate self-signed for the subdomain.
+                let domain = self.subdomain();
+                let cert = crate::tls::generate_self_signed(&domain)?;
+
+                // Cache the self-signed cert so subsequent calls don't
+                // regenerate (it's still valid for 365 days).
+                {
+                    let mut guard = self.cached_cert.write().await;
+                    *guard = Some(cert.clone());
+                }
+
+                Ok(cert)
+            }
+        }
+    }
+
+    /// Returns the assigned domain, if registration has completed.
+    ///
+    /// Returns `None` before the first successful `provision()` call.
+    pub async fn assigned_domain(&self) -> Option<String> {
+        self.assigned_domain.read().await.clone()
+    }
+}
+
+/// [`TlsProvider`](crate::TlsProvider) implementation for [`ScpDnsProvider`].
+///
+/// Does not require an HTTP-01 challenge listener — the DNS API handles
+/// DNS-01 challenges server-side.
+impl crate::TlsProvider for ScpDnsProvider {
+    fn provision(
+        &self,
+    ) -> std::pin::Pin<
+        Box<dyn std::future::Future<Output = Result<CertificateData, TlsError>> + Send + '_>,
+    > {
+        Box::pin(self.provision_with_fallback())
+    }
+
+    // No challenge listener needed — DNS-01 is handled by the API.
+    // Default `challenges()` and `needs_challenge_listener()` are correct.
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+#[allow(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    clippy::panic,
+    clippy::significant_drop_tightening
+)]
+mod tests {
+    use super::*;
+    use std::net::Ipv4Addr;
+
+    #[test]
+    fn node_id_is_deterministic() {
+        let provider = ScpDnsProvider::new("did:dht:abc123", IpAddr::V4(Ipv4Addr::LOCALHOST), 8443);
+        let id1 = provider.node_id();
+        let id2 = provider.node_id();
+        assert_eq!(id1, id2, "node_id must be deterministic");
+        assert_eq!(id1.len(), 8, "node_id should be 8 hex chars");
+    }
+
+    #[test]
+    fn different_dids_produce_different_node_ids() {
+        let p1 = ScpDnsProvider::new("did:dht:abc123", IpAddr::V4(Ipv4Addr::LOCALHOST), 8443);
+        let p2 = ScpDnsProvider::new("did:dht:xyz789", IpAddr::V4(Ipv4Addr::LOCALHOST), 8443);
+        assert_ne!(
+            p1.node_id(),
+            p2.node_id(),
+            "different DIDs should produce different node IDs"
+        );
+    }
+
+    #[test]
+    fn subdomain_format() {
+        let provider = ScpDnsProvider::new("did:dht:abc123", IpAddr::V4(Ipv4Addr::LOCALHOST), 8443);
+        let subdomain = provider.subdomain();
+        assert!(
+            subdomain.ends_with(".scp.ctx.network"),
+            "subdomain should end with base domain, got: {subdomain}"
+        );
+        assert!(
+            subdomain.starts_with(&provider.node_id()),
+            "subdomain should start with node_id"
+        );
+    }
+
+    #[test]
+    fn custom_base_domain() {
+        let provider = ScpDnsProvider::new("did:dht:abc123", IpAddr::V4(Ipv4Addr::LOCALHOST), 8443)
+            .with_base_domain("custom.example.com");
+        let subdomain = provider.subdomain();
+        assert!(
+            subdomain.ends_with(".custom.example.com"),
+            "custom base domain should be used, got: {subdomain}"
+        );
+    }
+
+    #[test]
+    fn custom_api_url() {
+        let provider = ScpDnsProvider::new("did:dht:abc123", IpAddr::V4(Ipv4Addr::LOCALHOST), 8443)
+            .with_api_url("https://custom.dns.example.com");
+        assert_eq!(provider.api_url, "https://custom.dns.example.com");
+    }
+
+    #[test]
+    fn node_id_is_valid_hex() {
+        let provider = ScpDnsProvider::new("did:dht:abc123", IpAddr::V4(Ipv4Addr::LOCALHOST), 8443);
+        let id = provider.node_id();
+        assert!(
+            id.chars().all(|c| c.is_ascii_hexdigit()),
+            "node_id should be valid hex, got: {id}"
+        );
+    }
+
+    #[test]
+    fn node_id_is_lowercase_hex() {
+        let provider = ScpDnsProvider::new("did:dht:ABCdef", IpAddr::V4(Ipv4Addr::LOCALHOST), 8443);
+        let id = provider.node_id();
+        assert_eq!(
+            id,
+            id.to_lowercase(),
+            "node_id should be lowercase hex, got: {id}"
+        );
+    }
+
+    #[test]
+    fn debug_does_not_leak_secrets() {
+        let provider = ScpDnsProvider::new("did:dht:secret", IpAddr::V4(Ipv4Addr::LOCALHOST), 8443);
+        let debug = format!("{provider:?}");
+        assert!(
+            debug.contains("ScpDnsProvider"),
+            "debug should contain struct name"
+        );
+        assert!(
+            debug.contains("did:dht:secret"),
+            "debug should contain DID (public)"
+        );
+    }
+
+    #[tokio::test]
+    async fn provision_falls_back_to_self_signed_when_api_unreachable() {
+        // Use a non-routable API URL that will fail immediately.
+        let provider = ScpDnsProvider::new(
+            "did:dht:test-fallback",
+            IpAddr::V4(Ipv4Addr::LOCALHOST),
+            8443,
+        )
+        .with_api_url("http://192.0.2.1:1"); // TEST-NET-1, non-routable
+
+        // provision_with_fallback() should succeed via self-signed fallback.
+        let cert = provider.provision_with_fallback().await.unwrap();
+        assert!(
+            cert.certificate_chain_pem.contains("BEGIN CERTIFICATE"),
+            "fallback should produce a valid certificate"
+        );
+        assert!(
+            cert.private_key_pem.contains("BEGIN PRIVATE KEY"),
+            "fallback should produce a valid private key"
+        );
+    }
+
+    #[tokio::test]
+    async fn cached_cert_is_returned_on_second_call() {
+        // Use a non-routable API so we get self-signed, then verify cache.
+        let provider =
+            ScpDnsProvider::new("did:dht:test-cache", IpAddr::V4(Ipv4Addr::LOCALHOST), 8443)
+                .with_api_url("http://192.0.2.1:1");
+
+        let cert1 = provider.provision_with_fallback().await.unwrap();
+        let cert2 = provider.provision_with_fallback().await.unwrap();
+
+        // Same certificate should be returned from cache.
+        assert_eq!(
+            cert1.certificate_chain_pem, cert2.certificate_chain_pem,
+            "second call should return cached certificate"
+        );
+    }
+
+    #[test]
+    fn needs_challenge_listener_is_false() {
+        use crate::TlsProvider;
+
+        let provider = ScpDnsProvider::new("did:dht:abc123", IpAddr::V4(Ipv4Addr::LOCALHOST), 8443);
+        assert!(
+            !provider.needs_challenge_listener(),
+            "DNS provider should not need HTTP-01 challenge listener"
+        );
+    }
+}

--- a/crates/scp-node/src/lib.rs
+++ b/crates/scp-node/src/lib.rs
@@ -14,6 +14,7 @@
 pub mod bridge_auth;
 pub mod bridge_handlers;
 pub mod dev_api;
+pub mod dns_provider;
 pub(crate) mod error;
 pub mod http;
 pub mod projection;
@@ -1260,6 +1261,10 @@ pub struct ApplicationNodeBuilder<
     /// before generating a new one, and persist newly created identities.
     /// Set by [`identity_with_storage`](Self::identity_with_storage).
     persist_identity: bool,
+    /// Optional DNS provider configuration for zero-config TLS via DNS
+    /// subdomain (issue #642). When set, `build()` overrides the domain
+    /// and TLS provider with DNS-derived values after identity resolution.
+    dns_provider_config: Option<dns_provider::DnsProviderConfig>,
     _domain_state: PhantomData<Dom>,
     _identity_state: PhantomData<Id>,
 }
@@ -1292,6 +1297,7 @@ impl ApplicationNodeBuilder {
             #[cfg(feature = "http3")]
             http3_config: None,
             persist_identity: false,
+            dns_provider_config: None,
             _domain_state: PhantomData,
             _identity_state: PhantomData,
         }
@@ -1337,6 +1343,7 @@ impl<K: KeyCustody + 'static, D: DidMethod + 'static, S: Storage + 'static, Id>
             #[cfg(feature = "http3")]
             http3_config: self.http3_config,
             persist_identity: self.persist_identity,
+            dns_provider_config: self.dns_provider_config,
             _domain_state: PhantomData,
             _identity_state: PhantomData,
         }
@@ -1374,6 +1381,7 @@ impl<K: KeyCustody + 'static, D: DidMethod + 'static, S: Storage + 'static, Id>
             #[cfg(feature = "http3")]
             http3_config: self.http3_config,
             persist_identity: self.persist_identity,
+            dns_provider_config: self.dns_provider_config,
             _domain_state: PhantomData,
             _identity_state: PhantomData,
         }
@@ -1471,6 +1479,26 @@ impl<K: KeyCustody + 'static, D: DidMethod + 'static, S: Storage + 'static, Dom,
     #[must_use]
     pub fn tls_provider(mut self, provider: Arc<dyn TlsProvider>) -> Self {
         self.tls_provider = Some(provider);
+        self
+    }
+
+    /// Configures zero-config TLS via the SCP DNS subdomain service (#642).
+    ///
+    /// When set, `build()` derives a deterministic subdomain from the node's
+    /// DID (after identity resolution) and creates an [`ScpDnsProvider`] that
+    /// registers with the Limn DNS API for automatic Let's Encrypt
+    /// certificate provisioning.
+    ///
+    /// The domain set via `.domain()` is **overridden** during `build()` with
+    /// the DNS-derived subdomain (e.g., `a3f8b2c1.scp.ctx.network`).
+    ///
+    /// Falls back to self-signed if the DNS API is unreachable — the protocol
+    /// still works because MLS provides real confidentiality.
+    ///
+    /// [`ScpDnsProvider`]: dns_provider::ScpDnsProvider
+    #[must_use]
+    pub fn dns_provider(mut self, config: dns_provider::DnsProviderConfig) -> Self {
+        self.dns_provider_config = Some(config);
         self
     }
 
@@ -1621,6 +1649,7 @@ impl<K: KeyCustody + 'static, D: DidMethod + 'static, Dom, Id>
             #[cfg(feature = "http3")]
             http3_config: self.http3_config,
             persist_identity: self.persist_identity,
+            dns_provider_config: self.dns_provider_config,
             _domain_state: PhantomData,
             _identity_state: PhantomData,
         }
@@ -1679,6 +1708,7 @@ impl<S: Storage + 'static, Dom>
             #[cfg(feature = "http3")]
             http3_config: self.http3_config,
             persist_identity: self.persist_identity,
+            dns_provider_config: self.dns_provider_config,
             _domain_state: PhantomData,
             _identity_state: PhantomData,
         }
@@ -1716,6 +1746,7 @@ impl<S: Storage + 'static, Dom>
             #[cfg(feature = "http3")]
             http3_config: self.http3_config,
             persist_identity: self.persist_identity,
+            dns_provider_config: self.dns_provider_config,
             _domain_state: PhantomData,
             _identity_state: PhantomData,
         }
@@ -1801,6 +1832,7 @@ impl<S: Storage + 'static, Dom>
             #[cfg(feature = "http3")]
             http3_config: self.http3_config,
             persist_identity: true,
+            dns_provider_config: self.dns_provider_config,
             _domain_state: PhantomData,
             _identity_state: PhantomData,
         }
@@ -1862,7 +1894,7 @@ impl<K: KeyCustody + 'static, D: DidMethod + 'static, S: Storage + 'static>
         self,
         protocol_repository: Arc<ProtocolRepository<S>>,
     ) -> Result<ApplicationNode<S>, NodeError> {
-        let domain = self.domain.ok_or(NodeError::MissingField("domain"))?;
+        let mut domain = self.domain.ok_or(NodeError::MissingField("domain"))?;
         let identity_source = self
             .identity_source
             .ok_or(NodeError::MissingField("identity"))?;
@@ -1871,6 +1903,23 @@ impl<K: KeyCustody + 'static, D: DidMethod + 'static, S: Storage + 'static>
         let (identity, document, did_method) =
             resolve_identity_persistent(identity_source, persist, protocol_repository.storage())
                 .await?;
+
+        // If DNS provider config is set, derive the subdomain from the DID
+        // and create the ScpDnsProvider as the TLS provider (#642).
+        let tls_provider_override = if let Some(dns_config) = self.dns_provider_config {
+            let (provider, dns_domain) = dns_config.build(&identity.did);
+            tracing::info!(
+                did = %identity.did,
+                dns_domain = %dns_domain,
+                node_id = %provider.node_id(),
+                "using DNS subdomain provider for zero-config TLS"
+            );
+            domain = dns_domain;
+            Some(Arc::new(provider) as Arc<dyn TlsProvider>)
+        } else {
+            None
+        };
+
         let bridge_secret = generate_bridge_secret();
         let bind_addr = self
             .bind_addr
@@ -1893,7 +1942,7 @@ impl<K: KeyCustody + 'static, D: DidMethod + 'static, S: Storage + 'static>
         let http_bind_addr = self.http_bind_addr.unwrap_or(DEFAULT_HTTP_BIND_ADDR);
 
         let tls_provider = resolve_tls(
-            self.tls_provider,
+            tls_provider_override.or(self.tls_provider),
             &domain,
             &protocol_repository,
             self.acme_email.as_ref(),

--- a/crates/scp-node/src/main.rs
+++ b/crates/scp-node/src/main.rs
@@ -862,6 +862,10 @@ async fn run_node_with<
         .map(|v| v == "1" || v == "true")
         .unwrap_or(false);
 
+    let use_dns_provider = env::var("SCP_NODE_DNS_PROVIDER")
+        .map(|v| v == "1" || v == "true")
+        .unwrap_or(false);
+
     let projection_rate: u32 = env_or(
         "SCP_NODE_PROJECTION_RATE_LIMIT",
         scp_node::DEFAULT_PROJECTION_RATE_LIMIT,
@@ -875,7 +879,38 @@ async fn run_node_with<
         .http_bind_addr(http_addr)
         .projection_rate_limit(projection_rate);
 
-    if use_self_signed {
+    if use_dns_provider {
+        // DNS subdomain provider: derive domain from DID, register with DNS
+        // API for zero-config TLS (#642). The domain set above is overridden
+        // during build() after identity resolution.
+        let public_ip: std::net::IpAddr = env::var("SCP_NODE_PUBLIC_IP")
+            .unwrap_or_else(|_| {
+                tracing::error!("SCP_NODE_PUBLIC_IP is required when SCP_NODE_DNS_PROVIDER=1");
+                std::process::exit(1);
+            })
+            .parse()
+            .unwrap_or_else(|e| {
+                tracing::error!(error = %e, "invalid SCP_NODE_PUBLIC_IP");
+                std::process::exit(1);
+            });
+
+        let port = http_addr.port();
+
+        let mut dns_config = scp_node::dns_provider::DnsProviderConfig::new(public_ip, port);
+        if let Ok(base) = env::var("SCP_NODE_DNS_BASE_DOMAIN") {
+            dns_config = dns_config.with_base_domain(&base);
+        }
+        if let Ok(url) = env::var("SCP_NODE_DNS_API_URL") {
+            dns_config = dns_config.with_api_url(&url);
+        }
+
+        tracing::info!(
+            public_ip = %public_ip,
+            port = port,
+            "using DNS subdomain provider for zero-config TLS"
+        );
+        builder = builder.dns_provider(dns_config);
+    } else if use_self_signed {
         tracing::info!(domain = %domain, "using self-signed TLS certificate (development mode)");
         builder = builder.tls_provider(Arc::new(SelfSignedTlsProvider {
             domain: domain.clone(),


### PR DESCRIPTION
Closes #642

## Summary
- `ScpDnsProvider` — deterministic subdomain from DID, registers with DNS API, falls back to self-signed
- `DnsProviderConfig` — deferred construction for builder (DID not known until build time)
- Builder integration: `.dns_provider(config)` overrides domain + TLS provider
- CLI: `SCP_NODE_DNS_PROVIDER=1` with optional `SCP_NODE_DNS_BASE_DOMAIN` and `SCP_NODE_DNS_API_URL`
- 11 tests covering node ID derivation, subdomain format, fallback, caching

## Review Cycles
- Cycles: 1
- Findings resolved: 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)