### PR TITLE
fix(deps): upgrade pyo3 0.23→0.24.1 and lru 0.12→0.16 (security)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1862,6 +1862,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
 
 [[package]]
+name = "foldhash"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
+
+[[package]]
 name = "foreign-types"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2209,7 +2215,7 @@ checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
 dependencies = [
  "allocator-api2",
  "equivalent",
- "foldhash",
+ "foldhash 0.1.5",
 ]
 
 [[package]]
@@ -2217,6 +2223,11 @@ name = "hashbrown"
 version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
+dependencies = [
+ "allocator-api2",
+ "equivalent",
+ "foldhash 0.2.0",
+]
 
 [[package]]
 name = "hashlink"
@@ -3250,6 +3261,9 @@ name = "lru"
 version = "0.16.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a1dc47f592c06f33f8e3aea9591776ec7c9f9e4124778ff8a3c3b87159f7e593"
+dependencies = [
+ "hashbrown 0.16.1",
+]
 
 [[package]]
 name = "lru-slab"
@@ -4246,9 +4260,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3"
-version = "0.23.5"
+version = "0.24.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7778bffd85cf38175ac1f545509665d0b9b92a198ca7941f131f85f7a4f9a872"
+checksum = "e5203598f366b11a02b13aa20cab591229ff0a89fd121a308a5df751d5fc9219"
 dependencies = [
  "cfg-if",
  "indoc",
@@ -4264,9 +4278,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-build-config"
-version = "0.23.5"
+version = "0.24.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94f6cbe86ef3bf18998d9df6e0f3fc1050a8c5efa409bf712e661a4366e010fb"
+checksum = "99636d423fa2ca130fa5acde3059308006d46f98caac629418e53f7ebb1e9999"
 dependencies = [
  "once_cell",
  "target-lexicon",
@@ -4274,9 +4288,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-ffi"
-version = "0.23.5"
+version = "0.24.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e9f1b4c431c0bb1c8fb0a338709859eed0d030ff6daa34368d3b152a63dfdd8d"
+checksum = "78f9cf92ba9c409279bc3305b5409d90db2d2c22392d443a87df3a1adad59e33"
 dependencies = [
  "libc",
  "pyo3-build-config",
@@ -4284,9 +4298,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-macros"
-version = "0.23.5"
+version = "0.24.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fbc2201328f63c4710f68abdf653c89d8dbc2858b88c5d88b0ff38a75288a9da"
+checksum = "0b999cb1a6ce21f9a6b147dcf1be9ffedf02e0043aec74dc390f3007047cecd9"
 dependencies = [
  "proc-macro2",
  "pyo3-macros-backend",
@@ -4296,9 +4310,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-macros-backend"
-version = "0.23.5"
+version = "0.24.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fca6726ad0f3da9c9de093d6f116a93c1a38e417ed73bf138472cf4064f72028"
+checksum = "822ece1c7e1012745607d5cf0bcb2874769f0f7cb34c4cde03b9358eb9ef911a"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -5036,7 +5050,7 @@ dependencies = [
  "hex",
  "hkdf",
  "jsonschema",
- "lru 0.12.5",
+ "lru 0.16.3",
  "openmls",
  "openmls_basic_credential",
  "openmls_memory_storage 0.5.0",
@@ -5444,7 +5458,7 @@ dependencies = [
  "igd-next",
  "js-sys",
  "k256",
- "lru 0.12.5",
+ "lru 0.16.3",
  "natpmp",
  "openssl",
  "quinn",
@@ -6126,9 +6140,9 @@ dependencies = [
 
 [[package]]
 name = "target-lexicon"
-version = "0.12.16"
+version = "0.13.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61c41af27dd6d1e27b1b16b489db798443478cef1f06a660c96db617ba5de3b1"
+checksum = "adb6935a6f5c20170eeceb1a3835a49e12e19d792f6dd344ccc76a985ca5a6ca"
 
 [[package]]
 name = "tempfile"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -57,7 +57,7 @@ bs58 = "0.5"
 jsonschema = { version = "0.28", default-features = false }
 zeroize = { version = "1", features = ["derive"] }
 tracing = "0.1"
-lru = "0.12"
+lru = "0.16"
 dashmap = "6"
 hex = "0.4"
 axum = "0.8"

--- a/crates/scp-ffi/Cargo.toml
+++ b/crates/scp-ffi/Cargo.toml
@@ -29,7 +29,7 @@ allow_in_memory_custody = ["scp-platform/testing", "dep:scp-testing"]
 server = ["scp-ffi-common/server", "dep:scp-node"]
 
 [dependencies]
-pyo3 = { version = "0.23", features = ["experimental-async"] }
+pyo3 = { version = "0.24.1", features = ["experimental-async"] }
 tokio = { workspace = true }
 scp-core = { path = "../scp-core" }
 scp-identity = { path = "../scp-identity" }
@@ -57,7 +57,7 @@ tls_codec = "0.4"
 zeroize = { workspace = true }
 
 [dev-dependencies]
-pyo3 = { version = "0.23", features = ["auto-initialize"] }
+pyo3 = { version = "0.24.1", features = ["auto-initialize"] }
 tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }
 scp-ffi-common = { path = "common", features = ["testing"] }
 # Tests need InMemoryKeyCustody.

--- a/deny.toml
+++ b/deny.toml
@@ -34,7 +34,6 @@ allow = [
 db-path = "~/.cargo/advisory-db"
 db-urls = ["https://github.com/rustsec/advisory-db"]
 ignore = [
-    "RUSTSEC-2025-0020",  # pyo3 0.23.5 PyString buffer overflow — bump to 0.24+ when available
     "RUSTSEC-2025-0134",  # rustls-pemfile unmaintained — awaiting upstream migration
     "RUSTSEC-2024-0436",  # paste unmaintained — transitive via netlink-packet-utils (natpmp); no safe upgrade
     # instant: unmaintained, transitive dep via openmls -> fluvio-wasm-timer.


### PR DESCRIPTION
## Summary

Addresses all 4 Dependabot security alerts:

- **pyo3** (alerts #1, #4): Upgraded from 0.23.5 → 0.24.2 (spec `"0.24.1"`). Fixes [RUSTSEC-2025-0020](https://rustsec.org/advisories/RUSTSEC-2025-0020) — buffer overflow in `PyString::from_object`. Removed the advisory ignore from `deny.toml`.
- **lru** (alert #2): Upgraded workspace dependency from 0.12.5 → 0.16.3 (spec `"0.16"`). Fixes Stacked Borrows violation in `IterMut`. Note: `lru 0.12.5` remains as a transitive dep of `aws-sdk-s3` — upstream has not upgraded yet.
- **tsup** (alert #3): Dismissed as inaccurate — our version 8.5.1 is above the vulnerable range ≤ 8.3.4.

Zero source code changes required — both upgrades are API-compatible with the existing codebase.

## Changes

- `crates/scp-ffi/Cargo.toml` — pyo3 version bump (deps + dev-deps)
- `Cargo.toml` — lru workspace version bump
- `deny.toml` — remove RUSTSEC-2025-0020 ignore
- `Cargo.lock` — updated

## Verification

All passed locally:
- `cargo build --workspace`
- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets` (with CI features, `-D warnings`)
- `cargo test --workspace` (5,643+ tests)
- `cargo deny check advisories`

## Test plan

- [x] Cargo build passes
- [x] Clippy clean (zero warnings)
- [x] All workspace tests pass
- [x] `cargo deny check` passes (RUSTSEC-2025-0020 no longer fires)
- [x] No source code changes needed (API-compatible upgrades)

🤖 Generated with [Claude Code](https://claude.com/claude-code)