### PR TITLE
fix(core): P0 audit fixes — WASM events, pseudonym oracle, atomic custody, ceiling escalation, phantom events

### DIFF
--- a/.claude/agent-memory/security-reviewer/MEMORY.md
+++ b/.claude/agent-memory/security-reviewer/MEMORY.md
@@ -67,9 +67,12 @@
 - HIGH: publicKeyFromKeystore takeLast(32) fragile
 - See pseudonym HMAC key material inconsistency below
 
-### Pseudonym HMAC Key Material Inconsistency -- HIGH
-- InMemoryKeyCustody uses PRIVATE key; spec/ADR-027/Android/WASM say PUBLIC key
-- Fix: change InMemoryKeyCustody to verifying_key().to_bytes(); regenerate golden vectors
+### Pseudonym Oracle Fix (PR fix/audit-batch-1-p0-blockers, #1431)
+- FIXED: InMemoryKeyCustody + FileKeyCustody now use HKDF(private_key) -> pseudonym_secret -> HMAC
+- UNFIXED: SqliteKeyCustody still uses public key (verifying_key) -- same oracle vulnerability
+- UNFIXED: WASM custody JSDoc documents public key algorithm -- implementors will use insecure pattern
+- Pattern: HKDF-SHA-256(salt="scp-pseudonym-secret-v1", ikm=signing_key_bytes), expand with empty info
+- Defense-in-depth gap: HKDF info param is empty; should use "scp-pseudonym-v1" for forward separation
 
 ### Tiered Storage & Context Discovery
 - See `tiered-storage-scp213.md` for full details
@@ -160,3 +163,11 @@
 - REMAINING MEDIUM: site_handler non-immutable branch uses "public, max-age=0, must-revalidate" for gated contexts -- should be "private, max-age=0, must-revalidate" (projection.rs line 2154)
 - Error codes 2070-2075: clean, no collisions
 - Pattern: WASM reimplementations of scp-core validators consistently miss defensive checks that the core version has. Always diff WASM vs core line-by-line when reimplementing.
+
+### P0 Audit Batch 1 Review (2026-03-19) -- fix/audit-batch-1-p0-blockers
+- FIXES VERIFIED: #1418 (WASM event tags), #1419 (ceiling escalation), #1420 (phantom events), #1431 (pseudonym oracle), #1470 (atomic writes)
+- REMAINING HIGH: SqliteKeyCustody pseudonym oracle (same as #1431 but unfixed)
+- REMAINING MEDIUM: append_entry missing fsync before rename; stale .tmp blocks create_new; HKDF empty info
+- send_message 3-phase pattern: sound; TOCTOU gap handled by Phase 3 re-validation; seq burn is harmless
+- Ceiling fix: NAPI + UniFFI fixed; PyO3 was already correct (resolves at registration); WASM was already correct
+- Atomic write: create_new has fsync; append_entry does NOT have fsync -- inconsistency

--- a/crates/scp-core/src/context/manager.rs
+++ b/crates/scp-core/src/context/manager.rs
@@ -2949,8 +2949,11 @@ impl ContextManager {
         let context_id = handle.context_id().to_owned();
         let context_id_bytes = context_id_to_bytes(&context_id);
 
-        // Determine if broadcast and, if so, produce the envelope under lock.
-        let broadcast_envelope: Option<BroadcastEnvelope> = {
+        // Phase 1 (under lock): State checks, capability check, membership
+        // verification, assign sequence number, produce broadcast envelope if
+        // applicable. Do NOT push to receive_buffer yet — transport may fail.
+        // See #1420 (phantom events) and #1422 (AAD zeros).
+        let (broadcast_envelope, seq) = {
             let mut contexts = self.contexts.lock().await;
             let ctx = contexts
                 .get_mut(&context_id)
@@ -3005,14 +3008,7 @@ impl ContextManager {
                     .next_sequence_number(sender_did)
                     .ok_or_else(|| ContextError::MemberNotFound(sender_did.to_string()))?;
 
-                // Emit MessageSent event to receive buffer.
-                ctx.receive_buffer.push(ContextEvent::MessageSent {
-                    sender_did: sender_did.clone(),
-                    sequence_number: seq,
-                    payload: payload.to_vec(),
-                });
-
-                Some(envelope)
+                (Some(envelope), seq)
             } else {
                 // Encrypted path: role-based capability check + seq under lock.
                 if !ctx
@@ -3029,32 +3025,49 @@ impl ContextManager {
                     .next_sequence_number(sender_did)
                     .ok_or_else(|| ContextError::MemberNotFound(sender_did.to_string()))?;
 
-                ctx.receive_buffer.push(ContextEvent::MessageSent {
-                    sender_did: sender_did.clone(),
-                    sequence_number: seq,
-                    payload: payload.to_vec(),
-                });
-
-                None
+                (None, seq)
             }
         };
         // Lock dropped before crypto/transport/event-log calls.
 
-        let encrypted = if let Some(envelope) = broadcast_envelope {
+        // Phase 2 (no lock): Encrypt + send via transport.
+        // If either fails, return error — no phantom MessageSent in buffer.
+        // Sequence number is burned on failure (gaps are harmless).
+        let encrypted = if let Some(ref envelope) = broadcast_envelope {
             // Broadcast: serialize envelope for transport.
-            envelope.encrypted_content
+            envelope.encrypted_content.clone()
         } else {
             // Encrypted: sender key (ADR-007) -> inner envelope (ADR-002) ->
             // MLS (ADR-001) -> outer envelope.
             // Epoch 0 for standard sender keys (epoch tracking is per-sender-key,
-            // incremented on key rotation; the trait consumer passes the current
-            // epoch). Sequence is the per-sender monotonic counter.
+            // incremented on key rotation). Sequence 0 — changing this requires
+            // sending the sequence in the clear alongside the ciphertext so the
+            // receiver can reconstruct the AAD.
             self.crypto
                 .encrypt_message(&context_id_bytes, sender_did, payload, 0, 0)?
         };
 
         // Send via transport.
         self.transport.send_message(&context_id_bytes, &encrypted)?;
+
+        // Phase 3 (re-acquire lock): Re-check context active + membership,
+        // then push MessageSent event to receive buffer. Only reached on
+        // successful transport send — no phantom events (#1420).
+        {
+            let mut contexts = self.contexts.lock().await;
+            if let Some(ctx) = contexts.get_mut(&context_id) {
+                // Best-effort: if context was closed/left during transport send,
+                // skip the event push. The message was still sent on the wire,
+                // but the local context is no longer active.
+                if require_active(&ctx.handle).is_ok() {
+                    ctx.receive_buffer.push(ContextEvent::MessageSent {
+                        sender_did: sender_did.clone(),
+                        sequence_number: seq,
+                        payload: payload.to_vec(),
+                    });
+                }
+            }
+        }
 
         // Append MessageSent event to event log.
         self.event_log
@@ -8743,6 +8756,39 @@ mod tests {
         }
     }
 
+    /// A transport mock that always fails on `send_message`.
+    /// Used to test that phantom `MessageSent` events are not emitted
+    /// when transport fails (#1420).
+    struct FailingTransport;
+
+    impl ContextTransportProvider for FailingTransport {
+        fn is_connected(&self) -> bool {
+            true
+        }
+
+        fn publish_context(
+            &self,
+            _id: &[u8; 32],
+            _params: &ContextParams,
+        ) -> Result<(), ContextCreationError> {
+            Ok(())
+        }
+
+        fn delete_published(&self, _id: &[u8; 32]) -> Result<(), ContextCreationError> {
+            Ok(())
+        }
+
+        fn send_message(
+            &self,
+            _context_id: &[u8; 32],
+            _encrypted_payload: &[u8],
+        ) -> Result<(), ContextError> {
+            Err(ContextError::TransportFailed(
+                "mock transport failure".into(),
+            ))
+        }
+    }
+
     // -----------------------------------------------------------------------
     // Helper: create a manager with default mocks and a registered context
     // -----------------------------------------------------------------------
@@ -9295,6 +9341,88 @@ mod tests {
             .collect();
 
         assert_eq!(seq_nums, vec![1, 2, 3, 4, 5]);
+    }
+
+    /// When transport fails, no phantom `MessageSent` event must appear in
+    /// the receive buffer. Fixes #1420.
+    #[tokio::test]
+    async fn send_message_transport_failure_no_phantom_event() {
+        let manager = ContextManager::new(
+            Box::new(MockCrypto::default()),
+            Box::new(FailingTransport),
+            Box::new(MockEventLog::default()),
+            noop_key_resolver(),
+        );
+
+        let params = ContextParams {
+            ceiling: vec![
+                crate::context::params::Capability::new("messages:read"),
+                crate::context::params::Capability::new("messages:write"),
+            ],
+            ..ContextParams::default()
+        };
+
+        let handle = manager
+            .create_context("test-ctx-fail".into(), params, "did:key:creator".into())
+            .await
+            .unwrap();
+
+        // send_message should fail because FailingTransport.send_message
+        // returns an error.
+        let result = manager
+            .send_message(&handle, &"did:key:creator".into(), b"hello", None)
+            .await;
+        assert!(
+            result.is_err(),
+            "send_message must fail when transport fails"
+        );
+
+        // The receive buffer must be empty — no phantom MessageSent event.
+        let events = manager.drain_events("test-ctx-fail").await;
+        let msg_events: Vec<_> = events
+            .iter()
+            .filter(|e| matches!(e, ContextEvent::MessageSent { .. }))
+            .collect();
+        assert!(
+            msg_events.is_empty(),
+            "no MessageSent event should be emitted when transport fails (#1420)"
+        );
+    }
+
+    /// When transport succeeds, `MessageSent` event must be present in the
+    /// receive buffer. Validates the positive path after the #1420 restructure.
+    #[tokio::test]
+    async fn send_message_transport_success_emits_event() {
+        let (manager, handle) = setup_active_context().await;
+
+        let result = manager
+            .send_message(&handle, &"did:key:creator".into(), b"positive-path", None)
+            .await;
+        assert!(
+            result.is_ok(),
+            "send_message must succeed with mock transport"
+        );
+
+        let events = manager.drain_events("test-ctx").await;
+        let msg_events: Vec<_> = events
+            .iter()
+            .filter(|e| matches!(e, ContextEvent::MessageSent { .. }))
+            .collect();
+        assert_eq!(
+            msg_events.len(),
+            1,
+            "exactly one MessageSent event must be emitted on success"
+        );
+
+        if let ContextEvent::MessageSent {
+            sender_did,
+            payload,
+            ..
+        } = &msg_events[0]
+        {
+            assert_eq!(sender_did, "did:key:creator");
+            assert_eq!(payload, b"positive-path");
+        }
     }
 
     // -----------------------------------------------------------------------

--- a/crates/scp-core/src/context/roles.rs
+++ b/crates/scp-core/src/context/roles.rs
@@ -418,6 +418,19 @@ impl CapabilityCeiling {
     pub fn len(&self) -> usize {
         self.capabilities.len()
     }
+
+    /// Returns the capabilities as UCAN-formatted string names.
+    ///
+    /// Each capability is converted to its UCAN wire-format name via
+    /// [`Capability::ucan_capability_name`]. Useful for passing ceilings
+    /// to UCAN mint/delegate operations.
+    #[must_use]
+    pub fn to_ucan_string_set(&self) -> HashSet<String> {
+        self.capabilities
+            .iter()
+            .map(Capability::ucan_capability_name)
+            .collect()
+    }
 }
 
 /// Returns the default capability ceiling for new contexts.

--- a/crates/scp-ffi/napi/src/ucan.rs
+++ b/crates/scp-ffi/napi/src/ucan.rs
@@ -355,14 +355,15 @@ pub async fn ucan_mint(
         let context_id = handle.context_id();
 
         // Get ceiling from the context handle for mint-time enforcement (#339).
-        // Empty ceiling means unrestricted — pass None, not Some(empty_set).
+        // Empty ceiling means the user passed `[]` — apply the default ceiling
+        // instead of `None` (which would mean unlimited). See #1419.
         let ceiling_strings: std::collections::HashSet<String> =
             handle.ceiling().into_iter().collect();
-        let ceiling = if ceiling_strings.is_empty() {
-            None
+        let ceiling = Some(if ceiling_strings.is_empty() {
+            scp_core::context::roles::default_ceiling().to_ucan_string_set()
         } else {
-            Some(ceiling_strings)
-        };
+            ceiling_strings
+        });
 
         let params = MintParams {
             issuer_did: &creator_did,
@@ -532,13 +533,15 @@ pub async fn ucan_delegate(
             .map_err(napi::Error::from)?;
 
         // Get ceiling from the context handle for delegation-time enforcement (#339).
+        // Empty ceiling means the user passed `[]` — apply the default ceiling
+        // instead of `None` (which would mean unlimited). See #1419.
         let ceiling_strings: std::collections::HashSet<String> =
             handle.ceiling().into_iter().collect();
-        let ceiling = if ceiling_strings.is_empty() {
-            None
+        let ceiling = Some(if ceiling_strings.is_empty() {
+            scp_core::context::roles::default_ceiling().to_ucan_string_set()
         } else {
-            Some(ceiling_strings)
-        };
+            ceiling_strings
+        });
 
         // Look up the DELEGATOR's identity from the global identity registry.
         // This is critical: the delegation must be signed with the delegator's

--- a/crates/scp-ffi/uniffi/src/bridge.rs
+++ b/crates/scp-ffi/uniffi/src/bridge.rs
@@ -5681,11 +5681,13 @@ async fn ucan_mint_impl(
                 facts: None,
                 key_scope: None,
                 signing_key_id: None,
-                ceiling: if handle.ceiling_strings.is_empty() {
-                    None
+                // Empty ceiling means the user passed `[]` — apply the default
+                // ceiling instead of `None` (which would mean unlimited). #1419.
+                ceiling: Some(if handle.ceiling_strings.is_empty() {
+                    scp_core::context::roles::default_ceiling().to_ucan_string_set()
                 } else {
-                    Some(handle.ceiling_strings.iter().cloned().collect())
-                },
+                    handle.ceiling_strings.iter().cloned().collect()
+                }),
             };
 
             let token = scp_core::crypto::ucan::mint::mint_ucan(&params, &custody.0)
@@ -5946,11 +5948,13 @@ async fn ucan_delegate_impl(
                 .collect();
 
             // Get ceiling from handle for delegation-time enforcement (#339).
-            let ceiling = if handle.ceiling_strings.is_empty() {
-                None
+            // Empty ceiling means the user passed `[]` — apply the default
+            // ceiling instead of `None` (which would mean unlimited). #1419.
+            let ceiling = Some(if handle.ceiling_strings.is_empty() {
+                scp_core::context::roles::default_ceiling().to_ucan_string_set()
             } else {
-                Some(handle.ceiling_strings.iter().cloned().collect())
-            };
+                handle.ceiling_strings.iter().cloned().collect()
+            });
 
             let params = DelegateParams {
                 parent_token: &parsed_parent,

--- a/crates/scp-ffi/wasm/src/manager.rs
+++ b/crates/scp-ffi/wasm/src/manager.rs
@@ -3343,7 +3343,7 @@ impl WasmContextManager {
             proposal_id: pid.clone(),
         });
         ctx.event_log.append_event(
-            crate::runtime::wasm_event_type_tag("GovernanceProposed"),
+            crate::runtime::wasm_event_type_tag("GovernanceProposalCreated"),
             proposer_did,
             proposal_id.as_bytes(),
         );
@@ -3443,7 +3443,7 @@ impl WasmContextManager {
         proposal.approvals.push((voter_did.to_owned(), vote_ts));
 
         ctx.event_log.append_event(
-            crate::runtime::wasm_event_type_tag("GovernanceVoteApproval"),
+            crate::runtime::wasm_event_type_tag("GovernanceVoteCast"),
             voter_did,
             proposal_id.as_bytes(),
         );
@@ -3536,7 +3536,7 @@ impl WasmContextManager {
         proposal.rejections.push((voter_did.to_owned(), vote_ts));
 
         ctx.event_log.append_event(
-            crate::runtime::wasm_event_type_tag("GovernanceVoteRejection"),
+            crate::runtime::wasm_event_type_tag("GovernanceVoteCast"),
             voter_did,
             proposal_id.as_bytes(),
         );
@@ -3601,7 +3601,7 @@ impl WasmContextManager {
         }
 
         ctx.event_log.append_event(
-            crate::runtime::wasm_event_type_tag("GovernanceVoteWithdraw"),
+            crate::runtime::wasm_event_type_tag("GovernanceVoteWithdrawn"),
             voter_did,
             proposal_id.as_bytes(),
         );

--- a/crates/scp-platform/src/file.rs
+++ b/crates/scp-platform/src/file.rs
@@ -153,6 +153,72 @@ impl HandleMap {
 }
 
 // ---------------------------------------------------------------------------
+// Atomic write helper
+// ---------------------------------------------------------------------------
+
+/// Writes `data` to `path` atomically via a `.tmp` sibling file.
+///
+/// 1. Writes to `{path}.tmp` with `mode(0o600)` on Unix.
+/// 2. Calls `sync_all` to flush to durable storage.
+/// 3. Renames to `path` (atomic on POSIX).
+/// 4. Cleans up the tmp file on any failure after creation.
+fn atomic_write(path: &Path, data: &[u8]) -> Result<(), PlatformError> {
+    let tmp_path = path.with_extension("tmp");
+
+    // Write to temp file with restrictive permissions on Unix.
+    #[cfg(unix)]
+    {
+        use std::io::Write;
+        use std::os::unix::fs::OpenOptionsExt;
+        let mut file = std::fs::OpenOptions::new()
+            .write(true)
+            .create(true)
+            .truncate(true)
+            .mode(0o600)
+            .open(&tmp_path)
+            .map_err(|e| {
+                PlatformError::CustodyError(format!("failed to create temp key file: {e}"))
+            })?;
+        file.write_all(data).map_err(|e| {
+            let _ = std::fs::remove_file(&tmp_path);
+            PlatformError::CustodyError(format!("failed to write temp key file: {e}"))
+        })?;
+        file.sync_all().map_err(|e| {
+            let _ = std::fs::remove_file(&tmp_path);
+            PlatformError::CustodyError(format!("failed to sync temp key file: {e}"))
+        })?;
+    }
+    #[cfg(not(unix))]
+    {
+        use std::io::Write;
+        let mut file = std::fs::OpenOptions::new()
+            .write(true)
+            .create(true)
+            .truncate(true)
+            .open(&tmp_path)
+            .map_err(|e| {
+                PlatformError::CustodyError(format!("failed to create temp key file: {e}"))
+            })?;
+        file.write_all(data).map_err(|e| {
+            let _ = std::fs::remove_file(&tmp_path);
+            PlatformError::CustodyError(format!("failed to write temp key file: {e}"))
+        })?;
+        file.sync_all().map_err(|e| {
+            let _ = std::fs::remove_file(&tmp_path);
+            PlatformError::CustodyError(format!("failed to sync temp key file: {e}"))
+        })?;
+    }
+
+    // Atomic rename: if this fails, the original file is untouched.
+    std::fs::rename(&tmp_path, path).map_err(|e| {
+        let _ = std::fs::remove_file(&tmp_path);
+        PlatformError::CustodyError(format!("failed to rename temp key file: {e}"))
+    })?;
+
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
 // FileKeyCustody
 // ---------------------------------------------------------------------------
 
@@ -204,6 +270,8 @@ impl FileKeyCustody {
     }
 
     /// Creates a new key file at `path` with a fresh salt.
+    ///
+    /// Uses write-to-tmp + rename for crash-safe atomic writes (#1470).
     fn create_new(path: &Path, passphrase: &str) -> Result<Self, PlatformError> {
         let mut salt = [0u8; SALT_LEN];
         rand::rngs::OsRng.fill_bytes(&mut salt);
@@ -216,38 +284,8 @@ impl FileKeyCustody {
         data.extend_from_slice(&salt);
         data.extend_from_slice(&0u32.to_le_bytes());
 
-        // Create the file with restrictive permissions atomically on Unix
-        // to avoid a TOCTOU window where the file is world-readable.
-        #[cfg(unix)]
-        {
-            use std::io::Write;
-            use std::os::unix::fs::OpenOptionsExt;
-            let mut file = std::fs::OpenOptions::new()
-                .write(true)
-                .create_new(true)
-                .mode(0o600)
-                .open(path)
-                .map_err(|e| {
-                    PlatformError::CustodyError(format!("failed to create key file: {e}"))
-                })?;
-            file.write_all(&data).map_err(|e| {
-                PlatformError::CustodyError(format!("failed to write key file: {e}"))
-            })?;
-        }
-        #[cfg(not(unix))]
-        {
-            use std::io::Write;
-            let mut file = std::fs::OpenOptions::new()
-                .write(true)
-                .create_new(true)
-                .open(path)
-                .map_err(|e| {
-                    PlatformError::CustodyError(format!("failed to create key file: {e}"))
-                })?;
-            file.write_all(&data).map_err(|e| {
-                PlatformError::CustodyError(format!("failed to write key file: {e}"))
-            })?;
-        }
+        // Write to temp file, sync, then atomic rename (#1470).
+        atomic_write(path, &data)?;
 
         Ok(Self {
             path: path.to_path_buf(),
@@ -405,6 +443,8 @@ impl FileKeyCustody {
     }
 
     /// Appends an encrypted key entry to the file and updates the entry count.
+    ///
+    /// Uses write-to-tmp + rename for crash-safe atomic writes (#1470).
     fn append_entry(
         &self,
         key_type: StoredKeyType,
@@ -438,9 +478,8 @@ impl FileKeyCustody {
         let new_count = current_count + 1;
         data[count_offset..count_offset + 4].copy_from_slice(&new_count.to_le_bytes());
 
-        // Write back.
-        std::fs::write(&self.path, &data)
-            .map_err(|e| PlatformError::CustodyError(format!("failed to write key file: {e}")))?;
+        // Write to temp file with sync_all, then atomic rename (#1470).
+        atomic_write(&self.path, &data)?;
 
         Ok(new_index)
     }
@@ -500,6 +539,8 @@ impl FileKeyCustody {
         Ok(signing_key)
     }
 }
+
+use crate::pseudonym::derive_pseudonym_secret;
 
 // Trait uses RPITIT with explicit `+ Send` bound; async fn in trait
 // does not guarantee Send futures, so manual impl Future is required.
@@ -656,13 +697,12 @@ impl KeyCustody for FileKeyCustody {
             let handle = KeyHandle::new(key_id);
             let (_key_bytes, signing_key) = self.decrypt_ed25519_key(&handle).await?;
 
-            // HMAC-SHA256(ed25519_public_key_bytes, context_id || "scp-pseudonym")
-            // ADR-027 amendment: uses verifying (public) key bytes for
-            // cross-platform determinism with hardware TEE adapters.
-            let verifying_key = signing_key.verifying_key();
-            let mut mac =
-                <Hmac<Sha256> as Mac>::new_from_slice(verifying_key.to_bytes().as_slice())
-                    .map_err(|e| PlatformError::CustodyError(e.to_string()))?;
+            // HMAC-SHA256(pseudonym_secret, context_id || "scp-pseudonym")
+            // Uses a secret derived from the private key via HKDF (§9.10.4A),
+            // NOT the public key, to prevent membership enumeration attacks.
+            let pseudonym_secret = derive_pseudonym_secret(&signing_key);
+            let mut mac = <Hmac<Sha256> as Mac>::new_from_slice(pseudonym_secret.as_slice())
+                .map_err(|e| PlatformError::CustodyError(e.to_string()))?;
             mac.update(&context_id);
             mac.update(b"scp-pseudonym");
             let hmac_output = mac.finalize().into_bytes();
@@ -697,11 +737,12 @@ impl KeyCustody for FileKeyCustody {
             let handle = KeyHandle::new(key_id);
             let (_key_bytes, signing_key) = self.decrypt_ed25519_key(&handle).await?;
 
-            // HMAC-SHA256(ed25519_public_key_bytes, context_id || epoch_BE || "scp-pseudonym-v2")
-            let verifying_key = signing_key.verifying_key();
-            let mut mac =
-                <Hmac<Sha256> as Mac>::new_from_slice(verifying_key.to_bytes().as_slice())
-                    .map_err(|e| PlatformError::CustodyError(e.to_string()))?;
+            // HMAC-SHA256(pseudonym_secret, context_id || epoch_BE || "scp-pseudonym-v2")
+            // Uses a secret derived from the private key via HKDF (§9.10.4A),
+            // NOT the public key, to prevent membership enumeration attacks.
+            let pseudonym_secret = derive_pseudonym_secret(&signing_key);
+            let mut mac = <Hmac<Sha256> as Mac>::new_from_slice(pseudonym_secret.as_slice())
+                .map_err(|e| PlatformError::CustodyError(e.to_string()))?;
             mac.update(&context_id);
             mac.update(&pseudonym_epoch.to_be_bytes());
             mac.update(b"scp-pseudonym-v2");

--- a/crates/scp-platform/src/lib.rs
+++ b/crates/scp-platform/src/lib.rs
@@ -58,6 +58,10 @@ pub mod apple;
 pub mod file;
 #[cfg(feature = "filesystem")]
 pub mod filesystem;
+// Shared pseudonym secret derivation — used by all KeyCustody backends.
+// Gated behind `software_platform` because it depends on ed25519-dalek, hkdf, sha2.
+#[cfg(feature = "software_platform")]
+pub(crate) mod pseudonym;
 #[cfg(feature = "sqlite")]
 pub mod sqlite;
 #[cfg(feature = "sync")]

--- a/crates/scp-platform/src/pseudonym.rs
+++ b/crates/scp-platform/src/pseudonym.rs
@@ -1,0 +1,41 @@
+//! Shared pseudonym secret derivation for all [`KeyCustody`](crate::traits::KeyCustody) backends.
+//!
+//! CRITICAL PRIVACY REQUIREMENT (§9.10.4A): Using public key bytes as the
+//! HMAC key for pseudonym derivation would be a membership enumeration oracle —
+//! anyone who knows a member's public key could compute their pseudonym for any
+//! `context_id` and check relay subscriptions. The `pseudonym_secret` is derived
+//! from private key bytes via HKDF-SHA-256, making it unknowable without the
+//! private key.
+
+use ed25519_dalek::SigningKey;
+use hkdf::Hkdf;
+use sha2::Sha256;
+use zeroize::Zeroizing;
+
+/// Salt for HKDF-SHA-256 pseudonym secret derivation (§9.10.4A).
+const PSEUDONYM_SECRET_SALT: &[u8] = b"scp-pseudonym-secret-v1";
+
+/// Derives a `pseudonym_secret` from an Ed25519 private key via HKDF-SHA-256.
+///
+/// ```text
+/// pseudonym_secret = HKDF-SHA256(
+///     ikm: ed25519_private_key_bytes,
+///     salt: "scp-pseudonym-secret-v1",
+///     info: "",
+///     len: 32
+/// )
+/// ```
+///
+/// All three Rust custody backends (`InMemory`, `File`, `SQLite`) use this function
+/// to ensure consistent pseudonym derivation. The derived secret is then used
+/// as the HMAC key in `derive_pseudonym` and `derive_rotatable_pseudonym`.
+pub fn derive_pseudonym_secret(signing_key: &SigningKey) -> Zeroizing<[u8; 32]> {
+    let hk = Hkdf::<Sha256>::new(Some(PSEUDONYM_SECRET_SALT), signing_key.as_bytes());
+    let mut secret = Zeroizing::new([0u8; 32]);
+    // HKDF-Expand with 32-byte output cannot fail (32 <= 255 * HashLen).
+    assert!(
+        hk.expand(b"", secret.as_mut()).is_ok(),
+        "HKDF-Expand with 32-byte output is infallible"
+    );
+    secret
+}

--- a/crates/scp-platform/src/sqlite/key_custody.rs
+++ b/crates/scp-platform/src/sqlite/key_custody.rs
@@ -389,12 +389,12 @@ impl KeyCustody for SqliteKeyCustody {
                 .get(&key_id)
                 .ok_or(PlatformError::KeyNotFound)?;
 
-            // HMAC-SHA256(ed25519_public_key_bytes, context_id || "scp-pseudonym")
-            // ADR-027 amendment: uses verifying (public) key bytes.
-            let verifying_key = signing_key.verifying_key();
-            let mut mac =
-                <Hmac<Sha256> as Mac>::new_from_slice(verifying_key.to_bytes().as_slice())
-                    .map_err(|e| PlatformError::CustodyError(e.to_string()))?;
+            // HMAC-SHA256(pseudonym_secret, context_id || "scp-pseudonym")
+            // Uses a secret derived from the private key via HKDF (§9.10.4A),
+            // NOT the public key, to prevent membership enumeration attacks.
+            let pseudonym_secret = crate::pseudonym::derive_pseudonym_secret(signing_key);
+            let mut mac = <Hmac<Sha256> as Mac>::new_from_slice(pseudonym_secret.as_slice())
+                .map_err(|e| PlatformError::CustodyError(e.to_string()))?;
             mac.update(&context_id);
             mac.update(b"scp-pseudonym");
             let hmac_output = mac.finalize().into_bytes();
@@ -443,11 +443,13 @@ impl KeyCustody for SqliteKeyCustody {
                 .get(&key_id)
                 .ok_or(PlatformError::KeyNotFound)?;
 
-            // HMAC-SHA256(ed25519_public_key_bytes, context_id || epoch_BE || "scp-pseudonym-v2")
-            let verifying_key = signing_key.verifying_key();
-            let mut mac =
-                <Hmac<Sha256> as Mac>::new_from_slice(verifying_key.to_bytes().as_slice())
-                    .map_err(|e| PlatformError::CustodyError(e.to_string()))?;
+            // HMAC-SHA256(pseudonym_secret, context_id || epoch_BE || "scp-pseudonym-v2")
+            // Uses a secret derived from the private key via HKDF (§9.10.4A),
+            // NOT the public key, to prevent membership enumeration attacks.
+            // BLACK-001 mitigation: epoch_BE breaks long-term pseudonym correlation.
+            let pseudonym_secret = crate::pseudonym::derive_pseudonym_secret(signing_key);
+            let mut mac = <Hmac<Sha256> as Mac>::new_from_slice(pseudonym_secret.as_slice())
+                .map_err(|e| PlatformError::CustodyError(e.to_string()))?;
             mac.update(&context_id);
             mac.update(&pseudonym_epoch.to_be_bytes());
             mac.update(b"scp-pseudonym-v2");

--- a/crates/scp-platform/src/testing/key_custody.rs
+++ b/crates/scp-platform/src/testing/key_custody.rs
@@ -8,7 +8,6 @@ use std::collections::HashMap;
 use std::sync::atomic::{AtomicU64, Ordering};
 
 use ed25519_dalek::{Signer, SigningKey, VerifyingKey};
-use hkdf::Hkdf;
 use hmac::{Hmac, Mac};
 use rand::{CryptoRng, RngCore, SeedableRng};
 use sha2::Sha256;
@@ -190,37 +189,7 @@ impl Default for InMemoryKeyCustody {
     }
 }
 
-/// Salt for HKDF-SHA-256 pseudonym secret derivation (§9.10.4A).
-#[allow(dead_code)] // Used by derive_pseudonym_secret, retained for future pseudonym wiring
-const PSEUDONYM_SECRET_SALT: &[u8] = b"scp-pseudonym-secret-v1";
-
-/// Derives a `pseudonym_secret` from Ed25519 private key bytes via HKDF-SHA-256.
-///
-/// ```text
-/// pseudonym_secret = HKDF-SHA256(
-///     ikm: ed25519_private_key_bytes,
-///     salt: "scp-pseudonym-secret-v1",
-///     info: "",
-///     len: 32
-/// )
-/// ```
-///
-/// CRITICAL PRIVACY REQUIREMENT (§9.10.4A): Using public key bytes as the
-/// HMAC key would be a membership enumeration oracle — anyone who knows a
-/// member's public key could compute their pseudonym for any `context_id`
-/// and check relay subscriptions. The `pseudonym_secret` is derived from
-/// private key bytes, making it unknowable without the private key.
-#[allow(dead_code)] // Retained for future pseudonym wiring
-fn derive_pseudonym_secret(signing_key: &SigningKey) -> Zeroizing<[u8; 32]> {
-    let hk = Hkdf::<Sha256>::new(Some(PSEUDONYM_SECRET_SALT), signing_key.as_bytes());
-    let mut secret = Zeroizing::new([0u8; 32]);
-    // HKDF-Expand with 32-byte output cannot fail (32 <= 255 * HashLen).
-    assert!(
-        hk.expand(b"", secret.as_mut()).is_ok(),
-        "HKDF-Expand with 32-byte output is infallible"
-    );
-    secret
-}
+use crate::pseudonym::derive_pseudonym_secret;
 
 // Trait uses RPITIT with explicit `+ Send` bound; async fn in trait
 // does not guarantee Send futures, so manual impl Future is required.
@@ -392,14 +361,12 @@ impl KeyCustody for InMemoryKeyCustody {
                 .get(&key_id)
                 .ok_or(PlatformError::KeyNotFound)?;
 
-            // HMAC-SHA256(ed25519_public_key_bytes, context_id || "scp-pseudonym")
-            // ADR-027 amendment: uses verifying (public) key bytes, not signing
-            // (private) key bytes, for cross-platform determinism with hardware
-            // TEE adapters that cannot export private key material.
-            let verifying_key = signing_key.verifying_key();
-            let mut mac =
-                <Hmac<Sha256> as Mac>::new_from_slice(verifying_key.to_bytes().as_slice())
-                    .map_err(|e| PlatformError::CustodyError(e.to_string()))?;
+            // HMAC-SHA256(pseudonym_secret, context_id || "scp-pseudonym")
+            // Uses a secret derived from the private key via HKDF (§9.10.4A),
+            // NOT the public key, to prevent membership enumeration attacks.
+            let pseudonym_secret = derive_pseudonym_secret(signing_key);
+            let mut mac = <Hmac<Sha256> as Mac>::new_from_slice(pseudonym_secret.as_slice())
+                .map_err(|e| PlatformError::CustodyError(e.to_string()))?;
             mac.update(&context_id);
             mac.update(b"scp-pseudonym");
             let hmac_output = mac.finalize().into_bytes();
@@ -449,15 +416,13 @@ impl KeyCustody for InMemoryKeyCustody {
                 .get(&key_id)
                 .ok_or(PlatformError::KeyNotFound)?;
 
-            // HMAC-SHA256(ed25519_public_key_bytes, context_id || epoch_BE || "scp-pseudonym-v2")
-            // ADR-027 amendment: uses verifying (public) key bytes, not signing
-            // (private) key bytes, for cross-platform determinism with hardware
-            // TEE adapters that cannot export private key material.
+            // HMAC-SHA256(pseudonym_secret, context_id || epoch_BE || "scp-pseudonym-v2")
+            // Uses a secret derived from the private key via HKDF (§9.10.4A),
+            // NOT the public key, to prevent membership enumeration attacks.
             // BLACK-001 mitigation: epoch_BE breaks long-term pseudonym correlation.
-            let verifying_key = signing_key.verifying_key();
-            let mut mac =
-                <Hmac<Sha256> as Mac>::new_from_slice(verifying_key.to_bytes().as_slice())
-                    .map_err(|e| PlatformError::CustodyError(e.to_string()))?;
+            let pseudonym_secret = derive_pseudonym_secret(signing_key);
+            let mut mac = <Hmac<Sha256> as Mac>::new_from_slice(pseudonym_secret.as_slice())
+                .map_err(|e| PlatformError::CustodyError(e.to_string()))?;
             mac.update(&context_id);
             mac.update(&pseudonym_epoch.to_be_bytes());
             mac.update(b"scp-pseudonym-v2");
@@ -866,11 +831,10 @@ mod tests {
         let epoch: u64 = 7;
 
         // Compute expected pseudonym seed using the v2 reference algorithm:
-        // seed = HMAC-SHA256(public_key_bytes, context_id || epoch_BE || "scp-pseudonym-v2")
+        // seed = HMAC-SHA256(pseudonym_secret, context_id || epoch_BE || "scp-pseudonym-v2")
         let identity_signing_key = SigningKey::from_bytes(&seed_bytes);
-        let identity_public_key = identity_signing_key.verifying_key();
-        let mut mac =
-            Hmac::<Sha256>::new_from_slice(identity_public_key.to_bytes().as_slice()).unwrap();
+        let pseudonym_secret = derive_pseudonym_secret(&identity_signing_key);
+        let mut mac = Hmac::<Sha256>::new_from_slice(pseudonym_secret.as_slice()).unwrap();
         mac.update(context_id);
         mac.update(&epoch.to_be_bytes());
         mac.update(b"scp-pseudonym-v2");
@@ -898,9 +862,9 @@ mod tests {
     ///
     /// Verifies that `derive_pseudonym` is deterministic and that different
     /// context IDs produce different pseudonyms. The `expected_seed` value is
-    /// computed from the reference HMAC-SHA256 algorithm using public key bytes
-    /// as the HMAC key (ADR-027 amendment). This golden vector is authoritative
-    /// for cross-language (Swift, Kotlin, TypeScript) verification.
+    /// computed from the reference HMAC-SHA256 algorithm using an HKDF-derived
+    /// pseudonym secret from the private key (§9.10.4A). This golden vector is
+    /// authoritative for cross-language (Swift, Kotlin, TypeScript) verification.
     #[tokio::test]
     async fn derive_pseudonym_cross_platform_golden_vector() {
         // Known identity key seed: 0x00...01 (31 zeros, then 0x01).
@@ -913,13 +877,12 @@ mod tests {
         let context_id = b"test";
 
         // Compute expected pseudonym seed using the reference algorithm directly:
-        // seed = HMAC-SHA256(public_key_bytes, context_id || "scp-pseudonym")
-        // ADR-027 amendment: HMAC key is the Ed25519 PUBLIC key, not the private
-        // key, for cross-platform determinism with hardware TEE adapters.
+        // seed = HMAC-SHA256(pseudonym_secret, context_id || "scp-pseudonym")
+        // §9.10.4A: HMAC key is a secret derived from the private key via HKDF,
+        // NOT the public key, to prevent membership enumeration attacks.
         let identity_signing_key = SigningKey::from_bytes(&seed_bytes);
-        let identity_public_key = identity_signing_key.verifying_key();
-        let mut mac =
-            Hmac::<Sha256>::new_from_slice(identity_public_key.to_bytes().as_slice()).unwrap();
+        let pseudonym_secret = derive_pseudonym_secret(&identity_signing_key);
+        let mut mac = Hmac::<Sha256>::new_from_slice(pseudonym_secret.as_slice()).unwrap();
         mac.update(context_id);
         mac.update(b"scp-pseudonym");
         let expected_seed: [u8; 32] = mac.finalize().into_bytes().into();
@@ -949,9 +912,9 @@ mod tests {
         );
 
         // Assert that the implementation matches the reference algorithm.
-        // expected_seed is HMAC-SHA256(sk, context_id || "scp-pseudonym"), so
-        // the expected public key is the verifying key of the Ed25519 signing key
-        // derived from that seed. This is the authoritative golden value —
+        // expected_seed is HMAC-SHA256(pseudonym_secret, context_id || "scp-pseudonym"),
+        // so the expected public key is the verifying key of the Ed25519 signing
+        // key derived from that seed. This is the authoritative golden value —
         // Swift, Kotlin, and TypeScript implementations MUST produce the same
         // public key bytes for these inputs.
         let expected_signing_key = SigningKey::from_bytes(&expected_seed);

--- a/crates/scp-platform/src/traits.rs
+++ b/crates/scp-platform/src/traits.rs
@@ -337,7 +337,8 @@ pub trait KeyCustody: Send + Sync {
     ///
     /// For hardware-backed keys: the HMAC is computed inside the HSM using an
     /// associated symmetric key derived during [`generate_keypair`](KeyCustody::generate_keypair).
-    /// For software keys: the HMAC uses the raw Ed25519 public key bytes (ADR-027 amendment).
+    /// For software keys: the HMAC key is an HKDF-derived pseudonym secret from
+    /// the private key (§9.10.4A), NOT the public key, to prevent enumeration attacks.
     ///
     /// The returned [`PseudonymKeypair`] is always software-managed (derived
     /// output).


### PR DESCRIPTION
## Summary

Fixes all 5 P0 launch blockers identified in the 2026-03-18/19 codebase audit.

- **#1418**: WASM governance event type tags corrected to match scp-core canonical names (`GovernanceProposalCreated`, `GovernanceVoteCast`, `GovernanceVoteWithdrawn`)
- **#1419**: Empty UCAN ceiling in NAPI/UniFFI bridges now applies `default_ceiling()` instead of `None` (which meant unlimited), via new `CapabilityCeiling::to_ucan_string_set()` helper
- **#1420**: Restructured `send_message` into 3-phase lock pattern (check+seq → encrypt+send → re-check+emit) to prevent phantom `MessageSent` events on transport failure
- **#1431**: Fixed pseudonym enumeration oracle — all 3 Rust custody backends (InMemory, File, SQLite) now derive HMAC key from private key via HKDF-SHA-256 instead of public key, via shared `pseudonym.rs` module
- **#1470**: Atomic file writes via `atomic_write` helper (write-to-tmp + `sync_all` + rename + failure cleanup) for `FileKeyCustody`

### Breaking changes

- **Pseudonym derivation**: Pseudonyms derived by Rust backends will differ from previous versions. Swift/Kotlin backends need separate updates (tracked).

### New files

- `crates/scp-platform/src/pseudonym.rs` — shared HKDF-based pseudonym secret derivation

### New tests

- `send_message_transport_failure_no_phantom_event` — verifies no phantom events on transport error
- `send_message_transport_success_emits_event` — verifies correct event on success

Closes #1418, closes #1419, closes #1420, closes #1431, closes #1470

## Test plan

- [x] `cargo test --workspace` — 4654 tests, 0 failures
- [x] `cargo clippy --workspace --all-targets` with all features — 0 warnings
- [x] `cargo fmt --all --check` — clean
- [x] `cargo check -p scp-ffi-wasm --target wasm32-unknown-unknown` — clean
- [x] `cargo test -p scp-core --test wasm_conformance` — 118 tests pass
- [x] 3 review rounds (10→manual→4 agents), double-zero achieved

🤖 Generated with [Claude Code](https://claude.com/claude-code)