### PR TITLE
chore(bridge-symmetry): batch 4h — init_storage matrix entry (#1543)

### DIFF
--- a/scripts/bridge-aliases.json
+++ b/scripts/bridge-aliases.json
@@ -2485,6 +2485,23 @@
       "wasm": [
         "context_governance_list_proposals"
       ]
+    },
+    {
+      "canonical": "init_storage",
+      "category": "transport",
+      "wasm_required": false,
+      "pyo3": [
+        "init_storage"
+      ],
+      "uniffi": [
+        "init_storage"
+      ],
+      "napi": [
+        "init_storage"
+      ],
+      "wasm": [
+        "init_storage"
+      ]
     }
   ],
   "exemptions": {
@@ -2498,12 +2515,20 @@
       {
         "canonical": "mcp_client",
         "reason": "UniFFI targets mobile; MCP is PyO3/NAPI only"
+      },
+      {
+        "canonical": "init_storage",
+        "reason": "Other bridges use SCP::with_storage(StorageConfig) factory (PR #1684); PyO3 retains init_storage for incremental initialization compatibility with pre-Phase-4 callers."
       }
     ],
     "napi": [
       {
         "canonical": "identity_migrate",
         "reason": "not yet exported in NAPI bridge (known gap)"
+      },
+      {
+        "canonical": "init_storage",
+        "reason": "Other bridges use SCP::with_storage(StorageConfig) factory (PR #1684); PyO3 retains init_storage for incremental initialization compatibility with pre-Phase-4 callers."
       }
     ],
     "wasm": [
@@ -2534,6 +2559,10 @@
       {
         "canonical": "access_key_restore",
         "reason": "Restoration reads persisted access key state; WASM has no scp-platform per ADR-034."
+      },
+      {
+        "canonical": "init_storage",
+        "reason": "Other bridges use SCP::with_storage(StorageConfig) factory (PR #1684); PyO3 retains init_storage for incremental initialization compatibility with pre-Phase-4 callers."
       }
     ]
   }

--- a/scripts/bridge-aliases.json
+++ b/scripts/bridge-aliases.json
@@ -2562,7 +2562,7 @@
       },
       {
         "canonical": "init_storage",
-        "reason": "Other bridges use SCP::with_storage(StorageConfig) factory (PR #1684); PyO3 retains init_storage for incremental initialization compatibility with pre-Phase-4 callers."
+        "reason": "WASM has no scp-platform per ADR-034 (no persistent storage), so neither SCP::with_storage factory nor PyO3's init_storage applies; storage is deferred to the host JS runtime."
       }
     ]
   }


### PR DESCRIPTION
## Summary

- Registers `init_storage` as a cross-bridge canonical operation
- PyO3 has the implementation (delegates to `crate::runtime::init_storage`)
- NAPI / UniFFI / WASM exempt — other bridges use `SCP::with_storage(StorageConfig)` factory (PR #1684)
- Matrix-only edit; no code changes
- `wasm_required: false` — exemption-only, not a coverage gap

## Why 4g (split-step MLS) is not in this PR

Batch 4g would have registered 5 WASM-only ops (`context_decrypt_message`, `context_extend_ttl`, `context_generate_key_package`, `context_join_encrypted`, `context_ttl_remaining`) with PyO3/UniFFI/NAPI exemptions. The reference-bridge test `pyo3_bridge_covers_all_operations` does not honor PyO3 exemptions, so WASM-only ops cannot be tracked through the parity matrix without porting them to PyO3. These remain bridge-internal helpers; other bridges achieve equivalent behavior via governance-driven flows (`context_propose_ttl_extension`, `context_send`/`context_subscribe`, welcome flow inside `context_join`).

## Test plan

- [x] `python3.12 -c "import json; json.load(open('scripts/bridge-aliases.json'))"` — JSON valid
- [x] `bash scripts/check-bridge-symmetry.sh` — 0 findings
- [x] `python3.12 scripts/check-call-invariants.py` — 0 findings
- [x] `cargo test -p scp-testing --test ffi_conformance` — 32/32 pass

Refs #1543; follows #1702–#1711.

🤖 Generated with [Claude Code](https://claude.com/claude-code)