### PR TITLE
fix: add NaN/Infinity guards for timestamp coercion

### DIFF
--- a/bindings/python/scp_sdk/identity.py
+++ b/bindings/python/scp_sdk/identity.py
@@ -644,6 +644,27 @@ class Identity:
 
 
 # ---------------------------------------------------------------------------
+# Internal helpers
+# ---------------------------------------------------------------------------
+
+
+def _parse_finite_int(value: object, field_name: str) -> int:
+    """Coerce *value* to ``int``, raising :class:`ValueError` on NaN/Infinity.
+
+    ``int(float('nan'))`` and ``int(float('inf'))`` both raise
+    ``ValueError`` already, but ``int(float('nan'))`` raises
+    ``ValueError: cannot convert float NaN to integer`` with an unhelpful
+    message in some Python versions.  This wrapper normalises the error
+    message and catches ``OverflowError`` (raised for very large floats on
+    some platforms).
+    """
+    try:
+        return int(value)  # type: ignore[arg-type]
+    except (TypeError, ValueError, OverflowError) as e:
+        raise ValueError(f"{field_name} must be a finite integer: {e}") from e
+
+
+# ---------------------------------------------------------------------------
 # RevocationStatus
 # ---------------------------------------------------------------------------
 
@@ -722,6 +743,11 @@ class IdentityAttestation:
     #: Optional platform-assigned unique identifier.
     platform_id: str | None = None
 
+    def __post_init__(self) -> None:
+        # Coerce verified_at to int — floats can sneak in from JSON deserialization.
+        if not isinstance(self.verified_at, int):
+            self.verified_at = int(self.verified_at)
+
     def _to_bridge_dict(self) -> dict[str, Any]:
         """Convert to a dict for bridge serialization."""
         rs = self.revocation_status
@@ -757,7 +783,7 @@ class IdentityAttestation:
                 raise ValueError("Bridge returned Revoked status without revoked_at timestamp")
             rs = RevocationStatus(
                 status="revoked",
-                revoked_at=int(revoked_at_raw),
+                revoked_at=_parse_finite_int(revoked_at_raw, "revoked_at"),
                 reason=revoked_data.get("reason"),
             )
         elif isinstance(raw_rs, str) and raw_rs.lower() == "active":
@@ -772,7 +798,7 @@ class IdentityAttestation:
             platform=data["platform"],
             platform_handle=data["platform_handle"],
             verification_method=data["verification_method"],
-            verified_at=int(data["verified_at"]),
+            verified_at=_parse_finite_int(data["verified_at"], "verified_at"),
             revocation_status=rs,
             platform_id=data.get("platform_id"),
         )

--- a/bindings/typescript/src/identity.ts
+++ b/bindings/typescript/src/identity.ts
@@ -8,7 +8,7 @@
  * See ADR-022 in `.docs/adrs/phase-4.md` and `.docs/scaffold/typescript.md`.
  */
 
-import { IdentityError, mapBridgeError } from "./errors";
+import { IdentityError, mapBridgeError, ValidationError } from "./errors";
 import type { BridgeIdentityHandle } from "./internal/bridge";
 import { getBridge } from "./internal/bridge";
 import type { DIDDocument } from "./types";
@@ -545,6 +545,9 @@ export class RevocationStatus {
       if (revokedAtRaw === undefined) {
         throw new Error("Bridge returned Revoked status without revoked_at timestamp");
       }
+      if (!Number.isFinite(revokedAtRaw)) {
+        throw new ValidationError("revoked_at must be a finite number", "SCP-VALID-7004");
+      }
       return RevocationStatus.revoked(
         Math.trunc(revokedAtRaw),
         revoked?.reason as string | undefined,
@@ -703,9 +706,11 @@ export class IdentityAttestation implements IdentityAttestationData {
     const verificationMethod = (evidence.method ??
       data.verification_method ??
       data.verificationMethod) as string;
-    const verifiedAt = Math.trunc(
-      (evidence.verified_at ?? data.verified_at ?? data.verifiedAt) as number,
-    );
+    const verifiedAtRaw = (evidence.verified_at ?? data.verified_at ?? data.verifiedAt) as number;
+    if (!Number.isFinite(verifiedAtRaw)) {
+      throw new ValidationError("verified_at must be a finite number", "SCP-VALID-7003");
+    }
+    const verifiedAt = Math.trunc(verifiedAtRaw);
     const rawRs = data.revocation_status ?? data.revocationStatus ?? "active";
     const revocationStatus =
       rawRs instanceof RevocationStatus ? rawRs : RevocationStatus._fromBridgeValue(rawRs);


### PR DESCRIPTION
## Summary

Review follow-up for PR #1638. Black-hat review found `Math.trunc(NaN)` silently returns NaN, poisoning timestamp comparisons.

- **TypeScript**: Added `Number.isFinite()` guards before `Math.trunc()` for both `verifiedAt` and `revokedAt`, throwing `ValidationError` with appropriate error codes
- **Python**: Added `_parse_finite_int()` helper with `try/except` around `int()` to catch `TypeError`/`ValueError`/`OverflowError` with domain-specific error messages
- **Python**: Added `__post_init__` to `IdentityAttestation` for `verified_at` float→int coercion (matching existing `RevocationStatus` pattern)

## Test plan

- [x] TypeScript: `bun run check` clean, 385 tests pass
- [x] Python: ruff clean, attestation tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)