### PR TITLE
fix(core): audit batch 2 — unbounded dedup, MCP stdio, governance validation, /tmp fallback, disposed race, economy leak

### DIFF
--- a/bindings/typescript/src/context.ts
+++ b/bindings/typescript/src/context.ts
@@ -1410,10 +1410,10 @@ export class Context implements AsyncDisposable {
     if (this._disposed) {
       return;
     }
-    this._disposed = true;
     try {
       const bridge = await getBridge();
       await bridge.contextLeave(this._handle, this._identityDid);
+      this._disposed = true;
     } catch (error) {
       throw mapBridgeError(error);
     }
@@ -1431,10 +1431,10 @@ export class Context implements AsyncDisposable {
     if (this._disposed) {
       return;
     }
-    this._disposed = true;
     try {
       const bridge = await getBridge();
       await bridge.contextClose(this._handle, this._identityDid);
+      this._disposed = true;
     } catch (error) {
       throw mapBridgeError(error);
     }

--- a/bindings/typescript/tests/real-napi.test.ts
+++ b/bindings/typescript/tests/real-napi.test.ts
@@ -288,16 +288,31 @@ if (bridge === null || serverAddon === null) {
       expect(ctx.contextId).toBeTruthy();
     });
 
-    test("creates a context with governance and TTL", async () => {
+    test("rejects unsupported governance model", async () => {
+      const identity = await napi.identityCreate("in_memory");
+      await expect(
+        napi.contextCreate(
+          identity,
+          JSON.stringify({
+            ceiling: ["messages:read"],
+            governance: "threshold",
+            ttlSeconds: 3600,
+            memoryScope: "full",
+            ceilingPolicy: "governed",
+          }),
+        ),
+      ).rejects.toThrow(/unsupported governance model/);
+    });
+
+    test("creates a context with single_admin governance and TTL", async () => {
       const identity = await napi.identityCreate("in_memory");
       const ctx = await napi.contextCreate(
         identity,
         JSON.stringify({
           ceiling: ["messages:read"],
-          governance: "threshold",
+          governance: "single_admin",
           ttlSeconds: 3600,
           memoryScope: "full",
-          ceilingPolicy: "governed",
         }),
       );
       expect(ctx.contextId).toBeTruthy();

--- a/crates/scp-core/src/context/manager.rs
+++ b/crates/scp-core/src/context/manager.rs
@@ -3125,7 +3125,18 @@ impl ContextManager {
         // `decrypt_message` is sync and takes its own internal mutex for
         // OpenMLS group state — no need to hold `self.contexts` here.
         // MLS layer (ADR-001) -> sender key layer (ADR-007).
-        // Uses epoch=0, sequence=0 matching the send path's AAD.
+        //
+        // AAD epoch=0, sequence=0: The sender key AAD includes epoch and
+        // sequence for replay/reorder protection (spec §9.7). However, the
+        // current wire format does not transmit these values in the clear —
+        // they are encrypted inside the MLS ciphertext. The receiver therefore
+        // cannot reconstruct the sender's epoch/sequence without first
+        // decrypting, creating a chicken-and-egg problem. Both send and
+        // receive paths use hardcoded zeros until the wire format carries
+        // epoch/sequence in an authenticated-but-unencrypted header (see
+        // #1422). This is safe because MLS already provides its own replay
+        // protection via the ratchet tree; the sender key AAD is a
+        // defense-in-depth layer that is currently inert.
         let decrypted = self
             .crypto
             .decrypt_message(&context_id_bytes, encrypted_blob, 0, 0)?;

--- a/crates/scp-ffi/napi/src/context.rs
+++ b/crates/scp-ffi/napi/src/context.rs
@@ -450,9 +450,21 @@ pub async fn context_create(
         _ => scp_core::context::params::MemoryScope::Ephemeral,
     };
 
-    // Currently only SingleAdmin is supported; governance string was already parsed.
-    let _ = governance.as_str();
-    let core_governance = scp_core::context::params::GovernanceModel::SingleAdmin;
+    // Validate governance model — reject unknown values instead of silently
+    // defaulting to SingleAdmin (#1421).
+    let core_governance = match governance.as_str() {
+        "single_admin" => scp_core::context::params::GovernanceModel::SingleAdmin,
+        other => {
+            return Err(ScpNapiError::Validation {
+                message: format!(
+                    "unsupported governance model: {other:?} — \
+                     only \"single_admin\" is currently supported"
+                ),
+                code: "SCP-VALID-7030".to_owned(),
+            }
+            .into());
+        }
+    };
 
     let core_ceiling: Vec<scp_core::context::roles::Capability> = ceiling
         .iter()

--- a/crates/scp-ffi/napi/src/mcp.rs
+++ b/crates/scp-ffi/napi/src/mcp.rs
@@ -448,11 +448,14 @@ async fn run_mcp_stdio_server(
                 };
 
                 if let Some(resp) = response
-                    && let Ok(json) = serde_json::to_string(&resp) {
-                        let _ = stdout.write_all(json.as_bytes()).await;
-                        let _ = stdout.write_all(b"\n").await;
-                        let _ = stdout.flush().await;
-                    }
+                    && let Ok(json) = serde_json::to_string(&resp)
+                    && (stdout.write_all(json.as_bytes()).await.is_err()
+                        || stdout.write_all(b"\n").await.is_err()
+                        || stdout.flush().await.is_err())
+                {
+                    tracing::warn!("MCP stdio server: stdout write failed, stopping");
+                    break;
+                }
             }
         } => {}
     }

--- a/crates/scp-ffi/src/mcp.rs
+++ b/crates/scp-ffi/src/mcp.rs
@@ -1232,11 +1232,14 @@ pub fn py_mcp_serve(
                             };
 
                             if let Some(resp) = response
-                                && let Ok(json) = serde_json::to_string(&resp) {
-                                    let _ = stdout.write_all(json.as_bytes()).await;
-                                    let _ = stdout.write_all(b"\n").await;
-                                    let _ = stdout.flush().await;
-                                }
+                                && let Ok(json) = serde_json::to_string(&resp)
+                                && (stdout.write_all(json.as_bytes()).await.is_err()
+                                    || stdout.write_all(b"\n").await.is_err()
+                                    || stdout.flush().await.is_err())
+                            {
+                                tracing::warn!("MCP stdio server: stdout write failed, stopping");
+                                break;
+                            }
                         }
                     } => {}
                 }

--- a/crates/scp-ffi/src/runtime.rs
+++ b/crates/scp-ffi/src/runtime.rs
@@ -663,6 +663,9 @@ pub fn remove_ffi_state(context_id: &str) {
     // Clean up per-context bridge connector state (ShadowRegistry + SenderKeyStore)
     // to prevent unbounded memory growth in long-running processes.
     crate::bridge_connector::remove_bridge_state(context_id);
+    // Clean up per-context economy state (budget + antispam trackers) to prevent
+    // unbounded memory growth in long-running processes (#1433).
+    remove_economy_state(context_id);
 }
 
 /// Re-syncs the `FfiBridgeState.role_state` for a context from the shared
@@ -1377,7 +1380,6 @@ where
 /// Removes economy state (budget tracker and antispam tracker) for a context.
 ///
 /// Should be called during context cleanup for long-running processes.
-#[allow(dead_code)]
 pub fn remove_economy_state(context_id: &str) {
     economy_budget_registry().remove(context_id);
     economy_antispam_registry().remove(context_id);

--- a/crates/scp-node/src/main.rs
+++ b/crates/scp-node/src/main.rs
@@ -164,7 +164,14 @@ fn resolve_storage_path(cli_path: Option<&PathBuf>) -> PathBuf {
     #[allow(clippy::option_if_let_else)]
     let data_home = env::var("XDG_DATA_HOME").map_or_else(
         |_| {
-            let home = env::var("HOME").unwrap_or_else(|_| "/tmp".to_owned());
+            let home = env::var("HOME").unwrap_or_else(|_| {
+                eprintln!(
+                    "error: HOME environment variable is not set and no \
+                     --storage-path or XDG_DATA_HOME was provided.\n\
+                     Set HOME, XDG_DATA_HOME, or pass --storage-path explicitly."
+                );
+                std::process::exit(1);
+            });
             PathBuf::from(home).join(".local").join("share")
         },
         PathBuf::from,

--- a/crates/scp-transport/src/native/client.rs
+++ b/crates/scp-transport/src/native/client.rs
@@ -24,7 +24,8 @@
 //! [`NativeRelayAdapter`]: super::adapter::NativeRelayAdapter
 //! [`TransportAdapter`]: crate::TransportAdapter
 
-use std::collections::{HashMap, HashSet};
+use std::collections::HashMap;
+use std::num::NonZeroUsize;
 use std::sync::Arc;
 use std::time::Duration;
 
@@ -64,6 +65,14 @@ const RECONNECT_OVERLAP: Duration = Duration::from_secs(5);
 /// forward-dating timestamps.
 #[allow(dead_code)]
 const RELAY_TIMESTAMP_DEVIATION_THRESHOLD_SECS: u64 = 60;
+
+/// Maximum number of entries in the deduplication LRU cache.
+///
+/// Blob IDs older than this window are evicted, bounding memory usage to
+/// approximately 320 KiB (10,000 x 32 bytes). This is sufficient for typical
+/// reconnect overlap windows while preventing unbounded growth in long-lived
+/// connections (#1466).
+const DEDUP_CACHE_CAPACITY: usize = 10_000;
 
 /// A pending request waiting for a relay response keyed by `ref_id`.
 struct PendingRequest {
@@ -120,8 +129,12 @@ struct ClientInner {
     next_ref_id: u64,
     /// Active subscriptions keyed by routing ID.
     subscriptions: HashMap<[u8; 32], SubscriptionState>,
-    /// Set of blob IDs already seen (for deduplication on reconnect).
-    seen_blob_ids: HashSet<[u8; 32]>,
+    /// LRU cache of blob IDs already seen (for deduplication on reconnect).
+    ///
+    /// Bounded to [`DEDUP_CACHE_CAPACITY`] entries to prevent unbounded memory
+    /// growth in long-lived connections (#1466). Oldest entries are evicted
+    /// when the cache is full.
+    seen_blob_ids: lru::LruCache<[u8; 32], ()>,
     /// Whether the client is currently connected.
     connected: bool,
 }
@@ -191,7 +204,9 @@ impl NativeRelayClient {
             pending: HashMap::new(),
             next_ref_id: 1,
             subscriptions: HashMap::new(),
-            seen_blob_ids: HashSet::new(),
+            seen_blob_ids: lru::LruCache::new(
+                NonZeroUsize::new(DEDUP_CACHE_CAPACITY).unwrap_or(NonZeroUsize::MIN),
+            ),
             connected: false,
         }));
 
@@ -353,9 +368,12 @@ impl NativeRelayClient {
                 let mut state = inner.write().await;
 
                 // Deduplication: skip if we've already seen this `blob_id`.
-                if !state.seen_blob_ids.insert(*blob_id) {
+                // `LruCache::contains` does NOT promote the entry (no LRU
+                // reorder), which is correct — we just want to check presence.
+                if state.seen_blob_ids.contains(blob_id) {
                     return;
                 }
+                state.seen_blob_ids.put(*blob_id, ());
 
                 if let Some(sub) = state.subscriptions.get_mut(routing_id) {
                     // Record local monotonic receive time for reconnection
@@ -830,7 +848,7 @@ impl NativeRelayClient {
             .collect()
     }
 
-    /// Clears the deduplication set. Useful after a successful reconnect
+    /// Clears the deduplication cache. Useful after a successful reconnect
     /// when the overlap window has passed.
     #[allow(dead_code)]
     pub async fn clear_dedup_set(&self) {
@@ -1022,7 +1040,9 @@ mod tests {
                     tx,
                 },
             )]),
-            seen_blob_ids: HashSet::new(),
+            seen_blob_ids: lru::LruCache::new(
+                NonZeroUsize::new(DEDUP_CACHE_CAPACITY).unwrap_or(NonZeroUsize::MIN),
+            ),
             connected: true,
         }));
         (inner, rx)


### PR DESCRIPTION
## Summary

7 quick-win fixes from the 2026-03-18/19 codebase audit.

- **#1422**: Document AAD epoch/sequence=0 limitation in `deliver_incoming` (chicken-and-egg: receiver needs sequence to verify AAD, but sequence isn't in the clear)
- **#1466**: Bound `seen_blob_ids` dedup set to 10,000 entries via `LruCache` (~320 KiB max)
- **#1429**: MCP stdio server breaks on write failure instead of silently dropping responses
- **#1421**: NAPI `context_create` validates governance model — rejects unsupported models with clear error
- **#1471**: Remove `/tmp` fallback when `HOME` is unset — exit with error instead
- **#1475**: TS `leave()`/`close()` set `_disposed` after bridge call, not before — failed calls can be retried
- **#1433**: `remove_ffi_state` now calls `remove_economy_state` — prevents economy state leak on context close

Closes #1421, closes #1422, closes #1429, closes #1433, closes #1466, closes #1471, closes #1475

## Test plan

- [x] `cargo test --workspace` — all tests pass
- [x] `cargo clippy --workspace --all-targets` with all features — 0 warnings
- [x] `cargo fmt --all --check` — clean
- [x] `cargo check -p scp-ffi-wasm --target wasm32-unknown-unknown` — clean
- [x] `bun run check && bun run lint` (TypeScript) — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)