### PR TITLE
chore(bridge-symmetry): batch 3g — identity verify_link_attestation + rotate_key matrix entries (#1543)

### DIFF
--- a/crates/scp-testing/tests/integration/ffi_conformance.rs
+++ b/crates/scp-testing/tests/integration/ffi_conformance.rs
@@ -1152,6 +1152,7 @@ const WASM_REQUIRED_OPERATIONS: &[&str] = &[
     "identity_migrate",
     "identity_attest_device",
     "identity_verify_device_attestation",
+    "identity_verify_link_attestation",
     // Context lifecycle
     "context_create",
     "context_join",

--- a/scripts/bridge-aliases.json
+++ b/scripts/bridge-aliases.json
@@ -2954,6 +2954,23 @@
       "wasm": [
         "with_storage"
       ]
+    },
+    {
+      "canonical": "identity_verify_link_attestation",
+      "category": "identity",
+      "wasm_required": true,
+      "pyo3": [
+        "verify_identity_link_attestation"
+      ],
+      "uniffi": [
+        "identity_verify_link_attestation"
+      ],
+      "napi": [
+        "identity_verify_link_attestation"
+      ],
+      "wasm": [
+        "identity_verify_link_attestation_signature"
+      ]
     }
   ],
   "exemptions": {


### PR DESCRIPTION
## Summary

Batch 3g of #1543. Adds 1 matrix entry — `identity_verify_link_attestation` — implemented in all 4 bridges under varying names:

- **identity_verify_link_attestation**: PyO3 `verify_identity_link_attestation`, UniFFI/NAPI `identity_verify_link_attestation`, WASM `identity_verify_link_attestation_signature`.

Promoted to `wasm_required: true` with `WASM_REQUIRED_OPERATIONS` updated in lockstep. Naming variation across bridges absorbed by the matrix's per-bridge alias arrays.

## Scope reduction

Originally this batch also included `identity_rotate_key` with a `_note` annotation flagging WASM's DID-migration semantics versus native active-only rotation per spec §3.7. PR #1720 supersedes that entry by stubbing WASM `identity_rotate_key` to return `SCP-IDENT-1029 NotImplemented` and pointing callers at `identity_migrate` for the prior DID-migration behavior. The matrix entry for `identity_rotate_key` is now owned by #1720.

Matrix: +1 op.

## Test plan

- [x] `bash scripts/check-bridge-symmetry.sh` — 0 findings
- [x] `cargo test -p scp-testing --test ffi_conformance` — 32/32 pass
- [x] `cargo fmt --all -- --check` — clean
- [x] All 4 bridge aliases resolve to real `fn <alias>(` definitions

Refs #1543; follows #1703, #1705, #1706, #1707, #1708, #1709, #1710; superseded by #1720 for rotate_key.

🤖 Generated with [Claude Code](https://claude.com/claude-code)