### PR TITLE
chore(bridge-symmetry): batch 3e — governance get/list_proposal matrix entries (#1543)

### DIFF
--- a/crates/scp-testing/tests/integration/ffi_conformance.rs
+++ b/crates/scp-testing/tests/integration/ffi_conformance.rs
@@ -1220,6 +1220,8 @@ const WASM_REQUIRED_OPERATIONS: &[&str] = &[
     "context_governance_approve",
     "context_governance_reject",
     "context_governance_withdraw",
+    "context_governance_get_proposal",
+    "context_governance_list_proposals",
     // Context lifecycle (6)
     "context_finalize_close",
     "context_apply_pending_ceiling_modification",

--- a/scripts/bridge-aliases.json
+++ b/scripts/bridge-aliases.json
@@ -2451,6 +2451,40 @@
       "wasm": [
         "access_key_restore"
       ]
+    },
+    {
+      "canonical": "context_governance_get_proposal",
+      "category": "governance",
+      "wasm_required": true,
+      "pyo3": [
+        "governance_get_proposal"
+      ],
+      "uniffi": [
+        "governance_get_proposal"
+      ],
+      "napi": [
+        "context_governance_get_proposal"
+      ],
+      "wasm": [
+        "context_governance_get_proposal"
+      ]
+    },
+    {
+      "canonical": "context_governance_list_proposals",
+      "category": "governance",
+      "wasm_required": true,
+      "pyo3": [
+        "governance_list_proposals"
+      ],
+      "uniffi": [
+        "governance_list_proposals"
+      ],
+      "napi": [
+        "context_governance_list_proposals"
+      ],
+      "wasm": [
+        "context_governance_list_proposals"
+      ]
     }
   ],
   "exemptions": {


### PR DESCRIPTION
## Summary

Batch 3e of #1543. Adds `context_governance_get_proposal` and `context_governance_list_proposals` to the matrix — both already exist in all 4 bridges (PyO3/UniFFI bare names, NAPI/WASM `context_*` prefix). Promoted to `wasm_required: true` with `WASM_REQUIRED_OPERATIONS` ratchet updated in lockstep.

Matrix: +2 ops.

## Test plan

- [x] `bash scripts/check-bridge-symmetry.sh` — 0 findings
- [x] `cargo test -p scp-testing --test ffi_conformance` — 32/32 pass
- [x] `python3.12 scripts/check-call-invariants.py` — pass

Refs #1543; follows #1703, #1705, #1706, #1707, #1708.

🤖 Generated with [Claude Code](https://claude.com/claude-code)