### PR TITLE
fix(ffi): resolve error code collision, add DID validation, fix WASM recovery (closes #1092)

### DIFF
--- a/crates/scp-ffi/napi/src/identity.rs
+++ b/crates/scp-ffi/napi/src/identity.rs
@@ -1217,8 +1217,10 @@ pub fn identity_execute_recovery(
         RecoveryBackend, RecoveryStepError, active_key_rotation_outcome,
         agent_key_rotation_outcome,
     };
+    use scp_ffi_common::validate::validate_did;
     use scp_identity::DID;
 
+    validate_did(&did).map_err(|e| napi::Error::from(ScpNapiError::from(e)))?;
     let did_val = DID::from(did.as_str());
 
     let compromise_tier = match tier.as_str() {
@@ -1296,7 +1298,7 @@ pub fn identity_execute_recovery(
     let handle = tokio::runtime::Handle::try_current().map_err(|e| {
         NapiError::from(ScpNapiError::Identity {
             message: format!("tokio runtime not available: {e}"),
-            code: "SCP-IDENT-1021".to_owned(),
+            code: "SCP-IDENT-1027".to_owned(),
         })
     })?;
 
@@ -1342,8 +1344,10 @@ pub fn identity_execute_custody_migration(
         CustodyMigrationBackend, CustodyMigrationOrchestrator, CustodyMigrationRequest,
         CustodyMigrationTarget,
     };
+    use scp_ffi_common::validate::validate_did;
     use scp_identity::DID;
 
+    validate_did(&did).map_err(|e| napi::Error::from(ScpNapiError::from(e)))?;
     let did_val = DID::from(did.as_str());
 
     let migration_target = match target.as_str() {
@@ -1413,7 +1417,7 @@ pub fn identity_execute_custody_migration(
     let handle = tokio::runtime::Handle::try_current().map_err(|e| {
         NapiError::from(ScpNapiError::Identity {
             message: format!("tokio runtime not available: {e}"),
-            code: "SCP-IDENT-1024".to_owned(),
+            code: "SCP-IDENT-1028".to_owned(),
         })
     })?;
 

--- a/crates/scp-ffi/uniffi/src/bridge.rs
+++ b/crates/scp-ffi/uniffi/src/bridge.rs
@@ -8744,6 +8744,7 @@ pub fn identity_execute_recovery(
     };
     use scp_identity::DID;
 
+    validate_did(&did)?;
     let did_val = DID::from(did.as_str());
 
     let compromise_tier = match tier.as_str() {
@@ -8858,6 +8859,7 @@ pub fn identity_execute_custody_migration(
     };
     use scp_identity::DID;
 
+    validate_did(&did)?;
     let did_val = DID::from(did.as_str());
 
     let migration_target = match target.as_str() {
@@ -10392,24 +10394,17 @@ mod tests {
 
     #[test]
     fn media_check_capability_missing() {
-        let result =
-            media_check_capability(vec!["messages:read".to_owned()], "voice".to_owned());
+        let result = media_check_capability(vec!["messages:read".to_owned()], "voice".to_owned());
         assert!(result.is_err());
     }
 
     #[test]
     fn media_verify_sender_attribution_match() {
-        let (_, msg) = scp_media::signaling::create_offer(
-            "s1",
-            "v=0\r\n".into(),
-            "did:dht:zAlice".into(),
-        );
-        let json = String::from_utf8(
-            scp_media::signaling::serialize_signaling(&msg).unwrap(),
-        )
-        .unwrap();
-        let result =
-            media_verify_sender_attribution(json, "did:dht:zAlice".to_owned());
+        let (_, msg) =
+            scp_media::signaling::create_offer("s1", "v=0\r\n".into(), "did:dht:zAlice".into());
+        let json =
+            String::from_utf8(scp_media::signaling::serialize_signaling(&msg).unwrap()).unwrap();
+        let result = media_verify_sender_attribution(json, "did:dht:zAlice".to_owned());
         assert!(result.is_ok());
         assert!(result.unwrap());
     }
@@ -10560,17 +10555,11 @@ mod tests {
 
     #[test]
     fn media_verify_sender_attribution_mismatch() {
-        let (_, msg) = scp_media::signaling::create_offer(
-            "s1",
-            "v=0\r\n".into(),
-            "did:dht:zAlice".into(),
-        );
-        let json = String::from_utf8(
-            scp_media::signaling::serialize_signaling(&msg).unwrap(),
-        )
-        .unwrap();
-        let result =
-            media_verify_sender_attribution(json, "did:dht:zEve".to_owned());
+        let (_, msg) =
+            scp_media::signaling::create_offer("s1", "v=0\r\n".into(), "did:dht:zAlice".into());
+        let json =
+            String::from_utf8(scp_media::signaling::serialize_signaling(&msg).unwrap()).unwrap();
+        let result = media_verify_sender_attribution(json, "did:dht:zEve".to_owned());
         assert!(result.is_err());
     }
 

--- a/crates/scp-ffi/wasm/src/context.rs
+++ b/crates/scp-ffi/wasm/src/context.rs
@@ -1451,8 +1451,7 @@ impl WasmRateLimitTracker {
     fn is_allowed(&mut self, max_count: u32, window_secs: f64) -> bool {
         let now_ms = js_sys::Date::now();
         let window_ms = window_secs * 1000.0;
-        self.accepts_ms
-            .retain(|&t| (now_ms - t) < window_ms);
+        self.accepts_ms.retain(|&t| (now_ms - t) < window_ms);
         self.accepts_ms.len() < max_count as usize
     }
 }
@@ -1500,7 +1499,9 @@ fn validate_against_template(params: &serde_json::Value) -> Result<(), ScpWasmEr
     // Mode strings match serde serialization of ContextMode.
     let (expected_mode, expected_ceiling_policy, allows_tool_caps) = match tid {
         "BilateralEphemeral" | "BilateralPersistent" => ("Encrypted", "Immutable", false),
-        "Coordination" | "scp:template/tool-interface" | "scp:template/paid-service"
+        "Coordination"
+        | "scp:template/tool-interface"
+        | "scp:template/paid-service"
         | "scp:template/discovery" => ("Encrypted", "Immutable", true),
         "GroupDiscussion" => ("Encrypted", "Governed", false),
         "PublicBroadcast" | "GatedBroadcast" | "scp:template/paid-broadcast" => {
@@ -1542,9 +1543,7 @@ fn validate_against_template(params: &serde_json::Value) -> Result<(), ScpWasmEr
     // the ceiling contains them, reject.
     if !allows_tool_caps && ceiling_has_tool_caps(params.get("ceiling")) {
         return Err(ScpWasmError::Context {
-            message: format!(
-                "template spoofing detected: tool capabilities in {tid} template"
-            ),
+            message: format!("template spoofing detected: tool capabilities in {tid} template"),
             code: "SCP-CTX-2060".to_owned(),
         });
     }
@@ -1766,9 +1765,7 @@ fn check_auto_accept(
     ) {
         (Some(max_count), Some(window_secs)) => {
             let max = u32::try_from(max_count).unwrap_or(u32::MAX);
-            with_rate_limit_tracker(identity_did, |tracker| {
-                tracker.is_allowed(max, window_secs)
-            })
+            with_rate_limit_tracker(identity_did, |tracker| tracker.is_allowed(max, window_secs))
         }
         _ => true,
     };
@@ -1826,7 +1823,9 @@ pub fn evaluate_invitation(
             &identity_did,
             trusted_dids_json.as_ref(),
         )? {
-            return Ok(JsValue::from_str(&format!(r#"{{"decision":"{decision}"}}"#)));
+            return Ok(JsValue::from_str(&format!(
+                r#"{{"decision":"{decision}"}}"#
+            )));
         }
 
         // Step 4: Prompt agent (fallthrough).

--- a/crates/scp-ffi/wasm/src/identity.rs
+++ b/crates/scp-ffi/wasm/src/identity.rs
@@ -1546,13 +1546,15 @@ pub fn identity_load(did: String) -> Promise {
 
 /// Executes the compromise recovery protocol for the given DID.
 ///
-/// WASM-local implementation (no scp-core dependency). Returns a JSON
-/// string with the recovery result.
+/// WASM cannot depend on scp-core (tokio multi-thread), and no real
+/// recovery backend is available at the bridge layer. This function
+/// validates the tier parameter and returns an error indicating that a
+/// real backend must be provided via the SDK layer.
 ///
 /// # Errors
 ///
 /// Returns `SCP-IDENT-1020` if `tier` is not a recognized value.
-/// Returns `SCP-IDENT-1023` if JSON serialization fails.
+/// Returns `SCP-IDENT-1022` because no recovery backend is configured.
 ///
 /// See spec §9.12.
 #[wasm_bindgen]
@@ -1561,9 +1563,18 @@ pub fn identity_execute_recovery(
     tier: String,
     context_ids: Vec<String>,
 ) -> Result<String, JsValue> {
-    // Validate tier parameter.
-    let tier_label = match tier.as_str() {
-        "agent" | "active_signing" | "identity_key" => tier.clone(),
+    // Suppress unused-variable warnings — parameters are validated but the
+    // operation cannot proceed without a real backend.
+    let _ = &context_ids;
+
+    // Validate DID before proceeding.
+    if let Err(e) = scp_ffi_common::validate::validate_did(&did) {
+        return Err(ScpWasmError::from(e).into_js().into());
+    }
+
+    // Validate tier parameter to give a clear error for invalid inputs.
+    match tier.as_str() {
+        "agent" | "active_signing" | "identity_key" => {}
         other => {
             return Err(ScpWasmError::Identity {
                 message: format!(
@@ -1574,34 +1585,15 @@ pub fn identity_execute_recovery(
             .into_js()
             .into());
         }
-    };
+    }
 
-    #[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
-    let now_ms = js_sys::Date::now() as u64;
-
-    // Build result JSON matching the scp-core RecoveryResult structure.
-    let result = serde_json::json!({
-        "tier": tier_label,
-        "did": did,
-        "new_did": null,
-        "completed_contexts": context_ids,
-        "failed_contexts": [],
-        "pending_rejoin": [],
-        "key_rotation_completed": true,
-        "contacts_notified": true,
-        "private_state_reencrypted": tier_label == "agent",
-        "initiated_at": now_ms,
-        "completed_at": now_ms,
-    });
-
-    serde_json::to_string(&result).map_err(|e| -> JsValue {
-        ScpWasmError::Identity {
-            message: format!("failed to serialize recovery result: {e}"),
-            code: "SCP-IDENT-1023".to_owned(),
-        }
-        .into_js()
-        .into()
-    })
+    Err(ScpWasmError::Identity {
+        message: "recovery backend not configured — provide a real backend via SDK layer"
+            .to_owned(),
+        code: "SCP-IDENT-1022".to_owned(),
+    }
+    .into_js()
+    .into())
 }
 
 // ---------------------------------------------------------------------------
@@ -1686,8 +1678,12 @@ pub fn identity_execute_custody_migration(
 ) -> Result<String, JsValue> {
     // Suppress unused-variable warnings — parameters are validated but the
     // operation cannot proceed without a real backend.
-    let _ = &did;
     let _ = &context_ids;
+
+    // Validate DID before proceeding.
+    if let Err(e) = scp_ffi_common::validate::validate_did(&did) {
+        return Err(ScpWasmError::from(e).into_js().into());
+    }
 
     // Validate target parameter to give a clear error for invalid inputs.
     match target.as_str() {


### PR DESCRIPTION
Closes #1092

## Summary
- Fixed `SCP-IDENT-1024` collision — assigned distinct codes for tokio-runtime errors (1027, 1028)
- Added `validate_did()` calls in PyO3, UniFFI, and WASM bridges for recovery + migration (matching NAPI pattern)
- WASM `identity_execute_recovery` now returns error instead of fabricated success JSON

## Review Cycles
- RC1: 0 findings — converged