### PR TITLE
feat(ffi): auto-resolve broadcast key in enableSiteProjection

### DIFF
--- a/bindings/kotlin/scp-kt/src/main/kotlin/works/limn/scp/Server.kt
+++ b/bindings/kotlin/scp-kt/src/main/kotlin/works/limn/scp/Server.kt
@@ -69,12 +69,15 @@ interface ServerBindings {
     /**
      * Activates HTTP broadcast projection for a context.
      *
+     * When [broadcastKeyHex] and [authorDid] are `null`, the key is
+     * auto-resolved from the `ContextManager` using the node's identity DID.
+     *
      * @param handleJson JSON-encoded node handle.
      * @param contextId The context ID to project.
-     * @param broadcastKeyHex 32-byte AES-256 broadcast key as 64-char hex string.
-     * @param authorDid DID of the broadcast key owner.
      * @param admission "open" or "gated".
      * @param hostname Virtual host hostname (RFC 1123).
+     * @param broadcastKeyHex 32-byte AES-256 broadcast key as 64-char hex string, or null for auto-lookup.
+     * @param authorDid DID of the broadcast key owner, or null for auto-lookup.
      * @param indexPath Default path for directory requests, or null for default "/index.html".
      * @param maxAssetsPerDeploy Max assets per deploy, or null for default 10000.
      * @param maxDeploySizeBytes Max total deploy size in bytes, or null for default 536870912.
@@ -85,10 +88,10 @@ interface ServerBindings {
     fun nodeEnableSiteProjection(
         handleJson: String,
         contextId: String,
-        broadcastKeyHex: String,
-        authorDid: String,
         admission: String,
         hostname: String,
+        broadcastKeyHex: String?,
+        authorDid: String?,
         indexPath: String?,
         maxAssetsPerDeploy: Int?,
         maxDeploySizeBytes: Long?,
@@ -282,23 +285,29 @@ class Node internal constructor(
      *
      * Registers a broadcast context for HTTP content delivery.
      *
+     * When [broadcastKeyHex] and [authorDid] are `null`, the key is
+     * auto-resolved from the `ContextManager` using the node's identity
+     * DID. This is the recommended usage for locally managed contexts.
+     *
      * @param contextId The context ID to project.
-     * @param broadcastKeyHex 32-byte AES-256 broadcast key as a 64-char hex string.
-     * @param authorDid DID of the broadcast key owner.
      * @param admission "open" or "gated".
      * @param config [SiteConfig] with hostname, index path, and deploy limits.
+     * @param broadcastKeyHex 32-byte AES-256 broadcast key as a 64-char hex string, or null for auto-lookup.
+     * @param authorDid DID of the broadcast key owner, or null for auto-lookup.
      * @throws BridgeException if parameters are invalid or operation fails.
      */
     @Suppress("LongParameterList")
     suspend fun enableSiteProjection(
         contextId: String,
-        broadcastKeyHex: String,
-        authorDid: String,
         admission: String,
         config: SiteConfig,
+        broadcastKeyHex: String? = null,
+        authorDid: String? = null,
     ) {
         validateAdmission(admission)
-        validateBroadcastKeyHex(broadcastKeyHex)
+        if (broadcastKeyHex != null) {
+            validateBroadcastKeyHex(broadcastKeyHex)
+        }
         bridge.enableSiteProjection(
             this,
             contextId,
@@ -489,8 +498,8 @@ class ServerBridge internal constructor(
      *
      * @param node The running node.
      * @param contextId The context ID to project.
-     * @param broadcastKeyHex 32-byte AES-256 broadcast key as 64-char hex string.
-     * @param authorDid DID of the broadcast key owner.
+     * @param broadcastKeyHex 32-byte AES-256 broadcast key as 64-char hex string, or null for auto-lookup.
+     * @param authorDid DID of the broadcast key owner, or null for auto-lookup.
      * @param admission "open" or "gated".
      * @param config [SiteConfig] with hostname, index path, and deploy limits.
      */
@@ -498,18 +507,18 @@ class ServerBridge internal constructor(
     internal suspend fun enableSiteProjection(
         node: Node,
         contextId: String,
-        broadcastKeyHex: String,
-        authorDid: String,
+        broadcastKeyHex: String?,
+        authorDid: String?,
         admission: String,
         config: SiteConfig,
     ) = bridge.ffiCall {
         bindings.nodeEnableSiteProjection(
             node.handleJson,
             contextId,
-            broadcastKeyHex,
-            authorDid,
             admission,
             config.hostname,
+            broadcastKeyHex,
+            authorDid,
             if (config.indexPath == "/index.html") null else config.indexPath,
             if (config.maxAssetsPerDeploy == 10_000) null else config.maxAssetsPerDeploy,
             if (config.maxDeploySizeBytes == 536_870_912L) null else config.maxDeploySizeBytes,

--- a/bindings/kotlin/scp-kt/src/test/kotlin/works/limn/scp/ServerTest.kt
+++ b/bindings/kotlin/scp-kt/src/test/kotlin/works/limn/scp/ServerTest.kt
@@ -60,10 +60,10 @@ class ServerTest {
 
         node.enableSiteProjection(
             contextId = "ctx-123",
-            broadcastKeyHex = "ab".repeat(32),
-            authorDid = "did:dht:z6MkAuthor",
             admission = "open",
             config = config,
+            broadcastKeyHex = "ab".repeat(32),
+            authorDid = "did:dht:z6MkAuthor",
         )
 
         val args = stubBindings.lastEnableSiteProjectionArgs
@@ -86,10 +86,10 @@ class ServerTest {
 
         node.enableSiteProjection(
             contextId = "ctx-456",
-            broadcastKeyHex = "cd".repeat(32),
-            authorDid = "did:dht:z6MkAuthor2",
             admission = "gated",
             config = config,
+            broadcastKeyHex = "cd".repeat(32),
+            authorDid = "did:dht:z6MkAuthor2",
         )
 
         val args = stubBindings.lastEnableSiteProjectionArgs
@@ -203,8 +203,8 @@ internal class StubServerBindings : ServerBindings {
     // enableSiteProjection
     data class EnableArgs(
         val contextId: String,
-        val broadcastKeyHex: String,
-        val authorDid: String,
+        val broadcastKeyHex: String?,
+        val authorDid: String?,
         val admission: String,
         val hostname: String,
         val indexPath: String?,
@@ -220,10 +220,10 @@ internal class StubServerBindings : ServerBindings {
     override fun nodeEnableSiteProjection(
         handleJson: String,
         contextId: String,
-        broadcastKeyHex: String,
-        authorDid: String,
         admission: String,
         hostname: String,
+        broadcastKeyHex: String?,
+        authorDid: String?,
         indexPath: String?,
         maxAssetsPerDeploy: Int?,
         maxDeploySizeBytes: Long?,

--- a/bindings/python/scp_sdk/server.py
+++ b/bindings/python/scp_sdk/server.py
@@ -191,37 +191,46 @@ class Node:
     async def enable_site_projection(
         self,
         context_id: str,
-        broadcast_key_hex: str,
-        author_did: str,
         admission: str,
         config: SiteConfig,
+        broadcast_key_hex: str | None = None,
+        author_did: str | None = None,
     ) -> None:
         """Activate HTTP broadcast projection for a context.
 
         Registers a broadcast context for HTTP content delivery.
 
+        When ``broadcast_key_hex`` and ``author_did`` are ``None``, the
+        key is auto-resolved from the ``ContextManager`` using the
+        node's identity DID. This is the recommended usage for locally
+        managed contexts.
+
         Args:
             context_id: The context ID to project.
-            broadcast_key_hex: 32-byte AES-256 broadcast key as a
-                64-character hex string.
-            author_did: DID of the broadcast key owner.
             admission: ``"open"`` or ``"gated"``.
             config: :class:`~scp_sdk.context.SiteConfig` with hostname,
                 index path, and deploy limits.
+            broadcast_key_hex: 32-byte AES-256 broadcast key as a
+                64-character hex string, or ``None`` for auto-lookup.
+            author_did: DID of the broadcast key owner, or ``None``
+                for auto-lookup.
 
         Raises:
-            ValueError: If parameters are invalid.
-            RuntimeError: If the underlying node operation fails.
+            ValueError: If parameters are invalid or only one of
+                ``broadcast_key_hex``/``author_did`` is provided.
+            RuntimeError: If the underlying node operation fails or
+                auto-lookup cannot find the key.
         """
         validate_admission(admission)
-        validate_broadcast_key_hex(broadcast_key_hex)
+        if broadcast_key_hex is not None:
+            validate_broadcast_key_hex(broadcast_key_hex)
         await asyncio.to_thread(
             self._handle.enable_site_projection,
             context_id,
-            broadcast_key_hex,
-            author_did,
             admission,
             config.hostname,
+            broadcast_key_hex,
+            author_did,
             config.index_path if config.index_path != "/index.html" else None,
             config.max_assets_per_deploy if config.max_assets_per_deploy != 10_000 else None,
             config.max_deploy_size_bytes if config.max_deploy_size_bytes != 536_870_912 else None,

--- a/bindings/python/tests/test_server.py
+++ b/bindings/python/tests/test_server.py
@@ -35,10 +35,10 @@ class _MockNodeHandle:
     def enable_site_projection(
         self,
         context_id: str,
-        broadcast_key_hex: str,
-        author_did: str,
         admission: str,
         hostname: str,
+        broadcast_key_hex: str | None = None,
+        author_did: str | None = None,
         index_path: str | None = None,
         max_assets_per_deploy: int | None = None,
         max_deploy_size_bytes: int | None = None,
@@ -94,10 +94,10 @@ async def test_enable_site_projection_delegates_to_handle() -> None:
 
     await node.enable_site_projection(
         context_id="ctx-123",
-        broadcast_key_hex="ab" * 32,
-        author_did="did:dht:z6MkAuthor",
         admission="open",
         config=config,
+        broadcast_key_hex="ab" * 32,
+        author_did="did:dht:z6MkAuthor",
     )
 
     assert handle._last_enable_args["context_id"] == "ctx-123"
@@ -121,10 +121,10 @@ async def test_enable_site_projection_defaults_pass_none() -> None:
 
     await node.enable_site_projection(
         context_id="ctx-456",
-        broadcast_key_hex="cd" * 32,
-        author_did="did:dht:z6MkAuthor2",
         admission="gated",
         config=config,
+        broadcast_key_hex="cd" * 32,
+        author_did="did:dht:z6MkAuthor2",
     )
 
     assert handle._last_enable_args["index_path"] is None
@@ -142,8 +142,6 @@ async def test_enable_site_projection_requires_config() -> None:
     with pytest.raises(TypeError):
         await node.enable_site_projection(  # type: ignore[call-arg]
             context_id="ctx-789",
-            broadcast_key_hex="ef" * 32,
-            author_did="did:dht:z6MkAuthor3",
             admission="open",
         )
 

--- a/bindings/swift/Sources/SCP/Server.swift
+++ b/bindings/swift/Sources/SCP/Server.swift
@@ -42,10 +42,10 @@ public enum ServerBridge {
     public typealias EnableSiteProjectionFn = @Sendable (
         _ handle: NodeHandle,
         _ contextId: String,
-        _ broadcastKeyHex: String,
-        _ authorDid: String,
         _ admission: String,
         _ hostname: String,
+        _ broadcastKeyHex: String?,
+        _ authorDid: String?,
         _ indexPath: String?,
         _ maxAssetsPerDeploy: UInt32?,
         _ maxDeploySizeBytes: UInt64?,
@@ -94,10 +94,10 @@ public enum ServerBridge {
     }
 
     /// Default enable site projection -- delegates to UniFFI ``NodeHandle.enableSiteProjection()``.
-    public static let defaultEnableSiteProjection: EnableSiteProjectionFn = { hdl, ctx, key, auth, adm, host, idx, maxA, maxS, ret, csp in // swiftlint:disable:this line_length
+    public static let defaultEnableSiteProjection: EnableSiteProjectionFn = { hdl, ctx, adm, host, key, auth, idx, maxA, maxS, ret, csp in // swiftlint:disable:this line_length
         try await hdl.enableSiteProjection(
-            contextId: ctx, broadcastKeyHex: key, authorDid: auth,
-            admission: adm, hostname: host, indexPath: idx,
+            contextId: ctx, admission: adm, hostname: host,
+            broadcastKeyHex: key, authorDid: auth, indexPath: idx,
             maxAssetsPerDeploy: maxA, maxDeploySizeBytes: maxS,
             deployRetentionCount: ret, cspOverride: csp
         )
@@ -274,31 +274,37 @@ public struct Node: Sendable {
     ///
     /// Registers a broadcast context for HTTP content delivery.
     ///
+    /// When `broadcastKeyHex` and `authorDid` are `nil`, the key is
+    /// auto-resolved from the `ContextManager` using the node's identity
+    /// DID. This is the recommended usage for locally managed contexts.
+    ///
     /// - Parameters:
     ///   - contextId: The context ID to project.
-    ///   - broadcastKeyHex: 32-byte AES-256 broadcast key as a 64-char hex string.
-    ///   - authorDid: DID of the broadcast key owner.
     ///   - admission: `"open"` or `"gated"`.
     ///   - config: ``SiteConfig`` with hostname, index path, and deploy limits.
+    ///   - broadcastKeyHex: 32-byte AES-256 broadcast key as a 64-char hex string, or `nil` for auto-lookup.
+    ///   - authorDid: DID of the broadcast key owner, or `nil` for auto-lookup.
     ///   - enableFn: Bridge function override for testing.
     /// - Throws: ``ScpError`` if parameters are invalid or operation fails.
     public func enableSiteProjection(
         contextId: String,
-        broadcastKeyHex: String,
-        authorDid: String,
         admission: String,
         config: SiteConfig,
+        broadcastKeyHex: String? = nil,
+        authorDid: String? = nil,
         enableFn: ServerBridge.EnableSiteProjectionFn = ServerBridge.defaultEnableSiteProjection
     ) async throws {
         try validateAdmission(admission)
-        try validateBroadcastKeyHex(broadcastKeyHex)
+        if let key = broadcastKeyHex {
+            try validateBroadcastKeyHex(key)
+        }
         try await enableFn(
             handle,
             contextId,
-            broadcastKeyHex,
-            authorDid,
             admission,
             config.hostname,
+            broadcastKeyHex,
+            authorDid,
             config.indexPath == "/index.html" ? nil : config.indexPath,
             config.maxAssetsPerDeploy == 10000 ? nil : UInt32(config.maxAssetsPerDeploy),
             config.maxDeploySizeBytes == 536_870_912 ? nil : UInt64(config.maxDeploySizeBytes),

--- a/bindings/swift/Tests/SCPTests/ServerTests.swift
+++ b/bindings/swift/Tests/SCPTests/ServerTests.swift
@@ -20,12 +20,12 @@ struct NodeLifecycleTests {
         var capturedAdmission: String?
         var capturedHostname: String?
 
-        let mockEnable: ServerBridge.EnableSiteProjectionFn = { _, cid, key, aut, adm, hst, _, _, _, _, _ in // swiftlint:disable:this line_length
+        let mockEnable: ServerBridge.EnableSiteProjectionFn = { _, cid, adm, hst, key, aut, _, _, _, _, _ in // swiftlint:disable:this line_length
             capturedContextId = cid
-            capturedBroadcastKeyHex = key
-            capturedAuthorDid = aut
             capturedAdmission = adm
             capturedHostname = hst
+            capturedBroadcastKeyHex = key
+            capturedAuthorDid = aut
         }
 
         let node = try await Node.startInMemory(startFn: mockNodeStart)
@@ -40,10 +40,10 @@ struct NodeLifecycleTests {
 
         try await node.enableSiteProjection(
             contextId: "ctx-123",
-            broadcastKeyHex: String(repeating: "ab", count: 32),
-            authorDid: "did:dht:z6MkAuthor",
             admission: "open",
             config: config,
+            broadcastKeyHex: String(repeating: "ab", count: 32),
+            authorDid: "did:dht:z6MkAuthor",
             enableFn: mockEnable
         )
 
@@ -82,10 +82,10 @@ struct NodeLifecycleTests {
 
         try await node.enableSiteProjection(
             contextId: "ctx-123",
-            broadcastKeyHex: String(repeating: "ab", count: 32),
-            authorDid: "did:dht:z6MkAuthor",
             admission: "open",
             config: config,
+            broadcastKeyHex: String(repeating: "ab", count: 32),
+            authorDid: "did:dht:z6MkAuthor",
             enableFn: mockEnable
         )
 
@@ -117,10 +117,10 @@ struct NodeLifecycleTests {
 
         try await node.enableSiteProjection(
             contextId: "ctx-456",
-            broadcastKeyHex: String(repeating: "cd", count: 32),
-            authorDid: "did:dht:z6MkAuthor2",
             admission: "gated",
             config: config,
+            broadcastKeyHex: String(repeating: "cd", count: 32),
+            authorDid: "did:dht:z6MkAuthor2",
             enableFn: mockEnable
         )
 

--- a/bindings/typescript/src/server.ts
+++ b/bindings/typescript/src/server.ts
@@ -48,10 +48,10 @@ interface NativeNodeHandle {
   shutdown(): void;
   enableSiteProjection(
     contextId: string,
-    broadcastKeyHex: string,
-    authorDid: string,
     admission: string,
     hostname: string,
+    broadcastKeyHex: string | null,
+    authorDid: string | null,
     indexPath: string | null,
     maxAssetsPerDeploy: number | null,
     maxDeploySizeBytes: number | null,
@@ -276,29 +276,36 @@ export class Node implements AsyncDisposable {
    *
    * Registers a broadcast context for HTTP content delivery.
    *
+   * When `broadcastKeyHex` and `authorDid` are omitted (or `undefined`),
+   * the key is auto-resolved from the `ContextManager` using the node's
+   * identity DID. This is the recommended usage for locally managed
+   * contexts.
+   *
    * @param contextId - The context ID to project.
-   * @param broadcastKeyHex - 32-byte AES-256 broadcast key as a 64-char hex string.
-   * @param authorDid - DID of the broadcast key owner.
    * @param admission - `"open"` or `"gated"`.
    * @param config - {@link SiteConfig} with hostname, index path, and deploy limits.
+   * @param broadcastKeyHex - 32-byte AES-256 broadcast key as a 64-char hex string, or omit for auto-lookup.
+   * @param authorDid - DID of the broadcast key owner, or omit for auto-lookup.
    * @throws {Error} If parameters are invalid.
    */
   async enableSiteProjection(
     contextId: string,
-    broadcastKeyHex: string,
-    authorDid: string,
     admission: string,
     config: SiteConfig,
+    broadcastKeyHex?: string,
+    authorDid?: string,
   ): Promise<void> {
     validateAdmission(admission);
-    validateBroadcastKeyHex(broadcastKeyHex);
+    if (broadcastKeyHex !== undefined) {
+      validateBroadcastKeyHex(broadcastKeyHex);
+    }
     validateSiteConfig(config);
     await this.#handle.enableSiteProjection(
       contextId,
-      broadcastKeyHex,
-      authorDid,
       admission,
       config.hostname,
+      broadcastKeyHex ?? null,
+      authorDid ?? null,
       config.indexPath ?? null,
       config.maxAssetsPerDeploy ?? null,
       config.maxDeploySizeBytes ?? null,

--- a/bindings/typescript/tests/server.test.ts
+++ b/bindings/typescript/tests/server.test.ts
@@ -21,10 +21,10 @@ interface MockNodeHandle {
   shutdown: () => void;
   enableSiteProjection: (
     contextId: string,
-    broadcastKeyHex: string,
-    authorDid: string,
     admission: string,
     hostname: string,
+    broadcastKeyHex: string | null,
+    authorDid: string | null,
     indexPath: string | null,
     maxAssetsPerDeploy: number | null,
     maxDeploySizeBytes: number | null,
@@ -141,10 +141,10 @@ describe("Node lifecycle methods (SCP-296)", () => {
 
     await handle.enableSiteProjection(
       "ctx-123",
-      "ab".repeat(32),
-      "did:dht:z6MkAuthor",
       "open",
       config.hostname,
+      "ab".repeat(32),
+      "did:dht:z6MkAuthor",
       config.indexPath ?? null,
       config.maxAssetsPerDeploy ?? null,
       config.maxDeploySizeBytes ?? null,

--- a/crates/scp-core/src/context/manager.rs
+++ b/crates/scp-core/src/context/manager.rs
@@ -55,6 +55,7 @@ use crate::crypto::ucan::validate::{
 use crate::economy::budget::MemberBudgetTracker;
 use crate::economy::types::EconomicPolicy;
 use scp_identity::DID;
+use zeroize::Zeroizing;
 
 // ---------------------------------------------------------------------------
 // Protocol-level collection size limits (§5.9)
@@ -1766,6 +1767,57 @@ impl ContextManager {
     /// This is a read-only query useful for diagnostics and testing.
     pub async fn is_local_did(&self, did: &DID) -> bool {
         self.local_dids.read().await.contains(did)
+    }
+
+    /// Returns the broadcast key and epoch for a locally controlled author
+    /// in a broadcast context.
+    ///
+    /// This enables FFI bridges to auto-resolve broadcast keys for
+    /// `enable_site_projection` without requiring the caller to manually
+    /// provide the key. The key is returned as `Zeroizing<[u8; 32]>` to
+    /// ensure sensitive material is wiped on drop.
+    ///
+    /// # Security
+    ///
+    /// Only returns keys for DIDs in [`local_dids`](Self::register_local_did).
+    /// This prevents leaking broadcast keys for remote authors.
+    ///
+    /// # Errors
+    ///
+    /// - [`ContextError::MembershipFailed`] if the context is not registered
+    ///   or is not a broadcast context.
+    /// - [`ContextError::PermissionDenied`] if `author_did` is not locally
+    ///   controlled.
+    /// - [`ContextError::MemberNotFound`] if `author_did` is not a registered
+    ///   author in the broadcast context.
+    pub async fn get_broadcast_key_for_local_author(
+        &self,
+        context_id: &str,
+        author_did: &str,
+    ) -> Result<(Zeroizing<[u8; 32]>, u64), ContextError> {
+        // Verify the DID is locally controlled.
+        if !self.local_dids.read().await.contains(author_did) {
+            return Err(ContextError::PermissionDenied(format!(
+                "author DID is not controlled by the local node: {author_did}"
+            )));
+        }
+
+        let contexts = self.contexts.lock().await;
+        let ctx = contexts
+            .get(context_id)
+            .ok_or_else(|| ContextError::MembershipFailed("context not registered".into()))?;
+
+        let bc = ctx
+            .broadcast_context
+            .as_ref()
+            .ok_or_else(|| ContextError::MembershipFailed("not a broadcast context".into()))?;
+
+        let author = bc.get_author(author_did).ok_or_else(|| {
+            ContextError::MemberNotFound(format!("author not found: {author_did}"))
+        })?;
+
+        let key_bytes = Zeroizing::new(*author.broadcast_key.as_bytes());
+        Ok((key_bytes, author.epoch))
     }
 
     /// Returns `true` if the given context needs to re-enter the
@@ -19628,6 +19680,134 @@ mod tests {
         assert_eq!(
             ctx.mls_epoch, 0,
             "epoch must not change for inactive context"
+        );
+    }
+
+    // -----------------------------------------------------------------------
+    // get_broadcast_key_for_local_author
+    // -----------------------------------------------------------------------
+
+    #[tokio::test]
+    async fn get_broadcast_key_for_local_author_returns_key_and_epoch() {
+        use zeroize::Zeroizing;
+
+        let manager = ContextManager::new(
+            Box::<MockCrypto>::default(),
+            Box::new(MockTransport::default()),
+            Box::new(MockEventLog::default()),
+            noop_key_resolver(),
+        );
+
+        let creator_did: DID = "did:key:creator1".into();
+        manager.register_local_did(creator_did.clone()).await;
+
+        let params = ContextParams {
+            mode: ContextMode::Broadcast,
+            memory_scope: MemoryScope::Full,
+            ..Default::default()
+        };
+
+        let _handle = manager
+            .create_context("bc-key-test".into(), params, creator_did.clone())
+            .await
+            .unwrap();
+
+        let (key_bytes, epoch) = manager
+            .get_broadcast_key_for_local_author("bc-key-test", creator_did.as_ref())
+            .await
+            .unwrap();
+
+        assert_eq!(epoch, 0, "initial epoch should be 0");
+        // Key should be 32 bytes, non-zero (randomly generated).
+        let zero = Zeroizing::new([0u8; 32]);
+        assert_ne!(key_bytes, zero, "broadcast key must not be all zeros");
+    }
+
+    #[tokio::test]
+    async fn get_broadcast_key_for_local_author_rejects_non_local_did() {
+        let manager = ContextManager::new(
+            Box::<MockCrypto>::default(),
+            Box::new(MockTransport::default()),
+            Box::new(MockEventLog::default()),
+            noop_key_resolver(),
+        );
+
+        let creator_did: DID = "did:key:creator2".into();
+        manager.register_local_did(creator_did.clone()).await;
+
+        let params = ContextParams {
+            mode: ContextMode::Broadcast,
+            memory_scope: MemoryScope::Full,
+            ..Default::default()
+        };
+
+        let _handle = manager
+            .create_context("bc-key-test-2".into(), params, creator_did.clone())
+            .await
+            .unwrap();
+
+        let result = manager
+            .get_broadcast_key_for_local_author("bc-key-test-2", "did:key:not-local")
+            .await;
+
+        assert!(result.is_err(), "should reject non-local DID");
+        assert!(
+            matches!(result.unwrap_err(), ContextError::PermissionDenied(_)),
+            "error should be PermissionDenied"
+        );
+    }
+
+    #[tokio::test]
+    async fn get_broadcast_key_for_local_author_rejects_unknown_context() {
+        let manager = ContextManager::new(
+            Box::<MockCrypto>::default(),
+            Box::new(MockTransport::default()),
+            Box::new(MockEventLog::default()),
+            noop_key_resolver(),
+        );
+
+        let did: DID = "did:key:creator3".into();
+        manager.register_local_did(did.clone()).await;
+
+        let result = manager
+            .get_broadcast_key_for_local_author("nonexistent-ctx", did.as_ref())
+            .await;
+
+        assert!(result.is_err(), "should reject unknown context");
+        assert!(
+            matches!(result.unwrap_err(), ContextError::MembershipFailed(_)),
+            "error should be MembershipFailed"
+        );
+    }
+
+    #[tokio::test]
+    async fn get_broadcast_key_for_local_author_rejects_encrypted_context() {
+        let manager = ContextManager::new(
+            Box::<MockCrypto>::default(),
+            Box::new(MockTransport::default()),
+            Box::new(MockEventLog::default()),
+            noop_key_resolver(),
+        );
+
+        let creator_did: DID = "did:key:creator4".into();
+        manager.register_local_did(creator_did.clone()).await;
+
+        // Default mode is Encrypted, not Broadcast.
+        let params = ContextParams::default();
+
+        let _handle = manager
+            .create_context("encrypted-ctx".into(), params, creator_did.clone())
+            .await
+            .unwrap();
+
+        let result = manager
+            .get_broadcast_key_for_local_author("encrypted-ctx", creator_did.as_ref())
+            .await;
+
+        assert!(result.is_err(), "should reject encrypted context");
+        assert!(
+            matches!(result.unwrap_err(), ContextError::MembershipFailed(_)),
+            "error should be MembershipFailed (not a broadcast context)"
         );
     }
 }

--- a/crates/scp-ffi/napi/src/server.rs
+++ b/crates/scp-ffi/napi/src/server.rs
@@ -246,18 +246,21 @@ impl NapiNodeHandle {
 
     /// Activates HTTP broadcast projection with site configuration.
     ///
-    /// `broadcastKeyHex` is the 32-byte AES-256 broadcast key as a 64-char
-    /// hex string. `authorDid` is the DID of the key owner. `admission` is
-    /// `"open"` or `"gated"`. `hostname` is the virtual host (RFC 1123).
+    /// When `broadcastKeyHex` and `authorDid` are `null`, the key is
+    /// auto-resolved from the `ContextManager` using the node's identity
+    /// DID. This is the recommended usage for locally managed contexts.
+    ///
+    /// `admission` is `"open"` or `"gated"`. `hostname` is the virtual
+    /// host (RFC 1123).
     #[napi]
     #[allow(clippy::too_many_arguments)]
     pub async fn enable_site_projection(
         &self,
         context_id: String,
-        broadcast_key_hex: String,
-        author_did: String,
         admission: String,
         hostname: String,
+        broadcast_key_hex: Option<String>,
+        author_did: Option<String>,
         index_path: Option<String>,
         max_assets_per_deploy: Option<u32>,
         max_deploy_size_bytes: Option<i64>,
@@ -265,22 +268,49 @@ impl NapiNodeHandle {
         csp_override: Option<String>,
     ) -> napi::Result<()> {
         validate_context_id(&context_id).map_err(|e| napi::Error::from(ScpNapiError::from(e)))?;
-        validate_did(&author_did).map_err(|e| napi::Error::from(ScpNapiError::from(e)))?;
-        let key_vec = Zeroizing::new(
-            hex::decode(&broadcast_key_hex)
-                .map_err(|e| NapiError::from_reason(format!("invalid broadcast_key_hex: {e}")))?,
-        );
-        let key_bytes: Zeroizing<[u8; 32]> =
-            Zeroizing::new(<[u8; 32]>::try_from(key_vec.as_slice()).map_err(|_| {
-                NapiError::from_reason(
-                    "broadcast_key_hex must be exactly 64 hex characters (32 bytes)",
-                )
-            })?);
+        if let Some(ref did) = author_did {
+            validate_did(did).map_err(|e| napi::Error::from(ScpNapiError::from(e)))?;
+        }
+
+        // Resolve broadcast key: explicit or auto-lookup from ContextManager.
+        let (resolved_key_bytes, resolved_epoch, resolved_author_did) =
+            match (broadcast_key_hex, author_did) {
+                (Some(key_hex), Some(did)) => {
+                    let key_hex = Zeroizing::new(key_hex);
+                    let key_vec = Zeroizing::new(hex::decode(&*key_hex).map_err(|e| {
+                        NapiError::from_reason(format!("invalid broadcast_key_hex: {e}"))
+                    })?);
+                    let key_bytes: Zeroizing<[u8; 32]> =
+                        Zeroizing::new(<[u8; 32]>::try_from(key_vec.as_slice()).map_err(|_| {
+                            NapiError::from_reason(
+                                "broadcast_key_hex must be exactly 64 hex characters (32 bytes)",
+                            )
+                        })?);
+                    (key_bytes, 0u64, did)
+                }
+                (None, None) => {
+                    // Auto-resolve from ContextManager using node's identity DID.
+                    let node_did = self.inner.did().to_owned();
+                    let mgr = crate::runtime::context_manager()?;
+                    let (key_bytes, epoch) = mgr
+                        .get_broadcast_key_for_local_author(&context_id, &node_did)
+                        .await
+                        .map_err(|e| {
+                            NapiError::from_reason(format!("broadcast key required — {e}"))
+                        })?;
+                    (key_bytes, epoch, node_did)
+                }
+                _ => {
+                    return Err(NapiError::from_reason(
+                        "broadcastKeyHex and authorDid must both be provided or both be null",
+                    ));
+                }
+            };
 
         let broadcast_key = scp_core::crypto::sender_keys::BroadcastKey::from_parts(
-            scp_core::crypto::sender_keys::SenderKey::from_bytes(*key_bytes),
-            0,
-            author_did,
+            scp_core::crypto::sender_keys::SenderKey::from_bytes(*resolved_key_bytes),
+            resolved_epoch,
+            resolved_author_did,
         );
 
         let adm = match admission.to_lowercase().as_str() {

--- a/crates/scp-ffi/src/server.rs
+++ b/crates/scp-ffi/src/server.rs
@@ -241,9 +241,13 @@ impl PyNodeHandle {
 
     /// Activates HTTP broadcast projection with site configuration.
     ///
-    /// Registers a broadcast context for HTTP content delivery. The
-    /// ``broadcast_key_hex`` is the 32-byte AES-256 broadcast key as a
-    /// 64-character hex string. ``author_did`` is the DID of the key owner.
+    /// Registers a broadcast context for HTTP content delivery.
+    ///
+    /// When ``broadcast_key_hex`` and ``author_did`` are ``None``, the key
+    /// is auto-resolved from the ``ContextManager`` using the node's
+    /// identity DID. This is the recommended usage for locally managed
+    /// contexts.
+    ///
     /// ``admission`` is ``"open"`` or ``"gated"``.
     ///
     /// Site configuration fields:
@@ -253,16 +257,16 @@ impl PyNodeHandle {
     /// - ``max_deploy_size_bytes``: max total deploy size in bytes (default 536870912).
     /// - ``deploy_retention_count``: deploys to retain (default 2, max 8).
     /// - ``csp_override``: optional Content-Security-Policy override.
-    #[pyo3(signature = (context_id, broadcast_key_hex, author_did, admission, hostname, index_path=None, max_assets_per_deploy=None, max_deploy_size_bytes=None, deploy_retention_count=None, csp_override=None))]
+    #[pyo3(signature = (context_id, admission, hostname, broadcast_key_hex=None, author_did=None, index_path=None, max_assets_per_deploy=None, max_deploy_size_bytes=None, deploy_retention_count=None, csp_override=None))]
     #[allow(clippy::too_many_arguments)]
     fn enable_site_projection(
         &self,
         py: Python<'_>,
         context_id: String,
-        broadcast_key_hex: String,
-        author_did: String,
         admission: String,
         hostname: String,
+        broadcast_key_hex: Option<String>,
+        author_did: Option<String>,
         index_path: Option<String>,
         max_assets_per_deploy: Option<usize>,
         max_deploy_size_bytes: Option<u64>,
@@ -270,23 +274,58 @@ impl PyNodeHandle {
         csp_override: Option<String>,
     ) -> PyResult<()> {
         crate::validate::validate_context_id(&context_id)?;
-        crate::validate::validate_did(&author_did)?;
+        if let Some(ref did) = author_did {
+            crate::validate::validate_did(did)?;
+        }
         let rt = crate::runtime()?;
 
-        let key_vec = Zeroizing::new(hex::decode(&broadcast_key_hex).map_err(|e| {
-            pyo3::exceptions::PyValueError::new_err(format!("invalid broadcast_key_hex: {e}"))
-        })?);
-        let key_bytes: Zeroizing<[u8; 32]> =
-            Zeroizing::new(<[u8; 32]>::try_from(key_vec.as_slice()).map_err(|_| {
-                pyo3::exceptions::PyValueError::new_err(
-                    "broadcast_key_hex must be exactly 64 hex characters (32 bytes)",
-                )
-            })?);
+        // Resolve broadcast key: explicit or auto-lookup from ContextManager.
+        let (resolved_key_bytes, resolved_epoch, resolved_author_did) =
+            match (broadcast_key_hex, author_did) {
+                (Some(key_hex), Some(did)) => {
+                    let key_hex = Zeroizing::new(key_hex);
+                    let key_vec = Zeroizing::new(hex::decode(&*key_hex).map_err(|e| {
+                        pyo3::exceptions::PyValueError::new_err(format!(
+                            "invalid broadcast_key_hex: {e}"
+                        ))
+                    })?);
+                    let key_bytes: Zeroizing<[u8; 32]> =
+                        Zeroizing::new(<[u8; 32]>::try_from(key_vec.as_slice()).map_err(|_| {
+                            pyo3::exceptions::PyValueError::new_err(
+                                "broadcast_key_hex must be exactly 64 hex characters (32 bytes)",
+                            )
+                        })?);
+                    (key_bytes, 0u64, did)
+                }
+                (None, None) => {
+                    // Auto-resolve from ContextManager using node's identity DID.
+                    let node_did = self.inner.did().to_owned();
+                    let mgr = crate::runtime::context_manager().map_err(|e| {
+                        pyo3::exceptions::PyRuntimeError::new_err(format!(
+                            "broadcast key auto-lookup failed: {e}"
+                        ))
+                    })?;
+                    let (key_bytes, epoch) = py.allow_threads(|| {
+                        rt.block_on(mgr.get_broadcast_key_for_local_author(&context_id, &node_did))
+                            .map_err(|e| {
+                                pyo3::exceptions::PyRuntimeError::new_err(format!(
+                                    "broadcast key required — {e}"
+                                ))
+                            })
+                    })?;
+                    (key_bytes, epoch, node_did)
+                }
+                _ => {
+                    return Err(pyo3::exceptions::PyValueError::new_err(
+                        "broadcast_key_hex and author_did must both be provided or both be None",
+                    ));
+                }
+            };
 
         let broadcast_key = scp_core::crypto::sender_keys::BroadcastKey::from_parts(
-            scp_core::crypto::sender_keys::SenderKey::from_bytes(*key_bytes),
-            0,
-            author_did,
+            scp_core::crypto::sender_keys::SenderKey::from_bytes(*resolved_key_bytes),
+            resolved_epoch,
+            resolved_author_did,
         );
 
         let adm = match admission.to_lowercase().as_str() {

--- a/crates/scp-ffi/uniffi/src/server.rs
+++ b/crates/scp-ffi/uniffi/src/server.rs
@@ -282,17 +282,20 @@ impl NodeHandle {
 
     /// Activates HTTP broadcast projection with site configuration.
     ///
-    /// `broadcast_key_hex` is the 32-byte AES-256 broadcast key as a 64-char
-    /// hex string. `author_did` is the DID of the key owner. `admission` is
-    /// `"open"` or `"gated"`. `hostname` is the virtual host (RFC 1123).
+    /// When `broadcast_key_hex` and `author_did` are `nil`/`null`, the key
+    /// is auto-resolved from the `ContextManager` using the node's identity
+    /// DID. This is the recommended usage for locally managed contexts.
+    ///
+    /// `admission` is `"open"` or `"gated"`. `hostname` is the virtual
+    /// host (RFC 1123).
     #[allow(clippy::too_many_arguments)]
     pub async fn enable_site_projection(
         &self,
         context_id: String,
-        broadcast_key_hex: String,
-        author_did: String,
         admission: String,
         hostname: String,
+        broadcast_key_hex: Option<String>,
+        author_did: Option<String>,
         index_path: Option<String>,
         max_assets_per_deploy: Option<u32>,
         max_deploy_size_bytes: Option<u64>,
@@ -300,27 +303,59 @@ impl NodeHandle {
         csp_override: Option<String>,
     ) -> Result<(), ScpError> {
         validate_context_id(&context_id)?;
-        validate_did(&author_did)?;
-        let key_vec =
-            Zeroizing::new(
-                hex::decode(&broadcast_key_hex).map_err(|e| ScpError::Validation {
-                    msg: format!("invalid broadcast_key_hex: {e}"),
-                    code: "SCP-TRANS-5060".to_owned(),
-                })?,
-            );
-        let key_bytes: Zeroizing<[u8; 32]> =
-            Zeroizing::new(<[u8; 32]>::try_from(key_vec.as_slice()).map_err(|_| {
-                ScpError::Validation {
-                    msg: "broadcast_key_hex must be exactly 64 hex characters (32 bytes)"
-                        .to_owned(),
-                    code: "SCP-TRANS-5060".to_owned(),
+        if let Some(ref did) = author_did {
+            validate_did(did)?;
+        }
+
+        // Resolve broadcast key: explicit or auto-lookup from ContextManager.
+        let (resolved_key_bytes, resolved_epoch, resolved_author_did) =
+            match (broadcast_key_hex, author_did) {
+                (Some(key_hex), Some(did)) => {
+                    let key_hex = Zeroizing::new(key_hex);
+                    let key_vec = Zeroizing::new(hex::decode(&*key_hex).map_err(|e| {
+                        ScpError::Validation {
+                            msg: format!("invalid broadcast_key_hex: {e}"),
+                            code: "SCP-TRANS-5060".to_owned(),
+                        }
+                    })?);
+                    let key_bytes: Zeroizing<[u8; 32]> =
+                        Zeroizing::new(<[u8; 32]>::try_from(key_vec.as_slice()).map_err(|_| {
+                            ScpError::Validation {
+                                msg:
+                                    "broadcast_key_hex must be exactly 64 hex characters (32 bytes)"
+                                        .to_owned(),
+                                code: "SCP-TRANS-5060".to_owned(),
+                            }
+                        })?);
+                    (key_bytes, 0u64, did)
                 }
-            })?);
+                (None, None) => {
+                    // Auto-resolve from ContextManager using node's identity DID.
+                    let node_did = self.inner.did().to_owned();
+                    let mgr = crate::runtime::context_manager()?;
+                    let (key_bytes, epoch) = mgr
+                        .get_broadcast_key_for_local_author(&context_id, &node_did)
+                        .await
+                        .map_err(|e| ScpError::Context {
+                            msg: format!("broadcast key required — {e}"),
+                            code: "SCP-CTX-2060".to_owned(),
+                        })?;
+                    (key_bytes, epoch, node_did)
+                }
+                _ => {
+                    return Err(ScpError::Validation {
+                    msg:
+                        "broadcast_key_hex and author_did must both be provided or both be omitted"
+                            .to_owned(),
+                    code: "SCP-TRANS-5060".to_owned(),
+                });
+                }
+            };
 
         let broadcast_key = scp_core::crypto::sender_keys::BroadcastKey::from_parts(
-            scp_core::crypto::sender_keys::SenderKey::from_bytes(*key_bytes),
-            0,
-            author_did,
+            scp_core::crypto::sender_keys::SenderKey::from_bytes(*resolved_key_bytes),
+            resolved_epoch,
+            resolved_author_did,
         );
 
         let adm = match admission.to_lowercase().as_str() {


### PR DESCRIPTION
## Summary
- Adds `ContextManager::get_broadcast_key_for_local_author()` — returns broadcast key for locally-controlled DIDs with `Zeroizing<[u8; 32]>` cleanup
- Makes `broadcastKeyHex` and `authorDid` optional in all 3 FFI bridges (PyO3, NAPI, UniFFI)
- Auto-resolves key from ContextManager when both params omitted
- All 4 SDK wrappers updated with optional params and documentation
- Explicit hex key string wrapped in `Zeroizing` for defense-in-depth
- 4 unit tests in scp-core (success, non-local DID rejection, unknown context, non-broadcast context)

## Test plan
- [x] `cargo test --workspace` — 6,854 tests pass
- [x] `cargo clippy --workspace --all-targets` — zero warnings
- [x] `cargo fmt --all --check` — clean
- [x] Review cycle: bug-catcher, security, API/alignment, cryptographer → zero findings after fixes

🤖 Generated with [Claude Code](https://claude.com/claude-code)