### PR TITLE
fix: surface passphrase error instead of generic I/O message

### DIFF
--- a/crates/scp-ffi/common/src/server.rs
+++ b/crates/scp-ffi/common/src/server.rs
@@ -74,6 +74,10 @@ pub enum ServerError {
     #[error("storage error: {0}")]
     Storage(#[from] StorageError),
 
+    /// No passphrase was provided when one is required for persistent node identity.
+    #[error("passphrase required for persistent node identity")]
+    MissingPassphrase,
+
     /// A filesystem I/O operation failed (e.g., creating the data directory).
     #[error("io error: {0}")]
     Io(#[from] std::io::Error),
@@ -97,6 +101,9 @@ impl ServerError {
             Self::Storage(_) => "storage initialization failed".to_owned(),
             Self::Io(_) => "I/O error during server operation".to_owned(),
             Self::Platform(_) => "platform error during server operation".to_owned(),
+            Self::MissingPassphrase => {
+                "passphrase required for persistent node identity".to_owned()
+            }
         }
     }
 }
@@ -354,7 +361,7 @@ pub async fn start_node_in_memory(
 /// - The data directory cannot be created ([`ServerError::Io`])
 /// - The filesystem storage cannot be initialized ([`ServerError::Platform`])
 /// - The redb blob database cannot be opened ([`ServerError::Storage`])
-/// - No passphrase provided when `identity` is `None` ([`ServerError::Io`])
+/// - No passphrase provided when `identity` is `None` ([`ServerError::MissingPassphrase`])
 /// - Relay binding, identity generation, or TLS fails ([`ServerError::Node`])
 pub async fn start_node_local(
     data_dir: &Path,
@@ -404,12 +411,7 @@ pub async fn start_node_local(
             .await?
     } else {
         // Persistent key custody — keys survive process restarts.
-        let passphrase = passphrase.ok_or_else(|| {
-            ServerError::Io(std::io::Error::new(
-                std::io::ErrorKind::InvalidInput,
-                "passphrase required for persistent node identity",
-            ))
-        })?;
+        let passphrase = passphrase.ok_or(ServerError::MissingPassphrase)?;
         let key_path = data_dir.join("identity.key");
         let key_custody = Arc::new(scp_platform::file::FileKeyCustody::new(
             &key_path,
@@ -949,6 +951,12 @@ mod tests {
 
         let storage_err = ServerError::Storage(StorageError::Internal("redb corruption".into()));
         assert_eq!(storage_err.user_message(), "storage initialization failed");
+
+        let missing_passphrase = ServerError::MissingPassphrase;
+        assert_eq!(
+            missing_passphrase.user_message(),
+            "passphrase required for persistent node identity"
+        );
     }
 
     #[test]
@@ -1189,8 +1197,8 @@ mod tests {
     }
 
     /// Verifies that `start_node_local` without identity and without
-    /// passphrase returns an error. No env var mutation needed — the
-    /// explicit `None` passphrase parameter is sufficient.
+    /// passphrase returns the dedicated `MissingPassphrase` variant —
+    /// not a generic `Io` error — so the actionable message reaches callers.
     #[tokio::test]
     async fn node_local_without_identity_requires_passphrase() {
         let tmp =
@@ -1198,10 +1206,14 @@ mod tests {
         let result = start_node_local(&tmp, None, None).await;
 
         let err = result.err().expect("should fail without passphrase");
-        let err_msg = err.to_string();
         assert!(
-            err_msg.contains("passphrase required"),
-            "error should mention passphrase requirement, got: {err_msg}"
+            matches!(err, ServerError::MissingPassphrase),
+            "expected ServerError::MissingPassphrase, got: {err:?}"
+        );
+        let user_msg = err.user_message();
+        assert!(
+            user_msg.contains("passphrase required"),
+            "user_message should mention passphrase requirement, got: {user_msg}"
         );
 
         // Cleanup (data_dir may not have been fully created).

--- a/crates/scp-ffi/uniffi/src/bridge.rs
+++ b/crates/scp-ffi/uniffi/src/bridge.rs
@@ -11405,10 +11405,17 @@ pub async fn identity_migrate(identity: Arc<Identity>) -> Result<Arc<Identity>, 
                 let _ = has_agent; // suppress unused warning
 
                 // Migrate attestation and custody registries from old DID to new DID.
+                // Custody migration happens first to consume `new_did`; attestation
+                // migration uses a clone so both blocks compile with or without
+                // the `allow_in_memory_custody` feature.
+                #[cfg(feature = "allow_in_memory_custody")]
+                let attestation_did = new_did.clone();
+                #[cfg(not(feature = "allow_in_memory_custody"))]
+                let attestation_did = new_did;
                 {
                     let registry = identity_link_attestation_registry();
                     if let Some((_, attestations)) = registry.remove(&old_did) {
-                        registry.insert(new_did.clone(), attestations);
+                        registry.insert(attestation_did, attestations);
                     }
                 }
                 #[cfg(feature = "allow_in_memory_custody")]
@@ -11458,10 +11465,17 @@ pub async fn identity_migrate(identity: Arc<Identity>) -> Result<Arc<Identity>, 
                 increment_handle_count();
 
                 // Migrate attestation and custody registries from old DID to new DID.
+                // Custody migration happens first to consume `new_did`; attestation
+                // migration uses a clone so both blocks compile with or without
+                // the `allow_in_memory_custody` feature.
+                #[cfg(feature = "allow_in_memory_custody")]
+                let attestation_did = new_did.clone();
+                #[cfg(not(feature = "allow_in_memory_custody"))]
+                let attestation_did = new_did;
                 {
                     let registry = identity_link_attestation_registry();
                     if let Some((_, attestations)) = registry.remove(&old_did) {
-                        registry.insert(new_did.clone(), attestations);
+                        registry.insert(attestation_did, attestations);
                     }
                 }
                 #[cfg(feature = "allow_in_memory_custody")]

--- a/crates/scp-ffi/uniffi/src/server.rs
+++ b/crates/scp-ffi/uniffi/src/server.rs
@@ -53,6 +53,10 @@ impl From<ServerError> for ScpError {
                 msg: user_msg,
                 code: codes::CTX_2052.to_owned(),
             },
+            ServerError::MissingPassphrase => Self::Validation {
+                msg: user_msg,
+                code: codes::VALID_7004.to_owned(),
+            },
         }
     }
 }


### PR DESCRIPTION
## Summary

- Added `ServerError::MissingPassphrase` variant replacing the `ServerError::Io(InvalidInput, ...)` workaround
- `user_message()` now returns the actionable "passphrase required for persistent node identity" instead of generic "I/O error during server operation"
- `start_node_local` passphrase check simplified from 5-line `Io(Error::new(...))` to `ok_or(ServerError::MissingPassphrase)?`
- UniFFI bridge maps new variant to `ScpError::Validation` with `VALID_7004`
- PyO3 and NAPI bridges automatically benefit (call `user_message()` without variant matching)
- Fixed pre-existing `redundant_clone` clippy warnings in UniFFI `identity_migrate`

## Test plan

- [x] `node_local_without_identity_requires_passphrase` asserts `MissingPassphrase` variant and `user_message()` content
- [x] `user_message_does_not_leak_internal_details` covers new variant
- [x] `cargo clippy --workspace --all-features` clean
- [x] `cargo test -p scp-ffi-common` — 165 tests pass

Closes #1465

🤖 Generated with [Claude Code](https://claude.com/claude-code)