### PR TITLE
fix: register SCP-ATTEST error codes and resolve semantic collisions

### DIFF
--- a/.docs/standards/sdk-common.md
+++ b/.docs/standards/sdk-common.md
@@ -43,6 +43,22 @@ ScpError (root)
 | `SCP-GOV-` | 11000-11999 |
 | `SCP-ECON-` | 12000-12999 |
 
+### Registered SCP-ATTEST- codes
+
+| Code | Description |
+|------|-------------|
+| `SCP-ATTEST-9001` | Device attestation provider call failed (Play Integrity API error) |
+| `SCP-ATTEST-9006` | Attestation verification requires raw JSON, which is absent |
+| `SCP-ATTEST-9010` | Identity link attestation create bridge function not yet exported |
+| `SCP-ATTEST-9011` | Identity link attestation list bridge function not yet exported |
+| `SCP-ATTEST-9012` | Identity link attestation remove bridge function not yet exported |
+| `SCP-ATTEST-9013` | Identity link attestation renew bridge function not yet exported |
+| `SCP-ATTEST-9014` | Identity link attestation verify bridge function not yet exported |
+| `SCP-ATTEST-9015` | Attestation JSON bytes are not valid UTF-8 |
+| `SCP-ATTEST-9016` | Attestation list JSON bytes are not valid UTF-8 |
+| `SCP-ATTEST-9017` | Failed to re-serialize attestation to UTF-8 JSON |
+| `SCP-ATTEST-9018` | Cryptographic-class verification method not verifiable via browser fetch |
+
 ## Stub and Placeholder Policy
 
 Code that does not fully implement its documented contract (acceptance criterion, ADR spec, or trait method) is a **stub**. Stubs are tolerated during phased implementation but must be traceable to the planning system.

--- a/bindings/swift/Sources/SCP/Identity.swift
+++ b/bindings/swift/Sources/SCP/Identity.swift
@@ -834,7 +834,7 @@ private struct AttestationWire: Codable {
         guard let data = json.data(using: .utf8) else {
             throw ScpError.Identity(
                 msg: "attestation JSON is not valid UTF-8",
-                code: "SCP-ATTEST-9010"
+                code: "SCP-ATTEST-9015"
             )
         }
         let decoder = JSONDecoder()
@@ -847,7 +847,7 @@ private struct AttestationWire: Codable {
         guard let data = json.data(using: .utf8) else {
             throw ScpError.Identity(
                 msg: "attestation list JSON is not valid UTF-8",
-                code: "SCP-ATTEST-9011"
+                code: "SCP-ATTEST-9016"
             )
         }
         let decoder = JSONDecoder()
@@ -891,7 +891,7 @@ private struct AttestationWire: Codable {
         guard let json = try String(data: encoder.encode(wire), encoding: .utf8) else {
             throw ScpError.Identity(
                 msg: "failed to encode attestation as UTF-8 JSON",
-                code: "SCP-ATTEST-9012"
+                code: "SCP-ATTEST-9017"
             )
         }
         return json

--- a/crates/scp-ffi/common/src/error_codes.rs
+++ b/crates/scp-ffi/common/src/error_codes.rs
@@ -668,8 +668,38 @@ pub const VALID_7403: &str = "SCP-VALID-7403";
 // Attestation (SCP-ATTEST- 9000--9999)
 // -------------------------------------------------------------------------
 
-/// Attestation operation error.
+/// Device attestation provider call failed (Play Integrity API error).
+pub const ATTEST_9001: &str = "SCP-ATTEST-9001";
+
+/// Attestation signature verification requires raw JSON, which is absent.
+pub const ATTEST_9006: &str = "SCP-ATTEST-9006";
+
+/// Identity link attestation create bridge function not yet exported.
 pub const ATTEST_9010: &str = "SCP-ATTEST-9010";
+
+/// Identity link attestation list bridge function not yet exported.
+pub const ATTEST_9011: &str = "SCP-ATTEST-9011";
+
+/// Identity link attestation remove bridge function not yet exported.
+pub const ATTEST_9012: &str = "SCP-ATTEST-9012";
+
+/// Identity link attestation renew bridge function not yet exported.
+pub const ATTEST_9013: &str = "SCP-ATTEST-9013";
+
+/// Identity link attestation verify bridge function not yet exported.
+pub const ATTEST_9014: &str = "SCP-ATTEST-9014";
+
+/// Attestation JSON bytes are not valid UTF-8.
+pub const ATTEST_9015: &str = "SCP-ATTEST-9015";
+
+/// Attestation list JSON bytes are not valid UTF-8.
+pub const ATTEST_9016: &str = "SCP-ATTEST-9016";
+
+/// Failed to re-serialize attestation to UTF-8 JSON.
+pub const ATTEST_9017: &str = "SCP-ATTEST-9017";
+
+/// Cryptographic-class verification method not verifiable via browser fetch.
+pub const ATTEST_9018: &str = "SCP-ATTEST-9018";
 
 // -------------------------------------------------------------------------
 // Economy (SCP-ECON- 12000--12999)

--- a/crates/scp-ffi/wasm/src/reference_verify.rs
+++ b/crates/scp-ffi/wasm/src/reference_verify.rs
@@ -450,7 +450,7 @@ pub fn verify_reference_attestation(attestation_json: String) -> Promise {
                              via fetch — use WebCrypto in the TypeScript wrapper layer",
                         input.method
                     ),
-                    code: codes::ATTEST_9010.to_owned(),
+                    code: codes::ATTEST_9018.to_owned(),
                 }
                 .into_js()
                 .into());


### PR DESCRIPTION
## Summary

- Registers `ATTEST_9001` through `ATTEST_9018` in `error_codes.rs` (previously only `ATTEST_9010` existed, with a misleading description)
- Fixes semantic collisions: codes 9010-9012 had three different meanings across Python/TS, Swift, and WASM bridges
- Swift UTF-8 parse error codes reassigned to 9015-9017 (were colliding with Python/TS bridge-not-available guards at 9010-9012)
- WASM crypto-class verification rejection reassigned to 9018 (was colliding with Python/TS 9010)
- Adds the registered per-code table to `.docs/standards/sdk-common.md`

## Verification

- `cargo clippy -p scp-ffi-common -- -D warnings` — clean
- `cargo clippy -p scp-ffi-wasm --target wasm32-unknown-unknown -- -D warnings` — clean
- `bash scripts/check-error-codes.sh` — 2106 occurrences checked, all in range

Closes #1512