### PR TITLE
feat(pyo3): batch 3a — migrate 5 stateless utilities to PyScp methods (#1543)

### DIFF
--- a/.docs/adrs/ADR-048-scp-multi-instance.md
+++ b/.docs/adrs/ADR-048-scp-multi-instance.md
@@ -28,7 +28,7 @@ Every language SDK exposes a class named exactly `SCP`:
 - Swift: `SCP` (`#[derive(uniffi::Object)] Scp`, renamed in UDL)
 - Kotlin: `SCP` (same UniFFI object, Kotlin binding)
 
-`SCP` wraps an owned `Arc<BridgeInstance>`. Instance state — ContextManager, identity registry, UCAN registry, MCP registries, transport manager, known-contexts cache, rate limiters, economy trackers, petname/handle/scope registries — lives on that instance. Operations that were previously free functions become methods on `SCP`:
+`SCP` wraps an owned `Arc<BridgeInstance>`. Instance state — ContextManager, identity registry, UCAN registry, MCP registries, transport manager, known-contexts cache, rate limiters, economy trackers, petname/handle/scope registries — lives on that instance. Operations that touch instance state become methods on `SCP`:
 
 ```python
 scp = scp_sdk.SCP()               # new
@@ -36,7 +36,17 @@ identity = scp.identity_create(…) # method, not module-level function
 context = scp.context_create(…)
 ```
 
-Pure protocol helpers that touch no registry (hashing, encoding, validation of shape-only inputs) stay as free functions.
+**Pure protocol helpers that touch no registry stay as free functions at the FFI Rust layer.** This rule is normative and non-negotiable. A function that takes `&self` but never reads `self` is a lie about its dependency surface — handle affinity (§4) becomes dead weight, lifecycle coupling (§5, §6) becomes spurious, and multi-instance neutrality (the central goal of this ADR) becomes inverted: `scp_a.X()` and `scp_b.X()` produce identical bytes for any pure helper, making the instance receiver meaningless variance. The compiler can express the difference between `pub fn` and `&self`; the FFI source must use it honestly.
+
+Examples of pure helpers that stay free at the FFI layer:
+- Protocol-constant lookups (`template_get_params` — maps a template ID enum to its canonical `ContextParams` struct)
+- Shape validators (`validate_against_template`, `validate_context_params`, `metadata_record_from_json`)
+- Pure builders (`discovery_create_query`)
+- Process-scoped resolvers (`context_discover` — uses `crate::runtime()` and per-call `DidDht::new()`; reads zero per-instance state)
+
+Detection heuristic during code review: if a `&self` method body never references `self`, or if the helper takes `_bi: &BridgeInstance` with the leading underscore (compiler-enforced unused-parameter elision), the helper is pure and belongs at module scope.
+
+**SDK wrapper layer is governed by §7, not §1.** Each SDK (Python, TypeScript, Swift, Kotlin, WASM) chooses whether to surface a pure helper as an `SCP` class method or as a module-level export based on its own language idiom. §1 governs the FFI Rust source; §7 governs the language-specific wrapper layer above it.
 
 The class is named after the protocol, not after internal plumbing. This matches the prevailing SDK convention (`OpenAI()`, `Anthropic()`, `Stripe()`) and avoids the collisions that `Node`, `Bridge`, or `Client` would create with existing application-layer classes (`server.py:125`, `server.ts:223`, `BridgeConnector` in spec §12).
 
@@ -109,19 +119,38 @@ Short-lived tasks (single-await-then-return) are allowed to hold an `Arc` for th
 
 Regression tests at `crates/scp-ffi/src/transport.rs::tests`, `crates/scp-ffi/src/mcp.rs::tests`, and `crates/scp-ffi/uniffi/src/bridge.rs::tests` assert (a) `Arc::strong_count(&bi) == 1` while the task is parked, and (b) `weak.upgrade().is_none()` once the caller-held `Arc` drops — proving `impl Drop for BridgeInstance` runs and `emergency_cancel_tasks` propagates.
 
-### 7. SDK-level Kotlin-parity: SCP methods are the sole entry point
+### 7. Per-SDK idiomatic shape — language constraints stay local
 
-Every SDK wraps the NAPI `Scp` surface (and its PyO3/UniFFI siblings) as instance methods on its own `SCP` class. The pre-Phase-4 shape — a three-method `SCP` lifecycle object alongside a parallel collection of namespace classes (`Identity`, `Context`, `Transport`, `EventLog`, `McpServer`, `McpClient`, `Relay`, `Node`) with their own lifecycle methods plus ~140 free functions — is gone. There is one class, one surface, one entry point:
+**Each SDK chooses its method-vs-free-function shape based on its own language semantics.** Cross-language symmetry is not a value when it requires importing another language's binding-tool constraints. The FFI Rust layer follows §1 strictly (pure helpers stay free functions at FFI); the SDK wrapper layer above is per-language.
 
-- **Python:** `scp_sdk.SCP` carries 162 methods (was 3).
-- **TypeScript:** the `SCP` class in `bindings/typescript/src/scp.ts` carries 181 methods (was 3).
-- **Kotlin:** `bindings/kotlin/scp-kt/src/main/kotlin/works/limn/scp/Scp.kt` carries 137 methods. Kotlin was the reference shape — it already expressed this surface via `CoroutineBridge` before Phase 4. Python and TypeScript now match.
+This section was originally drafted (commit `efc58ecfd`, 2026-04-25) with a universalist framing — *"There is one class, one surface, one entry point"* — and tabulated method counts (Python 162, TypeScript 181, Kotlin 137) as if convergence on a single shape was an achieved architectural goal. **It was not.** The single-shape claim was Kotlin's `CoroutineBridge` constraint propagated to Python and TypeScript without independent justification, while Swift (UniFFI generator) and WASM (wasm-bindgen) silently opted out because they couldn't implement it. That framing is amended below.
 
-The namespace classes collapsed to pure handle types — `Identity { did, custodyType }`, `Context { contextId, identityDid }`, `Transport { handle }`, `EventLog { handle }`, `McpServer { handle }`, `McpClient { handle }`, `Relay { handle, relayPort }`, `Node { handle, relayPort }` — with no methods. Every lifecycle, content, governance, economy, attestation, sync, discovery, event-log, MCP, relay, and node operation is a method on `SCP` (`scp.contextCreate(...)`, `scp.ucanMint(...)`, `scp.eventLogQuery(handle, filter)`, `scp.relayStart(config)`, etc.). Handles are owned by the `SCP` that issued them and enforced by `instance_id` per §4.
+**Stateful operations (the §1 carve-out's complement) are methods on `SCP` in every SDK.** Lifecycle, content, governance, economy, attestation, sync, MCP, relay, node, identity-registry-touching, and any operation that reads or mutates the per-instance `BridgeInstance` state lives as `scp.contextCreate(...)`, `scp.ucanMint(...)`, etc. Handles are owned by the issuing `SCP` and enforced via `instance_id` per §4. The pre-Phase-4 namespace classes (`Identity`, `Context`, `Transport`, `EventLog`, `McpServer`, `McpClient`, `Relay`, `Node`) collapsed to pure handle types with no methods.
 
-Swift retains per-object UniFFI-generated wrappers alongside `Scp.swift` — UniFFI does not expose a mechanism to collapse `#[uniffi::Object]` receivers into methods on an unrelated outer object without hand-written shims on both sides of the bridge. Per ADR-021, UniFFI's generator constraints govern the Swift surface. Swift callers get the same semantic surface (one `SCP` instance, handle-scoped operations) with the generator's natural shape; Python, Kotlin, and TypeScript converge on the single-class form.
+**Pure helpers' SDK-side shape is per-language**:
 
-Commits (all on `refactor/phase4-facade-delete`, issue #1549): `dc7face6d` (Python Agent A — class scaffold), `4fb4572f8` (TS Agent A — class scaffold), `bdd2cb58a` (TS B1 — namespace class collapse), `4612e7eff` (TS B2 — Proxy mock-bridge rewrite), `ecc668bd3` (Python B+C — handle collapse + test rewrite), `cd85f3f8b` (TS B4 — large test rewrites), `5271ef84d` (TS B5 — WASM + examples).
+- **Kotlin** (`bindings/kotlin/scp-kt/...`): pure helpers are methods on `SCP`. Driven by `CoroutineBridge`'s requirement for object-bound coroutine scope inheritance — Kotlin's structured concurrency makes module-level functions awkward to compose with `SupervisorJob` cancellation. This is a Kotlin-local language-runtime constraint.
+
+- **Python** (`bindings/python/scp_sdk/`): pure helpers stay as module-level functions (`scp_sdk.context.template_get_params`, `scp_sdk.discovery.context_discover`, etc.). Python idiom favors module-level functions for pure operations; forcing them onto `SCP` creates false instance dependencies and forces consumers to instantiate `SCP()` (which spins up the tokio runtime, identity registry, semaphores) just to call deterministic shape validators.
+
+- **TypeScript** (`bindings/typescript/src/scp.ts`): pure helpers MAY be exposed as `SCP` methods or as module-level exports — the choice is TS-local ergonomic. When exposed as methods on `SCP`, the method body routes to a module-level NAPI export, NOT to a method on the underlying `napi-rs` `Scp` class (which does not exist for pure helpers per §1). The class shape is decoration over a free-function FFI.
+
+- **Swift** (`bindings/swift/Sources/SCP/`): pure helpers and per-object methods are both free `pub fn` at the FFI layer. UniFFI does not expose a mechanism to collapse `#[uniffi::Object]` receivers into methods on an unrelated outer object without hand-written shims on both sides. Per ADR-021, UniFFI's generator constraints govern the Swift surface.
+
+- **WASM** (`crates/scp-ffi/wasm/src/`, consumed by browser TypeScript): pure helpers are free `#[wasm_bindgen] pub fn` exports. ADR-034 prohibits the full `BridgeInstance` surface in WASM; the wasm-bindgen idiom favors free function exports for stateless utilities.
+
+**The principle**: language-runtime constraints (Kotlin coroutine scope, Python GIL, JavaScript async/Promise model) and binding-tool structural limits (UniFFI generator, napi-rs class semantics, wasm-bindgen) are local to that language/bridge. They do not propagate. When a binding tool in language A forces a particular API shape, that shape is local to A. Asking "should language B follow A's pattern for cross-SDK consistency" is the wrong question; the right question is "is there a reason in B's own language semantics or binding constraints to use this pattern?"
+
+**Detection heuristic**: when an audit or symmetry check flags a function as "missing in bridge X but present in bridge Y," do NOT assume Y is the reference. The ADR is the reference. Both X and Y may be wrong (the most common case in practice — a pre-existing violation propagated as it was discovered). Read §1 first, then this section, then prescribe.
+
+**Cross-references**:
+- `.docs/lessons/per-sdk-idiom-not-cross-language-dogma.md` — full lesson on the §1-vs-§7 contradiction history, audit-vs-spec drift, review-agent unanimity epistemics, and the principle that triggered this amendment.
+- §1 above — the FFI Rust layer rule (pure helpers stay free fns).
+- ADR-034 — WASM bridge constraints (no scp-platform; constrained surface).
+- ADR-021 — UniFFI binding constraints.
+- ADR-047 — bridge-symmetry enforcement (matrix supports both alias forms; symmetry is per-bridge, not per-SDK).
+
+Commits documenting the original §7 collapse (issue #1549, all on `refactor/phase4-facade-delete`): `dc7face6d` (Python Agent A — class scaffold), `4fb4572f8` (TS Agent A — class scaffold), `bdd2cb58a` (TS B1 — namespace class collapse), `4612e7eff` (TS B2 — Proxy mock-bridge rewrite), `ecc668bd3` (Python B+C — handle collapse + test rewrite), `cd85f3f8b` (TS B4 — large test rewrites), `5271ef84d` (TS B5 — WASM + examples). The 2026-04-25 amendment that introduced the per-SDK framing is on the same issue (#1543 / Batch 3a follow-up).
 
 **Round-2 and round-3 hardening (post-§7 review loop, 2026-04-21).** After the §7 migration landed the full review roster surfaced three classes of finding that were addressed in `3de6cbe30`, `78102c871`, `d8ffcdadf`, and `d489f6610`. The decisions baked into those commits supersede naïve readings of the earlier §7 framing:
 

--- a/.docs/adrs/ADR-048-scp-multi-instance.md
+++ b/.docs/adrs/ADR-048-scp-multi-instance.md
@@ -121,11 +121,21 @@ Regression tests at `crates/scp-ffi/src/transport.rs::tests`, `crates/scp-ffi/sr
 
 ### 7. Per-SDK idiomatic shape — language constraints stay local
 
-**Each SDK chooses its method-vs-free-function shape based on its own language semantics.** Cross-language symmetry is not a value when it requires importing another language's binding-tool constraints. The FFI Rust layer follows §1 strictly (pure helpers stay free functions at FFI); the SDK wrapper layer above is per-language.
+**The rule.** Each SDK chooses its method-vs-free-function shape based on
+its own language semantics and binding-tool constraints. Cross-language
+symmetry is not a value when it requires importing another language's
+constraints. The FFI Rust layer follows §1 strictly (pure helpers stay
+free functions at FFI); the SDK wrapper layer above is per-language.
 
-This section was originally drafted (commit `efc58ecfd`, 2026-04-25) with a universalist framing — *"There is one class, one surface, one entry point"* — and tabulated method counts (Python 162, TypeScript 181, Kotlin 137) as if convergence on a single shape was an achieved architectural goal. **It was not.** The single-shape claim was Kotlin's `CoroutineBridge` constraint propagated to Python and TypeScript without independent justification, while Swift (UniFFI generator) and WASM (wasm-bindgen) silently opted out because they couldn't implement it. That framing is amended below.
-
-**Stateful operations (the §1 carve-out's complement) are methods on `SCP` in every SDK.** Lifecycle, content, governance, economy, attestation, sync, MCP, relay, node, identity-registry-touching, and any operation that reads or mutates the per-instance `BridgeInstance` state lives as `scp.contextCreate(...)`, `scp.ucanMint(...)`, etc. Handles are owned by the issuing `SCP` and enforced via `instance_id` per §4. The pre-Phase-4 namespace classes (`Identity`, `Context`, `Transport`, `EventLog`, `McpServer`, `McpClient`, `Relay`, `Node`) collapsed to pure handle types with no methods.
+**Stateful operations are methods on `SCP` in every SDK.** Lifecycle,
+content, governance, economy, attestation, sync, MCP, relay, node,
+identity-registry-touching, and any operation that reads or mutates the
+per-instance `BridgeInstance` state lives as `scp.contextCreate(...)`,
+`scp.ucanMint(...)`, etc. Handles are owned by the issuing `SCP` and
+enforced via `instance_id` per §4. The pre-Phase-4 namespace classes
+(`Identity`, `Context`, `Transport`, `EventLog`, `McpServer`,
+`McpClient`, `Relay`, `Node`) collapsed to pure handle types with no
+methods.
 
 **Pure helpers' SDK-side shape is per-language**:
 
@@ -139,12 +149,12 @@ This section was originally drafted (commit `efc58ecfd`, 2026-04-25) with a univ
 
 - **WASM** (`crates/scp-ffi/wasm/src/`, consumed by browser TypeScript): pure helpers are free `#[wasm_bindgen] pub fn` exports. ADR-034 prohibits the full `BridgeInstance` surface in WASM; the wasm-bindgen idiom favors free function exports for stateless utilities.
 
-**The principle**: language-runtime constraints (Kotlin coroutine scope, Python GIL, JavaScript async/Promise model) and binding-tool structural limits (UniFFI generator, napi-rs class semantics, wasm-bindgen) are local to that language/bridge. They do not propagate. When a binding tool in language A forces a particular API shape, that shape is local to A. Asking "should language B follow A's pattern for cross-SDK consistency" is the wrong question; the right question is "is there a reason in B's own language semantics or binding constraints to use this pattern?"
-
-**Detection heuristic**: when an audit or symmetry check flags a function as "missing in bridge X but present in bridge Y," do NOT assume Y is the reference. The ADR is the reference. Both X and Y may be wrong (the most common case in practice — a pre-existing violation propagated as it was discovered). Read §1 first, then this section, then prescribe.
+When a cross-bridge audit or symmetry check flags a function as "missing
+in X but present in Y," the ADR is the reference — both X and Y may be
+wrong. Read §1, then this section, then prescribe.
 
 **Cross-references**:
-- `.docs/lessons/per-sdk-idiom-not-cross-language-dogma.md` — full lesson on the §1-vs-§7 contradiction history, audit-vs-spec drift, review-agent unanimity epistemics, and the principle that triggered this amendment.
+- `.docs/lessons/per-sdk-idiom-not-cross-language-dogma.md` — full lesson and the principle that triggered this amendment.
 - §1 above — the FFI Rust layer rule (pure helpers stay free fns).
 - ADR-034 — WASM bridge constraints (no scp-platform; constrained surface).
 - ADR-021 — UniFFI binding constraints.

--- a/.docs/adrs/ADR-048-scp-multi-instance.md
+++ b/.docs/adrs/ADR-048-scp-multi-instance.md
@@ -135,7 +135,7 @@ This section was originally drafted (commit `efc58ecfd`, 2026-04-25) with a univ
 
 - **TypeScript** (`bindings/typescript/src/scp.ts`): pure helpers MAY be exposed as `SCP` methods or as module-level exports — the choice is TS-local ergonomic. When exposed as methods on `SCP`, the method body routes to a module-level NAPI export, NOT to a method on the underlying `napi-rs` `Scp` class (which does not exist for pure helpers per §1). The class shape is decoration over a free-function FFI.
 
-- **Swift** (`bindings/swift/Sources/SCP/`): pure helpers and per-object methods are both free `pub fn` at the FFI layer. UniFFI does not expose a mechanism to collapse `#[uniffi::Object]` receivers into methods on an unrelated outer object without hand-written shims on both sides. Per ADR-021, UniFFI's generator constraints govern the Swift surface.
+- **Swift** (`bindings/swift/Sources/SCP/`): per-object UniFFI-generated wrappers retained alongside `Scp.swift`. Per ADR-021, UniFFI's generator constraints prevent collapsing `#[uniffi::Object]` receivers into methods on an unrelated outer class without hand-written shims on both sides — so the SDK surface follows the generator's natural shape. Pure helpers surface as free top-level functions; per-object methods stay on their `#[uniffi::Object]` types. The FFI Rust layer for these helpers is governed by §1 (free `pub fn`) and is unaffected by this Swift-side shape choice.
 
 - **WASM** (`crates/scp-ffi/wasm/src/`, consumed by browser TypeScript): pure helpers are free `#[wasm_bindgen] pub fn` exports. ADR-034 prohibits the full `BridgeInstance` surface in WASM; the wasm-bindgen idiom favors free function exports for stateless utilities.
 

--- a/.docs/lessons/per-sdk-idiom-not-cross-language-dogma.md
+++ b/.docs/lessons/per-sdk-idiom-not-cross-language-dogma.md
@@ -1,0 +1,165 @@
+# Per-SDK idiom — language constraints stay local
+
+## Principle
+
+> "I don't want optimizations or constraints for one language to dictate what
+> happens in another's SDK. That's bad dogma."
+> — Alec, 2026-04-25
+
+The SCP project ships SDKs in five languages (Python, TypeScript, Swift, Kotlin,
+WASM) over four FFI bridges (PyO3, NAPI, UniFFI, wasm-bindgen). Each binding
+tool has its own constraints — some structural, some ergonomic, some historical.
+**Those constraints must not propagate across languages.** When a binding tool
+in language A forces a particular API shape, that shape is local to language A.
+It does not become the universal shape for B, C, D.
+
+## What "bad dogma" looks like
+
+The failure mode this lesson exists to prevent: an architectural decision in
+one binding gets enshrined as a project-wide rule because "we want consistency
+across SDKs." Then every future change is forced to match that one binding's
+constraints, even when the other languages have no equivalent constraint and
+would naturally express the API differently.
+
+Concrete example — what triggered this lesson:
+
+ADR-048 §7 originally claimed *"There is one class, one surface, one entry
+point"* across all SDKs. It tabulated method counts (Python 162, TypeScript
+181, Kotlin 137) as if the convergence on a single shape was a goal achieved
+through deliberate design.
+
+It wasn't. The shape came from Kotlin: Kotlin's `CoroutineBridge` requires
+object-bound coroutine scope for cancellation/inheritance, which made
+free-function APIs awkward to compose with structured concurrency. So Kotlin
+went method-on-`SCP`, and Python and TypeScript inherited the shape without
+independent justification. UniFFI/Swift opted out (UniFFI generator can't
+collapse `#[uniffi::Object]` into methods on an outer class). WASM stayed as
+free functions.
+
+**Result**: Python and TypeScript carried Kotlin's constraint without ever
+needing it, while Swift and WASM ignored the rule because they couldn't
+implement it. The "one surface" claim was Kotlin's idiom dressed up as a
+project-wide architectural decision.
+
+## The correction
+
+ADR-048 §1 reasserts itself at the FFI Rust layer:
+
+> Pure protocol helpers that touch no registry (hashing, encoding, validation
+> of shape-only inputs) stay as free functions.
+
+This governs `crates/scp-ffi/*/src/*` — the Rust-side FFI surface. PyO3, NAPI,
+UniFFI, WASM all expose pure helpers as free `#[pyfunction]` / `#[napi]` /
+`pub fn` / `#[wasm_bindgen] pub fn`. The compiler's `&self` signature is honest
+only when `&self` is actually read.
+
+ADR-048 §7 governs the SDK wrapper layer. Each SDK chooses its idiom locally:
+
+- **Kotlin**: methods on `SCP` for `CoroutineBridge` scope inheritance. Pure
+  helpers also live as methods because Kotlin's coroutine semantics make
+  module-level functions awkward to compose with structured concurrency.
+- **Python**: stateful operations are methods on `scp_sdk.SCP`. Pure protocol
+  helpers stay as module-level functions (`scp_sdk.context.template_get_params`
+  etc.). Python idiom favors module-level functions for pure operations.
+- **TypeScript**: stateful operations are methods on the `SCP` class. Pure
+  helpers may be exposed as `SCP` methods that route to module-level NAPI
+  exports, or as module-level imports — TS-local ergonomic choice.
+- **Swift**: per-object UniFFI-generated wrappers. Pure helpers and per-object
+  methods are both free `pub fn` at the FFI layer — UniFFI generator constraints.
+- **WASM**: free functions at module scope.
+
+## How this lesson applies to future decisions
+
+When you encounter an apparent cross-language asymmetry:
+
+1. **Identify the constraint's origin.** Is the asymmetry forced by a binding
+   tool's structural rules (UniFFI generator, napi-rs limitations,
+   `wasm_bindgen` constraints)? Is it forced by a language's runtime semantics
+   (Kotlin's CoroutineBridge, Python's GIL, TypeScript's async/Promise model)?
+   Or is it just a maintainer preference?
+
+2. **Bound the constraint to its source.** Constraints rooted in language
+   semantics or binding-tool structure stay in that language/bridge. They do
+   not propagate. Don't ask "should X follow Y's pattern" — ask "is there a
+   reason in X's own language/binding to use this pattern?"
+
+3. **Audit the matrix against the spec, not the implementation.** When a
+   cross-bridge consistency audit flags an op as "missing in bridge A but
+   present in bridge B," do not assume B is the reference. The reference is
+   the ADR. Both A and B may be right or wrong. Read the ADR before
+   prescribing a "catch-up."
+
+4. **Never use audit scripts to redefine architecture.** Audit scripts measure
+   code state. Code state can drift from ADRs. The ADR governs (CLAUDE.md
+   artifact-flow invariant: plans → specs → ADRs → stories → source code).
+   Letting code state define the new pattern reverses the flow and creates
+   phantom provenance.
+
+## How this lesson applies to ADR review
+
+When reading or amending an ADR:
+
+1. **Survey the full ADR.** Later sections can supersede or qualify earlier
+   ones. Don't cite §N as authoritative without checking §N+1...§final.
+
+2. **Trace clauses to their source commits.** ADR-048's §1 was drafted
+   2026-04-18 (commit `5c4b4b62d`). §7 was added 2026-04-25 (commit
+   `efc58ecfd` — Phase 4 PR 5). The §7 universalism reflected the §7 commit's
+   PR scope (Kotlin parity), not a reconsideration of §1.
+
+3. **Distinguish architectural claims from implementation snapshots.**
+   "There is one class, one surface, one entry point" is an architectural
+   claim that the SDKs converge on a single shape. "Python: 162 methods,
+   TypeScript: 181 methods, Kotlin: 137 methods" is an implementation
+   snapshot. Snapshots become wrong with the next refactor; only the
+   architectural claim stays load-bearing. ADRs should make architectural
+   claims, not record snapshots.
+
+## How this lesson applies to review-agent workflows
+
+When dispatching multiple review agents to evaluate an architectural choice:
+
+1. **The prompt is part of the experiment.** A prompt that frames the question
+   narrowly (e.g., "should this function be a method or a free function?") will
+   get narrow answers. Agents may unanimously cite the same clause without ever
+   arbitrating a clause-vs-clause contradiction in the same ADR.
+
+2. **Unanimity is weak evidence when the prompt converges agents.** Two
+   agents agreeing on §1 because the prompt asked about pure helpers doesn't
+   tell you whether §1 or §7 governs. To force arbitration, the prompt must
+   surface the contradiction explicitly or ask "which clause governs?" rather
+   than "what's the right pattern?"
+
+3. **Validate review-agent verdicts against the actual ADR before acting.**
+   Even when agents converge with high confidence, read the ADR yourself and
+   confirm they engaged with the relevant sections. Agents skim ADRs the same
+   way humans do.
+
+## Permanent guidance
+
+- The FFI Rust layer (`crates/scp-ffi/*/src/*`) is governed by ADR-048 §1: pure
+  protocol helpers are free functions. Period. No `&self` parameters that
+  go unused. No `_bi: &BridgeInstance` underscore-elision. No "for symmetry
+  with [other bridge]" arguments.
+
+- The SDK wrapper layer (`bindings/{python,typescript,swift,kotlin}/`) is
+  governed by per-language idiom. Each SDK's shape is a local choice, not a
+  project-wide rule.
+
+- ADR-048 §7 has been amended (2026-04-25) to reflect this. Do not re-litigate
+  the universalism question without engaging with this lesson and the
+  amendment commit.
+
+- When in doubt, ask: "Is this constraint rooted in [this language/bridge]'s
+  own semantics, or am I propagating it from elsewhere?" If propagating, stop.
+
+## Related artifacts
+
+- `.docs/adrs/ADR-048-scp-multi-instance.md` §1 (FFI layer rule), §7 (per-SDK
+  idiom)
+- `crates/scp-ffi/src/*` — PyO3 free functions
+- `crates/scp-ffi/napi/src/context.rs` — NAPI free functions for pure helpers
+- `crates/scp-ffi/uniffi/src/bridge.rs` — UniFFI free functions
+- `bindings/python/scp_sdk/{context,discovery}.py` — Python module-level exports
+- `bindings/kotlin/scp-kt/...` — Kotlin SCP methods (CoroutineBridge constraint)
+- CLAUDE.md → artifact-flow invariant (plans → specs → ADRs → code)

--- a/.docs/lessons/per-sdk-idiom-not-cross-language-dogma.md
+++ b/.docs/lessons/per-sdk-idiom-not-cross-language-dogma.md
@@ -6,160 +6,59 @@
 > happens in another's SDK. That's bad dogma."
 > — Alec, 2026-04-25
 
-The SCP project ships SDKs in five languages (Python, TypeScript, Swift, Kotlin,
-WASM) over four FFI bridges (PyO3, NAPI, UniFFI, wasm-bindgen). Each binding
-tool has its own constraints — some structural, some ergonomic, some historical.
-**Those constraints must not propagate across languages.** When a binding tool
-in language A forces a particular API shape, that shape is local to language A.
-It does not become the universal shape for B, C, D.
+SCP ships SDKs in five languages (Python, TypeScript, Swift, Kotlin, WASM)
+over four FFI bridges (PyO3, NAPI, UniFFI, wasm-bindgen). Each binding tool
+has its own constraints. **Those constraints must not propagate across
+languages.** When a binding tool in language A forces an API shape, that
+shape is local to A — it does not become the universal shape for B, C, D.
 
-## What "bad dogma" looks like
-
-The failure mode this lesson exists to prevent: an architectural decision in
-one binding gets enshrined as a project-wide rule because "we want consistency
-across SDKs." Then every future change is forced to match that one binding's
-constraints, even when the other languages have no equivalent constraint and
-would naturally express the API differently.
-
-Concrete example — what triggered this lesson:
+## What triggered the lesson
 
 ADR-048 §7 originally claimed *"There is one class, one surface, one entry
-point"* across all SDKs. It tabulated method counts (Python 162, TypeScript
-181, Kotlin 137) as if the convergence on a single shape was a goal achieved
-through deliberate design.
+point"* across all SDKs and tabulated method counts as if convergence on a
+single shape was a deliberate architectural goal. It wasn't. The shape came
+from Kotlin: `CoroutineBridge` requires object-bound coroutine scope, which
+made free-function APIs awkward to compose with structured concurrency.
+Python and TypeScript inherited Kotlin's shape without independent
+justification; Swift (UniFFI generator) and WASM (wasm-bindgen) opted out
+because they couldn't implement it. The "one surface" claim was Kotlin's
+idiom dressed up as a project-wide architectural decision.
 
-It wasn't. The shape came from Kotlin: Kotlin's `CoroutineBridge` requires
-object-bound coroutine scope for cancellation/inheritance, which made
-free-function APIs awkward to compose with structured concurrency. So Kotlin
-went method-on-`SCP`, and Python and TypeScript inherited the shape without
-independent justification. UniFFI/Swift opted out (UniFFI generator can't
-collapse `#[uniffi::Object]` into methods on an outer class). WASM stayed as
-free functions.
+## The rules
 
-**Result**: Python and TypeScript carried Kotlin's constraint without ever
-needing it, while Swift and WASM ignored the rule because they couldn't
-implement it. The "one surface" claim was Kotlin's idiom dressed up as a
-project-wide architectural decision.
+**FFI Rust layer (`crates/scp-ffi/*/src/*`)** is governed by [ADR-048 §1](../adrs/ADR-048-scp-multi-instance.md#1-scp-is-the-first-class-sdk-level-opaque-object-in-all-four-language-sdks):
+pure protocol helpers (hashing, encoding, shape validators) stay as free
+functions. No `&self` parameters that go unused. No `_bi: &BridgeInstance`
+underscore-elision. No "for symmetry with [other bridge]" arguments.
 
-## The correction
+**SDK wrapper layer (`bindings/{python,typescript,swift,kotlin}/`)** is
+governed by [ADR-048 §7](../adrs/ADR-048-scp-multi-instance.md#7-per-sdk-idiomatic-shape--language-constraints-stay-local).
+Each SDK's shape is a local choice. See §7 for the per-language table —
+do not duplicate it here.
 
-ADR-048 §1 reasserts itself at the FFI Rust layer:
-
-> Pure protocol helpers that touch no registry (hashing, encoding, validation
-> of shape-only inputs) stay as free functions.
-
-This governs `crates/scp-ffi/*/src/*` — the Rust-side FFI surface. PyO3, NAPI,
-UniFFI, WASM all expose pure helpers as free `#[pyfunction]` / `#[napi]` /
-`pub fn` / `#[wasm_bindgen] pub fn`. The compiler's `&self` signature is honest
-only when `&self` is actually read.
-
-ADR-048 §7 governs the SDK wrapper layer. Each SDK chooses its idiom locally:
-
-- **Kotlin**: methods on `SCP` for `CoroutineBridge` scope inheritance. Pure
-  helpers also live as methods because Kotlin's coroutine semantics make
-  module-level functions awkward to compose with structured concurrency.
-- **Python**: stateful operations are methods on `scp_sdk.SCP`. Pure protocol
-  helpers stay as module-level functions (`scp_sdk.context.template_get_params`
-  etc.). Python idiom favors module-level functions for pure operations.
-- **TypeScript**: stateful operations are methods on the `SCP` class. Pure
-  helpers may be exposed as `SCP` methods that route to module-level NAPI
-  exports, or as module-level imports — TS-local ergonomic choice.
-- **Swift**: per-object UniFFI-generated wrappers. Pure helpers and per-object
-  methods are both free `pub fn` at the FFI layer — UniFFI generator constraints.
-- **WASM**: free functions at module scope.
-
-## How this lesson applies to future decisions
-
-When you encounter an apparent cross-language asymmetry:
-
-1. **Identify the constraint's origin.** Is the asymmetry forced by a binding
-   tool's structural rules (UniFFI generator, napi-rs limitations,
-   `wasm_bindgen` constraints)? Is it forced by a language's runtime semantics
-   (Kotlin's CoroutineBridge, Python's GIL, TypeScript's async/Promise model)?
-   Or is it just a maintainer preference?
-
-2. **Bound the constraint to its source.** Constraints rooted in language
-   semantics or binding-tool structure stay in that language/bridge. They do
-   not propagate. Don't ask "should X follow Y's pattern" — ask "is there a
-   reason in X's own language/binding to use this pattern?"
-
-3. **Audit the matrix against the spec, not the implementation.** When a
-   cross-bridge consistency audit flags an op as "missing in bridge A but
-   present in bridge B," do not assume B is the reference. The reference is
-   the ADR. Both A and B may be right or wrong. Read the ADR before
-   prescribing a "catch-up."
-
-4. **Never use audit scripts to redefine architecture.** Audit scripts measure
-   code state. Code state can drift from ADRs. The ADR governs (CLAUDE.md
-   artifact-flow invariant: plans → specs → ADRs → stories → source code).
-   Letting code state define the new pattern reverses the flow and creates
-   phantom provenance.
-
-## How this lesson applies to ADR review
-
-When reading or amending an ADR:
-
-1. **Survey the full ADR.** Later sections can supersede or qualify earlier
-   ones. Don't cite §N as authoritative without checking §N+1...§final.
-
-2. **Trace clauses to their source commits.** ADR-048's §1 was drafted
-   2026-04-18 (commit `5c4b4b62d`). §7 was added 2026-04-25 (commit
-   `efc58ecfd` — Phase 4 PR 5). The §7 universalism reflected the §7 commit's
-   PR scope (Kotlin parity), not a reconsideration of §1.
-
-3. **Distinguish architectural claims from implementation snapshots.**
-   "There is one class, one surface, one entry point" is an architectural
-   claim that the SDKs converge on a single shape. "Python: 162 methods,
-   TypeScript: 181 methods, Kotlin: 137 methods" is an implementation
-   snapshot. Snapshots become wrong with the next refactor; only the
-   architectural claim stays load-bearing. ADRs should make architectural
-   claims, not record snapshots.
-
-## How this lesson applies to review-agent workflows
-
-When dispatching multiple review agents to evaluate an architectural choice:
-
-1. **The prompt is part of the experiment.** A prompt that frames the question
-   narrowly (e.g., "should this function be a method or a free function?") will
-   get narrow answers. Agents may unanimously cite the same clause without ever
-   arbitrating a clause-vs-clause contradiction in the same ADR.
-
-2. **Unanimity is weak evidence when the prompt converges agents.** Two
-   agents agreeing on §1 because the prompt asked about pure helpers doesn't
-   tell you whether §1 or §7 governs. To force arbitration, the prompt must
-   surface the contradiction explicitly or ask "which clause governs?" rather
-   than "what's the right pattern?"
-
-3. **Validate review-agent verdicts against the actual ADR before acting.**
-   Even when agents converge with high confidence, read the ADR yourself and
-   confirm they engaged with the relevant sections. Agents skim ADRs the same
-   way humans do.
+When in doubt, ask: "Is this constraint rooted in this language/bridge's
+own semantics, or am I propagating it from elsewhere?" If propagating, stop.
 
 ## Permanent guidance
 
-- The FFI Rust layer (`crates/scp-ffi/*/src/*`) is governed by ADR-048 §1: pure
-  protocol helpers are free functions. Period. No `&self` parameters that
-  go unused. No `_bi: &BridgeInstance` underscore-elision. No "for symmetry
-  with [other bridge]" arguments.
+- **The ADR is the reference, not the implementation.** When a cross-bridge
+  audit flags an op as "missing in X but present in Y," do not assume Y is
+  the reference. Both may be wrong. Read §1 and §7 first, then prescribe.
 
-- The SDK wrapper layer (`bindings/{python,typescript,swift,kotlin}/`) is
-  governed by per-language idiom. Each SDK's shape is a local choice, not a
-  project-wide rule.
+- **Audit scripts measure code state, not intent.** Code can drift from
+  ADRs. ADR-048 §7 was added 2026-04-25 (commit `efc58ecfd`) with one
+  framing; the per-SDK amendment landed the same week (#1543 batch 3a).
+  Letting an audit script's view of code redefine the architecture
+  reverses the artifact-flow invariant in CLAUDE.md.
 
-- ADR-048 §7 has been amended (2026-04-25) to reflect this. Do not re-litigate
-  the universalism question without engaging with this lesson and the
-  amendment commit.
-
-- When in doubt, ask: "Is this constraint rooted in [this language/bridge]'s
-  own semantics, or am I propagating it from elsewhere?" If propagating, stop.
+- **Review-agent unanimity is weak evidence when the prompt converges
+  agents.** If you ask "should this function be a method or a free fn?",
+  agents will cite §1 in unison without arbitrating §1-vs-§7
+  contradictions in the same ADR. To force arbitration the prompt must
+  surface the conflict explicitly.
 
 ## Related artifacts
 
-- `.docs/adrs/ADR-048-scp-multi-instance.md` §1 (FFI layer rule), §7 (per-SDK
-  idiom)
-- `crates/scp-ffi/src/*` — PyO3 free functions
-- `crates/scp-ffi/napi/src/context.rs` — NAPI free functions for pure helpers
-- `crates/scp-ffi/uniffi/src/bridge.rs` — UniFFI free functions
-- `bindings/python/scp_sdk/{context,discovery}.py` — Python module-level exports
-- `bindings/kotlin/scp-kt/...` — Kotlin SCP methods (CoroutineBridge constraint)
-- CLAUDE.md → artifact-flow invariant (plans → specs → ADRs → code)
+- [ADR-048 §1](../adrs/ADR-048-scp-multi-instance.md#1-scp-is-the-first-class-sdk-level-opaque-object-in-all-four-language-sdks) — FFI layer rule.
+- [ADR-048 §7](../adrs/ADR-048-scp-multi-instance.md#7-per-sdk-idiomatic-shape--language-constraints-stay-local) — per-SDK shape table.
+- CLAUDE.md → artifact-flow invariant (plans → specs → ADRs → code).

--- a/.docs/migration/phase-4.md
+++ b/.docs/migration/phase-4.md
@@ -1,8 +1,8 @@
 # Phase 4 upgrade guide — SCP as first-class SDK object
 
 **Target audience:** external SDK consumers upgrading past the #1549 Phase 4
-merge (PR 1 → PR 2 → PR 3 → PR 4 façade deletion → PR 5 Kotlin-parity
-method collapse).
+merge (PR 1 → PR 2 → PR 3 → PR 4 façade deletion → PR 5 namespace-class
+collapse onto `SCP`).
 **ADR:** [ADR-048 — SCP as First-Class Multi-Instance SDK Object](../adrs/ADR-048-scp-multi-instance.md)
 **Status:** live — update for any breaking change landed after 2026-04-21.
 
@@ -10,13 +10,19 @@ Phase 4 converts the four language SDKs from a single process-wide default
 bridge instance into first-class multi-instance objects (PR 1–3), deletes
 the default-instance façade outright (PR 4), then collapses the per-domain
 namespace classes (`Identity`, `Context`, `Relay`, `Node`, `McpServer`,
-`McpClient`, `Transport`, `EventLog`) onto `SCP` itself (PR 5, ADR-048
-§7). Per ADR-048 (re-scoped 2026-04-19), the builder-tenet "no deferral"
-applies — there is no sunset window, no `DeprecationWarning` scaffold, no
-`SCP.default()` accessor, and post-PR-5 there are no free-function or
-namespace-static entry points: **every stateful operation is an instance
-method on `SCP`**. The four SDK surfaces are now Python 162 / TypeScript
-181 / Kotlin 137 / Swift per-handle methods, respectively.
+`McpClient`, `Transport`, `EventLog`) onto `SCP` itself (PR 5). Per
+ADR-048 (re-scoped 2026-04-19), the builder-tenet "no deferral" applies
+— there is no sunset window, no `DeprecationWarning` scaffold, no
+`SCP.default()` accessor, and post-PR-5 there is no free-function or
+namespace-static façade.
+
+**Per-SDK shape** is governed by [ADR-048 §7](../adrs/ADR-048-scp-multi-instance.md#7-per-sdk-idiomatic-shape--language-constraints-stay-local):
+stateful operations land as instance methods on `SCP` in every SDK, while
+pure protocol helpers' SDK shape is a per-language idiomatic choice (Python
+keeps them as module-level functions; Kotlin folds them onto `SCP`;
+TypeScript supports either; Swift and WASM follow their binding-tool
+constraints). Cross-language symmetry is not a goal where it would force
+one language's binding-tool constraints onto another.
 
 ---
 
@@ -36,9 +42,9 @@ method on `SCP`**. The four SDK surfaces are now Python 162 / TypeScript
 Every SDK entry point that previously delegated to a process-wide default
 instance is gone (PR 4). Post-PR-5 the per-domain namespace classes
 (`Identity`, `Context`, `Relay`, `Node`, `McpServer`, `McpClient`,
-`Transport`, `EventLog`) are pure handle types with no methods — every
-stateful operation is a **method on `SCP`**. Callers construct an `SCP`
-at process start and invoke it directly.
+`Transport`, `EventLog`) are pure handle types with no methods — stateful
+operations are **methods on `SCP`** (see [ADR-048 §7](../adrs/ADR-048-scp-multi-instance.md#7-per-sdk-idiomatic-shape--language-constraints-stay-local)).
+Callers construct an `SCP` at process start and invoke it directly.
 
 ```python
 # Before Phase 4
@@ -46,7 +52,7 @@ from scp_sdk import Identity, Context
 identity = await Identity.create(custody="in_memory")
 ctx = await Context.create(creator=identity, ...)
 
-# After Phase 4 PR 5 (Kotlin-parity — ADR-048 §7)
+# After Phase 4 PR 5
 from scp_sdk import SCP
 with SCP() as scp:
     identity = await scp.identity_create("in_memory")
@@ -59,7 +65,7 @@ import { Identity, Context } from "@limn-works/scp-ts";
 const identity = await Identity.create({ custody: "in_memory" });
 const ctx = await Context.create(identity, { ceiling, memoryScope });
 
-// After Phase 4 PR 5 (Kotlin-parity — ADR-048 §7)
+// After Phase 4 PR 5
 import { SCP } from "@limn-works/scp-ts";
 const scp = new SCP();
 try {
@@ -71,15 +77,22 @@ try {
 ```
 
 Pure protocol helpers that touch no registry state (hashing, encoding,
-shape-only validation, `defineToolDefinition`, `parseAddress`) remain as
-free functions. Swift retains per-handle `#[uniffi::Object]` wrappers
-alongside `Scp.swift` — UniFFI does not expose a mechanism to collapse
-`#[uniffi::Object]` receivers into methods on an unrelated outer object
-without hand-written shims, so Swift callers invoke methods on the
-generated handle types (`ctx.send(payload)`) rather than on `scp`.
-Semantically the surface is identical — every handle still carries the
-issuing `SCP`'s `instance_id` and every operation crosses the same
-handle-affinity gate.
+shape-only validation, `defineToolDefinition`, `parseAddress`) remain
+free functions at the FFI Rust layer per ADR-048 §1; their SDK-side
+shape is per-language (see ADR-048 §7). Python keeps them as
+`scp_sdk.context.template_get_params(...)` module-level imports;
+TypeScript exposes them as both `SCP` methods and direct module imports
+(`import { templateGetParams }`); Kotlin folds them onto `SCP` to
+compose with `CoroutineBridge` scope; Swift surfaces them through the
+generated UniFFI handle types. Swift retains per-handle
+`#[uniffi::Object]` wrappers alongside `Scp.swift` — UniFFI does not
+expose a mechanism to collapse `#[uniffi::Object]` receivers into
+methods on an unrelated outer object without hand-written shims, so
+Swift callers invoke methods on the generated handle types
+(`ctx.send(payload)`) rather than on `scp`. Semantically the surface is
+identical — every handle still carries the issuing `SCP`'s
+`instance_id` and every operation crosses the same handle-affinity
+gate.
 
 ### 2. `SCP.resume()` is async (#1678)
 

--- a/bindings/typescript/src/internal/native.ts
+++ b/bindings/typescript/src/internal/native.ts
@@ -1159,9 +1159,12 @@ export function createNativeBridge(scp: SCP): Bridge {
       };
     },
 
-    // Discovery
+    // Discovery — pure protocol helpers per ADR-048 §1. These are
+    // module-level NAPI free functions, NOT methods on the SCP class —
+    // dispatch through `addon.<name>`, never `native.<name>` (which is
+    // the SCP class instance and does not inherit module-level exports).
     discoveryParseAddress(address: string) {
-      return (native.discoveryParseAddress as (a: string) => string)(address);
+      return (addon.discoveryParseAddress as (a: string) => string)(address);
     },
 
     discoveryCreateQuery(
@@ -1170,7 +1173,7 @@ export function createNativeBridge(scp: SCP): Bridge {
       minHistorySecs: number | undefined,
     ) {
       return (
-        native.discoveryCreateQuery as (
+        addon.discoveryCreateQuery as (
           c: string[] | undefined,
           k: string[] | undefined,
           m: number | undefined,
@@ -1179,11 +1182,11 @@ export function createNativeBridge(scp: SCP): Bridge {
     },
 
     discoveryNormalizeAddress(address: string) {
-      return (native.discoveryNormalizeAddress as (a: string) => string)(address);
+      return (addon.discoveryNormalizeAddress as (a: string) => string)(address);
     },
 
     async contextDiscover(query: string): Promise<string> {
-      return await (native.contextDiscover as (q: string) => Promise<string>)(query);
+      return await (addon.contextDiscover as (q: string) => Promise<string>)(query);
     },
 
     // Petnames (§22.4)
@@ -1593,21 +1596,26 @@ export function createNativeBridge(scp: SCP): Bridge {
       )(contextId, sequence, signerDid, timestamp, structuralJson, operationalJson, signatureHex);
     },
 
+    // Pure protocol helpers per ADR-048 §1 — module-level NAPI free
+    // functions, NOT methods on the SCP class. Dispatch through `addon`,
+    // not `native` (the SCP class instance does not inherit module-level
+    // exports). Was previously `native.<name>` which silently became
+    // `(undefined)(args)` at runtime — fixed in #1543 batch 3a.
     metadataRecordFromJson(jsonStr: string): string {
-      return (native.metadataRecordFromJson as (j: string) => string)(jsonStr);
+      return (addon.metadataRecordFromJson as (j: string) => string)(jsonStr);
     },
 
-    // Context template inspection (§5.14, #615)
+    // Context template inspection (§5.14, #615) — pure helpers per ADR-048 §1.
     templateGetParams(templateId: string): string {
-      return (native.templateGetParams as (t: string) => string)(templateId);
+      return (addon.templateGetParams as (t: string) => string)(templateId);
     },
 
     validateAgainstTemplate(paramsJson: string): string | null {
-      return (native.validateAgainstTemplate as (p: string) => string | null)(paramsJson);
+      return (addon.validateAgainstTemplate as (p: string) => string | null)(paramsJson);
     },
 
     validateContextParams(paramsJson: string): string | null {
-      return (native.validateContextParams as (p: string) => string | null)(paramsJson);
+      return (addon.validateContextParams as (p: string) => string | null)(paramsJson);
     },
 
     // Economy (§19, ADR-033)

--- a/bindings/typescript/src/internal/native.ts
+++ b/bindings/typescript/src/internal/native.ts
@@ -1091,8 +1091,9 @@ export function createNativeBridge(scp: SCP): Bridge {
       mode: BridgeMode,
     ) {
       // napi-rs #[napi(object)] returns camelCase keys; Bridge interface expects snake_case.
+      // bridgeRegister is a module-level NAPI free fn (bridge_connector.rs:145), not on the SCP class.
       const raw = (
-        native.bridgeRegister as (
+        addon.bridgeRegister as (
           c: string,
           o: string,
           g: string,
@@ -1122,7 +1123,8 @@ export function createNativeBridge(scp: SCP): Bridge {
       isNativeTransport: boolean,
       shadowStatus: ShadowStatus,
     ) {
-      return (native.bridgeEvaluateTrust as (b: boolean, n: boolean, s: ShadowStatus) => number)(
+      // Module-level NAPI free fn (bridge_connector.rs:76), not on the SCP class.
+      return (addon.bridgeEvaluateTrust as (b: boolean, n: boolean, s: ShadowStatus) => number)(
         isBridged,
         isNativeTransport,
         shadowStatus,
@@ -1804,13 +1806,15 @@ export function createNativeBridge(scp: SCP): Bridge {
       );
     },
 
-    // SCPID authentication (§3.11)
+    // SCPID authentication (§3.11) — methods on the SCP class
+    // (scp.rs:3749, 3761, 3781), NOT module-level NAPI exports.
+    // Dispatch through `native` (the SCP class instance), not `addon`.
     scpidChallenge(audience: string, ttlSeconds: number): string {
-      return (addon.scpidChallenge as (a: string, t: number) => string)(audience, ttlSeconds);
+      return (native.scpidChallenge as (a: string, t: number) => string)(audience, ttlSeconds);
     },
 
     scpidSign(did: string, signingKeyId: string, challengeJson: string): string {
-      return (addon.scpidSign as (d: string, k: string, c: string) => string)(
+      return (native.scpidSign as (d: string, k: string, c: string) => string)(
         did,
         signingKeyId,
         challengeJson,
@@ -1818,7 +1822,7 @@ export function createNativeBridge(scp: SCP): Bridge {
     },
 
     scpidVerify(responseJson: string, challengeJson: string): string {
-      return (addon.scpidVerify as (r: string, c: string) => string)(responseJson, challengeJson);
+      return (native.scpidVerify as (r: string, c: string) => string)(responseJson, challengeJson);
     },
 
     // Trust — participation verification (SCP-BA-004, §7.3.2.1)

--- a/bindings/typescript/src/internal/native.ts
+++ b/bindings/typescript/src/internal/native.ts
@@ -89,21 +89,44 @@ function resolveNapiPackage(): string {
 // Native addon loading
 // ---------------------------------------------------------------------------
 
-/** Shape of the native addon's exported functions. */
-type NativeAddon = Record<string, (...args: never[]) => unknown>;
+/**
+ * Shape of the native addon as observed at the bridge layer. Both module-
+ * level NAPI free functions and the `SCP` class constructor live on the
+ * same object; sibling modules narrow at the use-site.
+ */
+export type NativeAddon = Record<string, unknown>;
+
+// why: one-time FFI addon load cache. Holds the raw napi-rs object whose
+// keys carry both the SCP class constructor (`addon.SCP`) and the
+// module-level free-function exports (templateGetParams, scpVersion,
+// discoveryParseAddress, …) per ADR-048 §1. A single shared cache is the
+// only way to guarantee `internal/native.ts` and `scp.ts` see the same
+// frozen handle — a second loader would call `createRequire(...)` again
+// and `require.cache` could be tampered with by a compromised dep
+// between calls. Allowlisted in scripts/check-no-ts-mutable-globals.sh.
+let _nativeAddon: NativeAddon | null = null;
 
 /**
- * Loads the platform-specific native addon via `createRequire`.
+ * Loads (or returns the cached) platform-specific native addon. The
+ * returned object is `Object.freeze`d post-load so any code path that
+ * later holds a reference cannot mutate the export shape (defence
+ * against require-cache tampering between loader calls — see round-3
+ * `_nativeScp` hardening discussion in ADR-048 §7).
  *
- * Uses the Node.js `module.createRequire` API for ESM compatibility.
- * Falls back to a helpful error message if the package is not installed.
+ * Both `internal/native.ts` and `scp.ts` route through this single
+ * loader — the cache discipline only holds because there is exactly one
+ * loader. Adding a second loader anywhere in the SDK is a regression.
  */
-function loadNativeAddon(): NativeAddon {
-  const packageName = resolveNapiPackage();
+export function loadNativeAddon(): NativeAddon {
+  if (_nativeAddon !== null) {
+    return _nativeAddon;
+  }
 
+  const packageName = resolveNapiPackage();
+  let addon: NativeAddon;
   try {
     const req = createRequire(import.meta.url);
-    return req(packageName) as NativeAddon;
+    addon = req(packageName) as NativeAddon;
   } catch {
     throw new TransportError(
       `Failed to load native addon ${packageName}. ` +
@@ -111,6 +134,19 @@ function loadNativeAddon(): NativeAddon {
       "SCP-TRANS-5001",
     );
   }
+
+  // Freeze before caching: any later code path holding the addon
+  // reference (the `addon` closure local in createNativeBridge, or any
+  // `nativeFreeFn` lookup in scp.ts) reads from the same frozen object.
+  // This blocks post-load monkey-patching of the addon's named exports
+  // — a defense-in-depth control against a compromised optional dep
+  // attempting to swap a free function for a malicious one between
+  // loads. The freeze is shallow (its own properties); the SCP class's
+  // prototype is left mutable because napi-rs constructs handles by
+  // dispatching through it.
+  Object.freeze(addon);
+  _nativeAddon = addon;
+  return _nativeAddon;
 }
 
 // ---------------------------------------------------------------------------
@@ -137,6 +173,20 @@ export function createNativeBridge(scp: SCP): Bridge {
   // Type-erased native handle — every NAPI `Scp` class method shares
   // the `async (...args) => unknown` shape after FFI monomorphization,
   // and routing requires dynamic lookup by camelCase method name.
+  //
+  // Dispatcher routing rule (ADR-048 §1 + §7, enforced by
+  // bindings/typescript/tests/dispatcher-invariant.test.ts):
+  //   • `native.X` → method on the per-instance SCP class
+  //                  (Rust source: `impl Scp { #[napi] fn X(&self) }`
+  //                   in crates/scp-ffi/napi/src/scp.rs)
+  //   • `addon.X`  → module-level NAPI free function
+  //                  (Rust source: `#[napi] pub fn X()` in any other
+  //                   crates/scp-ffi/napi/src/*.rs file)
+  // Routing through the wrong handle becomes `(undefined)(args)` at
+  // runtime; a previous regression masked exactly this bug class —
+  // fixed in 97051e32e + 176763958. The dispatcher invariant test
+  // statically reads both source files and fails CI if any site uses
+  // the wrong handle.
   const native = __getNativeScp(scp) as unknown as Record<string, (...args: never[]) => unknown>;
 
   return {
@@ -1082,7 +1132,11 @@ export function createNativeBridge(scp: SCP): Bridge {
       };
     },
 
-    // Bridge Connector
+    // Bridge Connector — `bridgeRegister` and `bridgeEvaluateTrust` are
+    // module-level NAPI free fns in bridge_connector.rs and dispatch
+    // through `addon.X`. `bridgeCreateShadow` is on the SCP class
+    // (scp.rs:3727) and dispatches through `native.X`. The dispatcher
+    // routing rule above governs.
     bridgeRegister(
       contextId: string,
       operatorDid: string,
@@ -1091,7 +1145,6 @@ export function createNativeBridge(scp: SCP): Bridge {
       mode: BridgeMode,
     ) {
       // napi-rs #[napi(object)] returns camelCase keys; Bridge interface expects snake_case.
-      // bridgeRegister is a module-level NAPI free fn (bridge_connector.rs:145), not on the SCP class.
       const raw = (
         addon.bridgeRegister as (
           c: string,
@@ -1123,7 +1176,6 @@ export function createNativeBridge(scp: SCP): Bridge {
       isNativeTransport: boolean,
       shadowStatus: ShadowStatus,
     ) {
-      // Module-level NAPI free fn (bridge_connector.rs:76), not on the SCP class.
       return (addon.bridgeEvaluateTrust as (b: boolean, n: boolean, s: ShadowStatus) => number)(
         isBridged,
         isNativeTransport,
@@ -1162,9 +1214,9 @@ export function createNativeBridge(scp: SCP): Bridge {
     },
 
     // Discovery — pure protocol helpers per ADR-048 §1. These are
-    // module-level NAPI free functions, NOT methods on the SCP class —
-    // dispatch through `addon.<name>`, never `native.<name>` (which is
-    // the SCP class instance and does not inherit module-level exports).
+    // module-level NAPI free fns in discovery.rs; the dispatcher
+    // routing rule (top of createNativeBridge) routes them through
+    // `addon.X`.
     discoveryParseAddress(address: string) {
       return (addon.discoveryParseAddress as (a: string) => string)(address);
     },
@@ -1599,10 +1651,10 @@ export function createNativeBridge(scp: SCP): Bridge {
     },
 
     // Pure protocol helpers per ADR-048 §1 — module-level NAPI free
-    // functions, NOT methods on the SCP class. Dispatch through `addon`,
-    // not `native` (the SCP class instance does not inherit module-level
-    // exports). Was previously `native.<name>` which silently became
-    // `(undefined)(args)` at runtime — fixed in #1543 batch 3a.
+    // fns (template/metadata/validate-* in context.rs). Routed through
+    // `addon.X` per the dispatcher routing rule. Earlier variants were
+    // `native.<name>` and silently became `(undefined)(args)` at
+    // runtime — fixed in #1543 batch 3a (97051e32e + 176763958).
     metadataRecordFromJson(jsonStr: string): string {
       return (addon.metadataRecordFromJson as (j: string) => string)(jsonStr);
     },
@@ -1807,8 +1859,8 @@ export function createNativeBridge(scp: SCP): Bridge {
     },
 
     // SCPID authentication (§3.11) — methods on the SCP class
-    // (scp.rs:3749, 3761, 3781), NOT module-level NAPI exports.
-    // Dispatch through `native` (the SCP class instance), not `addon`.
+    // (scp.rs:3749, 3761, 3781). Routed through `native.X` per the
+    // dispatcher routing rule.
     scpidChallenge(audience: string, ttlSeconds: number): string {
       return (native.scpidChallenge as (a: string, t: number) => string)(audience, ttlSeconds);
     },

--- a/bindings/typescript/src/scp.ts
+++ b/bindings/typescript/src/scp.ts
@@ -126,6 +126,11 @@ function resolveNapiPackage(): string {
 }
 
 let _nativeScp: NativeScpCtor | null = null;
+// why: one-time FFI addon load cache. Holds both the SCP class and the
+// module-level pure-helper exports (templateGetParams,
+// validateAgainstTemplate, validateContextParams, metadataRecordFromJson)
+// per ADR-048 §1. Direct analog of `_nativeScp` extended for free-function
+// exports. Allowlisted in scripts/check-no-ts-mutable-globals.sh.
 let _nativeAddon: NativeAddon | null = null;
 
 function loadAddon(): NativeAddon {

--- a/bindings/typescript/src/scp.ts
+++ b/bindings/typescript/src/scp.ts
@@ -43,13 +43,23 @@ import type { Node, Relay } from "./server";
 
 /**
  * Shape of the native addon — a subset sufficient to describe the
- * `SCP` class and its static factories.
+ * `SCP` class, its static factories, and the module-level free
+ * functions for pure protocol helpers (per ADR-048 §1: pure helpers
+ * stay free functions at the FFI Rust layer).
  */
 type NativeAddon = {
   // The raw addon exports `SCP` as an opaque napi-rs class. We refine to
   // `NativeScpCtor` after a runtime `typeof` check; `unknown` keeps
   // biome's `noExplicitAny` happy while the check provides the real type.
   SCP?: unknown;
+  // Pure protocol helpers — exported at module scope per ADR-048 §1
+  // because they touch no per-instance state. The `SCP` class methods
+  // for these names route to these module-level exports per ADR-048 §7
+  // (TS keeps the method shape as a TS-local ergonomic choice).
+  metadataRecordFromJson?: unknown;
+  templateGetParams?: unknown;
+  validateAgainstTemplate?: unknown;
+  validateContextParams?: unknown;
 };
 
 /**
@@ -116,10 +126,11 @@ function resolveNapiPackage(): string {
 }
 
 let _nativeScp: NativeScpCtor | null = null;
+let _nativeAddon: NativeAddon | null = null;
 
-function nativeScp(): NativeScpCtor {
-  if (_nativeScp !== null) {
-    return _nativeScp;
+function loadAddon(): NativeAddon {
+  if (_nativeAddon !== null) {
+    return _nativeAddon;
   }
 
   if (typeof process === "undefined" || !process.versions?.node) {
@@ -157,8 +168,52 @@ function nativeScp(): NativeScpCtor {
     );
   }
 
+  _nativeAddon = addon;
   _nativeScp = addon.SCP as unknown as NativeScpCtor;
+  return _nativeAddon;
+}
+
+function nativeScp(): NativeScpCtor {
+  if (_nativeScp !== null) {
+    return _nativeScp;
+  }
+  // loadAddon() either populates _nativeScp or throws — it never returns
+  // without setting the cache.
+  loadAddon();
+  if (_nativeScp === null) {
+    // Defensive: should be unreachable because loadAddon() either
+    // throws (above) or populates _nativeScp before returning.
+    throw new ValidationError(
+      "Native addon loaded but SCP constructor is unavailable — internal " +
+        "invariant violated. File an issue against scp-ts.",
+      "SCP-VALID-7005",
+    );
+  }
   return _nativeScp;
+}
+
+/**
+ * Returns the loaded native addon's module-level export for a pure
+ * protocol helper. Pure helpers live at module scope on the addon per
+ * ADR-048 §1; `SCP` class methods that wrap them route through this
+ * accessor instead of `this.#native[name]`.
+ *
+ * Throws `SCP-VALID-7005` if the addon is unloadable or does not
+ * export the named function (e.g., a stale prebuilt addon predating
+ * the §1 split).
+ */
+function nativeFreeFn<T>(name: keyof NativeAddon): T {
+  const addon = loadAddon();
+  const fn = addon[name];
+  if (typeof fn !== "function") {
+    throw new ValidationError(
+      `Native addon does not export the module-level free function "${String(name)}" — ` +
+        "the addon may be stale (predating ADR-048 §1 pure-helper split). " +
+        "Rebuild with `cargo build -p scp-ffi-napi` or upgrade the platform package.",
+      "SCP-VALID-7005",
+    );
+  }
+  return fn as T;
 }
 
 // ---------------------------------------------------------------------------
@@ -1146,20 +1201,31 @@ export class SCP {
     )(contextId, sequence, signerDid, timestamp, structuralJson, operationalJson, signatureHex);
   }
 
+  // The four pure protocol helpers below are method-shaped on `SCP` for
+  // TS-local ergonomic consistency (ADR-048 §7), but the FFI Rust source
+  // exposes them as module-level free functions per ADR-048 §1 (no
+  // per-instance state to read). Each method routes to the addon's
+  // module-level NAPI export; the `this` receiver carries no runtime
+  // weight in these calls.
+
   metadataRecordFromJson(jsonStr: string): string {
-    return (this.#native.metadataRecordFromJson as (j: string) => string)(jsonStr);
+    const fn = nativeFreeFn<(j: string) => string>("metadataRecordFromJson");
+    return fn(jsonStr);
   }
 
   templateGetParams(templateId: string): string {
-    return (this.#native.templateGetParams as (t: string) => string)(templateId);
+    const fn = nativeFreeFn<(t: string) => string>("templateGetParams");
+    return fn(templateId);
   }
 
   validateAgainstTemplate(paramsJson: string): string | null {
-    return (this.#native.validateAgainstTemplate as (p: string) => string | null)(paramsJson);
+    const fn = nativeFreeFn<(p: string) => string | null>("validateAgainstTemplate");
+    return fn(paramsJson);
   }
 
   validateContextParams(paramsJson: string): string | null {
-    return (this.#native.validateContextParams as (p: string) => string | null)(paramsJson);
+    const fn = nativeFreeFn<(p: string) => string | null>("validateContextParams");
+    return fn(paramsJson);
   }
 
   // ───────────────────────────────────────────────────────────────────────

--- a/bindings/typescript/src/scp.ts
+++ b/bindings/typescript/src/scp.ts
@@ -28,8 +28,6 @@
  * with `SCP-VALID-7005`.
  */
 
-import { createRequire } from "node:module";
-
 // Deferred imports of opaque classes. The classes import `SCP` for
 // typing, so importing them eagerly here creates a module cycle at
 // evaluation time. Using type-only imports keeps the SCP module
@@ -39,18 +37,21 @@ import { createRequire } from "node:module";
 import type { Context } from "./context";
 import { ValidationError } from "./errors";
 import type { Identity } from "./identity";
+import { loadNativeAddon, type NativeAddon as RawNativeAddon } from "./internal/native";
 import type { Node, Relay } from "./server";
 
 /**
- * Shape of the native addon — a subset sufficient to describe the
- * `SCP` class, its static factories, and the module-level free
- * functions for pure protocol helpers (per ADR-048 §1: pure helpers
- * stay free functions at the FFI Rust layer).
+ * Refined view of the native addon used by this module. The shared
+ * loader in `internal/native.ts` returns the raw addon as
+ * `Record<string, unknown>`; we narrow here to surface the names that
+ * `scp.ts` cares about (the `SCP` class constructor + the four
+ * module-level pure-helper exports per ADR-048 §1).
+ *
+ * Both `internal/native.ts` and this module read from the same
+ * `loadNativeAddon`-cached addon — there is one cache, one freeze,
+ * one platform package resolution.
  */
-type NativeAddon = {
-  // The raw addon exports `SCP` as an opaque napi-rs class. We refine to
-  // `NativeScpCtor` after a runtime `typeof` check; `unknown` keeps
-  // biome's `noExplicitAny` happy while the check provides the real type.
+type NativeAddon = RawNativeAddon & {
   SCP?: unknown;
   // Pure protocol helpers — exported at module scope per ADR-048 §1
   // because they touch no per-instance state. The `SCP` class methods
@@ -92,52 +93,18 @@ interface NativeScpInstance {
 }
 
 /**
- * Resolves the platform-specific napi package name.
+ * Resolves the cached native addon and validates the SCP-class export.
  *
- * Mirrors the mapping in `internal/native.ts` so that `SCP` can load
- * the addon directly without going through the `Bridge` interface
- * (which doesn't expose class constructors).
+ * Routes through the shared `loadNativeAddon` cache in
+ * `internal/native.ts` so this module and the bridge factory share a
+ * single frozen addon reference. The shared loader throws
+ * `TransportError` (`SCP-TRANS-5001`) on platform-package missing or
+ * load failure; this wrapper layers an additional WASM-runtime check
+ * and a stale-addon (no `SCP` class) check, both surfaced as
+ * `ValidationError` (`SCP-VALID-7005`) — the public-API code that
+ * SDK consumers see when they call `new SCP(...)`.
  */
-function resolveNapiPackage(): string {
-  const platform = process.platform;
-  const arch = process.arch;
-
-  const platformMap: Record<string, string> = {
-    "linux-x64": "@limn-works/scp-ts-napi-linux-x64-gnu",
-    "linux-arm64": "@limn-works/scp-ts-napi-linux-arm64-gnu",
-    "darwin-x64": "@limn-works/scp-ts-napi-darwin-x64",
-    "darwin-arm64": "@limn-works/scp-ts-napi-darwin-arm64",
-    "win32-x64": "@limn-works/scp-ts-napi-win32-x64-msvc",
-  };
-
-  const key = `${platform}-${arch}`;
-  const pkg = platformMap[key];
-
-  if (pkg === undefined) {
-    throw new ValidationError(
-      `Native addon not found — the @limn-works/scp-ts-napi-* package for ` +
-        `platform ${key} is not published. Install the matching platform package ` +
-        "for your host, or use the WASM bridge in a browser environment.",
-      "SCP-VALID-7005",
-    );
-  }
-
-  return pkg;
-}
-
-let _nativeScp: NativeScpCtor | null = null;
-// why: one-time FFI addon load cache. Holds both the SCP class and the
-// module-level pure-helper exports (templateGetParams,
-// validateAgainstTemplate, validateContextParams, metadataRecordFromJson)
-// per ADR-048 §1. Direct analog of `_nativeScp` extended for free-function
-// exports. Allowlisted in scripts/check-no-ts-mutable-globals.sh.
-let _nativeAddon: NativeAddon | null = null;
-
 function loadAddon(): NativeAddon {
-  if (_nativeAddon !== null) {
-    return _nativeAddon;
-  }
-
   if (typeof process === "undefined" || !process.versions?.node) {
     throw new ValidationError(
       "SCP class is not available in WASM runtime — the browser build of " +
@@ -147,53 +114,40 @@ function loadAddon(): NativeAddon {
     );
   }
 
-  const packageName = resolveNapiPackage();
   let addon: NativeAddon;
   try {
-    const req = createRequire(import.meta.url);
-    addon = req(packageName) as NativeAddon;
+    addon = loadNativeAddon() as NativeAddon;
   } catch (cause) {
     const underlying = (cause as Error)?.message ?? String(cause);
     throw new ValidationError(
-      `Native addon failed to load: ${underlying}. Package ${packageName} ` +
-        "was resolved but could not be instantiated — check that the binary " +
-        "for your host is installed, then reinstall with " +
-        `\`bun install ${packageName}\`.`,
+      `Native addon failed to load: ${underlying}. ` +
+        "Ensure the matching @limn-works/scp-ts-napi-* platform package is " +
+        "installed, then reinstall with `bun install`.",
       "SCP-VALID-7005",
     );
   }
 
   if (typeof addon.SCP !== "function") {
     throw new ValidationError(
-      `Native addon loaded but does not export the SCP class — ` +
-        `${packageName} was built before the Phase 4 PR 1 multi-instance ` +
+      "Native addon loaded but does not export the SCP class — " +
+        "the platform addon was built before the Phase 4 PR 1 multi-instance " +
         "surface landed. Upgrade the package or rebuild from the current " +
         "codebase with `cargo build -p scp-ffi-napi`.",
       "SCP-VALID-7005",
     );
   }
 
-  _nativeAddon = addon;
-  _nativeScp = addon.SCP as unknown as NativeScpCtor;
-  return _nativeAddon;
+  return addon;
 }
+
+let _nativeScp: NativeScpCtor | null = null;
 
 function nativeScp(): NativeScpCtor {
   if (_nativeScp !== null) {
     return _nativeScp;
   }
-  // loadAddon() either populates _nativeScp or throws — it never returns
-  // without setting the cache.
-  loadAddon();
-  if (_nativeScp === null) {
-    // Defensive: should be unreachable because loadAddon() either
-    // throws (above) or populates _nativeScp before returning.
-    throw new ValidationError(
-      "Native addon loaded but SCP constructor is unavailable — internal " +
-        "invariant violated. File an issue against scp-ts.",
-      "SCP-VALID-7005",
-    );
-  }
+  const addon = loadAddon();
+  _nativeScp = addon.SCP as unknown as NativeScpCtor;
   return _nativeScp;
 }
 

--- a/bindings/typescript/tests/dispatcher-invariant.test.ts
+++ b/bindings/typescript/tests/dispatcher-invariant.test.ts
@@ -1,0 +1,458 @@
+/**
+ * Dispatcher invariant test (#1543 batch 3a follow-up).
+ *
+ * `internal/native.ts` routes calls through one of two handles:
+ *   • `native.X` — method on the per-instance `Scp` class (Rust source:
+ *                  `impl Scp { #[napi] fn X(&self) }` in `crates/scp-ffi/napi/src/scp.rs`).
+ *   • `addon.X` — module-level NAPI free function (Rust source:
+ *                 `#[napi] pub fn X()` in any other `crates/scp-ffi/napi/src/*.rs`).
+ *
+ * Routing through the wrong handle silently becomes `(undefined)(args)` at
+ * runtime — a regression caught and fixed across two follow-up PRs (97051e32e,
+ * 176763958), which corrected 13 mis-routed sites. This test guards against
+ * the same bug class returning.
+ *
+ * Approach (static): parse the Rust sources and the dispatcher TS file
+ * directly. The runtime introspection alternative (loading the actual NAPI
+ * addon and reading `Object.getOwnPropertyNames(addon.SCP.prototype)`) is
+ * infeasible in the default test environment because `@limn-works/scp-ts-napi-*`
+ * is not always built before `bun test` runs. Static analysis catches the
+ * same invariant from the Rust source of truth — `#[napi]` placement
+ * (inside `impl Scp` vs at module scope) determines the JS-side handle, and
+ * napi-rs's snake_case → camelCase default conversion is well-defined.
+ */
+
+import { describe, expect, test } from "bun:test";
+import { readdirSync, readFileSync } from "node:fs";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+const REPO_ROOT = resolve(__dirname, "../../..");
+
+const NAPI_SRC_DIR = join(REPO_ROOT, "crates", "scp-ffi", "napi", "src");
+const SCP_RS = join(NAPI_SRC_DIR, "scp.rs");
+const DISPATCHER_TS = join(REPO_ROOT, "bindings", "typescript", "src", "internal", "native.ts");
+
+// ---------------------------------------------------------------------------
+// Naming conversion (Rust snake_case → napi-rs default camelCase)
+// ---------------------------------------------------------------------------
+
+/**
+ * napi-rs default conversion: `snake_case` → `camelCase`. Used when no
+ * explicit `js_name = "..."` is provided on `#[napi]`. Non-leading
+ * underscores boundary into uppercase; leading underscores are kept (private).
+ */
+function toCamelCase(snake: string): string {
+  return snake.replace(/_([a-z0-9])/g, (_, c: string) => c.toUpperCase());
+}
+
+// ---------------------------------------------------------------------------
+// Parse Rust sources
+// ---------------------------------------------------------------------------
+
+interface NapiDecl {
+  name: string;
+  rangeStart: number;
+}
+
+/** Skips over whitespace, doc comments, block comments, and intervening attrs. */
+function skipNonCodePrefix(after: string): number {
+  let cursor = 0;
+  while (cursor < after.length) {
+    // Whitespace
+    if (/\s/.test(after.charAt(cursor))) {
+      cursor++;
+      continue;
+    }
+    // Line comments (including doc comments)
+    if (after.startsWith("//", cursor)) {
+      const eol = after.indexOf("\n", cursor);
+      if (eol === -1) return cursor;
+      cursor = eol + 1;
+      continue;
+    }
+    // Block comments
+    if (after.startsWith("/*", cursor)) {
+      const end = after.indexOf("*/", cursor + 2);
+      if (end === -1) return cursor;
+      cursor = end + 2;
+      continue;
+    }
+    // Another attribute (#[allow(...)] etc.)
+    if (after.startsWith("#[", cursor)) {
+      const end = after.indexOf("]", cursor + 2);
+      if (end === -1) return cursor;
+      cursor = end + 1;
+      continue;
+    }
+    break;
+  }
+  return cursor;
+}
+
+const FN_RE = /^(?:pub(?:\s*\(\s*[a-z]+\s*\))?\s+)?(?:async\s+)?fn\s+([a-z_][a-z0-9_]*)/i;
+const JS_NAME_RE = /js_name\s*=\s*"([^"]+)"/;
+
+/**
+ * Extracts `#[napi]`-annotated function declarations from Rust source. For
+ * each match returns the declared JS name (either the `js_name` override
+ * or the snake_case→camelCase default).
+ */
+function extractNapiDecls(rustSrc: string): NapiDecl[] {
+  const out: NapiDecl[] = [];
+
+  const napiRe = /#\[napi(?:\(([^)]*)\))?\]/g;
+  let m: RegExpExecArray | null = napiRe.exec(rustSrc);
+  while (m !== null) {
+    const args = m[1] ?? "";
+    const attrEnd = m.index + m[0].length;
+    const matchIndex = m.index;
+
+    const after = rustSrc.slice(attrEnd, attrEnd + 1500);
+    const cursor = skipNonCodePrefix(after);
+
+    const next = after.slice(cursor, cursor + 200);
+    const fnM = FN_RE.exec(next);
+
+    if (fnM?.[1] && !/\bconstructor\b/.test(args)) {
+      const rustName = fnM[1];
+      const jsNameMatch = JS_NAME_RE.exec(args);
+      const jsName = jsNameMatch?.[1] ?? toCamelCase(rustName);
+      out.push({ name: jsName, rangeStart: matchIndex });
+    }
+
+    m = napiRe.exec(rustSrc);
+  }
+  return out;
+}
+
+interface BlockRange {
+  start: number;
+  end: number;
+}
+
+interface ScanState {
+  i: number;
+  inString: boolean;
+  inLineComment: boolean;
+  inBlockComment: boolean;
+}
+
+/** Advance one character in a brace-balanced scan, tracking string/comment state. */
+function advanceScan(rustSrc: string, state: ScanState): { depthDelta: number } {
+  const ch = rustSrc.charAt(state.i);
+  const next = rustSrc.charAt(state.i + 1);
+
+  if (state.inLineComment) {
+    if (ch === "\n") state.inLineComment = false;
+    state.i++;
+    return { depthDelta: 0 };
+  }
+  if (state.inBlockComment) {
+    if (ch === "*" && next === "/") {
+      state.inBlockComment = false;
+      state.i += 2;
+    } else {
+      state.i++;
+    }
+    return { depthDelta: 0 };
+  }
+  if (state.inString) {
+    if (ch === "\\") {
+      state.i += 2;
+    } else {
+      if (ch === '"') state.inString = false;
+      state.i++;
+    }
+    return { depthDelta: 0 };
+  }
+  if (ch === "/" && next === "/") {
+    state.inLineComment = true;
+    state.i += 2;
+    return { depthDelta: 0 };
+  }
+  if (ch === "/" && next === "*") {
+    state.inBlockComment = true;
+    state.i += 2;
+    return { depthDelta: 0 };
+  }
+  if (ch === '"') {
+    state.inString = true;
+    state.i++;
+    return { depthDelta: 0 };
+  }
+  state.i++;
+  if (ch === "{") return { depthDelta: 1 };
+  if (ch === "}") return { depthDelta: -1 };
+  return { depthDelta: 0 };
+}
+
+/**
+ * Returns the byte-offset ranges of every `impl <Type> { ... }` block
+ * body matching `implRe`. Pass `/^impl\s+Scp\s*\{/gm` for `impl Scp`,
+ * or `/^impl\s+\w+\s*\{/gm` for any `impl <Type>` block.
+ */
+function findImplBlockRanges(rustSrc: string, implRe: RegExp): BlockRange[] {
+  const out: BlockRange[] = [];
+  let m: RegExpExecArray | null = implRe.exec(rustSrc);
+  while (m !== null) {
+    const bodyStart = m.index + m[0].length;
+    const state: ScanState = {
+      i: bodyStart,
+      inString: false,
+      inLineComment: false,
+      inBlockComment: false,
+    };
+    let depth = 1;
+    while (state.i < rustSrc.length && depth > 0) {
+      depth += advanceScan(rustSrc, state).depthDelta;
+    }
+    if (depth === 0) {
+      out.push({ start: bodyStart, end: state.i - 1 });
+    }
+    m = implRe.exec(rustSrc);
+  }
+  return out;
+}
+
+function isInRange(offset: number, ranges: BlockRange[]): boolean {
+  return ranges.some((r) => offset >= r.start && offset < r.end);
+}
+
+interface NapiSurface {
+  classMethods: Set<string>;
+  freeFns: Set<string>;
+}
+
+/**
+ * Returns two sets of JS-visible names:
+ *   • classMethods — names declared as `#[napi] fn ...` inside `impl Scp { ... }`
+ *                    blocks of `crates/scp-ffi/napi/src/scp.rs`.
+ *   • freeFns      — names declared as `#[napi] pub fn ...` at module scope
+ *                    in any other `crates/scp-ffi/napi/src/*.rs` file.
+ */
+function extractNapiSurface(): NapiSurface {
+  const classMethods = new Set<string>();
+  const freeFns = new Set<string>();
+
+  // scp.rs — split inside vs outside impl Scp.
+  const scpRs = readFileSync(SCP_RS, "utf8");
+  const implScpRanges = findImplBlockRanges(scpRs, /^impl\s+Scp\s*\{/gm);
+  for (const decl of extractNapiDecls(scpRs)) {
+    if (isInRange(decl.rangeStart, implScpRanges)) {
+      classMethods.add(decl.name);
+    } else {
+      freeFns.add(decl.name);
+    }
+  }
+
+  // All other *.rs files in crates/scp-ffi/napi/src/. These contain a mix
+  // of module-level `#[napi] pub fn ...` (free fns) and
+  // `#[napi] impl <OtherType> { ... }` (methods on opaque handle classes
+  // like NapiContextHandle, NapiIdentity, Relay, Node). Methods on those
+  // handles are dispatched through the handle object itself, not via
+  // `addon.X` or `native.X` — exclude them from both sets.
+  for (const entry of readdirSync(NAPI_SRC_DIR)) {
+    if (!entry.endsWith(".rs")) continue;
+    if (entry === "scp.rs") continue;
+    const src = readFileSync(join(NAPI_SRC_DIR, entry), "utf8");
+    const otherImplRanges = findImplBlockRanges(src, /^impl\s+\w+\s*\{/gm);
+    for (const decl of extractNapiDecls(src)) {
+      if (isInRange(decl.rangeStart, otherImplRanges)) continue;
+      freeFns.add(decl.name);
+    }
+  }
+
+  return { classMethods, freeFns };
+}
+
+// ---------------------------------------------------------------------------
+// Parse internal/native.ts dispatch sites
+// ---------------------------------------------------------------------------
+
+interface DispatchSite {
+  handle: "addon" | "native";
+  name: string;
+  line: number;
+}
+
+const DISPATCH_RE = /(?<![A-Za-z0-9_$])(addon|native)\.([A-Za-z_$][A-Za-z0-9_$]*)/g;
+
+function extractDispatchSitesFromLine(line: string, lineNo: number): DispatchSite[] {
+  // Skip pure comment lines so documentation prose (e.g. `addon.X` cited
+  // in the dispatcher routing-rule comment block) is not treated as a
+  // dispatch site.
+  const codeOnly = line.replace(/^\s*\/\/.*$/, "").replace(/^\s*\*.*$/, "");
+  if (codeOnly.trim().length === 0) return [];
+  const sites: DispatchSite[] = [];
+  let m: RegExpExecArray | null = DISPATCH_RE.exec(codeOnly);
+  while (m !== null) {
+    const handle = m[1];
+    const name = m[2];
+    if ((handle === "addon" || handle === "native") && name) {
+      sites.push({ handle, name, line: lineNo });
+    }
+    m = DISPATCH_RE.exec(codeOnly);
+  }
+  return sites;
+}
+
+function extractDispatchSites(): DispatchSite[] {
+  const src = readFileSync(DISPATCHER_TS, "utf8");
+  const lines = src.split("\n");
+  const sites: DispatchSite[] = [];
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i];
+    if (line === undefined) continue;
+    sites.push(...extractDispatchSitesFromLine(line, i + 1));
+  }
+  return sites;
+}
+
+// ---------------------------------------------------------------------------
+// Per-site validation
+// ---------------------------------------------------------------------------
+
+function validateNativeSite(
+  site: DispatchSite,
+  classMethods: Set<string>,
+  freeFns: Set<string>,
+): string | null {
+  if (classMethods.has(site.name)) return null;
+  if (freeFns.has(site.name)) {
+    return (
+      `${DISPATCHER_TS}:${site.line}  uses \`native.${site.name}\` ` +
+      `but '${site.name}' is a module-level NAPI free function ` +
+      `(declared outside \`impl Scp\`). Use \`addon.${site.name}\` instead.`
+    );
+  }
+  return (
+    `${DISPATCHER_TS}:${site.line}  uses \`native.${site.name}\` ` +
+    `but '${site.name}' is not declared anywhere in ` +
+    `crates/scp-ffi/napi/src/. Either add the #[napi] export or fix the dispatcher.`
+  );
+}
+
+function validateAddonSite(
+  site: DispatchSite,
+  classMethods: Set<string>,
+  freeFns: Set<string>,
+): string | null {
+  // `addon.SCP` is the napi-rs class constructor — legitimately a top-level
+  // export, not a method, even though it isn't a `#[napi] pub fn`.
+  if (site.name === "SCP") return null;
+  if (freeFns.has(site.name)) return null;
+  if (classMethods.has(site.name)) {
+    return (
+      `${DISPATCHER_TS}:${site.line}  uses \`addon.${site.name}\` ` +
+      `but '${site.name}' is a method on the SCP class ` +
+      `(declared inside \`impl Scp\`). Use \`native.${site.name}\` instead.`
+    );
+  }
+  return (
+    `${DISPATCHER_TS}:${site.line}  uses \`addon.${site.name}\` ` +
+    `but '${site.name}' is not declared anywhere in ` +
+    `crates/scp-ffi/napi/src/. Either add the #[napi] export or fix the dispatcher.`
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("dispatcher invariant (ADR-048 §1 + §7)", () => {
+  test("scp.rs is the sole `impl Scp` host", () => {
+    // Sanity check: extractNapiSurface assumes `impl Scp` only lives in scp.rs.
+    // If a future change moves `impl Scp` blocks to other files, the static
+    // analysis below would silently misclassify those methods as free fns.
+    for (const entry of readdirSync(NAPI_SRC_DIR)) {
+      if (!entry.endsWith(".rs")) continue;
+      if (entry === "scp.rs") continue;
+      const src = readFileSync(join(NAPI_SRC_DIR, entry), "utf8");
+      expect(/^impl\s+Scp\s*\{/m.test(src)).toBe(false);
+    }
+  });
+
+  test("extracted surfaces are non-empty", () => {
+    const { classMethods, freeFns } = extractNapiSurface();
+    // If the parser regresses to zero matches, the test would pass trivially
+    // (every dispatch site would fail closed). Guard the parser instead. The
+    // thresholds are deliberate floors well below current counts (~180 class
+    // methods, ~12 free fns) so they survive ordinary changes — they catch
+    // a parser regression that goes from "many" to "few", not exact counts.
+    expect(classMethods.size).toBeGreaterThan(50);
+    expect(freeFns.size).toBeGreaterThan(8);
+  });
+
+  test("known anchors land in the correct surface", () => {
+    const { classMethods, freeFns } = extractNapiSurface();
+
+    expect(classMethods.has("identityCreate")).toBe(true);
+    expect(classMethods.has("contextCreate")).toBe(true);
+    expect(classMethods.has("scpidSign")).toBe(true);
+    expect(classMethods.has("bridgeCreateShadow")).toBe(true);
+    expect(classMethods.has("instanceId")).toBe(true);
+
+    expect(freeFns.has("discoveryParseAddress")).toBe(true);
+    expect(freeFns.has("metadataRecordFromJson")).toBe(true);
+    expect(freeFns.has("templateGetParams")).toBe(true);
+    expect(freeFns.has("validateAgainstTemplate")).toBe(true);
+    expect(freeFns.has("validateContextParams")).toBe(true);
+    expect(freeFns.has("contextDiscover")).toBe(true);
+    expect(freeFns.has("bridgeRegister")).toBe(true);
+    expect(freeFns.has("bridgeEvaluateTrust")).toBe(true);
+    expect(freeFns.has("scpVersion")).toBe(true);
+  });
+
+  test("every (addon|native).X dispatch site routes to the correct handle", () => {
+    const { classMethods, freeFns } = extractNapiSurface();
+    const sites = extractDispatchSites();
+
+    expect(sites.length).toBeGreaterThan(50);
+
+    const errors: string[] = [];
+    for (const site of sites) {
+      const err =
+        site.handle === "native"
+          ? validateNativeSite(site, classMethods, freeFns)
+          : validateAddonSite(site, classMethods, freeFns);
+      if (err) errors.push(err);
+    }
+
+    if (errors.length > 0) {
+      throw new Error(`Dispatcher invariant violations (${errors.length}):\n${errors.join("\n")}`);
+    }
+  });
+
+  test("intentional class+free overlaps are accounted for", () => {
+    // Some names are deliberately exported as BOTH an `Scp` method and a
+    // module-level free fn — e.g. `check_scoped_capability` is a pure
+    // helper exported both ways so callers may use either entry point.
+    // The dispatcher's routing site is unambiguous as long as it routes
+    // consistently (the per-site test above checks that). Track known
+    // overlaps here so a NEW overlap surfaces as a test diff rather than
+    // silently passing.
+    const KNOWN_INTENTIONAL_OVERLAPS = new Set<string>([
+      // crates/scp-ffi/napi/src/{scp.rs,context.rs} — pure helper exported
+      // both as Scp::check_scoped_capability and as a free fn so callers
+      // outside an SCP context (test harnesses, examples) can invoke it
+      // without constructing an SCP. native.ts routes through the class.
+      "checkScopedCapability",
+    ]);
+    const { classMethods, freeFns } = extractNapiSurface();
+    const observed: string[] = [];
+    for (const name of classMethods) {
+      if (freeFns.has(name)) observed.push(name);
+    }
+    const unexpected = observed.filter((n) => !KNOWN_INTENTIONAL_OVERLAPS.has(n));
+    if (unexpected.length > 0) {
+      throw new Error(
+        `NAPI name(s) declared as both Scp method AND free fn (NEW overlap, not in known-intentional set): ${unexpected.join(", ")}. ` +
+          "If the dual export is intentional, add to KNOWN_INTENTIONAL_OVERLAPS; " +
+          "otherwise disambiguate at the Rust source (rename the free fn or remove the duplicate).",
+      );
+    }
+  });
+});

--- a/bindings/typescript/tests/mock-bridge.ts
+++ b/bindings/typescript/tests/mock-bridge.ts
@@ -16,10 +16,10 @@
  * in B1 — every call on a live SDK now lands on a `SCP.*` method, which
  * dispatches directly to `this.#native.methodName(...)`.
  *
- * The mock therefore needs to shadow the NAPI `Scp` class surface
- * (~181 methods + `instanceId` + `suspend`/`resume`/`shutdown`). Rather
- * than hand-rolling a full reimplementation, the factory returns a
- * `Proxy` that:
+ * The mock therefore needs to shadow the live `Scp` NAPI surface
+ * (per-instance lifecycle, governance, content, identity, and pure
+ * helper methods). Rather than hand-rolling a full reimplementation,
+ * the factory returns a `Proxy` that:
  *
  * 1. Intercepts every `get` on the fake handle.
  * 2. If the caller has configured a stub for that method name via

--- a/bindings/typescript/tsconfig.json
+++ b/bindings/typescript/tsconfig.json
@@ -15,7 +15,8 @@
     "outDir": "dist",
     "rootDir": "src",
     "skipLibCheck": true,
-    "lib": ["ESNext", "DOM", "DOM.Iterable"]
+    "lib": ["ESNext", "DOM", "DOM.Iterable"],
+    "types": ["node"]
   },
   "include": ["src/**/*.ts"],
   "exclude": ["node_modules", "dist"]

--- a/crates/scp-ffi/napi/src/context.rs
+++ b/crates/scp-ffi/napi/src/context.rs
@@ -3205,11 +3205,12 @@ pub(crate) fn metadata_record_to_json_on(
     })
 }
 
-/// Per-bridge-instance implementation of [`metadata_record_from_json`].
-pub(crate) fn metadata_record_from_json_on(
-    _bi: &NapiBridgeInstance,
-    json_str: String,
-) -> napi::Result<String> {
+/// Pure protocol helper — parses, validates, and re-serializes a `MetadataRecord` JSON.
+///
+/// Touches no per-instance state, so it is a top-level free function per ADR-048 §1
+/// ("Pure protocol helpers stay free functions at the FFI Rust layer").
+#[napi(js_name = "metadataRecordFromJson")]
+pub fn metadata_record_from_json(json_str: String) -> napi::Result<String> {
     use scp_core::context::metadata::MetadataRecord;
 
     let record: MetadataRecord = serde_json::from_str(&json_str).map_err(|e| {
@@ -3250,11 +3251,12 @@ pub(crate) fn metadata_record_from_json_on(
 // Context template inspection (§5.14, #615)
 // ---------------------------------------------------------------------------
 
-/// Per-bridge-instance implementation of `template_get_params`.
-pub(crate) fn template_get_params_on(
-    _bi: &NapiBridgeInstance,
-    template_id: String,
-) -> napi::Result<String> {
+/// Pure protocol helper — looks up the canonical `ContextParams` for a template ID.
+///
+/// Touches no per-instance state, so it is a top-level free function per ADR-048 §1
+/// ("Pure protocol helpers stay free functions at the FFI Rust layer").
+#[napi(js_name = "templateGetParams")]
+pub fn template_get_params(template_id: String) -> napi::Result<String> {
     use scp_core::context::templates::template_params;
 
     let tid = parse_template_id_napi(&template_id)?;
@@ -3267,11 +3269,12 @@ pub(crate) fn template_get_params_on(
     })
 }
 
-/// Per-bridge-instance implementation of `validate_against_template`.
-pub(crate) fn validate_against_template_on(
-    _bi: &NapiBridgeInstance,
-    params_json: String,
-) -> napi::Result<Option<String>> {
+/// Pure protocol helper — validates `ContextParams` JSON against template constraints.
+///
+/// Touches no per-instance state, so it is a top-level free function per ADR-048 §1
+/// ("Pure protocol helpers stay free functions at the FFI Rust layer").
+#[napi(js_name = "validateAgainstTemplate")]
+pub fn validate_against_template(params_json: String) -> napi::Result<Option<String>> {
     use scp_core::context::templates::validate_against_template;
 
     let params: scp_core::context::ContextParams =
@@ -3288,11 +3291,12 @@ pub(crate) fn validate_against_template_on(
     }
 }
 
-/// Per-bridge-instance implementation of `validate_context_params`.
-pub(crate) fn validate_context_params_on(
-    _bi: &NapiBridgeInstance,
-    params_json: String,
-) -> napi::Result<Option<String>> {
+/// Pure protocol helper — validates `ContextParams` JSON for shape correctness.
+///
+/// Touches no per-instance state, so it is a top-level free function per ADR-048 §1
+/// ("Pure protocol helpers stay free functions at the FFI Rust layer").
+#[napi(js_name = "validateContextParams")]
+pub fn validate_context_params(params_json: String) -> napi::Result<Option<String>> {
     use scp_core::context::templates::validate_context_params;
 
     let params: scp_core::context::ContextParams =

--- a/crates/scp-ffi/napi/src/scp.rs
+++ b/crates/scp-ffi/napi/src/scp.rs
@@ -2592,30 +2592,6 @@ impl Scp {
         )
     }
 
-    /// Per-instance equivalent of the free-function `metadata_record_from_json`.
-    #[napi(js_name = "metadataRecordFromJson")]
-    pub fn metadata_record_from_json(&self, json_str: String) -> napi::Result<String> {
-        crate::context::metadata_record_from_json_on(&self.inner, json_str)
-    }
-
-    /// Per-instance equivalent of the free-function `template_get_params`.
-    #[napi(js_name = "templateGetParams")]
-    pub fn template_get_params(&self, template_id: String) -> napi::Result<String> {
-        crate::context::template_get_params_on(&self.inner, template_id)
-    }
-
-    /// Per-instance equivalent of the free-function `validate_against_template`.
-    #[napi(js_name = "validateAgainstTemplate")]
-    pub fn validate_against_template(&self, params_json: String) -> napi::Result<Option<String>> {
-        crate::context::validate_against_template_on(&self.inner, params_json)
-    }
-
-    /// Per-instance equivalent of the free-function `validate_context_params`.
-    #[napi(js_name = "validateContextParams")]
-    pub fn validate_context_params(&self, params_json: String) -> napi::Result<Option<String>> {
-        crate::context::validate_context_params_on(&self.inner, params_json)
-    }
-
     // ===== sub-slice C: tools =====
 
     /// Per-instance equivalent of the free-function `tool_register`.

--- a/scripts/bridge-aliases.json
+++ b/scripts/bridge-aliases.json
@@ -2485,6 +2485,125 @@
       "wasm": [
         "context_governance_list_proposals"
       ]
+    },
+    {
+      "canonical": "template_get_params",
+      "category": "context",
+      "wasm_required": false,
+      "pyo3": [
+        "py_template_get_params"
+      ],
+      "uniffi": [
+        "template_get_params"
+      ],
+      "napi": [
+        "template_get_params"
+      ],
+      "wasm": [
+        "template_get_params"
+      ]
+    },
+    {
+      "canonical": "validate_against_template",
+      "category": "context",
+      "wasm_required": false,
+      "pyo3": [
+        "py_validate_against_template"
+      ],
+      "uniffi": [
+        "validate_against_template"
+      ],
+      "napi": [
+        "validate_against_template"
+      ],
+      "wasm": [
+        "validate_against_template"
+      ]
+    },
+    {
+      "canonical": "validate_context_params",
+      "category": "context",
+      "wasm_required": false,
+      "pyo3": [
+        "py_validate_context_params"
+      ],
+      "uniffi": [
+        "validate_context_params"
+      ],
+      "napi": [
+        "validate_context_params"
+      ],
+      "wasm": [
+        "validate_context_params"
+      ]
+    },
+    {
+      "canonical": "metadata_record_from_json",
+      "category": "context",
+      "wasm_required": false,
+      "pyo3": [
+        "py_metadata_record_from_json"
+      ],
+      "uniffi": [
+        "metadata_record_from_json"
+      ],
+      "napi": [
+        "metadata_record_from_json"
+      ],
+      "wasm": [
+        "metadata_record_from_json"
+      ]
+    },
+    {
+      "canonical": "discovery_create_query",
+      "category": "discovery",
+      "wasm_required": false,
+      "pyo3": [
+        "py_discovery_create_query"
+      ],
+      "uniffi": [
+        "discovery_create_query"
+      ],
+      "napi": [
+        "discovery_create_query"
+      ],
+      "wasm": [
+        "discovery_create_query"
+      ]
+    },
+    {
+      "canonical": "context_discover",
+      "category": "discovery",
+      "wasm_required": false,
+      "pyo3": [
+        "py_context_discover"
+      ],
+      "uniffi": [
+        "context_discover"
+      ],
+      "napi": [
+        "context_discover"
+      ],
+      "wasm": [
+        "context_discover"
+      ]
+    },
+    {
+      "canonical": "identity_remove_link_attestation",
+      "category": "identity",
+      "wasm_required": false,
+      "pyo3": [
+        "remove_identity_link_attestation"
+      ],
+      "uniffi": [
+        "identity_remove_link_attestation"
+      ],
+      "napi": [
+        "identity_remove_link_attestation"
+      ],
+      "wasm": [
+        "identity_remove_link_attestation"
+      ]
     }
   ],
   "exemptions": {

--- a/scripts/check-no-ts-mutable-globals.sh
+++ b/scripts/check-no-ts-mutable-globals.sh
@@ -99,6 +99,12 @@ ALLOWLIST=(
     _initPromise
     # scp.ts — lazy-resolved napi native constructor.
     _nativeScp
+    # scp.ts — cached napi addon handle holding both the SCP class and
+    # module-level pure-helper exports (templateGetParams,
+    # validateAgainstTemplate, validateContextParams,
+    # metadataRecordFromJson per ADR-048 §1). One-time FFI addon load —
+    # the analog of `_nativeScp` for the module-level helper exports.
+    _nativeAddon
     # mcp.ts — cached napi addon handle for MCP bridge functions.
     _mcpAddon
     # server.ts — cached napi addon handle for Server bridge functions.

--- a/scripts/check-no-ts-mutable-globals.sh
+++ b/scripts/check-no-ts-mutable-globals.sh
@@ -99,11 +99,15 @@ ALLOWLIST=(
     _initPromise
     # scp.ts — lazy-resolved napi native constructor.
     _nativeScp
-    # scp.ts — cached napi addon handle holding both the SCP class and
-    # module-level pure-helper exports (templateGetParams,
-    # validateAgainstTemplate, validateContextParams,
-    # metadataRecordFromJson per ADR-048 §1). One-time FFI addon load —
-    # the analog of `_nativeScp` for the module-level helper exports.
+    # internal/native.ts — single shared napi addon cache. Holds both
+    # the SCP class constructor (`addon.SCP`) and the module-level
+    # pure-helper exports (templateGetParams, validateAgainstTemplate,
+    # validateContextParams, metadataRecordFromJson, scpVersion,
+    # discoveryParseAddress, …) per ADR-048 §1. Both `internal/native.ts`
+    # and `scp.ts` route through `loadNativeAddon()` so there is exactly
+    # one frozen handle per process — a second loader anywhere in the
+    # SDK would defeat the cache discipline and re-open the
+    # `require.cache` mutation surface that the freeze closes.
     _nativeAddon
     # mcp.ts — cached napi addon handle for MCP bridge functions.
     _mcpAddon


### PR DESCRIPTION
## Summary

Batch 3a of #1543 (cross-bridge consistency, Phase 5). Closes the PyO3 cross-bridge gap for 6 ops:

- 5 migrations from legacy `py_*` free fns → `PyScp` methods (per the post-#1700 instance-method pattern):
  - `context_discover`, `discovery_create_query`
  - `template_get_params`, `validate_against_template`, `validate_context_params`
- 1 matrix-only entry (`identity_remove_link_attestation` — already exists as `PyScp::remove_identity_link_attestation` since #1700).

Module-level free functions in `scp_sdk/discovery.py` (`create_query`) and `scp_sdk/context.py` (`template_get_params`, `validate_against_template`, `validate_context_params`) deleted; replaced by async methods on the `SCP` class. Type stubs in `_scp_core.pyi` updated.

Matrix: 134 → 140 ops.

## Test plan

- [x] `cargo check -p scp-ffi` — clean
- [x] `bash scripts/check-bridge-symmetry.sh` — 0 findings
- [x] `python3.12 scripts/check-call-invariants.py` — pass
- [x] `cargo test -p scp-testing --test ffi_conformance` — 32/32 pass
- [x] `maturin develop --release --features scp-ffi/allow_in_memory_custody` — clean
- [x] `python3.12 -m pytest tests/` — 605 passed, 1 skipped
- [x] `cargo clippy --workspace --all-targets --features <CI set> -- -D warnings` — clean
- [x] `cargo fmt --all -- --check` — clean
- [x] `python3.12 -m ruff check . && ruff format --check .` — clean

Refs #1543; follows #1703 (Batch 2) and #1704 (Batch 2b helper extraction).

🤖 Generated with [Claude Code](https://claude.com/claude-code)