### PR TITLE
fix: update stale ATTEST error code reference in doc comment

### DIFF
--- a/crates/scp-ffi/wasm/src/reference_verify.rs
+++ b/crates/scp-ffi/wasm/src/reference_verify.rs
@@ -401,7 +401,7 @@ async fn verify_dns_record(issuer_did: &str, proof: &serde_json::Value) -> (bool
 ///   for TXT records at `{record_name}.{domain}`, checks one contains the DID.
 ///
 /// Other methods (e.g., `"oauth"`, `"challenge_response"`) are Cryptographic-class
-/// and are not verifiable via fetch — the promise rejects with `SCP-ATTEST-9010`.
+/// and are not verifiable via fetch — the promise rejects with `SCP-ATTEST-9018`.
 ///
 /// # JS usage
 ///


### PR DESCRIPTION
## Summary

Review follow-up for PR #1635. Doc comment in `reference_verify.rs:404` still referenced `SCP-ATTEST-9010` after the code was changed to use `SCP-ATTEST-9018`.

One-line doc comment fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)