### PR TITLE
fix(swift,kotlin): add TestVector description field and Kotlin type (closes #1096)

### DIFF
--- a/bindings/kotlin/scp-kt/src/main/kotlin/works/limn/scp/Types.kt
+++ b/bindings/kotlin/scp-kt/src/main/kotlin/works/limn/scp/Types.kt
@@ -193,3 +193,26 @@ class ScopedHandle internal constructor(
     override fun toString(): String =
         "ScopedHandle(contextId=$contextId, appDid=$appDid, capabilities=${grantedCapabilities.size})"
 }
+
+// ---------------------------------------------------------------------------
+// TestVector (spec §7.3.3, ADR-010)
+// ---------------------------------------------------------------------------
+
+/**
+ * A known input-output pair for tool conformance testing.
+ *
+ * Mirrors `scp_core::context::tools::TestVector`. Any agent can invoke a
+ * tool with test vector inputs and verify the output matches the expected
+ * result.
+ *
+ * Provenance: spec §7.3.3, ADR-010 (phase-2)
+ *
+ * @property description Human-readable description of what this test vector validates.
+ * @property input The serialized input value (JSON string).
+ * @property expectedOutput The expected serialized output value (JSON string).
+ */
+data class TestVector(
+    val description: String,
+    val input: String,
+    val expectedOutput: String,
+)

--- a/bindings/kotlin/scp-kt/src/test/kotlin/works/limn/scp/TestVectorTest.kt
+++ b/bindings/kotlin/scp-kt/src/test/kotlin/works/limn/scp/TestVectorTest.kt
@@ -1,0 +1,83 @@
+// TestVectorTest.kt — Unit tests for TestVector data class (#1096)
+//
+// Verifies that the TestVector type matches scp-core::context::tools::TestVector:
+// description, input, and expectedOutput fields are stored and forwarded correctly.
+//
+// Provenance: spec §7.3.3, ADR-010 (phase-2), issue #1096
+
+package works.limn.scp
+
+import org.junit.jupiter.api.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotEquals
+
+class TestVectorTest {
+    @Test
+    fun `TestVector stores description, input, and expected output`() {
+        val vector = TestVector(
+            description = "addition of two operands",
+            input = """{"operands": [2, 3]}""",
+            expectedOutput = """{"sum": 5}""",
+        )
+        assertEquals("addition of two operands", vector.description)
+        assertEquals("""{"operands": [2, 3]}""", vector.input)
+        assertEquals("""{"sum": 5}""", vector.expectedOutput)
+    }
+
+    @Test
+    fun `TestVector data class equality compares all fields`() {
+        val a = TestVector(
+            description = "add",
+            input = """{"a": 1}""",
+            expectedOutput = """{"b": 2}""",
+        )
+        val b = TestVector(
+            description = "add",
+            input = """{"a": 1}""",
+            expectedOutput = """{"b": 2}""",
+        )
+        assertEquals(a, b)
+        assertEquals(a.hashCode(), b.hashCode())
+    }
+
+    @Test
+    fun `TestVector with different description is not equal`() {
+        val a = TestVector(
+            description = "add",
+            input = "{}",
+            expectedOutput = "{}",
+        )
+        val b = TestVector(
+            description = "subtract",
+            input = "{}",
+            expectedOutput = "{}",
+        )
+        assertNotEquals(a, b)
+    }
+
+    @Test
+    fun `TestVector copy preserves description`() {
+        val original = TestVector(
+            description = "original description",
+            input = """{"x": 1}""",
+            expectedOutput = """{"y": 2}""",
+        )
+        val copied = original.copy(input = """{"x": 99}""")
+        assertEquals("original description", copied.description)
+        assertEquals("""{"x": 99}""", copied.input)
+        assertEquals("""{"y": 2}""", copied.expectedOutput)
+    }
+
+    @Test
+    fun `TestVector toString includes all fields`() {
+        val vector = TestVector(
+            description = "smoke",
+            input = "{}",
+            expectedOutput = "{}",
+        )
+        val str = vector.toString()
+        assert(str.contains("smoke")) { "toString() should contain description" }
+        assert(str.contains("input")) { "toString() should reference input" }
+        assert(str.contains("expectedOutput")) { "toString() should reference expectedOutput" }
+    }
+}

--- a/bindings/swift/Sources/SCP/Types.swift
+++ b/bindings/swift/Sources/SCP/Types.swift
@@ -97,16 +97,25 @@ public nonisolated struct Capability: Sendable {
 
 /// An input/output pair used for tool conformance testing.
 ///
+/// Mirrors `scp_core::context::tools::TestVector`. Each vector carries a
+/// human-readable description of what it validates, plus the input and
+/// expected output as JSON strings.
+///
 /// This type is a pure Swift convenience type. It does not conflict with any
 /// UniFFI-generated type.
+///
+/// Provenance: spec §7.3.3, ADR-010 (phase-2)
 public nonisolated struct TestVector: Sendable {
+    /// Human-readable description of what this test vector validates.
+    public let description: String
     /// The serialized input value (JSON).
     public let input: String
     /// The expected serialized output value (JSON).
     public let expectedOutput: String
 
     /// Memberwise initializer.
-    public init(input: String, expectedOutput: String) {
+    public init(description: String, input: String, expectedOutput: String) {
+        self.description = description
         self.input = input
         self.expectedOutput = expectedOutput
     }

--- a/bindings/swift/Tests/SCPTests/ToolsTests.swift
+++ b/bindings/swift/Tests/SCPTests/ToolsTests.swift
@@ -97,19 +97,25 @@ struct ToolsTests {
 
     // MARK: - TestVector type shape (hand-written, not UniFFI)
 
-    @Test("TestVector stores input and expected output")
+    @Test("TestVector stores description, input, and expected output")
     func vectorFields() {
         let vector = TestVector(
+            description: "addition of two operands",
             input: #"{"operands": [2, 3]}"#,
             expectedOutput: #"{"sum": 5}"#
         )
+        #expect(vector.description == "addition of two operands")
         #expect(vector.input == #"{"operands": [2, 3]}"#)
         #expect(vector.expectedOutput == #"{"sum": 5}"#)
     }
 
     @Test("TestVector is Sendable")
     func vectorIsSendable() {
-        let vector: any Sendable = TestVector(input: "{}", expectedOutput: "{}")
+        let vector: any Sendable = TestVector(
+            description: "smoke",
+            input: "{}",
+            expectedOutput: "{}"
+        )
         #expect(vector is TestVector)
     }
 


### PR DESCRIPTION
Closes #1096

## Summary
- Swift: Add `description: String` field to `TestVector`, update tests
- Kotlin: Create `TestVector` data class with 5 tests
- All SDKs now have complete `TestVector` matching Rust core

## Review Cycles
- Cycles: 1 — converged

🤖 Generated with [Claude Code](https://claude.com/claude-code)