### PR TITLE
fix(node): restore ETag mention in site_handler doc comment

### DIFF
--- a/crates/scp-node/src/projection.rs
+++ b/crates/scp-node/src/projection.rs
@@ -1984,10 +1984,12 @@ fn site_security_headers(csp: &str) -> axum::http::HeaderMap {
 /// For public contexts:
 /// - `immutable=true`: `Cache-Control: public, immutable, max-age=31536000`
 /// - `immutable=false`: `Cache-Control: public, max-age=0, must-revalidate`
+///   with `ETag: "<deploy_id>:<content_hash>"`
 ///
 /// For gated/author-choice contexts:
 /// - `immutable=true`: `Cache-Control: private, immutable, max-age=31536000`
 /// - `immutable=false`: `Cache-Control: private, max-age=0, must-revalidate`
+///   with `ETag: "<deploy_id>:<content_hash>"`
 ///
 /// - 404: `Cache-Control: no-store`
 ///


### PR DESCRIPTION
Doc comment rewrite in #1320 dropped the ETag annotation for non-immutable responses. Restore it for both public and gated cases.

Doc-only change, 2 lines added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)