### PR TITLE
feat(node): serve relay QUIC listener on the TLS port alongside WebSocket

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1751,18 +1751,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "fastbloom"
-version = "0.14.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e7f34442dbe69c60fe8eaf58a8cafff81a1f278816d8ab4db255b3bef4ac3c4"
-dependencies = [
- "getrandom 0.3.4",
- "libm",
- "rand 0.9.2",
- "siphasher 1.0.2",
-]
-
-[[package]]
 name = "fastrand"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4372,7 +4360,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
 dependencies = [
  "bytes",
- "fastbloom",
  "getrandom 0.3.4",
  "lru-slab",
  "rand 0.9.2",
@@ -4380,7 +4367,6 @@ dependencies = [
  "rustc-hash",
  "rustls",
  "rustls-pki-types",
- "rustls-platform-verifier",
  "slab",
  "thiserror 2.0.18",
  "tinyvec",
@@ -5344,6 +5330,7 @@ dependencies = [
  "metrics",
  "metrics-exporter-prometheus",
  "percent-encoding",
+ "quinn",
  "rand 0.8.5",
  "rcgen 0.14.7",
  "reqwest",
@@ -5894,12 +5881,6 @@ name = "siphasher"
 version = "0.3.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "38b58827f4464d87d377d175e90bf58eb00fd8716ff0a62f80356b5e61555d0d"
-
-[[package]]
-name = "siphasher"
-version = "1.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2aa850e253778c88a04c3d7323b043aeda9d3e30d5971937c1855769763678e"
 
 [[package]]
 name = "sketches-ddsketch"
@@ -6850,7 +6831,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "beadc1f460eb2e209263c49c4f5b19e9a02e00a3b2b393f78ad10d766346ecff"
 dependencies = [
  "anyhow",
- "siphasher 0.3.11",
+ "siphasher",
  "uniffi_internal_macros",
  "uniffi_pipeline",
 ]

--- a/crates/scp-node/Cargo.toml
+++ b/crates/scp-node/Cargo.toml
@@ -32,6 +32,15 @@ ed25519-dalek = { workspace = true }
 instant-acme = "0.8"
 rcgen = "0.14"
 reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls"] }
+# default-features disabled to avoid quinn's `platform-verifier` feature, which
+# pulls in `aws-lc-rs` and conflicts with the rest of scp-node's ring-backed
+# rustls (a dual provider makes rustls' process-default ambiguous). We only need
+# the tokio runtime and the ring-backed rustls integration.
+quinn = { version = "0.11", optional = true, default-features = false, features = [
+    "runtime-tokio",
+    "rustls-ring",
+    "log",
+] }
 rustls = { version = "0.23", default-features = false, features = ["ring", "logging", "std"] }
 rustls-pemfile = "2"
 base64 = { workspace = true }
@@ -77,7 +86,7 @@ tempfile = "3"
 # Gates `ApplicationNodeBuilder::build_for_testing()` — accepts any `Storage`
 # backend without the `EncryptedStorage` bound. See issue #695.
 allow_unencrypted_storage = ["scp-core/allow_unencrypted_storage"]
-quic = ["scp-transport/quic"]
+quic = ["scp-transport/quic", "dep:quinn"]
 http3 = ["scp-transport/http3"]
 udp = ["scp-transport/udp"]
 coap = ["scp-transport/coap"]

--- a/crates/scp-node/src/dev_api.rs
+++ b/crates/scp-node/src/dev_api.rs
@@ -644,6 +644,12 @@ mod tests {
             hostname_index: RwLock::new(HashMap::new()),
             bridge_state: Arc::new(crate::bridge_handlers::BridgeState::new()),
             bridge_lookup: None,
+            #[cfg(feature = "quic")]
+            publish_rate_limiter: scp_transport::relay::rate_limit::PublishRateLimiter::new(100),
+            #[cfg(feature = "quic")]
+            quic_server_config: None,
+            #[cfg(feature = "quic")]
+            quic_listening: std::sync::atomic::AtomicBool::new(false),
         })
     }
 

--- a/crates/scp-node/src/http.rs
+++ b/crates/scp-node/src/http.rs
@@ -215,6 +215,45 @@ pub struct NodeState {
     /// tests or when bridges are not configured), the bridge router is mounted
     /// without authentication.
     pub(crate) bridge_lookup: Option<Arc<dyn crate::bridge_auth::BridgeLookup>>,
+
+    /// Shared PUBLISH rate limiter from the relay server.
+    ///
+    /// Cloned from the WebSocket relay so the QUIC listener enforces the same
+    /// per-IP PUBLISH budget across both transports (unified rate limiting,
+    /// ADR-037 AC3, spec §10.14.3). Only present when the `quic` feature is
+    /// enabled, since it is consumed exclusively by the QUIC listener.
+    #[cfg(feature = "quic")]
+    pub(crate) publish_rate_limiter: PublishRateLimiter,
+
+    /// Pre-built QUIC server config for the relay-side QUIC listener.
+    ///
+    /// `Some` only in domain mode with a provisioned TLS certificate: the same
+    /// certificate that terminates WSS also authenticates QUIC, so the relay
+    /// cert covers both protocols (spec §10.14.3 item 1). `None` in no-domain
+    /// mode (plaintext `ws://`, no certificate) — QUIC requires TLS and is not
+    /// served there.
+    ///
+    /// When `Some`, [`ApplicationNode::serve`] starts a [`QuicListener`] bound
+    /// to UDP on the same port as the WebSocket TCP listener, sharing this
+    /// node's [`SubscriptionRegistry`], [`BlobStorageBackend`], and
+    /// [`ConnectionTracker`] (spec §10.14.3 item 2: cross-transport delivery).
+    ///
+    /// [`QuicListener`]: scp_transport::quic::listener::QuicListener
+    #[cfg(feature = "quic")]
+    pub(crate) quic_server_config: Option<quinn::ServerConfig>,
+
+    /// Whether the relay-side QUIC listener actually bound and started.
+    ///
+    /// Set to `true` by [`ApplicationNode::serve`] only after
+    /// [`spawn_quic_listener`] reports a successful UDP bind, and stays `false`
+    /// if the bind fails (port held, permission denied) or no
+    /// [`quic_server_config`](Self::quic_server_config) is present. This is the
+    /// value `.well-known/scp` reads to decide whether to advertise `"quic"`, so
+    /// the advertisement reflects the *running* listener — not merely that the
+    /// config was built. Closes the advertise-but-don't-serve gap for the
+    /// bind-failure case (spec §10.14.3 item 1).
+    #[cfg(feature = "quic")]
+    pub(crate) quic_listening: std::sync::atomic::AtomicBool,
 }
 
 // ---------------------------------------------------------------------------
@@ -633,6 +672,24 @@ impl<S: Storage + Send + Sync + 'static> ApplicationNode<S> {
         let local_addr = listener
             .local_addr()
             .map_err(|e| NodeError::Serve(e.to_string()))?;
+
+        // Start the relay-side QUIC listener on the SAME port as the WebSocket
+        // TCP listener, but UDP (spec §10.14.3 item 1). We start it after the
+        // TCP bind so that, when `http_bind_addr` requests an OS-assigned port
+        // (port 0), QUIC binds the *actual* bound port rather than a second,
+        // unrelated OS-assigned port. Shares subscription + blob state with the
+        // WebSocket relay (spec §10.14.3 item 2). No-op without the `quic`
+        // feature or in no-domain mode (no TLS certificate).
+        #[cfg(feature = "quic")]
+        {
+            // The bind is synchronous (it completes before `start()` returns),
+            // so the flag is settled before the server future below is awaited
+            // and before the first `.well-known/scp` request can be served.
+            let started = spawn_quic_listener(&state, local_addr.port());
+            state
+                .quic_listening
+                .store(started, std::sync::atomic::Ordering::Release);
+        }
         let shutdown_token = state.shutdown_token.clone();
         let token = shutdown_token.clone();
         tokio::spawn(async move {
@@ -1019,6 +1076,12 @@ mod tests {
             hostname_index: RwLock::new(HashMap::new()),
             bridge_state: Arc::new(crate::bridge_handlers::BridgeState::new()),
             bridge_lookup: None,
+            #[cfg(feature = "quic")]
+            publish_rate_limiter: scp_transport::relay::rate_limit::PublishRateLimiter::new(100),
+            #[cfg(feature = "quic")]
+            quic_server_config: None,
+            #[cfg(feature = "quic")]
+            quic_listening: std::sync::atomic::AtomicBool::new(false),
         })
     }
 
@@ -1206,6 +1269,12 @@ mod vhost_tests {
             hostname_index: RwLock::new(hostname_index),
             bridge_state: Arc::new(crate::bridge_handlers::BridgeState::new()),
             bridge_lookup: None,
+            #[cfg(feature = "quic")]
+            publish_rate_limiter: scp_transport::relay::rate_limit::PublishRateLimiter::new(100),
+            #[cfg(feature = "quic")]
+            quic_server_config: None,
+            #[cfg(feature = "quic")]
+            quic_listening: std::sync::atomic::AtomicBool::new(false),
         })
     }
 
@@ -1575,4 +1644,76 @@ fn spawn_http3_listener(http3_config: scp_transport::http3::Http3Config, state: 
             }
         }
     });
+}
+
+/// Starts the relay-side QUIC listener when a QUIC server config is present.
+///
+/// The listener binds UDP on the **same port** as the WebSocket TCP listener
+/// (`tcp_port`, the actually-bound port of the public TLS listener), so a relay
+/// accepts QUIC and WebSocket on one TLS port (spec §10.14.3 item 1). It shares
+/// this node's [`SubscriptionRegistry`], [`BlobStorageBackend`],
+/// [`ConnectionTracker`], and PUBLISH rate limiter with the WebSocket relay, so
+/// a QUIC subscriber receives blobs published over WebSocket and vice-versa
+/// (spec §10.14.3 item 2).
+///
+/// Returns `true` if the listener was started, `false` otherwise (no config, or
+/// bind failure — in which case the node degrades to WebSocket-only).
+///
+/// The listener's lifecycle is tied to `state.shutdown_token`: a small task
+/// awaits cancellation and then signals the QUIC listener to stop, so
+/// [`ApplicationNode::shutdown`] (and `serve()`'s graceful shutdown) stop both
+/// transports together.
+#[cfg(feature = "quic")]
+fn spawn_quic_listener(state: &Arc<NodeState>, tcp_port: u16) -> bool {
+    use scp_transport::quic::listener::{QuicListener, QuicListenerConfig};
+
+    let Some(server_config) = state.quic_server_config.clone() else {
+        return false;
+    };
+
+    // Bind UDP on the same interface and port as the public WebSocket/TLS
+    // listener so both transports share one address (spec §10.14.3 item 1).
+    let bind_addr = SocketAddr::new(state.http_bind_addr.ip(), tcp_port);
+
+    // Mirror the relay's operational limits so QUIC and WebSocket enforce the
+    // same policy.
+    let rc = &state.relay_config;
+    let config = QuicListenerConfig {
+        bind_addr,
+        max_blob_size: rc.max_blob_size,
+        max_blob_ttl: rc.max_blob_ttl,
+        max_subscriptions_per_connection: rc.max_subscriptions_per_connection,
+        max_query_limit: rc.max_query_limit,
+        max_connections_per_ip: rc.max_connections_per_ip,
+        max_total_connections: rc.max_total_connections,
+        rate_limit_publishes_per_second: rc.rate_limit_publishes_per_second,
+        rate_limit_subscribes_per_minute: rc.rate_limit_subscribes_per_minute,
+        delivery_jitter_ms: rc.delivery_jitter_ms,
+    };
+
+    let listener = QuicListener::new(
+        config,
+        Arc::clone(&state.blob_storage),
+        state.subscription_registry.clone(),
+        state.publish_rate_limiter.clone(),
+        state.connection_tracker.clone(),
+    );
+
+    match listener.start(server_config) {
+        Ok((quic_handle, local_addr)) => {
+            tracing::info!(addr = %local_addr, "relay QUIC listener started");
+            // Bridge the node's cancellation token to the QUIC shutdown handle so
+            // graceful shutdown stops both transports.
+            let shutdown_token = state.shutdown_token.clone();
+            tokio::spawn(async move {
+                shutdown_token.cancelled().await;
+                quic_handle.shutdown();
+            });
+            true
+        }
+        Err(e) => {
+            tracing::error!(error = %e, "failed to start relay QUIC listener — serving WebSocket only");
+            false
+        }
+    }
 }

--- a/crates/scp-node/src/lib.rs
+++ b/crates/scp-node/src/lib.rs
@@ -2760,6 +2760,10 @@ impl<K: KeyCustody + 'static, D: DidMethod + 'static, S: Storage + 'static>
         let relay_server = RelayServer::new(relay_config.clone(), Arc::clone(&blob_storage));
         let connection_tracker = relay_server.connection_tracker();
         let subscription_registry = relay_server.subscriptions();
+        // Shared PUBLISH rate limiter — the QUIC listener reuses it so PUBLISH
+        // budgets are enforced uniformly across WebSocket and QUIC (ADR-037 AC3).
+        #[cfg(feature = "quic")]
+        let publish_rate_limiter = relay_server.publish_rate_limiter();
         let (shutdown_handle, bound_addr) = relay_server.start().await?;
         let dev_token = self.local_api_addr.map(generate_dev_token);
         let http_bind_addr = self.http_bind_addr.unwrap_or(DEFAULT_HTTP_BIND_ADDR);
@@ -2798,6 +2802,8 @@ impl<K: KeyCustody + 'static, D: DidMethod + 'static, S: Storage + 'static>
                     cert_data,
                     connection_tracker.clone(),
                     subscription_registry.clone(),
+                    #[cfg(feature = "quic")]
+                    publish_rate_limiter.clone(),
                     acme_challenges,
                     #[cfg(feature = "http3")]
                     self.http3_config,
@@ -2835,6 +2841,8 @@ impl<K: KeyCustody + 'static, D: DidMethod + 'static, S: Storage + 'static>
                     self.network_detector,
                     connection_tracker,
                     subscription_registry,
+                    #[cfg(feature = "quic")]
+                    publish_rate_limiter,
                 )
                 .await
             }
@@ -3310,6 +3318,8 @@ async fn build_domain_inner<D: DidMethod + 'static, S: Storage + 'static>(
     cert_data: tls::CertificateData,
     connection_tracker: scp_transport::relay::rate_limit::ConnectionTracker,
     subscription_registry: scp_transport::relay::subscription::SubscriptionRegistry,
+    #[cfg(feature = "quic")]
+    publish_rate_limiter: scp_transport::relay::rate_limit::PublishRateLimiter,
     acme_challenges: Option<Arc<tokio::sync::RwLock<std::collections::HashMap<String, String>>>>,
     #[cfg(feature = "http3")] http3_config: Option<scp_transport::http3::Http3Config>,
 ) -> Result<ApplicationNode<S>, NodeError> {
@@ -3322,6 +3332,29 @@ async fn build_domain_inner<D: DidMethod + 'static, S: Storage + 'static>(
     // without restarting the server (spec section 18.6.3).
     let (tls_server_config, cert_resolver) =
         tls::build_reloadable_tls_config(&cert_data).map_err(NodeError::Tls)?;
+
+    // Build the QUIC server config from the SAME provisioned certificate so the
+    // relay cert covers both WebSocket (TCP) and QUIC (UDP) on the public TLS
+    // port (spec §10.14.3 item 1). The listener itself is started lazily in
+    // `serve()`; here we only prepare the config so `serve()` has everything it
+    // needs without re-parsing the certificate.
+    #[cfg(feature = "quic")]
+    let quic_server_config = {
+        let cert_chain = cert_data.certificate_chain_der().map_err(NodeError::Tls)?;
+        let private_key = cert_data.private_key_der().map_err(NodeError::Tls)?;
+        match scp_transport::quic::listener::build_server_config(cert_chain, private_key) {
+            Ok(cfg) => Some(cfg),
+            Err(e) => {
+                // A malformed cert should not prevent the node from serving
+                // WebSocket; degrade to WebSocket-only and log loudly.
+                tracing::error!(
+                    domain = %domain, error = %e,
+                    "failed to build QUIC server config — serving WebSocket only"
+                );
+                None
+            }
+        }
+    };
 
     tracing::info!(
         domain = %domain, relay_url = %relay_url,
@@ -3368,6 +3401,13 @@ async fn build_domain_inner<D: DidMethod + 'static, S: Storage + 'static>(
         hostname_index: tokio::sync::RwLock::new(HashMap::new()),
         bridge_state: Arc::new(crate::bridge_handlers::BridgeState::new()),
         bridge_lookup: Some(bridge_lookup),
+        #[cfg(feature = "quic")]
+        publish_rate_limiter,
+        #[cfg(feature = "quic")]
+        quic_server_config,
+        // Set to `true` by `serve()` once the QUIC listener binds (§10.14.3).
+        #[cfg(feature = "quic")]
+        quic_listening: std::sync::atomic::AtomicBool::new(false),
     });
 
     Ok(ApplicationNode {
@@ -3393,6 +3433,23 @@ async fn build_domain_inner<D: DidMethod + 'static, S: Storage + 'static>(
 // Shared no-domain build logic (used by HasNoDomain::build and domain fallthrough)
 // ---------------------------------------------------------------------------
 
+/// Appends an `SCPRelay` service entry to the DID document for `relay_url`.
+///
+/// The service id is suffixed with the next sequential index so multiple relays
+/// can coexist on one document (`<did>#scp-relay-<n>`).
+fn push_relay_service(document: &mut DidDocument, relay_url: &str) {
+    let relay_count = document
+        .service
+        .iter()
+        .filter(|s| s.service_type == "SCPRelay")
+        .count();
+    document.service.push(scp_identity::document::Service {
+        id: format!("{}#scp-relay-{}", document.id, relay_count + 1),
+        service_type: "SCPRelay".to_owned(),
+        service_endpoint: relay_url.to_owned(),
+    });
+}
+
 // Node builder internal: all parameters are required for server construction.
 #[allow(clippy::too_many_arguments)]
 async fn build_no_domain_inner<D: DidMethod + 'static, S: Storage + 'static>(
@@ -3414,6 +3471,8 @@ async fn build_no_domain_inner<D: DidMethod + 'static, S: Storage + 'static>(
     network_detector: Option<Arc<dyn NetworkChangeDetector>>,
     connection_tracker: scp_transport::relay::rate_limit::ConnectionTracker,
     subscription_registry: scp_transport::relay::subscription::SubscriptionRegistry,
+    #[cfg(feature = "quic")]
+    publish_rate_limiter: scp_transport::relay::rate_limit::PublishRateLimiter,
 ) -> Result<ApplicationNode<S>, NodeError> {
     // NAT strategy needs the public HTTP port, not the internal relay port (#641).
     let http_bind_addr = http_bind_addr.unwrap_or(DEFAULT_HTTP_BIND_ADDR);
@@ -3427,17 +3486,7 @@ async fn build_no_domain_inner<D: DidMethod + 'static, S: Storage + 'static>(
         ReachabilityTier::Bridge { bridge_url } => bridge_url.clone(),
     };
 
-    let relay_count = document
-        .service
-        .iter()
-        .filter(|s| s.service_type == "SCPRelay")
-        .count();
-
-    document.service.push(scp_identity::document::Service {
-        id: format!("{}#scp-relay-{}", document.id, relay_count + 1),
-        service_type: "SCPRelay".to_owned(),
-        service_endpoint: relay_url.clone(),
-    });
+    push_relay_service(&mut document, &relay_url);
 
     // 4. Publish DID document.
     did_method.publish(&identity, &document).await?;
@@ -3504,6 +3553,14 @@ async fn build_no_domain_inner<D: DidMethod + 'static, S: Storage + 'static>(
         hostname_index: tokio::sync::RwLock::new(HashMap::new()),
         bridge_state: Arc::new(crate::bridge_handlers::BridgeState::new()),
         bridge_lookup: Some(bridge_lookup),
+        // No-domain mode is plaintext `ws://` (no cert), so QUIC is not served (§10.14.3).
+        #[cfg(feature = "quic")]
+        publish_rate_limiter,
+        #[cfg(feature = "quic")]
+        quic_server_config: None,
+        // No QUIC config means `serve()` never sets this; stays `false`.
+        #[cfg(feature = "quic")]
+        quic_listening: std::sync::atomic::AtomicBool::new(false),
     });
 
     Ok(ApplicationNode {
@@ -3607,6 +3664,10 @@ impl<K: KeyCustody + 'static, D: DidMethod + 'static, S: Storage + 'static>
         let relay_server = RelayServer::new(relay_config.clone(), Arc::clone(&blob_storage));
         let connection_tracker = relay_server.connection_tracker();
         let subscription_registry = relay_server.subscriptions();
+        // Shared PUBLISH rate limiter (unused in no-domain mode because QUIC is
+        // not served without TLS, but kept on NodeState for a uniform struct).
+        #[cfg(feature = "quic")]
+        let publish_rate_limiter = relay_server.publish_rate_limiter();
         let (shutdown_handle, bound_addr) = relay_server.start().await?;
 
         // 4. Generate dev API token if local_api was configured.
@@ -3641,6 +3702,8 @@ impl<K: KeyCustody + 'static, D: DidMethod + 'static, S: Storage + 'static>
             self.network_detector,
             connection_tracker,
             subscription_registry,
+            #[cfg(feature = "quic")]
+            publish_rate_limiter,
         )
         .await
     }

--- a/crates/scp-node/src/projection.rs
+++ b/crates/scp-node/src/projection.rs
@@ -2625,6 +2625,12 @@ mod tests {
             hostname_index: RwLock::new(HashMap::new()),
             bridge_state: Arc::new(crate::bridge_handlers::BridgeState::new()),
             bridge_lookup: None,
+            #[cfg(feature = "quic")]
+            publish_rate_limiter: scp_transport::relay::rate_limit::PublishRateLimiter::new(100),
+            #[cfg(feature = "quic")]
+            quic_server_config: None,
+            #[cfg(feature = "quic")]
+            quic_listening: std::sync::atomic::AtomicBool::new(false),
         })
     }
 

--- a/crates/scp-node/src/well_known.rs
+++ b/crates/scp-node/src/well_known.rs
@@ -33,20 +33,27 @@ use crate::http::NodeState;
 /// Returns the list of transports advertised in `.well-known/scp`.
 ///
 /// WebSocket is always included (it is the baseline SCP transport).
-/// Additional transports are included when their corresponding feature
-/// flags are enabled at compile time:
+/// Additional transports are advertised only when this node actually serves
+/// them, so the document never advertises a transport the binary does not run:
 ///
-/// - `quic` feature -> `"quic"`
+/// - `"quic"` -> advertised only when a QUIC listener is started, i.e. the
+///   `quic` feature is enabled **and** a TLS certificate was provisioned
+///   (`quic_listening == true`). In no-domain (plaintext) mode QUIC is not
+///   served, so it is not advertised — closing the advertise-but-don't-serve
+///   gap (spec §10.14.3 item 1).
 /// - `http3` feature -> `"webtransport"`
 /// - `udp` feature -> `"udp-dtls"`
 ///
-/// See spec §10.5.1 and SCP-264.
+/// See spec §10.5.1 and §10.14.3.
 #[must_use]
-fn advertised_transports() -> Vec<String> {
+fn advertised_transports(quic_listening: bool) -> Vec<String> {
     #[allow(unused_mut)]
     let mut transports = vec!["websocket".to_owned()];
-    #[cfg(feature = "quic")]
-    transports.push("quic".to_owned());
+    // `quic_listening` is only ever `true` when the `quic` feature is enabled
+    // (the field that feeds it is gated), so this reflects the running listener.
+    if quic_listening {
+        transports.push("quic".to_owned());
+    }
     #[cfg(feature = "http3")]
     transports.push("webtransport".to_owned());
     #[cfg(feature = "udp")]
@@ -54,6 +61,36 @@ fn advertised_transports() -> Vec<String> {
     #[cfg(feature = "coap")]
     transports.push("coap".to_owned());
     transports
+}
+
+/// Returns whether this node serves a relay-side QUIC listener.
+///
+/// `true` only when the `quic` feature is enabled and the QUIC listener
+/// actually bound and started (set by [`ApplicationNode::serve`] after a
+/// successful UDP bind, not merely when the QUIC server config was built).
+/// Always `false` without the feature. Reading the *running* state rather than
+/// the config-built state ensures `.well-known/scp` does not advertise `"quic"`
+/// when the bind failed and the node degraded to WebSocket-only.
+///
+/// [`ApplicationNode::serve`]: crate::ApplicationNode::serve
+//
+// Not `const fn`: with the `quic` feature the body performs an atomic load,
+// which is not permitted in a const context. Without the feature the body is
+// trivially const-able, so silence the lint on that build only.
+#[cfg_attr(not(feature = "quic"), allow(clippy::missing_const_for_fn))]
+#[must_use]
+fn quic_listening(state: &NodeState) -> bool {
+    #[cfg(feature = "quic")]
+    {
+        state
+            .quic_listening
+            .load(std::sync::atomic::Ordering::Acquire)
+    }
+    #[cfg(not(feature = "quic"))]
+    {
+        let _ = state;
+        false
+    }
 }
 
 /// Builds the complete [`WellKnownScp`] document from node state.
@@ -105,7 +142,7 @@ pub async fn build_well_known_scp(state: &NodeState) -> WellKnownScp {
         rate_limit_subscribe: Some(
             u32::try_from(rc.max_subscriptions_per_connection).unwrap_or(u32::MAX),
         ),
-        transports: Some(advertised_transports()),
+        transports: Some(advertised_transports(quic_listening(state))),
         economic: None,
     };
 
@@ -143,7 +180,7 @@ mod tests {
 
     #[test]
     fn advertised_transports_always_includes_websocket() {
-        let transports = advertised_transports();
+        let transports = advertised_transports(false);
         assert!(
             transports.contains(&"websocket".to_owned()),
             "websocket must always be present in advertised transports"
@@ -153,29 +190,32 @@ mod tests {
     }
 
     #[test]
-    #[cfg(not(feature = "quic"))]
-    fn advertised_transports_excludes_quic_without_feature() {
-        let transports = advertised_transports();
+    fn advertised_transports_excludes_quic_when_not_listening() {
+        // Regardless of the compile-time feature, a node that is not running a
+        // QUIC listener must not advertise quic (§10.14.3 item 1: no
+        // advertise-but-don't-serve).
+        let transports = advertised_transports(false);
         assert!(
             !transports.contains(&"quic".to_owned()),
-            "quic must not be advertised without the quic feature flag"
+            "quic must not be advertised when no QUIC listener is running"
         );
     }
 
     #[test]
-    #[cfg(feature = "quic")]
-    fn advertised_transports_includes_quic_with_feature() {
-        let transports = advertised_transports();
+    fn advertised_transports_includes_quic_when_listening() {
+        // When a QUIC listener is running, quic must be advertised so clients
+        // can discover and prefer it (§10.5.1).
+        let transports = advertised_transports(true);
         assert!(
             transports.contains(&"quic".to_owned()),
-            "quic must be advertised when the quic feature flag is enabled"
+            "quic must be advertised when a QUIC listener is running"
         );
     }
 
     #[test]
     #[cfg(not(feature = "http3"))]
     fn advertised_transports_excludes_webtransport_without_feature() {
-        let transports = advertised_transports();
+        let transports = advertised_transports(false);
         assert!(
             !transports.contains(&"webtransport".to_owned()),
             "webtransport must not be advertised without the http3 feature flag"
@@ -185,7 +225,7 @@ mod tests {
     #[test]
     #[cfg(feature = "http3")]
     fn advertised_transports_includes_webtransport_with_feature() {
-        let transports = advertised_transports();
+        let transports = advertised_transports(false);
         assert!(
             transports.contains(&"webtransport".to_owned()),
             "webtransport must be advertised when the http3 feature flag is enabled"
@@ -195,7 +235,7 @@ mod tests {
     #[test]
     #[cfg(not(feature = "udp"))]
     fn advertised_transports_excludes_udp_dtls_without_feature() {
-        let transports = advertised_transports();
+        let transports = advertised_transports(false);
         assert!(
             !transports.contains(&"udp-dtls".to_owned()),
             "udp-dtls must not be advertised without the udp feature flag"
@@ -205,7 +245,7 @@ mod tests {
     #[test]
     #[cfg(feature = "udp")]
     fn advertised_transports_includes_udp_dtls_with_feature() {
-        let transports = advertised_transports();
+        let transports = advertised_transports(false);
         assert!(
             transports.contains(&"udp-dtls".to_owned()),
             "udp-dtls must be advertised when the udp feature flag is enabled"
@@ -213,13 +253,15 @@ mod tests {
     }
 
     #[test]
-    #[cfg(not(any(feature = "quic", feature = "http3", feature = "udp")))]
-    fn advertised_transports_default_is_websocket_only() {
-        let transports = advertised_transports();
+    #[cfg(not(any(feature = "http3", feature = "udp", feature = "coap")))]
+    fn advertised_transports_not_listening_is_websocket_only() {
+        // With no other transport features and no QUIC listener, only websocket
+        // should be advertised.
+        let transports = advertised_transports(false);
         assert_eq!(
             transports,
             vec!["websocket".to_owned()],
-            "without any transport feature flags, only websocket should be advertised"
+            "without any transport features and no QUIC listener, only websocket should be advertised"
         );
     }
 }

--- a/crates/scp-node/tests/quic_listener.rs
+++ b/crates/scp-node/tests/quic_listener.rs
@@ -1,0 +1,348 @@
+//! Integration tests for the relay-side QUIC listener wired into the node
+//! serve path.
+//!
+//! These tests verify that, when the `quic` feature is enabled and a TLS
+//! certificate is provisioned (domain mode), `ApplicationNode::serve` starts a
+//! QUIC listener on the same UDP port as the WebSocket TCP listener, that the
+//! listener shares subscription and blob state with the WebSocket relay, and
+//! that `.well-known/scp` advertises `"quic"` only when the listener is
+//! actually running.
+//!
+//! Spec: section 10.14.3 (QUIC on the same TLS port, shared state),
+//! section 10.5.1 (transport advertisement). SCP-257 AC1.
+
+#![cfg(all(feature = "quic", feature = "allow_unencrypted_storage"))]
+#![allow(clippy::unwrap_used, clippy::expect_used, clippy::panic)]
+
+use std::net::SocketAddr;
+use std::sync::Arc;
+use std::time::Duration;
+
+use quinn::{ClientConfig, Endpoint};
+use scp_transport::native::protocol::{ClientMessage, RelayMessage};
+use scp_transport::quic::listener::SCP_ALPN;
+
+use scp_identity::DidCache;
+use scp_identity::InMemoryDhtClient;
+use scp_identity::cache::SystemClock;
+use scp_identity::dht::DidDht;
+use scp_node::{ApplicationNode, ApplicationNodeBuilder, SelfSignedTlsProvider};
+use scp_platform::testing::{InMemoryKeyCustody, InMemoryStorage};
+
+type TestDidDht = DidDht<InMemoryDhtClient, SystemClock>;
+
+/// A rustls server-certificate verifier that accepts any certificate.
+///
+/// Test-only: the node generates its self-signed certificate internally, so the
+/// QUIC client has no way to pin it. Skipping verification is acceptable here
+/// because the test only exercises transport plumbing, not TLS trust.
+#[derive(Debug)]
+struct SkipServerVerification(Arc<rustls::crypto::CryptoProvider>);
+
+impl rustls::client::danger::ServerCertVerifier for SkipServerVerification {
+    fn verify_server_cert(
+        &self,
+        _end_entity: &rustls::pki_types::CertificateDer<'_>,
+        _intermediates: &[rustls::pki_types::CertificateDer<'_>],
+        _server_name: &rustls::pki_types::ServerName<'_>,
+        _ocsp: &[u8],
+        _now: rustls::pki_types::UnixTime,
+    ) -> Result<rustls::client::danger::ServerCertVerified, rustls::Error> {
+        Ok(rustls::client::danger::ServerCertVerified::assertion())
+    }
+
+    fn verify_tls12_signature(
+        &self,
+        message: &[u8],
+        cert: &rustls::pki_types::CertificateDer<'_>,
+        dss: &rustls::DigitallySignedStruct,
+    ) -> Result<rustls::client::danger::HandshakeSignatureValid, rustls::Error> {
+        rustls::crypto::verify_tls12_signature(
+            message,
+            cert,
+            dss,
+            &self.0.signature_verification_algorithms,
+        )
+    }
+
+    fn verify_tls13_signature(
+        &self,
+        message: &[u8],
+        cert: &rustls::pki_types::CertificateDer<'_>,
+        dss: &rustls::DigitallySignedStruct,
+    ) -> Result<rustls::client::danger::HandshakeSignatureValid, rustls::Error> {
+        rustls::crypto::verify_tls13_signature(
+            message,
+            cert,
+            dss,
+            &self.0.signature_verification_algorithms,
+        )
+    }
+
+    fn supported_verify_schemes(&self) -> Vec<rustls::SignatureScheme> {
+        self.0.signature_verification_algorithms.supported_schemes()
+    }
+}
+
+/// Installs the process-wide rustls crypto provider exactly once.
+///
+/// Both the node's TLS stack and the QUIC client config builder require a
+/// default [`CryptoProvider`]; installing it is idempotent (a second call
+/// returns `Err`, which we ignore).
+fn install_crypto_provider() {
+    let _ = rustls::crypto::ring::default_provider().install_default();
+}
+
+/// Builds a QUIC client config that trusts any server certificate and
+/// negotiates the SCP ALPN.
+fn insecure_client_config() -> ClientConfig {
+    let provider = Arc::new(rustls::crypto::ring::default_provider());
+    let mut tls_config = rustls::ClientConfig::builder()
+        .dangerous()
+        .with_custom_certificate_verifier(Arc::new(SkipServerVerification(Arc::clone(&provider))))
+        .with_no_client_auth();
+    tls_config.alpn_protocols = vec![SCP_ALPN.to_vec()];
+
+    let quic_client_config = quinn::crypto::rustls::QuicClientConfig::try_from(tls_config).unwrap();
+    ClientConfig::new(Arc::new(quic_client_config))
+}
+
+/// Reserves a free TCP port by binding to port 0 and immediately releasing it.
+///
+/// The returned port is then used as a fixed `http_bind_addr` so the test can
+/// connect a QUIC client to the known UDP port (`serve()` does not surface the
+/// bound address).
+async fn reserve_port() -> u16 {
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let port = listener.local_addr().unwrap().port();
+    drop(listener);
+    port
+}
+
+/// Builds a domain-mode node with a self-signed certificate (so a QUIC server
+/// config is provisioned) bound to the given public HTTP/TLS port.
+async fn build_tls_node(http_port: u16) -> ApplicationNode<InMemoryStorage> {
+    let custody = Arc::new(InMemoryKeyCustody::new());
+    let dht_client = Arc::new(InMemoryDhtClient::new());
+    let cache = Arc::new(DidCache::new());
+    let sign_fn = TestDidDht::make_sign_fn(Arc::clone(&custody));
+    let did_method = Arc::new(TestDidDht::with_client_and_signer(
+        dht_client, cache, sign_fn,
+    ));
+
+    ApplicationNodeBuilder::new()
+        .storage(InMemoryStorage::new())
+        .domain("localhost")
+        .http_bind_addr(SocketAddr::from(([127, 0, 0, 1], http_port)))
+        .tls_provider(Arc::new(SelfSignedTlsProvider::new("localhost")))
+        .generate_identity_with(custody, did_method)
+        .build_for_testing()
+        .await
+        .expect("node build should succeed")
+}
+
+/// Connects a QUIC client to `addr`, retrying until the listener is accepting
+/// or the timeout elapses.
+async fn connect_quic(addr: SocketAddr) -> quinn::Connection {
+    let mut endpoint = Endpoint::client(SocketAddr::from(([127, 0, 0, 1], 0))).unwrap();
+    endpoint.set_default_client_config(insecure_client_config());
+
+    let deadline = tokio::time::Instant::now() + Duration::from_secs(10);
+    loop {
+        match endpoint.connect(addr, "localhost").unwrap().await {
+            Ok(conn) => return conn,
+            Err(e) => {
+                assert!(
+                    tokio::time::Instant::now() < deadline,
+                    "QUIC connection to {addr} never succeeded: {e}"
+                );
+                tokio::time::sleep(Duration::from_millis(50)).await;
+            }
+        }
+    }
+}
+
+/// Sends a single client message on a fresh bidi stream and reads all responses.
+async fn send_and_recv(conn: &quinn::Connection, msg: &ClientMessage) -> Vec<RelayMessage> {
+    let (mut send, mut recv) = conn.open_bi().await.unwrap();
+    let payload = msg.to_bytes().unwrap();
+    let len = u32::try_from(payload.len()).unwrap();
+    send.write_all(&len.to_be_bytes()).await.unwrap();
+    send.write_all(&payload).await.unwrap();
+    send.finish().unwrap();
+
+    let mut messages = Vec::new();
+    loop {
+        let mut len_buf = [0u8; 4];
+        if recv.read_exact(&mut len_buf).await.is_err() {
+            break;
+        }
+        let msg_len = u32::from_be_bytes(len_buf) as usize;
+        let mut buf = vec![0u8; msg_len];
+        if recv.read_exact(&mut buf).await.is_err() {
+            break;
+        }
+        match RelayMessage::from_bytes(&buf) {
+            Ok(m) => messages.push(m),
+            Err(_) => break,
+        }
+    }
+    messages
+}
+
+/// Asserts the node accepts a QUIC connection on the same UDP port as its
+/// WebSocket TCP listener (spec §10.14.3 item 1, SCP-257 AC1).
+#[tokio::test]
+async fn quic_listener_accepts_connection_on_serve() {
+    install_crypto_provider();
+    let port = reserve_port().await;
+    let node = build_tls_node(port).await;
+
+    // Run serve() in the background; it consumes the node and runs until the
+    // shutdown future resolves.
+    let (tx, rx) = tokio::sync::oneshot::channel::<()>();
+    let serve_handle = tokio::spawn(async move {
+        node.serve(axum::Router::new(), async move {
+            let _ = rx.await;
+        })
+        .await
+        .ok();
+    });
+
+    let addr = SocketAddr::from(([127, 0, 0, 1], port));
+    let conn = connect_quic(addr).await;
+    assert_eq!(conn.remote_address(), addr);
+
+    conn.close(0u32.into(), b"done");
+    let _ = tx.send(());
+    let _ = serve_handle.await;
+}
+
+/// Asserts a PUBLISH over QUIC is stored and visible to a subsequent QUERY over
+/// QUIC (shared blob storage smoke test, spec §10.14.3 item 2).
+#[tokio::test]
+async fn quic_publish_then_query_roundtrips() {
+    install_crypto_provider();
+    let port = reserve_port().await;
+    let node = build_tls_node(port).await;
+
+    let (tx, rx) = tokio::sync::oneshot::channel::<()>();
+    let serve_handle = tokio::spawn(async move {
+        node.serve(axum::Router::new(), async move {
+            let _ = rx.await;
+        })
+        .await
+        .ok();
+    });
+
+    let addr = SocketAddr::from(([127, 0, 0, 1], port));
+    let conn = connect_quic(addr).await;
+
+    let routing_id = [7u8; 32];
+    let blob = vec![123u8; 64];
+
+    // PUBLISH.
+    let publish = ClientMessage::Publish {
+        ref_id: Some("pub-1".to_owned()),
+        routing_id,
+        recipient_hint: None,
+        blob_ttl: 3600,
+        blob: blob.clone(),
+    };
+    let pub_responses = send_and_recv(&conn, &publish).await;
+    assert_eq!(
+        pub_responses.len(),
+        1,
+        "publish should produce one response"
+    );
+    match &pub_responses[0] {
+        RelayMessage::Ok { ref_id, blob_id } => {
+            assert_eq!(ref_id.as_deref(), Some("pub-1"));
+            assert!(blob_id.is_some(), "publish OK must include blob_id");
+        }
+        other => panic!("expected OK, got {other:?}"),
+    }
+
+    // QUERY the same routing id over QUIC — must see the published blob.
+    let query = ClientMessage::Query {
+        ref_id: Some("q-1".to_owned()),
+        routing_id,
+        since: None,
+        limit: None,
+    };
+    let query_responses = send_and_recv(&conn, &query).await;
+    assert!(
+        query_responses
+            .iter()
+            .any(|m| matches!(m, RelayMessage::Blob { blob: b, .. } if b == &blob)),
+        "query must return the blob published over QUIC, got {query_responses:?}"
+    );
+
+    conn.close(0u32.into(), b"done");
+    let _ = tx.send(());
+    let _ = serve_handle.await;
+}
+
+/// Asserts `.well-known/scp` advertises `"quic"` when (and only when) a QUIC
+/// listener is running. The node serves HTTPS with a self-signed certificate,
+/// so the request accepts invalid certs (test-only). Spec §10.5.1 / §10.14.3.
+#[tokio::test]
+async fn well_known_advertises_quic_when_listener_running() {
+    install_crypto_provider();
+    let port = reserve_port().await;
+    let node = build_tls_node(port).await;
+
+    let (tx, rx) = tokio::sync::oneshot::channel::<()>();
+    let serve_handle = tokio::spawn(async move {
+        node.serve(axum::Router::new(), async move {
+            let _ = rx.await;
+        })
+        .await
+        .ok();
+    });
+
+    // Confirm the QUIC listener is up before asserting the advertisement, so the
+    // advertisement reflects a genuinely running listener.
+    let addr = SocketAddr::from(([127, 0, 0, 1], port));
+    let conn = connect_quic(addr).await;
+    conn.close(0u32.into(), b"probe");
+
+    let client = reqwest::Client::builder()
+        .danger_accept_invalid_certs(true)
+        .build()
+        .unwrap();
+
+    let url = format!("https://127.0.0.1:{port}/.well-known/scp");
+    // The TCP listener may need a moment after bind; retry briefly.
+    let mut doc: Option<serde_json::Value> = None;
+    let deadline = tokio::time::Instant::now() + Duration::from_secs(10);
+    while tokio::time::Instant::now() < deadline {
+        if let Ok(resp) = client.get(&url).send().await
+            && let Ok(json) = resp.json::<serde_json::Value>().await
+        {
+            doc = Some(json);
+            break;
+        }
+        tokio::time::sleep(Duration::from_millis(50)).await;
+    }
+    let doc = doc.expect("well-known document should be reachable over HTTPS");
+
+    let transports = doc
+        .get("relay_config")
+        .and_then(|rc| rc.get("transports"))
+        .and_then(|t| t.as_array())
+        .expect("relay_config.transports must be present");
+    let transport_names: Vec<&str> = transports.iter().filter_map(|v| v.as_str()).collect();
+
+    assert!(
+        transport_names.contains(&"websocket"),
+        "websocket must always be advertised, got {transport_names:?}"
+    );
+    assert!(
+        transport_names.contains(&"quic"),
+        "quic must be advertised while the QUIC listener is running, got {transport_names:?}"
+    );
+
+    let _ = tx.send(());
+    let _ = serve_handle.await;
+}

--- a/crates/scp-transport/Cargo.toml
+++ b/crates/scp-transport/Cargo.toml
@@ -59,7 +59,16 @@ sqlx = { version = "0.8", features = ["runtime-tokio", "postgres"], optional = t
 aws-sdk-s3 = { version = "1", optional = true, default-features = false, features = ["default-https-client", "rt-tokio", "sigv4a", "behavior-version-latest"] }
 aws-config = { version = "1", features = ["behavior-version-latest"], optional = true }
 http-body = { version = "1", optional = true }
-quinn = { version = "0.11", optional = true }
+# default-features disabled to avoid quinn's `platform-verifier` feature, which
+# pulls in `aws-lc-rs`. scp-transport is ring-only (see the `rustls` dep below),
+# and a second rustls provider makes the process-default crypto provider
+# ambiguous for downstream crates (e.g. scp-node). `rustls-ring` keeps quinn on
+# the same ring backend.
+quinn = { version = "0.11", optional = true, default-features = false, features = [
+    "runtime-tokio",
+    "rustls-ring",
+    "log",
+] }
 openssl = { version = "0.10", optional = true }
 socket2 = { version = "0.5", optional = true, features = ["all"] }
 h3 = { version = "0.0.8", optional = true }

--- a/crates/scp-transport/src/quic/listener.rs
+++ b/crates/scp-transport/src/quic/listener.rs
@@ -300,7 +300,15 @@ pub fn build_server_config(
     cert_chain: Vec<CertificateDer<'static>>,
     private_key: PrivateKeyDer<'static>,
 ) -> Result<ServerConfig, QuicListenerError> {
-    let mut tls_config = rustls::ServerConfig::builder()
+    // Pin the ring crypto provider explicitly rather than relying on the
+    // process default. When a binary links both the `ring` and `aws-lc-rs`
+    // rustls providers (e.g. via aws-sdk / reqwest pulling aws-lc-rs alongside
+    // our ring backend), `ServerConfig::builder()` has no unambiguous default
+    // and panics. SCP is ring-only, so name the provider directly.
+    let provider = Arc::new(rustls::crypto::ring::default_provider());
+    let mut tls_config = rustls::ServerConfig::builder_with_provider(provider)
+        .with_safe_default_protocol_versions()
+        .map_err(|e| QuicListenerError::TlsError(e.to_string()))?
         .with_no_client_auth()
         .with_single_cert(cert_chain, private_key)
         .map_err(|e| QuicListenerError::TlsError(e.to_string()))?;


### PR DESCRIPTION
## Summary

Starts the relay-side `QuicListener` from `scp-node`'s TLS `serve()` path so a relay accepts QUIC (UDP) on the **same port** as WebSocket (TCP), sharing one `SubscriptionRegistry`, `BlobStorageBackend`, `ConnectionTracker`, and PUBLISH rate limiter. A QUIC subscriber therefore receives blobs published over WebSocket and vice-versa. Previously `scp-node` served only WebSocket while `.well-known/scp` already advertised `"quic"` — an advertise-but-don't-serve inconsistency, now closed.

Implements spec §10.14.3 items 1–2 (QUIC on the same TLS port, shared subscription + blob state); satisfies SCP-257 AC1. Part of the QUIC restoration effort (`.docs/planning-sessions/planning-session-07-quic-restoration.md`, PR-3b).

## Details

- QUIC `ServerConfig` built once at node build time from the provisioned TLS cert (domain mode only; no-domain plaintext mode serves WS-only and does not advertise QUIC). The same cert covers both protocols.
- `.well-known/scp` advertises `"quic"` **only when the listener actually bound** — keyed on a runtime `AtomicBool` set from the bind result, not on config presence. A UDP bind failure degrades cleanly to WS-only without a false advertisement (which would cost QUIC clients a 3s probe timeout per refresh).
- Graceful shutdown ties the QUIC listener into the node's cancellation token alongside the WebSocket server.
- **Crypto-provider fix (scp-transport):** pins `quinn` off `platform-verifier`/`aws-lc-rs` and names the `ring` provider explicitly in `build_server_config`, resolving a rustls dual-provider runtime panic (instant-acme pulls aws-lc-rs alongside our ring backend). Mirrors `scp-node/src/tls.rs`. Behavior-equivalent; TLS 1.3 for QUIC enforced structurally by quinn's `QuicServerConfig::try_from`.
- FFI parity intentionally not wired: the FFI `serve_background` path is plaintext/no-TLS, and QUIC requires a cert — consistent with decision D3 (transport selection is internal/transparent).

## Verification

- `cargo clippy -p scp-node --features quic,allow_unencrypted_storage --all-targets -- -D warnings` clean; default build clean
- `cargo test -p scp-node --features quic` → 343 lib + 3 quic_listener integration (accept-on-port, publish→query roundtrip over shared storage, well-known advertises when running) + 11 other integration pass
- `cargo test -p scp-transport --features quic` → 687/19/19 pass
- Reviews: bug-catcher (wiring + shared state + the advertise-on-bind-failure fix) + cryptographer (provider change non-weakening; ring consistent with repo).

Forward note for the native-selection PR: since `platform-verifier` is dropped, the QUIC **client** config must supply its own `RootCertStore`/verifier via `builder_with_provider(ring)`, never a permissive fallback.