### PR TITLE
fix: MCP server registry leak, provenance_status parameter, doc comments

### DIFF
--- a/crates/scp-core/src/context/manager.rs
+++ b/crates/scp-core/src/context/manager.rs
@@ -3038,6 +3038,10 @@ impl ContextManager {
     /// event is emitted). If the context is not registered, this is also a
     /// no-op.
     ///
+    /// NOTE: No production callers yet. Each FFI bridge's envelope receive path
+    /// must call this after `check_version_compatibility` returns `DegradedMode`.
+    /// Tracked by issue #1077 (FFI exposure of version-compatibility helpers).
+    ///
     /// # Arguments
     ///
     /// * `context_id` — The context where the envelope was received.

--- a/crates/scp-core/src/envelope/mod.rs
+++ b/crates/scp-core/src/envelope/mod.rs
@@ -81,12 +81,22 @@ pub enum VersionCompatibility {
 
 impl VersionCompatibility {
     /// Returns `true` if this result indicates degraded mode (§13.6).
+    ///
+    /// NOTE: This helper has no production callers yet. The envelope receive
+    /// path in each FFI bridge must call this (and [`report_degraded_mode`] on
+    /// `ContextManager`) after deserializing an incoming envelope. Tracked by
+    /// issue #1077 (FFI exposure of version-compatibility helpers).
+    ///
+    /// [`report_degraded_mode`]: crate::context::ContextManager::report_degraded_mode
     #[must_use]
     pub const fn is_degraded(&self) -> bool {
         matches!(self, Self::DegradedMode { .. })
     }
 
     /// Returns `true` if this result indicates exact version match.
+    ///
+    /// NOTE: No production callers yet — see [`is_degraded`](Self::is_degraded)
+    /// and issue #1077.
     #[must_use]
     pub const fn is_exact(&self) -> bool {
         matches!(self, Self::Exact)
@@ -94,6 +104,9 @@ impl VersionCompatibility {
 
     /// Returns the local and remote minor versions if degraded, or `None` if
     /// the versions match exactly.
+    ///
+    /// NOTE: No production callers yet — see [`is_degraded`](Self::is_degraded)
+    /// and issue #1077.
     #[must_use]
     pub const fn degraded_versions(&self) -> Option<(u8, u8)> {
         match self {

--- a/crates/scp-ffi/napi/src/mcp.rs
+++ b/crates/scp-ffi/napi/src/mcp.rs
@@ -568,6 +568,12 @@ pub async fn mcp_server_stop(handle: &NapiMcpServerHandle) -> napi::Result<()> {
         let _ = tx.send(());
     }
 
+    // Release the mutable ref before removing (DashMap requires no outstanding refs).
+    drop(entry);
+
+    // Remove the server entry from the registry to prevent memory leak (#1165).
+    mcp_server_registry().remove(&handle.handle_id);
+
     Ok(())
 }
 

--- a/crates/scp-ffi/src/bridge_connector.rs
+++ b/crates/scp-ffi/src/bridge_connector.rs
@@ -533,6 +533,9 @@ pub fn py_bridge_claim_shadow(
 /// * `sequence` -- The per-sender monotonic sequence number (AAD binding).
 /// * `platform_message_id` -- Optional platform message ID for correlation.
 /// * `platform_timestamp` -- Optional platform-reported timestamp.
+/// * `attributed_role` -- Optional role for the shadow (defaults to `"observer"`).
+/// * `provenance_status` -- Optional provenance status: `"shadow"` or
+///   `"claimed"`. Defaults to `"shadow"` (#1166).
 ///
 /// # Returns
 ///
@@ -558,7 +561,8 @@ pub fn py_bridge_claim_shadow(
     sequence,
     platform_message_id=None,
     platform_timestamp=None,
-    attributed_role=None
+    attributed_role=None,
+    provenance_status=None
 ))]
 #[allow(clippy::too_many_arguments)]
 pub fn py_bridge_seal_shadow_envelope(
@@ -576,6 +580,7 @@ pub fn py_bridge_seal_shadow_envelope(
     platform_message_id: Option<String>,
     platform_timestamp: Option<u64>,
     attributed_role: Option<String>,
+    provenance_status: Option<String>,
 ) -> PyResult<String> {
     crate::validate::validate_context_id(context_id)?;
     crate::validate::validate_did(operator_did)?;
@@ -598,12 +603,17 @@ pub fn py_bridge_seal_shadow_envelope(
     );
     let sender_key = SenderKey::from_bytes(*key_bytes);
 
+    let status = match provenance_status.as_deref() {
+        Some(s) => parse_shadow_status(s)?,
+        None => ShadowProvenanceStatus::Shadow,
+    };
+
     let shadow = ShadowIdentity {
         shadow_id: shadow_id.to_string(),
         platform_handle: platform_handle.to_string(),
         bridge_id: bridge_id.to_string(),
         attributed_role: attributed_role.unwrap_or_else(|| "observer".to_string()),
-        provenance_status: ShadowProvenanceStatus::Shadow,
+        provenance_status: status,
         created_at: 0,
     };
 
@@ -1824,7 +1834,8 @@ mod tests {
             1,
             Some("msg-001".to_owned()),
             Some(1_700_000_000),
-            None,
+            None, // attributed_role — defaults to "observer"
+            None, // provenance_status — defaults to "shadow"
         )
         .unwrap();
 
@@ -1865,6 +1876,7 @@ mod tests {
             None,
             None,
             None,
+            None,
         )
         .unwrap();
 
@@ -1893,6 +1905,7 @@ mod tests {
             "ctx-test",
             0,
             1,
+            None,
             None,
             None,
             None,


### PR DESCRIPTION
## Summary
- Fix MCP server registry leak: `mcp_server_stop` now removes entry from NAPI registry
- Fix `py_bridge_seal_shadow_envelope`: make `provenance_status` a parameter (was hardcoded to Shadow)
- Add doc comments to envelope/manager noting zero production callers, referencing #1077
- Fix WASM trust.rs formatting

## Review Cycles
- Cycles: 2
- Findings resolved: 3
- Findings dismissed: 1 (informational)

## Provenance
Discovered during full PR audit of session PRs. All changes went through coder → reviewer → arbiter cycle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)