### PR TITLE
fix: restore target consistency after fuzz_merkle_proof_random addition

### DIFF
--- a/crates/scp-protocol/src/crypto/sender_keys/encrypt.rs
+++ b/crates/scp-protocol/src/crypto/sender_keys/encrypt.rs
@@ -139,6 +139,24 @@ fn build_sender_aad(context_id: &str, sender_did: &str, epoch: u64, sequence: u6
     aad
 }
 
+/// Public re-export of [`build_sender_aad`] for use in fuzz targets and
+/// cross-crate tests.
+///
+/// Gated behind `feature = "testing"` so it is never part of the public API
+/// in release builds. Fuzz targets use this to avoid maintaining a replica
+/// of the AAD construction logic.
+#[doc(hidden)]
+#[must_use]
+#[cfg(any(test, feature = "testing"))]
+pub fn build_sender_aad_for_testing(
+    context_id: &str,
+    sender_did: &str,
+    epoch: u64,
+    sequence: u64,
+) -> Vec<u8> {
+    build_sender_aad(context_id, sender_did, epoch, sequence)
+}
+
 /// Size of the epoch + sequence header in bytes.
 pub const SENDER_HEADER_SIZE: usize = 16;
 

--- a/crates/scp-protocol/src/crypto/sender_keys/mod.rs
+++ b/crates/scp-protocol/src/crypto/sender_keys/mod.rs
@@ -39,6 +39,8 @@ pub use broadcast::{
 pub use encrypt::{decrypt_sender_layer, encrypt_sender_layer};
 // build_sender_header, parse_sender_header, and SENDER_HEADER_SIZE are wire-format
 // internals used by crypto providers — access via encrypt:: submodule directly.
+#[cfg(any(test, feature = "testing"))]
+pub use encrypt::build_sender_aad_for_testing;
 pub use key_protocol_verify::{
     BlockNotification, BridgeShadowKeyParams, HandleRequestParams, NonceDedup,
     RotateForBlockParams, RotateForBlockResult, SenderKeyDistributionMessage,

--- a/fuzz/.claude/CLAUDE.md
+++ b/fuzz/.claude/CLAUDE.md
@@ -77,6 +77,21 @@ Targets call production `pub` functions only. No `unsafe` in `fuzz_targets/`. If
 
 Location: `fuzz/dicts/` (one file per target family).
 
+### Naming Convention
+
+Dict filenames follow the pattern `<format>_<target>.dict` where:
+- `<format>` is the wire format family: `msgpack`, `jwt`, or `uri`
+- `<target>` is the target-type name (e.g., `outer_envelope`, `inner_envelope`)
+
+Examples:
+- `msgpack_outer_envelope.dict` — MessagePack parser for `OuterEnvelope`
+- `ucan_jwt.dict` — JWT tokens for UCAN parsing (format family = `jwt`, target = `ucan`)
+- `scp_uri.dict` — SCP URI parser (format family = `uri`, target = `scp`)
+- `capability_uri.dict` — capability URI parser (format family = `uri`, target = `capability`)
+
+**New dicts must follow this convention.** Do NOT rename existing dict files — that requires
+CI workflow updates (the `-dict=` flag paths are hardcoded in `.github/workflows/fuzz.yml`).
+
 Format: libFuzzer dictionary syntax — one token per line, strings in double quotes:
 
 ```

--- a/fuzz/README.md
+++ b/fuzz/README.md
@@ -80,7 +80,7 @@ cargo +nightly fuzz list --fuzz-dir fuzz
 
 ## Target Inventory
 
-All 18 targets, grouped by tier and trust boundary.
+All 19 targets, grouped by tier and trust boundary.
 
 **Trust boundaries:**
 - **B1** — Relay wire protocol (any unauthenticated TCP connection)
@@ -120,6 +120,7 @@ Test security properties beyond no-panic. Mix of raw bytes and structured `Arbit
 | `fuzz_sender_header_roundtrip` | B1 | Raw bytes | I1, parse→build→parse identity |
 | `fuzz_chunk_envelope` | B2 | Raw bytes | I1, I2 (`total_chunks` allocation bounds) |
 | `fuzz_merkle_proof` | B3 | Arbitrary (`ArbMerkleProof`) | I1, I2, single-bit flip in sibling hash changes result |
+| `fuzz_merkle_proof_random` | B3 | Arbitrary (`ArbInclusionProof`) | I1 (no panic on adversarially random proofs) |
 | `fuzz_canonical_hash_differential` | B2 | Arbitrary (`ArbCanonicalHashInput`) | I1, I10 (different `InnerEnvelopeParams` → different hash) |
 | `fuzz_aad_differential` | B2 | Arbitrary (`ArbAadInput`) | I1, I9 (different `(context_id, sender_did)` → different AAD) |
 
@@ -196,8 +197,10 @@ in the libFuzzer logs plateaus at a low number, check that:
    #![allow(clippy::unwrap_used, clippy::panic, clippy::expect_used)]
    ```
 
-4. **Add to the CI matrix** in `.github/workflows/fuzz.yml` under `fuzz-nightly` → `matrix.include`.
-   Specify `target`, `dict`, `max_len`, and `time`.
+4. **Add to the CI matrix** (Tier 1-2 only) in `.github/workflows/fuzz.yml` under `fuzz-nightly` →
+   `matrix.include`. Specify `target`, `dict`, `max_len`, and `time`. Tier 3-4 targets use `Arbitrary`
+   structured input (no dict) and are not added to the nightly matrix — run them locally or via
+   `workflow_dispatch`.
 
 5. **Seed the corpus directory** in `fuzz/corpus/fuzz_my_target/`:
    - At least one valid input per enum variant (valid-per-variant seeds)

--- a/fuzz/fuzz_targets/fuzz_aad_differential.rs
+++ b/fuzz/fuzz_targets/fuzz_aad_differential.rs
@@ -3,28 +3,7 @@
 
 use libfuzzer_sys::fuzz_target;
 use scp_fuzz::ArbAadInput;
-
-/// Replicates `scp_protocol::crypto::sender_keys::encrypt::build_sender_aad`,
-/// which is `pub(crate)` and cannot be called directly from an external crate.
-///
-/// The format is: 4-byte BE context_id length + context_id bytes +
-///                4-byte BE sender_did length + sender_did bytes +
-///                8-byte BE epoch + 8-byte BE sequence.
-///
-/// See `scp-protocol/src/crypto/sender_keys/encrypt.rs` for the authoritative
-/// definition. If that function changes, this replica MUST be updated to match.
-fn build_aad(context_id: &str, sender_did: &str, epoch: u64, seq: u64) -> Vec<u8> {
-    let mut aad = Vec::with_capacity(
-        4 + context_id.len() + 4 + sender_did.len() + 8 + 8,
-    );
-    aad.extend_from_slice(&(context_id.len() as u32).to_be_bytes());
-    aad.extend_from_slice(context_id.as_bytes());
-    aad.extend_from_slice(&(sender_did.len() as u32).to_be_bytes());
-    aad.extend_from_slice(sender_did.as_bytes());
-    aad.extend_from_slice(&epoch.to_be_bytes());
-    aad.extend_from_slice(&seq.to_be_bytes());
-    aad
-}
+use scp_protocol::crypto::sender_keys::build_sender_aad_for_testing;
 
 fuzz_target!(|input: ArbAadInput| {
     // Convert byte vecs to UTF-8 strings; skip if not valid UTF-8.
@@ -52,8 +31,8 @@ fuzz_target!(|input: ArbAadInput| {
         return;
     }
 
-    let aad_a = build_aad(ctx_a, did_a, input.a_epoch, input.a_seq);
-    let aad_b = build_aad(ctx_b, did_b, input.b_epoch, input.b_seq);
+    let aad_a = build_sender_aad_for_testing(ctx_a, did_a, input.a_epoch, input.a_seq);
+    let aad_b = build_sender_aad_for_testing(ctx_b, did_b, input.b_epoch, input.b_seq);
 
     assert_ne!(
         aad_a, aad_b,

--- a/fuzz/fuzz_targets/fuzz_canonical_hash_differential.rs
+++ b/fuzz/fuzz_targets/fuzz_canonical_hash_differential.rs
@@ -96,8 +96,7 @@ fuzz_target!(|input: ArbCanonicalHashInput| {
         || input.a.timestamp != input.b.timestamp
         || input.a.payload_hash != input.b.payload_hash
         || input.a.provenance_hash != input.b.provenance_hash
-        || input.a.message_type.discriminant()
-            != input.b.message_type.discriminant();
+        || msg_type_a.as_discriminator_byte() != msg_type_b.as_discriminator_byte();
 
     if !inputs_differ {
         return;

--- a/fuzz/fuzz_targets/fuzz_merkle_proof_random.rs
+++ b/fuzz/fuzz_targets/fuzz_merkle_proof_random.rs
@@ -18,5 +18,5 @@ use scp_fuzz::ArbInclusionProof;
 
 fuzz_target!(|arb: ArbInclusionProof| {
     // I1: no panic on any input — result is intentionally discarded.
-    let _ = verify_inclusion(&arb.into_proof());
+    let _ = verify_inclusion(&arb.into());
 });

--- a/fuzz/src/lib.rs
+++ b/fuzz/src/lib.rs
@@ -78,7 +78,7 @@ impl From<ArbProofStep> for ProofStep {
 /// exceed depth 40, and 8 steps is more than sufficient to exercise all
 /// proof-verification invariants. Using a fixed array bounds memory at
 /// `Arbitrary` generation time, avoiding the previous pattern of generating
-/// an unbounded `Vec<ArbProofStep>` before truncating in `into_proof`.
+/// an unbounded `Vec<ArbProofStep>` before truncating in the conversion.
 #[derive(Debug, Clone, Arbitrary)]
 pub struct ArbInclusionProof {
     pub leaf_index: u64,
@@ -88,14 +88,13 @@ pub struct ArbInclusionProof {
     pub root: [u8; 32],
 }
 
-impl ArbInclusionProof {
-    /// Converts to the production [`InclusionProof`] type.
-    pub fn into_proof(self) -> InclusionProof {
+impl From<ArbInclusionProof> for InclusionProof {
+    fn from(p: ArbInclusionProof) -> Self {
         InclusionProof {
-            leaf_index: self.leaf_index,
-            leaf_hash: self.leaf_hash,
-            path: self.path.into_iter().map(ProofStep::from).collect(),
-            root: self.root,
+            leaf_index: p.leaf_index,
+            leaf_hash: p.leaf_hash,
+            path: p.path.into_iter().map(ProofStep::from).collect(),
+            root: p.root,
         }
     }
 }
@@ -153,19 +152,6 @@ impl From<ArbMessageType> for MessageType {
     }
 }
 
-impl ArbMessageType {
-    /// Returns a numeric discriminant for equality comparison in differential
-    /// targets. Matches the byte values produced by `MessageType::as_discriminator_byte`.
-    #[must_use]
-    pub fn discriminant(&self) -> u8 {
-        match self {
-            Self::Content => 0,
-            Self::Signaling => 1,
-            Self::KeyDistribution => 2,
-            Self::Recovery => 3,
-        }
-    }
-}
 
 /// One set of `InnerEnvelope`-compatible fields for the canonical hash
 /// differential target.
@@ -208,10 +194,11 @@ pub struct ArbCanonicalHashInput {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use scp_protocol::crypto::sender_keys::build_sender_aad_for_testing;
     use scp_protocol::envelope::MessageType;
 
-    /// Asserts that `ArbMessageType::discriminant()` values match
-    /// `MessageType::as_discriminator_byte()` exactly (0/1/2/3).
+    /// Asserts that `From<ArbMessageType> for MessageType` maps each variant to
+    /// the correct production discriminator byte via `as_discriminator_byte()`.
     ///
     /// If `MessageType` gains a new variant or reorders its discriminants, the
     /// `From<ArbMessageType> for MessageType` impl and this test will both need
@@ -219,24 +206,66 @@ mod tests {
     #[test]
     fn arb_message_type_discriminants_match_production() {
         assert_eq!(
-            ArbMessageType::Content.discriminant(),
+            MessageType::from(ArbMessageType::Content).as_discriminator_byte(),
             MessageType::Content.as_discriminator_byte(),
             "Content discriminant mismatch"
         );
         assert_eq!(
-            ArbMessageType::Signaling.discriminant(),
+            MessageType::from(ArbMessageType::Signaling).as_discriminator_byte(),
             MessageType::Signaling.as_discriminator_byte(),
             "Signaling discriminant mismatch"
         );
         assert_eq!(
-            ArbMessageType::KeyDistribution.discriminant(),
+            MessageType::from(ArbMessageType::KeyDistribution).as_discriminator_byte(),
             MessageType::KeyDistribution.as_discriminator_byte(),
             "KeyDistribution discriminant mismatch"
         );
         assert_eq!(
-            ArbMessageType::Recovery.discriminant(),
+            MessageType::from(ArbMessageType::Recovery).as_discriminator_byte(),
             MessageType::Recovery.as_discriminator_byte(),
             "Recovery discriminant mismatch"
         );
+    }
+
+    /// Verifies that `build_sender_aad_for_testing` produces the expected
+    /// length-prefixed binary format for a set of known inputs.
+    ///
+    /// This test guards against accidental changes to the AAD wire format.
+    /// The expected bytes are computed manually from the format spec:
+    ///   [4-byte ctx_len BE][ctx bytes][4-byte did_len BE][did bytes][8-byte epoch BE][8-byte seq BE]
+    #[test]
+    fn build_sender_aad_known_output() {
+        let ctx = "ctx-abc";
+        let did = "did:dht:z6Mk";
+        let epoch: u64 = 1;
+        let seq: u64 = 42;
+
+        let aad = build_sender_aad_for_testing(ctx, did, epoch, seq);
+
+        let mut expected = Vec::new();
+        expected.extend_from_slice(&(ctx.len() as u32).to_be_bytes());
+        expected.extend_from_slice(ctx.as_bytes());
+        expected.extend_from_slice(&(did.len() as u32).to_be_bytes());
+        expected.extend_from_slice(did.as_bytes());
+        expected.extend_from_slice(&epoch.to_be_bytes());
+        expected.extend_from_slice(&seq.to_be_bytes());
+
+        assert_eq!(aad, expected, "AAD wire format diverged from spec");
+    }
+
+    /// Verifies that distinct `(context_id, sender_did, epoch, seq)` tuples
+    /// produce distinct AAD bytes (security invariant I9) for known inputs.
+    #[test]
+    fn build_sender_aad_injectivity_known_inputs() {
+        let aad1 = build_sender_aad_for_testing("ctx-a", "did:dht:alice", 1, 1);
+        let aad2 = build_sender_aad_for_testing("ctx-b", "did:dht:alice", 1, 1);
+        let aad3 = build_sender_aad_for_testing("ctx-a", "did:dht:bob", 1, 1);
+        let aad4 = build_sender_aad_for_testing("ctx-a", "did:dht:alice", 2, 1);
+        let aad5 = build_sender_aad_for_testing("ctx-a", "did:dht:alice", 1, 2);
+
+        assert_ne!(aad1, aad2, "context_id must contribute to AAD");
+        assert_ne!(aad1, aad3, "sender_did must contribute to AAD");
+        assert_ne!(aad1, aad4, "epoch must contribute to AAD");
+        assert_ne!(aad1, aad5, "sequence must contribute to AAD");
     }
 }


### PR DESCRIPTION
## Summary

- Add `fuzz/corpus/fuzz_merkle_proof_random/.gitkeep` — maintains the one-corpus-dir-per-target invariant (19 targets, 19 corpus dirs)
- Update README target count: 18 → 19
- Add `fuzz_merkle_proof_random` to the Tier 3 inventory table (`ArbInclusionProof`, I1 only)
- Clarify "Adding a New Target" step 4: Tier 3-4 targets use `Arbitrary` input (no dict) and are **not** added to the nightly CI matrix — consistent with all other Tier 3-4 targets

No production code or CI changes in the original commit.

## Post-merge nits (second commit)

- **Nit 1**: Replace `ArbInclusionProof::into_proof()` with `impl From<ArbInclusionProof> for InclusionProof`; update caller in `fuzz_merkle_proof_random` to use `.into()`
- **Nit 2**: Delete `ArbMessageType::discriminant()` (duplicated `MessageType::as_discriminator_byte()`); update `fuzz_canonical_hash_differential` and the alignment test to call the production method via `Into<MessageType>` conversion
- **Nit 3**: Expose `build_sender_aad` under `feature = "testing"` as `build_sender_aad_for_testing` in `scp-protocol`; update `fuzz_aad_differential` to call the production function directly instead of maintaining a replica; add conformance tests (`known-output` + `injectivity`) to the fuzz lib
- **Nit 4**: Document dict filename convention (`<format>_<target>.dict`) in `fuzz/.claude/CLAUDE.md`

## Verification

- `cargo +nightly check --manifest-path fuzz/Cargo.toml` — passes
- `cargo +nightly fuzz list --fuzz-dir fuzz | wc -l` — 19
- `cargo +nightly test --manifest-path fuzz/Cargo.toml --lib` — 3 tests pass
- `ls fuzz/corpus/ | wc -l` — 19

Closes gaps from #1643 and #1645.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[cross-layer: test-infrastructure] build_sender_aad_for_testing