### PR TITLE
fix(transport): sanitize remaining error-path leak vectors

### DIFF
--- a/crates/scp-transport/src/quic/adapter.rs
+++ b/crates/scp-transport/src/quic/adapter.rs
@@ -322,9 +322,10 @@ impl TransportAdapter for QuicAdapter {
             // authoritative gate; this pre-check is a fast-path
             // optimization that narrows the relay-side leak window when
             // the cap is hit. A residual TOCTOU between this check and
-            // `insert_or_replace` is acceptable. (Broader QUIC error-path
-            // leak classes -- e.g., not finishing the send stream on
-            // intermediate failures -- are tracked separately.)
+            // `insert_or_replace` is acceptable: if the insert nonetheless
+            // fails in that window, the error path below finishes the send
+            // stream so a conforming relay can release any subscription state
+            // gracefully (whether it does is relay-implementation-dependent).
             if !self
                 .subscriptions
                 .contains(&RoutingId::new(routing_id_bytes))
@@ -345,28 +346,43 @@ impl TransportAdapter for QuicAdapter {
                 TransportError::SubscriptionFailed(format!("failed to open stream: {e}"))
             })?;
 
-            Self::write_client_message(&mut send, &msg)
-                .await
-                .map_err(|e| {
-                    TransportError::SubscriptionFailed(format!("failed to send SUBSCRIBE: {e}"))
-                })?;
-            // Do NOT finish the send stream -- subscribe stream stays open.
+            // Error paths between open_bi() and successful registration in
+            // `self.subscriptions` must call `send.finish()` before returning
+            // so the relay sees a graceful FIN rather than a stream RESET.
+            // RESET is a hard close; a FIN lets a conforming relay release any
+            // subscription state it created. Whether a given relay keys cleanup
+            // off the per-stream FIN is relay-implementation-dependent (SCP's
+            // own relay cleans up on connection-level close).
+            if let Err(e) = Self::write_client_message(&mut send, &msg).await {
+                let _ = send.finish();
+                return Err(TransportError::SubscriptionFailed(format!(
+                    "failed to send SUBSCRIBE: {e}"
+                )));
+            }
+            // Do NOT finish the send stream on the success path -- subscribe
+            // stream stays open and is moved into the spawned read loop below.
 
             // Read the OK/ERR response from the relay.
-            let response = Self::read_relay_message(&mut recv).await.map_err(|e| {
-                TransportError::SubscriptionFailed(format!(
-                    "failed to read SUBSCRIBE response: {e}"
-                ))
-            })?;
+            let response = match Self::read_relay_message(&mut recv).await {
+                Ok(r) => r,
+                Err(e) => {
+                    let _ = send.finish();
+                    return Err(TransportError::SubscriptionFailed(format!(
+                        "failed to read SUBSCRIBE response: {e}"
+                    )));
+                }
+            };
 
             match &response {
                 RelayMessage::Ok { .. } => {}
                 RelayMessage::Err { code, msg, .. } => {
+                    let _ = send.finish();
                     return Err(TransportError::SubscriptionFailed(format!(
                         "relay rejected subscription: {code}: {msg}"
                     )));
                 }
                 _ => {
+                    let _ = send.finish();
                     return Err(TransportError::ProtocolError(
                         "unexpected response to SUBSCRIBE".to_string(),
                     ));
@@ -380,14 +396,23 @@ impl TransportAdapter for QuicAdapter {
             // Store the subscription handle, replacing any previous one for
             // this routing ID (and cancelling the old read loop).
             let new_handle = SubscriptionHandle { cancel };
-            if let Some(prev) = self
+            match self
                 .subscriptions
                 .insert_or_replace(RoutingId::new(routing_id_bytes), new_handle)
-                .map_err(|e| {
-                    TransportError::SubscriptionFailed(format!("subscription map full: {e}"))
-                })?
             {
-                prev.cancel.cancel();
+                Ok(Some(prev)) => prev.cancel.cancel(),
+                Ok(None) => {}
+                Err(e) => {
+                    // Registration failed after IO (TOCTOU vs the pre-IO cap
+                    // check above); finish the send stream so the relay sees a
+                    // graceful FIN rather than a RESET, allowing a conforming
+                    // relay to release any subscription state it just created
+                    // (whether it does is relay-implementation-dependent).
+                    let _ = send.finish();
+                    return Err(TransportError::SubscriptionFailed(format!(
+                        "subscription map full: {e}"
+                    )));
+                }
             }
 
             // Create a channel for the subscription stream.

--- a/crates/scp-transport/src/quic/listener.rs
+++ b/crates/scp-transport/src/quic/listener.rs
@@ -690,7 +690,12 @@ async fn read_client_message(mut recv: RecvStream) -> Result<ClientMessage, Stre
         .await
         .map_err(|e| StreamError::Read(e.to_string()))?;
 
-    ClientMessage::from_bytes(&buf).map_err(|e| StreamError::Protocol(e.to_string()))
+    // Drop the deserializer's Display string: rmp_serde can embed excerpts of
+    // the attacker-controlled malformed MessagePack bytes, which would then be
+    // logged at the stream-handler error site (error = %e). Keep a static
+    // description so no input bytes reach the relay's logs.
+    ClientMessage::from_bytes(&buf)
+        .map_err(|_| StreamError::Protocol("failed to deserialize message".to_string()))
 }
 
 /// Writes a relay message to a QUIC send stream.

--- a/crates/scp-transport/src/udp/listener.rs
+++ b/crates/scp-transport/src/udp/listener.rs
@@ -728,8 +728,8 @@ async fn per_client_recv_loop<S: BlobStorage + 'static>(
         // before invoking the MessagePack deserializer, preventing allocation bombs.
         let client_msg: ClientMessage = match ClientMessage::from_bytes(&datagram) {
             Ok(msg) => msg,
-            Err(e) => {
-                debug!(remote = %remote_addr, error = %e, "failed to deserialize UDP datagram");
+            Err(_) => {
+                debug!(remote = %remote_addr, "failed to deserialize UDP datagram");
                 let err = RelayMessage::Err {
                     ref_id: None,
                     code: 400,


### PR DESCRIPTION
## Summary

Two pre-existing leak vectors flagged during PR #1732 review by the security-reviewer and adversarial-expert agents. Both predate #1732; filed here as a focused follow-up rather than as tracking issues per CLAUDE.md `feedback_no_tracking_issues`.

## What changed

1. **`udp/listener.rs`** — incoming-datagram debug log dropped attacker-controlled bytes via `error = %e`. `rmp_serde::Error::Display` can include byte excerpts of the malformed input, which a malicious or buggy remote can spam into operator logs. The `remote = %addr` field is retained for triage; the `error = %e` field is dropped.

2. **`quic/adapter.rs::subscribe`** — error paths between `open_bi()` and successful subscription registration now call `send.finish()` before returning. Previously, these paths dropped the `send`/`recv` handles which caused a stream RESET. Most relays interpret RESET as "client abandoned, drop subscription state," but RESET is a hard close, not graceful, and a non-conformant or buggy relay may not clean up subscription state on RESET. Calling `send.finish()` sends a FIN; the relay handles it as graceful close and is more likely to consistently clean up subscription state.

   Four error paths are covered:
   - `write_client_message` failure (failed to send SUBSCRIBE).
   - `read_relay_message` failure (failed to read OK/ERR).
   - Relay returned `RelayMessage::Err`.
   - Unexpected response shape.

   This addresses the broader QUIC error-path leak class flagged by adversarial reviewer Finding 3 on #1732, which the pre-IO cap-check there only narrowed.

## Provenance

- #1732 round-6 security review surfaced fix #1.
- #1732 round-7 adversarial review surfaced fix #2.

Both are pre-existing on `origin/main`; not introduced or worsened by #1732.

## Notes

- This branch is based on `origin/main` (pre-#1732). After #1732 merges, this branch will need a trivial rebase — the QUIC `subscribe()` shape changes slightly under #1732 but the four error paths still exist.
- The QUIC test infrastructure does not currently exercise the `subscribe()` error paths (and the `quic` feature is broken on `main` — pre-existing rot in `quic/lifecycle.rs`). The fix is an invariant ("every error return between `open_bi` and successful registration calls `send.finish()`") best verified by code review; a regression test would require non-trivial quinn server scaffolding.

## Test plan

- [x] `cargo fmt --all -- --check` — clean.
- [x] `cargo clippy --workspace --all-targets --features scp-ffi-uniffi/allow_in_memory_custody,scp-ffi/allow_in_memory_custody,scp-ffi-napi/allow_in_memory_custody,scp-core/testing,scp-runtime/testing -- -D warnings` — zero warnings.
- [x] `cargo test --workspace --features ...` — all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
