### PR TITLE
feat(ts): add browser demo with WASM backend

### DIFF
--- a/bindings/typescript/examples/browser-demo/.gitignore
+++ b/bindings/typescript/examples/browser-demo/.gitignore
@@ -1,0 +1,5 @@
+# Built WASM package — not checked in, must be built locally.
+# See README instructions or run:
+#   wasm-pack build crates/scp-ffi/wasm --target web \
+#     --out-dir bindings/typescript/examples/browser-demo/pkg
+pkg/

--- a/bindings/typescript/examples/browser-demo/demo.js
+++ b/bindings/typescript/examples/browser-demo/demo.js
@@ -1,0 +1,324 @@
+/**
+ * SCP Browser Demo — demonstrates core protocol operations via the WASM module.
+ *
+ * Operations demonstrated:
+ *   1. Initialize WASM module
+ *   2. Create a DID identity
+ *   3. Create a governed context
+ *   4. Register a tool in the context
+ *   5. Send a message to the context
+ *   6. Attach provenance metadata (cross-context data flow)
+ *   7. Query the event log (Merkle-backed)
+ *   8. Evaluate provenance quality tier
+ *
+ * Prerequisites:
+ *   wasm-pack build crates/scp-ffi/wasm --target web --out-dir bindings/typescript/examples/browser-demo/pkg
+ *
+ * Serve:
+ *   cd bindings/typescript/examples/browser-demo && python3 -m http.server 8080
+ *   Open http://localhost:8080
+ */
+
+// ---------------------------------------------------------------------------
+// UI helpers
+// ---------------------------------------------------------------------------
+
+const QUALITY_TIERS = {
+  0: "NoProvenance",
+  1: "EphemeralKnownParties",
+  2: "SummaryVerified",
+  3: "PersistentVerifiable",
+};
+
+function setStatus(step, status, label) {
+  const el = document.getElementById(`status-${step}`);
+  el.className = `step-status status-${status}`;
+  el.textContent = label || status;
+}
+
+function setOutput(step, html) {
+  const el = document.getElementById(`output-${step}`);
+  el.innerHTML = html;
+  el.classList.add("visible");
+}
+
+function showError(msg) {
+  const el = document.getElementById("error-banner");
+  el.textContent = msg;
+  el.classList.add("visible");
+}
+
+function kv(key, value) {
+  return `<span class="key">${esc(key)}</span>: <span class="val">${esc(String(value))}</span>`;
+}
+
+function esc(s) {
+  return s
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;");
+}
+
+function addSummaryItem(label, value) {
+  const li = document.createElement("li");
+  li.innerHTML = `<span class="label">${esc(label)}:</span> ${esc(String(value))}`;
+  document.getElementById("summary-list").appendChild(li);
+}
+
+// ---------------------------------------------------------------------------
+// Demo runner
+// ---------------------------------------------------------------------------
+
+/** @type {() => Promise<void>} */
+async function runDemo() {
+  const btn = document.getElementById("run-btn");
+  btn.disabled = true;
+
+  // Reset UI state.
+  document.getElementById("error-banner").classList.remove("visible");
+  document.getElementById("summary").classList.remove("visible");
+  document.getElementById("summary-list").innerHTML = "";
+  for (let i = 1; i <= 8; i++) {
+    setStatus(i, "pending", "pending");
+    const out = document.getElementById(`output-${i}`);
+    out.innerHTML = "";
+    out.classList.remove("visible");
+  }
+
+  try {
+    await runDemoSteps();
+  } catch (err) {
+    showError(`Fatal error: ${err.message || err}`);
+    console.error(err);
+  } finally {
+    btn.disabled = false;
+  }
+}
+
+async function runDemoSteps() {
+  // -----------------------------------------------------------------------
+  // Step 1: Initialize WASM module
+  // -----------------------------------------------------------------------
+  setStatus(1, "running", "loading...");
+
+  let wasm;
+  try {
+    wasm = await import("./pkg/scp_ffi_wasm.js");
+    await wasm.default(); // load + instantiate the .wasm binary
+    wasm.scp_init();      // set up panic hook
+  } catch (err) {
+    setStatus(1, "error", "failed");
+    setOutput(1, `<span class="dimmed">Failed to load WASM module.\n\nHave you built it?\n  wasm-pack build crates/scp-ffi/wasm --target web \\\n    --out-dir bindings/typescript/examples/browser-demo/pkg\n\n${esc(err.message || String(err))}</span>`);
+    throw err;
+  }
+
+  const version = wasm.scp_version();
+  setStatus(1, "done", "ready");
+  setOutput(1, [
+    kv("scp-ffi-wasm version", version),
+    kv("wasm-bindgen target", "web"),
+    `<span class="dimmed">Panic hook installed, console errors enabled.</span>`,
+  ].join("\n"));
+  addSummaryItem("WASM version", version);
+
+  // -----------------------------------------------------------------------
+  // Step 2: Create identity
+  // -----------------------------------------------------------------------
+  setStatus(2, "running", "generating...");
+
+  const identity = await wasm.identity_create("in_memory");
+  const did = identity.did;
+  const custodyType = identity.custodyType;
+
+  setStatus(2, "done", "created");
+  setOutput(2, [
+    kv("DID", did),
+    kv("custody", custodyType),
+    `<span class="dimmed">Ed25519 keypair generated via crypto.getRandomValues.</span>`,
+  ].join("\n"));
+  addSummaryItem("Identity DID", did);
+
+  // -----------------------------------------------------------------------
+  // Step 3: Create context
+  // -----------------------------------------------------------------------
+  setStatus(3, "running", "creating...");
+
+  const contextParams = {
+    mode: "broadcast",
+    governance: "creator_admin",
+    ceiling: ["scp:ctx:*/*"],
+  };
+
+  const ctx = await wasm.context_create(did, JSON.stringify(contextParams));
+  const contextId = ctx.contextId;
+  const contextState = ctx.state;
+  const contextMode = ctx.mode;
+  const memberCount = ctx.memberCount;
+  const governance = ctx.governance;
+
+  setStatus(3, "done", "active");
+  setOutput(3, [
+    kv("context ID", contextId),
+    kv("state", contextState),
+    kv("mode", contextMode),
+    kv("governance", governance),
+    kv("members", memberCount),
+    kv("creator", ctx.creatorDid),
+  ].join("\n"));
+  addSummaryItem("Context ID", contextId);
+
+  // -----------------------------------------------------------------------
+  // Step 4: Register tool
+  // -----------------------------------------------------------------------
+  setStatus(4, "running", "registering...");
+
+  const toolDef = {
+    name: "text-summarizer",
+    description: "Summarizes text content using extractive methods",
+    operatorDid: did,
+    schema: {
+      type: "object",
+      properties: {
+        text: { type: "string", description: "Input text to summarize" },
+        maxLength: { type: "number", description: "Maximum summary length" },
+      },
+      required: ["text"],
+    },
+    outputSchema: {
+      type: "object",
+      properties: {
+        summary: { type: "string" },
+        wordCount: { type: "number" },
+      },
+      required: ["summary"],
+    },
+  };
+
+  const toolId = await wasm.tool_register(ctx, JSON.stringify(toolDef));
+
+  setStatus(4, "done", "registered");
+  setOutput(4, [
+    kv("tool ID", toolId),
+    kv("name", toolDef.name),
+    kv("description", toolDef.description),
+    kv("input schema", JSON.stringify(toolDef.schema, null, 2)),
+  ].join("\n"));
+  addSummaryItem("Tool registered", `${toolDef.name} (${toolId})`);
+
+  // -----------------------------------------------------------------------
+  // Step 5: Send message
+  // -----------------------------------------------------------------------
+  setStatus(5, "running", "sending...");
+
+  const message = { type: "chat", text: "Hello from the browser WASM demo!" };
+  const payloadBytes = new TextEncoder().encode(JSON.stringify(message));
+  const payloadBase64 = btoa(String.fromCharCode(...payloadBytes));
+
+  await wasm.context_send(ctx, did, payloadBase64);
+
+  setStatus(5, "done", "sent");
+  setOutput(5, [
+    kv("payload (decoded)", JSON.stringify(message)),
+    kv("payload (base64)", payloadBase64),
+    kv("sender", did),
+    kv("context", contextId),
+    `<span class="dimmed">Message recorded in context event log.</span>`,
+  ].join("\n"));
+  addSummaryItem("Message sent", message.text);
+
+  // -----------------------------------------------------------------------
+  // Step 6: Attach provenance
+  // -----------------------------------------------------------------------
+  setStatus(6, "running", "attaching...");
+
+  // Simulate cross-context data flow: data from this context is being
+  // shared into a hypothetical target context.
+  const targetContextId = `ctx-${crypto.randomUUID()}`;
+  const provenanceJson = wasm.provenance_attach(
+    contextId,          // source_context_id
+    "persistent",       // source_type
+    "full",             // memory_scope
+    JSON.stringify([did]), // counterparties
+    targetContextId,    // target_context_id
+    did,                // actor_did
+    undefined,          // existing_chain_depth (first hop)
+    "[]",               // existing_chain_path_json
+    "direct",           // discovery_method
+    "demo",             // purpose
+  );
+
+  const provenance = JSON.parse(provenanceJson);
+
+  setStatus(6, "done", "attached");
+  setOutput(6, [
+    kv("source context", provenance.source_context),
+    kv("source type", provenance.source_type),
+    kv("memory scope", provenance.memory_scope),
+    kv("chain depth", provenance.chain_depth),
+    kv("discovery method", provenance.discovery_method),
+    kv("purpose", provenance.purpose),
+    kv("content hash", provenance.content_hash),
+    kv("counterparties", JSON.stringify(provenance.counterparties)),
+    `<span class="dimmed">Provenance metadata for cross-context data flow.</span>`,
+  ].join("\n"));
+  addSummaryItem("Provenance chain depth", provenance.chain_depth);
+
+  // -----------------------------------------------------------------------
+  // Step 7: Query event log
+  // -----------------------------------------------------------------------
+  setStatus(7, "running", "querying...");
+
+  const eventsJson = await wasm.event_log_query(ctx, null);
+  const events = JSON.parse(eventsJson);
+
+  setStatus(7, "done", `${events.length} event(s)`);
+
+  if (events.length > 0) {
+    const logSummary = events[0];
+    const payload = JSON.parse(logSummary.payloadJson);
+    setOutput(7, [
+      kv("event type", logSummary.eventType),
+      kv("event count", payload.event_count),
+      kv("merkle root", payload.merkle_root),
+      kv("sequence", logSummary.sequence),
+      `<span class="dimmed">Merkle tree provides cryptographic integrity guarantees.</span>`,
+    ].join("\n"));
+    addSummaryItem("Events in log", payload.event_count);
+    addSummaryItem("Merkle root", payload.merkle_root.substring(0, 16) + "...");
+  } else {
+    setOutput(7, `<span class="dimmed">No events in log.</span>`);
+    addSummaryItem("Events in log", 0);
+  }
+
+  // -----------------------------------------------------------------------
+  // Step 8: Evaluate provenance quality
+  // -----------------------------------------------------------------------
+  setStatus(8, "running", "evaluating...");
+
+  const qualityTier = wasm.evaluate_provenance_quality(
+    contextId,             // source_context
+    "persistent",          // source_type
+    "active",              // context_state
+    JSON.stringify([did]),  // counterparties_json
+  );
+
+  const tierName = QUALITY_TIERS[qualityTier] || `Unknown (${qualityTier})`;
+
+  setStatus(8, "done", tierName);
+  setOutput(8, [
+    kv("quality tier", qualityTier),
+    kv("tier name", tierName),
+    kv("source type", "persistent"),
+    kv("context state", "active"),
+    `<span class="dimmed">Tier 3 = PersistentVerifiable (highest). Active context + persistent source.</span>`,
+  ].join("\n"));
+  addSummaryItem("Provenance quality", `${qualityTier} (${tierName})`);
+
+  // -----------------------------------------------------------------------
+  // Done
+  // -----------------------------------------------------------------------
+  document.getElementById("summary").classList.add("visible");
+}
+
+// Expose to HTML onclick.
+window.runDemo = runDemo;

--- a/bindings/typescript/examples/browser-demo/index.html
+++ b/bindings/typescript/examples/browser-demo/index.html
@@ -1,0 +1,282 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>SCP Browser Demo</title>
+  <style>
+    :root {
+      --bg: #0d1117;
+      --surface: #161b22;
+      --border: #30363d;
+      --text: #e6edf3;
+      --text-muted: #8b949e;
+      --accent: #58a6ff;
+      --green: #3fb950;
+      --red: #f85149;
+      --orange: #d29922;
+      --font-mono: 'SF Mono', 'Fira Code', 'Cascadia Code', monospace;
+    }
+
+    * { box-sizing: border-box; margin: 0; padding: 0; }
+
+    body {
+      background: var(--bg);
+      color: var(--text);
+      font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Helvetica, Arial, sans-serif;
+      line-height: 1.6;
+      padding: 2rem;
+      max-width: 900px;
+      margin: 0 auto;
+    }
+
+    h1 {
+      font-size: 1.8rem;
+      margin-bottom: 0.25rem;
+    }
+
+    .subtitle {
+      color: var(--text-muted);
+      font-size: 0.95rem;
+      margin-bottom: 2rem;
+    }
+
+    .step {
+      background: var(--surface);
+      border: 1px solid var(--border);
+      border-radius: 8px;
+      padding: 1.25rem 1.5rem;
+      margin-bottom: 1rem;
+    }
+
+    .step-header {
+      display: flex;
+      align-items: center;
+      gap: 0.75rem;
+      margin-bottom: 0.75rem;
+    }
+
+    .step-number {
+      background: var(--accent);
+      color: var(--bg);
+      font-weight: 700;
+      font-size: 0.85rem;
+      width: 1.75rem;
+      height: 1.75rem;
+      border-radius: 50%;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      flex-shrink: 0;
+    }
+
+    .step-title {
+      font-size: 1.05rem;
+      font-weight: 600;
+    }
+
+    .step-status {
+      margin-left: auto;
+      font-family: var(--font-mono);
+      font-size: 0.8rem;
+      padding: 0.15rem 0.5rem;
+      border-radius: 4px;
+    }
+
+    .status-pending { color: var(--text-muted); }
+    .status-running { color: var(--orange); }
+    .status-done { color: var(--green); }
+    .status-error { color: var(--red); }
+
+    .step-output {
+      background: var(--bg);
+      border: 1px solid var(--border);
+      border-radius: 6px;
+      padding: 0.75rem 1rem;
+      font-family: var(--font-mono);
+      font-size: 0.82rem;
+      line-height: 1.5;
+      white-space: pre-wrap;
+      word-break: break-all;
+      overflow-x: auto;
+      max-height: 300px;
+      overflow-y: auto;
+      display: none;
+    }
+
+    .step-output.visible { display: block; }
+
+    .key { color: var(--accent); }
+    .val { color: var(--green); }
+    .dimmed { color: var(--text-muted); }
+
+    button {
+      background: var(--accent);
+      color: var(--bg);
+      border: none;
+      border-radius: 6px;
+      padding: 0.6rem 1.5rem;
+      font-size: 0.95rem;
+      font-weight: 600;
+      cursor: pointer;
+      margin-top: 1rem;
+      transition: opacity 0.15s;
+    }
+
+    button:hover { opacity: 0.85; }
+    button:disabled {
+      opacity: 0.4;
+      cursor: not-allowed;
+    }
+
+    .error-banner {
+      background: #3d1418;
+      border: 1px solid var(--red);
+      border-radius: 8px;
+      padding: 1rem 1.25rem;
+      margin-bottom: 1rem;
+      display: none;
+      font-family: var(--font-mono);
+      font-size: 0.85rem;
+      color: var(--red);
+      white-space: pre-wrap;
+    }
+
+    .error-banner.visible { display: block; }
+
+    .summary {
+      background: var(--surface);
+      border: 1px solid var(--green);
+      border-radius: 8px;
+      padding: 1.25rem 1.5rem;
+      margin-top: 1.5rem;
+      display: none;
+    }
+
+    .summary.visible { display: block; }
+
+    .summary h2 {
+      color: var(--green);
+      font-size: 1.1rem;
+      margin-bottom: 0.5rem;
+    }
+
+    .summary ul {
+      list-style: none;
+      padding: 0;
+    }
+
+    .summary li {
+      padding: 0.25rem 0;
+      font-size: 0.9rem;
+      color: var(--text-muted);
+    }
+
+    .summary li .label {
+      color: var(--text);
+      font-weight: 500;
+    }
+
+    footer {
+      margin-top: 2rem;
+      color: var(--text-muted);
+      font-size: 0.8rem;
+      text-align: center;
+    }
+
+    footer a { color: var(--accent); text-decoration: none; }
+    footer a:hover { text-decoration: underline; }
+  </style>
+</head>
+<body>
+  <h1>Shared Context Protocol</h1>
+  <p class="subtitle">Browser WASM Demo &mdash; Identity, Context, Tool Registration, Provenance, and Event Log</p>
+
+  <div id="error-banner" class="error-banner"></div>
+
+  <div class="step" id="step-1">
+    <div class="step-header">
+      <div class="step-number">1</div>
+      <div class="step-title">Initialize WASM Module</div>
+      <div class="step-status status-pending" id="status-1">pending</div>
+    </div>
+    <div class="step-output" id="output-1"></div>
+  </div>
+
+  <div class="step" id="step-2">
+    <div class="step-header">
+      <div class="step-number">2</div>
+      <div class="step-title">Create Identity (DID)</div>
+      <div class="step-status status-pending" id="status-2">pending</div>
+    </div>
+    <div class="step-output" id="output-2"></div>
+  </div>
+
+  <div class="step" id="step-3">
+    <div class="step-header">
+      <div class="step-number">3</div>
+      <div class="step-title">Create Context</div>
+      <div class="step-status status-pending" id="status-3">pending</div>
+    </div>
+    <div class="step-output" id="output-3"></div>
+  </div>
+
+  <div class="step" id="step-4">
+    <div class="step-header">
+      <div class="step-number">4</div>
+      <div class="step-title">Register Tool</div>
+      <div class="step-status status-pending" id="status-4">pending</div>
+    </div>
+    <div class="step-output" id="output-4"></div>
+  </div>
+
+  <div class="step" id="step-5">
+    <div class="step-header">
+      <div class="step-number">5</div>
+      <div class="step-title">Send Message</div>
+      <div class="step-status status-pending" id="status-5">pending</div>
+    </div>
+    <div class="step-output" id="output-5"></div>
+  </div>
+
+  <div class="step" id="step-6">
+    <div class="step-header">
+      <div class="step-number">6</div>
+      <div class="step-title">Attach Provenance</div>
+      <div class="step-status status-pending" id="status-6">pending</div>
+    </div>
+    <div class="step-output" id="output-6"></div>
+  </div>
+
+  <div class="step" id="step-7">
+    <div class="step-header">
+      <div class="step-number">7</div>
+      <div class="step-title">Query Event Log</div>
+      <div class="step-status status-pending" id="status-7">pending</div>
+    </div>
+    <div class="step-output" id="output-7"></div>
+  </div>
+
+  <div class="step" id="step-8">
+    <div class="step-header">
+      <div class="step-number">8</div>
+      <div class="step-title">Evaluate Provenance Quality</div>
+      <div class="step-status status-pending" id="status-8">pending</div>
+    </div>
+    <div class="step-output" id="output-8"></div>
+  </div>
+
+  <div class="summary" id="summary">
+    <h2>Demo Complete</h2>
+    <ul id="summary-list"></ul>
+  </div>
+
+  <button id="run-btn" onclick="runDemo()">Run Demo</button>
+
+  <footer>
+    <p>SCP WASM Module &mdash; <a href="https://github.com/limn-works/scp">github.com/limn-works/scp</a></p>
+  </footer>
+
+  <script type="module" src="./demo.js"></script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
Minimal browser demo: HTML + ES module that loads WASM and demonstrates identity creation, context creation, tool registration, messaging, provenance, and event log.

- `bindings/typescript/examples/browser-demo/` (index.html + demo.js + .gitignore)
- Uses `wasm-pack build --target web` (no bundler needed)
- Dark theme, step-by-step UI with status indicators
- All dynamic values XSS-escaped via `esc()` helper
- Works with `python3 -m http.server`

## Test plan
- [x] HTML valid
- [x] JS syntax check clean
- [x] All WASM function calls match actual exports
- [x] XSS protection verified

🤖 Generated with [Claude Code](https://claude.com/claude-code)
Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>