### PR TITLE
feat(transport): route napi + uniffi connect sites through the QUIC selector

### DIFF
--- a/crates/scp-ffi/napi/src/runtime.rs
+++ b/crates/scp-ffi/napi/src/runtime.rs
@@ -848,7 +848,7 @@ pub fn init_context_manager_with_local_transport(bi: &NapiBridgeInstance, local_
 pub fn init_context_manager_with_relay_transport(
     bi: &NapiBridgeInstance,
     local_did: &str,
-    adapter: scp_transport::native::adapter::NativeRelayAdapter,
+    adapter: Box<dyn scp_transport::TransportAdapter>,
 ) {
     if bi.core.has_context_manager() {
         tracing::warn!(

--- a/crates/scp-ffi/napi/src/server.rs
+++ b/crates/scp-ffi/napi/src/server.rs
@@ -87,7 +87,14 @@ async fn auto_wire_context_manager(
     .await
     {
         Ok(adapter) => {
-            crate::runtime::init_context_manager_with_relay_transport(bi, did, adapter);
+            // The bearer auto-wire path stays WebSocket-only (QUIC has no
+            // bearer-upgrade surface, spec §10.14.3 item 4), so it connects
+            // directly via `connect_sourced_with_bearer` rather than the QUIC
+            // selector. The shared `init_context_manager_with_relay_transport`
+            // helper now takes a `Box<dyn TransportAdapter>` (so the discovering
+            // connect sites can hand it the selector's boxed adapter); box the
+            // concrete bearer adapter here to match.
+            crate::runtime::init_context_manager_with_relay_transport(bi, did, Box::new(adapter));
 
             // Also populate the BridgeInstance transport manager so that
             // broadcast publish, context subscribe, and discovery probing

--- a/crates/scp-ffi/napi/src/transport.rs
+++ b/crates/scp-ffi/napi/src/transport.rs
@@ -252,26 +252,41 @@ pub(crate) async fn transport_connect_on(
 
     let start = std::time::Instant::now();
     let profile = scp_transport::profile::TransportProfile::platform_default();
-    let adapter_result =
-        scp_transport::native::NativeRelayAdapter::connect_sourced(&sourced, Some(&profile)).await;
+    // Route through the instance-scoped transport selector for transparent
+    // QUIC↔WebSocket selection (spec §10.14.3 item 4; ADR-037). The discovering
+    // variant fetches the relay's advertised transports from `.well-known/scp`
+    // (spec §10.5.1) at connect time and feeds that list into the
+    // QUIC-vs-WebSocket decision — failing open to WebSocket when the relay
+    // serves no well-known. The selector is owned by the bridge instance so its
+    // per-relay QUIC-suppression and well-known caches survive across connects.
+    // Mirrors the PyO3 reference bridge's `transport_connect`. The selector
+    // surfaces the suppression receiver (drained into reliability scoring,
+    // #1533 AC5) for the WebSocket branch; cover traffic auto-starts via the
+    // profile inside `finalize_connection` (#1532 AC6).
+    let selector = bi.core.transport_selector();
+    let adapter_result = selector
+        .select_and_connect_discovering_with_suppression(&sourced, Some(&profile))
+        .await;
 
     match adapter_result {
-        Ok(mut adapter) => {
+        Ok((adapter, suppression_rx)) => {
             // Connection succeeded. Measure latency.
             #[allow(clippy::cast_precision_loss)]
             let latency = start.elapsed().as_millis() as f64;
 
-            // Extract the suppression event receiver BEFORE moving the adapter
-            // into the TransportManager. The spawned task drains suppression
-            // events and downgrades the relay's reliability score (#1533 AC5).
-            let suppression_rx = adapter.take_suppression_receiver();
+            // The suppression receiver is surfaced by the selector (the
+            // concrete `NativeRelayAdapter::take_suppression_receiver` lives
+            // behind the `Box<dyn TransportAdapter>` the selector returns, so
+            // we cannot call it here — the selector hands it back directly,
+            // exactly like the PyO3 bridge).
 
-            // Wrap the adapter in a TransportManager for multi-relay support,
-            // then store it on the bridge instance. Same pattern as the
-            // PyO3 bridge's `py_transport_connect`.
-            // Cover traffic is already running — `connect_sourced` with a
-            // profile auto-starts it via `finalize_connection` (#1532 AC6).
-            let manager = scp_transport::TransportManager::new(Box::new(adapter));
+            // Wrap the selected adapter in a TransportManager for multi-relay
+            // support, then store it on the bridge instance. Same pattern as
+            // the PyO3 bridge's `transport_connect`. The selector returns a
+            // `Box<dyn TransportAdapter>`; the blanket
+            // `impl TransportAdapter for Box<dyn TransportAdapter>` lets it be
+            // used anywhere a concrete adapter is expected.
+            let manager = scp_transport::TransportManager::new(adapter);
             set_transport_manager_on(bi, manager)?;
 
             // Register the URL on the bridge's pending-reconnect set so
@@ -415,13 +430,20 @@ pub(crate) async fn configure_relay_transport_on(
     };
 
     let profile = scp_transport::profile::TransportProfile::platform_default();
-    let adapter =
-        scp_transport::native::NativeRelayAdapter::connect_sourced(&sourced, Some(&profile))
-            .await
-            .map_err(|e| ScpNapiError::Transport {
-                message: format!("failed to connect to relay '{relay_url}': {e}"),
-                code: codes::TRANS_5001.to_owned(),
-            })?;
+    // Route through the instance-scoped transport selector for transparent
+    // QUIC↔WebSocket selection (spec §10.14.3 item 4; ADR-037). The discovering
+    // variant reads the relay's advertised transports from `.well-known/scp`
+    // (spec §10.5.1) at connect time to enable QUIC, failing open to WebSocket
+    // when discovery is unavailable. Mirrors the PyO3 reference bridge's
+    // `configure_relay_transport`.
+    let selector = bi.core.transport_selector();
+    let adapter = selector
+        .select_and_connect_discovering(&sourced, Some(&profile))
+        .await
+        .map_err(|e| ScpNapiError::Transport {
+            message: format!("failed to connect to relay '{relay_url}': {e}"),
+            code: codes::TRANS_5001.to_owned(),
+        })?;
 
     crate::runtime::init_context_manager_with_relay_transport(bi, &local_did, adapter);
     Ok(())
@@ -467,24 +489,25 @@ pub(crate) async fn transport_add_relay_on(
         source: scp_transport::relay::connection::RelayUrlSource::Explicit,
     };
     let profile = scp_transport::profile::TransportProfile::platform_default();
-    // Cover traffic auto-starts per adapter via `connect_sourced` with a
-    // profile — `finalize_connection` launches the cover traffic background
-    // task based on the profile's tier (#1532 AC6).
-    let mut adapter =
-        scp_transport::native::NativeRelayAdapter::connect_sourced(&sourced, Some(&profile))
-            .await
-            .map_err(|e| ScpNapiError::Transport {
-                message: format!("failed to connect to relay '{relay_url}': {e}"),
-                code: codes::TRANS_5001.to_owned(),
-            })?;
-
-    // Extract the suppression event receiver BEFORE moving the adapter into
-    // the TransportManager. The spawned task drains suppression events and
-    // downgrades the relay's reliability score (#1533 AC5).
-    let suppression_rx = adapter.take_suppression_receiver();
+    // Route through the instance-scoped transport selector for transparent
+    // QUIC↔WebSocket selection (spec §10.14.3 item 4; ADR-037). The discovering
+    // variant reads the relay's advertised transports from `.well-known/scp`
+    // (spec §10.5.1) at connect time to enable QUIC, failing open to WebSocket
+    // when discovery is unavailable. Cover traffic auto-starts per adapter via
+    // the profile inside `finalize_connection` (#1532 AC6). The selector
+    // surfaces the suppression receiver (drained into reliability scoring,
+    // #1533 AC5). Mirrors the PyO3 reference bridge's `transport_add_relay`.
+    let selector = bi.core.transport_selector();
+    let (adapter, suppression_rx) = selector
+        .select_and_connect_discovering_with_suppression(&sourced, Some(&profile))
+        .await
+        .map_err(|e| ScpNapiError::Transport {
+            message: format!("failed to connect to relay '{relay_url}': {e}"),
+            code: codes::TRANS_5001.to_owned(),
+        })?;
 
     let count = with_transport_manager_mut_on(bi, |manager| {
-        let _eviction = manager.add_adapter(Box::new(adapter));
+        let _eviction = manager.add_adapter(adapter);
         #[allow(clippy::cast_possible_truncation)]
         Ok(manager.adapter_count() as u32)
     })?;
@@ -679,9 +702,10 @@ mod tests {
         let _ = clear_transport_manager_on(&bi);
     }
 
-    // Note: set_transport_manager_on requires a real `NativeRelayAdapter`
-    // which can only be obtained by connecting to a live relay. Full
-    // set→clear roundtrip coverage is in E2E tests.
+    // Note: a populated transport manager requires a real adapter, which can
+    // only be obtained by connecting to a live relay (the connect now routes
+    // through the bridge instance's transport selector). Full set→clear
+    // roundtrip coverage is in E2E tests.
 
     // -----------------------------------------------------------------------
     // NapiTransportManager — connected state and defense-in-depth
@@ -816,5 +840,105 @@ mod tests {
             "fresh NapiBridgeInstance instances must have distinct ids — otherwise the \
              per-instance isolation test below is meaningless"
         );
+    }
+
+    // -----------------------------------------------------------------------
+    // Selector routing — connect sites must go through the instance selector
+    // (cross-SDK QUIC selection). The in-memory relay serves no
+    // `.well-known/scp`, so the selector's discovering connect fails open to
+    // WebSocket and still succeeds. These tests prove each napi connect site
+    // routes through `bi.core.transport_selector()` rather than dialing
+    // `NativeRelayAdapter::connect_sourced` directly.
+    // -----------------------------------------------------------------------
+
+    /// `transport_connect_on` must route through the instance selector and
+    /// connect via WebSocket fallback against a relay that advertises no QUIC.
+    /// After the call the bridge instance must own a transport manager.
+    #[test]
+    fn transport_connect_routes_through_selector_ws_fallback() {
+        let rt = crate::runtime();
+        // An in-memory relay serves no `.well-known/scp`; QUIC is never
+        // advertised, so a selector-routed connect must fail open to WS.
+        let relay = rt
+            .block_on(scp_ffi_common::server::start_relay_in_memory())
+            .unwrap();
+        let relay_url = relay.relay_url().to_owned();
+
+        let bi = Arc::new(NapiBridgeInstance::new_napi());
+        let handle = rt
+            .block_on(transport_connect_on(&bi, relay_url.clone()))
+            .expect("selector-routed connect to a no-QUIC relay must succeed via WS fallback");
+
+        assert!(
+            handle.is_connected(),
+            "handle must report connected after selector-routed connect"
+        );
+        assert_eq!(handle.relay_url().as_deref(), Some(relay_url.as_str()));
+        assert!(
+            has_transport_manager_on(&bi),
+            "transport manager must be populated on the bridge instance after \
+             the selector-routed connect"
+        );
+
+        // Drop the handle explicitly so its Drop decrements the handle count.
+        drop(handle);
+        relay.shutdown();
+    }
+
+    /// `transport_add_relay_on` must route through the instance selector and
+    /// add a second WS-fallback adapter to the manager.
+    #[test]
+    fn transport_add_relay_routes_through_selector_ws_fallback() {
+        let rt = crate::runtime();
+        let relay = rt
+            .block_on(scp_ffi_common::server::start_relay_in_memory())
+            .unwrap();
+        let relay_url = relay.relay_url().to_owned();
+
+        let bi = Arc::new(NapiBridgeInstance::new_napi());
+        // First connect establishes the manager (also selector-routed).
+        let handle = rt
+            .block_on(transport_connect_on(&bi, relay_url.clone()))
+            .expect("initial selector-routed connect must succeed");
+        assert_eq!(transport_adapter_count_on(&bi).unwrap(), 1);
+
+        // add_relay must also route through the selector and fall open to WS.
+        let count = rt
+            .block_on(transport_add_relay_on(&bi, relay_url))
+            .expect("selector-routed add_relay to a no-QUIC relay must succeed via WS fallback");
+        assert_eq!(
+            count, 2,
+            "second selector-routed adapter must be registered in the manager"
+        );
+
+        drop(handle);
+        relay.shutdown();
+    }
+
+    /// `configure_relay_transport_on` must route through the instance selector
+    /// and install a `RelayTransportProvider` over the WS-fallback adapter.
+    #[test]
+    fn configure_relay_transport_routes_through_selector_ws_fallback() {
+        let rt = crate::runtime();
+        let relay = rt
+            .block_on(scp_ffi_common::server::start_relay_in_memory())
+            .unwrap();
+        let relay_url = relay.relay_url().to_owned();
+
+        let bi = NapiBridgeInstance::new_napi();
+        let did = "did:dht:z6MkTestConfigureRelay".to_owned();
+        rt.block_on(configure_relay_transport_on(&bi, relay_url, did))
+            .expect(
+                "selector-routed configure_relay_transport to a no-QUIC relay must succeed via \
+                 WS fallback and install a ContextManager",
+            );
+
+        assert!(
+            bi.core.has_context_manager(),
+            "ContextManager must be attached after configure_relay_transport routes through \
+             the selector"
+        );
+
+        relay.shutdown();
     }
 }

--- a/crates/scp-ffi/uniffi/src/bridge.rs
+++ b/crates/scp-ffi/uniffi/src/bridge.rs
@@ -2583,9 +2583,23 @@ impl Drop for TransportManager {
 /// The bridge instance is captured as a [`std::sync::Weak`], not an `Arc`.
 /// Holding an `Arc<UniffiBridgeInstance>` here would keep the instance
 /// alive forever because this task is spawned on the shared tokio runtime
-/// (`tokio::spawn(...)`) and is NOT enrolled in the per-instance
+/// (`crate::runtime().spawn(...)`) and is NOT enrolled in the per-instance
 /// [`JoinSet`](scp_ffi_common::bridge_instance::CoreFields::task_handle)
 /// that `emergency_cancel_tasks` aborts.
+///
+/// # Runtime context (must spawn on the shared runtime handle)
+///
+/// This is spawned via `crate::runtime().spawn(...)` — the shared
+/// `&'static tokio::runtime::Runtime` handle — NOT a bare
+/// `tokio::spawn(...)`. The sole sync caller, `TransportManager::add_relay`,
+/// is a sync `#[uniffi::export]` method, which `UniFFI` runs on the foreign
+/// caller thread with NO ambient tokio runtime entered. After
+/// `add_relay`'s internal `runtime().block_on(...)` returns, the runtime
+/// context is gone, so a bare `tokio::spawn(...)` would panic ("there is no
+/// reactor running"). Spawning through the runtime handle works regardless
+/// of ambient context. This mirrors the `PyO3` reference bridge's
+/// `spawn_suppression_scoring_task` (`crates/scp-ffi/src/transport.rs`),
+/// which uses `rt.spawn(...)` for the same reason.
 ///
 /// Without a `Weak`, dropping the last `Arc<UniffiBridgeInstance>` from
 /// the caller side would not actually drop the instance: the task body
@@ -2605,7 +2619,10 @@ fn spawn_suppression_scoring_task(
     mut rx: tokio::sync::mpsc::Receiver<scp_transport::heartbeat::SuppressionSuspected>,
     relay_url: String,
 ) {
-    tokio::spawn(async move {
+    // Spawn on the shared runtime handle, not a bare `tokio::spawn`: the sync
+    // `TransportManager::add_relay` caller runs outside any tokio runtime
+    // context (see this fn's doc comment), so a bare spawn would panic.
+    crate::runtime().spawn(async move {
         loop {
             let suppression = tokio::select! {
                 () = cancel_token.cancelled() => {
@@ -16150,21 +16167,24 @@ mod tests {
             .expect("initial selector-routed connect must succeed");
         assert_eq!(handle.adapter_count(), 1);
 
-        // `add_relay` is a sync method that uses `runtime().block_on` for the
-        // connect and then `tokio::spawn`s its suppression-scoring task — the
-        // spawn needs an ambient reactor (in production the UniFFI dispatcher
-        // provides one). Run it inside `spawn_blocking` so the internal
-        // `block_on` is permitted (it runs on a blocking worker of the same
-        // runtime) and the suppression task's `tokio::spawn` sees the runtime
-        // context. This does not change what is under test: the connect still
-        // routes through the instance selector and falls open to WS.
+        // Invoke `add_relay` exactly as production does: it is a SYNC
+        // `#[uniffi::export]` method, which UniFFI runs on the foreign caller
+        // thread with NO ambient tokio runtime entered. Call it from a plain
+        // `std::thread` that never enters/spawns on a runtime, so this test
+        // genuinely exercises the sync production path. `add_relay` drives its
+        // own connect via the bridge's static `runtime().block_on(...)` and
+        // then spawns the suppression-scoring task on that same runtime handle.
+        //
+        // This is the regression guard for the suppression task's spawn: if it
+        // reverts to a bare `tokio::spawn(...)`, that spawn runs after
+        // `block_on` returns (when the runtime context is gone) and panics
+        // ("there is no reactor running"), failing this test. The prior
+        // `spawn_blocking` wrapper hid that panic by providing a runtime
+        // context the real sync export never has.
         let add_handle = Arc::clone(&handle);
-        let count = runtime()
-            .block_on(async move {
-                tokio::task::spawn_blocking(move || add_handle.add_relay(relay_url))
-                    .await
-                    .expect("spawn_blocking join must succeed")
-            })
+        let count = std::thread::spawn(move || add_handle.add_relay(relay_url))
+            .join()
+            .expect("add_relay thread must not panic — a panic here means the suppression task spawned without a runtime context")
             .expect("selector-routed add_relay to a no-QUIC relay must succeed via WS fallback");
         assert_eq!(
             count, 2,

--- a/crates/scp-ffi/uniffi/src/bridge.rs
+++ b/crates/scp-ffi/uniffi/src/bridge.rs
@@ -2430,7 +2430,6 @@ impl TransportManager {
     /// Returns `ScpError::Transport` if the URL is invalid or the connection
     /// fails.
     pub fn add_relay(self: Arc<Self>, relay_url: String) -> Result<u32, ScpError> {
-        use scp_transport::native::adapter::NativeRelayAdapter;
         use scp_transport::relay::connection::{RelayUrlSource, SourcedRelayUrl};
 
         validate_relay_url(&relay_url)?;
@@ -2442,24 +2441,30 @@ impl TransportManager {
             url: relay_url.clone(),
             source: RelayUrlSource::Explicit,
         };
-        // Cover traffic auto-starts per adapter via `connect_sourced` with a
-        // profile — `finalize_connection` launches the cover traffic background
-        // task based on the profile's tier (#1532 AC6).
+        // Route through the instance-scoped transport selector for transparent
+        // QUIC↔WebSocket selection (spec §10.14.3 item 4; ADR-037). The
+        // discovering variant reads the relay's advertised transports from
+        // `.well-known/scp` (spec §10.5.1) at connect time to enable QUIC,
+        // failing open to WebSocket when discovery is unavailable. Cover traffic
+        // auto-starts per adapter via the profile inside `finalize_connection`
+        // (#1532 AC6). The selector surfaces the suppression receiver (drained
+        // into reliability scoring, #1533 AC5). Mirrors the PyO3 reference
+        // bridge's `transport_add_relay`.
         let profile = scp_transport::profile::TransportProfile::platform_default();
-        let mut adapter = rt
-            .block_on(async { NativeRelayAdapter::connect_sourced(&sourced, Some(&profile)).await })
+        let selector = self.bi.core.transport_selector();
+        let (adapter, suppression_rx) = rt
+            .block_on(async {
+                selector
+                    .select_and_connect_discovering_with_suppression(&sourced, Some(&profile))
+                    .await
+            })
             .map_err(ScpError::from)?;
-
-        // Extract the suppression event receiver BEFORE moving the adapter
-        // into the TransportManager. The spawned task drains suppression
-        // events and downgrades the relay's reliability score (#1533 AC5).
-        let suppression_rx = adapter.take_suppression_receiver();
 
         let count = self
             .bi
             .core
             .with_transport_mut(|mgr| {
-                let _eviction = mgr.add_adapter(Box::new(adapter));
+                let _eviction = mgr.add_adapter(adapter);
                 #[allow(clippy::cast_possible_truncation)] // Bounded by connection budget.
                 let count = mgr.adapter_count() as u32;
                 count
@@ -11624,7 +11629,6 @@ impl Scp {
         &self,
         relay_url: String,
     ) -> Result<Arc<TransportManager>, ScpError> {
-        use scp_transport::native::adapter::NativeRelayAdapter;
         use scp_transport::relay::connection::{RelayUrlSource, SourcedRelayUrl};
 
         validate_relay_url(&relay_url)?;
@@ -11637,25 +11641,33 @@ impl Scp {
                     source: RelayUrlSource::Explicit,
                 };
 
-                // Establish a real WebSocket connection to the relay. Cover
-                // traffic auto-starts per adapter via `connect_sourced` with
-                // a profile — `finalize_connection` launches the cover
-                // traffic background task based on the profile's tier.
+                // Route through the instance-scoped transport selector for
+                // transparent QUIC↔WebSocket selection (spec §10.14.3 item 4;
+                // ADR-037). The discovering variant fetches the relay's
+                // advertised transports from `.well-known/scp` (spec §10.5.1)
+                // at connect time and feeds that list into the
+                // QUIC-vs-WebSocket decision — failing open to WebSocket when
+                // the relay serves no well-known. The selector is owned by the
+                // bridge instance so its per-relay QUIC-suppression and
+                // well-known caches survive across connects. Cover traffic
+                // auto-starts per adapter via the profile inside
+                // `finalize_connection`. The selector surfaces the suppression
+                // receiver (drained into reliability scoring). Mirrors the PyO3
+                // reference bridge's `transport_connect`.
                 let profile = scp_transport::profile::TransportProfile::platform_default();
-                let mut adapter = NativeRelayAdapter::connect_sourced(&sourced, Some(&profile))
+                let selector = bi.core.transport_selector();
+                let (adapter, suppression_rx) = selector
+                    .select_and_connect_discovering_with_suppression(&sourced, Some(&profile))
                     .await
                     .map_err(ScpError::from)?;
 
-                // Extract the suppression event receiver BEFORE moving the
-                // adapter into the TransportManager. The spawned task drains
-                // suppression events and downgrades the relay's reliability
-                // score.
-                let suppression_rx = adapter.take_suppression_receiver();
-
-                // Wrap the adapter in a real TransportManager for multi-relay
-                // support (ADR-012). The manager provides relay set
+                // Wrap the selected adapter in a real TransportManager for
+                // multi-relay support (ADR-012). The manager provides relay set
                 // assignment, reliability scoring, and suppression detection.
-                let manager = scp_transport::TransportManager::new(Box::new(adapter));
+                // The selector returns a `Box<dyn TransportAdapter>`; the
+                // blanket `impl TransportAdapter for Box<dyn TransportAdapter>`
+                // lets it be used where a concrete adapter is expected.
+                let manager = scp_transport::TransportManager::new(adapter);
 
                 // Install the manager on THIS instance's CoreFields — not on
                 // the process-wide DEFAULT_BRIDGE_INSTANCE.
@@ -11828,13 +11840,20 @@ impl Scp {
         };
 
         let profile = scp_transport::profile::TransportProfile::platform_default();
-        let adapter =
-            scp_transport::native::NativeRelayAdapter::connect_sourced(&sourced, Some(&profile))
-                .await
-                .map_err(|e| ScpError::Transport {
-                    msg: format!("failed to connect to relay '{relay_url}': {e}"),
-                    code: codes::TRANS_5001.to_owned(),
-                })?;
+        // Route through the instance-scoped transport selector for transparent
+        // QUIC↔WebSocket selection (spec §10.14.3 item 4; ADR-037). The
+        // discovering variant reads the relay's advertised transports from
+        // `.well-known/scp` (spec §10.5.1) at connect time to enable QUIC,
+        // failing open to WebSocket when discovery is unavailable. Mirrors the
+        // PyO3 reference bridge's `configure_relay_transport`.
+        let selector = self.inner.core.transport_selector();
+        let adapter = selector
+            .select_and_connect_discovering(&sourced, Some(&profile))
+            .await
+            .map_err(|e| ScpError::Transport {
+                msg: format!("failed to connect to relay '{relay_url}': {e}"),
+                code: codes::TRANS_5001.to_owned(),
+            })?;
 
         self.inner
             .init_context_manager_with_relay_transport(&local_did, adapter);
@@ -16074,5 +16093,116 @@ mod tests {
     fn non_pre_rotation_identity_errors_keep_generic_envelope() {
         let err: ScpError = scp_identity::IdentityError::InvalidDidFormat("bad".into()).into();
         assert_eq!(pre_rotation_code_of(err), codes::IDENT_1001);
+    }
+
+    // -----------------------------------------------------------------------
+    // Selector routing — connect sites must go through the instance selector
+    // (cross-SDK QUIC selection). The in-memory relay serves no
+    // `.well-known/scp`, so the selector's discovering connect fails open to
+    // WebSocket and still succeeds. These tests prove each uniffi connect site
+    // routes through `self.inner.core.transport_selector()` rather than dialing
+    // `NativeRelayAdapter::connect_sourced` directly.
+    //
+    // Driven via `runtime().block_on(...)` from sync `#[test]` fns because the
+    // bridge methods spawn / block on the bridge's own static runtime; a
+    // `#[tokio::test]` would nest runtimes and panic.
+    // -----------------------------------------------------------------------
+
+    /// `Scp::transport_connect` must route through the instance selector and
+    /// connect via WebSocket fallback against a relay that advertises no QUIC.
+    #[cfg(feature = "server")]
+    #[test]
+    fn transport_connect_routes_through_selector_ws_fallback() {
+        let scp = crate::scp::Scp::new();
+        // An in-memory relay serves no `.well-known/scp`; QUIC is never
+        // advertised, so a selector-routed connect must fail open to WS.
+        let relay = runtime()
+            .block_on(scp.relay_start_in_memory())
+            .expect("in-memory relay must start");
+        let relay_url = relay.relay_url();
+
+        let handle = runtime()
+            .block_on(scp.transport_connect(relay_url))
+            .expect("selector-routed connect to a no-QUIC relay must succeed via WS fallback");
+
+        assert!(
+            handle.is_connected(),
+            "handle must report connected after selector-routed connect"
+        );
+        assert_eq!(handle.adapter_count(), 1);
+
+        relay.shutdown();
+    }
+
+    /// `TransportManager::add_relay` must route through the instance selector
+    /// and add a second WS-fallback adapter to the manager.
+    #[cfg(feature = "server")]
+    #[test]
+    fn add_relay_routes_through_selector_ws_fallback() {
+        let scp = crate::scp::Scp::new();
+        let relay = runtime()
+            .block_on(scp.relay_start_in_memory())
+            .expect("in-memory relay must start");
+        let relay_url = relay.relay_url();
+
+        let handle = runtime()
+            .block_on(scp.transport_connect(relay_url.clone()))
+            .expect("initial selector-routed connect must succeed");
+        assert_eq!(handle.adapter_count(), 1);
+
+        // `add_relay` is a sync method that uses `runtime().block_on` for the
+        // connect and then `tokio::spawn`s its suppression-scoring task — the
+        // spawn needs an ambient reactor (in production the UniFFI dispatcher
+        // provides one). Run it inside `spawn_blocking` so the internal
+        // `block_on` is permitted (it runs on a blocking worker of the same
+        // runtime) and the suppression task's `tokio::spawn` sees the runtime
+        // context. This does not change what is under test: the connect still
+        // routes through the instance selector and falls open to WS.
+        let add_handle = Arc::clone(&handle);
+        let count = runtime()
+            .block_on(async move {
+                tokio::task::spawn_blocking(move || add_handle.add_relay(relay_url))
+                    .await
+                    .expect("spawn_blocking join must succeed")
+            })
+            .expect("selector-routed add_relay to a no-QUIC relay must succeed via WS fallback");
+        assert_eq!(
+            count, 2,
+            "second selector-routed adapter must be registered in the manager"
+        );
+
+        relay.shutdown();
+    }
+
+    /// `Scp::configure_relay_transport` must route through the instance selector
+    /// and install a `RelayTransportProvider` over the WS-fallback adapter.
+    #[cfg(feature = "server")]
+    #[test]
+    fn configure_relay_transport_routes_through_selector_ws_fallback() {
+        let scp = crate::scp::Scp::new();
+        let relay = runtime()
+            .block_on(scp.relay_start_in_memory())
+            .expect("in-memory relay must start");
+        let relay_url = relay.relay_url();
+
+        runtime()
+            .block_on(
+                scp.configure_relay_transport(
+                    relay_url,
+                    "did:dht:z6MkTestConfigureRelay".to_owned(),
+                ),
+            )
+            .expect(
+                "selector-routed configure_relay_transport to a no-QUIC relay must succeed via \
+                 WS fallback and install a ContextManager",
+            );
+
+        assert!(
+            scp.inner.core.has_context_manager(),
+            "ContextManager must be attached after configure_relay_transport routes through \
+             the selector"
+        );
+
+        relay.shutdown();
     }
 }

--- a/crates/scp-ffi/uniffi/src/runtime.rs
+++ b/crates/scp-ffi/uniffi/src/runtime.rs
@@ -625,7 +625,7 @@ impl UniffiBridgeInstance {
     pub fn init_context_manager_with_relay_transport(
         &self,
         local_did: &str,
-        adapter: scp_transport::native::adapter::NativeRelayAdapter,
+        adapter: Box<dyn scp_transport::TransportAdapter>,
     ) {
         if self.core.has_context_manager() {
             tracing::warn!(

--- a/crates/scp-ffi/uniffi/src/server.rs
+++ b/crates/scp-ffi/uniffi/src/server.rs
@@ -147,7 +147,14 @@ async fn auto_wire_context_manager(
     .await
     {
         Ok(adapter) => {
-            bi.init_context_manager_with_relay_transport(did, adapter);
+            // The bearer auto-wire path stays WebSocket-only (QUIC has no
+            // bearer-upgrade surface, spec §10.14.3 item 4), so it connects
+            // directly via `connect_sourced_with_bearer` rather than the QUIC
+            // selector. The shared `init_context_manager_with_relay_transport`
+            // helper now takes a `Box<dyn TransportAdapter>` (so the discovering
+            // connect sites can hand it the selector's boxed adapter); box the
+            // concrete bearer adapter here to match.
+            bi.init_context_manager_with_relay_transport(did, Box::new(adapter));
         }
         Err(e) => {
             tracing::warn!(


### PR DESCRIPTION
## Summary

Closes cross-SDK QUIC-selection parity. PR-3a/3c made QUIC selection live for the PyO3 (Python) bridge; the napi (TS) and uniffi (Swift/Kotlin) bridges still connected directly via `NativeRelayAdapter`, bypassing the selector. This routes all their connect sites through the shared per-instance `TransportSelector` (`CoreFields.transport_selector()`), mirroring the PyO3 reference exactly — so QUIC↔WebSocket selection + `.well-known/scp` discovery now work from all non-WASM SDKs.

Part of the QUIC restoration effort (`.docs/planning-sessions/planning-session-07-quic-restoration.md`, PR-3d).

## What's here

- napi + uniffi: 3 connect sites each routed through `select_and_connect_discovering[_with_suppression]`. `init_context_manager_with_relay_transport` now takes `Box<dyn TransportAdapter>` (via the blanket impl); the concrete bearer adapter is boxed.
- **Bearer path unchanged** — stays WebSocket-only (QUIC structurally unreachable), token preserved.
- Transparent (D3): no exported FFI signature change, no SDK wrapper, no capability-matrix change. Bridge-symmetry + no-bridge-globals pass (0 findings); no enforcement files touched.
- **Fixed a HIGH production panic** found in review: uniffi `add_relay` is a *sync* `#[uniffi::export]` (no ambient tokio runtime), so the suppression-scoring task's bare `tokio::spawn` panicked ("no reactor running") on the WebSocket-fallback path — the default case for Swift/Kotlin `addRelay`. Now spawns on the shared `runtime().spawn` handle (matching PyO3). The regression test was de-masked (plain `std::thread`, no `spawn_blocking`) and proven to fail with the bare spawn / pass with the fix.

## Verification

- workspace clippy (CI feature set) clean; `cargo fmt --all --check` clean
- `cargo test -p scp-ffi-napi` 212 pass; `cargo test -p scp-ffi-uniffi` 112 pass (incl. the de-masked runtime-context regression test)
- 6 new tests proving each site routes through the selector (WS fail-open)
- `bash scripts/check-bridge-symmetry.sh` → 0 findings
- Reviews: security-reviewer (bearer WS-only + token preserved, PyO3 parity, no enforcement weakened — SOUND) + bug-catcher (found & fixed the HIGH runtime-context panic; type plumbing + suppression drain correct).