### PR TITLE
fix: address ADR-043 totality review findings

### DIFF
--- a/.docs/specs/09-security-model.md
+++ b/.docs/specs/09-security-model.md
@@ -1687,6 +1687,12 @@ This section consolidates all HKDF labels, HPKE info prefixes, HMAC domain strin
 | Default key package min buffer | 10 | Minimum MLS key packages to keep available | §9.7 |
 | Key package replenish threshold | 5 | Trigger replenishment when buffer drops below this | §9.7 |
 
+#### 9.18.17 External Constraints
+
+| Constant | Value | Notes | Spec Reference |
+|----------|-------|-------|----------------|
+| DHT republish interval | 7200s (2h) | External constraint (BEP44 expiry). Not configurable — the DHT requires periodic republishing within its expiry window. | §3.3 |
+
 ### 9.18.B Configurable Parameters
 
 The following constants have protocol-defined mechanisms and acceptable ranges, but the actual value is set by the context creator, relay operator, or deployer. Defaults are provided for when no explicit value is configured. Per ADR-043.
@@ -1698,7 +1704,6 @@ The following constants have protocol-defined mechanisms and acceptable ranges, 
 | Session cap per caller | 1000 | [1, u32 max] | `ContextParams::session_cap`. `None` = use default. | §6.2.1 |
 | Relay blob TTL | 604,800s (7d) | [1, infinity] | Relay operator configuration. | §10.5 |
 | Relay republish interval | Derived: `max(ttl - 86400, ttl / 2, 60)` | Derived from TTL | Computed from relay blob TTL. Floor of 60s prevents spin loop at very small TTLs. | §10.5 |
-| DHT republish interval | 7200s (2h) | Fixed (BEP44) | BEP44 constraint. Listed here because the value is externally imposed, but functionally invariant. | §3.3 |
 
 ### 9.18.C Implementation Recommendations
 

--- a/bindings/typescript/src/types.ts
+++ b/bindings/typescript/src/types.ts
@@ -39,6 +39,12 @@ export interface ContextParams {
    * Omit for default SCP/1.0 baseline.
    */
   readonly minProtocolVersion?: readonly [number, number];
+  /** Maximum cross-context chain depth (ADR-043). Default 8, range [1, 255]. */
+  readonly maxChainDepth?: number;
+  /** Maximum context nesting depth (§5.13.8). Omit for unbounded. */
+  readonly maxNestingDepth?: number;
+  /** Per-caller session cap (§6.2.1). Default 1000. */
+  readonly sessionCap?: number;
 }
 
 // ---------------------------------------------------------------------------

--- a/crates/scp-ffi/napi/src/provenance.rs
+++ b/crates/scp-ffi/napi/src/provenance.rs
@@ -110,21 +110,29 @@ pub fn provenance_attach(
         counterparty_policy: cp,
     };
 
-    #[allow(clippy::cast_possible_truncation)]
-    let existing_prov = existing_chain_depth.map(|depth| DataProvenance {
-        source_context: String::new(),
-        source_type: SourceType::Persistent,
-        counterparties: vec![],
-        purpose: None,
-        discovery_method: DiscoveryMethod::OutOfBand,
-        age: std::time::Duration::from_secs(0),
-        memory_scope: MemoryScope::Full,
-        chain_depth: depth as u8,
-        chain_path: None,
-        payment_amount: None,
-        payment_adapter: None,
-        payment_receipt_id: None,
-    });
+    let existing_prov = existing_chain_depth
+        .map(|depth| -> napi::Result<DataProvenance> {
+            let chain_depth = u8::try_from(depth).map_err(|_| {
+                napi::Error::from_reason(format!(
+                    "existing_chain_depth {depth} exceeds u8 range (max 255)"
+                ))
+            })?;
+            Ok(DataProvenance {
+                source_context: String::new(),
+                source_type: SourceType::Persistent,
+                counterparties: vec![],
+                purpose: None,
+                discovery_method: DiscoveryMethod::OutOfBand,
+                age: std::time::Duration::from_secs(0),
+                memory_scope: MemoryScope::Full,
+                chain_depth,
+                chain_path: None,
+                payment_amount: None,
+                payment_adapter: None,
+                payment_receipt_id: None,
+            })
+        })
+        .transpose()?;
 
     let prov = attach_provenance(
         &source_info,
@@ -210,12 +218,21 @@ pub fn provenance_attach(
 ///
 /// Returns `true` if within limit, `false` otherwise.
 #[napi]
-#[must_use]
-pub fn provenance_check_chain_depth(chain_depth: u32, max_depth: Option<u32>) -> bool {
-    #[allow(clippy::cast_possible_truncation)]
-    let depth = chain_depth as u8;
-    #[allow(clippy::cast_possible_truncation)]
-    let max = max_depth.map_or(DEFAULT_MAX_CHAIN_DEPTH, |d| d as u8);
+pub fn provenance_check_chain_depth(
+    chain_depth: u32,
+    max_depth: Option<u32>,
+) -> napi::Result<bool> {
+    let depth = u8::try_from(chain_depth).map_err(|_| {
+        napi::Error::from_reason(format!(
+            "chain_depth {chain_depth} exceeds u8 range (max 255)"
+        ))
+    })?;
+    let max = match max_depth {
+        Some(d) => u8::try_from(d).map_err(|_| {
+            napi::Error::from_reason(format!("max_depth {d} exceeds u8 range (max 255)"))
+        })?,
+        None => DEFAULT_MAX_CHAIN_DEPTH,
+    };
     let prov = DataProvenance {
         source_context: String::new(),
         source_type: SourceType::Persistent,
@@ -230,7 +247,7 @@ pub fn provenance_check_chain_depth(chain_depth: u32, max_depth: Option<u32>) ->
         payment_adapter: None,
         payment_receipt_id: None,
     };
-    check_chain_depth(&prov, max).is_ok()
+    Ok(check_chain_depth(&prov, max).is_ok())
 }
 
 /// Redacts counterparties from a provenance record (§24.3.5).
@@ -511,14 +528,20 @@ mod tests {
 
     #[test]
     fn check_chain_depth_within_limit() {
-        assert!(provenance_check_chain_depth(0, None));
-        assert!(provenance_check_chain_depth(8, None)); // default is 8 (ADR-043)
+        assert!(provenance_check_chain_depth(0, None).unwrap());
+        assert!(provenance_check_chain_depth(8, None).unwrap()); // default is 8 (ADR-043)
     }
 
     #[test]
     fn check_chain_depth_exceeds_limit() {
-        assert!(!provenance_check_chain_depth(9, None)); // 9 > default 8
-        assert!(!provenance_check_chain_depth(2, Some(1)));
+        assert!(!provenance_check_chain_depth(9, None).unwrap()); // 9 > default 8
+        assert!(!provenance_check_chain_depth(2, Some(1)).unwrap());
+    }
+
+    #[test]
+    fn check_chain_depth_rejects_out_of_u8_range() {
+        assert!(provenance_check_chain_depth(256, None).is_err());
+        assert!(provenance_check_chain_depth(0, Some(256)).is_err());
     }
 
     #[test]

--- a/crates/scp-ffi/wasm/src/context.rs
+++ b/crates/scp-ffi/wasm/src/context.rs
@@ -2412,7 +2412,7 @@ fn wasm_template_params(template_id: &str) -> Result<serde_json::Value, JsError>
             "memory_scope": mem, "governance": gov, "template_id": null,
             "economic_policy": null, "metadata_visibility": vis,
             "projection_policy": proj, "discoverable": disc,
-            "max_chain_depth": null, "max_nesting_depth": null, "session_cap": null,
+            "maxChainDepth": null, "maxNestingDepth": null, "sessionCap": null,
             "counterparty_policy": default_cp,
             "participation_requirements": [],
             "incomplete_verification_policy": "AllowWithWarning",

--- a/crates/scp-ffi/wasm/src/manager.rs
+++ b/crates/scp-ffi/wasm/src/manager.rs
@@ -1858,9 +1858,9 @@ impl WasmContextManager {
             .params_json
             .get("maxChainDepth")
             .and_then(serde_json::Value::as_u64)
-            .and_then(|v| u32::try_from(v).ok())
+            .and_then(|v| u8::try_from(v).ok())
             .unwrap_or(crate::provenance::DEFAULT_MAX_CHAIN_DEPTH);
-        if u32::from(chain_depth) > max_chain_depth {
+        if chain_depth > max_chain_depth {
             return Err(ScpWasmError::Tool {
                 message: format!(
                     "cross-context chain depth {chain_depth} exceeds maximum {max_chain_depth}"

--- a/crates/scp-ffi/wasm/src/provenance.rs
+++ b/crates/scp-ffi/wasm/src/provenance.rs
@@ -28,7 +28,7 @@ use zeroize::Zeroizing;
 // ---------------------------------------------------------------------------
 
 /// Default maximum chain depth (8 hops, ADR-043).
-pub(crate) const DEFAULT_MAX_CHAIN_DEPTH: u32 = 8;
+pub(crate) const DEFAULT_MAX_CHAIN_DEPTH: u8 = 8;
 
 // ---------------------------------------------------------------------------
 // Local enums (mirror scp-core::provenance)
@@ -182,7 +182,7 @@ fn compute_quality(
 /// ```
 #[must_use]
 #[wasm_bindgen]
-pub fn provenance_check_chain_depth(depth: u32, max_depth_override: Option<u32>) -> bool {
+pub fn provenance_check_chain_depth(depth: u8, max_depth_override: Option<u8>) -> bool {
     let effective_max = max_depth_override.unwrap_or(DEFAULT_MAX_CHAIN_DEPTH);
     depth <= effective_max
 }


### PR DESCRIPTION
## Summary

Fixes 5 findings from the cross-layer totality review of ADR-043:

1. **WASM JSON keys** — param lookups use camelCase (`maxChainDepth`, `sessionCap`) matching TypeScript ContextParams and all other WASM param reads. Template builder also updated to camelCase for consistency.
2. **TypeScript ContextParams** — added `maxChainDepth`, `maxNestingDepth`, `sessionCap` optional fields so TS developers can configure context limits.
3. **WASM chain depth type** — `DEFAULT_MAX_CHAIN_DEPTH` changed from u32 to u8 matching scp-core. `provenance_check_chain_depth` signature updated.
4. **NAPI truncation** — replaced silent `as u8` casts with `u8::try_from()` + error propagation. Added out-of-range test.
5. **Spec §9.18** — moved DHT republish interval from §9.18.B (Configurable) to §9.18.A (Invariants) with "external constraint (BEP44)" note.

## Test plan
- [x] `cargo clippy --workspace --all-targets --features ...` — clean
- [x] `cargo test --workspace` — zero failures
- [x] `bun run check` (TypeScript) — clean
- [x] Review: bug-catcher full-scope → 1 finding (comment regression) → fixed → clean
- [ ] GitHub CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)