### PR TITLE
feat: attestation core types + bootstrap endorsement independence (§3.5, §7.4.1, §22.13)

### DIFF
--- a/.docs/specs/03-identity.md
+++ b/.docs/specs/03-identity.md
@@ -201,8 +201,7 @@ Identity attestations use the attestation envelope defined in §7.4.1, with iden
   },
   evidence: {
     method:         String,      // Verification method: "oauth", "signed_post", "dns_record", "challenge_response"
-    proof:          String,      // Method-specific proof data (see §3.5.0, §3.5.1)
-                                     // Verifiers MUST use this string as-is in signature scope — do not parse and re-serialize
+    proof:          String,           // Method-specific proof data (opaque — see below)
     verified_at:    u64,         // Unix timestamp (s) of last verification
     verifier_did:   Option<DID>, // DID of the verifier, if third-party verified (challenge_response only)
   },
@@ -211,7 +210,13 @@ Identity attestations use the attestation envelope defined in §7.4.1, with iden
 }
 ```
 
-**Signature scope:** The signature covers the §9.5.1 canonical hash of `(id, attestation_type, issuer, subject, issued_at, expires_at, claim, evidence, revocation_status)` using domain separator `"SCP-IDENTITY-LINK-ATTESTATION-V2:"`. String and DID fields use 4-byte BE length-prefixed encoding, `issued_at` uses 8-byte BE u64, `expires_at` uses the absent sentinel when not set, and sub-structures (`claim`, `evidence`, `revocation_status`) are individually serialized as MessagePack (sorted-key encoding) and included as variable-length byte fields. See §25.13 (Vector 26) for the exact construction.
+> **Proof opacity.** Verifiers MUST use the `proof` string as-is in the
+> signature scope — do not parse and re-serialize. This ensures:
+> (1) forward compatibility with new verification methods,
+> (2) cross-implementation canonical hash determinism,
+> (3) verifiers need not understand proof contents to verify signatures.
+
+**Signature scope:** The signature covers the §9.5.1 canonical hash of `(id, attestation_type, issuer, subject, issued_at, expires_at, claim, evidence, revocation_status)` using domain separator `"SCP-IDENTITY-LINK-ATTESTATION-V1:"`. String and DID fields use 4-byte BE length-prefixed encoding, `issued_at` uses 8-byte BE u64, `expires_at` uses the absent sentinel when not set, and sub-structures (`claim`, `evidence`, `revocation_status`) are individually serialized as MessagePack (sorted-key encoding) and included as variable-length byte fields. See §25.13 (Vector 26) for the exact construction.
 
 **Attestation ID construction:** The `id` field is a deterministic, hex-encoded SHA-256 hash derived from the attestation's identifying fields using the canonical hash construction (§9.5.1). The domain separator `"SCP-ATTESTATION-ID-V1:"` prevents cross-protocol collision, and 4-byte big-endian length prefixes on variable-length fields prevent field boundary ambiguity (e.g., platform `"ab"` + handle `"cd"` vs platform `"a"` + handle `"bcd"`).
 

--- a/.docs/specs/09-security-model.md
+++ b/.docs/specs/09-security-model.md
@@ -357,9 +357,10 @@ Note: `context_id` is not in the current signed hash (the request struct does no
 | 5 | `claim` | 4-byte BE length + UTF-8 bytes (compact JSON — see note) |
 | 6 | `evidence` | 4-byte BE length + raw bytes if present, or `SHA-256(0x00)` sentinel if absent |
 | 7 | `issued_at` | 8-byte BE u64 |
-| 8 | `expires_at` | 8-byte BE u64 (0 if no expiry) |
+| 8 | `expires_at` | 8-byte BE u64 if present, or `SHA-256(0x00)` sentinel if absent |
+| 9 | `revocation_status` | 4-byte BE length + MessagePack bytes of `RevocationStatus` enum |
 
-Note: the `claim` field uses compact JSON with no whitespace (equivalent to Python `json.dumps(separators=(',', ':'))`). JSON key ordering within claim objects is NOT guaranteed deterministic across implementations — claims with nested objects should use only flat key-value structures or pre-serialized byte strings. The `evidence` field, when present, is serialized as MessagePack bytes of the `AttestationEvidence` struct.
+Note: the `claim` field uses compact JSON with no whitespace (equivalent to Python `json.dumps(separators=(',', ':'))`). JSON key ordering within claim objects is NOT guaranteed deterministic across implementations — claims with nested objects should use only flat key-value structures or pre-serialized byte strings. The `evidence` field, when present, is serialized as MessagePack bytes of the `AttestationEvidence` struct. The `revocation_status` field is always present (never absent) — `Active` serializes as a distinct MessagePack value from `Revoked{...}`. Including `revocation_status` in the signed scope prevents an intermediary from flipping Active↔Revoked without invalidating the signature (§7.4.1).
 
 **ParticipationProfile** — domain: `"SCP-PARTICIPATION-PROFILE-V1:"`
 

--- a/.docs/specs/25-test-vectors.md
+++ b/.docs/specs/25-test-vectors.md
@@ -488,11 +488,11 @@ Note: Both the sender key and access key info strings use 4-byte BE length-prefi
 
 ## 25.13 Attestation Signing Vectors (§3.5.2, §9.5.1)
 
-Domain: `"SCP-IDENTITY-LINK-ATTESTATION-V2:"`
+Domain: `"SCP-IDENTITY-LINK-ATTESTATION-V1:"`
 
 ### Vector 26: Identity Link Attestation Signature
 
-The signing payload uses the canonical hash construction from §9.5.1 with domain separator `"SCP-IDENTITY-LINK-ATTESTATION-V2:"`. Fields are serialized in a fixed order. Sub-structures (`claim`, `evidence`, `revocation_status`) are serialized as MessagePack (`rmp_serde::to_vec_named`, sorted-key encoding) and included as variable-length byte fields.
+The signing payload uses the canonical hash construction from §9.5.1 with domain separator `"SCP-IDENTITY-LINK-ATTESTATION-V1:"`. Fields are serialized in a fixed order. Sub-structures (`claim`, `evidence`, `revocation_status`) are serialized as MessagePack (`rmp_serde::to_vec_named`, sorted-key encoding) and included as variable-length byte fields.
 
 Note: this is the *signature* construction (used by `verify_signature`). The *attestation ID* uses a different domain separator (`"SCP-ATTESTATION-ID-V1:"`) and different fields — see `compute_id()` in `attestation.rs`.
 
@@ -511,13 +511,13 @@ Input:
   revocation_status: RevocationStatus::Active
 
 Canonical hash input:
-  "SCP-IDENTITY-LINK-ATTESTATION-V2:"         (33 bytes, no length prefix)
+  "SCP-IDENTITY-LINK-ATTESTATION-V1:"         (33 bytes, no length prefix)
   || BE32(7)   || "att-001"                    (4 + 7 = 11 bytes — id)
   || BE32(13)  || "identity_link"              (4 + 13 = 17 bytes — attestation_type)
   || BE32(18)  || "did:dht:z6MkIssuer"        (4 + 18 = 22 bytes — issuer)
   || BE32(18)  || "did:dht:z6MkIssuer"        (4 + 18 = 22 bytes — subject)
   || BE64(1700000000)                          (8 bytes — issued_at)
-  || BE32(32)  || SHA-256(0x00)                (4 + 32 = 36 bytes — absent expires_at sentinel)
+  || SHA-256(0x00)                              (32 bytes, raw — no length prefix — absent expires_at sentinel)
   || BE32(N_c) || msgpack(claim)               (4 + N_c bytes — claim as MessagePack)
   || BE32(N_e) || msgpack(evidence)            (4 + N_e bytes — evidence as MessagePack)
   || BE32(N_r) || msgpack(revocation_status)    (4 + N_r bytes — revocation_status as MessagePack)
@@ -608,9 +608,8 @@ Canonical hash input:
 
 Total: 22 + 22 + 14 + 19 + 8 = 85 bytes
 
-// Hash must be recomputed from reference implementation
 Expected SHA-256:
-  (recompute from reference implementation — input changed from "x"/"@alice" to "google.com"/"alice@gmail.com")
+  0x97eedd3adfbd0dc8ee901c9f2baf57c151ddf81e3cf49e7ae3b559f4cd2176e0
 ```
 
 ## 25.17 Verification Procedure

--- a/crates/scp-core/src/bridge/claiming.rs
+++ b/crates/scp-core/src/bridge/claiming.rs
@@ -298,7 +298,18 @@ fn validate_claim_request(
     }
 
     // 5. Validate the attestation is not revoked.
-    if let RevocationStatus::Revoked { .. } = &request.identity_attestation.revocation_status {
+    // Per §7.4.1, only the issuer can revoke their own attestation.
+    if let RevocationStatus::Revoked { revoked_by, .. } =
+        &request.identity_attestation.revocation_status
+    {
+        if *revoked_by != request.identity_attestation.issuer {
+            return Err(ClaimError::AttestationInvalid {
+                reason: format!(
+                    "attestation revoked_by {} does not match issuer {}",
+                    revoked_by, request.identity_attestation.issuer,
+                ),
+            });
+        }
         return Err(ClaimError::AttestationInvalid {
             reason: "attestation has been revoked".to_owned(),
         });
@@ -791,13 +802,42 @@ mod tests {
         let mut attestation = make_identity_attestation(&did, HANDLE, &signing_key);
         attestation.revocation_status = RevocationStatus::Revoked {
             revoked_at: 1_700_000_250,
-            reason: Some("compromised".to_owned()),
+            reason: "compromised".to_owned(),
+            revoked_by: did.clone(),
         };
 
         let request = make_claim_request(SHADOW_ID, &did, HANDLE, attestation, &signing_key);
         let err = claim_shadow(&mut registry, &request).unwrap_err();
 
         assert!(matches!(err, ClaimError::AttestationInvalid { .. }));
+    }
+
+    #[test]
+    fn claim_shadow_fails_when_revoked_by_non_issuer() {
+        let mut registry = make_registry();
+        create_test_shadow(&mut registry);
+
+        let (verifying_key, signing_key) = test_keypair();
+        let did = did_from_pubkey(&verifying_key);
+        let mut attestation = make_identity_attestation(&did, HANDLE, &signing_key);
+        attestation.revocation_status = RevocationStatus::Revoked {
+            revoked_at: 1_700_000_250,
+            reason: "forged revocation".to_owned(),
+            revoked_by: "did:key:mallory".into(),
+        };
+
+        let request = make_claim_request(SHADOW_ID, &did, HANDLE, attestation, &signing_key);
+        let err = claim_shadow(&mut registry, &request).unwrap_err();
+
+        match &err {
+            ClaimError::AttestationInvalid { reason } => {
+                assert!(
+                    reason.contains("revoked_by"),
+                    "expected revoked_by mismatch error, got: {reason}",
+                );
+            }
+            other => panic!("expected AttestationInvalid, got {other:?}"),
+        }
     }
 
     // -------------------------------------------------------------------

--- a/crates/scp-core/src/discovery/bootstrap.rs
+++ b/crates/scp-core/src/discovery/bootstrap.rs
@@ -1,21 +1,126 @@
 //! Discovery bootstrap and fallback configuration.
 //!
-//! Provides configurable default bootstrap context IDs (analogous to DNS root
+//! Provides configurable default bootstrap context entries (analogous to DNS root
 //! servers) and a resolver that combines context queries with
 //! fallback to direct DID resolution.
+//!
+//! Each bootstrap context entry pairs a context ID with the expected creator DID,
+//! enabling post-join verification that defends against context ID substitution
+//! attacks (§22.13.2).
 //!
 //! The SDK ships with configurable defaults that are auto-queried on first
 //! identity creation (opt-out). Users can add custom contexts with discovery tools and
 //! configure fallback behavior.
 //!
 //! See ADR-020 in `.docs/adrs/phase-4.md`, acceptance criterion 8.
+//! See §22.13 for bootstrap context governance.
 
+use scp_identity::DID;
 use serde::{Deserialize, Serialize};
 
 use crate::well_known::{WellKnownScp, WellKnownValidationError};
 use scp_identity::DidMethod;
 
 use super::{ContextId, DiscoveryError};
+
+// ---------------------------------------------------------------------------
+// BootstrapContextEntry
+// ---------------------------------------------------------------------------
+
+/// A bootstrap context with expected creator DID for post-join verification.
+///
+/// Pairs a `context_id` with an `expected_creator_did`. After the SDK joins a
+/// bootstrap context via MLS group join, it MUST verify that the context's
+/// creator DID matches the `expected_creator_did`. The creator DID is available
+/// from the context's event log (the first event in any context is the creation
+/// event, signed by the creator's DID). If the creator DID does not match, the
+/// SDK MUST leave the context and treat the entry as failed — the context may
+/// have been substituted by an attacker.
+///
+/// See §22.13.2 for the full verification protocol.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct BootstrapContextEntry {
+    /// The bootstrap context's ID (hex-encoded).
+    pub context_id: ContextId,
+    /// The DID of the expected context creator. SDK MUST verify this matches the
+    /// actual context creator after joining (§22.13.2).
+    pub expected_creator_did: DID,
+}
+
+impl BootstrapContextEntry {
+    /// Creates a new `BootstrapContextEntry`.
+    ///
+    /// # Arguments
+    ///
+    /// * `context_id` -- The bootstrap context's ID.
+    /// * `expected_creator_did` -- The DID of the expected context creator.
+    #[must_use]
+    pub const fn new(context_id: ContextId, expected_creator_did: DID) -> Self {
+        Self {
+            context_id,
+            expected_creator_did,
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// BootstrapVerificationError
+// ---------------------------------------------------------------------------
+
+/// Errors produced when verifying a bootstrap context's creator DID.
+#[derive(Debug, thiserror::Error)]
+pub enum BootstrapVerificationError {
+    /// The actual creator DID does not match the expected creator DID from
+    /// the bootstrap configuration.
+    ///
+    /// This indicates a potential context ID substitution attack (§22.13.2).
+    /// The SDK MUST leave the context when this error is returned.
+    #[error(
+        "bootstrap context creator mismatch for {context_id}: expected {expected}, got {actual}"
+    )]
+    CreatorMismatch {
+        /// The context ID that was verified.
+        context_id: ContextId,
+        /// The expected creator DID from the bootstrap configuration.
+        expected: DID,
+        /// The actual creator DID from the context's event log.
+        actual: DID,
+    },
+
+    /// The custom contexts list has reached its maximum capacity.
+    ///
+    /// Prevents unbounded growth of the custom contexts list. The limit is
+    /// [`MAX_CUSTOM_CONTEXTS`].
+    #[error("custom contexts list has reached maximum capacity ({MAX_CUSTOM_CONTEXTS})")]
+    TooManyCustomContexts,
+
+    /// The default contexts list exceeds the maximum allowed size.
+    ///
+    /// Prevents unbounded growth of the default contexts list. The limit is
+    /// [`MAX_DEFAULT_CONTEXTS`].
+    #[error("default contexts list length {count} exceeds maximum of {MAX_DEFAULT_CONTEXTS}")]
+    TooManyDefaultContexts {
+        /// The number of entries that were provided.
+        count: usize,
+    },
+}
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+/// Maximum number of default bootstrap context entries allowed in a [`BootstrapConfig`].
+///
+/// Prevents unbounded growth of the default contexts list. Callers passing
+/// more entries to [`BootstrapConfig::with_defaults`] will receive a
+/// [`BootstrapVerificationError::TooManyDefaultContexts`] error.
+pub const MAX_DEFAULT_CONTEXTS: usize = 100;
+
+/// Maximum number of custom context entries allowed in a [`BootstrapConfig`].
+///
+/// Prevents unbounded growth of the custom contexts list. Contexts beyond
+/// this limit are rejected with [`BootstrapVerificationError::TooManyCustomContexts`].
+pub const MAX_CUSTOM_CONTEXTS: usize = 100;
 
 // ---------------------------------------------------------------------------
 // BootstrapConfig
@@ -28,17 +133,20 @@ use super::{ContextId, DiscoveryError};
 /// direct DID resolution when contexts with discovery tools are unavailable.
 ///
 /// Analogous to DNS root servers: the SDK ships with configurable default
-/// bootstrap context IDs. Users can add custom contexts with discovery tools. If
-/// defaults are unreachable, direct DID resolution still works.
+/// bootstrap context entries. Users can add custom contexts with discovery tools.
+/// If defaults are unreachable, direct DID resolution still works.
 ///
-/// See ADR-020 acceptance criterion 8.
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+/// Each context entry includes the expected creator DID for post-join
+/// verification (§22.13.2).
+///
+/// See ADR-020 acceptance criterion 8, §22.13.
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
 pub struct BootstrapConfig {
-    /// Default bootstrap context IDs shipped with the SDK.
+    /// Default bootstrap context entries shipped with the SDK.
     ///
     /// These are queried automatically on first identity creation unless
     /// `auto_query_on_identity_creation` is set to `false`.
-    pub default_context_ids: Vec<ContextId>,
+    pub default_contexts: Vec<BootstrapContextEntry>,
 
     /// Whether to automatically query contexts with discovery tools on first identity
     /// creation.
@@ -47,11 +155,11 @@ pub struct BootstrapConfig {
     /// queries.
     pub auto_query_on_identity_creation: bool,
 
-    /// User-added custom context IDs.
+    /// User-added custom context entries.
     ///
     /// These are queried alongside the defaults. Users can add contexts via
     /// [`BootstrapConfig::add_custom_context`].
-    pub custom_context_ids: Vec<ContextId>,
+    pub custom_contexts: Vec<BootstrapContextEntry>,
 
     /// Whether to fall back to direct DID resolution when contexts with discovery tools
     /// are unavailable or return no results.
@@ -61,54 +169,170 @@ pub struct BootstrapConfig {
     pub fallback_to_did_resolution: bool,
 }
 
+/// Raw deserialization target for [`BootstrapConfig`] that validates Vec lengths
+/// on deserialization. Rejects payloads where `default_contexts` exceeds
+/// [`MAX_DEFAULT_CONTEXTS`] or `custom_contexts` exceeds [`MAX_CUSTOM_CONTEXTS`].
+#[derive(Deserialize)]
+struct BootstrapConfigRaw {
+    #[serde(default)]
+    default_contexts: Vec<BootstrapContextEntry>,
+    #[serde(default = "default_true")]
+    auto_query_on_identity_creation: bool,
+    #[serde(default)]
+    custom_contexts: Vec<BootstrapContextEntry>,
+    #[serde(default = "default_true")]
+    fallback_to_did_resolution: bool,
+}
+
+const fn default_true() -> bool {
+    true
+}
+
+impl<'de> Deserialize<'de> for BootstrapConfig {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let raw = BootstrapConfigRaw::deserialize(deserializer)?;
+        if raw.default_contexts.len() > MAX_DEFAULT_CONTEXTS {
+            return Err(serde::de::Error::custom(format!(
+                "default_contexts length {} exceeds maximum of {MAX_DEFAULT_CONTEXTS}",
+                raw.default_contexts.len()
+            )));
+        }
+        if raw.custom_contexts.len() > MAX_CUSTOM_CONTEXTS {
+            return Err(serde::de::Error::custom(format!(
+                "custom_contexts length {} exceeds maximum of {MAX_CUSTOM_CONTEXTS}",
+                raw.custom_contexts.len()
+            )));
+        }
+        Ok(Self {
+            default_contexts: raw.default_contexts,
+            auto_query_on_identity_creation: raw.auto_query_on_identity_creation,
+            custom_contexts: raw.custom_contexts,
+            fallback_to_did_resolution: raw.fallback_to_did_resolution,
+        })
+    }
+}
+
 impl Default for BootstrapConfig {
     fn default() -> Self {
         Self {
-            default_context_ids: Vec::new(),
+            default_contexts: Vec::new(),
             auto_query_on_identity_creation: true,
-            custom_context_ids: Vec::new(),
+            custom_contexts: Vec::new(),
             fallback_to_did_resolution: true,
         }
     }
 }
 
 impl BootstrapConfig {
-    /// Creates a new `BootstrapConfig` with the given default discovery
-    /// context IDs.
+    /// Creates a new `BootstrapConfig` with the given default bootstrap context
+    /// entries.
     ///
     /// All other fields are set to their defaults: auto-query enabled,
     /// fallback enabled, no custom contexts.
     ///
     /// # Arguments
     ///
-    /// * `context_ids` -- Default bootstrap context IDs to query on bootstrap.
-    #[must_use]
-    pub fn with_defaults(context_ids: Vec<ContextId>) -> Self {
-        Self {
-            default_context_ids: context_ids,
-            ..Self::default()
+    /// * `contexts` -- Default bootstrap context entries to query on bootstrap.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`BootstrapVerificationError::TooManyDefaultContexts`] if
+    /// `contexts.len()` exceeds [`MAX_DEFAULT_CONTEXTS`].
+    pub fn with_defaults(
+        contexts: Vec<BootstrapContextEntry>,
+    ) -> Result<Self, BootstrapVerificationError> {
+        if contexts.len() > MAX_DEFAULT_CONTEXTS {
+            return Err(BootstrapVerificationError::TooManyDefaultContexts {
+                count: contexts.len(),
+            });
         }
+        Ok(Self {
+            default_contexts: contexts,
+            ..Self::default()
+        })
     }
 
-    /// Adds a custom context ID.
+    /// Adds a custom context entry.
     ///
     /// Custom contexts are queried alongside the defaults. Duplicate context
     /// IDs are not filtered here -- deduplication happens at query time in
     /// [`BootstrapResolver::resolve_contexts`].
-    pub fn add_custom_context(&mut self, context_id: ContextId) {
-        self.custom_context_ids.push(context_id);
+    ///
+    /// # Errors
+    ///
+    /// Returns [`BootstrapVerificationError::TooManyCustomContexts`] if the
+    /// custom contexts list has reached [`MAX_CUSTOM_CONTEXTS`].
+    pub fn add_custom_context(
+        &mut self,
+        entry: BootstrapContextEntry,
+    ) -> Result<(), BootstrapVerificationError> {
+        if self.custom_contexts.len() >= MAX_CUSTOM_CONTEXTS {
+            return Err(BootstrapVerificationError::TooManyCustomContexts);
+        }
+        self.custom_contexts.push(entry);
+        Ok(())
     }
 
-    /// Returns all context IDs (defaults + custom) as a combined list.
+    /// Returns all context entries (defaults + custom) as a combined list.
     ///
-    /// The returned list contains references to the default context IDs
-    /// followed by the custom context IDs.
+    /// The returned list contains references to the default context entries
+    /// followed by the custom context entries.
     #[must_use]
-    pub fn all_context_ids(&self) -> Vec<&ContextId> {
-        self.default_context_ids
+    pub fn all_contexts(&self) -> Vec<&BootstrapContextEntry> {
+        self.default_contexts
             .iter()
-            .chain(self.custom_context_ids.iter())
+            .chain(self.custom_contexts.iter())
             .collect()
+    }
+
+    /// Verifies that a context's actual creator DID matches the expected
+    /// creator DID in the bootstrap configuration.
+    ///
+    /// This implements the post-join verification step from §22.13.2. After
+    /// joining a bootstrap context, the SDK calls this method with the context
+    /// ID and the creator DID extracted from the context's event log.
+    ///
+    /// # Returns
+    ///
+    /// - `Ok(true)` if the context was found in the configuration and the
+    ///   creator DID matches.
+    /// - `Ok(false)` if the context is not in the bootstrap configuration
+    ///   (not a bootstrap context, no verification needed).
+    /// - `Err(CreatorMismatch)` if the context was found but the actual
+    ///   creator DID does not match the expected one. The SDK MUST leave the
+    ///   context in this case.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`BootstrapVerificationError::CreatorMismatch`] when the context
+    /// is found in the configuration but the creator DID does not match.
+    pub fn verify_context_creator(
+        &self,
+        context_id: &ContextId,
+        actual_creator_did: &DID,
+    ) -> Result<bool, BootstrapVerificationError> {
+        // Check custom_contexts first so user overrides take precedence
+        // over stale default entries.
+        let entry = self
+            .custom_contexts
+            .iter()
+            .chain(self.default_contexts.iter())
+            .find(|e| e.context_id == *context_id);
+
+        entry.map_or(Ok(false), |e| {
+            if e.expected_creator_did == *actual_creator_did {
+                Ok(true)
+            } else {
+                Err(BootstrapVerificationError::CreatorMismatch {
+                    context_id: context_id.clone(),
+                    expected: e.expected_creator_did.clone(),
+                    actual: actual_creator_did.clone(),
+                })
+            }
+        })
     }
 
     /// Returns whether the SDK should auto-query contexts with discovery tools on first
@@ -157,12 +381,15 @@ impl BootstrapResolver {
 
     /// Returns all available context IDs (defaults + custom),
     /// deduplicated while preserving order.
+    ///
+    /// Extracts context IDs from [`BootstrapContextEntry`] entries.
     #[must_use]
     pub fn resolve_contexts(&self) -> Vec<ContextId> {
         let mut seen = std::collections::HashSet::new();
         self.config
-            .all_context_ids()
+            .all_contexts()
             .into_iter()
+            .map(|entry| &entry.context_id)
             .filter(|id| seen.insert((*id).clone()))
             .cloned()
             .collect()
@@ -272,6 +499,32 @@ impl From<BootstrapConfig> for BootstrapResolver {
 mod tests {
     use super::*;
 
+    // -- Helper: create a BootstrapContextEntry ----------------------------
+
+    fn entry(ctx_id: &str, creator: &str) -> BootstrapContextEntry {
+        BootstrapContextEntry::new(ctx_id.to_owned(), DID::from(creator))
+    }
+
+    // -- BootstrapContextEntry --------------------------------------------
+
+    #[test]
+    fn bootstrap_context_entry_construction() {
+        let e = BootstrapContextEntry::new(
+            "ctx-discovery-1".to_owned(),
+            DID::from("did:dht:zCreator1"),
+        );
+        assert_eq!(e.context_id, "ctx-discovery-1");
+        assert_eq!(e.expected_creator_did, "did:dht:zCreator1");
+    }
+
+    #[test]
+    fn bootstrap_context_entry_serde_roundtrip() {
+        let e = entry("ctx-discovery-1", "did:dht:zCreator1");
+        let json = serde_json::to_string(&e).unwrap();
+        let deserialized: BootstrapContextEntry = serde_json::from_str(&json).unwrap();
+        assert_eq!(e, deserialized);
+    }
+
     // -- BootstrapConfig defaults -----------------------------------------
 
     #[test]
@@ -289,25 +542,28 @@ mod tests {
     #[test]
     fn default_config_has_empty_context_lists() {
         let config = BootstrapConfig::default();
-        assert!(config.default_context_ids.is_empty());
-        assert!(config.custom_context_ids.is_empty());
+        assert!(config.default_contexts.is_empty());
+        assert!(config.custom_contexts.is_empty());
     }
 
     #[test]
-    fn default_config_all_context_ids_returns_empty() {
+    fn default_config_all_contexts_returns_empty() {
         let config = BootstrapConfig::default();
-        assert!(config.all_context_ids().is_empty());
+        assert!(config.all_contexts().is_empty());
     }
 
     // -- BootstrapConfig construction -------------------------------------
 
     #[test]
-    fn with_defaults_sets_default_context_ids() {
-        let ids = vec!["ctx-discovery-1".to_owned(), "ctx-discovery-2".to_owned()];
-        let config = BootstrapConfig::with_defaults(ids.clone());
+    fn with_defaults_sets_default_contexts() {
+        let entries = vec![
+            entry("ctx-discovery-1", "did:dht:zCreator1"),
+            entry("ctx-discovery-2", "did:dht:zCreator2"),
+        ];
+        let config = BootstrapConfig::with_defaults(entries.clone()).unwrap();
 
-        assert_eq!(config.default_context_ids, ids);
-        assert!(config.custom_context_ids.is_empty());
+        assert_eq!(config.default_contexts, entries);
+        assert!(config.custom_contexts.is_empty());
         assert!(config.should_auto_query());
         assert!(config.should_fallback());
     }
@@ -317,38 +573,50 @@ mod tests {
     #[test]
     fn add_custom_context_appends_to_custom_list() {
         let mut config = BootstrapConfig::default();
-        config.add_custom_context("ctx-custom-1".to_owned());
-        config.add_custom_context("ctx-custom-2".to_owned());
+        config
+            .add_custom_context(entry("ctx-custom-1", "did:dht:zCustom1"))
+            .unwrap();
+        config
+            .add_custom_context(entry("ctx-custom-2", "did:dht:zCustom2"))
+            .unwrap();
 
-        assert_eq!(config.custom_context_ids.len(), 2);
-        assert_eq!(config.custom_context_ids[0], "ctx-custom-1");
-        assert_eq!(config.custom_context_ids[1], "ctx-custom-2");
+        assert_eq!(config.custom_contexts.len(), 2);
+        assert_eq!(config.custom_contexts[0].context_id, "ctx-custom-1");
+        assert_eq!(config.custom_contexts[1].context_id, "ctx-custom-2");
     }
 
-    // -- all_context_ids combines defaults and custom ---------------------
+    // -- all_contexts combines defaults and custom ------------------------
 
     #[test]
-    fn all_context_ids_combines_defaults_and_custom() {
-        let mut config = BootstrapConfig::with_defaults(vec!["ctx-default-1".to_owned()]);
-        config.add_custom_context("ctx-custom-1".to_owned());
-
-        let all_ids = config.all_context_ids();
-        assert_eq!(all_ids.len(), 2);
-        assert_eq!(all_ids[0], "ctx-default-1");
-        assert_eq!(all_ids[1], "ctx-custom-1");
-    }
-
-    #[test]
-    fn all_context_ids_defaults_come_before_custom() {
+    fn all_contexts_combines_defaults_and_custom() {
         let mut config =
-            BootstrapConfig::with_defaults(vec!["ctx-d1".to_owned(), "ctx-d2".to_owned()]);
-        config.add_custom_context("ctx-c1".to_owned());
+            BootstrapConfig::with_defaults(vec![entry("ctx-default-1", "did:dht:zD1")]).unwrap();
+        config
+            .add_custom_context(entry("ctx-custom-1", "did:dht:zC1"))
+            .unwrap();
 
-        let all_ids = config.all_context_ids();
-        assert_eq!(all_ids.len(), 3);
-        assert_eq!(*all_ids[0], "ctx-d1");
-        assert_eq!(*all_ids[1], "ctx-d2");
-        assert_eq!(*all_ids[2], "ctx-c1");
+        let all = config.all_contexts();
+        assert_eq!(all.len(), 2);
+        assert_eq!(all[0].context_id, "ctx-default-1");
+        assert_eq!(all[1].context_id, "ctx-custom-1");
+    }
+
+    #[test]
+    fn all_contexts_defaults_come_before_custom() {
+        let mut config = BootstrapConfig::with_defaults(vec![
+            entry("ctx-d1", "did:dht:zD1"),
+            entry("ctx-d2", "did:dht:zD2"),
+        ])
+        .unwrap();
+        config
+            .add_custom_context(entry("ctx-c1", "did:dht:zC1"))
+            .unwrap();
+
+        let all = config.all_contexts();
+        assert_eq!(all.len(), 3);
+        assert_eq!(all[0].context_id, "ctx-d1");
+        assert_eq!(all[1].context_id, "ctx-d2");
+        assert_eq!(all[2].context_id, "ctx-c1");
     }
 
     // -- Opt-out of auto-query --------------------------------------------
@@ -373,8 +641,12 @@ mod tests {
 
     #[test]
     fn bootstrap_config_serialization_roundtrip() {
-        let mut config = BootstrapConfig::with_defaults(vec!["ctx-discovery-1".to_owned()]);
-        config.add_custom_context("ctx-custom-1".to_owned());
+        let mut config =
+            BootstrapConfig::with_defaults(vec![entry("ctx-discovery-1", "did:dht:zCreator1")])
+                .unwrap();
+        config
+            .add_custom_context(entry("ctx-custom-1", "did:dht:zCustom1"))
+            .unwrap();
         config.auto_query_on_identity_creation = false;
 
         let json = serde_json::to_string(&config).unwrap();
@@ -383,12 +655,116 @@ mod tests {
         assert_eq!(config, deserialized);
     }
 
+    // -- verify_context_creator -------------------------------------------
+
+    #[test]
+    fn verify_context_creator_success() {
+        let config =
+            BootstrapConfig::with_defaults(vec![entry("ctx-discovery-1", "did:dht:zCreator1")])
+                .unwrap();
+
+        let result = config
+            .verify_context_creator(
+                &"ctx-discovery-1".to_owned(),
+                &DID::from("did:dht:zCreator1"),
+            )
+            .unwrap();
+        assert!(result);
+    }
+
+    #[test]
+    fn verify_context_creator_not_found() {
+        let config =
+            BootstrapConfig::with_defaults(vec![entry("ctx-discovery-1", "did:dht:zCreator1")])
+                .unwrap();
+
+        let result = config
+            .verify_context_creator(&"ctx-unknown".to_owned(), &DID::from("did:dht:zCreator1"))
+            .unwrap();
+        assert!(!result);
+    }
+
+    #[test]
+    fn verify_context_creator_mismatch() {
+        let config =
+            BootstrapConfig::with_defaults(vec![entry("ctx-discovery-1", "did:dht:zCreator1")])
+                .unwrap();
+
+        let err = config
+            .verify_context_creator(
+                &"ctx-discovery-1".to_owned(),
+                &DID::from("did:dht:zAttacker"),
+            )
+            .unwrap_err();
+
+        assert!(matches!(
+            err,
+            BootstrapVerificationError::CreatorMismatch { .. }
+        ));
+        let msg = err.to_string();
+        assert!(msg.contains("ctx-discovery-1"));
+        assert!(msg.contains("did:dht:zCreator1"));
+        assert!(msg.contains("did:dht:zAttacker"));
+    }
+
+    #[test]
+    fn verify_context_creator_checks_custom_contexts() {
+        let mut config = BootstrapConfig::default();
+        config
+            .add_custom_context(entry("ctx-custom-1", "did:dht:zCustomCreator"))
+            .unwrap();
+
+        let result = config
+            .verify_context_creator(
+                &"ctx-custom-1".to_owned(),
+                &DID::from("did:dht:zCustomCreator"),
+            )
+            .unwrap();
+        assert!(result);
+    }
+
+    #[test]
+    fn verify_context_creator_custom_overrides_default() {
+        // When the same context_id exists in both default and custom lists,
+        // the custom entry's expected_creator_did should win.
+        let mut config =
+            BootstrapConfig::with_defaults(vec![entry("ctx-shared", "did:dht:zDefaultCreator")])
+                .unwrap();
+        config
+            .add_custom_context(entry("ctx-shared", "did:dht:zCustomCreator"))
+            .unwrap();
+
+        // The custom creator DID should verify successfully.
+        let result = config
+            .verify_context_creator(
+                &"ctx-shared".to_owned(),
+                &DID::from("did:dht:zCustomCreator"),
+            )
+            .unwrap();
+        assert!(result);
+
+        // The default creator DID should now fail (custom overrides it).
+        let err = config
+            .verify_context_creator(
+                &"ctx-shared".to_owned(),
+                &DID::from("did:dht:zDefaultCreator"),
+            )
+            .unwrap_err();
+        assert!(matches!(
+            err,
+            BootstrapVerificationError::CreatorMismatch { .. }
+        ));
+    }
+
     // -- BootstrapResolver ------------------------------------------------
 
     #[test]
     fn resolver_returns_all_context_ids() {
-        let mut config = BootstrapConfig::with_defaults(vec!["ctx-default-1".to_owned()]);
-        config.add_custom_context("ctx-custom-1".to_owned());
+        let mut config =
+            BootstrapConfig::with_defaults(vec![entry("ctx-default-1", "did:dht:zD1")]).unwrap();
+        config
+            .add_custom_context(entry("ctx-custom-1", "did:dht:zC1"))
+            .unwrap();
 
         let resolver = BootstrapResolver::new(config);
         let contexts = resolver.resolve_contexts();
@@ -400,9 +776,14 @@ mod tests {
 
     #[test]
     fn resolver_deduplicates_context_ids() {
-        let mut config = BootstrapConfig::with_defaults(vec!["ctx-shared".to_owned()]);
-        config.add_custom_context("ctx-shared".to_owned());
-        config.add_custom_context("ctx-unique".to_owned());
+        let mut config =
+            BootstrapConfig::with_defaults(vec![entry("ctx-shared", "did:dht:zCreator")]).unwrap();
+        config
+            .add_custom_context(entry("ctx-shared", "did:dht:zCreator"))
+            .unwrap();
+        config
+            .add_custom_context(entry("ctx-unique", "did:dht:zOther"))
+            .unwrap();
 
         let resolver = BootstrapResolver::new(config);
         let contexts = resolver.resolve_contexts();
@@ -421,14 +802,14 @@ mod tests {
 
     #[test]
     fn resolver_config_accessor_returns_config() {
-        let config = BootstrapConfig::with_defaults(vec!["ctx-1".to_owned()]);
+        let config = BootstrapConfig::with_defaults(vec![entry("ctx-1", "did:dht:zC1")]).unwrap();
         let resolver = BootstrapResolver::new(config.clone());
         assert_eq!(resolver.config(), &config);
     }
 
     #[test]
     fn resolver_from_config() {
-        let config = BootstrapConfig::with_defaults(vec!["ctx-1".to_owned()]);
+        let config = BootstrapConfig::with_defaults(vec![entry("ctx-1", "did:dht:zC1")]).unwrap();
         let resolver: BootstrapResolver = config.into();
         assert_eq!(resolver.resolve_contexts(), vec!["ctx-1"]);
     }
@@ -437,7 +818,9 @@ mod tests {
 
     #[test]
     fn resolve_with_fallback_returns_contexts_when_available() {
-        let config = BootstrapConfig::with_defaults(vec!["ctx-discovery-1".to_owned()]);
+        let config =
+            BootstrapConfig::with_defaults(vec![entry("ctx-discovery-1", "did:dht:zCreator1")])
+                .unwrap();
         let resolver = BootstrapResolver::new(config);
 
         let result = resolver.resolve_with_fallback("did:dht:zTestDid").unwrap();
@@ -468,5 +851,55 @@ mod tests {
 
         assert!(matches!(err, DiscoveryError::DidResolutionFailed(_)));
         assert!(err.to_string().contains("did:dht:zTestDid"));
+    }
+
+    // -- with_defaults capacity limit -------------------------------------
+
+    #[test]
+    fn with_defaults_accepts_max_default_contexts() {
+        let entries: Vec<_> = (0..MAX_DEFAULT_CONTEXTS)
+            .map(|i| entry(&format!("ctx-{i}"), &format!("did:dht:zCreator{i}")))
+            .collect();
+        let config = BootstrapConfig::with_defaults(entries).unwrap();
+        assert_eq!(config.default_contexts.len(), MAX_DEFAULT_CONTEXTS);
+    }
+
+    #[test]
+    fn with_defaults_rejects_over_max_default_contexts() {
+        let entries: Vec<_> = (0..=MAX_DEFAULT_CONTEXTS)
+            .map(|i| entry(&format!("ctx-{i}"), &format!("did:dht:zCreator{i}")))
+            .collect();
+        let err = BootstrapConfig::with_defaults(entries).unwrap_err();
+        assert!(
+            matches!(
+                err,
+                BootstrapVerificationError::TooManyDefaultContexts { .. }
+            ),
+            "expected TooManyDefaultContexts, got: {err:?}"
+        );
+    }
+
+    // -- add_custom_context capacity limit --------------------------------
+
+    #[test]
+    fn add_custom_context_rejects_at_capacity() {
+        let mut config = BootstrapConfig::default();
+        for i in 0..MAX_CUSTOM_CONTEXTS {
+            config
+                .add_custom_context(entry(&format!("ctx-{i}"), &format!("did:dht:zCreator{i}")))
+                .unwrap();
+        }
+        assert_eq!(config.custom_contexts.len(), MAX_CUSTOM_CONTEXTS);
+
+        // The next add must fail.
+        let err = config
+            .add_custom_context(entry("ctx-overflow", "did:dht:zOverflow"))
+            .unwrap_err();
+        assert!(
+            matches!(err, BootstrapVerificationError::TooManyCustomContexts),
+            "expected TooManyCustomContexts, got: {err:?}"
+        );
+        // Ensure the list did not grow.
+        assert_eq!(config.custom_contexts.len(), MAX_CUSTOM_CONTEXTS);
     }
 }

--- a/crates/scp-core/src/discovery/mod.rs
+++ b/crates/scp-core/src/discovery/mod.rs
@@ -30,7 +30,7 @@
 //! - [`DiscoveryResult`] -- Merged search results with provenance.
 //! - [`DiscoveryResultEntry`] -- A single result entry with relevance scoring.
 //! - [`RegistrationEntry`] -- A registered agent entry in a context with discovery tools.
-//! - [`DiscoveryBootstrap`] -- Default context configuration.
+//! - [`BootstrapContextEntry`] -- Bootstrap context with creator DID verification (§22.13.2).
 //! - [`DataProvenance`] -- Placeholder provenance metadata (replaced by SCP-070).
 //! - [`DiscoveryError`] -- Error type for discovery operations.
 //! - [`AddressResolver`] -- Multi-path address resolution (§22.8).
@@ -59,7 +59,10 @@ pub use addressing::{
     PetnameStore, ResolutionCache, ResolutionLayer, ResolutionPath, TrustLevel, normalize_address,
     parse_address,
 };
-pub use bootstrap::{BootstrapConfig, BootstrapResolver, WellKnownBootstrapError};
+pub use bootstrap::{
+    BootstrapConfig, BootstrapContextEntry, BootstrapResolver, BootstrapVerificationError,
+    MAX_CUSTOM_CONTEXTS, WellKnownBootstrapError,
+};
 pub use context::{
     AgentDeregisterParams, AgentDeregisterResult, AgentRegisterParams, AgentRegisterResult,
     AgentSearchParams, AgentSearchResult, RegistrationEvent, TOOL_AGENT_DEREGISTER,
@@ -199,23 +202,6 @@ pub struct RegistrationEntry {
 }
 
 // ---------------------------------------------------------------------------
-// DiscoveryBootstrap
-// ---------------------------------------------------------------------------
-
-/// Default context configuration for SDK bootstrap.
-///
-/// Analogous to DNS root servers: the SDK ships with configurable default
-/// bootstrap context IDs that are queried on first identity creation (opt-out).
-/// If defaults are unreachable, direct DID resolution still works.
-///
-/// See ADR-020 acceptance criterion 8.
-#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
-pub struct DiscoveryBootstrap {
-    /// Default bootstrap context IDs to query on bootstrap.
-    pub default_context_ids: Vec<ContextId>,
-}
-
-// ---------------------------------------------------------------------------
 // DiscoveryError
 // ---------------------------------------------------------------------------
 
@@ -302,20 +288,6 @@ mod tests {
         let deserialized: RegistrationEntry = serde_json::from_str(&json).unwrap();
 
         assert_eq!(entry, deserialized);
-    }
-
-    #[test]
-    fn discovery_bootstrap_default_has_no_contexts() {
-        let bootstrap = DiscoveryBootstrap::default();
-        assert!(bootstrap.default_context_ids.is_empty());
-    }
-
-    #[test]
-    fn discovery_bootstrap_with_contexts() {
-        let bootstrap = DiscoveryBootstrap {
-            default_context_ids: vec!["ctx-discovery-1".to_owned(), "ctx-discovery-2".to_owned()],
-        };
-        assert_eq!(bootstrap.default_context_ids.len(), 2);
     }
 
     #[test]

--- a/crates/scp-core/src/identity/attestation.rs
+++ b/crates/scp-core/src/identity/attestation.rs
@@ -56,8 +56,32 @@ pub const RENEWAL_INTERVAL_DNS_RECORD_DAYS: u32 = 180;
 /// No persistent proof exists; freshness of the interaction matters more.
 pub const RENEWAL_INTERVAL_CHALLENGE_RESPONSE_DAYS: u32 = 60;
 
-/// Milliseconds per day, for converting renewal intervals to timestamps.
-pub const MS_PER_DAY: u64 = 86_400_000;
+/// Seconds per day, for converting renewal intervals to timestamps.
+///
+/// All attestation timestamps use seconds (spec §3.5.1). Wire format,
+/// `verified_at`, `issued_at`, and expiry are all Unix seconds.
+pub const SECS_PER_DAY: u64 = 86_400;
+
+// ---------------------------------------------------------------------------
+// AttestationClass (§3.5.2)
+// ---------------------------------------------------------------------------
+
+/// Classification of verification methods by their proof model (§3.5.2).
+///
+/// Determines cache TTLs and verification strategy:
+/// - **Cryptographic** — backed by cryptographic verification (OAuth JWTs
+///   verified against JWKS, challenge-response signatures). Can be verified
+///   without re-fetching external resources. Cache TTL: 24h.
+/// - **Reference** — requires fetching an external resource to verify (signed
+///   posts, DNS records). Verification requires network access. Cache TTL: 1h.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum AttestationClass {
+    /// Self-verifying via cryptographic proof (OAuth, challenge-response).
+    Cryptographic,
+    /// Requires fetching external resource to verify (signed post, DNS record).
+    Reference,
+}
 
 // ---------------------------------------------------------------------------
 // VerificationMethod (§3.5.2)
@@ -113,6 +137,27 @@ pub enum VerificationMethod {
     ChallengeResponse,
 }
 
+impl std::str::FromStr for VerificationMethod {
+    type Err = String;
+
+    /// Parses a wire-format string into a `VerificationMethod`.
+    ///
+    /// Accepted values: `"oauth"`, `"signed_post"`, `"dns_record"`,
+    /// `"challenge_response"`.
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "oauth" => Ok(Self::Oauth),
+            "signed_post" => Ok(Self::SignedPost),
+            "dns_record" => Ok(Self::DnsRecord),
+            "challenge_response" => Ok(Self::ChallengeResponse),
+            other => Err(format!(
+                "invalid verification method: {other}; expected 'oauth', \
+                 'signed_post', 'dns_record', or 'challenge_response'"
+            )),
+        }
+    }
+}
+
 impl VerificationMethod {
     /// Returns the recommended renewal interval in days for this method (§3.5.2).
     #[must_use]
@@ -125,10 +170,10 @@ impl VerificationMethod {
         }
     }
 
-    /// Returns the recommended renewal interval in milliseconds for this method.
+    /// Returns the recommended renewal interval in seconds for this method.
     #[must_use]
-    pub const fn renewal_interval_ms(self) -> u64 {
-        self.renewal_interval_days() as u64 * MS_PER_DAY
+    pub const fn renewal_interval_secs(self) -> u64 {
+        self.renewal_interval_days() as u64 * SECS_PER_DAY
     }
 
     /// Returns the wire-format string for this method (matches `evidence.method`).
@@ -140,6 +185,116 @@ impl VerificationMethod {
             Self::DnsRecord => "dns_record",
             Self::ChallengeResponse => "challenge_response",
         }
+    }
+
+    /// Returns the attestation class for this verification method (§7.4.1).
+    ///
+    /// - **Cryptographic** methods (OAuth, challenge-response) produce proofs
+    ///   backed by cryptographic verification (OAuth JWTs verified against JWKS,
+    ///   challenge-response signatures). Can be verified without re-fetching the
+    ///   original external resource.
+    /// - **Reference** methods (signed post, DNS record) require fetching or
+    ///   validating external platform data that may become unavailable.
+    #[must_use]
+    pub const fn attestation_class(self) -> AttestationClass {
+        match self {
+            Self::Oauth | Self::ChallengeResponse => AttestationClass::Cryptographic,
+            Self::SignedPost | Self::DnsRecord => AttestationClass::Reference,
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// AttestationProof (§3.5.2)
+// ---------------------------------------------------------------------------
+
+/// Typed proof data for an identity link attestation (§3.5.2).
+///
+/// Each variant corresponds to one [`VerificationMethod`] and carries only the
+/// fields relevant to that method. The `type` tag in the JSON/msgpack wire
+/// format discriminates variants using `snake_case` names.
+///
+/// # Variant–method correspondence
+///
+/// | Variant                      | VerificationMethod   |
+/// |------------------------------|----------------------|
+/// | `OauthVerified`              | `Oauth`              |
+/// | `SignedPostVerified`         | `SignedPost`         |
+/// | `DnsRecordVerified`          | `DnsRecord`          |
+/// | `ChallengeResponseVerified`  | `ChallengeResponse`  |
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum AttestationProof {
+    /// OAuth 2.0 verification proof (§3.5.2).
+    ///
+    /// Contains the provider name, the platform-specific subject ID returned
+    /// by the OAuth provider, and the verification timestamp (seconds).
+    OauthVerified {
+        /// OAuth provider identifier (e.g., `"github.com"`, `"google.com"`).
+        provider: String,
+        /// Platform-specific user/subject ID from the OAuth token.
+        subject_id: String,
+        /// Unix timestamp (seconds) when the OAuth verification occurred.
+        verified_at: u64,
+    },
+
+    /// Signed post verification proof (§3.5.2).
+    ///
+    /// The user posted a message containing their DID and a nonce on the
+    /// target platform. Verifiers fetch the post to confirm authorship.
+    SignedPostVerified {
+        /// Full URL of the post containing the DID and nonce.
+        post_url: String,
+        /// Random nonce included in the post to prevent replay.
+        nonce: String,
+        /// Unix timestamp (seconds) when the post was created.
+        posted_at: u64,
+    },
+
+    /// DNS TXT record verification proof (§3.5.2).
+    ///
+    /// The user added a TXT record at `_scp-verify.<domain>` containing
+    /// their DID. Verifiers perform a DNS lookup to confirm.
+    DnsRecordVerified {
+        /// Domain where the TXT record was placed.
+        domain: String,
+        /// DNS record name (e.g., `"_scp-verify"`).
+        record_name: String,
+    },
+
+    /// Challenge-response verification proof (§3.5.2).
+    ///
+    /// A verifier sent a challenge through the platform; the user signed it
+    /// with their SCP identity key.
+    ChallengeResponseVerified {
+        /// The challenge string sent by the verifier.
+        challenge: String,
+        /// Ed25519 signature over the challenge, hex-encoded.
+        response_signature: String,
+    },
+}
+
+impl AttestationProof {
+    /// Returns the [`VerificationMethod`] that this proof variant corresponds to.
+    ///
+    /// This is the inverse of the variant–method mapping: given a proof, you
+    /// can determine which verification method produced it.
+    #[must_use]
+    pub const fn expected_method(&self) -> VerificationMethod {
+        match self {
+            Self::OauthVerified { .. } => VerificationMethod::Oauth,
+            Self::SignedPostVerified { .. } => VerificationMethod::SignedPost,
+            Self::DnsRecordVerified { .. } => VerificationMethod::DnsRecord,
+            Self::ChallengeResponseVerified { .. } => VerificationMethod::ChallengeResponse,
+        }
+    }
+
+    /// Returns the [`AttestationClass`] for this proof type.
+    ///
+    /// Delegates to the corresponding [`VerificationMethod::attestation_class`].
+    #[must_use]
+    pub const fn attestation_class(&self) -> AttestationClass {
+        self.expected_method().attestation_class()
     }
 }
 
@@ -195,23 +350,23 @@ impl AttestationClaim {
 
 /// Evidence supporting an identity link attestation (§3.5.1).
 ///
-/// Contains the verification method, method-specific proof data, the
-/// timestamp of last verification, and an optional third-party verifier DID.
+/// Contains the verification method, proof data, the timestamp of
+/// last verification, and an optional third-party verifier DID.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct AttestationEvidence {
     /// Verification method used to establish the link.
     pub method: VerificationMethod,
 
-    /// Method-specific proof data (§3.5.2).
+    /// Method-specific proof data as an OPAQUE STRING (spec §3.5.2).
     ///
-    /// Contents depend on `method`:
-    /// - OAuth: signed ID token (JWT) or signed provider assertion.
-    /// - Signed post: `{ "post_url", "nonce", "posted_at" }`.
-    /// - DNS record: `{ "domain", "record_name" }`.
-    /// - Challenge-response: `{ "challenge", "response_signature", "verifier_did" }`.
+    /// Verifiers MUST use this string as-is in signature scope — do not parse
+    /// and re-serialize. Three reasons:
+    /// 1. Forward compatibility — new methods without wire format changes
+    /// 2. Cross-implementation determinism — no serialization ambiguity
+    /// 3. No parsing requirement — verifiers only need Ed25519 signature check
     pub proof: String,
 
-    /// Unix timestamp (milliseconds) of last verification.
+    /// Unix timestamp (seconds) of last verification.
     pub verified_at: u64,
 
     /// DID of the third-party verifier, if the evidence was verified by
@@ -222,46 +377,13 @@ pub struct AttestationEvidence {
 
 impl AttestationEvidence {
     /// Returns whether this evidence has expired relative to the given
-    /// current timestamp, based on the verification method's renewal interval.
+    /// current timestamp (seconds), based on the verification method's renewal interval.
     ///
     /// An evidence record is considered expired when
-    /// `now_ms - verified_at > method.renewal_interval_ms()`.
+    /// `now_secs - verified_at > method.renewal_interval_secs()`.
     #[must_use]
-    pub const fn is_expired(&self, now_ms: u64) -> bool {
-        now_ms.saturating_sub(self.verified_at) > self.method.renewal_interval_ms()
-    }
-}
-
-// ---------------------------------------------------------------------------
-// AttestationRevocation (§3.5.1)
-// ---------------------------------------------------------------------------
-
-/// Revocation metadata for an identity link attestation (§3.5.1).
-///
-/// Specifies how verifiers check whether this attestation has been revoked.
-/// The canonical method is `"did_document"` — verifiers resolve the issuer's
-/// DID document and check the `AttestationRevocations` service endpoint
-/// (§18.2.2) for the attestation's ID.
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-pub struct AttestationRevocation {
-    /// Revocation check method. Currently always `"did_document"`.
-    pub method: Cow<'static, str>,
-
-    /// DID document service endpoint path for revocation status.
-    pub endpoint: String,
-}
-
-impl AttestationRevocation {
-    /// The canonical revocation method value.
-    pub const DID_DOCUMENT: &'static str = "did_document";
-
-    /// Creates a new revocation entry with the canonical method.
-    #[must_use]
-    pub const fn new(endpoint: String) -> Self {
-        Self {
-            method: Cow::Borrowed(Self::DID_DOCUMENT),
-            endpoint,
-        }
+    pub const fn is_expired(&self, now_secs: u64) -> bool {
+        now_secs.saturating_sub(self.verified_at) > self.method.renewal_interval_secs()
     }
 }
 
@@ -301,10 +423,10 @@ pub struct IdentityLinkAttestation {
     /// Same as `issuer` for self-attestations.
     pub subject: DID,
 
-    /// Unix timestamp (milliseconds) when the attestation was created.
+    /// Unix timestamp (seconds) when the attestation was created.
     pub issued_at: u64,
 
-    /// Optional expiry timestamp (milliseconds). If absent, valid until revoked.
+    /// Optional expiry timestamp (seconds). If absent, valid until revoked.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub expires_at: Option<u64>,
 
@@ -314,8 +436,9 @@ pub struct IdentityLinkAttestation {
     /// Evidence supporting the claim.
     pub evidence: AttestationEvidence,
 
-    /// Revocation metadata.
-    pub revocation: AttestationRevocation,
+    /// Revocation status: `Active` or `Revoked` (§7.4.1). Included in
+    /// the signed scope to prevent replay of revoked attestations.
+    pub revocation_status: crate::trust::attestation::RevocationStatus,
 
     /// Ed25519 signature over the canonical `MessagePack` of all other fields.
     ///
@@ -334,24 +457,24 @@ impl IdentityLinkAttestation {
     /// Returns `false` if `expires_at` is `None` (no expiry set — valid
     /// until revoked).
     #[must_use]
-    pub fn is_time_expired(&self, now_ms: u64) -> bool {
-        self.expires_at.is_some_and(|exp| now_ms > exp)
+    pub fn is_time_expired(&self, now_secs: u64) -> bool {
+        self.expires_at.is_some_and(|exp| now_secs > exp)
     }
 
     /// Returns whether the evidence needs renewal based on the verification
     /// method's recommended interval (§3.5.2).
     #[must_use]
-    pub const fn needs_renewal(&self, now_ms: u64) -> bool {
-        self.evidence.is_expired(now_ms)
+    pub const fn needs_renewal(&self, now_secs: u64) -> bool {
+        self.evidence.is_expired(now_secs)
     }
 
-    /// Returns the renewal deadline (milliseconds) — the timestamp after
+    /// Returns the renewal deadline (seconds) — the timestamp after
     /// which this attestation's evidence is considered stale.
     #[must_use]
-    pub const fn renewal_deadline_ms(&self) -> u64 {
+    pub const fn renewal_deadline_secs(&self) -> u64 {
         self.evidence
             .verified_at
-            .saturating_add(self.evidence.method.renewal_interval_ms())
+            .saturating_add(self.evidence.method.renewal_interval_secs())
     }
 
     /// Computes the deterministic attestation ID from its components.
@@ -399,7 +522,7 @@ impl IdentityLinkAttestation {
     /// The canonical form uses domain separator `"SCP-IDENTITY-LINK-ATTESTATION-V1:"`
     /// with fields in a fixed order: `id`, `attestation_type`, `issuer`, `subject`,
     /// `issued_at`, `expires_at` (or absent sentinel), `claim` (`MessagePack`),
-    /// `evidence` (`MessagePack`), `revocation` (`MessagePack`).
+    /// `evidence` (`MessagePack`), `revocation_status` (`MessagePack`).
     ///
     /// # Arguments
     ///
@@ -420,12 +543,18 @@ impl IdentityLinkAttestation {
     ///
     /// The payload includes all fields except `signature`, serialized using the
     /// protocol's canonical hash construction (§9.5.1). Sub-structs (`claim`,
-    /// `evidence`, `revocation`) are serialized as `MessagePack` bytes and included
-    /// as variable-length fields.
+    /// `evidence`, `revocation_status`) are serialized as `MessagePack` bytes
+    /// and included as variable-length fields.
     ///
     /// This method is deterministic: identical attestation data always produces
     /// identical bytes, regardless of serde field ordering.
-    fn canonical_signing_bytes(&self) -> Result<Vec<u8>, AttestationSignatureError> {
+    ///
+    /// # Errors
+    ///
+    /// Returns [`AttestationSignatureError::SerializationFailed`] if any
+    /// sub-struct (`claim`, `evidence`, `revocation_status`) cannot be serialized
+    /// to `MessagePack`.
+    pub fn canonical_signing_bytes(&self) -> Result<Vec<u8>, AttestationSignatureError> {
         use crate::crypto::canonical::{CanonicalField, canonical_hash};
 
         let claim_bytes = rmp_serde::to_vec_named(&self.claim).map_err(|e| {
@@ -438,11 +567,12 @@ impl IdentityLinkAttestation {
                 "evidence serialization failed: {e}"
             ))
         })?;
-        let revocation_bytes = rmp_serde::to_vec_named(&self.revocation).map_err(|e| {
-            AttestationSignatureError::SerializationFailed(format!(
-                "revocation serialization failed: {e}"
-            ))
-        })?;
+        let revocation_status_bytes =
+            rmp_serde::to_vec_named(&self.revocation_status).map_err(|e| {
+                AttestationSignatureError::SerializationFailed(format!(
+                    "revocation_status serialization failed: {e}"
+                ))
+            })?;
 
         Ok(canonical_hash(
             "SCP-IDENTITY-LINK-ATTESTATION-V1:",
@@ -456,7 +586,7 @@ impl IdentityLinkAttestation {
                     .map_or(CanonicalField::Absent, CanonicalField::U64),
                 CanonicalField::VarBytes(&claim_bytes),
                 CanonicalField::VarBytes(&evidence_bytes),
-                CanonicalField::VarBytes(&revocation_bytes),
+                CanonicalField::VarBytes(&revocation_status_bytes),
             ],
         )
         .to_vec())
@@ -470,6 +600,8 @@ impl IdentityLinkAttestation {
     /// - `issuer` equals `subject` (self-attestation).
     /// - `id` matches the computed deterministic ID.
     /// - `claim.link_type` is `"self_attestation"`.
+    /// - If revoked, `revoked_by` equals `issuer` (§7.4.1: only the issuer
+    ///   can revoke their own attestation).
     ///
     /// Returns a list of validation errors. Empty list means structurally valid.
     #[must_use]
@@ -506,6 +638,29 @@ impl IdentityLinkAttestation {
             errors.push(Cow::Owned(format!(
                 "link_type must be \"self_attestation\", got {:?}",
                 self.claim.link_type,
+            )));
+        }
+
+        // §7.4.1: only the issuer can revoke their own attestation.
+        // Defense in depth — signature verification prevents tampering, but
+        // structural validation catches malformed attestations early.
+        if let crate::trust::attestation::RevocationStatus::Revoked { revoked_by, .. } =
+            &self.revocation_status
+            && *revoked_by != self.issuer
+        {
+            errors.push(Cow::Owned(format!(
+                "revoked_by {} does not match issuer {}",
+                revoked_by, self.issuer,
+            )));
+        }
+
+        // expires_at, when present, must be after issued_at.
+        if let Some(expires_at) = self.expires_at
+            && expires_at <= self.issued_at
+        {
+            errors.push(Cow::Owned(format!(
+                "expires_at ({expires_at}) must be greater than issued_at ({})",
+                self.issued_at,
             )));
         }
 
@@ -547,7 +702,7 @@ mod tests {
         let issuer = did("did:dht:z6MkAlice");
         let platform = "github.com";
         let handle = "alice";
-        let issued_at = 1_700_000_000_000_u64;
+        let issued_at = 1_700_000_000_u64;
 
         IdentityLinkAttestation {
             id: IdentityLinkAttestation::compute_id(&issuer, platform, handle, issued_at),
@@ -563,12 +718,11 @@ mod tests {
             ),
             evidence: AttestationEvidence {
                 method: VerificationMethod::Oauth,
-                proof: r#"{"provider":"github.com","subject":"12345","issued_at":1700000000}"#
-                    .to_owned(),
-                verified_at: 1_700_000_000_000,
+                proof: r#"{"type":"oauth_verified","provider":"github.com","subject_id":"12345","verified_at":1700000000}"#.to_owned(),
+                verified_at: 1_700_000_000,
                 verifier_did: None,
             },
-            revocation: AttestationRevocation::new("/revocations".to_owned()),
+            revocation_status: crate::trust::attestation::RevocationStatus::Active,
             signature: vec![0xAA; 64],
         }
     }
@@ -589,14 +743,14 @@ mod tests {
     }
 
     #[test]
-    fn verification_method_renewal_ms() {
+    fn verification_method_renewal_secs() {
         assert_eq!(
-            VerificationMethod::Oauth.renewal_interval_ms(),
-            30 * MS_PER_DAY
+            VerificationMethod::Oauth.renewal_interval_secs(),
+            30 * SECS_PER_DAY
         );
         assert_eq!(
-            VerificationMethod::DnsRecord.renewal_interval_ms(),
-            180 * MS_PER_DAY
+            VerificationMethod::DnsRecord.renewal_interval_secs(),
+            180 * SECS_PER_DAY
         );
     }
 
@@ -669,12 +823,12 @@ mod tests {
     fn attestation_evidence_not_expired() {
         let evidence = AttestationEvidence {
             method: VerificationMethod::Oauth,
-            proof: "jwt-token".to_owned(),
-            verified_at: 1_700_000_000_000,
+            proof: r#"{"type":"oauth_verified","provider":"github.com","subject_id":"12345","verified_at":1700000000}"#.to_owned(),
+            verified_at: 1_700_000_000,
             verifier_did: None,
         };
         // 15 days later — within 30-day renewal
-        let now = 1_700_000_000_000 + 15 * MS_PER_DAY;
+        let now = 1_700_000_000 + 15 * SECS_PER_DAY;
         assert!(!evidence.is_expired(now));
     }
 
@@ -682,12 +836,12 @@ mod tests {
     fn attestation_evidence_expired() {
         let evidence = AttestationEvidence {
             method: VerificationMethod::Oauth,
-            proof: "jwt-token".to_owned(),
-            verified_at: 1_700_000_000_000,
+            proof: r#"{"type":"oauth_verified","provider":"github.com","subject_id":"12345","verified_at":1700000000}"#.to_owned(),
+            verified_at: 1_700_000_000,
             verifier_did: None,
         };
         // 31 days later — past 30-day renewal
-        let now = 1_700_000_000_000 + 31 * MS_PER_DAY;
+        let now = 1_700_000_000 + 31 * SECS_PER_DAY;
         assert!(evidence.is_expired(now));
     }
 
@@ -695,12 +849,12 @@ mod tests {
     fn attestation_evidence_exactly_at_boundary() {
         let evidence = AttestationEvidence {
             method: VerificationMethod::SignedPost,
-            proof: "post-data".to_owned(),
-            verified_at: 1_700_000_000_000,
+            proof: r#"{"type":"signed_post_verified","post_url":"https://x.com/alice/123","nonce":"abc123","posted_at":1700000000}"#.to_owned(),
+            verified_at: 1_700_000_000,
             verifier_did: None,
         };
         // Exactly at 90 days — not expired (boundary is >)
-        let now = 1_700_000_000_000 + 90 * MS_PER_DAY;
+        let now = 1_700_000_000 + 90 * SECS_PER_DAY;
         assert!(!evidence.is_expired(now));
     }
 
@@ -708,32 +862,13 @@ mod tests {
     fn attestation_evidence_serialization_roundtrip() {
         let evidence = AttestationEvidence {
             method: VerificationMethod::ChallengeResponse,
-            proof: r#"{"challenge":"abc","response_signature":"def","verifier_did":"did:dht:z6MkVerifier"}"#.to_owned(),
-            verified_at: 1_700_000_000_000,
+            proof: r#"{"type":"challenge_response_verified","challenge":"abc","response_signature":"def"}"#.to_owned(),
+            verified_at: 1_700_000_000,
             verifier_did: Some(did("did:dht:z6MkVerifier")),
         };
         let json = serde_json::to_string(&evidence).unwrap();
         let deserialized: AttestationEvidence = serde_json::from_str(&json).unwrap();
         assert_eq!(evidence, deserialized);
-    }
-
-    // -----------------------------------------------------------------------
-    // AttestationRevocation
-    // -----------------------------------------------------------------------
-
-    #[test]
-    fn attestation_revocation_construction() {
-        let rev = AttestationRevocation::new("/revocations/v1".to_owned());
-        assert_eq!(rev.method, "did_document");
-        assert_eq!(rev.endpoint, "/revocations/v1");
-    }
-
-    #[test]
-    fn attestation_revocation_serialization_roundtrip() {
-        let rev = AttestationRevocation::new("/attestation-revocations".to_owned());
-        let json = serde_json::to_string(&rev).unwrap();
-        let deserialized: AttestationRevocation = serde_json::from_str(&json).unwrap();
-        assert_eq!(rev, deserialized);
     }
 
     // -----------------------------------------------------------------------
@@ -804,6 +939,37 @@ mod tests {
     }
 
     #[test]
+    fn attestation_validate_structure_revoked_by_non_issuer() {
+        let mut attestation = make_attestation();
+        attestation.revocation_status = crate::trust::attestation::RevocationStatus::Revoked {
+            revoked_at: 1_700_000_100_000,
+            reason: String::new(),
+            revoked_by: did("did:dht:z6MkMallory"),
+        };
+        let errors = attestation.validate_structure();
+        assert!(
+            errors.iter().any(|e| e.contains("revoked_by")),
+            "expected revoked_by mismatch error, got: {errors:?}",
+        );
+    }
+
+    #[test]
+    fn attestation_validate_structure_revoked_by_issuer_ok() {
+        let mut attestation = make_attestation();
+        attestation.revocation_status = crate::trust::attestation::RevocationStatus::Revoked {
+            revoked_at: 1_700_000_100_000,
+            reason: String::new(),
+            revoked_by: attestation.issuer.clone(),
+        };
+        let errors = attestation.validate_structure();
+        // No revoked_by error — only issuer can revoke.
+        assert!(
+            !errors.iter().any(|e| e.contains("revoked_by")),
+            "unexpected revoked_by error: {errors:?}",
+        );
+    }
+
+    #[test]
     fn attestation_is_time_expired_no_expiry() {
         let attestation = make_attestation();
         assert!(!attestation.is_time_expired(u64::MAX));
@@ -812,22 +978,22 @@ mod tests {
     #[test]
     fn attestation_is_time_expired_before_expiry() {
         let mut attestation = make_attestation();
-        attestation.expires_at = Some(2_000_000_000_000);
-        assert!(!attestation.is_time_expired(1_999_999_999_999));
+        attestation.expires_at = Some(2_000_000_000);
+        assert!(!attestation.is_time_expired(1_999_999_999));
     }
 
     #[test]
     fn attestation_is_time_expired_after_expiry() {
         let mut attestation = make_attestation();
-        attestation.expires_at = Some(2_000_000_000_000);
-        assert!(attestation.is_time_expired(2_000_000_000_001));
+        attestation.expires_at = Some(2_000_000_000);
+        assert!(attestation.is_time_expired(2_000_000_001));
     }
 
     #[test]
     fn attestation_needs_renewal_fresh() {
         let attestation = make_attestation();
         // 5 days later — well within 30-day OAuth renewal
-        let now = attestation.evidence.verified_at + 5 * MS_PER_DAY;
+        let now = attestation.evidence.verified_at + 5 * SECS_PER_DAY;
         assert!(!attestation.needs_renewal(now));
     }
 
@@ -835,15 +1001,15 @@ mod tests {
     fn attestation_needs_renewal_stale() {
         let attestation = make_attestation();
         // 31 days later — past 30-day OAuth renewal
-        let now = attestation.evidence.verified_at + 31 * MS_PER_DAY;
+        let now = attestation.evidence.verified_at + 31 * SECS_PER_DAY;
         assert!(attestation.needs_renewal(now));
     }
 
     #[test]
-    fn attestation_renewal_deadline_ms() {
+    fn attestation_renewal_deadline_secs() {
         let attestation = make_attestation();
-        let expected = attestation.evidence.verified_at + 30 * MS_PER_DAY;
-        assert_eq!(attestation.renewal_deadline_ms(), expected);
+        let expected = attestation.evidence.verified_at + 30 * SECS_PER_DAY;
+        assert_eq!(attestation.renewal_deadline_secs(), expected);
     }
 
     #[test]
@@ -865,11 +1031,11 @@ mod tests {
     #[test]
     fn attestation_with_expiry_serialization() {
         let mut attestation = make_attestation();
-        attestation.expires_at = Some(1_800_000_000_000);
+        attestation.expires_at = Some(1_800_000_000);
         let json = serde_json::to_string(&attestation).unwrap();
-        assert!(json.contains("1800000000000"));
+        assert!(json.contains("1800000000"));
         let deserialized: IdentityLinkAttestation = serde_json::from_str(&json).unwrap();
-        assert_eq!(deserialized.expires_at, Some(1_800_000_000_000));
+        assert_eq!(deserialized.expires_at, Some(1_800_000_000));
     }
 
     #[test]
@@ -877,10 +1043,10 @@ mod tests {
         let mut attestation = make_attestation();
         attestation.evidence.method = VerificationMethod::DnsRecord;
         // 100 days — within 180-day DNS renewal
-        let now = attestation.evidence.verified_at + 100 * MS_PER_DAY;
+        let now = attestation.evidence.verified_at + 100 * SECS_PER_DAY;
         assert!(!attestation.needs_renewal(now));
         // 181 days — past renewal
-        let now = attestation.evidence.verified_at + 181 * MS_PER_DAY;
+        let now = attestation.evidence.verified_at + 181 * SECS_PER_DAY;
         assert!(attestation.needs_renewal(now));
     }
 
@@ -928,7 +1094,7 @@ mod tests {
     fn attestation_evidence_ignores_unknown_fields() {
         let evidence = AttestationEvidence {
             method: VerificationMethod::Oauth,
-            proof: "proof-data".to_owned(),
+            proof: r#"{"type":"oauth_verified","provider":"github.com","subject_id":"12345","verified_at":1700000000}"#.to_owned(),
             verified_at: 1_700_000_000_000,
             verifier_did: None,
         };
@@ -944,23 +1110,6 @@ mod tests {
         let decoded = result.unwrap();
         assert_eq!(decoded.method, VerificationMethod::Oauth);
         assert_eq!(decoded.verified_at, 1_700_000_000_000);
-    }
-
-    #[test]
-    fn attestation_revocation_ignores_unknown_fields() {
-        let revocation = AttestationRevocation::new("/revocations".to_owned());
-        let mut map: serde_json::Map<String, serde_json::Value> =
-            serde_json::from_value(serde_json::to_value(&revocation).unwrap()).unwrap();
-        map.insert("future_field".into(), "v2-data".into());
-        let result =
-            serde_json::from_value::<AttestationRevocation>(serde_json::Value::Object(map));
-        assert!(
-            result.is_ok(),
-            "wire-format types must ignore unknown fields per §13.5.1: {:?}",
-            result.unwrap_err()
-        );
-        let decoded = result.unwrap();
-        assert_eq!(decoded.endpoint, "/revocations");
     }
 
     // -----------------------------------------------------------------------
@@ -993,12 +1142,11 @@ mod tests {
             ),
             evidence: AttestationEvidence {
                 method: VerificationMethod::Oauth,
-                proof: r#"{"provider":"github.com","subject":"12345","issued_at":1700000000}"#
-                    .to_owned(),
+                proof: r#"{"type":"oauth_verified","provider":"github.com","subject_id":"12345","verified_at":1700000000}"#.to_owned(),
                 verified_at: 1_700_000_000_000,
                 verifier_did: None,
             },
-            revocation: AttestationRevocation::new("/revocations".to_owned()),
+            revocation_status: crate::trust::attestation::RevocationStatus::Active,
             signature: Vec::new(), // placeholder — will be replaced
         };
 
@@ -1081,13 +1229,21 @@ mod tests {
     }
 
     #[test]
-    fn verify_signature_tampered_revocation() {
+    fn verify_signature_tampered_revocation_status() {
         let sk = test_signing_key(0xAA);
         let mut attestation = make_signed_attestation(&sk);
-        attestation.revocation.endpoint = "/evil".to_owned();
+        // Tamper revocation_status from Active to Revoked — must invalidate
+        attestation.revocation_status = crate::trust::attestation::RevocationStatus::Revoked {
+            revoked_at: 1_700_000_000_000,
+            reason: "tampered".to_owned(),
+            revoked_by: attestation.issuer.clone(),
+        };
         let vk = sk.verifying_key();
         let result = attestation.verify_signature(vk.as_bytes());
-        assert!(result.is_err(), "should fail with tampered revocation");
+        assert!(
+            result.is_err(),
+            "should fail with tampered revocation_status"
+        );
     }
 
     #[test]
@@ -1162,13 +1318,11 @@ mod tests {
             claim: AttestationClaim::new(platform.to_owned(), handle.to_owned(), None),
             evidence: AttestationEvidence {
                 method: VerificationMethod::SignedPost,
-                proof:
-                    r#"{"post_url":"https://x.com/alice/123","nonce":"abc","posted_at":1700000000}"#
-                        .to_owned(),
+                proof: r#"{"type":"signed_post_verified","post_url":"https://x.com/alice/123","nonce":"abc","posted_at":1700000000}"#.to_owned(),
                 verified_at: 1_700_000_000_000,
                 verifier_did: None,
             },
-            revocation: AttestationRevocation::new("/revocations".to_owned()),
+            revocation_status: crate::trust::attestation::RevocationStatus::Active,
             signature: Vec::new(),
         };
 
@@ -1186,5 +1340,187 @@ mod tests {
         let bytes1 = attestation.canonical_signing_bytes().unwrap();
         let bytes2 = attestation.canonical_signing_bytes().unwrap();
         assert_eq!(bytes1, bytes2, "canonical bytes must be deterministic");
+    }
+
+    // -----------------------------------------------------------------------
+    // AttestationClass
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn attestation_class_from_verification_method() {
+        assert_eq!(
+            VerificationMethod::Oauth.attestation_class(),
+            AttestationClass::Cryptographic
+        );
+        assert_eq!(
+            VerificationMethod::ChallengeResponse.attestation_class(),
+            AttestationClass::Cryptographic
+        );
+        assert_eq!(
+            VerificationMethod::SignedPost.attestation_class(),
+            AttestationClass::Reference
+        );
+        assert_eq!(
+            VerificationMethod::DnsRecord.attestation_class(),
+            AttestationClass::Reference
+        );
+    }
+
+    #[test]
+    fn attestation_class_serialization_roundtrip() {
+        let classes = [AttestationClass::Cryptographic, AttestationClass::Reference];
+        for class in &classes {
+            let json = serde_json::to_string(class).unwrap();
+            let deserialized: AttestationClass = serde_json::from_str(&json).unwrap();
+            assert_eq!(class, &deserialized);
+        }
+    }
+
+    #[test]
+    fn attestation_class_serde_snake_case() {
+        assert_eq!(
+            serde_json::to_string(&AttestationClass::Cryptographic).unwrap(),
+            "\"cryptographic\""
+        );
+        assert_eq!(
+            serde_json::to_string(&AttestationClass::Reference).unwrap(),
+            "\"reference\""
+        );
+    }
+
+    // -----------------------------------------------------------------------
+    // AttestationProof (deprecated — kept for SDK-side parsing tests)
+    // -----------------------------------------------------------------------
+
+    #[allow(deprecated)]
+    #[test]
+    fn attestation_proof_expected_method() {
+        let oauth = AttestationProof::OauthVerified {
+            provider: "g".to_owned(),
+            subject_id: "1".to_owned(),
+            verified_at: 0,
+        };
+        assert_eq!(oauth.expected_method(), VerificationMethod::Oauth);
+
+        let signed_post = AttestationProof::SignedPostVerified {
+            post_url: "u".to_owned(),
+            nonce: "n".to_owned(),
+            posted_at: 0,
+        };
+        assert_eq!(
+            signed_post.expected_method(),
+            VerificationMethod::SignedPost
+        );
+
+        let dns = AttestationProof::DnsRecordVerified {
+            domain: "d".to_owned(),
+            record_name: "r".to_owned(),
+        };
+        assert_eq!(dns.expected_method(), VerificationMethod::DnsRecord);
+
+        let cr = AttestationProof::ChallengeResponseVerified {
+            challenge: "c".to_owned(),
+            response_signature: "s".to_owned(),
+        };
+        assert_eq!(cr.expected_method(), VerificationMethod::ChallengeResponse);
+    }
+
+    #[allow(deprecated)]
+    #[test]
+    fn attestation_proof_attestation_class() {
+        let oauth = AttestationProof::OauthVerified {
+            provider: "g".to_owned(),
+            subject_id: "1".to_owned(),
+            verified_at: 0,
+        };
+        assert_eq!(oauth.attestation_class(), AttestationClass::Cryptographic);
+
+        let dns = AttestationProof::DnsRecordVerified {
+            domain: "d".to_owned(),
+            record_name: "r".to_owned(),
+        };
+        assert_eq!(dns.attestation_class(), AttestationClass::Reference);
+    }
+
+    #[allow(deprecated)]
+    #[test]
+    fn attestation_proof_serialization_roundtrip_all_variants() {
+        let proofs = [
+            AttestationProof::OauthVerified {
+                provider: "github.com".to_owned(),
+                subject_id: "12345".to_owned(),
+                verified_at: 1_700_000_000,
+            },
+            AttestationProof::SignedPostVerified {
+                post_url: "https://x.com/alice/123".to_owned(),
+                nonce: "abc123".to_owned(),
+                posted_at: 1_700_000_000,
+            },
+            AttestationProof::DnsRecordVerified {
+                domain: "example.com".to_owned(),
+                record_name: "_scp-verify".to_owned(),
+            },
+            AttestationProof::ChallengeResponseVerified {
+                challenge: "random-challenge".to_owned(),
+                response_signature: "deadbeef".to_owned(),
+            },
+        ];
+
+        for proof in &proofs {
+            // JSON roundtrip
+            let json = serde_json::to_string(proof).unwrap();
+            let deserialized: AttestationProof = serde_json::from_str(&json).unwrap();
+            assert_eq!(proof, &deserialized, "JSON roundtrip failed for {proof:?}");
+
+            // MessagePack roundtrip
+            let bytes = rmp_serde::to_vec_named(proof).unwrap();
+            let deserialized: AttestationProof = rmp_serde::from_slice(&bytes).unwrap();
+            assert_eq!(
+                proof, &deserialized,
+                "MessagePack roundtrip failed for {proof:?}"
+            );
+        }
+    }
+
+    #[allow(deprecated)]
+    #[test]
+    fn attestation_proof_json_has_type_tag() {
+        let proof = AttestationProof::OauthVerified {
+            provider: "github.com".to_owned(),
+            subject_id: "12345".to_owned(),
+            verified_at: 1_700_000_000,
+        };
+        let json = serde_json::to_string(&proof).unwrap();
+        assert!(
+            json.contains("\"type\":\"oauth_verified\""),
+            "expected type tag in JSON: {json}"
+        );
+
+        let proof = AttestationProof::DnsRecordVerified {
+            domain: "example.com".to_owned(),
+            record_name: "_scp-verify".to_owned(),
+        };
+        let json = serde_json::to_string(&proof).unwrap();
+        assert!(
+            json.contains("\"type\":\"dns_record_verified\""),
+            "expected type tag in JSON: {json}"
+        );
+    }
+
+    // -----------------------------------------------------------------------
+    // Proof is opaque string — no proof-method validation
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn validate_structure_does_not_check_proof_content() {
+        // Proof is an opaque string per §3.5.2. validate_structure does not
+        // inspect its content, even if it doesn't match the method.
+        let mut attestation = make_attestation();
+        attestation.evidence.proof = "arbitrary-non-json-string".to_owned();
+        let errors = attestation.validate_structure();
+        assert!(
+            !errors.iter().any(|e| e.contains("proof")),
+            "validate_structure must not inspect proof content: {errors:?}"
+        );
     }
 }

--- a/crates/scp-core/src/identity/private_state_events.rs
+++ b/crates/scp-core/src/identity/private_state_events.rs
@@ -1113,13 +1113,11 @@ mod tests {
                     ),
                     evidence: super::super::attestation::AttestationEvidence {
                         method: super::super::attestation::VerificationMethod::Oauth,
-                        proof: "proof".to_owned(),
+                        proof: r#"{"type":"oauth_verified","provider":"github.com","subject_id":"12345","verified_at":1700000000}"#.to_owned(),
                         verified_at: 1_700_000_000_000,
                         verifier_did: None,
                     },
-                    revocation: super::super::attestation::AttestationRevocation::new(
-                        "/rev".to_owned(),
-                    ),
+                    revocation_status: crate::trust::attestation::RevocationStatus::Active,
                     signature: vec![0; 64],
                 }),
                 timestamp: 19000,

--- a/crates/scp-core/src/trust/attestation.rs
+++ b/crates/scp-core/src/trust/attestation.rs
@@ -24,12 +24,13 @@
 //!
 //! See ADR-017 in `.docs/adrs/phase-4.md`.
 
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
 use std::time::Duration;
 
 use serde::{Deserialize, Serialize};
 
 use crate::crypto::ed25519::verify_ed25519_signature;
+use crate::identity::attestation::AttestationClass;
 use scp_event_log::Ed25519Signature;
 use scp_identity::DID;
 use scp_identity::cache::Clock;
@@ -154,7 +155,7 @@ impl IdentityLinkClaim {
 // RevocationStatus
 // ---------------------------------------------------------------------------
 
-/// Revocation status of an attestation.
+/// Revocation status of an attestation (§7.4.1).
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub enum RevocationStatus {
     /// The attestation is active and not revoked.
@@ -163,9 +164,31 @@ pub enum RevocationStatus {
     Revoked {
         /// Unix timestamp (seconds) when the revocation occurred.
         revoked_at: u64,
-        /// Optional reason for revocation.
-        reason: Option<String>,
+        /// Reason for revocation (empty string if no reason provided).
+        #[serde(default, deserialize_with = "deserialize_string_or_null")]
+        reason: String,
+        /// DID that performed the revocation. Must equal the attestation's
+        /// issuer — only the issuer can revoke their own attestation (§7.4.1).
+        #[serde(default = "default_revoked_by")]
+        revoked_by: DID,
     },
+}
+
+/// Deserializes a `String` field that may be `null` in JSON. Returns the string
+/// value when present, or an empty string for both missing keys and explicit
+/// `null` values. `#[serde(default)]` alone only handles missing keys — an
+/// explicit `"reason": null` would fail deserialization without this.
+fn deserialize_string_or_null<'de, D>(deserializer: D) -> Result<String, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    Option::<String>::deserialize(deserializer).map(Option::unwrap_or_default)
+}
+
+/// Default `revoked_by` DID for pre-migration attestations that were serialized
+/// without the `revoked_by` field.
+fn default_revoked_by() -> DID {
+    DID::from("did:unknown:pre-migration")
 }
 
 // ---------------------------------------------------------------------------
@@ -203,28 +226,90 @@ pub enum FreshnessStatus {
 /// (`total_attestors`) must provide attestations of a given type, and the
 /// minimum independence score required among those attestors.
 ///
+/// All `f64` fields must be finite (not NaN or infinity). Value ranges are
+/// enforced: `independence_threshold` must be in \[0.0, 1.0\], penalty fields
+/// must be non-negative, and `required_count` must be <= `total_attestors`.
+/// Deserialization rejects invalid values via `TryFrom<ThresholdRequirementRaw>`.
+///
+/// Fields are private to prevent bypass of validation. Use [`ThresholdRequirement::new`]
+/// or [`ThresholdRequirement::try_new`] for construction, and accessor methods for reading.
+///
 /// See ADR-017 acceptance criterion 7.
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Serialize)]
+#[serde(into = "ThresholdRequirementRaw")]
 pub struct ThresholdRequirement {
     /// The minimum number of valid attestations required (N).
-    pub required_count: u32,
+    required_count: u32,
     /// The total number of attestors in the set (M).
-    pub total_attestors: u32,
+    total_attestors: u32,
     /// Minimum independence score (0.0 to 1.0). Attestors with shared context
     /// memberships or mutual endorsements have reduced independence.
-    pub independence_threshold: f64,
+    independence_threshold: f64,
     /// Independence penalty per shared context membership between a pair of
     /// attestors. Default: 0.1. Capped at `shared_context_penalty_cap` total.
-    #[serde(default = "default_shared_context_penalty")]
-    pub shared_context_penalty: f64,
+    shared_context_penalty: f64,
     /// Maximum total penalty from shared context memberships for a single
     /// pair. Default: 0.5.
-    #[serde(default = "default_shared_context_penalty_cap")]
-    pub shared_context_penalty_cap: f64,
+    shared_context_penalty_cap: f64,
     /// Independence penalty per mutual endorsement direction (A endorsed B
     /// = one direction, B endorsed A = another). Default: 0.2.
+    mutual_endorsement_penalty: f64,
+}
+
+/// Raw deserialization helper for [`ThresholdRequirement`].
+///
+/// Carries `#[serde(default)]` annotations for backward-compatible
+/// deserialization, then validates f64 fields via `TryFrom`.
+#[derive(Deserialize, Serialize)]
+struct ThresholdRequirementRaw {
+    required_count: u32,
+    total_attestors: u32,
+    independence_threshold: f64,
+    #[serde(default = "default_shared_context_penalty")]
+    shared_context_penalty: f64,
+    #[serde(default = "default_shared_context_penalty_cap")]
+    shared_context_penalty_cap: f64,
     #[serde(default = "default_mutual_endorsement_penalty")]
-    pub mutual_endorsement_penalty: f64,
+    mutual_endorsement_penalty: f64,
+}
+
+impl From<ThresholdRequirement> for ThresholdRequirementRaw {
+    fn from(t: ThresholdRequirement) -> Self {
+        Self {
+            required_count: t.required_count,
+            total_attestors: t.total_attestors,
+            independence_threshold: t.independence_threshold,
+            shared_context_penalty: t.shared_context_penalty,
+            shared_context_penalty_cap: t.shared_context_penalty_cap,
+            mutual_endorsement_penalty: t.mutual_endorsement_penalty,
+        }
+    }
+}
+
+impl TryFrom<ThresholdRequirementRaw> for ThresholdRequirement {
+    type Error = String;
+
+    fn try_from(raw: ThresholdRequirementRaw) -> Result<Self, Self::Error> {
+        let t = Self {
+            required_count: raw.required_count,
+            total_attestors: raw.total_attestors,
+            independence_threshold: raw.independence_threshold,
+            shared_context_penalty: raw.shared_context_penalty,
+            shared_context_penalty_cap: raw.shared_context_penalty_cap,
+            mutual_endorsement_penalty: raw.mutual_endorsement_penalty,
+        };
+        t.validate().map(|()| t)
+    }
+}
+
+impl<'de> Deserialize<'de> for ThresholdRequirement {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let raw = ThresholdRequirementRaw::deserialize(deserializer)?;
+        Self::try_from(raw).map_err(serde::de::Error::custom)
+    }
 }
 
 const fn default_shared_context_penalty() -> f64 {
@@ -241,6 +326,20 @@ const fn default_mutual_endorsement_penalty() -> f64 {
 
 impl ThresholdRequirement {
     /// Creates a new `ThresholdRequirement` with default penalty values.
+    ///
+    /// # Safety (logical)
+    ///
+    /// **This constructor performs NO validation.** It is `const` for use in
+    /// static/const contexts (e.g., compile-time policy definitions). The caller
+    /// MUST ensure:
+    ///
+    /// - `required_count <= total_attestors`
+    /// - `independence_threshold` is in \[0.0, 1.0\] and finite
+    /// - All f64 penalty fields (using defaults here) are finite and non-negative
+    ///
+    /// Violating these invariants will cause incorrect threshold evaluation at
+    /// runtime. For runtime construction with validation, use
+    /// [`ThresholdRequirement::try_new`] instead.
     #[must_use]
     pub const fn new(
         required_count: u32,
@@ -255,6 +354,188 @@ impl ThresholdRequirement {
             shared_context_penalty_cap: default_shared_context_penalty_cap(),
             mutual_endorsement_penalty: default_mutual_endorsement_penalty(),
         }
+    }
+
+    /// Creates a new `ThresholdRequirement` with explicit penalty values.
+    ///
+    /// Like [`ThresholdRequirement::new`], this is `const` and does not
+    /// validate. For runtime construction with validation, use
+    /// [`ThresholdRequirement::try_new_with_penalties`].
+    ///
+    /// Prefer [`ThresholdRequirement::new`] + [`ThresholdRequirement::try_new`]
+    /// when default penalties suffice. This constructor is for advanced use
+    /// cases that need custom penalty tuning.
+    #[must_use]
+    pub const fn new_with_penalties(
+        required_count: u32,
+        total_attestors: u32,
+        independence_threshold: f64,
+        shared_context_penalty: f64,
+        shared_context_penalty_cap: f64,
+        mutual_endorsement_penalty: f64,
+    ) -> Self {
+        Self {
+            required_count,
+            total_attestors,
+            independence_threshold,
+            shared_context_penalty,
+            shared_context_penalty_cap,
+            mutual_endorsement_penalty,
+        }
+    }
+
+    /// Creates a new `ThresholdRequirement` with explicit penalty values and
+    /// validation.
+    ///
+    /// # Errors
+    ///
+    /// Returns a description of the invalid field if validation fails.
+    pub fn try_new_with_penalties(
+        required_count: u32,
+        total_attestors: u32,
+        independence_threshold: f64,
+        shared_context_penalty: f64,
+        shared_context_penalty_cap: f64,
+        mutual_endorsement_penalty: f64,
+    ) -> Result<Self, String> {
+        let t = Self::new_with_penalties(
+            required_count,
+            total_attestors,
+            independence_threshold,
+            shared_context_penalty,
+            shared_context_penalty_cap,
+            mutual_endorsement_penalty,
+        );
+        t.validate().map(|()| t)
+    }
+
+    /// Creates a new `ThresholdRequirement` with validation.
+    ///
+    /// Returns an error if any field violates its constraints: f64 fields must
+    /// be finite, `independence_threshold` must be in \[0.0, 1.0\], penalty
+    /// fields must be non-negative, and `required_count` must be <=
+    /// `total_attestors`.
+    ///
+    /// # Errors
+    ///
+    /// Returns a description of the invalid field if validation fails.
+    pub fn try_new(
+        required_count: u32,
+        total_attestors: u32,
+        independence_threshold: f64,
+    ) -> Result<Self, String> {
+        let t = Self::new(required_count, total_attestors, independence_threshold);
+        t.validate().map(|()| t)
+    }
+
+    /// Validates all field constraints.
+    ///
+    /// - All f64 fields must be finite (not NaN or infinity).
+    /// - `independence_threshold` must be in \[0.0, 1.0\].
+    /// - `shared_context_penalty`, `shared_context_penalty_cap`, and
+    ///   `mutual_endorsement_penalty` must be non-negative.
+    /// - `required_count` must be <= `total_attestors`.
+    ///
+    /// # Errors
+    ///
+    /// Returns a description of the first invalid field found.
+    pub fn validate(&self) -> Result<(), String> {
+        // Check finiteness first (catches NaN and infinity).
+        let fields: &[(&str, f64)] = &[
+            ("independence_threshold", self.independence_threshold),
+            ("shared_context_penalty", self.shared_context_penalty),
+            (
+                "shared_context_penalty_cap",
+                self.shared_context_penalty_cap,
+            ),
+            (
+                "mutual_endorsement_penalty",
+                self.mutual_endorsement_penalty,
+            ),
+        ];
+        for &(name, value) in fields {
+            if !value.is_finite() {
+                return Err(format!(
+                    "ThresholdRequirement::{name} must be finite, got {value}"
+                ));
+            }
+        }
+
+        // independence_threshold must be in [0.0, 1.0].
+        if !(0.0..=1.0).contains(&self.independence_threshold) {
+            return Err(format!(
+                "ThresholdRequirement::independence_threshold must be in [0.0, 1.0], got {}",
+                self.independence_threshold
+            ));
+        }
+
+        // Penalty fields must be non-negative.
+        if self.shared_context_penalty < 0.0 {
+            return Err(format!(
+                "ThresholdRequirement::shared_context_penalty must be non-negative, got {}",
+                self.shared_context_penalty
+            ));
+        }
+        if self.shared_context_penalty_cap < 0.0 {
+            return Err(format!(
+                "ThresholdRequirement::shared_context_penalty_cap must be non-negative, got {}",
+                self.shared_context_penalty_cap
+            ));
+        }
+        if self.mutual_endorsement_penalty < 0.0 {
+            return Err(format!(
+                "ThresholdRequirement::mutual_endorsement_penalty must be non-negative, got {}",
+                self.mutual_endorsement_penalty
+            ));
+        }
+
+        // required_count must be <= total_attestors.
+        if self.required_count > self.total_attestors {
+            return Err(format!(
+                "ThresholdRequirement::required_count ({}) must be <= total_attestors ({})",
+                self.required_count, self.total_attestors
+            ));
+        }
+
+        Ok(())
+    }
+
+    // --- Accessor methods ---
+
+    /// Returns the minimum number of valid attestations required (N).
+    #[must_use]
+    pub const fn required_count(&self) -> u32 {
+        self.required_count
+    }
+
+    /// Returns the total number of attestors in the set (M).
+    #[must_use]
+    pub const fn total_attestors(&self) -> u32 {
+        self.total_attestors
+    }
+
+    /// Returns the minimum independence score (0.0 to 1.0).
+    #[must_use]
+    pub const fn independence_threshold(&self) -> f64 {
+        self.independence_threshold
+    }
+
+    /// Returns the independence penalty per shared context membership.
+    #[must_use]
+    pub const fn shared_context_penalty(&self) -> f64 {
+        self.shared_context_penalty
+    }
+
+    /// Returns the maximum total penalty from shared context memberships.
+    #[must_use]
+    pub const fn shared_context_penalty_cap(&self) -> f64 {
+        self.shared_context_penalty_cap
+    }
+
+    /// Returns the independence penalty per mutual endorsement direction.
+    #[must_use]
+    pub const fn mutual_endorsement_penalty(&self) -> f64 {
+        self.mutual_endorsement_penalty
     }
 }
 
@@ -380,6 +661,185 @@ impl DidPublicKeyResolver for IdentityDidPublicKeyResolver {
 }
 
 // ---------------------------------------------------------------------------
+// AttestationRevocationChecker trait (§7.4.1)
+// ---------------------------------------------------------------------------
+
+/// Trait for checking attestation revocation status.
+///
+/// Implementations may check DID document service endpoints, local revocation
+/// lists, or external revocation services. The trait is object-safe and
+/// designed for injection into [`verify_attestation`].
+///
+/// See spec §7.4.1 (attestation verification).
+pub trait AttestationRevocationChecker {
+    /// Checks if the attestation with the given ID has been revoked by the issuer.
+    ///
+    /// Returns `Some(revoked_at)` with the revocation timestamp (seconds) if the
+    /// attestation has been revoked, or `None` if the attestation is still active.
+    fn check_revocation(&self, attestation_id: &str, issuer: &DID) -> Option<u64>;
+}
+
+/// No-op revocation checker that always returns `None` (not revoked).
+///
+/// Suitable for testing, offline verification, or contexts where external
+/// revocation checking is not available.
+pub struct NoOpRevocationChecker;
+
+impl AttestationRevocationChecker for NoOpRevocationChecker {
+    fn check_revocation(&self, _attestation_id: &str, _issuer: &DID) -> Option<u64> {
+        None
+    }
+}
+
+// ---------------------------------------------------------------------------
+// AttestationVerificationCache (§7.4.1)
+// ---------------------------------------------------------------------------
+
+/// TTL for cached Reference attestation verification results: 1 hour.
+///
+/// Reference attestations (signed post, DNS record) depend on external platform data
+/// that can change or disappear. Shorter TTL ensures freshness.
+pub const REFERENCE_TTL_SECS: u64 = 3600;
+
+/// TTL for cached Cryptographic attestation verification results: 24 hours.
+///
+/// Cryptographic attestations (OAuth, challenge-response) are self-verifiable
+/// and change infrequently. Longer TTL reduces redundant verification.
+pub const CRYPTOGRAPHIC_TTL_SECS: u64 = 86400;
+
+/// A cached attestation verification result.
+struct VerificationCacheEntry {
+    /// When the verification was performed (seconds since epoch).
+    verified_at: u64,
+    /// The class of the attestation, determining the TTL.
+    attestation_class: AttestationClass,
+    /// The cached verification result.
+    result: Result<(), TrustError>,
+}
+
+/// Cache for attestation verification results with class-based TTLs (§7.4.1).
+///
+/// Per-class TTLs: [`REFERENCE_TTL_SECS`] (1 hour) for Reference attestations,
+/// [`CRYPTOGRAPHIC_TTL_SECS`] (24 hours) for Cryptographic attestations.
+///
+/// This is a simple in-memory cache keyed by attestation ID. It does not
+/// persist across process restarts. For persistent caching, use
+/// [`super::aggregate::AttestationCache`] backed by a
+/// [`super::aggregate::TrustProtocolRepository`].
+pub struct AttestationVerificationCache {
+    entries: HashMap<String, VerificationCacheEntry>,
+    /// Maximum number of entries the cache can hold. When full, the oldest
+    /// entry (by `verified_at`) is evicted before inserting a new one.
+    max_capacity: usize,
+}
+
+/// Default maximum capacity for the attestation verification cache.
+const DEFAULT_CACHE_CAPACITY: usize = 10_000;
+
+impl AttestationVerificationCache {
+    /// Creates an empty verification cache with the default capacity (10000).
+    #[must_use]
+    pub fn new() -> Self {
+        Self {
+            entries: HashMap::new(),
+            max_capacity: DEFAULT_CACHE_CAPACITY,
+        }
+    }
+
+    /// Creates an empty verification cache with the specified maximum capacity.
+    #[must_use]
+    pub fn with_capacity(max_capacity: usize) -> Self {
+        Self {
+            entries: HashMap::new(),
+            max_capacity,
+        }
+    }
+
+    /// Returns the TTL in seconds for the given attestation class.
+    #[must_use]
+    const fn ttl_for_class(class: AttestationClass) -> u64 {
+        match class {
+            AttestationClass::Reference => REFERENCE_TTL_SECS,
+            AttestationClass::Cryptographic => CRYPTOGRAPHIC_TTL_SECS,
+        }
+    }
+
+    /// Retrieves a cached verification result if the entry exists and has not
+    /// expired.
+    ///
+    /// Returns `None` if the entry is missing or expired.
+    #[must_use]
+    pub fn get(&self, attestation_id: &str, now: u64) -> Option<&Result<(), TrustError>> {
+        let entry = self.entries.get(attestation_id)?;
+        let ttl = Self::ttl_for_class(entry.attestation_class);
+        if now > entry.verified_at.saturating_add(ttl) {
+            return None;
+        }
+        Some(&entry.result)
+    }
+
+    /// Inserts a verification result into the cache.
+    ///
+    /// Overwrites any existing entry for the same attestation ID. If the
+    /// cache is at capacity and the key is new, evicts the oldest entry
+    /// (by `verified_at` timestamp) before inserting.
+    ///
+    /// # Performance
+    ///
+    /// Eviction scans all entries to find the oldest (`O(n)` where `n` is
+    /// the cache size). This is acceptable for the default capacity (10000)
+    /// and typical usage patterns where eviction is infrequent. For larger
+    /// caches, consider a `BTreeMap<(u64, String), _>` indexed by
+    /// `(verified_at, id)` for `O(log n)` eviction.
+    pub fn insert(
+        &mut self,
+        attestation_id: String,
+        class: AttestationClass,
+        result: Result<(), TrustError>,
+        now: u64,
+    ) {
+        // A cache with max_capacity == 0 is effectively disabled.
+        if self.max_capacity == 0 {
+            return;
+        }
+        // If this key already exists, overwriting won't increase count.
+        if !self.entries.contains_key(&attestation_id) && self.entries.len() >= self.max_capacity {
+            // Evict the oldest entry by verified_at.
+            if let Some(oldest_key) = self
+                .entries
+                .iter()
+                .min_by_key(|(_, v)| v.verified_at)
+                .map(|(k, _)| k.clone())
+            {
+                self.entries.remove(&oldest_key);
+            }
+        }
+        self.entries.insert(
+            attestation_id,
+            VerificationCacheEntry {
+                verified_at: now,
+                attestation_class: class,
+                result,
+            },
+        );
+    }
+
+    /// Removes all expired entries from the cache.
+    pub fn evict_expired(&mut self, now: u64) {
+        self.entries.retain(|_, entry| {
+            let ttl = Self::ttl_for_class(entry.attestation_class);
+            now <= entry.verified_at.saturating_add(ttl)
+        });
+    }
+}
+
+impl Default for AttestationVerificationCache {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+// ---------------------------------------------------------------------------
 // verify_attestation
 // ---------------------------------------------------------------------------
 
@@ -392,14 +852,21 @@ impl DidPublicKeyResolver for IdentityDidPublicKeyResolver {
 /// 2. **Evidence:** Validates that evidence is present when required by the
 ///    attestation type.
 /// 3. **Expiry:** Rejects if `expires_at < now`.
-/// 4. **Revocation:** Rejects if the attestation has been revoked.
+/// 4. **Revocation (field):** Rejects if the attestation's `revocation_status`
+///    field is `Revoked`.
+/// 5. **Revocation (external):** If a [`AttestationRevocationChecker`] is
+///    provided, queries it for external revocation signals. This is belt-and-
+///    suspenders with step 4: the field may be stale while the checker queries
+///    a live revocation service.
 ///
 /// # Errors
 ///
 /// Returns a specific [`TrustError`] variant for each failure mode:
 /// - [`TrustError::AttestationSignatureInvalid`] for signature failures
 /// - [`TrustError::AttestationExpired`] when past expiry
-/// - [`TrustError::AttestationRevoked`] when revoked
+/// - [`TrustError::AttestationRevocationInvalid`] when `revoked_by` does not
+///   match the issuer (§7.4.1)
+/// - [`TrustError::AttestationRevoked`] when revoked by the issuer (field or external)
 /// - [`TrustError::AttestationEvidenceInvalid`] when required evidence is
 ///   missing or invalid
 ///
@@ -408,6 +875,30 @@ pub fn verify_attestation(
     attestation: &Attestation,
     resolver: &impl DidPublicKeyResolver,
     clock: &impl Clock,
+) -> Result<(), TrustError> {
+    verify_attestation_with_revocation(attestation, resolver, clock, None)
+}
+
+/// Verifies an attestation with an optional external revocation checker.
+///
+/// This is the full-featured verification entry point. [`verify_attestation`]
+/// delegates here with `revocation_checker: None` for backward compatibility.
+///
+/// See [`verify_attestation`] for the verification steps and error semantics.
+///
+/// # Errors
+///
+/// Returns a specific [`TrustError`] variant for each failure mode:
+/// - [`TrustError::AttestationSignatureInvalid`] for signature failures
+/// - [`TrustError::AttestationExpired`] when past expiry
+/// - [`TrustError::AttestationRevoked`] when revoked (field or external checker)
+/// - [`TrustError::AttestationEvidenceInvalid`] when required evidence is
+///   missing or invalid
+pub fn verify_attestation_with_revocation(
+    attestation: &Attestation,
+    resolver: &impl DidPublicKeyResolver,
+    clock: &impl Clock,
+    revocation_checker: Option<&dyn AttestationRevocationChecker>,
 ) -> Result<(), TrustError> {
     // 1. Verify Ed25519 signature against issuer's public key.
     let public_key_bytes = resolver.resolve_public_key(&attestation.issuer)?;
@@ -433,11 +924,34 @@ pub fn verify_attestation(
         });
     }
 
-    // 4. Check revocation status.
-    if let RevocationStatus::Revoked { revoked_at, .. } = &attestation.revocation_status {
+    // 4. Check revocation status (field on the attestation itself).
+    if let RevocationStatus::Revoked {
+        revoked_at,
+        revoked_by,
+        ..
+    } = &attestation.revocation_status
+    {
+        // Per §7.4.1, only the issuer can revoke their own attestation.
+        if *revoked_by != attestation.issuer {
+            return Err(TrustError::AttestationRevocationInvalid {
+                attestation_id: attestation.id.clone(),
+                revoked_by: revoked_by.to_string(),
+                issuer: attestation.issuer.to_string(),
+            });
+        }
         return Err(TrustError::AttestationRevoked {
             attestation_id: attestation.id.clone(),
             revoked_at: *revoked_at,
+        });
+    }
+
+    // 5. Check external revocation (belt-and-suspenders with step 4).
+    if let Some(checker) = revocation_checker
+        && let Some(revoked_at) = checker.check_revocation(&attestation.id, &attestation.issuer)
+    {
+        return Err(TrustError::AttestationRevoked {
+            attestation_id: attestation.id.clone(),
+            revoked_at,
         });
     }
 
@@ -515,6 +1029,13 @@ pub fn check_threshold_attestation(
     attestors: &[AttestorInfo],
     requirement: &ThresholdRequirement,
 ) -> ThresholdResult {
+    // Defense-in-depth: validate requirement even though constructors enforce it.
+    debug_assert!(
+        requirement.validate().is_ok(),
+        "ThresholdRequirement invariants violated: {:?}",
+        requirement.validate()
+    );
+
     // Count valid attestations of the required type.
     let valid_attestors: Vec<&AttestorInfo> = attestors
         .iter()
@@ -530,20 +1051,20 @@ pub fn check_threshold_attestation(
     // Compute independence score among valid attestors.
     let independence_score = compute_independence_score(
         &valid_attestors,
-        requirement.shared_context_penalty,
-        requirement.shared_context_penalty_cap,
-        requirement.mutual_endorsement_penalty,
+        requirement.shared_context_penalty(),
+        requirement.shared_context_penalty_cap(),
+        requirement.mutual_endorsement_penalty(),
     );
 
-    let count_met = valid_count >= requirement.required_count;
-    let independence_met = independence_score >= requirement.independence_threshold;
+    let count_met = valid_count >= requirement.required_count();
+    let independence_met = independence_score >= requirement.independence_threshold();
 
     ThresholdResult {
         met: count_met && independence_met,
         valid_count,
-        required_count: requirement.required_count,
+        required_count: requirement.required_count(),
         independence_score,
-        independence_threshold: requirement.independence_threshold,
+        independence_threshold: requirement.independence_threshold(),
     }
 }
 
@@ -556,7 +1077,8 @@ pub fn check_threshold_attestation(
 /// ```text
 /// "SCP-ATTESTATION-V1:" || len(id) || id || attestation_type_tag_BE
 ///     || len(issuer) || issuer || len(subject) || subject
-///     || len(claim_json) || claim_json || issued_at_BE
+///     || len(claim_json) || claim_json || len(evidence_msgpack) || evidence_msgpack
+///     || issued_at_BE || expires_at_BE || len(revocation_status_msgpack) || revocation_status_msgpack
 /// ```
 ///
 /// Variable-length fields are prefixed with their length as a 4-byte
@@ -565,26 +1087,50 @@ pub fn check_threshold_attestation(
 /// numeric tag (u16 big-endian) instead of Debug formatting for
 /// cross-version determinism. `issued_at` uses big-endian encoding,
 /// consistent with all other canonical hash functions.
+///
+/// `revocation_status` is included in the signed scope so that an
+/// intermediary cannot flip Active↔Revoked without invalidating the
+/// signature.
 pub(crate) fn canonical_attestation_bytes(
     attestation: &Attestation,
 ) -> Result<Vec<u8>, TrustError> {
     use crate::crypto::canonical::{CanonicalField, canonical_hash};
 
-    // Serialize evidence as MessagePack bytes if present.
+    // Serialize evidence as MessagePack bytes (named/sorted keys) if present.
     let evidence_bytes = attestation
         .evidence
         .as_ref()
         .map(|e| {
-            rmp_serde::to_vec(e).map_err(|err| TrustError::InvalidEventData {
+            rmp_serde::to_vec_named(e).map_err(|err| TrustError::InvalidEventData {
                 sequence: 0,
                 reason: format!("evidence serialization failed: {err}"),
             })
         })
         .transpose()?;
 
+    // Serialize revocation_status as MessagePack bytes (named/sorted keys).
+    let revocation_bytes =
+        rmp_serde::to_vec_named(&attestation.revocation_status).map_err(|err| {
+            TrustError::InvalidEventData {
+                sequence: 0,
+                reason: format!("revocation_status serialization failed: {err}"),
+            }
+        })?;
+
     // Field order per §9.5.2: id, attestation_type, issuer, subject, claim,
-    // evidence, issued_at, expires_at.
-    let claim_bytes = attestation.claim.to_string();
+    // evidence, issued_at, expires_at, revocation_status.
+    //
+    // Serialize claim as MessagePack (named/sorted keys) for deterministic
+    // ordering. Using `serde_json::Value::to_string()` would produce JSON
+    // with non-deterministic key ordering. This matches
+    // `IdentityLinkAttestation::canonical_signing_bytes` which also uses
+    // `rmp_serde::to_vec_named`.
+    let claim_bytes = rmp_serde::to_vec_named(&attestation.claim).map_err(|err| {
+        TrustError::InvalidEventData {
+            sequence: 0,
+            reason: format!("claim serialization failed: {err}"),
+        }
+    })?;
     Ok(canonical_hash(
         "SCP-ATTESTATION-V1:",
         &[
@@ -592,12 +1138,15 @@ pub(crate) fn canonical_attestation_bytes(
             CanonicalField::U16(super::attestation_type_tag(&attestation.attestation_type)),
             CanonicalField::VarBytes(attestation.issuer.as_bytes()),
             CanonicalField::VarBytes(attestation.subject.as_bytes()),
-            CanonicalField::VarBytes(claim_bytes.as_bytes()),
+            CanonicalField::VarBytes(&claim_bytes),
             evidence_bytes
                 .as_deref()
                 .map_or(CanonicalField::Absent, CanonicalField::VarBytes),
             CanonicalField::U64(attestation.issued_at),
-            CanonicalField::U64(attestation.expires_at.unwrap_or(0)),
+            attestation
+                .expires_at
+                .map_or(CanonicalField::Absent, CanonicalField::U64),
+            CanonicalField::VarBytes(&revocation_bytes),
         ],
     )
     .to_vec())
@@ -771,7 +1320,7 @@ mod tests {
         (signing_key, verifying_key.to_bytes().to_vec())
     }
 
-    /// Creates and signs a test attestation.
+    /// Creates and signs a test attestation with `RevocationStatus::Active`.
     fn make_signed_attestation(
         signing_key: &SigningKey,
         attestation_type: AttestationType,
@@ -781,6 +1330,34 @@ mod tests {
         expires_at: Option<u64>,
         renewal_interval: Option<Duration>,
         evidence: Option<AttestationEvidence>,
+    ) -> Attestation {
+        make_signed_attestation_with_revocation(
+            signing_key,
+            attestation_type,
+            issuer,
+            subject,
+            issued_at,
+            expires_at,
+            renewal_interval,
+            evidence,
+            RevocationStatus::Active,
+        )
+    }
+
+    /// Creates and signs a test attestation with the given `RevocationStatus`.
+    ///
+    /// The signature is computed over the full canonical bytes including
+    /// `revocation_status`, matching the V2 canonical construction.
+    fn make_signed_attestation_with_revocation(
+        signing_key: &SigningKey,
+        attestation_type: AttestationType,
+        issuer: &str,
+        subject: &str,
+        issued_at: u64,
+        expires_at: Option<u64>,
+        renewal_interval: Option<Duration>,
+        evidence: Option<AttestationEvidence>,
+        revocation_status: RevocationStatus,
     ) -> Attestation {
         let mut attestation = Attestation {
             id: format!("att-{issued_at}"),
@@ -793,7 +1370,7 @@ mod tests {
             expires_at,
             renewal_interval,
             renewed_at: None,
-            revocation_status: RevocationStatus::Active,
+            revocation_status,
             signature: vec![],
         };
 
@@ -922,6 +1499,45 @@ mod tests {
         resolver.add_key("did:key:issuer", pubkey_bytes);
         let clock = TestClock::new(1000);
 
+        // Sign the attestation with RevocationStatus::Revoked already set.
+        // This models an issuer who signs the revocation envelope.
+        let attestation = make_signed_attestation_with_revocation(
+            &signing_key,
+            AttestationType::Endorsement,
+            "did:key:issuer",
+            "did:key:subject",
+            900,
+            Some(2000),
+            None,
+            None,
+            RevocationStatus::Revoked {
+                revoked_at: 950,
+                reason: "compromised".to_owned(),
+                revoked_by: "did:key:issuer".into(),
+            },
+        );
+
+        let result = verify_attestation(&attestation, &resolver, &clock);
+        assert!(result.is_err());
+        match result {
+            Err(TrustError::AttestationRevoked {
+                revoked_at: 950, ..
+            }) => {}
+            other => panic!("expected AttestationRevoked, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn verify_attestation_rejects_tampered_revocation_status() {
+        // An attestation signed as Active, then mutated to Revoked by an
+        // intermediary, must fail signature verification (not reach the
+        // revocation check). This proves revocation_status is in the
+        // signed scope.
+        let (signing_key, pubkey_bytes) = test_keypair();
+        let mut resolver = TestResolver::new();
+        resolver.add_key("did:key:issuer", pubkey_bytes);
+        let clock = TestClock::new(1000);
+
         let mut attestation = make_signed_attestation(
             &signing_key,
             AttestationType::Endorsement,
@@ -933,18 +1549,20 @@ mod tests {
             None,
         );
 
+        // Tamper: flip Active -> Revoked without re-signing.
         attestation.revocation_status = RevocationStatus::Revoked {
             revoked_at: 950,
-            reason: Some("compromised".to_owned()),
+            reason: "tampered".to_owned(),
+            revoked_by: "did:key:issuer".into(),
         };
 
         let result = verify_attestation(&attestation, &resolver, &clock);
         assert!(result.is_err());
         match result {
-            Err(TrustError::AttestationRevoked {
-                revoked_at: 950, ..
-            }) => {}
-            other => panic!("expected AttestationRevoked, got {other:?}"),
+            Err(TrustError::AttestationSignatureInvalid { .. }) => {}
+            other => panic!(
+                "expected AttestationSignatureInvalid (tampered revocation_status), got {other:?}"
+            ),
         }
     }
 
@@ -1595,5 +2213,613 @@ mod tests {
         // Valid prefix but garbage z-base-32
         let result = resolver.resolve_public_key("did:dht:z!@#$%^&*");
         assert!(result.is_err());
+    }
+
+    // -----------------------------------------------------------------------
+    // revocation_status in signed scope tests
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn canonical_bytes_differ_for_active_vs_revoked() {
+        let active = Attestation {
+            id: "att-1".to_owned(),
+            attestation_type: AttestationType::Endorsement,
+            issuer: "did:key:issuer".into(),
+            subject: "did:key:subject".into(),
+            claim: serde_json::json!({"test": true}),
+            evidence: None,
+            issued_at: 1000,
+            expires_at: Some(2000),
+            renewal_interval: None,
+            renewed_at: None,
+            revocation_status: RevocationStatus::Active,
+            signature: vec![],
+        };
+
+        let revoked = Attestation {
+            revocation_status: RevocationStatus::Revoked {
+                revoked_at: 1500,
+                reason: "compromised".to_owned(),
+                revoked_by: "did:key:issuer".into(),
+            },
+            ..active.clone()
+        };
+
+        let bytes_active = canonical_attestation_bytes(&active).unwrap();
+        let bytes_revoked = canonical_attestation_bytes(&revoked).unwrap();
+        assert_ne!(
+            bytes_active, bytes_revoked,
+            "revocation_status must be in the signed scope: Active and Revoked \
+             must produce different canonical bytes"
+        );
+    }
+
+    // --- ThresholdRequirement NaN / Infinity guard tests ---
+
+    #[test]
+    fn threshold_requirement_validate_rejects_nan_independence() {
+        let t = ThresholdRequirement::new(2, 3, f64::NAN);
+        let err = t.validate().unwrap_err();
+        assert!(
+            err.contains("independence_threshold"),
+            "error should name the field: {err}"
+        );
+    }
+
+    #[test]
+    fn threshold_requirement_validate_rejects_infinity() {
+        let t = ThresholdRequirement::new_with_penalties(2, 3, 0.5, f64::INFINITY, 0.5, 0.2);
+        let err = t.validate().unwrap_err();
+        assert!(
+            err.contains("shared_context_penalty"),
+            "error should name the field: {err}"
+        );
+    }
+
+    #[test]
+    fn threshold_requirement_validate_rejects_neg_infinity() {
+        let t = ThresholdRequirement::new_with_penalties(2, 3, 0.5, 0.1, 0.5, f64::NEG_INFINITY);
+        let err = t.validate().unwrap_err();
+        assert!(
+            err.contains("mutual_endorsement_penalty"),
+            "error should name the field: {err}"
+        );
+    }
+
+    #[test]
+    fn threshold_requirement_validate_accepts_finite_values() {
+        let t = ThresholdRequirement::new(2, 3, 0.5);
+        assert!(t.validate().is_ok());
+    }
+
+    #[test]
+    fn threshold_requirement_serde_roundtrip_finite() {
+        let t = ThresholdRequirement::new(2, 3, 0.5);
+        let json = serde_json::to_string(&t).unwrap();
+        let back: ThresholdRequirement = serde_json::from_str(&json).unwrap();
+        assert_eq!(back, t);
+    }
+
+    #[test]
+    fn threshold_requirement_serde_backward_compat_defaults() {
+        // Deserialize without optional penalty fields — should use defaults.
+        let json = r#"{"required_count":2,"total_attestors":3,"independence_threshold":0.5}"#;
+        let t: ThresholdRequirement = serde_json::from_str(json).unwrap();
+        assert_eq!(t.required_count(), 2);
+        assert_eq!(t.total_attestors(), 3);
+        assert!((t.independence_threshold() - 0.5).abs() < f64::EPSILON);
+        assert!((t.shared_context_penalty() - 0.1).abs() < f64::EPSILON);
+        assert!((t.shared_context_penalty_cap() - 0.5).abs() < f64::EPSILON);
+        assert!((t.mutual_endorsement_penalty() - 0.2).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn threshold_requirement_serde_accepts_unknown_fields() {
+        // Wire-format types must tolerate unknown fields for forward
+        // compatibility — a newer sender may include fields this version
+        // doesn't know about yet.
+        let json = r#"{"required_count":2,"total_attestors":3,"independence_threshold":0.5,"evil_field":true}"#;
+        let result: Result<ThresholdRequirement, _> = serde_json::from_str(json);
+        assert!(
+            result.is_ok(),
+            "unknown fields must be accepted for forward compatibility: {result:?}"
+        );
+    }
+
+    // --- Value range validation tests ---
+
+    #[test]
+    fn threshold_requirement_rejects_independence_below_zero() {
+        let t = ThresholdRequirement::new(2, 3, -0.1);
+        let err = t.validate().unwrap_err();
+        assert!(
+            err.contains("independence_threshold"),
+            "error should mention independence_threshold: {err}"
+        );
+    }
+
+    #[test]
+    fn threshold_requirement_rejects_independence_above_one() {
+        let t = ThresholdRequirement::new(2, 3, 1.01);
+        let err = t.validate().unwrap_err();
+        assert!(
+            err.contains("independence_threshold"),
+            "error should mention independence_threshold: {err}"
+        );
+    }
+
+    #[test]
+    fn threshold_requirement_accepts_independence_boundary_values() {
+        // 0.0 and 1.0 are both valid boundary values.
+        assert!(ThresholdRequirement::new(2, 3, 0.0).validate().is_ok());
+        assert!(ThresholdRequirement::new(2, 3, 1.0).validate().is_ok());
+    }
+
+    #[test]
+    fn threshold_requirement_rejects_negative_shared_context_penalty() {
+        let t = ThresholdRequirement::new_with_penalties(2, 3, 0.5, -0.01, 0.5, 0.2);
+        let err = t.validate().unwrap_err();
+        assert!(
+            err.contains("shared_context_penalty"),
+            "error should mention shared_context_penalty: {err}"
+        );
+    }
+
+    #[test]
+    fn threshold_requirement_rejects_negative_shared_context_penalty_cap() {
+        let t = ThresholdRequirement::new_with_penalties(2, 3, 0.5, 0.1, -0.01, 0.2);
+        let err = t.validate().unwrap_err();
+        assert!(
+            err.contains("shared_context_penalty_cap"),
+            "error should mention shared_context_penalty_cap: {err}"
+        );
+    }
+
+    #[test]
+    fn threshold_requirement_rejects_negative_mutual_endorsement_penalty() {
+        let t = ThresholdRequirement::new_with_penalties(2, 3, 0.5, 0.1, 0.5, -0.01);
+        let err = t.validate().unwrap_err();
+        assert!(
+            err.contains("mutual_endorsement_penalty"),
+            "error should mention mutual_endorsement_penalty: {err}"
+        );
+    }
+
+    #[test]
+    fn threshold_requirement_rejects_required_count_exceeding_total() {
+        let t = ThresholdRequirement::new(5, 3, 0.5);
+        let err = t.validate().unwrap_err();
+        assert!(
+            err.contains("required_count"),
+            "error should mention required_count: {err}"
+        );
+    }
+
+    #[test]
+    fn threshold_requirement_accepts_required_count_equal_to_total() {
+        let t = ThresholdRequirement::new(3, 3, 0.5);
+        assert!(t.validate().is_ok());
+    }
+
+    #[test]
+    fn threshold_requirement_try_new_enforces_ranges() {
+        assert!(ThresholdRequirement::try_new(5, 3, 0.5).is_err());
+        assert!(ThresholdRequirement::try_new(2, 3, -0.1).is_err());
+        assert!(ThresholdRequirement::try_new(2, 3, 1.5).is_err());
+        assert!(ThresholdRequirement::try_new(2, 3, 0.5).is_ok());
+    }
+
+    #[test]
+    fn threshold_requirement_try_new_with_penalties_enforces_ranges() {
+        // Negative penalty.
+        assert!(ThresholdRequirement::try_new_with_penalties(2, 3, 0.5, -0.1, 0.5, 0.2).is_err());
+        // required_count > total_attestors.
+        assert!(ThresholdRequirement::try_new_with_penalties(5, 3, 0.5, 0.1, 0.5, 0.2).is_err());
+        // Valid.
+        assert!(ThresholdRequirement::try_new_with_penalties(2, 3, 0.5, 0.1, 0.5, 0.2).is_ok());
+    }
+
+    #[test]
+    fn threshold_requirement_serde_rejects_invalid_ranges() {
+        // independence_threshold > 1.0.
+        let json = r#"{"required_count":2,"total_attestors":3,"independence_threshold":1.5}"#;
+        assert!(serde_json::from_str::<ThresholdRequirement>(json).is_err());
+
+        // required_count > total_attestors.
+        let json = r#"{"required_count":5,"total_attestors":3,"independence_threshold":0.5}"#;
+        assert!(serde_json::from_str::<ThresholdRequirement>(json).is_err());
+
+        // Negative penalty.
+        let json = r#"{"required_count":2,"total_attestors":3,"independence_threshold":0.5,"shared_context_penalty":-0.1}"#;
+        assert!(serde_json::from_str::<ThresholdRequirement>(json).is_err());
+    }
+
+    // --- Accessor method tests ---
+
+    #[test]
+    fn threshold_requirement_accessor_methods() {
+        let t = ThresholdRequirement::new_with_penalties(2, 5, 0.7, 0.15, 0.6, 0.25);
+        assert_eq!(t.required_count(), 2);
+        assert_eq!(t.total_attestors(), 5);
+        assert!((t.independence_threshold() - 0.7).abs() < f64::EPSILON);
+        assert!((t.shared_context_penalty() - 0.15).abs() < f64::EPSILON);
+        assert!((t.shared_context_penalty_cap() - 0.6).abs() < f64::EPSILON);
+        assert!((t.mutual_endorsement_penalty() - 0.25).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn verify_attestation_rejects_revoked_by_non_issuer() {
+        let (signing_key, pubkey_bytes) = test_keypair();
+        let mut resolver = TestResolver::new();
+        resolver.add_key("did:key:issuer", pubkey_bytes);
+        let clock = TestClock::new(1000);
+
+        // Sign the attestation with revoked_by pointing to a non-issuer DID.
+        // The issuer signs this envelope (so the signature is valid), but the
+        // revoked_by field doesn't match the issuer -- this must be rejected.
+        let attestation = make_signed_attestation_with_revocation(
+            &signing_key,
+            AttestationType::Endorsement,
+            "did:key:issuer",
+            "did:key:subject",
+            900,
+            Some(2000),
+            None,
+            None,
+            RevocationStatus::Revoked {
+                revoked_at: 950,
+                reason: "unauthorized".to_owned(),
+                revoked_by: "did:key:attacker".into(),
+            },
+        );
+
+        let result = verify_attestation(&attestation, &resolver, &clock);
+        assert!(result.is_err());
+        match result {
+            Err(TrustError::AttestationRevocationInvalid {
+                revoked_by, issuer, ..
+            }) => {
+                assert_eq!(revoked_by, "did:key:attacker");
+                assert_eq!(issuer, "did:key:issuer");
+            }
+            other => panic!("expected AttestationRevocationInvalid, got {other:?}"),
+        }
+    }
+
+    // -----------------------------------------------------------------------
+    // AttestationRevocationChecker tests
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn noop_revocation_checker_returns_none() {
+        let checker = NoOpRevocationChecker;
+        let result = checker.check_revocation("att-1", &DID::from("did:key:issuer"));
+        assert!(result.is_none());
+    }
+
+    /// A test revocation checker that always reports a specific attestation as
+    /// revoked at a given timestamp.
+    struct AlwaysRevokedChecker {
+        revoked_at: u64,
+    }
+
+    impl AttestationRevocationChecker for AlwaysRevokedChecker {
+        fn check_revocation(&self, _attestation_id: &str, _issuer: &DID) -> Option<u64> {
+            Some(self.revoked_at)
+        }
+    }
+
+    /// A test revocation checker that only revokes a specific attestation ID.
+    struct SelectiveRevokedChecker {
+        target_id: String,
+        revoked_at: u64,
+    }
+
+    impl AttestationRevocationChecker for SelectiveRevokedChecker {
+        fn check_revocation(&self, attestation_id: &str, _issuer: &DID) -> Option<u64> {
+            if attestation_id == self.target_id {
+                Some(self.revoked_at)
+            } else {
+                None
+            }
+        }
+    }
+
+    #[test]
+    fn verify_attestation_with_revocation_checker_rejects_revoked() {
+        let (signing_key, pubkey_bytes) = test_keypair();
+        let mut resolver = TestResolver::new();
+        resolver.add_key("did:key:issuer", pubkey_bytes);
+        let clock = TestClock::new(1000);
+
+        let attestation = make_signed_attestation(
+            &signing_key,
+            AttestationType::Endorsement,
+            "did:key:issuer",
+            "did:key:subject",
+            900,
+            Some(2000),
+            None,
+            None,
+        );
+
+        let checker = AlwaysRevokedChecker { revoked_at: 999 };
+        let result =
+            verify_attestation_with_revocation(&attestation, &resolver, &clock, Some(&checker));
+        assert!(result.is_err());
+        match result {
+            Err(TrustError::AttestationRevoked {
+                revoked_at: 999, ..
+            }) => {}
+            other => panic!("expected AttestationRevoked, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn verify_attestation_with_noop_checker_succeeds() {
+        let (signing_key, pubkey_bytes) = test_keypair();
+        let mut resolver = TestResolver::new();
+        resolver.add_key("did:key:issuer", pubkey_bytes);
+        let clock = TestClock::new(1000);
+
+        let attestation = make_signed_attestation(
+            &signing_key,
+            AttestationType::Endorsement,
+            "did:key:issuer",
+            "did:key:subject",
+            900,
+            Some(2000),
+            None,
+            None,
+        );
+
+        let checker = NoOpRevocationChecker;
+        let result =
+            verify_attestation_with_revocation(&attestation, &resolver, &clock, Some(&checker));
+        assert!(result.is_ok(), "expected Ok, got {result:?}");
+    }
+
+    #[test]
+    fn verify_attestation_with_none_checker_succeeds() {
+        let (signing_key, pubkey_bytes) = test_keypair();
+        let mut resolver = TestResolver::new();
+        resolver.add_key("did:key:issuer", pubkey_bytes);
+        let clock = TestClock::new(1000);
+
+        let attestation = make_signed_attestation(
+            &signing_key,
+            AttestationType::Endorsement,
+            "did:key:issuer",
+            "did:key:subject",
+            900,
+            Some(2000),
+            None,
+            None,
+        );
+
+        let result = verify_attestation_with_revocation(&attestation, &resolver, &clock, None);
+        assert!(result.is_ok(), "expected Ok, got {result:?}");
+    }
+
+    #[test]
+    fn verify_attestation_field_revocation_takes_precedence_over_checker() {
+        // Even with a noop checker, a revoked field should fail.
+        // Must use make_signed_attestation_with_revocation so the signature
+        // covers the revocation_status (it's in the signed scope).
+        let (signing_key, pubkey_bytes) = test_keypair();
+        let mut resolver = TestResolver::new();
+        resolver.add_key("did:key:issuer", pubkey_bytes);
+        let clock = TestClock::new(1000);
+
+        let attestation = make_signed_attestation_with_revocation(
+            &signing_key,
+            AttestationType::Endorsement,
+            "did:key:issuer",
+            "did:key:subject",
+            900,
+            Some(2000),
+            None,
+            None,
+            RevocationStatus::Revoked {
+                revoked_at: 950,
+                reason: "compromised".to_owned(),
+                revoked_by: "did:key:issuer".into(),
+            },
+        );
+
+        let checker = NoOpRevocationChecker;
+        let result =
+            verify_attestation_with_revocation(&attestation, &resolver, &clock, Some(&checker));
+        assert!(result.is_err());
+        match result {
+            Err(TrustError::AttestationRevoked {
+                revoked_at: 950, ..
+            }) => {}
+            other => panic!("expected AttestationRevoked at 950, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn selective_revocation_checker_only_revokes_targeted_attestation() {
+        let (signing_key, pubkey_bytes) = test_keypair();
+        let mut resolver = TestResolver::new();
+        resolver.add_key("did:key:issuer", pubkey_bytes);
+        let clock = TestClock::new(1000);
+
+        let attestation = make_signed_attestation(
+            &signing_key,
+            AttestationType::Endorsement,
+            "did:key:issuer",
+            "did:key:subject",
+            900,
+            Some(2000),
+            None,
+            None,
+        );
+
+        // Checker targets a different attestation ID.
+        let checker = SelectiveRevokedChecker {
+            target_id: "some-other-att-id".to_owned(),
+            revoked_at: 999,
+        };
+        let result =
+            verify_attestation_with_revocation(&attestation, &resolver, &clock, Some(&checker));
+        assert!(
+            result.is_ok(),
+            "expected Ok for non-targeted attestation, got {result:?}"
+        );
+    }
+
+    // -----------------------------------------------------------------------
+    // AttestationVerificationCache tests
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn cache_new_is_empty() {
+        let cache = AttestationVerificationCache::new();
+        assert!(cache.get("att-1", 1000).is_none());
+    }
+
+    #[test]
+    fn cache_insert_and_get_success() {
+        let mut cache = AttestationVerificationCache::new();
+        cache.insert(
+            "att-1".to_owned(),
+            AttestationClass::Cryptographic,
+            Ok(()),
+            1000,
+        );
+
+        let result = cache.get("att-1", 1000);
+        assert!(result.is_some());
+        assert!(result.unwrap().is_ok());
+    }
+
+    #[test]
+    fn cache_insert_and_get_error() {
+        let mut cache = AttestationVerificationCache::new();
+        let err = TrustError::AttestationExpired {
+            attestation_id: "att-1".to_owned(),
+            expired_at: 900,
+        };
+        cache.insert(
+            "att-1".to_owned(),
+            AttestationClass::Reference,
+            Err(err),
+            1000,
+        );
+
+        let result = cache.get("att-1", 1000);
+        assert!(result.is_some());
+        assert!(result.unwrap().is_err());
+    }
+
+    #[test]
+    fn cache_reference_ttl_1_hour() {
+        let mut cache = AttestationVerificationCache::new();
+        cache.insert(
+            "att-ref".to_owned(),
+            AttestationClass::Reference,
+            Ok(()),
+            1000,
+        );
+
+        // Just within TTL (1000 + 3600 = 4600)
+        assert!(cache.get("att-ref", 4600).is_some());
+
+        // Past TTL
+        assert!(cache.get("att-ref", 4601).is_none());
+    }
+
+    #[test]
+    fn cache_cryptographic_ttl_24_hours() {
+        let mut cache = AttestationVerificationCache::new();
+        cache.insert(
+            "att-crypto".to_owned(),
+            AttestationClass::Cryptographic,
+            Ok(()),
+            1000,
+        );
+
+        // Just within TTL (1000 + 86400 = 87400)
+        assert!(cache.get("att-crypto", 87400).is_some());
+
+        // Past TTL
+        assert!(cache.get("att-crypto", 87401).is_none());
+    }
+
+    #[test]
+    fn cache_evict_expired_removes_stale_entries() {
+        let mut cache = AttestationVerificationCache::new();
+        cache.insert(
+            "att-ref".to_owned(),
+            AttestationClass::Reference,
+            Ok(()),
+            1000,
+        );
+        cache.insert(
+            "att-crypto".to_owned(),
+            AttestationClass::Cryptographic,
+            Ok(()),
+            1000,
+        );
+
+        // At 4601: Reference (TTL 3600) is expired, Cryptographic (TTL 86400) is not.
+        cache.evict_expired(4601);
+
+        assert!(
+            cache.get("att-ref", 1000).is_none(),
+            "expired reference should be evicted"
+        );
+        assert!(
+            cache.get("att-crypto", 1000).is_some(),
+            "non-expired cryptographic should remain"
+        );
+    }
+
+    #[test]
+    fn cache_overwrite_existing_entry() {
+        let mut cache = AttestationVerificationCache::new();
+        cache.insert(
+            "att-1".to_owned(),
+            AttestationClass::Reference,
+            Ok(()),
+            1000,
+        );
+
+        // Overwrite with an error result and different class.
+        let err = TrustError::AttestationRevoked {
+            attestation_id: "att-1".to_owned(),
+            revoked_at: 1500,
+        };
+        cache.insert(
+            "att-1".to_owned(),
+            AttestationClass::Cryptographic,
+            Err(err),
+            2000,
+        );
+
+        let result = cache.get("att-1", 2000);
+        assert!(result.is_some());
+        assert!(result.unwrap().is_err());
+
+        // New entry uses Cryptographic TTL (24h from 2000 = 88400)
+        assert!(cache.get("att-1", 88400).is_some());
+        assert!(cache.get("att-1", 88401).is_none());
+    }
+
+    #[test]
+    fn cache_default_trait() {
+        let cache = AttestationVerificationCache::default();
+        assert!(cache.get("anything", 0).is_none());
+    }
+
+    #[test]
+    fn cache_ttl_constants_match_spec() {
+        assert_eq!(REFERENCE_TTL_SECS, 3600, "Reference TTL should be 1 hour");
+        assert_eq!(
+            CRYPTOGRAPHIC_TTL_SECS, 86400,
+            "Cryptographic TTL should be 24 hours"
+        );
     }
 }

--- a/crates/scp-core/src/trust/mod.rs
+++ b/crates/scp-core/src/trust/mod.rs
@@ -90,9 +90,11 @@ pub use admission::{
     AdmissionError, CapabilityRequirement, VerificationLevel, check_capability_requirements,
 };
 pub use attestation::{
-    Attestation, AttestationEvidence, AttestorInfo, DidPublicKeyResolver, FreshnessStatus,
-    IdentityDidPublicKeyResolver, RevocationStatus, ThresholdRequirement, ThresholdResult,
-    check_attestation_freshness, check_threshold_attestation, verify_attestation,
+    Attestation, AttestationEvidence, AttestationRevocationChecker, AttestationVerificationCache,
+    AttestorInfo, CRYPTOGRAPHIC_TTL_SECS, DidPublicKeyResolver, FreshnessStatus,
+    IdentityDidPublicKeyResolver, NoOpRevocationChecker, REFERENCE_TTL_SECS, RevocationStatus,
+    ThresholdRequirement, ThresholdResult, check_attestation_freshness,
+    check_threshold_attestation, verify_attestation, verify_attestation_with_revocation,
 };
 pub use capability_registry::{
     CapabilityRegistryError, RegistryEntry, is_known_protocol_capability,
@@ -149,7 +151,7 @@ pub type ToolId = String;
 // ---------------------------------------------------------------------------
 
 /// Errors produced by trust engine operations.
-#[derive(Debug, thiserror::Error)]
+#[derive(Debug, Clone, thiserror::Error)]
 pub enum TrustError {
     /// No events found for the specified subject DID in the event log.
     #[error("no events found for subject DID: {did}")]
@@ -196,6 +198,21 @@ pub enum TrustError {
         attestation_id: String,
         /// Unix timestamp (seconds) when the attestation was revoked.
         revoked_at: u64,
+    },
+
+    /// The attestation's `revoked_by` DID does not match the issuer.
+    ///
+    /// Per §7.4.1, only the issuer can revoke their own attestation.
+    #[error(
+        "attestation {attestation_id}: revoked_by '{revoked_by}' does not match issuer '{issuer}'"
+    )]
+    AttestationRevocationInvalid {
+        /// The attestation ID.
+        attestation_id: String,
+        /// The DID that claims to have revoked the attestation.
+        revoked_by: String,
+        /// The attestation's issuer DID.
+        issuer: String,
     },
 
     /// The attestation evidence is missing or invalid.

--- a/crates/scp-core/src/trust/renewal.rs
+++ b/crates/scp-core/src/trust/renewal.rs
@@ -445,24 +445,47 @@ mod tests {
         let mut resolver = TestResolver::new();
         resolver.add_key("did:key:issuer", pubkey_bytes);
         let clock = TestClock::new(2000);
-        let mut attestation = make_signed_renewable_attestation(
-            &signing_key,
-            1000,
-            Some(5000),
-            Duration::from_secs(600),
-            None,
-        );
-        attestation.revocation_status = RevocationStatus::Revoked {
-            revoked_at: 1500,
-            reason: Some("revoked for test".to_owned()),
+        // Build an attestation that is signed WITH Revoked status so the
+        // signature is valid, and verify_attestation reaches the revocation
+        // check (not just the signature check).
+        let mut attestation = Attestation {
+            id: "att-renewable".to_owned(),
+            attestation_type: AttestationType::IdentityLink,
+            issuer: "did:key:issuer".into(),
+            subject: "did:key:subject".into(),
+            claim: serde_json::json!({"platform": "github"}),
+            evidence: None,
+            issued_at: 1000,
+            expires_at: Some(5000),
+            renewal_interval: Some(Duration::from_secs(600)),
+            renewed_at: None,
+            revocation_status: RevocationStatus::Revoked {
+                revoked_at: 1500,
+                reason: "revoked for test".to_owned(),
+                revoked_by: "did:key:issuer".into(),
+            },
+            signature: vec![],
         };
+        let canonical = canonical_attestation_bytes(&attestation).unwrap();
+        let sig = signing_key.sign(&canonical);
+        attestation.signature = sig.to_bytes().to_vec();
 
         let result = renew_attestation(&attestation, &resolver, &clock);
 
         assert!(result.is_err());
         match result {
-            Err(RenewalError::VerificationFailed { attestation_id, .. }) => {
+            Err(RenewalError::VerificationFailed {
+                attestation_id,
+                source,
+            }) => {
                 assert_eq!(attestation_id, "att-renewable");
+                // Verify the underlying error is specifically AttestationRevoked,
+                // not AttestationSignatureInvalid — proving we're testing the
+                // revocation rejection path, not the signature path.
+                assert!(
+                    matches!(source, TrustError::AttestationRevoked { .. }),
+                    "expected AttestationRevoked, got {source:?}",
+                );
             }
             other => panic!("expected VerificationFailed, got {other:?}"),
         }

--- a/crates/scp-core/src/trust/sybil.rs
+++ b/crates/scp-core/src/trust/sybil.rs
@@ -49,6 +49,9 @@ use serde::{Deserialize, Serialize};
 
 use scp_identity::DID;
 
+use super::AttestationType;
+use super::attestation::{AttestorInfo, ThresholdRequirement, check_threshold_attestation};
+
 // ---------------------------------------------------------------------------
 // TrustSignalCategory — the 6 composable signal types from §9.3
 // ---------------------------------------------------------------------------
@@ -544,7 +547,12 @@ pub struct ContextSybilPolicy {
 }
 
 /// A required trust signal for context admission.
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+///
+/// When `threshold_requirement` is `Some` and `category` is `Endorsement`,
+/// the admission evaluator invokes [`check_threshold_attestation`] with the
+/// provided [`ThresholdRequirement`] to enforce endorsement independence
+/// (§22.13.3). This prevents Sybil rings of mutually-endorsing identities.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct RequiredSignal {
     /// Which signal category is required.
     pub category: TrustSignalCategory,
@@ -556,6 +564,16 @@ pub struct RequiredSignal {
     /// This is the binary cutoff — signals older than this are rejected
     /// regardless of freshness weight.
     pub max_age_secs: u64,
+
+    /// Optional threshold requirement for endorsement independence (§22.13.3).
+    ///
+    /// When present and `category == TrustSignalCategory::Endorsement`, the
+    /// evaluator calls `check_threshold_attestation` with attestor information
+    /// to verify that endorsers are independently trustworthy (not colluding).
+    /// `ThresholdRequirement` contains `f64` fields so `RequiredSignal` cannot
+    /// derive `Eq`.
+    #[serde(default)]
+    pub threshold_requirement: Option<ThresholdRequirement>,
 }
 
 impl ContextSybilPolicy {
@@ -588,7 +606,8 @@ impl ContextSybilPolicy {
     }
 
     /// High-trust policy suitable for sensitive contexts.
-    /// Requires multiple signal categories and significant depth.
+    /// Requires multiple signal categories and significant depth, including
+    /// independent endorsements (§22.13.3).
     #[must_use]
     pub fn high_trust() -> Self {
         Self {
@@ -599,11 +618,19 @@ impl ContextSybilPolicy {
                     category: TrustSignalCategory::ParticipationHistory,
                     min_strength: 30 * 24 * 3600, // 30 days
                     max_age_secs: 90 * 24 * 3600, // 90 days
+                    threshold_requirement: None,
                 },
                 RequiredSignal {
                     category: TrustSignalCategory::ParticipationRecord,
                     min_strength: 2, // clean records in 2+ contexts
                     max_age_secs: 90 * 24 * 3600,
+                    threshold_requirement: None,
+                },
+                RequiredSignal {
+                    category: TrustSignalCategory::Endorsement,
+                    min_strength: 2,               // at least 2 endorsements
+                    max_age_secs: 180 * 24 * 3600, // 180 days
+                    threshold_requirement: Some(ThresholdRequirement::new(2, 3, 0.5)),
                 },
             ],
             freshness_config: FreshnessWeight::default_config(),
@@ -673,6 +700,31 @@ pub enum SybilResistanceError {
     /// Device attestation is required but not present.
     #[error("device attestation required but not present")]
     DeviceAttestationRequired,
+
+    /// Endorsement independence check failed (§22.13.3).
+    ///
+    /// The endorsing attestors do not meet the independence threshold required
+    /// by `ThresholdRequirement`. This typically means the endorsers share too
+    /// many context memberships or mutual endorsements, suggesting collusion
+    /// or a Sybil ring.
+    ///
+    /// The `Display` impl deliberately omits exact scores and thresholds to
+    /// avoid leaking policy internals. Structured fields are available for
+    /// internal logging via `Debug`.
+    #[error("endorsement independence insufficient: {reason}")]
+    EndorsementIndependenceInsufficient {
+        /// High-level reason without exact numbers (e.g. "insufficient
+        /// independent attestors" or "independence score too low").
+        reason: String,
+        /// Computed independence score (for debug/logging only).
+        independence_score: f64,
+        /// Required independence threshold (for debug/logging only).
+        threshold: f64,
+        /// Number of valid attestations found (for debug/logging only).
+        valid_count: u32,
+        /// Required attestation count (for debug/logging only).
+        required_count: u32,
+    },
 }
 
 // ---------------------------------------------------------------------------
@@ -689,24 +741,33 @@ pub enum SybilResistanceError {
 /// 2. Signal breadth (number of distinct categories).
 /// 3. Total freshness-weighted strength.
 /// 4. Per-category signal requirements (strength and age).
+/// 5. Endorsement independence (§22.13.3) when a `RequiredSignal` for
+///    `Endorsement` has `threshold_requirement` set and `attestors` are
+///    provided.
 ///
 /// # Arguments
 ///
 /// * `assessment` — The DID's aggregated trust signals.
 /// * `policy` — The context's Sybil resistance policy.
 /// * `current_time` — Unix timestamp (seconds) for freshness evaluation.
+/// * `attestors` — Optional slice of attestor information for endorsement
+///   independence evaluation. Required when the policy includes an endorsement
+///   `RequiredSignal` with `threshold_requirement`. Pass `None` when
+///   endorsement independence checking is not needed (existing callers).
 ///
 /// # Errors
 ///
 /// Returns [`SybilResistanceError`] if the assessment does not meet the
 /// policy requirements (missing attestation, insufficient breadth/strength,
-/// or missing/stale per-category signals).
+/// missing/stale per-category signals, or failed endorsement independence).
 ///
-/// See spec §9.3 (context-level thresholds).
+/// See spec §9.3 (context-level thresholds), §22.13.3 (endorsement
+/// independence).
 pub fn evaluate_sybil_resistance(
     assessment: &IdentityDepthAssessment,
     policy: &ContextSybilPolicy,
     current_time: u64,
+    attestors: Option<&[AttestorInfo]>,
 ) -> Result<(), SybilResistanceError> {
     // 1. Check device attestation requirement.
     if policy.require_device_attestation
@@ -778,6 +839,81 @@ pub fn evaluate_sybil_resistance(
         }
     }
 
+    // 5. Endorsement independence check (§22.13.3).
+    check_endorsement_independence(assessment, policy, attestors)?;
+
+    Ok(())
+}
+
+/// Checks endorsement independence requirements (§22.13.3).
+///
+/// For each required signal with category Endorsement and a
+/// `threshold_requirement`, invokes [`check_threshold_attestation`] to verify
+/// that endorsers are independently trustworthy — not a Sybil ring.
+fn check_endorsement_independence(
+    assessment: &IdentityDepthAssessment,
+    policy: &ContextSybilPolicy,
+    attestors: Option<&[AttestorInfo]>,
+) -> Result<(), SybilResistanceError> {
+    for req in &policy.required_signals {
+        let (TrustSignalCategory::Endorsement, Some(threshold)) =
+            (&req.category, &req.threshold_requirement)
+        else {
+            continue;
+        };
+        let att =
+            attestors.ok_or_else(
+                || SybilResistanceError::EndorsementIndependenceInsufficient {
+                    reason: "attestors required for endorsement independence \
+                         check but not provided"
+                        .into(),
+                    independence_score: 0.0,
+                    threshold: threshold.independence_threshold(),
+                    valid_count: 0,
+                    required_count: threshold.required_count(),
+                },
+            )?;
+        // Filter attestors to only those whose attestation subject matches the
+        // DID being evaluated AND whose attestation issuer matches their own
+        // DID. Without the subject check, an attacker could submit endorsement
+        // attestations for a different DID. Without the issuer check, an
+        // attacker could claim attestations issued by someone else.
+        //
+        // Deduplicate by DID to prevent the same attestor from being counted
+        // multiple times (e.g., submitting the same endorsement 5 times should
+        // not satisfy a 3-of-5 threshold).
+        let mut seen_dids = std::collections::HashSet::new();
+        let subject_attestors: Vec<AttestorInfo> = att
+            .iter()
+            .filter(|a| {
+                a.attestation
+                    .as_ref()
+                    .is_some_and(|att| att.subject == assessment.subject_did && att.issuer == a.did)
+            })
+            .filter(|a| seen_dids.insert(a.did.clone()))
+            .cloned()
+            .collect();
+        let result = check_threshold_attestation(
+            &AttestationType::Endorsement,
+            &subject_attestors,
+            threshold,
+        );
+        if !result.met {
+            let count_ok = result.valid_count >= result.required_count;
+            let reason = if count_ok {
+                "independence score too low".to_owned()
+            } else {
+                "insufficient independent attestors".to_owned()
+            };
+            return Err(SybilResistanceError::EndorsementIndependenceInsufficient {
+                reason,
+                independence_score: result.independence_score,
+                threshold: result.independence_threshold,
+                valid_count: result.valid_count,
+                required_count: result.required_count,
+            });
+        }
+    }
     Ok(())
 }
 
@@ -838,7 +974,10 @@ pub fn evaluate_earned_capacity(
     clippy::cast_precision_loss
 )]
 mod tests {
+    use std::collections::HashSet;
+
     use super::*;
+    use crate::trust::{Attestation, AttestationType, RevocationStatus};
 
     fn did(s: &str) -> DID {
         DID::from(s)
@@ -847,6 +986,116 @@ mod tests {
     fn now() -> u64 {
         // Stable test time: 2026-01-15 00:00:00 UTC
         1_768_435_200
+    }
+
+    /// Creates an `Attestation` of type `Endorsement` for testing.
+    fn make_endorsement_attestation(issuer: &str, subject: &str, issued_at: u64) -> Attestation {
+        Attestation {
+            id: format!("endorse-{issuer}-{subject}"),
+            attestation_type: AttestationType::Endorsement,
+            issuer: did(issuer),
+            subject: did(subject),
+            claim: serde_json::json!({"endorsement": true}),
+            evidence: None,
+            issued_at,
+            expires_at: None,
+            renewal_interval: None,
+            renewed_at: None,
+            revocation_status: RevocationStatus::Active,
+            signature: vec![0u8; 64], // dummy signature for tests
+        }
+    }
+
+    /// Creates a set of 3 independent attestors with no shared contexts
+    /// or mutual endorsements — passes endorsement independence checks.
+    fn make_independent_attestors(current_time: u64) -> Vec<AttestorInfo> {
+        let subject = "did:dht:z6MkDeepIdentity";
+        vec![
+            AttestorInfo {
+                did: did("did:dht:z6MkEndorserA"),
+                context_memberships: HashSet::from(["ctx-alpha".into()]),
+                endorsements: HashSet::new(),
+                attestation: Some(make_endorsement_attestation(
+                    "did:dht:z6MkEndorserA",
+                    subject,
+                    current_time - 3600,
+                )),
+            },
+            AttestorInfo {
+                did: did("did:dht:z6MkEndorserB"),
+                context_memberships: HashSet::from(["ctx-beta".into()]),
+                endorsements: HashSet::new(),
+                attestation: Some(make_endorsement_attestation(
+                    "did:dht:z6MkEndorserB",
+                    subject,
+                    current_time - 7200,
+                )),
+            },
+            AttestorInfo {
+                did: did("did:dht:z6MkEndorserC"),
+                context_memberships: HashSet::from(["ctx-gamma".into()]),
+                endorsements: HashSet::new(),
+                attestation: Some(make_endorsement_attestation(
+                    "did:dht:z6MkEndorserC",
+                    subject,
+                    current_time - 10800,
+                )),
+            },
+        ]
+    }
+
+    /// Creates a set of 3 colluding attestors — all share the same contexts
+    /// and mutually endorse each other, failing independence checks.
+    fn make_colluding_attestors(current_time: u64) -> Vec<AttestorInfo> {
+        let subject = "did:dht:z6MkDeepIdentity";
+        let shared = HashSet::from([
+            "ctx-shared-1".to_string(),
+            "ctx-shared-2".to_string(),
+            "ctx-shared-3".to_string(),
+            "ctx-shared-4".to_string(),
+            "ctx-shared-5".to_string(),
+        ]);
+        vec![
+            AttestorInfo {
+                did: did("did:dht:z6MkColluderA"),
+                context_memberships: shared.clone(),
+                endorsements: HashSet::from([
+                    did("did:dht:z6MkColluderB"),
+                    did("did:dht:z6MkColluderC"),
+                ]),
+                attestation: Some(make_endorsement_attestation(
+                    "did:dht:z6MkColluderA",
+                    subject,
+                    current_time - 3600,
+                )),
+            },
+            AttestorInfo {
+                did: did("did:dht:z6MkColluderB"),
+                context_memberships: shared.clone(),
+                endorsements: HashSet::from([
+                    did("did:dht:z6MkColluderA"),
+                    did("did:dht:z6MkColluderC"),
+                ]),
+                attestation: Some(make_endorsement_attestation(
+                    "did:dht:z6MkColluderB",
+                    subject,
+                    current_time - 3600,
+                )),
+            },
+            AttestorInfo {
+                did: did("did:dht:z6MkColluderC"),
+                context_memberships: shared,
+                endorsements: HashSet::from([
+                    did("did:dht:z6MkColluderA"),
+                    did("did:dht:z6MkColluderB"),
+                ]),
+                attestation: Some(make_endorsement_attestation(
+                    "did:dht:z6MkColluderC",
+                    subject,
+                    current_time - 3600,
+                )),
+            },
+        ]
     }
 
     fn make_signal(category: TrustSignalCategory, strength: u64, verified_at: u64) -> TrustSignal {
@@ -1147,7 +1396,7 @@ mod tests {
         let assessment =
             IdentityDepthAssessment::new(did("did:dht:z6MkNew"), HashMap::new(), now());
         let policy = ContextSybilPolicy::casual();
-        assert!(evaluate_sybil_resistance(&assessment, &policy, now()).is_ok());
+        assert!(evaluate_sybil_resistance(&assessment, &policy, now(), None).is_ok());
     }
 
     #[test]
@@ -1155,7 +1404,7 @@ mod tests {
         let assessment =
             IdentityDepthAssessment::new(did("did:dht:z6MkNew"), HashMap::new(), now());
         let policy = ContextSybilPolicy::standard();
-        let result = evaluate_sybil_resistance(&assessment, &policy, now());
+        let result = evaluate_sybil_resistance(&assessment, &policy, now(), None);
         assert!(matches!(
             result,
             Err(SybilResistanceError::InsufficientSignalBreadth {
@@ -1179,14 +1428,14 @@ mod tests {
 
         let assessment = IdentityDepthAssessment::new(did("did:dht:z6MkModerate"), signals, now());
         let policy = ContextSybilPolicy::standard();
-        assert!(evaluate_sybil_resistance(&assessment, &policy, now()).is_ok());
+        assert!(evaluate_sybil_resistance(&assessment, &policy, now(), None).is_ok());
     }
 
     #[test]
     fn high_trust_policy_rejects_shallow_identity() {
         let assessment = make_shallow_assessment(now());
         let policy = ContextSybilPolicy::high_trust();
-        let result = evaluate_sybil_resistance(&assessment, &policy, now());
+        let result = evaluate_sybil_resistance(&assessment, &policy, now(), None);
         assert!(matches!(
             result,
             Err(SybilResistanceError::InsufficientSignalBreadth { .. })
@@ -1197,7 +1446,8 @@ mod tests {
     fn high_trust_policy_accepts_deep_identity() {
         let assessment = make_deep_assessment(now());
         let policy = ContextSybilPolicy::high_trust();
-        assert!(evaluate_sybil_resistance(&assessment, &policy, now()).is_ok());
+        let attestors = make_independent_attestors(now());
+        assert!(evaluate_sybil_resistance(&assessment, &policy, now(), Some(&attestors)).is_ok());
     }
 
     #[test]
@@ -1205,7 +1455,7 @@ mod tests {
         let assessment = make_deep_assessment(now());
         let mut policy = ContextSybilPolicy::casual();
         policy.require_device_attestation = true;
-        let result = evaluate_sybil_resistance(&assessment, &policy, now());
+        let result = evaluate_sybil_resistance(&assessment, &policy, now(), None);
         assert!(matches!(
             result,
             Err(SybilResistanceError::DeviceAttestationRequired)
@@ -1225,7 +1475,7 @@ mod tests {
 
         let mut policy = ContextSybilPolicy::casual();
         policy.require_device_attestation = true;
-        assert!(evaluate_sybil_resistance(&assessment, &policy, t).is_ok());
+        assert!(evaluate_sybil_resistance(&assessment, &policy, t, None).is_ok());
     }
 
     #[test]
@@ -1252,7 +1502,7 @@ mod tests {
         let assessment = IdentityDepthAssessment::new(did("did:dht:z6MkStale"), signals, t);
 
         let policy = ContextSybilPolicy::high_trust();
-        let result = evaluate_sybil_resistance(&assessment, &policy, t);
+        let result = evaluate_sybil_resistance(&assessment, &policy, t, None);
         // ParticipationHistory has max_age_secs of 90 days, signal is 200 days old
         assert!(matches!(
             result,
@@ -1331,7 +1581,7 @@ mod tests {
             let assessment =
                 IdentityDepthAssessment::new(did(&format!("did:dht:z6MkSybil{i}")), signals, now());
 
-            let result = evaluate_sybil_resistance(&assessment, &policy, now());
+            let result = evaluate_sybil_resistance(&assessment, &policy, now(), None);
             // Strength 60 < required 10.0? No, 60 > 10. But breadth is 1 >= 1.
             // Actually this passes standard (1 category, 60 strength).
             // Standard is intentionally low-bar — just needs any signal.
@@ -1350,7 +1600,7 @@ mod tests {
             let assessment =
                 IdentityDepthAssessment::new(did(&format!("did:dht:z6MkSybil{i}")), signals, now());
 
-            let result = evaluate_sybil_resistance(&assessment, &high_trust, now());
+            let result = evaluate_sybil_resistance(&assessment, &high_trust, now(), None);
             assert!(result.is_err());
         }
     }
@@ -1498,5 +1748,467 @@ mod tests {
             let back: EarnedCapacityLevel = serde_json::from_str(&json).unwrap();
             assert_eq!(&back, level);
         }
+    }
+
+    // --- Endorsement independence tests (§22.13.3) ---
+
+    #[test]
+    fn endorsement_independence_passes_with_independent_attestors() {
+        let assessment = make_deep_assessment(now());
+        let policy = ContextSybilPolicy::high_trust();
+        let attestors = make_independent_attestors(now());
+        let result = evaluate_sybil_resistance(&assessment, &policy, now(), Some(&attestors));
+        assert!(
+            result.is_ok(),
+            "independent attestors should pass: {result:?}"
+        );
+    }
+
+    #[test]
+    fn endorsement_independence_fails_with_colluding_attestors() {
+        let assessment = make_deep_assessment(now());
+        let policy = ContextSybilPolicy::high_trust();
+        let attestors = make_colluding_attestors(now());
+        let result = evaluate_sybil_resistance(&assessment, &policy, now(), Some(&attestors));
+        assert!(
+            matches!(
+                result,
+                Err(SybilResistanceError::EndorsementIndependenceInsufficient { .. })
+            ),
+            "colluding attestors should fail independence check: {result:?}"
+        );
+    }
+
+    #[test]
+    fn endorsement_independence_fails_when_attestors_not_provided() {
+        let assessment = make_deep_assessment(now());
+        let policy = ContextSybilPolicy::high_trust();
+        let result = evaluate_sybil_resistance(&assessment, &policy, now(), None);
+        assert!(
+            matches!(
+                result,
+                Err(SybilResistanceError::EndorsementIndependenceInsufficient { .. })
+            ),
+            "missing attestors should fail: {result:?}"
+        );
+    }
+
+    #[test]
+    fn high_trust_preset_includes_endorsement_requirement() {
+        let policy = ContextSybilPolicy::high_trust();
+        let endorsement_req = policy
+            .required_signals
+            .iter()
+            .find(|r| r.category == TrustSignalCategory::Endorsement);
+        assert!(
+            endorsement_req.is_some(),
+            "high_trust() must include an Endorsement RequiredSignal"
+        );
+        let req = endorsement_req.unwrap();
+        assert_eq!(req.min_strength, 2);
+        assert_eq!(req.max_age_secs, 180 * 24 * 3600);
+        assert!(
+            req.threshold_requirement.is_some(),
+            "Endorsement signal must have threshold_requirement"
+        );
+        let threshold = req.threshold_requirement.as_ref().unwrap();
+        assert_eq!(threshold.required_count(), 2);
+        assert_eq!(threshold.total_attestors(), 3);
+        assert!((threshold.independence_threshold() - 0.5).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn serde_roundtrip_required_signal_with_threshold() {
+        // Verify that RequiredSignal with threshold_requirement roundtrips
+        // through JSON, including the #[serde(default)] for backward compat.
+        let req = RequiredSignal {
+            category: TrustSignalCategory::Endorsement,
+            min_strength: 2,
+            max_age_secs: 180 * 24 * 3600,
+            threshold_requirement: Some(ThresholdRequirement::new(2, 3, 0.5)),
+        };
+        let json = serde_json::to_string(&req).unwrap();
+        let back: RequiredSignal = serde_json::from_str(&json).unwrap();
+        assert_eq!(back, req);
+    }
+
+    #[test]
+    fn serde_backward_compat_required_signal_without_threshold() {
+        // Old serialized RequiredSignal without threshold_requirement field
+        // should deserialize with threshold_requirement = None.
+        let json = r#"{"category":"Endorsement","min_strength":2,"max_age_secs":15552000}"#;
+        let req: RequiredSignal = serde_json::from_str(json).unwrap();
+        assert_eq!(req.category, TrustSignalCategory::Endorsement);
+        assert_eq!(req.min_strength, 2);
+        assert!(
+            req.threshold_requirement.is_none(),
+            "missing field should default to None"
+        );
+    }
+
+    #[test]
+    fn serde_required_signal_accepts_unknown_fields() {
+        // Wire-format types must tolerate unknown fields for forward
+        // compatibility — a newer sender may include fields this version
+        // doesn't know about yet.
+        let json = r#"{"category":"Endorsement","min_strength":2,"max_age_secs":15552000,"evil_field":true}"#;
+        let result: Result<RequiredSignal, _> = serde_json::from_str(json);
+        assert!(
+            result.is_ok(),
+            "unknown fields must be accepted for forward compatibility: {result:?}"
+        );
+    }
+
+    #[test]
+    fn policy_without_endorsement_requirement_ignores_attestors() {
+        // Standard policy has no endorsement requirement, so passing None
+        // for attestors should work fine.
+        let mut signals = HashMap::new();
+        signals.insert(
+            TrustSignalCategory::ParticipationHistory,
+            make_signal(
+                TrustSignalCategory::ParticipationHistory,
+                30 * 24 * 3600,
+                now() - 3600,
+            ),
+        );
+        let assessment = IdentityDepthAssessment::new(did("did:dht:z6MkStandard"), signals, now());
+        let policy = ContextSybilPolicy::standard();
+        assert!(evaluate_sybil_resistance(&assessment, &policy, now(), None).is_ok());
+    }
+
+    // --- Subject binding tests (endorsement attestation subject must match) ---
+
+    #[test]
+    fn endorsement_attestations_for_different_subject_are_ignored() {
+        // Attestors provide endorsements for a DIFFERENT DID than the subject
+        // being evaluated. These must be filtered out, causing the independence
+        // check to fail (zero valid attestations for the actual subject).
+        let assessment = make_deep_assessment(now());
+        let wrong_subject = "did:dht:z6MkWrongSubject";
+
+        let attestors = vec![
+            AttestorInfo {
+                did: did("did:dht:z6MkEndorserA"),
+                context_memberships: HashSet::from(["ctx-alpha".into()]),
+                endorsements: HashSet::new(),
+                attestation: Some(make_endorsement_attestation(
+                    "did:dht:z6MkEndorserA",
+                    wrong_subject,
+                    now() - 3600,
+                )),
+            },
+            AttestorInfo {
+                did: did("did:dht:z6MkEndorserB"),
+                context_memberships: HashSet::from(["ctx-beta".into()]),
+                endorsements: HashSet::new(),
+                attestation: Some(make_endorsement_attestation(
+                    "did:dht:z6MkEndorserB",
+                    wrong_subject,
+                    now() - 7200,
+                )),
+            },
+            AttestorInfo {
+                did: did("did:dht:z6MkEndorserC"),
+                context_memberships: HashSet::from(["ctx-gamma".into()]),
+                endorsements: HashSet::new(),
+                attestation: Some(make_endorsement_attestation(
+                    "did:dht:z6MkEndorserC",
+                    wrong_subject,
+                    now() - 10800,
+                )),
+            },
+        ];
+
+        let policy = ContextSybilPolicy::high_trust();
+        let result = evaluate_sybil_resistance(&assessment, &policy, now(), Some(&attestors));
+        assert!(
+            matches!(
+                result,
+                Err(SybilResistanceError::EndorsementIndependenceInsufficient { .. })
+            ),
+            "attestations for a different subject must be filtered out: {result:?}"
+        );
+    }
+
+    #[test]
+    fn mixed_subject_attestations_only_count_correct_subject() {
+        // Mix of attestations: some for the correct subject, some for a
+        // different one. Only those for the correct subject should count.
+        // With threshold requiring 2 of 3, having only 1 valid should fail.
+        let assessment = make_deep_assessment(now());
+        let correct_subject = "did:dht:z6MkDeepIdentity";
+        let wrong_subject = "did:dht:z6MkWrongSubject";
+
+        let attestors = vec![
+            AttestorInfo {
+                did: did("did:dht:z6MkEndorserA"),
+                context_memberships: HashSet::from(["ctx-alpha".into()]),
+                endorsements: HashSet::new(),
+                attestation: Some(make_endorsement_attestation(
+                    "did:dht:z6MkEndorserA",
+                    correct_subject,
+                    now() - 3600,
+                )),
+            },
+            AttestorInfo {
+                did: did("did:dht:z6MkEndorserB"),
+                context_memberships: HashSet::from(["ctx-beta".into()]),
+                endorsements: HashSet::new(),
+                attestation: Some(make_endorsement_attestation(
+                    "did:dht:z6MkEndorserB",
+                    wrong_subject,
+                    now() - 7200,
+                )),
+            },
+            AttestorInfo {
+                did: did("did:dht:z6MkEndorserC"),
+                context_memberships: HashSet::from(["ctx-gamma".into()]),
+                endorsements: HashSet::new(),
+                attestation: Some(make_endorsement_attestation(
+                    "did:dht:z6MkEndorserC",
+                    wrong_subject,
+                    now() - 10800,
+                )),
+            },
+        ];
+
+        let policy = ContextSybilPolicy::high_trust();
+        let result = evaluate_sybil_resistance(&assessment, &policy, now(), Some(&attestors));
+        // high_trust requires 2 of 3, but only 1 attestation is for the correct subject
+        assert!(
+            matches!(
+                result,
+                Err(SybilResistanceError::EndorsementIndependenceInsufficient { .. })
+            ),
+            "only 1 of 3 attestations is for the correct subject, should fail: {result:?}"
+        );
+    }
+
+    // --- Issuer-DID consistency tests ---
+
+    #[test]
+    fn attestor_with_mismatched_issuer_did_is_filtered_out() {
+        // An attestor with did "alice" provides an attestation issued by "bob".
+        // This must be filtered out — the attestor can only claim attestations
+        // they themselves issued.
+        let assessment = make_deep_assessment(now());
+        let correct_subject = "did:dht:z6MkDeepIdentity";
+
+        let attestors = vec![
+            AttestorInfo {
+                did: did("did:dht:z6MkAlice"),
+                context_memberships: HashSet::from(["ctx-alpha".into()]),
+                endorsements: HashSet::new(),
+                // Attestation issued by Bob, not Alice — should be filtered out.
+                attestation: Some(make_endorsement_attestation(
+                    "did:dht:z6MkBob",
+                    correct_subject,
+                    now() - 3600,
+                )),
+            },
+            AttestorInfo {
+                did: did("did:dht:z6MkEndorserB"),
+                context_memberships: HashSet::from(["ctx-beta".into()]),
+                endorsements: HashSet::new(),
+                attestation: Some(make_endorsement_attestation(
+                    "did:dht:z6MkEndorserB",
+                    correct_subject,
+                    now() - 7200,
+                )),
+            },
+            AttestorInfo {
+                did: did("did:dht:z6MkEndorserC"),
+                context_memberships: HashSet::from(["ctx-gamma".into()]),
+                endorsements: HashSet::new(),
+                attestation: Some(make_endorsement_attestation(
+                    "did:dht:z6MkEndorserC",
+                    correct_subject,
+                    now() - 10800,
+                )),
+            },
+        ];
+
+        let policy = ContextSybilPolicy::high_trust();
+        let result = evaluate_sybil_resistance(&assessment, &policy, now(), Some(&attestors));
+        // high_trust requires 2 of 3, but Alice's attestation (issued by Bob) is
+        // filtered out, leaving only 2 valid attestors which should pass.
+        assert!(
+            result.is_ok(),
+            "2 valid attestors (Alice filtered) should still meet 2-of-3 threshold: {result:?}"
+        );
+    }
+
+    #[test]
+    fn all_attestors_with_mismatched_issuer_fails_independence() {
+        // All attestors provide attestations issued by someone else.
+        // All should be filtered out, causing the independence check to fail.
+        let assessment = make_deep_assessment(now());
+        let correct_subject = "did:dht:z6MkDeepIdentity";
+
+        let attestors = vec![
+            AttestorInfo {
+                did: did("did:dht:z6MkAlice"),
+                context_memberships: HashSet::from(["ctx-alpha".into()]),
+                endorsements: HashSet::new(),
+                attestation: Some(make_endorsement_attestation(
+                    "did:dht:z6MkBob",
+                    correct_subject,
+                    now() - 3600,
+                )),
+            },
+            AttestorInfo {
+                did: did("did:dht:z6MkCarol"),
+                context_memberships: HashSet::from(["ctx-beta".into()]),
+                endorsements: HashSet::new(),
+                attestation: Some(make_endorsement_attestation(
+                    "did:dht:z6MkDave",
+                    correct_subject,
+                    now() - 7200,
+                )),
+            },
+            AttestorInfo {
+                did: did("did:dht:z6MkEve"),
+                context_memberships: HashSet::from(["ctx-gamma".into()]),
+                endorsements: HashSet::new(),
+                attestation: Some(make_endorsement_attestation(
+                    "did:dht:z6MkFrank",
+                    correct_subject,
+                    now() - 10800,
+                )),
+            },
+        ];
+
+        let policy = ContextSybilPolicy::high_trust();
+        let result = evaluate_sybil_resistance(&assessment, &policy, now(), Some(&attestors));
+        assert!(
+            matches!(
+                result,
+                Err(SybilResistanceError::EndorsementIndependenceInsufficient { .. })
+            ),
+            "all attestors with mismatched issuer must fail: {result:?}"
+        );
+    }
+
+    // --- ThresholdRequirement NaN guard tests ---
+
+    #[test]
+    fn threshold_requirement_rejects_nan_on_validation() {
+        // serde_json doesn't support NaN literals, so we test via validate().
+        let t = ThresholdRequirement::new(2, 3, f64::NAN);
+        assert!(
+            t.validate().is_err(),
+            "NaN independence_threshold must fail validation"
+        );
+    }
+
+    #[test]
+    fn threshold_requirement_rejects_infinity_on_validation() {
+        let t = ThresholdRequirement::new(2, 3, f64::INFINITY);
+        assert!(
+            t.validate().is_err(),
+            "infinite independence_threshold must fail validation"
+        );
+    }
+
+    #[test]
+    fn threshold_requirement_try_new_rejects_nan() {
+        let result = ThresholdRequirement::try_new(2, 3, f64::NAN);
+        assert!(result.is_err(), "try_new with NaN must return Err");
+    }
+
+    #[test]
+    fn threshold_requirement_try_new_accepts_finite() {
+        let result = ThresholdRequirement::try_new(2, 3, 0.5);
+        assert!(result.is_ok(), "try_new with finite value must succeed");
+    }
+
+    // --- Edge case: min_strength 0 with threshold_requirement ---
+
+    #[test]
+    fn zero_min_strength_still_runs_independence_check() {
+        // Even when min_strength is 0 (trivially met), the endorsement
+        // independence check must still run when threshold_requirement is set.
+        let assessment = make_deep_assessment(now());
+        let colluding_attestors = make_colluding_attestors(now());
+
+        let mut policy = ContextSybilPolicy::casual();
+        policy.required_signals = vec![RequiredSignal {
+            category: TrustSignalCategory::Endorsement,
+            min_strength: 0, // trivially met
+            max_age_secs: 365 * 24 * 3600,
+            threshold_requirement: Some(ThresholdRequirement::new(2, 3, 0.5)),
+        }];
+
+        let result =
+            evaluate_sybil_resistance(&assessment, &policy, now(), Some(&colluding_attestors));
+        assert!(
+            matches!(
+                result,
+                Err(SybilResistanceError::EndorsementIndependenceInsufficient { .. })
+            ),
+            "min_strength=0 must not bypass independence check: {result:?}"
+        );
+    }
+
+    #[test]
+    fn duplicate_attestor_dids_not_counted_multiple_times() {
+        // Submit the same DID 5 times — should NOT meet a 3-of-5 threshold
+        // because deduplication collapses them to 1 unique attestor.
+        let assessment = make_deep_assessment(now());
+        let subject = "did:dht:z6MkDeepIdentity";
+        let same_did = "did:dht:z6MkEndorserDuplicate";
+
+        let attestors: Vec<AttestorInfo> = (0u64..5)
+            .map(|i| AttestorInfo {
+                did: did(same_did),
+                context_memberships: HashSet::from([format!("ctx-{i}")]),
+                endorsements: HashSet::new(),
+                attestation: Some(make_endorsement_attestation(
+                    same_did,
+                    subject,
+                    now() - 3600 * (i + 1),
+                )),
+            })
+            .collect();
+
+        let mut policy = ContextSybilPolicy::casual();
+        policy.required_signals = vec![RequiredSignal {
+            category: TrustSignalCategory::Endorsement,
+            min_strength: 1,
+            max_age_secs: 365 * 24 * 3600,
+            threshold_requirement: Some(ThresholdRequirement::new(3, 5, 0.3)),
+        }];
+
+        let result = evaluate_sybil_resistance(&assessment, &policy, now(), Some(&attestors));
+        assert!(
+            matches!(
+                result,
+                Err(SybilResistanceError::EndorsementIndependenceInsufficient { .. })
+            ),
+            "5 copies of the same DID must not satisfy a 3-of-5 threshold: {result:?}"
+        );
+    }
+
+    #[test]
+    fn zero_min_strength_passes_with_independent_attestors() {
+        // Confirm that min_strength=0 with independent attestors passes.
+        let assessment = make_deep_assessment(now());
+        let independent_attestors = make_independent_attestors(now());
+
+        let mut policy = ContextSybilPolicy::casual();
+        policy.required_signals = vec![RequiredSignal {
+            category: TrustSignalCategory::Endorsement,
+            min_strength: 0, // trivially met
+            max_age_secs: 365 * 24 * 3600,
+            threshold_requirement: Some(ThresholdRequirement::new(2, 3, 0.5)),
+        }];
+
+        let result =
+            evaluate_sybil_resistance(&assessment, &policy, now(), Some(&independent_attestors));
+        assert!(
+            result.is_ok(),
+            "min_strength=0 with independent attestors should pass: {result:?}"
+        );
     }
 }

--- a/crates/scp-core/tests/forward_compatibility_conformance.rs
+++ b/crates/scp-core/tests/forward_compatibility_conformance.rs
@@ -768,8 +768,7 @@ mod sender_key_types {
 mod attestation_types {
     use super::*;
     use scp_core::identity::attestation::{
-        AttestationClaim, AttestationEvidence, AttestationRevocation, IdentityLinkAttestation,
-        VerificationMethod,
+        AttestationClaim, AttestationEvidence, IdentityLinkAttestation, VerificationMethod,
     };
 
     /// §13.9 item 3: `AttestationClaim` MUST ignore unknown fields (JSON).
@@ -820,7 +819,7 @@ mod attestation_types {
     fn evidence_ignores_unknown_fields_json() {
         let evidence = AttestationEvidence {
             method: VerificationMethod::Oauth,
-            proof: "token123".to_string(),
+            proof: r#"{"type":"oauth_verified","provider":"github.com","subject_id":"token123","verified_at":1700000000}"#.to_string(),
             verified_at: 1_700_000_000,
             verifier_did: None,
         };
@@ -834,7 +833,7 @@ mod attestation_types {
             result.unwrap_err()
         );
         let decoded = result.unwrap();
-        assert_eq!(decoded.proof, "token123");
+        assert_eq!(decoded.method, VerificationMethod::Oauth);
     }
 
     /// §13.9 item 3: `AttestationEvidence` MUST ignore unknown fields (msgpack).
@@ -842,7 +841,7 @@ mod attestation_types {
     fn evidence_ignores_unknown_fields_msgpack() {
         let evidence = AttestationEvidence {
             method: VerificationMethod::Oauth,
-            proof: "token123".to_string(),
+            proof: r#"{"type":"oauth_verified","provider":"github.com","subject_id":"token123","verified_at":1700000000}"#.to_string(),
             verified_at: 1_700_000_000,
             verifier_did: None,
         };
@@ -856,41 +855,7 @@ mod attestation_types {
             result.unwrap_err()
         );
         let decoded = result.unwrap();
-        assert_eq!(decoded.proof, "token123");
-    }
-
-    /// §13.9 item 3: `AttestationRevocation` MUST ignore unknown fields (JSON).
-    #[test]
-    fn revocation_ignores_unknown_fields_json() {
-        let rev = AttestationRevocation::new("#scp-revocations".to_string());
-        let json = serde_json::to_string(&rev).unwrap();
-        let with_extras = inject_unknown_json_fields(&json, &future_json_fields());
-
-        let result: Result<AttestationRevocation, _> = serde_json::from_str(&with_extras);
-        assert!(
-            result.is_ok(),
-            "AttestationRevocation must ignore unknown JSON fields, got: {:?}",
-            result.unwrap_err()
-        );
-        let decoded = result.unwrap();
-        assert_eq!(&*decoded.method, "did_document");
-    }
-
-    /// §13.9 item 3: `AttestationRevocation` MUST ignore unknown fields (msgpack).
-    #[test]
-    fn revocation_ignores_unknown_fields_msgpack() {
-        let rev = AttestationRevocation::new("#scp-revocations".to_string());
-        let bytes = rmp_serde::to_vec_named(&rev).unwrap();
-        let with_extras = inject_unknown_msgpack_fields(&bytes, &future_msgpack_fields());
-
-        let result: Result<AttestationRevocation, _> = rmp_serde::from_slice(&with_extras);
-        assert!(
-            result.is_ok(),
-            "AttestationRevocation must ignore unknown msgpack fields, got: {:?}",
-            result.unwrap_err()
-        );
-        let decoded = result.unwrap();
-        assert_eq!(&*decoded.method, "did_document");
+        assert_eq!(decoded.method, VerificationMethod::Oauth);
     }
 
     /// §13.9 item 3: `IdentityLinkAttestation` MUST ignore unknown fields (JSON).
@@ -906,11 +871,11 @@ mod attestation_types {
             claim: AttestationClaim::new("github.com".to_string(), "alice".to_string(), None),
             evidence: AttestationEvidence {
                 method: VerificationMethod::Oauth,
-                proof: "token".to_string(),
+                proof: r#"{"type":"oauth_verified","provider":"github.com","subject_id":"token","verified_at":1700000000}"#.to_string(),
                 verified_at: 1_700_000_000,
                 verifier_did: None,
             },
-            revocation: AttestationRevocation::new("#scp-revocations".to_string()),
+            revocation_status: scp_core::trust::attestation::RevocationStatus::Active,
             signature: vec![0xAA; 64],
         };
         let json = serde_json::to_string(&attestation).unwrap();
@@ -940,11 +905,11 @@ mod attestation_types {
             claim: AttestationClaim::new("github.com".to_string(), "alice".to_string(), None),
             evidence: AttestationEvidence {
                 method: VerificationMethod::Oauth,
-                proof: "token".to_string(),
+                proof: r#"{"type":"oauth_verified","provider":"github.com","subject_id":"token","verified_at":1700000000}"#.to_string(),
                 verified_at: 1_700_000_000,
                 verifier_did: None,
             },
-            revocation: AttestationRevocation::new("#scp-revocations".to_string()),
+            revocation_status: scp_core::trust::attestation::RevocationStatus::Active,
             signature: vec![0xAA; 64],
         };
         let bytes = rmp_serde::to_vec_named(&attestation).unwrap();

--- a/crates/scp-core/tests/phase5_integration.rs
+++ b/crates/scp-core/tests/phase5_integration.rs
@@ -209,11 +209,13 @@ fn compute_claim_hash(request: &ClaimRequest) -> Vec<u8> {
 fn compute_attestation_canonical_bytes(attestation: &Attestation) -> Vec<u8> {
     use scp_core::crypto::canonical::{CanonicalField, canonical_hash};
 
-    let evidence_bytes = attestation
-        .evidence
-        .as_ref()
-        .map(|e| rmp_serde::to_vec(e).expect("AttestationEvidence serialization is infallible"));
-    let claim_bytes = attestation.claim.to_string();
+    let evidence_bytes = attestation.evidence.as_ref().map(|e| {
+        rmp_serde::to_vec_named(e).expect("AttestationEvidence serialization is infallible")
+    });
+    let claim_bytes =
+        rmp_serde::to_vec_named(&attestation.claim).expect("claim serialization is infallible");
+    let revocation_bytes = rmp_serde::to_vec_named(&attestation.revocation_status)
+        .expect("RevocationStatus serialization is infallible");
 
     canonical_hash(
         "SCP-ATTESTATION-V1:",
@@ -224,12 +226,15 @@ fn compute_attestation_canonical_bytes(attestation: &Attestation) -> Vec<u8> {
             )),
             CanonicalField::VarBytes(attestation.issuer.as_bytes()),
             CanonicalField::VarBytes(attestation.subject.as_bytes()),
-            CanonicalField::VarBytes(claim_bytes.as_bytes()),
+            CanonicalField::VarBytes(&claim_bytes),
             evidence_bytes
                 .as_deref()
                 .map_or(CanonicalField::Absent, CanonicalField::VarBytes),
             CanonicalField::U64(attestation.issued_at),
-            CanonicalField::U64(attestation.expires_at.unwrap_or(0)),
+            attestation
+                .expires_at
+                .map_or(CanonicalField::Absent, CanonicalField::U64),
+            CanonicalField::VarBytes(&revocation_bytes),
         ],
     )
     .to_vec()

--- a/crates/scp-core/tests/test_vectors.rs
+++ b/crates/scp-core/tests/test_vectors.rs
@@ -936,47 +936,75 @@ fn vector_24_25_sender_and_access_info_differ() {
 
 #[test]
 fn vector_26_identity_link_attestation() {
-    println!("=== Vector 26: Identity Link Attestation ===");
+    use scp_core::identity::attestation::{
+        ATTESTATION_TYPE_IDENTITY_LINK, AttestationClaim, AttestationEvidence,
+        IdentityLinkAttestation, VerificationMethod,
+    };
+    use scp_core::trust::attestation::RevocationStatus;
+    use std::borrow::Cow;
 
-    let id = b"att-001";
-    let attestation_type: u16 = 0x0001; // IdentityLink
-    let issuer = b"did:dht:z6MkIssuer";
-    let subject = b"did:dht:z6MkSubject";
-    let claim = br#"{"handle":"@alice","platform":"x"}"#;
-    let issued_at: u64 = 1_700_000_000;
-    let expires_at: u64 = 0; // no expiry
+    println!("=== Vector 26: Identity Link Attestation Signature (V1) ===");
 
-    let bytes = canonical_hash_bytes(
-        b"SCP-ATTESTATION-V1:",
+    // Construct the attestation per §25.13 spec inputs.
+    let issuer: DID = "did:dht:z6MkIssuer".into();
+    let attestation = IdentityLinkAttestation {
+        id: "att-001".to_owned(),
+        attestation_type: Cow::Borrowed(ATTESTATION_TYPE_IDENTITY_LINK),
+        issuer: issuer.clone(),
+        subject: issuer,
+        issued_at: 1_700_000_000,
+        expires_at: None,
+        claim: AttestationClaim::new("google.com".to_owned(), "alice@gmail.com".to_owned(), None),
+        evidence: AttestationEvidence {
+            method: VerificationMethod::Oauth,
+            proof: r#"{"type":"oauth_verified","provider":"google.com","subject_id":"12345","verified_at":1700000000}"#.to_owned(),
+            verified_at: 1_700_000_000,
+            verifier_did: None,
+        },
+        revocation_status: RevocationStatus::Active,
+        signature: Vec::new(),
+    };
+
+    // Sign with reference key and verify round-trip.
+    let signing_key = ed25519_dalek::SigningKey::from_bytes(&REF_SEED);
+    let pubkey_bytes = signing_key.verifying_key().to_bytes();
+
+    // Sign by computing canonical bytes, signing, and embedding.
+    let mut signed = attestation;
+    // Use the verify_signature path to confirm construction.
+    // First, manually build canonical bytes via the same construction the
+    // struct uses internally, sign them, and embed the signature.
+    let claim_bytes = rmp_serde::to_vec_named(&signed.claim).unwrap();
+    let evidence_bytes = rmp_serde::to_vec_named(&signed.evidence).unwrap();
+    let revocation_status_bytes = rmp_serde::to_vec_named(&signed.revocation_status).unwrap();
+
+    let canonical = canonical_hash_bytes(
+        b"SCP-IDENTITY-LINK-ATTESTATION-V1:",
         &[
-            CanonicalField::VarBytes(id),
-            CanonicalField::U16(attestation_type),
-            CanonicalField::VarBytes(issuer),
-            CanonicalField::VarBytes(subject),
-            CanonicalField::VarBytes(claim),
-            CanonicalField::Absent, // evidence absent
-            CanonicalField::U64(issued_at),
-            CanonicalField::U64(expires_at),
+            CanonicalField::VarBytes(signed.id.as_bytes()),
+            CanonicalField::VarBytes(signed.attestation_type.as_bytes()),
+            CanonicalField::VarBytes((*signed.issuer).as_bytes()),
+            CanonicalField::VarBytes((*signed.subject).as_bytes()),
+            CanonicalField::U64(signed.issued_at),
+            CanonicalField::Absent, // expires_at is None
+            CanonicalField::VarBytes(&claim_bytes),
+            CanonicalField::VarBytes(&evidence_bytes),
+            CanonicalField::VarBytes(&revocation_status_bytes),
         ],
     );
 
-    println!("  Canonical hash input length: {} bytes", bytes.len());
-    // 19 (domain) + (4+7) + 2 + (4+18) + (4+19) + (4+34) + 32 (Absent) + 8 + 8
-    // = 19 + 11 + 2 + 22 + 23 + 38 + 32 + 8 + 8 = 163
-    assert_eq!(bytes.len(), 163);
+    let hash: [u8; 32] = Sha256::digest(&canonical).into();
+    print_vec("Identity link attestation canonical hash (V1)", &hash);
 
-    let hash: [u8; 32] = Sha256::digest(&bytes).into();
-    print_vec("Attestation canonical hash", &hash);
-
-    // Sign with reference key
-    let signing_key = ed25519_dalek::SigningKey::from_bytes(&REF_SEED);
     let signature = signing_key.sign(&hash);
-    print_vec("Attestation signature", signature.to_bytes().as_slice());
+    signed.signature = signature.to_bytes().to_vec();
+    print_vec("Identity link attestation signature", &signed.signature);
 
-    signing_key
-        .verifying_key()
-        .verify(&hash, &signature)
-        .expect("attestation signature must verify");
+    // Verify using the struct's verify_signature method — this confirms
+    // the internal canonical_signing_bytes matches our manual construction.
+    signed
+        .verify_signature(&pubkey_bytes)
+        .expect("identity link attestation V1 signature must verify");
 }
 
 // ---------------------------------------------------------------------------
@@ -1096,8 +1124,8 @@ fn vector_29_attestation_id() {
     println!("=== Vector 29: Attestation ID ===");
 
     let issuer: DID = "did:dht:z6MkIssuer".into();
-    let platform = "x";
-    let platform_handle = "@alice";
+    let platform = "google.com";
+    let platform_handle = "alice@gmail.com";
     let issued_at: u64 = 1_700_000_000;
 
     // Use the actual IdentityLinkAttestation::compute_id implementation.
@@ -1108,7 +1136,7 @@ fn vector_29_attestation_id() {
     // §25.16 Vector 29: assert exact spec hex value.
     assert_eq!(
         attestation_id,
-        "3b7567f7331372b900e4cf9f764708cebf88df9173cb626e2984fb31ee1bcf4c"
+        "97eedd3adfbd0dc8ee901c9f2baf57c151ddf81e3cf49e7ae3b559f4cd2176e0"
     );
 
     // Also verify via manual construction to confirm the implementation matches.
@@ -1125,8 +1153,8 @@ fn vector_29_attestation_id() {
 
     assert_eq!(
         buf.len(),
-        67,
-        "attestation ID input must be 67 bytes per §25.16"
+        85,
+        "attestation ID input must be 85 bytes per §25.16"
     );
 
     let manual_hash: [u8; 32] = Sha256::digest(&buf).into();

--- a/crates/scp-core/tests/wasm_conformance.rs
+++ b/crates/scp-core/tests/wasm_conformance.rs
@@ -6685,3 +6685,292 @@ fn provenance_hash_chain_depth_u8_vs_u32() {
         );
     }
 }
+
+// ---------------------------------------------------------------------------
+// Identity link attestation canonical bytes conformance
+// ---------------------------------------------------------------------------
+
+/// Mirror structs matching the WASM bridge's `canonical_attestation` module.
+/// These reproduce the WASM's field declaration order exactly.
+mod wasm_mirror_attestation {
+    use serde::{Deserialize, Serialize};
+
+    #[derive(Serialize, Deserialize)]
+    pub struct Claim {
+        pub platform: String,
+        pub platform_handle: String,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        pub platform_id: Option<String>,
+        pub link_type: String,
+    }
+
+    #[derive(Serialize, Deserialize)]
+    pub struct Evidence {
+        pub method: String,
+        pub proof: String,
+        pub verified_at: u64,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        pub verifier_did: Option<String>,
+    }
+
+    #[derive(Serialize, Deserialize)]
+    pub enum RevocationStatus {
+        Active,
+        Revoked {
+            revoked_at: u64,
+            reason: String,
+            #[serde(default = "default_revoked_by")]
+            revoked_by: String,
+        },
+    }
+
+    fn default_revoked_by() -> String {
+        "did:unknown:pre-migration".to_owned()
+    }
+}
+
+/// Verifies that scp-core's `IdentityLinkAttestation::canonical_signing_bytes`
+/// produces the same output as the WASM mirror construction.
+///
+/// This is the critical cross-implementation conformance test: if the WASM
+/// bridge and scp-core ever diverge in their canonical byte computation,
+/// attestation signatures created by one will fail verification in the other.
+#[test]
+fn wasm_attestation_canonical_bytes_match_core() {
+    use scp_core::crypto::canonical::{CanonicalField, canonical_hash};
+    use scp_core::identity::attestation::{
+        AttestationClaim, AttestationEvidence, IdentityLinkAttestation, VerificationMethod,
+    };
+    use scp_core::trust::attestation::RevocationStatus;
+
+    let issuer = "did:dht:z6MkTestAlice".to_string();
+    let issued_at = 1_700_000_000u64;
+    let proof_str = r#"{"type":"oauth_verified","provider":"github.com","subject_id":"12345","verified_at":1700000000}"#.to_string();
+
+    // Build a core IdentityLinkAttestation.
+    let core_attestation = IdentityLinkAttestation {
+        id: "deadbeef".to_string(),
+        attestation_type: "identity_link".into(),
+        issuer: issuer.clone().into(),
+        subject: issuer.clone().into(),
+        issued_at,
+        expires_at: None,
+        claim: AttestationClaim::new("github.com".to_string(), "alice".to_string(), None),
+        evidence: AttestationEvidence {
+            method: VerificationMethod::Oauth,
+            proof: proof_str.clone(),
+            verified_at: issued_at,
+            verifier_did: None,
+        },
+        revocation_status: RevocationStatus::Active,
+        signature: vec![0u8; 64],
+    };
+
+    let core_bytes = core_attestation
+        .canonical_signing_bytes()
+        .expect("core canonical bytes");
+
+    // Reproduce the WASM mirror construction.
+    let absent_sentinel: [u8; 32] = {
+        let mut h = Sha256::new();
+        h.update([0x00]);
+        h.finalize().into()
+    };
+
+    let wasm_claim = wasm_mirror_attestation::Claim {
+        platform: "github.com".to_string(),
+        platform_handle: "alice".to_string(),
+        platform_id: None,
+        link_type: "self_attestation".to_string(),
+    };
+    let wasm_evidence = wasm_mirror_attestation::Evidence {
+        method: "oauth".to_string(),
+        proof: proof_str,
+        verified_at: issued_at,
+        verifier_did: None,
+    };
+    let wasm_revocation = wasm_mirror_attestation::RevocationStatus::Active;
+
+    let claim_msgpack = rmp_serde::to_vec_named(&wasm_claim).expect("claim msgpack");
+    let evidence_msgpack = rmp_serde::to_vec_named(&wasm_evidence).expect("evidence msgpack");
+    let revocation_msgpack = rmp_serde::to_vec_named(&wasm_revocation).expect("revocation msgpack");
+
+    // WASM construction: SHA-256 with domain separator + fields
+    let mut h = Sha256::new();
+    h.update(b"SCP-IDENTITY-LINK-ATTESTATION-V1:");
+    for field in &[
+        b"deadbeef".to_vec(),
+        b"identity_link".to_vec(),
+        issuer.as_bytes().to_vec(),
+        issuer.as_bytes().to_vec(),
+    ] {
+        h.update(u32::try_from(field.len()).unwrap().to_be_bytes());
+        h.update(field);
+    }
+    h.update(issued_at.to_be_bytes());
+    // expires_at = None → absent sentinel
+    h.update(absent_sentinel);
+    for field in &[
+        claim_msgpack.clone(),
+        evidence_msgpack.clone(),
+        revocation_msgpack.clone(),
+    ] {
+        h.update(u32::try_from(field.len()).unwrap().to_be_bytes());
+        h.update(field);
+    }
+    let wasm_bytes: Vec<u8> = h.finalize().to_vec();
+
+    assert_eq!(
+        core_bytes,
+        wasm_bytes,
+        "scp-core canonical bytes must match WASM mirror construction.\n\
+         Core: {}\nWASM: {}",
+        hex::encode(&core_bytes),
+        hex::encode(&wasm_bytes),
+    );
+
+    // Also verify the scp-core canonical_hash function produces the same result.
+    let hash_fn_bytes = canonical_hash(
+        "SCP-IDENTITY-LINK-ATTESTATION-V1:",
+        &[
+            CanonicalField::VarBytes(b"deadbeef"),
+            CanonicalField::VarBytes(b"identity_link"),
+            CanonicalField::VarBytes(issuer.as_bytes()),
+            CanonicalField::VarBytes(issuer.as_bytes()),
+            CanonicalField::U64(issued_at),
+            CanonicalField::Absent,
+            CanonicalField::VarBytes(&claim_msgpack),
+            CanonicalField::VarBytes(&evidence_msgpack),
+            CanonicalField::VarBytes(&revocation_msgpack),
+        ],
+    );
+    assert_eq!(
+        core_bytes,
+        hash_fn_bytes.to_vec(),
+        "canonical_hash utility must match IdentityLinkAttestation::canonical_signing_bytes"
+    );
+}
+
+/// Helper: build core + WASM mirror attestations for a given proof variant and
+/// assert their canonical bytes match.
+#[allow(clippy::too_many_arguments)]
+fn assert_attestation_proof_conformance(
+    proof_str: &str,
+    core_method: scp_core::identity::attestation::VerificationMethod,
+    wasm_method_str: &str,
+) {
+    use scp_core::identity::attestation::{
+        AttestationClaim, AttestationEvidence, IdentityLinkAttestation,
+    };
+    use scp_core::trust::attestation::RevocationStatus;
+
+    let issuer = "did:dht:z6MkTestAlice".to_string();
+    let issued_at = 1_700_000_000u64;
+
+    let core_attestation = IdentityLinkAttestation {
+        id: "deadbeef".to_string(),
+        attestation_type: "identity_link".into(),
+        issuer: issuer.clone().into(),
+        subject: issuer.clone().into(),
+        issued_at,
+        expires_at: None,
+        claim: AttestationClaim::new("github.com".to_string(), "alice".to_string(), None),
+        evidence: AttestationEvidence {
+            method: core_method,
+            proof: proof_str.to_string(),
+            verified_at: issued_at,
+            verifier_did: None,
+        },
+        revocation_status: RevocationStatus::Active,
+        signature: vec![0u8; 64],
+    };
+
+    let core_bytes = core_attestation
+        .canonical_signing_bytes()
+        .expect("core canonical bytes");
+
+    let absent_sentinel: [u8; 32] = {
+        let mut h = Sha256::new();
+        h.update([0x00]);
+        h.finalize().into()
+    };
+
+    let wasm_claim = wasm_mirror_attestation::Claim {
+        platform: "github.com".to_string(),
+        platform_handle: "alice".to_string(),
+        platform_id: None,
+        link_type: "self_attestation".to_string(),
+    };
+    let wasm_evidence = wasm_mirror_attestation::Evidence {
+        method: wasm_method_str.to_string(),
+        proof: proof_str.to_string(),
+        verified_at: issued_at,
+        verifier_did: None,
+    };
+    let wasm_revocation = wasm_mirror_attestation::RevocationStatus::Active;
+
+    let claim_msgpack = rmp_serde::to_vec_named(&wasm_claim).expect("claim msgpack");
+    let evidence_msgpack = rmp_serde::to_vec_named(&wasm_evidence).expect("evidence msgpack");
+    let revocation_msgpack = rmp_serde::to_vec_named(&wasm_revocation).expect("revocation msgpack");
+
+    let mut h = Sha256::new();
+    h.update(b"SCP-IDENTITY-LINK-ATTESTATION-V1:");
+    for field in &[
+        b"deadbeef".to_vec(),
+        b"identity_link".to_vec(),
+        issuer.as_bytes().to_vec(),
+        issuer.as_bytes().to_vec(),
+    ] {
+        h.update(u32::try_from(field.len()).unwrap().to_be_bytes());
+        h.update(field);
+    }
+    h.update(issued_at.to_be_bytes());
+    h.update(absent_sentinel);
+    for field in &[claim_msgpack, evidence_msgpack, revocation_msgpack] {
+        h.update(u32::try_from(field.len()).unwrap().to_be_bytes());
+        h.update(field);
+    }
+    let wasm_bytes: Vec<u8> = h.finalize().to_vec();
+
+    assert_eq!(
+        core_bytes,
+        wasm_bytes,
+        "scp-core canonical bytes must match WASM mirror for {wasm_method_str}.\n\
+         Core: {}\nWASM: {}",
+        hex::encode(&core_bytes),
+        hex::encode(&wasm_bytes),
+    );
+}
+
+#[test]
+fn wasm_attestation_canonical_bytes_signed_post_verified() {
+    use scp_core::identity::attestation::VerificationMethod;
+
+    assert_attestation_proof_conformance(
+        r#"{"type":"signed_post_verified","post_url":"https://x.com/alice/status/123","nonce":"abc123","posted_at":1700000000}"#,
+        VerificationMethod::SignedPost,
+        "signed_post",
+    );
+}
+
+#[test]
+fn wasm_attestation_canonical_bytes_dns_record_verified() {
+    use scp_core::identity::attestation::VerificationMethod;
+
+    assert_attestation_proof_conformance(
+        r#"{"type":"dns_record_verified","domain":"example.com","record_name":"_scp-verify"}"#,
+        VerificationMethod::DnsRecord,
+        "dns_record",
+    );
+}
+
+#[test]
+fn wasm_attestation_canonical_bytes_challenge_response_verified() {
+    use scp_core::identity::attestation::VerificationMethod;
+
+    assert_attestation_proof_conformance(
+        r#"{"type":"challenge_response_verified","challenge":"random-challenge-value","response_signature":"deadbeefdeadbeef"}"#,
+        VerificationMethod::ChallengeResponse,
+        "challenge_response",
+    );
+}

--- a/crates/scp-ffi/common/Cargo.toml
+++ b/crates/scp-ffi/common/Cargo.toml
@@ -11,7 +11,7 @@ publish = false
 default = ["resolvers"]
 # Full resolver implementations (BridgeDidResolver, IdentityBackedDidResolver, etc.).
 # Requires scp-core, scp-identity, tokio. Disable for WASM (which only needs validate).
-resolvers = ["dep:scp-core", "dep:scp-identity", "dep:scp-event-log", "dep:z-base-32", "dep:tokio", "dep:tracing"]
+resolvers = ["dep:scp-core", "dep:scp-identity", "dep:scp-event-log", "dep:tokio", "dep:tracing"]
 # Enables the did:key:{hex} DID format in BridgeDidResolver. This is a
 # non-standard test convenience — production builds must resolve via did:dht:z.
 testing = ["resolvers"]
@@ -31,7 +31,7 @@ zeroize = { workspace = true }
 serde_json = { workspace = true }
 sha2 = { workspace = true }
 hex = { workspace = true }
-z-base-32 = { workspace = true, optional = true }
+z-base-32 = { workspace = true }
 thiserror = { workspace = true, optional = true }
 tokio = { workspace = true, optional = true }
 tracing = { workspace = true, optional = true }

--- a/crates/scp-ffi/common/src/bridge_id.rs
+++ b/crates/scp-ffi/common/src/bridge_id.rs
@@ -4,6 +4,21 @@
 
 use sha2::{Digest, Sha256};
 
+/// The system clock is unavailable or before the Unix epoch.
+///
+/// A bridge ID with timestamp 0 would produce a deterministic hash that could
+/// collide with other registrations experiencing the same clock failure.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ClockError;
+
+impl std::fmt::Display for ClockError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str("system clock is unavailable or before Unix epoch")
+    }
+}
+
+impl std::error::Error for ClockError {}
+
 /// Generates a bridge ID per spec section 12.2.1.
 ///
 /// Computes `SHA-256(context_id || operator_did || platform || timestamp)`
@@ -19,12 +34,19 @@ use sha2::{Digest, Sha256};
 ///
 /// Returns `(bridge_id_hex, timestamp_secs)` so callers can use the same
 /// timestamp for `BridgeRegistrationRequest::requested_at`.
-#[must_use]
-pub fn generate_bridge_id(context_id: &str, operator_did: &str, platform: &str) -> (String, u64) {
+///
+/// # Errors
+///
+/// Returns [`ClockError`] if the system clock is before the Unix epoch.
+pub fn generate_bridge_id(
+    context_id: &str,
+    operator_did: &str,
+    platform: &str,
+) -> Result<(String, u64), ClockError> {
     let now_secs = std::time::SystemTime::now()
         .duration_since(std::time::UNIX_EPOCH)
         .map(|d| d.as_secs())
-        .unwrap_or(0);
+        .map_err(|_| ClockError)?;
 
     let mut hasher = Sha256::new();
     hasher.update(context_id.as_bytes());
@@ -32,7 +54,7 @@ pub fn generate_bridge_id(context_id: &str, operator_did: &str, platform: &str) 
     hasher.update(platform.as_bytes());
     hasher.update(now_secs.to_be_bytes());
 
-    (hex::encode(hasher.finalize()), now_secs)
+    Ok((hex::encode(hasher.finalize()), now_secs))
 }
 
 #[cfg(test)]
@@ -42,7 +64,7 @@ mod tests {
 
     #[test]
     fn bridge_id_format() {
-        let (id, ts) = generate_bridge_id("ctx-test", "did:key:operator", "discord");
+        let (id, ts) = generate_bridge_id("ctx-test", "did:key:operator", "discord").unwrap();
         // SHA-256 output is 64 hex chars.
         assert_eq!(id.len(), 64);
         assert!(id.chars().all(|c| c.is_ascii_hexdigit()));
@@ -54,8 +76,8 @@ mod tests {
         // Two calls with the same inputs in the same second produce the same ID.
         // (This is inherently racy if the test spans a second boundary, but
         // extremely unlikely in practice.)
-        let (id1, ts1) = generate_bridge_id("ctx-a", "did:key:op", "slack");
-        let (id2, ts2) = generate_bridge_id("ctx-a", "did:key:op", "slack");
+        let (id1, ts1) = generate_bridge_id("ctx-a", "did:key:op", "slack").unwrap();
+        let (id2, ts2) = generate_bridge_id("ctx-a", "did:key:op", "slack").unwrap();
         if ts1 == ts2 {
             assert_eq!(id1, id2);
         }
@@ -63,8 +85,8 @@ mod tests {
 
     #[test]
     fn bridge_id_different_for_different_inputs() {
-        let (id1, _) = generate_bridge_id("ctx-a", "did:key:op", "slack");
-        let (id2, _) = generate_bridge_id("ctx-b", "did:key:op", "slack");
+        let (id1, _) = generate_bridge_id("ctx-a", "did:key:op", "slack").unwrap();
+        let (id2, _) = generate_bridge_id("ctx-b", "did:key:op", "slack").unwrap();
         // Different context_id must produce different bridge_id (same second).
         assert_ne!(id1, id2);
     }
@@ -79,7 +101,7 @@ mod tests {
         let ctx = "ctx-test";
         let op = "did:key:operator";
         let plat = "discord";
-        let (id, ts) = generate_bridge_id(ctx, op, plat);
+        let (id, ts) = generate_bridge_id(ctx, op, plat).unwrap();
 
         let mut hasher = Sha256::new();
         hasher.update(ctx.as_bytes());

--- a/crates/scp-ffi/common/src/discovery.rs
+++ b/crates/scp-ffi/common/src/discovery.rs
@@ -62,15 +62,20 @@ pub const fn map_discovery_source(
 /// current wall-clock time (seconds since UNIX epoch).
 ///
 /// Used by the `PyO3` (test-only JSON path), NAPI, and `UniFFI` bridges.
-#[must_use]
-pub fn discovery_result_to_json(result: &ContextDiscoveryResult) -> serde_json::Value {
+///
+/// # Errors
+///
+/// Returns an error string if the system clock is before the Unix epoch.
+pub fn discovery_result_to_json(
+    result: &ContextDiscoveryResult,
+) -> Result<serde_json::Value, String> {
     let (source_str, trust_level_kind, resolution_layer, resolution_source, resolution_source_id) =
         map_discovery_source(&result.discovery_source);
 
     let now_secs = std::time::SystemTime::now()
         .duration_since(std::time::UNIX_EPOCH)
         .map(|d| d.as_secs())
-        .unwrap_or(0);
+        .map_err(|_| "system clock is unavailable or before Unix epoch".to_owned())?;
 
     let mut obj = serde_json::json!({
         "context_id": result.context_id,
@@ -95,7 +100,7 @@ pub fn discovery_result_to_json(result: &ContextDiscoveryResult) -> serde_json::
         obj["discovery_context_id"] = serde_json::Value::String(context_id.clone());
     }
 
-    obj
+    Ok(obj)
 }
 
 #[cfg(test)]
@@ -163,7 +168,7 @@ mod tests {
     #[test]
     fn result_to_json_dht_source() {
         let result = make_result(ContextDiscoverySource::DhtDidDocument);
-        let json = discovery_result_to_json(&result);
+        let json = discovery_result_to_json(&result).unwrap();
 
         assert_eq!(json["context_id"], "test-ctx");
         assert_eq!(json["discovery_source"], "dht_did_document");
@@ -181,7 +186,7 @@ mod tests {
         let result = make_result(ContextDiscoverySource::DiscoveryContext {
             context_id: "disc-ctx-1".to_owned(),
         });
-        let json = discovery_result_to_json(&result);
+        let json = discovery_result_to_json(&result).unwrap();
 
         assert_eq!(json["trust_level"]["kind"], "DiscoveryContextVerified");
         assert_eq!(json["resolution_path"]["layer"], "DiscoveryContext");
@@ -193,7 +198,7 @@ mod tests {
     #[test]
     fn result_to_json_context_uri_source() {
         let result = make_result(ContextDiscoverySource::ContextUri);
-        let json = discovery_result_to_json(&result);
+        let json = discovery_result_to_json(&result).unwrap();
 
         assert_eq!(json["trust_level"]["kind"], "DirectExchange");
         assert_eq!(json["resolution_path"]["layer"], "Domain");
@@ -205,7 +210,7 @@ mod tests {
     #[test]
     fn result_to_json_well_known_source() {
         let result = make_result(ContextDiscoverySource::WellKnown);
-        let json = discovery_result_to_json(&result);
+        let json = discovery_result_to_json(&result).unwrap();
 
         assert_eq!(json["trust_level"]["kind"], "DomainVerified");
         assert_eq!(json["resolution_path"]["layer"], "Domain");

--- a/crates/scp-ffi/common/src/petname_helpers.rs
+++ b/crates/scp-ffi/common/src/petname_helpers.rs
@@ -321,7 +321,12 @@ impl HandleQuerier for LocalHandleQuerier {
             type_filter: filter,
         });
 
-        let now = scp_core::time::now_secs().unwrap_or(0);
+        // Clock failure means we cannot produce valid resolved_at timestamps.
+        // Return empty results rather than silently using epoch 0, which would
+        // bypass freshness checks downstream.
+        let Ok(now) = scp_core::time::now_secs() else {
+            return Vec::new();
+        };
 
         result
             .results

--- a/crates/scp-ffi/common/src/validate.rs
+++ b/crates/scp-ffi/common/src/validate.rs
@@ -91,6 +91,15 @@ pub const MAX_TRANSPORT_MODE_LEN: usize = 64;
 /// Maximum length for a deploy ID (matches `scp-core::context::broadcast_content::MAX_DEPLOY_ID_BYTES`).
 pub const MAX_DEPLOY_ID_LEN: usize = 128;
 
+/// Maximum length for an attestation platform string (e.g., "github.com").
+pub const MAX_ATTESTATION_PLATFORM_LEN: usize = 256;
+
+/// Maximum length for an attestation platform handle (e.g., "@alice").
+pub const MAX_ATTESTATION_HANDLE_LEN: usize = 256;
+
+/// Maximum length for an attestation proof JSON string.
+pub const MAX_ATTESTATION_PROOF_LEN: usize = 65_536;
+
 // ---------------------------------------------------------------------------
 // String emptiness and length
 // ---------------------------------------------------------------------------
@@ -466,6 +475,34 @@ pub const fn json_value_type_name(v: &serde_json::Value) -> &'static str {
 }
 
 // ---------------------------------------------------------------------------
+// Attestation field validation
+// ---------------------------------------------------------------------------
+
+/// Validates the input fields for an identity link attestation creation.
+///
+/// Enforces size limits on `platform`, `handle`, and `proof` to prevent
+/// unbounded input sizes in all FFI bridges. Limits are defined by
+/// [`MAX_ATTESTATION_PLATFORM_LEN`], [`MAX_ATTESTATION_HANDLE_LEN`], and
+/// [`MAX_ATTESTATION_PROOF_LEN`].
+///
+/// # Errors
+///
+/// Returns [`ValidationError`] if any field is empty or exceeds its limit.
+pub fn validate_attestation_fields(
+    platform: &str,
+    handle: &str,
+    proof: &str,
+) -> Result<(), ValidationError> {
+    validate_non_empty(platform, "platform", MAX_ATTESTATION_PLATFORM_LEN)?;
+    reject_control_chars(platform, "platform")?;
+    validate_non_empty(handle, "handle", MAX_ATTESTATION_HANDLE_LEN)?;
+    reject_control_chars(handle, "handle")?;
+    validate_non_empty(proof, "proof", MAX_ATTESTATION_PROOF_LEN)?;
+    reject_control_chars(proof, "proof")?;
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
 // Tests
 // ---------------------------------------------------------------------------
 
@@ -805,6 +842,71 @@ mod tests {
     fn empty_transport_mode_rejected() {
         let err = validate_transport_mode("").unwrap_err();
         assert!(err.message.contains("must not be empty"));
+    }
+
+    // -- Attestation fields --
+
+    #[test]
+    fn valid_attestation_fields() {
+        assert!(validate_attestation_fields("github.com", "@alice", r#"{"sig":"abc"}"#).is_ok());
+    }
+
+    #[test]
+    fn attestation_empty_platform_rejected() {
+        let err = validate_attestation_fields("", "@alice", "proof").unwrap_err();
+        assert!(err.message.contains("must not be empty"));
+    }
+
+    #[test]
+    fn attestation_empty_handle_rejected() {
+        let err = validate_attestation_fields("github.com", "", "proof").unwrap_err();
+        assert!(err.message.contains("must not be empty"));
+    }
+
+    #[test]
+    fn attestation_empty_proof_rejected() {
+        let err = validate_attestation_fields("github.com", "@alice", "").unwrap_err();
+        assert!(err.message.contains("must not be empty"));
+    }
+
+    #[test]
+    fn attestation_platform_control_chars_rejected() {
+        let err = validate_attestation_fields("git\nhub.com", "@alice", "proof").unwrap_err();
+        assert!(err.message.contains("control character"));
+    }
+
+    #[test]
+    fn attestation_handle_control_chars_rejected() {
+        let err = validate_attestation_fields("github.com", "@al\0ice", "proof").unwrap_err();
+        assert!(err.message.contains("control character"));
+    }
+
+    #[test]
+    fn attestation_proof_control_chars_rejected() {
+        let err =
+            validate_attestation_fields("github.com", "@alice", "proof\x1binject").unwrap_err();
+        assert!(err.message.contains("control character"));
+    }
+
+    #[test]
+    fn attestation_platform_too_long_rejected() {
+        let long = "a".repeat(MAX_ATTESTATION_PLATFORM_LEN + 1);
+        let err = validate_attestation_fields(&long, "@alice", "proof").unwrap_err();
+        assert!(err.message.contains("exceeds maximum length"));
+    }
+
+    #[test]
+    fn attestation_handle_too_long_rejected() {
+        let long = "a".repeat(MAX_ATTESTATION_HANDLE_LEN + 1);
+        let err = validate_attestation_fields("github.com", &long, "proof").unwrap_err();
+        assert!(err.message.contains("exceeds maximum length"));
+    }
+
+    #[test]
+    fn attestation_proof_too_long_rejected() {
+        let long = "a".repeat(MAX_ATTESTATION_PROOF_LEN + 1);
+        let err = validate_attestation_fields("github.com", "@alice", &long).unwrap_err();
+        assert!(err.message.contains("exceeds maximum length"));
     }
 
     // -- json_value_type_name --

--- a/crates/scp-ffi/napi/src/bridge_connector.rs
+++ b/crates/scp-ffi/napi/src/bridge_connector.rs
@@ -210,7 +210,12 @@ pub fn bridge_register(
 
     // Bridge ID per spec §12.2.1: SHA-256(context_id || operator_did || platform || timestamp).
     let (bridge_id, now_secs) =
-        scp_ffi_common::generate_bridge_id(&context_id, &operator_did, &platform);
+        scp_ffi_common::generate_bridge_id(&context_id, &operator_did, &platform).map_err(|e| {
+            napi::Error::from(ScpNapiError::Context {
+                message: e.to_string(),
+                code: "SCP-CTX-2017".to_owned(),
+            })
+        })?;
     let request = BridgeRegistrationRequest {
         bridge_id: bridge_id.clone(),
         operator_did: operator_did.clone().into(),

--- a/crates/scp-ffi/napi/src/discovery.rs
+++ b/crates/scp-ffi/napi/src/discovery.rs
@@ -189,7 +189,12 @@ pub async fn context_discover(query: String) -> napi::Result<String> {
             })
         })?;
 
-        let results = vec![discovery_result_to_json(&result)];
+        let results = vec![discovery_result_to_json(&result).map_err(|e| {
+            napi::Error::from(ScpNapiError::Context {
+                message: e,
+                code: "SCP-CTX-2020".to_owned(),
+            })
+        })?];
         serde_json::to_string(&results).map_err(|e| {
             napi::Error::from(ScpNapiError::Context {
                 message: format!("failed to serialize discovery results: {e}"),
@@ -207,8 +212,17 @@ pub async fn context_discover(query: String) -> napi::Result<String> {
                 })
             })?;
 
-        let json_results: Vec<serde_json::Value> =
-            results.iter().map(discovery_result_to_json).collect();
+        let json_results: Vec<serde_json::Value> = results
+            .iter()
+            .map(|r| {
+                discovery_result_to_json(r).map_err(|e| {
+                    napi::Error::from(ScpNapiError::Context {
+                        message: e,
+                        code: "SCP-CTX-2022".to_owned(),
+                    })
+                })
+            })
+            .collect::<napi::Result<Vec<_>>>()?;
         serde_json::to_string(&json_results).map_err(|e| {
             napi::Error::from(ScpNapiError::Context {
                 message: format!("failed to serialize discovery results: {e}"),
@@ -859,7 +873,7 @@ mod tests {
             metadata_summary: None,
         };
 
-        let json = discovery_result_to_json(&result);
+        let json = discovery_result_to_json(&result).unwrap();
         assert_eq!(json["context_id"], "abc123");
         assert_eq!(json["discovery_source"], "dht_did_document");
         assert_eq!(json["mode"], "broadcast");
@@ -884,7 +898,7 @@ mod tests {
             metadata_summary: None,
         };
 
-        let json = discovery_result_to_json(&result);
+        let json = discovery_result_to_json(&result).unwrap();
         assert_eq!(json["trust_level"]["kind"], "DiscoveryContextVerified");
         assert_eq!(json["resolution_path"]["layer"], "DiscoveryContext");
         assert_eq!(json["resolution_path"]["source"], "discovery_context");

--- a/crates/scp-ffi/src/bridge_connector.rs
+++ b/crates/scp-ffi/src/bridge_connector.rs
@@ -200,7 +200,12 @@ pub fn py_bridge_register(
 
     // Bridge ID per spec §12.2.1: SHA-256(context_id || operator_did || platform || timestamp).
     let (bridge_id, now_secs) =
-        scp_ffi_common::generate_bridge_id(context_id, operator_did, platform);
+        scp_ffi_common::generate_bridge_id(context_id, operator_did, platform).map_err(|e| {
+            ScpPyError::ContextError {
+                message: e.to_string(),
+                code: "SCP-CTX-2017".to_owned(),
+            }
+        })?;
     let request = BridgeRegistrationRequest {
         bridge_id: bridge_id.clone(),
         operator_did: operator_did.into(),

--- a/crates/scp-ffi/src/discovery.rs
+++ b/crates/scp-ffi/src/discovery.rs
@@ -211,7 +211,11 @@ fn discovery_result_to_dict<'py>(
     let now_secs = std::time::SystemTime::now()
         .duration_since(std::time::UNIX_EPOCH)
         .map(|d| d.as_secs())
-        .unwrap_or(0);
+        .map_err(|_| {
+            pyo3::exceptions::PyRuntimeError::new_err(
+                "system clock is unavailable or before Unix epoch",
+            )
+        })?;
 
     let trust_level = PyDict::new(py);
     trust_level.set_item("kind", trust_level_kind)?;
@@ -1248,7 +1252,7 @@ mod tests {
             metadata_summary: None,
         };
 
-        let json = discovery_result_to_json(&result);
+        let json = discovery_result_to_json(&result).unwrap();
         assert_eq!(json["context_id"], "abc123");
         assert_eq!(json["discovery_source"], "dht_did_document");
         assert_eq!(json["mode"], "broadcast");
@@ -1273,7 +1277,7 @@ mod tests {
             metadata_summary: None,
         };
 
-        let json = discovery_result_to_json(&result);
+        let json = discovery_result_to_json(&result).unwrap();
         assert_eq!(json["trust_level"]["kind"], "DiscoveryContextVerified");
         assert_eq!(json["resolution_path"]["layer"], "DiscoveryContext");
         assert_eq!(json["resolution_path"]["source"], "discovery_context");
@@ -1292,7 +1296,7 @@ mod tests {
             metadata_summary: None,
         };
 
-        let json = discovery_result_to_json(&result);
+        let json = discovery_result_to_json(&result).unwrap();
         assert_eq!(json["trust_level"]["kind"], "DirectExchange");
         assert_eq!(json["resolution_path"]["layer"], "Domain");
         assert_eq!(json["resolution_path"]["source"], "context_uri");
@@ -1311,7 +1315,7 @@ mod tests {
             metadata_summary: Some("Example context".to_owned()),
         };
 
-        let json = discovery_result_to_json(&result);
+        let json = discovery_result_to_json(&result).unwrap();
         assert_eq!(json["trust_level"]["kind"], "DomainVerified");
         assert_eq!(json["resolution_path"]["layer"], "Domain");
         assert_eq!(json["resolution_path"]["source"], "well-known");

--- a/crates/scp-ffi/uniffi/src/bridge.rs
+++ b/crates/scp-ffi/uniffi/src/bridge.rs
@@ -10742,7 +10742,12 @@ pub fn bridge_register(
 
     // Bridge ID per spec §12.2.1: SHA-256(context_id || operator_did || platform || timestamp).
     let (bridge_id, now_secs) =
-        scp_ffi_common::generate_bridge_id(&context_id, &operator_did, &platform);
+        scp_ffi_common::generate_bridge_id(&context_id, &operator_did, &platform).map_err(|e| {
+            ScpError::Context {
+                msg: e.to_string(),
+                code: "SCP-CTX-2017".to_owned(),
+            }
+        })?;
     let request = scp_core::bridge::registration::BridgeRegistrationRequest {
         bridge_id: bridge_id.clone(),
         operator_did: operator_did.clone().into(),
@@ -10914,7 +10919,12 @@ pub async fn context_discover(query: String) -> Result<String, ScpError> {
                 code: "SCP-CTX-2020".to_owned(),
             })?;
 
-        let results = vec![discovery_result_to_json(&result)];
+        let results = vec![
+            discovery_result_to_json(&result).map_err(|e| ScpError::Context {
+                msg: e,
+                code: "SCP-CTX-2020".to_owned(),
+            })?,
+        ];
         serde_json::to_string(&results).map_err(|e| ScpError::Context {
             msg: format!("failed to serialize discovery results: {e}"),
             code: "SCP-CTX-2021".to_owned(),
@@ -10932,8 +10942,15 @@ pub async fn context_discover(query: String) -> Result<String, ScpError> {
                         code: "SCP-CTX-2022".to_owned(),
                     })?;
 
-                let json_results: Vec<serde_json::Value> =
-                    results.iter().map(discovery_result_to_json).collect();
+                let json_results: Vec<serde_json::Value> = results
+                    .iter()
+                    .map(|r| {
+                        discovery_result_to_json(r).map_err(|e| ScpError::Context {
+                            msg: e,
+                            code: "SCP-CTX-2022".to_owned(),
+                        })
+                    })
+                    .collect::<Result<Vec<_>, _>>()?;
                 serde_json::to_string(&json_results).map_err(|e| ScpError::Context {
                     msg: format!("failed to serialize discovery results: {e}"),
                     code: "SCP-CTX-2023".to_owned(),
@@ -12361,7 +12378,7 @@ mod tests {
             metadata_summary: None,
         };
 
-        let json = discovery_result_to_json(&result);
+        let json = discovery_result_to_json(&result).unwrap();
         assert_eq!(json["context_id"], "abc123");
         assert_eq!(json["discovery_source"], "dht_did_document");
         assert_eq!(json["mode"], "broadcast");
@@ -12386,7 +12403,7 @@ mod tests {
             metadata_summary: None,
         };
 
-        let json = discovery_result_to_json(&result);
+        let json = discovery_result_to_json(&result).unwrap();
         assert_eq!(json["trust_level"]["kind"], "DiscoveryContextVerified");
         assert_eq!(json["resolution_path"]["layer"], "DiscoveryContext");
         assert_eq!(json["resolution_path"]["source"], "discovery_context");
@@ -12405,7 +12422,7 @@ mod tests {
             metadata_summary: None,
         };
 
-        let json = discovery_result_to_json(&result);
+        let json = discovery_result_to_json(&result).unwrap();
         assert_eq!(json["trust_level"]["kind"], "DirectExchange");
         assert_eq!(json["resolution_path"]["layer"], "Domain");
         assert_eq!(json["resolution_path"]["source"], "context_uri");
@@ -12424,7 +12441,7 @@ mod tests {
             metadata_summary: Some("Example context".to_owned()),
         };
 
-        let json = discovery_result_to_json(&result);
+        let json = discovery_result_to_json(&result).unwrap();
         assert_eq!(json["trust_level"]["kind"], "DomainVerified");
         assert_eq!(json["resolution_path"]["layer"], "Domain");
         assert_eq!(json["resolution_path"]["source"], "well-known");

--- a/crates/scp-identity/src/attestation.rs
+++ b/crates/scp-identity/src/attestation.rs
@@ -22,6 +22,9 @@
 //!
 //! See ADR-039 §Enforcement Stack Layer 4 in `.docs/adrs/phase-1.md`.
 
+use std::fmt;
+use std::str::FromStr;
+
 use super::IdentityError;
 use super::document::Service;
 use serde::{Deserialize, Serialize};
@@ -235,6 +238,330 @@ impl ScpKeyCustodyAttestation {
                 "failed to parse custody attestation from service endpoint: {e}"
             ))
         })
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Identity Link Attestation Service Entry (spec §3.5.3)
+// ---------------------------------------------------------------------------
+
+/// The service type string for identity link attestation entries.
+const IDENTITY_LINK_SERVICE_TYPE: &str = "ScpIdentityLinkAttestation";
+
+/// Platform identifier for identity link attestations (spec §3.5.1).
+///
+/// Each variant corresponds to an entry in the closed provider registry.
+/// New providers are added by spec amendment only.
+///
+/// NOTE: The spec currently lists 7 platforms. This enum includes 16 as
+/// agreed in the attestation design discussion. A spec amendment adding
+/// the remaining 9 (linkedin.com, discord.com, reddit.com, bluesky.com,
+/// telegram.com, npm, pypi, steam, well-known) is pending.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub enum IdentityLinkPlatform {
+    /// GitHub (`github.com`). Class 2. Verification: `SignedPost` (profile bio).
+    #[serde(rename = "github.com")]
+    Github,
+    /// X / Twitter (`x.com`). Class 2. Verification: `SignedPost` (profile description).
+    #[serde(rename = "x.com")]
+    X,
+    /// Google (`google.com`). Class 1. Verification: `Oauth` (OIDC).
+    #[serde(rename = "google.com")]
+    Google,
+    /// Apple (`apple.com`). Class 1. Verification: `Oauth` (OIDC).
+    #[serde(rename = "apple.com")]
+    Apple,
+    /// Microsoft (`microsoft.com`). Class 1. Verification: `Oauth` (OIDC).
+    #[serde(rename = "microsoft.com")]
+    Microsoft,
+    /// Mastodon (`mastodon`). Class 2. Verification: `SignedPost` (profile bio).
+    ///
+    /// Mastodon is a federated platform with many instances. The spec says the
+    /// platform value should be `mastodon:<instance>` (e.g., `mastodon:mastodon.social`).
+    /// However, the enum variant serializes to just `"mastodon"` because enum
+    /// variants cannot carry instance-specific data.
+    ///
+    /// **Convention:** The `platform_handle` field should include the full Mastodon
+    /// address with instance (e.g., `@user@mastodon.social`). Verifiers should
+    /// extract the instance from the handle when needed. For attestations that
+    /// need instance-specific platform values, use the raw string `"mastodon:<instance>"`
+    /// directly instead of this enum variant.
+    #[serde(rename = "mastodon")]
+    Mastodon,
+    /// DNS (`dns`). Class 2. Verification: `DnsRecord` (`_scp-verify.<domain>`).
+    #[serde(rename = "dns")]
+    Dns,
+    /// `LinkedIn` (`linkedin.com`). Class 2. Verification: `SignedPost`.
+    #[serde(rename = "linkedin.com")]
+    Linkedin,
+    /// Discord (`discord.com`). Class 1. Verification: `Oauth`.
+    #[serde(rename = "discord.com")]
+    Discord,
+    /// Reddit (`reddit.com`). Class 2. Verification: `SignedPost`.
+    #[serde(rename = "reddit.com")]
+    Reddit,
+    /// Bluesky (`bluesky.com`). Class 2. Verification: `SignedPost`.
+    #[serde(rename = "bluesky.com")]
+    Bluesky,
+    /// Telegram (`telegram.com`). Class 2. Verification: `ChallengeResponse`.
+    #[serde(rename = "telegram.com")]
+    Telegram,
+    /// npm (`npm`). Class 2. Verification: `SignedPost` (package metadata).
+    #[serde(rename = "npm")]
+    Npm,
+    /// `PyPI` (`pypi`). Class 2. Verification: `SignedPost` (package metadata).
+    #[serde(rename = "pypi")]
+    Pypi,
+    /// Steam (`steam`). Class 2. Verification: `SignedPost` (profile).
+    #[serde(rename = "steam")]
+    Steam,
+    /// Well-known (`well-known`). Class 2. Verification: `DnsRecord`
+    /// (`/.well-known/scp-verify`).
+    #[serde(rename = "well-known")]
+    WellKnown,
+}
+
+/// All platform variants in registry order, for iteration.
+const ALL_PLATFORMS: [IdentityLinkPlatform; 16] = [
+    IdentityLinkPlatform::Github,
+    IdentityLinkPlatform::X,
+    IdentityLinkPlatform::Google,
+    IdentityLinkPlatform::Apple,
+    IdentityLinkPlatform::Microsoft,
+    IdentityLinkPlatform::Mastodon,
+    IdentityLinkPlatform::Dns,
+    IdentityLinkPlatform::Linkedin,
+    IdentityLinkPlatform::Discord,
+    IdentityLinkPlatform::Reddit,
+    IdentityLinkPlatform::Bluesky,
+    IdentityLinkPlatform::Telegram,
+    IdentityLinkPlatform::Npm,
+    IdentityLinkPlatform::Pypi,
+    IdentityLinkPlatform::Steam,
+    IdentityLinkPlatform::WellKnown,
+];
+
+impl IdentityLinkPlatform {
+    /// Returns the canonical wire-format string for this platform.
+    #[must_use]
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Github => "github.com",
+            Self::X => "x.com",
+            Self::Google => "google.com",
+            Self::Apple => "apple.com",
+            Self::Microsoft => "microsoft.com",
+            Self::Mastodon => "mastodon",
+            Self::Dns => "dns",
+            Self::Linkedin => "linkedin.com",
+            Self::Discord => "discord.com",
+            Self::Reddit => "reddit.com",
+            Self::Bluesky => "bluesky.com",
+            Self::Telegram => "telegram.com",
+            Self::Npm => "npm",
+            Self::Pypi => "pypi",
+            Self::Steam => "steam",
+            Self::WellKnown => "well-known",
+        }
+    }
+
+    /// Returns all platform variants in registry order.
+    #[must_use]
+    pub const fn all() -> &'static [Self; 16] {
+        &ALL_PLATFORMS
+    }
+}
+
+impl fmt::Display for IdentityLinkPlatform {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+/// Error returned when a string does not match any known platform.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct UnknownPlatformError(pub String);
+
+impl fmt::Display for UnknownPlatformError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "unknown identity link platform: '{}'", self.0)
+    }
+}
+
+impl std::error::Error for UnknownPlatformError {}
+
+impl FromStr for IdentityLinkPlatform {
+    type Err = UnknownPlatformError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "github.com" => Ok(Self::Github),
+            "x.com" => Ok(Self::X),
+            "google.com" => Ok(Self::Google),
+            "apple.com" => Ok(Self::Apple),
+            "microsoft.com" => Ok(Self::Microsoft),
+            "mastodon" => Ok(Self::Mastodon),
+            "dns" => Ok(Self::Dns),
+            "linkedin.com" => Ok(Self::Linkedin),
+            "discord.com" => Ok(Self::Discord),
+            "reddit.com" => Ok(Self::Reddit),
+            "bluesky.com" => Ok(Self::Bluesky),
+            "telegram.com" => Ok(Self::Telegram),
+            "npm" => Ok(Self::Npm),
+            "pypi" => Ok(Self::Pypi),
+            "steam" => Ok(Self::Steam),
+            "well-known" => Ok(Self::WellKnown),
+            other => Err(UnknownPlatformError(other.to_owned())),
+        }
+    }
+}
+
+/// Identity link attestation published as a DID document service entry (spec §3.5.3).
+///
+/// Represents a self-signed claim that the DID owner controls a specific
+/// external platform identity. Published as a service entry in the DID
+/// document for discovery — any party resolving the document can enumerate
+/// the owner's identity links.
+///
+/// Follows the same pattern as [`ScpKeyCustodyAttestation`]: the struct is
+/// serialized as JSON in the `serviceEndpoint` field.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ScpIdentityLinkService {
+    /// Deterministic attestation ID (hex-encoded SHA-256, per §3.5.2).
+    pub attestation_id: String,
+
+    /// Platform identifier from the provider registry (§3.5.1).
+    pub platform: IdentityLinkPlatform,
+
+    /// Handle on the platform (e.g., `"@alice"`, `"alice123"`).
+    pub platform_handle: String,
+
+    /// Platform-specific immutable user ID (e.g., Twitter user ID, OIDC sub).
+    /// `None` when the platform does not provide a stable ID.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub platform_id: Option<String>,
+
+    /// The DID verification method fragment that signed the attestation
+    /// (e.g., `"#active"` or `"#agent"`).
+    pub verification_method: String,
+
+    /// Unix timestamp (seconds) when the attestation was last verified.
+    pub verified_at: u64,
+
+    /// Revocation status: `"active"` or `"revoked"`.
+    pub revocation_status: ServiceRevocationStatus,
+}
+
+/// Revocation status for identity link service entries.
+///
+/// A typed enum replacing the raw `String` field. Serializes to
+/// lowercase `"active"` / `"revoked"` for wire compatibility with
+/// existing DID document service entries.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum ServiceRevocationStatus {
+    /// The attestation is active (not revoked).
+    Active,
+    /// The attestation has been revoked.
+    Revoked,
+}
+
+impl ServiceRevocationStatus {
+    /// Returns the wire-format string for this status.
+    #[must_use]
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Active => "active",
+            Self::Revoked => "revoked",
+        }
+    }
+}
+
+impl std::fmt::Display for ServiceRevocationStatus {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+impl ScpIdentityLinkService {
+    /// Revocation status value for an active attestation.
+    pub const STATUS_ACTIVE: &'static str = "active";
+
+    /// Revocation status value for a revoked attestation.
+    pub const STATUS_REVOKED: &'static str = "revoked";
+
+    /// Creates a DID document service entry for this identity link attestation
+    /// (spec §3.5.3).
+    ///
+    /// The `serviceEndpoint` contains the hex-encoded attestation ID only (not
+    /// a JSON blob). The service `id` uses the fragment format
+    /// `attestation-<platform>--<index>` (double dash, zero-based numeric index)
+    /// per spec §3.5.3.
+    ///
+    /// # Arguments
+    ///
+    /// * `did` - The DID string that owns this attestation (used for service ID).
+    /// * `index` - Zero-based index among attestation service entries of the same
+    ///   platform type. The caller (typically [`DidDocument::set_identity_link_attestation`])
+    ///   computes this by counting existing same-platform entries.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`IdentityError::DocumentSerializationError`] if the
+    /// `attestation_id` contains non-hex characters.
+    pub fn to_service_entry(&self, did: &str, index: usize) -> Result<Service, IdentityError> {
+        // Validate attestation_id is hex-only before using it in the endpoint.
+        if !self.attestation_id.chars().all(|c| c.is_ascii_hexdigit()) {
+            return Err(IdentityError::DocumentSerializationError(format!(
+                "attestation_id must be hex-encoded, got '{}'",
+                self.attestation_id
+            )));
+        }
+
+        Ok(Service {
+            id: format!("{did}#attestation-{}--{index}", self.platform.as_str()),
+            service_type: IDENTITY_LINK_SERVICE_TYPE.to_owned(),
+            service_endpoint: self.attestation_id.clone(),
+        })
+    }
+
+    /// Extracts the attestation ID from a DID document service entry (spec §3.5.3).
+    ///
+    /// The `serviceEndpoint` is the hex-encoded attestation ID string. This method
+    /// returns only the attestation ID -- the caller must look up the full
+    /// `IdentityLinkAttestation` from the identity's attestation store via relay
+    /// or DHT using this ID.
+    ///
+    /// # Arguments
+    ///
+    /// * `entry` - A service entry with `type: "ScpIdentityLinkAttestation"`.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`IdentityError::DocumentDeserializationError`] if the service
+    /// type does not match or the endpoint is not a valid hex string.
+    pub fn from_service_entry(entry: &Service) -> Result<String, IdentityError> {
+        if entry.service_type != IDENTITY_LINK_SERVICE_TYPE {
+            return Err(IdentityError::DocumentDeserializationError(format!(
+                "expected service type '{}', got '{}'",
+                IDENTITY_LINK_SERVICE_TYPE, entry.service_type
+            )));
+        }
+
+        // Validate that the endpoint is a hex string (attestation ID).
+        let endpoint = entry.service_endpoint.trim();
+        if endpoint.is_empty() {
+            return Err(IdentityError::DocumentDeserializationError(
+                "service endpoint (attestation_id) is empty".to_owned(),
+            ));
+        }
+        if !endpoint.chars().all(|c| c.is_ascii_hexdigit()) {
+            return Err(IdentityError::DocumentDeserializationError(format!(
+                "service endpoint must be a hex-encoded attestation ID, got '{endpoint}'"
+            )));
+        }
+
+        Ok(endpoint.to_owned())
     }
 }
 
@@ -601,5 +928,248 @@ mod tests {
         assert_eq!(attestation.platform, Platform::Ios);
         assert!(attestation.platform_attestation.is_none());
         assert_eq!(attestation.created_at, 1_700_000_000);
+    }
+
+    // ===================================================================
+    // IdentityLinkPlatform tests
+    // ===================================================================
+
+    #[test]
+    fn identity_link_platform_as_str_roundtrip_all() {
+        let expected: &[(&str, IdentityLinkPlatform)] = &[
+            ("github.com", IdentityLinkPlatform::Github),
+            ("x.com", IdentityLinkPlatform::X),
+            ("google.com", IdentityLinkPlatform::Google),
+            ("apple.com", IdentityLinkPlatform::Apple),
+            ("microsoft.com", IdentityLinkPlatform::Microsoft),
+            ("mastodon", IdentityLinkPlatform::Mastodon),
+            ("dns", IdentityLinkPlatform::Dns),
+            ("linkedin.com", IdentityLinkPlatform::Linkedin),
+            ("discord.com", IdentityLinkPlatform::Discord),
+            ("reddit.com", IdentityLinkPlatform::Reddit),
+            ("bluesky.com", IdentityLinkPlatform::Bluesky),
+            ("telegram.com", IdentityLinkPlatform::Telegram),
+            ("npm", IdentityLinkPlatform::Npm),
+            ("pypi", IdentityLinkPlatform::Pypi),
+            ("steam", IdentityLinkPlatform::Steam),
+            ("well-known", IdentityLinkPlatform::WellKnown),
+        ];
+
+        assert_eq!(
+            expected.len(),
+            16,
+            "must test all 16 platforms in the provider registry"
+        );
+
+        for &(s, variant) in expected {
+            assert_eq!(variant.as_str(), s, "as_str mismatch for {variant:?}");
+            let parsed: IdentityLinkPlatform = s.parse().unwrap();
+            assert_eq!(parsed, variant, "from_str mismatch for '{s}'");
+        }
+    }
+
+    #[test]
+    fn identity_link_platform_from_str_unknown() {
+        let err = "unknown-platform"
+            .parse::<IdentityLinkPlatform>()
+            .unwrap_err();
+        assert!(
+            err.to_string().contains("unknown identity link platform"),
+            "error should mention unknown platform, got: {err}"
+        );
+    }
+
+    #[test]
+    fn identity_link_platform_display() {
+        assert_eq!(format!("{}", IdentityLinkPlatform::Github), "github.com");
+        assert_eq!(format!("{}", IdentityLinkPlatform::WellKnown), "well-known");
+    }
+
+    #[test]
+    fn identity_link_platform_serde_roundtrip_all() {
+        for &platform in IdentityLinkPlatform::all() {
+            let json = serde_json::to_string(&platform).unwrap();
+            let parsed: IdentityLinkPlatform = serde_json::from_str(&json).unwrap();
+            assert_eq!(platform, parsed, "serde roundtrip failed for {platform:?}");
+            // Verify the JSON value matches as_str.
+            assert_eq!(json, format!("\"{}\"", platform.as_str()));
+        }
+    }
+
+    #[test]
+    fn identity_link_platform_all_returns_16() {
+        assert_eq!(IdentityLinkPlatform::all().len(), 16);
+    }
+
+    // ===================================================================
+    // ScpIdentityLinkService tests
+    // ===================================================================
+
+    fn test_link_service() -> ScpIdentityLinkService {
+        ScpIdentityLinkService {
+            attestation_id: "abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789"
+                .to_owned(),
+            platform: IdentityLinkPlatform::Github,
+            platform_handle: "@alice".to_owned(),
+            platform_id: Some("12345678".to_owned()),
+            verification_method: "#active".to_owned(),
+            verified_at: 1_700_000_000,
+            revocation_status: ServiceRevocationStatus::Active,
+        }
+    }
+
+    #[test]
+    fn identity_link_service_entry_format() {
+        let original = test_link_service();
+        let service = original.to_service_entry(test_did(), 0).unwrap();
+
+        assert_eq!(service.service_type, "ScpIdentityLinkAttestation");
+        // Fragment uses double-dash and zero-based index per §3.5.3.
+        assert_eq!(
+            service.id,
+            format!("{}#attestation-github.com--0", test_did())
+        );
+        // Endpoint is just the attestation ID, not JSON.
+        assert_eq!(service.service_endpoint, original.attestation_id);
+    }
+
+    #[test]
+    fn identity_link_service_from_entry_returns_attestation_id() {
+        let original = test_link_service();
+        let service = original.to_service_entry(test_did(), 0).unwrap();
+
+        let id = ScpIdentityLinkService::from_service_entry(&service).unwrap();
+        assert_eq!(id, original.attestation_id);
+    }
+
+    #[test]
+    fn identity_link_service_index_in_fragment() {
+        let original = test_link_service();
+        let s0 = original.to_service_entry(test_did(), 0).unwrap();
+        let s1 = original.to_service_entry(test_did(), 1).unwrap();
+        let s5 = original.to_service_entry(test_did(), 5).unwrap();
+
+        assert!(s0.id.ends_with("#attestation-github.com--0"));
+        assert!(s1.id.ends_with("#attestation-github.com--1"));
+        assert!(s5.id.ends_with("#attestation-github.com--5"));
+    }
+
+    #[test]
+    fn identity_link_service_each_platform() {
+        for (i, &platform) in IdentityLinkPlatform::all().iter().enumerate() {
+            let service_entry = ScpIdentityLinkService {
+                attestation_id: "abcdef0123456789".to_owned(),
+                platform,
+                platform_handle: "testuser".to_owned(),
+                platform_id: None,
+                verification_method: "#active".to_owned(),
+                verified_at: 1_700_000_000,
+                revocation_status: ServiceRevocationStatus::Active,
+            };
+
+            let service = service_entry.to_service_entry(test_did(), i).unwrap();
+            assert!(
+                service
+                    .id
+                    .contains(&format!("attestation-{}--", platform.as_str())),
+                "service ID should contain platform with double-dash: {platform:?}"
+            );
+
+            // Endpoint should be the attestation ID.
+            assert_eq!(service.service_endpoint, "abcdef0123456789");
+
+            // from_service_entry should return the attestation ID.
+            let id = ScpIdentityLinkService::from_service_entry(&service).unwrap();
+            assert_eq!(id, "abcdef0123456789");
+        }
+    }
+
+    #[test]
+    fn identity_link_service_rejects_wrong_type() {
+        let service = Service {
+            id: format!("{}#custody-attestation", test_did()),
+            service_type: "ScpKeyCustodyAttestation".to_owned(),
+            service_endpoint: "abcdef01".to_owned(),
+        };
+
+        let result = ScpIdentityLinkService::from_service_entry(&service);
+        assert!(result.is_err());
+        let err = result.unwrap_err();
+        assert!(
+            err.to_string().contains("expected service type"),
+            "error should mention expected type, got: {err}"
+        );
+    }
+
+    #[test]
+    fn identity_link_service_rejects_non_hex_endpoint() {
+        let service = Service {
+            id: format!("{}#attestation-github.com--0", test_did()),
+            service_type: IDENTITY_LINK_SERVICE_TYPE.to_owned(),
+            service_endpoint: "not-valid-hex!@#$".to_owned(),
+        };
+
+        let result = ScpIdentityLinkService::from_service_entry(&service);
+        assert!(result.is_err());
+        let err = result.unwrap_err();
+        assert!(
+            err.to_string().contains("hex-encoded attestation ID"),
+            "error should mention hex requirement, got: {err}"
+        );
+    }
+
+    #[test]
+    fn identity_link_service_rejects_empty_endpoint() {
+        let service = Service {
+            id: format!("{}#attestation-github.com--0", test_did()),
+            service_type: IDENTITY_LINK_SERVICE_TYPE.to_owned(),
+            service_endpoint: String::new(),
+        };
+
+        let result = ScpIdentityLinkService::from_service_entry(&service);
+        assert!(result.is_err());
+        let err = result.unwrap_err();
+        assert!(
+            err.to_string().contains("empty"),
+            "error should mention empty, got: {err}"
+        );
+    }
+
+    #[test]
+    fn identity_link_service_serde_json_roundtrip() {
+        let original = test_link_service();
+        let json = serde_json::to_string(&original).unwrap();
+        let parsed: ScpIdentityLinkService = serde_json::from_str(&json).unwrap();
+        assert_eq!(original, parsed);
+    }
+
+    #[test]
+    fn identity_link_service_status_constants() {
+        assert_eq!(ScpIdentityLinkService::STATUS_ACTIVE, "active");
+        assert_eq!(ScpIdentityLinkService::STATUS_REVOKED, "revoked");
+    }
+
+    #[test]
+    fn identity_link_service_non_hex_attestation_id_rejected() {
+        // Non-hex attestation IDs (including multi-byte UTF-8) must be rejected
+        // by the hex validation in `to_service_entry`.
+        let original = ScpIdentityLinkService {
+            attestation_id: "\u{1F600}\u{1F601}\u{1F602}\u{1F603}\u{1F604}\u{1F605}\u{1F606}\u{1F607}\u{1F608}\u{1F609}".to_owned(),
+            platform: IdentityLinkPlatform::Github,
+            platform_handle: "@alice".to_owned(),
+            platform_id: None,
+            verification_method: "#active".to_owned(),
+            verified_at: 1_700_000_000,
+            revocation_status: ServiceRevocationStatus::Active,
+        };
+
+        let result = original.to_service_entry(test_did(), 0);
+        assert!(result.is_err());
+        let err = result.unwrap_err();
+        assert!(
+            err.to_string()
+                .contains("attestation_id must be hex-encoded"),
+            "error should mention hex requirement, got: {err}"
+        );
     }
 }

--- a/crates/scp-identity/src/document.rs
+++ b/crates/scp-identity/src/document.rs
@@ -35,7 +35,7 @@
 //! See ADR-003 and ADR-039 in `.docs/adrs/phase-1.md`.
 
 use super::IdentityError;
-use super::attestation::ScpKeyCustodyAttestation;
+use super::attestation::{ScpIdentityLinkService, ScpKeyCustodyAttestation};
 use serde::{Deserialize, Serialize};
 
 /// Custom serde module for `[u8; 64]` fields.
@@ -200,6 +200,9 @@ const DEVICE_ATTESTATION_FRAGMENT: &str = "device-attestation";
 /// When rotating the `#agent` key, older retired keys beyond this limit are
 /// pruned to bound document size. Per ADR-039, this is set to 2.
 const MAX_RETIRED_AGENT_KEYS: usize = 2;
+
+/// Maximum identity link attestations per DID document (§3.5.3).
+const MAX_IDENTITY_LINK_ATTESTATIONS: usize = 10;
 
 impl DidDocument {
     /// Constructs a new DID Document for an SCP identity.
@@ -593,6 +596,106 @@ impl DidDocument {
         let service = attestation.to_service_entry(&self.id)?;
         self.service.push(service);
         Ok(())
+    }
+
+    /// Returns all identity link attestation IDs from this DID document.
+    ///
+    /// Searches the service entries for those with type
+    /// `ScpIdentityLinkAttestation` and extracts the attestation ID (hex string)
+    /// from each `serviceEndpoint`. Returns an empty `Vec` if none exist.
+    /// Malformed entries are silently skipped.
+    ///
+    /// Callers use these IDs to look up the full `IdentityLinkAttestation` from
+    /// the identity's attestation store (via relay or DHT).
+    ///
+    /// See spec §3.5.3.
+    #[must_use]
+    pub fn identity_link_attestation_ids(&self) -> Vec<String> {
+        self.service
+            .iter()
+            .filter(|s| s.service_type == "ScpIdentityLinkAttestation")
+            .filter_map(|s| ScpIdentityLinkService::from_service_entry(s).ok())
+            .collect()
+    }
+
+    /// Sets (adds) an identity link attestation in this DID document.
+    ///
+    /// If an existing entry with the same `attestation_id` exists, it is
+    /// replaced. Otherwise the new entry is appended. Other service entries
+    /// are preserved.
+    ///
+    /// The service entry fragment uses `attestation-<platform>--<index>` per
+    /// spec §3.5.3, where `<index>` is the zero-based position among entries
+    /// of the same platform type.
+    ///
+    /// See spec §3.5.3.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`IdentityError::DocumentSerializationError`] if the attestation
+    /// cannot be serialized.
+    pub fn set_identity_link_attestation(
+        &mut self,
+        attestation: &ScpIdentityLinkService,
+    ) -> Result<(), IdentityError> {
+        // Remove any existing entry with the same attestation_id.
+        let target_id = &attestation.attestation_id;
+        let had_existing = self.service.iter().any(|s| {
+            s.service_type == "ScpIdentityLinkAttestation"
+                && ScpIdentityLinkService::from_service_entry(s).is_ok_and(|id| id == *target_id)
+        });
+        self.service.retain(|s| {
+            if s.service_type != "ScpIdentityLinkAttestation" {
+                return true;
+            }
+            ScpIdentityLinkService::from_service_entry(s).map_or(true, |id| id != *target_id)
+        });
+
+        // Enforce 10-attestation-per-DID-document cap (§3.5.3).
+        if !had_existing {
+            let count = self
+                .service
+                .iter()
+                .filter(|s| s.service_type == "ScpIdentityLinkAttestation")
+                .count();
+            if count >= MAX_IDENTITY_LINK_ATTESTATIONS {
+                return Err(IdentityError::TooManyIdentityLinkAttestations {
+                    count: count + 1,
+                    max: MAX_IDENTITY_LINK_ATTESTATIONS,
+                });
+            }
+        }
+
+        // Compute the zero-based index for this platform among existing
+        // attestation service entries.
+        let platform_str = attestation.platform.as_str();
+        let prefix = format!("#attestation-{platform_str}--");
+        let index = self
+            .service
+            .iter()
+            .filter(|s| s.service_type == "ScpIdentityLinkAttestation" && s.id.contains(&prefix))
+            .count();
+
+        let service = attestation.to_service_entry(&self.id, index)?;
+        self.service.push(service);
+        Ok(())
+    }
+
+    /// Removes an identity link attestation from this DID document by attestation ID.
+    ///
+    /// Returns `true` if an entry was removed, `false` if no matching entry
+    /// was found.
+    ///
+    /// See spec §3.5.3.
+    pub fn remove_identity_link_attestation(&mut self, attestation_id: &str) -> bool {
+        let before = self.service.len();
+        self.service.retain(|s| {
+            if s.service_type != "ScpIdentityLinkAttestation" {
+                return true;
+            }
+            ScpIdentityLinkService::from_service_entry(s).map_or(true, |id| id != attestation_id)
+        });
+        self.service.len() < before
     }
 
     /// Returns the device attestation token from this DID document, if present.
@@ -2066,5 +2169,240 @@ mod tests {
 
         let result = doc.device_attestation_token();
         assert!(result.is_err());
+    }
+
+    // ===================================================================
+    // Identity link attestation document methods
+    // ===================================================================
+
+    fn test_link_attestation(
+        platform: crate::attestation::IdentityLinkPlatform,
+        id: &str,
+    ) -> crate::attestation::ScpIdentityLinkService {
+        crate::attestation::ScpIdentityLinkService {
+            attestation_id: id.to_owned(),
+            platform,
+            platform_handle: "@test".to_owned(),
+            platform_id: None,
+            verification_method: "#active".to_owned(),
+            verified_at: 1_700_000_000,
+            revocation_status: crate::attestation::ServiceRevocationStatus::Active,
+        }
+    }
+
+    #[test]
+    fn identity_link_attestation_ids_empty_by_default() {
+        let doc = DidDocument::new("did:dht:zNoLinks", &[1u8; 32], &[2u8; 32], &[3u8; 32]);
+        assert!(doc.identity_link_attestation_ids().is_empty());
+    }
+
+    #[test]
+    fn set_and_get_identity_link_attestation() {
+        let mut doc = DidDocument::new("did:dht:zLinks1", &[1u8; 32], &[2u8; 32], &[3u8; 32]);
+        let att =
+            test_link_attestation(crate::attestation::IdentityLinkPlatform::Github, "abcdef01");
+        doc.set_identity_link_attestation(&att).unwrap();
+
+        let ids = doc.identity_link_attestation_ids();
+        assert_eq!(ids.len(), 1);
+        assert_eq!(ids[0], "abcdef01");
+    }
+
+    #[test]
+    fn set_identity_link_replaces_same_id() {
+        let mut doc = DidDocument::new("did:dht:zLinks2", &[1u8; 32], &[2u8; 32], &[3u8; 32]);
+        let att1 = crate::attestation::ScpIdentityLinkService {
+            attestation_id: "aa00bb0012345678".to_owned(),
+            platform: crate::attestation::IdentityLinkPlatform::Github,
+            platform_handle: "@alice".to_owned(),
+            platform_id: None,
+            verification_method: "#active".to_owned(),
+            verified_at: 1_700_000_000,
+            revocation_status: crate::attestation::ServiceRevocationStatus::Active,
+        };
+        doc.set_identity_link_attestation(&att1).unwrap();
+
+        let att2 = crate::attestation::ScpIdentityLinkService {
+            attestation_id: "aa00bb0012345678".to_owned(),
+            platform: crate::attestation::IdentityLinkPlatform::Github,
+            platform_handle: "@alice_updated".to_owned(),
+            platform_id: Some("9999".to_owned()),
+            verification_method: "#active".to_owned(),
+            verified_at: 1_700_000_001,
+            revocation_status: crate::attestation::ServiceRevocationStatus::Active,
+        };
+        doc.set_identity_link_attestation(&att2).unwrap();
+
+        // Same attestation ID, so still only 1 entry.
+        let ids = doc.identity_link_attestation_ids();
+        assert_eq!(ids.len(), 1);
+        assert_eq!(ids[0], "aa00bb0012345678");
+    }
+
+    #[test]
+    fn multiple_attestations_same_platform() {
+        let mut doc = DidDocument::new("did:dht:zLinks3", &[1u8; 32], &[2u8; 32], &[3u8; 32]);
+        let att1 = test_link_attestation(
+            crate::attestation::IdentityLinkPlatform::Mastodon,
+            "aabb111100001111",
+        );
+        let att2 = crate::attestation::ScpIdentityLinkService {
+            attestation_id: "aabb222200002222".to_owned(),
+            platform: crate::attestation::IdentityLinkPlatform::Mastodon,
+            platform_handle: "@bob@mastodon.social".to_owned(),
+            platform_id: None,
+            verification_method: "#active".to_owned(),
+            verified_at: 1_700_000_000,
+            revocation_status: crate::attestation::ServiceRevocationStatus::Active,
+        };
+
+        doc.set_identity_link_attestation(&att1).unwrap();
+        doc.set_identity_link_attestation(&att2).unwrap();
+
+        let ids = doc.identity_link_attestation_ids();
+        assert_eq!(ids.len(), 2);
+
+        // Verify the service entry fragments use double-dash index format.
+        let link_services: Vec<_> = doc
+            .service
+            .iter()
+            .filter(|s| s.service_type == "ScpIdentityLinkAttestation")
+            .collect();
+        assert!(link_services[0].id.contains("#attestation-mastodon--0"));
+        assert!(link_services[1].id.contains("#attestation-mastodon--1"));
+    }
+
+    #[test]
+    fn remove_identity_link_attestation_returns_true() {
+        let mut doc = DidDocument::new("did:dht:zLinks4", &[1u8; 32], &[2u8; 32], &[3u8; 32]);
+        let att = test_link_attestation(
+            crate::attestation::IdentityLinkPlatform::Discord,
+            "ddcc001100001234",
+        );
+        doc.set_identity_link_attestation(&att).unwrap();
+
+        assert!(doc.remove_identity_link_attestation("ddcc001100001234"));
+        assert!(doc.identity_link_attestation_ids().is_empty());
+    }
+
+    #[test]
+    fn remove_identity_link_attestation_returns_false_when_absent() {
+        let mut doc = DidDocument::new("did:dht:zLinks5", &[1u8; 32], &[2u8; 32], &[3u8; 32]);
+        assert!(!doc.remove_identity_link_attestation("nonexistent"));
+    }
+
+    #[test]
+    fn identity_link_preserves_other_services() {
+        let did = "did:dht:zLinks6";
+        let mut doc = DidDocument::new(did, &[1u8; 32], &[2u8; 32], &[3u8; 32]);
+        doc.add_relay_service("wss://relay.example.com/scp/v1")
+            .unwrap();
+
+        let att = test_link_attestation(
+            crate::attestation::IdentityLinkPlatform::X,
+            "ee0012345678aabb",
+        );
+        doc.set_identity_link_attestation(&att).unwrap();
+
+        // Should have: PreRotationCommitment + SCPRelay + ScpIdentityLinkAttestation.
+        assert_eq!(doc.service.len(), 3);
+        assert!(doc.pre_rotation_service().is_some());
+        assert_eq!(doc.relay_service_urls().len(), 1);
+        assert_eq!(doc.identity_link_attestation_ids().len(), 1);
+    }
+
+    #[test]
+    fn identity_link_attestation_ids_skip_malformed() {
+        let did = "did:dht:zLinks7";
+        let mut doc = DidDocument::new(did, &[1u8; 32], &[2u8; 32], &[3u8; 32]);
+
+        // Add a valid one.
+        let att = test_link_attestation(
+            crate::attestation::IdentityLinkPlatform::Apple,
+            "aa0012345678ccdd",
+        );
+        doc.set_identity_link_attestation(&att).unwrap();
+
+        // Manually add a malformed one (non-hex endpoint).
+        doc.service.push(Service {
+            id: format!("{did}#attestation-bad-entry"),
+            service_type: "ScpIdentityLinkAttestation".to_owned(),
+            service_endpoint: "not-valid-hex!@#$".to_owned(),
+        });
+
+        // Should return only the valid one, silently skipping the malformed.
+        let ids = doc.identity_link_attestation_ids();
+        assert_eq!(ids.len(), 1);
+        assert_eq!(ids[0], "aa0012345678ccdd");
+    }
+
+    #[test]
+    fn identity_link_survives_json_roundtrip() {
+        let did = "did:dht:zLinks8";
+        let mut doc = DidDocument::new(did, &[1u8; 32], &[2u8; 32], &[3u8; 32]);
+
+        let att = crate::attestation::ScpIdentityLinkService {
+            attestation_id: "ff0011223344aabb".to_owned(),
+            platform: crate::attestation::IdentityLinkPlatform::Google,
+            platform_handle: "user@gmail.com".to_owned(),
+            platform_id: Some("oidc-sub-abc".to_owned()),
+            verification_method: "#active".to_owned(),
+            verified_at: 1_700_000_000,
+            revocation_status: crate::attestation::ServiceRevocationStatus::Active,
+        };
+        doc.set_identity_link_attestation(&att).unwrap();
+
+        let json = doc.to_json().unwrap();
+        let parsed = DidDocument::from_json(&json).unwrap();
+
+        // After JSON roundtrip, the endpoint contains the attestation ID.
+        let ids = parsed.identity_link_attestation_ids();
+        assert_eq!(ids.len(), 1);
+        assert_eq!(ids[0], "ff0011223344aabb");
+    }
+
+    #[test]
+    fn service_entry_endpoint_is_just_attestation_id() {
+        let did = "did:dht:zLinks9";
+        let mut doc = DidDocument::new(did, &[1u8; 32], &[2u8; 32], &[3u8; 32]);
+
+        let att = test_link_attestation(
+            crate::attestation::IdentityLinkPlatform::Github,
+            "abcdef0123456789",
+        );
+        doc.set_identity_link_attestation(&att).unwrap();
+
+        // Find the service entry and verify the endpoint is just the hex ID.
+        let entry = doc
+            .service
+            .iter()
+            .find(|s| s.service_type == "ScpIdentityLinkAttestation")
+            .unwrap();
+        assert_eq!(entry.service_endpoint, "abcdef0123456789");
+        // Should NOT be JSON.
+        assert!(!entry.service_endpoint.starts_with('{'));
+    }
+
+    #[test]
+    fn service_entry_fragment_uses_double_dash_index() {
+        let did = "did:dht:zLinks10";
+        let mut doc = DidDocument::new(did, &[1u8; 32], &[2u8; 32], &[3u8; 32]);
+
+        let att = test_link_attestation(
+            crate::attestation::IdentityLinkPlatform::Github,
+            "abcdef0123456789",
+        );
+        doc.set_identity_link_attestation(&att).unwrap();
+
+        let entry = doc
+            .service
+            .iter()
+            .find(|s| s.service_type == "ScpIdentityLinkAttestation")
+            .unwrap();
+        assert_eq!(
+            entry.id,
+            format!("{did}#attestation-github.com--0"),
+            "Fragment should use double-dash and zero-based index"
+        );
     }
 }

--- a/crates/scp-identity/src/lib.rs
+++ b/crates/scp-identity/src/lib.rs
@@ -43,7 +43,9 @@ pub mod resolution;
 pub mod resolver;
 
 pub use attestation::{
-    AttestationPlatform, KeyCustodyModel, Platform, PlatformAttestation, ScpKeyCustodyAttestation,
+    AttestationPlatform, IdentityLinkPlatform, KeyCustodyModel, Platform, PlatformAttestation,
+    ScpIdentityLinkService, ScpKeyCustodyAttestation, ServiceRevocationStatus,
+    UnknownPlatformError,
 };
 pub use cache::{DidCache, DidResolutionResult, Staleness};
 pub use dht::{
@@ -378,6 +380,15 @@ pub enum IdentityError {
     #[error("too many retired agent keys: found {count}, maximum is {max}")]
     TooManyRetiredAgentKeys {
         /// The number of retired agent keys found.
+        count: usize,
+        /// The maximum allowed.
+        max: usize,
+    },
+
+    /// Too many identity link attestations in the DID document (§3.5.3).
+    #[error("too many identity link attestations: {count} exceeds maximum of {max}")]
+    TooManyIdentityLinkAttestations {
+        /// The number of attestations that would exist after the add.
         count: usize,
         /// The maximum allowed.
         max: usize,

--- a/crates/scp-testing/src/clock.rs
+++ b/crates/scp-testing/src/clock.rs
@@ -86,16 +86,21 @@ pub trait Clock: Send + Sync + 'static {
 pub struct SystemClock;
 
 impl Clock for SystemClock {
+    #[allow(clippy::expect_used)]
     fn now_secs(&self) -> u64 {
-        // In production the system clock should always be available. If it
-        // somehow is not (clock before epoch), fall back to 0 rather than
-        // panicking -- callers that care about correctness already validate
-        // timestamps downstream.
-        scp_primitives::time::now_secs().unwrap_or(0)
+        // The Clock trait returns u64 (not Result), so we cannot propagate the
+        // error. A system clock before the Unix epoch is an unrecoverable
+        // environment failure — panicking is the correct behaviour here, as
+        // silently returning 0 would bypass UCAN expiry and nonce freshness
+        // checks.
+        scp_primitives::time::now_secs().expect("system clock is unavailable or before Unix epoch")
     }
 
+    #[allow(clippy::expect_used)]
     fn now_millis(&self) -> u64 {
-        scp_primitives::time::now_millis().unwrap_or(0)
+        // Same rationale as now_secs — returning 0 would bypass security checks.
+        scp_primitives::time::now_millis()
+            .expect("system clock is unavailable or before Unix epoch")
     }
 
     fn register_timer(&self, _at_millis: u64, _callback: Box<dyn FnOnce() + Send>) -> TimerHandle {

--- a/crates/scp-testing/tests/integration/conformance.rs
+++ b/crates/scp-testing/tests/integration/conformance.rs
@@ -217,18 +217,32 @@ fn conf_004_agent_binding_attestation() {
     let human_key = make_signing_key(0x01);
     let agent_key = make_signing_key(0x02);
 
+    // Use did:key:{hex} format so IdentityDidPublicKeyResolver can resolve
+    // the issuer's public key during cross-verification.
+    let human_did = format!("did:key:{}", hex(&human_key.verifying_key().to_bytes()));
+    let agent_did = format!("did:key:{}", hex(&agent_key.verifying_key().to_bytes()));
+
+    let claim = serde_json::json!({"platform": "agent-binding"});
+    let claim_bytes = rmp_serde::to_vec_named(&claim).expect("claim msgpack serialization");
+
     print_step(1, "Create identity attestation binding agent to human");
+    // RevocationStatus::Active serialized as MessagePack (named keys).
+    let revocation_active_bytes =
+        rmp_serde::to_vec_named(&scp_core::trust::RevocationStatus::Active).unwrap();
+    // Field order per §9.5.2: id, attestation_type, issuer, subject, claim,
+    // evidence, issued_at, expires_at, revocation_status.
     let attestation_payload = canonical_hash_bytes(
         b"SCP-ATTESTATION-V1:",
         &[
             CanonicalField::VarBytes(b"agent-binding-001"),
-            CanonicalField::U16(0x0001), // IdentityLink
-            CanonicalField::VarBytes(b"did:dht:z6MkHuman"),
-            CanonicalField::VarBytes(b"did:dht:z6MkAgent"),
-            CanonicalField::VarBytes(&agent_key.verifying_key().to_bytes()),
+            CanonicalField::U16(0x0000), // IdentityLink = tag 0
+            CanonicalField::VarBytes(human_did.as_bytes()),
+            CanonicalField::VarBytes(agent_did.as_bytes()),
+            CanonicalField::VarBytes(&claim_bytes),
             CanonicalField::Absent, // no evidence
             CanonicalField::U64(1_700_000_000),
-            CanonicalField::U64(0),
+            CanonicalField::Absent, // expires_at: None → Absent per V2 spec
+            CanonicalField::VarBytes(&revocation_active_bytes),
         ],
     );
     let hash: [u8; 32] = Sha256::digest(&attestation_payload).into();
@@ -236,13 +250,39 @@ fn conf_004_agent_binding_attestation() {
     print_step(2, "Sign attestation with human's active key");
     let signature = human_key.sign(&hash);
 
-    print_step(3, "Verify attestation signature");
+    print_step(3, "Verify attestation signature (manual)");
     human_key
         .verifying_key()
         .verify(&hash, &signature)
         .expect("attestation must verify");
 
-    print_step(4, "Verify agent key matches attestation");
+    print_step(
+        4,
+        "Cross-verify: manual canonical bytes match verify_attestation()",
+    );
+    // Build an Attestation struct with the same fields and verify it through
+    // the production verify_attestation() code path. This ensures the manual
+    // canonical construction above matches canonical_attestation_bytes().
+    let attestation = scp_core::trust::Attestation {
+        id: "agent-binding-001".to_owned(),
+        attestation_type: scp_core::trust::AttestationType::IdentityLink,
+        issuer: DID::from(human_did.as_str()),
+        subject: DID::from(agent_did.as_str()),
+        claim,
+        evidence: None,
+        issued_at: 1_700_000_000,
+        expires_at: None,
+        renewal_interval: None,
+        renewed_at: None,
+        revocation_status: scp_core::trust::RevocationStatus::Active,
+        signature: signature.to_bytes().to_vec(),
+    };
+    let resolver = scp_core::trust::IdentityDidPublicKeyResolver;
+    let clock = scp_identity::cache::TestClock::new(1_700_000_000);
+    scp_core::trust::verify_attestation(&attestation, &resolver, &clock)
+        .expect("cross-verification: manual bytes must match canonical_attestation_bytes()");
+
+    print_step(5, "Verify agent key matches attestation");
     let agent_pub = agent_key.verifying_key().to_bytes();
     assert_eq!(agent_pub.len(), 32);
 

--- a/crates/scp-testing/tests/integration/discovery.rs
+++ b/crates/scp-testing/tests/integration/discovery.rs
@@ -14,8 +14,8 @@
 //! configuration, trust level ordering, and handle target variants.
 
 use scp_core::discovery::{
-    BootstrapConfig, DataProvenance, DiscoveryQuery, HandleTarget, ParsedAddress, PetnameMap,
-    RegistrationEntry, TrustLevel, normalize_address, parse_address,
+    BootstrapConfig, BootstrapContextEntry, DataProvenance, DiscoveryQuery, HandleTarget,
+    ParsedAddress, PetnameMap, RegistrationEntry, TrustLevel, normalize_address, parse_address,
 };
 use scp_core::discovery::{
     HandleDeregisterParams, HandleLookupParams, HandleRegisterParams, HandleRegistry,
@@ -394,37 +394,43 @@ async fn did_routing_id_deterministic() {
 }
 
 // ---------------------------------------------------------------------------
-// 16. bootstrap_config: with_defaults, add_custom_context, all_context_ids
+// 16. bootstrap_config: with_defaults, add_custom_context, all_contexts
 // ---------------------------------------------------------------------------
 
 #[tokio::test]
 async fn bootstrap_config() {
     // Default config.
     let default_config = BootstrapConfig::default();
-    assert!(default_config.default_context_ids.is_empty());
-    assert!(default_config.custom_context_ids.is_empty());
+    assert!(default_config.default_contexts.is_empty());
+    assert!(default_config.custom_contexts.is_empty());
     assert!(default_config.should_auto_query());
     assert!(default_config.should_fallback());
 
-    // with_defaults.
+    // with_defaults using BootstrapContextEntry.
     let config = BootstrapConfig::with_defaults(vec![
-        "ctx-discovery-1".to_owned(),
-        "ctx-discovery-2".to_owned(),
-    ]);
-    assert_eq!(config.default_context_ids.len(), 2);
-    assert!(config.custom_context_ids.is_empty());
+        BootstrapContextEntry::new("ctx-discovery-1".to_owned(), DID::from("did:dht:zCreator1")),
+        BootstrapContextEntry::new("ctx-discovery-2".to_owned(), DID::from("did:dht:zCreator2")),
+    ])
+    .unwrap();
+    assert_eq!(config.default_contexts.len(), 2);
+    assert!(config.custom_contexts.is_empty());
 
     // add_custom_context.
     let mut config = config;
-    config.add_custom_context("ctx-custom-1".to_owned());
-    assert_eq!(config.custom_context_ids.len(), 1);
+    config
+        .add_custom_context(BootstrapContextEntry::new(
+            "ctx-custom-1".to_owned(),
+            DID::from("did:dht:zCustom1"),
+        ))
+        .unwrap();
+    assert_eq!(config.custom_contexts.len(), 1);
 
-    // all_context_ids combines defaults and custom.
-    let all = config.all_context_ids();
+    // all_contexts combines defaults and custom.
+    let all = config.all_contexts();
     assert_eq!(all.len(), 3);
-    assert_eq!(*all[0], "ctx-discovery-1");
-    assert_eq!(*all[1], "ctx-discovery-2");
-    assert_eq!(*all[2], "ctx-custom-1");
+    assert_eq!(all[0].context_id, "ctx-discovery-1");
+    assert_eq!(all[1].context_id, "ctx-discovery-2");
+    assert_eq!(all[2].context_id, "ctx-custom-1");
 }
 
 // ---------------------------------------------------------------------------

--- a/crates/scp-testing/tests/integration/trust.rs
+++ b/crates/scp-testing/tests/integration/trust.rs
@@ -164,9 +164,13 @@ fn make_signed_attestation(
     use scp_core::crypto::canonical::{CanonicalField, canonical_hash};
     use scp_core::trust::attestation_type_tag;
 
-    let claim_str = att.claim.to_string();
-    let evidence_bytes = att.evidence.as_ref().map(|e| rmp_serde::to_vec(e).unwrap());
+    let claim_bytes = rmp_serde::to_vec_named(&att.claim).unwrap();
+    let evidence_bytes = att
+        .evidence
+        .as_ref()
+        .map(|e| rmp_serde::to_vec_named(e).unwrap());
     let att_type_tag = attestation_type_tag(&att.attestation_type);
+    let revocation_bytes = rmp_serde::to_vec_named(&att.revocation_status).unwrap();
 
     let canonical = canonical_hash(
         "SCP-ATTESTATION-V1:",
@@ -175,12 +179,14 @@ fn make_signed_attestation(
             CanonicalField::U16(att_type_tag),
             CanonicalField::VarBytes(att.issuer.as_bytes()),
             CanonicalField::VarBytes(att.subject.as_bytes()),
-            CanonicalField::VarBytes(claim_str.as_bytes()),
+            CanonicalField::VarBytes(&claim_bytes),
             evidence_bytes
                 .as_deref()
                 .map_or(CanonicalField::Absent, CanonicalField::VarBytes),
             CanonicalField::U64(att.issued_at),
-            CanonicalField::U64(att.expires_at.unwrap_or(0)),
+            att.expires_at
+                .map_or(CanonicalField::Absent, CanonicalField::U64),
+            CanonicalField::VarBytes(&revocation_bytes),
         ],
     );
     let sig = sk.sign(&canonical);
@@ -349,10 +355,13 @@ async fn attestation_threshold() {
     assert!(result.met, "2-of-3 threshold should be met");
     assert_eq!(result.valid_count, 3);
 
-    // 4-of-3 threshold should NOT be met.
-    let strict_requirement = ThresholdRequirement::new(4, 3, 0.5);
+    // 4-of-5 threshold should NOT be met (only 3 attestors provided).
+    let strict_requirement = ThresholdRequirement::new(4, 5, 0.5);
     let result_strict = check_threshold_attestation(&att_type, &attestors, &strict_requirement);
-    assert!(!result_strict.met, "4-of-3 threshold should not be met");
+    assert!(
+        !result_strict.met,
+        "4-of-5 threshold should not be met with only 3 attestors"
+    );
 }
 
 // ---------------------------------------------------------------------------
@@ -826,11 +835,11 @@ async fn sybil_resistance_evaluation() {
     let casual = ContextSybilPolicy::casual();
     let empty =
         IdentityDepthAssessment::new(did("did:dht:z6MkEmpty"), HashMap::new(), current_time);
-    assert!(evaluate_sybil_resistance(&empty, &casual, current_time).is_ok());
+    assert!(evaluate_sybil_resistance(&empty, &casual, current_time, None).is_ok());
 
     // Standard policy: fails with no signals (min_signal_breadth = 1).
     let standard = ContextSybilPolicy::standard();
-    let err = evaluate_sybil_resistance(&empty, &standard, current_time).unwrap_err();
+    let err = evaluate_sybil_resistance(&empty, &standard, current_time, None).unwrap_err();
     assert!(
         matches!(
             err,
@@ -850,11 +859,11 @@ async fn sybil_resistance_evaluation() {
         ),
     );
     let adequate = IdentityDepthAssessment::new(did("did:dht:z6MkAdequate"), signals, current_time);
-    assert!(evaluate_sybil_resistance(&adequate, &standard, current_time).is_ok());
+    assert!(evaluate_sybil_resistance(&adequate, &standard, current_time, None).is_ok());
 
     // High-trust policy: requires 3+ categories + specific signals.
     let high = ContextSybilPolicy::high_trust();
-    let err2 = evaluate_sybil_resistance(&adequate, &high, current_time).unwrap_err();
+    let err2 = evaluate_sybil_resistance(&adequate, &high, current_time, None).unwrap_err();
     assert!(
         matches!(
             err2,
@@ -868,7 +877,8 @@ async fn sybil_resistance_evaluation() {
         require_device_attestation: true,
         ..ContextSybilPolicy::casual()
     };
-    let err3 = evaluate_sybil_resistance(&adequate, &device_required, current_time).unwrap_err();
+    let err3 =
+        evaluate_sybil_resistance(&adequate, &device_required, current_time, None).unwrap_err();
     assert!(matches!(
         err3,
         scp_core::trust::sybil::SybilResistanceError::DeviceAttestationRequired

--- a/deny.toml
+++ b/deny.toml
@@ -39,6 +39,10 @@ ignore = [
     # instant: unmaintained, transitive dep via openmls -> fluvio-wasm-timer.
     # No alternative available; openmls uses it for WASM time abstraction.
     "RUSTSEC-2024-0384",
+    # aws-lc-sys advisories — upstream hasn't patched yet
+    "RUSTSEC-2026-0044",
+    "RUSTSEC-2026-0048",
+    "RUSTSEC-2026-0049",
 ]
 
 # ── Bans ────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

- **IdentityLinkAttestation** types with canonical signing bytes, `compute_id`, and `validate_structure` (§3.5)
- **RevocationStatus** with `revoked_by` and `reason: String` fields; `AttestationRevocationChecker` trait + `AttestationVerificationCache` with class-based TTLs (§7.4.1)
- **Endorsement independence** wired into sybil evaluation with hardened `ThresholdRequirement` (§22.13.3)
- **BootstrapContextEntry** with `verify_context_creator` for bootstrap context discovery (§22.13)
- **ScpIdentityLinkService** for DID document attestation entries + document methods (scp-identity)
- Shared FFI validation (`validate_attestation_fields` in scp-ffi-common)
- Spec updates for §3.5, §9, §25 test vectors
- Comprehensive tests (unit + integration + conformance + WASM conformance vectors)
- `deny.toml` advisory ignores for aws-lc-sys

### What is NOT in this PR (split to a follow-up):
- FFI bridge attestation functions (PyO3, NAPI, UniFFI, WASM)
- SDK wrappers (Python, TypeScript, Swift, Kotlin)
- WASM reference verification code

Minimal bridge fixes included only where shared common function signatures changed (bridge_id returning Result, discovery_result_to_json returning Result).

## Test plan
- [x] `cargo build --workspace` passes
- [x] `cargo clippy --workspace --all-targets --features ...` passes with zero warnings
- [x] `cargo test --workspace` passes (5,700+ tests, 0 failures)
- [x] `cargo fmt --all -- --check` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)