### PR TITLE
test(transport): QUIC conformance suite + connection-migration coverage

### DIFF
--- a/crates/scp-testing/src/conformance/transport.rs
+++ b/crates/scp-testing/src/conformance/transport.rs
@@ -56,6 +56,20 @@ macro_rules! transport_conformance {
                     .expect("test envelope construction should succeed")
             }
 
+            /// The canonical relay blob identity: SHA-256 of the *full*
+            /// `MessagePack`-serialized outer envelope. This matches what every
+            /// SCP relay computes on PUBLISH (`blob_id = SHA-256(blob)`, where
+            /// `blob` is `OuterEnvelope::to_bytes()`), so it is the identity an
+            /// adapter's `send` returns and the one a queried/streamed envelope
+            /// must reproduce. Hashing only `encrypted_blob` would be wrong: the
+            /// relay keys on the whole envelope, not the inner ciphertext.
+            fn envelope_blob_id(env: &scp_core::envelope::OuterEnvelope) -> BlobId {
+                let bytes = env
+                    .to_bytes()
+                    .expect("envelope re-serialization should succeed");
+                BlobId::from_sha256(&bytes)
+            }
+
             #[tokio::test]
             async fn send_subscribe_roundtrip() {
                 let adapter = $factory;
@@ -65,9 +79,16 @@ macro_rules! transport_conformance {
                 // Send the envelope.
                 let blob_id = adapter.send(&envelope).await.expect("send should succeed");
 
-                // Subscribe to the routing_id with no since (backfill everything).
+                // Subscribe AFTER sending, requesting backfill from the epoch
+                // (`since = 1`) so the already-stored envelope is replayed onto
+                // the subscription stream. Per the relay contract (spec
+                // §10.14.4 / ADR-004), `since = None` means "live only — no
+                // backfill", so a None subscription opened after the send would
+                // never observe it. `since = Some(1)` selects every blob stored
+                // at epoch second 1 or later, which is every blob a test could
+                // have written.
                 let mut stream = adapter
-                    .subscribe(&routing_id, None)
+                    .subscribe(&routing_id, Some(1))
                     .await
                     .expect("subscribe should succeed");
 
@@ -79,7 +100,7 @@ macro_rules! transport_conformance {
                         .await
                     {
                         Ok(Some(TransportEvent::Envelope(env))) => {
-                            if BlobId::from_sha256(&env.encrypted_blob) == blob_id {
+                            if envelope_blob_id(&env) == blob_id {
                                 found = true;
                                 break;
                             }
@@ -91,7 +112,9 @@ macro_rules! transport_conformance {
                                 break;
                             }
                         }
-                        Ok(Some(_)) => continue,
+                        // Other transport events (errors, reconnects) are not
+                        // the envelope we are waiting for; keep draining.
+                        Ok(Some(_)) => {}
                         Ok(None) | Err(_) => break,
                     }
                 }
@@ -110,6 +133,15 @@ macro_rules! transport_conformance {
                     let bid = adapter.send(&envelope).await.expect("send should succeed");
                     blob_ids.push(bid);
                 }
+
+                // Distinct content must yield distinct blob IDs (content-addressed
+                // storage): three different payloads, three different SHA-256s.
+                let unique: std::collections::HashSet<_> = blob_ids.iter().copied().collect();
+                assert_eq!(
+                    unique.len(),
+                    blob_ids.len(),
+                    "distinct envelope payloads should produce distinct blob IDs"
+                );
 
                 // Query all to learn the first blob's timestamp-equivalent context.
                 let all = adapter
@@ -182,9 +214,7 @@ macro_rules! transport_conformance {
                     "query should return at least one envelope"
                 );
 
-                let found = results
-                    .iter()
-                    .any(|env| BlobId::from_sha256(&env.encrypted_blob) == blob_id);
+                let found = results.iter().any(|env| envelope_blob_id(env) == blob_id);
                 assert!(found, "query results should include the sent envelope");
             }
 
@@ -208,9 +238,7 @@ macro_rules! transport_conformance {
                     .await
                     .expect("query should succeed");
 
-                let still_present = results
-                    .iter()
-                    .any(|env| BlobId::from_sha256(&env.encrypted_blob) == blob_id);
+                let still_present = results.iter().any(|env| envelope_blob_id(env) == blob_id);
                 assert!(
                     !still_present,
                     "deleted envelope should not appear in query results"
@@ -247,7 +275,7 @@ macro_rules! transport_conformance {
 
                 let count = results
                     .iter()
-                    .filter(|env| BlobId::from_sha256(&env.encrypted_blob) == blob_id_1)
+                    .filter(|env| envelope_blob_id(env) == blob_id_1)
                     .count();
                 assert_eq!(
                     count, 1,

--- a/crates/scp-transport/src/quic/adapter.rs
+++ b/crates/scp-transport/src/quic/adapter.rs
@@ -951,95 +951,17 @@ fn map_subscribe_relay_message(
     clippy::too_many_lines
 )]
 mod tests {
-    use std::net::SocketAddr;
-    use std::sync::Arc;
     use std::time::Duration;
 
     use futures::StreamExt;
-    use rustls::pki_types::{CertificateDer, PrivateKeyDer, PrivatePkcs8KeyDer};
     use scp_core::envelope::create_outer_envelope;
 
     use super::*;
-    use crate::native::storage::InMemoryBlobStorage;
     use crate::profile::TransportProfile;
-    use crate::quic::lifecycle::{QuicLifecycleManager, SessionTicketStore};
-    use crate::quic::listener::{
-        QuicListener, QuicListenerConfig, QuicShutdownHandle, SCP_ALPN, build_server_config,
-    };
-    use crate::relay::rate_limit::{self, PublishRateLimiter};
-    use crate::relay::subscription::{self, SubscriptionRegistry};
-
-    // -----------------------------------------------------------------------
-    // Test helpers
-    // -----------------------------------------------------------------------
-
-    fn test_server_config() -> (quinn::ServerConfig, Vec<CertificateDer<'static>>) {
-        let _ = rustls::crypto::ring::default_provider().install_default();
-        let cert = rcgen::generate_simple_self_signed(vec!["localhost".to_string()]).unwrap();
-        let cert_der = CertificateDer::from(cert.cert);
-        let key_der = PrivatePkcs8KeyDer::from(cert.key_pair.serialize_der());
-        let server_config =
-            build_server_config(vec![cert_der.clone()], PrivateKeyDer::Pkcs8(key_der)).unwrap();
-        (server_config, vec![cert_der])
-    }
-
-    fn test_client_config(server_certs: &[CertificateDer<'static>]) -> quinn::ClientConfig {
-        let mut root_store = rustls::RootCertStore::empty();
-        for cert in server_certs {
-            root_store.add(cert.clone()).unwrap();
-        }
-        let mut tls_config = rustls::ClientConfig::builder()
-            .with_root_certificates(root_store)
-            .with_no_client_auth();
-        tls_config.alpn_protocols = vec![SCP_ALPN.to_vec()];
-
-        let quic_client_config =
-            quinn::crypto::rustls::QuicClientConfig::try_from(tls_config).unwrap();
-        quinn::ClientConfig::new(Arc::new(quic_client_config))
-    }
-
-    fn start_test_listener() -> (
-        QuicShutdownHandle,
-        SocketAddr,
-        Vec<CertificateDer<'static>>,
-        Arc<InMemoryBlobStorage>,
-        SubscriptionRegistry,
-    ) {
-        let (server_config, certs) = test_server_config();
-        let storage = Arc::new(InMemoryBlobStorage::new());
-        let subscriptions = subscription::new_registry();
-        let publish_rate_limiter = PublishRateLimiter::new(100);
-        let connection_tracker = rate_limit::new_connection_tracker();
-
-        let config = QuicListenerConfig {
-            bind_addr: SocketAddr::from(([127, 0, 0, 1], 0)),
-            delivery_jitter_ms: 0,
-            ..QuicListenerConfig::default()
-        };
-
-        let listener = QuicListener::new(
-            config,
-            Arc::clone(&storage),
-            Arc::clone(&subscriptions),
-            publish_rate_limiter,
-            connection_tracker,
-        );
-        let (handle, addr) = listener.start(server_config).unwrap();
-
-        (handle, addr, certs, storage, subscriptions)
-    }
-
-    fn test_lifecycle() -> QuicLifecycleManager {
-        QuicLifecycleManager::new(TransportProfile::Desktop, SessionTicketStore::new())
-    }
-
-    async fn connect_adapter(addr: SocketAddr, certs: &[CertificateDer<'static>]) -> QuicAdapter {
-        let client_config = test_client_config(certs);
-        let lifecycle = test_lifecycle();
-        QuicAdapter::connect(addr, "localhost", client_config, lifecycle)
-            .await
-            .expect("failed to connect QuicAdapter")
-    }
+    // The QUIC test harness (listener + matching client) is shared with the
+    // out-of-crate conformance/migration integration tests; see
+    // `crate::quic::test_support` for why it lives in `src/`.
+    use crate::quic::test_support::{connect_adapter, start_test_listener, test_lifecycle};
 
     fn test_envelope() -> OuterEnvelope {
         create_outer_envelope(&[0xAA; 32], None, 3600, vec![0x01, 0x02, 0x03]).unwrap()

--- a/crates/scp-transport/src/quic/mod.rs
+++ b/crates/scp-transport/src/quic/mod.rs
@@ -32,6 +32,15 @@ pub mod lifecycle;
 pub mod listener;
 pub mod streams;
 
+/// Reusable QUIC test harness (in-process listener + matching client).
+///
+/// `#[doc(hidden)]` test scaffolding shared between the in-crate adapter tests
+/// and the out-of-crate conformance/migration integration tests. Not part of
+/// the supported public API. See the module docs for the rationale on why it
+/// lives in `src/` rather than a `tests/` module.
+#[doc(hidden)]
+pub mod test_support;
+
 pub use adapter::QuicAdapter;
 pub use lifecycle::{
     ConnectionMigrationEvent, QuicKeepaliveConfig, QuicLifecycleManager, ReconnectBackoff,

--- a/crates/scp-transport/src/quic/test_support.rs
+++ b/crates/scp-transport/src/quic/test_support.rs
@@ -1,0 +1,245 @@
+//! Reusable QUIC test harness (in-process listener + matching client).
+//!
+//! These helpers spin up a real `quinn` QUIC listener bound to a loopback
+//! ephemeral port with a self-signed certificate, plus a [`QuicAdapter`] client
+//! configured to trust exactly that certificate. They back both the in-module
+//! `QuicAdapter` integration tests (`quic/adapter.rs`) and the out-of-crate
+//! conformance / migration integration tests (`tests/quic_conformance.rs`,
+//! `tests/quic_migration.rs`).
+//!
+//! # Why this lives in `src/` rather than a `tests/` module
+//!
+//! Cargo integration tests compile the crate as an *external* dependency, so
+//! they can only reach `pub` items. The harness therefore has to be a public
+//! module of the crate. It is gated on `#[cfg(feature = "quic")]` (the same
+//! gate as the QUIC adapter it exercises) and marked `#[doc(hidden)]` so it
+//! never appears in the public API surface — it is test scaffolding, not a
+//! supported entry point.
+//!
+//! The helpers are intentionally permissive about `unwrap`/`expect`: they are
+//! test fixtures whose failure should abort the test loudly.
+#![allow(clippy::unwrap_used, clippy::expect_used, clippy::panic)]
+
+use std::net::SocketAddr;
+use std::sync::Arc;
+
+use rustls::pki_types::{CertificateDer, PrivateKeyDer, PrivatePkcs8KeyDer};
+
+use crate::native::storage::InMemoryBlobStorage;
+use crate::profile::TransportProfile;
+use crate::quic::adapter::QuicAdapter;
+use crate::quic::lifecycle::{QuicLifecycleManager, SessionTicketStore};
+use crate::quic::listener::{
+    QuicListener, QuicListenerConfig, QuicShutdownHandle, SCP_ALPN, build_server_config,
+};
+use crate::relay::rate_limit::{self, PublishRateLimiter};
+use crate::relay::subscription::{self, SubscriptionRegistry};
+
+/// Builds a self-signed `localhost` server config and returns it alongside the
+/// certificate DER so a client can be configured to trust exactly this cert.
+#[must_use]
+pub fn test_server_config() -> (quinn::ServerConfig, Vec<CertificateDer<'static>>) {
+    // Idempotent: harmless if another test already installed the provider.
+    let _ = rustls::crypto::ring::default_provider().install_default();
+    let cert = rcgen::generate_simple_self_signed(vec!["localhost".to_string()]).unwrap();
+    let cert_der = CertificateDer::from(cert.cert);
+    let key_der = PrivatePkcs8KeyDer::from(cert.key_pair.serialize_der());
+    let server_config =
+        build_server_config(vec![cert_der.clone()], PrivateKeyDer::Pkcs8(key_der)).unwrap();
+    (server_config, vec![cert_der])
+}
+
+/// Builds a `quinn::ClientConfig` trusting exactly the supplied server certs.
+///
+/// Uses a private root store (NOT the Web PKI bundle) with the SCP ALPN
+/// negotiated. This is the test counterpart to the production
+/// `build_quic_client_config`, which uses Web PKI roots.
+#[must_use]
+pub fn test_client_config(server_certs: &[CertificateDer<'static>]) -> quinn::ClientConfig {
+    let mut root_store = rustls::RootCertStore::empty();
+    for cert in server_certs {
+        root_store.add(cert.clone()).unwrap();
+    }
+    let mut tls_config = rustls::ClientConfig::builder()
+        .with_root_certificates(root_store)
+        .with_no_client_auth();
+    tls_config.alpn_protocols = vec![SCP_ALPN.to_vec()];
+
+    let quic_client_config = quinn::crypto::rustls::QuicClientConfig::try_from(tls_config).unwrap();
+    quinn::ClientConfig::new(Arc::new(quic_client_config))
+}
+
+/// Starts an in-process QUIC listener bound to `127.0.0.1:0` (ephemeral port)
+/// backed by [`InMemoryBlobStorage`] with delivery jitter disabled.
+///
+/// Returns the shutdown handle, the bound address, the server cert chain (for
+/// configuring a matching client), the shared blob storage, and the shared
+/// subscription registry.
+///
+/// Must be called from within a tokio runtime context: the listener spawns its
+/// accept loop via [`tokio::spawn`].
+#[must_use]
+pub fn start_test_listener() -> (
+    QuicShutdownHandle,
+    SocketAddr,
+    Vec<CertificateDer<'static>>,
+    Arc<InMemoryBlobStorage>,
+    SubscriptionRegistry,
+) {
+    let (server_config, certs) = test_server_config();
+    let storage = Arc::new(InMemoryBlobStorage::new());
+    let subscriptions = subscription::new_registry();
+    let publish_rate_limiter = PublishRateLimiter::new(100);
+    let connection_tracker = rate_limit::new_connection_tracker();
+
+    let config = QuicListenerConfig {
+        bind_addr: SocketAddr::from(([127, 0, 0, 1], 0)),
+        delivery_jitter_ms: 0,
+        ..QuicListenerConfig::default()
+    };
+
+    let listener = QuicListener::new(
+        config,
+        Arc::clone(&storage),
+        Arc::clone(&subscriptions),
+        publish_rate_limiter,
+        connection_tracker,
+    );
+    let (handle, addr) = listener.start(server_config).unwrap();
+
+    (handle, addr, certs, storage, subscriptions)
+}
+
+/// A desktop-profile lifecycle manager with a fresh, empty session ticket store.
+#[must_use]
+pub fn test_lifecycle() -> QuicLifecycleManager {
+    QuicLifecycleManager::new(TransportProfile::Desktop, SessionTicketStore::new())
+}
+
+/// Connects a [`QuicAdapter`] to the given address, trusting `certs`, using a
+/// fresh desktop lifecycle. Panics if the connection cannot be established.
+#[must_use]
+pub async fn connect_adapter(addr: SocketAddr, certs: &[CertificateDer<'static>]) -> QuicAdapter {
+    let client_config = test_client_config(certs);
+    let lifecycle = test_lifecycle();
+    QuicAdapter::connect(addr, "localhost", client_config, lifecycle)
+        .await
+        .expect("failed to connect QuicAdapter")
+}
+
+/// Connects a [`QuicAdapter`] to `addr` (trusting `certs`) over a client
+/// [`quinn::Endpoint`] that is **returned to the caller** alongside the adapter.
+///
+/// [`connect_adapter`] hides the endpoint inside `QuicAdapter::connect`, which
+/// is the right shape for the conformance suite but useless for a migration
+/// test: exercising connection migration requires calling
+/// [`quinn::Endpoint::rebind`] on the *client* endpoint to swap its local UDP
+/// socket. This helper therefore builds the endpoint explicitly (mirroring
+/// `QuicAdapter::connect`'s loopback-IPv4 bind), performs the handshake, and
+/// wraps the resulting connection via [`QuicAdapter::from_connection`] so the
+/// adapter and the endpoint that drives it are both available.
+///
+/// # Panics
+///
+/// Panics if the client endpoint cannot bind or the handshake fails — both
+/// abort the test.
+#[must_use]
+pub async fn connect_adapter_with_endpoint(
+    addr: SocketAddr,
+    certs: &[CertificateDer<'static>],
+) -> (QuicAdapter, quinn::Endpoint) {
+    // Bind the client to the loopback IPv4 wildcard, matching the IPv4
+    // listener address family that `start_test_listener` binds.
+    let mut endpoint =
+        quinn::Endpoint::client(SocketAddr::from((std::net::Ipv4Addr::UNSPECIFIED, 0)))
+            .expect("client endpoint should bind");
+    endpoint.set_default_client_config(test_client_config(certs));
+
+    let connection = endpoint
+        .connect(addr, "localhost")
+        .expect("connect should be accepted")
+        .await
+        .expect("handshake should complete");
+
+    let adapter = QuicAdapter::from_connection(connection, test_lifecycle());
+    (adapter, endpoint)
+}
+
+/// Builds a fully connected [`QuicAdapter`] backed by a fresh in-process QUIC
+/// listener, returning it from a **synchronous** call.
+///
+/// # Why this exists
+///
+/// The `transport_conformance!` macro evaluates its factory expression
+/// *synchronously* — once per generated `#[tokio::test]` — and never `.await`s
+/// it (`let adapter = $factory;`). QUIC setup, however, is inherently async:
+/// binding a `quinn::Endpoint`, spawning the listener accept loop, and
+/// completing the TLS 1.3 handshake all require a tokio runtime. A naive
+/// `Handle::current().block_on(...)` inside the factory would panic (you cannot
+/// block the current-thread test runtime on itself), and `block_in_place`
+/// requires the multi-threaded flavor the macro does not use.
+///
+/// This helper therefore drives the entire async setup on a **dedicated
+/// background OS thread** running its own current-thread runtime. That runtime
+/// owns the listener endpoint *and* the client endpoint, so their packet
+/// drivers keep running there. The returned [`QuicAdapter`] holds a
+/// `quinn::Connection`, which is `Send` and can be polled from the *test's*
+/// runtime in the macro body; quinn drives the connection's actual I/O via the
+/// endpoint drivers on the background runtime. This cross-runtime split is a
+/// supported quinn usage pattern.
+///
+/// # Lifetime / leak rationale
+///
+/// The background runtime, the listener shutdown handle, and the storage Arc
+/// are intentionally **leaked** (`Box::leak` / `std::mem::forget`) so they live
+/// for the remainder of the test binary. If they dropped at the end of this
+/// function, the endpoints would close and the connection would die before the
+/// conformance test could use it. The `combined_conformance` storage harness
+/// leaks its `TempDir` for the same reason: a per-test fixture that must
+/// outlive the synchronous factory call. The OS process reclaims everything on
+/// exit, so this is a bounded, test-only leak (one listener + one runtime per
+/// conformance test case).
+///
+/// # Panics
+///
+/// Panics if the background runtime cannot be built, the listener fails to
+/// bind, or the client handshake fails — all of which should abort the test.
+#[must_use]
+pub fn conformance_quic_adapter() -> QuicAdapter {
+    // Channel to hand the connected adapter back to the caller's (test) thread.
+    let (tx, rx) = std::sync::mpsc::channel::<QuicAdapter>();
+
+    // A dedicated background OS thread owns a current-thread runtime that builds
+    // and then *keeps driving* both endpoints. We never join this thread: it
+    // parks forever inside `block_on`, so the listener + client endpoint packet
+    // drivers (spawned onto this runtime) keep running for the whole test. The
+    // thread, its runtime, listener handle, and storage are all effectively
+    // leaked for the test binary's lifetime — the OS reclaims them at exit. This
+    // mirrors the `combined_conformance` storage harness, which leaks its
+    // `TempDir` so a per-test fixture outlives the synchronous factory call.
+    std::thread::spawn(move || {
+        let runtime = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .expect("failed to build background QUIC runtime");
+
+        runtime.block_on(async move {
+            let (handle, addr, certs, storage, _subs) = start_test_listener();
+            let adapter = connect_adapter(addr, &certs).await;
+
+            // Hand the connected adapter to the test thread.
+            tx.send(adapter)
+                .expect("conformance adapter receiver dropped before setup completed");
+
+            // Keep the listener up and storage alive for the test's lifetime;
+            // never shut down. Park forever so this current-thread runtime keeps
+            // driving the listener accept loop and both endpoints' packet I/O.
+            let _keep_listener = handle;
+            let _keep_storage = storage;
+            std::future::pending::<()>().await;
+        });
+    });
+
+    rx.recv()
+        .expect("background QUIC setup thread terminated before producing an adapter")
+}

--- a/crates/scp-transport/tests/quic_conformance.rs
+++ b/crates/scp-transport/tests/quic_conformance.rs
@@ -1,0 +1,20 @@
+//! QUIC transport adapter conformance.
+//!
+//! Runs the shared [`transport_conformance!`](scp_testing::transport_conformance)
+//! suite (6 cases, spec §16.12.1 / ADR-005) against a real in-process `quinn`
+//! QUIC listener + matching [`QuicAdapter`](scp_transport::quic::QuicAdapter)
+//! client. This is the Tier-1 conformance gate for the QUIC adapter
+//! (spec §10.5.1: "Must pass `transport_conformance!()`").
+//!
+//! The adapter factory is the synchronous
+//! [`conformance_quic_adapter`](scp_transport::quic::test_support::conformance_quic_adapter)
+//! helper: the macro evaluates its factory expression synchronously (once per
+//! generated `#[tokio::test]`), but QUIC setup is inherently async, so the
+//! helper drives listener+client bring-up on a dedicated background runtime and
+//! hands back a connected adapter. See `test_support` for the full rationale.
+
+#![cfg(feature = "quic")]
+
+use scp_transport::quic::test_support::conformance_quic_adapter;
+
+scp_testing::transport_conformance!(conformance_quic_adapter());

--- a/crates/scp-transport/tests/quic_migration.rs
+++ b/crates/scp-transport/tests/quic_migration.rs
@@ -1,0 +1,157 @@
+//! QUIC connection-migration survival.
+//!
+//! Exercises QUIC's connection-migration property (RFC 9000 §9, spec §10.14):
+//! when the client's local UDP address changes, the connection survives because
+//! the QUIC connection ID decouples the connection from the UDP 4-tuple. A
+//! WebSocket (TCP) connection would be severed by the same event.
+//!
+//! ## What this test actually verifies (honest scope)
+//!
+//! - A live subscription stream and the bidirectional request/response streams
+//!   (`send`) keep working after the **client** endpoint swaps its local UDP
+//!   socket via [`quinn::Endpoint::rebind`].
+//! - `rebind` genuinely changes the client's local socket address: the
+//!   post-rebind `local_addr()` differs from the pre-rebind one, so the
+//!   server observes packets arriving from a new source `ip:port` (the migration
+//!   trigger), and the in-flight `quinn::Connection` is migrated onto it.
+//!
+//! ## What this test does NOT claim
+//!
+//! - It does not exercise a realistic multi-hop network path, NAT translation,
+//!   or an adversarial path-validation/amplification scenario. Both endpoints
+//!   are on loopback; only the client's *local* address changes. quinn still
+//!   runs RFC 9000 §9.3 path validation (a `PATH_CHALLENGE`/`PATH_RESPONSE`
+//!   round-trip) against the new client address before fully migrating, so the
+//!   survival demonstrated here is the connection-ID-based migration mechanism,
+//!   not the network conditions that trigger it in production.
+//! - It does not assert anything about the server-side (relay) endpoint
+//!   rebinding; only the client migrates.
+
+#![cfg(feature = "quic")]
+#![allow(clippy::unwrap_used, clippy::expect_used, clippy::panic)]
+
+use std::net::{SocketAddr, UdpSocket};
+use std::time::Duration;
+
+use futures::StreamExt;
+use scp_core::envelope::outer::create_outer_envelope;
+use scp_transport::quic::test_support::{connect_adapter_with_endpoint, start_test_listener};
+use scp_transport::traits::{BlobId, RoutingId, TransportAdapter, TransportEvent};
+
+/// SHA-256 of the full MessagePack-serialized envelope — the blob identity a
+/// relay assigns on PUBLISH and the one a delivered envelope must reproduce.
+fn envelope_blob_id(env: &scp_core::envelope::OuterEnvelope) -> BlobId {
+    let bytes = env
+        .to_bytes()
+        .expect("envelope re-serialization should succeed");
+    BlobId::from_sha256(&bytes)
+}
+
+/// Drains up to `max_events` events from a subscription stream (2s per-event
+/// timeout) looking for an `Envelope` whose blob identity equals `target`.
+/// Returns `true` if found. Ignores non-Envelope events (e.g. `Reconnected`
+/// emitted around a migration) rather than treating them as failures.
+async fn await_envelope(
+    stream: &mut (impl StreamExt<Item = TransportEvent> + Unpin),
+    target: BlobId,
+    max_events: usize,
+) -> bool {
+    for _ in 0..max_events {
+        match tokio::time::timeout(Duration::from_secs(2), stream.next()).await {
+            Ok(Some(TransportEvent::Envelope(env))) => {
+                if envelope_blob_id(&env) == target {
+                    return true;
+                }
+            }
+            // Migration may surface transient transport events; keep draining.
+            Ok(Some(_)) => {}
+            Ok(None) | Err(_) => return false,
+        }
+    }
+    false
+}
+
+/// A live subscription survives the client migrating to a new local UDP socket.
+///
+/// 1. Establish a QUIC connection and a live (`since = None`) subscription.
+/// 2. Publish envelope #1, confirm it arrives on the subscription (baseline:
+///    the live path works before migration).
+/// 3. `rebind` the client endpoint onto a fresh loopback UDP socket and assert
+///    the local address actually changed.
+/// 4. Publish envelope #2 over the *same* connection (now driven by the new
+///    socket) and confirm it still arrives on the *same* subscription stream —
+///    proving the connection and its streams survived the address change.
+#[tokio::test]
+async fn subscription_survives_client_socket_rebind() {
+    let (handle, addr, certs, _storage, _subs) = start_test_listener();
+
+    let (adapter, endpoint) = connect_adapter_with_endpoint(addr, &certs).await;
+
+    let routing_id = RoutingId::new([0x5A; 32]);
+
+    // Live subscription (no backfill) — only blobs published *after* this point
+    // are delivered, so each publish below is unambiguously a post-subscription
+    // delivery over the live stream.
+    let mut stream = adapter
+        .subscribe(&routing_id, None)
+        .await
+        .expect("subscribe should succeed");
+
+    // (2) Baseline: publish before migration and confirm live delivery.
+    let env_before =
+        create_outer_envelope(routing_id.as_bytes(), None, 3600, b"pre-migration".to_vec())
+            .expect("envelope construction should succeed");
+    let blob_before = adapter
+        .send(&env_before)
+        .await
+        .expect("pre-migration send should succeed");
+    assert!(
+        await_envelope(&mut stream, blob_before, 10).await,
+        "subscription should deliver the pre-migration envelope (baseline live delivery)"
+    );
+
+    // (3) Migrate the client: bind a brand-new UDP socket on loopback and swap
+    // the endpoint onto it. This changes the client's source ip:port — the
+    // exact event QUIC connection migration is designed to survive.
+    let addr_before = endpoint
+        .local_addr()
+        .expect("endpoint should have a local addr");
+    let new_socket = UdpSocket::bind(SocketAddr::from((std::net::Ipv4Addr::LOCALHOST, 0)))
+        .expect("rebind socket should bind");
+    let new_socket_addr = new_socket
+        .local_addr()
+        .expect("new socket should have a local addr");
+    endpoint.rebind(new_socket).expect("rebind should succeed");
+    let addr_after = endpoint
+        .local_addr()
+        .expect("endpoint should have a local addr");
+
+    assert_ne!(
+        addr_before, addr_after,
+        "rebind must change the client's local address (before={addr_before}, after={addr_after})"
+    );
+    assert_eq!(
+        addr_after, new_socket_addr,
+        "endpoint local address should now be the rebound socket's address"
+    );
+
+    // (4) Post-migration: publish over the SAME connection (now driven by the
+    // new socket) and confirm the SAME subscription stream still delivers it.
+    let env_after = create_outer_envelope(
+        routing_id.as_bytes(),
+        None,
+        3600,
+        b"post-migration".to_vec(),
+    )
+    .expect("envelope construction should succeed");
+    let blob_after = adapter
+        .send(&env_after)
+        .await
+        .expect("post-migration send should succeed over the migrated connection");
+    assert!(
+        await_envelope(&mut stream, blob_after, 10).await,
+        "subscription stream should survive the client socket rebind and deliver the post-migration envelope"
+    );
+
+    handle.shutdown();
+}


### PR DESCRIPTION
## Summary

Adds the QUIC transport conformance suite and a connection-migration survival test, closing SCP-255 AC6 and SCP-256 AC2. Part of the QUIC restoration effort (`.docs/planning-sessions/planning-session-07-quic-restoration.md`, PR-4a).

## What's here

- **`tests/quic_conformance.rs`** — invokes `scp_testing::transport_conformance!` against an in-process QUIC listener+client (the first-ever invocation of that macro). 6/6 cases pass: send/subscribe roundtrip, backfill-with-since, unsubscribe-stops-delivery, query-returns-stored, delete-removes-blob, dedup-by-blob-id.
- **`tests/quic_migration.rs`** — `Endpoint::rebind` changes the client's local UDP address; asserts the active subscription stream survives and delivers a post-rebind publish on the same migrated connection (RFC 9000 §9 connection-ID migration). Honestly scoped to loopback client-side local-addr change (not multi-hop/NAT). 10/10 non-flaky.
- **Harness extraction** — the QUIC test helpers moved from `quic/adapter.rs` `#[cfg(test)]` into a reusable `quic/test_support.rs` so both the bespoke adapter tests and the macro use one harness. Byte-equivalent; no production code changed.

## Fix to the shared conformance contract (`scp-testing`)

Invoking `transport_conformance!` for the first time exposed **two latent bugs in the macro** (it was defined but never called, so never validated — it would have failed for *any* conforming adapter):
1. **Blob identity** — compared `SHA-256(encrypted_blob)` (inner ciphertext field) to the relay's `blob_id`, but every SCP relay computes `blob_id = SHA-256(OuterEnvelope::to_bytes())` (the full envelope). Verified against the QUIC listener, native client integrity check, and adapters. Could never have matched.
2. **Backfill** — used `since=None` (live-only, no backfill) where the already-stored blob was expected; changed to `since=Some(1)`.
The fix flows down to the shared contract (artifact-flow invariant); it strengthens (not weakens) the assertions.

## Verification

- `cargo test -p scp-transport --features quic` → 772 pass, 0 fail (conformance 6/6, migration 1/1)
- conformance 8/8 + migration 10/10 repeated runs — non-flaky
- `cargo clippy -p scp-transport -p scp-testing --features quic --all-targets -- -D warnings` clean; default + workspace clippy clean
- Reviews: bug-catcher (×1, deep) — confirmed the macro fix matches real relay blob-id semantics across all relays, harness extraction byte-equivalent, migration test genuinely proves the property. Ship.