### PR TITLE
fix(ffi): scrub ServerError internals, validate data_dir, deduplicate NodeInner

### DIFF
--- a/crates/scp-ffi/common/src/server.rs
+++ b/crates/scp-ffi/common/src/server.rs
@@ -9,7 +9,7 @@
 //! Gated behind the `server` feature. Not available for WASM (ADR-034).
 
 use std::net::SocketAddr;
-use std::path::Path;
+use std::path::{Component, Path};
 use std::sync::Arc;
 
 use scp_node::NodeError;
@@ -47,6 +47,73 @@ pub enum ServerError {
     /// The platform storage backend could not be initialized.
     #[error("platform error: {0}")]
     Platform(#[from] scp_platform::error::PlatformError),
+}
+
+impl ServerError {
+    /// Returns a sanitized message safe to expose to SDK consumers.
+    ///
+    /// Internal details (filesystem paths, OS error descriptions, permission
+    /// info) are stripped. Use `tracing::error!` with the full error for
+    /// server-side debugging before converting.
+    #[must_use]
+    pub fn user_message(&self) -> String {
+        match self {
+            Self::Relay(_) => "relay startup failed".to_owned(),
+            Self::Node(_) => "node startup failed".to_owned(),
+            Self::Storage(_) => "storage initialization failed".to_owned(),
+            Self::Io(_) => "I/O error during server operation".to_owned(),
+            Self::Platform(_) => "platform error during server operation".to_owned(),
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Data-directory validation
+// ---------------------------------------------------------------------------
+
+/// Validates a data directory path before use.
+///
+/// Rejects paths that:
+/// - Are empty
+/// - Contain `..` components (path traversal)
+/// - Exceed 4096 bytes
+/// - Contain null bytes
+///
+/// # Errors
+///
+/// Returns [`ServerError::Io`] with a descriptive message on validation failure.
+pub fn validate_data_dir(path: &Path) -> Result<(), ServerError> {
+    let os_str = path.as_os_str();
+    if os_str.is_empty() {
+        return Err(ServerError::Io(std::io::Error::new(
+            std::io::ErrorKind::InvalidInput,
+            "data directory path must not be empty",
+        )));
+    }
+    if os_str.len() > 4096 {
+        return Err(ServerError::Io(std::io::Error::new(
+            std::io::ErrorKind::InvalidInput,
+            "data directory path exceeds 4096 bytes",
+        )));
+    }
+    // Check for null bytes (encoded_bytes on Unix, to_string_lossy everywhere).
+    let lossy = path.to_string_lossy();
+    if lossy.contains('\0') {
+        return Err(ServerError::Io(std::io::Error::new(
+            std::io::ErrorKind::InvalidInput,
+            "data directory path contains null bytes",
+        )));
+    }
+    // Reject parent-directory components.
+    for component in path.components() {
+        if matches!(component, Component::ParentDir) {
+            return Err(ServerError::Io(std::io::Error::new(
+                std::io::ErrorKind::InvalidInput,
+                "data directory path must not contain '..' components",
+            )));
+        }
+    }
+    Ok(())
 }
 
 // ---------------------------------------------------------------------------
@@ -145,6 +212,7 @@ pub async fn start_relay_in_memory() -> Result<RunningRelay, ServerError> {
 /// [`ServerError::Storage`] if the database cannot be opened, or
 /// [`ServerError::Relay`] if the relay cannot bind.
 pub async fn start_relay_local(data_dir: &Path) -> Result<RunningRelay, ServerError> {
+    validate_data_dir(data_dir)?;
     std::fs::create_dir_all(data_dir)?;
     let db_path = data_dir.join("blobs.redb");
     let storage = BlobStorageBackend::redb(&db_path)?;
@@ -236,7 +304,8 @@ pub async fn start_node_local(
 
     type DevDidDht = DidDht<InMemoryDhtClient, SystemClock>;
 
-    // Ensure data directory exists.
+    // Validate and ensure data directory exists.
+    validate_data_dir(data_dir)?;
     std::fs::create_dir_all(data_dir)?;
 
     // File-backed protocol storage under <data_dir>/storage/.
@@ -277,6 +346,149 @@ pub async fn start_node_local(
         "application node started (local file-backed)"
     );
     Ok(node)
+}
+
+// ---------------------------------------------------------------------------
+// RunningNode — type-erased ApplicationNode wrapper (shared across bridges)
+// ---------------------------------------------------------------------------
+
+/// Type-erased wrapper over `ApplicationNode<S>` for the two concrete storage
+/// backends used by the shared server code.
+///
+/// `ApplicationNode<S>` is generic over `S: Storage`. The `Storage` trait uses
+/// RPITIT and is not object-safe, so we cannot use `dyn Storage`. Instead we
+/// use a closed enum over `InMemoryStorage` and `FilesystemStorage`.
+///
+/// This mirrors the pattern established by [`RunningRelay`] — shared in
+/// `scp-ffi-common` so each FFI bridge wraps this rather than duplicating the
+/// enum and its dispatch methods.
+pub enum RunningNode {
+    /// In-memory storage variant (ephemeral — suitable for tests/demos).
+    InMemory(scp_node::ApplicationNode<InMemoryStorage>),
+    /// Filesystem-backed storage variant (persistent — suitable for local dev).
+    Filesystem(scp_node::ApplicationNode<scp_platform::filesystem::FilesystemStorage>),
+}
+
+impl RunningNode {
+    /// Returns the WebSocket URL clients should connect to for this node's relay.
+    #[must_use]
+    pub fn relay_url(&self) -> &str {
+        match self {
+            Self::InMemory(n) => n.relay_url(),
+            Self::Filesystem(n) => n.relay_url(),
+        }
+    }
+
+    /// Returns the node's DID string.
+    #[must_use]
+    pub fn did(&self) -> &str {
+        match self {
+            Self::InMemory(n) => n.identity().did(),
+            Self::Filesystem(n) => n.identity().did(),
+        }
+    }
+
+    /// Returns the port the node's relay is listening on.
+    #[must_use]
+    pub const fn relay_port(&self) -> u16 {
+        match self {
+            Self::InMemory(n) => n.relay().bound_addr().port(),
+            Self::Filesystem(n) => n.relay().bound_addr().port(),
+        }
+    }
+
+    /// Returns `true` if shutdown has already been signaled.
+    #[must_use]
+    pub fn is_shutdown(&self) -> bool {
+        match self {
+            Self::InMemory(n) => n.relay().shutdown_handle().is_shutdown(),
+            Self::Filesystem(n) => n.relay().shutdown_handle().is_shutdown(),
+        }
+    }
+
+    /// Signals the node to stop (relay + background tasks).
+    pub fn shutdown(&self) {
+        match self {
+            Self::InMemory(n) => n.shutdown(),
+            Self::Filesystem(n) => n.shutdown(),
+        }
+    }
+
+    /// Activates HTTP broadcast projection with optional site configuration.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`NodeError`] if projection activation fails.
+    pub async fn enable_broadcast_projection_with_site(
+        &self,
+        context_id: &str,
+        broadcast_key: scp_core::crypto::sender_keys::BroadcastKey,
+        admission: scp_core::context::broadcast::BroadcastAdmission,
+        site_config: Option<scp_node::projection::SiteConfig>,
+    ) -> Result<(), NodeError> {
+        match self {
+            Self::InMemory(n) => {
+                n.enable_broadcast_projection_with_site(
+                    context_id,
+                    broadcast_key,
+                    admission,
+                    None,
+                    site_config,
+                )
+                .await
+            }
+            Self::Filesystem(n) => {
+                n.enable_broadcast_projection_with_site(
+                    context_id,
+                    broadcast_key,
+                    admission,
+                    None,
+                    site_config,
+                )
+                .await
+            }
+        }
+    }
+
+    /// Commits a deploy for a projected context.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`NodeError`] if the context is not projected or commit fails.
+    pub async fn commit_deploy(
+        &self,
+        context_id: &str,
+        deploy_id: &str,
+    ) -> Result<usize, NodeError> {
+        match self {
+            Self::InMemory(n) => n.commit_deploy(context_id, deploy_id).await,
+            Self::Filesystem(n) => n.commit_deploy(context_id, deploy_id).await,
+        }
+    }
+
+    /// Rolls back to a previous deploy for a projected context.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`NodeError`] if the context is not projected or rollback fails.
+    pub async fn rollback_deploy(
+        &self,
+        context_id: &str,
+        deploy_id: &str,
+    ) -> Result<(), NodeError> {
+        match self {
+            Self::InMemory(n) => n.rollback_deploy(context_id, deploy_id).await,
+            Self::Filesystem(n) => n.rollback_deploy(context_id, deploy_id).await,
+        }
+    }
+
+    /// Deactivates HTTP broadcast projection for the given context.
+    pub async fn disable_broadcast_projection(&self, context_id: &str) {
+        match self {
+            Self::InMemory(n) => n.disable_broadcast_projection(context_id).await,
+            Self::Filesystem(n) => n.disable_broadcast_projection(context_id).await,
+        }
+    }
 }
 
 #[cfg(test)]
@@ -426,5 +638,70 @@ mod tests {
 
         let relay_err = ServerError::Relay(RelayError::BindFailed("addr in use".into()));
         assert!(relay_err.to_string().contains("addr in use"), "{relay_err}");
+    }
+
+    #[test]
+    fn user_message_does_not_leak_internal_details() {
+        let io_err = ServerError::Io(std::io::Error::new(
+            std::io::ErrorKind::PermissionDenied,
+            "permission denied: /home/user/.secret/data",
+        ));
+        let msg = io_err.user_message();
+        assert_eq!(msg, "I/O error during server operation");
+        assert!(
+            !msg.contains("/home"),
+            "user_message must not contain paths"
+        );
+
+        let relay_err = ServerError::Relay(RelayError::BindFailed("0.0.0.0:443".into()));
+        assert_eq!(relay_err.user_message(), "relay startup failed");
+
+        let storage_err = ServerError::Storage(StorageError::Internal("redb corruption".into()));
+        assert_eq!(storage_err.user_message(), "storage initialization failed");
+    }
+
+    #[test]
+    fn validate_data_dir_rejects_empty() {
+        let result = validate_data_dir(Path::new(""));
+        assert!(result.is_err(), "empty path should be rejected");
+        let msg = result.unwrap_err().to_string();
+        assert!(msg.contains("empty"), "error: {msg}");
+    }
+
+    #[test]
+    fn validate_data_dir_rejects_parent_traversal() {
+        let result = validate_data_dir(Path::new("/tmp/foo/../bar"));
+        assert!(result.is_err(), ".. component should be rejected");
+        let msg = result.unwrap_err().to_string();
+        assert!(msg.contains(".."), "error: {msg}");
+    }
+
+    #[test]
+    fn validate_data_dir_rejects_long_path() {
+        let long = "a".repeat(4097);
+        let result = validate_data_dir(Path::new(&long));
+        assert!(result.is_err(), "path >4096 bytes should be rejected");
+        let msg = result.unwrap_err().to_string();
+        assert!(msg.contains("4096"), "error: {msg}");
+    }
+
+    #[test]
+    fn validate_data_dir_accepts_valid_path() {
+        assert!(validate_data_dir(Path::new("/tmp/scp-test")).is_ok());
+        assert!(validate_data_dir(Path::new("relative/path")).is_ok());
+    }
+
+    #[tokio::test]
+    async fn running_node_in_memory_dispatch() {
+        let node = start_node_in_memory().await.unwrap();
+        let running = RunningNode::InMemory(node);
+        assert!(
+            running.relay_url().starts_with("ws://") || running.relay_url().starts_with("wss://")
+        );
+        assert!(running.did().starts_with("did:"));
+        assert!(running.relay_port() > 0);
+        assert!(!running.is_shutdown());
+        running.shutdown();
+        assert!(running.is_shutdown());
     }
 }

--- a/crates/scp-ffi/napi/src/server.rs
+++ b/crates/scp-ffi/napi/src/server.rs
@@ -17,10 +17,9 @@ use napi::Error as NapiError;
 use napi_derive::napi;
 use zeroize::Zeroizing;
 
-use scp_ffi_common::server::{self, RunningRelay, ServerError};
+use scp_ffi_common::server::{self, RunningNode, RunningRelay, ServerError};
 use scp_ffi_common::validate::{validate_context_id, validate_deploy_id, validate_did};
 use scp_node::NodeError;
-use scp_platform::testing::InMemoryStorage;
 
 use crate::error::ScpNapiError;
 use crate::{decrement_handle_count, increment_handle_count};
@@ -30,11 +29,13 @@ use crate::{decrement_handle_count, increment_handle_count};
 // ---------------------------------------------------------------------------
 
 fn server_err(e: ServerError) -> NapiError {
-    NapiError::from_reason(e.to_string())
+    tracing::error!(error = %e, "server operation failed");
+    NapiError::from_reason(e.user_message())
 }
 
 fn node_err(e: NodeError) -> NapiError {
-    NapiError::from_reason(e.to_string())
+    tracing::error!(error = %e, "node operation failed");
+    NapiError::from_reason("node operation failed")
 }
 
 // ---------------------------------------------------------------------------
@@ -96,106 +97,6 @@ impl Drop for NapiRelayHandle {
 // NapiNodeHandle — type-erased ApplicationNode wrapper
 // ---------------------------------------------------------------------------
 
-/// Internal enum that erases the `ApplicationNode<S>` generic parameter.
-///
-/// `ApplicationNode<S>` is generic over `S: Storage`. The `Storage` trait uses
-/// RPITIT and is not object-safe, so we cannot use `dyn Storage`. Instead we
-/// use a closed enum over the two concrete storage backends used by the shared
-/// server code: `InMemoryStorage` and `FilesystemStorage`.
-enum NodeInner {
-    InMemory(scp_node::ApplicationNode<InMemoryStorage>),
-    Filesystem(scp_node::ApplicationNode<scp_platform::filesystem::FilesystemStorage>),
-}
-
-impl NodeInner {
-    fn relay_url(&self) -> &str {
-        match self {
-            Self::InMemory(n) => n.relay_url(),
-            Self::Filesystem(n) => n.relay_url(),
-        }
-    }
-
-    fn did(&self) -> &str {
-        match self {
-            Self::InMemory(n) => n.identity().did(),
-            Self::Filesystem(n) => n.identity().did(),
-        }
-    }
-
-    const fn relay_port(&self) -> u16 {
-        match self {
-            Self::InMemory(n) => n.relay().bound_addr().port(),
-            Self::Filesystem(n) => n.relay().bound_addr().port(),
-        }
-    }
-
-    fn is_shutdown(&self) -> bool {
-        match self {
-            Self::InMemory(n) => n.relay().shutdown_handle().is_shutdown(),
-            Self::Filesystem(n) => n.relay().shutdown_handle().is_shutdown(),
-        }
-    }
-
-    fn shutdown(&self) {
-        match self {
-            Self::InMemory(n) => n.shutdown(),
-            Self::Filesystem(n) => n.shutdown(),
-        }
-    }
-
-    async fn enable_broadcast_projection_with_site(
-        &self,
-        context_id: &str,
-        broadcast_key: scp_core::crypto::sender_keys::BroadcastKey,
-        admission: scp_core::context::broadcast::BroadcastAdmission,
-        site_config: Option<scp_node::projection::SiteConfig>,
-    ) -> Result<(), NodeError> {
-        match self {
-            Self::InMemory(n) => {
-                n.enable_broadcast_projection_with_site(
-                    context_id,
-                    broadcast_key,
-                    admission,
-                    None,
-                    site_config,
-                )
-                .await
-            }
-            Self::Filesystem(n) => {
-                n.enable_broadcast_projection_with_site(
-                    context_id,
-                    broadcast_key,
-                    admission,
-                    None,
-                    site_config,
-                )
-                .await
-            }
-        }
-    }
-
-    async fn commit_deploy(&self, context_id: &str, deploy_id: &str) -> Result<usize, NodeError> {
-        match self {
-            Self::InMemory(n) => n.commit_deploy(context_id, deploy_id).await,
-            Self::Filesystem(n) => n.commit_deploy(context_id, deploy_id).await,
-        }
-    }
-
-    async fn rollback_deploy(&self, context_id: &str, deploy_id: &str) -> Result<(), NodeError> {
-        match self {
-            Self::InMemory(n) => n.rollback_deploy(context_id, deploy_id).await,
-            Self::Filesystem(n) => n.rollback_deploy(context_id, deploy_id).await,
-        }
-    }
-
-    async fn disable_broadcast_projection(&self, context_id: &str) {
-        match self {
-            Self::InMemory(n) => n.disable_broadcast_projection(context_id).await,
-            Self::Filesystem(n) => n.disable_broadcast_projection(context_id).await,
-        }
-    }
-}
-
 /// Opaque handle to a running SCP application node.
 ///
 /// Created by [`node_start_in_memory`] or [`node_start_local`]. The node
@@ -204,7 +105,7 @@ impl NodeInner {
 /// only the relay is bound.
 #[napi]
 pub struct NapiNodeHandle {
-    inner: NodeInner,
+    inner: RunningNode,
 }
 
 #[napi]
@@ -430,7 +331,7 @@ pub async fn node_start_in_memory() -> napi::Result<NapiNodeHandle> {
     let node = server::start_node_in_memory().await.map_err(server_err)?;
     increment_handle_count();
     Ok(NapiNodeHandle {
-        inner: NodeInner::InMemory(node),
+        inner: RunningNode::InMemory(node),
     })
 }
 
@@ -454,7 +355,7 @@ pub async fn node_start_local(data_dir: String) -> napi::Result<NapiNodeHandle> 
         .map_err(server_err)?;
     increment_handle_count();
     Ok(NapiNodeHandle {
-        inner: NodeInner::Filesystem(node),
+        inner: RunningNode::Filesystem(node),
     })
 }
 
@@ -567,7 +468,7 @@ mod tests {
     #[test]
     fn enable_site_projection_dispatches_through_node_inner() {
         let node = rt().block_on(server::start_node_in_memory()).unwrap();
-        let inner = NodeInner::InMemory(node);
+        let inner = RunningNode::InMemory(node);
         let key = scp_core::crypto::sender_keys::BroadcastKey::from_parts(
             scp_core::crypto::sender_keys::SenderKey::from_bytes([0xAB; 32]),
             0,
@@ -588,7 +489,7 @@ mod tests {
     #[test]
     fn commit_deploy_returns_error_for_unprojected_context() {
         let node = rt().block_on(server::start_node_in_memory()).unwrap();
-        let inner = NodeInner::InMemory(node);
+        let inner = RunningNode::InMemory(node);
         let result = rt().block_on(inner.commit_deploy("no-such-ctx", "deploy-1"));
         assert!(
             result.is_err(),
@@ -600,7 +501,7 @@ mod tests {
     #[test]
     fn rollback_deploy_returns_error_for_unprojected_context() {
         let node = rt().block_on(server::start_node_in_memory()).unwrap();
-        let inner = NodeInner::InMemory(node);
+        let inner = RunningNode::InMemory(node);
         let result = rt().block_on(inner.rollback_deploy("no-such-ctx", "deploy-1"));
         assert!(
             result.is_err(),
@@ -612,7 +513,7 @@ mod tests {
     #[test]
     fn disable_site_projection_is_noop_for_unprojected_context() {
         let node = rt().block_on(server::start_node_in_memory()).unwrap();
-        let inner = NodeInner::InMemory(node);
+        let inner = RunningNode::InMemory(node);
         rt().block_on(inner.disable_broadcast_projection("no-such-ctx"));
         // Should not panic.
         inner.shutdown();

--- a/crates/scp-ffi/src/server.rs
+++ b/crates/scp-ffi/src/server.rs
@@ -16,20 +16,21 @@
 use pyo3::prelude::*;
 use zeroize::Zeroizing;
 
-use scp_ffi_common::server::{self, RunningRelay, ServerError};
+use scp_ffi_common::server::{self, RunningNode, RunningRelay, ServerError};
 use scp_node::NodeError;
-use scp_platform::testing::InMemoryStorage;
 
 // ---------------------------------------------------------------------------
 // Error conversion
 // ---------------------------------------------------------------------------
 
 fn server_err(e: ServerError) -> PyErr {
-    pyo3::exceptions::PyRuntimeError::new_err(e.to_string())
+    tracing::error!(error = %e, "server operation failed");
+    pyo3::exceptions::PyRuntimeError::new_err(e.user_message())
 }
 
 fn node_err(e: NodeError) -> PyErr {
-    pyo3::exceptions::PyRuntimeError::new_err(e.to_string())
+    tracing::error!(error = %e, "node operation failed");
+    pyo3::exceptions::PyRuntimeError::new_err("node operation failed")
 }
 
 // ---------------------------------------------------------------------------
@@ -93,106 +94,6 @@ impl Drop for PyRelayHandle {
 // PyNodeHandle -- type-erased ApplicationNode wrapper
 // ---------------------------------------------------------------------------
 
-/// Internal enum that erases the `ApplicationNode<S>` generic parameter.
-///
-/// `ApplicationNode<S>` is generic over `S: Storage`. The `Storage` trait uses
-/// RPITIT and is not object-safe, so we cannot use `dyn Storage`. Instead we
-/// use a closed enum over the two concrete storage backends used by the shared
-/// server code: `InMemoryStorage` and `FilesystemStorage`.
-enum NodeInner {
-    InMemory(scp_node::ApplicationNode<InMemoryStorage>),
-    Filesystem(scp_node::ApplicationNode<scp_platform::filesystem::FilesystemStorage>),
-}
-
-impl NodeInner {
-    fn relay_url(&self) -> &str {
-        match self {
-            Self::InMemory(n) => n.relay_url(),
-            Self::Filesystem(n) => n.relay_url(),
-        }
-    }
-
-    fn did(&self) -> &str {
-        match self {
-            Self::InMemory(n) => n.identity().did(),
-            Self::Filesystem(n) => n.identity().did(),
-        }
-    }
-
-    const fn relay_port(&self) -> u16 {
-        match self {
-            Self::InMemory(n) => n.relay().bound_addr().port(),
-            Self::Filesystem(n) => n.relay().bound_addr().port(),
-        }
-    }
-
-    fn is_shutdown(&self) -> bool {
-        match self {
-            Self::InMemory(n) => n.relay().shutdown_handle().is_shutdown(),
-            Self::Filesystem(n) => n.relay().shutdown_handle().is_shutdown(),
-        }
-    }
-
-    fn shutdown(&self) {
-        match self {
-            Self::InMemory(n) => n.shutdown(),
-            Self::Filesystem(n) => n.shutdown(),
-        }
-    }
-
-    async fn enable_broadcast_projection_with_site(
-        &self,
-        context_id: &str,
-        broadcast_key: scp_core::crypto::sender_keys::BroadcastKey,
-        admission: scp_core::context::broadcast::BroadcastAdmission,
-        site_config: Option<scp_node::projection::SiteConfig>,
-    ) -> Result<(), NodeError> {
-        match self {
-            Self::InMemory(n) => {
-                n.enable_broadcast_projection_with_site(
-                    context_id,
-                    broadcast_key,
-                    admission,
-                    None,
-                    site_config,
-                )
-                .await
-            }
-            Self::Filesystem(n) => {
-                n.enable_broadcast_projection_with_site(
-                    context_id,
-                    broadcast_key,
-                    admission,
-                    None,
-                    site_config,
-                )
-                .await
-            }
-        }
-    }
-
-    async fn commit_deploy(&self, context_id: &str, deploy_id: &str) -> Result<usize, NodeError> {
-        match self {
-            Self::InMemory(n) => n.commit_deploy(context_id, deploy_id).await,
-            Self::Filesystem(n) => n.commit_deploy(context_id, deploy_id).await,
-        }
-    }
-
-    async fn rollback_deploy(&self, context_id: &str, deploy_id: &str) -> Result<(), NodeError> {
-        match self {
-            Self::InMemory(n) => n.rollback_deploy(context_id, deploy_id).await,
-            Self::Filesystem(n) => n.rollback_deploy(context_id, deploy_id).await,
-        }
-    }
-
-    async fn disable_broadcast_projection(&self, context_id: &str) {
-        match self {
-            Self::InMemory(n) => n.disable_broadcast_projection(context_id).await,
-            Self::Filesystem(n) => n.disable_broadcast_projection(context_id).await,
-        }
-    }
-}
-
 /// Opaque handle to a running SCP application node.
 ///
 /// Created by `node_start_in_memory()` or `node_start_local()`. The node
@@ -201,7 +102,7 @@ impl NodeInner {
 /// only the relay is bound.
 #[pyclass(name = "NodeHandle")]
 pub struct PyNodeHandle {
-    inner: NodeInner,
+    inner: RunningNode,
 }
 
 // PyO3 `#[getter]` methods require `&self` and cannot be `const` or `#[must_use]`.
@@ -443,7 +344,7 @@ pub fn py_node_start_in_memory(py: Python<'_>) -> PyResult<PyNodeHandle> {
             .block_on(server::start_node_in_memory())
             .map_err(server_err)?;
         Ok(PyNodeHandle {
-            inner: NodeInner::InMemory(node),
+            inner: RunningNode::InMemory(node),
         })
     })
 }
@@ -460,7 +361,7 @@ pub fn py_node_start_local(py: Python<'_>, data_dir: String) -> PyResult<PyNodeH
             .block_on(server::start_node_local(std::path::Path::new(&data_dir)))
             .map_err(server_err)?;
         Ok(PyNodeHandle {
-            inner: NodeInner::Filesystem(node),
+            inner: RunningNode::Filesystem(node),
         })
     })
 }
@@ -611,11 +512,11 @@ mod tests {
 
     #[test]
     fn node_inner_lifecycle_dispatch() {
-        // Test the NodeInner dispatch methods (which are the FFI layer).
+        // Test the RunningNode dispatch methods (which are the FFI layer).
         let node = rt().block_on(server::start_node_in_memory()).unwrap();
-        let inner = NodeInner::InMemory(node);
+        let inner = RunningNode::InMemory(node);
 
-        // enable_site_projection via NodeInner
+        // enable_site_projection via RunningNode
         let key = scp_core::crypto::sender_keys::BroadcastKey::from_parts(
             scp_core::crypto::sender_keys::SenderKey::from_bytes([0xCD; 32]),
             0,
@@ -631,7 +532,7 @@ mod tests {
         ));
         assert!(
             result.is_ok(),
-            "NodeInner enable should succeed: {result:?}"
+            "RunningNode enable should succeed: {result:?}"
         );
 
         // commit_deploy — will fail because no blobs exist but should return

--- a/crates/scp-ffi/uniffi/src/server.rs
+++ b/crates/scp-ffi/uniffi/src/server.rs
@@ -17,10 +17,9 @@ use std::sync::Arc;
 
 use zeroize::Zeroizing;
 
-use scp_ffi_common::server::{self, ServerError};
+use scp_ffi_common::server::{self, RunningNode, ServerError};
 use scp_ffi_common::validate::{validate_context_id, validate_deploy_id, validate_did};
 use scp_node::NodeError;
-use scp_platform::testing::InMemoryStorage;
 
 use crate::bridge::ScpError;
 use crate::{decrement_handle_count, increment_handle_count};
@@ -31,22 +30,24 @@ use crate::{decrement_handle_count, increment_handle_count};
 
 impl From<ServerError> for ScpError {
     fn from(e: ServerError) -> Self {
+        let user_msg = e.user_message();
+        tracing::error!(error = %e, "server operation failed");
         match e {
-            ServerError::Relay(inner) => Self::Transport {
-                msg: format!("relay error: {inner}"),
+            ServerError::Relay(_) => Self::Transport {
+                msg: user_msg,
                 code: "SCP-TRANS-5050".to_owned(),
             },
             ServerError::Node(inner) => Self::from(inner),
-            ServerError::Storage(inner) => Self::Context {
-                msg: format!("storage error: {inner}"),
+            ServerError::Storage(_) => Self::Context {
+                msg: user_msg,
                 code: "SCP-CTX-2051".to_owned(),
             },
-            ServerError::Platform(inner) => Self::Context {
-                msg: format!("platform error: {inner}"),
+            ServerError::Platform(_) => Self::Context {
+                msg: user_msg,
                 code: "SCP-CTX-2053".to_owned(),
             },
-            ServerError::Io(inner) => Self::Context {
-                msg: format!("io error: {inner}"),
+            ServerError::Io(_) => Self::Context {
+                msg: user_msg,
                 code: "SCP-CTX-2052".to_owned(),
             },
         }
@@ -55,25 +56,26 @@ impl From<ServerError> for ScpError {
 
 impl From<NodeError> for ScpError {
     fn from(e: NodeError) -> Self {
-        match &e {
+        tracing::error!(error = %e, "node operation failed");
+        match e {
             NodeError::MissingField(_) | NodeError::InvalidConfig(_) => Self::Validation {
-                msg: e.to_string(),
+                msg: "node configuration error".to_owned(),
                 code: "SCP-TRANS-5050".to_owned(),
             },
             NodeError::Identity(_) => Self::Identity {
-                msg: e.to_string(),
+                msg: "node identity operation failed".to_owned(),
                 code: "SCP-TRANS-5051".to_owned(),
             },
             NodeError::Relay(_) => Self::Transport {
-                msg: e.to_string(),
+                msg: "node relay error".to_owned(),
                 code: "SCP-TRANS-5052".to_owned(),
             },
             NodeError::Storage(_) => Self::Context {
-                msg: e.to_string(),
+                msg: "node storage error".to_owned(),
                 code: "SCP-TRANS-5053".to_owned(),
             },
             NodeError::Serve(_) | NodeError::Nat(_) | NodeError::Tls(_) => Self::Transport {
-                msg: e.to_string(),
+                msg: "node network error".to_owned(),
                 code: "SCP-TRANS-5054".to_owned(),
             },
         }
@@ -136,106 +138,6 @@ impl Drop for RelayHandle {
 // NodeHandle -- type-erased ApplicationNode wrapper
 // ---------------------------------------------------------------------------
 
-/// Internal enum that erases the `ApplicationNode<S>` generic parameter.
-///
-/// `ApplicationNode<S>` is generic over `S: Storage`. The `Storage` trait uses
-/// RPITIT and is not object-safe, so we cannot use `dyn Storage`. Instead we
-/// use a closed enum over the two concrete storage backends used by the shared
-/// server code: `InMemoryStorage` and `FilesystemStorage`.
-enum NodeInner {
-    InMemory(scp_node::ApplicationNode<InMemoryStorage>),
-    Filesystem(scp_node::ApplicationNode<scp_platform::filesystem::FilesystemStorage>),
-}
-
-impl NodeInner {
-    fn relay_url(&self) -> &str {
-        match self {
-            Self::InMemory(n) => n.relay_url(),
-            Self::Filesystem(n) => n.relay_url(),
-        }
-    }
-
-    fn did(&self) -> &str {
-        match self {
-            Self::InMemory(n) => n.identity().did(),
-            Self::Filesystem(n) => n.identity().did(),
-        }
-    }
-
-    const fn relay_port(&self) -> u16 {
-        match self {
-            Self::InMemory(n) => n.relay().bound_addr().port(),
-            Self::Filesystem(n) => n.relay().bound_addr().port(),
-        }
-    }
-
-    fn is_shutdown(&self) -> bool {
-        match self {
-            Self::InMemory(n) => n.relay().shutdown_handle().is_shutdown(),
-            Self::Filesystem(n) => n.relay().shutdown_handle().is_shutdown(),
-        }
-    }
-
-    fn shutdown(&self) {
-        match self {
-            Self::InMemory(n) => n.shutdown(),
-            Self::Filesystem(n) => n.shutdown(),
-        }
-    }
-
-    async fn enable_broadcast_projection_with_site(
-        &self,
-        context_id: &str,
-        broadcast_key: scp_core::crypto::sender_keys::BroadcastKey,
-        admission: scp_core::context::broadcast::BroadcastAdmission,
-        site_config: Option<scp_node::projection::SiteConfig>,
-    ) -> Result<(), NodeError> {
-        match self {
-            Self::InMemory(n) => {
-                n.enable_broadcast_projection_with_site(
-                    context_id,
-                    broadcast_key,
-                    admission,
-                    None,
-                    site_config,
-                )
-                .await
-            }
-            Self::Filesystem(n) => {
-                n.enable_broadcast_projection_with_site(
-                    context_id,
-                    broadcast_key,
-                    admission,
-                    None,
-                    site_config,
-                )
-                .await
-            }
-        }
-    }
-
-    async fn commit_deploy(&self, context_id: &str, deploy_id: &str) -> Result<usize, NodeError> {
-        match self {
-            Self::InMemory(n) => n.commit_deploy(context_id, deploy_id).await,
-            Self::Filesystem(n) => n.commit_deploy(context_id, deploy_id).await,
-        }
-    }
-
-    async fn rollback_deploy(&self, context_id: &str, deploy_id: &str) -> Result<(), NodeError> {
-        match self {
-            Self::InMemory(n) => n.rollback_deploy(context_id, deploy_id).await,
-            Self::Filesystem(n) => n.rollback_deploy(context_id, deploy_id).await,
-        }
-    }
-
-    async fn disable_broadcast_projection(&self, context_id: &str) {
-        match self {
-            Self::InMemory(n) => n.disable_broadcast_projection(context_id).await,
-            Self::Filesystem(n) => n.disable_broadcast_projection(context_id).await,
-        }
-    }
-}
-
 /// Opaque handle to a running SCP application node.
 ///
 /// Created by [`node_start_in_memory`] or [`node_start_local`]. The node
@@ -244,7 +146,7 @@ impl NodeInner {
 /// only the relay is bound.
 #[derive(uniffi::Object)]
 pub struct NodeHandle {
-    inner: NodeInner,
+    inner: RunningNode,
 }
 
 #[uniffi::export]
@@ -466,7 +368,7 @@ pub async fn node_start_in_memory() -> Result<Arc<NodeHandle>, ScpError> {
     let node = server::start_node_in_memory().await?;
     increment_handle_count();
     Ok(Arc::new(NodeHandle {
-        inner: NodeInner::InMemory(node),
+        inner: RunningNode::InMemory(node),
     }))
 }
 
@@ -479,7 +381,7 @@ pub async fn node_start_local(data_dir: String) -> Result<Arc<NodeHandle>, ScpEr
     let node = server::start_node_local(std::path::Path::new(&data_dir)).await?;
     increment_handle_count();
     Ok(Arc::new(NodeHandle {
-        inner: NodeInner::Filesystem(node),
+        inner: RunningNode::Filesystem(node),
     }))
 }
 
@@ -571,7 +473,7 @@ mod tests {
     #[test]
     fn enable_site_projection_dispatches_through_node_inner() {
         let node = rt().block_on(server::start_node_in_memory()).unwrap();
-        let inner = NodeInner::InMemory(node);
+        let inner = RunningNode::InMemory(node);
         let key = scp_core::crypto::sender_keys::BroadcastKey::from_parts(
             scp_core::crypto::sender_keys::SenderKey::from_bytes([0xAB; 32]),
             0,
@@ -592,7 +494,7 @@ mod tests {
     #[test]
     fn commit_deploy_returns_error_for_unprojected_context() {
         let node = rt().block_on(server::start_node_in_memory()).unwrap();
-        let inner = NodeInner::InMemory(node);
+        let inner = RunningNode::InMemory(node);
         let result = rt().block_on(inner.commit_deploy("no-such-ctx", "deploy-1"));
         assert!(
             result.is_err(),
@@ -604,7 +506,7 @@ mod tests {
     #[test]
     fn rollback_deploy_returns_error_for_unprojected_context() {
         let node = rt().block_on(server::start_node_in_memory()).unwrap();
-        let inner = NodeInner::InMemory(node);
+        let inner = RunningNode::InMemory(node);
         let result = rt().block_on(inner.rollback_deploy("no-such-ctx", "deploy-1"));
         assert!(
             result.is_err(),
@@ -616,19 +518,23 @@ mod tests {
     #[test]
     fn disable_site_projection_is_noop_for_unprojected_context() {
         let node = rt().block_on(server::start_node_in_memory()).unwrap();
-        let inner = NodeInner::InMemory(node);
+        let inner = RunningNode::InMemory(node);
         rt().block_on(inner.disable_broadcast_projection("no-such-ctx"));
         // Should not panic.
         inner.shutdown();
     }
 
     #[test]
-    fn node_error_maps_to_scp_error() {
-        let err = NodeError::InvalidConfig("test config".into());
+    fn node_error_maps_to_scp_error_with_sanitized_message() {
+        let err = NodeError::InvalidConfig("/secret/path/data.db".into());
         let scp_err: ScpError = err.into();
         match scp_err {
             ScpError::Validation { msg, code } => {
-                assert!(msg.contains("test config"), "msg={msg}");
+                assert!(
+                    !msg.contains("/secret"),
+                    "internal path leaked in msg: {msg}"
+                );
+                assert_eq!(msg, "node configuration error");
                 assert_eq!(code, "SCP-TRANS-5050");
             }
             other => panic!("expected Validation, got: {other:?}"),


### PR DESCRIPTION
## Summary

Three unresolved review findings from the #1336 review cycle, now fixed.

### ServerError path leakage
`ServerError` was exposing internal filesystem paths, OS error descriptions, and stack details to SDK consumers via `.to_string()`. Added `user_message()` that returns sanitized messages. Full errors still logged via `tracing::error!` for debugging.

### data_dir validation
`start_relay_local` and `start_node_local` accepted any path without validation. Added `validate_data_dir()` that rejects: empty paths, `..` components, paths >4096 bytes, null bytes.

### NodeInner dedup
`NodeInner` enum was copy-pasted identically in PyO3, NAPI, and UniFFI bridges. Moved to `scp-ffi-common` as `RunningNode`, matching the existing `RunningRelay` pattern.

Reviewed: security LGTM, bug-catcher no bugs found.

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>