### PR TITLE
fix(kotlin): prevent JSON injection in ToolDefinition.toJson() and Streams.kt (closes #1203)

### DIFF
--- a/bindings/kotlin/scp-kt/src/main/kotlin/works/limn/scp/Types.kt
+++ b/bindings/kotlin/scp-kt/src/main/kotlin/works/limn/scp/Types.kt
@@ -8,6 +8,10 @@
 
 package works.limn.scp
 
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.put
+import kotlinx.serialization.json.putJsonObject
 import works.limn.scp.bridge.BridgeException
 
 /**
@@ -124,7 +128,11 @@ data class ToolCost(
     val currency: String,
     val payee: String,
     val costFormula: String? = null,
-)
+) {
+    init {
+        require(amount >= 0) { "ToolCost amount must be non-negative, got $amount" }
+    }
+}
 
 /**
  * Definition of a tool that can be registered in an SCP context.
@@ -155,32 +163,35 @@ data class ToolDefinition(
 ) {
     /**
      * Serializes this definition to a JSON string suitable for the FFI bridge.
+     *
+     * Uses [buildJsonObject] from kotlinx.serialization to produce structurally
+     * valid JSON, preventing injection via untrusted string fields.
      */
-    fun toJson(): String = buildString {
-        append("{")
-        append("\"name\":\""); append(name); append("\",")
-        append("\"description\":\""); append(description); append("\",")
-        append("\"input_schema_json\":"); append(inputSchemaJson); append(",")
-        append("\"output_schema_json\":"); append(outputSchemaJson); append(",")
-        append("\"operator_did\":\""); append(operatorDid); append("\"")
-        if (testVectorsJson != null) {
-            append(",\"test_vectors_json\":"); append(testVectorsJson)
-        }
-        if (implementationHashHex != null) {
-            append(",\"implementation_hash\":\""); append(implementationHashHex); append("\"")
-        }
-        if (cost != null) {
-            append(",\"cost\":{")
-            append("\"amount\":"); append(cost.amount); append(",")
-            append("\"currency\":\""); append(cost.currency); append("\",")
-            append("\"payee\":\""); append(cost.payee); append("\"")
-            if (cost.costFormula != null) {
-                append(",\"cost_formula\":\""); append(cost.costFormula); append("\"")
+    fun toJson(): String = Json.encodeToString(
+        buildJsonObject {
+            put("name", name)
+            put("description", description)
+            put("input_schema_json", Json.parseToJsonElement(inputSchemaJson))
+            put("output_schema_json", Json.parseToJsonElement(outputSchemaJson))
+            put("operator_did", operatorDid)
+            if (testVectorsJson != null) {
+                put("test_vectors_json", Json.parseToJsonElement(testVectorsJson))
             }
-            append("}")
-        }
-        append("}")
-    }
+            if (implementationHashHex != null) {
+                put("implementation_hash", implementationHashHex)
+            }
+            if (cost != null) {
+                putJsonObject("cost") {
+                    put("amount", cost.amount)
+                    put("currency", cost.currency)
+                    put("payee", cost.payee)
+                    if (cost.costFormula != null) {
+                        put("cost_formula", cost.costFormula)
+                    }
+                }
+            }
+        },
+    )
 }
 
 // ---------------------------------------------------------------------------

--- a/bindings/kotlin/scp-kt/src/main/kotlin/works/limn/scp/stream/Streams.kt
+++ b/bindings/kotlin/scp-kt/src/main/kotlin/works/limn/scp/stream/Streams.kt
@@ -3,10 +3,8 @@
 
 package works.limn.scp.stream
 
-import works.limn.scp.bridge.BridgeException
-import works.limn.scp.bridge.ContextBindings
-import works.limn.scp.bridge.InfraBindings
-import works.limn.scp.bridge.MessageCallback
+import java.util.concurrent.ConcurrentHashMap
+import java.util.concurrent.atomic.AtomicBoolean
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.channels.BufferOverflow
@@ -21,8 +19,13 @@ import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
 import kotlinx.coroutines.withContext
-import java.util.concurrent.ConcurrentHashMap
-import java.util.concurrent.atomic.AtomicBoolean
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.put
+import works.limn.scp.bridge.BridgeException
+import works.limn.scp.bridge.ContextBindings
+import works.limn.scp.bridge.InfraBindings
+import works.limn.scp.bridge.MessageCallback
 
 /**
  * Callback interface for real-time context events from the Rust engine.
@@ -255,7 +258,15 @@ class HotStreamFactory(
                         code: String,
                         message: String,
                     ) {
-                        sharedFlow.tryEmit("""{"_error":true,"code":"$code","message":"$message"}""")
+                        sharedFlow.tryEmit(
+                            Json.encodeToString(
+                                buildJsonObject {
+                                    put("_error", true)
+                                    put("code", code)
+                                    put("message", message)
+                                },
+                            ),
+                        )
                     }
 
                     override fun onComplete() {
@@ -312,7 +323,15 @@ class HotStreamFactory(
                         code: String,
                         message: String,
                     ) {
-                        sharedFlow.tryEmit("""{"_error":true,"code":"$code","message":"$message"}""")
+                        sharedFlow.tryEmit(
+                            Json.encodeToString(
+                                buildJsonObject {
+                                    put("_error", true)
+                                    put("code", code)
+                                    put("message", message)
+                                },
+                            ),
+                        )
                     }
 
                     override fun onComplete() {

--- a/bindings/kotlin/scp-kt/src/test/kotlin/works/limn/scp/ToolDefinitionTest.kt
+++ b/bindings/kotlin/scp-kt/src/test/kotlin/works/limn/scp/ToolDefinitionTest.kt
@@ -1,0 +1,184 @@
+// ToolDefinitionTest.kt — Unit tests for ToolDefinition.toJson() and ToolCost validation (#1203)
+//
+// Verifies that ToolDefinition.toJson() produces structurally valid JSON that is
+// immune to injection via untrusted string fields, and that ToolCost rejects
+// negative amounts.
+//
+// Provenance: spec §5.4.1, ADR-010, issue #1203
+
+package works.limn.scp
+
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+import kotlinx.serialization.json.long
+import org.junit.jupiter.api.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class ToolDefinitionTest {
+    @Test
+    fun `basic round-trip`() {
+        val def = ToolDefinition(
+            name = "calculator",
+            description = "Adds two numbers",
+            inputSchemaJson = """{"type":"object","properties":{"a":{"type":"number"}}}""",
+            outputSchemaJson = """{"type":"object","properties":{"sum":{"type":"number"}}}""",
+            operatorDid = "did:dht:operator123",
+            testVectorsJson = """[{"input":{"a":1},"output":{"sum":1}}]""",
+            implementationHashHex = "abcdef0123456789",
+            cost = ToolCost(amount = 100, currency = "USD", payee = "did:dht:payee456", costFormula = "flat"),
+        )
+        val json = def.toJson()
+        val obj = Json.parseToJsonElement(json).jsonObject
+
+        assertEquals("calculator", obj["name"]?.jsonPrimitive?.content)
+        assertEquals("Adds two numbers", obj["description"]?.jsonPrimitive?.content)
+        assertEquals("did:dht:operator123", obj["operator_did"]?.jsonPrimitive?.content)
+        assertEquals("abcdef0123456789", obj["implementation_hash"]?.jsonPrimitive?.content)
+
+        val costObj = obj["cost"]?.jsonObject
+        assertEquals(100L, costObj?.get("amount")?.jsonPrimitive?.long)
+        assertEquals("USD", costObj?.get("currency")?.jsonPrimitive?.content)
+        assertEquals("did:dht:payee456", costObj?.get("payee")?.jsonPrimitive?.content)
+        assertEquals("flat", costObj?.get("cost_formula")?.jsonPrimitive?.content)
+
+        // Schema fields are parsed JSON objects, not escaped strings
+        assertTrue(obj["input_schema_json"]?.jsonObject?.containsKey("type") == true)
+        assertTrue(obj["output_schema_json"]?.jsonObject?.containsKey("type") == true)
+
+        // Test vectors are a parsed JSON array, not an escaped string
+        val vectors = obj["test_vectors_json"]
+        assertTrue(vectors.toString().startsWith("["))
+    }
+
+    @Test
+    fun `minimal definition`() {
+        val def = ToolDefinition(
+            name = "ping",
+            description = "health check",
+            inputSchemaJson = """{}""",
+            outputSchemaJson = """{}""",
+            operatorDid = "did:dht:op1",
+        )
+        val json = def.toJson()
+        val obj = Json.parseToJsonElement(json).jsonObject
+
+        assertEquals("ping", obj["name"]?.jsonPrimitive?.content)
+        assertEquals("health check", obj["description"]?.jsonPrimitive?.content)
+        assertEquals("did:dht:op1", obj["operator_did"]?.jsonPrimitive?.content)
+        assertFalse(obj.containsKey("test_vectors_json"))
+        assertFalse(obj.containsKey("implementation_hash"))
+        assertFalse(obj.containsKey("cost"))
+    }
+
+    @Test
+    fun `special characters in name`() {
+        val def = ToolDefinition(
+            name = "tool\"with\\special\nchars",
+            description = "desc\twith\ttabs",
+            inputSchemaJson = """{}""",
+            outputSchemaJson = """{}""",
+            operatorDid = "did:dht:op",
+        )
+        val json = def.toJson()
+        // Must parse without exception — proves structural validity
+        val obj = Json.parseToJsonElement(json).jsonObject
+        assertEquals("tool\"with\\special\nchars", obj["name"]?.jsonPrimitive?.content)
+        assertEquals("desc\twith\ttabs", obj["description"]?.jsonPrimitive?.content)
+    }
+
+    @Test
+    fun `special characters in cost fields`() {
+        val def = ToolDefinition(
+            name = "tool",
+            description = "d",
+            inputSchemaJson = """{}""",
+            outputSchemaJson = """{}""",
+            operatorDid = "did:dht:op",
+            cost = ToolCost(
+                amount = 50,
+                currency = "US\"D",
+                payee = "did:dht:payee\u00e9\u00fc",
+            ),
+        )
+        val json = def.toJson()
+        val obj = Json.parseToJsonElement(json).jsonObject
+        val costObj = obj["cost"]?.jsonObject
+        assertEquals("US\"D", costObj?.get("currency")?.jsonPrimitive?.content)
+        assertEquals("did:dht:payee\u00e9\u00fc", costObj?.get("payee")?.jsonPrimitive?.content)
+    }
+
+    @Test
+    fun `negative amount rejection`() {
+        assertFailsWith<IllegalArgumentException> {
+            ToolCost(amount = -1, currency = "USD", payee = "did:dht:p")
+        }
+    }
+
+    @Test
+    fun `zero amount accepted`() {
+        val cost = ToolCost(amount = 0, currency = "USD", payee = "did:dht:p")
+        assertEquals(0L, cost.amount)
+    }
+
+    @Test
+    fun `large amount`() {
+        val cost = ToolCost(amount = Long.MAX_VALUE, currency = "BTC", payee = "did:dht:p")
+        assertEquals(Long.MAX_VALUE, cost.amount)
+
+        // Verify it serializes correctly through toJson
+        val def = ToolDefinition(
+            name = "expensive",
+            description = "d",
+            inputSchemaJson = """{}""",
+            outputSchemaJson = """{}""",
+            operatorDid = "did:dht:op",
+            cost = cost,
+        )
+        val json = def.toJson()
+        val obj = Json.parseToJsonElement(json).jsonObject
+        assertEquals(Long.MAX_VALUE, obj["cost"]?.jsonObject?.get("amount")?.jsonPrimitive?.long)
+    }
+
+    @Test
+    fun `cost formula omission`() {
+        val def = ToolDefinition(
+            name = "tool",
+            description = "d",
+            inputSchemaJson = """{}""",
+            outputSchemaJson = """{}""",
+            operatorDid = "did:dht:op",
+            cost = ToolCost(amount = 10, currency = "USD", payee = "did:dht:p"),
+        )
+        val json = def.toJson()
+        val costObj = Json.parseToJsonElement(json).jsonObject["cost"]?.jsonObject
+        assertFalse(costObj?.containsKey("cost_formula") == true)
+    }
+
+    @Test
+    fun `schema fields embedded as objects`() {
+        val inputSchema = """{"type":"object","properties":{"x":{"type":"integer"}}}"""
+        val outputSchema = """{"type":"array","items":{"type":"string"}}"""
+        val def = ToolDefinition(
+            name = "tool",
+            description = "d",
+            inputSchemaJson = inputSchema,
+            outputSchemaJson = outputSchema,
+            operatorDid = "did:dht:op",
+        )
+        val json = def.toJson()
+        val obj = Json.parseToJsonElement(json).jsonObject
+
+        // These must be JSON objects/arrays, not double-encoded strings
+        val parsedInput = obj["input_schema_json"]?.jsonObject
+        assertEquals("object", parsedInput?.get("type")?.jsonPrimitive?.content)
+
+        val parsedOutput = obj["output_schema_json"]
+        // output_schema_json is an array type schema — verify it parsed as a JSON object
+        assertTrue(parsedOutput?.jsonObject?.containsKey("type") == true)
+        assertEquals("array", parsedOutput?.jsonObject?.get("type")?.jsonPrimitive?.content)
+    }
+}

--- a/bindings/kotlin/scp-kt/src/test/kotlin/works/limn/scp/conformance/ConformanceDispatcher.kt
+++ b/bindings/kotlin/scp-kt/src/test/kotlin/works/limn/scp/conformance/ConformanceDispatcher.kt
@@ -10,6 +10,9 @@ import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.toList
 import kotlinx.coroutines.test.TestDispatcher
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.put
 
 /**
  * Maps conformance operation strings to Kotlin SDK bridge calls.
@@ -221,7 +224,7 @@ class ConformanceDispatcher(
         input: Map<String, String>,
     ): Map<String, String> = catchBridge {
         val relayUrl = input["relay_url"] ?: ""
-        val config = """{"url":"$relayUrl"}"""
+        val config = Json.encodeToString(buildJsonObject { put("url", relayUrl) })
         val handle = bridge.infra.transportConnect(config)
         mapOf("handle" to handle.toString(), "status" to "connected")
     }

--- a/bindings/kotlin/scp-kt/src/test/kotlin/works/limn/scp/conformance/ConformanceStubBindings.kt
+++ b/bindings/kotlin/scp-kt/src/test/kotlin/works/limn/scp/conformance/ConformanceStubBindings.kt
@@ -3,6 +3,9 @@
 
 package works.limn.scp.conformance
 
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.put
 import works.limn.scp.bridge.BridgeException
 import works.limn.scp.bridge.CancellationHandle
 import works.limn.scp.bridge.MessageCallback
@@ -246,8 +249,15 @@ class ConformanceStubBindings : NativeBindings {
         toolId: String,
         targetContextId: String,
         rateLimitJson: String?,
-    ): String = """{"source_context":"ctx-src","target_context":"$targetContextId",""" +
-        """"tool_id":"$toolId","approved_by_source":true,"approved_by_target":false}"""
+    ): String = Json.encodeToString(
+        buildJsonObject {
+            put("source_context", "ctx-src")
+            put("target_context", targetContextId)
+            put("tool_id", toolId)
+            put("approved_by_source", true)
+            put("approved_by_target", false)
+        },
+    )
 
     override fun toolInterfaceAccept(
         contextHandle: Long,
@@ -257,7 +267,13 @@ class ConformanceStubBindings : NativeBindings {
     override fun toolInterfaceRevoke(
         contextHandle: Long,
         interfaceIdHex: String,
-    ): String = """{"interface_id":"$interfaceIdHex","revoking_context":"ctx-revoker","revoked_at":1700000000000}"""
+    ): String = Json.encodeToString(
+        buildJsonObject {
+            put("interface_id", interfaceIdHex)
+            put("revoking_context", "ctx-revoker")
+            put("revoked_at", 1700000000000)
+        },
+    )
 
     @Suppress("LongParameterList")
     override fun toolInvokeCrossContext(


### PR DESCRIPTION
## Summary
- **P0 security fix**: Replace all manual JSON string concatenation with `kotlinx.serialization.json.buildJsonObject` across production and test code
- `ToolDefinition.toJson()`: safe escaping of all string fields, schema fields embedded as JSON objects
- `Streams.kt`: error callbacks in `HotStreamFactory` (production code)
- `ConformanceDispatcher.kt` and `ConformanceStubBindings.kt`: test code
- Added `ToolCost.init{}` validation rejecting negative amounts (`IllegalArgumentException`)
- 9 new test cases in `ToolDefinitionTest.kt`: round-trip, special chars, injection, validation, schema embedding

## Test plan
- [x] All 9 new ToolDefinitionTest cases pass
- [x] `./gradlew :scp-kt:test` — BUILD SUCCESSFUL
- [x] `./gradlew :scp-kt:detekt` — BUILD SUCCESSFUL
- [x] No remaining manual JSON string interpolation in production Kotlin code

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>