### PR TITLE
fix(security): add pre-deserialization size checks to prevent allocation bombs

### DIFF
--- a/crates/scp-protocol/src/context/broadcast_content.rs
+++ b/crates/scp-protocol/src/context/broadcast_content.rs
@@ -1479,6 +1479,28 @@ mod tests {
     // -----------------------------------------------------------------------
 
     #[test]
+    fn deserialize_broadcast_content_rejects_oversize() {
+        let oversized = vec![0u8; MAX_BROADCAST_WIRE_SIZE + 1];
+        let result = deserialize_broadcast_content(&oversized);
+        assert!(
+            matches!(result, Err(BroadcastContentError::PayloadTooLarge(size)) if size == MAX_BROADCAST_WIRE_SIZE + 1),
+            "expected PayloadTooLarge, got: {result:?}"
+        );
+    }
+
+    #[test]
+    fn deserialize_broadcast_content_accepts_at_max_wire_size() {
+        // A buffer exactly at the limit passes the size gate; the missing magic
+        // yields InvalidMagic, not PayloadTooLarge.
+        let at_limit = vec![0u8; MAX_BROADCAST_WIRE_SIZE];
+        let result = deserialize_broadcast_content(&at_limit);
+        assert!(
+            matches!(result, Err(BroadcastContentError::InvalidMagic)),
+            "expected InvalidMagic at limit (not PayloadTooLarge), got: {result:?}"
+        );
+    }
+
+    #[test]
     fn deserialization_error_does_not_leak_internals() {
         // Feed invalid msgpack after a valid header. The error message
         // must be generic, not the raw rmp_serde error.

--- a/crates/scp-protocol/src/context/broadcast_content.rs
+++ b/crates/scp-protocol/src/context/broadcast_content.rs
@@ -54,6 +54,13 @@ const MAX_DEPLOY_ID_BYTES: usize = 128;
 /// Maximum body size in bytes (10 MiB).
 const MAX_BODY_BYTES: usize = 10 * 1024 * 1024;
 
+/// Maximum wire size for a serialized broadcast content payload in bytes.
+///
+/// Accounts for the 4-byte magic+version header plus `MAX_BODY_BYTES` of
+/// body, with headroom for metadata fields. Pre-deserialization guard against
+/// allocation bombs.
+const MAX_BROADCAST_WIRE_SIZE: usize = MAX_BODY_BYTES + 4 + 65_536;
+
 // ---------------------------------------------------------------------------
 // BroadcastContentError
 // ---------------------------------------------------------------------------
@@ -89,6 +96,10 @@ pub enum BroadcastContentError {
     /// Body exceeds `MAX_BODY_BYTES`.
     #[error("body too large: {0} bytes (max {MAX_BODY_BYTES})")]
     BodyTooLarge(usize),
+
+    /// Wire payload exceeds `MAX_BROADCAST_WIRE_SIZE` before deserialization.
+    #[error("broadcast payload too large: {0} bytes")]
+    PayloadTooLarge(usize),
 
     /// An `ETag` value has an invalid format (must be 64 lowercase hex chars).
     #[error("invalid etag format: {0}")]
@@ -432,6 +443,9 @@ pub fn serialize_broadcast_content(
 pub fn deserialize_broadcast_content(
     bytes: &[u8],
 ) -> Result<BroadcastContent, BroadcastContentError> {
+    if bytes.len() > MAX_BROADCAST_WIRE_SIZE {
+        return Err(BroadcastContentError::PayloadTooLarge(bytes.len()));
+    }
     if bytes.len() < 4 {
         return Err(BroadcastContentError::InvalidMagic);
     }

--- a/crates/scp-protocol/src/crypto/sender_keys/key_protocol_verify.rs
+++ b/crates/scp-protocol/src/crypto/sender_keys/key_protocol_verify.rs
@@ -59,6 +59,11 @@ pub fn generate_wrapping_keypair() -> ([u8; 32], [u8; 32]) {
 /// AES-128-GCM nonce size in bytes.
 pub const HPKE_NONCE_SIZE: usize = 12;
 
+/// Maximum size of a serialized [`SenderKeyDistributionMessage`] in bytes (64 KiB).
+///
+/// Pre-deserialization guard against allocation bombs from malformed input.
+pub const MAX_SENDER_KEY_MESSAGE_SIZE: usize = 65_536;
+
 /// HKDF info domain separator for sender key HPKE encryption (§9.16.2).
 /// The full info string is `"scp-sender-key-v1" || context_id || sender_did || epoch_BE`.
 const HPKE_INFO_PREFIX: &[u8] = b"scp-sender-key-v1";
@@ -265,8 +270,16 @@ impl SenderKeyDistributionMessage {
     ///
     /// # Errors
     ///
+    /// Returns [`SenderKeyError::MessageTooLarge`] if `bytes.len()` exceeds
+    /// [`MAX_SENDER_KEY_MESSAGE_SIZE`].
     /// Returns [`SenderKeyError::SerializationFailed`] if deserialization fails.
     pub fn from_bytes(bytes: &[u8]) -> Result<Self, SenderKeyError> {
+        if bytes.len() > MAX_SENDER_KEY_MESSAGE_SIZE {
+            return Err(SenderKeyError::MessageTooLarge {
+                size: bytes.len(),
+                max: MAX_SENDER_KEY_MESSAGE_SIZE,
+            });
+        }
         rmp_serde::from_slice(bytes).map_err(|e| SenderKeyError::SerializationFailed(e.to_string()))
     }
 }

--- a/crates/scp-protocol/src/crypto/sender_keys/key_protocol_verify.rs
+++ b/crates/scp-protocol/src/crypto/sender_keys/key_protocol_verify.rs
@@ -2113,4 +2113,34 @@ mod tests {
         assert_eq!(decoded.blocker, "did:dht:alice");
         assert_eq!(decoded.blocked, "did:dht:dave");
     }
+
+    // -------------------------------------------------------------------
+    // Pre-deserialization size limit tests for SenderKeyDistributionMessage
+    // -------------------------------------------------------------------
+
+    #[test]
+    fn sender_key_distribution_message_from_bytes_rejects_oversize() {
+        let oversized = vec![0u8; MAX_SENDER_KEY_MESSAGE_SIZE + 1];
+        let result = SenderKeyDistributionMessage::from_bytes(&oversized);
+        assert!(
+            matches!(
+                result,
+                Err(SenderKeyError::MessageTooLarge { size, max })
+                    if size == MAX_SENDER_KEY_MESSAGE_SIZE + 1 && max == MAX_SENDER_KEY_MESSAGE_SIZE
+            ),
+            "expected MessageTooLarge, got: {result:?}"
+        );
+    }
+
+    #[test]
+    fn sender_key_distribution_message_from_bytes_accepts_at_max_size() {
+        // A buffer exactly at the limit is accepted by the size gate; invalid
+        // MessagePack yields SerializationFailed, not MessageTooLarge.
+        let at_limit = vec![0xFFu8; MAX_SENDER_KEY_MESSAGE_SIZE];
+        let result = SenderKeyDistributionMessage::from_bytes(&at_limit);
+        assert!(
+            matches!(result, Err(SenderKeyError::SerializationFailed(_))),
+            "expected SerializationFailed at limit (not MessageTooLarge), got: {result:?}"
+        );
+    }
 }

--- a/crates/scp-protocol/src/crypto/sender_keys/mod.rs
+++ b/crates/scp-protocol/src/crypto/sender_keys/mod.rs
@@ -239,6 +239,15 @@ pub enum SenderKeyError {
     /// See ADR-039 and SCP-AB-020.
     #[error("Category A violation: {0}")]
     CategoryAViolation(String),
+
+    /// The message exceeds the maximum allowed size.
+    #[error("message too large: {size} bytes (max {max})")]
+    MessageTooLarge {
+        /// Actual message size in bytes.
+        size: usize,
+        /// Maximum allowed size in bytes.
+        max: usize,
+    },
 }
 
 // ---------------------------------------------------------------------------

--- a/crates/scp-transport/src/coap/adapter.rs
+++ b/crates/scp-transport/src/coap/adapter.rs
@@ -600,6 +600,17 @@ impl TransportAdapter for CoapAdapter {
             // The relay returns blobs as MessagePack-encoded envelopes.
             // A single CoAP response may contain one envelope, or a
             // MessagePack array of envelopes for multi-result queries.
+            //
+            // Reject oversized payloads before invoking any deserializer to prevent
+            // allocation bombs. `OuterEnvelope::from_bytes` has its own size guard
+            // for the single-envelope case; the array path applies `max_reassembly_bytes`.
+            if full_payload.len() > self.max_reassembly_bytes {
+                return Err(TransportError::PayloadTooLarge(format!(
+                    "CoAP QUERY response exceeds maximum payload size: {} > {}",
+                    full_payload.len(),
+                    self.max_reassembly_bytes,
+                )));
+            }
             if let Ok(envelope) = OuterEnvelope::from_bytes(&full_payload) {
                 // Verify blob integrity
                 let computed = BlobId::from_sha256(&full_payload);
@@ -609,7 +620,8 @@ impl TransportAdapter for CoapAdapter {
                 );
                 Ok(vec![envelope])
             } else {
-                // Try parsing as MessagePack array of envelopes
+                // Try parsing as MessagePack array of envelopes.
+                // Payload is already bounded by the `max_reassembly_bytes` check above.
                 let envelopes: Vec<OuterEnvelope> =
                     rmp_serde::from_slice(&full_payload).map_err(|e| {
                         TransportError::ProtocolError(format!(

--- a/crates/scp-transport/src/native/error.rs
+++ b/crates/scp-transport/src/native/error.rs
@@ -111,6 +111,15 @@ pub enum NativeProtocolError {
     /// A constraint validation failed on a client message.
     #[error("validation failed: {0}")]
     ValidationFailed(String),
+
+    /// The message exceeds the maximum allowed size.
+    #[error("message too large: {size} bytes (max {max})")]
+    MessageTooLarge {
+        /// Actual message size in bytes.
+        size: usize,
+        /// Maximum allowed size in bytes.
+        max: usize,
+    },
 }
 
 #[cfg(test)]

--- a/crates/scp-transport/src/native/protocol.rs
+++ b/crates/scp-transport/src/native/protocol.rs
@@ -51,6 +51,12 @@ pub const DEFAULT_QUERY_LIMIT: u32 = 100;
 /// Maximum QUERY limit.
 pub const MAX_QUERY_LIMIT: u32 = 1000;
 
+/// Maximum size of a `ClientMessage` or `RelayMessage` in bytes (1 MiB).
+///
+/// Pre-deserialization guard against allocation bombs from malformed
+/// `MessagePack` input.
+pub const MAX_MESSAGE_SIZE: usize = 1_048_576;
+
 // ---------------------------------------------------------------------------
 // Serde helper for Option<[u8; 32]> as MessagePack binary
 // ---------------------------------------------------------------------------
@@ -335,9 +341,17 @@ impl ClientMessage {
     ///
     /// # Errors
     ///
-    /// Returns [`NativeProtocolError::DeserializationFailed`] if the bytes
-    /// are not a valid `MessagePack`-encoded `ClientMessage`.
+    /// Returns [`NativeProtocolError::MessageTooLarge`] if `bytes.len()` exceeds
+    /// [`MAX_MESSAGE_SIZE`].
+    /// Returns [`NativeProtocolError::DeserializationFailed`] if the bytes are
+    /// not a valid `MessagePack`-encoded `ClientMessage`.
     pub fn from_bytes(bytes: &[u8]) -> Result<Self, NativeProtocolError> {
+        if bytes.len() > MAX_MESSAGE_SIZE {
+            return Err(NativeProtocolError::MessageTooLarge {
+                size: bytes.len(),
+                max: MAX_MESSAGE_SIZE,
+            });
+        }
         rmp_serde::from_slice(bytes)
             .map_err(|e| NativeProtocolError::DeserializationFailed(e.to_string()))
     }
@@ -561,9 +575,17 @@ impl RelayMessage {
     ///
     /// # Errors
     ///
-    /// Returns [`NativeProtocolError::DeserializationFailed`] if the bytes
-    /// are not a valid `MessagePack`-encoded `RelayMessage`.
+    /// Returns [`NativeProtocolError::MessageTooLarge`] if `bytes.len()` exceeds
+    /// [`MAX_MESSAGE_SIZE`].
+    /// Returns [`NativeProtocolError::DeserializationFailed`] if the bytes are
+    /// not a valid `MessagePack`-encoded `RelayMessage`.
     pub fn from_bytes(bytes: &[u8]) -> Result<Self, NativeProtocolError> {
+        if bytes.len() > MAX_MESSAGE_SIZE {
+            return Err(NativeProtocolError::MessageTooLarge {
+                size: bytes.len(),
+                max: MAX_MESSAGE_SIZE,
+            });
+        }
         rmp_serde::from_slice(bytes)
             .map_err(|e| NativeProtocolError::DeserializationFailed(e.to_string()))
     }

--- a/crates/scp-transport/src/native/protocol.rs
+++ b/crates/scp-transport/src/native/protocol.rs
@@ -1486,6 +1486,57 @@ mod tests {
         assert!(result.is_err());
     }
 
+    #[test]
+    fn client_message_from_bytes_rejects_oversize() {
+        let oversized = vec![0u8; MAX_MESSAGE_SIZE + 1];
+        let result = ClientMessage::from_bytes(&oversized);
+        assert!(
+            matches!(
+                result,
+                Err(NativeProtocolError::MessageTooLarge { size, max })
+                    if size == MAX_MESSAGE_SIZE + 1 && max == MAX_MESSAGE_SIZE
+            ),
+            "expected MessageTooLarge, got: {result:?}"
+        );
+    }
+
+    #[test]
+    fn relay_message_from_bytes_rejects_oversize() {
+        let oversized = vec![0u8; MAX_MESSAGE_SIZE + 1];
+        let result = RelayMessage::from_bytes(&oversized);
+        assert!(
+            matches!(
+                result,
+                Err(NativeProtocolError::MessageTooLarge { size, max })
+                    if size == MAX_MESSAGE_SIZE + 1 && max == MAX_MESSAGE_SIZE
+            ),
+            "expected MessageTooLarge, got: {result:?}"
+        );
+    }
+
+    #[test]
+    fn client_message_from_bytes_accepts_at_max_size() {
+        // A buffer exactly at the limit is accepted (rejected only if strictly greater).
+        // The payload is not valid MessagePack so we get DeserializationFailed, not
+        // MessageTooLarge -- this confirms the size gate did NOT trigger.
+        let at_limit = vec![0xFFu8; MAX_MESSAGE_SIZE];
+        let result = ClientMessage::from_bytes(&at_limit);
+        assert!(
+            matches!(result, Err(NativeProtocolError::DeserializationFailed(_))),
+            "expected DeserializationFailed at limit (not MessageTooLarge), got: {result:?}"
+        );
+    }
+
+    #[test]
+    fn relay_message_from_bytes_accepts_at_max_size() {
+        let at_limit = vec![0xFFu8; MAX_MESSAGE_SIZE];
+        let result = RelayMessage::from_bytes(&at_limit);
+        assert!(
+            matches!(result, Err(NativeProtocolError::DeserializationFailed(_))),
+            "expected DeserializationFailed at limit (not MessageTooLarge), got: {result:?}"
+        );
+    }
+
     // -----------------------------------------------------------------------
     // Wire format field name compliance (ADR-004)
     // -----------------------------------------------------------------------

--- a/crates/scp-transport/src/nostr/adapter.rs
+++ b/crates/scp-transport/src/nostr/adapter.rs
@@ -420,14 +420,16 @@ impl NostrAdapter {
     }
 
     /// Parse an SCP outer envelope from a Nostr event's base64-encoded content.
+    ///
+    /// Uses [`OuterEnvelope::from_bytes`] which rejects payloads exceeding
+    /// `MAX_ENVELOPE_SIZE` before invoking the MessagePack deserializer,
+    /// preventing allocation bombs from malicious Nostr events.
     fn parse_envelope_from_event(event: &NostrEvent) -> Result<OuterEnvelope, TransportError> {
         let bytes = base64_decode(&event.content).map_err(|e| {
             TransportError::ProtocolError(format!("invalid base64 in Nostr event content: {e}"))
         })?;
-        rmp_serde::from_slice(&bytes).map_err(|e| {
-            TransportError::ProtocolError(format!(
-                "invalid MessagePack in Nostr event content: {e}"
-            ))
+        OuterEnvelope::from_bytes(&bytes).map_err(|e| {
+            TransportError::ProtocolError(format!("invalid envelope in Nostr event content: {e}"))
         })
     }
 }

--- a/crates/scp-transport/src/quic/streams.rs
+++ b/crates/scp-transport/src/quic/streams.rs
@@ -290,20 +290,42 @@ pub fn decode_frame_from_buf(buf: &[u8]) -> Result<Option<(usize, Vec<u8>)>, Tra
 
 /// Deserializes a relay frame from raw `MessagePack` bytes.
 ///
+/// Callers are expected to pass a payload that was already gated by
+/// [`decode_frame_from_buf`]'s `MAX_FRAME_SIZE` check (512 KB). This explicit
+/// guard provides defense-in-depth for any caller that bypasses that path.
+///
 /// # Errors
 ///
-/// Returns [`TransportError::ProtocolError`] if deserialization fails.
+/// Returns [`TransportError::ProtocolError`] if `payload.len()` exceeds
+/// [`MAX_FRAME_SIZE`] or if deserialization fails.
 pub fn decode_relay_frame(payload: &[u8]) -> Result<QuicRelayFrame, TransportError> {
+    if payload.len() > MAX_FRAME_SIZE as usize {
+        return Err(TransportError::ProtocolError(format!(
+            "relay frame too large: {} > {MAX_FRAME_SIZE}",
+            payload.len()
+        )));
+    }
     rmp_serde::from_slice(payload)
         .map_err(|e| TransportError::ProtocolError(format!("invalid relay frame: {e}")))
 }
 
 /// Deserializes a client frame from raw `MessagePack` bytes.
 ///
+/// Callers are expected to pass a payload that was already gated by
+/// [`decode_frame_from_buf`]'s `MAX_FRAME_SIZE` check (512 KB). This explicit
+/// guard provides defense-in-depth for any caller that bypasses that path.
+///
 /// # Errors
 ///
-/// Returns [`TransportError::ProtocolError`] if deserialization fails.
+/// Returns [`TransportError::ProtocolError`] if `payload.len()` exceeds
+/// [`MAX_FRAME_SIZE`] or if deserialization fails.
 pub fn decode_client_frame(payload: &[u8]) -> Result<QuicClientFrame, TransportError> {
+    if payload.len() > MAX_FRAME_SIZE as usize {
+        return Err(TransportError::ProtocolError(format!(
+            "client frame too large: {} > {MAX_FRAME_SIZE}",
+            payload.len()
+        )));
+    }
     rmp_serde::from_slice(payload)
         .map_err(|e| TransportError::ProtocolError(format!("invalid client frame: {e}")))
 }

--- a/crates/scp-transport/src/udp/adapter.rs
+++ b/crates/scp-transport/src/udp/adapter.rs
@@ -187,8 +187,10 @@ impl UdpDtlsAdapter {
 
         let response_data = self.recv_datagram().await?;
 
-        let response: RelayMessage = rmp_serde::from_slice(&response_data).map_err(|e| {
-            TransportError::ProtocolError(format!("MessagePack deserialization failed: {e}"))
+        // `RelayMessage::from_bytes` rejects payloads exceeding `MAX_MESSAGE_SIZE`
+        // before invoking the MessagePack deserializer, preventing allocation bombs.
+        let response: RelayMessage = RelayMessage::from_bytes(&response_data).map_err(|e| {
+            TransportError::ProtocolError(format!("relay message deserialization failed: {e}"))
         })?;
 
         Ok(response)

--- a/crates/scp-transport/src/udp/listener.rs
+++ b/crates/scp-transport/src/udp/listener.rs
@@ -724,7 +724,9 @@ async fn per_client_recv_loop<S: BlobStorage + 'static>(
         }
 
         // Deserialize the client message.
-        let client_msg: ClientMessage = match rmp_serde::from_slice(&datagram) {
+        // `ClientMessage::from_bytes` rejects payloads exceeding `MAX_MESSAGE_SIZE`
+        // before invoking the MessagePack deserializer, preventing allocation bombs.
+        let client_msg: ClientMessage = match ClientMessage::from_bytes(&datagram) {
             Ok(msg) => msg,
             Err(e) => {
                 debug!(remote = %remote_addr, error = %e, "failed to deserialize UDP datagram");

--- a/crates/scp-transport/src/webrtc/adapter.rs
+++ b/crates/scp-transport/src/webrtc/adapter.rs
@@ -272,12 +272,12 @@ impl TransportAdapter for WebRtcAdapter {
 
                     match provider.recv_data(&label).await {
                         Ok(Some(raw_bytes)) => {
-                            let event = match rmp_serde::from_slice::<OuterEnvelope>(&raw_bytes) {
+                            let event = match OuterEnvelope::from_bytes(&raw_bytes) {
                                 Ok(envelope) => TransportEvent::Envelope(envelope),
                                 Err(e) => {
                                     warn!(error = %e, "failed to deserialize envelope from WebRTC data channel");
                                     TransportEvent::Error(TransportError::ProtocolError(format!(
-                                        "invalid MessagePack in data channel message: {e}"
+                                        "invalid envelope in data channel message: {e}"
                                     )))
                                 }
                             };
@@ -630,6 +630,45 @@ mod tests {
         assert_eq!(config.max_message_size, 262_144);
         assert_eq!(config.ice_timeout_secs, 30);
         assert_eq!(config.ice_servers.len(), 1);
+    }
+
+    /// WebRTC peers are untrusted (TURN/STUN-relayed), so the data channel
+    /// handler must reject oversized payloads before calling the MessagePack
+    /// deserializer. `OuterEnvelope::from_bytes` provides this guard via
+    /// `MAX_ENVELOPE_SIZE`. Regression test for the bypass path identified in
+    /// PR #1644.
+    #[tokio::test]
+    async fn webrtc_rejects_oversized_envelope() {
+        use scp_core::serde_util::MAX_ENVELOPE_SIZE;
+
+        let (adapter, _, provider) = make_adapter();
+        adapter.ensure_connected().await.unwrap();
+
+        let routing_id = RoutingId::new([0xDD; 32]);
+        let routing_id_hex = hex::encode(routing_id.as_bytes());
+
+        // Open the channel and subscribe before injecting data.
+        provider.open_channel(&routing_id_hex).await.unwrap();
+
+        // Inject an oversized payload (exceeds MAX_ENVELOPE_SIZE by 1).
+        let oversized = vec![0u8; MAX_ENVELOPE_SIZE + 1];
+        provider.inject_data(&routing_id_hex, oversized).await;
+
+        // Pull one item from the subscription stream.
+        let mut stream = adapter.subscribe(&routing_id, None).await.unwrap();
+        use futures::StreamExt as _;
+        let event = stream.next().await.expect("stream should yield an event");
+
+        // Must be a ProtocolError, not a panic or a successful parse.
+        match event {
+            TransportEvent::Error(TransportError::ProtocolError(msg)) => {
+                assert!(
+                    msg.contains("invalid envelope"),
+                    "expected size-guard error, got: {msg}"
+                );
+            }
+            other => panic!("expected ProtocolError for oversized payload, got {other:?}"),
+        }
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Add `MAX_MESSAGE_SIZE` (1 MiB) pre-deserialization check to `ClientMessage::from_bytes` and `RelayMessage::from_bytes` — previously called `rmp_serde::from_slice` directly on untrusted network input with no size gate
- Add `MAX_SENDER_KEY_MESSAGE_SIZE` (64 KiB) pre-deserialization check to `SenderKeyDistributionMessage::from_bytes`
- Move `BroadcastContent` body size check BEFORE `rmp_serde::from_slice` — previously allocated up to 10 MiB before rejecting oversized input
- Add typed error variants: `NativeProtocolError::MessageTooLarge`, `SenderKeyError::MessageTooLarge`, `BroadcastContentError::PayloadTooLarge`

`#[serde(deny_unknown_fields)]` on sender key variants was NOT applied — spec §13.5.1 mandates ignoring unknown fields for forward compatibility, enforced by 4 existing conformance tests.

Discovered during fuzzing plan review by 7 independent agents (red-hat, white-hat, black-hat, security-reviewer, adversarial-expert, architect, bug-catcher).

## Test plan

- [x] `cargo test -p scp-protocol` — passes
- [x] `cargo test -p scp-transport` — passes
- [x] Full workspace clippy with all features — clean
- [x] `cargo fmt --all -- --check` — clean
- [ ] Verify oversized `ClientMessage` bytes are rejected before allocation

🤖 Generated with [Claude Code](https://claude.com/claude-code)