### PR TITLE
fix(python): remove false caching claim from attestations docstring

### DIFF
--- a/bindings/python/scp_sdk/identity.py
+++ b/bindings/python/scp_sdk/identity.py
@@ -515,8 +515,8 @@ class Identity:
     def attestations(self) -> list[IdentityAttestation]:
         """List all identity link attestations for this identity.
 
-        This is a synchronous property that returns the cached list of
-        attestations from the bridge layer. For the async variant, use
+        This is a synchronous property that makes a live call to the
+        bridge layer on every access. For the async variant, use
         :meth:`list_attestations`.
 
         Returns:


### PR DESCRIPTION
## Summary

- `Identity.attestations` property docstring falsely claimed "the cached list of attestations from the bridge layer" — there is no caching, it makes a live FFI call every access
- Updated to accurately say "makes a live call to the bridge layer on every access"

Closes #1463

🤖 Generated with [Claude Code](https://claude.com/claude-code)