### PR TITLE
feat(identity): add convenience constructors for identity creation (closes #530)

### DIFF
--- a/crates/scp-identity/Cargo.toml
+++ b/crates/scp-identity/Cargo.toml
@@ -30,6 +30,7 @@ reqwest = { version = "0.12", default-features = false, features = ["rustls-tls"
 [features]
 default = []
 production-dht = ["dep:mainline", "dep:reqwest"]
+testing = ["scp-platform/testing"]
 
 [dev-dependencies]
 tokio = { workspace = true, features = ["macros", "rt-multi-thread", "test-util"] }

--- a/crates/scp-identity/src/dht.rs
+++ b/crates/scp-identity/src/dht.rs
@@ -254,6 +254,101 @@ impl DidDht<InMemoryDhtClient, SystemClock> {
             post_resolve_hook: None,
         }
     }
+
+    /// Creates a `DidDht` instance with in-memory DHT, cache, and a signing
+    /// function derived from the provided [`KeyCustody`].
+    ///
+    /// This is the recommended constructor for tests and examples that need
+    /// to create identities and publish DID documents. Equivalent to manually
+    /// constructing an `InMemoryDhtClient`, `DidCache`, calling `make_sign_fn`,
+    /// and wiring them together via `with_client_and_signer`.
+    ///
+    /// # Example
+    ///
+    /// ```no_run
+    /// use std::sync::Arc;
+    /// use scp_identity::dht::DidDht;
+    /// use scp_identity::DidMethod;
+    /// use scp_platform::testing::InMemoryKeyCustody;
+    ///
+    /// # async fn example() -> Result<(), Box<dyn std::error::Error>> {
+    /// let custody = Arc::new(InMemoryKeyCustody::new());
+    /// let did_dht = DidDht::with_in_memory_custody(Arc::clone(&custody));
+    /// let (identity, document) = did_dht.create(&*custody).await?;
+    /// # Ok(())
+    /// # }
+    /// ```
+    ///
+    /// See issue #530.
+    #[must_use]
+    pub fn with_in_memory_custody<K: KeyCustody + 'static>(key_custody: Arc<K>) -> Self {
+        let dht_client = Arc::new(InMemoryDhtClient::new());
+        let cache = Arc::new(DidCache::new());
+        let sign_fn = Self::make_sign_fn(key_custody);
+        Self {
+            dht_client,
+            cache,
+            sequence: AtomicU64::new(0),
+            sign_fn: Some(sign_fn),
+            sequence_store: None,
+            post_resolve_hook: None,
+        }
+    }
+}
+
+#[cfg(any(test, feature = "testing"))]
+impl DidDht<InMemoryDhtClient, SystemClock> {
+    /// Creates an in-memory identity in a single call.
+    ///
+    /// Wires up [`InMemoryKeyCustody`](scp_platform::testing::InMemoryKeyCustody),
+    /// `InMemoryDhtClient`, `DidCache`, and the signing function, then calls
+    /// [`DidMethod::create`] to generate the identity. Returns all components
+    /// the caller needs for subsequent operations.
+    ///
+    /// This replaces the 5-line boilerplate pattern:
+    ///
+    /// ```no_run
+    /// # use std::sync::Arc;
+    /// # use scp_identity::dht::DidDht;
+    /// # use scp_identity::DidMethod;
+    /// # use scp_platform::testing::InMemoryKeyCustody;
+    /// # async fn example() -> Result<(), Box<dyn std::error::Error>> {
+    /// // Before (5 lines):
+    /// let custody = Arc::new(InMemoryKeyCustody::new());
+    /// let dht_client = Arc::new(scp_identity::dht_client::InMemoryDhtClient::new());
+    /// let cache = Arc::new(scp_identity::cache::DidCache::new());
+    /// let sign_fn = DidDht::make_sign_fn(Arc::clone(&custody));
+    /// let did_dht = DidDht::with_client_and_signer(dht_client, cache, sign_fn);
+    /// let (identity, document) = did_dht.create(&*custody).await?;
+    ///
+    /// // After (1 line):
+    /// let (identity, document, custody, did_dht) = DidDht::create_in_memory().await?;
+    /// # Ok(())
+    /// # }
+    /// ```
+    ///
+    /// See issue #530.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`IdentityError`] if key generation or identity creation fails
+    /// (should not happen with in-memory backends).
+    pub async fn create_in_memory() -> Result<
+        (
+            ScpIdentity,
+            DidDocument,
+            Arc<scp_platform::testing::InMemoryKeyCustody>,
+            Self,
+        ),
+        IdentityError,
+    > {
+        use scp_platform::testing::InMemoryKeyCustody;
+
+        let custody = Arc::new(InMemoryKeyCustody::new());
+        let did_dht = Self::with_in_memory_custody(Arc::clone(&custody));
+        let (identity, document) = did_dht.create(&*custody).await?;
+        Ok((identity, document, custody, did_dht))
+    }
 }
 
 impl<D: DhtClient> DidDht<D, SystemClock> {
@@ -3830,5 +3925,55 @@ mod tests {
         let original_token = updated_doc.device_attestation_token().unwrap().unwrap();
         let parsed_token = parsed.device_attestation_token().unwrap().unwrap();
         assert_eq!(original_token, parsed_token);
+    }
+
+    // -----------------------------------------------------------------------
+    // Convenience constructor tests (issue #530)
+    // -----------------------------------------------------------------------
+
+    #[tokio::test]
+    async fn with_in_memory_custody_creates_signing_capable_instance() {
+        let custody = Arc::new(InMemoryKeyCustody::new());
+        let dht = DidDht::with_in_memory_custody(Arc::clone(&custody));
+        let (identity, doc) = dht.create(&*custody).await.unwrap();
+
+        // DID is valid.
+        assert!(identity.did.starts_with("did:dht:z"));
+        assert_eq!(doc.id, identity.did);
+
+        // Publish works (signing is wired up).
+        dht.publish(&identity, &doc).await.unwrap();
+
+        // Resolve returns the published document.
+        let resolved = dht.resolve(&identity.did).await.unwrap();
+        assert_eq!(resolved.id, identity.did);
+    }
+
+    #[tokio::test]
+    async fn create_in_memory_returns_all_components() {
+        let (identity, document, custody, did_dht) = DidDht::create_in_memory().await.unwrap();
+
+        // Identity is valid.
+        assert!(identity.did.starts_with("did:dht:z"));
+        assert_eq!(document.id, identity.did);
+
+        // Custody is functional — can sign with identity keys.
+        let sig = custody
+            .sign(&identity.active_signing_key, b"test")
+            .await
+            .unwrap();
+        assert_eq!(sig.as_bytes().len(), 64);
+
+        // DidDht is functional — publish and resolve work.
+        did_dht.publish(&identity, &document).await.unwrap();
+        let resolved = did_dht.resolve(&identity.did).await.unwrap();
+        assert_eq!(resolved.id, identity.did);
+    }
+
+    #[tokio::test]
+    async fn create_in_memory_produces_unique_identities() {
+        let (id1, _, _, _) = DidDht::create_in_memory().await.unwrap();
+        let (id2, _, _, _) = DidDht::create_in_memory().await.unwrap();
+        assert_ne!(id1.did, id2.did, "each call must produce a unique DID");
     }
 }

--- a/crates/scp-testing/Cargo.toml
+++ b/crates/scp-testing/Cargo.toml
@@ -17,7 +17,7 @@ combined = ["scp-transport/combined"]
 
 [dependencies]
 scp-core = { path = "../scp-core", features = ["allow_unencrypted_storage"] }
-scp-identity = { path = "../scp-identity" }
+scp-identity = { path = "../scp-identity", features = ["testing"] }
 scp-platform = { path = "../scp-platform", features = ["testing"] }
 scp-primitives = { path = "../scp-primitives" }
 scp-node = { path = "../scp-node", features = ["allow_unencrypted_storage"] }

--- a/crates/scp-testing/src/helpers.rs
+++ b/crates/scp-testing/src/helpers.rs
@@ -19,10 +19,10 @@
 
 use std::sync::Arc;
 
-use scp_identity::cache::{DidCache, SystemClock};
+use scp_identity::cache::SystemClock;
 use scp_identity::dht::DidDht;
 use scp_identity::dht_client::InMemoryDhtClient;
-use scp_identity::{DidDocument, DidMethod, ScpIdentity};
+use scp_identity::{DidDocument, ScpIdentity};
 use scp_node::tls;
 use scp_node::{
     ApplicationNodeBuilder, HasDomain, HasIdentity, HasNoDomain, NatStrategy, NodeError,
@@ -38,10 +38,7 @@ pub type TestDidDht = DidDht<InMemoryDhtClient, SystemClock>;
 /// The signing function is derived from the provided custody, enabling
 /// `create()` and `publish()` operations in tests.
 pub fn make_test_dht(custody: &Arc<InMemoryKeyCustody>) -> TestDidDht {
-    let dht_client = Arc::new(InMemoryDhtClient::new());
-    let cache = Arc::new(DidCache::new());
-    let sign_fn = TestDidDht::make_sign_fn(Arc::clone(custody));
-    DidDht::with_client_and_signer(dht_client, cache, sign_fn)
+    DidDht::with_in_memory_custody(Arc::clone(custody))
 }
 
 /// Mock TLS provider that succeeds with a self-signed certificate.
@@ -168,8 +165,6 @@ pub fn test_no_domain_builder(
 /// in-memory backends).
 pub async fn create_test_identity()
 -> Result<(ScpIdentity, DidDocument, Arc<InMemoryKeyCustody>), Box<dyn std::error::Error>> {
-    let custody = Arc::new(InMemoryKeyCustody::new());
-    let did_dht = make_test_dht(&custody);
-    let (identity, document) = did_dht.create(&*custody).await?;
+    let (identity, document, custody, _did_dht) = DidDht::create_in_memory().await?;
     Ok((identity, document, custody))
 }


### PR DESCRIPTION
Closes #530

## Summary
- Add `DidDht::with_in_memory_custody(custody)` — generic 2-line identity setup (always available)
- Add `DidDht::create_in_memory()` — true 1-liner (test/testing feature-gated)
- Refactor `scp-testing` helpers to use new constructors
- 3 new tests (signing, components, uniqueness)

## Review Cycles
- Cycles: 1 — converged

🤖 Generated with [Claude Code](https://claude.com/claude-code)