### PR TITLE
chore(bridge-symmetry): batch 3f+3g — sandbox + configure_relay_transport + identity_verify_link_attestation matrix entries (#1543)

### DIFF
--- a/crates/scp-testing/tests/integration/ffi_conformance.rs
+++ b/crates/scp-testing/tests/integration/ffi_conformance.rs
@@ -1152,6 +1152,7 @@ const WASM_REQUIRED_OPERATIONS: &[&str] = &[
     "identity_migrate",
     "identity_attest_device",
     "identity_verify_device_attestation",
+    "identity_verify_link_attestation",
     // Context lifecycle
     "context_create",
     "context_join",

--- a/crates/scp-testing/tests/integration/ffi_conformance.rs
+++ b/crates/scp-testing/tests/integration/ffi_conformance.rs
@@ -1240,6 +1240,9 @@ const WASM_REQUIRED_OPERATIONS: &[&str] = &[
     "context_governance_withdraw",
     "context_governance_get_proposal",
     "context_governance_list_proposals",
+    // Sandbox / capability checking (Batch 3f)
+    "sandbox_check_capability",
+    "sandbox_validate_declaration",
     // Context lifecycle (6)
     "context_finalize_close",
     "context_apply_pending_ceiling_modification",

--- a/scripts/bridge-aliases.json
+++ b/scripts/bridge-aliases.json
@@ -3005,6 +3005,23 @@
       "wasm": [
         "configure_relay_transport"
       ]
+    },
+    {
+      "canonical": "identity_verify_link_attestation",
+      "category": "identity",
+      "wasm_required": true,
+      "pyo3": [
+        "verify_identity_link_attestation"
+      ],
+      "uniffi": [
+        "identity_verify_link_attestation"
+      ],
+      "napi": [
+        "identity_verify_link_attestation"
+      ],
+      "wasm": [
+        "identity_verify_link_attestation_signature"
+      ]
     }
   ],
   "exemptions": {

--- a/scripts/bridge-aliases.json
+++ b/scripts/bridge-aliases.json
@@ -2954,6 +2954,57 @@
       "wasm": [
         "with_storage"
       ]
+    },
+    {
+      "canonical": "sandbox_check_capability",
+      "category": "context",
+      "wasm_required": true,
+      "pyo3": [
+        "py_check_scoped_capability"
+      ],
+      "uniffi": [
+        "sandbox_check_capability"
+      ],
+      "napi": [
+        "check_scoped_capability"
+      ],
+      "wasm": [
+        "sandbox_check_capability"
+      ]
+    },
+    {
+      "canonical": "sandbox_validate_declaration",
+      "category": "context",
+      "wasm_required": true,
+      "pyo3": [
+        "py_validate_capability_declaration"
+      ],
+      "uniffi": [
+        "sandbox_validate_declaration"
+      ],
+      "napi": [
+        "validate_capability_declaration"
+      ],
+      "wasm": [
+        "sandbox_validate_declaration"
+      ]
+    },
+    {
+      "canonical": "configure_relay_transport",
+      "category": "transport",
+      "wasm_required": false,
+      "pyo3": [
+        "configure_relay_transport"
+      ],
+      "uniffi": [
+        "configure_relay_transport"
+      ],
+      "napi": [
+        "configure_relay_transport"
+      ],
+      "wasm": [
+        "configure_relay_transport"
+      ]
     }
   ],
   "exemptions": {
@@ -3058,6 +3109,10 @@
       {
         "canonical": "with_storage",
         "reason": "WASM bridge has no scp-platform per ADR-034 — no persistent on-disk storage primitives. Storage attachment is a no-op on WASM; consumers either use the in-memory default or wire persistence via the host JS runtime."
+      },
+      {
+        "canonical": "configure_relay_transport",
+        "reason": "WASM has no scp-platform / no transport per ADR-034."
       }
     ]
   }


### PR DESCRIPTION
## Summary

Combined batches 3f and 3g of #1543 (squashed to avoid serialized matrix conflicts on the merge queue). Adds 4 cross-bridge matrix entries:

**Batch 3f (3 entries):**
- \`sandbox_check_capability\` — same op across all 4 bridges under different names (PyO3 \`py_check_scoped_capability\`, NAPI \`check_scoped_capability\`, UniFFI/WASM \`sandbox_check_capability\`).
- \`sandbox_validate_declaration\` — same pattern (PyO3 \`py_validate_capability_declaration\`, NAPI \`validate_capability_declaration\`, UniFFI/WASM \`sandbox_validate_declaration\`).
- \`configure_relay_transport\` — PyO3+NAPI+UniFFI; WASM-exempt per ADR-034.

**Batch 3g (1 entry):**
- \`identity_verify_link_attestation\` — PyO3 \`verify_identity_link_attestation\`, UniFFI/NAPI \`identity_verify_link_attestation\`, WASM \`identity_verify_link_attestation_signature\`.

Sandbox ops + verify_link_attestation promoted to \`wasm_required: true\` (\`WASM_REQUIRED_OPERATIONS\` updated in lockstep).

Closes #1711 (3g content cherry-picked into this branch). \`identity_rotate_key\` matrix entry remains owned by #1720 (superseded path) / #1717 (real WASM port).

Matrix: 136 → 140 ops.

## Test plan

- [x] \`bash scripts/check-bridge-symmetry.sh\` — 0 findings
- [x] \`cargo test -p scp-testing --test ffi_conformance\` — 32/32 pass
- [x] \`python3.12 scripts/check-call-invariants.py\` — pass
- [x] \`cargo fmt --all -- --check\` — clean
- [x] All 4 bridge aliases resolve to real \`fn <alias>(\` definitions

Refs #1543. Follow-ups still needed (real impl gaps, separate PRs):
- \`identity_verify_link_attestation\` in PyO3 — already exists; matrix entry above closes the cross-bridge gap
- \`identity_rotate_key\` in NAPI/UniFFI — owned by #1717

🤖 Generated with [Claude Code](https://claude.com/claude-code)