### PR TITLE
chore(ci): pin Fuzz nightly toolchain to nightly-2026-05-03

### DIFF
--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -83,7 +83,16 @@ jobs:
 
       - uses: actions/checkout@v5
 
-      - uses: dtolnay/rust-toolchain@nightly
+      # TEMPORARY: pinned nightly. Recent nightlies (post-2026-05-03) tightened
+      # E0365 enforcement on glob re-exports, which fires on openmls 0.8.1's
+      # prelude — its trailing `pub use crate::ciphersuite::*` picks up the
+      # earlier `pub(crate) use signature::*` shadow and re-exports
+      # `Signature` / `SignContent` / `SignaturePublicKey` /
+      # `OpenMlsSignaturePublicKey` at insufficient visibility.
+      #
+      # Unpin to `@nightly` once openmls publishes a fixed prelude (likely
+      # 0.8.2 or 0.9) and `crates/scp-runtime` updates its dependency.
+      - uses: dtolnay/rust-toolchain@nightly-2026-05-03
 
       - name: Install cargo-fuzz
         run: cargo install cargo-fuzz --locked
@@ -173,7 +182,16 @@ jobs:
 
       - uses: actions/checkout@v5
 
-      - uses: dtolnay/rust-toolchain@nightly
+      # TEMPORARY: pinned nightly. Recent nightlies (post-2026-05-03) tightened
+      # E0365 enforcement on glob re-exports, which fires on openmls 0.8.1's
+      # prelude — its trailing `pub use crate::ciphersuite::*` picks up the
+      # earlier `pub(crate) use signature::*` shadow and re-exports
+      # `Signature` / `SignContent` / `SignaturePublicKey` /
+      # `OpenMlsSignaturePublicKey` at insufficient visibility.
+      #
+      # Unpin to `@nightly` once openmls publishes a fixed prelude (likely
+      # 0.8.2 or 0.9) and `crates/scp-runtime` updates its dependency.
+      - uses: dtolnay/rust-toolchain@nightly-2026-05-03
 
       - name: Install cargo-fuzz
         run: cargo install cargo-fuzz --locked


### PR DESCRIPTION
## Summary

Pre-existing Fuzz CI failure on `main`. Pinning nightly to `nightly-2026-05-03` (last known-good date) restores the gate. To be unpinned when openmls upstream fixes the prelude bug.

## Why

Recent nightlies (post-2026-05-03) tightened E0365 enforcement on glob re-exports, which now fires on openmls 0.8.1's prelude:

```rust
// crates/scp-runtime depends on openmls 0.8 (pulls 0.8.1).
// openmls' prelude.rs:
pub use crate::ciphersuite::{hash_ref::KeyPackageRef, signable::*, signature::*, *};
//                                                                                ^
// The trailing `*` glob picks up `pub(crate) use signature::*` from
// `ciphersuite/mod.rs`, which shadows `Signature` / `SignContent` /
// `SignaturePublicKey` / `OpenMlsSignaturePublicKey` at `pub(crate)`
// visibility — and the outer prelude tries to re-export them as `pub`.
// Nightly rustc correctly rejects with E0365.
```

This is a latent bug in openmls that older rustc accepted (it picked the more permissive binding when resolving the glob). Stable Rust hasn't adopted the stricter check yet, which is why the rest of the workspace still compiles. Only the Fuzz job (which needs nightly for `cargo-fuzz`) is affected.

## Evidence of pre-existing rot

`gh run list --workflow=fuzz.yml --branch=main` shows scheduled main Fuzz failures every day since 2026-05-04. The last green run was 2026-05-03 against `64033b8f`. The pin date matches.

## Unpin trigger

When openmls ships a fix (expected in 0.8.2 or 0.9 — drop the offending `pub(crate) use signature::*` or remove the trailing `*` from the prelude), bump the openmls version in `Cargo.toml` and revert this pin in the same PR. Comments in the workflow file describe the same.

## Test plan

- [x] `actionlint` clean (no syntactic change).
- [ ] Watch the next Fuzz workflow run after merge — should be green again.

🤖 Generated with [Claude Code](https://claude.com/claude-code)