### PR TITLE
chore(bridge-symmetry): batch 3c — register MCP cluster matrix entries (#1543)

### DIFF
--- a/scripts/bridge-aliases.json
+++ b/scripts/bridge-aliases.json
@@ -2487,122 +2487,190 @@
       ]
     },
     {
-      "canonical": "template_get_params",
-      "category": "context",
+      "canonical": "mcp_server_create",
+      "category": "mcp",
       "wasm_required": false,
       "pyo3": [
-        "py_template_get_params"
+        "py_mcp_serve"
       ],
       "uniffi": [
-        "template_get_params"
+        "mcp_server_create"
       ],
       "napi": [
-        "template_get_params"
+        "mcp_server_create"
       ],
       "wasm": [
-        "template_get_params"
+        "mcp_server_create"
       ]
     },
     {
-      "canonical": "validate_against_template",
-      "category": "context",
+      "canonical": "mcp_server_stop",
+      "category": "mcp",
       "wasm_required": false,
       "pyo3": [
-        "py_validate_against_template"
+        "py_mcp_server_stop"
       ],
       "uniffi": [
-        "validate_against_template"
+        "mcp_server_stop"
       ],
       "napi": [
-        "validate_against_template"
+        "mcp_server_stop"
       ],
       "wasm": [
-        "validate_against_template"
+        "mcp_server_stop"
       ]
     },
     {
-      "canonical": "validate_context_params",
-      "category": "context",
+      "canonical": "mcp_client_connect_stdio",
+      "category": "mcp",
       "wasm_required": false,
       "pyo3": [
-        "py_validate_context_params"
+        "py_mcp_client_connect_stdio"
       ],
       "uniffi": [
-        "validate_context_params"
+        "mcp_client_connect_stdio"
       ],
       "napi": [
-        "validate_context_params"
+        "mcp_client_connect_stdio"
       ],
       "wasm": [
-        "validate_context_params"
+        "mcp_client_connect_stdio"
       ]
     },
     {
-      "canonical": "metadata_record_from_json",
-      "category": "context",
+      "canonical": "mcp_client_connect_sse",
+      "category": "mcp",
       "wasm_required": false,
       "pyo3": [
-        "py_metadata_record_from_json"
+        "py_mcp_client_connect_sse"
       ],
       "uniffi": [
-        "metadata_record_from_json"
+        "mcp_client_connect_sse"
       ],
       "napi": [
-        "metadata_record_from_json"
+        "mcp_client_connect_sse"
       ],
       "wasm": [
-        "metadata_record_from_json"
+        "mcp_client_connect_sse"
       ]
     },
     {
-      "canonical": "discovery_create_query",
-      "category": "discovery",
+      "canonical": "mcp_client_disconnect",
+      "category": "mcp",
       "wasm_required": false,
       "pyo3": [
-        "py_discovery_create_query"
+        "py_mcp_client_disconnect"
       ],
       "uniffi": [
-        "discovery_create_query"
+        "mcp_client_disconnect"
       ],
       "napi": [
-        "discovery_create_query"
+        "mcp_client_disconnect"
       ],
       "wasm": [
-        "discovery_create_query"
+        "mcp_client_disconnect"
       ]
     },
     {
-      "canonical": "context_discover",
-      "category": "discovery",
+      "canonical": "mcp_client_list_tools",
+      "category": "mcp",
       "wasm_required": false,
       "pyo3": [
-        "py_context_discover"
+        "py_mcp_client_list_tools"
       ],
       "uniffi": [
-        "context_discover"
+        "mcp_client_list_tools"
       ],
       "napi": [
-        "context_discover"
+        "mcp_client_list_tools"
       ],
       "wasm": [
-        "context_discover"
+        "mcp_client_list_tools"
       ]
     },
     {
-      "canonical": "identity_remove_link_attestation",
-      "category": "identity",
+      "canonical": "mcp_client_invoke",
+      "category": "mcp",
       "wasm_required": false,
       "pyo3": [
-        "remove_identity_link_attestation"
+        "py_mcp_client_invoke"
       ],
       "uniffi": [
-        "identity_remove_link_attestation"
+        "mcp_client_invoke"
       ],
       "napi": [
-        "identity_remove_link_attestation"
+        "mcp_client_invoke"
       ],
       "wasm": [
-        "identity_remove_link_attestation"
+        "mcp_client_invoke"
+      ]
+    },
+    {
+      "canonical": "mcp_configure_stdio_allowlist",
+      "category": "mcp",
+      "wasm_required": false,
+      "pyo3": [
+        "py_mcp_configure_stdio_allowlist"
+      ],
+      "uniffi": [
+        "mcp_configure_stdio_allowlist"
+      ],
+      "napi": [
+        "mcp_configure_stdio_allowlist"
+      ],
+      "wasm": [
+        "mcp_configure_stdio_allowlist"
+      ]
+    },
+    {
+      "canonical": "mcp_disable_stdio_allowlist",
+      "category": "mcp",
+      "wasm_required": false,
+      "pyo3": [
+        "py_mcp_disable_stdio_allowlist"
+      ],
+      "uniffi": [
+        "mcp_disable_stdio_allowlist"
+      ],
+      "napi": [
+        "mcp_disable_stdio_allowlist"
+      ],
+      "wasm": [
+        "mcp_disable_stdio_allowlist"
+      ]
+    },
+    {
+      "canonical": "mcp_reset_stdio_allowlist",
+      "category": "mcp",
+      "wasm_required": false,
+      "pyo3": [
+        "py_mcp_reset_stdio_allowlist"
+      ],
+      "uniffi": [
+        "mcp_reset_stdio_allowlist"
+      ],
+      "napi": [
+        "mcp_reset_stdio_allowlist"
+      ],
+      "wasm": [
+        "mcp_reset_stdio_allowlist"
+      ]
+    },
+    {
+      "canonical": "mcp_get_stdio_allowlist",
+      "category": "mcp",
+      "wasm_required": false,
+      "pyo3": [
+        "py_mcp_get_stdio_allowlist"
+      ],
+      "uniffi": [
+        "mcp_get_stdio_allowlist"
+      ],
+      "napi": [
+        "mcp_get_stdio_allowlist"
+      ],
+      "wasm": [
+        "mcp_get_stdio_allowlist"
       ]
     }
   ],
@@ -2653,6 +2721,50 @@
       {
         "canonical": "access_key_restore",
         "reason": "Restoration reads persisted access key state; WASM has no scp-platform per ADR-034."
+      },
+      {
+        "canonical": "mcp_server_create",
+        "reason": "MCP requires stdio/process spawning or HTTP transport for SSE; WASM has no scp-platform / no stdio per ADR-034. MCP is server/desktop-only."
+      },
+      {
+        "canonical": "mcp_server_stop",
+        "reason": "MCP requires stdio/process spawning or HTTP transport for SSE; WASM has no scp-platform / no stdio per ADR-034. MCP is server/desktop-only."
+      },
+      {
+        "canonical": "mcp_client_connect_stdio",
+        "reason": "MCP requires stdio/process spawning or HTTP transport for SSE; WASM has no scp-platform / no stdio per ADR-034. MCP is server/desktop-only."
+      },
+      {
+        "canonical": "mcp_client_connect_sse",
+        "reason": "MCP requires stdio/process spawning or HTTP transport for SSE; WASM has no scp-platform / no stdio per ADR-034. MCP is server/desktop-only."
+      },
+      {
+        "canonical": "mcp_client_disconnect",
+        "reason": "MCP requires stdio/process spawning or HTTP transport for SSE; WASM has no scp-platform / no stdio per ADR-034. MCP is server/desktop-only."
+      },
+      {
+        "canonical": "mcp_client_list_tools",
+        "reason": "MCP requires stdio/process spawning or HTTP transport for SSE; WASM has no scp-platform / no stdio per ADR-034. MCP is server/desktop-only."
+      },
+      {
+        "canonical": "mcp_client_invoke",
+        "reason": "MCP requires stdio/process spawning or HTTP transport for SSE; WASM has no scp-platform / no stdio per ADR-034. MCP is server/desktop-only."
+      },
+      {
+        "canonical": "mcp_configure_stdio_allowlist",
+        "reason": "MCP requires stdio/process spawning or HTTP transport for SSE; WASM has no scp-platform / no stdio per ADR-034. MCP is server/desktop-only."
+      },
+      {
+        "canonical": "mcp_disable_stdio_allowlist",
+        "reason": "MCP requires stdio/process spawning or HTTP transport for SSE; WASM has no scp-platform / no stdio per ADR-034. MCP is server/desktop-only."
+      },
+      {
+        "canonical": "mcp_reset_stdio_allowlist",
+        "reason": "MCP requires stdio/process spawning or HTTP transport for SSE; WASM has no scp-platform / no stdio per ADR-034. MCP is server/desktop-only."
+      },
+      {
+        "canonical": "mcp_get_stdio_allowlist",
+        "reason": "MCP requires stdio/process spawning or HTTP transport for SSE; WASM has no scp-platform / no stdio per ADR-034. MCP is server/desktop-only."
       }
     ]
   }

--- a/scripts/bridge-aliases.json
+++ b/scripts/bridge-aliases.json
@@ -1020,48 +1020,6 @@
       ]
     },
     {
-      "canonical": "mcp_server",
-      "category": "mcp",
-      "wasm_required": false,
-      "pyo3": [
-        "py_mcp_server",
-        "mcp_server",
-        "py_mcp_serve",
-        "mcp_serve"
-      ],
-      "uniffi": [
-        "mcp_server"
-      ],
-      "napi": [
-        "mcp_server",
-        "mcp_server_create"
-      ],
-      "wasm": [
-        "mcp_server"
-      ]
-    },
-    {
-      "canonical": "mcp_client",
-      "category": "mcp",
-      "wasm_required": false,
-      "pyo3": [
-        "py_mcp_client",
-        "mcp_client",
-        "py_mcp_client_connect_stdio",
-        "mcp_client_connect_stdio"
-      ],
-      "uniffi": [
-        "mcp_client"
-      ],
-      "napi": [
-        "mcp_client",
-        "mcp_client_connect_stdio"
-      ],
-      "wasm": [
-        "mcp_client"
-      ]
-    },
-    {
       "canonical": "economy_estimate_cost",
       "category": "economy",
       "wasm_required": false,
@@ -2487,6 +2445,125 @@
       ]
     },
     {
+      "canonical": "template_get_params",
+      "category": "context",
+      "wasm_required": false,
+      "pyo3": [
+        "py_template_get_params"
+      ],
+      "uniffi": [
+        "template_get_params"
+      ],
+      "napi": [
+        "template_get_params"
+      ],
+      "wasm": [
+        "template_get_params"
+      ]
+    },
+    {
+      "canonical": "validate_against_template",
+      "category": "context",
+      "wasm_required": false,
+      "pyo3": [
+        "py_validate_against_template"
+      ],
+      "uniffi": [
+        "validate_against_template"
+      ],
+      "napi": [
+        "validate_against_template"
+      ],
+      "wasm": [
+        "validate_against_template"
+      ]
+    },
+    {
+      "canonical": "validate_context_params",
+      "category": "context",
+      "wasm_required": false,
+      "pyo3": [
+        "py_validate_context_params"
+      ],
+      "uniffi": [
+        "validate_context_params"
+      ],
+      "napi": [
+        "validate_context_params"
+      ],
+      "wasm": [
+        "validate_context_params"
+      ]
+    },
+    {
+      "canonical": "metadata_record_from_json",
+      "category": "context",
+      "wasm_required": false,
+      "pyo3": [
+        "py_metadata_record_from_json"
+      ],
+      "uniffi": [
+        "metadata_record_from_json"
+      ],
+      "napi": [
+        "metadata_record_from_json"
+      ],
+      "wasm": [
+        "metadata_record_from_json"
+      ]
+    },
+    {
+      "canonical": "discovery_create_query",
+      "category": "discovery",
+      "wasm_required": false,
+      "pyo3": [
+        "py_discovery_create_query"
+      ],
+      "uniffi": [
+        "discovery_create_query"
+      ],
+      "napi": [
+        "discovery_create_query"
+      ],
+      "wasm": [
+        "discovery_create_query"
+      ]
+    },
+    {
+      "canonical": "context_discover",
+      "category": "discovery",
+      "wasm_required": false,
+      "pyo3": [
+        "py_context_discover"
+      ],
+      "uniffi": [
+        "context_discover"
+      ],
+      "napi": [
+        "context_discover"
+      ],
+      "wasm": [
+        "context_discover"
+      ]
+    },
+    {
+      "canonical": "identity_remove_link_attestation",
+      "category": "identity",
+      "wasm_required": false,
+      "pyo3": [
+        "remove_identity_link_attestation"
+      ],
+      "uniffi": [
+        "identity_remove_link_attestation"
+      ],
+      "napi": [
+        "identity_remove_link_attestation"
+      ],
+      "wasm": [
+        "identity_remove_link_attestation"
+      ]
+    },
+    {
       "canonical": "mcp_server_create",
       "category": "mcp",
       "wasm_required": false,
@@ -2677,16 +2754,7 @@
   "exemptions": {
     "_comment": "Per-bridge exemptions for operations that are intentionally not implemented in that bridge. This is a MIRROR of the language-level exemptions in .docs/standards/sdk-capability-matrix.json, keyed by bridge name (pyo3 / uniffi / napi / wasm) rather than SDK language. The symmetry script consults this map in addition to the wasm_required flag before emitting a finding.",
     "pyo3": [],
-    "uniffi": [
-      {
-        "canonical": "mcp_server",
-        "reason": "UniFFI targets mobile; MCP is PyO3/NAPI only"
-      },
-      {
-        "canonical": "mcp_client",
-        "reason": "UniFFI targets mobile; MCP is PyO3/NAPI only"
-      }
-    ],
+    "uniffi": [],
     "napi": [
       {
         "canonical": "identity_migrate",


### PR DESCRIPTION
## Summary

Batch 3c of #1543. Pure matrix-only PR adding 11 MCP entries — all already exist in PyO3 (`py_mcp_*` legacy names), NAPI, and UniFFI. WASM-exempt per ADR-034 (MCP requires stdio/process spawning or SSE/HTTP transport).

Ops: `mcp_server_create` (PyO3 alias `py_mcp_serve`), `mcp_server_stop`, `mcp_client_{connect_stdio, connect_sse, disconnect, list_tools, invoke}`, `mcp_{configure, disable, reset, get}_stdio_allowlist`.

Matrix: 137 → 148 ops. WASM exemptions: 7 → 18.

## Test plan

- [x] `bash scripts/check-bridge-symmetry.sh` — 0 findings
- [x] `cargo test -p scp-testing --test ffi_conformance` — 32/32 pass
- [x] `python3.12 scripts/check-call-invariants.py` — pass

Refs #1543; follows #1703, #1705, #1706.

🤖 Generated with [Claude Code](https://claude.com/claude-code)