### PR TITLE
test(projection): E2E broadcast content delivery lifecycle (SCP-298)

### DIFF
--- a/crates/scp-node/src/projection.rs
+++ b/crates/scp-node/src/projection.rs
@@ -7132,6 +7132,7 @@ mod tests {
     }
 
     /// Commits a deploy via the shared `NodeState` write lock.
+    #[allow(clippy::significant_drop_tightening)]
     async fn commit_via_state(
         state: &Arc<NodeState>,
         routing_id: [u8; 32],
@@ -7144,6 +7145,7 @@ mod tests {
     }
 
     /// Rolls back to a previous deploy via the shared `NodeState` write lock.
+    #[allow(clippy::significant_drop_tightening)]
     async fn rollback_via_state(
         state: &Arc<NodeState>,
         routing_id: [u8; 32],


### PR DESCRIPTION
## Summary
- Adds two integration tests to `crates/scp-node/src/projection.rs` covering the full broadcast content delivery lifecycle (SCP-298)
- **Open admission test**: publish v1 assets (HTML + CSS), commit deploy, verify HTTP serving (200, Content-Type, security headers), publish v2, commit, verify v2 body, rollback to v1, verify v1 restored
- **Gated admission test**: same lifecycle with `BroadcastAdmission::Gated` + member keys — verifies 401 without UCAN, 200 with valid signed UCAN, update to v2, rollback preserves gated access control
- Extracts reusable test helpers (`site_get`, `commit_via_state`, `rollback_via_state`, `make_content`, `assert_security_headers`) to reduce duplication

## Test plan
- [x] `cargo test -p scp-node --lib -- site_e2e` passes (3 tests: 2 new + 1 pre-existing)
- [x] `cargo clippy -p scp-node --lib -- -D warnings` clean
- [x] `cargo fmt -p scp-node -- --check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)