### PR TITLE
chore(bridge-symmetry): batch 3b — register access_key_* matrix entries (#1543)

### DIFF
--- a/scripts/bridge-aliases.json
+++ b/scripts/bridge-aliases.json
@@ -1,6 +1,6 @@
 {
   "schema_version": "1.0",
-  "_generated_from": "crates/scp-testing/tests/integration/ffi_conformance.rs \u2014 PARITY_OPERATIONS + per-bridge alias match arms",
+  "_generated_from": "crates/scp-testing/tests/integration/ffi_conformance.rs — PARITY_OPERATIONS + per-bridge alias match arms",
   "operations": [
     {
       "canonical": "identity_create",
@@ -2400,6 +2400,57 @@
       "wasm": [
         "context_tombstone_migrated"
       ]
+    },
+    {
+      "canonical": "access_key_generate",
+      "category": "context",
+      "wasm_required": false,
+      "pyo3": [
+        "access_key_generate"
+      ],
+      "uniffi": [
+        "access_key_generate"
+      ],
+      "napi": [
+        "access_key_generate"
+      ],
+      "wasm": [
+        "access_key_generate"
+      ]
+    },
+    {
+      "canonical": "access_key_revoke",
+      "category": "context",
+      "wasm_required": false,
+      "pyo3": [
+        "access_key_revoke"
+      ],
+      "uniffi": [
+        "access_key_revoke"
+      ],
+      "napi": [
+        "access_key_revoke"
+      ],
+      "wasm": [
+        "access_key_revoke"
+      ]
+    },
+    {
+      "canonical": "access_key_restore",
+      "category": "context",
+      "wasm_required": false,
+      "pyo3": [
+        "access_key_restore"
+      ],
+      "uniffi": [
+        "access_key_restore"
+      ],
+      "napi": [
+        "access_key_restore"
+      ],
+      "wasm": [
+        "access_key_restore"
+      ]
     }
   ],
   "exemptions": {
@@ -2437,6 +2488,18 @@
       {
         "canonical": "context_tombstone_migrated",
         "reason": "Tombstone helper relies on scp-platform persistence; WASM defers persistence to host JS runtime per ADR-034"
+      },
+      {
+        "canonical": "access_key_generate",
+        "reason": "Per-context access keys involve MLS group membership state and persistence; WASM has no scp-platform / no openmls direct linkage per ADR-034. Generation in WASM is a follow-up if/when WASM gets first-class membership."
+      },
+      {
+        "canonical": "access_key_revoke",
+        "reason": "Revocation requires modifying persisted access key state and broadcasting to MLS group; WASM has no scp-platform per ADR-034."
+      },
+      {
+        "canonical": "access_key_restore",
+        "reason": "Restoration reads persisted access key state; WASM has no scp-platform per ADR-034."
       }
     ]
   }


### PR DESCRIPTION
## Summary

Batch 3b of #1543 (cross-bridge consistency, Phase 5). Pure matrix-only PR adding 3 entries for the access-key family:

- `access_key_generate`, `access_key_revoke`, `access_key_restore` — already present in PyO3, NAPI, UniFFI. WASM-exempt per ADR-034 (access keys involve MLS-bound membership state and persistence; WASM has no scp-platform / no openmls direct linkage).

Matrix: 134 → 137 ops. WASM exemptions: 4 → 7.

## Test plan

- [x] `python3.12 -c "import json; json.load(open('scripts/bridge-aliases.json'))"` — JSON valid
- [x] `bash scripts/check-bridge-symmetry.sh` — 0 findings
- [x] `python3.12 scripts/check-call-invariants.py` — pass
- [x] `cargo test -p scp-testing --test ffi_conformance` — 32/32 pass
- [x] `cargo clippy --workspace --all-targets --features <CI set> -- -D warnings` — clean

Refs #1543; follows #1703 (Batch 2), #1704 (Batch 2b), #1705 (Batch 3a).

🤖 Generated with [Claude Code](https://claude.com/claude-code)