### PR TITLE
refactor: Part 3 Phase 2 remaining — shared adapters (#1457, #1227, #1242)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5097,6 +5097,7 @@ dependencies = [
 name = "scp-ffi-common"
 version = "0.1.0"
 dependencies = [
+ "dashmap",
  "hex",
  "scp-core",
  "scp-event-log",
@@ -5321,7 +5322,6 @@ dependencies = [
  "tower-http",
  "tower-service",
  "tracing",
- "tracing-subscriber",
  "url",
  "x509-parser 0.16.0",
  "zeroize",
@@ -5412,7 +5412,6 @@ dependencies = [
  "tempfile",
  "tokio",
  "tracing",
- "tracing-subscriber",
 ]
 
 [[package]]

--- a/crates/scp-ffi/common/Cargo.toml
+++ b/crates/scp-ffi/common/Cargo.toml
@@ -29,6 +29,7 @@ scp-identity = { path = "../../scp-identity", optional = true }
 scp-transport = { path = "../../scp-transport", features = ["redb-blob"], optional = true }
 scp-node = { path = "../../scp-node", features = ["allow_unencrypted_storage"], optional = true }
 scp-platform = { path = "../../scp-platform", features = ["testing", "filesystem", "file"], optional = true }
+dashmap = { workspace = true }
 zeroize = { workspace = true }
 serde_json = { workspace = true }
 sha2 = { workspace = true }

--- a/crates/scp-ffi/common/src/attestation.rs
+++ b/crates/scp-ffi/common/src/attestation.rs
@@ -1,0 +1,160 @@
+//! Shared identity link attestation construction for FFI bridges.
+//!
+//! All non-WASM FFI bridges (`PyO3`, napi-rs, `UniFFI`) create identity link
+//! attestations with identical logic: parse verification method, compute the
+//! attestation ID, build the unsigned struct, validate structure, and compute
+//! canonical signing bytes. This module extracts that shared pipeline so each
+//! bridge only needs to handle custody access, signing, and storage — the
+//! bridge-specific parts.
+//!
+//! Gated behind the `resolvers` feature (not available for WASM — ADR-034).
+//!
+//! See spec §3.5.1, §3.5.2.
+
+use std::borrow::Cow;
+use std::fmt;
+
+use scp_core::identity::attestation::{
+    ATTESTATION_TYPE_IDENTITY_LINK, AttestationClaim, AttestationEvidence, IdentityLinkAttestation,
+    VerificationMethod,
+};
+use scp_core::trust::attestation::RevocationStatus;
+use scp_identity::DID;
+
+// ---------------------------------------------------------------------------
+// Error type
+// ---------------------------------------------------------------------------
+
+/// Errors from the shared attestation construction pipeline.
+///
+/// Each bridge converts this to its own error type (e.g. `ScpPyError`,
+/// `ScpNapiError`, `ScpError`).
+#[derive(Debug)]
+pub enum AttestationBuildError {
+    /// The verification method string could not be parsed.
+    InvalidMethod(String),
+    /// The system clock is before the UNIX epoch.
+    ClockError,
+    /// Structural validation of the attestation failed.
+    StructureValidation(String),
+    /// Computing canonical signing bytes failed.
+    Canonicalization(String),
+}
+
+impl fmt::Display for AttestationBuildError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::InvalidMethod(e) => write!(f, "{e}"),
+            Self::ClockError => write!(f, "system clock is before UNIX epoch"),
+            Self::StructureValidation(e) => {
+                write!(f, "attestation structure validation failed: {e}")
+            }
+            Self::Canonicalization(e) => write!(f, "attestation signing failed: {e}"),
+        }
+    }
+}
+
+impl std::error::Error for AttestationBuildError {}
+
+// ---------------------------------------------------------------------------
+// Builder result
+// ---------------------------------------------------------------------------
+
+/// Result of [`build_unsigned_attestation`]: an unsigned attestation and the
+/// canonical bytes that must be signed to complete it.
+pub struct UnsignedAttestation {
+    /// The attestation with an empty `signature` field.
+    pub attestation: IdentityLinkAttestation,
+    /// The canonical bytes to sign with the identity's active signing key.
+    pub canonical_bytes: Vec<u8>,
+}
+
+// ---------------------------------------------------------------------------
+// Shared construction pipeline
+// ---------------------------------------------------------------------------
+
+/// Builds an unsigned [`IdentityLinkAttestation`] and computes its canonical
+/// signing bytes.
+///
+/// This is the shared logic across all FFI bridges. After calling this, the
+/// bridge must:
+/// 1. Sign `canonical_bytes` with the identity's active signing key.
+/// 2. Set `attestation.signature` to the signature bytes.
+/// 3. Store the attestation in the bridge-specific registry.
+///
+/// # Arguments
+///
+/// * `did` — The DID string of the attesting identity.
+/// * `platform` — Platform identifier (e.g., `"github.com"`, `"x.com"`).
+/// * `handle` — Handle on the platform (e.g., `"@alice"`, `"alice123"`).
+/// * `proof` — Method-specific proof data (e.g., OAuth JWT, post URL).
+///   Opaque string per §3.5.2 — passed through as-is.
+/// * `verification_method` — One of `"oauth"`, `"signed_post"`, `"dns_record"`,
+///   `"challenge_response"`.
+/// * `platform_id` — Optional platform-specific immutable user ID.
+///
+/// # Errors
+///
+/// Returns [`AttestationBuildError`] if the verification method is invalid,
+/// the system clock is before the UNIX epoch, structural validation fails,
+/// or canonical byte computation fails.
+pub fn build_unsigned_attestation(
+    did: &str,
+    platform: String,
+    handle: String,
+    proof: String,
+    verification_method: &str,
+    platform_id: Option<String>,
+) -> Result<UnsignedAttestation, AttestationBuildError> {
+    let method: VerificationMethod = verification_method
+        .parse()
+        .map_err(AttestationBuildError::InvalidMethod)?;
+
+    let issuer = DID::from(did);
+    let now_secs = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map_err(|_| AttestationBuildError::ClockError)?
+        .as_secs();
+
+    let id = IdentityLinkAttestation::compute_id(&issuer, &platform, &handle, now_secs);
+
+    let attestation = IdentityLinkAttestation {
+        id,
+        attestation_type: Cow::Borrowed(ATTESTATION_TYPE_IDENTITY_LINK),
+        issuer: issuer.clone(),
+        subject: issuer,
+        issued_at: now_secs,
+        expires_at: None,
+        claim: AttestationClaim::new(platform, handle, platform_id),
+        evidence: AttestationEvidence {
+            method,
+            proof,
+            verified_at: now_secs,
+            verifier_did: None,
+        },
+        revocation_status: RevocationStatus::Active,
+        signature: Vec::new(),
+    };
+
+    // Structural validation before signing.
+    let structure_errors = attestation.validate_structure();
+    if !structure_errors.is_empty() {
+        return Err(AttestationBuildError::StructureValidation(
+            structure_errors
+                .iter()
+                .map(AsRef::as_ref)
+                .collect::<Vec<_>>()
+                .join("; "),
+        ));
+    }
+
+    // Compute canonical bytes for signing.
+    let canonical_bytes = attestation
+        .canonical_signing_bytes()
+        .map_err(|e| AttestationBuildError::Canonicalization(e.to_string()))?;
+
+    Ok(UnsignedAttestation {
+        attestation,
+        canonical_bytes,
+    })
+}

--- a/crates/scp-ffi/common/src/bridge_state.rs
+++ b/crates/scp-ffi/common/src/bridge_state.rs
@@ -1,0 +1,61 @@
+//! Shared per-context bridge connector state for FFI bridges.
+//!
+//! All non-WASM FFI bridges (`PyO3`, napi-rs, `UniFFI`) maintain per-context
+//! [`ShadowRegistry`] and [`SenderKeyStore`] instances across bridge function
+//! calls. Without this persistent state, each call to `bridge_create_shadow`
+//! would create ephemeral registries that are dropped when the function returns.
+//!
+//! This module provides the shared type, global registry, and accessor functions
+//! so each bridge avoids reimplementing the same `OnceLock<DashMap<String, ...>>`
+//! boilerplate.
+//!
+//! Gated behind the `resolvers` feature (not available for WASM — ADR-034).
+//!
+//! See spec section 12 (Bridge System) and ADR-023.
+
+use std::sync::OnceLock;
+
+use dashmap::DashMap;
+use scp_protocol::bridge::shadow::ShadowRegistry;
+use scp_protocol::crypto::sender_keys::SenderKeyStore;
+
+// ---------------------------------------------------------------------------
+// BridgeContextState
+// ---------------------------------------------------------------------------
+
+/// Per-context bridge connector state that persists across function calls.
+///
+/// Without this, `bridge_create_shadow` would create ephemeral
+/// `ShadowRegistry` and `SenderKeyStore` instances that are dropped when the
+/// function returns, losing all shadow identity and sender key state.
+///
+/// Keyed by context ID in the global [`bridge_state_registry`].
+pub struct BridgeContextState {
+    /// Shadow identity registry for this context.
+    pub shadow_registry: ShadowRegistry,
+    /// Sender key store for shadow envelope encryption.
+    pub sender_key_store: SenderKeyStore,
+}
+
+// ---------------------------------------------------------------------------
+// Global registry
+// ---------------------------------------------------------------------------
+
+/// Process-global registry of per-context bridge connector state.
+///
+/// Uses `DashMap` for lock-free concurrent reads, matching the pattern
+/// used throughout the FFI bridges.
+static BRIDGE_STATE: OnceLock<DashMap<String, BridgeContextState>> = OnceLock::new();
+
+/// Returns a reference to the bridge state registry, initializing on first access.
+pub fn bridge_state_registry() -> &'static DashMap<String, BridgeContextState> {
+    BRIDGE_STATE.get_or_init(DashMap::new)
+}
+
+/// Removes per-context bridge state on context close, preventing unbounded
+/// memory growth in long-running processes.
+///
+/// Called from each bridge's context-close or cleanup path.
+pub fn remove_bridge_state(context_id: &str) {
+    bridge_state_registry().remove(context_id);
+}

--- a/crates/scp-ffi/common/src/lib.rs
+++ b/crates/scp-ffi/common/src/lib.rs
@@ -16,6 +16,7 @@
 //!
 //! See §3.10.10, §9.5, §7.4.1, §22.3.1, §22.4, §22.8 in `.docs/specs/`.
 
+pub mod bridge_state;
 pub mod error_codes;
 pub mod validate;
 
@@ -78,6 +79,11 @@ pub fn html_escape_json(json: &str) -> String {
         .replace('&', "\\u0026")
         .replace('\'', "\\u0027")
 }
+
+// Shared attestation construction pipeline for all non-WASM bridges.
+// Requires scp-core + scp-identity (behind `resolvers` feature). Not available for WASM.
+#[cfg(feature = "resolvers")]
+pub mod attestation;
 
 // Shared context-parameter builder for all non-WASM bridges.
 // Requires scp-core (behind `resolvers` feature). Not available for WASM.

--- a/crates/scp-ffi/napi/src/bridge_connector.rs
+++ b/crates/scp-ffi/napi/src/bridge_connector.rs
@@ -8,10 +8,9 @@
 //!
 //! See spec section 12 (Bridge System) and ADR-023.
 
+use scp_ffi_common::bridge_state::{BridgeContextState, bridge_state_registry};
 use scp_ffi_common::error_codes as codes;
-use std::sync::OnceLock;
 
-use dashmap::DashMap;
 use napi_derive::napi;
 
 use scp_core::bridge::provenance::{evaluate_trust_level, mark_bridge_provenance};
@@ -31,35 +30,9 @@ use crate::error::ScpNapiError;
 // ---------------------------------------------------------------------------
 // Per-context bridge state — persistent ShadowRegistry + SenderKeyStore
 // ---------------------------------------------------------------------------
-
-/// Per-context bridge connector state that persists across function calls.
-///
-/// Without this, `bridge_create_shadow` would create ephemeral
-/// `ShadowRegistry` and `SenderKeyStore` instances that are dropped when the
-/// function returns, losing all shadow identity and sender key state.
-///
-/// Keyed by context ID in `BRIDGE_STATE`.
-struct BridgeContextState {
-    shadow_registry: ShadowRegistry,
-    sender_key_store: SenderKeyStore,
-}
-
-/// Process-global registry of per-context bridge connector state.
-///
-/// Uses `DashMap` for lock-free concurrent reads, matching the pattern
-/// used by `UcanContextState` in `runtime.rs`.
-static BRIDGE_STATE: OnceLock<DashMap<String, BridgeContextState>> = OnceLock::new();
-
-/// Returns a reference to the bridge state registry, initializing on first access.
-fn bridge_state_registry() -> &'static DashMap<String, BridgeContextState> {
-    BRIDGE_STATE.get_or_init(DashMap::new)
-}
-
-/// Removes per-context bridge state on context close, preventing unbounded
-/// memory growth in long-running processes. Called from `context_close`.
-pub(crate) fn remove_bridge_state(context_id: &str) {
-    bridge_state_registry().remove(context_id);
-}
+//
+// `BridgeContextState`, `bridge_state_registry()`, and `remove_bridge_state()`
+// are defined in `scp_ffi_common::bridge_state` and imported above.
 
 // ---------------------------------------------------------------------------
 // Result types

--- a/crates/scp-ffi/napi/src/context.rs
+++ b/crates/scp-ffi/napi/src/context.rs
@@ -711,7 +711,7 @@ pub async fn context_close(handle: &NapiContextHandle, identity_did: String) -> 
 
     // Clean up per-context bridge connector state (ShadowRegistry + SenderKeyStore)
     // to prevent unbounded memory growth in long-running processes.
-    crate::bridge_connector::remove_bridge_state(&handle.context_id);
+    scp_ffi_common::bridge_state::remove_bridge_state(&handle.context_id);
 
     Ok(())
 }

--- a/crates/scp-ffi/napi/src/identity.rs
+++ b/crates/scp-ffi/napi/src/identity.rs
@@ -1413,9 +1413,14 @@ pub async fn identity_create_link_attestation(
         platform_id,
     )
     .map_err(|e| {
+        let code = match &e {
+            scp_ffi_common::attestation::AttestationBuildError::InvalidMethod(_)
+            | scp_ffi_common::attestation::AttestationBuildError::ClockError => codes::IDENT_1040,
+            _ => codes::IDENT_1041,
+        };
         NapiError::from(ScpNapiError::Identity {
             message: e.to_string(),
-            code: codes::IDENT_1041.to_owned(),
+            code: code.to_owned(),
         })
     })?;
 

--- a/crates/scp-ffi/napi/src/identity.rs
+++ b/crates/scp-ffi/napi/src/identity.rs
@@ -1389,29 +1389,11 @@ pub async fn identity_create_link_attestation(
     verification_method: String,
     platform_id: Option<String>,
 ) -> napi::Result<String> {
-    use std::borrow::Cow;
-
-    use scp_core::identity::attestation::{
-        ATTESTATION_TYPE_IDENTITY_LINK, AttestationClaim, AttestationEvidence,
-        IdentityLinkAttestation, VerificationMethod,
-    };
-    use scp_core::trust::attestation::RevocationStatus;
-    use scp_identity::DID;
     use scp_platform::traits::KeyCustody;
 
     // Validate attestation input field sizes.
     scp_ffi_common::validate::validate_attestation_fields(&platform, &handle, &proof)
         .map_err(|e| NapiError::from(ScpNapiError::from(e)))?;
-
-    let method: VerificationMethod = verification_method.parse().map_err(|e: String| {
-        NapiError::from(ScpNapiError::Identity {
-            message: e,
-            code: codes::IDENT_1040.to_owned(),
-        })
-    })?;
-
-    // Proof is an opaque string per §3.5.2 — pass through as-is.
-    // Do not parse and re-serialize.
 
     // Phase 1: read custody + key handle (under DashMap lock, then drop).
     let (custody, key_handle) = crate::runtime::with_identity(&did, |entry| {
@@ -1421,59 +1403,23 @@ pub async fn identity_create_link_attestation(
         ))
     })?;
 
-    let issuer = DID::from(did.as_str());
-    let now_secs = std::time::SystemTime::now()
-        .duration_since(std::time::UNIX_EPOCH)
-        .map_err(|_| {
-            NapiError::from(ScpNapiError::Identity {
-                message: "system clock is before UNIX epoch".to_owned(),
-                code: codes::IDENT_1042.to_owned(),
-            })
-        })?
-        .as_secs();
-
-    let id = IdentityLinkAttestation::compute_id(&issuer, &platform, &handle, now_secs);
-
-    let mut attestation = IdentityLinkAttestation {
-        id,
-        attestation_type: Cow::Borrowed(ATTESTATION_TYPE_IDENTITY_LINK),
-        issuer: issuer.clone(),
-        subject: issuer,
-        issued_at: now_secs,
-        expires_at: None,
-        claim: AttestationClaim::new(platform, handle, platform_id),
-        evidence: AttestationEvidence {
-            method,
-            proof,
-            verified_at: now_secs,
-            verifier_did: None,
-        },
-        revocation_status: RevocationStatus::Active,
-        signature: Vec::new(),
-    };
-
-    // Structural validation before signing.
-    let structure_errors = attestation.validate_structure();
-    if !structure_errors.is_empty() {
-        return Err(NapiError::from(ScpNapiError::Identity {
-            message: format!(
-                "attestation structure validation failed: {}",
-                structure_errors
-                    .iter()
-                    .map(AsRef::as_ref)
-                    .collect::<Vec<_>>()
-                    .join("; "),
-            ),
-            code: codes::IDENT_1041.to_owned(),
-        }));
-    }
-
-    let canonical = attestation.canonical_signing_bytes().map_err(|e| {
+    // Build unsigned attestation using shared pipeline.
+    let built = scp_ffi_common::attestation::build_unsigned_attestation(
+        &did,
+        platform,
+        handle,
+        proof,
+        &verification_method,
+        platform_id,
+    )
+    .map_err(|e| {
         NapiError::from(ScpNapiError::Identity {
-            message: format!("attestation signing failed: {e}"),
+            message: e.to_string(),
             code: codes::IDENT_1041.to_owned(),
         })
     })?;
+
+    let mut attestation = built.attestation;
 
     // Phase 2: sign (no DashMap lock held — safe to block_in_place).
     let rt = tokio::runtime::Handle::try_current().map_err(|e| {
@@ -1483,13 +1429,15 @@ pub async fn identity_create_link_attestation(
         })
     })?;
 
-    let sig = tokio::task::block_in_place(|| rt.block_on(custody.0.sign(&key_handle, &canonical)))
-        .map_err(|e| {
-            NapiError::from(ScpNapiError::Identity {
-                message: format!("Ed25519 signing failed: {e}"),
-                code: codes::IDENT_1041.to_owned(),
-            })
-        })?;
+    let sig = tokio::task::block_in_place(|| {
+        rt.block_on(custody.0.sign(&key_handle, &built.canonical_bytes))
+    })
+    .map_err(|e| {
+        NapiError::from(ScpNapiError::Identity {
+            message: format!("Ed25519 signing failed: {e}"),
+            code: codes::IDENT_1041.to_owned(),
+        })
+    })?;
     attestation.signature = sig.as_bytes().to_vec();
 
     // Phase 3: store attestation (re-acquire DashMap lock, TOCTOU guard).

--- a/crates/scp-ffi/src/bridge_connector.rs
+++ b/crates/scp-ffi/src/bridge_connector.rs
@@ -28,7 +28,6 @@
 use scp_ffi_common::error_codes as codes;
 use std::sync::OnceLock;
 
-use dashmap::DashMap;
 use pyo3::prelude::*;
 use pyo3::types::{PyDict, PyList};
 
@@ -55,6 +54,7 @@ use scp_core::bridge::{
 use scp_core::crypto::sender_keys::{SenderKey, SenderKeyStore};
 use scp_core::provenance::{DataProvenance, DiscoveryMethod, SourceType};
 use scp_core::trust::attestation::Attestation;
+use scp_ffi_common::bridge_state::{BridgeContextState, bridge_state_registry};
 use zeroize::Zeroizing;
 
 use crate::error::ScpPyError;
@@ -62,35 +62,9 @@ use crate::error::ScpPyError;
 // ---------------------------------------------------------------------------
 // Per-context bridge state — persistent ShadowRegistry + SenderKeyStore
 // ---------------------------------------------------------------------------
-
-/// Per-context bridge connector state that persists across function calls.
-///
-/// Without this, `bridge_create_shadow` would create ephemeral
-/// `ShadowRegistry` and `SenderKeyStore` instances that are dropped when the
-/// function returns, losing all shadow identity and sender key state.
-///
-/// Keyed by context ID in `BRIDGE_STATE`.
-struct BridgeContextState {
-    shadow_registry: ShadowRegistry,
-    sender_key_store: SenderKeyStore,
-}
-
-/// Process-global registry of per-context bridge connector state.
-///
-/// Uses `DashMap` for lock-free concurrent reads, matching the pattern
-/// used by `FfiBridgeState` in `runtime.rs`.
-static BRIDGE_STATE: OnceLock<DashMap<String, BridgeContextState>> = OnceLock::new();
-
-/// Returns a reference to the bridge state registry, initializing on first access.
-fn bridge_state_registry() -> &'static DashMap<String, BridgeContextState> {
-    BRIDGE_STATE.get_or_init(DashMap::new)
-}
-
-/// Removes per-context bridge state on context close, preventing unbounded
-/// memory growth in long-running processes. Called from `runtime::remove_ffi_state`.
-pub(crate) fn remove_bridge_state(context_id: &str) {
-    bridge_state_registry().remove(context_id);
-}
+//
+// `BridgeContextState`, `bridge_state_registry()`, and `remove_bridge_state()`
+// are defined in `scp_ffi_common::bridge_state` and re-imported above.
 
 // ---------------------------------------------------------------------------
 // Global credential store (in-memory, per-process)

--- a/crates/scp-ffi/src/identity.rs
+++ b/crates/scp-ffi/src/identity.rs
@@ -1265,14 +1265,6 @@ fn py_create_identity_link_attestation(
     verification_method: &str,
     platform_id: Option<&str>,
 ) -> PyResult<String> {
-    use std::borrow::Cow;
-
-    use scp_core::identity::attestation::{
-        ATTESTATION_TYPE_IDENTITY_LINK, AttestationClaim, AttestationEvidence,
-        IdentityLinkAttestation, VerificationMethod,
-    };
-    use scp_core::trust::attestation::RevocationStatus;
-    use scp_identity::DID;
     use scp_platform::traits::KeyCustody;
 
     validate::validate_did(did)?;
@@ -1286,11 +1278,6 @@ fn py_create_identity_link_attestation(
     let rt = crate::runtime()?;
 
     py.allow_threads(move || {
-        let method: VerificationMethod = method_owned.parse().map_err(ScpPyError::identity)?;
-
-        // Proof is an opaque string per §3.5.2 — pass through as-is.
-        // Do not parse and re-serialize.
-
         // Phase 1: read custody + key handle (under DashMap lock, then drop).
         let (custody, key_handle) = crate::runtime::with_identity(&did_owned, |entry| {
             Ok((
@@ -1299,55 +1286,22 @@ fn py_create_identity_link_attestation(
             ))
         })?;
 
-        let issuer = DID::from(did_owned.as_str());
-        let now_secs = std::time::SystemTime::now()
-            .duration_since(std::time::UNIX_EPOCH)
-            .map_err(|_| ScpPyError::identity("system clock is before UNIX epoch"))?
-            .as_secs();
+        // Build unsigned attestation using shared pipeline.
+        let built = scp_ffi_common::attestation::build_unsigned_attestation(
+            &did_owned,
+            platform_owned,
+            handle_owned,
+            proof_owned,
+            &method_owned,
+            platform_id_owned,
+        )
+        .map_err(|e| ScpPyError::identity(e.to_string()))?;
 
-        let id =
-            IdentityLinkAttestation::compute_id(&issuer, &platform_owned, &handle_owned, now_secs);
-
-        // Build the attestation with a placeholder signature.
-        let mut attestation = IdentityLinkAttestation {
-            id,
-            attestation_type: Cow::Borrowed(ATTESTATION_TYPE_IDENTITY_LINK),
-            issuer: issuer.clone(),
-            subject: issuer,
-            issued_at: now_secs,
-            expires_at: None,
-            claim: AttestationClaim::new(platform_owned, handle_owned, platform_id_owned),
-            evidence: AttestationEvidence {
-                method,
-                proof: proof_owned,
-                verified_at: now_secs,
-                verifier_did: None,
-            },
-            revocation_status: RevocationStatus::Active,
-            signature: Vec::new(),
-        };
-
-        // Structural validation before signing.
-        let structure_errors = attestation.validate_structure();
-        if !structure_errors.is_empty() {
-            return Err(ScpPyError::identity(format!(
-                "attestation structure validation failed: {}",
-                structure_errors
-                    .iter()
-                    .map(AsRef::as_ref)
-                    .collect::<Vec<_>>()
-                    .join("; "),
-            )));
-        }
-
-        // Compute canonical bytes and sign with active signing key.
-        let canonical = attestation
-            .canonical_signing_bytes()
-            .map_err(|e| ScpPyError::identity(format!("attestation signing failed: {e}")))?;
+        let mut attestation = built.attestation;
 
         // Phase 2: sign (no DashMap lock held — safe to block_on).
         let sig = rt
-            .block_on(custody.sign(&key_handle, &canonical))
+            .block_on(custody.sign(&key_handle, &built.canonical_bytes))
             .map_err(|e| ScpPyError::identity(format!("Ed25519 signing failed: {e}")))?;
         attestation.signature = sig.as_bytes().to_vec();
 

--- a/crates/scp-ffi/src/runtime.rs
+++ b/crates/scp-ffi/src/runtime.rs
@@ -657,7 +657,7 @@ pub fn remove_ffi_state(context_id: &str) {
     known_contexts_registry().remove(context_id);
     // Clean up per-context bridge connector state (ShadowRegistry + SenderKeyStore)
     // to prevent unbounded memory growth in long-running processes.
-    crate::bridge_connector::remove_bridge_state(context_id);
+    scp_ffi_common::bridge_state::remove_bridge_state(context_id);
     // Clean up per-context economy state (budget + antispam trackers) to prevent
     // unbounded memory growth in long-running processes (#1433).
     remove_economy_state(context_id);

--- a/crates/scp-ffi/uniffi/src/bridge.rs
+++ b/crates/scp-ffi/uniffi/src/bridge.rs
@@ -2774,9 +2774,16 @@ async fn identity_create_link_attestation_impl(
         &verification_method,
         platform_id,
     )
-    .map_err(|e| ScpError::Identity {
-        msg: e.to_string(),
-        code: codes::IDENT_1041.to_owned(),
+    .map_err(|e| {
+        let code = match &e {
+            scp_ffi_common::attestation::AttestationBuildError::InvalidMethod(_)
+            | scp_ffi_common::attestation::AttestationBuildError::ClockError => codes::IDENT_1040,
+            _ => codes::IDENT_1041,
+        };
+        ScpError::Identity {
+            msg: e.to_string(),
+            code: code.to_owned(),
+        }
     })?;
 
     let mut attestation = built.attestation;

--- a/crates/scp-ffi/uniffi/src/bridge.rs
+++ b/crates/scp-ffi/uniffi/src/bridge.rs
@@ -26,7 +26,7 @@
 
 use scp_ffi_common::error_codes as codes;
 use std::fmt;
-use std::sync::{Arc, OnceLock};
+use std::sync::Arc;
 
 use sha2::Digest;
 use zeroize::Zeroizing;
@@ -2740,14 +2740,6 @@ async fn identity_create_link_attestation_impl(
     platform_id: Option<String>,
 ) -> Result<String, ScpError> {
     use scp_ffi_common::error_codes as codes;
-    use std::borrow::Cow;
-
-    use scp_core::identity::attestation::{
-        ATTESTATION_TYPE_IDENTITY_LINK, AttestationClaim, AttestationEvidence,
-        IdentityLinkAttestation, VerificationMethod,
-    };
-    use scp_core::trust::attestation::RevocationStatus;
-    use scp_identity::DID;
     use scp_platform::traits::KeyCustody;
 
     // Validate attestation input field sizes.
@@ -2757,17 +2749,6 @@ async fn identity_create_link_attestation_impl(
             code: codes::VALID_7037.to_owned(),
         },
     )?;
-
-    let method: VerificationMethod =
-        verification_method
-            .parse()
-            .map_err(|e: String| ScpError::Identity {
-                msg: e,
-                code: codes::IDENT_1040.to_owned(),
-            })?;
-
-    // Proof is an opaque string per §3.5.2 — pass through as-is.
-    // Do not parse and re-serialize.
 
     let core_id = identity
         .core_id
@@ -2784,61 +2765,25 @@ async fn identity_create_link_attestation_impl(
             code: codes::IDENT_1040.to_owned(),
         })?;
 
-    let did_str = identity.did.clone();
-    let issuer = DID::from(did_str.as_str());
-    let now_secs = std::time::SystemTime::now()
-        .duration_since(std::time::UNIX_EPOCH)
-        .map_err(|_| ScpError::Identity {
-            msg: "system clock is before UNIX epoch".to_owned(),
-            code: codes::IDENT_1042.to_owned(),
-        })?
-        .as_secs();
+    // Build unsigned attestation using shared pipeline.
+    let built = scp_ffi_common::attestation::build_unsigned_attestation(
+        &identity.did,
+        platform,
+        handle,
+        proof,
+        &verification_method,
+        platform_id,
+    )
+    .map_err(|e| ScpError::Identity {
+        msg: e.to_string(),
+        code: codes::IDENT_1041.to_owned(),
+    })?;
 
-    let id = IdentityLinkAttestation::compute_id(&issuer, &platform, &handle, now_secs);
-
-    let mut attestation = IdentityLinkAttestation {
-        id,
-        attestation_type: Cow::Borrowed(ATTESTATION_TYPE_IDENTITY_LINK),
-        issuer: issuer.clone(),
-        subject: issuer,
-        issued_at: now_secs,
-        expires_at: None,
-        claim: AttestationClaim::new(platform, handle, platform_id),
-        evidence: AttestationEvidence {
-            method,
-            proof,
-            verified_at: now_secs,
-            verifier_did: None,
-        },
-        revocation_status: RevocationStatus::Active,
-        signature: Vec::new(),
-    };
-
-    // Structural validation before signing.
-    let structure_errors = attestation.validate_structure();
-    if !structure_errors.is_empty() {
-        return Err(ScpError::Identity {
-            msg: format!(
-                "attestation structure validation failed: {}",
-                structure_errors
-                    .iter()
-                    .map(AsRef::as_ref)
-                    .collect::<Vec<_>>()
-                    .join("; "),
-            ),
-            code: codes::IDENT_1041.to_owned(),
-        });
-    }
-
-    let canonical = attestation
-        .canonical_signing_bytes()
-        .map_err(|e| ScpError::Identity {
-            msg: format!("attestation signing failed: {e}"),
-            code: codes::IDENT_1041.to_owned(),
-        })?;
+    let mut attestation = built.attestation;
 
     let active_key = core_id.active_signing_key;
     let custody_clone = Arc::clone(custody);
+    let canonical = built.canonical_bytes;
 
     let sig = runtime()
         .spawn(async move { custody_clone.0.sign(&active_key, &canonical).await })
@@ -2886,7 +2831,7 @@ async fn identity_create_link_attestation_impl(
     {
         let registry = identity_link_attestation_registry();
         let len = registry.len();
-        match registry.entry(did_str) {
+        match registry.entry(identity.did.clone()) {
             dashmap::mapref::entry::Entry::Occupied(mut occ) => {
                 if occ.get().len() >= MAX_IDENTITY_LINK_ATTESTATIONS_PER_DID {
                     return Err(ScpError::Identity {
@@ -11559,35 +11504,13 @@ pub fn sync_get_policy() -> SyncPolicyResult {
 // ---------------------------------------------------------------------------
 // Bridge connector — register and create shadow (#421)
 // ---------------------------------------------------------------------------
+//
+// `BridgeContextState`, `bridge_state_registry()`, and `remove_bridge_state()`
+// are defined in `scp_ffi_common::bridge_state`.
 
-/// Per-context bridge connector state that persists across function calls.
-///
-/// Without this, `bridge_create_shadow` would create ephemeral
-/// `ShadowRegistry` and `SenderKeyStore` instances that are dropped when the
-/// function returns, losing all shadow identity and sender key state.
-///
-/// Keyed by context ID in `BRIDGE_STATE`.
-struct BridgeContextState {
-    shadow_registry: scp_core::bridge::shadow::ShadowRegistry,
-    sender_key_store: scp_core::crypto::sender_keys::SenderKeyStore,
-}
-
-/// Process-global registry of per-context bridge connector state.
-///
-/// Uses `DashMap` for lock-free concurrent reads, matching the pattern
-/// used by `UcanContextState` in `runtime.rs`.
-static BRIDGE_STATE: OnceLock<dashmap::DashMap<String, BridgeContextState>> = OnceLock::new();
-
-/// Returns a reference to the bridge state registry, initializing on first access.
-fn bridge_state_registry() -> &'static dashmap::DashMap<String, BridgeContextState> {
-    BRIDGE_STATE.get_or_init(dashmap::DashMap::new)
-}
-
-/// Removes per-context bridge state on context close, preventing unbounded
-/// memory growth in long-running processes. Called from `context_close`.
-fn remove_bridge_state(context_id: &str) {
-    bridge_state_registry().remove(context_id);
-}
+use scp_ffi_common::bridge_state::{
+    BridgeContextState, bridge_state_registry, remove_bridge_state,
+};
 
 /// Bridge registration result record.
 ///

--- a/crates/scp-node/Cargo.toml
+++ b/crates/scp-node/Cargo.toml
@@ -23,6 +23,7 @@ scp-transport = { path = "../scp-transport", version = "=0.1.0-beta.1", features
     "redb-blob",
     "postgres-blob",
     "s3-blob",
+    "startup",
 ] }
 scp-platform = { path = "../scp-platform", version = "=0.1.0-beta.1", features = ["testing", "sqlite", "file", "encrypting"] }
 arc-swap = { workspace = true }
@@ -55,7 +56,6 @@ percent-encoding = { workspace = true }
 rand = { workspace = true }
 tracing = { workspace = true }
 zeroize = { workspace = true }
-tracing-subscriber = { version = "0.3", features = ["env-filter", "json"] }
 url = "2"
 x509-parser = "0.16"
 metrics = { workspace = true }

--- a/crates/scp-node/src/main.rs
+++ b/crates/scp-node/src/main.rs
@@ -30,9 +30,8 @@ use scp_platform::EncryptedStorage;
 use scp_platform::sqlite::{SqliteKeyCustody, SqliteStorage};
 use scp_platform::testing::{InMemoryKeyCustody, InMemoryStorage};
 use scp_platform::traits::Storage;
-use scp_transport::native::server::{RelayConfig, RelayServer};
-use scp_transport::native::storage::BlobStorageBackend;
-use tracing_subscriber::EnvFilter;
+use scp_transport::native::server::RelayServer;
+use scp_transport::startup;
 
 // ---------------------------------------------------------------------------
 // CLI argument parsing
@@ -135,17 +134,7 @@ ENVIRONMENT VARIABLES:
 // Environment variable helpers
 // ---------------------------------------------------------------------------
 
-/// Reads an environment variable and parses it, returning the default on
-/// absence or parse failure (with a warning).
-fn env_or<T: std::str::FromStr>(name: &str, default: T) -> T {
-    match env::var(name) {
-        Ok(val) => val.parse().unwrap_or_else(|_| {
-            tracing::warn!(var = name, value = %val, "invalid value, using default");
-            default
-        }),
-        Err(_) => default,
-    }
-}
+// `env_or` is provided by `scp_transport::startup::env_or`.
 
 // ---------------------------------------------------------------------------
 // Storage path resolution
@@ -326,46 +315,13 @@ impl<S: Storage + 'static> SequenceStore for StorageSequenceStore<S> {
 // Tracing
 // ---------------------------------------------------------------------------
 
-/// Initializes the `tracing` subscriber.
-fn init_tracing() {
-    let default_level = env::var("SCP_RELAY_LOG_LEVEL").unwrap_or_else(|_| "info".into());
-    let filter = EnvFilter::try_from_default_env().unwrap_or_else(|_| {
-        EnvFilter::try_new(&default_level).unwrap_or_else(|_| EnvFilter::new("info"))
-    });
-
-    let format = env::var("SCP_RELAY_LOG_FORMAT").unwrap_or_else(|_| "pretty".into());
-
-    if format == "json" {
-        tracing_subscriber::fmt()
-            .json()
-            .with_env_filter(filter)
-            .init();
-    } else {
-        tracing_subscriber::fmt().with_env_filter(filter).init();
-    }
-}
+// `init_tracing` is provided by `scp_transport::startup::init_tracing`.
 
 // ---------------------------------------------------------------------------
 // Relay config from env
 // ---------------------------------------------------------------------------
 
-/// Builds a [`RelayConfig`] from `SCP_RELAY_*` environment variables.
-fn relay_config_from_env() -> RelayConfig {
-    let bind_addr: SocketAddr = env_or(
-        "SCP_RELAY_BIND_ADDR",
-        SocketAddr::from(([0, 0, 0, 0], 9000)),
-    );
-
-    RelayConfig {
-        bind_addr,
-        max_blob_size: env_or("SCP_RELAY_MAX_BLOB_SIZE", 262_144),
-        max_blob_ttl: env_or("SCP_RELAY_MAX_BLOB_TTL", 604_800),
-        max_total_connections: env_or("SCP_RELAY_MAX_CONNECTIONS", 1_000),
-        max_connections_per_ip: env_or("SCP_RELAY_MAX_CONNECTIONS_PER_IP", 10),
-        rate_limit_publishes_per_second: env_or("SCP_RELAY_RATE_LIMIT", 100),
-        ..RelayConfig::default()
-    }
-}
+// `relay_config_from_env` is provided by `scp_transport::startup::relay_config_from_env`.
 
 // ---------------------------------------------------------------------------
 // Self-signed TLS provider (development mode)
@@ -395,130 +351,17 @@ impl TlsProvider for SelfSignedTlsProvider {
 }
 
 // ---------------------------------------------------------------------------
-// Health check
+// Health check + shutdown signal
 // ---------------------------------------------------------------------------
 
-/// Runs the `--health` probe: attempts a TCP connection to `addr` and
-/// exits with 0 on success, 1 on failure.
-async fn health_check(addr: SocketAddr) {
-    match tokio::net::TcpStream::connect(addr).await {
-        Ok(_) => std::process::exit(0),
-        Err(_) => std::process::exit(1),
-    }
-}
-
-// ---------------------------------------------------------------------------
-// Shutdown signal
-// ---------------------------------------------------------------------------
-
-/// Waits for either SIGINT (`ctrl_c`) or SIGTERM.
-async fn shutdown_signal() {
-    let ctrl_c = tokio::signal::ctrl_c();
-
-    #[cfg(unix)]
-    {
-        let mut sigterm = tokio::signal::unix::signal(tokio::signal::unix::SignalKind::terminate())
-            .unwrap_or_else(|_| {
-                tokio::signal::unix::signal(tokio::signal::unix::SignalKind::interrupt())
-                    .unwrap_or_else(|_| std::process::exit(1))
-            });
-        tokio::select! {
-            _ = ctrl_c => {}
-            _ = sigterm.recv() => {}
-        }
-    }
-
-    #[cfg(not(unix))]
-    {
-        let _ = ctrl_c.await;
-    }
-}
+// `health_check` and `shutdown_signal` are provided by
+// `scp_transport::startup`.
 
 // ---------------------------------------------------------------------------
 // Relay blob storage from env
 // ---------------------------------------------------------------------------
 
-/// Valid backend names for error messages.
-const VALID_BLOB_BACKENDS: &str = "sqlite, redb, postgres, s3, memory";
-
-/// Constructs the blob storage backend from environment configuration.
-///
-/// Reads `SCP_RELAY_STORAGE_BACKEND` (default: `sqlite`) and delegates to the
-/// appropriate backend constructor. Exits on misconfiguration with a
-/// descriptive error naming the valid options.
-///
-/// This mirrors the logic in `scp-relay/src/main.rs::storage_from_env()`.
-async fn blob_storage_from_env() -> BlobStorageBackend {
-    let backend = env::var("SCP_RELAY_STORAGE_BACKEND")
-        .unwrap_or_else(|_| "sqlite".to_owned())
-        .to_lowercase();
-
-    match backend.as_str() {
-        "sqlite" => {
-            let path =
-                env::var("SCP_RELAY_STORAGE_PATH").unwrap_or_else(|_| "./scp-relay.db".to_owned());
-            let path = PathBuf::from(path);
-            tracing::info!(path = %path.display(), "using sqlite blob storage");
-            BlobStorageBackend::sqlite(&path).unwrap_or_else(|e| {
-                tracing::error!(error = %e, path = %path.display(), "failed to open sqlite blob storage");
-                std::process::exit(1);
-            })
-        }
-        "redb" => {
-            let path = env::var("SCP_RELAY_STORAGE_PATH")
-                .unwrap_or_else(|_| "./scp-relay.redb".to_owned());
-            let path = PathBuf::from(path);
-            tracing::info!(path = %path.display(), "using redb blob storage");
-            BlobStorageBackend::redb(&path).unwrap_or_else(|e| {
-                tracing::error!(error = %e, path = %path.display(), "failed to open redb blob storage");
-                std::process::exit(1);
-            })
-        }
-        "postgres" => {
-            let Ok(url) = env::var("SCP_RELAY_DATABASE_URL") else {
-                eprintln!(
-                    "error: SCP_RELAY_STORAGE_BACKEND=postgres requires SCP_RELAY_DATABASE_URL to be set"
-                );
-                std::process::exit(1);
-            };
-            tracing::info!("using postgres blob storage");
-            let store = scp_transport::native::postgres_blob::PostgresBlobStore::open(&url)
-                .await
-                .unwrap_or_else(|e| {
-                    tracing::error!(error = %e, "failed to connect to postgres");
-                    std::process::exit(1);
-                });
-            BlobStorageBackend::Postgres(store)
-        }
-        "s3" => {
-            let Ok(bucket) = env::var("SCP_RELAY_S3_BUCKET") else {
-                eprintln!(
-                    "error: SCP_RELAY_STORAGE_BACKEND=s3 requires SCP_RELAY_S3_BUCKET to be set"
-                );
-                std::process::exit(1);
-            };
-            let prefix = env::var("SCP_RELAY_S3_PREFIX").unwrap_or_else(|_| "blobs/".to_owned());
-            tracing::info!(bucket = %bucket, prefix = %prefix, "using s3 blob storage");
-            let store = scp_transport::native::s3_blob::S3BlobStore::open(&bucket, &prefix)
-                .await
-                .unwrap_or_else(|e| {
-                    tracing::error!(error = %e, "failed to initialize s3 storage");
-                    std::process::exit(1);
-                });
-            BlobStorageBackend::S3(store)
-        }
-        "memory" => {
-            tracing::warn!("using in-memory blob storage — all data will be lost on restart");
-            BlobStorageBackend::in_memory()
-        }
-        other => {
-            eprintln!(
-                "error: unknown storage backend '{other}'. Valid options: {VALID_BLOB_BACKENDS}"
-            );
-            std::process::exit(1);
-        }
-    }
-}
+// `storage_from_env` is provided by `scp_transport::startup::storage_from_env`.
 
 // ---------------------------------------------------------------------------
 // Relay-only mode
@@ -526,7 +369,7 @@ async fn blob_storage_from_env() -> BlobStorageBackend {
 
 /// Runs a bare relay server (same as `scp-relay` binary).
 async fn run_relay_only() {
-    let config = relay_config_from_env();
+    let config = startup::relay_config_from_env();
     tracing::info!(
         bind_addr = %config.bind_addr,
         max_blob_size = config.max_blob_size,
@@ -534,7 +377,7 @@ async fn run_relay_only() {
         "starting scp-node in relay-only mode"
     );
 
-    let storage = Arc::new(blob_storage_from_env().await);
+    let storage = Arc::new(startup::storage_from_env().await);
     let server = RelayServer::new(config, storage);
 
     let (handle, local_addr) = match server.start().await {
@@ -547,7 +390,7 @@ async fn run_relay_only() {
 
     tracing::info!(addr = %local_addr, "relay listening");
 
-    shutdown_signal().await;
+    startup::shutdown_signal().await;
 
     tracing::info!("shutdown signal received, stopping relay");
     handle.shutdown();
@@ -804,7 +647,7 @@ fn require_domain() -> String {
 
 /// Reads the HTTP bind address from env or returns the default.
 fn node_http_addr() -> SocketAddr {
-    env_or("SCP_NODE_BIND_ADDR", SocketAddr::from(([0, 0, 0, 0], 9000)))
+    startup::env_or("SCP_NODE_BIND_ADDR", SocketAddr::from(([0, 0, 0, 0], 9000)))
 }
 
 /// Builds a [`PkarrDhtClient`] from env configuration.
@@ -873,7 +716,7 @@ async fn run_node_with<
         .map(|v| v == "1" || v == "true")
         .unwrap_or(false);
 
-    let projection_rate: u32 = env_or(
+    let projection_rate: u32 = startup::env_or(
         "SCP_NODE_PROJECTION_RATE_LIMIT",
         scp_node::DEFAULT_PROJECTION_RATE_LIMIT,
     );
@@ -949,7 +792,7 @@ async fn run_node_with<
     // Install Prometheus metrics recorder and add /metrics endpoint (#1467).
     let metrics_router = install_metrics_recorder();
 
-    if let Err(e) = node.serve(metrics_router, shutdown_signal()).await {
+    if let Err(e) = node.serve(metrics_router, startup::shutdown_signal()).await {
         tracing::error!(error = %e, "application node exited with error");
         std::process::exit(1);
     }
@@ -1008,21 +851,21 @@ async fn main() {
     // --health: probe the appropriate bind address and exit.
     if config.health {
         let addr: SocketAddr = if config.relay_only {
-            env_or(
+            startup::env_or(
                 "SCP_RELAY_BIND_ADDR",
                 SocketAddr::from(([127, 0, 0, 1], 9000)),
             )
         } else {
-            env_or(
+            startup::env_or(
                 "SCP_NODE_BIND_ADDR",
                 SocketAddr::from(([127, 0, 0, 1], 9000)),
             )
         };
-        health_check(addr).await;
+        startup::health_check(addr).await;
         return;
     }
 
-    init_tracing();
+    startup::init_tracing();
 
     if config.relay_only {
         run_relay_only().await;

--- a/crates/scp-relay/Cargo.toml
+++ b/crates/scp-relay/Cargo.toml
@@ -20,11 +20,11 @@ scp-transport = { path = "../scp-transport", version = "=0.1.0-beta.1", features
     "redb-blob",
     "postgres-blob",
     "s3-blob",
+    "startup",
 ] }
 axum = "0.8"
 tokio = { workspace = true }
 tracing = { workspace = true }
-tracing-subscriber = { version = "0.3", features = ["env-filter", "json"] }
 metrics = { workspace = true }
 metrics-exporter-prometheus = { workspace = true }
 

--- a/crates/scp-relay/src/main.rs
+++ b/crates/scp-relay/src/main.rs
@@ -23,204 +23,35 @@
 //!
 //! See §10.5 of the SCP infrastructure spec.
 
-use std::env;
 use std::net::SocketAddr;
-use std::path::PathBuf;
-use std::sync::Arc;
 
-use scp_transport::native::server::{RelayConfig, RelayServer};
-use scp_transport::native::storage::BlobStorageBackend;
-use tracing_subscriber::EnvFilter;
-
-/// Reads an environment variable and parses it, returning the default on
-/// absence or parse failure (with a warning).
-fn env_or<T: std::str::FromStr>(name: &str, default: T) -> T {
-    match env::var(name) {
-        Ok(val) => val.parse().unwrap_or_else(|_| {
-            tracing::warn!(var = name, value = %val, "invalid value, using default");
-            default
-        }),
-        Err(_) => default,
-    }
-}
-
-/// Builds a [`RelayConfig`] from `SCP_RELAY_*` environment variables.
-fn config_from_env() -> RelayConfig {
-    let bind_addr: SocketAddr = env_or(
-        "SCP_RELAY_BIND_ADDR",
-        SocketAddr::from(([0, 0, 0, 0], 9000)),
-    );
-
-    RelayConfig {
-        bind_addr,
-        max_blob_size: env_or("SCP_RELAY_MAX_BLOB_SIZE", 262_144),
-        max_blob_ttl: env_or("SCP_RELAY_MAX_BLOB_TTL", 604_800),
-        max_total_connections: env_or("SCP_RELAY_MAX_CONNECTIONS", 1_000),
-        max_connections_per_ip: env_or("SCP_RELAY_MAX_CONNECTIONS_PER_IP", 10),
-        rate_limit_publishes_per_second: env_or("SCP_RELAY_RATE_LIMIT", 100),
-        ..RelayConfig::default()
-    }
-}
-
-/// Valid backend names for error messages.
-const VALID_BACKENDS: &str = "sqlite, redb, postgres, s3, memory";
-
-/// Constructs the blob storage backend from environment configuration.
-///
-/// Reads `SCP_RELAY_STORAGE_BACKEND` (default: `sqlite`) and delegates to the
-/// appropriate backend constructor. Exits on misconfiguration with a
-/// descriptive error naming the valid options.
-async fn storage_from_env() -> BlobStorageBackend {
-    let backend = env::var("SCP_RELAY_STORAGE_BACKEND")
-        .unwrap_or_else(|_| "sqlite".to_owned())
-        .to_lowercase();
-
-    match backend.as_str() {
-        "sqlite" => {
-            let path =
-                env::var("SCP_RELAY_STORAGE_PATH").unwrap_or_else(|_| "./scp-relay.db".to_owned());
-            let path = PathBuf::from(path);
-            tracing::info!(path = %path.display(), "using sqlite blob storage");
-            BlobStorageBackend::sqlite(&path).unwrap_or_else(|e| {
-                tracing::error!(error = %e, path = %path.display(), "failed to open sqlite storage");
-                std::process::exit(1);
-            })
-        }
-        "redb" => {
-            let path = env::var("SCP_RELAY_STORAGE_PATH")
-                .unwrap_or_else(|_| "./scp-relay.redb".to_owned());
-            let path = PathBuf::from(path);
-            tracing::info!(path = %path.display(), "using redb blob storage");
-            BlobStorageBackend::redb(&path).unwrap_or_else(|e| {
-                tracing::error!(error = %e, path = %path.display(), "failed to open redb storage");
-                std::process::exit(1);
-            })
-        }
-        "postgres" => {
-            let Ok(url) = env::var("SCP_RELAY_DATABASE_URL") else {
-                eprintln!(
-                    "error: SCP_RELAY_STORAGE_BACKEND=postgres requires SCP_RELAY_DATABASE_URL to be set"
-                );
-                std::process::exit(1);
-            };
-            tracing::info!("using postgres blob storage");
-            let store = scp_transport::native::postgres_blob::PostgresBlobStore::open(&url)
-                .await
-                .unwrap_or_else(|e| {
-                    tracing::error!(error = %e, "failed to connect to postgres");
-                    std::process::exit(1);
-                });
-            BlobStorageBackend::Postgres(store)
-        }
-        "s3" => {
-            let Ok(bucket) = env::var("SCP_RELAY_S3_BUCKET") else {
-                eprintln!(
-                    "error: SCP_RELAY_STORAGE_BACKEND=s3 requires SCP_RELAY_S3_BUCKET to be set"
-                );
-                std::process::exit(1);
-            };
-            let prefix = env::var("SCP_RELAY_S3_PREFIX").unwrap_or_else(|_| "blobs/".to_owned());
-            tracing::info!(bucket = %bucket, prefix = %prefix, "using s3 blob storage");
-            let store = scp_transport::native::s3_blob::S3BlobStore::open(&bucket, &prefix)
-                .await
-                .unwrap_or_else(|e| {
-                    tracing::error!(error = %e, "failed to initialize s3 storage");
-                    std::process::exit(1);
-                });
-            BlobStorageBackend::S3(store)
-        }
-        "memory" => {
-            tracing::warn!("using in-memory blob storage — all data will be lost on restart");
-            BlobStorageBackend::in_memory()
-        }
-        other => {
-            eprintln!("error: unknown storage backend '{other}'. Valid options: {VALID_BACKENDS}");
-            std::process::exit(1);
-        }
-    }
-}
-
-/// Initializes the `tracing` subscriber.
-///
-/// Log level is determined by `RUST_LOG` (takes precedence) or
-/// `SCP_RELAY_LOG_LEVEL` (default: `info`). Output format is controlled
-/// by `SCP_RELAY_LOG_FORMAT`: `json` for structured JSON, anything else
-/// for human-readable pretty output.
-fn init_tracing() {
-    let default_level = env::var("SCP_RELAY_LOG_LEVEL").unwrap_or_else(|_| "info".into());
-    let filter = EnvFilter::try_from_default_env().unwrap_or_else(|_| {
-        EnvFilter::try_new(&default_level).unwrap_or_else(|_| EnvFilter::new("info"))
-    });
-
-    let format = env::var("SCP_RELAY_LOG_FORMAT").unwrap_or_else(|_| "pretty".into());
-
-    if format == "json" {
-        tracing_subscriber::fmt()
-            .json()
-            .with_writer(std::io::stderr)
-            .with_env_filter(filter)
-            .init();
-    } else {
-        tracing_subscriber::fmt()
-            .with_writer(std::io::stderr)
-            .with_env_filter(filter)
-            .init();
-    }
-}
-
-/// Runs the `--health` probe: attempts a TCP connection to `addr` and
-/// exits with 0 on success, 1 on failure.
-async fn health_check(addr: SocketAddr) {
-    match tokio::net::TcpStream::connect(addr).await {
-        Ok(_) => std::process::exit(0),
-        Err(_) => std::process::exit(1),
-    }
-}
+use scp_transport::startup;
 
 #[tokio::main]
 async fn main() {
     // Check for --health before initializing tracing (keep probe quiet).
-    let args: Vec<String> = env::args().collect();
+    let args: Vec<String> = std::env::args().collect();
     if args.iter().any(|a| a == "--health") {
-        let addr: SocketAddr = env_or(
+        let addr: SocketAddr = startup::env_or(
             "SCP_RELAY_BIND_ADDR",
             SocketAddr::from(([127, 0, 0, 1], 9000)),
         );
-        health_check(addr).await;
+        startup::health_check(addr).await;
         // health_check always calls process::exit, but satisfy the compiler.
         return;
     }
 
-    init_tracing();
+    startup::init_tracing();
 
-    let config = config_from_env();
-    tracing::info!(
-        bind_addr = %config.bind_addr,
-        max_blob_size = config.max_blob_size,
-        max_connections = config.max_total_connections,
-        "starting scp-relay"
-    );
-
-    let storage = Arc::new(storage_from_env().await);
-    let server = RelayServer::new(config, storage);
-
-    let (handle, local_addr) = match server.start().await {
-        Ok(pair) => pair,
-        Err(e) => {
-            tracing::error!(error = %e, "relay failed to start");
-            std::process::exit(1);
-        }
-    };
-
-    tracing::info!(addr = %local_addr, "relay listening");
+    let (handle, _local_addr, _storage) = startup::start_relay_from_env().await;
 
     // Start Prometheus metrics HTTP server on a separate port (#1467).
-    let metrics_port = env_or("SCP_RELAY_METRICS_PORT", 9001u16);
+    let metrics_port = startup::env_or("SCP_RELAY_METRICS_PORT", 9001u16);
     let metrics_addr: SocketAddr = SocketAddr::from(([0, 0, 0, 0], metrics_port));
     let metrics_handle = spawn_metrics_server(metrics_addr).await;
 
     // Wait for shutdown signal (SIGINT / SIGTERM).
-    shutdown_signal().await;
+    startup::shutdown_signal().await;
 
     tracing::info!("shutdown signal received, stopping relay");
     if let Some(h) = metrics_handle {
@@ -283,30 +114,4 @@ async fn spawn_metrics_server(addr: SocketAddr) -> Option<tokio::task::JoinHandl
     Some(tokio::spawn(async move {
         let _ = axum::serve(listener, app).await;
     }))
-}
-
-/// Waits for either SIGINT (`ctrl_c`) or SIGTERM.
-async fn shutdown_signal() {
-    let ctrl_c = tokio::signal::ctrl_c();
-
-    #[cfg(unix)]
-    {
-        let mut sigterm = tokio::signal::unix::signal(tokio::signal::unix::SignalKind::terminate())
-            .unwrap_or_else(|_| {
-                // If we cannot register SIGTERM, fall back to ctrl_c only.
-                // This is unreachable on any standard Unix system but
-                // satisfies the no-panic lint without process::exit.
-                tokio::signal::unix::signal(tokio::signal::unix::SignalKind::interrupt())
-                    .unwrap_or_else(|_| std::process::exit(1))
-            });
-        tokio::select! {
-            _ = ctrl_c => {}
-            _ = sigterm.recv() => {}
-        }
-    }
-
-    #[cfg(not(unix))]
-    {
-        let _ = ctrl_c.await;
-    }
 }

--- a/crates/scp-relay/tests/storage_backend.rs
+++ b/crates/scp-relay/tests/storage_backend.rs
@@ -188,7 +188,7 @@ fn default_backend_is_sqlite() {
         .env("SCP_RELAY_STORAGE_PATH", db_path.to_str().unwrap())
         .env("SCP_RELAY_BIND_ADDR", "127.0.0.1:0")
         .env("SCP_RELAY_LOG_FORMAT", "json")
-        .env("RUST_LOG", "scp_relay=info")
+        .env("RUST_LOG", "scp_relay=info,scp_transport=info")
         .stdout(std::process::Stdio::null())
         .stderr(std::process::Stdio::piped())
         .spawn()

--- a/crates/scp-transport/Cargo.toml
+++ b/crates/scp-transport/Cargo.toml
@@ -26,6 +26,9 @@ coap = ["dep:coap-lite", "dep:openssl"]
 nostr = ["dep:base64", "dep:k256"]
 webrtc = []
 upnp = ["dep:igd-next", "dep:natpmp"]
+# Shared startup utilities for relay/node binaries: env_or, config_from_env,
+# storage_from_env, init_tracing, health_check, shutdown_signal.
+startup = ["dep:tracing-subscriber"]
 
 [dependencies]
 scp-core = { path = "../scp-core", version = "=0.1.0-beta.1" }
@@ -76,6 +79,7 @@ base64 = { workspace = true, optional = true }
 k256 = { version = "0.13", optional = true, features = ["schnorr"] }
 igd-next = { version = "0.16", optional = true, features = ["aio_tokio"] }
 natpmp = { version = "0.5", optional = true, features = ["tokio"] }
+tracing-subscriber = { version = "0.3", optional = true, features = ["env-filter", "json"] }
 
 [dev-dependencies]
 scp-core = { path = "../scp-core" }

--- a/crates/scp-transport/src/lib.rs
+++ b/crates/scp-transport/src/lib.rs
@@ -51,6 +51,8 @@ pub mod provider;
 pub mod quic;
 pub mod relay;
 pub mod scoring;
+#[cfg(feature = "startup")]
+pub mod startup;
 pub mod traits;
 #[cfg(feature = "udp")]
 pub mod udp;

--- a/crates/scp-transport/src/startup.rs
+++ b/crates/scp-transport/src/startup.rs
@@ -28,7 +28,11 @@ use crate::native::storage::BlobStorageBackend;
 pub fn env_or<T: std::str::FromStr>(name: &str, default: T) -> T {
     match env::var(name) {
         Ok(val) => val.parse().unwrap_or_else(|_| {
-            tracing::warn!(var = name, value = %val, "invalid value, using default");
+            tracing::warn!(
+                var = name,
+                value_len = val.len(),
+                "invalid value, using default"
+            );
             default
         }),
         Err(_) => default,

--- a/crates/scp-transport/src/startup.rs
+++ b/crates/scp-transport/src/startup.rs
@@ -1,0 +1,288 @@
+//! Shared startup utilities for SCP relay and node binaries.
+//!
+//! Both `scp-relay` and `scp-node` binaries use identical logic for environment
+//! variable parsing, relay configuration, blob storage backend selection,
+//! tracing initialization, health checks, and graceful shutdown. This module
+//! provides the shared implementations so changes need only be made once.
+//!
+//! Gated behind the `startup` feature. Not used by the library or FFI bridges.
+//!
+//! See §10.5 of the SCP infrastructure spec.
+
+use std::env;
+use std::net::SocketAddr;
+use std::path::PathBuf;
+use std::sync::Arc;
+
+use tracing_subscriber::EnvFilter;
+
+use crate::native::server::RelayConfig;
+use crate::native::storage::BlobStorageBackend;
+
+// ---------------------------------------------------------------------------
+// env_or — typed environment variable with fallback
+// ---------------------------------------------------------------------------
+
+/// Reads an environment variable and parses it, returning the default on
+/// absence or parse failure (with a warning).
+pub fn env_or<T: std::str::FromStr>(name: &str, default: T) -> T {
+    match env::var(name) {
+        Ok(val) => val.parse().unwrap_or_else(|_| {
+            tracing::warn!(var = name, value = %val, "invalid value, using default");
+            default
+        }),
+        Err(_) => default,
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Relay configuration from environment
+// ---------------------------------------------------------------------------
+
+/// Builds a [`RelayConfig`] from `SCP_RELAY_*` environment variables.
+///
+/// | Variable | Default |
+/// |---|---|
+/// | `SCP_RELAY_BIND_ADDR` | `0.0.0.0:9000` |
+/// | `SCP_RELAY_MAX_BLOB_SIZE` | 262,144 (256 KiB) |
+/// | `SCP_RELAY_MAX_BLOB_TTL` | 604,800 (7 days) |
+/// | `SCP_RELAY_MAX_CONNECTIONS` | 1,000 |
+/// | `SCP_RELAY_MAX_CONNECTIONS_PER_IP` | 10 |
+/// | `SCP_RELAY_RATE_LIMIT` | 100 |
+#[must_use]
+pub fn relay_config_from_env() -> RelayConfig {
+    let bind_addr: SocketAddr = env_or(
+        "SCP_RELAY_BIND_ADDR",
+        SocketAddr::from(([0, 0, 0, 0], 9000)),
+    );
+
+    RelayConfig {
+        bind_addr,
+        max_blob_size: env_or("SCP_RELAY_MAX_BLOB_SIZE", 262_144),
+        max_blob_ttl: env_or("SCP_RELAY_MAX_BLOB_TTL", 604_800),
+        max_total_connections: env_or("SCP_RELAY_MAX_CONNECTIONS", 1_000),
+        max_connections_per_ip: env_or("SCP_RELAY_MAX_CONNECTIONS_PER_IP", 10),
+        rate_limit_publishes_per_second: env_or("SCP_RELAY_RATE_LIMIT", 100),
+        ..RelayConfig::default()
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Blob storage backend from environment
+// ---------------------------------------------------------------------------
+
+/// Valid backend names for error messages.
+pub const VALID_BACKENDS: &str = "sqlite, redb, postgres, s3, memory";
+
+/// Constructs the blob storage backend from environment configuration.
+///
+/// Reads `SCP_RELAY_STORAGE_BACKEND` (default: `sqlite`) and delegates to the
+/// appropriate backend constructor. Calls [`std::process::exit`] on
+/// misconfiguration with a descriptive error naming the valid options.
+///
+/// # Storage backend selection
+///
+/// | Value | Backend | Config env vars | Default |
+/// |---|---|---|---|
+/// | `sqlite` | `SQLite` | `SCP_RELAY_STORAGE_PATH` (default `./scp-relay.db`) | **yes** |
+/// | `redb` | redb | `SCP_RELAY_STORAGE_PATH` (default `./scp-relay.redb`) | |
+/// | `postgres` | `PostgreSQL` | `SCP_RELAY_DATABASE_URL` (required) | |
+/// | `s3` | S3-compat | `SCP_RELAY_S3_BUCKET` (required) + AWS env | |
+/// | `memory` | In-memory | — | |
+///
+/// # Panics
+///
+/// Backend arms are compiled only when the corresponding feature is enabled
+/// (`sqlite-blob`, `redb-blob`, `postgres-blob`, `s3-blob`). If a backend
+/// is requested but the feature is not compiled in, the function prints an
+/// error and exits.
+pub async fn storage_from_env() -> BlobStorageBackend {
+    let backend = env::var("SCP_RELAY_STORAGE_BACKEND")
+        .unwrap_or_else(|_| "sqlite".to_owned())
+        .to_lowercase();
+
+    match backend.as_str() {
+        #[cfg(feature = "sqlite-blob")]
+        "sqlite" => {
+            let path =
+                env::var("SCP_RELAY_STORAGE_PATH").unwrap_or_else(|_| "./scp-relay.db".to_owned());
+            let path = PathBuf::from(path);
+            tracing::info!(path = %path.display(), "using sqlite blob storage");
+            BlobStorageBackend::sqlite(&path).unwrap_or_else(|e| {
+                tracing::error!(error = %e, path = %path.display(), "failed to open sqlite storage");
+                std::process::exit(1);
+            })
+        }
+        #[cfg(feature = "redb-blob")]
+        "redb" => {
+            let path = env::var("SCP_RELAY_STORAGE_PATH")
+                .unwrap_or_else(|_| "./scp-relay.redb".to_owned());
+            let path = PathBuf::from(path);
+            tracing::info!(path = %path.display(), "using redb blob storage");
+            BlobStorageBackend::redb(&path).unwrap_or_else(|e| {
+                tracing::error!(error = %e, path = %path.display(), "failed to open redb storage");
+                std::process::exit(1);
+            })
+        }
+        #[cfg(feature = "postgres-blob")]
+        "postgres" => {
+            let Ok(url) = env::var("SCP_RELAY_DATABASE_URL") else {
+                eprintln!(
+                    "error: SCP_RELAY_STORAGE_BACKEND=postgres requires SCP_RELAY_DATABASE_URL to be set"
+                );
+                std::process::exit(1);
+            };
+            tracing::info!("using postgres blob storage");
+            let store = crate::native::postgres_blob::PostgresBlobStore::open(&url)
+                .await
+                .unwrap_or_else(|e| {
+                    tracing::error!(error = %e, "failed to connect to postgres");
+                    std::process::exit(1);
+                });
+            BlobStorageBackend::Postgres(store)
+        }
+        #[cfg(feature = "s3-blob")]
+        "s3" => {
+            let Ok(bucket) = env::var("SCP_RELAY_S3_BUCKET") else {
+                eprintln!(
+                    "error: SCP_RELAY_STORAGE_BACKEND=s3 requires SCP_RELAY_S3_BUCKET to be set"
+                );
+                std::process::exit(1);
+            };
+            let prefix = env::var("SCP_RELAY_S3_PREFIX").unwrap_or_else(|_| "blobs/".to_owned());
+            tracing::info!(bucket = %bucket, prefix = %prefix, "using s3 blob storage");
+            let store = crate::native::s3_blob::S3BlobStore::open(&bucket, &prefix)
+                .await
+                .unwrap_or_else(|e| {
+                    tracing::error!(error = %e, "failed to initialize s3 storage");
+                    std::process::exit(1);
+                });
+            BlobStorageBackend::S3(store)
+        }
+        "memory" => {
+            tracing::warn!("using in-memory blob storage — all data will be lost on restart");
+            BlobStorageBackend::in_memory()
+        }
+        other => {
+            eprintln!("error: unknown storage backend '{other}'. Valid options: {VALID_BACKENDS}");
+            std::process::exit(1);
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Tracing initialization
+// ---------------------------------------------------------------------------
+
+/// Initializes the `tracing` subscriber.
+///
+/// Log level is determined by `RUST_LOG` (takes precedence) or
+/// `SCP_RELAY_LOG_LEVEL` (default: `info`). Output format is controlled
+/// by `SCP_RELAY_LOG_FORMAT`: `json` for structured JSON, anything else
+/// for human-readable pretty output.
+pub fn init_tracing() {
+    let default_level = env::var("SCP_RELAY_LOG_LEVEL").unwrap_or_else(|_| "info".into());
+    let filter = EnvFilter::try_from_default_env().unwrap_or_else(|_| {
+        EnvFilter::try_new(&default_level).unwrap_or_else(|_| EnvFilter::new("info"))
+    });
+
+    let format = env::var("SCP_RELAY_LOG_FORMAT").unwrap_or_else(|_| "pretty".into());
+
+    if format == "json" {
+        tracing_subscriber::fmt()
+            .json()
+            .with_writer(std::io::stderr)
+            .with_env_filter(filter)
+            .init();
+    } else {
+        tracing_subscriber::fmt()
+            .with_writer(std::io::stderr)
+            .with_env_filter(filter)
+            .init();
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Health check
+// ---------------------------------------------------------------------------
+
+/// Runs a TCP health probe: attempts a connection to `addr` and exits with
+/// code 0 on success, 1 on failure.
+///
+/// Designed for container health checks (`--health` CLI flag).
+pub async fn health_check(addr: SocketAddr) {
+    match tokio::net::TcpStream::connect(addr).await {
+        Ok(_) => std::process::exit(0),
+        Err(_) => std::process::exit(1),
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Shutdown signal
+// ---------------------------------------------------------------------------
+
+/// Waits for either SIGINT (`ctrl_c`) or SIGTERM.
+///
+/// On non-Unix platforms, only `ctrl_c` is supported.
+pub async fn shutdown_signal() {
+    let ctrl_c = tokio::signal::ctrl_c();
+
+    #[cfg(unix)]
+    {
+        let mut sigterm = tokio::signal::unix::signal(tokio::signal::unix::SignalKind::terminate())
+            .unwrap_or_else(|_| {
+                // If we cannot register SIGTERM, fall back to ctrl_c only.
+                // This is unreachable on any standard Unix system but
+                // satisfies the no-panic lint without process::exit.
+                tokio::signal::unix::signal(tokio::signal::unix::SignalKind::interrupt())
+                    .unwrap_or_else(|_| std::process::exit(1))
+            });
+        tokio::select! {
+            _ = ctrl_c => {}
+            _ = sigterm.recv() => {}
+        }
+    }
+
+    #[cfg(not(unix))]
+    {
+        let _ = ctrl_c.await;
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Relay startup helper
+// ---------------------------------------------------------------------------
+
+/// Starts a relay server from environment configuration and returns the
+/// server handle, bound address, and storage reference.
+///
+/// This encapsulates the common pattern of reading config + storage from env,
+/// building the relay, starting it, and logging the result.
+pub async fn start_relay_from_env() -> (
+    crate::native::server::ShutdownHandle,
+    SocketAddr,
+    Arc<BlobStorageBackend>,
+) {
+    let config = relay_config_from_env();
+    tracing::info!(
+        bind_addr = %config.bind_addr,
+        max_blob_size = config.max_blob_size,
+        max_connections = config.max_total_connections,
+        "starting relay"
+    );
+
+    let storage = Arc::new(storage_from_env().await);
+    let server = crate::native::server::RelayServer::new(config, Arc::clone(&storage));
+
+    let (handle, local_addr) = match server.start().await {
+        Ok(pair) => pair,
+        Err(e) => {
+            tracing::error!(error = %e, "relay failed to start");
+            std::process::exit(1);
+        }
+    };
+
+    tracing::info!(addr = %local_addr, "relay listening");
+
+    (handle, local_addr, storage)
+}


### PR DESCRIPTION
## Summary

Completes the Phase 2 items from the master plan that were skipped in PR #1627.

### BridgeContextState extraction (#1227)
- New `bridge_state.rs` in scp-ffi-common with shared `BridgeContextState`
- All 3 bridges import from common instead of defining locally

### Attestation construction (#1457)
- New `attestation.rs` in scp-ffi-common with `build_unsigned_attestation()`
- All 3 bridges delegate construction to shared function

### Relay/node startup extraction (#1242)
- New `startup.rs` in scp-transport with shared env parsing, config, tracing, health check, shutdown signal
- `scp-relay/src/main.rs` reduced from ~313 to ~109 lines
- `scp-node/src/main.rs` delegates all duplicated functions

### Validate.rs (#1371)
Already completed in a prior PR.

**Net: -570 lines**

## Test plan
- [ ] `cargo clippy --workspace --all-targets --features ...` — 0 warnings
- [ ] `cargo test --workspace` — 0 failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)