### PR TITLE
fix(ffi): zeroize intermediate key material at FFI boundaries

### DIFF
--- a/crates/scp-ffi/napi/src/context.rs
+++ b/crates/scp-ffi/napi/src/context.rs
@@ -22,6 +22,8 @@ use uuid::Uuid;
 #[cfg(feature = "allow_in_memory_custody")]
 use scp_platform::traits::KeyCustody;
 
+use zeroize::Zeroizing;
+
 use scp_ffi_common::validate::validate_did;
 
 use crate::error::ScpNapiError;
@@ -2093,12 +2095,12 @@ pub async fn context_create_governance_checkpoint(
     let merkle_root = parse_napi_hex_32(&merkle_root_hex, "merkle_root")?;
     let last_event_hash = parse_napi_hex_32(&last_event_hash_hex, "last_event_hash")?;
     let state_snapshot_hash = parse_napi_hex_32(&state_snapshot_hash_hex, "state_snapshot_hash")?;
-    let creator_signature = hex::decode(&creator_signature_hex).map_err(|e| {
+    let creator_signature = Zeroizing::new(hex::decode(&creator_signature_hex).map_err(|e| {
         NapiError::from(ScpNapiError::Validation {
             message: format!("invalid creator_signature hex: {e}"),
             code: "SCP-CTX-2062".to_owned(),
         })
-    })?;
+    })?);
     let did = DID(creator_did);
 
     #[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
@@ -2115,7 +2117,7 @@ pub async fn context_create_governance_checkpoint(
             last_event_hash,
             state_snapshot_hash,
             &did,
-            creator_signature,
+            (*creator_signature).clone(),
         )
         .await
         .map_err(|e| {
@@ -2157,16 +2159,16 @@ pub async fn context_add_checkpoint_cosignature(
             })
         })?;
 
-    let signature = hex::decode(&signature_hex).map_err(|e| {
+    let signature = Zeroizing::new(hex::decode(&signature_hex).map_err(|e| {
         NapiError::from(ScpNapiError::Validation {
             message: format!("invalid signature hex: {e}"),
             code: "SCP-CTX-2063".to_owned(),
         })
-    })?;
+    })?);
 
     let cosignature = scp_core::context::governance::CosignedCheckpoint {
         signer_did: DID(signer_did),
-        signature,
+        signature: (*signature).clone(),
     };
 
     let status = manager
@@ -2776,12 +2778,12 @@ pub fn metadata_record_to_json(
             })
         })?;
 
-    let signature = hex::decode(&signature_hex).map_err(|e| {
+    let signature = Zeroizing::new(hex::decode(&signature_hex).map_err(|e| {
         NapiError::from(ScpNapiError::Validation {
             message: format!("invalid signature hex: {e}"),
             code: "SCP-VALID-7001".to_owned(),
         })
-    })?;
+    })?);
     if signature.len() != 64 {
         return Err(NapiError::from(ScpNapiError::Validation {
             message: format!("signature must be 64 bytes (got {})", signature.len()),
@@ -2798,7 +2800,7 @@ pub fn metadata_record_to_json(
         timestamp: ts,
         structural,
         operational,
-        signature,
+        signature: (*signature).clone(),
     };
 
     serde_json::to_string(&record).map_err(|e| {

--- a/crates/scp-ffi/napi/src/provenance.rs
+++ b/crates/scp-ffi/napi/src/provenance.rs
@@ -18,6 +18,7 @@
 
 use napi_derive::napi;
 use sha2::{Digest, Sha256};
+use zeroize::Zeroizing;
 
 use scp_core::context::MemoryScope;
 use scp_core::provenance::attach::{
@@ -274,12 +275,12 @@ pub fn provenance_pseudonymize_counterparties(
         })
     })?;
 
-    let key = hex::decode(&pseudonym_key_hex).map_err(|e| {
+    let key = Zeroizing::new(hex::decode(&pseudonym_key_hex).map_err(|e| {
         napi::Error::from(ScpNapiError::Validation {
             message: format!("invalid pseudonym_key_hex: {e}"),
             code: "SCP-VALID-7052".to_owned(),
         })
-    })?;
+    })?);
 
     pseudonymize_counterparties(&mut prov, &key);
 

--- a/crates/scp-ffi/napi/src/server.rs
+++ b/crates/scp-ffi/napi/src/server.rs
@@ -262,16 +262,16 @@ impl NapiNodeHandle {
         deploy_retention_count: Option<u32>,
         csp_override: Option<String>,
     ) -> napi::Result<()> {
-        let key_bytes: Zeroizing<[u8; 32]> = Zeroizing::new(
+        let key_vec = Zeroizing::new(
             hex::decode(&broadcast_key_hex)
-                .map_err(|e| NapiError::from_reason(format!("invalid broadcast_key_hex: {e}")))?
-                .try_into()
-                .map_err(|_| {
-                    NapiError::from_reason(
-                        "broadcast_key_hex must be exactly 64 hex characters (32 bytes)",
-                    )
-                })?,
+                .map_err(|e| NapiError::from_reason(format!("invalid broadcast_key_hex: {e}")))?,
         );
+        let key_bytes: Zeroizing<[u8; 32]> =
+            Zeroizing::new(<[u8; 32]>::try_from(key_vec.as_slice()).map_err(|_| {
+                NapiError::from_reason(
+                    "broadcast_key_hex must be exactly 64 hex characters (32 bytes)",
+                )
+            })?);
 
         let broadcast_key = scp_core::crypto::sender_keys::BroadcastKey::from_parts(
             scp_core::crypto::sender_keys::SenderKey::from_bytes(*key_bytes),

--- a/crates/scp-ffi/src/bridge_connector.rs
+++ b/crates/scp-ffi/src/bridge_connector.rs
@@ -783,6 +783,10 @@ pub fn py_bridge_derive_credential_key(
             code: "SCP-CRYPTO-4012".to_string(),
         })?;
 
+    // SAFETY: `.to_vec()` creates an unzeroized copy of the derived key
+    // material. This is unavoidable at the FFI boundary — PyO3 requires
+    // `Vec<u8>` for bytes returns and Python's GC controls the lifetime.
+    // The `Zeroizing<[u8; 32]>` source is zeroized on drop.
     Ok(derived.to_vec())
 }
 
@@ -799,6 +803,10 @@ pub fn py_bridge_derive_credential_key(
 #[pyo3(name = "bridge_generate_credential_key")]
 pub fn py_bridge_generate_credential_key() -> Vec<u8> {
     let key = generate_bridge_credential_key();
+    // SAFETY: `.to_vec()` creates an unzeroized copy of the generated key
+    // material. This is unavoidable at the FFI boundary — PyO3 requires
+    // `Vec<u8>` for bytes returns and Python's GC controls the lifetime.
+    // The `Zeroizing<[u8; 32]>` source is zeroized on drop.
     key.to_vec()
 }
 

--- a/crates/scp-ffi/src/context.rs
+++ b/crates/scp-ffi/src/context.rs
@@ -34,6 +34,8 @@ use pyo3::types::PyDict;
 use scp_platform::traits::KeyCustody;
 use tokio::sync::mpsc;
 
+use zeroize::Zeroizing;
+
 use crate::validate;
 
 // ---------------------------------------------------------------------------
@@ -2377,9 +2379,9 @@ fn py_create_governance_checkpoint(
     let merkle_root = parse_hex_32(merkle_root_hex, "merkle_root")?;
     let last_event_hash = parse_hex_32(last_event_hash_hex, "last_event_hash")?;
     let state_snapshot_hash = parse_hex_32(state_snapshot_hash_hex, "state_snapshot_hash")?;
-    let creator_signature = hex::decode(creator_signature_hex).map_err(|e| {
+    let creator_signature = Zeroizing::new(hex::decode(creator_signature_hex).map_err(|e| {
         PyValueError::new_err(format!("SCP-CTX-2062: invalid creator_signature hex: {e}"))
-    })?;
+    })?);
     let did = scp_identity::DID(creator_did.to_owned());
 
     rt.block_on(async move {
@@ -2392,7 +2394,7 @@ fn py_create_governance_checkpoint(
                 last_event_hash,
                 state_snapshot_hash,
                 &did,
-                creator_signature,
+                (*creator_signature).clone(),
             )
             .await
             .map_err(|e| {
@@ -2444,12 +2446,14 @@ fn py_add_checkpoint_cosignature(
             PyValueError::new_err(format!("SCP-CTX-2063: invalid checkpoint JSON: {e}"))
         })?;
 
-    let signature = hex::decode(signature_hex)
-        .map_err(|e| PyValueError::new_err(format!("SCP-CTX-2063: invalid signature hex: {e}")))?;
+    let signature =
+        Zeroizing::new(hex::decode(signature_hex).map_err(|e| {
+            PyValueError::new_err(format!("SCP-CTX-2063: invalid signature hex: {e}"))
+        })?);
 
     let cosignature = scp_core::context::governance::CosignedCheckpoint {
         signer_did: scp_identity::DID(signer_did.to_owned()),
-        signature,
+        signature: (*signature).clone(),
     };
 
     rt.block_on(async move {
@@ -3559,8 +3563,9 @@ pub fn py_metadata_record_to_json(
             crate::error::ScpPyError::validation(format!("invalid operational metadata JSON: {e}"))
         })?;
 
-    let signature = hex::decode(&signature_hex)
-        .map_err(|e| crate::error::ScpPyError::validation(format!("invalid signature hex: {e}")))?;
+    let signature = Zeroizing::new(hex::decode(&signature_hex).map_err(|e| {
+        crate::error::ScpPyError::validation(format!("invalid signature hex: {e}"))
+    })?);
     if signature.len() != 64 {
         return Err(crate::error::ScpPyError::validation(format!(
             "signature must be 64 bytes (got {})",
@@ -3576,7 +3581,7 @@ pub fn py_metadata_record_to_json(
         timestamp,
         structural,
         operational,
-        signature,
+        signature: (*signature).clone(),
     };
 
     serde_json::to_string(&record).map_err(|e| {

--- a/crates/scp-ffi/src/provenance.rs
+++ b/crates/scp-ffi/src/provenance.rs
@@ -20,6 +20,7 @@
 use pyo3::prelude::*;
 use pyo3::types::PyDict;
 use sha2::{Digest, Sha256};
+use zeroize::Zeroizing;
 
 use scp_core::context::MemoryScope;
 use scp_core::provenance::attach::{
@@ -259,10 +260,12 @@ pub fn py_provenance_pseudonymize_counterparties(
             code: "SCP-VALID-7050".to_string(),
         })?;
 
-    let key = hex::decode(pseudonym_key_hex).map_err(|e| ScpPyError::ValidationError {
-        message: format!("invalid pseudonym_key_hex: {e}"),
-        code: "SCP-VALID-7052".to_string(),
-    })?;
+    let key = Zeroizing::new(hex::decode(pseudonym_key_hex).map_err(|e| {
+        ScpPyError::ValidationError {
+            message: format!("invalid pseudonym_key_hex: {e}"),
+            code: "SCP-VALID-7052".to_string(),
+        }
+    })?);
 
     pseudonymize_counterparties(&mut prov, &key);
 

--- a/crates/scp-ffi/src/server.rs
+++ b/crates/scp-ffi/src/server.rs
@@ -271,20 +271,15 @@ impl PyNodeHandle {
     ) -> PyResult<()> {
         let rt = crate::runtime()?;
 
-        let key_bytes: Zeroizing<[u8; 32]> = Zeroizing::new(
-            hex::decode(&broadcast_key_hex)
-                .map_err(|e| {
-                    pyo3::exceptions::PyValueError::new_err(format!(
-                        "invalid broadcast_key_hex: {e}"
-                    ))
-                })?
-                .try_into()
-                .map_err(|_| {
-                    pyo3::exceptions::PyValueError::new_err(
-                        "broadcast_key_hex must be exactly 64 hex characters (32 bytes)",
-                    )
-                })?,
-        );
+        let key_vec = Zeroizing::new(hex::decode(&broadcast_key_hex).map_err(|e| {
+            pyo3::exceptions::PyValueError::new_err(format!("invalid broadcast_key_hex: {e}"))
+        })?);
+        let key_bytes: Zeroizing<[u8; 32]> =
+            Zeroizing::new(<[u8; 32]>::try_from(key_vec.as_slice()).map_err(|_| {
+                pyo3::exceptions::PyValueError::new_err(
+                    "broadcast_key_hex must be exactly 64 hex characters (32 bytes)",
+                )
+            })?);
 
         let broadcast_key = scp_core::crypto::sender_keys::BroadcastKey::from_parts(
             scp_core::crypto::sender_keys::SenderKey::from_bytes(*key_bytes),

--- a/crates/scp-ffi/uniffi/src/bridge.rs
+++ b/crates/scp-ffi/uniffi/src/bridge.rs
@@ -28,6 +28,7 @@ use std::fmt;
 use std::sync::{Arc, OnceLock};
 
 use sha2::Digest;
+use zeroize::Zeroizing;
 
 use scp_identity::DidCache;
 use scp_identity::IdentityError;
@@ -6972,10 +6973,12 @@ pub async fn create_governance_checkpoint(
     let last_event_hash = parse_uniffi_hex_32(&last_event_hash_hex, "last_event_hash")?;
     let state_snapshot_hash = parse_uniffi_hex_32(&state_snapshot_hash_hex, "state_snapshot_hash")?;
     let creator_signature =
-        hex::decode(&creator_signature_hex).map_err(|e| ScpError::Validation {
-            msg: format!("invalid creator_signature hex: {e}"),
-            code: "SCP-CTX-2062".to_owned(),
-        })?;
+        Zeroizing::new(
+            hex::decode(&creator_signature_hex).map_err(|e| ScpError::Validation {
+                msg: format!("invalid creator_signature hex: {e}"),
+                code: "SCP-CTX-2062".to_owned(),
+            })?,
+        );
     let did = scp_identity::DID(creator_did);
 
     runtime()
@@ -6990,7 +6993,7 @@ pub async fn create_governance_checkpoint(
                     last_event_hash,
                     state_snapshot_hash,
                     &did,
-                    creator_signature,
+                    (*creator_signature).clone(),
                 )
                 .await
                 .map_err(ScpError::from)?;
@@ -7031,14 +7034,17 @@ pub async fn add_checkpoint_cosignature(
             code: "SCP-CTX-2063".to_owned(),
         })?;
 
-    let signature = hex::decode(&signature_hex).map_err(|e| ScpError::Validation {
-        msg: format!("invalid signature hex: {e}"),
-        code: "SCP-CTX-2063".to_owned(),
-    })?;
+    let signature =
+        Zeroizing::new(
+            hex::decode(&signature_hex).map_err(|e| ScpError::Validation {
+                msg: format!("invalid signature hex: {e}"),
+                code: "SCP-CTX-2063".to_owned(),
+            })?,
+        );
 
     let cosignature = scp_core::context::governance::CosignedCheckpoint {
         signer_did: scp_identity::DID(signer_did),
-        signature,
+        signature: (*signature).clone(),
     };
 
     runtime()
@@ -9026,10 +9032,13 @@ pub fn provenance_pseudonymize_counterparties(
             code: "SCP-VALID-7050".to_owned(),
         })?;
 
-    let key = hex::decode(&pseudonym_key_hex).map_err(|e| ScpError::Validation {
-        msg: format!("invalid pseudonym_key_hex: {e}"),
-        code: "SCP-VALID-7052".to_owned(),
-    })?;
+    let key =
+        Zeroizing::new(
+            hex::decode(&pseudonym_key_hex).map_err(|e| ScpError::Validation {
+                msg: format!("invalid pseudonym_key_hex: {e}"),
+                code: "SCP-VALID-7052".to_owned(),
+            })?,
+        );
 
     scp_core::provenance::attach::pseudonymize_counterparties(&mut prov, &key);
 
@@ -11657,10 +11666,13 @@ pub fn metadata_record_to_json(
             code: "SCP-VALID-7001".to_owned(),
         })?;
 
-    let signature = hex::decode(&signature_hex).map_err(|e| ScpError::Validation {
-        msg: format!("invalid signature hex: {e}"),
-        code: "SCP-VALID-7001".to_owned(),
-    })?;
+    let signature =
+        Zeroizing::new(
+            hex::decode(&signature_hex).map_err(|e| ScpError::Validation {
+                msg: format!("invalid signature hex: {e}"),
+                code: "SCP-VALID-7001".to_owned(),
+            })?,
+        );
     if signature.len() != 64 {
         return Err(ScpError::Validation {
             msg: format!("signature must be 64 bytes (got {})", signature.len()),
@@ -11675,7 +11687,7 @@ pub fn metadata_record_to_json(
         timestamp,
         structural,
         operational,
-        signature,
+        signature: (*signature).clone(),
     };
 
     serde_json::to_string(&record).map_err(|e| ScpError::Validation {

--- a/crates/scp-ffi/uniffi/src/server.rs
+++ b/crates/scp-ffi/uniffi/src/server.rs
@@ -298,19 +298,21 @@ impl NodeHandle {
         deploy_retention_count: Option<u32>,
         csp_override: Option<String>,
     ) -> Result<(), ScpError> {
-        let key_bytes: Zeroizing<[u8; 32]> = Zeroizing::new(
-            hex::decode(&broadcast_key_hex)
-                .map_err(|e| ScpError::Validation {
+        let key_vec =
+            Zeroizing::new(
+                hex::decode(&broadcast_key_hex).map_err(|e| ScpError::Validation {
                     msg: format!("invalid broadcast_key_hex: {e}"),
                     code: "SCP-TRANS-5060".to_owned(),
-                })?
-                .try_into()
-                .map_err(|_| ScpError::Validation {
+                })?,
+            );
+        let key_bytes: Zeroizing<[u8; 32]> =
+            Zeroizing::new(<[u8; 32]>::try_from(key_vec.as_slice()).map_err(|_| {
+                ScpError::Validation {
                     msg: "broadcast_key_hex must be exactly 64 hex characters (32 bytes)"
                         .to_owned(),
                     code: "SCP-TRANS-5060".to_owned(),
-                })?,
-        );
+                }
+            })?);
 
         let broadcast_key = scp_core::crypto::sender_keys::BroadcastKey::from_parts(
             scp_core::crypto::sender_keys::SenderKey::from_bytes(*key_bytes),

--- a/crates/scp-ffi/wasm/src/context.rs
+++ b/crates/scp-ffi/wasm/src/context.rs
@@ -11,6 +11,8 @@ use js_sys::Promise;
 use wasm_bindgen::prelude::*;
 use wasm_bindgen_futures::future_to_promise;
 
+use zeroize::Zeroizing;
+
 use scp_ffi_common::validate::validate_did;
 
 use crate::error::ScpWasmError;
@@ -954,13 +956,14 @@ pub fn context_create_governance_checkpoint(
         let last_event_hash = parse_wasm_hex_32(&last_event_hash_hex, "last_event_hash")?;
         let state_snapshot_hash =
             parse_wasm_hex_32(&state_snapshot_hash_hex, "state_snapshot_hash")?;
-        let creator_signature = hex::decode(&creator_signature_hex).map_err(|e| {
-            ScpWasmError::Validation {
-                message: format!("invalid creator_signature hex: {e}"),
-                code: "SCP-CTX-2062".to_owned(),
-            }
-            .into_js()
-        })?;
+        let creator_signature =
+            Zeroizing::new(hex::decode(&creator_signature_hex).map_err(|e| {
+                ScpWasmError::Validation {
+                    message: format!("invalid creator_signature hex: {e}"),
+                    code: "SCP-CTX-2062".to_owned(),
+                }
+                .into_js()
+            })?);
 
         #[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
         let seq = checkpoint_seq as u64;
@@ -1020,13 +1023,13 @@ pub fn context_add_checkpoint_cosignature(
                 .into_js()
             })?;
 
-        let signature = hex::decode(&signature_hex).map_err(|e| {
+        let signature = Zeroizing::new(hex::decode(&signature_hex).map_err(|e| {
             ScpWasmError::Validation {
                 message: format!("invalid signature hex: {e}"),
                 code: "SCP-CTX-2063".to_owned(),
             }
             .into_js()
-        })?;
+        })?);
 
         let status = with_manager(|mgr| {
             mgr.add_checkpoint_cosignature(&context_id, &mut checkpoint, &signer_did, &signature)
@@ -2113,13 +2116,13 @@ pub fn metadata_record_to_json(
         .into_js()
     })?;
 
-    let signature = hex::decode(&signature_hex).map_err(|e| {
+    let signature = Zeroizing::new(hex::decode(&signature_hex).map_err(|e| {
         ScpWasmError::Validation {
             message: format!("invalid signature hex: {e}"),
             code: "SCP-VALID-7001".to_owned(),
         }
         .into_js()
-    })?;
+    })?);
     if signature.len() != 64 {
         return Err(ScpWasmError::Validation {
             message: format!("signature must be 64 bytes (got {})", signature.len()),
@@ -2137,7 +2140,7 @@ pub fn metadata_record_to_json(
         timestamp: ts,
         structural,
         operational,
-        signature,
+        signature: (*signature).clone(),
     };
 
     serde_json::to_string(&record).map_err(|e| {

--- a/crates/scp-ffi/wasm/src/provenance.rs
+++ b/crates/scp-ffi/wasm/src/provenance.rs
@@ -21,6 +21,7 @@
 
 use sha2::Digest;
 use wasm_bindgen::prelude::*;
+use zeroize::Zeroizing;
 
 // ---------------------------------------------------------------------------
 // Constants (mirror scp-core::provenance::attach)
@@ -501,8 +502,10 @@ pub fn provenance_pseudonymize_counterparties(
     let mut parsed: serde_json::Value = serde_json::from_str(&provenance_json)
         .map_err(|e| JsError::new(&format!("[SCP-VALID-7050] invalid provenance JSON: {e}")))?;
 
-    let key = hex::decode(&pseudonym_key_hex)
-        .map_err(|e| JsError::new(&format!("[SCP-VALID-7052] invalid pseudonym_key_hex: {e}")))?;
+    let key =
+        Zeroizing::new(hex::decode(&pseudonym_key_hex).map_err(|e| {
+            JsError::new(&format!("[SCP-VALID-7052] invalid pseudonym_key_hex: {e}"))
+        })?);
 
     let context_id = parsed
         .get("source_context")


### PR DESCRIPTION
Closes #1358

Wraps all `hex::decode` results for key material in `Zeroizing` across all 4 FFI bridges.

- Signatures (checkpoint, cosignature, metadata): all bridges
- Provenance pseudonym key: all bridges
- Broadcast encryption key: PyO3, NAPI, UniFFI
- Bridge credential key: documented limitation (SAFETY comments)
- Hash/nonce decodes correctly excluded (not secret)

Reviewed: security LGTM. No findings.

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>