### PR TITLE
fix(ucan): resolve capability URI resource/action split mismatch (closes #1293)

### DIFF
--- a/crates/scp-core/src/context/roles.rs
+++ b/crates/scp-core/src/context/roles.rs
@@ -187,6 +187,146 @@ impl Capability {
             Self::Custom(name) => std::borrow::Cow::Borrowed(name.as_str()),
         }
     }
+
+    /// Returns the `(resource, action)` pair for UCAN capability URIs.
+    ///
+    /// The canonical user-facing format uses colons (e.g., `"tool:invoke:*"`),
+    /// but UCAN URIs use `{resource}:{action}` where `resource` is a single
+    /// underscore-joined token. This method bridges the two formats:
+    ///
+    /// - `tool:invoke:*`         -> `("tool_invoke", "*")`
+    /// - `tool:invoke:calculator` -> `("tool_invoke", "calculator")`
+    /// - `context:child:create`  -> `("context_child", "create")`
+    /// - `messages:write`        -> `("messages", "write")`
+    /// - `context:close`         -> `("context", "close")`
+    /// - `role:assign`           -> `("role", "assign")`
+    /// - `bridging`              -> `("bridging", "*")`
+    ///
+    /// The returned strings are suitable for constructing
+    /// [`CapabilityUri`](crate::crypto::ucan::capability::CapabilityUri) values
+    /// and for building ceiling string sets (`{resource}:{action}`).
+    ///
+    /// See issue #1293 for the mismatch this method resolves.
+    #[must_use]
+    pub fn ucan_resource_action(&self) -> (std::borrow::Cow<'_, str>, std::borrow::Cow<'_, str>) {
+        match self {
+            Self::MessagesRead => (
+                std::borrow::Cow::Borrowed("messages"),
+                std::borrow::Cow::Borrowed("read"),
+            ),
+            Self::MessagesWrite => (
+                std::borrow::Cow::Borrowed("messages"),
+                std::borrow::Cow::Borrowed("write"),
+            ),
+            Self::ToolInvoke(id) => (
+                std::borrow::Cow::Borrowed("tool_invoke"),
+                std::borrow::Cow::Borrowed(id.as_str()),
+            ),
+            Self::ToolInvokeAll => (
+                std::borrow::Cow::Borrowed("tool_invoke"),
+                std::borrow::Cow::Borrowed("*"),
+            ),
+            Self::ToolRegister => (
+                std::borrow::Cow::Borrowed("tool"),
+                std::borrow::Cow::Borrowed("register"),
+            ),
+            Self::MemberInvite => (
+                std::borrow::Cow::Borrowed("member"),
+                std::borrow::Cow::Borrowed("invite"),
+            ),
+            Self::MemberRemove => (
+                std::borrow::Cow::Borrowed("member"),
+                std::borrow::Cow::Borrowed("remove"),
+            ),
+            Self::RoleAssign => (
+                std::borrow::Cow::Borrowed("role"),
+                std::borrow::Cow::Borrowed("assign"),
+            ),
+            Self::GovernancePropose => (
+                std::borrow::Cow::Borrowed("governance"),
+                std::borrow::Cow::Borrowed("propose"),
+            ),
+            Self::GovernanceVote => (
+                std::borrow::Cow::Borrowed("governance"),
+                std::borrow::Cow::Borrowed("vote"),
+            ),
+            Self::ContextClose => (
+                std::borrow::Cow::Borrowed("context"),
+                std::borrow::Cow::Borrowed("close"),
+            ),
+            Self::ChildContextCreate => (
+                std::borrow::Cow::Borrowed("context_child"),
+                std::borrow::Cow::Borrowed("create"),
+            ),
+            Self::ToolInterface => (
+                std::borrow::Cow::Borrowed("tool"),
+                std::borrow::Cow::Borrowed("interface"),
+            ),
+            Self::Bridging => (
+                std::borrow::Cow::Borrowed("bridging"),
+                std::borrow::Cow::Borrowed("*"),
+            ),
+            Self::MediaVoice => (
+                std::borrow::Cow::Borrowed("media"),
+                std::borrow::Cow::Borrowed("voice"),
+            ),
+            Self::MediaVideo => (
+                std::borrow::Cow::Borrowed("media"),
+                std::borrow::Cow::Borrowed("video"),
+            ),
+            Self::MediaScreenShare => (
+                std::borrow::Cow::Borrowed("media"),
+                std::borrow::Cow::Borrowed("screen_share"),
+            ),
+            Self::MemberBan => (
+                std::borrow::Cow::Borrowed("member"),
+                std::borrow::Cow::Borrowed("ban"),
+            ),
+            Self::MetadataEdit => (
+                std::borrow::Cow::Borrowed("metadata"),
+                std::borrow::Cow::Borrowed("edit"),
+            ),
+            Self::Custom(name) => {
+                // Custom capabilities may use either colon or underscore format.
+                // Split on the last colon to separate resource from action.
+                if let Some((resource, action)) = name.rsplit_once(':') {
+                    (
+                        std::borrow::Cow::Owned(resource.replace(':', "_")),
+                        std::borrow::Cow::Borrowed(action),
+                    )
+                } else {
+                    // No colon — treat entire name as resource with wildcard action.
+                    (
+                        std::borrow::Cow::Borrowed(name.as_str()),
+                        std::borrow::Cow::Borrowed("*"),
+                    )
+                }
+            }
+        }
+    }
+
+    /// Returns the UCAN capability name string in `{resource}:{action}` format.
+    ///
+    /// This is the format used in capability ceiling sets and
+    /// [`CapabilityUri::capability_name()`](crate::crypto::ucan::capability::CapabilityUri::capability_name).
+    /// Unlike [`name()`](Self::name) which returns the canonical user-facing
+    /// colon format, this returns the UCAN-internal format with underscores
+    /// for multi-segment resources.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use scp_core::context::roles::Capability;
+    ///
+    /// assert_eq!(Capability::ToolInvokeAll.ucan_capability_name(), "tool_invoke:*");
+    /// assert_eq!(Capability::MessagesWrite.ucan_capability_name(), "messages:write");
+    /// assert_eq!(Capability::ChildContextCreate.ucan_capability_name(), "context_child:create");
+    /// ```
+    #[must_use]
+    pub fn ucan_capability_name(&self) -> String {
+        let (resource, action) = self.ucan_resource_action();
+        format!("{resource}:{action}")
+    }
 }
 
 impl std::fmt::Display for Capability {
@@ -972,9 +1112,10 @@ fn mint_role_tokens(
     role.capabilities
         .iter()
         .map(|cap| {
+            let (resource, action) = cap.ucan_resource_action();
             let att = UcanAttestation {
-                with: format!("scp:ctx:{context_id}/{cap}"),
-                can: "invoke".to_owned(),
+                with: format!("scp:ctx:{context_id}/{resource}:{action}"),
+                can: action.into_owned(),
             };
             Ok(UcanToken {
                 iss: creator_did.to_owned(),
@@ -1665,7 +1806,7 @@ mod tests {
         assert_eq!(token.aud, "did:dht:alice");
         assert_eq!(token.att.len(), 1);
         assert_eq!(token.att[0].with, "scp:ctx:ctx-1/messages:read");
-        assert_eq!(token.att[0].can, "invoke");
+        assert_eq!(token.att[0].can, "read");
         assert!(!token.nnc.is_empty());
         // Verify nonce format: {millis}-{hex}.
         assert!(token.nnc.contains('-'));
@@ -2038,5 +2179,165 @@ mod tests {
             matches!(&err, RoleError::InvalidRoleName(msg) if msg.contains("reserved")),
             "expected reserved name error, got: {err}"
         );
+    }
+
+    // -----------------------------------------------------------------------
+    // ucan_resource_action (#1293)
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn ucan_resource_action_tool_invoke_all() {
+        let (resource, action) = Capability::ToolInvokeAll.ucan_resource_action();
+        assert_eq!(resource.as_ref(), "tool_invoke");
+        assert_eq!(action.as_ref(), "*");
+    }
+
+    #[test]
+    fn ucan_resource_action_tool_invoke_specific() {
+        let cap = Capability::ToolInvoke("calculator".to_owned());
+        let (resource, action) = cap.ucan_resource_action();
+        assert_eq!(resource.as_ref(), "tool_invoke");
+        assert_eq!(action.as_ref(), "calculator");
+    }
+
+    #[test]
+    fn ucan_resource_action_messages() {
+        let (resource, action) = Capability::MessagesRead.ucan_resource_action();
+        assert_eq!(resource.as_ref(), "messages");
+        assert_eq!(action.as_ref(), "read");
+
+        let (resource, action) = Capability::MessagesWrite.ucan_resource_action();
+        assert_eq!(resource.as_ref(), "messages");
+        assert_eq!(action.as_ref(), "write");
+    }
+
+    #[test]
+    fn ucan_resource_action_context_close() {
+        let (resource, action) = Capability::ContextClose.ucan_resource_action();
+        assert_eq!(resource.as_ref(), "context");
+        assert_eq!(action.as_ref(), "close");
+    }
+
+    #[test]
+    fn ucan_resource_action_child_context_create() {
+        let (resource, action) = Capability::ChildContextCreate.ucan_resource_action();
+        assert_eq!(resource.as_ref(), "context_child");
+        assert_eq!(action.as_ref(), "create");
+    }
+
+    #[test]
+    fn ucan_resource_action_role_assign() {
+        let (resource, action) = Capability::RoleAssign.ucan_resource_action();
+        assert_eq!(resource.as_ref(), "role");
+        assert_eq!(action.as_ref(), "assign");
+    }
+
+    #[test]
+    fn ucan_resource_action_bridging() {
+        let (resource, action) = Capability::Bridging.ucan_resource_action();
+        assert_eq!(resource.as_ref(), "bridging");
+        assert_eq!(action.as_ref(), "*");
+    }
+
+    #[test]
+    fn ucan_resource_action_from_name_string() {
+        // Parsing from the canonical colon name produces the correct UCAN pair.
+        let cap = Capability::new("tool:invoke:*");
+        let (resource, action) = cap.ucan_resource_action();
+        assert_eq!(resource.as_ref(), "tool_invoke");
+        assert_eq!(action.as_ref(), "*");
+    }
+
+    #[test]
+    fn ucan_resource_action_tool_invoke_specific_from_name() {
+        let cap = Capability::new("tool:invoke:calculator");
+        let (resource, action) = cap.ucan_resource_action();
+        assert_eq!(resource.as_ref(), "tool_invoke");
+        assert_eq!(action.as_ref(), "calculator");
+    }
+
+    #[test]
+    fn ucan_capability_name_format() {
+        assert_eq!(
+            Capability::ToolInvokeAll.ucan_capability_name(),
+            "tool_invoke:*"
+        );
+        assert_eq!(
+            Capability::MessagesWrite.ucan_capability_name(),
+            "messages:write"
+        );
+        assert_eq!(
+            Capability::ChildContextCreate.ucan_capability_name(),
+            "context_child:create"
+        );
+        assert_eq!(
+            Capability::ToolInvoke("calc".to_owned()).ucan_capability_name(),
+            "tool_invoke:calc"
+        );
+        assert_eq!(Capability::Bridging.ucan_capability_name(), "bridging:*");
+        assert_eq!(
+            Capability::ToolRegister.ucan_capability_name(),
+            "tool:register"
+        );
+    }
+
+    #[test]
+    fn ucan_resource_action_custom_with_colons() {
+        let cap = Capability::Custom("some:nested:name".to_owned());
+        let (resource, action) = cap.ucan_resource_action();
+        assert_eq!(resource.as_ref(), "some_nested");
+        assert_eq!(action.as_ref(), "name");
+    }
+
+    #[test]
+    fn ucan_resource_action_custom_no_colons() {
+        let cap = Capability::Custom("single".to_owned());
+        let (resource, action) = cap.ucan_resource_action();
+        assert_eq!(resource.as_ref(), "single");
+        assert_eq!(action.as_ref(), "*");
+    }
+
+    #[test]
+    fn ucan_resource_action_custom_simple_colon() {
+        let cap = Capability::Custom("foo:bar".to_owned());
+        let (resource, action) = cap.ucan_resource_action();
+        assert_eq!(resource.as_ref(), "foo");
+        assert_eq!(action.as_ref(), "bar");
+    }
+
+    #[test]
+    fn ucan_resource_action_all_standard_variants() {
+        // Every standard variant must produce a non-empty resource and action.
+        let caps = vec![
+            Capability::MessagesRead,
+            Capability::MessagesWrite,
+            Capability::ToolInvoke("test".to_owned()),
+            Capability::ToolInvokeAll,
+            Capability::ToolRegister,
+            Capability::MemberInvite,
+            Capability::MemberRemove,
+            Capability::RoleAssign,
+            Capability::GovernancePropose,
+            Capability::GovernanceVote,
+            Capability::ContextClose,
+            Capability::ChildContextCreate,
+            Capability::ToolInterface,
+            Capability::Bridging,
+            Capability::MediaVoice,
+            Capability::MediaVideo,
+            Capability::MediaScreenShare,
+            Capability::MemberBan,
+            Capability::MetadataEdit,
+        ];
+        for cap in &caps {
+            let (resource, action) = cap.ucan_resource_action();
+            assert!(!resource.is_empty(), "empty resource for {cap:?}");
+            assert!(!action.is_empty(), "empty action for {cap:?}");
+            // Resource must not contain colons (UCAN uses underscores).
+            assert!(
+                !resource.contains(':'),
+                "resource for {cap:?} contains colon: {resource}"
+            );
+        }
     }
 }

--- a/crates/scp-core/src/crypto/ucan/mint.rs
+++ b/crates/scp-core/src/crypto/ucan/mint.rs
@@ -262,20 +262,28 @@ pub async fn mint_ucan(
         return Err(UcanError::ExpiryTooFar(params.lifetime_secs));
     }
 
+    // Convert capability strings to UCAN resource/action pairs. This bridges
+    // the canonical user-facing colon format (e.g. "tool:invoke:*") to the
+    // UCAN underscore format (e.g. resource="tool_invoke", action="*") by
+    // parsing through the Capability enum. See #1293.
+    let parsed_caps: Vec<(String, String)> = params
+        .capabilities
+        .iter()
+        .map(|cap| {
+            let capability = crate::context::roles::Capability::new(cap);
+            let (resource, action) = capability.ucan_resource_action();
+            (resource.into_owned(), action.into_owned())
+        })
+        .collect();
+
     // Enforce ceiling compliance before doing any work (§5.3, #339).
     if let Some(ref ceiling) = params.ceiling {
-        let cap_uris: Vec<CapabilityUri> = params
-            .capabilities
+        let cap_uris: Vec<CapabilityUri> = parsed_caps
             .iter()
-            .map(|cap| {
-                let (resource, action) = cap.split_once(':').ok_or_else(|| {
-                    UcanError::MalformedToken(format!(
-                        "capability must be in 'resource:action' format, got: {cap}"
-                    ))
-                })?;
-                Ok(CapabilityUri::new(params.context_id, resource, action))
+            .map(|(resource, action)| {
+                CapabilityUri::new(params.context_id, resource.as_str(), action.as_str())
             })
-            .collect::<Result<Vec<_>, UcanError>>()?;
+            .collect();
         verify_ceiling_compliance(&cap_uris, ceiling)?;
     }
 
@@ -283,22 +291,17 @@ pub async fn mint_ucan(
     let exp = now + params.lifetime_secs;
 
     // Build attestations from capabilities, scoped to the context.
-    // Validate capability format: must be "resource:action".
-    let att: Vec<Attenuation> = params
-        .capabilities
+    // Uses UCAN resource/action format for correct URI construction (#1293).
+    let att: Vec<Attenuation> = parsed_caps
         .iter()
-        .map(|cap| {
-            let (_resource, action) = cap.split_once(':').ok_or_else(|| {
-                UcanError::MalformedToken(format!(
-                    "capability must be in 'resource:action' format, got: {cap}"
-                ))
-            })?;
-            Ok(Attenuation {
-                with: format!("scp:ctx:{}/{cap}", params.context_id),
-                can: action.to_owned(),
-            })
+        .map(|(resource, action)| {
+            let ucan_cap = format!("{resource}:{action}");
+            Attenuation {
+                with: format!("scp:ctx:{}/{ucan_cap}", params.context_id),
+                can: action.clone(),
+            }
         })
-        .collect::<Result<Vec<_>, UcanError>>()?;
+        .collect();
 
     // Build header — include kid when signing_key_id or key_scope is present
     // (ADR-039). signing_key_id takes precedence over key_scope for the kid
@@ -2844,6 +2847,190 @@ mod tests {
         assert!(
             delegate_ucan(&delegate_params, &bob_custody).await.is_ok(),
             "delegation narrowing within ceiling must succeed"
+        );
+    }
+
+    // -----------------------------------------------------------------------
+    // #1293 — UCAN capability URI resource/action split
+    // -----------------------------------------------------------------------
+
+    #[tokio::test]
+    async fn mint_ucan_tool_invoke_produces_underscore_resource() {
+        // Minting with the colon-format name "tool:invoke:*" must produce
+        // a UCAN URI with resource "tool_invoke", not "tool".
+        let (custody, key_handle, issuer_did) = setup_custody().await;
+        let caps = vec!["tool:invoke:*".to_owned()];
+
+        let params = MintParams {
+            issuer_did: &issuer_did,
+            issuer_key: &key_handle,
+            audience_did: "did:dht:z6MkMember",
+            context_id: "ctx-1293",
+            capabilities: &caps,
+            lifetime_secs: 3600,
+            not_before: None,
+            proofs: vec![],
+            facts: None,
+            key_scope: None,
+            signing_key_id: None,
+            ceiling: None,
+        };
+
+        let token = mint_ucan(&params, &custody).await.unwrap();
+
+        // The attestation URI must use underscore format.
+        assert_eq!(
+            token.payload.att[0].with, "scp:ctx:ctx-1293/tool_invoke:*",
+            "tool:invoke:* must produce tool_invoke:* in UCAN URI"
+        );
+        assert_eq!(token.payload.att[0].can, "*");
+    }
+
+    #[tokio::test]
+    async fn mint_ucan_tool_invoke_specific_produces_underscore_resource() {
+        let (custody, key_handle, issuer_did) = setup_custody().await;
+        let caps = vec!["tool:invoke:calculator".to_owned()];
+
+        let params = MintParams {
+            issuer_did: &issuer_did,
+            issuer_key: &key_handle,
+            audience_did: "did:dht:z6MkMember",
+            context_id: "ctx-1293",
+            capabilities: &caps,
+            lifetime_secs: 3600,
+            not_before: None,
+            proofs: vec![],
+            facts: None,
+            key_scope: None,
+            signing_key_id: None,
+            ceiling: None,
+        };
+
+        let token = mint_ucan(&params, &custody).await.unwrap();
+
+        assert_eq!(
+            token.payload.att[0].with, "scp:ctx:ctx-1293/tool_invoke:calculator",
+            "tool:invoke:calculator must produce tool_invoke:calculator in UCAN URI"
+        );
+        assert_eq!(token.payload.att[0].can, "calculator");
+    }
+
+    #[tokio::test]
+    async fn mint_ucan_child_context_create_produces_underscore_resource() {
+        let (custody, key_handle, issuer_did) = setup_custody().await;
+        let caps = vec!["context:child:create".to_owned()];
+
+        let params = MintParams {
+            issuer_did: &issuer_did,
+            issuer_key: &key_handle,
+            audience_did: "did:dht:z6MkMember",
+            context_id: "ctx-1293",
+            capabilities: &caps,
+            lifetime_secs: 3600,
+            not_before: None,
+            proofs: vec![],
+            facts: None,
+            key_scope: None,
+            signing_key_id: None,
+            ceiling: None,
+        };
+
+        let token = mint_ucan(&params, &custody).await.unwrap();
+
+        assert_eq!(
+            token.payload.att[0].with, "scp:ctx:ctx-1293/context_child:create",
+            "context:child:create must produce context_child:create in UCAN URI"
+        );
+        assert_eq!(token.payload.att[0].can, "create");
+    }
+
+    #[tokio::test]
+    async fn mint_ucan_simple_cap_unchanged() {
+        // Capabilities without multi-segment resources should be unchanged.
+        let (custody, key_handle, issuer_did) = setup_custody().await;
+        let caps = vec!["messages:write".to_owned()];
+
+        let params = MintParams {
+            issuer_did: &issuer_did,
+            issuer_key: &key_handle,
+            audience_did: "did:dht:z6MkMember",
+            context_id: "ctx-1293",
+            capabilities: &caps,
+            lifetime_secs: 3600,
+            not_before: None,
+            proofs: vec![],
+            facts: None,
+            key_scope: None,
+            signing_key_id: None,
+            ceiling: None,
+        };
+
+        let token = mint_ucan(&params, &custody).await.unwrap();
+
+        assert_eq!(
+            token.payload.att[0].with, "scp:ctx:ctx-1293/messages:write",
+            "simple capabilities must pass through unchanged"
+        );
+        assert_eq!(token.payload.att[0].can, "write");
+    }
+
+    #[tokio::test]
+    async fn mint_ucan_tool_invoke_passes_ceiling_check() {
+        // A ceiling with UCAN-format entries must accept tool:invoke:* capabilities.
+        let (custody, key_handle, issuer_did) = setup_custody().await;
+        let caps = vec!["tool:invoke:*".to_owned()];
+
+        let mut ceiling = HashSet::new();
+        ceiling.insert("tool_invoke:*".to_owned());
+
+        let params = MintParams {
+            issuer_did: &issuer_did,
+            issuer_key: &key_handle,
+            audience_did: "did:dht:z6MkMember",
+            context_id: "ctx-1293",
+            capabilities: &caps,
+            lifetime_secs: 3600,
+            not_before: None,
+            proofs: vec![],
+            facts: None,
+            key_scope: None,
+            signing_key_id: None,
+            ceiling: Some(ceiling),
+        };
+
+        assert!(
+            mint_ucan(&params, &custody).await.is_ok(),
+            "tool:invoke:* must pass ceiling check with tool_invoke:* in ceiling"
+        );
+    }
+
+    #[tokio::test]
+    async fn mint_ucan_tool_invoke_rejected_when_not_in_ceiling() {
+        let (custody, key_handle, issuer_did) = setup_custody().await;
+        let caps = vec!["tool:invoke:*".to_owned()];
+
+        let mut ceiling = HashSet::new();
+        ceiling.insert("messages:write".to_owned());
+
+        let params = MintParams {
+            issuer_did: &issuer_did,
+            issuer_key: &key_handle,
+            audience_did: "did:dht:z6MkMember",
+            context_id: "ctx-1293",
+            capabilities: &caps,
+            lifetime_secs: 3600,
+            not_before: None,
+            proofs: vec![],
+            facts: None,
+            key_scope: None,
+            signing_key_id: None,
+            ceiling: Some(ceiling),
+        };
+
+        let err = mint_ucan(&params, &custody).await.unwrap_err();
+        assert!(
+            matches!(err, UcanError::CapabilityOutsideCeiling(_)),
+            "tool:invoke:* must be rejected when not in ceiling: {err:?}"
         );
     }
 }

--- a/crates/scp-core/src/crypto/ucan/mod.rs
+++ b/crates/scp-core/src/crypto/ucan/mod.rs
@@ -349,19 +349,26 @@ impl Default for UcanHeader {
 /// A single capability grant within a UCAN token.
 ///
 /// Each attenuation specifies a resource URI and an action. The resource URI
-/// follows the SCP capability URI format: `scp:ctx:{context_id}/{capability}`.
-/// The action is one of `"invoke"`, `"read"`, or `"write"`.
+/// follows the SCP capability URI format: `scp:ctx:{context_id}/{resource}:{action}`,
+/// where compound resources use underscores (e.g. `tool_invoke`, `context_child`).
 ///
-/// See ADR-016 acceptance criterion 4.
+/// The `can` field holds the action portion (e.g. `"*"`, `"calculator"`,
+/// `"write"`, `"propose"`). See [`CapabilityUri`](capability::CapabilityUri)
+/// for the full URI format and [`Capability::ucan_resource_action`](crate::context::roles::Capability::ucan_resource_action)
+/// for the mapping from canonical colon-format to UCAN format.
+///
+/// See ADR-016 acceptance criterion 4 and #1293.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct Attenuation {
-    /// Resource URI: `scp:ctx:{context_id}/{capability}`.
+    /// Resource URI: `scp:ctx:{context_id}/{resource}:{action}`.
     ///
     /// Examples:
     /// - `"scp:ctx:abc123/messages:write"`
+    /// - `"scp:ctx:abc123/tool_invoke:*"`
     /// - `"scp:ctx:*/messages:write"` (wildcard — all contexts)
     pub with: String,
-    /// Action: `"invoke"`, `"read"`, or `"write"`.
+    /// Action on the resource (e.g. `"*"`, `"write"`, `"calculator"`,
+    /// `"propose"`). This is the action portion extracted from the `with` URI.
     pub can: String,
 }
 

--- a/crates/scp-core/tests/wasm_conformance.rs
+++ b/crates/scp-core/tests/wasm_conformance.rs
@@ -4838,7 +4838,7 @@ mod wasm_role_broadcast_mirror {
                 "messages:read",
                 "messages:write",
                 "tool:register",
-                "tool:invoke:*",
+                "tool_invoke:*",
                 "role:assign",
                 "member:invite",
                 "member:remove",
@@ -4876,7 +4876,7 @@ mod wasm_role_broadcast_mirror {
                         capability,
                         "messages:read"
                             | "messages:write"
-                            | "tool:invoke:*"
+                            | "tool_invoke:*"
                             | "member:remove"
                             | "governance:propose"
                     );
@@ -4885,14 +4885,14 @@ mod wasm_role_broadcast_mirror {
                 "author" => {
                     let role_grants = matches!(
                         capability,
-                        "messages:write" | "messages:read" | "tool:invoke:*"
+                        "messages:write" | "messages:read" | "tool_invoke:*"
                     );
                     role_grants && in_ceiling(capability)
                 }
                 "member" => {
                     let role_grants = matches!(
                         capability,
-                        "messages:read" | "messages:write" | "tool:invoke:*"
+                        "messages:read" | "messages:write" | "tool_invoke:*"
                     );
                     role_grants && in_ceiling(capability)
                 }
@@ -5102,7 +5102,7 @@ fn moderator_has_governance_propose_capability() {
     // And the standard messaging + tool capabilities.
     assert!(ctx.member_has_capability(did, "messages:read"));
     assert!(ctx.member_has_capability(did, "messages:write"));
-    assert!(ctx.member_has_capability(did, "tool:invoke:*"));
+    assert!(ctx.member_has_capability(did, "tool_invoke:*"));
     // But NOT admin-only capabilities.
     assert!(
         !ctx.member_has_capability(did, "context:close"),
@@ -5133,15 +5133,15 @@ fn subscriber_has_messages_read_only() {
         !ctx.member_has_capability(did, "messages:write"),
         "subscriber should NOT have messages:write"
     );
-    // And NOT tool:invoke:*.
+    // And NOT tool_invoke:*.
     assert!(
-        !ctx.member_has_capability(did, "tool:invoke:*"),
-        "subscriber should NOT have tool:invoke:*"
+        !ctx.member_has_capability(did, "tool_invoke:*"),
+        "subscriber should NOT have tool_invoke:*"
     );
 }
 
 // ===========================================================================
-// Test: member role includes tool:invoke:* (intersected with ceiling)
+// Test: member role includes tool_invoke:* (intersected with ceiling)
 // ===========================================================================
 
 #[test]
@@ -5156,8 +5156,8 @@ fn member_has_tool_invoke_all_capability() {
     assert!(ctx.member_has_capability(did, "messages:read"));
     assert!(ctx.member_has_capability(did, "messages:write"));
     assert!(
-        ctx.member_has_capability(did, "tool:invoke:*"),
-        "member should have tool:invoke:* capability"
+        ctx.member_has_capability(did, "tool_invoke:*"),
+        "member should have tool_invoke:* capability"
     );
     // But NOT governance:propose (that's moderator+).
     assert!(
@@ -5167,8 +5167,8 @@ fn member_has_tool_invoke_all_capability() {
 }
 
 // ===========================================================================
-// Test: member role respects ceiling — removing tool:invoke:* from ceiling
-// should deny tool:invoke:*
+// Test: member role respects ceiling — removing tool_invoke:* from ceiling
+// should deny tool_invoke:*
 // ===========================================================================
 
 #[test]
@@ -5178,18 +5178,18 @@ fn member_capability_ceiling_intersection() {
     let mut ctx = PerContextState::new_with_default_ceiling(None);
     let did = "did:key:member-002";
 
-    // Remove tool:invoke:* from ceiling.
-    ctx.ceiling_strings.remove("tool:invoke:*");
+    // Remove tool_invoke:* from ceiling.
+    ctx.ceiling_strings.remove("tool_invoke:*");
 
     ctx.add_member(did, "member");
 
     // messages:read/write should still work.
     assert!(ctx.member_has_capability(did, "messages:read"));
     assert!(ctx.member_has_capability(did, "messages:write"));
-    // tool:invoke:* should be denied (not in ceiling).
+    // tool_invoke:* should be denied (not in ceiling).
     assert!(
-        !ctx.member_has_capability(did, "tool:invoke:*"),
-        "member should NOT have tool:invoke:* when tool:invoke:* is removed from ceiling"
+        !ctx.member_has_capability(did, "tool_invoke:*"),
+        "member should NOT have tool_invoke:* when tool_invoke:* is removed from ceiling"
     );
 }
 

--- a/crates/scp-ffi/napi/src/context.rs
+++ b/crates/scp-ffi/napi/src/context.rs
@@ -440,7 +440,10 @@ pub async fn context_create(
         state: std::sync::Mutex::new(ContextState::Active),
         creator_did,
         mode: mode_str,
-        ceiling,
+        ceiling: ceiling
+            .iter()
+            .map(|s| scp_core::context::roles::Capability::new(s).ucan_capability_name())
+            .collect(),
         ceiling_policy,
         ttl_seconds,
         promotion_policy,

--- a/crates/scp-ffi/napi/src/runtime.rs
+++ b/crates/scp-ffi/napi/src/runtime.rs
@@ -483,10 +483,13 @@ pub fn ensure_registered(handle: &NapiContextHandle) -> Result<(), ScpNapiError>
         scp_core::context::roles::default_ceiling()
             .capabilities
             .iter()
-            .map(std::string::ToString::to_string)
+            .map(scp_core::context::roles::Capability::ucan_capability_name)
             .collect::<HashSet<String>>()
     } else {
-        handle_ceiling.into_iter().collect::<HashSet<String>>()
+        handle_ceiling
+            .into_iter()
+            .map(|s| scp_core::context::roles::Capability::new(&s).ucan_capability_name())
+            .collect::<HashSet<String>>()
     };
 
     let event_log = EventLog::new(context_id.clone());
@@ -672,7 +675,7 @@ pub fn register_test_context(context_id: &str, creator_did: &str) {
     let ceiling_strings = scp_core::context::roles::default_ceiling()
         .capabilities
         .iter()
-        .map(std::string::ToString::to_string)
+        .map(scp_core::context::roles::Capability::ucan_capability_name)
         .collect::<HashSet<String>>();
 
     // Default ceiling + no custom roles: infallible in practice.

--- a/crates/scp-ffi/src/context.rs
+++ b/crates/scp-ffi/src/context.rs
@@ -758,7 +758,7 @@ fn py_context_create(identity_did: &str, params: &Bound<'_, PyDict>) -> PyResult
     // Register FFI-specific state (ToolRegistry, EventLog, RoleState, RevocationList)
     // in the global FFI state registry so that tools/UCAN/event_log bridge functions
     // can look them up by context ID. Also initializes the shared ContextManager.
-    crate::runtime::register_context(&context_id, identity_did)
+    crate::runtime::register_context(&context_id, identity_did, &parsed.ceiling)
         .map_err(|e| PyRuntimeError::new_err(format!("failed to register context state: {e}")))?;
 
     // Delegate context creation to the shared ContextManager for lifecycle tracking.
@@ -3669,7 +3669,7 @@ mod tests {
     async fn deliver_message_via_runtime() {
         let context_id = "ctx-deliver-test";
 
-        crate::runtime::register_context(context_id, "did:test:creator").unwrap();
+        crate::runtime::register_context(context_id, "did:test:creator", &[]).unwrap();
 
         let (tx, rx) = mpsc::channel::<PyMessage>(RECEIVE_BUFFER_CAPACITY);
         let rx_arc = Arc::new(tokio::sync::Mutex::new(rx));
@@ -3702,7 +3702,7 @@ mod tests {
         let context_id = "ctx-overflow-deliver";
         let capacity = RECEIVE_BUFFER_CAPACITY;
 
-        crate::runtime::register_context(context_id, "did:test:creator").unwrap();
+        crate::runtime::register_context(context_id, "did:test:creator", &[]).unwrap();
 
         let (tx, rx) = mpsc::channel::<PyMessage>(capacity);
         let rx_arc = Arc::new(tokio::sync::Mutex::new(rx));
@@ -3756,7 +3756,7 @@ mod tests {
         crate::init_runtime().ok();
         let context_id = "ctx-leave-close";
 
-        crate::runtime::register_context(context_id, "did:test:creator").unwrap();
+        crate::runtime::register_context(context_id, "did:test:creator", &[]).unwrap();
 
         let (tx, rx) = mpsc::channel::<PyMessage>(RECEIVE_BUFFER_CAPACITY);
         let rx_arc = Arc::new(tokio::sync::Mutex::new(rx));
@@ -4073,7 +4073,7 @@ mod tests {
         crate::init_runtime().ok();
         let ctx_id = format!("sync-role-{}", uuid::Uuid::new_v4());
         let creator = "did:key:z6MkCreatorSync1";
-        crate::runtime::register_context(&ctx_id, creator).unwrap();
+        crate::runtime::register_context(&ctx_id, creator, &[]).unwrap();
         let mgr = crate::runtime::context_manager().unwrap();
         let rt = crate::runtime().unwrap();
         let params = scp_core::context::ContextParams {
@@ -4132,7 +4132,7 @@ mod tests {
         crate::init_runtime().ok();
         let ctx_id = format!("sync-add-{}", uuid::Uuid::new_v4());
         let creator = "did:key:z6MkCreatorSync2";
-        crate::runtime::register_context(&ctx_id, creator).unwrap();
+        crate::runtime::register_context(&ctx_id, creator, &[]).unwrap();
         let mgr = crate::runtime::context_manager().unwrap();
         let rt = crate::runtime().unwrap();
         let params = scp_core::context::ContextParams {
@@ -4184,7 +4184,7 @@ mod tests {
         let ctx_id = format!("sync-rm-{}", uuid::Uuid::new_v4());
         let creator = "did:key:z6MkCreatorSync3";
         let target = "did:key:z6MkRemoveTarget";
-        crate::runtime::register_context(&ctx_id, creator).unwrap();
+        crate::runtime::register_context(&ctx_id, creator, &[]).unwrap();
         let mgr = crate::runtime::context_manager().unwrap();
         let rt = crate::runtime().unwrap();
         let params = scp_core::context::ContextParams {

--- a/crates/scp-ffi/src/mcp.rs
+++ b/crates/scp-ffi/src/mcp.rs
@@ -2319,7 +2319,7 @@ mod tests {
     fn setup_test_context(creator_did: &str, with_tool: bool) -> String {
         // Use a unique context ID to avoid collisions across parallel tests.
         let ctx_id = crate::types::generate_random_id("test-mcp");
-        crate::runtime::register_context(&ctx_id, creator_did).unwrap();
+        crate::runtime::register_context(&ctx_id, creator_did, &[]).unwrap();
 
         if with_tool {
             crate::runtime::with_context(&ctx_id, |rt| {

--- a/crates/scp-ffi/src/runtime.rs
+++ b/crates/scp-ffi/src/runtime.rs
@@ -503,11 +503,20 @@ pub const RECEIVE_BUFFER_CAPACITY: usize = 1000;
 /// [`RevocationList`] for the context. The creator DID is assigned admin
 /// capabilities (all capabilities in the ceiling).
 ///
+/// `user_ceiling` contains user-provided ceiling strings in colon format
+/// (e.g. `"tool:invoke:*"`). These are converted to UCAN underscore format
+/// (e.g. `"tool_invoke:*"`) via `Capability::new` + `ucan_capability_name`.
+/// Pass an empty slice to use the default ceiling.
+///
 /// # Errors
 ///
 /// Returns `ScpPyError::ContextError` if the context ID is already registered
 /// or if role state creation fails.
-pub fn register_ffi_state(context_id: &str, creator_did: &str) -> Result<(), ScpPyError> {
+pub fn register_ffi_state(
+    context_id: &str,
+    creator_did: &str,
+    user_ceiling: &[String],
+) -> Result<(), ScpPyError> {
     use dashmap::mapref::entry::Entry;
 
     let map = ffi_state_registry();
@@ -522,11 +531,18 @@ pub fn register_ffi_state(context_id: &str, creator_did: &str) -> Result<(), Scp
             let tool_registry = ToolRegistry::new();
             let event_log = EventLog::new(context_id.to_owned());
             let ceiling = default_ceiling();
-            let ceiling_strings = ceiling
-                .capabilities
-                .iter()
-                .map(std::string::ToString::to_string)
-                .collect::<HashSet<String>>();
+            let ceiling_strings = if user_ceiling.is_empty() {
+                ceiling
+                    .capabilities
+                    .iter()
+                    .map(scp_core::context::roles::Capability::ucan_capability_name)
+                    .collect::<HashSet<String>>()
+            } else {
+                user_ceiling
+                    .iter()
+                    .map(|s| scp_core::context::roles::Capability::new(s).ucan_capability_name())
+                    .collect::<HashSet<String>>()
+            };
             let role_state = ContextRoleState::new(context_id, creator_did, ceiling, vec![])
                 .map_err(|e| ScpPyError::context(format!("failed to create role state: {e}")))?;
             let revocation_list = RevocationList::new(context_id.to_owned());
@@ -1146,7 +1162,11 @@ pub fn clear_relay_connection() -> Result<(), ScpPyError> {
 /// # Errors
 ///
 /// Returns `ScpPyError::ContextError` if registration fails.
-pub fn register_context(context_id: &str, creator_did: &str) -> Result<(), ScpPyError> {
+pub fn register_context(
+    context_id: &str,
+    creator_did: &str,
+    user_ceiling: &[String],
+) -> Result<(), ScpPyError> {
     // Ensure the ContextManager is initialized.
     // Tests use LocalTransportProvider so publish_context succeeds silently.
     // Production uses NotConfiguredTransportProvider — publish_context
@@ -1158,7 +1178,7 @@ pub fn register_context(context_id: &str, creator_did: &str) -> Result<(), ScpPy
     init_context_manager();
 
     // Register FFI-specific state.
-    register_ffi_state(context_id, creator_did)
+    register_ffi_state(context_id, creator_did, user_ceiling)
 }
 
 /// Backward-compatible alias for [`with_ffi_state`].
@@ -1385,7 +1405,7 @@ mod tests {
         let ctx_id = unique_ctx_id("stats-ctx");
         let creator = "did:dht:z6MkStatsTest";
 
-        register_context(&ctx_id, creator).unwrap();
+        register_context(&ctx_id, creator, &[]).unwrap();
         let stats = registry_stats().unwrap();
 
         // Verify that stats reports at least 1 context (our registered one).
@@ -1537,7 +1557,7 @@ mod tests {
     fn with_ffi_state_finds_registered_context() {
         let ctx_id = unique_ctx_id("ffi-find");
         let creator = "did:dht:z6MkFfiFind";
-        register_context(&ctx_id, creator).unwrap();
+        register_context(&ctx_id, creator, &[]).unwrap();
 
         let creator_did = with_ffi_state(&ctx_id, |st| Ok(st.creator_did.clone())).unwrap();
         assert_eq!(creator_did, creator);
@@ -1549,5 +1569,83 @@ mod tests {
     fn with_ffi_state_errors_on_missing_context() {
         let result = with_ffi_state("nonexistent-ctx-id", |_| Ok(()));
         assert!(result.is_err());
+    }
+
+    /// User-provided ceiling strings in colon format (e.g. `"tool:invoke:*"`)
+    /// must be converted to UCAN underscore format (e.g. `"tool_invoke:*"`)
+    /// when stored in `FfiBridgeState.ceiling_strings`. Without this conversion,
+    /// `mint_ucan` ceiling checks fail because the minted capability name
+    /// (underscore format) doesn't match the stored raw string.
+    ///
+    /// Regression test for PR #1293 review finding.
+    #[test]
+    fn user_ceiling_strings_converted_to_ucan_format() {
+        let ctx_id = unique_ctx_id("ceiling-conv");
+        let creator = "did:dht:z6MkCeilingConv";
+
+        let user_ceiling = vec![
+            "tool:invoke:*".to_owned(),
+            "messages:write".to_owned(),
+            "context:child:create".to_owned(),
+            "tool:invoke:calculator".to_owned(),
+        ];
+
+        register_context(&ctx_id, creator, &user_ceiling).unwrap();
+
+        let ceiling = with_ffi_state(&ctx_id, |st| Ok(st.ceiling_strings.clone())).unwrap();
+
+        // Compound resources must have underscores joining their segments.
+        assert!(
+            ceiling.contains("tool_invoke:*"),
+            "expected 'tool_invoke:*' but got: {ceiling:?}"
+        );
+        assert!(
+            ceiling.contains("context_child:create"),
+            "expected 'context_child:create' but got: {ceiling:?}"
+        );
+        assert!(
+            ceiling.contains("tool_invoke:calculator"),
+            "expected 'tool_invoke:calculator' but got: {ceiling:?}"
+        );
+        // Simple two-segment capabilities should pass through unchanged.
+        assert!(
+            ceiling.contains("messages:write"),
+            "expected 'messages:write' but got: {ceiling:?}"
+        );
+        // Raw colon-format strings must NOT be present.
+        assert!(
+            !ceiling.contains("tool:invoke:*"),
+            "raw 'tool:invoke:*' should not be in ceiling: {ceiling:?}"
+        );
+        assert!(
+            !ceiling.contains("context:child:create"),
+            "raw 'context:child:create' should not be in ceiling: {ceiling:?}"
+        );
+
+        remove_context(&ctx_id);
+    }
+
+    /// When no user ceiling is provided (empty slice), the default ceiling
+    /// should be used with proper UCAN underscore format.
+    #[test]
+    fn empty_user_ceiling_uses_default_in_ucan_format() {
+        let ctx_id = unique_ctx_id("ceiling-default");
+        let creator = "did:dht:z6MkCeilingDefault";
+
+        register_context(&ctx_id, creator, &[]).unwrap();
+
+        let ceiling = with_ffi_state(&ctx_id, |st| Ok(st.ceiling_strings.clone())).unwrap();
+
+        // Default ceiling must include tool_invoke:* (not tool:invoke:*).
+        assert!(
+            ceiling.contains("tool_invoke:*"),
+            "default ceiling should contain 'tool_invoke:*' but got: {ceiling:?}"
+        );
+        assert!(
+            !ceiling.contains("tool:invoke:*"),
+            "default ceiling should not contain raw 'tool:invoke:*': {ceiling:?}"
+        );
+
+        remove_context(&ctx_id);
     }
 }

--- a/crates/scp-ffi/src/tools.rs
+++ b/crates/scp-ffi/src/tools.rs
@@ -1717,7 +1717,7 @@ mod tests {
         let creator_did = "did:dht:z6MkTestTimestamp";
 
         // Register FFI state so the context exists in the runtime registry.
-        crate::runtime::register_ffi_state(&ctx_id, creator_did).unwrap();
+        crate::runtime::register_ffi_state(&ctx_id, creator_did, &[]).unwrap();
 
         pyo3::prepare_freethreaded_python();
         Python::with_gil(|py| {

--- a/crates/scp-ffi/tests/e2e_bridge.rs
+++ b/crates/scp-ffi/tests/e2e_bridge.rs
@@ -98,7 +98,7 @@ fn create_test_identity() -> String {
 fn create_test_context(creator_did: &str) -> String {
     setup();
     let context_id = random_context_id();
-    runtime::register_context(&context_id, creator_did).unwrap();
+    runtime::register_context(&context_id, creator_did, &[]).unwrap();
 
     let rt = test_runtime();
     let mgr = runtime::context_manager().unwrap().clone();

--- a/crates/scp-ffi/uniffi/src/bridge.rs
+++ b/crates/scp-ffi/uniffi/src/bridge.rs
@@ -2426,7 +2426,11 @@ pub async fn context_create(
                 in_memory_custody,
                 callback_custody,
                 signing_key,
-                ceiling_strings: params.ceiling.clone(),
+                ceiling_strings: params
+                    .ceiling
+                    .iter()
+                    .map(|s| scp_core::context::roles::Capability::new(s).ucan_capability_name())
+                    .collect(),
                 tool_registry: tokio::sync::Mutex::new(
                     scp_core::context::tools::ToolRegistry::new(),
                 ),

--- a/crates/scp-ffi/uniffi/src/runtime.rs
+++ b/crates/scp-ffi/uniffi/src/runtime.rs
@@ -379,10 +379,13 @@ pub fn ensure_ucan_registered(context_id: &str, creator_did: &str, ceiling: &[St
         scp_core::context::roles::default_ceiling()
             .capabilities
             .iter()
-            .map(std::string::ToString::to_string)
+            .map(scp_core::context::roles::Capability::ucan_capability_name)
             .collect::<HashSet<String>>()
     } else {
-        ceiling.iter().cloned().collect::<HashSet<String>>()
+        ceiling
+            .iter()
+            .map(|s| scp_core::context::roles::Capability::new(s).ucan_capability_name())
+            .collect::<HashSet<String>>()
     };
 
     let event_log = EventLog::new(context_id.to_owned());

--- a/crates/scp-ffi/wasm/src/context.rs
+++ b/crates/scp-ffi/wasm/src/context.rs
@@ -1468,7 +1468,7 @@ pub fn context_reset_ttl_timer(handle: &WasmContextHandle, new_duration_secs: u3
 fn map_capability_names(category: &str, action: &str, is_tool: bool) -> Vec<String> {
     match (category, action, is_tool) {
         // ToolInvoke(specific) -- resource ends with tools/{tool_name}
-        (_, "invoke", true) => vec![format!("tool:invoke:{category}")],
+        (_, "invoke", true) => vec![format!("tool_invoke:{category}")],
         // MessagesRead -- core accepts ("messaging"|"members", "read")
         ("messaging" | "members", "read", _) => vec!["messages:read".to_owned()],
         // MessagesWrite -- core accepts ("messaging", "write") only
@@ -1476,7 +1476,7 @@ fn map_capability_names(category: &str, action: &str, is_tool: bool) -> Vec<Stri
         // MemberInvite -- core accepts ("members", "write"|"admin")
         ("members", "write" | "admin", _) => vec!["member:invite".to_owned()],
         // ToolInvokeAll
-        ("tools", "invoke", _) => vec!["tool:invoke:*".to_owned()],
+        ("tools", "invoke", _) => vec!["tool_invoke:*".to_owned()],
         // ToolRegister -- core accepts ("tools", "register"|"admin")
         ("tools", "register" | "admin", _) => vec!["tool:register".to_owned()],
         // GovernancePropose -- core accepts ("governance", "write")
@@ -1606,9 +1606,9 @@ pub fn sandbox_validate_declaration(
 
     for cap in &requested {
         let in_ceiling = ceiling_set.contains(cap.as_str())
-            || (cap.starts_with("tool:invoke:") && ceiling_set.contains("tool:invoke:*"));
+            || (cap.starts_with("tool_invoke:") && ceiling_set.contains("tool_invoke:*"));
         let in_role = role_set.contains(cap.as_str())
-            || (cap.starts_with("tool:invoke:") && role_set.contains("tool:invoke:*"));
+            || (cap.starts_with("tool_invoke:") && role_set.contains("tool_invoke:*"));
         if !in_ceiling || !in_role {
             return sandbox_err(&app_did, &format!("capability denied: {cap}"));
         }
@@ -1638,9 +1638,9 @@ pub fn sandbox_check_capability(
         return true;
     }
     // ToolInvokeAll covers any specific ToolInvoke.
-    if required_capability.starts_with("tool:invoke:")
-        && required_capability != "tool:invoke:*"
-        && granted.contains("tool:invoke:*")
+    if required_capability.starts_with("tool_invoke:")
+        && required_capability != "tool_invoke:*"
+        && granted.contains("tool_invoke:*")
     {
         return true;
     }
@@ -2548,19 +2548,19 @@ fn wasm_capability_sets() -> CapabilitySets {
         msg_tools_invoke_ban: serde_json::json!([
             "messages:read",
             "messages:write",
-            "tool:invoke:*",
+            "tool_invoke:*",
             "member:ban"
         ]),
         msg_tools: serde_json::json!([
             "messages:read",
             "messages:write",
-            "tool:invoke:*",
+            "tool_invoke:*",
             "tool:register"
         ]),
         msg_tools_ban: serde_json::json!([
             "messages:read",
             "messages:write",
-            "tool:invoke:*",
+            "tool_invoke:*",
             "tool:register",
             "member:ban"
         ]),

--- a/crates/scp-ffi/wasm/src/manager.rs
+++ b/crates/scp-ffi/wasm/src/manager.rs
@@ -516,15 +516,18 @@ impl PerContextState {
     /// Mirrors `ContextRoleState::member_has_capability` in scp-core. In the
     /// default role system (see `builtin_*` functions in scp-core roles.rs):
     /// - "admin" — all capabilities in the ceiling.
-    /// - "moderator" — messages:read, messages:write, `tool:invoke:*`,
+    /// - "moderator" — messages:read, messages:write, `tool_invoke:*`,
     ///   member:remove, governance:propose (§5.9 elected moderators pattern).
-    /// - "member" — messages:read, messages:write, `tool:invoke:*`.
-    /// - "author" — messages:write, messages:read, `tool:invoke:*`.
+    /// - "member" — messages:read, messages:write, `tool_invoke:*`.
+    /// - "author" — messages:write, messages:read, `tool_invoke:*`.
     /// - "observer" — messages:read only.
     /// - "subscriber" — messages:read only (broadcast contexts).
     ///
-    /// Capability strings use the format `"{resource}:{action}"` (e.g.
-    /// `"context:close"`, `"messages:write"`).
+    /// Capability strings use the UCAN `{resource}:{action}` format where
+    /// compound resources use underscores (e.g. `"tool_invoke:*"`,
+    /// `"context:close"`, `"messages:write"`). This matches scp-core's
+    /// `Capability::ucan_capability_name()` output and the ceiling string
+    /// format, ensuring cross-platform UCAN token exchange works correctly.
     fn member_has_capability(&self, member_did: &str, capability: &str) -> bool {
         let Some(member) = self.members.get(member_did) else {
             return false;
@@ -549,7 +552,7 @@ impl PerContextState {
                     capability,
                     "messages:read"
                         | "messages:write"
-                        | "tool:invoke:*"
+                        | "tool_invoke:*"
                         | "member:remove"
                         | "governance:propose"
                 );
@@ -559,16 +562,16 @@ impl PerContextState {
                 // Authors: messages r/w, tool invoke — intersected with ceiling.
                 let role_grants = matches!(
                     capability,
-                    "messages:write" | "messages:read" | "tool:invoke:*"
+                    "messages:write" | "messages:read" | "tool_invoke:*"
                 );
                 role_grants && in_ceiling(capability)
             }
             "member" => {
                 // Default member capabilities: messages:read, messages:write,
-                // tool:invoke:* — intersected with ceiling.
+                // tool_invoke:* — intersected with ceiling.
                 let role_grants = matches!(
                     capability,
-                    "messages:read" | "messages:write" | "tool:invoke:*"
+                    "messages:read" | "messages:write" | "tool_invoke:*"
                 );
                 role_grants && in_ceiling(capability)
             }
@@ -2008,8 +2011,7 @@ impl WasmContextManager {
     /// Returns the required capability string for a governance action.
     ///
     /// Maps each `WasmGovernanceAction` variant to the capability that
-    /// the initiator must hold. Uses the WASM ceiling format
-    /// Uses scp-core `Capability::Display` format (`"{resource}:{action}"`),
+    /// the initiator must hold. Uses the UCAN `{resource}:{action}` format,
     /// matching `member_has_capability` and the ceiling strings.
     fn required_capability_for_action(action: &WasmGovernanceAction) -> &'static str {
         match action {
@@ -2196,7 +2198,7 @@ impl WasmContextManager {
                         code: "SCP-PERM-3000".to_owned(),
                     });
                 }
-                ctx.ceiling_strings = new_ceiling.iter().cloned().collect();
+                ctx.ceiling_strings = new_ceiling.iter().map(|s| Self::capability_to_ucan_format(s)).collect();
                 Ok(serde_json::json!({"action": "ModifyCeiling"}))
             }
             WasmGovernanceAction::CloseContext { .. } => {
@@ -3912,15 +3914,50 @@ impl WasmContextManager {
     // Internal helpers
     // -----------------------------------------------------------------------
 
+    /// Converts a capability string from the canonical user-facing colon
+    /// format (e.g. `"tool:invoke:*"`) to the UCAN `{resource}:{action}`
+    /// format (e.g. `"tool_invoke:*"`).
+    ///
+    /// The rule: if a capability has more than one colon (compound resource),
+    /// join all segments except the last with underscores to form the resource,
+    /// and the last segment becomes the action. Simple capabilities with
+    /// exactly one colon (e.g. `"messages:write"`) pass through unchanged.
+    ///
+    /// This mirrors `Capability::ucan_resource_action` in scp-core (see #1293).
+    fn capability_to_ucan_format(cap: &str) -> String {
+        if let Some((resource_part, action)) = cap.rsplit_once(':') {
+            if resource_part.contains(':') {
+                // 3+ segments: join all-but-last with underscores.
+                // "a:b:c:d" → "a_b_c:d" (matches scp-core rsplit_once behavior)
+                format!("{}:{}", resource_part.replace(':', "_"), action)
+            } else {
+                // 2 parts: "messages:write" — already in UCAN format
+                cap.to_owned()
+            }
+        } else {
+            // 1 part: "bridging" — no colon at all → pass through unchanged
+            cap.to_owned()
+        }
+    }
+
     /// Builds the capability ceiling string set from explicit ceiling entries
-    /// or defaults matching scp-core's `Capability::Display` format (H5).
+    /// or defaults matching scp-core's UCAN `{resource}:{action}` format.
+    ///
+    /// Default capabilities use underscore-format for compound resources
+    /// (e.g. `"tool_invoke:*"`, `"tool:register"`) to match scp-core's
+    /// `Capability::ucan_capability_name()` output. This ensures UCAN ceiling
+    /// checks (step 8 of validation) pass when tokens minted by scp-core are
+    /// validated in the WASM bridge.
+    ///
+    /// User-provided ceiling strings are converted from colon-format to
+    /// UCAN format via [`capability_to_ucan_format`].
     fn build_ceiling_strings(ceiling: &[String]) -> HashSet<String> {
         if ceiling.is_empty() {
             [
                 "messages:read",
                 "messages:write",
                 "tool:register",
-                "tool:invoke:*",
+                "tool_invoke:*",
                 "role:assign",
                 "member:invite",
                 "member:remove",
@@ -3932,7 +3969,10 @@ impl WasmContextManager {
             .map(|s| (*s).to_owned())
             .collect()
         } else {
-            ceiling.iter().cloned().collect()
+            ceiling
+                .iter()
+                .map(|s| Self::capability_to_ucan_format(s))
+                .collect()
         }
     }
 


### PR DESCRIPTION
## Summary

Fixes three-way naming mismatch between `Capability` enum Display (colons), `mint_ucan` split logic, and `validate_tool_invocation_ucan` expected resource names (underscores).

### Core fix
- Added `Capability::ucan_resource_action()` → `(Cow<str>, Cow<str>)` mapping each variant to correct UCAN format
- Added `Capability::ucan_capability_name()` → `"{resource}:{action}"` string
- `mint_ucan` now uses `Capability::new(cap).ucan_resource_action()` instead of naive `split_once(':')`
- `mint_role_tokens` uses correct per-variant action (was hardcoded `"invoke"` for all)

### All bridges updated
- PyO3, NAPI, UniFFI: ceiling strings converted via `Capability::new(&s).ucan_capability_name()`
- UniFFI bridge: `ceiling_strings` on `ContextHandle` converted at storage time
- WASM: `capability_to_ucan_format` rewritten to use `rsplit_once` matching scp-core
- WASM: `ModifyCeiling` governance action now converts ceiling strings
- WASM: `wasm_capability_sets` presets use underscore format
- WASM conformance test mirror updated

### Reviewed by (3 reviewers × 3 passes)
- Security reviewer: LGTM (pass 1 found WASM divergence → fixed, pass 2 LGTM, pass 3 found conformance mirror → fixed)
- Bug-catcher: Found ceiling conversion gap in NAPI/UniFFI → fixed. Found ModifyCeiling gap → fixed. Found `rsplit_once` divergence → fixed. Found Custom variant test gap → fixed.
- Alignment reviewer: Confirmed spec alignment, found same ceiling conversion gap → fixed.

## Test plan
- [x] 21 new unit tests (11 roles, 7 mint, 3 Custom variant)
- [x] 2 new runtime tests (ceiling conversion, default ceiling format)
- [x] 111 WASM conformance tests pass
- [x] clippy clean (lib targets + NAPI + WASM)
- [x] `cargo fmt` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>