### PR TITLE
feat: implement per-member pseudonym routing for encrypted contexts (§9.10.4)

### DIFF
--- a/.clippy.toml
+++ b/.clippy.toml
@@ -8,6 +8,10 @@ cognitive-complexity-threshold = 25
 # Increased from 800000 to 900000 after broadcast content tests (SCP-287)
 # added ~68 new test functions to scp-core.
 stack-size-threshold = 900000
+# Default large_futures threshold is 16384. Adding `local_pseudonym: Option<[u8; 32]>`
+# to create_context/join_context pushed test futures to 16416 bytes. Raise the
+# threshold slightly to accommodate. Production code is unaffected.
+future-size-threshold = 16512
 
 # ----- Disallowed methods -----
 # now_secs/now_millis are private to scp-primitives — the compiler enforces

--- a/crates/scp-ffi/napi/src/context.rs
+++ b/crates/scp-ffi/napi/src/context.rs
@@ -346,23 +346,31 @@ pub struct NapiMessage {
 // Helper — pseudonym derivation (SCP-214 criterion 5)
 // ---------------------------------------------------------------------------
 
-/// Derives the context-scoped pseudonym routing ID via the retained
-/// `KeyCustody` provider (SCP-214 criterion 5, spec §9.10.4).
+/// Derives the pseudonym routing ID for a context (§9.10.4).
 ///
-/// Returns `Ok(())` on success or if no custody/identity is available
-/// (graceful no-op). Errors are logged but not propagated.
+/// Returns the 32-byte Ed25519 public key derived via
+/// `KeyCustody::derive_pseudonym`. The pseudonym is used as the member's
+/// per-context routing ID for encrypted contexts, replacing the shared
+/// `context_routing_id` to prevent relay-side correlation.
 #[cfg(feature = "allow_in_memory_custody")]
-async fn derive_context_pseudonym(identity: &NapiIdentity, context_id: &str) {
-    if let (Some(scp_id), Some(custody)) = (
-        identity.inner.scp_identity.as_ref(),
-        &identity.inner.in_memory_custody,
-    ) {
-        let _pseudonym = custody
-            .0
-            .derive_pseudonym(&scp_id.identity_key, context_id.as_bytes())
-            .await
-            .ok();
-    }
+async fn derive_context_pseudonym(identity: &NapiIdentity, context_id: &str) -> Option<[u8; 32]> {
+    let (scp_id, custody) = (
+        identity.inner.scp_identity.as_ref()?,
+        identity.inner.in_memory_custody.as_ref()?,
+    );
+    let pseudonym = custody
+        .0
+        .derive_pseudonym(&scp_id.identity_key, context_id.as_bytes())
+        .await
+        .ok()?;
+    let bytes: [u8; 32] = pseudonym.public_key.as_bytes().try_into().ok()?;
+    Some(bytes)
+}
+
+/// Fallback for non-custody builds — always returns `None`.
+#[cfg(not(feature = "allow_in_memory_custody"))]
+async fn derive_context_pseudonym(_identity: &NapiIdentity, _context_id: &str) -> Option<[u8; 32]> {
+    None
 }
 
 // ---------------------------------------------------------------------------
@@ -510,19 +518,24 @@ pub async fn context_create(
     // Passes the creator DID to MlsCryptoProvider for real MLS encryption (#1294).
     crate::runtime::init_context_manager(&creator_did);
 
-    // Delegate to ContextManager.
+    // Derive the context-scoped pseudonym routing ID (§9.10.4, SCP-214 criterion 5).
+    // Derived BEFORE create_context so it can be passed to the ContextManager.
+    let local_pseudonym = derive_context_pseudonym(identity, &context_id).await;
+
+    // Delegate to ContextManager with pseudonym for per-member routing.
     let manager = context_manager()?;
     let core_handle = manager
-        .create_context(context_id.clone(), context_params, DID(creator_did.clone()))
+        .create_context_with_pseudonym(
+            context_id.clone(),
+            context_params,
+            DID(creator_did.clone()),
+            local_pseudonym,
+        )
         .await
         .map_err(|e| NapiError::from(ScpNapiError::from(e)))?;
 
     // Register the creator's DID as a local DID for defense-in-depth.
     manager.register_local_did(DID(creator_did.clone())).await;
-
-    // Derive the context-scoped pseudonym routing ID (SCP-214 criterion 5).
-    #[cfg(feature = "allow_in_memory_custody")]
-    derive_context_pseudonym(identity, &context_id).await;
 
     let handle = NapiContextHandle {
         context_id,
@@ -892,10 +905,16 @@ pub fn context_subscribe(
     };
 
     let context_id = handle.context_id.clone();
-    // Both subscribe and send paths use domain-separated
-    // SHA-256("scp:context-routing:" || context_id) as the routing ID.
-    let routing_id_bytes = scp_core::context::context_routing_id(&context_id);
-    let routing_id = scp_transport::RoutingId::new(routing_id_bytes);
+    // §9.10.4: dual subscription — subscribe to both the shared context
+    // routing ID (for backward compat and MLS management messages) and the
+    // member's pseudonym routing ID (for pseudonym-routed application messages).
+    let shared_routing_id_bytes = scp_core::context::context_routing_id(&context_id);
+    let shared_routing_id = scp_transport::RoutingId::new(shared_routing_id_bytes);
+
+    // Collect the member's pseudonym from the ContextManager state.
+    let local_pseudonym = context_manager()
+        .ok()
+        .and_then(|mgr| mgr.local_pseudonym(&context_id).ok().flatten());
 
     // Replace the cancellation token with a fresh one so a previously
     // cancelled token doesn't immediately cancel the new subscription.
@@ -927,8 +946,11 @@ pub fn context_subscribe(
     crate::runtime().spawn(async move {
         use futures::StreamExt;
 
-        let stream_result = transport_mgr.subscribe(&routing_id, None).await;
-        let mut stream = match stream_result {
+        // §9.10.4: dual subscription — always subscribe to the shared routing
+        // ID (MLS management messages, backward compat). If the member has a
+        // pseudonym, also subscribe to it for pseudonym-routed messages.
+        let stream_result = transport_mgr.subscribe(&shared_routing_id, None).await;
+        let stream = match stream_result {
             Ok(s) => s,
             Err(e) => {
                 tracing::error!(
@@ -946,6 +968,27 @@ pub fn context_subscribe(
                 return;
             }
         };
+
+        // §9.10.4: if the member has a pseudonym, subscribe to that routing
+        // ID too and merge both streams. Best-effort: if the pseudonym
+        // subscription fails, we still have the shared subscription.
+        let mut stream: std::pin::Pin<
+            Box<dyn futures::Stream<Item = scp_transport::TransportEvent> + Send>,
+        > = stream;
+        if let Some(pseudonym_bytes) = local_pseudonym {
+            let pseudonym_rid = scp_transport::RoutingId::new(pseudonym_bytes);
+            if let Ok(pseudonym_stream) = transport_mgr.subscribe(&pseudonym_rid, None).await {
+                // Merge the pseudonym stream into the main stream using
+                // futures::stream::select so events from either routing ID
+                // are delivered through the same processing loop.
+                stream = Box::pin(futures::stream::select(stream, pseudonym_stream));
+            } else {
+                tracing::warn!(
+                    context_id = %context_id,
+                    "pseudonym relay subscription failed — using shared routing ID only"
+                );
+            }
+        }
 
         let manager = match context_manager() {
             Ok(m) => m.clone(),

--- a/crates/scp-ffi/napi/src/context.rs
+++ b/crates/scp-ffi/napi/src/context.rs
@@ -525,7 +525,7 @@ pub async fn context_create(
     // Delegate to ContextManager with pseudonym for per-member routing.
     let manager = context_manager()?;
     let core_handle = manager
-        .create_context_with_pseudonym(
+        .create_context(
             context_id.clone(),
             context_params,
             DID(creator_did.clone()),
@@ -628,36 +628,25 @@ pub async fn context_join(
 
     // §9.10.4: Derive pseudonym for the joining member so it can be stored
     // in PerContextState and announced to other members.
+    // Extract custody + identity key from registry (sync), then derive
+    // the pseudonym asynchronously — avoids block_on inside an async fn.
     let context_id = handle.context_id.clone();
     let local_pseudonym: Option<[u8; 32]> = {
         #[cfg(feature = "allow_in_memory_custody")]
         {
-            crate::runtime::with_identity(&identity_did, |entry| {
-                let custody = &entry.custody;
-                let scp_id = &entry.identity;
-                let ctx = context_id.clone();
-                // Block on the async pseudonym derivation.
-                let rt_handle = tokio::runtime::Handle::current();
-                let pseudonym = rt_handle
-                    .block_on(async {
-                        custody
-                            .0
-                            .derive_pseudonym(&scp_id.identity_key, ctx.as_bytes())
-                            .await
-                    })
-                    .map_err(|e| ScpNapiError::Context {
-                        message: format!("pseudonym derivation failed: {e}"),
-                        code: codes::CTX_2014.to_owned(),
-                    })?;
-                let bytes: [u8; 32] = pseudonym.public_key.as_bytes().try_into().map_err(|_| {
-                    ScpNapiError::Context {
-                        message: "pseudonym public key must be 32 bytes".to_owned(),
-                        code: codes::CTX_2014.to_owned(),
-                    }
-                })?;
-                Ok(bytes)
+            let custody_and_key = crate::runtime::with_identity(&identity_did, |entry| {
+                Ok((entry.custody.clone(), entry.identity.identity_key))
             })
-            .ok()
+            .ok();
+            match custody_and_key {
+                Some((custody, identity_key)) => custody
+                    .0
+                    .derive_pseudonym(&identity_key, context_id.as_bytes())
+                    .await
+                    .ok()
+                    .and_then(|p| p.public_key.as_bytes().try_into().ok()),
+                None => None,
+            }
         }
         #[cfg(not(feature = "allow_in_memory_custody"))]
         {
@@ -667,7 +656,7 @@ pub async fn context_join(
 
     let manager = context_manager()?;
     manager
-        .join_context_with_pseudonym(
+        .join_context(
             core_handle,
             key_package,
             spending_ucan.as_ref(),
@@ -681,30 +670,23 @@ pub async fn context_join(
     if local_pseudonym.is_some() {
         #[cfg(feature = "allow_in_memory_custody")]
         {
-            let _ = async {
-                let entry = crate::runtime::with_identity(&identity_did, |e| {
-                    let key_handle = e.identity.active_signing_key;
-                    let rt_handle = tokio::runtime::Handle::current();
-                    let sk = rt_handle
-                        .block_on(async {
-                            e.custody.0.export_ed25519_signing_key(&key_handle).await
-                        })
-                        .map_err(|err| ScpNapiError::Context {
-                            message: format!("signing key export failed: {err}"),
-                            code: codes::CTX_2014.to_owned(),
-                        })?;
-                    Ok(sk)
-                });
-                if let Ok(sk) = entry {
-                    let sender_did = DID(identity_did.clone());
-                    let mgr = context_manager().ok()?;
-                    let ann_handle = handle.require_core_handle().ok()?;
+            // Extract custody + key handle from registry (sync), then export
+            // the signing key asynchronously — avoids block_on inside async fn.
+            let custody_and_key = crate::runtime::with_identity(&identity_did, |e| {
+                Ok((e.custody.clone(), e.identity.active_signing_key))
+            })
+            .ok();
+            if let Some((custody, key_handle)) = custody_and_key
+                && let Ok(sk) = custody.0.export_ed25519_signing_key(&key_handle).await
+            {
+                let sender_did = DID(identity_did.clone());
+                if let (Some(mgr), Ok(ann_handle)) =
+                    (context_manager().ok(), handle.require_core_handle())
+                {
                     mgr.send_pseudonym_announcement(ann_handle, &sender_did, &sk)
                         .await;
                 }
-                Some(())
             }
-            .await;
         }
     }
 
@@ -984,6 +966,10 @@ pub fn context_subscribe(
     // §9.10.4: dual subscription — subscribe to both the shared context
     // routing ID (for backward compat and MLS management messages) and the
     // member's pseudonym routing ID (for pseudonym-routed application messages).
+    //
+    // TODO(§9.10.4.A step 4): After all members have exchanged pseudonyms,
+    // unsubscribe from the shared routing ID to achieve full pseudonym privacy.
+    // Currently the shared subscription is permanent (migration never completes).
     let shared_routing_id_bytes = scp_core::context::context_routing_id(&context_id);
     let shared_routing_id = scp_transport::RoutingId::new(shared_routing_id_bytes);
 
@@ -3569,7 +3555,7 @@ mod tests {
         };
 
         let handle = manager
-            .create_context(ctx_id.clone(), params, creator)
+            .create_context(ctx_id.clone(), params, creator, None)
             .await
             .expect("create_context should succeed");
 
@@ -3581,7 +3567,7 @@ mod tests {
 
         let kp = KeyPackage::mock(DID("did:key:z6MkJoiner".to_owned()));
         manager
-            .join_context(&handle, kp, None)
+            .join_context(&handle, kp, None, None)
             .await
             .expect("join_context should succeed");
 
@@ -3643,7 +3629,7 @@ mod tests {
             ..ContextParams::default()
         };
         manager
-            .create_context(ctx_id.clone(), params, DID(creator.to_owned()))
+            .create_context(ctx_id.clone(), params, DID(creator.to_owned()), None)
             .await
             .unwrap();
         crate::runtime::register_test_context(&ctx_id, creator);
@@ -3704,7 +3690,7 @@ mod tests {
             ..ContextParams::default()
         };
         manager
-            .create_context(ctx_id.clone(), params, DID(creator.to_owned()))
+            .create_context(ctx_id.clone(), params, DID(creator.to_owned()), None)
             .await
             .unwrap();
         crate::runtime::register_test_context(&ctx_id, creator);
@@ -3757,7 +3743,7 @@ mod tests {
             ..ContextParams::default()
         };
         manager
-            .create_context(ctx_id.clone(), params, DID(creator.to_owned()))
+            .create_context(ctx_id.clone(), params, DID(creator.to_owned()), None)
             .await
             .unwrap();
         crate::runtime::register_test_context(&ctx_id, creator);

--- a/crates/scp-ffi/napi/src/context.rs
+++ b/crates/scp-ffi/napi/src/context.rs
@@ -626,11 +626,87 @@ pub async fn context_join(
         mls_key_package_bytes: Some(kp_bytes),
     };
 
+    // §9.10.4: Derive pseudonym for the joining member so it can be stored
+    // in PerContextState and announced to other members.
+    let context_id = handle.context_id.clone();
+    let local_pseudonym: Option<[u8; 32]> = {
+        #[cfg(feature = "allow_in_memory_custody")]
+        {
+            crate::runtime::with_identity(&identity_did, |entry| {
+                let custody = &entry.custody;
+                let scp_id = &entry.identity;
+                let ctx = context_id.clone();
+                // Block on the async pseudonym derivation.
+                let rt_handle = tokio::runtime::Handle::current();
+                let pseudonym = rt_handle
+                    .block_on(async {
+                        custody
+                            .0
+                            .derive_pseudonym(&scp_id.identity_key, ctx.as_bytes())
+                            .await
+                    })
+                    .map_err(|e| ScpNapiError::Context {
+                        message: format!("pseudonym derivation failed: {e}"),
+                        code: codes::CTX_2014.to_owned(),
+                    })?;
+                let bytes: [u8; 32] = pseudonym.public_key.as_bytes().try_into().map_err(|_| {
+                    ScpNapiError::Context {
+                        message: "pseudonym public key must be 32 bytes".to_owned(),
+                        code: codes::CTX_2014.to_owned(),
+                    }
+                })?;
+                Ok(bytes)
+            })
+            .ok()
+        }
+        #[cfg(not(feature = "allow_in_memory_custody"))]
+        {
+            None
+        }
+    };
+
     let manager = context_manager()?;
     manager
-        .join_context(core_handle, key_package, spending_ucan.as_ref())
+        .join_context_with_pseudonym(
+            core_handle,
+            key_package,
+            spending_ucan.as_ref(),
+            local_pseudonym,
+        )
         .await
         .map_err(|e| NapiError::from(ScpNapiError::from(e)))?;
+
+    // §9.10.4: Send pseudonym announcement to inform existing members.
+    // Best-effort: if signing key is not available, skip silently.
+    if local_pseudonym.is_some() {
+        #[cfg(feature = "allow_in_memory_custody")]
+        {
+            let _ = async {
+                let entry = crate::runtime::with_identity(&identity_did, |e| {
+                    let key_handle = e.identity.active_signing_key;
+                    let rt_handle = tokio::runtime::Handle::current();
+                    let sk = rt_handle
+                        .block_on(async {
+                            e.custody.0.export_ed25519_signing_key(&key_handle).await
+                        })
+                        .map_err(|err| ScpNapiError::Context {
+                            message: format!("signing key export failed: {err}"),
+                            code: codes::CTX_2014.to_owned(),
+                        })?;
+                    Ok(sk)
+                });
+                if let Ok(sk) = entry {
+                    let sender_did = DID(identity_did.clone());
+                    let mgr = context_manager().ok()?;
+                    let ann_handle = handle.require_core_handle().ok()?;
+                    mgr.send_pseudonym_announcement(ann_handle, &sender_did, &sk)
+                        .await;
+                }
+                Some(())
+            }
+            .await;
+        }
+    }
 
     Ok(())
 }
@@ -911,11 +987,6 @@ pub fn context_subscribe(
     let shared_routing_id_bytes = scp_core::context::context_routing_id(&context_id);
     let shared_routing_id = scp_transport::RoutingId::new(shared_routing_id_bytes);
 
-    // Collect the member's pseudonym from the ContextManager state.
-    let local_pseudonym = context_manager()
-        .ok()
-        .and_then(|mgr| mgr.local_pseudonym(&context_id).ok().flatten());
-
     // Replace the cancellation token with a fresh one so a previously
     // cancelled token doesn't immediately cancel the new subscription.
     let cancel_token = {
@@ -945,6 +1016,13 @@ pub fn context_subscribe(
     // which has no active tokio runtime context.
     crate::runtime().spawn(async move {
         use futures::StreamExt;
+
+        // Collect the member's pseudonym from the ContextManager state.
+        // Done inside the async block because local_pseudonym is async.
+        let local_pseudonym = match context_manager() {
+            Ok(mgr) => mgr.local_pseudonym(&context_id).await.ok().flatten(),
+            Err(_) => None,
+        };
 
         // §9.10.4: dual subscription — always subscribe to the shared routing
         // ID (MLS management messages, backward compat). If the member has a

--- a/crates/scp-ffi/napi/src/context.rs
+++ b/crates/scp-ffi/napi/src/context.rs
@@ -537,6 +537,30 @@ pub async fn context_create(
     // Register the creator's DID as a local DID for defense-in-depth.
     manager.register_local_did(DID(creator_did.clone())).await;
 
+    // §9.10.4: Send pseudonym announcement to inform other members of the
+    // creator's per-context routing ID. For freshly created single-member
+    // contexts this is a no-op (no recipients), but on restored/imported
+    // contexts with existing members the announcement is needed.
+    // Best-effort: if signing key is not available, skip silently.
+    if local_pseudonym.is_some() {
+        #[cfg(feature = "allow_in_memory_custody")]
+        {
+            let custody_and_key = crate::runtime::with_identity(&creator_did, |e| {
+                Ok((e.custody.clone(), e.identity.active_signing_key))
+            })
+            .ok();
+            if let Some((custody, key_handle)) = custody_and_key
+                && let Ok(sk) = custody.0.export_ed25519_signing_key(&key_handle).await
+            {
+                let sender_did = DID(creator_did.clone());
+                if let Ok(mgr) = context_manager() {
+                    mgr.send_pseudonym_announcement(&core_handle, &sender_did, &sk)
+                        .await;
+                }
+            }
+        }
+    }
+
     let handle = NapiContextHandle {
         context_id,
         state: std::sync::Mutex::new(ContextState::Active),

--- a/crates/scp-ffi/napi/src/context.rs
+++ b/crates/scp-ffi/napi/src/context.rs
@@ -963,14 +963,25 @@ pub fn context_subscribe(
     };
 
     let context_id = handle.context_id.clone();
-    // §9.10.4: dual subscription — subscribe to both the shared context
-    // routing ID (for backward compat and MLS management messages) and the
-    // member's pseudonym routing ID (for pseudonym-routed application messages).
+    let is_broadcast = handle.mode() == "Broadcast";
+    // §9.10.4 / §5.14: choose the correct shared routing ID based on context
+    // mode. Broadcast contexts use `broadcast_routing_id` = SHA-256(context_id)
+    // (plain hash, matching the send path in messaging.rs). Encrypted contexts
+    // use `context_routing_id` = SHA-256("scp:context-routing:" || context_id)
+    // (domain-separated). Using the wrong routing ID means messages never
+    // reach subscribers. Bug fix (#1534).
+    //
+    // For encrypted contexts, also subscribe to the member's pseudonym
+    // routing ID for pseudonym-routed application messages (§9.10.4).
     //
     // TODO(§9.10.4.A step 4): After all members have exchanged pseudonyms,
     // unsubscribe from the shared routing ID to achieve full pseudonym privacy.
     // Currently the shared subscription is permanent (migration never completes).
-    let shared_routing_id_bytes = scp_core::context::context_routing_id(&context_id);
+    let shared_routing_id_bytes = if is_broadcast {
+        scp_core::context::broadcast_routing_id(&context_id)
+    } else {
+        scp_core::context::context_routing_id(&context_id)
+    };
     let shared_routing_id = scp_transport::RoutingId::new(shared_routing_id_bytes);
 
     // Replace the cancellation token with a fresh one so a previously
@@ -1005,9 +1016,14 @@ pub fn context_subscribe(
 
         // Collect the member's pseudonym from the ContextManager state.
         // Done inside the async block because local_pseudonym is async.
-        let local_pseudonym = match context_manager() {
-            Ok(mgr) => mgr.local_pseudonym(&context_id).await.ok().flatten(),
-            Err(_) => None,
+        // Broadcast contexts do not use pseudonyms — skip the lookup.
+        let local_pseudonym = if is_broadcast {
+            None
+        } else {
+            match context_manager() {
+                Ok(mgr) => mgr.local_pseudonym(&context_id).await.ok().flatten(),
+                Err(_) => None,
+            }
         };
 
         // §9.10.4: dual subscription — always subscribe to the shared routing
@@ -1112,11 +1128,12 @@ pub fn context_subscribe(
                             );
                         }
                         Ok(None) => {
-                            // MLS Commit or Proposal — epoch advanced or proposal
-                            // cached, no application payload to deliver.
+                            // MLS Commit/Proposal or pseudonym announcement —
+                            // internal protocol message processed, no application
+                            // payload to forward to JS caller.
                             tracing::debug!(
                                 context_id = %context_id,
-                                "MLS control message processed (Commit/Proposal) — no payload"
+                                "protocol control message processed — no payload"
                             );
                         }
                         Err(e) => {

--- a/crates/scp-ffi/src/context.rs
+++ b/crates/scp-ffi/src/context.rs
@@ -913,6 +913,31 @@ fn py_context_create(identity_did: &str, params: &Bound<'_, PyDict>) -> PyResult
         .map_err(|e| PyRuntimeError::new_err(format!("failed to register context state: {e}")))?;
 
     // Delegate context creation to the shared ContextManager for lifecycle tracking.
+    // §9.10.4: Derive pseudonym BEFORE context creation so it can be passed
+    // to the ContextManager for per-member routing. The pseudonym derivation
+    // is also reused for the known-contexts registry below.
+    let local_pseudonym: Option<[u8; 32]> = crate::runtime::with_identity(identity_did, |entry| {
+        let rt = crate::runtime().map_err(|e| {
+            crate::error::ScpPyError::identity(format!("runtime not available: {e}"))
+        })?;
+        let pseudonym = rt.block_on(async {
+            entry
+                .custody
+                .derive_pseudonym(&entry.identity.identity_key, context_id.as_bytes())
+                .await
+        });
+        let pk = pseudonym
+            .map_err(|e| {
+                crate::error::ScpPyError::identity(format!("pseudonym derivation failed: {e}"))
+            })?
+            .public_key;
+        let bytes: [u8; 32] = pk.as_bytes().try_into().map_err(|_| {
+            crate::error::ScpPyError::identity("pseudonym public key must be 32 bytes")
+        })?;
+        Ok(bytes)
+    })
+    .ok();
+
     // Build scp-core ContextParams from the parsed PyContextParams.
     {
         let core_params = build_core_context_params(&parsed)?;
@@ -924,9 +949,14 @@ fn py_context_create(identity_did: &str, params: &Bound<'_, PyDict>) -> PyResult
         let ctx_id = context_id.clone();
         let creator_did_for_register = scp_identity::DID(identity_did.to_owned());
         rt.block_on(async move {
-            mgr.create_context(ctx_id, core_params, creator_did_owned)
-                .await
-                .map_err(|e| scp_core::context::ContextError::CreationFailed(e.to_string()))?;
+            mgr.create_context_with_pseudonym(
+                ctx_id,
+                core_params,
+                creator_did_owned,
+                local_pseudonym,
+            )
+            .await
+            .map_err(|e| scp_core::context::ContextError::CreationFailed(e.to_string()))?;
             // Register the creator's DID as a local DID for defense-in-depth,
             // matching NAPI's behavior.
             mgr.register_local_did(creator_did_for_register).await;
@@ -940,32 +970,12 @@ fn py_context_create(identity_did: &str, params: &Bound<'_, PyDict>) -> PyResult
     }
 
     // Register in the known-contexts registry for discovery via
-    // py_mcp_load_contexts. Derive a per-identity routing ID using
-    // KeyCustody::derive_pseudonym with real key material (§9.10.4).
-    // The pseudonym is deterministic for the same identity + context pair,
-    // providing unlinkability across contexts. See SCP-214 criterion 4.
+    // py_mcp_load_contexts. Reuse the pre-derived pseudonym routing ID
+    // (§9.10.4, SCP-214 criterion 4). Falls back to context_routing_id
+    // if pseudonym derivation was not available.
     {
-        let routing_id = crate::runtime::with_identity(identity_did, |entry| {
-            let rt = crate::runtime().map_err(|e| {
-                crate::error::ScpPyError::identity(format!("runtime not available: {e}"))
-            })?;
-            let pseudonym = rt.block_on(async {
-                entry
-                    .custody
-                    .derive_pseudonym(&entry.identity.identity_key, context_id.as_bytes())
-                    .await
-            });
-            let pk = pseudonym
-                .map_err(|e| {
-                    crate::error::ScpPyError::identity(format!("pseudonym derivation failed: {e}"))
-                })?
-                .public_key;
-            let bytes: [u8; 32] = pk.as_bytes().try_into().map_err(|_| {
-                crate::error::ScpPyError::identity("pseudonym public key must be 32 bytes")
-            })?;
-            Ok(bytes)
-        })
-        .map_err(|e| PyRuntimeError::new_err(format!("routing ID derivation failed: {e}")))?;
+        let routing_id =
+            local_pseudonym.unwrap_or_else(|| scp_core::context::context_routing_id(&context_id));
 
         // Get the relay URL from transport status if a relay is connected.
         let relay_url = match crate::transport::py_transport_status() {

--- a/crates/scp-ffi/src/context.rs
+++ b/crates/scp-ffi/src/context.rs
@@ -969,6 +969,29 @@ fn py_context_create(identity_did: &str, params: &Bound<'_, PyDict>) -> PyResult
         })?;
     }
 
+    // §9.10.4: Send pseudonym announcement to inform other members of the
+    // creator's per-context routing ID. For freshly created single-member
+    // contexts this is a no-op (no recipients), but on restored/imported
+    // contexts with existing members the announcement is needed.
+    if local_pseudonym.is_some()
+        && let Ok(sk) = resolve_signing_key(identity_did)
+    {
+        let rt = crate::runtime()?;
+        let mgr = crate::runtime::context_manager()
+            .map_err(|e| PyRuntimeError::new_err(e.to_string()))?;
+        let mgr = mgr.clone();
+        let sender_did = scp_identity::DID(identity_did.to_owned());
+        let core_params = build_core_context_params(&handle.params)?;
+        let temp_handle = scp_core::context::ContextHandle::new(context_id.clone(), core_params);
+        rt.block_on(async move {
+            let _ = temp_handle
+                .transition_to(&scp_core::context::ContextState::Active)
+                .await;
+            mgr.send_pseudonym_announcement(&temp_handle, &sender_did, &sk)
+                .await;
+        });
+    }
+
     // Register in the known-contexts registry for discovery via
     // py_mcp_load_contexts. Reuse the pre-derived pseudonym routing ID
     // (§9.10.4, SCP-214 criterion 4). Falls back to context_routing_id
@@ -1078,6 +1101,33 @@ fn py_context_join(
             mls_key_package_bytes: Some(kp_bytes),
         };
 
+        // §9.10.4: Derive pseudonym for the joining member so it can be
+        // stored in PerContextState and announced to other members.
+        let local_pseudonym: Option<[u8; 32]> =
+            crate::runtime::with_identity(identity_did, |entry| {
+                let rt = crate::runtime().map_err(|e| {
+                    crate::error::ScpPyError::identity(format!("runtime init failed: {e}"))
+                })?;
+                let pseudonym = rt.block_on(async {
+                    entry
+                        .custody
+                        .derive_pseudonym(&entry.identity.identity_key, context_id.as_bytes())
+                        .await
+                });
+                let pk = pseudonym
+                    .map_err(|e| {
+                        crate::error::ScpPyError::identity(format!(
+                            "pseudonym derivation failed: {e}"
+                        ))
+                    })?
+                    .public_key;
+                let bytes: [u8; 32] = pk.as_bytes().try_into().map_err(|_| {
+                    crate::error::ScpPyError::identity("pseudonym public key must be 32 bytes")
+                })?;
+                Ok(bytes)
+            })
+            .ok();
+
         // Look up the ContextHandle from a completed create_context call.
         // The ContextManager stores PerContextState keyed by context_id.
         // We need the handle to delegate. Since the handle is stored in
@@ -1086,14 +1136,39 @@ fn py_context_join(
         let core_params = build_core_context_params(&handle.params)?;
         let temp_handle = scp_core::context::ContextHandle::new(context_id.clone(), core_params);
         // Transition the temp handle to Active to match the real state.
+        // §9.10.4: use join_context_with_pseudonym to store the pseudonym
+        // in PerContextState for subsequent send_message fan-out.
         rt.block_on(async {
             let _ = temp_handle
                 .transition_to(&scp_core::context::ContextState::Active)
                 .await;
-            mgr.join_context(&temp_handle, key_package, spending_ucan.as_ref())
-                .await
+            mgr.join_context_with_pseudonym(
+                &temp_handle,
+                key_package,
+                spending_ucan.as_ref(),
+                local_pseudonym,
+            )
+            .await
         })
         .map_err(|e| PyRuntimeError::new_err(format!("ContextManager join_context failed: {e}")))?;
+
+        // §9.10.4: Send pseudonym announcement to inform existing members.
+        if local_pseudonym.is_some()
+            && let Ok(sk) = resolve_signing_key(identity_did)
+        {
+            let sender_did = scp_identity::DID(member_did.clone());
+            let temp_handle2 = scp_core::context::ContextHandle::new(
+                context_id.clone(),
+                build_core_context_params(&handle.params)?,
+            );
+            rt.block_on(async move {
+                let _ = temp_handle2
+                    .transition_to(&scp_core::context::ContextState::Active)
+                    .await;
+                mgr.send_pseudonym_announcement(&temp_handle2, &sender_did, &sk)
+                    .await;
+            });
+        }
 
         // Also update FFI bridge state's role_state for UCAN/tool capability checks.
         crate::runtime::with_ffi_state(&context_id, |st| {

--- a/crates/scp-ffi/src/context.rs
+++ b/crates/scp-ffi/src/context.rs
@@ -949,14 +949,9 @@ fn py_context_create(identity_did: &str, params: &Bound<'_, PyDict>) -> PyResult
         let ctx_id = context_id.clone();
         let creator_did_for_register = scp_identity::DID(identity_did.to_owned());
         rt.block_on(async move {
-            mgr.create_context_with_pseudonym(
-                ctx_id,
-                core_params,
-                creator_did_owned,
-                local_pseudonym,
-            )
-            .await
-            .map_err(|e| scp_core::context::ContextError::CreationFailed(e.to_string()))?;
+            mgr.create_context(ctx_id, core_params, creator_did_owned, local_pseudonym)
+                .await
+                .map_err(|e| scp_core::context::ContextError::CreationFailed(e.to_string()))?;
             // Register the creator's DID as a local DID for defense-in-depth,
             // matching NAPI's behavior.
             mgr.register_local_did(creator_did_for_register).await;
@@ -1136,13 +1131,13 @@ fn py_context_join(
         let core_params = build_core_context_params(&handle.params)?;
         let temp_handle = scp_core::context::ContextHandle::new(context_id.clone(), core_params);
         // Transition the temp handle to Active to match the real state.
-        // §9.10.4: use join_context_with_pseudonym to store the pseudonym
-        // in PerContextState for subsequent send_message fan-out.
+        // §9.10.4: pass the pseudonym to join_context so it is stored in
+        // PerContextState for subsequent send_message fan-out.
         rt.block_on(async {
             let _ = temp_handle
                 .transition_to(&scp_core::context::ContextState::Active)
                 .await;
-            mgr.join_context_with_pseudonym(
+            mgr.join_context(
                 &temp_handle,
                 key_package,
                 spending_ucan.as_ref(),
@@ -4696,6 +4691,7 @@ mod tests {
             ctx_id.clone(),
             params,
             scp_identity::DID(creator.to_owned()),
+            None,
         ))
         .unwrap();
         let new_did = "did:key:z6MkNewMember1";
@@ -4755,6 +4751,7 @@ mod tests {
             ctx_id.clone(),
             params,
             scp_identity::DID(creator.to_owned()),
+            None,
         ))
         .unwrap();
         let new_did = "did:key:z6MkAdded1";
@@ -4807,6 +4804,7 @@ mod tests {
             ctx_id.clone(),
             params,
             scp_identity::DID(creator.to_owned()),
+            None,
         ))
         .unwrap();
         let add = approved_proposal(

--- a/crates/scp-ffi/src/context.rs
+++ b/crates/scp-ffi/src/context.rs
@@ -990,10 +990,17 @@ fn py_context_create(identity_did: &str, params: &Bound<'_, PyDict>) -> PyResult
     // Register in the known-contexts registry for discovery via
     // py_mcp_load_contexts. Reuse the pre-derived pseudonym routing ID
     // (§9.10.4, SCP-214 criterion 4). Falls back to context_routing_id
-    // if pseudonym derivation was not available.
+    // for encrypted contexts or broadcast_routing_id for broadcast contexts.
+    // Bug fix (#1534): broadcast contexts use broadcast_routing_id (plain
+    // SHA-256) matching the send path, not context_routing_id (domain-separated).
     {
-        let routing_id =
-            local_pseudonym.unwrap_or_else(|| scp_core::context::context_routing_id(&context_id));
+        let routing_id = local_pseudonym.unwrap_or_else(|| {
+            if handle.params.mode == "broadcast" {
+                scp_core::context::broadcast_routing_id(&context_id)
+            } else {
+                scp_core::context::context_routing_id(&context_id)
+            }
+        });
 
         // Get the relay URL from transport status if a relay is connected.
         let relay_url = match crate::transport::py_transport_status() {

--- a/crates/scp-ffi/tests/e2e_bridge.rs
+++ b/crates/scp-ffi/tests/e2e_bridge.rs
@@ -108,7 +108,7 @@ fn create_test_context(creator_did: &str) -> String {
 
     rt.block_on(async move {
         let params = scp_core::context::ContextParams::default();
-        mgr.create_context(ctx_id.clone(), params, creator.clone())
+        mgr.create_context(ctx_id.clone(), params, creator.clone(), None)
             .await
             .unwrap();
         mgr.register_local_did(creator).await;

--- a/crates/scp-ffi/uniffi/src/bridge.rs
+++ b/crates/scp-ffi/uniffi/src/bridge.rs
@@ -3038,7 +3038,7 @@ pub async fn context_create(
             // Delegate to the shared ContextManager with pseudonym.
             let manager = crate::runtime::context_manager()?;
             let _core_handle = manager
-                .create_context_with_pseudonym(
+                .create_context(
                     context_id.clone(),
                     core_params,
                     identity.did.clone().into(),
@@ -3205,7 +3205,7 @@ pub async fn context_join(
             };
 
             manager
-                .join_context_with_pseudonym(
+                .join_context(
                     &core_handle,
                     key_package,
                     spending_ucan.as_ref(),

--- a/crates/scp-ffi/uniffi/src/bridge.rs
+++ b/crates/scp-ffi/uniffi/src/bridge.rs
@@ -2998,10 +2998,52 @@ pub async fn context_create(
             // Initialize the ContextManager if not already done (first context_create call).
             crate::runtime::init_context_manager();
 
-            // Delegate to the shared ContextManager.
+            // Extract key custody and signing key from the identity.
+            #[cfg(feature = "allow_in_memory_custody")]
+            let in_memory_custody = identity.in_memory_custody.clone();
+            let callback_custody = identity.callback_custody.clone();
+            let signing_key = identity.core_id.as_ref().map(|id| id.active_signing_key);
+
+            // §9.10.4: Derive the context-scoped pseudonym routing ID via the
+            // retained KeyCustody BEFORE context creation so it can be passed
+            // to the ContextManager for per-member routing.
+            let local_pseudonym: Option<[u8; 32]> =
+                if let Some(identity_key) = identity.core_id.as_ref().map(|id| &id.identity_key) {
+                    let pseudonym = if let Some(ref cb) = callback_custody {
+                        cb.derive_pseudonym(identity_key, context_id.as_bytes())
+                            .await
+                            .ok()
+                    } else {
+                        #[cfg(feature = "allow_in_memory_custody")]
+                        {
+                            if let Some(ref imc) = identity.in_memory_custody {
+                                imc.0
+                                    .derive_pseudonym(identity_key, context_id.as_bytes())
+                                    .await
+                                    .ok()
+                            } else {
+                                None
+                            }
+                        }
+                        #[cfg(not(feature = "allow_in_memory_custody"))]
+                        {
+                            None
+                        }
+                    };
+                    pseudonym.and_then(|p| p.public_key.as_bytes().try_into().ok())
+                } else {
+                    None
+                };
+
+            // Delegate to the shared ContextManager with pseudonym.
             let manager = crate::runtime::context_manager()?;
             let _core_handle = manager
-                .create_context(context_id.clone(), core_params, identity.did.clone().into())
+                .create_context_with_pseudonym(
+                    context_id.clone(),
+                    core_params,
+                    identity.did.clone().into(),
+                    local_pseudonym,
+                )
                 .await
                 .map_err(ScpError::from)?;
 
@@ -3010,47 +3052,6 @@ pub async fn context_create(
             manager
                 .register_local_did(identity.did.clone().into())
                 .await;
-
-            // Extract key custody and signing key from the identity.
-            #[cfg(feature = "allow_in_memory_custody")]
-            let in_memory_custody = identity.in_memory_custody.clone();
-            let callback_custody = identity.callback_custody.clone();
-            let signing_key = identity.core_id.as_ref().map(|id| id.active_signing_key);
-
-            // Derive the context-scoped pseudonym routing ID via the retained
-            // KeyCustody (SCP-214 criterion 5, spec §9.10.4). This produces a
-            // deterministic pseudonym from the identity key + context ID.
-            if let (Some(core_id), Some(identity_key)) = (
-                identity.core_id.as_ref(),
-                identity.core_id.as_ref().map(|id| &id.identity_key),
-            ) {
-                let _pseudonym = if let Some(ref cb) = callback_custody {
-                    cb.derive_pseudonym(identity_key, context_id.as_bytes())
-                        .await
-                        .ok()
-                } else {
-                    #[cfg(feature = "allow_in_memory_custody")]
-                    {
-                        if let Some(ref imc) = identity.in_memory_custody {
-                            imc.0
-                                .derive_pseudonym(identity_key, context_id.as_bytes())
-                                .await
-                                .ok()
-                        } else {
-                            None
-                        }
-                    }
-                    #[cfg(not(feature = "allow_in_memory_custody"))]
-                    {
-                        None
-                    }
-                };
-                // The pseudonym is derived for routing ID use. The actual
-                // routing ID is stored by the ContextManager's transport
-                // provider. Here we validate the derivation succeeds and
-                // the custody provider is functional for this context.
-                let _ = core_id;
-            }
 
             // Register per-context UCAN validation state (revocation list,
             // nonce tracker, event log) for the UCAN pipeline.

--- a/crates/scp-ffi/uniffi/src/bridge.rs
+++ b/crates/scp-ffi/uniffi/src/bridge.rs
@@ -3057,6 +3057,54 @@ pub async fn context_create(
             // nonce tracker, event log) for the UCAN pipeline.
             crate::runtime::ensure_ucan_registered(&context_id, &identity.did, &params.ceiling);
 
+            // §9.10.4: Send pseudonym announcement to inform other members of
+            // the creator's per-context routing ID. For freshly created
+            // single-member contexts this is a no-op (no recipients), but on
+            // restored/imported contexts with existing members the announcement
+            // is needed. Best-effort: if signing key is not available, skip.
+            if local_pseudonym.is_some() {
+                let sender_did = scp_identity::DID(identity.did.clone());
+                let core_handle = scp_core::context::ContextHandle::new(
+                    context_id.clone(),
+                    retained_core_params.clone(),
+                );
+                let _ = core_handle
+                    .transition_to(&scp_core::context::ContextState::Active)
+                    .await;
+                let sk_opt: Option<ed25519_dalek::SigningKey> =
+                    if let Some(ref ik) = identity.core_id {
+                        if let Some(ref cb) = identity.callback_custody {
+                            cb.export_ed25519_signing_key(&ik.active_signing_key)
+                                .await
+                                .ok()
+                        } else {
+                            #[cfg(feature = "allow_in_memory_custody")]
+                            {
+                                if let Some(ref custody) = identity.in_memory_custody {
+                                    custody
+                                        .0
+                                        .export_ed25519_signing_key(&ik.active_signing_key)
+                                        .await
+                                        .ok()
+                                } else {
+                                    None
+                                }
+                            }
+                            #[cfg(not(feature = "allow_in_memory_custody"))]
+                            {
+                                None
+                            }
+                        }
+                    } else {
+                        None
+                    };
+                if let Some(sk) = sk_opt {
+                    manager
+                        .send_pseudonym_announcement(&core_handle, &sender_did, &sk)
+                        .await;
+                }
+            }
+
             let handle = Arc::new(ContextHandle {
                 context_id,
                 state: tokio::sync::Mutex::new(ContextState::Active),

--- a/crates/scp-ffi/uniffi/src/bridge.rs
+++ b/crates/scp-ffi/uniffi/src/bridge.rs
@@ -3173,10 +3173,84 @@ pub async fn context_join(
                 mls_key_package_bytes: None,
             };
 
+            // §9.10.4: Derive pseudonym for per-member routing. Uses the
+            // identity's custody provider (callback or in-memory).
+            let identity_key = identity.core_id.as_ref().map(|id| id.identity_key);
+            let local_pseudonym: Option<[u8; 32]> = if let Some(ik) = identity_key {
+                let pseudonym = if let Some(ref cb) = identity.callback_custody {
+                    cb.derive_pseudonym(&ik, handle.context_id.as_bytes())
+                        .await
+                        .ok()
+                } else {
+                    #[cfg(feature = "allow_in_memory_custody")]
+                    {
+                        if let Some(ref custody) = identity.in_memory_custody {
+                            custody
+                                .0
+                                .derive_pseudonym(&ik, handle.context_id.as_bytes())
+                                .await
+                                .ok()
+                        } else {
+                            None
+                        }
+                    }
+                    #[cfg(not(feature = "allow_in_memory_custody"))]
+                    {
+                        None
+                    }
+                };
+                pseudonym.and_then(|p| p.public_key.as_bytes().try_into().ok())
+            } else {
+                None
+            };
+
             manager
-                .join_context(&core_handle, key_package, spending_ucan.as_ref())
+                .join_context_with_pseudonym(
+                    &core_handle,
+                    key_package,
+                    spending_ucan.as_ref(),
+                    local_pseudonym,
+                )
                 .await
                 .map_err(ScpError::from)?;
+
+            // §9.10.4: Send pseudonym announcement to inform existing members.
+            // Best-effort: if signing key is not available, skip silently.
+            if local_pseudonym.is_some() {
+                let sender_did = scp_identity::DID(identity.did.clone());
+                let sk_opt: Option<ed25519_dalek::SigningKey> =
+                    if let Some(ref ik) = identity.core_id {
+                        if let Some(ref cb) = identity.callback_custody {
+                            cb.export_ed25519_signing_key(&ik.active_signing_key)
+                                .await
+                                .ok()
+                        } else {
+                            #[cfg(feature = "allow_in_memory_custody")]
+                            {
+                                if let Some(ref custody) = identity.in_memory_custody {
+                                    custody
+                                        .0
+                                        .export_ed25519_signing_key(&ik.active_signing_key)
+                                        .await
+                                        .ok()
+                                } else {
+                                    None
+                                }
+                            }
+                            #[cfg(not(feature = "allow_in_memory_custody"))]
+                            {
+                                None
+                            }
+                        }
+                    } else {
+                        None
+                    };
+                if let Some(sk) = sk_opt {
+                    manager
+                        .send_pseudonym_announcement(&core_handle, &sender_did, &sk)
+                        .await;
+                }
+            }
 
             Ok(())
         })

--- a/crates/scp-protocol/src/context/membership.rs
+++ b/crates/scp-protocol/src/context/membership.rs
@@ -780,6 +780,18 @@ pub enum ContextEvent {
         /// Total attempt count.
         attempts: u32,
     },
+    /// A member announced their pseudonym routing ID for this context (§9.10.4).
+    ///
+    /// Emitted when an incoming MLS application message carries a pseudonym
+    /// announcement. The pseudonym is stored in the per-context pseudonym
+    /// registry so that subsequent `send_message` calls route messages to the
+    /// member's pseudonym rather than the shared context routing ID.
+    PseudonymAnnounced {
+        /// The DID of the member who announced their pseudonym.
+        member_did: DID,
+        /// The 32-byte pseudonym-derived routing ID.
+        pseudonym: [u8; 32],
+    },
 }
 
 // ---------------------------------------------------------------------------

--- a/crates/scp-protocol/src/context/mod.rs
+++ b/crates/scp-protocol/src/context/mod.rs
@@ -109,6 +109,18 @@ pub fn context_routing_id(context_id: &str) -> [u8; 32] {
     bytes
 }
 
+/// Derives a 32-byte routing ID for broadcast contexts using plain SHA-256.
+///
+/// Broadcast contexts use `SHA-256(context_id)` without the
+/// `"scp:context-routing:"` domain separator, per spec §5.14. This matches
+/// [`context_id_bytes`] by design — broadcast routing IDs are the raw hash
+/// of the context ID string, distinct from the domain-separated
+/// [`context_routing_id`] used by encrypted contexts.
+#[must_use]
+pub fn broadcast_routing_id(context_id: &str) -> [u8; 32] {
+    context_id_bytes(context_id)
+}
+
 // ---------------------------------------------------------------------------
 // ContextState
 // ---------------------------------------------------------------------------
@@ -463,5 +475,36 @@ mod tests {
 
         let actual = context_routing_id("test-ctx");
         assert_eq!(&actual[..], &expected[..]);
+    }
+
+    #[test]
+    fn broadcast_routing_id_equals_context_id_bytes() {
+        // Broadcast contexts use plain SHA-256(context_id) per spec §5.14,
+        // which is the same as context_id_bytes.
+        let broadcast = broadcast_routing_id("test-ctx");
+        let raw = context_id_bytes("test-ctx");
+        assert_eq!(
+            broadcast, raw,
+            "broadcast_routing_id must equal context_id_bytes"
+        );
+    }
+
+    #[test]
+    fn broadcast_routing_id_differs_from_context_routing_id() {
+        // Broadcast routing ID (no domain separator) must differ from
+        // encrypted context routing ID (domain-separated).
+        let broadcast = broadcast_routing_id("test-ctx");
+        let encrypted = context_routing_id("test-ctx");
+        assert_ne!(
+            broadcast, encrypted,
+            "broadcast and encrypted routing IDs must differ"
+        );
+    }
+
+    #[test]
+    fn broadcast_routing_id_is_deterministic() {
+        let id1 = broadcast_routing_id("test-ctx");
+        let id2 = broadcast_routing_id("test-ctx");
+        assert_eq!(id1, id2);
     }
 }

--- a/crates/scp-runtime/examples/context.rs
+++ b/crates/scp-runtime/examples/context.rs
@@ -59,7 +59,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     // 4. Create the context — returns a handle for all subsequent operations.
     let handle = manager
-        .create_context("demo-context".to_owned(), params, alice.clone())
+        .create_context("demo-context".to_owned(), params, alice.clone(), None)
         .await?;
 
     println!();

--- a/crates/scp-runtime/examples/messaging.rs
+++ b/crates/scp-runtime/examples/messaging.rs
@@ -51,7 +51,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     };
 
     let handle = manager
-        .create_context("chat-demo".to_owned(), params, alice.clone())
+        .create_context("chat-demo".to_owned(), params, alice.clone(), None)
         .await?;
     println!("Alice created context: {}", handle.context_id());
 
@@ -60,7 +60,9 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         owner_did: bob.clone(),
         mls_key_package_bytes: None, // mock — no real MLS in this example
     };
-    manager.join_context(&handle, bob_key_package, None).await?;
+    manager
+        .join_context(&handle, bob_key_package, None, None)
+        .await?;
     println!("Bob joined the context.");
 
     // Check membership.

--- a/crates/scp-runtime/src/context/export_import.rs
+++ b/crates/scp-runtime/src/context/export_import.rs
@@ -373,6 +373,10 @@ fn strip_snapshot_for_public(snapshot: &ContextSnapshot) -> ContextSnapshot {
         // Generation counter is local runtime state — no meaning to a
         // public observer. Always zero in public scope.
         generation: 0,
+        // §9.10.4: pseudonym state is local-instance routing state —
+        // no meaning to a public observer. Always empty/None in public scope.
+        local_pseudonym: None,
+        pseudonym_registry: HashMap::new(),
     }
 }
 
@@ -496,6 +500,8 @@ mod tests {
             checkpoint_events_since: 0,
             checkpoint_last_time_secs: 0,
             generation: 0,
+            local_pseudonym: None,
+            pseudonym_registry: HashMap::new(),
         }
     }
 

--- a/crates/scp-runtime/src/context/manager/governance.rs
+++ b/crates/scp-runtime/src/context/manager/governance.rs
@@ -2905,6 +2905,10 @@ impl ContextManager {
             // Destroy the removed member's access key (§9.17.2, ADR-038).
             ctx.access.access_key_store.remove(context_id, did.as_ref());
 
+            // §9.10.4: remove the member's pseudonym routing ID so future
+            // fan-outs do not send messages to a stale routing ID.
+            ctx.pseudonym_registry.remove(did);
+
             ctx.receive_buffer.push(ContextEvent::MemberLeft {
                 member_did: did.clone(),
             });
@@ -4987,7 +4991,12 @@ impl ContextManager {
         // Create the destination context AFTER the source has been
         // transitioned to MigratingOut. If creation fails, roll back.
         if let Err(e) = self
-            .create_context(destination_context_id.clone(), dest_params, creator_did)
+            .create_context(
+                destination_context_id.clone(),
+                dest_params,
+                creator_did,
+                None,
+            )
             .await
         {
             // Roll back: revert source to Active and clear migration state.

--- a/crates/scp-runtime/src/context/manager/lifecycle.rs
+++ b/crates/scp-runtime/src/context/manager/lifecycle.rs
@@ -2212,6 +2212,64 @@ impl ContextManager {
         Ok(())
     }
 
+    /// Sends a `PseudonymAnnouncement` to inform other members of this
+    /// member's per-context routing ID (§9.10.4).
+    ///
+    /// Called by the FFI bridges after `create_context_with_pseudonym` or
+    /// `join_context_with_pseudonym` succeeds. The signing key is available
+    /// at the FFI bridge layer but NOT in the runtime lifecycle methods, so
+    /// this method is separated from the create/join paths.
+    ///
+    /// Best-effort: logs a warning but does not fail if the announcement
+    /// cannot be sent (e.g. transport not yet connected, or the context is
+    /// a single-member context with nobody to announce to).
+    ///
+    /// # Arguments
+    ///
+    /// * `handle` -- The context handle.
+    /// * `sender_did` -- The announcing member's DID.
+    /// * `signing_key` -- Ed25519 signing key for MLS application message.
+    pub async fn send_pseudonym_announcement(
+        &self,
+        handle: &ContextHandle,
+        sender_did: &DID,
+        signing_key: &ed25519_dalek::SigningKey,
+    ) {
+        let context_id = handle.context_id().to_owned();
+        let pseudonym = {
+            let Ok(ctx_arc) = self.get_context_arc(&context_id) else {
+                return;
+            };
+            let guard = ctx_arc.lock().await;
+            guard.local_pseudonym
+        };
+        let Some(pseudonym) = pseudonym else {
+            return;
+        };
+        let announcement = super::PseudonymAnnouncement {
+            tag: super::PSEUDONYM_ANNOUNCEMENT_TAG.to_owned(),
+            member_did: sender_did.as_ref().to_owned(),
+            pseudonym,
+        };
+        let Ok(payload) = rmp_serde::to_vec_named(&announcement) else {
+            tracing::warn!(
+                context_id = %context_id,
+                "failed to serialize pseudonym announcement"
+            );
+            return;
+        };
+        if let Err(e) = self
+            .send_message(handle, sender_did, &payload, Some(signing_key), None, None)
+            .await
+        {
+            tracing::warn!(
+                context_id = %context_id,
+                error = %e,
+                "failed to send pseudonym announcement — other members will use shared routing"
+            );
+        }
+    }
+
     /// Performs the membership state mutations for `join_context` (Phase 4).
     ///
     /// Extracted to keep `join_context` within the clippy `too_many_lines` limit.

--- a/crates/scp-runtime/src/context/manager/lifecycle.rs
+++ b/crates/scp-runtime/src/context/manager/lifecycle.rs
@@ -588,6 +588,13 @@ impl ContextManager {
             // are needed. Deferred to the Welcome delivery plan (#1311)
             // which adds cross-process event log synchronization.
             merkle_tree: scp_event_log::EventLog::new(context_id.to_owned()),
+            // §9.10.4: restore pseudonym routing state from snapshot.
+            local_pseudonym: ctx_snapshot.local_pseudonym,
+            pseudonym_registry: ctx_snapshot
+                .pseudonym_registry
+                .into_iter()
+                .map(|(did_str, p)| (DID(did_str), p))
+                .collect(),
         };
 
         // Atomic check-and-insert — eliminates TOCTOU race between
@@ -1305,6 +1312,10 @@ impl ContextManager {
             // Fresh Merkle tree for imported contexts. Proofs cover
             // post-import events only (same rationale as restore_context).
             merkle_tree: scp_event_log::EventLog::new(context_id.clone()),
+            // §9.10.4: pseudonym state is local-instance — wiped on import.
+            // The importing member must re-derive and re-announce.
+            local_pseudonym: None,
+            pseudonym_registry: HashMap::new(),
         };
 
         // 7. Register the context.
@@ -1394,6 +1405,41 @@ impl ContextManager {
         context_id: String,
         params: ContextParams,
         creator_did: DID,
+    ) -> Result<ContextHandle, ContextCreationError> {
+        self.create_context_inner(context_id, params, creator_did, None)
+            .await
+    }
+
+    /// Creates a new SCP context with a pre-derived pseudonym routing ID.
+    ///
+    /// The `local_pseudonym` is the 32-byte Ed25519 public key derived via
+    /// `KeyCustody::derive_pseudonym` in the FFI bridge. For encrypted
+    /// contexts, this pseudonym will be used as the member's per-context
+    /// routing ID (§9.10.4) instead of the shared `context_routing_id`.
+    ///
+    /// # Errors
+    ///
+    /// Same as [`create_context`](Self::create_context).
+    pub async fn create_context_with_pseudonym(
+        &self,
+        context_id: String,
+        params: ContextParams,
+        creator_did: DID,
+        local_pseudonym: Option<[u8; 32]>,
+    ) -> Result<ContextHandle, ContextCreationError> {
+        self.create_context_inner(context_id, params, creator_did, local_pseudonym)
+            .await
+    }
+
+    /// Internal implementation for context creation, shared by both
+    /// `create_context` and `create_context_with_pseudonym`.
+    #[allow(clippy::too_many_lines)] // Context creation initializes many subsystems including pseudonym routing.
+    async fn create_context_inner(
+        &self,
+        context_id: String,
+        params: ContextParams,
+        creator_did: DID,
+        local_pseudonym: Option<[u8; 32]>,
     ) -> Result<ContextHandle, ContextCreationError> {
         // Defense-in-depth: verify creator's SDK version satisfies min_protocol_version.
         params.check_version_compatibility(scp_protocol::envelope::SCP_PROTOCOL_VERSION)?;
@@ -1503,6 +1549,10 @@ impl ContextManager {
             checkpoint_last_time_secs: self.clock.now_secs(),
             checkpoints: Vec::new(),
             merkle_tree: scp_event_log::EventLog::new(context_id.clone()),
+            // §9.10.4: pseudonym routing. Only meaningful for encrypted
+            // contexts; broadcast contexts ignore this field.
+            local_pseudonym,
+            pseudonym_registry: HashMap::new(),
         };
 
         // Atomic check-and-insert — eliminates TOCTOU race between
@@ -1834,6 +1884,11 @@ impl ContextManager {
             checkpoint_last_time_secs: self.clock.now_secs(),
             checkpoints: Vec::new(),
             merkle_tree: scp_event_log::EventLog::new(context_id.to_owned()),
+            // §9.10.4: pseudonym routing — governance-path creation does not
+            // yet support pseudonym injection. The FFI bridge can set this
+            // later via the standard create_context_with_pseudonym path.
+            local_pseudonym: None,
+            pseudonym_registry: HashMap::new(),
         })
     }
 
@@ -1850,13 +1905,46 @@ impl ContextManager {
     /// Returns [`ContextError`] if:
     /// - The context is not in `Active` state.
     /// - The key package is invalid.
-    #[allow(clippy::too_many_lines)]
-    #[instrument(skip_all, fields(context_id = handle.context_id()))]
     pub async fn join_context(
         &self,
         handle: &ContextHandle,
         key_package: KeyPackage,
         spending_ucan: Option<&scp_protocol::crypto::ucan::UcanToken>,
+    ) -> Result<(), ContextError> {
+        self.join_context_inner(handle, key_package, spending_ucan, None)
+            .await
+    }
+
+    /// Joins a member to a context with a pre-derived pseudonym routing ID.
+    ///
+    /// The `local_pseudonym` is stored in `PerContextState` and used for
+    /// per-member pseudonym routing (§9.10.4). After a successful join, a
+    /// `PseudonymAnnouncement` MLS message is sent to inform other members.
+    ///
+    /// # Errors
+    ///
+    /// Same as [`join_context`](Self::join_context).
+    pub async fn join_context_with_pseudonym(
+        &self,
+        handle: &ContextHandle,
+        key_package: KeyPackage,
+        spending_ucan: Option<&scp_protocol::crypto::ucan::UcanToken>,
+        local_pseudonym: Option<[u8; 32]>,
+    ) -> Result<(), ContextError> {
+        self.join_context_inner(handle, key_package, spending_ucan, local_pseudonym)
+            .await
+    }
+
+    /// Internal join implementation shared by `join_context` and
+    /// `join_context_with_pseudonym`.
+    #[allow(clippy::too_many_lines)]
+    #[instrument(skip_all, fields(context_id = handle.context_id()))]
+    async fn join_context_inner(
+        &self,
+        handle: &ContextHandle,
+        key_package: KeyPackage,
+        spending_ucan: Option<&scp_protocol::crypto::ucan::UcanToken>,
+        local_pseudonym: Option<[u8; 32]>,
     ) -> Result<(), ContextError> {
         let context_id = handle.context_id().to_owned();
         let context_id_bytes = context_id_to_bytes(&context_id);
@@ -2077,6 +2165,17 @@ impl ContextManager {
             }
             super::economy::rollback_economy_ticket(self, &context_id, ticket, &ctx_gen).await;
             return Err(e);
+        }
+
+        // Phase 4.5: Store local pseudonym after membership mutation succeeds.
+        // The pseudonym was pre-derived by the FFI bridge; storing it here
+        // makes it available for subsequent send_message fan-out (§9.10.4).
+        if let Some(pseudonym) = local_pseudonym
+            && let Ok(ctx_arc) = self.get_context_arc(&context_id)
+        {
+            let mut guard = ctx_arc.lock().await;
+            let ctx = &mut *guard;
+            ctx.local_pseudonym = Some(pseudonym);
         }
 
         // Phase 5: Capture the escrow hold after all mutations succeeded.

--- a/crates/scp-runtime/src/context/manager/lifecycle.rs
+++ b/crates/scp-runtime/src/context/manager/lifecycle.rs
@@ -1405,34 +1405,13 @@ impl ContextManager {
         context_id: String,
         params: ContextParams,
         creator_did: DID,
-    ) -> Result<ContextHandle, ContextCreationError> {
-        self.create_context_inner(context_id, params, creator_did, None)
-            .await
-    }
-
-    /// Creates a new SCP context with a pre-derived pseudonym routing ID.
-    ///
-    /// The `local_pseudonym` is the 32-byte Ed25519 public key derived via
-    /// `KeyCustody::derive_pseudonym` in the FFI bridge. For encrypted
-    /// contexts, this pseudonym will be used as the member's per-context
-    /// routing ID (§9.10.4) instead of the shared `context_routing_id`.
-    ///
-    /// # Errors
-    ///
-    /// Same as [`create_context`](Self::create_context).
-    pub async fn create_context_with_pseudonym(
-        &self,
-        context_id: String,
-        params: ContextParams,
-        creator_did: DID,
         local_pseudonym: Option<[u8; 32]>,
     ) -> Result<ContextHandle, ContextCreationError> {
         self.create_context_inner(context_id, params, creator_did, local_pseudonym)
             .await
     }
 
-    /// Internal implementation for context creation, shared by both
-    /// `create_context` and `create_context_with_pseudonym`.
+    /// Internal implementation for context creation.
     #[allow(clippy::too_many_lines)] // Context creation initializes many subsystems including pseudonym routing.
     async fn create_context_inner(
         &self,
@@ -1886,7 +1865,7 @@ impl ContextManager {
             merkle_tree: scp_event_log::EventLog::new(context_id.to_owned()),
             // §9.10.4: pseudonym routing — governance-path creation does not
             // yet support pseudonym injection. The FFI bridge can set this
-            // later via the standard create_context_with_pseudonym path.
+            // later via the standard create_context path.
             local_pseudonym: None,
             pseudonym_registry: HashMap::new(),
         })
@@ -1910,33 +1889,13 @@ impl ContextManager {
         handle: &ContextHandle,
         key_package: KeyPackage,
         spending_ucan: Option<&scp_protocol::crypto::ucan::UcanToken>,
-    ) -> Result<(), ContextError> {
-        self.join_context_inner(handle, key_package, spending_ucan, None)
-            .await
-    }
-
-    /// Joins a member to a context with a pre-derived pseudonym routing ID.
-    ///
-    /// The `local_pseudonym` is stored in `PerContextState` and used for
-    /// per-member pseudonym routing (§9.10.4). After a successful join, a
-    /// `PseudonymAnnouncement` MLS message is sent to inform other members.
-    ///
-    /// # Errors
-    ///
-    /// Same as [`join_context`](Self::join_context).
-    pub async fn join_context_with_pseudonym(
-        &self,
-        handle: &ContextHandle,
-        key_package: KeyPackage,
-        spending_ucan: Option<&scp_protocol::crypto::ucan::UcanToken>,
         local_pseudonym: Option<[u8; 32]>,
     ) -> Result<(), ContextError> {
         self.join_context_inner(handle, key_package, spending_ucan, local_pseudonym)
             .await
     }
 
-    /// Internal join implementation shared by `join_context` and
-    /// `join_context_with_pseudonym`.
+    /// Internal join implementation.
     #[allow(clippy::too_many_lines)]
     #[instrument(skip_all, fields(context_id = handle.context_id()))]
     async fn join_context_inner(
@@ -2215,8 +2174,8 @@ impl ContextManager {
     /// Sends a `PseudonymAnnouncement` to inform other members of this
     /// member's per-context routing ID (§9.10.4).
     ///
-    /// Called by the FFI bridges after `create_context_with_pseudonym` or
-    /// `join_context_with_pseudonym` succeeds. The signing key is available
+    /// Called by the FFI bridges after `create_context` or `join_context`
+    /// succeeds with a pseudonym. The signing key is available
     /// at the FFI bridge layer but NOT in the runtime lifecycle methods, so
     /// this method is separated from the create/join paths.
     ///
@@ -2525,6 +2484,9 @@ impl ContextManager {
             ctx.access
                 .access_key_store
                 .remove(&context_id, member_did.as_ref());
+
+            // §9.10.4: remove the departing member's pseudonym routing ID.
+            ctx.pseudonym_registry.remove(member_did);
 
             // Emit MemberLeft event to receive buffer.
             ctx.receive_buffer.push(ContextEvent::MemberLeft {

--- a/crates/scp-runtime/src/context/manager/lifecycle.rs
+++ b/crates/scp-runtime/src/context/manager/lifecycle.rs
@@ -1398,22 +1398,9 @@ impl ContextManager {
     /// persists.
     ///
     /// See ADR-008 acceptance criterion 2.
-    #[allow(clippy::too_many_lines)] // Context creation initializes many subsystems including nonce tracking.
+    #[allow(clippy::too_many_lines)] // Context creation initializes many subsystems including pseudonym routing.
     #[instrument(skip_all, fields(context_id = %context_id))]
     pub async fn create_context(
-        &self,
-        context_id: String,
-        params: ContextParams,
-        creator_did: DID,
-        local_pseudonym: Option<[u8; 32]>,
-    ) -> Result<ContextHandle, ContextCreationError> {
-        self.create_context_inner(context_id, params, creator_did, local_pseudonym)
-            .await
-    }
-
-    /// Internal implementation for context creation.
-    #[allow(clippy::too_many_lines)] // Context creation initializes many subsystems including pseudonym routing.
-    async fn create_context_inner(
         &self,
         context_id: String,
         params: ContextParams,
@@ -1884,21 +1871,9 @@ impl ContextManager {
     /// Returns [`ContextError`] if:
     /// - The context is not in `Active` state.
     /// - The key package is invalid.
-    pub async fn join_context(
-        &self,
-        handle: &ContextHandle,
-        key_package: KeyPackage,
-        spending_ucan: Option<&scp_protocol::crypto::ucan::UcanToken>,
-        local_pseudonym: Option<[u8; 32]>,
-    ) -> Result<(), ContextError> {
-        self.join_context_inner(handle, key_package, spending_ucan, local_pseudonym)
-            .await
-    }
-
-    /// Internal join implementation.
     #[allow(clippy::too_many_lines)]
     #[instrument(skip_all, fields(context_id = handle.context_id()))]
-    async fn join_context_inner(
+    pub async fn join_context(
         &self,
         handle: &ContextHandle,
         key_package: KeyPackage,

--- a/crates/scp-runtime/src/context/manager/messaging.rs
+++ b/crates/scp-runtime/src/context/manager/messaging.rs
@@ -305,10 +305,23 @@ fn deliver_plaintext_or_announcement(
     plaintext: &[u8],
     context_id: &str,
 ) {
+    // KNOWN LIMITATION (§9.10.4 vs §9.10.4.A): Spec says receivers should verify
+    // the pseudonym-to-DID mapping, but the privacy model (pseudonym_secret from
+    // private key) makes independent verification impossible. We trust MLS-
+    // authenticated senders to honestly announce their pseudonyms. A malicious
+    // member can only misdirect their own message copies.
     if let Ok(announcement) = rmp_serde::from_slice::<super::PseudonymAnnouncement>(plaintext)
         && announcement.tag == super::PSEUDONYM_ANNOUNCEMENT_TAG
-        && announcement.member_did == sender_did
     {
+        if announcement.member_did != sender_did {
+            tracing::warn!(
+                context_id,
+                sender_did,
+                claimed_did = %announcement.member_did,
+                "buffered pseudonym announcement sender mismatch — dropping"
+            );
+            return; // Drop forged announcement, don't deliver as message
+        }
         let did = DID(announcement.member_did.clone());
         ctx.pseudonym_registry
             .insert(did.clone(), announcement.pseudonym);
@@ -508,14 +521,19 @@ impl ContextManager {
                 // For encrypted contexts with known pseudonyms, send to each
                 // member's pseudonym. Always include the shared routing ID as
                 // fallback for members whose pseudonym is not yet known.
+                //
+                // KNOWN LIMITATION (§9.10.4): Fan-out sends the SAME MLS ciphertext to all
+                // routing IDs. A relay can correlate pseudonyms by observing identical blobs.
+                // Per-recipient re-encryption (different nonce per blob) would fix this but
+                // increases bandwidth by O(N). Acceptable until relay-blinding is implemented.
                 let mut routing_ids: Vec<[u8; 32]> =
                     ctx.pseudonym_registry.values().copied().collect();
                 let shared_rid = scp_protocol::context::context_routing_id(&context_id);
                 // Always include the shared routing ID for backward compat /
-                // members who haven't announced a pseudonym yet.
-                if !routing_ids.contains(&shared_rid) {
-                    routing_ids.push(shared_rid);
-                }
+                // members who haven't announced a pseudonym yet. Duplicates
+                // in the fan-out are harmless (same blob to same routing ID
+                // is idempotent at the relay).
+                routing_ids.push(shared_rid);
                 (
                     None,
                     ctx.access.access_key_store.get_all(&context_id),
@@ -1231,6 +1249,12 @@ impl ContextManager {
         // as a regular message. Announcements are internal protocol messages
         // that update the pseudonym registry — they are NOT forwarded to the
         // application receive buffer as regular MessageReceived events.
+        //
+        // KNOWN LIMITATION (§9.10.4 vs §9.10.4.A): Spec says receivers should verify
+        // the pseudonym-to-DID mapping, but the privacy model (pseudonym_secret from
+        // private key) makes independent verification impossible. We trust MLS-
+        // authenticated senders to honestly announce their pseudonyms. A malicious
+        // member can only misdirect their own message copies.
         if let Ok(announcement) = rmp_serde::from_slice::<super::PseudonymAnnouncement>(plaintext)
             && announcement.tag == super::PSEUDONYM_ANNOUNCEMENT_TAG
         {

--- a/crates/scp-runtime/src/context/manager/messaging.rs
+++ b/crates/scp-runtime/src/context/manager/messaging.rs
@@ -291,6 +291,44 @@ fn verify_and_unwrap(
     .map_err(|e| ContextError::CryptoFailed(e.to_string()))
 }
 
+/// Delivers a single plaintext to the receive buffer, checking if it is a
+/// pseudonym announcement first. If it is a valid announcement from the
+/// authenticated sender, updates the pseudonym registry and emits a
+/// `PseudonymAnnounced` event instead of `MessageReceived`.
+///
+/// Used by all buffered/drained delivery paths (`drain_timed_out`,
+/// `drain_consecutive`, buffer overflow) to ensure announcements received
+/// out of order are still handled correctly.
+fn deliver_plaintext_or_announcement(
+    ctx: &mut PerContextState,
+    sender_did: &str,
+    plaintext: &[u8],
+    context_id: &str,
+) {
+    if let Ok(announcement) = rmp_serde::from_slice::<super::PseudonymAnnouncement>(plaintext)
+        && announcement.tag == super::PSEUDONYM_ANNOUNCEMENT_TAG
+        && announcement.member_did == sender_did
+    {
+        let did = DID(announcement.member_did.clone());
+        ctx.pseudonym_registry
+            .insert(did.clone(), announcement.pseudonym);
+        ctx.receive_buffer.push(ContextEvent::PseudonymAnnounced {
+            member_did: did,
+            pseudonym: announcement.pseudonym,
+        });
+        tracing::debug!(
+            context_id,
+            sender_did,
+            "processed buffered pseudonym announcement"
+        );
+        return;
+    }
+    ctx.receive_buffer.push(ContextEvent::MessageReceived {
+        sender_did: DID(sender_did.to_owned()),
+        payload: plaintext.to_vec(),
+    });
+}
+
 #[allow(clippy::significant_drop_tightening)]
 impl ContextManager {
     /// Sends a message within a context.
@@ -616,10 +654,29 @@ impl ContextManager {
             result
         };
         // §9.10.4: fan-out — seal once, send to all routing IDs.
+        // Best-effort: only fail if ALL sends fail. A partial fan-out
+        // (some routing IDs succeed, others fail) is acceptable — at least
+        // some members will receive the message. Record a metric per
+        // successful send to avoid undercounting (Bug 6).
+        let mut last_err = None;
+        let mut any_success = false;
         for rid in routing_ids {
-            self.transport.send_message(rid, &encrypted)?;
+            match self.transport.send_message(rid, &encrypted) {
+                Ok(()) => {
+                    any_success = true;
+                    crate::metrics::record_message_sent();
+                }
+                Err(e) => {
+                    tracing::warn!(routing_id = ?rid, error = %e, "fan-out send failed");
+                    last_err = Some(e);
+                }
+            }
         }
-        crate::metrics::record_message_sent();
+        if !any_success {
+            return Err(last_err.unwrap_or_else(|| {
+                ContextError::TransportFailed("all fan-out sends failed".into())
+            }));
+        }
         Ok(())
     }
 
@@ -1047,10 +1104,7 @@ impl ContextManager {
                     msg.inner.sequence,
                     msg.inner.timestamp,
                 );
-                ctx.receive_buffer.push(ContextEvent::MessageReceived {
-                    sender_did: DID(msg.sender_did.clone()),
-                    payload: msg.plaintext.clone(),
-                });
+                deliver_plaintext_or_announcement(ctx, &msg.sender_did, &msg.plaintext, context_id);
             }
         }
 
@@ -1113,10 +1167,7 @@ impl ContextManager {
                     msg.inner.sequence,
                     msg.inner.timestamp,
                 );
-                ctx.receive_buffer.push(ContextEvent::MessageReceived {
-                    sender_did: DID(msg.sender_did.clone()),
-                    payload: msg.plaintext.clone(),
-                });
+                deliver_plaintext_or_announcement(ctx, &msg.sender_did, &msg.plaintext, context_id);
             }
         }
 
@@ -1183,6 +1234,21 @@ impl ContextManager {
         if let Ok(announcement) = rmp_serde::from_slice::<super::PseudonymAnnouncement>(plaintext)
             && announcement.tag == super::PSEUDONYM_ANNOUNCEMENT_TAG
         {
+            // Bug fix: verify announcement.member_did matches the MLS-authenticated
+            // sender_did. Without this check, any member could forge a pseudonym
+            // announcement for another member, redirecting their messages.
+            if announcement.member_did != sender_did {
+                tracing::warn!(
+                    context_id,
+                    sender_did,
+                    claimed_did = %announcement.member_did,
+                    "pseudonym announcement sender mismatch — rejecting forged announcement"
+                );
+                return Err(ContextError::PermissionDenied(format!(
+                    "pseudonym announcement member_did ({}) does not match sender ({sender_did})",
+                    announcement.member_did
+                )));
+            }
             let announced_did = DID(announcement.member_did.clone());
             ctx.pseudonym_registry
                 .insert(announced_did.clone(), announcement.pseudonym);
@@ -1214,10 +1280,7 @@ impl ContextManager {
                     msg.inner.sequence,
                     msg.inner.timestamp,
                 );
-                ctx.receive_buffer.push(ContextEvent::MessageReceived {
-                    sender_did: DID(msg.sender_did.clone()),
-                    payload: msg.plaintext.clone(),
-                });
+                deliver_plaintext_or_announcement(ctx, &msg.sender_did, &msg.plaintext, context_id);
             }
 
             // Velocity, consequence, event log — same as normal messages.
@@ -1267,10 +1330,7 @@ impl ContextManager {
                 msg.inner.sequence,
                 msg.inner.timestamp,
             );
-            ctx.receive_buffer.push(ContextEvent::MessageReceived {
-                sender_did: DID(msg.sender_did.clone()),
-                payload: msg.plaintext.clone(),
-            });
+            deliver_plaintext_or_announcement(ctx, &msg.sender_did, &msg.plaintext, context_id);
         }
 
         // H5: Append the durable event log entry for `MessageReceived` BEFORE

--- a/crates/scp-runtime/src/context/manager/messaging.rs
+++ b/crates/scp-runtime/src/context/manager/messaging.rs
@@ -320,8 +320,17 @@ impl ContextManager {
     ) -> Result<(), ContextError> {
         let context_id = handle.context_id().to_owned();
         let context_id_bytes = context_id_to_bytes(&context_id);
-        let routing_id = scp_protocol::context::context_routing_id(&context_id);
-        let (broadcast_envelope, recipients_data, sequence, is_broadcast, ticket, ctx_gen) = {
+        // Routing ID computation is deferred to Phase 1 (under lock) where
+        // the context mode and pseudonym registry are available.
+        let (
+            broadcast_envelope,
+            recipients_data,
+            sequence,
+            is_broadcast,
+            ticket,
+            ctx_gen,
+            send_routing_ids,
+        ) = {
             let (mut guard, ctx_gen) = self
                 .lock_context(&context_id)
                 .await
@@ -436,6 +445,8 @@ impl ContextManager {
                         return Err(e);
                     }
                 };
+                // Broadcast: use plain SHA-256(context_id) per spec §5.14.
+                let broadcast_rid = scp_protocol::context::broadcast_routing_id(&context_id);
                 (
                     Some(env),
                     std::collections::HashMap::new(),
@@ -443,6 +454,7 @@ impl ContextManager {
                     true,
                     ticket,
                     ctx_gen,
+                    vec![broadcast_rid],
                 )
             } else {
                 // Capability already checked above (H7: before budget deduction).
@@ -454,6 +466,18 @@ impl ContextManager {
                         "cannot assign sequence: {sender_did} is not a member"
                     )));
                 };
+                // §9.10.4: collect pseudonym routing IDs for fan-out.
+                // For encrypted contexts with known pseudonyms, send to each
+                // member's pseudonym. Always include the shared routing ID as
+                // fallback for members whose pseudonym is not yet known.
+                let mut routing_ids: Vec<[u8; 32]> =
+                    ctx.pseudonym_registry.values().copied().collect();
+                let shared_rid = scp_protocol::context::context_routing_id(&context_id);
+                // Always include the shared routing ID for backward compat /
+                // members who haven't announced a pseudonym yet.
+                if !routing_ids.contains(&shared_rid) {
+                    routing_ids.push(shared_rid);
+                }
                 (
                     None,
                     ctx.access.access_key_store.get_all(&context_id),
@@ -461,6 +485,7 @@ impl ContextManager {
                     false,
                     ticket,
                     ctx_gen,
+                    routing_ids,
                 )
             }
         };
@@ -490,6 +515,7 @@ impl ContextManager {
         };
 
         // Phase 2: encrypt + send (no lock held).
+        // §9.10.4: fan-out — send to all collected routing IDs.
         let phase2_result = self.encrypt_and_send(
             broadcast_envelope,
             signing_key,
@@ -499,7 +525,7 @@ impl ContextManager {
             &recipients_data,
             sequence,
             source_provenance,
-            &routing_id,
+            &send_routing_ids,
         );
         if let Err(e) = phase2_result {
             // Void the escrow hold and roll back the full ticket (budget,
@@ -546,6 +572,11 @@ impl ContextManager {
 
     /// Encrypts the payload and sends it via transport (Phase 2 of `send_message`).
     ///
+    /// For pseudonym routing (§9.10.4), `routing_ids` may contain multiple
+    /// targets: each member's pseudonym plus the shared context routing ID
+    /// as a fallback. The encrypted blob is computed once and sent to each
+    /// routing ID.
+    ///
     /// Extracted to keep `send_message` within the clippy `too_many_lines` limit.
     #[allow(clippy::too_many_arguments)]
     fn encrypt_and_send(
@@ -561,7 +592,7 @@ impl ContextManager {
         >,
         sequence: u64,
         source_provenance: Option<&scp_protocol::provenance::attach::SourceContextInfo>,
-        routing_id: &[u8; 32],
+        routing_ids: &[[u8; 32]],
     ) -> Result<(), ContextError> {
         let encrypted = if let Some(envelope) = broadcast_envelope {
             rmp_serde::to_vec_named(&envelope)
@@ -584,7 +615,10 @@ impl ContextManager {
             crate::metrics::record_encrypt_duration(encrypt_start.elapsed());
             result
         };
-        self.transport.send_message(routing_id, &encrypted)?;
+        // §9.10.4: fan-out — seal once, send to all routing IDs.
+        for rid in routing_ids {
+            self.transport.send_message(rid, &encrypted)?;
+        }
         crate::metrics::record_message_sent();
         Ok(())
     }
@@ -1140,6 +1174,67 @@ impl ContextManager {
                 format!("member {sender_did} does not have messages:write capability")
             };
             return Err(ContextError::PermissionDenied(msg));
+        }
+
+        // §9.10.4: check if this is a pseudonym announcement before treating
+        // as a regular message. Announcements are internal protocol messages
+        // that update the pseudonym registry — they are NOT forwarded to the
+        // application receive buffer as regular MessageReceived events.
+        if let Ok(announcement) = rmp_serde::from_slice::<super::PseudonymAnnouncement>(plaintext)
+            && announcement.tag == super::PSEUDONYM_ANNOUNCEMENT_TAG
+        {
+            let announced_did = DID(announcement.member_did.clone());
+            ctx.pseudonym_registry
+                .insert(announced_did.clone(), announcement.pseudonym);
+            ctx.receive_buffer.push(ContextEvent::PseudonymAnnounced {
+                member_did: announced_did,
+                pseudonym: announcement.pseudonym,
+            });
+            // Advance sequence tracker for the announcement message.
+            ctx.sequence_tracker
+                .advance(context_id, sender_did, inner.sequence, inner.timestamp);
+            // Skip the normal message delivery path — announcements are
+            // consumed by the protocol, not forwarded to the application.
+            // Still drain buffered messages that may now be unblocked.
+            let next_expected = inner.sequence.saturating_add(1);
+            let consecutive =
+                ctx.reorder_buffer
+                    .drain_consecutive(context_id, sender_did, next_expected);
+            for msg in &consecutive {
+                if !ctx.membership.contains(&msg.sender_did)
+                    || !ctx
+                        .role_state
+                        .member_has_capability(&msg.sender_did, &Capability::MessagesWrite)
+                {
+                    continue;
+                }
+                ctx.sequence_tracker.advance(
+                    &msg.inner.context_id,
+                    &msg.sender_did,
+                    msg.inner.sequence,
+                    msg.inner.timestamp,
+                );
+                ctx.receive_buffer.push(ContextEvent::MessageReceived {
+                    sender_did: DID(msg.sender_did.clone()),
+                    payload: msg.plaintext.clone(),
+                });
+            }
+
+            // Velocity, consequence, event log — same as normal messages.
+            if !skip_velocity {
+                let now_secs = self.clock.now_secs();
+                ctx.governance
+                    .velocity_tracker
+                    .record_message(&DID(sender_did.to_owned()), now_secs);
+            }
+            self.event_log.append_context_event(
+                context_id_bytes,
+                "PseudonymAnnounced",
+                sender_did,
+            )?;
+            ctx.checkpoint_events_since += 1;
+
+            return Ok(());
         }
 
         // Advance sequence tracker and deliver the in-order message.

--- a/crates/scp-runtime/src/context/manager/messaging.rs
+++ b/crates/scp-runtime/src/context/manager/messaging.rs
@@ -299,12 +299,17 @@ fn verify_and_unwrap(
 /// Used by all buffered/drained delivery paths (`drain_timed_out`,
 /// `drain_consecutive`, buffer overflow) to ensure announcements received
 /// out of order are still handled correctly.
+///
+/// Returns the event-log event name for the delivered message, or `None`
+/// when the message was silently dropped (e.g. forged announcement).
+/// Callers use the return value to drive post-delivery logic (velocity,
+/// event log, consequences, checkpoint).
 fn deliver_plaintext_or_announcement(
     ctx: &mut PerContextState,
     sender_did: &str,
     plaintext: &[u8],
     context_id: &str,
-) {
+) -> Option<&'static str> {
     // KNOWN LIMITATION (§9.10.4 vs §9.10.4.A): Spec says receivers should verify
     // the pseudonym-to-DID mapping, but the privacy model (pseudonym_secret from
     // private key) makes independent verification impossible. We trust MLS-
@@ -320,7 +325,7 @@ fn deliver_plaintext_or_announcement(
                 claimed_did = %announcement.member_did,
                 "buffered pseudonym announcement sender mismatch — dropping"
             );
-            return; // Drop forged announcement, don't deliver as message
+            return None; // Drop forged announcement, don't deliver as message
         }
         let did = DID(announcement.member_did.clone());
         ctx.pseudonym_registry
@@ -334,12 +339,78 @@ fn deliver_plaintext_or_announcement(
             sender_did,
             "processed buffered pseudonym announcement"
         );
-        return;
+        return Some("PseudonymAnnounced");
     }
     ctx.receive_buffer.push(ContextEvent::MessageReceived {
         sender_did: DID(sender_did.to_owned()),
         payload: plaintext.to_vec(),
     });
+    Some("MessageReceived")
+}
+
+/// Runs post-delivery governance logic for a single buffered/drained message.
+///
+/// This ensures that messages delivered via reorder-buffer drain (timeout,
+/// consecutive fill, overflow) receive the same velocity tracking, event-log
+/// append, consequence evaluation, and checkpoint increment as messages
+/// delivered directly through `deliver_message_and_drain_buffered`.
+///
+/// Bug fix (#1534): previously, all buffered delivery paths skipped these
+/// steps, allowing a malicious sender to evade rate limiting and consequence
+/// enforcement by exploiting out-of-order delivery.
+fn run_buffered_post_delivery(
+    ctx: &mut PerContextState,
+    context_id: &str,
+    context_id_bytes: &[u8; 32],
+    sender_did: &str,
+    event_name: &str,
+    clock: &dyn scp_primitives::Clock,
+    event_log: &dyn super::ContextEventLogProvider,
+) {
+    let now = clock.now_secs();
+
+    // Velocity tracking — always record for buffered messages. Buffered
+    // messages arrived via the receive path; we cannot determine whether the
+    // sender is local (the info isn't stored in BufferedMessage). Recording
+    // unconditionally is the safe default: a minor double-count on single-node
+    // self-loops is preferable to a missed count that bypasses rate limiting.
+    ctx.governance
+        .velocity_tracker
+        .record_message(&DID(sender_did.to_owned()), now);
+
+    // Durable event-log append — mirrors the direct delivery path.
+    if let Err(e) = event_log.append_context_event(context_id_bytes, event_name, sender_did) {
+        tracing::warn!(
+            context_id,
+            sender_did,
+            event_name,
+            "failed to append buffered event to event log: {e}"
+        );
+    }
+
+    // Consequence evaluation — same rules as the direct path.
+    let consequence_rules: Vec<super::ConsequenceRule> = ctx.governance.consequence_rules.clone();
+    if !consequence_rules.is_empty() {
+        let events =
+            super::governance::event_log_entries_for_consequences(ctx, context_id, now, event_log);
+        let triggered = evaluate_consequence_rules(&consequence_rules, &events, sender_did, now);
+        let member_did = DID(sender_did.to_owned());
+        super::governance::enforce_triggered_consequences(
+            ctx,
+            &super::governance::EnforceConsequencesCtx {
+                context_id,
+                member_did: &member_did,
+                now,
+                triggered: &triggered,
+                rules: &consequence_rules,
+                clock,
+                event_log,
+            },
+        );
+    }
+
+    // Checkpoint tracking — increment so thresholds stay accurate.
+    ctx.checkpoint_events_since += 1;
 }
 
 #[allow(clippy::significant_drop_tightening)]
@@ -1104,6 +1175,7 @@ impl ContextManager {
             .map_err(|e| ContextError::CryptoFailed(e.to_string()))?;
 
         // Also drain any timed-out gaps on each delivery call.
+        let context_id_bytes = context_id_to_bytes(context_id);
         let timed_out = ctx
             .reorder_buffer
             .drain_timed_out(now_ms, &ctx.sequence_tracker);
@@ -1131,7 +1203,25 @@ impl ContextManager {
                     msg.inner.sequence,
                     msg.inner.timestamp,
                 );
-                deliver_plaintext_or_announcement(ctx, &msg.sender_did, &msg.plaintext, context_id);
+                if let Some(event_name) = deliver_plaintext_or_announcement(
+                    ctx,
+                    &msg.sender_did,
+                    &msg.plaintext,
+                    context_id,
+                ) {
+                    // Bug fix (#1534): buffered messages now receive the same
+                    // post-delivery governance treatment as directly delivered
+                    // messages — velocity, event log, consequence evaluation.
+                    run_buffered_post_delivery(
+                        ctx,
+                        context_id,
+                        &context_id_bytes,
+                        &msg.sender_did,
+                        event_name,
+                        &*self.clock,
+                        &*self.event_log,
+                    );
+                }
             }
         }
 
@@ -1164,6 +1254,7 @@ impl ContextManager {
         let ctx = &mut *guard;
 
         if let Some((mut gap_info, messages)) = ctx.reorder_buffer.buffer(buffered_msg) {
+            let context_id_bytes = context_id_to_bytes(context_id);
             let expected = ctx
                 .sequence_tracker
                 .expected_sequence(context_id, sender_did)
@@ -1194,7 +1285,24 @@ impl ContextManager {
                     msg.inner.sequence,
                     msg.inner.timestamp,
                 );
-                deliver_plaintext_or_announcement(ctx, &msg.sender_did, &msg.plaintext, context_id);
+                if let Some(event_name) = deliver_plaintext_or_announcement(
+                    ctx,
+                    &msg.sender_did,
+                    &msg.plaintext,
+                    context_id,
+                ) {
+                    // Bug fix (#1534): overflow-forced delivery now runs
+                    // consequence evaluation, matching the direct path.
+                    run_buffered_post_delivery(
+                        ctx,
+                        context_id,
+                        &context_id_bytes,
+                        &msg.sender_did,
+                        event_name,
+                        &*self.clock,
+                        &*self.event_log,
+                    );
+                }
             }
         }
 
@@ -1313,7 +1421,24 @@ impl ContextManager {
                     msg.inner.sequence,
                     msg.inner.timestamp,
                 );
-                deliver_plaintext_or_announcement(ctx, &msg.sender_did, &msg.plaintext, context_id);
+                if let Some(event_name) = deliver_plaintext_or_announcement(
+                    ctx,
+                    &msg.sender_did,
+                    &msg.plaintext,
+                    context_id,
+                ) {
+                    // Bug fix (#1534): drain_consecutive within announcement
+                    // path now runs consequence evaluation per message.
+                    run_buffered_post_delivery(
+                        ctx,
+                        context_id,
+                        context_id_bytes,
+                        &msg.sender_did,
+                        event_name,
+                        &*self.clock,
+                        &*self.event_log,
+                    );
+                }
             }
 
             // Velocity, consequence, event log — same as normal messages.
@@ -1398,7 +1523,21 @@ impl ContextManager {
                 msg.inner.sequence,
                 msg.inner.timestamp,
             );
-            deliver_plaintext_or_announcement(ctx, &msg.sender_did, &msg.plaintext, context_id);
+            if let Some(event_name) =
+                deliver_plaintext_or_announcement(ctx, &msg.sender_did, &msg.plaintext, context_id)
+            {
+                // Bug fix (#1534): drain_consecutive within normal message
+                // path now runs consequence evaluation per message.
+                run_buffered_post_delivery(
+                    ctx,
+                    context_id,
+                    context_id_bytes,
+                    &msg.sender_did,
+                    event_name,
+                    &*self.clock,
+                    &*self.event_log,
+                );
+            }
         }
 
         // H5: Append the durable event log entry for `MessageReceived` BEFORE

--- a/crates/scp-runtime/src/context/manager/messaging.rs
+++ b/crates/scp-runtime/src/context/manager/messaging.rs
@@ -1047,16 +1047,25 @@ impl ContextManager {
         match sequence_check {
             SequenceCheck::Expected => {
                 // Message is in order — deliver immediately.
-                self.deliver_message_and_drain_buffered(
-                    context_id,
-                    &context_id_bytes,
-                    &sender_did,
-                    &inner,
-                    &plaintext,
-                    is_local_sender,
-                )
-                .await?;
-                Ok(Some((plaintext, sender_did)))
+                // Bug fix (#1534): `deliver_message_and_drain_buffered` returns
+                // `true` when the message was consumed as a pseudonym announcement
+                // (internal protocol message). Announcements must NOT be forwarded
+                // to FFI callers as regular user messages.
+                let consumed_as_announcement = self
+                    .deliver_message_and_drain_buffered(
+                        context_id,
+                        &context_id_bytes,
+                        &sender_did,
+                        &inner,
+                        &plaintext,
+                        is_local_sender,
+                    )
+                    .await?;
+                if consumed_as_announcement {
+                    Ok(None)
+                } else {
+                    Ok(Some((plaintext, sender_did)))
+                }
             }
             SequenceCheck::Ahead { expected: _ } => {
                 // Message is ahead of expected — buffer it (§9.8.5).
@@ -1209,7 +1218,7 @@ impl ContextManager {
         inner: &scp_protocol::envelope::inner::InnerEnvelope,
         plaintext: &[u8],
         skip_velocity: bool,
-    ) -> Result<(), ContextError> {
+    ) -> Result<bool, ContextError> {
         let sender_did_obj = DID(sender_did.to_owned());
 
         let ctx_arc = self
@@ -1308,20 +1317,55 @@ impl ContextManager {
             }
 
             // Velocity, consequence, event log — same as normal messages.
+            // Bug fix (#1534): consequence evaluation was previously missing from
+            // the announcement path, allowing a malicious member to send
+            // announcements at high velocity without triggering rate-limiting
+            // consequences. Now both paths share identical post-delivery logic.
+            let now = self.clock.now_secs();
             if !skip_velocity {
-                let now_secs = self.clock.now_secs();
                 ctx.governance
                     .velocity_tracker
-                    .record_message(&DID(sender_did.to_owned()), now_secs);
+                    .record_message(&DID(sender_did.to_owned()), now);
             }
-            self.event_log.append_context_event(
+            if let Err(e) = self.event_log.append_context_event(
                 context_id_bytes,
                 "PseudonymAnnounced",
                 sender_did,
-            )?;
+            ) {
+                tracing::warn!(
+                    context_id,
+                    sender_did,
+                    "failed to append PseudonymAnnounced to event log: {e}"
+                );
+            }
+            let consequence_rules: Vec<super::ConsequenceRule> =
+                ctx.governance.consequence_rules.clone();
+            if !consequence_rules.is_empty() {
+                let recv_events = super::governance::event_log_entries_for_consequences(
+                    ctx,
+                    context_id,
+                    now,
+                    &*self.event_log,
+                );
+                let recv_triggered =
+                    evaluate_consequence_rules(&consequence_rules, &recv_events, sender_did, now);
+                let recv_member_did = DID(sender_did.to_owned());
+                super::governance::enforce_triggered_consequences(
+                    ctx,
+                    &super::governance::EnforceConsequencesCtx {
+                        context_id,
+                        member_did: &recv_member_did,
+                        now,
+                        triggered: &recv_triggered,
+                        rules: &consequence_rules,
+                        clock: &*self.clock,
+                        event_log: &*self.event_log,
+                    },
+                );
+            }
             ctx.checkpoint_events_since += 1;
 
-            return Ok(());
+            return Ok(true);
         }
 
         // Advance sequence tracker and deliver the in-order message.
@@ -1441,6 +1485,6 @@ impl ContextManager {
 
         crate::metrics::record_message_received();
 
-        Ok(())
+        Ok(false)
     }
 }

--- a/crates/scp-runtime/src/context/manager/mod.rs
+++ b/crates/scp-runtime/src/context/manager/mod.rs
@@ -807,6 +807,15 @@ pub struct ContextSnapshot {
     /// deserialize as `0` via `#[serde(default)]`.
     #[serde(default)]
     pub generation: u64,
+    /// This member's pseudonym-derived routing ID for this context (§9.10.4).
+    /// Pre-derived by the FFI bridge. `None` for legacy snapshots and
+    /// broadcast contexts.
+    #[serde(default)]
+    pub local_pseudonym: Option<[u8; 32]>,
+    /// Known members' pseudonym routing IDs (§9.10.4), learned via
+    /// `PseudonymAnnouncement` MLS messages. Keyed by member DID string.
+    #[serde(default)]
+    pub pseudonym_registry: HashMap<String, [u8; 32]>,
 }
 
 /// Serializable snapshot of [`SenderVelocityTracker`](scp_protocol::economy::antispam::SenderVelocityTracker)
@@ -1118,6 +1127,27 @@ struct TtlState {
     extension: Option<TtlExtension>,
 }
 
+/// Wire format for pseudonym announcements sent as MLS application messages.
+///
+/// When a member joins or creates a context with a pre-derived pseudonym,
+/// they announce it to other members via this structure serialized with
+/// `MessagePack`. Recipients store the mapping in their pseudonym registry.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub(super) struct PseudonymAnnouncement {
+    /// Magic prefix to distinguish from regular application messages.
+    pub tag: String,
+    /// The announcing member's DID.
+    pub member_did: String,
+    /// The 32-byte pseudonym routing ID.
+    pub pseudonym: [u8; 32],
+}
+
+/// Magic tag used to identify pseudonym announcement messages in the MLS
+/// application message stream. Prefixed with `\0` to avoid collision with
+/// user-generated content (which is always valid UTF-8 and will never start
+/// with a null byte when deserialized from `MessagePack`).
+pub(super) const PSEUDONYM_ANNOUNCEMENT_TAG: &str = "\0scp:pseudonym-announce:v1";
+
 /// Internal state tracked by the manager for each context.
 pub(super) struct PerContextState {
     /// Monotonic generation counter. Assigned on insertion into the contexts
@@ -1148,6 +1178,15 @@ pub(super) struct PerContextState {
     access: AccessControlState,
     /// TTL timer and extension state (SCP-021).
     ttl: TtlState,
+    /// This member's pseudonym-derived routing ID for this context (§9.10.4).
+    /// Pre-derived by the FFI bridge via `KeyCustody::derive_pseudonym` and
+    /// passed into `create_context` / `join_context`. `None` if the bridge
+    /// did not supply a pseudonym (legacy callers, broadcast contexts).
+    local_pseudonym: Option<[u8; 32]>,
+    /// Known members' pseudonym routing IDs, learned via
+    /// [`PseudonymAnnouncement`] MLS application messages. Keyed by member
+    /// DID so `send_message` can fan-out to each member's pseudonym.
+    pseudonym_registry: HashMap<DID, [u8; 32]>,
     /// Per-sender sequence tracker for anti-replay protection (§9.8.2).
     /// Validates that per-sender sequence numbers and timestamps are
     /// monotonically increasing within this context.
@@ -2481,6 +2520,12 @@ impl ContextManager {
             checkpoint_events_since: ctx.checkpoint_events_since,
             checkpoint_last_time_secs: ctx.checkpoint_last_time_secs,
             generation: ctx.generation,
+            local_pseudonym: ctx.local_pseudonym,
+            pseudonym_registry: ctx
+                .pseudonym_registry
+                .iter()
+                .map(|(did, p)| (did.to_string(), *p))
+                .collect(),
         }
     }
 

--- a/crates/scp-runtime/src/context/manager/mod.rs
+++ b/crates/scp-runtime/src/context/manager/mod.rs
@@ -1133,6 +1133,7 @@ struct TtlState {
 /// they announce it to other members via this structure serialized with
 /// `MessagePack`. Recipients store the mapping in their pseudonym registry.
 #[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub(super) struct PseudonymAnnouncement {
     /// Magic prefix to distinguish from regular application messages.
     pub tag: String,
@@ -1858,7 +1859,7 @@ pub enum ContextManagerBuildError {
 ///
 /// ```ignore
 /// let manager = ContextManager::new(crypto, transport, event_log, key_resolver);
-/// let handle = manager.create_context("ctx-1".into(), params, "did:key:creator".into()).await?;
+/// let handle = manager.create_context("ctx-1".into(), params, "did:key:creator".into(), None).await?;
 /// assert_eq!(handle.state().await, ContextState::Active);
 /// ```
 pub struct ContextManager {

--- a/crates/scp-runtime/src/context/manager/mod.rs
+++ b/crates/scp-runtime/src/context/manager/mod.rs
@@ -1140,6 +1140,7 @@ pub(super) struct PseudonymAnnouncement {
     /// The announcing member's DID.
     pub member_did: String,
     /// The 32-byte pseudonym routing ID.
+    #[serde(with = "serde_bytes")]
     pub pseudonym: [u8; 32],
 }
 

--- a/crates/scp-runtime/src/context/manager/queries.rs
+++ b/crates/scp-runtime/src/context/manager/queries.rs
@@ -50,6 +50,24 @@ impl ContextManager {
         self.local_dids.read().await.contains(did)
     }
 
+    /// Returns the local member's pseudonym routing ID for a context (§9.10.4).
+    ///
+    /// Returns `None` if no pseudonym was set (legacy callers, broadcast contexts).
+    ///
+    /// # Errors
+    ///
+    /// Returns [`ContextError::ContextNotRegistered`] if the context is not registered.
+    pub fn local_pseudonym(&self, context_id: &str) -> Result<Option<[u8; 32]>, ContextError> {
+        let ctx_arc = self
+            .get_context_arc(context_id)
+            .map_err(|_| ContextError::ContextNotRegistered(context_id.to_owned()))?;
+        // Use try_lock to avoid blocking on the per-context mutex. If
+        // contended (unlikely during subscribe setup), fall back to None.
+        Ok(ctx_arc
+            .try_lock()
+            .map_or(None, |guard| guard.local_pseudonym))
+    }
+
     /// Returns the broadcast key and epoch for a locally controlled author
     /// in a broadcast context.
     ///

--- a/crates/scp-runtime/src/context/manager/queries.rs
+++ b/crates/scp-runtime/src/context/manager/queries.rs
@@ -57,15 +57,15 @@ impl ContextManager {
     /// # Errors
     ///
     /// Returns [`ContextError::ContextNotRegistered`] if the context is not registered.
-    pub fn local_pseudonym(&self, context_id: &str) -> Result<Option<[u8; 32]>, ContextError> {
+    pub async fn local_pseudonym(
+        &self,
+        context_id: &str,
+    ) -> Result<Option<[u8; 32]>, ContextError> {
         let ctx_arc = self
             .get_context_arc(context_id)
             .map_err(|_| ContextError::ContextNotRegistered(context_id.to_owned()))?;
-        // Use try_lock to avoid blocking on the per-context mutex. If
-        // contended (unlikely during subscribe setup), fall back to None.
-        Ok(ctx_arc
-            .try_lock()
-            .map_or(None, |guard| guard.local_pseudonym))
+        let guard = ctx_arc.lock().await;
+        Ok(guard.local_pseudonym)
     }
 
     /// Returns the broadcast key and epoch for a locally controlled author

--- a/crates/scp-runtime/src/context/manager/standing.rs
+++ b/crates/scp-runtime/src/context/manager/standing.rs
@@ -155,7 +155,7 @@ impl ContextManager {
         // ContextManager::create_context flow (membership, roles, governance).
         let params = template_params(&TemplateId::BilateralPersistent);
         match self
-            .create_context(context_id.clone(), params, local_did.clone())
+            .create_context(context_id.clone(), params, local_did.clone(), None)
             .await
         {
             Ok(_) => {}

--- a/crates/scp-runtime/src/context/manager/tests/broadcast.rs
+++ b/crates/scp-runtime/src/context/manager/tests/broadcast.rs
@@ -775,6 +775,7 @@ async fn broadcast_close_context_drops_state() {
             "broadcast-close-ctx".into(),
             params,
             "did:key:author1".into(),
+            None,
         )
         .await
         .unwrap();
@@ -1328,7 +1329,7 @@ async fn revoke_read_access_rejected_without_member_ban_ceiling() {
         ..ContextParams::default()
     };
     let _handle = manager
-        .create_context("no-ban-ctx".into(), params, "did:key:alice".into())
+        .create_context("no-ban-ctx".into(), params, "did:key:alice".into(), None)
         .await
         .unwrap();
     {
@@ -1470,7 +1471,12 @@ async fn restore_read_access_rejected_without_member_ban_ceiling() {
         ..ContextParams::default()
     };
     let _handle = manager
-        .create_context("no-ban-restore-ctx".into(), params, "did:key:alice".into())
+        .create_context(
+            "no-ban-restore-ctx".into(),
+            params,
+            "did:key:alice".into(),
+            None,
+        )
         .await
         .unwrap();
     let ctx_id = "no-ban-restore-ctx".to_owned();
@@ -2513,7 +2519,12 @@ async fn revoke_write_access_rejected_without_member_ban() {
         ..ContextParams::default()
     };
     let _handle = manager
-        .create_context("no-ban-write-ctx".into(), params, "did:key:alice".into())
+        .create_context(
+            "no-ban-write-ctx".into(),
+            params,
+            "did:key:alice".into(),
+            None,
+        )
         .await
         .unwrap();
     {

--- a/crates/scp-runtime/src/context/manager/tests/commit_retry.rs
+++ b/crates/scp-runtime/src/context/manager/tests/commit_retry.rs
@@ -114,7 +114,7 @@ async fn setup_retry_manager() -> (
 
     let admin_did: DID = "did:key:admin".into();
     let _handle = manager
-        .create_context("retry-ctx".into(), params, admin_did.clone())
+        .create_context("retry-ctx".into(), params, admin_did.clone(), None)
         .await
         .unwrap();
 

--- a/crates/scp-runtime/src/context/manager/tests/commit_retry.rs
+++ b/crates/scp-runtime/src/context/manager/tests/commit_retry.rs
@@ -319,6 +319,7 @@ async fn test_execute_remove_member_commit_max_retries_marks_failed() {
 /// PR #1606 C6 test 3: `ContextSnapshot` round-trips `pending_commits`
 /// and `commit_fault` so retries survive process restart.
 #[test]
+#[allow(clippy::too_many_lines)] // Test verifies roundtrip of all snapshot fields.
 fn test_pending_commits_persist_across_snapshot_roundtrip() {
     let routing_id = scp_protocol::context::context_routing_id("snapshot-ctx");
     let pending = PendingCommit {
@@ -395,6 +396,8 @@ fn test_pending_commits_persist_across_snapshot_roundtrip() {
         checkpoint_events_since: 0,
         checkpoint_last_time_secs: 0,
         generation: 0,
+        local_pseudonym: None,
+        pseudonym_registry: std::collections::HashMap::new(),
     };
 
     // Round-trip via JSON to ensure serde derive works for both new types.

--- a/crates/scp-runtime/src/context/manager/tests/governance.rs
+++ b/crates/scp-runtime/src/context/manager/tests/governance.rs
@@ -105,6 +105,7 @@ async fn create_context_rejects_threshold_exceeding_signers() {
             "ctx-bad-threshold".into(),
             params,
             "did:dht:z6MkAlice".into(),
+            None,
         )
         .await;
 
@@ -133,6 +134,7 @@ async fn create_context_rejects_threshold_zero() {
             "ctx-zero-threshold".into(),
             params,
             "did:dht:z6MkAlice".into(),
+            None,
         )
         .await;
 
@@ -160,6 +162,7 @@ async fn create_context_rejects_majority_empty_voters() {
             "ctx-empty-majority".into(),
             params,
             "did:dht:z6MkAlice".into(),
+            None,
         )
         .await;
 
@@ -190,6 +193,7 @@ async fn create_context_rejects_unanimity_empty_voters() {
             "ctx-empty-unanimity".into(),
             params,
             "did:dht:z6MkAlice".into(),
+            None,
         )
         .await;
 
@@ -231,6 +235,7 @@ async fn single_admin_propose_auto_executes() {
             "ctx-single-admin-lifecycle".into(),
             params,
             creator_did.clone(),
+            None,
         )
         .await
         .unwrap();
@@ -311,7 +316,7 @@ async fn threshold_context_proposal_lifecycle() {
 
     // Create context (alice is the creator/admin).
     let _handle = manager
-        .create_context("ctx-threshold".into(), params, alice.clone())
+        .create_context("ctx-threshold".into(), params, alice.clone(), None)
         .await
         .unwrap();
 
@@ -386,7 +391,7 @@ async fn majority_context_proposal_lifecycle() {
     };
 
     let _handle = manager
-        .create_context("ctx-majority".into(), params, alice.clone())
+        .create_context("ctx-majority".into(), params, alice.clone(), None)
         .await
         .unwrap();
 
@@ -452,7 +457,7 @@ async fn unanimity_context_single_rejection_defeats_proposal() {
 
     // Add bob as member so we can test RemoveMember doesn't happen.
     let _handle = manager
-        .create_context("ctx-unanimity".into(), params, alice.clone())
+        .create_context("ctx-unanimity".into(), params, alice.clone(), None)
         .await
         .unwrap();
 
@@ -550,7 +555,7 @@ async fn non_eligible_voter_rejected() {
     };
 
     let _handle = manager
-        .create_context("ctx-eligibility".into(), params, alice.clone())
+        .create_context("ctx-eligibility".into(), params, alice.clone(), None)
         .await
         .unwrap();
 
@@ -750,7 +755,7 @@ async fn promote_context_succeeds_when_policy_is_promotable() {
     };
 
     let handle = manager
-        .create_context("promo-ctx".into(), params, "did:key:creator".into())
+        .create_context("promo-ctx".into(), params, "did:key:creator".into(), None)
         .await
         .unwrap();
 
@@ -831,7 +836,12 @@ async fn promote_context_does_not_mutate_promotion_policy() {
     };
 
     let handle = manager
-        .create_context("promo-immut-ctx".into(), params, "did:key:creator".into())
+        .create_context(
+            "promo-immut-ctx".into(),
+            params,
+            "did:key:creator".into(),
+            None,
+        )
         .await
         .unwrap();
 
@@ -900,7 +910,12 @@ async fn setup_context_with_ceiling(
     };
 
     let handle = manager
-        .create_context("ceiling-test-ctx".into(), params, "did:key:creator".into())
+        .create_context(
+            "ceiling-test-ctx".into(),
+            params,
+            "did:key:creator".into(),
+            None,
+        )
         .await
         .unwrap();
 
@@ -1089,7 +1104,7 @@ async fn revoke_rejected_without_member_ban_ceiling() {
     };
 
     let _handle = manager
-        .create_context("bc-no-ban".into(), params, "did:key:alice".into())
+        .create_context("bc-no-ban".into(), params, "did:key:alice".into(), None)
         .await
         .unwrap();
 
@@ -1137,7 +1152,7 @@ async fn governance_single_admin_engine_constructed() {
     };
     let creator: DID = "did:key:admin1".into();
     let handle = manager
-        .create_context("ctx-gov-sa".into(), params, creator.clone())
+        .create_context("ctx-gov-sa".into(), params, creator.clone(), None)
         .await
         .unwrap();
     assert_eq!(handle.state().await, ContextState::Active);
@@ -1513,7 +1528,7 @@ async fn governance_default_engine_all_variants() {
         };
         let ctx_id = format!("ctx-default-{i}");
         let handle = manager
-            .create_context(ctx_id.clone(), params, creator.clone())
+            .create_context(ctx_id.clone(), params, creator.clone(), None)
             .await
             .unwrap();
         assert_eq!(handle.state().await, ContextState::Active);
@@ -1548,7 +1563,7 @@ async fn setup_governance_context() -> (ContextManager, ContextHandle, String) {
 
     let admin_did: DID = "did:key:admin".into();
     let handle = manager
-        .create_context("gov-ctx".into(), params, admin_did)
+        .create_context("gov-ctx".into(), params, admin_did, None)
         .await
         .unwrap();
 
@@ -1622,7 +1637,10 @@ async fn governance_propose_checked_without_capability_rejected() {
         let ctx = arc.lock().await;
         ctx.handle.clone()
     };
-    manager.join_context(&handle_ref, kp, None).await.unwrap();
+    manager
+        .join_context(&handle_ref, kp, None, None)
+        .await
+        .unwrap();
 
     let bob_did: DID = "did:key:bob".into();
     let signing_key = signing_key_for_did(&bob_did);
@@ -1655,7 +1673,10 @@ async fn governance_vote_without_capability_rejected() {
         let ctx = arc.lock().await;
         ctx.handle.clone()
     };
-    manager.join_context(&handle_ref, kp, None).await.unwrap();
+    manager
+        .join_context(&handle_ref, kp, None, None)
+        .await
+        .unwrap();
 
     let bob_did: DID = "did:key:bob".into();
     let signing_key = signing_key_for_did(&bob_did);
@@ -1704,7 +1725,7 @@ async fn governance_propose_checked_records_events() {
 
     let admin_did: DID = "did:key:admin".into();
     let _handle = manager
-        .create_context("ev-ctx".into(), params, admin_did.clone())
+        .create_context("ev-ctx".into(), params, admin_did.clone(), None)
         .await
         .unwrap();
 
@@ -1755,13 +1776,13 @@ async fn governance_threshold_propose_approve_lifecycle() {
     };
 
     let handle = manager
-        .create_context("thresh-ctx".into(), params, alice_did.clone())
+        .create_context("thresh-ctx".into(), params, alice_did.clone(), None)
         .await
         .unwrap();
 
     // Join bob.
     let kp = KeyPackage::mock("did:key:bob".into());
-    manager.join_context(&handle, kp, None).await.unwrap();
+    manager.join_context(&handle, kp, None, None).await.unwrap();
 
     // Grant governance capabilities to bob.
     {
@@ -1918,7 +1939,12 @@ async fn governance_dispatch_returns_typed_results() {
 
     let params = governance_params();
     let _handle = manager
-        .create_context("typed-result-ctx".into(), params, "did:key:creator".into())
+        .create_context(
+            "typed-result-ctx".into(),
+            params,
+            "did:key:creator".into(),
+            None,
+        )
         .await
         .unwrap();
 
@@ -2035,7 +2061,7 @@ async fn governance_auto_execution_threshold_on_approval() {
     };
 
     let _handle = manager
-        .create_context("thresh-auto-ctx".into(), params, creator.clone())
+        .create_context("thresh-auto-ctx".into(), params, creator.clone(), None)
         .await
         .unwrap();
 
@@ -2090,7 +2116,7 @@ async fn close_context_through_governance_threshold() {
     };
 
     let handle = manager
-        .create_context("close-thresh-ctx".into(), params, creator.clone())
+        .create_context("close-thresh-ctx".into(), params, creator.clone(), None)
         .await
         .unwrap();
 
@@ -2118,7 +2144,12 @@ async fn extend_ttl_rejects_without_unanimity() {
     let mut params = governance_params();
     params.ttl = Some(std::time::Duration::from_hours(1));
     let _handle = manager
-        .create_context("ttl-unan-ctx".into(), params, "did:key:creator".into())
+        .create_context(
+            "ttl-unan-ctx".into(),
+            params,
+            "did:key:creator".into(),
+            None,
+        )
         .await
         .unwrap();
 
@@ -2168,7 +2199,12 @@ async fn extend_ttl_succeeds_with_unanimity() {
     let mut params = governance_params();
     params.ttl = Some(std::time::Duration::from_hours(1));
     let _handle = manager
-        .create_context("ttl-unan2-ctx".into(), params, "did:key:creator".into())
+        .create_context(
+            "ttl-unan2-ctx".into(),
+            params,
+            "did:key:creator".into(),
+            None,
+        )
         .await
         .unwrap();
 
@@ -2232,6 +2268,7 @@ async fn promote_context_requires_unanimity() {
             "promo-unanimity-ctx".into(),
             params,
             "did:key:creator".into(),
+            None,
         )
         .await
         .unwrap();
@@ -2309,7 +2346,7 @@ async fn governance_bypass_prevented_for_multi_admin_close() {
         eligible_voters: vec![creator.clone()],
     };
     let handle = manager
-        .create_context("bypass-test-ctx".into(), params, creator.clone())
+        .create_context("bypass-test-ctx".into(), params, creator.clone(), None)
         .await
         .unwrap();
 
@@ -2350,7 +2387,12 @@ async fn add_signer_mints_governance_ucans() {
         signers: vec!["did:key:creator".into()],
     };
     let _handle = manager
-        .create_context("signer-ucan-ctx".into(), params, "did:key:creator".into())
+        .create_context(
+            "signer-ucan-ctx".into(),
+            params,
+            "did:key:creator".into(),
+            None,
+        )
         .await
         .unwrap();
 
@@ -2416,7 +2458,12 @@ async fn remove_signer_revokes_governance_ucans() {
         signers: vec!["did:key:creator".into()],
     };
     let _handle = manager
-        .create_context("rm-signer-ctx".into(), params, "did:key:creator".into())
+        .create_context(
+            "rm-signer-ctx".into(),
+            params,
+            "did:key:creator".into(),
+            None,
+        )
         .await
         .unwrap();
 
@@ -2560,7 +2607,7 @@ async fn scp274_threshold_full_lifecycle() {
         signers: vec![creator.clone(), signer2.clone()],
     };
     let _handle = manager
-        .create_context("scp274-thresh".into(), params, creator.clone())
+        .create_context("scp274-thresh".into(), params, creator.clone(), None)
         .await
         .unwrap();
     {
@@ -2628,7 +2675,7 @@ async fn scp274_majority_full_lifecycle() {
         eligible_voters: vec![creator.clone()],
     };
     let _handle = manager
-        .create_context("scp274-maj".into(), params, creator.clone())
+        .create_context("scp274-maj".into(), params, creator.clone(), None)
         .await
         .unwrap();
     {
@@ -2678,7 +2725,7 @@ async fn scp274_unanimity_full_lifecycle() {
         eligible_voters: vec![creator.clone(), member2.clone()],
     };
     let _handle = manager
-        .create_context("scp274-unan".into(), params, creator.clone())
+        .create_context("scp274-unan".into(), params, creator.clone(), None)
         .await
         .unwrap();
     {
@@ -2738,7 +2785,7 @@ async fn scp274_rejected_proposal_does_not_execute() {
         signers: vec![creator.clone(), signer2.clone()],
     };
     let _handle = manager
-        .create_context("scp274-reject".into(), params, creator.clone())
+        .create_context("scp274-reject".into(), params, creator.clone(), None)
         .await
         .unwrap();
     {
@@ -2799,7 +2846,7 @@ async fn scp274_governance_events_in_log() {
         signers: vec![creator.clone(), signer2.clone()],
     };
     let _handle = manager
-        .create_context("scp274-events".into(), params, creator.clone())
+        .create_context("scp274-events".into(), params, creator.clone(), None)
         .await
         .unwrap();
     {
@@ -2868,7 +2915,7 @@ async fn scp274_bypass_prevention() {
         eligible_voters: vec![creator.clone()],
     };
     let handle = manager
-        .create_context("scp274-bypass".into(), params, creator.clone())
+        .create_context("scp274-bypass".into(), params, creator.clone(), None)
         .await
         .unwrap();
     let result = manager.close_context(&handle, &creator).await;
@@ -2889,7 +2936,7 @@ async fn scp274_exercises_seven_action_variants() {
     );
     let params = governance_params();
     let _handle = manager
-        .create_context("scp274-7a".into(), params, "did:key:admin".into())
+        .create_context("scp274-7a".into(), params, "did:key:admin".into(), None)
         .await
         .unwrap();
     let add = approved_proposal(
@@ -2971,7 +3018,7 @@ async fn scp274_exercises_seven_action_variants() {
     let mut params2 = governance_params();
     params2.ttl = Some(std::time::Duration::from_hours(1));
     let _h2 = manager
-        .create_context("scp274-7b".into(), params2, "did:key:admin".into())
+        .create_context("scp274-7b".into(), params2, "did:key:admin".into(), None)
         .await
         .unwrap();
     {
@@ -3073,7 +3120,12 @@ async fn scp274_extend_ttl_unanimity_override_in_threshold() {
         signers: vec!["did:key:creator".into()],
     };
     let _handle = manager
-        .create_context("scp274-ttl-t".into(), params, "did:key:creator".into())
+        .create_context(
+            "scp274-ttl-t".into(),
+            params,
+            "did:key:creator".into(),
+            None,
+        )
         .await
         .unwrap();
     let add = approved_proposal(
@@ -3139,7 +3191,7 @@ async fn scp274_promote_context_unanimity_override_in_majority() {
     params.memory_scope = MemoryScope::Ephemeral;
     params.ttl = Some(std::time::Duration::from_hours(1));
     let _handle = manager
-        .create_context("scp274-promo".into(), params, creator.clone())
+        .create_context("scp274-promo".into(), params, creator.clone(), None)
         .await
         .unwrap();
     let add = approved_proposal(
@@ -3193,7 +3245,12 @@ async fn scp274_conflict_detection_change_role() {
     );
     let params = governance_params();
     let _handle = manager
-        .create_context("scp274-conflict".into(), params, "did:key:admin".into())
+        .create_context(
+            "scp274-conflict".into(),
+            params,
+            "did:key:admin".into(),
+            None,
+        )
         .await
         .unwrap();
     {
@@ -3389,7 +3446,7 @@ async fn execute_modify_ceiling_sets_pending_with_72h_period() {
     };
 
     let _handle = manager
-        .create_context("ctx-ceiling".into(), params, alice.clone())
+        .create_context("ctx-ceiling".into(), params, alice.clone(), None)
         .await
         .unwrap();
 
@@ -3451,7 +3508,7 @@ async fn apply_pending_ceiling_modification_respects_notification_period() {
     };
 
     let _handle = manager
-        .create_context("ctx-apply".into(), params, alice.clone())
+        .create_context("ctx-apply".into(), params, alice.clone(), None)
         .await
         .unwrap();
 
@@ -3534,7 +3591,7 @@ async fn execute_modify_ceiling_emits_ceiling_change_notification() {
     };
 
     let _handle = manager
-        .create_context("ctx-notify".into(), params, alice.clone())
+        .create_context("ctx-notify".into(), params, alice.clone(), None)
         .await
         .unwrap();
 
@@ -3686,7 +3743,7 @@ async fn execute_set_economic_policy_stages_with_24h_delay() {
     };
 
     let _handle = manager
-        .create_context("ctx-econ-delay".into(), params, alice.clone())
+        .create_context("ctx-econ-delay".into(), params, alice.clone(), None)
         .await
         .unwrap();
 
@@ -3759,7 +3816,7 @@ async fn apply_pending_economic_policy_change_respects_notification_period() {
     };
 
     let _handle = manager
-        .create_context("ctx-econ-apply".into(), params, alice.clone())
+        .create_context("ctx-econ-apply".into(), params, alice.clone(), None)
         .await
         .unwrap();
 
@@ -3858,7 +3915,7 @@ async fn execute_set_economic_policy_emits_notification_event() {
     };
 
     let _handle = manager
-        .create_context("ctx-econ-notify".into(), params, alice.clone())
+        .create_context("ctx-econ-notify".into(), params, alice.clone(), None)
         .await
         .unwrap();
 
@@ -3926,7 +3983,7 @@ async fn execute_set_economic_policy_rejects_when_already_pending() {
     };
 
     let _handle = manager
-        .create_context("ctx-econ-dup".into(), params, alice.clone())
+        .create_context("ctx-econ-dup".into(), params, alice.clone(), None)
         .await
         .unwrap();
 
@@ -3991,7 +4048,7 @@ async fn modify_hard_rate_limit_updates_live_limiter() {
         ..ContextParams::default()
     };
     let _handle = manager
-        .create_context("ctx-rl-modify".into(), params, alice.clone())
+        .create_context("ctx-rl-modify".into(), params, alice.clone(), None)
         .await
         .unwrap();
 
@@ -4085,7 +4142,7 @@ async fn modify_hard_rate_limit_clamps_preserved_state_when_tightening() {
         ..ContextParams::default()
     };
     let _handle = manager
-        .create_context("ctx-rl-clamp".into(), params, alice.clone())
+        .create_context("ctx-rl-clamp".into(), params, alice.clone(), None)
         .await
         .unwrap();
 
@@ -4174,7 +4231,7 @@ async fn modify_hard_rate_limit_rejects_invalid_config() {
         ..ContextParams::default()
     };
     let _handle = manager
-        .create_context("ctx-rl-invalid".into(), params, alice.clone())
+        .create_context("ctx-rl-invalid".into(), params, alice.clone(), None)
         .await
         .unwrap();
 
@@ -4236,7 +4293,7 @@ async fn setup_budget_context(ctx_id: &str) -> (ContextManager, DID, DID) {
         ..ContextParams::default()
     };
     manager
-        .create_context(ctx_id.into(), params, admin_did.clone())
+        .create_context(ctx_id.into(), params, admin_did.clone(), None)
         .await
         .unwrap();
     let sk = signing_key_for_did(&admin_did);
@@ -4340,7 +4397,7 @@ async fn approve_spend_rejects_non_member_spender() {
         ..ContextParams::default()
     };
     manager
-        .create_context("reject-ctx".into(), params, admin_did.clone())
+        .create_context("reject-ctx".into(), params, admin_did.clone(), None)
         .await
         .unwrap();
     let sk = signing_key_for_did(&admin_did);
@@ -5247,7 +5304,7 @@ async fn test_remove_member_sender_key_before_mls_removal() {
 
     let params = governance_params();
     let _handle = manager
-        .create_context("sk-order-ctx".into(), params, "did:key:admin".into())
+        .create_context("sk-order-ctx".into(), params, "did:key:admin".into(), None)
         .await
         .unwrap();
 
@@ -5318,7 +5375,7 @@ async fn test_consequence_rule_triggers_enforcement_event() {
     let mut params = governance_params();
     params.economic_policy = None;
     let _handle = manager
-        .create_context("conseq-ctx".into(), params, "did:key:admin".into())
+        .create_context("conseq-ctx".into(), params, "did:key:admin".into(), None)
         .await
         .unwrap();
 
@@ -5404,7 +5461,7 @@ async fn test_economy_cost_deducted_on_send() {
         payee: DID::from("did:key:payee"),
     });
     let _handle = manager
-        .create_context("econ-ctx".into(), params, "did:key:admin".into())
+        .create_context("econ-ctx".into(), params, "did:key:admin".into(), None)
         .await
         .unwrap();
 
@@ -5474,7 +5531,7 @@ async fn test_cooldown_prevents_consequence_retrigger() {
 
     let params = governance_params();
     let _handle = manager
-        .create_context("cooldown-ctx".into(), params, "did:key:admin".into())
+        .create_context("cooldown-ctx".into(), params, "did:key:admin".into(), None)
         .await
         .unwrap();
 
@@ -5596,7 +5653,12 @@ async fn test_budget_exceeded_blocks_send() {
         payee: DID::from("did:key:payee"),
     });
     let _handle = manager
-        .create_context("budget-fail-ctx".into(), params, "did:key:admin".into())
+        .create_context(
+            "budget-fail-ctx".into(),
+            params,
+            "did:key:admin".into(),
+            None,
+        )
         .await
         .unwrap();
 
@@ -5662,7 +5724,12 @@ async fn test_access_revocation_revokes_read_and_write() {
 
     let params = governance_params();
     let _handle = manager
-        .create_context("access-rev-ctx".into(), params, "did:key:admin".into())
+        .create_context(
+            "access-rev-ctx".into(),
+            params,
+            "did:key:admin".into(),
+            None,
+        )
         .await
         .unwrap();
 
@@ -5750,7 +5817,7 @@ async fn role_demotion_changes_member_role() {
             .collect(),
         });
     let _handle = manager
-        .create_context("demotion-ctx".into(), params, "did:key:admin".into())
+        .create_context("demotion-ctx".into(), params, "did:key:admin".into(), None)
         .await
         .unwrap();
 
@@ -5822,7 +5889,7 @@ async fn test_participation_decay_clears_caches() {
     // Add ContextClose capability to allow close_context.
     params.ceiling.push(Capability::ContextClose);
     let handle = manager
-        .create_context("decay-ctx".into(), params, "did:key:admin".into())
+        .create_context("decay-ctx".into(), params, "did:key:admin".into(), None)
         .await
         .unwrap();
 
@@ -5891,7 +5958,7 @@ async fn test_rotate_content_keys_advances_epoch() {
 
     let params = governance_params();
     let _handle = manager
-        .create_context("rotate-ctx".into(), params, "did:key:admin".into())
+        .create_context("rotate-ctx".into(), params, "did:key:admin".into(), None)
         .await
         .unwrap();
 
@@ -5945,7 +6012,7 @@ async fn test_capability_suspension_no_match_returns_false() {
 
     let params = governance_params();
     let _handle = manager
-        .create_context("no-match-ctx".into(), params, "did:key:admin".into())
+        .create_context("no-match-ctx".into(), params, "did:key:admin".into(), None)
         .await
         .unwrap();
 
@@ -6053,7 +6120,7 @@ async fn test_auto_accept_blocked_for_paid_contexts() {
         payee: DID::from("did:key:payee"),
     });
     let handle = manager
-        .create_context("paid-ctx".into(), params, "did:key:admin".into())
+        .create_context("paid-ctx".into(), params, "did:key:admin".into(), None)
         .await
         .unwrap();
 
@@ -6062,7 +6129,7 @@ async fn test_auto_accept_blocked_for_paid_contexts() {
         owner_did: "did:key:joiner".into(),
         mls_key_package_bytes: None,
     };
-    let result = manager.join_context(&handle, key_package, None).await;
+    let result = manager.join_context(&handle, key_package, None, None).await;
     assert!(
         result.is_err(),
         "join should fail for paid contexts without explicit acceptance"
@@ -6096,7 +6163,7 @@ async fn pending_removal_blocks_proposal() {
 
     let params = governance_params();
     let handle = manager
-        .create_context("standing-ctx".into(), params, admin.clone())
+        .create_context("standing-ctx".into(), params, admin.clone(), None)
         .await
         .unwrap();
 
@@ -6105,7 +6172,7 @@ async fn pending_removal_blocks_proposal() {
         owner_did: alice.clone(),
         mls_key_package_bytes: None,
     };
-    manager.join_context(&handle, kp, None).await.unwrap();
+    manager.join_context(&handle, kp, None, None).await.unwrap();
 
     // Manually insert a pending removal against Alice.
     {
@@ -6166,7 +6233,7 @@ async fn participation_influences_governance_eligibility() {
 
     let params = governance_params();
     let _handle = manager
-        .create_context("standing-vote-ctx".into(), params, admin.clone())
+        .create_context("standing-vote-ctx".into(), params, admin.clone(), None)
         .await
         .unwrap();
 
@@ -6195,7 +6262,7 @@ async fn decay_participation_clears_state() {
 
     let params = governance_params();
     let _handle = manager
-        .create_context("decay-ctx".into(), params, "did:key:admin".into())
+        .create_context("decay-ctx".into(), params, "did:key:admin".into(), None)
         .await
         .unwrap();
 
@@ -6264,7 +6331,7 @@ async fn sender_key_before_mls_removal_ordering() {
 
     let params = governance_params();
     let handle = manager
-        .create_context("order-ctx".into(), params, admin.clone())
+        .create_context("order-ctx".into(), params, admin.clone(), None)
         .await
         .unwrap();
 
@@ -6273,7 +6340,7 @@ async fn sender_key_before_mls_removal_ordering() {
         owner_did: alice.clone(),
         mls_key_package_bytes: None,
     };
-    manager.join_context(&handle, kp, None).await.unwrap();
+    manager.join_context(&handle, kp, None, None).await.unwrap();
 
     // Clear call log from join operations so we only see removal calls.
     call_order.lock().unwrap().clear();
@@ -6379,7 +6446,7 @@ async fn participation_record_updated_after_message_send() {
 
     let params = governance_params();
     let _handle = manager
-        .create_context("part-msg-ctx".into(), params, "did:key:admin".into())
+        .create_context("part-msg-ctx".into(), params, "did:key:admin".into(), None)
         .await
         .unwrap();
 
@@ -6458,7 +6525,7 @@ async fn consequence_triggers_after_governance_action() {
         window: Duration::from_hours(1),
     }];
     let _handle = manager
-        .create_context("gov-conseq-ctx".into(), params, admin.clone())
+        .create_context("gov-conseq-ctx".into(), params, admin.clone(), None)
         .await
         .unwrap();
 
@@ -6544,7 +6611,12 @@ async fn cooldown_expires_allows_retrigger() {
 
     let params = governance_params();
     let _handle = manager
-        .create_context("cooldown-exp-ctx".into(), params, "did:key:admin".into())
+        .create_context(
+            "cooldown-exp-ctx".into(),
+            params,
+            "did:key:admin".into(),
+            None,
+        )
         .await
         .unwrap();
 
@@ -6648,7 +6720,12 @@ async fn empty_consequence_rules_no_evaluation() {
 
     let params = governance_params();
     let _handle = manager
-        .create_context("empty-rules-ctx".into(), params, "did:key:admin".into())
+        .create_context(
+            "empty-rules-ctx".into(),
+            params,
+            "did:key:admin".into(),
+            None,
+        )
         .await
         .unwrap();
 
@@ -6729,7 +6806,12 @@ async fn event_log_entries_feed_consequence_evaluation() {
         window: Duration::from_hours(1),
     }];
     let _handle = manager
-        .create_context("event-feed-ctx".into(), params, "did:key:admin".into())
+        .create_context(
+            "event-feed-ctx".into(),
+            params,
+            "did:key:admin".into(),
+            None,
+        )
         .await
         .unwrap();
 
@@ -6807,7 +6889,7 @@ async fn remaining_members_keys_after_removal() {
 
     let params = governance_params();
     let handle = manager
-        .create_context("remain-ctx".into(), params, admin.clone())
+        .create_context("remain-ctx".into(), params, admin.clone(), None)
         .await
         .unwrap();
 
@@ -6817,7 +6899,7 @@ async fn remaining_members_keys_after_removal() {
             owner_did: did.clone(),
             mls_key_package_bytes: None,
         };
-        manager.join_context(&handle, kp, None).await.unwrap();
+        manager.join_context(&handle, kp, None, None).await.unwrap();
     }
 
     // Clear call log to isolate removal calls.
@@ -6884,7 +6966,7 @@ async fn broadcast_rotation_calls_rotate_author_keys() {
     params.mode = ContextMode::Broadcast;
     params.memory_scope = scp_protocol::context::params::MemoryScope::Full;
     let _handle = manager
-        .create_context("bc-rotate-ctx".into(), params, admin.clone())
+        .create_context("bc-rotate-ctx".into(), params, admin.clone(), None)
         .await
         .unwrap();
 
@@ -6933,7 +7015,7 @@ async fn encrypted_rotation_updates_epoch_counter() {
     let mut params = governance_params();
     params.mode = ContextMode::Encrypted;
     let _handle = manager
-        .create_context("epoch-ctr-ctx".into(), params, admin.clone())
+        .create_context("epoch-ctr-ctx".into(), params, admin.clone(), None)
         .await
         .unwrap();
 
@@ -7016,7 +7098,7 @@ async fn full_send_consequence_enforcement_round_trip() {
         window: Duration::from_hours(1),
     }];
     let _handle = manager
-        .create_context("roundtrip-ctx".into(), params, "did:key:admin".into())
+        .create_context("roundtrip-ctx".into(), params, "did:key:admin".into(), None)
         .await
         .unwrap();
 
@@ -7126,7 +7208,7 @@ async fn governance_participation_round_trip() {
 
     let params = governance_params();
     let _handle = manager
-        .create_context("gov-stand-ctx".into(), params, admin.clone())
+        .create_context("gov-stand-ctx".into(), params, admin.clone(), None)
         .await
         .unwrap();
 
@@ -7205,7 +7287,12 @@ async fn capability_suspension_blocks_subsequent_send() {
         window: Duration::from_hours(1),
     }];
     let _handle = manager
-        .create_context("block-send-ctx".into(), params, "did:key:admin".into())
+        .create_context(
+            "block-send-ctx".into(),
+            params,
+            "did:key:admin".into(),
+            None,
+        )
         .await
         .unwrap();
 
@@ -7278,7 +7365,12 @@ async fn access_revocation_blocks_subsequent_send() {
         window: Duration::from_hours(1),
     }];
     let _handle = manager
-        .create_context("block-access-ctx".into(), params, "did:key:admin".into())
+        .create_context(
+            "block-access-ctx".into(),
+            params,
+            "did:key:admin".into(),
+            None,
+        )
         .await
         .unwrap();
 
@@ -7352,7 +7444,7 @@ async fn join_context_with_join_cost_no_budget_rejected() {
         payee: DID::from("did:key:payee"),
     });
     let handle = manager
-        .create_context("join-cost-ctx".into(), params, "did:key:admin".into())
+        .create_context("join-cost-ctx".into(), params, "did:key:admin".into(), None)
         .await
         .unwrap();
 
@@ -7361,7 +7453,7 @@ async fn join_context_with_join_cost_no_budget_rejected() {
         owner_did: "did:key:joiner".into(),
         mls_key_package_bytes: None,
     };
-    let result = manager.join_context(&handle, kp, None).await;
+    let result = manager.join_context(&handle, kp, None, None).await;
     assert!(
         result.is_err(),
         "join should fail for paid context: {result:?}"
@@ -7403,7 +7495,7 @@ async fn eligibility_blocks_low_participation() {
         signers: vec![admin.clone(), bob.clone()],
     };
     let handle = manager
-        .create_context("low-stand-ctx".into(), params, admin.clone())
+        .create_context("low-stand-ctx".into(), params, admin.clone(), None)
         .await
         .unwrap();
 
@@ -7412,7 +7504,7 @@ async fn eligibility_blocks_low_participation() {
         owner_did: bob.clone(),
         mls_key_package_bytes: None,
     };
-    manager.join_context(&handle, kp, None).await.unwrap();
+    manager.join_context(&handle, kp, None, None).await.unwrap();
 
     // Drain events from the buffer so check_proposer_eligibility's refresh
     // finds an empty event list and preserves our injected cache entry.
@@ -7505,7 +7597,7 @@ async fn eligibility_allows_good_participation() {
         signers: vec![admin.clone(), alice.clone()],
     };
     let handle = manager
-        .create_context("good-stand-ctx".into(), params, admin.clone())
+        .create_context("good-stand-ctx".into(), params, admin.clone(), None)
         .await
         .unwrap();
 
@@ -7514,7 +7606,7 @@ async fn eligibility_allows_good_participation() {
         owner_did: alice.clone(),
         mls_key_package_bytes: None,
     };
-    manager.join_context(&handle, kp, None).await.unwrap();
+    manager.join_context(&handle, kp, None, None).await.unwrap();
 
     // Manually inject a good participation record for Alice: more actions
     // by than against.
@@ -7597,7 +7689,12 @@ async fn consequence_triggers_on_message_send() {
         window: Duration::from_hours(1),
     }];
     let _handle = manager
-        .create_context("msg-conseq-ctx".into(), params, "did:key:admin".into())
+        .create_context(
+            "msg-conseq-ctx".into(),
+            params,
+            "did:key:admin".into(),
+            None,
+        )
         .await
         .unwrap();
 
@@ -7678,7 +7775,7 @@ async fn send_message_deducts_budget() {
         payee: DID::from("did:key:payee"),
     });
     let _handle = manager
-        .create_context("deduct-ctx".into(), params, "did:key:sender".into())
+        .create_context("deduct-ctx".into(), params, "did:key:sender".into(), None)
         .await
         .unwrap();
 
@@ -7927,7 +8024,7 @@ async fn velocity_tracker_records_messages() {
 
     let params = governance_params();
     let _handle = manager
-        .create_context("velocity-ctx".into(), params, "did:key:admin".into())
+        .create_context("velocity-ctx".into(), params, "did:key:admin".into(), None)
         .await
         .unwrap();
 
@@ -8046,7 +8143,7 @@ async fn encrypted_rotation_advance_epoch_called() {
     let mut params = governance_params();
     params.mode = ContextMode::Encrypted;
     let _handle = manager
-        .create_context("adv-epoch-ctx".into(), params, admin.clone())
+        .create_context("adv-epoch-ctx".into(), params, admin.clone(), None)
         .await
         .unwrap();
 
@@ -8111,7 +8208,7 @@ async fn paid_join_end_to_end_with_adapter() {
         payee: DID::from("did:key:payee"),
     });
     let _handle = manager
-        .create_context("paid-join-ctx".into(), params, "did:key:admin".into())
+        .create_context("paid-join-ctx".into(), params, "did:key:admin".into(), None)
         .await
         .unwrap();
 
@@ -8134,7 +8231,7 @@ async fn paid_join_end_to_end_with_adapter() {
         owner_did: "did:key:joiner".into(),
         mls_key_package_bytes: None,
     };
-    let result = manager.join_context(&handle, kp, None).await;
+    let result = manager.join_context(&handle, kp, None, None).await;
     assert!(
         result.is_err(),
         "join should fail for paid context even with adapter: {result:?}"
@@ -8197,7 +8294,7 @@ async fn sybil_resistance_evaluated_on_join() {
 
     let params = governance_params();
     let handle = manager
-        .create_context("sybil-ctx".into(), params, "did:key:admin".into())
+        .create_context("sybil-ctx".into(), params, "did:key:admin".into(), None)
         .await
         .unwrap();
 
@@ -8206,7 +8303,7 @@ async fn sybil_resistance_evaluated_on_join() {
         owner_did: "did:key:newmember".into(),
         mls_key_package_bytes: None,
     };
-    let result = manager.join_context(&handle, kp, None).await;
+    let result = manager.join_context(&handle, kp, None, None).await;
     assert!(
         result.is_ok(),
         "join should succeed with valid member (sybil evaluation passes): {result:?}"
@@ -8255,7 +8352,12 @@ async fn join_context_deducts_budget_when_granted() {
         payee: DID::from("did:key:payee"),
     });
     let _handle = manager
-        .create_context("join-budget-ctx".into(), params, "did:key:admin".into())
+        .create_context(
+            "join-budget-ctx".into(),
+            params,
+            "did:key:admin".into(),
+            None,
+        )
         .await
         .unwrap();
 
@@ -8345,7 +8447,7 @@ async fn participation_record_updated_after_governance() {
 
     let params = governance_params();
     let _handle = manager
-        .create_context("part-gov2-ctx".into(), params, admin.clone())
+        .create_context("part-gov2-ctx".into(), params, admin.clone(), None)
         .await
         .unwrap();
 
@@ -8431,7 +8533,7 @@ async fn test_send_rejected_insufficient_budget() {
         payee: DID::from("did:key:payee"),
     });
     let _handle = manager
-        .create_context("insuf-ctx".into(), params, "did:key:admin".into())
+        .create_context("insuf-ctx".into(), params, "did:key:admin".into(), None)
         .await
         .unwrap();
 
@@ -8556,7 +8658,12 @@ async fn test_join_rejected_insufficient_budget() {
         payee: DID::from("did:key:payee"),
     });
     let handle = manager
-        .create_context("join-insuf-ctx".into(), params, "did:key:admin".into())
+        .create_context(
+            "join-insuf-ctx".into(),
+            params,
+            "did:key:admin".into(),
+            None,
+        )
         .await
         .unwrap();
 
@@ -8566,7 +8673,7 @@ async fn test_join_rejected_insufficient_budget() {
         owner_did: "did:key:joiner".into(),
         mls_key_package_bytes: None,
     };
-    let result = manager.join_context(&handle, kp, None).await;
+    let result = manager.join_context(&handle, kp, None, None).await;
     assert!(
         result.is_err(),
         "join should fail for paid context with insufficient budget: {result:?}"
@@ -8606,7 +8713,7 @@ async fn test_execute_paid_action_skips_without_adapter() {
         payee: DID::from("did:key:payee"),
     });
     let _handle = manager
-        .create_context("no-adpt2-ctx".into(), params, "did:key:admin".into())
+        .create_context("no-adpt2-ctx".into(), params, "did:key:admin".into(), None)
         .await
         .unwrap();
 
@@ -8660,7 +8767,7 @@ async fn test_execute_paid_action_full_flow_with_adapter() {
         payee: DID::from("did:key:payee"),
     });
     let _handle = manager
-        .create_context("adpt2-ctx".into(), params, "did:key:admin".into())
+        .create_context("adpt2-ctx".into(), params, "did:key:admin".into(), None)
         .await
         .unwrap();
 
@@ -8714,7 +8821,7 @@ async fn test_free_context_no_budget_deduction() {
     // No economic_policy set (free context).
     let params = governance_params();
     let _handle = manager
-        .create_context("free-ctx".into(), params, "did:key:admin".into())
+        .create_context("free-ctx".into(), params, "did:key:admin".into(), None)
         .await
         .unwrap();
 
@@ -8784,7 +8891,7 @@ async fn test_remaining_members_unaffected_after_removal() {
 
     let params = governance_params();
     let handle = manager
-        .create_context("remain2-ctx".into(), params, admin.clone())
+        .create_context("remain2-ctx".into(), params, admin.clone(), None)
         .await
         .unwrap();
 
@@ -8794,7 +8901,7 @@ async fn test_remaining_members_unaffected_after_removal() {
             owner_did: did.clone(),
             mls_key_package_bytes: None,
         };
-        manager.join_context(&handle, kp, None).await.unwrap();
+        manager.join_context(&handle, kp, None, None).await.unwrap();
     }
 
     // Remove Bob.
@@ -8850,7 +8957,7 @@ async fn test_broadcast_rotation_rotates_author_keys() {
     params.mode = ContextMode::Broadcast;
     params.memory_scope = scp_protocol::context::params::MemoryScope::Full;
     let _handle = manager
-        .create_context("bc-rot2-ctx".into(), params, admin.clone())
+        .create_context("bc-rot2-ctx".into(), params, admin.clone(), None)
         .await
         .unwrap();
 
@@ -8897,7 +9004,7 @@ async fn test_encrypted_rotation_increments_epoch() {
     let mut params = governance_params();
     params.mode = ContextMode::Encrypted;
     let _handle = manager
-        .create_context("enc-rot2-ctx".into(), params, admin.clone())
+        .create_context("enc-rot2-ctx".into(), params, admin.clone(), None)
         .await
         .unwrap();
 
@@ -8959,7 +9066,7 @@ async fn test_send_consequence_economy_round_trip() {
         window: Duration::from_hours(1),
     }];
     let _handle = manager
-        .create_context("xcut-rt-ctx".into(), params, "did:key:admin".into())
+        .create_context("xcut-rt-ctx".into(), params, "did:key:admin".into(), None)
         .await
         .unwrap();
 
@@ -9042,7 +9149,7 @@ async fn test_governance_eligibility_participation_round_trip() {
 
     let params = governance_params();
     let _handle = manager
-        .create_context("stand-rt-ctx".into(), params, admin.clone())
+        .create_context("stand-rt-ctx".into(), params, admin.clone(), None)
         .await
         .unwrap();
 
@@ -9093,6 +9200,7 @@ async fn test_governance_eligibility_participation_round_trip() {
 
 /// Paid join with consequence rules — join cost and consequence evaluation (#1537, #1531).
 #[tokio::test]
+#[allow(clippy::too_many_lines)]
 async fn test_paid_join_with_consequence_evaluation() {
     use scp_protocol::economy::types::{Amount, CostSchedule, CurrencyCode, EconomicPolicy};
     use scp_protocol::trust::consequence::{
@@ -9131,7 +9239,12 @@ async fn test_paid_join_with_consequence_evaluation() {
         window: Duration::from_hours(1),
     }];
     let handle = manager
-        .create_context("paid-join-cq-ctx".into(), params, "did:key:admin".into())
+        .create_context(
+            "paid-join-cq-ctx".into(),
+            params,
+            "did:key:admin".into(),
+            None,
+        )
         .await
         .unwrap();
 
@@ -9140,7 +9253,7 @@ async fn test_paid_join_with_consequence_evaluation() {
         owner_did: "did:key:joiner".into(),
         mls_key_package_bytes: None,
     };
-    let result = manager.join_context(&handle, kp, None).await;
+    let result = manager.join_context(&handle, kp, None, None).await;
     assert!(result.is_err(), "join should fail for paid context");
 
     // Verify the budget deduction works by directly testing.
@@ -9248,7 +9361,12 @@ async fn test_full_lifecycle_economy() {
         payee: DID::from("did:key:payee"),
     });
     let _handle = manager
-        .create_context("lifecycle-econ-ctx".into(), params, "did:key:user".into())
+        .create_context(
+            "lifecycle-econ-ctx".into(),
+            params,
+            "did:key:user".into(),
+            None,
+        )
         .await
         .unwrap();
 
@@ -9484,7 +9602,7 @@ async fn setup_velocity_escalation_context() -> (
     });
 
     manager
-        .create_context("vel-esc-ctx".into(), params, "did:key:admin".into())
+        .create_context("vel-esc-ctx".into(), params, "did:key:admin".into(), None)
         .await
         .unwrap();
 
@@ -9531,7 +9649,7 @@ async fn rotate_sender_key_called_after_remove_member() {
 
     let params = governance_params();
     let handle = manager
-        .create_context("rotate-ctx".into(), params, admin.clone())
+        .create_context("rotate-ctx".into(), params, admin.clone(), None)
         .await
         .unwrap();
 
@@ -9540,7 +9658,7 @@ async fn rotate_sender_key_called_after_remove_member() {
         owner_did: alice.clone(),
         mls_key_package_bytes: None,
     };
-    manager.join_context(&handle, kp, None).await.unwrap();
+    manager.join_context(&handle, kp, None, None).await.unwrap();
 
     // Clear call log from join operations.
     call_order.lock().unwrap().clear();
@@ -9602,7 +9720,7 @@ async fn rotate_sender_key_error_propagates() {
 
     let params = governance_params();
     let handle = manager
-        .create_context("rotate-err-ctx".into(), params, admin.clone())
+        .create_context("rotate-err-ctx".into(), params, admin.clone(), None)
         .await
         .unwrap();
 
@@ -9611,7 +9729,7 @@ async fn rotate_sender_key_error_propagates() {
         owner_did: alice.clone(),
         mls_key_package_bytes: None,
     };
-    manager.join_context(&handle, kp, None).await.unwrap();
+    manager.join_context(&handle, kp, None, None).await.unwrap();
 
     // Remove Alice — rotation failure is non-fatal, so the governance
     // action succeeds. MLS removal (the hard security boundary) completes;
@@ -9649,7 +9767,7 @@ async fn rotate_sender_key_called_on_leave() {
 
     let params = governance_params();
     let handle = manager
-        .create_context("leave-rotate-ctx".into(), params, admin.clone())
+        .create_context("leave-rotate-ctx".into(), params, admin.clone(), None)
         .await
         .unwrap();
 
@@ -9658,7 +9776,7 @@ async fn rotate_sender_key_called_on_leave() {
         owner_did: alice.clone(),
         mls_key_package_bytes: None,
     };
-    manager.join_context(&handle, kp, None).await.unwrap();
+    manager.join_context(&handle, kp, None, None).await.unwrap();
 
     // Clear call log from join operations.
     call_order.lock().unwrap().clear();
@@ -9735,7 +9853,12 @@ async fn test_paid_send_rejected_without_spending_ucan() {
         payee: DID::from("did:key:payee"),
     });
     let _handle = manager
-        .create_context("paid-no-ucan-ctx".into(), params, "did:key:sender".into())
+        .create_context(
+            "paid-no-ucan-ctx".into(),
+            params,
+            "did:key:sender".into(),
+            None,
+        )
         .await
         .unwrap();
 
@@ -9842,7 +9965,7 @@ async fn test_paid_join_rejected_without_spending_ucan() {
         payee: DID::from("did:key:payee"),
     });
     let handle = manager
-        .create_context("paid-join-ctx".into(), params, "did:key:admin".into())
+        .create_context("paid-join-ctx".into(), params, "did:key:admin".into(), None)
         .await
         .unwrap();
 
@@ -9851,7 +9974,7 @@ async fn test_paid_join_rejected_without_spending_ucan() {
         owner_did: "did:key:joiner".into(),
         mls_key_package_bytes: None,
     };
-    let result = manager.join_context(&handle, kp, None).await;
+    let result = manager.join_context(&handle, kp, None, None).await;
     assert!(
         result.is_err(),
         "paid join without spending UCAN should fail"
@@ -9878,7 +10001,7 @@ async fn test_free_join_ok_without_spending_ucan() {
 
     let params = governance_params();
     let handle = manager
-        .create_context("free-join-ctx".into(), params, "did:key:admin".into())
+        .create_context("free-join-ctx".into(), params, "did:key:admin".into(), None)
         .await
         .unwrap();
 
@@ -9887,7 +10010,7 @@ async fn test_free_join_ok_without_spending_ucan() {
         owner_did: "did:key:joiner".into(),
         mls_key_package_bytes: None,
     };
-    let result = manager.join_context(&handle, kp, None).await;
+    let result = manager.join_context(&handle, kp, None, None).await;
     assert!(
         result.is_ok(),
         "free join without spending UCAN should succeed: {result:?}"
@@ -9912,7 +10035,12 @@ async fn test_event_log_stores_actor_did() {
 
     let params = governance_params();
     let handle = manager
-        .create_context("actor-did-ctx".into(), params, "did:key:sender".into())
+        .create_context(
+            "actor-did-ctx".into(),
+            params,
+            "did:key:sender".into(),
+            None,
+        )
         .await
         .unwrap();
 
@@ -9986,7 +10114,7 @@ async fn test_consequence_evaluation_uses_full_history() {
         window: Duration::from_hours(1),
     }];
     let _handle = manager
-        .create_context("hist-ctx".into(), params, "did:key:admin".into())
+        .create_context("hist-ctx".into(), params, "did:key:admin".into(), None)
         .await
         .unwrap();
 
@@ -10116,7 +10244,12 @@ async fn paid_send_with_valid_spending_ucan_succeeds() {
         payee: DID::from("did:key:payee"),
     });
     let _handle = manager
-        .create_context("paid-ucan-ok-ctx".into(), params, "did:key:sender".into())
+        .create_context(
+            "paid-ucan-ok-ctx".into(),
+            params,
+            "did:key:sender".into(),
+            None,
+        )
         .await
         .unwrap();
 
@@ -10223,7 +10356,12 @@ async fn zero_cost_per_message_no_ucan_required() {
         payee: DID::from("did:key:payee"),
     });
     let _handle = manager
-        .create_context("zero-cost-ctx".into(), params, "did:key:sender".into())
+        .create_context(
+            "zero-cost-ctx".into(),
+            params,
+            "did:key:sender".into(),
+            None,
+        )
         .await
         .unwrap();
 
@@ -10287,7 +10425,7 @@ async fn none_per_message_no_ucan_required() {
         payee: DID::from("did:key:payee"),
     });
     let _handle = manager
-        .create_context("none-msg-ctx".into(), params, "did:key:sender".into())
+        .create_context("none-msg-ctx".into(), params, "did:key:sender".into(), None)
         .await
         .unwrap();
 
@@ -10352,7 +10490,12 @@ async fn multiple_sends_unique_spending_ucans_all_succeed() {
         payee: DID::from("did:key:payee"),
     });
     let _handle = manager
-        .create_context("multi-ucan-ctx".into(), params, "did:key:sender".into())
+        .create_context(
+            "multi-ucan-ctx".into(),
+            params,
+            "did:key:sender".into(),
+            None,
+        )
         .await
         .unwrap();
 
@@ -10440,7 +10583,12 @@ async fn paid_join_with_spending_ucan_still_blocked_by_auto_accept() {
         payee: DID::from("did:key:payee"),
     });
     let handle = manager
-        .create_context("paid-join-ucan-ctx".into(), params, "did:key:admin".into())
+        .create_context(
+            "paid-join-ucan-ctx".into(),
+            params,
+            "did:key:admin".into(),
+            None,
+        )
         .await
         .unwrap();
 
@@ -10464,7 +10612,7 @@ async fn paid_join_with_spending_ucan_still_blocked_by_auto_accept() {
         mls_key_package_bytes: None,
     };
     let ucan = dummy_spending_ucan();
-    let result = manager.join_context(&handle, kp, Some(&ucan)).await;
+    let result = manager.join_context(&handle, kp, Some(&ucan), None).await;
     // Paid contexts block auto-accept even with a spending UCAN (§19.3).
     // The spending UCAN covers payment, not the auto-accept gate.
     assert!(
@@ -10501,7 +10649,7 @@ async fn rotate_sender_key_not_called_when_remove_member_fails() {
 
     let params = governance_params();
     let handle = manager
-        .create_context("no-rotate-ctx".into(), params, admin.clone())
+        .create_context("no-rotate-ctx".into(), params, admin.clone(), None)
         .await
         .unwrap();
 
@@ -10510,7 +10658,7 @@ async fn rotate_sender_key_not_called_when_remove_member_fails() {
         owner_did: alice.clone(),
         mls_key_package_bytes: None,
     };
-    manager.join_context(&handle, kp, None).await.unwrap();
+    manager.join_context(&handle, kp, None, None).await.unwrap();
 
     // Clear call log from join operations.
     call_order.lock().unwrap().clear();
@@ -10564,7 +10712,12 @@ async fn join_context_stores_actor_did() {
 
     let params = governance_params();
     let handle = manager
-        .create_context("join-actor-ctx".into(), params, "did:key:admin".into())
+        .create_context(
+            "join-actor-ctx".into(),
+            params,
+            "did:key:admin".into(),
+            None,
+        )
         .await
         .unwrap();
 
@@ -10573,7 +10726,7 @@ async fn join_context_stores_actor_did() {
         owner_did: "did:key:joiner".into(),
         mls_key_package_bytes: None,
     };
-    manager.join_context(&handle, kp, None).await.unwrap();
+    manager.join_context(&handle, kp, None, None).await.unwrap();
 
     // Check event log for MemberJoined entry.
     let context_id_bytes = scp_protocol::context::context_id_bytes("join-actor-ctx");
@@ -10613,7 +10766,12 @@ async fn leave_context_stores_actor_did() {
 
     let params = governance_params();
     let handle = manager
-        .create_context("leave-actor-ctx".into(), params, "did:key:admin".into())
+        .create_context(
+            "leave-actor-ctx".into(),
+            params,
+            "did:key:admin".into(),
+            None,
+        )
         .await
         .unwrap();
 
@@ -10622,7 +10780,7 @@ async fn leave_context_stores_actor_did() {
         owner_did: "did:key:leaver".into(),
         mls_key_package_bytes: None,
     };
-    manager.join_context(&handle, kp, None).await.unwrap();
+    manager.join_context(&handle, kp, None, None).await.unwrap();
 
     // Leave.
     manager
@@ -10668,7 +10826,7 @@ async fn governance_action_stores_actor_did() {
 
     let params = governance_params();
     let handle = manager
-        .create_context("gov-actor-ctx".into(), params, admin.clone())
+        .create_context("gov-actor-ctx".into(), params, admin.clone(), None)
         .await
         .unwrap();
 
@@ -10677,7 +10835,7 @@ async fn governance_action_stores_actor_did() {
         owner_did: target.clone(),
         mls_key_package_bytes: None,
     };
-    manager.join_context(&handle, kp, None).await.unwrap();
+    manager.join_context(&handle, kp, None, None).await.unwrap();
 
     // Execute governance action: RemoveMember.
     let action = scp_protocol::context::governance::GovernanceAction::RemoveMember {
@@ -10721,7 +10879,12 @@ async fn context_created_event_has_creator_actor_did() {
 
     let params = governance_params();
     let _handle = manager
-        .create_context("system-actor-ctx".into(), params, "did:key:admin".into())
+        .create_context(
+            "system-actor-ctx".into(),
+            params,
+            "did:key:admin".into(),
+            None,
+        )
         .await
         .unwrap();
 
@@ -10779,7 +10942,12 @@ async fn no_auto_grant_requires_explicit_budget() {
         payee: DID::from("did:key:payee"),
     });
     let _handle = manager
-        .create_context("no-autogrant-ctx".into(), params, "did:key:sender".into())
+        .create_context(
+            "no-autogrant-ctx".into(),
+            params,
+            "did:key:sender".into(),
+            None,
+        )
         .await
         .unwrap();
 
@@ -10879,7 +11047,7 @@ async fn no_double_charge_on_paid_send() {
         payee: DID::from("did:key:payee"),
     });
     let _handle = manager
-        .create_context("double-ctx".into(), params, "did:key:sender".into())
+        .create_context("double-ctx".into(), params, "did:key:sender".into(), None)
         .await
         .unwrap();
 
@@ -10951,7 +11119,12 @@ async fn capability_suspension_exact_match_no_false_positive() {
     // to bypass validation (which now rejects unknown capability names).
     // This test exercises the enforcement path for an unrecognized capability.
     let _handle = manager
-        .create_context("cap-exact-ctx".into(), params, "did:key:sender".into())
+        .create_context(
+            "cap-exact-ctx".into(),
+            params,
+            "did:key:sender".into(),
+            None,
+        )
         .await
         .unwrap();
     {
@@ -11066,7 +11239,12 @@ async fn capability_suspension_write_revokes_write() {
         window: Duration::from_hours(1),
     }];
     let _handle = manager
-        .create_context("cap-write-ctx".into(), params, "did:key:sender".into())
+        .create_context(
+            "cap-write-ctx".into(),
+            params,
+            "did:key:sender".into(),
+            None,
+        )
         .await
         .unwrap();
 
@@ -11144,7 +11322,7 @@ async fn capability_suspension_read_revokes_read() {
         window: Duration::from_hours(1),
     }];
     let _handle = manager
-        .create_context("cap-read-ctx".into(), params, "did:key:sender".into())
+        .create_context("cap-read-ctx".into(), params, "did:key:sender".into(), None)
         .await
         .unwrap();
 
@@ -11226,7 +11404,12 @@ async fn role_demotion_nonexistent_role_reports_failure() {
         window: Duration::from_hours(1),
     }];
     let _handle = manager
-        .create_context("role-noexist-ctx".into(), params, "did:key:sender".into())
+        .create_context(
+            "role-noexist-ctx".into(),
+            params,
+            "did:key:sender".into(),
+            None,
+        )
         .await
         .unwrap();
 
@@ -11330,7 +11513,12 @@ async fn execute_paid_action_skips_zero_cost() {
         payee: DID::from("did:key:payee"),
     });
     let _handle = manager
-        .create_context("zero-paid-ctx".into(), params, "did:key:sender".into())
+        .create_context(
+            "zero-paid-ctx".into(),
+            params,
+            "did:key:sender".into(),
+            None,
+        )
         .await
         .unwrap();
 
@@ -11420,7 +11608,7 @@ async fn participation_cache_cleared_after_member_leaves() {
 
     let params = governance_params();
     let handle = manager
-        .create_context("part-cache-ctx".into(), params, admin.clone())
+        .create_context("part-cache-ctx".into(), params, admin.clone(), None)
         .await
         .unwrap();
 
@@ -11429,7 +11617,7 @@ async fn participation_cache_cleared_after_member_leaves() {
         owner_did: alice.clone(),
         mls_key_package_bytes: None,
     };
-    manager.join_context(&handle, kp, None).await.unwrap();
+    manager.join_context(&handle, kp, None, None).await.unwrap();
 
     // Seed participation cache with an entry for Alice.
     {
@@ -11524,7 +11712,12 @@ async fn capability_suspension_empty_caps_no_action() {
     // bypass validation (which now rejects empty capabilities in
     // SuspendCapability).
     let _handle = manager
-        .create_context("empty-caps-ctx".into(), params, "did:key:sender".into())
+        .create_context(
+            "empty-caps-ctx".into(),
+            params,
+            "did:key:sender".into(),
+            None,
+        )
         .await
         .unwrap();
     {
@@ -11652,7 +11845,12 @@ async fn multiple_consequence_rules_all_trigger() {
         },
     ];
     let _handle = manager
-        .create_context("multi-rule-ctx".into(), params, "did:key:sender".into())
+        .create_context(
+            "multi-rule-ctx".into(),
+            params,
+            "did:key:sender".into(),
+            None,
+        )
         .await
         .unwrap();
 
@@ -11743,7 +11941,7 @@ async fn aggregate_velocity_via_manager_send() {
         payee: DID::from("did:key:payee"),
     });
     let _handle = manager
-        .create_context("agg-vel-ctx".into(), params, "did:key:sender".into())
+        .create_context("agg-vel-ctx".into(), params, "did:key:sender".into(), None)
         .await
         .unwrap();
 
@@ -11883,7 +12081,7 @@ async fn test_warning_count_trigger_fires_behavioral() {
         window: Duration::from_hours(1),
     }];
     let handle = manager
-        .create_context("warn-ctx".into(), params, admin.clone())
+        .create_context("warn-ctx".into(), params, admin.clone(), None)
         .await
         .unwrap();
 
@@ -11892,7 +12090,7 @@ async fn test_warning_count_trigger_fires_behavioral() {
         owner_did: target.clone(),
         mls_key_package_bytes: None,
     };
-    manager.join_context(&handle, kp, None).await.unwrap();
+    manager.join_context(&handle, kp, None, None).await.unwrap();
 
     // Drain creation + join events.
     let _ = manager.drain_events("warn-ctx").await;
@@ -11920,7 +12118,10 @@ async fn test_warning_count_trigger_fires_behavioral() {
         owner_did: target.clone(),
         mls_key_package_bytes: None,
     };
-    manager.join_context(&handle, kp2, None).await.unwrap();
+    manager
+        .join_context(&handle, kp2, None, None)
+        .await
+        .unwrap();
     let _ = manager.drain_events("warn-ctx").await;
 
     // Second governance action against target — threshold met.
@@ -11974,7 +12175,7 @@ async fn test_participation_actions_against_populated() {
     let mut params = governance_params();
     params.consequence_rules = vec![];
     let handle = manager
-        .create_context("part-act-ctx".into(), params, admin.clone())
+        .create_context("part-act-ctx".into(), params, admin.clone(), None)
         .await
         .unwrap();
 
@@ -11982,7 +12183,7 @@ async fn test_participation_actions_against_populated() {
         owner_did: target.clone(),
         mls_key_package_bytes: None,
     };
-    manager.join_context(&handle, kp, None).await.unwrap();
+    manager.join_context(&handle, kp, None, None).await.unwrap();
 
     // Execute a governance action against the target.
     let action = scp_protocol::context::governance::GovernanceAction::RemoveMember {
@@ -12033,7 +12234,7 @@ async fn event_log_entries_merge_buffer_and_history() {
 
     let params = governance_params();
     let _handle = manager
-        .create_context("merge-ctx".into(), params, "did:key:sender".into())
+        .create_context("merge-ctx".into(), params, "did:key:sender".into(), None)
         .await
         .unwrap();
 
@@ -12111,6 +12312,7 @@ async fn buffer_event_timestamp_bounds_m18() {
             "bounds-ctx".into(),
             governance_params(),
             "did:key:admin".into(),
+            None,
         )
         .await
         .unwrap();
@@ -12255,7 +12457,7 @@ async fn budget_not_deducted_on_transport_failure() {
         payee: DID::from("did:key:payee"),
     });
     let _handle = manager
-        .create_context("rollback-ctx".into(), params, "did:key:sender".into())
+        .create_context("rollback-ctx".into(), params, "did:key:sender".into(), None)
         .await
         .unwrap();
 
@@ -12343,7 +12545,7 @@ async fn eligibility_check_uses_context_manager_clock() {
 
     let params = governance_params();
     let handle = manager
-        .create_context("clock-ctx".into(), params, admin.clone())
+        .create_context("clock-ctx".into(), params, admin.clone(), None)
         .await
         .unwrap();
 
@@ -12352,7 +12554,7 @@ async fn eligibility_check_uses_context_manager_clock() {
         owner_did: "did:key:member".into(),
         mls_key_package_bytes: None,
     };
-    manager.join_context(&handle, kp, None).await.unwrap();
+    manager.join_context(&handle, kp, None, None).await.unwrap();
 
     // Execute a governance action — verifies clock is used without panicking.
     let action = scp_protocol::context::governance::GovernanceAction::RemoveMember {
@@ -12400,7 +12602,7 @@ async fn observable_metrics_time_of_day_populated() {
         payee: DID::from("did:key:payee"),
     });
     let _handle = manager
-        .create_context("tod-ctx".into(), params, "did:key:sender".into())
+        .create_context("tod-ctx".into(), params, "did:key:sender".into(), None)
         .await
         .unwrap();
 
@@ -12473,7 +12675,7 @@ async fn context_message_rate_from_aggregate_velocity() {
         payee: DID::from("did:key:payee"),
     });
     let _handle = manager
-        .create_context("cmr-ctx".into(), params, "did:key:sender".into())
+        .create_context("cmr-ctx".into(), params, "did:key:sender".into(), None)
         .await
         .unwrap();
 
@@ -12837,7 +13039,7 @@ async fn consequence_timer_fires_without_user_action() {
     }];
 
     let _handle = manager
-        .create_context("timer-conseq-ctx".into(), params, admin.clone())
+        .create_context("timer-conseq-ctx".into(), params, admin.clone(), None)
         .await
         .unwrap();
 
@@ -12920,7 +13122,7 @@ async fn consequence_timer_respects_cooldown() {
     }];
 
     let _handle = manager
-        .create_context("cooldown-timer-ctx".into(), params, admin.clone())
+        .create_context("cooldown-timer-ctx".into(), params, admin.clone(), None)
         .await
         .unwrap();
 
@@ -12993,7 +13195,7 @@ async fn consequence_timer_noop_without_rules() {
     // No consequence rules — default.
 
     let _handle = manager
-        .create_context("no-rules-ctx".into(), params, admin.clone())
+        .create_context("no-rules-ctx".into(), params, admin.clone(), None)
         .await
         .unwrap();
 
@@ -13195,7 +13397,7 @@ async fn test_fabricated_spending_ucan_rejected() {
         payee: DID::from("did:dht:z6MkPayee"),
     });
     let handle = manager
-        .create_context("fab-ucan-ctx".into(), params, "did:key:sender".into())
+        .create_context("fab-ucan-ctx".into(), params, "did:key:sender".into(), None)
         .await
         .unwrap();
 
@@ -13303,7 +13505,7 @@ async fn c1_paid_context(name: &str, sender_did: &DID) -> (ContextManager, Conte
     });
 
     let handle = manager
-        .create_context(name.to_owned(), params, sender_did.clone())
+        .create_context(name.to_owned(), params, sender_did.clone(), None)
         .await
         .unwrap();
 
@@ -13679,7 +13881,7 @@ async fn test_capability_failure_no_budget_leak() {
         payee: DID::from("did:dht:z6MkPayee"),
     });
     let handle = manager
-        .create_context("cap-leak-ctx".into(), params, "did:key:admin".into())
+        .create_context("cap-leak-ctx".into(), params, "did:key:admin".into(), None)
         .await
         .unwrap();
 
@@ -13777,7 +13979,7 @@ async fn test_capture_failure_budget_retained() {
         payee: DID::from("did:dht:z6MkPayee"),
     });
     let handle = manager
-        .create_context("capture-ctx".into(), params, "did:key:sender".into())
+        .create_context("capture-ctx".into(), params, "did:key:sender".into(), None)
         .await
         .unwrap();
     {
@@ -13854,7 +14056,12 @@ async fn spending_ucan_nonce_replay_rejected() {
         payee: DID::from("did:key:payee"),
     });
     let _handle = manager
-        .create_context("nonce-replay-ctx".into(), params, "did:key:sender".into())
+        .create_context(
+            "nonce-replay-ctx".into(),
+            params,
+            "did:key:sender".into(),
+            None,
+        )
         .await
         .unwrap();
 
@@ -13962,7 +14169,7 @@ async fn test_sender_key_failure_still_removes_from_mls() {
 
     let params = governance_params();
     let handle = manager
-        .create_context("sk-fail-ctx".into(), params, admin.clone())
+        .create_context("sk-fail-ctx".into(), params, admin.clone(), None)
         .await
         .unwrap();
 
@@ -13970,7 +14177,7 @@ async fn test_sender_key_failure_still_removes_from_mls() {
         owner_did: alice.clone(),
         mls_key_package_bytes: None,
     };
-    manager.join_context(&handle, kp, None).await.unwrap();
+    manager.join_context(&handle, kp, None, None).await.unwrap();
     call_order.lock().unwrap().clear();
 
     // Remove Alice — sender key fails but MLS succeeds.
@@ -14023,7 +14230,7 @@ async fn test_consequence_failure_escalates() {
         window: Duration::from_hours(1),
     }];
     let _handle = manager
-        .create_context("esc-ctx".into(), params, "did:key:sender".into())
+        .create_context("esc-ctx".into(), params, "did:key:sender".into(), None)
         .await
         .unwrap();
 
@@ -14161,7 +14368,7 @@ async fn test_velocity_includes_current_message() {
         payee: DID::from("did:dht:z6MkPayee"),
     });
     let handle = manager
-        .create_context("vel-msg-ctx2".into(), params, "did:key:sender".into())
+        .create_context("vel-msg-ctx2".into(), params, "did:key:sender".into(), None)
         .await
         .unwrap();
     {
@@ -14263,12 +14470,12 @@ async fn test_member_reset_rotates_sender_keys() {
     ];
 
     let handle = manager
-        .create_context("reset-sk-ctx".into(), params, alice.clone())
+        .create_context("reset-sk-ctx".into(), params, alice.clone(), None)
         .await
         .unwrap();
     let context_id = handle.context_id().to_owned();
     manager
-        .join_context(&handle, KeyPackage::mock(bob.clone()), None)
+        .join_context(&handle, KeyPackage::mock(bob.clone()), None, None)
         .await
         .unwrap();
 
@@ -14328,6 +14535,7 @@ async fn test_governance_close_decays_participation() {
             "decay-close-ctx".into(),
             ContextParams::default(),
             alice.clone(),
+            None,
         )
         .await
         .unwrap();
@@ -14496,7 +14704,12 @@ async fn h17_setup_alice_and_bob(
         ..ContextParams::default()
     };
     let alice_handle = alice_manager
-        .create_context(context_id.to_owned(), alice_params, alice_did_str.into())
+        .create_context(
+            context_id.to_owned(),
+            alice_params,
+            alice_did_str.into(),
+            None,
+        )
         .await
         .unwrap();
 
@@ -14532,7 +14745,7 @@ async fn h17_setup_alice_and_bob(
         ..ContextParams::default()
     };
     let _bob_handle = bob_manager
-        .create_context(context_id.to_owned(), bob_params, bob_did_str.into())
+        .create_context(context_id.to_owned(), bob_params, bob_did_str.into(), None)
         .await
         .unwrap();
 
@@ -14917,12 +15130,12 @@ async fn execute_revoke_write_rotates_sender_key() {
     };
 
     let handle = manager
-        .create_context("h7-write-ctx".into(), params, alice.clone())
+        .create_context("h7-write-ctx".into(), params, alice.clone(), None)
         .await
         .unwrap();
     let context_id = handle.context_id().to_owned();
     manager
-        .join_context(&handle, KeyPackage::mock(bob.clone()), None)
+        .join_context(&handle, KeyPackage::mock(bob.clone()), None, None)
         .await
         .unwrap();
 
@@ -14982,12 +15195,12 @@ async fn execute_revoke_both_rotates_sender_key() {
     };
 
     let handle = manager
-        .create_context("h7-both-ctx".into(), params, alice.clone())
+        .create_context("h7-both-ctx".into(), params, alice.clone(), None)
         .await
         .unwrap();
     let context_id = handle.context_id().to_owned();
     manager
-        .join_context(&handle, KeyPackage::mock(bob.clone()), None)
+        .join_context(&handle, KeyPackage::mock(bob.clone()), None, None)
         .await
         .unwrap();
 
@@ -15047,12 +15260,12 @@ async fn execute_revoke_read_does_not_rotate_sender_key() {
     };
 
     let handle = manager
-        .create_context("h7-read-ctx".into(), params, alice.clone())
+        .create_context("h7-read-ctx".into(), params, alice.clone(), None)
         .await
         .unwrap();
     let context_id = handle.context_id().to_owned();
     manager
-        .join_context(&handle, KeyPackage::mock(bob.clone()), None)
+        .join_context(&handle, KeyPackage::mock(bob.clone()), None, None)
         .await
         .unwrap();
 
@@ -15114,12 +15327,12 @@ async fn execute_revoke_rotation_failure_still_completes() {
     };
 
     let handle = manager
-        .create_context("h7-fail-ctx".into(), params, alice.clone())
+        .create_context("h7-fail-ctx".into(), params, alice.clone(), None)
         .await
         .unwrap();
     let context_id = handle.context_id().to_owned();
     manager
-        .join_context(&handle, KeyPackage::mock(bob.clone()), None)
+        .join_context(&handle, KeyPackage::mock(bob.clone()), None, None)
         .await
         .unwrap();
 
@@ -15170,6 +15383,7 @@ async fn test_decay_participation_clears_velocity_tracker() {
             "decay-vt-ctx".into(),
             ContextParams::default(),
             alice.clone(),
+            None,
         )
         .await
         .unwrap();
@@ -15211,7 +15425,12 @@ async fn test_evict_stale_entries_removes_non_members() {
 
     let alice = DID::from("did:dht:z6MkAlice");
     let handle = manager
-        .create_context("evict-ctx".into(), ContextParams::default(), alice.clone())
+        .create_context(
+            "evict-ctx".into(),
+            ContextParams::default(),
+            alice.clone(),
+            None,
+        )
         .await
         .unwrap();
     let context_id = handle.context_id().to_owned();
@@ -15358,7 +15577,7 @@ async fn earned_capacity_limits_governance_proposals() {
     params.sybil_policy = Some(ContextSybilPolicy::casual());
 
     let _handle = manager
-        .create_context("capacity-ctx".into(), params, admin.clone())
+        .create_context("capacity-ctx".into(), params, admin.clone(), None)
         .await
         .unwrap();
 
@@ -15419,7 +15638,7 @@ async fn no_sybil_policy_allows_unlimited_proposals() {
     // No sybil_policy (default).
     let params = governance_params();
     let _handle = manager
-        .create_context("no-sybil-ctx".into(), params, admin.clone())
+        .create_context("no-sybil-ctx".into(), params, admin.clone(), None)
         .await
         .unwrap();
 
@@ -15473,7 +15692,7 @@ async fn earned_capacity_evicts_stale_timestamps() {
     params.sybil_policy = Some(ContextSybilPolicy::casual());
 
     let _handle = manager
-        .create_context("evict-ctx".into(), params, admin.clone())
+        .create_context("evict-ctx".into(), params, admin.clone(), None)
         .await
         .unwrap();
 
@@ -15582,7 +15801,7 @@ async fn revoke_access_event_carries_target_did_payload() {
     params.consequence_rules = vec![];
 
     let handle = manager
-        .create_context("rev-payload-ctx".into(), params, admin.clone())
+        .create_context("rev-payload-ctx".into(), params, admin.clone(), None)
         .await
         .unwrap();
 
@@ -15591,7 +15810,7 @@ async fn revoke_access_event_carries_target_did_payload() {
         owner_did: target.clone(),
         mls_key_package_bytes: None,
     };
-    manager.join_context(&handle, kp, None).await.unwrap();
+    manager.join_context(&handle, kp, None, None).await.unwrap();
 
     // Propose + auto-approve (SingleAdmin) a RevokeAccess governance action.
     let action = scp_protocol::context::governance::GovernanceAction::RevokeAccess {
@@ -15650,7 +15869,7 @@ async fn consequence_evaluation_caps_buffer_events() {
         ..ContextParams::default()
     };
     manager
-        .create_context("cap-buf-ctx".into(), params, creator.clone())
+        .create_context("cap-buf-ctx".into(), params, creator.clone(), None)
         .await
         .unwrap();
 
@@ -16037,6 +16256,7 @@ async fn h2_execute_change_role_works_when_creator_demoted() {
             "h2-change-role-ctx".into(),
             params,
             "did:key:creator".into(),
+            None,
         )
         .await
         .unwrap();
@@ -16139,7 +16359,12 @@ async fn h2_execute_add_member_works_when_creator_demoted() {
     );
     let params = governance_params();
     let _handle = manager
-        .create_context("h2-add-member-ctx".into(), params, "did:key:creator".into())
+        .create_context(
+            "h2-add-member-ctx".into(),
+            params,
+            "did:key:creator".into(),
+            None,
+        )
         .await
         .unwrap();
 
@@ -16231,6 +16456,7 @@ async fn h2_execute_change_role_updates_tokens_correctly() {
             "h2-change-tokens-ctx".into(),
             params,
             "did:key:creator".into(),
+            None,
         )
         .await
         .unwrap();
@@ -16406,7 +16632,7 @@ async fn h10_setup_with_test_clock(
 
     let params = governance_params();
     let handle = manager
-        .create_context(context_id.into(), params, "did:key:admin".into())
+        .create_context(context_id.into(), params, "did:key:admin".into(), None)
         .await
         .unwrap();
 
@@ -16988,7 +17214,7 @@ async fn suspend_all_consequence_preserves_mls_membership() {
     }];
 
     let handle = manager
-        .create_context("h20a-ctx".into(), params, admin.clone())
+        .create_context("h20a-ctx".into(), params, admin.clone(), None)
         .await
         .unwrap();
 
@@ -16998,7 +17224,10 @@ async fn suspend_all_consequence_preserves_mls_membership() {
     // this, `suspend_all` would have nothing to copy into the suspended
     // set and the assertions would be vacuous.
     let alice_kp = scp_protocol::context::membership::KeyPackage::mock(alice.clone());
-    manager.join_context(&handle, alice_kp, None).await.unwrap();
+    manager
+        .join_context(&handle, alice_kp, None, None)
+        .await
+        .unwrap();
 
     // Snapshot Alice's pre-condition state — she must be in membership,
     // hold the role-granted caps, and have a sender-key store entry.
@@ -17223,12 +17452,15 @@ async fn suspend_capability_consequence_preserves_mls_membership() {
     }];
 
     let handle = manager
-        .create_context("h20b-ctx".into(), params, admin.clone())
+        .create_context("h20b-ctx".into(), params, admin.clone(), None)
         .await
         .unwrap();
 
     let alice_kp = scp_protocol::context::membership::KeyPackage::mock(alice.clone());
-    manager.join_context(&handle, alice_kp, None).await.unwrap();
+    manager
+        .join_context(&handle, alice_kp, None, None)
+        .await
+        .unwrap();
 
     // Pre-flight: Alice has both MessagesRead and MessagesWrite via the
     // member role.
@@ -17397,12 +17629,15 @@ async fn restore_access_after_suspend_all_regrants_capabilities() {
     let params = governance_params();
 
     let handle = manager
-        .create_context("h20c-ctx".into(), params, admin.clone())
+        .create_context("h20c-ctx".into(), params, admin.clone(), None)
         .await
         .unwrap();
 
     let alice_kp = scp_protocol::context::membership::KeyPackage::mock(alice.clone());
-    manager.join_context(&handle, alice_kp, None).await.unwrap();
+    manager
+        .join_context(&handle, alice_kp, None, None)
+        .await
+        .unwrap();
 
     // Snapshot Alice's role-granted capability set BEFORE suspension so
     // we can compare it after RestoreAccess.
@@ -17612,7 +17847,12 @@ async fn consequence_enforced_appended_to_durable_event_log() {
     let mut params = governance_params();
     params.economic_policy = None;
     let _handle = manager
-        .create_context("h4-enforce-ctx".into(), params, "did:key:admin".into())
+        .create_context(
+            "h4-enforce-ctx".into(),
+            params,
+            "did:key:admin".into(),
+            None,
+        )
         .await
         .unwrap();
 
@@ -17750,7 +17990,7 @@ async fn consequence_escalation_appended_with_distinct_event_type() {
 
     let params = governance_params();
     let _handle = manager
-        .create_context("h4-escal-ctx".into(), params, "did:key:sender".into())
+        .create_context("h4-escal-ctx".into(), params, "did:key:sender".into(), None)
         .await
         .unwrap();
 
@@ -17878,7 +18118,7 @@ async fn consequence_events_visible_to_subsequent_rule_evaluation() {
 
     let params = governance_params();
     let _handle = manager
-        .create_context("h4-recur-ctx".into(), params, "did:key:alice".into())
+        .create_context("h4-recur-ctx".into(), params, "did:key:alice".into(), None)
         .await
         .unwrap();
 
@@ -18201,7 +18441,7 @@ async fn consequence_rule_with_empty_rules_no_durable_append() {
     let mut params = governance_params();
     params.consequence_rules = vec![];
     let _handle = manager
-        .create_context("h4-empty-ctx".into(), params, "did:key:admin".into())
+        .create_context("h4-empty-ctx".into(), params, "did:key:admin".into(), None)
         .await
         .unwrap();
 

--- a/crates/scp-runtime/src/context/manager/tests/governance.rs
+++ b/crates/scp-runtime/src/context/manager/tests/governance.rs
@@ -657,6 +657,8 @@ fn governance_snapshot_serde_roundtrip() {
         checkpoint_events_since: 0,
         checkpoint_last_time_secs: 0,
         generation: 0,
+        local_pseudonym: None,
+        pseudonym_registry: std::collections::HashMap::new(),
     };
 
     let json = serde_json::to_string(&snapshot).expect("serialize");
@@ -4256,7 +4258,7 @@ async fn setup_budget_context(ctx_id: &str) -> (ContextManager, DID, DID) {
 /// Verifies that `ApproveSpend` grants budget and additive grants accumulate.
 #[tokio::test]
 async fn approve_spend_grants_budget_to_member_tracker() {
-    let (manager, admin, spender) = setup_budget_context("budget-ctx").await;
+    let (manager, admin, spender) = Box::pin(setup_budget_context("budget-ctx")).await;
     let sk = signing_key_for_did(&admin);
 
     // No budget initially.
@@ -4365,7 +4367,7 @@ async fn approve_spend_rejects_non_member_spender() {
 /// and survives serde roundtrip.
 #[tokio::test]
 async fn budget_tracker_included_in_snapshot() {
-    let (manager, admin, spender) = setup_budget_context("snap-ctx").await;
+    let (manager, admin, spender) = Box::pin(setup_budget_context("snap-ctx")).await;
     let sk = signing_key_for_did(&admin);
     manager
         .propose_governance_action(
@@ -12651,6 +12653,8 @@ fn velocity_tracker_state_in_context_snapshot_roundtrip() {
         checkpoint_events_since: 0,
         checkpoint_last_time_secs: 0,
         generation: 0,
+        local_pseudonym: None,
+        pseudonym_registry: std::collections::HashMap::new(),
     };
 
     let json = serde_json::to_string(&snapshot).expect("serialize");
@@ -12737,6 +12741,8 @@ fn velocity_tracker_backward_compat_deserialization() {
         checkpoint_events_since: 0,
         checkpoint_last_time_secs: 0,
         generation: 0,
+        local_pseudonym: None,
+        pseudonym_registry: std::collections::HashMap::new(),
     };
 
     let mut json_value: serde_json::Value =

--- a/crates/scp-runtime/src/context/manager/tests/lifecycle.rs
+++ b/crates/scp-runtime/src/context/manager/tests/lifecycle.rs
@@ -775,6 +775,8 @@ async fn persist_drop_restore_roundtrip() {
         checkpoint_events_since: 0,
         checkpoint_last_time_secs: 0,
         generation: 0,
+        local_pseudonym: None,
+        pseudonym_registry: std::collections::HashMap::new(),
     };
 
     let bc_snapshot = test_broadcast_snapshot("persist-ctx-2");
@@ -902,6 +904,8 @@ async fn restore_preserves_executed_proposals() {
         checkpoint_events_since: 0,
         checkpoint_last_time_secs: 0,
         generation: 0,
+        local_pseudonym: None,
+        pseudonym_registry: std::collections::HashMap::new(),
     };
 
     persistence
@@ -1017,6 +1021,8 @@ async fn restore_respawns_ttl_timer() {
         checkpoint_events_since: 0,
         checkpoint_last_time_secs: 0,
         generation: 0,
+        local_pseudonym: None,
+        pseudonym_registry: std::collections::HashMap::new(),
     };
 
     persistence.persist_context("ttl-ctx", &snapshot).unwrap();
@@ -1111,6 +1117,8 @@ async fn restore_all_contexts_restores_persisted() {
             checkpoint_events_since: 0,
             checkpoint_last_time_secs: 0,
             generation: 0,
+            local_pseudonym: None,
+            pseudonym_registry: std::collections::HashMap::new(),
         };
         persistence.persist_context(ctx_name, &snapshot).unwrap();
     }
@@ -1203,6 +1211,8 @@ async fn restore_context_rejects_duplicate() {
         checkpoint_events_since: 0,
         checkpoint_last_time_secs: 0,
         generation: 0,
+        local_pseudonym: None,
+        pseudonym_registry: std::collections::HashMap::new(),
     };
 
     let bc_snapshot = test_broadcast_snapshot("dup-ctx");
@@ -1317,6 +1327,8 @@ async fn restore_context_sets_needs_reconnect_on_grace_inconsistency() {
         checkpoint_events_since: 0,
         checkpoint_last_time_secs: 0,
         generation: 0,
+        local_pseudonym: None,
+        pseudonym_registry: std::collections::HashMap::new(),
     };
 
     let bc_snapshot = test_broadcast_snapshot("grace-incon-ctx");
@@ -1438,6 +1450,8 @@ async fn restore_context_no_reconnect_when_grace_consistent() {
         checkpoint_events_since: 0,
         checkpoint_last_time_secs: 0,
         generation: 0,
+        local_pseudonym: None,
+        pseudonym_registry: std::collections::HashMap::new(),
     };
 
     let bc_snapshot = test_broadcast_snapshot("grace-ok-ctx");
@@ -1574,6 +1588,8 @@ async fn restore_preserves_spending_nonce_tracker_across_restart() {
         checkpoint_events_since: 0,
         checkpoint_last_time_secs: 0,
         generation: 0,
+        local_pseudonym: None,
+        pseudonym_registry: std::collections::HashMap::new(),
     };
 
     persistence
@@ -1711,6 +1727,8 @@ fn reconnect_test_snapshot(
         checkpoint_events_since: 0,
         checkpoint_last_time_secs: 0,
         generation: 0,
+        local_pseudonym: None,
+        pseudonym_registry: std::collections::HashMap::new(),
     }
 }
 
@@ -3113,6 +3131,8 @@ fn c3_test_snapshot(context_id: &str) -> super::ContextSnapshot {
         checkpoint_events_since: 0,
         checkpoint_last_time_secs: 0,
         generation: 0,
+        local_pseudonym: None,
+        pseudonym_registry: std::collections::HashMap::new(),
     }
 }
 
@@ -3676,6 +3696,8 @@ fn make_epoch_test_export(context_id: &str) -> crate::context::export_import::Co
         checkpoint_events_since: 0,
         checkpoint_last_time_secs: 0,
         generation: 0,
+        local_pseudonym: None,
+        pseudonym_registry: std::collections::HashMap::new(),
     };
 
     crate::context::export_import::ContextExport {

--- a/crates/scp-runtime/src/context/manager/tests/lifecycle.rs
+++ b/crates/scp-runtime/src/context/manager/tests/lifecycle.rs
@@ -127,7 +127,7 @@ async fn join_adds_member_to_mls_group_and_issues_ucan_tokens() {
 
     let kp = KeyPackage::mock("did:key:bob".into());
 
-    let result = manager.join_context(&handle, kp, None).await;
+    let result = manager.join_context(&handle, kp, None, None).await;
     assert!(result.is_ok());
 
     // Verify member was added.
@@ -159,7 +159,7 @@ async fn join_rejects_when_context_not_active() {
 
     let kp = KeyPackage::mock("did:key:bob".into());
 
-    let result = manager.join_context(&handle, kp, None).await;
+    let result = manager.join_context(&handle, kp, None, None).await;
     assert!(result.is_err());
     assert!(matches!(
         result.unwrap_err(),
@@ -200,7 +200,9 @@ async fn join_version_check_rejects_before_crypto_ops() {
         .unwrap();
 
     let kp = KeyPackage::mock("did:key:bob".into());
-    let result = manager.join_context(&ephemeral_handle, kp, None).await;
+    let result = manager
+        .join_context(&ephemeral_handle, kp, None, None)
+        .await;
 
     // Must fail with VersionIncompatible — the early check rejects
     // before any crypto operations (validate_key_package, add_member,
@@ -263,7 +265,7 @@ async fn leave_does_not_close_when_members_remain() {
 
     // Add a second member.
     let kp = KeyPackage::mock("did:key:bob".into());
-    manager.join_context(&handle, kp, None).await.unwrap();
+    manager.join_context(&handle, kp, None, None).await.unwrap();
     assert_eq!(manager.member_count("test-ctx").await, Some(2));
 
     // Remove bob (self-removal).
@@ -324,13 +326,13 @@ async fn setup_context_with_member_remove() -> (ContextManager, ContextHandle) {
     };
 
     let handle = manager
-        .create_context("auth-ctx".into(), params, "did:key:creator".into())
+        .create_context("auth-ctx".into(), params, "did:key:creator".into(), None)
         .await
         .unwrap();
 
     // Add an observer member.
     let kp = KeyPackage::mock("did:key:observer".into());
-    manager.join_context(&handle, kp, None).await.unwrap();
+    manager.join_context(&handle, kp, None, None).await.unwrap();
 
     // Reassign to observer role (joined members default to "member").
     {
@@ -452,7 +454,7 @@ async fn concurrent_joins_and_sends_do_not_corrupt_state() {
     };
 
     let handle = manager
-        .create_context("conc-ctx".into(), params, "did:key:creator".into())
+        .create_context("conc-ctx".into(), params, "did:key:creator".into(), None)
         .await
         .unwrap();
 
@@ -465,7 +467,7 @@ async fn concurrent_joins_and_sends_do_not_corrupt_state() {
         let h = std::sync::Arc::clone(&handle);
         join_handles.push(tokio::spawn(async move {
             let kp = KeyPackage::mock(format!("did:key:member-{i}").into());
-            mgr.join_context(&h, kp, None).await
+            mgr.join_context(&h, kp, None, None).await
         }));
     }
 
@@ -526,7 +528,7 @@ async fn panic_does_not_poison_mutex() {
     };
 
     let handle = manager
-        .create_context("panic-ctx".into(), params, "did:key:creator".into())
+        .create_context("panic-ctx".into(), params, "did:key:creator".into(), None)
         .await
         .unwrap();
 
@@ -552,7 +554,7 @@ async fn panic_does_not_poison_mutex() {
 
     // Further operations should succeed.
     let kp = KeyPackage::mock("did:key:after-panic".into());
-    let join_result = manager.join_context(&handle_clone, kp, None).await;
+    let join_result = manager.join_context(&handle_clone, kp, None, None).await;
     assert!(join_result.is_ok(), "join after panic should succeed");
     assert_eq!(manager.member_count("panic-ctx").await, Some(2));
 }
@@ -712,6 +714,7 @@ async fn persist_drop_restore_roundtrip() {
             "persist-ctx".into(),
             params.clone(),
             "did:key:creator".into(),
+            None,
         )
         .await
         .unwrap();
@@ -1991,7 +1994,7 @@ async fn create_context_rejects_incompatible_min_protocol_version() {
         ..ContextParams::default()
     };
     let result = manager
-        .create_context("ver-reject".into(), params, "did:key:creator".into())
+        .create_context("ver-reject".into(), params, "did:key:creator".into(), None)
         .await;
     assert!(
         result.is_err(),
@@ -2017,7 +2020,7 @@ async fn create_context_accepts_compatible_min_protocol_version() {
         ..ContextParams::default()
     };
     let result = manager
-        .create_context("ver-accept".into(), params, "did:key:creator".into())
+        .create_context("ver-accept".into(), params, "did:key:creator".into(), None)
         .await;
     assert!(
         result.is_ok(),
@@ -2038,7 +2041,7 @@ async fn create_context_accepts_none_min_protocol_version() {
         ..ContextParams::default()
     };
     let result = manager
-        .create_context("ver-none".into(), params, "did:key:creator".into())
+        .create_context("ver-none".into(), params, "did:key:creator".into(), None)
         .await;
     assert!(
         result.is_ok(),
@@ -2643,7 +2646,7 @@ async fn auto_accept_blocked_by_economics_rejects_join() {
         payee: DID::from("did:key:payee"),
     });
     let handle = manager
-        .create_context("paid-join-ctx".into(), params, "did:key:admin".into())
+        .create_context("paid-join-ctx".into(), params, "did:key:admin".into(), None)
         .await
         .unwrap();
 
@@ -2651,7 +2654,7 @@ async fn auto_accept_blocked_by_economics_rejects_join() {
         owner_did: DID::from("did:key:joiner"),
         mls_key_package_bytes: None,
     };
-    let result = manager.join_context(&handle, kp, None).await;
+    let result = manager.join_context(&handle, kp, None, None).await;
     assert!(
         result.is_err(),
         "join should be blocked for paid context without explicit acceptance"
@@ -2677,7 +2680,7 @@ async fn sybil_reject_insufficient_signals() {
 
     let params = ContextParams::default();
     let _handle = manager
-        .create_context("sybil-ctx".into(), params, "did:key:admin".into())
+        .create_context("sybil-ctx".into(), params, "did:key:admin".into(), None)
         .await
         .unwrap();
 
@@ -2727,7 +2730,12 @@ async fn budget_exceeded_on_join_rejects() {
         payee: DID::from("did:key:payee"),
     });
     let handle = manager
-        .create_context("budget-join-ctx".into(), params, "did:key:admin".into())
+        .create_context(
+            "budget-join-ctx".into(),
+            params,
+            "did:key:admin".into(),
+            None,
+        )
         .await
         .unwrap();
 
@@ -2735,7 +2743,7 @@ async fn budget_exceeded_on_join_rejects() {
         owner_did: DID::from("did:key:joiner"),
         mls_key_package_bytes: None,
     };
-    let result = manager.join_context(&handle, kp, None).await;
+    let result = manager.join_context(&handle, kp, None, None).await;
     assert!(
         result.is_err(),
         "join should fail: paid context auto_accept blocked"
@@ -2785,7 +2793,7 @@ async fn test_spawn_ttl_timer_decays_governance_on_expiry() {
 
     let admin: DID = "did:key:h8-admin".into();
     let handle = manager
-        .create_context("h8-ttl-decay-ctx".into(), params, admin.clone())
+        .create_context("h8-ttl-decay-ctx".into(), params, admin.clone(), None)
         .await
         .unwrap();
     let context_id = handle.context_id().to_owned();
@@ -2893,7 +2901,7 @@ async fn test_spawn_ttl_timer_cancels_governance_timeout_task() {
 
     let admin: DID = "did:key:h8-cancel-admin".into();
     let handle = manager
-        .create_context("h8-ttl-cancel-ctx".into(), params, admin)
+        .create_context("h8-ttl-cancel-ctx".into(), params, admin, None)
         .await
         .unwrap();
     let context_id = handle.context_id().to_owned();
@@ -2963,7 +2971,7 @@ async fn capture_join_payment_failure_appends_event_log_entry() {
         ..ContextParams::default()
     };
     manager
-        .create_context("h19-join-ctx".into(), params, "did:key:admin".into())
+        .create_context("h19-join-ctx".into(), params, "did:key:admin".into(), None)
         .await
         .unwrap();
 
@@ -3752,6 +3760,7 @@ async fn import_context_rejects_epoch_floor_regression() {
             ctx_id.to_owned(),
             ContextParams::default(),
             DID::from("did:key:test-creator"),
+            None,
         )
         .await
         .expect("create_context should succeed");
@@ -3812,6 +3821,7 @@ async fn import_context_accepts_epoch_advance_within_ceiling() {
             ctx_id.to_owned(),
             ContextParams::default(),
             DID::from("did:key:test-creator"),
+            None,
         )
         .await
         .expect("create_context should succeed");
@@ -3864,6 +3874,7 @@ async fn import_context_rejects_epoch_advance_beyond_ceiling() {
             ctx_id.to_owned(),
             ContextParams::default(),
             DID::from("did:key:test-creator"),
+            None,
         )
         .await
         .expect("create_context should succeed");

--- a/crates/scp-runtime/src/context/manager/tests/messaging.rs
+++ b/crates/scp-runtime/src/context/manager/tests/messaging.rs
@@ -4341,3 +4341,176 @@ async fn tool_invoke_happy_path_with_valid_spending_ucan() {
         "happy-path invoke must deduct at least per_tool_invoke=10: before={before} after={after}"
     );
 }
+
+// ---------------------------------------------------------------------------
+// §9.10.4 Pseudonym Routing Tests
+// ---------------------------------------------------------------------------
+
+/// Verifies that creating a context with a pseudonym stores it in `PerContextState`.
+#[tokio::test]
+async fn create_context_with_pseudonym_stores_in_state() {
+    let manager = ContextManager::new(
+        Box::new(MockCrypto::default()),
+        Box::new(MockTransport::connected()),
+        Box::new(MockEventLog::default()),
+        noop_key_resolver(),
+    );
+    let pseudonym: [u8; 32] = [42u8; 32];
+
+    let _handle = manager
+        .create_context_with_pseudonym(
+            "pseudonym-ctx-1".into(),
+            scp_protocol::context::ContextParams::default(),
+            "did:key:creator".into(),
+            Some(pseudonym),
+        )
+        .await
+        .expect("create_context_with_pseudonym should succeed");
+
+    // Verify the pseudonym is stored.
+    let stored = manager.local_pseudonym("pseudonym-ctx-1").unwrap();
+    assert_eq!(
+        stored,
+        Some(pseudonym),
+        "pseudonym must be stored in context state"
+    );
+}
+
+/// Verifies that creating a context without a pseudonym stores None.
+#[tokio::test]
+async fn create_context_without_pseudonym_stores_none() {
+    let manager = ContextManager::new(
+        Box::new(MockCrypto::default()),
+        Box::new(MockTransport::connected()),
+        Box::new(MockEventLog::default()),
+        noop_key_resolver(),
+    );
+
+    let _handle = manager
+        .create_context(
+            "no-pseudonym-ctx".into(),
+            scp_protocol::context::ContextParams::default(),
+            "did:key:creator".into(),
+        )
+        .await
+        .expect("create_context should succeed");
+
+    let stored = manager.local_pseudonym("no-pseudonym-ctx").unwrap();
+    assert_eq!(stored, None, "pseudonym must be None when not provided");
+}
+
+/// Verifies that `PseudonymAnnouncement` deserialization round-trips correctly.
+#[test]
+fn pseudonym_announcement_roundtrip() {
+    use super::super::{PSEUDONYM_ANNOUNCEMENT_TAG, PseudonymAnnouncement};
+
+    let announcement = PseudonymAnnouncement {
+        tag: PSEUDONYM_ANNOUNCEMENT_TAG.to_owned(),
+        member_did: "did:key:alice".to_owned(),
+        pseudonym: [7u8; 32],
+    };
+
+    let bytes = rmp_serde::to_vec_named(&announcement).expect("serialize");
+    let decoded: PseudonymAnnouncement = rmp_serde::from_slice(&bytes).expect("deserialize");
+
+    assert_eq!(decoded.tag, PSEUDONYM_ANNOUNCEMENT_TAG);
+    assert_eq!(decoded.member_did, "did:key:alice");
+    assert_eq!(decoded.pseudonym, [7u8; 32]);
+}
+
+/// Verifies that `broadcast_routing_id` uses plain SHA-256 (no domain separator).
+#[test]
+fn broadcast_routing_id_uses_plain_sha256() {
+    let ctx_id = "broadcast-test-ctx";
+    let broadcast_rid = scp_protocol::context::broadcast_routing_id(ctx_id);
+    let raw_bytes = scp_protocol::context::context_id_bytes(ctx_id);
+    assert_eq!(
+        broadcast_rid, raw_bytes,
+        "broadcast routing ID must be plain SHA-256(context_id)"
+    );
+
+    // Must differ from encrypted routing ID.
+    let encrypted_rid = scp_protocol::context::context_routing_id(ctx_id);
+    assert_ne!(
+        broadcast_rid, encrypted_rid,
+        "broadcast and encrypted routing IDs must differ"
+    );
+}
+
+/// Verifies that `send_message` for encrypted contexts uses pseudonym fan-out
+/// when members have announced pseudonyms.
+#[tokio::test]
+async fn send_message_encrypted_uses_pseudonym_fanout() {
+    let transport = MockTransport::connected();
+    let routing_ids = transport.routing_ids_handle();
+
+    let manager = ContextManager::new(
+        Box::new(MockCrypto::default()),
+        Box::new(transport),
+        Box::new(MockEventLog::default()),
+        mock_key_resolver(),
+    );
+
+    let params = ContextParams {
+        ceiling: vec![
+            scp_protocol::context::params::Capability::new("messages:read"),
+            scp_protocol::context::params::Capability::new("messages:write"),
+        ],
+        ..ContextParams::default()
+    };
+
+    manager.register_local_did("did:key:alice".into()).await;
+
+    let handle = manager
+        .create_context("fanout-ctx".into(), params, "did:key:alice".into())
+        .await
+        .unwrap();
+
+    // Add Bob as a member.
+    {
+        let arc = manager.get_context_arc("fanout-ctx").unwrap();
+        let mut guard = arc.lock().await;
+        let ctx = &mut *guard;
+        ctx.membership
+            .add_member("did:key:bob".into(), "member".into(), vec![]);
+        ctx.role_state.members.insert("did:key:bob".to_owned());
+        let bob_access_key =
+            scp_protocol::crypto::access_keys::generate_access_key("fanout-ctx", "did:key:bob");
+        ctx.access
+            .access_key_store
+            .set("fanout-ctx", "did:key:bob", bob_access_key);
+
+        // Insert a pseudonym for Bob into the registry.
+        ctx.pseudonym_registry
+            .insert("did:key:bob".into(), [0xBBu8; 32]);
+    }
+
+    let alice_did: DID = "did:key:alice".into();
+    let alice_sk = signing_key_for_did(&alice_did);
+
+    // Send a message — should fan out to both Bob's pseudonym and shared routing ID.
+    manager
+        .send_message(&handle, &alice_did, b"hello", Some(&alice_sk), None, None)
+        .await
+        .expect("send should succeed");
+
+    // The transport should have received sends to multiple routing IDs.
+    let sent_rids = routing_ids.lock().unwrap();
+    assert!(
+        sent_rids.len() >= 2,
+        "expected at least 2 transport sends (pseudonym + shared), got {}",
+        sent_rids.len()
+    );
+
+    // Verify that the shared routing ID is among the sends.
+    let shared_rid = scp_protocol::context::context_routing_id("fanout-ctx");
+    let has_shared = sent_rids.contains(&shared_rid);
+    assert!(has_shared, "shared routing ID must be included in fan-out");
+
+    // Verify that Bob's pseudonym is among the sends.
+    let has_pseudonym = sent_rids.contains(&[0xBBu8; 32]);
+    assert!(
+        has_pseudonym,
+        "Bob's pseudonym routing ID must be included in fan-out"
+    );
+}

--- a/crates/scp-runtime/src/context/manager/tests/messaging.rs
+++ b/crates/scp-runtime/src/context/manager/tests/messaging.rs
@@ -4368,7 +4368,7 @@ async fn create_context_with_pseudonym_stores_in_state() {
         .expect("create_context_with_pseudonym should succeed");
 
     // Verify the pseudonym is stored.
-    let stored = manager.local_pseudonym("pseudonym-ctx-1").unwrap();
+    let stored = manager.local_pseudonym("pseudonym-ctx-1").await.unwrap();
     assert_eq!(
         stored,
         Some(pseudonym),
@@ -4395,7 +4395,7 @@ async fn create_context_without_pseudonym_stores_none() {
         .await
         .expect("create_context should succeed");
 
-    let stored = manager.local_pseudonym("no-pseudonym-ctx").unwrap();
+    let stored = manager.local_pseudonym("no-pseudonym-ctx").await.unwrap();
     assert_eq!(stored, None, "pseudonym must be None when not provided");
 }
 
@@ -4513,4 +4513,94 @@ async fn send_message_encrypted_uses_pseudonym_fanout() {
         has_pseudonym,
         "Bob's pseudonym routing ID must be included in fan-out"
     );
+}
+
+/// Verifies that a forged `PseudonymAnnouncement` where `member_did` does not
+/// match the MLS-authenticated sender is rejected with `PermissionDenied`.
+#[tokio::test]
+async fn forged_pseudonym_announcement_rejected() {
+    use super::super::{PSEUDONYM_ANNOUNCEMENT_TAG, PseudonymAnnouncement};
+
+    let manager = ContextManager::new(
+        Box::new(MockCrypto::default()),
+        Box::new(MockTransport::connected()),
+        Box::new(MockEventLog::default()),
+        noop_key_resolver(),
+    );
+
+    let params = governance_params();
+
+    manager.register_local_did("did:key:alice".into()).await;
+
+    let _handle = manager
+        .create_context("forge-ctx".into(), params, "did:key:alice".into())
+        .await
+        .unwrap();
+
+    // Add Bob as a member.
+    {
+        let arc = manager.get_context_arc("forge-ctx").unwrap();
+        let mut guard = arc.lock().await;
+        let ctx = &mut *guard;
+        ctx.membership
+            .add_member("did:key:bob".into(), "member".into(), vec![]);
+        ctx.role_state.members.insert("did:key:bob".to_owned());
+        // Grant Bob messages:write via admin-like role (default ceiling includes it).
+        let bob_did: DID = "did:key:bob".into();
+        let _ = scp_protocol::context::roles::system_assign_role(
+            &mut ctx.role_state,
+            &bob_did,
+            "member",
+            &scp_primitives::SystemClock,
+        );
+    }
+
+    let context_id_bytes = scp_protocol::context::context_id_bytes("forge-ctx");
+
+    // Build a forged announcement: Bob sends an announcement claiming to be Alice.
+    let forged = PseudonymAnnouncement {
+        tag: PSEUDONYM_ANNOUNCEMENT_TAG.to_owned(),
+        member_did: "did:key:alice".to_owned(), // <-- forged: claims to be Alice
+        pseudonym: [0xEEu8; 32],
+    };
+    let payload = rmp_serde::to_vec_named(&forged).unwrap();
+
+    let inner = minimal_inner_envelope("forge-ctx", "did:key:bob", 1);
+
+    // Deliver as if Bob sent this message (MLS-authenticated sender = Bob).
+    let result = manager
+        .deliver_message_and_drain_buffered(
+            "forge-ctx",
+            &context_id_bytes,
+            "did:key:bob", // MLS says this is Bob
+            &inner,
+            &payload,
+            false,
+        )
+        .await;
+
+    // Must be rejected with PermissionDenied.
+    match result {
+        Err(scp_protocol::context::ContextError::PermissionDenied(msg)) => {
+            assert!(
+                msg.contains("does not match sender"),
+                "error should mention sender mismatch: {msg}"
+            );
+        }
+        other => {
+            panic!(
+                "forged pseudonym announcement must be rejected with PermissionDenied, got: {other:?}"
+            );
+        }
+    }
+
+    // Verify the forged pseudonym was NOT stored in the registry.
+    {
+        let arc = manager.get_context_arc("forge-ctx").unwrap();
+        let guard = arc.lock().await;
+        assert!(
+            !guard.pseudonym_registry.contains_key("did:key:alice"),
+            "forged pseudonym must not be stored in registry"
+        );
+    }
 }

--- a/crates/scp-runtime/src/context/manager/tests/messaging.rs
+++ b/crates/scp-runtime/src/context/manager/tests/messaging.rs
@@ -150,7 +150,12 @@ async fn send_message_transport_failure_no_phantom_event() {
     };
 
     let handle = manager
-        .create_context("test-ctx-fail".into(), params, "did:key:creator".into())
+        .create_context(
+            "test-ctx-fail".into(),
+            params,
+            "did:key:creator".into(),
+            None,
+        )
         .await
         .unwrap();
 
@@ -382,7 +387,7 @@ async fn setup_two_member_verified_context() -> (
     manager.register_local_did("did:key:alice".into()).await;
 
     let handle = manager
-        .create_context("test-ctx".into(), params, "did:key:alice".into())
+        .create_context("test-ctx".into(), params, "did:key:alice".into(), None)
         .await
         .unwrap();
 
@@ -667,7 +672,7 @@ async fn revoked_member_cannot_decrypt_new_messages() {
         ..ContextParams::default()
     };
     let _bob_handle = bob_manager
-        .create_context("test-ctx".into(), bob_params, "did:key:bob".into())
+        .create_context("test-ctx".into(), bob_params, "did:key:bob".into(), None)
         .await
         .unwrap();
 
@@ -1328,7 +1333,12 @@ async fn send_message_produces_valid_outer_envelope() {
     };
 
     let handle = manager
-        .create_context("envelope-test-ctx".into(), params, "did:key:creator".into())
+        .create_context(
+            "envelope-test-ctx".into(),
+            params,
+            "did:key:creator".into(),
+            None,
+        )
         .await
         .unwrap();
 
@@ -1584,7 +1594,7 @@ async fn velocity_consequence_trigger_on_send() {
         window: Duration::from_hours(1),
     }];
     let _handle = manager
-        .create_context("vel-msg-ctx".into(), params, "did:key:admin".into())
+        .create_context("vel-msg-ctx".into(), params, "did:key:admin".into(), None)
         .await
         .unwrap();
 
@@ -1669,7 +1679,12 @@ async fn escalation_kicks_in_at_velocity_threshold_10() {
     let mut params = governance_params();
     params.economic_policy = Some(escalation_test_policy());
     let handle = manager
-        .create_context("escalation-ctx".into(), params, "did:key:sender".into())
+        .create_context(
+            "escalation-ctx".into(),
+            params,
+            "did:key:sender".into(),
+            None,
+        )
         .await
         .unwrap();
 
@@ -1787,7 +1802,12 @@ async fn tool_invoke_escalation_via_managed_wrapper() {
         .push(scp_protocol::context::params::Capability::ToolInvokeAll);
     params.economic_policy = Some(escalation_test_policy());
     let _handle = manager
-        .create_context("tool-esc-ctx".into(), params, "did:key:invoker".into())
+        .create_context(
+            "tool-esc-ctx".into(),
+            params,
+            "did:key:invoker".into(),
+            None,
+        )
         .await
         .unwrap();
 
@@ -1891,7 +1911,12 @@ async fn try_consume_hard_rate_limit_async_variant_is_safe_from_async_context() 
     );
     let alice: DID = "did:key:alice".into();
     let _handle = manager
-        .create_context("async-hrl-ctx".into(), governance_params(), alice.clone())
+        .create_context(
+            "async-hrl-ctx".into(),
+            governance_params(),
+            alice.clone(),
+            None,
+        )
         .await
         .unwrap();
 
@@ -1953,7 +1978,12 @@ fn any_context_helper_survives_current_thread_runtime() {
     let alice_for_setup = alice.clone();
     rt.block_on(async move {
         manager_for_setup
-            .create_context("ct-rt-ctx".into(), governance_params(), alice_for_setup)
+            .create_context(
+                "ct-rt-ctx".into(),
+                governance_params(),
+                alice_for_setup,
+                None,
+            )
             .await
             .expect("create_context must succeed");
     });
@@ -2008,7 +2038,7 @@ fn any_context_helper_survives_no_runtime() {
         let alice_setup = alice.clone();
         rt.block_on(async move {
             manager_setup
-                .create_context("no-rt-ctx".into(), governance_params(), alice_setup)
+                .create_context("no-rt-ctx".into(), governance_params(), alice_setup, None)
                 .await
                 .expect("create_context must succeed");
         });
@@ -2047,7 +2077,12 @@ async fn block_in_place_bridge_pattern_survives_mcp_sync_in_async_call() {
     );
     let alice: DID = "did:key:alice".into();
     let _handle = manager
-        .create_context("mcp-sync-ctx".into(), governance_params(), alice.clone())
+        .create_context(
+            "mcp-sync-ctx".into(),
+            governance_params(),
+            alice.clone(),
+            None,
+        )
         .await
         .unwrap();
 
@@ -2096,7 +2131,7 @@ async fn tool_invoke_respects_hard_rate_limit() {
         .push(scp_protocol::context::params::Capability::ToolInvokeAll);
     // Free context — the hard rate limit fires independent of cost.
     let _handle = manager
-        .create_context("tool-rl-ctx".into(), params, "did:key:spammer".into())
+        .create_context("tool-rl-ctx".into(), params, "did:key:spammer".into(), None)
         .await
         .unwrap();
 
@@ -2205,6 +2240,7 @@ async fn tool_invoke_failure_refunds_hard_rate_limit_token() {
             "tool-rl-refund-ctx".into(),
             params,
             "did:key:invoker".into(),
+            None,
         )
         .await
         .unwrap();
@@ -2541,6 +2577,7 @@ async fn tool_invoke_output_validation_failure_voids_escrow_and_refunds_budget()
             "h17-output-fail-ctx".into(),
             params,
             "did:key:invoker".into(),
+            None,
         )
         .await
         .unwrap();
@@ -2734,7 +2771,12 @@ async fn tool_invoke_happy_path_captures_escrow_and_deducts_budget() {
         .push(scp_protocol::context::params::Capability::ToolInvokeAll);
     params.economic_policy = Some(h17_priced_tool_policy());
     let _handle = manager
-        .create_context("h17-happy-ctx".into(), params, "did:key:invoker".into())
+        .create_context(
+            "h17-happy-ctx".into(),
+            params,
+            "did:key:invoker".into(),
+            None,
+        )
         .await
         .unwrap();
 
@@ -2856,7 +2898,12 @@ async fn join_context_records_velocity_for_joiner() {
 
     let params = governance_params();
     let handle = manager
-        .create_context("join-vel-ctx".into(), params, "did:key:creator".into())
+        .create_context(
+            "join-vel-ctx".into(),
+            params,
+            "did:key:creator".into(),
+            None,
+        )
         .await
         .unwrap();
 
@@ -2864,7 +2911,7 @@ async fn join_context_records_velocity_for_joiner() {
         owner_did: "did:key:joiner".into(),
         mls_key_package_bytes: None,
     };
-    manager.join_context(&handle, kp, None).await.unwrap();
+    manager.join_context(&handle, kp, None, None).await.unwrap();
 
     let velocity = {
         let arc = manager
@@ -2908,7 +2955,7 @@ async fn enforcement_failure_rolls_back_velocity_and_rate_limit() {
     let mut params = governance_params();
     params.economic_policy = Some(escalation_test_policy());
     let handle = manager
-        .create_context("rollback-ctx".into(), params, "did:key:sender".into())
+        .create_context("rollback-ctx".into(), params, "did:key:sender".into(), None)
         .await
         .unwrap();
 
@@ -3008,7 +3055,7 @@ async fn hard_rate_limit_rejects_burst_over_ten() {
     // independent of cost and should still fire.
     let params = governance_params();
     let handle = manager
-        .create_context("rate-ctx".into(), params, "did:key:spammer".into())
+        .create_context("rate-ctx".into(), params, "did:key:spammer".into(), None)
         .await
         .unwrap();
 
@@ -3077,7 +3124,7 @@ async fn governance_actions_stay_free_under_priced_policy() {
     let mut params = governance_params();
     params.economic_policy = Some(escalation_test_policy());
     let _handle = manager
-        .create_context("gov-free-ctx".into(), params, "did:key:admin".into())
+        .create_context("gov-free-ctx".into(), params, "did:key:admin".into(), None)
         .await
         .unwrap();
 
@@ -3348,7 +3395,12 @@ async fn capture_send_payment_success_no_failure_event() {
         ..ContextParams::default()
     };
     let handle = manager
-        .create_context("h19-success-ctx".into(), params, "did:key:sender".into())
+        .create_context(
+            "h19-success-ctx".into(),
+            params,
+            "did:key:sender".into(),
+            None,
+        )
         .await
         .unwrap();
 
@@ -3454,7 +3506,12 @@ async fn deliver_message_skips_velocity_for_local_sender() {
 
     let params = governance_params();
     manager
-        .create_context("vel-skip-ctx".into(), params, "did:key:local-sender".into())
+        .create_context(
+            "vel-skip-ctx".into(),
+            params,
+            "did:key:local-sender".into(),
+            None,
+        )
         .await
         .unwrap();
 
@@ -3613,7 +3670,7 @@ async fn setup_two_member_context_with(
     manager.register_local_did("did:key:alice".into()).await;
 
     let handle = manager
-        .create_context("test-ctx".into(), params, "did:key:alice".into())
+        .create_context("test-ctx".into(), params, "did:key:alice".into(), None)
         .await
         .unwrap();
 
@@ -3955,7 +4012,7 @@ async fn c1b_paid_tool_context(
     });
 
     let _handle = manager
-        .create_context(name.to_owned(), params, invoker.clone())
+        .create_context(name.to_owned(), params, invoker.clone(), None)
         .await
         .unwrap();
 
@@ -4358,14 +4415,14 @@ async fn create_context_with_pseudonym_stores_in_state() {
     let pseudonym: [u8; 32] = [42u8; 32];
 
     let _handle = manager
-        .create_context_with_pseudonym(
+        .create_context(
             "pseudonym-ctx-1".into(),
             scp_protocol::context::ContextParams::default(),
             "did:key:creator".into(),
             Some(pseudonym),
         )
         .await
-        .expect("create_context_with_pseudonym should succeed");
+        .expect("create_context should succeed");
 
     // Verify the pseudonym is stored.
     let stored = manager.local_pseudonym("pseudonym-ctx-1").await.unwrap();
@@ -4391,6 +4448,7 @@ async fn create_context_without_pseudonym_stores_none() {
             "no-pseudonym-ctx".into(),
             scp_protocol::context::ContextParams::default(),
             "did:key:creator".into(),
+            None,
         )
         .await
         .expect("create_context should succeed");
@@ -4462,7 +4520,7 @@ async fn send_message_encrypted_uses_pseudonym_fanout() {
     manager.register_local_did("did:key:alice".into()).await;
 
     let handle = manager
-        .create_context("fanout-ctx".into(), params, "did:key:alice".into())
+        .create_context("fanout-ctx".into(), params, "did:key:alice".into(), None)
         .await
         .unwrap();
 
@@ -4533,7 +4591,7 @@ async fn forged_pseudonym_announcement_rejected() {
     manager.register_local_did("did:key:alice".into()).await;
 
     let _handle = manager
-        .create_context("forge-ctx".into(), params, "did:key:alice".into())
+        .create_context("forge-ctx".into(), params, "did:key:alice".into(), None)
         .await
         .unwrap();
 

--- a/crates/scp-runtime/src/context/manager/tests/mod.rs
+++ b/crates/scp-runtime/src/context/manager/tests/mod.rs
@@ -1453,7 +1453,7 @@ pub(super) async fn setup_failing_capture_manager_with_context(
     };
 
     let handle = manager
-        .create_context(context_id.into(), params, creator_did.into())
+        .create_context(context_id.into(), params, creator_did.into(), None)
         .await
         .unwrap();
 
@@ -1497,7 +1497,7 @@ pub(super) async fn setup_active_context() -> (ContextManager, ContextHandle) {
     };
 
     let handle = manager
-        .create_context("test-ctx".into(), params, "did:key:creator".into())
+        .create_context("test-ctx".into(), params, "did:key:creator".into(), None)
         .await
         .unwrap();
 
@@ -1529,7 +1529,7 @@ pub(super) async fn setup_active_context_with_key_resolver() -> (ContextManager,
     };
 
     let handle = manager
-        .create_context("test-ctx".into(), params, "did:key:creator".into())
+        .create_context("test-ctx".into(), params, "did:key:creator".into(), None)
         .await
         .unwrap();
 
@@ -1642,7 +1642,12 @@ pub(super) async fn setup_broadcast_context_two_authors() -> (ContextManager, Co
     };
 
     let handle = manager
-        .create_context("broadcast-2auth-ctx".into(), params, "did:key:alice".into())
+        .create_context(
+            "broadcast-2auth-ctx".into(),
+            params,
+            "did:key:alice".into(),
+            None,
+        )
         .await
         .unwrap();
 
@@ -1692,7 +1697,12 @@ pub(super) async fn setup_broadcast_with_member_ban() -> (ContextManager, String
     };
 
     let _handle = manager
-        .create_context("broadcast-ban-ctx".into(), params, "did:key:alice".into())
+        .create_context(
+            "broadcast-ban-ctx".into(),
+            params,
+            "did:key:alice".into(),
+            None,
+        )
         .await
         .unwrap();
 
@@ -1752,7 +1762,7 @@ pub(super) async fn setup_encrypted_with_member_ban() -> (ContextManager, String
     };
 
     let _handle = manager
-        .create_context("enc-ban-ctx".into(), params, "did:key:alice".into())
+        .create_context("enc-ban-ctx".into(), params, "did:key:alice".into(), None)
         .await
         .unwrap();
 
@@ -1834,7 +1844,12 @@ pub(super) async fn setup_broadcast_context() -> (ContextManager, ContextHandle,
     };
 
     let handle = manager
-        .create_context("broadcast-ctx".into(), params, "did:key:author1".into())
+        .create_context(
+            "broadcast-ctx".into(),
+            params,
+            "did:key:author1".into(),
+            None,
+        )
         .await
         .unwrap();
 

--- a/crates/scp-runtime/src/context/manager/tests/queries.rs
+++ b/crates/scp-runtime/src/context/manager/tests/queries.rs
@@ -15,7 +15,7 @@ async fn member_list_queries() {
     // Add members.
     for name in &["alice", "bob", "charlie"] {
         let kp = KeyPackage::mock(format!("did:key:{name}").into());
-        manager.join_context(&handle, kp, None).await.unwrap();
+        manager.join_context(&handle, kp, None, None).await.unwrap();
     }
 
     assert_eq!(manager.member_count("test-ctx").await, Some(4));
@@ -47,7 +47,7 @@ async fn member_role_assignment() {
 
     // Add a member.
     let kp = KeyPackage::mock("did:key:alice".into());
-    manager.join_context(&handle, kp, None).await.unwrap();
+    manager.join_context(&handle, kp, None, None).await.unwrap();
 
     let role = manager.member_role("test-ctx", "did:key:alice").await;
     assert!(role.is_some());
@@ -414,7 +414,7 @@ async fn get_broadcast_key_for_local_author_returns_key_and_epoch() {
     };
 
     let _handle = manager
-        .create_context("bc-key-test".into(), params, creator_did.clone())
+        .create_context("bc-key-test".into(), params, creator_did.clone(), None)
         .await
         .unwrap();
 
@@ -448,7 +448,7 @@ async fn get_broadcast_key_for_local_author_rejects_non_local_did() {
     };
 
     let _handle = manager
-        .create_context("bc-key-test-2".into(), params, creator_did.clone())
+        .create_context("bc-key-test-2".into(), params, creator_did.clone(), None)
         .await
         .unwrap();
 
@@ -502,7 +502,7 @@ async fn get_broadcast_key_for_local_author_rejects_encrypted_context() {
     let params = ContextParams::default();
 
     let _handle = manager
-        .create_context("encrypted-ctx".into(), params, creator_did.clone())
+        .create_context("encrypted-ctx".into(), params, creator_did.clone(), None)
         .await
         .unwrap();
 

--- a/crates/scp-runtime/src/context/manager/tests/trust_recovery.rs
+++ b/crates/scp-runtime/src/context/manager/tests/trust_recovery.rs
@@ -25,7 +25,7 @@ async fn cac009_tier1_encrypted_block_unblock() {
         ..ContextParams::default()
     };
     let _handle = manager
-        .create_context("cac009-enc".into(), params, "did:key:alice".into())
+        .create_context("cac009-enc".into(), params, "did:key:alice".into(), None)
         .await
         .unwrap();
     for did in &["did:key:dave", "did:key:bob"] {
@@ -124,11 +124,21 @@ async fn cac009_tier2_global_block_multiple_contexts() {
         ..ContextParams::default()
     };
     let _h1 = manager
-        .create_context("cac009-g1".into(), make_params(), "did:key:alice".into())
+        .create_context(
+            "cac009-g1".into(),
+            make_params(),
+            "did:key:alice".into(),
+            None,
+        )
         .await
         .unwrap();
     let _h2 = manager
-        .create_context("cac009-g2".into(), make_params(), "did:key:alice".into())
+        .create_context(
+            "cac009-g2".into(),
+            make_params(),
+            "did:key:alice".into(),
+            None,
+        )
         .await
         .unwrap();
     for ctx_id in &["cac009-g1", "cac009-g2"] {
@@ -516,7 +526,7 @@ async fn cac010_threshold_revoke_read_access() {
         signers: vec![creator.clone()],
     };
     let _handle = manager
-        .create_context("cac010-thresh".into(), params, creator.clone())
+        .create_context("cac010-thresh".into(), params, creator.clone(), None)
         .await
         .unwrap();
     {
@@ -786,6 +796,7 @@ async fn test_recovery_advance_epoch_calls_crypto_provider() {
             "recovery-epoch-1".into(),
             ContextParams::default(),
             "did:key:creator".into(),
+            None,
         )
         .await
         .unwrap();
@@ -841,6 +852,7 @@ async fn test_recovery_advance_epoch_rollback_on_crypto_failure() {
             "recovery-fail-1".into(),
             ContextParams::default(),
             "did:key:creator".into(),
+            None,
         )
         .await
         .unwrap();
@@ -882,6 +894,7 @@ async fn test_recovery_advance_epoch_rejects_inactive_context() {
             "recovery-inactive-1".into(),
             ContextParams::default(),
             "did:key:creator".into(),
+            None,
         )
         .await
         .unwrap();

--- a/crates/scp-runtime/src/context/manager/ttl_close.rs
+++ b/crates/scp-runtime/src/context/manager/ttl_close.rs
@@ -122,6 +122,12 @@ impl ContextManager {
                 // Drop broadcast context state -- keys are zeroed by Zeroize.
                 ctx.broadcast_context = None;
 
+                // §9.10.4: clear pseudonym state on close. The local pseudonym
+                // is derived from secret key material; zeroing it prevents
+                // leaking the routing ID after context teardown.
+                ctx.local_pseudonym = None;
+                ctx.pseudonym_registry.clear();
+
                 // Participation decay: clear participation cache and cooldown
                 // state on context close (#1530).
                 ctx.governance.decay_participation();

--- a/crates/scp-runtime/src/context/providers/persistence.rs
+++ b/crates/scp-runtime/src/context/providers/persistence.rs
@@ -211,6 +211,8 @@ mod tests {
             checkpoint_events_since: 0,
             checkpoint_last_time_secs: 0,
             generation: 0,
+            local_pseudonym: None,
+            pseudonym_registry: std::collections::HashMap::new(),
         }
     }
 

--- a/crates/scp-runtime/src/identity/recovery.rs
+++ b/crates/scp-runtime/src/identity/recovery.rs
@@ -1985,7 +1985,7 @@ mod tests {
 
         // Create the context. This registers it in the manager.
         let handle = manager
-            .create_context(context_id.to_owned(), params, creator_did.clone())
+            .create_context(context_id.to_owned(), params, creator_did.clone(), None)
             .await
             .expect("failed to create test context");
 
@@ -1993,7 +1993,7 @@ mod tests {
         for member_did in additional_members {
             let kp = KeyPackage::mock((*member_did).clone());
             manager
-                .join_context(&handle, kp, None)
+                .join_context(&handle, kp, None, None)
                 .await
                 .expect("failed to join test member");
         }

--- a/crates/scp-runtime/src/store/context.rs
+++ b/crates/scp-runtime/src/store/context.rs
@@ -1762,6 +1762,8 @@ mod tests {
             checkpoint_events_since: 0,
             checkpoint_last_time_secs: 0,
             generation: 0,
+            local_pseudonym: None,
+            pseudonym_registry: std::collections::HashMap::new(),
         }
     }
 

--- a/crates/scp-runtime/tests/content_access_governance_integration.rs
+++ b/crates/scp-runtime/tests/content_access_governance_integration.rs
@@ -252,7 +252,7 @@ async fn setup_threshold_context_with_dave(ctx_id: &str) -> ContextManager {
         ..ContextParams::default()
     };
     let _handle = manager
-        .create_context(ctx_id.into(), params, alice())
+        .create_context(ctx_id.into(), params, alice(), None)
         .await
         .unwrap();
 
@@ -703,7 +703,7 @@ async fn revoked_member_can_still_participate_in_governance() {
         ..ContextParams::default()
     };
     let _handle = manager
-        .create_context(ctx_id.into(), params, alice())
+        .create_context(ctx_id.into(), params, alice(), None)
         .await
         .unwrap();
 
@@ -867,7 +867,7 @@ async fn single_admin_auto_executes_revoke_read_access() {
         ..ContextParams::default()
     };
     let _handle = manager
-        .create_context(ctx_id.into(), params, alice())
+        .create_context(ctx_id.into(), params, alice(), None)
         .await
         .unwrap();
 
@@ -936,7 +936,7 @@ async fn single_admin_auto_executes_revoke_write_access() {
         ..ContextParams::default()
     };
     let _handle = manager
-        .create_context(ctx_id.into(), params, alice())
+        .create_context(ctx_id.into(), params, alice(), None)
         .await
         .unwrap();
 
@@ -994,7 +994,7 @@ async fn single_admin_auto_executes_restore_read_access() {
         ..ContextParams::default()
     };
     let _handle = manager
-        .create_context(ctx_id.into(), params, alice())
+        .create_context(ctx_id.into(), params, alice(), None)
         .await
         .unwrap();
 
@@ -1064,7 +1064,7 @@ async fn single_admin_auto_executes_rotate_content_keys() {
         ..ContextParams::default()
     };
     let _handle = manager
-        .create_context(ctx_id.into(), params, alice())
+        .create_context(ctx_id.into(), params, alice(), None)
         .await
         .unwrap();
 
@@ -1107,7 +1107,7 @@ async fn unanimity_rotate_content_keys_requires_all_votes() {
         ..ContextParams::default()
     };
     let _handle = manager
-        .create_context(ctx_id.into(), params, alice())
+        .create_context(ctx_id.into(), params, alice(), None)
         .await
         .unwrap();
 
@@ -1177,7 +1177,7 @@ async fn unanimity_rotate_content_keys_rejected_by_single_vote() {
         ..ContextParams::default()
     };
     let _handle = manager
-        .create_context(ctx_id.into(), params, alice())
+        .create_context(ctx_id.into(), params, alice(), None)
         .await
         .unwrap();
 
@@ -1339,7 +1339,7 @@ async fn majority_revoke_write_access() {
         ..ContextParams::default()
     };
     let _handle = manager
-        .create_context(ctx_id.into(), params, alice())
+        .create_context(ctx_id.into(), params, alice(), None)
         .await
         .unwrap();
 

--- a/crates/scp-runtime/tests/content_access_integration.rs
+++ b/crates/scp-runtime/tests/content_access_integration.rs
@@ -795,7 +795,7 @@ async fn tier3_governance_revoke_write_access_broadcast() {
         ..ContextParams::default()
     };
     let _handle = manager
-        .create_context(ctx_id.into(), params.clone(), alice())
+        .create_context(ctx_id.into(), params.clone(), alice(), None)
         .await
         .unwrap();
 
@@ -1503,7 +1503,7 @@ async fn governance_tier_stacking_via_context_manager() {
         ..ContextParams::default()
     };
     let _handle = manager
-        .create_context(ctx_id.into(), params.clone(), alice())
+        .create_context(ctx_id.into(), params.clone(), alice(), None)
         .await
         .unwrap();
 

--- a/crates/scp-runtime/tests/governance_integration.rs
+++ b/crates/scp-runtime/tests/governance_integration.rs
@@ -255,7 +255,7 @@ async fn ac1_create_single_admin_context() {
         ..ContextParams::default()
     };
     let handle = manager
-        .create_context("ctx-single-admin".into(), params, alice())
+        .create_context("ctx-single-admin".into(), params, alice(), None)
         .await
         .unwrap();
     assert_eq!(handle.try_read_state().unwrap(), ContextState::Active);
@@ -273,7 +273,7 @@ async fn ac1_create_threshold_context() {
         ..ContextParams::default()
     };
     let handle = manager
-        .create_context("ctx-threshold".into(), params, alice())
+        .create_context("ctx-threshold".into(), params, alice(), None)
         .await
         .unwrap();
     assert_eq!(handle.try_read_state().unwrap(), ContextState::Active);
@@ -290,7 +290,7 @@ async fn ac1_create_majority_context() {
         ..ContextParams::default()
     };
     let handle = manager
-        .create_context("ctx-majority".into(), params, alice())
+        .create_context("ctx-majority".into(), params, alice(), None)
         .await
         .unwrap();
     assert_eq!(handle.try_read_state().unwrap(), ContextState::Active);
@@ -307,7 +307,7 @@ async fn ac1_create_unanimity_context() {
         ..ContextParams::default()
     };
     let handle = manager
-        .create_context("ctx-unanimity".into(), params, alice())
+        .create_context("ctx-unanimity".into(), params, alice(), None)
         .await
         .unwrap();
     assert_eq!(handle.try_read_state().unwrap(), ContextState::Active);
@@ -327,7 +327,7 @@ async fn ac2_single_admin_auto_approve_and_execute() {
         ..ContextParams::default()
     };
     let _handle = manager
-        .create_context(ctx_id.into(), params, alice())
+        .create_context(ctx_id.into(), params, alice(), None)
         .await
         .unwrap();
 
@@ -374,7 +374,7 @@ async fn ac2_single_admin_checked_returns_execution_result() {
         ..ContextParams::default()
     };
     let _handle = manager
-        .create_context(ctx_id.into(), params, alice())
+        .create_context(ctx_id.into(), params, alice(), None)
         .await
         .unwrap();
 
@@ -417,7 +417,7 @@ async fn ac3_threshold_propose_approve_execute() {
         ..ContextParams::default()
     };
     let _handle = manager
-        .create_context(ctx_id.into(), params, alice())
+        .create_context(ctx_id.into(), params, alice(), None)
         .await
         .unwrap();
 
@@ -481,7 +481,7 @@ async fn ac4_majority_propose_approve_execute() {
         ..ContextParams::default()
     };
     let _handle = manager
-        .create_context(ctx_id.into(), params, alice())
+        .create_context(ctx_id.into(), params, alice(), None)
         .await
         .unwrap();
 
@@ -530,7 +530,7 @@ async fn ac5_unanimity_all_approve_execute() {
         ..ContextParams::default()
     };
     let _handle = manager
-        .create_context(ctx_id.into(), params, alice())
+        .create_context(ctx_id.into(), params, alice(), None)
         .await
         .unwrap();
 
@@ -579,7 +579,7 @@ async fn ac6_rejected_proposal_not_executed_unanimity() {
         ..ContextParams::default()
     };
     let _handle = manager
-        .create_context(ctx_id.into(), params, alice())
+        .create_context(ctx_id.into(), params, alice(), None)
         .await
         .unwrap();
 
@@ -635,7 +635,7 @@ async fn ac6_rejected_threshold_proposal() {
         ..ContextParams::default()
     };
     let _handle = manager
-        .create_context(ctx_id.into(), params, alice())
+        .create_context(ctx_id.into(), params, alice(), None)
         .await
         .unwrap();
 
@@ -820,7 +820,7 @@ async fn ac8_vote_withdrawn_event_via_manager() {
         ..ContextParams::default()
     };
     let _handle = manager
-        .create_context(ctx_id.into(), params, alice())
+        .create_context(ctx_id.into(), params, alice(), None)
         .await
         .unwrap();
 
@@ -861,7 +861,7 @@ async fn ac9_non_admin_cannot_propose_in_single_admin() {
         ..ContextParams::default()
     };
     let _handle = manager
-        .create_context(ctx_id.into(), params, alice())
+        .create_context(ctx_id.into(), params, alice(), None)
         .await
         .unwrap();
 
@@ -896,7 +896,7 @@ async fn ac9_checked_propose_requires_capability() {
         ..ContextParams::default()
     };
     let _handle = manager
-        .create_context(ctx_id.into(), params, alice())
+        .create_context(ctx_id.into(), params, alice(), None)
         .await
         .unwrap();
 
@@ -932,7 +932,7 @@ async fn ac10_remove_member_action() {
         ..ContextParams::default()
     };
     let _handle = manager
-        .create_context(ctx_id.into(), params, alice())
+        .create_context(ctx_id.into(), params, alice(), None)
         .await
         .unwrap();
 
@@ -978,7 +978,7 @@ async fn ac10_change_role_action() {
         ..ContextParams::default()
     };
     let _handle = manager
-        .create_context(ctx_id.into(), params, alice())
+        .create_context(ctx_id.into(), params, alice(), None)
         .await
         .unwrap();
 
@@ -1008,7 +1008,7 @@ async fn ac10_close_context_action() {
         ..ContextParams::default()
     };
     let _handle = manager
-        .create_context(ctx_id.into(), params, alice())
+        .create_context(ctx_id.into(), params, alice(), None)
         .await
         .unwrap();
 
@@ -1040,7 +1040,7 @@ async fn ac10_add_signer_action() {
         ..ContextParams::default()
     };
     let _handle = manager
-        .create_context(ctx_id.into(), params, alice())
+        .create_context(ctx_id.into(), params, alice(), None)
         .await
         .unwrap();
 
@@ -1103,7 +1103,7 @@ async fn ac10_extend_ttl_action() {
         ..ContextParams::default()
     };
     let _handle = manager
-        .create_context(ctx_id.into(), params, alice())
+        .create_context(ctx_id.into(), params, alice(), None)
         .await
         .unwrap();
 
@@ -1133,7 +1133,7 @@ async fn ac10_revoke_write_access_action() {
         ..ContextParams::default()
     };
     let _handle = manager
-        .create_context(ctx_id.into(), params, alice())
+        .create_context(ctx_id.into(), params, alice(), None)
         .await
         .unwrap();
 
@@ -1178,7 +1178,7 @@ async fn ac10_restore_write_access_action() {
         ..ContextParams::default()
     };
     let _handle = manager
-        .create_context(ctx_id.into(), params, alice())
+        .create_context(ctx_id.into(), params, alice(), None)
         .await
         .unwrap();
 
@@ -1244,7 +1244,7 @@ async fn ac11_extend_ttl_requires_unanimity_in_threshold() {
         ..ContextParams::default()
     };
     let _handle = manager
-        .create_context(ctx_id.into(), params, alice())
+        .create_context(ctx_id.into(), params, alice(), None)
         .await
         .unwrap();
 
@@ -1308,7 +1308,7 @@ async fn ac12_promote_context_requires_unanimity_in_majority() {
         ..ContextParams::default()
     };
     let _handle = manager
-        .create_context(ctx_id.into(), params, alice())
+        .create_context(ctx_id.into(), params, alice(), None)
         .await
         .unwrap();
 
@@ -1810,7 +1810,7 @@ async fn list_proposals_returns_all_proposals() {
         ..ContextParams::default()
     };
     let _handle = manager
-        .create_context(ctx_id.into(), params, alice())
+        .create_context(ctx_id.into(), params, alice(), None)
         .await
         .unwrap();
 
@@ -1866,7 +1866,7 @@ async fn full_threshold_lifecycle_add_signer_then_change_role() {
         ..ContextParams::default()
     };
     let _handle = manager
-        .create_context(ctx_id.into(), params, alice())
+        .create_context(ctx_id.into(), params, alice(), None)
         .await
         .unwrap();
 
@@ -2077,7 +2077,7 @@ async fn multi_party_threshold_propose_approve_verify() {
         ..ContextParams::default()
     };
     let _handle = manager
-        .create_context(ctx_id.into(), params, alice())
+        .create_context(ctx_id.into(), params, alice(), None)
         .await
         .unwrap();
 

--- a/crates/scp-testing/src/fullstack/node.rs
+++ b/crates/scp-testing/src/fullstack/node.rs
@@ -161,7 +161,7 @@ impl FullStackNode {
     ) -> Result<ContextHandle, ContextCreationError> {
         let handle = self
             .manager
-            .create_context(context_id.to_owned(), params, self.did.clone())
+            .create_context(context_id.to_owned(), params, self.did.clone(), None)
             .await?;
 
         // Copy the creator's access key from ContextManager's PerContextState
@@ -196,7 +196,7 @@ impl FullStackNode {
         member_did: &str,
     ) -> Result<(), ContextError> {
         let kp = KeyPackage::mock(DID::from(member_did));
-        self.manager.join_context(handle, kp, None).await?;
+        self.manager.join_context(handle, kp, None, None).await?;
 
         // Deposit ALL existing members' access keys in the KeyExchange for
         // the joiner. This includes:

--- a/crates/scp-testing/tests/integration/e2e_context_manager.rs
+++ b/crates/scp-testing/tests/integration/e2e_context_manager.rs
@@ -433,7 +433,7 @@ async fn e2e_message_round_trip_encrypted() {
 
     // Step 1: Alice creates a context with governance policy (SingleAdmin).
     let handle = manager
-        .create_context(ctx_id.to_owned(), encrypted_params(), alice_did.clone())
+        .create_context(ctx_id.to_owned(), encrypted_params(), alice_did.clone(), None)
         .await
         .unwrap();
     assert_eq!(handle.state().await, ContextState::Active);
@@ -495,7 +495,7 @@ async fn e2e_governance_role_change_and_unauthorized_rejection() {
 
     // Step 1: Admin creates context.
     let handle = manager
-        .create_context(ctx_id.to_owned(), encrypted_params(), admin_did.clone())
+        .create_context(ctx_id.to_owned(), encrypted_params(), admin_did.clone(), None)
         .await
         .unwrap();
 
@@ -597,7 +597,7 @@ async fn e2e_broadcast_publish_subscribe() {
 
     // Step 1: Publisher creates broadcast context.
     let _handle = manager
-        .create_context(ctx_id.to_owned(), broadcast_params(), publisher_did.clone())
+        .create_context(ctx_id.to_owned(), broadcast_params(), publisher_did.clone(), None)
         .await
         .unwrap();
 
@@ -717,7 +717,7 @@ async fn e2e_persistence_drop_and_restore() {
         );
 
         let handle = manager
-            .create_context(ctx_id.to_owned(), encrypted_params(), admin_did.clone())
+            .create_context(ctx_id.to_owned(), encrypted_params(), admin_did.clone(), None)
             .await
             .unwrap();
         assert_eq!(handle.state().await, ContextState::Active);
@@ -894,7 +894,7 @@ async fn e2e_broadcast_persistence_drop_and_restore() {
         manager.register_local_did(publisher_did.clone()).await;
 
         let _handle = manager
-            .create_context(ctx_id.to_owned(), broadcast_params(), publisher_did.clone())
+            .create_context(ctx_id.to_owned(), broadcast_params(), publisher_did.clone(), None)
             .await
             .unwrap();
 
@@ -966,7 +966,7 @@ async fn e2e_governance_replay_protection() {
     let ctx_id = "e2e-gov-replay";
 
     let handle = manager
-        .create_context(ctx_id.to_owned(), encrypted_params(), admin_did.clone())
+        .create_context(ctx_id.to_owned(), encrypted_params(), admin_did.clone(), None)
         .await
         .unwrap();
 
@@ -1036,7 +1036,7 @@ async fn e2e_full_lifecycle_create_join_send_leave_close() {
 
     // Create context.
     let handle = manager
-        .create_context(ctx_id.to_owned(), encrypted_params(), admin_did.clone())
+        .create_context(ctx_id.to_owned(), encrypted_params(), admin_did.clone(), None)
         .await
         .unwrap();
     assert_eq!(handle.state().await, ContextState::Active);
@@ -1117,7 +1117,7 @@ async fn e2e_multi_bridge_api_surface_verification() {
 
     let enc_ctx_id = "bridge-enc";
     let enc_handle = manager
-        .create_context(enc_ctx_id.to_owned(), encrypted_params(), alice.clone())
+        .create_context(enc_ctx_id.to_owned(), encrypted_params(), alice.clone(), None)
         .await
         .unwrap();
 
@@ -1193,7 +1193,7 @@ async fn e2e_multi_bridge_api_surface_verification() {
     manager.register_local_did(alice.clone()).await;
 
     let _bc_handle = manager
-        .create_context(bc_ctx_id.to_owned(), broadcast_params(), alice.clone())
+        .create_context(bc_ctx_id.to_owned(), broadcast_params(), alice.clone(), None)
         .await
         .unwrap();
 

--- a/crates/scp-testing/tests/integration/network_simulation.rs
+++ b/crates/scp-testing/tests/integration/network_simulation.rs
@@ -1125,7 +1125,7 @@ async fn application_layer_demo() {
     println!();
 
     let handle = manager
-        .create_context(ctx_id.to_owned(), params, alice.clone())
+        .create_context(ctx_id.to_owned(), params, alice.clone(), None)
         .await
         .unwrap();
     let state = handle.state().await;
@@ -1146,7 +1146,10 @@ async fn application_layer_demo() {
         owner_did: bob.clone(),
         mls_key_package_bytes: None,
     };
-    manager.join_context(&handle, bob_kp, None).await.unwrap();
+    manager
+        .join_context(&handle, bob_kp, None, None)
+        .await
+        .unwrap();
     println!("  Bob joined context");
 
     let charlie_kp = KeyPackage {
@@ -1154,7 +1157,7 @@ async fn application_layer_demo() {
         mls_key_package_bytes: None,
     };
     manager
-        .join_context(&handle, charlie_kp, None)
+        .join_context(&handle, charlie_kp, None, None)
         .await
         .unwrap();
     println!("  Charlie joined context");

--- a/crates/scp-testing/tests/integration/persistence.rs
+++ b/crates/scp-testing/tests/integration/persistence.rs
@@ -1188,7 +1188,7 @@ async fn context_manager_broadcast_restore_roundtrip() {
     manager.register_local_did(creator_did.clone()).await;
 
     let _handle = manager
-        .create_context(ctx_id.into(), params.clone(), creator_did.clone())
+        .create_context(ctx_id.into(), params.clone(), creator_did.clone(), None)
         .await
         .unwrap();
 

--- a/crates/scp-testing/tests/integration/tool_economy_wiring.rs
+++ b/crates/scp-testing/tests/integration/tool_economy_wiring.rs
@@ -427,7 +427,7 @@ async fn invoke_tool_with_economy_deducts_budget_and_records_velocity() {
     params.economic_policy = Some(priced_policy(7));
 
     let _handle = manager
-        .create_context(context_id.clone(), params, invoker.clone())
+        .create_context(context_id.clone(), params, invoker.clone(), None)
         .await
         .expect("create_context");
 
@@ -548,7 +548,7 @@ async fn invoke_tool_with_economy_rejects_insufficient_budget() {
     params.economic_policy = Some(priced_policy(100));
 
     let _handle = manager
-        .create_context(context_id.clone(), params, invoker.clone())
+        .create_context(context_id.clone(), params, invoker.clone(), None)
         .await
         .expect("create_context");
 

--- a/scaffolds/rust-client/src/main.rs
+++ b/scaffolds/rust-client/src/main.rs
@@ -67,7 +67,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     };
 
     let handle = manager
-        .create_context("my-context".to_owned(), params, did.clone())
+        .create_context("my-context".to_owned(), params, did.clone(), None)
         .await?;
     println!("Created context: {}", handle.context_id());
 


### PR DESCRIPTION
## Summary

- Implements spec §9.10.4 per-member pseudonym routing for encrypted contexts
- Adds `local_pseudonym` and `pseudonym_registry` to `PerContextState` for pseudonym-based routing
- `send_message` fans out encrypted blobs to all known member pseudonyms + shared routing_id fallback
- `PseudonymAnnouncement` MLS message exchanges pseudonyms between members (with sender authentication)
- `broadcast_routing_id()` added for broadcast contexts matching spec §5.14 (`SHA-256(context_id)`)
- All 3 FFI bridges (PyO3, NAPI, UniFFI) pre-derive pseudonyms and thread through create/join
- NAPI dual subscription: own pseudonym + shared routing_id via `futures::stream::select`
- Sender verification rejects forged announcements (member_did must match MLS sender)
- Best-effort fan-out: partial send failure doesn't roll back sequence (prevents anti-replay breakage)
- Out-of-order pseudonym announcements correctly handled via `deliver_plaintext_or_announcement` helper
- `local_pseudonym()` query is async (no try_lock fallback)

Closes #1534

## Test plan

- [x] `create_context_with_pseudonym_stores_in_state`
- [x] `create_context_without_pseudonym_stores_none`
- [x] `pseudonym_announcement_roundtrip` (wire format)
- [x] `broadcast_routing_id_uses_plain_sha256` (§5.14 compliance)
- [x] `send_message_encrypted_uses_pseudonym_fanout`
- [x] `forged_pseudonym_announcement_rejected` (security)
- [x] 3 protocol-level broadcast_routing_id tests
- [x] Clippy clean (full workspace + all features)

🤖 Generated with [Claude Code](https://claude.com/claude-code)