### PR TITLE
fix(wasm): align link-attestation signer to #active per spec §3.5 (#1543)

### DIFF
--- a/crates/scp-ffi/wasm/src/identity.rs
+++ b/crates/scp-ffi/wasm/src/identity.rs
@@ -168,10 +168,12 @@ enum IdentityRecord {
     /// `StdRng`) builds — see ADR-046 for cross-bridge parity.
     Local {
         /// Ed25519 signing key bytes (32 bytes) for the DID-deriving
-        /// identity key (`#0`). Used to sign device attestations and
-        /// identity link attestations; NEVER used for day-to-day
-        /// `#active` signatures (those go through
-        /// `active_signing_key_bytes`).
+        /// identity key (`#0`). Used to sign device attestations
+        /// (signed by `#0` per spec). NEVER used for day-to-day
+        /// `#active` signatures, identity link attestations
+        /// (signed by `#active` or `#agent` per spec §3.5/§3.5.2),
+        /// or other operational signatures — those go through
+        /// `active_signing_key_bytes`.
         ///
         /// Wrapped in `Zeroizing` for defense-in-depth: WASM linear
         /// memory is readable by same-origin JS, so key material must be
@@ -2626,8 +2628,9 @@ pub fn identity_create_link_attestation(
         // Compute canonical signing bytes via the shared function (§9.5.1).
         let canonical = compute_attestation_canonical_bytes(&attestation)?;
 
-        // Sign inside the registry closure. Link attestations sign
-        // with the `#0` identity key (§3.5.2). Only `Local` records
+        // Sign with the issuer's #active key per spec §3.5 ("signed by
+        // the issuer's #active or #agent key") and §3.5.2 wire format
+        // ("using issuer's #active or #agent key"). Only `Local` records
         // carry it; `Resolved` handles refuse structurally.
         let signature_bytes = IDENTITY_REGISTRY.with(|reg| {
             let map = reg.borrow();
@@ -2640,10 +2643,11 @@ pub fn identity_create_link_attestation(
                 .into()
             })?;
 
-            let signing_key_bytes = match entry {
+            let active_signing_key_bytes = match entry {
                 IdentityRecord::Local {
-                    signing_key_bytes, ..
-                } => signing_key_bytes,
+                    active_signing_key_bytes,
+                    ..
+                } => active_signing_key_bytes,
                 IdentityRecord::Resolved { .. } => {
                     return Err::<[u8; 64], JsValue>(
                         ScpWasmError::Identity {
@@ -2659,7 +2663,7 @@ pub fn identity_create_link_attestation(
                     );
                 }
             };
-            let signing_key = ed25519_dalek::SigningKey::from_bytes(signing_key_bytes);
+            let signing_key = ed25519_dalek::SigningKey::from_bytes(active_signing_key_bytes);
             let signature = signing_key.sign(&canonical);
             Ok::<[u8; 64], JsValue>(signature.to_bytes())
         })?;


### PR DESCRIPTION
## Summary

WASM `identity_create_link_attestation` was signing link attestations with the `#0` identity key while every other bridge (PyO3/NAPI/UniFFI) and the spec itself use `#active`. The WASM code carried a fabricated comment claiming "§3.5.2 mandates #0" — false; spec §3.5.2 says "#active or #agent".

The same WASM file already had two correct comments on the verify-side (lines 2858, 2886). The create-side was the lone outlier.

## Why

Surfaced by cryptographer review of #1711 (2026-04-25). Alec's directive 2026-04-26: "clean up the spec and all comments so we never have this discussion again."

Per Vestige history: WASM was supposed to be aligned during the 2026-03-18 attestation overhaul (PR #1414 / #1415) but the link-attestation signer was never fixed.

## Changes

- `crates/scp-ffi/wasm/src/identity.rs` — destructure `active_signing_key_bytes` instead of `signing_key_bytes` at line 2643; updated comment to cite spec §3.5 and §3.5.2 directly. Also corrected the `Local::signing_key_bytes` field doc (line 170) which previously asserted #0 was used for link attestations.

## Spec & comment audit

- Confirmed spec §3.5.2 (wire format), §3.5 (intro), §3 (lines 26, 53, 57, 1071, 1164, 1168) all say `#active`.
- WASM verify-side already correct.
- No other contradictions found (device attestation correctly uses `#0` per its own spec; key-custody attestation correctly uses `#0` per ADR-039 — both unrelated to link attestations).

## Test plan

- [x] `cargo build -p scp-ffi-wasm --target wasm32-unknown-unknown` clean
- [x] `cargo clippy -p scp-ffi-wasm --target wasm32-unknown-unknown -- -D warnings` clean
- [x] `cargo fmt --all -- --check` clean
- [x] `cargo test -p scp-testing --test ffi_conformance` 32/32 pass
- [x] `cargo test -p scp-runtime --test wasm_conformance --features testing` 45/45 pass
- [x] `bash scripts/check-bridge-symmetry.sh` 0 findings

Refs #1543. Cleans up tech debt that surfaced in #1711 review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)