### PR TITLE
fix(ucan): add wildcard action matching to CapabilityUri for tool invoke (closes #1326)

### DIFF
--- a/bindings/typescript/tests/real-napi.test.ts
+++ b/bindings/typescript/tests/real-napi.test.ts
@@ -335,35 +335,30 @@ if (bridge === null) {
       expect(toolId.length).toBeGreaterThan(0);
     });
 
-    // toolInvoke requires UCAN authorization. Three naming mismatches exist:
-    // 1. mint_ucan splits "tool:invoke:*" → resource="tool", action="invoke:*".
-    //    validate_tool_invocation_ucan creates resource="tool_invoke", action=toolId.
-    // 2. The CapabilityUri.matches() check requires exact resource+action match,
-    //    so "tool"/"invoke:*" never matches "tool_invoke"/toolId.
-    // 3. Ceiling uses Capability::to_string() → "tool:invoke:*" but CapabilityUri
-    //    ceiling check uses capability_name() → "tool_invoke:*". Different strings.
-    // Root cause: Capability enum (roles.rs) and CapabilityUri (capability.rs) use
-    // incompatible naming conventions. Needs a coordinated fix across both systems.
-    // See #1144.
-    test.skip("invokes a registered tool (Capability/CapabilityUri naming mismatch)", async () => {
-      const identity = await napi.identityCreate("in_memory");
+    test("invokes a registered tool", async () => {
+      const admin = await napi.identityCreate("in_memory");
+      const member = await napi.identityCreate("in_memory");
       const ctx = await napi.contextCreate(
-        identity,
+        admin,
         JSON.stringify({ ceiling: ["tool:register", "tool:invoke:*"] }),
       );
       const toolId = await napi.toolRegister(ctx, {
         name: "test-tool",
         description: "A test tool",
-        inputSchema: { type: "object" },
+        inputSchema: {
+          type: "object",
+          properties: { x: { type: "number" }, y: { type: "number" } },
+        },
         outputSchema: { type: "object" },
-        operator: identity.did,
+        operator: admin.did,
       });
-      const ucan = await napi.ucanMint(ctx, identity.did, ["tool:invoke:*"]);
+      // Mint UCAN for the member (not self-delegation).
+      const ucan = await napi.ucanMint(ctx, member.did, ["tool:invoke:*"]);
       const resultJson = await napi.toolInvoke(
         ctx,
         toolId,
-        JSON.stringify({ x: 42 }),
-        identity.did,
+        JSON.stringify({ x: 42, y: 7 }),
+        member.did,
         ucan.encoded,
       );
       expect(typeof resultJson).toBe("string");
@@ -944,14 +939,11 @@ if (bridge === null) {
   // ---------------------------------------------------------------------------
 
   describe("E2E tool lifecycle (real NAPI)", () => {
-    // Capability enum (roles.rs) uses "tool:invoke:*" but CapabilityUri
-    // (capability.rs) expects "tool_invoke" as a single resource token.
-    // Three-way naming mismatch between mint, validate, and ceiling.
-    // See detailed comment in "invokes a registered tool" test and #1144.
-    test.skip("register -> invoke -> verify (Capability/CapabilityUri naming mismatch)", async () => {
-      const identity = await napi.identityCreate("in_memory");
+    test("register -> invoke -> verify", async () => {
+      const admin = await napi.identityCreate("in_memory");
+      const member = await napi.identityCreate("in_memory");
       const ctx = await napi.contextCreate(
-        identity,
+        admin,
         JSON.stringify({
           ceiling: ["tool:register", "tool:invoke:*"],
         }),
@@ -963,23 +955,23 @@ if (bridge === null) {
         description: "End-to-end test tool",
         inputSchema: {
           type: "object",
-          properties: { value: { type: "number" } },
+          properties: { value: { type: "number" }, mode: { type: "string" } },
         },
         outputSchema: {
           type: "object",
-          properties: { doubled: { type: "number" } },
+          properties: { doubled: { type: "number" }, ok: { type: "boolean" } },
         },
-        operator: identity.did,
+        operator: admin.did,
       });
       expect(toolId).toBeTruthy();
 
-      // Invoke.
-      const ucan = await napi.ucanMint(ctx, identity.did, ["tool:invoke:*"]);
+      // Invoke (mint for member, not self-delegation).
+      const ucan = await napi.ucanMint(ctx, member.did, ["tool:invoke:*"]);
       const resultJson = await napi.toolInvoke(
         ctx,
         toolId,
         JSON.stringify({ value: 21 }),
-        identity.did,
+        member.did,
         ucan.encoded,
       );
       expect(typeof resultJson).toBe("string");

--- a/crates/scp-core/src/crypto/ucan/capability.rs
+++ b/crates/scp-core/src/crypto/ucan/capability.rs
@@ -147,14 +147,22 @@ impl CapabilityUri {
     ///
     /// A wildcard URI matches any URI with the same resource and action.
     /// A specific URI matches only URIs with the same context ID, resource,
-    /// and action.
+    /// and action. A wildcard action (`"*"`) on the granting URI matches any
+    /// action on the same resource (e.g., `tool_invoke:*` grants
+    /// `tool_invoke:calculator`).
     ///
     /// This is used during capability matching in UCAN validation: a token's
     /// attenuation must match the required capability.
     #[must_use]
     pub fn matches(&self, required: &Self) -> bool {
-        // Resource and action must always match exactly.
-        if self.resource != required.resource || self.action != required.action {
+        // Resource must always match exactly.
+        if self.resource != required.resource {
+            return false;
+        }
+
+        // Action: wildcard "*" on the granting side matches any required action.
+        // Otherwise, actions must match exactly.
+        if self.action != "*" && self.action != required.action {
             return false;
         }
 
@@ -176,13 +184,22 @@ impl CapabilityUri {
     /// (e.g., `"messages:write"`, `"tool_invoke:assistant"`). This performs a
     /// constant-time set membership test as specified by ADR-016.
     ///
+    /// A wildcard entry `{resource}:*` in the ceiling covers all actions on
+    /// that resource. For example, `"tool_invoke:*"` in the ceiling allows
+    /// `tool_invoke:calculator`, `tool_invoke:assistant`, etc.
+    ///
     /// # Arguments
     ///
     /// * `ceiling` - The context's immutable capability ceiling, represented as
     ///   a set of capability name strings.
     #[must_use]
     pub fn is_within_ceiling<S: BuildHasher>(&self, ceiling: &HashSet<String, S>) -> bool {
-        ceiling.contains(&self.capability_name())
+        // Exact match first (fast path).
+        if ceiling.contains(&self.capability_name()) {
+            return true;
+        }
+        // Check for wildcard: {resource}:* covers all actions on this resource.
+        ceiling.contains(&format!("{}:*", self.resource))
     }
 }
 
@@ -588,6 +605,45 @@ mod tests {
         assert!(!granted.matches(&required));
     }
 
+    #[test]
+    fn matches_wildcard_action_grants_specific_action() {
+        // tool_invoke:* grants tool_invoke:calculator (#1326)
+        let granted = CapabilityUri::new("abc123", "tool_invoke", "*");
+        let required = CapabilityUri::new("abc123", "tool_invoke", "calculator");
+        assert!(granted.matches(&required));
+    }
+
+    #[test]
+    fn matches_wildcard_action_grants_any_action_on_same_resource() {
+        let granted = CapabilityUri::new("abc123", "tool_invoke", "*");
+        let required_a = CapabilityUri::new("abc123", "tool_invoke", "assistant");
+        let required_b = CapabilityUri::new("abc123", "tool_invoke", "calculator");
+        assert!(granted.matches(&required_a));
+        assert!(granted.matches(&required_b));
+    }
+
+    #[test]
+    fn matches_wildcard_action_does_not_cross_resources() {
+        let granted = CapabilityUri::new("abc123", "tool_invoke", "*");
+        let required = CapabilityUri::new("abc123", "messages", "write");
+        assert!(!granted.matches(&required));
+    }
+
+    #[test]
+    fn matches_wildcard_action_with_wildcard_context() {
+        let granted = CapabilityUri::wildcard("tool_invoke", "*");
+        let required = CapabilityUri::new("any-ctx", "tool_invoke", "calculator");
+        assert!(granted.matches(&required));
+    }
+
+    #[test]
+    fn matches_specific_action_does_not_satisfy_wildcard_action_requirement() {
+        // A specific grant cannot satisfy a wildcard action requirement.
+        let granted = CapabilityUri::new("abc123", "tool_invoke", "calculator");
+        let required = CapabilityUri::new("abc123", "tool_invoke", "*");
+        assert!(!granted.matches(&required));
+    }
+
     // -----------------------------------------------------------------------
     // is_within_ceiling
     // -----------------------------------------------------------------------
@@ -630,6 +686,34 @@ mod tests {
         let ceiling: HashSet<String> = HashSet::new();
         let uri = CapabilityUri::new("abc123", "messages", "write");
         assert!(!uri.is_within_ceiling(&ceiling));
+    }
+
+    #[test]
+    fn is_within_ceiling_wildcard_action_covers_specific() {
+        // "tool_invoke:*" in ceiling allows tool_invoke:calculator (#1326)
+        let ceiling: HashSet<String> = ["tool_invoke:*".to_owned()].into_iter().collect();
+        let uri = CapabilityUri::new("abc123", "tool_invoke", "calculator");
+        assert!(uri.is_within_ceiling(&ceiling));
+    }
+
+    #[test]
+    fn is_within_ceiling_wildcard_action_does_not_cross_resources() {
+        let ceiling: HashSet<String> = ["tool_invoke:*".to_owned()].into_iter().collect();
+        let uri = CapabilityUri::new("abc123", "messages", "write");
+        assert!(!uri.is_within_ceiling(&ceiling));
+    }
+
+    #[test]
+    fn is_within_ceiling_exact_match_preferred_over_wildcard() {
+        // Both exact and wildcard are present — exact match takes the fast path.
+        let ceiling: HashSet<String> = [
+            "tool_invoke:calculator".to_owned(),
+            "tool_invoke:*".to_owned(),
+        ]
+        .into_iter()
+        .collect();
+        let uri = CapabilityUri::new("abc123", "tool_invoke", "calculator");
+        assert!(uri.is_within_ceiling(&ceiling));
     }
 
     // -----------------------------------------------------------------------

--- a/crates/scp-ffi/wasm/src/ucan.rs
+++ b/crates/scp-ffi/wasm/src/ucan.rs
@@ -173,7 +173,13 @@ impl CapabilityUri {
     }
 
     fn matches(&self, required: &Self) -> bool {
-        if self.resource != required.resource || self.action != required.action {
+        // Resource must always match exactly.
+        if self.resource != required.resource {
+            return false;
+        }
+        // Action: wildcard "*" on the granting side matches any required action.
+        // Otherwise, actions must match exactly.
+        if self.action != "*" && self.action != required.action {
             return false;
         }
         match (&self.context_id, &required.context_id) {
@@ -571,7 +577,10 @@ fn validate_ucan_full(params: &UcanValidationParams<'_>) -> Result<(), String> {
 
     // Step 8: Capability ceiling check.
     let cap_name = required_cap.capability_name();
-    if !ceiling.is_empty() && !ceiling.contains(&cap_name) {
+    if !ceiling.is_empty()
+        && !ceiling.contains(&cap_name)
+        && !ceiling.contains(&format!("{}:*", required_cap.resource))
+    {
         return Err(format!("capability outside ceiling: {cap_name}"));
     }
 
@@ -1982,6 +1991,104 @@ mod tests {
         assert!(
             err.contains("signature verification failed"),
             "expected signature error at step 2, got: {err}"
+        );
+    }
+
+    // -----------------------------------------------------------------------
+    // CapabilityUri::matches() wildcard action
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn capability_matches_wildcard_action_grants_specific() {
+        let granted = CapabilityUri {
+            context_id: Some("ctx-1".to_owned()),
+            resource: "tool_invoke".to_owned(),
+            action: "*".to_owned(),
+        };
+        let required = CapabilityUri {
+            context_id: Some("ctx-1".to_owned()),
+            resource: "tool_invoke".to_owned(),
+            action: "calculator".to_owned(),
+        };
+        assert!(
+            granted.matches(&required),
+            "wildcard action '*' should match specific action 'calculator'"
+        );
+    }
+
+    #[test]
+    fn capability_matches_wildcard_action_does_not_cross_resources() {
+        let granted = CapabilityUri {
+            context_id: Some("ctx-1".to_owned()),
+            resource: "tool_invoke".to_owned(),
+            action: "*".to_owned(),
+        };
+        let required = CapabilityUri {
+            context_id: Some("ctx-1".to_owned()),
+            resource: "messages".to_owned(),
+            action: "write".to_owned(),
+        };
+        assert!(
+            !granted.matches(&required),
+            "wildcard on tool_invoke must not match messages resource"
+        );
+    }
+
+    #[test]
+    fn capability_matches_specific_does_not_satisfy_wildcard_requirement() {
+        let granted = CapabilityUri {
+            context_id: Some("ctx-1".to_owned()),
+            resource: "tool_invoke".to_owned(),
+            action: "calculator".to_owned(),
+        };
+        let required = CapabilityUri {
+            context_id: Some("ctx-1".to_owned()),
+            resource: "tool_invoke".to_owned(),
+            action: "*".to_owned(),
+        };
+        assert!(
+            !granted.matches(&required),
+            "specific grant must not satisfy wildcard requirement"
+        );
+    }
+
+    // -----------------------------------------------------------------------
+    // Ceiling wildcard fallback
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn ceiling_wildcard_fallback_allows_specific_action() {
+        // A ceiling containing "tool_invoke:*" should allow
+        // a capability with "tool_invoke:calculator".
+        let cap = CapabilityUri {
+            context_id: Some("ctx-1".to_owned()),
+            resource: "tool_invoke".to_owned(),
+            action: "calculator".to_owned(),
+        };
+        let ceiling: HashSet<String> = HashSet::from(["tool_invoke:*".to_owned()]);
+        let cap_name = cap.capability_name();
+        let within_ceiling =
+            ceiling.contains(&cap_name) || ceiling.contains(&format!("{}:*", cap.resource));
+        assert!(
+            within_ceiling,
+            "ceiling with 'tool_invoke:*' should cover 'tool_invoke:calculator'"
+        );
+    }
+
+    #[test]
+    fn ceiling_wildcard_does_not_cross_resources() {
+        let cap = CapabilityUri {
+            context_id: Some("ctx-1".to_owned()),
+            resource: "messages".to_owned(),
+            action: "write".to_owned(),
+        };
+        let ceiling: HashSet<String> = HashSet::from(["tool_invoke:*".to_owned()]);
+        let cap_name = cap.capability_name();
+        let within_ceiling =
+            ceiling.contains(&cap_name) || ceiling.contains(&format!("{}:*", cap.resource));
+        assert!(
+            !within_ceiling,
+            "ceiling with 'tool_invoke:*' should not cover 'messages:write'"
         );
     }
 


### PR DESCRIPTION
CapabilityUri::matches() and is_within_ceiling() now support wildcard actions. tool_invoke:* grants tool_invoke:calculator. Both NAPI tool invoke tests unskipped and passing.

Reviewed: cryptographer LGTM (no escalation possible), second-pass no bugs found.

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>