### PR TITLE
fix(test): strengthen E2E test assertions

### DIFF
--- a/bindings/typescript/tests/real-napi.test.ts
+++ b/bindings/typescript/tests/real-napi.test.ts
@@ -1541,11 +1541,9 @@ if (bridge === null) {
         expect(typeof result.blobId).toBe("string");
         expect(result.blobId.length).toBe(64);
       } catch (e: unknown) {
-        // If it fails due to transport (no relay), verify it is a transport
-        // error, not a content validation error.
-        const msg = e instanceof Error ? e.message : String(e);
-        expect(msg).not.toContain("invalid path");
-        expect(msg).not.toContain("invalid content_type");
+        const msg = (e instanceof Error ? e.message : String(e)).toLowerCase();
+        const isTransportError = msg.includes("transport") || msg.includes("not configured");
+        expect(isTransportError).toBe(true);
       }
     });
 
@@ -1586,10 +1584,9 @@ if (bridge === null) {
           expect(r).toHaveProperty("etag");
         }
       } catch (e: unknown) {
-        // Transport error is acceptable (no relay configured).
-        const msg = e instanceof Error ? e.message : String(e);
-        expect(msg).not.toContain("invalid path");
-        expect(msg).not.toContain("invalid content_type");
+        const msg = (e instanceof Error ? e.message : String(e)).toLowerCase();
+        const isTransportError = msg.includes("transport") || msg.includes("not configured");
+        expect(isTransportError).toBe(true);
       }
     });
   });

--- a/crates/scp-core/tests/wasm_conformance.rs
+++ b/crates/scp-core/tests/wasm_conformance.rs
@@ -6164,17 +6164,25 @@ fn broadcast_content_wire_format_matches_wasm() {
             body: b"cafe",
             desc: "Unicode NFC path",
         },
+        TestCase {
+            path: "/cafe\u{0301}.html", // NFD: 'e' + combining acute accent
+            content_type: "text/html",
+            deploy_id: Some("deploy-nfd"),
+            body: b"nfd",
+            desc: "Unicode NFD path (must NFC-normalize to match)",
+        },
     ];
 
     for tc in &test_cases {
         // Compute etag as SHA-256 hex of body (matches compute_etag).
         let etag = scp_core::context::broadcast_content::compute_etag(tc.body);
 
-        // Serialize via scp-core.
+        // Serialize via scp-core (ContentPath::new normalizes NFD → NFC).
+        let content_path = ContentPath::new(tc.path).unwrap();
         let content = BroadcastContent {
             version: BROADCAST_CONTENT_VERSION,
             metadata: ContentMetadata {
-                path: Some(ContentPath::new(tc.path).unwrap()),
+                path: Some(content_path.clone()),
                 content_type: Some(MimeType::new(tc.content_type).unwrap()),
                 deploy_id: tc.deploy_id.map(str::to_owned),
                 etag: Some(etag.clone()),
@@ -6184,9 +6192,11 @@ fn broadcast_content_wire_format_matches_wasm() {
         };
         let core_bytes = serialize_broadcast_content(&content).unwrap();
 
-        // Serialize via WASM mirror.
+        // Serialize via WASM mirror. Use the NFC-normalized path (matching
+        // the real WASM bridge which validates/normalizes before serializing).
+        let normalized_path = content_path.as_str();
         let wasm_bytes = wasm_broadcast_mirror::serialize_broadcast_content_wasm(
-            tc.path,
+            normalized_path,
             tc.content_type,
             tc.deploy_id,
             &etag,
@@ -6214,7 +6224,7 @@ fn broadcast_content_wire_format_matches_wasm() {
         );
         assert_eq!(
             deserialized.metadata.path.as_ref().unwrap().as_str(),
-            tc.path,
+            normalized_path,
             "round-trip path mismatch for {}",
             tc.desc
         );
@@ -6243,6 +6253,8 @@ fn broadcast_content_path_validation_matches_wasm() {
         "/assets/style.css",
         "/a/b/c/d.js",
         "/caf\u{00E9}.html",
+        "/",
+        "/cafe\u{0301}.html", // NFD input, normalizes to NFC
     ];
     for path in &valid_paths {
         let core_result = ContentPath::new(*path);
@@ -6257,10 +6269,18 @@ fn broadcast_content_path_validation_matches_wasm() {
             "WASM rejected valid path {path:?}: {:?}",
             wasm_result.err()
         );
+        // Cross-check: normalized paths must match between core and WASM.
+        let core_normalized = core_result.unwrap().as_str().to_owned();
+        let wasm_normalized = wasm_result.unwrap();
+        assert_eq!(
+            core_normalized, wasm_normalized,
+            "normalized path mismatch for {path:?}: core={core_normalized:?}, wasm={wasm_normalized:?}"
+        );
     }
 
     // Invalid paths: both must reject.
     let invalid_paths = [
+        "",
         "no-leading-slash",
         "/path/../traversal",
         "/double//slash",


### PR DESCRIPTION
## Summary
- **TypeScript catch blocks**: Replace permissive `not.toContain` assertions in `broadcastPublishAsset`/`broadcastPublishAssets` tests with positive transport error matching (`msg.includes("transport") || msg.includes("not configured")`)
- **WASM NFD conformance**: Add NFD normalization test case to `broadcast_content_wire_format_matches_wasm` and `broadcast_content_path_validation_matches_wasm`, plus cross-check that core and WASM produce identical normalized paths
- **Edge cases**: Add `"/"` (root) to valid paths and `""` (empty) to invalid paths in path validation conformance

## Test plan
- [x] `cargo test -p scp-core --test wasm_conformance --features scp-core/testing -- broadcast_content` — 2 passed, 0 warnings
- [x] `cd bindings/typescript && bun test tests/real-napi.test.ts` — passes (skipped, no native bridge)
- [x] `cargo fmt --all` — clean
- [x] `bunx biome check tests/real-napi.test.ts` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)