### PR TITLE
feat(transport): unify client-side subscription state under TransportSubscriptionMap

### DIFF
--- a/crates/scp-transport/README.md
+++ b/crates/scp-transport/README.md
@@ -4,6 +4,10 @@ Transport abstraction layer for [SCP](https://github.com/limn/scp) (Shared Conte
 
 Native relay client (`WebSocket`), blob storage adapters (`SQLite`, `redb`, `Postgres`, `S3`), and optional protocol adapters (`QUIC`, `HTTP/3`, `UDP`, `CoAP`, `Nostr`, `WebRTC`, `WebTransport`).
 
+## Subscription maps
+
+`TransportSubscriptionMap<V>` (in `subscription.rs`) is the 1:1 routing-id → adapter-state map shared by client-side transport adapters (QUIC, native relay client, WebTransport). It is **not** the same shape as `relay::SubscriptionRegistry`, which is the server-side 1:N fan-out registry. Adapters consume `TransportSubscriptionMap<V>` for capacity-bounded, duplicate-detecting subscription state with reconnect snapshot helpers; the registry is for the relay's per-routing-id subscriber set.
+
 ## License
 
 Apache-2.0

--- a/crates/scp-transport/src/lib.rs
+++ b/crates/scp-transport/src/lib.rs
@@ -53,6 +53,7 @@ pub mod relay;
 pub mod scoring;
 #[cfg(feature = "startup")]
 pub mod startup;
+pub mod subscription;
 pub mod traits;
 #[cfg(feature = "udp")]
 pub mod udp;
@@ -82,4 +83,5 @@ pub use pool::{ConnectionPool, PoolKey, TransportType};
 pub use profile::{CoverTrafficTier, TransportProfile};
 pub use provider::RelayTransportProvider;
 pub use scoring::SuppressionWarning;
+pub use subscription::{MAX_TRANSPORT_SUBSCRIPTIONS, SubscriptionError, TransportSubscriptionMap};
 pub use traits::{BlobId, RoutingId, SubscriptionStream, TransportAdapter, TransportEvent};

--- a/crates/scp-transport/src/lib.rs
+++ b/crates/scp-transport/src/lib.rs
@@ -83,5 +83,5 @@ pub use pool::{ConnectionPool, PoolKey, TransportType};
 pub use profile::{CoverTrafficTier, TransportProfile};
 pub use provider::RelayTransportProvider;
 pub use scoring::SuppressionWarning;
-pub use subscription::{MAX_TRANSPORT_SUBSCRIPTIONS, SubscriptionError, TransportSubscriptionMap};
+pub use subscription::{SubscriptionError, TransportSubscriptionMap};
 pub use traits::{BlobId, RoutingId, SubscriptionStream, TransportAdapter, TransportEvent};

--- a/crates/scp-transport/src/native/adapter.rs
+++ b/crates/scp-transport/src/native/adapter.rs
@@ -640,12 +640,15 @@ fn subscription_message_to_event(msg: SubscriptionMessage) -> Option<TransportEv
 /// PONG, OK responses).
 fn relay_message_to_event(msg: RelayMessage) -> Option<TransportEvent> {
     match msg {
-        RelayMessage::Blob { blob, .. } => match OuterEnvelope::from_bytes(&blob) {
-            Ok(envelope) => Some(TransportEvent::Envelope(envelope)),
-            Err(e) => Some(TransportEvent::Error(TransportError::ProtocolError(
-                format!("failed to deserialize envelope from blob: {e}"),
-            ))),
-        },
+        RelayMessage::Blob { blob, .. } => Some(OuterEnvelope::from_bytes(&blob).map_or_else(
+            |_| {
+                tracing::warn!("envelope deserialization failed");
+                TransportEvent::Error(TransportError::ProtocolError(
+                    "failed to deserialize envelope from blob".to_owned(),
+                ))
+            },
+            TransportEvent::Envelope,
+        )),
         RelayMessage::Event { event_type, .. } => match event_type.as_str() {
             "backfill_complete" => Some(TransportEvent::BackfillComplete),
             _ => None,

--- a/crates/scp-transport/src/native/client.rs
+++ b/crates/scp-transport/src/native/client.rs
@@ -928,10 +928,16 @@ impl NativeRelayClient {
                     // occurred so the adapter can emit
                     // `TransportEvent::Reconnected`. Reuses the same snapshot
                     // taken above; the senders are already cloned out of the
-                    // map's read lock. A subscription may have been
-                    // unsubscribed between the snapshot and this loop -- skip
-                    // entries no longer present in the live map so receivers
-                    // never see a spurious `Reconnected` after unsubscribe.
+                    // map's read lock.
+                    //
+                    // A subscription may be unsubscribed between the snapshot
+                    // and this loop; the contains() check below skips those
+                    // entries on the common path. A small TOCTOU window
+                    // remains between the contains() check and tx.send().await
+                    // -- receivers must tolerate one final `Reconnected` after
+                    // `unsubscribe` returns, the same way they tolerate one
+                    // final `Relay(...)` per the SubscriptionState::Clone
+                    // documentation above.
                     for (rid, _last_local_receive, tx) in snap {
                         if !self.subscriptions.contains(&rid) {
                             continue;

--- a/crates/scp-transport/src/native/client.rs
+++ b/crates/scp-transport/src/native/client.rs
@@ -928,8 +928,14 @@ impl NativeRelayClient {
                     // occurred so the adapter can emit
                     // `TransportEvent::Reconnected`. Reuses the same snapshot
                     // taken above; the senders are already cloned out of the
-                    // map's read lock.
-                    for (_rid, _last_local_receive, tx) in snap {
+                    // map's read lock. A subscription may have been
+                    // unsubscribed between the snapshot and this loop -- skip
+                    // entries no longer present in the live map so receivers
+                    // never see a spurious `Reconnected` after unsubscribe.
+                    for (rid, _last_local_receive, tx) in snap {
+                        if !self.subscriptions.contains(&rid) {
+                            continue;
+                        }
                         let _ = tx.send(SubscriptionMessage::Reconnected).await;
                     }
 

--- a/crates/scp-transport/src/native/client.rs
+++ b/crates/scp-transport/src/native/client.rs
@@ -440,10 +440,17 @@ impl NativeRelayClient {
                 let receive_time = Instant::now();
                 let rid = crate::traits::RoutingId::new(*routing_id);
 
-                // 1. Deduplication check (read-only, no commit yet). A
-                //    write-locked check + commit here would let an attacker
-                //    poison the dedup LRU with `blob_id`s for unsolicited
-                //    routing_ids, evicting legitimate entries.
+                // 1. Deduplication check (read-only, no commit yet).
+                //    Dedup-cache poisoning defense: check dedup first
+                //    (read-locked, no commit), then check subscription
+                //    presence below, then send, then commit dedup ONLY
+                //    after a successful send to a present subscriber.
+                //    Committing dedup before the subscriber check would
+                //    let unsolicited routing_ids evict legitimate dedup
+                //    entries, suppressing legitimate post-resubscribe
+                //    redelivery for those entries. The load-bearing
+                //    invariant is the step ordering (commit-after-success),
+                //    not the lock kind.
                 {
                     let state = inner.read().await;
                     if state.seen_blob_ids.contains(blob_id) {

--- a/crates/scp-transport/src/native/client.rs
+++ b/crates/scp-transport/src/native/client.rs
@@ -44,6 +44,7 @@ use zeroize::Zeroizing;
 use super::protocol::{ClientMessage, RelayMessage};
 use crate::backoff::ReconnectBackoff;
 use crate::error::TransportError;
+use crate::subscription::TransportSubscriptionMap;
 
 /// Keepalive interval: client sends PING every 30 seconds.
 const PING_INTERVAL: Duration = Duration::from_secs(30);
@@ -107,11 +108,17 @@ pub enum SubscriptionMessage {
 }
 
 /// Subscription state tracked for reconnection recovery.
+///
+/// Stored as the value type in the [`TransportSubscriptionMap`]; the routing
+/// ID is the map key, not duplicated here.
+///
+/// `Clone` is required because [`TransportSubscriptionMap::snapshot`] returns
+/// owned `(RoutingId, V)` pairs (used by [`NativeRelayClient::reconnect`]).
+/// Snapshots may yield one final clone of the sender that delivers a message
+/// after the caller has invoked `unsubscribe` -- receivers tolerate this in
+/// the same way `mpsc::Receiver` already tolerates the close race.
 #[derive(Debug, Clone)]
 struct SubscriptionState {
-    /// The routing ID this subscription is for (used during reconnection).
-    #[allow(dead_code)]
-    routing_id: [u8; 32],
     /// The last relay-provided `stored_at` timestamp (untrusted metadata, used
     /// only for logging/diagnostics -- never for security decisions).
     last_stored_at: Option<u64>,
@@ -130,13 +137,11 @@ struct ClientInner {
     pending: HashMap<String, PendingRequest>,
     /// Next `ref_id` counter for generating unique request IDs.
     next_ref_id: u64,
-    /// Active subscriptions keyed by routing ID.
-    subscriptions: HashMap<[u8; 32], SubscriptionState>,
     /// LRU cache of blob IDs already seen (for deduplication on reconnect).
     ///
     /// Bounded to [`DEDUP_CACHE_CAPACITY`] entries to prevent unbounded memory
-    /// growth in long-lived connections (#1466). Oldest entries are evicted
-    /// when the cache is full.
+    /// growth in long-lived connections. Oldest entries are evicted when the
+    /// cache is full.
     seen_blob_ids: lru::LruCache<[u8; 32], ()>,
     /// Whether the client is currently connected.
     connected: bool,
@@ -175,6 +180,12 @@ pub struct NativeRelayClient {
     bearer_token: Option<Arc<Zeroizing<String>>>,
     /// Shared mutable inner state.
     inner: Arc<RwLock<ClientInner>>,
+    /// Active subscriptions keyed by routing ID.
+    ///
+    /// Lives as a sibling of [`ClientInner`] (rather than a field within it)
+    /// because [`TransportSubscriptionMap`] manages its own internal lock;
+    /// nesting it inside `RwLock<ClientInner>` would double-lock.
+    subscriptions: Arc<TransportSubscriptionMap<SubscriptionState>>,
     /// The WebSocket sink (write half), protected by a mutex for exclusive
     /// write access across concurrent callers.
     ws_sink: Arc<Mutex<Option<WsSink>>>,
@@ -231,7 +242,6 @@ impl NativeRelayClient {
         let inner = Arc::new(RwLock::new(ClientInner {
             pending: HashMap::new(),
             next_ref_id: 1,
-            subscriptions: HashMap::new(),
             seen_blob_ids: lru::LruCache::new(
                 NonZeroUsize::new(DEDUP_CACHE_CAPACITY).unwrap_or(NonZeroUsize::MIN),
             ),
@@ -244,6 +254,7 @@ impl NativeRelayClient {
             url: url.to_string(),
             bearer_token: bearer_token.map(Arc::new),
             inner,
+            subscriptions: Arc::new(TransportSubscriptionMap::new()),
             ws_sink: Arc::new(Mutex::new(None)),
             reader_handle: Arc::new(Mutex::new(None)),
             keepalive_handle: Arc::new(Mutex::new(None)),
@@ -313,6 +324,7 @@ impl NativeRelayClient {
         let reader_handle = tokio::spawn(Self::reader_loop(
             source,
             Arc::clone(&self.inner),
+            Arc::clone(&self.subscriptions),
             shutdown_rx,
         ));
         *self.reader_handle.lock().await = Some(reader_handle);
@@ -334,6 +346,7 @@ impl NativeRelayClient {
     async fn reader_loop(
         mut source: WsSource,
         inner: Arc<RwLock<ClientInner>>,
+        subscriptions: Arc<TransportSubscriptionMap<SubscriptionState>>,
         mut shutdown_rx: tokio::sync::broadcast::Receiver<()>,
     ) {
         loop {
@@ -352,7 +365,7 @@ impl NativeRelayClient {
                     match msg {
                         Message::Binary(data) => {
                             if let Ok(relay_msg) = RelayMessage::from_bytes(&data) {
-                                Self::dispatch_relay_message(&inner, relay_msg).await;
+                                Self::dispatch_relay_message(&inner, &subscriptions, relay_msg).await;
                             }
                         }
                         Message::Close(_) => {
@@ -373,7 +386,11 @@ impl NativeRelayClient {
 
     /// Dispatches a relay message to the appropriate pending request or
     /// subscription channel.
-    async fn dispatch_relay_message(inner: &Arc<RwLock<ClientInner>>, msg: RelayMessage) {
+    async fn dispatch_relay_message(
+        inner: &Arc<RwLock<ClientInner>>,
+        subscriptions: &Arc<TransportSubscriptionMap<SubscriptionState>>,
+        msg: RelayMessage,
+    ) {
         match &msg {
             // OK and ERR responses are correlated by `ref_id`.
             RelayMessage::Ok { ref_id, .. } | RelayMessage::Err { ref_id, .. } => {
@@ -386,7 +403,8 @@ impl NativeRelayClient {
             }
 
             // BLOB messages are delivered to the subscription channel for the
-            // matching routing ID.
+            // matching routing ID. The reader_loop is single-task, so a stalled
+            // `tx.send().await` here also stalls subsequent BLOB and OK dispatch.
             RelayMessage::Blob {
                 routing_id,
                 blob_id,
@@ -407,12 +425,10 @@ impl NativeRelayClient {
                     );
 
                     // Emit BlobIntegrityError to the subscription channel if one exists.
-                    let maybe_tx = inner
-                        .read()
-                        .await
-                        .subscriptions
-                        .get(routing_id)
-                        .map(|sub| sub.tx.clone());
+                    let maybe_tx = subscriptions
+                        .with(&crate::traits::RoutingId::new(*routing_id), |sub| {
+                            sub.tx.clone()
+                        });
                     if let Some(tx) = maybe_tx {
                         let _ = tx
                             .send(SubscriptionMessage::BlobIntegrityError { expected, actual })
@@ -422,46 +438,78 @@ impl NativeRelayClient {
                 }
 
                 let receive_time = Instant::now();
-                let mut state = inner.write().await;
+                let rid = crate::traits::RoutingId::new(*routing_id);
 
-                // Deduplication: skip if we've already seen this `blob_id`.
-                // `LruCache::contains` does NOT promote the entry (no LRU
-                // reorder), which is correct — we just want to check presence.
-                if state.seen_blob_ids.contains(blob_id) {
-                    return;
+                // 1. Deduplication check (read-only, no commit yet). A
+                //    write-locked check + commit here would let an attacker
+                //    poison the dedup LRU with `blob_id`s for unsolicited
+                //    routing_ids, evicting legitimate entries.
+                {
+                    let state = inner.read().await;
+                    if state.seen_blob_ids.contains(blob_id) {
+                        return;
+                    }
                 }
-                state.seen_blob_ids.put(*blob_id, ());
 
-                if let Some(sub) = state.subscriptions.get_mut(routing_id) {
+                // 2. Plausibility check: warn if relay timestamp deviates
+                //    significantly from local wall-clock time. Independent of
+                //    dedup; runs whether or not the routing_id is subscribed.
+                {
+                    let local_now = scp_primitives::SystemClock.now_secs();
+                    let deviation = local_now.abs_diff(*stored_at);
+                    if deviation > RELAY_TIMESTAMP_DEVIATION_THRESHOLD_SECS {
+                        tracing::warn!(
+                            relay_stored_at = *stored_at,
+                            local_time = local_now,
+                            deviation_secs = deviation,
+                            "relay stored_at deviates from local time by more \
+                             than {RELAY_TIMESTAMP_DEVIATION_THRESHOLD_SECS}s; \
+                             possible malicious relay"
+                        );
+                    }
+                }
+
+                // 3. Mutate subscription state and clone its sender. If no
+                //    subscription exists for this routing_id, return WITHOUT
+                //    committing the dedup mark. Returning without committing
+                //    means a future legitimate redelivery (e.g. after an
+                //    unsubscribe-then-resubscribe race) is still deliverable.
+                let maybe_tx = subscriptions.with_mut(&rid, |sub| {
                     // Record local monotonic receive time for reconnection
                     // window calculations (immune to relay timestamp
                     // manipulation).
                     sub.last_local_receive = Some(receive_time);
-
                     // Update relay-provided `stored_at` as untrusted metadata
                     // (informational/logging only).
                     if sub.last_stored_at.is_none_or(|prev| *stored_at > prev) {
                         sub.last_stored_at = Some(*stored_at);
                     }
+                    sub.tx.clone()
+                });
 
-                    // Plausibility check: warn if relay timestamp deviates
-                    // significantly from local wall-clock time.
-                    {
-                        let local_now = scp_primitives::SystemClock.now_secs();
-                        let deviation = local_now.abs_diff(*stored_at);
-                        if deviation > RELAY_TIMESTAMP_DEVIATION_THRESHOLD_SECS {
-                            tracing::warn!(
-                                relay_stored_at = *stored_at,
-                                local_time = local_now,
-                                deviation_secs = deviation,
-                                "relay stored_at deviates from local time by more \
-                                 than {RELAY_TIMESTAMP_DEVIATION_THRESHOLD_SECS}s; \
-                                 possible malicious relay"
-                            );
-                        }
+                let Some(tx) = maybe_tx else {
+                    // No subscriber: do not pollute the dedup cache so future
+                    // redelivery for this blob_id remains possible.
+                    return;
+                };
+
+                // 4. Send outside any lock. A slow or stalled subscriber here
+                //    blocks the reader_loop (see the note on the BLOB arm),
+                //    but does not contend with `inner.write()`-holders such
+                //    as `send_request`'s pending-map mutation.
+                //
+                //    On `Err`: the receiver was dropped between `with_mut`
+                //    (which cloned the sender) and `tx.send`. We must NOT
+                //    commit dedup -- a future redelivery (e.g. after
+                //    resubscribe) for this `blob_id` must remain deliverable.
+                let blob_id_copy = *blob_id;
+                if tx.send(SubscriptionMessage::Relay(msg)).await.is_ok() {
+                    // Double-check guards the static dispatch_relay_message helper when
+                    // invoked concurrently from tests; the production reader_loop is single-task.
+                    let mut state = inner.write().await;
+                    if !state.seen_blob_ids.contains(&blob_id_copy) {
+                        state.seen_blob_ids.put(blob_id_copy, ());
                     }
-
-                    let _ = sub.tx.send(SubscriptionMessage::Relay(msg)).await;
                 }
             }
 
@@ -477,9 +525,10 @@ impl NativeRelayClient {
                     drop(state);
                 }
 
-                // Broadcast event to all subscriptions.
-                let state = inner.read().await;
-                for sub in state.subscriptions.values() {
+                // Broadcast event to all subscriptions. Snapshot senders first
+                // so the map's read lock is dropped before each `send().await`.
+                let snap = subscriptions.snapshot();
+                for (_rid, sub) in snap {
                     let _ = sub.tx.send(SubscriptionMessage::Relay(msg.clone())).await;
                 }
             }
@@ -611,16 +660,22 @@ impl NativeRelayClient {
     ) -> Result<mpsc::Receiver<SubscriptionMessage>, TransportError> {
         let (tx, rx) = mpsc::channel(256);
 
+        let rid = crate::traits::RoutingId::new(*routing_id);
+
         // Register subscription state before sending to avoid race conditions.
-        self.inner.write().await.subscriptions.insert(
-            *routing_id,
-            SubscriptionState {
-                routing_id: *routing_id,
-                last_stored_at: None,
-                last_local_receive: None,
-                tx,
-            },
-        );
+        // Use `insert` (not `insert_or_replace`): a duplicate routing ID
+        // surfaces as an error rather than silently overwriting (and leaking
+        // the prior subscriber's `mpsc::Sender`).
+        self.subscriptions
+            .insert(
+                rid,
+                SubscriptionState {
+                    last_stored_at: None,
+                    last_local_receive: None,
+                    tx,
+                },
+            )
+            .map_err(|e| TransportError::SubscriptionFailed(e.to_string()))?;
 
         let msg = ClientMessage::Subscribe {
             ref_id: None,
@@ -629,24 +684,20 @@ impl NativeRelayClient {
         };
 
         let response = self.send_request(msg).await.map_err(|e| {
-            let inner = Arc::clone(&self.inner);
-            let rid = *routing_id;
-            tokio::spawn(async move {
-                inner.write().await.subscriptions.remove(&rid);
-            });
+            self.subscriptions.remove(&rid);
             TransportError::SubscriptionFailed(e.to_string())
         })?;
 
         match response {
             RelayMessage::Ok { .. } => Ok(rx),
             RelayMessage::Err { code, msg, .. } => {
-                self.inner.write().await.subscriptions.remove(routing_id);
+                self.subscriptions.remove(&rid);
                 Err(TransportError::SubscriptionFailed(format!(
                     "relay error {code}: {msg}"
                 )))
             }
             _ => {
-                self.inner.write().await.subscriptions.remove(routing_id);
+                self.subscriptions.remove(&rid);
                 Err(TransportError::SubscriptionFailed(
                     "unexpected response to SUBSCRIBE".to_string(),
                 ))
@@ -671,7 +722,8 @@ impl NativeRelayClient {
         let response = self.send_request(msg).await?;
 
         // Remove subscription regardless of response.
-        self.inner.write().await.subscriptions.remove(routing_id);
+        self.subscriptions
+            .remove(&crate::traits::RoutingId::new(*routing_id));
 
         match response {
             RelayMessage::Err { code, msg, .. } => Err(TransportError::SendFailed(format!(
@@ -696,14 +748,10 @@ impl NativeRelayClient {
         routing_id: &[u8; 32],
         since: Option<u64>,
     ) -> Result<Vec<OuterEnvelope>, TransportError> {
+        let rid = crate::traits::RoutingId::new(*routing_id);
+
         // Check if there's already an active subscription for this `routing_id`.
-        if self
-            .inner
-            .read()
-            .await
-            .subscriptions
-            .contains_key(routing_id)
-        {
+        if self.subscriptions.contains(&rid) {
             // When there's an active subscription, just send the QUERY.
             // Results will be delivered through the existing subscription.
             let msg = ClientMessage::Query {
@@ -719,15 +767,20 @@ impl NativeRelayClient {
         let (tx, mut rx) = mpsc::channel::<SubscriptionMessage>(256);
 
         // Register a temporary subscription for receiving BLOB messages.
-        self.inner.write().await.subscriptions.insert(
-            *routing_id,
-            SubscriptionState {
-                routing_id: *routing_id,
-                last_stored_at: None,
-                last_local_receive: None,
-                tx,
-            },
-        );
+        // `Duplicate` may occur under concurrent `subscribe`+`query` for the
+        // same routing_id; the check/insert is intentionally racy because the
+        // cost of a brief misorder is just a `SubscriptionFailed` to the
+        // caller.
+        self.subscriptions
+            .insert(
+                rid,
+                SubscriptionState {
+                    last_stored_at: None,
+                    last_local_receive: None,
+                    tx,
+                },
+            )
+            .map_err(|e| TransportError::SubscriptionFailed(e.to_string()))?;
 
         // Send the QUERY command.
         let msg = ClientMessage::Query {
@@ -738,15 +791,11 @@ impl NativeRelayClient {
         };
 
         let response = self.send_request(msg).await.inspect_err(|_| {
-            let inner = Arc::clone(&self.inner);
-            let rid = *routing_id;
-            tokio::spawn(async move {
-                inner.write().await.subscriptions.remove(&rid);
-            });
+            self.subscriptions.remove(&rid);
         })?;
 
         if let RelayMessage::Err { code, msg, .. } = &response {
-            self.inner.write().await.subscriptions.remove(routing_id);
+            self.subscriptions.remove(&rid);
             return Err(TransportError::SendFailed(format!(
                 "relay error {code}: {msg}"
             )));
@@ -783,7 +832,7 @@ impl NativeRelayClient {
         }
 
         // Clean up temporary subscription.
-        self.inner.write().await.subscriptions.remove(routing_id);
+        self.subscriptions.remove(&rid);
 
         Ok(envelopes)
     }
@@ -834,17 +883,19 @@ impl NativeRelayClient {
 
             match self.establish_connection().await {
                 Ok(()) => {
-                    // Re-subscribe to all active routing IDs.
-                    let subs_snapshot: Vec<_> = self
-                        .inner
-                        .read()
-                        .await
+                    // Single snapshot reused for both re-subscribe and the
+                    // post-reconnect Reconnected notification, avoiding two
+                    // independent walks of the map.
+                    let snap: Vec<_> = self
                         .subscriptions
-                        .values()
-                        .map(|s| (s.routing_id, s.last_local_receive))
+                        .snapshot()
+                        .into_iter()
+                        .map(|(rid, s)| (rid, s.last_local_receive, s.tx))
                         .collect();
 
-                    for (routing_id, last_local_receive) in subs_snapshot {
+                    // Re-subscribe to all active routing IDs first so any
+                    // backfill begins flowing before we notify subscribers.
+                    for (rid, last_local_receive, _tx) in &snap {
                         // Use local receive time (immune to relay timestamp
                         // manipulation) to compute the reconnect window.
                         let since = last_local_receive.map(|instant| {
@@ -857,7 +908,7 @@ impl NativeRelayClient {
 
                         let msg = ClientMessage::Subscribe {
                             ref_id: None,
-                            routing_id,
+                            routing_id: *rid.as_bytes(),
                             since,
                         };
 
@@ -868,12 +919,12 @@ impl NativeRelayClient {
 
                     // Notify all active subscriptions that a reconnection
                     // occurred so the adapter can emit
-                    // `TransportEvent::Reconnected`.
-                    let state = self.inner.read().await;
-                    for sub in state.subscriptions.values() {
-                        let _ = sub.tx.send(SubscriptionMessage::Reconnected).await;
+                    // `TransportEvent::Reconnected`. Reuses the same snapshot
+                    // taken above; the senders are already cloned out of the
+                    // map's read lock.
+                    for (_rid, _last_local_receive, tx) in snap {
+                        let _ = tx.send(SubscriptionMessage::Reconnected).await;
                     }
-                    drop(state);
 
                     return Ok(());
                 }
@@ -888,18 +939,6 @@ impl NativeRelayClient {
                 "reconnection failed after all backoff steps".to_string(),
             )
         }))
-    }
-
-    /// Returns a snapshot of the current subscription routing IDs.
-    #[allow(dead_code)]
-    pub async fn active_subscriptions(&self) -> Vec<[u8; 32]> {
-        self.inner
-            .read()
-            .await
-            .subscriptions
-            .keys()
-            .copied()
-            .collect()
     }
 
     /// Clears the deduplication cache. Useful after a successful reconnect
@@ -1073,33 +1112,37 @@ mod tests {
     // Blob integrity verification tests (SCP-193)
     // -----------------------------------------------------------------------
 
-    /// Helper: creates a `ClientInner` with a subscription for the given
-    /// routing ID, returning the inner state and the subscription receiver.
+    /// Helper: creates a `ClientInner` and a sibling subscription map with a
+    /// subscription registered for the given routing ID. Returns the inner
+    /// state, the subscriptions map, and the subscription receiver.
     fn setup_inner_with_subscription(
         routing_id: [u8; 32],
     ) -> (
         Arc<RwLock<ClientInner>>,
+        Arc<TransportSubscriptionMap<SubscriptionState>>,
         mpsc::Receiver<SubscriptionMessage>,
     ) {
         let (tx, rx) = mpsc::channel(16);
         let inner = Arc::new(RwLock::new(ClientInner {
             pending: HashMap::new(),
             next_ref_id: 1,
-            subscriptions: HashMap::from([(
-                routing_id,
-                SubscriptionState {
-                    routing_id,
-                    last_stored_at: None,
-                    last_local_receive: None,
-                    tx,
-                },
-            )]),
             seen_blob_ids: lru::LruCache::new(
                 NonZeroUsize::new(DEDUP_CACHE_CAPACITY).unwrap_or(NonZeroUsize::MIN),
             ),
             connected: true,
         }));
-        (inner, rx)
+        let subscriptions = Arc::new(TransportSubscriptionMap::<SubscriptionState>::new());
+        subscriptions
+            .insert(
+                crate::traits::RoutingId::new(routing_id),
+                SubscriptionState {
+                    last_stored_at: None,
+                    last_local_receive: None,
+                    tx,
+                },
+            )
+            .unwrap();
+        (inner, subscriptions, rx)
     }
 
     /// Computes SHA-256 of the given data, returning a 32-byte array.
@@ -1112,7 +1155,7 @@ mod tests {
         let routing_id = [0xAA; 32];
         let blob_data = vec![0x01, 0x02, 0x03];
         let correct_blob_id = sha256(&blob_data);
-        let (inner, mut rx) = setup_inner_with_subscription(routing_id);
+        let (inner, subscriptions, mut rx) = setup_inner_with_subscription(routing_id);
 
         let msg = RelayMessage::Blob {
             routing_id,
@@ -1123,7 +1166,7 @@ mod tests {
             blob: blob_data,
         };
 
-        NativeRelayClient::dispatch_relay_message(&inner, msg.clone()).await;
+        NativeRelayClient::dispatch_relay_message(&inner, &subscriptions, msg.clone()).await;
 
         // The blob should be delivered to the subscription channel.
         let received = rx.try_recv().unwrap();
@@ -1145,7 +1188,7 @@ mod tests {
         let original_blob = vec![0x01, 0x02, 0x03];
         let original_blob_id = sha256(&original_blob);
         let tampered_blob = vec![0xFF, 0xFE, 0xFD]; // Different content.
-        let (inner, mut rx) = setup_inner_with_subscription(routing_id);
+        let (inner, subscriptions, mut rx) = setup_inner_with_subscription(routing_id);
 
         let msg = RelayMessage::Blob {
             routing_id,
@@ -1156,7 +1199,7 @@ mod tests {
             blob: tampered_blob,
         };
 
-        NativeRelayClient::dispatch_relay_message(&inner, msg).await;
+        NativeRelayClient::dispatch_relay_message(&inner, &subscriptions, msg).await;
 
         // Should receive a BlobIntegrityError, not a Blob.
         let received = rx.try_recv().unwrap();
@@ -1174,7 +1217,7 @@ mod tests {
         let routing_id = [0xCC; 32];
         let empty_blob: Vec<u8> = vec![];
         let correct_blob_id = sha256(&empty_blob);
-        let (inner, mut rx) = setup_inner_with_subscription(routing_id);
+        let (inner, subscriptions, mut rx) = setup_inner_with_subscription(routing_id);
 
         let msg = RelayMessage::Blob {
             routing_id,
@@ -1185,7 +1228,7 @@ mod tests {
             blob: empty_blob,
         };
 
-        NativeRelayClient::dispatch_relay_message(&inner, msg).await;
+        NativeRelayClient::dispatch_relay_message(&inner, &subscriptions, msg).await;
 
         // Empty blob with correct hash should be accepted.
         let received = rx.try_recv().unwrap();
@@ -1198,6 +1241,164 @@ mod tests {
         );
 
         assert!(inner.read().await.seen_blob_ids.contains(&correct_blob_id));
+    }
+
+    /// Regression: a BLOB delivered for a `routing_id` we have no
+    /// subscription for must NOT poison the dedup LRU. The early return
+    /// at step 3 (`with_mut` returns `None`) means we never reach the
+    /// commit step.
+    #[tokio::test]
+    async fn dedup_not_committed_for_unsubscribed_routing_id() {
+        // Subscribe routing_id A.
+        let routing_id_a = [0xAAu8; 32];
+        let routing_id_b = [0xBBu8; 32];
+        let (inner, subscriptions, mut rx) = setup_inner_with_subscription(routing_id_a);
+
+        // Build a well-formed BLOB for routing_id B (NOT subscribed) with a
+        // payload chosen so that the same payload would also be valid on A.
+        let blob_payload = vec![0x01u8, 0x02, 0x03, 0x04];
+        let blob_id = sha256(&blob_payload);
+
+        let msg_for_b = RelayMessage::Blob {
+            routing_id: routing_id_b,
+            blob_id,
+            recipient_hint: None,
+            blob_ttl: 3600,
+            stored_at: 1_700_000_000,
+            blob: blob_payload.clone(),
+        };
+
+        NativeRelayClient::dispatch_relay_message(&inner, &subscriptions, msg_for_b).await;
+
+        // The unsolicited BLOB must NOT have committed to dedup -- there
+        // was no subscriber for routing_id B, so we never made it past
+        // step 3 (the `with_mut` early return) into the commit step.
+        assert!(
+            !inner.read().await.seen_blob_ids.contains(&blob_id),
+            "unsolicited routing_id must not pollute dedup cache"
+        );
+
+        // A's subscriber must not have received B's BLOB.
+        assert!(
+            rx.try_recv().is_err(),
+            "subscriber for routing_id A must not receive a BLOB addressed to B"
+        );
+
+        // Now an identical BLOB (same blob_id) for routing_id A. Because
+        // dedup was not poisoned by the prior delivery, this must reach
+        // A's subscription channel.
+        let msg_for_a = RelayMessage::Blob {
+            routing_id: routing_id_a,
+            blob_id,
+            recipient_hint: None,
+            blob_ttl: 3600,
+            stored_at: 1_700_000_000,
+            blob: blob_payload,
+        };
+
+        NativeRelayClient::dispatch_relay_message(&inner, &subscriptions, msg_for_a).await;
+
+        let received = rx.try_recv().unwrap();
+        assert!(
+            matches!(
+                received,
+                SubscriptionMessage::Relay(RelayMessage::Blob { .. })
+            ),
+            "expected Relay(Blob) for routing_id A, got {received:?}"
+        );
+
+        // After successful delivery, dedup commits.
+        assert!(inner.read().await.seen_blob_ids.contains(&blob_id));
+    }
+
+    /// Regression for the unsubscribe-during-dispatch race: if `with_mut`
+    /// finds a live subscription and clones its sender but the receiver is
+    /// dropped before `tx.send().await` completes, the dispatcher must
+    /// commit the dedup mark only when the send succeeds. Otherwise a
+    /// future resubscribe-then-redelivery for the same `blob_id` would be
+    /// silently suppressed.
+    #[tokio::test]
+    async fn dedup_not_committed_when_send_fails_after_unsubscribe() {
+        let routing_id = [0xCDu8; 32];
+
+        // Subscriber A is registered with a live (tx, rx) pair. Drop rx
+        // immediately: the subscription entry is still present in the map
+        // (with_mut will find it and clone tx), but the next
+        // tx.send().await will return Err.
+        let (inner, subscriptions, rx_a) = setup_inner_with_subscription(routing_id);
+        drop(rx_a);
+
+        // Build a well-formed BLOB for the still-mapped routing_id.
+        let blob_payload = vec![0x10u8, 0x11, 0x12, 0x13];
+        let blob_id = sha256(&blob_payload);
+
+        let msg = RelayMessage::Blob {
+            routing_id,
+            blob_id,
+            recipient_hint: None,
+            blob_ttl: 3600,
+            stored_at: 1_700_000_000,
+            blob: blob_payload.clone(),
+        };
+
+        NativeRelayClient::dispatch_relay_message(&inner, &subscriptions, msg).await;
+
+        // The send failed (rx dropped), so the dedup mark must NOT have
+        // been committed. This is the load-bearing assertion: pre-fix
+        // (dedup committed before send) this would be `true`.
+        assert!(
+            !inner.read().await.seen_blob_ids.contains(&blob_id),
+            "dedup must not commit when tx.send fails after unsubscribe"
+        );
+
+        // Resubscribe: fresh (tx, rx) pair under the same routing_id.
+        // First clear the existing subscription entry, then insert a
+        // fresh one (insert rejects duplicates).
+        subscriptions.remove(&crate::traits::RoutingId::new(routing_id));
+        let (tx_a2, mut rx_a2) = mpsc::channel::<SubscriptionMessage>(16);
+        subscriptions
+            .insert(
+                crate::traits::RoutingId::new(routing_id),
+                SubscriptionState {
+                    last_stored_at: None,
+                    last_local_receive: None,
+                    tx: tx_a2,
+                },
+            )
+            .unwrap();
+
+        // Redeliver the SAME blob_id. If the dedup mark had been
+        // poisoned by the prior failed send, the dispatcher would
+        // early-return at step 1 and the new subscriber would never
+        // see the message.
+        let msg2 = RelayMessage::Blob {
+            routing_id,
+            blob_id,
+            recipient_hint: None,
+            blob_ttl: 3600,
+            stored_at: 1_700_000_000,
+            blob: blob_payload,
+        };
+        NativeRelayClient::dispatch_relay_message(&inner, &subscriptions, msg2).await;
+
+        // Robust against future async refactors that decouple `tx.send().await`
+        // completion from the rest of dispatch: wait on the channel rather
+        // than `try_recv`.
+        let received = tokio::time::timeout(std::time::Duration::from_secs(1), rx_a2.recv())
+            .await
+            .expect("timeout waiting for redelivery")
+            .expect("channel closed before redelivery");
+        assert!(
+            matches!(
+                received,
+                SubscriptionMessage::Relay(RelayMessage::Blob { .. })
+            ),
+            "fresh subscriber must receive the redelivered BLOB; \
+             got {received:?}. Dedup was poisoned by the prior failed send."
+        );
+
+        // After the successful delivery, dedup now commits.
+        assert!(inner.read().await.seen_blob_ids.contains(&blob_id));
     }
 
     // -----------------------------------------------------------------------
@@ -1346,5 +1547,58 @@ mod tests {
 
         // Pending map must be empty after successful response.
         assert_eq!(client.pending_len().await, 0);
+    }
+
+    #[tokio::test]
+    async fn subscribe_twice_to_same_routing_id_returns_error() {
+        use crate::native::server::{RelayConfig, RelayServer};
+        use crate::native::storage::BlobStorageBackend;
+        use std::net::SocketAddr;
+        use std::sync::Arc;
+
+        let config = RelayConfig {
+            bind_addr: SocketAddr::from(([127, 0, 0, 1], 0)),
+            ttl_check_interval: Duration::from_millis(100),
+            delivery_jitter_ms: 0,
+            ..RelayConfig::default()
+        };
+        let storage = Arc::new(BlobStorageBackend::in_memory());
+        let server = RelayServer::new(config, storage);
+        let (_handle, addr) = server.start().await.unwrap();
+        let url = format!("ws://{addr}/scp/v1");
+
+        let client = NativeRelayClient::connect(&url).await.unwrap();
+
+        let routing_id = [0x77u8; 32];
+
+        // First subscribe should succeed.
+        let _rx1 = client
+            .subscribe(&routing_id, None)
+            .await
+            .expect("first subscribe should succeed");
+
+        // Second subscribe to the same routing ID must fail with
+        // SubscriptionFailed -- the underlying TransportSubscriptionMap
+        // surfaces duplicates rather than silently overwriting.
+        let err = client
+            .subscribe(&routing_id, None)
+            .await
+            .expect_err("second subscribe should fail");
+        assert!(
+            matches!(err, TransportError::SubscriptionFailed(_)),
+            "expected SubscriptionFailed, got {err:?}"
+        );
+
+        // The first subscriber's receiver is still live (rx1 above), so
+        // the original subscription remains active. A third subscribe
+        // would still fail for the same reason.
+        let err2 = client
+            .subscribe(&routing_id, None)
+            .await
+            .expect_err("third subscribe should still fail");
+        assert!(
+            matches!(err2, TransportError::SubscriptionFailed(_)),
+            "expected SubscriptionFailed on third attempt, got {err2:?}"
+        );
     }
 }

--- a/crates/scp-transport/src/quic/adapter.rs
+++ b/crates/scp-transport/src/quic/adapter.rs
@@ -316,12 +316,15 @@ impl TransportAdapter for QuicAdapter {
         Box::pin(async move {
             let connection = self.get_connection().await?;
 
-            // Pre-IO capacity check: if the local map is full and this
-            // routing ID is not already present, reject before opening a
-            // QUIC stream and sending SUBSCRIBE. The post-IO insert below
-            // remains the authoritative gate (TOCTOU is acceptable: the
-            // pre-check is a fast-path optimization that avoids relay-side
-            // subscription leaks under non-pathological load).
+            // Best-effort pre-IO cap check: avoid opening a QUIC stream +
+            // sending SUBSCRIBE when we already know the post-IO insert
+            // would reject. The post-IO `insert_or_replace` below is the
+            // authoritative gate; this pre-check is a fast-path
+            // optimization that narrows the relay-side leak window when
+            // the cap is hit. A residual TOCTOU between this check and
+            // `insert_or_replace` is acceptable. (Broader QUIC error-path
+            // leak classes -- e.g., not finishing the send stream on
+            // intermediate failures -- are tracked separately.)
             if !self
                 .subscriptions
                 .contains(&RoutingId::new(routing_id_bytes))

--- a/crates/scp-transport/src/quic/adapter.rs
+++ b/crates/scp-transport/src/quic/adapter.rs
@@ -18,7 +18,6 @@
 //! See section 10.14 in `.docs/specs/10-infrastructure-and-self-hosting.md` and
 //! ADR-037 in `.docs/adrs/phase-2.md` for the full specification.
 
-use std::collections::HashMap;
 use std::pin::Pin;
 
 use futures::Stream;
@@ -30,6 +29,7 @@ use crate::error::TransportError;
 use crate::native::protocol::{ClientMessage, RelayMessage};
 use crate::quic::lifecycle::QuicLifecycleManager;
 use crate::quic::streams::{LENGTH_PREFIX_SIZE, MAX_FRAME_SIZE};
+use crate::subscription::TransportSubscriptionMap;
 use crate::traits::{BlobId, RoutingId, SubscriptionStream, TransportAdapter, TransportEvent};
 
 /// A boxed, pinned, `Send`-safe future -- the return type for all
@@ -76,7 +76,7 @@ pub struct QuicAdapter {
     lifecycle: RwLock<QuicLifecycleManager>,
 
     /// Active subscription handles keyed by routing ID.
-    subscriptions: RwLock<HashMap<[u8; 32], SubscriptionHandle>>,
+    subscriptions: TransportSubscriptionMap<SubscriptionHandle>,
 }
 
 impl std::fmt::Debug for QuicAdapter {
@@ -126,7 +126,7 @@ impl QuicAdapter {
         Ok(Self {
             connection: RwLock::new(Some(connection)),
             lifecycle: RwLock::new(lifecycle),
-            subscriptions: RwLock::new(HashMap::new()),
+            subscriptions: TransportSubscriptionMap::new(),
         })
     }
 
@@ -138,7 +138,7 @@ impl QuicAdapter {
         Self {
             connection: RwLock::new(Some(connection)),
             lifecycle: RwLock::new(lifecycle),
-            subscriptions: RwLock::new(HashMap::new()),
+            subscriptions: TransportSubscriptionMap::new(),
         }
     }
 
@@ -215,8 +215,10 @@ impl QuicAdapter {
             TransportError::ProtocolError(format!("failed to read message payload: {e}"))
         })?;
 
-        RelayMessage::from_bytes(&buf)
-            .map_err(|e| TransportError::ProtocolError(format!("invalid relay message: {e}")))
+        RelayMessage::from_bytes(&buf).map_err(|_| {
+            tracing::warn!("relay message deserialization failed");
+            TransportError::ProtocolError("invalid relay message".to_owned())
+        })
     }
 }
 
@@ -356,14 +358,17 @@ impl TransportAdapter for QuicAdapter {
             let cancel = CancellationToken::new();
             let cancel_clone = cancel.clone();
 
-            // Store the subscription handle.
+            // Store the subscription handle, replacing any previous one for
+            // this routing ID (and cancelling the old read loop).
+            let new_handle = SubscriptionHandle { cancel };
+            if let Some(prev) = self
+                .subscriptions
+                .insert_or_replace(RoutingId::new(routing_id_bytes), new_handle)
+                .map_err(|e| {
+                    TransportError::SubscriptionFailed(format!("subscription map full: {e}"))
+                })?
             {
-                let mut subs = self.subscriptions.write().await;
-                // Cancel any existing subscription for this routing ID.
-                if let Some(existing) = subs.remove(&routing_id_bytes) {
-                    existing.cancel.cancel();
-                }
-                subs.insert(routing_id_bytes, SubscriptionHandle { cancel });
+                prev.cancel.cancel();
             }
 
             // Create a channel for the subscription stream.
@@ -383,29 +388,11 @@ impl TransportAdapter for QuicAdapter {
                         }
                         result = Self::read_relay_message(&mut recv) => {
                             if let Ok(relay_msg) = result {
-                                let event = match relay_msg {
-                                    RelayMessage::Blob { blob, .. } => {
-                                        match OuterEnvelope::from_bytes(&blob) {
-                                            Ok(envelope) => TransportEvent::Envelope(envelope),
-                                            Err(e) => TransportEvent::Error(
-                                                TransportError::ProtocolError(format!(
-                                                    "failed to deserialize envelope from blob: {e}"
-                                                )),
-                                            ),
-                                        }
-                                    }
-                                    RelayMessage::Event { event_type, .. } => {
-                                        match event_type.as_str() {
-                                            "backfill_complete" => TransportEvent::BackfillComplete,
-                                            _ => continue,
-                                        }
-                                    }
-                                    RelayMessage::Err { code, msg, .. } => {
-                                        TransportEvent::Error(TransportError::ProtocolError(
-                                            format!("relay error {code}: {msg}"),
-                                        ))
-                                    }
-                                    _ => continue,
+                                let Some(event) = map_subscribe_relay_message(
+                                    relay_msg,
+                                    &routing_id_bytes,
+                                ) else {
+                                    continue;
                                 };
                                 if tx.send(event).await.is_err() {
                                     // Receiver dropped, stop reading.
@@ -442,11 +429,7 @@ impl TransportAdapter for QuicAdapter {
             // Verify we have a connection.
             let _connection = self.get_connection().await?;
 
-            let handle = {
-                let mut subs = self.subscriptions.write().await;
-                subs.remove(&routing_id_bytes)
-            };
-            if let Some(h) = handle {
+            if let Some(h) = self.subscriptions.remove(&RoutingId::new(routing_id_bytes)) {
                 h.cancel.cancel();
             }
             Ok(())
@@ -503,10 +486,13 @@ impl TransportAdapter for QuicAdapter {
                         }
                         match OuterEnvelope::from_bytes(&blob) {
                             Ok(envelope) => envelopes.push(envelope),
-                            Err(e) => {
-                                return Err(TransportError::ProtocolError(format!(
-                                    "failed to deserialize envelope from blob: {e}"
-                                )));
+                            Err(_) => {
+                                // The blob is attacker-controlled. Some serde
+                                // codecs include byte excerpts in their
+                                // `Display`; do not include the inner error.
+                                return Err(TransportError::ProtocolError(
+                                    "failed to deserialize envelope from blob".to_string(),
+                                ));
                             }
                         }
                     }
@@ -583,6 +569,47 @@ impl Stream for QuicSubscriptionStream {
         cx: &mut std::task::Context<'_>,
     ) -> std::task::Poll<Option<Self::Item>> {
         self.rx.poll_recv(cx)
+    }
+}
+
+/// Maps a `RelayMessage` received on a QUIC subscribe stream to the
+/// corresponding `TransportEvent`. Returns `None` for messages the
+/// subscriber should ignore (BLOBs with mismatched routing_id from a
+/// non-conformant relay, unknown event types, OK/Pong/Bridge messages).
+fn map_subscribe_relay_message(
+    relay_msg: RelayMessage,
+    expected_routing_id: &[u8; 32],
+) -> Option<TransportEvent> {
+    // Defense against a non-conformant relay that pushes BLOBs from
+    // another routing_id into this subscription's dedicated stream.
+    if let RelayMessage::Blob {
+        routing_id: blob_rid,
+        ..
+    } = &relay_msg
+        && blob_rid != expected_routing_id
+    {
+        tracing::debug!(
+            expected = ?expected_routing_id,
+            received = ?blob_rid,
+            "QUIC subscribe stream received BLOB with mismatched routing_id; dropping"
+        );
+        return None;
+    }
+    match relay_msg {
+        RelayMessage::Blob { blob, .. } => Some(match OuterEnvelope::from_bytes(&blob) {
+            Ok(envelope) => TransportEvent::Envelope(envelope),
+            Err(_) => TransportEvent::Error(TransportError::ProtocolError(
+                "failed to deserialize envelope from blob".to_string(),
+            )),
+        }),
+        RelayMessage::Event { event_type, .. } => match event_type.as_str() {
+            "backfill_complete" => Some(TransportEvent::BackfillComplete),
+            _ => None,
+        },
+        RelayMessage::Err { code, msg, .. } => Some(TransportEvent::Error(
+            TransportError::ProtocolError(format!("relay error {code}: {msg}")),
+        )),
+        _ => None,
     }
 }
 
@@ -815,6 +842,65 @@ mod tests {
         handle.shutdown();
     }
 
+    #[tokio::test]
+    async fn subscribe_twice_to_same_routing_id_replaces_previous() {
+        let (handle, addr, certs, _storage, _subs) = start_test_listener();
+
+        let routing_id_bytes = [0x4A; 32];
+        let routing_id = RoutingId::new(routing_id_bytes);
+
+        let adapter = connect_adapter(addr, &certs).await;
+
+        // First subscription.
+        let mut first_stream = adapter
+            .subscribe(&routing_id, None)
+            .await
+            .expect("first subscribe should succeed");
+
+        tokio::time::sleep(Duration::from_millis(100)).await;
+
+        // Second subscription for the same routing ID. The previous
+        // subscription's read loop must be cancelled and its stream
+        // terminated; the new stream is the one that should receive
+        // subsequent messages.
+        let mut second_stream = adapter
+            .subscribe(&routing_id, None)
+            .await
+            .expect("second subscribe should succeed");
+
+        // The first stream's background read loop was cancelled, which
+        // closes its forwarding channel. It either yields a Terminated
+        // event or simply ends (None). Either is acceptable.
+        let first_outcome = tokio::time::timeout(Duration::from_secs(2), first_stream.next()).await;
+        match first_outcome {
+            Ok(Some(TransportEvent::Terminated { .. }) | None) => {
+                // Expected.
+            }
+            Ok(Some(other)) => panic!("first stream yielded unexpected event: {other:?}"),
+            Err(_) => panic!("first stream did not terminate within 2s"),
+        }
+
+        // Publish on this routing ID and confirm the second stream
+        // receives the envelope.
+        let pub_adapter = connect_adapter(addr, &certs).await;
+        let envelope = test_envelope_with_routing(&routing_id_bytes);
+        pub_adapter
+            .send(&envelope)
+            .await
+            .expect("publish should succeed");
+
+        let event = tokio::time::timeout(Duration::from_secs(5), second_stream.next())
+            .await
+            .expect("timed out waiting for second-stream event")
+            .expect("second stream should not be empty");
+        assert!(
+            matches!(event, TransportEvent::Envelope(_)),
+            "expected Envelope on second stream, got {event:?}"
+        );
+
+        handle.shutdown();
+    }
+
     // -----------------------------------------------------------------------
     // Integration tests: query
     // -----------------------------------------------------------------------
@@ -990,5 +1076,57 @@ mod tests {
         );
 
         handle.shutdown();
+    }
+
+    // -----------------------------------------------------------------------
+    // Routing-id mismatch defense (unit tests on the read-loop helper)
+    // -----------------------------------------------------------------------
+
+    /// A BLOB whose `routing_id` does not match the dedicated subscribe
+    /// stream's expected `routing_id` is silently dropped.
+    #[test]
+    fn map_subscribe_relay_message_drops_blob_with_mismatched_routing_id() {
+        let expected = [0xAAu8; 32];
+        let mismatched = [0xBBu8; 32];
+
+        // Build a well-formed OuterEnvelope so the deserialization path
+        // would succeed if the message were forwarded; the test must
+        // confirm we drop BEFORE deserialization.
+        let envelope = create_outer_envelope(&mismatched, None, 3600, vec![1, 2, 3]).unwrap();
+        let blob = envelope.to_bytes().unwrap();
+        let msg = RelayMessage::Blob {
+            routing_id: mismatched,
+            blob_id: [0xCCu8; 32],
+            recipient_hint: None,
+            blob_ttl: 3600,
+            stored_at: 1_700_000_000,
+            blob,
+        };
+
+        let result = map_subscribe_relay_message(msg, &expected);
+        assert!(
+            result.is_none(),
+            "BLOB with mismatched routing_id must be dropped, got {result:?}"
+        );
+    }
+
+    /// `backfill_complete` events propagate; unknown event types are dropped.
+    #[test]
+    fn map_subscribe_relay_message_event_kinds() {
+        let expected = [0xAAu8; 32];
+        let backfill = RelayMessage::Event {
+            ref_id: None,
+            event_type: "backfill_complete".to_string(),
+        };
+        assert!(matches!(
+            map_subscribe_relay_message(backfill, &expected),
+            Some(TransportEvent::BackfillComplete)
+        ));
+
+        let unknown = RelayMessage::Event {
+            ref_id: None,
+            event_type: "made_up_event".to_string(),
+        };
+        assert!(map_subscribe_relay_message(unknown, &expected).is_none());
     }
 }

--- a/crates/scp-transport/src/quic/adapter.rs
+++ b/crates/scp-transport/src/quic/adapter.rs
@@ -29,7 +29,7 @@ use crate::error::TransportError;
 use crate::native::protocol::{ClientMessage, RelayMessage};
 use crate::quic::lifecycle::QuicLifecycleManager;
 use crate::quic::streams::{LENGTH_PREFIX_SIZE, MAX_FRAME_SIZE};
-use crate::subscription::TransportSubscriptionMap;
+use crate::subscription::{MAX_TRANSPORT_SUBSCRIPTIONS, TransportSubscriptionMap};
 use crate::traits::{BlobId, RoutingId, SubscriptionStream, TransportAdapter, TransportEvent};
 
 /// A boxed, pinned, `Send`-safe future -- the return type for all
@@ -315,6 +315,22 @@ impl TransportAdapter for QuicAdapter {
         let routing_id_bytes = *routing_id.as_bytes();
         Box::pin(async move {
             let connection = self.get_connection().await?;
+
+            // Pre-IO capacity check: if the local map is full and this
+            // routing ID is not already present, reject before opening a
+            // QUIC stream and sending SUBSCRIBE. The post-IO insert below
+            // remains the authoritative gate (TOCTOU is acceptable: the
+            // pre-check is a fast-path optimization that avoids relay-side
+            // subscription leaks under non-pathological load).
+            if !self
+                .subscriptions
+                .contains(&RoutingId::new(routing_id_bytes))
+                && self.subscriptions.len() >= MAX_TRANSPORT_SUBSCRIPTIONS
+            {
+                return Err(TransportError::SubscriptionFailed(format!(
+                    "subscription map full (max {MAX_TRANSPORT_SUBSCRIPTIONS} entries)"
+                )));
+            }
 
             let msg = ClientMessage::Subscribe {
                 ref_id: None,

--- a/crates/scp-transport/src/quic/streams.rs
+++ b/crates/scp-transport/src/quic/streams.rs
@@ -305,8 +305,10 @@ pub fn decode_relay_frame(payload: &[u8]) -> Result<QuicRelayFrame, TransportErr
             payload.len()
         )));
     }
-    rmp_serde::from_slice(payload)
-        .map_err(|e| TransportError::ProtocolError(format!("invalid relay frame: {e}")))
+    rmp_serde::from_slice(payload).map_err(|_| {
+        tracing::warn!("relay frame deserialization failed");
+        TransportError::ProtocolError("invalid relay frame".to_owned())
+    })
 }
 
 /// Deserializes a client frame from raw `MessagePack` bytes.
@@ -326,8 +328,10 @@ pub fn decode_client_frame(payload: &[u8]) -> Result<QuicClientFrame, TransportE
             payload.len()
         )));
     }
-    rmp_serde::from_slice(payload)
-        .map_err(|e| TransportError::ProtocolError(format!("invalid client frame: {e}")))
+    rmp_serde::from_slice(payload).map_err(|_| {
+        tracing::warn!("client frame deserialization failed");
+        TransportError::ProtocolError("invalid client frame".to_owned())
+    })
 }
 
 // ---------------------------------------------------------------------------

--- a/crates/scp-transport/src/subscription.rs
+++ b/crates/scp-transport/src/subscription.rs
@@ -37,11 +37,15 @@ use crate::traits::RoutingId;
 
 /// Maximum concurrent subscriptions tracked per transport adapter.
 ///
-/// Mirrors the server-side SEC-006 per-routing-ID cap but applied at the
-/// transport adapter. Ten thousand entries is far beyond any realistic SCP
-/// transport adapter (a heavy participant might be in hundreds of contexts at
-/// once) while still bounding memory growth from pathological producers or
-/// bugs.
+/// Bounds memory growth from pathological producers or programming bugs
+/// (e.g., a runaway loop calling `subscribe`). Ten thousand entries is well
+/// above any realistic SCP transport-adapter participant -- a heavy
+/// participant might be in hundreds of contexts at once -- while still
+/// capping pathological growth.
+///
+/// This cap is independent of the server-side relay caps in
+/// [`crate::relay::subscription`], which protect relay memory under a
+/// different shape (1:N fan-out, total + per-routing-id limits).
 ///
 /// Adapters that cannot use [`TransportSubscriptionMap`] directly (e.g.,
 /// the WebTransport HTTP/3 path with its `web_sys` value type) must enforce
@@ -139,6 +143,8 @@ impl<V> TransportSubscriptionMap<V> {
     /// recoverable condition.
     pub fn insert(&self, routing_id: RoutingId, value: V) -> Result<(), SubscriptionError> {
         {
+            // Hold the write lock across contains-then-insert to make the
+            // check-and-insert atomic.
             let mut guard = self
                 .inner
                 .write()

--- a/crates/scp-transport/src/subscription.rs
+++ b/crates/scp-transport/src/subscription.rs
@@ -1,0 +1,574 @@
+//! Subscription map for transport adapters.
+//!
+//! Unifies the ad-hoc `HashMap<[u8; 32], V>` pattern used across transport
+//! adapters (QUIC, `NativeRelayClient`, WebTransport). Distinct from
+//! [`relay::SubscriptionRegistry`](crate::relay::subscription::SubscriptionRegistry),
+//! which is a 1:N fan-out registry; this one is a 1:1 keyed map.
+//!
+//! # Closure constraints for [`with`], [`with_mut`], [`for_each`]
+//!
+//! These methods invoke a caller-supplied closure while holding the inner
+//! `RwLock`. To stay safe, the closure must:
+//!
+//! * Run synchronously to completion. The closure is `FnOnce` / `FnMut`,
+//!   never `async`. A closure that calls `block_on` will stall the runtime
+//!   worker (and on WASM there is no runtime worker to stall it on).
+//! * Avoid acquiring any other lock that participates in a lock ordering
+//!   with this map -- otherwise the program may deadlock.
+//! * Avoid re-entering the same map (any of [`insert`], [`remove`],
+//!   [`with`], etc.) -- otherwise the program will deadlock or, on a
+//!   re-entrant write attempt, panic on poison.
+//!
+//! Keep closures short: clone out anything you need, drop the closure, and
+//! do further work on the cloned value.
+//!
+//! [`with`]: TransportSubscriptionMap::with
+//! [`with_mut`]: TransportSubscriptionMap::with_mut
+//! [`for_each`]: TransportSubscriptionMap::for_each
+//! [`insert`]: TransportSubscriptionMap::insert
+//! [`remove`]: TransportSubscriptionMap::remove
+
+use std::collections::HashMap;
+use std::sync::RwLock;
+
+use thiserror::Error;
+
+use crate::traits::RoutingId;
+
+/// Maximum concurrent subscriptions tracked per transport adapter.
+///
+/// Mirrors the server-side SEC-006 per-routing-ID cap but applied at the
+/// transport adapter. Ten thousand entries is far beyond any realistic SCP
+/// transport adapter (a heavy participant might be in hundreds of contexts at
+/// once) while still bounding memory growth from pathological producers or
+/// bugs.
+///
+/// Adapters that cannot use [`TransportSubscriptionMap`] directly (e.g.,
+/// the WebTransport HTTP/3 path with its `web_sys` value type) must enforce
+/// this cap inline; see `crates/scp-transport/src/webtransport/client.rs`
+/// for the canonical example.
+pub const MAX_TRANSPORT_SUBSCRIPTIONS: usize = 10_000;
+
+/// Errors returned by [`TransportSubscriptionMap`] mutation methods.
+#[derive(Debug, Clone, Error, PartialEq, Eq)]
+pub enum SubscriptionError {
+    /// A subscription is already registered for this routing ID.
+    ///
+    /// Callers that want "replace" semantics should [`remove`] the existing
+    /// entry first (and tear it down as appropriate for the adapter), then
+    /// [`insert`] the new value. Callers always know which routing ID they
+    /// attempted to insert, so the variant carries no payload -- including
+    /// the routing ID would just produce a noisy 100+ char `Debug` blob in
+    /// log output.
+    ///
+    /// [`remove`]: TransportSubscriptionMap::remove
+    /// [`insert`]: TransportSubscriptionMap::insert
+    #[error("subscription already exists for routing id")]
+    Duplicate,
+
+    /// The map has reached [`MAX_TRANSPORT_SUBSCRIPTIONS`] entries and cannot
+    /// accept another subscription until an existing one is removed.
+    #[error("subscription capacity exceeded: max {0}")]
+    CapacityExceeded(usize),
+}
+
+/// A 1:1 map from SCP routing ID to adapter-specific subscription value.
+///
+/// Used by transport adapters (QUIC, `NativeRelayClient`, WebTransport) to
+/// track active subscriptions. See the [module-level documentation](self) for
+/// closure-safety constraints on [`with`](Self::with),
+/// [`with_mut`](Self::with_mut), and [`for_each`](Self::for_each).
+///
+/// # Type parameter
+///
+/// `V` is the adapter's per-subscription value. Typical choices:
+///
+/// | Adapter | `V` |
+/// |---------|-----|
+/// | QUIC | cancellation handle for the read-loop task |
+/// | `NativeRelayClient` | subscription state + sender channel |
+/// | WebTransport (WebSocket fallback) | `mpsc::UnboundedSender<TransportEvent>` |
+///
+/// # Concurrency
+///
+/// The map is `Send + Sync` when `V: Send + Sync`. Internal synchronization
+/// uses [`std::sync::RwLock`] (rather than `tokio::sync::RwLock`) so the map
+/// works on `wasm32` and avoids forcing callers to be `async`.
+#[derive(Debug)]
+pub struct TransportSubscriptionMap<V> {
+    inner: RwLock<HashMap<RoutingId, V>>,
+    max: usize,
+}
+
+impl<V> Default for TransportSubscriptionMap<V> {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl<V> TransportSubscriptionMap<V> {
+    /// Creates an empty map with the default capacity
+    /// [`MAX_TRANSPORT_SUBSCRIPTIONS`].
+    #[must_use]
+    pub fn new() -> Self {
+        Self::with_capacity(MAX_TRANSPORT_SUBSCRIPTIONS)
+    }
+
+    /// Creates an empty map with the given maximum entry count. For tests
+    /// and internal use; zero is legal (rejects every insert) but useless.
+    #[must_use]
+    pub(crate) fn with_capacity(max: usize) -> Self {
+        Self {
+            inner: RwLock::new(HashMap::new()),
+            max,
+        }
+    }
+
+    /// Inserts `value` at `routing_id`.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`SubscriptionError::Duplicate`] if an entry already exists
+    /// for `routing_id`, or [`SubscriptionError::CapacityExceeded`] if the
+    /// map has reached its configured maximum.
+    ///
+    /// # Panics
+    ///
+    /// Panics only if the inner lock is poisoned, which would require a
+    /// previous panic while holding the lock -- a bug rather than a
+    /// recoverable condition.
+    pub fn insert(&self, routing_id: RoutingId, value: V) -> Result<(), SubscriptionError> {
+        {
+            let mut guard = self
+                .inner
+                .write()
+                .unwrap_or_else(std::sync::PoisonError::into_inner);
+            if guard.contains_key(&routing_id) {
+                return Err(SubscriptionError::Duplicate);
+            }
+            if guard.len() >= self.max {
+                return Err(SubscriptionError::CapacityExceeded(self.max));
+            }
+            guard.insert(routing_id, value);
+        }
+        Ok(())
+    }
+
+    /// Inserts `value` at `routing_id`, replacing any existing entry.
+    ///
+    /// Returns the previous value if the slot was occupied. Use
+    /// [`insert`](Self::insert) instead when duplicate detection is required.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`SubscriptionError::CapacityExceeded`] if the map is at its
+    /// maximum and the insert would grow it (i.e. the routing ID was not
+    /// already present).
+    ///
+    /// # Panics
+    ///
+    /// Panics only if the inner lock is poisoned (see [`insert`](Self::insert)).
+    pub fn insert_or_replace(
+        &self,
+        routing_id: RoutingId,
+        value: V,
+    ) -> Result<Option<V>, SubscriptionError> {
+        let mut guard = self
+            .inner
+            .write()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        let present = guard.contains_key(&routing_id);
+        if !present && guard.len() >= self.max {
+            return Err(SubscriptionError::CapacityExceeded(self.max));
+        }
+        Ok(guard.insert(routing_id, value))
+    }
+
+    /// Removes and returns the value at `routing_id`, if any.
+    ///
+    /// # Panics
+    ///
+    /// Panics only if the inner lock is poisoned.
+    pub fn remove(&self, routing_id: &RoutingId) -> Option<V> {
+        let mut guard = self
+            .inner
+            .write()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        guard.remove(routing_id)
+    }
+
+    /// Returns `true` if the map contains an entry for `routing_id`.
+    ///
+    /// # Panics
+    ///
+    /// Panics only if the inner lock is poisoned.
+    #[must_use]
+    pub fn contains(&self, routing_id: &RoutingId) -> bool {
+        let guard = self
+            .inner
+            .read()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        guard.contains_key(routing_id)
+    }
+
+    /// Applies `f` to the value at `routing_id`, if present.
+    ///
+    /// Acquires a read lock and calls `f` with a shared reference to the
+    /// value. Returns `None` if the slot is empty; otherwise returns
+    /// `Some(f(&V))`. Used by adapters that need to read a field of `V`
+    /// without cloning it. The closure runs while the lock is held; see
+    /// [module docs](self) for constraints.
+    ///
+    /// # Panics
+    ///
+    /// Panics only if the inner lock is poisoned.
+    pub fn with<R>(&self, routing_id: &RoutingId, f: impl FnOnce(&V) -> R) -> Option<R> {
+        let guard = self
+            .inner
+            .read()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        guard.get(routing_id).map(f)
+    }
+
+    /// Applies `f` to a mutable reference to the value at `routing_id`,
+    /// if present.
+    ///
+    /// Acquires a write lock and calls `f` with an exclusive reference to
+    /// the value. Returns `None` if the slot is empty; otherwise returns
+    /// `Some(f(&mut V))`. The closure runs while the lock is held; see
+    /// [module docs](self) for constraints.
+    ///
+    /// # Panics
+    ///
+    /// Panics only if the inner lock is poisoned.
+    pub fn with_mut<R>(&self, routing_id: &RoutingId, f: impl FnOnce(&mut V) -> R) -> Option<R> {
+        let mut guard = self
+            .inner
+            .write()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        guard.get_mut(routing_id).map(f)
+    }
+
+    /// Applies `f` to each value in the map.
+    ///
+    /// Holds a read lock for the duration of iteration. Intended for simple
+    /// fan-out operations (e.g. notifying every subscription of a reconnect
+    /// event). The closure runs while the lock is held; see
+    /// [module docs](self) for constraints.
+    ///
+    /// # Panics
+    ///
+    /// Panics only if the inner lock is poisoned.
+    pub fn for_each(&self, mut f: impl FnMut(&RoutingId, &V)) {
+        let guard = self
+            .inner
+            .read()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        for (k, v) in guard.iter() {
+            f(k, v);
+        }
+    }
+}
+
+impl<V: Clone> TransportSubscriptionMap<V> {
+    /// Returns a snapshot of every `(routing_id, value)` pair.
+    ///
+    /// Used by adapters during reconnection when both the routing ID and
+    /// per-subscription state are needed to re-issue SUBSCRIBE.
+    ///
+    /// # Panics
+    ///
+    /// Panics only if the inner lock is poisoned.
+    #[must_use]
+    pub fn snapshot(&self) -> Vec<(RoutingId, V)> {
+        let guard = self
+            .inner
+            .read()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        guard.iter().map(|(k, v)| (*k, v.clone())).collect()
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used, clippy::panic)]
+mod tests {
+    use std::sync::Arc;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    use super::*;
+
+    fn rid(byte: u8) -> RoutingId {
+        RoutingId::new([byte; 32])
+    }
+
+    #[test]
+    fn new_is_empty() {
+        let map: TransportSubscriptionMap<u32> = TransportSubscriptionMap::new();
+        assert!(map.snapshot().is_empty());
+    }
+
+    #[test]
+    fn insert_and_contains() {
+        let map = TransportSubscriptionMap::<u32>::new();
+        assert!(!map.contains(&rid(1)));
+        map.insert(rid(1), 42).unwrap();
+        assert!(map.contains(&rid(1)));
+        assert_eq!(map.snapshot().len(), 1);
+    }
+
+    #[test]
+    fn insert_duplicate_is_rejected() {
+        let map = TransportSubscriptionMap::<u32>::new();
+        map.insert(rid(1), 42).unwrap();
+        let err = map.insert(rid(1), 99).unwrap_err();
+        assert_eq!(err, SubscriptionError::Duplicate);
+        // Original value untouched.
+        assert_eq!(map.with(&rid(1), |v| *v), Some(42));
+    }
+
+    #[test]
+    fn insert_or_replace_returns_previous() {
+        let map = TransportSubscriptionMap::<u32>::new();
+        assert_eq!(map.insert_or_replace(rid(1), 42).unwrap(), None);
+        assert_eq!(map.insert_or_replace(rid(1), 99).unwrap(), Some(42));
+        assert_eq!(map.with(&rid(1), |v| *v), Some(99));
+    }
+
+    #[test]
+    fn insert_or_replace_respects_capacity() {
+        let map = TransportSubscriptionMap::<u32>::with_capacity(2);
+        map.insert_or_replace(rid(1), 1).unwrap();
+        map.insert_or_replace(rid(2), 2).unwrap();
+        // Replacing an existing key never grows the map.
+        assert!(map.insert_or_replace(rid(1), 11).is_ok());
+        // New key at capacity fails.
+        let err = map.insert_or_replace(rid(3), 3).unwrap_err();
+        assert_eq!(err, SubscriptionError::CapacityExceeded(2));
+    }
+
+    #[test]
+    fn remove_returns_value() {
+        let map = TransportSubscriptionMap::<u32>::new();
+        map.insert(rid(1), 42).unwrap();
+        assert_eq!(map.remove(&rid(1)), Some(42));
+        assert_eq!(map.remove(&rid(1)), None);
+        assert!(map.snapshot().is_empty());
+    }
+
+    #[test]
+    fn capacity_limit_blocks_inserts() {
+        let map = TransportSubscriptionMap::<u32>::with_capacity(2);
+        map.insert(rid(1), 1).unwrap();
+        map.insert(rid(2), 2).unwrap();
+        let err = map.insert(rid(3), 3).unwrap_err();
+        assert_eq!(err, SubscriptionError::CapacityExceeded(2));
+        assert_eq!(map.snapshot().len(), 2);
+    }
+
+    #[test]
+    fn capacity_limit_recovers_after_remove() {
+        let map = TransportSubscriptionMap::<u32>::with_capacity(1);
+        map.insert(rid(1), 1).unwrap();
+        assert!(map.insert(rid(2), 2).is_err());
+        map.remove(&rid(1));
+        map.insert(rid(2), 2).unwrap();
+    }
+
+    #[test]
+    fn zero_capacity_rejects_every_insert() {
+        let map = TransportSubscriptionMap::<u32>::with_capacity(0);
+        let err = map.insert(rid(1), 1).unwrap_err();
+        assert_eq!(err, SubscriptionError::CapacityExceeded(0));
+    }
+
+    #[test]
+    fn snapshot_contains_inserted_keys() {
+        let map = TransportSubscriptionMap::<u32>::new();
+        map.insert(rid(1), 1).unwrap();
+        map.insert(rid(2), 2).unwrap();
+        let mut ids: Vec<RoutingId> = map.snapshot().into_iter().map(|(k, _)| k).collect();
+        ids.sort_by_key(|id| id.as_bytes()[0]);
+        assert_eq!(ids, vec![rid(1), rid(2)]);
+    }
+
+    #[test]
+    fn with_returns_none_when_absent() {
+        let map = TransportSubscriptionMap::<u32>::new();
+        assert!(map.with(&rid(1), |_| ()).is_none());
+    }
+
+    #[test]
+    fn with_mut_mutates_in_place() {
+        let map = TransportSubscriptionMap::<u32>::new();
+        map.insert(rid(1), 10).unwrap();
+        map.with_mut(&rid(1), |v| *v += 5).unwrap();
+        assert_eq!(map.with(&rid(1), |v| *v), Some(15));
+    }
+
+    #[test]
+    fn for_each_visits_every_entry() {
+        let map = TransportSubscriptionMap::<u32>::new();
+        map.insert(rid(1), 1).unwrap();
+        map.insert(rid(2), 2).unwrap();
+        map.insert(rid(3), 3).unwrap();
+        let seen = AtomicUsize::new(0);
+        map.for_each(|_, v| {
+            seen.fetch_add(*v as usize, Ordering::Relaxed);
+        });
+        assert_eq!(seen.load(Ordering::Relaxed), 6);
+    }
+
+    #[test]
+    fn snapshot_returns_all_pairs() {
+        let map = TransportSubscriptionMap::<u32>::new();
+        map.insert(rid(1), 10).unwrap();
+        map.insert(rid(2), 20).unwrap();
+        let mut pairs = map.snapshot();
+        pairs.sort_by_key(|(k, _)| k.as_bytes()[0]);
+        assert_eq!(pairs, vec![(rid(1), 10), (rid(2), 20)]);
+        // Original still present.
+        assert_eq!(map.snapshot().len(), 2);
+    }
+
+    #[test]
+    fn concurrent_inserts_and_removes_do_not_deadlock() {
+        // Smoke test: disjoint thread keyspaces ensure no insert/remove ever
+        // contends on the same routing ID. Verifies the lock plumbing alone.
+        let map = Arc::new(TransportSubscriptionMap::<u64>::new());
+        let mut handles = Vec::new();
+        for thread_idx in 0..8u8 {
+            let map = Arc::clone(&map);
+            handles.push(std::thread::spawn(move || {
+                for i in 0..100u8 {
+                    let mut id = [0u8; 32];
+                    id[0] = thread_idx;
+                    id[1] = i;
+                    let _ = map.insert(
+                        RoutingId::new(id),
+                        u64::from(thread_idx) * 1000 + u64::from(i),
+                    );
+                }
+                for i in 0..100u8 {
+                    let mut id = [0u8; 32];
+                    id[0] = thread_idx;
+                    id[1] = i;
+                    let _ = map.remove(&RoutingId::new(id));
+                }
+            }));
+        }
+        for h in handles {
+            h.join().unwrap();
+        }
+        assert!(map.snapshot().is_empty());
+    }
+
+    #[test]
+    fn concurrent_inserts_and_removes_preserve_invariants() {
+        // Stress test: 4 threads each cycle through the SAME 16 routing IDs
+        // with random insert / insert_or_replace / remove operations. After
+        // joining we verify (a) no entry is torn (every present value is one
+        // we wrote), (b) `snapshot().len()` is at most 16, and (c)
+        // `insert_or_replace` against a present key never trips the capacity
+        // bound (capacity is bounded but greater than the keyspace).
+        const KEYSPACE: u8 = 16;
+        const THREADS: usize = 4;
+        const ITERATIONS: usize = 500;
+
+        // Capacity > keyspace so resize-by-replace never hits the cap.
+        let map = Arc::new(TransportSubscriptionMap::<u64>::with_capacity(
+            usize::from(KEYSPACE) + 4,
+        ));
+        let cap_violations = Arc::new(AtomicUsize::new(0));
+        let mut handles = Vec::new();
+        for thread_idx in 0..THREADS {
+            let map = Arc::clone(&map);
+            let cap_violations = Arc::clone(&cap_violations);
+            handles.push(std::thread::spawn(move || {
+                // Cheap thread-distinct xorshift64* sequence.
+                let mut state: u64 = (thread_idx as u64).wrapping_mul(0x9E37_79B9_7F4A_7C15);
+                for iter in 0..ITERATIONS {
+                    state ^= state << 13;
+                    state ^= state >> 7;
+                    state ^= state << 17;
+
+                    // Low bits drive the key, high bits the op; sharing
+                    // bits would pin each key to a single operation.
+                    let key_byte =
+                        u8::try_from(state % u64::from(KEYSPACE)).expect("modulo fits in u8");
+                    let mut id = [0u8; 32];
+                    id[0] = key_byte;
+                    let rid = RoutingId::new(id);
+                    let value = (thread_idx as u64) << 32 | iter as u64;
+
+                    match (state >> 32) & 0x3 {
+                        0 => {
+                            // insert: may legitimately error with Duplicate.
+                            let _ = map.insert(rid, value);
+                        }
+                        1 => {
+                            // insert_or_replace: against any key, must not
+                            // trip CapacityExceeded with cap > keyspace.
+                            if let Err(SubscriptionError::CapacityExceeded(_)) =
+                                map.insert_or_replace(rid, value)
+                            {
+                                cap_violations.fetch_add(1, Ordering::Relaxed);
+                            }
+                        }
+                        2 => {
+                            let _ = map.remove(&rid);
+                        }
+                        _ => {
+                            let _ = map.contains(&rid);
+                        }
+                    }
+                }
+            }));
+        }
+        for h in handles {
+            h.join().unwrap();
+        }
+
+        assert_eq!(
+            cap_violations.load(Ordering::Relaxed),
+            0,
+            "insert_or_replace must never report CapacityExceeded when capacity > keyspace"
+        );
+
+        // Final state is some valid subset of the keyspace -- no orphan or
+        // torn entries.
+        let ids: Vec<RoutingId> = map.snapshot().into_iter().map(|(k, _)| k).collect();
+        assert!(ids.len() <= usize::from(KEYSPACE));
+        for id in &ids {
+            assert!(id.as_bytes()[0] < KEYSPACE);
+        }
+    }
+
+    #[test]
+    fn concurrent_readers_do_not_block_each_other() {
+        // Smoke test: many readers run concurrently without deadlock.
+        let map = Arc::new(TransportSubscriptionMap::<u32>::new());
+        for i in 0..10u8 {
+            let mut id = [0u8; 32];
+            id[0] = i;
+            map.insert(RoutingId::new(id), u32::from(i)).unwrap();
+        }
+
+        let mut handles = Vec::new();
+        for _ in 0..8 {
+            let map = Arc::clone(&map);
+            handles.push(std::thread::spawn(move || {
+                for _ in 0..100 {
+                    let _ = map.snapshot();
+                }
+            }));
+        }
+        for h in handles {
+            h.join().unwrap();
+        }
+        assert_eq!(map.snapshot().len(), 10);
+    }
+}

--- a/crates/scp-transport/src/subscription.rs
+++ b/crates/scp-transport/src/subscription.rs
@@ -38,19 +38,21 @@ use crate::traits::RoutingId;
 /// Maximum concurrent subscriptions tracked per transport adapter.
 ///
 /// Bounds memory growth from pathological producers or programming bugs
-/// (e.g., a runaway loop calling `subscribe`). Ten thousand entries is well
-/// above any realistic SCP transport-adapter participant -- a heavy
-/// participant might be in hundreds of contexts at once -- while still
-/// capping pathological growth.
+/// (e.g., a runaway loop calling `subscribe`). 10,000 is well above the
+/// highest realistic SCP transport-adapter participant footprint (a heavy
+/// participant typically holds ~hundreds of context subscriptions; the cap
+/// leaves >100x headroom). The cap exists to bound memory growth from
+/// pathological producers or bugs. Revisit this constant if real participant
+/// counts approach 1,000.
 ///
 /// This cap is independent of the server-side relay caps in
 /// [`crate::relay::subscription`], which protect relay memory under a
 /// different shape (1:N fan-out, total + per-routing-id limits).
 ///
-/// Adapters that cannot use [`TransportSubscriptionMap`] directly (e.g.,
-/// the WebTransport HTTP/3 path with its `web_sys` value type) must enforce
-/// this cap inline; see `crates/scp-transport/src/webtransport/client.rs`
-/// for the canonical example.
+/// Adapters whose subscription lifecycle requires close-on-unsubscribe with
+/// network IO outside the lock (e.g., the WebTransport HTTP/3 bidi-stream
+/// path) must enforce this cap inline rather than going through the
+/// [`TransportSubscriptionMap`] storage primitive.
 pub const MAX_TRANSPORT_SUBSCRIPTIONS: usize = 10_000;
 
 /// Errors returned by [`TransportSubscriptionMap`] mutation methods.
@@ -58,15 +60,10 @@ pub const MAX_TRANSPORT_SUBSCRIPTIONS: usize = 10_000;
 pub enum SubscriptionError {
     /// A subscription is already registered for this routing ID.
     ///
-    /// Callers that want "replace" semantics should [`remove`] the existing
-    /// entry first (and tear it down as appropriate for the adapter), then
-    /// [`insert`] the new value. Callers always know which routing ID they
-    /// attempted to insert, so the variant carries no payload -- including
-    /// the routing ID would just produce a noisy 100+ char `Debug` blob in
-    /// log output.
-    ///
-    /// [`remove`]: TransportSubscriptionMap::remove
-    /// [`insert`]: TransportSubscriptionMap::insert
+    /// Callers wanting replace semantics should use
+    /// [`insert_or_replace`](TransportSubscriptionMap::insert_or_replace)
+    /// or call [`remove`](TransportSubscriptionMap::remove) then
+    /// [`insert`](TransportSubscriptionMap::insert).
     #[error("subscription already exists for routing id")]
     Duplicate,
 
@@ -82,6 +79,10 @@ pub enum SubscriptionError {
 /// track active subscriptions. See the [module-level documentation](self) for
 /// closure-safety constraints on [`with`](Self::with),
 /// [`with_mut`](Self::with_mut), and [`for_each`](Self::for_each).
+///
+/// All methods recover from lock-poisoning automatically by extracting the
+/// inner state via [`std::sync::PoisonError::into_inner`]. They do not panic
+/// on poison.
 ///
 /// # Type parameter
 ///
@@ -135,12 +136,6 @@ impl<V> TransportSubscriptionMap<V> {
     /// Returns [`SubscriptionError::Duplicate`] if an entry already exists
     /// for `routing_id`, or [`SubscriptionError::CapacityExceeded`] if the
     /// map has reached its configured maximum.
-    ///
-    /// # Panics
-    ///
-    /// Panics only if the inner lock is poisoned, which would require a
-    /// previous panic while holding the lock -- a bug rather than a
-    /// recoverable condition.
     pub fn insert(&self, routing_id: RoutingId, value: V) -> Result<(), SubscriptionError> {
         {
             // Hold the write lock across contains-then-insert to make the
@@ -170,10 +165,6 @@ impl<V> TransportSubscriptionMap<V> {
     /// Returns [`SubscriptionError::CapacityExceeded`] if the map is at its
     /// maximum and the insert would grow it (i.e. the routing ID was not
     /// already present).
-    ///
-    /// # Panics
-    ///
-    /// Panics only if the inner lock is poisoned (see [`insert`](Self::insert)).
     pub fn insert_or_replace(
         &self,
         routing_id: RoutingId,
@@ -191,10 +182,6 @@ impl<V> TransportSubscriptionMap<V> {
     }
 
     /// Removes and returns the value at `routing_id`, if any.
-    ///
-    /// # Panics
-    ///
-    /// Panics only if the inner lock is poisoned.
     pub fn remove(&self, routing_id: &RoutingId) -> Option<V> {
         let mut guard = self
             .inner
@@ -204,10 +191,6 @@ impl<V> TransportSubscriptionMap<V> {
     }
 
     /// Returns `true` if the map contains an entry for `routing_id`.
-    ///
-    /// # Panics
-    ///
-    /// Panics only if the inner lock is poisoned.
     #[must_use]
     pub fn contains(&self, routing_id: &RoutingId) -> bool {
         let guard = self
@@ -217,6 +200,28 @@ impl<V> TransportSubscriptionMap<V> {
         guard.contains_key(routing_id)
     }
 
+    /// Returns the count of currently registered subscriptions.
+    ///
+    /// Useful for callers that want to pre-check capacity before doing
+    /// expensive work (e.g. opening a network stream) that would fail at
+    /// insert time. The post-insert capacity gate in
+    /// [`insert`](Self::insert) and [`insert_or_replace`](Self::insert_or_replace)
+    /// remains the authoritative bound; this is a fast-path optimization.
+    #[must_use]
+    pub fn len(&self) -> usize {
+        let guard = self
+            .inner
+            .read()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        guard.len()
+    }
+
+    /// Returns `true` if the map contains no subscriptions.
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+
     /// Applies `f` to the value at `routing_id`, if present.
     ///
     /// Acquires a read lock and calls `f` with a shared reference to the
@@ -224,10 +229,6 @@ impl<V> TransportSubscriptionMap<V> {
     /// `Some(f(&V))`. Used by adapters that need to read a field of `V`
     /// without cloning it. The closure runs while the lock is held; see
     /// [module docs](self) for constraints.
-    ///
-    /// # Panics
-    ///
-    /// Panics only if the inner lock is poisoned.
     pub fn with<R>(&self, routing_id: &RoutingId, f: impl FnOnce(&V) -> R) -> Option<R> {
         let guard = self
             .inner
@@ -243,10 +244,6 @@ impl<V> TransportSubscriptionMap<V> {
     /// the value. Returns `None` if the slot is empty; otherwise returns
     /// `Some(f(&mut V))`. The closure runs while the lock is held; see
     /// [module docs](self) for constraints.
-    ///
-    /// # Panics
-    ///
-    /// Panics only if the inner lock is poisoned.
     pub fn with_mut<R>(&self, routing_id: &RoutingId, f: impl FnOnce(&mut V) -> R) -> Option<R> {
         let mut guard = self
             .inner
@@ -261,10 +258,6 @@ impl<V> TransportSubscriptionMap<V> {
     /// fan-out operations (e.g. notifying every subscription of a reconnect
     /// event). The closure runs while the lock is held; see
     /// [module docs](self) for constraints.
-    ///
-    /// # Panics
-    ///
-    /// Panics only if the inner lock is poisoned.
     pub fn for_each(&self, mut f: impl FnMut(&RoutingId, &V)) {
         let guard = self
             .inner
@@ -281,10 +274,6 @@ impl<V: Clone> TransportSubscriptionMap<V> {
     ///
     /// Used by adapters during reconnection when both the routing ID and
     /// per-subscription state are needed to re-issue SUBSCRIBE.
-    ///
-    /// # Panics
-    ///
-    /// Panics only if the inner lock is poisoned.
     #[must_use]
     pub fn snapshot(&self) -> Vec<(RoutingId, V)> {
         let guard = self
@@ -545,11 +534,20 @@ mod tests {
         );
 
         // Final state is some valid subset of the keyspace -- no orphan or
-        // torn entries.
-        let ids: Vec<RoutingId> = map.snapshot().into_iter().map(|(k, _)| k).collect();
-        assert!(ids.len() <= usize::from(KEYSPACE));
-        for id in &ids {
+        // torn entries. Verify (a) keys live in the configured keyspace, and
+        // (b) every present value decodes back to a `(thread_idx, iter)` pair
+        // we actually wrote, with no torn or interleaved high/low halves.
+        let entries: Vec<(RoutingId, u64)> = map.snapshot();
+        assert!(entries.len() <= usize::from(KEYSPACE));
+        for (id, value) in &entries {
             assert!(id.as_bytes()[0] < KEYSPACE);
+            let thread_idx = (value >> 32) as usize;
+            let iter = (value & 0xFFFF_FFFF) as usize;
+            assert!(
+                thread_idx < THREADS,
+                "torn entry: thread_idx {thread_idx} out of range"
+            );
+            assert!(iter < ITERATIONS, "torn entry: iter {iter} out of range");
         }
     }
 

--- a/crates/scp-transport/src/subscription.rs
+++ b/crates/scp-transport/src/subscription.rs
@@ -41,8 +41,7 @@ use crate::traits::RoutingId;
 /// (e.g., a runaway loop calling `subscribe`). 10,000 is well above the
 /// highest realistic SCP transport-adapter participant footprint (a heavy
 /// participant typically holds ~hundreds of context subscriptions; the cap
-/// leaves >100x headroom). The cap exists to bound memory growth from
-/// pathological producers or bugs. Revisit this constant if real participant
+/// leaves >100x headroom). Revisit this constant if real participant
 /// counts approach 1,000.
 ///
 /// This cap is independent of the server-side relay caps in

--- a/crates/scp-transport/src/traits.rs
+++ b/crates/scp-transport/src/traits.rs
@@ -185,6 +185,13 @@ pub trait TransportAdapter: Send + Sync {
     /// Returns [`TransportError::SubscriptionFailed`] if the subscription
     /// cannot be established, or [`TransportError::NotConnected`] if the
     /// adapter has no active connection.
+    ///
+    /// # Behavior on duplicate `routing_id`
+    ///
+    /// `subscribe` semantics on duplicate routing-id are not uniform across
+    /// adapters; callers must not depend on either rejection or replacement.
+    /// Track local subscription state and avoid issuing duplicate subscribes.
+    /// See the follow-up tracking issue for the planned uniform contract.
     fn subscribe(
         &self,
         routing_id: &RoutingId,

--- a/crates/scp-transport/src/traits.rs
+++ b/crates/scp-transport/src/traits.rs
@@ -191,7 +191,6 @@ pub trait TransportAdapter: Send + Sync {
     /// `subscribe` semantics on duplicate routing-id are not uniform across
     /// adapters; callers must not depend on either rejection or replacement.
     /// Track local subscription state and avoid issuing duplicate subscribes.
-    /// See the follow-up tracking issue for the planned uniform contract.
     fn subscribe(
         &self,
         routing_id: &RoutingId,

--- a/crates/scp-transport/src/udp/adapter.rs
+++ b/crates/scp-transport/src/udp/adapter.rs
@@ -189,8 +189,12 @@ impl UdpDtlsAdapter {
 
         // `RelayMessage::from_bytes` rejects payloads exceeding `MAX_MESSAGE_SIZE`
         // before invoking the MessagePack deserializer, preventing allocation bombs.
-        let response: RelayMessage = RelayMessage::from_bytes(&response_data).map_err(|e| {
-            TransportError::ProtocolError(format!("relay message deserialization failed: {e}"))
+        // The byte payload is relay-supplied and some serde codecs include byte
+        // excerpts in `Display`; do not propagate the serde error into the
+        // surfaced `TransportError`.
+        let response: RelayMessage = RelayMessage::from_bytes(&response_data).map_err(|_| {
+            tracing::warn!("relay message deserialization failed");
+            TransportError::ProtocolError("invalid relay message".to_owned())
         })?;
 
         Ok(response)
@@ -338,10 +342,14 @@ impl TransportAdapter for UdpDtlsAdapter {
                         });
                     }
 
-                    let envelope = OuterEnvelope::from_bytes(&blob).map_err(|e| {
-                        TransportError::ProtocolError(format!(
-                            "failed to deserialize envelope: {e}"
-                        ))
+                    let envelope = OuterEnvelope::from_bytes(&blob).map_err(|_| {
+                        // The blob is relay-supplied; do not propagate the
+                        // serde error into the TransportError -- some codecs
+                        // include byte excerpts in `Display`.
+                        tracing::warn!("envelope deserialization failed");
+                        TransportError::ProtocolError(
+                            "failed to deserialize envelope from blob".to_owned(),
+                        )
                     })?;
 
                     Ok(vec![envelope])

--- a/crates/scp-transport/src/webtransport/client.rs
+++ b/crates/scp-transport/src/webtransport/client.rs
@@ -58,6 +58,9 @@ use crate::native::protocol::{ClientMessage, RelayMessage};
 use crate::quic::streams::{
     QuicClientFrame, QuicRelayFrame, decode_frame_from_buf, decode_relay_frame, encode_client_frame,
 };
+use crate::subscription::{
+    MAX_TRANSPORT_SUBSCRIPTIONS, SubscriptionError, TransportSubscriptionMap,
+};
 use crate::traits::{BlobId, RoutingId, SubscriptionStream, TransportAdapter, TransportEvent};
 
 /// A boxed, pinned, `Send`-safe future -- the return type for all
@@ -159,9 +162,10 @@ pub struct WebTransportAdapter {
     /// Active WebSocket handle, wrapped for Send+Sync.
     ws_handle: Arc<Mutex<Option<SendSyncWrapper<web_sys::WebSocket>>>>,
 
-    /// WebTransport bidi stream handles for active subscriptions, keyed
-    /// by routing_id. Stored so that `unsubscribe()` can close the stream
-    /// to signal the relay.
+    /// Active WebTransport (HTTP/3) bidi-stream handles keyed by routing_id.
+    /// Used by the WT-HTTP/3 subscribe path; the lifecycle re-architecture
+    /// is tracked in a follow-up issue. The minimal cap+duplicate guard in
+    /// `subscribe()` uses a check-do-check pattern around this map.
     #[cfg(target_arch = "wasm32")]
     wt_bidi_handles:
         Arc<Mutex<HashMap<[u8; 32], SendSyncWrapper<web_sys::WebTransportBidirectionalStream>>>>,
@@ -169,7 +173,7 @@ pub struct WebTransportAdapter {
     /// WebSocket subscription routing: routing_id -> event sender.
     /// The WebSocket onmessage handler dispatches BLOB messages to the
     /// appropriate subscription sender based on the routing_id.
-    subscriptions: Arc<Mutex<HashMap<[u8; 32], mpsc::UnboundedSender<TransportEvent>>>>,
+    subscriptions: Arc<TransportSubscriptionMap<mpsc::UnboundedSender<TransportEvent>>>,
 
     /// Pending request-response correlation for WebSocket path.
     /// Maps ref_id -> oneshot sender for the response.
@@ -233,7 +237,7 @@ impl WebTransportAdapter {
             ws_handle: Arc::new(Mutex::new(None)),
             #[cfg(target_arch = "wasm32")]
             wt_bidi_handles: Arc::new(Mutex::new(HashMap::new())),
-            subscriptions: Arc::new(Mutex::new(HashMap::new())),
+            subscriptions: Arc::new(TransportSubscriptionMap::new()),
             pending_requests: Arc::new(Mutex::new(HashMap::new())),
             subscribe_ref_ids: Arc::new(Mutex::new(HashMap::new())),
             next_ref_id: Arc::new(Mutex::new(1)),
@@ -451,11 +455,14 @@ impl WebTransportAdapter {
                 return;
             };
 
-            // Deserialize as RelayMessage (MessagePack).
+            // Deserialize as RelayMessage (MessagePack). The relay's bytes
+            // are attacker-controlled; deliberately do not surface the
+            // serde error in any user-visible string -- it can include
+            // byte excerpts in `Display`.
             let relay_msg = match RelayMessage::from_bytes(&bytes) {
                 Ok(msg) => msg,
-                Err(e) => {
-                    tracing::warn!("failed to deserialize relay message: {e}");
+                Err(_) => {
+                    tracing::warn!("relay message deserialization failed");
                     return;
                 }
             };
@@ -940,14 +947,58 @@ impl TransportAdapter for WebTransportAdapter {
         Box::pin(async move {
             match state {
                 FallbackState::Connected(TransportKind::WebTransport) => {
-                    // WebTransport path: open a long-lived bidirectional stream,
-                    // send SUBSCRIBE frame, return event stream.
+                    // Check-do-check: race semantics under concurrent
+                    // subscribe/unsubscribe interleaving are documented as
+                    // known limitations; see the follow-up tracking issue
+                    // for the planned uniform lifecycle contract.
+                    {
+                        let guard = self.wt_bidi_handles.lock().map_err(|_| {
+                            TransportError::ProtocolError(
+                                "wt_bidi_handles lock poisoned".to_owned(),
+                            )
+                        })?;
+                        if guard.contains_key(&routing_id_bytes) {
+                            return Err(TransportError::SubscriptionFailed(
+                                "already subscribed to this routing_id".to_owned(),
+                            ));
+                        }
+                        if guard.len() >= MAX_TRANSPORT_SUBSCRIPTIONS {
+                            return Err(TransportError::SubscriptionFailed(format!(
+                                "subscription map full (max {MAX_TRANSPORT_SUBSCRIPTIONS} entries)"
+                            )));
+                        }
+                    }
+
                     let (stream, bidi_handle) =
                         self.wt_subscribe_stream(routing_id_bytes, since).await?;
-                    // Store the bidi handle so unsubscribe() can close it.
-                    if let Ok(mut guard) = self.wt_bidi_handles.lock() {
+
+                    {
+                        let mut guard = self.wt_bidi_handles.lock().map_err(|_| {
+                            TransportError::ProtocolError(
+                                "wt_bidi_handles lock poisoned".to_owned(),
+                            )
+                        })?;
+                        if guard.contains_key(&routing_id_bytes) {
+                            drop(guard);
+                            if let Ok(writer) = bidi_handle.inner().writable().get_writer() {
+                                let _ = writer.close();
+                            }
+                            return Err(TransportError::SubscriptionFailed(
+                                "concurrent subscribe completed for this routing_id".to_owned(),
+                            ));
+                        }
+                        if guard.len() >= MAX_TRANSPORT_SUBSCRIPTIONS {
+                            drop(guard);
+                            if let Ok(writer) = bidi_handle.inner().writable().get_writer() {
+                                let _ = writer.close();
+                            }
+                            return Err(TransportError::SubscriptionFailed(format!(
+                                "subscription map full (max {MAX_TRANSPORT_SUBSCRIPTIONS} entries)"
+                            )));
+                        }
                         guard.insert(routing_id_bytes, bidi_handle);
                     }
+
                     Ok(stream)
                 }
                 FallbackState::Connected(TransportKind::WebSocket) => {
@@ -968,18 +1019,18 @@ impl TransportAdapter for WebTransportAdapter {
                     // messages between send and registration. If a subscription
                     // already exists for this routing_id, reject the request
                     // to prevent clobbering the existing subscription's sender.
-                    {
-                        let mut guard = self
-                            .subscriptions
-                            .lock()
-                            .map_err(|_| TransportError::NotConnected)?;
-                        if guard.contains_key(&routing_id_bytes) {
-                            return Err(TransportError::SubscriptionFailed(
+                    self.subscriptions
+                        .insert(RoutingId::new(routing_id_bytes), tx)
+                        .map_err(|e| match e {
+                            SubscriptionError::Duplicate => TransportError::SubscriptionFailed(
                                 "already subscribed to this routing_id".to_owned(),
-                            ));
-                        }
-                        guard.insert(routing_id_bytes, tx);
-                    }
+                            ),
+                            SubscriptionError::CapacityExceeded(n) => {
+                                TransportError::SubscriptionFailed(format!(
+                                    "subscription map full ({n} entries)"
+                                ))
+                            }
+                        })?;
 
                     // Register ref_id -> routing_id mapping so that
                     // backfill_complete events can be routed to this specific
@@ -1016,25 +1067,25 @@ impl TransportAdapter for WebTransportAdapter {
         Box::pin(async move {
             match state {
                 FallbackState::Connected(TransportKind::WebTransport) => {
-                    // Remove the bidi handle and close its writable stream
-                    // to signal the relay that this subscription is done.
-                    // The relay recognizes closing the writer as an implicit
+                    let removed_handle = self
+                        .wt_bidi_handles
+                        .lock()
+                        .ok()
+                        .and_then(|mut guard| guard.remove(&routing_id_bytes));
+
+                    // Close the writable stream outside the lock to signal
+                    // the relay that this subscription is done. The relay
+                    // recognizes closing the writer as an implicit
                     // unsubscribe per the QUIC stream-per-operation model.
-                    if let Ok(mut guard) = self.wt_bidi_handles.lock() {
-                        if let Some(handle) = guard.remove(&routing_id_bytes) {
-                            // Close the writable stream to signal the relay.
-                            let writable = handle.inner().writable();
-                            if let Ok(writer) = writable.get_writer() {
-                                let _ = writer.close();
-                            }
-                        }
+                    if let Some(handle) = removed_handle
+                        && let Ok(writer) = handle.inner().writable().get_writer()
+                    {
+                        let _ = writer.close();
                     }
 
                     // Remove from local subscriptions (the background reader
                     // task will exit when the sender is dropped).
-                    if let Ok(mut guard) = self.subscriptions.lock() {
-                        guard.remove(&routing_id_bytes);
-                    }
+                    self.subscriptions.remove(&RoutingId::new(routing_id_bytes));
 
                     Ok(())
                 }
@@ -1051,9 +1102,7 @@ impl TransportAdapter for WebTransportAdapter {
                     self.ws_send_fire_and_forget(&msg)?;
 
                     // Remove from local subscriptions.
-                    if let Ok(mut guard) = self.subscriptions.lock() {
-                        guard.remove(&routing_id_bytes);
-                    }
+                    self.subscriptions.remove(&RoutingId::new(routing_id_bytes));
 
                     Ok(())
                 }
@@ -1179,9 +1228,14 @@ impl TransportAdapter for WebTransportAdapter {
                                         QuicRelayFrame::Blob { blob, .. } => {
                                             match OuterEnvelope::from_bytes(&blob) {
                                                 Ok(env) => envelopes.push(env),
-                                                Err(e) => {
+                                                Err(_) => {
+                                                    // Sanitized: do not log the
+                                                    // serde error; the byte
+                                                    // payload is relay-supplied
+                                                    // and some codecs include
+                                                    // byte excerpts in `Display`.
                                                     tracing::warn!(
-                                                        "failed to deserialize envelope: {e}"
+                                                        "envelope deserialization failed"
                                                     );
                                                 }
                                             }
@@ -1224,16 +1278,13 @@ impl TransportAdapter for WebTransportAdapter {
                     // registration to avoid clobbering it -- query results
                     // will still arrive via the pending_request for
                     // query_complete, and we accept potentially fewer results.
-                    let registered_temp_sub;
-                    {
-                        let mut guard = self
-                            .subscriptions
-                            .lock()
-                            .map_err(|_| TransportError::NotConnected)?;
-                        registered_temp_sub = !guard.contains_key(&routing_id_bytes);
-                        if registered_temp_sub {
-                            guard.insert(routing_id_bytes, tx);
-                        }
+                    let registered_temp_sub = !self
+                        .subscriptions
+                        .contains(&RoutingId::new(routing_id_bytes));
+                    if registered_temp_sub {
+                        self.subscriptions
+                            .insert(RoutingId::new(routing_id_bytes), tx)
+                            .map_err(|e| TransportError::SubscriptionFailed(e.to_string()))?;
                     }
 
                     // Also register a pending request for the query_complete
@@ -1270,9 +1321,7 @@ impl TransportAdapter for WebTransportAdapter {
                     // Clean up the temporary subscription only if we
                     // registered it (i.e., no pre-existing subscription).
                     if registered_temp_sub {
-                        if let Ok(mut guard) = self.subscriptions.lock() {
-                            guard.remove(&routing_id_bytes);
-                        }
+                        self.subscriptions.remove(&RoutingId::new(routing_id_bytes));
                     }
 
                     Ok(envelopes)
@@ -1355,7 +1404,7 @@ impl TransportAdapter for WebTransportAdapter {
 /// to prevent broadcasting to all subscribers.
 fn dispatch_relay_message(
     msg: &RelayMessage,
-    subscriptions: &Arc<Mutex<HashMap<[u8; 32], mpsc::UnboundedSender<TransportEvent>>>>,
+    subscriptions: &Arc<TransportSubscriptionMap<mpsc::UnboundedSender<TransportEvent>>>,
     pending_requests: &Arc<Mutex<HashMap<String, oneshot::Sender<RelayMessage>>>>,
     subscribe_ref_ids: &Arc<Mutex<HashMap<String, [u8; 32]>>>,
 ) {
@@ -1376,22 +1425,31 @@ fn dispatch_relay_message(
         }
     }
 
-    // Route BLOB messages to subscriptions by routing_id.
+    // Route BLOB messages to subscriptions by routing_id. Decoding only
+    // runs after a presence check so malformed BLOBs at unsolicited
+    // routing_ids cannot drive log spam or attacker-controlled bytes
+    // toward error surfaces (sanitized regardless on the failure path).
     if let RelayMessage::Blob {
         routing_id, blob, ..
     } = msg
     {
-        if let Ok(guard) = subscriptions.lock() {
-            if let Some(tx) = guard.get(routing_id) {
-                let event = match OuterEnvelope::from_bytes(blob) {
-                    Ok(env) => TransportEvent::Envelope(env),
-                    Err(e) => TransportEvent::Error(TransportError::ProtocolError(format!(
-                        "failed to deserialize envelope from blob: {e}"
-                    ))),
-                };
-                let _ = tx.unbounded_send(event);
-            }
+        let rid = RoutingId::new(*routing_id);
+        if !subscriptions.contains(&rid) {
+            return;
         }
+        let event = match OuterEnvelope::from_bytes(blob) {
+            Ok(env) => TransportEvent::Envelope(env),
+            Err(_) => {
+                // The blob is attacker-controlled. Some serde codecs include
+                // raw byte excerpts in their `Display`; do not include `e` in
+                // the surfaced error message.
+                tracing::warn!("envelope deserialization failed");
+                TransportEvent::Error(TransportError::ProtocolError(
+                    "failed to deserialize envelope from blob".to_owned(),
+                ))
+            }
+        };
+        let _ = subscriptions.with(&rid, |tx| tx.unbounded_send(event));
     }
 
     // Route backfill_complete events to the specific subscription that
@@ -1410,20 +1468,16 @@ fn dispatch_relay_message(
 
             if let Some(routing_id) = target_routing_id {
                 // Scoped delivery: only the subscription that requested backfill.
-                if let Ok(guard) = subscriptions.lock() {
-                    if let Some(tx) = guard.get(&routing_id) {
-                        let _ = tx.unbounded_send(TransportEvent::BackfillComplete);
-                    }
-                }
+                let _ = subscriptions.with(&RoutingId::new(routing_id), |tx| {
+                    tx.unbounded_send(TransportEvent::BackfillComplete)
+                });
             } else {
                 // Fallback: no ref_id mapping available. Broadcast to all
                 // subscriptions for backwards compatibility with relays that
                 // send backfill_complete without a ref_id.
-                if let Ok(guard) = subscriptions.lock() {
-                    for tx in guard.values() {
-                        let _ = tx.unbounded_send(TransportEvent::BackfillComplete);
-                    }
-                }
+                subscriptions.for_each(|_rid, tx| {
+                    let _ = tx.unbounded_send(TransportEvent::BackfillComplete);
+                });
             }
         }
     }
@@ -1438,9 +1492,16 @@ fn relay_frame_to_event(frame: QuicRelayFrame) -> Option<TransportEvent> {
     match frame {
         QuicRelayFrame::Blob { blob, .. } => match OuterEnvelope::from_bytes(&blob) {
             Ok(env) => Some(TransportEvent::Envelope(env)),
-            Err(e) => Some(TransportEvent::Error(TransportError::ProtocolError(
-                format!("failed to deserialize envelope: {e}"),
-            ))),
+            Err(_) => {
+                // Sanitized: do not propagate the serde error message into the
+                // TransportEvent. The byte payload is relay-supplied and some
+                // codecs include byte excerpts in `Display`, which would leak
+                // attacker-controlled bytes into SDK error surfaces.
+                tracing::warn!("envelope deserialization failed");
+                Some(TransportEvent::Error(TransportError::ProtocolError(
+                    "failed to deserialize envelope from blob".to_owned(),
+                )))
+            }
         },
         QuicRelayFrame::Event { event_type } => match event_type.as_str() {
             "backfill_complete" => Some(TransportEvent::BackfillComplete),
@@ -1600,5 +1661,69 @@ mod tests {
         let frame = QuicRelayFrame::Ok { blob_id: None };
         let event = relay_frame_to_event(frame);
         assert!(event.is_none());
+    }
+
+    #[test]
+    fn dispatch_blob_routes_to_correct_subscription() {
+        // Verify that a BLOB message addressed to one routing_id is delivered
+        // only to the matching subscription's sender, not to every subscriber.
+        let routing_a = [0xAAu8; 32];
+        let routing_b = [0xBBu8; 32];
+
+        let subscriptions: Arc<TransportSubscriptionMap<mpsc::UnboundedSender<TransportEvent>>> =
+            Arc::new(TransportSubscriptionMap::new());
+        let pending_requests: Arc<Mutex<HashMap<String, oneshot::Sender<RelayMessage>>>> =
+            Arc::new(Mutex::new(HashMap::new()));
+        let subscribe_ref_ids: Arc<Mutex<HashMap<String, [u8; 32]>>> =
+            Arc::new(Mutex::new(HashMap::new()));
+
+        let (tx_a, mut rx_a) = mpsc::unbounded::<TransportEvent>();
+        let (tx_b, mut rx_b) = mpsc::unbounded::<TransportEvent>();
+        subscriptions
+            .insert(RoutingId::new(routing_a), tx_a)
+            .unwrap();
+        subscriptions
+            .insert(RoutingId::new(routing_b), tx_b)
+            .unwrap();
+
+        // Build a valid envelope addressed to routing_a so that
+        // OuterEnvelope::from_bytes succeeds.
+        let envelope = scp_core::envelope::create_outer_envelope(
+            &routing_a,
+            None,
+            3600,
+            vec![0x01, 0x02, 0x03],
+        )
+        .unwrap();
+        let blob_bytes = envelope.to_bytes().unwrap();
+
+        let blob_msg = RelayMessage::Blob {
+            routing_id: routing_a,
+            blob_id: *crate::traits::BlobId::from_sha256(&blob_bytes).as_bytes(),
+            recipient_hint: None,
+            blob_ttl: 3600,
+            stored_at: 1_700_000_000,
+            blob: blob_bytes,
+        };
+
+        dispatch_relay_message(
+            &blob_msg,
+            &subscriptions,
+            &pending_requests,
+            &subscribe_ref_ids,
+        );
+
+        // routing_a's subscription must receive the envelope.
+        let event_a = rx_a.try_next().expect("rx_a should have an event").unwrap();
+        assert!(
+            matches!(event_a, TransportEvent::Envelope(_)),
+            "expected Envelope on rx_a, got {event_a:?}"
+        );
+
+        // routing_b's subscription must NOT receive anything.
+        assert!(
+            rx_b.try_next().is_err(),
+            "rx_b should be empty after dispatch to routing_a"
+        );
     }
 }

--- a/crates/scp-transport/src/webtransport/client.rs
+++ b/crates/scp-transport/src/webtransport/client.rs
@@ -163,9 +163,8 @@ pub struct WebTransportAdapter {
     ws_handle: Arc<Mutex<Option<SendSyncWrapper<web_sys::WebSocket>>>>,
 
     /// Active WebTransport (HTTP/3) bidi-stream handles keyed by routing_id.
-    /// Used by the WT-HTTP/3 subscribe path; the lifecycle re-architecture
-    /// is tracked in a follow-up issue. The minimal cap+duplicate guard in
-    /// `subscribe()` uses a check-do-check pattern around this map.
+    /// Used by the WT-HTTP/3 subscribe path. The minimal cap+duplicate guard
+    /// in `subscribe()` uses a check-do-check pattern around this map.
     #[cfg(target_arch = "wasm32")]
     wt_bidi_handles:
         Arc<Mutex<HashMap<[u8; 32], SendSyncWrapper<web_sys::WebTransportBidirectionalStream>>>>,
@@ -949,14 +948,12 @@ impl TransportAdapter for WebTransportAdapter {
                 FallbackState::Connected(TransportKind::WebTransport) => {
                     // Check-do-check: race semantics under concurrent
                     // subscribe/unsubscribe interleaving are documented as
-                    // known limitations; see the follow-up tracking issue
-                    // for the planned uniform lifecycle contract.
+                    // known limitations.
                     {
-                        let guard = self.wt_bidi_handles.lock().map_err(|_| {
-                            TransportError::ProtocolError(
-                                "wt_bidi_handles lock poisoned".to_owned(),
-                            )
-                        })?;
+                        let guard = self
+                            .wt_bidi_handles
+                            .lock()
+                            .unwrap_or_else(std::sync::PoisonError::into_inner);
                         if guard.contains_key(&routing_id_bytes) {
                             return Err(TransportError::SubscriptionFailed(
                                 "already subscribed to this routing_id".to_owned(),
@@ -973,11 +970,10 @@ impl TransportAdapter for WebTransportAdapter {
                         self.wt_subscribe_stream(routing_id_bytes, since).await?;
 
                     {
-                        let mut guard = self.wt_bidi_handles.lock().map_err(|_| {
-                            TransportError::ProtocolError(
-                                "wt_bidi_handles lock poisoned".to_owned(),
-                            )
-                        })?;
+                        let mut guard = self
+                            .wt_bidi_handles
+                            .lock()
+                            .unwrap_or_else(std::sync::PoisonError::into_inner);
                         if guard.contains_key(&routing_id_bytes) {
                             drop(guard);
                             if let Ok(writer) = bidi_handle.inner().writable().get_writer() {
@@ -1067,11 +1063,13 @@ impl TransportAdapter for WebTransportAdapter {
         Box::pin(async move {
             match state {
                 FallbackState::Connected(TransportKind::WebTransport) => {
-                    let removed_handle = self
-                        .wt_bidi_handles
-                        .lock()
-                        .ok()
-                        .and_then(|mut guard| guard.remove(&routing_id_bytes));
+                    let removed_handle = {
+                        let mut guard = self
+                            .wt_bidi_handles
+                            .lock()
+                            .unwrap_or_else(std::sync::PoisonError::into_inner);
+                        guard.remove(&routing_id_bytes)
+                    };
 
                     // Close the writable stream outside the lock to signal
                     // the relay that this subscription is done. The relay


### PR DESCRIPTION
## Summary

Lands Prerequisite 2 of the actor-per-context plan: a unified `TransportSubscriptionMap<V>` storage primitive at `crates/scp-transport/src/subscription.rs`, used by the QUIC, native relay client, and WebTransport WebSocket-fallback adapters. The server-side `SubscriptionRegistry` (1:N fan-out) is unchanged.

Renamed from the working name `ClientSubscriptionMap` (existed as a draft in the `actor-per-context` integration worktree) to avoid semantic collision with the SDK-facing `SCP` "client" class introduced by cozy-fluttering-rose Phase 4.

## What changed

**New storage primitive**:
- `TransportSubscriptionMap<V>` keyed on `RoutingId`, capacity-bounded (`MAX_TRANSPORT_SUBSCRIPTIONS = 10_000`), duplicate-rejecting, with closure-API for read/mutate/iter access and a `snapshot()` helper for reconnect.
- `SubscriptionError { Duplicate, CapacityExceeded(usize) }`.
- Re-exported at the crate root.

**Adapter migrations**:
- QUIC, native, WebTransport WebSocket-fallback all use `TransportSubscriptionMap`.
- WebTransport HTTP/3's `wt_bidi_handles` is NOT migrated (its value type is wasm32-conditional `web_sys` JS handles, distinct shape). It receives a minimal pre-IO + post-IO cap+duplicate guard inline. Race semantics under concurrent subscribe/unsubscribe interleaving are documented as known limitations; the comprehensive lifecycle re-architecture is tracked at #1731.

**Pre-existing bugs the migration uncovered, fixed in this PR**:
- Native `subscribe()` no longer silently overwrites and leaks the prior `mpsc::Sender`. Returns `SubscriptionFailed` on duplicate.
- Native BLOB dispatch checks subscription presence BEFORE committing the dedup-cache mark. Closes a relay-cache-poisoning vector where unsolicited BLOBs from a malicious or buggy relay could evict legitimate dedup entries.
- Native dedup commit moved to AFTER successful `tx.send`. Closes an unsubscribe-during-dispatch race that could silently suppress legitimate post-resubscribe redelivery.
- Deserialization-error sanitization across QUIC, WebTransport, and UDP sites. Relay-supplied bytes no longer reach SDK error surfaces or trace logs via serde `Display` (which can include byte excerpts).
- QUIC subscribe read-loop verifies `BLOB.routing_id` matches the dedicated stream's routing-id, defending against non-conformant relays.

## Behavior changes visible to public callers

- **`NativeRelayClient::subscribe`** now returns `TransportError::SubscriptionFailed` when called twice for the same `routing_id` without an intervening unsubscribe. Pre-PR: silently overwrote the entry, leaking the prior `mpsc::Sender`. The new error path uses an existing variant, no new public type. Strictly safer.
- **`NativeRelayClient::query`** has a similar visible behavior change: a concurrent `subscribe(rid).await` running while `query(rid).await` is in flight (from two tasks) can now surface `SubscriptionFailed` to the caller of whichever loses the race. Pre-PR, the second arrival's `HashMap::insert` silently clobbered the first. Acceptable — the new behavior is strictly safer (no silent `Sender` clobber) and the only path that exercises it is concurrent subscribe-and-query for the same routing_id, which has no legitimate caller pattern.
- **`NativeRelayClient::active_subscriptions`** has been removed. Pre-PR it was `#[allow(dead_code)]`-annotated with no external callers. Callers wanting a snapshot can use the `TransportSubscriptionMap::snapshot` accessor on the underlying field.

## Provenance

- `.docs/plans/generic-moseying-lightning.md` lines 1484-1490 (Prerequisite 2 scope).
- Rejected alternative around line 1652: "exclude SubscriptionRegistry unification, fold into this PR" — out of scope per CLAUDE.md "never bundle unrelated changes."

## Tracked follow-up

#1731 — `SubscriptionLifecycle<H>`: typed transactional subscription registration across heterogeneous transports. Designed in detail with implementation guide and AC checklist. Addresses race semantics, cap-bypass, cancel-safety, and per-adapter behavior asymmetry across all client transports (including the WT-HTTP/3 path this PR pragmatically guards inline).

## Test plan

- [x] `cargo fmt --all -- --check` — clean.
- [x] `cargo clippy --workspace --all-targets --features scp-ffi-uniffi/allow_in_memory_custody,scp-ffi/allow_in_memory_custody,scp-ffi-napi/allow_in_memory_custody,scp-core/testing,scp-runtime/testing -- -D warnings` — zero warnings.
- [x] `DYLD_LIBRARY_PATH=$(python3.12 -c "import sysconfig; print(sysconfig.get_config_var('LIBDIR'))") cargo test --workspace --features ...` — all tests pass.
- [x] New unit tests on `TransportSubscriptionMap` covering insert, insert_or_replace, capacity bounds, concurrent contention with overlapping keys.
- [x] New regression test in native: `dedup_not_committed_when_send_fails_after_unsubscribe` exercises the unsubscribe-during-dispatch race.
- [x] New regression test in native: `subscribe_twice_to_same_routing_id_returns_error` locks in the duplicate-rejection contract.
- [x] New unit test in QUIC: `subscribe_twice_to_same_routing_id_replaces_previous` (gated `--features quic`; pre-existing `quic/lifecycle.rs` rot prevents the feature from building locally — same on `main`).
- [x] New helper `map_subscribe_relay_message` factored out of QUIC read-loop with three unit tests covering routing-id mismatch drop and event-kind handling.
- [x] WebTransport `dispatch_blob_routes_to_correct_subscription` host-runnable smoke test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
