### PR TITLE
chore(deps): ignore RUSTSEC-2026-0124 (libcrux-chacha20poly1305 panic, transitive via openmls)

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -49,6 +49,16 @@ ignore = [
     # libcrux-sha3: incorrect incremental SHAKE XOF output. Transitive via
     # openmls -> openmls_libcrux_crypto. Awaiting openmls upgrade.
     "RUSTSEC-2026-0074",
+    # libcrux-chacha20poly1305: panic when `encrypt` is given a ciphertext
+    # buffer longer than `ptxt.len() + TAG_LEN`. Transitive via openmls ->
+    # openmls_libcrux_crypto -> libcrux-aead, which pins
+    # libcrux-chacha20poly1305 = "=0.0.6"; no openmls release past 0.8.1
+    # exists, so it cannot be upgraded. SCP's MLS ciphersuite is AES-128-GCM
+    # (MLS_128_DHKEMX25519_AES128GCM_SHA256_Ed25519), so the ChaCha20-Poly1305
+    # encrypt path is not selected, and OpenMLS sizes the ciphertext buffer
+    # internally rather than from attacker-controlled input. Awaiting openmls
+    # upgrade.
+    "RUSTSEC-2026-0124",
     # rand 0.8.5 unsound: aliased mutable reference when a custom logger
     # calls `rand::rng()` during ThreadRng reseed. Transitive via
     # hpke-rs-rust-crypto -> openmls_rust_crypto. Cannot upgrade: hpke-rs


### PR DESCRIPTION
## Problem

RUSTSEC-2026-0124 (libcrux-chacha20poly1305: *Potential Panic on Overlong Ciphertext Buffer*), published 2026-06-01, is failing the **Rust / deny** job in the GitHub **merge queue** (which runs `cargo deny check --all-features`). This blocks **every** PR from merging, not just one — the queue evicts on the failed check.

## Why ignore rather than upgrade

The vulnerable crate is reached transitively and is **unfixable without an openmls release that doesn't exist yet**:

```
openmls 0.8.1 → openmls_libcrux_crypto 0.3.1 → libcrux-aead 0.0.6 → libcrux-chacha20poly1305 (=0.0.6)
```

`libcrux-aead 0.0.6` pins `libcrux-chacha20poly1305 = "=0.0.6"` exactly; latest openmls on crates.io is 0.8.1. `cargo update --precise 0.0.8` fails ("candidate versions found which didn't match: 0.0.8").

## Why it is not exploitable in SCP

- SCP's MLS ciphersuite is **AES-128-GCM** (`MLS_128_DHKEMX25519_AES128GCM_SHA256_Ed25519`) — the ChaCha20-Poly1305 `encrypt` path that panics is **not selected**.
- The ciphertext buffer length is sized **internally by OpenMLS**, not from attacker-controlled input, so the overlong-buffer precondition cannot be met.

This mirrors the existing `RUSTSEC-2026-0073/0074/0075` libcrux-via-openmls ignores. All four are removed together when openmls upgrades (the same trigger that unpins the Fuzz nightly toolchain from #1736).