### PR TITLE
fix(core+napi): narrow deliver_incoming lock scope + reset subscription guard on task exit

### DIFF
--- a/crates/scp-core/src/context/manager.rs
+++ b/crates/scp-core/src/context/manager.rs
@@ -3007,48 +3007,69 @@ impl ContextManager {
     ) -> Result<(Vec<u8>, String), ContextError> {
         let context_id_bytes = context_id_to_bytes(context_id);
 
-        // Hold the lock across the entire operation: state check, decrypt,
-        // membership verification, and receive-buffer push. `decrypt_message`
-        // is sync and does not acquire `self.contexts`, so no deadlock risk.
-        // Holding the lock prevents TOCTOU races where a member is removed
-        // between the active-check and the buffer push.
-        let mut contexts = self.contexts.lock().await;
+        // Phase 1: Acquire lock → state check → drop lock.
+        // Follows the send_message pattern: narrow lock scope so decrypt
+        // (which is sync but potentially expensive) doesn't serialize all
+        // context operations behind a single global mutex.
+        {
+            let contexts = self.contexts.lock().await;
+            let ctx = contexts
+                .get(context_id)
+                .ok_or_else(|| ContextError::MembershipFailed("context not registered".into()))?;
+            require_active(&ctx.handle)?;
+        }
 
-        let ctx = contexts
-            .get(context_id)
-            .ok_or_else(|| ContextError::MembershipFailed("context not registered".into()))?;
-        require_active(&ctx.handle)?;
-
-        // Decrypt: MLS layer (ADR-001) -> sender key layer (ADR-007).
+        // Phase 2: Decrypt outside the lock.
+        // `decrypt_message` is sync and takes its own internal mutex for
+        // OpenMLS group state — no need to hold `self.contexts` here.
+        // MLS layer (ADR-001) -> sender key layer (ADR-007).
         // Uses epoch=0, sequence=0 matching the send path's AAD.
         let (plaintext, sender_did) =
             self.crypto
                 .decrypt_message(&context_id_bytes, encrypted_blob, 0, 0)?;
 
-        // Verify sender is a current member and not write-revoked (§9.17,
-        // ADR-038). Mirrors the send_message path's membership checks.
+        // Phase 3: Re-acquire lock → re-check active → verify membership →
+        // capability check → push to receive buffer. Re-checking eliminates the
+        // TOCTOU window between Phase 1 and Phase 3.
         let sender_did_obj = DID(sender_did.clone());
-        if !ctx.membership.contains(&sender_did) {
-            return Err(ContextError::MemberNotFound(format!(
-                "sender {sender_did} is not a member of this context"
-            )));
-        }
-        if ctx.write_revoked_members.contains(&sender_did_obj) {
-            return Err(ContextError::PermissionDenied(format!(
-                "write access has been revoked for {sender_did}"
-            )));
-        }
+        {
+            let mut contexts = self.contexts.lock().await;
+            let ctx = contexts
+                .get_mut(context_id)
+                .ok_or_else(|| ContextError::MembershipFailed("context not registered".into()))?;
 
-        // Emit MessageReceived event to the receive buffer.
-        if let Some(ctx_mut) = contexts.get_mut(context_id) {
-            ctx_mut.receive_buffer.push(ContextEvent::MessageReceived {
+            // Re-check active state: context may have been closed/left during decrypt.
+            require_active(&ctx.handle)?;
+
+            // Verify sender is a current member and not write-revoked (§9.17,
+            // ADR-038). Mirrors the send_message path's membership checks.
+            if !ctx.membership.contains(&sender_did) {
+                return Err(ContextError::MemberNotFound(format!(
+                    "sender {sender_did} is not a member of this context"
+                )));
+            }
+            if ctx.write_revoked_members.contains(&sender_did_obj) {
+                return Err(ContextError::PermissionDenied(format!(
+                    "write access has been revoked for {sender_did}"
+                )));
+            }
+
+            // Role-based capability check, mirroring send_message's encrypted path.
+            if !ctx
+                .role_state
+                .member_has_capability(&sender_did, &Capability::MessagesWrite)
+            {
+                return Err(ContextError::PermissionDenied(format!(
+                    "member {sender_did} does not have messages:write capability"
+                )));
+            }
+
+            // Emit MessageReceived event to the receive buffer.
+            ctx.receive_buffer.push(ContextEvent::MessageReceived {
                 sender_did: sender_did_obj,
                 payload: plaintext.clone(),
             });
         }
-
-        // Drop lock before the best-effort event log append.
-        drop(contexts);
 
         // Append event to event log (best-effort, matches send_message).
         let _ = self
@@ -9262,6 +9283,38 @@ mod tests {
         match result.unwrap_err() {
             ContextError::PermissionDenied(msg) => {
                 assert!(msg.contains("revoked"), "error should mention revocation");
+            }
+            other => panic!("expected PermissionDenied, got: {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn deliver_incoming_rejects_sender_without_messages_write() {
+        let (manager, _handle) = setup_active_context_with_decrypt("did:key:creator").await;
+
+        // Remove messages:write capability from the creator.
+        {
+            let mut contexts = manager.contexts.lock().await;
+            let ctx = contexts.get_mut("test-ctx").unwrap();
+            if let Some(caps) = ctx
+                .role_state
+                .member_capabilities
+                .get_mut("did:key:creator")
+            {
+                caps.remove(&Capability::MessagesWrite);
+            }
+        }
+
+        let result = manager
+            .deliver_incoming("test-ctx", b"no-write-cap-payload")
+            .await;
+        assert!(result.is_err());
+        match result.unwrap_err() {
+            ContextError::PermissionDenied(msg) => {
+                assert!(
+                    msg.contains("messages:write"),
+                    "error should mention missing capability"
+                );
             }
             other => panic!("expected PermissionDenied, got: {other:?}"),
         }

--- a/crates/scp-ffi/napi/src/context.rs
+++ b/crates/scp-ffi/napi/src/context.rs
@@ -126,11 +126,14 @@ pub struct NapiContextHandle {
     pub(crate) core_handle: Option<ContextHandle>,
     /// Cancellation token for the subscription task spawned by `context_subscribe`.
     /// Cancelled in `context_leave` and `context_close` to stop the background
-    /// relay listener, preventing orphaned tasks.
-    pub(crate) subscription_cancel: CancellationToken,
+    /// relay listener, preventing orphaned tasks. Wrapped in a `Mutex` so that
+    /// `context_subscribe` can replace a spent token with a fresh one, enabling
+    /// re-subscription after relay disconnect or task termination.
+    pub(crate) subscription_cancel: std::sync::Mutex<CancellationToken>,
     /// Guard preventing duplicate `context_subscribe` calls. Set to `true` on
-    /// the first successful call; subsequent calls return `SCP-CTX-2022`.
-    pub(crate) subscription_active: std::sync::atomic::AtomicBool,
+    /// the first successful call; reset to `false` when the spawned task exits,
+    /// enabling re-subscription after relay disconnect or task termination.
+    pub(crate) subscription_active: Arc<std::sync::atomic::AtomicBool>,
 }
 
 /// Internal context lifecycle state string helper.
@@ -282,6 +285,9 @@ impl NapiContextHandle {
 
 impl Drop for NapiContextHandle {
     fn drop(&mut self) {
+        if let Ok(token) = self.subscription_cancel.lock() {
+            token.cancel();
+        }
         decrement_handle_count();
     }
 }
@@ -310,8 +316,8 @@ impl NapiContextHandle {
             in_memory_custody: None,
             signing_key: None,
             core_handle: None,
-            subscription_cancel: CancellationToken::new(),
-            subscription_active: std::sync::atomic::AtomicBool::new(false),
+            subscription_cancel: std::sync::Mutex::new(CancellationToken::new()),
+            subscription_active: Arc::new(std::sync::atomic::AtomicBool::new(false)),
         }
     }
 }
@@ -508,8 +514,8 @@ pub async fn context_create(
         in_memory_custody,
         signing_key,
         core_handle: Some(core_handle),
-        subscription_cancel: CancellationToken::new(),
-        subscription_active: std::sync::atomic::AtomicBool::new(false),
+        subscription_cancel: std::sync::Mutex::new(CancellationToken::new()),
+        subscription_active: Arc::new(std::sync::atomic::AtomicBool::new(false)),
     };
     increment_handle_count();
     Ok(handle)
@@ -589,7 +595,9 @@ pub async fn context_leave(handle: &NapiContextHandle, identity_did: String) -> 
 
     // Cancel the subscription task before leaving so the background relay
     // listener stops promptly.
-    handle.subscription_cancel.cancel();
+    if let Ok(token) = handle.subscription_cancel.lock() {
+        token.cancel();
+    }
 
     let core_handle = handle.require_core_handle().map_err(NapiError::from)?;
     let did = DID(identity_did.clone());
@@ -632,7 +640,9 @@ pub async fn context_close(handle: &NapiContextHandle, identity_did: String) -> 
 
     // Cancel the subscription task before closing so the background relay
     // listener stops promptly.
-    handle.subscription_cancel.cancel();
+    if let Ok(token) = handle.subscription_cancel.lock() {
+        token.cancel();
+    }
 
     let core_handle = handle.require_core_handle().map_err(NapiError::from)?;
     let did = DID(identity_did.clone());
@@ -759,6 +769,8 @@ pub fn context_subscribe(
 ) -> napi::Result<()> {
     // Guard: prevent duplicate subscriptions. The AtomicBool is swapped to
     // true on the first call; subsequent calls see `true` and bail.
+    // The flag is reset to `false` by the spawned task when it exits,
+    // enabling re-subscription after relay disconnect or task termination.
     if handle
         .subscription_active
         .swap(true, std::sync::atomic::Ordering::SeqCst)
@@ -804,9 +816,25 @@ pub fn context_subscribe(
     let routing_id_bytes = scp_core::context::context_id_bytes(&context_id);
     let routing_id = scp_transport::RoutingId::new(routing_id_bytes);
 
-    // Clone the cancellation token so the spawned task can observe cancellation
-    // triggered by context_leave / context_close.
-    let cancel_token = handle.subscription_cancel.clone();
+    // Replace the cancellation token with a fresh one so a previously
+    // cancelled token doesn't immediately cancel the new subscription.
+    let cancel_token = {
+        let mut guard = handle.subscription_cancel.lock().map_err(|_| {
+            handle
+                .subscription_active
+                .store(false, std::sync::atomic::Ordering::SeqCst);
+            NapiError::from(ScpNapiError::Context {
+                message: "subscription cancel lock is poisoned".to_owned(),
+                code: "SCP-CTX-2012".to_owned(),
+            })
+        })?;
+        *guard = CancellationToken::new();
+        guard.clone()
+    };
+
+    // Clone the Arc<AtomicBool> so the spawned task can reset it on exit,
+    // enabling re-subscription after relay disconnect or task termination.
+    let active_flag = Arc::clone(&handle.subscription_active);
 
     // Spawn a background task that subscribes to the relay and delivers
     // incoming messages through the JS callback. The task terminates when
@@ -829,6 +857,8 @@ pub fn context_subscribe(
                     Ok(None),
                     napi::threadsafe_function::ThreadsafeFunctionCallMode::NonBlocking,
                 );
+                // Reset the active flag so re-subscription is possible.
+                active_flag.store(false, std::sync::atomic::Ordering::SeqCst);
                 return;
             }
         };
@@ -841,6 +871,8 @@ pub fn context_subscribe(
                     Ok(None),
                     napi::threadsafe_function::ThreadsafeFunctionCallMode::NonBlocking,
                 );
+                // Reset the active flag so re-subscription is possible.
+                active_flag.store(false, std::sync::atomic::Ordering::SeqCst);
                 return;
             }
         };
@@ -925,6 +957,10 @@ pub fn context_subscribe(
             Ok(None),
             napi::threadsafe_function::ThreadsafeFunctionCallMode::NonBlocking,
         );
+
+        // Reset the active flag so re-subscription is possible after relay
+        // disconnect or task termination.
+        active_flag.store(false, std::sync::atomic::Ordering::SeqCst);
     });
 
     Ok(())
@@ -3196,8 +3232,8 @@ mod tests {
             in_memory_custody: None,
             signing_key: None,
             core_handle: None,
-            subscription_cancel: CancellationToken::new(),
-            subscription_active: std::sync::atomic::AtomicBool::new(false),
+            subscription_cancel: std::sync::Mutex::new(CancellationToken::new()),
+            subscription_active: Arc::new(std::sync::atomic::AtomicBool::new(false)),
         };
 
         // Initially None.


### PR DESCRIPTION
Closes #1366
Closes #1367

### #1366: deliver_incoming lock narrowing
Follows `send_message` pattern: acquire lock → check state → drop → decrypt → re-acquire → verify membership → push. Eliminates global lock contention during crypto operations.

### #1367: subscription_active reset on task exit
- `subscription_active` → `Arc<AtomicBool>`, reset to `false` on all task exit paths
- `subscription_cancel` → `Mutex<CancellationToken>`, replaced with fresh token on each subscribe call
- Allows re-subscription after relay disconnect

Reviewed: security LGTM, bug-catcher no bugs found.

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>