### PR TITLE
fix(spec): unify attestation-per-DID cap at 64 across all layers

### DIFF
--- a/.docs/specs/03-identity.md
+++ b/.docs/specs/03-identity.md
@@ -267,7 +267,9 @@ Service {
 - `type`: `ScpIdentityLinkAttestation` (constant). Consumers filter DID document services by this type to discover identity link attestations.
 - `serviceEndpoint`: The attestation ID (hex string). Consumers use this to look up the full `IdentityLinkAttestation` from the identity's attestation store (via relay or DHT).
 
-**Maximum attestations per DID document:** 10. This prevents DID document bloat — each service entry adds to the DID document size, which is replicated across resolvers. A user with more than 10 platform identities must choose which 10 to publish. The limit applies to service entries of type `ScpIdentityLinkAttestation` only; other service types have their own limits.
+**Maximum attestations per DID document:** 64. This prevents DID document bloat — each service entry adds to the DID document size, which is replicated across resolvers — while providing enough headroom for users with many platform identities. The limit applies to service entries of type `ScpIdentityLinkAttestation` only; other service types have their own limits.
+
+**Bridge-layer attestation store limit:** Implementations MUST enforce the same 64-attestation-per-DID cap as the DID document layer. This unified limit ensures consistent behavior across all layers — the DID document and the bridge attestation store share a single bound. The constant `MAX_IDENTITY_LINK_ATTESTATIONS_PER_DID` (defined in `scp-ffi-common`) is the single source of truth for all bridge implementations.
 
 **Lifecycle:** When an attestation is revoked, the corresponding service entry MUST be removed from the DID document. When an attestation is renewed (re-verified), the service entry is unchanged — it still points to the same attestation ID. When an attestation is replaced (new attestation for the same platform+handle), the service entry's `serviceEndpoint` is updated to the new attestation ID.
 

--- a/crates/scp-ffi/common/src/validate.rs
+++ b/crates/scp-ffi/common/src/validate.rs
@@ -100,6 +100,13 @@ pub const MAX_ATTESTATION_HANDLE_LEN: usize = 256;
 /// Maximum length for an attestation proof JSON string.
 pub const MAX_ATTESTATION_PROOF_LEN: usize = 65_536;
 
+/// Maximum number of identity link attestations per DID (spec §3.5.3).
+///
+/// Unified across the DID document layer (`scp-identity`) and all FFI bridge
+/// attestation stores. A single constant ensures consistent enforcement
+/// everywhere — no divergent limits.
+pub const MAX_IDENTITY_LINK_ATTESTATIONS_PER_DID: usize = 64;
+
 // ---------------------------------------------------------------------------
 // String emptiness and length
 // ---------------------------------------------------------------------------

--- a/crates/scp-ffi/napi/src/identity.rs
+++ b/crates/scp-ffi/napi/src/identity.rs
@@ -52,9 +52,8 @@ use scp_platform::traits::KeyCustody;
 use crate::error::{ScpNapiError, validate_custody_type};
 use crate::{decrement_handle_count, increment_handle_count};
 
-/// Maximum number of identity link attestations per DID in the NAPI bridge.
 #[cfg(feature = "allow_in_memory_custody")]
-const NAPI_LINK_ATTESTATION_PER_DID_CAP: usize = 1_000;
+use scp_ffi_common::validate::MAX_IDENTITY_LINK_ATTESTATIONS_PER_DID;
 
 /// Ensures the global production DID resolver is initialized (idempotent). #311
 ///
@@ -1502,11 +1501,11 @@ pub async fn identity_create_link_attestation(
             });
         }
 
-        if entry.identity_link_attestations.len() >= NAPI_LINK_ATTESTATION_PER_DID_CAP {
+        if entry.identity_link_attestations.len() >= MAX_IDENTITY_LINK_ATTESTATIONS_PER_DID {
             return Err(ScpNapiError::Identity {
                 message: format!(
                     "DID has reached the per-identity attestation limit \
-                     ({NAPI_LINK_ATTESTATION_PER_DID_CAP}) — cannot store additional attestations"
+                     ({MAX_IDENTITY_LINK_ATTESTATIONS_PER_DID}) — cannot store additional attestations"
                 ),
                 code: "SCP-VALID-7403".to_owned(),
             });

--- a/crates/scp-ffi/src/identity.rs
+++ b/crates/scp-ffi/src/identity.rs
@@ -52,8 +52,7 @@ use crate::error::ScpPyError;
 use crate::runtime::IdentityEntry;
 use crate::validate;
 
-/// Maximum number of identity link attestations per DID in the `PyO3` bridge.
-const PYO3_LINK_ATTESTATION_PER_DID_CAP: usize = 1_000;
+use scp_ffi_common::validate::MAX_IDENTITY_LINK_ATTESTATIONS_PER_DID;
 
 /// Ensures the global production DID resolver is initialized.
 ///
@@ -1361,10 +1360,10 @@ fn py_create_identity_link_attestation(
                 ));
             }
 
-            if entry.identity_link_attestations.len() >= PYO3_LINK_ATTESTATION_PER_DID_CAP {
+            if entry.identity_link_attestations.len() >= MAX_IDENTITY_LINK_ATTESTATIONS_PER_DID {
                 return Err(ScpPyError::validation(format!(
                     "DID has reached the per-identity attestation limit \
-                     ({PYO3_LINK_ATTESTATION_PER_DID_CAP}) — cannot store additional attestations"
+                     ({MAX_IDENTITY_LINK_ATTESTATIONS_PER_DID}) — cannot store additional attestations"
                 )));
             }
             entry.identity_link_attestations.push(attestation.clone());

--- a/crates/scp-ffi/uniffi/src/bridge.rs
+++ b/crates/scp-ffi/uniffi/src/bridge.rs
@@ -2401,9 +2401,8 @@ const UNIFFI_CUSTODY_REGISTRY_CAP: usize = 10_000;
 #[cfg(feature = "allow_in_memory_custody")]
 const UNIFFI_LINK_ATTESTATION_REGISTRY_CAP: usize = 10_000;
 
-/// Maximum number of attestations per DID in the identity link attestation registry.
 #[cfg(feature = "allow_in_memory_custody")]
-const UNIFFI_LINK_ATTESTATION_PER_DID_CAP: usize = 1_000;
+use scp_ffi_common::validate::MAX_IDENTITY_LINK_ATTESTATIONS_PER_DID;
 
 /// Global registry of identity link attestations, keyed by DID string.
 fn identity_link_attestation_registry()
@@ -2611,11 +2610,11 @@ async fn identity_create_link_attestation_impl(
         let len = registry.len();
         match registry.entry(did_str) {
             dashmap::mapref::entry::Entry::Occupied(mut occ) => {
-                if occ.get().len() >= UNIFFI_LINK_ATTESTATION_PER_DID_CAP {
+                if occ.get().len() >= MAX_IDENTITY_LINK_ATTESTATIONS_PER_DID {
                     return Err(ScpError::Identity {
                         msg: format!(
                             "DID has reached the per-identity attestation limit \
-                             ({UNIFFI_LINK_ATTESTATION_PER_DID_CAP}) — cannot store additional attestations"
+                             ({MAX_IDENTITY_LINK_ATTESTATIONS_PER_DID}) — cannot store additional attestations"
                         ),
                         code: "SCP-VALID-7403".to_owned(),
                     });

--- a/crates/scp-ffi/wasm/src/identity.rs
+++ b/crates/scp-ffi/wasm/src/identity.rs
@@ -237,8 +237,7 @@ const WASM_MIGRATION_LINKS_CAP: usize = 10_000;
 /// WASM-local attestation registry.
 const WASM_LINK_ATTESTATIONS_CAP: usize = 1_000;
 
-/// Maximum number of attestations per DID in the WASM-local attestation registry.
-const WASM_LINK_ATTESTATIONS_PER_DID_CAP: usize = 1_000;
+use scp_ffi_common::validate::MAX_IDENTITY_LINK_ATTESTATIONS_PER_DID;
 
 thread_local! {
     /// Maps DID strings to identity state. WASM is single-threaded, so
@@ -2112,12 +2111,12 @@ pub fn identity_create_link_attestation(
                 "SCP-VALID-7402",
             )?;
             let entry = map.entry(did).or_default();
-            if entry.len() >= WASM_LINK_ATTESTATIONS_PER_DID_CAP {
+            if entry.len() >= MAX_IDENTITY_LINK_ATTESTATIONS_PER_DID {
                 return Err(JsValue::from(
                     ScpWasmError::Validation {
                         message: format!(
                             "DID has reached the per-identity attestation limit \
-                             ({WASM_LINK_ATTESTATIONS_PER_DID_CAP}) — cannot store additional attestations"
+                             ({MAX_IDENTITY_LINK_ATTESTATIONS_PER_DID}) — cannot store additional attestations"
                         ),
                         code: "SCP-VALID-7403".to_owned(),
                     }

--- a/crates/scp-identity/src/document.rs
+++ b/crates/scp-identity/src/document.rs
@@ -205,7 +205,8 @@ const MAX_RETIRED_AGENT_KEYS: usize = 2;
 const IDENTITY_LINK_ATTESTATION_SERVICE_TYPE: &str = "ScpIdentityLinkAttestation";
 
 /// Maximum number of identity link attestation service entries per DID document (§3.5.3).
-const MAX_IDENTITY_LINK_ATTESTATIONS: usize = 10;
+/// Unified at 64 across the DID document layer and all FFI bridge attestation stores.
+const MAX_IDENTITY_LINK_ATTESTATIONS: usize = 64;
 
 impl DidDocument {
     /// Constructs a new DID Document for an SCP identity.
@@ -2274,17 +2275,17 @@ mod tests {
     fn identity_link_max_limit_enforced() {
         let mut doc = DidDocument::new("did:dht:zIdLink8", &[1u8; 32], &[2u8; 32], &[3u8; 32]);
 
-        // Add 10 entries (the maximum).
-        for i in 0..10 {
+        // Add 64 entries (the maximum).
+        for i in 0..64 {
             doc.set_identity_link_attestation(&format!("platform-{i}.com"), &format!("attest-{i}"))
                 .unwrap();
         }
-        assert_eq!(doc.identity_link_attestation_count(), 10);
+        assert_eq!(doc.identity_link_attestation_count(), 64);
 
-        // The 11th should fail.
-        let result = doc.set_identity_link_attestation("one-too-many.com", "attest-10");
+        // The 65th should fail.
+        let result = doc.set_identity_link_attestation("one-too-many.com", "attest-64");
         assert!(result.is_err());
-        assert!(result.unwrap_err().to_string().contains("maximum of 10"));
+        assert!(result.unwrap_err().to_string().contains("maximum of 64"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Raises the DID document attestation service entry cap from **10 → 64** (covers all 16 platforms with multi-account headroom, ~10KB — well within 256KB blob limit)
- Replaces 4 independent bridge-layer 1,000-entry store caps with a single shared constant `MAX_IDENTITY_LINK_ATTESTATIONS_PER_DID = 64` in `scp-ffi-common`
- Updates spec §3.5.3, `scp-identity` document enforcement, all 4 bridges, and the limit test

The two-tier system (10 doc / 1,000 store) was redundant — you can't present more attestations than the document holds, so the store cap was pointless. Unified to one number everywhere.

Dropped from #1416 due to auto-merge timing.

## Test plan

- [ ] `cargo test -p scp-identity` — `identity_link_max_limit_enforced` passes at 64
- [ ] `cargo check` for all 4 bridges + WASM target
- [ ] Full CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)