### PR TITLE
fix(sdk): update TypeScript, Kotlin, and Swift examples to current API

### DIFF
--- a/bindings/kotlin/examples/BasicMessaging.kt
+++ b/bindings/kotlin/examples/BasicMessaging.kt
@@ -2,40 +2,40 @@
 
 package works.limn.scp.examples
 
-import works.limn.scp.Context
+import works.limn.scp.CustodyType
 import works.limn.scp.Identity
+import works.limn.scp.Context
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.runBlocking
 
 fun main() = runBlocking {
-    // Create two identities
-    val alice = Identity.create(custody = "platform")
-    val bob = Identity.create(custody = "platform")
+    // Create two identities (in_memory custody for examples)
+    val alice = Identity.create(custody = CustodyType.IN_MEMORY)
+    val bob = Identity.create(custody = CustodyType.IN_MEMORY)
     println("Alice DID: ${alice.did}")
     println("Bob DID: ${bob.did}")
 
     // Alice creates a context
-    val ctxAlice = Context.create(
+    val ctx = Context.create(
         identity = alice,
-        params = mapOf(
-            "ceiling" to listOf("msg:send", "msg:receive"),
-            "ttl" to 3600,
-            "governance" to "single_admin",
-        ),
+        ceiling = listOf("messages:read", "messages:write"),
+        memoryScope = "ephemeral",
+        governance = "single_admin",
+        ttl = 3600,
     )
-    println("Context ID: ${ctxAlice.contextId}")
+    println("Context ID: ${ctx.contextId}")
 
     // Bob joins the context
-    val ctxBob = Context.join(identity = bob, contextId = ctxAlice.contextId)
+    ctx.join(identity = bob)
 
     // Alice sends a message
-    ctxAlice.send("Hello Bob, this is Alice".toByteArray())
+    ctx.send("Hello Bob, this is Alice".toByteArray())
 
     // Bob receives it
-    val msg = ctxBob.receiveFlow().first()
+    val msg = ctx.receiveFlow().first()
     println("Bob received from ${msg.senderDid}: ${String(msg.content)}")
 
     // Cleanup
-    ctxBob.leave()
-    ctxAlice.close()
+    ctx.leave(identity = bob)
+    ctx.close(identity = alice)
 }

--- a/bindings/kotlin/examples/McpIntegration.kt
+++ b/bindings/kotlin/examples/McpIntegration.kt
@@ -3,36 +3,32 @@
 package works.limn.scp.examples
 
 import works.limn.scp.Context
+import works.limn.scp.CustodyType
 import works.limn.scp.Identity
 import works.limn.scp.McpClient
+import works.limn.scp.ToolDefinition
 import works.limn.scp.serveMcp
 import kotlinx.coroutines.runBlocking
 
 fun main() = runBlocking {
-    val identity = Identity.create(custody = "platform")
+    val identity = Identity.create(custody = CustodyType.IN_MEMORY)
 
     val ctx = Context.create(
         identity = identity,
-        params = mapOf(
-            "ceiling" to listOf("msg:send", "msg:receive", "tool:invoke", "mcp:serve"),
-            "tools" to listOf(
-                mapOf(
-                    "name" to "summarize",
-                    "description" to "Summarize text content",
-                    "inputSchema" to mapOf(
-                        "type" to "object",
-                        "properties" to mapOf("text" to mapOf("type" to "string")),
-                        "required" to listOf("text"),
-                    ),
-                    "outputSchema" to mapOf(
-                        "type" to "object",
-                        "properties" to mapOf("summary" to mapOf("type" to "string")),
-                    ),
-                    "operator" to identity.did,
-                ),
-            ),
-        ),
+        ceiling = listOf("messages:read", "messages:write", "tool:invoke:*", "tool:register"),
+        memoryScope = "ephemeral",
+        governance = "single_admin",
     )
+
+    // Register a tool in the context
+    val tool = ToolDefinition(
+        name = "summarize",
+        description = "Summarize text content",
+        inputSchemaJson = """{"type":"object","properties":{"text":{"type":"string"}},"required":["text"]}""",
+        outputSchemaJson = """{"type":"object","properties":{"summary":{"type":"string"}}}""",
+        operatorDid = identity.did,
+    )
+    ctx.registerTool(tool)
 
     // Start an MCP server exposing context tools on stdio
     val server = serveMcp(ctx, transport = "stdio")
@@ -48,5 +44,5 @@ fun main() = runBlocking {
 
     client.close()
     server.stop()
-    ctx.close()
+    ctx.close(identity = identity)
 }

--- a/bindings/kotlin/examples/MultiAgent.kt
+++ b/bindings/kotlin/examples/MultiAgent.kt
@@ -3,6 +3,7 @@
 package works.limn.scp.examples
 
 import works.limn.scp.Context
+import works.limn.scp.CustodyType
 import works.limn.scp.Identity
 import works.limn.scp.Ucan
 import kotlinx.coroutines.async
@@ -10,11 +11,11 @@ import kotlinx.coroutines.flow.take
 import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.runBlocking
 
-suspend fun runAgent(name: String, identity: Identity, contextId: String) {
-    val ctx = Context.join(identity = identity, contextId = contextId)
-    println("[$name] Joined context $contextId")
+suspend fun runAgent(name: String, identity: Identity, ctx: Context) {
+    ctx.join(identity = identity)
+    println("[$name] Joined context ${ctx.contextId}")
 
-    ctx.send("[$name] reporting in".toByteArray())
+    ctx.send("[$name] reporting in".toByteArray(), identity = identity)
 
     var count = 0
     ctx.receiveFlow().collect { msg ->
@@ -24,24 +25,30 @@ suspend fun runAgent(name: String, identity: Identity, contextId: String) {
         if (count >= 2) return@collect
     }
 
-    ctx.leave()
+    ctx.leave(identity = identity)
     println("[$name] Left context")
 }
 
 fun main() = runBlocking {
     // Create identities for coordinator and two agents
-    val coordinator = Identity.create(custody = "platform")
-    val agentA = Identity.create(custody = "platform")
-    val agentB = Identity.create(custody = "platform")
+    val coordinator = Identity.create(custody = CustodyType.IN_MEMORY)
+    val agentA = Identity.create(custody = CustodyType.IN_MEMORY)
+    val agentB = Identity.create(custody = CustodyType.IN_MEMORY)
 
     // Coordinator creates the context
     val ctx = Context.create(
         identity = coordinator,
-        params = mapOf(
-            "ceiling" to listOf("msg:send", "msg:receive", "tool:invoke"),
-            "roles" to mapOf("agent" to listOf("msg:send", "msg:receive", "tool:invoke")),
-            "governance" to "single_admin",
+        ceiling = listOf(
+            "messages:read",
+            "messages:write",
+            "tool:invoke:*",
+            "member:invite",
+            "member:remove",
+            "role:assign",
         ),
+        roles = mapOf("agent" to listOf("messages:write", "messages:read", "tool:invoke:*")),
+        memoryScope = "ephemeral",
+        governance = "single_admin",
     )
     println("Context created: ${ctx.contextId}")
 
@@ -49,21 +56,21 @@ fun main() = runBlocking {
     Ucan.mint(
         issuer = coordinator,
         audience = agentA.did,
-        capabilities = listOf("msg:send", "msg:receive"),
+        capabilities = listOf("messages:write", "messages:read"),
         contextId = ctx.contextId,
     )
     Ucan.mint(
         issuer = coordinator,
         audience = agentB.did,
-        capabilities = listOf("msg:send", "msg:receive"),
+        capabilities = listOf("messages:write", "messages:read"),
         contextId = ctx.contextId,
     )
 
     // Run agents concurrently
-    val taskA = async { runAgent("Agent-A", agentA, ctx.contextId) }
-    val taskB = async { runAgent("Agent-B", agentB, ctx.contextId) }
+    val taskA = async { runAgent("Agent-A", agentA, ctx) }
+    val taskB = async { runAgent("Agent-B", agentB, ctx) }
     taskA.await()
     taskB.await()
 
-    ctx.close()
+    ctx.close(identity = coordinator)
 }

--- a/bindings/kotlin/examples/ToolInvocation.kt
+++ b/bindings/kotlin/examples/ToolInvocation.kt
@@ -3,48 +3,37 @@
 package works.limn.scp.examples
 
 import works.limn.scp.Context
+import works.limn.scp.CustodyType
 import works.limn.scp.Identity
+import works.limn.scp.ToolDefinition
 import kotlinx.coroutines.runBlocking
 
 fun main() = runBlocking {
-    val identity = Identity.create(custody = "platform")
+    val identity = Identity.create(custody = CustodyType.IN_MEMORY)
+
+    val weatherTool = ToolDefinition(
+        name = "weather",
+        description = "Get current weather for a city",
+        inputSchemaJson = """{"type":"object","properties":{"city":{"type":"string"}},"required":["city"]}""",
+        outputSchemaJson = """{"type":"object","properties":{"tempC":{"type":"number"},"condition":{"type":"string"}}}""",
+        operatorDid = identity.did,
+        testVectorsJson = """[{"input":{"city":"Berlin"},"expected":{"tempC":18,"condition":"cloudy"}}]""",
+    )
 
     val ctx = Context.create(
         identity = identity,
-        params = mapOf(
-            "ceiling" to listOf("msg:send", "msg:receive", "tool:invoke"),
-            "tools" to listOf(
-                mapOf(
-                    "name" to "weather",
-                    "description" to "Get current weather for a city",
-                    "inputSchema" to mapOf(
-                        "type" to "object",
-                        "properties" to mapOf("city" to mapOf("type" to "string")),
-                        "required" to listOf("city"),
-                    ),
-                    "outputSchema" to mapOf(
-                        "type" to "object",
-                        "properties" to mapOf(
-                            "tempC" to mapOf("type" to "number"),
-                            "condition" to mapOf("type" to "string"),
-                        ),
-                    ),
-                    "operator" to identity.did,
-                    "testVectors" to listOf(
-                        mapOf(
-                            "input" to mapOf("city" to "Berlin"),
-                            "expectedOutput" to mapOf("tempC" to 18, "condition" to "cloudy"),
-                            "description" to "Berlin weather lookup",
-                        ),
-                    ),
-                ),
-            ),
-        ),
+        ceiling = listOf("messages:read", "messages:write", "tool:invoke:*", "tool:register"),
+        memoryScope = "ephemeral",
+        governance = "single_admin",
     )
 
+    // Register the tool
+    val toolId = ctx.registerTool(weatherTool)
+    println("Registered tool: $toolId")
+
     // Invoke the tool
-    val result = ctx.invokeTool("weather", mapOf("city" to "Berlin"))
+    val result = ctx.invokeTool("weather", """{"city":"Berlin"}""", identity)
     println("Weather result: $result")
 
-    ctx.close()
+    ctx.close(identity = identity)
 }

--- a/bindings/swift/examples/BasicMessaging.swift
+++ b/bindings/swift/examples/BasicMessaging.swift
@@ -10,20 +10,21 @@ import SCP
 @main
 struct BasicMessaging {
     static func main() async throws {
-        // Create two identities via the UniFFI bridge function
-        let alice = try await identityCreate(custody: "platform")
-        let bob = try await identityCreate(custody: "platform")
+        // Create two identities via the UniFFI bridge function (in_memory custody for examples)
+        let alice = try await identityCreate(custody: "in_memory")
+        let bob = try await identityCreate(custody: "in_memory")
         print("Alice DID: \(alice.did())")
         print("Bob DID: \(bob.did())")
 
         // Alice creates a context via the UniFFI bridge function.
-        // ContextParams requires: ceiling, governance, memoryScope, ttlSeconds, promotable
+        // ContextParams requires: ceiling, governance, memoryScope, ttlSeconds, promotable, minProtocolVersion
         let params = ContextParams(
-            ceiling: ["msg:send", "msg:receive"],
+            ceiling: ["messages:read", "messages:write", "member:invite"],
             governance: .singleAdmin,
             memoryScope: .ephemeral,
             ttlSeconds: 3600,
-            promotable: false
+            promotable: false,
+            minProtocolVersion: 0
         )
         let aliceHandle = try await contextCreate(identity: alice, params: params)
         print("Context ID: \(aliceHandle.contextId())")

--- a/bindings/swift/examples/McpIntegration.swift
+++ b/bindings/swift/examples/McpIntegration.swift
@@ -9,15 +9,16 @@ import SCP
 @main
 struct McpIntegration {
     static func main() async throws {
-        let identity = try await identityCreate(custody: "platform")
+        let identity = try await identityCreate(custody: "in_memory")
 
         // Create a context with tool capabilities
         let params = ContextParams(
-            ceiling: ["msg:send", "msg:receive", "tool:invoke"],
+            ceiling: ["messages:read", "messages:write", "tool:invoke:*", "tool:register"],
             governance: .singleAdmin,
             memoryScope: .ephemeral,
             ttlSeconds: 3600,
-            promotable: false
+            promotable: false,
+            minProtocolVersion: 0
         )
         let handle = try await contextCreate(identity: identity, params: params)
 
@@ -36,7 +37,7 @@ struct McpIntegration {
 
         // Start an MCP server exposing context tools on stdio.
         // Note: serveMcp takes an McpServerConfig, not a Context.
-        // The bridge function is not yet wired — this will throw SCP-MCP-10001.
+        // The bridge function is not yet wired -- this will throw SCP-MCP-10001.
         let serverConfig = McpServerConfig(
             identityDid: identity.did(),
             contextIds: [handle.contextId()],
@@ -52,7 +53,7 @@ struct McpIntegration {
 
         // Connect as an MCP client to a remote server.
         // McpClient.connect takes an McpClientConfig enum.
-        // The bridge function is not yet wired — this will throw SCP-MCP-10002.
+        // The bridge function is not yet wired -- this will throw SCP-MCP-10002.
         do {
             let client = try await McpClient.connect(
                 config: .sse(url: "http://localhost:8080/mcp")

--- a/bindings/swift/examples/MultiAgent.swift
+++ b/bindings/swift/examples/MultiAgent.swift
@@ -63,17 +63,25 @@ struct MultiAgent {
 
     static func main() async throws {
         // Create identities for coordinator and two agents
-        let coordinator = try await identityCreate(custody: "platform")
-        let agentA = try await identityCreate(custody: "platform")
-        let agentB = try await identityCreate(custody: "platform")
+        let coordinator = try await identityCreate(custody: "in_memory")
+        let agentA = try await identityCreate(custody: "in_memory")
+        let agentB = try await identityCreate(custody: "in_memory")
 
         // Coordinator creates the context
         let params = ContextParams(
-            ceiling: ["msg:send", "msg:receive", "tool:invoke"],
+            ceiling: [
+                "messages:read",
+                "messages:write",
+                "tool:invoke:*",
+                "member:invite",
+                "member:remove",
+                "role:assign"
+            ],
             governance: .singleAdmin,
             memoryScope: .ephemeral,
             ttlSeconds: 3600,
-            promotable: false
+            promotable: false,
+            minProtocolVersion: 0
         )
         let handle = try await contextCreate(identity: coordinator, params: params)
         print("Context created: \(handle.contextId())")
@@ -82,12 +90,12 @@ struct MultiAgent {
         _ = try await ucanMint(
             handle: handle,
             memberDid: agentA.did(),
-            capabilities: ["msg:send", "msg:receive"]
+            capabilities: ["messages:write", "messages:read"]
         )
         _ = try await ucanMint(
             handle: handle,
             memberDid: agentB.did(),
-            capabilities: ["msg:send", "msg:receive"]
+            capabilities: ["messages:write", "messages:read"]
         )
 
         // Run agents concurrently

--- a/bindings/swift/examples/ToolInvocation.swift
+++ b/bindings/swift/examples/ToolInvocation.swift
@@ -10,7 +10,7 @@ import SCP
 @main
 struct ToolInvocation {
     static func main() async throws {
-        let identity = try await identityCreate(custody: "platform")
+        let identity = try await identityCreate(custody: "in_memory")
 
         // ToolDefinition uses UniFFI field names: inputSchemaJson, outputSchemaJson,
         // testVectorsJson (optional JSON string), implementationHash (optional Data)
@@ -27,11 +27,12 @@ struct ToolInvocation {
 
         // Create a context and register the tool
         let params = ContextParams(
-            ceiling: ["msg:send", "msg:receive", "tool:invoke"],
+            ceiling: ["messages:read", "messages:write", "tool:invoke:*", "tool:register"],
             governance: .singleAdmin,
             memoryScope: .ephemeral,
             ttlSeconds: 3600,
-            promotable: false
+            promotable: false,
+            minProtocolVersion: 0
         )
         let handle = try await contextCreate(identity: identity, params: params)
 

--- a/bindings/typescript/examples/basic-messaging.ts
+++ b/bindings/typescript/examples/basic-messaging.ts
@@ -5,36 +5,37 @@
 import { Context, Identity } from "@limn-works/scp-ts";
 
 async function main(): Promise<void> {
-  // Create two identities
-  const alice = await Identity.create({ custody: "platform" });
-  const bob = await Identity.create({ custody: "platform" });
+  // Create two identities (in_memory custody for examples)
+  const alice = await Identity.create({ custody: "in_memory" });
+  const bob = await Identity.create({ custody: "in_memory" });
   console.log(`Alice DID: ${alice.did}`);
   console.log(`Bob DID: ${bob.did}`);
 
   // Alice creates a context
-  const ctxAlice = await Context.create(alice, {
-    ceiling: ["msg:send", "msg:receive"],
-    ttl: 3600,
+  const ctx = await Context.create(alice, {
+    ceiling: ["messages:read", "messages:write"],
+    memoryScope: "ephemeral",
     governance: "single_admin",
+    ttl: 3600,
   });
-  console.log(`Context ID: ${ctxAlice.contextId}`);
+  console.log(`Context ID: ${ctx.contextId}`);
 
-  // Bob joins the context
-  const ctxBob = await Context.join(bob, ctxAlice.contextId);
+  // Bob joins the context (admin adds bob via the context instance)
+  await ctx.join(bob);
 
   // Alice sends a message
-  await ctxAlice.send(new TextEncoder().encode("Hello Bob, this is Alice"));
+  await ctx.send(new TextEncoder().encode("Hello Bob, this is Alice"));
 
   // Bob receives it
-  for await (const msg of ctxBob.receive()) {
+  for await (const msg of ctx.receive()) {
     const text = new TextDecoder().decode(msg.content as Uint8Array);
     console.log(`Bob received from ${msg.senderDid}: ${text}`);
     break;
   }
 
   // Cleanup
-  await ctxBob.leave();
-  await ctxAlice.close();
+  await ctx.leave();
+  await ctx.close();
 }
 
 main().catch(console.error);

--- a/bindings/typescript/examples/mcp-integration.ts
+++ b/bindings/typescript/examples/mcp-integration.ts
@@ -3,14 +3,41 @@
  */
 
 import { Context, Identity } from "@limn-works/scp-ts";
-import { McpClient, serveMcp } from "@limn-works/scp-ts/mcp";
+import { connectMcp, serveMcp } from "@limn-works/scp-ts/mcp";
 
 async function main(): Promise<void> {
-  const identity = await Identity.create({ custody: "platform" });
+  const identity = await Identity.create({ custody: "in_memory" });
 
-  // Create a context with tools
+  // Create a context with tool capabilities
   const ctx = await Context.create(identity, {
-    ceiling: ["msg:send", "msg:receive", "tool:invoke", "mcp:serve"],
+    ceiling: [
+      "messages:read",
+      "messages:write",
+      "tool:invoke:*",
+      "tool:register",
+    ],
+    memoryScope: "ephemeral",
+    governance: "single_admin",
+  });
+
+  // Register a tool in the context
+  await ctx.registerTool({
+    name: "summarize",
+    description: "Summarize text content",
+    inputSchema: {
+      type: "object",
+      properties: { text: { type: "string" } },
+      required: ["text"],
+    },
+    outputSchema: {
+      type: "object",
+      properties: { summary: { type: "string" } },
+    },
+    operator: identity.did,
+  });
+
+  // Start an MCP server exposing context tools on stdio
+  const server = await serveMcp(ctx, {
     tools: [
       {
         name: "summarize",
@@ -28,22 +55,19 @@ async function main(): Promise<void> {
       },
     ],
   });
-
-  // Start an MCP server exposing context tools on stdio
-  const server = await serveMcp(ctx, { transport: "stdio" });
-  console.log(`MCP server running, exposing tools`);
+  console.log("MCP server running, exposing tools");
 
   // Or connect as an MCP client to a remote server
-  const client = await McpClient.connect("ws://localhost:8080/mcp");
+  const client = await connectMcp({ serverUrl: "http://localhost:8080/mcp" });
   const tools = await client.listTools();
   console.log(`Remote server offers ${tools.length} tool(s)`);
 
-  const result = await client.callTool("summarize", {
+  const result = await client.invokeTool("summarize", {
     text: "SCP is a protocol for...",
   });
   console.log("Result:", result);
 
-  await client.close();
+  await client.disconnect();
   await server.stop();
   await ctx.close();
 }

--- a/bindings/typescript/examples/multi-agent.ts
+++ b/bindings/typescript/examples/multi-agent.ts
@@ -7,10 +7,10 @@ import { Context, Identity, mintUcan } from "@limn-works/scp-ts";
 async function runAgent(
   name: string,
   identity: Identity,
-  contextId: string,
+  ctx: Context,
 ): Promise<void> {
-  const ctx = await Context.join(identity, contextId);
-  console.log(`[${name}] Joined context ${contextId}`);
+  await ctx.join(identity);
+  console.log(`[${name}] Joined context ${ctx.contextId}`);
 
   await ctx.send(new TextEncoder().encode(`[${name}] reporting in`));
 
@@ -28,28 +28,36 @@ async function runAgent(
 
 async function main(): Promise<void> {
   // Create identities for coordinator and two agents
-  const coordinator = await Identity.create({ custody: "platform" });
-  const agentA = await Identity.create({ custody: "platform" });
-  const agentB = await Identity.create({ custody: "platform" });
+  const coordinator = await Identity.create({ custody: "in_memory" });
+  const agentA = await Identity.create({ custody: "in_memory" });
+  const agentB = await Identity.create({ custody: "in_memory" });
 
   // Coordinator creates the context with agent capabilities
   const ctx = await Context.create(coordinator, {
-    ceiling: ["msg:send", "msg:receive", "tool:invoke"],
+    ceiling: [
+      "messages:read",
+      "messages:write",
+      "tool:invoke:*",
+      "member:invite",
+      "member:remove",
+      "role:assign",
+    ],
     roles: {
-      agent: ["msg:send", "msg:receive", "tool:invoke"],
+      agent: ["messages:write", "messages:read", "tool:invoke:*"],
     },
+    memoryScope: "ephemeral",
     governance: "single_admin",
   });
   console.log(`Context created: ${ctx.contextId}`);
 
   // Mint UCANs for each agent (capability delegation)
-  await mintUcan(ctx, agentA.did, ["msg:send", "msg:receive"]);
-  await mintUcan(ctx, agentB.did, ["msg:send", "msg:receive"]);
+  await mintUcan(ctx, agentA.did, ["messages:write", "messages:read"]);
+  await mintUcan(ctx, agentB.did, ["messages:write", "messages:read"]);
 
   // Run agents concurrently
   await Promise.all([
-    runAgent("Agent-A", agentA, ctx.contextId),
-    runAgent("Agent-B", agentB, ctx.contextId),
+    runAgent("Agent-A", agentA, ctx),
+    runAgent("Agent-B", agentB, ctx),
   ]);
 
   await ctx.close();

--- a/bindings/typescript/examples/tool-invocation.ts
+++ b/bindings/typescript/examples/tool-invocation.ts
@@ -6,7 +6,7 @@ import { Context, Identity, mintUcan } from "@limn-works/scp-ts";
 import type { ToolDefinition } from "@limn-works/scp-ts";
 
 async function main(): Promise<void> {
-  const identity = await Identity.create({ custody: "platform" });
+  const identity = await Identity.create({ custody: "in_memory" });
 
   const weatherTool: ToolDefinition = {
     name: "weather",
@@ -34,9 +34,14 @@ async function main(): Promise<void> {
   };
 
   const ctx = await Context.create(identity, {
-    ceiling: ["msg:send", "msg:receive", "tool:invoke"],
-    tools: [weatherTool],
+    ceiling: ["messages:read", "messages:write", "tool:invoke:*", "tool:register"],
+    memoryScope: "ephemeral",
+    governance: "single_admin",
   });
+
+  // Register the tool
+  const toolId = await ctx.registerTool(weatherTool);
+  console.log(`Registered tool: ${toolId}`);
 
   // Mint a UCAN token for tool invocation (§7.2 — required for all actions)
   const ucan = await mintUcan(ctx, identity.did, ["tool_invoke:*"]);


### PR DESCRIPTION
## Summary
Same fixes as Python examples (#1297) applied to the other 3 SDKs. 12 files updated.

- Old capability strings (`"msg:send"`) → correct (`"messages:write"`)
- `custody: "platform"` → `CustodyType.IN_MEMORY` / `"in_memory"`
- Stale API patterns → current SDK methods
- Kotlin: typed `ToolDefinition` instead of raw `mapOf()`
- Swift: added `minProtocolVersion: 0` (now required)

## Test plan
- [x] TypeScript: `tsc --noEmit` clean
- [x] Kotlin: `detekt` clean
- [x] Swift: `swiftlint --strict` 0 violations

🤖 Generated with [Claude Code](https://claude.com/claude-code)
Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>