### PR TITLE
fix(sync): add deny_unknown_fields to EquivocationEvidence/Alert, warn on DID mismatch

### DIFF
--- a/crates/scp-core/src/sync/mod.rs
+++ b/crates/scp-core/src/sync/mod.rs
@@ -346,6 +346,7 @@ impl ConsistencyCheckpoint {
 /// Evidence of relay equivocation: two conflicting consistency checkpoints
 /// from different members that should agree but don't. See spec §9.9.3.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct EquivocationEvidence {
     /// The checkpoint from the local (detecting) member.
     pub local_checkpoint: ConsistencyCheckpoint,
@@ -367,6 +368,7 @@ pub struct EquivocationEvidence {
 ///
 /// See spec §9.9.3, §23.7.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct EquivocationAlert {
     /// The context where equivocation was detected.
     pub context_id: ContextId,
@@ -719,6 +721,14 @@ pub enum SyncOutcome {
 /// Returns `Ok(None)` if context IDs differ (cross-context comparison is
 /// meaningless), if event counts differ (one member is behind), or if
 /// Merkle roots match (consistent). See spec §9.9.3, §23.12.
+///
+/// # Parameters
+///
+/// * `now` - Current timestamp (seconds since epoch). Used only to
+///   stamp the output `EquivocationAlert`. No freshness validation is
+///   performed on the remote checkpoint's timestamp -- replay
+///   protection relies on event-count divergence detection, not
+///   temporal freshness.
 ///
 /// # Errors
 ///

--- a/crates/scp-ffi/napi/src/runtime.rs
+++ b/crates/scp-ffi/napi/src/runtime.rs
@@ -158,7 +158,7 @@ pub fn context_manager() -> napi::Result<&'static Arc<ContextManager>> {
 /// Subsequent calls are no-ops (`OnceLock` guarantees single initialization).
 pub fn init_context_manager(local_did: &str) {
     if CONTEXT_MANAGER.get().is_some() {
-        tracing::debug!(
+        tracing::warn!(
             requested_did = %local_did,
             "init_context_manager already initialized — MLS crypto uses the original DID"
         );


### PR DESCRIPTION
## Summary
Follow-up from post-merge re-review of #1280 and #1305. 3 fixes:

1. `#[serde(deny_unknown_fields)]` on `EquivocationEvidence` and `EquivocationAlert` — matches the guard already on `ConsistencyCheckpoint`
2. Document `now` parameter intent: no freshness check, replay protection relies on event-count divergence
3. `tracing::debug!` → `tracing::warn!` in NAPI `init_context_manager` when called with different DID

## Test plan
- [x] clippy clean (scp-core + scp-ffi-napi)
- [x] cargo fmt clean
- [x] 2 files, 12 lines

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>