### PR TITLE
fix(core): audit batch 4 — governance TOCTOU, key destroy disk, pruning trigger, operational metrics

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3340,6 +3340,52 @@ dependencies = [
 ]
 
 [[package]]
+name = "metrics"
+version = "0.24.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d5312e9ba3771cfa961b585728215e3d972c950a3eed9252aa093d6301277e8"
+dependencies = [
+ "ahash",
+ "portable-atomic",
+]
+
+[[package]]
+name = "metrics-exporter-prometheus"
+version = "0.16.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd7399781913e5393588a8d8c6a2867bf85fb38eaf2502fdce465aad2dc6f034"
+dependencies = [
+ "base64",
+ "http-body-util",
+ "hyper 1.8.1",
+ "hyper-util",
+ "indexmap",
+ "ipnet",
+ "metrics",
+ "metrics-util",
+ "quanta",
+ "thiserror 1.0.69",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "metrics-util"
+version = "0.19.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8496cc523d1f94c1385dd8f0f0c2c480b2b8aeccb5b7e4485ad6365523ae376"
+dependencies = [
+ "crossbeam-epoch",
+ "crossbeam-utils",
+ "hashbrown 0.15.5",
+ "metrics",
+ "quanta",
+ "rand 0.9.2",
+ "rand_xoshiro",
+ "sketches-ddsketch",
+]
+
+[[package]]
 name = "mime"
 version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4322,6 +4368,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "quanta"
+version = "0.12.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f3ab5a9d756f0d97bdc89019bd2e4ea098cf9cde50ee7564dde6b81ccc8f06c7"
+dependencies = [
+ "crossbeam-utils",
+ "libc",
+ "once_cell",
+ "raw-cpuid",
+ "wasi",
+ "web-sys",
+ "winapi",
+]
+
+[[package]]
 name = "quick-error"
 version = "1.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4498,6 +4559,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "513962919efc330f829edb2535844d1b912b0fbe2ca165d613e4e8788bb05a5a"
 dependencies = [
  "rand_core 0.9.5",
+]
+
+[[package]]
+name = "rand_xoshiro"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f703f4665700daf5512dcca5f43afa6af89f09db47fb56be587f80636bda2d41"
+dependencies = [
+ "rand_core 0.9.5",
+]
+
+[[package]]
+name = "raw-cpuid"
+version = "11.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "498cd0dc59d73224351ee52a95fee0f1a617a2eae0e7d9d720cc622c73a54186"
+dependencies = [
+ "bitflags 2.11.0",
 ]
 
 [[package]]
@@ -5051,6 +5130,7 @@ dependencies = [
  "hkdf",
  "jsonschema",
  "lru 0.16.3",
+ "metrics",
  "openmls",
  "openmls_basic_credential",
  "openmls_memory_storage 0.5.0",
@@ -5328,6 +5408,8 @@ dependencies = [
  "hyper 1.8.1",
  "hyper-util",
  "instant-acme",
+ "metrics",
+ "metrics-exporter-prometheus",
  "percent-encoding",
  "rand 0.8.5",
  "rcgen 0.14.7",
@@ -5394,6 +5476,9 @@ dependencies = [
 name = "scp-relay"
 version = "0.1.0-beta.1"
 dependencies = [
+ "axum",
+ "metrics",
+ "metrics-exporter-prometheus",
  "scp-transport",
  "tempfile",
  "tokio",
@@ -5794,6 +5879,12 @@ name = "siphasher"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b2aa850e253778c88a04c3d7323b043aeda9d3e30d5971937c1855769763678e"
+
+[[package]]
+name = "sketches-ddsketch"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c6f73aeb92d671e0cc4dca167e59b2deb6387c375391bc99ee743f326994a2b"
 
 [[package]]
 name = "slab"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -65,6 +65,8 @@ tower-http = { version = "0.6", features = ["cors"] }
 tokio-stream = { version = "0.1", features = ["sync"] }
 tokio-util = "0.7"
 subtle = "2"
+metrics = "0.24"
+metrics-exporter-prometheus = { version = "0.16", default-features = false, features = ["http-listener"] }
 unicode-normalization = "0.1"
 arc-swap = "1"
 rusqlite = { version = "0.32", features = ["bundled-sqlcipher"] }

--- a/crates/scp-core/Cargo.toml
+++ b/crates/scp-core/Cargo.toml
@@ -59,6 +59,7 @@ tracing = { workspace = true }
 zeroize = { workspace = true }
 subtle = { workspace = true }
 unicode-normalization = { workspace = true }
+metrics = { workspace = true }
 
 [dev-dependencies]
 tokio = { workspace = true, features = ["macros", "rt-multi-thread", "test-util"] }

--- a/crates/scp-core/src/context/builder.rs
+++ b/crates/scp-core/src/context/builder.rs
@@ -640,6 +640,26 @@ pub trait ContextEventLogProvider: Send + Sync {
         // Default: initialize empty event log (no persistence).
         self.init_event_log(context_id)
     }
+
+    /// Prunes event log entries before a checkpoint boundary based on a
+    /// [`PruningPolicy`](crate::context::governance::PruningPolicy).
+    ///
+    /// Called after creating a governance checkpoint (#1474). The default
+    /// implementation is a no-op — providers that support pruning override
+    /// this method.
+    ///
+    /// # Returns
+    ///
+    /// The number of entries removed, or `None` if no log exists for the
+    /// context or the provider does not support pruning.
+    fn prune_before_checkpoint(
+        &self,
+        _context_id: &[u8; 32],
+        _checkpoint_event_count: u64,
+        _policy: &crate::context::governance::PruningPolicy,
+    ) -> Option<usize> {
+        None
+    }
 }
 
 // ---------------------------------------------------------------------------

--- a/crates/scp-core/src/context/manager.rs
+++ b/crates/scp-core/src/context/manager.rs
@@ -1468,6 +1468,18 @@ impl ContextManager {
     /// low probability and acceptable for v1 -- the worst case is a
     /// single extra key-epoch replay on restart, which the pull-based
     /// key distribution protocol already handles idempotently.
+    /// Updates operational gauge metrics (active contexts, buffer occupancy).
+    ///
+    /// Called after mutations that change context count or buffer state.
+    /// Takes the contexts lock, so callers must NOT hold it. Best-effort:
+    /// if no metrics recorder is installed, these are no-ops (#1467).
+    async fn update_context_gauges(&self) {
+        let contexts = self.contexts.lock().await;
+        crate::metrics::set_active_contexts(contexts.len());
+        let total_buffered: usize = contexts.values().map(|c| c.receive_buffer.len()).sum();
+        crate::metrics::set_buffer_occupancy(total_buffered);
+    }
+
     fn persist_context_snapshot(&self, context_id: &str, mut snapshot: ContextSnapshot) {
         if let Some(ref persistence) = self.persistence {
             // Export MLS crypto state alongside the context snapshot (#645).
@@ -1489,6 +1501,7 @@ impl ContextManager {
             if let Err(e) = persistence.persist_context(context_id, &snapshot) {
                 // Best-effort persistence: log but don't fail the operation.
                 // In-memory state remains authoritative.
+                crate::metrics::record_persistence_failure();
                 let _ = e; // Suppress unused warning; tracing integration is TBD.
             }
         }
@@ -2264,6 +2277,8 @@ impl ContextManager {
             contexts.insert(context_id.clone(), per_context);
         }
 
+        self.update_context_gauges().await;
+
         // Start governance timeout task (ADR-031 §5).
         self.start_governance_timeout_task(&context_id).await;
 
@@ -2405,6 +2420,7 @@ impl ContextManager {
             contexts.insert(context_id.clone(), per_context);
         }
 
+        self.update_context_gauges().await;
         self.start_governance_timeout_task(&context_id).await;
         self.persist_context_and_broadcast(&context_id).await;
         if let Some(ttl_duration) = params.ttl {
@@ -3039,12 +3055,19 @@ impl ContextManager {
             // incremented on key rotation). Sequence 0 — changing this requires
             // sending the sequence in the clear alongside the ciphertext so the
             // receiver can reconstruct the AAD.
-            self.crypto
-                .encrypt_message(&context_id_bytes, sender_did, payload, 0, 0)?
+            let encrypt_start = std::time::Instant::now();
+            let result =
+                self.crypto
+                    .encrypt_message(&context_id_bytes, sender_did, payload, 0, 0)?;
+            crate::metrics::record_encrypt_duration(encrypt_start.elapsed());
+            result
         };
 
         // Send via transport.
         self.transport.send_message(&context_id_bytes, &encrypted)?;
+
+        // Record message sent metric (#1467).
+        crate::metrics::record_message_sent();
 
         // Phase 3 (re-acquire lock): Re-check context active + membership,
         // assign sequence number NOW (post-transport), then push MessageSent
@@ -3135,9 +3158,11 @@ impl ContextManager {
         // #1422). This is safe because MLS already provides its own replay
         // protection via the ratchet tree; the sender key AAD is a
         // defense-in-depth layer that is currently inert.
+        let decrypt_start = std::time::Instant::now();
         let decrypted = self
             .crypto
             .decrypt_message(&context_id_bytes, encrypted_blob, 0, 0)?;
+        crate::metrics::record_decrypt_duration(decrypt_start.elapsed());
 
         // Commit/Proposal messages have no application payload — the MLS epoch
         // was advanced (Commit) or the proposal was cached (Proposal). Skip
@@ -3188,6 +3213,9 @@ impl ContextManager {
                 payload: plaintext.clone(),
             });
         }
+
+        // Record message received metric (#1467).
+        crate::metrics::record_message_received();
 
         // Append event to event log (best-effort, matches send_message).
         let _ = self
@@ -3947,27 +3975,29 @@ impl ContextManager {
         // Construct the structured GovernanceEvent::GovernanceActionExecuted
         // and emit it to both the Merkle event log and the receive buffer
         // (ADR-031 §8, PRD SCP-269/SCP-270).
+        let executed_event = GovernanceEvent::GovernanceActionExecuted {
+            proposal_id: proposal.proposal_id,
+            action: Box::new(proposal.action.clone()),
+            executor_did: proposal.proposer_did.clone(),
+            resulting_epoch,
+        };
+
+        // Append to Merkle event log using the standard governance event
+        // label path (same pattern as propose/approve/reject/withdraw).
+        let context_id_bytes = context_id_to_bytes(context_id);
+        self.event_log.append_context_event(
+            &context_id_bytes,
+            Self::governance_event_label(&executed_event),
+        )?;
+
+        // Single lock acquisition for all post-event-log state mutations
+        // (#1428 — eliminates TOCTOU window from multiple lock acquisitions).
         {
-            let executed_event = GovernanceEvent::GovernanceActionExecuted {
-                proposal_id: proposal.proposal_id,
-                action: Box::new(proposal.action.clone()),
-                executor_did: proposal.proposer_did.clone(),
-                resulting_epoch,
-            };
-
-            // Append to Merkle event log using the standard governance event
-            // label path (same pattern as propose/approve/reject/withdraw).
-            let context_id_bytes = context_id_to_bytes(context_id);
-            self.event_log.append_context_event(
-                &context_id_bytes,
-                Self::governance_event_label(&executed_event),
-            )?;
-
-            // Push to receive buffer so SDK consumers observe outcomes with
-            // rich context.
             let action_summary = proposal.action.variant_name().to_owned();
             let mut contexts = self.contexts.lock().await;
             if let Some(ctx) = contexts.get_mut(context_id) {
+                // 1. Push GovernanceActionExecuted to receive buffer so SDK
+                //    consumers observe outcomes with rich context.
                 ctx.receive_buffer
                     .push(ContextEvent::GovernanceActionExecuted {
                         proposal_id: proposal.proposal_id,
@@ -3975,15 +4005,11 @@ impl ContextManager {
                         executor_did: proposal.proposer_did.clone(),
                         resulting_epoch,
                     });
-            }
-        }
 
-        // Trigger checkpoint cosignature collection for multi-admin contexts
-        // (ADR-031 §9, issue #630). SingleAdmin contexts emit no event because
-        // they require no cosignatures (quorum is 0).
-        {
-            let mut contexts = self.contexts.lock().await;
-            if let Some(ctx) = contexts.get_mut(context_id) {
+                // 2. Trigger checkpoint cosignature collection for multi-admin
+                //    contexts (ADR-031 §9, issue #630). SingleAdmin contexts
+                //    emit no event because they require no cosignatures
+                //    (quorum is 0).
                 let (required_signers, minimum_count) =
                     ctx.governance_engine.checkpoint_cosignature_requirements();
                 if minimum_count > 0 {
@@ -3995,17 +4021,14 @@ impl ContextManager {
                             at_epoch: ctx.mls_epoch,
                         });
                 }
-            }
-        }
 
-        // Remove the executed proposal from approved_proposals so it no
-        // longer participates in conflict detection (ADR-031 §7).  Replay
-        // prevention is already handled by `executed_proposals`.
-        // Persist the updated context state afterwards.
-        {
-            let mut contexts = self.contexts.lock().await;
-            if let Some(ctx) = contexts.get_mut(context_id) {
+                // 3. Remove the executed proposal from approved_proposals so
+                //    it no longer participates in conflict detection
+                //    (ADR-031 §7). Replay prevention is already handled by
+                //    `executed_proposals`.
                 ctx.approved_proposals.remove(&proposal.proposal_id);
+
+                // 4. Persist the updated context state (best-effort).
                 if self.has_persistence() {
                     let snapshot = Self::snapshot_context(ctx);
                     drop(contexts);
@@ -7440,6 +7463,8 @@ impl ContextManager {
             }
         }
 
+        self.update_context_gauges().await;
+
         // Persist context state after close (best-effort).
         if self.has_persistence() {
             let contexts = self.contexts.lock().await;
@@ -8046,12 +8071,15 @@ impl ContextManager {
             CheckpointAttestationStatus::PartiallyAttested
         };
 
+        // Capture pruning policy before dropping the lock.
+        let pruning_policy = ctx.pruning_policy.clone();
+
         let created_at = SystemTime::now()
             .duration_since(UNIX_EPOCH)
             .unwrap_or_default()
             .as_secs();
 
-        Ok(ContextCheckpoint {
+        let checkpoint = ContextCheckpoint {
             checkpoint_seq,
             merkle_root,
             event_count,
@@ -8062,7 +8090,31 @@ impl ContextManager {
             creator_signature,
             cosignatures: Vec::new(),
             attestation_status,
-        })
+        };
+
+        // Drop the contexts lock before pruning to avoid holding it during
+        // potentially expensive I/O (persistence writes).
+        drop(contexts);
+
+        // Trigger event log pruning if a pruning policy is configured on the
+        // context (#1474). Best-effort: log but do not fail the checkpoint
+        // creation if pruning encounters an error.
+        if let Some(ref policy) = pruning_policy {
+            let context_id_bytes = context_id_to_bytes(context_id);
+            if self
+                .event_log
+                .prune_before_checkpoint(&context_id_bytes, event_count, policy)
+                .is_some_and(|pruned| pruned > 0)
+            {
+                tracing::info!(
+                    context_id = %context_id,
+                    checkpoint_seq = checkpoint_seq,
+                    "pruned event log entries after governance checkpoint"
+                );
+            }
+        }
+
+        Ok(checkpoint)
     }
 
     /// Adds a cosignature to an existing checkpoint and re-evaluates attestation status.

--- a/crates/scp-core/src/context/providers/event_log.rs
+++ b/crates/scp-core/src/context/providers/event_log.rs
@@ -447,6 +447,122 @@ impl MerkleEventLogProvider {
         Some(remove_count)
     }
 
+    /// Prunes event log entries before a checkpoint boundary based on a
+    /// [`PruningPolicy`](crate::context::governance::PruningPolicy).
+    ///
+    /// Called after creating a governance checkpoint (#1474). If the policy
+    /// has time-based pruning configured, entries older than
+    /// `now - retention_secs` (clamped to 30-day minimum) and before the
+    /// checkpoint boundary (`checkpoint_event_count`) are removed.
+    ///
+    /// If only size-based pruning is configured, entries beyond
+    /// `max_event_count` are removed (keeping the most recent).
+    ///
+    /// Structural events (governance, membership) are retained
+    /// `structural_retention_multiplier / 10000` times longer than
+    /// operational events per ADR-030 §2c.
+    ///
+    /// # Returns
+    ///
+    /// The number of entries removed, or `None` if no log exists for
+    /// the context.
+    pub fn prune_before_checkpoint(
+        &self,
+        context_id: &[u8; 32],
+        checkpoint_event_count: u64,
+        policy: &crate::context::governance::PruningPolicy,
+    ) -> Option<usize> {
+        use std::time::{SystemTime, UNIX_EPOCH};
+
+        /// Minimum retention: 30 days (protocol floor per ADR-030 §2a).
+        const MIN_RETENTION_SECS: u64 = 2_592_000;
+
+        let now = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_secs();
+
+        let mut logs = self
+            .logs
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        let log = logs.get_mut(context_id)?;
+
+        let total = log.entries.len();
+        if total == 0 {
+            return Some(0);
+        }
+
+        // Cannot prune beyond the checkpoint boundary (entries at or after
+        // the checkpoint are still live).
+        #[allow(clippy::cast_possible_truncation)]
+        let checkpoint_bound = (checkpoint_event_count as usize).min(total);
+
+        let mut prune_count = 0usize;
+
+        // Time-based and size-based pruning evaluate independently;
+        // we take the maximum of the two so that both policies are honored.
+        if let Some(ref time_policy) = policy.time_based {
+            let retention = time_policy.retention_secs.max(MIN_RETENTION_SECS);
+
+            let mut time_prune = 0usize;
+            for entry in log.entries.iter().take(checkpoint_bound) {
+                let is_structural = is_structural_event_name(&entry.event);
+                // Apply structural retention multiplier: structural events are
+                // retained longer. Uses integer arithmetic (basis points) to
+                // avoid f64 precision loss on u64 values.
+                let effective_retention = if is_structural {
+                    let multiplier_bp =
+                        u128::from(policy.event_type_retention.structural_retention_multiplier);
+                    #[allow(clippy::cast_possible_truncation)]
+                    let r = (u128::from(retention) * multiplier_bp / 10_000) as u64;
+                    r.max(retention)
+                } else {
+                    retention
+                };
+
+                if entry.timestamp < now.saturating_sub(effective_retention) {
+                    time_prune += 1;
+                } else {
+                    // Entries are ordered by time; once we find a
+                    // retained entry, all subsequent are also retained.
+                    break;
+                }
+            }
+            prune_count = prune_count.max(time_prune);
+        }
+
+        if let Some(ref size_policy) = policy.size_based {
+            // Size-based: keep at most `max_event_count` entries.
+            #[allow(clippy::cast_possible_truncation)]
+            let max_count = size_policy.max_event_count as usize;
+            if total > max_count {
+                let size_prune = (total - max_count).min(checkpoint_bound);
+                prune_count = prune_count.max(size_prune);
+            }
+        }
+
+        if prune_count == 0 {
+            return Some(0);
+        }
+
+        tracing::info!(
+            context_id = %hex::encode(context_id),
+            pruned = prune_count,
+            remaining = total - prune_count,
+            "pruned event log entries after checkpoint"
+        );
+
+        log.entries.drain(..prune_count);
+
+        // Persist the pruned state (bulk rewrite with renumbered keys).
+        let entries_snapshot = log.entries.clone();
+        drop(logs);
+        self.persist_entries_best_effort(context_id, &entries_snapshot);
+
+        Some(prune_count)
+    }
+
     /// Best-effort O(1) persistence of a single entry at a given sequence.
     ///
     /// Used by `append_event` to persist only the newly appended entry.
@@ -498,6 +614,34 @@ impl Default for MerkleEventLogProvider {
     fn default() -> Self {
         Self::new()
     }
+}
+
+/// Returns `true` if the event name represents a structural event
+/// (governance, membership) that should be retained longer than
+/// operational events per ADR-030 §2c.
+///
+/// Mirrors the `is_structural_event` function in `scp-event-log/src/pruning.rs`
+/// but operates on event name strings rather than `EventType` enum values.
+fn is_structural_event_name(event: &str) -> bool {
+    matches!(
+        event,
+        "ContextCreated"
+            | "MemberJoined"
+            | "MemberLeft"
+            | "RoleAssigned"
+            | "GovernanceAction"
+            | "GovernanceActionProposed"
+            | "GovernanceActionApproved"
+            | "GovernanceActionExecuted"
+            | "GovernanceActionRejected"
+            | "GovernanceActionWithdrawn"
+            | "ContextClosing"
+            | "ContextClosed"
+            | "ContextExpired"
+            | "MemberBlocked"
+            | "ConsistencyCheckpoint"
+            | "PruningPolicyModified"
+    )
 }
 
 // Nursery lint — false-positives on lock guards across block boundaries.
@@ -587,6 +731,16 @@ impl ContextEventLogProvider for MerkleEventLogProvider {
                 hex::encode(context_id)
             ))
         })
+    }
+
+    fn prune_before_checkpoint(
+        &self,
+        context_id: &[u8; 32],
+        checkpoint_event_count: u64,
+        policy: &crate::context::governance::PruningPolicy,
+    ) -> Option<usize> {
+        // Delegate to the concrete method on MerkleEventLogProvider.
+        Self::prune_before_checkpoint(self, context_id, checkpoint_event_count, policy)
     }
 }
 

--- a/crates/scp-core/src/lib.rs
+++ b/crates/scp-core/src/lib.rs
@@ -28,6 +28,7 @@ pub mod envelope;
 pub mod event_log;
 pub mod identity;
 pub(crate) mod jcs;
+pub mod metrics;
 pub mod provenance;
 pub mod serde_util;
 pub mod store;

--- a/crates/scp-core/src/metrics.rs
+++ b/crates/scp-core/src/metrics.rs
@@ -1,0 +1,57 @@
+//! Operational metrics for SCP core protocol.
+//!
+//! Uses the [`metrics`] crate facade. Counters, histograms, and gauges are
+//! emitted via the global recorder — callers must install a backend (e.g.,
+//! `metrics-exporter-prometheus`) at program startup. If no recorder is
+//! installed, metrics calls are no-ops.
+//!
+//! # Metric names
+//!
+//! | Name                              | Type      | Description                                    |
+//! |-----------------------------------|-----------|------------------------------------------------|
+//! | `scp_messages_sent_total`         | Counter   | Messages sent (encrypted + broadcast)          |
+//! | `scp_messages_received_total`     | Counter   | Messages delivered to receive buffer           |
+//! | `scp_mls_encrypt_duration_seconds`| Histogram | MLS + sender key encryption latency            |
+//! | `scp_mls_decrypt_duration_seconds`| Histogram | MLS + sender key decryption latency            |
+//! | `scp_persistence_failures_total`  | Counter   | Persistence write failures (best-effort saves) |
+//! | `scp_active_contexts`             | Gauge     | Number of registered (active) contexts         |
+//! | `scp_buffer_occupancy`            | Gauge     | Total events buffered across all contexts      |
+//!
+//! See issue #1467.
+
+/// Records a message sent.
+pub fn record_message_sent() {
+    metrics::counter!("scp_messages_sent_total").increment(1);
+}
+
+/// Records a message received and delivered to the receive buffer.
+pub fn record_message_received() {
+    metrics::counter!("scp_messages_received_total").increment(1);
+}
+
+/// Records MLS encryption duration in seconds.
+pub fn record_encrypt_duration(duration: std::time::Duration) {
+    metrics::histogram!("scp_mls_encrypt_duration_seconds").record(duration.as_secs_f64());
+}
+
+/// Records MLS decryption duration in seconds.
+pub fn record_decrypt_duration(duration: std::time::Duration) {
+    metrics::histogram!("scp_mls_decrypt_duration_seconds").record(duration.as_secs_f64());
+}
+
+/// Records a persistence failure (counter).
+pub fn record_persistence_failure() {
+    metrics::counter!("scp_persistence_failures_total").increment(1);
+}
+
+/// Sets the active context gauge to the given count.
+pub fn set_active_contexts(count: usize) {
+    #[allow(clippy::cast_precision_loss)]
+    metrics::gauge!("scp_active_contexts").set(count as f64);
+}
+
+/// Sets the buffer occupancy gauge (total events across all contexts).
+pub fn set_buffer_occupancy(count: usize) {
+    #[allow(clippy::cast_precision_loss)]
+    metrics::gauge!("scp_buffer_occupancy").set(count as f64);
+}

--- a/crates/scp-node/Cargo.toml
+++ b/crates/scp-node/Cargo.toml
@@ -56,6 +56,8 @@ tracing = { workspace = true }
 zeroize = { workspace = true }
 tracing-subscriber = { version = "0.3", features = ["env-filter", "json"] }
 x509-parser = "0.16"
+metrics = { workspace = true }
+metrics-exporter-prometheus = { workspace = true }
 
 [dev-dependencies]
 ed25519-dalek = { workspace = true }

--- a/crates/scp-node/src/main.rs
+++ b/crates/scp-node/src/main.rs
@@ -946,12 +946,51 @@ async fn run_node_with<
         "application node identity ready"
     );
 
-    if let Err(e) = node.serve(axum::Router::new(), shutdown_signal()).await {
+    // Install Prometheus metrics recorder and add /metrics endpoint (#1467).
+    let metrics_router = install_metrics_recorder();
+
+    if let Err(e) = node.serve(metrics_router, shutdown_signal()).await {
         tracing::error!(error = %e, "application node exited with error");
         std::process::exit(1);
     }
 
     tracing::info!("scp-node stopped");
+}
+
+// ---------------------------------------------------------------------------
+// Prometheus metrics (#1467)
+// ---------------------------------------------------------------------------
+
+/// Installs the Prometheus metrics recorder and returns an axum router with
+/// a `/metrics` endpoint that serves the metrics in Prometheus text format.
+///
+/// The recorder is installed globally via [`metrics_exporter_prometheus::PrometheusBuilder`].
+/// If installation fails (e.g., a recorder is already installed), the endpoint
+/// returns an empty body with a 503 status.
+fn install_metrics_recorder() -> axum::Router {
+    let recorder = metrics_exporter_prometheus::PrometheusBuilder::new().build_recorder();
+    let handle = recorder.handle();
+    // Best-effort: if a recorder is already installed, the metrics
+    // endpoint will return empty data.
+    let _ = metrics::set_global_recorder(recorder);
+
+    axum::Router::new().route(
+        "/metrics",
+        axum::routing::get(move || {
+            let h = handle.clone();
+            async move {
+                let body = h.render();
+                (
+                    axum::http::StatusCode::OK,
+                    [(
+                        axum::http::header::CONTENT_TYPE,
+                        "text/plain; version=0.0.4",
+                    )],
+                    body,
+                )
+            }
+        }),
+    )
 }
 
 // ---------------------------------------------------------------------------

--- a/crates/scp-platform/src/file.rs
+++ b/crates/scp-platform/src/file.rs
@@ -490,24 +490,21 @@ impl FileKeyCustody {
         KeyHandle::new(id)
     }
 
-    /// Looks up handle metadata; returns key type and entry index.
-    async fn lookup_handle(
-        &self,
-        handle: &KeyHandle,
-    ) -> Result<(StoredKeyType, usize), PlatformError> {
-        let map = self.handle_map.lock().await;
-        map.entries
-            .get(&handle.id())
-            .copied()
-            .ok_or(PlatformError::KeyNotFound)
-    }
-
     /// Decrypts an Ed25519 signing key from the file for the given handle.
+    ///
+    /// Holds the `handle_map` lock across both the lookup and the file read to
+    /// prevent a concurrent `destroy_key` from rewriting the file between the
+    /// two operations (TOCTOU).
     async fn decrypt_ed25519_key(
         &self,
         handle: &KeyHandle,
     ) -> Result<(Zeroizing<[u8; KEY_LEN]>, SigningKey), PlatformError> {
-        let (key_type, entry_index) = self.lookup_handle(handle).await?;
+        let map = self.handle_map.lock().await;
+        let (key_type, entry_index) = map
+            .entries
+            .get(&handle.id())
+            .copied()
+            .ok_or(PlatformError::KeyNotFound)?;
         if key_type != StoredKeyType::Ed25519 {
             return Err(PlatformError::WrongKeyType {
                 expected: KeyType::Ed25519,
@@ -515,6 +512,7 @@ impl FileKeyCustody {
             });
         }
         let data = self.read_file()?;
+        drop(map);
         let key_bytes = self.decrypt_entry(&data, entry_index)?;
         let signing_key = SigningKey::from_bytes(&key_bytes);
         Ok((key_bytes, signing_key))
@@ -610,8 +608,16 @@ impl KeyCustody for FileKeyCustody {
                 }
             }
 
-            let (key_type, entry_index) = self.lookup_handle(&handle).await?;
+            // Hold handle_map lock across lookup and file read to prevent
+            // a concurrent destroy_key from rewriting the file (TOCTOU).
+            let map = self.handle_map.lock().await;
+            let (key_type, entry_index) = map
+                .entries
+                .get(&handle.id())
+                .copied()
+                .ok_or(PlatformError::KeyNotFound)?;
             let data = self.read_file()?;
+            drop(map);
             let key_bytes = self.decrypt_entry(&data, entry_index)?;
 
             match key_type {
@@ -636,6 +642,7 @@ impl KeyCustody for FileKeyCustody {
         let key_id = key.id();
         async move {
             // Remove from pseudonym keys if present.
+            // Pseudonym keys are in-memory only — no disk rewrite needed.
             {
                 let mut pseudonyms = self.pseudonym_keys.lock().await;
                 if pseudonyms.remove(&key_id).is_some() {
@@ -644,15 +651,57 @@ impl KeyCustody for FileKeyCustody {
             }
 
             let mut map = self.handle_map.lock().await;
-            if map.entries.remove(&key_id).is_none() {
+            let Some((_, removed_index)) = map.entries.remove(&key_id) else {
                 return Err(PlatformError::KeyNotFound);
+            };
+
+            // Rewrite the key file without the destroyed entry (#1469).
+            // This ensures key material is removed from disk, not just from
+            // the in-memory handle map.
+            let _lock = self
+                .file_write_lock
+                .lock()
+                .map_err(|_| PlatformError::CustodyError("file write lock poisoned".into()))?;
+
+            let data = self.read_file()?;
+
+            // Reconstruct the file: copy header, skip the destroyed entry,
+            // decrement the entry count.
+            let count_offset = 1 + SALT_LEN;
+            let current_count = u32::from_le_bytes(
+                data[count_offset..count_offset + 4]
+                    .try_into()
+                    .map_err(|_| PlatformError::CustodyError("invalid entry count".into()))?,
+            );
+
+            let new_count = current_count.saturating_sub(1);
+            let mut new_data = Vec::with_capacity(HEADER_SIZE + (new_count as usize) * ENTRY_SIZE);
+
+            // Copy header (version + salt).
+            new_data.extend_from_slice(&data[..count_offset]);
+            // Write updated entry count.
+            new_data.extend_from_slice(&new_count.to_le_bytes());
+
+            // Copy all entries except the removed one.
+            for i in 0..current_count as usize {
+                if i == removed_index {
+                    continue;
+                }
+                let entry_offset = HEADER_SIZE + i * ENTRY_SIZE;
+                new_data.extend_from_slice(&data[entry_offset..entry_offset + ENTRY_SIZE]);
+            }
+
+            atomic_write(&self.path, &new_data)?;
+
+            // Update indices in handle_map: entries after the removed index
+            // shift down by one.
+            for (_key_type, entry_index) in map.entries.values_mut() {
+                if *entry_index > removed_index {
+                    *entry_index -= 1;
+                }
             }
             drop(map);
-            // Note: We remove the handle mapping but leave the encrypted entry
-            // in the file. The entry is unreachable and encrypted. A compaction
-            // step could be added in the future but is not required for
-            // correctness or security — the key material remains encrypted and
-            // the handle is invalidated.
+
             Ok(())
         }
     }
@@ -666,7 +715,14 @@ impl KeyCustody for FileKeyCustody {
         let peer = *peer_public;
         async move {
             let handle = KeyHandle::new(key_id);
-            let (key_type, entry_index) = self.lookup_handle(&handle).await?;
+            // Hold handle_map lock across lookup and file read to prevent
+            // a concurrent destroy_key from rewriting the file (TOCTOU).
+            let map = self.handle_map.lock().await;
+            let (key_type, entry_index) = map
+                .entries
+                .get(&handle.id())
+                .copied()
+                .ok_or(PlatformError::KeyNotFound)?;
 
             if key_type != StoredKeyType::X25519 {
                 return Err(PlatformError::WrongKeyType {
@@ -676,6 +732,7 @@ impl KeyCustody for FileKeyCustody {
             }
 
             let data = self.read_file()?;
+            drop(map);
             let key_bytes = self.decrypt_entry(&data, entry_index)?;
 
             let secret = StaticSecret::from(*key_bytes);

--- a/crates/scp-relay/Cargo.toml
+++ b/crates/scp-relay/Cargo.toml
@@ -21,9 +21,12 @@ scp-transport = { path = "../scp-transport", version = "=0.1.0-beta.1", features
     "postgres-blob",
     "s3-blob",
 ] }
+axum = "0.8"
 tokio = { workspace = true }
 tracing = { workspace = true }
 tracing-subscriber = { version = "0.3", features = ["env-filter", "json"] }
+metrics = { workspace = true }
+metrics-exporter-prometheus = { workspace = true }
 
 [dev-dependencies]
 tempfile = "3"

--- a/crates/scp-relay/src/main.rs
+++ b/crates/scp-relay/src/main.rs
@@ -214,12 +214,75 @@ async fn main() {
 
     tracing::info!(addr = %local_addr, "relay listening");
 
+    // Start Prometheus metrics HTTP server on a separate port (#1467).
+    let metrics_port = env_or("SCP_RELAY_METRICS_PORT", 9001u16);
+    let metrics_addr: SocketAddr = SocketAddr::from(([0, 0, 0, 0], metrics_port));
+    let metrics_handle = spawn_metrics_server(metrics_addr).await;
+
     // Wait for shutdown signal (SIGINT / SIGTERM).
     shutdown_signal().await;
 
     tracing::info!("shutdown signal received, stopping relay");
+    if let Some(h) = metrics_handle {
+        h.abort();
+    }
     handle.shutdown();
     tracing::info!("relay stopped");
+}
+
+// ---------------------------------------------------------------------------
+// Prometheus metrics (#1467)
+// ---------------------------------------------------------------------------
+
+/// Spawns a minimal axum HTTP server serving `/metrics` in Prometheus text
+/// format. Returns the task handle so the caller can abort on shutdown.
+///
+/// Uses `metrics-exporter-prometheus` as the global recorder. If the metrics
+/// port cannot be bound, a warning is logged and `None` is returned.
+async fn spawn_metrics_server(addr: SocketAddr) -> Option<tokio::task::JoinHandle<()>> {
+    use axum::response::IntoResponse;
+
+    let recorder = metrics_exporter_prometheus::PrometheusBuilder::new().build_recorder();
+    let handle = recorder.handle();
+    let _ = metrics::set_global_recorder(recorder);
+
+    let app = axum::Router::new().route(
+        "/metrics",
+        axum::routing::get(move || {
+            let h = handle.clone();
+            async move {
+                let body = h.render();
+                (
+                    axum::http::StatusCode::OK,
+                    [(
+                        axum::http::header::CONTENT_TYPE,
+                        "text/plain; version=0.0.4",
+                    )],
+                    body,
+                )
+                    .into_response()
+            }
+        }),
+    );
+
+    let listener = match tokio::net::TcpListener::bind(addr).await {
+        Ok(l) => l,
+        Err(e) => {
+            tracing::warn!(
+                addr = %addr,
+                error = %e,
+                "failed to bind metrics server; metrics endpoint unavailable"
+            );
+            return None;
+        }
+    };
+
+    let bound_addr = listener.local_addr().unwrap_or(addr);
+    tracing::info!(addr = %bound_addr, "metrics server listening");
+
+    Some(tokio::spawn(async move {
+        let _ = axum::serve(listener, app).await;
+    }))
 }
 
 /// Waits for either SIGINT (`ctrl_c`) or SIGTERM.

--- a/crates/scp-testing/src/fullstack/node.rs
+++ b/crates/scp-testing/src/fullstack/node.rs
@@ -375,4 +375,13 @@ impl ContextEventLogProvider for ArcEventLogProvider {
     fn restore_event_log(&self, id: &[u8; 32]) -> Result<(), ContextCreationError> {
         self.0.restore_event_log(id)
     }
+    fn prune_before_checkpoint(
+        &self,
+        context_id: &[u8; 32],
+        checkpoint_event_count: u64,
+        policy: &scp_core::context::governance::PruningPolicy,
+    ) -> Option<usize> {
+        self.0
+            .prune_before_checkpoint(context_id, checkpoint_event_count, policy)
+    }
 }


### PR DESCRIPTION
## Summary

4 deeper fixes from the 2026-03-18/19 codebase audit.

- **#1428**: Governance TOCTOU — consolidated 3 separate lock acquisitions after event log append in `finalize_governance_action` into a single lock scope
- **#1469**: `destroy_key` now rewrites the file without the destroyed entry using `atomic_write` helper (previously only removed from in-memory map, leaving encrypted entry on disk)
- **#1474**: Event log pruning trigger — `create_governance_checkpoint` now calls `prune_before_checkpoint` when `PruningPolicy` is set (time-based + size-based pruning with structural event retention)
- **#1467**: Operational metrics — added `metrics` + `metrics-exporter-prometheus` crates with 7 metric helpers (message send/receive counters, MLS encrypt/decrypt histograms, persistence failure counter, active context gauge, buffer occupancy gauge) and `/metrics` Prometheus endpoints on both `scp-node` and `scp-relay`

Closes #1428, closes #1467, closes #1469, closes #1474

## Test plan

- [x] `cargo test --workspace` — 5800+ tests, 0 failures
- [x] `cargo clippy --workspace --all-targets` with all features — 0 warnings
- [x] `cargo fmt --all --check` — clean
- [x] `cargo check -p scp-ffi-wasm --target wasm32-unknown-unknown` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)