### PR TITLE
fix: enforce integer timestamps for verifiedAt/revokedAt across SDKs

### DIFF
--- a/bindings/python/scp_sdk/identity.py
+++ b/bindings/python/scp_sdk/identity.py
@@ -677,6 +677,9 @@ class RevocationStatus:
             raise ValueError(
                 f"Invalid revocation status: {self.status!r} (expected 'active' or 'revoked')"
             )
+        # Coerce revoked_at to int — floats can sneak in from JSON deserialization.
+        if self.revoked_at is not None and not isinstance(self.revoked_at, int):
+            object.__setattr__(self, "revoked_at", int(self.revoked_at))
 
 
 # ---------------------------------------------------------------------------
@@ -749,12 +752,12 @@ class IdentityAttestation:
         raw_rs = data.get("revocation_status", "active")
         if isinstance(raw_rs, dict) and "Revoked" in raw_rs:
             revoked_data = raw_rs["Revoked"]
-            revoked_at = revoked_data.get("revoked_at")
-            if revoked_at is None:
+            revoked_at_raw = revoked_data.get("revoked_at")
+            if revoked_at_raw is None:
                 raise ValueError("Bridge returned Revoked status without revoked_at timestamp")
             rs = RevocationStatus(
                 status="revoked",
-                revoked_at=revoked_at,
+                revoked_at=int(revoked_at_raw),
                 reason=revoked_data.get("reason"),
             )
         elif isinstance(raw_rs, str) and raw_rs.lower() == "active":
@@ -769,7 +772,7 @@ class IdentityAttestation:
             platform=data["platform"],
             platform_handle=data["platform_handle"],
             verification_method=data["verification_method"],
-            verified_at=data["verified_at"],
+            verified_at=int(data["verified_at"]),
             revocation_status=rs,
             platform_id=data.get("platform_id"),
         )

--- a/bindings/python/tests/test_identity_attestation.py
+++ b/bindings/python/tests/test_identity_attestation.py
@@ -85,6 +85,9 @@ class TestIdentityAttestationDataclass:
         att = IdentityAttestation._from_dict(data)
         assert att.revocation_status == RevocationStatus(status="active")
         assert att.platform_id is None
+        # Float verified_at should be coerced to int at the deserialization boundary.
+        assert isinstance(att.verified_at, int)
+        assert att.verified_at == 1700000000
 
     def test_to_bridge_dict_roundtrip(self) -> None:
         att = IdentityAttestation(

--- a/bindings/swift/Sources/SCP/Identity.swift
+++ b/bindings/swift/Sources/SCP/Identity.swift
@@ -550,7 +550,7 @@ public enum RevocationStatus: Sendable, Equatable {
     /// - Parameters:
     ///   - revokedAt: Unix timestamp (seconds) when the attestation was revoked.
     ///   - reason: Optional human-readable revocation reason.
-    case revoked(revokedAt: Int, reason: String? = nil)
+    case revoked(revokedAt: UInt64, reason: String? = nil)
 
     /// The status string: `"active"` or `"revoked"`. Internal — use pattern matching.
     var status: String {
@@ -564,7 +564,7 @@ public enum RevocationStatus: Sendable, Equatable {
 
     /// Unix timestamp (seconds) when the attestation was revoked.
     /// Returns `nil` for active attestations.
-    public var revokedAt: Int? {
+    public var revokedAt: UInt64? {
         switch self {
         case .active:
             return nil
@@ -901,7 +901,7 @@ private struct AttestationWire: Codable {
     func toIdentityAttestation(rawJson: String?) -> IdentityAttestation {
         let status: RevocationStatus = revocationStatus == "Active"
             ? .active
-            : .revoked(revokedAt: Int(issuedAt), reason: nil)
+            : .revoked(revokedAt: issuedAt, reason: nil)
         return IdentityAttestation(
             id: id,
             platform: claim.platform,

--- a/bindings/typescript/src/identity.ts
+++ b/bindings/typescript/src/identity.ts
@@ -41,13 +41,21 @@ export interface IdentityLinkAttestation {
     method: string;
     /** Opaque proof string per spec §3.5.2 — verifiers MUST use as-is in signature scope. */
     proof: string;
+    /** Unix timestamp (integer seconds) when the claim was verified. */
     verified_at: number;
     verifier_did?: string;
   };
   /** Revocation status: `"Active"` or `{ Revoked: { revoked_at, reason, revoked_by } }`. */
   revocation_status:
     | "Active"
-    | { Revoked: { revoked_at: number; reason: string; revoked_by: string } };
+    | {
+        Revoked: {
+          /** Unix timestamp (integer seconds) when the attestation was revoked. */
+          revoked_at: number;
+          reason: string;
+          revoked_by: string;
+        };
+      };
   /** Ed25519 signature bytes. */
   signature: number[];
 }
@@ -533,11 +541,14 @@ export class RevocationStatus {
   static _fromBridgeValue(raw: unknown): RevocationStatus {
     if (typeof raw === "object" && raw !== null && "Revoked" in raw) {
       const revoked = (raw as Record<string, Record<string, unknown>>).Revoked;
-      const revokedAt = revoked?.revoked_at as number | undefined;
-      if (revokedAt === undefined) {
+      const revokedAtRaw = revoked?.revoked_at as number | undefined;
+      if (revokedAtRaw === undefined) {
         throw new Error("Bridge returned Revoked status without revoked_at timestamp");
       }
-      return RevocationStatus.revoked(revokedAt, revoked?.reason as string | undefined);
+      return RevocationStatus.revoked(
+        Math.trunc(revokedAtRaw),
+        revoked?.reason as string | undefined,
+      );
     }
     if (typeof raw === "string") {
       const lower = raw.toLowerCase();
@@ -692,7 +703,9 @@ export class IdentityAttestation implements IdentityAttestationData {
     const verificationMethod = (evidence.method ??
       data.verification_method ??
       data.verificationMethod) as string;
-    const verifiedAt = (evidence.verified_at ?? data.verified_at ?? data.verifiedAt) as number;
+    const verifiedAt = Math.trunc(
+      (evidence.verified_at ?? data.verified_at ?? data.verifiedAt) as number,
+    );
     const rawRs = data.revocation_status ?? data.revocationStatus ?? "active";
     const revocationStatus =
       rawRs instanceof RevocationStatus ? rawRs : RevocationStatus._fromBridgeValue(rawRs);


### PR DESCRIPTION
## Summary

Rust source uses `u64` for all timestamps. Some SDKs used float types or didn't enforce integer at deserialization:

- **Swift**: `RevocationStatus.revokedAt` was `Int` (signed), now `UInt64` — matches `verifiedAt: UInt64`
- **Python**: Added `int()` coercion in `_from_dict` and `__post_init__` — prevents float smuggling
- **TypeScript**: Added `Math.trunc()` at JSON boundary + JSDoc documenting integer seconds
- **Kotlin**: Already correct (`Long`) — no changes

## Test plan

- [x] Python: `test_from_dict_missing_optional` now asserts `isinstance(att.verified_at, int)`
- [x] Python: ruff clean, 8/8 attestation tests pass
- [x] TypeScript: `bun run check` clean, 385 tests pass
- [x] Swift: types align (`UInt64` throughout)

Closes #1461

🤖 Generated with [Claude Code](https://claude.com/claude-code)