### PR TITLE
chore(bridge-symmetry): batch 2 — 6 dropped ops + 33 ratchet promotions (#1543)

### DIFF
--- a/.claude/agent-memory/chronicler/MEMORY.md
+++ b/.claude/agent-memory/chronicler/MEMORY.md
@@ -45,4 +45,9 @@
 ## Cross-Bridge Matrix (PR #1702, 2026-04-25)
 - See [feedback_bridge_canonical_naming.md](feedback_bridge_canonical_naming.md) -- canonical name in bridge-aliases.json must already exist in all 4 bridges; otherwise file source-side rename
 - See [feedback_enforcement_hook_matrix_expansion.md](feedback_enforcement_hook_matrix_expansion.md) -- ADD-only edits to bridge-aliases.json bypass the PreToolUse hook via dangerouslyDisableSandbox; only for additive diffs
-- Lesson at `.docs/lessons/cross-bridge-canonical-naming.md` covers naming divergence (PyO3/UniFFI bare-verb vs NAPI/WASM noun-verb), inverse-coverage blind spot in bridge-symmetry harness, sibling-stem alignment, category-by-semantics rule
+- See [feedback_lockstep_enforcement.md](feedback_lockstep_enforcement.md) -- bridge-aliases.json wasm_required:true entries must equal WASM_REQUIRED_OPERATIONS in ffi_conformance.rs; aliases_json_is_in_sync_with_parity_operations test enforces. Edit both atomically.
+- Lesson at `.docs/lessons/cross-bridge-canonical-naming.md` covers naming divergence (PyO3/UniFFI bare-verb vs NAPI/WASM noun-verb), inverse-coverage blind spot in bridge-symmetry harness, sibling-stem alignment, category-by-semantics rule, lockstep enforcement pattern
+
+## Cross-Bridge Matrix Batch 2 (PR #1703, 2026-04-25)
+- Branch `cross-bridge/1543-batch2-ratchet-promotion`. Added 6 ops (4 WASM-exempt per ADR-034). 5 new include_str! + 7 category coverage tests gated on per-bridge exemptions. Promoted 33 ops to wasm_required:true (96 of 134 total). All reviews CLEAN.
+- Batch 3 next: ~60 real impl gaps in UniFFI economy/provenance/discovery/petnames/handle/scope/media + canonical reconciliation for 14 bare-verb vs noun-verb divergences.

--- a/.claude/agent-memory/chronicler/feedback_lockstep_enforcement.md
+++ b/.claude/agent-memory/chronicler/feedback_lockstep_enforcement.md
@@ -1,0 +1,11 @@
+---
+name: Lockstep enforcement of bridge matrix and WASM ratchet
+description: When promoting or demoting wasm_required entries, edit bridge-aliases.json and WASM_REQUIRED_OPERATIONS atomically — a test enforces equality
+type: feedback
+---
+
+When extending the bridge-symmetry matrix's `wasm_required` entries, edit both `scripts/bridge-aliases.json` AND `WASM_REQUIRED_OPERATIONS` in `crates/scp-testing/tests/integration/ffi_conformance.rs` atomically in the same commit.
+
+**Why:** The `aliases_json_is_in_sync_with_parity_operations` test in `ffi_conformance.rs` asserts that the set of ops with `"wasm_required": true` in the JSON matrix equals the `WASM_REQUIRED_OPERATIONS` Rust constant. Editing one without the other breaks the test and silently weakens enforcement — the JSON and the constant are a single logical artifact split across two files for tooling reasons. PR #1703 (Batch 2 of #1543, 2026-04-25) promoted 33 ops in lockstep and validated the pattern.
+
+**How to apply:** Any PR that adds, removes, or flips a `wasm_required:true` entry MUST include both edits. Workflow: flip the JSON value, add (or remove) the op name in the Rust array, run the conformance test until green. If only one of the two appears in the diff, the PR is incomplete — request the missing edit before merge. The lesson in `.docs/lessons/cross-bridge-canonical-naming.md` documents this under "Lockstep enforcement: matrix and ratchet must move together."

--- a/.docs/lessons/cross-bridge-canonical-naming.md
+++ b/.docs/lessons/cross-bridge-canonical-naming.md
@@ -36,3 +36,15 @@ The PreToolUse hook on `scripts/bridge-aliases.json` blocks the `Edit` tool beca
 **Workaround used in PR #1702:** `dangerouslyDisableSandbox` to proceed with ADD-only edits. This is acceptable for matrix expansion that strictly grows coverage, never for edits that remove or weaken existing entries.
 
 **Better long-term fix:** refine the hook to allow ADD-only diffs to `bridge-aliases.json` (new top-level keys, new alias entries within existing keys) and continue blocking removal or modification of existing entries. Until then, document the bypass clearly in PR descriptions so reviewers can verify the diff is additive.
+
+## Lockstep enforcement: matrix and ratchet must move together
+
+The `aliases_json_is_in_sync_with_parity_operations` test in `crates/scp-testing/tests/integration/ffi_conformance.rs` asserts that the set of operations marked `wasm_required:true` in `scripts/bridge-aliases.json` is exactly equal to the `WASM_REQUIRED_OPERATIONS` constant in the Rust ratchet. The two artifacts encode the same fact in different syntaxes, and the test fails compilation/run if they diverge by even one op.
+
+The common failure mode this catches: a contributor edits the JSON matrix to flip `wasm_required` from `false` to `true` (because WASM has the function and exemption is no longer warranted) but forgets to update the Rust `WASM_REQUIRED_OPERATIONS` array — or vice versa. Either direction leaves the matrix and the ratchet describing different realities, which silently weakens enforcement.
+
+**Rule:** Any PR that promotes (or demotes) a `wasm_required` entry must edit *both* files atomically in the same commit:
+1. `scripts/bridge-aliases.json` — flip `"wasm_required": true` on the entry.
+2. `crates/scp-testing/tests/integration/ffi_conformance.rs` — add the op name to `WASM_REQUIRED_OPERATIONS`.
+
+PR #1703 (Batch 2 of #1543) promoted 33 ops in lockstep this way, validating the pattern. The test gives a sharp diff on mismatch, so the workflow is mechanical: edit one, run the test, edit the other until green. Treat the JSON and the constant as a single logical artifact split across two files for tooling reasons — never edit one without the other.

--- a/crates/scp-testing/tests/integration/ffi_conformance.rs
+++ b/crates/scp-testing/tests/integration/ffi_conformance.rs
@@ -52,9 +52,17 @@ const PYO3_MEDIA: &str = include_str!("../../../../crates/scp-ffi/src/media.rs")
 // files above still contain these methods on PyScp; `scp.rs` holds the
 // lifecycle surface (new / with_storage / suspend / resume / shutdown).
 const PYO3_SCP: &str = include_str!("../../../../crates/scp-ffi/src/scp.rs");
+// PyO3 surface for `scpid_*` (challenge/sign/verify) and the server lifecycle
+// (start_in_memory / start_local / enable_site_projection / disable_site_projection).
+// Both files were not previously embedded — Batch 2 (#1543) folds them in so
+// SCPID and site-projection canonicals can resolve.
+const PYO3_SCPID: &str = include_str!("../../../../crates/scp-ffi/src/scpid.rs");
+const PYO3_SERVER: &str = include_str!("../../../../crates/scp-ffi/src/server.rs");
 
-// UniFFI bridge (single file)
+// UniFFI bridge (single file) plus the server module that hosts UniFFI's
+// site-projection methods (enable/disable_site_projection on the Server type).
 const UNIFFI_BRIDGE: &str = include_str!("../../../../crates/scp-ffi/uniffi/src/bridge.rs");
+const UNIFFI_SERVER: &str = include_str!("../../../../crates/scp-ffi/uniffi/src/server.rs");
 
 // NAPI bridge sources
 const NAPI_IDENTITY: &str = include_str!("../../../../crates/scp-ffi/napi/src/identity.rs");
@@ -76,6 +84,9 @@ const NAPI_MEDIA: &str = include_str!("../../../../crates/scp-ffi/napi/src/media
 // methods in `scp.rs`. The per-category source files retain helpers and types,
 // but the canonical bridge surface now lives on the `Scp` struct.
 const NAPI_SCP: &str = include_str!("../../../../crates/scp-ffi/napi/src/scp.rs");
+// NAPI server module hosts `enable_site_projection` / `disable_site_projection`
+// methods on the `Server` type — added in Batch 2 (#1543).
+const NAPI_SERVER: &str = include_str!("../../../../crates/scp-ffi/napi/src/server.rs");
 
 // WASM bridge sources
 const WASM_IDENTITY: &str = include_str!("../../../../crates/scp-ffi/wasm/src/identity.rs");
@@ -89,6 +100,9 @@ const WASM_PROVENANCE: &str = include_str!("../../../../crates/scp-ffi/wasm/src/
 const WASM_DISCOVERY: &str = include_str!("../../../../crates/scp-ffi/wasm/src/discovery.rs");
 const WASM_TRUST: &str = include_str!("../../../../crates/scp-ffi/wasm/src/trust.rs");
 const WASM_ECONOMY: &str = include_str!("../../../../crates/scp-ffi/wasm/src/economy.rs");
+// WASM SCPID module hosts `scpid_challenge` / `scpid_sign` (verify is exempt
+// per ADR-034 — see crates/scp-ffi/wasm/src/scpid.rs:11). Added in Batch 2 (#1543).
+const WASM_SCPID: &str = include_str!("../../../../crates/scp-ffi/wasm/src/scpid.rs");
 
 // ---------------------------------------------------------------------------
 // Shared alias table — compiled in at build time from scripts/bridge-aliases.json
@@ -483,9 +497,12 @@ fn pyo3_has_operation(sources: &[&'static str], canonical: &str) -> bool {
 }
 
 fn uniffi_has_operation(canonical: &str) -> bool {
+    // UniFFI's surface spans both the central bridge.rs (most ops) and a
+    // smaller server.rs module that hosts site-projection methods on the
+    // `Server` type. Search both — Batch 2 (#1543).
     uniffi_names(canonical)
         .iter()
-        .any(|name| source_has_fn(UNIFFI_BRIDGE, name))
+        .any(|name| source_has_fn(UNIFFI_BRIDGE, name) || source_has_fn(UNIFFI_SERVER, name))
 }
 
 fn napi_has_operation(sources: &[&'static str], canonical: &str) -> bool {
@@ -521,6 +538,8 @@ fn pyo3_sources() -> Vec<&'static str> {
         PYO3_ECONOMY,
         PYO3_MEDIA,
         PYO3_SCP,
+        PYO3_SCPID,
+        PYO3_SERVER,
     ]
 }
 
@@ -541,6 +560,7 @@ fn napi_sources() -> Vec<&'static str> {
         NAPI_ECONOMY,
         NAPI_MEDIA,
         NAPI_SCP,
+        NAPI_SERVER,
     ]
 }
 
@@ -557,6 +577,7 @@ fn wasm_sources() -> Vec<&'static str> {
         WASM_DISCOVERY,
         WASM_TRUST,
         WASM_ECONOMY,
+        WASM_SCPID,
     ]
 }
 
@@ -998,6 +1019,7 @@ fn identity_category_coverage() {
 
 /// Verifies context lifecycle operations are present across all bridges.
 /// Handles naming variance: PyO3 uses `context_receive` for `context_subscribe`.
+/// Per-bridge exemptions are sourced from `scripts/bridge-aliases.json`.
 #[test]
 fn context_category_coverage() {
     let ops = parity_operations();
@@ -1007,24 +1029,38 @@ fn context_category_coverage() {
     let napi_srcs = napi_sources();
     let wasm_srcs = wasm_sources();
 
+    let uniffi_exempt = exemptions_for("uniffi");
+    let napi_exempt = exemptions_for("napi");
+    let pyo3_exempt = exemptions_for("pyo3");
+    let wasm_exempt = exemptions_for("wasm");
+
     for (_, op, _) in &context_ops {
-        assert!(
-            pyo3_has_operation(&pyo3_srcs, op),
-            "PyO3 missing context op: {op}"
-        );
-        assert!(uniffi_has_operation(op), "UniFFI missing context op: {op}");
-        assert!(
-            napi_has_operation(&napi_srcs, op),
-            "NAPI missing context op: {op}"
-        );
-        assert!(
-            wasm_has_operation(&wasm_srcs, op),
-            "WASM missing context op: {op}"
-        );
+        if !pyo3_exempt.contains(*op) {
+            assert!(
+                pyo3_has_operation(&pyo3_srcs, op),
+                "PyO3 missing context op: {op}"
+            );
+        }
+        if !uniffi_exempt.contains(*op) {
+            assert!(uniffi_has_operation(op), "UniFFI missing context op: {op}");
+        }
+        if !napi_exempt.contains(*op) {
+            assert!(
+                napi_has_operation(&napi_srcs, op),
+                "NAPI missing context op: {op}"
+            );
+        }
+        if !wasm_exempt.contains(*op) {
+            assert!(
+                wasm_has_operation(&wasm_srcs, op),
+                "WASM missing context op: {op}"
+            );
+        }
     }
 }
 
-/// Verifies UCAN operations are present across all bridges.
+/// Verifies UCAN operations are present across all bridges. Per-bridge
+/// exemptions are sourced from `scripts/bridge-aliases.json`.
 #[test]
 fn ucan_category_coverage() {
     let ops = parity_operations();
@@ -1034,24 +1070,38 @@ fn ucan_category_coverage() {
     let napi_srcs = napi_sources();
     let wasm_srcs = wasm_sources();
 
+    let uniffi_exempt = exemptions_for("uniffi");
+    let napi_exempt = exemptions_for("napi");
+    let pyo3_exempt = exemptions_for("pyo3");
+    let wasm_exempt = exemptions_for("wasm");
+
     for (_, op, _) in &ucan_ops {
-        assert!(
-            pyo3_has_operation(&pyo3_srcs, op),
-            "PyO3 missing UCAN op: {op}"
-        );
-        assert!(uniffi_has_operation(op), "UniFFI missing UCAN op: {op}");
-        assert!(
-            napi_has_operation(&napi_srcs, op),
-            "NAPI missing UCAN op: {op}"
-        );
-        assert!(
-            wasm_has_operation(&wasm_srcs, op),
-            "WASM missing UCAN op: {op}"
-        );
+        if !pyo3_exempt.contains(*op) {
+            assert!(
+                pyo3_has_operation(&pyo3_srcs, op),
+                "PyO3 missing UCAN op: {op}"
+            );
+        }
+        if !uniffi_exempt.contains(*op) {
+            assert!(uniffi_has_operation(op), "UniFFI missing UCAN op: {op}");
+        }
+        if !napi_exempt.contains(*op) {
+            assert!(
+                napi_has_operation(&napi_srcs, op),
+                "NAPI missing UCAN op: {op}"
+            );
+        }
+        if !wasm_exempt.contains(*op) {
+            assert!(
+                wasm_has_operation(&wasm_srcs, op),
+                "WASM missing UCAN op: {op}"
+            );
+        }
     }
 }
 
-/// Verifies tool operations are present across all bridges.
+/// Verifies tool operations are present across all bridges. Per-bridge
+/// exemptions are sourced from `scripts/bridge-aliases.json`.
 #[test]
 fn tools_category_coverage() {
     let ops = parity_operations();
@@ -1061,25 +1111,39 @@ fn tools_category_coverage() {
     let napi_srcs = napi_sources();
     let wasm_srcs = wasm_sources();
 
+    let uniffi_exempt = exemptions_for("uniffi");
+    let napi_exempt = exemptions_for("napi");
+    let pyo3_exempt = exemptions_for("pyo3");
+    let wasm_exempt = exemptions_for("wasm");
+
     for (_, op, _) in &tool_ops {
-        assert!(
-            pyo3_has_operation(&pyo3_srcs, op),
-            "PyO3 missing tool op: {op}"
-        );
-        assert!(uniffi_has_operation(op), "UniFFI missing tool op: {op}");
-        assert!(
-            napi_has_operation(&napi_srcs, op),
-            "NAPI missing tool op: {op}"
-        );
-        assert!(
-            wasm_has_operation(&wasm_srcs, op),
-            "WASM missing tool op: {op}"
-        );
+        if !pyo3_exempt.contains(*op) {
+            assert!(
+                pyo3_has_operation(&pyo3_srcs, op),
+                "PyO3 missing tool op: {op}"
+            );
+        }
+        if !uniffi_exempt.contains(*op) {
+            assert!(uniffi_has_operation(op), "UniFFI missing tool op: {op}");
+        }
+        if !napi_exempt.contains(*op) {
+            assert!(
+                napi_has_operation(&napi_srcs, op),
+                "NAPI missing tool op: {op}"
+            );
+        }
+        if !wasm_exempt.contains(*op) {
+            assert!(
+                wasm_has_operation(&wasm_srcs, op),
+                "WASM missing tool op: {op}"
+            );
+        }
     }
 }
 
 /// Verifies broadcast operations are present across all bridges.
 /// Accounts for naming variance: `broadcast_block` vs `broadcast_block_subscriber`.
+/// Per-bridge exemptions are sourced from `scripts/bridge-aliases.json`.
 #[test]
 fn broadcast_category_coverage() {
     let ops = parity_operations();
@@ -1092,27 +1156,41 @@ fn broadcast_category_coverage() {
     let napi_srcs = napi_sources();
     let wasm_srcs = wasm_sources();
 
+    let uniffi_exempt = exemptions_for("uniffi");
+    let napi_exempt = exemptions_for("napi");
+    let pyo3_exempt = exemptions_for("pyo3");
+    let wasm_exempt = exemptions_for("wasm");
+
     for (_, op, _) in &broadcast_ops {
-        assert!(
-            pyo3_has_operation(&pyo3_srcs, op),
-            "PyO3 missing broadcast op: {op}"
-        );
-        assert!(
-            uniffi_has_operation(op),
-            "UniFFI missing broadcast op: {op}"
-        );
-        assert!(
-            napi_has_operation(&napi_srcs, op),
-            "NAPI missing broadcast op: {op}"
-        );
-        assert!(
-            wasm_has_operation(&wasm_srcs, op),
-            "WASM missing broadcast op: {op}"
-        );
+        if !pyo3_exempt.contains(*op) {
+            assert!(
+                pyo3_has_operation(&pyo3_srcs, op),
+                "PyO3 missing broadcast op: {op}"
+            );
+        }
+        if !uniffi_exempt.contains(*op) {
+            assert!(
+                uniffi_has_operation(op),
+                "UniFFI missing broadcast op: {op}"
+            );
+        }
+        if !napi_exempt.contains(*op) {
+            assert!(
+                napi_has_operation(&napi_srcs, op),
+                "NAPI missing broadcast op: {op}"
+            );
+        }
+        if !wasm_exempt.contains(*op) {
+            assert!(
+                wasm_has_operation(&wasm_srcs, op),
+                "WASM missing broadcast op: {op}"
+            );
+        }
     }
 }
 
-/// Verifies trust operations are present across all bridges.
+/// Verifies trust operations are present across all bridges. Per-bridge
+/// exemptions are sourced from `scripts/bridge-aliases.json`.
 #[test]
 fn trust_category_coverage() {
     let ops = parity_operations();
@@ -1122,24 +1200,38 @@ fn trust_category_coverage() {
     let napi_srcs = napi_sources();
     let wasm_srcs = wasm_sources();
 
+    let uniffi_exempt = exemptions_for("uniffi");
+    let napi_exempt = exemptions_for("napi");
+    let pyo3_exempt = exemptions_for("pyo3");
+    let wasm_exempt = exemptions_for("wasm");
+
     for (_, op, _) in &trust_ops {
-        assert!(
-            pyo3_has_operation(&pyo3_srcs, op),
-            "PyO3 missing trust op: {op}"
-        );
-        assert!(uniffi_has_operation(op), "UniFFI missing trust op: {op}");
-        assert!(
-            napi_has_operation(&napi_srcs, op),
-            "NAPI missing trust op: {op}"
-        );
-        assert!(
-            wasm_has_operation(&wasm_srcs, op),
-            "WASM missing trust op: {op}"
-        );
+        if !pyo3_exempt.contains(*op) {
+            assert!(
+                pyo3_has_operation(&pyo3_srcs, op),
+                "PyO3 missing trust op: {op}"
+            );
+        }
+        if !uniffi_exempt.contains(*op) {
+            assert!(uniffi_has_operation(op), "UniFFI missing trust op: {op}");
+        }
+        if !napi_exempt.contains(*op) {
+            assert!(
+                napi_has_operation(&napi_srcs, op),
+                "NAPI missing trust op: {op}"
+            );
+        }
+        if !wasm_exempt.contains(*op) {
+            assert!(
+                wasm_has_operation(&wasm_srcs, op),
+                "WASM missing trust op: {op}"
+            );
+        }
     }
 }
 
-/// Verifies event_log operations are present across all bridges.
+/// Verifies event_log operations are present across all bridges. Per-bridge
+/// exemptions are sourced from `scripts/bridge-aliases.json`.
 #[test]
 fn event_log_category_coverage() {
     let ops = parity_operations();
@@ -1152,27 +1244,41 @@ fn event_log_category_coverage() {
     let napi_srcs = napi_sources();
     let wasm_srcs = wasm_sources();
 
+    let uniffi_exempt = exemptions_for("uniffi");
+    let napi_exempt = exemptions_for("napi");
+    let pyo3_exempt = exemptions_for("pyo3");
+    let wasm_exempt = exemptions_for("wasm");
+
     for (_, op, _) in &event_log_ops {
-        assert!(
-            pyo3_has_operation(&pyo3_srcs, op),
-            "PyO3 missing event_log op: {op}"
-        );
-        assert!(
-            uniffi_has_operation(op),
-            "UniFFI missing event_log op: {op}"
-        );
-        assert!(
-            napi_has_operation(&napi_srcs, op),
-            "NAPI missing event_log op: {op}"
-        );
-        assert!(
-            wasm_has_operation(&wasm_srcs, op),
-            "WASM missing event_log op: {op}"
-        );
+        if !pyo3_exempt.contains(*op) {
+            assert!(
+                pyo3_has_operation(&pyo3_srcs, op),
+                "PyO3 missing event_log op: {op}"
+            );
+        }
+        if !uniffi_exempt.contains(*op) {
+            assert!(
+                uniffi_has_operation(op),
+                "UniFFI missing event_log op: {op}"
+            );
+        }
+        if !napi_exempt.contains(*op) {
+            assert!(
+                napi_has_operation(&napi_srcs, op),
+                "NAPI missing event_log op: {op}"
+            );
+        }
+        if !wasm_exempt.contains(*op) {
+            assert!(
+                wasm_has_operation(&wasm_srcs, op),
+                "WASM missing event_log op: {op}"
+            );
+        }
     }
 }
 
 /// Verifies discovery and provenance operations are present across all bridges.
+/// Per-bridge exemptions are sourced from `scripts/bridge-aliases.json`.
 #[test]
 fn discovery_and_provenance_coverage() {
     let ops = parity_operations();
@@ -1185,20 +1291,33 @@ fn discovery_and_provenance_coverage() {
     let napi_srcs = napi_sources();
     let wasm_srcs = wasm_sources();
 
+    let uniffi_exempt = exemptions_for("uniffi");
+    let napi_exempt = exemptions_for("napi");
+    let pyo3_exempt = exemptions_for("pyo3");
+    let wasm_exempt = exemptions_for("wasm");
+
     for (cat, op, _) in &selected {
-        assert!(
-            pyo3_has_operation(&pyo3_srcs, op),
-            "PyO3 missing {cat} op: {op}"
-        );
-        assert!(uniffi_has_operation(op), "UniFFI missing {cat} op: {op}");
-        assert!(
-            napi_has_operation(&napi_srcs, op),
-            "NAPI missing {cat} op: {op}"
-        );
-        assert!(
-            wasm_has_operation(&wasm_srcs, op),
-            "WASM missing {cat} op: {op}"
-        );
+        if !pyo3_exempt.contains(*op) {
+            assert!(
+                pyo3_has_operation(&pyo3_srcs, op),
+                "PyO3 missing {cat} op: {op}"
+            );
+        }
+        if !uniffi_exempt.contains(*op) {
+            assert!(uniffi_has_operation(op), "UniFFI missing {cat} op: {op}");
+        }
+        if !napi_exempt.contains(*op) {
+            assert!(
+                napi_has_operation(&napi_srcs, op),
+                "NAPI missing {cat} op: {op}"
+            );
+        }
+        if !wasm_exempt.contains(*op) {
+            assert!(
+                wasm_has_operation(&wasm_srcs, op),
+                "WASM missing {cat} op: {op}"
+            );
+        }
     }
 }
 
@@ -1304,6 +1423,51 @@ const WASM_REQUIRED_OPERATIONS: &[&str] = &[
     // Governance checkpoints
     "context_create_governance_checkpoint",
     "context_add_checkpoint_cosignature",
+    // Batch 2 (#1543) — 31 Batch-1 ops promoted from optional to required after
+    // matrix hygiene confirmed each is implemented across all four bridges with
+    // a real `fn` definition (verified by every_alias_resolves_to_a_real_fn_or_exemption).
+    // Governance lifecycle (4)
+    "context_governance_propose",
+    "context_governance_approve",
+    "context_governance_reject",
+    "context_governance_withdraw",
+    // Context lifecycle (6)
+    "context_finalize_close",
+    "context_apply_pending_ceiling_modification",
+    "context_get_economic_policy",
+    "context_set_economic_policy",
+    "context_restore",
+    "context_restore_all",
+    // TTL (3)
+    "context_handle_ttl_expiry",
+    "context_propose_ttl_extension",
+    "context_reset_ttl_timer",
+    // Broadcast (4)
+    "broadcast_publish_asset",
+    "broadcast_publish_assets",
+    "broadcast_handle_key_request",
+    "broadcast_unblock",
+    // Identity (7)
+    "identity_link_attestations",
+    "identity_create_with_agent_key",
+    "identity_execute_recovery",
+    "identity_execute_custody_migration",
+    "identity_add_agent_key",
+    "identity_remove_agent_key",
+    "identity_rotate_agent_key",
+    // Stateless utility ops (4)
+    "address_resolve",
+    "aggregate_trust_input",
+    "evaluate_invitation",
+    "transport_disconnect",
+    // Provenance (3)
+    "provenance_redact_counterparties",
+    "provenance_pseudonymize_counterparties",
+    "provenance_update_source_type",
+    // Batch 2 — newly registered SCPID ops promoted alongside the 31 Batch-1
+    // ops. `scpid_verify` stays optional (WASM-exempt: needs network DID resolver).
+    "scpid_challenge",
+    "scpid_sign",
 ];
 
 // ---------------------------------------------------------------------------
@@ -1517,13 +1681,12 @@ fn every_alias_resolves_to_a_real_fn_or_exemption() {
         }
         // --- uniffi ---
         if !uniffi_exempt.contains(op.canonical.as_str()) {
-            let any_resolves = op
-                .uniffi
-                .iter()
-                .any(|name| source_has_fn(UNIFFI_BRIDGE, name));
+            let any_resolves = op.uniffi.iter().any(|name| {
+                source_has_fn(UNIFFI_BRIDGE, name) || source_has_fn(UNIFFI_SERVER, name)
+            });
             if !any_resolves {
                 phantom.push(format!(
-                    "uniffi:{} — none of the declared aliases {:?} resolve to `fn <name>(` in crates/scp-ffi/uniffi/src/bridge.rs",
+                    "uniffi:{} — none of the declared aliases {:?} resolve to `fn <name>(` in crates/scp-ffi/uniffi/src/{{bridge,server}}.rs",
                     op.canonical, op.uniffi
                 ));
             }

--- a/scripts/bridge-aliases.json
+++ b/scripts/bridge-aliases.json
@@ -1772,7 +1772,7 @@
     {
       "canonical": "context_governance_propose",
       "category": "governance",
-      "wasm_required": false,
+      "wasm_required": true,
       "pyo3": [
         "governance_propose"
       ],
@@ -1789,7 +1789,7 @@
     {
       "canonical": "context_governance_approve",
       "category": "governance",
-      "wasm_required": false,
+      "wasm_required": true,
       "pyo3": [
         "governance_approve"
       ],
@@ -1806,7 +1806,7 @@
     {
       "canonical": "context_governance_reject",
       "category": "governance",
-      "wasm_required": false,
+      "wasm_required": true,
       "pyo3": [
         "governance_reject"
       ],
@@ -1823,7 +1823,7 @@
     {
       "canonical": "context_governance_withdraw",
       "category": "governance",
-      "wasm_required": false,
+      "wasm_required": true,
       "pyo3": [
         "governance_withdraw"
       ],
@@ -1840,7 +1840,7 @@
     {
       "canonical": "context_finalize_close",
       "category": "context",
-      "wasm_required": false,
+      "wasm_required": true,
       "pyo3": [
         "finalize_close"
       ],
@@ -1857,7 +1857,7 @@
     {
       "canonical": "context_apply_pending_ceiling_modification",
       "category": "context",
-      "wasm_required": false,
+      "wasm_required": true,
       "pyo3": [
         "apply_pending_ceiling_modification"
       ],
@@ -1874,7 +1874,7 @@
     {
       "canonical": "context_get_economic_policy",
       "category": "economy",
-      "wasm_required": false,
+      "wasm_required": true,
       "pyo3": [
         "get_economic_policy"
       ],
@@ -1891,7 +1891,7 @@
     {
       "canonical": "context_set_economic_policy",
       "category": "economy",
-      "wasm_required": false,
+      "wasm_required": true,
       "pyo3": [
         "set_economic_policy"
       ],
@@ -1908,7 +1908,7 @@
     {
       "canonical": "context_restore",
       "category": "context",
-      "wasm_required": false,
+      "wasm_required": true,
       "pyo3": [
         "restore_context"
       ],
@@ -1925,7 +1925,7 @@
     {
       "canonical": "context_restore_all",
       "category": "context",
-      "wasm_required": false,
+      "wasm_required": true,
       "pyo3": [
         "restore_all_contexts"
       ],
@@ -1942,7 +1942,7 @@
     {
       "canonical": "context_handle_ttl_expiry",
       "category": "context",
-      "wasm_required": false,
+      "wasm_required": true,
       "pyo3": [
         "context_handle_ttl_expiry"
       ],
@@ -1959,7 +1959,7 @@
     {
       "canonical": "context_propose_ttl_extension",
       "category": "context",
-      "wasm_required": false,
+      "wasm_required": true,
       "pyo3": [
         "context_propose_ttl_extension"
       ],
@@ -1976,7 +1976,7 @@
     {
       "canonical": "context_reset_ttl_timer",
       "category": "context",
-      "wasm_required": false,
+      "wasm_required": true,
       "pyo3": [
         "context_reset_ttl_timer"
       ],
@@ -1993,7 +1993,7 @@
     {
       "canonical": "broadcast_publish_asset",
       "category": "broadcast",
-      "wasm_required": false,
+      "wasm_required": true,
       "pyo3": [
         "broadcast_publish_asset"
       ],
@@ -2010,7 +2010,7 @@
     {
       "canonical": "broadcast_publish_assets",
       "category": "broadcast",
-      "wasm_required": false,
+      "wasm_required": true,
       "pyo3": [
         "broadcast_publish_assets"
       ],
@@ -2027,7 +2027,7 @@
     {
       "canonical": "broadcast_handle_key_request",
       "category": "broadcast",
-      "wasm_required": false,
+      "wasm_required": true,
       "pyo3": [
         "broadcast_handle_key_request"
       ],
@@ -2044,7 +2044,7 @@
     {
       "canonical": "broadcast_unblock",
       "category": "broadcast",
-      "wasm_required": false,
+      "wasm_required": true,
       "pyo3": [
         "broadcast_unblock_subscriber"
       ],
@@ -2061,7 +2061,7 @@
     {
       "canonical": "identity_link_attestations",
       "category": "identity",
-      "wasm_required": false,
+      "wasm_required": true,
       "pyo3": [
         "identity_link_attestations"
       ],
@@ -2078,7 +2078,7 @@
     {
       "canonical": "identity_create_with_agent_key",
       "category": "identity",
-      "wasm_required": false,
+      "wasm_required": true,
       "pyo3": [
         "identity_create_with_agent_key"
       ],
@@ -2095,7 +2095,7 @@
     {
       "canonical": "identity_execute_recovery",
       "category": "identity",
-      "wasm_required": false,
+      "wasm_required": true,
       "pyo3": [
         "identity_execute_recovery"
       ],
@@ -2112,7 +2112,7 @@
     {
       "canonical": "identity_execute_custody_migration",
       "category": "identity",
-      "wasm_required": false,
+      "wasm_required": true,
       "pyo3": [
         "identity_execute_custody_migration"
       ],
@@ -2129,7 +2129,7 @@
     {
       "canonical": "identity_add_agent_key",
       "category": "identity",
-      "wasm_required": false,
+      "wasm_required": true,
       "pyo3": [
         "identity_add_agent_key"
       ],
@@ -2147,7 +2147,7 @@
     {
       "canonical": "identity_remove_agent_key",
       "category": "identity",
-      "wasm_required": false,
+      "wasm_required": true,
       "pyo3": [
         "identity_remove_agent_key"
       ],
@@ -2165,7 +2165,7 @@
     {
       "canonical": "identity_rotate_agent_key",
       "category": "identity",
-      "wasm_required": false,
+      "wasm_required": true,
       "pyo3": [
         "identity_rotate_agent_key"
       ],
@@ -2183,7 +2183,7 @@
     {
       "canonical": "address_resolve",
       "category": "discovery",
-      "wasm_required": false,
+      "wasm_required": true,
       "pyo3": [
         "address_resolve"
       ],
@@ -2200,7 +2200,7 @@
     {
       "canonical": "aggregate_trust_input",
       "category": "trust",
-      "wasm_required": false,
+      "wasm_required": true,
       "pyo3": [
         "aggregate_trust_input"
       ],
@@ -2217,7 +2217,7 @@
     {
       "canonical": "evaluate_invitation",
       "category": "membership",
-      "wasm_required": false,
+      "wasm_required": true,
       "pyo3": [
         "evaluate_invitation"
       ],
@@ -2234,7 +2234,7 @@
     {
       "canonical": "transport_disconnect",
       "category": "transport",
-      "wasm_required": false,
+      "wasm_required": true,
       "pyo3": [
         "transport_disconnect"
       ],
@@ -2251,7 +2251,7 @@
     {
       "canonical": "provenance_redact_counterparties",
       "category": "provenance",
-      "wasm_required": false,
+      "wasm_required": true,
       "pyo3": [
         "provenance_redact_counterparties"
       ],
@@ -2268,7 +2268,7 @@
     {
       "canonical": "provenance_pseudonymize_counterparties",
       "category": "provenance",
-      "wasm_required": false,
+      "wasm_required": true,
       "pyo3": [
         "provenance_pseudonymize_counterparties"
       ],
@@ -2285,7 +2285,7 @@
     {
       "canonical": "provenance_update_source_type",
       "category": "provenance",
-      "wasm_required": false,
+      "wasm_required": true,
       "pyo3": [
         "provenance_update_source_type"
       ],
@@ -2297,6 +2297,108 @@
       ],
       "wasm": [
         "provenance_update_source_type"
+      ]
+    },
+    {
+      "canonical": "scpid_challenge",
+      "category": "scpid",
+      "wasm_required": true,
+      "pyo3": [
+        "scpid_challenge"
+      ],
+      "uniffi": [
+        "scpid_challenge"
+      ],
+      "napi": [
+        "scpid_challenge"
+      ],
+      "wasm": [
+        "scpid_challenge"
+      ]
+    },
+    {
+      "canonical": "scpid_sign",
+      "category": "scpid",
+      "wasm_required": true,
+      "pyo3": [
+        "scpid_sign"
+      ],
+      "uniffi": [
+        "scpid_sign"
+      ],
+      "napi": [
+        "scpid_sign"
+      ],
+      "wasm": [
+        "scpid_sign"
+      ]
+    },
+    {
+      "canonical": "scpid_verify",
+      "category": "scpid",
+      "wasm_required": false,
+      "pyo3": [
+        "scpid_verify"
+      ],
+      "uniffi": [
+        "scpid_verify"
+      ],
+      "napi": [
+        "scpid_verify"
+      ],
+      "wasm": [
+        "scpid_verify"
+      ]
+    },
+    {
+      "canonical": "enable_site_projection",
+      "category": "server",
+      "wasm_required": false,
+      "pyo3": [
+        "enable_site_projection"
+      ],
+      "uniffi": [
+        "enable_site_projection"
+      ],
+      "napi": [
+        "enable_site_projection"
+      ],
+      "wasm": [
+        "enable_site_projection"
+      ]
+    },
+    {
+      "canonical": "disable_site_projection",
+      "category": "server",
+      "wasm_required": false,
+      "pyo3": [
+        "disable_site_projection"
+      ],
+      "uniffi": [
+        "disable_site_projection"
+      ],
+      "napi": [
+        "disable_site_projection"
+      ],
+      "wasm": [
+        "disable_site_projection"
+      ]
+    },
+    {
+      "canonical": "context_tombstone_migrated",
+      "category": "context",
+      "wasm_required": false,
+      "pyo3": [
+        "tombstone_migrated_context"
+      ],
+      "uniffi": [
+        "tombstone_migrated_context"
+      ],
+      "napi": [
+        "context_tombstone_migrated"
+      ],
+      "wasm": [
+        "context_tombstone_migrated"
       ]
     }
   ],
@@ -2319,6 +2421,23 @@
         "reason": "not yet exported in NAPI bridge (known gap)"
       }
     ],
-    "wasm": []
+    "wasm": [
+      {
+        "canonical": "scpid_verify",
+        "reason": "SCPID verification requires DID resolver with DHT/network access; WASM lacks raw UDP and the tokio multi-thread runtime per ADR-034 (see crates/scp-ffi/wasm/src/scpid.rs:11)"
+      },
+      {
+        "canonical": "enable_site_projection",
+        "reason": "Site projection depends on scp-platform server APIs; WASM cannot host an HTTP server per ADR-034"
+      },
+      {
+        "canonical": "disable_site_projection",
+        "reason": "Site projection depends on scp-platform server APIs; WASM cannot host an HTTP server per ADR-034"
+      },
+      {
+        "canonical": "context_tombstone_migrated",
+        "reason": "Tombstone helper relies on scp-platform persistence; WASM defers persistence to host JS runtime per ADR-034"
+      }
+    ]
   }
 }


### PR DESCRIPTION
## Summary

Batch 2 of #1543 (cross-bridge consistency, Phase 5). Builds on Batch 1 (#1702).

**A. 6 new ops added** to `scripts/bridge-aliases.json` (operations dropped from Batch 1):
- `scpid_challenge`, `scpid_sign`, `scpid_verify` — SCPID auth (§3.11) across PyO3/UniFFI/NAPI; `scpid_verify` is WASM-exempt (no DHT/network access — see `crates/scp-ffi/wasm/src/scpid.rs:11`).
- `enable_site_projection`, `disable_site_projection`, `context_tombstone_migrated` — Server lifecycle and tombstone helpers; WASM-exempt per ADR-034 (no `scp-platform` on `wasm32`).

**B. Conformance test infrastructure updates** in `crates/scp-testing/tests/integration/ffi_conformance.rs`:
- Embed 5 additional bridge sources via `include_str!`: `PYO3_SCPID`, `PYO3_SERVER`, `NAPI_SERVER`, `UNIFFI_SERVER`, `WASM_SCPID`. Append each to the corresponding `*_sources()` Vec.
- `uniffi_has_operation()` and `every_alias_resolves_to_a_real_fn_or_exemption` now search both `UNIFFI_BRIDGE` and `UNIFFI_SERVER` (UniFFI's projection methods live on the `Server` type in `server.rs`).
- 7 sibling category coverage tests (`context_*`, `ucan_*`, `tools_*`, `broadcast_*`, `trust_*`, `event_log_*`, `discovery_and_provenance_*`) now consult `exemptions_for(bridge)` for **every** bridge before asserting per-bridge presence — mirroring the `identity_category_coverage` pattern exactly. This lets WASM-exempt ops (e.g. `context_tombstone_migrated`) live in the matrix without breaking the category test.

**C. Promote 33 ops to `wasm_required: true`** in JSON and `WASM_REQUIRED_OPERATIONS` in `ffi_conformance.rs`:
- All 31 Batch-1 ops (governance lifecycle ×4, context lifecycle ×6, TTL ×3, broadcast ×4, identity ×7, stateless utility ×4, provenance ×3) — every alias verified to resolve to a real `fn` in the WASM bridge by the existing `every_alias_resolves_to_a_real_fn_or_exemption` test.
- `scpid_challenge` + `scpid_sign` from this PR's new ops.
- `context_tombstone_migrated`, `scpid_verify`, `enable_site_projection`, `disable_site_projection` stay `wasm_required: false` (WASM-exempt with documented reasons).

The 33-op promotion is atomic — both JSON and Rust constant move in lockstep. `aliases_json_is_in_sync_with_parity_operations` enforces this; any drift fails CI immediately.

## Verification

After this PR:
- Total ops: **134** (128 from Batch 1 + 6 new)
- `wasm_required: true` count: **96** (63 baseline + 33 promotions)
- `MIN_PARITY_OPERATIONS` ratchet: 97 (unchanged — current count comfortably exceeds)

Local verification (all green):
- `python3.12 -m json.tool scripts/bridge-aliases.json` — valid JSON
- `bash scripts/check-bridge-symmetry.sh` — 0 findings
- `python3.12 scripts/check-call-invariants.py` — 3 rules verified
- `cargo test -p scp-testing --test ffi_conformance -- --test-threads=1` — 32/32 passing
- `cargo clippy --workspace --all-targets --features ... -- -D warnings` — clean

## Test plan
- [x] All 32 `ffi_conformance` tests green (every alias resolves to real `fn`, JSON in sync with Rust ratchet, no hardcoded exclusion arrays)
- [x] `check-bridge-symmetry.sh` reports 0 findings
- [x] Full clippy with all CI features clean
- [x] No tampering with `MIN_PARITY_OPERATIONS`, `bridge_ratchet_baseline.json`, or other ratchet files

## Notes

This PR's branch is currently rebased on Batch 1's branch (#1702) since Batch 1 is in the merge queue. If Batch 1 lands on `main` first, GitHub squash will reduce this PR's diff to only the Batch 2 changes. If GitHub flags it as conflicting, rebase: `git fetch origin && git rebase origin/main`.

Refs #1543; follows #1702 (Batch 1).

🤖 Generated with [Claude Code](https://claude.com/claude-code)