### PR TITLE
feat(wasm): add real MLS encryption to WASM bridge (closes #602, closes #646, closes #535)

### DIFF
--- a/.docs/adrs/phase-4.md
+++ b/.docs/adrs/phase-4.md
@@ -1414,7 +1414,7 @@ ADR-022 specifies a wasm-bindgen bridge crate (`crates/scp-ffi/wasm/`) that comp
 
 1. **tokio multi-thread runtime.** scp-core uses `tokio::runtime::Runtime` with the multi-thread scheduler (required by PyO3 native async, MLS group operations, and transport concurrency). The `wasm32-unknown-unknown` target does not support `std::thread`, so `tokio::runtime::Builder::new_multi_thread()` fails to compile. While tokio offers a `current_thread` runtime that compiles to WASM, switching would require pervasive changes throughout scp-core and all FFI bridges, breaking the single-implementation invariant.
 
-2. **OpenMLS dependencies.** OpenMLS pulls in platform-specific crypto backends (RustCrypto or ring) that include assembly routines and C code incompatible with `wasm32-unknown-unknown`. The OpenMLS `wasm` feature flag exists but changes the API surface and introduces a different set of trait requirements that would require a parallel integration path.
+2. **OpenMLS dependencies.** ~~OpenMLS pulls in platform-specific crypto backends (RustCrypto or ring) that include assembly routines and C code incompatible with `wasm32-unknown-unknown`.~~ **Update (2026-03-15):** OpenMLS 0.8 with `default-features = false, features = ["js"]` compiles cleanly to `wasm32-unknown-unknown`. The `js` feature uses the RustCrypto backend with WASM-compatible randomness (`getrandom/js`). The WASM bridge now uses OpenMLS directly for MLS encryption (see `crates/scp-ffi/wasm/src/crypto/`). Wire's production WASM deployment validates this approach. The remaining blocker is tokio multi-thread (item 1), not OpenMLS.
 
 These are not feature-flag-able constraints — they are structural incompatibilities between scp-core's architecture and the WASM compilation target.
 
@@ -1424,8 +1424,8 @@ The WASM bridge (`crates/scp-ffi/wasm/`) uses **verbatim re-implementation** of 
 
 - Implements the same public API types and function signatures as the napi-rs bridge.
 - Uses `wasm-bindgen-futures` for async bridging (single-threaded, cooperative scheduling on the browser event loop).
-- Uses WebCrypto API (via `web-sys`) for cryptographic operations instead of ring/RustCrypto.
-- Uses a WASM-compatible MLS implementation or a pure-Rust MLS subset that compiles to WASM.
+- Uses WebCrypto API (via `web-sys`) for non-MLS cryptographic operations (Ed25519, randomness). **Update (2026-03-15):** MLS encryption uses OpenMLS directly with `features = ["js"]` — no WebCrypto shim needed for MLS.
+- Uses OpenMLS 0.8 with the `js` feature flag for MLS group encryption, compiled directly to WASM. The `OpenMlsRustCrypto` in-memory provider handles crypto and storage.
 - Passes the same cross-language conformance test suite as all other bridges (JSON fixtures from `tests/conformance/`).
 
 The re-implementation is NOT a fork — it is a second implementation of the same specification, verified against the same acceptance criteria.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1401,7 +1401,7 @@ dependencies = [
  "hashbrown 0.14.5",
  "lock_api",
  "once_cell",
- "parking_lot_core",
+ "parking_lot_core 0.9.12",
 ]
 
 [[package]]
@@ -1826,6 +1826,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "fluvio-wasm-timer"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b768c170dc045fa587a8f948c91f9bcfb87f774930477c6215addf54317f137f"
+dependencies = [
+ "futures",
+ "js-sys",
+ "parking_lot 0.11.2",
+ "pin-utils",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+]
+
+[[package]]
 name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1936,7 +1951,7 @@ checksum = "1d930c203dd0b6ff06e0201a4a2fe9149b43c684fd4420555b26d21b1a02956f"
 dependencies = [
  "futures-core",
  "lock_api",
- "parking_lot",
+ "parking_lot 0.12.5",
 ]
 
 [[package]]
@@ -2697,6 +2712,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "879f10e63c20629ecabbb64a8010319738c66a5cd0c29b02d63d272b03751d01"
 dependencies = [
  "generic-array",
+]
+
+[[package]]
+name = "instant"
+version = "0.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e0242819d153cba4b4b05a5a8f2a7e9bbf97b6055b2a002b395c96b5ff3c0222"
+dependencies = [
+ "cfg-if",
+ "js-sys",
+ "wasm-bindgen",
+ "web-sys",
 ]
 
 [[package]]
@@ -3652,6 +3679,8 @@ version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dcb512bfe6a55777518853ea535c6241f069cb0e8984678c117151d2a1e7e903"
 dependencies = [
+ "fluvio-wasm-timer",
+ "getrandom 0.3.4",
  "log",
  "openmls_libcrux_crypto 0.3.1",
  "openmls_test",
@@ -3926,12 +3955,37 @@ checksum = "f38d5652c16fde515bb1ecef450ab0f6a219d619a7274976324d5e377f7dceba"
 
 [[package]]
 name = "parking_lot"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d17b78036a60663b797adeaee46f5c9dfebb86948d1255007a1d6be0271ff99"
+dependencies = [
+ "instant",
+ "lock_api",
+ "parking_lot_core 0.8.6",
+]
+
+[[package]]
+name = "parking_lot"
 version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "93857453250e3077bd71ff98b6a65ea6621a19bb0f559a85248955ac12c45a1a"
 dependencies = [
  "lock_api",
- "parking_lot_core",
+ "parking_lot_core 0.9.12",
+]
+
+[[package]]
+name = "parking_lot_core"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "60a2cfe6f0ad2bfc16aefa463b497d5c7a5ecd44a23efa72aa342d90177356dc"
+dependencies = [
+ "cfg-if",
+ "instant",
+ "libc",
+ "redox_syscall 0.2.16",
+ "smallvec",
+ "winapi",
 ]
 
 [[package]]
@@ -4478,6 +4532,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8eca1e9d98d5a7e9002d0013e18d5a9b000aee942eb134883a82f06ebffb6c01"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "redox_syscall"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb5a58c1855b4b6819d59012155603f0b22ad30cad752600aadfcb695265519a"
+dependencies = [
+ "bitflags 1.3.2",
 ]
 
 [[package]]
@@ -5126,6 +5189,7 @@ dependencies = [
 name = "scp-ffi-wasm"
 version = "0.1.0"
 dependencies = [
+ "aes-gcm",
  "base64",
  "ed25519-dalek 2.2.0",
  "getrandom 0.2.17",
@@ -5134,7 +5198,12 @@ dependencies = [
  "hmac",
  "js-sys",
  "jsonschema",
+ "openmls",
+ "openmls_basic_credential",
+ "openmls_rust_crypto 0.5.1",
+ "openmls_traits 0.5.0",
  "rand_core 0.6.4",
+ "rmp-serde",
  "scp-ffi-common",
  "serde",
  "serde_bytes",
@@ -5143,6 +5212,7 @@ dependencies = [
  "sha2 0.10.9",
  "subtle",
  "thiserror 2.0.18",
+ "tls_codec",
  "uuid",
  "wasm-bindgen",
  "wasm-bindgen-futures",
@@ -6192,7 +6262,7 @@ dependencies = [
  "bytes",
  "libc",
  "mio",
- "parking_lot",
+ "parking_lot 0.12.5",
  "pin-project-lite",
  "signal-hook-registry",
  "socket2 0.6.3",

--- a/crates/scp-ffi/wasm/CLAUDE.md
+++ b/crates/scp-ffi/wasm/CLAUDE.md
@@ -24,6 +24,30 @@ All re-implementations must be algorithm-identical to scp-core. When scp-core ch
 | `custody.rs` | `JsKeyCustody` extern type (WebCrypto injection point) |
 | `storage.rs` | `JsStorage` extern type (OPFS/IndexedDB injection point) |
 | `error.rs` | `ScpWasmError` → `JsError` mapping with stable error codes |
+| `crypto/` | MLS encryption + sender key layer (see below) |
+
+## MLS Encryption (`crypto/` module)
+
+Real MLS encryption using OpenMLS 0.8 with `features = ["js"]`. **Not a reimplementation** — uses the same `openmls` crate as scp-core, just with the WASM-compatible JS crypto backend instead of `libcrux-provider`.
+
+| Submodule | Responsibility |
+|-----------|---------------|
+| `crypto/error.rs` | `WasmCryptoError` enum → `JsError` mapping |
+| `crypto/credential.rs` | `WasmScpCredential` — MessagePack-serialized MLS identity payload (byte-compatible with scp-core) |
+| `crypto/group.rs` | `WasmMlsGroup` — OpenMLS `MlsGroup` wrapper (create, add, remove, join, encrypt, decrypt, destroy) |
+| `crypto/encrypt.rs` | Higher-level MLS encrypt/decrypt with TLS serialization |
+| `crypto/sender_key.rs` | AES-256-GCM sender-side key layer (AAD format matches scp-core exactly) |
+| `crypto/state.rs` | `WasmCryptoState` — orchestrates double encryption (sender key → MLS on send, MLS → sender key on receive) |
+
+**Key design points:**
+- `PerContextState` in `manager.rs` has a `crypto: Option<WasmCryptoState>` field. `Some` for encrypted contexts, `None` for broadcast/unencrypted.
+- `create_context` auto-initializes crypto for Encrypted mode contexts.
+- `send_message` encrypts via double layer when crypto is present.
+- `join_context_encrypted` requires a prior `generate_key_package_for_join` call (two-step flow: generate KP → send to adder → receive Welcome → join).
+- `close_context` and `leave_context` destroy crypto state (zeroize keys).
+- `WasmContextManager.pending_key_packages` stores key package holders between generate and join steps.
+
+**Ciphersuite:** `MLS_128_DHKEMX25519_AES128GCM_SHA256_Ed25519` (same as scp-core).
 
 ## Runtime Registry
 

--- a/crates/scp-ffi/wasm/Cargo.toml
+++ b/crates/scp-ffi/wasm/Cargo.toml
@@ -38,6 +38,15 @@ serde_bytes = { workspace = true }
 scp-ffi-common = { path = "../common", default-features = false }
 zeroize = { workspace = true }
 subtle = { workspace = true }
+# MLS encryption — openmls with `js` feature for WASM crypto backend.
+# NOT workspace (workspace uses `libcrux-provider` which is native-only).
+openmls = { version = "0.8", default-features = false, features = ["js"] }
+openmls_traits = { workspace = true }
+openmls_basic_credential = { workspace = true }
+openmls_rust_crypto = { workspace = true }
+tls_codec = { version = "0.4", features = ["derive"] }
+rmp-serde = { workspace = true }
+aes-gcm = { workspace = true }
 
 [dev-dependencies]
 wasm-bindgen-test = "0.3"

--- a/crates/scp-ffi/wasm/src/context.rs
+++ b/crates/scp-ffi/wasm/src/context.rs
@@ -382,6 +382,104 @@ pub fn context_send(
     })
 }
 
+/// Decrypts a message received from an encrypted SCP context.
+///
+/// Reverses the double encryption: MLS decrypt -> sender key decrypt.
+/// Returns the decrypted plaintext as a `Uint8Array`.
+///
+/// # Errors
+///
+/// Returns an error if the context has no MLS encryption state, or if
+/// decryption fails.
+#[wasm_bindgen]
+pub fn context_decrypt_message(
+    handle: &WasmContextHandle,
+    sender_did: String,
+    ciphertext_base64: String,
+    epoch: u64,
+    sequence: u64,
+) -> Promise {
+    if let Err(e) = validate_did(&sender_did) {
+        return future_to_promise(async move { Err(ScpWasmError::from(e).into_js().into()) });
+    }
+    let context_id = handle.context_id();
+
+    future_to_promise(async move {
+        let plaintext = with_manager(|mgr| {
+            mgr.decrypt_message(
+                &context_id,
+                &sender_did,
+                &ciphertext_base64,
+                epoch,
+                sequence,
+            )
+        })
+        .map_err(ScpWasmError::into_js)?;
+
+        // Return as Uint8Array.
+        let js_array = js_sys::Uint8Array::from(plaintext.as_slice());
+        Ok(JsValue::from(js_array))
+    })
+}
+
+/// Generates an MLS key package for joining an encrypted context.
+///
+/// Returns the TLS-serialized key package bytes as a `Uint8Array`. The
+/// private key material is retained internally for later use by
+/// [`context_join_encrypted`].
+///
+/// This must be called BEFORE `context_join_encrypted` — the returned
+/// key package is sent to the adder, who uses it to produce a Welcome.
+///
+/// # Errors
+///
+/// Returns an error if key package generation fails.
+#[wasm_bindgen]
+pub fn context_generate_key_package(handle: &WasmContextHandle, identity_did: String) -> Promise {
+    if let Err(e) = validate_did(&identity_did) {
+        return future_to_promise(async move { Err(ScpWasmError::from(e).into_js().into()) });
+    }
+    let context_id = handle.context_id();
+
+    future_to_promise(async move {
+        let kp_bytes =
+            with_manager(|mgr| mgr.generate_key_package_for_join(&context_id, &identity_did))
+                .map_err(ScpWasmError::into_js)?;
+
+        let js_array = js_sys::Uint8Array::from(kp_bytes.as_slice());
+        Ok(JsValue::from(js_array))
+    })
+}
+
+/// Joins an encrypted SCP context using an MLS Welcome message.
+///
+/// Processes the Welcome to reconstruct the MLS group state, then sets up
+/// the sender key layer. A key package must have been previously generated
+/// via [`context_generate_key_package`] for the same context and identity.
+///
+/// # Errors
+///
+/// Returns an error if no pending key package exists, the Welcome cannot
+/// be processed, or the context is not active.
+#[wasm_bindgen]
+pub fn context_join_encrypted(
+    handle: &WasmContextHandle,
+    identity_did: String,
+    welcome_bytes: Vec<u8>,
+) -> Promise {
+    if let Err(e) = validate_did(&identity_did) {
+        return future_to_promise(async move { Err(ScpWasmError::from(e).into_js().into()) });
+    }
+    let context_id = handle.context_id();
+
+    future_to_promise(async move {
+        with_manager(|mgr| mgr.join_context_encrypted(&context_id, &identity_did, &welcome_bytes))
+            .map_err(ScpWasmError::into_js)?;
+
+        Ok(JsValue::UNDEFINED)
+    })
+}
+
 /// Subscribes to incoming messages from an SCP context.
 ///
 /// Registers a JS callback. In the full runtime, the transport layer calls

--- a/crates/scp-ffi/wasm/src/crypto/credential.rs
+++ b/crates/scp-ffi/wasm/src/crypto/credential.rs
@@ -1,0 +1,224 @@
+//! WASM-local SCP credential for MLS `LeafNode` identity payloads.
+//!
+//! Ports `scp_core::crypto::mls::credential::ScpCredential` into a
+//! WASM-compatible form. Serialization uses `MessagePack` (`rmp-serde`)
+//! for binary compatibility with scp-core credentials.
+//!
+//! See ADR-001 and spec section 9.7.1 for the credential design,
+//! and ADR-039 for the signing key model.
+
+use serde::{Deserialize, Serialize};
+
+use super::error::WasmCryptoError;
+
+/// Identifies which DID document verification method signed a credential.
+///
+/// Maps to `scp_identity::SigningKeyId`. Serialized as `"#active"` or
+/// `"#agent"` via serde, matching the scp-core format for `MessagePack`
+/// interoperability.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum WasmSigningKeyId {
+    /// The `#active` verification method (human or primary key).
+    #[serde(rename = "#active")]
+    Active,
+    /// The `#agent` verification method (agent key per ADR-039).
+    #[serde(rename = "#agent")]
+    Agent,
+}
+
+impl WasmSigningKeyId {
+    /// Returns the DID document fragment for this signing key ID.
+    #[must_use]
+    pub const fn fragment(&self) -> &str {
+        match self {
+            Self::Active => "#active",
+            Self::Agent => "#agent",
+        }
+    }
+}
+
+/// Returns the default `WasmSigningKeyId` (`Active`) for serde deserialization
+/// of credentials that predate the `signing_key_id` field (backward compat).
+const fn default_signing_key_id() -> WasmSigningKeyId {
+    WasmSigningKeyId::Active
+}
+
+/// An SCP credential containing the participant's DID, optional UCAN token,
+/// and signing key identifier.
+///
+/// This struct is serialized to `MessagePack` bytes and used as the identity
+/// payload inside an MLS `BasicCredential`. The format is byte-compatible
+/// with `scp_core::crypto::mls::credential::ScpCredential`.
+///
+/// See ADR-001 for the MLS wrapper design, spec section 9.7.1 for the
+/// SCP-to-MLS concept mapping, and ADR-039 for the signing key model.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct WasmScpCredential {
+    /// The participant's decentralized identifier (DID).
+    pub did: String,
+    /// Optional UCAN authorization token.
+    pub ucan_token: Option<String>,
+    /// Which DID document verification method signed this credential.
+    #[serde(default = "default_signing_key_id")]
+    pub signing_key_id: WasmSigningKeyId,
+}
+
+impl WasmScpCredential {
+    /// Creates a new SCP credential with the given DID, optional UCAN token,
+    /// and signing key identifier.
+    ///
+    /// The DID must be a valid `did:dht` identifier starting with `"did:dht:z"`.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`WasmCryptoError::InvalidDidFormat`] if the DID does not start
+    /// with `"did:dht:z"`.
+    pub fn new(
+        did: String,
+        ucan_token: Option<String>,
+        signing_key_id: WasmSigningKeyId,
+    ) -> Result<Self, WasmCryptoError> {
+        if !did.starts_with("did:dht:z") {
+            return Err(WasmCryptoError::InvalidDidFormat(did));
+        }
+        Ok(Self {
+            did,
+            ucan_token,
+            signing_key_id,
+        })
+    }
+
+    /// Serializes this credential to `MessagePack` bytes.
+    ///
+    /// The resulting bytes are suitable for use as the identity payload in an
+    /// MLS `BasicCredential`.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`WasmCryptoError::CredentialSerializationFailed`] if
+    /// `MessagePack` serialization fails.
+    pub fn to_bytes(&self) -> Result<Vec<u8>, WasmCryptoError> {
+        rmp_serde::to_vec(self)
+            .map_err(|e| WasmCryptoError::CredentialSerializationFailed(e.to_string()))
+    }
+
+    /// Deserializes an SCP credential from `MessagePack` bytes.
+    ///
+    /// Handles both the current format (with `signing_key_id`) and the legacy
+    /// format (without it, defaults to `WasmSigningKeyId::Active`).
+    ///
+    /// # Errors
+    ///
+    /// Returns [`WasmCryptoError::CredentialSerializationFailed`] if the
+    /// bytes are not valid `MessagePack` or do not represent a valid credential.
+    pub fn from_bytes(bytes: &[u8]) -> Result<Self, WasmCryptoError> {
+        rmp_serde::from_slice(bytes)
+            .map_err(|e| WasmCryptoError::CredentialSerializationFailed(e.to_string()))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const TEST_DID: &str = "did:dht:z6MkhaXgBZDvotDkL5257faiztiGiC2QtKLGpbnnEGta2doK";
+
+    #[test]
+    #[allow(clippy::unwrap_used)]
+    fn credential_roundtrip_active() {
+        let cred = WasmScpCredential::new(
+            TEST_DID.to_string(),
+            Some("eyJhbGciOiJFZERTQSJ9.test-ucan-token".to_string()),
+            WasmSigningKeyId::Active,
+        )
+        .unwrap();
+        let bytes = cred.to_bytes().unwrap();
+        let decoded = WasmScpCredential::from_bytes(&bytes).unwrap();
+        assert_eq!(cred, decoded);
+        assert_eq!(decoded.signing_key_id, WasmSigningKeyId::Active);
+    }
+
+    #[test]
+    #[allow(clippy::unwrap_used)]
+    fn credential_roundtrip_agent() {
+        let cred = WasmScpCredential::new(
+            TEST_DID.to_string(),
+            Some("eyJhbGciOiJFZERTQSJ9.test-ucan-token".to_string()),
+            WasmSigningKeyId::Agent,
+        )
+        .unwrap();
+        let bytes = cred.to_bytes().unwrap();
+        let decoded = WasmScpCredential::from_bytes(&bytes).unwrap();
+        assert_eq!(cred, decoded);
+        assert_eq!(decoded.signing_key_id, WasmSigningKeyId::Agent);
+    }
+
+    #[test]
+    #[allow(clippy::unwrap_used)]
+    fn credential_roundtrip_without_ucan() {
+        let cred =
+            WasmScpCredential::new(TEST_DID.to_string(), None, WasmSigningKeyId::Active).unwrap();
+        let bytes = cred.to_bytes().unwrap();
+        let decoded = WasmScpCredential::from_bytes(&bytes).unwrap();
+        assert_eq!(cred, decoded);
+    }
+
+    #[test]
+    #[allow(clippy::unwrap_used)]
+    fn backward_compat_old_format_defaults_to_active() {
+        // Simulate legacy credential without signing_key_id.
+        #[derive(Serialize)]
+        struct LegacyCredential {
+            did: String,
+            ucan_token: Option<String>,
+        }
+        let legacy = LegacyCredential {
+            did: TEST_DID.to_string(),
+            ucan_token: Some("test-ucan".to_string()),
+        };
+        let bytes = rmp_serde::to_vec(&legacy).unwrap();
+        let decoded = WasmScpCredential::from_bytes(&bytes).unwrap();
+        assert_eq!(decoded.did, TEST_DID);
+        assert_eq!(decoded.signing_key_id, WasmSigningKeyId::Active);
+    }
+
+    #[test]
+    fn credential_from_invalid_bytes_returns_error() {
+        let result = WasmScpCredential::from_bytes(&[0xff, 0xfe, 0xfd]);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn new_rejects_empty_did() {
+        let result = WasmScpCredential::new(String::new(), None, WasmSigningKeyId::Active);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn new_rejects_wrong_method() {
+        let result = WasmScpCredential::new(
+            "did:key:z6MkSomething".to_string(),
+            None,
+            WasmSigningKeyId::Active,
+        );
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn new_rejects_missing_z_prefix() {
+        let result =
+            WasmScpCredential::new("did:dht:abc123".to_string(), None, WasmSigningKeyId::Active);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    #[allow(clippy::unwrap_used)]
+    fn signing_key_id_preserved_in_roundtrip() {
+        for key_id in [WasmSigningKeyId::Active, WasmSigningKeyId::Agent] {
+            let cred = WasmScpCredential::new(TEST_DID.to_string(), None, key_id).unwrap();
+            let bytes = cred.to_bytes().unwrap();
+            let decoded = WasmScpCredential::from_bytes(&bytes).unwrap();
+            assert_eq!(decoded.signing_key_id, key_id);
+        }
+    }
+}

--- a/crates/scp-ffi/wasm/src/crypto/encrypt.rs
+++ b/crates/scp-ffi/wasm/src/crypto/encrypt.rs
@@ -1,0 +1,107 @@
+//! Higher-level MLS encrypt/decrypt with TLS serialization.
+//!
+//! Wraps `WasmMlsGroup::encrypt`/`decrypt` with TLS codec pre-validation
+//! and serialization for wire-ready ciphertext. The decrypt path performs
+//! TLS deserialization *before* calling into `OpenMLS` `process_message`,
+//! catching malformed wire data early.
+
+use openmls::prelude::*;
+use tls_codec::Deserialize as TlsDeserializeTrait;
+
+use super::error::WasmCryptoError;
+use super::group::WasmMlsGroup;
+
+/// Encrypts plaintext using the MLS group and returns TLS-serialized bytes.
+///
+/// This is a convenience wrapper around `WasmMlsGroup::encrypt` that
+/// handles serialization. The returned bytes can be sent over the wire.
+///
+/// # Errors
+///
+/// Returns an error if the group is destroyed or encryption fails.
+pub fn mls_encrypt(group: &mut WasmMlsGroup, plaintext: &[u8]) -> Result<Vec<u8>, WasmCryptoError> {
+    group.encrypt(plaintext)
+}
+
+/// Decrypts TLS-serialized MLS ciphertext and returns the plaintext.
+///
+/// Pre-validates the ciphertext by TLS-deserializing into `MlsMessageIn` and
+/// verifying it is a protocol message *before* passing to `process_message`.
+/// This catches obviously malformed wire data early (deserialization errors)
+/// rather than deep inside `OpenMLS` where panics are possible.
+///
+/// # WASM trap risk
+///
+/// On `wasm32`, `std::panic::catch_unwind` is a no-op — panics abort the
+/// WASM instance. `OpenMLS` 0.8 may panic on tampered AEAD ciphertext
+/// (specifically inside `libcrux`/`RustCrypto` AES-GCM decryption), causing
+/// a WASM trap that kills the browser tab.
+///
+/// **Mitigation:** The relay is untrusted by design (ADR-004); clients should
+/// handle WASM trap errors at the JS layer (e.g., `try/catch` around the
+/// `wasm-bindgen` call). The pre-validation here reduces (but cannot eliminate)
+/// the attack surface — well-formed TLS framing with tampered AEAD payloads
+/// will still reach `process_message`.
+///
+// SAFETY: On wasm32, catch_unwind is a no-op. OpenMLS 0.8 may panic on tampered
+// AEAD ciphertext, causing a WASM trap. This is a known DoS vector against
+// browser clients. Mitigation: the relay is untrusted by design; clients
+// should handle WASM trap errors at the JS layer.
+///
+/// # Errors
+///
+/// Returns an error if the group is destroyed, TLS deserialization fails,
+/// the message is not a protocol message, or decryption fails.
+pub fn mls_decrypt(
+    group: &mut WasmMlsGroup,
+    ciphertext: &[u8],
+) -> Result<Vec<u8>, WasmCryptoError> {
+    // Pre-validate: TLS-deserialize the wire bytes into an MlsMessageIn.
+    // This catches malformed framing before OpenMLS touches the AEAD payload.
+    let mls_in = MlsMessageIn::tls_deserialize(&mut &*ciphertext)
+        .map_err(|e| WasmCryptoError::DecryptionFailed(format!("TLS deserialization: {e}")))?;
+
+    // Verify it is a protocol message (not a Welcome, GroupInfo, or KeyPackage).
+    let protocol_msg = mls_in.try_into_protocol_message().map_err(|_| {
+        WasmCryptoError::DecryptionFailed("message is not a protocol message".to_string())
+    })?;
+
+    // Delegate to the group for AEAD decryption and epoch processing.
+    group.decrypt_protocol_message(protocol_msg)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::crypto::credential::{WasmScpCredential, WasmSigningKeyId};
+
+    #[allow(clippy::unwrap_used)]
+    fn test_credential(name: &str) -> WasmScpCredential {
+        WasmScpCredential::new(
+            format!("did:dht:z6Mk{name}"),
+            None,
+            WasmSigningKeyId::Active,
+        )
+        .unwrap()
+    }
+
+    #[test]
+    #[allow(clippy::unwrap_used)]
+    fn mls_encrypt_decrypt_roundtrip() {
+        let alice_cred = test_credential("alice");
+        let mut alice_group = WasmMlsGroup::create_group(&alice_cred).unwrap();
+
+        let bob_cred = test_credential("bob");
+        let (bob_kp_bytes, bob_holder) = WasmMlsGroup::generate_key_package(&bob_cred).unwrap();
+
+        let bob_kp_in = KeyPackageIn::tls_deserialize(&mut &*bob_kp_bytes).unwrap();
+        let (_commit, welcome) = alice_group.add_member(bob_kp_in).unwrap();
+
+        let mut bob_group = WasmMlsGroup::join_from_welcome(&welcome, bob_holder).unwrap();
+
+        let plaintext = b"mls roundtrip test message";
+        let ciphertext = mls_encrypt(&mut alice_group, plaintext).unwrap();
+        let decrypted = mls_decrypt(&mut bob_group, &ciphertext).unwrap();
+        assert_eq!(decrypted, plaintext);
+    }
+}

--- a/crates/scp-ffi/wasm/src/crypto/error.rs
+++ b/crates/scp-ffi/wasm/src/crypto/error.rs
@@ -1,0 +1,88 @@
+//! WASM MLS crypto error types.
+//!
+//! All errors produced by the WASM crypto module are represented as
+//! [`WasmCryptoError`]. These map to `JsError` for propagation to JavaScript.
+
+use std::fmt;
+use wasm_bindgen::JsError;
+
+/// Errors produced by WASM MLS and sender key operations.
+///
+/// Each variant covers a distinct failure mode. Error messages include
+/// the underlying cause (stringified to avoid leaking `OpenMLS` types).
+#[derive(Debug)]
+pub enum WasmCryptoError {
+    /// Failed to create a new MLS group.
+    GroupCreationFailed(String),
+    /// Failed to add a member to the group.
+    AddMemberFailed(String),
+    /// Failed to remove a member from the group.
+    RemoveMemberFailed(String),
+    /// Failed to generate a key package.
+    KeyPackageGenerationFailed(String),
+    /// Failed to process a Welcome message.
+    WelcomeProcessingFailed(String),
+    /// Credential serialization or deserialization failed.
+    CredentialSerializationFailed(String),
+    /// The MLS group has been destroyed and cannot be used.
+    GroupDestroyed,
+    /// MLS encryption failed.
+    EncryptionFailed(String),
+    /// MLS decryption failed.
+    DecryptionFailed(String),
+    /// Sender key layer error.
+    SenderKeyError(String),
+    /// Failed to merge a pending commit.
+    MergePendingCommitFailed(String),
+    /// The processed message was not an application message.
+    NotApplicationMessage,
+    /// Ciphertext too short for sender key decryption.
+    CiphertextTooShort {
+        /// Actual ciphertext length.
+        actual: usize,
+        /// Minimum required length.
+        minimum: usize,
+    },
+    /// Sender key authentication tag verification failed.
+    AuthenticationFailed,
+    /// Invalid DID format.
+    InvalidDidFormat(String),
+}
+
+impl fmt::Display for WasmCryptoError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::GroupCreationFailed(msg) => write!(f, "group creation failed: {msg}"),
+            Self::AddMemberFailed(msg) => write!(f, "add member failed: {msg}"),
+            Self::RemoveMemberFailed(msg) => write!(f, "remove member failed: {msg}"),
+            Self::KeyPackageGenerationFailed(msg) => {
+                write!(f, "key package generation failed: {msg}")
+            }
+            Self::WelcomeProcessingFailed(msg) => write!(f, "welcome processing failed: {msg}"),
+            Self::CredentialSerializationFailed(msg) => {
+                write!(f, "credential serialization failed: {msg}")
+            }
+            Self::GroupDestroyed => write!(f, "group has been destroyed"),
+            Self::EncryptionFailed(msg) => write!(f, "encryption failed: {msg}"),
+            Self::DecryptionFailed(msg) => write!(f, "decryption failed: {msg}"),
+            Self::SenderKeyError(msg) => write!(f, "sender key error: {msg}"),
+            Self::MergePendingCommitFailed(msg) => {
+                write!(f, "merge pending commit failed: {msg}")
+            }
+            Self::NotApplicationMessage => write!(f, "not an application message"),
+            Self::CiphertextTooShort { actual, minimum } => {
+                write!(f, "ciphertext too short: {actual} bytes, minimum {minimum}")
+            }
+            Self::AuthenticationFailed => {
+                write!(f, "authentication tag verification failed")
+            }
+            Self::InvalidDidFormat(did) => write!(f, "invalid DID format: {did}"),
+        }
+    }
+}
+
+impl From<WasmCryptoError> for JsError {
+    fn from(err: WasmCryptoError) -> Self {
+        Self::new(&err.to_string())
+    }
+}

--- a/crates/scp-ffi/wasm/src/crypto/group.rs
+++ b/crates/scp-ffi/wasm/src/crypto/group.rs
@@ -1,0 +1,504 @@
+//! WASM-local MLS group lifecycle operations.
+//!
+//! Ports `scp_core::crypto::mls::group` into a WASM-compatible form. Uses
+//! `OpenMlsRustCrypto` (in-memory provider) since the WASM bridge cannot use
+//! the platform `Storage` backend.
+//!
+//! All operations are synchronous (no tokio, no async).
+//!
+//! # Ciphersuite
+//!
+//! All groups use `MLS_128_DHKEMX25519_AES128GCM_SHA256_Ed25519` — no
+//! ciphersuite negotiation. See ADR-001 for the rationale.
+
+use openmls::prelude::*;
+use openmls_basic_credential::SignatureKeyPair;
+use openmls_rust_crypto::OpenMlsRustCrypto;
+use openmls_traits::OpenMlsProvider;
+use tls_codec::{Deserialize as TlsDeserializeTrait, Serialize as TlsSerializeTrait};
+
+use super::credential::WasmScpCredential;
+use super::error::WasmCryptoError;
+
+/// The single ciphersuite used by all SCP MLS groups.
+///
+/// `MLS_128_DHKEMX25519_AES128GCM_SHA256_Ed25519` provides:
+/// - X25519 for key exchange (DHKEM)
+/// - AES-128-GCM for authenticated encryption
+/// - SHA-256 for hashing
+/// - Ed25519 for digital signatures
+///
+/// No ciphersuite negotiation. See ADR-001.
+pub const SCP_CIPHERSUITE: Ciphersuite = Ciphersuite::MLS_128_DHKEMX25519_AES128GCM_SHA256_Ed25519;
+
+/// Wrapper around an `OpenMLS` `MlsGroup` for WASM.
+///
+/// Holds the MLS group state, the in-memory crypto provider, and the local
+/// member's signing key. All operations are synchronous.
+pub struct WasmMlsGroup {
+    /// The underlying `OpenMLS` group. `None` after destruction.
+    group: Option<MlsGroup>,
+    /// The MLS provider (crypto + in-memory storage).
+    provider: OpenMlsRustCrypto,
+    /// Ed25519 signing key pair. `None` after destruction.
+    ///
+    /// # Zeroization gap
+    ///
+    /// `SignatureKeyPair` (`OpenMLS` upstream) stores the private key in
+    /// a plain `Vec<u8>` and does NOT implement `Zeroize` or `ZeroizeOnDrop`.
+    /// On drop, the key material remains in WASM linear memory until
+    /// overwritten by the allocator. scp-core mitigates this with
+    /// `EagerDropSigner`; the WASM bridge accepts the residue risk because
+    /// WASM linear memory is same-origin isolated.
+    signer: Option<SignatureKeyPair>,
+}
+
+impl WasmMlsGroup {
+    /// Creates a new MLS group with the creator as the sole member.
+    ///
+    /// The group uses [`SCP_CIPHERSUITE`] and starts at epoch 0.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if credential serialization or group creation fails.
+    pub fn create_group(credential: &WasmScpCredential) -> Result<Self, WasmCryptoError> {
+        let provider = OpenMlsRustCrypto::default();
+
+        let signer = SignatureKeyPair::new(SCP_CIPHERSUITE.signature_algorithm()).map_err(|e| {
+            WasmCryptoError::GroupCreationFailed(format!("signature key generation: {e}"))
+        })?;
+
+        signer.store(provider.storage()).map_err(|e| {
+            WasmCryptoError::GroupCreationFailed(format!("storing signature key: {e}"))
+        })?;
+
+        let credential_bytes = credential.to_bytes()?;
+        let basic_credential = BasicCredential::new(credential_bytes);
+        let credential_with_key = CredentialWithKey {
+            credential: basic_credential.into(),
+            signature_key: signer.to_public_vec().into(),
+        };
+
+        // max_past_epochs(2) matches scp-core for grace window compatibility.
+        let group_create_config = MlsGroupCreateConfig::builder()
+            .ciphersuite(SCP_CIPHERSUITE)
+            .use_ratchet_tree_extension(true)
+            .max_past_epochs(2)
+            .build();
+
+        let group = MlsGroup::new(
+            &provider,
+            &signer,
+            &group_create_config,
+            credential_with_key,
+        )
+        .map_err(|e| WasmCryptoError::GroupCreationFailed(e.to_string()))?;
+
+        Ok(Self {
+            group: Some(group),
+            provider,
+            signer: Some(signer),
+        })
+    }
+
+    /// Adds a member to the group using their pre-published `KeyPackage`.
+    ///
+    /// Returns `(commit_bytes, welcome_bytes)` — TLS-serialized MLS messages.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the group is destroyed or the add operation fails.
+    pub fn add_member(
+        &mut self,
+        key_package: KeyPackageIn,
+    ) -> Result<(Vec<u8>, Vec<u8>), WasmCryptoError> {
+        let verified_key_package = key_package
+            .validate(self.provider.crypto(), ProtocolVersion::Mls10)
+            .map_err(|e| {
+                WasmCryptoError::AddMemberFailed(format!("key package validation: {e}"))
+            })?;
+
+        let signer = self
+            .signer
+            .as_ref()
+            .ok_or(WasmCryptoError::GroupDestroyed)?;
+        let g = self.group.as_mut().ok_or(WasmCryptoError::GroupDestroyed)?;
+
+        let (commit, welcome, _group_info) = g
+            .add_members(
+                &self.provider,
+                signer,
+                core::slice::from_ref(&verified_key_package),
+            )
+            .map_err(|e| WasmCryptoError::AddMemberFailed(e.to_string()))?;
+
+        // Merge the pending commit.
+        let g = self.group.as_mut().ok_or(WasmCryptoError::GroupDestroyed)?;
+        g.merge_pending_commit(&self.provider)
+            .map_err(|e| WasmCryptoError::MergePendingCommitFailed(e.to_string()))?;
+
+        // TLS-serialize for transport.
+        let commit_bytes = commit
+            .tls_serialize_detached()
+            .map_err(|e| WasmCryptoError::AddMemberFailed(format!("serializing commit: {e}")))?;
+        let welcome_bytes = welcome
+            .tls_serialize_detached()
+            .map_err(|e| WasmCryptoError::AddMemberFailed(format!("serializing welcome: {e}")))?;
+
+        Ok((commit_bytes, welcome_bytes))
+    }
+
+    /// Removes a member from the group by their leaf index.
+    ///
+    /// Returns `commit_bytes` — TLS-serialized commit message.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the group is destroyed or the remove operation fails.
+    pub fn remove_member(&mut self, member: &LeafNodeIndex) -> Result<Vec<u8>, WasmCryptoError> {
+        let signer = self
+            .signer
+            .as_ref()
+            .ok_or(WasmCryptoError::GroupDestroyed)?;
+        let g = self.group.as_mut().ok_or(WasmCryptoError::GroupDestroyed)?;
+
+        let (commit, _welcome, _group_info) = g
+            .remove_members(&self.provider, signer, core::slice::from_ref(member))
+            .map_err(|e| WasmCryptoError::RemoveMemberFailed(e.to_string()))?;
+
+        // Merge the pending commit.
+        let g = self.group.as_mut().ok_or(WasmCryptoError::GroupDestroyed)?;
+        g.merge_pending_commit(&self.provider)
+            .map_err(|e| WasmCryptoError::MergePendingCommitFailed(e.to_string()))?;
+
+        commit
+            .tls_serialize_detached()
+            .map_err(|e| WasmCryptoError::RemoveMemberFailed(format!("serializing commit: {e}")))
+    }
+
+    /// Joins a group from a Welcome message.
+    ///
+    /// The `welcome_bytes` must be TLS-serialized `MlsMessageOut` bytes
+    /// containing a Welcome. The `holder` must be the `WasmMlsGroup` returned
+    /// by [`generate_key_package`] — it contains the provider and signer
+    /// that hold the private key material matching the `KeyPackage` that was
+    /// sent to the adder.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the Welcome cannot be processed.
+    pub fn join_from_welcome(welcome_bytes: &[u8], holder: Self) -> Result<Self, WasmCryptoError> {
+        let provider = holder.provider;
+        let signer = holder.signer;
+
+        // Deserialize the Welcome.
+        let welcome_in = MlsMessageIn::tls_deserialize(&mut &*welcome_bytes).map_err(|e| {
+            WasmCryptoError::WelcomeProcessingFailed(format!("deserializing welcome: {e}"))
+        })?;
+
+        let welcome_body = welcome_in.extract();
+        let MlsMessageBodyIn::Welcome(welcome) = welcome_body else {
+            return Err(WasmCryptoError::WelcomeProcessingFailed(
+                "message is not a Welcome".to_string(),
+            ));
+        };
+
+        // max_past_epochs(2) must match create_group.
+        let join_config = MlsGroupJoinConfig::builder().max_past_epochs(2).build();
+
+        let staged_welcome =
+            StagedWelcome::new_from_welcome(&provider, &join_config, welcome, None)
+                .map_err(|e| WasmCryptoError::WelcomeProcessingFailed(e.to_string()))?;
+
+        let group = staged_welcome
+            .into_group(&provider)
+            .map_err(|e| WasmCryptoError::WelcomeProcessingFailed(e.to_string()))?;
+
+        Ok(Self {
+            group: Some(group),
+            provider,
+            signer,
+        })
+    }
+
+    /// Generates a `KeyPackage` for a participant.
+    ///
+    /// Returns `(key_package_bytes, WasmMlsGroup)` where `key_package_bytes`
+    /// is TLS-serialized and the `WasmMlsGroup` holds the private key material
+    /// needed to later join via Welcome. Pass the returned `WasmMlsGroup` to
+    /// [`join_from_welcome`] when the Welcome message arrives.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if key package generation fails.
+    pub fn generate_key_package(
+        credential: &WasmScpCredential,
+    ) -> Result<(Vec<u8>, Self), WasmCryptoError> {
+        let provider = OpenMlsRustCrypto::default();
+
+        let signer = SignatureKeyPair::new(SCP_CIPHERSUITE.signature_algorithm()).map_err(|e| {
+            WasmCryptoError::KeyPackageGenerationFailed(format!("signer generation: {e}"))
+        })?;
+
+        signer.store(provider.storage()).map_err(|e| {
+            WasmCryptoError::KeyPackageGenerationFailed(format!("storing signature key: {e}"))
+        })?;
+
+        let credential_bytes = credential.to_bytes()?;
+        let basic_credential = BasicCredential::new(credential_bytes);
+        let credential_with_key = CredentialWithKey {
+            credential: basic_credential.into(),
+            signature_key: signer.to_public_vec().into(),
+        };
+
+        let key_package_bundle = KeyPackage::builder()
+            .build(SCP_CIPHERSUITE, &provider, &signer, credential_with_key)
+            .map_err(|e| WasmCryptoError::KeyPackageGenerationFailed(e.to_string()))?;
+
+        let kp_bytes = key_package_bundle
+            .key_package()
+            .tls_serialize_detached()
+            .map_err(|e| {
+                WasmCryptoError::KeyPackageGenerationFailed(format!("serializing key package: {e}"))
+            })?;
+
+        Ok((
+            kp_bytes,
+            Self {
+                group: None, // No group yet — will be set when joining via Welcome.
+                provider,
+                signer: Some(signer),
+            },
+        ))
+    }
+
+    /// Encrypts plaintext as an MLS application message.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the group is destroyed or encryption fails.
+    pub fn encrypt(&mut self, plaintext: &[u8]) -> Result<Vec<u8>, WasmCryptoError> {
+        let signer = self
+            .signer
+            .as_ref()
+            .ok_or(WasmCryptoError::GroupDestroyed)?;
+        let g = self.group.as_mut().ok_or(WasmCryptoError::GroupDestroyed)?;
+
+        let mls_out = g
+            .create_message(&self.provider, signer, plaintext)
+            .map_err(|e| WasmCryptoError::EncryptionFailed(e.to_string()))?;
+
+        mls_out
+            .tls_serialize_detached()
+            .map_err(|e| WasmCryptoError::EncryptionFailed(format!("serializing: {e}")))
+    }
+
+    /// Decrypts an MLS application message from raw TLS-serialized bytes.
+    ///
+    /// Prefer [`mls_decrypt`](super::encrypt::mls_decrypt) which pre-validates
+    /// the wire bytes before calling into `OpenMLS`.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the group is destroyed, decryption fails, or the
+    /// message is not an application message.
+    pub fn decrypt(&mut self, mls_ciphertext: &[u8]) -> Result<Vec<u8>, WasmCryptoError> {
+        let mls_in = MlsMessageIn::tls_deserialize(&mut &*mls_ciphertext)
+            .map_err(|e| WasmCryptoError::DecryptionFailed(format!("deserializing: {e}")))?;
+
+        let protocol_msg = mls_in.try_into_protocol_message().map_err(|_| {
+            WasmCryptoError::DecryptionFailed("message is not a protocol message".to_string())
+        })?;
+
+        self.decrypt_protocol_message(protocol_msg)
+    }
+
+    /// Decrypts a pre-validated `ProtocolMessage`.
+    ///
+    /// Called by [`mls_decrypt`](super::encrypt::mls_decrypt) after TLS
+    /// deserialization and message-type validation have already succeeded.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the group is destroyed, AEAD decryption fails,
+    /// or the message is not an application message.
+    pub fn decrypt_protocol_message(
+        &mut self,
+        protocol_msg: ProtocolMessage,
+    ) -> Result<Vec<u8>, WasmCryptoError> {
+        let g = self.group.as_mut().ok_or(WasmCryptoError::GroupDestroyed)?;
+
+        let processed = g
+            .process_message(&self.provider, protocol_msg)
+            .map_err(|e| WasmCryptoError::DecryptionFailed(e.to_string()))?;
+
+        match processed.into_content() {
+            ProcessedMessageContent::ApplicationMessage(app_msg) => Ok(app_msg.into_bytes()),
+            ProcessedMessageContent::StagedCommitMessage(staged_commit) => {
+                // Process staged commits to advance the group epoch.
+                let g = self.group.as_mut().ok_or(WasmCryptoError::GroupDestroyed)?;
+                g.merge_staged_commit(&self.provider, *staged_commit)
+                    .map_err(|e| {
+                        WasmCryptoError::DecryptionFailed(format!("merging staged commit: {e}"))
+                    })?;
+                Err(WasmCryptoError::NotApplicationMessage)
+            }
+            ProcessedMessageContent::ProposalMessage(_)
+            | ProcessedMessageContent::ExternalJoinProposalMessage(_) => {
+                Err(WasmCryptoError::NotApplicationMessage)
+            }
+        }
+    }
+
+    /// Destroys the MLS group state.
+    ///
+    /// After destruction, all operations will return `GroupDestroyed`.
+    pub fn destroy(&mut self) {
+        drop(self.group.take());
+        drop(self.signer.take());
+        self.provider = OpenMlsRustCrypto::default();
+    }
+
+    /// Returns the current epoch number.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`WasmCryptoError::GroupDestroyed`] if the group is destroyed.
+    pub fn epoch(&self) -> Result<u64, WasmCryptoError> {
+        let g = self.group.as_ref().ok_or(WasmCryptoError::GroupDestroyed)?;
+        Ok(g.epoch().as_u64())
+    }
+
+    /// Returns a reference to the inner provider.
+    #[must_use]
+    pub const fn provider(&self) -> &OpenMlsRustCrypto {
+        &self.provider
+    }
+
+    /// Returns `true` if the group has been destroyed.
+    #[must_use]
+    pub const fn is_destroyed(&self) -> bool {
+        self.group.is_none()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::crypto::credential::WasmSigningKeyId;
+
+    #[allow(clippy::unwrap_used)]
+    fn test_credential(name: &str) -> WasmScpCredential {
+        WasmScpCredential::new(
+            format!("did:dht:z6Mk{name}"),
+            None,
+            WasmSigningKeyId::Active,
+        )
+        .unwrap()
+    }
+
+    #[test]
+    #[allow(clippy::unwrap_used)]
+    fn create_group_starts_at_epoch_0() {
+        let cred = test_credential("alice");
+        let group = WasmMlsGroup::create_group(&cred).unwrap();
+        assert_eq!(group.epoch().unwrap(), 0);
+    }
+
+    #[test]
+    #[allow(clippy::unwrap_used)]
+    fn generate_key_package_produces_bytes() {
+        let cred = test_credential("bob");
+        let (kp_bytes, _holder) = WasmMlsGroup::generate_key_package(&cred).unwrap();
+        assert!(
+            !kp_bytes.is_empty(),
+            "key package bytes should not be empty"
+        );
+    }
+
+    #[test]
+    #[allow(clippy::unwrap_used)]
+    fn add_member_returns_commit_and_welcome() {
+        let alice_cred = test_credential("alice");
+        let mut alice_group = WasmMlsGroup::create_group(&alice_cred).unwrap();
+
+        let bob_cred = test_credential("bob");
+        let (bob_kp_bytes, _bob_holder) = WasmMlsGroup::generate_key_package(&bob_cred).unwrap();
+
+        let bob_kp_in = KeyPackageIn::tls_deserialize(&mut &*bob_kp_bytes).unwrap();
+        let (commit_bytes, welcome_bytes) = alice_group.add_member(bob_kp_in).unwrap();
+
+        assert!(!commit_bytes.is_empty());
+        assert!(!welcome_bytes.is_empty());
+        assert_eq!(alice_group.epoch().unwrap(), 1);
+    }
+
+    #[test]
+    #[allow(clippy::unwrap_used)]
+    fn join_from_welcome_works() {
+        let alice_cred = test_credential("alice");
+        let mut alice_group = WasmMlsGroup::create_group(&alice_cred).unwrap();
+
+        let bob_cred = test_credential("bob");
+        let (bob_kp_bytes, bob_holder) = WasmMlsGroup::generate_key_package(&bob_cred).unwrap();
+
+        let bob_kp_in = KeyPackageIn::tls_deserialize(&mut &*bob_kp_bytes).unwrap();
+        let (_commit_bytes, welcome_bytes) = alice_group.add_member(bob_kp_in).unwrap();
+
+        let bob_group = WasmMlsGroup::join_from_welcome(&welcome_bytes, bob_holder).unwrap();
+
+        assert_eq!(alice_group.epoch().unwrap(), 1);
+        assert_eq!(bob_group.epoch().unwrap(), 1);
+    }
+
+    // NOTE: OpenMLS cannot decrypt your own messages. A two-party setup is
+    // required for encrypt/decrypt round-trip tests. This is tested in the
+    // state module's integration tests.
+
+    #[test]
+    #[allow(clippy::unwrap_used)]
+    fn encrypt_produces_bytes() {
+        let alice_cred = test_credential("alice");
+        let mut alice_group = WasmMlsGroup::create_group(&alice_cred).unwrap();
+
+        // Need at least 2 members to encrypt (OpenMLS requires it for app messages
+        // in some configurations, but single-member groups can still encrypt).
+        let ciphertext = alice_group.encrypt(b"hello world").unwrap();
+        assert!(!ciphertext.is_empty(), "ciphertext should not be empty");
+    }
+
+    #[test]
+    #[allow(clippy::unwrap_used)]
+    fn destroy_prevents_further_operations() {
+        let cred = test_credential("alice");
+        let mut group = WasmMlsGroup::create_group(&cred).unwrap();
+
+        group.destroy();
+
+        assert!(group.is_destroyed());
+        assert!(group.epoch().is_err());
+        assert!(group.encrypt(b"test").is_err());
+        assert!(group.decrypt(b"test").is_err());
+    }
+
+    #[test]
+    #[allow(clippy::unwrap_used)]
+    fn two_party_encrypt_decrypt_roundtrip() {
+        let alice_cred = test_credential("alice");
+        let mut alice_group = WasmMlsGroup::create_group(&alice_cred).unwrap();
+
+        let bob_cred = test_credential("bob");
+        let (bob_kp_bytes, bob_holder) = WasmMlsGroup::generate_key_package(&bob_cred).unwrap();
+
+        let bob_kp_in = KeyPackageIn::tls_deserialize(&mut &*bob_kp_bytes).unwrap();
+        let (_commit_bytes, welcome_bytes) = alice_group.add_member(bob_kp_in).unwrap();
+
+        let mut bob_group = WasmMlsGroup::join_from_welcome(&welcome_bytes, bob_holder).unwrap();
+
+        // Alice encrypts, Bob decrypts.
+        let plaintext = b"secret message from alice to bob";
+        let ciphertext = alice_group.encrypt(plaintext).unwrap();
+        let decrypted = bob_group.decrypt(&ciphertext).unwrap();
+        assert_eq!(decrypted, plaintext);
+    }
+}

--- a/crates/scp-ffi/wasm/src/crypto/mod.rs
+++ b/crates/scp-ffi/wasm/src/crypto/mod.rs
@@ -1,0 +1,30 @@
+//! WASM-local MLS encryption and sender key layer.
+//!
+//! This module ports the cryptographic operations from `scp-core`'s
+//! `crypto::mls` and `crypto::sender_keys` modules into a WASM-compatible
+//! form. All operations are synchronous (no tokio, no async).
+//!
+//! # Architecture
+//!
+//! - [`credential`] — `WasmScpCredential` (MessagePack-serialized identity payload).
+//! - [`error`] — `WasmCryptoError` error type.
+//! - [`group`] — `WasmMlsGroup` wrapping `OpenMLS` `MlsGroup`.
+//! - [`encrypt`] — Higher-level MLS encrypt/decrypt with TLS serialization.
+//! - [`sender_key`] — AES-256-GCM sender-side key layer.
+//! - [`state`] — `WasmCryptoState` orchestrating both layers.
+//!
+//! See ADR-001 for the MLS wrapper design and ADR-007 for the sender key layer.
+
+pub mod credential;
+pub mod encrypt;
+pub mod error;
+pub mod group;
+pub mod sender_key;
+pub mod state;
+
+pub use credential::{WasmScpCredential, WasmSigningKeyId};
+pub use encrypt::{mls_decrypt, mls_encrypt};
+pub use error::WasmCryptoError;
+pub use group::WasmMlsGroup;
+pub use sender_key::{SenderKey, decrypt_sender_layer, encrypt_sender_layer, generate_sender_key};
+pub use state::WasmCryptoState;

--- a/crates/scp-ffi/wasm/src/crypto/sender_key.rs
+++ b/crates/scp-ffi/wasm/src/crypto/sender_key.rs
@@ -1,0 +1,381 @@
+//! WASM-local sender-side AES-256-GCM key layer.
+//!
+//! Ports `scp_core::crypto::sender_keys` into a WASM-compatible form.
+//! Each sender in an SCP context maintains an AES-256 symmetric key.
+//! Messages are encrypted with this key before MLS group encryption
+//! (double encryption), enabling per-relationship blocking.
+//!
+//! # Wire Format
+//!
+//! The ciphertext produced by [`encrypt_sender_layer`] is:
+//!
+//! ```text
+//! nonce (12 bytes) || ciphertext || auth_tag (16 bytes)
+//! ```
+//!
+//! # AAD Format
+//!
+//! The AAD format MUST match `scp_core::crypto::sender_keys::encrypt::build_sender_aad`
+//! exactly for cross-bridge conformance:
+//!
+//! ```text
+//! [4-byte context_id len (BE)][context_id bytes][4-byte DID len (BE)][DID bytes][8-byte epoch (BE)][8-byte sequence (BE)]
+//! ```
+//!
+//! See ADR-007 in `.docs/adrs/phase-1.md`.
+
+use aes_gcm::aead::Payload;
+use aes_gcm::{Aes256Gcm, KeyInit, Nonce, aead::Aead};
+use rand_core::{OsRng, RngCore};
+use zeroize::{Zeroize, ZeroizeOnDrop};
+
+use super::error::WasmCryptoError;
+
+/// Size of the AES-256-GCM nonce in bytes.
+const NONCE_SIZE: usize = 12;
+
+/// Opaque handle for a 32-byte AES-256 sender key.
+///
+/// Key material is zeroized on drop.
+#[derive(Clone, Zeroize, ZeroizeOnDrop)]
+pub struct SenderKey([u8; 32]);
+
+impl SenderKey {
+    /// Creates a sender key from raw 32-byte key material.
+    #[must_use]
+    pub const fn from_bytes(bytes: [u8; 32]) -> Self {
+        Self(bytes)
+    }
+
+    /// Returns a reference to the raw 32-byte key material.
+    #[must_use]
+    pub const fn as_bytes(&self) -> &[u8; 32] {
+        &self.0
+    }
+}
+
+impl std::fmt::Debug for SenderKey {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_tuple("SenderKey").field(&"[REDACTED]").finish()
+    }
+}
+
+/// Generates a random 32-byte AES-256 sender key.
+///
+/// Uses the platform's cryptographically secure random number generator
+/// (`WebCrypto`'s `getRandomValues` in WASM).
+#[must_use]
+pub fn generate_sender_key() -> SenderKey {
+    let mut bytes = [0u8; 32];
+    OsRng.fill_bytes(&mut bytes);
+    SenderKey(bytes)
+}
+
+/// Encrypts `plaintext` with AES-256-GCM using the given sender key,
+/// binding cleartext metadata as Additional Authenticated Data (AAD).
+///
+/// Returns `nonce (12 bytes) || ciphertext || auth_tag (16 bytes)`.
+///
+/// # Errors
+///
+/// Returns [`WasmCryptoError::SenderKeyError`] if encryption fails.
+#[allow(clippy::too_many_arguments)]
+pub fn encrypt_sender_layer(
+    sender_key: &SenderKey,
+    plaintext: &[u8],
+    context_id: &str,
+    sender_did: &str,
+    epoch: u64,
+    sequence: u64,
+) -> Result<Vec<u8>, WasmCryptoError> {
+    let cipher = Aes256Gcm::new_from_slice(sender_key.as_bytes())
+        .map_err(|e| WasmCryptoError::SenderKeyError(format!("key init: {e}")))?;
+
+    let mut nonce_bytes = [0u8; NONCE_SIZE];
+    OsRng.fill_bytes(&mut nonce_bytes);
+    let nonce = Nonce::from_slice(&nonce_bytes);
+
+    let aad = build_sender_aad(context_id, sender_did, epoch, sequence);
+    let ciphertext = cipher
+        .encrypt(
+            nonce,
+            Payload {
+                msg: plaintext,
+                aad: &aad,
+            },
+        )
+        .map_err(|e| WasmCryptoError::SenderKeyError(format!("encryption: {e}")))?;
+
+    let mut output = Vec::with_capacity(NONCE_SIZE + ciphertext.len());
+    output.extend_from_slice(&nonce_bytes);
+    output.extend_from_slice(&ciphertext);
+    Ok(output)
+}
+
+/// Decrypts AES-256-GCM ciphertext produced by [`encrypt_sender_layer`].
+///
+/// # Errors
+///
+/// - [`WasmCryptoError::CiphertextTooShort`] if `ciphertext` is shorter
+///   than the nonce size.
+/// - [`WasmCryptoError::AuthenticationFailed`] if the authentication tag
+///   verification fails.
+#[allow(clippy::too_many_arguments)]
+pub fn decrypt_sender_layer(
+    sender_key: &SenderKey,
+    ciphertext: &[u8],
+    context_id: &str,
+    sender_did: &str,
+    epoch: u64,
+    sequence: u64,
+) -> Result<Vec<u8>, WasmCryptoError> {
+    if ciphertext.len() < NONCE_SIZE {
+        return Err(WasmCryptoError::CiphertextTooShort {
+            actual: ciphertext.len(),
+            minimum: NONCE_SIZE,
+        });
+    }
+
+    let (nonce_bytes, encrypted) = ciphertext.split_at(NONCE_SIZE);
+    let nonce = Nonce::from_slice(nonce_bytes);
+
+    let cipher = Aes256Gcm::new_from_slice(sender_key.as_bytes())
+        .map_err(|e| WasmCryptoError::SenderKeyError(format!("key init: {e}")))?;
+
+    let aad = build_sender_aad(context_id, sender_did, epoch, sequence);
+    cipher
+        .decrypt(
+            nonce,
+            Payload {
+                msg: encrypted,
+                aad: &aad,
+            },
+        )
+        .map_err(|_| WasmCryptoError::AuthenticationFailed)
+}
+
+/// Builds the Additional Authenticated Data (AAD) for sender-layer
+/// AES-256-GCM operations.
+///
+/// Format: `[4-byte context_id len (BE)][context_id bytes][4-byte DID len (BE)][DID bytes][8-byte epoch (BE)][8-byte sequence (BE)]`
+///
+/// This format MUST match `scp_core::crypto::sender_keys::encrypt::build_sender_aad`
+/// exactly for cross-bridge conformance.
+#[must_use]
+#[allow(clippy::cast_possible_truncation)] // String lengths are always < 4 GiB
+pub fn build_sender_aad(context_id: &str, sender_did: &str, epoch: u64, sequence: u64) -> Vec<u8> {
+    let ctx_bytes = context_id.as_bytes();
+    let did_bytes = sender_did.as_bytes();
+    let mut aad = Vec::with_capacity(4 + ctx_bytes.len() + 4 + did_bytes.len() + 8 + 8);
+    aad.extend_from_slice(&(ctx_bytes.len() as u32).to_be_bytes());
+    aad.extend_from_slice(ctx_bytes);
+    aad.extend_from_slice(&(did_bytes.len() as u32).to_be_bytes());
+    aad.extend_from_slice(did_bytes);
+    aad.extend_from_slice(&epoch.to_be_bytes());
+    aad.extend_from_slice(&sequence.to_be_bytes());
+    aad
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const TEST_CTX: &str = "ctx-test-123";
+    const TEST_DID: &str = "did:dht:z6MkTestSender";
+    const TEST_EPOCH: u64 = 1;
+    const TEST_SEQ: u64 = 42;
+
+    #[test]
+    #[allow(clippy::unwrap_used)]
+    fn encrypt_decrypt_roundtrip() {
+        let key = generate_sender_key();
+        let plaintext = b"hello world sender key";
+        let ciphertext =
+            encrypt_sender_layer(&key, plaintext, TEST_CTX, TEST_DID, TEST_EPOCH, TEST_SEQ)
+                .unwrap();
+        let decrypted =
+            decrypt_sender_layer(&key, &ciphertext, TEST_CTX, TEST_DID, TEST_EPOCH, TEST_SEQ)
+                .unwrap();
+        assert_eq!(decrypted, plaintext);
+    }
+
+    #[test]
+    fn generate_sender_key_produces_32_bytes() {
+        let key = generate_sender_key();
+        assert_eq!(key.as_bytes().len(), 32);
+    }
+
+    #[test]
+    fn generate_sender_key_produces_distinct_keys() {
+        let key1 = generate_sender_key();
+        let key2 = generate_sender_key();
+        assert_ne!(key1.as_bytes(), key2.as_bytes());
+    }
+
+    #[test]
+    #[allow(clippy::unwrap_used)]
+    fn decrypt_rejects_tampered_ciphertext() {
+        let key = generate_sender_key();
+        let plaintext = b"tamper test";
+        let mut ciphertext =
+            encrypt_sender_layer(&key, plaintext, TEST_CTX, TEST_DID, TEST_EPOCH, TEST_SEQ)
+                .unwrap();
+
+        // Flip a byte after the nonce.
+        let tamper_index = NONCE_SIZE + 1;
+        ciphertext[tamper_index] ^= 0xFF;
+
+        let result =
+            decrypt_sender_layer(&key, &ciphertext, TEST_CTX, TEST_DID, TEST_EPOCH, TEST_SEQ);
+        assert!(matches!(result, Err(WasmCryptoError::AuthenticationFailed)));
+    }
+
+    #[test]
+    fn decrypt_rejects_too_short_ciphertext() {
+        let key = generate_sender_key();
+        let short = vec![0u8; 5];
+        let result = decrypt_sender_layer(&key, &short, TEST_CTX, TEST_DID, TEST_EPOCH, TEST_SEQ);
+        assert!(matches!(
+            result,
+            Err(WasmCryptoError::CiphertextTooShort {
+                actual: 5,
+                minimum: 12
+            })
+        ));
+    }
+
+    #[test]
+    #[allow(clippy::unwrap_used)]
+    fn decrypt_with_wrong_key_fails() {
+        let key1 = generate_sender_key();
+        let key2 = generate_sender_key();
+        let plaintext = b"wrong key test";
+        let ciphertext =
+            encrypt_sender_layer(&key1, plaintext, TEST_CTX, TEST_DID, TEST_EPOCH, TEST_SEQ)
+                .unwrap();
+
+        let result =
+            decrypt_sender_layer(&key2, &ciphertext, TEST_CTX, TEST_DID, TEST_EPOCH, TEST_SEQ);
+        assert!(matches!(result, Err(WasmCryptoError::AuthenticationFailed)));
+    }
+
+    #[test]
+    #[allow(clippy::unwrap_used)]
+    fn ciphertext_is_nonce_plus_payload_plus_tag() {
+        let key = generate_sender_key();
+        let plaintext = b"size test";
+        let ciphertext =
+            encrypt_sender_layer(&key, plaintext, TEST_CTX, TEST_DID, TEST_EPOCH, TEST_SEQ)
+                .unwrap();
+
+        // nonce(12) + plaintext(9) + tag(16) = 37
+        assert_eq!(ciphertext.len(), NONCE_SIZE + plaintext.len() + 16);
+    }
+
+    #[test]
+    #[allow(clippy::unwrap_used)]
+    fn decrypt_rejects_wrong_context_id() {
+        let key = generate_sender_key();
+        let plaintext = b"context-bound";
+        let ciphertext =
+            encrypt_sender_layer(&key, plaintext, TEST_CTX, TEST_DID, TEST_EPOCH, TEST_SEQ)
+                .unwrap();
+
+        let result = decrypt_sender_layer(
+            &key,
+            &ciphertext,
+            "wrong-ctx",
+            TEST_DID,
+            TEST_EPOCH,
+            TEST_SEQ,
+        );
+        assert!(matches!(result, Err(WasmCryptoError::AuthenticationFailed)));
+    }
+
+    #[test]
+    #[allow(clippy::unwrap_used)]
+    fn decrypt_rejects_wrong_sender_did() {
+        let key = generate_sender_key();
+        let plaintext = b"sender-bound";
+        let ciphertext =
+            encrypt_sender_layer(&key, plaintext, TEST_CTX, TEST_DID, TEST_EPOCH, TEST_SEQ)
+                .unwrap();
+
+        let result = decrypt_sender_layer(
+            &key,
+            &ciphertext,
+            TEST_CTX,
+            "did:dht:z6MkWrong",
+            TEST_EPOCH,
+            TEST_SEQ,
+        );
+        assert!(matches!(result, Err(WasmCryptoError::AuthenticationFailed)));
+    }
+
+    #[test]
+    #[allow(clippy::unwrap_used)]
+    fn decrypt_rejects_wrong_epoch() {
+        let key = generate_sender_key();
+        let plaintext = b"epoch-bound";
+        let ciphertext =
+            encrypt_sender_layer(&key, plaintext, TEST_CTX, TEST_DID, TEST_EPOCH, TEST_SEQ)
+                .unwrap();
+
+        let result = decrypt_sender_layer(
+            &key,
+            &ciphertext,
+            TEST_CTX,
+            TEST_DID,
+            TEST_EPOCH + 1,
+            TEST_SEQ,
+        );
+        assert!(matches!(result, Err(WasmCryptoError::AuthenticationFailed)));
+    }
+
+    #[test]
+    #[allow(clippy::unwrap_used)]
+    fn decrypt_rejects_wrong_sequence() {
+        let key = generate_sender_key();
+        let plaintext = b"sequence-bound";
+        let ciphertext =
+            encrypt_sender_layer(&key, plaintext, TEST_CTX, TEST_DID, TEST_EPOCH, TEST_SEQ)
+                .unwrap();
+
+        let result = decrypt_sender_layer(
+            &key,
+            &ciphertext,
+            TEST_CTX,
+            TEST_DID,
+            TEST_EPOCH,
+            TEST_SEQ + 1,
+        );
+        assert!(matches!(result, Err(WasmCryptoError::AuthenticationFailed)));
+    }
+
+    #[test]
+    fn build_sender_aad_is_deterministic() {
+        let aad1 = build_sender_aad("ctx-1", "did:dht:z6MkA", 5, 10);
+        let aad2 = build_sender_aad("ctx-1", "did:dht:z6MkA", 5, 10);
+        assert_eq!(aad1, aad2);
+    }
+
+    #[test]
+    fn build_sender_aad_differs_by_field() {
+        let base = build_sender_aad("ctx-1", "did:dht:z6MkA", 5, 10);
+        assert_ne!(base, build_sender_aad("ctx-2", "did:dht:z6MkA", 5, 10));
+        assert_ne!(base, build_sender_aad("ctx-1", "did:dht:z6MkB", 5, 10));
+        assert_ne!(base, build_sender_aad("ctx-1", "did:dht:z6MkA", 6, 10));
+        assert_ne!(base, build_sender_aad("ctx-1", "did:dht:z6MkA", 5, 11));
+    }
+
+    #[test]
+    fn sender_key_debug_redacts_material() {
+        let key = generate_sender_key();
+        let debug = format!("{key:?}");
+        assert!(debug.contains("REDACTED"));
+        assert!(
+            !debug.contains(", "),
+            "debug output should not contain raw byte values"
+        );
+    }
+}

--- a/crates/scp-ffi/wasm/src/crypto/state.rs
+++ b/crates/scp-ffi/wasm/src/crypto/state.rs
@@ -1,0 +1,254 @@
+//! Orchestration layer combining MLS encryption and sender key layer.
+//!
+//! `WasmCryptoState` holds both an MLS group and a sender key store, providing
+//! a single entry point for the full double-encryption pipeline:
+//! sender key encrypt -> MLS encrypt (on send) and
+//! MLS decrypt -> sender key decrypt (on receive).
+
+use std::collections::HashMap;
+
+use zeroize::Zeroize;
+
+use super::error::WasmCryptoError;
+use super::group::WasmMlsGroup;
+use super::sender_key::{
+    SenderKey, decrypt_sender_layer, encrypt_sender_layer, generate_sender_key,
+};
+
+/// Combined MLS + sender key state for a single context.
+///
+/// Owns the MLS group and manages per-sender AES-256 keys. The double
+/// encryption pipeline is:
+///
+/// **Send:** `plaintext` -> sender key encrypt -> MLS encrypt -> `ciphertext`
+/// **Receive:** `ciphertext` -> MLS decrypt -> sender key decrypt -> `plaintext`
+pub struct WasmCryptoState {
+    /// The MLS group for this context.
+    pub mls_group: WasmMlsGroup,
+    /// This participant's own sender key.
+    pub local_sender_key: SenderKey,
+    /// Sender keys from other participants, keyed by DID.
+    pub sender_key_store: HashMap<String, SenderKey>,
+}
+
+impl WasmCryptoState {
+    /// Creates a new crypto state for a context.
+    ///
+    /// Creates the MLS group with the creator as sole member and generates
+    /// a fresh sender key.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if MLS group creation fails.
+    pub fn new_for_context(creator_did: &str) -> Result<Self, WasmCryptoError> {
+        let credential = super::credential::WasmScpCredential::new(
+            creator_did.to_string(),
+            None,
+            super::credential::WasmSigningKeyId::Active,
+        )?;
+
+        let mls_group = WasmMlsGroup::create_group(&credential)?;
+        let local_sender_key = generate_sender_key();
+
+        Ok(Self {
+            mls_group,
+            local_sender_key,
+            sender_key_store: HashMap::new(),
+        })
+    }
+
+    /// Encrypts a message using the full double-encryption pipeline.
+    ///
+    /// 1. Encrypt with the local sender key (AES-256-GCM with AAD).
+    /// 2. Encrypt the result with MLS.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if either encryption layer fails.
+    pub fn encrypt_message(
+        &mut self,
+        plaintext: &[u8],
+        context_id: &str,
+        sender_did: &str,
+        epoch: u64,
+        sequence: u64,
+    ) -> Result<Vec<u8>, WasmCryptoError> {
+        // Layer 1: sender key encrypt.
+        let sender_encrypted = encrypt_sender_layer(
+            &self.local_sender_key,
+            plaintext,
+            context_id,
+            sender_did,
+            epoch,
+            sequence,
+        )?;
+
+        // Layer 2: MLS encrypt.
+        self.mls_group.encrypt(&sender_encrypted)
+    }
+
+    /// Decrypts a message using the full double-decryption pipeline.
+    ///
+    /// 1. Decrypt with MLS.
+    /// 2. Decrypt with the sender's key (looked up by DID).
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if either decryption layer fails, or if the sender's
+    /// key is not in the store.
+    pub fn decrypt_message(
+        &mut self,
+        ciphertext: &[u8],
+        context_id: &str,
+        sender_did: &str,
+        epoch: u64,
+        sequence: u64,
+    ) -> Result<Vec<u8>, WasmCryptoError> {
+        // Layer 1: MLS decrypt.
+        let mls_decrypted = self.mls_group.decrypt(ciphertext)?;
+
+        // Layer 2: sender key decrypt.
+        let sender_key = self.sender_key_store.get(sender_did).ok_or_else(|| {
+            WasmCryptoError::SenderKeyError(format!("no sender key for DID '{sender_did}'"))
+        })?;
+
+        decrypt_sender_layer(
+            sender_key,
+            &mls_decrypted,
+            context_id,
+            sender_did,
+            epoch,
+            sequence,
+        )
+    }
+
+    /// Destroys all crypto state (MLS group + sender keys).
+    ///
+    /// Eagerly zeroizes the local sender key rather than waiting for
+    /// `WasmCryptoState` to be dropped.
+    pub fn destroy(&mut self) {
+        self.mls_group.destroy();
+        // SenderKey implements ZeroizeOnDrop, so clearing the map will
+        // zeroize each key as it's dropped.
+        self.sender_key_store.clear();
+        // Eagerly zeroize the local sender key. The old value is overwritten
+        // in-place, triggering Zeroize on the inner [u8; 32].
+        self.local_sender_key.zeroize();
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::crypto::credential::{WasmScpCredential, WasmSigningKeyId};
+    use crate::crypto::sender_key::generate_sender_key;
+    use openmls::prelude::*;
+    use tls_codec::Deserialize as TlsDeserializeTrait;
+
+    const ALICE_DID: &str = "did:dht:z6MkAlice";
+    const BOB_DID: &str = "did:dht:z6MkBob";
+    const CTX_ID: &str = "ctx-test-crypto-state";
+
+    #[test]
+    #[allow(clippy::unwrap_used)]
+    fn new_for_context_creates_valid_state() {
+        let state = WasmCryptoState::new_for_context(ALICE_DID).unwrap();
+        assert!(!state.mls_group.is_destroyed());
+        assert_eq!(state.mls_group.epoch().unwrap(), 0);
+        assert_eq!(state.local_sender_key.as_bytes().len(), 32);
+    }
+
+    #[test]
+    #[allow(clippy::unwrap_used)]
+    fn full_encrypt_decrypt_chain() {
+        // Set up Alice's state (creator).
+        let mut alice_state = WasmCryptoState::new_for_context(ALICE_DID).unwrap();
+
+        // Generate Bob's key package.
+        let bob_cred =
+            WasmScpCredential::new(BOB_DID.to_string(), None, WasmSigningKeyId::Active).unwrap();
+        let (bob_kp_bytes, bob_holder) = WasmMlsGroup::generate_key_package(&bob_cred).unwrap();
+
+        // Alice adds Bob.
+        let bob_kp_in = KeyPackageIn::tls_deserialize(&mut &*bob_kp_bytes).unwrap();
+        let (_commit, welcome) = alice_state.mls_group.add_member(bob_kp_in).unwrap();
+
+        // Bob joins from Welcome using the holder from generate_key_package.
+        let bob_mls_group = WasmMlsGroup::join_from_welcome(&welcome, bob_holder).unwrap();
+        let bob_sender_key = generate_sender_key();
+
+        let mut bob_state = WasmCryptoState {
+            mls_group: bob_mls_group,
+            local_sender_key: bob_sender_key,
+            sender_key_store: HashMap::new(),
+        };
+
+        // Exchange sender keys: Alice gives Bob her sender key, Bob gives Alice his.
+        bob_state.sender_key_store.insert(
+            ALICE_DID.to_string(),
+            SenderKey::from_bytes(*alice_state.local_sender_key.as_bytes()),
+        );
+        alice_state.sender_key_store.insert(
+            BOB_DID.to_string(),
+            SenderKey::from_bytes(*bob_state.local_sender_key.as_bytes()),
+        );
+
+        // Alice encrypts a message.
+        let plaintext = b"encrypted via double layer";
+        let ciphertext = alice_state
+            .encrypt_message(plaintext, CTX_ID, ALICE_DID, 1, 0)
+            .unwrap();
+
+        // Bob decrypts.
+        let decrypted = bob_state
+            .decrypt_message(&ciphertext, CTX_ID, ALICE_DID, 1, 0)
+            .unwrap();
+
+        assert_eq!(decrypted, plaintext);
+    }
+
+    #[test]
+    #[allow(clippy::unwrap_used)]
+    fn decrypt_fails_without_sender_key() {
+        // Set up Alice's state.
+        let mut alice_state = WasmCryptoState::new_for_context(ALICE_DID).unwrap();
+
+        // Generate Bob and add to group so Alice can encrypt.
+        let bob_cred =
+            WasmScpCredential::new(BOB_DID.to_string(), None, WasmSigningKeyId::Active).unwrap();
+        let (bob_kp_bytes, bob_holder) = WasmMlsGroup::generate_key_package(&bob_cred).unwrap();
+
+        let bob_kp_in = KeyPackageIn::tls_deserialize(&mut &*bob_kp_bytes).unwrap();
+        let (_commit, welcome) = alice_state.mls_group.add_member(bob_kp_in).unwrap();
+
+        let bob_mls_group = WasmMlsGroup::join_from_welcome(&welcome, bob_holder).unwrap();
+        let mut bob_state = WasmCryptoState {
+            mls_group: bob_mls_group,
+            local_sender_key: generate_sender_key(),
+            sender_key_store: HashMap::new(),
+            // Deliberately NOT adding Alice's sender key.
+        };
+
+        let plaintext = b"should fail";
+        let ciphertext = alice_state
+            .encrypt_message(plaintext, CTX_ID, ALICE_DID, 1, 0)
+            .unwrap();
+
+        let result = bob_state.decrypt_message(&ciphertext, CTX_ID, ALICE_DID, 1, 0);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    #[allow(clippy::unwrap_used)]
+    fn destroy_prevents_further_operations() {
+        let mut state = WasmCryptoState::new_for_context(ALICE_DID).unwrap();
+        state.destroy();
+
+        assert!(state.mls_group.is_destroyed());
+        assert!(
+            state
+                .encrypt_message(b"test", CTX_ID, ALICE_DID, 0, 0)
+                .is_err()
+        );
+    }
+}

--- a/crates/scp-ffi/wasm/src/lib.rs
+++ b/crates/scp-ffi/wasm/src/lib.rs
@@ -76,6 +76,8 @@
 pub mod bridge;
 /// Context lifecycle and messaging (create, join, leave, close, send, subscribe).
 pub mod context;
+/// MLS encryption and sender key layer for real message confidentiality.
+pub mod crypto;
 /// JS-injected key custody callback types (`WebCrypto` integration).
 pub mod custody;
 /// Context discovery operations.

--- a/crates/scp-ffi/wasm/src/manager.rs
+++ b/crates/scp-ffi/wasm/src/manager.rs
@@ -28,6 +28,8 @@
 use std::cell::RefCell;
 use std::collections::{HashMap, HashSet, VecDeque};
 
+use base64::Engine as _;
+
 use crate::error::ScpWasmError;
 use crate::runtime::{
     ToolRegistration, ToolRegistry, WasmEventLog, prove_absence, prove_inclusion,
@@ -423,6 +425,9 @@ struct PerContextState {
     pruning_policy: Option<String>,
     /// Whether the economic policy is locked (§19.3, ADR-033).
     economic_policy_locked: bool,
+    /// MLS encryption + sender key state. `Some` for encrypted contexts,
+    /// `None` for broadcast-only or unencrypted contexts.
+    crypto: Option<crate::crypto::WasmCryptoState>,
 }
 
 /// A stateful tool session for the WASM bridge.
@@ -623,6 +628,10 @@ impl PerContextState {
 /// call these synchronously within `future_to_promise`).
 pub struct WasmContextManager {
     contexts: HashMap<String, PerContextState>,
+    /// Pending MLS key package holders for encrypted context joins.
+    /// Keyed by `"{context_id}:{member_did}"`. Consumed by
+    /// `join_context_encrypted`.
+    pending_key_packages: HashMap<String, crate::crypto::group::WasmMlsGroup>,
 }
 
 // ---------------------------------------------------------------------------
@@ -765,6 +774,7 @@ impl WasmContextManager {
     pub fn new() -> Self {
         Self {
             contexts: HashMap::new(),
+            pending_key_packages: HashMap::new(),
         }
     }
 
@@ -829,6 +839,20 @@ impl WasmContextManager {
             None
         };
 
+        // Initialize MLS crypto state for Encrypted mode.
+        let crypto = if mode == "Encrypted" {
+            Some(
+                crate::crypto::WasmCryptoState::new_for_context(creator_did).map_err(|e| {
+                    ScpWasmError::Crypto {
+                        message: format!("MLS group creation failed: {e}"),
+                        code: "SCP-CRYPTO-4004".to_owned(),
+                    }
+                })?,
+            )
+        } else {
+            None
+        };
+
         // Initialize creator as admin member.
         let mut members = HashMap::new();
         members.insert(
@@ -872,6 +896,7 @@ impl WasmContextManager {
             resolved_proposals: HashMap::new(),
             pruning_policy: None,
             economic_policy_locked: false,
+            crypto,
         };
 
         self.contexts.insert(context_id.to_owned(), per_context);
@@ -955,6 +980,13 @@ impl WasmContextManager {
             bc.subscribers.remove(member_did);
         }
 
+        // Destroy crypto state on leave — the leaving member should not
+        // retain MLS key material.
+        if let Some(ref mut crypto) = ctx.crypto {
+            crypto.destroy();
+        }
+        ctx.crypto = None;
+
         ctx.push_event(WasmContextEvent::MemberLeft {
             member_did: member_did.to_owned(),
         });
@@ -1007,16 +1039,42 @@ impl WasmContextManager {
         let seq = member.sequence_number;
         member.sequence_number += 1;
 
+        // If crypto state is available, encrypt the payload before recording.
+        let recorded_payload = if let Some(ref mut crypto) = ctx.crypto {
+            let raw_bytes = base64::engine::general_purpose::STANDARD
+                .decode(payload_base64)
+                .map_err(|e| ScpWasmError::Crypto {
+                    message: format!("invalid base64 payload: {e}"),
+                    code: "SCP-CRYPTO-4001".to_owned(),
+                })?;
+
+            let epoch = crypto.mls_group.epoch().map_err(|e| ScpWasmError::Crypto {
+                message: format!("failed to read MLS epoch: {e}"),
+                code: "SCP-CRYPTO-4002".to_owned(),
+            })?;
+
+            let ciphertext = crypto
+                .encrypt_message(&raw_bytes, context_id, sender_did, epoch, seq)
+                .map_err(|e| ScpWasmError::Crypto {
+                    message: format!("encryption failed: {e}"),
+                    code: "SCP-CRYPTO-4003".to_owned(),
+                })?;
+
+            base64::engine::general_purpose::STANDARD.encode(&ciphertext)
+        } else {
+            payload_base64.to_owned()
+        };
+
         ctx.push_event(WasmContextEvent::MessageSent {
             sender_did: sender_did.to_owned(),
             sequence_number: seq,
-            payload_base64: payload_base64.to_owned(),
+            payload_base64: recorded_payload.clone(),
         });
 
         ctx.event_log.append_event(
             crate::runtime::wasm_event_type_tag("MessageSent"),
             sender_did,
-            payload_base64.as_bytes(),
+            recorded_payload.as_bytes(),
         );
 
         Ok(())
@@ -1048,6 +1106,13 @@ impl WasmContextManager {
         "closed".clone_into(&mut ctx.state);
         ctx.broadcast = None;
 
+        // Destroy crypto state on close — releases MLS group keys and
+        // sender key material.
+        if let Some(ref mut crypto) = ctx.crypto {
+            crypto.destroy();
+        }
+        ctx.crypto = None;
+
         ctx.push_event(WasmContextEvent::SystemClose {
             initiator_did: initiator_did.to_owned(),
         });
@@ -1057,6 +1122,133 @@ impl WasmContextManager {
             initiator_did,
             b"",
         );
+
+        Ok(())
+    }
+
+    /// Decrypts a message within a context.
+    ///
+    /// Reverses the double encryption: MLS decrypt -> sender key decrypt.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the context has no crypto state, or if decryption fails.
+    pub fn decrypt_message(
+        &mut self,
+        context_id: &str,
+        sender_did: &str,
+        ciphertext_base64: &str,
+        epoch: u64,
+        sequence: u64,
+    ) -> Result<Vec<u8>, ScpWasmError> {
+        let ctx = self.require_active_context_mut(context_id)?;
+
+        let crypto = ctx.crypto.as_mut().ok_or_else(|| ScpWasmError::Crypto {
+            message: "context has no MLS encryption state".to_string(),
+            code: "SCP-CRYPTO-4010".to_owned(),
+        })?;
+
+        let ciphertext = base64::engine::general_purpose::STANDARD
+            .decode(ciphertext_base64)
+            .map_err(|e| ScpWasmError::Crypto {
+                message: format!("invalid base64 ciphertext: {e}"),
+                code: "SCP-CRYPTO-4001".to_owned(),
+            })?;
+
+        crypto
+            .decrypt_message(&ciphertext, context_id, sender_did, epoch, sequence)
+            .map_err(|e| ScpWasmError::Crypto {
+                message: format!("decryption failed: {e}"),
+                code: "SCP-CRYPTO-4011".to_owned(),
+            })
+    }
+
+    /// Generates an MLS `KeyPackage` for joining an encrypted context.
+    ///
+    /// Returns the TLS-serialized key package bytes. The private key material
+    /// is stored in `pending_key_packages` keyed by `(context_id, member_did)`
+    /// for later use by [`join_context_encrypted`].
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if key package generation fails.
+    pub fn generate_key_package_for_join(
+        &mut self,
+        context_id: &str,
+        member_did: &str,
+    ) -> Result<Vec<u8>, ScpWasmError> {
+        let credential = crate::crypto::credential::WasmScpCredential::new(
+            member_did.to_string(),
+            None,
+            crate::crypto::credential::WasmSigningKeyId::Active,
+        )
+        .map_err(|e| ScpWasmError::Crypto {
+            message: format!("credential creation failed: {e}"),
+            code: "SCP-CRYPTO-4020".to_owned(),
+        })?;
+
+        let (kp_bytes, holder) =
+            crate::crypto::group::WasmMlsGroup::generate_key_package(&credential).map_err(|e| {
+                ScpWasmError::Crypto {
+                    message: format!("key package generation failed: {e}"),
+                    code: "SCP-CRYPTO-4022".to_owned(),
+                }
+            })?;
+
+        // Store the holder for later use in join_context_encrypted.
+        self.pending_key_packages
+            .insert(format!("{context_id}:{member_did}"), holder);
+
+        Ok(kp_bytes)
+    }
+
+    /// Joins a context with encrypted MLS state.
+    ///
+    /// The joiner processes the MLS Welcome message to reconstruct the group.
+    /// A key package must have been previously generated via
+    /// [`generate_key_package_for_join`] for the same `(context_id, member_did)`.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if no pending key package exists, or if the Welcome
+    /// cannot be processed.
+    pub fn join_context_encrypted(
+        &mut self,
+        context_id: &str,
+        member_did: &str,
+        welcome_bytes: &[u8],
+    ) -> Result<(), ScpWasmError> {
+        // Retrieve the pending key package holder.
+        let pending_key = format!("{context_id}:{member_did}");
+        let holder = self
+            .pending_key_packages
+            .remove(&pending_key)
+            .ok_or_else(|| ScpWasmError::Crypto {
+                message: format!(
+                    "no pending key package for '{member_did}' in context '{context_id}' — \
+                     call generate_key_package_for_join first"
+                ),
+                code: "SCP-CRYPTO-4023".to_owned(),
+            })?;
+
+        // First join the context normally (membership, events, etc.).
+        self.join_context(context_id, member_did)?;
+
+        // Then set up MLS crypto state from the Welcome.
+        let mls_group =
+            crate::crypto::group::WasmMlsGroup::join_from_welcome(welcome_bytes, holder).map_err(
+                |e| ScpWasmError::Crypto {
+                    message: format!("MLS welcome processing failed: {e}"),
+                    code: "SCP-CRYPTO-4021".to_owned(),
+                },
+            )?;
+
+        let ctx = self.require_active_context_mut(context_id)?;
+        ctx.crypto = Some(crate::crypto::WasmCryptoState {
+            mls_group,
+            local_sender_key: crate::crypto::sender_key::generate_sender_key(),
+            sender_key_store: std::collections::HashMap::new(),
+        });
 
         Ok(())
     }
@@ -4069,6 +4261,9 @@ impl WasmContextManager {
             resolved_proposals: HashMap::new(),
             pruning_policy: snap.pruning_policy.clone(),
             economic_policy_locked: snap.economic_policy_locked,
+            // Imported contexts do not carry MLS state — they must re-establish
+            // encryption via join_context_encrypted after import.
+            crypto: None,
         };
 
         self.contexts.insert(context_id.clone(), ctx);
@@ -5204,6 +5399,7 @@ mod tests {
             resolved_proposals: HashMap::new(),
             pruning_policy: None,
             economic_policy_locked: false,
+            crypto: None,
         };
 
         let mut mgr = WasmContextManager::new();
@@ -5308,6 +5504,7 @@ mod tests {
             resolved_proposals: HashMap::new(),
             pruning_policy: None,
             economic_policy_locked: false,
+            crypto: None,
         };
         let mut mgr = WasmContextManager::new();
         mgr.contexts.insert(context_id.to_owned(), ctx);

--- a/deny.toml
+++ b/deny.toml
@@ -37,6 +37,9 @@ ignore = [
     "RUSTSEC-2025-0020",  # pyo3 0.23.5 PyString buffer overflow — bump to 0.24+ when available
     "RUSTSEC-2025-0134",  # rustls-pemfile unmaintained — awaiting upstream migration
     "RUSTSEC-2024-0436",  # paste unmaintained — transitive via netlink-packet-utils (natpmp); no safe upgrade
+    # instant: unmaintained, transitive dep via openmls -> fluvio-wasm-timer.
+    # No alternative available; openmls uses it for WASM time abstraction.
+    "RUSTSEC-2024-0384",
 ]
 
 # ── Bans ────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

**The WASM bridge now has real MLS encryption.** Previously, `send_message` recorded events but never encrypted payloads. Browser clients can now participate in encrypted contexts.

### New `crypto/` module (7 files, 1,931 lines)
Discrete MLS integration layer using OpenMLS directly (no scp-core dependency, no tokio):

- **credential.rs** — `WasmScpCredential` (MessagePack byte-compatible with scp-core's `ScpCredential`)
- **group.rs** — `WasmMlsGroup` wrapping OpenMLS: create, add/remove member, join from Welcome, encrypt/decrypt
- **sender_key.rs** — AES-256-GCM selective confidentiality with AAD binding (byte-identical to scp-core)
- **encrypt.rs** — MLS encrypt/decrypt with TLS pre-validation (DoS mitigation for WASM trap on tampered ciphertext)
- **state.rs** — `WasmCryptoState` orchestrating double encryption: sender key → MLS on send, MLS → sender key on receive

### WasmContextManager integration
- `create_context` (encrypted mode) → creates MLS group + sender key
- `send_message` → double encryption chain
- `decrypt_message` (new) → double decryption chain
- `join_context_encrypted` (new) → join from MLS Welcome
- `close_context` / `leave_context` → destroy crypto state with eager zeroization

### ADR-034 corrected
The premise that OpenMLS can't compile to WASM was wrong. Blocker is tokio multi-thread (scp-core architecture), not OpenMLS crypto. WASM crate shares `openmls` with native — no parallel crypto implementation.

## Cross-bridge conformance
- Sender key AAD format: byte-identical to scp-core (length-prefixed binary)
- Credential serialization: byte-compatible MessagePack
- Ciphersuite: `MLS_128_DHKEMX25519_AES128GCM_SHA256_Ed25519`
- Double encryption ordering matches scp-core

## Security notes
- `SenderKey` implements `Zeroize + ZeroizeOnDrop`
- `SignatureKeyPair` zeroization gap documented (OpenMLS upstream, accepted for WASM same-origin isolation)
- TLS pre-validation before `process_message` (mitigates OpenMLS AEAD panic → WASM trap DoS)
- All randomness via `OsRng` → `crypto.getRandomValues()`

## Test plan
- [x] 35 new crypto unit tests (credential roundtrip, group lifecycle, encrypt/decrypt, sender key, full chain)
- [x] 263 total tests pass (228 existing + 35 new)
- [x] `cargo clippy --target wasm32-unknown-unknown -p scp-ffi-wasm -- -D warnings` clean
- [x] `wasm-pack build crates/scp-ffi/wasm --target bundler` succeeds
- [x] `cargo fmt` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>