### PR TITLE
fix(transport): restore deleted QUIC lifecycle types and green the feature

### DIFF
--- a/crates/scp-transport/src/quic/adapter.rs
+++ b/crates/scp-transport/src/quic/adapter.rs
@@ -420,41 +420,13 @@ impl TransportAdapter for QuicAdapter {
 
             // Spawn a background task to read BLOBs from the QUIC stream
             // and forward them as `TransportEvent`s.
-            tokio::spawn(async move {
-                loop {
-                    tokio::select! {
-                        biased;
-                        () = cancel_clone.cancelled() => {
-                            // Clean shutdown: finish the send side to signal
-                            // the relay that we are done.
-                            let _ = send.finish();
-                            break;
-                        }
-                        result = Self::read_relay_message(&mut recv) => {
-                            if let Ok(relay_msg) = result {
-                                let Some(event) = map_subscribe_relay_message(
-                                    relay_msg,
-                                    &routing_id_bytes,
-                                ) else {
-                                    continue;
-                                };
-                                if tx.send(event).await.is_err() {
-                                    // Receiver dropped, stop reading.
-                                    break;
-                                }
-                            } else {
-                                // Stream closed or error -- subscription terminated.
-                                let _ = tx
-                                    .send(TransportEvent::Terminated {
-                                        reason: "QUIC stream closed".to_string(),
-                                    })
-                                    .await;
-                                break;
-                            }
-                        }
-                    }
-                }
-            });
+            tokio::spawn(run_subscribe_read_loop(
+                send,
+                recv,
+                cancel_clone,
+                routing_id_bytes,
+                tx,
+            ));
 
             let stream = QuicSubscriptionStream { rx };
             Ok(Box::pin(stream) as SubscriptionStream)
@@ -616,9 +588,57 @@ impl Stream for QuicSubscriptionStream {
     }
 }
 
+/// Background read loop for a QUIC subscription stream.
+///
+/// Reads `RelayMessage`s from `recv`, maps them to [`TransportEvent`]s via
+/// [`map_subscribe_relay_message`], and forwards them on `tx` until the
+/// subscription is cancelled, the stream closes, or the receiver is dropped.
+/// On cancellation the send side is finished so the relay sees a graceful FIN.
+async fn run_subscribe_read_loop(
+    mut send: quinn::SendStream,
+    mut recv: quinn::RecvStream,
+    cancel: CancellationToken,
+    routing_id_bytes: [u8; 32],
+    tx: tokio::sync::mpsc::Sender<TransportEvent>,
+) {
+    loop {
+        tokio::select! {
+            biased;
+            () = cancel.cancelled() => {
+                // Clean shutdown: finish the send side to signal
+                // the relay that we are done.
+                let _ = send.finish();
+                break;
+            }
+            result = QuicAdapter::read_relay_message(&mut recv) => {
+                if let Ok(relay_msg) = result {
+                    let Some(event) = map_subscribe_relay_message(
+                        relay_msg,
+                        &routing_id_bytes,
+                    ) else {
+                        continue;
+                    };
+                    if tx.send(event).await.is_err() {
+                        // Receiver dropped, stop reading.
+                        break;
+                    }
+                } else {
+                    // Stream closed or error -- subscription terminated.
+                    let _ = tx
+                        .send(TransportEvent::Terminated {
+                            reason: "QUIC stream closed".to_string(),
+                        })
+                        .await;
+                    break;
+                }
+            }
+        }
+    }
+}
+
 /// Maps a `RelayMessage` received on a QUIC subscribe stream to the
 /// corresponding `TransportEvent`. Returns `None` for messages the
-/// subscriber should ignore (BLOBs with mismatched routing_id from a
+/// subscriber should ignore (BLOBs with mismatched `routing_id` from a
 /// non-conformant relay, unknown event types, OK/Pong/Bridge messages).
 fn map_subscribe_relay_message(
     relay_msg: RelayMessage,
@@ -640,12 +660,14 @@ fn map_subscribe_relay_message(
         return None;
     }
     match relay_msg {
-        RelayMessage::Blob { blob, .. } => Some(match OuterEnvelope::from_bytes(&blob) {
-            Ok(envelope) => TransportEvent::Envelope(envelope),
-            Err(_) => TransportEvent::Error(TransportError::ProtocolError(
-                "failed to deserialize envelope from blob".to_string(),
-            )),
-        }),
+        RelayMessage::Blob { blob, .. } => Some(OuterEnvelope::from_bytes(&blob).map_or_else(
+            |_| {
+                TransportEvent::Error(TransportError::ProtocolError(
+                    "failed to deserialize envelope from blob".to_string(),
+                ))
+            },
+            TransportEvent::Envelope,
+        )),
         RelayMessage::Event { event_type, .. } => match event_type.as_str() {
             "backfill_complete" => Some(TransportEvent::BackfillComplete),
             _ => None,
@@ -921,7 +943,7 @@ mod tests {
                 // Expected.
             }
             Ok(Some(other)) => panic!("first stream yielded unexpected event: {other:?}"),
-            Err(_) => panic!("first stream did not terminate within 2s"),
+            Err(elapsed) => panic!("first stream did not terminate within 2s: {elapsed}"),
         }
 
         // Publish on this routing ID and confirm the second stream

--- a/crates/scp-transport/src/quic/lifecycle.rs
+++ b/crates/scp-transport/src/quic/lifecycle.rs
@@ -39,6 +39,537 @@ use zeroize::Zeroizing;
 use crate::profile::TransportProfile;
 
 // ---------------------------------------------------------------------------
+// Session Ticket Store (0-RTT resumption)
+// ---------------------------------------------------------------------------
+
+/// Opaque session ticket data for QUIC 0-RTT resumption.
+///
+/// Wraps the raw bytes of a TLS 1.3 session ticket (`NewSessionTicket`
+/// message). The ticket is issued by the server at the end of the QUIC
+/// handshake and stored by the client for future 0-RTT connections.
+///
+/// Session tickets are opaque to the client -- only the server can
+/// validate them. The client stores them by relay URL and presents them
+/// on reconnection to enable 0-RTT data transmission.
+///
+/// # Security
+///
+/// 0-RTT data has no forward secrecy and is vulnerable to replay attacks
+/// (RFC 9001 section 9.2). SCP operations sent as 0-RTT MUST be idempotent
+/// or the relay MUST implement anti-replay measures per spec section 10.14.2.
+#[derive(Debug, Clone)]
+pub struct SessionTicket {
+    /// The raw session ticket bytes (opaque TLS 1.3 `NewSessionTicket`).
+    ///
+    /// Wrapped in [`Zeroizing`] so that the key material is securely
+    /// erased from memory when this ticket is dropped (CRYPTO-004a).
+    data: Zeroizing<Vec<u8>>,
+
+    /// When this ticket was received from the server.
+    received_at: Instant,
+
+    /// Maximum lifetime of the ticket as declared by the server.
+    /// After this duration, the ticket MUST NOT be used for 0-RTT.
+    max_lifetime: Duration,
+}
+
+impl SessionTicket {
+    /// Creates a new session ticket from raw bytes.
+    ///
+    /// # Arguments
+    ///
+    /// * `data` -- raw session ticket bytes from the TLS 1.3 handshake.
+    /// * `max_lifetime` -- server-declared maximum ticket lifetime.
+    #[must_use]
+    pub fn new(data: Vec<u8>, max_lifetime: Duration) -> Self {
+        Self {
+            data: Zeroizing::new(data),
+            received_at: Instant::now(),
+            max_lifetime,
+        }
+    }
+
+    /// Returns `true` if this ticket has expired.
+    ///
+    /// A ticket expires when `elapsed_since_received >= max_lifetime`.
+    /// Expired tickets MUST NOT be used for 0-RTT resumption.
+    #[must_use]
+    pub fn is_expired(&self) -> bool {
+        self.received_at.elapsed() >= self.max_lifetime
+    }
+
+    /// Returns the raw session ticket bytes.
+    #[must_use]
+    pub fn data(&self) -> &[u8] {
+        &self.data
+    }
+
+    /// Returns the time this ticket was received.
+    #[must_use]
+    pub const fn received_at(&self) -> Instant {
+        self.received_at
+    }
+
+    /// Returns the server-declared maximum lifetime.
+    #[must_use]
+    pub const fn max_lifetime(&self) -> Duration {
+        self.max_lifetime
+    }
+}
+
+/// Persistent session ticket store for QUIC 0-RTT resumption across
+/// adapter restarts (section 10.14.2).
+///
+/// Stores session tickets keyed by relay URL. When a QUIC connection
+/// completes a handshake and the server issues a session ticket, the
+/// client stores it here. On reconnection, the client retrieves the
+/// stored ticket for the target relay and uses it for 0-RTT data
+/// transmission.
+///
+/// The store is thread-safe (`Send + Sync`) via interior mutability so
+/// it can be shared across adapter instances and tokio tasks.
+///
+/// # Persistence
+///
+/// The store supports serialization to/from bytes for persistence across
+/// process restarts. Callers are responsible for the actual I/O -- the
+/// store provides [`export`](Self::export) and
+/// [`import`](Self::import) methods for the data.
+///
+/// # Capacity
+///
+/// The store evicts the oldest ticket when capacity is reached. Default
+/// capacity is 256 relay entries, which covers typical deployment
+/// scenarios.
+#[derive(Debug, Clone)]
+pub struct SessionTicketStore {
+    inner: Arc<Mutex<SessionTicketStoreInner>>,
+}
+
+/// Inner state of the session ticket store, protected by a mutex.
+struct SessionTicketStoreInner {
+    /// Application-layer session tickets keyed by relay URL (for
+    /// persistence across restarts via [`SessionTicketStore::export`]).
+    tickets: HashMap<String, SessionTicket>,
+
+    /// Maximum number of relay entries to store.
+    capacity: usize,
+
+    /// TLS 1.3 session tickets keyed by server name, used by rustls
+    /// via the [`ClientSessionStore`] trait for 0-RTT resumption.
+    /// Each server may have multiple valid tickets (FIFO queue).
+    tls13_tickets: HashMap<ServerName<'static>, Vec<rustls::client::Tls13ClientSessionValue>>,
+
+    /// Key exchange group hints keyed by server name.
+    kx_hints: HashMap<ServerName<'static>, NamedGroup>,
+}
+
+impl fmt::Debug for SessionTicketStoreInner {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("SessionTicketStoreInner")
+            .field("tickets", &self.tickets)
+            .field("capacity", &self.capacity)
+            .field(
+                "tls13_tickets_count",
+                &self.tls13_tickets.values().map(Vec::len).sum::<usize>(),
+            )
+            .field("kx_hints_count", &self.kx_hints.len())
+            .finish()
+    }
+}
+
+/// Default capacity for the session ticket store.
+const DEFAULT_TICKET_STORE_CAPACITY: usize = 256;
+
+impl SessionTicketStore {
+    /// Creates a new empty session ticket store with default capacity (256).
+    #[must_use]
+    pub fn new() -> Self {
+        Self::with_capacity(DEFAULT_TICKET_STORE_CAPACITY)
+    }
+
+    /// Creates a new empty session ticket store with the specified capacity.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `capacity` is zero. A zero-capacity store cannot store any
+    /// tickets but the eviction logic cannot enforce this constraint.
+    #[must_use]
+    pub fn with_capacity(capacity: usize) -> Self {
+        assert!(
+            capacity > 0,
+            "session ticket store capacity must be at least 1"
+        );
+        Self {
+            inner: Arc::new(Mutex::new(SessionTicketStoreInner {
+                tickets: HashMap::with_capacity(capacity.min(256)),
+                capacity,
+                tls13_tickets: HashMap::new(),
+                kx_hints: HashMap::new(),
+            })),
+        }
+    }
+
+    /// Stores a session ticket for a relay URL.
+    ///
+    /// If the store is at capacity, the oldest ticket (by `received_at`)
+    /// is evicted. If a ticket already exists for this relay, it is
+    /// replaced.
+    pub fn store(&self, relay_url: &str, ticket: SessionTicket) {
+        let Ok(mut inner) = self.inner.lock() else {
+            // Mutex poisoned -- silently drop the ticket.
+            // This can only happen if a panic occurred while holding the
+            // lock, which is a catastrophic failure mode. Losing session
+            // tickets is acceptable in this case.
+            return;
+        };
+
+        // If at capacity and this is a new key, evict the oldest.
+        if inner.tickets.len() >= inner.capacity && !inner.tickets.contains_key(relay_url) {
+            evict_oldest(&mut inner.tickets);
+        }
+
+        inner.tickets.insert(relay_url.to_owned(), ticket);
+    }
+
+    /// Retrieves the session ticket for a relay URL, if one exists and
+    /// has not expired.
+    ///
+    /// Expired tickets are removed from the store and `None` is returned.
+    #[must_use]
+    pub fn get(&self, relay_url: &str) -> Option<SessionTicket> {
+        let Ok(mut inner) = self.inner.lock() else {
+            return None;
+        };
+
+        if let Some(ticket) = inner.tickets.get(relay_url) {
+            if ticket.is_expired() {
+                inner.tickets.remove(relay_url);
+                return None;
+            }
+            return Some(ticket.clone());
+        }
+
+        None
+    }
+
+    /// Removes the session ticket for a relay URL.
+    ///
+    /// Returns `true` if a ticket was removed, `false` if no ticket
+    /// existed for this relay.
+    #[must_use]
+    pub fn remove(&self, relay_url: &str) -> bool {
+        let Ok(mut inner) = self.inner.lock() else {
+            return false;
+        };
+        inner.tickets.remove(relay_url).is_some()
+    }
+
+    /// Returns the number of stored tickets (including expired ones that
+    /// have not yet been lazily cleaned).
+    #[must_use]
+    pub fn len(&self) -> usize {
+        let Ok(inner) = self.inner.lock() else {
+            return 0;
+        };
+        inner.tickets.len()
+    }
+
+    /// Returns `true` if the store contains no tickets.
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+
+    /// Removes all expired tickets from the store.
+    ///
+    /// Returns the number of tickets removed.
+    #[must_use]
+    pub fn prune_expired(&self) -> usize {
+        let Ok(mut inner) = self.inner.lock() else {
+            return 0;
+        };
+        let before = inner.tickets.len();
+        inner.tickets.retain(|_, ticket| !ticket.is_expired());
+        before - inner.tickets.len()
+    }
+
+    /// Exports all non-expired tickets as `(relay_url, ticket_data, max_lifetime_secs)` tuples.
+    ///
+    /// Callers can serialize these for persistence across restarts.
+    /// The `received_at` field is reset to `Instant::now()` minus the
+    /// elapsed time -- callers should persist the remaining lifetime.
+    #[must_use]
+    pub fn export(&self) -> Vec<(String, Vec<u8>, u64)> {
+        let Ok(inner) = self.inner.lock() else {
+            return Vec::new();
+        };
+
+        inner
+            .tickets
+            .iter()
+            .filter(|(_, ticket)| !ticket.is_expired())
+            .map(|(url, ticket)| {
+                let elapsed = ticket.received_at.elapsed();
+                let remaining = ticket.max_lifetime.saturating_sub(elapsed);
+                (url.clone(), (*ticket.data).clone(), remaining.as_secs())
+            })
+            .collect()
+    }
+
+    /// Imports tickets from `(relay_url, ticket_data, remaining_lifetime_secs)` tuples.
+    ///
+    /// Tickets with zero remaining lifetime are skipped. This is the
+    /// counterpart to [`export`](Self::export) for restoring tickets
+    /// from persistent storage.
+    pub fn import(&self, tickets: &[(String, Vec<u8>, u64)]) {
+        let Ok(mut inner) = self.inner.lock() else {
+            return;
+        };
+
+        for (url, data, remaining_secs) in tickets {
+            if *remaining_secs == 0 {
+                continue;
+            }
+
+            // Evict oldest if at capacity and this is a new key.
+            if inner.tickets.len() >= inner.capacity && !inner.tickets.contains_key(url.as_str()) {
+                evict_oldest(&mut inner.tickets);
+            }
+
+            let ticket = SessionTicket {
+                data: Zeroizing::new(data.clone()),
+                received_at: Instant::now(),
+                max_lifetime: Duration::from_secs(*remaining_secs),
+            };
+            inner.tickets.insert(url.clone(), ticket);
+        }
+    }
+}
+
+impl Default for SessionTicketStore {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+/// Evicts the oldest ticket (by `received_at`) from the map.
+fn evict_oldest(tickets: &mut HashMap<String, SessionTicket>) {
+    if tickets.is_empty() {
+        return;
+    }
+
+    let oldest_key = tickets
+        .iter()
+        .min_by_key(|(_, ticket)| ticket.received_at)
+        .map(|(key, _)| key.clone());
+
+    if let Some(key) = oldest_key {
+        tickets.remove(&key);
+    }
+}
+
+// ---------------------------------------------------------------------------
+// rustls ClientSessionStore integration
+// ---------------------------------------------------------------------------
+
+/// Maximum number of TLS 1.3 tickets stored per server name.
+///
+/// Rustls may issue multiple tickets per connection; we keep a bounded
+/// queue to prevent unbounded growth.
+const MAX_TLS13_TICKETS_PER_SERVER: usize = 8;
+
+impl ClientSessionStore for SessionTicketStore {
+    fn set_kx_hint(&self, server_name: ServerName<'static>, group: NamedGroup) {
+        let Ok(mut inner) = self.inner.lock() else {
+            return;
+        };
+        inner.kx_hints.insert(server_name, group);
+    }
+
+    fn kx_hint(&self, server_name: &ServerName<'_>) -> Option<NamedGroup> {
+        let Ok(inner) = self.inner.lock() else {
+            return None;
+        };
+        inner.kx_hints.get(server_name).copied()
+    }
+
+    fn set_tls12_session(
+        &self,
+        _server_name: ServerName<'static>,
+        _value: rustls::client::Tls12ClientSessionValue,
+    ) {
+        // QUIC mandates TLS 1.3 (RFC 9001 §4.1); TLS 1.2 sessions are
+        // not applicable. Silently ignore.
+    }
+
+    fn tls12_session(
+        &self,
+        _server_name: &ServerName<'_>,
+    ) -> Option<rustls::client::Tls12ClientSessionValue> {
+        // QUIC mandates TLS 1.3.
+        None
+    }
+
+    fn remove_tls12_session(&self, _server_name: &ServerName<'static>) {
+        // QUIC mandates TLS 1.3.
+    }
+
+    fn insert_tls13_ticket(
+        &self,
+        server_name: ServerName<'static>,
+        value: rustls::client::Tls13ClientSessionValue,
+    ) {
+        let Ok(mut inner) = self.inner.lock() else {
+            return;
+        };
+        let tickets = inner.tls13_tickets.entry(server_name).or_default();
+        // Evict oldest if at per-server capacity.
+        if tickets.len() >= MAX_TLS13_TICKETS_PER_SERVER {
+            tickets.remove(0);
+        }
+        tickets.push(value);
+    }
+
+    fn take_tls13_ticket(
+        &self,
+        server_name: &ServerName<'static>,
+    ) -> Option<rustls::client::Tls13ClientSessionValue> {
+        let Ok(mut inner) = self.inner.lock() else {
+            return None;
+        };
+        let tickets = inner.tls13_tickets.get_mut(server_name)?;
+        if tickets.is_empty() {
+            return None;
+        }
+        // Return the most recent ticket (LIFO — last inserted is freshest).
+        tickets.pop()
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Connection Migration
+// ---------------------------------------------------------------------------
+
+/// Event emitted when a QUIC connection migrates to a new network path.
+///
+/// QUIC connections survive IP address changes (e.g., Wi-Fi to cellular)
+/// without closing. Active subscription streams continue uninterrupted.
+/// This event is emitted for logging and metrics purposes.
+///
+/// See spec section 10.14.2 point 3 (connection migration).
+#[derive(Debug, Clone)]
+pub struct ConnectionMigrationEvent {
+    /// The relay URL whose connection migrated.
+    pub relay_url: String,
+
+    /// When the migration was detected.
+    pub detected_at: Instant,
+
+    /// Whether active streams survived the migration.
+    ///
+    /// In QUIC, streams survive migration by default. This is `false`
+    /// only if the migration failed and the connection was reset.
+    pub streams_preserved: bool,
+}
+
+impl ConnectionMigrationEvent {
+    /// Creates a new migration event indicating successful stream preservation.
+    #[must_use]
+    pub fn success(relay_url: String) -> Self {
+        Self {
+            relay_url,
+            detected_at: Instant::now(),
+            streams_preserved: true,
+        }
+    }
+
+    /// Creates a new migration event indicating streams were lost.
+    #[must_use]
+    pub fn failed(relay_url: String) -> Self {
+        Self {
+            relay_url,
+            detected_at: Instant::now(),
+            streams_preserved: false,
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// QUIC Keepalive Configuration
+// ---------------------------------------------------------------------------
+
+/// Configuration for QUIC-native keepalive via PING frames.
+///
+/// QUIC's native PING frame mechanism (RFC 9000 section 19.2) replaces
+/// WebSocket PING/PONG. PING frames are ack-eliciting, resetting the
+/// idle timeout. No application-level keepalive is needed.
+///
+/// See spec section 10.14.2 point 5 (keepalive).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct QuicKeepaliveConfig {
+    /// Interval at which QUIC PING frames are sent.
+    ///
+    /// This should be less than the server's idle timeout to prevent
+    /// the connection from being closed. quinn's `keep_alive_interval`
+    /// maps directly to this.
+    ///
+    /// Default: 15 seconds (half of a typical 30-second idle timeout).
+    interval: Duration,
+}
+
+/// Default keepalive interval: 15 seconds.
+///
+/// This is half of the typical relay idle timeout (30s per ADR-004).
+/// Sending PINGs at half the idle timeout provides a comfortable margin
+/// for network jitter while keeping the connection alive.
+const DEFAULT_KEEPALIVE_INTERVAL: Duration = Duration::from_secs(15);
+
+impl QuicKeepaliveConfig {
+    /// Creates a new keepalive config with the specified interval.
+    ///
+    /// # Arguments
+    ///
+    /// * `interval` -- interval between QUIC PING frames. Must be
+    ///   greater than zero.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `interval` is zero. A zero interval causes quinn to send
+    /// PING frames in a tight loop, consuming CPU and flooding the connection.
+    #[must_use]
+    pub const fn new(interval: Duration) -> Self {
+        assert!(
+            interval.as_nanos() > 0,
+            "keepalive interval must be greater than zero"
+        );
+        Self { interval }
+    }
+
+    /// Returns the keepalive interval.
+    #[must_use]
+    pub const fn interval(&self) -> Duration {
+        self.interval
+    }
+
+    /// Applies this keepalive configuration to a quinn transport config.
+    ///
+    /// Sets `keep_alive_interval` on the quinn transport config, which
+    /// causes quinn to send QUIC PING frames at the specified interval.
+    /// This replaces application-level PING/PONG entirely (section 10.14.2
+    /// point 5).
+    pub fn apply_to_transport_config(&self, config: &mut quinn::TransportConfig) {
+        config.keep_alive_interval(Some(self.interval));
+    }
+}
+
+impl Default for QuicKeepaliveConfig {
+    fn default() -> Self {
+        Self::new(DEFAULT_KEEPALIVE_INTERVAL)
+    }
+}
+
+// ---------------------------------------------------------------------------
 // Reconnect Backoff (re-export from shared module)
 // ---------------------------------------------------------------------------
 
@@ -263,20 +794,20 @@ mod tests {
 
     #[test]
     fn session_ticket_not_expired_when_fresh() {
-        let ticket = SessionTicket::new(vec![1, 2, 3], Duration::from_secs(3600));
+        let ticket = SessionTicket::new(vec![1, 2, 3], Duration::from_hours(1));
         assert!(!ticket.is_expired());
     }
 
     #[test]
     fn session_ticket_data_roundtrip() {
         let data = vec![0xAA, 0xBB, 0xCC];
-        let ticket = SessionTicket::new(data.clone(), Duration::from_secs(60));
+        let ticket = SessionTicket::new(data.clone(), Duration::from_mins(1));
         assert_eq!(ticket.data(), &data);
     }
 
     #[test]
     fn session_ticket_max_lifetime_accessor() {
-        let lifetime = Duration::from_secs(7200);
+        let lifetime = Duration::from_hours(2);
         let ticket = SessionTicket::new(vec![], lifetime);
         assert_eq!(ticket.max_lifetime(), lifetime);
     }
@@ -292,7 +823,7 @@ mod tests {
     #[test]
     fn store_and_retrieve_ticket() {
         let store = SessionTicketStore::new();
-        let ticket = SessionTicket::new(vec![1, 2, 3], Duration::from_secs(3600));
+        let ticket = SessionTicket::new(vec![1, 2, 3], Duration::from_hours(1));
 
         store.store("wss://relay1.example.com/scp/v1", ticket);
 
@@ -320,8 +851,8 @@ mod tests {
     #[test]
     fn store_replaces_existing_ticket() {
         let store = SessionTicketStore::new();
-        let ticket1 = SessionTicket::new(vec![1], Duration::from_secs(3600));
-        let ticket2 = SessionTicket::new(vec![2], Duration::from_secs(3600));
+        let ticket1 = SessionTicket::new(vec![1], Duration::from_hours(1));
+        let ticket2 = SessionTicket::new(vec![2], Duration::from_hours(1));
 
         store.store("wss://relay1.example.com/scp/v1", ticket1);
         store.store("wss://relay1.example.com/scp/v1", ticket2);
@@ -338,7 +869,7 @@ mod tests {
 
         store.store(
             "wss://relay1.example.com/scp/v1",
-            SessionTicket::new(vec![1], Duration::from_secs(3600)),
+            SessionTicket::new(vec![1], Duration::from_hours(1)),
         );
         assert!(!store.is_empty());
         assert_eq!(store.len(), 1);
@@ -349,7 +880,7 @@ mod tests {
         let store = SessionTicketStore::new();
         store.store(
             "wss://relay1.example.com/scp/v1",
-            SessionTicket::new(vec![1], Duration::from_secs(3600)),
+            SessionTicket::new(vec![1], Duration::from_hours(1)),
         );
 
         assert!(store.remove("wss://relay1.example.com/scp/v1"));
@@ -363,16 +894,16 @@ mod tests {
 
         store.store(
             "wss://relay1.example.com/scp/v1",
-            SessionTicket::new(vec![1], Duration::from_secs(3600)),
+            SessionTicket::new(vec![1], Duration::from_hours(1)),
         );
         store.store(
             "wss://relay2.example.com/scp/v1",
-            SessionTicket::new(vec![2], Duration::from_secs(3600)),
+            SessionTicket::new(vec![2], Duration::from_hours(1)),
         );
         // At capacity. Adding a third should evict the oldest.
         store.store(
             "wss://relay3.example.com/scp/v1",
-            SessionTicket::new(vec![3], Duration::from_secs(3600)),
+            SessionTicket::new(vec![3], Duration::from_hours(1)),
         );
 
         assert_eq!(store.len(), 2);
@@ -393,7 +924,7 @@ mod tests {
         );
         store.store(
             "wss://valid.example.com/scp/v1",
-            SessionTicket::new(vec![2], Duration::from_secs(3600)),
+            SessionTicket::new(vec![2], Duration::from_hours(1)),
         );
 
         let pruned = store.prune_expired();
@@ -407,7 +938,7 @@ mod tests {
         let store = SessionTicketStore::new();
         store.store(
             "wss://relay1.example.com/scp/v1",
-            SessionTicket::new(vec![0xAA, 0xBB], Duration::from_secs(3600)),
+            SessionTicket::new(vec![0xAA, 0xBB], Duration::from_hours(1)),
         );
 
         let exported = store.export();
@@ -501,7 +1032,7 @@ mod tests {
         manager.store_session_ticket(
             "wss://relay.example.com/scp/v1",
             vec![0xDE, 0xAD],
-            Duration::from_secs(3600),
+            Duration::from_hours(1),
         );
 
         let ticket = manager.get_session_ticket("wss://relay.example.com/scp/v1");
@@ -573,7 +1104,7 @@ mod tests {
         let store = SessionTicketStore::new();
         store.store(
             "wss://relay.example.com/scp/v1",
-            SessionTicket::new(vec![1, 2], Duration::from_secs(3600)),
+            SessionTicket::new(vec![1, 2], Duration::from_hours(1)),
         );
 
         let manager = QuicLifecycleManager::new(TransportProfile::Desktop, store);

--- a/crates/scp-transport/src/quic/listener.rs
+++ b/crates/scp-transport/src/quic/listener.rs
@@ -277,7 +277,7 @@ impl<S: BlobStorage + 'static> QuicListener<S> {
         tokio::spawn(async move {
             cleanup_rate_limiter
                 .cleanup_loop(
-                    Duration::from_secs(60),
+                    Duration::from_mins(1),
                     Duration::from_secs(90),
                     cleanup_token,
                 )


### PR DESCRIPTION
## Problem

The `quic` cargo feature in `crates/scp-transport` does not compile. Commit `b288d64c5` ("production readiness") deleted four type definitions from `quic/lifecycle.rs` — `SessionTicket`, `SessionTicketStore` (+ its `rustls::client::ClientSessionStore` impl for 0-RTT), `ConnectionMigrationEvent`, `QuicKeepaliveConfig` — while correctly extracting `ReconnectBackoff` to `backoff.rs`, but left every consumer (`QuicLifecycleManager`, ~30 tests, the `mod.rs` re-export, and the `QuicAdapter` that owns it). CI never builds `--features quic`, so the breakage went unnoticed.

QUIC is a spec-mandated Tier-1 transport (ADR-037, Decided; spec §10.14.2). Per the one-way artifact-flow invariant, the fix is restoration, not removal.

## Change

- Restore the four deleted types **verbatim** from `b516c46df` (the commit that introduced them). `ReconnectBackoff` stays in `backoff.rs` (re-exported); no `rand` dependency reintroduced.
- Bring the feature to a clean clippy state by fixing pre-existing lints that only surface now that the feature compiles: duration-unit constructors (`from_secs` → `from_hours`/`from_mins`, arithmetically identical), `too_many_lines` extraction of the subscribe read loop into a free `async fn` (verbatim body), doc backticks, one `map_or_else`. Behavior-preserving throughout. #1734's registration-leak fix is untouched.

This is PR-1 of the QUIC restoration plan (`.docs/planning-sessions/planning-session-07-quic-restoration.md`). Follow-ups: CI gate for optional transports, native probe-and-fallback selection, relay listener wiring, conformance + PRD reconciliation.

## Verification

- `cargo clippy -p scp-transport --features quic --all-targets -- -D warnings` clean
- `cargo clippy -p scp-transport --all-targets -- -D warnings` clean (default build)
- `cargo test -p scp-transport --features quic` → 687 lib + 38 conformance + 4 doc pass, 0 fail
- Reviews: cryptographer (SessionTicketStore 0-RTT/zeroize/anti-replay) + bug-catcher (restore fidelity + behavior-preservation) — both confirm verbatim restoration and behavior-preserving fixes.