### PR TITLE
feat: wire TransportManager FFI + outstanding batch 3 ACs (#1490, #1532, #1533, #1539)

### DIFF
--- a/crates/scp-ffi/napi/src/context.rs
+++ b/crates/scp-ffi/napi/src/context.rs
@@ -120,6 +120,8 @@ pub struct NapiContextHandle {
     #[cfg(feature = "allow_in_memory_custody")]
     pub(crate) in_memory_custody: Option<Arc<OpaqueInMemoryKeyCustody>>,
     /// Handle to the creator's active signing key for UCAN minting.
+    /// Only read inside `#[cfg(feature = "allow_in_memory_custody")]` blocks.
+    #[allow(dead_code)]
     pub(crate) signing_key: Option<scp_platform::traits::KeyHandle>,
     /// The scp-core `ContextHandle` for this context, used for manager delegation.
     pub(crate) core_handle: Option<ContextHandle>,
@@ -1546,6 +1548,7 @@ pub async fn broadcast_unsubscribe(
 /// - Rejects with `SCP-PERM-3020` if the context has no custody provider.
 #[napi(js_name = "broadcastPublish")]
 #[allow(clippy::needless_pass_by_value)] // napi-rs requires owned String
+#[allow(clippy::unused_async)] // napi requires async for Promise return type
 pub async fn broadcast_publish(
     handle: &NapiContextHandle,
     author_did: String,
@@ -1643,6 +1646,7 @@ pub struct NapiBatchPublishResult {
 /// - Rejects with `SCP-PERM-3020` if the context has no custody provider.
 #[napi(js_name = "broadcastPublishAsset")]
 #[allow(clippy::needless_pass_by_value)] // napi-rs requires owned String
+#[allow(clippy::unused_async)] // napi requires async for Promise return type
 pub async fn broadcast_publish_asset(
     handle: &NapiContextHandle,
     author_did: String,
@@ -1693,13 +1697,19 @@ pub async fn broadcast_publish_asset(
     let etag = scp_core::context::compute_etag(&asset.body);
     // Capture the deploy_id string before moving into BroadcastContent (SCP-292).
     let deploy_id_str = deploy_id.as_ref().map_or_else(String::new, Clone::clone);
+    // Clone etag when custody feature is enabled — it's needed again in the
+    // return value after `content` consumes the clone.
+    #[cfg(feature = "allow_in_memory_custody")]
+    let etag_for_metadata = etag.clone();
+    #[cfg(not(feature = "allow_in_memory_custody"))]
+    let etag_for_metadata = etag;
     let content = scp_core::context::BroadcastContent {
         version: scp_core::context::BROADCAST_CONTENT_VERSION,
         metadata: scp_core::context::ContentMetadata {
             path: Some(content_path),
             content_type: Some(mime_type),
             deploy_id,
-            etag: Some(etag.clone()),
+            etag: Some(etag_for_metadata),
             immutable: false,
         },
         body: asset.body,
@@ -1775,6 +1785,7 @@ pub async fn broadcast_publish_asset(
 /// - Rejects if any asset fails validation or publish.
 #[napi(js_name = "broadcastPublishAssets")]
 #[allow(clippy::needless_pass_by_value)] // napi-rs requires owned String
+#[allow(clippy::unused_async)] // napi requires async for Promise return type
 pub async fn broadcast_publish_assets(
     handle: &NapiContextHandle,
     author_did: String,
@@ -2199,6 +2210,7 @@ fn parse_napi_proposal_id(hex_str: &str) -> napi::Result<[u8; 32]> {
 /// - Rejects with `SCP-CTX-2041` if the proposal fails.
 #[napi(js_name = "contextGovernancePropose")]
 #[allow(clippy::needless_pass_by_value)]
+#[allow(clippy::unused_async)] // napi requires async for Promise return type
 pub async fn context_governance_propose(
     handle: &NapiContextHandle,
     action_json: String,
@@ -2284,6 +2296,7 @@ pub async fn context_governance_propose(
 /// - Rejects with `SCP-CTX-2042` if the vote fails.
 #[napi(js_name = "contextGovernanceApprove")]
 #[allow(clippy::needless_pass_by_value)]
+#[allow(clippy::unused_async)] // napi requires async for Promise return type
 pub async fn context_governance_approve(
     handle: &NapiContextHandle,
     proposal_id_hex: String,
@@ -2344,6 +2357,7 @@ pub async fn context_governance_approve(
 /// - Rejects with `SCP-CTX-2043` if the vote fails.
 #[napi(js_name = "contextGovernanceReject")]
 #[allow(clippy::needless_pass_by_value)]
+#[allow(clippy::unused_async)] // napi requires async for Promise return type
 pub async fn context_governance_reject(
     handle: &NapiContextHandle,
     proposal_id_hex: String,

--- a/crates/scp-ffi/napi/src/context.rs
+++ b/crates/scp-ffi/napi/src/context.rs
@@ -942,7 +942,7 @@ pub fn context_subscribe(
     validate_did(&identity_did).map_err(|e| napi::Error::from(ScpNapiError::from(e)))?;
     drop(identity_did);
 
-    let Some(adapter) = crate::transport::get_relay_adapter() else {
+    let Some(transport_mgr) = crate::transport::get_transport_manager() else {
         // Reset the guard so the caller can retry after connecting a relay.
         handle
             .subscription_active
@@ -988,9 +988,8 @@ pub fn context_subscribe(
     // which has no active tokio runtime context.
     crate::runtime().spawn(async move {
         use futures::StreamExt;
-        use scp_transport::TransportAdapter;
 
-        let stream_result = adapter.subscribe(&routing_id, None).await;
+        let stream_result = transport_mgr.subscribe(&routing_id, None).await;
         let mut stream = match stream_result {
             Ok(s) => s,
             Err(e) => {

--- a/crates/scp-ffi/napi/src/event_log.rs
+++ b/crates/scp-ffi/napi/src/event_log.rs
@@ -462,13 +462,13 @@ pub fn event_log_checkpoint(
     #[cfg(not(feature = "allow_in_memory_custody"))]
     {
         let _ = (&handle, &identity, &epoch);
-        return Err(napi::Error::from(ScpNapiError::Permission {
+        Err(napi::Error::from(ScpNapiError::Permission {
             message: "event log checkpoint requires key custody -- the in_memory custody path \
                        is not available in this build. Enable allow_in_memory_custody \
                        for dev/desktop use."
                 .to_owned(),
             code: "SCP-PERM-3023".to_owned(),
-        }));
+        }))
     }
 
     #[cfg(feature = "allow_in_memory_custody")]
@@ -568,13 +568,13 @@ pub fn event_log_checkpoint_by_did(
     #[cfg(not(feature = "allow_in_memory_custody"))]
     {
         let _ = (&handle, &did, &epoch);
-        return Err(napi::Error::from(ScpNapiError::Permission {
+        Err(napi::Error::from(ScpNapiError::Permission {
             message: "event log checkpoint requires key custody -- the in_memory custody path \
                        is not available in this build. Enable allow_in_memory_custody \
                        for dev/desktop use."
                 .to_owned(),
             code: "SCP-PERM-3023".to_owned(),
-        }));
+        }))
     }
 
     #[cfg(feature = "allow_in_memory_custody")]
@@ -635,6 +635,7 @@ pub fn event_log_checkpoint_by_did(
 /// Validates that an f64 epoch value is non-negative and returns it as u64.
 ///
 /// Returns `napi::Error` with `SCP-VALID-7040` if the value is negative.
+#[cfg(feature = "allow_in_memory_custody")]
 fn validate_non_negative_epoch(epoch: f64) -> napi::Result<u64> {
     if epoch < 0.0 || !epoch.is_finite() {
         return Err(napi::Error::from(ScpNapiError::Validation {
@@ -752,34 +753,40 @@ mod tests {
     // -----------------------------------------------------------------------
 
     #[test]
+    #[cfg(feature = "allow_in_memory_custody")]
     fn validate_epoch_accepts_zero() {
         assert_eq!(validate_non_negative_epoch(0.0).unwrap(), 0);
     }
 
     #[test]
+    #[cfg(feature = "allow_in_memory_custody")]
     fn validate_epoch_accepts_positive() {
         assert_eq!(validate_non_negative_epoch(42.0).unwrap(), 42);
     }
 
     #[test]
+    #[cfg(feature = "allow_in_memory_custody")]
     fn validate_epoch_rejects_negative() {
         let result = validate_non_negative_epoch(-1.0);
         assert!(result.is_err(), "negative epoch should error");
     }
 
     #[test]
+    #[cfg(feature = "allow_in_memory_custody")]
     fn validate_epoch_rejects_negative_infinity() {
         let result = validate_non_negative_epoch(f64::NEG_INFINITY);
         assert!(result.is_err(), "NEG_INFINITY epoch should error");
     }
 
     #[test]
+    #[cfg(feature = "allow_in_memory_custody")]
     fn validate_epoch_rejects_f64_min() {
         let result = validate_non_negative_epoch(f64::MIN);
         assert!(result.is_err(), "f64::MIN epoch should error");
     }
 
     #[test]
+    #[cfg(feature = "allow_in_memory_custody")]
     fn validate_epoch_negative_error_contains_code() {
         let result = validate_non_negative_epoch(-42.0);
         let err = result.unwrap_err();
@@ -793,12 +800,14 @@ mod tests {
     }
 
     #[test]
+    #[cfg(feature = "allow_in_memory_custody")]
     fn validate_epoch_rejects_nan() {
         let result = validate_non_negative_epoch(f64::NAN);
         assert!(result.is_err(), "NaN epoch should error");
     }
 
     #[test]
+    #[cfg(feature = "allow_in_memory_custody")]
     fn validate_epoch_rejects_positive_infinity() {
         let result = validate_non_negative_epoch(f64::INFINITY);
         assert!(result.is_err(), "INFINITY epoch should error");

--- a/crates/scp-ffi/napi/src/identity.rs
+++ b/crates/scp-ffi/napi/src/identity.rs
@@ -35,20 +35,23 @@
 //!
 //! See ADR-022 in `.docs/adrs/phase-4.md` and ADR-039.
 
-use std::fmt;
 use std::sync::Arc;
 
 use napi::Error as NapiError;
 use napi_derive::napi;
+#[cfg(feature = "allow_in_memory_custody")]
+use scp_identity::{DhtClient, IdentityError};
 use scp_identity::{
-    DhtClient, DidCache, DidDht, DidDocument, DidMethod, DualLayerResolver, IdentityError,
-    InMemoryDhtClient, NoOpRelayQuerier, ScpIdentity,
+    DidCache, DidDht, DidDocument, DidMethod, DualLayerResolver, InMemoryDhtClient,
+    NoOpRelayQuerier, ScpIdentity,
 };
 #[cfg(feature = "allow_in_memory_custody")]
 use scp_platform::testing::InMemoryKeyCustody;
 #[cfg(feature = "allow_in_memory_custody")]
 use scp_platform::traits::KeyCustody;
 use scp_primitives::Clock;
+#[cfg(feature = "allow_in_memory_custody")]
+use std::fmt;
 
 use crate::error::{ScpNapiError, validate_custody_type};
 use crate::{decrement_handle_count, increment_handle_count};
@@ -341,17 +344,18 @@ impl NapiIdentity {
     ///
     /// See §3.9 Key Lifecycle, ADR-003 DID Creation.
     #[napi]
+    #[allow(clippy::unused_async)] // napi requires async for Promise return type
     pub async fn rotate_key(&self) -> napi::Result<Self> {
         #[cfg(not(feature = "allow_in_memory_custody"))]
         {
             let _ = self;
-            return Err(ScpNapiError::Identity {
+            Err(ScpNapiError::Identity {
                 message: "key rotation requires in-memory custody -- \
                           enable allow_in_memory_custody"
                     .to_owned(),
                 code: "SCP-IDENT-1007".to_owned(),
             }
-            .into());
+            .into())
         }
         #[cfg(feature = "allow_in_memory_custody")]
         {
@@ -414,11 +418,12 @@ impl NapiIdentity {
     ///
     /// See ADR-039 acceptance criterion 4 and SCP-AB-016.
     #[napi(js_name = "addAgentKey")]
+    #[allow(clippy::unused_async)] // napi requires async for Promise return type
     pub async fn add_agent_key(&self) -> napi::Result<Self> {
         #[cfg(not(feature = "allow_in_memory_custody"))]
         {
             let _ = self;
-            return Err(ScpNapiError::Identity { message: "agent key operations require in-memory custody -- enable allow_in_memory_custody".to_owned(), code: "SCP-IDENT-1007".to_owned() }.into());
+            Err(ScpNapiError::Identity { message: "agent key operations require in-memory custody -- enable allow_in_memory_custody".to_owned(), code: "SCP-IDENT-1007".to_owned() }.into())
         }
         #[cfg(feature = "allow_in_memory_custody")]
         {
@@ -482,11 +487,12 @@ impl NapiIdentity {
     ///
     /// See ADR-039 acceptance criterion 4 and SCP-AB-016.
     #[napi(js_name = "rotateAgentKey")]
+    #[allow(clippy::unused_async)] // napi requires async for Promise return type
     pub async fn rotate_agent_key(&self) -> napi::Result<Self> {
         #[cfg(not(feature = "allow_in_memory_custody"))]
         {
             let _ = self;
-            return Err(ScpNapiError::Identity { message: "agent key operations require in-memory custody -- enable allow_in_memory_custody".to_owned(), code: "SCP-IDENT-1007".to_owned() }.into());
+            Err(ScpNapiError::Identity { message: "agent key operations require in-memory custody -- enable allow_in_memory_custody".to_owned(), code: "SCP-IDENT-1007".to_owned() }.into())
         }
         #[cfg(feature = "allow_in_memory_custody")]
         {
@@ -550,11 +556,12 @@ impl NapiIdentity {
     ///
     /// See ADR-039 acceptance criterion 4 and SCP-AB-016.
     #[napi(js_name = "removeAgentKey")]
+    #[allow(clippy::unused_async)] // napi requires async for Promise return type
     pub async fn remove_agent_key(&self) -> napi::Result<Self> {
         #[cfg(not(feature = "allow_in_memory_custody"))]
         {
             let _ = self;
-            return Err(ScpNapiError::Identity { message: "agent key operations require in-memory custody -- enable allow_in_memory_custody".to_owned(), code: "SCP-IDENT-1007".to_owned() }.into());
+            Err(ScpNapiError::Identity { message: "agent key operations require in-memory custody -- enable allow_in_memory_custody".to_owned(), code: "SCP-IDENT-1007".to_owned() }.into())
         }
         #[cfg(feature = "allow_in_memory_custody")]
         {
@@ -623,17 +630,18 @@ impl NapiIdentity {
     ///
     /// See ADR-003 acceptance criterion 4b, spec §9.12, and SCP-214 criterion 10.
     #[napi]
+    #[allow(clippy::unused_async)] // napi requires async for Promise return type
     pub async fn migrate(&self) -> napi::Result<Self> {
         #[cfg(not(feature = "allow_in_memory_custody"))]
         {
             let _ = self;
-            return Err(ScpNapiError::Identity {
+            Err(ScpNapiError::Identity {
                 message: "identity migration requires in-memory custody -- \
                           enable allow_in_memory_custody"
                     .to_owned(),
                 code: "SCP-IDENT-1007".to_owned(),
             }
-            .into());
+            .into())
         }
         #[cfg(feature = "allow_in_memory_custody")]
         {
@@ -885,6 +893,7 @@ pub struct NapiDIDDocument {
 /// testing, CLI, and desktop builds. NOT suitable for production mobile use —
 /// use `"platform"` custody on iOS/Android.
 #[napi]
+#[allow(clippy::unused_async)] // napi requires async for Promise return type
 pub async fn identity_create(custody: String) -> napi::Result<NapiIdentity> {
     validate_custody_type(&custody).map_err(NapiError::from)?;
 
@@ -989,6 +998,7 @@ pub async fn identity_create(custody: String) -> napi::Result<NapiIdentity> {
 ///
 /// See ADR-039 acceptance criterion 4 and SCP-AB-016.
 #[napi(js_name = "identityCreateWithAgentKey")]
+#[allow(clippy::unused_async)] // napi requires async for Promise return type
 pub async fn identity_create_with_agent_key(custody: String) -> napi::Result<NapiIdentity> {
     validate_custody_type(&custody).map_err(NapiError::from)?;
 

--- a/crates/scp-ffi/napi/src/scpid.rs
+++ b/crates/scp-ffi/napi/src/scpid.rs
@@ -12,10 +12,12 @@ use std::time::Duration;
 
 use napi_derive::napi;
 
+#[cfg(feature = "allow_in_memory_custody")]
+use scp_core::identity::scpid_sign as core_sign;
 use scp_core::identity::{
-    ScpIdChallenge, ScpIdResponse, scpid_challenge as core_challenge, scpid_sign as core_sign,
-    scpid_verify as core_verify,
+    ScpIdChallenge, ScpIdResponse, scpid_challenge as core_challenge, scpid_verify as core_verify,
 };
+#[cfg(feature = "allow_in_memory_custody")]
 use scp_identity::SigningKeyId;
 
 use crate::error::ScpNapiError;
@@ -171,6 +173,7 @@ pub fn scpid_verify(response_json: String, challenge_json: String) -> napi::Resu
 
 /// Parses a signing key ID string (`"#active"` or `"#agent"`) into a
 /// [`SigningKeyId`] enum.
+#[cfg(feature = "allow_in_memory_custody")]
 fn parse_signing_key_id(s: &str) -> napi::Result<SigningKeyId> {
     match s {
         "#active" => Ok(SigningKeyId::Active),
@@ -241,6 +244,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg(feature = "allow_in_memory_custody")]
     fn parse_signing_key_id_valid() {
         assert_eq!(
             parse_signing_key_id("#active").unwrap(),
@@ -250,6 +254,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg(feature = "allow_in_memory_custody")]
     fn parse_signing_key_id_invalid() {
         assert!(parse_signing_key_id("active").is_err());
         assert!(parse_signing_key_id("#owner").is_err());
@@ -341,6 +346,7 @@ mod tests {
     /// type used by the bridge function). Proves that the resolver impl
     /// works end-to-end for SCPID verification.
     #[tokio::test]
+    #[cfg(feature = "allow_in_memory_custody")]
     async fn sign_verify_roundtrip_via_identity_backed_resolver() {
         use scp_identity::DidMethod;
 

--- a/crates/scp-ffi/napi/src/server.rs
+++ b/crates/scp-ffi/napi/src/server.rs
@@ -70,7 +70,7 @@ async fn auto_wire_context_manager(did: &str, relay_url: &str, bridge_token: Zer
         Ok(adapter) => {
             crate::runtime::init_context_manager_with_relay_transport(did, adapter);
 
-            // Also populate the RELAY_ADAPTER global so that broadcast
+            // Also populate the TRANSPORT_MANAGER global so that broadcast
             // publish, context subscribe, and discovery probing work without
             // a separate `transportConnect` call. This requires a second
             // WebSocket connection because NativeRelayAdapter is not Clone
@@ -83,14 +83,16 @@ async fn auto_wire_context_manager(did: &str, relay_url: &str, bridge_token: Zer
             .await
             {
                 Ok(relay_adapter) => {
-                    let _ = crate::transport::set_relay_adapter(std::sync::Arc::new(relay_adapter));
+                    let manager = scp_transport::TransportManager::new(Box::new(relay_adapter));
+                    let _ =
+                        crate::transport::set_transport_manager_arc(std::sync::Arc::new(manager));
                 }
                 Err(e) => {
                     tracing::warn!(
                         error = %e,
                         relay_url = %relay_url,
                         "auto_wire_context_manager: ContextManager wired but failed to \
-                         populate RELAY_ADAPTER — broadcast publish and discovery may \
+                         populate TRANSPORT_MANAGER — broadcast publish and discovery may \
                          require a manual transportConnect call"
                     );
                 }

--- a/crates/scp-ffi/napi/src/transport.rs
+++ b/crates/scp-ffi/napi/src/transport.rs
@@ -128,29 +128,8 @@ pub(crate) fn with_transport_manager<T>(
 pub(crate) fn with_transport_manager_mut<T>(
     f: impl FnOnce(&mut scp_transport::TransportManager) -> napi::Result<T>,
 ) -> napi::Result<T> {
-    let guard = transport_state()
-        .write()
-        .map_err(|_| ScpNapiError::Transport {
-            message: "transport manager lock is poisoned".to_owned(),
-            code: "SCP-TRANS-5002".to_owned(),
-        })?;
-    // Arc::get_mut won't work here because there may be cloned references
-    // held by async subscription tasks. Use Arc::make_mut which is
-    // Clone-only. Instead, we downcast through the Option.
-    //
-    // Since TransportManager uses interior mutability for most operations
-    // (relay_assignments: RwLock, reliability_scores: Arc<Mutex>, etc.),
-    // `add_adapter` is the only method requiring &mut self. We obtain it
-    // by temporarily taking the Arc out and using Arc::get_mut or
-    // reconstructing.
-    //
-    // Actually, `add_adapter(&mut self)` needs exclusive access. If other
-    // async tasks hold Arc clones, we can't get &mut. We use a write lock
-    // on the outer RwLock to serialize, but the Arc prevents &mut access.
-    // Solution: use `Arc::get_mut` which succeeds only when refcount == 1.
-    // If it fails (subscription in progress), we error out.
-    drop(guard);
-
+    // Arc::get_mut requires refcount == 1. If subscriptions hold cloned
+    // Arc references, this fails with a clear error rather than deadlocking.
     let mut guard = transport_state()
         .write()
         .map_err(|_| ScpNapiError::Transport {

--- a/crates/scp-ffi/napi/src/transport.rs
+++ b/crates/scp-ffi/napi/src/transport.rs
@@ -2,95 +2,208 @@
 //!
 //! Exposes relay connection management to JavaScript:
 //!
-//! - [`transport_connect`] — Connect to an SCP relay.
+//! - [`transport_connect`] — Connect to an SCP relay (wraps adapter in `TransportManager`).
 //! - [`transport_status`] — Query the current transport connection status.
 //! - [`transport_disconnect`] — Disconnect from the relay.
+//! - [`transport_add_relay`] — Add an additional relay adapter to the manager.
+//! - [`transport_assign_relay_set`] — Assign a relay set for a context.
+//! - [`transport_adapter_count`] — Query the number of registered adapters.
+//! - [`transport_reliability`] — Query reliability score for an adapter.
 //!
 //! # Transport model
 //!
-//! The napi bridge has full access to the native filesystem and OS networking
-//! stack — there are no WASM constraints. The tokio multi-thread runtime
-//! drives all async I/O. Full transport wiring (WebSocket, multi-relay
-//! routing) is connected in integration stories.
+//! The napi bridge stores a process-global [`scp_transport::TransportManager`]
+//! that wraps one or more [`NativeRelayAdapter`] instances. The manager
+//! provides multi-relay fanout, per-context relay set assignment, suppression
+//! cross-checking, and reliability scoring.
 //!
-//! See ADR-022 and ADR-005 (Transport Abstraction) in `.docs/adrs/`.
+//! The tokio multi-thread runtime drives all async I/O. Full transport wiring
+//! (WebSocket, multi-relay routing) is connected via the `TransportManager`.
+//!
+//! See ADR-022, ADR-005 (Transport Abstraction), and ADR-012 (Multi-Relay) in
+//! `.docs/adrs/`.
 
 use std::sync::{Arc, OnceLock, RwLock};
 
 use napi_derive::napi;
-use scp_ffi_common::validate::validate_relay_url;
-use scp_transport::native::adapter::NativeRelayAdapter;
+use scp_ffi_common::validate::{validate_context_id, validate_relay_url};
 
 use crate::error::ScpNapiError;
 use crate::{decrement_handle_count, increment_handle_count};
 
 // ---------------------------------------------------------------------------
-// Persistent relay adapter state
+// Persistent transport manager state
 // ---------------------------------------------------------------------------
 
-/// Global relay adapter connection, stored persistently so the WebSocket
-/// connection survives beyond the scope of `transport_connect`.
+/// Global transport manager for multi-relay support.
+///
+/// Stores the real [`scp_transport::TransportManager`] wrapping one or more
+/// [`NativeRelayAdapter`] instances. Provides multi-relay fanout, per-context
+/// relay set assignment, suppression detection, and reliability scoring.
 ///
 /// Set by [`transport_connect`] on successful connection.
 /// Cleared by [`transport_disconnect`].
-/// Read by [`transport_status`] to verify the connection is truly alive.
+/// Read by [`transport_status`] and [`context_subscribe`] (via
+/// [`get_transport_manager`]).
 ///
-/// Uses `OnceLock<RwLock<Option<Arc<NativeRelayAdapter>>>>` — the same
-/// pattern as the `PyO3` bridge's `RELAY_CONNECTION` in `runtime.rs`.
-static RELAY_ADAPTER: OnceLock<RwLock<Option<Arc<NativeRelayAdapter>>>> = OnceLock::new();
+/// Wrapped in `Arc` so async subscription tasks (which outlive the closure)
+/// can hold a reference without keeping the `RwLock` guard alive across
+/// `.await` points. Same `OnceLock<RwLock<...>>` pattern as the `PyO3`
+/// bridge's `TRANSPORT_MANAGER` in `runtime.rs`.
+static TRANSPORT_MANAGER: OnceLock<RwLock<Option<Arc<scp_transport::TransportManager>>>> =
+    OnceLock::new();
 
-/// Returns a reference to the global relay adapter state.
-fn relay_adapter_state() -> &'static RwLock<Option<Arc<NativeRelayAdapter>>> {
-    RELAY_ADAPTER.get_or_init(|| RwLock::new(None))
+/// Returns a reference to the global transport manager state.
+fn transport_state() -> &'static RwLock<Option<Arc<scp_transport::TransportManager>>> {
+    TRANSPORT_MANAGER.get_or_init(|| RwLock::new(None))
 }
 
-/// Stores a relay adapter in the global state.
+/// Stores a new `TransportManager` (called by [`transport_connect`]).
 ///
 /// # Errors
 ///
 /// Returns `ScpNapiError::Transport` if the lock is poisoned.
-pub(crate) fn set_relay_adapter(adapter: Arc<NativeRelayAdapter>) -> Result<(), ScpNapiError> {
-    *relay_adapter_state()
+fn set_transport_manager(manager: scp_transport::TransportManager) -> napi::Result<()> {
+    *transport_state()
         .write()
         .map_err(|_| ScpNapiError::Transport {
-            message: "relay adapter state lock is poisoned".to_owned(),
+            message: "transport manager lock is poisoned".to_owned(),
             code: "SCP-TRANS-5002".to_owned(),
-        })? = Some(adapter);
+        })? = Some(Arc::new(manager));
     Ok(())
 }
 
-/// Clears the stored relay adapter, dropping the WebSocket connection.
+/// Stores a pre-built `Arc<TransportManager>` (called by [`server.rs`]
+/// auto-wire where the caller needs to construct the manager externally).
 ///
 /// # Errors
 ///
 /// Returns `ScpNapiError::Transport` if the lock is poisoned.
-fn clear_relay_adapter() -> Result<(), ScpNapiError> {
-    *relay_adapter_state()
+pub(crate) fn set_transport_manager_arc(
+    manager: Arc<scp_transport::TransportManager>,
+) -> Result<(), ScpNapiError> {
+    *transport_state()
         .write()
         .map_err(|_| ScpNapiError::Transport {
-            message: "relay adapter state lock is poisoned".to_owned(),
+            message: "transport manager lock is poisoned".to_owned(),
             code: "SCP-TRANS-5002".to_owned(),
-        })? = None;
+        })? = Some(manager);
     Ok(())
 }
 
-/// Returns `true` if a relay adapter is currently stored (connection alive).
-fn has_relay_adapter() -> bool {
-    relay_adapter_state()
+/// Executes a closure with a read reference to the `TransportManager`.
+///
+/// Used by callers that need to query, probe, or inspect the manager
+/// without mutating it (sync operations only — for async, use
+/// [`get_transport_manager`]).
+///
+/// # Errors
+///
+/// Returns `ScpNapiError::Transport` if the lock is poisoned or no
+/// transport manager has been initialized.
+pub(crate) fn with_transport_manager<T>(
+    f: impl FnOnce(&scp_transport::TransportManager) -> napi::Result<T>,
+) -> napi::Result<T> {
+    let guard = transport_state()
+        .read()
+        .map_err(|_| ScpNapiError::Transport {
+            message: "transport manager lock is poisoned".to_owned(),
+            code: "SCP-TRANS-5002".to_owned(),
+        })?;
+    let manager = guard.as_ref().ok_or_else(|| ScpNapiError::Transport {
+        message: "no transport manager — call transportConnect() first".to_owned(),
+        code: "SCP-TRANS-5010".to_owned(),
+    })?;
+    f(manager)
+}
+
+/// Executes a closure with a mutable reference to the `TransportManager`.
+///
+/// Used by callers that need to add adapters or modify relay assignments.
+///
+/// # Errors
+///
+/// Returns `ScpNapiError::Transport` if the lock is poisoned or no
+/// transport manager has been initialized.
+pub(crate) fn with_transport_manager_mut<T>(
+    f: impl FnOnce(&mut scp_transport::TransportManager) -> napi::Result<T>,
+) -> napi::Result<T> {
+    let guard = transport_state()
+        .write()
+        .map_err(|_| ScpNapiError::Transport {
+            message: "transport manager lock is poisoned".to_owned(),
+            code: "SCP-TRANS-5002".to_owned(),
+        })?;
+    // Arc::get_mut won't work here because there may be cloned references
+    // held by async subscription tasks. Use Arc::make_mut which is
+    // Clone-only. Instead, we downcast through the Option.
+    //
+    // Since TransportManager uses interior mutability for most operations
+    // (relay_assignments: RwLock, reliability_scores: Arc<Mutex>, etc.),
+    // `add_adapter` is the only method requiring &mut self. We obtain it
+    // by temporarily taking the Arc out and using Arc::get_mut or
+    // reconstructing.
+    //
+    // Actually, `add_adapter(&mut self)` needs exclusive access. If other
+    // async tasks hold Arc clones, we can't get &mut. We use a write lock
+    // on the outer RwLock to serialize, but the Arc prevents &mut access.
+    // Solution: use `Arc::get_mut` which succeeds only when refcount == 1.
+    // If it fails (subscription in progress), we error out.
+    drop(guard);
+
+    let mut guard = transport_state()
+        .write()
+        .map_err(|_| ScpNapiError::Transport {
+            message: "transport manager lock is poisoned".to_owned(),
+            code: "SCP-TRANS-5002".to_owned(),
+        })?;
+
+    let arc = guard.as_mut().ok_or_else(|| ScpNapiError::Transport {
+        message: "no transport manager — call transportConnect() first".to_owned(),
+        code: "SCP-TRANS-5010".to_owned(),
+    })?;
+
+    let manager = Arc::get_mut(arc).ok_or_else(|| ScpNapiError::Transport {
+        message: "transport manager is in use by an active subscription — \
+                  cannot modify while subscriptions are active"
+            .to_owned(),
+        code: "SCP-TRANS-5003".to_owned(),
+    })?;
+    f(manager)
+}
+
+/// Returns `true` if a transport manager has been initialized.
+fn has_transport_manager() -> bool {
+    transport_state()
         .read()
         .map(|guard| guard.is_some())
         .unwrap_or(false)
 }
 
-/// Returns a clone of the current relay adapter, if one is connected.
+/// Returns an `Arc` clone of the current transport manager, if one exists.
 ///
-/// Used by the context module to subscribe to relay messages for incoming
-/// message delivery.
-pub(crate) fn get_relay_adapter() -> Option<Arc<NativeRelayAdapter>> {
-    relay_adapter_state()
+/// Used by `context_subscribe` which needs to move the manager reference
+/// into an async task that outlives any lock guard.
+pub(crate) fn get_transport_manager() -> Option<Arc<scp_transport::TransportManager>> {
+    transport_state()
         .read()
         .ok()
         .and_then(|guard| guard.clone())
+}
+
+/// Clears the transport manager (called by [`transport_disconnect`]).
+///
+/// # Errors
+///
+/// Returns `ScpNapiError::Transport` if the lock is poisoned.
+fn clear_transport_manager() -> napi::Result<()> {
+    *transport_state()
+        .write()
+        .map_err(|_| ScpNapiError::Transport {
+            message: "transport manager lock is poisoned".to_owned(),
+            code: "SCP-TRANS-5002".to_owned(),
+        })? = None;
+    Ok(())
 }
 
 // ---------------------------------------------------------------------------
@@ -231,10 +344,11 @@ pub async fn transport_connect(relay_url: String) -> napi::Result<NapiTransportM
             #[allow(clippy::cast_precision_loss)]
             let latency = start.elapsed().as_millis() as f64;
 
-            // Store the adapter in persistent global state so the WebSocket
-            // connection survives beyond this function scope.
-            let arc_adapter = Arc::new(adapter);
-            set_relay_adapter(arc_adapter)?;
+            // Wrap the adapter in a TransportManager for multi-relay support,
+            // then store it in the process-global state. Same pattern as the
+            // PyO3 bridge's `py_transport_connect`.
+            let manager = scp_transport::TransportManager::new(Box::new(adapter));
+            set_transport_manager(manager)?;
 
             let handle = NapiTransportManager {
                 status: std::sync::Mutex::new(NapiTransportStatus {
@@ -272,11 +386,11 @@ pub async fn transport_connect(relay_url: String) -> napi::Result<NapiTransportM
 #[allow(clippy::unused_async)] // napi-rs requires async for Promise return
 pub async fn transport_status(manager: &NapiTransportManager) -> napi::Result<NapiTransportStatus> {
     let mut status = manager.status();
-    // Defense-in-depth: verify the adapter is actually alive, not just
-    // what the manager's local status believes. If the adapter has been
-    // dropped (e.g., disconnect was called without updating the manager),
-    // report disconnected.
-    if status.connected && !has_relay_adapter() {
+    // Defense-in-depth: verify the transport manager is actually alive,
+    // not just what the manager's local status believes. If the transport
+    // manager has been dropped (e.g., disconnect was called without
+    // updating the manager), report disconnected.
+    if status.connected && !has_transport_manager() {
         status.connected = false;
     }
     Ok(status)
@@ -316,8 +430,8 @@ pub async fn transport_disconnect(manager: &NapiTransportManager) -> napi::Resul
     s.latency_ms = None;
     drop(s);
 
-    // Drop the persistent adapter, closing the WebSocket connection.
-    clear_relay_adapter()?;
+    // Drop the transport manager, closing all WebSocket connections.
+    clear_transport_manager()?;
 
     Ok(())
 }
@@ -362,7 +476,7 @@ pub fn configure_local_transport(local_did: String) -> napi::Result<()> {
 ///
 /// The `relay_url` must point to a running relay. A separate
 /// `transportConnect` call is still needed for `contextSubscribe` (which
-/// uses the global `RELAY_ADAPTER` for its subscription stream).
+/// uses the global `TRANSPORT_MANAGER` for its subscription stream).
 ///
 /// # Arguments
 ///
@@ -398,6 +512,170 @@ pub async fn configure_relay_transport(relay_url: String, local_did: String) -> 
 
     crate::runtime::init_context_manager_with_relay_transport(&local_did, adapter);
     Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// NapiReliabilityScore — per-adapter reliability metrics
+// ---------------------------------------------------------------------------
+
+/// Per-adapter reliability score exposed to JavaScript.
+///
+/// Returned by [`transport_reliability`] and maps to the core
+/// [`scp_transport::scoring::ReliabilityScore`].
+#[napi(object)]
+pub struct NapiReliabilityScore {
+    /// The relay URL this score tracks.
+    pub relay_url: String,
+    /// Delivery success rate (0.0 to 1.0), updated via EMA.
+    pub delivery_success_rate: f64,
+    /// Average latency in milliseconds, updated via EMA.
+    pub average_latency_ms: f64,
+    /// Deletion compliance rate (0.0 to 1.0), updated via EMA.
+    pub deletion_compliance_rate: f64,
+    /// Total number of send attempts.
+    pub total_sends: f64,
+    /// Total number of send failures.
+    pub total_failures: f64,
+}
+
+// ---------------------------------------------------------------------------
+// Multi-relay management functions
+// ---------------------------------------------------------------------------
+
+/// Registers an additional relay adapter with the transport manager.
+///
+/// Connects to the specified relay URL and adds the resulting adapter to
+/// the global [`TransportManager`]. The [`transport_connect`] function must
+/// have been called first to initialize the manager.
+///
+/// # Arguments
+///
+/// * `relay_url` — The URL of the additional SCP relay to connect to.
+///
+/// # Returns
+///
+/// A `Promise<number>` resolving to the total number of adapters after
+/// adding (i.e. the new adapter count).
+///
+/// # Errors
+///
+/// - Rejects with `SCP-TRANS-5010` if no transport manager exists.
+/// - Rejects with `SCP-VALID-7000` if the URL is invalid.
+/// - Rejects with `SCP-TRANS-5001` if the connection fails.
+/// - Rejects with `SCP-TRANS-5003` if a subscription is active.
+#[napi]
+pub async fn transport_add_relay(relay_url: String) -> napi::Result<u32> {
+    validate_relay_url(&relay_url).map_err(|e| napi::Error::from(ScpNapiError::from(e)))?;
+
+    let sourced = scp_transport::relay::connection::SourcedRelayUrl {
+        url: relay_url.clone(),
+        source: scp_transport::relay::connection::RelayUrlSource::Explicit,
+    };
+    let profile = scp_transport::profile::TransportProfile::platform_default();
+    let adapter =
+        scp_transport::native::NativeRelayAdapter::connect_sourced(&sourced, Some(&profile))
+            .await
+            .map_err(|e| ScpNapiError::Transport {
+                message: format!("failed to connect to relay '{relay_url}': {e}"),
+                code: "SCP-TRANS-5001".to_owned(),
+            })?;
+
+    with_transport_manager_mut(|manager| {
+        let _eviction = manager.add_adapter(Box::new(adapter));
+        #[allow(clippy::cast_possible_truncation)]
+        Ok(manager.adapter_count() as u32)
+    })
+}
+
+/// Assigns a relay set for the given context.
+///
+/// Delegates to [`TransportManager::assign_relay_set`] which selects at
+/// least `min_relays` adapters per context using round-robin spread to
+/// minimize overlap.
+///
+/// # Arguments
+///
+/// * `context_id` — The context to assign relays for.
+///
+/// # Returns
+///
+/// A list of adapter indices assigned to this context.
+///
+/// # Errors
+///
+/// - Rejects with `SCP-TRANS-5010` if no transport manager exists.
+/// - Rejects with `SCP-VALID-7000` if `context_id` is invalid.
+/// - Rejects with `SCP-TRANS-5002` if relay set assignment fails.
+#[napi]
+pub fn transport_assign_relay_set(context_id: String) -> napi::Result<Vec<u32>> {
+    validate_context_id(&context_id).map_err(|e| napi::Error::from(ScpNapiError::from(e)))?;
+    with_transport_manager(|manager| {
+        manager
+            .assign_relay_set(&context_id)
+            .map(|indices| {
+                indices
+                    .into_iter()
+                    .map(|i| {
+                        #[allow(clippy::cast_possible_truncation)]
+                        {
+                            i as u32
+                        }
+                    })
+                    .collect()
+            })
+            .map_err(|e| {
+                napi::Error::from(ScpNapiError::Transport {
+                    message: format!("relay set assignment failed: {e}"),
+                    code: "SCP-TRANS-5002".to_owned(),
+                })
+            })
+    })
+}
+
+/// Returns the number of adapters registered in the transport manager.
+///
+/// # Errors
+///
+/// Rejects with `SCP-TRANS-5010` if no transport manager has been
+/// initialized.
+#[napi]
+pub fn transport_adapter_count() -> napi::Result<u32> {
+    with_transport_manager(|manager| {
+        #[allow(clippy::cast_possible_truncation)]
+        Ok(manager.adapter_count() as u32)
+    })
+}
+
+/// Returns the reliability score for an adapter by index.
+///
+/// Returns the score as a [`NapiReliabilityScore`] object, or `null` if
+/// no score exists for the given adapter index.
+///
+/// # Arguments
+///
+/// * `adapter_index` — The adapter index (0-based) to query.
+///
+/// # Errors
+///
+/// Rejects with `SCP-TRANS-5010` if no transport manager has been
+/// initialized.
+#[napi]
+pub fn transport_reliability(adapter_index: u32) -> napi::Result<Option<NapiReliabilityScore>> {
+    with_transport_manager(|manager| {
+        Ok(manager
+            .get_reliability_score(adapter_index as usize)
+            .map(|score| {
+                #[allow(clippy::cast_precision_loss)]
+                NapiReliabilityScore {
+                    relay_url: score.relay_url.clone(),
+                    delivery_success_rate: score.delivery_success_rate,
+                    average_latency_ms: score.average_latency_ms as f64,
+                    deletion_compliance_rate: score.deletion_compliance_rate,
+                    total_sends: score.total_sends as f64,
+                    total_failures: score.total_failures as f64,
+                }
+            }))
+    })
 }
 
 #[cfg(test)]
@@ -466,27 +744,29 @@ mod tests {
     }
 
     // -----------------------------------------------------------------------
-    // Relay adapter persistence
+    // Transport manager persistence
     // -----------------------------------------------------------------------
 
     #[test]
-    fn relay_adapter_initially_absent() {
-        // Before any connection, no adapter should be stored.
-        assert!(!has_relay_adapter());
+    fn transport_manager_initially_absent() {
+        // Before any connection, no transport manager should be stored.
+        assert!(!has_transport_manager());
     }
 
     #[test]
-    fn clear_relay_adapter_is_idempotent() {
+    fn clear_transport_manager_is_idempotent() {
         // Clearing when nothing is stored should not error.
-        assert!(clear_relay_adapter().is_ok());
+        assert!(clear_transport_manager().is_ok());
     }
 
-    // Note: `set_relay_adapter` requires a real `NativeRelayAdapter` which
-    // can only be obtained by connecting to a live relay. A full set→clear
-    // roundtrip test would need integration-test infrastructure (a running
-    // relay). The adapter persistence helpers (`set_relay_adapter`,
-    // `clear_relay_adapter`, `has_relay_adapter`) are individually covered
-    // above; the integration-level roundtrip is deferred to E2E tests.
+    // Note: `set_transport_manager` requires a real `NativeRelayAdapter`
+    // (wrapped in `TransportManager`) which can only be obtained by
+    // connecting to a live relay. A full set→clear roundtrip test would
+    // need integration-test infrastructure (a running relay). The
+    // persistence helpers (`set_transport_manager`,
+    // `clear_transport_manager`, `has_transport_manager`) are individually
+    // covered above; the integration-level roundtrip is deferred to E2E
+    // tests.
 
     // -----------------------------------------------------------------------
     // NapiTransportManager — connected state and defense-in-depth
@@ -551,26 +831,26 @@ mod tests {
     }
 
     #[test]
-    fn transport_status_defense_in_depth_detects_absent_adapter() {
+    fn transport_status_defense_in_depth_detects_absent_manager() {
         // Construct a manager that believes it is connected, but ensure
-        // the global adapter state is empty. The defense-in-depth check in
-        // `transport_status` should override the local status to report
-        // disconnected.
-        clear_relay_adapter().unwrap();
+        // the global transport manager state is empty. The defense-in-depth
+        // check in `transport_status` should override the local status to
+        // report disconnected.
+        clear_transport_manager().unwrap();
         let manager = make_connected_manager();
 
         // The manager's local status says connected.
         assert!(manager.is_connected());
 
-        // But transport_status checks has_relay_adapter() and corrects it.
+        // But transport_status checks has_transport_manager() and corrects it.
         let mut status = manager.status();
-        if status.connected && !has_relay_adapter() {
+        if status.connected && !has_transport_manager() {
             status.connected = false;
         }
         assert!(
             !status.connected,
             "defense-in-depth: transport_status should report disconnected \
-             when the adapter is absent even if the manager thinks it is connected"
+             when the transport manager is absent even if the handle thinks it is connected"
         );
     }
 }

--- a/crates/scp-ffi/napi/src/transport.rs
+++ b/crates/scp-ffi/napi/src/transport.rs
@@ -339,16 +339,28 @@ pub async fn transport_connect(relay_url: String) -> napi::Result<NapiTransportM
         scp_transport::native::NativeRelayAdapter::connect_sourced(&sourced, Some(&profile)).await;
 
     match adapter_result {
-        Ok(adapter) => {
+        Ok(mut adapter) => {
             // Connection succeeded. Measure latency.
             #[allow(clippy::cast_precision_loss)]
             let latency = start.elapsed().as_millis() as f64;
 
+            // Extract the suppression event receiver BEFORE moving the adapter
+            // into the TransportManager. The spawned task drains suppression
+            // events and downgrades the relay's reliability score (#1533 AC5).
+            let suppression_rx = adapter.take_suppression_receiver();
+
             // Wrap the adapter in a TransportManager for multi-relay support,
             // then store it in the process-global state. Same pattern as the
             // PyO3 bridge's `py_transport_connect`.
+            // Cover traffic is already running — `connect_sourced` with a
+            // profile auto-starts it via `finalize_connection` (#1532 AC6).
             let manager = scp_transport::TransportManager::new(Box::new(adapter));
             set_transport_manager(manager)?;
+
+            // Spawn suppression → scoring bridge task.
+            if let Some(rx) = suppression_rx {
+                spawn_suppression_scoring_task(rx, relay_url.clone());
+            }
 
             let handle = NapiTransportManager {
                 status: std::sync::Mutex::new(NapiTransportStatus {
@@ -572,7 +584,10 @@ pub async fn transport_add_relay(relay_url: String) -> napi::Result<u32> {
         source: scp_transport::relay::connection::RelayUrlSource::Explicit,
     };
     let profile = scp_transport::profile::TransportProfile::platform_default();
-    let adapter =
+    // Cover traffic auto-starts per adapter via `connect_sourced` with a
+    // profile — `finalize_connection` launches the cover traffic background
+    // task based on the profile's tier (#1532 AC6).
+    let mut adapter =
         scp_transport::native::NativeRelayAdapter::connect_sourced(&sourced, Some(&profile))
             .await
             .map_err(|e| ScpNapiError::Transport {
@@ -580,11 +595,23 @@ pub async fn transport_add_relay(relay_url: String) -> napi::Result<u32> {
                 code: "SCP-TRANS-5001".to_owned(),
             })?;
 
-    with_transport_manager_mut(|manager| {
+    // Extract the suppression event receiver BEFORE moving the adapter into
+    // the TransportManager. The spawned task drains suppression events and
+    // downgrades the relay's reliability score (#1533 AC5).
+    let suppression_rx = adapter.take_suppression_receiver();
+
+    let count = with_transport_manager_mut(|manager| {
         let _eviction = manager.add_adapter(Box::new(adapter));
         #[allow(clippy::cast_possible_truncation)]
         Ok(manager.adapter_count() as u32)
-    })
+    })?;
+
+    // Spawn suppression → scoring bridge task.
+    if let Some(rx) = suppression_rx {
+        spawn_suppression_scoring_task(rx, relay_url);
+    }
+
+    Ok(count)
 }
 
 /// Assigns a relay set for the given context.
@@ -676,6 +703,46 @@ pub fn transport_reliability(adapter_index: u32) -> napi::Result<Option<NapiReli
                 }
             }))
     })
+}
+
+// ---------------------------------------------------------------------------
+// Suppression → scoring bridge task
+// ---------------------------------------------------------------------------
+
+/// Spawns a background task that drains heartbeat suppression events from a
+/// per-adapter receiver and records each as a delivery failure in the global
+/// transport manager's reliability scoring.
+///
+/// This bridges the per-adapter heartbeat monitor (spec §9.9.2) with the
+/// `TransportManager`'s cross-relay `SuppressionTracker` (spec §9.9.4,
+/// #1533 AC5). Each suppression event downgrades the relay's reliability
+/// score via `DeliveryOutcome::Failure`.
+///
+/// The task exits gracefully when the sender half is dropped (adapter
+/// dropped or disconnected).
+fn spawn_suppression_scoring_task(
+    mut rx: tokio::sync::mpsc::Receiver<scp_transport::heartbeat::SuppressionSuspected>,
+    relay_url: String,
+) {
+    tokio::spawn(async move {
+        while let Some(_suppression) = rx.recv().await {
+            tracing::debug!(
+                relay_url = %relay_url,
+                "heartbeat suppression → downgrading relay reliability score"
+            );
+            // Read-lock the global transport manager to update the score.
+            // If the manager was cleared (disconnect), we silently stop.
+            if let Ok(guard) = transport_state().read()
+                && let Some(ref arc_mgr) = *guard
+            {
+                arc_mgr.update_score(&relay_url, scp_transport::scoring::DeliveryOutcome::Failure);
+            }
+        }
+        tracing::debug!(
+            relay_url = %relay_url,
+            "suppression scoring task exited — adapter disconnected"
+        );
+    });
 }
 
 #[cfg(test)]

--- a/crates/scp-ffi/napi/src/ucan.rs
+++ b/crates/scp-ffi/napi/src/ucan.rs
@@ -29,6 +29,7 @@
 use std::collections::HashMap;
 
 use napi_derive::napi;
+#[cfg(feature = "allow_in_memory_custody")]
 use scp_core::crypto::ucan::mint::{MintParams, mint_ucan};
 use scp_ffi_common::validate::{validate_capability_uri, validate_did, validate_ucan_token};
 
@@ -45,8 +46,10 @@ use scp_ffi_common::{
 };
 
 use crate::context::NapiContextHandle;
+use crate::decrement_handle_count;
 use crate::error::ScpNapiError;
-use crate::{decrement_handle_count, increment_handle_count};
+#[cfg(feature = "allow_in_memory_custody")]
+use crate::increment_handle_count;
 
 // ---------------------------------------------------------------------------
 // NapiUcanTokenData — UCAN token metadata record
@@ -313,6 +316,7 @@ pub async fn ucan_validate(
 /// - Rejects with `SCP-PERM-3023` if signing or token construction fails.
 #[napi]
 #[allow(clippy::needless_pass_by_value)] // napi-rs requires owned String/Vec/Option<Vec>
+#[allow(clippy::unused_async)] // napi requires async for Promise return type
 pub async fn ucan_mint(
     handle: &NapiContextHandle,
     member_did: String,
@@ -330,10 +334,10 @@ pub async fn ucan_mint(
     #[cfg(not(feature = "allow_in_memory_custody"))]
     {
         let _ = (&handle, &member_did, &capabilities, &proofs);
-        return Err(napi::Error::from(ScpNapiError::Permission {
+        Err(napi::Error::from(ScpNapiError::Permission {
             message: "UCAN minting requires key custody -- the in_memory custody path                       is not available in this build. Enable allow_in_memory_custody                       for dev/desktop use.".to_owned(),
             code: "SCP-PERM-3023".to_owned(),
-        }));
+        }))
     }
 
     #[cfg(feature = "allow_in_memory_custody")]
@@ -478,13 +482,13 @@ pub async fn ucan_delegate(
             &parent_token,
             &capabilities,
         );
-        return Err(napi::Error::from(ScpNapiError::Permission {
+        Err(napi::Error::from(ScpNapiError::Permission {
             message: "UCAN delegation requires key custody -- the in_memory custody path \
                        is not available in this build. Enable allow_in_memory_custody \
                        for dev/desktop use."
                 .to_owned(),
             code: "SCP-PERM-3023".to_owned(),
-        }));
+        }))
     }
 
     #[cfg(feature = "allow_in_memory_custody")]

--- a/crates/scp-ffi/src/mcp.rs
+++ b/crates/scp-ffi/src/mcp.rs
@@ -1866,7 +1866,6 @@ pub fn py_mcp_load_contexts(
 fn probe_relay_for_known_contexts(
     known: &[(String, crate::runtime::KnownContext)],
 ) -> std::collections::HashSet<String> {
-    use scp_transport::TransportAdapter;
     use scp_transport::traits::RoutingId;
 
     let mut active = std::collections::HashSet::new();
@@ -1875,25 +1874,25 @@ fn probe_relay_for_known_contexts(
         return active;
     }
 
-    // Get the relay adapter. If none is connected, return empty set.
-    let Ok(Some(adapter)) = crate::runtime::get_relay_connection() else {
+    // Check if a transport manager is available. If not, return empty set.
+    if !crate::runtime::has_transport_manager() {
         return active;
-    };
+    }
 
     // Get the tokio runtime for blocking on async queries.
     let Ok(rt) = crate::runtime() else {
         return active;
     };
 
-    // Probe each known context's routing ID on the relay.
+    // Probe each known context's routing ID on the relay via the
+    // TransportManager. Uses manager.query() which delegates to the
+    // first adapter (Phase 1 single-adapter mode).
     for (ctx_id, known_ctx) in known {
         let routing_id = RoutingId::new(known_ctx.routing_id);
-        let query_result = rt.block_on(async {
-            // Use query() from the TransportAdapter trait with limit-like
-            // behavior: we only need to know if any blobs exist. The QUERY
-            // message returns all matching blobs up to the default limit, but
-            // we only check if the result is non-empty.
-            adapter.query(&routing_id, None).await
+        let query_result = crate::runtime::with_transport_manager(|manager| {
+            rt.block_on(manager.query(&routing_id, None)).map_err(|e| {
+                crate::error::ScpPyError::transport(format!("relay probe failed: {e}"))
+            })
         });
 
         match query_result {
@@ -2153,11 +2152,11 @@ fn cleanup_stopped_servers() -> usize {
 ///
 /// # Errors
 ///
-/// Raises `TransportError` if the relay state lock is poisoned.
+/// Raises `PyErr` if building the result dict fails.
 #[pyfunction]
 #[pyo3(name = "py_registry_stats")]
 pub fn py_registry_stats(py: Python<'_>) -> PyResult<PyObject> {
-    let core_stats = crate::runtime::registry_stats()?;
+    let core_stats = crate::runtime::registry_stats();
     let mcp_stats = mcp_registry_stats();
 
     let dict = PyDict::new(py);
@@ -3227,7 +3226,7 @@ mod tests {
 
     #[test]
     fn core_registry_stats_includes_all_fields() {
-        let stats = crate::runtime::registry_stats().unwrap();
+        let stats = crate::runtime::registry_stats();
         // Just verify the struct has the expected fields and doesn't panic.
         let _ = stats.contexts;
         let _ = stats.known_contexts;

--- a/crates/scp-ffi/src/runtime.rs
+++ b/crates/scp-ffi/src/runtime.rs
@@ -1179,6 +1179,22 @@ pub fn has_transport_manager() -> bool {
         .is_some_and(|guard| guard.is_some())
 }
 
+/// Records a heartbeat suppression event for a relay, downgrading its
+/// reliability score.
+///
+/// Called from the background task spawned by `transport_add_relay` /
+/// `transport_connect` that drains the per-adapter suppression receiver
+/// (#1533 AC5). Silently no-ops if the transport manager has been cleared
+/// (e.g., after disconnect).
+pub fn record_suppression(relay_url: &str) {
+    let Ok(guard) = transport_state().read() else {
+        return;
+    };
+    if let Some(manager) = guard.as_ref() {
+        manager.update_score(relay_url, scp_transport::scoring::DeliveryOutcome::Failure);
+    }
+}
+
 /// Clears the transport manager (called by `py_transport_disconnect`).
 ///
 /// After this, relay-based context discovery in `py_mcp_load_contexts`

--- a/crates/scp-ffi/src/runtime.rs
+++ b/crates/scp-ffi/src/runtime.rs
@@ -75,7 +75,6 @@ use scp_identity::{DidDocument, ScpIdentity};
 use scp_platform::encrypting_adapter::EncryptingAdapter;
 use scp_platform::testing::InMemoryStorage;
 use scp_primitives::Clock;
-use scp_transport::native::adapter::NativeRelayAdapter;
 use tokio::sync::mpsc;
 use zeroize::Zeroizing;
 
@@ -1032,7 +1031,7 @@ pub fn remove_identity(did: &str) {
 /// replace it when platform storage adapters land.
 ///
 /// Uses the same `OnceLock` pattern as `FFI_BRIDGE_STATE` and
-/// `RELAY_CONNECTION`. The `Arc` enables shared ownership across bridge
+/// `TRANSPORT_MANAGER`. The `Arc` enables shared ownership across bridge
 /// functions without lifetime issues.
 ///
 /// See spec section 17.3 for key conventions and section 17.4 for
@@ -1095,67 +1094,105 @@ pub fn get_storage() -> Result<&'static Arc<EncryptingAdapter<InMemoryStorage>>,
 // Relay connection state (SCP-213: transport wiring)
 // ---------------------------------------------------------------------------
 
-/// Global relay connection for context discovery probing.
+/// Global transport manager for multi-relay support.
 ///
-/// Set by [`set_relay_connection`] when `py_transport_connect` succeeds.
-/// Read by `py_mcp_load_contexts` to probe routing IDs on the relay.
-/// Uses `RwLock` for infrequent writes (connect) and concurrent reads (probe).
+/// Stores the real [`scp_transport::TransportManager`] with multi-relay
+/// fanout, per-context relay set assignment, suppression detection, and
+/// reliability scoring.
+///
+/// Initialized by [`set_transport_manager`] when `py_transport_connect`
+/// succeeds. Read by `py_mcp_load_contexts` to probe routing IDs on
+/// relays. Uses `RwLock` for infrequent writes (connect) and concurrent
+/// reads (probe/query).
 ///
 /// # Safety: Single-Tenant Only
 ///
 /// This registry is process-global. See module-level documentation.
-static RELAY_CONNECTION: OnceLock<RwLock<Option<Arc<NativeRelayAdapter>>>> = OnceLock::new();
+static TRANSPORT_MANAGER: OnceLock<RwLock<Option<scp_transport::TransportManager>>> =
+    OnceLock::new();
 
-/// Returns a reference to the global relay connection state.
-fn relay_state() -> &'static RwLock<Option<Arc<NativeRelayAdapter>>> {
-    RELAY_CONNECTION.get_or_init(|| RwLock::new(None))
+/// Returns a reference to the global transport manager state.
+fn transport_state() -> &'static RwLock<Option<scp_transport::TransportManager>> {
+    TRANSPORT_MANAGER.get_or_init(|| RwLock::new(None))
 }
 
-/// Stores a relay adapter connection for use by context discovery.
-///
-/// Called by `py_transport_connect` after a successful connection. The
-/// adapter is wrapped in `Arc` for shared ownership between the transport
-/// module and the discovery path in `py_mcp_load_contexts`.
+/// Stores a new `TransportManager` (called by `py_transport_connect`).
 ///
 /// # Errors
 ///
-/// Returns `ScpPyError::TransportError` if the relay state lock is poisoned.
-pub fn set_relay_connection(adapter: Arc<NativeRelayAdapter>) -> Result<(), ScpPyError> {
-    *relay_state().write().map_err(|_| {
-        ScpPyError::transport("relay connection state lock is poisoned".to_owned())
-    })? = Some(adapter);
+/// Returns `ScpPyError::TransportError` if the transport manager lock is
+/// poisoned.
+pub fn set_transport_manager(manager: scp_transport::TransportManager) -> Result<(), ScpPyError> {
+    let mut guard = transport_state()
+        .write()
+        .map_err(|_| ScpPyError::transport("transport manager lock poisoned".to_owned()))?;
+    *guard = Some(manager);
     Ok(())
 }
 
-/// Returns the current relay adapter connection, if one is active.
+/// Executes a closure with a read reference to the `TransportManager`.
 ///
-/// Used by `py_mcp_load_contexts` to probe routing IDs. Returns `None`
-/// if `py_transport_connect` has not been called or the connection was
-/// cleared.
+/// Used by callers that need to query, probe, or inspect the manager
+/// without mutating it.
 ///
 /// # Errors
 ///
-/// Returns `ScpPyError::TransportError` if the relay state lock is poisoned.
-pub fn get_relay_connection() -> Result<Option<Arc<NativeRelayAdapter>>, ScpPyError> {
-    let guard = relay_state()
+/// Returns `ScpPyError::TransportError` if the lock is poisoned or no
+/// transport manager has been initialized.
+pub fn with_transport_manager<T>(
+    f: impl FnOnce(&scp_transport::TransportManager) -> Result<T, ScpPyError>,
+) -> Result<T, ScpPyError> {
+    let guard = transport_state()
         .read()
-        .map_err(|_| ScpPyError::transport("relay connection state lock is poisoned".to_owned()))?;
-    Ok(guard.clone())
+        .map_err(|_| ScpPyError::transport("transport manager lock poisoned".to_owned()))?;
+    let manager = guard.as_ref().ok_or_else(|| {
+        ScpPyError::transport("no transport manager — call transport_connect first".to_owned())
+    })?;
+    f(manager)
 }
 
-/// Clears the active relay connection.
+/// Executes a closure with a mutable reference to the `TransportManager`.
 ///
-/// Called when the transport is disconnected. After this, relay-based
-/// context discovery in `py_mcp_load_contexts` will fall back to
-/// local-only mode.
+/// Used by callers that need to add adapters or modify relay assignments.
 ///
 /// # Errors
 ///
-/// Returns `ScpPyError::TransportError` if the relay state lock is poisoned.
-pub fn clear_relay_connection() -> Result<(), ScpPyError> {
-    *relay_state().write().map_err(|_| {
-        ScpPyError::transport("relay connection state lock is poisoned".to_owned())
-    })? = None;
+/// Returns `ScpPyError::TransportError` if the lock is poisoned or no
+/// transport manager has been initialized.
+pub fn with_transport_manager_mut<T>(
+    f: impl FnOnce(&mut scp_transport::TransportManager) -> Result<T, ScpPyError>,
+) -> Result<T, ScpPyError> {
+    let mut guard = transport_state()
+        .write()
+        .map_err(|_| ScpPyError::transport("transport manager lock poisoned".to_owned()))?;
+    let manager = guard.as_mut().ok_or_else(|| {
+        ScpPyError::transport("no transport manager — call transport_connect first".to_owned())
+    })?;
+    f(manager)
+}
+
+/// Returns `true` if a transport manager has been initialized.
+pub fn has_transport_manager() -> bool {
+    TRANSPORT_MANAGER
+        .get()
+        .and_then(|lock| lock.read().ok())
+        .is_some_and(|guard| guard.is_some())
+}
+
+/// Clears the transport manager (called by `py_transport_disconnect`).
+///
+/// After this, relay-based context discovery in `py_mcp_load_contexts`
+/// will fall back to local-only mode.
+///
+/// # Errors
+///
+/// Returns `ScpPyError::TransportError` if the transport manager lock is
+/// poisoned.
+pub fn clear_transport_manager() -> Result<(), ScpPyError> {
+    let mut guard = transport_state()
+        .write()
+        .map_err(|_| ScpPyError::transport("transport manager lock poisoned".to_owned()))?;
+    *guard = None;
     Ok(())
 }
 
@@ -1240,23 +1277,16 @@ pub struct RegistryStats {
 /// Returns current entry counts for all global registries.
 ///
 /// Intended for monitoring and debugging in long-running processes.
-/// All reads are lock-free (`DashMap`) or brief (`RwLock` on relay state).
-///
-/// # Errors
-///
-/// Returns `ScpPyError::TransportError` if the relay state lock is poisoned.
-pub fn registry_stats() -> Result<RegistryStats, ScpPyError> {
-    let relay_connected = relay_state()
-        .read()
-        .map_err(|_| ScpPyError::transport("relay connection state lock is poisoned".to_owned()))?
-        .is_some();
-
-    Ok(RegistryStats {
+/// All reads are lock-free (`DashMap`) or brief (`RwLock` on transport
+/// state).
+#[must_use]
+pub fn registry_stats() -> RegistryStats {
+    RegistryStats {
         contexts: ffi_state_registry().len(),
         known_contexts: known_contexts_registry().len(),
         identities: identity_registry().len(),
-        relay_connected,
-    })
+        relay_connected: has_transport_manager(),
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -1418,7 +1448,7 @@ mod tests {
         let creator = "did:dht:z6MkStatsTest";
 
         register_context(&ctx_id, creator, &[]).unwrap();
-        let stats = registry_stats().unwrap();
+        let stats = registry_stats();
 
         // Verify that stats reports at least 1 context (our registered one).
         // Cannot assert exact counts due to parallel test interference.
@@ -1461,7 +1491,7 @@ mod tests {
             identity_link_attestations: Vec::new(),
         };
         register_identity(did, entry);
-        let stats = registry_stats().unwrap();
+        let stats = registry_stats();
 
         assert!(
             stats.identities >= 1,
@@ -1491,7 +1521,7 @@ mod tests {
         };
 
         register_known_context(&ctx_id, known);
-        let stats = registry_stats().unwrap();
+        let stats = registry_stats();
 
         assert!(
             stats.known_contexts >= 1,
@@ -1541,7 +1571,7 @@ mod tests {
     #[test]
     fn registry_stats_returns_all_fields() {
         // Verifies the struct shape and that registry_stats() doesn't panic.
-        let stats = registry_stats().unwrap();
+        let stats = registry_stats();
         // Destructure to catch struct changes at compile time. If a field is
         // added or removed, this will fail to compile.
         let RegistryStats {

--- a/crates/scp-ffi/src/server.rs
+++ b/crates/scp-ffi/src/server.rs
@@ -85,7 +85,7 @@ fn auto_wire_context_manager(
                 Box::new(crate::runtime::NoOpEventLogProvider);
             crate::runtime::init_context_manager_with(crypto, transport, event_log, None);
 
-            // Also populate the RELAY_CONNECTION global so that broadcast
+            // Also populate the TRANSPORT_MANAGER global so that broadcast
             // publish, context subscribe, and discovery probing work without
             // a separate `transport_connect` call. This requires a second
             // WebSocket connection because NativeRelayAdapter is not Clone
@@ -98,14 +98,15 @@ fn auto_wire_context_manager(
                 ))
             }) {
                 Ok(relay_adapter) => {
-                    let _ = crate::runtime::set_relay_connection(Arc::new(relay_adapter));
+                    let manager = scp_transport::TransportManager::new(Box::new(relay_adapter));
+                    let _ = crate::runtime::set_transport_manager(manager);
                 }
                 Err(e) => {
                     tracing::warn!(
                         error = %e,
                         relay_url = %relay_url,
                         "auto_wire_context_manager: ContextManager wired but failed to \
-                         populate RELAY_CONNECTION — broadcast publish and discovery may \
+                         populate TRANSPORT_MANAGER — broadcast publish and discovery may \
                          require a manual transport_connect call"
                     );
                 }
@@ -868,10 +869,10 @@ mod tests {
     }
 
     /// Verifies that auto-wiring a node's relay populates the global
-    /// `RELAY_CONNECTION` so that broadcast publish, context subscribe,
+    /// `TRANSPORT_MANAGER` so that broadcast publish, context subscribe,
     /// and discovery probing work without a separate `transport_connect`.
     #[test]
-    fn auto_wire_populates_relay_connection_global() {
+    fn auto_wire_populates_transport_manager_global() {
         use scp_transport::relay::connection::{RelayUrlSource, SourcedRelayUrl};
 
         // Start a standalone relay to get a stable WebSocket endpoint.
@@ -887,19 +888,18 @@ mod tests {
         let adapter = rt()
             .block_on(NativeRelayAdapter::connect_sourced(&sourced, None))
             .expect("should connect to the relay");
-        crate::runtime::set_relay_connection(Arc::new(adapter))
-            .expect("should store adapter in global");
+        let manager = scp_transport::TransportManager::new(Box::new(adapter));
+        crate::runtime::set_transport_manager(manager)
+            .expect("should store transport manager in global");
 
         // Verify the global is populated.
-        let conn =
-            crate::runtime::get_relay_connection().expect("should read global without error");
         assert!(
-            conn.is_some(),
-            "RELAY_CONNECTION should be populated after auto-wire"
+            crate::runtime::has_transport_manager(),
+            "TRANSPORT_MANAGER should be populated after auto-wire"
         );
 
         // Clean up.
-        crate::runtime::clear_relay_connection().ok();
+        crate::runtime::clear_transport_manager().ok();
         relay.shutdown();
     }
 }

--- a/crates/scp-ffi/src/transport.rs
+++ b/crates/scp-ffi/src/transport.rs
@@ -5,24 +5,31 @@
 //! - [`py_transport_connect`] -- Connect to an SCP relay.
 //! - [`py_transport_disconnect`] -- Disconnect from the current relay.
 //! - [`py_transport_status`] -- Query transport connection status.
+//! - [`py_transport_add_relay`] -- Register an additional relay adapter.
+//! - [`py_transport_assign_relay_set`] -- Assign a relay set for a context.
+//! - [`py_transport_adapter_count`] -- Number of registered adapters.
+//! - [`py_transport_reliability`] -- Per-adapter reliability score.
 //!
 //! # Types
 //!
 //! - [`PyTransportStatus`] -- Connection status (connected, relay URL, latency).
 //!
-//! # Transport Wiring (SCP-213)
+//! # Transport Wiring (SCP-213, #1490)
 //!
 //! `py_transport_connect` creates a [`NativeRelayAdapter`] connected to the
-//! given relay URL and stores it in the global relay connection state (see
-//! [`crate::runtime`]). This adapter is shared with `py_mcp_load_contexts`
-//! for relay-based context discovery.
+//! given relay URL, wraps it in a [`scp_transport::TransportManager`], and
+//! stores the manager in the global transport state (see
+//! [`crate::runtime`]). The manager provides multi-relay fanout,
+//! per-context relay set assignment, suppression detection, and reliability
+//! scoring. This manager is shared with `py_mcp_load_contexts` for
+//! relay-based context discovery.
 //!
 //! The relay URL is tracked in a module-level `RwLock` so that
 //! `py_transport_status` can report it without querying the adapter.
 //!
 //! See ADR-013 in `.docs/adrs/phase-3.md` section 5 for the bridge specification.
 
-use std::sync::{Arc, OnceLock, RwLock};
+use std::sync::{OnceLock, RwLock};
 
 use pyo3::prelude::*;
 use scp_transport::native::adapter::NativeRelayAdapter;
@@ -148,10 +155,9 @@ pub fn py_transport_connect(relay_url: &str, source: &str) -> PyResult<()> {
 
     match adapter {
         Ok(adapter) => {
-            let arc_adapter = Arc::new(adapter);
-
-            // Store the adapter in the global relay connection state.
-            crate::runtime::set_relay_connection(Arc::clone(&arc_adapter))?;
+            // Wrap the adapter in a TransportManager for multi-relay support.
+            let manager = scp_transport::TransportManager::new(Box::new(adapter));
+            crate::runtime::set_transport_manager(manager)?;
 
             // Track the URL for status queries.
             *connected_url_state().write().map_err(|_| {
@@ -177,7 +183,7 @@ pub fn py_transport_connect(relay_url: &str, source: &str) -> PyResult<()> {
 #[pyfunction]
 #[pyo3(name = "transport_disconnect")]
 pub fn py_transport_disconnect() -> PyResult<()> {
-    crate::runtime::clear_relay_connection()?;
+    crate::runtime::clear_transport_manager()?;
 
     *connected_url_state()
         .write()
@@ -201,9 +207,7 @@ pub fn py_transport_disconnect() -> PyResult<()> {
 #[pyfunction]
 #[pyo3(name = "transport_status")]
 pub fn py_transport_status() -> PyResult<PyTransportStatus> {
-    let has_connection = crate::runtime::get_relay_connection()
-        .map(|opt| opt.is_some())
-        .unwrap_or(false);
+    let has_connection = crate::runtime::has_transport_manager();
 
     let relay_url = connected_url_state()
         .read()
@@ -270,6 +274,149 @@ pub fn py_configure_relay_transport(relay_url: &str, local_did: &str) -> PyResul
 }
 
 // ---------------------------------------------------------------------------
+// Multi-relay management functions
+// ---------------------------------------------------------------------------
+
+/// Registers an additional relay adapter with the transport manager.
+///
+/// Connects to the specified relay URL and adds the resulting adapter to
+/// the global [`TransportManager`]. The `transport_connect` function must
+/// have been called first to initialize the manager.
+///
+/// # Arguments
+///
+/// * `relay_url` -- The URL of the additional SCP relay to connect to.
+/// * `source` -- How the URL was discovered (default: `"explicit"`).
+///
+/// # Returns
+///
+/// The total number of adapters after adding (i.e. the new adapter count).
+///
+/// # Errors
+///
+/// Raises `TransportError` if no transport manager exists, the URL is
+/// invalid, or the connection fails.
+#[pyfunction]
+#[pyo3(name = "transport_add_relay", signature = (relay_url, source = "explicit"))]
+pub fn py_transport_add_relay(relay_url: &str, source: &str) -> PyResult<usize> {
+    validate::validate_relay_url(relay_url)?;
+    let rt = crate::runtime()?;
+
+    let relay_source = match source {
+        "dht_resolved" => RelayUrlSource::DhtResolved,
+        "well_known" => RelayUrlSource::WellKnown,
+        "explicit" => RelayUrlSource::Explicit,
+        "peer_discovered" => RelayUrlSource::PeerDiscovered,
+        other => {
+            return Err(ScpPyError::validation(format!(
+                "invalid relay URL source: {other:?}. Expected one of: \
+                 \"dht_resolved\", \"well_known\", \"explicit\", \"peer_discovered\""
+            ))
+            .into());
+        }
+    };
+
+    let sourced = SourcedRelayUrl {
+        url: relay_url.to_owned(),
+        source: relay_source,
+    };
+    let profile = scp_transport::profile::TransportProfile::platform_default();
+    let adapter = rt
+        .block_on(async { NativeRelayAdapter::connect_sourced(&sourced, Some(&profile)).await })
+        .map_err(ScpPyError::from)?;
+
+    crate::runtime::with_transport_manager_mut(|manager| {
+        let _eviction = manager.add_adapter(Box::new(adapter));
+        Ok(manager.adapter_count())
+    })
+    .map_err(Into::into)
+}
+
+/// Assigns a relay set for the given context.
+///
+/// Delegates to [`TransportManager::assign_relay_set`] which selects at
+/// least `min_relays` adapters per context using round-robin spread to
+/// minimize overlap.
+///
+/// # Arguments
+///
+/// * `context_id` -- The context to assign relays for.
+///
+/// # Returns
+///
+/// A list of adapter indices assigned to this context.
+///
+/// # Errors
+///
+/// Raises `TransportError` if no transport manager exists or no adapters
+/// are registered.
+#[pyfunction]
+#[pyo3(name = "transport_assign_relay_set")]
+pub fn py_transport_assign_relay_set(context_id: &str) -> PyResult<Vec<usize>> {
+    validate::validate_context_id(context_id)?;
+    crate::runtime::with_transport_manager(|manager| {
+        manager
+            .assign_relay_set(&context_id.to_owned())
+            .map_err(|e| ScpPyError::transport(format!("relay set assignment failed: {e}")))
+    })
+    .map_err(Into::into)
+}
+
+/// Returns the number of adapters registered in the transport manager.
+///
+/// # Errors
+///
+/// Raises `TransportError` if no transport manager has been initialized.
+#[pyfunction]
+#[pyo3(name = "transport_adapter_count")]
+pub fn py_transport_adapter_count() -> PyResult<usize> {
+    crate::runtime::with_transport_manager(|manager| Ok(manager.adapter_count()))
+        .map_err(Into::into)
+}
+
+/// Returns the reliability score for an adapter by index.
+///
+/// Returns a dict with the score fields, or `None` if no score exists
+/// for the given adapter index.
+///
+/// # Arguments
+///
+/// * `adapter_index` -- The adapter index (0-based) to query.
+///
+/// # Errors
+///
+/// Raises `TransportError` if no transport manager has been initialized.
+#[pyfunction]
+#[pyo3(name = "transport_reliability")]
+pub fn py_transport_reliability(
+    py: Python<'_>,
+    adapter_index: usize,
+) -> PyResult<Option<PyObject>> {
+    crate::runtime::with_transport_manager(|manager| {
+        match manager.get_reliability_score(adapter_index) {
+            Some(score) => {
+                let dict = pyo3::types::PyDict::new(py);
+                dict.set_item("relay_url", &score.relay_url)
+                    .map_err(|e| ScpPyError::transport(format!("dict build failed: {e}")))?;
+                dict.set_item("delivery_success_rate", score.delivery_success_rate)
+                    .map_err(|e| ScpPyError::transport(format!("dict build failed: {e}")))?;
+                dict.set_item("average_latency_ms", score.average_latency_ms)
+                    .map_err(|e| ScpPyError::transport(format!("dict build failed: {e}")))?;
+                dict.set_item("deletion_compliance_rate", score.deletion_compliance_rate)
+                    .map_err(|e| ScpPyError::transport(format!("dict build failed: {e}")))?;
+                dict.set_item("total_sends", score.total_sends)
+                    .map_err(|e| ScpPyError::transport(format!("dict build failed: {e}")))?;
+                dict.set_item("total_failures", score.total_failures)
+                    .map_err(|e| ScpPyError::transport(format!("dict build failed: {e}")))?;
+                Ok(Some(dict.into()))
+            }
+            None => Ok(None),
+        }
+    })
+    .map_err(Into::into)
+}
+
+// ---------------------------------------------------------------------------
 // Module registration
 // ---------------------------------------------------------------------------
 
@@ -286,6 +433,10 @@ pub fn register_transport(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(py_transport_disconnect, m)?)?;
     m.add_function(wrap_pyfunction!(py_transport_status, m)?)?;
     m.add_function(wrap_pyfunction!(py_configure_relay_transport, m)?)?;
+    m.add_function(wrap_pyfunction!(py_transport_add_relay, m)?)?;
+    m.add_function(wrap_pyfunction!(py_transport_assign_relay_set, m)?)?;
+    m.add_function(wrap_pyfunction!(py_transport_adapter_count, m)?)?;
+    m.add_function(wrap_pyfunction!(py_transport_reliability, m)?)?;
     Ok(())
 }
 

--- a/crates/scp-ffi/src/transport.rs
+++ b/crates/scp-ffi/src/transport.rs
@@ -462,7 +462,11 @@ fn spawn_suppression_scoring_task(
     mut rx: tokio::sync::mpsc::Receiver<scp_transport::heartbeat::SuppressionSuspected>,
     relay_url: String,
 ) {
-    tokio::spawn(async move {
+    // Use crate::runtime() to get the tokio Runtime handle, then spawn on it.
+    // We cannot use bare `tokio::spawn` because PyO3 functions run outside
+    // the tokio runtime context (they use block_on for individual calls).
+    let Ok(rt) = crate::runtime() else { return };
+    rt.spawn(async move {
         while let Some(_suppression) = rx.recv().await {
             tracing::debug!(
                 relay_url = %relay_url,

--- a/crates/scp-ffi/src/transport.rs
+++ b/crates/scp-ffi/src/transport.rs
@@ -154,10 +154,22 @@ pub fn py_transport_connect(relay_url: &str, source: &str) -> PyResult<()> {
         rt.block_on(async { NativeRelayAdapter::connect_sourced(&sourced, Some(&profile)).await });
 
     match adapter {
-        Ok(adapter) => {
+        Ok(mut adapter) => {
+            // Extract the suppression event receiver BEFORE moving the adapter
+            // into the TransportManager. The spawned task drains suppression
+            // events and downgrades the relay's reliability score (#1533 AC5).
+            let suppression_rx = adapter.take_suppression_receiver();
+
             // Wrap the adapter in a TransportManager for multi-relay support.
+            // Cover traffic is already running — `connect_sourced` with a
+            // profile auto-starts it via `finalize_connection` (#1532 AC6).
             let manager = scp_transport::TransportManager::new(Box::new(adapter));
             crate::runtime::set_transport_manager(manager)?;
+
+            // Spawn suppression → scoring bridge task.
+            if let Some(suppression_rx) = suppression_rx {
+                spawn_suppression_scoring_task(suppression_rx, url.clone());
+            }
 
             // Track the URL for status queries.
             *connected_url_state().write().map_err(|_| {
@@ -321,15 +333,30 @@ pub fn py_transport_add_relay(relay_url: &str, source: &str) -> PyResult<usize> 
         source: relay_source,
     };
     let profile = scp_transport::profile::TransportProfile::platform_default();
-    let adapter = rt
+    // Cover traffic auto-starts per adapter via `connect_sourced` with a
+    // profile — `finalize_connection` launches the cover traffic background
+    // task based on the profile's tier (#1532 AC6).
+    let mut adapter = rt
         .block_on(async { NativeRelayAdapter::connect_sourced(&sourced, Some(&profile)).await })
         .map_err(ScpPyError::from)?;
 
-    crate::runtime::with_transport_manager_mut(|manager| {
+    // Extract the suppression event receiver BEFORE moving the adapter into
+    // the TransportManager. The spawned task drains suppression events and
+    // downgrades the relay's reliability score (#1533 AC5).
+    let suppression_rx = adapter.take_suppression_receiver();
+    let scoring_url = relay_url.to_owned();
+
+    let count = crate::runtime::with_transport_manager_mut(|manager| {
         let _eviction = manager.add_adapter(Box::new(adapter));
         Ok(manager.adapter_count())
-    })
-    .map_err(Into::into)
+    })?;
+
+    // Spawn suppression → scoring bridge task.
+    if let Some(suppression_rx) = suppression_rx {
+        spawn_suppression_scoring_task(suppression_rx, scoring_url);
+    }
+
+    Ok(count)
 }
 
 /// Assigns a relay set for the given context.
@@ -414,6 +441,40 @@ pub fn py_transport_reliability(
         }
     })
     .map_err(Into::into)
+}
+
+// ---------------------------------------------------------------------------
+// Suppression → scoring bridge task
+// ---------------------------------------------------------------------------
+
+/// Spawns a background task that drains heartbeat suppression events from a
+/// per-adapter receiver and records each as a delivery failure in the global
+/// transport manager's reliability scoring.
+///
+/// This bridges the per-adapter heartbeat monitor (spec §9.9.2) with the
+/// `TransportManager`'s cross-relay `SuppressionTracker` (spec §9.9.4,
+/// #1533 AC5). Each suppression event downgrades the relay's reliability
+/// score via `DeliveryOutcome::Failure`.
+///
+/// The task exits gracefully when the sender half is dropped (adapter
+/// dropped or disconnected).
+fn spawn_suppression_scoring_task(
+    mut rx: tokio::sync::mpsc::Receiver<scp_transport::heartbeat::SuppressionSuspected>,
+    relay_url: String,
+) {
+    tokio::spawn(async move {
+        while let Some(_suppression) = rx.recv().await {
+            tracing::debug!(
+                relay_url = %relay_url,
+                "heartbeat suppression → downgrading relay reliability score"
+            );
+            crate::runtime::record_suppression(&relay_url);
+        }
+        tracing::debug!(
+            relay_url = %relay_url,
+            "suppression scoring task exited — adapter disconnected"
+        );
+    });
 }
 
 // ---------------------------------------------------------------------------

--- a/crates/scp-ffi/uniffi/src/bridge.rs
+++ b/crates/scp-ffi/uniffi/src/bridge.rs
@@ -2054,7 +2054,7 @@ impl TransportManager {
     ///
     /// Returns `ScpError::Transport` if the URL is invalid or the connection
     /// fails.
-    pub fn add_relay(&self, relay_url: String) -> Result<u32, ScpError> {
+    pub fn add_relay(self: Arc<Self>, relay_url: String) -> Result<u32, ScpError> {
         use scp_transport::native::adapter::NativeRelayAdapter;
         use scp_transport::relay::connection::{RelayUrlSource, SourcedRelayUrl};
 
@@ -2062,13 +2062,21 @@ impl TransportManager {
 
         let rt = runtime();
         let sourced = SourcedRelayUrl {
-            url: relay_url,
+            url: relay_url.clone(),
             source: RelayUrlSource::Explicit,
         };
+        // Cover traffic auto-starts per adapter via `connect_sourced` with a
+        // profile — `finalize_connection` launches the cover traffic background
+        // task based on the profile's tier (#1532 AC6).
         let profile = scp_transport::profile::TransportProfile::platform_default();
-        let adapter = rt
+        let mut adapter = rt
             .block_on(async { NativeRelayAdapter::connect_sourced(&sourced, Some(&profile)).await })
             .map_err(ScpError::from)?;
+
+        // Extract the suppression event receiver BEFORE moving the adapter
+        // into the TransportManager. The spawned task drains suppression
+        // events and downgrades the relay's reliability score (#1533 AC5).
+        let suppression_rx = adapter.take_suppression_receiver();
 
         let mut mgr = self.inner.write().map_err(|_| ScpError::Transport {
             msg: "transport manager lock is poisoned".to_owned(),
@@ -2076,7 +2084,15 @@ impl TransportManager {
         })?;
         let _eviction = mgr.add_adapter(Box::new(adapter));
         #[allow(clippy::cast_possible_truncation)] // Bounded by connection budget.
-        Ok(mgr.adapter_count() as u32)
+        let count = mgr.adapter_count() as u32;
+        drop(mgr);
+
+        // Spawn suppression → scoring bridge task.
+        if let Some(rx) = suppression_rx {
+            spawn_suppression_scoring_task(rx, relay_url, Arc::downgrade(&self));
+        }
+
+        Ok(count)
     }
 
     /// Assigns a relay set for the given context.
@@ -2141,6 +2157,47 @@ impl Drop for TransportManager {
     fn drop(&mut self) {
         decrement_handle_count();
     }
+}
+
+// ---------------------------------------------------------------------------
+// Suppression → scoring bridge task
+// ---------------------------------------------------------------------------
+
+/// Spawns a background task that drains heartbeat suppression events from a
+/// per-adapter receiver and records each as a delivery failure in the
+/// `TransportManager`'s reliability scoring.
+///
+/// This bridges the per-adapter heartbeat monitor (spec §9.9.2) with the
+/// `TransportManager`'s cross-relay `SuppressionTracker` (spec §9.9.4,
+/// #1533 AC5). Each suppression event downgrades the relay's reliability
+/// score via `DeliveryOutcome::Failure`.
+///
+/// Uses a `Weak` reference so the task exits gracefully when the
+/// `TransportManager` is dropped (no prevent-drop cycles).
+fn spawn_suppression_scoring_task(
+    mut rx: tokio::sync::mpsc::Receiver<scp_transport::heartbeat::SuppressionSuspected>,
+    relay_url: String,
+    manager: std::sync::Weak<TransportManager>,
+) {
+    tokio::spawn(async move {
+        while let Some(_suppression) = rx.recv().await {
+            let Some(mgr) = manager.upgrade() else {
+                // TransportManager dropped — exit gracefully.
+                break;
+            };
+            tracing::debug!(
+                relay_url = %relay_url,
+                "heartbeat suppression → downgrading relay reliability score"
+            );
+            if let Ok(inner) = mgr.inner.read() {
+                inner.update_score(&relay_url, scp_transport::scoring::DeliveryOutcome::Failure);
+            }
+        }
+        tracing::debug!(
+            relay_url = %relay_url,
+            "suppression scoring task exited — adapter disconnected"
+        );
+    });
 }
 
 // ---------------------------------------------------------------------------
@@ -4723,10 +4780,18 @@ pub async fn transport_connect(relay_url: String) -> Result<Arc<TransportManager
             };
 
             // Establish a real WebSocket connection to the relay.
+            // Cover traffic auto-starts per adapter via `connect_sourced`
+            // with a profile — `finalize_connection` launches the cover
+            // traffic background task based on the profile's tier (#1532 AC6).
             let profile = scp_transport::profile::TransportProfile::platform_default();
-            let adapter = NativeRelayAdapter::connect_sourced(&sourced, Some(&profile))
+            let mut adapter = NativeRelayAdapter::connect_sourced(&sourced, Some(&profile))
                 .await
                 .map_err(ScpError::from)?;
+
+            // Extract the suppression event receiver BEFORE moving the adapter
+            // into the TransportManager. The spawned task drains suppression
+            // events and downgrades the relay's reliability score (#1533 AC5).
+            let suppression_rx = adapter.take_suppression_receiver();
 
             // Wrap the adapter in a real TransportManager for multi-relay
             // support (ADR-012). The manager provides relay set assignment,
@@ -4736,12 +4801,18 @@ pub async fn transport_connect(relay_url: String) -> Result<Arc<TransportManager
             let handle = Arc::new(TransportManager {
                 status: std::sync::Mutex::new(TransportStatus {
                     connected: true,
-                    relay_url: Some(relay_url),
+                    relay_url: Some(relay_url.clone()),
                     latency_ms: None,
                 }),
                 inner: std::sync::RwLock::new(manager),
             });
             increment_handle_count();
+
+            // Spawn suppression → scoring bridge task.
+            if let Some(rx) = suppression_rx {
+                spawn_suppression_scoring_task(rx, relay_url, Arc::downgrade(&handle));
+            }
+
             Ok(handle)
         })
         .await

--- a/crates/scp-ffi/uniffi/src/bridge.rs
+++ b/crates/scp-ffi/uniffi/src/bridge.rs
@@ -1943,24 +1943,57 @@ impl Drop for UcanToken {
 
 /// Opaque handle to the transport layer.
 ///
-/// Exposes connection status and relay URL without leaking connection state.
-/// The actual transport (WebSocket, multi-relay routing) is managed internally.
-///
-/// Holds a reference to the underlying `NativeRelayAdapter` established by
-/// `transport_connect`. The adapter represents a live WebSocket connection
-/// to an SCP relay.
+/// Wraps a real [`scp_transport::TransportManager`] that supports multi-relay
+/// routing, per-context relay set assignment, suppression detection, and
+/// reliability scoring (ADR-012). Swift/Kotlin callers get the full multi-relay
+/// API: `addRelay`, `assignRelaySet`, `adapterCount`, `reliabilityScore`.
 ///
 /// Generated as `class TransportManager` in both Swift and Kotlin.
 ///
-/// See ADR-005 (Transport Abstraction).
-#[derive(Debug, uniffi::Object)]
+/// See ADR-005 (Transport Abstraction) and ADR-012 (Multi-transport routing).
+#[derive(uniffi::Object)]
 pub struct TransportManager {
-    /// Current connection state.
+    /// Current connection state (relay URL, latency).
     pub(crate) status: std::sync::Mutex<TransportStatus>,
-    /// The underlying relay adapter (live WebSocket connection).
-    /// `None` after `transport_disconnect` is called.
-    pub(crate) adapter:
-        std::sync::Mutex<Option<Arc<scp_transport::native::adapter::NativeRelayAdapter>>>,
+    /// The real multi-relay transport manager.
+    /// Wrapped in `RwLock` for concurrent read access (status, adapter count)
+    /// with exclusive write access (add relay, disconnect).
+    pub(crate) inner: std::sync::RwLock<scp_transport::TransportManager>,
+}
+
+impl fmt::Debug for TransportManager {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let adapter_count = self
+            .inner
+            .read()
+            .map(|mgr| mgr.adapter_count())
+            .unwrap_or(0);
+        f.debug_struct("TransportManager")
+            .field("adapter_count", &adapter_count)
+            .finish_non_exhaustive()
+    }
+}
+
+/// Per-adapter reliability score record exposed to Swift/Kotlin.
+///
+/// Contains the key fields from [`scp_transport::scoring::ReliabilityScore`]
+/// needed for relay health monitoring and selection decisions.
+///
+/// See ADR-012 acceptance criterion 5.
+#[derive(Debug, Clone, uniffi::Record)]
+pub struct ReliabilityScoreRecord {
+    /// The relay URL this score tracks.
+    pub relay_url: String,
+    /// Delivery success rate (0.0 to 1.0).
+    pub delivery_success_rate: f64,
+    /// Average latency in milliseconds.
+    pub average_latency_ms: u64,
+    /// Deletion compliance rate (0.0 to 1.0).
+    pub deletion_compliance_rate: f64,
+    /// Total number of send attempts.
+    pub total_sends: u64,
+    /// Total number of send failures.
+    pub total_failures: u64,
 }
 
 #[uniffi::export]
@@ -1968,9 +2001,13 @@ impl TransportManager {
     /// Returns the current transport connection status record.
     ///
     /// Reflects actual connection state: `connected` is `true` only if the
-    /// underlying relay adapter is still held.
+    /// inner transport manager has at least one adapter registered.
     pub fn status(&self) -> TransportStatus {
-        let has_adapter = self.adapter.lock().map(|a| a.is_some()).unwrap_or(false);
+        let has_adapters = self
+            .inner
+            .read()
+            .map(|mgr| mgr.adapter_count() > 0)
+            .unwrap_or(false);
         let status = self
             .status
             .lock()
@@ -1981,15 +2018,117 @@ impl TransportManager {
                 latency_ms: None,
             });
         TransportStatus {
-            connected: has_adapter && status.connected,
-            relay_url: if has_adapter { status.relay_url } else { None },
+            connected: has_adapters && status.connected,
+            relay_url: if has_adapters { status.relay_url } else { None },
             latency_ms: status.latency_ms,
         }
     }
 
-    /// Returns `true` if the transport is currently connected.
+    /// Returns `true` if the transport is currently connected (has adapters).
     pub fn is_connected(&self) -> bool {
-        self.adapter.lock().map(|a| a.is_some()).unwrap_or(false)
+        self.inner
+            .read()
+            .map(|mgr| mgr.adapter_count() > 0)
+            .unwrap_or(false)
+    }
+
+    /// Returns the number of adapters registered in the transport manager.
+    #[allow(clippy::cast_possible_truncation)] // Adapter count is bounded by connection budget (<<u32::MAX).
+    pub fn adapter_count(&self) -> u32 {
+        self.inner
+            .read()
+            .map(|mgr| mgr.adapter_count() as u32)
+            .unwrap_or(0)
+    }
+
+    /// Registers an additional relay adapter with the transport manager.
+    ///
+    /// Connects to the specified relay URL and adds the resulting adapter to
+    /// the manager. Returns the total adapter count after adding.
+    ///
+    /// # Arguments
+    ///
+    /// * `relay_url` -- The URL of the additional SCP relay to connect to.
+    ///
+    /// # Errors
+    ///
+    /// Returns `ScpError::Transport` if the URL is invalid or the connection
+    /// fails.
+    pub fn add_relay(&self, relay_url: String) -> Result<u32, ScpError> {
+        use scp_transport::native::adapter::NativeRelayAdapter;
+        use scp_transport::relay::connection::{RelayUrlSource, SourcedRelayUrl};
+
+        validate_relay_url(&relay_url)?;
+
+        let rt = runtime();
+        let sourced = SourcedRelayUrl {
+            url: relay_url,
+            source: RelayUrlSource::Explicit,
+        };
+        let profile = scp_transport::profile::TransportProfile::platform_default();
+        let adapter = rt
+            .block_on(async { NativeRelayAdapter::connect_sourced(&sourced, Some(&profile)).await })
+            .map_err(ScpError::from)?;
+
+        let mut mgr = self.inner.write().map_err(|_| ScpError::Transport {
+            msg: "transport manager lock is poisoned".to_owned(),
+            code: "SCP-TRANS-5003".to_owned(),
+        })?;
+        let _eviction = mgr.add_adapter(Box::new(adapter));
+        #[allow(clippy::cast_possible_truncation)] // Bounded by connection budget.
+        Ok(mgr.adapter_count() as u32)
+    }
+
+    /// Assigns a relay set for the given context.
+    ///
+    /// Delegates to [`scp_transport::TransportManager::assign_relay_set`]
+    /// which selects adapters using round-robin spread to minimize overlap.
+    ///
+    /// # Arguments
+    ///
+    /// * `context_id` -- The context to assign relays for.
+    ///
+    /// # Returns
+    ///
+    /// A list of adapter indices assigned to this context.
+    ///
+    /// # Errors
+    ///
+    /// Returns `ScpError::Transport` if no adapters are registered.
+    pub fn assign_relay_set(&self, context_id: String) -> Result<Vec<u32>, ScpError> {
+        validate_context_id(&context_id)?;
+        let mgr = self.inner.read().map_err(|_| ScpError::Transport {
+            msg: "transport manager lock is poisoned".to_owned(),
+            code: "SCP-TRANS-5003".to_owned(),
+        })?;
+        let indices = mgr
+            .assign_relay_set(&context_id)
+            .map_err(|e| ScpError::Transport {
+                msg: format!("relay set assignment failed: {e}"),
+                code: "SCP-TRANS-5004".to_owned(),
+            })?;
+        #[allow(clippy::cast_possible_truncation)] // Adapter indices bounded by adapter count.
+        Ok(indices.into_iter().map(|i| i as u32).collect())
+    }
+
+    /// Returns the reliability score for an adapter by index.
+    ///
+    /// Returns `None` if no score exists for the given adapter index.
+    ///
+    /// # Arguments
+    ///
+    /// * `adapter_index` -- The adapter index (0-based) to query.
+    pub fn reliability_score(&self, adapter_index: u32) -> Option<ReliabilityScoreRecord> {
+        let mgr = self.inner.read().ok()?;
+        let score = mgr.get_reliability_score(adapter_index as usize)?;
+        Some(ReliabilityScoreRecord {
+            relay_url: score.relay_url.clone(),
+            delivery_success_rate: score.delivery_success_rate,
+            average_latency_ms: score.average_latency_ms,
+            deletion_compliance_rate: score.deletion_compliance_rate,
+            total_sends: score.total_sends,
+            total_failures: score.total_failures,
+        })
     }
 }
 
@@ -4589,7 +4728,10 @@ pub async fn transport_connect(relay_url: String) -> Result<Arc<TransportManager
                 .await
                 .map_err(ScpError::from)?;
 
-            let arc_adapter = Arc::new(adapter);
+            // Wrap the adapter in a real TransportManager for multi-relay
+            // support (ADR-012). The manager provides relay set assignment,
+            // reliability scoring, and suppression detection.
+            let manager = scp_transport::TransportManager::new(Box::new(adapter));
 
             let handle = Arc::new(TransportManager {
                 status: std::sync::Mutex::new(TransportStatus {
@@ -4597,7 +4739,7 @@ pub async fn transport_connect(relay_url: String) -> Result<Arc<TransportManager
                     relay_url: Some(relay_url),
                     latency_ms: None,
                 }),
-                adapter: std::sync::Mutex::new(Some(arc_adapter)),
+                inner: std::sync::RwLock::new(manager),
             });
             increment_handle_count();
             Ok(handle)
@@ -4624,9 +4766,9 @@ pub async fn transport_status(manager: Arc<TransportManager>) -> Result<Transpor
 
 /// Disconnects from the current SCP relay.
 ///
-/// Clears the relay adapter from the `TransportManager` handle. After this
-/// call, the `TransportManager` reports `connected: false` and the adapter's
-/// WebSocket connection is released when the last reference is dropped.
+/// Replaces the inner `TransportManager` with an empty builder, releasing
+/// all adapter connections. After this call, the `TransportManager` reports
+/// `connected: false` and `adapter_count() == 0`.
 ///
 /// This is idempotent — calling it when already disconnected is a no-op.
 ///
@@ -4636,19 +4778,18 @@ pub async fn transport_status(manager: Arc<TransportManager>) -> Result<Transpor
 ///
 /// # Errors
 ///
-/// Returns `ScpError::Transport` if the internal mutex is poisoned.
+/// Returns `ScpError::Transport` if the internal lock is poisoned.
 #[uniffi::export]
 pub async fn transport_disconnect(manager: Arc<TransportManager>) -> Result<(), ScpError> {
     runtime()
         .spawn(async move {
-            // Clear the adapter from the manager.
+            // Replace the inner manager with an empty one, dropping all adapters.
             {
-                let mut adapter_guard =
-                    manager.adapter.lock().map_err(|_| ScpError::Transport {
-                        msg: "adapter mutex is poisoned — cannot clear relay adapter".to_owned(),
-                        code: "SCP-TRANS-5003".to_owned(),
-                    })?;
-                *adapter_guard = None;
+                let mut inner_guard = manager.inner.write().map_err(|_| ScpError::Transport {
+                    msg: "transport manager lock is poisoned — cannot disconnect".to_owned(),
+                    code: "SCP-TRANS-5003".to_owned(),
+                })?;
+                *inner_guard = scp_transport::TransportManager::builder();
             }
 
             // Update the status to disconnected.

--- a/crates/scp-node/src/webhook.rs
+++ b/crates/scp-node/src/webhook.rs
@@ -96,6 +96,18 @@ pub async fn dispatch_webhook(
         };
     }
 
+    dispatch_webhook_inner(url, event, signing_key, client).await
+}
+
+/// Inner dispatch logic shared between production (with URL validation) and
+/// test (without URL validation) paths. Signs the event body with the signing
+/// key and sends an HTTP POST with retry-with-backoff.
+async fn dispatch_webhook_inner(
+    url: &str,
+    event: &WebhookEvent,
+    signing_key: &SigningKey,
+    client: &reqwest::Client,
+) -> WebhookResult {
     let body = match serde_json::to_vec(event) {
         Ok(b) => b,
         Err(e) => {
@@ -134,9 +146,12 @@ pub async fn dispatch_webhook(
     let mut delay = INITIAL_RETRY_DELAY_MS;
 
     for attempt in 1..=MAX_RETRIES {
-        // SAFETY: URL was validated as HTTPS-only at the top of this function.
+        // SAFETY: In production, URL was validated as HTTPS-only by dispatch_webhook.
         // Assert here so CodeQL's data-flow analysis can verify.
-        debug_assert!(url.starts_with("https://"), "webhook URL must be HTTPS");
+        debug_assert!(
+            url.starts_with("https://") || cfg!(test),
+            "webhook URL must be HTTPS (relaxed in tests)"
+        );
         match client
             .post(url)
             .header("Content-Type", "application/json")
@@ -805,5 +820,150 @@ mod tests {
     async fn dispatcher_default_is_empty() {
         let dispatcher = WebhookDispatcher::default();
         assert_eq!(dispatcher.target_count().await, 0);
+    }
+
+    // -----------------------------------------------------------------------
+    // End-to-end webhook integration test (#1539 AC6)
+    // -----------------------------------------------------------------------
+
+    /// Captured HTTP request data from the local webhook server.
+    #[derive(Debug)]
+    struct CapturedWebhook {
+        content_type: Option<String>,
+        signature: Option<String>,
+        timestamp: Option<String>,
+        body: Vec<u8>,
+    }
+
+    /// Starts a local HTTP server that captures the first POST to `/webhook`
+    /// and sends it back via the returned oneshot receiver.
+    async fn start_webhook_server() -> (
+        std::net::SocketAddr,
+        tokio::sync::oneshot::Receiver<CapturedWebhook>,
+        tokio::task::JoinHandle<()>,
+    ) {
+        use std::sync::Arc;
+
+        let (tx, rx) = tokio::sync::oneshot::channel::<CapturedWebhook>();
+        let tx = Arc::new(tokio::sync::Mutex::new(Some(tx)));
+
+        let handler_tx = Arc::clone(&tx);
+        let app = axum::Router::new().route(
+            "/webhook",
+            axum::routing::post(
+                move |headers: axum::http::HeaderMap, body: axum::body::Bytes| {
+                    let tx = Arc::clone(&handler_tx);
+                    async move {
+                        let captured = CapturedWebhook {
+                            content_type: headers
+                                .get("content-type")
+                                .map(|v| v.to_str().unwrap_or("").to_owned()),
+                            signature: headers
+                                .get("x-scp-signature")
+                                .map(|v| v.to_str().unwrap_or("").to_owned()),
+                            timestamp: headers
+                                .get("x-scp-timestamp")
+                                .map(|v| v.to_str().unwrap_or("").to_owned()),
+                            body: body.to_vec(),
+                        };
+                        let sender = tx.lock().await.take();
+                        if let Some(sender) = sender {
+                            let _ = sender.send(captured);
+                        }
+                        axum::http::StatusCode::OK
+                    }
+                },
+            ),
+        );
+
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        let handle = tokio::spawn(async move {
+            axum::serve(listener, app).await.unwrap();
+        });
+
+        (addr, rx, handle)
+    }
+
+    /// Verifies that the captured request has valid headers, body, and
+    /// Ed25519 signature.
+    fn verify_webhook_request(
+        captured: &CapturedWebhook,
+        verifying_key: &ed25519_dalek::VerifyingKey,
+    ) {
+        use ed25519_dalek::Signature;
+
+        // 1. Content-Type
+        assert_eq!(
+            captured.content_type.as_deref(),
+            Some("application/json"),
+            "Content-Type header must be application/json"
+        );
+        // 2. X-SCP-Signature present and non-empty
+        let sig_hex = captured
+            .signature
+            .as_ref()
+            .expect("X-SCP-Signature must be present");
+        assert!(!sig_hex.is_empty(), "X-SCP-Signature must be non-empty");
+        // 3. X-SCP-Timestamp present and non-empty
+        let ts_str = captured
+            .timestamp
+            .as_ref()
+            .expect("X-SCP-Timestamp must be present");
+        assert!(!ts_str.is_empty(), "X-SCP-Timestamp must be non-empty");
+        let timestamp: u64 = ts_str.parse().expect("timestamp must be a valid u64");
+        // 4. Body is valid JSON with expected fields
+        let body_json: serde_json::Value =
+            serde_json::from_slice(&captured.body).expect("body must be valid JSON");
+        assert_eq!(body_json["event_type"], "message.received");
+        assert_eq!(body_json["context_id"], "ctx-integration-test");
+        assert_eq!(body_json["event_id"], "evt-integration-1");
+        assert_eq!(body_json["payload"]["sender"], "did:dht:test");
+        assert_eq!(body_json["payload"]["size"], 256);
+        // 5. Verify the Ed25519 signature
+        let sig_bytes = hex::decode(sig_hex).expect("signature must be valid hex");
+        let signature = Signature::from_slice(&sig_bytes).expect("signature must be 64 bytes");
+        let domain_separator = b"SCP-WEBHOOK-V1:";
+        let mut signing_payload =
+            Vec::with_capacity(domain_separator.len() + 8 + captured.body.len());
+        signing_payload.extend_from_slice(domain_separator);
+        signing_payload.extend_from_slice(&timestamp.to_be_bytes());
+        signing_payload.extend_from_slice(&captured.body);
+        verifying_key
+            .verify(&signing_payload, &signature)
+            .expect("Ed25519 signature must be valid");
+    }
+
+    /// Full HTTP roundtrip: local server receives POST with valid Ed25519
+    /// signature, correct headers, and structured JSON body (#1539 AC6).
+    #[tokio::test]
+    async fn webhook_integration_end_to_end() {
+        let (addr, rx, server_handle) = start_webhook_server().await;
+
+        let signing_key = SigningKey::from_bytes(&[42u8; 32]);
+        let verifying_key = signing_key.verifying_key();
+        let event = WebhookEvent {
+            event_id: "evt-integration-1".to_owned(),
+            event_type: "message.received".to_owned(),
+            context_id: "ctx-integration-test".to_owned(),
+            timestamp: 1_700_000_000,
+            payload: serde_json::json!({"sender": "did:dht:test", "size": 256}),
+        };
+
+        let url = format!("http://127.0.0.1:{}/webhook", addr.port());
+        let result = dispatch_webhook_inner(&url, &event, &signing_key, &test_client()).await;
+
+        assert!(
+            result.success,
+            "webhook dispatch should succeed: {:?}",
+            result.error
+        );
+        assert_eq!(result.attempts, 1, "should succeed on first attempt");
+        assert_eq!(result.status_code, Some(200));
+
+        let captured = rx.await.expect("should have received captured request");
+        verify_webhook_request(&captured, &verifying_key);
+
+        server_handle.abort();
     }
 }

--- a/crates/scp-transport/src/native/adapter.rs
+++ b/crates/scp-transport/src/native/adapter.rs
@@ -1305,6 +1305,97 @@ mod tests {
         );
     }
 
+    /// Integration test: verifies that suppression is detected and reported
+    /// on the `suppression_events()` channel when no heartbeats are received
+    /// for longer than the threshold (spec §9.9.2, #1533 AC8).
+    ///
+    /// Uses `tokio::time::pause()` to control time without waiting real seconds.
+    /// The Server profile uses a 60s heartbeat interval with 2x multiplier,
+    /// so suppression fires after 120s of silence. We advance 130s to ensure
+    /// the heartbeat check loop has ticked past the threshold.
+    #[tokio::test(start_paused = true)]
+    async fn suppression_detected_after_threshold() {
+        use crate::native::server::{RelayConfig, RelayServer};
+        use crate::native::storage::BlobStorageBackend;
+        use crate::profile::TransportProfile;
+        use crate::relay::connection::{RelayUrlSource, SourcedRelayUrl};
+        use std::net::SocketAddr;
+        use std::sync::Arc;
+        use std::time::Duration;
+
+        // Start a local relay server so the adapter can connect.
+        let config = RelayConfig {
+            bind_addr: SocketAddr::from(([127, 0, 0, 1], 0)),
+            ttl_check_interval: Duration::from_millis(100),
+            delivery_jitter_ms: 0,
+            ..RelayConfig::default()
+        };
+        let storage = Arc::new(BlobStorageBackend::in_memory());
+        let server = RelayServer::new(config, storage);
+        let (_handle, addr) = server.start().await.unwrap();
+        let url = format!("ws://{addr}/scp/v1");
+
+        let sourced = SourcedRelayUrl {
+            url,
+            source: RelayUrlSource::DhtResolved,
+        };
+
+        // Connect with Server profile (60s heartbeat, 2x threshold = 120s).
+        let mut adapter =
+            NativeRelayAdapter::connect_sourced(&sourced, Some(&TransportProfile::Server))
+                .await
+                .unwrap();
+
+        assert!(
+            adapter.has_heartbeat_monitor(),
+            "Server profile must have a heartbeat monitor"
+        );
+
+        // Do NOT call record_heartbeat_received — simulate silence.
+        //
+        // First, yield to let the spawned heartbeat task start and
+        // consume its initial timer tick + record_heartbeat_sent.
+        tokio::task::yield_now().await;
+        tokio::task::yield_now().await;
+
+        // Now advance time past the suppression threshold (120s) in
+        // steps of the heartbeat interval (60s). Each advance fires
+        // the pending timer tick; yielding lets the background task
+        // process the tick, acquire the monitor lock, check for
+        // suppression, and push to the channel.
+        for _ in 0..3 {
+            tokio::time::advance(Duration::from_secs(61)).await;
+            // Yield enough times for the background task to run.
+            for _ in 0..20 {
+                tokio::task::yield_now().await;
+            }
+        }
+
+        // Read from the suppression events channel.
+        let rx = adapter
+            .suppression_events()
+            .expect("suppression_events() must return Some for Server profile");
+
+        let event = rx.try_recv();
+        assert!(
+            event.is_ok(),
+            "expected SuppressionSuspected event on the channel after 130s of silence"
+        );
+
+        let suppression = event.unwrap();
+        assert!(
+            !suppression.relay_url.is_empty(),
+            "suppression event should include the relay URL"
+        );
+        // The gap_duration will be small (1-2s) because suppression fires on
+        // the first tick after the threshold is exceeded.
+        assert!(
+            suppression.gap_duration > Duration::ZERO,
+            "gap_duration should be positive, got {:?}",
+            suppression.gap_duration,
+        );
+    }
+
     /// Verifies that `TransportProfile::Mobile` creates a heartbeat monitor
     /// (profile-driven config selects Mobile → 120s interval).
     #[tokio::test]

--- a/crates/scp-transport/src/native/adapter.rs
+++ b/crates/scp-transport/src/native/adapter.rs
@@ -346,6 +346,23 @@ impl NativeRelayAdapter {
         self.suppression_rx.as_mut()
     }
 
+    /// Takes ownership of the suppression event receiver, leaving `None` in
+    /// its place.
+    ///
+    /// After this call, [`suppression_events`](Self::suppression_events)
+    /// returns `None`. This is used by the FFI bridge layer to extract the
+    /// receiver before moving the adapter into [`TransportManager`] — the
+    /// bridge spawns a background task that drains the receiver and feeds
+    /// suppression events into the manager's reliability scoring (#1533 AC5).
+    ///
+    /// Returns `None` if heartbeat monitoring is not active (no profile or
+    /// constrained profile) or if the receiver was already taken.
+    pub const fn take_suppression_receiver(
+        &mut self,
+    ) -> Option<tokio::sync::mpsc::Receiver<crate::heartbeat::SuppressionSuspected>> {
+        self.suppression_rx.take()
+    }
+
     /// Records that a heartbeat was received from the relay.
     ///
     /// Called by subscription message processing when heartbeat-like


### PR DESCRIPTION
## Summary

Follow-up to PR #1621. Resolves outstanding acceptance criteria from the batch 3 wiring sprint by wiring `TransportManager` through all 3 non-WASM FFI bridges and adding integration tests.

### TransportManager FFI wiring (#1490)
- **PyO3**: Replace `RELAY_CONNECTION` singleton with `TRANSPORT_MANAGER`. Expose `transport_add_relay`, `transport_assign_relay_set`, `transport_adapter_count`, `transport_reliability`.
- **NAPI**: Same migration pattern. `context_subscribe` now uses `TransportManager::subscribe` for merged multi-relay streams.
- **UniFFI**: Replace stub `TransportManager` handle with real `scp_transport::TransportManager` behind `RwLock`. Swift/Kotlin get `addRelay`, `assignRelaySet`, `adapterCount`, `reliabilityScore`.

### Outstanding ACs resolved
- **#1532 AC6**: Cover traffic auto-starts per adapter (verified — `connect_sourced` with profile)
- **#1533 AC5**: Heartbeat `SuppressionSuspected` events feed into relay reliability scoring via spawned suppression-to-scoring tasks in all 3 bridges
- **#1533 AC6**: `TransportManager::subscribe_context` MergedStream aggregates cross-relay suppression via `SuppressionTracker`
- **#1533 AC8**: Integration test — time-controlled suppression detection through adapter
- **#1539 AC6**: Integration test — full HTTP roundtrip with Ed25519 signature verification

### Cleanup
- NAPI dead lock acquisition removed (`with_transport_manager_mut`)
- NAPI clippy warnings cleaned (unused imports, dead code, unused_async on napi functions)
- PyO3 suppression task uses `rt.spawn()` instead of bare `tokio::spawn` (runtime context fix)

Closes #1490

## Test plan

- [ ] `cargo clippy --workspace --all-targets --features ...` — 0 warnings
- [ ] `cargo test --workspace` — 0 failures
- [ ] `cargo test -p scp-ffi` — PyO3 bridge tests
- [ ] `cargo test -p scp-ffi-napi` — NAPI bridge tests
- [ ] `cargo test -p scp-ffi-uniffi` — UniFFI bridge tests
- [ ] `cargo test -p scp-node -- webhook_integration` — webhook E2E test
- [ ] `cargo test -p scp-transport -- suppression_detected` — heartbeat suppression test

🤖 Generated with [Claude Code](https://claude.com/claude-code)