### PR TITLE
fix(media): use typed enum comparison in check_media_capability (closes #1042)

### DIFF
--- a/crates/scp-media/src/session.rs
+++ b/crates/scp-media/src/session.rs
@@ -98,6 +98,19 @@ impl MediaCapability {
             Self::ScreenShare => "media:screen_share",
         }
     }
+
+    /// Returns the corresponding [`ParamCapability`] enum variant.
+    ///
+    /// Converts this media capability to the typed `Capability` variant used
+    /// in context parameter ceilings. Prefer this over string comparison.
+    #[must_use]
+    pub const fn to_capability(&self) -> ParamCapability {
+        match self {
+            Self::Voice => ParamCapability::MediaVoice,
+            Self::Video => ParamCapability::MediaVideo,
+            Self::ScreenShare => ParamCapability::MediaScreenShare,
+        }
+    }
 }
 
 /// Lifecycle state of a [`MediaSession`].
@@ -186,11 +199,13 @@ pub fn check_media_capability(
     ceiling: &[ParamCapability],
     capability: &MediaCapability,
 ) -> Result<(), MediaError> {
-    let name = capability.ceiling_name();
-    if ceiling.iter().any(|c| c.name() == name) {
+    let expected = capability.to_capability();
+    if ceiling.contains(&expected) {
         Ok(())
     } else {
-        Err(MediaError::CapabilityNotInCeiling(name.to_owned()))
+        Err(MediaError::CapabilityNotInCeiling(
+            capability.ceiling_name().to_owned(),
+        ))
     }
 }
 


### PR DESCRIPTION
Closes #1042

## Summary
- Add `MediaCapability::to_capability()` for typed enum mapping (Voice→MediaVoice, Video→MediaVideo, ScreenShare→MediaScreenShare)
- Replace fragile string comparison in `check_media_capability()` with `ceiling.contains(&expected)` using enum `PartialEq`
- ceiling_name() already uses colon notation on main

## Review Cycles
- Cycles: 1
- Findings: 0 — converged

🤖 Generated with [Claude Code](https://claude.com/claude-code)