### PR TITLE
docs(adr): amend ADR-034 Alternative #2 — extraction boundary now viable

### DIFF
--- a/.docs/adrs/phase-4.md
+++ b/.docs/adrs/phase-4.md
@@ -1436,6 +1436,8 @@ The re-implementation is NOT a fork — it is a second implementation of the sam
 
 2. **Extracting `scp-core-portable`.** A hypothetical refactoring that strips scp-core into a platform-agnostic core with no tokio or OpenMLS dependency. The remaining functionality would be too thin to be useful — most protocol logic requires crypto and async I/O. Rejected because the extraction boundary does not exist at a useful abstraction layer.
 
+   **Update (2026-03-21):** The "too thin to be useful" rationale is now empirically false. Dependency traces (4 agents, 2026-03-18) confirmed ~92K lines of pure sync protocol logic in scp-core (trust, governance, UCAN validation, envelope verification, provenance, capability matching, discovery registries, economy policy, sync algorithms) with zero tokio, zero async, zero OpenMLS, and zero scp-platform dependencies — roughly 47% of scp-core's 195K total lines. The extraction boundary became viable as scp-core grew from its original size to its current scale. See #1446 for the detailed extraction plan (`scp-protocol` + `scp-runtime`). The core ADR-034 decision (WASM bridge as separate re-implementation) remains correct and unchanged; this alternative is now viable but has not yet been executed.
+
 3. **Emscripten compilation.** Emscripten can compile C/C++ dependencies (ring, OpenMLS's C backend) to WASM, but produces significantly larger binaries, requires manual JavaScript glue, and does not integrate with wasm-bindgen's type system. Rejected because it trades one set of problems for a worse set.
 
 ### Risk Profile


### PR DESCRIPTION
## Summary
- Amends ADR-034 Alternative #2 ("Extracting scp-core-portable") with an update paragraph acknowledging that the extraction boundary is now empirically viable
- ~92K lines of pure sync protocol logic confirmed with zero tokio/async/OpenMLS/scp-platform dependencies
- Core ADR-034 decision (WASM bridge as separate re-implementation) remains unchanged

Prerequisite for #1446.

Part of #1446 — ADR amendment only

## Test plan
- [ ] Verify paragraph follows the established `**Update (date):**` convention
- [ ] Verify no other ADR-034 sections were modified

🤖 Generated with [Claude Code](https://claude.com/claude-code)