### PR TITLE
fix(python): remove unsupported CustodyType.SOFTWARE

### DIFF
--- a/bindings/python/scp_sdk/identity.py
+++ b/bindings/python/scp_sdk/identity.py
@@ -146,8 +146,6 @@ class Identity:
                 - :attr:`CustodyType.IN_MEMORY` / ``"in_memory"`` --
                   ephemeral in-memory key store, suitable for testing or
                   short-lived agents.
-                - :attr:`CustodyType.SOFTWARE` / ``"software"`` --
-                  software-backed file-based key store.
 
         Returns:
             A new :class:`Identity` instance.
@@ -216,8 +214,7 @@ class Identity:
         Args:
             custody: Key custody type.  Accepts a
                 :class:`~scp_sdk.types.CustodyType` enum member or a
-                raw string (``"file"``, ``"platform"``, ``"in_memory"``,
-                ``"software"``).
+                raw string (``"file"``, ``"platform"``, ``"in_memory"``).
 
         Returns:
             A new :class:`Identity` instance with an agent key.

--- a/bindings/python/scp_sdk/types.py
+++ b/bindings/python/scp_sdk/types.py
@@ -48,8 +48,6 @@ class CustodyType(enum.Enum):
     #: Ephemeral in-memory key store, suitable for testing or short-lived
     #: agents.  Keys are lost on process exit.
     IN_MEMORY = "in_memory"
-    #: Software-backed file-based key store with passphrase protection.
-    SOFTWARE = "software"
 
 
 class BridgeMode(enum.Enum):


### PR DESCRIPTION
## Summary
- Removes `CustodyType.SOFTWARE` enum variant from the Python SDK's `types.py` — the Rust bridge's `parse_custody()` only accepts `"in_memory"`, `"file"`, and `"platform"`, so `"software"` always errors at runtime
- Removes all docstring references to `CustodyType.SOFTWARE` in `identity.py` (`Identity.create` and `Identity.create_with_agent_key`)
- No feature loss: `FileKeyCustody` (mapped from `"file"` / `"platform"`) already provides software-backed file-based key storage with Argon2id + AES-256-GCM passphrase protection — exactly what SOFTWARE's docstring described

## Test plan
- [x] `python3.12 -m ruff check bindings/python/` passes
- [x] `python3.12 -m ruff format --check bindings/python/` passes
- [ ] No existing tests reference `CustodyType.SOFTWARE` (verified via grep)
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)