### PR TITLE
fix(python): wrap PyO3 bridge calls in asyncio.to_thread (closes #1306)

### DIFF
--- a/bindings/python/scp_sdk/context.py
+++ b/bindings/python/scp_sdk/context.py
@@ -17,6 +17,7 @@ canonical design.
 
 from __future__ import annotations
 
+import asyncio
 import json
 import logging
 from collections import deque
@@ -307,7 +308,7 @@ class Context:
             "economic_policy": economic_policy,
         }
 
-        handle = _scp_core.py_context_create(creator.did, params)
+        handle = await asyncio.to_thread(_scp_core.py_context_create, creator.did, params)
         return cls(handle=handle, creator_did=creator.did, buffer_size=buffer_size)
 
     # -- Lifecycle ----------------------------------------------------------
@@ -332,7 +333,7 @@ class Context:
                 code="SCP-CTX-2001",
             ) from exc
 
-        _scp_core.py_context_join(self._handle, identity.did)
+        await asyncio.to_thread(_scp_core.py_context_join, self._handle, identity.did)
         return Membership(
             did=identity.did,
             role="member",
@@ -356,7 +357,7 @@ class Context:
                 code="SCP-CTX-2001",
             ) from exc
 
-        _scp_core.py_context_leave(self._handle, identity.did)
+        await asyncio.to_thread(_scp_core.py_context_leave, self._handle, identity.did)
 
     async def close(self, identity: Identity) -> None:
         """Close this context.
@@ -377,7 +378,7 @@ class Context:
                 code="SCP-CTX-2001",
             ) from exc
 
-        _scp_core.py_context_close(self._handle, identity.did)
+        await asyncio.to_thread(_scp_core.py_context_close, self._handle, identity.did)
 
     # -- Messaging ----------------------------------------------------------
 
@@ -405,7 +406,7 @@ class Context:
             ) from exc
 
         sender_did = identity.did if identity is not None else self._creator_did
-        _scp_core.py_context_send(self._handle, sender_did, message)
+        await asyncio.to_thread(_scp_core.py_context_send, self._handle, sender_did, message)
 
     async def receive(self) -> AsyncIterator[Message]:
         """Return an async iterator of incoming messages.
@@ -430,7 +431,7 @@ class Context:
                 code="SCP-CTX-2001",
             ) from exc
 
-        bridge_receiver = _scp_core.py_context_receive(self._handle)
+        bridge_receiver = await asyncio.to_thread(_scp_core.py_context_receive, self._handle)
         return _ReceiveIterator(bridge_receiver, self._buffer_size)
 
     # -- Tool invocation ----------------------------------------------------
@@ -491,7 +492,8 @@ class Context:
             ) from exc
 
         invoker_did = identity.did if identity is not None else self._creator_did
-        result = _scp_core.tool_invoke(
+        result = await asyncio.to_thread(
+            _scp_core.tool_invoke,
             self.context_id,
             tool,
             input,
@@ -520,7 +522,7 @@ class Context:
                 code="SCP-CTX-2001",
             ) from exc
 
-        result = _scp_core.py_context_member_count(self._handle)
+        result = await asyncio.to_thread(_scp_core.py_context_member_count, self._handle)
         return int(result) if result is not None else None
 
     async def is_member(self, did: str) -> bool:
@@ -543,7 +545,7 @@ class Context:
                 code="SCP-CTX-2001",
             ) from exc
 
-        return _scp_core.py_context_is_member(self._handle, did)
+        return await asyncio.to_thread(_scp_core.py_context_is_member, self._handle, did)
 
     async def member_dids(self) -> list[str]:
         """Return all member DIDs in this context.
@@ -562,7 +564,7 @@ class Context:
                 code="SCP-CTX-2001",
             ) from exc
 
-        return _scp_core.py_context_member_dids(self._handle)
+        return await asyncio.to_thread(_scp_core.py_context_member_dids, self._handle)
 
     async def member_role(self, did: str) -> MemberRole | None:
         """Return the role of a member in this context.
@@ -585,7 +587,7 @@ class Context:
                 code="SCP-CTX-2001",
             ) from exc
 
-        raw = _scp_core.py_context_member_role(self._handle, did)
+        raw = await asyncio.to_thread(_scp_core.py_context_member_role, self._handle, did)
         if raw is None:
             return None
         return MemberRole.from_bridge(raw)
@@ -614,7 +616,7 @@ class Context:
                 code="SCP-CTX-2001",
             ) from exc
 
-        _scp_core.py_set_economic_policy(self._handle, policy_json)
+        await asyncio.to_thread(_scp_core.py_set_economic_policy, self._handle, policy_json)
 
     async def get_economic_policy(self) -> str | None:
         """Return the economic policy for this context as a JSON string.
@@ -633,7 +635,7 @@ class Context:
                 code="SCP-CTX-2001",
             ) from exc
 
-        return _scp_core.py_get_economic_policy(self._handle)
+        return await asyncio.to_thread(_scp_core.py_get_economic_policy, self._handle)
 
     # -- Broadcast operations -----------------------------------------------
 
@@ -657,7 +659,7 @@ class Context:
                 code="SCP-CTX-2001",
             ) from exc
 
-        _scp_core.py_broadcast_subscribe(self._handle, subscriber_did)
+        await asyncio.to_thread(_scp_core.py_broadcast_subscribe, self._handle, subscriber_did)
 
     async def broadcast_unsubscribe(
         self,
@@ -683,7 +685,9 @@ class Context:
                 code="SCP-CTX-2001",
             ) from exc
 
-        _scp_core.py_broadcast_unsubscribe(self._handle, subscriber_did, rotate_keys)
+        await asyncio.to_thread(
+            _scp_core.py_broadcast_unsubscribe, self._handle, subscriber_did, rotate_keys
+        )
 
     async def broadcast_publish(
         self,
@@ -711,7 +715,7 @@ class Context:
             ) from exc
 
         author_did = identity.did if identity is not None else self._creator_did
-        _scp_core.py_broadcast_publish(self._handle, author_did, payload)
+        await asyncio.to_thread(_scp_core.py_broadcast_publish, self._handle, author_did, payload)
 
     async def broadcast_publish_asset(
         self,
@@ -745,7 +749,8 @@ class Context:
             ) from exc
 
         author_did = identity.did if identity is not None else self._creator_did
-        result = _scp_core.py_broadcast_publish_asset(
+        result = await asyncio.to_thread(
+            _scp_core.py_broadcast_publish_asset,
             self._handle,
             author_did,
             asset.path,
@@ -788,7 +793,8 @@ class Context:
 
         author_did = identity.did if identity is not None else self._creator_did
         asset_tuples = [(a.path, a.content_type, a.body) for a in assets]
-        results = _scp_core.py_broadcast_publish_assets(
+        results = await asyncio.to_thread(
+            _scp_core.py_broadcast_publish_assets,
             self._handle,
             author_did,
             asset_tuples,
@@ -820,7 +826,9 @@ class Context:
             ) from exc
 
         blocker = blocker_did if blocker_did is not None else self._creator_did
-        _scp_core.py_broadcast_block_subscriber(self._handle, subscriber_did, blocker)
+        await asyncio.to_thread(
+            _scp_core.py_broadcast_block_subscriber, self._handle, subscriber_did, blocker
+        )
 
     async def broadcast_unblock_subscriber(
         self,
@@ -850,7 +858,12 @@ class Context:
             ) from exc
 
         unblocker = unblocker_did if unblocker_did is not None else self._creator_did
-        _scp_core.py_broadcast_unblock_subscriber(self._handle, subscriber_did, unblocker)
+        await asyncio.to_thread(
+            _scp_core.py_broadcast_unblock_subscriber,
+            self._handle,
+            subscriber_did,
+            unblocker,
+        )
 
     async def broadcast_handle_key_request(
         self,
@@ -877,7 +890,12 @@ class Context:
                 code="SCP-CTX-2001",
             ) from exc
 
-        return _scp_core.py_broadcast_handle_key_request(self._handle, author_did, requester_did)
+        return await asyncio.to_thread(
+            _scp_core.py_broadcast_handle_key_request,
+            self._handle,
+            author_did,
+            requester_did,
+        )
 
     async def broadcast_subscriber_count(self) -> int | None:
         """Return the number of broadcast subscribers for this context.
@@ -897,7 +915,7 @@ class Context:
                 code="SCP-CTX-2001",
             ) from exc
 
-        result = _scp_core.py_broadcast_subscriber_count(self._handle)
+        result = await asyncio.to_thread(_scp_core.py_broadcast_subscriber_count, self._handle)
         return int(result) if result is not None else None
 
     async def broadcast_is_subscriber(self, did: str) -> bool:
@@ -920,7 +938,7 @@ class Context:
                 code="SCP-CTX-2001",
             ) from exc
 
-        return _scp_core.py_broadcast_is_subscriber(self._handle, did)
+        return await asyncio.to_thread(_scp_core.py_broadcast_is_subscriber, self._handle, did)
 
     async def broadcast_admission(self) -> str | None:
         """Return the broadcast admission policy for this context.
@@ -940,7 +958,7 @@ class Context:
                 code="SCP-CTX-2001",
             ) from exc
 
-        return _scp_core.py_broadcast_admission(self._handle)
+        return await asyncio.to_thread(_scp_core.py_broadcast_admission, self._handle)
 
     # -- Configuration ------------------------------------------------------
 

--- a/bindings/python/scp_sdk/event_log.py
+++ b/bindings/python/scp_sdk/event_log.py
@@ -16,6 +16,7 @@ design and ``.docs/standards/python.md`` for coding conventions.
 
 from __future__ import annotations
 
+import asyncio
 import logging
 import time
 from dataclasses import dataclass
@@ -310,7 +311,8 @@ class EventLog:
         )
 
         bridge = _bridge()
-        raw_events = bridge.event_log_query(
+        raw_events = await asyncio.to_thread(
+            bridge.event_log_query,
             self._context_id,
             filter_dict if filter_dict else None,
         )
@@ -352,7 +354,7 @@ class EventLog:
         )
 
         bridge = _bridge()
-        raw_proof = bridge.event_log_verify(self._context_id, claim)
+        raw_proof = await asyncio.to_thread(bridge.event_log_verify, self._context_id, claim)
 
         return Proof(
             verified=raw_proof.verified,
@@ -385,7 +387,7 @@ class EventLog:
         )
 
         bridge = _bridge()
-        events = bridge.event_log_query(self._context_id, None)
+        events = await asyncio.to_thread(bridge.event_log_query, self._context_id, None)
 
         if not events:
             return Checkpoint(
@@ -441,7 +443,8 @@ class EventLog:
         )
 
         bridge = _bridge()
-        raw = bridge.event_log_checkpoint(
+        raw = await asyncio.to_thread(
+            bridge.event_log_checkpoint,
             self._context_id,
             identity_did,
             epoch,

--- a/bindings/python/scp_sdk/governance.py
+++ b/bindings/python/scp_sdk/governance.py
@@ -9,6 +9,7 @@ See ``.docs/specs/05-contexts.md`` section 5.9 and ADR-031.
 
 from __future__ import annotations
 
+import asyncio
 import enum
 from typing import TYPE_CHECKING
 
@@ -105,7 +106,7 @@ async def execute_governance_action(
             code="SCP-CTX-2001",
         ) from exc
 
-    raw = _scp_core.py_governance_execute(context._handle, proposal_json)
+    raw = await asyncio.to_thread(_scp_core.py_governance_execute, context._handle, proposal_json)
     return GovernanceActionResult.from_bridge(raw)
 
 
@@ -221,7 +222,9 @@ async def propose_governance_action(
         ) from exc
 
     did = identity_did or context._creator_did
-    return _scp_core.py_governance_propose(context._handle, did, action_json)
+    return await asyncio.to_thread(
+        _scp_core.py_governance_propose, context._handle, did, action_json
+    )
 
 
 async def approve_governance_proposal(
@@ -257,7 +260,9 @@ async def approve_governance_proposal(
         ) from exc
 
     did = identity_did or context._creator_did
-    return _scp_core.py_governance_approve(context._handle, did, proposal_id_hex)
+    return await asyncio.to_thread(
+        _scp_core.py_governance_approve, context._handle, did, proposal_id_hex
+    )
 
 
 async def reject_governance_proposal(
@@ -291,7 +296,9 @@ async def reject_governance_proposal(
         ) from exc
 
     did = identity_did or context._creator_did
-    return _scp_core.py_governance_reject(context._handle, did, proposal_id_hex)
+    return await asyncio.to_thread(
+        _scp_core.py_governance_reject, context._handle, did, proposal_id_hex
+    )
 
 
 async def withdraw_governance_vote(
@@ -328,7 +335,9 @@ async def withdraw_governance_vote(
         ) from exc
 
     did = identity_did or context._creator_did
-    return _scp_core.py_governance_withdraw(context._handle, did, proposal_id_hex)
+    return await asyncio.to_thread(
+        _scp_core.py_governance_withdraw, context._handle, did, proposal_id_hex
+    )
 
 
 async def get_governance_proposal(
@@ -358,7 +367,9 @@ async def get_governance_proposal(
             code="SCP-CTX-2001",
         ) from exc
 
-    return _scp_core.py_governance_get_proposal(context._handle, proposal_id_hex)
+    return await asyncio.to_thread(
+        _scp_core.py_governance_get_proposal, context._handle, proposal_id_hex
+    )
 
 
 async def list_governance_proposals(context: Context) -> str:
@@ -384,7 +395,7 @@ async def list_governance_proposals(context: Context) -> str:
             code="SCP-CTX-2001",
         ) from exc
 
-    return _scp_core.py_governance_list_proposals(context._handle)
+    return await asyncio.to_thread(_scp_core.py_governance_list_proposals, context._handle)
 
 
 # ---------------------------------------------------------------------------
@@ -419,7 +430,9 @@ async def apply_pending_ceiling_modification(
             code="SCP-CTX-2001",
         ) from exc
 
-    return _scp_core.py_apply_pending_ceiling_modification(context._handle, current_timestamp)
+    return await asyncio.to_thread(
+        _scp_core.py_apply_pending_ceiling_modification, context._handle, current_timestamp
+    )
 
 
 async def finalize_close(context: Context) -> None:
@@ -446,7 +459,7 @@ async def finalize_close(context: Context) -> None:
             code="SCP-CTX-2001",
         ) from exc
 
-    _scp_core.py_finalize_close(context._handle)
+    await asyncio.to_thread(_scp_core.py_finalize_close, context._handle)
 
 
 async def create_governance_checkpoint(
@@ -490,7 +503,8 @@ async def create_governance_checkpoint(
         ) from exc
 
     did = creator_did or context._creator_did
-    return _scp_core.py_create_governance_checkpoint(
+    return await asyncio.to_thread(
+        _scp_core.py_create_governance_checkpoint,
         context._handle,
         checkpoint_seq,
         merkle_root_hex,
@@ -534,8 +548,12 @@ async def add_checkpoint_cosignature(
             code="SCP-CTX-2001",
         ) from exc
 
-    return _scp_core.py_add_checkpoint_cosignature(
-        context._handle, checkpoint_json, signer_did, signature_hex
+    return await asyncio.to_thread(
+        _scp_core.py_add_checkpoint_cosignature,
+        context._handle,
+        checkpoint_json,
+        signer_did,
+        signature_hex,
     )
 
 
@@ -559,7 +577,7 @@ async def restore_context(context_id: str) -> None:
             code="SCP-CTX-2001",
         ) from exc
 
-    _scp_core.py_restore_context(context_id)
+    await asyncio.to_thread(_scp_core.py_restore_context, context_id)
 
 
 async def restore_all_contexts() -> str:
@@ -582,7 +600,7 @@ async def restore_all_contexts() -> str:
             code="SCP-CTX-2001",
         ) from exc
 
-    return _scp_core.py_restore_all_contexts()
+    return await asyncio.to_thread(_scp_core.py_restore_all_contexts)
 
 
 __all__ = [

--- a/bindings/python/scp_sdk/identity.py
+++ b/bindings/python/scp_sdk/identity.py
@@ -11,6 +11,7 @@ functions.
 
 from __future__ import annotations
 
+import asyncio
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any
 
@@ -157,7 +158,7 @@ class Identity:
         import _scp_core
 
         custody_str = custody.value if isinstance(custody, CustodyType) else custody
-        handle = _scp_core.py_identity_create(custody_str)
+        handle = await asyncio.to_thread(_scp_core.py_identity_create, custody_str)
         return cls(handle)
 
     @classmethod
@@ -176,7 +177,7 @@ class Identity:
         """
         import _scp_core
 
-        handle = _scp_core.py_identity_load(did)
+        handle = await asyncio.to_thread(_scp_core.py_identity_load, did)
         return cls(handle)
 
     # -- Sync convenience wrappers -------------------------------------------
@@ -227,7 +228,7 @@ class Identity:
         import _scp_core
 
         custody_str = custody.value if isinstance(custody, CustodyType) else custody
-        handle = _scp_core.py_identity_create_with_agent_key(custody_str)
+        handle = await asyncio.to_thread(_scp_core.py_identity_create_with_agent_key, custody_str)
         return cls(handle)
 
     async def add_agent_key(self) -> Identity:
@@ -245,7 +246,7 @@ class Identity:
         """
         import _scp_core
 
-        handle = _scp_core.py_identity_add_agent_key(self._handle)
+        handle = await asyncio.to_thread(_scp_core.py_identity_add_agent_key, self._handle)
         return Identity(handle)
 
     async def rotate_agent_key(self) -> Identity:
@@ -263,7 +264,7 @@ class Identity:
         """
         import _scp_core
 
-        handle = _scp_core.py_identity_rotate_agent_key(self._handle)
+        handle = await asyncio.to_thread(_scp_core.py_identity_rotate_agent_key, self._handle)
         return Identity(handle)
 
     async def remove_agent_key(self) -> Identity:
@@ -280,7 +281,7 @@ class Identity:
         """
         import _scp_core
 
-        handle = _scp_core.py_identity_remove_agent_key(self._handle)
+        handle = await asyncio.to_thread(_scp_core.py_identity_remove_agent_key, self._handle)
         return Identity(handle)
 
     async def migrate(self) -> Identity:
@@ -299,7 +300,7 @@ class Identity:
         """
         import _scp_core
 
-        handle = _scp_core.py_identity_migrate(self._handle)
+        handle = await asyncio.to_thread(_scp_core.py_identity_migrate, self._handle)
         return Identity(handle)
 
     async def attest_device(self) -> str:
@@ -319,7 +320,7 @@ class Identity:
                 "Device attestation requires the 'allow_in_memory_custody' feature",
                 "SCP-IDENT-1050",
             )
-        return _scp_core.py_identity_attest_device(self.did)
+        return await asyncio.to_thread(_scp_core.py_identity_attest_device, self.did)
 
     async def verify_device_attestation(self, token_base64: str) -> bool:
         """Verify a device attestation token.
@@ -341,7 +342,9 @@ class Identity:
                 "Device attestation verification requires the 'allow_in_memory_custody' feature",
                 "SCP-IDENT-1051",
             )
-        return _scp_core.py_identity_verify_device_attestation(self.did, token_base64)
+        return await asyncio.to_thread(
+            _scp_core.py_identity_verify_device_attestation, self.did, token_base64
+        )
 
     async def rotate_key(self) -> Identity:
         """Rotate this identity's active signing key.
@@ -372,7 +375,7 @@ class Identity:
         )
         import _scp_core
 
-        handle = _scp_core.py_identity_rotate_key(self._handle)
+        handle = await asyncio.to_thread(_scp_core.py_identity_rotate_key, self._handle)
         return Identity(handle)
 
     async def resolve(self, did: str) -> DIDDocument:
@@ -389,7 +392,7 @@ class Identity:
         """
         import _scp_core
 
-        bridge_doc = _scp_core.py_identity_resolve(did)
+        bridge_doc = await asyncio.to_thread(_scp_core.py_identity_resolve, did)
         return _bridge_doc_to_dataclass(bridge_doc)
 
     # -- Recovery and custody migration ---------------------------------------
@@ -423,7 +426,8 @@ class Identity:
 
         import _scp_core
 
-        result_json = _scp_core.identity_execute_recovery(
+        result_json = await asyncio.to_thread(
+            _scp_core.identity_execute_recovery,
             self.did,
             tier,
             context_ids or [],
@@ -461,7 +465,8 @@ class Identity:
 
         import _scp_core
 
-        result_json = _scp_core.identity_execute_custody_migration(
+        result_json = await asyncio.to_thread(
+            _scp_core.identity_execute_custody_migration,
             self.did,
             target,
             context_ids or [],

--- a/bindings/python/scp_sdk/mcp.py
+++ b/bindings/python/scp_sdk/mcp.py
@@ -16,6 +16,7 @@ See ``.docs/adrs/phase-3.md`` ADR-015 for the full design.
 
 from __future__ import annotations
 
+import asyncio
 import logging
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any
@@ -189,7 +190,7 @@ class McpServer:
             return
         logger.info("Stopping MCP server (transport=%s)", self._transport)
         bridge = _bridge()
-        bridge.py_mcp_server_stop(self._handle)
+        await asyncio.to_thread(bridge.py_mcp_server_stop, self._handle)
         self._stopped = True
         logger.debug("MCP server stopped")
 
@@ -309,7 +310,8 @@ async def serve_mcp(
     bridge = _bridge()
 
     context_ids = [c.context_id for c in contexts]
-    handle = bridge.py_mcp_serve(
+    handle = await asyncio.to_thread(
+        bridge.py_mcp_serve,
         identity.did,
         context_ids,
         transport,
@@ -661,9 +663,9 @@ class McpClient:
         bridge = _bridge()
 
         if transport == "stdio":
-            handle = bridge.py_mcp_client_connect_stdio(command)
+            handle = await asyncio.to_thread(bridge.py_mcp_client_connect_stdio, command)
         else:
-            handle = bridge.py_mcp_client_connect_sse(url)
+            handle = await asyncio.to_thread(bridge.py_mcp_client_connect_sse, url)
 
         client = cls(handle=handle, transport=transport, command=command)
         logger.info("MCP client connected (transport=%s)", transport)
@@ -679,7 +681,7 @@ class McpClient:
             TransportError: If the server communication fails.
         """
         bridge = _bridge()
-        raw_tools = bridge.py_mcp_client_list_tools(self._handle)
+        raw_tools = await asyncio.to_thread(bridge.py_mcp_client_list_tools, self._handle)
         return [
             McpToolDefinition(
                 name=t["name"],
@@ -716,7 +718,8 @@ class McpClient:
             TransportError: If server communication fails.
         """
         bridge = _bridge()
-        raw = bridge.py_mcp_client_invoke(
+        raw = await asyncio.to_thread(
+            bridge.py_mcp_client_invoke,
             self._handle,
             tool,
             input,
@@ -747,7 +750,7 @@ class McpClient:
             return
         logger.info("Disconnecting MCP client (transport=%s)", self._transport)
         bridge = _bridge()
-        bridge.py_mcp_client_disconnect(self._handle)
+        await asyncio.to_thread(bridge.py_mcp_client_disconnect, self._handle)
         self._disconnected = True
         logger.debug("MCP client disconnected")
 
@@ -820,7 +823,6 @@ def cli_main() -> None:
         scp-mcp serve --identity <did> --relay <relay_url> --transport stdio
     """
     import argparse
-    import asyncio
 
     parser = argparse.ArgumentParser(
         prog="scp-mcp",
@@ -884,11 +886,11 @@ async def _cli_serve(did: str, relay_url: str, transport: str) -> None:
 
     # Step 3: Load active contexts via the bridge.
     bridge = _bridge()
-    context_handles = bridge.py_mcp_load_contexts(did, relay_url)
+    context_handles = await asyncio.to_thread(bridge.py_mcp_load_contexts, did, relay_url)
 
     # Step 4: Start the MCP server.
     context_ids = [h["context_id"] for h in context_handles]
-    handle = bridge.py_mcp_serve(did, context_ids, transport)
+    handle = await asyncio.to_thread(bridge.py_mcp_serve, did, context_ids, transport)
 
     logger.info(
         "MCP server running: %d contexts, transport=%s",
@@ -906,8 +908,6 @@ async def _wait_for_shutdown(handle: Any, transport: str) -> None:
     For stdio transport, waits until stdin is closed (EOF).
     For SSE transport, waits until a termination signal is received.
     """
-    import asyncio
-
     bridge = _bridge()
     try:
         # The bridge provides a blocking wait that we run in a thread
@@ -916,7 +916,7 @@ async def _wait_for_shutdown(handle: Any, transport: str) -> None:
         await loop.run_in_executor(None, bridge.py_mcp_server_wait, handle)
     except KeyboardInterrupt:
         logger.info("Received interrupt, shutting down MCP server")
-        bridge.py_mcp_server_stop(handle)
+        await asyncio.to_thread(bridge.py_mcp_server_stop, handle)
 
 
 __all__ = [

--- a/bindings/python/scp_sdk/transport.py
+++ b/bindings/python/scp_sdk/transport.py
@@ -11,6 +11,7 @@ for conventions.
 
 from __future__ import annotations
 
+import asyncio
 import logging
 from dataclasses import dataclass
 from typing import Any
@@ -95,7 +96,7 @@ class TransportConfig:
         """
         logger.debug("Connecting to relay %s", self.relay_url)
         bridge = _bridge()
-        bridge.transport_connect(self.relay_url)
+        await asyncio.to_thread(bridge.transport_connect, self.relay_url)
         logger.info("Connected to relay %s", self.relay_url)
 
     async def status(self) -> TransportStatus:
@@ -109,7 +110,7 @@ class TransportConfig:
             TransportError: If querying transport status fails.
         """
         bridge = _bridge()
-        raw = bridge.transport_status()
+        raw = await asyncio.to_thread(bridge.transport_status)
         return TransportStatus(
             connected=raw.connected,
             relay_url=raw.relay_url,
@@ -154,7 +155,7 @@ async def relay_status() -> TransportStatus:
         TransportError: If querying transport status fails.
     """
     bridge = _bridge()
-    raw = bridge.transport_status()
+    raw = await asyncio.to_thread(bridge.transport_status)
     return TransportStatus(
         connected=raw.connected,
         relay_url=raw.relay_url,

--- a/bindings/python/scp_sdk/trust.py
+++ b/bindings/python/scp_sdk/trust.py
@@ -19,6 +19,7 @@ See ``.docs/sketch.md`` section ``SCP.Trust.evaluate`` and
 
 from __future__ import annotations
 
+import asyncio
 import json
 import logging
 from dataclasses import dataclass, field
@@ -472,7 +473,7 @@ async def evaluate_trust(
         # single invalid token is sufficient to fail the capability check.
         for token in capability_tokens:
             try:
-                bridge.ucan_validate(context_id, token, "*")
+                await asyncio.to_thread(bridge.ucan_validate, context_id, token, "*")
             except bridge.UcanError as exc:
                 error_msg = str(exc)
                 failed_category = _classify_ucan_error(error_msg)
@@ -492,7 +493,8 @@ async def evaluate_trust(
     # Layer 2: Query behavioral record from event log.
     behavioral: BehavioralRecord | None = None
     try:
-        events = bridge.event_log_query(
+        events = await asyncio.to_thread(
+            bridge.event_log_query,
             context_id,
             {"actor_did": subject_did},
         )


### PR DESCRIPTION
## Summary

- Every `async def` method in the Python SDK was calling synchronous PyO3 bridge functions that internally call `rt.block_on()`, blocking the asyncio event loop
- Wrapped all blocking bridge calls in `asyncio.to_thread()` to run them on a thread pool executor, freeing the event loop for concurrent work
- 7 files changed across `context.py`, `identity.py`, `transport.py`, `governance.py`, `event_log.py`, `mcp.py`, and `trust.py`
- `ucan.py` and `tools.py` were already correct (they already used `asyncio.to_thread`)
- Sync-only modules (`auth.py`, `bridge.py`, `discovery.py`, `economy.py`, `media.py`, `provenance.py`, `sync.py`) unchanged — no async methods to fix

## Verification

- AST-based scan confirms zero remaining direct bridge calls in any `async def` function body
- `ruff check` and `ruff format --check` pass
- All 425 Python tests pass
- `cargo clippy` and `cargo fmt --check` pass (no Rust changes)

## Test plan

- [x] `python3.12 -m ruff check bindings/python/` passes
- [x] `python3.12 -m ruff format --check bindings/python/` passes
- [x] `python3.12 -m pytest bindings/python/tests/ -v` — 425 passed
- [x] `cargo clippy --workspace --all-targets` — no warnings
- [x] AST scan confirms no blocking bridge calls remain in async functions


🤖 Generated with [Claude Code](https://claude.com/claude-code)