### PR TITLE
docs: fix all cargo doc warnings across workspace (23 files)

### DIFF
--- a/crates/scp-core/src/context/broadcast_content.rs
+++ b/crates/scp-core/src/context/broadcast_content.rs
@@ -86,7 +86,7 @@ pub enum BroadcastContentError {
     #[error("invalid deploy ID: {0}")]
     InvalidDeployId(String),
 
-    /// Body exceeds [`MAX_BODY_BYTES`].
+    /// Body exceeds `MAX_BODY_BYTES`.
     #[error("body too large: {0} bytes (max {MAX_BODY_BYTES})")]
     BodyTooLarge(usize),
 

--- a/crates/scp-core/src/context/manager.rs
+++ b/crates/scp-core/src/context/manager.rs
@@ -3031,11 +3031,11 @@ impl ContextManager {
     /// context.
     ///
     /// Called by the SDK/FFI layer after processing a received envelope whose
-    /// [`VersionCompatibility`] is [`DegradedMode`]. This pushes a
+    /// `VersionCompatibility` is `DegradedMode`. This pushes a
     /// [`ContextEvent::DegradedMode`] to the context's receive buffer so the
     /// application layer can observe the degraded state via [`drain_events`].
     ///
-    /// If `compat` is [`VersionCompatibility::Exact`], this is a no-op (no
+    /// If `compat` is `VersionCompatibility::Exact`, this is a no-op (no
     /// event is emitted). If the context is not registered, this is also a
     /// no-op.
     ///
@@ -3373,7 +3373,7 @@ impl ContextManager {
     /// - [`ContextError::ContextNotActive`] if the context is not `Active`.
     /// - [`ContextError::MembershipFailed`] if the context is not broadcast.
     /// - [`ContextError::PermissionDenied`] if the sender is not an author.
-    /// - [`ContextError::InvalidInput`] if serialization fails.
+    /// - `ContextError::InvalidInput` if serialization fails.
     pub async fn publish_broadcast_content(
         &self,
         context_id: &str,

--- a/crates/scp-core/src/crypto/ucan/mod.rs
+++ b/crates/scp-core/src/crypto/ucan/mod.rs
@@ -353,7 +353,7 @@ impl Default for UcanHeader {
 /// where compound resources use underscores (e.g. `tool_invoke`, `context_child`).
 ///
 /// The `can` field holds the action portion (e.g. `"*"`, `"calculator"`,
-/// `"write"`, `"propose"`). See [`CapabilityUri`](capability::CapabilityUri)
+/// `"write"`, `"propose"`). See [`CapabilityUri`]
 /// for the full URI format and [`Capability::ucan_resource_action`](crate::context::roles::Capability::ucan_resource_action)
 /// for the mapping from canonical colon-format to UCAN format.
 ///

--- a/crates/scp-core/src/envelope/inner.rs
+++ b/crates/scp-core/src/envelope/inner.rs
@@ -476,7 +476,7 @@ pub fn enforce_inner_envelope_category_a(
 /// Validates that an inner envelope's version field is compatible (§13.5).
 ///
 /// Accepts envelopes with the same major version. Returns
-/// [`VersionCompatibility`] so the caller can decide whether and how to log
+/// `VersionCompatibility` so the caller can decide whether and how to log
 /// degraded-mode situations. This function intentionally does **not** emit
 /// `tracing::warn!` itself, because [`verify_inner_signature`] also calls
 /// [`check_version_compatibility`](super::check_version_compatibility) and

--- a/crates/scp-core/src/envelope/mod.rs
+++ b/crates/scp-core/src/envelope/mod.rs
@@ -122,9 +122,9 @@ impl VersionCompatibility {
 /// Checks whether a wire version is compatible with the local protocol version.
 ///
 /// Per spec §13.5, same-major envelopes are always accepted:
-/// - Exact match → [`VersionCompatibility::Exact`]
-/// - Same major, different minor → [`VersionCompatibility::DegradedMode`]
-/// - Different major → [`Err(EnvelopeError::UnsupportedVersion)`]
+/// - Exact match → `VersionCompatibility::Exact`
+/// - Same major, different minor → `VersionCompatibility::DegradedMode`
+/// - Different major → `Err(EnvelopeError::UnsupportedVersion)`
 ///
 /// This replaces the previous exact-match-only check that would reject any
 /// version other than `SCP_PROTOCOL_VERSION` (issue #628).

--- a/crates/scp-core/src/identity/custody_migration.rs
+++ b/crates/scp-core/src/identity/custody_migration.rs
@@ -323,7 +323,7 @@ pub trait CustodyMigrationBackend {
 ///
 /// - Step 1 or 2 failure: No state change. Abort cleanly.
 /// - Step 3 failure (partial publication): Safe — peers with old document
-///   continue to work. The [`RepublishManager`] converges on retry.
+///   continue to work. The `RepublishManager` converges on retry.
 /// - Step 4 failure: The SDK queues failed operations for retry.
 /// - Step 5 failure: Non-fatal — old key is orphaned but harmless.
 ///

--- a/crates/scp-core/src/store/trust.rs
+++ b/crates/scp-core/src/store/trust.rs
@@ -2,7 +2,7 @@
 //!
 //! Implements persistent storage for trust engine data: cached attestations,
 //! revocation state, and challenge results. These methods back the
-//! [`TrustProtocolRepository`](crate::trust::aggregate::TrustProtocolRepository)
+//! [`TrustProtocolRepository`]
 //! trait via the synchronous [`ProtocolRepositoryTrustBridge`] adapter.
 //!
 //! # Key convention

--- a/crates/scp-core/src/sync/conflict_resolution.rs
+++ b/crates/scp-core/src/sync/conflict_resolution.rs
@@ -476,8 +476,8 @@ pub fn resolve_governance_conflict(
 /// resolved pair.
 ///
 /// **Freeze triggers are unchanged:** if ANY pair is a
-/// [`ConflictPairKind::SimultaneousCommit`] or
-/// [`ConflictPairKind::MutualRemoval`], the function returns a single
+/// `ConflictPairKind::SimultaneousCommit` or
+/// `ConflictPairKind::MutualRemoval`, the function returns a single
 /// [`ConflictResolutionStrategy::GovernanceFreeze`] containing all
 /// conflicting proposal IDs (same behavior as
 /// `resolve_governance_conflict`).

--- a/crates/scp-core/src/sync/mod.rs
+++ b/crates/scp-core/src/sync/mod.rs
@@ -686,7 +686,7 @@ pub enum CatchUpStatus {
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub enum SyncOutcome {
     /// Sync has not yet executed. Returned by planning methods; replaced by
-    /// a concrete outcome after [`ReconnectionCoordinator::execute`] runs.
+    /// a concrete outcome after `ReconnectionCoordinator::execute` runs.
     Pending,
     /// All epochs and events caught up via sequential processing.
     FullyCaughtUp,

--- a/crates/scp-ffi/common/src/resolvers.rs
+++ b/crates/scp-ffi/common/src/resolvers.rs
@@ -441,7 +441,7 @@ impl DidPublicKeyResolver for IdentityBackedDidResolver {
 /// (which requires the async identity-layer resolver trait, not the sync UCAN
 /// validation trait).
 ///
-/// Delegates to the type-erased [`AsyncResolveFn`] stored during construction.
+/// Delegates to the type-erased `AsyncResolveFn` stored during construction.
 impl scp_identity::resolver::DidResolver for IdentityBackedDidResolver {
     fn resolve(
         &self,
@@ -566,7 +566,7 @@ impl<C: Clock> NonceTrackerTrait for BridgeNonceTracker<'_, C> {
 // BridgeRevocationAuthorizer (issue #499)
 // ---------------------------------------------------------------------------
 
-/// Bridge [`RevocationAuthorizer`] that checks the revoker DID against the
+/// Bridge `RevocationAuthorizer` that checks the revoker DID against the
 /// token's issuer DID and the context creator DID.
 ///
 /// The authorizer is constructed with the issuer DID extracted from the parsed
@@ -605,7 +605,7 @@ impl scp_core::crypto::ucan::revoke::RevocationAuthorizer for BridgeRevocationAu
 // BridgeRevocationDistributor (issue #499)
 // ---------------------------------------------------------------------------
 
-/// No-op [`RevocationDistributor`] for FFI bridges.
+/// No-op `RevocationDistributor` for FFI bridges.
 ///
 /// FFI bridges do not have direct access to MLS group state for distributing
 /// revocations to context members. In the full runtime, revocations would be
@@ -635,7 +635,7 @@ impl scp_core::crypto::ucan::revoke::RevocationDistributor for BridgeRevocationD
 // BridgeRevocationEventLogger (issue #499)
 // ---------------------------------------------------------------------------
 
-/// Bridge [`RevocationEventLogger`] that appends unsigned `TokenRevoked`
+/// Bridge `RevocationEventLogger` that appends unsigned `TokenRevoked`
 /// events to the context's Merkle event log.
 ///
 /// Uses `append_unsigned_event` because `KeyCustody::sign()` is async and

--- a/crates/scp-ffi/napi/src/runtime.rs
+++ b/crates/scp-ffi/napi/src/runtime.rs
@@ -143,11 +143,11 @@ pub fn context_manager() -> napi::Result<&'static Arc<ContextManager>> {
 
 /// Initializes the global [`ContextManager`] with production providers.
 ///
-/// Uses [`MlsCryptoProvider`] (real MLS encryption, #1294),
+/// Uses `MlsCryptoProvider` (real MLS encryption, #1294),
 /// `NotConfiguredTransportProvider`, `MerkleEventLogProvider` (persistent,
 /// #484), and `NapiBridgePersistence`.
 ///
-/// The `local_did` is passed to [`MlsCryptoProvider::new`] which uses it as
+/// The `local_did` is passed to `MlsCryptoProvider::new` which uses it as
 /// the MLS credential identity for group operations and sender key generation.
 ///
 /// Event log persistence is wired via `MerkleEventLogProvider::with_persistence`

--- a/crates/scp-ffi/napi/src/scpid.rs
+++ b/crates/scp-ffi/napi/src/scpid.rs
@@ -2,8 +2,8 @@
 //!
 //! Exposes SCPID challenge generation, signing, and verification to Node.js/Bun:
 //!
-//! - [`scpid_challenge`] — Generate an SCPID challenge for a relying party.
-//! - [`scpid_sign`] — Sign an SCPID challenge with a registered identity's key.
+//! - `scpid_challenge` — Generate an SCPID challenge for a relying party.
+//! - `scpid_sign` — Sign an SCPID challenge with a registered identity's key.
 //! - [`scpid_verify`] — Verify a signed SCPID response (relying-party side).
 //!
 //! See spec §3.11 and the `scp-core` `scpid` module.

--- a/crates/scp-ffi/src/bridge_connector.rs
+++ b/crates/scp-ffi/src/bridge_connector.rs
@@ -539,7 +539,7 @@ pub fn py_bridge_claim_shadow(
 ///
 /// # Returns
 ///
-/// JSON string of the sealed [`SenderKeyEnvelope`].
+/// JSON string of the sealed `SenderKeyEnvelope`.
 ///
 /// # Errors
 ///
@@ -675,7 +675,7 @@ pub fn py_bridge_seal_shadow_envelope(
 ///
 /// # Arguments
 ///
-/// * `envelope_json` -- JSON-serialized [`SenderKeyEnvelope`].
+/// * `envelope_json` -- JSON-serialized `SenderKeyEnvelope`.
 /// * `sender_key_bytes` -- The shadow's 32-byte AES-256-GCM sender key.
 /// * `context_id` -- The SCP context identifier (AAD binding).
 /// * `sender_did` -- The shadow DID (AAD binding).

--- a/crates/scp-ffi/src/runtime.rs
+++ b/crates/scp-ffi/src/runtime.rs
@@ -172,8 +172,8 @@ pub fn init_context_manager_with(
     });
 }
 
-/// Test variant of [`init_context_manager`] that uses [`LocalTransportProvider`]
-/// instead of [`NotConfiguredTransportProvider`].
+/// Test variant of [`init_context_manager`] that uses `LocalTransportProvider`
+/// instead of `NotConfiguredTransportProvider`.
 ///
 /// Production code uses `NotConfiguredTransportProvider` to surface descriptive
 /// errors when transport operations (publish, send) are attempted without a

--- a/crates/scp-ffi/src/ucan.rs
+++ b/crates/scp-ffi/src/ucan.rs
@@ -230,10 +230,10 @@ pub fn py_ucan_validate(
 ///
 /// # Errors
 ///
-/// Raises `ValidationError` if `member_did` fails [`validate_did`]
+/// Raises `ValidationError` if `member_did` fails `validate_did`
 /// (empty, malformed `did:{method}:{id}` format, or control characters),
-/// if any capability URI fails [`validate_capability_uri`], or if any
-/// proof token fails [`validate_ucan_token`].
+/// if any capability URI fails `validate_capability_uri`, or if any
+/// proof token fails `validate_ucan_token`.
 ///
 /// Raises `UcanError` if minting fails: capabilities outside the context
 /// ceiling, issuer not authorized, signing fails, etc.
@@ -331,9 +331,9 @@ pub fn py_ucan_mint(
 /// # Errors
 ///
 /// Raises `ValidationError` if `delegator_did` or `delegatee_did` fails
-/// [`validate_did`] (empty, malformed `did:{method}:{id}` format, or
-/// control characters), if `parent_token` fails [`validate_ucan_token`],
-/// or if any capability URI fails [`validate_capability_uri`].
+/// `validate_did` (empty, malformed `did:{method}:{id}` format, or
+/// control characters), if `parent_token` fails `validate_ucan_token`,
+/// or if any capability URI fails `validate_capability_uri`.
 ///
 /// Raises `UcanError` if delegation fails: delegator not matching parent
 /// audience, capabilities wider than parent, signing failure, etc.
@@ -426,9 +426,9 @@ pub fn py_ucan_delegate(
 /// Performs the complete UCAN revocation flow from ADR-016:
 ///
 /// 1. **Authorization** -- Verifies the revoker is the token's issuer or the
-///    context creator via [`BridgeRevocationAuthorizer`].
+///    context creator via `BridgeRevocationAuthorizer`.
 /// 2. **Local revocation** -- Adds the token CID to the context's
-///    [`RevocationList`] (fail-closed via `RevocationPending` state).
+///    `RevocationList` (fail-closed via `RevocationPending` state).
 /// 3. **Distribution** -- Logs the revocation for transport-layer broadcast
 ///    (MLS distribution deferred to transport connection).
 /// 4. **Event logging** -- Appends a `TokenRevoked` event to the context's

--- a/crates/scp-ffi/uniffi/src/bridge.rs
+++ b/crates/scp-ffi/uniffi/src/bridge.rs
@@ -11276,6 +11276,8 @@ pub fn scpid_verify(response_json: String, challenge_json: String) -> Result<Str
 }
 
 /// Parses an SCPID signing key ID string (`"#active"` or `"#agent"`).
+// Called from `#[uniffi::export]` `scpid_sign` which the dead_code lint cannot trace.
+#[allow(dead_code)]
 fn parse_scpid_signing_key_id(s: &str) -> Result<scp_identity::SigningKeyId, ScpError> {
     match s {
         "#active" => Ok(scp_identity::SigningKeyId::Active),

--- a/crates/scp-ffi/wasm/src/crypto/group.rs
+++ b/crates/scp-ffi/wasm/src/crypto/group.rs
@@ -180,7 +180,7 @@ impl WasmMlsGroup {
     ///
     /// The `welcome_bytes` must be TLS-serialized `MlsMessageOut` bytes
     /// containing a Welcome. The `holder` must be the `WasmMlsGroup` returned
-    /// by [`generate_key_package`] — it contains the provider and signer
+    /// by `generate_key_package` — it contains the provider and signer
     /// that hold the private key material matching the `KeyPackage` that was
     /// sent to the adder.
     ///
@@ -226,7 +226,7 @@ impl WasmMlsGroup {
     /// Returns `(key_package_bytes, WasmMlsGroup)` where `key_package_bytes`
     /// is TLS-serialized and the `WasmMlsGroup` holds the private key material
     /// needed to later join via Welcome. Pass the returned `WasmMlsGroup` to
-    /// [`join_from_welcome`] when the Welcome message arrives.
+    /// `join_from_welcome` when the Welcome message arrives.
     ///
     /// # Errors
     ///

--- a/crates/scp-ffi/wasm/src/crypto/mod.rs
+++ b/crates/scp-ffi/wasm/src/crypto/mod.rs
@@ -6,12 +6,12 @@
 //!
 //! # Architecture
 //!
-//! - [`credential`] — `WasmScpCredential` (MessagePack-serialized identity payload).
-//! - [`error`] — `WasmCryptoError` error type.
-//! - [`group`] — `WasmMlsGroup` wrapping `OpenMLS` `MlsGroup`.
-//! - [`encrypt`] — Higher-level MLS encrypt/decrypt with TLS serialization.
-//! - [`sender_key`] — AES-256-GCM sender-side key layer.
-//! - [`state`] — `WasmCryptoState` orchestrating both layers.
+//! - `credential` — `WasmScpCredential` (MessagePack-serialized identity payload).
+//! - `error` — `WasmCryptoError` error type.
+//! - `group` — `WasmMlsGroup` wrapping `OpenMLS` `MlsGroup`.
+//! - `encrypt` — Higher-level MLS encrypt/decrypt with TLS serialization.
+//! - `sender_key` — AES-256-GCM sender-side key layer.
+//! - `state` — `WasmCryptoState` orchestrating both layers.
 //!
 //! See ADR-001 for the MLS wrapper design and ADR-007 for the sender key layer.
 

--- a/crates/scp-ffi/wasm/src/manager.rs
+++ b/crates/scp-ffi/wasm/src/manager.rs
@@ -1466,7 +1466,7 @@ impl WasmContextManager {
     ///
     /// Returns the TLS-serialized key package bytes. The private key material
     /// is stored in `pending_key_packages` keyed by `(context_id, member_did)`
-    /// for later use by [`join_context_encrypted`].
+    /// for later use by `join_context_encrypted`.
     ///
     /// # Errors
     ///
@@ -1505,7 +1505,7 @@ impl WasmContextManager {
     ///
     /// The joiner processes the MLS Welcome message to reconstruct the group.
     /// A key package must have been previously generated via
-    /// [`generate_key_package_for_join`] for the same `(context_id, member_did)`.
+    /// `generate_key_package_for_join` for the same `(context_id, member_did)`.
     ///
     /// # Errors
     ///

--- a/crates/scp-ffi/wasm/src/scpid.rs
+++ b/crates/scp-ffi/wasm/src/scpid.rs
@@ -5,8 +5,8 @@
 //! see ADR-034). The algorithms are pure crypto (SHA-256, Ed25519) with no
 //! network I/O, so they translate directly to WASM.
 //!
-//! - [`scpid_challenge`] — Generate an SCPID challenge for a relying party.
-//! - [`scpid_sign`] — Sign an SCPID challenge with a registered identity's key.
+//! - `scpid_challenge` — Generate an SCPID challenge for a relying party.
+//! - `scpid_sign` — Sign an SCPID challenge with a registered identity's key.
 //!
 //! **`scpid_verify` is NOT exposed in the WASM bridge.** Verification requires
 //! a network-capable `DidResolver` to resolve the signer's DID document from

--- a/crates/scp-node/src/bridge_auth.rs
+++ b/crates/scp-node/src/bridge_auth.rs
@@ -842,7 +842,7 @@ pub async fn bridge_auth_middleware_dyn(
 ///
 /// Per spec §12.10.2, the signed payload is `timestamp_bytes || body_bytes`
 /// where `timestamp` is the value of the `X-SCP-Timestamp` header. The
-/// timestamp must be within [`WEBHOOK_TIMESTAMP_TOLERANCE_SECS`] of the
+/// timestamp must be within `WEBHOOK_TIMESTAMP_TOLERANCE_SECS` of the
 /// current time.
 pub fn verify_webhook_signature(
     signature_header: &str,

--- a/crates/scp-node/src/dev_api.rs
+++ b/crates/scp-node/src/dev_api.rs
@@ -526,7 +526,7 @@ pub async fn delete_context_handler(
 /// Prevents unbounded memory allocation from oversized POST bodies.
 const DEV_API_MAX_BODY_SIZE: usize = 64 * 1024;
 
-/// Returns an axum [`Router`] serving the dev API endpoints under
+/// Returns an axum `Router` serving the dev API endpoints under
 /// `/scp/dev/v1`.
 ///
 /// All routes are protected by bearer token authentication. The `token`

--- a/crates/scp-node/src/projection.rs
+++ b/crates/scp-node/src/projection.rs
@@ -105,7 +105,7 @@ pub struct DeployManifestEntry {
 
 /// Node-local site configuration for broadcast projection (§18.11.12).
 ///
-/// Passed to [`ApplicationNode::enable_broadcast_projection`] to configure
+/// Passed to `ApplicationNode::enable_broadcast_projection` to configure
 /// path-based serving. NOT part of governance — deployment concern only.
 #[derive(Debug, Clone)]
 pub struct SiteConfig {


### PR DESCRIPTION
## Summary
Fixed 39 cargo doc warnings across 7 crates (23 files):
- 25 unresolved intra-doc links → plain backticks
- 4 links to private items → backticks
- 2 redundant explicit link targets → simplified
- 1 false-positive dead_code (UniFFI proc-macro) → #[allow]

`cargo doc --workspace --no-deps` now builds with 0 warnings.

## Test plan
- [x] `cargo doc` 0 warnings
- [x] `cargo fmt` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>