### PR TITLE
fix(sdk): custody "file" alias + optional identity params (SCP-294)

### DIFF
--- a/bindings/kotlin/scp-kt/src/main/kotlin/works/limn/scp/bridge/CoroutineBridge.kt
+++ b/bindings/kotlin/scp-kt/src/main/kotlin/works/limn/scp/bridge/CoroutineBridge.kt
@@ -2135,11 +2135,23 @@ class GovernanceBridgeOps internal constructor(
 
 /**
  * Broadcast operations bridge. Wraps broadcast-related FFI calls as suspend functions.
+ *
+ * Set [defaultIdentityHandle] to avoid passing the identity handle to every
+ * publish call. When a publish method receives `identityHandle = null`, it
+ * falls back to [defaultIdentityHandle]. If both are null, a
+ * [BridgeException] is thrown. Callers typically set this once after
+ * identity creation (SCP-294b).
  */
 class BroadcastBridgeOps internal constructor(
     private val bindings: BroadcastBindings,
     private val bridge: CoroutineBridge,
 ) {
+    /**
+     * Default identity handle used when publish methods receive a null
+     * `identityHandle`. Set this after identity creation to avoid passing
+     * the handle on every call (SCP-294b).
+     */
+    var defaultIdentityHandle: Long? = null
     /**
      * Subscribe a DID to a broadcast context.
      *
@@ -2264,19 +2276,23 @@ class BroadcastBridgeOps internal constructor(
      *
      * @param contextHandle Handle from context create or join.
      * @param identityHandle Handle from identity create or load for the publishing author.
+     *   Defaults to [defaultIdentityHandle] when null (SCP-294b).
      * @param asset The asset to publish (path, content type, body).
      * @param deployId Optional deploy ID to group assets into atomic deploys.
      * @return A [PublishResult] with blob ID and ETag.
+     * @throws BridgeException if no identity handle is provided and
+     *   [defaultIdentityHandle] is not set.
      */
     suspend fun publishAsset(
         contextHandle: Long,
-        identityHandle: Long,
+        identityHandle: Long? = null,
         asset: AssetEntry,
         deployId: String? = null,
     ): PublishResult {
+        val resolved = resolveIdentityHandle(identityHandle)
         val assetJson = serializeAsset(asset)
         val resultJson = bridge.ffiCall {
-            bindings.broadcastPublishAsset(contextHandle, identityHandle, assetJson, deployId)
+            bindings.broadcastPublishAsset(contextHandle, resolved, assetJson, deployId)
         }
         return parsePublishResult(resultJson)
     }
@@ -2289,22 +2305,37 @@ class BroadcastBridgeOps internal constructor(
      *
      * @param contextHandle Handle from context create or join.
      * @param identityHandle Handle from identity create or load for the publishing author.
+     *   Defaults to [defaultIdentityHandle] when null (SCP-294b).
      * @param assets The assets to publish.
      * @param deployId Optional deploy ID to group assets into atomic deploys.
      * @return A list of [PublishResult] values, one per asset.
+     * @throws BridgeException if no identity handle is provided and
+     *   [defaultIdentityHandle] is not set.
      */
     suspend fun publishAssets(
         contextHandle: Long,
-        identityHandle: Long,
+        identityHandle: Long? = null,
         assets: List<AssetEntry>,
         deployId: String? = null,
     ): List<PublishResult> {
+        val resolved = resolveIdentityHandle(identityHandle)
         val assetsJson = serializeAssets(assets)
         val resultJson = bridge.ffiCall {
-            bindings.broadcastPublishAssets(contextHandle, identityHandle, assetsJson, deployId)
+            bindings.broadcastPublishAssets(contextHandle, resolved, assetsJson, deployId)
         }
         return parsePublishResults(resultJson)
     }
+
+    /**
+     * Resolves the effective identity handle from an explicit value or the
+     * [defaultIdentityHandle] fallback (SCP-294b).
+     */
+    private fun resolveIdentityHandle(explicit: Long?): Long =
+        explicit ?: defaultIdentityHandle ?: throw BridgeException(
+            "identityHandle is required: pass it explicitly or set " +
+                "BroadcastBridgeOps.defaultIdentityHandle",
+            "SCP-IDENT-1060",
+        )
 }
 
 // ---------------------------------------------------------------------------

--- a/bindings/kotlin/scp-kt/src/test/kotlin/works/limn/scp/bridge/CoroutineBridgeTest.kt
+++ b/bindings/kotlin/scp-kt/src/test/kotlin/works/limn/scp/bridge/CoroutineBridgeTest.kt
@@ -630,6 +630,42 @@ class CoroutineBridgeTest {
                 }
                 assertEquals("SCP-CTX-2036", exception.code)
             }
+
+        @Test
+        fun `publishAsset uses defaultIdentityHandle when identityHandle is null`() =
+            runTest(ioDispatcher) {
+                bridge.broadcast.defaultIdentityHandle = 99L
+                val asset = works.limn.scp.AssetEntry("/index.html", "text/html", "hi".toByteArray())
+                val result = bridge.broadcast.publishAsset(1L, asset = asset)
+                assertEquals("abc123", result.blobId)
+                assertEquals(99L, stubBindings.lastPublishAssetIdentityHandle)
+                bridge.broadcast.defaultIdentityHandle = null
+            }
+
+        @Test
+        fun `publishAssets uses defaultIdentityHandle when identityHandle is null`() =
+            runTest(ioDispatcher) {
+                bridge.broadcast.defaultIdentityHandle = 99L
+                val assets = listOf(
+                    works.limn.scp.AssetEntry("/index.html", "text/html", "hi".toByteArray()),
+                    works.limn.scp.AssetEntry("/style.css", "text/css", "body{}".toByteArray()),
+                )
+                val results = bridge.broadcast.publishAssets(1L, assets = assets)
+                assertEquals(2, results.size)
+                assertEquals(99L, stubBindings.lastPublishAssetsIdentityHandle)
+                bridge.broadcast.defaultIdentityHandle = null
+            }
+
+        @Test
+        fun `publishAsset throws when no identity handle available`() =
+            runTest(ioDispatcher) {
+                bridge.broadcast.defaultIdentityHandle = null
+                val asset = works.limn.scp.AssetEntry("/a.html", "text/html", "x".toByteArray())
+                val exception = assertFailsWith<BridgeException> {
+                    bridge.broadcast.publishAsset(1L, asset = asset)
+                }
+                assertEquals("SCP-IDENT-1060", exception.code)
+            }
     }
 
     // -------------------------------------------------------------------

--- a/bindings/python/scp_sdk/identity.py
+++ b/bindings/python/scp_sdk/identity.py
@@ -91,7 +91,7 @@ class Identity:
 
         identity = await Identity.create()
         print(identity.did)           # "did:dht:z6Mk..."
-        print(identity.custody_type)  # "platform"
+        print(identity.custody_type)  # CustodyType.FILE
 
     See ``.docs/adrs/phase-3.md`` ADR-014 acceptance criterion 1.
     """
@@ -129,7 +129,7 @@ class Identity:
     # -- Async factory methods -----------------------------------------------
 
     @classmethod
-    async def create(cls, custody: CustodyType | str = CustodyType.PLATFORM) -> Identity:
+    async def create(cls, custody: CustodyType | str = CustodyType.FILE) -> Identity:
         """Create a new SCP identity with the specified key custody method.
 
         Args:
@@ -137,10 +137,12 @@ class Identity:
                 :class:`~scp_sdk.types.CustodyType` enum member or a raw
                 string.  Valid values:
 
-                - :attr:`CustodyType.PLATFORM` / ``"platform"``
-                  (default) -- platform-native secure storage (Keychain
-                  on macOS/iOS, Keystore on Android, credential manager
-                  on Windows/Linux).
+                - :attr:`CustodyType.FILE` / ``"file"`` (default) --
+                  encrypted file-backed key custody (Argon2id +
+                  AES-256-GCM at ``$HOME/.scp/keys.bin``).  Requires
+                  the ``SCP_KEY_PASSPHRASE`` environment variable.
+                - :attr:`CustodyType.PLATFORM` / ``"platform"`` --
+                  backward-compatible alias for ``"file"``.
                 - :attr:`CustodyType.IN_MEMORY` / ``"in_memory"`` --
                   ephemeral in-memory key store, suitable for testing or
                   short-lived agents.
@@ -183,7 +185,7 @@ class Identity:
     # -- Sync convenience wrappers -------------------------------------------
 
     @classmethod
-    def create_sync(cls, custody: CustodyType | str = CustodyType.PLATFORM) -> Identity:
+    def create_sync(cls, custody: CustodyType | str = CustodyType.FILE) -> Identity:
         """Synchronous convenience wrapper for :meth:`create`.
 
         Uses :func:`scp_sdk.sync.run_sync` with a dedicated background
@@ -205,9 +207,7 @@ class Identity:
     # -- Async instance methods ----------------------------------------------
 
     @classmethod
-    async def create_with_agent_key(
-        cls, custody: CustodyType | str = CustodyType.PLATFORM
-    ) -> Identity:
+    async def create_with_agent_key(cls, custody: CustodyType | str = CustodyType.FILE) -> Identity:
         """Create a new SCP identity with an agent signing key (ADR-039).
 
         Creates a DID identity with both the standard signing key and an
@@ -216,7 +216,7 @@ class Identity:
         Args:
             custody: Key custody type.  Accepts a
                 :class:`~scp_sdk.types.CustodyType` enum member or a
-                raw string (``"platform"``, ``"in_memory"``,
+                raw string (``"file"``, ``"platform"``, ``"in_memory"``,
                 ``"software"``).
 
         Returns:

--- a/bindings/python/scp_sdk/types.py
+++ b/bindings/python/scp_sdk/types.py
@@ -27,10 +27,23 @@ class CustodyType(enum.Enum):
 
     Determines where cryptographic keys are stored and managed.
     Mirrors ``scp_core::identity::CustodyType``.
+
+    The bridge layer accepts both ``"file"`` and ``"platform"`` for
+    file-backed custody (:attr:`FILE` and :attr:`PLATFORM` respectively).
+    ``"platform"`` is a backward-compatible alias — both resolve to
+    ``FileKeyCustody`` (Argon2id + AES-256-GCM encrypted key file at
+    ``$HOME/.scp/keys.bin``).  Prefer :attr:`FILE` for new code.
+
+    See SCP-294a.
     """
 
-    #: Platform-native secure storage (Keychain on macOS/iOS, Keystore
-    #: on Android, credential manager on Windows/Linux).  Default.
+    #: Encrypted file-backed key custody (Argon2id + AES-256-GCM).
+    #: Canonical name for what was previously called ``"platform"``.
+    #: Requires the ``SCP_KEY_PASSPHRASE`` environment variable.
+    FILE = "file"
+    #: Backward-compatible alias for :attr:`FILE`.  Both resolve to
+    #: ``FileKeyCustody`` in the bridge layer.  Prefer :attr:`FILE`
+    #: for new code.
     PLATFORM = "platform"
     #: Ephemeral in-memory key store, suitable for testing or short-lived
     #: agents.  Keys are lost on process exit.

--- a/bindings/swift/Sources/SCP/Governance.swift
+++ b/bindings/swift/Sources/SCP/Governance.swift
@@ -951,6 +951,7 @@ public extension Context {
     /// - Parameters:
     ///   - asset: The asset to publish (path, content type, body).
     ///   - identity: The identity of the author publishing the asset.
+    ///     Defaults to the context creator's identity (SCP-294b).
     ///   - deployId: Optional deploy ID to group assets into atomic deploys.
     ///   - publishAssetFn: Bridge function override for testing.
     /// - Returns: A ``PublishResult`` with `blobId` and `etag`.
@@ -958,7 +959,7 @@ public extension Context {
     ///   active or publishing fails.
     func broadcastPublishAsset(
         asset: AssetEntry,
-        identity: Identity,
+        identity: Identity? = nil,
         deployId: String? = nil,
         publishAssetFn: BroadcastBridge.PublishAssetFn = BroadcastBridge.defaultPublishAsset
     ) async throws -> PublishResult {
@@ -966,7 +967,8 @@ public extension Context {
             throw ScpError.Context(msg: "Context is not active", code: "SCP-CTX-2001")
         }
 
-        return try await publishAssetFn(handle, identity, asset, deployId)
+        let resolvedIdentity = identity ?? self.identity
+        return try await publishAssetFn(handle, resolvedIdentity, asset, deployId)
     }
 
     /// Publishes multiple assets to this broadcast context as structured content (SCP-290).
@@ -977,6 +979,7 @@ public extension Context {
     /// - Parameters:
     ///   - assets: The assets to publish.
     ///   - identity: The identity of the author publishing the assets.
+    ///     Defaults to the context creator's identity (SCP-294b).
     ///   - deployId: Optional deploy ID to group assets into atomic deploys.
     ///   - publishAssetsFn: Bridge function override for testing.
     /// - Returns: An array of ``PublishResult`` values, one per asset.
@@ -984,7 +987,7 @@ public extension Context {
     ///   active or publishing fails.
     func broadcastPublishAssets(
         assets: [AssetEntry],
-        identity: Identity,
+        identity: Identity? = nil,
         deployId: String? = nil,
         publishAssetsFn: BroadcastBridge.PublishAssetsFn = BroadcastBridge.defaultPublishAssets
     ) async throws -> [PublishResult] {
@@ -992,7 +995,8 @@ public extension Context {
             throw ScpError.Context(msg: "Context is not active", code: "SCP-CTX-2001")
         }
 
-        return try await publishAssetsFn(handle, identity, assets, deployId)
+        let resolvedIdentity = identity ?? self.identity
+        return try await publishAssetsFn(handle, resolvedIdentity, assets, deployId)
     }
 }
 

--- a/bindings/swift/Tests/SCPTests/GovernanceTests.swift
+++ b/bindings/swift/Tests/SCPTests/GovernanceTests.swift
@@ -988,6 +988,53 @@ struct GovernanceTests {
         }
     }
 
+    // MARK: - Optional identity parameter tests (SCP-294b)
+
+    @Test("broadcastPublishAsset defaults to context identity when identity is nil")
+    func broadcastPublishAssetDefaultIdentity() async throws {
+        let context = makeActiveContext()
+
+        var receivedIdentity: Identity?
+        let mockPublishAsset: BroadcastBridge.PublishAssetFn = { _, identity, _, _ in
+            receivedIdentity = identity
+            return PublishResult(blobId: "abc", etag: "def")
+        }
+
+        let asset = AssetEntry(
+            path: "/index.html",
+            contentType: "text/html",
+            body: Data("<h1>Hello</h1>".utf8)
+        )
+        // Call without explicit identity — should use context's self.identity
+        let result = try await context.broadcastPublishAsset(
+            asset: asset,
+            publishAssetFn: mockPublishAsset
+        )
+        #expect(result.blobId == "abc")
+        #expect(receivedIdentity != nil)
+    }
+
+    @Test("broadcastPublishAssets defaults to context identity when identity is nil")
+    func broadcastPublishAssetsDefaultIdentity() async throws {
+        let context = makeActiveContext()
+
+        var receivedIdentity: Identity?
+        let mockPublishAssets: BroadcastBridge.PublishAssetsFn = { _, identity, assets, _ in
+            receivedIdentity = identity
+            return assets.map { _ in PublishResult(blobId: "b", etag: "e") }
+        }
+
+        let assets = [
+            AssetEntry(path: "/index.html", contentType: "text/html", body: Data("hi".utf8))
+        ]
+        let results = try await context.broadcastPublishAssets(
+            assets: assets,
+            publishAssetsFn: mockPublishAssets
+        )
+        #expect(results.count == 1)
+        #expect(receivedIdentity != nil)
+    }
+
     // MARK: - Bridge error propagation tests
 
     @Test("memberCount propagates bridge errors")

--- a/crates/scp-ffi/src/identity.rs
+++ b/crates/scp-ffi/src/identity.rs
@@ -298,24 +298,26 @@ impl PyDIDDocument {
 ///
 /// - `"in_memory"` — Test-only in-memory custody. Keys are lost on process
 ///   exit. Only available when compiled with `cfg(feature = "testing")`.
-/// - `"platform"` — Encrypted file-backed custody ([`FileKeyCustody`]) using
+/// - `"file"` — Encrypted file-backed custody ([`FileKeyCustody`]) using
 ///   Argon2id + AES-256-GCM. This is the production default for desktop/server
 ///   platforms. Mobile platforms (iOS/Android) should use their native
 ///   `KeyCustodyProvider` callback interface via `UniFFI` instead.
+/// - `"platform"` — Backward-compatible alias for `"file"` (SCP-294a).
 ///
-/// The `"platform"` path creates a [`FileKeyCustody`] at a default location
-/// (`$HOME/.scp/keys.bin`) with a passphrase from the `SCP_KEY_PASSPHRASE`
-/// environment variable. If the variable is not set, an error is returned.
+/// The `"file"` / `"platform"` path creates a [`FileKeyCustody`] at a default
+/// location (`$HOME/.scp/keys.bin`) with a passphrase from the
+/// `SCP_KEY_PASSPHRASE` environment variable. If the variable is not set, an
+/// error is returned.
 ///
 /// # Errors
 ///
 /// Returns [`ScpPyError::ValidationError`] if:
 /// - The custody string is not recognized.
 /// - `"in_memory"` is requested but the `testing` feature is not enabled.
-/// - `"platform"` is requested but `SCP_KEY_PASSPHRASE` is not set.
+/// - `"file"` / `"platform"` is requested but `SCP_KEY_PASSPHRASE` is not set.
 /// - [`FileKeyCustody`] initialization fails (I/O error, corrupt key file).
 ///
-/// See issue #323 and ADR-006.
+/// See issue #323, ADR-006, and SCP-294a.
 fn parse_custody(custody: &str) -> Result<(Arc<FfiKeyCustody>, String), ScpPyError> {
     match custody {
         #[cfg(feature = "allow_in_memory_custody")]
@@ -327,10 +329,12 @@ fn parse_custody(custody: &str) -> Result<(Arc<FfiKeyCustody>, String), ScpPyErr
         "in_memory" => Err(ScpPyError::validation(
             "in_memory custody is not available in this build -- enable the              allow_in_memory_custody feature for dev/desktop use",
         )),
-        "platform" => {
+        // "file" is the canonical name; "platform" is a backward-compat alias
+        // (SCP-294a). Both resolve to FileKeyCustody.
+        "file" | "platform" => {
             let passphrase = std::env::var("SCP_KEY_PASSPHRASE").map_err(|_| {
                 ScpPyError::validation(
-                    "platform custody requires the SCP_KEY_PASSPHRASE environment \
+                    "file custody requires the SCP_KEY_PASSPHRASE environment \
                      variable to be set — this passphrase protects the encrypted key file",
                 )
             })?;
@@ -351,10 +355,12 @@ fn parse_custody(custody: &str) -> Result<(Arc<FfiKeyCustody>, String), ScpPyErr
                 ))
             })?;
 
-            Ok((Arc::new(FfiKeyCustody::File(file_kc)), custody.to_owned()))
+            // Normalize: always store "file" as the canonical custody type,
+            // even when the caller passed the "platform" backward-compat alias.
+            Ok((Arc::new(FfiKeyCustody::File(file_kc)), "file".to_owned()))
         }
         other => Err(ScpPyError::validation(format!(
-            "unknown custody type: {other:?} — expected \"in_memory\" or \"platform\""
+            "unknown custody type: {other:?} — expected \"in_memory\", \"file\", or \"platform\""
         ))),
     }
 }


### PR DESCRIPTION
## Summary

- **Part A (SCP-294a):** Adds `"file"` as the canonical custody name for `FileKeyCustody` in the Rust FFI `parse_custody` function. `"platform"` remains as a backward-compatible alias. Python `CustodyType` enum gains `FILE = "file"` variant; default changes from `PLATFORM` to `FILE` across all `Identity.create` methods.
- **Part B (SCP-294b):** Makes `identity` optional in Swift `broadcastPublishAsset`/`broadcastPublishAssets` (defaults to `self.identity`). Adds `defaultIdentityHandle` property to Kotlin `BroadcastBridgeOps`; `publishAsset`/`publishAssets` accept nullable `identityHandle` with fallback to the default.

### Files changed
- `crates/scp-ffi/src/identity.rs` — `parse_custody` accepts `"file"` | `"platform"`, normalizes stored type to `"file"`
- `bindings/python/scp_sdk/types.py` — `CustodyType.FILE` added, docstrings updated
- `bindings/python/scp_sdk/identity.py` — defaults changed to `CustodyType.FILE`, docstrings updated
- `bindings/swift/Sources/SCP/Governance.swift` — `identity: Identity? = nil` with `?? self.identity` fallback
- `bindings/kotlin/.../CoroutineBridge.kt` — `defaultIdentityHandle` property, nullable `identityHandle` params
- Tests added in both Swift and Kotlin

## Test plan

- [x] Rust clippy passes (workspace, all features)
- [x] scp-ffi Rust tests pass (54 tests)
- [x] Full workspace Rust tests pass
- [x] Python lint + format + 425 tests pass
- [x] Kotlin compile + detekt + ktlint + 234 tests pass (including 3 new SCP-294b tests)
- [x] Swift lint (SwiftLint + SwiftFormat) clean
- [x] Error code check passes
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)