### PR TITLE
feat(discovery): BootstrapContextEntry with creator DID verification (§22.13)

### DIFF
--- a/crates/scp-core/src/discovery/bootstrap.rs
+++ b/crates/scp-core/src/discovery/bootstrap.rs
@@ -1,21 +1,92 @@
 //! Discovery bootstrap and fallback configuration.
 //!
-//! Provides configurable default bootstrap context IDs (analogous to DNS root
+//! Provides configurable default bootstrap context entries (analogous to DNS root
 //! servers) and a resolver that combines context queries with
 //! fallback to direct DID resolution.
+//!
+//! Each bootstrap context entry pairs a context ID with the expected creator DID,
+//! enabling post-join verification that defends against context ID substitution
+//! attacks (§22.13.2).
 //!
 //! The SDK ships with configurable defaults that are auto-queried on first
 //! identity creation (opt-out). Users can add custom contexts with discovery tools and
 //! configure fallback behavior.
 //!
 //! See ADR-020 in `.docs/adrs/phase-4.md`, acceptance criterion 8.
+//! See §22.13 for bootstrap context governance.
 
+use scp_identity::DID;
 use serde::{Deserialize, Serialize};
 
 use crate::well_known::{WellKnownScp, WellKnownValidationError};
 use scp_identity::DidMethod;
 
 use super::{ContextId, DiscoveryError};
+
+// ---------------------------------------------------------------------------
+// BootstrapContextEntry
+// ---------------------------------------------------------------------------
+
+/// A bootstrap context with expected creator DID for post-join verification.
+///
+/// Pairs a `context_id` with an `expected_creator_did`. After the SDK joins a
+/// bootstrap context via MLS group join, it MUST verify that the context's
+/// creator DID matches the `expected_creator_did`. The creator DID is available
+/// from the context's event log (the first event in any context is the creation
+/// event, signed by the creator's DID). If the creator DID does not match, the
+/// SDK MUST leave the context and treat the entry as failed — the context may
+/// have been substituted by an attacker.
+///
+/// See §22.13.2 for the full verification protocol.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct BootstrapContextEntry {
+    /// The bootstrap context's ID (hex-encoded).
+    pub context_id: ContextId,
+    /// The DID of the expected context creator. SDK MUST verify this matches the
+    /// actual context creator after joining (§22.13.2).
+    pub expected_creator_did: DID,
+}
+
+impl BootstrapContextEntry {
+    /// Creates a new `BootstrapContextEntry`.
+    ///
+    /// # Arguments
+    ///
+    /// * `context_id` -- The bootstrap context's ID.
+    /// * `expected_creator_did` -- The DID of the expected context creator.
+    #[must_use]
+    pub const fn new(context_id: ContextId, expected_creator_did: DID) -> Self {
+        Self {
+            context_id,
+            expected_creator_did,
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// BootstrapVerificationError
+// ---------------------------------------------------------------------------
+
+/// Errors produced when verifying a bootstrap context's creator DID.
+#[derive(Debug, thiserror::Error)]
+pub enum BootstrapVerificationError {
+    /// The actual creator DID does not match the expected creator DID from
+    /// the bootstrap configuration.
+    ///
+    /// This indicates a potential context ID substitution attack (§22.13.2).
+    /// The SDK MUST leave the context when this error is returned.
+    #[error(
+        "bootstrap context creator mismatch for {context_id}: expected {expected}, got {actual}"
+    )]
+    CreatorMismatch {
+        /// The context ID that was verified.
+        context_id: ContextId,
+        /// The expected creator DID from the bootstrap configuration.
+        expected: DID,
+        /// The actual creator DID from the context's event log.
+        actual: DID,
+    },
+}
 
 // ---------------------------------------------------------------------------
 // BootstrapConfig
@@ -28,17 +99,20 @@ use super::{ContextId, DiscoveryError};
 /// direct DID resolution when contexts with discovery tools are unavailable.
 ///
 /// Analogous to DNS root servers: the SDK ships with configurable default
-/// bootstrap context IDs. Users can add custom contexts with discovery tools. If
-/// defaults are unreachable, direct DID resolution still works.
+/// bootstrap context entries. Users can add custom contexts with discovery tools.
+/// If defaults are unreachable, direct DID resolution still works.
 ///
-/// See ADR-020 acceptance criterion 8.
+/// Each context entry includes the expected creator DID for post-join
+/// verification (§22.13.2).
+///
+/// See ADR-020 acceptance criterion 8, §22.13.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct BootstrapConfig {
-    /// Default bootstrap context IDs shipped with the SDK.
+    /// Default bootstrap context entries shipped with the SDK.
     ///
     /// These are queried automatically on first identity creation unless
     /// `auto_query_on_identity_creation` is set to `false`.
-    pub default_context_ids: Vec<ContextId>,
+    pub default_contexts: Vec<BootstrapContextEntry>,
 
     /// Whether to automatically query contexts with discovery tools on first identity
     /// creation.
@@ -47,11 +121,11 @@ pub struct BootstrapConfig {
     /// queries.
     pub auto_query_on_identity_creation: bool,
 
-    /// User-added custom context IDs.
+    /// User-added custom context entries.
     ///
     /// These are queried alongside the defaults. Users can add contexts via
     /// [`BootstrapConfig::add_custom_context`].
-    pub custom_context_ids: Vec<ContextId>,
+    pub custom_contexts: Vec<BootstrapContextEntry>,
 
     /// Whether to fall back to direct DID resolution when contexts with discovery tools
     /// are unavailable or return no results.
@@ -64,51 +138,96 @@ pub struct BootstrapConfig {
 impl Default for BootstrapConfig {
     fn default() -> Self {
         Self {
-            default_context_ids: Vec::new(),
+            default_contexts: Vec::new(),
             auto_query_on_identity_creation: true,
-            custom_context_ids: Vec::new(),
+            custom_contexts: Vec::new(),
             fallback_to_did_resolution: true,
         }
     }
 }
 
 impl BootstrapConfig {
-    /// Creates a new `BootstrapConfig` with the given default discovery
-    /// context IDs.
+    /// Creates a new `BootstrapConfig` with the given default bootstrap context
+    /// entries.
     ///
     /// All other fields are set to their defaults: auto-query enabled,
     /// fallback enabled, no custom contexts.
     ///
     /// # Arguments
     ///
-    /// * `context_ids` -- Default bootstrap context IDs to query on bootstrap.
+    /// * `contexts` -- Default bootstrap context entries to query on bootstrap.
     #[must_use]
-    pub fn with_defaults(context_ids: Vec<ContextId>) -> Self {
+    pub fn with_defaults(contexts: Vec<BootstrapContextEntry>) -> Self {
         Self {
-            default_context_ids: context_ids,
+            default_contexts: contexts,
             ..Self::default()
         }
     }
 
-    /// Adds a custom context ID.
+    /// Adds a custom context entry.
     ///
     /// Custom contexts are queried alongside the defaults. Duplicate context
     /// IDs are not filtered here -- deduplication happens at query time in
     /// [`BootstrapResolver::resolve_contexts`].
-    pub fn add_custom_context(&mut self, context_id: ContextId) {
-        self.custom_context_ids.push(context_id);
+    pub fn add_custom_context(&mut self, entry: BootstrapContextEntry) {
+        self.custom_contexts.push(entry);
     }
 
-    /// Returns all context IDs (defaults + custom) as a combined list.
+    /// Returns all context entries (defaults + custom) as a combined list.
     ///
-    /// The returned list contains references to the default context IDs
-    /// followed by the custom context IDs.
+    /// The returned list contains references to the default context entries
+    /// followed by the custom context entries.
     #[must_use]
-    pub fn all_context_ids(&self) -> Vec<&ContextId> {
-        self.default_context_ids
+    pub fn all_contexts(&self) -> Vec<&BootstrapContextEntry> {
+        self.default_contexts
             .iter()
-            .chain(self.custom_context_ids.iter())
+            .chain(self.custom_contexts.iter())
             .collect()
+    }
+
+    /// Verifies that a context's actual creator DID matches the expected
+    /// creator DID in the bootstrap configuration.
+    ///
+    /// This implements the post-join verification step from §22.13.2. After
+    /// joining a bootstrap context, the SDK calls this method with the context
+    /// ID and the creator DID extracted from the context's event log.
+    ///
+    /// # Returns
+    ///
+    /// - `Ok(true)` if the context was found in the configuration and the
+    ///   creator DID matches.
+    /// - `Ok(false)` if the context is not in the bootstrap configuration
+    ///   (not a bootstrap context, no verification needed).
+    /// - `Err(CreatorMismatch)` if the context was found but the actual
+    ///   creator DID does not match the expected one. The SDK MUST leave the
+    ///   context in this case.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`BootstrapVerificationError::CreatorMismatch`] when the context
+    /// is found in the configuration but the creator DID does not match.
+    pub fn verify_context_creator(
+        &self,
+        context_id: &ContextId,
+        actual_creator_did: &DID,
+    ) -> Result<bool, BootstrapVerificationError> {
+        let entry = self
+            .default_contexts
+            .iter()
+            .chain(self.custom_contexts.iter())
+            .find(|e| e.context_id == *context_id);
+
+        entry.map_or(Ok(false), |e| {
+            if e.expected_creator_did == *actual_creator_did {
+                Ok(true)
+            } else {
+                Err(BootstrapVerificationError::CreatorMismatch {
+                    context_id: context_id.clone(),
+                    expected: e.expected_creator_did.clone(),
+                    actual: actual_creator_did.clone(),
+                })
+            }
+        })
     }
 
     /// Returns whether the SDK should auto-query contexts with discovery tools on first
@@ -157,12 +276,15 @@ impl BootstrapResolver {
 
     /// Returns all available context IDs (defaults + custom),
     /// deduplicated while preserving order.
+    ///
+    /// Extracts context IDs from [`BootstrapContextEntry`] entries.
     #[must_use]
     pub fn resolve_contexts(&self) -> Vec<ContextId> {
         let mut seen = std::collections::HashSet::new();
         self.config
-            .all_context_ids()
+            .all_contexts()
             .into_iter()
+            .map(|entry| &entry.context_id)
             .filter(|id| seen.insert((*id).clone()))
             .cloned()
             .collect()
@@ -272,6 +394,32 @@ impl From<BootstrapConfig> for BootstrapResolver {
 mod tests {
     use super::*;
 
+    // -- Helper: create a BootstrapContextEntry ----------------------------
+
+    fn entry(ctx_id: &str, creator: &str) -> BootstrapContextEntry {
+        BootstrapContextEntry::new(ctx_id.to_owned(), DID::from(creator))
+    }
+
+    // -- BootstrapContextEntry --------------------------------------------
+
+    #[test]
+    fn bootstrap_context_entry_construction() {
+        let e = BootstrapContextEntry::new(
+            "ctx-discovery-1".to_owned(),
+            DID::from("did:dht:zCreator1"),
+        );
+        assert_eq!(e.context_id, "ctx-discovery-1");
+        assert_eq!(e.expected_creator_did, "did:dht:zCreator1");
+    }
+
+    #[test]
+    fn bootstrap_context_entry_serde_roundtrip() {
+        let e = entry("ctx-discovery-1", "did:dht:zCreator1");
+        let json = serde_json::to_string(&e).unwrap();
+        let deserialized: BootstrapContextEntry = serde_json::from_str(&json).unwrap();
+        assert_eq!(e, deserialized);
+    }
+
     // -- BootstrapConfig defaults -----------------------------------------
 
     #[test]
@@ -289,25 +437,28 @@ mod tests {
     #[test]
     fn default_config_has_empty_context_lists() {
         let config = BootstrapConfig::default();
-        assert!(config.default_context_ids.is_empty());
-        assert!(config.custom_context_ids.is_empty());
+        assert!(config.default_contexts.is_empty());
+        assert!(config.custom_contexts.is_empty());
     }
 
     #[test]
-    fn default_config_all_context_ids_returns_empty() {
+    fn default_config_all_contexts_returns_empty() {
         let config = BootstrapConfig::default();
-        assert!(config.all_context_ids().is_empty());
+        assert!(config.all_contexts().is_empty());
     }
 
     // -- BootstrapConfig construction -------------------------------------
 
     #[test]
-    fn with_defaults_sets_default_context_ids() {
-        let ids = vec!["ctx-discovery-1".to_owned(), "ctx-discovery-2".to_owned()];
-        let config = BootstrapConfig::with_defaults(ids.clone());
+    fn with_defaults_sets_default_contexts() {
+        let entries = vec![
+            entry("ctx-discovery-1", "did:dht:zCreator1"),
+            entry("ctx-discovery-2", "did:dht:zCreator2"),
+        ];
+        let config = BootstrapConfig::with_defaults(entries.clone());
 
-        assert_eq!(config.default_context_ids, ids);
-        assert!(config.custom_context_ids.is_empty());
+        assert_eq!(config.default_contexts, entries);
+        assert!(config.custom_contexts.is_empty());
         assert!(config.should_auto_query());
         assert!(config.should_fallback());
     }
@@ -317,38 +468,41 @@ mod tests {
     #[test]
     fn add_custom_context_appends_to_custom_list() {
         let mut config = BootstrapConfig::default();
-        config.add_custom_context("ctx-custom-1".to_owned());
-        config.add_custom_context("ctx-custom-2".to_owned());
+        config.add_custom_context(entry("ctx-custom-1", "did:dht:zCustom1"));
+        config.add_custom_context(entry("ctx-custom-2", "did:dht:zCustom2"));
 
-        assert_eq!(config.custom_context_ids.len(), 2);
-        assert_eq!(config.custom_context_ids[0], "ctx-custom-1");
-        assert_eq!(config.custom_context_ids[1], "ctx-custom-2");
+        assert_eq!(config.custom_contexts.len(), 2);
+        assert_eq!(config.custom_contexts[0].context_id, "ctx-custom-1");
+        assert_eq!(config.custom_contexts[1].context_id, "ctx-custom-2");
     }
 
-    // -- all_context_ids combines defaults and custom ---------------------
+    // -- all_contexts combines defaults and custom ------------------------
 
     #[test]
-    fn all_context_ids_combines_defaults_and_custom() {
-        let mut config = BootstrapConfig::with_defaults(vec!["ctx-default-1".to_owned()]);
-        config.add_custom_context("ctx-custom-1".to_owned());
-
-        let all_ids = config.all_context_ids();
-        assert_eq!(all_ids.len(), 2);
-        assert_eq!(all_ids[0], "ctx-default-1");
-        assert_eq!(all_ids[1], "ctx-custom-1");
-    }
-
-    #[test]
-    fn all_context_ids_defaults_come_before_custom() {
+    fn all_contexts_combines_defaults_and_custom() {
         let mut config =
-            BootstrapConfig::with_defaults(vec!["ctx-d1".to_owned(), "ctx-d2".to_owned()]);
-        config.add_custom_context("ctx-c1".to_owned());
+            BootstrapConfig::with_defaults(vec![entry("ctx-default-1", "did:dht:zD1")]);
+        config.add_custom_context(entry("ctx-custom-1", "did:dht:zC1"));
 
-        let all_ids = config.all_context_ids();
-        assert_eq!(all_ids.len(), 3);
-        assert_eq!(*all_ids[0], "ctx-d1");
-        assert_eq!(*all_ids[1], "ctx-d2");
-        assert_eq!(*all_ids[2], "ctx-c1");
+        let all = config.all_contexts();
+        assert_eq!(all.len(), 2);
+        assert_eq!(all[0].context_id, "ctx-default-1");
+        assert_eq!(all[1].context_id, "ctx-custom-1");
+    }
+
+    #[test]
+    fn all_contexts_defaults_come_before_custom() {
+        let mut config = BootstrapConfig::with_defaults(vec![
+            entry("ctx-d1", "did:dht:zD1"),
+            entry("ctx-d2", "did:dht:zD2"),
+        ]);
+        config.add_custom_context(entry("ctx-c1", "did:dht:zC1"));
+
+        let all = config.all_contexts();
+        assert_eq!(all.len(), 3);
+        assert_eq!(all[0].context_id, "ctx-d1");
+        assert_eq!(all[1].context_id, "ctx-d2");
+        assert_eq!(all[2].context_id, "ctx-c1");
     }
 
     // -- Opt-out of auto-query --------------------------------------------
@@ -373,8 +527,9 @@ mod tests {
 
     #[test]
     fn bootstrap_config_serialization_roundtrip() {
-        let mut config = BootstrapConfig::with_defaults(vec!["ctx-discovery-1".to_owned()]);
-        config.add_custom_context("ctx-custom-1".to_owned());
+        let mut config =
+            BootstrapConfig::with_defaults(vec![entry("ctx-discovery-1", "did:dht:zCreator1")]);
+        config.add_custom_context(entry("ctx-custom-1", "did:dht:zCustom1"));
         config.auto_query_on_identity_creation = false;
 
         let json = serde_json::to_string(&config).unwrap();
@@ -383,12 +538,76 @@ mod tests {
         assert_eq!(config, deserialized);
     }
 
+    // -- verify_context_creator -------------------------------------------
+
+    #[test]
+    fn verify_context_creator_success() {
+        let config =
+            BootstrapConfig::with_defaults(vec![entry("ctx-discovery-1", "did:dht:zCreator1")]);
+
+        let result = config
+            .verify_context_creator(
+                &"ctx-discovery-1".to_owned(),
+                &DID::from("did:dht:zCreator1"),
+            )
+            .unwrap();
+        assert!(result);
+    }
+
+    #[test]
+    fn verify_context_creator_not_found() {
+        let config =
+            BootstrapConfig::with_defaults(vec![entry("ctx-discovery-1", "did:dht:zCreator1")]);
+
+        let result = config
+            .verify_context_creator(&"ctx-unknown".to_owned(), &DID::from("did:dht:zCreator1"))
+            .unwrap();
+        assert!(!result);
+    }
+
+    #[test]
+    fn verify_context_creator_mismatch() {
+        let config =
+            BootstrapConfig::with_defaults(vec![entry("ctx-discovery-1", "did:dht:zCreator1")]);
+
+        let err = config
+            .verify_context_creator(
+                &"ctx-discovery-1".to_owned(),
+                &DID::from("did:dht:zAttacker"),
+            )
+            .unwrap_err();
+
+        assert!(matches!(
+            err,
+            BootstrapVerificationError::CreatorMismatch { .. }
+        ));
+        let msg = err.to_string();
+        assert!(msg.contains("ctx-discovery-1"));
+        assert!(msg.contains("did:dht:zCreator1"));
+        assert!(msg.contains("did:dht:zAttacker"));
+    }
+
+    #[test]
+    fn verify_context_creator_checks_custom_contexts() {
+        let mut config = BootstrapConfig::default();
+        config.add_custom_context(entry("ctx-custom-1", "did:dht:zCustomCreator"));
+
+        let result = config
+            .verify_context_creator(
+                &"ctx-custom-1".to_owned(),
+                &DID::from("did:dht:zCustomCreator"),
+            )
+            .unwrap();
+        assert!(result);
+    }
+
     // -- BootstrapResolver ------------------------------------------------
 
     #[test]
     fn resolver_returns_all_context_ids() {
-        let mut config = BootstrapConfig::with_defaults(vec!["ctx-default-1".to_owned()]);
-        config.add_custom_context("ctx-custom-1".to_owned());
+        let mut config =
+            BootstrapConfig::with_defaults(vec![entry("ctx-default-1", "did:dht:zD1")]);
+        config.add_custom_context(entry("ctx-custom-1", "did:dht:zC1"));
 
         let resolver = BootstrapResolver::new(config);
         let contexts = resolver.resolve_contexts();
@@ -400,9 +619,10 @@ mod tests {
 
     #[test]
     fn resolver_deduplicates_context_ids() {
-        let mut config = BootstrapConfig::with_defaults(vec!["ctx-shared".to_owned()]);
-        config.add_custom_context("ctx-shared".to_owned());
-        config.add_custom_context("ctx-unique".to_owned());
+        let mut config =
+            BootstrapConfig::with_defaults(vec![entry("ctx-shared", "did:dht:zCreator")]);
+        config.add_custom_context(entry("ctx-shared", "did:dht:zCreator"));
+        config.add_custom_context(entry("ctx-unique", "did:dht:zOther"));
 
         let resolver = BootstrapResolver::new(config);
         let contexts = resolver.resolve_contexts();
@@ -421,14 +641,14 @@ mod tests {
 
     #[test]
     fn resolver_config_accessor_returns_config() {
-        let config = BootstrapConfig::with_defaults(vec!["ctx-1".to_owned()]);
+        let config = BootstrapConfig::with_defaults(vec![entry("ctx-1", "did:dht:zC1")]);
         let resolver = BootstrapResolver::new(config.clone());
         assert_eq!(resolver.config(), &config);
     }
 
     #[test]
     fn resolver_from_config() {
-        let config = BootstrapConfig::with_defaults(vec!["ctx-1".to_owned()]);
+        let config = BootstrapConfig::with_defaults(vec![entry("ctx-1", "did:dht:zC1")]);
         let resolver: BootstrapResolver = config.into();
         assert_eq!(resolver.resolve_contexts(), vec!["ctx-1"]);
     }
@@ -437,7 +657,8 @@ mod tests {
 
     #[test]
     fn resolve_with_fallback_returns_contexts_when_available() {
-        let config = BootstrapConfig::with_defaults(vec!["ctx-discovery-1".to_owned()]);
+        let config =
+            BootstrapConfig::with_defaults(vec![entry("ctx-discovery-1", "did:dht:zCreator1")]);
         let resolver = BootstrapResolver::new(config);
 
         let result = resolver.resolve_with_fallback("did:dht:zTestDid").unwrap();

--- a/crates/scp-core/src/discovery/mod.rs
+++ b/crates/scp-core/src/discovery/mod.rs
@@ -30,7 +30,7 @@
 //! - [`DiscoveryResult`] -- Merged search results with provenance.
 //! - [`DiscoveryResultEntry`] -- A single result entry with relevance scoring.
 //! - [`RegistrationEntry`] -- A registered agent entry in a context with discovery tools.
-//! - [`DiscoveryBootstrap`] -- Default context configuration.
+//! - [`BootstrapContextEntry`] -- Bootstrap context with creator DID verification (§22.13.2).
 //! - [`DataProvenance`] -- Placeholder provenance metadata (replaced by SCP-070).
 //! - [`DiscoveryError`] -- Error type for discovery operations.
 //! - [`AddressResolver`] -- Multi-path address resolution (§22.8).
@@ -59,7 +59,10 @@ pub use addressing::{
     PetnameStore, ResolutionCache, ResolutionLayer, ResolutionPath, TrustLevel, normalize_address,
     parse_address,
 };
-pub use bootstrap::{BootstrapConfig, BootstrapResolver, WellKnownBootstrapError};
+pub use bootstrap::{
+    BootstrapConfig, BootstrapContextEntry, BootstrapResolver, BootstrapVerificationError,
+    WellKnownBootstrapError,
+};
 pub use context::{
     AgentDeregisterParams, AgentDeregisterResult, AgentRegisterParams, AgentRegisterResult,
     AgentSearchParams, AgentSearchResult, RegistrationEvent, TOOL_AGENT_DEREGISTER,
@@ -199,23 +202,6 @@ pub struct RegistrationEntry {
 }
 
 // ---------------------------------------------------------------------------
-// DiscoveryBootstrap
-// ---------------------------------------------------------------------------
-
-/// Default context configuration for SDK bootstrap.
-///
-/// Analogous to DNS root servers: the SDK ships with configurable default
-/// bootstrap context IDs that are queried on first identity creation (opt-out).
-/// If defaults are unreachable, direct DID resolution still works.
-///
-/// See ADR-020 acceptance criterion 8.
-#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
-pub struct DiscoveryBootstrap {
-    /// Default bootstrap context IDs to query on bootstrap.
-    pub default_context_ids: Vec<ContextId>,
-}
-
-// ---------------------------------------------------------------------------
 // DiscoveryError
 // ---------------------------------------------------------------------------
 
@@ -302,20 +288,6 @@ mod tests {
         let deserialized: RegistrationEntry = serde_json::from_str(&json).unwrap();
 
         assert_eq!(entry, deserialized);
-    }
-
-    #[test]
-    fn discovery_bootstrap_default_has_no_contexts() {
-        let bootstrap = DiscoveryBootstrap::default();
-        assert!(bootstrap.default_context_ids.is_empty());
-    }
-
-    #[test]
-    fn discovery_bootstrap_with_contexts() {
-        let bootstrap = DiscoveryBootstrap {
-            default_context_ids: vec!["ctx-discovery-1".to_owned(), "ctx-discovery-2".to_owned()],
-        };
-        assert_eq!(bootstrap.default_context_ids.len(), 2);
     }
 
     #[test]

--- a/crates/scp-testing/tests/integration/discovery.rs
+++ b/crates/scp-testing/tests/integration/discovery.rs
@@ -14,8 +14,8 @@
 //! configuration, trust level ordering, and handle target variants.
 
 use scp_core::discovery::{
-    BootstrapConfig, DataProvenance, DiscoveryQuery, HandleTarget, ParsedAddress, PetnameMap,
-    RegistrationEntry, TrustLevel, normalize_address, parse_address,
+    BootstrapConfig, BootstrapContextEntry, DataProvenance, DiscoveryQuery, HandleTarget,
+    ParsedAddress, PetnameMap, RegistrationEntry, TrustLevel, normalize_address, parse_address,
 };
 use scp_core::discovery::{
     HandleDeregisterParams, HandleLookupParams, HandleRegisterParams, HandleRegistry,
@@ -394,37 +394,40 @@ async fn did_routing_id_deterministic() {
 }
 
 // ---------------------------------------------------------------------------
-// 16. bootstrap_config: with_defaults, add_custom_context, all_context_ids
+// 16. bootstrap_config: with_defaults, add_custom_context, all_contexts
 // ---------------------------------------------------------------------------
 
 #[tokio::test]
 async fn bootstrap_config() {
     // Default config.
     let default_config = BootstrapConfig::default();
-    assert!(default_config.default_context_ids.is_empty());
-    assert!(default_config.custom_context_ids.is_empty());
+    assert!(default_config.default_contexts.is_empty());
+    assert!(default_config.custom_contexts.is_empty());
     assert!(default_config.should_auto_query());
     assert!(default_config.should_fallback());
 
-    // with_defaults.
+    // with_defaults using BootstrapContextEntry.
     let config = BootstrapConfig::with_defaults(vec![
-        "ctx-discovery-1".to_owned(),
-        "ctx-discovery-2".to_owned(),
+        BootstrapContextEntry::new("ctx-discovery-1".to_owned(), DID::from("did:dht:zCreator1")),
+        BootstrapContextEntry::new("ctx-discovery-2".to_owned(), DID::from("did:dht:zCreator2")),
     ]);
-    assert_eq!(config.default_context_ids.len(), 2);
-    assert!(config.custom_context_ids.is_empty());
+    assert_eq!(config.default_contexts.len(), 2);
+    assert!(config.custom_contexts.is_empty());
 
     // add_custom_context.
     let mut config = config;
-    config.add_custom_context("ctx-custom-1".to_owned());
-    assert_eq!(config.custom_context_ids.len(), 1);
+    config.add_custom_context(BootstrapContextEntry::new(
+        "ctx-custom-1".to_owned(),
+        DID::from("did:dht:zCustom1"),
+    ));
+    assert_eq!(config.custom_contexts.len(), 1);
 
-    // all_context_ids combines defaults and custom.
-    let all = config.all_context_ids();
+    // all_contexts combines defaults and custom.
+    let all = config.all_contexts();
     assert_eq!(all.len(), 3);
-    assert_eq!(*all[0], "ctx-discovery-1");
-    assert_eq!(*all[1], "ctx-discovery-2");
-    assert_eq!(*all[2], "ctx-custom-1");
+    assert_eq!(all[0].context_id, "ctx-discovery-1");
+    assert_eq!(all[1].context_id, "ctx-discovery-2");
+    assert_eq!(all[2].context_id, "ctx-custom-1");
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Adds `BootstrapContextEntry` struct pairing context IDs with expected creator DIDs
- Renames `default_context_ids`/`custom_context_ids` to `default_contexts`/`custom_contexts`
- Adds `verify_context_creator()` method for post-join creator DID verification
- Removes vestigial `DiscoveryBootstrap` struct
- Renames `all_context_ids()` to `all_contexts()` returning entries with DIDs

## Security
Defends against context ID substitution attacks (§22.13.2). After joining a bootstrap context via MLS, the SDK verifies the creator DID matches the expected value hardcoded in the bootstrap config.

## Test plan
- [ ] 6 new tests: entry construction, serde roundtrip, verify success/not-found/mismatch, custom contexts
- [ ] All 25 existing bootstrap tests updated and passing
- [ ] Integration test updated

🤖 Generated with [Claude Code](https://claude.com/claude-code)