### PR TITLE
fix: add capacity limit to HandleRegistry matching ScopeRegistry

### DIFF
--- a/.docs/specs/22-human-readable-addressing.md
+++ b/.docs/specs/22-human-readable-addressing.md
@@ -97,7 +97,7 @@ handle_register(handle, target, metadata?) → confirmation
     }
   }
   output: {
-    status:    "registered" | "conflict",  // unambiguous outcome
+    status:    "registered" | "conflict" | "ownership_mismatch" | "capacity_exceeded",
     entry_id:  string?                     // present when status = "registered"
   }
 
@@ -144,6 +144,8 @@ handle_deregister(handle, did) → removal
 The `did` parameter in `handle_deregister` is explicit rather than inferred from the request signature — this ensures the tool schema is self-documenting and the DID-to-handle ownership check is visible in the interface. Writers verify the DID-signed request signature matches the provided DID and that the DID owns the handle.
 
 **Uniqueness.** A context with discovery tools enforces handle uniqueness within its own namespace. `handle_register` returns `{ status: "conflict" }` when another DID already holds the requested handle. The handle uniqueness constraint applies per local-part: there can be at most one `alice` in a given context, regardless of target type. Governance determines conflict resolution policy (first-come-first-served, admin-arbitrated, etc.).
+
+**Capacity limits.** `HandleRegistry` implementations SHOULD enforce a `max_entries` limit (recommended default: 10,000) to prevent resource exhaustion. Registrations that would exceed the limit return `{ status: "capacity_exceeded" }`. This matches the `ScopeRegistry` capacity model (§22.3.5).
 
 **Ownership and verification.** The registrant's DID (authenticated via the DID-signed request) is the handle owner. Only the owner can update or deregister. All handle tool requests MUST carry a DID signature over the request payload. Writers MUST verify the signature before processing. The event log entry for a registration includes the full signed request as payload, making verification replayable by any party with access to the event log. The ownership chain is: DID-signed request → writer verifies signature cryptographically → event log records the registration with the signed payload and owner DID.
 
@@ -843,6 +845,7 @@ These types are the tool call schemas for the standard context tools defined in 
 | `Registered` | `"registered"` | Handle registered successfully. |
 | `Conflict` | `"conflict"` | Another DID already holds this handle. |
 | `OwnershipMismatch` | `"ownership_mismatch"` | Requester DID does not match handle owner. |
+| `CapacityExceeded` | `"capacity_exceeded"` | Registry is at capacity (default limit: 10,000). |
 
 **`HandleMetadata`** — Optional descriptive metadata for handles.
 

--- a/crates/scp-protocol/src/discovery/handles.rs
+++ b/crates/scp-protocol/src/discovery/handles.rs
@@ -35,6 +35,9 @@ pub const TOOL_HANDLE_LOOKUP: &str = "handle_lookup";
 /// Standard tool name for handle deregistration.
 pub const TOOL_HANDLE_DEREGISTER: &str = "handle_deregister";
 
+/// Maximum number of entries in a single handle registry (§22.3.1).
+const MAX_HANDLE_ENTRIES: usize = 10_000;
+
 // ---------------------------------------------------------------------------
 // HandleRegisterParams / HandleRegisterResult (§22.3.1)
 // ---------------------------------------------------------------------------
@@ -87,6 +90,8 @@ pub enum HandleRegisterStatus {
     Conflict,
     /// The registrant DID does not match the target identity DID.
     OwnershipMismatch,
+    /// The handle registry is at capacity and cannot accept new registrations.
+    CapacityExceeded,
 }
 
 // ---------------------------------------------------------------------------
@@ -238,6 +243,13 @@ impl HandleRegistry {
         if self.entries.contains_key(&normalized) {
             return HandleRegisterResult {
                 status: HandleRegisterStatus::Conflict,
+                entry_id: None,
+            };
+        }
+
+        if self.entries.len() >= MAX_HANDLE_ENTRIES {
+            return HandleRegisterResult {
+                status: HandleRegisterStatus::CapacityExceeded,
                 entry_id: None,
             };
         }
@@ -698,5 +710,68 @@ mod tests {
         };
         let result = registry.register(&params2, &bob_did, &scp_primitives::SystemClock);
         assert_eq!(result.status, HandleRegisterStatus::Registered);
+    }
+
+    // -- HandleRegistry: capacity limit -------------------------------------
+
+    #[test]
+    fn register_returns_capacity_exceeded_at_limit() {
+        let owner_did = DID::from("did:dht:testowner");
+        let mut registry = HandleRegistry::new("ctx-capacity".to_owned());
+
+        for i in 0..MAX_HANDLE_ENTRIES {
+            let params = HandleRegisterParams {
+                handle: format!("handle_{i}"),
+                target: make_context_target(&format!("ctx-{i}")),
+                metadata: None,
+            };
+            let result = registry.register(&params, &owner_did, &scp_primitives::SystemClock);
+            assert_eq!(result.status, HandleRegisterStatus::Registered);
+        }
+
+        assert_eq!(registry.len(), MAX_HANDLE_ENTRIES);
+
+        let overflow_params = HandleRegisterParams {
+            handle: "handle_overflow".to_owned(),
+            target: make_context_target("ctx-overflow"),
+            metadata: None,
+        };
+        let result = registry.register(&overflow_params, &owner_did, &scp_primitives::SystemClock);
+        assert_eq!(result.status, HandleRegisterStatus::CapacityExceeded);
+        assert!(result.entry_id.is_none());
+        assert_eq!(registry.len(), MAX_HANDLE_ENTRIES);
+    }
+
+    #[test]
+    fn register_succeeds_after_deregister_at_capacity() {
+        let owner_did = DID::from("did:dht:testowner");
+        let mut registry = HandleRegistry::new("ctx-capacity".to_owned());
+
+        for i in 0..MAX_HANDLE_ENTRIES {
+            let params = HandleRegisterParams {
+                handle: format!("handle_{i}"),
+                target: make_context_target(&format!("ctx-{i}")),
+                metadata: None,
+            };
+            registry.register(&params, &owner_did, &scp_primitives::SystemClock);
+        }
+
+        assert_eq!(registry.len(), MAX_HANDLE_ENTRIES);
+
+        registry.deregister(&HandleDeregisterParams {
+            handle: "handle_0".to_owned(),
+            did: owner_did.clone(),
+        });
+
+        assert_eq!(registry.len(), MAX_HANDLE_ENTRIES - 1);
+
+        let new_params = HandleRegisterParams {
+            handle: "handle_new".to_owned(),
+            target: make_context_target("ctx-new"),
+            metadata: None,
+        };
+        let result = registry.register(&new_params, &owner_did, &scp_primitives::SystemClock);
+        assert_eq!(result.status, HandleRegisterStatus::Registered);
+        assert!(result.entry_id.is_some());
     }
 }

--- a/crates/scp-protocol/src/discovery/handles.rs
+++ b/crates/scp-protocol/src/discovery/handles.rs
@@ -82,7 +82,7 @@ pub struct HandleRegisterResult {
 
 /// The outcome of a handle registration attempt.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-#[serde(rename_all = "lowercase")]
+#[serde(rename_all = "snake_case")]
 pub enum HandleRegisterStatus {
     /// The handle was successfully registered.
     Registered,


### PR DESCRIPTION
## Summary

- Added `MAX_HANDLE_ENTRIES = 10,000` constant matching `ScopeRegistry`'s existing `MAX_SCOPE_ENTRIES`
- Added `CapacityExceeded` variant to `HandleRegisterStatus` enum
- Capacity guard in `register()` placed after conflict check, before entry insertion
- WASM bridge inherits fix automatically (delegates to protocol crate)

## Test plan

- [x] `register_returns_capacity_exceeded_at_limit` — fills to 10K, verifies 10,001st returns `CapacityExceeded`
- [x] `register_succeeds_after_deregister_at_capacity` — fills to 10K, deregisters one, verifies next succeeds
- [x] `cargo clippy --workspace` clean
- [x] `cargo test -p scp-protocol` — 2,952 tests pass

Closes #1391

🤖 Generated with [Claude Code](https://claude.com/claude-code)