### PR TITLE
chore(bridge-symmetry): batch 3d — 11 cross-bridge matrix entries (broadcast subscriber, tool_interface, link attestation, node/relay startup) (#1543)

### DIFF
--- a/crates/scp-testing/tests/integration/ffi_conformance.rs
+++ b/crates/scp-testing/tests/integration/ffi_conformance.rs
@@ -1162,6 +1162,9 @@ const WASM_REQUIRED_OPERATIONS: &[&str] = &[
     "tool_register",
     "tool_invoke",
     "tool_verify",
+    "tool_interface_expose",
+    "tool_interface_accept",
+    "tool_interface_revoke",
     // UCAN
     "ucan_validate",
     "ucan_mint",
@@ -1176,6 +1179,9 @@ const WASM_REQUIRED_OPERATIONS: &[&str] = &[
     "broadcast_unsubscribe",
     "broadcast_publish",
     "broadcast_block",
+    "broadcast_subscriber_count",
+    "broadcast_is_subscriber",
+    "broadcast_admission",
     // Trust
     "trust_query_score",
     "trust_verify_attestation",
@@ -1240,6 +1246,7 @@ const WASM_REQUIRED_OPERATIONS: &[&str] = &[
     "broadcast_unblock",
     // Identity (7)
     "identity_link_attestations",
+    "identity_create_link_attestation",
     "identity_create_with_agent_key",
     "identity_execute_recovery",
     "identity_execute_custody_migration",

--- a/scripts/bridge-aliases.json
+++ b/scripts/bridge-aliases.json
@@ -2751,48 +2751,6 @@
       ]
     },
     {
-      "canonical": "mcp_server",
-      "category": "mcp",
-      "wasm_required": false,
-      "pyo3": [
-        "py_mcp_server",
-        "mcp_server",
-        "py_mcp_serve",
-        "mcp_serve"
-      ],
-      "uniffi": [
-        "mcp_server"
-      ],
-      "napi": [
-        "mcp_server",
-        "mcp_server_create"
-      ],
-      "wasm": [
-        "mcp_server"
-      ]
-    },
-    {
-      "canonical": "mcp_client",
-      "category": "mcp",
-      "wasm_required": false,
-      "pyo3": [
-        "py_mcp_client",
-        "mcp_client",
-        "py_mcp_client_connect_stdio",
-        "mcp_client_connect_stdio"
-      ],
-      "uniffi": [
-        "mcp_client"
-      ],
-      "napi": [
-        "mcp_client",
-        "mcp_client_connect_stdio"
-      ],
-      "wasm": [
-        "mcp_client"
-      ]
-    },
-    {
       "canonical": "tool_interface_expose",
       "category": "tools",
       "wasm_required": true,
@@ -2909,7 +2867,8 @@
       ],
       "wasm": [
         "identity_create_link_attestation"
-      ]
+      ],
+      "_note": "WASM diverges from native bridges in attestation signer key. PyO3/NAPI/UniFFI sign with core_id.active_signing_key (#active per spec §3.5.1; crates/scp-ffi/src/identity.rs and equivalents in napi/uniffi). WASM identity_create_link_attestation (crates/scp-ffi/wasm/src/identity.rs:2632) signs with signing_key_bytes (#0 identity key per spec §3.5.2). Cross-bridge verification must know the issuer bridge to choose the correct verification key. Symmetry harness must NOT treat these as byte-equivalent operations. Tracked for spec-vs-impl reconciliation (align WASM to #active or formally document #0 per spec §3.5.2); see ADR-048 §7 + .docs/lessons/per-sdk-idiom-not-cross-language-dogma.md."
     },
     {
       "canonical": "node_start_in_memory",
@@ -2983,16 +2942,7 @@
   "exemptions": {
     "_comment": "Per-bridge exemptions for operations that are intentionally not implemented in that bridge. This is a MIRROR of the language-level exemptions in .docs/standards/sdk-capability-matrix.json, keyed by bridge name (pyo3 / uniffi / napi / wasm) rather than SDK language. The symmetry script consults this map in addition to the wasm_required flag before emitting a finding.",
     "pyo3": [],
-    "uniffi": [
-      {
-        "canonical": "mcp_server",
-        "reason": "UniFFI targets mobile; MCP is PyO3/NAPI only"
-      },
-      {
-        "canonical": "mcp_client",
-        "reason": "UniFFI targets mobile; MCP is PyO3/NAPI only"
-      }
-    ],
+    "uniffi": [],
     "napi": [
       {
         "canonical": "identity_migrate",

--- a/scripts/bridge-aliases.json
+++ b/scripts/bridge-aliases.json
@@ -3074,19 +3074,19 @@
       },
       {
         "canonical": "node_start_in_memory",
-        "reason": "Application Node and Relay binaries are server-side; WASM has no scp-platform / no openmls direct linkage / no transport per ADR-034."
+        "reason": "Application Node and Relay binaries are server-side; WASM has no scp-platform / no transport per ADR-034."
       },
       {
         "canonical": "node_start_local",
-        "reason": "Application Node and Relay binaries are server-side; WASM has no scp-platform / no openmls direct linkage / no transport per ADR-034."
+        "reason": "Application Node and Relay binaries are server-side; WASM has no scp-platform / no transport per ADR-034."
       },
       {
         "canonical": "relay_start_in_memory",
-        "reason": "Application Node and Relay binaries are server-side; WASM has no scp-platform / no openmls direct linkage / no transport per ADR-034."
+        "reason": "Application Node and Relay binaries are server-side; WASM has no scp-platform / no transport per ADR-034."
       },
       {
         "canonical": "relay_start_local",
-        "reason": "Application Node and Relay binaries are server-side; WASM has no scp-platform / no openmls direct linkage / no transport per ADR-034."
+        "reason": "Application Node and Relay binaries are server-side; WASM has no scp-platform / no transport per ADR-034."
       }
     ]
   }

--- a/scripts/bridge-aliases.json
+++ b/scripts/bridge-aliases.json
@@ -2749,12 +2749,250 @@
       "wasm": [
         "mcp_get_stdio_allowlist"
       ]
+    },
+    {
+      "canonical": "mcp_server",
+      "category": "mcp",
+      "wasm_required": false,
+      "pyo3": [
+        "py_mcp_server",
+        "mcp_server",
+        "py_mcp_serve",
+        "mcp_serve"
+      ],
+      "uniffi": [
+        "mcp_server"
+      ],
+      "napi": [
+        "mcp_server",
+        "mcp_server_create"
+      ],
+      "wasm": [
+        "mcp_server"
+      ]
+    },
+    {
+      "canonical": "mcp_client",
+      "category": "mcp",
+      "wasm_required": false,
+      "pyo3": [
+        "py_mcp_client",
+        "mcp_client",
+        "py_mcp_client_connect_stdio",
+        "mcp_client_connect_stdio"
+      ],
+      "uniffi": [
+        "mcp_client"
+      ],
+      "napi": [
+        "mcp_client",
+        "mcp_client_connect_stdio"
+      ],
+      "wasm": [
+        "mcp_client"
+      ]
+    },
+    {
+      "canonical": "tool_interface_expose",
+      "category": "tools",
+      "wasm_required": true,
+      "pyo3": [
+        "tool_interface_expose"
+      ],
+      "uniffi": [
+        "tool_interface_expose"
+      ],
+      "napi": [
+        "tool_interface_expose"
+      ],
+      "wasm": [
+        "tool_interface_expose"
+      ]
+    },
+    {
+      "canonical": "tool_interface_accept",
+      "category": "tools",
+      "wasm_required": true,
+      "pyo3": [
+        "tool_interface_accept"
+      ],
+      "uniffi": [
+        "tool_interface_accept"
+      ],
+      "napi": [
+        "tool_interface_accept"
+      ],
+      "wasm": [
+        "tool_interface_accept"
+      ]
+    },
+    {
+      "canonical": "tool_interface_revoke",
+      "category": "tools",
+      "wasm_required": true,
+      "pyo3": [
+        "tool_interface_revoke"
+      ],
+      "uniffi": [
+        "tool_interface_revoke"
+      ],
+      "napi": [
+        "tool_interface_revoke"
+      ],
+      "wasm": [
+        "tool_interface_revoke"
+      ]
+    },
+    {
+      "canonical": "broadcast_subscriber_count",
+      "category": "broadcast",
+      "wasm_required": true,
+      "pyo3": [
+        "broadcast_subscriber_count"
+      ],
+      "uniffi": [
+        "broadcast_subscriber_count"
+      ],
+      "napi": [
+        "context_broadcast_subscriber_count"
+      ],
+      "wasm": [
+        "broadcast_subscriber_count"
+      ]
+    },
+    {
+      "canonical": "broadcast_is_subscriber",
+      "category": "broadcast",
+      "wasm_required": true,
+      "pyo3": [
+        "broadcast_is_subscriber"
+      ],
+      "uniffi": [
+        "broadcast_is_subscriber"
+      ],
+      "napi": [
+        "context_is_broadcast_subscriber"
+      ],
+      "wasm": [
+        "broadcast_is_subscriber"
+      ]
+    },
+    {
+      "canonical": "broadcast_admission",
+      "category": "broadcast",
+      "wasm_required": true,
+      "pyo3": [
+        "broadcast_admission"
+      ],
+      "uniffi": [
+        "broadcast_admission"
+      ],
+      "napi": [
+        "context_broadcast_admission"
+      ],
+      "wasm": [
+        "broadcast_admission"
+      ]
+    },
+    {
+      "canonical": "identity_create_link_attestation",
+      "category": "identity",
+      "wasm_required": true,
+      "pyo3": [
+        "create_identity_link_attestation"
+      ],
+      "uniffi": [
+        "identity_create_link_attestation"
+      ],
+      "napi": [
+        "identity_create_link_attestation"
+      ],
+      "wasm": [
+        "identity_create_link_attestation"
+      ]
+    },
+    {
+      "canonical": "node_start_in_memory",
+      "category": "transport",
+      "wasm_required": false,
+      "pyo3": [
+        "node_start_in_memory"
+      ],
+      "uniffi": [
+        "node_start_in_memory"
+      ],
+      "napi": [
+        "node_start_in_memory"
+      ],
+      "wasm": [
+        "node_start_in_memory"
+      ]
+    },
+    {
+      "canonical": "node_start_local",
+      "category": "transport",
+      "wasm_required": false,
+      "pyo3": [
+        "node_start_local"
+      ],
+      "uniffi": [
+        "node_start_local"
+      ],
+      "napi": [
+        "node_start_local"
+      ],
+      "wasm": [
+        "node_start_local"
+      ]
+    },
+    {
+      "canonical": "relay_start_in_memory",
+      "category": "transport",
+      "wasm_required": false,
+      "pyo3": [
+        "relay_start_in_memory"
+      ],
+      "uniffi": [
+        "relay_start_in_memory"
+      ],
+      "napi": [
+        "relay_start_in_memory"
+      ],
+      "wasm": [
+        "relay_start_in_memory"
+      ]
+    },
+    {
+      "canonical": "relay_start_local",
+      "category": "transport",
+      "wasm_required": false,
+      "pyo3": [
+        "relay_start_local"
+      ],
+      "uniffi": [
+        "relay_start_local"
+      ],
+      "napi": [
+        "relay_start_local"
+      ],
+      "wasm": [
+        "relay_start_local"
+      ]
     }
   ],
   "exemptions": {
     "_comment": "Per-bridge exemptions for operations that are intentionally not implemented in that bridge. This is a MIRROR of the language-level exemptions in .docs/standards/sdk-capability-matrix.json, keyed by bridge name (pyo3 / uniffi / napi / wasm) rather than SDK language. The symmetry script consults this map in addition to the wasm_required flag before emitting a finding.",
     "pyo3": [],
-    "uniffi": [],
+    "uniffi": [
+      {
+        "canonical": "mcp_server",
+        "reason": "UniFFI targets mobile; MCP is PyO3/NAPI only"
+      },
+      {
+        "canonical": "mcp_client",
+        "reason": "UniFFI targets mobile; MCP is PyO3/NAPI only"
+      }
+    ],
     "napi": [
       {
         "canonical": "identity_migrate",
@@ -2833,6 +3071,22 @@
       {
         "canonical": "mcp_get_stdio_allowlist",
         "reason": "MCP requires stdio/process spawning or HTTP transport for SSE; WASM has no scp-platform / no stdio per ADR-034. MCP is server/desktop-only."
+      },
+      {
+        "canonical": "node_start_in_memory",
+        "reason": "Application Node and Relay binaries are server-side; WASM has no scp-platform / no openmls direct linkage / no transport per ADR-034."
+      },
+      {
+        "canonical": "node_start_local",
+        "reason": "Application Node and Relay binaries are server-side; WASM has no scp-platform / no openmls direct linkage / no transport per ADR-034."
+      },
+      {
+        "canonical": "relay_start_in_memory",
+        "reason": "Application Node and Relay binaries are server-side; WASM has no scp-platform / no openmls direct linkage / no transport per ADR-034."
+      },
+      {
+        "canonical": "relay_start_local",
+        "reason": "Application Node and Relay binaries are server-side; WASM has no scp-platform / no openmls direct linkage / no transport per ADR-034."
       }
     ]
   }


### PR DESCRIPTION
## Summary

Batch 3d of #1543. Matrix-only PR adding 11 entries for ops already symmetric across bridges.

- **3 broadcast subscriber ops** (PyO3+UniFFI+WASM bare names; NAPI uses `context_broadcast_*` prefix): `broadcast_subscriber_count`, `broadcast_is_subscriber`, `broadcast_admission`
- **identity_create_link_attestation** (PyO3 alias `create_identity_link_attestation`; rest use canonical)
- **3 tool_interface ops**: `tool_interface_expose`, `tool_interface_accept`, `tool_interface_revoke`
- **4 server startup ops** (PyO3+NAPI+UniFFI; WASM-exempt per ADR-034): `node_start_in_memory`, `node_start_local`, `relay_start_in_memory`, `relay_start_local`

Promotes 7 to `wasm_required: true` (broadcast subscriber trio, identity_create_link_attestation, tool_interface trio) — `WASM_REQUIRED_OPERATIONS` in `ffi_conformance.rs` updated in lockstep.

Matrix: 137 → 148 ops. WASM exemptions: 7 → 11.

## Test plan

- [x] `bash scripts/check-bridge-symmetry.sh` — 0 findings
- [x] `python3.12 scripts/check-call-invariants.py` — pass
- [x] `cargo test -p scp-testing --test ffi_conformance` — 32/32 pass
- [x] `cargo clippy --workspace --all-targets --features <CI set> -- -D warnings` — clean
- [x] `cargo fmt --all -- --check` — clean

Refs #1543; follows #1703, #1705, #1706, #1707.

🤖 Generated with [Claude Code](https://claude.com/claude-code)