### PR TITLE
fix: joiner context handle, bidirectional test, decrypt_message Option return

### DIFF
--- a/bindings/python/tests/test_e2e_fullstack.py
+++ b/bindings/python/tests/test_e2e_fullstack.py
@@ -80,6 +80,33 @@ class TestAliceToBobEncryptedRoundtrip:
         assert bytes(decrypted) == plaintext
 
 
+class TestBobSendsAliceDecrypts:
+    """Bob sends a message and Alice decrypts it (bidirectional)."""
+
+    def test_bidirectional_roundtrip(self) -> None:
+        alice = _scp_core.py_fullstack_create_node("did:dht:z6MkAliceBidirPy")
+        bob = _scp_core.py_fullstack_create_node("did:dht:z6MkBobBidirPy")
+
+        ctx_id = _scp_core.py_fullstack_create_context(alice, "py-ctx-bidir", CEILING_JSON)
+
+        _scp_core.py_fullstack_add_member(alice, ctx_id, bob.did)
+        _scp_core.py_fullstack_join_from_welcome(bob, ctx_id)
+
+        # Sync sender keys so both nodes can decrypt each other's messages.
+        _scp_core.py_fullstack_sync_sender_keys(alice, bob, ctx_id)
+
+        # Bob sends a message.
+        plaintext = b"Hello from Bob via Python!"
+        ciphertext = _scp_core.py_fullstack_send_message(bob, ctx_id, plaintext)
+
+        # Ciphertext must differ from plaintext.
+        assert ciphertext != plaintext
+
+        # Alice decrypts Bob's message.
+        decrypted = _scp_core.py_fullstack_decrypt_message(alice, ctx_id, ciphertext, bob.did)
+        assert bytes(decrypted) == plaintext
+
+
 class TestThreePartyGroup:
     """Alice sends, Bob and Carol both decrypt the same ciphertext."""
 

--- a/bindings/typescript/tests/e2e-fullstack.test.ts
+++ b/bindings/typescript/tests/e2e-fullstack.test.ts
@@ -95,6 +95,44 @@ if (addon === null) {
       expect(Buffer.from(decrypted)).toEqual(plaintext);
     });
 
+    test("Bob sends, Alice decrypts (bidirectional)", () => {
+      const alice = napi.fullstackCreateNode("did:dht:z6MkAliceBidir");
+      const bob = napi.fullstackCreateNode("did:dht:z6MkBobBidir");
+
+      const ctxId = napi.fullstackCreateContext(
+        alice,
+        "test-ctx-bidir",
+        JSON.stringify({
+          ceiling: [
+            "messages:read",
+            "messages:write",
+            "role:assign",
+            "member:invite",
+            "member:remove",
+            "context:close",
+          ],
+          governance: "single_admin",
+        }),
+      );
+
+      napi.fullstackAddMember(alice, ctxId, bob.did);
+      napi.fullstackJoinFromWelcome(bob, ctxId);
+
+      // Sync sender keys so both nodes can decrypt each other's messages.
+      napi.fullstackSyncSenderKeys(alice, bob, ctxId);
+
+      // Bob sends a message.
+      const plaintext = Buffer.from("Hello from Bob!");
+      const ciphertext = napi.fullstackSendMessage(bob, ctxId, plaintext);
+
+      // Ciphertext must differ from plaintext.
+      expect(Buffer.from(ciphertext)).not.toEqual(plaintext);
+
+      // Alice decrypts Bob's message.
+      const decrypted = napi.fullstackDecryptMessage(alice, ctxId, ciphertext, bob.did);
+      expect(Buffer.from(decrypted)).toEqual(plaintext);
+    });
+
     test("three-party: Alice sends, Bob and Carol both decrypt", () => {
       const alice = napi.fullstackCreateNode("did:dht:z6MkAlice3Party");
       const bob = napi.fullstackCreateNode("did:dht:z6MkBob3Party");

--- a/crates/scp-core/src/context/builder.rs
+++ b/crates/scp-core/src/context/builder.rs
@@ -295,7 +295,9 @@ pub trait ContextCryptoProvider: Send + Sync {
     /// extract sender DID from the MLS credential, then sender key decrypt
     /// (ADR-007).
     ///
-    /// Returns `(plaintext, sender_did)` on success.
+    /// Returns `Ok(Some((plaintext, sender_did)))` for application messages,
+    /// or `Ok(None)` when the MLS message was a Commit or Proposal (processed
+    /// successfully but containing no application payload).
     ///
     /// `epoch` and `sequence` are the sender-key AAD values. For standard
     /// sender keys these are `(0, 0)` matching the encrypt path.
@@ -313,7 +315,7 @@ pub trait ContextCryptoProvider: Send + Sync {
         _ciphertext: &[u8],
         _epoch: u64,
         _sequence: u64,
-    ) -> Result<(Vec<u8>, String), ContextError> {
+    ) -> Result<Option<(Vec<u8>, String)>, ContextError> {
         Err(ContextError::CryptoFailed(
             "decrypt_message not supported by this provider".to_string(),
         ))

--- a/crates/scp-core/src/context/manager.rs
+++ b/crates/scp-core/src/context/manager.rs
@@ -3004,7 +3004,7 @@ impl ContextManager {
         &self,
         context_id: &str,
         encrypted_blob: &[u8],
-    ) -> Result<(Vec<u8>, String), ContextError> {
+    ) -> Result<Option<(Vec<u8>, String)>, ContextError> {
         let context_id_bytes = context_id_to_bytes(context_id);
 
         // Phase 1: Acquire lock → state check → drop lock.
@@ -3024,9 +3024,16 @@ impl ContextManager {
         // OpenMLS group state — no need to hold `self.contexts` here.
         // MLS layer (ADR-001) -> sender key layer (ADR-007).
         // Uses epoch=0, sequence=0 matching the send path's AAD.
-        let (plaintext, sender_did) =
-            self.crypto
-                .decrypt_message(&context_id_bytes, encrypted_blob, 0, 0)?;
+        let decrypted = self
+            .crypto
+            .decrypt_message(&context_id_bytes, encrypted_blob, 0, 0)?;
+
+        // Commit/Proposal messages have no application payload — the MLS epoch
+        // was advanced (Commit) or the proposal was cached (Proposal). Skip
+        // membership checks and buffer push.
+        let Some((plaintext, sender_did)) = decrypted else {
+            return Ok(None);
+        };
 
         // Phase 3: Re-acquire lock → re-check active → verify membership →
         // capability check → push to receive buffer. Re-checking eliminates the
@@ -3076,7 +3083,7 @@ impl ContextManager {
             .event_log
             .append_context_event(&context_id_bytes, "MessageReceived");
 
-        Ok((plaintext, sender_did))
+        Ok(Some((plaintext, sender_did)))
     }
 
     /// Returns the current member count for a context.
@@ -8539,14 +8546,14 @@ mod tests {
             ciphertext: &[u8],
             _epoch: u64,
             _sequence: u64,
-        ) -> Result<(Vec<u8>, String), ContextError> {
+        ) -> Result<Option<(Vec<u8>, String)>, ContextError> {
             self.decrypt_sender_did.as_ref().map_or_else(
                 || {
                     Err(ContextError::CryptoFailed(
                         "decrypt_message not configured in mock".to_owned(),
                     ))
                 },
-                |did| Ok((ciphertext.to_vec(), did.clone())),
+                |did| Ok(Some((ciphertext.to_vec(), did.clone()))),
             )
         }
 
@@ -9237,7 +9244,9 @@ mod tests {
             .await;
         assert!(result.is_ok());
 
-        let (plaintext, sender) = result.unwrap();
+        let (plaintext, sender) = result
+            .unwrap()
+            .expect("expected Some for application message");
         assert_eq!(plaintext, b"encrypted-payload");
         assert_eq!(sender, "did:key:creator");
 

--- a/crates/scp-core/src/crypto/mls/provider.rs
+++ b/crates/scp-core/src/crypto/mls/provider.rs
@@ -787,7 +787,7 @@ impl ContextCryptoProvider for MlsCryptoProvider {
         ciphertext: &[u8],
         epoch: u64,
         sequence: u64,
-    ) -> Result<(Vec<u8>, String), ContextError> {
+    ) -> Result<Option<(Vec<u8>, String)>, ContextError> {
         self.with_context(context_id, |state| {
             let ctx_str = hex::encode(context_id);
 
@@ -824,22 +824,18 @@ impl ContextCryptoProvider for MlsCryptoProvider {
                     )
                     .map_err(|e| ContextError::CryptoFailed(e.to_string()))?;
 
-                    Ok((plaintext, sender_did))
+                    Ok(Some((plaintext, sender_did)))
                 }
-                DecryptedContent::Commit { sender_did } => {
+                DecryptedContent::Commit { sender_did: _ } => {
                     // Commit messages advance the MLS epoch. `decrypt_with_sender_did`
                     // has already called `merge_staged_commit` to apply the epoch
-                    // change. Signal to the caller that no application payload exists.
-                    Err(ContextError::CryptoFailed(format!(
-                        "received MLS Commit from {sender_did} — epoch advanced, no application payload"
-                    )))
+                    // change. No application payload exists.
+                    Ok(None)
                 }
-                DecryptedContent::Proposal { sender_did } => {
+                DecryptedContent::Proposal { sender_did: _ } => {
                     // Proposals are cached by OpenMLS during process_message.
                     // No application payload to return.
-                    Err(ContextError::CryptoFailed(format!(
-                        "received MLS Proposal from {sender_did} — cached, no application payload"
-                    )))
+                    Ok(None)
                 }
             }
         })

--- a/crates/scp-ffi/napi/src/context.rs
+++ b/crates/scp-ffi/napi/src/context.rs
@@ -928,7 +928,7 @@ pub fn context_subscribe(
                         .deliver_incoming(&context_id, &envelope.encrypted_blob)
                         .await
                     {
-                        Ok((plaintext, sender_did)) => {
+                        Ok(Some((plaintext, sender_did))) => {
                             sequence_counter += 1.0;
                             #[allow(clippy::cast_precision_loss)]
                             let ts = scp_core::time::now_secs().map_or(0.0, |s| s as f64);
@@ -942,6 +942,14 @@ pub fn context_subscribe(
                             on_message.call(
                                 Ok(Some(msg)),
                                 napi::threadsafe_function::ThreadsafeFunctionCallMode::NonBlocking,
+                            );
+                        }
+                        Ok(None) => {
+                            // MLS Commit or Proposal — epoch advanced or proposal
+                            // cached, no application payload to deliver.
+                            tracing::debug!(
+                                context_id = %context_id,
+                                "MLS control message processed (Commit/Proposal) — no payload"
                             );
                         }
                         Err(e) => {

--- a/crates/scp-ffi/napi/src/testing.rs
+++ b/crates/scp-ffi/napi/src/testing.rs
@@ -12,6 +12,7 @@ use std::sync::{Arc, Mutex};
 
 use napi::bindgen_prelude::Buffer;
 use napi_derive::napi;
+use scp_core::context::builder::ContextCryptoProvider;
 use scp_core::context::governance::KeyResolver;
 use scp_core::context::{Capability, ContextHandle, ContextMode, ContextParams, context_id_bytes};
 use scp_testing::fullstack::{FullStackNetwork, FullStackNode};
@@ -193,18 +194,118 @@ pub fn fullstack_add_member(
 ///
 /// This is the joiner-side operation. The adder must have called
 /// `fullstack_add_member` first to deposit the Welcome and sender keys.
+///
+/// After joining, the context is registered on the joiner's `ContextManager`
+/// with a `ContextHandle`, enabling subsequent `fullstack_send_message` and
+/// `fullstack_remove_member` calls on this node.
 #[napi]
 pub fn fullstack_join_from_welcome(
     node: &NapiFullStackNode,
     context_id: String,
 ) -> napi::Result<()> {
     let ctx_bytes = context_id_bytes(&context_id);
+    let rt = crate::runtime();
+
+    // Step 1: Register the context on the joiner's ContextManager.
+    // This creates a throwaway MLS group + the joiner's own sender key +
+    // a PerContextState entry so send_message / leave_context work.
+    let params = ContextParams {
+        mode: ContextMode::Encrypted,
+        ceiling: vec![
+            Capability::MessagesRead,
+            Capability::MessagesWrite,
+            Capability::RoleAssign,
+            Capability::MemberInvite,
+            Capability::MemberRemove,
+            Capability::ContextClose,
+        ],
+        ..ContextParams::default()
+    };
+    let handle = rt
+        .block_on(node.inner.create_context(&context_id, params))
+        .map_err(|e| {
+            napi::Error::from(ScpNapiError::Context {
+                message: format!("failed to register context on joiner: {e}"),
+                code: "SCP-CTX-2055".to_owned(),
+            })
+        })?;
+
+    // Step 2: Replace the throwaway MLS group with the Welcome-derived one
+    // and pick up the adder's sender keys from the exchange.
     node.inner.join_from_welcome(&ctx_bytes).map_err(|e| {
         napi::Error::from(ScpNapiError::Crypto {
             message: format!("failed to join from Welcome: {e}"),
             code: "SCP-CRYPTO-4051".to_owned(),
         })
-    })
+    })?;
+
+    // Step 3: Store the handle so subsequent operations can retrieve it.
+    {
+        let mut handles = node
+            .handles
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        handles.insert(context_id, handle);
+    }
+
+    Ok(())
+}
+
+/// Synchronises sender keys between two nodes for a given context.
+///
+/// Each node distributes its own sender key to the other via the shared
+/// `KeyExchange`, then picks up the other's key. After this call, both
+/// nodes can encrypt and decrypt messages from each other.
+///
+/// Call this after `fullstack_join_from_welcome` to enable bidirectional
+/// messaging in tests.
+#[napi]
+pub fn fullstack_sync_sender_keys(
+    node_a: &NapiFullStackNode,
+    node_b: &NapiFullStackNode,
+    context_id: String,
+) -> napi::Result<()> {
+    let ctx_bytes = context_id_bytes(&context_id);
+    let did_a = node_a.inner.did.to_string();
+    let did_b = node_b.inner.did.to_string();
+
+    // A distributes to B, B distributes to A.
+    node_a
+        .inner
+        .crypto
+        .distribute_sender_key(&ctx_bytes, &did_b)
+        .map_err(|e| {
+            napi::Error::from(ScpNapiError::Crypto {
+                message: format!("failed to distribute sender key from A to B: {e}"),
+                code: "SCP-CRYPTO-4056".to_owned(),
+            })
+        })?;
+    node_b
+        .inner
+        .crypto
+        .distribute_sender_key(&ctx_bytes, &did_a)
+        .map_err(|e| {
+            napi::Error::from(ScpNapiError::Crypto {
+                message: format!("failed to distribute sender key from B to A: {e}"),
+                code: "SCP-CRYPTO-4057".to_owned(),
+            })
+        })?;
+
+    // Both pick up the other's key from the exchange.
+    node_a.inner.pickup_sender_keys(&ctx_bytes).map_err(|e| {
+        napi::Error::from(ScpNapiError::Crypto {
+            message: format!("failed to pick up sender keys for A: {e}"),
+            code: "SCP-CRYPTO-4058".to_owned(),
+        })
+    })?;
+    node_b.inner.pickup_sender_keys(&ctx_bytes).map_err(|e| {
+        napi::Error::from(ScpNapiError::Crypto {
+            message: format!("failed to pick up sender keys for B: {e}"),
+            code: "SCP-CRYPTO-4059".to_owned(),
+        })
+    })?;
+
+    Ok(())
 }
 
 /// Encrypts a message and returns the ciphertext.

--- a/crates/scp-ffi/src/testing.rs
+++ b/crates/scp-ffi/src/testing.rs
@@ -12,6 +12,7 @@ use std::sync::{Arc, Mutex};
 
 use pyo3::prelude::*;
 use pyo3::types::PyBytes;
+use scp_core::context::builder::ContextCryptoProvider;
 use scp_core::context::governance::KeyResolver;
 use scp_core::context::{Capability, ContextHandle, ContextMode, ContextParams, context_id_bytes};
 use scp_testing::fullstack::{FullStackNetwork, FullStackNode};
@@ -164,12 +165,102 @@ pub fn py_fullstack_add_member(
 }
 
 /// Joins a context by retrieving the Welcome from the shared `KeyExchange`.
+///
+/// After joining, the context is registered on the joiner's `ContextManager`
+/// with a `ContextHandle`, enabling subsequent `py_fullstack_send_message`
+/// and `py_fullstack_remove_member` calls on this node.
 #[pyfunction]
 pub fn py_fullstack_join_from_welcome(node: &PyFullStackNode, context_id: String) -> PyResult<()> {
     let ctx_bytes = context_id_bytes(&context_id);
+    let rt = crate::runtime()?;
+
+    // Step 1: Register the context on the joiner's ContextManager.
+    let params = ContextParams {
+        mode: ContextMode::Encrypted,
+        ceiling: vec![
+            Capability::MessagesRead,
+            Capability::MessagesWrite,
+            Capability::RoleAssign,
+            Capability::MemberInvite,
+            Capability::MemberRemove,
+            Capability::ContextClose,
+        ],
+        ..ContextParams::default()
+    };
+    let handle = rt
+        .block_on(node.inner.create_context(&context_id, params))
+        .map_err(|e| {
+            pyo3::exceptions::PyRuntimeError::new_err(format!(
+                "failed to register context on joiner: {e}"
+            ))
+        })?;
+
+    // Step 2: Replace the throwaway MLS group with the Welcome-derived one
+    // and pick up the adder's sender keys from the exchange.
     node.inner.join_from_welcome(&ctx_bytes).map_err(|e| {
         pyo3::exceptions::PyRuntimeError::new_err(format!("failed to join from Welcome: {e}"))
-    })
+    })?;
+
+    // Step 3: Store the handle.
+    {
+        let mut handles = node
+            .handles
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        handles.insert(context_id, handle);
+    }
+
+    Ok(())
+}
+
+/// Synchronises sender keys between two nodes for a given context.
+///
+/// Each node distributes its own sender key to the other via the shared
+/// `KeyExchange`, then picks up the other's key. After this call, both
+/// nodes can encrypt and decrypt messages from each other.
+#[pyfunction]
+pub fn py_fullstack_sync_sender_keys(
+    node_a: &PyFullStackNode,
+    node_b: &PyFullStackNode,
+    context_id: String,
+) -> PyResult<()> {
+    let ctx_bytes = context_id_bytes(&context_id);
+    let did_a = node_a.inner.did.to_string();
+    let did_b = node_b.inner.did.to_string();
+
+    // A distributes to B, B distributes to A.
+    node_a
+        .inner
+        .crypto
+        .distribute_sender_key(&ctx_bytes, &did_b)
+        .map_err(|e| {
+            pyo3::exceptions::PyRuntimeError::new_err(format!(
+                "failed to distribute sender key from A to B: {e}"
+            ))
+        })?;
+    node_b
+        .inner
+        .crypto
+        .distribute_sender_key(&ctx_bytes, &did_a)
+        .map_err(|e| {
+            pyo3::exceptions::PyRuntimeError::new_err(format!(
+                "failed to distribute sender key from B to A: {e}"
+            ))
+        })?;
+
+    // Both pick up the other's key.
+    node_a.inner.pickup_sender_keys(&ctx_bytes).map_err(|e| {
+        pyo3::exceptions::PyRuntimeError::new_err(format!(
+            "failed to pick up sender keys for A: {e}"
+        ))
+    })?;
+    node_b.inner.pickup_sender_keys(&ctx_bytes).map_err(|e| {
+        pyo3::exceptions::PyRuntimeError::new_err(format!(
+            "failed to pick up sender keys for B: {e}"
+        ))
+    })?;
+
+    Ok(())
 }
 
 /// Encrypts a message and returns the ciphertext as bytes.
@@ -269,6 +360,7 @@ pub fn register_testing(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(py_fullstack_create_context, m)?)?;
     m.add_function(wrap_pyfunction!(py_fullstack_add_member, m)?)?;
     m.add_function(wrap_pyfunction!(py_fullstack_join_from_welcome, m)?)?;
+    m.add_function(wrap_pyfunction!(py_fullstack_sync_sender_keys, m)?)?;
     m.add_function(wrap_pyfunction!(py_fullstack_send_message, m)?)?;
     m.add_function(wrap_pyfunction!(py_fullstack_decrypt_message, m)?)?;
     m.add_function(wrap_pyfunction!(py_fullstack_remove_member, m)?)?;

--- a/crates/scp-testing/src/fullstack/crypto.rs
+++ b/crates/scp-testing/src/fullstack/crypto.rs
@@ -197,6 +197,37 @@ impl E2eCryptoProvider {
         Ok(())
     }
 
+    /// Picks up any pending sender keys from the shared `KeyExchange`.
+    ///
+    /// This is the complement of `distribute_sender_key`: when another node
+    /// deposits its sender key for this node, calling `pickup_sender_keys`
+    /// retrieves and stores them locally so `decrypt_message` can find them.
+    ///
+    /// # Errors
+    ///
+    /// Returns `ContextError` if the lock is poisoned (shouldn't happen in
+    /// well-behaved tests).
+    pub fn pickup_sender_keys(&self, context_id: &[u8; 32]) -> Result<(), ContextError> {
+        let ctx_hex = Self::context_id_hex(context_id);
+        let sender_keys = {
+            let mut exchange = self
+                .exchange
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner);
+            exchange.take_sender_keys(&ctx_hex, &self.local_did)
+        };
+        if !sender_keys.is_empty() {
+            let mut store = self
+                .sender_keys
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner);
+            for (sender_did, key) in sender_keys {
+                store.set(&ctx_hex, &sender_did, key);
+            }
+        }
+        Ok(())
+    }
+
     /// Decrypts a message that was encrypted by `encrypt_message`.
     ///
     /// Performs the reverse: MLS decrypt → sender key decrypt.
@@ -417,9 +448,13 @@ impl ContextCryptoProvider for E2eCryptoProvider {
                 },
             );
 
-            // Deposit the commit for all existing members (not the new joiner).
+            // Deposit the commit for all existing members except the local
+            // node (the adder already merged the commit) and the new joiner
+            // (who receives the Welcome instead).
             for did in &existing_members {
-                exchange.deposit_commit(*context_id, did, commit_bytes.clone());
+                if did != &self.local_did {
+                    exchange.deposit_commit(*context_id, did, commit_bytes.clone());
+                }
             }
         }
 

--- a/crates/scp-testing/src/fullstack/node.rs
+++ b/crates/scp-testing/src/fullstack/node.rs
@@ -237,6 +237,18 @@ impl FullStackNode {
             .decrypt_message(context_id, ciphertext, sender_did, epoch, sequence)
     }
 
+    /// Picks up any pending sender keys from the shared `KeyExchange`.
+    ///
+    /// Call this after another node has distributed its sender key so this
+    /// node can decrypt messages from that sender.
+    ///
+    /// # Errors
+    ///
+    /// Propagates `ContextError` from the crypto provider.
+    pub fn pickup_sender_keys(&self, context_id: &[u8; 32]) -> Result<(), ContextError> {
+        self.crypto.pickup_sender_keys(context_id)
+    }
+
     /// Drains events from the `ContextManager`.
     pub async fn drain_events(&self, context_id: &str) -> Vec<ContextEvent> {
         self.manager.drain_events(context_id).await


### PR DESCRIPTION
Closes #1376
Closes #1377

## Summary

### Joiner handle + bidirectional test
- `fullstackJoinFromWelcome` now registers a ContextHandle so joiners can send/remove
- New "Bob sends, Alice decrypts" test in both TS and Python (bidirectional E2E)
- Fixed `E2eCryptoProvider::add_member` depositing commits to local (adder) node causing epoch mismatch

### decrypt_message Option return (#1377)
- `ContextCryptoProvider::decrypt_message` → `Result<Option<(Vec<u8>, String)>>`
- `None` = Commit/Proposal processed successfully, no application payload
- `deliver_incoming` returns `Ok(None)` for non-application messages
- NAPI `context_subscribe` logs at `debug` (not `warn`) for Commit/Proposal

### Receive buffer (#1376)
Already implemented — `ReceiveBuffer` has `DEFAULT_BUFFER_CAPACITY = 1000` with oldest-drop. No change needed.

Reviewed: security LGTM, bug-catcher no bugs found.

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>