### PR TITLE
chore(deny): ignore RUSTSEC-2026-0124 (libcrux-chacha20poly1305 transitive)

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -46,6 +46,13 @@ ignore = [
     # openmls_libcrux_crypto -> libcrux-aead. Standalone MAC not used by SCP;
     # OpenMLS uses AEAD path which is unaffected. Awaiting openmls upgrade.
     "RUSTSEC-2026-0073",
+    # libcrux-chacha20poly1305: panic when caller supplies a ciphertext buffer
+    # longer than `ptxt.len() + TAG_LEN`. Transitive via openmls ->
+    # openmls_libcrux_crypto -> libcrux-aead. SCP never sizes the ciphertext
+    # buffer from attacker-controlled input — buffer length is always
+    # `ptxt.len() + TAG_LEN` per the AEAD trait contract OpenMLS implements.
+    # Awaiting openmls / libcrux upstream patch.
+    "RUSTSEC-2026-0124",
     # libcrux-sha3: incorrect incremental SHAKE XOF output. Transitive via
     # openmls -> openmls_libcrux_crypto. Awaiting openmls upgrade.
     "RUSTSEC-2026-0074",


### PR DESCRIPTION
## Summary
RUSTSEC-2026-0124 landed today flagging \`libcrux_chacha20poly1305::encrypt\` for panicking when a caller supplies a ciphertext buffer longer than \`ptxt.len() + TAG_LEN\`. The advisory is breaking \`Rust / deny\` on every open PR.

## Why ignore
The dep is transitive via \`openmls -> openmls_libcrux_crypto -> libcrux-aead\`. SCP never sizes its ciphertext buffer from attacker-controlled input — all AEAD use goes through OpenMLS's trait contract, which always allocates exactly \`ptxt.len() + TAG_LEN\`. The panic path is unreachable from SCP code.

Same posture as the other libcrux advisories already ignored in \`deny.toml\` (RUSTSEC-2026-0073/0074/0075). All will drop together when OpenMLS upgrades upstream.

## Test plan
- [x] \`cargo deny check advisories\` → \`advisories ok\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)