### PR TITLE
fix(ci): use correct sdkmanager path for license acceptance

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -308,7 +308,7 @@ jobs:
           distribution: zulu
           java-version: "17"
       - uses: android-actions/setup-android@v3
-      - run: yes | sdkmanager --licenses > /dev/null 2>&1 || true
+      - run: yes | $ANDROID_HOME/cmdline-tools/latest/bin/sdkmanager --licenses > /dev/null 2>&1 || true
       - run: sdkmanager "platforms;android-35"
       - uses: gradle/actions/setup-gradle@v4
       - run: ./gradlew :scp-kt:runKtlintCheckOverMainSourceSet
@@ -329,7 +329,7 @@ jobs:
           distribution: zulu
           java-version: "17"
       - uses: android-actions/setup-android@v3
-      - run: yes | sdkmanager --licenses > /dev/null 2>&1 || true
+      - run: yes | $ANDROID_HOME/cmdline-tools/latest/bin/sdkmanager --licenses > /dev/null 2>&1 || true
       - run: sdkmanager "platforms;android-35"
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2


### PR DESCRIPTION
## Summary
- Fixes Android SDK license acceptance failures in CI by using the explicit `$ANDROID_HOME/cmdline-tools/latest/bin/sdkmanager` path instead of the bare `sdkmanager` command
- `android-actions/setup-android@v3` installs its own cmdline-tools, but the bare `sdkmanager` on PATH may resolve to the preinstalled runner version, causing "wrong version" license mismatches
- Applied to both `kotlin-lint` and `kotlin-test` jobs

## Test plan
- [ ] Verify `kotlin-lint` job passes license acceptance and `sdkmanager "platforms;android-35"` succeeds
- [ ] Verify `kotlin-test` job passes license acceptance and `sdkmanager "platforms;android-35"` succeeds
- [ ] If Option A fails (path doesn't exist), fall back to Option C (direct license hash files)

🤖 Generated with [Claude Code](https://claude.com/claude-code)