### PR TITLE
fix(ci): auto-accept Android SDK licenses before sdkmanager install

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -308,6 +308,7 @@ jobs:
           distribution: zulu
           java-version: "17"
       - uses: android-actions/setup-android@v3
+      - run: yes | sdkmanager --licenses > /dev/null 2>&1 || true
       - run: sdkmanager "platforms;android-35"
       - uses: gradle/actions/setup-gradle@v4
       - run: ./gradlew :scp-kt:runKtlintCheckOverMainSourceSet
@@ -328,6 +329,7 @@ jobs:
           distribution: zulu
           java-version: "17"
       - uses: android-actions/setup-android@v3
+      - run: yes | sdkmanager --licenses > /dev/null 2>&1 || true
       - run: sdkmanager "platforms;android-35"
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2


### PR DESCRIPTION
## Summary
- Adds `yes | sdkmanager --licenses > /dev/null 2>&1 || true` before each `sdkmanager "platforms;android-35"` call in the `kotlin-lint` and `kotlin-test` CI jobs
- Fixes license acceptance failures that block Kotlin CI when the runner hasn't previously accepted Android SDK licenses

## Test plan
- [ ] Verify `kotlin-lint` job passes without license acceptance errors
- [ ] Verify `kotlin-test` job passes without license acceptance errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)