### PR TITLE
ci: add pipeline_wiring assertions for wiring sprint

### DIFF
--- a/.claude/plans/scp-protocol-agent1-prompt.md
+++ b/.claude/plans/scp-protocol-agent1-prompt.md
@@ -1,0 +1,687 @@
+# Agent 1 Prompt: Create scp-protocol + scp-runtime + scp-core facade
+
+## Task
+
+Three-crate extraction from the current scp-core monolith:
+1. Create `scp-protocol` — pure sync protocol types (~82K lines)
+2. Rename current `scp-core` to `scp-runtime` — keeps async orchestration
+3. Create NEW `scp-core` — facade with explicit wrapper modules merging both crates
+
+Do NOT attempt to compile — Agent 2 handles compilation fixes.
+
+**Execute phases in strict order: A → B → C → D → E → F → G → H → I.**
+Phase B must complete before Phase C (the `git mv` frees the `crates/scp-core` path for the new facade).
+
+## Branch: `refactor/scp-protocol-extraction`
+
+Create from latest main.
+
+---
+
+## Phase A: Create scp-protocol crate
+
+1. Add `"crates/scp-protocol"` to workspace `Cargo.toml` members list
+
+2. Create `crates/scp-protocol/Cargo.toml`:
+
+```toml
+[package]
+name = "scp-protocol"
+version = "0.1.0-beta.1"
+description = "Pure sync protocol types and logic for SCP"
+edition.workspace = true
+repository.workspace = true
+license.workspace = true
+homepage.workspace = true
+
+[dependencies]
+scp-primitives = { path = "../scp-primitives", version = "=0.1.0-beta.1" }
+scp-event-log = { path = "../scp-event-log", version = "=0.1.0-beta.1" }
+serde = { workspace = true }
+serde_json = { workspace = true }
+serde_json_canonicalizer = { workspace = true }
+serde_bytes = { workspace = true }
+rmp-serde = { workspace = true }
+rmpv = { workspace = true }
+thiserror = { workspace = true }
+sha2 = { workspace = true }
+ed25519-dalek = { workspace = true }
+x25519-dalek = { workspace = true }
+hkdf = { workspace = true }
+aes = { workspace = true }
+aes-gcm = { workspace = true }
+rand = { workspace = true }
+hex = { workspace = true }
+base64 = { workspace = true }
+bs58 = { workspace = true }
+uuid = { workspace = true }
+zeroize = { workspace = true }
+subtle = { workspace = true }
+tracing = { workspace = true }
+percent-encoding = { workspace = true }
+unicode-normalization = { workspace = true }
+jsonschema = { version = "0.28", default-features = false }
+metrics = { workspace = true }
+lru = { workspace = true }
+
+[dev-dependencies]
+serde_json = { workspace = true }
+rmp-serde = { workspace = true }
+proptest = "1"
+# dev-only: some #[cfg(test)] blocks extracted from scp-core use async test infrastructure.
+# These do NOT affect the production crate — scp-protocol has zero async in production code.
+tokio = { workspace = true, features = ["macros", "rt-multi-thread", "test-util"] }
+scp-primitives = { path = "../scp-primitives" }
+scp-platform = { path = "../scp-platform", features = ["testing"] }
+scp-event-log = { path = "../scp-event-log", features = ["testing"] }
+
+[lints]
+workspace = true
+```
+
+---
+
+## Phase B: Rename scp-core to scp-runtime
+
+1. In `crates/scp-core/Cargo.toml`, change `name = "scp-core"` to `name = "scp-runtime"`
+2. In workspace `Cargo.toml`, change `"crates/scp-core"` member to `"crates/scp-runtime"`
+3. `git mv crates/scp-core crates/scp-runtime`
+4. Add `scp-protocol` dependency to `crates/scp-runtime/Cargo.toml`:
+   ```toml
+   scp-protocol = { path = "../scp-protocol", version = "=0.1.0-beta.1" }
+   ```
+
+---
+
+## Phase C: Create new scp-core facade
+
+1. Add `"crates/scp-core"` back to workspace `Cargo.toml` members
+2. Create `crates/scp-core/Cargo.toml`:
+
+```toml
+[package]
+name = "scp-core"
+version = "0.1.0-beta.1"
+description = "SCP protocol + runtime — unified API surface"
+edition.workspace = true
+repository.workspace = true
+license.workspace = true
+homepage.workspace = true
+
+[dependencies]
+scp-protocol = { path = "../scp-protocol", version = "=0.1.0-beta.1" }
+scp-runtime = { path = "../scp-runtime", version = "=0.1.0-beta.1" }
+
+[features]
+testing = ["scp-runtime/testing"]
+allow_unencrypted_storage = ["scp-runtime/allow_unencrypted_storage"]
+allow_in_memory_custody = ["scp-runtime/allow_in_memory_custody"]
+
+[dev-dependencies]
+serde_json = { workspace = true }
+
+[lints]
+workspace = true
+```
+
+3. Create `crates/scp-core/src/lib.rs` with **explicit wrapper modules**.
+
+The facade merges sub-modules from both crates by name. Within each wrapper, re-export
+sub-modules EXPLICITLY (not `pub use *`) to avoid hidden name conflicts:
+
+```rust
+//! SCP protocol + runtime — unified API surface.
+//!
+//! Merges [`scp_protocol`] (pure sync types) and [`scp_runtime`] (async
+//! orchestration) into a single namespace. Downstream crates depend on
+//! `scp-core` alone.
+//!
+//! MAINTENANCE: When adding a public module to scp-protocol or scp-runtime,
+//! add the corresponding re-export here. The CI check and structural test
+//! in tests/facade_completeness.rs will catch omissions.
+
+// --- Modules that exist ONLY in scp-protocol (no conflict) ---
+pub use scp_protocol::jcs;
+pub use scp_protocol::serde_util;
+pub use scp_protocol::time;
+pub use scp_protocol::uri;
+
+// --- Modules that exist ONLY in scp-runtime (no conflict) ---
+pub use scp_runtime::store;
+pub use scp_runtime::event_log;
+pub use scp_runtime::metrics;
+pub use scp_runtime::well_known;
+
+// --- Modules split across both crates (explicit sub-module merging) ---
+
+pub mod crypto {
+    // From scp-protocol (pure):
+    pub use scp_protocol::crypto::canonical;
+    pub use scp_protocol::crypto::ed25519;
+    pub use scp_protocol::crypto::tofu;
+    pub use scp_protocol::crypto::key_continuity;
+    pub use scp_protocol::crypto::envelope_seal;
+    // From scp-runtime (async):
+    pub use scp_runtime::crypto::mls;
+    // Split sub-modules (disjoint children merged):
+    pub mod sender_keys {
+        // Protocol: SenderKey types, encrypt, key_protocol_verify, broadcast
+        pub use scp_protocol::crypto::sender_keys::*;
+        // Runtime: key_protocol (async signing)
+        pub use scp_runtime::crypto::sender_keys::key_protocol;
+    }
+    pub mod access_keys {
+        // Protocol: AccessKey types, wrapping
+        pub use scp_protocol::crypto::access_keys::*;
+        // Runtime: lifecycle, wire (async)
+        pub use scp_runtime::crypto::access_keys::lifecycle;
+        pub use scp_runtime::crypto::access_keys::wire;
+    }
+    pub mod ucan {
+        // Protocol: UcanError/Token types, validate, capability, nonce, revoke, spending
+        pub use scp_protocol::crypto::ucan::*;
+        // Runtime: mint (async signing)
+        pub use scp_runtime::crypto::ucan::mint;
+    }
+}
+
+pub mod context {
+    // Protocol: ContextState, ContextError, context_id_bytes, params, roles, etc.
+    pub use scp_protocol::context::*;
+    // Runtime: ContextHandle, manager, builder, providers, ttl, etc.
+    pub use scp_runtime::context::manager;
+    pub use scp_runtime::context::builder;
+    pub use scp_runtime::context::providers;
+    pub use scp_runtime::context::ttl;
+    pub use scp_runtime::context::export_import;
+    pub use scp_runtime::context::standing;
+    pub use scp_runtime::context::app_sandbox;
+    pub use scp_runtime::context::policy;
+    // Split sub-modules:
+    pub mod governance {
+        pub use scp_protocol::context::governance::*;
+        pub use scp_runtime::context::governance::timeout;
+    }
+    pub mod tools {
+        pub use scp_protocol::context::tools::*;
+        pub use scp_runtime::context::tools::invoke;
+        pub use scp_runtime::context::tools::session;
+    }
+}
+
+pub mod trust {
+    pub use scp_protocol::trust::*;
+    // Runtime: only ProtocolRepositoryTrustBridge (NOT glob — avoid duplicate re-exports)
+    pub use scp_runtime::trust::ProtocolRepositoryTrustBridge;
+}
+
+pub mod identity {
+    pub use scp_protocol::identity::*;
+    // Runtime: blocking, recovery, custody_migration, scpid
+    pub use scp_runtime::identity::blocking;
+    pub use scp_runtime::identity::recovery;
+    pub use scp_runtime::identity::custody_migration;
+    pub use scp_runtime::identity::scpid;
+}
+
+pub mod economy {
+    pub use scp_protocol::economy::*;
+    // Runtime: credentials, integration, adapter, receipt
+    pub use scp_runtime::economy::credentials;
+    pub use scp_runtime::economy::integration;
+    pub use scp_runtime::economy::adapter;
+    pub use scp_runtime::economy::receipt;
+}
+
+pub mod discovery {
+    pub use scp_protocol::discovery::*;
+    // Runtime: addressing, search, did_capabilities, bootstrap, dht_context
+    pub use scp_runtime::discovery::addressing;
+    pub use scp_runtime::discovery::search;
+    pub use scp_runtime::discovery::did_capabilities;
+    pub use scp_runtime::discovery::bootstrap;
+    pub use scp_runtime::discovery::dht_context;
+}
+
+pub mod envelope {
+    pub use scp_protocol::envelope::*;
+    // Runtime: pseudonym (async)
+    pub use scp_runtime::envelope::pseudonym;
+    // Split sub-modules:
+    pub mod inner {
+        pub use scp_protocol::envelope::inner::*;
+        pub use scp_runtime::envelope::inner::sign;
+    }
+    pub mod outer {
+        pub use scp_protocol::envelope::outer::*;
+        pub use scp_runtime::envelope::outer::ops;
+    }
+}
+
+pub mod sync {
+    pub use scp_protocol::sync::*;
+    // Runtime: days_offline, hours_offline, weeks_offline
+    pub use scp_runtime::sync::days_offline;
+    pub use scp_runtime::sync::hours_offline;
+    pub use scp_runtime::sync::weeks_offline;
+}
+
+pub mod bridge {
+    pub use scp_protocol::bridge::*;
+    // Runtime: oauth, credentials
+    pub use scp_runtime::bridge::oauth;
+    pub use scp_runtime::bridge::credentials;
+}
+
+pub mod provenance {
+    pub use scp_protocol::provenance::*;
+}
+```
+
+NOTE: Protocol side uses `pub use *` within wrappers (safe — scp-protocol exports only pure
+sub-modules with no name conflicts). Runtime side uses EXPLICIT sub-module names (safe —
+we know exactly what stays). If a protocol-side `pub use *` ever conflicts with a runtime
+sub-module name, the compiler will catch it immediately.
+
+---
+
+## Phase D: Move files from scp-runtime to scp-protocol
+
+All source paths are now under `crates/scp-runtime/src/`.
+
+Create destination directories:
+```bash
+mkdir -p crates/scp-protocol/src/{crypto/{sender_keys,access_keys,ucan},context/{governance,tools},trust,identity,economy,discovery,envelope/{inner,outer},sync,bridge,provenance}
+```
+
+### File moves:
+
+**Leaf utilities:**
+```bash
+git mv crates/scp-runtime/src/jcs.rs crates/scp-protocol/src/jcs.rs
+git mv crates/scp-runtime/src/serde_util.rs crates/scp-protocol/src/serde_util.rs
+git mv crates/scp-runtime/src/time.rs crates/scp-protocol/src/time.rs
+git mv crates/scp-runtime/src/uri.rs crates/scp-protocol/src/uri.rs
+```
+
+**Crypto primitives:**
+```bash
+git mv crates/scp-runtime/src/crypto/canonical.rs crates/scp-protocol/src/crypto/canonical.rs
+git mv crates/scp-runtime/src/crypto/ed25519.rs crates/scp-protocol/src/crypto/ed25519.rs
+git mv crates/scp-runtime/src/crypto/tofu.rs crates/scp-protocol/src/crypto/tofu.rs
+git mv crates/scp-runtime/src/crypto/key_continuity.rs crates/scp-protocol/src/crypto/key_continuity.rs
+git mv crates/scp-runtime/src/crypto/bip39_wordlist.rs crates/scp-protocol/src/crypto/bip39_wordlist.rs
+git mv crates/scp-runtime/src/crypto/envelope_seal.rs crates/scp-protocol/src/crypto/envelope_seal.rs
+```
+
+**Sender keys (pure parts):**
+```bash
+git mv crates/scp-runtime/src/crypto/sender_keys/encrypt.rs crates/scp-protocol/src/crypto/sender_keys/encrypt.rs
+git mv crates/scp-runtime/src/crypto/sender_keys/key_protocol_verify.rs crates/scp-protocol/src/crypto/sender_keys/key_protocol_verify.rs
+git mv crates/scp-runtime/src/crypto/sender_keys/broadcast.rs crates/scp-protocol/src/crypto/sender_keys/broadcast.rs
+```
+
+**Access keys (pure parts):**
+```bash
+git mv crates/scp-runtime/src/crypto/access_keys/wrapping.rs crates/scp-protocol/src/crypto/access_keys/wrapping.rs
+```
+
+**UCAN (pure parts — NOT mint.rs):**
+```bash
+git mv crates/scp-runtime/src/crypto/ucan/capability.rs crates/scp-protocol/src/crypto/ucan/capability.rs
+git mv crates/scp-runtime/src/crypto/ucan/nonce.rs crates/scp-protocol/src/crypto/ucan/nonce.rs
+git mv crates/scp-runtime/src/crypto/ucan/revoke.rs crates/scp-protocol/src/crypto/ucan/revoke.rs
+git mv crates/scp-runtime/src/crypto/ucan/spending.rs crates/scp-protocol/src/crypto/ucan/spending.rs
+git mv crates/scp-runtime/src/crypto/ucan/validate.rs crates/scp-protocol/src/crypto/ucan/validate.rs
+```
+
+**Trust (all files):**
+```bash
+git mv crates/scp-runtime/src/trust/custody_violation.rs crates/scp-protocol/src/trust/custody_violation.rs
+git mv crates/scp-runtime/src/trust/admission.rs crates/scp-protocol/src/trust/admission.rs
+git mv crates/scp-runtime/src/trust/aggregate.rs crates/scp-protocol/src/trust/aggregate.rs
+git mv crates/scp-runtime/src/trust/attestation.rs crates/scp-protocol/src/trust/attestation.rs
+git mv crates/scp-runtime/src/trust/capability_registry.rs crates/scp-protocol/src/trust/capability_registry.rs
+git mv crates/scp-runtime/src/trust/capability_uri.rs crates/scp-protocol/src/trust/capability_uri.rs
+git mv crates/scp-runtime/src/trust/challenge.rs crates/scp-protocol/src/trust/challenge.rs
+git mv crates/scp-runtime/src/trust/consequence.rs crates/scp-protocol/src/trust/consequence.rs
+git mv crates/scp-runtime/src/trust/participation.rs crates/scp-protocol/src/trust/participation.rs
+git mv crates/scp-runtime/src/trust/renewal.rs crates/scp-protocol/src/trust/renewal.rs
+git mv crates/scp-runtime/src/trust/sybil.rs crates/scp-protocol/src/trust/sybil.rs
+```
+
+**Context types (NOT policy.rs — async):**
+```bash
+git mv crates/scp-runtime/src/context/params.rs crates/scp-protocol/src/context/params.rs
+git mv crates/scp-runtime/src/context/state_machine.rs crates/scp-protocol/src/context/state_machine.rs
+git mv crates/scp-runtime/src/context/roles.rs crates/scp-protocol/src/context/roles.rs
+git mv crates/scp-runtime/src/context/membership.rs crates/scp-protocol/src/context/membership.rs
+git mv crates/scp-runtime/src/context/memory_scope.rs crates/scp-protocol/src/context/memory_scope.rs
+git mv crates/scp-runtime/src/context/metadata.rs crates/scp-protocol/src/context/metadata.rs
+git mv crates/scp-runtime/src/context/templates.rs crates/scp-protocol/src/context/templates.rs
+git mv crates/scp-runtime/src/context/close.rs crates/scp-protocol/src/context/close.rs
+git mv crates/scp-runtime/src/context/nesting.rs crates/scp-protocol/src/context/nesting.rs
+git mv crates/scp-runtime/src/context/invitation.rs crates/scp-protocol/src/context/invitation.rs
+git mv crates/scp-runtime/src/context/promotion.rs crates/scp-protocol/src/context/promotion.rs
+git mv crates/scp-runtime/src/context/broadcast.rs crates/scp-protocol/src/context/broadcast.rs
+git mv crates/scp-runtime/src/context/broadcast_content.rs crates/scp-protocol/src/context/broadcast_content.rs
+```
+
+**Identity pure parts:**
+```bash
+git mv crates/scp-runtime/src/identity/block_list.rs crates/scp-protocol/src/identity/block_list.rs
+git mv crates/scp-runtime/src/identity/private_state.rs crates/scp-protocol/src/identity/private_state.rs
+git mv crates/scp-runtime/src/identity/private_state_events.rs crates/scp-protocol/src/identity/private_state_events.rs
+git mv crates/scp-runtime/src/identity/attestation.rs crates/scp-protocol/src/identity/attestation.rs
+```
+
+**Governance (pure parts — NOT timeout.rs):**
+```bash
+git mv crates/scp-runtime/src/context/governance/majority.rs crates/scp-protocol/src/context/governance/majority.rs
+git mv crates/scp-runtime/src/context/governance/multisig.rs crates/scp-protocol/src/context/governance/multisig.rs
+git mv crates/scp-runtime/src/context/governance/unanimity.rs crates/scp-protocol/src/context/governance/unanimity.rs
+git mv crates/scp-runtime/src/context/governance/mls_integration.rs crates/scp-protocol/src/context/governance/mls_integration.rs
+```
+
+**Context tools (pure parts — NOT invoke.rs, session.rs. YES interface.rs — it IS pure):**
+```bash
+git mv crates/scp-runtime/src/context/tools/integrity.rs crates/scp-protocol/src/context/tools/integrity.rs
+git mv crates/scp-runtime/src/context/tools/lifecycle.rs crates/scp-protocol/src/context/tools/lifecycle.rs
+git mv crates/scp-runtime/src/context/tools/registry.rs crates/scp-protocol/src/context/tools/registry.rs
+git mv crates/scp-runtime/src/context/tools/schema.rs crates/scp-protocol/src/context/tools/schema.rs
+git mv crates/scp-runtime/src/context/tools/summary.rs crates/scp-protocol/src/context/tools/summary.rs
+git mv crates/scp-runtime/src/context/tools/interface.rs crates/scp-protocol/src/context/tools/interface.rs
+```
+
+**Economy (pure parts — NOT credentials.rs, integration.rs, adapter.rs, receipt.rs):**
+```bash
+git mv crates/scp-runtime/src/economy/types.rs crates/scp-protocol/src/economy/types.rs
+git mv crates/scp-runtime/src/economy/policy.rs crates/scp-protocol/src/economy/policy.rs
+git mv crates/scp-runtime/src/economy/budget.rs crates/scp-protocol/src/economy/budget.rs
+git mv crates/scp-runtime/src/economy/pricing.rs crates/scp-protocol/src/economy/pricing.rs
+git mv crates/scp-runtime/src/economy/estimate.rs crates/scp-protocol/src/economy/estimate.rs
+git mv crates/scp-runtime/src/economy/antispam.rs crates/scp-protocol/src/economy/antispam.rs
+```
+
+**Discovery (pure parts only):**
+```bash
+git mv crates/scp-runtime/src/discovery/handles.rs crates/scp-protocol/src/discovery/handles.rs
+git mv crates/scp-runtime/src/discovery/petnames.rs crates/scp-protocol/src/discovery/petnames.rs
+git mv crates/scp-runtime/src/discovery/scope.rs crates/scp-protocol/src/discovery/scope.rs
+git mv crates/scp-runtime/src/discovery/context.rs crates/scp-protocol/src/discovery/context.rs
+git mv crates/scp-runtime/src/discovery/push.rs crates/scp-protocol/src/discovery/push.rs
+```
+
+**Envelope (pure parts — NOT pseudonym.rs, NOT sign.rs, NOT ops.rs):**
+```bash
+git mv crates/scp-runtime/src/envelope/inner/mod.rs crates/scp-protocol/src/envelope/inner/mod.rs
+git mv crates/scp-runtime/src/envelope/outer/mod.rs crates/scp-protocol/src/envelope/outer/mod.rs
+git mv crates/scp-runtime/src/envelope/chunk.rs crates/scp-protocol/src/envelope/chunk.rs
+git mv crates/scp-runtime/src/envelope/padding.rs crates/scp-protocol/src/envelope/padding.rs
+git mv crates/scp-runtime/src/envelope/validation.rs crates/scp-protocol/src/envelope/validation.rs
+```
+
+**Sync (pure parts):**
+```bash
+git mv crates/scp-runtime/src/sync/alerts.rs crates/scp-protocol/src/sync/alerts.rs
+git mv crates/scp-runtime/src/sync/conflict_resolution.rs crates/scp-protocol/src/sync/conflict_resolution.rs
+```
+
+**Bridge types (NOT oauth.rs, NOT credentials.rs):**
+```bash
+git mv crates/scp-runtime/src/bridge/claiming.rs crates/scp-protocol/src/bridge/claiming.rs
+git mv crates/scp-runtime/src/bridge/envelope.rs crates/scp-protocol/src/bridge/envelope.rs
+git mv crates/scp-runtime/src/bridge/provenance.rs crates/scp-protocol/src/bridge/provenance.rs
+git mv crates/scp-runtime/src/bridge/registration.rs crates/scp-protocol/src/bridge/registration.rs
+git mv crates/scp-runtime/src/bridge/shadow.rs crates/scp-protocol/src/bridge/shadow.rs
+```
+
+**Provenance:**
+```bash
+git mv crates/scp-runtime/src/provenance/attach.rs crates/scp-protocol/src/provenance/attach.rs
+git mv crates/scp-runtime/src/provenance/evaluate.rs crates/scp-protocol/src/provenance/evaluate.rs
+```
+
+---
+
+## Phase E: Create scp-protocol module tree + split mod.rs files
+
+For each module, READ the scp-runtime mod.rs IN FULL, then:
+1. CREATE scp-protocol mod.rs with pure types + pure submodule declarations
+2. EDIT scp-runtime mod.rs to REMOVE moved types, keep ONLY async submodule declarations
+
+**SCOPING RULE for scp-protocol mod.rs files:**
+Declare sub-modules as `pub mod X;` (keeping items scoped to `module::X::Item`).
+Do NOT flatten with `pub use self::X::*;`. Flattening would cause name collisions in the
+facade's `pub use scp_protocol::context::*` when scp-runtime adds explicit sub-modules.
+
+**RE-EXPORT RULE for scp-runtime mod.rs files:**
+scp-runtime mod.rs files must NOT re-export scp-protocol types (no `pub use scp_protocol::*;`).
+Only declare their own async sub-modules. The scp-core facade handles merging — if scp-runtime
+also re-exports, types appear via two paths, which is fragile and confusing.
+Exception: envelope inner/outer mod.rs stubs (below) re-export for sign.rs/ops.rs internal use.
+
+**CRITICAL for moved inner/mod.rs and outer/mod.rs:**
+After moving these files, REMOVE `pub mod sign;` from the moved `inner/mod.rs` and `pub mod ops;` from the moved `outer/mod.rs` (those files stay in scp-runtime). Then create NEW mod.rs stubs in scp-runtime:
+
+`crates/scp-runtime/src/envelope/inner/mod.rs`:
+```rust
+pub use scp_protocol::envelope::inner::*;
+pub mod sign;
+```
+
+`crates/scp-runtime/src/envelope/outer/mod.rs`:
+```rust
+pub use scp_protocol::envelope::outer::*;
+pub mod ops;
+```
+
+### The 15 mod.rs files to split:
+
+1. `context/mod.rs` — Pure: ContextState, ContextError, context_id_bytes(). Stays: ContextHandle (tokio::RwLock), builder, manager, providers, ttl, export_import, standing, app_sandbox, policy.
+   **NOTE:** ContextError::IntegrationFailed embeds IntegrationError from economy/integration.rs (stays). Agent 2 must handle this — either move IntegrationError or restructure.
+2. `trust/mod.rs` — Pure: all trust types. Stays: `pub use crate::store::trust::ProtocolRepositoryTrustBridge;`
+   **NOTE:** `participation` module is `pub(crate)` — promote to `pub` in scp-protocol.
+3. `crypto/mod.rs` — Pure: re-exports of pure crypto modules. Stays: `pub mod mls;`, agent_binding_tests.
+4. `crypto/ucan/mod.rs` — Pure: UcanError, UcanToken, UcanHeader, UcanPayload, Attenuation types. Stays: `pub mod mint;`
+5. `crypto/sender_keys/mod.rs` — Pure: SenderKey, SenderKeyStore, SenderKeyError, generate_sender_key. Stays: `pub mod key_protocol;`
+6. `crypto/access_keys/mod.rs` — Pure: AccessKey, AccessKeyError, ContentEncryptionKey types. Stays: `pub mod lifecycle;`, `pub mod wire;`
+7. `envelope/mod.rs` — Pure: SCP_PROTOCOL_VERSION, EnvelopeError, VersionCompatibility. Stays: pseudonym.rs, inner/sign.rs, outer/ops.rs.
+8. `economy/mod.rs` — Pure: module declarations for types, policy, budget, pricing, estimate, antispam. Stays: `pub mod credentials;`, `pub mod integration;`, `pub mod adapter;`, `pub mod receipt;`
+9. `discovery/mod.rs` — Pure: DiscoveryError. Stays: addressing, search, did_capabilities, bootstrap, dht_context.
+10. `bridge/mod.rs` — Pure: BridgeMode, BridgeConnector, ShadowIdentity types. Stays: `pub mod oauth;`, `pub mod credentials;`
+11. `sync/mod.rs` — Pure: SyncEvent, SyncError. Stays: days_offline, hours_offline, weeks_offline.
+    **NOTE:** SyncEvent::QueueOverflow references store::queue::QueueOverflowInfo — Agent 2 must move QueueOverflowInfo to scp-protocol.
+12. `identity/mod.rs` — Pure: re-exports of pure parts. Stays: blocking, recovery, custody_migration, scpid.
+13. `provenance/mod.rs` — Pure: DataProvenance, CounterpartyPolicy types.
+14. `context/governance/mod.rs` — Pure: GovernanceAction, GovernanceEngine trait, compute_proposal_id (promote to `pub`). Stays: `pub mod timeout;`
+15. `context/tools/mod.rs` — Pure: ToolSchema, ToolError. Stays: `pub mod invoke;`, `pub mod session;`
+
+---
+
+## Phase F: Known issues for Agent 2
+
+### Harness artifacts with hardcoded paths (MUST update after rename)
+
+These files use `include_str!()` or grep patterns with hardcoded `crates/scp-core/` paths that break after the rename to `crates/scp-runtime/`:
+
+1. `crates/scp-testing/tests/integration/pipeline_wiring.rs` — two `include_str!` paths:
+   - `include_str!("../../../../crates/scp-core/src/context/manager.rs")` → change to `crates/scp-runtime/src/context/manager.rs`
+   - `include_str!("../../../../crates/scp-core/src/crypto/mls/provider.rs")` → change to `crates/scp-runtime/src/crypto/mls/provider.rs`
+   - Also has a meta-test checking CLAUDE.md enforcement sections — verify it still passes.
+
+2. `scripts/check-cross-layer.sh` — grep patterns reference `crates/scp-core/src/`:
+   - Update to `crates/scp-runtime/src/`
+
+3. `crates/scp-testing/tests/integration/ffi_conformance.rs` — points to `scp-ffi/` paths (unchanged by rename, but verify).
+
+4. `scripts/check-sdk-coverage.py` — tree-sitter AST parsing. Check if it references `scp-core` anywhere.
+
+### Why most `crate::` paths DON'T need changing
+
+Moved files use `crate::trust::TrustError`, `crate::crypto::ucan::UcanError`, etc. After the
+move, `crate::` refers to scp-protocol instead of scp-core. But because the module tree within
+scp-protocol mirrors the original structure, these paths STILL RESOLVE. The analysis confirmed
+311 internal references that work automatically. Only 4 outbound references need fixing.
+
+### scp-identity imports
+
+5 test files import `scp_identity::cache::TestClock`. Change to `scp_primitives::TestClock`:
+- `trust/renewal.rs:191`
+- `trust/aggregate.rs:456`
+- `trust/challenge.rs:762`
+- `trust/attestation.rs:1284`
+- `crypto/ucan/nonce.rs:373`
+
+No production code imports from scp-identity. scp-protocol does NOT depend on scp-identity.
+
+### Cross-crate type issues
+
+1. `ContextError::IntegrationFailed` embeds `IntegrationError` from economy/integration.rs (stays). Either move IntegrationError type to scp-protocol or restructure ContextError.
+2. `SyncEvent::QueueOverflow` references `store::queue::QueueOverflowInfo` (stays). Move QueueOverflowInfo (pure data type) to scp-protocol.
+3. `trust/mod.rs` re-exports `ProtocolRepositoryTrustBridge` from store — stays in scp-runtime's trust module only.
+
+### Path and visibility fixes
+
+4. `compute_proposal_id` — promote from `pub(crate)` to `pub`.
+5. `trust/participation` — promote from `pub(crate)` to `pub`.
+6. `jcs` and `serde_util` — moved to scp-protocol but referenced by staying files (sign.rs, app_sandbox.rs). scp-runtime imports from `scp_protocol::jcs` / `scp_protocol::serde_util`.
+7. Moved `inner/mod.rs` must have `pub mod sign;` line REMOVED (sign.rs stays in scp-runtime).
+8. Moved `outer/mod.rs` must have `pub mod ops;` line REMOVED (ops.rs stays in scp-runtime).
+
+### Test extraction
+
+9. 26 `#[cfg(test)]` blocks in moved files reference async modules (mint.rs, builder, etc.) that stay in scp-runtime. These tests cannot compile in scp-protocol because scp-protocol cannot depend on scp-runtime (circular). Options:
+   a. Extract the test functions to scp-runtime integration tests (preferred)
+   b. Delete the tests from scp-protocol and rely on scp-runtime's integration test coverage
+
+   The 26 tests are in: validate.rs (12), close.rs (3), memory_scope.rs (3), standing.rs (3), majority.rs (3), multisig.rs (3), unanimity.rs (3), governance/mod.rs (1), wrapping.rs (1), encrypt.rs (1), envelope/validation.rs (1).
+
+---
+
+## Phase G: Facade completeness enforcement
+
+### CI script: `scripts/check-facade-completeness.sh`
+
+```bash
+#!/usr/bin/env bash
+# Verify scp-core facade re-exports all public items from scp-protocol and scp-runtime.
+# Fails if any public module in either crate is not accessible through scp-core.
+set -euo pipefail
+
+# Get public modules from scp-protocol
+protocol_mods=$(cargo doc --package scp-protocol --no-deps 2>/dev/null && \
+  find target/doc/scp_protocol -maxdepth 1 -name "*.html" -exec basename {} .html \; | sort)
+
+# Get public modules from scp-runtime
+runtime_mods=$(cargo doc --package scp-runtime --no-deps 2>/dev/null && \
+  find target/doc/scp_runtime -maxdepth 1 -name "*.html" -exec basename {} .html \; | sort)
+
+# Get public modules from scp-core
+core_mods=$(cargo doc --package scp-core --no-deps 2>/dev/null && \
+  find target/doc/scp_core -maxdepth 1 -name "*.html" -exec basename {} .html \; | sort)
+
+# Check that every protocol/runtime module appears in core
+missing=0
+for mod in $protocol_mods $runtime_mods; do
+  if ! echo "$core_mods" | grep -q "^${mod}$"; then
+    echo "MISSING from scp-core facade: $mod"
+    missing=$((missing + 1))
+  fi
+done
+
+if [ "$missing" -gt 0 ]; then
+  echo "ERROR: $missing modules not re-exported through scp-core facade"
+  exit 1
+fi
+echo "Facade completeness check passed."
+```
+
+### Structural test: `crates/scp-core/tests/facade_completeness.rs`
+
+```rust
+//! Verifies the scp-core facade correctly re-exports key types from both
+//! scp-protocol and scp-runtime. If a type is added to either crate but
+//! not wired through the facade, this test fails to compile.
+
+// Protocol types (from scp-protocol)
+use scp_core::trust::TrustError;
+use scp_core::crypto::ucan::UcanError;
+use scp_core::crypto::sender_keys::SenderKey;
+use scp_core::context::ContextState;
+use scp_core::envelope::EnvelopeError;
+use scp_core::bridge::BridgeMode;
+use scp_core::economy::EconomicPolicy;
+use scp_core::provenance::DataProvenance;
+
+// Runtime types (from scp-runtime)
+use scp_core::crypto::mls::MlsCryptoProvider;
+use scp_core::crypto::ucan::mint::mint_ucan;
+use scp_core::store::ProtocolRepository;
+
+#[test]
+fn facade_exposes_protocol_types() {
+    // These just need to compile — the use statements above verify the facade.
+    let _ = std::any::type_name::<TrustError>();
+    let _ = std::any::type_name::<UcanError>();
+    let _ = std::any::type_name::<SenderKey>();
+    let _ = std::any::type_name::<ContextState>();
+    let _ = std::any::type_name::<EnvelopeError>();
+    let _ = std::any::type_name::<BridgeMode>();
+    // Verify runtime types are also accessible
+    let _ = std::any::type_name::<MlsCryptoProvider>();
+}
+```
+
+This test is a compile-time check — if any re-export path breaks, the test fails to compile, not at runtime. Add types as they're created.
+
+---
+
+## Phase H: Commit
+
+```
+git add -A
+git commit -m "refactor: extract scp-protocol + rename scp-core to scp-runtime + create facade
+
+Three-crate split: scp-protocol (pure sync ~82K lines), scp-runtime
+(async orchestration, renamed from scp-core), scp-core (facade with
+explicit wrapper modules merging both). Zero downstream API changes.
+
+Does not compile yet — compilation fixes in next commit.
+
+Partial implementation of #1446."
+```
+
+Push: `-u origin refactor/scp-protocol-extraction`
+
+---
+
+## Phase I: Update artifacts (Agent 2 scope, after compilation works)
+
+- `.docs/architecture.md` §2.1 — add scp-protocol, update scp-core description
+- `.docs/architecture.md` §2.2 — update dependency graph
+- `CLAUDE.md` project map — update crate descriptions
+
+---
+
+## What NOT to move
+
+- `crypto/mls/` — OpenMLS runtime
+- `crypto/ucan/mint.rs` — async KeyCustody
+- `crypto/sender_keys/key_protocol.rs` — async KeyCustody
+- `crypto/access_keys/wire.rs`, `lifecycle.rs` — async
+- `crypto/agent_binding_tests.rs` — test infrastructure
+- `context/manager.rs`, `builder.rs`, `ttl.rs`, `export_import.rs`, `standing.rs`, `app_sandbox.rs`, `policy.rs`
+- `context/providers/` — async persistence
+- `context/governance/timeout.rs` — tokio
+- `context/tools/invoke.rs`, `session.rs` — async
+- `economy/credentials.rs`, `integration.rs`, `adapter.rs`, `receipt.rs` — async (RPITIT)
+- `discovery/addressing.rs`, `search.rs`, `did_capabilities.rs`, `bootstrap.rs`, `dht_context.rs` — async
+- `envelope/inner/sign.rs`, `envelope/outer/ops.rs`, `envelope/pseudonym.rs` — async
+- `sync/days_offline.rs`, `hours_offline.rs`, `weeks_offline.rs` — async
+- `bridge/oauth.rs`, `bridge/credentials.rs` — async
+- `store/` — async persistence
+- `identity/blocking.rs`, `recovery.rs`, `custody_migration.rs`, `scpid.rs` — async
+- `event_log/` (scp-runtime internal) — async
+- `metrics.rs`, `well_known.rs` — runtime
+- `crates/scp-ffi/wasm/` — separate crate, don't touch

--- a/.docs/specs/11-5-tahoe-lafs-prior-art.md
+++ b/.docs/specs/11-5-tahoe-lafs-prior-art.md
@@ -1,0 +1,305 @@
+## 11.5 Tahoe-LAFS
+
+**Tahoe-LAFS** (Tahoe Least-Authority File Store) is an open-source, decentralized, cryptographically secure distributed file system created by Zooko Wilcox-O'Hearn and Brian Warner. Originally developed at allmydata.com (2006-2009) as a commercial backup service, it was released as open-source software and became the reference implementation of provider-independent, capability-secured storage. The foundational paper was presented at ACM StorageSS 2008 (Wilcox-O'Hearn & Warner, "Tahoe: the least-authority filesystem," Proceedings of the 4th ACM International Workshop on Storage Security and Survivability, 2008, pp. 21-26). Tahoe-LAFS is the most complete real-world application of object-capability security principles to distributed storage, and the intellectual ancestor of the capability-based authorization model that SCP inherits through UCAN.
+
+### 11.5.1 The Principle of Least Authority
+
+The "LAFS" in the name is literal: the system is designed around the principle of least authority (POLA) — every component has exactly the minimum power required for its function, enforced by cryptography rather than policy. Storage servers cannot read the data they store. Clients cannot modify data they have only read access to. Repairers can reconstruct missing shares without decrypting content. The system's security properties hold even if every storage server is adversarial.
+
+This is the same design principle that informs SCP's relay architecture. Both protocols begin from the premise that infrastructure operators should have no access to the data they handle:
+
+| Principle | Tahoe-LAFS | SCP |
+|-----------|------------|-----|
+| **Operator access to content** | None — servers store encrypted, erasure-coded shares | None — relays store encrypted MLS blobs |
+| **Enforcement mechanism** | Client-side encryption + capability URIs | MLS group keys + UCAN tokens |
+| **What operators see** | Opaque ciphertext shares indexed by storage index | Opaque ciphertext indexed by pseudonym-derived routing IDs (§9.10.2) |
+| **Can operators deny service?** | Yes (availability threat) | Yes (availability threat) |
+| **Can operators read content?** | No (encryption at client) | No (MLS encryption at sender) |
+| **Can operators modify content?** | Detectable (Merkle hash verification) | Detectable (MLS authenticated encryption) |
+| **Redundancy model** | k-of-n erasure coding across storage nodes | Multi-relay publishing for suppression resistance (§9.9.2) |
+
+The shared insight: the math enforces access control, not the infrastructure. Infrastructure is treated as an adversarial commodity. This is "provider-independent security" in Tahoe's terminology and "dumb-pipe relays" in SCP's.
+
+### 11.5.2 Capability Model
+
+The capability model is the centerpiece of Tahoe-LAFS and the most important comparison with SCP. In Tahoe, a capability (cap) is a cryptographic URI string that simultaneously provides both **location** (where to find the data on the grid) and **identification** (proof that the retrieved data is authentic). Possessing the cap IS the authorization — there is no access control list, no identity check, no server-side permission enforcement. The cap is an unforgeable bearer token.
+
+#### Capability Types
+
+Tahoe defines 13 capability types across two categories (filecaps and dircaps), organized in a derivation hierarchy where stronger capabilities can derive weaker ones (called "diminishing") but never the reverse:
+
+**Immutable files:**
+
+| Cap Type | URI Prefix | Contains | Grants |
+|----------|-----------|----------|--------|
+| Read-cap | `URI:CHK:` | 16-byte AES read key + SHA-256 hash of URI Extension Block | Decrypt and read file content |
+| Verify-cap | `URI:CHK-Verifier:` | Storage index + UEB hash (no read key) | Verify integrity of ciphertext shares without reading plaintext |
+| Literal | `URI:LIT:` | File content inline (files <= 55 bytes) | Read (content embedded in cap itself) |
+
+The read key is a 16-byte AES key. The storage index (the address used to locate shares on the grid) is derived by hashing the read key with SHA-256d and a single-purpose tag. This means: knowing the read key lets you derive the storage index (and thus locate + decrypt the file), but knowing the storage index does not let you derive the read key (and thus you can verify shares but not decrypt them). The one-way derivation chain is:
+
+```
+read_key → SHA-256d → storage_index → (locate shares, verify integrity)
+read_key → AES-CTR decrypt → plaintext
+```
+
+**Mutable files (SSK — from Freenet's "Sub-Space Keys"):**
+
+| Cap Type | URI Prefix | Contains | Grants |
+|----------|-----------|----------|--------|
+| Write-cap | `URI:SSK:` | 16-byte AES write key + verification key hash | Read + write (update file content) |
+| Read-cap | `URI:SSK-RO:` | 16-byte AES read key + verification key hash | Read (decrypt current version) |
+| Verify-cap | `URI:SSK-Verifier:` | Storage index + verification key hash | Verify integrity without reading |
+
+Mutable files add RSA-2048 for asymmetric signing. The derivation chain is:
+
+```
+RSA-2048 private key (signature key)
+  → hash + truncate to 16 bytes → write_key (encrypts the RSA private key in shares)
+    → hash + truncate to 16 bytes → read_key (encrypts/decrypts file content)
+      → hash + truncate to 16 bytes → storage_index (locates shares on grid)
+
+RSA-2048 public key (verification key)
+  → SHA-256 → verification_key_hash (included in all URIs for integrity binding)
+```
+
+Each derivation step is a one-way hash truncation. A write-cap holder can derive the read-cap and verify-cap. A read-cap holder can derive only the verify-cap. A verify-cap holder can verify share integrity but neither read nor write. The write key encrypts the RSA private key within shares; the read key encrypts the file content. This separation means the RSA private key (and thus write authority) is protected by a different symmetric key than the content itself.
+
+**Directories** mirror the file hierarchy: mutable directory write-cap (`URI:DIR2:`), read-cap (`URI:DIR2-RO:`), verify-cap (`URI:DIR2-Verifier:`), plus immutable variants. Directories are implemented as mutable files whose content is a serialized mapping of child names to child capabilities. Read-only access to a directory is transitively read-only — you cannot extract write-caps for children from a read-only directory cap.
+
+#### The Repaircap: Least Privilege in Action
+
+Tahoe's repair mechanism demonstrates the capability model's granularity. A repairer receives a cap that contains enough information to download shares, verify their integrity, reconstruct missing shares via erasure coding, and upload replacements — but cannot decrypt the file content. The repairer works entirely on ciphertext. This is the principle of least authority applied to infrastructure maintenance: the entity responsible for data durability has no access to data confidentiality.
+
+### 11.5.3 Capability Model Comparison: Tahoe-LAFS vs SCP UCAN
+
+Both Tahoe-LAFS and SCP use capability-based authorization where the bearer token (not an identity lookup) determines access. But the capability models differ fundamentally in structure, delegation, lifecycle, and scope.
+
+| Dimension | Tahoe-LAFS Capabilities | SCP UCAN Tokens |
+|-----------|------------------------|-----------------|
+| **Representation** | Cryptographic URI string (`URI:CHK:...`, `URI:SSK:...`) | Signed JWT (JSON Web Token with `ucv`, `iss`, `aud`, `att`, `exp` fields) |
+| **What it encodes** | Encryption key + content hash (location + identification) | Issuer DID + audience DID + capability set + expiration + proofs |
+| **Bearer semantics** | Pure bearer — anyone with the URI string has access | Audience-bound — only the `aud` DID can exercise the capability |
+| **Identity binding** | None — capabilities are anonymous | DID-bound — issuer and audience are cryptographically identified |
+| **Delegation** | None — you share the cap string, granting full access at that level | Native — `prf` (proof) field chains delegations; each link is a signed JWT |
+| **Attenuation** | One direction only: write → read → verify (diminishing) | Arbitrary: any capability subset, custom resources, narrower scope |
+| **Time-bounding** | None — caps are permanent while the data exists | Native — `exp` (expiration) and `nbf` (not-before) fields |
+| **Revocation** | Impossible — the cap is the key, and you cannot un-share a key | Revocation records (§7.3) checked at verification time |
+| **Scope** | Single file or directory | Context-scoped: `scp:ctx:{context_id}/{resource}:{action}` |
+| **Governance** | None — no concept of rules governing capability exercise | Full governance model: 28 action types, pluggable engines (§5.9) |
+| **Accountability** | None — caps are anonymous, no audit trail of who used them | Full — every action signed by a DID, recorded in event logs |
+| **Composability** | File-level only | Protocol-wide: identity + capability + context + governance |
+
+**The fundamental divergence:** Tahoe capabilities are static and anonymous. Once you have a read-cap, you have read access forever, and no one can tell who is reading. UCAN tokens are dynamic and identified. They expire, they can be revoked, they chain through identified delegators, and every exercise is attributable to a specific DID.
+
+This reflects the different problem domains. Tahoe secures data at rest — files on a grid. The threat model is the storage provider reading or modifying your files. Anonymity is a feature: the cap proves you are authorized without revealing who you are. SCP secures interaction — communication within governed contexts. The threat model includes unauthorized agents, capability escalation, and unattributable actions. Identity is a feature: the UCAN proves both that you are authorized AND who you are.
+
+Both inherit from the object-capability tradition (Dennis & Van Horn 1966, Mark Miller's E language, erights.org). The intellectual lineage runs: object-capability theory → Tahoe-LAFS (cryptographic capabilities for storage) → UCAN (cryptographic capabilities for authorization delegation) → SCP (capabilities embedded in a governance and identity framework). Tahoe proved that cryptographic capabilities work for decentralized access control without ACLs. UCAN added the delegation, attenuation, and identity-binding that real-world authorization requires. SCP embedded UCANs in a context-governed, MLS-encrypted interaction protocol.
+
+### 11.5.4 Provider-Independent Security
+
+Tahoe-LAFS coined the term "provider-independent security" to describe a property that goes beyond encryption:
+
+> "The service provider never has the ability to read or modify your data in the first place: never."
+
+This is not just "data is encrypted." It means:
+
+1. **Confidentiality** — the provider cannot read your data (AES encryption, key held only by client)
+2. **Integrity** — the provider cannot modify your data undetectably (Merkle hash trees, cap-embedded hashes)
+3. **Unforgeability** — the provider cannot create data that appears to be yours (RSA signatures for mutable files, content-hash binding for immutable files)
+
+The provider can deny service (refuse to store or serve shares). It cannot do anything else. All three properties derive from cryptographic constructions that the client performs independently of the server.
+
+SCP achieves the same three properties through different mechanisms:
+
+| Property | Tahoe-LAFS Mechanism | SCP Mechanism |
+|----------|---------------------|---------------|
+| **Confidentiality** | AES-128-CTR, key in client-held capability | MLS group key (AES-128-GCM), distributed via MLS key schedule |
+| **Integrity** | Merkle hash trees + SHA-256d, roots embedded in caps | MLS authenticated encryption (AEAD) + event log Merkle trees |
+| **Unforgeability** | RSA-2048 signatures (mutable files), content-hash binding (immutable) | Ed25519 signatures on MLS messages + UCAN chain verification |
+| **Relay/server access** | Sees encrypted shares + storage index | Sees encrypted blobs + pseudonym-derived routing IDs |
+| **Key management** | Embedded in capability URIs (no separate key distribution) | MLS key schedule (ratcheting, forward secrecy, post-compromise security) |
+
+The deepest parallel is the design philosophy: both protocols treat the infrastructure layer as an adversarial commodity service. Tahoe's storage servers are interchangeable, untrusted, and unaware of what they store. SCP's relays are interchangeable, untrusted, and unaware of what they forward. The client (Tahoe) or participant (SCP) performs all security-critical operations.
+
+Where SCP extends beyond Tahoe: MLS provides forward secrecy and post-compromise security — properties that Tahoe's static encryption keys cannot provide. Tahoe's AES key for a file is permanent; if it leaks, all past and future access to that file is compromised. MLS ratchets keys with each epoch, so compromise of a current key does not expose past messages, and removal of a compromised member restores confidentiality for future messages. This difference reflects storage (static) vs communication (evolving group membership).
+
+### 11.5.5 Erasure Coding and Redundancy
+
+Tahoe distributes each file across multiple storage nodes using erasure coding. The default parameters are:
+
+- **k = 3** — minimum shares needed to reconstruct the file
+- **N = 10** — total shares created
+- **H = 7** — minimum independent servers required for upload success ("servers of happiness")
+- **Expansion factor: 3.3x** — each file consumes 3.3x its plaintext size in storage
+
+The pipeline: plaintext → AES-CTR encryption → segmentation (128 KiB default) → erasure coding per segment → one block per segment per share → distribution across servers. Each share gets one block per segment, plus Merkle hash trees for verification.
+
+The erasure coding algorithm (zfec, based on Rizzo's FEC) means any k-of-N shares suffice for reconstruction. Up to (N - k) = 7 servers can fail simultaneously without data loss. The system can tolerate the loss of any 70% of its storage nodes.
+
+**Comparison with SCP's multi-relay architecture (§9.9.2):**
+
+| Dimension | Tahoe-LAFS Erasure Coding | SCP Multi-Relay Publishing |
+|-----------|--------------------------|---------------------------|
+| **Purpose** | Data durability — survive storage node failure | Message availability — survive relay failure or censorship |
+| **Mechanism** | k-of-N erasure coding (zfec) | Full message replication to multiple relays |
+| **Redundancy** | Encoded fragments — any k of N suffice | Full copies — any 1 of M relays suffice |
+| **Expansion cost** | 3.3x storage (tunable via k/N ratio) | Mx storage and bandwidth (M = number of relays) |
+| **Failure tolerance** | (N - k) simultaneous node failures | (M - 1) simultaneous relay failures |
+| **Reconstruction** | Client downloads k shares, decodes | Client reads from first available relay |
+| **Suppression resistance** | High — attacker must compromise >70% of nodes | High — attacker must compromise all relays (§9.9.2) |
+| **What's distributed** | Encoded ciphertext fragments | Complete encrypted messages |
+
+Tahoe's approach is more storage-efficient (3.3x vs Mx). SCP's approach is simpler (no erasure coding, no multi-share reconstruction). The difference reflects their domains: Tahoe must store large files durably for long periods, making encoding efficiency critical. SCP must deliver messages reliably in real time, making simplicity and latency critical. Erasure coding adds reconstruction latency; full replication provides instant availability from any relay.
+
+Tahoe's redundancy model offers one insight relevant to SCP: k-of-N encoding could improve SCP's relay-layer efficiency for large payloads (blob storage, file attachments). Instead of replicating a 100 MB file to 3 relays (300 MB total), erasure coding to 3-of-10 across 10 relays would use 330 MB but survive 7 relay failures instead of 2. This is an optimization opportunity, not a design necessity.
+
+### 11.5.6 Convergent Encryption
+
+Tahoe's convergent-key method computes the file's encryption key deterministically from its content:
+
+```
+encryption_key = SHA-256d(tag || encoding_params || convergence_secret || file_contents)[:16]
+```
+
+If two clients upload the same file with the same convergence secret, they produce the same ciphertext and the same capability URI. The file is stored once on the grid — deduplication without the server ever seeing the plaintext.
+
+The convergence secret is a per-client random value generated on first startup. By default, each client's files converge only with their own previous uploads. Sharing the convergence secret between clients enables cross-client deduplication but introduces two attacks:
+
+1. **Confirmation-of-a-file attack** — an adversary who knows both the convergence secret and a candidate plaintext can check whether that file exists on the grid (compute the expected cap, attempt download).
+2. **Learn-the-remaining-information attack** — if the adversary knows most of a file's content and the convergence secret, brute-forcing the remaining unknown bytes becomes an offline attack (no server interaction needed).
+
+Tahoe also offers a random-key method (non-convergent) for applications where deduplication is less important than privacy against these attacks.
+
+SCP has no equivalent of convergent encryption. MLS encryption keys are derived from the group key schedule, not from message content. Each message produces unique ciphertext even if the plaintext is identical. Deduplication is not a goal — in a communication protocol, message identity matters (the same text sent twice is two distinct messages with distinct timestamps and sequence numbers). Tahoe's convergent encryption is a storage optimization that is inapplicable to real-time communication.
+
+### 11.5.7 Mutable Files and Versioning
+
+Tahoe's immutable files are write-once: the capability is derived from the content, so changing the content changes the capability. Mutable files (SSK format) add updateability:
+
+- **RSA-2048 keypair** — the private key signs updates, the public key verifies them
+- **Sequence numbers** — 64-bit monotonic counter prevents rollback attacks
+- **Two formats:** SDMF (Small Distributed Mutable Files, single segment, entire file downloaded for any read) and MDMF (Medium Distributed Mutable Files, 128 KiB segments, partial reads/writes)
+- **Write coordination:** The "Prime Coordination Directive" warns that uncoordinated simultaneous writes can corrupt a file if competing versions exceed the erasure coding recovery threshold (S > N/k)
+- **Per-server write enablers:** `H(write_enabler_master + server_nodeid)` — each storage server gets a unique authorization token, preventing cross-server impersonation
+
+**Comparison with SCP event logs:**
+
+| Dimension | Tahoe Mutable Files | SCP Event Logs (§8) |
+|-----------|--------------------|--------------------|
+| **Mutability model** | Replace-in-place (latest version wins) | Append-only (events accumulate) |
+| **Signing** | RSA-2048 (single writer per file) | Ed25519 via MLS (multi-writer per context) |
+| **Multi-writer** | Discouraged — "Prime Coordination Directive" warns of corruption | Native — MLS group membership defines write authority |
+| **Versioning** | Sequence number (64-bit monotonic counter) | MLS epoch + generation + sequence triple |
+| **Conflict resolution** | Last-writer-wins (no CRDT, no merge) | Ordered by MLS epoch (no conflict — append-only) |
+| **Forward secrecy** | None — same RSA key for all versions | Yes — MLS key ratcheting per epoch |
+| **Rollback prevention** | Sequence number check | Merkle tree inclusion proofs |
+| **Write authorization** | Possession of write-cap (anonymous) | MLS membership + UCAN capability + governance check |
+
+Tahoe's mutable files are a storage primitive — they provide a single mutable slot with integrity and confidentiality. SCP's event logs are a richer structure: append-only (no destructive update), multi-writer with cryptographic membership enforcement, embedded in a governance framework that controls who can append what.
+
+### 11.5.8 Grid Architecture
+
+A Tahoe grid consists of three node types:
+
+1. **Introducer** — a coordination node that maintains the server roster. Servers announce themselves to the introducer; clients connect to receive the list of available servers. The introducer is a recoverable single point of failure: it is defined by a hostname and a private key, easily relocated. Once clients have the server roster, they maintain direct connections without the introducer.
+
+2. **Storage servers** — user-space processes that store shares (encrypted, erasure-coded fragments). Servers perform no cryptographic operations — no decryption, no signature verification, no erasure coding. They are deliberately simple: accept shares, serve shares, manage leases. This simplicity is a security feature — the server has no capability that could be exploited to compromise data.
+
+3. **Client nodes (gateways)** — the security-critical component. Clients perform all encryption, erasure coding, share distribution, Merkle tree computation, capability generation, and download reconstruction. Clients connect to every known server in a bi-clique topology. The client is the only component that handles plaintext or encryption keys.
+
+Server selection uses consistent permutation: `HASH(storage_index + nodeid)` sorts servers into a deterministic, per-file order, ensuring even distribution across the grid. Nodes communicate over TCP using Foolscap (the original protocol) or HTTPS (default since v1.19).
+
+**Comparison with SCP's architecture:**
+
+| Dimension | Tahoe-LAFS Grid | SCP Relay + Node Architecture |
+|-----------|----------------|------------------------------|
+| **Discovery** | Introducer (centralized roster) | DHT + relay layer + DID document service endpoints (§3.10, §18) |
+| **Infrastructure role** | Storage servers — store shares, serve shares, nothing else | Relays — receive blobs, deliver blobs, nothing else |
+| **Client role** | All crypto + erasure coding + share management | All crypto + MLS + governance + capability validation |
+| **Topology** | Bi-clique (every client → every server) | Subscription-based (participants subscribe to routing IDs on relays) |
+| **Protocol** | Foolscap / HTTPS | WebSocket (primary) + 17 transport adapters (§10.5) |
+| **Server intelligence** | Minimal — store/serve/lease | Minimal — receive/deliver/TTL |
+| **Single point of failure** | Introducer (recoverable) | None — DHT + multiple relays + relay fallback list (§18.5.1) |
+| **NAT traversal** | Requires Foolscap connection (bi-clique limited by NAT) | 4-tier reachability: port mapping, hole punching, bridge relay, domain TLS (§10.12) |
+
+Both architectures share the principle that infrastructure nodes (storage servers / relays) are deliberately stupid. All security-critical logic lives in the client. The main architectural difference is discovery: Tahoe uses a centralized introducer (simple, but a single point of failure); SCP uses decentralized multi-layer resolution (more complex, but no single point of failure).
+
+### 11.5.9 Zooko's Triangle
+
+Zooko Wilcox-O'Hearn, the co-creator of Tahoe-LAFS, is also the originator of Zooko's triangle (2001) — the conjecture that no single naming system can simultaneously achieve all three properties:
+
+1. **Secure** — names cannot be spoofed or hijacked
+2. **Human-meaningful** — names are memorable and readable
+3. **Decentralized** — names resolve without a central authority
+
+This is the same naming trilemma discussed in §11.3.5 (GNS). The connection between Tahoe-LAFS and Zooko's triangle is not merely biographical — the same person who identified the fundamental naming problem also built a system that sidesteps it entirely. Tahoe capabilities occupy the "secure + decentralized" edge: they are cryptographic strings that no human will memorize, but they are unforgeable and resolve without any authority. Tahoe does not attempt human-meaningful naming — it delegates that to the directory layer, where users create named hierarchies from capability-addressed files.
+
+SCP's DID approach makes the same trade-off: `did:dht:z6Mk...` strings are secure and globally unique but not human-meaningful. Like Tahoe, SCP compensates at the application layer (display names in DID documents, context-level naming). The parallel is exact: both systems choose cryptographic identifiers at the infrastructure layer and push human-readable naming to a higher layer.
+
+| System | Secure | Human-meaningful | Decentralized | Compensation |
+|--------|--------|-----------------|---------------|--------------|
+| **Tahoe-LAFS caps** | Yes (cryptographic) | No (opaque URIs) | Yes (no authority) | Directory hierarchy with named children |
+| **SCP DIDs** | Yes (self-certifying) | No (z-base-32 strings) | Yes (DHT-resolved) | Display names in DID documents, context naming |
+| **DNS** | Weak (DNSSEC optional) | Yes | No (ICANN hierarchy) | — |
+| **GNS** | Yes | Yes (petnames) | Yes (no authority) | Local only — not globally unique |
+| **ENS** | Yes | Yes | Partial (requires Ethereum) | Blockchain as global state |
+
+### 11.5.10 What SCP Borrows Conceptually
+
+Three ideas flow directly from Tahoe-LAFS into SCP's design:
+
+1. **Capability-based authorization without ACLs.** Tahoe proved that distributed systems can enforce access control using cryptographic bearer tokens rather than identity lookups or server-side permission lists. This is the foundation of SCP's UCAN model. The conceptual step from Tahoe caps to UCANs is: add identity binding (issuer/audience DIDs), add delegation chains (proof fields), add time-bounding (expiration), add revocation, add governance. But the core insight — the token IS the authorization, verified by cryptography not by asking a server — originates in this tradition.
+
+2. **Provider-independent security.** The principle that infrastructure operators should have zero access to the data they handle. Tahoe applied this to file storage (servers cannot read files). SCP applies it to message delivery (relays cannot read messages). Same principle, different scope. In both cases, the client/participant performs all encryption and the infrastructure handles only opaque ciphertext.
+
+3. **The math enforces access, not the infrastructure.** Tahoe's entire security model derives from the hardness of AES, SHA-256, and RSA — not from trusting servers to enforce permissions. SCP's security model derives from the hardness of AES-128-GCM (MLS AEAD), SHA-256 (Merkle trees, storage indices), and Ed25519 (signatures, DID binding) — not from trusting relays or governance servers. Both protocols are designed so that a fully adversarial infrastructure cannot compromise confidentiality or integrity. Only availability is at risk.
+
+The intellectual lineage: object-capability theory (Dennis & Van Horn 1966) → E language (Mark Miller 1997) → Tahoe-LAFS (Wilcox-O'Hearn & Warner 2007) → UCAN (Fission/Brooklyn Zelenka 2021) → SCP. Each step adds structure: E added language-level enforcement; Tahoe added cryptographic enforcement for distributed storage; UCAN added delegation, attenuation, and identity binding; SCP added governance, group encryption, and context isolation.
+
+### 11.5.11 Why SCP Diverges
+
+Despite the shared intellectual heritage, Tahoe-LAFS and SCP solve fundamentally different problems. The divergences are not deficiencies in either system — they reflect different domains.
+
+| Dimension | Tahoe-LAFS | SCP | Why Different |
+|-----------|------------|-----|---------------|
+| **Domain** | File storage (data at rest) | Communication (data in motion within governed contexts) | Storage is static; communication is dynamic with evolving group membership |
+| **Capability lifecycle** | Permanent — a cap grants access as long as the data exists | Time-bounded — UCANs expire, can be revoked, are governance-scoped | Communication requires temporal control; file access is typically permanent |
+| **Capability delegation** | None — share the URI string, that's it | Native — delegation chains with attenuation at each link | Communication requires scoped, auditable delegation; file sharing is simpler |
+| **Identity** | None — capabilities are anonymous bearer tokens | Core — every action traces to a DID, attestation chains to human accountability | Storage can be anonymous; communication in governed contexts requires accountability |
+| **Group communication** | None — Tahoe is single-user or share-the-cap | Native — MLS groups with add/remove/update, forward secrecy, post-compromise security | File storage does not require real-time group membership management |
+| **Governance** | None — no concept of rules, roles, or permissions beyond read/write/verify | 28 governance action types, pluggable engines, capability ceilings (§5.9) | File storage is ungoverned; collaborative communication requires governance |
+| **Forward secrecy** | None — static encryption keys per file | Yes — MLS key ratcheting per epoch | Static files do not benefit from key ratcheting; communication sessions do |
+| **Conflict resolution** | Last-writer-wins for mutable files | Append-only event logs — no conflict by construction | File replacement is a valid operation; message history is immutable |
+| **Transport** | Grid-specific (Foolscap/HTTPS between Tahoe nodes) | Transport-agnostic (17 adapters, §10.5) | File grids are a closed system; communication must bridge protocol worlds |
+| **Agent model** | No concept of AI agents | First-class — agents are UCAN-bounded participants with human accountability chains | 2007 design predates the agentic paradigm entirely |
+| **Provenance** | None beyond capability possession | Protocol-level — every action carries verifiable origin metadata (§24) | File access does not require provenance; agentic communication does |
+
+**The sharpest difference:** Tahoe capabilities are anonymous and permanent. This is correct for file storage — you want a link to a file to work forever, and you do not need to know who is reading it. SCP's UCAN tokens are identified and ephemeral. This is correct for communication — you need to know who is speaking, you need to bound how long a delegation lasts, and you need to revoke access when group membership changes.
+
+### 11.5.12 Least Authority, Zcash, and the Capability Lineage
+
+Zooko Wilcox-O'Hearn's trajectory after Tahoe-LAFS traces the evolution of capability thinking:
+
+- **2006-2009:** Co-created Tahoe-LAFS at allmydata.com with Brian Warner. Proved that cryptographic capabilities work for provider-independent distributed storage.
+- **2011:** Founded **Least Authority Enterprises** in Boulder, Colorado — a security consulting firm that performed audits for privacy and transparency projects (GlobalLeaks, Ethereum, and others). The company name is a direct reference to the principle of least authority that underpins Tahoe-LAFS.
+- **2016:** Co-founded **Zcash** (launched October 28, 2016) — a privacy-preserving cryptocurrency using zero-knowledge proofs (zk-SNARKs). Zcash applies the same principle at the transaction layer: the blockchain verifier never learns the transaction amounts or parties. Wilcox-O'Hearn served as CEO of the Electric Coin Company (Zcash's development organization) until December 2023.
+
+The thread connecting these projects: **cryptographic enforcement of minimal authority.** Tahoe-LAFS applies it to storage (the server cannot read your files). Zcash applies it to transactions (the network cannot see your payments). SCP applies it to communication (the relay cannot read your messages). The common denominator is that the infrastructure layer is denied authority over the data it processes, enforced by mathematics rather than policy.
+
+The direct intellectual lineage from Tahoe to UCAN runs through the broader object-capability community. Brooklyn Zelenka and the Fission team who created UCAN explicitly cite capability-based security principles. While UCAN was not derived from Tahoe-LAFS's code, it addresses the same fundamental question — "how do you authorize access in a decentralized system without a central authority?" — and arrives at the same answer: bearer tokens containing cryptographic material, where possession of the token is both necessary and sufficient for the authorized action.
+
+### 11.5.13 References
+
+- Wilcox-O'Hearn, Zooko & Warner, Brian. "Tahoe: the least-authority filesystem." *Proceedings of the 4th ACM International Workshop on Storage Security and Survivability (StorageSS '08)*, October 2008, pp. 21-26. doi:10.1145/1456469.1456474. Also: IACR Cryptology ePrint Archive, Paper 2012/524.
+- Tahoe-LAFS project documentation: https://tahoe-lafs.readthedocs.io/
+- Tahoe-LAFS source repository: https://github.com/tahoe-lafs/tahoe-lafs
+- Tahoe-LAFS capability specification: https://tahoe-lafs.org/trac/tahoe-lafs/wiki/Capabilities
+- Tahoe-LAFS file encoding specification: https://tahoe-lafs.readthedocs.io/en/latest/specifications/file-encoding.html
+- Tahoe-LAFS mutable file specification: https://tahoe-lafs.readthedocs.io/en/latest/specifications/mutable.html
+- Tahoe-LAFS architecture overview: https://tahoe-lafs.readthedocs.io/en/latest/architecture.html
+- Tahoe-LAFS convergence secret: https://tahoe-lafs.readthedocs.io/en/latest/convergence-secret.html
+- Wilcox-O'Hearn, Zooko. "Names: Distributed, Secure, Human-Readable: Choose Two." 2001. (Origin of Zooko's triangle.)
+- Miller, Mark S. "Robust Composition: Towards a Unified Approach to Access Control and Concurrency Control." PhD thesis, Johns Hopkins University, 2006. (Foundation of the object-capability model.)
+- Dennis, Jack B. & Van Horn, Earl C. "Programming Semantics for Multiprogrammed Computations." *Communications of the ACM* 9(3), March 1966, pp. 143-155. (Origin of capability-based security.)
+- UCAN specification: https://github.com/ucan-wg/spec

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -183,6 +183,22 @@ The orchestrator never writes code. It manages execution, maintains plan alignme
 - Validate that agent output aligns with the plan and referenced issues.
 - Keep context lean — delegate, don't accumulate.
 
+**Orchestrator verification protocol (MANDATORY after every agent merge):**
+- Verify against the PUSHED REMOTE branch (`git show origin/branch:file`), never the local working directory. Local state may be on a different branch.
+- For type deletions: `grep -c "struct TypeName" <file>` must return 0.
+- For imports: `grep -c "scp_protocol::module" <file>` must return >0.
+- Run the exact CI clippy command with ALL features before pushing: `cargo clippy --workspace --all-targets --features scp-ffi-uniffi/allow_in_memory_custody,scp-ffi/allow_in_memory_custody,scp-ffi-napi/allow_in_memory_custody,scp-core/testing,scp-runtime/testing -- -D warnings`
+- If a cherry-pick resolves to "nothing to commit," the changes DID NOT LAND. Investigate.
+- Never say "done" without showing verification output.
+
+**Agent execution rules (MANDATORY):**
+- Every agent prompt must specify which branch to start from. Include: "Verify with `git log --oneline -3` that you see [expected commits]. If not, STOP."
+- Never checkout migration/feature branches on the main worktree. All branch work happens in worktrees. Main worktree stays on main.
+- When the plan says "delete X and import Y," agents MUST delete X and import Y. No excuses. "Different serde format," "different field types," "architectural mismatch" are NOT valid reasons to keep local reimplementations when there are zero consumers. The only valid reason is a compiler-level mechanical restriction.
+- When an agent hits friction (type is `pub(crate)`, missing derive, missing method), fix the impediment — don't work around it by keeping the reimplementation.
+- Don't manually edit code to fix clippy warnings. Use `cargo clippy --fix` or dispatch an agent.
+- Parallel coding agents that touch the same files WILL conflict. Run them sequentially, not in parallel.
+
 ## Scope discipline
 
 **When asked to verify, audit, or review "everything," enumerate the full scope FIRST:**

--- a/crates/scp-testing/tests/integration/pipeline_wiring.rs
+++ b/crates/scp-testing/tests/integration/pipeline_wiring.rs
@@ -273,6 +273,21 @@ fn encrypt_path_calls_attach_provenance() {
     );
 }
 
+// --- Anti-replay (#1546) ---
+
+#[test]
+#[ignore = "#1546 — sequence/replay check not yet wired into deliver_incoming"]
+fn deliver_incoming_calls_validate_received_envelope() {
+    assert!(
+        fn_body_contains(
+            MANAGER_SRC,
+            "deliver_incoming",
+            "validate_received_envelope"
+        ),
+        "deliver_incoming must call validate_received_envelope (anti-replay)"
+    );
+}
+
 // --- Governance / lifecycle ---
 
 #[test]
@@ -294,6 +309,62 @@ fn execute_add_member_calls_generate_access_key() {
     assert!(
         fn_body_contains(MANAGER_SRC, "execute_add_member", "generate_access_key"),
         "execute_add_member must call generate_access_key"
+    );
+}
+
+// --- Standing (#1530) ---
+
+#[test]
+#[ignore = "#1530 — standing score not yet consulted in governance proposals"]
+fn propose_governance_checks_standing() {
+    assert!(
+        fn_body_contains(
+            MANAGER_SRC,
+            "propose_governance_action_inner",
+            "check_standing"
+        ),
+        "propose_governance_action_inner must consult standing scores"
+    );
+}
+
+// --- Consequences (#1531) ---
+
+#[test]
+#[ignore = "#1531 — consequence evaluation not yet wired into governance dispatch"]
+fn governance_dispatch_calls_evaluate_consequences() {
+    assert!(
+        fn_body_contains(
+            MANAGER_SRC,
+            "finalize_governance_action",
+            "evaluate_consequence_rules"
+        ),
+        "finalize_governance_action must call evaluate_consequence_rules"
+    );
+}
+
+// --- Economy (#1537) ---
+
+#[test]
+#[ignore = "#1537 — economy enforcement not yet wired into governance"]
+fn governance_enforces_economic_policy() {
+    assert!(
+        fn_body_contains(
+            MANAGER_SRC,
+            "propose_governance_action_inner",
+            "evaluate_cost"
+        ) || fn_body_contains(MANAGER_SRC, "send_message", "evaluate_cost"),
+        "governance or send_message must call evaluate_cost for economic enforcement"
+    );
+}
+
+// --- Content key rotation (#1548) ---
+
+#[test]
+#[ignore = "#1548 — encrypted mode content key rotation is a no-op"]
+fn rotate_content_keys_calls_propose_update() {
+    assert!(
+        fn_body_contains(MANAGER_SRC, "execute_rotate_content_keys", "propose_update"),
+        "execute_rotate_content_keys must call propose_update for encrypted mode MLS rotation"
     );
 }
 
@@ -394,6 +465,48 @@ fn no_stale_ignores() {
         "remove_member_sender_key",
     ) {
         stale.push("execute_remove_member_calls_remove_member_sender_key (#1541)");
+    }
+
+    // Anti-replay (#1546)
+    if fn_body_contains(
+        MANAGER_SRC,
+        "deliver_incoming",
+        "validate_received_envelope",
+    ) {
+        stale.push("deliver_incoming_calls_validate_received_envelope (#1546)");
+    }
+
+    // Standing (#1530)
+    if fn_body_contains(
+        MANAGER_SRC,
+        "propose_governance_action_inner",
+        "check_standing",
+    ) {
+        stale.push("propose_governance_checks_standing (#1530)");
+    }
+
+    // Consequences (#1531)
+    if fn_body_contains(
+        MANAGER_SRC,
+        "finalize_governance_action",
+        "evaluate_consequence_rules",
+    ) {
+        stale.push("governance_dispatch_calls_evaluate_consequences (#1531)");
+    }
+
+    // Economy (#1537)
+    if fn_body_contains(
+        MANAGER_SRC,
+        "propose_governance_action_inner",
+        "evaluate_cost",
+    ) || fn_body_contains(MANAGER_SRC, "send_message", "evaluate_cost")
+    {
+        stale.push("governance_enforces_economic_policy (#1537)");
+    }
+
+    // Content key rotation (#1548)
+    if fn_body_contains(MANAGER_SRC, "execute_rotate_content_keys", "propose_update") {
+        stale.push("rotate_content_keys_calls_propose_update (#1548)");
     }
 
     assert!(

--- a/scripts/analyze-extraction.py
+++ b/scripts/analyze-extraction.py
@@ -1,0 +1,379 @@
+#!/usr/bin/env python3.12
+"""Analyze scp-core module dependencies for scp-protocol extraction.
+
+For each file planned to move to scp-protocol, extracts all `crate::` references
+and classifies them as:
+- INTERNAL: target module also moves → no change needed
+- OUTBOUND: target stays in scp-core → must refactor
+- TEST_ONLY: reference is inside #[cfg(test)] → can stay as integration test
+
+Uses tree-sitter for accurate Rust parsing (handles grouped imports, inline refs).
+"""
+
+import tree_sitter_rust as ts_rust
+from tree_sitter import Language, Parser
+from pathlib import Path
+import re
+import sys
+
+RUST_LANG = Language(ts_rust.language())
+parser = Parser(RUST_LANG)
+
+# Root of scp-core source
+CORE_SRC = Path("crates/scp-core/src")
+
+# Files/directories planned to move to scp-protocol
+# Each entry is relative to crates/scp-core/src/
+MOVING = {
+    # Leaf utils
+    "jcs.rs",
+    "serde_util.rs",
+    "time.rs",
+    "uri.rs",
+    # Crypto
+    "crypto/canonical.rs",
+    "crypto/ed25519.rs",
+    "crypto/tofu.rs",
+    "crypto/key_continuity.rs",
+    "crypto/bip39_wordlist.rs",
+    "crypto/envelope_seal.rs",
+    # Sender keys (pure parts)
+    "crypto/sender_keys/encrypt.rs",
+    "crypto/sender_keys/key_protocol_verify.rs",
+    # Access keys (pure parts)
+    "crypto/access_keys/wrapping.rs",
+    # UCAN (pure parts)
+    "crypto/ucan/capability.rs",
+    "crypto/ucan/nonce.rs",
+    "crypto/ucan/revoke.rs",
+    "crypto/ucan/spending.rs",
+    "crypto/ucan/validate.rs",
+    # Trust
+    "trust/custody_violation.rs",
+    "trust/admission.rs",
+    "trust/aggregate.rs",
+    "trust/attestation.rs",
+    "trust/capability_registry.rs",
+    "trust/capability_uri.rs",
+    "trust/challenge.rs",
+    "trust/consequence.rs",
+    "trust/participation.rs",
+    "trust/renewal.rs",
+    "trust/sybil.rs",
+    # Context types
+    "context/params.rs",
+    "context/state_machine.rs",
+    "context/roles.rs",
+    "context/membership.rs",
+    "context/memory_scope.rs",
+    "context/metadata.rs",
+    "context/templates.rs",
+    "context/close.rs",
+    "context/nesting.rs",
+    "context/invitation.rs",
+    "context/promotion.rs",
+    # Identity pure parts
+    "identity/block_list.rs",
+    "identity/private_state.rs",
+    "identity/private_state_events.rs",
+    "identity/attestation.rs",
+    # Governance (pure parts)
+    "context/governance/majority.rs",
+    "context/governance/multisig.rs",
+    "context/governance/unanimity.rs",
+    "context/governance/mls_integration.rs",
+    # Broadcast
+    "context/broadcast.rs",
+    "context/broadcast_content.rs",
+    "crypto/sender_keys/broadcast.rs",
+    # Provenance
+    "provenance/attach.rs",
+    "provenance/evaluate.rs",
+    # Context tools (pure parts)
+    "context/tools/integrity.rs",
+    "context/tools/lifecycle.rs",
+    "context/tools/registry.rs",
+    "context/tools/schema.rs",
+    "context/tools/summary.rs",
+    # Economy (pure parts)
+    "economy/types.rs",
+    "economy/policy.rs",
+    "economy/budget.rs",
+    "economy/pricing.rs",
+    "economy/estimate.rs",
+    "economy/antispam.rs",
+    # Discovery (pure parts only)
+    "discovery/handles.rs",
+    "discovery/petnames.rs",
+    "discovery/scope.rs",
+    "discovery/context.rs",
+    "discovery/push.rs",
+    # Envelope (pure parts)
+    "envelope/inner/mod.rs",
+    "envelope/outer/mod.rs",
+    "envelope/chunk.rs",
+    "envelope/padding.rs",
+    "envelope/validation.rs",
+    # Sync (pure parts)
+    "sync/alerts.rs",
+    "sync/conflict_resolution.rs",
+    # Bridge types
+    "bridge/mod.rs",  # BridgeMode, BridgeConnector, ShadowIdentity types
+    "bridge/claiming.rs",
+    "bridge/envelope.rs",
+    "bridge/provenance.rs",
+    "bridge/registration.rs",
+    "bridge/shadow.rs",
+    # Parent mod.rs files (contain types that move)
+    "context/mod.rs",  # ContextState, ContextError, context_id_bytes (NOT ContextHandle — tokio)
+    "context/governance/mod.rs",  # GovernanceAction, GovernanceEngine trait, compute_proposal_id
+    "context/tools/mod.rs",  # ToolSchema, ToolError types
+    "crypto/mod.rs",  # re-exports
+    "crypto/sender_keys/mod.rs",  # SenderKey, SenderKeyError, SenderKeyStore types
+    "crypto/access_keys/mod.rs",  # AccessKey, AccessKeyError types
+    "crypto/ucan/mod.rs",  # UcanError, UcanToken, UcanHeader types
+    "trust/mod.rs",  # TrustError, trust types
+    "identity/mod.rs",  # re-exports
+    "envelope/mod.rs",  # SCP_PROTOCOL_VERSION, VersionCompatibility, EnvelopeError
+    "economy/mod.rs",  # EconomicPolicy, CostSchedule, Amount types
+    "economy/types.rs",
+    "discovery/mod.rs",  # DiscoveryError
+    "provenance/mod.rs",  # DataProvenance, CounterpartyPolicy types
+    "sync/mod.rs",  # sync types
+    # Additional context files
+    "context/policy.rs",  # policy types
+    "context/standing.rs",  # standing types
+}
+
+# Exact module paths that are moving (derived from file paths)
+# "crypto/ucan/validate.rs" -> "crypto::ucan::validate"
+MOVING_MODULES = set()
+for f in MOVING:
+    mod_path = f.replace("/", "::").replace(".rs", "").replace("::mod", "")
+    MOVING_MODULES.add(mod_path)
+
+# Also track which PARENT modules have ALL children moving vs SOME
+# A parent is "fully moving" if all its .rs files are in MOVING
+# A parent is "partially moving" if only some files move
+STAYING_FILES = set()
+for p in CORE_SRC.rglob("*.rs"):
+    rel = str(p.relative_to(CORE_SRC))
+    if rel not in MOVING and "mod.rs" not in rel:
+        mod_path = rel.replace("/", "::").replace(".rs", "")
+        STAYING_FILES.add(mod_path)
+
+
+def resolve_crate_ref(ref_path: str) -> str:
+    """Given a crate:: reference path, determine if the target is moving or staying.
+
+    Strategy: find the most specific module in the path and check if it's moving.
+    For crate::crypto::ucan::mint::MintParams, check:
+    1. crypto::ucan::mint::MintParams - not a module
+    2. crypto::ucan::mint - is this moving? Check MOVING_MODULES
+    3. crypto::ucan - is this moving? Only if ALL ucan files move
+    """
+    path = ref_path.removeprefix("crate::")
+    parts = path.split("::")
+
+    # Try longest module path first
+    for i in range(len(parts), 0, -1):
+        candidate = "::".join(parts[:i])
+        # Direct match: this exact module is moving
+        if candidate in MOVING_MODULES:
+            return "INTERNAL"
+        # Direct match: this exact module is staying
+        if candidate in STAYING_FILES:
+            return "OUTBOUND"
+
+    # If no direct match, check if the top-level module has ANY moving files
+    # This handles cases like crate::trust::TrustError where trust/mod.rs
+    # isn't in MOVING but trust/*.rs files are
+    top = parts[0]
+    has_moving = any(m.startswith(top) for m in MOVING_MODULES)
+    has_staying = any(m.startswith(top) for m in STAYING_FILES)
+
+    if has_moving and not has_staying:
+        return "INTERNAL"
+    elif has_staying and not has_moving:
+        return "OUTBOUND"
+    else:
+        # Mixed module - could go either way. Flag as OUTBOUND to be safe.
+        return "OUTBOUND"
+
+
+def extract_crate_refs(source: bytes, file_path: str) -> list[dict]:
+    """Extract all crate:: references from a Rust source file using tree-sitter."""
+    tree = parser.parse(source)
+    refs = []
+
+    def walk(node, in_test: bool = False):
+        # Check if we're inside a #[cfg(test)] block
+        test_ctx = in_test
+        if node.type == "attribute_item":
+            text = source[node.start_byte : node.end_byte].decode("utf-8", errors="replace")
+            if "cfg(test)" in text:
+                # The NEXT sibling is the test module
+                test_ctx = True
+
+        # Look for use_declaration and scoped_use_list containing "crate::"
+        if node.type == "use_declaration":
+            text = source[node.start_byte : node.end_byte].decode("utf-8", errors="replace")
+            if "crate::" in text:
+                # Extract all crate:: paths from this use statement
+                for match in re.finditer(r"crate::([\w:]+)", text):
+                    full_path = f"crate::{match.group(1)}"
+                    refs.append({
+                        "path": full_path,
+                        "line": node.start_point[0] + 1,
+                        "in_test": in_test,
+                        "classification": resolve_crate_ref(full_path),
+                    })
+
+        # Look for inline crate:: references (not in use statements)
+        if node.type == "scoped_identifier" or node.type == "scoped_type_identifier":
+            text = source[node.start_byte : node.end_byte].decode("utf-8", errors="replace")
+            if text.startswith("crate::"):
+                refs.append({
+                    "path": text.split("(")[0].split("<")[0],  # strip generics/calls
+                    "line": node.start_point[0] + 1,
+                    "in_test": in_test,
+                    "classification": resolve_crate_ref(text),
+                })
+
+        # Check for #[cfg(test)] module
+        if node.type == "mod_item":
+            # Check if preceded by #[cfg(test)]
+            for child in node.children:
+                if child.type == "attribute_item":
+                    attr_text = source[child.start_byte : child.end_byte].decode("utf-8", errors="replace")
+                    if "cfg(test)" in attr_text:
+                        test_ctx = True
+
+        for child in node.children:
+            walk(child, test_ctx)
+
+    walk(tree.root_node)
+    return refs
+
+
+def find_cfg_test_ranges(source: bytes) -> list[tuple[int, int]]:
+    """Find line ranges of #[cfg(test)] modules using simple text search."""
+    lines = source.decode("utf-8", errors="replace").split("\n")
+    ranges = []
+    i = 0
+    while i < len(lines):
+        if "#[cfg(test)]" in lines[i]:
+            # Find the module/impl block that follows
+            # Look for the opening brace
+            brace_count = 0
+            started = False
+            start_line = i + 1
+            for j in range(i + 1, len(lines)):
+                for ch in lines[j]:
+                    if ch == "{":
+                        brace_count += 1
+                        started = True
+                    elif ch == "}":
+                        brace_count -= 1
+                if started and brace_count == 0:
+                    ranges.append((start_line, j + 1))
+                    i = j + 1
+                    break
+            else:
+                i += 1
+        else:
+            i += 1
+    return ranges
+
+
+def is_in_test(line: int, test_ranges: list[tuple[int, int]]) -> bool:
+    for start, end in test_ranges:
+        if start <= line <= end:
+            return True
+    return False
+
+
+def main():
+    outbound_total = 0
+    internal_total = 0
+    test_only_total = 0
+
+    outbound_details = []
+
+    for rel_path in sorted(MOVING):
+        file_path = CORE_SRC / rel_path
+        if not file_path.exists():
+            print(f"WARNING: {file_path} does not exist!")
+            continue
+
+        source = file_path.read_bytes()
+        test_ranges = find_cfg_test_ranges(source)
+
+        # Use regex-based extraction (more reliable for use statements)
+        lines = source.decode("utf-8", errors="replace").split("\n")
+        refs = []
+        for i, line in enumerate(lines, 1):
+            for match in re.finditer(r"crate::([\w:]+)", line):
+                full_path = f"crate::{match.group(1)}"
+                in_test = is_in_test(i, test_ranges)
+                classification = resolve_crate_ref(full_path)
+                if in_test and classification == "OUTBOUND":
+                    classification = "TEST_ONLY"
+                refs.append({
+                    "path": full_path,
+                    "line": i,
+                    "in_test": in_test,
+                    "classification": classification,
+                })
+
+        if not refs:
+            continue
+
+        outbound = [r for r in refs if r["classification"] == "OUTBOUND"]
+        test_only = [r for r in refs if r["classification"] == "TEST_ONLY"]
+        internal = [r for r in refs if r["classification"] == "INTERNAL"]
+
+        if outbound or test_only:
+            print(f"\n{'='*60}")
+            print(f"FILE: {rel_path}")
+            print(f"  INTERNAL: {len(internal)} | OUTBOUND: {len(outbound)} | TEST_ONLY: {len(test_only)}")
+
+            if outbound:
+                print(f"  --- OUTBOUND (must fix) ---")
+                for r in outbound:
+                    print(f"    L{r['line']}: {r['path']}")
+                    outbound_details.append((rel_path, r["line"], r["path"]))
+
+            if test_only:
+                print(f"  --- TEST_ONLY (extract to scp-core integration tests) ---")
+                for r in test_only:
+                    print(f"    L{r['line']}: {r['path']}")
+
+        outbound_total += len(outbound)
+        internal_total += len(internal)
+        test_only_total += len(test_only)
+
+    print(f"\n{'='*60}")
+    print(f"SUMMARY")
+    print(f"  INTERNAL (no change needed): {internal_total}")
+    print(f"  OUTBOUND (must fix):         {outbound_total}")
+    print(f"  TEST_ONLY (extract tests):   {test_only_total}")
+    print(f"  TOTAL references:            {internal_total + outbound_total + test_only_total}")
+
+    if outbound_details:
+        print(f"\n{'='*60}")
+        print(f"ALL OUTBOUND REFERENCES (production code that breaks):")
+        # Group by target module
+        targets = {}
+        for file, line, path in outbound_details:
+            target = path.split("::")[1] if "::" in path else path
+            targets.setdefault(target, []).append((file, line, path))
+
+        for target in sorted(targets):
+            print(f"\n  Target module: {target}")
+            for file, line, path in targets[target]:
+                print(f"    {file}:{line} → {path}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- Adds 5 new `#[ignore]` pipeline_wiring tests for issues lacking structural assertions: #1546 (anti-replay), #1530 (standing), #1531 (consequences), #1537 (economy), #1548 (content key rotation)
- Each has a corresponding `no_stale_ignores` check to enforce removal when wiring lands
- Adds orchestrator verification protocol and agent execution rules to CLAUDE.md

## Test plan
- [x] `cargo test -p scp-testing --test pipeline_wiring` — 8 pass, 16 ignored, 0 fail
- [x] `no_stale_ignores` passes (none of the new assertions are stale)
- [x] `pipeline_active_assertions_never_decrease` passes (MIN_ACTIVE unchanged at 5)

🤖 Generated with [Claude Code](https://claude.com/claude-code)