### PR TITLE
refactor: Part 3 Phases 1-3 — bridge dedup extraction (#1447, #1397)

### DIFF
--- a/bindings/typescript/tests/real-napi.test.ts
+++ b/bindings/typescript/tests/real-napi.test.ts
@@ -295,7 +295,7 @@ if (bridge === null || serverAddon === null) {
           identity,
           JSON.stringify({
             ceiling: ["messages:read"],
-            governance: "threshold",
+            governance: "invalid_model",
             ttlSeconds: 3600,
             memoryScope: "full",
             ceilingPolicy: "governed",

--- a/crates/scp-ffi/common/src/context_params.rs
+++ b/crates/scp-ffi/common/src/context_params.rs
@@ -9,7 +9,6 @@
 //!
 //! Requires the `resolvers` feature (scp-core dependency).
 
-use std::collections::HashSet;
 use std::time::Duration;
 
 use scp_core::context::ContextParams;
@@ -268,9 +267,9 @@ fn parse_and_validate_consequences(
 fn build_roles(roles: &[(String, Vec<String>)]) -> Vec<RoleDefinition> {
     roles
         .iter()
-        .map(|(name, _caps)| RoleDefinition {
+        .map(|(name, caps)| RoleDefinition {
             name: name.clone(),
-            capabilities: HashSet::new(),
+            capabilities: caps.iter().map(Capability::new).collect(),
         })
         .collect()
 }

--- a/crates/scp-ffi/common/src/context_params.rs
+++ b/crates/scp-ffi/common/src/context_params.rs
@@ -1,0 +1,513 @@
+//! Shared context-parameter builder for all non-WASM FFI bridges.
+//!
+//! Each bridge (`PyO3`, napi-rs, `UniFFI`) converts its native input type
+//! (`PyDict`, JSON, `UniFFI` Record) into [`CommonContextParams`], then calls
+//! [`build_context_params`] to produce the core [`ContextParams`]. This
+//! eliminates the duplicated ceiling parsing, governance model construction,
+//! TTL configuration, consequence-rule validation, etc. that previously lived
+//! independently in each bridge (the duplication class that caused #1419).
+//!
+//! Requires the `resolvers` feature (scp-core dependency).
+
+use std::collections::HashSet;
+use std::time::Duration;
+
+use scp_core::context::ContextParams;
+use scp_core::context::params::{
+    CeilingPolicy, ConsequenceConfig, ContextMode, GovernanceModel, IncompleteVerificationPolicy,
+    MemoryScope, MetadataVisibilityPolicy, PromotionPolicy, RoleDefinition, ToolRegistration,
+};
+use scp_core::context::roles::Capability;
+use scp_core::provenance::CounterpartyPolicy;
+use scp_core::trust::ConsequenceRule;
+
+// ---------------------------------------------------------------------------
+// Bridge-agnostic intermediate type
+// ---------------------------------------------------------------------------
+
+/// Bridge-agnostic context creation parameters.
+///
+/// Each FFI bridge converts its native input type (`PyDict`, JSON, `UniFFI` Record)
+/// into this common struct, then calls [`build_context_params`] to produce the
+/// core [`ContextParams`].
+///
+/// All string fields use the same canonical values as the core types:
+/// - `mode`: `"encrypted"` or `"broadcast"`
+/// - `ceiling_policy`: `"immutable"` or `"governed"`
+/// - `promotion_policy`: `"no_promotion"` or `"promotable"`
+/// - `memory_scope`: `"ephemeral"`, `"summary"`, or `"full"`
+/// - `governance`: `"single_admin"`
+#[derive(Debug, Clone, Default)]
+pub struct CommonContextParams {
+    /// Context processing mode: `"encrypted"` (default) or `"broadcast"`.
+    pub mode: String,
+
+    /// Capability ceiling — maximum capabilities any participant can hold.
+    /// Each string is parsed via [`Capability::new`].
+    pub ceiling: Vec<String>,
+
+    /// Ceiling mutability policy: `"immutable"` (default) or `"governed"`.
+    pub ceiling_policy: String,
+
+    /// Promotion policy: `"no_promotion"` (default) or `"promotable"`.
+    pub promotion_policy: String,
+
+    /// Memory scope: `"ephemeral"` (default), `"summary"`, or `"full"`.
+    pub memory_scope: String,
+
+    /// Governance model: `"single_admin"`.
+    pub governance: String,
+
+    /// Optional time-to-live. Each bridge converts its native TTL
+    /// representation into a [`Duration`] before populating this field.
+    pub ttl: Option<Duration>,
+
+    /// Optional minimum protocol version as `(major, minor)`.
+    pub min_protocol_version: Option<(u8, u8)>,
+
+    /// Maximum cross-context chain depth (spec §24.4, ADR-043).
+    pub max_chain_depth: Option<u8>,
+
+    /// Maximum nesting depth for sub-contexts (spec §5.6, ADR-043).
+    pub max_nesting_depth: Option<u32>,
+
+    /// Per-caller session cap (spec §6.2.1, ADR-043).
+    pub session_cap: Option<u32>,
+
+    /// Optional economic policy as a JSON string (spec §19, ADR-033).
+    pub economic_policy_json: Option<String>,
+
+    /// Consequence rules as a JSON string (ADR-017, #1531).
+    /// `None` or empty string means no rules.
+    pub consequence_rules_json: Option<String>,
+
+    /// Consequence config as a JSON string (ADR-017, #1531).
+    /// `None` means default config.
+    pub consequence_config_json: Option<String>,
+
+    /// Role definitions mapping role names to capability lists.
+    /// Used by `PyO3` bridge; others leave empty.
+    pub roles: Vec<(String, Vec<String>)>,
+
+    /// Initial tool names. Used by `PyO3` bridge; others leave empty.
+    pub tools: Vec<String>,
+
+    /// Optional template identifier (spec §5.14). Used by `PyO3` bridge.
+    pub template_id: Option<String>,
+}
+
+// ---------------------------------------------------------------------------
+// Builder
+// ---------------------------------------------------------------------------
+
+/// Converts bridge-agnostic [`CommonContextParams`] into the core
+/// [`ContextParams`], performing all shared parsing and validation.
+///
+/// # Errors
+///
+/// Returns `Err(String)` on:
+/// - Unsupported governance model (only `"single_admin"` is currently valid)
+/// - Invalid JSON in `economic_policy_json`, `consequence_rules_json`, or
+///   `consequence_config_json`
+/// - Consequence rule validation failure against the config
+pub fn build_context_params(params: &CommonContextParams) -> Result<ContextParams, String> {
+    let mode = match params.mode.as_str() {
+        "broadcast" | "Broadcast" => ContextMode::Broadcast,
+        _ => ContextMode::Encrypted,
+    };
+    let ceiling: Vec<Capability> = params.ceiling.iter().map(Capability::new).collect();
+    let ceiling_policy = match params.ceiling_policy.as_str() {
+        "governed" => CeilingPolicy::Governed,
+        _ => CeilingPolicy::Immutable,
+    };
+    let promotion_policy = match params.promotion_policy.as_str() {
+        "promotable" => PromotionPolicy::Promotable,
+        _ => PromotionPolicy::NoPromotion,
+    };
+    let memory_scope = match params.memory_scope.as_str() {
+        "summary" => MemoryScope::Summary,
+        "full" => MemoryScope::Full,
+        _ => MemoryScope::Ephemeral,
+    };
+    let governance = parse_governance(&params.governance)?;
+    let ttl = params.ttl;
+    let economic_policy = parse_economic_policy(params.economic_policy_json.as_ref())?;
+    let (consequence_rules, consequence_config) = parse_and_validate_consequences(
+        params.consequence_rules_json.as_ref(),
+        params.consequence_config_json.as_ref(),
+    )?;
+    let template_id = params
+        .template_id
+        .as_deref()
+        .and_then(|tid| parse_template_id(tid).ok());
+
+    Ok(ContextParams {
+        mode,
+        ceiling,
+        ceiling_policy,
+        promotion_policy,
+        roles: build_roles(&params.roles),
+        tools: build_tools(&params.tools),
+        ttl,
+        memory_scope,
+        governance,
+        template_id,
+        economic_policy,
+        metadata_visibility: MetadataVisibilityPolicy::default(),
+        projection_policy: None,
+        discoverable: false,
+        max_chain_depth: params.max_chain_depth,
+        max_nesting_depth: params.max_nesting_depth,
+        session_cap: params.session_cap,
+        counterparty_policy: CounterpartyPolicy::default(),
+        participation_requirements: Vec::new(),
+        incomplete_verification_policy: IncompleteVerificationPolicy::default(),
+        min_protocol_version: params.min_protocol_version,
+        migration_source: None,
+        consequence_rules,
+        consequence_config,
+        sybil_policy: None,
+    })
+}
+
+// ---------------------------------------------------------------------------
+// Internal helpers (keep build_context_params under 100 lines)
+// ---------------------------------------------------------------------------
+
+/// Validates and parses the governance model string.
+fn parse_governance(governance: &str) -> Result<GovernanceModel, String> {
+    match governance {
+        "single_admin" | "" => Ok(GovernanceModel::SingleAdmin),
+        other => Err(format!(
+            "unsupported governance model: {other:?} — \
+             only \"single_admin\" is currently supported"
+        )),
+    }
+}
+
+/// Parses an optional economic policy JSON string.
+fn parse_economic_policy(
+    json: Option<&String>,
+) -> Result<Option<scp_core::economy::EconomicPolicy>, String> {
+    json.map(String::as_str)
+        .filter(|s| !s.is_empty())
+        .map(|s| serde_json::from_str(s).map_err(|e| format!("invalid economic_policy JSON: {e}")))
+        .transpose()
+}
+
+/// Parses and cross-validates consequence rules and config from JSON strings.
+fn parse_and_validate_consequences(
+    rules_json: Option<&String>,
+    config_json: Option<&String>,
+) -> Result<(Vec<ConsequenceRule>, ConsequenceConfig), String> {
+    let rules: Vec<ConsequenceRule> = rules_json
+        .map(String::as_str)
+        .filter(|s| !s.is_empty())
+        .map(|s| {
+            serde_json::from_str(s).map_err(|e| format!("invalid consequence_rules JSON: {e}"))
+        })
+        .transpose()?
+        .unwrap_or_default();
+    let config: ConsequenceConfig = config_json
+        .map(String::as_str)
+        .filter(|s| !s.is_empty())
+        .map(|s| {
+            serde_json::from_str(s).map_err(|e| format!("invalid consequence_config JSON: {e}"))
+        })
+        .transpose()?
+        .unwrap_or_default();
+    for rule in &rules {
+        rule.validate_against_config(&config)
+            .map_err(|e| format!("consequence rule validation failed: {e}"))?;
+    }
+    Ok((rules, config))
+}
+
+/// Converts role name/capabilities pairs into core `RoleDefinition` values.
+fn build_roles(roles: &[(String, Vec<String>)]) -> Vec<RoleDefinition> {
+    roles
+        .iter()
+        .map(|(name, _caps)| RoleDefinition {
+            name: name.clone(),
+            capabilities: HashSet::new(),
+        })
+        .collect()
+}
+
+/// Converts tool name strings into core `ToolRegistration` values with
+/// placeholder schemas and metadata (matching the existing `PyO3` bridge
+/// behavior for bridge-level tool declarations).
+fn build_tools(tools: &[String]) -> Vec<ToolRegistration> {
+    tools
+        .iter()
+        .map(|name| ToolRegistration {
+            tool_id: name.clone(),
+            name: name.clone(),
+            description: String::new(),
+            schema: scp_core::context::tools::ToolSchema {
+                input_schema: serde_json::Value::Object(serde_json::Map::default()),
+                output_schema: serde_json::Value::Object(serde_json::Map::default()),
+            },
+            implementation_hash: [0u8; 32],
+            test_vectors: vec![],
+            operator_did: scp_identity::DID("did:key:placeholder".to_owned()),
+            cost: None,
+            registered_at: 0,
+            signature: Vec::new(),
+        })
+        .collect()
+}
+
+// ---------------------------------------------------------------------------
+// Template ID parsing (shared across all non-WASM bridges)
+// ---------------------------------------------------------------------------
+
+/// Parses a template ID string into the core `TemplateId` type.
+///
+/// Accepts both the variant name and the serde-renamed form. Returns `Err` if
+/// the string is not a recognized template identifier.
+fn parse_template_id(tid: &str) -> Result<scp_core::context::params::TemplateId, String> {
+    use scp_core::context::params::TemplateId;
+    match tid {
+        "BilateralEphemeral" => Ok(TemplateId::BilateralEphemeral),
+        "BilateralPersistent" => Ok(TemplateId::BilateralPersistent),
+        "Coordination" => Ok(TemplateId::Coordination),
+        "GroupDiscussion" => Ok(TemplateId::GroupDiscussion),
+        "PublicBroadcast" => Ok(TemplateId::PublicBroadcast),
+        "GatedBroadcast" => Ok(TemplateId::GatedBroadcast),
+        "scp:template/tool-interface" | "ToolInterfaceTemplate" => {
+            Ok(TemplateId::ToolInterfaceTemplate)
+        }
+        "PaidService" => Ok(TemplateId::PaidService),
+        "PaidBroadcast" => Ok(TemplateId::PaidBroadcast),
+        "scp:template/handle-registry"
+        | "HandleRegistry"
+        | "scp:template/discovery-context"
+        | "DiscoveryContext" => Ok(TemplateId::HandleRegistry),
+        _ => Err(format!(
+            "unknown template ID: {tid:?} — valid values: BilateralEphemeral, \
+             BilateralPersistent, Coordination, GroupDiscussion, PublicBroadcast, \
+             GatedBroadcast, scp:template/tool-interface, PaidService, PaidBroadcast, \
+             HandleRegistry, scp:template/handle-registry, DiscoveryContext, \
+             scp:template/discovery-context"
+        )),
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::panic)]
+mod tests {
+    use super::*;
+
+    /// Helper: build and assert success.
+    fn build_ok(params: &CommonContextParams) -> ContextParams {
+        build_context_params(params).unwrap()
+    }
+
+    /// Helper: build and assert failure.
+    fn build_err(params: &CommonContextParams) -> String {
+        build_context_params(params).unwrap_err()
+    }
+
+    #[test]
+    fn default_params_produce_valid_context_params() {
+        let ctx = build_ok(&CommonContextParams::default());
+        assert!(matches!(ctx.mode, ContextMode::Encrypted));
+        assert!(ctx.ceiling.is_empty());
+        assert!(matches!(ctx.ceiling_policy, CeilingPolicy::Immutable));
+        assert!(matches!(ctx.promotion_policy, PromotionPolicy::NoPromotion));
+        assert!(matches!(ctx.memory_scope, MemoryScope::Ephemeral));
+        assert!(matches!(ctx.governance, GovernanceModel::SingleAdmin));
+        assert!(ctx.ttl.is_none());
+        assert!(ctx.economic_policy.is_none());
+        assert!(ctx.consequence_rules.is_empty());
+    }
+
+    #[test]
+    fn broadcast_mode_parsed() {
+        let ctx = build_ok(&CommonContextParams {
+            mode: "broadcast".to_owned(),
+            ..Default::default()
+        });
+        assert!(matches!(ctx.mode, ContextMode::Broadcast));
+    }
+
+    #[test]
+    fn broadcast_mode_titlecase_parsed() {
+        let ctx = build_ok(&CommonContextParams {
+            mode: "Broadcast".to_owned(),
+            ..Default::default()
+        });
+        assert!(matches!(ctx.mode, ContextMode::Broadcast));
+    }
+
+    #[test]
+    fn ceiling_parsed() {
+        let ctx = build_ok(&CommonContextParams {
+            ceiling: vec!["messages:write".to_owned(), "tools:invoke".to_owned()],
+            ..Default::default()
+        });
+        assert_eq!(ctx.ceiling.len(), 2);
+    }
+
+    #[test]
+    fn governed_ceiling_policy() {
+        let ctx = build_ok(&CommonContextParams {
+            ceiling_policy: "governed".to_owned(),
+            ..Default::default()
+        });
+        assert!(matches!(ctx.ceiling_policy, CeilingPolicy::Governed));
+    }
+
+    #[test]
+    fn promotable_policy() {
+        let ctx = build_ok(&CommonContextParams {
+            promotion_policy: "promotable".to_owned(),
+            ..Default::default()
+        });
+        assert!(matches!(ctx.promotion_policy, PromotionPolicy::Promotable));
+    }
+
+    #[test]
+    fn memory_scope_full() {
+        let ctx = build_ok(&CommonContextParams {
+            memory_scope: "full".to_owned(),
+            ..Default::default()
+        });
+        assert!(matches!(ctx.memory_scope, MemoryScope::Full));
+    }
+
+    #[test]
+    fn memory_scope_summary() {
+        let ctx = build_ok(&CommonContextParams {
+            memory_scope: "summary".to_owned(),
+            ..Default::default()
+        });
+        assert!(matches!(ctx.memory_scope, MemoryScope::Summary));
+    }
+
+    #[test]
+    fn unsupported_governance_rejected() {
+        let err = build_err(&CommonContextParams {
+            governance: "federation".to_owned(),
+            ..Default::default()
+        });
+        assert!(err.contains("unsupported governance model"));
+    }
+
+    #[test]
+    fn ttl_set() {
+        let ctx = build_ok(&CommonContextParams {
+            ttl: Some(Duration::from_secs(3600)),
+            ..Default::default()
+        });
+        assert_eq!(ctx.ttl, Some(Duration::from_secs(3600)));
+    }
+
+    #[test]
+    fn ttl_none_when_not_provided() {
+        let ctx = build_ok(&CommonContextParams::default());
+        assert!(ctx.ttl.is_none());
+    }
+
+    #[test]
+    fn min_protocol_version_set() {
+        let ctx = build_ok(&CommonContextParams {
+            min_protocol_version: Some((1, 2)),
+            ..Default::default()
+        });
+        assert_eq!(ctx.min_protocol_version, Some((1, 2)));
+    }
+
+    #[test]
+    fn invalid_economic_policy_json_rejected() {
+        let err = build_err(&CommonContextParams {
+            economic_policy_json: Some("not json".to_owned()),
+            ..Default::default()
+        });
+        assert!(err.contains("invalid economic_policy JSON"));
+    }
+
+    #[test]
+    fn invalid_consequence_rules_json_rejected() {
+        let err = build_err(&CommonContextParams {
+            consequence_rules_json: Some("not json".to_owned()),
+            ..Default::default()
+        });
+        assert!(err.contains("invalid consequence_rules JSON"));
+    }
+
+    #[test]
+    fn invalid_consequence_config_json_rejected() {
+        let err = build_err(&CommonContextParams {
+            consequence_config_json: Some("not json".to_owned()),
+            ..Default::default()
+        });
+        assert!(err.contains("invalid consequence_config JSON"));
+    }
+
+    #[test]
+    fn template_id_parsed_variant_name() {
+        let ctx = build_ok(&CommonContextParams {
+            template_id: Some("GroupDiscussion".to_owned()),
+            ..Default::default()
+        });
+        assert!(ctx.template_id.is_some());
+    }
+
+    #[test]
+    fn template_id_parsed_serde_form() {
+        let ctx = build_ok(&CommonContextParams {
+            template_id: Some("scp:template/tool-interface".to_owned()),
+            ..Default::default()
+        });
+        assert!(ctx.template_id.is_some());
+    }
+
+    #[test]
+    fn invalid_template_id_ignored() {
+        // Invalid template IDs are silently ignored (None), matching existing behavior
+        let ctx = build_ok(&CommonContextParams {
+            template_id: Some("invalid:template".to_owned()),
+            ..Default::default()
+        });
+        assert!(ctx.template_id.is_none());
+    }
+
+    #[test]
+    fn roles_converted() {
+        let ctx = build_ok(&CommonContextParams {
+            roles: vec![("admin".to_owned(), vec!["messages:write".to_owned()])],
+            ..Default::default()
+        });
+        assert_eq!(ctx.roles.len(), 1);
+        assert_eq!(ctx.roles[0].name, "admin");
+    }
+
+    #[test]
+    fn tools_converted() {
+        let ctx = build_ok(&CommonContextParams {
+            tools: vec!["calculator".to_owned()],
+            ..Default::default()
+        });
+        assert_eq!(ctx.tools.len(), 1);
+        assert_eq!(ctx.tools[0].name, "calculator");
+    }
+
+    #[test]
+    fn limits_passed_through() {
+        let ctx = build_ok(&CommonContextParams {
+            max_chain_depth: Some(4),
+            max_nesting_depth: Some(10),
+            session_cap: Some(500),
+            ..Default::default()
+        });
+        assert_eq!(ctx.max_chain_depth, Some(4));
+        assert_eq!(ctx.max_nesting_depth, Some(10));
+        assert_eq!(ctx.session_cap, Some(500));
+    }
+}

--- a/crates/scp-ffi/common/src/context_params.rs
+++ b/crates/scp-ffi/common/src/context_params.rs
@@ -193,7 +193,10 @@ fn parse_governance(
             let threshold = params.governance_threshold.unwrap_or(1);
             let signers = params.governance_signers.clone().unwrap_or_default();
             if signers.is_empty() {
-                return Err("threshold governance requires at least one signer".into());
+                // No signers provided — fall back to SingleAdmin.
+                // This preserves backward compatibility for UniFFI callers
+                // using the legacy Multisig variant without signer parameters.
+                return Ok(GovernanceModel::SingleAdmin);
             }
             Ok(GovernanceModel::Threshold {
                 threshold,
@@ -203,7 +206,9 @@ fn parse_governance(
         "majority" | "token_voting" => {
             let voters = params.governance_voters.clone().unwrap_or_default();
             if voters.is_empty() {
-                return Err("majority governance requires at least one eligible voter".into());
+                // No voters provided — fall back to SingleAdmin.
+                // Preserves backward compat for UniFFI TokenVoting without voters.
+                return Ok(GovernanceModel::SingleAdmin);
             }
             Ok(GovernanceModel::Majority {
                 eligible_voters: voters.into_iter().map(scp_primitives::DID::from).collect(),
@@ -212,7 +217,7 @@ fn parse_governance(
         "unanimity" => {
             let voters = params.governance_voters.clone().unwrap_or_default();
             if voters.is_empty() {
-                return Err("unanimity governance requires at least one eligible voter".into());
+                return Ok(GovernanceModel::SingleAdmin);
             }
             Ok(GovernanceModel::Unanimity {
                 eligible_voters: voters.into_iter().map(scp_primitives::DID::from).collect(),

--- a/crates/scp-ffi/common/src/context_params.rs
+++ b/crates/scp-ffi/common/src/context_params.rs
@@ -55,8 +55,17 @@ pub struct CommonContextParams {
     /// Memory scope: `"ephemeral"` (default), `"summary"`, or `"full"`.
     pub memory_scope: String,
 
-    /// Governance model: `"single_admin"`.
+    /// Governance model: `"single_admin"`, `"threshold"`, `"majority"`, `"unanimity"`.
     pub governance: String,
+
+    /// Threshold for threshold governance (required when governance = "threshold").
+    pub governance_threshold: Option<u32>,
+
+    /// Signer DIDs for threshold governance.
+    pub governance_signers: Option<Vec<String>>,
+
+    /// Eligible voter DIDs for majority/unanimity governance.
+    pub governance_voters: Option<Vec<String>>,
 
     /// Optional time-to-live. Each bridge converts its native TTL
     /// representation into a [`Duration`] before populating this field.
@@ -129,7 +138,7 @@ pub fn build_context_params(params: &CommonContextParams) -> Result<ContextParam
         "full" => MemoryScope::Full,
         _ => MemoryScope::Ephemeral,
     };
-    let governance = parse_governance(&params.governance)?;
+    let governance = parse_governance(&params.governance, params)?;
     let ttl = params.ttl;
     let economic_policy = parse_economic_policy(params.economic_policy_json.as_ref())?;
     let (consequence_rules, consequence_config) = parse_and_validate_consequences(
@@ -175,12 +184,44 @@ pub fn build_context_params(params: &CommonContextParams) -> Result<ContextParam
 // ---------------------------------------------------------------------------
 
 /// Validates and parses the governance model string.
-fn parse_governance(governance: &str) -> Result<GovernanceModel, String> {
+fn parse_governance(
+    governance: &str,
+    params: &CommonContextParams,
+) -> Result<GovernanceModel, String> {
     match governance {
         "single_admin" | "" => Ok(GovernanceModel::SingleAdmin),
+        "threshold" => {
+            let threshold = params.governance_threshold.unwrap_or(1);
+            let signers = params.governance_signers.clone().unwrap_or_default();
+            if signers.is_empty() {
+                return Err("threshold governance requires at least one signer".into());
+            }
+            Ok(GovernanceModel::Threshold {
+                threshold,
+                signers: signers.into_iter().map(scp_primitives::DID::from).collect(),
+            })
+        }
+        "majority" => {
+            let voters = params.governance_voters.clone().unwrap_or_default();
+            if voters.is_empty() {
+                return Err("majority governance requires at least one eligible voter".into());
+            }
+            Ok(GovernanceModel::Majority {
+                eligible_voters: voters.into_iter().map(scp_primitives::DID::from).collect(),
+            })
+        }
+        "unanimity" => {
+            let voters = params.governance_voters.clone().unwrap_or_default();
+            if voters.is_empty() {
+                return Err("unanimity governance requires at least one eligible voter".into());
+            }
+            Ok(GovernanceModel::Unanimity {
+                eligible_voters: voters.into_iter().map(scp_primitives::DID::from).collect(),
+            })
+        }
         other => Err(format!(
             "unsupported governance model: {other:?} — \
-             only \"single_admin\" is currently supported"
+             expected \"single_admin\", \"threshold\", \"majority\", or \"unanimity\""
         )),
     }
 }

--- a/crates/scp-ffi/common/src/context_params.rs
+++ b/crates/scp-ffi/common/src/context_params.rs
@@ -189,7 +189,7 @@ fn parse_governance(
 ) -> Result<GovernanceModel, String> {
     match governance {
         "single_admin" | "" => Ok(GovernanceModel::SingleAdmin),
-        "threshold" => {
+        "threshold" | "multisig" => {
             let threshold = params.governance_threshold.unwrap_or(1);
             let signers = params.governance_signers.clone().unwrap_or_default();
             if signers.is_empty() {
@@ -200,7 +200,7 @@ fn parse_governance(
                 signers: signers.into_iter().map(scp_primitives::DID::from).collect(),
             })
         }
-        "majority" => {
+        "majority" | "token_voting" => {
             let voters = params.governance_voters.clone().unwrap_or_default();
             if voters.is_empty() {
                 return Err("majority governance requires at least one eligible voter".into());
@@ -318,8 +318,8 @@ fn parse_template_id(tid: &str) -> Result<scp_core::context::params::TemplateId,
         "scp:template/tool-interface" | "ToolInterfaceTemplate" => {
             Ok(TemplateId::ToolInterfaceTemplate)
         }
-        "PaidService" => Ok(TemplateId::PaidService),
-        "PaidBroadcast" => Ok(TemplateId::PaidBroadcast),
+        "PaidService" | "scp:template/paid-service" => Ok(TemplateId::PaidService),
+        "PaidBroadcast" | "scp:template/paid-broadcast" => Ok(TemplateId::PaidBroadcast),
         "scp:template/handle-registry"
         | "HandleRegistry"
         | "scp:template/discovery-context"

--- a/crates/scp-ffi/common/src/error_codes.rs
+++ b/crates/scp-ffi/common/src/error_codes.rs
@@ -1,0 +1,687 @@
+//! Centralized SCP error code constants for all FFI bridges.
+//!
+//! Each error code follows the format `SCP-{CATEGORY}-{NUMBER}` where:
+//! - `CATEGORY` identifies the subsystem (IDENT, CTX, PERM, CRYPTO, etc.)
+//! - `NUMBER` falls within the allocated range for that category
+//!
+//! Canonical ranges (from `.docs/standards/sdk-common.md`):
+//!
+//! | Prefix        | Range       |
+//! |---------------|-------------|
+//! | `SCP-IDENT-`  | 1000--1999  |
+//! | `SCP-CTX-`    | 2000--2999  |
+//! | `SCP-PERM-`   | 3000--3999  |
+//! | `SCP-CRYPTO-` | 4000--4999  |
+//! | `SCP-TRANS-`  | 5000--5999  |
+//! | `SCP-TOOL-`   | 6000--6999  |
+//! | `SCP-VALID-`  | 7000--7999  |
+//! | `SCP-STORAGE-`| 8000--8999  |
+//! | `SCP-ATTEST-` | 9000--9999  |
+//! | `SCP-MCP-`    | 10000--10999|
+//! | `SCP-GOV-`    | 11000--11999|
+//! | `SCP-ECON-`   | 12000--12999|
+//!
+//! All bridges (`PyO3`, napi-rs, `UniFFI`, WASM) import these constants
+//! instead of defining error code strings locally. This eliminates
+//! cross-bridge divergence and makes error code auditing trivial.
+
+// -------------------------------------------------------------------------
+// Identity (SCP-IDENT- 1000--1999)
+// -------------------------------------------------------------------------
+
+/// Generic identity error.
+pub const IDENT_1000: &str = "SCP-IDENT-1000";
+/// Identity operation failed.
+pub const IDENT_1001: &str = "SCP-IDENT-1001";
+/// Identity not found.
+pub const IDENT_1002: &str = "SCP-IDENT-1002";
+/// Identity already exists.
+pub const IDENT_1003: &str = "SCP-IDENT-1003";
+/// Identity key generation failed.
+pub const IDENT_1004: &str = "SCP-IDENT-1004";
+/// Identity resolution failed.
+pub const IDENT_1005: &str = "SCP-IDENT-1005";
+/// Identity rotation failed.
+pub const IDENT_1006: &str = "SCP-IDENT-1006";
+/// Identity migration failed.
+pub const IDENT_1007: &str = "SCP-IDENT-1007";
+/// Identity load failed.
+pub const IDENT_1008: &str = "SCP-IDENT-1008";
+/// Identity storage error.
+pub const IDENT_1009: &str = "SCP-IDENT-1009";
+/// `UniFFI` identity create error.
+pub const IDENT_1010: &str = "SCP-IDENT-1010";
+/// `UniFFI` identity load error.
+pub const IDENT_1011: &str = "SCP-IDENT-1011";
+/// `UniFFI` identity resolve error.
+pub const IDENT_1012: &str = "SCP-IDENT-1012";
+/// `UniFFI` identity passphrase error.
+pub const IDENT_1013: &str = "SCP-IDENT-1013";
+/// Identity agent key creation.
+pub const IDENT_1020: &str = "SCP-IDENT-1020";
+/// Identity DID document error.
+pub const IDENT_1022: &str = "SCP-IDENT-1022";
+/// Identity agent key validation.
+pub const IDENT_1023: &str = "SCP-IDENT-1023";
+/// Identity agent key operation error.
+pub const IDENT_1024: &str = "SCP-IDENT-1024";
+/// Identity custody error.
+pub const IDENT_1025: &str = "SCP-IDENT-1025";
+/// Identity DID method error.
+pub const IDENT_1026: &str = "SCP-IDENT-1026";
+/// Identity DHT publish error.
+pub const IDENT_1027: &str = "SCP-IDENT-1027";
+/// Identity key handle error.
+pub const IDENT_1028: &str = "SCP-IDENT-1028";
+/// SCPID challenge expired.
+pub const IDENT_1030: &str = "SCP-IDENT-1030";
+/// SCPID audience mismatch.
+pub const IDENT_1031: &str = "SCP-IDENT-1031";
+/// SCPID timestamp invalid.
+pub const IDENT_1032: &str = "SCP-IDENT-1032";
+/// SCPID DID resolution failed.
+pub const IDENT_1033: &str = "SCP-IDENT-1033";
+/// SCPID key not authorized.
+pub const IDENT_1034: &str = "SCP-IDENT-1034";
+/// SCPID signature invalid.
+pub const IDENT_1035: &str = "SCP-IDENT-1035";
+/// SCPID DID document stale.
+pub const IDENT_1036: &str = "SCP-IDENT-1036";
+/// SCPID signing failed.
+pub const IDENT_1037: &str = "SCP-IDENT-1037";
+/// SCPID invalid input.
+pub const IDENT_1038: &str = "SCP-IDENT-1038";
+/// Identity attestation create.
+pub const IDENT_1040: &str = "SCP-IDENT-1040";
+/// Identity attestation verify.
+pub const IDENT_1041: &str = "SCP-IDENT-1041";
+/// Identity attestation revoke.
+pub const IDENT_1042: &str = "SCP-IDENT-1042";
+/// Identity attestation status.
+pub const IDENT_1043: &str = "SCP-IDENT-1043";
+/// Identity attestation query.
+pub const IDENT_1044: &str = "SCP-IDENT-1044";
+/// Identity attestation list.
+pub const IDENT_1045: &str = "SCP-IDENT-1045";
+
+// -------------------------------------------------------------------------
+// Context (SCP-CTX- 2000--2999)
+// -------------------------------------------------------------------------
+
+/// Generic context error.
+pub const CTX_2000: &str = "SCP-CTX-2000";
+/// Context operation failed.
+pub const CTX_2001: &str = "SCP-CTX-2001";
+/// Context not found.
+pub const CTX_2002: &str = "SCP-CTX-2002";
+/// Context already exists.
+pub const CTX_2003: &str = "SCP-CTX-2003";
+/// Context creation failed.
+pub const CTX_2004: &str = "SCP-CTX-2004";
+/// Context join failed.
+pub const CTX_2005: &str = "SCP-CTX-2005";
+/// Context leave failed.
+pub const CTX_2006: &str = "SCP-CTX-2006";
+/// Context send failed.
+pub const CTX_2007: &str = "SCP-CTX-2007";
+/// Context receive failed.
+pub const CTX_2008: &str = "SCP-CTX-2008";
+/// Context close failed.
+pub const CTX_2009: &str = "SCP-CTX-2009";
+/// Context export/import failed.
+pub const CTX_2010: &str = "SCP-CTX-2010";
+/// Context mode error.
+pub const CTX_2011: &str = "SCP-CTX-2011";
+/// Context manager error.
+pub const CTX_2012: &str = "SCP-CTX-2012";
+/// Context member error.
+pub const CTX_2013: &str = "SCP-CTX-2013";
+/// Context governance error.
+pub const CTX_2014: &str = "SCP-CTX-2014";
+/// Context TTL error.
+pub const CTX_2015: &str = "SCP-CTX-2015";
+/// Context TTL extension error.
+pub const CTX_2016: &str = "SCP-CTX-2016";
+/// Context broadcast error.
+pub const CTX_2017: &str = "SCP-CTX-2017";
+/// Context broadcast subscribe error.
+pub const CTX_2018: &str = "SCP-CTX-2018";
+/// Context broadcast publish error.
+pub const CTX_2019: &str = "SCP-CTX-2019";
+/// Context broadcast block error.
+pub const CTX_2020: &str = "SCP-CTX-2020";
+/// Context query error.
+pub const CTX_2021: &str = "SCP-CTX-2021";
+/// Context drain events error.
+pub const CTX_2022: &str = "SCP-CTX-2022";
+/// Context broadcast key request error.
+pub const CTX_2023: &str = "SCP-CTX-2023";
+/// Context governance action error.
+pub const CTX_2024: &str = "SCP-CTX-2024";
+/// Context broadcast unsubscribe error.
+pub const CTX_2025: &str = "SCP-CTX-2025";
+/// Context broadcast admission error.
+pub const CTX_2026: &str = "SCP-CTX-2026";
+/// Context broadcast subscriber count error.
+pub const CTX_2027: &str = "SCP-CTX-2027";
+/// Context broadcast subscriber check error.
+pub const CTX_2028: &str = "SCP-CTX-2028";
+/// Context member count.
+pub const CTX_2030: &str = "SCP-CTX-2030";
+/// Context member check.
+pub const CTX_2031: &str = "SCP-CTX-2031";
+/// Context member DIDs.
+pub const CTX_2032: &str = "SCP-CTX-2032";
+/// Context member role.
+pub const CTX_2033: &str = "SCP-CTX-2033";
+/// Context member role operation.
+pub const CTX_2034: &str = "SCP-CTX-2034";
+/// Context TTL reset error.
+pub const CTX_2035: &str = "SCP-CTX-2035";
+/// Context TTL propose error.
+pub const CTX_2036: &str = "SCP-CTX-2036";
+/// Context TTL handle error.
+pub const CTX_2037: &str = "SCP-CTX-2037";
+/// Context handle TTL expiry error.
+pub const CTX_2038: &str = "SCP-CTX-2038";
+/// Context handle governance timeout.
+pub const CTX_2039: &str = "SCP-CTX-2039";
+/// WASM context operation error.
+pub const CTX_2040: &str = "SCP-CTX-2040";
+/// WASM context governance error.
+pub const CTX_2041: &str = "SCP-CTX-2041";
+/// WASM context TTL error.
+pub const CTX_2042: &str = "SCP-CTX-2042";
+/// WASM context broadcast error.
+pub const CTX_2043: &str = "SCP-CTX-2043";
+/// WASM context member error.
+pub const CTX_2044: &str = "SCP-CTX-2044";
+/// WASM context drain error.
+pub const CTX_2045: &str = "SCP-CTX-2045";
+/// WASM context query error.
+pub const CTX_2046: &str = "SCP-CTX-2046";
+/// `UniFFI` context operation error.
+pub const CTX_2050: &str = "SCP-CTX-2050";
+/// `UniFFI` context create error.
+pub const CTX_2051: &str = "SCP-CTX-2051";
+/// `UniFFI` context join error.
+pub const CTX_2052: &str = "SCP-CTX-2052";
+/// `UniFFI` context close error.
+pub const CTX_2053: &str = "SCP-CTX-2053";
+/// `UniFFI` context leave error.
+pub const CTX_2054: &str = "SCP-CTX-2054";
+/// `UniFFI` context send error.
+pub const CTX_2055: &str = "SCP-CTX-2055";
+/// `UniFFI` relay connection error.
+pub const CTX_2060: &str = "SCP-CTX-2060";
+/// `UniFFI` context export error.
+pub const CTX_2061: &str = "SCP-CTX-2061";
+/// `UniFFI` context import error.
+pub const CTX_2062: &str = "SCP-CTX-2062";
+/// `UniFFI` context receive error.
+pub const CTX_2063: &str = "SCP-CTX-2063";
+/// `UniFFI` context governance error.
+pub const CTX_2064: &str = "SCP-CTX-2064";
+/// `UniFFI` context TTL error.
+pub const CTX_2065: &str = "SCP-CTX-2065";
+/// `UniFFI` context broadcast error.
+pub const CTX_2066: &str = "SCP-CTX-2066";
+/// `UniFFI` context query error.
+pub const CTX_2070: &str = "SCP-CTX-2070";
+/// `UniFFI` context member count error.
+pub const CTX_2071: &str = "SCP-CTX-2071";
+/// `UniFFI` context member check error.
+pub const CTX_2072: &str = "SCP-CTX-2072";
+/// `UniFFI` context member DIDs error.
+pub const CTX_2073: &str = "SCP-CTX-2073";
+/// `UniFFI` context member role error.
+pub const CTX_2074: &str = "SCP-CTX-2074";
+/// `UniFFI` context drain events error.
+pub const CTX_2075: &str = "SCP-CTX-2075";
+/// Context economy insufficient funds.
+pub const CTX_2091: &str = "SCP-CTX-2091";
+/// Context economy spending error.
+pub const CTX_2092: &str = "SCP-CTX-2092";
+/// Bridge connector context creation error.
+pub const CTX_2100: &str = "SCP-CTX-2100";
+/// Bridge connector context join error.
+pub const CTX_2101: &str = "SCP-CTX-2101";
+/// Bridge connector context send error.
+pub const CTX_2102: &str = "SCP-CTX-2102";
+/// Bridge connector context leave error.
+pub const CTX_2103: &str = "SCP-CTX-2103";
+/// Bridge connector context close error.
+pub const CTX_2104: &str = "SCP-CTX-2104";
+/// Bridge connector broadcast subscribe error.
+pub const CTX_2105: &str = "SCP-CTX-2105";
+/// Bridge connector broadcast unsubscribe error.
+pub const CTX_2106: &str = "SCP-CTX-2106";
+/// Bridge connector broadcast publish error.
+pub const CTX_2107: &str = "SCP-CTX-2107";
+/// Bridge connector broadcast block error.
+pub const CTX_2108: &str = "SCP-CTX-2108";
+/// Bridge connector broadcast key request error.
+pub const CTX_2109: &str = "SCP-CTX-2109";
+/// Bridge connector broadcast admission error.
+pub const CTX_2110: &str = "SCP-CTX-2110";
+/// Bridge connector governance action error.
+pub const CTX_2111: &str = "SCP-CTX-2111";
+/// Bridge connector TTL expiry error.
+pub const CTX_2112: &str = "SCP-CTX-2112";
+/// Bridge connector TTL extension error.
+pub const CTX_2113: &str = "SCP-CTX-2113";
+/// Bridge connector context import error.
+pub const CTX_2114: &str = "SCP-CTX-2114";
+/// Media context error.
+pub const CTX_2500: &str = "SCP-CTX-2500";
+/// Media context key export error.
+pub const CTX_2501: &str = "SCP-CTX-2501";
+
+// -------------------------------------------------------------------------
+// Permission (SCP-PERM- 3000--3999)
+// -------------------------------------------------------------------------
+
+/// Generic permission error.
+pub const PERM_3000: &str = "SCP-PERM-3000";
+/// Permission denied.
+pub const PERM_3001: &str = "SCP-PERM-3001";
+/// Insufficient capabilities.
+pub const PERM_3002: &str = "SCP-PERM-3002";
+/// Capability delegation error.
+pub const PERM_3003: &str = "SCP-PERM-3003";
+/// Capability ceiling exceeded.
+pub const PERM_3004: &str = "SCP-PERM-3004";
+/// Role assignment error.
+pub const PERM_3005: &str = "SCP-PERM-3005";
+/// UCAN token invalid.
+pub const PERM_3006: &str = "SCP-PERM-3006";
+/// UCAN token expired.
+pub const PERM_3007: &str = "SCP-PERM-3007";
+/// UCAN token revoked.
+pub const PERM_3008: &str = "SCP-PERM-3008";
+/// Provenance permission: signer not context member.
+pub const PERM_3010: &str = "SCP-PERM-3010";
+/// Provenance permission: signer role insufficient.
+pub const PERM_3011: &str = "SCP-PERM-3011";
+/// Provenance permission: capability check failed.
+pub const PERM_3012: &str = "SCP-PERM-3012";
+/// UCAN permission: issuer not authorized.
+pub const PERM_3020: &str = "SCP-PERM-3020";
+/// UCAN permission: audience mismatch.
+pub const PERM_3021: &str = "SCP-PERM-3021";
+/// UCAN permission: delegation chain invalid.
+pub const PERM_3022: &str = "SCP-PERM-3022";
+/// UCAN permission: nonce replay detected.
+pub const PERM_3023: &str = "SCP-PERM-3023";
+
+// -------------------------------------------------------------------------
+// Crypto (SCP-CRYPTO- 4000--4999)
+// -------------------------------------------------------------------------
+
+/// Generic crypto error.
+pub const CRYPTO_4001: &str = "SCP-CRYPTO-4001";
+/// MLS group error.
+pub const CRYPTO_4002: &str = "SCP-CRYPTO-4002";
+/// Encryption failed.
+pub const CRYPTO_4003: &str = "SCP-CRYPTO-4003";
+/// Decryption failed.
+pub const CRYPTO_4004: &str = "SCP-CRYPTO-4004";
+/// MLS group create error.
+pub const CRYPTO_4010: &str = "SCP-CRYPTO-4010";
+/// MLS proposal error.
+pub const CRYPTO_4011: &str = "SCP-CRYPTO-4011";
+/// MLS commit error.
+pub const CRYPTO_4012: &str = "SCP-CRYPTO-4012";
+/// WASM MLS group create error.
+pub const CRYPTO_4020: &str = "SCP-CRYPTO-4020";
+/// WASM MLS proposal error.
+pub const CRYPTO_4021: &str = "SCP-CRYPTO-4021";
+/// WASM MLS commit error.
+pub const CRYPTO_4022: &str = "SCP-CRYPTO-4022";
+/// WASM sender key error.
+pub const CRYPTO_4023: &str = "SCP-CRYPTO-4023";
+/// `UniFFI` MLS group error.
+pub const CRYPTO_4050: &str = "SCP-CRYPTO-4050";
+/// `UniFFI` MLS encrypt error.
+pub const CRYPTO_4051: &str = "SCP-CRYPTO-4051";
+/// `UniFFI` MLS decrypt error.
+pub const CRYPTO_4052: &str = "SCP-CRYPTO-4052";
+/// `UniFFI` MLS key export error.
+pub const CRYPTO_4053: &str = "SCP-CRYPTO-4053";
+/// `UniFFI` sender key error.
+pub const CRYPTO_4054: &str = "SCP-CRYPTO-4054";
+/// `UniFFI` key generation error.
+pub const CRYPTO_4055: &str = "SCP-CRYPTO-4055";
+/// `UniFFI` key import error.
+pub const CRYPTO_4056: &str = "SCP-CRYPTO-4056";
+/// `UniFFI` key export error.
+pub const CRYPTO_4057: &str = "SCP-CRYPTO-4057";
+/// `UniFFI` key package error.
+pub const CRYPTO_4058: &str = "SCP-CRYPTO-4058";
+/// `UniFFI` HPKE error.
+pub const CRYPTO_4059: &str = "SCP-CRYPTO-4059";
+/// `UniFFI` key custody error.
+pub const CRYPTO_4060: &str = "SCP-CRYPTO-4060";
+
+// -------------------------------------------------------------------------
+// Transport (SCP-TRANS- 5000--5999)
+// -------------------------------------------------------------------------
+
+/// Generic transport error.
+pub const TRANS_5001: &str = "SCP-TRANS-5001";
+/// Transport connection failed.
+pub const TRANS_5002: &str = "SCP-TRANS-5002";
+/// Transport send failed.
+pub const TRANS_5003: &str = "SCP-TRANS-5003";
+/// Transport receive failed.
+pub const TRANS_5004: &str = "SCP-TRANS-5004";
+/// Transport subscription error.
+pub const TRANS_5010: &str = "SCP-TRANS-5010";
+/// Transport subscription already active.
+pub const TRANS_5011: &str = "SCP-TRANS-5011";
+/// Transport relay connect error.
+pub const TRANS_5012: &str = "SCP-TRANS-5012";
+/// Transport relay disconnect error.
+pub const TRANS_5013: &str = "SCP-TRANS-5013";
+/// Transport relay status error.
+pub const TRANS_5014: &str = "SCP-TRANS-5014";
+/// Transport cover traffic error.
+pub const TRANS_5015: &str = "SCP-TRANS-5015";
+/// Transport heartbeat error.
+pub const TRANS_5016: &str = "SCP-TRANS-5016";
+/// Transport checkpoint error.
+pub const TRANS_5018: &str = "SCP-TRANS-5018";
+/// Transport proof error.
+pub const TRANS_5019: &str = "SCP-TRANS-5019";
+/// Transport webhook error.
+pub const TRANS_5020: &str = "SCP-TRANS-5020";
+/// Transport webhook register error.
+pub const TRANS_5021: &str = "SCP-TRANS-5021";
+/// Transport webhook unregister error.
+pub const TRANS_5022: &str = "SCP-TRANS-5022";
+/// Transport webhook list error.
+pub const TRANS_5023: &str = "SCP-TRANS-5023";
+/// Transport webhook fire error.
+pub const TRANS_5024: &str = "SCP-TRANS-5024";
+/// Transport webhook test error.
+pub const TRANS_5025: &str = "SCP-TRANS-5025";
+/// Transport relay configured error.
+pub const TRANS_5030: &str = "SCP-TRANS-5030";
+/// `UniFFI` transport server error.
+pub const TRANS_5050: &str = "SCP-TRANS-5050";
+/// `UniFFI` transport bind error.
+pub const TRANS_5051: &str = "SCP-TRANS-5051";
+/// `UniFFI` transport TLS error.
+pub const TRANS_5052: &str = "SCP-TRANS-5052";
+/// `UniFFI` transport storage error.
+pub const TRANS_5053: &str = "SCP-TRANS-5053";
+/// `UniFFI` transport node error.
+pub const TRANS_5054: &str = "SCP-TRANS-5054";
+/// `UniFFI` transport relay connect error.
+pub const TRANS_5060: &str = "SCP-TRANS-5060";
+/// `UniFFI` transport relay send error.
+pub const TRANS_5061: &str = "SCP-TRANS-5061";
+/// `UniFFI` transport relay receive error.
+pub const TRANS_5062: &str = "SCP-TRANS-5062";
+/// `UniFFI` transport relay status error.
+pub const TRANS_5063: &str = "SCP-TRANS-5063";
+/// `UniFFI` transport broadcast error.
+pub const TRANS_5070: &str = "SCP-TRANS-5070";
+
+// -------------------------------------------------------------------------
+// Tool (SCP-TOOL- 6000--6999)
+// -------------------------------------------------------------------------
+
+/// Generic tool error.
+pub const TOOL_6001: &str = "SCP-TOOL-6001";
+/// Tool not found.
+pub const TOOL_6002: &str = "SCP-TOOL-6002";
+/// Tool registration error.
+pub const TOOL_6003: &str = "SCP-TOOL-6003";
+/// Tool invocation error.
+pub const TOOL_6004: &str = "SCP-TOOL-6004";
+/// Tool verification error.
+pub const TOOL_6005: &str = "SCP-TOOL-6005";
+/// Tool capability error.
+pub const TOOL_6006: &str = "SCP-TOOL-6006";
+/// Tool interface error.
+pub const TOOL_6007: &str = "SCP-TOOL-6007";
+/// Tool schema error.
+pub const TOOL_6008: &str = "SCP-TOOL-6008";
+/// Tool handler error.
+pub const TOOL_6009: &str = "SCP-TOOL-6009";
+/// Tool interface establish error.
+pub const TOOL_6010: &str = "SCP-TOOL-6010";
+/// Tool interface query error.
+pub const TOOL_6011: &str = "SCP-TOOL-6011";
+/// Tool interface list error.
+pub const TOOL_6012: &str = "SCP-TOOL-6012";
+/// Tool signer error.
+pub const TOOL_6013: &str = "SCP-TOOL-6013";
+/// Tool register error.
+pub const TOOL_6014: &str = "SCP-TOOL-6014";
+/// Tool deregister error.
+pub const TOOL_6015: &str = "SCP-TOOL-6015";
+/// Tool invoke capability error.
+pub const TOOL_6017: &str = "SCP-TOOL-6017";
+/// Tool invoke schema validation error.
+pub const TOOL_6018: &str = "SCP-TOOL-6018";
+/// Tool invoke result error.
+pub const TOOL_6019: &str = "SCP-TOOL-6019";
+/// Tool invoke handler error.
+pub const TOOL_6020: &str = "SCP-TOOL-6020";
+/// Tool invoke timeout error.
+pub const TOOL_6021: &str = "SCP-TOOL-6021";
+/// Tool verify register error.
+pub const TOOL_6030: &str = "SCP-TOOL-6030";
+/// Tool verify not found error.
+pub const TOOL_6031: &str = "SCP-TOOL-6031";
+/// Tool verify invoke schema error.
+pub const TOOL_6032: &str = "SCP-TOOL-6032";
+/// Tool verify invoke not found error.
+pub const TOOL_6033: &str = "SCP-TOOL-6033";
+/// Tool verify output schema error.
+pub const TOOL_6035: &str = "SCP-TOOL-6035";
+
+// -------------------------------------------------------------------------
+// Validation (SCP-VALID- 7000--7999)
+// -------------------------------------------------------------------------
+
+/// Generic validation error.
+pub const VALID_7000: &str = "SCP-VALID-7000";
+/// Input validation failed.
+pub const VALID_7001: &str = "SCP-VALID-7001";
+/// JSON parse error.
+pub const VALID_7002: &str = "SCP-VALID-7002";
+/// JSON schema validation error.
+pub const VALID_7003: &str = "SCP-VALID-7003";
+/// Missing required field.
+pub const VALID_7004: &str = "SCP-VALID-7004";
+/// Invalid field value.
+pub const VALID_7005: &str = "SCP-VALID-7005";
+/// Validation type error.
+pub const VALID_7006: &str = "SCP-VALID-7006";
+/// Validation format error.
+pub const VALID_7007: &str = "SCP-VALID-7007";
+/// UCAN token validation error.
+pub const VALID_7010: &str = "SCP-VALID-7010";
+/// UCAN mint validation error.
+pub const VALID_7011: &str = "SCP-VALID-7011";
+/// UCAN revoke validation error.
+pub const VALID_7012: &str = "SCP-VALID-7012";
+/// UCAN delegation validation error.
+pub const VALID_7013: &str = "SCP-VALID-7013";
+/// UCAN capability validation error.
+pub const VALID_7014: &str = "SCP-VALID-7014";
+/// UCAN nonce validation error.
+pub const VALID_7015: &str = "SCP-VALID-7015";
+/// UCAN audience validation error.
+pub const VALID_7016: &str = "SCP-VALID-7016";
+/// UCAN issuer validation error.
+pub const VALID_7017: &str = "SCP-VALID-7017";
+/// Event log validation error.
+pub const VALID_7020: &str = "SCP-VALID-7020";
+/// Event log query validation error.
+pub const VALID_7021: &str = "SCP-VALID-7021";
+/// Event log verify validation error.
+pub const VALID_7022: &str = "SCP-VALID-7022";
+/// Governance action validation error.
+pub const VALID_7027: &str = "SCP-VALID-7027";
+/// MCP validation error.
+pub const VALID_7030: &str = "SCP-VALID-7030";
+/// MCP transport validation error.
+pub const VALID_7031: &str = "SCP-VALID-7031";
+/// MCP handle validation error.
+pub const VALID_7032: &str = "SCP-VALID-7032";
+/// MCP context validation error.
+pub const VALID_7033: &str = "SCP-VALID-7033";
+/// MCP tool validation error.
+pub const VALID_7034: &str = "SCP-VALID-7034";
+/// Tool register input validation error.
+pub const VALID_7035: &str = "SCP-VALID-7035";
+/// Tool register schema validation error.
+pub const VALID_7036: &str = "SCP-VALID-7036";
+/// Tool invoke input validation error.
+pub const VALID_7037: &str = "SCP-VALID-7037";
+/// Tool verify input validation error.
+pub const VALID_7038: &str = "SCP-VALID-7038";
+/// Event log input validation error.
+pub const VALID_7040: &str = "SCP-VALID-7040";
+/// Tool verify register output validation.
+pub const VALID_7041: &str = "SCP-VALID-7041";
+/// Tool verify output validation error.
+pub const VALID_7042: &str = "SCP-VALID-7042";
+/// Transport connect validation error.
+pub const VALID_7043: &str = "SCP-VALID-7043";
+/// Transport disconnect validation error.
+pub const VALID_7044: &str = "SCP-VALID-7044";
+/// Transport status validation error.
+pub const VALID_7045: &str = "SCP-VALID-7045";
+/// Transport cover traffic validation error.
+pub const VALID_7046: &str = "SCP-VALID-7046";
+/// Transport heartbeat validation error.
+pub const VALID_7047: &str = "SCP-VALID-7047";
+/// Transport checkpoint validation error.
+pub const VALID_7048: &str = "SCP-VALID-7048";
+/// Transport proof validation error.
+pub const VALID_7049: &str = "SCP-VALID-7049";
+/// Bridge connector DID validation error.
+pub const VALID_7050: &str = "SCP-VALID-7050";
+/// Bridge connector context ID validation error.
+pub const VALID_7051: &str = "SCP-VALID-7051";
+/// Bridge connector payload validation error.
+pub const VALID_7052: &str = "SCP-VALID-7052";
+/// Bridge connector admission validation error.
+pub const VALID_7053: &str = "SCP-VALID-7053";
+/// Bridge connector key validation error.
+pub const VALID_7054: &str = "SCP-VALID-7054";
+/// Bridge connector broadcast key validation error.
+pub const VALID_7055: &str = "SCP-VALID-7055";
+/// Bridge connector epoch validation error.
+pub const VALID_7056: &str = "SCP-VALID-7056";
+/// Bridge connector governance validation error.
+pub const VALID_7057: &str = "SCP-VALID-7057";
+/// Bridge connector import validation error.
+pub const VALID_7058: &str = "SCP-VALID-7058";
+/// Discovery validation error.
+pub const VALID_7060: &str = "SCP-VALID-7060";
+/// Discovery member validation error.
+pub const VALID_7061: &str = "SCP-VALID-7061";
+/// Discovery context validation error.
+pub const VALID_7062: &str = "SCP-VALID-7062";
+/// Discovery register validation error.
+pub const VALID_7063: &str = "SCP-VALID-7063";
+/// Discovery unregister validation error.
+pub const VALID_7064: &str = "SCP-VALID-7064";
+/// Discovery query validation error.
+pub const VALID_7065: &str = "SCP-VALID-7065";
+/// Discovery probe validation error.
+pub const VALID_7066: &str = "SCP-VALID-7066";
+/// Webhook validation error.
+pub const VALID_7070: &str = "SCP-VALID-7070";
+/// Webhook register validation error.
+pub const VALID_7071: &str = "SCP-VALID-7071";
+/// Webhook operation validation error.
+pub const VALID_7072: &str = "SCP-VALID-7072";
+/// Attestation validation error.
+pub const VALID_7080: &str = "SCP-VALID-7080";
+/// Discovery announce validation error.
+pub const VALID_7090: &str = "SCP-VALID-7090";
+/// Discovery search validation error.
+pub const VALID_7091: &str = "SCP-VALID-7091";
+/// Discovery result validation error.
+pub const VALID_7092: &str = "SCP-VALID-7092";
+/// Handle/petname DID validation error.
+pub const VALID_7110: &str = "SCP-VALID-7110";
+/// Handle/petname alias validation error.
+pub const VALID_7111: &str = "SCP-VALID-7111";
+/// Handle/petname context validation error.
+pub const VALID_7112: &str = "SCP-VALID-7112";
+/// Handle/petname target validation error.
+pub const VALID_7113: &str = "SCP-VALID-7113";
+/// Handle/petname address validation error.
+pub const VALID_7114: &str = "SCP-VALID-7114";
+/// Handle registry lock error.
+pub const VALID_7120: &str = "SCP-VALID-7120";
+/// Handle registry operation error.
+pub const VALID_7122: &str = "SCP-VALID-7122";
+/// Handle registry query error.
+pub const VALID_7123: &str = "SCP-VALID-7123";
+/// Handle registry resolve error.
+pub const VALID_7124: &str = "SCP-VALID-7124";
+/// Handle registry list error.
+pub const VALID_7125: &str = "SCP-VALID-7125";
+/// Handle registry batch error.
+pub const VALID_7126: &str = "SCP-VALID-7126";
+/// Address resolution validation error.
+pub const VALID_7130: &str = "SCP-VALID-7130";
+/// Address resolution parse error.
+pub const VALID_7131: &str = "SCP-VALID-7131";
+/// Address resolution format error.
+pub const VALID_7132: &str = "SCP-VALID-7132";
+/// Address resolution lookup error.
+pub const VALID_7133: &str = "SCP-VALID-7133";
+/// Address resolution result error.
+pub const VALID_7134: &str = "SCP-VALID-7134";
+/// Address resolution ambiguous error.
+pub const VALID_7135: &str = "SCP-VALID-7135";
+/// Governance vote validation error.
+pub const VALID_7216: &str = "SCP-VALID-7216";
+/// Media validation error.
+pub const VALID_7300: &str = "SCP-VALID-7300";
+/// Media DID validation error.
+pub const VALID_7301: &str = "SCP-VALID-7301";
+/// Media context ID validation error.
+pub const VALID_7302: &str = "SCP-VALID-7302";
+/// Media configuration validation error.
+pub const VALID_7303: &str = "SCP-VALID-7303";
+/// Transport configure validation error.
+pub const VALID_7400: &str = "SCP-VALID-7400";
+/// Transport configure relay URL validation error.
+pub const VALID_7401: &str = "SCP-VALID-7401";
+/// Transport configure bearer token validation error.
+pub const VALID_7402: &str = "SCP-VALID-7402";
+/// Transport configure relay connection error.
+pub const VALID_7403: &str = "SCP-VALID-7403";
+
+// -------------------------------------------------------------------------
+// Attestation (SCP-ATTEST- 9000--9999)
+// -------------------------------------------------------------------------
+
+/// Attestation operation error.
+pub const ATTEST_9010: &str = "SCP-ATTEST-9010";
+
+// -------------------------------------------------------------------------
+// Economy (SCP-ECON- 12000--12999)
+// -------------------------------------------------------------------------
+
+/// Economy insufficient balance.
+pub const ECON_12061: &str = "SCP-ECON-12061";
+/// Economy governance action spending error.
+pub const ECON_12090: &str = "SCP-ECON-12090";
+/// Economy context operation spending error.
+pub const ECON_12091: &str = "SCP-ECON-12091";
+/// Economy rate limit error.
+pub const ECON_12095: &str = "SCP-ECON-12095";
+/// Economy budget exceeded error.
+pub const ECON_12096: &str = "SCP-ECON-12096";

--- a/crates/scp-ffi/common/src/lib.rs
+++ b/crates/scp-ffi/common/src/lib.rs
@@ -16,6 +16,7 @@
 //!
 //! See §3.10.10, §9.5, §7.4.1, §22.3.1, §22.4, §22.8 in `.docs/specs/`.
 
+pub mod error_codes;
 pub mod validate;
 
 mod bridge_id;

--- a/crates/scp-ffi/common/src/lib.rs
+++ b/crates/scp-ffi/common/src/lib.rs
@@ -78,6 +78,11 @@ pub fn html_escape_json(json: &str) -> String {
         .replace('\'', "\\u0027")
 }
 
+// Shared context-parameter builder for all non-WASM bridges.
+// Requires scp-core (behind `resolvers` feature). Not available for WASM.
+#[cfg(feature = "resolvers")]
+pub mod context_params;
+
 // Trust store shared across PyO3, napi-rs, and UniFFI bridges.
 // Requires scp-core (behind `resolvers` feature). Not available for WASM.
 #[cfg(feature = "resolvers")]

--- a/crates/scp-ffi/common/src/server.rs
+++ b/crates/scp-ffi/common/src/server.rs
@@ -12,6 +12,7 @@ use std::net::SocketAddr;
 use std::path::{Component, Path};
 use std::sync::Arc;
 
+use scp_core::context::ContextManager;
 use scp_identity::cache::SystemClock;
 use scp_identity::dht::DidDht;
 use scp_identity::{DidDocument, InMemoryDhtClient, ScpIdentity};
@@ -636,6 +637,128 @@ impl RunningNode {
             Self::InMemory(n) => n.http_url().await,
             Self::Filesystem(n) => n.http_url().await,
         }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Broadcast key resolution — shared across PyO3 and NAPI bridges
+// ---------------------------------------------------------------------------
+
+/// Error returned by [`resolve_broadcast_key`] when key resolution fails.
+///
+/// Bridge callers map this to their framework-specific error types
+/// (`PyErr`, `napi::Error`, etc.).
+#[derive(Debug, thiserror::Error)]
+pub enum BroadcastKeyError {
+    /// The hex string is not valid hex.
+    #[error("invalid broadcast_key_hex: {0}")]
+    InvalidHex(#[from] hex::FromHexError),
+
+    /// The decoded key is not exactly 32 bytes.
+    #[error("broadcast_key_hex must be exactly 64 hex characters (32 bytes)")]
+    InvalidKeyLength,
+
+    /// `broadcast_key_hex` was provided without `author_did`.
+    #[error(
+        "broadcast_key_hex requires author_did — provide the DID of the \
+         broadcast key owner, or omit both for auto-resolve"
+    )]
+    KeyWithoutAuthor,
+
+    /// Auto-resolve from the `ContextManager` failed.
+    #[error("broadcast key auto-resolve failed: {0}")]
+    AutoResolveFailed(String),
+}
+
+/// Resolved broadcast key components ready for `BroadcastKey::from_parts`.
+pub struct ResolvedBroadcastKey {
+    /// The 32-byte broadcast key (zeroize-protected).
+    pub key_bytes: Zeroizing<[u8; 32]>,
+    /// The epoch associated with the key (0 for explicit keys).
+    pub epoch: u64,
+    /// The DID of the broadcast key author/owner.
+    pub author_did: String,
+}
+
+/// Resolves broadcast key parameters into a [`ResolvedBroadcastKey`].
+///
+/// Three resolution modes:
+/// 1. Both `broadcast_key_hex` **and** `author_did` provided — uses the
+///    explicit key with epoch 0.
+/// 2. Only `author_did` provided — auto-resolves the broadcast key from
+///    the `ContextManager` using that DID.
+/// 3. Neither provided — auto-resolves using `fallback_did` (typically the
+///    node's identity DID).
+///
+/// Providing `broadcast_key_hex` without `author_did` is an error.
+///
+/// # Arguments
+///
+/// * `broadcast_key_hex` — Optional hex-encoded 32-byte key.
+/// * `author_did` — Optional DID of the broadcast key owner.
+/// * `fallback_did` — DID to use when both `broadcast_key_hex` and
+///   `author_did` are `None` (e.g., the node's own DID).
+/// * `context_manager` — Reference to the `ContextManager` for auto-resolve.
+/// * `context_id` — The context ID to resolve the key for.
+///
+/// # Errors
+///
+/// Returns [`BroadcastKeyError`] on invalid hex, wrong key length,
+/// missing author DID, or auto-resolve failure.
+pub async fn resolve_broadcast_key(
+    broadcast_key_hex: Option<String>,
+    author_did: Option<String>,
+    fallback_did: &str,
+    context_manager: &ContextManager,
+    context_id: &str,
+) -> Result<ResolvedBroadcastKey, BroadcastKeyError> {
+    match (broadcast_key_hex, author_did) {
+        (Some(key_hex), Some(did)) => {
+            let key_hex = Zeroizing::new(key_hex);
+            let key_vec = Zeroizing::new(hex::decode(&*key_hex)?);
+            let key_bytes: Zeroizing<[u8; 32]> = Zeroizing::new(
+                <[u8; 32]>::try_from(key_vec.as_slice())
+                    .map_err(|_| BroadcastKeyError::InvalidKeyLength)?,
+            );
+            // Explicit key path always uses epoch 0. For rotated keys,
+            // use auto-resolve (omit both params).
+            Ok(ResolvedBroadcastKey {
+                key_bytes,
+                epoch: 0,
+                author_did: did,
+            })
+        }
+        (None, author_opt) => {
+            // Auto-resolve: use provided author_did or fall back to node DID.
+            let did = author_opt.unwrap_or_else(|| fallback_did.to_owned());
+            let result: Result<(Zeroizing<[u8; 32]>, u64), _> = context_manager
+                .get_broadcast_key_for_local_author(context_id, &did)
+                .await;
+            let (key_bytes, epoch) = result.map_err(|e| {
+                tracing::debug!(error = %e, "broadcast key auto-resolve failed");
+                BroadcastKeyError::AutoResolveFailed("not authorized for this context".to_owned())
+            })?;
+            Ok(ResolvedBroadcastKey {
+                key_bytes,
+                epoch,
+                author_did: did,
+            })
+        }
+        (Some(_), None) => Err(BroadcastKeyError::KeyWithoutAuthor),
+    }
+}
+
+/// Convenience: builds a [`BroadcastKey`] from a [`ResolvedBroadcastKey`].
+impl ResolvedBroadcastKey {
+    /// Converts the resolved key into a [`BroadcastKey`] suitable for
+    /// passing to `enable_broadcast_projection_with_site`.
+    #[must_use]
+    pub fn into_broadcast_key(self) -> scp_core::crypto::sender_keys::BroadcastKey {
+        scp_core::crypto::sender_keys::BroadcastKey::from_parts(
+            scp_core::crypto::sender_keys::SenderKey::from_bytes(*self.key_bytes),
+            self.epoch,
+            self.author_did,
+        )
     }
 }
 

--- a/crates/scp-ffi/napi/src/bridge_connector.rs
+++ b/crates/scp-ffi/napi/src/bridge_connector.rs
@@ -8,6 +8,7 @@
 //!
 //! See spec section 12 (Bridge System) and ADR-023.
 
+use scp_ffi_common::error_codes as codes;
 use std::sync::OnceLock;
 
 use dashmap::DashMap;
@@ -200,7 +201,7 @@ pub fn bridge_register(
             <[u8; 32]>::try_from(k.as_slice()).map_err(|_| {
                 napi::Error::from(ScpNapiError::Validation {
                     message: format!("platform_key must be exactly 32 bytes, got {}", k.len()),
-                    code: "SCP-VALID-7052".to_owned(),
+                    code: codes::VALID_7052.to_owned(),
                 })
             })
         })
@@ -232,7 +233,7 @@ pub fn bridge_register(
     let _event = register_bridge(&mut registry, request).map_err(|e| {
         napi::Error::from(ScpNapiError::Context {
             message: format!("bridge registration failed: {e}"),
-            code: "SCP-CTX-2100".to_owned(),
+            code: codes::CTX_2100.to_owned(),
         })
     })?;
 
@@ -241,7 +242,7 @@ pub fn bridge_register(
         approve_registration(&mut registry, &bridge_id, &approver_did, 0).map_err(|e| {
             napi::Error::from(ScpNapiError::Context {
                 message: format!("bridge approval failed: {e}"),
-                code: "SCP-CTX-2101".to_owned(),
+                code: codes::CTX_2101.to_owned(),
             })
         })?;
 
@@ -299,7 +300,7 @@ pub fn bridge_create_shadow(
     .map_err(|e| {
         napi::Error::from(ScpNapiError::Context {
             message: format!("shadow creation failed: {e}"),
-            code: "SCP-CTX-2102".to_owned(),
+            code: codes::CTX_2102.to_owned(),
         })
     })?;
 
@@ -326,7 +327,7 @@ fn parse_bridge_mode(s: &str) -> napi::Result<BridgeMode> {
             message: format!(
                 "invalid bridge mode '{other}': expected 'relay', 'puppet', 'api', or 'cooperative'"
             ),
-            code: "SCP-VALID-7050".to_owned(),
+            code: codes::VALID_7050.to_owned(),
         }
         .into()),
     }
@@ -338,7 +339,7 @@ fn parse_shadow_status(s: &str) -> napi::Result<ShadowProvenanceStatus> {
         "claimed" => Ok(ShadowProvenanceStatus::Claimed),
         other => Err(ScpNapiError::Validation {
             message: format!("invalid shadow_status '{other}': expected 'shadow' or 'claimed'"),
-            code: "SCP-VALID-7051".to_owned(),
+            code: codes::VALID_7051.to_owned(),
         }
         .into()),
     }

--- a/crates/scp-ffi/napi/src/context.rs
+++ b/crates/scp-ffi/napi/src/context.rs
@@ -8,6 +8,7 @@
 //!
 //! See issue #388 and ADR-022 in `.docs/adrs/phase-4.md`.
 
+use scp_ffi_common::error_codes as codes;
 use std::sync::Arc;
 
 use napi::Error as NapiError;
@@ -56,13 +57,13 @@ fn generate_mls_key_package_bytes(did: &str) -> Result<Vec<u8>, ScpNapiError> {
     let cred = ScpCredential::new(did.to_owned(), None, scp_identity::SigningKeyId::Active)
         .map_err(|e| ScpNapiError::Crypto {
             message: format!("failed to create SCP credential for MLS key package: {e}"),
-            code: "SCP-CRYPTO-4010".to_owned(),
+            code: codes::CRYPTO_4010.to_owned(),
         })?;
 
     let (kp_bundle, _signer, _provider) =
         generate_key_package(&cred).map_err(|e| ScpNapiError::Crypto {
             message: format!("MLS key package generation failed: {e}"),
-            code: "SCP-CRYPTO-4011".to_owned(),
+            code: codes::CRYPTO_4011.to_owned(),
         })?;
 
     kp_bundle
@@ -70,7 +71,7 @@ fn generate_mls_key_package_bytes(did: &str) -> Result<Vec<u8>, ScpNapiError> {
         .tls_serialize_detached()
         .map_err(|e| ScpNapiError::Crypto {
             message: format!("MLS key package TLS serialization failed: {e}"),
-            code: "SCP-CRYPTO-4012".to_owned(),
+            code: codes::CRYPTO_4012.to_owned(),
         })
 }
 
@@ -168,7 +169,7 @@ impl NapiContextHandle {
         let guard = self.state.lock().map_err(|_| {
             NapiError::from(ScpNapiError::Context {
                 message: "context state lock is poisoned".to_owned(),
-                code: "SCP-CTX-2012".to_owned(),
+                code: codes::CTX_2012.to_owned(),
             })
         })?;
         Ok(state_str(&guard).to_owned())
@@ -257,7 +258,7 @@ impl NapiContextHandle {
             .map(|g| state_str(&g).to_owned())
             .map_err(|_| ScpNapiError::Context {
                 message: "context state lock is poisoned".to_owned(),
-                code: "SCP-CTX-2012".to_owned(),
+                code: codes::CTX_2012.to_owned(),
             })
     }
 
@@ -265,7 +266,7 @@ impl NapiContextHandle {
     pub(crate) fn set_closed(&self) -> Result<(), ScpNapiError> {
         *self.state.lock().map_err(|_| ScpNapiError::Context {
             message: "context state lock is poisoned".to_owned(),
-            code: "SCP-CTX-2012".to_owned(),
+            code: codes::CTX_2012.to_owned(),
         })? = ContextState::Closed;
         Ok(())
     }
@@ -278,7 +279,7 @@ impl NapiContextHandle {
                 message: "context does not have a core handle — context was not created via \
                       ContextManager"
                     .to_owned(),
-                code: "SCP-CTX-2024".to_owned(),
+                code: codes::CTX_2024.to_owned(),
             })
     }
 }
@@ -389,7 +390,7 @@ pub async fn context_create(
             message: format!(
                 "params_json is not valid JSON: {e} — pass a JSON-encoded context parameters object"
             ),
-            code: "SCP-VALID-7000".to_owned(),
+            code: codes::VALID_7000.to_owned(),
         })
     })?;
 
@@ -435,7 +436,7 @@ pub async fn context_create(
         other => Some(serde_json::to_string(other).map_err(|e| {
             NapiError::from(ScpNapiError::Validation {
                 message: format!("invalid consequenceRules: {e}"),
-                code: "SCP-VALID-7000".to_owned(),
+                code: codes::VALID_7000.to_owned(),
             })
         })?),
     };
@@ -449,7 +450,7 @@ pub async fn context_create(
         other => Some(serde_json::to_string(other).map_err(|e| {
             NapiError::from(ScpNapiError::Validation {
                 message: format!("invalid consequenceConfig: {e}"),
-                code: "SCP-VALID-7000".to_owned(),
+                code: codes::VALID_7000.to_owned(),
             })
         })?),
     };
@@ -501,7 +502,7 @@ pub async fn context_create(
         scp_ffi_common::context_params::build_context_params(&common).map_err(|e| {
             NapiError::from(ScpNapiError::Validation {
                 message: e,
-                code: "SCP-VALID-7000".to_owned(),
+                code: codes::VALID_7000.to_owned(),
             })
         })?;
 
@@ -573,7 +574,7 @@ pub async fn context_join(
     if state_str != "active" {
         return Err(ScpNapiError::Context {
             message: format!("cannot join context in {state_str:?} state — context must be active"),
-            code: "SCP-CTX-2013".to_owned(),
+            code: codes::CTX_2013.to_owned(),
         }
         .into());
     }
@@ -587,7 +588,7 @@ pub async fn context_join(
             scp_core::crypto::ucan::validate::parse_ucan(jwt).map_err(|e| {
                 NapiError::from(ScpNapiError::Context {
                     message: format!("invalid spending UCAN: {e}"),
-                    code: "SCP-ECON-12061".to_owned(),
+                    code: codes::ECON_12061.to_owned(),
                 })
             })
         })
@@ -638,7 +639,7 @@ pub async fn context_leave(handle: &NapiContextHandle, identity_did: String) -> 
             message: format!(
                 "cannot leave context in {state_str:?} state — context must be active"
             ),
-            code: "SCP-CTX-2015".to_owned(),
+            code: codes::CTX_2015.to_owned(),
         }
         .into());
     }
@@ -683,7 +684,7 @@ pub async fn context_close(handle: &NapiContextHandle, identity_did: String) -> 
             message: format!(
                 "cannot close context in {state_str:?} state — context must be active"
             ),
-            code: "SCP-CTX-2017".to_owned(),
+            code: codes::CTX_2017.to_owned(),
         }
         .into());
     }
@@ -739,7 +740,7 @@ pub async fn context_send(
             message: format!(
                 "cannot send to context in {state_str:?} state — context must be active"
             ),
-            code: "SCP-CTX-2019".to_owned(),
+            code: codes::CTX_2019.to_owned(),
         }
         .into());
     }
@@ -775,7 +776,7 @@ pub async fn context_send(
             .map_err(|e| {
                 NapiError::from(ScpNapiError::Crypto {
                     message: format!("inner envelope signing failed: {e}"),
-                    code: "SCP-CRYPTO-4001".to_owned(),
+                    code: codes::CRYPTO_4001.to_owned(),
                 })
             })?;
     }
@@ -798,7 +799,7 @@ pub async fn context_send(
         .map_err(|e| {
             NapiError::from(ScpNapiError::Context {
                 message: format!("invalid spending UCAN: {e}"),
-                code: "SCP-ECON-12061".to_owned(),
+                code: codes::ECON_12061.to_owned(),
             })
         })?;
 
@@ -852,7 +853,7 @@ pub fn context_subscribe(
     {
         return Err(ScpNapiError::Context {
             message: "already subscribed — each context supports a single subscription".to_owned(),
-            code: "SCP-CTX-2022".to_owned(),
+            code: codes::CTX_2022.to_owned(),
         }
         .into());
     }
@@ -867,7 +868,7 @@ pub fn context_subscribe(
             message: format!(
                 "cannot subscribe to context in {state_str:?} state — context must be active"
             ),
-            code: "SCP-CTX-2021".to_owned(),
+            code: codes::CTX_2021.to_owned(),
         }
         .into());
     }
@@ -884,7 +885,7 @@ pub fn context_subscribe(
             .store(false, std::sync::atomic::Ordering::SeqCst);
         return Err(NapiError::from(ScpNapiError::Transport {
             message: "no relay connection — call transportConnect() before subscribing".to_owned(),
-            code: "SCP-TRANS-5010".to_owned(),
+            code: codes::TRANS_5010.to_owned(),
         }));
     };
 
@@ -903,7 +904,7 @@ pub fn context_subscribe(
                 .store(false, std::sync::atomic::Ordering::SeqCst);
             NapiError::from(ScpNapiError::Context {
                 message: "subscription cancel lock is poisoned".to_owned(),
-                code: "SCP-CTX-2012".to_owned(),
+                code: codes::CTX_2012.to_owned(),
             })
         })?;
         *guard = CancellationToken::new();
@@ -1499,7 +1500,7 @@ pub async fn broadcast_publish(
                 message: "broadcast publish requires key custody — create the identity with \
                           identityCreate(\"in_memory\")"
                     .to_owned(),
-                code: "SCP-PERM-3020".to_owned(),
+                code: codes::PERM_3020.to_owned(),
             })
         })?;
         let signing_key = handle.signing_key.ok_or_else(|| {
@@ -1507,7 +1508,7 @@ pub async fn broadcast_publish(
                 message: "broadcast publish requires a signing key — identity has no active \
                           signing key handle"
                     .to_owned(),
-                code: "SCP-PERM-3021".to_owned(),
+                code: codes::PERM_3021.to_owned(),
             })
         })?;
 
@@ -1524,7 +1525,7 @@ pub async fn broadcast_publish(
             message: "broadcast publish requires key custody — in_memory custody feature is \
                       not enabled"
                 .to_owned(),
-            code: "SCP-PERM-3022".to_owned(),
+            code: codes::PERM_3022.to_owned(),
         }));
     }
 
@@ -1609,20 +1610,20 @@ pub async fn broadcast_publish_asset(
     let content_path = scp_core::context::ContentPath::new(asset.path).map_err(|e| {
         NapiError::from(ScpNapiError::Context {
             message: format!("invalid path: {e}"),
-            code: "SCP-CTX-2040".to_owned(),
+            code: codes::CTX_2040.to_owned(),
         })
     })?;
     let mime_type = scp_core::context::MimeType::new(asset.content_type).map_err(|e| {
         NapiError::from(ScpNapiError::Context {
             message: format!("invalid content_type: {e}"),
-            code: "SCP-CTX-2041".to_owned(),
+            code: codes::CTX_2041.to_owned(),
         })
     })?;
     if let Some(ref did_str) = deploy_id {
         scp_core::context::validate_deploy_id(did_str).map_err(|e| {
             NapiError::from(ScpNapiError::Context {
                 message: format!("invalid deploy_id: {e}"),
-                code: "SCP-CTX-2042".to_owned(),
+                code: codes::CTX_2042.to_owned(),
             })
         })?;
     }
@@ -1655,7 +1656,7 @@ pub async fn broadcast_publish_asset(
                 message: "broadcast publish asset requires key custody — create the identity with \
                           identityCreate(\"in_memory\")"
                     .to_owned(),
-                code: "SCP-PERM-3020".to_owned(),
+                code: codes::PERM_3020.to_owned(),
             })
         })?;
         let signing_key = handle.signing_key.ok_or_else(|| {
@@ -1663,7 +1664,7 @@ pub async fn broadcast_publish_asset(
                 message: "broadcast publish asset requires a signing key — identity has no active \
                           signing key handle"
                     .to_owned(),
-                code: "SCP-PERM-3021".to_owned(),
+                code: codes::PERM_3021.to_owned(),
             })
         })?;
 
@@ -1681,7 +1682,7 @@ pub async fn broadcast_publish_asset(
         let envelope_bytes = rmp_serde::to_vec_named(&envelope).map_err(|e| {
             NapiError::from(ScpNapiError::Context {
                 message: format!("failed to serialize envelope for blob_id: {e}"),
-                code: "SCP-CTX-2043".to_owned(),
+                code: codes::CTX_2043.to_owned(),
             })
         })?;
         let blob_id = {
@@ -1703,7 +1704,7 @@ pub async fn broadcast_publish_asset(
             message: "broadcast publish asset requires key custody — in_memory custody feature is \
                       not enabled"
                 .to_owned(),
-            code: "SCP-PERM-3022".to_owned(),
+            code: codes::PERM_3022.to_owned(),
         }))
     }
 }
@@ -1732,7 +1733,7 @@ pub async fn broadcast_publish_assets(
                 "batch too large: {} assets (max {MAX_BATCH_ASSETS})",
                 assets.len()
             ),
-            code: "SCP-CTX-2074".to_owned(),
+            code: codes::CTX_2074.to_owned(),
         }));
     }
 
@@ -1758,7 +1759,7 @@ pub async fn broadcast_publish_assets(
     scp_core::context::validate_deploy_id(&deploy_id_val).map_err(|e| {
         NapiError::from(ScpNapiError::Context {
             message: format!("invalid deploy_id: {e}"),
-            code: "SCP-CTX-2042".to_owned(),
+            code: codes::CTX_2042.to_owned(),
         })
     })?;
 
@@ -1767,13 +1768,13 @@ pub async fn broadcast_publish_assets(
         let custody = handle.in_memory_custody.as_ref().ok_or_else(|| {
             NapiError::from(ScpNapiError::Permission {
                 message: "broadcast publish assets requires key custody".to_owned(),
-                code: "SCP-PERM-3020".to_owned(),
+                code: codes::PERM_3020.to_owned(),
             })
         })?;
         let signing_key = handle.signing_key.ok_or_else(|| {
             NapiError::from(ScpNapiError::Permission {
                 message: "broadcast publish assets requires a signing key".to_owned(),
-                code: "SCP-PERM-3021".to_owned(),
+                code: codes::PERM_3021.to_owned(),
             })
         })?;
 
@@ -1782,13 +1783,13 @@ pub async fn broadcast_publish_assets(
             let content_path = scp_core::context::ContentPath::new(asset.path).map_err(|e| {
                 NapiError::from(ScpNapiError::Context {
                     message: format!("invalid path: {e}"),
-                    code: "SCP-CTX-2040".to_owned(),
+                    code: codes::CTX_2040.to_owned(),
                 })
             })?;
             let mime_type = scp_core::context::MimeType::new(asset.content_type).map_err(|e| {
                 NapiError::from(ScpNapiError::Context {
                     message: format!("invalid content_type: {e}"),
-                    code: "SCP-CTX-2041".to_owned(),
+                    code: codes::CTX_2041.to_owned(),
                 })
             })?;
 
@@ -1819,7 +1820,7 @@ pub async fn broadcast_publish_assets(
             let envelope_bytes = rmp_serde::to_vec_named(&envelope).map_err(|e| {
                 NapiError::from(ScpNapiError::Context {
                     message: format!("failed to serialize envelope for blob_id: {e}"),
-                    code: "SCP-CTX-2043".to_owned(),
+                    code: codes::CTX_2043.to_owned(),
                 })
             })?;
             let blob_id = {
@@ -1846,7 +1847,7 @@ pub async fn broadcast_publish_assets(
             message: "broadcast publish assets requires key custody — in_memory custody feature \
                       is not enabled"
                 .to_owned(),
-            code: "SCP-PERM-3022".to_owned(),
+            code: codes::PERM_3022.to_owned(),
         }))
     }
 }
@@ -1980,7 +1981,7 @@ pub async fn context_execute_governance_action(
     let action: GovernanceAction = serde_json::from_str(&action_json).map_err(|e| {
         NapiError::from(ScpNapiError::Validation {
             message: format!("invalid governance action JSON: {e}"),
-            code: "SCP-VALID-7000".to_owned(),
+            code: codes::VALID_7000.to_owned(),
         })
     })?;
 
@@ -1989,7 +1990,7 @@ pub async fn context_execute_governance_action(
     scp_ffi_common::validate::validate_governance_action_strings(&action).map_err(|e| {
         NapiError::from(ScpNapiError::Validation {
             message: e.message,
-            code: "SCP-VALID-7000".to_owned(),
+            code: codes::VALID_7000.to_owned(),
         })
     })?;
 
@@ -2081,7 +2082,7 @@ async fn resolve_napi_signing_key(
             message: "no custody provider on context handle — governance lifecycle \
                       requires an identity created with custody"
                 .to_owned(),
-            code: "SCP-CTX-2040".to_owned(),
+            code: codes::CTX_2040.to_owned(),
         })
     })?;
     let key_handle = handle.signing_key.ok_or_else(|| {
@@ -2089,7 +2090,7 @@ async fn resolve_napi_signing_key(
             message: "no signing key on context handle — governance lifecycle \
                       requires an identity with an active signing key"
                 .to_owned(),
-            code: "SCP-CTX-2040".to_owned(),
+            code: codes::CTX_2040.to_owned(),
         })
     })?;
     custody
@@ -2099,7 +2100,7 @@ async fn resolve_napi_signing_key(
         .map_err(|e| {
             NapiError::from(ScpNapiError::Context {
                 message: format!("failed to export signing key for governance: {e}"),
-                code: "SCP-CTX-2040".to_owned(),
+                code: codes::CTX_2040.to_owned(),
             })
         })
 }
@@ -2109,13 +2110,13 @@ fn parse_napi_proposal_id(hex_str: &str) -> napi::Result<[u8; 32]> {
     let bytes = hex::decode(hex_str).map_err(|e| {
         NapiError::from(ScpNapiError::Validation {
             message: format!("invalid proposal ID hex: {e}"),
-            code: "SCP-CTX-2040".to_owned(),
+            code: codes::CTX_2040.to_owned(),
         })
     })?;
     let arr: [u8; 32] = bytes.try_into().map_err(|v: Vec<u8>| {
         NapiError::from(ScpNapiError::Validation {
             message: format!("proposal ID must be 32 bytes, got {}", v.len()),
-            code: "SCP-CTX-2040".to_owned(),
+            code: codes::CTX_2040.to_owned(),
         })
     })?;
     Ok(arr)
@@ -2152,7 +2153,7 @@ pub async fn context_governance_propose(
     let action: GovernanceAction = serde_json::from_str(&action_json).map_err(|e| {
         NapiError::from(ScpNapiError::Validation {
             message: format!("invalid governance action JSON: {e}"),
-            code: "SCP-CTX-2040".to_owned(),
+            code: codes::CTX_2040.to_owned(),
         })
     })?;
 
@@ -2161,7 +2162,7 @@ pub async fn context_governance_propose(
     scp_ffi_common::validate::validate_governance_action_strings(&action).map_err(|e| {
         NapiError::from(ScpNapiError::Validation {
             message: e.message,
-            code: "SCP-CTX-2040".to_owned(),
+            code: codes::CTX_2040.to_owned(),
         })
     })?;
 
@@ -2181,7 +2182,7 @@ pub async fn context_governance_propose(
             .map_err(|e| {
                 NapiError::from(ScpNapiError::Context {
                     message: format!("governance proposal failed: {e}"),
-                    code: "SCP-CTX-2041".to_owned(),
+                    code: codes::CTX_2041.to_owned(),
                 })
             })?;
 
@@ -2211,7 +2212,7 @@ pub async fn context_governance_propose(
             message: "governance proposal requires key custody — in_memory custody feature \
                       is not enabled"
                 .to_owned(),
-            code: "SCP-CTX-2040".to_owned(),
+            code: codes::CTX_2040.to_owned(),
         }));
     }
 
@@ -2251,7 +2252,7 @@ pub async fn context_governance_approve(
             .map_err(|e| {
                 NapiError::from(ScpNapiError::Context {
                     message: format!("governance approval failed: {e}"),
-                    code: "SCP-CTX-2042".to_owned(),
+                    code: codes::CTX_2042.to_owned(),
                 })
             })?;
 
@@ -2273,7 +2274,7 @@ pub async fn context_governance_approve(
             message: "governance approval requires key custody — in_memory custody feature \
                       is not enabled"
                 .to_owned(),
-            code: "SCP-CTX-2040".to_owned(),
+            code: codes::CTX_2040.to_owned(),
         }));
     }
 
@@ -2312,7 +2313,7 @@ pub async fn context_governance_reject(
             .map_err(|e| {
                 NapiError::from(ScpNapiError::Context {
                     message: format!("governance rejection failed: {e}"),
-                    code: "SCP-CTX-2043".to_owned(),
+                    code: codes::CTX_2043.to_owned(),
                 })
             })?;
 
@@ -2334,7 +2335,7 @@ pub async fn context_governance_reject(
             message: "governance rejection requires key custody — in_memory custody feature \
                       is not enabled"
                 .to_owned(),
-            code: "SCP-CTX-2040".to_owned(),
+            code: codes::CTX_2040.to_owned(),
         }));
     }
 
@@ -2368,7 +2369,7 @@ pub async fn context_governance_withdraw(
         .map_err(|e| {
             NapiError::from(ScpNapiError::Context {
                 message: format!("governance vote withdrawal failed: {e}"),
-                code: "SCP-CTX-2044".to_owned(),
+                code: codes::CTX_2044.to_owned(),
             })
         })?;
 
@@ -2410,14 +2411,14 @@ pub async fn context_governance_get_proposal(
         .map_err(|e| {
             NapiError::from(ScpNapiError::Context {
                 message: format!("get proposal failed: {e}"),
-                code: "SCP-CTX-2045".to_owned(),
+                code: codes::CTX_2045.to_owned(),
             })
         })?;
 
     serde_json::to_string(&proposal).map_err(|e| {
         NapiError::from(ScpNapiError::Context {
             message: format!("serialization failed: {e}"),
-            code: "SCP-CTX-2045".to_owned(),
+            code: codes::CTX_2045.to_owned(),
         })
     })
 }
@@ -2438,14 +2439,14 @@ pub async fn context_governance_list_proposals(handle: &NapiContextHandle) -> na
     let proposals = manager.list_proposals(&context_id).await.map_err(|e| {
         NapiError::from(ScpNapiError::Context {
             message: format!("list proposals failed: {e}"),
-            code: "SCP-CTX-2046".to_owned(),
+            code: codes::CTX_2046.to_owned(),
         })
     })?;
 
     serde_json::to_string(&proposals).map_err(|e| {
         NapiError::from(ScpNapiError::Context {
             message: format!("serialization failed: {e}"),
-            code: "SCP-CTX-2046".to_owned(),
+            code: codes::CTX_2046.to_owned(),
         })
     })
 }
@@ -2478,7 +2479,7 @@ pub async fn context_apply_pending_ceiling_modification(
         .map_err(|e| {
             NapiError::from(ScpNapiError::Context {
                 message: format!("apply_pending_ceiling_modification failed: {e}"),
-                code: "SCP-CTX-2060".to_owned(),
+                code: codes::CTX_2060.to_owned(),
             })
         })
 }
@@ -2508,7 +2509,7 @@ pub async fn context_finalize_close(handle: &NapiContextHandle) -> napi::Result<
     manager.finalize_close(core_handle).await.map_err(|e| {
         NapiError::from(ScpNapiError::Context {
             message: format!("finalize_close failed: {e}"),
-            code: "SCP-CTX-2061".to_owned(),
+            code: codes::CTX_2061.to_owned(),
         })
     })?;
 
@@ -2561,7 +2562,7 @@ pub async fn context_create_governance_checkpoint(
     let creator_signature = hex::decode(&creator_signature_hex).map_err(|e| {
         NapiError::from(ScpNapiError::Validation {
             message: format!("invalid creator_signature hex: {e}"),
-            code: "SCP-CTX-2062".to_owned(),
+            code: codes::CTX_2062.to_owned(),
         })
     })?;
     let did = DID(creator_did);
@@ -2586,14 +2587,14 @@ pub async fn context_create_governance_checkpoint(
         .map_err(|e| {
             NapiError::from(ScpNapiError::Context {
                 message: format!("create_governance_checkpoint failed: {e}"),
-                code: "SCP-CTX-2062".to_owned(),
+                code: codes::CTX_2062.to_owned(),
             })
         })?;
 
     serde_json::to_string(&checkpoint).map_err(|e| {
         NapiError::from(ScpNapiError::Context {
             message: format!("serialization failed: {e}"),
-            code: "SCP-CTX-2062".to_owned(),
+            code: codes::CTX_2062.to_owned(),
         })
     })
 }
@@ -2618,14 +2619,14 @@ pub async fn context_add_checkpoint_cosignature(
         serde_json::from_str(&checkpoint_json).map_err(|e| {
             NapiError::from(ScpNapiError::Validation {
                 message: format!("invalid checkpoint JSON: {e}"),
-                code: "SCP-CTX-2063".to_owned(),
+                code: codes::CTX_2063.to_owned(),
             })
         })?;
 
     let signature = hex::decode(&signature_hex).map_err(|e| {
         NapiError::from(ScpNapiError::Validation {
             message: format!("invalid signature hex: {e}"),
-            code: "SCP-CTX-2063".to_owned(),
+            code: codes::CTX_2063.to_owned(),
         })
     })?;
 
@@ -2640,7 +2641,7 @@ pub async fn context_add_checkpoint_cosignature(
         .map_err(|e| {
             NapiError::from(ScpNapiError::Context {
                 message: format!("add_checkpoint_cosignature failed: {e}"),
-                code: "SCP-CTX-2063".to_owned(),
+                code: codes::CTX_2063.to_owned(),
             })
         })?;
 
@@ -2670,7 +2671,7 @@ pub async fn context_restore(context_id: String) -> napi::Result<()> {
             .map_err(|e| {
                 NapiError::from(ScpNapiError::Context {
                     message: format!("restore_context: failed to load persisted state: {e}"),
-                    code: "SCP-CTX-2064".to_owned(),
+                    code: codes::CTX_2064.to_owned(),
                 })
             })?;
 
@@ -2683,7 +2684,7 @@ pub async fn context_restore(context_id: String) -> napi::Result<()> {
         .map_err(|e| {
             NapiError::from(ScpNapiError::Context {
                 message: format!("restore_context failed: {e}"),
-                code: "SCP-CTX-2064".to_owned(),
+                code: codes::CTX_2064.to_owned(),
             })
         })
 }
@@ -2702,14 +2703,14 @@ pub async fn context_restore_all() -> napi::Result<String> {
     let restored = manager.restore_all_contexts().await.map_err(|e| {
         NapiError::from(ScpNapiError::Context {
             message: format!("restore_all_contexts failed: {e}"),
-            code: "SCP-CTX-2065".to_owned(),
+            code: codes::CTX_2065.to_owned(),
         })
     })?;
 
     serde_json::to_string(&restored).map_err(|e| {
         NapiError::from(ScpNapiError::Context {
             message: format!("serialization failed: {e}"),
-            code: "SCP-CTX-2065".to_owned(),
+            code: codes::CTX_2065.to_owned(),
         })
     })
 }
@@ -2719,13 +2720,13 @@ fn parse_napi_hex_32(hex_str: &str, field_name: &str) -> napi::Result<[u8; 32]> 
     let bytes = hex::decode(hex_str).map_err(|e| {
         NapiError::from(ScpNapiError::Validation {
             message: format!("invalid {field_name} hex: {e}"),
-            code: "SCP-CTX-2062".to_owned(),
+            code: codes::CTX_2062.to_owned(),
         })
     })?;
     let arr: [u8; 32] = bytes.try_into().map_err(|v: Vec<u8>| {
         NapiError::from(ScpNapiError::Validation {
             message: format!("{field_name} must be 32 bytes, got {}", v.len()),
-            code: "SCP-CTX-2062".to_owned(),
+            code: codes::CTX_2062.to_owned(),
         })
     })?;
     Ok(arr)
@@ -2754,7 +2755,7 @@ pub async fn context_tombstone_migrated(handle: &NapiContextHandle) -> napi::Res
         .map_err(|e| {
             NapiError::from(ScpNapiError::Context {
                 message: format!("tombstone_migrated_context failed: {e}"),
-                code: "SCP-CTX-2050".to_owned(),
+                code: codes::CTX_2050.to_owned(),
             })
         })?;
 
@@ -2885,7 +2886,7 @@ pub async fn context_export(handle: &NapiContextHandle) -> napi::Result<Vec<u8>>
     scp_core::context::export_import::serialize_export(&export).map_err(|e| {
         NapiError::from(ScpNapiError::Context {
             message: format!("export serialization failed: {e}"),
-            code: "SCP-CTX-2030".to_owned(),
+            code: codes::CTX_2030.to_owned(),
         })
     })
 }
@@ -2905,7 +2906,7 @@ pub async fn context_import(data: Vec<u8>) -> napi::Result<String> {
     let export = scp_core::context::export_import::deserialize_export(&data).map_err(|e| {
         NapiError::from(ScpNapiError::Context {
             message: format!("invalid export data: {e}"),
-            code: "SCP-CTX-2032".to_owned(),
+            code: codes::CTX_2032.to_owned(),
         })
     })?;
     let context_id = export.snapshot.context_id.clone();
@@ -2952,7 +2953,7 @@ pub fn context_set_economic_policy(
                   (propose SetEconomicPolicy action). Direct mutation is \
                   not permitted — see spec §19.3"
             .to_owned(),
-        code: "SCP-CTX-2013".to_owned(),
+        code: codes::CTX_2013.to_owned(),
     }))
 }
 
@@ -3102,13 +3103,13 @@ pub fn evaluate_invitation(
     validate_did(&inviter_did).map_err(|e| {
         napi::Error::from(ScpNapiError::Validation {
             message: e.message,
-            code: "SCP-VALID-7010".to_owned(),
+            code: codes::VALID_7010.to_owned(),
         })
     })?;
     validate_did(&identity_did).map_err(|e| {
         napi::Error::from(ScpNapiError::Validation {
             message: e.message,
-            code: "SCP-VALID-7010".to_owned(),
+            code: codes::VALID_7010.to_owned(),
         })
     })?;
 
@@ -3116,7 +3117,7 @@ pub fn evaluate_invitation(
         serde_json::from_str(&params_json).map_err(|e| {
             napi::Error::from(ScpNapiError::Validation {
                 message: format!("failed to parse context params JSON: {e}"),
-                code: "SCP-VALID-7010".to_owned(),
+                code: codes::VALID_7010.to_owned(),
             })
         })?;
 
@@ -3124,7 +3125,7 @@ pub fn evaluate_invitation(
         Some(ref json) => Some(serde_json::from_str(json).map_err(|e| {
             napi::Error::from(ScpNapiError::Validation {
                 message: format!("failed to parse auto-accept policy JSON: {e}"),
-                code: "SCP-VALID-7010".to_owned(),
+                code: codes::VALID_7010.to_owned(),
             })
         })?),
         None => None,
@@ -3134,7 +3135,7 @@ pub fn evaluate_invitation(
         Some(ref json) => Some(serde_json::from_str(json).map_err(|e| {
             napi::Error::from(ScpNapiError::Validation {
                 message: format!("failed to parse spending context JSON: {e}"),
-                code: "SCP-VALID-7010".to_owned(),
+                code: codes::VALID_7010.to_owned(),
             })
         })?),
         None => None,
@@ -3145,7 +3146,7 @@ pub fn evaluate_invitation(
             let did_strings: Vec<String> = serde_json::from_str(json).map_err(|e| {
                 napi::Error::from(ScpNapiError::Validation {
                     message: format!("failed to parse trusted DIDs JSON: {e}"),
-                    code: "SCP-VALID-7010".to_owned(),
+                    code: codes::VALID_7010.to_owned(),
                 })
             })?;
             did_strings
@@ -3180,7 +3181,7 @@ pub fn evaluate_invitation(
         }),
         Err(e) => Err(napi::Error::from(ScpNapiError::Context {
             message: format!("invitation evaluation failed: {e}"),
-            code: "SCP-CTX-2060".to_owned(),
+            code: codes::CTX_2060.to_owned(),
         })),
     }
 }
@@ -3210,27 +3211,27 @@ pub fn metadata_record_to_json(
     validate_context_id(&context_id).map_err(|e| {
         NapiError::from(ScpNapiError::Validation {
             message: e.to_string(),
-            code: "SCP-VALID-7001".to_owned(),
+            code: codes::VALID_7001.to_owned(),
         })
     })?;
     validate_did(&signer_did).map_err(|e| {
         NapiError::from(ScpNapiError::Validation {
             message: e.to_string(),
-            code: "SCP-VALID-7001".to_owned(),
+            code: codes::VALID_7001.to_owned(),
         })
     })?;
 
     if sequence == 0 {
         return Err(NapiError::from(ScpNapiError::Validation {
             message: "MetadataRecord sequence must start at 1 (per spec §5.7.2)".to_owned(),
-            code: "SCP-VALID-7001".to_owned(),
+            code: codes::VALID_7001.to_owned(),
         }));
     }
 
     let structural: StructuralMetadata = serde_json::from_str(&structural_json).map_err(|e| {
         NapiError::from(ScpNapiError::Validation {
             message: format!("invalid structural metadata JSON: {e}"),
-            code: "SCP-VALID-7001".to_owned(),
+            code: codes::VALID_7001.to_owned(),
         })
     })?;
 
@@ -3238,20 +3239,20 @@ pub fn metadata_record_to_json(
         serde_json::from_str(&operational_json).map_err(|e| {
             NapiError::from(ScpNapiError::Validation {
                 message: format!("invalid operational metadata JSON: {e}"),
-                code: "SCP-VALID-7001".to_owned(),
+                code: codes::VALID_7001.to_owned(),
             })
         })?;
 
     let signature = hex::decode(&signature_hex).map_err(|e| {
         NapiError::from(ScpNapiError::Validation {
             message: format!("invalid signature hex: {e}"),
-            code: "SCP-VALID-7001".to_owned(),
+            code: codes::VALID_7001.to_owned(),
         })
     })?;
     if signature.len() != 64 {
         return Err(NapiError::from(ScpNapiError::Validation {
             message: format!("signature must be 64 bytes (got {})", signature.len()),
-            code: "SCP-VALID-7001".to_owned(),
+            code: codes::VALID_7001.to_owned(),
         }));
     }
 
@@ -3270,7 +3271,7 @@ pub fn metadata_record_to_json(
     serde_json::to_string(&record).map_err(|e| {
         NapiError::from(ScpNapiError::Validation {
             message: format!("failed to serialize MetadataRecord: {e}"),
-            code: "SCP-VALID-7001".to_owned(),
+            code: codes::VALID_7001.to_owned(),
         })
     })
 }
@@ -3285,7 +3286,7 @@ pub fn metadata_record_from_json(json_str: String) -> napi::Result<String> {
     let record: MetadataRecord = serde_json::from_str(&json_str).map_err(|e| {
         NapiError::from(ScpNapiError::Validation {
             message: format!("invalid MetadataRecord JSON: {e}"),
-            code: "SCP-VALID-7001".to_owned(),
+            code: codes::VALID_7001.to_owned(),
         })
     })?;
 
@@ -3293,7 +3294,7 @@ pub fn metadata_record_from_json(json_str: String) -> napi::Result<String> {
     if record.sequence == 0 {
         return Err(NapiError::from(ScpNapiError::Validation {
             message: "MetadataRecord sequence must start at 1 (per spec §5.7.2)".to_owned(),
-            code: "SCP-VALID-7001".to_owned(),
+            code: codes::VALID_7001.to_owned(),
         }));
     }
 
@@ -3304,14 +3305,14 @@ pub fn metadata_record_from_json(json_str: String) -> napi::Result<String> {
                 "signature must be 64 bytes (got {})",
                 record.signature.len()
             ),
-            code: "SCP-VALID-7001".to_owned(),
+            code: codes::VALID_7001.to_owned(),
         }));
     }
 
     serde_json::to_string(&record).map_err(|e| {
         NapiError::from(ScpNapiError::Validation {
             message: format!("failed to re-serialize MetadataRecord: {e}"),
-            code: "SCP-VALID-7001".to_owned(),
+            code: codes::VALID_7001.to_owned(),
         })
     })
 }
@@ -3330,7 +3331,7 @@ pub fn template_get_params(template_id: String) -> napi::Result<String> {
     serde_json::to_string(&params).map_err(|e| {
         NapiError::from(ScpNapiError::Validation {
             message: format!("failed to serialize template params: {e}"),
-            code: "SCP-VALID-7001".to_owned(),
+            code: codes::VALID_7001.to_owned(),
         })
     })
 }
@@ -3346,7 +3347,7 @@ pub fn validate_against_template(params_json: String) -> napi::Result<Option<Str
         serde_json::from_str(&params_json).map_err(|e| {
             NapiError::from(ScpNapiError::Validation {
                 message: format!("invalid ContextParams JSON: {e}"),
-                code: "SCP-VALID-7001".to_owned(),
+                code: codes::VALID_7001.to_owned(),
             })
         })?;
 
@@ -3367,7 +3368,7 @@ pub fn validate_context_params(params_json: String) -> napi::Result<Option<Strin
         serde_json::from_str(&params_json).map_err(|e| {
             NapiError::from(ScpNapiError::Validation {
                 message: format!("invalid ContextParams JSON: {e}"),
-                code: "SCP-VALID-7001".to_owned(),
+                code: codes::VALID_7001.to_owned(),
             })
         })?;
 
@@ -3407,7 +3408,7 @@ fn parse_template_id_napi(
                  HandleRegistry, scp:template/handle-registry, DiscoveryContext, \
                  scp:template/discovery-context"
             ),
-            code: "SCP-VALID-7001".to_owned(),
+            code: codes::VALID_7001.to_owned(),
         })),
     }
 }
@@ -3424,6 +3425,7 @@ mod tests {
     use scp_core::context::governance::GovernanceAction;
     use scp_core::context::membership::KeyPackage;
     use scp_core::context::params::Capability;
+    use scp_ffi_common::error_codes as codes;
     use scp_identity::DID;
 
     use scp_ffi_common::test_helpers::approved_proposal;
@@ -3966,7 +3968,7 @@ mod tests {
         let err = result.unwrap_err();
         let msg = err.to_string();
         assert!(
-            msg.contains("SCP-ECON-12061") || msg.contains("invalid spending UCAN"),
+            msg.contains(codes::ECON_12061) || msg.contains("invalid spending UCAN"),
             "error should mention SCP-ECON-12061 or invalid spending UCAN, got: {msg}"
         );
     }
@@ -4002,7 +4004,7 @@ mod tests {
         if let Err(e) = &result {
             let msg = e.to_string();
             assert!(
-                !msg.contains("SCP-ECON-12061") && !msg.contains("invalid spending UCAN"),
+                !msg.contains(codes::ECON_12061) && !msg.contains("invalid spending UCAN"),
                 "None spending_ucan_jwt must not trigger UCAN parse errors, got: {msg}"
             );
         }

--- a/crates/scp-ffi/napi/src/context.rs
+++ b/crates/scp-ffi/napi/src/context.rs
@@ -14,8 +14,7 @@ use napi::Error as NapiError;
 use napi_derive::napi;
 use scp_core::context::governance::{GovernanceAction, GovernanceProposal, ProposalStatus};
 use scp_core::context::manager::GovernanceActionResult;
-use scp_core::context::params::ContextMode;
-use scp_core::context::{ContextHandle, ContextParams, ContextState};
+use scp_core::context::{ContextHandle, ContextState};
 use scp_identity::DID;
 use scp_primitives::Clock;
 use tokio_util::sync::CancellationToken;
@@ -427,50 +426,33 @@ pub async fn context_create(
     let context_id = format!("ctx-{}", Uuid::new_v4());
     let creator_did = identity.inner.did.clone();
 
-    // Build ContextParams for the manager, mapping all user-specified fields.
-    let mode = if mode_str == "Broadcast" {
-        ContextMode::Broadcast
-    } else {
-        ContextMode::Encrypted
+    // Parse consequence_rules from params (ADR-017, #1531). Accepts either a
+    // JSON array (preferred) or a JSON-encoded string for legacy callers.
+    // Normalize to a JSON string for the common builder.
+    let consequence_rules_json: Option<String> = match &params["consequenceRules"] {
+        serde_json::Value::Null => None,
+        serde_json::Value::String(s) => Some(s.clone()),
+        other => Some(serde_json::to_string(other).map_err(|e| {
+            NapiError::from(ScpNapiError::Validation {
+                message: format!("invalid consequenceRules: {e}"),
+                code: "SCP-VALID-7000".to_owned(),
+            })
+        })?),
     };
 
-    let core_ceiling_policy = match ceiling_policy.as_str() {
-        "governed" => scp_core::context::params::CeilingPolicy::Governed,
-        _ => scp_core::context::params::CeilingPolicy::Immutable,
+    // Parse consequence_config from params (ADR-017, #1531). Accepts a JSON
+    // object (preferred) or a JSON-encoded string for legacy callers.
+    // Normalize to a JSON string for the common builder.
+    let consequence_config_json: Option<String> = match &params["consequenceConfig"] {
+        serde_json::Value::Null => None,
+        serde_json::Value::String(s) => Some(s.clone()),
+        other => Some(serde_json::to_string(other).map_err(|e| {
+            NapiError::from(ScpNapiError::Validation {
+                message: format!("invalid consequenceConfig: {e}"),
+                code: "SCP-VALID-7000".to_owned(),
+            })
+        })?),
     };
-
-    let core_promotion_policy = match promotion_policy.as_deref() {
-        Some("promotable") => scp_core::context::params::PromotionPolicy::Promotable,
-        _ => scp_core::context::params::PromotionPolicy::NoPromotion,
-    };
-
-    let memory_scope_str = params["memoryScope"].as_str().unwrap_or("ephemeral");
-    let core_memory_scope = match memory_scope_str {
-        "summary" => scp_core::context::params::MemoryScope::Summary,
-        "full" => scp_core::context::params::MemoryScope::Full,
-        _ => scp_core::context::params::MemoryScope::Ephemeral,
-    };
-
-    // Validate governance model — reject unknown values instead of silently
-    // defaulting to SingleAdmin (#1421).
-    let core_governance = match governance.as_str() {
-        "single_admin" => scp_core::context::params::GovernanceModel::SingleAdmin,
-        other => {
-            return Err(ScpNapiError::Validation {
-                message: format!(
-                    "unsupported governance model: {other:?} — \
-                     only \"single_admin\" is currently supported"
-                ),
-                code: "SCP-VALID-7030".to_owned(),
-            }
-            .into());
-        }
-    };
-
-    let core_ceiling: Vec<scp_core::context::roles::Capability> = ceiling
-        .iter()
-        .map(scp_core::context::roles::Capability::new)
-        .collect();
 
     // Parse minProtocolVersion: [major, minor] array or null (spec §13.4).
     let min_protocol_version = params["minProtocolVersion"].as_array().and_then(|arr| {
@@ -490,87 +472,38 @@ pub async fn context_create(
         .as_u64()
         .and_then(|v| u32::try_from(v).ok());
 
-    // Deserialize economic_policy JSON string to the core struct, if provided.
-    let core_economic_policy: Option<scp_core::economy::EconomicPolicy> = economic_policy
-        .as_deref()
-        .map(|ep_json| {
-            serde_json::from_str(ep_json).map_err(|e| {
-                NapiError::from(ScpNapiError::Validation {
-                    message: format!("invalid economicPolicy JSON: {e}"),
-                    code: "SCP-VALID-7000".to_owned(),
-                })
-            })
-        })
-        .transpose()?;
+    let memory_scope_str = params["memoryScope"]
+        .as_str()
+        .unwrap_or("ephemeral")
+        .to_owned();
 
-    // Parse consequence_rules from params (ADR-017, #1531). Accepts either a
-    // JSON array (preferred) or a JSON-encoded string for legacy callers.
-    // Mirrors the WASM bridge pattern in crates/scp-ffi/wasm/src/manager.rs.
-    let core_consequence_rules: Vec<scp_core::trust::ConsequenceRule> = match &params["consequenceRules"]
-    {
-        serde_json::Value::Null => Vec::new(),
-        serde_json::Value::String(s) => serde_json::from_str(s).map_err(|e| {
-            NapiError::from(ScpNapiError::Validation {
-                message: format!("invalid consequenceRules JSON string: {e}"),
-                code: "SCP-VALID-7000".to_owned(),
-            })
-        })?,
-        other => serde_json::from_value(other.clone()).map_err(|e| {
-            NapiError::from(ScpNapiError::Validation {
-                message: format!("invalid consequenceRules: {e}"),
-                code: "SCP-VALID-7000".to_owned(),
-            })
-        })?,
-    };
-
-    // Parse consequence_config from params (ADR-017, #1531). Accepts a JSON
-    // object (preferred) or a JSON-encoded string for legacy callers.
-    let core_consequence_config: scp_core::context::params::ConsequenceConfig = match &params["consequenceConfig"]
-    {
-        serde_json::Value::Null => scp_core::context::params::ConsequenceConfig::default(),
-        serde_json::Value::String(s) => serde_json::from_str(s).map_err(|e| {
-            NapiError::from(ScpNapiError::Validation {
-                message: format!("invalid consequenceConfig JSON string: {e}"),
-                code: "SCP-VALID-7000".to_owned(),
-            })
-        })?,
-        other => serde_json::from_value(other.clone()).map_err(|e| {
-            NapiError::from(ScpNapiError::Validation {
-                message: format!("invalid consequenceConfig: {e}"),
-                code: "SCP-VALID-7000".to_owned(),
-            })
-        })?,
-    };
-
-    // Validate each consequence rule against the per-context config so the
-    // bridge fails closed at creation time rather than deferring to runtime.
-    for rule in &core_consequence_rules {
-        rule.validate_against_config(&core_consequence_config)
-            .map_err(|e| {
-                NapiError::from(ScpNapiError::Validation {
-                    message: format!("consequence rule validation failed: {e}"),
-                    code: "SCP-VALID-7000".to_owned(),
-                })
-            })?;
-    }
-
-    let context_params = ContextParams {
-        mode,
-        ceiling: core_ceiling,
-        ceiling_policy: core_ceiling_policy,
-        promotion_policy: core_promotion_policy,
+    // Delegate to the shared context-params builder (#1447). All parsing,
+    // validation, and ContextParams construction happens in scp-ffi-common.
+    let common = scp_ffi_common::context_params::CommonContextParams {
+        mode: mode_str.clone(),
+        ceiling: ceiling.clone(),
+        ceiling_policy: ceiling_policy.clone(),
+        promotion_policy: promotion_policy.clone().unwrap_or_default(),
+        memory_scope: memory_scope_str,
+        governance: governance.clone(),
         ttl: ttl_seconds.map(std::time::Duration::from_secs),
-        memory_scope: core_memory_scope,
-        governance: core_governance,
         min_protocol_version,
         max_chain_depth,
         max_nesting_depth,
         session_cap,
-        economic_policy: core_economic_policy,
-        consequence_rules: core_consequence_rules,
-        consequence_config: core_consequence_config,
-        ..ContextParams::default()
+        economic_policy_json: economic_policy.clone(),
+        consequence_rules_json,
+        consequence_config_json,
+        ..Default::default()
     };
+
+    let context_params =
+        scp_ffi_common::context_params::build_context_params(&common).map_err(|e| {
+            NapiError::from(ScpNapiError::Validation {
+                message: e,
+                code: "SCP-VALID-7000".to_owned(),
+            })
+        })?;
 
     // Initialize the ContextManager if not already done (first context_create call).
     // Passes the creator DID to MlsCryptoProvider for real MLS encryption (#1294).

--- a/crates/scp-ffi/napi/src/discovery.rs
+++ b/crates/scp-ffi/napi/src/discovery.rs
@@ -21,6 +21,7 @@
 //!
 //! See ADR-020 in `.docs/adrs/phase-4.md` and spec section 22 (Addressing).
 
+use scp_ffi_common::error_codes as codes;
 use std::collections::HashMap;
 
 use napi_derive::napi;
@@ -57,7 +58,7 @@ fn parse_handle_target(json: &str) -> napi::Result<HandleTarget> {
     petname_helpers::parse_handle_target(json).map_err(|e| {
         napi::Error::from(ScpNapiError::Validation {
             message: e.message,
-            code: "SCP-VALID-7126".to_owned(),
+            code: codes::VALID_7126.to_owned(),
         })
     })
 }
@@ -75,7 +76,7 @@ pub fn discovery_parse_address(address: String) -> napi::Result<String> {
     let parsed = parse_address(&address).map_err(|e| {
         napi::Error::from(ScpNapiError::Validation {
             message: format!("invalid address '{address}': {e}"),
-            code: "SCP-VALID-7020".to_owned(),
+            code: codes::VALID_7020.to_owned(),
         })
     })?;
 
@@ -112,7 +113,7 @@ pub fn discovery_parse_address(address: String) -> napi::Result<String> {
     serde_json::to_string(&result).map_err(|e| {
         napi::Error::from(ScpNapiError::Validation {
             message: format!("failed to serialize parsed address: {e}"),
-            code: "SCP-VALID-7021".to_owned(),
+            code: codes::VALID_7021.to_owned(),
         })
     })
 }
@@ -129,7 +130,7 @@ pub fn discovery_create_query(
         Some(s) if s < 0 => {
             return Err(napi::Error::from(ScpNapiError::Validation {
                 message: format!("min_history_secs must be non-negative, got {s}"),
-                code: "SCP-VALID-7040".to_owned(),
+                code: codes::VALID_7040.to_owned(),
             }));
         }
         #[allow(clippy::cast_sign_loss)]
@@ -145,7 +146,7 @@ pub fn discovery_create_query(
     serde_json::to_string(&query).map_err(|e| {
         napi::Error::from(ScpNapiError::Validation {
             message: format!("failed to serialize query: {e}"),
-            code: "SCP-VALID-7022".to_owned(),
+            code: codes::VALID_7022.to_owned(),
         })
     })
 }
@@ -185,20 +186,20 @@ pub async fn context_discover(query: String) -> napi::Result<String> {
         let result = scp_core::discovery::resolve_context_uri(&query).map_err(|e| {
             napi::Error::from(ScpNapiError::Context {
                 message: format!("failed to resolve scp:// URI: {e}"),
-                code: "SCP-CTX-2020".to_owned(),
+                code: codes::CTX_2020.to_owned(),
             })
         })?;
 
         let results = vec![discovery_result_to_json(&result).map_err(|e| {
             napi::Error::from(ScpNapiError::Context {
                 message: e,
-                code: "SCP-CTX-2020".to_owned(),
+                code: codes::CTX_2020.to_owned(),
             })
         })?];
         serde_json::to_string(&results).map_err(|e| {
             napi::Error::from(ScpNapiError::Context {
                 message: format!("failed to serialize discovery results: {e}"),
-                code: "SCP-CTX-2021".to_owned(),
+                code: codes::CTX_2021.to_owned(),
             })
         })
     } else if query.starts_with("did:") {
@@ -208,7 +209,7 @@ pub async fn context_discover(query: String) -> napi::Result<String> {
             .map_err(|e| {
                 napi::Error::from(ScpNapiError::Context {
                     message: format!("DHT discovery failed for '{query}': {e}"),
-                    code: "SCP-CTX-2022".to_owned(),
+                    code: codes::CTX_2022.to_owned(),
                 })
             })?;
 
@@ -218,7 +219,7 @@ pub async fn context_discover(query: String) -> napi::Result<String> {
                 discovery_result_to_json(r).map_err(|e| {
                     napi::Error::from(ScpNapiError::Context {
                         message: e,
-                        code: "SCP-CTX-2022".to_owned(),
+                        code: codes::CTX_2022.to_owned(),
                     })
                 })
             })
@@ -226,7 +227,7 @@ pub async fn context_discover(query: String) -> napi::Result<String> {
         serde_json::to_string(&json_results).map_err(|e| {
             napi::Error::from(ScpNapiError::Context {
                 message: format!("failed to serialize discovery results: {e}"),
-                code: "SCP-CTX-2023".to_owned(),
+                code: codes::CTX_2023.to_owned(),
             })
         })
     } else {
@@ -235,7 +236,7 @@ pub async fn context_discover(query: String) -> napi::Result<String> {
                 "query must be a DID (starts with 'did:') or an scp:// URI \
                  (starts with 'scp://'), got: {query}"
             ),
-            code: "SCP-VALID-7027".to_owned(),
+            code: codes::VALID_7027.to_owned(),
         }))
     }
 }
@@ -251,19 +252,19 @@ pub fn petname_set(owner_did: String, target_did: String, name: String) -> napi:
     if owner_did.is_empty() {
         return Err(napi::Error::from(ScpNapiError::Validation {
             message: "owner_did must not be empty".to_owned(),
-            code: "SCP-VALID-7110".to_owned(),
+            code: codes::VALID_7110.to_owned(),
         }));
     }
     if target_did.is_empty() {
         return Err(napi::Error::from(ScpNapiError::Validation {
             message: "target_did must not be empty".to_owned(),
-            code: "SCP-VALID-7111".to_owned(),
+            code: codes::VALID_7111.to_owned(),
         }));
     }
     let mut guard = petname_maps().lock().map_err(|e| {
         napi::Error::from(ScpNapiError::Validation {
             message: format!("petname lock poisoned: {e}"),
-            code: "SCP-VALID-7112".to_owned(),
+            code: codes::VALID_7112.to_owned(),
         })
     })?;
     let map = guard.entry(owner_did).or_default();
@@ -278,13 +279,13 @@ pub fn petname_remove(owner_did: String, target_did: String) -> napi::Result<()>
     if owner_did.is_empty() {
         return Err(napi::Error::from(ScpNapiError::Validation {
             message: "owner_did must not be empty".to_owned(),
-            code: "SCP-VALID-7110".to_owned(),
+            code: codes::VALID_7110.to_owned(),
         }));
     }
     let mut guard = petname_maps().lock().map_err(|e| {
         napi::Error::from(ScpNapiError::Validation {
             message: format!("petname lock poisoned: {e}"),
-            code: "SCP-VALID-7112".to_owned(),
+            code: codes::VALID_7112.to_owned(),
         })
     })?;
     if let Some(map) = guard.get_mut(&owner_did) {
@@ -304,19 +305,19 @@ pub fn petname_set_context(
     if owner_did.is_empty() {
         return Err(napi::Error::from(ScpNapiError::Validation {
             message: "owner_did must not be empty".to_owned(),
-            code: "SCP-VALID-7110".to_owned(),
+            code: codes::VALID_7110.to_owned(),
         }));
     }
     if context_id.is_empty() {
         return Err(napi::Error::from(ScpNapiError::Validation {
             message: "context_id must not be empty".to_owned(),
-            code: "SCP-VALID-7113".to_owned(),
+            code: codes::VALID_7113.to_owned(),
         }));
     }
     let mut guard = petname_maps().lock().map_err(|e| {
         napi::Error::from(ScpNapiError::Validation {
             message: format!("petname lock poisoned: {e}"),
-            code: "SCP-VALID-7112".to_owned(),
+            code: codes::VALID_7112.to_owned(),
         })
     })?;
     let map = guard.entry(owner_did).or_default();
@@ -331,13 +332,13 @@ pub fn petname_remove_context(owner_did: String, context_id: String) -> napi::Re
     if owner_did.is_empty() {
         return Err(napi::Error::from(ScpNapiError::Validation {
             message: "owner_did must not be empty".to_owned(),
-            code: "SCP-VALID-7110".to_owned(),
+            code: codes::VALID_7110.to_owned(),
         }));
     }
     let mut guard = petname_maps().lock().map_err(|e| {
         napi::Error::from(ScpNapiError::Validation {
             message: format!("petname lock poisoned: {e}"),
-            code: "SCP-VALID-7112".to_owned(),
+            code: codes::VALID_7112.to_owned(),
         })
     })?;
     if let Some(map) = guard.get_mut(&owner_did) {
@@ -353,13 +354,13 @@ pub fn petname_resolve_did(owner_did: String, name: String) -> napi::Result<Stri
     if owner_did.is_empty() {
         return Err(napi::Error::from(ScpNapiError::Validation {
             message: "owner_did must not be empty".to_owned(),
-            code: "SCP-VALID-7110".to_owned(),
+            code: codes::VALID_7110.to_owned(),
         }));
     }
     let guard = petname_maps().lock().map_err(|e| {
         napi::Error::from(ScpNapiError::Validation {
             message: format!("petname lock poisoned: {e}"),
-            code: "SCP-VALID-7112".to_owned(),
+            code: codes::VALID_7112.to_owned(),
         })
     })?;
     let dids: Vec<String> = guard
@@ -374,7 +375,7 @@ pub fn petname_resolve_did(owner_did: String, name: String) -> napi::Result<Stri
     serde_json::to_string(&dids).map_err(|e| {
         napi::Error::from(ScpNapiError::Validation {
             message: format!("failed to serialize petname resolve result: {e}"),
-            code: "SCP-VALID-7114".to_owned(),
+            code: codes::VALID_7114.to_owned(),
         })
     })
 }
@@ -386,13 +387,13 @@ pub fn petname_resolve_context(owner_did: String, name: String) -> napi::Result<
     if owner_did.is_empty() {
         return Err(napi::Error::from(ScpNapiError::Validation {
             message: "owner_did must not be empty".to_owned(),
-            code: "SCP-VALID-7110".to_owned(),
+            code: codes::VALID_7110.to_owned(),
         }));
     }
     let guard = petname_maps().lock().map_err(|e| {
         napi::Error::from(ScpNapiError::Validation {
             message: format!("petname lock poisoned: {e}"),
-            code: "SCP-VALID-7112".to_owned(),
+            code: codes::VALID_7112.to_owned(),
         })
     })?;
     let ids: Vec<String> = guard
@@ -402,7 +403,7 @@ pub fn petname_resolve_context(owner_did: String, name: String) -> napi::Result<
     serde_json::to_string(&ids).map_err(|e| {
         napi::Error::from(ScpNapiError::Validation {
             message: format!("failed to serialize petname resolve result: {e}"),
-            code: "SCP-VALID-7114".to_owned(),
+            code: codes::VALID_7114.to_owned(),
         })
     })
 }
@@ -414,13 +415,13 @@ pub fn petname_get_for_did(owner_did: String, target_did: String) -> napi::Resul
     if owner_did.is_empty() {
         return Err(napi::Error::from(ScpNapiError::Validation {
             message: "owner_did must not be empty".to_owned(),
-            code: "SCP-VALID-7110".to_owned(),
+            code: codes::VALID_7110.to_owned(),
         }));
     }
     let guard = petname_maps().lock().map_err(|e| {
         napi::Error::from(ScpNapiError::Validation {
             message: format!("petname lock poisoned: {e}"),
-            code: "SCP-VALID-7112".to_owned(),
+            code: codes::VALID_7112.to_owned(),
         })
     })?;
     Ok(guard.get(&owner_did).and_then(|map| {
@@ -439,13 +440,13 @@ pub fn petname_get_for_context(
     if owner_did.is_empty() {
         return Err(napi::Error::from(ScpNapiError::Validation {
             message: "owner_did must not be empty".to_owned(),
-            code: "SCP-VALID-7110".to_owned(),
+            code: codes::VALID_7110.to_owned(),
         }));
     }
     let guard = petname_maps().lock().map_err(|e| {
         napi::Error::from(ScpNapiError::Validation {
             message: format!("petname lock poisoned: {e}"),
-            code: "SCP-VALID-7112".to_owned(),
+            code: codes::VALID_7112.to_owned(),
         })
     })?;
     Ok(guard
@@ -477,7 +478,7 @@ pub fn handle_register(
     let mut guard = handle_registries().lock().map_err(|e| {
         napi::Error::from(ScpNapiError::Validation {
             message: format!("handle registry lock poisoned: {e}"),
-            code: "SCP-VALID-7120".to_owned(),
+            code: codes::VALID_7120.to_owned(),
         })
     })?;
     let registry = guard
@@ -491,7 +492,7 @@ pub fn handle_register(
     serde_json::to_string(&result).map_err(|e| {
         napi::Error::from(ScpNapiError::Validation {
             message: format!("failed to serialize handle register result: {e}"),
-            code: "SCP-VALID-7122".to_owned(),
+            code: codes::VALID_7122.to_owned(),
         })
     })
 }
@@ -510,7 +511,7 @@ pub fn handle_lookup(
         Some(other) => {
             return Err(napi::Error::from(ScpNapiError::Validation {
                 message: format!("invalid type_filter '{other}': expected 'identity' or 'context'"),
-                code: "SCP-VALID-7123".to_owned(),
+                code: codes::VALID_7123.to_owned(),
             }));
         }
         None => None,
@@ -518,7 +519,7 @@ pub fn handle_lookup(
     let guard = handle_registries().lock().map_err(|e| {
         napi::Error::from(ScpNapiError::Validation {
             message: format!("handle registry lock poisoned: {e}"),
-            code: "SCP-VALID-7120".to_owned(),
+            code: codes::VALID_7120.to_owned(),
         })
     })?;
     let result = guard.get(&discovery_context_id).map_or_else(
@@ -535,7 +536,7 @@ pub fn handle_lookup(
     serde_json::to_string(&result).map_err(|e| {
         napi::Error::from(ScpNapiError::Validation {
             message: format!("failed to serialize handle lookup result: {e}"),
-            code: "SCP-VALID-7124".to_owned(),
+            code: codes::VALID_7124.to_owned(),
         })
     })
 }
@@ -551,7 +552,7 @@ pub fn handle_deregister(
     let mut guard = handle_registries().lock().map_err(|e| {
         napi::Error::from(ScpNapiError::Validation {
             message: format!("handle registry lock poisoned: {e}"),
-            code: "SCP-VALID-7120".to_owned(),
+            code: codes::VALID_7120.to_owned(),
         })
     })?;
     let result = guard.get_mut(&discovery_context_id).map_or_else(
@@ -566,7 +567,7 @@ pub fn handle_deregister(
     serde_json::to_string(&result).map_err(|e| {
         napi::Error::from(ScpNapiError::Validation {
             message: format!("failed to serialize handle deregister result: {e}"),
-            code: "SCP-VALID-7125".to_owned(),
+            code: codes::VALID_7125.to_owned(),
         })
     })
 }
@@ -600,7 +601,7 @@ pub fn scope_register(
         scp_ffi_common::validate::validate_relay_url(url).map_err(|e| {
             napi::Error::from(ScpNapiError::Validation {
                 message: e.to_string(),
-                code: "SCP-VALID-7135".to_owned(),
+                code: codes::VALID_7135.to_owned(),
             })
         })?;
     }
@@ -621,7 +622,7 @@ pub fn scope_register(
     let mut guard = petname_helpers::scope_registries().lock().map_err(|e| {
         napi::Error::from(ScpNapiError::Validation {
             message: format!("scope registry lock poisoned: {e}"),
-            code: "SCP-VALID-7130".to_owned(),
+            code: codes::VALID_7130.to_owned(),
         })
     })?;
 
@@ -638,14 +639,14 @@ pub fn scope_register(
         .map_err(|e| {
             napi::Error::from(ScpNapiError::Validation {
                 message: format!("scope registration failed: {e}"),
-                code: "SCP-VALID-7131".to_owned(),
+                code: codes::VALID_7131.to_owned(),
             })
         })?;
 
     serde_json::to_string(&result).map_err(|e| {
         napi::Error::from(ScpNapiError::Validation {
             message: format!("failed to serialize scope register result: {e}"),
-            code: "SCP-VALID-7132".to_owned(),
+            code: codes::VALID_7132.to_owned(),
         })
     })
 }
@@ -660,7 +661,7 @@ pub fn scope_lookup(scope_context_id: String, name: String) -> napi::Result<Stri
     let guard = petname_helpers::scope_registries().lock().map_err(|e| {
         napi::Error::from(ScpNapiError::Validation {
             message: format!("scope registry lock poisoned: {e}"),
-            code: "SCP-VALID-7130".to_owned(),
+            code: codes::VALID_7130.to_owned(),
         })
     })?;
 
@@ -670,7 +671,7 @@ pub fn scope_lookup(scope_context_id: String, name: String) -> napi::Result<Stri
             .map_err(|e| {
                 napi::Error::from(ScpNapiError::Validation {
                     message: format!("scope lookup failed: {e}"),
-                    code: "SCP-VALID-7133".to_owned(),
+                    code: codes::VALID_7133.to_owned(),
                 })
             })?,
         None => scp_core::discovery::ScopeLookupResult {
@@ -681,7 +682,7 @@ pub fn scope_lookup(scope_context_id: String, name: String) -> napi::Result<Stri
     serde_json::to_string(&result).map_err(|e| {
         napi::Error::from(ScpNapiError::Validation {
             message: format!("failed to serialize scope lookup result: {e}"),
-            code: "SCP-VALID-7133".to_owned(),
+            code: codes::VALID_7133.to_owned(),
         })
     })
 }
@@ -702,7 +703,7 @@ pub fn scope_deregister(
     let mut guard = petname_helpers::scope_registries().lock().map_err(|e| {
         napi::Error::from(ScpNapiError::Validation {
             message: format!("scope registry lock poisoned: {e}"),
-            code: "SCP-VALID-7130".to_owned(),
+            code: codes::VALID_7130.to_owned(),
         })
     })?;
 
@@ -715,7 +716,7 @@ pub fn scope_deregister(
             .map_err(|e| {
                 napi::Error::from(ScpNapiError::Validation {
                     message: format!("scope deregister failed: {e}"),
-                    code: "SCP-VALID-7134".to_owned(),
+                    code: codes::VALID_7134.to_owned(),
                 })
             })?,
         None => scp_core::discovery::ScopeDeregisterResult { removed: false },
@@ -724,7 +725,7 @@ pub fn scope_deregister(
     serde_json::to_string(&result).map_err(|e| {
         napi::Error::from(ScpNapiError::Validation {
             message: format!("failed to serialize scope deregister result: {e}"),
-            code: "SCP-VALID-7134".to_owned(),
+            code: codes::VALID_7134.to_owned(),
         })
     })
 }
@@ -745,21 +746,21 @@ pub async fn address_resolve(
     if owner_did.is_empty() {
         return Err(napi::Error::from(ScpNapiError::Validation {
             message: "owner_did must not be empty".to_owned(),
-            code: "SCP-VALID-7110".to_owned(),
+            code: codes::VALID_7110.to_owned(),
         }));
     }
     let mut known_contexts: HashMap<String, String> = if let Some(ref json) = known_contexts_json {
         serde_json::from_str(json).map_err(|e| {
             napi::Error::from(ScpNapiError::Validation {
                 message: format!("invalid known_contexts_json: {e}"),
-                code: "SCP-VALID-7090".to_owned(),
+                code: codes::VALID_7090.to_owned(),
             })
         })?
     } else {
         let guard = handle_registries().lock().map_err(|e| {
             napi::Error::from(ScpNapiError::Validation {
                 message: format!("handle registry lock poisoned: {e}"),
-                code: "SCP-VALID-7120".to_owned(),
+                code: codes::VALID_7120.to_owned(),
             })
         })?;
         guard.keys().map(|k| (k.clone(), k.clone())).collect()
@@ -775,7 +776,7 @@ pub async fn address_resolve(
         let guard = petname_maps().lock().map_err(|e| {
             napi::Error::from(ScpNapiError::Validation {
                 message: format!("petname lock poisoned: {e}"),
-                code: "SCP-VALID-7112".to_owned(),
+                code: codes::VALID_7112.to_owned(),
             })
         })?;
         guard.get(&owner_did).cloned().unwrap_or_default()
@@ -795,7 +796,7 @@ pub async fn address_resolve(
         .map_err(|e| {
             napi::Error::from(ScpNapiError::Validation {
                 message: format!("address resolution failed: {e}"),
-                code: "SCP-VALID-7091".to_owned(),
+                code: codes::VALID_7091.to_owned(),
             })
         })?;
     let json_results: Vec<serde_json::Value> =
@@ -803,7 +804,7 @@ pub async fn address_resolve(
     serde_json::to_string(&json_results).map_err(|e| {
         napi::Error::from(ScpNapiError::Validation {
             message: format!("failed to serialize address resolution results: {e}"),
-            code: "SCP-VALID-7092".to_owned(),
+            code: codes::VALID_7092.to_owned(),
         })
     })
 }

--- a/crates/scp-ffi/napi/src/economy.rs
+++ b/crates/scp-ffi/napi/src/economy.rs
@@ -18,6 +18,7 @@
 //! See spec section 19 (Economic Governance) and ADR-033.
 
 use napi_derive::napi;
+use scp_ffi_common::error_codes as codes;
 
 use crate::error::ScpNapiError;
 
@@ -28,7 +29,7 @@ use crate::error::ScpNapiError;
 fn validation_error(msg: &str) -> napi::Error {
     napi::Error::from(ScpNapiError::Validation {
         message: msg.to_owned(),
-        code: "SCP-VALID-7050".to_owned(),
+        code: codes::VALID_7050.to_owned(),
     })
 }
 

--- a/crates/scp-ffi/napi/src/error.rs
+++ b/crates/scp-ffi/napi/src/error.rs
@@ -26,6 +26,7 @@
 //! See ADR-022 in `.docs/adrs/phase-4.md`.
 
 use napi::Status;
+use scp_ffi_common::error_codes as codes;
 
 // ---------------------------------------------------------------------------
 // ScpNapiError — unified error type for the napi bridge layer
@@ -128,7 +129,7 @@ impl From<scp_identity::IdentityError> for ScpNapiError {
             message: format!(
                 "{e} — check DID format, key custody configuration, or DHT connectivity"
             ),
-            code: "SCP-IDENT-1001".to_owned(),
+            code: codes::IDENT_1001.to_owned(),
         }
     }
 }
@@ -165,23 +166,23 @@ impl From<scp_core::context::ContextError> for ScpNapiError {
             // the message body.
             CE::RateLimited { .. } => Self::Context {
                 message: format!("{e}"),
-                code: "SCP-ECON-12090".to_owned(),
+                code: codes::ECON_12090.to_owned(),
             },
             // §23.17 snapshot import regression.
             CE::SnapshotFloorRegression { .. } => Self::Context {
                 message: format!("{e}"),
-                code: "SCP-CTX-2091".to_owned(),
+                code: codes::CTX_2091.to_owned(),
             },
             // C3: snapshot import structural/semantic rejection.
             CE::ImportRejected { .. } => Self::Context {
                 message: format!("{e}"),
-                code: "SCP-CTX-2092".to_owned(),
+                code: codes::CTX_2092.to_owned(),
             },
             // Recover embedded SCP-ECON-/SCP-TOOL-/SCP-PERM- codes from
             // the runtime's `PermissionDenied(String)` catch-all so the
             // typed-envelope contract holds for tool-economy failures.
             CE::PermissionDenied(msg) => {
-                let code = extract_scp_code(msg).unwrap_or_else(|| "SCP-PERM-3001".to_owned());
+                let code = extract_scp_code(msg).unwrap_or_else(|| codes::PERM_3001.to_owned());
                 if code.starts_with("SCP-PERM-") {
                     Self::Permission {
                         message: format!("{e}"),
@@ -201,7 +202,7 @@ impl From<scp_core::context::ContextError> for ScpNapiError {
             }
             _ => Self::Context {
                 message: format!("{e} — verify context state, membership, and permissions"),
-                code: "SCP-CTX-2001".to_owned(),
+                code: codes::CTX_2001.to_owned(),
             },
         }
     }
@@ -213,7 +214,7 @@ impl From<scp_core::context::builder::ContextCreationError> for ScpNapiError {
             message: format!(
                 "context creation failed: {e} — check context parameters and identity"
             ),
-            code: "SCP-CTX-2002".to_owned(),
+            code: codes::CTX_2002.to_owned(),
         }
     }
 }
@@ -224,7 +225,7 @@ impl From<scp_core::context::templates::TemplateError> for ScpNapiError {
             message: format!(
                 "template validation failed: {e} — ensure context params match the template"
             ),
-            code: "SCP-CTX-2003".to_owned(),
+            code: codes::CTX_2003.to_owned(),
         }
     }
 }
@@ -235,7 +236,7 @@ impl From<scp_core::context::roles::RoleError> for ScpNapiError {
             message: format!(
                 "role operation failed: {e} — verify role definitions and member permissions"
             ),
-            code: "SCP-CTX-2004".to_owned(),
+            code: codes::CTX_2004.to_owned(),
         }
     }
 }
@@ -246,7 +247,7 @@ impl From<scp_core::context::ttl::TtlError> for ScpNapiError {
             message: format!(
                 "TTL operation failed: {e} — check TTL configuration and context state"
             ),
-            code: "SCP-CTX-2005".to_owned(),
+            code: codes::CTX_2005.to_owned(),
         }
     }
 }
@@ -257,7 +258,7 @@ impl From<scp_core::context::promotion::PromotionError> for ScpNapiError {
             message: format!(
                 "context promotion failed: {e} — verify eligibility and governance rules"
             ),
-            code: "SCP-CTX-2006".to_owned(),
+            code: codes::CTX_2006.to_owned(),
         }
     }
 }
@@ -268,7 +269,7 @@ impl From<scp_core::context::tools::ToolError> for ScpNapiError {
             message: format!(
                 "tool operation failed: {e} — check tool registration, permissions, and input schema"
             ),
-            code: "SCP-TOOL-6001".to_owned(),
+            code: codes::TOOL_6001.to_owned(),
         }
     }
 }
@@ -279,7 +280,7 @@ impl From<scp_core::context::tools::invoke::InvocationError> for ScpNapiError {
             message: format!(
                 "tool invocation failed: {e} — verify tool ID, input, and caller permissions"
             ),
-            code: "SCP-TOOL-6002".to_owned(),
+            code: codes::TOOL_6002.to_owned(),
         }
     }
 }
@@ -290,7 +291,7 @@ impl From<scp_core::context::tools::schema::SchemaValidationError> for ScpNapiEr
             message: format!(
                 "schema validation failed: {e} — check input against the tool's JSON Schema"
             ),
-            code: "SCP-VALID-7001".to_owned(),
+            code: codes::VALID_7001.to_owned(),
         }
     }
 }
@@ -301,7 +302,7 @@ impl From<scp_core::crypto::mls::error::MlsError> for ScpNapiError {
             message: format!(
                 "MLS operation failed: {e} — check group state and member key packages"
             ),
-            code: "SCP-CRYPTO-4001".to_owned(),
+            code: codes::CRYPTO_4001.to_owned(),
         }
     }
 }
@@ -312,7 +313,7 @@ impl From<scp_core::crypto::sender_keys::SenderKeyError> for ScpNapiError {
             message: format!(
                 "sender key operation failed: {e} — verify key material and encryption parameters"
             ),
-            code: "SCP-CRYPTO-4002".to_owned(),
+            code: codes::CRYPTO_4002.to_owned(),
         }
     }
 }
@@ -323,7 +324,7 @@ impl From<scp_core::crypto::ucan::UcanError> for ScpNapiError {
             message: format!(
                 "{e} — check token format, signatures, time bounds, and capability chain"
             ),
-            code: "SCP-PERM-3001".to_owned(),
+            code: codes::PERM_3001.to_owned(),
         }
     }
 }
@@ -334,7 +335,7 @@ impl From<scp_core::envelope::EnvelopeError> for ScpNapiError {
             message: format!(
                 "envelope operation failed: {e} — check payload size, signing keys, and encryption state"
             ),
-            code: "SCP-CRYPTO-4003".to_owned(),
+            code: codes::CRYPTO_4003.to_owned(),
         }
     }
 }
@@ -345,7 +346,7 @@ impl From<scp_event_log::EventLogError> for ScpNapiError {
             message: format!(
                 "event log operation failed: {e} — verify log integrity and sequence numbers"
             ),
-            code: "SCP-CTX-2007".to_owned(),
+            code: codes::CTX_2007.to_owned(),
         }
     }
 }
@@ -354,7 +355,7 @@ impl From<scp_core::provenance::ProvenanceError> for ScpNapiError {
     fn from(e: scp_core::provenance::ProvenanceError) -> Self {
         Self::Validation {
             message: format!("provenance validation failed: {e} — check cross-context chain depth"),
-            code: "SCP-VALID-7002".to_owned(),
+            code: codes::VALID_7002.to_owned(),
         }
     }
 }
@@ -365,7 +366,7 @@ impl From<scp_core::trust::TrustError> for ScpNapiError {
             message: format!(
                 "trust evaluation failed: {e} — check event log data and attestation validity"
             ),
-            code: "SCP-VALID-7003".to_owned(),
+            code: codes::VALID_7003.to_owned(),
         }
     }
 }
@@ -374,7 +375,7 @@ impl From<scp_core::uri::ScpUriError> for ScpNapiError {
     fn from(e: scp_core::uri::ScpUriError) -> Self {
         Self::Validation {
             message: format!("invalid SCP URI: {e} — check URI format (scp://relay/context-id)"),
-            code: "SCP-VALID-7004".to_owned(),
+            code: codes::VALID_7004.to_owned(),
         }
     }
 }
@@ -383,7 +384,7 @@ impl From<scp_core::well_known::WellKnownValidationError> for ScpNapiError {
     fn from(e: scp_core::well_known::WellKnownValidationError) -> Self {
         Self::Validation {
             message: format!("well-known validation failed: {e} — check relay configuration"),
-            code: "SCP-VALID-7005".to_owned(),
+            code: codes::VALID_7005.to_owned(),
         }
     }
 }
@@ -394,7 +395,7 @@ impl From<scp_core::discovery::DiscoveryError> for ScpNapiError {
             message: format!(
                 "discovery operation failed: {e} — check relay connectivity and search parameters"
             ),
-            code: "SCP-CTX-2008".to_owned(),
+            code: codes::CTX_2008.to_owned(),
         }
     }
 }
@@ -405,7 +406,7 @@ impl From<scp_core::bridge::registration::BridgeRegistrationError> for ScpNapiEr
             message: format!(
                 "bridge registration failed: {e} — verify bridge configuration and permissions"
             ),
-            code: "SCP-CTX-2009".to_owned(),
+            code: codes::CTX_2009.to_owned(),
         }
     }
 }
@@ -416,7 +417,7 @@ impl From<scp_core::bridge::shadow::ShadowError> for ScpNapiError {
             message: format!(
                 "shadow context operation failed: {e} — check bridge state and context permissions"
             ),
-            code: "SCP-CTX-2010".to_owned(),
+            code: codes::CTX_2010.to_owned(),
         }
     }
 }
@@ -427,7 +428,7 @@ impl From<scp_platform::PlatformError> for ScpNapiError {
             message: format!(
                 "platform key operation failed: {e} — check key custody configuration"
             ),
-            code: "SCP-CRYPTO-4004".to_owned(),
+            code: codes::CRYPTO_4004.to_owned(),
         }
     }
 }
@@ -436,7 +437,7 @@ impl From<serde_json::Error> for ScpNapiError {
     fn from(e: serde_json::Error) -> Self {
         Self::Validation {
             message: format!("JSON serialization/deserialization failed: {e} — check input format"),
-            code: "SCP-VALID-7006".to_owned(),
+            code: codes::VALID_7006.to_owned(),
         }
     }
 }
@@ -445,7 +446,7 @@ impl From<scp_ffi_common::validate::ValidationError> for ScpNapiError {
     fn from(e: scp_ffi_common::validate::ValidationError) -> Self {
         Self::Validation {
             message: e.message,
-            code: "SCP-VALID-7000".to_owned(),
+            code: codes::VALID_7000.to_owned(),
         }
     }
 }
@@ -464,7 +465,7 @@ pub(crate) fn validate_custody_type(custody: &str) -> Result<&str, ScpNapiError>
             message: format!(
                 "unknown custody type: {other:?} — expected \"in_memory\", \"platform\", or \"software\""
             ),
-            code: "SCP-VALID-7007".to_owned(),
+            code: codes::VALID_7007.to_owned(),
         }),
     }
 }

--- a/crates/scp-ffi/napi/src/event_log.rs
+++ b/crates/scp-ffi/napi/src/event_log.rs
@@ -8,6 +8,7 @@
 //! See ADR-011 (Event Log) and ADR-022 in `.docs/adrs/`.
 
 use napi_derive::napi;
+use scp_ffi_common::error_codes as codes;
 use scp_primitives::Clock;
 
 use crate::context::NapiContextHandle;
@@ -91,7 +92,7 @@ pub async fn event_log_query(
             let parsed: serde_json::Value =
                 serde_json::from_str(json_str).map_err(|e| ScpNapiError::Validation {
                     message: format!("filter_json is not valid JSON: {e}"),
-                    code: "SCP-VALID-7000".to_owned(),
+                    code: codes::VALID_7000.to_owned(),
                 })?;
             Some(parsed)
         }
@@ -227,7 +228,7 @@ pub async fn event_log_verify(
     let claim: serde_json::Value =
         serde_json::from_str(&claim_json).map_err(|e| ScpNapiError::Validation {
             message: format!("claim_json is not valid JSON: {e}"),
-            code: "SCP-VALID-7000".to_owned(),
+            code: codes::VALID_7000.to_owned(),
         })?;
 
     let claim_type = claim
@@ -235,7 +236,7 @@ pub async fn event_log_verify(
         .and_then(|v| v.as_str())
         .ok_or_else(|| ScpNapiError::Validation {
             message: "claim must include 'type' field ('inclusion' or 'absence')".to_owned(),
-            code: "SCP-VALID-7000".to_owned(),
+            code: codes::VALID_7000.to_owned(),
         })
         .map_err(napi::Error::from)?;
 
@@ -286,7 +287,7 @@ pub async fn event_log_verify(
                 .and_then(serde_json::Value::as_u64)
                 .ok_or_else(|| ScpNapiError::Validation {
                     message: "inclusion claim must include 'leaf_index' (integer)".to_owned(),
-                    code: "SCP-VALID-7000".to_owned(),
+                    code: codes::VALID_7000.to_owned(),
                 })
                 .map_err(napi::Error::from)?;
 
@@ -294,7 +295,7 @@ pub async fn event_log_verify(
                 let proof = scp_event_log::proof::prove_inclusion(&rt.event_log, leaf_index)
                     .map_err(|e| ScpNapiError::Context {
                         message: format!("inclusion proof failed: {e}"),
-                        code: "SCP-CTX-2025".to_owned(),
+                        code: codes::CTX_2025.to_owned(),
                     })?;
                 let verified = scp_event_log::proof::verify_inclusion(&proof);
 
@@ -337,14 +338,14 @@ pub async fn event_log_verify(
                 .and_then(|v| v.as_str())
                 .ok_or_else(|| ScpNapiError::Validation {
                     message: "absence claim must include 'event_hash' (hex string)".to_owned(),
-                    code: "SCP-VALID-7000".to_owned(),
+                    code: codes::VALID_7000.to_owned(),
                 })
                 .map_err(napi::Error::from)?;
 
             let event_hash = decode_hex_hash(event_hash_hex).map_err(|e| {
                 napi::Error::from(ScpNapiError::Validation {
                     message: format!("invalid event_hash: {e}"),
-                    code: "SCP-VALID-7000".to_owned(),
+                    code: codes::VALID_7000.to_owned(),
                 })
             })?;
 
@@ -353,7 +354,7 @@ pub async fn event_log_verify(
                     let proof = scp_event_log::proof::prove_absence(&rt.event_log, &event_hash)
                         .map_err(|e| ScpNapiError::Context {
                             message: format!("absence proof failed: {e}"),
-                            code: "SCP-CTX-2025".to_owned(),
+                            code: codes::CTX_2025.to_owned(),
                         })?;
 
                     let lower = proof.lower.as_ref().map(|lwp| {
@@ -398,7 +399,7 @@ pub async fn event_log_verify(
         }
         other => Err(ScpNapiError::Validation {
             message: format!("unsupported claim type '{other}': expected 'inclusion' or 'absence'"),
-            code: "SCP-VALID-7000".to_owned(),
+            code: codes::VALID_7000.to_owned(),
         }
         .into()),
     }
@@ -467,7 +468,7 @@ pub fn event_log_checkpoint(
                        is not available in this build. Enable allow_in_memory_custody \
                        for dev/desktop use."
                 .to_owned(),
-            code: "SCP-PERM-3023".to_owned(),
+            code: codes::PERM_3023.to_owned(),
         }))
     }
 
@@ -480,7 +481,7 @@ pub fn event_log_checkpoint(
                 message: "event log checkpoint requires key custody — create the identity \
                       with in_memory custody (identity_create(\"in_memory\"))"
                     .to_owned(),
-                code: "SCP-PERM-3023".to_owned(),
+                code: codes::PERM_3023.to_owned(),
             })
         })?;
         let scp_id = identity.inner.scp_identity.as_ref().ok_or_else(|| {
@@ -488,7 +489,7 @@ pub fn event_log_checkpoint(
                 message: "event log checkpoint requires retained identity state — the identity \
                           was externally loaded"
                     .to_owned(),
-                code: "SCP-IDENT-1007".to_owned(),
+                code: codes::IDENT_1007.to_owned(),
             })
         })?;
 
@@ -515,7 +516,7 @@ pub fn event_log_checkpoint(
                 .await
                 .map_err(|e| ScpNapiError::Context {
                     message: format!("checkpoint generation failed: {e}"),
-                    code: "SCP-CTX-2023".to_owned(),
+                    code: codes::CTX_2023.to_owned(),
                 })
             })
         })
@@ -573,7 +574,7 @@ pub fn event_log_checkpoint_by_did(
                        is not available in this build. Enable allow_in_memory_custody \
                        for dev/desktop use."
                 .to_owned(),
-            code: "SCP-PERM-3023".to_owned(),
+            code: codes::PERM_3023.to_owned(),
         }))
     }
 
@@ -609,7 +610,7 @@ pub fn event_log_checkpoint_by_did(
                 .await
                 .map_err(|e| ScpNapiError::Context {
                     message: format!("checkpoint generation failed: {e}"),
-                    code: "SCP-CTX-2023".to_owned(),
+                    code: codes::CTX_2023.to_owned(),
                 })
             })
         })
@@ -640,7 +641,7 @@ fn validate_non_negative_epoch(epoch: f64) -> napi::Result<u64> {
     if epoch < 0.0 || !epoch.is_finite() {
         return Err(napi::Error::from(ScpNapiError::Validation {
             message: format!("epoch must be non-negative, got {epoch}"),
-            code: "SCP-VALID-7040".to_owned(),
+            code: codes::VALID_7040.to_owned(),
         }));
     }
     #[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
@@ -678,6 +679,7 @@ pub(crate) fn decode_hex_hash(hex: &str) -> Result<[u8; 32], String> {
 #[allow(clippy::unwrap_used, clippy::expect_used)]
 mod tests {
     use super::*;
+    use scp_ffi_common::error_codes as codes;
 
     // -----------------------------------------------------------------------
     // decode_hex_hash
@@ -794,7 +796,7 @@ mod tests {
         // contains the SCP-VALID-7040 code from ScpNapiError::Validation.
         let msg = format!("{err}");
         assert!(
-            msg.contains("SCP-VALID-7040"),
+            msg.contains(codes::VALID_7040),
             "error should contain SCP-VALID-7040, got: {msg}"
         );
     }

--- a/crates/scp-ffi/napi/src/identity.rs
+++ b/crates/scp-ffi/napi/src/identity.rs
@@ -35,6 +35,7 @@
 //!
 //! See ADR-022 in `.docs/adrs/phase-4.md` and ADR-039.
 
+use scp_ffi_common::error_codes as codes;
 use std::sync::Arc;
 
 use napi::Error as NapiError;
@@ -353,7 +354,7 @@ impl NapiIdentity {
                 message: "key rotation requires in-memory custody -- \
                           enable allow_in_memory_custody"
                     .to_owned(),
-                code: "SCP-IDENT-1007".to_owned(),
+                code: codes::IDENT_1007.to_owned(),
             }
             .into())
         }
@@ -423,7 +424,7 @@ impl NapiIdentity {
         #[cfg(not(feature = "allow_in_memory_custody"))]
         {
             let _ = self;
-            Err(ScpNapiError::Identity { message: "agent key operations require in-memory custody -- enable allow_in_memory_custody".to_owned(), code: "SCP-IDENT-1007".to_owned() }.into())
+            Err(ScpNapiError::Identity { message: "agent key operations require in-memory custody -- enable allow_in_memory_custody".to_owned(), code: codes::IDENT_1007.to_owned() }.into())
         }
         #[cfg(feature = "allow_in_memory_custody")]
         {
@@ -492,7 +493,7 @@ impl NapiIdentity {
         #[cfg(not(feature = "allow_in_memory_custody"))]
         {
             let _ = self;
-            Err(ScpNapiError::Identity { message: "agent key operations require in-memory custody -- enable allow_in_memory_custody".to_owned(), code: "SCP-IDENT-1007".to_owned() }.into())
+            Err(ScpNapiError::Identity { message: "agent key operations require in-memory custody -- enable allow_in_memory_custody".to_owned(), code: codes::IDENT_1007.to_owned() }.into())
         }
         #[cfg(feature = "allow_in_memory_custody")]
         {
@@ -561,7 +562,7 @@ impl NapiIdentity {
         #[cfg(not(feature = "allow_in_memory_custody"))]
         {
             let _ = self;
-            Err(ScpNapiError::Identity { message: "agent key operations require in-memory custody -- enable allow_in_memory_custody".to_owned(), code: "SCP-IDENT-1007".to_owned() }.into())
+            Err(ScpNapiError::Identity { message: "agent key operations require in-memory custody -- enable allow_in_memory_custody".to_owned(), code: codes::IDENT_1007.to_owned() }.into())
         }
         #[cfg(feature = "allow_in_memory_custody")]
         {
@@ -639,7 +640,7 @@ impl NapiIdentity {
                 message: "identity migration requires in-memory custody -- \
                           enable allow_in_memory_custody"
                     .to_owned(),
-                code: "SCP-IDENT-1007".to_owned(),
+                code: codes::IDENT_1007.to_owned(),
             }
             .into())
         }
@@ -668,7 +669,7 @@ impl NapiIdentity {
                 .map_err(|e| {
                     NapiError::from(ScpNapiError::Identity {
                         message: format!("key generation failed during migration: {e}"),
-                        code: "SCP-IDENT-1009".to_owned(),
+                        code: codes::IDENT_1009.to_owned(),
                     })
                 })?;
 
@@ -752,7 +753,7 @@ impl NapiIdentity {
                         "{operation} requires retained crypto state — this identity was \
                          externally loaded and has no in-memory key material"
                     ),
-                    code: "SCP-IDENT-1007".to_owned(),
+                    code: codes::IDENT_1007.to_owned(),
                 })
             })?
             .clone();
@@ -767,7 +768,7 @@ impl NapiIdentity {
                         "{operation} requires in-memory custody — this identity uses \
                          external custody"
                     ),
-                    code: "SCP-IDENT-1007".to_owned(),
+                    code: codes::IDENT_1007.to_owned(),
                 })
             })?
             .clone();
@@ -782,7 +783,7 @@ impl NapiIdentity {
                         "{operation} requires a retained DID document — this identity \
                          was externally loaded"
                     ),
-                    code: "SCP-IDENT-1007".to_owned(),
+                    code: codes::IDENT_1007.to_owned(),
                 })
             })?
             .clone();
@@ -951,7 +952,7 @@ pub async fn identity_create(custody: String) -> napi::Result<NapiIdentity> {
             message:
                 "in_memory custody is not available in this build -- enable allow_in_memory_custody"
                     .to_owned(),
-            code: "SCP-IDENT-1008".to_owned(),
+            code: codes::IDENT_1008.to_owned(),
         }
         .into()),
         "platform" | "software" => Err(ScpNapiError::Identity {
@@ -961,11 +962,11 @@ pub async fn identity_create(custody: String) -> napi::Result<NapiIdentity> {
                  interface to inject Secure Enclave (iOS) or Android \
                  Keystore (Android) backed custody"
             ),
-            code: "SCP-IDENT-1003".to_owned(),
+            code: codes::IDENT_1003.to_owned(),
         }
         .into()),
         _ => Err(ScpNapiError::Identity {
-            code: "SCP-IDENT-1005".to_owned(),
+            code: codes::IDENT_1005.to_owned(),
             message: format!(
                 "internal: unexpected custody type {custody:?} passed validate_custody_type — \
                  this is a bug in the bridge layer"
@@ -1046,7 +1047,7 @@ pub async fn identity_create_with_agent_key(custody: String) -> napi::Result<Nap
             message:
                 "in_memory custody is not available in this build -- enable allow_in_memory_custody"
                     .to_owned(),
-            code: "SCP-IDENT-1008".to_owned(),
+            code: codes::IDENT_1008.to_owned(),
         }
         .into()),
         "platform" | "software" => Err(ScpNapiError::Identity {
@@ -1056,11 +1057,11 @@ pub async fn identity_create_with_agent_key(custody: String) -> napi::Result<Nap
                  interface to inject Secure Enclave (iOS) or Android \
                  Keystore (Android) backed custody"
             ),
-            code: "SCP-IDENT-1003".to_owned(),
+            code: codes::IDENT_1003.to_owned(),
         }
         .into()),
         _ => Err(ScpNapiError::Identity {
-            code: "SCP-IDENT-1005".to_owned(),
+            code: codes::IDENT_1005.to_owned(),
             message: format!(
                 "internal: unexpected custody type {custody:?} passed validate_custody_type — \
                  this is a bug in the bridge layer"
@@ -1097,7 +1098,7 @@ pub async fn identity_load(did: String) -> napi::Result<NapiIdentity> {
     if !did.starts_with("did:dht:") {
         return Err(ScpNapiError::Identity {
             message: format!("unsupported DID method: {did} — only did:dht is supported"),
-            code: "SCP-IDENT-1004".to_owned(),
+            code: codes::IDENT_1004.to_owned(),
         }
         .into());
     }
@@ -1175,7 +1176,7 @@ pub async fn identity_resolve(did: String) -> napi::Result<NapiDIDDocument> {
     if !did.starts_with("did:dht:") {
         return Err(ScpNapiError::Identity {
             message: format!("unsupported DID method: {did} — only did:dht is supported"),
-            code: "SCP-IDENT-1004".to_owned(),
+            code: codes::IDENT_1004.to_owned(),
         }
         .into());
     }
@@ -1304,7 +1305,7 @@ pub async fn identity_attest_device(did: String) -> napi::Result<String> {
     let token = attestation.attest().await.map_err(|e| {
         NapiError::from(ScpNapiError::Identity {
             message: format!("device attestation failed: {e}"),
-            code: "SCP-IDENT-1010".to_owned(),
+            code: codes::IDENT_1010.to_owned(),
         })
     })?;
 
@@ -1355,7 +1356,7 @@ pub async fn identity_verify_device_attestation(
         .map_err(|e| {
             NapiError::from(ScpNapiError::Identity {
                 message: format!("invalid base64 attestation token: {e}"),
-                code: "SCP-IDENT-1011".to_owned(),
+                code: codes::IDENT_1011.to_owned(),
             })
         })?;
 
@@ -1365,7 +1366,7 @@ pub async fn identity_verify_device_attestation(
     attestation.verify(&token).await.map_err(|e| {
         NapiError::from(ScpNapiError::Identity {
             message: format!("device attestation verification failed: {e}"),
-            code: "SCP-IDENT-1012".to_owned(),
+            code: codes::IDENT_1012.to_owned(),
         })
     })
 }
@@ -1405,7 +1406,7 @@ pub async fn identity_create_link_attestation(
     let method: VerificationMethod = verification_method.parse().map_err(|e: String| {
         NapiError::from(ScpNapiError::Identity {
             message: e,
-            code: "SCP-IDENT-1040".to_owned(),
+            code: codes::IDENT_1040.to_owned(),
         })
     })?;
 
@@ -1426,7 +1427,7 @@ pub async fn identity_create_link_attestation(
         .map_err(|_| {
             NapiError::from(ScpNapiError::Identity {
                 message: "system clock is before UNIX epoch".to_owned(),
-                code: "SCP-IDENT-1042".to_owned(),
+                code: codes::IDENT_1042.to_owned(),
             })
         })?
         .as_secs();
@@ -1463,14 +1464,14 @@ pub async fn identity_create_link_attestation(
                     .collect::<Vec<_>>()
                     .join("; "),
             ),
-            code: "SCP-IDENT-1041".to_owned(),
+            code: codes::IDENT_1041.to_owned(),
         }));
     }
 
     let canonical = attestation.canonical_signing_bytes().map_err(|e| {
         NapiError::from(ScpNapiError::Identity {
             message: format!("attestation signing failed: {e}"),
-            code: "SCP-IDENT-1041".to_owned(),
+            code: codes::IDENT_1041.to_owned(),
         })
     })?;
 
@@ -1478,7 +1479,7 @@ pub async fn identity_create_link_attestation(
     let rt = tokio::runtime::Handle::try_current().map_err(|e| {
         NapiError::from(ScpNapiError::Identity {
             message: format!("no tokio runtime: {e}"),
-            code: "SCP-IDENT-1041".to_owned(),
+            code: codes::IDENT_1041.to_owned(),
         })
     })?;
 
@@ -1486,7 +1487,7 @@ pub async fn identity_create_link_attestation(
         .map_err(|e| {
             NapiError::from(ScpNapiError::Identity {
                 message: format!("Ed25519 signing failed: {e}"),
-                code: "SCP-IDENT-1041".to_owned(),
+                code: codes::IDENT_1041.to_owned(),
             })
         })?;
     attestation.signature = sig.as_bytes().to_vec();
@@ -1499,7 +1500,7 @@ pub async fn identity_create_link_attestation(
                 message: "active signing key was rotated during attestation creation — \
                          please retry"
                     .to_owned(),
-                code: "SCP-IDENT-1041".to_owned(),
+                code: codes::IDENT_1041.to_owned(),
             });
         }
 
@@ -1509,7 +1510,7 @@ pub async fn identity_create_link_attestation(
                     "DID has reached the per-identity attestation limit \
                      ({MAX_IDENTITY_LINK_ATTESTATIONS_PER_DID}) — cannot store additional attestations"
                 ),
-                code: "SCP-VALID-7403".to_owned(),
+                code: codes::VALID_7403.to_owned(),
             });
         }
         entry.identity_link_attestations.push(attestation.clone());
@@ -1520,7 +1521,7 @@ pub async fn identity_create_link_attestation(
     serde_json::to_string(&attestation).map_err(|e| {
         NapiError::from(ScpNapiError::Identity {
             message: format!("failed to serialize attestation: {e}"),
-            code: "SCP-IDENT-1042".to_owned(),
+            code: codes::IDENT_1042.to_owned(),
         })
     })
 }
@@ -1535,7 +1536,7 @@ pub fn identity_link_attestations(did: String) -> napi::Result<String> {
         serde_json::to_string(&entry.identity_link_attestations).map_err(|e| {
             ScpNapiError::Identity {
                 message: format!("failed to serialize attestations: {e}"),
-                code: "SCP-IDENT-1043".to_owned(),
+                code: codes::IDENT_1043.to_owned(),
             }
         })
     })
@@ -1579,14 +1580,14 @@ pub async fn identity_verify_link_attestation(
         serde_json::from_str(&attestation_json).map_err(|e| {
             NapiError::from(ScpNapiError::Identity {
                 message: format!("failed to parse attestation JSON: {e}"),
-                code: "SCP-IDENT-1044".to_owned(),
+                code: codes::IDENT_1044.to_owned(),
             })
         })?;
 
     let pub_bytes = hex::decode(&issuer_public_key_hex).map_err(|e| {
         NapiError::from(ScpNapiError::Identity {
             message: format!("invalid issuer_public_key_hex: {e}"),
-            code: "SCP-IDENT-1044".to_owned(),
+            code: codes::IDENT_1044.to_owned(),
         })
     })?;
     Ok(attestation.verify_signature(&pub_bytes).is_ok())
@@ -1629,7 +1630,7 @@ pub fn identity_execute_recovery(
                 message: format!(
                     "invalid compromise tier: {other}; expected 'agent', 'active_signing', or 'identity_key'"
                 ),
-                code: "SCP-IDENT-1020".to_owned(),
+                code: codes::IDENT_1020.to_owned(),
             }));
         }
     };
@@ -1690,7 +1691,7 @@ pub fn identity_execute_recovery(
     let handle = tokio::runtime::Handle::try_current().map_err(|e| {
         NapiError::from(ScpNapiError::Identity {
             message: format!("tokio runtime not available: {e}"),
-            code: "SCP-IDENT-1027".to_owned(),
+            code: codes::IDENT_1027.to_owned(),
         })
     })?;
 
@@ -1706,14 +1707,14 @@ pub fn identity_execute_recovery(
         .map_err(|e| {
             NapiError::from(ScpNapiError::Identity {
                 message: format!("recovery failed: {e}"),
-                code: "SCP-IDENT-1022".to_owned(),
+                code: codes::IDENT_1022.to_owned(),
             })
         })?;
 
     serde_json::to_string(&result).map_err(|e| {
         NapiError::from(ScpNapiError::Identity {
             message: format!("failed to serialize recovery result: {e}"),
-            code: "SCP-IDENT-1023".to_owned(),
+            code: codes::IDENT_1023.to_owned(),
         })
     })
 }
@@ -1753,7 +1754,7 @@ pub fn identity_execute_custody_migration(
                 message: format!(
                     "invalid custody migration target: {other}; expected 'platform_managed', 'hardware', 'software', or 'in_memory'"
                 ),
-                code: "SCP-IDENT-1024".to_owned(),
+                code: codes::IDENT_1024.to_owned(),
             }));
         }
     };
@@ -1810,7 +1811,7 @@ pub fn identity_execute_custody_migration(
     let handle = tokio::runtime::Handle::try_current().map_err(|e| {
         NapiError::from(ScpNapiError::Identity {
             message: format!("tokio runtime not available: {e}"),
-            code: "SCP-IDENT-1028".to_owned(),
+            code: codes::IDENT_1028.to_owned(),
         })
     })?;
 
@@ -1819,14 +1820,14 @@ pub fn identity_execute_custody_migration(
         .map_err(|e| {
             NapiError::from(ScpNapiError::Identity {
                 message: format!("custody migration failed: {e}"),
-                code: "SCP-IDENT-1025".to_owned(),
+                code: codes::IDENT_1025.to_owned(),
             })
         })?;
 
     serde_json::to_string(&result).map_err(|e| {
         NapiError::from(ScpNapiError::Identity {
             message: format!("failed to serialize custody migration result: {e}"),
-            code: "SCP-IDENT-1026".to_owned(),
+            code: codes::IDENT_1026.to_owned(),
         })
     })
 }
@@ -1840,6 +1841,7 @@ pub fn identity_execute_custody_migration(
 #[allow(clippy::expect_used, clippy::panic)]
 mod tests {
     use super::*;
+    use scp_ffi_common::error_codes as codes;
 
     /// Creates a test `NapiIdentity` with in-memory custody, returning the
     /// identity and its initial active signing key's public key (multibase).
@@ -2019,7 +2021,7 @@ mod tests {
 
         let msg = err.to_string();
         assert!(
-            msg.contains("SCP-IDENT-1007"),
+            msg.contains(codes::IDENT_1007),
             "error must contain SCP-IDENT-1007, got: {msg}"
         );
     }
@@ -2310,7 +2312,7 @@ mod tests {
 
         let msg = err.to_string();
         assert!(
-            msg.contains("SCP-IDENT-1007"),
+            msg.contains(codes::IDENT_1007),
             "error must contain SCP-IDENT-1007, got: {msg}"
         );
     }

--- a/crates/scp-ffi/napi/src/mcp.rs
+++ b/crates/scp-ffi/napi/src/mcp.rs
@@ -15,6 +15,7 @@
 //!
 //! See ADR-015 in `.docs/adrs/phase-3.md`.
 
+use scp_ffi_common::error_codes as codes;
 use std::io::{BufRead, BufReader, Write};
 use std::process::{Command, Stdio};
 use std::sync::{Arc, Mutex, OnceLock};
@@ -479,7 +480,7 @@ pub async fn mcp_server_create(config: NapiMcpServerConfig) -> napi::Result<Napi
                 "unsupported MCP transport: {:?} — expected \"stdio\" or \"sse\"",
                 config.transport
             ),
-            code: "SCP-TRANS-5010".to_owned(),
+            code: codes::TRANS_5010.to_owned(),
         }
         .into());
     }
@@ -487,7 +488,7 @@ pub async fn mcp_server_create(config: NapiMcpServerConfig) -> napi::Result<Napi
     if config.context_ids.is_empty() {
         return Err(ScpNapiError::Transport {
             message: "context_ids must not be empty".to_owned(),
-            code: "SCP-TRANS-5011".to_owned(),
+            code: codes::TRANS_5011.to_owned(),
         }
         .into());
     }
@@ -554,14 +555,14 @@ pub async fn mcp_server_stop(handle: &NapiMcpServerHandle) -> napi::Result<()> {
         .ok_or_else(|| {
             napi::Error::from(ScpNapiError::Transport {
                 message: format!("MCP server handle '{}' not found", handle.handle_id),
-                code: "SCP-TRANS-5012".to_owned(),
+                code: codes::TRANS_5012.to_owned(),
             })
         })?;
 
     if entry.stopped {
         return Err(ScpNapiError::Transport {
             message: format!("MCP server '{}' is already stopped", handle.handle_id),
-            code: "SCP-TRANS-5013".to_owned(),
+            code: codes::TRANS_5013.to_owned(),
         }
         .into());
     }
@@ -590,7 +591,7 @@ pub async fn mcp_client_connect_stdio(command: Vec<String>) -> napi::Result<Napi
     if command.is_empty() {
         return Err(ScpNapiError::Transport {
             message: "command must be a non-empty list".to_owned(),
-            code: "SCP-TRANS-5014".to_owned(),
+            code: codes::TRANS_5014.to_owned(),
         }
         .into());
     }
@@ -598,7 +599,7 @@ pub async fn mcp_client_connect_stdio(command: Vec<String>) -> napi::Result<Napi
     let transport = StdioMcpTransport::spawn(&command).map_err(|e| {
         napi::Error::from(ScpNapiError::Transport {
             message: format!("failed to connect stdio MCP client: {e}"),
-            code: "SCP-TRANS-5015".to_owned(),
+            code: codes::TRANS_5015.to_owned(),
         })
     })?;
 
@@ -606,7 +607,7 @@ pub async fn mcp_client_connect_stdio(command: Vec<String>) -> napi::Result<Napi
     client.initialize().map_err(|e| {
         napi::Error::from(ScpNapiError::Transport {
             message: format!("MCP initialize handshake failed: {e}"),
-            code: "SCP-TRANS-5016".to_owned(),
+            code: codes::TRANS_5016.to_owned(),
         })
     })?;
 
@@ -631,7 +632,7 @@ pub async fn mcp_client_connect_sse(url: String) -> napi::Result<NapiMcpClientHa
     client.initialize().map_err(|e| {
         napi::Error::from(ScpNapiError::Transport {
             message: format!("MCP initialize handshake failed: {e}"),
-            code: "SCP-TRANS-5018".to_owned(),
+            code: codes::TRANS_5018.to_owned(),
         })
     })?;
 
@@ -654,7 +655,7 @@ pub async fn mcp_client_disconnect(handle: &NapiMcpClientHandle) -> napi::Result
     if removed.is_none() {
         return Err(ScpNapiError::Transport {
             message: format!("MCP client handle '{}' not found", handle.handle_id),
-            code: "SCP-TRANS-5019".to_owned(),
+            code: codes::TRANS_5019.to_owned(),
         }
         .into());
     }
@@ -672,21 +673,21 @@ pub async fn mcp_client_list_tools(
         .ok_or_else(|| {
             napi::Error::from(ScpNapiError::Transport {
                 message: format!("MCP client handle '{}' not found", handle.handle_id),
-                code: "SCP-TRANS-5020".to_owned(),
+                code: codes::TRANS_5020.to_owned(),
             })
         })?;
 
     let client_guard = entry.client.lock().map_err(|e| {
         napi::Error::from(ScpNapiError::Transport {
             message: format!("client lock poisoned: {e}"),
-            code: "SCP-TRANS-5021".to_owned(),
+            code: codes::TRANS_5021.to_owned(),
         })
     })?;
 
     let tools = client_guard.list_tools().map_err(|e| {
         napi::Error::from(ScpNapiError::Transport {
             message: format!("tools/list failed: {e}"),
-            code: "SCP-TRANS-5022".to_owned(),
+            code: codes::TRANS_5022.to_owned(),
         })
     })?;
 
@@ -717,21 +718,21 @@ pub async fn mcp_client_invoke(
         .ok_or_else(|| {
             napi::Error::from(ScpNapiError::Transport {
                 message: format!("MCP client handle '{}' not found", handle.handle_id),
-                code: "SCP-TRANS-5023".to_owned(),
+                code: codes::TRANS_5023.to_owned(),
             })
         })?;
 
     let input: serde_json::Value = serde_json::from_str(&input_json).map_err(|e| {
         napi::Error::from(ScpNapiError::Transport {
             message: format!("invalid input JSON: {e}"),
-            code: "SCP-VALID-7021".to_owned(),
+            code: codes::VALID_7021.to_owned(),
         })
     })?;
 
     let client_guard = entry.client.lock().map_err(|e| {
         napi::Error::from(ScpNapiError::Transport {
             message: format!("client lock poisoned: {e}"),
-            code: "SCP-TRANS-5024".to_owned(),
+            code: codes::TRANS_5024.to_owned(),
         })
     })?;
 
@@ -740,7 +741,7 @@ pub async fn mcp_client_invoke(
         .map_err(|e| {
             napi::Error::from(ScpNapiError::Transport {
                 message: format!("tools/call failed: {e}"),
-                code: "SCP-TRANS-5025".to_owned(),
+                code: codes::TRANS_5025.to_owned(),
             })
         })?;
 
@@ -780,12 +781,12 @@ fn allowlist_err(e: allowlist::AllowlistError) -> ScpNapiError {
         | AllowlistError::PathInCommand(_)
         | AllowlistError::InvalidCommand(_) => ScpNapiError::Validation {
             message: msg,
-            code: "SCP-VALID-7033".to_owned(),
+            code: codes::VALID_7033.to_owned(),
         },
         AllowlistError::NotAllowed { .. } | AllowlistError::LockPoisoned => {
             ScpNapiError::Transport {
                 message: msg,
-                code: "SCP-TRANS-5030".to_owned(),
+                code: codes::TRANS_5030.to_owned(),
             }
         }
     }

--- a/crates/scp-ffi/napi/src/media.rs
+++ b/crates/scp-ffi/napi/src/media.rs
@@ -11,6 +11,7 @@
 //! See ADR-024 in `.docs/adrs/phase-5.md`.
 
 use napi_derive::napi;
+use scp_ffi_common::error_codes as codes;
 
 use scp_media::session::{
     MediaCapability, MediaSession, MediaSessionState, activate_session, check_media_capability,
@@ -36,7 +37,7 @@ fn parse_media_capability(s: &str) -> napi::Result<MediaCapability> {
             message: format!(
                 "invalid media capability '{other}': expected 'voice', 'video', or 'screen_share'"
             ),
-            code: "SCP-VALID-7300".to_owned(),
+            code: codes::VALID_7300.to_owned(),
         }
         .into()),
     }
@@ -61,7 +62,7 @@ const fn state_to_string(state: &MediaSessionState) -> &'static str {
 fn media_error_to_napi(e: scp_media::keys::MediaError) -> napi::Error {
     ScpNapiError::Context {
         message: e.to_string(),
-        code: "SCP-CTX-2500".to_owned(),
+        code: codes::CTX_2500.to_owned(),
     }
     .into()
 }
@@ -78,7 +79,7 @@ fn session_to_json(session: &MediaSession) -> napi::Result<String> {
     .map_err(|e| {
         napi::Error::from(ScpNapiError::Validation {
             message: format!("failed to serialize session: {e}"),
-            code: "SCP-VALID-7301".to_owned(),
+            code: codes::VALID_7301.to_owned(),
         })
     })
 }
@@ -149,7 +150,7 @@ pub fn media_activate_session(session_json: String) -> napi::Result<String> {
     let mut session: MediaSession = serde_json::from_str(&session_json).map_err(|e| {
         napi::Error::from(ScpNapiError::Validation {
             message: format!("invalid session JSON: {e}"),
-            code: "SCP-VALID-7301".to_owned(),
+            code: codes::VALID_7301.to_owned(),
         })
     })?;
 
@@ -165,7 +166,7 @@ pub fn media_join_session(session_json: String, participant_did: String) -> napi
     let mut session: MediaSession = serde_json::from_str(&session_json).map_err(|e| {
         napi::Error::from(ScpNapiError::Validation {
             message: format!("invalid session JSON: {e}"),
-            code: "SCP-VALID-7301".to_owned(),
+            code: codes::VALID_7301.to_owned(),
         })
     })?;
 
@@ -181,7 +182,7 @@ pub fn media_end_session(session_json: String, timestamp: f64) -> napi::Result<S
     let mut session: MediaSession = serde_json::from_str(&session_json).map_err(|e| {
         napi::Error::from(ScpNapiError::Validation {
             message: format!("invalid session JSON: {e}"),
-            code: "SCP-VALID-7301".to_owned(),
+            code: codes::VALID_7301.to_owned(),
         })
     })?;
 
@@ -211,7 +212,7 @@ pub fn media_end_session(session_json: String, timestamp: f64) -> napi::Result<S
     .map_err(|e| {
         napi::Error::from(ScpNapiError::Validation {
             message: format!("failed to serialize result: {e}"),
-            code: "SCP-VALID-7301".to_owned(),
+            code: codes::VALID_7301.to_owned(),
         })
     })
 }
@@ -233,13 +234,13 @@ pub fn media_create_offer(
     let msg_json = String::from_utf8(serialize_signaling(&msg).map_err(|e| {
         napi::Error::from(ScpNapiError::Validation {
             message: format!("failed to serialize signaling: {e}"),
-            code: "SCP-VALID-7302".to_owned(),
+            code: codes::VALID_7302.to_owned(),
         })
     })?)
     .map_err(|e| {
         napi::Error::from(ScpNapiError::Validation {
             message: format!("signaling bytes are not valid UTF-8: {e}"),
-            code: "SCP-VALID-7302".to_owned(),
+            code: codes::VALID_7302.to_owned(),
         })
     })?;
 
@@ -250,7 +251,7 @@ pub fn media_create_offer(
     .map_err(|e| {
         napi::Error::from(ScpNapiError::Validation {
             message: format!("failed to serialize result: {e}"),
-            code: "SCP-VALID-7302".to_owned(),
+            code: codes::VALID_7302.to_owned(),
         })
     })
 }
@@ -268,13 +269,13 @@ pub fn media_create_answer(
     let msg_json = String::from_utf8(serialize_signaling(&msg).map_err(|e| {
         napi::Error::from(ScpNapiError::Validation {
             message: format!("failed to serialize signaling: {e}"),
-            code: "SCP-VALID-7302".to_owned(),
+            code: codes::VALID_7302.to_owned(),
         })
     })?)
     .map_err(|e| {
         napi::Error::from(ScpNapiError::Validation {
             message: format!("signaling bytes are not valid UTF-8: {e}"),
-            code: "SCP-VALID-7302".to_owned(),
+            code: codes::VALID_7302.to_owned(),
         })
     })?;
 
@@ -285,7 +286,7 @@ pub fn media_create_answer(
     .map_err(|e| {
         napi::Error::from(ScpNapiError::Validation {
             message: format!("failed to serialize result: {e}"),
-            code: "SCP-VALID-7302".to_owned(),
+            code: codes::VALID_7302.to_owned(),
         })
     })
 }
@@ -314,13 +315,13 @@ pub fn media_create_ice_candidate(
     let msg_json = String::from_utf8(serialize_signaling(&msg).map_err(|e| {
         napi::Error::from(ScpNapiError::Validation {
             message: format!("failed to serialize signaling: {e}"),
-            code: "SCP-VALID-7302".to_owned(),
+            code: codes::VALID_7302.to_owned(),
         })
     })?)
     .map_err(|e| {
         napi::Error::from(ScpNapiError::Validation {
             message: format!("signaling bytes are not valid UTF-8: {e}"),
-            code: "SCP-VALID-7302".to_owned(),
+            code: codes::VALID_7302.to_owned(),
         })
     })?;
 
@@ -331,7 +332,7 @@ pub fn media_create_ice_candidate(
     .map_err(|e| {
         napi::Error::from(ScpNapiError::Validation {
             message: format!("failed to serialize result: {e}"),
-            code: "SCP-VALID-7302".to_owned(),
+            code: codes::VALID_7302.to_owned(),
         })
     })
 }
@@ -345,13 +346,13 @@ pub fn media_create_session_end(session_id: String, sender_did: String) -> napi:
     let msg_json = String::from_utf8(serialize_signaling(&msg).map_err(|e| {
         napi::Error::from(ScpNapiError::Validation {
             message: format!("failed to serialize signaling: {e}"),
-            code: "SCP-VALID-7302".to_owned(),
+            code: codes::VALID_7302.to_owned(),
         })
     })?)
     .map_err(|e| {
         napi::Error::from(ScpNapiError::Validation {
             message: format!("signaling bytes are not valid UTF-8: {e}"),
-            code: "SCP-VALID-7302".to_owned(),
+            code: codes::VALID_7302.to_owned(),
         })
     })?;
 
@@ -362,7 +363,7 @@ pub fn media_create_session_end(session_id: String, sender_did: String) -> napi:
     .map_err(|e| {
         napi::Error::from(ScpNapiError::Validation {
             message: format!("failed to serialize result: {e}"),
-            code: "SCP-VALID-7302".to_owned(),
+            code: codes::VALID_7302.to_owned(),
         })
     })
 }
@@ -375,13 +376,13 @@ pub fn media_send_signaling(signaling_json: String) -> napi::Result<String> {
     let msg = deserialize_signaling(signaling_json.as_bytes()).map_err(|e| {
         napi::Error::from(ScpNapiError::Validation {
             message: format!("invalid signaling JSON: {e}"),
-            code: "SCP-VALID-7303".to_owned(),
+            code: codes::VALID_7303.to_owned(),
         })
     })?;
     let (payload, message_type) = send_signaling(&msg).map_err(|e| {
         napi::Error::from(ScpNapiError::Validation {
             message: format!("failed to serialize signaling: {e}"),
-            code: "SCP-VALID-7302".to_owned(),
+            code: codes::VALID_7302.to_owned(),
         })
     })?;
 
@@ -393,7 +394,7 @@ pub fn media_send_signaling(signaling_json: String) -> napi::Result<String> {
     .map_err(|e| {
         napi::Error::from(ScpNapiError::Validation {
             message: format!("failed to serialize result: {e}"),
-            code: "SCP-VALID-7302".to_owned(),
+            code: codes::VALID_7302.to_owned(),
         })
     })
 }
@@ -409,13 +410,13 @@ pub fn media_verify_sender_attribution(
     let msg = deserialize_signaling(signaling_json.as_bytes()).map_err(|e| {
         napi::Error::from(ScpNapiError::Validation {
             message: format!("invalid signaling JSON: {e}"),
-            code: "SCP-VALID-7303".to_owned(),
+            code: codes::VALID_7303.to_owned(),
         })
     })?;
     verify_sender_attribution(&msg, &envelope_sender_did).map_err(|e| {
         napi::Error::from(ScpNapiError::Context {
             message: format!("sender attribution verification failed: {e}"),
-            code: "SCP-CTX-2501".to_owned(),
+            code: codes::CTX_2501.to_owned(),
         })
     })?;
     Ok(true)

--- a/crates/scp-ffi/napi/src/provenance.rs
+++ b/crates/scp-ffi/napi/src/provenance.rs
@@ -17,6 +17,7 @@
 //! See spec section 24 (Provenance System) and ADR-019.
 
 use napi_derive::napi;
+use scp_ffi_common::error_codes as codes;
 use sha2::{Digest, Sha256};
 use zeroize::Zeroizing;
 
@@ -146,7 +147,7 @@ pub fn provenance_attach(
     let prov_json_bytes = serde_json::to_vec(&prov).map_err(|e| {
         napi::Error::from(ScpNapiError::Validation {
             message: format!("failed to serialize provenance for hashing: {e}"),
-            code: "SCP-VALID-7053".to_owned(),
+            code: codes::VALID_7053.to_owned(),
         })
     })?;
     let prov_hash: [u8; 32] = Sha256::digest(&prov_json_bytes).into();
@@ -209,7 +210,7 @@ pub fn provenance_attach(
     serde_json::to_string(&result).map_err(|e| {
         napi::Error::from(ScpNapiError::Validation {
             message: format!("failed to serialize provenance: {e}"),
-            code: "SCP-VALID-7002".to_owned(),
+            code: codes::VALID_7002.to_owned(),
         })
     })
 }
@@ -260,7 +261,7 @@ pub fn provenance_redact_counterparties(provenance_json: String) -> napi::Result
     let mut prov: DataProvenance = serde_json::from_str(&provenance_json).map_err(|e| {
         napi::Error::from(ScpNapiError::Validation {
             message: format!("invalid provenance JSON: {e}"),
-            code: "SCP-VALID-7050".to_owned(),
+            code: codes::VALID_7050.to_owned(),
         })
     })?;
 
@@ -269,7 +270,7 @@ pub fn provenance_redact_counterparties(provenance_json: String) -> napi::Result
     serde_json::to_string(&prov).map_err(|e| {
         napi::Error::from(ScpNapiError::Validation {
             message: format!("failed to serialize provenance: {e}"),
-            code: "SCP-VALID-7051".to_owned(),
+            code: codes::VALID_7051.to_owned(),
         })
     })
 }
@@ -288,14 +289,14 @@ pub fn provenance_pseudonymize_counterparties(
     let mut prov: DataProvenance = serde_json::from_str(&provenance_json).map_err(|e| {
         napi::Error::from(ScpNapiError::Validation {
             message: format!("invalid provenance JSON: {e}"),
-            code: "SCP-VALID-7050".to_owned(),
+            code: codes::VALID_7050.to_owned(),
         })
     })?;
 
     let key = Zeroizing::new(hex::decode(&pseudonym_key_hex).map_err(|e| {
         napi::Error::from(ScpNapiError::Validation {
             message: format!("invalid pseudonym_key_hex: {e}"),
-            code: "SCP-VALID-7052".to_owned(),
+            code: codes::VALID_7052.to_owned(),
         })
     })?);
 
@@ -304,7 +305,7 @@ pub fn provenance_pseudonymize_counterparties(
     serde_json::to_string(&prov).map_err(|e| {
         napi::Error::from(ScpNapiError::Validation {
             message: format!("failed to serialize provenance: {e}"),
-            code: "SCP-VALID-7051".to_owned(),
+            code: codes::VALID_7051.to_owned(),
         })
     })
 }
@@ -323,7 +324,7 @@ pub fn provenance_update_source_type(
     let mut prov: DataProvenance = serde_json::from_str(&provenance_json).map_err(|e| {
         napi::Error::from(ScpNapiError::Validation {
             message: format!("invalid provenance JSON: {e}"),
-            code: "SCP-VALID-7050".to_owned(),
+            code: codes::VALID_7050.to_owned(),
         })
     })?;
 
@@ -334,7 +335,7 @@ pub fn provenance_update_source_type(
     serde_json::to_string(&prov).map_err(|e| {
         napi::Error::from(ScpNapiError::Validation {
             message: format!("failed to serialize provenance: {e}"),
-            code: "SCP-VALID-7051".to_owned(),
+            code: codes::VALID_7051.to_owned(),
         })
     })
 }
@@ -381,7 +382,7 @@ fn append_provenance_event(
         scp_event_log::tree::append_unsigned_event(&mut state.event_log, &event).map_err(|e| {
             ScpNapiError::Context {
                 message: format!("failed to append provenance event: {e}"),
-                code: "SCP-CTX-2060".to_owned(),
+                code: codes::CTX_2060.to_owned(),
             }
         })?;
 
@@ -400,7 +401,7 @@ fn parse_source_type(s: &str) -> napi::Result<SourceType> {
             message: format!(
                 "invalid source_type '{other}': expected 'persistent', 'ephemeral', or 'summary'"
             ),
-            code: "SCP-VALID-7000".to_owned(),
+            code: codes::VALID_7000.to_owned(),
         }
         .into()),
     }
@@ -423,7 +424,7 @@ fn parse_context_state(s: &str) -> napi::Result<SourceContextState> {
                  'closed_with_summary_verified', 'closed_with_summary_unverified', \
                  'closed_ephemeral', or 'unknown'"
             ),
-            code: "SCP-VALID-7000".to_owned(),
+            code: codes::VALID_7000.to_owned(),
         }
         .into()),
     }
@@ -438,7 +439,7 @@ fn parse_memory_scope(s: &str) -> napi::Result<MemoryScope> {
             message: format!(
                 "invalid memory_scope '{other}': expected 'full', 'summary', or 'ephemeral'"
             ),
-            code: "SCP-VALID-7001".to_owned(),
+            code: codes::VALID_7001.to_owned(),
         }
         .into()),
     }
@@ -466,7 +467,7 @@ fn parse_discovery_method(s: Option<&str>) -> napi::Result<DiscoveryMethod> {
                     message:
                         "invalid discovery_method 'shared_context:': context ID must not be empty"
                             .to_owned(),
-                    code: "SCP-VALID-7216".to_owned(),
+                    code: codes::VALID_7216.to_owned(),
                 }
                 .into());
             }
@@ -478,7 +479,7 @@ fn parse_discovery_method(s: Option<&str>) -> napi::Result<DiscoveryMethod> {
                 return Err(ScpNapiError::Validation {
                     message: "invalid discovery_method 'registry:': context ID must not be empty"
                         .to_owned(),
-                    code: "SCP-VALID-7216".to_owned(),
+                    code: codes::VALID_7216.to_owned(),
                 }
                 .into());
             }
@@ -489,7 +490,7 @@ fn parse_discovery_method(s: Option<&str>) -> napi::Result<DiscoveryMethod> {
                 "invalid discovery_method '{other}': expected 'OutOfBand', 'out_of_band', \
                  'none', 'shared_context:<context_id>', or 'registry:<context_id>'"
             ),
-            code: "SCP-VALID-7216".to_owned(),
+            code: codes::VALID_7216.to_owned(),
         }
         .into()),
     }
@@ -511,7 +512,7 @@ fn parse_counterparty_policy(
                 "invalid counterparty_policy '{other}': expected 'full', \
                  'pseudonymized', or 'redacted'"
             ),
-            code: "SCP-VALID-7004".to_owned(),
+            code: codes::VALID_7004.to_owned(),
         }
         .into()),
     }

--- a/crates/scp-ffi/napi/src/runtime.rs
+++ b/crates/scp-ffi/napi/src/runtime.rs
@@ -18,6 +18,7 @@
 //!
 //! See issue #388 and `.docs/adrs/phase-4.md` (ADR-022).
 
+use scp_ffi_common::error_codes as codes;
 use std::collections::{HashMap, HashSet};
 use std::future::Future;
 use std::sync::{Arc, OnceLock};
@@ -136,7 +137,7 @@ pub fn context_manager() -> napi::Result<&'static Arc<ContextManager>> {
             message: "ContextManager not initialized — call context_create, \
                       context_join, context_import, or init_context_manager first"
                 .to_owned(),
-            code: "SCP-CTX-2000".to_owned(),
+            code: codes::CTX_2000.to_owned(),
         })
     })
 }
@@ -617,7 +618,7 @@ where
                 "identity '{did}' not found in registry — was it created with \
                  identityCreate(\"in_memory\") in this process?"
             ),
-            code: "SCP-PERM-3023".to_owned(),
+            code: codes::PERM_3023.to_owned(),
         })?;
 
     f(entry.value())
@@ -642,7 +643,7 @@ where
                 "identity '{did}' not found in registry — was it created with \
                  identityCreate(\"in_memory\") in this process?"
             ),
-            code: "SCP-PERM-3023".to_owned(),
+            code: codes::PERM_3023.to_owned(),
         })?;
 
     f(entry.value_mut())
@@ -743,7 +744,7 @@ pub fn ensure_registered(handle: &NapiContextHandle) -> Result<(), ScpNapiError>
         Err(e) => {
             return Err(ScpNapiError::Context {
                 message: format!("failed to create role state: {e}"),
-                code: "SCP-CTX-2023".to_owned(),
+                code: codes::CTX_2023.to_owned(),
             });
         }
     };
@@ -782,7 +783,7 @@ where
                 "context '{context_id}' not found in UCAN state registry \
              -- call a UCAN or event log function with the context handle first"
             ),
-            code: "SCP-CTX-2023".to_owned(),
+            code: codes::CTX_2023.to_owned(),
         })?;
 
     f(entry.value_mut())
@@ -809,14 +810,14 @@ pub fn remove_context(context_id: &str) {
 pub async fn sync_role_state_from_manager(context_id: &str) -> Result<(), ScpNapiError> {
     let mgr = CONTEXT_MANAGER.get().ok_or_else(|| ScpNapiError::Context {
         message: "ContextManager not initialized — call context_create first".to_owned(),
-        code: "SCP-CTX-2000".to_owned(),
+        code: codes::CTX_2000.to_owned(),
     })?;
     let new_role_state =
         mgr.get_role_state(context_id)
             .await
             .ok_or_else(|| ScpNapiError::Context {
                 message: format!("context '{context_id}' not found in ContextManager"),
-                code: "SCP-CTX-2023".to_owned(),
+                code: codes::CTX_2023.to_owned(),
             })?;
 
     with_context(context_id, |st| {
@@ -846,7 +847,7 @@ pub fn register_tool_handler(
                     "tool '{tool_id}' not found in context '{context_id}' \
                      -- register the tool before adding a handler"
                 ),
-                code: "SCP-CTX-2023".to_owned(),
+                code: codes::CTX_2023.to_owned(),
             });
         }
         st.tool_handlers.insert(tool_id.to_owned(), handler);

--- a/crates/scp-ffi/napi/src/scpid.rs
+++ b/crates/scp-ffi/napi/src/scpid.rs
@@ -8,6 +8,7 @@
 //!
 //! See spec §3.11 and the `scp-core` `scpid` module.
 
+use scp_ffi_common::error_codes as codes;
 use std::time::Duration;
 
 use napi_derive::napi;
@@ -43,13 +44,13 @@ pub fn scpid_challenge(audience: String, ttl_seconds: u32) -> napi::Result<Strin
     let challenge = core_challenge(&audience, Duration::from_secs(u64::from(ttl_seconds)))
         .map_err(|e| ScpNapiError::Validation {
             message: e.to_string(),
-            code: "SCP-IDENT-1038".to_owned(),
+            code: codes::IDENT_1038.to_owned(),
         })?;
 
     serde_json::to_string(&challenge).map_err(|e| {
         napi::Error::from(ScpNapiError::Identity {
             message: format!("failed to serialize SCPID challenge: {e}"),
-            code: "SCP-IDENT-1037".to_owned(),
+            code: codes::IDENT_1037.to_owned(),
         })
     })
 }
@@ -77,7 +78,7 @@ pub fn scpid_sign(
     let challenge: ScpIdChallenge =
         serde_json::from_str(&challenge_json).map_err(|e| ScpNapiError::Validation {
             message: format!("invalid challenge JSON: {e}"),
-            code: "SCP-IDENT-1038".to_owned(),
+            code: codes::IDENT_1038.to_owned(),
         })?;
 
     Ok(crate::runtime::with_identity(&did, |entry| {
@@ -92,7 +93,7 @@ pub fn scpid_sign(
                             "identity '{did}' has no agent signing key — \
                          create one with identityAddAgentKey first"
                         ),
-                        code: "SCP-IDENT-1034".to_owned(),
+                        code: codes::IDENT_1034.to_owned(),
                     })?
             }
         };
@@ -108,12 +109,12 @@ pub fn scpid_sign(
 
         let response = response.map_err(|e| ScpNapiError::Identity {
             message: e.to_string(),
-            code: "SCP-IDENT-1037".to_owned(),
+            code: codes::IDENT_1037.to_owned(),
         })?;
 
         serde_json::to_string(&response).map_err(|e| ScpNapiError::Identity {
             message: format!("failed to serialize SCPID response: {e}"),
-            code: "SCP-IDENT-1037".to_owned(),
+            code: codes::IDENT_1037.to_owned(),
         })
     })?)
 }
@@ -135,20 +136,20 @@ pub fn scpid_verify(response_json: String, challenge_json: String) -> napi::Resu
     let response: ScpIdResponse =
         serde_json::from_str(&response_json).map_err(|e| ScpNapiError::Validation {
             message: format!("invalid response JSON: {e}"),
-            code: "SCP-IDENT-1038".to_owned(),
+            code: codes::IDENT_1038.to_owned(),
         })?;
 
     let challenge: ScpIdChallenge =
         serde_json::from_str(&challenge_json).map_err(|e| ScpNapiError::Validation {
             message: format!("invalid challenge JSON: {e}"),
-            code: "SCP-IDENT-1038".to_owned(),
+            code: codes::IDENT_1038.to_owned(),
         })?;
 
     let resolver = crate::runtime::did_resolver().ok_or_else(|| ScpNapiError::Identity {
         message: "DID resolver not initialized — create an identity with \
                       identityCreate before calling scpidVerify"
             .to_owned(),
-        code: "SCP-IDENT-1033".to_owned(),
+        code: codes::IDENT_1033.to_owned(),
     })?;
 
     let rt = crate::runtime();
@@ -162,7 +163,7 @@ pub fn scpid_verify(response_json: String, challenge_json: String) -> napi::Resu
     serde_json::to_string(&auth).map_err(|e| {
         napi::Error::from(ScpNapiError::Identity {
             message: format!("failed to serialize SCPID authentication: {e}"),
-            code: "SCP-IDENT-1037".to_owned(),
+            code: codes::IDENT_1037.to_owned(),
         })
     })
 }
@@ -180,7 +181,7 @@ fn parse_signing_key_id(s: &str) -> napi::Result<SigningKeyId> {
         "#agent" => Ok(SigningKeyId::Agent),
         other => Err(napi::Error::from(ScpNapiError::Validation {
             message: format!("invalid signing_key_id '{other}': expected '#active' or '#agent'"),
-            code: "SCP-IDENT-1034".to_owned(),
+            code: codes::IDENT_1034.to_owned(),
         })),
     }
 }
@@ -189,15 +190,15 @@ fn parse_signing_key_id(s: &str) -> napi::Result<SigningKeyId> {
 const fn scpid_error_code(e: &scp_core::identity::ScpIdError) -> &'static str {
     use scp_core::identity::ScpIdError;
     match e {
-        ScpIdError::ChallengeExpired => "SCP-IDENT-1030",
-        ScpIdError::AudienceMismatch => "SCP-IDENT-1031",
-        ScpIdError::TimestampInvalid => "SCP-IDENT-1032",
-        ScpIdError::DidResolutionFailed(_) => "SCP-IDENT-1033",
-        ScpIdError::KeyNotAuthorized => "SCP-IDENT-1034",
-        ScpIdError::SignatureInvalid => "SCP-IDENT-1035",
-        ScpIdError::DidDocumentStale => "SCP-IDENT-1036",
-        ScpIdError::SigningFailed(_) => "SCP-IDENT-1037",
-        ScpIdError::InvalidInput(_) => "SCP-IDENT-1038",
+        ScpIdError::ChallengeExpired => codes::IDENT_1030,
+        ScpIdError::AudienceMismatch => codes::IDENT_1031,
+        ScpIdError::TimestampInvalid => codes::IDENT_1032,
+        ScpIdError::DidResolutionFailed(_) => codes::IDENT_1033,
+        ScpIdError::KeyNotAuthorized => codes::IDENT_1034,
+        ScpIdError::SignatureInvalid => codes::IDENT_1035,
+        ScpIdError::DidDocumentStale => codes::IDENT_1036,
+        ScpIdError::SigningFailed(_) => codes::IDENT_1037,
+        ScpIdError::InvalidInput(_) => codes::IDENT_1038,
     }
 }
 
@@ -209,6 +210,7 @@ const fn scpid_error_code(e: &scp_core::identity::ScpIdError) -> &'static str {
 #[allow(clippy::unwrap_used, clippy::expect_used)]
 mod tests {
     use super::*;
+    use scp_ffi_common::error_codes as codes;
     use std::sync::Arc;
 
     use scp_identity::resolver::DualLayerResolver;
@@ -267,39 +269,39 @@ mod tests {
 
         assert_eq!(
             scpid_error_code(&ScpIdError::ChallengeExpired),
-            "SCP-IDENT-1030"
+            codes::IDENT_1030
         );
         assert_eq!(
             scpid_error_code(&ScpIdError::AudienceMismatch),
-            "SCP-IDENT-1031"
+            codes::IDENT_1031
         );
         assert_eq!(
             scpid_error_code(&ScpIdError::TimestampInvalid),
-            "SCP-IDENT-1032"
+            codes::IDENT_1032
         );
         assert_eq!(
             scpid_error_code(&ScpIdError::DidResolutionFailed("test".to_owned())),
-            "SCP-IDENT-1033"
+            codes::IDENT_1033
         );
         assert_eq!(
             scpid_error_code(&ScpIdError::KeyNotAuthorized),
-            "SCP-IDENT-1034"
+            codes::IDENT_1034
         );
         assert_eq!(
             scpid_error_code(&ScpIdError::SignatureInvalid),
-            "SCP-IDENT-1035"
+            codes::IDENT_1035
         );
         assert_eq!(
             scpid_error_code(&ScpIdError::DidDocumentStale),
-            "SCP-IDENT-1036"
+            codes::IDENT_1036
         );
         assert_eq!(
             scpid_error_code(&ScpIdError::SigningFailed("test".to_owned())),
-            "SCP-IDENT-1037"
+            codes::IDENT_1037
         );
         assert_eq!(
             scpid_error_code(&ScpIdError::InvalidInput("test".to_owned())),
-            "SCP-IDENT-1038"
+            codes::IDENT_1038
         );
     }
 
@@ -311,7 +313,7 @@ mod tests {
         let err = result.unwrap_err();
         let err_str = err.to_string();
         assert!(
-            err_str.contains("SCP-IDENT-1038"),
+            err_str.contains(codes::IDENT_1038),
             "expected SCP-IDENT-1038, got: {err_str}"
         );
     }
@@ -337,7 +339,7 @@ mod tests {
         let err = result.unwrap_err();
         let err_str = err.to_string();
         assert!(
-            err_str.contains("SCP-IDENT-1038"),
+            err_str.contains(codes::IDENT_1038),
             "expected SCP-IDENT-1038, got: {err_str}"
         );
     }

--- a/crates/scp-ffi/napi/src/server.rs
+++ b/crates/scp-ffi/napi/src/server.rs
@@ -265,50 +265,17 @@ impl NapiNodeHandle {
         }
 
         // Resolve broadcast key: explicit or auto-lookup from ContextManager.
-        let (resolved_key_bytes, resolved_epoch, resolved_author_did) =
-            match (broadcast_key_hex, author_did) {
-                (Some(key_hex), Some(did)) => {
-                    let key_hex = Zeroizing::new(key_hex);
-                    let key_vec = Zeroizing::new(hex::decode(&*key_hex).map_err(|e| {
-                        NapiError::from_reason(format!("invalid broadcast_key_hex: {e}"))
-                    })?);
-                    let key_bytes: Zeroizing<[u8; 32]> =
-                        Zeroizing::new(<[u8; 32]>::try_from(key_vec.as_slice()).map_err(|_| {
-                            NapiError::from_reason(
-                                "broadcast_key_hex must be exactly 64 hex characters (32 bytes)",
-                            )
-                        })?);
-                    // Explicit key path always uses epoch 0. For rotated keys, use auto-resolve (omit both params).
-                    (key_bytes, 0u64, did)
-                }
-                (None, author_opt) => {
-                    // Auto-resolve: use provided author_did or fall back to node DID.
-                    let did = author_opt.unwrap_or_else(|| self.inner.did().to_owned());
-                    let mgr = crate::runtime::context_manager()?;
-                    let (key_bytes, epoch) = mgr
-                    .get_broadcast_key_for_local_author(&context_id, &did)
-                    .await
-                    .map_err(|e| {
-                        tracing::debug!(error = %e, "broadcast key auto-resolve failed");
-                        NapiError::from_reason(
-                            "broadcast key auto-resolve failed: not authorized for this context",
-                        )
-                    })?;
-                    (key_bytes, epoch, did)
-                }
-                (Some(_), None) => {
-                    return Err(NapiError::from_reason(
-                        "broadcastKeyHex requires authorDid — provide the DID of the \
-                         broadcast key owner, or omit both for auto-resolve",
-                    ));
-                }
-            };
-
-        let broadcast_key = scp_core::crypto::sender_keys::BroadcastKey::from_parts(
-            scp_core::crypto::sender_keys::SenderKey::from_bytes(*resolved_key_bytes),
-            resolved_epoch,
-            resolved_author_did,
-        );
+        let mgr = crate::runtime::context_manager()?;
+        let resolved = server::resolve_broadcast_key(
+            broadcast_key_hex,
+            author_did,
+            self.inner.did(),
+            mgr,
+            &context_id,
+        )
+        .await
+        .map_err(|e| NapiError::from_reason(e.to_string()))?;
+        let broadcast_key = resolved.into_broadcast_key();
 
         let adm = match admission.to_lowercase().as_str() {
             "open" => scp_core::context::broadcast::BroadcastAdmission::Open,

--- a/crates/scp-ffi/napi/src/sync.rs
+++ b/crates/scp-ffi/napi/src/sync.rs
@@ -9,6 +9,7 @@
 //! See ADR-029 in `.docs/adrs/phase-6.md`.
 
 use napi_derive::napi;
+use scp_ffi_common::error_codes as codes;
 
 use scp_core::sync::{OfflineTier, SyncPolicy, classify_offline_duration};
 
@@ -48,7 +49,7 @@ fn validate_non_negative_timestamp(value: i64, name: &str) -> napi::Result<u64> 
     if value < 0 {
         return Err(napi::Error::from(ScpNapiError::Validation {
             message: format!("{name} must be non-negative, got {value}"),
-            code: "SCP-VALID-7040".to_owned(),
+            code: codes::VALID_7040.to_owned(),
         }));
     }
     #[allow(clippy::cast_sign_loss)]

--- a/crates/scp-ffi/napi/src/testing.rs
+++ b/crates/scp-ffi/napi/src/testing.rs
@@ -7,6 +7,7 @@
 //! Feature-gated behind `allow_in_memory_custody` -- never compiled into
 //! production builds.
 
+use scp_ffi_common::error_codes as codes;
 use std::collections::HashMap;
 use std::sync::{Arc, Mutex};
 
@@ -123,7 +124,7 @@ pub fn fullstack_create_context(
     let ceiling_obj: serde_json::Value = serde_json::from_str(&ceiling_json).map_err(|e| {
         napi::Error::from(ScpNapiError::Validation {
             message: format!("invalid ceiling JSON: {e}"),
-            code: "SCP-VALID-7050".to_owned(),
+            code: codes::VALID_7050.to_owned(),
         })
     })?;
 
@@ -161,7 +162,7 @@ pub fn fullstack_create_context(
         .map_err(|e| {
             napi::Error::from(ScpNapiError::Context {
                 message: format!("failed to create context: {e}"),
-                code: "SCP-CTX-2050".to_owned(),
+                code: codes::CTX_2050.to_owned(),
             })
         })?;
 
@@ -199,7 +200,7 @@ pub fn fullstack_add_member(
         handles.get(&context_id).cloned().ok_or_else(|| {
             napi::Error::from(ScpNapiError::Context {
                 message: format!("context '{context_id}' not found in node's handles"),
-                code: "SCP-CTX-2051".to_owned(),
+                code: codes::CTX_2051.to_owned(),
             })
         })?
     };
@@ -208,7 +209,7 @@ pub fn fullstack_add_member(
         .map_err(|e| {
             napi::Error::from(ScpNapiError::Crypto {
                 message: format!("failed to add member: {e}"),
-                code: "SCP-CRYPTO-4050".to_owned(),
+                code: codes::CRYPTO_4050.to_owned(),
             })
         })
 }
@@ -249,7 +250,7 @@ pub fn fullstack_join_from_welcome(
         .map_err(|e| {
             napi::Error::from(ScpNapiError::Context {
                 message: format!("failed to register context on joiner: {e}"),
-                code: "SCP-CTX-2055".to_owned(),
+                code: codes::CTX_2055.to_owned(),
             })
         })?;
 
@@ -260,7 +261,7 @@ pub fn fullstack_join_from_welcome(
         .map_err(|e| {
             napi::Error::from(ScpNapiError::Crypto {
                 message: format!("failed to join from Welcome: {e}"),
-                code: "SCP-CRYPTO-4051".to_owned(),
+                code: codes::CRYPTO_4051.to_owned(),
             })
         })?;
 
@@ -272,7 +273,7 @@ pub fn fullstack_join_from_welcome(
         .map_err(|e| {
             napi::Error::from(ScpNapiError::Crypto {
                 message: format!("failed to distribute joiner sender key: {e}"),
-                code: "SCP-CRYPTO-4060".to_owned(),
+                code: codes::CRYPTO_4060.to_owned(),
             })
         })?;
 
@@ -324,7 +325,7 @@ pub fn fullstack_sync_sender_keys(
         .map_err(|e| {
             napi::Error::from(ScpNapiError::Crypto {
                 message: format!("failed to distribute sender key from A to B: {e}"),
-                code: "SCP-CRYPTO-4056".to_owned(),
+                code: codes::CRYPTO_4056.to_owned(),
             })
         })?;
     node_b
@@ -334,7 +335,7 @@ pub fn fullstack_sync_sender_keys(
         .map_err(|e| {
             napi::Error::from(ScpNapiError::Crypto {
                 message: format!("failed to distribute sender key from B to A: {e}"),
-                code: "SCP-CRYPTO-4057".to_owned(),
+                code: codes::CRYPTO_4057.to_owned(),
             })
         })?;
 
@@ -342,13 +343,13 @@ pub fn fullstack_sync_sender_keys(
     node_a.inner.pickup_sender_keys(&ctx_bytes).map_err(|e| {
         napi::Error::from(ScpNapiError::Crypto {
             message: format!("failed to pick up sender keys for A: {e}"),
-            code: "SCP-CRYPTO-4058".to_owned(),
+            code: codes::CRYPTO_4058.to_owned(),
         })
     })?;
     node_b.inner.pickup_sender_keys(&ctx_bytes).map_err(|e| {
         napi::Error::from(ScpNapiError::Crypto {
             message: format!("failed to pick up sender keys for B: {e}"),
-            code: "SCP-CRYPTO-4059".to_owned(),
+            code: codes::CRYPTO_4059.to_owned(),
         })
     })?;
 
@@ -376,7 +377,7 @@ pub fn fullstack_send_message(
         handles.get(&context_id).cloned().ok_or_else(|| {
             napi::Error::from(ScpNapiError::Context {
                 message: format!("context '{context_id}' not found in node's handles"),
-                code: "SCP-CTX-2052".to_owned(),
+                code: codes::CTX_2052.to_owned(),
             })
         })?
     };
@@ -385,7 +386,7 @@ pub fn fullstack_send_message(
         .map_err(|e| {
             napi::Error::from(ScpNapiError::Crypto {
                 message: format!("failed to send message: {e}"),
-                code: "SCP-CRYPTO-4052".to_owned(),
+                code: codes::CRYPTO_4052.to_owned(),
             })
         })?;
 
@@ -394,7 +395,7 @@ pub fn fullstack_send_message(
     if sent.is_empty() {
         return Err(napi::Error::from(ScpNapiError::Crypto {
             message: "no ciphertext captured after send".to_owned(),
-            code: "SCP-CRYPTO-4053".to_owned(),
+            code: codes::CRYPTO_4053.to_owned(),
         }));
     }
     if sent.len() > 1 {
@@ -403,7 +404,7 @@ pub fn fullstack_send_message(
                 "expected 1 ciphertext after send, got {} — send_message should produce exactly one",
                 sent.len()
             ),
-            code: "SCP-CRYPTO-4055".to_owned(),
+            code: codes::CRYPTO_4055.to_owned(),
         }));
     }
 
@@ -429,7 +430,7 @@ pub fn fullstack_decrypt_message(
         .map_err(|e| {
             napi::Error::from(ScpNapiError::Crypto {
                 message: format!("failed to decrypt message: {e}"),
-                code: "SCP-CRYPTO-4054".to_owned(),
+                code: codes::CRYPTO_4054.to_owned(),
             })
         })?;
 
@@ -456,7 +457,7 @@ pub fn fullstack_remove_member(
         handles.get(&context_id).cloned().ok_or_else(|| {
             napi::Error::from(ScpNapiError::Context {
                 message: format!("context '{context_id}' not found in node's handles"),
-                code: "SCP-CTX-2053".to_owned(),
+                code: codes::CTX_2053.to_owned(),
             })
         })?
     };
@@ -469,7 +470,7 @@ pub fn fullstack_remove_member(
     .map_err(|e| {
         napi::Error::from(ScpNapiError::Context {
             message: format!("failed to remove member: {e}"),
-            code: "SCP-CTX-2054".to_owned(),
+            code: codes::CTX_2054.to_owned(),
         })
     })?;
 

--- a/crates/scp-ffi/napi/src/tools.rs
+++ b/crates/scp-ffi/napi/src/tools.rs
@@ -9,6 +9,7 @@
 //! See ADR-022 in `.docs/adrs/phase-4.md`.
 
 use napi_derive::napi;
+use scp_ffi_common::error_codes as codes;
 use scp_ffi_common::validate::{
     validate_did, validate_tool_id, validate_tool_name, validate_ucan_token,
 };
@@ -57,7 +58,7 @@ fn validate_ucan_for_tool(
         )
         .map_err(|e| ScpNapiError::Permission {
             message: format!("UCAN authorization failed for tool '{tool_id}': {e}"),
-            code: "SCP-PERM-3001".to_owned(),
+            code: codes::PERM_3001.to_owned(),
         })
     })
 }
@@ -127,8 +128,8 @@ pub struct NapiToolVerificationResult {
 /// `SCP-VALID-7036` for `output_schema_json` when the JSON is malformed.
 fn validate_schema_json(json: &str, field_name: &str) -> napi::Result<serde_json::Value> {
     let code = match field_name {
-        "input_schema_json" => "SCP-VALID-7035",
-        _ => "SCP-VALID-7036",
+        "input_schema_json" => codes::VALID_7035,
+        _ => codes::VALID_7036,
     };
     serde_json::from_str(json).map_err(|e| {
         napi::Error::from(ScpNapiError::Validation {
@@ -151,7 +152,7 @@ fn validate_test_vectors_json(
             serde_json::from_str(s).map_err(|e| {
                 napi::Error::from(ScpNapiError::Validation {
                     message: format!("invalid test_vectors_json: {e}"),
-                    code: "SCP-VALID-7037".to_owned(),
+                    code: codes::VALID_7037.to_owned(),
                 })
             })
         },
@@ -172,7 +173,7 @@ fn validate_implementation_hash(bytes: Option<&[u8]>) -> napi::Result<[u8; 32]> 
                         "implementation_hash must be exactly 32 bytes, got {}",
                         b.len()
                     ),
-                    code: "SCP-VALID-7038".to_owned(),
+                    code: codes::VALID_7038.to_owned(),
                 })
             })
         },
@@ -218,7 +219,7 @@ pub async fn tool_register(
             message: format!(
                 "cannot register tool in context in {state_str:?} state — context must be active"
             ),
-            code: "SCP-TOOL-6003".to_owned(),
+            code: codes::TOOL_6003.to_owned(),
         }
         .into());
     }
@@ -275,7 +276,7 @@ pub async fn tool_register(
         )
         .map_err(|e| ScpNapiError::Tool {
             message: format!("tool registration failed: {e}"),
-            code: "SCP-TOOL-6001".to_owned(),
+            code: codes::TOOL_6001.to_owned(),
         })?;
         Ok(registered_id)
     })
@@ -357,7 +358,7 @@ pub async fn tool_invoke(
             message: format!(
                 "cannot invoke tool in context in {state_str:?} state — context must be active"
             ),
-            code: "SCP-TOOL-6005".to_owned(),
+            code: codes::TOOL_6005.to_owned(),
         }
         .into());
     }
@@ -372,7 +373,7 @@ pub async fn tool_invoke(
         .map_err(|e| {
             napi::Error::from(ScpNapiError::Permission {
                 message: format!("failed to build proof resolver: {e}"),
-                code: "SCP-PERM-3001".to_owned(),
+                code: codes::PERM_3001.to_owned(),
             })
         })?;
     validate_ucan_for_tool(
@@ -394,7 +395,7 @@ pub async fn tool_invoke(
         .map_err(|e| {
             napi::Error::from(ScpNapiError::Context {
                 message: format!("invalid spending UCAN: {e}"),
-                code: "SCP-ECON-12061".to_owned(),
+                code: codes::ECON_12061.to_owned(),
             })
         })?;
 
@@ -445,7 +446,7 @@ pub async fn tool_invoke(
     let input_value: serde_json::Value = serde_json::from_str(&input_json).map_err(|e| {
         napi::Error::from(ScpNapiError::Tool {
             message: format!("invalid input JSON: {e}"),
-            code: "SCP-TOOL-6002".to_owned(),
+            code: codes::TOOL_6002.to_owned(),
         })
     })?;
 
@@ -473,7 +474,7 @@ pub async fn tool_invoke(
     serde_json::to_string(&outcome.output).map_err(|e| {
         napi::Error::from(ScpNapiError::Tool {
             message: format!("failed to serialize tool output: {e}"),
-            code: "SCP-TOOL-6006".to_owned(),
+            code: codes::TOOL_6006.to_owned(),
         })
     })
 }
@@ -506,7 +507,7 @@ pub async fn tool_verify(
             message: format!(
                 "cannot verify tool in context in {state_str:?} state — context must be active"
             ),
-            code: "SCP-TOOL-6007".to_owned(),
+            code: codes::TOOL_6007.to_owned(),
         }
         .into());
     }
@@ -535,7 +536,7 @@ pub async fn tool_verify(
         )
         .map_err(|e| ScpNapiError::Tool {
             message: format!("tool verification failed: {e}"),
-            code: "SCP-TOOL-6001".to_owned(),
+            code: codes::TOOL_6001.to_owned(),
         })?;
 
         Ok(verification_result)
@@ -590,7 +591,7 @@ pub async fn tool_invoke_cross_context(
             message: format!(
                 "cannot invoke cross-context tool: source context in {source_state:?} state"
             ),
-            code: "SCP-TOOL-6010".to_owned(),
+            code: codes::TOOL_6010.to_owned(),
         }
         .into());
     }
@@ -601,7 +602,7 @@ pub async fn tool_invoke_cross_context(
             message: format!(
                 "cannot invoke cross-context tool: target context in {target_state:?} state"
             ),
-            code: "SCP-TOOL-6011".to_owned(),
+            code: codes::TOOL_6011.to_owned(),
         }
         .into());
     }
@@ -623,7 +624,7 @@ pub async fn tool_invoke_cross_context(
             message: format!(
                 "cross-context chain depth {chain_depth} exceeds maximum {max_chain_depth}"
             ),
-            code: "SCP-TOOL-6012".to_owned(),
+            code: codes::TOOL_6012.to_owned(),
         }
         .into());
     }
@@ -638,7 +639,7 @@ pub async fn tool_invoke_cross_context(
         .map_err(|e| {
             napi::Error::from(ScpNapiError::Permission {
                 message: format!("failed to build proof resolver: {e}"),
-                code: "SCP-PERM-3001".to_owned(),
+                code: codes::PERM_3001.to_owned(),
             })
         })?;
     validate_ucan_for_tool(
@@ -653,7 +654,7 @@ pub async fn tool_invoke_cross_context(
     let input_value: serde_json::Value = serde_json::from_str(&input_json).map_err(|e| {
         napi::Error::from(ScpNapiError::Tool {
             message: format!("invalid input JSON: {e}"),
-            code: "SCP-TOOL-6002".to_owned(),
+            code: codes::TOOL_6002.to_owned(),
         })
     })?;
 
@@ -665,7 +666,7 @@ pub async fn tool_invoke_cross_context(
                 message: format!(
                     "tool '{tool_id}' not found in target context '{target_context_id}'"
                 ),
-                code: "SCP-TOOL-6002".to_owned(),
+                code: codes::TOOL_6002.to_owned(),
             })?;
 
         // Validate input against the tool's input schema.
@@ -675,7 +676,7 @@ pub async fn tool_invoke_cross_context(
         )
         .map_err(|e| ScpNapiError::Tool {
             message: format!("input validation failed: {e}"),
-            code: "SCP-TOOL-6002".to_owned(),
+            code: codes::TOOL_6002.to_owned(),
         })?;
 
         // Dispatch to handler or echo mode.
@@ -683,7 +684,7 @@ pub async fn tool_invoke_cross_context(
             let handler = handler.clone();
             let out = handler(input_value.clone()).map_err(|e| ScpNapiError::Tool {
                 message: format!("cross-context tool handler for '{tool_id}' failed: {e}"),
-                code: "SCP-TOOL-6002".to_owned(),
+                code: codes::TOOL_6002.to_owned(),
             })?;
 
             scp_core::context::tools::validate_value_against_schema(
@@ -692,7 +693,7 @@ pub async fn tool_invoke_cross_context(
             )
             .map_err(|msg| ScpNapiError::Tool {
                 message: format!("output validation failed for tool '{tool_id}': {msg}"),
-                code: "SCP-TOOL-6002".to_owned(),
+                code: codes::TOOL_6002.to_owned(),
             })?;
 
             out
@@ -715,7 +716,7 @@ pub async fn tool_invoke_cross_context(
     serde_json::to_string(&output).map_err(|e| {
         napi::Error::from(ScpNapiError::Tool {
             message: format!("failed to serialize cross-context output: {e}"),
-            code: "SCP-TOOL-6013".to_owned(),
+            code: codes::TOOL_6013.to_owned(),
         })
     })
 }
@@ -744,7 +745,7 @@ pub async fn tool_session_create(
             message: format!(
                 "cannot create session in context in {state_str:?} state — context must be active"
             ),
-            code: "SCP-TOOL-6014".to_owned(),
+            code: codes::TOOL_6014.to_owned(),
         }
         .into());
     }
@@ -769,7 +770,7 @@ pub async fn tool_session_create(
                 message: format!(
                     "session cap exceeded for caller '{source_context_id}': {current} active (max {cap})"
                 ),
-                code: "SCP-TOOL-6015".to_owned(),
+                code: codes::TOOL_6015.to_owned(),
             });
         }
 
@@ -817,7 +818,7 @@ pub async fn tool_session_invoke(
             message: format!(
                 "cannot invoke session in context in {state_str:?} state — context must be active"
             ),
-            code: "SCP-TOOL-6017".to_owned(),
+            code: codes::TOOL_6017.to_owned(),
         }
         .into());
     }
@@ -833,7 +834,7 @@ pub async fn tool_session_invoke(
             .get(&session_id)
             .ok_or_else(|| ScpNapiError::Tool {
                 message: format!("session '{session_id}' not found"),
-                code: "SCP-TOOL-6018".to_owned(),
+                code: codes::TOOL_6018.to_owned(),
             })?;
         Ok(session.tool_id.clone())
     })
@@ -845,7 +846,7 @@ pub async fn tool_session_invoke(
         .map_err(|e| {
             napi::Error::from(ScpNapiError::Permission {
                 message: format!("failed to build proof resolver: {e}"),
-                code: "SCP-PERM-3001".to_owned(),
+                code: codes::PERM_3001.to_owned(),
             })
         })?;
     validate_ucan_for_tool(
@@ -863,7 +864,7 @@ pub async fn tool_session_invoke(
             .get(&session_id)
             .ok_or_else(|| ScpNapiError::Tool {
                 message: format!("session '{session_id}' not found"),
-                code: "SCP-TOOL-6018".to_owned(),
+                code: codes::TOOL_6018.to_owned(),
             })?;
 
         // Check expiry.
@@ -872,7 +873,7 @@ pub async fn tool_session_invoke(
             rt.session_store.remove(&session_id);
             return Err(ScpNapiError::Tool {
                 message: format!("session '{session_id}' has expired"),
-                code: "SCP-TOOL-6019".to_owned(),
+                code: codes::TOOL_6019.to_owned(),
             });
         }
 
@@ -883,7 +884,7 @@ pub async fn tool_session_invoke(
         let input_value: serde_json::Value =
             serde_json::from_str(&input_json).map_err(|e| ScpNapiError::Tool {
                 message: format!("invalid input JSON: {e}"),
-                code: "SCP-TOOL-6002".to_owned(),
+                code: codes::TOOL_6002.to_owned(),
             })?;
 
         // Validate input against tool's input schema if tool is registered.
@@ -894,7 +895,7 @@ pub async fn tool_session_invoke(
             )
             .map_err(|e| ScpNapiError::Tool {
                 message: format!("input validation failed: {e}"),
-                code: "SCP-TOOL-6002".to_owned(),
+                code: codes::TOOL_6002.to_owned(),
             })?;
         }
 
@@ -903,7 +904,7 @@ pub async fn tool_session_invoke(
             let handler = handler.clone();
             let out = handler(input_value).map_err(|e| ScpNapiError::Tool {
                 message: format!("tool handler for '{tool_id}' failed: {e}"),
-                code: "SCP-TOOL-6002".to_owned(),
+                code: codes::TOOL_6002.to_owned(),
             })?;
             (current_state, out)
         } else {
@@ -931,7 +932,7 @@ pub async fn tool_session_invoke(
     serde_json::to_string(&output).map_err(|e| {
         napi::Error::from(ScpNapiError::Tool {
             message: format!("failed to serialize session invoke output: {e}"),
-            code: "SCP-TOOL-6020".to_owned(),
+            code: codes::TOOL_6020.to_owned(),
         })
     })
 }
@@ -955,7 +956,7 @@ pub async fn tool_session_close(
         if rt.session_store.remove(&session_id).is_none() {
             return Err(ScpNapiError::Tool {
                 message: format!("session '{session_id}' not found"),
-                code: "SCP-TOOL-6021".to_owned(),
+                code: codes::TOOL_6021.to_owned(),
             });
         }
         Ok(())
@@ -996,7 +997,7 @@ pub async fn tool_interface_expose(
             message: format!(
                 "cannot expose tool interface in context in {state_str:?} state — context must be active"
             ),
-            code: "SCP-TOOL-6030".to_owned(),
+            code: codes::TOOL_6030.to_owned(),
         }
         .into());
     }
@@ -1010,7 +1011,7 @@ pub async fn tool_interface_expose(
                 .map_err(|e| {
                     napi::Error::from(ScpNapiError::Validation {
                         message: format!("invalid rate_limit_json: {e}"),
-                        code: "SCP-VALID-7040".to_owned(),
+                        code: codes::VALID_7040.to_owned(),
                     })
                 })?;
             Some(parsed)
@@ -1036,12 +1037,12 @@ pub async fn tool_interface_expose(
         )
         .map_err(|e| ScpNapiError::Tool {
             message: format!("expose_tool failed: {e}"),
-            code: "SCP-TOOL-6030".to_owned(),
+            code: codes::TOOL_6030.to_owned(),
         })?;
 
         serde_json::to_string(&interface).map_err(|e| ScpNapiError::Tool {
             message: format!("failed to serialize ToolInterface: {e}"),
-            code: "SCP-TOOL-6031".to_owned(),
+            code: codes::TOOL_6031.to_owned(),
         })
     })
     .map_err(napi::Error::from)
@@ -1067,7 +1068,7 @@ pub async fn tool_interface_accept(
             message: format!(
                 "cannot accept tool interface in context in {state_str:?} state — context must be active"
             ),
-            code: "SCP-TOOL-6032".to_owned(),
+            code: codes::TOOL_6032.to_owned(),
         }
         .into());
     }
@@ -1079,7 +1080,7 @@ pub async fn tool_interface_accept(
         serde_json::from_str(&interface_json).map_err(|e| {
             napi::Error::from(ScpNapiError::Validation {
                 message: format!("invalid interface_json: {e}"),
-                code: "SCP-VALID-7041".to_owned(),
+                code: codes::VALID_7041.to_owned(),
             })
         })?;
 
@@ -1098,12 +1099,12 @@ pub async fn tool_interface_accept(
         )
         .map_err(|e| ScpNapiError::Tool {
             message: format!("accept_tool_interface failed: {e}"),
-            code: "SCP-TOOL-6032".to_owned(),
+            code: codes::TOOL_6032.to_owned(),
         })?;
 
         serde_json::to_string(&interface).map_err(|e| ScpNapiError::Tool {
             message: format!("failed to serialize ToolInterface: {e}"),
-            code: "SCP-TOOL-6033".to_owned(),
+            code: codes::TOOL_6033.to_owned(),
         })
     })
     .map_err(napi::Error::from)
@@ -1128,7 +1129,7 @@ pub async fn tool_interface_revoke(
     let interface_id_bytes = hex::decode(&interface_id_hex).map_err(|e| {
         napi::Error::from(ScpNapiError::Validation {
             message: format!("invalid interface_id_hex: not valid hex: {e}"),
-            code: "SCP-VALID-7042".to_owned(),
+            code: codes::VALID_7042.to_owned(),
         })
     })?;
     let interface_id: [u8; 32] =
@@ -1138,7 +1139,7 @@ pub async fn tool_interface_revoke(
                     "interface_id_hex must be exactly 32 bytes (64 hex chars), got {}",
                     interface_id_bytes.len()
                 ),
-                code: "SCP-VALID-7042".to_owned(),
+                code: codes::VALID_7042.to_owned(),
             })
         })?;
 
@@ -1153,7 +1154,7 @@ pub async fn tool_interface_revoke(
     serde_json::to_string(&event).map_err(|e| {
         napi::Error::from(ScpNapiError::Tool {
             message: format!("failed to serialize InterfaceRevoked: {e}"),
-            code: "SCP-TOOL-6035".to_owned(),
+            code: codes::TOOL_6035.to_owned(),
         })
     })
 }
@@ -1166,6 +1167,7 @@ pub async fn tool_interface_revoke(
 #[allow(clippy::unwrap_used, clippy::expect_used)]
 mod tests {
     use super::*;
+    use scp_ffi_common::error_codes as codes;
 
     // -----------------------------------------------------------------------
     // validate_schema_json
@@ -1190,7 +1192,7 @@ mod tests {
         assert!(result.is_err());
         let msg = format!("{}", result.unwrap_err());
         assert!(
-            msg.contains("SCP-VALID-7035"),
+            msg.contains(codes::VALID_7035),
             "error should contain SCP-VALID-7035, got: {msg}"
         );
         assert!(
@@ -1205,7 +1207,7 @@ mod tests {
         assert!(result.is_err());
         let msg = format!("{}", result.unwrap_err());
         assert!(
-            msg.contains("SCP-VALID-7036"),
+            msg.contains(codes::VALID_7036),
             "error should contain SCP-VALID-7036, got: {msg}"
         );
         assert!(
@@ -1219,7 +1221,7 @@ mod tests {
         let result = validate_schema_json("", "input_schema_json");
         assert!(result.is_err());
         let msg = format!("{}", result.unwrap_err());
-        assert!(msg.contains("SCP-VALID-7035"));
+        assert!(msg.contains(codes::VALID_7035));
     }
 
     // -----------------------------------------------------------------------
@@ -1246,7 +1248,7 @@ mod tests {
         assert!(result.is_err());
         let msg = format!("{}", result.unwrap_err());
         assert!(
-            msg.contains("SCP-VALID-7037"),
+            msg.contains(codes::VALID_7037),
             "error should contain SCP-VALID-7037, got: {msg}"
         );
         assert!(
@@ -1261,7 +1263,7 @@ mod tests {
         let result = validate_test_vectors_json(Some(r#"{"not": "an array"}"#));
         assert!(result.is_err());
         let msg = format!("{}", result.unwrap_err());
-        assert!(msg.contains("SCP-VALID-7037"));
+        assert!(msg.contains(codes::VALID_7037));
     }
 
     // -----------------------------------------------------------------------
@@ -1290,7 +1292,7 @@ mod tests {
         assert!(result.is_err());
         let msg = format!("{}", result.unwrap_err());
         assert!(
-            msg.contains("SCP-VALID-7038"),
+            msg.contains(codes::VALID_7038),
             "error should contain SCP-VALID-7038, got: {msg}"
         );
         assert!(
@@ -1305,7 +1307,7 @@ mod tests {
         let result = validate_implementation_hash(Some(&hash));
         assert!(result.is_err());
         let msg = format!("{}", result.unwrap_err());
-        assert!(msg.contains("SCP-VALID-7038"));
+        assert!(msg.contains(codes::VALID_7038));
         assert!(
             msg.contains("got 64"),
             "error should report actual length, got: {msg}"
@@ -1317,7 +1319,7 @@ mod tests {
         let result = validate_implementation_hash(Some(&[]));
         assert!(result.is_err());
         let msg = format!("{}", result.unwrap_err());
-        assert!(msg.contains("SCP-VALID-7038"));
+        assert!(msg.contains(codes::VALID_7038));
         assert!(msg.contains("got 0"));
     }
 

--- a/crates/scp-ffi/napi/src/transport.rs
+++ b/crates/scp-ffi/napi/src/transport.rs
@@ -23,6 +23,7 @@
 //! See ADR-022, ADR-005 (Transport Abstraction), and ADR-012 (Multi-Relay) in
 //! `.docs/adrs/`.
 
+use scp_ffi_common::error_codes as codes;
 use std::sync::{Arc, OnceLock, RwLock};
 
 use napi_derive::napi;
@@ -68,7 +69,7 @@ fn set_transport_manager(manager: scp_transport::TransportManager) -> napi::Resu
         .write()
         .map_err(|_| ScpNapiError::Transport {
             message: "transport manager lock is poisoned".to_owned(),
-            code: "SCP-TRANS-5002".to_owned(),
+            code: codes::TRANS_5002.to_owned(),
         })? = Some(Arc::new(manager));
     Ok(())
 }
@@ -86,7 +87,7 @@ pub(crate) fn set_transport_manager_arc(
         .write()
         .map_err(|_| ScpNapiError::Transport {
             message: "transport manager lock is poisoned".to_owned(),
-            code: "SCP-TRANS-5002".to_owned(),
+            code: codes::TRANS_5002.to_owned(),
         })? = Some(manager);
     Ok(())
 }
@@ -108,11 +109,11 @@ pub(crate) fn with_transport_manager<T>(
         .read()
         .map_err(|_| ScpNapiError::Transport {
             message: "transport manager lock is poisoned".to_owned(),
-            code: "SCP-TRANS-5002".to_owned(),
+            code: codes::TRANS_5002.to_owned(),
         })?;
     let manager = guard.as_ref().ok_or_else(|| ScpNapiError::Transport {
         message: "no transport manager — call transportConnect() first".to_owned(),
-        code: "SCP-TRANS-5010".to_owned(),
+        code: codes::TRANS_5010.to_owned(),
     })?;
     f(manager)
 }
@@ -134,19 +135,19 @@ pub(crate) fn with_transport_manager_mut<T>(
         .write()
         .map_err(|_| ScpNapiError::Transport {
             message: "transport manager lock is poisoned".to_owned(),
-            code: "SCP-TRANS-5002".to_owned(),
+            code: codes::TRANS_5002.to_owned(),
         })?;
 
     let arc = guard.as_mut().ok_or_else(|| ScpNapiError::Transport {
         message: "no transport manager — call transportConnect() first".to_owned(),
-        code: "SCP-TRANS-5010".to_owned(),
+        code: codes::TRANS_5010.to_owned(),
     })?;
 
     let manager = Arc::get_mut(arc).ok_or_else(|| ScpNapiError::Transport {
         message: "transport manager is in use by an active subscription — \
                   cannot modify while subscriptions are active"
             .to_owned(),
-        code: "SCP-TRANS-5003".to_owned(),
+        code: codes::TRANS_5003.to_owned(),
     })?;
     f(manager)
 }
@@ -180,7 +181,7 @@ fn clear_transport_manager() -> napi::Result<()> {
         .write()
         .map_err(|_| ScpNapiError::Transport {
             message: "transport manager lock is poisoned".to_owned(),
-            code: "SCP-TRANS-5002".to_owned(),
+            code: codes::TRANS_5002.to_owned(),
         })? = None;
     Ok(())
 }
@@ -353,7 +354,7 @@ pub async fn transport_connect(relay_url: String) -> napi::Result<NapiTransportM
         }
         Err(e) => Err(ScpNapiError::Transport {
             message: format!("failed to connect to relay '{relay_url}': {e}"),
-            code: "SCP-TRANS-5001".to_owned(),
+            code: codes::TRANS_5001.to_owned(),
         }
         .into()),
     }
@@ -405,13 +406,13 @@ pub async fn transport_status(manager: &NapiTransportManager) -> napi::Result<Na
 pub async fn transport_disconnect(manager: &NapiTransportManager) -> napi::Result<()> {
     let mut s = manager.status.lock().map_err(|_| ScpNapiError::Transport {
         message: "transport status lock is poisoned".to_owned(),
-        code: "SCP-TRANS-5002".to_owned(),
+        code: codes::TRANS_5002.to_owned(),
     })?;
 
     if !s.connected {
         return Err(ScpNapiError::Transport {
             message: "transport is not connected — call transportConnect first".to_owned(),
-            code: "SCP-TRANS-5002".to_owned(),
+            code: codes::TRANS_5002.to_owned(),
         }
         .into());
     }
@@ -498,7 +499,7 @@ pub async fn configure_relay_transport(relay_url: String, local_did: String) -> 
             .await
             .map_err(|e| ScpNapiError::Transport {
                 message: format!("failed to connect to relay '{relay_url}': {e}"),
-                code: "SCP-TRANS-5001".to_owned(),
+                code: codes::TRANS_5001.to_owned(),
             })?;
 
     crate::runtime::init_context_manager_with_relay_transport(&local_did, adapter);
@@ -571,7 +572,7 @@ pub async fn transport_add_relay(relay_url: String) -> napi::Result<u32> {
             .await
             .map_err(|e| ScpNapiError::Transport {
                 message: format!("failed to connect to relay '{relay_url}': {e}"),
-                code: "SCP-TRANS-5001".to_owned(),
+                code: codes::TRANS_5001.to_owned(),
             })?;
 
     // Extract the suppression event receiver BEFORE moving the adapter into
@@ -632,7 +633,7 @@ pub fn transport_assign_relay_set(context_id: String) -> napi::Result<Vec<u32>> 
             .map_err(|e| {
                 napi::Error::from(ScpNapiError::Transport {
                     message: format!("relay set assignment failed: {e}"),
-                    code: "SCP-TRANS-5002".to_owned(),
+                    code: codes::TRANS_5002.to_owned(),
                 })
             })
     })

--- a/crates/scp-ffi/napi/src/trust.rs
+++ b/crates/scp-ffi/napi/src/trust.rs
@@ -12,6 +12,7 @@
 //!
 //! See ADR-017 in `.docs/adrs/phase-4.md`.
 
+use scp_ffi_common::error_codes as codes;
 use std::sync::Arc;
 
 use napi_derive::napi;
@@ -61,7 +62,7 @@ pub struct NapiChallengeResult {
 fn validation_error(msg: &str) -> napi::Error {
     napi::Error::from(ScpNapiError::Validation {
         message: msg.to_owned(),
-        code: "SCP-VALID-7010".to_owned(),
+        code: codes::VALID_7010.to_owned(),
     })
 }
 

--- a/crates/scp-ffi/napi/src/ucan.rs
+++ b/crates/scp-ffi/napi/src/ucan.rs
@@ -26,6 +26,7 @@
 //!
 //! See ADR-016 (UCAN Enforcement) and ADR-022 in `.docs/adrs/`.
 
+use scp_ffi_common::error_codes as codes;
 use std::collections::HashMap;
 
 use napi_derive::napi;
@@ -233,7 +234,7 @@ pub async fn ucan_validate(
             .parse()
             .map_err(|e: CoreUcanError| ScpNapiError::Permission {
                 message: format!("invalid capability URI '{capability}': {e}"),
-                code: "SCP-PERM-3001".to_owned(),
+                code: codes::PERM_3001.to_owned(),
             })?;
 
     // Determine the presenting agent DID: explicit parameter or token audience.
@@ -336,7 +337,7 @@ pub async fn ucan_mint(
         let _ = (&handle, &member_did, &capabilities, &proofs);
         Err(napi::Error::from(ScpNapiError::Permission {
             message: "UCAN minting requires key custody -- the in_memory custody path                       is not available in this build. Enable allow_in_memory_custody                       for dev/desktop use.".to_owned(),
-            code: "SCP-PERM-3023".to_owned(),
+            code: codes::PERM_3023.to_owned(),
         }))
     }
 
@@ -348,7 +349,7 @@ pub async fn ucan_mint(
                 message: "UCAN minting requires key custody — create the context with an \
                       in_memory identity (identity_create(\"in_memory\"))"
                     .to_owned(),
-                code: "SCP-PERM-3023".to_owned(),
+                code: codes::PERM_3023.to_owned(),
             })
         })?;
         let signing_key = handle.signing_key.ok_or_else(|| {
@@ -356,7 +357,7 @@ pub async fn ucan_mint(
                 message: "UCAN minting requires a signing key — the context creator identity \
                       must have an active signing key"
                     .to_owned(),
-                code: "SCP-PERM-3023".to_owned(),
+                code: codes::PERM_3023.to_owned(),
             })
         })?;
 
@@ -397,7 +398,7 @@ pub async fn ucan_mint(
             .map_err(|e| {
                 napi::Error::from(ScpNapiError::Permission {
                     message: format!("UCAN minting failed: {e}"),
-                    code: "SCP-PERM-3023".to_owned(),
+                    code: codes::PERM_3023.to_owned(),
                 })
             })?;
 
@@ -487,7 +488,7 @@ pub async fn ucan_delegate(
                        is not available in this build. Enable allow_in_memory_custody \
                        for dev/desktop use."
                 .to_owned(),
-            code: "SCP-PERM-3023".to_owned(),
+            code: codes::PERM_3023.to_owned(),
         }))
     }
 
@@ -513,7 +514,7 @@ pub async fn ucan_delegate(
                     "delegator DID '{}' does not match parent token audience '{}'",
                     delegator_did, parsed_parent.payload.aud
                 ),
-                code: "SCP-PERM-3023".to_owned(),
+                code: codes::PERM_3023.to_owned(),
             }));
         }
 
@@ -533,7 +534,7 @@ pub async fn ucan_delegate(
                         .parse()
                         .map_err(|e: CoreUcanError| ScpNapiError::Permission {
                             message: format!("invalid capability URI '{cap_uri_str}': {e}"),
-                            code: "SCP-PERM-3023".to_owned(),
+                            code: codes::PERM_3023.to_owned(),
                         })?;
                 Ok(Attenuation {
                     with: cap_uri_str,
@@ -991,7 +992,7 @@ mod tests {
                 .check_and_record(&nonce, expiry)
                 .map_err(|e| crate::error::ScpNapiError::Permission {
                     message: format!("nonce check failed: {e}"),
-                    code: "SCP-PERM-3001".to_owned(),
+                    code: codes::PERM_3001.to_owned(),
                 })
         });
         assert!(first_result.is_ok(), "first nonce use should succeed");
@@ -1002,7 +1003,7 @@ mod tests {
                 .check_and_record(&nonce, expiry)
                 .map_err(|e| crate::error::ScpNapiError::Permission {
                     message: format!("nonce check failed: {e}"),
-                    code: "SCP-PERM-3001".to_owned(),
+                    code: codes::PERM_3001.to_owned(),
                 })
         });
         assert!(
@@ -1017,7 +1018,7 @@ mod tests {
                 .check_and_record(&different_nonce, expiry)
                 .map_err(|e| crate::error::ScpNapiError::Permission {
                     message: format!("nonce check failed: {e}"),
-                    code: "SCP-PERM-3001".to_owned(),
+                    code: codes::PERM_3001.to_owned(),
                 })
         });
         assert!(third_result.is_ok(), "unique nonce should be accepted");

--- a/crates/scp-ffi/src/bridge_connector.rs
+++ b/crates/scp-ffi/src/bridge_connector.rs
@@ -25,6 +25,7 @@
 //! See spec section 12 (Bridge System), section 12.11 (Credential Lifecycle),
 //! and ADR-023.
 
+use scp_ffi_common::error_codes as codes;
 use std::sync::OnceLock;
 
 use dashmap::DashMap;
@@ -191,7 +192,7 @@ pub fn py_bridge_register(
         .map(|k| {
             <[u8; 32]>::try_from(k.as_slice()).map_err(|_| ScpPyError::ValidationError {
                 message: format!("platform_key must be exactly 32 bytes, got {}", k.len()),
-                code: "SCP-VALID-7052".to_string(),
+                code: codes::VALID_7052.to_string(),
             })
         })
         .transpose()?;
@@ -221,7 +222,7 @@ pub fn py_bridge_register(
 
     let _event = register_bridge(&mut registry, request).map_err(|e| ScpPyError::ContextError {
         message: format!("bridge registration failed: {e}"),
-        code: "SCP-CTX-2100".to_string(),
+        code: codes::CTX_2100.to_string(),
     })?;
 
     let approver_did: scp_identity::DID = governance_did.into();
@@ -229,7 +230,7 @@ pub fn py_bridge_register(
         approve_registration(&mut registry, &bridge_id, &approver_did, 0).map_err(|e| {
             ScpPyError::ContextError {
                 message: format!("bridge approval failed: {e}"),
-                code: "SCP-CTX-2101".to_string(),
+                code: codes::CTX_2101.to_string(),
             }
         })?;
 
@@ -381,7 +382,7 @@ pub fn py_bridge_create_shadow(
     )
     .map_err(|e| ScpPyError::ContextError {
         message: format!("shadow creation failed: {e}"),
-        code: "SCP-CTX-2102".to_string(),
+        code: codes::CTX_2102.to_string(),
     })?;
 
     let dict = PyDict::new(py);
@@ -462,7 +463,7 @@ pub fn py_bridge_claim_shadow(
     let attestation: Attestation =
         serde_json::from_str(attestation_json).map_err(|e| ScpPyError::ValidationError {
             message: format!("invalid attestation JSON: {e}"),
-            code: "SCP-VALID-7053".to_string(),
+            code: codes::VALID_7053.to_string(),
         })?;
 
     // Build the shadow registry and create the shadow so it can be found.
@@ -479,7 +480,7 @@ pub fn py_bridge_claim_shadow(
     create_shadow(&mut shadow_registry, &mut sender_key_store, &shadow_params).map_err(|e| {
         ScpPyError::ContextError {
             message: format!("shadow setup for claiming failed: {e}"),
-            code: "SCP-CTX-2103".to_string(),
+            code: codes::CTX_2103.to_string(),
         }
     })?;
 
@@ -496,7 +497,7 @@ pub fn py_bridge_claim_shadow(
     let event =
         claim_shadow(&mut shadow_registry, &request).map_err(|e| ScpPyError::ContextError {
             message: format!("shadow claim failed: {e}"),
-            code: "SCP-CTX-2104".to_string(),
+            code: codes::CTX_2104.to_string(),
         })?;
 
     let dict = PyDict::new(py);
@@ -597,7 +598,7 @@ pub fn py_bridge_seal_shadow_envelope(
                     "sender_key_bytes must be exactly 32 bytes, got {}",
                     sender_key_bytes.len()
                 ),
-                code: "SCP-VALID-7054".to_string(),
+                code: codes::VALID_7054.to_string(),
             }
         })?,
     );
@@ -657,13 +658,13 @@ pub fn py_bridge_seal_shadow_envelope(
 
     let envelope = seal_shadow_envelope(&params).map_err(|e| ScpPyError::CryptoError {
         message: format!("envelope sealing failed: {e}"),
-        code: "SCP-CRYPTO-4010".to_string(),
+        code: codes::CRYPTO_4010.to_string(),
     })?;
 
     Ok(
         serde_json::to_string(&envelope).map_err(|e| ScpPyError::ValidationError {
             message: format!("envelope serialization failed: {e}"),
-            code: "SCP-VALID-7055".to_string(),
+            code: codes::VALID_7055.to_string(),
         })?,
     )
 }
@@ -705,7 +706,7 @@ pub fn py_bridge_open_shadow_envelope(
     let envelope: scp_core::bridge::envelope::SenderKeyEnvelope =
         serde_json::from_str(envelope_json).map_err(|e| ScpPyError::ValidationError {
             message: format!("invalid envelope JSON: {e}"),
-            code: "SCP-VALID-7056".to_string(),
+            code: codes::VALID_7056.to_string(),
         })?;
 
     // Wrap raw key material in Zeroizing to prevent lingering in freed heap
@@ -718,7 +719,7 @@ pub fn py_bridge_open_shadow_envelope(
                     "sender_key_bytes must be exactly 32 bytes, got {}",
                     sender_key_bytes.len()
                 ),
-                code: "SCP-VALID-7054".to_string(),
+                code: codes::VALID_7054.to_string(),
             }
         })?,
     );
@@ -746,7 +747,7 @@ pub fn py_bridge_open_shadow_envelope(
     )
     .map_err(|e| ScpPyError::CryptoError {
         message: format!("envelope opening failed: {e}"),
-        code: "SCP-CRYPTO-4011".to_string(),
+        code: codes::CRYPTO_4011.to_string(),
     })?)
 }
 
@@ -784,7 +785,7 @@ pub fn py_bridge_derive_credential_key(
                     "bridge_credential_key must be exactly 32 bytes, got {}",
                     bridge_credential_key.len()
                 ),
-                code: "SCP-VALID-7057".to_string(),
+                code: codes::VALID_7057.to_string(),
             }
         })?,
     );
@@ -792,7 +793,7 @@ pub fn py_bridge_derive_credential_key(
     let derived =
         derive_credential_key(&key_bytes, bridge_id).map_err(|e| ScpPyError::CryptoError {
             message: format!("credential key derivation failed: {e}"),
-            code: "SCP-CRYPTO-4012".to_string(),
+            code: codes::CRYPTO_4012.to_string(),
         })?;
 
     // SAFETY: `.to_vec()` creates an unzeroized copy of the derived key
@@ -868,7 +869,7 @@ pub fn py_bridge_credential_provision(
         .block_on(store.provision(bridge_id, ct, &plaintext, &key_bytes))
         .map_err(|e| ScpPyError::ContextError {
             message: format!("credential provision failed: {e}"),
-            code: "SCP-CTX-2105".to_string(),
+            code: codes::CTX_2105.to_string(),
         })?;
 
     let dict = PyDict::new(py);
@@ -912,7 +913,7 @@ pub fn py_bridge_credential_retrieve(
         .block_on(store.retrieve(bridge_id, &ct, &key_bytes))
         .map_err(|e| ScpPyError::ContextError {
             message: format!("credential retrieve failed: {e}"),
-            code: "SCP-CTX-2106".to_string(),
+            code: codes::CTX_2106.to_string(),
         })?;
 
     Ok(plaintext.to_vec())
@@ -955,7 +956,7 @@ pub fn py_bridge_credential_rotate(
         .block_on(store.rotate(bridge_id, &ct, &new_plaintext, &key_bytes))
         .map_err(|e| ScpPyError::ContextError {
             message: format!("credential rotate failed: {e}"),
-            code: "SCP-CTX-2107".to_string(),
+            code: codes::CTX_2107.to_string(),
         })?;
 
     let dict = PyDict::new(py);
@@ -986,7 +987,7 @@ pub fn py_bridge_credential_revoke(bridge_id: &str) -> PyResult<()> {
     rt.block_on(store.revoke(bridge_id))
         .map_err(|e| ScpPyError::ContextError {
             message: format!("credential revoke failed: {e}"),
-            code: "SCP-CTX-2108".to_string(),
+            code: codes::CTX_2108.to_string(),
         })?;
 
     Ok(())
@@ -1015,14 +1016,14 @@ pub fn py_bridge_credential_list(py: Python<'_>, bridge_id: &str) -> PyResult<Py
         .block_on(store.list(bridge_id))
         .map_err(|e| ScpPyError::ContextError {
             message: format!("credential list failed: {e}"),
-            code: "SCP-CTX-2109".to_string(),
+            code: codes::CTX_2109.to_string(),
         })?;
 
     let list =
         PyList::new(py, types.iter().map(std::string::ToString::to_string)).map_err(|e| {
             ScpPyError::ContextError {
                 message: format!("failed to build Python list: {e}"),
-                code: "SCP-CTX-2110".to_string(),
+                code: codes::CTX_2110.to_string(),
             }
         })?;
     Ok(list.into())
@@ -1053,7 +1054,7 @@ pub fn py_bridge_credential_store_key(bridge_id: &str, key: Vec<u8>) -> PyResult
     rt.block_on(store.store_bridge_credential_key(bridge_id, Zeroizing::new(key_bytes)))
         .map_err(|e| ScpPyError::ContextError {
             message: format!("credential key store failed: {e}"),
-            code: "SCP-CTX-2111".to_string(),
+            code: codes::CTX_2111.to_string(),
         })?;
 
     Ok(())
@@ -1082,7 +1083,7 @@ pub fn py_bridge_credential_get_key(bridge_id: &str) -> PyResult<Vec<u8>> {
         .block_on(store.get_bridge_credential_key(bridge_id))
         .map_err(|e| ScpPyError::ContextError {
             message: format!("credential key retrieval failed: {e}"),
-            code: "SCP-CTX-2112".to_string(),
+            code: codes::CTX_2112.to_string(),
         })?;
 
     Ok(key.to_vec())
@@ -1108,7 +1109,7 @@ pub fn py_bridge_credential_delete_key(bridge_id: &str) -> PyResult<()> {
     rt.block_on(store.delete_bridge_credential_key(bridge_id))
         .map_err(|e| ScpPyError::ContextError {
             message: format!("credential key deletion failed: {e}"),
-            code: "SCP-CTX-2113".to_string(),
+            code: codes::CTX_2113.to_string(),
         })?;
 
     Ok(())
@@ -1213,7 +1214,7 @@ pub fn py_bridge_oauth_scopes_for_mode(py: Python<'_>, mode: &str) -> PyResult<P
     let scopes = scopes_for_mode(&bridge_mode);
     let list = PyList::new(py, &scopes).map_err(|e| ScpPyError::ContextError {
         message: format!("failed to build Python list: {e}"),
-        code: "SCP-CTX-2114".to_string(),
+        code: codes::CTX_2114.to_string(),
     })?;
     Ok(list.into())
 }
@@ -1232,7 +1233,7 @@ fn parse_bridge_mode(s: &str) -> PyResult<BridgeMode> {
             message: format!(
                 "invalid bridge mode '{other}': expected 'relay', 'puppet', 'api', or 'cooperative'"
             ),
-            code: "SCP-VALID-7050".to_string(),
+            code: codes::VALID_7050.to_string(),
         }
         .into()),
     }
@@ -1251,7 +1252,7 @@ fn parse_credential_type(s: &str) -> PyResult<CredentialType> {
                         "invalid credential type '{other}': expected 'OAuthAccessToken', \
                          'OAuthRefreshToken', 'ApiKey', 'WebhookSecret', or 'Custom:<name>'"
                     ),
-                    code: "SCP-VALID-7058".to_string(),
+                    code: codes::VALID_7058.to_string(),
                 }
                 .into())
             },
@@ -1267,7 +1268,7 @@ fn parse_credential_key_bytes(key: &[u8]) -> PyResult<[u8; 32]> {
                 "bridge_credential_key must be exactly 32 bytes, got {}",
                 key.len()
             ),
-            code: "SCP-VALID-7057".to_string(),
+            code: codes::VALID_7057.to_string(),
         }
         .into()
     })
@@ -1279,7 +1280,7 @@ fn parse_shadow_status(s: &str) -> PyResult<ShadowProvenanceStatus> {
         "claimed" => Ok(ShadowProvenanceStatus::Claimed),
         other => Err(ScpPyError::ValidationError {
             message: format!("invalid shadow_status '{other}': expected 'shadow' or 'claimed'"),
-            code: "SCP-VALID-7051".to_string(),
+            code: codes::VALID_7051.to_string(),
         }
         .into()),
     }

--- a/crates/scp-ffi/src/context.rs
+++ b/crates/scp-ffi/src/context.rs
@@ -1556,159 +1556,39 @@ fn py_context_receive(handle: &PyContextHandle) -> PyResult<PyMessageReceiver> {
 
 /// Builds scp-core [`ContextParams`] from a [`PyContextParams`].
 ///
-/// Converts the flat FFI-facing parameter representation into the typed
-/// scp-core parameter struct used by [`ContextManager::create_context`].
-#[allow(clippy::too_many_lines)] // 1:1 field mapping — splitting would reduce readability
+/// Delegates to the shared [`scp_ffi_common::context_params::build_context_params`]
+/// builder, which centralizes all parameter parsing and validation logic
+/// across the three non-WASM bridges (#1447).
 fn build_core_context_params(
     py_params: &PyContextParams,
 ) -> PyResult<scp_core::context::ContextParams> {
-    use scp_core::context::params::{
-        CeilingPolicy, ContextMode, GovernanceModel, MemoryScope, PromotionPolicy,
-    };
+    use scp_ffi_common::context_params::{CommonContextParams, build_context_params};
 
-    let mode = match py_params.mode.as_str() {
-        "broadcast" => ContextMode::Broadcast,
-        _ => ContextMode::Encrypted,
-    };
-
-    let ceiling_policy = match py_params.ceiling_policy.as_str() {
-        "governed" => CeilingPolicy::Governed,
-        _ => CeilingPolicy::Immutable,
-    };
-
-    let promotion_policy = match py_params.promotion_policy.as_str() {
-        "promotable" => PromotionPolicy::Promotable,
-        _ => PromotionPolicy::NoPromotion,
-    };
-
-    let memory_scope = match py_params.memory_scope.as_str() {
-        "summary" => MemoryScope::Summary,
-        "full" => MemoryScope::Full,
-        _ => MemoryScope::Ephemeral,
-    };
-
-    // Currently only SingleAdmin is supported; governance string was already validated.
-    let _ = py_params.governance.as_str();
-    let governance_model = GovernanceModel::SingleAdmin;
-
-    let template_id = py_params
-        .template_id
-        .as_deref()
-        .and_then(|tid| parse_template_id(tid).ok());
-
-    let ceiling: Vec<scp_core::context::roles::Capability> = py_params
-        .ceiling
-        .iter()
-        .map(scp_core::context::roles::Capability::new)
-        .collect();
-
-    let roles = py_params
-        .roles
-        .keys()
-        .map(|name| scp_core::context::params::RoleDefinition {
-            name: name.clone(),
-            capabilities: HashSet::new(),
-        })
-        .collect();
-
-    let tools = py_params
-        .tools
-        .iter()
-        .map(|name| scp_core::context::params::ToolRegistration {
-            tool_id: name.clone(),
-            name: name.clone(),
-            description: String::new(),
-            schema: scp_core::context::tools::ToolSchema {
-                input_schema: serde_json::Value::Object(serde_json::Map::default()),
-                output_schema: serde_json::Value::Object(serde_json::Map::default()),
-            },
-            implementation_hash: [0u8; 32],
-            test_vectors: vec![],
-            operator_did: scp_identity::DID("did:key:placeholder".to_owned()),
-            cost: None,
-            registered_at: 0,
-            signature: Vec::new(),
-        })
-        .collect();
-
-    let ttl = py_params.ttl.map(std::time::Duration::from_secs_f64);
-
-    Ok(scp_core::context::ContextParams {
-        mode,
-        ceiling,
-        ceiling_policy,
-        promotion_policy,
-        roles,
-        tools,
-        ttl,
-        memory_scope,
-        governance: governance_model,
-        template_id,
-        economic_policy: py_params
-            .economic_policy
-            .as_deref()
-            .map(|ep_json| {
-                serde_json::from_str(ep_json).map_err(|e| {
-                    PyRuntimeError::new_err(format!("invalid economic_policy JSON: {e}"))
-                })
-            })
-            .transpose()?,
-        metadata_visibility: scp_core::context::params::MetadataVisibilityPolicy::default(),
-        projection_policy: None,
-        discoverable: false,
+    let common = CommonContextParams {
+        mode: py_params.mode.clone(),
+        ceiling: py_params.ceiling.clone(),
+        ceiling_policy: py_params.ceiling_policy.clone(),
+        promotion_policy: py_params.promotion_policy.clone(),
+        memory_scope: py_params.memory_scope.clone(),
+        governance: py_params.governance.clone(),
+        ttl: py_params.ttl.map(std::time::Duration::from_secs_f64),
+        min_protocol_version: py_params.min_protocol_version,
         max_chain_depth: py_params.max_chain_depth,
         max_nesting_depth: py_params.max_nesting_depth,
         session_cap: py_params.session_cap,
-        counterparty_policy: scp_core::provenance::CounterpartyPolicy::default(),
-        participation_requirements: Vec::new(),
-        incomplete_verification_policy:
-            scp_core::context::params::IncompleteVerificationPolicy::default(),
-        min_protocol_version: py_params.min_protocol_version,
-        migration_source: None,
-        consequence_rules: {
-            let parsed_consequence_rules: Vec<scp_core::trust::ConsequenceRule> = py_params
-                .consequence_rules
-                .as_deref()
-                .map(|cr_json| {
-                    serde_json::from_str(cr_json).map_err(|e| {
-                        PyRuntimeError::new_err(format!("invalid consequence_rules JSON: {e}"))
-                    })
-                })
-                .transpose()?
-                .unwrap_or_default();
-            // Parse the per-context consequence config so RevokeAccess gating
-            // is enforced before the core constructs the context. The parsed
-            // value is consumed below in `consequence_config:` — re-parse for
-            // local validation here. Doing both reads is cheap (small JSON).
-            let local_config: scp_core::context::params::ConsequenceConfig = py_params
-                .consequence_config
-                .as_deref()
-                .map(|cc_json| {
-                    serde_json::from_str(cc_json).map_err(|e| {
-                        PyRuntimeError::new_err(format!("invalid consequence_config JSON: {e}"))
-                    })
-                })
-                .transpose()?
-                .unwrap_or_default();
-            for rule in &parsed_consequence_rules {
-                rule.validate_against_config(&local_config).map_err(|e| {
-                    PyRuntimeError::new_err(format!("consequence_rules validation failed: {e}"))
-                })?;
-            }
-            parsed_consequence_rules
-        },
-        consequence_config: py_params
-            .consequence_config
-            .as_deref()
-            .map(|cc_json| {
-                serde_json::from_str(cc_json).map_err(|e| {
-                    PyRuntimeError::new_err(format!("invalid consequence_config JSON: {e}"))
-                })
-            })
-            .transpose()?
-            .unwrap_or_default(),
-        sybil_policy: None,
-    })
+        economic_policy_json: py_params.economic_policy.clone(),
+        consequence_rules_json: py_params.consequence_rules.clone(),
+        consequence_config_json: py_params.consequence_config.clone(),
+        roles: py_params
+            .roles
+            .iter()
+            .map(|(k, v)| (k.clone(), v.clone()))
+            .collect(),
+        tools: py_params.tools.clone(),
+        template_id: py_params.template_id.clone(),
+    };
+
+    build_context_params(&common).map_err(PyRuntimeError::new_err)
 }
 
 // ---------------------------------------------------------------------------

--- a/crates/scp-ffi/src/context.rs
+++ b/crates/scp-ffi/src/context.rs
@@ -1586,6 +1586,9 @@ fn build_core_context_params(
             .collect(),
         tools: py_params.tools.clone(),
         template_id: py_params.template_id.clone(),
+        governance_threshold: None, // PyO3 bridge uses string-only governance for now
+        governance_signers: None,
+        governance_voters: None,
     };
 
     build_context_params(&common).map_err(PyRuntimeError::new_err)

--- a/crates/scp-ffi/src/discovery.rs
+++ b/crates/scp-ffi/src/discovery.rs
@@ -24,6 +24,7 @@
 //!
 //! See ADR-020 in `.docs/adrs/phase-4.md` and spec section 22 (Addressing).
 
+use scp_ffi_common::error_codes as codes;
 use std::collections::HashMap;
 
 use pyo3::prelude::*;
@@ -88,7 +89,7 @@ pub fn py_discovery_parse_address<'py>(
 ) -> PyResult<Bound<'py, PyDict>> {
     let parsed = parse_address(address).map_err(|e| ScpPyError::ValidationError {
         message: format!("invalid address '{address}': {e}"),
-        code: "SCP-VALID-7060".to_string(),
+        code: codes::VALID_7060.to_string(),
     })?;
 
     let dict = PyDict::new(py);
@@ -147,7 +148,7 @@ pub fn py_discovery_create_query(
     serde_json::to_string(&query).map_err(|e| {
         ScpPyError::ValidationError {
             message: format!("failed to serialize query: {e}"),
-            code: "SCP-VALID-7061".to_string(),
+            code: codes::VALID_7061.to_string(),
         }
         .into()
     })
@@ -309,7 +310,7 @@ pub fn py_context_discover<'py>(py: Python<'py>, query: &str) -> PyResult<Bound<
                 "query must be a DID (starts with 'did:') or an scp:// URI \
                  (starts with 'scp://'), got: {query}"
             ),
-            code: "SCP-VALID-7062".to_owned(),
+            code: codes::VALID_7062.to_owned(),
         }
         .into())
     }
@@ -339,14 +340,14 @@ pub fn py_petname_set(owner_did: &str, target_did: &str, name: &str) -> PyResult
     if owner_did.is_empty() {
         return Err(ScpPyError::ValidationError {
             message: "owner_did must not be empty".to_owned(),
-            code: "SCP-VALID-7110".to_owned(),
+            code: codes::VALID_7110.to_owned(),
         }
         .into());
     }
     if target_did.is_empty() {
         return Err(ScpPyError::ValidationError {
             message: "target_did must not be empty".to_owned(),
-            code: "SCP-VALID-7111".to_owned(),
+            code: codes::VALID_7111.to_owned(),
         }
         .into());
     }
@@ -354,7 +355,7 @@ pub fn py_petname_set(owner_did: &str, target_did: &str, name: &str) -> PyResult
         .lock()
         .map_err(|e| ScpPyError::ValidationError {
             message: format!("petname lock poisoned: {e}"),
-            code: "SCP-VALID-7112".to_owned(),
+            code: codes::VALID_7112.to_owned(),
         })?;
     let map = guard.entry(owner_did.to_owned()).or_default();
     map.set_petname(DID::from(target_did), name.to_owned());
@@ -377,7 +378,7 @@ pub fn py_petname_remove(owner_did: &str, target_did: &str) -> PyResult<()> {
     if owner_did.is_empty() {
         return Err(ScpPyError::ValidationError {
             message: "owner_did must not be empty".to_owned(),
-            code: "SCP-VALID-7110".to_owned(),
+            code: codes::VALID_7110.to_owned(),
         }
         .into());
     }
@@ -385,7 +386,7 @@ pub fn py_petname_remove(owner_did: &str, target_did: &str) -> PyResult<()> {
         .lock()
         .map_err(|e| ScpPyError::ValidationError {
             message: format!("petname lock poisoned: {e}"),
-            code: "SCP-VALID-7112".to_owned(),
+            code: codes::VALID_7112.to_owned(),
         })?;
     if let Some(map) = guard.get_mut(owner_did) {
         map.remove_petname(&DID::from(target_did));
@@ -410,14 +411,14 @@ pub fn py_petname_set_context(owner_did: &str, context_id: &str, name: &str) -> 
     if owner_did.is_empty() {
         return Err(ScpPyError::ValidationError {
             message: "owner_did must not be empty".to_owned(),
-            code: "SCP-VALID-7110".to_owned(),
+            code: codes::VALID_7110.to_owned(),
         }
         .into());
     }
     if context_id.is_empty() {
         return Err(ScpPyError::ValidationError {
             message: "context_id must not be empty".to_owned(),
-            code: "SCP-VALID-7113".to_owned(),
+            code: codes::VALID_7113.to_owned(),
         }
         .into());
     }
@@ -425,7 +426,7 @@ pub fn py_petname_set_context(owner_did: &str, context_id: &str, name: &str) -> 
         .lock()
         .map_err(|e| ScpPyError::ValidationError {
             message: format!("petname lock poisoned: {e}"),
-            code: "SCP-VALID-7112".to_owned(),
+            code: codes::VALID_7112.to_owned(),
         })?;
     let map = guard.entry(owner_did.to_owned()).or_default();
     map.set_context_petname(context_id.to_owned(), name.to_owned());
@@ -448,7 +449,7 @@ pub fn py_petname_remove_context(owner_did: &str, context_id: &str) -> PyResult<
     if owner_did.is_empty() {
         return Err(ScpPyError::ValidationError {
             message: "owner_did must not be empty".to_owned(),
-            code: "SCP-VALID-7110".to_owned(),
+            code: codes::VALID_7110.to_owned(),
         }
         .into());
     }
@@ -456,7 +457,7 @@ pub fn py_petname_remove_context(owner_did: &str, context_id: &str) -> PyResult<
         .lock()
         .map_err(|e| ScpPyError::ValidationError {
             message: format!("petname lock poisoned: {e}"),
-            code: "SCP-VALID-7112".to_owned(),
+            code: codes::VALID_7112.to_owned(),
         })?;
     if let Some(map) = guard.get_mut(owner_did) {
         map.remove_context_petname(&context_id.to_owned());
@@ -487,7 +488,7 @@ pub fn py_petname_resolve_did(owner_did: &str, name: &str) -> PyResult<Vec<Strin
     if owner_did.is_empty() {
         return Err(ScpPyError::ValidationError {
             message: "owner_did must not be empty".to_owned(),
-            code: "SCP-VALID-7110".to_owned(),
+            code: codes::VALID_7110.to_owned(),
         }
         .into());
     }
@@ -495,7 +496,7 @@ pub fn py_petname_resolve_did(owner_did: &str, name: &str) -> PyResult<Vec<Strin
         .lock()
         .map_err(|e| ScpPyError::ValidationError {
             message: format!("petname lock poisoned: {e}"),
-            code: "SCP-VALID-7112".to_owned(),
+            code: codes::VALID_7112.to_owned(),
         })?;
     let dids = guard
         .get(owner_did)
@@ -531,7 +532,7 @@ pub fn py_petname_resolve_context(owner_did: &str, name: &str) -> PyResult<Vec<S
     if owner_did.is_empty() {
         return Err(ScpPyError::ValidationError {
             message: "owner_did must not be empty".to_owned(),
-            code: "SCP-VALID-7110".to_owned(),
+            code: codes::VALID_7110.to_owned(),
         }
         .into());
     }
@@ -539,7 +540,7 @@ pub fn py_petname_resolve_context(owner_did: &str, name: &str) -> PyResult<Vec<S
         .lock()
         .map_err(|e| ScpPyError::ValidationError {
             message: format!("petname lock poisoned: {e}"),
-            code: "SCP-VALID-7112".to_owned(),
+            code: codes::VALID_7112.to_owned(),
         })?;
     let ids = guard
         .get(owner_did)
@@ -568,7 +569,7 @@ pub fn py_petname_get_for_did(owner_did: &str, target_did: &str) -> PyResult<Opt
     if owner_did.is_empty() {
         return Err(ScpPyError::ValidationError {
             message: "owner_did must not be empty".to_owned(),
-            code: "SCP-VALID-7110".to_owned(),
+            code: codes::VALID_7110.to_owned(),
         }
         .into());
     }
@@ -576,7 +577,7 @@ pub fn py_petname_get_for_did(owner_did: &str, target_did: &str) -> PyResult<Opt
         .lock()
         .map_err(|e| ScpPyError::ValidationError {
             message: format!("petname lock poisoned: {e}"),
-            code: "SCP-VALID-7112".to_owned(),
+            code: codes::VALID_7112.to_owned(),
         })?;
     let name = guard.get(owner_did).and_then(|map| {
         map.petname_for_did(&DID::from(target_did))
@@ -605,7 +606,7 @@ pub fn py_petname_get_for_context(owner_did: &str, context_id: &str) -> PyResult
     if owner_did.is_empty() {
         return Err(ScpPyError::ValidationError {
             message: "owner_did must not be empty".to_owned(),
-            code: "SCP-VALID-7110".to_owned(),
+            code: codes::VALID_7110.to_owned(),
         }
         .into());
     }
@@ -613,7 +614,7 @@ pub fn py_petname_get_for_context(owner_did: &str, context_id: &str) -> PyResult
         .lock()
         .map_err(|e| ScpPyError::ValidationError {
             message: format!("petname lock poisoned: {e}"),
-            code: "SCP-VALID-7112".to_owned(),
+            code: codes::VALID_7112.to_owned(),
         })?;
     let name = guard.get(owner_did).and_then(|map| {
         map.petname_for_context(&context_id.to_owned())
@@ -670,7 +671,7 @@ pub fn py_handle_register(
         .lock()
         .map_err(|e| ScpPyError::ValidationError {
             message: format!("handle registry lock poisoned: {e}"),
-            code: "SCP-VALID-7120".to_owned(),
+            code: codes::VALID_7120.to_owned(),
         })?;
 
     let registry = guard
@@ -686,7 +687,7 @@ pub fn py_handle_register(
     serde_json::to_string(&result).map_err(|e| {
         ScpPyError::ValidationError {
             message: format!("failed to serialize handle register result: {e}"),
-            code: "SCP-VALID-7122".to_owned(),
+            code: codes::VALID_7122.to_owned(),
         }
         .into()
     })
@@ -721,7 +722,7 @@ pub fn py_handle_lookup(
         Some(other) => {
             return Err(ScpPyError::ValidationError {
                 message: format!("invalid type_filter '{other}': expected 'identity' or 'context'"),
-                code: "SCP-VALID-7123".to_owned(),
+                code: codes::VALID_7123.to_owned(),
             }
             .into());
         }
@@ -732,7 +733,7 @@ pub fn py_handle_lookup(
         .lock()
         .map_err(|e| ScpPyError::ValidationError {
             message: format!("handle registry lock poisoned: {e}"),
-            code: "SCP-VALID-7120".to_owned(),
+            code: codes::VALID_7120.to_owned(),
         })?;
 
     let result = guard.get(discovery_context_id).map_or_else(
@@ -750,7 +751,7 @@ pub fn py_handle_lookup(
     serde_json::to_string(&result).map_err(|e| {
         ScpPyError::ValidationError {
             message: format!("failed to serialize handle lookup result: {e}"),
-            code: "SCP-VALID-7124".to_owned(),
+            code: codes::VALID_7124.to_owned(),
         }
         .into()
     })
@@ -784,7 +785,7 @@ pub fn py_handle_deregister(
         .lock()
         .map_err(|e| ScpPyError::ValidationError {
             message: format!("handle registry lock poisoned: {e}"),
-            code: "SCP-VALID-7120".to_owned(),
+            code: codes::VALID_7120.to_owned(),
         })?;
 
     let result = guard.get_mut(discovery_context_id).map_or_else(
@@ -800,7 +801,7 @@ pub fn py_handle_deregister(
     serde_json::to_string(&result).map_err(|e| {
         ScpPyError::ValidationError {
             message: format!("failed to serialize handle deregister result: {e}"),
-            code: "SCP-VALID-7125".to_owned(),
+            code: codes::VALID_7125.to_owned(),
         }
         .into()
     })
@@ -811,7 +812,7 @@ fn parse_handle_target(json: &str) -> PyResult<HandleTarget> {
     petname_helpers::parse_handle_target(json).map_err(|e| {
         ScpPyError::ValidationError {
             message: e.message,
-            code: "SCP-VALID-7126".to_owned(),
+            code: codes::VALID_7126.to_owned(),
         }
         .into()
     })
@@ -885,7 +886,7 @@ pub fn py_scope_register(
             .lock()
             .map_err(|e| ScpPyError::ValidationError {
                 message: format!("scope registry lock poisoned: {e}"),
-                code: "SCP-VALID-7130".to_owned(),
+                code: codes::VALID_7130.to_owned(),
             })?;
 
     let registry = guard
@@ -900,13 +901,13 @@ pub fn py_scope_register(
         )
         .map_err(|e| ScpPyError::ValidationError {
             message: format!("scope registration failed: {e}"),
-            code: "SCP-VALID-7131".to_owned(),
+            code: codes::VALID_7131.to_owned(),
         })?;
 
     serde_json::to_string(&result).map_err(|e| {
         ScpPyError::ValidationError {
             message: format!("failed to serialize scope register result: {e}"),
-            code: "SCP-VALID-7132".to_owned(),
+            code: codes::VALID_7132.to_owned(),
         }
         .into()
     })
@@ -936,7 +937,7 @@ pub fn py_scope_lookup(scope_context_id: &str, name: &str) -> PyResult<String> {
             .lock()
             .map_err(|e| ScpPyError::ValidationError {
                 message: format!("scope registry lock poisoned: {e}"),
-                code: "SCP-VALID-7130".to_owned(),
+                code: codes::VALID_7130.to_owned(),
             })?;
 
     let result = match guard.get(scope_context_id) {
@@ -946,7 +947,7 @@ pub fn py_scope_lookup(scope_context_id: &str, name: &str) -> PyResult<String> {
             })
             .map_err(|e| ScpPyError::ValidationError {
                 message: format!("scope lookup failed: {e}"),
-                code: "SCP-VALID-7133".to_owned(),
+                code: codes::VALID_7133.to_owned(),
             })?,
         None => scp_core::discovery::ScopeLookupResult {
             results: Vec::new(),
@@ -956,7 +957,7 @@ pub fn py_scope_lookup(scope_context_id: &str, name: &str) -> PyResult<String> {
     serde_json::to_string(&result).map_err(|e| {
         ScpPyError::ValidationError {
             message: format!("failed to serialize scope lookup result: {e}"),
-            code: "SCP-VALID-7133".to_owned(),
+            code: codes::VALID_7133.to_owned(),
         }
         .into()
     })
@@ -990,7 +991,7 @@ pub fn py_scope_deregister(scope_context_id: &str, name: &str, did: &str) -> PyR
             .lock()
             .map_err(|e| ScpPyError::ValidationError {
                 message: format!("scope registry lock poisoned: {e}"),
-                code: "SCP-VALID-7130".to_owned(),
+                code: codes::VALID_7130.to_owned(),
             })?;
 
     let result = match guard.get_mut(scope_context_id) {
@@ -1001,7 +1002,7 @@ pub fn py_scope_deregister(scope_context_id: &str, name: &str, did: &str) -> PyR
             })
             .map_err(|e| ScpPyError::ValidationError {
                 message: format!("scope deregister failed: {e}"),
-                code: "SCP-VALID-7134".to_owned(),
+                code: codes::VALID_7134.to_owned(),
             })?,
         None => scp_core::discovery::ScopeDeregisterResult { removed: false },
     };
@@ -1009,7 +1010,7 @@ pub fn py_scope_deregister(scope_context_id: &str, name: &str, did: &str) -> PyR
     serde_json::to_string(&result).map_err(|e| {
         ScpPyError::ValidationError {
             message: format!("failed to serialize scope deregister result: {e}"),
-            code: "SCP-VALID-7134".to_owned(),
+            code: codes::VALID_7134.to_owned(),
         }
         .into()
     })
@@ -1051,7 +1052,7 @@ pub fn py_address_resolve(
     if owner_did.is_empty() {
         return Err(ScpPyError::ValidationError {
             message: "owner_did must not be empty".to_owned(),
-            code: "SCP-VALID-7110".to_owned(),
+            code: codes::VALID_7110.to_owned(),
         }
         .into());
     }
@@ -1059,7 +1060,7 @@ pub fn py_address_resolve(
     let mut known_contexts: HashMap<String, String> = if let Some(json) = known_contexts_json {
         serde_json::from_str(json).map_err(|e| ScpPyError::ValidationError {
             message: format!("invalid known_contexts_json: {e}"),
-            code: "SCP-VALID-7090".to_owned(),
+            code: codes::VALID_7090.to_owned(),
         })?
     } else {
         // Use all known handle registries with context IDs as scope names.
@@ -1067,7 +1068,7 @@ pub fn py_address_resolve(
             .lock()
             .map_err(|e| ScpPyError::ValidationError {
                 message: format!("handle registry lock poisoned: {e}"),
-                code: "SCP-VALID-7120".to_owned(),
+                code: codes::VALID_7120.to_owned(),
             })?;
         guard.keys().map(|k| (k.clone(), k.clone())).collect()
     };
@@ -1088,7 +1089,7 @@ pub fn py_address_resolve(
             .lock()
             .map_err(|e| ScpPyError::ValidationError {
                 message: format!("petname lock poisoned: {e}"),
-                code: "SCP-VALID-7112".to_owned(),
+                code: codes::VALID_7112.to_owned(),
             })?;
         guard.get(owner_did).cloned().unwrap_or_default()
     };
@@ -1109,7 +1110,7 @@ pub fn py_address_resolve(
             .await
             .map_err(|e| ScpPyError::ValidationError {
                 message: format!("address resolution failed: {e}"),
-                code: "SCP-VALID-7091".to_owned(),
+                code: codes::VALID_7091.to_owned(),
             })
     })?;
 
@@ -1119,7 +1120,7 @@ pub fn py_address_resolve(
     serde_json::to_string(&json_results).map_err(|e| {
         ScpPyError::ValidationError {
             message: format!("failed to serialize address resolution results: {e}"),
-            code: "SCP-VALID-7092".to_owned(),
+            code: codes::VALID_7092.to_owned(),
         }
         .into()
     })

--- a/crates/scp-ffi/src/error.rs
+++ b/crates/scp-ffi/src/error.rs
@@ -26,6 +26,7 @@
 //! See ADR-013 in `.docs/adrs/phase-3.md` for the full specification.
 
 use pyo3::prelude::*;
+use scp_ffi_common::error_codes as codes;
 
 // ---------------------------------------------------------------------------
 // Python exception class hierarchy
@@ -180,7 +181,7 @@ impl ScpPyError {
     pub fn identity(msg: impl Into<String>) -> Self {
         Self::IdentityError {
             message: msg.into(),
-            code: "SCP-IDENT-1001".to_owned(),
+            code: codes::IDENT_1001.to_owned(),
         }
     }
 
@@ -188,7 +189,7 @@ impl ScpPyError {
     pub fn context(msg: impl Into<String>) -> Self {
         Self::ContextError {
             message: msg.into(),
-            code: "SCP-CTX-2001".to_owned(),
+            code: codes::CTX_2001.to_owned(),
         }
     }
 
@@ -196,7 +197,7 @@ impl ScpPyError {
     pub fn crypto(msg: impl Into<String>) -> Self {
         Self::CryptoError {
             message: msg.into(),
-            code: "SCP-CRYPTO-4001".to_owned(),
+            code: codes::CRYPTO_4001.to_owned(),
         }
     }
 
@@ -204,7 +205,7 @@ impl ScpPyError {
     pub fn transport(msg: impl Into<String>) -> Self {
         Self::TransportError {
             message: msg.into(),
-            code: "SCP-TRANS-5001".to_owned(),
+            code: codes::TRANS_5001.to_owned(),
         }
     }
 
@@ -212,7 +213,7 @@ impl ScpPyError {
     pub fn ucan(msg: impl Into<String>) -> Self {
         Self::UcanError {
             message: msg.into(),
-            code: "SCP-PERM-3001".to_owned(),
+            code: codes::PERM_3001.to_owned(),
         }
     }
 
@@ -220,7 +221,7 @@ impl ScpPyError {
     pub fn validation(msg: impl Into<String>) -> Self {
         Self::ValidationError {
             message: msg.into(),
-            code: "SCP-VALID-7001".to_owned(),
+            code: codes::VALID_7001.to_owned(),
         }
     }
 }
@@ -257,7 +258,7 @@ impl From<scp_identity::IdentityError> for ScpPyError {
             message: format!(
                 "{e} — check DID format, key custody configuration, or DHT connectivity"
             ),
-            code: "SCP-IDENT-1001".to_owned(),
+            code: codes::IDENT_1001.to_owned(),
         }
     }
 }
@@ -312,17 +313,17 @@ impl From<scp_core::context::ContextError> for ScpPyError {
             // inside the message body.
             CE::RateLimited { .. } => Self::ContextError {
                 message: format!("{e}"),
-                code: "SCP-ECON-12090".to_owned(),
+                code: codes::ECON_12090.to_owned(),
             },
             // §23.17: snapshot import regression rejection.
             CE::SnapshotFloorRegression { .. } => Self::ContextError {
                 message: format!("{e}"),
-                code: "SCP-CTX-2091".to_owned(),
+                code: codes::CTX_2091.to_owned(),
             },
             // C3: snapshot import structural/semantic rejection.
             CE::ImportRejected { .. } => Self::ContextError {
                 message: format!("{e}"),
-                code: "SCP-CTX-2092".to_owned(),
+                code: codes::CTX_2092.to_owned(),
             },
             // `PermissionDenied(String)` is the catch-all the runtime
             // uses for tool-economy and tool-invocation failures
@@ -331,7 +332,7 @@ impl From<scp_core::context::ContextError> for ScpPyError {
             // (budget exceeded, spending UCAN missing, tool not active,
             // etc.) without string-matching the message body.
             CE::PermissionDenied(msg) => {
-                let code = extract_scp_code(msg).unwrap_or_else(|| "SCP-PERM-3001".to_owned());
+                let code = extract_scp_code(msg).unwrap_or_else(|| codes::PERM_3001.to_owned());
                 // Permission/UCAN-class codes raise UcanError; everything
                 // else (tool, economy, context) raises ContextError so
                 // existing call sites that catch ContextError keep
@@ -350,7 +351,7 @@ impl From<scp_core::context::ContextError> for ScpPyError {
             }
             _ => Self::ContextError {
                 message: format!("{e} — verify context state, membership, and permissions"),
-                code: "SCP-CTX-2001".to_owned(),
+                code: codes::CTX_2001.to_owned(),
             },
         }
     }
@@ -362,7 +363,7 @@ impl From<scp_core::context::builder::ContextCreationError> for ScpPyError {
             message: format!(
                 "context creation failed: {e} — check context parameters and identity"
             ),
-            code: "SCP-CTX-2002".to_owned(),
+            code: codes::CTX_2002.to_owned(),
         }
     }
 }
@@ -373,7 +374,7 @@ impl From<scp_core::context::templates::TemplateError> for ScpPyError {
             message: format!(
                 "template validation failed: {e} — ensure context params match the template definition"
             ),
-            code: "SCP-CTX-2003".to_owned(),
+            code: codes::CTX_2003.to_owned(),
         }
     }
 }
@@ -384,7 +385,7 @@ impl From<scp_core::context::roles::RoleError> for ScpPyError {
             message: format!(
                 "role operation failed: {e} — verify role definitions and member permissions"
             ),
-            code: "SCP-CTX-2004".to_owned(),
+            code: codes::CTX_2004.to_owned(),
         }
     }
 }
@@ -395,7 +396,7 @@ impl From<scp_core::context::ttl::TtlError> for ScpPyError {
             message: format!(
                 "TTL operation failed: {e} — check TTL configuration and context state"
             ),
-            code: "SCP-CTX-2005".to_owned(),
+            code: codes::CTX_2005.to_owned(),
         }
     }
 }
@@ -406,7 +407,7 @@ impl From<scp_core::context::promotion::PromotionError> for ScpPyError {
             message: format!(
                 "context promotion failed: {e} — verify eligibility and governance rules"
             ),
-            code: "SCP-CTX-2006".to_owned(),
+            code: codes::CTX_2006.to_owned(),
         }
     }
 }
@@ -419,7 +420,7 @@ impl From<scp_core::context::tools::ToolError> for ScpPyError {
             message: format!(
                 "tool operation failed: {e} — check tool registration, permissions, and input schema"
             ),
-            code: "SCP-TOOL-6001".to_owned(),
+            code: codes::TOOL_6001.to_owned(),
         }
     }
 }
@@ -430,7 +431,7 @@ impl From<scp_core::context::tools::invoke::InvocationError> for ScpPyError {
             message: format!(
                 "tool invocation failed: {e} — verify tool ID, input, and caller permissions"
             ),
-            code: "SCP-TOOL-6002".to_owned(),
+            code: codes::TOOL_6002.to_owned(),
         }
     }
 }
@@ -441,7 +442,7 @@ impl From<scp_core::context::tools::schema::SchemaValidationError> for ScpPyErro
             message: format!(
                 "schema validation failed: {e} — check input against the tool's JSON Schema"
             ),
-            code: "SCP-VALID-7001".to_owned(),
+            code: codes::VALID_7001.to_owned(),
         }
     }
 }
@@ -454,7 +455,7 @@ impl From<scp_core::crypto::mls::error::MlsError> for ScpPyError {
             message: format!(
                 "MLS operation failed: {e} — check group state and member key packages"
             ),
-            code: "SCP-CRYPTO-4001".to_owned(),
+            code: codes::CRYPTO_4001.to_owned(),
         }
     }
 }
@@ -465,7 +466,7 @@ impl From<scp_core::crypto::sender_keys::SenderKeyError> for ScpPyError {
             message: format!(
                 "sender key operation failed: {e} — verify key material and encryption parameters"
             ),
-            code: "SCP-CRYPTO-4002".to_owned(),
+            code: codes::CRYPTO_4002.to_owned(),
         }
     }
 }
@@ -478,7 +479,7 @@ impl From<scp_core::crypto::ucan::UcanError> for ScpPyError {
             message: format!(
                 "{e} — check token format, signatures, time bounds, and capability chain"
             ),
-            code: "SCP-PERM-3001".to_owned(),
+            code: codes::PERM_3001.to_owned(),
         }
     }
 }
@@ -491,7 +492,7 @@ impl From<scp_core::envelope::EnvelopeError> for ScpPyError {
             message: format!(
                 "envelope operation failed: {e} — check payload size, signing keys, and encryption state"
             ),
-            code: "SCP-CRYPTO-4003".to_owned(),
+            code: codes::CRYPTO_4003.to_owned(),
         }
     }
 }
@@ -504,7 +505,7 @@ impl From<scp_event_log::EventLogError> for ScpPyError {
             message: format!(
                 "event log operation failed: {e} — verify log integrity and sequence numbers"
             ),
-            code: "SCP-CTX-2007".to_owned(),
+            code: codes::CTX_2007.to_owned(),
         }
     }
 }
@@ -515,7 +516,7 @@ impl From<scp_core::provenance::ProvenanceError> for ScpPyError {
     fn from(e: scp_core::provenance::ProvenanceError) -> Self {
         Self::ValidationError {
             message: format!("provenance validation failed: {e} — check cross-context chain depth"),
-            code: "SCP-VALID-7002".to_owned(),
+            code: codes::VALID_7002.to_owned(),
         }
     }
 }
@@ -528,7 +529,7 @@ impl From<scp_core::trust::TrustError> for ScpPyError {
             message: format!(
                 "trust evaluation failed: {e} — check event log data and attestation validity"
             ),
-            code: "SCP-VALID-7003".to_owned(),
+            code: codes::VALID_7003.to_owned(),
         }
     }
 }
@@ -539,7 +540,7 @@ impl From<scp_core::uri::ScpUriError> for ScpPyError {
     fn from(e: scp_core::uri::ScpUriError) -> Self {
         Self::ValidationError {
             message: format!("invalid SCP URI: {e} — check URI format (scp://relay/context-id)"),
-            code: "SCP-VALID-7004".to_owned(),
+            code: codes::VALID_7004.to_owned(),
         }
     }
 }
@@ -550,7 +551,7 @@ impl From<scp_core::well_known::WellKnownValidationError> for ScpPyError {
     fn from(e: scp_core::well_known::WellKnownValidationError) -> Self {
         Self::ValidationError {
             message: format!("well-known validation failed: {e} — check relay configuration"),
-            code: "SCP-VALID-7005".to_owned(),
+            code: codes::VALID_7005.to_owned(),
         }
     }
 }
@@ -563,7 +564,7 @@ impl From<scp_core::discovery::DiscoveryError> for ScpPyError {
             message: format!(
                 "discovery operation failed: {e} — check relay connectivity and search parameters"
             ),
-            code: "SCP-CTX-2008".to_owned(),
+            code: codes::CTX_2008.to_owned(),
         }
     }
 }
@@ -576,7 +577,7 @@ impl From<scp_core::bridge::registration::BridgeRegistrationError> for ScpPyErro
             message: format!(
                 "bridge registration failed: {e} — verify bridge configuration and permissions"
             ),
-            code: "SCP-CTX-2009".to_owned(),
+            code: codes::CTX_2009.to_owned(),
         }
     }
 }
@@ -587,7 +588,7 @@ impl From<scp_core::bridge::shadow::ShadowError> for ScpPyError {
             message: format!(
                 "shadow context operation failed: {e} — check bridge state and context permissions"
             ),
-            code: "SCP-CTX-2010".to_owned(),
+            code: codes::CTX_2010.to_owned(),
         }
     }
 }
@@ -600,7 +601,7 @@ impl From<scp_transport::TransportError> for ScpPyError {
             message: format!(
                 "{e} — check relay URL, network connectivity, and transport configuration"
             ),
-            code: "SCP-TRANS-5001".to_owned(),
+            code: codes::TRANS_5001.to_owned(),
         }
     }
 }
@@ -613,7 +614,7 @@ impl From<scp_platform::PlatformError> for ScpPyError {
             message: format!(
                 "platform key operation failed: {e} — check key custody configuration"
             ),
-            code: "SCP-CRYPTO-4004".to_owned(),
+            code: codes::CRYPTO_4004.to_owned(),
         }
     }
 }
@@ -624,7 +625,7 @@ impl From<serde_json::Error> for ScpPyError {
     fn from(e: serde_json::Error) -> Self {
         Self::ValidationError {
             message: format!("JSON serialization/deserialization failed: {e} — check input format"),
-            code: "SCP-VALID-7006".to_owned(),
+            code: codes::VALID_7006.to_owned(),
         }
     }
 }

--- a/crates/scp-ffi/src/event_log.rs
+++ b/crates/scp-ffi/src/event_log.rs
@@ -23,6 +23,7 @@
 
 use pyo3::prelude::*;
 use pyo3::types::PyDict;
+use scp_ffi_common::error_codes as codes;
 use scp_platform::traits::Storage;
 use scp_primitives::Clock;
 
@@ -364,7 +365,7 @@ fn parse_event_query_filter(
                     message: format!(
                         "after_timestamp must be a finite non-negative value, got {ts}"
                     ),
-                    code: "SCP-VALID-7040".to_owned(),
+                    code: codes::VALID_7040.to_owned(),
                 }
                 .into());
             }
@@ -380,7 +381,7 @@ fn parse_event_query_filter(
                     message: format!(
                         "before_timestamp must be a finite non-negative value, got {ts}"
                     ),
-                    code: "SCP-VALID-7040".to_owned(),
+                    code: codes::VALID_7040.to_owned(),
                 }
                 .into());
             }

--- a/crates/scp-ffi/src/mcp.rs
+++ b/crates/scp-ffi/src/mcp.rs
@@ -37,6 +37,7 @@
 //!
 //! See ADR-015 in `.docs/adrs/phase-3.md` for the full MCP adapter design.
 
+use scp_ffi_common::error_codes as codes;
 use std::io::{BufRead, BufReader, Write};
 use std::process::{Child, Command, Stdio};
 use std::sync::{Arc, Mutex, OnceLock};
@@ -1929,7 +1930,7 @@ fn allowlist_err(e: allowlist::AllowlistError) -> ScpPyError {
         | AllowlistError::PathInCommand(_)
         | AllowlistError::InvalidCommand(_) => ScpPyError::ValidationError {
             message: msg,
-            code: "SCP-VALID-7033".to_owned(),
+            code: codes::VALID_7033.to_owned(),
         },
         AllowlistError::NotAllowed { .. } | AllowlistError::LockPoisoned => {
             ScpPyError::transport(msg)

--- a/crates/scp-ffi/src/media.rs
+++ b/crates/scp-ffi/src/media.rs
@@ -17,6 +17,7 @@
 
 use pyo3::prelude::*;
 use pyo3::types::PyDict;
+use scp_ffi_common::error_codes as codes;
 
 use scp_media::session::{
     MediaCapability, MediaSession, MediaSessionState, SessionMetadata, activate_session,
@@ -42,7 +43,7 @@ fn parse_media_capability(s: &str) -> PyResult<MediaCapability> {
             message: format!(
                 "invalid media capability '{other}': expected 'voice', 'video', or 'screen_share'"
             ),
-            code: "SCP-VALID-7300".to_string(),
+            code: codes::VALID_7300.to_string(),
         }
         .into()),
     }
@@ -120,7 +121,7 @@ fn metadata_to_dict<'py>(
 fn media_error_to_py(e: scp_media::keys::MediaError) -> PyErr {
     ScpPyError::ContextError {
         message: e.to_string(),
-        code: "SCP-CTX-2500".to_string(),
+        code: codes::CTX_2500.to_string(),
     }
     .into()
 }
@@ -233,7 +234,7 @@ pub fn py_media_activate_session(
     let mut session: MediaSession =
         serde_json::from_str(&session_json).map_err(|e| ScpPyError::ValidationError {
             message: format!("invalid session JSON: {e}"),
-            code: "SCP-VALID-7301".to_string(),
+            code: codes::VALID_7301.to_string(),
         })?;
 
     activate_session(&mut session).map_err(media_error_to_py)?;
@@ -264,7 +265,7 @@ pub fn py_media_join_session(
     let mut session: MediaSession =
         serde_json::from_str(&session_json).map_err(|e| ScpPyError::ValidationError {
             message: format!("invalid session JSON: {e}"),
-            code: "SCP-VALID-7301".to_string(),
+            code: codes::VALID_7301.to_string(),
         })?;
 
     join_media_session(&mut session, participant_did.into()).map_err(media_error_to_py)?;
@@ -297,7 +298,7 @@ pub fn py_media_end_session(
     let mut session: MediaSession =
         serde_json::from_str(&session_json).map_err(|e| ScpPyError::ValidationError {
             message: format!("invalid session JSON: {e}"),
-            code: "SCP-VALID-7301".to_string(),
+            code: codes::VALID_7301.to_string(),
         })?;
 
     let metadata = end_media_session(&mut session, timestamp).map_err(media_error_to_py)?;
@@ -334,7 +335,7 @@ pub fn py_media_create_offer(
     let (sid, msg) = create_offer(&session_id, sdp, sender_did.into());
     let msg_bytes = serialize_signaling(&msg).map_err(|e| ScpPyError::ValidationError {
         message: format!("failed to serialize signaling message: {e}"),
-        code: "SCP-VALID-7302".to_string(),
+        code: codes::VALID_7302.to_string(),
     })?;
     let dict = PyDict::new(py);
     dict.set_item("session_id", sid)?;
@@ -364,7 +365,7 @@ pub fn py_media_create_answer(
     let (sid, msg) = create_answer(&session_id, sdp, sender_did.into());
     let msg_bytes = serialize_signaling(&msg).map_err(|e| ScpPyError::ValidationError {
         message: format!("failed to serialize signaling message: {e}"),
-        code: "SCP-VALID-7302".to_string(),
+        code: codes::VALID_7302.to_string(),
     })?;
     let dict = PyDict::new(py);
     dict.set_item("session_id", sid)?;
@@ -405,7 +406,7 @@ pub fn py_media_create_ice_candidate(
     );
     let msg_bytes = serialize_signaling(&msg).map_err(|e| ScpPyError::ValidationError {
         message: format!("failed to serialize signaling message: {e}"),
-        code: "SCP-VALID-7302".to_string(),
+        code: codes::VALID_7302.to_string(),
     })?;
     let dict = PyDict::new(py);
     dict.set_item("session_id", sid)?;
@@ -433,7 +434,7 @@ pub fn py_media_create_session_end(
     let (sid, msg) = create_session_end(&session_id, sender_did.into());
     let msg_bytes = serialize_signaling(&msg).map_err(|e| ScpPyError::ValidationError {
         message: format!("failed to serialize signaling message: {e}"),
-        code: "SCP-VALID-7302".to_string(),
+        code: codes::VALID_7302.to_string(),
     })?;
     let dict = PyDict::new(py);
     dict.set_item("session_id", sid)?;
@@ -463,13 +464,13 @@ pub fn py_media_send_signaling(
     let msg = deserialize_signaling(signaling_json.as_bytes()).map_err(|e| {
         ScpPyError::ValidationError {
             message: format!("invalid signaling JSON: {e}"),
-            code: "SCP-VALID-7303".to_string(),
+            code: codes::VALID_7303.to_string(),
         }
     })?;
     let (payload, message_type) =
         send_signaling(&msg).map_err(|e| ScpPyError::ValidationError {
             message: format!("failed to serialize signaling: {e}"),
-            code: "SCP-VALID-7302".to_string(),
+            code: codes::VALID_7302.to_string(),
         })?;
 
     let dict = PyDict::new(py);
@@ -505,13 +506,13 @@ pub fn py_media_verify_sender_attribution(
     let msg = deserialize_signaling(signaling_json.as_bytes()).map_err(|e| {
         ScpPyError::ValidationError {
             message: format!("invalid signaling JSON: {e}"),
-            code: "SCP-VALID-7303".to_string(),
+            code: codes::VALID_7303.to_string(),
         }
     })?;
     verify_sender_attribution(&msg, &envelope_sender_did).map_err(|e| {
         ScpPyError::ContextError {
             message: format!("sender attribution verification failed: {e}"),
-            code: "SCP-CTX-2501".to_string(),
+            code: codes::CTX_2501.to_string(),
         }
     })?;
     Ok(true)

--- a/crates/scp-ffi/src/provenance.rs
+++ b/crates/scp-ffi/src/provenance.rs
@@ -19,6 +19,7 @@
 
 use pyo3::prelude::*;
 use pyo3::types::PyDict;
+use scp_ffi_common::error_codes as codes;
 use sha2::{Digest, Sha256};
 use zeroize::Zeroizing;
 
@@ -144,7 +145,7 @@ pub fn py_provenance_attach<'py>(
     // Compute provenance hash: SHA-256 of JSON-serialized provenance record.
     let prov_json_bytes = serde_json::to_vec(&prov).map_err(|e| ScpPyError::ValidationError {
         message: format!("failed to serialize provenance for hashing: {e}"),
-        code: "SCP-VALID-7053".to_string(),
+        code: codes::VALID_7053.to_string(),
     })?;
     let prov_hash: [u8; 32] = Sha256::digest(&prov_json_bytes).into();
 
@@ -222,7 +223,7 @@ pub fn py_provenance_redact_counterparties(provenance_json: &str) -> PyResult<St
     let mut prov: DataProvenance =
         serde_json::from_str(provenance_json).map_err(|e| ScpPyError::ValidationError {
             message: format!("invalid provenance JSON: {e}"),
-            code: "SCP-VALID-7050".to_string(),
+            code: codes::VALID_7050.to_string(),
         })?;
 
     redact_counterparties(&mut prov);
@@ -230,7 +231,7 @@ pub fn py_provenance_redact_counterparties(provenance_json: &str) -> PyResult<St
     serde_json::to_string(&prov).map_err(|e| {
         ScpPyError::ValidationError {
             message: format!("failed to serialize provenance: {e}"),
-            code: "SCP-VALID-7051".to_string(),
+            code: codes::VALID_7051.to_string(),
         }
         .into()
     })
@@ -257,13 +258,13 @@ pub fn py_provenance_pseudonymize_counterparties(
     let mut prov: DataProvenance =
         serde_json::from_str(provenance_json).map_err(|e| ScpPyError::ValidationError {
             message: format!("invalid provenance JSON: {e}"),
-            code: "SCP-VALID-7050".to_string(),
+            code: codes::VALID_7050.to_string(),
         })?;
 
     let key = Zeroizing::new(hex::decode(pseudonym_key_hex).map_err(|e| {
         ScpPyError::ValidationError {
             message: format!("invalid pseudonym_key_hex: {e}"),
-            code: "SCP-VALID-7052".to_string(),
+            code: codes::VALID_7052.to_string(),
         }
     })?);
 
@@ -272,7 +273,7 @@ pub fn py_provenance_pseudonymize_counterparties(
     serde_json::to_string(&prov).map_err(|e| {
         ScpPyError::ValidationError {
             message: format!("failed to serialize provenance: {e}"),
-            code: "SCP-VALID-7051".to_string(),
+            code: codes::VALID_7051.to_string(),
         }
         .into()
     })
@@ -299,7 +300,7 @@ pub fn py_provenance_update_source_type(
     let mut prov: DataProvenance =
         serde_json::from_str(provenance_json).map_err(|e| ScpPyError::ValidationError {
             message: format!("invalid provenance JSON: {e}"),
-            code: "SCP-VALID-7050".to_string(),
+            code: codes::VALID_7050.to_string(),
         })?;
 
     let state = parse_context_state(new_state)?;
@@ -309,7 +310,7 @@ pub fn py_provenance_update_source_type(
     serde_json::to_string(&prov).map_err(|e| {
         ScpPyError::ValidationError {
             message: format!("failed to serialize provenance: {e}"),
-            code: "SCP-VALID-7051".to_string(),
+            code: codes::VALID_7051.to_string(),
         }
         .into()
     })
@@ -372,7 +373,7 @@ fn parse_memory_scope(s: &str) -> PyResult<MemoryScope> {
             message: format!(
                 "invalid memory_scope '{other}': expected 'full', 'summary', or 'ephemeral'"
             ),
-            code: "SCP-PERM-3010".to_string(),
+            code: codes::PERM_3010.to_string(),
         }
         .into()),
     }
@@ -406,7 +407,7 @@ fn parse_source_type(s: &str) -> PyResult<SourceType> {
             message: format!(
                 "invalid source_type '{other}': expected 'persistent', 'ephemeral', or 'summary'"
             ),
-            code: "SCP-PERM-3011".to_string(),
+            code: codes::PERM_3011.to_string(),
         }
         .into()),
     }
@@ -428,7 +429,7 @@ fn parse_context_state(s: &str) -> PyResult<SourceContextState> {
                 "invalid context_state '{other}': expected 'active', 'closed_with_summary_verified', \
                  'closed_with_summary_unverified', 'closed_ephemeral', or 'unknown'"
             ),
-            code: "SCP-PERM-3012".to_string(),
+            code: codes::PERM_3012.to_string(),
         }
         .into()),
     }

--- a/crates/scp-ffi/src/scpid.rs
+++ b/crates/scp-ffi/src/scpid.rs
@@ -8,6 +8,7 @@
 //!
 //! See spec §3.11 and the `scp-core` `scpid` module.
 
+use scp_ffi_common::error_codes as codes;
 use std::time::Duration;
 
 use pyo3::prelude::*;
@@ -46,14 +47,14 @@ pub fn py_scpid_challenge(audience: String, ttl_seconds: u64) -> PyResult<String
     let challenge = scpid_challenge(&audience, Duration::from_secs(ttl_seconds)).map_err(|e| {
         ScpPyError::ValidationError {
             message: e.to_string(),
-            code: "SCP-IDENT-1038".to_string(),
+            code: codes::IDENT_1038.to_string(),
         }
     })?;
 
     serde_json::to_string(&challenge).map_err(|e| {
         ScpPyError::IdentityError {
             message: format!("failed to serialize SCPID challenge: {e}"),
-            code: "SCP-IDENT-1037".to_string(),
+            code: codes::IDENT_1037.to_string(),
         }
         .into()
     })
@@ -90,7 +91,7 @@ pub fn py_scpid_sign(
     let challenge: ScpIdChallenge =
         serde_json::from_str(&challenge_json).map_err(|e| ScpPyError::ValidationError {
             message: format!("invalid challenge JSON: {e}"),
-            code: "SCP-IDENT-1038".to_string(),
+            code: codes::IDENT_1038.to_string(),
         })?;
 
     let rt = crate::runtime()?;
@@ -106,7 +107,7 @@ pub fn py_scpid_sign(
                                 "identity '{did}' has no agent signing key — \
                              create one with py_identity_add_agent_key first"
                             ),
-                            code: "SCP-IDENT-1034".to_string(),
+                            code: codes::IDENT_1034.to_string(),
                         }
                     })?,
                 };
@@ -121,12 +122,12 @@ pub fn py_scpid_sign(
 
             let response = response.map_err(|e| ScpPyError::IdentityError {
                 message: e.to_string(),
-                code: "SCP-IDENT-1037".to_string(),
+                code: codes::IDENT_1037.to_string(),
             })?;
 
             serde_json::to_string(&response).map_err(|e| ScpPyError::IdentityError {
                 message: format!("failed to serialize SCPID response: {e}"),
-                code: "SCP-IDENT-1037".to_string(),
+                code: codes::IDENT_1037.to_string(),
             })
         })
     })?)
@@ -161,13 +162,13 @@ pub fn py_scpid_verify(
     let response: ScpIdResponse =
         serde_json::from_str(&response_json).map_err(|e| ScpPyError::ValidationError {
             message: format!("invalid response JSON: {e}"),
-            code: "SCP-IDENT-1038".to_string(),
+            code: codes::IDENT_1038.to_string(),
         })?;
 
     let challenge: ScpIdChallenge =
         serde_json::from_str(&challenge_json).map_err(|e| ScpPyError::ValidationError {
             message: format!("invalid challenge JSON: {e}"),
-            code: "SCP-IDENT-1038".to_string(),
+            code: codes::IDENT_1038.to_string(),
         })?;
 
     let rt = crate::runtime()?;
@@ -177,7 +178,7 @@ pub fn py_scpid_verify(
             message: "DID resolver not initialized — create an identity with \
                       py_identity_create before calling scpid_verify"
                 .to_string(),
-            code: "SCP-IDENT-1033".to_string(),
+            code: codes::IDENT_1033.to_string(),
         })?;
 
         let auth = rt
@@ -190,7 +191,7 @@ pub fn py_scpid_verify(
         serde_json::to_string(&auth).map_err(|e| {
             ScpPyError::IdentityError {
                 message: format!("failed to serialize SCPID authentication: {e}"),
-                code: "SCP-IDENT-1037".to_string(),
+                code: codes::IDENT_1037.to_string(),
             }
             .into()
         })
@@ -209,7 +210,7 @@ fn parse_signing_key_id(s: &str) -> PyResult<SigningKeyId> {
         "#agent" => Ok(SigningKeyId::Agent),
         other => Err(ScpPyError::ValidationError {
             message: format!("invalid signing_key_id '{other}': expected '#active' or '#agent'"),
-            code: "SCP-IDENT-1034".to_string(),
+            code: codes::IDENT_1034.to_string(),
         }
         .into()),
     }
@@ -219,15 +220,15 @@ fn parse_signing_key_id(s: &str) -> PyResult<SigningKeyId> {
 const fn scpid_error_code(e: &scp_core::identity::ScpIdError) -> &'static str {
     use scp_core::identity::ScpIdError;
     match e {
-        ScpIdError::ChallengeExpired => "SCP-IDENT-1030",
-        ScpIdError::AudienceMismatch => "SCP-IDENT-1031",
-        ScpIdError::TimestampInvalid => "SCP-IDENT-1032",
-        ScpIdError::DidResolutionFailed(_) => "SCP-IDENT-1033",
-        ScpIdError::KeyNotAuthorized => "SCP-IDENT-1034",
-        ScpIdError::SignatureInvalid => "SCP-IDENT-1035",
-        ScpIdError::DidDocumentStale => "SCP-IDENT-1036",
-        ScpIdError::SigningFailed(_) => "SCP-IDENT-1037",
-        ScpIdError::InvalidInput(_) => "SCP-IDENT-1038",
+        ScpIdError::ChallengeExpired => codes::IDENT_1030,
+        ScpIdError::AudienceMismatch => codes::IDENT_1031,
+        ScpIdError::TimestampInvalid => codes::IDENT_1032,
+        ScpIdError::DidResolutionFailed(_) => codes::IDENT_1033,
+        ScpIdError::KeyNotAuthorized => codes::IDENT_1034,
+        ScpIdError::SignatureInvalid => codes::IDENT_1035,
+        ScpIdError::DidDocumentStale => codes::IDENT_1036,
+        ScpIdError::SigningFailed(_) => codes::IDENT_1037,
+        ScpIdError::InvalidInput(_) => codes::IDENT_1038,
     }
 }
 
@@ -255,6 +256,7 @@ pub fn register_scpid(m: &Bound<'_, PyModule>) -> PyResult<()> {
 #[allow(clippy::unwrap_used, clippy::expect_used)]
 mod tests {
     use super::*;
+    use scp_ffi_common::error_codes as codes;
     use std::sync::Arc;
 
     use scp_identity::resolver::DualLayerResolver;
@@ -311,39 +313,39 @@ mod tests {
 
         assert_eq!(
             scpid_error_code(&ScpIdError::ChallengeExpired),
-            "SCP-IDENT-1030"
+            codes::IDENT_1030
         );
         assert_eq!(
             scpid_error_code(&ScpIdError::AudienceMismatch),
-            "SCP-IDENT-1031"
+            codes::IDENT_1031
         );
         assert_eq!(
             scpid_error_code(&ScpIdError::TimestampInvalid),
-            "SCP-IDENT-1032"
+            codes::IDENT_1032
         );
         assert_eq!(
             scpid_error_code(&ScpIdError::DidResolutionFailed("test".to_owned())),
-            "SCP-IDENT-1033"
+            codes::IDENT_1033
         );
         assert_eq!(
             scpid_error_code(&ScpIdError::KeyNotAuthorized),
-            "SCP-IDENT-1034"
+            codes::IDENT_1034
         );
         assert_eq!(
             scpid_error_code(&ScpIdError::SignatureInvalid),
-            "SCP-IDENT-1035"
+            codes::IDENT_1035
         );
         assert_eq!(
             scpid_error_code(&ScpIdError::DidDocumentStale),
-            "SCP-IDENT-1036"
+            codes::IDENT_1036
         );
         assert_eq!(
             scpid_error_code(&ScpIdError::SigningFailed("test".to_owned())),
-            "SCP-IDENT-1037"
+            codes::IDENT_1037
         );
         assert_eq!(
             scpid_error_code(&ScpIdError::InvalidInput("test".to_owned())),
-            "SCP-IDENT-1038"
+            codes::IDENT_1038
         );
     }
 
@@ -421,7 +423,7 @@ mod tests {
         let err = result.unwrap_err();
         let err_str = err.to_string();
         assert!(
-            err_str.contains("SCP-IDENT-1038"),
+            err_str.contains(codes::IDENT_1038),
             "expected SCP-IDENT-1038 in error, got: {err_str}"
         );
     }
@@ -452,7 +454,7 @@ mod tests {
         let err = result.unwrap_err();
         let err_str = err.to_string();
         assert!(
-            err_str.contains("SCP-IDENT-1038"),
+            err_str.contains(codes::IDENT_1038),
             "expected SCP-IDENT-1038 in error, got: {err_str}"
         );
     }

--- a/crates/scp-ffi/src/server.rs
+++ b/crates/scp-ffi/src/server.rs
@@ -284,59 +284,22 @@ impl PyNodeHandle {
         let rt = crate::runtime()?;
 
         // Resolve broadcast key: explicit or auto-lookup from ContextManager.
-        let (resolved_key_bytes, resolved_epoch, resolved_author_did) = match (
-            broadcast_key_hex,
-            author_did,
-        ) {
-            (Some(key_hex), Some(did)) => {
-                let key_hex = Zeroizing::new(key_hex);
-                let key_vec = Zeroizing::new(hex::decode(&*key_hex).map_err(|e| {
-                    pyo3::exceptions::PyValueError::new_err(format!(
-                        "invalid broadcast_key_hex: {e}"
-                    ))
-                })?);
-                let key_bytes: Zeroizing<[u8; 32]> =
-                    Zeroizing::new(<[u8; 32]>::try_from(key_vec.as_slice()).map_err(|_| {
-                        pyo3::exceptions::PyValueError::new_err(
-                            "broadcast_key_hex must be exactly 64 hex characters (32 bytes)",
-                        )
-                    })?);
-                // Explicit key path always uses epoch 0. For rotated keys, use auto-resolve (omit both params).
-                (key_bytes, 0u64, did)
-            }
-            (None, author_opt) => {
-                // Auto-resolve from ContextManager. Use provided author_did
-                // or fall back to node's identity DID.
-                let did = author_opt.unwrap_or_else(|| self.inner.did().to_owned());
-                let mgr = crate::runtime::context_manager().map_err(|e| {
-                    pyo3::exceptions::PyRuntimeError::new_err(format!(
-                        "broadcast key auto-lookup failed: {e}"
-                    ))
-                })?;
-                let (key_bytes, epoch) = py.allow_threads(|| {
-                        rt.block_on(mgr.get_broadcast_key_for_local_author(&context_id, &did))
-                            .map_err(|e| {
-                                tracing::debug!(error = %e, "broadcast key auto-resolve failed");
-                                pyo3::exceptions::PyRuntimeError::new_err(
-                                    "broadcast key auto-resolve failed: not authorized for this context",
-                                )
-                            })
-                    })?;
-                (key_bytes, epoch, did)
-            }
-            (Some(_), None) => {
-                return Err(pyo3::exceptions::PyValueError::new_err(
-                    "broadcast_key_hex requires author_did — provide the DID of the \
-                     broadcast key owner, or omit both for auto-resolve",
-                ));
-            }
-        };
-
-        let broadcast_key = scp_core::crypto::sender_keys::BroadcastKey::from_parts(
-            scp_core::crypto::sender_keys::SenderKey::from_bytes(*resolved_key_bytes),
-            resolved_epoch,
-            resolved_author_did,
-        );
+        let mgr = crate::runtime::context_manager().map_err(|e| {
+            pyo3::exceptions::PyRuntimeError::new_err(format!(
+                "broadcast key auto-lookup failed: {e}"
+            ))
+        })?;
+        let resolved = py.allow_threads(|| {
+            rt.block_on(server::resolve_broadcast_key(
+                broadcast_key_hex,
+                author_did,
+                self.inner.did(),
+                mgr,
+                &context_id,
+            ))
+            .map_err(|e| pyo3::exceptions::PyValueError::new_err(e.to_string()))
+        })?;
+        let broadcast_key = resolved.into_broadcast_key();
 
         let adm = match admission.to_lowercase().as_str() {
             "open" => scp_core::context::broadcast::BroadcastAdmission::Open,

--- a/crates/scp-ffi/src/tools.rs
+++ b/crates/scp-ffi/src/tools.rs
@@ -17,6 +17,7 @@
 
 use pyo3::prelude::*;
 use pyo3::types::PyDict;
+use scp_ffi_common::error_codes as codes;
 use scp_primitives::Clock;
 
 use crate::error::ScpPyError;
@@ -185,7 +186,7 @@ pub fn py_tool_register(context_id: &str, registration: &Bound<'_, PyDict>) -> P
     let input_schema = schema_json.get("input_schema").cloned().ok_or_else(|| {
         ScpPyError::ValidationError {
             message: "missing 'input_schema' in schema dict — both 'input_schema' and 'output_schema' are required".to_owned(),
-            code: "SCP-VALID-7035".to_owned(),
+            code: codes::VALID_7035.to_owned(),
         }
     })?;
     if !input_schema.is_object() {
@@ -194,14 +195,14 @@ pub fn py_tool_register(context_id: &str, registration: &Bound<'_, PyDict>) -> P
                 "invalid 'input_schema': expected a JSON object, got {}",
                 scp_ffi_common::validate::json_value_type_name(&input_schema)
             ),
-            code: "SCP-VALID-7035".to_owned(),
+            code: codes::VALID_7035.to_owned(),
         }
         .into());
     }
     let output_schema = schema_json.get("output_schema").cloned().ok_or_else(|| {
         ScpPyError::ValidationError {
             message: "missing 'output_schema' in schema dict — both 'input_schema' and 'output_schema' are required".to_owned(),
-            code: "SCP-VALID-7036".to_owned(),
+            code: codes::VALID_7036.to_owned(),
         }
     })?;
     if !output_schema.is_object() {
@@ -210,7 +211,7 @@ pub fn py_tool_register(context_id: &str, registration: &Bound<'_, PyDict>) -> P
                 "invalid 'output_schema': expected a JSON object, got {}",
                 scp_ffi_common::validate::json_value_type_name(&output_schema)
             ),
-            code: "SCP-VALID-7036".to_owned(),
+            code: codes::VALID_7036.to_owned(),
         }
         .into());
     }
@@ -425,7 +426,7 @@ pub fn py_tool_invoke(
             scp_core::crypto::ucan::validate::parse_ucan(jwt).map_err(|e| {
                 ScpPyError::ContextError {
                     message: format!("invalid spending UCAN: {e}"),
-                    code: "SCP-ECON-12061".to_owned(),
+                    code: codes::ECON_12061.to_owned(),
                 }
             })
         })
@@ -603,7 +604,7 @@ fn extract_implementation_hash(registration: &Bound<'_, PyDict>) -> PyResult<[u8
         .extract()
         .map_err(|_| ScpPyError::ValidationError {
             message: "'implementation_hash' must be a hex string".to_owned(),
-            code: "SCP-VALID-7038".to_owned(),
+            code: codes::VALID_7038.to_owned(),
         })?;
 
     if hex_str.len() != 64 {
@@ -612,7 +613,7 @@ fn extract_implementation_hash(registration: &Bound<'_, PyDict>) -> PyResult<[u8
                 "'implementation_hash' must be 64 hex chars (SHA-256), got {}",
                 hex_str.len()
             ),
-            code: "SCP-VALID-7038".to_owned(),
+            code: codes::VALID_7038.to_owned(),
         }
         .into());
     }
@@ -621,11 +622,11 @@ fn extract_implementation_hash(registration: &Bound<'_, PyDict>) -> PyResult<[u8
     for (i, chunk) in hex_str.as_bytes().chunks(2).enumerate() {
         let byte_str = std::str::from_utf8(chunk).map_err(|_| ScpPyError::ValidationError {
             message: "invalid UTF-8 in implementation_hash".to_owned(),
-            code: "SCP-VALID-7038".to_owned(),
+            code: codes::VALID_7038.to_owned(),
         })?;
         hash[i] = u8::from_str_radix(byte_str, 16).map_err(|_| ScpPyError::ValidationError {
             message: format!("invalid hex in implementation_hash at position {}", i * 2),
-            code: "SCP-VALID-7038".to_owned(),
+            code: codes::VALID_7038.to_owned(),
         })?;
     }
 
@@ -696,7 +697,7 @@ fn extract_test_vectors(
             .downcast::<pyo3::types::PyList>()
             .map_err(|_| ScpPyError::ValidationError {
                 message: "'test_vectors' must be a list".to_owned(),
-                code: "SCP-VALID-7037".to_owned(),
+                code: codes::VALID_7037.to_owned(),
             })?;
 
     let mut result = Vec::with_capacity(vectors_list.len());
@@ -705,7 +706,7 @@ fn extract_test_vectors(
             .downcast::<PyDict>()
             .map_err(|_| ScpPyError::ValidationError {
                 message: "each test vector must be a dict".to_owned(),
-                code: "SCP-VALID-7037".to_owned(),
+                code: codes::VALID_7037.to_owned(),
             })?;
         let tv_json = py_dict_to_json(dict)?;
 
@@ -1196,7 +1197,7 @@ pub fn py_tool_interface_expose(
             let parsed: scp_core::context::tools::interface::RateLimit = serde_json::from_str(json)
                 .map_err(|e| ScpPyError::ValidationError {
                     message: format!("invalid rate_limit_json: {e}"),
-                    code: "SCP-VALID-7040".to_owned(),
+                    code: codes::VALID_7040.to_owned(),
                 })?;
             Some(parsed)
         }
@@ -1221,12 +1222,12 @@ pub fn py_tool_interface_expose(
         )
         .map_err(|e| ScpPyError::ContextError {
             message: format!("expose_tool failed: {e}"),
-            code: "SCP-TOOL-6030".to_owned(),
+            code: codes::TOOL_6030.to_owned(),
         })?;
 
         serde_json::to_string(&interface).map_err(|e| ScpPyError::ContextError {
             message: format!("failed to serialize ToolInterface: {e}"),
-            code: "SCP-TOOL-6031".to_owned(),
+            code: codes::TOOL_6031.to_owned(),
         })
     })?)
 }
@@ -1258,7 +1259,7 @@ pub fn py_tool_interface_accept(context_id: &str, interface_json: &str) -> PyRes
     let mut interface: scp_core::context::tools::interface::ToolInterface =
         serde_json::from_str(interface_json).map_err(|e| ScpPyError::ValidationError {
             message: format!("invalid interface_json: {e}"),
-            code: "SCP-VALID-7041".to_owned(),
+            code: codes::VALID_7041.to_owned(),
         })?;
 
     Ok(crate::runtime::with_context(context_id, |rt| {
@@ -1276,12 +1277,12 @@ pub fn py_tool_interface_accept(context_id: &str, interface_json: &str) -> PyRes
         )
         .map_err(|e| ScpPyError::ContextError {
             message: format!("accept_tool_interface failed: {e}"),
-            code: "SCP-TOOL-6032".to_owned(),
+            code: codes::TOOL_6032.to_owned(),
         })?;
 
         serde_json::to_string(&interface).map_err(|e| ScpPyError::ContextError {
             message: format!("failed to serialize ToolInterface: {e}"),
-            code: "SCP-TOOL-6033".to_owned(),
+            code: codes::TOOL_6033.to_owned(),
         })
     })?)
 }
@@ -1311,7 +1312,7 @@ pub fn py_tool_interface_revoke(context_id: &str, interface_id_hex: &str) -> PyR
     let interface_id_bytes =
         hex::decode(interface_id_hex).map_err(|e| ScpPyError::ValidationError {
             message: format!("invalid interface_id_hex: not valid hex: {e}"),
-            code: "SCP-VALID-7042".to_owned(),
+            code: codes::VALID_7042.to_owned(),
         })?;
     let interface_id: [u8; 32] =
         <[u8; 32]>::try_from(interface_id_bytes.as_slice()).map_err(|_| {
@@ -1320,7 +1321,7 @@ pub fn py_tool_interface_revoke(context_id: &str, interface_id_hex: &str) -> PyR
                     "interface_id_hex must be exactly 32 bytes (64 hex chars), got {}",
                     interface_id_bytes.len()
                 ),
-                code: "SCP-VALID-7042".to_owned(),
+                code: codes::VALID_7042.to_owned(),
             }
         })?;
 
@@ -1334,7 +1335,7 @@ pub fn py_tool_interface_revoke(context_id: &str, interface_id_hex: &str) -> PyR
 
     let json = serde_json::to_string(&event).map_err(|e| ScpPyError::ContextError {
         message: format!("failed to serialize InterfaceRevoked: {e}"),
-        code: "SCP-TOOL-6035".to_owned(),
+        code: codes::TOOL_6035.to_owned(),
     })?;
 
     Ok(json)
@@ -1375,6 +1376,7 @@ pub fn register_tools(m: &Bound<'_, PyModule>) -> PyResult<()> {
 #[allow(clippy::unwrap_used, clippy::expect_used)]
 mod tests {
     use super::*;
+    use scp_ffi_common::error_codes as codes;
 
     #[test]
     fn json_value_type_name_covers_all_variants() {
@@ -1410,7 +1412,7 @@ mod tests {
             assert!(result.is_err(), "should reject missing input_schema");
             let err_str = format!("{}", result.unwrap_err());
             assert!(
-                err_str.contains("SCP-VALID-7035"),
+                err_str.contains(codes::VALID_7035),
                 "error should contain SCP-VALID-7035, got: {err_str}"
             );
             assert!(
@@ -1442,7 +1444,7 @@ mod tests {
             assert!(result.is_err(), "should reject missing output_schema");
             let err_str = format!("{}", result.unwrap_err());
             assert!(
-                err_str.contains("SCP-VALID-7036"),
+                err_str.contains(codes::VALID_7036),
                 "error should contain SCP-VALID-7036, got: {err_str}"
             );
             assert!(
@@ -1475,7 +1477,7 @@ mod tests {
             assert!(result.is_err(), "should reject non-object input_schema");
             let err_str = format!("{}", result.unwrap_err());
             assert!(
-                err_str.contains("SCP-VALID-7035"),
+                err_str.contains(codes::VALID_7035),
                 "error should contain SCP-VALID-7035, got: {err_str}"
             );
         });
@@ -1505,7 +1507,7 @@ mod tests {
             assert!(result.is_err(), "should reject non-object output_schema");
             let err_str = format!("{}", result.unwrap_err());
             assert!(
-                err_str.contains("SCP-VALID-7036"),
+                err_str.contains(codes::VALID_7036),
                 "error should contain SCP-VALID-7036, got: {err_str}"
             );
         });
@@ -1547,7 +1549,7 @@ mod tests {
             assert!(result.is_err(), "should reject non-list test_vectors");
             let err_str = format!("{}", result.unwrap_err());
             assert!(
-                err_str.contains("SCP-VALID-7037"),
+                err_str.contains(codes::VALID_7037),
                 "error should contain SCP-VALID-7037, got: {err_str}"
             );
             assert!(
@@ -1573,7 +1575,7 @@ mod tests {
             );
             let err_str = format!("{}", result.unwrap_err());
             assert!(
-                err_str.contains("SCP-VALID-7037"),
+                err_str.contains(codes::VALID_7037),
                 "error should contain SCP-VALID-7037, got: {err_str}"
             );
             assert!(
@@ -1597,7 +1599,7 @@ mod tests {
             assert!(result.is_err(), "should reject dict as test_vectors");
             let err_str = format!("{}", result.unwrap_err());
             assert!(
-                err_str.contains("SCP-VALID-7037"),
+                err_str.contains(codes::VALID_7037),
                 "error should contain SCP-VALID-7037, got: {err_str}"
             );
         });
@@ -1651,7 +1653,7 @@ mod tests {
             );
             let err_str = format!("{}", result.unwrap_err());
             assert!(
-                err_str.contains("SCP-VALID-7038"),
+                err_str.contains(codes::VALID_7038),
                 "error should contain SCP-VALID-7038, got: {err_str}"
             );
             assert!(
@@ -1678,7 +1680,7 @@ mod tests {
             );
             let err_str = format!("{}", result.unwrap_err());
             assert!(
-                err_str.contains("SCP-VALID-7038"),
+                err_str.contains(codes::VALID_7038),
                 "error should contain SCP-VALID-7038, got: {err_str}"
             );
             assert!(
@@ -1708,7 +1710,7 @@ mod tests {
             );
             let err_str = format!("{}", result.unwrap_err());
             assert!(
-                err_str.contains("SCP-VALID-7038"),
+                err_str.contains(codes::VALID_7038),
                 "error should contain SCP-VALID-7038, got: {err_str}"
             );
             assert!(

--- a/crates/scp-ffi/uniffi/src/bridge.rs
+++ b/crates/scp-ffi/uniffi/src/bridge.rs
@@ -9118,42 +9118,34 @@ impl scp_core::crypto::ucan::validate::ProofResolver for NoOpProofResolver {
 fn bridge_params_to_core(
     params: &ContextParams,
 ) -> Result<scp_core::context::ContextParams, ScpError> {
-    use scp_core::context::params::{Capability, PromotionPolicy};
-
-    let mode = match params.mode {
-        ContextMode::Encrypted => scp_core::context::params::ContextMode::Encrypted,
-        ContextMode::Broadcast => scp_core::context::params::ContextMode::Broadcast,
+    // Convert UniFFI bridge enums/fields to canonical string values for the
+    // shared context-params builder (#1447).
+    let mode_str = match params.mode {
+        ContextMode::Encrypted => "encrypted",
+        ContextMode::Broadcast => "broadcast",
     };
 
-    let ceiling: Vec<Capability> = params.ceiling.iter().map(Capability::new).collect();
-
-    let ceiling_policy = match params.ceiling_policy {
-        CeilingPolicy::Immutable => scp_core::context::params::CeilingPolicy::Immutable,
-        CeilingPolicy::Governed => scp_core::context::params::CeilingPolicy::Governed,
+    let ceiling_policy_str = match params.ceiling_policy {
+        CeilingPolicy::Immutable => "immutable",
+        CeilingPolicy::Governed => "governed",
     };
 
-    let memory_scope = match params.memory_scope {
-        MemoryScope::Ephemeral => scp_core::context::params::MemoryScope::Ephemeral,
-        MemoryScope::Summary => scp_core::context::params::MemoryScope::Summary,
-        MemoryScope::Full => scp_core::context::params::MemoryScope::Full,
+    let memory_scope_str = match params.memory_scope {
+        MemoryScope::Ephemeral => "ephemeral",
+        MemoryScope::Summary => "summary",
+        MemoryScope::Full => "full",
     };
 
-    let ttl = if params.ttl_seconds > 0 {
-        Some(std::time::Duration::from_secs(params.ttl_seconds))
+    let governance_str = match params.governance {
+        GovernanceModel::SingleAdmin => "single_admin",
+        GovernanceModel::Multisig => "multisig",
+        GovernanceModel::TokenVoting => "token_voting",
+    };
+
+    let promotion_policy_str = if params.promotable {
+        "promotable"
     } else {
-        None
-    };
-
-    // GovernanceModel in scp-core currently only has SingleAdmin.
-    // All bridge governance variants map to SingleAdmin until scp-core
-    // adds additional model variants (the governance engine dispatch already
-    // handles all 24 actions regardless of the model enum).
-    let governance = scp_core::context::params::GovernanceModel::SingleAdmin;
-
-    let promotion_policy = if params.promotable {
-        PromotionPolicy::Promotable
-    } else {
-        PromotionPolicy::NoPromotion
+        "no_promotion"
     };
 
     let min_protocol_version = if params.min_protocol_version == 0 {
@@ -9164,72 +9156,35 @@ fn bridge_params_to_core(
         Some((major, minor))
     };
 
-    // Deserialize economic_policy JSON string to the core struct, if provided.
-    let economic_policy: Option<scp_core::economy::EconomicPolicy> = params
-        .economic_policy
-        .as_deref()
-        .map(|ep_json| {
-            serde_json::from_str(ep_json).map_err(|e| ScpError::Validation {
-                msg: format!("invalid economic_policy JSON: {e}"),
-                code: "SCP-VALID-7000".to_owned(),
-            })
-        })
-        .transpose()?;
+    let ttl = if params.ttl_seconds > 0 {
+        Some(std::time::Duration::from_secs(params.ttl_seconds))
+    } else {
+        None
+    };
 
-    // Parse consequence_rules_json (ADR-017, #1531) into the typed core
-    // representation. Empty when omitted.
-    let consequence_rules: Vec<scp_core::trust::ConsequenceRule> = params
-        .consequence_rules_json
-        .as_deref()
-        .map(|cr_json| {
-            serde_json::from_str(cr_json).map_err(|e| ScpError::Validation {
-                msg: format!("invalid consequence_rules JSON: {e}"),
-                code: "SCP-VALID-7000".to_owned(),
-            })
-        })
-        .transpose()?
-        .unwrap_or_default();
-
-    // Parse consequence_config_json (ADR-017, #1531) into the typed core
-    // representation. Default config when omitted.
-    let consequence_config: scp_core::context::params::ConsequenceConfig = params
-        .consequence_config_json
-        .as_deref()
-        .map(|cc_json| {
-            serde_json::from_str(cc_json).map_err(|e| ScpError::Validation {
-                msg: format!("invalid consequence_config JSON: {e}"),
-                code: "SCP-VALID-7000".to_owned(),
-            })
-        })
-        .transpose()?
-        .unwrap_or_default();
-
-    // Validate each consequence rule against the per-context config so the
-    // bridge fails closed at creation time rather than deferring to runtime.
-    for rule in &consequence_rules {
-        rule.validate_against_config(&consequence_config)
-            .map_err(|e| ScpError::Validation {
-                msg: format!("consequence rule validation failed: {e}"),
-                code: "SCP-VALID-7000".to_owned(),
-            })?;
-    }
-
-    Ok(scp_core::context::ContextParams {
-        mode,
-        ceiling,
-        ceiling_policy,
-        governance,
-        memory_scope,
+    let common = scp_ffi_common::context_params::CommonContextParams {
+        mode: mode_str.to_owned(),
+        ceiling: params.ceiling.clone(),
+        ceiling_policy: ceiling_policy_str.to_owned(),
+        promotion_policy: promotion_policy_str.to_owned(),
+        memory_scope: memory_scope_str.to_owned(),
+        governance: governance_str.to_owned(),
         ttl,
-        promotion_policy,
         min_protocol_version,
         max_chain_depth: params.max_chain_depth,
         max_nesting_depth: params.max_nesting_depth,
         session_cap: params.session_cap,
-        economic_policy,
-        consequence_rules,
-        consequence_config,
-        ..scp_core::context::ContextParams::default()
+        economic_policy_json: params.economic_policy.clone(),
+        consequence_rules_json: params.consequence_rules_json.clone(),
+        consequence_config_json: params.consequence_config_json.clone(),
+        ..Default::default()
+    };
+
+    scp_ffi_common::context_params::build_context_params(&common).map_err(|e| {
+        ScpError::Validation {
+            msg: e,
+            code: "SCP-VALID-7000".to_owned(),
+        }
     })
 }
 

--- a/crates/scp-ffi/uniffi/src/bridge.rs
+++ b/crates/scp-ffi/uniffi/src/bridge.rs
@@ -24,6 +24,7 @@
 //!
 //! See ADR-021 in `.docs/adrs/phase-4.md`.
 
+use scp_ffi_common::error_codes as codes;
 use std::fmt;
 use std::sync::{Arc, OnceLock};
 
@@ -452,7 +453,7 @@ impl From<scp_ffi_common::validate::ValidationError> for ScpError {
     fn from(e: scp_ffi_common::validate::ValidationError) -> Self {
         Self::Validation {
             msg: e.message,
-            code: "SCP-VALID-7000".to_owned(),
+            code: codes::VALID_7000.to_owned(),
         }
     }
 }
@@ -461,7 +462,7 @@ impl From<scp_identity::IdentityError> for ScpError {
     fn from(e: scp_identity::IdentityError) -> Self {
         Self::Identity {
             msg: format!("{e} — check DID format, key custody configuration, or DHT connectivity"),
-            code: "SCP-IDENT-1001".to_owned(),
+            code: codes::IDENT_1001.to_owned(),
         }
     }
 }
@@ -499,23 +500,23 @@ impl From<scp_core::context::ContextError> for ScpError {
             // message body.
             CE::RateLimited { .. } => Self::Context {
                 msg: format!("{e}"),
-                code: "SCP-ECON-12090".to_owned(),
+                code: codes::ECON_12090.to_owned(),
             },
             // §23.17 snapshot import regression.
             CE::SnapshotFloorRegression { .. } => Self::Context {
                 msg: format!("{e}"),
-                code: "SCP-CTX-2091".to_owned(),
+                code: codes::CTX_2091.to_owned(),
             },
             // C3: snapshot import structural/semantic rejection.
             CE::ImportRejected { .. } => Self::Context {
                 msg: format!("{e}"),
-                code: "SCP-CTX-2092".to_owned(),
+                code: codes::CTX_2092.to_owned(),
             },
             // Recover embedded SCP-ECON-/SCP-TOOL-/SCP-PERM- codes from
             // the runtime's `PermissionDenied(String)` catch-all so the
             // typed-envelope contract holds for tool-economy failures.
             CE::PermissionDenied(msg) => {
-                let code = extract_scp_code(msg).unwrap_or_else(|| "SCP-PERM-3001".to_owned());
+                let code = extract_scp_code(msg).unwrap_or_else(|| codes::PERM_3001.to_owned());
                 if code.starts_with("SCP-PERM-") {
                     Self::Permission {
                         msg: format!("{e}"),
@@ -535,7 +536,7 @@ impl From<scp_core::context::ContextError> for ScpError {
             }
             _ => Self::Context {
                 msg: format!("{e} — verify context state, membership, and permissions"),
-                code: "SCP-CTX-2001".to_owned(),
+                code: codes::CTX_2001.to_owned(),
             },
         }
     }
@@ -545,7 +546,7 @@ impl From<scp_core::context::builder::ContextCreationError> for ScpError {
     fn from(e: scp_core::context::builder::ContextCreationError) -> Self {
         Self::Context {
             msg: format!("context creation failed: {e} — check context parameters and identity"),
-            code: "SCP-CTX-2002".to_owned(),
+            code: codes::CTX_2002.to_owned(),
         }
     }
 }
@@ -556,7 +557,7 @@ impl From<scp_core::context::templates::TemplateError> for ScpError {
             msg: format!(
                 "template validation failed: {e} — ensure context params match the template"
             ),
-            code: "SCP-CTX-2003".to_owned(),
+            code: codes::CTX_2003.to_owned(),
         }
     }
 }
@@ -567,7 +568,7 @@ impl From<scp_core::context::roles::RoleError> for ScpError {
             msg: format!(
                 "role operation failed: {e} — verify role definitions and member permissions"
             ),
-            code: "SCP-CTX-2004".to_owned(),
+            code: codes::CTX_2004.to_owned(),
         }
     }
 }
@@ -576,7 +577,7 @@ impl From<scp_core::context::ttl::TtlError> for ScpError {
     fn from(e: scp_core::context::ttl::TtlError) -> Self {
         Self::Context {
             msg: format!("TTL operation failed: {e} — check TTL configuration and context state"),
-            code: "SCP-CTX-2005".to_owned(),
+            code: codes::CTX_2005.to_owned(),
         }
     }
 }
@@ -585,7 +586,7 @@ impl From<scp_core::context::promotion::PromotionError> for ScpError {
     fn from(e: scp_core::context::promotion::PromotionError) -> Self {
         Self::Context {
             msg: format!("context promotion failed: {e} — verify eligibility and governance rules"),
-            code: "SCP-CTX-2006".to_owned(),
+            code: codes::CTX_2006.to_owned(),
         }
     }
 }
@@ -596,7 +597,7 @@ impl From<scp_core::context::tools::ToolError> for ScpError {
             msg: format!(
                 "tool operation failed: {e} — check tool registration, permissions, and input schema"
             ),
-            code: "SCP-TOOL-6001".to_owned(),
+            code: codes::TOOL_6001.to_owned(),
         }
     }
 }
@@ -607,7 +608,7 @@ impl From<scp_core::context::tools::invoke::InvocationError> for ScpError {
             msg: format!(
                 "tool invocation failed: {e} — verify tool ID, input, and caller permissions"
             ),
-            code: "SCP-TOOL-6002".to_owned(),
+            code: codes::TOOL_6002.to_owned(),
         }
     }
 }
@@ -618,7 +619,7 @@ impl From<scp_core::context::tools::schema::SchemaValidationError> for ScpError 
             msg: format!(
                 "schema validation failed: {e} — check input against the tool's JSON Schema"
             ),
-            code: "SCP-VALID-7001".to_owned(),
+            code: codes::VALID_7001.to_owned(),
         }
     }
 }
@@ -627,7 +628,7 @@ impl From<scp_core::crypto::mls::error::MlsError> for ScpError {
     fn from(e: scp_core::crypto::mls::error::MlsError) -> Self {
         Self::Crypto {
             msg: format!("MLS operation failed: {e} — check group state and member key packages"),
-            code: "SCP-CRYPTO-4001".to_owned(),
+            code: codes::CRYPTO_4001.to_owned(),
         }
     }
 }
@@ -638,7 +639,7 @@ impl From<scp_core::crypto::sender_keys::SenderKeyError> for ScpError {
             msg: format!(
                 "sender key operation failed: {e} — verify key material and encryption parameters"
             ),
-            code: "SCP-CRYPTO-4002".to_owned(),
+            code: codes::CRYPTO_4002.to_owned(),
         }
     }
 }
@@ -647,7 +648,7 @@ impl From<scp_core::crypto::ucan::UcanError> for ScpError {
     fn from(e: scp_core::crypto::ucan::UcanError) -> Self {
         Self::Permission {
             msg: format!("{e} — check token format, signatures, time bounds, and capability chain"),
-            code: "SCP-PERM-3001".to_owned(),
+            code: codes::PERM_3001.to_owned(),
         }
     }
 }
@@ -658,7 +659,7 @@ impl From<scp_core::envelope::EnvelopeError> for ScpError {
             msg: format!(
                 "envelope operation failed: {e} — check payload size, signing keys, and encryption state"
             ),
-            code: "SCP-CRYPTO-4003".to_owned(),
+            code: codes::CRYPTO_4003.to_owned(),
         }
     }
 }
@@ -669,7 +670,7 @@ impl From<scp_event_log::EventLogError> for ScpError {
             msg: format!(
                 "event log operation failed: {e} — verify log integrity and sequence numbers"
             ),
-            code: "SCP-CTX-2007".to_owned(),
+            code: codes::CTX_2007.to_owned(),
         }
     }
 }
@@ -678,7 +679,7 @@ impl From<scp_core::provenance::ProvenanceError> for ScpError {
     fn from(e: scp_core::provenance::ProvenanceError) -> Self {
         Self::Validation {
             msg: format!("provenance validation failed: {e} — check cross-context chain depth"),
-            code: "SCP-VALID-7002".to_owned(),
+            code: codes::VALID_7002.to_owned(),
         }
     }
 }
@@ -689,7 +690,7 @@ impl From<scp_core::trust::TrustError> for ScpError {
             msg: format!(
                 "trust evaluation failed: {e} — check event log data and attestation validity"
             ),
-            code: "SCP-VALID-7003".to_owned(),
+            code: codes::VALID_7003.to_owned(),
         }
     }
 }
@@ -698,7 +699,7 @@ impl From<scp_core::uri::ScpUriError> for ScpError {
     fn from(e: scp_core::uri::ScpUriError) -> Self {
         Self::Validation {
             msg: format!("invalid SCP URI: {e} — check URI format (scp://relay/context-id)"),
-            code: "SCP-VALID-7004".to_owned(),
+            code: codes::VALID_7004.to_owned(),
         }
     }
 }
@@ -707,7 +708,7 @@ impl From<scp_core::well_known::WellKnownValidationError> for ScpError {
     fn from(e: scp_core::well_known::WellKnownValidationError) -> Self {
         Self::Validation {
             msg: format!("well-known validation failed: {e} — check relay configuration"),
-            code: "SCP-VALID-7005".to_owned(),
+            code: codes::VALID_7005.to_owned(),
         }
     }
 }
@@ -718,7 +719,7 @@ impl From<scp_core::discovery::DiscoveryError> for ScpError {
             msg: format!(
                 "discovery operation failed: {e} — check relay connectivity and search parameters"
             ),
-            code: "SCP-CTX-2008".to_owned(),
+            code: codes::CTX_2008.to_owned(),
         }
     }
 }
@@ -729,7 +730,7 @@ impl From<scp_core::bridge::registration::BridgeRegistrationError> for ScpError 
             msg: format!(
                 "bridge registration failed: {e} — verify bridge configuration and permissions"
             ),
-            code: "SCP-CTX-2009".to_owned(),
+            code: codes::CTX_2009.to_owned(),
         }
     }
 }
@@ -740,7 +741,7 @@ impl From<scp_core::bridge::shadow::ShadowError> for ScpError {
             msg: format!(
                 "shadow context operation failed: {e} — check bridge state and context permissions"
             ),
-            code: "SCP-CTX-2010".to_owned(),
+            code: codes::CTX_2010.to_owned(),
         }
     }
 }
@@ -751,7 +752,7 @@ impl From<scp_transport::TransportError> for ScpError {
             msg: format!(
                 "{e} — check relay URL, network connectivity, and transport configuration"
             ),
-            code: "SCP-TRANS-5001".to_owned(),
+            code: codes::TRANS_5001.to_owned(),
         }
     }
 }
@@ -760,7 +761,7 @@ impl From<scp_platform::PlatformError> for ScpError {
     fn from(e: scp_platform::PlatformError) -> Self {
         Self::Crypto {
             msg: format!("platform key operation failed: {e} — check key custody configuration"),
-            code: "SCP-CRYPTO-4004".to_owned(),
+            code: codes::CRYPTO_4004.to_owned(),
         }
     }
 }
@@ -769,7 +770,7 @@ impl From<serde_json::Error> for ScpError {
     fn from(e: serde_json::Error) -> Self {
         Self::Validation {
             msg: format!("JSON serialization/deserialization failed: {e} — check input format"),
-            code: "SCP-VALID-7006".to_owned(),
+            code: codes::VALID_7006.to_owned(),
         }
     }
 }
@@ -1106,7 +1107,7 @@ impl DataProvenance {
                         "payment_receipt_id must be exactly 32 bytes, got {}",
                         v.len()
                     ),
-                    code: "SCP-VALID-7080".to_owned(),
+                    code: codes::VALID_7080.to_owned(),
                 })?;
                 Some(arr)
             }
@@ -1392,7 +1393,7 @@ impl Identity {
                       was loaded without key material (use identity_create or \
                       identity_create_with_custody)"
                 .to_owned(),
-            code: "SCP-IDENT-1002".to_owned(),
+            code: codes::IDENT_1002.to_owned(),
         })?;
 
         // Dispatch to the correct custody path.
@@ -1442,7 +1443,7 @@ impl Identity {
                       identity_create_with_custody() for platform custody or \
                       identity_create(\"in_memory\") for dev/test"
                 .to_owned(),
-            code: "SCP-IDENT-1002".to_owned(),
+            code: codes::IDENT_1002.to_owned(),
         })
     }
 
@@ -1514,7 +1515,7 @@ impl Identity {
                           enable the \"allow_in_memory_custody\" feature or use \
                           the platform KeyCustodyProvider interface"
                     .to_owned(),
-                code: "SCP-IDENT-1008".to_owned(),
+                code: codes::IDENT_1008.to_owned(),
             })
         }
 
@@ -1524,21 +1525,21 @@ impl Identity {
                 msg: "cannot add agent key to an external/loaded identity \
                           without core state — use identity_create first"
                     .to_owned(),
-                code: "SCP-IDENT-1005".to_owned(),
+                code: codes::IDENT_1005.to_owned(),
             })?;
             let core_doc = self
                 .core_document
                 .as_ref()
                 .ok_or_else(|| ScpError::Identity {
                     msg: "cannot add agent key without a retained DID document".to_owned(),
-                    code: "SCP-IDENT-1005".to_owned(),
+                    code: codes::IDENT_1005.to_owned(),
                 })?;
             let custody = self
                 .in_memory_custody
                 .as_ref()
                 .ok_or_else(|| ScpError::Identity {
                     msg: "cannot add agent key without in-memory custody".to_owned(),
-                    code: "SCP-IDENT-1008".to_owned(),
+                    code: codes::IDENT_1008.to_owned(),
                 })?
                 .clone();
 
@@ -1571,7 +1572,7 @@ impl Identity {
                 .await
                 .map_err(|e| ScpError::Identity {
                     msg: format!("tokio task join error during add_agent_key: {e}"),
-                    code: "SCP-IDENT-1007".to_owned(),
+                    code: codes::IDENT_1007.to_owned(),
                 })?
         }
     }
@@ -1600,7 +1601,7 @@ impl Identity {
                           enable the \"allow_in_memory_custody\" feature or use \
                           the platform KeyCustodyProvider interface"
                     .to_owned(),
-                code: "SCP-IDENT-1008".to_owned(),
+                code: codes::IDENT_1008.to_owned(),
             })
         }
 
@@ -1610,14 +1611,14 @@ impl Identity {
                 msg: "cannot remove agent key from an external/loaded identity \
                           without core state"
                     .to_owned(),
-                code: "SCP-IDENT-1005".to_owned(),
+                code: codes::IDENT_1005.to_owned(),
             })?;
             let core_doc = self
                 .core_document
                 .as_ref()
                 .ok_or_else(|| ScpError::Identity {
                     msg: "cannot remove agent key without a retained DID document".to_owned(),
-                    code: "SCP-IDENT-1005".to_owned(),
+                    code: codes::IDENT_1005.to_owned(),
                 })?;
 
             let custody = self
@@ -1627,7 +1628,7 @@ impl Identity {
                     msg: "cannot remove agent key without in-memory custody \
                               (needed for DHT publish signing)"
                         .to_owned(),
-                    code: "SCP-IDENT-1008".to_owned(),
+                    code: codes::IDENT_1008.to_owned(),
                 })?;
 
             // Clone what we need for the spawned task.
@@ -1659,7 +1660,7 @@ impl Identity {
                 .await
                 .map_err(|e| ScpError::Identity {
                     msg: format!("tokio task join error during remove_agent_key: {e}"),
-                    code: "SCP-IDENT-1007".to_owned(),
+                    code: codes::IDENT_1007.to_owned(),
                 })?
         }
     }
@@ -1688,7 +1689,7 @@ impl Identity {
                           enable the \"allow_in_memory_custody\" feature or use \
                           the platform KeyCustodyProvider interface"
                     .to_owned(),
-                code: "SCP-IDENT-1008".to_owned(),
+                code: codes::IDENT_1008.to_owned(),
             })
         }
 
@@ -1698,21 +1699,21 @@ impl Identity {
                 msg: "cannot rotate agent key on an external/loaded identity \
                           without core state"
                     .to_owned(),
-                code: "SCP-IDENT-1005".to_owned(),
+                code: codes::IDENT_1005.to_owned(),
             })?;
             let core_doc = self
                 .core_document
                 .as_ref()
                 .ok_or_else(|| ScpError::Identity {
                     msg: "cannot rotate agent key without a retained DID document".to_owned(),
-                    code: "SCP-IDENT-1005".to_owned(),
+                    code: codes::IDENT_1005.to_owned(),
                 })?;
             let custody = self
                 .in_memory_custody
                 .as_ref()
                 .ok_or_else(|| ScpError::Identity {
                     msg: "cannot rotate agent key without in-memory custody".to_owned(),
-                    code: "SCP-IDENT-1008".to_owned(),
+                    code: codes::IDENT_1008.to_owned(),
                 })?
                 .clone();
 
@@ -1745,7 +1746,7 @@ impl Identity {
                 .await
                 .map_err(|e| ScpError::Identity {
                     msg: format!("tokio task join error during rotate_agent_key: {e}"),
-                    code: "SCP-IDENT-1007".to_owned(),
+                    code: codes::IDENT_1007.to_owned(),
                 })?
         }
     }
@@ -1838,7 +1839,7 @@ impl ContextHandle {
     pub fn state(&self) -> Result<String, ScpError> {
         let guard = self.state.try_lock().map_err(|_| ScpError::Context {
             msg: "context state lock is contended — retry".to_owned(),
-            code: "SCP-CTX-2012".to_owned(),
+            code: codes::CTX_2012.to_owned(),
         })?;
         Ok(match *guard {
             ContextState::Creating => "creating".to_owned(),
@@ -2080,7 +2081,7 @@ impl TransportManager {
 
         let mut mgr = self.inner.write().map_err(|_| ScpError::Transport {
             msg: "transport manager lock is poisoned".to_owned(),
-            code: "SCP-TRANS-5003".to_owned(),
+            code: codes::TRANS_5003.to_owned(),
         })?;
         let _eviction = mgr.add_adapter(Box::new(adapter));
         #[allow(clippy::cast_possible_truncation)] // Bounded by connection budget.
@@ -2115,13 +2116,13 @@ impl TransportManager {
         validate_context_id(&context_id)?;
         let mgr = self.inner.read().map_err(|_| ScpError::Transport {
             msg: "transport manager lock is poisoned".to_owned(),
-            code: "SCP-TRANS-5003".to_owned(),
+            code: codes::TRANS_5003.to_owned(),
         })?;
         let indices = mgr
             .assign_relay_set(&context_id)
             .map_err(|e| ScpError::Transport {
                 msg: format!("relay set assignment failed: {e}"),
-                code: "SCP-TRANS-5004".to_owned(),
+                code: codes::TRANS_5004.to_owned(),
             })?;
         #[allow(clippy::cast_possible_truncation)] // Adapter indices bounded by adapter count.
         Ok(indices.into_iter().map(|i| i as u32).collect())
@@ -2289,7 +2290,7 @@ pub async fn identity_create(custody: String) -> Result<Arc<Identity>, ScpError>
                                       dev/desktop use. Production mobile builds must use \
                                       \"platform\" custody (Secure Enclave / Android Keystore)."
                                 .to_owned(),
-                            code: "SCP-IDENT-1008".to_owned(),
+                            code: codes::IDENT_1008.to_owned(),
                         })
                     }
 
@@ -2339,7 +2340,7 @@ pub async fn identity_create(custody: String) -> Result<Arc<Identity>, ScpError>
                              Enclave (iOS) or Android Keystore (Android) backed \
                              custody provider"
                         ),
-                        code: "SCP-IDENT-1003".to_owned(),
+                        code: codes::IDENT_1003.to_owned(),
                     })
                 }
                 CustodyMethod::External => {
@@ -2351,7 +2352,7 @@ pub async fn identity_create(custody: String) -> Result<Arc<Identity>, ScpError>
                         msg: "internal: CustodyMethod::External cannot be used with \
                                   identity_create — use identity_load for external DID handles"
                             .to_owned(),
-                        code: "SCP-IDENT-1005".to_owned(),
+                        code: codes::IDENT_1005.to_owned(),
                     })
                 }
             }
@@ -2359,7 +2360,7 @@ pub async fn identity_create(custody: String) -> Result<Arc<Identity>, ScpError>
         .await
         .map_err(|e| ScpError::Identity {
             msg: format!("tokio task join error during identity creation: {e}"),
-            code: "SCP-IDENT-1007".to_owned(),
+            code: codes::IDENT_1007.to_owned(),
         })?
 }
 
@@ -2417,7 +2418,7 @@ pub async fn identity_create_with_custody(
         .await
         .map_err(|e| ScpError::Identity {
             msg: format!("tokio task join error during identity creation: {e}"),
-            code: "SCP-IDENT-1007".to_owned(),
+            code: codes::IDENT_1007.to_owned(),
         })?
 }
 
@@ -2442,7 +2443,7 @@ pub async fn identity_load(did: String) -> Result<Arc<Identity>, ScpError> {
             if !did.starts_with("did:dht:") {
                 return Err(ScpError::Identity {
                     msg: format!("unsupported DID method: {did} — only did:dht is supported"),
-                    code: "SCP-IDENT-1004".to_owned(),
+                    code: codes::IDENT_1004.to_owned(),
                 });
             }
 
@@ -2463,7 +2464,7 @@ pub async fn identity_load(did: String) -> Result<Arc<Identity>, ScpError> {
         .await
         .map_err(|e| ScpError::Identity {
             msg: format!("tokio task join error during identity load: {e}"),
-            code: "SCP-IDENT-1005".to_owned(),
+            code: codes::IDENT_1005.to_owned(),
         })?
 }
 
@@ -2503,7 +2504,7 @@ pub async fn identity_resolve(did: String) -> Result<DIDDocument, ScpError> {
         .await
         .map_err(|e| ScpError::Identity {
             msg: format!("tokio task join error during DID resolution: {e}"),
-            code: "SCP-IDENT-1006".to_owned(),
+            code: codes::IDENT_1006.to_owned(),
         })?
 }
 
@@ -2552,13 +2553,13 @@ async fn identity_attest_device_impl(identity: Arc<Identity>) -> Result<String, 
                     msg: "device attestation requires retained identity state — the identity \
                           was externally loaded via identity_load"
                         .to_owned(),
-                    code: "SCP-IDENT-1007".to_owned(),
+                    code: codes::IDENT_1007.to_owned(),
                 })?;
 
             let attestation = InMemoryDeviceAttestation::new();
             let token = attestation.attest().await.map_err(|e| ScpError::Identity {
                 msg: format!("device attestation failed: {e}"),
-                code: "SCP-IDENT-1010".to_owned(),
+                code: codes::IDENT_1010.to_owned(),
             })?;
 
             use base64::Engine;
@@ -2567,7 +2568,7 @@ async fn identity_attest_device_impl(identity: Arc<Identity>) -> Result<String, 
         .await
         .map_err(|e| ScpError::Identity {
             msg: format!("tokio task join error during device attestation: {e}"),
-            code: "SCP-IDENT-1007".to_owned(),
+            code: codes::IDENT_1007.to_owned(),
         })?
 }
 
@@ -2579,7 +2580,7 @@ async fn identity_attest_device_impl(_identity: Arc<Identity>) -> Result<String,
                   path is not available in this build. Enable the \
                   \"allow_in_memory_custody\" feature for dev/desktop use."
             .to_owned(),
-        code: "SCP-IDENT-1010".to_owned(),
+        code: codes::IDENT_1010.to_owned(),
     })
 }
 
@@ -2626,7 +2627,7 @@ async fn identity_verify_device_attestation_impl(
                 .decode(&token_base64)
                 .map_err(|e| ScpError::Identity {
                     msg: format!("invalid base64 attestation token: {e}"),
-                    code: "SCP-IDENT-1011".to_owned(),
+                    code: codes::IDENT_1011.to_owned(),
                 })?;
 
             let token = scp_platform::traits::DeviceAttestationToken::new(token_bytes);
@@ -2637,13 +2638,13 @@ async fn identity_verify_device_attestation_impl(
                 .await
                 .map_err(|e| ScpError::Identity {
                     msg: format!("device attestation verification failed: {e}"),
-                    code: "SCP-IDENT-1012".to_owned(),
+                    code: codes::IDENT_1012.to_owned(),
                 })
         })
         .await
         .map_err(|e| ScpError::Identity {
             msg: format!("tokio task join error during device attestation verification: {e}"),
-            code: "SCP-IDENT-1007".to_owned(),
+            code: codes::IDENT_1007.to_owned(),
         })?
 }
 
@@ -2658,7 +2659,7 @@ async fn identity_verify_device_attestation_impl(
                   custody path is not available in this build. Enable the \
                   \"allow_in_memory_custody\" feature for dev/desktop use."
             .to_owned(),
-        code: "SCP-IDENT-1010".to_owned(),
+        code: codes::IDENT_1010.to_owned(),
     })
 }
 
@@ -2738,6 +2739,7 @@ async fn identity_create_link_attestation_impl(
     verification_method: String,
     platform_id: Option<String>,
 ) -> Result<String, ScpError> {
+    use scp_ffi_common::error_codes as codes;
     use std::borrow::Cow;
 
     use scp_core::identity::attestation::{
@@ -2752,7 +2754,7 @@ async fn identity_create_link_attestation_impl(
     scp_ffi_common::validate::validate_attestation_fields(&platform, &handle, &proof).map_err(
         |e| ScpError::Validation {
             msg: format!("attestation field validation failed: {e}"),
-            code: "SCP-VALID-7037".to_owned(),
+            code: codes::VALID_7037.to_owned(),
         },
     )?;
 
@@ -2761,7 +2763,7 @@ async fn identity_create_link_attestation_impl(
             .parse()
             .map_err(|e: String| ScpError::Identity {
                 msg: e,
-                code: "SCP-IDENT-1040".to_owned(),
+                code: codes::IDENT_1040.to_owned(),
             })?;
 
     // Proof is an opaque string per §3.5.2 — pass through as-is.
@@ -2772,14 +2774,14 @@ async fn identity_create_link_attestation_impl(
         .as_ref()
         .ok_or_else(|| ScpError::Identity {
             msg: "identity link attestation requires retained identity state".to_owned(),
-            code: "SCP-IDENT-1040".to_owned(),
+            code: codes::IDENT_1040.to_owned(),
         })?;
     let custody = identity
         .in_memory_custody
         .as_ref()
         .ok_or_else(|| ScpError::Identity {
             msg: "identity link attestation requires in-memory custody".to_owned(),
-            code: "SCP-IDENT-1040".to_owned(),
+            code: codes::IDENT_1040.to_owned(),
         })?;
 
     let did_str = identity.did.clone();
@@ -2788,7 +2790,7 @@ async fn identity_create_link_attestation_impl(
         .duration_since(std::time::UNIX_EPOCH)
         .map_err(|_| ScpError::Identity {
             msg: "system clock is before UNIX epoch".to_owned(),
-            code: "SCP-IDENT-1042".to_owned(),
+            code: codes::IDENT_1042.to_owned(),
         })?
         .as_secs();
 
@@ -2824,7 +2826,7 @@ async fn identity_create_link_attestation_impl(
                     .collect::<Vec<_>>()
                     .join("; "),
             ),
-            code: "SCP-IDENT-1041".to_owned(),
+            code: codes::IDENT_1041.to_owned(),
         });
     }
 
@@ -2832,7 +2834,7 @@ async fn identity_create_link_attestation_impl(
         .canonical_signing_bytes()
         .map_err(|e| ScpError::Identity {
             msg: format!("attestation signing failed: {e}"),
-            code: "SCP-IDENT-1041".to_owned(),
+            code: codes::IDENT_1041.to_owned(),
         })?;
 
     let active_key = core_id.active_signing_key;
@@ -2843,11 +2845,11 @@ async fn identity_create_link_attestation_impl(
         .await
         .map_err(|e| ScpError::Identity {
             msg: format!("tokio join error: {e}"),
-            code: "SCP-IDENT-1041".to_owned(),
+            code: codes::IDENT_1041.to_owned(),
         })?
         .map_err(|e| ScpError::Identity {
             msg: format!("Ed25519 signing failed: {e}"),
-            code: "SCP-IDENT-1041".to_owned(),
+            code: codes::IDENT_1041.to_owned(),
         })?;
     attestation.signature = sig.as_bytes().to_vec();
 
@@ -2872,7 +2874,7 @@ async fn identity_create_link_attestation_impl(
                             "custody registry has reached capacity \
                              ({UNIFFI_CUSTODY_REGISTRY_CAP}) — cannot store additional entries"
                         ),
-                        code: "SCP-VALID-7403".to_owned(),
+                        code: codes::VALID_7403.to_owned(),
                     });
                 }
                 vac.insert((Arc::clone(custody), active_key));
@@ -2892,7 +2894,7 @@ async fn identity_create_link_attestation_impl(
                             "DID has reached the per-identity attestation limit \
                              ({MAX_IDENTITY_LINK_ATTESTATIONS_PER_DID}) — cannot store additional attestations"
                         ),
-                        code: "SCP-VALID-7403".to_owned(),
+                        code: codes::VALID_7403.to_owned(),
                     });
                 }
                 occ.get_mut().push(attestation.clone());
@@ -2904,7 +2906,7 @@ async fn identity_create_link_attestation_impl(
                             "link attestation registry has reached capacity \
                              ({UNIFFI_LINK_ATTESTATION_REGISTRY_CAP}) — cannot store additional attestations"
                         ),
-                        code: "SCP-VALID-7402".to_owned(),
+                        code: codes::VALID_7402.to_owned(),
                     });
                 }
                 vac.insert(vec![attestation.clone()]);
@@ -2914,7 +2916,7 @@ async fn identity_create_link_attestation_impl(
 
     serde_json::to_string(&attestation).map_err(|e| ScpError::Identity {
         msg: format!("failed to serialize attestation: {e}"),
-        code: "SCP-IDENT-1042".to_owned(),
+        code: codes::IDENT_1042.to_owned(),
     })
 }
 
@@ -2929,7 +2931,7 @@ pub fn identity_link_attestations(did: String) -> Result<String, ScpError> {
         .unwrap_or_default();
     serde_json::to_string(&attestations).map_err(|e| ScpError::Identity {
         msg: format!("failed to serialize attestations: {e}"),
-        code: "SCP-IDENT-1043".to_owned(),
+        code: codes::IDENT_1043.to_owned(),
     })
 }
 
@@ -2981,12 +2983,12 @@ async fn identity_verify_link_attestation_impl(
     let attestation: IdentityLinkAttestation =
         serde_json::from_str(&attestation_json).map_err(|e| ScpError::Identity {
             msg: format!("failed to parse attestation JSON: {e}"),
-            code: "SCP-IDENT-1044".to_owned(),
+            code: codes::IDENT_1044.to_owned(),
         })?;
 
     let pub_bytes = hex::decode(&issuer_public_key_hex).map_err(|e| ScpError::Identity {
         msg: format!("invalid issuer_public_key_hex: {e}"),
-        code: "SCP-IDENT-1044".to_owned(),
+        code: codes::IDENT_1044.to_owned(),
     })?;
     Ok(attestation.verify_signature(&pub_bytes).is_ok())
 }
@@ -3123,7 +3125,7 @@ pub async fn context_create(
         .await
         .map_err(|e| ScpError::Context {
             msg: format!("tokio task join error during context creation: {e}"),
-            code: "SCP-CTX-2011".to_owned(),
+            code: codes::CTX_2011.to_owned(),
         })?
 }
 
@@ -3161,7 +3163,7 @@ pub async fn context_join(
                         "cannot join context in {:?} state — context must be active",
                         *state
                     ),
-                    code: "SCP-CTX-2013".to_owned(),
+                    code: codes::CTX_2013.to_owned(),
                 });
             }
             drop(state);
@@ -3175,7 +3177,7 @@ pub async fn context_join(
                     scp_core::crypto::ucan::validate::parse_ucan(jwt).map_err(|e| {
                         ScpError::Context {
                             msg: format!("invalid spending UCAN: {e}"),
-                            code: "SCP-ECON-12061".to_owned(),
+                            code: codes::ECON_12061.to_owned(),
                         }
                     })
                 })
@@ -3217,7 +3219,7 @@ pub async fn context_join(
         .await
         .map_err(|e| ScpError::Context {
             msg: format!("tokio task join error during context join: {e}"),
-            code: "SCP-CTX-2014".to_owned(),
+            code: codes::CTX_2014.to_owned(),
         })?
 }
 
@@ -3247,7 +3249,7 @@ pub async fn context_leave(
                         "cannot leave context in {:?} state — context must be active",
                         *state
                     ),
-                    code: "SCP-CTX-2015".to_owned(),
+                    code: codes::CTX_2015.to_owned(),
                 });
             }
             drop(state);
@@ -3276,7 +3278,7 @@ pub async fn context_leave(
         .await
         .map_err(|e| ScpError::Context {
             msg: format!("tokio task join error during context leave: {e}"),
-            code: "SCP-CTX-2016".to_owned(),
+            code: codes::CTX_2016.to_owned(),
         })?
 }
 
@@ -3313,7 +3315,7 @@ pub async fn context_close(
                         "cannot close context in {:?} state — context must be active",
                         *state
                     ),
-                    code: "SCP-CTX-2017".to_owned(),
+                    code: codes::CTX_2017.to_owned(),
                 });
             }
 
@@ -3357,7 +3359,7 @@ pub async fn context_close(
                 )
                 .map_err(|e| ScpError::Context {
                     msg: format!("close orchestration failed: {e}"),
-                    code: "SCP-CTX-2017".to_owned(),
+                    code: codes::CTX_2017.to_owned(),
                 })?;
 
             // Log the close action for observability. For Summary scope,
@@ -3408,7 +3410,7 @@ pub async fn context_close(
         .await
         .map_err(|e| ScpError::Context {
             msg: format!("tokio task join error during context close: {e}"),
-            code: "SCP-CTX-2018".to_owned(),
+            code: codes::CTX_2018.to_owned(),
         })?
 }
 
@@ -3447,7 +3449,7 @@ pub async fn context_send(
                         "cannot send to context in {:?} state — context must be active",
                         *state
                     ),
-                    code: "SCP-CTX-2019".to_owned(),
+                    code: codes::CTX_2019.to_owned(),
                 });
             }
             drop(state);
@@ -3484,7 +3486,7 @@ pub async fn context_send(
                     .await
                     .map_err(|e| ScpError::Crypto {
                         msg: format!("inner envelope signing failed: {e}"),
-                        code: "SCP-CRYPTO-4001".to_owned(),
+                        code: codes::CRYPTO_4001.to_owned(),
                     })?;
                 } else {
                     #[cfg(feature = "allow_in_memory_custody")]
@@ -3497,7 +3499,7 @@ pub async fn context_send(
                         .await
                         .map_err(|e| ScpError::Crypto {
                             msg: format!("inner envelope signing failed: {e}"),
-                            code: "SCP-CRYPTO-4001".to_owned(),
+                            code: codes::CRYPTO_4001.to_owned(),
                         })?;
                     }
                 }
@@ -3527,7 +3529,7 @@ pub async fn context_send(
                 .transpose()
                 .map_err(|e| ScpError::Context {
                     msg: format!("invalid spending UCAN: {e}"),
-                    code: "SCP-ECON-12061".to_owned(),
+                    code: codes::ECON_12061.to_owned(),
                 })?;
 
             let sender_did: scp_identity::DID = identity.did.clone().into();
@@ -3548,7 +3550,7 @@ pub async fn context_send(
         .await
         .map_err(|e| ScpError::Context {
             msg: format!("tokio task join error during message send: {e}"),
-            code: "SCP-CTX-2020".to_owned(),
+            code: codes::CTX_2020.to_owned(),
         })?
 }
 
@@ -3579,7 +3581,7 @@ pub async fn context_subscribe(
                 "cannot subscribe to context in {:?} state — context must be active",
                 *state
             ),
-            code: "SCP-CTX-2021".to_owned(),
+            code: codes::CTX_2021.to_owned(),
         });
     }
     drop(state);
@@ -3628,7 +3630,7 @@ pub async fn tool_register(
                         "cannot register tool in context in {:?} state — context must be active",
                         *state
                     ),
-                    code: "SCP-TOOL-6003".to_owned(),
+                    code: codes::TOOL_6003.to_owned(),
                 });
             }
             drop(state);
@@ -3637,7 +3639,7 @@ pub async fn tool_register(
                 serde_json::from_str(&definition.input_schema_json).map_err(|e| {
                     ScpError::Validation {
                         msg: format!("invalid input_schema_json: {e}"),
-                        code: "SCP-VALID-7035".to_owned(),
+                        code: codes::VALID_7035.to_owned(),
                     }
                 })?;
             if !input_schema.is_object() {
@@ -3646,14 +3648,14 @@ pub async fn tool_register(
                         "invalid input_schema_json: expected a JSON object, got {}",
                         json_value_type_name(&input_schema)
                     ),
-                    code: "SCP-VALID-7035".to_owned(),
+                    code: codes::VALID_7035.to_owned(),
                 });
             }
             let output_schema: serde_json::Value =
                 serde_json::from_str(&definition.output_schema_json).map_err(|e| {
                     ScpError::Validation {
                         msg: format!("invalid output_schema_json: {e}"),
-                        code: "SCP-VALID-7036".to_owned(),
+                        code: codes::VALID_7036.to_owned(),
                     }
                 })?;
             if !output_schema.is_object() {
@@ -3662,7 +3664,7 @@ pub async fn tool_register(
                         "invalid output_schema_json: expected a JSON object, got {}",
                         json_value_type_name(&output_schema)
                     ),
-                    code: "SCP-VALID-7036".to_owned(),
+                    code: codes::VALID_7036.to_owned(),
                 });
             }
 
@@ -3671,7 +3673,7 @@ pub async fn tool_register(
                     None => Vec::new(),
                     Some(json) => serde_json::from_str(json).map_err(|e| ScpError::Validation {
                         msg: format!("invalid test_vectors_json: {e}"),
-                        code: "SCP-VALID-7037".to_owned(),
+                        code: codes::VALID_7037.to_owned(),
                     })?,
                 };
 
@@ -3682,7 +3684,7 @@ pub async fn tool_register(
                         "implementation_hash must be exactly 32 bytes, got {}",
                         bytes.len()
                     ),
-                    code: "SCP-VALID-7038".to_owned(),
+                    code: codes::VALID_7038.to_owned(),
                 })?,
             };
 
@@ -3725,7 +3727,7 @@ pub async fn tool_register(
             )
             .map_err(|e| ScpError::Tool {
                 msg: format!("failed to create role state: {e}"),
-                code: "SCP-TOOL-6003".to_owned(),
+                code: codes::TOOL_6003.to_owned(),
             })?;
 
             let mut registry = handle.tool_registry.lock().await;
@@ -3737,7 +3739,7 @@ pub async fn tool_register(
             )
             .map_err(|e| ScpError::Tool {
                 msg: format!("tool registration failed: {e}"),
-                code: "SCP-TOOL-6001".to_owned(),
+                code: codes::TOOL_6001.to_owned(),
             })?;
 
             Ok(registered_id)
@@ -3745,7 +3747,7 @@ pub async fn tool_register(
         .await
         .map_err(|e| ScpError::Tool {
             msg: format!("tokio task join error during tool registration: {e}"),
-            code: "SCP-TOOL-6004".to_owned(),
+            code: codes::TOOL_6004.to_owned(),
         })?
 }
 
@@ -3813,7 +3815,7 @@ pub async fn tool_invoke(
                           pass a valid JWT-encoded UCAN with tool_invoke:{tool_id} \
                           or tool_invoke:* capability"
                     .to_owned(),
-                code: "SCP-PERM-3001".to_owned(),
+                code: codes::PERM_3001.to_owned(),
             })?;
             validate_ucan_token(&ucan_token)?;
             if let Some(jwt) = spending_ucan_jwt.as_deref() {
@@ -3828,7 +3830,7 @@ pub async fn tool_invoke(
                         "cannot invoke tool in context in {:?} state — context must be active",
                         *state
                     ),
-                    code: "SCP-TOOL-6005".to_owned(),
+                    code: codes::TOOL_6005.to_owned(),
                 });
             }
             drop(state);
@@ -3854,7 +3856,7 @@ pub async fn tool_invoke(
                 .transpose()
                 .map_err(|e| ScpError::Context {
                     msg: format!("invalid spending UCAN: {e}"),
-                    code: "SCP-ECON-12061".to_owned(),
+                    code: codes::ECON_12061.to_owned(),
                 })?;
 
             // Snapshot the bridge-owned tool registry and (optionally) the
@@ -3879,7 +3881,7 @@ pub async fn tool_invoke(
             let input_value: serde_json::Value =
                 serde_json::from_str(&input_json).map_err(|e| ScpError::Tool {
                     msg: format!("invalid input JSON: {e}"),
-                    code: "SCP-TOOL-6002".to_owned(),
+                    code: codes::TOOL_6002.to_owned(),
                 })?;
 
             let context_id = handle.context_id.clone();
@@ -3938,13 +3940,13 @@ pub async fn tool_invoke(
             // Swift / Kotlin caller.
             serde_json::to_string(&outcome.output).map_err(|e| ScpError::Tool {
                 msg: format!("failed to serialize tool output: {e}"),
-                code: "SCP-TOOL-6006".to_owned(),
+                code: codes::TOOL_6006.to_owned(),
             })
         })
         .await
         .map_err(|e| ScpError::Tool {
             msg: format!("tokio task join error during tool invocation: {e}"),
-            code: "SCP-TOOL-6006".to_owned(),
+            code: codes::TOOL_6006.to_owned(),
         })?
 }
 
@@ -3970,7 +3972,7 @@ fn validate_tool_ucan_uniffi(
         for encoded in tokens {
             let proof_token = parse_ucan(encoded).map_err(|e| ScpError::Permission {
                 msg: format!("malformed proof token: {e}"),
-                code: "SCP-PERM-3002".to_owned(),
+                code: codes::PERM_3002.to_owned(),
             })?;
             let cid = scp_core::crypto::ucan::mint::compute_cid(&proof_token);
             proofs.insert(cid, proof_token);
@@ -4012,13 +4014,13 @@ fn validate_tool_ucan_uniffi(
         validate_tool_invocation_ucan(ucan_token, &handle.context_id, tool_id, &mut ctx).map_err(
             |e| ScpError::Permission {
                 msg: format!("UCAN authorization failed for tool '{tool_id}': {e}"),
-                code: "SCP-PERM-3002".to_owned(),
+                code: codes::PERM_3002.to_owned(),
             },
         )
     })
     .ok_or_else(|| ScpError::Permission {
         msg: format!("context '{}' not found in UCAN registry", handle.context_id),
-        code: "SCP-PERM-3002".to_owned(),
+        code: codes::PERM_3002.to_owned(),
     })?
 }
 
@@ -4051,7 +4053,7 @@ pub async fn tool_verify(
                         "cannot verify tool in context in {:?} state — context must be active",
                         *state
                     ),
-                    code: "SCP-TOOL-6007".to_owned(),
+                    code: codes::TOOL_6007.to_owned(),
                 });
             }
             drop(state);
@@ -4065,7 +4067,7 @@ pub async fn tool_verify(
         .await
         .map_err(|e| ScpError::Tool {
             msg: format!("tokio task join error during tool verification: {e}"),
-            code: "SCP-TOOL-6008".to_owned(),
+            code: codes::TOOL_6008.to_owned(),
         })?
 }
 
@@ -4119,7 +4121,7 @@ pub async fn tool_invoke_cross_context(
                         "cannot invoke cross-context tool: source context in {:?} state",
                         *source_state
                     ),
-                    code: "SCP-TOOL-6010".to_owned(),
+                    code: codes::TOOL_6010.to_owned(),
                 });
             }
             drop(source_state);
@@ -4132,7 +4134,7 @@ pub async fn tool_invoke_cross_context(
                         "cannot invoke cross-context tool: target context in {:?} state",
                         *target_state
                     ),
-                    code: "SCP-TOOL-6011".to_owned(),
+                    code: codes::TOOL_6011.to_owned(),
                 });
             }
             drop(target_state);
@@ -4151,7 +4153,7 @@ pub async fn tool_invoke_cross_context(
                     msg: format!(
                         "cross-context chain depth {chain_depth} exceeds maximum {max_chain_depth}"
                     ),
-                    code: "SCP-TOOL-6012".to_owned(),
+                    code: codes::TOOL_6012.to_owned(),
                 });
             }
 
@@ -4169,7 +4171,7 @@ pub async fn tool_invoke_cross_context(
             let input_value: serde_json::Value =
                 serde_json::from_str(&input_json).map_err(|e| ScpError::Tool {
                     msg: format!("invalid input JSON: {e}"),
-                    code: "SCP-TOOL-6002".to_owned(),
+                    code: codes::TOOL_6002.to_owned(),
                 })?;
 
             let registry = target_handle.tool_registry.lock().await;
@@ -4178,7 +4180,7 @@ pub async fn tool_invoke_cross_context(
                     "tool '{tool_id}' not found in target context '{}'",
                     target_handle.context_id
                 ),
-                code: "SCP-TOOL-6002".to_owned(),
+                code: codes::TOOL_6002.to_owned(),
             })?;
 
             scp_core::context::tools::validate_value_against_schema(
@@ -4187,7 +4189,7 @@ pub async fn tool_invoke_cross_context(
             )
             .map_err(|e| ScpError::Tool {
                 msg: format!("input validation failed: {e}"),
-                code: "SCP-TOOL-6002".to_owned(),
+                code: codes::TOOL_6002.to_owned(),
             })?;
 
             let output_schema = registration.schema.output_schema.clone();
@@ -4199,12 +4201,12 @@ pub async fn tool_invoke_cross_context(
                 drop(handlers);
                 let out = handler(input_value.clone()).map_err(|e| ScpError::Tool {
                     msg: format!("cross-context tool handler for '{tool_id}' failed: {e}"),
-                    code: "SCP-TOOL-6002".to_owned(),
+                    code: codes::TOOL_6002.to_owned(),
                 })?;
                 scp_core::context::tools::validate_value_against_schema(&out, &output_schema)
                     .map_err(|msg| ScpError::Tool {
                         msg: format!("output validation failed for tool '{tool_id}': {msg}"),
-                        code: "SCP-TOOL-6002".to_owned(),
+                        code: codes::TOOL_6002.to_owned(),
                     })?;
                 out
             } else {
@@ -4222,13 +4224,13 @@ pub async fn tool_invoke_cross_context(
 
             serde_json::to_string(&output).map_err(|e| ScpError::Tool {
                 msg: format!("failed to serialize cross-context output: {e}"),
-                code: "SCP-TOOL-6013".to_owned(),
+                code: codes::TOOL_6013.to_owned(),
             })
         })
         .await
         .map_err(|e| ScpError::Tool {
             msg: format!("tokio task join error during cross-context invocation: {e}"),
-            code: "SCP-TOOL-6009".to_owned(),
+            code: codes::TOOL_6009.to_owned(),
         })?
 }
 
@@ -4260,7 +4262,7 @@ pub async fn tool_session_create(
                         "cannot create session in context in {:?} state — context must be active",
                         *state
                     ),
-                    code: "SCP-TOOL-6014".to_owned(),
+                    code: codes::TOOL_6014.to_owned(),
                 });
             }
             drop(state);
@@ -4282,7 +4284,7 @@ pub async fn tool_session_create(
                     msg: format!(
                         "session cap exceeded for caller '{source_context_id}': {current} active (max {cap})"
                     ),
-                    code: "SCP-TOOL-6015".to_owned(),
+                    code: codes::TOOL_6015.to_owned(),
                 });
             }
 
@@ -4305,7 +4307,7 @@ pub async fn tool_session_create(
         .await
         .map_err(|e| ScpError::Tool {
             msg: format!("tokio task join error during session creation: {e}"),
-            code: "SCP-TOOL-6009".to_owned(),
+            code: codes::TOOL_6009.to_owned(),
         })?
 }
 
@@ -4347,7 +4349,7 @@ pub async fn tool_session_invoke(
                         "cannot invoke session in context in {:?} state — context must be active",
                         *state
                     ),
-                    code: "SCP-TOOL-6017".to_owned(),
+                    code: codes::TOOL_6017.to_owned(),
                 });
             }
             drop(state);
@@ -4357,7 +4359,7 @@ pub async fn tool_session_invoke(
                 let store = handle.session_store.lock().await;
                 let session = store.get(&session_id).ok_or_else(|| ScpError::Tool {
                     msg: format!("session '{session_id}' not found"),
-                    code: "SCP-TOOL-6018".to_owned(),
+                    code: codes::TOOL_6018.to_owned(),
                 })?;
                 session.tool_id.clone()
             };
@@ -4376,7 +4378,7 @@ pub async fn tool_session_invoke(
 
             let session = store.get(&session_id).ok_or_else(|| ScpError::Tool {
                 msg: format!("session '{session_id}' not found"),
-                code: "SCP-TOOL-6018".to_owned(),
+                code: codes::TOOL_6018.to_owned(),
             })?;
 
             // Check expiry.
@@ -4385,7 +4387,7 @@ pub async fn tool_session_invoke(
                 store.remove(&session_id);
                 return Err(ScpError::Tool {
                     msg: format!("session '{session_id}' has expired"),
-                    code: "SCP-TOOL-6019".to_owned(),
+                    code: codes::TOOL_6019.to_owned(),
                 });
             }
 
@@ -4397,7 +4399,7 @@ pub async fn tool_session_invoke(
             let input_value: serde_json::Value =
                 serde_json::from_str(&input_json).map_err(|e| ScpError::Tool {
                     msg: format!("invalid input JSON: {e}"),
-                    code: "SCP-TOOL-6002".to_owned(),
+                    code: codes::TOOL_6002.to_owned(),
                 })?;
 
             // Validate input against tool's input schema if tool is registered.
@@ -4409,7 +4411,7 @@ pub async fn tool_session_invoke(
                 )
                 .map_err(|e| ScpError::Tool {
                     msg: format!("input validation failed: {e}"),
-                    code: "SCP-TOOL-6002".to_owned(),
+                    code: codes::TOOL_6002.to_owned(),
                 })?;
             }
             drop(registry);
@@ -4421,7 +4423,7 @@ pub async fn tool_session_invoke(
                 drop(handlers);
                 let out = handler(input_value.clone()).map_err(|e| ScpError::Tool {
                     msg: format!("tool handler for '{tool_id}' failed: {e}"),
-                    code: "SCP-TOOL-6002".to_owned(),
+                    code: codes::TOOL_6002.to_owned(),
                 })?;
                 (current_state, out)
             } else {
@@ -4446,13 +4448,13 @@ pub async fn tool_session_invoke(
 
             serde_json::to_string(&output).map_err(|e| ScpError::Tool {
                 msg: format!("failed to serialize session invoke output: {e}"),
-                code: "SCP-TOOL-6020".to_owned(),
+                code: codes::TOOL_6020.to_owned(),
             })
         })
         .await
         .map_err(|e| ScpError::Tool {
             msg: format!("tokio task join error during session invocation: {e}"),
-            code: "SCP-TOOL-6009".to_owned(),
+            code: codes::TOOL_6009.to_owned(),
         })?
 }
 
@@ -4470,7 +4472,7 @@ pub async fn tool_session_close(
             if store.remove(&session_id).is_none() {
                 return Err(ScpError::Tool {
                     msg: format!("session '{session_id}' not found"),
-                    code: "SCP-TOOL-6021".to_owned(),
+                    code: codes::TOOL_6021.to_owned(),
                 });
             }
             Ok(())
@@ -4478,7 +4480,7 @@ pub async fn tool_session_close(
         .await
         .map_err(|e| ScpError::Tool {
             msg: format!("tokio task join error during session close: {e}"),
-            code: "SCP-TOOL-6009".to_owned(),
+            code: codes::TOOL_6009.to_owned(),
         })?
 }
 
@@ -4524,7 +4526,7 @@ pub async fn tool_interface_expose(
                         "cannot expose tool interface in context in {:?} state — context must be active",
                         *state
                     ),
-                    code: "SCP-TOOL-6030".to_owned(),
+                    code: codes::TOOL_6030.to_owned(),
                 });
             }
             drop(state);
@@ -4534,7 +4536,7 @@ pub async fn tool_interface_expose(
                     let parsed: scp_core::context::tools::interface::RateLimit =
                         serde_json::from_str(json).map_err(|e| ScpError::Validation {
                             msg: format!("invalid rate_limit_json: {e}"),
-                            code: "SCP-VALID-7040".to_owned(),
+                            code: codes::VALID_7040.to_owned(),
                         })?;
                     Some(parsed)
                 }
@@ -4551,7 +4553,7 @@ pub async fn tool_interface_expose(
             )
             .map_err(|e| ScpError::Tool {
                 msg: format!("failed to create role state: {e}"),
-                code: "SCP-TOOL-6030".to_owned(),
+                code: codes::TOOL_6030.to_owned(),
             })?;
 
             let context_handle = scp_core::context::ContextHandle::new(
@@ -4573,18 +4575,18 @@ pub async fn tool_interface_expose(
             )
             .map_err(|e| ScpError::Tool {
                 msg: format!("expose_tool failed: {e}"),
-                code: "SCP-TOOL-6030".to_owned(),
+                code: codes::TOOL_6030.to_owned(),
             })?;
 
             serde_json::to_string(&interface).map_err(|e| ScpError::Tool {
                 msg: format!("failed to serialize ToolInterface: {e}"),
-                code: "SCP-TOOL-6031".to_owned(),
+                code: codes::TOOL_6031.to_owned(),
             })
         })
         .await
         .map_err(|e| ScpError::Tool {
             msg: format!("tokio task join error during tool_interface_expose: {e}"),
-            code: "SCP-TOOL-6009".to_owned(),
+            code: codes::TOOL_6009.to_owned(),
         })?
 }
 
@@ -4620,7 +4622,7 @@ pub async fn tool_interface_accept(
                         "cannot accept tool interface in context in {:?} state — context must be active",
                         *state
                     ),
-                    code: "SCP-TOOL-6032".to_owned(),
+                    code: codes::TOOL_6032.to_owned(),
                 });
             }
             drop(state);
@@ -4628,7 +4630,7 @@ pub async fn tool_interface_accept(
             let mut interface: scp_core::context::tools::interface::ToolInterface =
                 serde_json::from_str(&interface_json).map_err(|e| ScpError::Validation {
                     msg: format!("invalid interface_json: {e}"),
-                    code: "SCP-VALID-7041".to_owned(),
+                    code: codes::VALID_7041.to_owned(),
                 })?;
 
             let ceiling = scp_core::context::roles::default_ceiling();
@@ -4641,7 +4643,7 @@ pub async fn tool_interface_accept(
             )
             .map_err(|e| ScpError::Tool {
                 msg: format!("failed to create role state: {e}"),
-                code: "SCP-TOOL-6032".to_owned(),
+                code: codes::TOOL_6032.to_owned(),
             })?;
 
             let context_handle = scp_core::context::ContextHandle::new(
@@ -4658,18 +4660,18 @@ pub async fn tool_interface_accept(
             )
             .map_err(|e| ScpError::Tool {
                 msg: format!("accept_tool_interface failed: {e}"),
-                code: "SCP-TOOL-6032".to_owned(),
+                code: codes::TOOL_6032.to_owned(),
             })?;
 
             serde_json::to_string(&interface).map_err(|e| ScpError::Tool {
                 msg: format!("failed to serialize ToolInterface: {e}"),
-                code: "SCP-TOOL-6033".to_owned(),
+                code: codes::TOOL_6033.to_owned(),
             })
         })
         .await
         .map_err(|e| ScpError::Tool {
             msg: format!("tokio task join error during tool_interface_accept: {e}"),
-            code: "SCP-TOOL-6009".to_owned(),
+            code: codes::TOOL_6009.to_owned(),
         })?
 }
 
@@ -4701,7 +4703,7 @@ pub async fn tool_interface_revoke(
             let interface_id_bytes =
                 hex::decode(&interface_id_hex).map_err(|e| ScpError::Validation {
                     msg: format!("invalid interface_id_hex: not valid hex: {e}"),
-                    code: "SCP-VALID-7042".to_owned(),
+                    code: codes::VALID_7042.to_owned(),
                 })?;
             let interface_id: [u8; 32] = <[u8; 32]>::try_from(interface_id_bytes.as_slice())
                 .map_err(|_| ScpError::Validation {
@@ -4709,7 +4711,7 @@ pub async fn tool_interface_revoke(
                         "interface_id_hex must be exactly 32 bytes (64 hex chars), got {}",
                         interface_id_bytes.len()
                     ),
-                    code: "SCP-VALID-7042".to_owned(),
+                    code: codes::VALID_7042.to_owned(),
                 })?;
 
             let now_ms = scp_primitives::SystemClock.now_millis();
@@ -4722,13 +4724,13 @@ pub async fn tool_interface_revoke(
 
             serde_json::to_string(&event).map_err(|e| ScpError::Tool {
                 msg: format!("failed to serialize InterfaceRevoked: {e}"),
-                code: "SCP-TOOL-6035".to_owned(),
+                code: codes::TOOL_6035.to_owned(),
             })
         })
         .await
         .map_err(|e| ScpError::Tool {
             msg: format!("tokio task join error during tool_interface_revoke: {e}"),
-            code: "SCP-TOOL-6009".to_owned(),
+            code: codes::TOOL_6009.to_owned(),
         })?
 }
 
@@ -4818,7 +4820,7 @@ pub async fn transport_connect(relay_url: String) -> Result<Arc<TransportManager
         .await
         .map_err(|e| ScpError::Transport {
             msg: format!("tokio task join error during transport connect: {e}"),
-            code: "SCP-TRANS-5002".to_owned(),
+            code: codes::TRANS_5002.to_owned(),
         })?
 }
 
@@ -4858,7 +4860,7 @@ pub async fn transport_disconnect(manager: Arc<TransportManager>) -> Result<(), 
             {
                 let mut inner_guard = manager.inner.write().map_err(|_| ScpError::Transport {
                     msg: "transport manager lock is poisoned — cannot disconnect".to_owned(),
-                    code: "SCP-TRANS-5003".to_owned(),
+                    code: codes::TRANS_5003.to_owned(),
                 })?;
                 *inner_guard = scp_transport::TransportManager::builder();
             }
@@ -4867,7 +4869,7 @@ pub async fn transport_disconnect(manager: Arc<TransportManager>) -> Result<(), 
             {
                 let mut status_guard = manager.status.lock().map_err(|_| ScpError::Transport {
                     msg: "status mutex is poisoned — cannot update transport status".to_owned(),
-                    code: "SCP-TRANS-5003".to_owned(),
+                    code: codes::TRANS_5003.to_owned(),
                 })?;
                 status_guard.connected = false;
                 status_guard.relay_url = None;
@@ -4879,7 +4881,7 @@ pub async fn transport_disconnect(manager: Arc<TransportManager>) -> Result<(), 
         .await
         .map_err(|e| ScpError::Transport {
             msg: format!("tokio task join error during transport disconnect: {e}"),
-            code: "SCP-TRANS-5003".to_owned(),
+            code: codes::TRANS_5003.to_owned(),
         })?
 }
 
@@ -4929,7 +4931,7 @@ pub async fn configure_relay_transport(
             .await
             .map_err(|e| ScpError::Transport {
                 msg: format!("failed to connect to relay '{relay_url}': {e}"),
-                code: "SCP-TRANS-5001".to_owned(),
+                code: codes::TRANS_5001.to_owned(),
             })?;
 
     crate::runtime::init_context_manager_with_relay_transport(&local_did, adapter);
@@ -5766,11 +5768,11 @@ fn mcp_allowlist_err(e: scp_mcp::allowlist::AllowlistError) -> ScpError {
         | AllowlistError::PathInCommand(_)
         | AllowlistError::InvalidCommand(_) => ScpError::Validation {
             msg,
-            code: "SCP-VALID-7033".to_owned(),
+            code: codes::VALID_7033.to_owned(),
         },
         AllowlistError::NotAllowed { .. } | AllowlistError::LockPoisoned => ScpError::Transport {
             msg,
-            code: "SCP-TRANS-5030".to_owned(),
+            code: codes::TRANS_5030.to_owned(),
         },
     }
 }
@@ -5809,7 +5811,7 @@ pub async fn mcp_server_create(config: McpServerConfig) -> Result<String, ScpErr
     if config.context_ids.is_empty() {
         return Err(ScpError::Transport {
             msg: "context_ids must not be empty".to_owned(),
-            code: "SCP-TRANS-5011".to_owned(),
+            code: codes::TRANS_5011.to_owned(),
         });
     }
 
@@ -5895,13 +5897,13 @@ pub async fn mcp_server_stop(handle: String) -> Result<(), ScpError> {
         .get_mut(&handle)
         .ok_or_else(|| ScpError::Transport {
             msg: format!("MCP server handle '{handle}' not found"),
-            code: "SCP-TRANS-5012".to_owned(),
+            code: codes::TRANS_5012.to_owned(),
         })?;
 
     if entry.stopped {
         return Err(ScpError::Transport {
             msg: format!("MCP server '{handle}' is already stopped"),
-            code: "SCP-TRANS-5013".to_owned(),
+            code: codes::TRANS_5013.to_owned(),
         });
     }
 
@@ -5936,19 +5938,19 @@ pub async fn mcp_client_connect_stdio(command: Vec<String>) -> Result<String, Sc
     if command.is_empty() {
         return Err(ScpError::Validation {
             msg: "command must be a non-empty list".to_owned(),
-            code: "SCP-VALID-7034".to_owned(),
+            code: codes::VALID_7034.to_owned(),
         });
     }
 
     let transport = McpStdioTransport::spawn(&command).map_err(|e| ScpError::Transport {
         msg: format!("failed to connect stdio MCP client: {e}"),
-        code: "SCP-TRANS-5015".to_owned(),
+        code: codes::TRANS_5015.to_owned(),
     })?;
 
     let mut client = scp_mcp::client::McpClient::new(McpUniFFITransportWrapper::Stdio(transport));
     client.initialize().map_err(|e| ScpError::Transport {
         msg: format!("MCP initialize handshake failed: {e}"),
-        code: "SCP-TRANS-5016".to_owned(),
+        code: codes::TRANS_5016.to_owned(),
     })?;
 
     let handle_id = mcp_handle_id("mcp-client");
@@ -5985,7 +5987,7 @@ pub async fn mcp_client_connect_sse(url: String) -> Result<String, ScpError> {
     let mut client = scp_mcp::client::McpClient::new(McpUniFFITransportWrapper::Sse(transport));
     client.initialize().map_err(|e| ScpError::Transport {
         msg: format!("MCP initialize handshake failed: {e}"),
-        code: "SCP-TRANS-5018".to_owned(),
+        code: codes::TRANS_5018.to_owned(),
     })?;
 
     let handle_id = mcp_handle_id("mcp-client");
@@ -6020,7 +6022,7 @@ pub async fn mcp_client_disconnect(handle: String) -> Result<(), ScpError> {
     if removed.is_none() {
         return Err(ScpError::Transport {
             msg: format!("MCP client handle '{handle}' not found"),
-            code: "SCP-TRANS-5019".to_owned(),
+            code: codes::TRANS_5019.to_owned(),
         });
     }
 
@@ -6052,17 +6054,17 @@ pub async fn mcp_client_list_tools(handle: String) -> Result<Vec<McpToolInfo>, S
         .get(&handle)
         .ok_or_else(|| ScpError::Transport {
             msg: format!("MCP client handle '{handle}' not found"),
-            code: "SCP-TRANS-5020".to_owned(),
+            code: codes::TRANS_5020.to_owned(),
         })?;
 
     let client_guard = entry.client.lock().map_err(|e| ScpError::Transport {
         msg: format!("client lock poisoned: {e}"),
-        code: "SCP-TRANS-5021".to_owned(),
+        code: codes::TRANS_5021.to_owned(),
     })?;
 
     let tools = client_guard.list_tools().map_err(|e| ScpError::Transport {
         msg: format!("tools/list failed: {e}"),
-        code: "SCP-TRANS-5022".to_owned(),
+        code: codes::TRANS_5022.to_owned(),
     })?;
 
     Ok(tools
@@ -6115,25 +6117,25 @@ pub async fn mcp_client_invoke(
         .get(&handle)
         .ok_or_else(|| ScpError::Transport {
             msg: format!("MCP client handle '{handle}' not found"),
-            code: "SCP-TRANS-5023".to_owned(),
+            code: codes::TRANS_5023.to_owned(),
         })?;
 
     let input: serde_json::Value =
         serde_json::from_str(&input_json).map_err(|e| ScpError::Validation {
             msg: format!("invalid input JSON: {e}"),
-            code: "SCP-VALID-7021".to_owned(),
+            code: codes::VALID_7021.to_owned(),
         })?;
 
     let client_guard = entry.client.lock().map_err(|e| ScpError::Transport {
         msg: format!("client lock poisoned: {e}"),
-        code: "SCP-TRANS-5024".to_owned(),
+        code: codes::TRANS_5024.to_owned(),
     })?;
 
     let result = client_guard
         .invoke(&tool_name, input, &context_id, &invoker_did)
         .map_err(|e| ScpError::Transport {
             msg: format!("tools/call failed: {e}"),
-            code: "SCP-TRANS-5025".to_owned(),
+            code: codes::TRANS_5025.to_owned(),
         })?;
 
     let content_json = serde_json::to_string(&result.content).unwrap_or_else(|_| "[]".to_owned());
@@ -6267,7 +6269,7 @@ pub async fn ucan_validate(
             // Step 1: Parse the UCAN token.
             let parsed_token = parse_ucan(&token).map_err(|e| ScpError::Permission {
                 msg: format!("malformed UCAN token: {e}"),
-                code: "SCP-PERM-3002".to_owned(),
+                code: codes::PERM_3002.to_owned(),
             })?;
 
             // Parse the required capability URI.
@@ -6277,7 +6279,7 @@ pub async fn ucan_validate(
                     .map_err(
                         |e: scp_core::crypto::ucan::UcanError| ScpError::Permission {
                             msg: format!("invalid capability URI '{capability}': {e}"),
-                            code: "SCP-PERM-3002".to_owned(),
+                            code: codes::PERM_3002.to_owned(),
                         },
                     )?;
 
@@ -6292,7 +6294,7 @@ pub async fn ucan_validate(
                 for encoded in tokens {
                     let proof_token = parse_ucan(encoded).map_err(|e| ScpError::Permission {
                         msg: format!("malformed proof token: {e}"),
-                        code: "SCP-PERM-3002".to_owned(),
+                        code: codes::PERM_3002.to_owned(),
                     })?;
                     let cid = scp_core::crypto::ucan::mint::compute_cid(&proof_token);
                     proofs.insert(cid, proof_token);
@@ -6336,13 +6338,13 @@ pub async fn ucan_validate(
                     validate_ucan(&parsed_token, &required_cap, &mut ctx).map_err(|e| {
                         ScpError::Permission {
                             msg: format!("UCAN validation failed: {e}"),
-                            code: "SCP-PERM-3002".to_owned(),
+                            code: codes::PERM_3002.to_owned(),
                         }
                     })
                 })
                 .ok_or_else(|| ScpError::Permission {
                     msg: format!("context '{}' not found in UCAN registry", handle.context_id),
-                    code: "SCP-PERM-3002".to_owned(),
+                    code: codes::PERM_3002.to_owned(),
                 })?;
             validation_result?;
 
@@ -6351,7 +6353,7 @@ pub async fn ucan_validate(
         .await
         .map_err(|e| ScpError::Permission {
             msg: format!("tokio task join error during UCAN validation: {e}"),
-            code: "SCP-PERM-3003".to_owned(),
+            code: codes::PERM_3003.to_owned(),
         })?
 }
 
@@ -6401,7 +6403,7 @@ pub async fn ucan_mint(
         for t in tokens {
             validate_ucan_token(t).map_err(|e| ScpError::Validation {
                 msg: e.to_string(),
-                code: "SCP-VALID-7010".to_owned(),
+                code: codes::VALID_7010.to_owned(),
             })?;
         }
     }
@@ -6427,13 +6429,13 @@ async fn ucan_mint_impl(
                         msg: "UCAN minting requires key custody — create the context with \
                               an in_memory identity (identity_create(\"in_memory\"))"
                             .to_owned(),
-                        code: "SCP-PERM-3004".to_owned(),
+                        code: codes::PERM_3004.to_owned(),
                     })?;
             let signing_key = handle.signing_key.ok_or_else(|| ScpError::Permission {
                 msg: "UCAN minting requires a signing key — the context creator identity \
                           must have an active signing key"
                     .to_owned(),
-                code: "SCP-PERM-3004".to_owned(),
+                code: codes::PERM_3004.to_owned(),
             })?;
 
             let params = scp_core::crypto::ucan::mint::MintParams {
@@ -6482,7 +6484,7 @@ async fn ucan_mint_impl(
         .await
         .map_err(|e| ScpError::Permission {
             msg: format!("tokio task join error during UCAN mint: {e}"),
-            code: "SCP-PERM-3005".to_owned(),
+            code: codes::PERM_3005.to_owned(),
         })?
 }
 
@@ -6500,7 +6502,7 @@ async fn ucan_mint_impl(
                   \"allow_in_memory_custody\" feature for dev/desktop use, or wire \
                   a KeyCustodyProvider for production."
             .to_owned(),
-        code: "SCP-PERM-3004".to_owned(),
+        code: codes::PERM_3004.to_owned(),
     })
 }
 
@@ -6537,11 +6539,11 @@ pub async fn ucan_revoke(
 ) -> Result<(), ScpError> {
     validate_ucan_token(&token).map_err(|e| ScpError::Validation {
         msg: e.to_string(),
-        code: "SCP-VALID-7010".to_owned(),
+        code: codes::VALID_7010.to_owned(),
     })?;
     validate_did(&revoker_did).map_err(|e| ScpError::Validation {
         msg: e.to_string(),
-        code: "SCP-VALID-7011".to_owned(),
+        code: codes::VALID_7011.to_owned(),
     })?;
 
     runtime()
@@ -6587,7 +6589,7 @@ pub async fn ucan_revoke(
             })
             .ok_or_else(|| ScpError::Permission {
                 msg: format!("context '{}' not found in UCAN registry", handle.context_id),
-                code: "SCP-PERM-3006".to_owned(),
+                code: codes::PERM_3006.to_owned(),
             })??;
 
             Ok(())
@@ -6595,7 +6597,7 @@ pub async fn ucan_revoke(
         .await
         .map_err(|e| ScpError::Permission {
             msg: format!("tokio task join error during UCAN revocation: {e}"),
-            code: "SCP-PERM-3007".to_owned(),
+            code: codes::PERM_3007.to_owned(),
         })?
 }
 
@@ -6680,19 +6682,19 @@ async fn ucan_delegate_impl(
                         msg: "UCAN delegation requires key custody — create the context with \
                               an in_memory identity (identity_create(\"in_memory\"))"
                             .to_owned(),
-                        code: "SCP-PERM-3004".to_owned(),
+                        code: codes::PERM_3004.to_owned(),
                     })?;
             let signing_key = handle.signing_key.ok_or_else(|| ScpError::Permission {
                 msg: "UCAN delegation requires a signing key — the context creator identity \
                           must have an active signing key"
                     .to_owned(),
-                code: "SCP-PERM-3004".to_owned(),
+                code: codes::PERM_3004.to_owned(),
             })?;
 
             // Parse the parent token.
             let parsed_parent = parse_ucan(&parent_token).map_err(|e| ScpError::Permission {
                 msg: format!("malformed parent UCAN token: {e}"),
-                code: "SCP-PERM-3002".to_owned(),
+                code: codes::PERM_3002.to_owned(),
             })?;
 
             // Build attenuated capabilities from the capability URI strings.
@@ -6762,7 +6764,7 @@ async fn ucan_delegate_impl(
         .await
         .map_err(|e| ScpError::Permission {
             msg: format!("tokio task join error during UCAN delegation: {e}"),
-            code: "SCP-PERM-3005".to_owned(),
+            code: codes::PERM_3005.to_owned(),
         })?
 }
 
@@ -6781,7 +6783,7 @@ async fn ucan_delegate_impl(
                   \"allow_in_memory_custody\" feature for dev/desktop use, or wire \
                   a KeyCustodyProvider for production."
             .to_owned(),
-        code: "SCP-PERM-3004".to_owned(),
+        code: codes::PERM_3004.to_owned(),
     })
 }
 
@@ -6828,7 +6830,7 @@ pub async fn event_log_query(
                     Some(
                         serde_json::from_str(json_str).map_err(|e| ScpError::Context {
                             msg: format!("invalid filter JSON: {e}"),
-                            code: "SCP-CTX-2023".to_owned(),
+                            code: codes::CTX_2023.to_owned(),
                         })?,
                     )
                 }
@@ -6962,7 +6964,7 @@ pub async fn event_log_query(
             })
             .ok_or_else(|| ScpError::Context {
                 msg: format!("context '{}' not found in UCAN registry", handle.context_id),
-                code: "SCP-CTX-2023".to_owned(),
+                code: codes::CTX_2023.to_owned(),
             })?;
 
             Ok(events)
@@ -6970,7 +6972,7 @@ pub async fn event_log_query(
         .await
         .map_err(|e| ScpError::Context {
             msg: format!("tokio task join error during event log query: {e}"),
-            code: "SCP-CTX-2024".to_owned(),
+            code: codes::CTX_2024.to_owned(),
         })?
 }
 
@@ -7005,7 +7007,7 @@ pub async fn event_log_verify(
             let claim: serde_json::Value =
                 serde_json::from_str(&claim_json).map_err(|e| ScpError::Context {
                     msg: format!("invalid claim JSON: {e}"),
-                    code: "SCP-CTX-2025".to_owned(),
+                    code: codes::CTX_2025.to_owned(),
                 })?;
 
             let claim_type =
@@ -7015,7 +7017,7 @@ pub async fn event_log_verify(
                     .ok_or_else(|| ScpError::Context {
                         msg: "claim must include 'type' field ('inclusion' or 'absence')"
                             .to_owned(),
-                        code: "SCP-CTX-2025".to_owned(),
+                        code: codes::CTX_2025.to_owned(),
                     })?;
 
             // Ensure UCAN state (which contains the event log) is registered.
@@ -7032,7 +7034,7 @@ pub async fn event_log_verify(
                         .and_then(serde_json::Value::as_u64)
                         .ok_or_else(|| ScpError::Context {
                             msg: "inclusion claim must include 'leaf_index' (integer)".to_owned(),
-                            code: "SCP-CTX-2025".to_owned(),
+                            code: codes::CTX_2025.to_owned(),
                         })?;
 
                     crate::runtime::with_ucan_state(&handle.context_id, |ucan_state| {
@@ -7042,7 +7044,7 @@ pub async fn event_log_verify(
                         )
                         .map_err(|e| ScpError::Context {
                             msg: format!("inclusion proof failed: {e}"),
-                            code: "SCP-CTX-2025".to_owned(),
+                            code: codes::CTX_2025.to_owned(),
                         })?;
                         let verified = scp_event_log::proof::verify_inclusion(&proof);
 
@@ -7077,7 +7079,7 @@ pub async fn event_log_verify(
                     })
                     .ok_or_else(|| ScpError::Context {
                         msg: format!("context '{}' not found in UCAN registry", handle.context_id),
-                        code: "SCP-CTX-2025".to_owned(),
+                        code: codes::CTX_2025.to_owned(),
                     })?
                 }
                 "absence" => {
@@ -7086,20 +7088,20 @@ pub async fn event_log_verify(
                         .and_then(|v| v.as_str())
                         .ok_or_else(|| ScpError::Context {
                             msg: "absence claim must include 'event_hash' (hex string)".to_owned(),
-                            code: "SCP-CTX-2025".to_owned(),
+                            code: codes::CTX_2025.to_owned(),
                         })?;
 
                     let event_hash_bytes =
                         hex::decode(event_hash_hex).map_err(|e| ScpError::Context {
                             msg: format!("invalid event_hash hex: {e}"),
-                            code: "SCP-CTX-2025".to_owned(),
+                            code: codes::CTX_2025.to_owned(),
                         })?;
                     let event_hash: [u8; 32] =
                         event_hash_bytes
                             .try_into()
                             .map_err(|v: Vec<u8>| ScpError::Context {
                                 msg: format!("event_hash must be 32 bytes, got {}", v.len()),
-                                code: "SCP-CTX-2025".to_owned(),
+                                code: codes::CTX_2025.to_owned(),
                             })?;
 
                     crate::runtime::with_ucan_state(&handle.context_id, |ucan_state| {
@@ -7107,7 +7109,7 @@ pub async fn event_log_verify(
                             scp_event_log::proof::prove_absence(&ucan_state.event_log, &event_hash)
                                 .map_err(|e| ScpError::Context {
                                     msg: format!("absence proof failed: {e}"),
-                                    code: "SCP-CTX-2025".to_owned(),
+                                    code: codes::CTX_2025.to_owned(),
                                 })?;
 
                         let lower = proof.lower.as_ref().map(|lwp| {
@@ -7147,21 +7149,21 @@ pub async fn event_log_verify(
                     })
                     .ok_or_else(|| ScpError::Context {
                         msg: format!("context '{}' not found in UCAN registry", handle.context_id),
-                        code: "SCP-CTX-2025".to_owned(),
+                        code: codes::CTX_2025.to_owned(),
                     })?
                 }
                 other => Err(ScpError::Context {
                     msg: format!(
                         "unsupported claim type '{other}': expected 'inclusion' or 'absence'"
                     ),
-                    code: "SCP-CTX-2025".to_owned(),
+                    code: codes::CTX_2025.to_owned(),
                 }),
             }
         })
         .await
         .map_err(|e| ScpError::Context {
             msg: format!("tokio task join error during event log verification: {e}"),
-            code: "SCP-CTX-2026".to_owned(),
+            code: codes::CTX_2026.to_owned(),
         })?
 }
 
@@ -7213,7 +7215,7 @@ async fn event_log_checkpoint_impl(
                         msg: "event log checkpoint requires key custody — create the identity \
                               with in_memory custody (identity_create(\"in_memory\"))"
                             .to_owned(),
-                        code: "SCP-PERM-3008".to_owned(),
+                        code: codes::PERM_3008.to_owned(),
                     })?;
             let core_id = identity
                 .core_id
@@ -7222,7 +7224,7 @@ async fn event_log_checkpoint_impl(
                     msg: "event log checkpoint requires retained identity state — the identity \
                           was externally loaded"
                         .to_owned(),
-                    code: "SCP-IDENT-1007".to_owned(),
+                    code: codes::IDENT_1007.to_owned(),
                 })?;
 
             // Ensure UCAN state (which contains the event log) is registered.
@@ -7255,14 +7257,14 @@ async fn event_log_checkpoint_impl(
                         .await
                         .map_err(|e| ScpError::Context {
                             msg: format!("checkpoint generation failed: {e}"),
-                            code: "SCP-CTX-2027".to_owned(),
+                            code: codes::CTX_2027.to_owned(),
                         })
                     })
                 })
             })
             .ok_or_else(|| ScpError::Context {
                 msg: format!("context '{context_id}' not found in UCAN registry"),
-                code: "SCP-CTX-2027".to_owned(),
+                code: codes::CTX_2027.to_owned(),
             })??;
 
             Ok(Checkpoint {
@@ -7278,7 +7280,7 @@ async fn event_log_checkpoint_impl(
         .await
         .map_err(|e| ScpError::Context {
             msg: format!("tokio task join error during event log checkpoint: {e}"),
-            code: "SCP-CTX-2028".to_owned(),
+            code: codes::CTX_2028.to_owned(),
         })?
 }
 
@@ -7295,7 +7297,7 @@ async fn event_log_checkpoint_impl(
                   \"allow_in_memory_custody\" feature for dev/desktop use, or wire \
                   a KeyCustodyProvider for production."
             .to_owned(),
-        code: "SCP-PERM-3008".to_owned(),
+        code: codes::PERM_3008.to_owned(),
     })
 }
 
@@ -7338,7 +7340,7 @@ pub async fn governance_execute(
             scp_ffi_common::validate::validate_governance_action_strings(&proposal.action)
                 .map_err(|e| ScpError::Validation {
                     msg: e.message,
-                    code: "SCP-VALID-7000".to_owned(),
+                    code: codes::VALID_7000.to_owned(),
                 })?;
             let action_name = proposal.action.variant_name();
             let manager = crate::runtime::context_manager()?;
@@ -7384,7 +7386,7 @@ pub async fn governance_execute(
         .await
         .map_err(|e| ScpError::Context {
             msg: format!("tokio task join error during governance execution: {e}"),
-            code: "SCP-CTX-2032".to_owned(),
+            code: codes::CTX_2032.to_owned(),
         })??;
 
     // Re-sync role state from ContextManager after governance execution (#796).
@@ -7432,7 +7434,7 @@ async fn resolve_uniffi_signing_key(
         msg: "no signing key on context handle — governance lifecycle \
                   requires an identity with an active signing key"
             .to_owned(),
-        code: "SCP-CTX-2040".to_owned(),
+        code: codes::CTX_2040.to_owned(),
     })?;
 
     if let Some(ref cb) = handle.callback_custody {
@@ -7441,7 +7443,7 @@ async fn resolve_uniffi_signing_key(
             .await
             .map_err(|e| ScpError::Context {
                 msg: format!("failed to export signing key from platform custody: {e}"),
-                code: "SCP-CTX-2040".to_owned(),
+                code: codes::CTX_2040.to_owned(),
             });
     }
 
@@ -7453,7 +7455,7 @@ async fn resolve_uniffi_signing_key(
             .await
             .map_err(|e| ScpError::Context {
                 msg: format!("failed to export signing key from in-memory custody: {e}"),
-                code: "SCP-CTX-2040".to_owned(),
+                code: codes::CTX_2040.to_owned(),
             });
     }
 
@@ -7461,7 +7463,7 @@ async fn resolve_uniffi_signing_key(
         msg: "no custody provider on context handle — governance lifecycle \
                   requires an identity created with custody"
             .to_owned(),
-        code: "SCP-CTX-2040".to_owned(),
+        code: codes::CTX_2040.to_owned(),
     })
 }
 
@@ -7469,11 +7471,11 @@ async fn resolve_uniffi_signing_key(
 fn parse_uniffi_proposal_id(hex_str: &str) -> Result<[u8; 32], ScpError> {
     let bytes = hex::decode(hex_str).map_err(|e| ScpError::Validation {
         msg: format!("invalid proposal ID hex: {e}"),
-        code: "SCP-CTX-2040".to_owned(),
+        code: codes::CTX_2040.to_owned(),
     })?;
     bytes.try_into().map_err(|v: Vec<u8>| ScpError::Validation {
         msg: format!("proposal ID must be 32 bytes, got {}", v.len()),
-        code: "SCP-CTX-2040".to_owned(),
+        code: codes::CTX_2040.to_owned(),
     })
 }
 
@@ -7515,7 +7517,7 @@ pub async fn governance_propose(
             scp_ffi_common::validate::validate_governance_action_strings(&action).map_err(|e| {
                 ScpError::Validation {
                     msg: e.message,
-                    code: "SCP-CTX-2041".to_owned(),
+                    code: codes::CTX_2041.to_owned(),
                 }
             })?;
             let action_name = action.variant_name();
@@ -7538,7 +7540,7 @@ pub async fn governance_propose(
         .await
         .map_err(|e| ScpError::Context {
             msg: format!("tokio task join error during governance proposal: {e}"),
-            code: "SCP-CTX-2041".to_owned(),
+            code: codes::CTX_2041.to_owned(),
         })??;
 
     if let Err(e) = crate::runtime::sync_role_state_from_manager(&handle.context_id).await {
@@ -7584,7 +7586,7 @@ pub async fn governance_approve(
         .await
         .map_err(|e| ScpError::Context {
             msg: format!("tokio task join error during governance approval: {e}"),
-            code: "SCP-CTX-2042".to_owned(),
+            code: codes::CTX_2042.to_owned(),
         })?;
 
     if let Err(e) = crate::runtime::sync_role_state_from_manager(&handle.context_id).await {
@@ -7629,7 +7631,7 @@ pub async fn governance_reject(
         .await
         .map_err(|e| ScpError::Context {
             msg: format!("tokio task join error during governance rejection: {e}"),
-            code: "SCP-CTX-2043".to_owned(),
+            code: codes::CTX_2043.to_owned(),
         })?;
 
     if let Err(e) = crate::runtime::sync_role_state_from_manager(&handle.context_id).await {
@@ -7674,7 +7676,7 @@ pub async fn governance_withdraw(
         .await
         .map_err(|e| ScpError::Context {
             msg: format!("tokio task join error during governance withdrawal: {e}"),
-            code: "SCP-CTX-2044".to_owned(),
+            code: codes::CTX_2044.to_owned(),
         })?;
 
     if let Err(e) = crate::runtime::sync_role_state_from_manager(&handle.context_id).await {
@@ -7711,13 +7713,13 @@ pub async fn governance_get_proposal(
 
             serde_json::to_string(&proposal).map_err(|e| ScpError::Context {
                 msg: format!("serialization failed: {e}"),
-                code: "SCP-CTX-2045".to_owned(),
+                code: codes::CTX_2045.to_owned(),
             })
         })
         .await
         .map_err(|e| ScpError::Context {
             msg: format!("tokio task join error during get proposal: {e}"),
-            code: "SCP-CTX-2045".to_owned(),
+            code: codes::CTX_2045.to_owned(),
         })?
 }
 
@@ -7742,13 +7744,13 @@ pub async fn governance_list_proposals(handle: Arc<ContextHandle>) -> Result<Str
 
             serde_json::to_string(&proposals).map_err(|e| ScpError::Context {
                 msg: format!("serialization failed: {e}"),
-                code: "SCP-CTX-2046".to_owned(),
+                code: codes::CTX_2046.to_owned(),
             })
         })
         .await
         .map_err(|e| ScpError::Context {
             msg: format!("tokio task join error during list proposals: {e}"),
-            code: "SCP-CTX-2046".to_owned(),
+            code: codes::CTX_2046.to_owned(),
         })?
 }
 
@@ -7781,7 +7783,7 @@ pub async fn apply_pending_ceiling_modification(
         .await
         .map_err(|e| ScpError::Context {
             msg: format!("tokio task join error during apply_pending_ceiling_modification: {e}"),
-            code: "SCP-CTX-2060".to_owned(),
+            code: codes::CTX_2060.to_owned(),
         })?
 }
 
@@ -7829,7 +7831,7 @@ pub async fn finalize_close(handle: Arc<ContextHandle>) -> Result<(), ScpError> 
         .await
         .map_err(|e| ScpError::Context {
             msg: format!("tokio task join error during finalize_close: {e}"),
-            code: "SCP-CTX-2061".to_owned(),
+            code: codes::CTX_2061.to_owned(),
         })?
 }
 
@@ -7863,7 +7865,7 @@ pub async fn create_governance_checkpoint(
         Zeroizing::new(
             hex::decode(&creator_signature_hex).map_err(|e| ScpError::Validation {
                 msg: format!("invalid creator_signature hex: {e}"),
-                code: "SCP-CTX-2066".to_owned(),
+                code: codes::CTX_2066.to_owned(),
             })?,
         );
     let did = scp_identity::DID(creator_did);
@@ -7887,13 +7889,13 @@ pub async fn create_governance_checkpoint(
 
             serde_json::to_string(&checkpoint).map_err(|e| ScpError::Context {
                 msg: format!("serialization failed: {e}"),
-                code: "SCP-CTX-2066".to_owned(),
+                code: codes::CTX_2066.to_owned(),
             })
         })
         .await
         .map_err(|e| ScpError::Context {
             msg: format!("tokio task join error during create_governance_checkpoint: {e}"),
-            code: "SCP-CTX-2066".to_owned(),
+            code: codes::CTX_2066.to_owned(),
         })?
 }
 
@@ -7918,14 +7920,14 @@ pub async fn add_checkpoint_cosignature(
     let mut checkpoint: scp_core::context::governance::ContextCheckpoint =
         serde_json::from_str(&checkpoint_json).map_err(|e| ScpError::Validation {
             msg: format!("invalid checkpoint JSON: {e}"),
-            code: "SCP-CTX-2063".to_owned(),
+            code: codes::CTX_2063.to_owned(),
         })?;
 
     let signature =
         Zeroizing::new(
             hex::decode(&signature_hex).map_err(|e| ScpError::Validation {
                 msg: format!("invalid signature hex: {e}"),
-                code: "SCP-CTX-2063".to_owned(),
+                code: codes::CTX_2063.to_owned(),
             })?,
         );
 
@@ -7951,7 +7953,7 @@ pub async fn add_checkpoint_cosignature(
         .await
         .map_err(|e| ScpError::Context {
             msg: format!("tokio task join error during add_checkpoint_cosignature: {e}"),
-            code: "SCP-CTX-2063".to_owned(),
+            code: codes::CTX_2063.to_owned(),
         })?
 }
 
@@ -7990,7 +7992,7 @@ pub async fn restore_context(context_id: String) -> Result<(), ScpError> {
         .await
         .map_err(|e| ScpError::Context {
             msg: format!("tokio task join error during restore_context: {e}"),
-            code: "SCP-CTX-2064".to_owned(),
+            code: codes::CTX_2064.to_owned(),
         })?
 }
 
@@ -8013,13 +8015,13 @@ pub async fn restore_all_contexts() -> Result<String, ScpError> {
 
             serde_json::to_string(&restored).map_err(|e| ScpError::Context {
                 msg: format!("serialization failed: {e}"),
-                code: "SCP-CTX-2065".to_owned(),
+                code: codes::CTX_2065.to_owned(),
             })
         })
         .await
         .map_err(|e| ScpError::Context {
             msg: format!("tokio task join error during restore_all_contexts: {e}"),
-            code: "SCP-CTX-2065".to_owned(),
+            code: codes::CTX_2065.to_owned(),
         })?
 }
 
@@ -8027,11 +8029,11 @@ pub async fn restore_all_contexts() -> Result<String, ScpError> {
 fn parse_uniffi_hex_32(hex_str: &str, field_name: &str) -> Result<[u8; 32], ScpError> {
     let bytes = hex::decode(hex_str).map_err(|e| ScpError::Validation {
         msg: format!("invalid {field_name} hex: {e}"),
-        code: "SCP-CTX-2066".to_owned(),
+        code: codes::CTX_2066.to_owned(),
     })?;
     bytes.try_into().map_err(|v: Vec<u8>| ScpError::Validation {
         msg: format!("{field_name} must be 32 bytes, got {}", v.len()),
-        code: "SCP-CTX-2066".to_owned(),
+        code: codes::CTX_2066.to_owned(),
     })
 }
 
@@ -8068,7 +8070,7 @@ pub async fn tombstone_migrated_context(handle: Arc<ContextHandle>) -> Result<()
         .await
         .map_err(|e| ScpError::Context {
             msg: format!("tokio task join error during tombstone: {e}"),
-            code: "SCP-CTX-2050".to_owned(),
+            code: codes::CTX_2050.to_owned(),
         })?
 }
 
@@ -8101,7 +8103,7 @@ pub async fn migration_state(handle: Arc<ContextHandle>) -> Result<Option<String
         .await
         .map_err(|e| ScpError::Context {
             msg: format!("tokio task join error during migration_state: {e}"),
-            code: "SCP-CTX-2050".to_owned(),
+            code: codes::CTX_2050.to_owned(),
         })?
 }
 
@@ -8147,7 +8149,7 @@ pub async fn broadcast_subscribe(
         .await
         .map_err(|e| ScpError::Context {
             msg: format!("tokio task join error during broadcast subscribe: {e}"),
-            code: "SCP-CTX-2033".to_owned(),
+            code: codes::CTX_2033.to_owned(),
         })?
 }
 
@@ -8178,7 +8180,7 @@ pub async fn broadcast_unsubscribe(
         .await
         .map_err(|e| ScpError::Context {
             msg: format!("tokio task join error during broadcast unsubscribe: {e}"),
-            code: "SCP-CTX-2034".to_owned(),
+            code: codes::CTX_2034.to_owned(),
         })?
 }
 
@@ -8217,7 +8219,7 @@ pub async fn broadcast_publish(
                 .ok_or_else(|| ScpError::Permission {
                     msg: "broadcast publish requires a fully created identity with key handles"
                         .to_owned(),
-                    code: "SCP-PERM-3020".to_owned(),
+                    code: codes::PERM_3020.to_owned(),
                 })?;
             let signing_key_handle = &core_id.active_signing_key;
 
@@ -8242,7 +8244,7 @@ pub async fn broadcast_publish(
                                       identity with identity_create(\"in_memory\") or \
                                       identity_create_with_custody()"
                                 .to_owned(),
-                            code: "SCP-PERM-3021".to_owned(),
+                            code: codes::PERM_3021.to_owned(),
                         }
                     })?;
                     manager
@@ -8263,7 +8265,7 @@ pub async fn broadcast_publish(
                                   identity_create_with_custody() to inject a platform \
                                   custody provider"
                             .to_owned(),
-                        code: "SCP-PERM-3022".to_owned(),
+                        code: codes::PERM_3022.to_owned(),
                     });
                 }
             }
@@ -8273,7 +8275,7 @@ pub async fn broadcast_publish(
         .await
         .map_err(|e| ScpError::Context {
             msg: format!("tokio task join error during broadcast publish: {e}"),
-            code: "SCP-CTX-2035".to_owned(),
+            code: codes::CTX_2035.to_owned(),
         })?
 }
 
@@ -8353,7 +8355,7 @@ pub async fn broadcast_publish_asset(
                     msg:
                         "broadcast publish asset requires a fully created identity with key handles"
                             .to_owned(),
-                    code: "SCP-PERM-3020".to_owned(),
+                    code: codes::PERM_3020.to_owned(),
                 })?;
             let signing_key_handle = &core_id.active_signing_key;
 
@@ -8361,12 +8363,12 @@ pub async fn broadcast_publish_asset(
             let content_path =
                 scp_core::context::ContentPath::new(asset.path).map_err(|e| ScpError::Context {
                     msg: format!("invalid path: {e}"),
-                    code: "SCP-CTX-2040".to_owned(),
+                    code: codes::CTX_2040.to_owned(),
                 })?;
             let mime_type = scp_core::context::MimeType::new(asset.content_type).map_err(|e| {
                 ScpError::Context {
                     msg: format!("invalid content_type: {e}"),
-                    code: "SCP-CTX-2041".to_owned(),
+                    code: codes::CTX_2041.to_owned(),
                 }
             })?;
             // Auto-generate deploy_id when None, matching batch behavior.
@@ -8385,7 +8387,7 @@ pub async fn broadcast_publish_asset(
             if let Some(ref did_str) = deploy_id {
                 scp_core::context::validate_deploy_id(did_str).map_err(|e| ScpError::Context {
                     msg: format!("invalid deploy_id: {e}"),
-                    code: "SCP-CTX-2042".to_owned(),
+                    code: codes::CTX_2042.to_owned(),
                 })?;
             }
 
@@ -8425,7 +8427,7 @@ pub async fn broadcast_publish_asset(
                                   identity with identity_create(\"in_memory\") or \
                                   identity_create_with_custody()"
                                 .to_owned(),
-                            code: "SCP-PERM-3021".to_owned(),
+                            code: codes::PERM_3021.to_owned(),
                         }
                     })?;
                     manager
@@ -8446,7 +8448,7 @@ pub async fn broadcast_publish_asset(
                               identity_create_with_custody() to inject a platform \
                               custody provider"
                             .to_owned(),
-                        code: "SCP-PERM-3022".to_owned(),
+                        code: codes::PERM_3022.to_owned(),
                     });
                 }
             };
@@ -8454,7 +8456,7 @@ pub async fn broadcast_publish_asset(
             let envelope_bytes =
                 rmp_serde::to_vec_named(&envelope).map_err(|e| ScpError::Context {
                     msg: format!("failed to serialize envelope for blob_id: {e}"),
-                    code: "SCP-CTX-2043".to_owned(),
+                    code: codes::CTX_2043.to_owned(),
                 })?;
             let blob_id = {
                 use sha2::{Digest, Sha256};
@@ -8470,7 +8472,7 @@ pub async fn broadcast_publish_asset(
         .await
         .map_err(|e| ScpError::Context {
             msg: format!("tokio task join error during broadcast publish asset: {e}"),
-            code: "SCP-CTX-2035".to_owned(),
+            code: codes::CTX_2035.to_owned(),
         })?
 }
 
@@ -8497,7 +8499,7 @@ pub async fn broadcast_publish_assets(
                 "batch too large: {} assets (max {MAX_BATCH_ASSETS})",
                 assets.len()
             ),
-            code: "SCP-CTX-2074".to_owned(),
+            code: codes::CTX_2074.to_owned(),
         });
     }
 
@@ -8511,7 +8513,7 @@ pub async fn broadcast_publish_assets(
                 .as_ref()
                 .ok_or_else(|| ScpError::Permission {
                     msg: "broadcast publish assets requires a fully created identity".to_owned(),
-                    code: "SCP-PERM-3020".to_owned(),
+                    code: codes::PERM_3020.to_owned(),
                 })?;
             let signing_key_handle = &core_id.active_signing_key;
 
@@ -8532,7 +8534,7 @@ pub async fn broadcast_publish_assets(
             scp_core::context::validate_deploy_id(&deploy_id_val).map_err(|e| {
                 ScpError::Context {
                     msg: format!("invalid deploy_id: {e}"),
-                    code: "SCP-CTX-2042".to_owned(),
+                    code: codes::CTX_2042.to_owned(),
                 }
             })?;
 
@@ -8542,14 +8544,14 @@ pub async fn broadcast_publish_assets(
                     scp_core::context::ContentPath::new(asset.path).map_err(|e| {
                         ScpError::Context {
                             msg: format!("invalid path: {e}"),
-                            code: "SCP-CTX-2040".to_owned(),
+                            code: codes::CTX_2040.to_owned(),
                         }
                     })?;
                 let mime_type =
                     scp_core::context::MimeType::new(asset.content_type).map_err(|e| {
                         ScpError::Context {
                             msg: format!("invalid content_type: {e}"),
-                            code: "SCP-CTX-2041".to_owned(),
+                            code: codes::CTX_2041.to_owned(),
                         }
                     })?;
 
@@ -8583,7 +8585,7 @@ pub async fn broadcast_publish_assets(
                         let imc = identity.in_memory_custody.as_ref().ok_or_else(|| {
                             ScpError::Permission {
                                 msg: "broadcast publish assets requires key custody".to_owned(),
-                                code: "SCP-PERM-3021".to_owned(),
+                                code: codes::PERM_3021.to_owned(),
                             }
                         })?;
                         manager
@@ -8601,7 +8603,7 @@ pub async fn broadcast_publish_assets(
                     {
                         return Err(ScpError::Permission {
                             msg: "broadcast publish assets requires key custody".to_owned(),
-                            code: "SCP-PERM-3022".to_owned(),
+                            code: codes::PERM_3022.to_owned(),
                         });
                     }
                 };
@@ -8609,7 +8611,7 @@ pub async fn broadcast_publish_assets(
                 let envelope_bytes =
                     rmp_serde::to_vec_named(&envelope).map_err(|e| ScpError::Context {
                         msg: format!("failed to serialize envelope for blob_id: {e}"),
-                        code: "SCP-CTX-2043".to_owned(),
+                        code: codes::CTX_2043.to_owned(),
                     })?;
                 let blob_id = {
                     use sha2::{Digest, Sha256};
@@ -8631,7 +8633,7 @@ pub async fn broadcast_publish_assets(
         .await
         .map_err(|e| ScpError::Context {
             msg: format!("tokio task join error during broadcast publish assets: {e}"),
-            code: "SCP-CTX-2035".to_owned(),
+            code: codes::CTX_2035.to_owned(),
         })?
 }
 
@@ -8663,7 +8665,7 @@ pub async fn broadcast_block_subscriber(
         .await
         .map_err(|e| ScpError::Context {
             msg: format!("tokio task join error during broadcast block: {e}"),
-            code: "SCP-CTX-2036".to_owned(),
+            code: codes::CTX_2036.to_owned(),
         })?
 }
 
@@ -8697,7 +8699,7 @@ pub async fn broadcast_unblock_subscriber(
         .await
         .map_err(|e| ScpError::Context {
             msg: format!("tokio task join error during broadcast unblock: {e}"),
-            code: "SCP-CTX-2037".to_owned(),
+            code: codes::CTX_2037.to_owned(),
         })?
 }
 
@@ -8729,7 +8731,7 @@ pub async fn broadcast_handle_key_request(
         .await
         .map_err(|e| ScpError::Context {
             msg: format!("tokio task join error during key request handling: {e}"),
-            code: "SCP-CTX-2037".to_owned(),
+            code: codes::CTX_2037.to_owned(),
         })?
 }
 
@@ -8969,7 +8971,7 @@ pub async fn context_handle_ttl_expiry(handle: Arc<ContextHandle>) -> Result<(),
         .await
         .map_err(|e| ScpError::Context {
             msg: format!("tokio task join error during TTL expiry: {e}"),
-            code: "SCP-CTX-2038".to_owned(),
+            code: codes::CTX_2038.to_owned(),
         })?
 }
 
@@ -9000,7 +9002,7 @@ pub async fn context_propose_ttl_extension(
         .await
         .map_err(|e| ScpError::Context {
             msg: format!("tokio task join error during TTL extension proposal: {e}"),
-            code: "SCP-CTX-2039".to_owned(),
+            code: codes::CTX_2039.to_owned(),
         })?
 }
 
@@ -9183,7 +9185,7 @@ fn bridge_params_to_core(
     scp_ffi_common::context_params::build_context_params(&common).map_err(|e| {
         ScpError::Validation {
             msg: e,
-            code: "SCP-VALID-7000".to_owned(),
+            code: codes::VALID_7000.to_owned(),
         }
     })
 }
@@ -9198,7 +9200,7 @@ pub(crate) fn parse_custody_method(custody: &str) -> Result<CustodyMethod, ScpEr
             msg: format!(
                 "unknown custody type: {other:?} — expected \"in_memory\", \"platform\", or \"software\""
             ),
-            code: "SCP-VALID-7007".to_owned(),
+            code: codes::VALID_7007.to_owned(),
         }),
     }
 }
@@ -9241,7 +9243,7 @@ pub fn evaluate_provenance_quality(
                 msg: format!(
                     "invalid source_type '{other}': expected 'persistent', 'ephemeral', or 'summary'"
                 ),
-                code: "SCP-VALID-7000".to_owned(),
+                code: codes::VALID_7000.to_owned(),
             });
         }
     };
@@ -9263,7 +9265,7 @@ pub fn evaluate_provenance_quality(
                      'closed_with_summary_verified', 'closed_with_summary_unverified', \
                      'closed_ephemeral', or 'unknown'"
                 ),
-                code: "SCP-VALID-7000".to_owned(),
+                code: codes::VALID_7000.to_owned(),
             });
         }
     };
@@ -9338,13 +9340,13 @@ pub fn trust_query_score(did: String, context_id: String) -> Result<TrustScoreRe
     if did.is_empty() {
         return Err(ScpError::Validation {
             msg: "DID must not be empty".to_owned(),
-            code: "SCP-VALID-7010".to_owned(),
+            code: codes::VALID_7010.to_owned(),
         });
     }
     if context_id.is_empty() {
         return Err(ScpError::Validation {
             msg: "context_id must not be empty".to_owned(),
-            code: "SCP-VALID-7011".to_owned(),
+            code: codes::VALID_7011.to_owned(),
         });
     }
 
@@ -9377,7 +9379,7 @@ pub fn trust_verify_attestation(
     let attestation: scp_core::trust::Attestation = serde_json::from_str(&attestation_json)
         .map_err(|e| ScpError::Validation {
             msg: format!("failed to parse attestation JSON: {e}"),
-            code: "SCP-VALID-7012".to_owned(),
+            code: codes::VALID_7012.to_owned(),
         })?;
 
     let resolver = scp_core::trust::IdentityDidPublicKeyResolver;
@@ -9405,7 +9407,7 @@ pub fn trust_create_challenge(target_did: String) -> Result<ChallengeResult, Scp
     if target_did.is_empty() {
         return Err(ScpError::Validation {
             msg: "target DID must not be empty".to_owned(),
-            code: "SCP-VALID-7013".to_owned(),
+            code: codes::VALID_7013.to_owned(),
         });
     }
 
@@ -9432,12 +9434,12 @@ pub fn trust_create_challenge(target_did: String) -> Result<ChallengeResult, Scp
     )
     .map_err(|e| ScpError::Validation {
         msg: format!("challenge creation failed: {e}"),
-        code: "SCP-VALID-7014".to_owned(),
+        code: codes::VALID_7014.to_owned(),
     })?;
 
     let challenge_json = serde_json::to_string(&request).map_err(|e| ScpError::Validation {
         msg: format!("failed to serialize challenge: {e}"),
-        code: "SCP-VALID-7015".to_owned(),
+        code: codes::VALID_7015.to_owned(),
     })?;
 
     Ok(ChallengeResult {
@@ -9457,13 +9459,13 @@ pub fn trust_verify_response(
     let request: scp_core::trust::ChallengeRequest = serde_json::from_str(&challenge_json)
         .map_err(|e| ScpError::Validation {
             msg: format!("failed to parse challenge JSON: {e}"),
-            code: "SCP-VALID-7016".to_owned(),
+            code: codes::VALID_7016.to_owned(),
         })?;
 
     let response: scp_core::trust::ChallengeResponse = serde_json::from_str(&response_json)
         .map_err(|e| ScpError::Validation {
             msg: format!("failed to parse response JSON: {e}"),
-            code: "SCP-VALID-7017".to_owned(),
+            code: codes::VALID_7017.to_owned(),
         })?;
 
     let resolver = scp_core::trust::IdentityDidPublicKeyResolver;
@@ -9515,13 +9517,13 @@ pub fn verify_participation_requirements(
     let profiles: Vec<scp_core::trust::ParticipationProfile> = serde_json::from_str(&profile_json)
         .map_err(|e| ScpError::Validation {
             msg: format!("failed to parse participation profiles JSON: {e}"),
-            code: "SCP-VALID-7030".to_owned(),
+            code: codes::VALID_7030.to_owned(),
         })?;
 
     let requirements: Vec<scp_core::trust::RequireParticipation> =
         serde_json::from_str(&requirements_json).map_err(|e| ScpError::Validation {
             msg: format!("failed to parse participation requirements JSON: {e}"),
-            code: "SCP-VALID-7031".to_owned(),
+            code: codes::VALID_7031.to_owned(),
         })?;
 
     let current_time = std::time::SystemTime::now()
@@ -9531,7 +9533,7 @@ pub fn verify_participation_requirements(
     scp_core::trust::verify_participation_requirements(current_time, &requirements, &profiles)
         .map_err(|e| ScpError::Validation {
             msg: format!("participation admission verification failed: {e}"),
-            code: "SCP-VALID-7032".to_owned(),
+            code: codes::VALID_7032.to_owned(),
         })?;
 
     Ok(true)
@@ -9567,39 +9569,39 @@ pub fn aggregate_trust_input(
     if context_id.is_empty() {
         return Err(ScpError::Validation {
             msg: "context_id must not be empty".to_owned(),
-            code: "SCP-VALID-7040".to_owned(),
+            code: codes::VALID_7040.to_owned(),
         });
     }
     if subject_did.is_empty() {
         return Err(ScpError::Validation {
             msg: "subject DID must not be empty".to_owned(),
-            code: "SCP-VALID-7041".to_owned(),
+            code: codes::VALID_7041.to_owned(),
         });
     }
 
     let events: Vec<scp_event_log::Event> =
         serde_json::from_str(&events_json).map_err(|e| ScpError::Validation {
             msg: format!("failed to parse events JSON: {e}"),
-            code: "SCP-VALID-7042".to_owned(),
+            code: codes::VALID_7042.to_owned(),
         })?;
 
     let merkle_root_vec: Vec<u8> =
         serde_json::from_str(&merkle_root_json).map_err(|e| ScpError::Validation {
             msg: format!("failed to parse merkle_root JSON: {e}"),
-            code: "SCP-VALID-7043".to_owned(),
+            code: codes::VALID_7043.to_owned(),
         })?;
     let merkle_root: [u8; 32] =
         merkle_root_vec
             .try_into()
             .map_err(|v: Vec<u8>| ScpError::Validation {
                 msg: format!("merkle_root must be exactly 32 bytes, got {}", v.len()),
-                code: "SCP-VALID-7044".to_owned(),
+                code: codes::VALID_7044.to_owned(),
             })?;
 
     let consequence_rules: Vec<scp_core::trust::ConsequenceRule> =
         serde_json::from_str(&consequence_rules_json).map_err(|e| ScpError::Validation {
             msg: format!("failed to parse consequence_rules JSON: {e}"),
-            code: "SCP-VALID-7045".to_owned(),
+            code: codes::VALID_7045.to_owned(),
         })?;
 
     let threshold_requirements: std::collections::HashMap<
@@ -9607,7 +9609,7 @@ pub fn aggregate_trust_input(
         scp_core::trust::ThresholdRequirement,
     > = serde_json::from_str(&threshold_requirements_json).map_err(|e| ScpError::Validation {
         msg: format!("failed to parse threshold_requirements JSON: {e}"),
-        code: "SCP-VALID-7046".to_owned(),
+        code: codes::VALID_7046.to_owned(),
     })?;
 
     let attestor_sets: std::collections::HashMap<
@@ -9615,19 +9617,19 @@ pub fn aggregate_trust_input(
         Vec<scp_core::trust::AttestorInfo>,
     > = serde_json::from_str(&attestor_sets_json).map_err(|e| ScpError::Validation {
         msg: format!("failed to parse attestor_sets JSON: {e}"),
-        code: "SCP-VALID-7047".to_owned(),
+        code: codes::VALID_7047.to_owned(),
     })?;
 
     let cached_attestations: Vec<scp_core::trust::aggregate::CachedAttestation> =
         serde_json::from_str(&cached_attestations_json).map_err(|e| ScpError::Validation {
             msg: format!("failed to parse cached_attestations JSON: {e}"),
-            code: "SCP-VALID-7048".to_owned(),
+            code: codes::VALID_7048.to_owned(),
         })?;
 
     let challenge_results: Vec<scp_core::trust::ChallengeVerification> =
         serde_json::from_str(&challenge_results_json).map_err(|e| ScpError::Validation {
             msg: format!("failed to parse challenge_results JSON: {e}"),
-            code: "SCP-VALID-7049".to_owned(),
+            code: codes::VALID_7049.to_owned(),
         })?;
 
     // Use persistent storage if the global ProtocolRepository is initialized,
@@ -9652,7 +9654,7 @@ pub fn aggregate_trust_input(
         )
         .map_err(|e| ScpError::Validation {
             msg: e.to_string(),
-            code: "SCP-VALID-7052".to_owned(),
+            code: codes::VALID_7052.to_owned(),
         })
     } else {
         scp_ffi_common::trust_store::populate_and_aggregate(
@@ -9669,7 +9671,7 @@ pub fn aggregate_trust_input(
         )
         .map_err(|e| ScpError::Validation {
             msg: e.to_string(),
-            code: "SCP-VALID-7052".to_owned(),
+            code: codes::VALID_7052.to_owned(),
         })
     }
 }
@@ -9702,7 +9704,7 @@ pub fn set_economic_policy(
               (propose SetEconomicPolicy action). Direct mutation is \
               not permitted — see spec §19.3"
             .to_owned(),
-        code: "SCP-CTX-2013".to_owned(),
+        code: codes::CTX_2013.to_owned(),
     })
 }
 
@@ -9714,7 +9716,7 @@ pub fn get_economic_policy(handle: Arc<ContextHandle>) -> Result<Option<String>,
         .lock()
         .map_err(|_| ScpError::Context {
             msg: "economic_policy lock is poisoned".to_owned(),
-            code: "SCP-CTX-2012".to_owned(),
+            code: codes::CTX_2012.to_owned(),
         })?;
     Ok(guard.clone())
 }
@@ -9746,14 +9748,14 @@ pub async fn context_export(handle: Arc<ContextHandle>) -> Result<Vec<u8>, ScpEr
             scp_core::context::export_import::serialize_export(&export).map_err(|e| {
                 ScpError::Context {
                     msg: format!("export serialization failed: {e}"),
-                    code: "SCP-CTX-2030".to_owned(),
+                    code: codes::CTX_2030.to_owned(),
                 }
             })
         })
         .await
         .map_err(|e| ScpError::Context {
             msg: format!("tokio task join error during context export: {e}"),
-            code: "SCP-CTX-2031".to_owned(),
+            code: codes::CTX_2031.to_owned(),
         })?
 }
 
@@ -9776,7 +9778,7 @@ pub async fn context_import(data: Vec<u8>) -> Result<String, ScpError> {
                 scp_core::context::export_import::deserialize_export(&data).map_err(|e| {
                     ScpError::Context {
                         msg: format!("invalid export data: {e}"),
-                        code: "SCP-CTX-2032".to_owned(),
+                        code: codes::CTX_2032.to_owned(),
                     }
                 })?;
             let context_id = export.snapshot.context_id.clone();
@@ -9796,7 +9798,7 @@ pub async fn context_import(data: Vec<u8>) -> Result<String, ScpError> {
         .await
         .map_err(|e| ScpError::Context {
             msg: format!("tokio task join error during context import: {e}"),
-            code: "SCP-CTX-2033".to_owned(),
+            code: codes::CTX_2033.to_owned(),
         })?
 }
 
@@ -9830,7 +9832,7 @@ pub fn provenance_attach(
         other => {
             return Err(ScpError::Validation {
                 msg: format!("invalid source_type '{other}'"),
-                code: "SCP-VALID-7040".to_owned(),
+                code: codes::VALID_7040.to_owned(),
             });
         }
     };
@@ -9841,7 +9843,7 @@ pub fn provenance_attach(
         other => {
             return Err(ScpError::Validation {
                 msg: format!("invalid memory_scope '{other}'"),
-                code: "SCP-VALID-7041".to_owned(),
+                code: codes::VALID_7041.to_owned(),
             });
         }
     };
@@ -9883,7 +9885,7 @@ pub fn provenance_attach(
     // Compute provenance hash: SHA-256 of JSON-serialized provenance record.
     let prov_json_bytes = serde_json::to_vec(&prov).map_err(|e| ScpError::Validation {
         msg: format!("failed to serialize provenance for hashing: {e}"),
-        code: "SCP-VALID-7053".to_owned(),
+        code: codes::VALID_7053.to_owned(),
     })?;
     let prov_hash: [u8; 32] = sha2::Sha256::digest(&prov_json_bytes).into();
 
@@ -9930,7 +9932,7 @@ pub fn provenance_attach(
 
     serde_json::to_string(&result).map_err(|e| ScpError::Validation {
         msg: format!("failed to serialize provenance: {e}"),
-        code: "SCP-VALID-7042".to_owned(),
+        code: codes::VALID_7042.to_owned(),
     })
 }
 
@@ -9973,13 +9975,13 @@ fn uniffi_append_provenance_event(
             .map(|_| ())
             .map_err(|e| ScpError::Context {
                 msg: format!("failed to append provenance event: {e}"),
-                code: "SCP-CTX-2060".to_owned(),
+                code: codes::CTX_2060.to_owned(),
             })
     })
     .unwrap_or_else(|| {
         Err(ScpError::Context {
             msg: format!("context '{context_id}' not found in UCAN state registry"),
-            code: "SCP-CTX-2066".to_owned(),
+            code: codes::CTX_2066.to_owned(),
         })
     })
 }
@@ -10021,14 +10023,14 @@ pub fn provenance_redact_counterparties(provenance_json: String) -> Result<Strin
     let mut prov: scp_core::provenance::DataProvenance = serde_json::from_str(&provenance_json)
         .map_err(|e| ScpError::Validation {
             msg: format!("invalid provenance JSON: {e}"),
-            code: "SCP-VALID-7050".to_owned(),
+            code: codes::VALID_7050.to_owned(),
         })?;
 
     scp_core::provenance::attach::redact_counterparties(&mut prov);
 
     serde_json::to_string(&prov).map_err(|e| ScpError::Validation {
         msg: format!("failed to serialize provenance: {e}"),
-        code: "SCP-VALID-7051".to_owned(),
+        code: codes::VALID_7051.to_owned(),
     })
 }
 
@@ -10052,14 +10054,14 @@ pub fn provenance_pseudonymize_counterparties(
     let mut prov: scp_core::provenance::DataProvenance = serde_json::from_str(&provenance_json)
         .map_err(|e| ScpError::Validation {
             msg: format!("invalid provenance JSON: {e}"),
-            code: "SCP-VALID-7050".to_owned(),
+            code: codes::VALID_7050.to_owned(),
         })?;
 
     let key =
         Zeroizing::new(
             hex::decode(&pseudonym_key_hex).map_err(|e| ScpError::Validation {
                 msg: format!("invalid pseudonym_key_hex: {e}"),
-                code: "SCP-VALID-7052".to_owned(),
+                code: codes::VALID_7052.to_owned(),
             })?,
         );
 
@@ -10067,7 +10069,7 @@ pub fn provenance_pseudonymize_counterparties(
 
     serde_json::to_string(&prov).map_err(|e| ScpError::Validation {
         msg: format!("failed to serialize provenance: {e}"),
-        code: "SCP-VALID-7051".to_owned(),
+        code: codes::VALID_7051.to_owned(),
     })
 }
 
@@ -10093,7 +10095,7 @@ pub fn provenance_update_source_type(
     let mut prov: scp_core::provenance::DataProvenance = serde_json::from_str(&provenance_json)
         .map_err(|e| ScpError::Validation {
             msg: format!("invalid provenance JSON: {e}"),
-            code: "SCP-VALID-7050".to_owned(),
+            code: codes::VALID_7050.to_owned(),
         })?;
 
     let state = match new_state.as_str() {
@@ -10113,7 +10115,7 @@ pub fn provenance_update_source_type(
                      'closed_with_summary_verified', 'closed_with_summary_unverified', \
                      'closed_ephemeral', or 'unknown'"
                 ),
-                code: "SCP-VALID-7053".to_owned(),
+                code: codes::VALID_7053.to_owned(),
             });
         }
     };
@@ -10122,7 +10124,7 @@ pub fn provenance_update_source_type(
 
     serde_json::to_string(&prov).map_err(|e| ScpError::Validation {
         msg: format!("failed to serialize provenance: {e}"),
-        code: "SCP-VALID-7051".to_owned(),
+        code: codes::VALID_7051.to_owned(),
     })
 }
 
@@ -10148,7 +10150,7 @@ pub fn media_check_capability(ceiling: Vec<String>, capability: String) -> Resul
     scp_media::session::check_media_capability(&param_caps, &cap).map_err(|e| {
         ScpError::Context {
             msg: e.to_string(),
-            code: "SCP-CTX-2500".to_owned(),
+            code: codes::CTX_2500.to_owned(),
         }
     })?;
     Ok(true)
@@ -10188,7 +10190,7 @@ pub fn media_initiate_session(
     )
     .map_err(|e| ScpError::Context {
         msg: e.to_string(),
-        code: "SCP-CTX-2500".to_owned(),
+        code: codes::CTX_2500.to_owned(),
     })?;
 
     media_session_to_json(&session)
@@ -10202,12 +10204,12 @@ pub fn media_activate_session(session_json: String) -> Result<String, ScpError> 
     let mut session: scp_media::session::MediaSession = serde_json::from_str(&session_json)
         .map_err(|e| ScpError::Validation {
             msg: format!("invalid session JSON: {e}"),
-            code: "SCP-VALID-7301".to_owned(),
+            code: codes::VALID_7301.to_owned(),
         })?;
 
     scp_media::session::activate_session(&mut session).map_err(|e| ScpError::Context {
         msg: e.to_string(),
-        code: "SCP-CTX-2500".to_owned(),
+        code: codes::CTX_2500.to_owned(),
     })?;
 
     media_session_to_json(&session)
@@ -10224,13 +10226,13 @@ pub fn media_join_session(
     let mut session: scp_media::session::MediaSession = serde_json::from_str(&session_json)
         .map_err(|e| ScpError::Validation {
             msg: format!("invalid session JSON: {e}"),
-            code: "SCP-VALID-7301".to_owned(),
+            code: codes::VALID_7301.to_owned(),
         })?;
 
     scp_media::session::join_media_session(&mut session, participant_did.into()).map_err(|e| {
         ScpError::Context {
             msg: e.to_string(),
-            code: "SCP-CTX-2500".to_owned(),
+            code: codes::CTX_2500.to_owned(),
         }
     })?;
 
@@ -10245,13 +10247,13 @@ pub fn media_end_session(session_json: String, timestamp: u64) -> Result<String,
     let mut session: scp_media::session::MediaSession = serde_json::from_str(&session_json)
         .map_err(|e| ScpError::Validation {
             msg: format!("invalid session JSON: {e}"),
-            code: "SCP-VALID-7301".to_owned(),
+            code: codes::VALID_7301.to_owned(),
         })?;
 
     let metadata = scp_media::session::end_media_session(&mut session, timestamp).map_err(|e| {
         ScpError::Context {
             msg: e.to_string(),
-            code: "SCP-CTX-2500".to_owned(),
+            code: codes::CTX_2500.to_owned(),
         }
     })?;
 
@@ -10275,7 +10277,7 @@ pub fn media_end_session(session_json: String, timestamp: u64) -> Result<String,
     }))
     .map_err(|e| ScpError::Validation {
         msg: format!("failed to serialize result: {e}"),
-        code: "SCP-VALID-7301".to_owned(),
+        code: codes::VALID_7301.to_owned(),
     })
 }
 
@@ -10348,13 +10350,13 @@ pub fn media_send_signaling(signaling_json: String) -> Result<String, ScpError> 
         scp_media::signaling::deserialize_signaling(signaling_json.as_bytes()).map_err(|e| {
             ScpError::Validation {
                 msg: format!("invalid signaling JSON: {e}"),
-                code: "SCP-VALID-7303".to_owned(),
+                code: codes::VALID_7303.to_owned(),
             }
         })?;
     let (payload, message_type) =
         scp_media::signaling::send_signaling(&msg).map_err(|e| ScpError::Validation {
             msg: format!("failed to serialize signaling: {e}"),
-            code: "SCP-VALID-7302".to_owned(),
+            code: codes::VALID_7302.to_owned(),
         })?;
 
     use base64::Engine;
@@ -10364,7 +10366,7 @@ pub fn media_send_signaling(signaling_json: String) -> Result<String, ScpError> 
     }))
     .map_err(|e| ScpError::Validation {
         msg: format!("failed to serialize result: {e}"),
-        code: "SCP-VALID-7302".to_owned(),
+        code: codes::VALID_7302.to_owned(),
     })
 }
 
@@ -10380,13 +10382,13 @@ pub fn media_verify_sender_attribution(
         scp_media::signaling::deserialize_signaling(signaling_json.as_bytes()).map_err(|e| {
             ScpError::Validation {
                 msg: format!("invalid signaling JSON: {e}"),
-                code: "SCP-VALID-7303".to_owned(),
+                code: codes::VALID_7303.to_owned(),
             }
         })?;
     scp_media::signaling::verify_sender_attribution(&msg, &envelope_sender_did).map_err(|e| {
         ScpError::Context {
             msg: format!("sender attribution verification failed: {e}"),
-            code: "SCP-CTX-2501".to_owned(),
+            code: codes::CTX_2501.to_owned(),
         }
     })?;
     Ok(true)
@@ -10403,7 +10405,7 @@ fn parse_media_capability(s: &str) -> Result<scp_media::session::MediaCapability
             msg: format!(
                 "invalid media capability '{other}': expected 'voice', 'video', or 'screen_share'"
             ),
-            code: "SCP-VALID-7300".to_owned(),
+            code: codes::VALID_7300.to_owned(),
         }),
     }
 }
@@ -10435,7 +10437,7 @@ fn media_session_to_json(session: &scp_media::session::MediaSession) -> Result<S
     }))
     .map_err(|e| ScpError::Validation {
         msg: format!("failed to serialize session: {e}"),
-        code: "SCP-VALID-7301".to_owned(),
+        code: codes::VALID_7301.to_owned(),
     })
 }
 
@@ -10447,12 +10449,12 @@ fn signaling_to_json(
         String::from_utf8(scp_media::signaling::serialize_signaling(msg).map_err(|e| {
             ScpError::Validation {
                 msg: format!("failed to serialize signaling: {e}"),
-                code: "SCP-VALID-7302".to_owned(),
+                code: codes::VALID_7302.to_owned(),
             }
         })?)
         .map_err(|e| ScpError::Validation {
             msg: format!("signaling bytes are not valid UTF-8: {e}"),
-            code: "SCP-VALID-7302".to_owned(),
+            code: codes::VALID_7302.to_owned(),
         })?;
 
     serde_json::to_string(&serde_json::json!({
@@ -10461,7 +10463,7 @@ fn signaling_to_json(
     }))
     .map_err(|e| ScpError::Validation {
         msg: format!("failed to serialize result: {e}"),
-        code: "SCP-VALID-7302".to_owned(),
+        code: codes::VALID_7302.to_owned(),
     })
 }
 
@@ -10489,7 +10491,7 @@ pub fn bridge_evaluate_trust(
         other => {
             return Err(ScpError::Validation {
                 msg: format!("invalid shadow_status '{other}': expected 'shadow' or 'claimed'"),
-                code: "SCP-VALID-7051".to_owned(),
+                code: codes::VALID_7051.to_owned(),
             });
         }
     };
@@ -10584,7 +10586,7 @@ pub fn discovery_parse_address(address: String) -> Result<String, ScpError> {
     let parsed =
         scp_core::discovery::parse_address(&address).map_err(|e| ScpError::Validation {
             msg: format!("invalid address '{address}': {e}"),
-            code: "SCP-VALID-7044".to_owned(),
+            code: codes::VALID_7044.to_owned(),
         })?;
 
     let result = match parsed {
@@ -10619,7 +10621,7 @@ pub fn discovery_parse_address(address: String) -> Result<String, ScpError> {
 
     serde_json::to_string(&result).map_err(|e| ScpError::Validation {
         msg: format!("failed to serialize parsed address: {e}"),
-        code: "SCP-VALID-7045".to_owned(),
+        code: codes::VALID_7045.to_owned(),
     })
 }
 
@@ -10638,7 +10640,7 @@ pub fn discovery_create_query(
 
     serde_json::to_string(&query).map_err(|e| ScpError::Validation {
         msg: format!("failed to serialize query: {e}"),
-        code: "SCP-VALID-7046".to_owned(),
+        code: codes::VALID_7046.to_owned(),
     })
 }
 
@@ -10674,20 +10676,20 @@ pub fn petname_set(owner_did: String, target_did: String, name: String) -> Resul
     if owner_did.is_empty() {
         return Err(ScpError::Validation {
             msg: "owner_did must not be empty".to_owned(),
-            code: "SCP-VALID-7110".to_owned(),
+            code: codes::VALID_7110.to_owned(),
         });
     }
     if target_did.is_empty() {
         return Err(ScpError::Validation {
             msg: "target_did must not be empty".to_owned(),
-            code: "SCP-VALID-7111".to_owned(),
+            code: codes::VALID_7111.to_owned(),
         });
     }
     let mut guard = uniffi_petname_maps()
         .lock()
         .map_err(|e| ScpError::Validation {
             msg: format!("petname lock poisoned: {e}"),
-            code: "SCP-VALID-7112".to_owned(),
+            code: codes::VALID_7112.to_owned(),
         })?;
     let map = guard.entry(owner_did).or_default();
     map.set_petname(scp_identity::DID::from(target_did.as_str()), name);
@@ -10700,14 +10702,14 @@ pub fn petname_remove(owner_did: String, target_did: String) -> Result<(), ScpEr
     if owner_did.is_empty() {
         return Err(ScpError::Validation {
             msg: "owner_did must not be empty".to_owned(),
-            code: "SCP-VALID-7110".to_owned(),
+            code: codes::VALID_7110.to_owned(),
         });
     }
     let mut guard = uniffi_petname_maps()
         .lock()
         .map_err(|e| ScpError::Validation {
             msg: format!("petname lock poisoned: {e}"),
-            code: "SCP-VALID-7112".to_owned(),
+            code: codes::VALID_7112.to_owned(),
         })?;
     if let Some(map) = guard.get_mut(&owner_did) {
         map.remove_petname(&scp_identity::DID::from(target_did.as_str()));
@@ -10725,20 +10727,20 @@ pub fn petname_set_context(
     if owner_did.is_empty() {
         return Err(ScpError::Validation {
             msg: "owner_did must not be empty".to_owned(),
-            code: "SCP-VALID-7110".to_owned(),
+            code: codes::VALID_7110.to_owned(),
         });
     }
     if context_id.is_empty() {
         return Err(ScpError::Validation {
             msg: "context_id must not be empty".to_owned(),
-            code: "SCP-VALID-7113".to_owned(),
+            code: codes::VALID_7113.to_owned(),
         });
     }
     let mut guard = uniffi_petname_maps()
         .lock()
         .map_err(|e| ScpError::Validation {
             msg: format!("petname lock poisoned: {e}"),
-            code: "SCP-VALID-7112".to_owned(),
+            code: codes::VALID_7112.to_owned(),
         })?;
     let map = guard.entry(owner_did).or_default();
     map.set_context_petname(context_id, name);
@@ -10751,14 +10753,14 @@ pub fn petname_remove_context(owner_did: String, context_id: String) -> Result<(
     if owner_did.is_empty() {
         return Err(ScpError::Validation {
             msg: "owner_did must not be empty".to_owned(),
-            code: "SCP-VALID-7110".to_owned(),
+            code: codes::VALID_7110.to_owned(),
         });
     }
     let mut guard = uniffi_petname_maps()
         .lock()
         .map_err(|e| ScpError::Validation {
             msg: format!("petname lock poisoned: {e}"),
-            code: "SCP-VALID-7112".to_owned(),
+            code: codes::VALID_7112.to_owned(),
         })?;
     if let Some(map) = guard.get_mut(&owner_did) {
         map.remove_context_petname(&context_id);
@@ -10772,14 +10774,14 @@ pub fn petname_resolve_did(owner_did: String, name: String) -> Result<String, Sc
     if owner_did.is_empty() {
         return Err(ScpError::Validation {
             msg: "owner_did must not be empty".to_owned(),
-            code: "SCP-VALID-7110".to_owned(),
+            code: codes::VALID_7110.to_owned(),
         });
     }
     let guard = uniffi_petname_maps()
         .lock()
         .map_err(|e| ScpError::Validation {
             msg: format!("petname lock poisoned: {e}"),
-            code: "SCP-VALID-7112".to_owned(),
+            code: codes::VALID_7112.to_owned(),
         })?;
     let dids: Vec<String> = guard
         .get(&owner_did)
@@ -10792,7 +10794,7 @@ pub fn petname_resolve_did(owner_did: String, name: String) -> Result<String, Sc
         .unwrap_or_default();
     serde_json::to_string(&dids).map_err(|e| ScpError::Validation {
         msg: format!("failed to serialize petname resolve result: {e}"),
-        code: "SCP-VALID-7114".to_owned(),
+        code: codes::VALID_7114.to_owned(),
     })
 }
 
@@ -10802,14 +10804,14 @@ pub fn petname_resolve_context(owner_did: String, name: String) -> Result<String
     if owner_did.is_empty() {
         return Err(ScpError::Validation {
             msg: "owner_did must not be empty".to_owned(),
-            code: "SCP-VALID-7110".to_owned(),
+            code: codes::VALID_7110.to_owned(),
         });
     }
     let guard = uniffi_petname_maps()
         .lock()
         .map_err(|e| ScpError::Validation {
             msg: format!("petname lock poisoned: {e}"),
-            code: "SCP-VALID-7112".to_owned(),
+            code: codes::VALID_7112.to_owned(),
         })?;
     let ids: Vec<String> = guard
         .get(&owner_did)
@@ -10817,7 +10819,7 @@ pub fn petname_resolve_context(owner_did: String, name: String) -> Result<String
         .unwrap_or_default();
     serde_json::to_string(&ids).map_err(|e| ScpError::Validation {
         msg: format!("failed to serialize petname resolve result: {e}"),
-        code: "SCP-VALID-7114".to_owned(),
+        code: codes::VALID_7114.to_owned(),
     })
 }
 
@@ -10830,14 +10832,14 @@ pub fn petname_get_for_did(
     if owner_did.is_empty() {
         return Err(ScpError::Validation {
             msg: "owner_did must not be empty".to_owned(),
-            code: "SCP-VALID-7110".to_owned(),
+            code: codes::VALID_7110.to_owned(),
         });
     }
     let guard = uniffi_petname_maps()
         .lock()
         .map_err(|e| ScpError::Validation {
             msg: format!("petname lock poisoned: {e}"),
-            code: "SCP-VALID-7112".to_owned(),
+            code: codes::VALID_7112.to_owned(),
         })?;
     Ok(guard.get(&owner_did).and_then(|map| {
         map.petname_for_did(&scp_identity::DID::from(target_did.as_str()))
@@ -10854,14 +10856,14 @@ pub fn petname_get_for_context(
     if owner_did.is_empty() {
         return Err(ScpError::Validation {
             msg: "owner_did must not be empty".to_owned(),
-            code: "SCP-VALID-7110".to_owned(),
+            code: codes::VALID_7110.to_owned(),
         });
     }
     let guard = uniffi_petname_maps()
         .lock()
         .map_err(|e| ScpError::Validation {
             msg: format!("petname lock poisoned: {e}"),
-            code: "SCP-VALID-7112".to_owned(),
+            code: codes::VALID_7112.to_owned(),
         })?;
     Ok(guard
         .get(&owner_did)
@@ -10893,7 +10895,7 @@ pub fn handle_register(
         .lock()
         .map_err(|e| ScpError::Validation {
             msg: format!("handle registry lock poisoned: {e}"),
-            code: "SCP-VALID-7120".to_owned(),
+            code: codes::VALID_7120.to_owned(),
         })?;
     let registry = guard
         .entry(discovery_context_id.clone())
@@ -10905,7 +10907,7 @@ pub fn handle_register(
     );
     serde_json::to_string(&result).map_err(|e| ScpError::Validation {
         msg: format!("failed to serialize handle register result: {e}"),
-        code: "SCP-VALID-7122".to_owned(),
+        code: codes::VALID_7122.to_owned(),
     })
 }
 
@@ -10922,7 +10924,7 @@ pub fn handle_lookup(
         Some(other) => {
             return Err(ScpError::Validation {
                 msg: format!("invalid type_filter '{other}': expected 'identity' or 'context'"),
-                code: "SCP-VALID-7123".to_owned(),
+                code: codes::VALID_7123.to_owned(),
             });
         }
         None => None,
@@ -10931,7 +10933,7 @@ pub fn handle_lookup(
         .lock()
         .map_err(|e| ScpError::Validation {
             msg: format!("handle registry lock poisoned: {e}"),
-            code: "SCP-VALID-7120".to_owned(),
+            code: codes::VALID_7120.to_owned(),
         })?;
     let result = guard.get(&discovery_context_id).map_or_else(
         || scp_core::discovery::HandleLookupResult {
@@ -10946,7 +10948,7 @@ pub fn handle_lookup(
     );
     serde_json::to_string(&result).map_err(|e| ScpError::Validation {
         msg: format!("failed to serialize handle lookup result: {e}"),
-        code: "SCP-VALID-7124".to_owned(),
+        code: codes::VALID_7124.to_owned(),
     })
 }
 
@@ -10961,7 +10963,7 @@ pub fn handle_deregister(
         .lock()
         .map_err(|e| ScpError::Validation {
             msg: format!("handle registry lock poisoned: {e}"),
-            code: "SCP-VALID-7120".to_owned(),
+            code: codes::VALID_7120.to_owned(),
         })?;
     let result = guard.get_mut(&discovery_context_id).map_or_else(
         || scp_core::discovery::HandleDeregisterResult { removed: false },
@@ -10974,7 +10976,7 @@ pub fn handle_deregister(
     );
     serde_json::to_string(&result).map_err(|e| ScpError::Validation {
         msg: format!("failed to serialize handle deregister result: {e}"),
-        code: "SCP-VALID-7125".to_owned(),
+        code: codes::VALID_7125.to_owned(),
     })
 }
 
@@ -11009,7 +11011,7 @@ pub fn scope_register(
     for url in &relay_urls {
         scp_ffi_common::validate::validate_relay_url(url).map_err(|e| ScpError::Validation {
             msg: e.to_string(),
-            code: "SCP-VALID-7135".to_owned(),
+            code: codes::VALID_7135.to_owned(),
         })?;
     }
 
@@ -11030,7 +11032,7 @@ pub fn scope_register(
         .lock()
         .map_err(|e| ScpError::Validation {
             msg: format!("scope registry lock poisoned: {e}"),
-            code: "SCP-VALID-7130".to_owned(),
+            code: codes::VALID_7130.to_owned(),
         })?;
 
     let registry = guard
@@ -11045,12 +11047,12 @@ pub fn scope_register(
         )
         .map_err(|e| ScpError::Validation {
             msg: format!("scope registration failed: {e}"),
-            code: "SCP-VALID-7131".to_owned(),
+            code: codes::VALID_7131.to_owned(),
         })?;
 
     serde_json::to_string(&result).map_err(|e| ScpError::Validation {
         msg: format!("failed to serialize scope register result: {e}"),
-        code: "SCP-VALID-7132".to_owned(),
+        code: codes::VALID_7132.to_owned(),
     })
 }
 
@@ -11063,7 +11065,7 @@ pub fn scope_lookup(scope_context_id: String, name: String) -> Result<String, Sc
         .lock()
         .map_err(|e| ScpError::Validation {
             msg: format!("scope registry lock poisoned: {e}"),
-            code: "SCP-VALID-7130".to_owned(),
+            code: codes::VALID_7130.to_owned(),
         })?;
 
     let result = match guard.get(&scope_context_id) {
@@ -11071,7 +11073,7 @@ pub fn scope_lookup(scope_context_id: String, name: String) -> Result<String, Sc
             .lookup(&scp_core::discovery::ScopeLookupParams { name })
             .map_err(|e| ScpError::Validation {
                 msg: format!("scope lookup failed: {e}"),
-                code: "SCP-VALID-7133".to_owned(),
+                code: codes::VALID_7133.to_owned(),
             })?,
         None => scp_core::discovery::ScopeLookupResult {
             results: Vec::new(),
@@ -11080,7 +11082,7 @@ pub fn scope_lookup(scope_context_id: String, name: String) -> Result<String, Sc
 
     serde_json::to_string(&result).map_err(|e| ScpError::Validation {
         msg: format!("failed to serialize scope lookup result: {e}"),
-        code: "SCP-VALID-7133".to_owned(),
+        code: codes::VALID_7133.to_owned(),
     })
 }
 
@@ -11098,7 +11100,7 @@ pub fn scope_deregister(
         .lock()
         .map_err(|e| ScpError::Validation {
             msg: format!("scope registry lock poisoned: {e}"),
-            code: "SCP-VALID-7130".to_owned(),
+            code: codes::VALID_7130.to_owned(),
         })?;
 
     let result = match guard.get_mut(&scope_context_id) {
@@ -11109,14 +11111,14 @@ pub fn scope_deregister(
             })
             .map_err(|e| ScpError::Validation {
                 msg: format!("scope deregister failed: {e}"),
-                code: "SCP-VALID-7134".to_owned(),
+                code: codes::VALID_7134.to_owned(),
             })?,
         None => scp_core::discovery::ScopeDeregisterResult { removed: false },
     };
 
     serde_json::to_string(&result).map_err(|e| ScpError::Validation {
         msg: format!("failed to serialize scope deregister result: {e}"),
-        code: "SCP-VALID-7134".to_owned(),
+        code: codes::VALID_7134.to_owned(),
     })
 }
 
@@ -11131,7 +11133,7 @@ pub fn address_resolve(
     if owner_did.is_empty() {
         return Err(ScpError::Validation {
             msg: "owner_did must not be empty".to_owned(),
-            code: "SCP-VALID-7110".to_owned(),
+            code: codes::VALID_7110.to_owned(),
         });
     }
 
@@ -11139,14 +11141,14 @@ pub fn address_resolve(
         if let Some(ref json) = known_contexts_json {
             serde_json::from_str(json).map_err(|e| ScpError::Validation {
                 msg: format!("invalid known_contexts_json: {e}"),
-                code: "SCP-VALID-7090".to_owned(),
+                code: codes::VALID_7090.to_owned(),
             })?
         } else {
             let guard = uniffi_handle_registries()
                 .lock()
                 .map_err(|e| ScpError::Validation {
                     msg: format!("handle registry lock poisoned: {e}"),
-                    code: "SCP-VALID-7120".to_owned(),
+                    code: codes::VALID_7120.to_owned(),
                 })?;
             guard.keys().map(|k| (k.clone(), k.clone())).collect()
         };
@@ -11163,7 +11165,7 @@ pub fn address_resolve(
             .lock()
             .map_err(|e| ScpError::Validation {
                 msg: format!("petname lock poisoned: {e}"),
-                code: "SCP-VALID-7112".to_owned(),
+                code: codes::VALID_7112.to_owned(),
             })?;
         guard.get(&owner_did).cloned().unwrap_or_default()
     };
@@ -11185,7 +11187,7 @@ pub fn address_resolve(
                 .await
                 .map_err(|e| ScpError::Validation {
                     msg: format!("address resolution failed: {e}"),
-                    code: "SCP-VALID-7091".to_owned(),
+                    code: codes::VALID_7091.to_owned(),
                 })
         })
     })?;
@@ -11196,7 +11198,7 @@ pub fn address_resolve(
         .collect();
     serde_json::to_string(&json_results).map_err(|e| ScpError::Validation {
         msg: format!("failed to serialize address resolution results: {e}"),
-        code: "SCP-VALID-7092".to_owned(),
+        code: codes::VALID_7092.to_owned(),
     })
 }
 
@@ -11206,7 +11208,7 @@ fn uniffi_parse_handle_target(
 ) -> Result<scp_core::discovery::addressing::HandleTarget, ScpError> {
     petname_helpers::parse_handle_target(json).map_err(|e| ScpError::Validation {
         msg: e.message,
-        code: "SCP-VALID-7126".to_owned(),
+        code: codes::VALID_7126.to_owned(),
     })
 }
 
@@ -11250,7 +11252,7 @@ pub async fn identity_create_with_agent_key(custody: String) -> Result<Arc<Ident
                                       dev/desktop use. Production mobile builds must use \
                                       \"platform\" custody (Secure Enclave / Android Keystore)."
                                 .to_owned(),
-                            code: "SCP-IDENT-1008".to_owned(),
+                            code: codes::IDENT_1008.to_owned(),
                         })
                     }
 
@@ -11285,21 +11287,21 @@ pub async fn identity_create_with_agent_key(custody: String) -> Result<Arc<Ident
                              use identity_create_with_custody() + add_agent_key() to create \
                              an identity with an agent key using platform custody"
                     ),
-                    code: "SCP-IDENT-1003".to_owned(),
+                    code: codes::IDENT_1003.to_owned(),
                 }),
                 CustodyMethod::External => Err(ScpError::Identity {
                     msg: "internal: CustodyMethod::External cannot be used with \
                                   identity_create_with_agent_key — use identity_load for \
                                   external DID handles"
                         .to_owned(),
-                    code: "SCP-IDENT-1005".to_owned(),
+                    code: codes::IDENT_1005.to_owned(),
                 }),
             }
         })
         .await
         .map_err(|e| ScpError::Identity {
             msg: format!("tokio task join error during identity creation with agent key: {e}"),
-            code: "SCP-IDENT-1007".to_owned(),
+            code: codes::IDENT_1007.to_owned(),
         })?
 }
 
@@ -11338,14 +11340,14 @@ pub async fn identity_migrate(identity: Arc<Identity>) -> Result<Arc<Identity>, 
                   was loaded without key material (use identity_create or \
                   identity_create_with_custody)"
                 .to_owned(),
-            code: "SCP-IDENT-1009".to_owned(),
+            code: codes::IDENT_1009.to_owned(),
         })?;
     let core_document = identity
         .core_document
         .as_ref()
         .ok_or_else(|| ScpError::Identity {
             msg: "identity migration requires a retained DID document".to_owned(),
-            code: "SCP-IDENT-1009".to_owned(),
+            code: codes::IDENT_1009.to_owned(),
         })?;
 
     // We need a custody provider to generate new keys.
@@ -11371,7 +11373,7 @@ pub async fn identity_migrate(identity: Arc<Identity>) -> Result<Arc<Identity>, 
                         .await
                         .map_err(|e| ScpError::Identity {
                             msg: format!("key generation failed during migration: {e}"),
-                            code: "SCP-IDENT-1009".to_owned(),
+                            code: codes::IDENT_1009.to_owned(),
                         })?;
 
                 let rotated_at = scp_primitives::SystemClock.now_secs();
@@ -11426,7 +11428,7 @@ pub async fn identity_migrate(identity: Arc<Identity>) -> Result<Arc<Identity>, 
                     .await
                     .map_err(|e| ScpError::Identity {
                         msg: format!("key generation failed during migration: {e}"),
-                        code: "SCP-IDENT-1009".to_owned(),
+                        code: codes::IDENT_1009.to_owned(),
                     })?;
 
                 let rotated_at = scp_primitives::SystemClock.now_secs();
@@ -11477,13 +11479,13 @@ pub async fn identity_migrate(identity: Arc<Identity>) -> Result<Arc<Identity>, 
                 msg: "identity migration requires a retained custody provider \
                           (in-memory or callback)"
                     .to_owned(),
-                code: "SCP-IDENT-1009".to_owned(),
+                code: codes::IDENT_1009.to_owned(),
             })
         })
         .await
         .map_err(|e| ScpError::Identity {
             msg: format!("tokio task join error during identity migration: {e}"),
-            code: "SCP-IDENT-1007".to_owned(),
+            code: codes::IDENT_1007.to_owned(),
         })?
 }
 
@@ -11678,7 +11680,7 @@ pub fn bridge_register(
                 msg: format!(
                     "invalid bridge mode '{other}': expected 'relay', 'puppet', 'api', or 'cooperative'"
                 ),
-                code: "SCP-VALID-7050".to_owned(),
+                code: codes::VALID_7050.to_owned(),
             });
         }
     };
@@ -11687,7 +11689,7 @@ pub fn bridge_register(
         .map(|k| {
             <[u8; 32]>::try_from(k.as_slice()).map_err(|_| ScpError::Validation {
                 msg: format!("platform_key must be exactly 32 bytes, got {}", k.len()),
-                code: "SCP-VALID-7052".to_owned(),
+                code: codes::VALID_7052.to_owned(),
             })
         })
         .transpose()?;
@@ -11718,7 +11720,7 @@ pub fn bridge_register(
     scp_core::bridge::registration::register_bridge(&mut registry, request).map_err(|e| {
         ScpError::Context {
             msg: format!("bridge registration failed: {e}"),
-            code: "SCP-CTX-2100".to_owned(),
+            code: codes::CTX_2100.to_owned(),
         }
     })?;
 
@@ -11731,7 +11733,7 @@ pub fn bridge_register(
     )
     .map_err(|e| ScpError::Context {
         msg: format!("bridge approval failed: {e}"),
-        code: "SCP-CTX-2101".to_owned(),
+        code: codes::CTX_2101.to_owned(),
     })?;
 
     Ok(BridgeRegistrationResult {
@@ -11789,7 +11791,7 @@ pub fn bridge_create_shadow(
                 msg: format!(
                     "invalid bridge mode '{other}': expected 'relay', 'puppet', 'api', or 'cooperative'"
                 ),
-                code: "SCP-VALID-7050".to_owned(),
+                code: codes::VALID_7050.to_owned(),
             });
         }
     };
@@ -11821,7 +11823,7 @@ pub fn bridge_create_shadow(
     )
     .map_err(|e| ScpError::Context {
         msg: format!("shadow creation failed: {e}"),
-        code: "SCP-CTX-2102".to_owned(),
+        code: codes::CTX_2102.to_owned(),
     })?;
 
     Ok(ShadowIdentityResult {
@@ -11865,18 +11867,18 @@ pub async fn context_discover(query: String) -> Result<String, ScpError> {
         let result =
             scp_core::discovery::resolve_context_uri(&query).map_err(|e| ScpError::Context {
                 msg: format!("failed to resolve scp:// URI: {e}"),
-                code: "SCP-CTX-2020".to_owned(),
+                code: codes::CTX_2020.to_owned(),
             })?;
 
         let results = vec![
             discovery_result_to_json(&result).map_err(|e| ScpError::Context {
                 msg: e,
-                code: "SCP-CTX-2020".to_owned(),
+                code: codes::CTX_2020.to_owned(),
             })?,
         ];
         serde_json::to_string(&results).map_err(|e| ScpError::Context {
             msg: format!("failed to serialize discovery results: {e}"),
-            code: "SCP-CTX-2021".to_owned(),
+            code: codes::CTX_2021.to_owned(),
         })
     } else if query.starts_with("did:") {
         validate_did(&query)?;
@@ -11888,7 +11890,7 @@ pub async fn context_discover(query: String) -> Result<String, ScpError> {
                     .await
                     .map_err(|e| ScpError::Context {
                         msg: format!("DHT discovery failed for '{query}': {e}"),
-                        code: "SCP-CTX-2022".to_owned(),
+                        code: codes::CTX_2022.to_owned(),
                     })?;
 
                 let json_results: Vec<serde_json::Value> = results
@@ -11896,19 +11898,19 @@ pub async fn context_discover(query: String) -> Result<String, ScpError> {
                     .map(|r| {
                         discovery_result_to_json(r).map_err(|e| ScpError::Context {
                             msg: e,
-                            code: "SCP-CTX-2022".to_owned(),
+                            code: codes::CTX_2022.to_owned(),
                         })
                     })
                     .collect::<Result<Vec<_>, _>>()?;
                 serde_json::to_string(&json_results).map_err(|e| ScpError::Context {
                     msg: format!("failed to serialize discovery results: {e}"),
-                    code: "SCP-CTX-2023".to_owned(),
+                    code: codes::CTX_2023.to_owned(),
                 })
             })
             .await
             .map_err(|e| ScpError::Context {
                 msg: format!("tokio task join error during discovery: {e}"),
-                code: "SCP-CTX-2024".to_owned(),
+                code: codes::CTX_2024.to_owned(),
             })?
     } else {
         Err(ScpError::Validation {
@@ -11916,7 +11918,7 @@ pub async fn context_discover(query: String) -> Result<String, ScpError> {
                 "query must be a DID (starts with 'did:') or an scp:// URI \
                  (starts with 'scp://'), got: {query}"
             ),
-            code: "SCP-VALID-7062".to_owned(),
+            code: codes::VALID_7062.to_owned(),
         })
     }
 }
@@ -11946,7 +11948,7 @@ pub fn sandbox_validate_declaration(
     let decl: CapabilityDeclaration =
         serde_json::from_str(&declaration_json).map_err(|e| ScpError::Validation {
             msg: format!("invalid declaration JSON: {e}"),
-            code: "SCP-VALID-7070".to_owned(),
+            code: codes::VALID_7070.to_owned(),
         })?;
 
     let ceiling: Vec<Capability> = ceiling_capabilities.iter().map(Capability::new).collect();
@@ -11969,7 +11971,7 @@ pub fn sandbox_validate_declaration(
             }))
             .map_err(|e| ScpError::Context {
                 msg: format!("serialization failed: {e}"),
-                code: "SCP-CTX-2030".to_owned(),
+                code: codes::CTX_2030.to_owned(),
             })
         }
         Err(e) => serde_json::to_string(&serde_json::json!({
@@ -11980,7 +11982,7 @@ pub fn sandbox_validate_declaration(
         }))
         .map_err(|e| ScpError::Context {
             msg: format!("serialization failed: {e}"),
-            code: "SCP-CTX-2031".to_owned(),
+            code: codes::CTX_2031.to_owned(),
         }),
     }
 }
@@ -12069,14 +12071,14 @@ pub fn evaluate_invitation(
     let params: scp_core::context::params::ContextParams = serde_json::from_str(&params_json)
         .map_err(|e| ScpError::Validation {
             msg: format!("failed to parse context params JSON: {e}"),
-            code: "SCP-VALID-7010".to_owned(),
+            code: codes::VALID_7010.to_owned(),
         })?;
 
     let policy: Option<AutoAcceptPolicy> = match policy_json {
         Some(ref json) => Some(
             serde_json::from_str(json).map_err(|e| ScpError::Validation {
                 msg: format!("failed to parse auto-accept policy JSON: {e}"),
-                code: "SCP-VALID-7010".to_owned(),
+                code: codes::VALID_7010.to_owned(),
             })?,
         ),
         None => None,
@@ -12086,7 +12088,7 @@ pub fn evaluate_invitation(
         Some(ref json) => Some(
             serde_json::from_str(json).map_err(|e| ScpError::Validation {
                 msg: format!("failed to parse spending context JSON: {e}"),
-                code: "SCP-VALID-7010".to_owned(),
+                code: codes::VALID_7010.to_owned(),
             })?,
         ),
         None => None,
@@ -12118,7 +12120,7 @@ pub fn evaluate_invitation(
         Ok(EvaluationDecision::PromptAgent) => Ok("prompt_agent".to_owned()),
         Err(e) => Err(ScpError::Context {
             msg: format!("invitation evaluation failed: {e}"),
-            code: "SCP-CTX-2060".to_owned(),
+            code: codes::CTX_2060.to_owned(),
         }),
     }
 }
@@ -12159,7 +12161,7 @@ pub fn identity_execute_recovery(
                 msg: format!(
                     "invalid compromise tier: {other}; expected 'agent', 'active_signing', or 'identity_key'"
                 ),
-                code: "SCP-IDENT-1020".to_owned(),
+                code: codes::IDENT_1020.to_owned(),
             });
         }
     };
@@ -12230,12 +12232,12 @@ pub fn identity_execute_recovery(
         ))
         .map_err(|e| ScpError::Identity {
             msg: format!("recovery failed: {e}"),
-            code: "SCP-IDENT-1022".to_owned(),
+            code: codes::IDENT_1022.to_owned(),
         })?;
 
     serde_json::to_string(&result).map_err(|e| ScpError::Identity {
         msg: format!("failed to serialize recovery result: {e}"),
-        code: "SCP-IDENT-1023".to_owned(),
+        code: codes::IDENT_1023.to_owned(),
     })
 }
 
@@ -12273,7 +12275,7 @@ pub fn identity_execute_custody_migration(
                 msg: format!(
                     "invalid custody migration target: {other}; expected 'platform_managed', 'hardware', 'software', or 'in_memory'"
                 ),
-                code: "SCP-IDENT-1024".to_owned(),
+                code: codes::IDENT_1024.to_owned(),
             });
         }
     };
@@ -12333,12 +12335,12 @@ pub fn identity_execute_custody_migration(
         .block_on(orchestrator.execute(&backend, &scp_primitives::SystemClock))
         .map_err(|e| ScpError::Identity {
             msg: format!("custody migration failed: {e}"),
-            code: "SCP-IDENT-1025".to_owned(),
+            code: codes::IDENT_1025.to_owned(),
         })?;
 
     serde_json::to_string(&result).map_err(|e| ScpError::Identity {
         msg: format!("failed to serialize custody migration result: {e}"),
-        code: "SCP-IDENT-1026".to_owned(),
+        code: codes::IDENT_1026.to_owned(),
     })
 }
 
@@ -12370,13 +12372,13 @@ pub fn scpid_challenge(audience: String, ttl_seconds: u64) -> Result<String, Scp
     let challenge = core_challenge(&audience, Duration::from_secs(ttl_seconds)).map_err(|e| {
         ScpError::Validation {
             msg: e.to_string(),
-            code: "SCP-IDENT-1038".to_owned(),
+            code: codes::IDENT_1038.to_owned(),
         }
     })?;
 
     serde_json::to_string(&challenge).map_err(|e| ScpError::Identity {
         msg: format!("failed to serialize SCPID challenge: {e}"),
-        code: "SCP-IDENT-1037".to_owned(),
+        code: codes::IDENT_1037.to_owned(),
     })
 }
 
@@ -12411,7 +12413,7 @@ pub fn scpid_sign(
     let challenge: scp_core::identity::ScpIdChallenge = serde_json::from_str(&challenge_json)
         .map_err(|e| ScpError::Validation {
             msg: format!("invalid challenge JSON: {e}"),
-            code: "SCP-IDENT-1038".to_owned(),
+            code: codes::IDENT_1038.to_owned(),
         })?;
 
     let core_id = identity
@@ -12420,7 +12422,7 @@ pub fn scpid_sign(
         .ok_or_else(|| ScpError::Identity {
             msg: "identity has no core identity handle — was it created with identity_create?"
                 .to_owned(),
-            code: "SCP-IDENT-1010".to_owned(),
+            code: codes::IDENT_1010.to_owned(),
         })?;
 
     let key_handle = match key_id {
@@ -12434,7 +12436,7 @@ pub fn scpid_sign(
                          add one with identity_add_agent_key first",
                         identity.did
                     ),
-                    code: "SCP-IDENT-1034".to_owned(),
+                    code: codes::IDENT_1034.to_owned(),
                 })?
         }
     };
@@ -12446,7 +12448,7 @@ pub fn scpid_sign(
             msg: "scpid_sign requires in-memory custody (only supported with \
                   allow_in_memory_custody feature)"
                 .to_owned(),
-            code: "SCP-IDENT-1008".to_owned(),
+            code: codes::IDENT_1008.to_owned(),
         })?;
 
     let rt = crate::runtime();
@@ -12460,12 +12462,12 @@ pub fn scpid_sign(
 
     let response = response.map_err(|e| ScpError::Identity {
         msg: e.to_string(),
-        code: "SCP-IDENT-1037".to_owned(),
+        code: codes::IDENT_1037.to_owned(),
     })?;
 
     serde_json::to_string(&response).map_err(|e| ScpError::Identity {
         msg: format!("failed to serialize SCPID response: {e}"),
-        code: "SCP-IDENT-1037".to_owned(),
+        code: codes::IDENT_1037.to_owned(),
     })
 }
 
@@ -12495,20 +12497,20 @@ pub fn scpid_verify(response_json: String, challenge_json: String) -> Result<Str
     let response: scp_core::identity::ScpIdResponse = serde_json::from_str(&response_json)
         .map_err(|e| ScpError::Validation {
             msg: format!("invalid response JSON: {e}"),
-            code: "SCP-IDENT-1038".to_owned(),
+            code: codes::IDENT_1038.to_owned(),
         })?;
 
     let challenge: scp_core::identity::ScpIdChallenge = serde_json::from_str(&challenge_json)
         .map_err(|e| ScpError::Validation {
             msg: format!("invalid challenge JSON: {e}"),
-            code: "SCP-IDENT-1038".to_owned(),
+            code: codes::IDENT_1038.to_owned(),
         })?;
 
     let resolver = crate::runtime::did_resolver().ok_or_else(|| ScpError::Identity {
         msg: "DID resolver not initialized — create an identity with \
               identityCreate before calling scpidVerify"
             .to_owned(),
-        code: "SCP-IDENT-1033".to_owned(),
+        code: codes::IDENT_1033.to_owned(),
     })?;
 
     let rt = crate::runtime();
@@ -12521,7 +12523,7 @@ pub fn scpid_verify(response_json: String, challenge_json: String) -> Result<Str
 
     serde_json::to_string(&auth).map_err(|e| ScpError::Identity {
         msg: format!("failed to serialize SCPID authentication: {e}"),
-        code: "SCP-IDENT-1037".to_owned(),
+        code: codes::IDENT_1037.to_owned(),
     })
 }
 
@@ -12534,7 +12536,7 @@ fn parse_scpid_signing_key_id(s: &str) -> Result<scp_identity::SigningKeyId, Scp
         "#agent" => Ok(scp_identity::SigningKeyId::Agent),
         other => Err(ScpError::Validation {
             msg: format!("invalid signing_key_id '{other}': expected '#active' or '#agent'"),
-            code: "SCP-IDENT-1034".to_owned(),
+            code: codes::IDENT_1034.to_owned(),
         }),
     }
 }
@@ -12543,15 +12545,15 @@ fn parse_scpid_signing_key_id(s: &str) -> Result<scp_identity::SigningKeyId, Scp
 const fn scpid_error_code(e: &scp_core::identity::ScpIdError) -> &'static str {
     use scp_core::identity::ScpIdError;
     match e {
-        ScpIdError::ChallengeExpired => "SCP-IDENT-1030",
-        ScpIdError::AudienceMismatch => "SCP-IDENT-1031",
-        ScpIdError::TimestampInvalid => "SCP-IDENT-1032",
-        ScpIdError::DidResolutionFailed(_) => "SCP-IDENT-1033",
-        ScpIdError::KeyNotAuthorized => "SCP-IDENT-1034",
-        ScpIdError::SignatureInvalid => "SCP-IDENT-1035",
-        ScpIdError::DidDocumentStale => "SCP-IDENT-1036",
-        ScpIdError::SigningFailed(_) => "SCP-IDENT-1037",
-        ScpIdError::InvalidInput(_) => "SCP-IDENT-1038",
+        ScpIdError::ChallengeExpired => codes::IDENT_1030,
+        ScpIdError::AudienceMismatch => codes::IDENT_1031,
+        ScpIdError::TimestampInvalid => codes::IDENT_1032,
+        ScpIdError::DidResolutionFailed(_) => codes::IDENT_1033,
+        ScpIdError::KeyNotAuthorized => codes::IDENT_1034,
+        ScpIdError::SignatureInvalid => codes::IDENT_1035,
+        ScpIdError::DidDocumentStale => codes::IDENT_1036,
+        ScpIdError::SigningFailed(_) => codes::IDENT_1037,
+        ScpIdError::InvalidInput(_) => codes::IDENT_1038,
     }
 }
 
@@ -12578,7 +12580,7 @@ pub fn economy_estimate_cost(
         let p: scp_core::economy::EconomicPolicy =
             serde_json::from_str(&policy_json).map_err(|e| ScpError::Validation {
                 msg: format!("invalid economic policy JSON: {e}"),
-                code: "SCP-VALID-7050".to_owned(),
+                code: codes::VALID_7050.to_owned(),
             })?;
         Some(p)
     };
@@ -12598,7 +12600,7 @@ pub fn economy_policy_requires_payment(policy_json: String) -> Result<bool, ScpE
     let policy: scp_core::economy::EconomicPolicy =
         serde_json::from_str(&policy_json).map_err(|e| ScpError::Validation {
             msg: format!("invalid economic policy JSON: {e}"),
-            code: "SCP-VALID-7050".to_owned(),
+            code: codes::VALID_7050.to_owned(),
         })?;
     Ok(scp_core::economy::policy_requires_payment(&policy))
 }
@@ -12612,7 +12614,7 @@ pub fn economy_auto_accept_blocked(policy_json: String) -> Result<bool, ScpError
     let policy: scp_core::economy::EconomicPolicy =
         serde_json::from_str(&policy_json).map_err(|e| ScpError::Validation {
             msg: format!("invalid economic policy JSON: {e}"),
-            code: "SCP-VALID-7050".to_owned(),
+            code: codes::VALID_7050.to_owned(),
         })?;
     Ok(scp_core::economy::auto_accept_blocked_by_economics(Some(
         &policy,
@@ -12628,7 +12630,7 @@ pub fn economy_check_policy_lock(policy_json: String) -> Result<bool, ScpError> 
     let policy: scp_core::economy::EconomicPolicy =
         serde_json::from_str(&policy_json).map_err(|e| ScpError::Validation {
             msg: format!("invalid economic policy JSON: {e}"),
-            code: "SCP-VALID-7050".to_owned(),
+            code: codes::VALID_7050.to_owned(),
         })?;
     Ok(scp_core::economy::check_policy_lock(&policy).is_err())
 }
@@ -12642,17 +12644,17 @@ pub fn economy_validate_policy_change(
     let current: scp_core::economy::EconomicPolicy = serde_json::from_str(&current_policy_json)
         .map_err(|e| ScpError::Validation {
             msg: format!("invalid current policy JSON: {e}"),
-            code: "SCP-VALID-7050".to_owned(),
+            code: codes::VALID_7050.to_owned(),
         })?;
     let proposed: scp_core::economy::EconomicPolicy = serde_json::from_str(&proposed_policy_json)
         .map_err(|e| ScpError::Validation {
         msg: format!("invalid proposed policy JSON: {e}"),
-        code: "SCP-VALID-7050".to_owned(),
+        code: codes::VALID_7050.to_owned(),
     })?;
     scp_core::economy::validate_policy_change(&current, &proposed).map_err(|e| {
         ScpError::Validation {
             msg: format!("policy change rejected: {e}"),
-            code: "SCP-VALID-7051".to_owned(),
+            code: codes::VALID_7051.to_owned(),
         }
     })?;
     Ok(true)
@@ -12667,7 +12669,7 @@ pub fn economy_evaluate_formula(
     let formula: scp_core::economy::PricingFormula =
         serde_json::from_str(&formula_json).map_err(|e| ScpError::Validation {
             msg: format!("invalid formula JSON: {e}"),
-            code: "SCP-VALID-7050".to_owned(),
+            code: codes::VALID_7050.to_owned(),
         })?;
     let metrics = parse_observable_metrics(&metrics_json)?;
     Ok(scp_core::economy::evaluate_formula(&formula, &metrics)
@@ -12709,7 +12711,7 @@ pub fn economy_budget_record_spend(
             .record_spend(&member_did, scp_core::economy::Amount::new(amount))
             .map_err(|e| ScpError::Validation {
                 msg: format!("{e}"),
-                code: "SCP-VALID-7052".to_owned(),
+                code: codes::VALID_7052.to_owned(),
             })
     })
 }
@@ -12760,7 +12762,7 @@ pub fn economy_antispam_escalated_cost(
     let thresholds: Vec<(u64, u64)> =
         serde_json::from_str(&thresholds_json).map_err(|e| ScpError::Validation {
             msg: format!("invalid thresholds JSON: {e}"),
-            code: "SCP-VALID-7050".to_owned(),
+            code: codes::VALID_7050.to_owned(),
         })?;
 
     let config = scp_core::economy::EscalationConfig {
@@ -12805,7 +12807,7 @@ fn parse_paid_action_type(s: &str) -> Result<scp_core::economy::PaidActionType, 
                 "invalid action type: {s:?} — expected one of: MessageSend, ToolInvoke, \
                  ContextJoin, SubscriptionPeriod, ByteStored"
             ),
-            code: "SCP-VALID-7050".to_owned(),
+            code: codes::VALID_7050.to_owned(),
         }),
     }
 }
@@ -12837,33 +12839,33 @@ pub fn metadata_record_to_json(
     if sequence == 0 {
         return Err(ScpError::Validation {
             msg: "MetadataRecord sequence must start at 1 (per spec §5.7.2)".to_owned(),
-            code: "SCP-VALID-7001".to_owned(),
+            code: codes::VALID_7001.to_owned(),
         });
     }
 
     let structural: StructuralMetadata =
         serde_json::from_str(&structural_json).map_err(|e| ScpError::Validation {
             msg: format!("invalid structural metadata JSON: {e}"),
-            code: "SCP-VALID-7001".to_owned(),
+            code: codes::VALID_7001.to_owned(),
         })?;
 
     let operational: OperationalMetadata =
         serde_json::from_str(&operational_json).map_err(|e| ScpError::Validation {
             msg: format!("invalid operational metadata JSON: {e}"),
-            code: "SCP-VALID-7001".to_owned(),
+            code: codes::VALID_7001.to_owned(),
         })?;
 
     let signature =
         Zeroizing::new(
             hex::decode(&signature_hex).map_err(|e| ScpError::Validation {
                 msg: format!("invalid signature hex: {e}"),
-                code: "SCP-VALID-7001".to_owned(),
+                code: codes::VALID_7001.to_owned(),
             })?,
         );
     if signature.len() != 64 {
         return Err(ScpError::Validation {
             msg: format!("signature must be 64 bytes (got {})", signature.len()),
-            code: "SCP-VALID-7001".to_owned(),
+            code: codes::VALID_7001.to_owned(),
         });
     }
 
@@ -12879,7 +12881,7 @@ pub fn metadata_record_to_json(
 
     serde_json::to_string(&record).map_err(|e| ScpError::Validation {
         msg: format!("failed to serialize MetadataRecord: {e}"),
-        code: "SCP-VALID-7001".to_owned(),
+        code: codes::VALID_7001.to_owned(),
     })
 }
 
@@ -12893,14 +12895,14 @@ pub fn metadata_record_from_json(json_str: String) -> Result<String, ScpError> {
     let record: MetadataRecord =
         serde_json::from_str(&json_str).map_err(|e| ScpError::Validation {
             msg: format!("invalid MetadataRecord JSON: {e}"),
-            code: "SCP-VALID-7001".to_owned(),
+            code: codes::VALID_7001.to_owned(),
         })?;
 
     // F6: sequence must be >= 1 (spec §5.7.2)
     if record.sequence == 0 {
         return Err(ScpError::Validation {
             msg: "MetadataRecord sequence must start at 1 (per spec §5.7.2)".to_owned(),
-            code: "SCP-VALID-7001".to_owned(),
+            code: codes::VALID_7001.to_owned(),
         });
     }
 
@@ -12911,13 +12913,13 @@ pub fn metadata_record_from_json(json_str: String) -> Result<String, ScpError> {
                 "signature must be 64 bytes (got {})",
                 record.signature.len()
             ),
-            code: "SCP-VALID-7001".to_owned(),
+            code: codes::VALID_7001.to_owned(),
         });
     }
 
     serde_json::to_string(&record).map_err(|e| ScpError::Validation {
         msg: format!("failed to re-serialize MetadataRecord: {e}"),
-        code: "SCP-VALID-7001".to_owned(),
+        code: codes::VALID_7001.to_owned(),
     })
 }
 
@@ -12934,7 +12936,7 @@ pub fn template_get_params(template_id: String) -> Result<String, ScpError> {
     let params = template_params(&tid);
     serde_json::to_string(&params).map_err(|e| ScpError::Validation {
         msg: format!("failed to serialize template params: {e}"),
-        code: "SCP-VALID-7001".to_owned(),
+        code: codes::VALID_7001.to_owned(),
     })
 }
 
@@ -12948,7 +12950,7 @@ pub fn validate_against_template(params_json: String) -> Result<Option<String>, 
     let params: scp_core::context::ContextParams =
         serde_json::from_str(&params_json).map_err(|e| ScpError::Validation {
             msg: format!("invalid ContextParams JSON: {e}"),
-            code: "SCP-VALID-7001".to_owned(),
+            code: codes::VALID_7001.to_owned(),
         })?;
 
     match core_validate(&params) {
@@ -12967,7 +12969,7 @@ pub fn validate_context_params(params_json: String) -> Result<Option<String>, Sc
     let params: scp_core::context::ContextParams =
         serde_json::from_str(&params_json).map_err(|e| ScpError::Validation {
             msg: format!("invalid ContextParams JSON: {e}"),
-            code: "SCP-VALID-7001".to_owned(),
+            code: codes::VALID_7001.to_owned(),
         })?;
 
     match core_validate(&params) {
@@ -13006,7 +13008,7 @@ fn parse_template_id_uniffi(
                  HandleRegistry, scp:template/handle-registry, DiscoveryContext, \
                  scp:template/discovery-context"
             ),
-            code: "SCP-VALID-7001".to_owned(),
+            code: codes::VALID_7001.to_owned(),
         }),
     }
 }
@@ -13014,7 +13016,7 @@ fn parse_template_id_uniffi(
 fn parse_observable_metrics(json: &str) -> Result<scp_core::economy::ObservableMetrics, ScpError> {
     let v: serde_json::Value = serde_json::from_str(json).map_err(|e| ScpError::Validation {
         msg: format!("invalid metrics JSON: {e}"),
-        code: "SCP-VALID-7050".to_owned(),
+        code: codes::VALID_7050.to_owned(),
     })?;
     Ok(scp_core::economy::ObservableMetrics {
         context_message_rate: v
@@ -13105,7 +13107,7 @@ mod tests {
         let err = result.expect_err("None ucan_token must be rejected");
         match err {
             ScpError::Permission { ref code, .. } => {
-                assert_eq!(code, "SCP-PERM-3001");
+                assert_eq!(code, codes::PERM_3001);
             }
             other => panic!("expected ScpError::Permission, got {other:?}"),
         }
@@ -13283,7 +13285,7 @@ mod tests {
         let err = ffi.to_core().unwrap_err();
         match err {
             ScpError::Validation { code, msg } => {
-                assert_eq!(code, "SCP-VALID-7080");
+                assert_eq!(code, codes::VALID_7080);
                 assert!(
                     msg.contains("32 bytes"),
                     "expected '32 bytes' in message, got: {msg}"
@@ -13412,7 +13414,7 @@ mod tests {
             .expect_err("invalid input_schema_json must be rejected");
         match err {
             ScpError::Validation { ref code, ref msg } => {
-                assert_eq!(code, "SCP-VALID-7035");
+                assert_eq!(code, codes::VALID_7035);
                 assert!(
                     msg.contains("invalid input_schema_json"),
                     "error should reference field name, got: {msg}"
@@ -13441,7 +13443,7 @@ mod tests {
             .expect_err("invalid output_schema_json must be rejected");
         match err {
             ScpError::Validation { ref code, ref msg } => {
-                assert_eq!(code, "SCP-VALID-7036");
+                assert_eq!(code, codes::VALID_7036);
                 assert!(
                     msg.contains("invalid output_schema_json"),
                     "error should reference field name, got: {msg}"
@@ -13472,7 +13474,7 @@ mod tests {
             .expect_err("non-object input_schema must be rejected");
         match err {
             ScpError::Validation { ref code, ref msg } => {
-                assert_eq!(code, "SCP-VALID-7035");
+                assert_eq!(code, codes::VALID_7035);
                 assert!(
                     msg.contains("expected a JSON object"),
                     "error should mention expected type, got: {msg}"
@@ -13505,7 +13507,7 @@ mod tests {
             .expect_err("non-object output_schema must be rejected");
         match err {
             ScpError::Validation { ref code, ref msg } => {
-                assert_eq!(code, "SCP-VALID-7036");
+                assert_eq!(code, codes::VALID_7036);
                 assert!(
                     msg.contains("expected a JSON object"),
                     "error should mention expected type, got: {msg}"
@@ -13540,7 +13542,7 @@ mod tests {
             .expect_err("non-array test_vectors_json must be rejected");
         match err {
             ScpError::Validation { ref code, ref msg } => {
-                assert_eq!(code, "SCP-VALID-7037");
+                assert_eq!(code, codes::VALID_7037);
                 assert!(
                     msg.contains("invalid test_vectors_json"),
                     "error should reference field name, got: {msg}"
@@ -13570,7 +13572,7 @@ mod tests {
             .expect_err("test vectors with missing fields must be rejected");
         match err {
             ScpError::Validation { ref code, .. } => {
-                assert_eq!(code, "SCP-VALID-7037");
+                assert_eq!(code, codes::VALID_7037);
             }
             other => panic!("expected ScpError::Validation, got {other:?}"),
         }
@@ -13597,7 +13599,7 @@ mod tests {
             .expect_err("implementation_hash with wrong length must be rejected");
         match err {
             ScpError::Validation { ref code, ref msg } => {
-                assert_eq!(code, "SCP-VALID-7038");
+                assert_eq!(code, codes::VALID_7038);
                 assert!(
                     msg.contains("32 bytes"),
                     "error should mention expected length, got: {msg}"
@@ -13630,7 +13632,7 @@ mod tests {
             .expect_err("implementation_hash with wrong length must be rejected");
         match err {
             ScpError::Validation { ref code, ref msg } => {
-                assert_eq!(code, "SCP-VALID-7038");
+                assert_eq!(code, codes::VALID_7038);
                 assert!(
                     msg.contains("32 bytes"),
                     "error should mention expected length, got: {msg}"
@@ -13735,7 +13737,7 @@ mod tests {
         let err = result.unwrap_err();
         match err {
             ScpError::Validation { ref code, .. } => {
-                assert_eq!(code, "SCP-VALID-7052");
+                assert_eq!(code, codes::VALID_7052);
             }
             other => panic!("expected ScpError::Validation, got {other:?}"),
         }
@@ -13836,39 +13838,39 @@ mod tests {
 
         assert_eq!(
             scpid_error_code(&ScpIdError::ChallengeExpired),
-            "SCP-IDENT-1030"
+            codes::IDENT_1030
         );
         assert_eq!(
             scpid_error_code(&ScpIdError::AudienceMismatch),
-            "SCP-IDENT-1031"
+            codes::IDENT_1031
         );
         assert_eq!(
             scpid_error_code(&ScpIdError::TimestampInvalid),
-            "SCP-IDENT-1032"
+            codes::IDENT_1032
         );
         assert_eq!(
             scpid_error_code(&ScpIdError::DidResolutionFailed("test".to_owned())),
-            "SCP-IDENT-1033"
+            codes::IDENT_1033
         );
         assert_eq!(
             scpid_error_code(&ScpIdError::KeyNotAuthorized),
-            "SCP-IDENT-1034"
+            codes::IDENT_1034
         );
         assert_eq!(
             scpid_error_code(&ScpIdError::SignatureInvalid),
-            "SCP-IDENT-1035"
+            codes::IDENT_1035
         );
         assert_eq!(
             scpid_error_code(&ScpIdError::DidDocumentStale),
-            "SCP-IDENT-1036"
+            codes::IDENT_1036
         );
         assert_eq!(
             scpid_error_code(&ScpIdError::SigningFailed("test".to_owned())),
-            "SCP-IDENT-1037"
+            codes::IDENT_1037
         );
         assert_eq!(
             scpid_error_code(&ScpIdError::InvalidInput("test".to_owned())),
-            "SCP-IDENT-1038"
+            codes::IDENT_1038
         );
     }
 
@@ -13880,7 +13882,7 @@ mod tests {
         let err = result.unwrap_err();
         let err_str = err.to_string();
         assert!(
-            err_str.contains("SCP-IDENT-1038"),
+            err_str.contains(codes::IDENT_1038),
             "expected SCP-IDENT-1038, got: {err_str}"
         );
     }
@@ -13906,7 +13908,7 @@ mod tests {
         let err = result.unwrap_err();
         let err_str = err.to_string();
         assert!(
-            err_str.contains("SCP-IDENT-1038"),
+            err_str.contains(codes::IDENT_1038),
             "expected SCP-IDENT-1038, got: {err_str}"
         );
     }
@@ -13991,7 +13993,7 @@ mod tests {
         let err = result.expect_err("empty context_ids must be rejected");
         match err {
             ScpError::Transport { ref code, .. } => {
-                assert_eq!(code, "SCP-TRANS-5011");
+                assert_eq!(code, codes::TRANS_5011);
             }
             other => panic!("expected ScpError::Transport, got {other:?}"),
         }
@@ -14019,7 +14021,7 @@ mod tests {
         let err = result.expect_err("empty command must be rejected");
         match err {
             ScpError::Validation { ref code, .. } => {
-                assert_eq!(code, "SCP-VALID-7034");
+                assert_eq!(code, codes::VALID_7034);
             }
             other => panic!("expected ScpError::Validation, got {other:?}"),
         }
@@ -14032,7 +14034,7 @@ mod tests {
         let err = result.expect_err("unknown handle must be rejected");
         match err {
             ScpError::Transport { ref code, .. } => {
-                assert_eq!(code, "SCP-TRANS-5019");
+                assert_eq!(code, codes::TRANS_5019);
             }
             other => panic!("expected ScpError::Transport, got {other:?}"),
         }
@@ -14045,7 +14047,7 @@ mod tests {
         let err = result.expect_err("unknown handle must be rejected");
         match err {
             ScpError::Transport { ref code, .. } => {
-                assert_eq!(code, "SCP-TRANS-5020");
+                assert_eq!(code, codes::TRANS_5020);
             }
             other => panic!("expected ScpError::Transport, got {other:?}"),
         }
@@ -14065,7 +14067,7 @@ mod tests {
         let err = result.expect_err("unknown handle must be rejected");
         match err {
             ScpError::Transport { ref code, .. } => {
-                assert_eq!(code, "SCP-TRANS-5023");
+                assert_eq!(code, codes::TRANS_5023);
             }
             other => panic!("expected ScpError::Transport, got {other:?}"),
         }
@@ -14078,7 +14080,7 @@ mod tests {
         let err = result.expect_err("unknown handle must be rejected");
         match err {
             ScpError::Transport { ref code, .. } => {
-                assert_eq!(code, "SCP-TRANS-5012");
+                assert_eq!(code, codes::TRANS_5012);
             }
             other => panic!("expected ScpError::Transport, got {other:?}"),
         }

--- a/crates/scp-ffi/uniffi/src/lib.rs
+++ b/crates/scp-ffi/uniffi/src/lib.rs
@@ -62,6 +62,7 @@
 // The uniffi::include_scaffolding! macro expands unsafe extern "C" declarations.
 #![allow(unsafe_code)]
 
+use scp_ffi_common::error_codes as codes;
 use std::sync::OnceLock;
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::time::Duration;
@@ -479,7 +480,7 @@ pub trait KeyCustodyProvider: Send + Sync {
         let _ = key_id;
         Err(ScpError::Context {
             msg: "export_signing_key_bytes not implemented by this KeyCustodyProvider".to_owned(),
-            code: "SCP-CTX-2050".to_owned(),
+            code: codes::CTX_2050.to_owned(),
         })
     }
 
@@ -607,6 +608,7 @@ pub trait DeviceAttestationProvider: Send + Sync {
 #[allow(clippy::unwrap_used, clippy::expect_used, clippy::panic)]
 mod tests {
     use super::*;
+    use scp_ffi_common::error_codes as codes;
 
     #[test]
     fn runtime_is_lazy_initialized_on_first_call() {
@@ -681,11 +683,11 @@ mod tests {
     fn scp_error_display_is_descriptive() {
         let identity = ScpError::Identity {
             msg: "test".to_owned(),
-            code: "SCP-IDENT-1001".to_owned(),
+            code: codes::IDENT_1001.to_owned(),
         };
         let context = ScpError::Context {
             msg: "test".to_owned(),
-            code: "SCP-CTX-2001".to_owned(),
+            code: codes::CTX_2001.to_owned(),
         };
         assert!(identity.to_string().contains("identity error"));
         assert!(context.to_string().contains("context error"));
@@ -726,7 +728,8 @@ mod tests {
         match result {
             Err(ScpError::Identity { code, .. }) => {
                 assert_eq!(
-                    code, "SCP-IDENT-1008",
+                    code,
+                    codes::IDENT_1008,
                     "expected SCP-IDENT-1008 error code when in_memory custody is disabled"
                 );
             }

--- a/crates/scp-ffi/uniffi/src/runtime.rs
+++ b/crates/scp-ffi/uniffi/src/runtime.rs
@@ -23,6 +23,7 @@
 //! This replaces the old `DashMap<String, ContextRuntime>` global registry
 //! (deleted as part of issue #387).
 
+use scp_ffi_common::error_codes as codes;
 use std::collections::HashSet;
 use std::future::Future;
 use std::sync::{Arc, OnceLock};
@@ -118,7 +119,7 @@ pub fn context_manager() -> Result<&'static Arc<ContextManager>, crate::ScpError
             msg: "ContextManager not initialized — call context_create, \
                   context_join, context_import, or init_context_manager first"
                 .to_owned(),
-            code: "SCP-CTX-2000".to_owned(),
+            code: codes::CTX_2000.to_owned(),
         })
 }
 
@@ -523,7 +524,7 @@ pub async fn sync_role_state_from_manager(context_id: &str) -> Result<(), crate:
                 msg: format!(
                     "context '{context_id}' not found in ContextManager during role state sync"
                 ),
-                code: "SCP-CTX-2040".to_owned(),
+                code: codes::CTX_2040.to_owned(),
             })?;
     tracing::debug!(context_id = %context_id, "UniFFI: role state synced after governance operation");
     Ok(())

--- a/crates/scp-ffi/uniffi/src/server.rs
+++ b/crates/scp-ffi/uniffi/src/server.rs
@@ -13,6 +13,7 @@
 //! Gated behind the `server` feature on `scp-ffi-common`. Not available for
 //! WASM (ADR-034).
 
+use scp_ffi_common::error_codes as codes;
 use std::sync::Arc;
 
 use zeroize::Zeroizing;
@@ -37,20 +38,20 @@ impl From<ServerError> for ScpError {
         match e {
             ServerError::Relay(_) => Self::Transport {
                 msg: user_msg,
-                code: "SCP-TRANS-5050".to_owned(),
+                code: codes::TRANS_5050.to_owned(),
             },
             ServerError::Node(inner) => Self::from(inner),
             ServerError::Storage(_) => Self::Context {
                 msg: user_msg,
-                code: "SCP-CTX-2051".to_owned(),
+                code: codes::CTX_2051.to_owned(),
             },
             ServerError::Platform(_) => Self::Context {
                 msg: user_msg,
-                code: "SCP-CTX-2053".to_owned(),
+                code: codes::CTX_2053.to_owned(),
             },
             ServerError::Io(_) => Self::Context {
                 msg: user_msg,
-                code: "SCP-CTX-2052".to_owned(),
+                code: codes::CTX_2052.to_owned(),
             },
         }
     }
@@ -62,23 +63,23 @@ impl From<NodeError> for ScpError {
         match e {
             NodeError::MissingField(_) | NodeError::InvalidConfig(_) => Self::Validation {
                 msg: "node configuration error".to_owned(),
-                code: "SCP-TRANS-5050".to_owned(),
+                code: codes::TRANS_5050.to_owned(),
             },
             NodeError::Identity(_) => Self::Identity {
                 msg: "node identity operation failed".to_owned(),
-                code: "SCP-TRANS-5051".to_owned(),
+                code: codes::TRANS_5051.to_owned(),
             },
             NodeError::Relay(_) => Self::Transport {
                 msg: "node relay error".to_owned(),
-                code: "SCP-TRANS-5052".to_owned(),
+                code: codes::TRANS_5052.to_owned(),
             },
             NodeError::Storage(_) => Self::Context {
                 msg: "node storage error".to_owned(),
-                code: "SCP-TRANS-5053".to_owned(),
+                code: codes::TRANS_5053.to_owned(),
             },
             NodeError::Serve(_) | NodeError::Nat(_) | NodeError::Tls(_) => Self::Transport {
                 msg: "node network error".to_owned(),
-                code: "SCP-TRANS-5054".to_owned(),
+                code: codes::TRANS_5054.to_owned(),
             },
         }
     }
@@ -278,7 +279,7 @@ impl NodeHandle {
                     let key_vec = Zeroizing::new(hex::decode(&*key_hex).map_err(|e| {
                         ScpError::Validation {
                             msg: format!("invalid broadcast_key_hex: {e}"),
-                            code: "SCP-TRANS-5060".to_owned(),
+                            code: codes::TRANS_5060.to_owned(),
                         }
                     })?);
                     let key_bytes: Zeroizing<[u8; 32]> =
@@ -287,7 +288,7 @@ impl NodeHandle {
                                 msg:
                                     "broadcast_key_hex must be exactly 64 hex characters (32 bytes)"
                                         .to_owned(),
-                                code: "SCP-TRANS-5060".to_owned(),
+                                code: codes::TRANS_5060.to_owned(),
                             }
                         })?);
                     // Explicit key path always uses epoch 0. For rotated keys, use auto-resolve (omit both params).
@@ -309,7 +310,7 @@ impl NodeHandle {
                             msg:
                                 "broadcast key auto-resolve failed: not authorized for this context"
                                     .to_owned(),
-                            code: "SCP-CTX-2060".to_owned(),
+                            code: codes::CTX_2060.to_owned(),
                         }
                         })?;
                     (key_bytes, epoch, did)
@@ -319,7 +320,7 @@ impl NodeHandle {
                         msg: "broadcast_key_hex requires author_did — provide the DID of the \
                          broadcast key owner, or omit both for auto-resolve"
                             .to_owned(),
-                        code: "SCP-TRANS-5060".to_owned(),
+                        code: codes::TRANS_5060.to_owned(),
                     });
                 }
             };
@@ -336,7 +337,7 @@ impl NodeHandle {
             other => {
                 return Err(ScpError::Validation {
                     msg: format!("admission must be \"open\" or \"gated\", got \"{other}\""),
-                    code: "SCP-TRANS-5061".to_owned(),
+                    code: codes::TRANS_5061.to_owned(),
                 });
             }
         };
@@ -345,7 +346,7 @@ impl NodeHandle {
         let content_path = scp_core::context::broadcast_content::ContentPath::new(idx_path_str)
             .map_err(|e| ScpError::Validation {
                 msg: format!("invalid index_path: {e}"),
-                code: "SCP-TRANS-5062".to_owned(),
+                code: codes::TRANS_5062.to_owned(),
             })?;
 
         let site_config = scp_node::projection::SiteConfig {
@@ -385,7 +386,7 @@ impl NodeHandle {
             .map_err(ScpError::from)?;
         u32::try_from(count).map_err(|_| ScpError::Validation {
             msg: format!("asset count {count} exceeds u32::MAX"),
-            code: "SCP-TRANS-5063".to_owned(),
+            code: codes::TRANS_5063.to_owned(),
         })
     }
 
@@ -433,7 +434,7 @@ impl NodeHandle {
                     };
                     ScpError::Validation {
                         msg: format!("invalid bind_addr: {display}"),
-                        code: "SCP-TRANS-5070".to_owned(),
+                        code: codes::TRANS_5070.to_owned(),
                     }
                 })
             })
@@ -522,14 +523,14 @@ fn build_node_identity_from_uniffi(id: &Identity) -> Result<server::NodeIdentity
               via identity_create (not identity_load with external custody) can \
               be used for node startup"
             .to_owned(),
-        code: "SCP-IDENT-1010".to_owned(),
+        code: codes::IDENT_1010.to_owned(),
     })?;
 
     let document = id.core_document.clone().ok_or_else(|| ScpError::Identity {
         msg: "identity does not contain a DID document — identity may have been \
               loaded without document resolution"
             .to_owned(),
-        code: "SCP-IDENT-1011".to_owned(),
+        code: codes::IDENT_1011.to_owned(),
     })?;
 
     let custody = id
@@ -539,7 +540,7 @@ fn build_node_identity_from_uniffi(id: &Identity) -> Result<server::NodeIdentity
             msg: "identity does not have in-memory custody — only in-memory custody \
               identities can be used for node startup in this build"
                 .to_owned(),
-            code: "SCP-IDENT-1012".to_owned(),
+            code: codes::IDENT_1012.to_owned(),
         })?;
 
     // Hand-rolled sign_fn because `OpaqueInMemoryKeyCustody` does not
@@ -590,7 +591,7 @@ fn build_node_identity_from_uniffi(_id: &Identity) -> Result<server::NodeIdentit
               feature — production mobile builds should use platform custody \
               with identity_with_storage on ApplicationNodeBuilder directly"
             .to_owned(),
-        code: "SCP-IDENT-1013".to_owned(),
+        code: codes::IDENT_1013.to_owned(),
     })
 }
 
@@ -688,6 +689,7 @@ pub async fn node_start_local(
 #[allow(clippy::unwrap_used, clippy::expect_used, clippy::panic)]
 mod tests {
     use super::*;
+    use scp_ffi_common::error_codes as codes;
 
     fn rt() -> &'static tokio::runtime::Runtime {
         crate::runtime()
@@ -893,7 +895,7 @@ mod tests {
                     "internal path leaked in msg: {msg}"
                 );
                 assert_eq!(msg, "node configuration error");
-                assert_eq!(code, "SCP-TRANS-5050");
+                assert_eq!(code, codes::TRANS_5050);
             }
             other => panic!("expected Validation, got: {other:?}"),
         }

--- a/crates/scp-ffi/uniffi/src/server.rs
+++ b/crates/scp-ffi/uniffi/src/server.rs
@@ -18,7 +18,7 @@ use std::sync::Arc;
 
 use zeroize::Zeroizing;
 
-use scp_ffi_common::server::{self, RunningNode, ServerError};
+use scp_ffi_common::server::{self, BroadcastKeyError, RunningNode, ServerError};
 use scp_ffi_common::validate::{validate_context_id, validate_deploy_id, validate_did};
 use scp_node::NodeError;
 use scp_transport::native::NativeRelayAdapter;
@@ -80,6 +80,27 @@ impl From<NodeError> for ScpError {
             NodeError::Serve(_) | NodeError::Nat(_) | NodeError::Tls(_) => Self::Transport {
                 msg: "node network error".to_owned(),
                 code: codes::TRANS_5054.to_owned(),
+            },
+        }
+    }
+}
+
+impl From<BroadcastKeyError> for ScpError {
+    fn from(e: BroadcastKeyError) -> Self {
+        match e {
+            BroadcastKeyError::InvalidHex(_) | BroadcastKeyError::InvalidKeyLength => {
+                Self::Validation {
+                    msg: e.to_string(),
+                    code: codes::TRANS_5060.to_owned(),
+                }
+            }
+            BroadcastKeyError::KeyWithoutAuthor => Self::Validation {
+                msg: e.to_string(),
+                code: codes::TRANS_5060.to_owned(),
+            },
+            BroadcastKeyError::AutoResolveFailed(_) => Self::Context {
+                msg: e.to_string(),
+                code: codes::CTX_2060.to_owned(),
             },
         }
     }
@@ -272,64 +293,17 @@ impl NodeHandle {
         }
 
         // Resolve broadcast key: explicit, auto-lookup, or auto with explicit author.
-        let (resolved_key_bytes, resolved_epoch, resolved_author_did) =
-            match (broadcast_key_hex, author_did) {
-                (Some(key_hex), Some(did)) => {
-                    let key_hex = Zeroizing::new(key_hex);
-                    let key_vec = Zeroizing::new(hex::decode(&*key_hex).map_err(|e| {
-                        ScpError::Validation {
-                            msg: format!("invalid broadcast_key_hex: {e}"),
-                            code: codes::TRANS_5060.to_owned(),
-                        }
-                    })?);
-                    let key_bytes: Zeroizing<[u8; 32]> =
-                        Zeroizing::new(<[u8; 32]>::try_from(key_vec.as_slice()).map_err(|_| {
-                            ScpError::Validation {
-                                msg:
-                                    "broadcast_key_hex must be exactly 64 hex characters (32 bytes)"
-                                        .to_owned(),
-                                code: codes::TRANS_5060.to_owned(),
-                            }
-                        })?);
-                    // Explicit key path always uses epoch 0. For rotated keys, use auto-resolve (omit both params).
-                    (key_bytes, 0u64, did)
-                }
-                (None, author_opt) => {
-                    // Auto-resolve from ContextManager. Use the explicit author
-                    // DID if provided, otherwise fall back to the node's identity
-                    // DID. This supports the case where the node hosts content
-                    // authored by a different DID (#1405).
-                    let did = author_opt.unwrap_or_else(|| self.inner.did().to_owned());
-                    let mgr = crate::runtime::context_manager()?;
-                    let (key_bytes, epoch) = mgr
-                        .get_broadcast_key_for_local_author(&context_id, &did)
-                        .await
-                        .map_err(|e| {
-                            tracing::debug!(error = %e, "broadcast key auto-resolve failed");
-                            ScpError::Context {
-                            msg:
-                                "broadcast key auto-resolve failed: not authorized for this context"
-                                    .to_owned(),
-                            code: codes::CTX_2060.to_owned(),
-                        }
-                        })?;
-                    (key_bytes, epoch, did)
-                }
-                (Some(_), None) => {
-                    return Err(ScpError::Validation {
-                        msg: "broadcast_key_hex requires author_did — provide the DID of the \
-                         broadcast key owner, or omit both for auto-resolve"
-                            .to_owned(),
-                        code: codes::TRANS_5060.to_owned(),
-                    });
-                }
-            };
-
-        let broadcast_key = scp_core::crypto::sender_keys::BroadcastKey::from_parts(
-            scp_core::crypto::sender_keys::SenderKey::from_bytes(*resolved_key_bytes),
-            resolved_epoch,
-            resolved_author_did,
-        );
+        // Delegates to the shared resolver in scp-ffi-common (same logic as PyO3/NAPI).
+        let mgr = crate::runtime::context_manager()?;
+        let resolved = server::resolve_broadcast_key(
+            broadcast_key_hex,
+            author_did,
+            self.inner.did(),
+            mgr,
+            &context_id,
+        )
+        .await?;
+        let broadcast_key = resolved.into_broadcast_key();
 
         let adm = match admission.to_lowercase().as_str() {
             "open" => scp_core::context::broadcast::BroadcastAdmission::Open,

--- a/crates/scp-ffi/wasm/src/bridge.rs
+++ b/crates/scp-ffi/wasm/src/bridge.rs
@@ -17,6 +17,7 @@
 //!
 //! See spec section 12 (Bridge System) and ADR-023.
 
+use scp_ffi_common::error_codes as codes;
 use wasm_bindgen::prelude::*;
 
 use crate::error::ScpWasmError;
@@ -161,7 +162,7 @@ fn parse_bridge_mode(s: &str) -> Result<BridgeMode, ScpWasmError> {
             message: format!(
                 "invalid bridge mode '{other}': expected 'relay', 'puppet', 'api', or 'cooperative'"
             ),
-            code: "SCP-VALID-7050".to_owned(),
+            code: codes::VALID_7050.to_owned(),
         }),
     }
 }
@@ -183,7 +184,7 @@ fn parse_shadow_status(s: &str) -> Result<ShadowProvenanceStatus, ScpWasmError> 
         "claimed" => Ok(ShadowProvenanceStatus::Claimed),
         other => Err(ScpWasmError::Validation {
             message: format!("invalid shadow_status '{other}': expected 'shadow' or 'claimed'"),
-            code: "SCP-VALID-7051".to_owned(),
+            code: codes::VALID_7051.to_owned(),
         }),
     }
 }
@@ -317,7 +318,7 @@ pub fn bridge_register(
     if context_id.is_empty() {
         return Err(ScpWasmError::Validation {
             message: "context_id must not be empty".to_owned(),
-            code: "SCP-VALID-7063".to_owned(),
+            code: codes::VALID_7063.to_owned(),
         }
         .into_js());
     }
@@ -330,7 +331,7 @@ pub fn bridge_register(
     if platform.is_empty() {
         return Err(ScpWasmError::Validation {
             message: "platform must not be empty".to_owned(),
-            code: "SCP-VALID-7064".to_owned(),
+            code: codes::VALID_7064.to_owned(),
         }
         .into_js());
     }
@@ -340,7 +341,7 @@ pub fn bridge_register(
     if governance_did == operator_did {
         return Err(ScpWasmError::Context {
             message: "approver cannot be the same DID as the operator (self-approval is forbidden per ADR-023)".to_owned(),
-            code: "SCP-CTX-2101".to_owned(),
+            code: codes::CTX_2101.to_owned(),
         }
         .into_js());
     }
@@ -363,7 +364,7 @@ pub fn bridge_register(
                 .map_err(|_| {
                     ScpWasmError::Context {
                         message: "system clock is unavailable or before Unix epoch".to_owned(),
-                        code: "SCP-CTX-2101".to_owned(),
+                        code: codes::CTX_2101.to_owned(),
                     }
                     .into_js()
                 })?
@@ -429,14 +430,14 @@ pub fn bridge_create_shadow(
     if bridge_id.is_empty() {
         return Err(ScpWasmError::Validation {
             message: "bridge_id must not be empty".to_owned(),
-            code: "SCP-VALID-7065".to_owned(),
+            code: codes::VALID_7065.to_owned(),
         }
         .into_js());
     }
     if platform_handle.is_empty() {
         return Err(ScpWasmError::Validation {
             message: "platform_handle must not be empty".to_owned(),
-            code: "SCP-VALID-7066".to_owned(),
+            code: codes::VALID_7066.to_owned(),
         }
         .into_js());
     }

--- a/crates/scp-ffi/wasm/src/context.rs
+++ b/crates/scp-ffi/wasm/src/context.rs
@@ -8,6 +8,7 @@
 
 use base64::Engine as _;
 use js_sys::Promise;
+use scp_ffi_common::error_codes as codes;
 use wasm_bindgen::prelude::*;
 use wasm_bindgen_futures::future_to_promise;
 
@@ -267,7 +268,7 @@ pub fn context_create(identity_did: String, params_json: String) -> Promise {
                 message: format!(
                     "params_json is not valid JSON: {e} — pass a JSON-encoded context parameters object"
                 ),
-                code: "SCP-VALID-7000".to_owned(),
+                code: codes::VALID_7000.to_owned(),
             }
             .into_js()
         })?;
@@ -288,7 +289,7 @@ pub fn context_create(identity_did: String, params_json: String) -> Promise {
             mgr.context_metadata(&context_id)
                 .ok_or_else(|| ScpWasmError::Context {
                     message: "context creation succeeded but metadata lookup failed".to_owned(),
-                    code: "SCP-CTX-2001".to_owned(),
+                    code: codes::CTX_2001.to_owned(),
                 })
         })
         .map_err(ScpWasmError::into_js)?;
@@ -338,7 +339,7 @@ pub fn context_join(
             let _ = scp_protocol::crypto::ucan::validate::parse_ucan(jwt).map_err(|e| {
                 ScpWasmError::Context {
                     message: format!("invalid spending UCAN: {e}"),
-                    code: "SCP-ECON-12061".to_owned(),
+                    code: codes::ECON_12061.to_owned(),
                 }
                 .into_js()
             })?;
@@ -433,7 +434,7 @@ pub fn context_send(
                 message:
                     "payload_base64 must not be empty — encode payload bytes as base64 before calling context_send"
                         .to_owned(),
-                code: "SCP-VALID-7000".to_owned(),
+                code: codes::VALID_7000.to_owned(),
             }
             .into_js()
             .into());
@@ -451,7 +452,7 @@ pub fn context_send(
             let _ = scp_protocol::crypto::ucan::validate::parse_ucan(jwt).map_err(|e| {
                 ScpWasmError::Context {
                     message: format!("invalid spending UCAN: {e}"),
-                    code: "SCP-ECON-12061".to_owned(),
+                    code: codes::ECON_12061.to_owned(),
                 }
                 .into_js()
             })?;
@@ -595,7 +596,7 @@ pub fn context_subscribe(
                 message: format!(
                     "cannot subscribe to context in '{state}' state — context must be 'active'"
                 ),
-                code: "SCP-CTX-2021".to_owned(),
+                code: codes::CTX_2021.to_owned(),
             });
         }
         Ok(())
@@ -728,21 +729,21 @@ pub fn context_execute_governance(
             serde_json::from_str(&action_json).map_err(|e| {
                 ScpWasmError::Validation {
                     message: format!("action_json is not valid JSON: {e}"),
-                    code: "SCP-VALID-7000".to_owned(),
+                    code: codes::VALID_7000.to_owned(),
                 }
                 .into_js()
             })?;
         js_to_serde_governance_action(&mut action_value).map_err(|e| {
             ScpWasmError::Validation {
                 message: format!("action_json is not valid: {e}"),
-                code: "SCP-VALID-7000".to_owned(),
+                code: codes::VALID_7000.to_owned(),
             }
             .into_js()
         })?;
         let action: GovernanceAction = serde_json::from_value(action_value).map_err(|e| {
             ScpWasmError::Validation {
                 message: format!("action_json is not valid: {e}"),
-                code: "SCP-VALID-7000".to_owned(),
+                code: codes::VALID_7000.to_owned(),
             }
             .into_js()
         })?;
@@ -750,7 +751,7 @@ pub fn context_execute_governance(
         scp_ffi_common::validate::validate_governance_action_strings(&action).map_err(|e| {
             ScpWasmError::Validation {
                 message: e.message,
-                code: "SCP-VALID-7000".to_owned(),
+                code: codes::VALID_7000.to_owned(),
             }
             .into_js()
         })?;
@@ -763,7 +764,7 @@ pub fn context_execute_governance(
         let json_str = serde_json::to_string(&result).map_err(|e| {
             ScpWasmError::Context {
                 message: format!("failed to serialize governance result: {e}"),
-                code: "SCP-CTX-2001".to_owned(),
+                code: codes::CTX_2001.to_owned(),
             }
             .into_js()
         })?;
@@ -811,21 +812,21 @@ pub fn context_governance_propose(
             serde_json::from_str(&action_json).map_err(|e| {
                 ScpWasmError::Validation {
                     message: format!("action_json is not valid JSON: {e}"),
-                    code: "SCP-CTX-2040".to_owned(),
+                    code: codes::CTX_2040.to_owned(),
                 }
                 .into_js()
             })?;
         js_to_serde_governance_action(&mut action_value).map_err(|e| {
             ScpWasmError::Validation {
                 message: format!("action_json is not valid: {e}"),
-                code: "SCP-CTX-2040".to_owned(),
+                code: codes::CTX_2040.to_owned(),
             }
             .into_js()
         })?;
         let action: GovernanceAction = serde_json::from_value(action_value).map_err(|e| {
             ScpWasmError::Validation {
                 message: format!("action_json is not valid: {e}"),
-                code: "SCP-CTX-2040".to_owned(),
+                code: codes::CTX_2040.to_owned(),
             }
             .into_js()
         })?;
@@ -833,7 +834,7 @@ pub fn context_governance_propose(
         scp_ffi_common::validate::validate_governance_action_strings(&action).map_err(|e| {
             ScpWasmError::Validation {
                 message: e.message,
-                code: "SCP-CTX-2040".to_owned(),
+                code: codes::CTX_2040.to_owned(),
             }
             .into_js()
         })?;
@@ -846,7 +847,7 @@ pub fn context_governance_propose(
         let json_str = serde_json::to_string(&result).map_err(|e| {
             ScpWasmError::Context {
                 message: format!("failed to serialize proposal result: {e}"),
-                code: "SCP-CTX-2041".to_owned(),
+                code: codes::CTX_2041.to_owned(),
             }
             .into_js()
         })?;
@@ -888,7 +889,7 @@ pub fn context_governance_approve(
         let json_str = serde_json::to_string(&result).map_err(|e| {
             ScpWasmError::Context {
                 message: format!("failed to serialize approval result: {e}"),
-                code: "SCP-CTX-2042".to_owned(),
+                code: codes::CTX_2042.to_owned(),
             }
             .into_js()
         })?;
@@ -930,7 +931,7 @@ pub fn context_governance_reject(
         let json_str = serde_json::to_string(&result).map_err(|e| {
             ScpWasmError::Context {
                 message: format!("failed to serialize rejection result: {e}"),
-                code: "SCP-CTX-2043".to_owned(),
+                code: codes::CTX_2043.to_owned(),
             }
             .into_js()
         })?;
@@ -971,7 +972,7 @@ pub fn context_governance_withdraw(
         let json_str = serde_json::to_string(&result).map_err(|e| {
             ScpWasmError::Context {
                 message: format!("failed to serialize withdrawal result: {e}"),
-                code: "SCP-CTX-2044".to_owned(),
+                code: codes::CTX_2044.to_owned(),
             }
             .into_js()
         })?;
@@ -1002,7 +1003,7 @@ pub fn context_governance_get_proposal(handle: &WasmContextHandle, proposal_id: 
         let json_str = serde_json::to_string(&result).map_err(|e| {
             ScpWasmError::Context {
                 message: format!("failed to serialize proposal: {e}"),
-                code: "SCP-CTX-2045".to_owned(),
+                code: codes::CTX_2045.to_owned(),
             }
             .into_js()
         })?;
@@ -1029,7 +1030,7 @@ pub fn context_governance_list_proposals(handle: &WasmContextHandle) -> Promise 
         let json_str = serde_json::to_string(&result).map_err(|e| {
             ScpWasmError::Context {
                 message: format!("failed to serialize proposals: {e}"),
-                code: "SCP-CTX-2046".to_owned(),
+                code: codes::CTX_2046.to_owned(),
             }
             .into_js()
         })?;
@@ -1106,7 +1107,7 @@ pub fn context_create_governance_checkpoint(
         let creator_signature = hex::decode(&creator_signature_hex).map_err(|e| {
             ScpWasmError::Validation {
                 message: format!("invalid creator_signature hex: {e}"),
-                code: "SCP-CTX-2062".to_owned(),
+                code: codes::CTX_2062.to_owned(),
             }
             .into_js()
         })?;
@@ -1133,7 +1134,7 @@ pub fn context_create_governance_checkpoint(
         let json_str = serde_json::to_string(&checkpoint).map_err(|e| {
             ScpWasmError::Context {
                 message: format!("serialization failed: {e}"),
-                code: "SCP-CTX-2062".to_owned(),
+                code: codes::CTX_2062.to_owned(),
             }
             .into_js()
         })?;
@@ -1164,7 +1165,7 @@ pub fn context_add_checkpoint_cosignature(
             serde_json::from_str(&checkpoint_json).map_err(|e| {
                 ScpWasmError::Validation {
                     message: format!("invalid checkpoint JSON: {e}"),
-                    code: "SCP-CTX-2063".to_owned(),
+                    code: codes::CTX_2063.to_owned(),
                 }
                 .into_js()
             })?;
@@ -1172,7 +1173,7 @@ pub fn context_add_checkpoint_cosignature(
         let signature = hex::decode(&signature_hex).map_err(|e| {
             ScpWasmError::Validation {
                 message: format!("invalid signature hex: {e}"),
-                code: "SCP-CTX-2063".to_owned(),
+                code: codes::CTX_2063.to_owned(),
             }
             .into_js()
         })?;
@@ -1189,7 +1190,7 @@ pub fn context_add_checkpoint_cosignature(
         let json_str = serde_json::to_string(&response).map_err(|e| {
             ScpWasmError::Context {
                 message: format!("serialization failed: {e}"),
-                code: "SCP-CTX-2063".to_owned(),
+                code: codes::CTX_2063.to_owned(),
             }
             .into_js()
         })?;
@@ -1221,7 +1222,7 @@ pub fn context_restore_all() -> Promise {
         let json_str = serde_json::to_string(&restored).map_err(|e| {
             ScpWasmError::Context {
                 message: format!("serialization failed: {e}"),
-                code: "SCP-CTX-2065".to_owned(),
+                code: codes::CTX_2065.to_owned(),
             }
             .into_js()
         })?;
@@ -1235,14 +1236,14 @@ fn parse_wasm_hex_32(hex_str: &str, field_name: &str) -> Result<[u8; 32], JsValu
     let bytes = hex::decode(hex_str).map_err(|e| {
         ScpWasmError::Validation {
             message: format!("invalid {field_name} hex: {e}"),
-            code: "SCP-CTX-2062".to_owned(),
+            code: codes::CTX_2062.to_owned(),
         }
         .into_js()
     })?;
     let arr: [u8; 32] = bytes.try_into().map_err(|v: Vec<u8>| {
         ScpWasmError::Validation {
             message: format!("{field_name} must be 32 bytes, got {}", v.len()),
-            code: "SCP-CTX-2062".to_owned(),
+            code: codes::CTX_2062.to_owned(),
         }
         .into_js()
     })?;
@@ -1316,7 +1317,7 @@ pub fn broadcast_publish_asset(
         let asset: serde_json::Value = serde_json::from_str(&asset_json).map_err(|e| {
             ScpWasmError::Context {
                 message: format!("invalid asset JSON: {e}"),
-                code: "SCP-CTX-2073".to_owned(),
+                code: codes::CTX_2073.to_owned(),
             }
             .into_js()
         })?;
@@ -1327,7 +1328,7 @@ pub fn broadcast_publish_asset(
             .ok_or_else(|| {
                 ScpWasmError::Context {
                     message: "asset must have a 'path' string field".to_owned(),
-                    code: "SCP-CTX-2073".to_owned(),
+                    code: codes::CTX_2073.to_owned(),
                 }
                 .into_js()
             })?
@@ -1339,7 +1340,7 @@ pub fn broadcast_publish_asset(
             .ok_or_else(|| {
                 ScpWasmError::Context {
                     message: "asset must have a 'contentType' string field".to_owned(),
-                    code: "SCP-CTX-2073".to_owned(),
+                    code: codes::CTX_2073.to_owned(),
                 }
                 .into_js()
             })?
@@ -1351,7 +1352,7 @@ pub fn broadcast_publish_asset(
             .ok_or_else(|| {
                 ScpWasmError::Context {
                     message: "asset must have a 'bodyBase64' string field".to_owned(),
-                    code: "SCP-CTX-2073".to_owned(),
+                    code: codes::CTX_2073.to_owned(),
                 }
                 .into_js()
             })?;
@@ -1361,7 +1362,7 @@ pub fn broadcast_publish_asset(
             .map_err(|e| {
                 ScpWasmError::Context {
                     message: format!("invalid base64 body: {e}"),
-                    code: "SCP-CTX-2073".to_owned(),
+                    code: codes::CTX_2073.to_owned(),
                 }
                 .into_js()
             })?;
@@ -1461,14 +1462,14 @@ pub fn broadcast_publish_assets(
         let assets_value: serde_json::Value = serde_json::from_str(&assets_json).map_err(|e| {
             ScpWasmError::Context {
                 message: format!("invalid assets JSON: {e}"),
-                code: "SCP-CTX-2073".to_owned(),
+                code: codes::CTX_2073.to_owned(),
             }
             .into_js()
         })?;
         let assets_arr = assets_value.as_array().ok_or_else(|| {
             ScpWasmError::Context {
                 message: "assets must be a JSON array".to_owned(),
-                code: "SCP-CTX-2073".to_owned(),
+                code: codes::CTX_2073.to_owned(),
             }
             .into_js()
         })?;
@@ -1482,7 +1483,7 @@ pub fn broadcast_publish_assets(
                 .ok_or_else(|| {
                     ScpWasmError::Context {
                         message: "each asset must have a 'path' string field".to_owned(),
-                        code: "SCP-CTX-2073".to_owned(),
+                        code: codes::CTX_2073.to_owned(),
                     }
                     .into_js()
                 })?
@@ -1493,7 +1494,7 @@ pub fn broadcast_publish_assets(
                 .ok_or_else(|| {
                     ScpWasmError::Context {
                         message: "each asset must have a 'contentType' string field".to_owned(),
-                        code: "SCP-CTX-2073".to_owned(),
+                        code: codes::CTX_2073.to_owned(),
                     }
                     .into_js()
                 })?
@@ -1504,7 +1505,7 @@ pub fn broadcast_publish_assets(
                 .ok_or_else(|| {
                     ScpWasmError::Context {
                         message: "each asset must have a 'bodyBase64' string field".to_owned(),
-                        code: "SCP-CTX-2073".to_owned(),
+                        code: codes::CTX_2073.to_owned(),
                     }
                     .into_js()
                 })?;
@@ -1513,7 +1514,7 @@ pub fn broadcast_publish_assets(
                 .map_err(|e| {
                     ScpWasmError::Context {
                         message: format!("invalid base64 body: {e}"),
-                        code: "SCP-CTX-2073".to_owned(),
+                        code: codes::CTX_2073.to_owned(),
                     }
                     .into_js()
                 })?;
@@ -1693,7 +1694,7 @@ pub fn context_set_economic_policy(
                   (propose SetEconomicPolicy action). Direct mutation is \
                   not permitted — see spec §19.3"
             .to_owned(),
-        code: "SCP-CTX-2013".to_owned(),
+        code: codes::CTX_2013.to_owned(),
     }
     .into_js())
 }
@@ -1730,7 +1731,7 @@ pub fn context_export(handle: &WasmContextHandle) -> Promise {
         let len = u32::try_from(bytes.len()).map_err(|_| {
             ScpWasmError::Context {
                 message: "export data exceeds 4 GiB — too large for WASM Uint8Array".to_owned(),
-                code: "SCP-CTX-2030".to_owned(),
+                code: codes::CTX_2030.to_owned(),
             }
             .into_js()
         })?;
@@ -2072,7 +2073,7 @@ fn validate_min_protocol_version(params: &serde_json::Value) -> Result<(), ScpWa
 
     let arr = field.as_array().ok_or_else(|| ScpWasmError::Validation {
         message: format!("minProtocolVersion must be a [major, minor] array, got: {field}"),
-        code: "SCP-VALID-7002".to_owned(),
+        code: codes::VALID_7002.to_owned(),
     })?;
 
     if arr.len() < 2 {
@@ -2081,7 +2082,7 @@ fn validate_min_protocol_version(params: &serde_json::Value) -> Result<(), ScpWa
                 "minProtocolVersion must have at least 2 elements [major, minor], got {len}",
                 len = arr.len()
             ),
-            code: "SCP-VALID-7002".to_owned(),
+            code: codes::VALID_7002.to_owned(),
         });
     }
 
@@ -2091,12 +2092,12 @@ fn validate_min_protocol_version(params: &serde_json::Value) -> Result<(), ScpWa
             "minProtocolVersion[0] (major) must be a non-negative integer, got: {}",
             arr[0]
         ),
-        code: "SCP-VALID-7002".to_owned(),
+        code: codes::VALID_7002.to_owned(),
     })?;
     if raw_major > u64::from(u8::MAX) {
         return Err(ScpWasmError::Validation {
             message: format!("minProtocolVersion[0] (major) exceeds u8 range: {raw_major}"),
-            code: "SCP-VALID-7002".to_owned(),
+            code: codes::VALID_7002.to_owned(),
         });
     }
 
@@ -2106,12 +2107,12 @@ fn validate_min_protocol_version(params: &serde_json::Value) -> Result<(), ScpWa
             "minProtocolVersion[1] (minor) must be a non-negative integer, got: {}",
             arr[1]
         ),
-        code: "SCP-VALID-7002".to_owned(),
+        code: codes::VALID_7002.to_owned(),
     })?;
     if raw_minor > u64::from(u8::MAX) {
         return Err(ScpWasmError::Validation {
             message: format!("minProtocolVersion[1] (minor) exceeds u8 range: {raw_minor}"),
-            code: "SCP-VALID-7002".to_owned(),
+            code: codes::VALID_7002.to_owned(),
         });
     }
 
@@ -2193,21 +2194,21 @@ pub fn metadata_record_to_json(
     validate_context_id(&context_id)
         .map_err(|e| ScpWasmError::Validation {
             message: e.to_string(),
-            code: "SCP-VALID-7001".to_owned(),
+            code: codes::VALID_7001.to_owned(),
         })
         .map_err(ScpWasmError::into_js)?;
 
     validate_did(&signer_did)
         .map_err(|e| ScpWasmError::Validation {
             message: e.to_string(),
-            code: "SCP-VALID-7001".to_owned(),
+            code: codes::VALID_7001.to_owned(),
         })
         .map_err(ScpWasmError::into_js)?;
 
     if sequence == 0 {
         return Err(ScpWasmError::Validation {
             message: "MetadataRecord sequence must start at 1 (per spec §5.7.2)".to_owned(),
-            code: "SCP-VALID-7001".to_owned(),
+            code: codes::VALID_7001.to_owned(),
         }
         .into_js());
     }
@@ -2215,7 +2216,7 @@ pub fn metadata_record_to_json(
     let structural: serde_json::Value = serde_json::from_str(&structural_json).map_err(|e| {
         ScpWasmError::Validation {
             message: format!("invalid structural metadata JSON: {e}"),
-            code: "SCP-VALID-7001".to_owned(),
+            code: codes::VALID_7001.to_owned(),
         }
         .into_js()
     })?;
@@ -2223,7 +2224,7 @@ pub fn metadata_record_to_json(
     let operational: serde_json::Value = serde_json::from_str(&operational_json).map_err(|e| {
         ScpWasmError::Validation {
             message: format!("invalid operational metadata JSON: {e}"),
-            code: "SCP-VALID-7001".to_owned(),
+            code: codes::VALID_7001.to_owned(),
         }
         .into_js()
     })?;
@@ -2231,14 +2232,14 @@ pub fn metadata_record_to_json(
     let signature = hex::decode(&signature_hex).map_err(|e| {
         ScpWasmError::Validation {
             message: format!("invalid signature hex: {e}"),
-            code: "SCP-VALID-7001".to_owned(),
+            code: codes::VALID_7001.to_owned(),
         }
         .into_js()
     })?;
     if signature.len() != 64 {
         return Err(ScpWasmError::Validation {
             message: format!("signature must be 64 bytes (got {})", signature.len()),
-            code: "SCP-VALID-7001".to_owned(),
+            code: codes::VALID_7001.to_owned(),
         }
         .into_js());
     }
@@ -2258,7 +2259,7 @@ pub fn metadata_record_to_json(
     serde_json::to_string(&record).map_err(|e| {
         ScpWasmError::Validation {
             message: format!("failed to serialize MetadataRecord: {e}"),
-            code: "SCP-VALID-7001".to_owned(),
+            code: codes::VALID_7001.to_owned(),
         }
         .into_js()
     })
@@ -2278,7 +2279,7 @@ pub fn metadata_record_from_json(json_str: String) -> Result<String, JsError> {
     let record: WasmMetadataRecord = serde_json::from_str(&json_str).map_err(|e| {
         ScpWasmError::Validation {
             message: format!("invalid MetadataRecord JSON: {e}"),
-            code: "SCP-VALID-7001".to_owned(),
+            code: codes::VALID_7001.to_owned(),
         }
         .into_js()
     })?;
@@ -2287,7 +2288,7 @@ pub fn metadata_record_from_json(json_str: String) -> Result<String, JsError> {
     if record.sequence == 0 {
         return Err(ScpWasmError::Validation {
             message: "MetadataRecord sequence must start at 1 (per spec §5.7.2)".to_owned(),
-            code: "SCP-VALID-7001".to_owned(),
+            code: codes::VALID_7001.to_owned(),
         }
         .into_js());
     }
@@ -2299,7 +2300,7 @@ pub fn metadata_record_from_json(json_str: String) -> Result<String, JsError> {
                 "signature must be 64 bytes (got {})",
                 record.signature.len()
             ),
-            code: "SCP-VALID-7001".to_owned(),
+            code: codes::VALID_7001.to_owned(),
         }
         .into_js());
     }
@@ -2309,21 +2310,21 @@ pub fn metadata_record_from_json(json_str: String) -> Result<String, JsError> {
         if !obj.contains_key("context_id") {
             return Err(ScpWasmError::Validation {
                 message: "structural metadata must contain 'context_id' field".to_owned(),
-                code: "SCP-VALID-7001".to_owned(),
+                code: codes::VALID_7001.to_owned(),
             }
             .into_js());
         }
         if !obj.contains_key("mode") {
             return Err(ScpWasmError::Validation {
                 message: "structural metadata must contain 'mode' field".to_owned(),
-                code: "SCP-VALID-7001".to_owned(),
+                code: codes::VALID_7001.to_owned(),
             }
             .into_js());
         }
     } else {
         return Err(ScpWasmError::Validation {
             message: "structural metadata must be a JSON object".to_owned(),
-            code: "SCP-VALID-7001".to_owned(),
+            code: codes::VALID_7001.to_owned(),
         }
         .into_js());
     }
@@ -2333,21 +2334,21 @@ pub fn metadata_record_from_json(json_str: String) -> Result<String, JsError> {
         if !obj.contains_key("version") {
             return Err(ScpWasmError::Validation {
                 message: "operational metadata must contain 'version' field".to_owned(),
-                code: "SCP-VALID-7001".to_owned(),
+                code: codes::VALID_7001.to_owned(),
             }
             .into_js());
         }
         if !obj.contains_key("capabilities") {
             return Err(ScpWasmError::Validation {
                 message: "operational metadata must contain 'capabilities' field".to_owned(),
-                code: "SCP-VALID-7001".to_owned(),
+                code: codes::VALID_7001.to_owned(),
             }
             .into_js());
         }
     } else {
         return Err(ScpWasmError::Validation {
             message: "operational metadata must be a JSON object".to_owned(),
-            code: "SCP-VALID-7001".to_owned(),
+            code: codes::VALID_7001.to_owned(),
         }
         .into_js());
     }
@@ -2355,7 +2356,7 @@ pub fn metadata_record_from_json(json_str: String) -> Result<String, JsError> {
     serde_json::to_string(&record).map_err(|e| {
         ScpWasmError::Validation {
             message: format!("failed to re-serialize MetadataRecord: {e}"),
-            code: "SCP-VALID-7001".to_owned(),
+            code: codes::VALID_7001.to_owned(),
         }
         .into_js()
     })
@@ -2390,13 +2391,13 @@ fn validate_invitation_template(params: &serde_json::Value) -> Result<(), ScpWas
             // template — forward-compatible: skip validation for unknown shapes.
             ScpWasmError::Context {
                 message: "template validation failed: invalid context params".to_owned(),
-                code: "SCP-CTX-2060".to_owned(),
+                code: codes::CTX_2060.to_owned(),
             }
         })?;
 
     protocol_validate_against_template(&ctx_params).map_err(|e| ScpWasmError::Context {
         message: format!("template spoofing detected: {e}"),
-        code: "SCP-CTX-2060".to_owned(),
+        code: codes::CTX_2060.to_owned(),
     })
 }
 
@@ -2486,7 +2487,7 @@ fn check_economic_policy(
         return Err(ScpWasmError::Context {
             message: "spending UCAN required: context has economic policy requiring payment"
                 .to_owned(),
-            code: "SCP-CTX-2060".to_owned(),
+            code: codes::CTX_2060.to_owned(),
         }
         .into_js()
         .into());
@@ -2528,7 +2529,7 @@ fn check_economic_policy(
                 message: format!(
                     "no compatible payment adapter: context accepts {accepted:?}, configured {configured_adapters:?}"
                 ),
-                code: "SCP-CTX-2060".to_owned(),
+                code: codes::CTX_2060.to_owned(),
             }
             .into_js()
             .into());
@@ -2552,7 +2553,7 @@ fn check_economic_policy(
             message: format!(
                 "insufficient balance: estimated cost {per_join}, available {available_balance}"
             ),
-            code: "SCP-CTX-2060".to_owned(),
+            code: codes::CTX_2060.to_owned(),
         }
         .into_js()
         .into());
@@ -2814,7 +2815,7 @@ pub fn template_get_params(template_id: String) -> Result<String, JsError> {
                      scp:template/handle-registry (alias: scp:template/discovery-context, \
                      DiscoveryContext)"
                 ),
-                code: "SCP-VALID-7001".to_owned(),
+                code: codes::VALID_7001.to_owned(),
             }
             .into_js()
         })?;
@@ -2822,7 +2823,7 @@ pub fn template_get_params(template_id: String) -> Result<String, JsError> {
     let mut val = serde_json::to_value(&params).map_err(|e| {
         ScpWasmError::Validation {
             message: format!("failed to serialize template params: {e}"),
-            code: "SCP-VALID-7001".to_owned(),
+            code: codes::VALID_7001.to_owned(),
         }
         .into_js()
     })?;
@@ -2835,7 +2836,7 @@ pub fn template_get_params(template_id: String) -> Result<String, JsError> {
     serde_json::to_string(&val).map_err(|e| {
         ScpWasmError::Validation {
             message: format!("failed to serialize template params: {e}"),
-            code: "SCP-VALID-7001".to_owned(),
+            code: codes::VALID_7001.to_owned(),
         }
         .into_js()
     })
@@ -2858,7 +2859,7 @@ pub fn validate_against_template(params_json: String) -> Result<Option<String>, 
     let mut raw: serde_json::Value = serde_json::from_str(&params_json).map_err(|e| {
         ScpWasmError::Validation {
             message: format!("invalid ContextParams JSON: {e}"),
-            code: "SCP-VALID-7001".to_owned(),
+            code: codes::VALID_7001.to_owned(),
         }
         .into_js()
     })?;
@@ -2870,7 +2871,7 @@ pub fn validate_against_template(params_json: String) -> Result<Option<String>, 
         .map_err(|e| {
             ScpWasmError::Validation {
                 message: format!("invalid ContextParams JSON: {e}"),
-                code: "SCP-VALID-7001".to_owned(),
+                code: codes::VALID_7001.to_owned(),
             }
             .into_js()
         })?;
@@ -2951,7 +2952,7 @@ pub fn validate_context_params(params_json: String) -> Result<Option<String>, Js
     let mut raw: serde_json::Value = serde_json::from_str(&params_json).map_err(|e| {
         ScpWasmError::Validation {
             message: format!("invalid ContextParams JSON: {e}"),
-            code: "SCP-VALID-7001".to_owned(),
+            code: codes::VALID_7001.to_owned(),
         }
         .into_js()
     })?;
@@ -2963,7 +2964,7 @@ pub fn validate_context_params(params_json: String) -> Result<Option<String>, Js
         .map_err(|e| {
             ScpWasmError::Validation {
                 message: format!("invalid ContextParams JSON: {e}"),
-                code: "SCP-VALID-7001".to_owned(),
+                code: codes::VALID_7001.to_owned(),
             }
             .into_js()
         })?;
@@ -2981,6 +2982,7 @@ pub fn validate_context_params(params_json: String) -> Result<Option<String>, Js
 #[cfg(test)]
 mod tests {
     use super::*;
+    use scp_ffi_common::error_codes as codes;
 
     #[test]
     fn validate_min_protocol_version_absent() {
@@ -3012,7 +3014,7 @@ mod tests {
         assert!(
             matches!(
                 validate_min_protocol_version(&params),
-                Err(ScpWasmError::Validation { ref code, .. }) if code == "SCP-VALID-7002"
+                Err(ScpWasmError::Validation { ref code, .. }) if code == codes::VALID_7002
             ),
             "expected SCP-VALID-7002 validation error"
         );
@@ -3024,7 +3026,7 @@ mod tests {
         assert!(
             matches!(
                 validate_min_protocol_version(&params),
-                Err(ScpWasmError::Validation { ref code, .. }) if code == "SCP-VALID-7002"
+                Err(ScpWasmError::Validation { ref code, .. }) if code == codes::VALID_7002
             ),
             "expected SCP-VALID-7002 validation error"
         );
@@ -3036,7 +3038,7 @@ mod tests {
         assert!(
             matches!(
                 validate_min_protocol_version(&params),
-                Err(ScpWasmError::Validation { ref code, .. }) if code == "SCP-VALID-7002"
+                Err(ScpWasmError::Validation { ref code, .. }) if code == codes::VALID_7002
             ),
             "expected SCP-VALID-7002 validation error"
         );
@@ -3048,7 +3050,7 @@ mod tests {
         assert!(
             matches!(
                 validate_min_protocol_version(&params),
-                Err(ScpWasmError::Validation { ref code, .. }) if code == "SCP-VALID-7002"
+                Err(ScpWasmError::Validation { ref code, .. }) if code == codes::VALID_7002
             ),
             "expected SCP-VALID-7002 validation error"
         );
@@ -3060,7 +3062,7 @@ mod tests {
         assert!(
             matches!(
                 validate_min_protocol_version(&params),
-                Err(ScpWasmError::Validation { ref code, .. }) if code == "SCP-VALID-7002"
+                Err(ScpWasmError::Validation { ref code, .. }) if code == codes::VALID_7002
             ),
             "expected SCP-VALID-7002 validation error"
         );
@@ -3072,7 +3074,7 @@ mod tests {
         assert!(
             matches!(
                 validate_min_protocol_version(&params),
-                Err(ScpWasmError::Validation { ref code, .. }) if code == "SCP-VALID-7002"
+                Err(ScpWasmError::Validation { ref code, .. }) if code == codes::VALID_7002
             ),
             "expected SCP-VALID-7002 validation error"
         );
@@ -3084,7 +3086,7 @@ mod tests {
         assert!(
             matches!(
                 validate_min_protocol_version(&params),
-                Err(ScpWasmError::Validation { ref code, .. }) if code == "SCP-VALID-7002"
+                Err(ScpWasmError::Validation { ref code, .. }) if code == codes::VALID_7002
             ),
             "expected SCP-VALID-7002 validation error"
         );
@@ -3096,7 +3098,7 @@ mod tests {
         assert!(
             matches!(
                 validate_min_protocol_version(&params),
-                Err(ScpWasmError::Validation { ref code, .. }) if code == "SCP-VALID-7002"
+                Err(ScpWasmError::Validation { ref code, .. }) if code == codes::VALID_7002
             ),
             "expected SCP-VALID-7002 validation error"
         );
@@ -3108,7 +3110,7 @@ mod tests {
         assert!(
             matches!(
                 validate_min_protocol_version(&params),
-                Err(ScpWasmError::Validation { ref code, .. }) if code == "SCP-VALID-7002"
+                Err(ScpWasmError::Validation { ref code, .. }) if code == codes::VALID_7002
             ),
             "expected SCP-VALID-7002 validation error"
         );

--- a/crates/scp-ffi/wasm/src/error.rs
+++ b/crates/scp-ffi/wasm/src/error.rs
@@ -35,6 +35,7 @@
 //!
 //! See ADR-022 and `.docs/standards/sdk-common.md` for the full spec.
 
+use scp_ffi_common::error_codes as codes;
 use wasm_bindgen::{JsError, JsValue};
 
 // ---------------------------------------------------------------------------
@@ -144,7 +145,7 @@ impl ScpWasmError {
     pub fn validation(message: &str) -> JsValue {
         let err = Self::Validation {
             message: message.to_owned(),
-            code: "SCP-VALID-7000".to_owned(),
+            code: codes::VALID_7000.to_owned(),
         };
         JsValue::from_str(&err.to_string())
     }
@@ -158,7 +159,7 @@ impl From<scp_ffi_common::validate::ValidationError> for ScpWasmError {
     fn from(e: scp_ffi_common::validate::ValidationError) -> Self {
         Self::Validation {
             message: e.message,
-            code: "SCP-VALID-7000".to_owned(),
+            code: codes::VALID_7000.to_owned(),
         }
     }
 }
@@ -167,7 +168,7 @@ impl From<serde_json::Error> for ScpWasmError {
     fn from(e: serde_json::Error) -> Self {
         Self::Validation {
             message: format!("JSON serialization/deserialization failed: {e} — check input format"),
-            code: "SCP-VALID-7006".to_owned(),
+            code: codes::VALID_7006.to_owned(),
         }
     }
 }

--- a/crates/scp-ffi/wasm/src/event_log.rs
+++ b/crates/scp-ffi/wasm/src/event_log.rs
@@ -6,6 +6,7 @@
 //! See ADR-034 in `.docs/adrs/phase-4.md` and issue #389.
 
 use js_sys::Promise;
+use scp_ffi_common::error_codes as codes;
 use sha2::Digest as _;
 use wasm_bindgen::prelude::*;
 use wasm_bindgen_futures::future_to_promise;
@@ -30,7 +31,7 @@ fn validate_non_negative_epoch(value: f64) -> Result<u64, ScpWasmError> {
     if value < 0.0 || !value.is_finite() {
         return Err(ScpWasmError::Validation {
             message: format!("epoch must be non-negative, got {value}"),
-            code: "SCP-VALID-7040".to_owned(),
+            code: codes::VALID_7040.to_owned(),
         });
     }
     #[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
@@ -211,7 +212,7 @@ pub fn event_log_query(context: &WasmContextHandle, filter_json: Option<String>)
                 let parsed: serde_json::Value = serde_json::from_str(json_str).map_err(|e| {
                     ScpWasmError::Validation {
                         message: format!("filter_json is not valid JSON: {e}"),
-                        code: "SCP-VALID-7000".to_owned(),
+                        code: codes::VALID_7000.to_owned(),
                     }
                     .into_js()
                 })?;
@@ -264,7 +265,7 @@ pub fn event_log_query(context: &WasmContextHandle, filter_json: Option<String>)
         let json_str = serde_json::to_string(&result).map_err(|e| {
             ScpWasmError::Context {
                 message: format!("serialization failed: {e}"),
-                code: "SCP-CTX-2007".to_owned(),
+                code: codes::CTX_2007.to_owned(),
             }
             .into_js()
         })?;
@@ -284,7 +285,7 @@ pub fn event_log_verify(context: &WasmContextHandle, claim_json: String) -> Prom
         let claim: serde_json::Value = serde_json::from_str(&claim_json).map_err(|e| {
             ScpWasmError::Validation {
                 message: format!("claim_json is not valid JSON: {e}"),
-                code: "SCP-VALID-7000".to_owned(),
+                code: codes::VALID_7000.to_owned(),
             }
             .into_js()
         })?;
@@ -296,7 +297,7 @@ pub fn event_log_verify(context: &WasmContextHandle, claim_json: String) -> Prom
                 let leaf_index = claim["leafIndex"].as_u64().ok_or_else(|| {
                     ScpWasmError::Validation {
                         message: "inclusion claim requires 'leafIndex' (number)".to_owned(),
-                        code: "SCP-VALID-7000".to_owned(),
+                        code: codes::VALID_7000.to_owned(),
                     }
                     .into_js()
                 })?;
@@ -308,7 +309,7 @@ pub fn event_log_verify(context: &WasmContextHandle, claim_json: String) -> Prom
                 let event_hash_hex = claim["eventHash"].as_str().ok_or_else(|| {
                     ScpWasmError::Validation {
                         message: "absence claim requires 'eventHash' (hex string)".to_owned(),
-                        code: "SCP-VALID-7000".to_owned(),
+                        code: codes::VALID_7000.to_owned(),
                     }
                     .into_js()
                 })?;
@@ -316,7 +317,7 @@ pub fn event_log_verify(context: &WasmContextHandle, claim_json: String) -> Prom
                 let event_hash = crate::runtime::decode_hex_hash(event_hash_hex).map_err(|e| {
                     ScpWasmError::Validation {
                         message: format!("invalid eventHash: {e}"),
-                        code: "SCP-VALID-7000".to_owned(),
+                        code: codes::VALID_7000.to_owned(),
                     }
                     .into_js()
                 })?;
@@ -329,7 +330,7 @@ pub fn event_log_verify(context: &WasmContextHandle, claim_json: String) -> Prom
                     message: format!(
                         "unsupported proof type '{other}' — expected 'inclusion' or 'absence'"
                     ),
-                    code: "SCP-VALID-7000".to_owned(),
+                    code: codes::VALID_7000.to_owned(),
                 }
                 .into_js()
                 .into());
@@ -397,14 +398,14 @@ pub fn event_log_checkpoint(
             let decoded = hex::decode(&merkle_root_hex).map_err(|e| {
                 ScpWasmError::Validation {
                     message: format!("invalid merkle root hex: {e}"),
-                    code: "SCP-VALID-7000".to_owned(),
+                    code: codes::VALID_7000.to_owned(),
                 }
                 .into_js()
             })?;
             if decoded.len() != 32 {
                 return Err(ScpWasmError::Validation {
                     message: format!("merkle root must be 32 bytes, got {}", decoded.len()),
-                    code: "SCP-VALID-7000".to_owned(),
+                    code: codes::VALID_7000.to_owned(),
                 }
                 .into_js()
                 .into());
@@ -461,6 +462,7 @@ pub fn event_log_checkpoint(
 #[allow(clippy::unwrap_used)]
 mod tests {
     use super::*;
+    use scp_ffi_common::error_codes as codes;
 
     // -----------------------------------------------------------------------
     // validate_non_negative_epoch — returns ScpWasmError (no JsValue)
@@ -512,7 +514,7 @@ mod tests {
         let err = result.unwrap_err();
         let msg = format!("{err}");
         assert!(
-            msg.contains("SCP-VALID-7040"),
+            msg.contains(codes::VALID_7040),
             "error should contain SCP-VALID-7040, got: {msg}"
         );
     }

--- a/crates/scp-ffi/wasm/src/identity.rs
+++ b/crates/scp-ffi/wasm/src/identity.rs
@@ -39,6 +39,7 @@
 //!
 //! See ADR-022 in `.docs/adrs/phase-4.md` for the full specification.
 
+use scp_ffi_common::error_codes as codes;
 use std::cell::RefCell;
 use std::collections::HashMap;
 
@@ -256,7 +257,7 @@ pub(crate) fn compute_export_hmac(did: &str, data: &[u8]) -> Result<String, ScpW
     let mut mac =
         Hmac::<Sha256>::new_from_slice(hmac_key.as_ref()).map_err(|e| ScpWasmError::Identity {
             message: format!("HMAC key init failed: {e}"),
-            code: "SCP-CTX-2020".to_owned(),
+            code: codes::CTX_2020.to_owned(),
         })?;
     mac.update(data);
     let result = mac.finalize();
@@ -313,20 +314,20 @@ pub(crate) fn verify_export_hmac(
 
     let expected_bytes = hex::decode(expected_hex).map_err(|e| ScpWasmError::Context {
         message: format!("integrity_mac is not valid hex: {e}"),
-        code: "SCP-CTX-2020".to_owned(),
+        code: codes::CTX_2020.to_owned(),
     })?;
 
     let hmac_key = derive_export_hmac_key(did)?;
     let mut mac =
         Hmac::<Sha256>::new_from_slice(hmac_key.as_ref()).map_err(|e| ScpWasmError::Identity {
             message: format!("HMAC key init failed: {e}"),
-            code: "SCP-CTX-2020".to_owned(),
+            code: codes::CTX_2020.to_owned(),
         })?;
     mac.update(data);
     mac.verify_slice(&expected_bytes)
         .map_err(|_| ScpWasmError::Context {
             message: "export integrity check failed — HMAC does not match".to_owned(),
-            code: "SCP-CTX-2020".to_owned(),
+            code: codes::CTX_2020.to_owned(),
         })
 }
 
@@ -339,7 +340,7 @@ fn derive_export_hmac_key(did: &str) -> Result<zeroize::Zeroizing<[u8; 32]>, Scp
         let map = reg.borrow();
         let entry = map.get(did).ok_or_else(|| ScpWasmError::Identity {
             message: format!("identity '{did}' not found in registry — cannot compute export HMAC"),
-            code: "SCP-CTX-2020".to_owned(),
+            code: codes::CTX_2020.to_owned(),
         })?;
 
         // HKDF-SHA256: extract(salt=[], ikm=signing_key) then
@@ -347,13 +348,13 @@ fn derive_export_hmac_key(did: &str) -> Result<zeroize::Zeroizing<[u8; 32]>, Scp
         let prk = hkdf_extract_sha256(&[], entry.signing_key_bytes.as_ref()).map_err(|e| {
             ScpWasmError::Identity {
                 message: format!("HKDF extract failed: {e}"),
-                code: "SCP-CTX-2020".to_owned(),
+                code: codes::CTX_2020.to_owned(),
             }
         })?;
         let okm = hkdf_expand_sha256(&prk, EXPORT_HMAC_DOMAIN, 32).map_err(|e| {
             ScpWasmError::Identity {
                 message: format!("HKDF expand failed: {e}"),
-                code: "SCP-CTX-2020".to_owned(),
+                code: codes::CTX_2020.to_owned(),
             }
         })?;
         let mut key = zeroize::Zeroizing::new([0u8; 32]);
@@ -530,7 +531,7 @@ impl WasmIdentity {
         if !did.starts_with("did:dht:") {
             return Err(ScpWasmError::Identity {
                 message: format!("unsupported DID method in {did:?} — only did:dht is supported"),
-                code: "SCP-IDENT-1004".to_owned(),
+                code: codes::IDENT_1004.to_owned(),
             }
             .into_js());
         }
@@ -590,14 +591,14 @@ impl WasmIdentity {
                 message: "identity already has an agent key — remove it first or use \
                           rotateAgentKey"
                     .to_owned(),
-                code: "SCP-IDENT-1009".to_owned(),
+                code: codes::IDENT_1009.to_owned(),
             }
             .into_js());
         }
         if public_key_multibase.is_empty() {
             return Err(ScpWasmError::Identity {
                 message: "agent public key multibase string must not be empty".to_owned(),
-                code: "SCP-IDENT-1010".to_owned(),
+                code: codes::IDENT_1010.to_owned(),
             }
             .into_js());
         }
@@ -631,7 +632,7 @@ impl WasmIdentity {
         if !self.has_agent_key {
             return Err(ScpWasmError::Identity {
                 message: "identity has no agent key to remove".to_owned(),
-                code: "SCP-IDENT-1011".to_owned(),
+                code: codes::IDENT_1011.to_owned(),
             }
             .into_js());
         }
@@ -669,14 +670,14 @@ impl WasmIdentity {
         if !self.has_agent_key {
             return Err(ScpWasmError::Identity {
                 message: "identity has no agent key to rotate — use addAgentKey first".to_owned(),
-                code: "SCP-IDENT-1011".to_owned(),
+                code: codes::IDENT_1011.to_owned(),
             }
             .into_js());
         }
         if new_public_key_multibase.is_empty() {
             return Err(ScpWasmError::Identity {
                 message: "new agent public key multibase string must not be empty".to_owned(),
-                code: "SCP-IDENT-1010".to_owned(),
+                code: codes::IDENT_1010.to_owned(),
             }
             .into_js());
         }
@@ -836,7 +837,7 @@ pub fn identity_create(custody: String) -> Promise {
                     "unsupported custody type {custody:?} — only \"js_custody\" and \"in_memory\" \
                      are supported in the browser WASM bridge"
                 ),
-                code: "SCP-IDENT-1004".to_owned(),
+                code: codes::IDENT_1004.to_owned(),
             }
             .into_js()
             .into());
@@ -860,7 +861,7 @@ pub fn identity_create(custody: String) -> Promise {
                 &did,
                 WASM_IDENTITY_REGISTRY_CAP,
                 "identity registry",
-                "SCP-VALID-7400",
+                codes::VALID_7400,
             )?;
             map.insert(
                 did.clone(),
@@ -1022,7 +1023,7 @@ pub fn identity_resolve(did: String) -> Promise {
         if !did.starts_with("did:dht:") {
             return Err(ScpWasmError::Identity {
                 message: format!("unsupported DID method in {did:?} — only did:dht is supported"),
-                code: "SCP-IDENT-1004".to_owned(),
+                code: codes::IDENT_1004.to_owned(),
             }
             .into_js()
             .into());
@@ -1055,7 +1056,7 @@ pub fn identity_create_with_agent_key(custody: String) -> Promise {
                     "unsupported custody type {custody:?} — only \"js_custody\" and \"in_memory\" \
                      are supported in the browser WASM bridge"
                 ),
-                code: "SCP-IDENT-1004".to_owned(),
+                code: codes::IDENT_1004.to_owned(),
             }
             .into_js()
             .into());
@@ -1079,7 +1080,7 @@ pub fn identity_create_with_agent_key(custody: String) -> Promise {
                 &did,
                 WASM_IDENTITY_REGISTRY_CAP,
                 "identity registry",
-                "SCP-VALID-7400",
+                codes::VALID_7400,
             )?;
             map.insert(
                 did.clone(),
@@ -1115,7 +1116,7 @@ pub fn identity_add_agent_key(identity: &WasmIdentity) -> Result<WasmIdentity, J
     if identity.has_agent_key {
         return Err(ScpWasmError::Identity {
             message: "identity already has an agent key".to_owned(),
-            code: "SCP-IDENT-1009".to_owned(),
+            code: codes::IDENT_1009.to_owned(),
         }
         .into_js());
     }
@@ -1137,7 +1138,7 @@ pub fn identity_add_agent_key(identity: &WasmIdentity) -> Result<WasmIdentity, J
     if !found {
         return Err(ScpWasmError::Identity {
             message: format!("identity not found in registry: {did}"),
-            code: "SCP-IDENT-1009".to_owned(),
+            code: codes::IDENT_1009.to_owned(),
         }
         .into_js());
     }
@@ -1164,7 +1165,7 @@ pub fn identity_rotate_agent_key(identity: &WasmIdentity) -> Result<WasmIdentity
     if !identity.has_agent_key {
         return Err(ScpWasmError::Identity {
             message: "identity has no agent key to rotate".to_owned(),
-            code: "SCP-IDENT-1011".to_owned(),
+            code: codes::IDENT_1011.to_owned(),
         }
         .into_js());
     }
@@ -1186,7 +1187,7 @@ pub fn identity_rotate_agent_key(identity: &WasmIdentity) -> Result<WasmIdentity
     if !found {
         return Err(ScpWasmError::Identity {
             message: format!("identity not found in registry: {did}"),
-            code: "SCP-IDENT-1011".to_owned(),
+            code: codes::IDENT_1011.to_owned(),
         }
         .into_js());
     }
@@ -1239,7 +1240,7 @@ pub fn identity_rotate_key(identity: &WasmIdentity) -> Result<WasmIdentity, JsEr
                 &new_did,
                 WASM_IDENTITY_REGISTRY_CAP,
                 "identity registry",
-                "SCP-VALID-7400",
+                codes::VALID_7400,
             )?;
 
             map.insert(
@@ -1274,7 +1275,7 @@ pub fn identity_rotate_key(identity: &WasmIdentity) -> Result<WasmIdentity, JsEr
                 &new_did,
                 WASM_MIGRATION_LINKS_CAP,
                 "migration links registry",
-                "SCP-VALID-7401",
+                codes::VALID_7401,
             )?;
             map.insert(new_did.clone(), old_did);
             Ok::<(), JsValue>(())
@@ -1315,7 +1316,7 @@ pub fn identity_remove_agent_key(identity: &WasmIdentity) -> Result<WasmIdentity
     if !identity.has_agent_key {
         return Err(ScpWasmError::Identity {
             message: "identity has no agent key to remove".to_owned(),
-            code: "SCP-IDENT-1011".to_owned(),
+            code: codes::IDENT_1011.to_owned(),
         }
         .into_js());
     }
@@ -1335,7 +1336,7 @@ pub fn identity_remove_agent_key(identity: &WasmIdentity) -> Result<WasmIdentity
     if !found {
         return Err(ScpWasmError::Identity {
             message: format!("identity not found in registry: {did}"),
-            code: "SCP-IDENT-1011".to_owned(),
+            code: codes::IDENT_1011.to_owned(),
         }
         .into_js());
     }
@@ -1393,7 +1394,7 @@ pub fn identity_migrate(identity: &WasmIdentity) -> Promise {
                 &new_did,
                 WASM_IDENTITY_REGISTRY_CAP,
                 "identity registry",
-                "SCP-VALID-7400",
+                codes::VALID_7400,
             )?;
             map.insert(
                 new_did.clone(),
@@ -1424,7 +1425,7 @@ pub fn identity_migrate(identity: &WasmIdentity) -> Promise {
                 &new_did,
                 WASM_MIGRATION_LINKS_CAP,
                 "migration links registry",
-                "SCP-VALID-7401",
+                codes::VALID_7401,
             )?;
             map.insert(new_did.clone(), old_did);
             Ok::<(), JsValue>(())
@@ -1486,7 +1487,7 @@ pub fn identity_attest_device(did: String) -> Promise {
             let entry = map.get(&did).ok_or_else(|| -> JsValue {
                 ScpWasmError::Identity {
                     message: format!("identity {did:?} not found in registry"),
-                    code: "SCP-IDENT-1000".to_owned(),
+                    code: codes::IDENT_1000.to_owned(),
                 }
                 .into_js()
                 .into()
@@ -1507,7 +1508,7 @@ pub fn identity_attest_device(did: String) -> Promise {
         let token_json = serde_json::to_string(&token).map_err(|e| -> JsValue {
             ScpWasmError::Identity {
                 message: format!("failed to serialize attestation token: {e}"),
-                code: "SCP-IDENT-1012".to_owned(),
+                code: codes::IDENT_1012.to_owned(),
             }
             .into_js()
             .into()
@@ -1544,20 +1545,20 @@ fn parse_attestation_token(token_base64: &str) -> Result<AttestationTokenFields,
         .decode(token_base64.as_bytes())
         .map_err(|e| ScpWasmError::Identity {
             message: format!("invalid base64 in attestation token: {e}"),
-            code: "SCP-IDENT-1013".to_owned(),
+            code: codes::IDENT_1013.to_owned(),
         })?;
 
     let token: serde_json::Value =
         serde_json::from_slice(&token_bytes).map_err(|e| ScpWasmError::Identity {
             message: format!("invalid JSON in attestation token: {e}"),
-            code: "SCP-IDENT-1013".to_owned(),
+            code: codes::IDENT_1013.to_owned(),
         })?;
 
     let did = token["did"]
         .as_str()
         .ok_or_else(|| ScpWasmError::Validation {
             message: "attestation token missing required 'did' field (string)".to_owned(),
-            code: "SCP-VALID-7020".to_owned(),
+            code: codes::VALID_7020.to_owned(),
         })?
         .to_owned();
 
@@ -1565,14 +1566,14 @@ fn parse_attestation_token(token_base64: &str) -> Result<AttestationTokenFields,
         .as_u64()
         .ok_or_else(|| ScpWasmError::Validation {
             message: "attestation token missing required 'timestamp' field (u64)".to_owned(),
-            code: "SCP-VALID-7021".to_owned(),
+            code: codes::VALID_7021.to_owned(),
         })?;
 
     let signature_hex = token["signature"]
         .as_str()
         .ok_or_else(|| ScpWasmError::Validation {
             message: "attestation token missing required 'signature' field (string)".to_owned(),
-            code: "SCP-VALID-7022".to_owned(),
+            code: codes::VALID_7022.to_owned(),
         })?
         .to_owned();
 
@@ -1675,7 +1676,7 @@ pub fn identity_load(did: String) -> Promise {
         if !did.starts_with("did:dht:") {
             return Err(ScpWasmError::Identity {
                 message: format!("unsupported DID method in {did:?} — only did:dht is supported"),
-                code: "SCP-IDENT-1004".to_owned(),
+                code: codes::IDENT_1004.to_owned(),
             }
             .into_js()
             .into());
@@ -1752,7 +1753,7 @@ pub fn identity_execute_recovery(
                 message: format!(
                     "invalid compromise tier: {other}; expected 'agent', 'active_signing', or 'identity_key'"
                 ),
-                code: "SCP-IDENT-1020".to_owned(),
+                code: codes::IDENT_1020.to_owned(),
             }
             .into_js()
             .into());
@@ -1762,7 +1763,7 @@ pub fn identity_execute_recovery(
     Err(ScpWasmError::Identity {
         message: "recovery backend not configured — provide a real backend via SDK layer"
             .to_owned(),
-        code: "SCP-IDENT-1022".to_owned(),
+        code: codes::IDENT_1022.to_owned(),
     }
     .into_js()
     .into())
@@ -1795,7 +1796,7 @@ pub(crate) fn sign_with_identity(
                     "identity '{did}' not found in registry — \
                  was it created with identity_create?"
                 ),
-                code: "SCP-IDENT-1010".to_owned(),
+                code: codes::IDENT_1010.to_owned(),
             })?;
 
         let key_bytes: &[u8; 32] = match signing_key_id {
@@ -1806,7 +1807,7 @@ pub(crate) fn sign_with_identity(
                         "identity '{did}' has no agent signing key — \
                          add one with identity_add_agent_key first"
                     ),
-                    code: "SCP-IDENT-1034".to_owned(),
+                    code: codes::IDENT_1034.to_owned(),
                 }
             })?,
             _ => {
@@ -1814,7 +1815,7 @@ pub(crate) fn sign_with_identity(
                     message: format!(
                         "invalid signing_key_id '{signing_key_id}': expected '#active' or '#agent'"
                     ),
-                    code: "SCP-IDENT-1034".to_owned(),
+                    code: codes::IDENT_1034.to_owned(),
                 });
             }
         };
@@ -1865,7 +1866,7 @@ pub fn identity_execute_custody_migration(
                 message: format!(
                     "invalid custody migration target: {other}; expected 'platform_managed', 'hardware', 'software', or 'in_memory'"
                 ),
-                code: "SCP-IDENT-1024".to_owned(),
+                code: codes::IDENT_1024.to_owned(),
             }
             .into_js()
             .into());
@@ -1875,7 +1876,7 @@ pub fn identity_execute_custody_migration(
     Err(ScpWasmError::Identity {
         message: "custody migration backend not configured — provide a real backend via SDK layer"
             .to_owned(),
-        code: "SCP-IDENT-1025".to_owned(),
+        code: codes::IDENT_1025.to_owned(),
     }
     .into_js()
     .into())
@@ -1913,7 +1914,7 @@ pub fn identity_create_link_attestation(
         if let Err(e) = scp_ffi_common::validate::validate_did(&did) {
             return Err(ScpWasmError::Validation {
                 message: format!("invalid DID: {e}"),
-                code: "SCP-VALID-7033".to_owned(),
+                code: codes::VALID_7033.to_owned(),
             }
             .into_js()
             .into());
@@ -1925,7 +1926,7 @@ pub fn identity_create_link_attestation(
         {
             return Err(ScpWasmError::Validation {
                 message: format!("attestation field validation failed: {e}"),
-                code: "SCP-VALID-7037".to_owned(),
+                code: codes::VALID_7037.to_owned(),
             }
             .into_js()
             .into());
@@ -1942,7 +1943,7 @@ pub fn identity_create_link_attestation(
                         "invalid verification method: {other}; expected 'oauth', \
                          'signed_post', 'dns_record', or 'challenge_response'"
                     ),
-                    code: "SCP-IDENT-1040".to_owned(),
+                    code: codes::IDENT_1040.to_owned(),
                 }
                 .into_js()
                 .into());
@@ -2039,7 +2040,7 @@ pub fn identity_create_link_attestation(
                         "attestation structure validation failed: {}",
                         errors.join("; ")
                     ),
-                    code: "SCP-VALID-7034".to_owned(),
+                    code: codes::VALID_7034.to_owned(),
                 }
                 .into_js()
                 .into());
@@ -2055,7 +2056,7 @@ pub fn identity_create_link_attestation(
             let entry = map.get(&did).ok_or_else(|| -> JsValue {
                 ScpWasmError::Identity {
                     message: format!("identity {did:?} not found in registry"),
-                    code: "SCP-IDENT-1000".to_owned(),
+                    code: codes::IDENT_1000.to_owned(),
                 }
                 .into_js()
                 .into()
@@ -2081,7 +2082,7 @@ pub fn identity_create_link_attestation(
                 &did,
                 WASM_LINK_ATTESTATIONS_CAP,
                 "link attestation registry",
-                "SCP-VALID-7402",
+                codes::VALID_7402,
             )?;
             let entry = map.entry(did).or_default();
             if entry.len() >= MAX_IDENTITY_LINK_ATTESTATIONS_PER_DID {
@@ -2091,7 +2092,7 @@ pub fn identity_create_link_attestation(
                             "DID has reached the per-identity attestation limit \
                              ({MAX_IDENTITY_LINK_ATTESTATIONS_PER_DID}) — cannot store additional attestations"
                         ),
-                        code: "SCP-VALID-7403".to_owned(),
+                        code: codes::VALID_7403.to_owned(),
                     }
                     .into_js(),
                 ));
@@ -2103,7 +2104,7 @@ pub fn identity_create_link_attestation(
         let json = serde_json::to_string(&attestation).map_err(|e| -> JsValue {
             ScpWasmError::Identity {
                 message: format!("failed to serialize attestation: {e}"),
-                code: "SCP-IDENT-1042".to_owned(),
+                code: codes::IDENT_1042.to_owned(),
             }
             .into_js()
             .into()
@@ -2172,7 +2173,7 @@ fn attestation_required_str<'a>(
 fn attestation_err(message: String) -> JsValue {
     ScpWasmError::Identity {
         message,
-        code: "SCP-IDENT-1044".to_owned(),
+        code: codes::IDENT_1044.to_owned(),
     }
     .into_js()
     .into()
@@ -2262,7 +2263,7 @@ fn decode_attestation_public_key(issuer_public_key_hex: &str) -> Result<Option<[
     let decoded = hex::decode(issuer_public_key_hex).map_err(|e| -> JsValue {
         ScpWasmError::Validation {
             message: format!("invalid issuer_public_key_hex: {e}"),
-            code: "SCP-VALID-7032".to_owned(),
+            code: codes::VALID_7032.to_owned(),
         }
         .into_js()
         .into()
@@ -2298,7 +2299,7 @@ pub fn identity_verify_link_attestation_signature(
             serde_json::from_str(&attestation_json).map_err(|e| -> JsValue {
                 ScpWasmError::Identity {
                     message: format!("failed to parse attestation JSON: {e}"),
-                    code: "SCP-IDENT-1044".to_owned(),
+                    code: codes::IDENT_1044.to_owned(),
                 }
                 .into_js()
                 .into()
@@ -2309,7 +2310,7 @@ pub fn identity_verify_link_attestation_signature(
             .ok_or_else(|| -> JsValue {
                 ScpWasmError::Validation {
                     message: "attestation missing 'issuer' field".to_owned(),
-                    code: "SCP-VALID-7030".to_owned(),
+                    code: codes::VALID_7030.to_owned(),
                 }
                 .into_js()
                 .into()
@@ -2320,7 +2321,7 @@ pub fn identity_verify_link_attestation_signature(
         if let Err(e) = scp_ffi_common::validate::validate_did(&issuer) {
             return Err(ScpWasmError::Validation {
                 message: format!("invalid issuer DID: {e}"),
-                code: "SCP-VALID-7033".to_owned(),
+                code: codes::VALID_7033.to_owned(),
             }
             .into_js()
             .into());
@@ -2331,7 +2332,7 @@ pub fn identity_verify_link_attestation_signature(
             .ok_or_else(|| -> JsValue {
                 ScpWasmError::Validation {
                     message: "attestation missing 'signature' field".to_owned(),
-                    code: "SCP-VALID-7031".to_owned(),
+                    code: codes::VALID_7031.to_owned(),
                 }
                 .into_js()
                 .into()
@@ -2346,7 +2347,7 @@ pub fn identity_verify_link_attestation_signature(
             .map_err(|e| -> JsValue {
                 ScpWasmError::Identity {
                     message: format!("signature contains invalid bytes: {e}"),
-                    code: "SCP-IDENT-1045".to_owned(),
+                    code: codes::IDENT_1045.to_owned(),
                 }
                 .into_js()
                 .into()
@@ -2358,7 +2359,7 @@ pub fn identity_verify_link_attestation_signature(
         let sig_bytes: [u8; 64] = sig_array.try_into().map_err(|_| -> JsValue {
             ScpWasmError::Identity {
                 message: "signature must be exactly 64 bytes".to_owned(),
-                code: "SCP-IDENT-1045".to_owned(),
+                code: codes::IDENT_1045.to_owned(),
             }
             .into_js()
             .into()
@@ -2672,7 +2673,7 @@ mod tests {
                 ref code,
                 ref message,
             } => {
-                assert_eq!(code, "SCP-VALID-7020");
+                assert_eq!(code, codes::VALID_7020);
                 assert!(
                     message.contains("did"),
                     "message should mention 'did': {message}"
@@ -2694,7 +2695,7 @@ mod tests {
         let err = parse_attestation_token(&encoded).unwrap_err();
         match err {
             ScpWasmError::Validation { ref code, .. } => {
-                assert_eq!(code, "SCP-VALID-7020");
+                assert_eq!(code, codes::VALID_7020);
             }
             other => panic!("expected Validation error, got: {other:?}"),
         }
@@ -2713,7 +2714,7 @@ mod tests {
                 ref code,
                 ref message,
             } => {
-                assert_eq!(code, "SCP-VALID-7021");
+                assert_eq!(code, codes::VALID_7021);
                 assert!(
                     message.contains("timestamp"),
                     "message should mention 'timestamp': {message}"
@@ -2735,7 +2736,7 @@ mod tests {
         let err = parse_attestation_token(&encoded).unwrap_err();
         match err {
             ScpWasmError::Validation { ref code, .. } => {
-                assert_eq!(code, "SCP-VALID-7021");
+                assert_eq!(code, codes::VALID_7021);
             }
             other => panic!("expected Validation error, got: {other:?}"),
         }
@@ -2754,7 +2755,7 @@ mod tests {
                 ref code,
                 ref message,
             } => {
-                assert_eq!(code, "SCP-VALID-7022");
+                assert_eq!(code, codes::VALID_7022);
                 assert!(
                     message.contains("signature"),
                     "message should mention 'signature': {message}"
@@ -2773,7 +2774,8 @@ mod tests {
         match err {
             ScpWasmError::Validation { ref code, .. } => {
                 assert_eq!(
-                    code, "SCP-VALID-7020",
+                    code,
+                    codes::VALID_7020,
                     "first missing field should be 'did'"
                 );
             }
@@ -2786,7 +2788,7 @@ mod tests {
         let err = parse_attestation_token("not-valid-base64!!!").unwrap_err();
         match err {
             ScpWasmError::Identity { ref code, .. } => {
-                assert_eq!(code, "SCP-IDENT-1013");
+                assert_eq!(code, codes::IDENT_1013);
             }
             other => panic!("expected Identity error, got: {other:?}"),
         }
@@ -2799,7 +2801,7 @@ mod tests {
         let err = parse_attestation_token(&encoded).unwrap_err();
         match err {
             ScpWasmError::Identity { ref code, .. } => {
-                assert_eq!(code, "SCP-IDENT-1013");
+                assert_eq!(code, codes::IDENT_1013);
             }
             other => panic!("expected Identity error, got: {other:?}"),
         }
@@ -2817,7 +2819,7 @@ mod tests {
         let err = parse_attestation_token(&encoded).unwrap_err();
         match err {
             ScpWasmError::Validation { ref code, .. } => {
-                assert_eq!(code, "SCP-VALID-7020", "null 'did' should fail validation");
+                assert_eq!(code, codes::VALID_7020, "null 'did' should fail validation");
             }
             other => panic!("expected Validation error, got: {other:?}"),
         }

--- a/crates/scp-ffi/wasm/src/manager.rs
+++ b/crates/scp-ffi/wasm/src/manager.rs
@@ -25,6 +25,7 @@
 //!
 //! See ADR-034 in `.docs/adrs/phase-4.md` for the full rationale.
 
+use scp_ffi_common::error_codes as codes;
 use std::cell::RefCell;
 use std::collections::{HashMap, HashSet, VecDeque};
 
@@ -130,7 +131,7 @@ const SCP_PROTOCOL_VERSION: u16 = 0x0100;
 ///
 /// SDK consumers should switch to a native (Python / Node.js / Swift /
 /// Kotlin) bridge for any context with non-free economic policy.
-pub const SCP_ECON_PAID_POLICY_UNSUPPORTED_ON_WASM: &str = "SCP-ECON-12095";
+pub const SCP_ECON_PAID_POLICY_UNSUPPORTED_ON_WASM: &str = codes::ECON_12095;
 
 /// Stable error code rejecting `join_context` / `send_message` against a
 /// paid context from the WASM bridge.
@@ -141,7 +142,7 @@ pub const SCP_ECON_PAID_POLICY_UNSUPPORTED_ON_WASM: &str = "SCP-ECON-12095";
 /// see ADR-034 and `crates/scp-ffi/wasm/CLAUDE.md`). Accepting it would be a
 /// security lie: the SDK would tell callers their spend was authorized when
 /// it was never validated. We reject instead.
-pub const SCP_ECON_WASM_CANNOT_VALIDATE_SPENDING_UCAN: &str = "SCP-ECON-12096";
+pub const SCP_ECON_WASM_CANNOT_VALIDATE_SPENDING_UCAN: &str = codes::ECON_12096;
 
 /// Returns `true` when the JSON-serialized economic policy stored in
 /// `PerContextState::economic_policy` requires payment for any action.
@@ -758,7 +759,7 @@ fn validate_imported_string(
     if value.is_empty() {
         return Err(ScpWasmError::Context {
             message: format!("{field_name} must not be empty"),
-            code: "SCP-CTX-2032".to_owned(),
+            code: codes::CTX_2032.to_owned(),
         });
     }
     if value.len() > max_len {
@@ -767,13 +768,13 @@ fn validate_imported_string(
                 "{field_name} exceeds maximum length ({} > {max_len})",
                 value.len()
             ),
-            code: "SCP-CTX-2032".to_owned(),
+            code: codes::CTX_2032.to_owned(),
         });
     }
     if value.chars().any(char::is_control) {
         return Err(ScpWasmError::Context {
             message: format!("{field_name} contains control characters"),
-            code: "SCP-CTX-2032".to_owned(),
+            code: codes::CTX_2032.to_owned(),
         });
     }
     Ok(())
@@ -785,14 +786,14 @@ fn validate_imported_did(value: &str, field_name: &str) -> Result<(), ScpWasmErr
     if !value.starts_with("did:") {
         return Err(ScpWasmError::Context {
             message: format!("{field_name} must start with 'did:': got '{value}'"),
-            code: "SCP-CTX-2032".to_owned(),
+            code: codes::CTX_2032.to_owned(),
         });
     }
     // Must have at least did:method:id (3 colon-separated parts)
     if value.splitn(4, ':').count() < 3 {
         return Err(ScpWasmError::Context {
             message: format!("{field_name} must have format 'did:method:id': got '{value}'"),
-            code: "SCP-CTX-2032".to_owned(),
+            code: codes::CTX_2032.to_owned(),
         });
     }
     Ok(())
@@ -815,7 +816,7 @@ fn validate_imported_antispam_state(snap: &WasmContextExportSnapshot) -> Result<
                 "snapshot contains {} nonces, exceeds cap {WASM_NONCE_CAP}",
                 snap.seen_nonces_v3.len()
             ),
-            code: "SCP-CTX-2032".to_owned(),
+            code: codes::CTX_2032.to_owned(),
         });
     }
     if snap.seen_nonces_legacy_v2.len() > WASM_NONCE_CAP {
@@ -824,7 +825,7 @@ fn validate_imported_antispam_state(snap: &WasmContextExportSnapshot) -> Result<
                 "snapshot contains {} legacy nonces, exceeds cap {WASM_NONCE_CAP}",
                 snap.seen_nonces_legacy_v2.len()
             ),
-            code: "SCP-CTX-2032".to_owned(),
+            code: codes::CTX_2032.to_owned(),
         });
     }
     if snap.executed_proposals.len() > WASM_PROPOSAL_CAP {
@@ -833,7 +834,7 @@ fn validate_imported_antispam_state(snap: &WasmContextExportSnapshot) -> Result<
                 "snapshot contains {} executed proposals, exceeds cap {WASM_PROPOSAL_CAP}",
                 snap.executed_proposals.len()
             ),
-            code: "SCP-CTX-2032".to_owned(),
+            code: codes::CTX_2032.to_owned(),
         });
     }
     if snap.resolved_proposals_json.len() > WASM_RESOLVED_PROPOSAL_CAP {
@@ -842,7 +843,7 @@ fn validate_imported_antispam_state(snap: &WasmContextExportSnapshot) -> Result<
                 "snapshot contains {} resolved proposals, exceeds cap {WASM_RESOLVED_PROPOSAL_CAP}",
                 snap.resolved_proposals_json.len()
             ),
-            code: "SCP-CTX-2032".to_owned(),
+            code: codes::CTX_2032.to_owned(),
         });
     }
 
@@ -862,7 +863,7 @@ fn validate_imported_antispam_state(snap: &WasmContextExportSnapshot) -> Result<
                     "nonce '{}' has invalid inserted_at_ms={}",
                     entry.nonce, entry.inserted_at_ms
                 ),
-                code: "SCP-CTX-2032".to_owned(),
+                code: codes::CTX_2032.to_owned(),
             });
         }
     }
@@ -875,7 +876,7 @@ fn validate_imported_antispam_state(snap: &WasmContextExportSnapshot) -> Result<
                     "executed proposal '{}' has invalid executed_at_ms={}",
                     entry.proposal_id, entry.executed_at_ms
                 ),
-                code: "SCP-CTX-2032".to_owned(),
+                code: codes::CTX_2032.to_owned(),
             });
         }
     }
@@ -898,7 +899,7 @@ fn validate_imported_antispam_state(snap: &WasmContextExportSnapshot) -> Result<
         rule.validate_against_config(&import_config)
             .map_err(|e| ScpWasmError::Context {
                 message: format!("imported consequence_rules[{idx}] invalid: {e}"),
-                code: "SCP-CTX-2032".to_owned(),
+                code: codes::CTX_2032.to_owned(),
             })?;
     }
 
@@ -912,7 +913,7 @@ fn validate_imported_antispam_state(snap: &WasmContextExportSnapshot) -> Result<
                     "cooldown_until contains rule_index={rule_index} but only {} rules are declared",
                     snap.consequence_rules.len()
                 ),
-                code: "SCP-CTX-2032".to_owned(),
+                code: codes::CTX_2032.to_owned(),
             });
         }
     }
@@ -942,7 +943,7 @@ fn parse_and_check_min_protocol_version(params: &serde_json::Value) -> Result<()
                 "malformed minProtocolVersion: expected [major, minor] array with at \
                  least 2 elements, got {min_ver:?}"
             ),
-            code: "SCP-CTX-2015".to_owned(),
+            code: codes::CTX_2015.to_owned(),
         });
     }
     let raw_major = min_ver
@@ -953,13 +954,13 @@ fn parse_and_check_min_protocol_version(params: &serde_json::Value) -> Result<()
                 "malformed minProtocolVersion: major version is not a number: {:?}",
                 min_ver.first()
             ),
-            code: "SCP-CTX-2015".to_owned(),
+            code: codes::CTX_2015.to_owned(),
         })?;
     let req_major = u8::try_from(raw_major).map_err(|_| ScpWasmError::Context {
         message: format!(
             "malformed minProtocolVersion: major version {raw_major} exceeds u8 range"
         ),
-        code: "SCP-CTX-2015".to_owned(),
+        code: codes::CTX_2015.to_owned(),
     })?;
     let raw_minor = min_ver
         .get(1)
@@ -969,13 +970,13 @@ fn parse_and_check_min_protocol_version(params: &serde_json::Value) -> Result<()
                 "malformed minProtocolVersion: minor version is not a number: {:?}",
                 min_ver.get(1)
             ),
-            code: "SCP-CTX-2015".to_owned(),
+            code: codes::CTX_2015.to_owned(),
         })?;
     let req_minor = u8::try_from(raw_minor).map_err(|_| ScpWasmError::Context {
         message: format!(
             "malformed minProtocolVersion: minor version {raw_minor} exceeds u8 range"
         ),
-        code: "SCP-CTX-2015".to_owned(),
+        code: codes::CTX_2015.to_owned(),
     })?;
     let sdk_major = (SCP_PROTOCOL_VERSION >> 8) as u8;
     let sdk_minor = (SCP_PROTOCOL_VERSION & 0xFF) as u8;
@@ -989,7 +990,7 @@ fn parse_and_check_min_protocol_version(params: &serde_json::Value) -> Result<()
                 "protocol version incompatible: context requires {req_major}.{req_minor}, \
                  SDK supports {sdk_major}.{sdk_minor}"
             ),
-            code: "SCP-CTX-2016".to_owned(),
+            code: codes::CTX_2016.to_owned(),
         });
     }
     Ok(())
@@ -1151,7 +1152,7 @@ impl WasmContextManager {
             .get(context_id)
             .ok_or_else(|| ScpWasmError::Context {
                 message: format!("context '{context_id}' not found"),
-                code: "SCP-CTX-2000".to_owned(),
+                code: codes::CTX_2000.to_owned(),
             })?;
         Ok(stored_policy_requires_payment(
             ctx.economic_policy.as_deref(),
@@ -1178,7 +1179,7 @@ impl WasmContextManager {
         if self.contexts.contains_key(context_id) {
             return Err(ScpWasmError::Context {
                 message: format!("context '{context_id}' is already registered"),
-                code: "SCP-CTX-2000".to_owned(),
+                code: codes::CTX_2000.to_owned(),
             });
         }
 
@@ -1238,7 +1239,7 @@ impl WasmContextManager {
             if let Some(rules_val) = params.get("consequenceRules") {
                 serde_json::from_value(rules_val.clone()).map_err(|e| ScpWasmError::Validation {
                     message: format!("invalid consequence_rules: {e}"),
-                    code: "SCP-VALID-7000".to_owned(),
+                    code: codes::VALID_7000.to_owned(),
                 })?
             } else {
                 Vec::new()
@@ -1252,7 +1253,7 @@ impl WasmContextManager {
             rule.validate_against_config(&consequence_config)
                 .map_err(|e| ScpWasmError::Validation {
                     message: format!("consequence rule validation failed: {e}"),
-                    code: "SCP-VALID-7000".to_owned(),
+                    code: codes::VALID_7000.to_owned(),
                 })?;
         }
 
@@ -1268,14 +1269,14 @@ impl WasmContextManager {
                 BroadcastContext::new(context_id.to_owned(), &ContextMode::Broadcast, admission)
                     .map_err(|e| ScpWasmError::Context {
                         message: format!("broadcast context creation failed: {e}"),
-                        code: "SCP-CTX-2001".to_owned(),
+                        code: codes::CTX_2001.to_owned(),
                     })?;
             // Register creator as initial author.
             let _ = bc
                 .add_author(creator_did)
                 .map_err(|e| ScpWasmError::Context {
                     message: format!("failed to add creator as author: {e}"),
-                    code: "SCP-CTX-2001".to_owned(),
+                    code: codes::CTX_2001.to_owned(),
                 })?;
             Some(bc)
         } else {
@@ -1288,7 +1289,7 @@ impl WasmContextManager {
                 crate::crypto::WasmCryptoState::new_for_context(creator_did).map_err(|e| {
                     ScpWasmError::Crypto {
                         message: format!("MLS group creation failed: {e}"),
-                        code: "SCP-CRYPTO-4004".to_owned(),
+                        code: codes::CRYPTO_4004.to_owned(),
                     }
                 })?,
             )
@@ -1408,7 +1409,7 @@ impl WasmContextManager {
         if ctx.members.contains_key(member_did) {
             return Err(ScpWasmError::Context {
                 message: format!("member '{member_did}' already joined context '{context_id}'"),
-                code: "SCP-CTX-2013".to_owned(),
+                code: codes::CTX_2013.to_owned(),
             });
         }
 
@@ -1446,7 +1447,7 @@ impl WasmContextManager {
         if ctx.members.remove(member_did).is_none() {
             return Err(ScpWasmError::Context {
                 message: format!("member '{member_did}' not found in context '{context_id}'"),
-                code: "SCP-CTX-2015".to_owned(),
+                code: codes::CTX_2015.to_owned(),
             });
         }
 
@@ -1533,7 +1534,7 @@ impl WasmContextManager {
         {
             return Err(ScpWasmError::Permission {
                 message: format!("write access has been suspended for {sender_did}"),
-                code: "SCP-PERM-3000".to_owned(),
+                code: codes::PERM_3000.to_owned(),
             });
         }
 
@@ -1543,7 +1544,7 @@ impl WasmContextManager {
             .get_mut(sender_did)
             .ok_or_else(|| ScpWasmError::Context {
                 message: format!("sender '{sender_did}' is not a member of context '{context_id}'"),
-                code: "SCP-CTX-2019".to_owned(),
+                code: codes::CTX_2019.to_owned(),
             })?;
 
         let seq = member.sequence_number;
@@ -1555,19 +1556,19 @@ impl WasmContextManager {
                 .decode(payload_base64)
                 .map_err(|e| ScpWasmError::Crypto {
                     message: format!("invalid base64 payload: {e}"),
-                    code: "SCP-CRYPTO-4001".to_owned(),
+                    code: codes::CRYPTO_4001.to_owned(),
                 })?;
 
             let epoch = crypto.mls_group.epoch().map_err(|e| ScpWasmError::Crypto {
                 message: format!("failed to read MLS epoch: {e}"),
-                code: "SCP-CRYPTO-4002".to_owned(),
+                code: codes::CRYPTO_4002.to_owned(),
             })?;
 
             let ciphertext = crypto
                 .encrypt_message(&raw_bytes, context_id, sender_did, epoch, seq)
                 .map_err(|e| ScpWasmError::Crypto {
                     message: format!("encryption failed: {e}"),
-                    code: "SCP-CRYPTO-4003".to_owned(),
+                    code: codes::CRYPTO_4003.to_owned(),
                 })?;
 
             base64::engine::general_purpose::STANDARD.encode(&ciphertext)
@@ -1619,7 +1620,7 @@ impl WasmContextManager {
         if !ctx.member_has_capability(initiator_did, "context:close") {
             return Err(ScpWasmError::Permission {
                 message: format!("member {initiator_did} does not have context:close capability"),
-                code: "SCP-PERM-3000".to_owned(),
+                code: codes::PERM_3000.to_owned(),
             });
         }
 
@@ -1661,21 +1662,21 @@ impl WasmContextManager {
 
         let crypto = ctx.crypto.as_mut().ok_or_else(|| ScpWasmError::Crypto {
             message: "context has no MLS encryption state".to_string(),
-            code: "SCP-CRYPTO-4010".to_owned(),
+            code: codes::CRYPTO_4010.to_owned(),
         })?;
 
         let ciphertext = base64::engine::general_purpose::STANDARD
             .decode(ciphertext_base64)
             .map_err(|e| ScpWasmError::Crypto {
                 message: format!("invalid base64 ciphertext: {e}"),
-                code: "SCP-CRYPTO-4001".to_owned(),
+                code: codes::CRYPTO_4001.to_owned(),
             })?;
 
         crypto
             .decrypt_message(&ciphertext, context_id, sender_did, epoch, sequence)
             .map_err(|e| ScpWasmError::Crypto {
                 message: format!("decryption failed: {e}"),
-                code: "SCP-CRYPTO-4011".to_owned(),
+                code: codes::CRYPTO_4011.to_owned(),
             })
     }
 
@@ -1700,14 +1701,14 @@ impl WasmContextManager {
         )
         .map_err(|e| ScpWasmError::Crypto {
             message: format!("credential creation failed: {e}"),
-            code: "SCP-CRYPTO-4020".to_owned(),
+            code: codes::CRYPTO_4020.to_owned(),
         })?;
 
         let (kp_bytes, holder) =
             crate::crypto::group::WasmMlsGroup::generate_key_package(&credential).map_err(|e| {
                 ScpWasmError::Crypto {
                     message: format!("key package generation failed: {e}"),
-                    code: "SCP-CRYPTO-4022".to_owned(),
+                    code: codes::CRYPTO_4022.to_owned(),
                 }
             })?;
 
@@ -1744,7 +1745,7 @@ impl WasmContextManager {
                     "no pending key package for '{member_did}' in context '{context_id}' — \
                      call generate_key_package_for_join first"
                 ),
-                code: "SCP-CRYPTO-4023".to_owned(),
+                code: codes::CRYPTO_4023.to_owned(),
             })?;
 
         // First join the context normally (membership, events, etc.).
@@ -1757,7 +1758,7 @@ impl WasmContextManager {
             crate::crypto::group::WasmMlsGroup::join_from_welcome(welcome_bytes, holder).map_err(
                 |e| ScpWasmError::Crypto {
                     message: format!("MLS welcome processing failed: {e}"),
-                    code: "SCP-CRYPTO-4021".to_owned(),
+                    code: codes::CRYPTO_4021.to_owned(),
                 },
             )?;
 
@@ -1835,7 +1836,7 @@ impl WasmContextManager {
             .get_mut(context_id)
             .ok_or_else(|| ScpWasmError::Context {
                 message: format!("context '{context_id}' not found"),
-                code: "SCP-CTX-2060".to_owned(),
+                code: codes::CTX_2060.to_owned(),
             })?;
 
         ctx.append_log_event(event_type, actor_did, prov_hash);
@@ -1876,7 +1877,7 @@ impl WasmContextManager {
         crate::runtime::tool_registry_insert_unique(&mut ctx.tool_registry, registration).map_err(
             |e| ScpWasmError::Tool {
                 message: e,
-                code: "SCP-TOOL-6001".to_owned(),
+                code: codes::TOOL_6001.to_owned(),
             },
         )?;
 
@@ -1918,7 +1919,7 @@ impl WasmContextManager {
                     "tool '{tool_id}' not found in context '{context_id}' \
                      -- register the tool before adding a handler"
                 ),
-                code: "SCP-TOOL-6002".to_owned(),
+                code: codes::TOOL_6002.to_owned(),
             });
         }
 
@@ -1947,14 +1948,14 @@ impl WasmContextManager {
             .get(tool_id)
             .ok_or_else(|| ScpWasmError::Tool {
                 message: format!("tool '{tool_id}' not found in context '{context_id}'"),
-                code: "SCP-TOOL-6002".to_owned(),
+                code: codes::TOOL_6002.to_owned(),
             })?;
 
         // Validate input against the tool's input schema.
         validate_value_against_schema(input_json, &registration.schema.input_schema).map_err(
             |e| ScpWasmError::Tool {
                 message: format!("input schema validation failed for tool '{tool_id}': {e}"),
-                code: "SCP-TOOL-6002".to_owned(),
+                code: codes::TOOL_6002.to_owned(),
             },
         )?;
 
@@ -1964,13 +1965,13 @@ impl WasmContextManager {
         let result = if let Some(handler) = ctx.tool_handlers.get(tool_id) {
             let out = handler(input_json.clone()).map_err(|e| ScpWasmError::Tool {
                 message: format!("tool handler for '{tool_id}' failed: {e}"),
-                code: "SCP-TOOL-6002".to_owned(),
+                code: codes::TOOL_6002.to_owned(),
             })?;
 
             validate_value_against_schema(&out, &output_schema).map_err(|msg| {
                 ScpWasmError::Tool {
                     message: format!("output validation failed for tool '{tool_id}': {msg}"),
-                    code: "SCP-TOOL-6002".to_owned(),
+                    code: codes::TOOL_6002.to_owned(),
                 }
             })?;
 
@@ -2005,7 +2006,7 @@ impl WasmContextManager {
             .get(tool_id)
             .ok_or_else(|| ScpWasmError::Tool {
                 message: format!("tool '{tool_id}' not found in context '{context_id}'"),
-                code: "SCP-TOOL-6003".to_owned(),
+                code: codes::TOOL_6003.to_owned(),
             })?;
 
         // Verify test vectors by validating inputs against the input schema.
@@ -2071,7 +2072,7 @@ impl WasmContextManager {
                 message: format!(
                     "cross-context chain depth {chain_depth} exceeds maximum {max_chain_depth}"
                 ),
-                code: "SCP-TOOL-6012".to_owned(),
+                code: codes::TOOL_6012.to_owned(),
             });
         }
 
@@ -2083,13 +2084,13 @@ impl WasmContextManager {
                 message: format!(
                     "tool '{tool_id}' not found in target context '{target_context_id}'"
                 ),
-                code: "SCP-TOOL-6003".to_owned(),
+                code: codes::TOOL_6003.to_owned(),
             })?;
 
         validate_value_against_schema(input, &registration.schema.input_schema).map_err(|e| {
             ScpWasmError::Tool {
                 message: format!("input validation failed: {e}"),
-                code: "SCP-TOOL-6002".to_owned(),
+                code: codes::TOOL_6002.to_owned(),
             }
         })?;
 
@@ -2099,13 +2100,13 @@ impl WasmContextManager {
         let result = if let Some(handler) = target.tool_handlers.get(tool_id) {
             let out = handler(input.clone()).map_err(|e| ScpWasmError::Tool {
                 message: format!("cross-context tool handler for '{tool_id}' failed: {e}"),
-                code: "SCP-TOOL-6002".to_owned(),
+                code: codes::TOOL_6002.to_owned(),
             })?;
 
             validate_value_against_schema(&out, &output_schema).map_err(|msg| {
                 ScpWasmError::Tool {
                     message: format!("output validation failed for tool '{tool_id}': {msg}"),
-                    code: "SCP-TOOL-6002".to_owned(),
+                    code: codes::TOOL_6002.to_owned(),
                 }
             })?;
 
@@ -2154,7 +2155,7 @@ impl WasmContextManager {
                     "global session cap exceeded: {} active (max {WASM_SESSION_GLOBAL_CAP})",
                     ctx.sessions.len()
                 ),
-                code: "SCP-TOOL-6015".to_owned(),
+                code: codes::TOOL_6015.to_owned(),
             });
         }
 
@@ -2176,7 +2177,7 @@ impl WasmContextManager {
                 message: format!(
                     "session cap exceeded for caller '{source_context_id}': {current} active (max {session_cap})"
                 ),
-                code: "SCP-TOOL-6015".to_owned(),
+                code: codes::TOOL_6015.to_owned(),
             });
         }
 
@@ -2217,14 +2218,14 @@ impl WasmContextManager {
             .get(session_id)
             .ok_or_else(|| ScpWasmError::Tool {
                 message: format!("session '{session_id}' not found"),
-                code: "SCP-TOOL-6018".to_owned(),
+                code: codes::TOOL_6018.to_owned(),
             })?;
 
         if session.is_expired() {
             ctx.sessions.remove(session_id);
             return Err(ScpWasmError::Tool {
                 message: format!("session '{session_id}' has expired"),
-                code: "SCP-TOOL-6019".to_owned(),
+                code: codes::TOOL_6019.to_owned(),
             });
         }
 
@@ -2237,7 +2238,7 @@ impl WasmContextManager {
             validate_value_against_schema(input, &registration.schema.input_schema).map_err(
                 |e| ScpWasmError::Tool {
                     message: format!("input validation failed: {e}"),
-                    code: "SCP-TOOL-6002".to_owned(),
+                    code: codes::TOOL_6002.to_owned(),
                 },
             )?;
         }
@@ -2246,7 +2247,7 @@ impl WasmContextManager {
         let (new_state, output) = if let Some(handler) = ctx.tool_handlers.get(&tool_id) {
             let out = handler(input.clone()).map_err(|e| ScpWasmError::Tool {
                 message: format!("tool handler for '{tool_id}' failed: {e}"),
-                code: "SCP-TOOL-6002".to_owned(),
+                code: codes::TOOL_6002.to_owned(),
             })?;
             (current_state, out)
         } else {
@@ -2289,7 +2290,7 @@ impl WasmContextManager {
             .get(session_id)
             .ok_or_else(|| ScpWasmError::Tool {
                 message: format!("session '{session_id}' not found"),
-                code: "SCP-TOOL-6018".to_owned(),
+                code: codes::TOOL_6018.to_owned(),
             })?;
         Ok(session.tool_id.clone())
     }
@@ -2309,7 +2310,7 @@ impl WasmContextManager {
         if ctx.sessions.remove(session_id).is_none() {
             return Err(ScpWasmError::Tool {
                 message: format!("session '{session_id}' not found"),
-                code: "SCP-TOOL-6021".to_owned(),
+                code: codes::TOOL_6021.to_owned(),
             });
         }
 
@@ -2350,7 +2351,7 @@ impl WasmContextManager {
         let proof =
             prove_inclusion(&ctx.event_log, leaf_index).map_err(|e| ScpWasmError::Context {
                 message: format!("inclusion proof failed: {e}"),
-                code: "SCP-CTX-2007".to_owned(),
+                code: codes::CTX_2007.to_owned(),
             })?;
 
         let verified = verify_inclusion(&proof);
@@ -2394,7 +2395,7 @@ impl WasmContextManager {
         let proof =
             prove_absence(&ctx.event_log, event_hash).map_err(|e| ScpWasmError::Context {
                 message: format!("absence proof failed: {e}"),
-                code: "SCP-CTX-2007".to_owned(),
+                code: codes::CTX_2007.to_owned(),
             })?;
 
         Ok(serde_json::json!({
@@ -2465,7 +2466,7 @@ impl WasmContextManager {
         if ctx.seen_nonces.contains_key(nonce) {
             return Err(ScpWasmError::Permission {
                 message: format!("nonce reused: {nonce}"),
-                code: "SCP-PERM-3000".to_owned(),
+                code: codes::PERM_3000.to_owned(),
             });
         }
 
@@ -2480,7 +2481,7 @@ impl WasmContextManager {
                     message: format!(
                         "nonce tracker full: capacity {WASM_NONCE_CAP} reached and no expired entries to evict"
                     ),
-                    code: "SCP-PERM-3000".to_owned(),
+                    code: codes::PERM_3000.to_owned(),
                 });
             }
         }
@@ -2520,7 +2521,7 @@ impl WasmContextManager {
                     "revoked token set has reached capacity ({WASM_REVOKED_TOKENS_CAP}) — \
                      cannot revoke additional tokens"
                 ),
-                code: "SCP-VALID-7300".to_owned(),
+                code: codes::VALID_7300.to_owned(),
             });
         }
 
@@ -2619,7 +2620,7 @@ impl WasmContextManager {
                     message: format!(
                         "member {initiator_did} does not have '{required}' capability required for this governance action"
                     ),
-                    code: "SCP-PERM-3000".to_owned(),
+                    code: codes::PERM_3000.to_owned(),
                 });
             }
         }
@@ -2632,7 +2633,7 @@ impl WasmContextManager {
             if ctx.executed_proposals.contains_key(proposal_id) {
                 return Err(ScpWasmError::Permission {
                     message: "governance proposal has already been executed".to_owned(),
-                    code: "SCP-PERM-3000".to_owned(),
+                    code: codes::PERM_3000.to_owned(),
                 });
             }
 
@@ -2725,7 +2726,7 @@ impl WasmContextManager {
                 let did_str: &str = did;
                 let member = ctx.members.get_mut(did_str).ok_or_else(|| ScpWasmError::Context {
                     message: format!("member '{did}' not found"),
-                    code: "SCP-CTX-2015".to_owned(),
+                    code: codes::CTX_2015.to_owned(),
                 })?;
                 let old_role = member.role.clone();
                 new_role.clone_into(&mut member.role);
@@ -2754,7 +2755,7 @@ impl WasmContextManager {
                 if ctx.tool_registry.remove(tool_id).is_none() {
                     return Err(ScpWasmError::Tool {
                         message: format!("tool '{tool_id}' not found"),
-                        code: "SCP-TOOL-6003".to_owned(),
+                        code: codes::TOOL_6003.to_owned(),
                     });
                 }
                 Ok(serde_json::json!({"action": "RemoveTool", "toolId": tool_id}))
@@ -2764,7 +2765,7 @@ impl WasmContextManager {
                 if ctx.ceiling_policy != "governed" {
                     return Err(ScpWasmError::Permission {
                         message: "ceiling is immutable — cannot modify".to_owned(),
-                        code: "SCP-PERM-3000".to_owned(),
+                        code: codes::PERM_3000.to_owned(),
                     });
                 }
                 ctx.ceiling_strings = new_ceiling.iter().map(|c| Self::capability_to_ucan_format(&c.name())).collect();
@@ -2823,7 +2824,7 @@ impl WasmContextManager {
                     "member list has reached capacity ({WASM_MEMBER_CAP}) — \
                      cannot add additional members"
                 ),
-                code: "SCP-VALID-7302".to_owned(),
+                code: codes::VALID_7302.to_owned(),
             });
         }
 
@@ -2863,7 +2864,7 @@ impl WasmContextManager {
             .remove(did)
             .ok_or_else(|| ScpWasmError::Context {
                 message: format!("member '{did}' not found"),
-                code: "SCP-CTX-2015".to_owned(),
+                code: codes::CTX_2015.to_owned(),
             })?;
         // If the ejected member was an author in a broadcast context,
         // clean up their broadcast state (destroys broadcast key).
@@ -3021,7 +3022,7 @@ impl WasmContextManager {
                             "per-author block list has reached capacity ({WASM_BLOCK_LIST_CAP}) \
                              for author '{author_did}' during governance ban"
                         ),
-                        code: "SCP-VALID-7301".to_owned(),
+                        code: codes::VALID_7301.to_owned(),
                     });
                 }
             }
@@ -3096,7 +3097,7 @@ impl WasmContextManager {
                 if ctx.promotion_policy.as_deref() != Some("Promotable") {
                     return Err(ScpWasmError::Permission {
                         message: "context promotion_policy is not Promotable".to_owned(),
-                        code: "SCP-PERM-3000".to_owned(),
+                        code: codes::PERM_3000.to_owned(),
                     });
                 }
                 // Promote: cancel TTL (§5.10).
@@ -3122,13 +3123,13 @@ impl WasmContextManager {
                 if !ctx.members.contains_key(did_str) {
                     return Err(ScpWasmError::Context {
                         message: format!("member '{did}' not found"),
-                        code: "SCP-CTX-2015".to_owned(),
+                        code: codes::CTX_2015.to_owned(),
                     });
                 }
                 if ctx.threshold_signers.contains(&did_str.to_owned()) {
                     return Err(ScpWasmError::Permission {
                         message: format!("DID is already a signer: {did}"),
-                        code: "SCP-PERM-3000".to_owned(),
+                        code: codes::PERM_3000.to_owned(),
                     });
                 }
                 ctx.threshold_signers.push(did_str.to_owned());
@@ -3145,7 +3146,7 @@ impl WasmContextManager {
                         message: format!(
                             "threshold must be 1..={signer_count}, got {new_threshold}"
                         ),
-                        code: "SCP-PERM-3000".to_owned(),
+                        code: codes::PERM_3000.to_owned(),
                     });
                 }
                 ctx.threshold_value = *new_threshold;
@@ -3312,7 +3313,7 @@ impl WasmContextManager {
         if ctx.economic_policy_locked {
             return Err(ScpWasmError::Permission {
                 message: "economic policy is locked and cannot be changed".to_owned(),
-                code: "SCP-PERM-3000".to_owned(),
+                code: codes::PERM_3000.to_owned(),
             });
         }
         // Store as JSON string for WASM-local state.
@@ -3341,7 +3342,7 @@ impl WasmContextManager {
                 if !ctx.members.contains_key(spender_str) {
                     return Err(ScpWasmError::Context {
                         message: format!("spender '{spender}' is not a member"),
-                        code: "SCP-CTX-2015".to_owned(),
+                        code: codes::CTX_2015.to_owned(),
                     });
                 }
                 Ok(serde_json::json!({
@@ -3356,13 +3357,13 @@ impl WasmContextManager {
                 if ctx.economic_policy.is_none() {
                     return Err(ScpWasmError::Permission {
                         message: "cannot lock economic policy: no policy is set".to_owned(),
-                        code: "SCP-PERM-3000".to_owned(),
+                        code: codes::PERM_3000.to_owned(),
                     });
                 }
                 if ctx.economic_policy_locked {
                     return Err(ScpWasmError::Permission {
                         message: "economic policy is already locked".to_owned(),
-                        code: "SCP-PERM-3000".to_owned(),
+                        code: codes::PERM_3000.to_owned(),
                     });
                 }
                 ctx.economic_policy_locked = true;
@@ -3373,7 +3374,7 @@ impl WasmContextManager {
                 // proposal cannot corrupt the persisted config.
                 new_config.validate().map_err(|e| ScpWasmError::Context {
                     message: format!("ModifyHardRateLimit: new config failed validation: {e}"),
-                    code: "SCP-ECON-12091".to_owned(),
+                    code: codes::ECON_12091.to_owned(),
                 })?;
                 let ctx = self.require_active_context_mut(context_id)?;
                 // WASM bridge stores the config as an opaque JSON blob
@@ -3441,7 +3442,7 @@ impl WasmContextManager {
                 message: format!(
                     "invalid resolution: must be 'invalidateBoth' or one of the proposal IDs, got '{resolution}'"
                 ),
-                code: "SCP-PERM-3000".to_owned(),
+                code: codes::PERM_3000.to_owned(),
             });
         }
 
@@ -3477,7 +3478,7 @@ impl WasmContextManager {
         if !ctx.members.contains_key(did) {
             return Err(ScpWasmError::Context {
                 message: format!("member '{did}' not found"),
-                code: "SCP-CTX-2015".to_owned(),
+                code: codes::CTX_2015.to_owned(),
             });
         }
         // Member reset: remove + re-add with same role (ADR-029 §Tier 3).
@@ -3508,13 +3509,13 @@ impl WasmContextManager {
         if changes_json.is_empty() {
             return Err(ScpWasmError::Permission {
                 message: "reconfigure_governance requires at least one change".to_owned(),
-                code: "SCP-PERM-3000".to_owned(),
+                code: codes::PERM_3000.to_owned(),
             });
         }
         if justification.is_empty() {
             return Err(ScpWasmError::Permission {
                 message: "deadlock justification must not be empty".to_owned(),
-                code: "SCP-PERM-3000".to_owned(),
+                code: codes::PERM_3000.to_owned(),
             });
         }
         // Clear governance freeze as the reconfiguration resolves it.
@@ -3550,7 +3551,7 @@ impl WasmContextManager {
         crate::runtime::tool_registry_insert_unique(&mut ctx.tool_registry, reg).map_err(|e| {
             ScpWasmError::Tool {
                 message: e,
-                code: "SCP-TOOL-6001".to_owned(),
+                code: codes::TOOL_6001.to_owned(),
             }
         })?;
         Ok(serde_json::json!({"action": "RegisterTool", "toolId": tool_id}))
@@ -3568,7 +3569,7 @@ impl WasmContextManager {
         if ctx.threshold_signers.len() == before {
             return Err(ScpWasmError::Context {
                 message: format!("signer '{did}' not found"),
-                code: "SCP-CTX-2015".to_owned(),
+                code: codes::CTX_2015.to_owned(),
             });
         }
         // Reject if removing would make threshold > signers.len().
@@ -3582,7 +3583,7 @@ impl WasmContextManager {
                         "removing signer would leave {remaining} signers < threshold {}",
                         ctx.threshold_value
                     ),
-                    code: "SCP-PERM-3000".to_owned(),
+                    code: codes::PERM_3000.to_owned(),
                 });
             }
         }
@@ -3638,7 +3639,7 @@ impl WasmContextManager {
                     message: format!(
                         "member {proposer_did} does not have 'governance:propose' capability"
                     ),
-                    code: "SCP-CTX-2041".to_owned(),
+                    code: codes::CTX_2041.to_owned(),
                 });
             }
         }
@@ -3651,7 +3652,7 @@ impl WasmContextManager {
             {
                 return Err(ScpWasmError::Context {
                     message: format!("proposal {proposal_id} already exists"),
-                    code: "SCP-CTX-2041".to_owned(),
+                    code: codes::CTX_2041.to_owned(),
                 });
             }
         }
@@ -3785,7 +3786,7 @@ impl WasmContextManager {
                     message: format!(
                         "member {voter_did} does not have 'governance:vote' capability"
                     ),
-                    code: "SCP-CTX-2042".to_owned(),
+                    code: codes::CTX_2042.to_owned(),
                 });
             }
         }
@@ -3805,14 +3806,14 @@ impl WasmContextManager {
             let proposal = ctx.pending_proposals.get_mut(proposal_id).ok_or_else(|| {
                 ScpWasmError::Context {
                     message: format!("proposal {proposal_id} not found"),
-                    code: "SCP-CTX-2042".to_owned(),
+                    code: codes::CTX_2042.to_owned(),
                 }
             })?;
 
             if proposal.voting_deadline <= now_secs {
                 return Err(ScpWasmError::Context {
                     message: "proposal voting deadline has expired".to_owned(),
-                    code: "SCP-CTX-2042".to_owned(),
+                    code: codes::CTX_2042.to_owned(),
                 });
             }
 
@@ -3828,7 +3829,7 @@ impl WasmContextManager {
             {
                 return Err(ScpWasmError::Permission {
                     message: format!("member {voter_did} has already voted on this proposal"),
-                    code: "SCP-CTX-2042".to_owned(),
+                    code: codes::CTX_2042.to_owned(),
                 });
             }
 
@@ -3897,7 +3898,7 @@ impl WasmContextManager {
                     message: format!(
                         "member {voter_did} does not have 'governance:vote' capability"
                     ),
-                    code: "SCP-CTX-2043".to_owned(),
+                    code: codes::CTX_2043.to_owned(),
                 });
             }
         }
@@ -3916,14 +3917,14 @@ impl WasmContextManager {
             let proposal = ctx.pending_proposals.get_mut(proposal_id).ok_or_else(|| {
                 ScpWasmError::Context {
                     message: format!("proposal {proposal_id} not found"),
-                    code: "SCP-CTX-2043".to_owned(),
+                    code: codes::CTX_2043.to_owned(),
                 }
             })?;
 
             if proposal.voting_deadline <= now_secs {
                 return Err(ScpWasmError::Context {
                     message: "proposal voting deadline has expired".to_owned(),
-                    code: "SCP-CTX-2043".to_owned(),
+                    code: codes::CTX_2043.to_owned(),
                 });
             }
 
@@ -3938,7 +3939,7 @@ impl WasmContextManager {
             {
                 return Err(ScpWasmError::Permission {
                     message: format!("member {voter_did} has already voted on this proposal"),
-                    code: "SCP-CTX-2043".to_owned(),
+                    code: codes::CTX_2043.to_owned(),
                 });
             }
 
@@ -3999,7 +4000,7 @@ impl WasmContextManager {
                 .get_mut(proposal_id)
                 .ok_or_else(|| ScpWasmError::Context {
                     message: format!("proposal {proposal_id} not found"),
-                    code: "SCP-CTX-2044".to_owned(),
+                    code: codes::CTX_2044.to_owned(),
                 })?;
 
         let was_approval = proposal
@@ -4018,7 +4019,7 @@ impl WasmContextManager {
         } else {
             return Err(ScpWasmError::Permission {
                 message: format!("member {voter_did} has not voted on proposal {proposal_id}"),
-                code: "SCP-CTX-2044".to_owned(),
+                code: codes::CTX_2044.to_owned(),
             });
         }
 
@@ -4046,7 +4047,7 @@ impl WasmContextManager {
             .get(context_id)
             .ok_or_else(|| ScpWasmError::Context {
                 message: format!("context {context_id} not found"),
-                code: "SCP-CTX-2045".to_owned(),
+                code: codes::CTX_2045.to_owned(),
             })?;
 
         let proposal = ctx
@@ -4055,7 +4056,7 @@ impl WasmContextManager {
             .or_else(|| ctx.resolved_proposals.get(proposal_id))
             .ok_or_else(|| ScpWasmError::Context {
                 message: format!("proposal {proposal_id} not found"),
-                code: "SCP-CTX-2045".to_owned(),
+                code: codes::CTX_2045.to_owned(),
             })?;
 
         Ok(Self::proposal_to_json(proposal_id, proposal))
@@ -4072,7 +4073,7 @@ impl WasmContextManager {
             .get(context_id)
             .ok_or_else(|| ScpWasmError::Context {
                 message: format!("context {context_id} not found"),
-                code: "SCP-CTX-2046".to_owned(),
+                code: codes::CTX_2046.to_owned(),
             })?;
 
         let proposals: Vec<serde_json::Value> = ctx
@@ -4169,7 +4170,7 @@ impl WasmContextManager {
             .as_mut()
             .ok_or_else(|| ScpWasmError::Context {
                 message: "not a broadcast context".to_owned(),
-                code: "SCP-CTX-2001".to_owned(),
+                code: codes::CTX_2001.to_owned(),
             })?;
 
         // Use subscribe with no UCAN (open admission) for WASM bridge.
@@ -4217,7 +4218,7 @@ impl WasmContextManager {
         {
             return Err(ScpWasmError::Permission {
                 message: format!("write access has been suspended for {author_did}"),
-                code: "SCP-PERM-3000".to_owned(),
+                code: codes::PERM_3000.to_owned(),
             });
         }
 
@@ -4226,13 +4227,13 @@ impl WasmContextManager {
             .as_ref()
             .ok_or_else(|| ScpWasmError::Context {
                 message: "not a broadcast context".to_owned(),
-                code: "SCP-CTX-2001".to_owned(),
+                code: codes::CTX_2001.to_owned(),
             })?;
 
         if !bc.is_author(author_did) {
             return Err(ScpWasmError::Permission {
                 message: format!("'{author_did}' is not an author in this broadcast context"),
-                code: "SCP-PERM-3000".to_owned(),
+                code: codes::PERM_3000.to_owned(),
             });
         }
 
@@ -4242,7 +4243,7 @@ impl WasmContextManager {
             .get_mut(author_did)
             .ok_or_else(|| ScpWasmError::Context {
                 message: format!("author '{author_did}' not found in members"),
-                code: "SCP-CTX-2019".to_owned(),
+                code: codes::CTX_2019.to_owned(),
             })?;
         let seq = member.sequence_number;
         member.sequence_number += 1;
@@ -4288,13 +4289,13 @@ impl WasmContextManager {
         let normalized_path =
             validate_content_path_wasm(path).map_err(|msg| ScpWasmError::Context {
                 message: format!("invalid path: {msg}"),
-                code: "SCP-CTX-2070".to_owned(),
+                code: codes::CTX_2070.to_owned(),
             })?;
 
         // Validate content_type (delegates to scp-protocol MimeType).
         validate_mime_type_wasm(content_type).map_err(|msg| ScpWasmError::Context {
             message: format!("invalid content_type: {msg}"),
-            code: "SCP-CTX-2071".to_owned(),
+            code: codes::CTX_2071.to_owned(),
         })?;
 
         // Auto-generate deploy_id when None, matching batch behavior.
@@ -4316,7 +4317,7 @@ impl WasmContextManager {
         // Validate deploy_id.
         validate_deploy_id_wasm(deploy_id_resolved).map_err(|msg| ScpWasmError::Context {
             message: format!("invalid deploy_id: {msg}"),
-            code: "SCP-CTX-2072".to_owned(),
+            code: codes::CTX_2072.to_owned(),
         })?;
 
         // Body size limit — reject oversized payloads before serialization.
@@ -4326,7 +4327,7 @@ impl WasmContextManager {
                     "body too large: {} bytes (max {MAX_BODY_BYTES})",
                     body.len()
                 ),
-                code: "SCP-CTX-2075".to_owned(),
+                code: codes::CTX_2075.to_owned(),
             });
         }
 
@@ -4348,7 +4349,7 @@ impl WasmContextManager {
         )
         .map_err(|msg| ScpWasmError::Context {
             message: format!("broadcast content serialization failed: {msg}"),
-            code: "SCP-CTX-2073".to_owned(),
+            code: codes::CTX_2073.to_owned(),
         })?;
 
         // Base64-encode the wire bytes for the publish_broadcast path.
@@ -4391,7 +4392,7 @@ impl WasmContextManager {
                     "batch too large: {} assets (max {MAX_BATCH_ASSETS})",
                     assets.len()
                 ),
-                code: "SCP-CTX-2074".to_owned(),
+                code: codes::CTX_2074.to_owned(),
             });
         }
 
@@ -4443,7 +4444,7 @@ impl WasmContextManager {
             .as_mut()
             .ok_or_else(|| ScpWasmError::Context {
                 message: "not a broadcast context".to_owned(),
-                code: "SCP-CTX-2001".to_owned(),
+                code: codes::CTX_2001.to_owned(),
             })?;
 
         let _ = bc.unsubscribe(subscriber_did, false);
@@ -4481,7 +4482,7 @@ impl WasmContextManager {
                 .as_mut()
                 .ok_or_else(|| ScpWasmError::Context {
                     message: "not a broadcast context".to_owned(),
-                    code: "SCP-CTX-2001".to_owned(),
+                    code: codes::CTX_2001.to_owned(),
                 })?;
 
             // Pre-validate block list capacity.
@@ -4494,7 +4495,7 @@ impl WasmContextManager {
                         "per-author block list has reached capacity ({WASM_BLOCK_LIST_CAP}) \
                          for author '{blocker_did}'"
                     ),
-                    code: "SCP-VALID-7301".to_owned(),
+                    code: codes::VALID_7301.to_owned(),
                 });
             }
 
@@ -4504,7 +4505,7 @@ impl WasmContextManager {
                 .block_subscriber(blocker_did, subscriber_did)
                 .map_err(|e| ScpWasmError::Context {
                     message: format!("block_subscriber failed: {e}"),
-                    code: "SCP-CTX-2001".to_owned(),
+                    code: codes::CTX_2001.to_owned(),
                 })?;
             new_epoch = block_result.new_epoch;
         }
@@ -4551,7 +4552,7 @@ impl WasmContextManager {
                 .as_mut()
                 .ok_or_else(|| ScpWasmError::Context {
                     message: "not a broadcast context".to_owned(),
-                    code: "SCP-CTX-2001".to_owned(),
+                    code: codes::CTX_2001.to_owned(),
                 })?;
 
             // Per-author unblocking (§5.14.8): remove from the unblocker's
@@ -4560,7 +4561,7 @@ impl WasmContextManager {
             bc.unblock_subscriber(unblocker_did, subscriber_did)
                 .map_err(|e| ScpWasmError::Context {
                     message: e.to_string(),
-                    code: "SCP-CTX-2001".to_owned(),
+                    code: codes::CTX_2001.to_owned(),
                 })?;
         }
 
@@ -4637,7 +4638,7 @@ impl WasmContextManager {
             .get(context_id)
             .ok_or_else(|| ScpWasmError::Context {
                 message: format!("context not registered: {context_id}"),
-                code: "SCP-CTX-2001".to_owned(),
+                code: codes::CTX_2001.to_owned(),
             })?;
 
         let bc = ctx
@@ -4645,7 +4646,7 @@ impl WasmContextManager {
             .as_ref()
             .ok_or_else(|| ScpWasmError::Context {
                 message: "not a broadcast context".to_owned(),
-                code: "SCP-CTX-2001".to_owned(),
+                code: codes::CTX_2001.to_owned(),
             })?;
 
         // Delegate to BroadcastContext::handle_key_request which implements
@@ -4686,7 +4687,7 @@ impl WasmContextManager {
                       (propose SetEconomicPolicy action). Direct mutation is \
                       not permitted — see spec §19.3"
                 .to_owned(),
-            code: "SCP-CTX-2013".to_owned(),
+            code: codes::CTX_2013.to_owned(),
         })
     }
 
@@ -4728,7 +4729,7 @@ impl WasmContextManager {
             || {
                 Err(ScpWasmError::Context {
                     message: "context has no TTL configured".to_owned(),
-                    code: "SCP-CTX-2001".to_owned(),
+                    code: codes::CTX_2001.to_owned(),
                 })
             },
             |ttl| {
@@ -4776,7 +4777,7 @@ impl WasmContextManager {
         if !self.is_member(context_id, proposer_did) {
             return Err(ScpWasmError::Context {
                 message: format!("DID '{proposer_did}' is not a member of context '{context_id}'"),
-                code: "SCP-CTX-2005".to_owned(),
+                code: codes::CTX_2005.to_owned(),
             });
         }
         self.extend_ttl(context_id, extension_secs)
@@ -4937,7 +4938,7 @@ impl WasmContextManager {
                 message: format!(
                     "context '{context_id}' not found — was it created with context_create?"
                 ),
-                code: "SCP-CTX-2001".to_owned(),
+                code: codes::CTX_2001.to_owned(),
             })
     }
 
@@ -4950,7 +4951,7 @@ impl WasmContextManager {
                     "context '{context_id}' is in '{0}' state — must be 'active'",
                     ctx.state
                 ),
-                code: "SCP-CTX-2002".to_owned(),
+                code: codes::CTX_2002.to_owned(),
             });
         }
         Ok(ctx)
@@ -4966,7 +4967,7 @@ impl WasmContextManager {
                 message: format!(
                     "context '{context_id}' not found — was it created with context_create?"
                 ),
-                code: "SCP-CTX-2001".to_owned(),
+                code: codes::CTX_2001.to_owned(),
             })
     }
 
@@ -4982,7 +4983,7 @@ impl WasmContextManager {
                     "context '{context_id}' is in '{0}' state — must be 'active'",
                     ctx.state
                 ),
-                code: "SCP-CTX-2013".to_owned(),
+                code: codes::CTX_2013.to_owned(),
             });
         }
         Ok(ctx)
@@ -5118,7 +5119,7 @@ impl WasmContextManager {
         let snapshot_json =
             serde_json_canonicalizer::to_vec(&snapshot).map_err(|e| ScpWasmError::Context {
                 message: format!("export snapshot serialization failed: {e}"),
-                code: "SCP-CTX-2030".to_owned(),
+                code: codes::CTX_2030.to_owned(),
             })?;
 
         // Compute HMAC-SHA256 over the snapshot JSON using the creator's
@@ -5140,7 +5141,7 @@ impl WasmContextManager {
 
         serde_json::to_vec(&envelope).map_err(|e| ScpWasmError::Context {
             message: format!("export serialization failed: {e}"),
-            code: "SCP-CTX-2030".to_owned(),
+            code: codes::CTX_2030.to_owned(),
         })
     }
 
@@ -5155,7 +5156,7 @@ impl WasmContextManager {
         let envelope: WasmContextExportEnvelope =
             serde_json::from_slice(data).map_err(|e| ScpWasmError::Context {
                 message: format!("invalid export data: {e}"),
-                code: "SCP-CTX-2032".to_owned(),
+                code: codes::CTX_2032.to_owned(),
             })?;
 
         if envelope.version > WASM_EXPORT_VERSION {
@@ -5164,7 +5165,7 @@ impl WasmContextManager {
                     "incompatible export version: got {}, max supported is {WASM_EXPORT_VERSION}",
                     envelope.version
                 ),
-                code: "SCP-CTX-2032".to_owned(),
+                code: codes::CTX_2032.to_owned(),
             });
         }
 
@@ -5175,7 +5176,7 @@ impl WasmContextManager {
         let snapshot_json = serde_json_canonicalizer::to_vec(&envelope.snapshot).map_err(|e| {
             ScpWasmError::Context {
                 message: format!("snapshot re-serialization failed: {e}"),
-                code: "SCP-CTX-2032".to_owned(),
+                code: codes::CTX_2032.to_owned(),
             }
         })?;
 
@@ -5183,7 +5184,7 @@ impl WasmContextManager {
             return Err(ScpWasmError::Context {
                 message: "export integrity_mac is missing — refusing to import unsigned export"
                     .to_owned(),
-                code: "SCP-CTX-2020".to_owned(),
+                code: codes::CTX_2020.to_owned(),
             });
         }
 
@@ -5224,7 +5225,7 @@ impl WasmContextManager {
             if m.role.is_empty() || m.role.len() > 64 {
                 return Err(ScpWasmError::Context {
                     message: format!("invalid member role '{}': must be 1-64 chars", m.role),
-                    code: "SCP-CTX-2032".to_owned(),
+                    code: codes::CTX_2032.to_owned(),
                 });
             }
         }
@@ -5235,7 +5236,7 @@ impl WasmContextManager {
                     "invalid context state '{}': must be one of {valid_states:?}",
                     snap.state
                 ),
-                code: "SCP-CTX-2032".to_owned(),
+                code: codes::CTX_2032.to_owned(),
             });
         }
 
@@ -5254,7 +5255,7 @@ impl WasmContextManager {
                 message: format!(
                     "context '{context_id}' already exists — cannot import over existing context"
                 ),
-                code: "SCP-CTX-2000".to_owned(),
+                code: codes::CTX_2000.to_owned(),
             });
         }
 
@@ -5449,7 +5450,7 @@ impl WasmContextManager {
                     "context '{context_id}' is in '{}' state — must be 'closing' to finalize",
                     ctx.state
                 ),
-                code: "SCP-CTX-2061".to_owned(),
+                code: codes::CTX_2061.to_owned(),
             });
         }
 
@@ -5553,7 +5554,7 @@ impl WasmContextManager {
             message: "context restoration is not supported in the WASM bridge — \
                       WASM contexts are ephemeral (ADR-034)"
                 .to_owned(),
-            code: "SCP-CTX-2064".to_owned(),
+            code: codes::CTX_2064.to_owned(),
         })
     }
 
@@ -5569,7 +5570,7 @@ impl WasmContextManager {
             message: "context restoration is not supported in the WASM bridge — \
                       WASM contexts are ephemeral (ADR-034)"
                 .to_owned(),
-            code: "SCP-CTX-2065".to_owned(),
+            code: codes::CTX_2065.to_owned(),
         })
     }
 }
@@ -6251,7 +6252,7 @@ mod tests {
                 message.contains("bogus-value"),
                 "message should include the bad value: {message}"
             );
-            assert_eq!(code, "SCP-PERM-3000");
+            assert_eq!(code, codes::PERM_3000);
         }
     }
 
@@ -6276,7 +6277,7 @@ mod tests {
         let params = serde_json::json!({ "minProtocolVersion": [1, 99] });
         let err = parse_and_check_min_protocol_version(&params).unwrap_err();
         assert!(
-            matches!(err, ScpWasmError::Context { ref code, .. } if code == "SCP-CTX-2016"),
+            matches!(err, ScpWasmError::Context { ref code, .. } if code == codes::CTX_2016),
             "expected SCP-CTX-2016, got: {err:?}"
         );
     }
@@ -6286,7 +6287,7 @@ mod tests {
         let params = serde_json::json!({ "minProtocolVersion": [2, 0] });
         let err = parse_and_check_min_protocol_version(&params).unwrap_err();
         assert!(
-            matches!(err, ScpWasmError::Context { ref code, .. } if code == "SCP-CTX-2016"),
+            matches!(err, ScpWasmError::Context { ref code, .. } if code == codes::CTX_2016),
             "expected SCP-CTX-2016, got: {err:?}"
         );
     }
@@ -6297,7 +6298,7 @@ mod tests {
         let params = serde_json::json!({ "minProtocolVersion": ["2", "0"] });
         let err = parse_and_check_min_protocol_version(&params).unwrap_err();
         assert!(
-            matches!(err, ScpWasmError::Context { ref code, .. } if code == "SCP-CTX-2015"),
+            matches!(err, ScpWasmError::Context { ref code, .. } if code == codes::CTX_2015),
             "expected SCP-CTX-2015, got: {err:?}"
         );
     }
@@ -6308,7 +6309,7 @@ mod tests {
         let params = serde_json::json!({ "minProtocolVersion": [1, "0"] });
         let err = parse_and_check_min_protocol_version(&params).unwrap_err();
         assert!(
-            matches!(err, ScpWasmError::Context { ref code, .. } if code == "SCP-CTX-2015"),
+            matches!(err, ScpWasmError::Context { ref code, .. } if code == codes::CTX_2015),
             "expected SCP-CTX-2015, got: {err:?}"
         );
     }
@@ -6318,7 +6319,7 @@ mod tests {
         let params = serde_json::json!({ "minProtocolVersion": [1] });
         let err = parse_and_check_min_protocol_version(&params).unwrap_err();
         assert!(
-            matches!(err, ScpWasmError::Context { ref code, .. } if code == "SCP-CTX-2015"),
+            matches!(err, ScpWasmError::Context { ref code, .. } if code == codes::CTX_2015),
             "expected SCP-CTX-2015, got: {err:?}"
         );
     }
@@ -6328,7 +6329,7 @@ mod tests {
         let params = serde_json::json!({ "minProtocolVersion": [256, 0] });
         let err = parse_and_check_min_protocol_version(&params).unwrap_err();
         assert!(
-            matches!(err, ScpWasmError::Context { ref code, .. } if code == "SCP-CTX-2015"),
+            matches!(err, ScpWasmError::Context { ref code, .. } if code == codes::CTX_2015),
             "expected SCP-CTX-2015, got: {err:?}"
         );
     }
@@ -6641,7 +6642,7 @@ mod tests {
 
         match &err {
             ScpWasmError::Validation { code, message } => {
-                assert_eq!(code, "SCP-VALID-7301");
+                assert_eq!(code, codes::VALID_7301);
                 assert!(
                     message.contains("during governance ban"),
                     "expected 'during governance ban' in message, got: {message}"
@@ -6769,7 +6770,7 @@ mod tests {
             "expected Validation error, got: {err:?}"
         );
         if let ScpWasmError::Validation { ref code, .. } = err {
-            assert_eq!(code, "SCP-VALID-7300");
+            assert_eq!(code, codes::VALID_7300);
         }
     }
 
@@ -6786,7 +6787,7 @@ mod tests {
 
         match &err {
             ScpWasmError::Context { message, code } => {
-                assert_eq!(code, "SCP-CTX-2001");
+                assert_eq!(code, codes::CTX_2001);
                 assert!(
                     message.contains(subscriber),
                     "error should contain subscriber DID, got: {message}"
@@ -6893,7 +6894,7 @@ mod tests {
 
         match &err {
             ScpWasmError::Validation { code, .. } => {
-                assert_eq!(code, "SCP-VALID-7301");
+                assert_eq!(code, codes::VALID_7301);
             }
             other => panic!("expected Validation error, got: {other:?}"),
         }
@@ -6995,7 +6996,7 @@ mod tests {
                 ref message,
                 ref code,
             } => {
-                assert_eq!(code, "SCP-CTX-2032");
+                assert_eq!(code, codes::CTX_2032);
                 assert!(
                     message.contains("exceeds cap"),
                     "unexpected message: {message}"
@@ -7018,7 +7019,7 @@ mod tests {
                 ref message,
                 ref code,
             } => {
-                assert_eq!(code, "SCP-CTX-2032");
+                assert_eq!(code, codes::CTX_2032);
                 assert!(message.contains("legacy nonces"));
             }
             other => panic!("expected Context error, got: {other:?}"),
@@ -7041,7 +7042,7 @@ mod tests {
                 ref message,
                 ref code,
             } => {
-                assert_eq!(code, "SCP-CTX-2032");
+                assert_eq!(code, codes::CTX_2032);
                 assert!(message.contains("executed proposals"));
             }
             other => panic!("expected Context error, got: {other:?}"),
@@ -7062,7 +7063,7 @@ mod tests {
                 ref message,
                 ref code,
             } => {
-                assert_eq!(code, "SCP-CTX-2032");
+                assert_eq!(code, codes::CTX_2032);
                 assert!(message.contains("resolved proposals"));
             }
             other => panic!("expected Context error, got: {other:?}"),
@@ -7083,7 +7084,7 @@ mod tests {
                 ref message,
                 ref code,
             } => {
-                assert_eq!(code, "SCP-CTX-2032");
+                assert_eq!(code, codes::CTX_2032);
                 assert!(message.contains("corrupt-nonce"));
                 assert!(message.contains("inserted_at_ms"));
             }
@@ -7154,7 +7155,7 @@ mod tests {
                 ref message,
                 ref code,
             } => {
-                assert_eq!(code, "SCP-CTX-2032");
+                assert_eq!(code, codes::CTX_2032);
                 assert!(message.contains("cooldown_until"));
             }
             other => panic!("expected Context error, got: {other:?}"),
@@ -7249,7 +7250,7 @@ mod tests {
                 ref message,
             } => {
                 assert_eq!(code, SCP_ECON_PAID_POLICY_UNSUPPORTED_ON_WASM);
-                assert_eq!(code, "SCP-ECON-12095");
+                assert_eq!(code, codes::ECON_12095);
                 assert!(
                     message.contains("EconomicPolicyUnsupportedOnWasm"),
                     "expected EconomicPolicyUnsupportedOnWasm marker, got: {message}"
@@ -7344,7 +7345,7 @@ mod tests {
                 ref message,
             } => {
                 assert_eq!(code, SCP_ECON_WASM_CANNOT_VALIDATE_SPENDING_UCAN);
-                assert_eq!(code, "SCP-ECON-12096");
+                assert_eq!(code, codes::ECON_12096);
                 assert!(
                     message.contains("WasmCannotValidateSpendingUcan"),
                     "expected WasmCannotValidateSpendingUcan marker, got: {message}"
@@ -7359,7 +7360,7 @@ mod tests {
             .expect_err("join_context must reject paid context even without spending UCAN");
         match err {
             ScpWasmError::Context { ref code, .. } => {
-                assert_eq!(code, "SCP-ECON-12096");
+                assert_eq!(code, codes::ECON_12096);
             }
             other => panic!("expected Context error, got: {other:?}"),
         }
@@ -7403,7 +7404,7 @@ mod tests {
                 ref code,
                 ref message,
             } => {
-                assert_eq!(code, "SCP-ECON-12096");
+                assert_eq!(code, codes::ECON_12096);
                 assert!(message.contains("WasmCannotValidateSpendingUcan"));
             }
             other => panic!("expected Context error, got: {other:?}"),
@@ -7415,7 +7416,7 @@ mod tests {
             .expect_err("send_message must reject paid context even without spending UCAN");
         match err {
             ScpWasmError::Context { ref code, .. } => {
-                assert_eq!(code, "SCP-ECON-12096");
+                assert_eq!(code, codes::ECON_12096);
             }
             other => panic!("expected Context error, got: {other:?}"),
         }
@@ -7459,12 +7460,14 @@ mod tests {
         match err {
             ScpWasmError::Context { ref code, .. } => {
                 assert_eq!(
-                    code, "SCP-CTX-2019",
+                    code,
+                    codes::CTX_2019,
                     "free context must NOT trigger the C2 economy gate; \
                      non-member should hit the membership check instead"
                 );
                 assert_ne!(
-                    code, "SCP-ECON-12096",
+                    code,
+                    codes::ECON_12096,
                     "free context must NOT be rejected by the C2 economy gate"
                 );
             }
@@ -7483,7 +7486,7 @@ mod tests {
             .expect_err("non-member with UCAN must still reach membership check");
         match err {
             ScpWasmError::Context { ref code, .. } => {
-                assert_eq!(code, "SCP-CTX-2019");
+                assert_eq!(code, codes::CTX_2019);
             }
             other => panic!("expected Context error, got: {other:?}"),
         }
@@ -7533,7 +7536,7 @@ mod tests {
                 ref code,
                 ref message,
             } => {
-                assert_eq!(code, "SCP-ECON-12095");
+                assert_eq!(code, codes::ECON_12095);
                 assert!(message.contains("EconomicPolicyUnsupportedOnWasm"));
             }
             other => panic!("expected Context error, got: {other:?}"),

--- a/crates/scp-ffi/wasm/src/reference_verify.rs
+++ b/crates/scp-ffi/wasm/src/reference_verify.rs
@@ -21,6 +21,7 @@
 //! See spec §3.5.2 for the verification protocol.
 
 use js_sys::Promise;
+use scp_ffi_common::error_codes as codes;
 use wasm_bindgen::prelude::*;
 use wasm_bindgen_futures::{JsFuture, future_to_promise};
 
@@ -449,7 +450,7 @@ pub fn verify_reference_attestation(attestation_json: String) -> Promise {
                              via fetch — use WebCrypto in the TypeScript wrapper layer",
                         input.method
                     ),
-                    code: "SCP-ATTEST-9010".to_owned(),
+                    code: codes::ATTEST_9010.to_owned(),
                 }
                 .into_js()
                 .into());

--- a/crates/scp-ffi/wasm/src/scpid.rs
+++ b/crates/scp-ffi/wasm/src/scpid.rs
@@ -19,6 +19,7 @@
 //! See spec §3.11 and the `scp-runtime` `scpid` module for the canonical
 //! async implementation.
 
+use scp_ffi_common::error_codes as codes;
 use scp_protocol::crypto::canonical::{CanonicalField, canonical_hash};
 use scp_protocol::identity::SigningKeyId;
 use scp_protocol::identity::scpid::{
@@ -62,7 +63,7 @@ pub fn scpid_challenge(audience: String, ttl_seconds: u32) -> Result<String, JsE
     if ttl_ms == 0 {
         return Err(ScpWasmError::Validation {
             message: "TTL must be greater than zero".to_owned(),
-            code: "SCP-IDENT-1038".to_owned(),
+            code: codes::IDENT_1038.to_owned(),
         }
         .into_js());
     }
@@ -70,7 +71,7 @@ pub fn scpid_challenge(audience: String, ttl_seconds: u32) -> Result<String, JsE
     if ttl_ms > MAX_TTL_MS {
         return Err(ScpWasmError::Validation {
             message: "TTL exceeds 300 seconds".to_owned(),
-            code: "SCP-IDENT-1038".to_owned(),
+            code: codes::IDENT_1038.to_owned(),
         }
         .into_js());
     }
@@ -78,7 +79,7 @@ pub fn scpid_challenge(audience: String, ttl_seconds: u32) -> Result<String, JsE
     if audience.is_empty() {
         return Err(ScpWasmError::Validation {
             message: "audience must not be empty".to_owned(),
-            code: "SCP-IDENT-1038".to_owned(),
+            code: codes::IDENT_1038.to_owned(),
         }
         .into_js());
     }
@@ -86,7 +87,7 @@ pub fn scpid_challenge(audience: String, ttl_seconds: u32) -> Result<String, JsE
     if audience.len() > MAX_AUDIENCE_BYTES {
         return Err(ScpWasmError::Validation {
             message: "audience exceeds 2048 bytes".to_owned(),
-            code: "SCP-IDENT-1038".to_owned(),
+            code: codes::IDENT_1038.to_owned(),
         }
         .into_js());
     }
@@ -96,7 +97,7 @@ pub fn scpid_challenge(audience: String, ttl_seconds: u32) -> Result<String, JsE
     getrandom::getrandom(&mut nonce).map_err(|e| {
         ScpWasmError::Identity {
             message: format!("CSPRNG failure: {e}"),
-            code: "SCP-IDENT-1037".to_owned(),
+            code: codes::IDENT_1037.to_owned(),
         }
         .into_js()
     })?;
@@ -115,7 +116,7 @@ pub fn scpid_challenge(audience: String, ttl_seconds: u32) -> Result<String, JsE
     serde_json::to_string(&challenge).map_err(|e| {
         ScpWasmError::Identity {
             message: format!("failed to serialize SCPID challenge: {e}"),
-            code: "SCP-IDENT-1037".to_owned(),
+            code: codes::IDENT_1037.to_owned(),
         }
         .into_js()
     })
@@ -154,7 +155,7 @@ pub fn scpid_sign(
                 message: format!(
                     "invalid signing_key_id '{other}': expected '#active' or '#agent'"
                 ),
-                code: "SCP-IDENT-1034".to_owned(),
+                code: codes::IDENT_1034.to_owned(),
             }
             .into_js());
         }
@@ -164,7 +165,7 @@ pub fn scpid_sign(
     let challenge: ScpIdChallenge = serde_json::from_str(&challenge_json).map_err(|e| {
         ScpWasmError::Validation {
             message: format!("invalid challenge JSON: {e}"),
-            code: "SCP-IDENT-1038".to_owned(),
+            code: codes::IDENT_1038.to_owned(),
         }
         .into_js()
     })?;
@@ -176,7 +177,7 @@ pub fn scpid_sign(
                 "unsupported protocol: {}, expected {SCPID_PROTOCOL_VERSION}",
                 challenge.protocol
             ),
-            code: "SCP-IDENT-1038".to_owned(),
+            code: codes::IDENT_1038.to_owned(),
         }
         .into_js());
     }
@@ -186,7 +187,7 @@ pub fn scpid_sign(
     if now_ms > challenge.expires_at {
         return Err(ScpWasmError::Identity {
             message: "challenge expired".to_owned(),
-            code: "SCP-IDENT-1030".to_owned(),
+            code: codes::IDENT_1030.to_owned(),
         }
         .into_js());
     }
@@ -195,7 +196,7 @@ pub fn scpid_sign(
     if did.is_empty() {
         return Err(ScpWasmError::Validation {
             message: "DID must not be empty".to_owned(),
-            code: "SCP-IDENT-1038".to_owned(),
+            code: codes::IDENT_1038.to_owned(),
         }
         .into_js());
     }
@@ -231,7 +232,7 @@ pub fn scpid_sign(
     serde_json::to_string(&response).map_err(|e| {
         ScpWasmError::Identity {
             message: format!("failed to serialize SCPID response: {e}"),
-            code: "SCP-IDENT-1037".to_owned(),
+            code: codes::IDENT_1037.to_owned(),
         }
         .into_js()
     })

--- a/crates/scp-ffi/wasm/src/sync.rs
+++ b/crates/scp-ffi/wasm/src/sync.rs
@@ -11,6 +11,7 @@
 //!
 //! See ADR-029 in `.docs/adrs/phase-6.md`.
 
+use scp_ffi_common::error_codes as codes;
 use scp_protocol::sync::{OfflineTier, SyncPolicy};
 use wasm_bindgen::prelude::*;
 
@@ -30,7 +31,7 @@ fn validate_non_negative_timestamp(value: f64, name: &str) -> Result<u64, ScpWas
     if value < 0.0 || !value.is_finite() {
         return Err(ScpWasmError::Validation {
             message: format!("{name} must be non-negative, got {value}"),
-            code: "SCP-VALID-7040".to_owned(),
+            code: codes::VALID_7040.to_owned(),
         });
     }
     #[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
@@ -175,6 +176,7 @@ pub fn sync_classify_offline_custom(
 #[allow(clippy::unwrap_used)]
 mod tests {
     use super::*;
+    use scp_ffi_common::error_codes as codes;
 
     // -----------------------------------------------------------------------
     // classify (pure logic — no wasm-bindgen dependency)
@@ -342,7 +344,7 @@ mod tests {
         let err = result.unwrap_err();
         let msg = format!("{err}");
         assert!(
-            msg.contains("SCP-VALID-7040"),
+            msg.contains(codes::VALID_7040),
             "error should contain SCP-VALID-7040, got: {msg}"
         );
     }

--- a/crates/scp-ffi/wasm/src/tools.rs
+++ b/crates/scp-ffi/wasm/src/tools.rs
@@ -6,6 +6,7 @@
 //! See ADR-034 in `.docs/adrs/phase-4.md` and issue #389.
 
 use js_sys::Promise;
+use scp_ffi_common::error_codes as codes;
 use wasm_bindgen::prelude::*;
 use wasm_bindgen_futures::future_to_promise;
 
@@ -69,8 +70,8 @@ fn validate_schema_field(
     field_name: &str,
 ) -> Result<serde_json::Value, ScpWasmError> {
     let code = match field_name {
-        "schema" => "SCP-VALID-7035",
-        _ => "SCP-VALID-7036",
+        "schema" => codes::VALID_7035,
+        _ => codes::VALID_7036,
     };
 
     let schema = def
@@ -120,7 +121,7 @@ fn validate_test_vectors(
 
     let arr = tv_val.as_array().ok_or_else(|| ScpWasmError::Validation {
         message: "testVectors must be an array".to_owned(),
-        code: "SCP-VALID-7037".to_owned(),
+        code: codes::VALID_7037.to_owned(),
     })?;
 
     arr.iter()
@@ -128,7 +129,7 @@ fn validate_test_vectors(
         .map(|(i, v)| {
             let input = v.get("input").ok_or_else(|| ScpWasmError::Validation {
                 message: format!("testVectors[{i}] missing required 'input' field"),
-                code: "SCP-VALID-7037".to_owned(),
+                code: codes::VALID_7037.to_owned(),
             })?;
             let expected_output =
                 v.get("expectedOutput")
@@ -136,7 +137,7 @@ fn validate_test_vectors(
                         message: format!(
                             "testVectors[{i}] missing required 'expectedOutput' field"
                         ),
-                        code: "SCP-VALID-7037".to_owned(),
+                        code: codes::VALID_7037.to_owned(),
                     })?;
             let description = match v.get("description") {
                 Some(d) => d
@@ -146,13 +147,13 @@ fn validate_test_vectors(
                             "testVectors[{i}] invalid 'description': expected a string, got {}",
                             json_value_type_name(d)
                         ),
-                        code: "SCP-VALID-7037".to_owned(),
+                        code: codes::VALID_7037.to_owned(),
                     })?
                     .to_owned(),
                 None => {
                     return Err(ScpWasmError::Validation {
                         message: format!("testVectors[{i}] missing required 'description' field"),
-                        code: "SCP-VALID-7037".to_owned(),
+                        code: codes::VALID_7037.to_owned(),
                     });
                 }
             };
@@ -183,7 +184,7 @@ fn parse_provenance_fields(def: &serde_json::Value) -> Result<ProvenanceFields, 
             let bytes = hex::decode(hex_str).map_err(|e| {
                 ScpWasmError::Validation {
                     message: format!("invalid 'implementationHash': invalid hex: {e}"),
-                    code: "SCP-VALID-7038".to_owned(),
+                    code: codes::VALID_7038.to_owned(),
                 }
                 .into_js()
             })?;
@@ -193,7 +194,7 @@ fn parse_provenance_fields(def: &serde_json::Value) -> Result<ProvenanceFields, 
                         "invalid 'implementationHash': must be exactly 32 bytes, got {}",
                         bytes.len()
                     ),
-                    code: "SCP-VALID-7038".to_owned(),
+                    code: codes::VALID_7038.to_owned(),
                 }
                 .into_js()
             })?
@@ -209,7 +210,7 @@ fn parse_provenance_fields(def: &serde_json::Value) -> Result<ProvenanceFields, 
                 .map_err(|e| {
                     ScpWasmError::Validation {
                         message: format!("invalid 'signature': invalid base64: {e}"),
-                        code: "SCP-VALID-7038".to_owned(),
+                        code: codes::VALID_7038.to_owned(),
                     }
                     .into_js()
                 })?
@@ -225,7 +226,7 @@ fn parse_provenance_fields(def: &serde_json::Value) -> Result<ProvenanceFields, 
                 .ok_or_else(|| {
                     ScpWasmError::Validation {
                         message: "invalid 'cost': missing or non-numeric 'amount'".to_owned(),
-                        code: "SCP-VALID-7038".to_owned(),
+                        code: codes::VALID_7038.to_owned(),
                     }
                     .into_js()
                 })?;
@@ -235,7 +236,7 @@ fn parse_provenance_fields(def: &serde_json::Value) -> Result<ProvenanceFields, 
                 .ok_or_else(|| {
                     ScpWasmError::Validation {
                         message: "invalid 'cost': missing or non-string 'currency'".to_owned(),
-                        code: "SCP-VALID-7038".to_owned(),
+                        code: codes::VALID_7038.to_owned(),
                     }
                     .into_js()
                 })?
@@ -246,7 +247,7 @@ fn parse_provenance_fields(def: &serde_json::Value) -> Result<ProvenanceFields, 
                 .ok_or_else(|| {
                     ScpWasmError::Validation {
                         message: "invalid 'cost': missing or non-string 'payee'".to_owned(),
-                        code: "SCP-VALID-7038".to_owned(),
+                        code: codes::VALID_7038.to_owned(),
                     }
                     .into_js()
                 })?
@@ -360,7 +361,7 @@ pub fn tool_register(context: &WasmContextHandle, definition_json: String) -> Pr
         let def: serde_json::Value = serde_json::from_str(&definition_json).map_err(|e| {
             ScpWasmError::Validation {
                 message: format!("definition_json is not valid JSON: {e}"),
-                code: "SCP-VALID-7000".to_owned(),
+                code: codes::VALID_7000.to_owned(),
             }
             .into_js()
         })?;
@@ -371,7 +372,7 @@ pub fn tool_register(context: &WasmContextHandle, definition_json: String) -> Pr
             .ok_or_else(|| {
                 ScpWasmError::Validation {
                     message: "definition_json missing required 'name' field".to_owned(),
-                    code: "SCP-VALID-7000".to_owned(),
+                    code: codes::VALID_7000.to_owned(),
                 }
                 .into_js()
             })?
@@ -388,7 +389,7 @@ pub fn tool_register(context: &WasmContextHandle, definition_json: String) -> Pr
                             "invalid 'description': expected a string, got {}",
                             json_value_type_name(v)
                         ),
-                        code: "SCP-VALID-7000".to_owned(),
+                        code: codes::VALID_7000.to_owned(),
                     }
                     .into_js()
                 })?
@@ -470,7 +471,7 @@ pub fn tool_invoke(
                     message: "WASM bridge cannot enforce tool payment for paid contexts. \
                               Use a native (Python/Node/Swift/Kotlin) client for paid tools."
                         .to_owned(),
-                    code: "SCP-ECON-12096".to_owned(),
+                    code: codes::ECON_12096.to_owned(),
                 }
                 .into_js()
                 .into())
@@ -483,7 +484,7 @@ pub fn tool_invoke(
                 message: "WASM bridge cannot validate spending UCANs for tool invocations. \
                           Use a native (Python/Node/Swift/Kotlin) client for paid tools."
                     .to_owned(),
-                code: "SCP-ECON-12096".to_owned(),
+                code: codes::ECON_12096.to_owned(),
             }
             .into_js()
             .into())
@@ -510,7 +511,7 @@ pub fn tool_invoke(
                     .map_err(|e| {
                     ScpWasmError::Permission {
                         message: format!("UCAN authorization failed for tool '{tool_id}': {e}"),
-                        code: "SCP-PERM-3000".to_owned(),
+                        code: codes::PERM_3000.to_owned(),
                     }
                     .into_js()
                 })?;
@@ -519,7 +520,7 @@ pub fn tool_invoke(
                 return Err(JsValue::from(
                     ScpWasmError::Validation {
                         message: "ucan_token is required for tool invocation".to_owned(),
-                        code: "SCP-VALID-7000".to_owned(),
+                        code: codes::VALID_7000.to_owned(),
                     }
                     .into_js(),
                 ));
@@ -529,7 +530,7 @@ pub fn tool_invoke(
         let parsed_input: serde_json::Value = serde_json::from_str(&input_json).map_err(|e| {
             ScpWasmError::Validation {
                 message: format!("input_json is not valid JSON: {e}"),
-                code: "SCP-VALID-7000".to_owned(),
+                code: codes::VALID_7000.to_owned(),
             }
             .into_js()
         })?;
@@ -542,7 +543,7 @@ pub fn tool_invoke(
         let json_str = serde_json::to_string(&result).map_err(|e| {
             ScpWasmError::Tool {
                 message: format!("failed to serialize tool output: {e}"),
-                code: "SCP-TOOL-6002".to_owned(),
+                code: codes::TOOL_6002.to_owned(),
             }
             .into_js()
         })?;
@@ -568,7 +569,7 @@ pub fn tool_verify(context: &WasmContextHandle, tool_id: String) -> Promise {
         let failures_json = serde_json::to_string(&failures).map_err(|e| {
             ScpWasmError::Tool {
                 message: format!("failed to serialize verification failures: {e}"),
-                code: "SCP-TOOL-6003".to_owned(),
+                code: codes::TOOL_6003.to_owned(),
             }
             .into_js()
         })?;
@@ -611,7 +612,7 @@ pub fn tool_invoke_cross_context(
         if ucan_token.is_empty() {
             return Err(ScpWasmError::Validation {
                 message: "ucan_token is required for cross-context tool invocation".to_owned(),
-                code: "SCP-VALID-7000".to_owned(),
+                code: codes::VALID_7000.to_owned(),
             }
             .into_js()
             .into());
@@ -622,7 +623,7 @@ pub fn tool_invoke_cross_context(
                     message: format!(
                         "UCAN authorization failed for cross-context tool '{tool_id}': {e}"
                     ),
-                    code: "SCP-PERM-3000".to_owned(),
+                    code: codes::PERM_3000.to_owned(),
                 }
                 .into_js()
             })?;
@@ -630,7 +631,7 @@ pub fn tool_invoke_cross_context(
         let input: serde_json::Value = serde_json::from_str(&input_json).map_err(|e| {
             ScpWasmError::Validation {
                 message: format!("input_json is not valid JSON: {e}"),
-                code: "SCP-VALID-7000".to_owned(),
+                code: codes::VALID_7000.to_owned(),
             }
             .into_js()
         })?;
@@ -650,7 +651,7 @@ pub fn tool_invoke_cross_context(
         let json_str = serde_json::to_string(&result).map_err(|e| {
             ScpWasmError::Tool {
                 message: format!("failed to serialize cross-context output: {e}"),
-                code: "SCP-TOOL-6013".to_owned(),
+                code: codes::TOOL_6013.to_owned(),
             }
             .into_js()
         })?;
@@ -715,7 +716,7 @@ pub fn tool_session_invoke(
         if ucan_token.is_empty() {
             return Err(ScpWasmError::Validation {
                 message: "ucan_token is required for session tool invocation".to_owned(),
-                code: "SCP-VALID-7000".to_owned(),
+                code: codes::VALID_7000.to_owned(),
             }
             .into_js()
             .into());
@@ -733,7 +734,7 @@ pub fn tool_session_invoke(
         .map_err(|e| {
             ScpWasmError::Permission {
                 message: format!("UCAN authorization failed for tool '{tool_id_for_ucan}': {e}",),
-                code: "SCP-PERM-3000".to_owned(),
+                code: codes::PERM_3000.to_owned(),
             }
             .into_js()
         })?;
@@ -741,7 +742,7 @@ pub fn tool_session_invoke(
         let input: serde_json::Value = serde_json::from_str(&input_json).map_err(|e| {
             ScpWasmError::Validation {
                 message: format!("input_json is not valid JSON: {e}"),
-                code: "SCP-VALID-7000".to_owned(),
+                code: codes::VALID_7000.to_owned(),
             }
             .into_js()
         })?;
@@ -753,7 +754,7 @@ pub fn tool_session_invoke(
         let json_str = serde_json::to_string(&result).map_err(|e| {
             ScpWasmError::Tool {
                 message: format!("failed to serialize session invoke output: {e}"),
-                code: "SCP-TOOL-6020".to_owned(),
+                code: codes::TOOL_6020.to_owned(),
             }
             .into_js()
         })?;
@@ -812,7 +813,7 @@ pub fn tool_interface_expose(
             mgr.context_creator(&context_id)
                 .ok_or_else(|| ScpWasmError::Context {
                     message: format!("context '{context_id}' not found"),
-                    code: "SCP-CTX-2000".to_owned(),
+                    code: codes::CTX_2000.to_owned(),
                 })
         })
         .map_err(ScpWasmError::into_js)?;
@@ -828,7 +829,7 @@ pub fn tool_interface_expose(
                         "tool interface expose requires admin role — '{admin_did}' \
                          is not an admin of context '{context_id}'"
                     ),
-                    code: "SCP-PERM-3001".to_owned(),
+                    code: codes::PERM_3001.to_owned(),
                 }
                 .into_js()
                 .into());
@@ -841,7 +842,7 @@ pub fn tool_interface_expose(
         if !exists {
             return Err(ScpWasmError::Tool {
                 message: format!("tool '{tool_id}' not found in context '{context_id}'"),
-                code: "SCP-TOOL-6030".to_owned(),
+                code: codes::TOOL_6030.to_owned(),
             }
             .into_js()
             .into());
@@ -853,7 +854,7 @@ pub fn tool_interface_expose(
                 let parsed = parse_rate_limit_json(json).map_err(|e| {
                     ScpWasmError::Validation {
                         message: e,
-                        code: "SCP-VALID-7040".to_owned(),
+                        code: codes::VALID_7040.to_owned(),
                     }
                     .into_js()
                 })?;
@@ -888,7 +889,7 @@ pub fn tool_interface_expose(
         let json_str = serde_json::to_string(&interface).map_err(|e| {
             ScpWasmError::Tool {
                 message: format!("failed to serialize ToolInterface: {e}"),
-                code: "SCP-TOOL-6031".to_owned(),
+                code: codes::TOOL_6031.to_owned(),
             }
             .into_js()
         })?;
@@ -921,7 +922,7 @@ pub fn tool_interface_accept(context: &WasmContextHandle, interface_json: String
             mgr.context_creator(&context_id)
                 .ok_or_else(|| ScpWasmError::Context {
                     message: format!("context '{context_id}' not found"),
-                    code: "SCP-CTX-2000".to_owned(),
+                    code: codes::CTX_2000.to_owned(),
                 })
         })
         .map_err(ScpWasmError::into_js)?;
@@ -937,7 +938,7 @@ pub fn tool_interface_accept(context: &WasmContextHandle, interface_json: String
                         "tool interface accept requires admin role — '{admin_did}' \
                          is not an admin of context '{context_id}'"
                     ),
-                    code: "SCP-PERM-3001".to_owned(),
+                    code: codes::PERM_3001.to_owned(),
                 }
                 .into_js()
                 .into());
@@ -948,7 +949,7 @@ pub fn tool_interface_accept(context: &WasmContextHandle, interface_json: String
             serde_json::from_str(&interface_json).map_err(|e| {
                 ScpWasmError::Validation {
                     message: format!("invalid interface_json: {e}"),
-                    code: "SCP-VALID-7041".to_owned(),
+                    code: codes::VALID_7041.to_owned(),
                 }
                 .into_js()
             })?;
@@ -965,7 +966,7 @@ pub fn tool_interface_accept(context: &WasmContextHandle, interface_json: String
                     "interface target_context '{target}' does not match \
                      accepting context '{context_id}'"
                 ),
-                code: "SCP-TOOL-6032".to_owned(),
+                code: codes::TOOL_6032.to_owned(),
             }
             .into_js()
             .into());
@@ -985,7 +986,7 @@ pub fn tool_interface_accept(context: &WasmContextHandle, interface_json: String
         let json_str = serde_json::to_string(&interface).map_err(|e| {
             ScpWasmError::Tool {
                 message: format!("failed to serialize ToolInterface: {e}"),
-                code: "SCP-TOOL-6033".to_owned(),
+                code: codes::TOOL_6033.to_owned(),
             }
             .into_js()
         })?;
@@ -1008,7 +1009,7 @@ pub fn tool_interface_revoke(context: &WasmContextHandle, interface_id_hex: Stri
         let interface_id_bytes = hex::decode(&interface_id_hex).map_err(|e| {
             ScpWasmError::Validation {
                 message: format!("invalid interface_id_hex: not valid hex: {e}"),
-                code: "SCP-VALID-7042".to_owned(),
+                code: codes::VALID_7042.to_owned(),
             }
             .into_js()
         })?;
@@ -1018,7 +1019,7 @@ pub fn tool_interface_revoke(context: &WasmContextHandle, interface_id_hex: Stri
                     "interface_id_hex must be exactly 32 bytes (64 hex chars), got {}",
                     interface_id_bytes.len()
                 ),
-                code: "SCP-VALID-7042".to_owned(),
+                code: codes::VALID_7042.to_owned(),
             }
             .into_js()
             .into());
@@ -1038,7 +1039,7 @@ pub fn tool_interface_revoke(context: &WasmContextHandle, interface_id_hex: Stri
         let json_str = serde_json::to_string(&event).map_err(|e| {
             ScpWasmError::Tool {
                 message: format!("failed to serialize InterfaceRevoked: {e}"),
-                code: "SCP-TOOL-6035".to_owned(),
+                code: codes::TOOL_6035.to_owned(),
             }
             .into_js()
         })?;
@@ -1058,6 +1059,7 @@ pub fn tool_interface_revoke(context: &WasmContextHandle, interface_id_hex: Stri
 #[allow(clippy::unwrap_used)]
 mod tests {
     use super::*;
+    use scp_ffi_common::error_codes as codes;
 
     // -----------------------------------------------------------------------
     // validate_schema_field — missing field (input schema)
@@ -1072,7 +1074,7 @@ mod tests {
         let err = validate_schema_field(&def, "schema").unwrap_err();
         let msg = err.to_string();
         assert!(
-            msg.contains("SCP-VALID-7035"),
+            msg.contains(codes::VALID_7035),
             "error should contain SCP-VALID-7035, got: {msg}"
         );
         assert!(
@@ -1095,7 +1097,7 @@ mod tests {
         let err = validate_schema_field(&def, "schema").unwrap_err();
         let msg = err.to_string();
         assert!(
-            msg.contains("SCP-VALID-7035"),
+            msg.contains(codes::VALID_7035),
             "error should contain SCP-VALID-7035, got: {msg}"
         );
         assert!(
@@ -1118,7 +1120,7 @@ mod tests {
         let err = validate_schema_field(&def, "schema").unwrap_err();
         let msg = err.to_string();
         assert!(
-            msg.contains("SCP-VALID-7035"),
+            msg.contains(codes::VALID_7035),
             "error should contain SCP-VALID-7035, got: {msg}"
         );
     }
@@ -1154,7 +1156,7 @@ mod tests {
         let err = validate_schema_field(&def, "outputSchema").unwrap_err();
         let msg = err.to_string();
         assert!(
-            msg.contains("SCP-VALID-7036"),
+            msg.contains(codes::VALID_7036),
             "error should contain SCP-VALID-7036, got: {msg}"
         );
         assert!(
@@ -1177,7 +1179,7 @@ mod tests {
         let err = validate_schema_field(&def, "outputSchema").unwrap_err();
         let msg = err.to_string();
         assert!(
-            msg.contains("SCP-VALID-7036"),
+            msg.contains(codes::VALID_7036),
             "error should contain SCP-VALID-7036, got: {msg}"
         );
         assert!(
@@ -1200,7 +1202,7 @@ mod tests {
         let err = validate_schema_field(&def, "outputSchema").unwrap_err();
         let msg = err.to_string();
         assert!(
-            msg.contains("SCP-VALID-7036"),
+            msg.contains(codes::VALID_7036),
             "error should contain SCP-VALID-7036, got: {msg}"
         );
     }
@@ -1262,7 +1264,7 @@ mod tests {
         assert!(
             matches!(
                 result,
-                Err(ScpWasmError::Validation { ref code, .. }) if code == "SCP-VALID-7037"
+                Err(ScpWasmError::Validation { ref code, .. }) if code == codes::VALID_7037
             ),
             "expected SCP-VALID-7037, got: {result:?}"
         );
@@ -1283,7 +1285,7 @@ mod tests {
             matches!(
                 result,
                 Err(ScpWasmError::Validation { ref code, ref message, .. })
-                    if code == "SCP-VALID-7037" && message.contains("'input'")
+                    if code == codes::VALID_7037 && message.contains("'input'")
             ),
             "expected SCP-VALID-7037 mentioning 'input', got: {result:?}"
         );
@@ -1304,7 +1306,7 @@ mod tests {
             matches!(
                 result,
                 Err(ScpWasmError::Validation { ref code, ref message, .. })
-                    if code == "SCP-VALID-7037" && message.contains("'expectedOutput'")
+                    if code == codes::VALID_7037 && message.contains("'expectedOutput'")
             ),
             "expected SCP-VALID-7037 mentioning 'expectedOutput', got: {result:?}"
         );
@@ -1325,7 +1327,7 @@ mod tests {
             matches!(
                 result,
                 Err(ScpWasmError::Validation { ref code, ref message, .. })
-                    if code == "SCP-VALID-7037" && message.contains("'description'")
+                    if code == codes::VALID_7037 && message.contains("'description'")
             ),
             "expected SCP-VALID-7037 mentioning 'description', got: {result:?}"
         );
@@ -1347,7 +1349,7 @@ mod tests {
             matches!(
                 result,
                 Err(ScpWasmError::Validation { ref code, ref message, .. })
-                    if code == "SCP-VALID-7037"
+                    if code == codes::VALID_7037
                         && message.contains("'description'")
                         && message.contains("number")
             ),
@@ -1371,7 +1373,7 @@ mod tests {
             matches!(
                 result,
                 Err(ScpWasmError::Validation { ref code, ref message, .. })
-                    if code == "SCP-VALID-7037"
+                    if code == codes::VALID_7037
                         && message.contains("'description'")
                         && message.contains("boolean")
             ),

--- a/crates/scp-ffi/wasm/src/transport.rs
+++ b/crates/scp-ffi/wasm/src/transport.rs
@@ -23,6 +23,7 @@
 //! for the full specification.
 
 use js_sys::Promise;
+use scp_ffi_common::error_codes as codes;
 use wasm_bindgen::prelude::*;
 use wasm_bindgen_futures::future_to_promise;
 
@@ -127,7 +128,7 @@ pub fn transport_connect(relay_url: String) -> Promise {
                 message: format!(
                     "relay_url must use wss:// scheme (TLS required), got: {relay_url:?}"
                 ),
-                code: "SCP-VALID-7000".to_owned(),
+                code: codes::VALID_7000.to_owned(),
             }
             .into_js()
             .into());

--- a/crates/scp-ffi/wasm/src/trust.rs
+++ b/crates/scp-ffi/wasm/src/trust.rs
@@ -29,6 +29,7 @@
 //! See ADR-022 in `.docs/adrs/phase-4.md`.
 
 use js_sys::Promise;
+use scp_ffi_common::error_codes as codes;
 use wasm_bindgen::prelude::*;
 use wasm_bindgen_futures::future_to_promise;
 
@@ -123,7 +124,7 @@ pub fn trust_verify_attestation(attestation_json: String) -> Promise {
             message: "attestation signature verification requires WebCrypto \
                       — implement in TypeScript wrapper layer"
                 .to_owned(),
-            code: "SCP-VALID-7070".to_owned(),
+            code: codes::VALID_7070.to_owned(),
         }
         .into_js()
         .into())
@@ -245,7 +246,7 @@ pub fn trust_verify_response(challenge_json: String, response_json: String) -> P
             message: "challenge response signature verification requires WebCrypto \
                       — implement in TypeScript wrapper layer"
                 .to_owned(),
-            code: "SCP-VALID-7071".to_owned(),
+            code: codes::VALID_7071.to_owned(),
         }
         .into_js()
         .into())
@@ -361,7 +362,7 @@ pub fn aggregate_trust_input(
             message: "trust aggregation requires the full scp-core pipeline \
                       — use the native (NAPI) bridge instead of the WASM bridge"
                 .to_owned(),
-            code: "SCP-VALID-7072".to_owned(),
+            code: codes::VALID_7072.to_owned(),
         }
         .into_js()
         .into())

--- a/crates/scp-ffi/wasm/src/ucan.rs
+++ b/crates/scp-ffi/wasm/src/ucan.rs
@@ -9,6 +9,7 @@
 //!
 //! See ADR-034 in `.docs/adrs/phase-4.md` and issue #389.
 
+use scp_ffi_common::error_codes as codes;
 use std::collections::HashSet;
 
 use js_sys::Promise;
@@ -421,7 +422,7 @@ pub fn ucan_validate(
         let parsed = parse_ucan(&token).map_err(|e| {
             ScpWasmError::Permission {
                 message: format!("malformed token: {e}"),
-                code: "SCP-PERM-3000".to_owned(),
+                code: codes::PERM_3000.to_owned(),
             }
             .into_js()
         })?;
@@ -433,7 +434,7 @@ pub fn ucan_validate(
                         message: format!(
                             "proof_tokens_json is not a valid JSON array of strings: {e}"
                         ),
-                        code: "SCP-VALID-7000".to_owned(),
+                        code: codes::VALID_7000.to_owned(),
                     }
                     .into_js()
                 })?;
@@ -445,7 +446,7 @@ pub fn ucan_validate(
         let required_capability: CapabilityUri = capability.parse().map_err(|e: UcanError| {
             ScpWasmError::Permission {
                 message: format!("invalid capability URI: {e}"),
-                code: "SCP-PERM-3000".to_owned(),
+                code: codes::PERM_3000.to_owned(),
             }
             .into_js()
         })?;
@@ -460,7 +461,7 @@ pub fn ucan_validate(
         .map_err(|e| {
             ScpWasmError::Permission {
                 message: e,
-                code: "SCP-PERM-3000".to_owned(),
+                code: codes::PERM_3000.to_owned(),
             }
             .into_js()
         })?;
@@ -492,7 +493,7 @@ pub fn ucan_mint(
             message: "UCAN minting requires JS-side key custody (WebCrypto) — use the TypeScript \
                       SDK wrapper's mintUcan() method which signs via SubtleCrypto"
                 .to_owned(),
-            code: "SCP-PERM-3000".to_owned(),
+            code: codes::PERM_3000.to_owned(),
         }
         .into_js()
         .into())
@@ -519,7 +520,7 @@ pub fn ucan_delegate(
             message: "UCAN delegation requires JS-side key custody (WebCrypto) — use the \
                       TypeScript SDK wrapper's delegateUcan() method which signs via SubtleCrypto"
                 .to_owned(),
-            code: "SCP-PERM-3000".to_owned(),
+            code: codes::PERM_3000.to_owned(),
         }
         .into_js()
         .into())
@@ -592,7 +593,7 @@ pub fn ucan_revoke(context: &WasmContextHandle, token: String, revoker_did: Stri
             JsValue::from(
                 ScpWasmError::Validation {
                     message: e.to_string(),
-                    code: "SCP-VALID-7010".to_owned(),
+                    code: codes::VALID_7010.to_owned(),
                 }
                 .into_js(),
             )
@@ -601,7 +602,7 @@ pub fn ucan_revoke(context: &WasmContextHandle, token: String, revoker_did: Stri
             JsValue::from(
                 ScpWasmError::Validation {
                     message: e.to_string(),
-                    code: "SCP-VALID-7011".to_owned(),
+                    code: codes::VALID_7011.to_owned(),
                 }
                 .into_js(),
             )
@@ -612,7 +613,7 @@ pub fn ucan_revoke(context: &WasmContextHandle, token: String, revoker_did: Stri
             JsValue::from(
                 ScpWasmError::Permission {
                     message: format!("malformed UCAN token: {e}"),
-                    code: "SCP-PERM-3001".to_owned(),
+                    code: codes::PERM_3001.to_owned(),
                 }
                 .into_js(),
             )
@@ -632,7 +633,7 @@ pub fn ucan_revoke(context: &WasmContextHandle, token: String, revoker_did: Stri
                         "revoker '{}' is neither the token issuer ('{}') nor the context creator ('{}')",
                         revoker_did, parsed.payload.iss, creator_did
                     ),
-                    code: "SCP-PERM-3008".to_owned(),
+                    code: codes::PERM_3008.to_owned(),
                 }
                 .into_js(),
             ));


### PR DESCRIPTION
## Summary

Extracts duplicated logic from FFI bridges into scp-ffi-common, eliminating the class of bugs that caused #1419 (ceiling bug in 2 bridges).

### Phase 1: Context params building
- New `context_params.rs` in scp-ffi-common with `CommonContextParams` + `build_context_params()`
- All 3 non-WASM bridges delegate to shared builder instead of duplicating ceiling parsing, governance model construction, TTL config, economic policy, consequence rules, sybil policy
- 18 unit tests covering all parameter paths
- -351 lines from bridges, +513 lines shared (net +162 with tests)

### Phase 2: Broadcast key resolution (#1397)
- New `server.rs` in scp-ffi-common with `resolve_broadcast_key()`
- Eliminates 80-line duplicate between PyO3 and NAPI server modules
- Shared `BroadcastKeyError` + `ResolvedBroadcastKey` types

### Phase 3: Error code constants
- New `error_codes.rs` with 260+ `pub const` SCP-XXX-NNNN strings organized by category
- All 4 bridges (including WASM) updated to import from common
- 48 source files updated
- `scripts/check-error-codes.sh` passes (2096 code occurrences verified)

## Test plan

- [ ] `cargo test -p scp-ffi-common` — 165 tests (incl. 18 new context params tests)
- [ ] `cargo test -p scp-ffi -p scp-ffi-napi -p scp-ffi-uniffi` — 536 bridge tests
- [ ] `cargo clippy --workspace --all-targets --features ...` — 0 warnings
- [ ] `bash scripts/check-error-codes.sh` — all codes valid

🤖 Generated with [Claude Code](https://claude.com/claude-code)