### PR TITLE
docs(lessons): capture session learnings on serde, timestamps, optional strings

### DIFF
--- a/.docs/lessons/cross-sdk-timestamp-integer-coercion.md
+++ b/.docs/lessons/cross-sdk-timestamp-integer-coercion.md
@@ -1,0 +1,71 @@
+# Cross-SDK timestamp integer coercion — guard NaN, Infinity, and signed/unsigned drift
+
+**Date:** 2026-04-14
+**Source:** PRs #1638 and #1642 — `verifiedAt` / `revokedAt` integer enforcement
+
+## The invariant
+
+Rust source uses `u64` for all timestamps. Every SDK must produce a `u64`-compatible value
+at the FFI boundary: a finite, non-negative integer. Floats, `NaN`, `Infinity`, negative
+numbers, and booleans all violate this invariant and must be rejected explicitly, not
+coerced silently.
+
+## What goes wrong per language
+
+| SDK        | Failure mode                                                                 | Fix                                                                 |
+| ---------- | ---------------------------------------------------------------------------- | ------------------------------------------------------------------- |
+| Swift      | `Int` used where `UInt64` expected — silently narrows and admits negatives   | Use `UInt64` throughout. Do **not** follow the Apple-convention `Date` type; the wire format is integer seconds, not `Date`. |
+| Python     | `int(x)` happily accepts `True` (returns `1`), `False` (returns `0`), floats | Wrap with a helper that catches `TypeError`/`ValueError`/`OverflowError` and rejects booleans explicitly if the field is semantically numeric |
+| TypeScript | `JSON.parse` returns `number` (f64). `Math.trunc(NaN) === NaN`               | Guard with `Number.isFinite(x)` before `Math.trunc(x)`. Throw `ValidationError` with `SCP-VALID-7005` on failure |
+| Kotlin     | `Long` already correct — JVM rejects non-integer JSON at deserialization     | Nothing required if using `kotlinx.serialization` with `Long`       |
+
+## Python's bool-is-int trap
+
+```python
+>>> isinstance(True, int)
+True
+>>> int(True)
+1
+```
+
+Any `int(value)` call where `value` came from untyped deserialization can smuggle a boolean
+through. For timestamp fields this is cosmetically harmless (you get `1`) but semantically
+wrong — the source type violated the schema and the SDK pretended it didn't. Either reject
+`bool` explicitly, or at least document that it is coerced.
+
+## Math.trunc(NaN) silently poisons timestamps
+
+```js
+Math.trunc(NaN)        // NaN  — not a thrown error
+Math.trunc(Infinity)   // Infinity
+NaN === NaN            // false  — comparisons silently all return false
+```
+
+If NaN enters a timestamp comparison (e.g. `verifiedAt < now`), every branch of the comparison
+returns `false`, which typically short-circuits to the "not yet valid" or "not yet expired"
+code path. The object looks like a valid attestation but is silently unusable. Always guard
+with `Number.isFinite()` **before** `Math.trunc()`.
+
+## Error code
+
+Use `SCP-VALID-7005` (invalid field value) for finite-integer failures. **Do not** use
+`SCP-VALID-7003` (JSON schema error — the JSON parsed fine) or `SCP-VALID-7004` (missing
+required field — the field was present). See `.docs/standards/sdk-common.md` §"Registered
+SCP-VALID- codes".
+
+## How to catch this when reviewing
+
+1. Every SDK field that maps to a Rust `u64`: grep for its access point and confirm either the
+   language's deserializer rejects non-integers (Kotlin `Long`, Rust `u64`, Swift `UInt64`)
+   or there is an explicit finite-integer guard at the FFI boundary.
+2. Swift-specific: any `Int` or `Date` in a struct that mirrors a Rust `u64` is wrong. Search
+   for `Int\b` in FFI-facing Swift structs.
+3. Python-specific: `int(x)` on an untyped field is a yellow flag. Prefer an explicit helper
+   that handles `bool`, `NaN`, `Infinity`, and overflow.
+
+## Related
+
+- `bindings/python/scp_sdk/identity.py::_parse_finite_int` — reference implementation
+- `bindings/typescript/src/identity.ts` — `Number.isFinite` + `Math.trunc` pattern
+- `bindings/swift/Sources/SCP/Identity.swift::RevocationStatus` — `UInt64` throughout
+- `.docs/standards/sdk-common.md` — registered `SCP-VALID-` codes including 7005

--- a/.docs/lessons/optional-string-empty-none-equivalence.md
+++ b/.docs/lessons/optional-string-empty-none-equivalence.md
@@ -1,0 +1,74 @@
+# Optional strings at the FFI boundary: treat `Some("")` as `None`
+
+**Date:** 2026-04-14
+**Source:** PR #1637 — governance `reason` field empty-string rejection
+
+## The bug
+
+Governance actions with an `Option<String> reason` field accepted `None` but rejected
+`Some("")` with a validation error. `validate_governance_reason("")` correctly rejects the
+empty string (the validator's contract is "non-empty human-readable reason"), and the caller
+blindly invoked it whenever `reason.is_some()`.
+
+SDKs vary in how they represent "no value":
+
+| SDK        | Idiomatic "no value"           | What reaches Rust                    |
+| ---------- | ------------------------------ | ------------------------------------ |
+| Rust       | `None`                         | `None`                               |
+| Python     | `None`                         | `None` — but `""` is truthy-neighbor |
+| TypeScript | `undefined` or `null` or `""`  | any of them                          |
+| Swift      | `nil`                          | `nil`                                |
+| Kotlin     | `null`                         | `null`                               |
+
+TypeScript in particular treats `""`, `null`, and `undefined` as semantically interchangeable
+for "user didn't provide a value." JSON serialization further flattens the distinction —
+`{"reason": ""}` and `{"reason": null}` are often produced interchangeably by higher-level
+frameworks.
+
+## The rule
+
+**At the FFI validation boundary, normalize `Some("")` to `None` for every optional string
+field where empty conveys "absent" rather than "explicitly empty."** Do not loosen the
+downstream validator — it has a contract that callers with a required field still depend on.
+
+Fix pattern:
+
+```rust
+| GovernanceAction::RemoveMember { reason: Some(r), .. }
+| GovernanceAction::CloseContext { reason: Some(r), .. }
+| GovernanceAction::RotateContentKeys { reason: Some(r), .. } => {
+    if !r.is_empty() {
+        validate_governance_reason(r)?;
+    }
+}
+// A required reason (e.g. ResetMember) still calls the validator directly — empty rejected.
+GovernanceAction::ResetMember { reason, .. } => {
+    validate_governance_reason(reason)?;
+}
+```
+
+## Why normalize at the validator, not the FFI bridge
+
+- **Consistency across 4 bridges.** Putting the normalization in `scp-ffi/common/src/validate.rs`
+  means PyO3, UniFFI, NAPI, and WASM all get the same behavior for free. Normalizing per-bridge
+  invites drift.
+- **Required-field callers unchanged.** The validator itself still rejects `""` for callers
+  that pass a non-optional reason. Only the "treat Some('') like None" behavior lives in the
+  optional-field call sites.
+- **Tests assert both paths.** `governance_reason_empty_string_rejected` covers the direct
+  validator contract; `*_empty_string_reason_accepted` covers the optional-field callers.
+
+## How to catch this when reviewing
+
+- Any FFI function with an `Option<String>` parameter: grep for calls to `validate_*` inside
+  its `Some(_)` arm. If the validator rejects empty strings, confirm the Some/None check is
+  on `!r.is_empty()`, not `.is_some()`.
+- Any SDK wrapper that converts `""` to a `String` and passes it across: confirm the receiving
+  end treats empty as absent. Better yet, normalize to `None` in the SDK wrapper before
+  crossing the boundary — defense in depth.
+
+## Related
+
+- `crates/scp-ffi/common/src/validate.rs::validate_governance_action_strings`
+- `crates/scp-protocol/src/context/governance.rs` — the `GovernanceAction` enum definition
+- Issue #1604 — the original report

--- a/.docs/lessons/serde-rename-all-snake-vs-lowercase.md
+++ b/.docs/lessons/serde-rename-all-snake-vs-lowercase.md
@@ -1,0 +1,51 @@
+# `serde(rename_all = "lowercase")` vs `"snake_case"` — pick what matches the spec
+
+**Date:** 2026-04-14
+**Source:** PR #1632 follow-up (commit `04e5e10b`) — `HandleRegisterStatus` wire-format drift
+
+## The bug
+
+`HandleRegisterStatus` was annotated `#[serde(rename_all = "lowercase")]`. For single-word
+variants (`Registered`, `Conflict`) this is identical to `snake_case`. The trap surfaces the
+moment you add a multi-word variant:
+
+| Variant              | `"lowercase"`           | `"snake_case"` (spec)     |
+| -------------------- | ----------------------- | ------------------------- |
+| `OwnershipMismatch`  | `"ownershipmismatch"`   | `"ownership_mismatch"`    |
+| `CapacityExceeded`   | `"capacityexceeded"`    | `"capacity_exceeded"`     |
+
+Spec §22.3.1 defines the wire-format values as `ownership_mismatch` / `capacity_exceeded`.
+The Rust enum silently emitted the no-separator form — tests that round-tripped the value
+through serde in a single implementation passed, but any consumer reading the spec literal
+would reject it.
+
+## Why it's subtle
+
+1. `"lowercase"` is a common default cargo-culted from examples. It looks harmless.
+2. The drift is invisible until someone adds a multi-word variant. The first variant you add
+   after that point quietly disagrees with the spec.
+3. `#[serde(rename = "ownership_mismatch")]` per-variant is what most devs reach for when they
+   notice — but that only fixes the variant they noticed. The container attribute is the real
+   bug.
+
+## The rule
+
+**Default to `rename_all = "snake_case"` for any enum whose wire format is defined in a spec**,
+unless the spec explicitly calls for a different convention (e.g. `camelCase` for JSON APIs).
+Never use `"lowercase"` unless the spec spells every variant as a single concatenated word.
+
+## How to catch this when reviewing
+
+- When adding a multi-word variant to an enum with `#[serde(rename_all = "…")]`, open the spec
+  and compare the expected wire value to what serde will produce.
+- When reviewing a new enum: grep for `rename_all = "lowercase"` and confirm every variant is
+  either single-word or has an explicit per-variant `rename`.
+- Prefer round-trip tests that assert the literal JSON string against the spec, not just
+  `assert_eq!(x, from_str(to_string(&x)?)?)` — internal round-trips hide spec drift.
+
+## Related
+
+- `crates/scp-protocol/src/discovery/handles.rs::HandleRegisterStatus`
+- `.docs/specs/22-human-readable-addressing.md` §22.3.1
+- `crates/scp-protocol/src/discovery/scope.rs` — `ScopeRegisterStatus` uses the same pattern
+  and needs the same scrutiny whenever a variant is added.


### PR DESCRIPTION
## Summary

Three lessons from chronicler review of session PRs #1629-#1642:

- **serde-rename-all-snake-vs-lowercase** — Caught when HandleRegisterStatus added `CapacityExceeded`. `rename_all="lowercase"` silently produces no-separator strings for multi-word variants. Use `snake_case`.

- **cross-sdk-timestamp-integer-coercion** — Per-SDK failure modes: Python `int(True)==1` (bool subclass), JS `Math.trunc(NaN)===NaN` (no throw), Swift's `UInt64` vs Apple `Date` convention rationale, `SCP-VALID-7005` standard.

- **optional-string-empty-none-equivalence** — Why `Some("")` normalizes to `None` at the validator (not per-bridge) for optional governance reasons.

Documentation only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)