### PR TITLE
fix(ci): Android SDK license hashes in Kotlin CI jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -308,7 +308,16 @@ jobs:
           distribution: zulu
           java-version: "17"
       - uses: android-actions/setup-android@v3
-      - run: yes | $ANDROID_HOME/cmdline-tools/latest/bin/sdkmanager --licenses > /dev/null 2>&1 || true
+      - name: Accept Android SDK licenses
+        run: |
+          mkdir -p $ANDROID_HOME/licenses
+          echo -e "\n24333f8a63b6825ea9c5514f83c2829b004d1fee" > $ANDROID_HOME/licenses/android-sdk-license
+          echo -e "\n84831b9409646a918e30573bab4c9c91346d8abd" > $ANDROID_HOME/licenses/android-sdk-preview-license
+          echo -e "\nd56f5187479451eabf01fb78af6dfcb131a6481e" > $ANDROID_HOME/licenses/google-gdk-license
+          echo -e "\ne9acab5b5fbb560a72797e9277c5b0adfeed3bca" > $ANDROID_HOME/licenses/intel-android-extra-license
+          echo -e "\n33b6a2b64607f11b759f320ef9dff4ae5c47d97a" > $ANDROID_HOME/licenses/android-googletv-license
+          echo -e "\nd975f751698a77b662f1254ddbeed3901e976f5a" > $ANDROID_HOME/licenses/android-googlexr-license
+          echo -e "\ne7ce8e93e13705710e8a1b7fdea3c49f149b1386" > $ANDROID_HOME/licenses/mips-android-sysimage-license
       - run: sdkmanager "platforms;android-35"
       - uses: gradle/actions/setup-gradle@v4
       - run: ./gradlew :scp-kt:runKtlintCheckOverMainSourceSet
@@ -329,7 +338,16 @@ jobs:
           distribution: zulu
           java-version: "17"
       - uses: android-actions/setup-android@v3
-      - run: yes | $ANDROID_HOME/cmdline-tools/latest/bin/sdkmanager --licenses > /dev/null 2>&1 || true
+      - name: Accept Android SDK licenses
+        run: |
+          mkdir -p $ANDROID_HOME/licenses
+          echo -e "\n24333f8a63b6825ea9c5514f83c2829b004d1fee" > $ANDROID_HOME/licenses/android-sdk-license
+          echo -e "\n84831b9409646a918e30573bab4c9c91346d8abd" > $ANDROID_HOME/licenses/android-sdk-preview-license
+          echo -e "\nd56f5187479451eabf01fb78af6dfcb131a6481e" > $ANDROID_HOME/licenses/google-gdk-license
+          echo -e "\ne9acab5b5fbb560a72797e9277c5b0adfeed3bca" > $ANDROID_HOME/licenses/intel-android-extra-license
+          echo -e "\n33b6a2b64607f11b759f320ef9dff4ae5c47d97a" > $ANDROID_HOME/licenses/android-googletv-license
+          echo -e "\nd975f751698a77b662f1254ddbeed3901e976f5a" > $ANDROID_HOME/licenses/android-googlexr-license
+          echo -e "\ne7ce8e93e13705710e8a1b7fdea3c49f149b1386" > $ANDROID_HOME/licenses/mips-android-sysimage-license
       - run: sdkmanager "platforms;android-35"
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2


### PR DESCRIPTION
## Summary
- Replace `yes | sdkmanager --licenses` with direct license hash file writes in both `kotlin-lint` and `kotlin-test` CI jobs
- Previous approaches (#1354, #1355) using explicit sdkmanager paths failed; writing hash files to `$ANDROID_HOME/licenses/` is the deterministic approach that doesn't depend on sdkmanager binary resolution

## Notes
- Error code conformance (`scripts/check-error-codes.sh`) already passes — no SCP-NODE codes exist in the codebase (they were already migrated to canonical prefixes)
- Only `.github/workflows/ci.yml` is modified

## Test plan
- [ ] `kotlin-lint` CI job passes with the new license acceptance step
- [ ] `kotlin-test` CI job passes with the new license acceptance step
- [ ] `sdkmanager "platforms;android-35"` succeeds after license files are written

🤖 Generated with [Claude Code](https://claude.com/claude-code)