### PR TITLE
chore(agent-memory): commit accumulated agent notes from #1543 work

### DIFF
--- a/.claude/agent-memory/backend/MEMORY.md
+++ b/.claude/agent-memory/backend/MEMORY.md
@@ -1,0 +1,1 @@
+- [Swift UniFFI bindings regenerated in CI](reference_swift_uniffi_regen.md) — stale committed ScpBindings.swift can hide signature drift; local swift build passes while CI fails

--- a/.claude/agent-memory/backend/reference_swift_uniffi_regen.md
+++ b/.claude/agent-memory/backend/reference_swift_uniffi_regen.md
@@ -1,0 +1,24 @@
+---
+name: Swift UniFFI bindings are regenerated in CI from Rust source
+description: CI regenerates bindings/swift/Sources/SCP/Internal/ScpBindings.swift during build-xcframework.sh; committed file may be stale and compile locally but not in CI
+type: reference
+---
+
+Swift CI job "Swift / build + test" runs `bindings/swift/build-xcframework.sh --dev`, which invokes `uniffi-bindgen` against the current Rust source in `crates/scp-ffi/uniffi/src/` and OVERWRITES `bindings/swift/Sources/SCP/Internal/ScpBindings.swift` before the Swift compile step.
+
+Implications for future sessions:
+- If a Rust FFI function changes signature (adds `async`, changes `-> T` to `-> Result<T, ScpError>`, etc.), the SDK wrapper code in `bindings/swift/Sources/SCP/*.swift` must match the regenerated signature — not whatever the currently committed `ScpBindings.swift` says.
+- Local `swift build` uses the committed `ScpBindings.swift` and may succeed when CI will fail. To preview the CI surface, run `bindings/swift/build-xcframework.sh --dev` locally first.
+- Rust signature → UniFFI Swift signature rules that matter:
+  - `pub fn foo() -> T` → `func foo() -> T` (sync, non-throwing)
+  - `pub fn foo() -> Result<T, ScpError>` → `func foo() throws -> T` (sync, throwing)
+  - `pub async fn foo() -> T` → `func foo() async -> T` (async, non-throwing)
+  - `pub async fn foo() -> Result<T, ScpError>` → `func foo() async throws -> T` (async, throwing)
+- When SDK wrapper default closures call FFI functions, their typealias signatures and default closure bodies must track all four quadrants.
+
+Files where this bit us during #1549 PR 3:
+- `bindings/swift/Sources/SCP/Governance.swift` (defaultRegisterLocalDid)
+- `bindings/swift/Sources/SCP/Lifecycle.swift` (defaultResume + ResumeFn + Lifecycle.resume)
+- `bindings/swift/Tests/SCPTests/LifecycleTests.swift` (resume test async-awareness)
+- `bindings/swift/Tests/SCPTests/RealFFITests.swift` (ffiLocalDidManagement)
+- `bindings/swift/Tests/SCPTests/PersistenceTests.swift` (used FFI param name `timeoutSecs:` instead of SDK wrapper `timeout:`)

--- a/.claude/agent-memory/black-hat/pr1628-bridge-instance.md
+++ b/.claude/agent-memory/black-hat/pr1628-bridge-instance.md
@@ -1,0 +1,41 @@
+---
+name: PR #1628 BridgeInstance Adversarial Review
+description: Full adversarial review of BridgeInstance extraction — singleton consolidation, lifecycle, shutdown hooks, placeholder DIDs, capacity bypasses
+type: project
+---
+
+## PR #1628 BridgeInstance Extraction -- Adversarial Review (2026-04-14)
+
+### BLACK-301: Post-shutdown ghost operations (all bridges)
+- context_manager() and bridge_instance() return warn-only on AlreadyShutDown
+- ContextManager Arc still alive after shutdown, MLS groups destroyed but provider active
+- Creating contexts after shutdown produces inconsistent state
+- Files: scp-ffi/src/runtime.rs:112-134, napi/runtime.rs:140-162, uniffi/runtime.rs:105-129
+
+### BLACK-302: DashMap capacity bypass via concurrent registration
+- register_known_context has TOCTOU between len() check and insert
+- Eviction race: between drop(oldest) and remove(&oldest_key), another thread can insert same key
+- File: scp-ffi/common/src/bridge_instance.rs:650-671
+
+### BLACK-303: Placeholder DID identity confusion (NAPI + UniFFI)
+- ensure_bridge_instance uses "did:unknown:napi-bridge" / "did:unknown:bridge"
+- OnceLock prevents later correction; MLS credentials bound to unresolvable DID
+- Files: napi/runtime.rs:240, uniffi/runtime.rs:210
+
+### BLACK-308: Rate limiter ephemeral bypass under load
+- When MAX_RATE_LIMITERS (1000) reached, creates ephemeral tracker with zero history
+- Attacker fills registry with 1000 DIDs, target DID gets unlimited auto-accept
+- File: scp-ffi/common/src/bridge_instance.rs:727-750
+
+### BLACK-309: Economy state unbounded growth
+- economy_budgets and economy_antispam have NO capacity limits
+- Unlike known_contexts (10K) and rate_limiters (1K), no eviction
+- File: scp-ffi/common/src/bridge_instance.rs:759-798
+
+### Confirmed Working
+- Shutdown idempotency (atomic swap)
+- Transport RwLock + Arc pattern
+- Hook panic isolation (catch_unwind)
+- SeqCst ordering on flags
+- DID resolver OnceLock immutability
+- Bridge connector per-context isolation


### PR DESCRIPTION
## Summary

Three agent-memory files accumulated during the #1543 cross-bridge consolidation work. Committing so they persist across sessions.

- \`.claude/agent-memory/backend/MEMORY.md\` — backend agent's index/notes
- \`.claude/agent-memory/backend/reference_swift_uniffi_regen.md\` — Swift UniFFI regen reference
- \`.claude/agent-memory/black-hat/pr1628-bridge-instance.md\` — black-hat threat model notes on BridgeInstance refactor

## Test plan

- [x] No code changes — agent-memory only
- [x] Files added under \`.claude/agent-memory/\` (already in repo via prior commits for other agent dirs)

Refs #1543.

🤖 Generated with [Claude Code](https://claude.com/claude-code)