### PR TITLE
docs: chronicle fuzzing infrastructure — ADR + lessons + cross-refs

### DIFF
--- a/.docs/adrs/phase-6.md
+++ b/.docs/adrs/phase-6.md
@@ -4,7 +4,7 @@
 **Phase goal:** Android platform, Kotlin SDK, scale hardening, security audit, advanced governance, offline strategy.
 **Timeline:** Weeks 21+
 
-**Note:** Phase 6 follows Phases 1-5 implementation. All ADRs in this phase — ADR-027 (Android), ADR-028 (Kotlin), ADR-029 (Offline/Sync), ADR-030 (Event Log Pruning), ADR-031 (Multi-Admin Governance), ADR-038 (Content Access Key Layer), ADR-043 (Protocol Constants), and ADR-044 (Attestation Two-Class Model) — are Decided.
+**Note:** Phase 6 follows Phases 1-5 implementation. All ADRs in this phase — ADR-027 (Android), ADR-028 (Kotlin), ADR-029 (Offline/Sync), ADR-030 (Event Log Pruning), ADR-031 (Multi-Admin Governance), ADR-038 (Content Access Key Layer), ADR-043 (Protocol Constants), ADR-044 (Attestation Two-Class Model), and ADR-045 (Fuzzing Infrastructure) — are Decided.
 
 **Dependencies between ADRs:**
 
@@ -21,7 +21,8 @@ Phase 1-5 ADRs
        ├── ADR-031 (Multi-Admin Governance) <── Phase 2 UCAN + single-admin governance
        ├── ADR-038 (Content Access Key Layer) <── ADR-007 (Sender Keys) + ADR-031 (Governance)
        ├── ADR-043 (Protocol Constants) <── Phase 1-5 implementation + empirical data
-       └── ADR-044 (Attestation Two-Class Model) <── §3.5 (Identity Attestations) + §7.4.1 (Attestation Format)
+       ├── ADR-044 (Attestation Two-Class Model) <── §3.5 (Identity Attestations) + §7.4.1 (Attestation Format)
+       └── ADR-045 (Fuzzing Infrastructure) <── Phase 1-5 parsers + ADR-043 (Protocol Constants) + §9 (Crypto)
 ```
 
 ---
@@ -3525,3 +3526,174 @@ The self-attestation model is acceptable for identity links specifically because
 7. No new `AttestationType` variant introduced — class is derived from `evidence.method`.
 
 **Migration note.** Changing the canonical signing bytes (replacing `revocation` with `revocation_status`) requires incrementing the domain separator from `SCP-IDENTITY-LINK-ATTESTATION-V1:` to `V2` per §9.5.1. No production attestations exist, so no backward compatibility is needed. The V2 separator is adopted in this spec change. The implementation PR uses V2 from the start.
+
+---
+
+## ADR-045: Fuzzing Infrastructure
+
+**Status:** Decided
+**Date:** April 2026
+**PRs:** #1643 (initial 18 targets), #1644 (size-gate fixes), #1645 (CI workflows), #1652 (documentation follow-up)
+
+### Context
+
+SCP's relay is explicitly an untrusted dumb pipe — any TCP connection can deliver bytes to the wire parser. Post-MLS decryption is a second trust boundary because authentication success does not imply that the plaintext is well-formed. A third boundary exists at resolution/discovery (DHT poisoning, adversarial UCAN chains). Parser panics at any of these boundaries are P0 security bugs.
+
+Property-based testing (proptest) covers algebraic properties of individual types and is already required (see `.docs/standards/rust.md` §Testing). Proptest does not provide: (a) coverage-guided mutation, (b) dictionary-assisted byte-level fuzzing of wire formats, or (c) continuous regression as the protocol evolves. cargo-fuzz (libFuzzer) fills this gap.
+
+The security audit phase (Phase 6) surfaced three categories of parser risk:
+
+1. **`#[serde(flatten)]` + `rmpv::Value` buffering.** MessagePack deserialization via `rmp-serde` with `#[serde(flatten)]` buffers the entire message into an intermediate `rmpv::Value` before field extraction. Without a size gate *before* `rmp_serde::from_slice`, a 4-byte "this blob is 4 GiB" header causes an OOM-abort before any application code runs. Found and fixed in PR #1644.
+
+2. **Replica drift.** Fuzz targets that re-implement private production functions (CID format, `build_sender_aad`, ceiling format) drift silently as the production code evolves. Three HIGH-severity bugs were found in `fuzz_validate_ucan_deep` (Round 1 review) because the replica was stale.
+
+3. **`InMemoryNonceTracker` clock coupling.** `InMemoryNonceTracker::check_replay` uses `SystemClock` directly, not an injected clock. Fuzz targets that exercise replay detection are therefore non-deterministic. Discovered during `fuzz_validate_ucan_deep` wiring.
+
+The plan for the fuzzing infrastructure was reviewed by 7 agents before implementation began. The key structural decision — standalone `fuzz/` crate vs. per-crate `fuzz/` dirs vs. workspace member — required explicit consensus because it affects how CI is structured, how nightly Rust is isolated, and how the corpus is organized.
+
+### Decision
+
+**Standalone `fuzz/` crate at repo root, not a workspace member.**
+
+`fuzz/Cargo.toml` contains `[workspace]`, explicitly opting out of the root workspace. The fuzz crate depends on production crates via path dependencies:
+
+```toml
+[workspace]
+
+scp-protocol = { path = "../crates/scp-protocol", features = ["testing"] }
+scp-transport = { path = "../crates/scp-transport" }
+scp-runtime   = { path = "../crates/scp-runtime",  features = ["testing"] }
+scp-event-log = { path = "../crates/scp-event-log" }
+```
+
+**Four-tier target strategy.** 19 targets total across four tiers:
+
+| Tier | Focus | Strategy | CI cadence |
+|------|-------|----------|-----------|
+| T1 — Wire Format Parsers | B1 relay wire, B2 post-MLS | Raw bytes + dict | Nightly, 15 min/target |
+| T2 — Content Trust Boundaries | B2 inner content, B3 resolution | Raw bytes + dict | Nightly, 5 min/target |
+| T3 — Invariant & Differential | Security properties, roundtrips | Mix raw + Arbitrary | Local / `workflow_dispatch` |
+| T4 — Validation Depth & State | Paths requiring semantic validity | Arbitrary + real Ed25519 | Local / `workflow_dispatch` |
+
+**Trust boundaries:**
+- **B1:** Relay wire protocol — any unauthenticated TCP connection
+- **B2:** Post-MLS decryption — authenticated but untrusted plaintext
+- **B3:** Resolution/discovery — network adversary, DHT poisoning
+
+**Raw bytes + dicts for T1/T2; Arbitrary only for T3/T4.**
+
+For parser and deserializer targets (T1/T2), the fuzzer receives a raw `&[u8]` slice and a libFuzzer dictionary of field names and structural MessagePack bytes. This gives libFuzzer direct mutation-coverage feedback — every mutated byte in the input corresponds to a byte in the parser's input. Wrapping in an `Arbitrary` type would cause the fuzzer to mutate the `Arbitrary` binary encoding, not the parser input, breaking the coverage feedback loop.
+
+`Arbitrary` is reserved for T3/T4 where raw bytes cannot reach the code path (e.g., merkle proof verification requires a structurally consistent proof, or differential targets require two semantically distinct inputs).
+
+**Invariant catalog I1–I10 as governance artifact.** The security invariants are defined once in `fuzz/README.md` and `fuzz/.claude/CLAUDE.md`, and referenced by target. Any new target must map to at least one invariant. Adding, weakening, or removing an invariant requires human approval.
+
+**CI cadence:**
+- **Nightly** (`.github/workflows/fuzz.yml`, 03:00 UTC): T1 targets 15 min each, T2 targets 5 min each. All targets parallel. Corpus cached per-target with `actions/cache`; `cargo fuzz cmin` runs after each campaign.
+- **Weekly deep-fuzz** (Saturday 00:00 UTC or `workflow_dispatch`): T1 targets only, 2 hours each, AddressSanitizer enabled (cargo-fuzz default) + UBSan on Saturdays.
+- **Per-PR compilation check** (`cargo +nightly check --manifest-path fuzz/Cargo.toml`): catches API breakage without running the fuzzer. Runs in `.github/workflows/ci.yml` as `fuzz-build`.
+
+### Rationale
+
+**Why standalone crate, not workspace member?**
+
+libFuzzer requires `rustc +nightly`. Adding `fuzz/` to the root workspace would force every `cargo clippy --workspace`, `cargo test --workspace`, and `cargo build --workspace` call to require nightly — or to skip the fuzz crate with `--exclude`, which is easily forgotten. The standalone crate cleanly separates the nightly build surface from the stable workspace. Clippy lints from the workspace `[workspace.lints]` do not apply to the fuzz crate; the fuzz crate uses `#![allow(clippy::unwrap_used, clippy::panic, clippy::expect_used)]` at the target level because the libFuzzer harness uses panics for crash detection.
+
+The 7-reviewer consensus during plan review confirmed this trade-off: corpus centralization (one `fuzz/corpus/` tree) and simpler CI matrix outweigh the mild awkwardness of a separate manifest path.
+
+**Why not per-crate `fuzz/` directories?**
+
+Per-crate directories fragment the corpus: `scp-protocol/fuzz/corpus/` and `scp-runtime/fuzz/corpus/` have no cross-pollination by default. Many wire-format fuzz targets exercise code paths across multiple crates (e.g., `fuzz_outer_envelope` calls into `scp-protocol` and `scp-transport`). A single `fuzz/` at the repo root with one corpus tree enables cross-pollination between related targets and avoids duplicate harness boilerplate.
+
+**Why not `Arbitrary`-everywhere?**
+
+The libFuzzer mutation engine works by flipping bytes in the input and observing which new coverage edges are discovered. For a raw-bytes target this works perfectly: a bit flip in a MessagePack field-name byte might cross a branch in the parser. For an `Arbitrary`-wrapped target, the mutation happens in the `Arbitrary` binary encoding — the actual parser input may not change at all, or may change in unrelated ways. This breaks the coverage-guided feedback loop that makes libFuzzer effective at finding parsing bugs.
+
+`Arbitrary` remains the right choice for T3/T4 where the target cannot accept arbitrary bytes (e.g., `fuzz_merkle_proof` needs a structurally consistent proof; `fuzz_canonical_hash_differential` needs two semantically distinct `InnerEnvelopeParams`).
+
+### Security Invariant Catalog (I1–I10)
+
+These invariants are the governance artifact for the fuzzing infrastructure. Every target maps to one or more of these invariants. Adding a new invariant requires an ADR amendment or a new ADR. Removing or weakening an existing invariant requires human approval.
+
+| ID | Invariant | Current coverage |
+|----|-----------|-----------------|
+| I1 | No panic on any untrusted input | All 19 targets |
+| I2 | No unbounded allocation (bounded by protocol constants from ADR-043) | T1–T6, T10–T11, T14–T15 |
+| I3 | Cryptographic signatures unforgeable (no structural bypass) | T16, T18 |
+| I4 | Nonce replay prevention: accepted nonce never re-accepted | Future T20 (blocked: `InMemoryNonceTracker` uses `SystemClock`) |
+| I5 | Epoch monotonicity: no rollback | Future T19 |
+| I6 | Timestamps outside `[now - max_age, now + skew]` always rejected | T18 |
+| I7 | Capabilities outside ceiling always rejected | T18 (wired but not exercised with non-empty chain) |
+| I8 | Delegation chain verification terminates (depth ≤ 32) | T18 (empty `prf`, no chain walked) |
+| I9 | Different `(context_id, sender_did)` → different AAD | T17 |
+| I10 | Different `InnerEnvelopeParams` → different canonical hash | T16 |
+
+I4 and I5 are blocked on clock injection into `InMemoryNonceTracker` (see `.docs/lessons/in-memory-nonce-tracker-system-clock.md`).
+
+### Rejected Alternatives
+
+**1. Per-crate `fuzz/` directories.** Rejected because: (a) corpus fragmentation — each crate has its own corpus with no cross-pollination; (b) duplicate harness boilerplate across crates; (c) CI matrix complexity — each crate would need its own fuzz workflow; (d) cross-crate targets (e.g., envelope parsing exercises `scp-protocol` + `scp-transport`) don't have a natural home.
+
+**2. `Arbitrary`-everywhere (all targets use structured generation).** Rejected because: (a) breaks libFuzzer mutation-coverage feedback for parser targets — the fuzzer mutates the `Arbitrary` encoding, not the parser input; (b) parser bugs (the primary security risk at B1) are best found by raw byte fuzzing + dictionaries; (c) `Arbitrary` types must be maintained in sync with production types — they drift (see `.docs/lessons/fuzz-replica-production-type-drift.md`). Reserved for T3/T4 where raw bytes cannot reach the code path.
+
+**3. Workspace member with `cfg(fuzzing)` feature flag.** Adding `fuzz/` to the root workspace with a feature flag to enable nightly-only code paths. Rejected because: (a) nightly is required by `libfuzzer-sys` at the crate level, not just by feature-gated code — the workspace would need nightly for all builds; (b) `cargo clippy --workspace` would cover fuzz targets, requiring the fuzz-specific `#![allow(...)]` suppression to be workspace-level or per-file.
+
+**4. AFL++ instead of cargo-fuzz/libFuzzer.** Rejected because: (a) cargo-fuzz is the idiomatic Rust fuzzing tool with best LLVM coverage integration; (b) AFL++ requires a separate build system integration; (c) structured `Arbitrary` generation is a cargo-fuzz/libFuzzer first-class feature via `libfuzzer-sys`.
+
+### Implementation
+
+```
+fuzz/                        # Standalone cargo-fuzz crate (not workspace member)
+├── Cargo.toml               # [workspace] block, path deps to production crates
+├── Cargo.lock               # Separate lock file — fuzzer deps don't pollute root lockfile
+├── README.md                # Operator docs: quick start, target inventory, crash workflow
+├── src/
+│   └── lib.rs               # Shared Arbitrary types (ArbMerkleProof, ArbCanonicalHashInput, …)
+├── fuzz_targets/            # 19 target files
+│   ├── fuzz_outer_envelope.rs          # T1/B1 — raw bytes
+│   ├── fuzz_inner_envelope.rs          # T1/B2 — raw bytes
+│   ├── fuzz_client_message.rs          # T1/B1 — raw bytes
+│   ├── fuzz_relay_message.rs           # T1/B1 — raw bytes
+│   ├── fuzz_sender_key_dist.rs         # T1/B2 — raw bytes
+│   ├── fuzz_scp_credential.rs          # T1/B2 — raw bytes
+│   ├── fuzz_parse_ucan.rs              # T2/B3 — raw UTF-8
+│   ├── fuzz_scp_uri.rs                 # T2/B3 — raw UTF-8
+│   ├── fuzz_capability_uri.rs          # T2/B3 — raw UTF-8
+│   ├── fuzz_broadcast_content.rs       # T2/B2 — raw bytes
+│   ├── fuzz_deserialize_export.rs      # T2/B2 — raw bytes
+│   ├── fuzz_outer_envelope_roundtrip.rs # T3/B1 — raw bytes, I1+roundtrip+hash stability
+│   ├── fuzz_sender_header_roundtrip.rs  # T3/B1 — raw bytes, I1+parse→build→parse identity
+│   ├── fuzz_chunk_envelope.rs           # T3/B2 — raw bytes, I1+I2
+│   ├── fuzz_merkle_proof.rs             # T3/B3 — Arbitrary, I1+I2+bit-flip sensitivity
+│   ├── fuzz_merkle_proof_random.rs      # T3/B3 — Arbitrary, I1
+│   ├── fuzz_canonical_hash_differential.rs # T3/B2 — Arbitrary, I1+I10
+│   ├── fuzz_aad_differential.rs         # T3/B2 — Arbitrary, I1+I9  (target 18)
+│   └── fuzz_validate_ucan_deep.rs       # T4/B3 — Arbitrary+real Ed25519, I1+I3+I6+I7+I8
+├── dicts/                   # libFuzzer dictionaries (one per target family)
+│   ├── msgpack_outer_envelope.dict
+│   ├── msgpack_inner_envelope.dict
+│   ├── msgpack_client_message.dict
+│   ├── msgpack_relay_message.dict
+│   ├── msgpack_sender_key.dict
+│   ├── msgpack_credential.dict
+│   ├── msgpack_broadcast.dict
+│   ├── msgpack_export.dict
+│   ├── ucan_jwt.dict
+│   ├── scp_uri.dict
+│   └── capability_uri.dict
+└── corpus/                  # Seed corpora (checked in); crash artifacts (gitignored)
+    └── <target>/            # One directory per target
+```
+
+### Acceptance Criteria
+
+1. `cargo +nightly fuzz list --fuzz-dir fuzz` lists all 19 targets.
+2. `cargo +nightly check --manifest-path fuzz/Cargo.toml` succeeds on stable CI (nightly toolchain via `+nightly` flag).
+3. Fuzz crate is NOT listed in root `Cargo.toml` `[workspace] members`.
+4. `.github/workflows/fuzz.yml` runs T1 targets (15 min) and T2 targets (5 min) nightly; T1 targets with UBSan weekly.
+5. `.github/workflows/ci.yml` includes a `fuzz-build` job that runs `cargo +nightly check --manifest-path fuzz/Cargo.toml`.
+6. Security invariants I1–I10 are documented in `fuzz/README.md` with current coverage status.
+7. `fuzz/.claude/CLAUDE.md` exists with agent-facing conventions: standalone crate caution, nightly requirement, raw-bytes-vs-Arbitrary guidance, dictionary format, invariant catalog.
+8. All T1/T2 targets use raw bytes (`|data: &[u8]|`). All T3/T4 targets that require semantic structure use `Arbitrary`.
+9. `fuzz/Cargo.lock` is committed (separate from root `Cargo.lock`).
+10. Crash workflow documented: reproduce → minimize (`fuzz tmin`) → file issue → add regression `#[test]`.

--- a/.docs/architecture.md
+++ b/.docs/architecture.md
@@ -1156,6 +1156,8 @@ Build:
   • Security audit
   • Governance models beyond single-admin — DONE: GovernanceEngine trait with SingleAdmin,
     Threshold (M-of-N), Majority, and Unanimity models (ADR-031, SCP-129–133)
+  • Fuzzing infrastructure — DONE: standalone fuzz/ crate, 19 targets across 4 tiers,
+    nightly + weekly CI campaigns (ADR-045, PRs #1643–1645)
 
 Test:
   • Load testing: 1000 SimulatedIdentity instances in scp-testing simulator,
@@ -1167,7 +1169,35 @@ Test:
   • Security: penetration testing, formal verification of crypto flows
   • Cross-platform conformance: all five language SDKs (Rust, Python, TypeScript,
     Swift, Kotlin) pass trait conformance suites through their respective FFI layers
+  • Fuzzing (parser safety + security invariants): 19 libFuzzer targets covering all
+    three trust boundaries (B1 relay wire, B2 post-MLS content, B3 resolution/discovery);
+    security invariants I1–I10 catalogued in fuzz/README.md; nightly CI runs T1 (15 min)
+    and T2 (5 min) targets; weekly Saturday deep-fuzz runs T1 with UBSan (2 h each);
+    per-PR fuzz-build check catches compilation breakage without running the fuzzer.
+    See ADR-045 and fuzz/README.md.
 ```
+
+#### Testing pyramid
+
+```
+  Integration / E2E tests    ← behavioral correctness across components (scp-testing harness)
+  Fuzz targets               ← parser safety + security invariants at trust boundaries
+  Property tests (proptest)  ← algebraic properties of individual types
+  Unit tests                 ← local function correctness
+```
+
+The fuzz layer occupies a distinct position between integration tests and property tests.
+It targets the protocol's external trust boundaries — the relay wire format (B1), post-MLS
+plaintext (B2), and resolution inputs (B3) — where remote adversaries control the input.
+Proptest verifies algebraic properties of already-parsed, trusted types. The two are
+complementary: proptest catches logic bugs, fuzzing catches parsing bugs.
+
+The 19 fuzz targets are organized into four tiers (ADR-045): T1 wire parsers (raw bytes +
+dicts), T2 content trust boundaries (raw bytes + dicts), T3 invariant/differential (mix
+of raw bytes and `Arbitrary`), and T4 deep validation (structured `Arbitrary` with real
+cryptographic material). The invariant catalog I1–I10 is the governance artifact: every
+target maps to one or more invariants; adding, weakening, or removing an invariant requires
+human approval.
 
 ---
 

--- a/.docs/lessons/fuzz-raw-bytes-over-arbitrary-wrappers.md
+++ b/.docs/lessons/fuzz-raw-bytes-over-arbitrary-wrappers.md
@@ -1,0 +1,96 @@
+# Fuzz parser targets with raw bytes + dicts, not `Arbitrary` wrappers
+
+**Date:** 2026-04-15
+**Source:** ADR-045 (Fuzzing Infrastructure) — design rationale; `fuzz/.claude/CLAUDE.md`
+
+## The principle
+
+For parser and deserializer fuzz targets (Tier 1–2 in ADR-045), always use raw byte slices as
+the fuzzer input. Reserve `Arbitrary` for Tier 3–4 invariant and differential targets where
+raw bytes cannot reach the code path.
+
+```rust
+// CORRECT — raw bytes for a parser target
+fuzz_target!(|data: &[u8]| {
+    let _ = OuterEnvelope::from_bytes(data);
+});
+
+// WRONG — Arbitrary wrapper for a parser target
+fuzz_target!(|input: ArbOuterEnvelope| {
+    let bytes = input.to_bytes();
+    let _ = OuterEnvelope::from_bytes(&bytes);
+});
+```
+
+## Why the distinction matters
+
+libFuzzer works by mutating the input buffer and observing which new LLVM coverage edges are
+discovered. When the input is a raw `&[u8]`:
+
+1. The fuzzer mutates bytes directly in the parser's input space.
+2. A single bit flip in a MessagePack field-name byte may expose a new branch in the parser.
+3. libFuzzer's mutation strategies (bit flip, byte substitution, crossover, dictionary tokens)
+   all operate directly on meaningful parser bytes.
+
+When the input is an `Arbitrary`-wrapped type:
+
+1. libFuzzer mutates bytes in the `Arbitrary` binary encoding (the serialized representation
+   of the `Arbitrary` struct), not in the final parser input.
+2. Many mutations of the `Arbitrary` encoding produce the same or structurally equivalent
+   parser input — no new coverage edge, no learning.
+3. The dictionary (`-dict=`) is useless: dictionary tokens are meaningful as MessagePack bytes,
+   not as bytes inside an `Arbitrary` encoding.
+4. Coverage plateaus quickly at a low value, and the fuzzer stops making progress.
+
+This break in the feedback loop is the single most common cause of ineffective fuzz campaigns.
+
+## When `Arbitrary` IS the right choice
+
+`Arbitrary` is appropriate when:
+
+1. **Raw bytes cannot reach the code path.** A merkle proof verifier requires a structurally
+   consistent proof (sibling hashes must be consistent lengths, root must match). Random bytes
+   are rejected before reaching the interesting code. `ArbMerkleProof` generates structurally
+   valid proofs with adversarially chosen values.
+
+2. **Differential invariants require two semantically distinct inputs.** `fuzz_aad_differential`
+   checks that different `(context_id, sender_did)` pairs always produce different AAD values.
+   This requires generating two structurally valid inputs, not two random byte arrays.
+
+3. **Targets require real cryptographic material.** `fuzz_validate_ucan_deep` uses real Ed25519
+   keypairs (generated once per run, seeded from the fuzzer input) to test signature
+   verification bypass. Raw bytes cannot produce a valid Ed25519 signature — `Arbitrary` with
+   real key generation is needed.
+
+## Recognizing the wrong pattern
+
+Red flags in a fuzz target:
+
+- `fuzz_target!(|input: ArbFoo|` for a type that has a `from_bytes` entry point.
+- A target that creates an `ArbFoo`, calls `to_bytes()` on it, then passes it to a parser.
+- A target description says "parser target" but uses `Arbitrary`.
+
+When reviewing a new target, ask: "Is the target testing a parser (Tier 1–2) or a security
+invariant that requires structural validity (Tier 3–4)?" If the former, the input must be
+`&[u8]`.
+
+## Dictionaries amplify raw-byte coverage
+
+For MessagePack parser targets, the `-dict=` flag is essential. Without a dictionary:
+- The fuzzer spends most of its time on inputs that fail before the first field check.
+- Coverage plateaus at the fixmap header byte (`\x81`–`\x8f`).
+
+With a dictionary of field names and MessagePack structural bytes:
+- The fuzzer can quickly construct inputs that reach deep field-parsing branches.
+- New enum variants and field names are discovered much faster.
+
+Add a dictionary for every new Tier 1–2 target. Update it whenever a new serde field or
+variant is added. See `fuzz/.claude/CLAUDE.md` §Dictionary Files for the format.
+
+## Related
+
+- `.docs/adrs/phase-6.md` §ADR-045 — Fuzzing Infrastructure (decision §"Raw bytes + dicts for T1/T2")
+- `fuzz/.claude/CLAUDE.md` — "Do NOT wrap raw bytes in Arbitrary types for parser targets"
+- `fuzz/fuzz_targets/fuzz_outer_envelope.rs` — canonical Tier 1 example (raw bytes)
+- `fuzz/fuzz_targets/fuzz_merkle_proof.rs` — canonical Tier 3 example (Arbitrary)
+- `fuzz/src/lib.rs` — shared `Arbitrary` type definitions for Tier 3–4 targets

--- a/.docs/lessons/fuzz-replica-production-type-drift.md
+++ b/.docs/lessons/fuzz-replica-production-type-drift.md
@@ -1,0 +1,113 @@
+# Fuzz targets that replicate private production functions drift silently
+
+**Date:** 2026-04-15
+**Source:** Round 1 review of fuzzing infrastructure — three HIGH bugs in `fuzz_validate_ucan_deep`
+
+## What happened
+
+`fuzz_validate_ucan_deep` (Tier 4, trust boundary B3) validates UCAN tokens by calling a
+sequence of validation steps that mirror the production validation pipeline. Three of those
+steps required access to private production functions — `build_sender_aad`, the CID format
+logic, and the ceiling format string — that were not `pub` in the production crates.
+
+The target re-implemented these functions locally:
+
+```rust
+// fuzz_targets/fuzz_validate_ucan_deep.rs
+fn build_sender_aad_replica(context_id: &str, sender_did: &str) -> Vec<u8> {
+    // Local replica of scp_runtime::encrypt::build_sender_aad
+    let mut aad = Vec::new();
+    aad.extend_from_slice(context_id.as_bytes());
+    aad.push(b':');
+    aad.extend_from_slice(sender_did.as_bytes());
+    aad
+}
+```
+
+Round 1 review found three HIGH bugs:
+
+1. The production `build_sender_aad` used a length-prefixed format (`[len][context_id][len][sender_did]`), not the colon-separated format in the replica. The replica produced a different byte sequence.
+2. The CID format replica omitted a version prefix byte that was added to the production function in PR #1602.
+3. The ceiling format replica used lowercase hex where the production function used uppercase.
+
+All three discrepancies would cause the fuzz target to miss bugs in the real production code:
+the target was testing the replica, not the production function.
+
+## Why this is dangerous
+
+A fuzz target that uses a stale replica of a production function provides false assurance:
+
+1. **The target continues to pass** — it is internally consistent with itself.
+2. **Production bugs are invisible** — the target never calls the production function, so
+   it cannot discover bugs in it.
+3. **Corpus is worthless** — inputs that find bugs in the replica would not exercise the
+   production code path at all.
+
+This is worse than having no fuzz target: a missing target is visible; a green fuzz target
+with a stale replica hides the gap.
+
+## The mitigation: prefer re-export over replica
+
+**Option 1 (preferred): `pub` or `pub(crate)` with `#[doc(hidden)]`.**
+
+Make the production function public with a `#[doc(hidden)]` attribute to signal it is
+implementation-internal but accessible for testing and fuzzing:
+
+```rust
+// crates/scp-runtime/src/encrypt.rs
+#[doc(hidden)]
+pub fn build_sender_aad(context_id: &str, sender_did: &str) -> Vec<u8> { ... }
+```
+
+The fuzz target then calls the real function:
+
+```rust
+use scp_runtime::build_sender_aad;
+fuzz_target!(|input: ArbAadInput| {
+    let aad = build_sender_aad(&input.context_id, &input.sender_did);
+    // ... invariant assertions on real output
+});
+```
+
+**Option 2: byte-equality conformance test.**
+
+Add a `#[test]` in the production crate that verifies the fuzz-target replica matches the
+production function for a representative set of inputs. This does not eliminate drift but
+detects it at CI time:
+
+```rust
+#[test]
+fn build_sender_aad_matches_fuzz_replica() {
+    let cases = [("ctx:abc", "did:dht:xyz"), ("", "did:dht:zzz")];
+    for (ctx, did) in cases {
+        assert_eq!(
+            build_sender_aad(ctx, did),
+            fuzz_replica::build_sender_aad(ctx, did),
+            "replica drifted from production for ({ctx}, {did})"
+        );
+    }
+}
+```
+
+**Option 3 (last resort): document the replica explicitly.**
+
+If neither option is feasible (e.g., the function is truly sealed in a private module with no
+way to expose it), document the replica with a comment linking to the production function and
+add a CI check that verifies the replica is reviewed when the production function changes.
+
+## How to catch replica drift during review
+
+1. `grep -n "replica\|// mirrors\|// replicates\|// copy of" fuzz/fuzz_targets/*.rs` — any
+   such comment is a candidate for a `#[doc(hidden)] pub` promotion.
+2. When a production crate changes a function that is also used (or replicated) in a fuzz
+   target, the `fuzz-build` CI check (`cargo +nightly check --manifest-path fuzz/Cargo.toml`)
+   will catch compilation errors but NOT semantic drift.
+3. When adding a new field to a struct used in fuzzing, audit all fuzz targets for local
+   replicas of functions that use that struct.
+
+## Related
+
+- `fuzz/fuzz_targets/fuzz_validate_ucan_deep.rs` — Tier 4 target (fixed after Round 1 review)
+- `crates/scp-runtime/src/encrypt.rs` — `build_sender_aad` (promoted to `#[doc(hidden)] pub`)
+- `.docs/adrs/phase-6.md` §ADR-045 — Fuzzing Infrastructure, "Rejected Alternatives §Arbitrary-everywhere"
+- `.docs/lessons/fuzz-raw-bytes-over-arbitrary-wrappers.md` — related target-quality lesson

--- a/.docs/lessons/in-memory-nonce-tracker-system-clock.md
+++ b/.docs/lessons/in-memory-nonce-tracker-system-clock.md
@@ -1,0 +1,68 @@
+# `InMemoryNonceTracker::check_replay` uses `SystemClock`, not injected clock
+
+**Date:** 2026-04-15
+**Source:** Round 1 review of fuzzing infrastructure plan — HIGH severity finding
+
+## The problem
+
+`InMemoryNonceTracker::check_replay` calls `SystemClock::now()` directly rather than accepting
+an injected clock. This makes nonce replay detection non-deterministic in:
+
+1. **Fuzz targets.** `fuzz_validate_ucan_deep` (invariant I4 — nonce replay prevention) cannot
+   achieve deterministic replay-detection testing because two invocations with the same input
+   may produce different results depending on wall time.
+
+2. **Property-based tests.** Proptest strategies that test replay behavior must sleep or
+   manipulate wall time, making them slow and flaky.
+
+3. **Simulation tests.** `SimulatedClock` (from `scp-testing`) cannot control the nonce
+   tracker's time window, breaking multi-node replay-detection scenarios.
+
+## Why invariant I4 is currently unimplemented in fuzzing
+
+Security invariant I4 — "accepted nonce never re-accepted" — is listed in the invariant
+catalog (`fuzz/README.md`) as "Future T20 (blocked: `InMemoryNonceTracker` uses `SystemClock`)".
+The target cannot be written until the clock is injectable.
+
+This is a documented architectural limitation, not an oversight. The fuzz target for I4 will
+require:
+
+1. Clock injection into `InMemoryNonceTracker` (make it generic over `Clock` trait or accept
+   `Arc<dyn Clock>`).
+2. A deterministic `FuzzClock` in `fuzz/src/lib.rs` that advances monotonically based on
+   fuzzer input bytes.
+3. A new fuzz target `fuzz_nonce_replay` (T20) that: accepts a nonce + timestamp pair, submits
+   it once (must succeed), submits the same nonce again (must be rejected).
+
+## Broader pattern: always inject clocks at construction
+
+Any component that makes time-dependent decisions must accept a clock at construction time, not
+call `SystemClock::now()` (or `std::time::SystemTime::now()`, `Instant::now()`, etc.) directly.
+
+This applies to:
+- Nonce trackers (`InMemoryNonceTracker`, `SqliteNonceTracker`)
+- Rate limiters (`BudgetTracker`, `RateLimitTracker` — already clock-generic per PR #1578)
+- Timestamp validators in UCAN / attestation verification
+- Any TTL cache with expiry logic
+
+The `Clock` trait already exists in `scp-runtime` (used by `RateLimitTracker` after PR #1578).
+Extend its usage to nonce trackers.
+
+## How to catch this when reviewing
+
+When reviewing a new type with time-dependent behavior:
+
+1. `grep -n "SystemTime::now\|Instant::now\|SystemClock" <file>` — any hit in a
+   struct method (not test code) is a candidate for clock injection.
+2. If the struct is used in tests, confirm there is a way to control time in the test.
+   If tests use `sleep`, that is a sign clock injection is missing.
+3. If the struct is referenced in a fuzz target, confirm the target can achieve deterministic
+   behavior. Non-deterministic fuzz targets are useless for regression detection.
+
+## Related
+
+- `crates/scp-runtime/src/nonce.rs` — `InMemoryNonceTracker` (clock injection needed)
+- `crates/scp-runtime/src/rate_limit.rs` — `RateLimitTracker` (already clock-generic, PR #1578)
+- `fuzz/README.md` §Security Invariants — I4 marked as "Future T20"
+- `.docs/adrs/phase-6.md` §ADR-045 — Fuzzing Infrastructure (invariant catalog)
+- PR #1578 — RateLimitTracker clock-generic refactor (reference implementation)

--- a/.docs/lessons/serde-flatten-rmpv-value-buffering.md
+++ b/.docs/lessons/serde-flatten-rmpv-value-buffering.md
@@ -1,0 +1,77 @@
+# `#[serde(flatten)]` + `rmpv::Value` buffers the whole message before rejection
+
+**Date:** 2026-04-15
+**Source:** PR #1644 — pre-deserialization size checks (security fix)
+
+## What happened
+
+`rmp-serde` with `#[serde(flatten)]` on a MessagePack struct does not stream field-by-field.
+It first deserializes the entire input into an intermediate `rmpv::Value` tree, then extracts
+named fields from that tree. This means a 4-byte MessagePack header claiming a 4 GiB blob
+(`\xc6\xff\xff\xff\xff`) causes an allocation attempt before any application-level size check
+runs.
+
+In the SCP wire format, `OuterEnvelope`, `InnerEnvelope`, and several sender-key structs all
+use `#[serde(flatten)]` for backward-compatible field layout. Without a size gate before
+`rmp_serde::from_slice`, any unauthenticated TCP connection can send a 4-byte packet and
+trigger an OOM-abort on the relay or SDK — a P0 denial-of-service.
+
+## The fix
+
+Always size-gate BEFORE calling any deserialization function:
+
+```rust
+use scp_protocol::constants::MAX_MESSAGE_SIZE; // from ADR-043
+
+pub fn from_bytes(data: &[u8]) -> Result<Self, EnvelopeError> {
+    if data.len() > MAX_MESSAGE_SIZE {
+        return Err(EnvelopeError::MessageTooLarge {
+            size: data.len(),
+            max: MAX_MESSAGE_SIZE,
+        });
+    }
+    rmp_serde::from_slice(data).map_err(EnvelopeError::Deserialize)
+}
+```
+
+The check must be the very first operation — before any prefix reading, magic bytes, or
+partial parsing. `rmp_serde::from_slice` does not accept a size limit parameter; the only safe
+approach is an explicit length check at the call site.
+
+## Why this is subtle
+
+1. **`#[serde(flatten)]` looks harmless.** It is a field annotation, not a deserialization
+   strategy annotation. Its effect on the internal buffering strategy is not obvious from
+   the `serde` documentation without reading the `serde_rmpv` internals.
+
+2. **MessagePack's length-prefixed encoding makes this exploitable.** JSON deserialization
+   typically fails fast on obvious junk. MessagePack is a binary format; a 4-byte header
+   `\xc6\xff\xff\xff\xff` is a valid `bin32` marker claiming 4 GiB follows. The deserializer
+   trusts this length and tries to allocate before reading any data.
+
+3. **Tests do not catch this.** Unit tests using valid or slightly malformed inputs will never
+   produce a 4 GiB length prefix. The size-gate bug is only discovered by: (a) fuzz targets
+   that mutate length bytes, or (b) explicit boundary tests with max-length prefixes.
+
+## Rule
+
+**For any type that calls `rmp_serde::from_slice` or `rmp_serde::from_read` with
+`#[serde(flatten)]` fields, the size gate MUST precede deserialization.**
+
+When reviewing a new `from_bytes` or deserialization entry point:
+1. Check if the type or any field uses `#[serde(flatten)]`.
+2. If yes, confirm there is a `data.len() > MAX_*` guard as the first line.
+3. Check the constant comes from `scp-protocol::constants` (ADR-043), not a local magic number.
+
+This applies to all trust boundaries — B1 (relay wire), B2 (post-MLS), B3 (discovery). Even
+authenticated inputs (B2) can be malformed: MLS authentication success does not imply
+well-formed plaintext.
+
+## Related
+
+- `crates/scp-protocol/src/envelope/outer.rs` — `OuterEnvelope::from_bytes` (size gate added)
+- `crates/scp-protocol/src/envelope/inner.rs` — `InnerEnvelope::from_bytes` (size gate added)
+- `crates/scp-protocol/src/constants.rs` — `MAX_MESSAGE_SIZE`, `MAX_SENDER_KEY_DIST_SIZE`, etc. (ADR-043)
+- `.docs/adrs/phase-6.md` §ADR-043 — Protocol Constants Reclassification
+- `.docs/adrs/phase-6.md` §ADR-045 — Fuzzing Infrastructure (the fuzz target that exposed this)
+- `fuzz/fuzz_targets/fuzz_outer_envelope.rs` — T1 target that catches regressions

--- a/.docs/lessons/validator-agents-read-worktree-not-main.md
+++ b/.docs/lessons/validator-agents-read-worktree-not-main.md
@@ -1,0 +1,78 @@
+# Validator subagents in worktrees read their working tree, not `origin/main`
+
+**Date:** 2026-04-15
+**Source:** Fuzzing infrastructure review — orchestrator verification protocol
+
+## What happened
+
+During the fuzzing infrastructure review, validator subagents dispatched into a worktree
+branch reported that certain files "do not exist" — files that had already been merged to
+`origin/main` days earlier. The agents were reading their own working tree (the feature branch
+worktree), which did not contain those files because the feature branch predated the merge.
+
+This produced false-positive review findings: the agent flagged real, correct code as missing.
+
+## Why this happens
+
+When an agent is dispatched into a worktree (e.g., `docs/fuzzing-chronicles`), its working
+directory is the worktree root. `Read`, `Grep`, and `Glob` tool calls resolve relative to that
+directory. If the working tree branch was created from `origin/main` before a particular commit
+landed, files from that commit do not appear in the worktree.
+
+The agent has no automatic awareness of what is on `origin/main` vs. the local worktree. It
+sees what is on disk.
+
+## The rule
+
+**Validators must always verify findings against `origin/main`, not their local working tree.**
+
+For any claim of the form "file X does not exist" or "function Y is not called":
+
+```sh
+# Check against origin/main, not local disk
+git show origin/main:path/to/file.rs | grep "function_name"
+
+# Or: fetch the file content from origin/main explicitly
+git show origin/main:.docs/lessons/some-lesson.md
+```
+
+The orchestrator verification protocol in `CLAUDE.md` already mandates this for post-merge
+verification:
+
+> Verify against the PUSHED REMOTE branch (`git show origin/branch:file`), never the local
+> working directory. Local state may be on a different branch.
+
+The same principle applies to review agents dispatched into worktrees that may be on different
+branches.
+
+## How to prevent false positives
+
+When dispatching a review agent:
+
+1. **Tell the agent which branch to treat as canonical.** "The authoritative state for
+   production code is `origin/main`. If a file or function appears to be missing, verify with
+   `git show origin/main:<path>` before reporting it as a finding."
+
+2. **Instruct the agent to rebase if in doubt.** If the worktree branch is stale relative to
+   `origin/main`, rebase before reviewing: `git rebase origin/main`.
+
+3. **Orchestrator post-review verification.** After receiving review findings, the orchestrator
+   must distinguish between: (a) findings about the PR's own changes, which are correctly
+   evaluated against the worktree; and (b) findings about pre-existing production code, which
+   must be verified against `origin/main`.
+
+## Related false-positive pattern: cherry-pick "nothing to commit"
+
+A related pattern from `CLAUDE.md`:
+
+> If a cherry-pick resolves to "nothing to commit," the changes DID NOT LAND. Investigate.
+
+This is the inverse: the orchestrator believed changes landed (because they were on a local
+branch) when they had not yet been pushed or merged. Both patterns stem from conflating local
+state with remote/canonical state.
+
+## Related
+
+- `CLAUDE.md` §"Orchestrator verification protocol" — verify against remote, not local
+- `.docs/lessons/worktree-all-changes.md` — related worktree pitfalls
+- `CLAUDE.md` §"Agent execution rules" — branch verification at agent start

--- a/.docs/standards/rust.md
+++ b/.docs/standards/rust.md
@@ -114,6 +114,53 @@ proptest! {
 }
 ```
 
+### Fuzzing (cargo-fuzz)
+
+SCP uses cargo-fuzz (libFuzzer) for parser safety and security invariant testing at trust
+boundaries. The fuzz crate lives at `fuzz/` (repo root) — a **standalone crate, not a
+workspace member**. All `cargo fuzz` commands require nightly:
+
+```sh
+cargo +nightly fuzz list --fuzz-dir fuzz          # list all 19 targets
+cargo +nightly fuzz run <target> --fuzz-dir fuzz \
+  -- -dict=fuzz/dicts/<dict> -max_total_time=60    # run one target locally
+cargo +nightly check --manifest-path fuzz/Cargo.toml  # compile-check (no fuzzing)
+```
+
+**Tier strategy** (ADR-045):
+
+| Tier | Focus | Input strategy | CI |
+|------|-------|----------------|-----|
+| T1 — Wire parsers | B1 relay wire, B2 post-MLS | Raw bytes + dictionary | Nightly, 15 min |
+| T2 — Content trust | B2 content, B3 resolution | Raw bytes + dictionary | Nightly, 5 min |
+| T3 — Invariants | Security properties, roundtrips | Raw bytes or `Arbitrary` | Local/manual |
+| T4 — Deep validation | Paths requiring semantic validity | `Arbitrary` + real crypto | Local/manual |
+
+**When to add a new fuzz target:**
+
+1. A new type has a `from_bytes` or `from_str` entry point at a trust boundary (B1/B2/B3).
+   → Add a Tier 1 or Tier 2 raw-bytes target.
+2. A security invariant (I1–I10 in `fuzz/README.md`) is not yet covered by any target.
+   → Add a Tier 3 or Tier 4 target.
+3. A new enum variant or struct field is added to a fuzzed type.
+   → Update the corresponding dictionary in `fuzz/dicts/`.
+
+**Do NOT use `Arbitrary` for parser targets (T1/T2).** Raw bytes give libFuzzer direct
+mutation-coverage feedback. `Arbitrary` wrappers cause the fuzzer to mutate the Arbitrary
+encoding rather than the parser input, breaking coverage guidance. See
+`.docs/lessons/fuzz-raw-bytes-over-arbitrary-wrappers.md`.
+
+**Do NOT replicate private production functions in fuzz targets.** Replicas drift silently.
+Prefer promoting the function to `#[doc(hidden)] pub` so the fuzz target calls the real
+implementation. See `.docs/lessons/fuzz-replica-production-type-drift.md`.
+
+**Size-gate before deserialization.** Any `from_bytes` function on a type with
+`#[serde(flatten)]` fields MUST check `data.len() > MAX_SIZE` before calling
+`rmp_serde::from_slice`. See `.docs/lessons/serde-flatten-rmpv-value-buffering.md`.
+
+See `fuzz/README.md` for the full target inventory, crash workflow, and corpus management.
+See `fuzz/.claude/CLAUDE.md` for agent-facing conventions.
+
 ### Test naming
 
 ```rust

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -141,6 +141,7 @@ All tools via [mise](https://mise.jdx.dev/) (see `.mise.toml`). **Never use npm 
 | **TypeScript** | `bindings/typescript/` | **bun** (not npm) | `bun run lint` (biome) | `bun run format` (biome) | `bun test` | `bun run build` (tsup) |
 | **Kotlin** | `bindings/kotlin/` | Gradle 8.x | `./gradlew detekt` | — | `./gradlew test` | `./gradlew assembleRelease` |
 | **WASM** | `crates/scp-ffi/wasm/` | cargo | `cargo clippy -p scp-ffi-wasm --target wasm32-unknown-unknown` | `cargo fmt` | conformance via `cargo test -p scp-core --test wasm_conformance` | `wasm-pack build crates/scp-ffi/wasm --target bundler` |
+| **Fuzzing** | `fuzz/` (standalone, not workspace) | cargo-fuzz (**nightly only**) | — | — | `cargo +nightly fuzz run <target> --fuzz-dir fuzz` | `cargo +nightly check --manifest-path fuzz/Cargo.toml` |
 
 **Language-specific gotchas:**
 
@@ -149,6 +150,7 @@ All tools via [mise](https://mise.jdx.dev/) (see `.mise.toml`). **Never use npm 
 - **WASM:** Cannot depend on scp-core (tokio multi-thread). Re-implements algorithms locally. See ADR-034.
 - **TypeScript:** `bun run check` runs `tsc --noEmit` for type checking. Biome handles both lint and format.
 - **PRD validation:** `python3.12 scripts/validate-prd.py` — run before committing PRD changes.
+- **Fuzzing:** `fuzz/` is a standalone crate — never add it to root `Cargo.toml` members. All commands require `+nightly`. List targets: `cargo +nightly fuzz list --fuzz-dir fuzz`. See ADR-045 and `fuzz/README.md`.
 
 ### Git
 


### PR DESCRIPTION
## Summary

- **ADR-045** added to `.docs/adrs/phase-6.md`: codifies the standalone `fuzz/` crate decision, four-tier target strategy (19 targets, T1–T4), I1–I10 invariant catalog as governance artifact, and four rejected alternatives (per-crate dirs, Arbitrary-everywhere, workspace member, AFL++)
- **5 lesson files** in `.docs/lessons/` capturing key learnings from the fuzzing sprint (serde flatten buffering, raw-bytes vs Arbitrary, clock injection, worktree false positives, replica drift)
- **`.docs/architecture.md`** §Phase 6: fuzzing added to Build and Test sections; testing pyramid diagram added
- **`.docs/standards/rust.md`**: Fuzzing (cargo-fuzz) subsection added alongside proptest; links to lessons
- **`CLAUDE.md`** toolchain table: Fuzzing row added; gotcha entry added for standalone crate + nightly requirement

References PRs #1643, #1644, #1645.

## Test plan

- [x] `python3.12 scripts/validate-prd.py` passes (PRD files unchanged)
- [x] All 9 files committed and pushed cleanly
- [x] ADR-045 header added to phase-6.md dependency graph and ADR list
- [x] All 5 lesson files use kebab-case names matching existing conventions
- [x] No new PRD files created (ADR + lessons, not stories)

🤖 Generated with [Claude Code](https://claude.com/claude-code)