### PR TITLE
docs(prd): reconcile QUIC transport stories with merged code + record planning session

### DIFF
--- a/.docs/planning-sessions/planning-session-07-quic-restoration.md
+++ b/.docs/planning-sessions/planning-session-07-quic-restoration.md
@@ -1,0 +1,112 @@
+# SCP Planning Session 07 — QUIC Transport Restoration and Integration
+
+**Date:** June 1–2, 2026
+**Scope:** Restore the broken `quic` cargo feature in `crates/scp-transport`, close the integration gaps the compile-break masked, and reconcile the affected PRD stories.
+**Status:** Executing — PR-1 in merge queue; PR-2/3a/3b/4 pending. Decisions D1–D6 locked.
+**Provenance:** ADR-037 (`.docs/adrs/phase-2.md`, Status: Decided, QUIC = Tier 1); spec §10.14 / §10.14.2 / §10.14.3 / §10.5.1 (`.docs/specs/10-infrastructure-and-self-hosting.md`); PRD stories SCP-254..257 (`.docs/prds/transport-expansion.json`).
+
+## Progress Log
+
+| PR | Status | Notes |
+|----|--------|-------|
+| PR-1 Restore lifecycle types | ✅ Merged (#1742) | Reviewed clean (cryptographer + bug-catcher). Scope grew: see "Modification 1". |
+| PR-2 Green + gate optional transports | ✅ Merged (#1745) | Greened http3/udp/coap + widened gate to all four. Exposed + fixed flaky loopback DTLS tests (see Modification 6). |
+| PR-3b Relay listener wiring | ✅ Merged (#1743) | One MEDIUM bug found & fixed (advertise-on-bind-failure). Carries scp-transport crypto-provider fix (Modification 5). |
+| PR-3a Native selection | 🟡 In merge queue (#1746) | Reviewed (security SOUND + bug-catcher ×2). Fixed a HIGH IPv4-only-bind bug + 0-RTT doc wording + userinfo strip. **Selector built but not yet fed** — see PR-3c. |
+| PR-3c Plumb transport discovery | ⏳ Pending (user-approved) | Fetch `.well-known/scp` transports at connect → feed selector so QUIC is actually selected end-to-end (transparent, D3). Starts after PR-3a. |
+| PR-4 Conformance + PRD reconciliation | ⏳ Pending | Includes committing this plan artifact. |
+
+- **Modification 6 (flaky DTLS tests — discovered via PR-2's gate):** PR-2's new gate ran the udp DTLS tests in CI for the first time ever; two flaked under CI parallelism. Root cause: the test DTLS client blocks the full 10s read timeout per `recv` (OpenSSL blocking DTLS can't fire its retransmission timer mid-`recv`), so a `SO_REUSEPORT`-misrouted loopback handshake compounds to ~150s and exhausts the 3-retry limit. Fix (PR-2): added `connect_with_timeout` (production `connect` unchanged at 10s); test client uses a 1.5s per-`recv` timeout — which MUST stay above OpenSSL's ~1s DTLS1.2 retransmission floor (400ms made every handshake abort) — with 8 attempts + backoff. Verified 20/20 green at `--test-threads 16`. The gate worked as intended: it caught real rot on first contact.
+- **Modification 7 (PR-3c split):** PR-3a delivers the selector + QUIC client (verified, secure) but leaves QUIC unselected because the advertised-transports list isn't available at the FFI connect sites. User approved closing this in a follow-up PR-3c that fetches `.well-known/scp` transports at connect and feeds the selector (transparent — FFI does discovery, no signature change per D3).
+
+- **Modification 4 (PR-2 scope — user-approved 2026-06-02):** PR-2's CI gate exposed that **http3, udp, and coap are also rotting** (same class as the quic break): `coap` won't compile standalone (its feature omits `udp` but `coap/adapter.rs` uses `crate::udp::dtls`), `http3` has a real `Http3Server::bind()` arity break **and** the same rustls dual-provider panic latent in `http3/config.rs:357` (bare `ServerConfig::builder()`), and `udp`/`http3` carry clippy debt. User chose "green all + widen gate": PR-2 now greens all three and widens the CI gate to clippy+test `quic,http3,udp,coap`. The initial quic-only ci.yml step (commit `ccb45e022`) is folded into this expanded PR.
+- **Modification 5 (crypto-provider standardization):** PR-3b fixes a rustls dual-provider panic — `instant-acme` pulls `aws-lc-rs` alongside SCP's `ring`, making the bare `ServerConfig::builder()` process-default ambiguous (panics). Fix: pin `quinn` off `platform-verifier`, name `ring` explicitly via `builder_with_provider`. **Forward constraint for PR-3a:** since `platform-verifier` is dropped, the QUIC *client* config must supply its own `RootCertStore`/`ServerCertVerifier` via `builder_with_provider(ring)` — never an implicit/permissive fallback. The identical bare-builder latent panic at `http3/config.rs:357` is fixed in the expanded PR-2.
+
+### Operational incident (worktree contention)
+
+During parallel coder dispatch, agents given `isolation: "worktree"` had their **absolute-path Read/Edit/Write operations leak into the repo root** (`/Users/alec/Developer/limn/scp`, checked out to another session's `remediation/r3-wasm` branch) instead of their own worktree, because the root path prefix is shared. Agents self-detected and reverted; no deliverable damage (commits landed correctly on their own branches; main worktree left with only untracked files). **Mitigation for remaining dispatches:** every coder prompt now mandates worktree-absolute paths and a `git -C <worktree> rev-parse --abbrev-ref HEAD` branch-confirmation guard before editing. Reviewers are likewise told to read only from the worktree path.
+
+### Modifications discovered during execution
+
+- **Modification 1 (PR-1 scope):** Greening `--features quic` for clippy surfaced **pre-existing** lints in `quic/adapter.rs` and `quic/listener.rs` that had never run (CI never built the feature). PR-1 therefore also includes behavior-preserving clippy fixes beyond the pure restore: duration-unit constructors (`from_secs`→`from_hours`/`from_mins`, arithmetically identical), `too_many_lines` extraction of the subscribe read loop into a free `async fn` (verbatim body — same extraction reverted from #1734, now justified because PR-2 makes CI clippy the feature), doc backticks, one `map_or_else`. #1734's registration-leak fix is untouched. Verified behavior-preserving by bug-catcher (byte-equivalent extraction) and cryptographer (zero drift in crypto bodies).
+- **Modification 2 (toolchain):** The plan assumed "signatures match exactly" (quinn 0.11.9 / rustls 0.23.37 unchanged — confirmed true). It did NOT anticipate that rustc/clippy **1.95.0** introduced new *style* lints postdating the deleted code; these drove Modification 1. No API drift; only lint surface.
+- **Modification 3 (PR-1 file count):** Plan listed PR-1 as touching only `lifecycle.rs`. Actual: `lifecycle.rs` + `adapter.rs` + `listener.rs` (per Modification 1). All within `scp-transport`, all behavior-preserving.
+
+### Corrections to the original investigation (now reflected below)
+
+- Spec citation for probe/fallback is **§10.14.3 item 4**, not "§10.14.3.4" (no such subsection exists). Advertisement format is **§10.5.1**.
+- The "~270 lines deleted" figure is closer to **~530 lines restored** (the four type bodies + impls + consts + the `ClientSessionStore` impl); `git show --stat` for PR-1 shows +561 in lifecycle.rs.
+
+---
+
+## 1. Root Cause
+
+The `quic` feature does not compile. Commit `b288d64c5` ("production readiness — implement 28 remaining items") deleted ~270 lines of real, working type definitions from `crates/scp-transport/src/quic/lifecycle.rs` while correctly extracting `ReconnectBackoff` into `crates/scp-transport/src/backoff.rs` — but left every consumer (`QuicLifecycleManager`, its methods, ~30 tests, the `quic/mod.rs` re-export, and `quic/adapter.rs` which holds `RwLock<QuicLifecycleManager>`).
+
+Deleted types (recoverable **verbatim** from `b516c46df:crates/scp-transport/src/quic/lifecycle.rs`, lines ~44–311):
+`SessionTicket`, `SessionTicketStore` (+ `SessionTicketStoreInner` + `impl rustls::client::ClientSessionStore`), `ConnectionMigrationEvent`, `QuicKeepaliveConfig`, plus consts `DEFAULT_TICKET_STORE_CAPACITY`, `MAX_TLS13_TICKETS_PER_SERVER`, `DEFAULT_KEEPALIVE_INTERVAL` and the free fn `evict_oldest`.
+
+CI never caught it: `.github/workflows/ci.yml` tests `scp-transport` only with `--features combined,local-cache`; no workflow builds `--features quic` or `--all-features`. The feature has been un-compilable since `b288d64c5` and CI has been structurally blind to it.
+
+## 2. Gaps the Compile-Break Masked
+
+1. **`QuicListener` is never started by the node binary.** `scp-node` serves only WebSocket; `QuicListener::start` is called only in unit tests. SCP-257 AC1 ("relay accepts QUIC on the same TLS port") is unmet at the binary level.
+2. **No native QUIC↔WebSocket selection.** The QUIC adapter exists but nothing selects it. The only transparent fallback heuristic that ships is `webtransport/fallback.rs` (WebTransport→WebSocket, browser path). §10.14.3 item 4 (native probe/fallback) has no implementing code and no story.
+3. **`transport_conformance!` is invoked nowhere** in the repo — not even for the native adapter.
+4. **No cross-transport integration test** (SCP-257 AC6: publish via WebSocket → deliver to QUIC subscriber).
+5. **`.well-known/scp` advertises `"quic"`** (`scp-node/src/well_known.rs`) — a transport the binary doesn't actually serve. Live inconsistency.
+
+NAT/STUN/ICE selection (`crates/scp-transport/src/nat/`, `webrtc/`, `scp-media`) is a **separate subsystem** (WebRTC media, peer-to-peer DTLS-SRTP) and is out of scope.
+
+## 3. Decisions (locked)
+
+| # | Decision | Resolution | Basis |
+|---|----------|-----------|-------|
+| D1 | Probe preference order | Prefer QUIC when advertised | §10.5.1 (client SHOULD prefer QUIC) |
+| D2 | Probe timeout | 3 seconds, fall back on timeout | §10.14.3 item 4 |
+| D3 | Selection surface | **Internal / transparent** — below the `TransportAdapter` boundary; no FFI/SDK/capability-matrix change | mirrors existing `webtransport/fallback.rs` pattern |
+| D4 | Client TLS trust | Reuse relay TLS trust model (`relay/connection.rs`); custom verifier for local `ws://` test relays | §10.14.3 (relay cert covers both protocols) |
+| D5 | PR-3 split | Split into PR-3a (client selection) and PR-3b (relay listener wiring) | different crates, independent acceptance |
+| D6 | Story status | Set SCP-256 and SCP-257 → `in-progress` (were falsely `done`); add new stories for native-selection and listener-wiring | artifact-flow: corrections flow down from spec |
+
+**Removal was rejected:** the one-way artifact-flow invariant forbids deleting spec-mandated behavior without first amending a Decided Tier-1 ADR.
+
+## 4. PR Decomposition (strictly ordered)
+
+### PR-1 — Restore lifecycle types + green the `quic` feature  — 🟡 IN MERGE QUEUE (#1742)
+*Done: restored all four types verbatim; feature builds + clippies clean + 687 lib/38 conformance/4 doc tests pass under `--features quic`. Also fixed pre-existing `adapter.rs`/`listener.rs` clippy debt (see Modification 1). Reviewed clean by cryptographer + bug-catcher. Branch `fix/restore-quic-lifecycle-types`, commit `8d7bf38c9`.*
+- Re-insert the four deleted types into `lifecycle.rs` verbatim from `b516c46df` (lines ~44–311).
+- **Do NOT** re-add `use rand::Rng` (lives only in `backoff.rs`) or restore `ReconnectBackoff` (re-exported from `backoff.rs`).
+- Existing imports in `lifecycle.rs` already match the restored types (the 8 current unused-import warnings map 1:1).
+- Green: `cargo clippy -p scp-transport --features quic --all-targets -- -D warnings` and `cargo test -p scp-transport --features quic`.
+
+### PR-2 — CI coverage for optional transports
+- Add to `.github/workflows/ci.yml`: clippy + test steps for `--features quic` (and `http3,udp,coap` where they co-compile; split per-feature if link conflicts via openssl/quinn).
+- ci.yml is not an enforcement file; additive coverage is permitted.
+
+### PR-3a — Native QUIC probe-and-fallback selection (transparent)
+- New `crates/scp-transport/src/selection.rs`: `TransportSelector` / `select_and_connect`, modeled on `webtransport/fallback.rs`. Probe QUIC (3 s) when `.well-known/scp` advertises `"quic"`; fall back to `NativeRelayAdapter`; suppress re-probe until next well-known refresh. Returns `Box<dyn TransportAdapter>` — transparent to callers.
+- Add `QuicAdapter::connect_url(...)` (host resolution + ALPN + `ClientConfig` with the restored `SessionTicketStore` for 0-RTT).
+- Route `crates/scp-ffi/src/transport.rs` + `server.rs` connect sites through the selector (signatures unchanged). Plumb the advertised-transports list to those sites; degrade to WebSocket-only where unavailable.
+- **Security gate:** PUBLISH/DELETE/UNSUBSCRIBE must never ride 0-RTT (§10.14.2). cryptographer + security-reviewer required.
+
+### PR-3b — Wire relay QUIC listener into the node serve path
+- In `scp-node` (`lib.rs` serve path + relay-start sites; `main.rs`), behind `cfg(feature="quic")`, start `QuicListener` on the same UDP port as the WebSocket TCP port, sharing `SubscriptionRegistry` + `BlobStorageBackend`; tie into the cancellation token.
+- Advertise `"quic"` in `.well-known/scp` only when the listener is actually started (close gap #5).
+
+### PR-4 — Conformance + capability matrix + story reconciliation
+- `crates/scp-transport/tests/quic_conformance.rs`: invoke `transport_conformance!` against an in-process QUIC listener (extract the reusable harness from `adapter.rs` tests).
+- Cross-transport test (publish-WS → receive-QUIC) for SCP-257 AC6.
+- **Capability matrix untouched** (D3 = internal); document the no-change rationale in the PR.
+- PRD reconciliation (`.docs/prds/transport-expansion.json`): SCP-254 keep `done`; SCP-255 keep `done` (verify AC6 by reading tests); SCP-256 → `done` after AC2 migration test lands; SCP-257 → `done` after PR-3b wiring + AC6 test; add new stories for native selection (§10.14.3 item 4) and listener wiring. Run `python3.12 scripts/validate-prd.py`.
+
+**Sequence:** PR-1 → PR-2 → PR-3a → PR-3b → PR-4. PR-4's PRD status corrections must not land before the code that makes them true.
+
+## 5. Risk Register (abridged)
+
+- **quinn/rustls API drift** — Low (versions identical: quinn 0.11.9, rustls 0.23.37; `keep_alive_interval` + `ClientSessionStore` signatures verified unchanged).
+- **`use rand` re-added** → unused-import clippy failure. PR-1 AC greps for it = 0.
+- **Cross-feature link conflicts** (`udp`+`coap` → openssl; `quic`+`http3` → quinn) in the new CI step. Split per-feature if needed.
+- **`transport_conformance!` has never been invoked** — the macro may assume a synchronous factory; QUIC needs an async listener. Budget extra time in PR-4.
+- **0-RTT replay of non-idempotent ops** — security-critical; gated review on PR-3.
+- **PRD status correction landing before code** → re-creates false-`done`. Enforce ordering.

--- a/.docs/prds/transport-expansion.json
+++ b/.docs/prds/transport-expansion.json
@@ -78,6 +78,17 @@
         "SCP-285",
         "SCP-286"
       ]
+    },
+    {
+      "id": "gate-transport-7",
+      "name": "Native QUIC Transport Selection and Discovery",
+      "priority": "P1",
+      "status": "done",
+      "stories": [
+        "SCP-299",
+        "SCP-300",
+        "SCP-301"
+      ]
     }
   ],
   "stories": [
@@ -360,7 +371,7 @@
     },
     {
       "id": "SCP-256",
-      "title": "Implement QUIC connection lifecycle (0-RTT, migration, reconnect)",
+      "title": "Implement QUIC connection lifecycle (session resumption, migration, reconnect)",
       "gate": "gate-transport-2",
       "priority": "P1",
       "severity": "major",
@@ -369,9 +380,9 @@
         "crates/scp-transport/src/quic/adapter.rs",
         "crates/scp-transport/src/quic/lifecycle.rs"
       ],
-      "description": "Implement QUIC connection lifecycle per \u00a710.14.2. 0-RTT connection resumption via session tickets stored across sessions. Connection migration when IP changes (quinn QUIC migration). Profile-aware reconnect backoff from TransportProfile. No PING/PONG \u2014 rely on QUIC native keepalive (PATH_CHALLENGE/PATH_RESPONSE).",
+      "description": "Implement QUIC connection lifecycle per \u00a710.14.2. TLS 1.3 session resumption (1-RTT) via session tickets persisted across adapter restarts (SessionTicketStore), abbreviating the handshake on reconnection. 0-RTT early data is deliberately NOT enabled: \u00a710.14.2's 0-RTT safety classification forbids non-idempotent operations (PUBLISH, DELETE, UNSUBSCRIBE) from riding 0-RTT to avoid replay, and the adapter establishes connections with the full 1-RTT handshake (never calling Connecting::into_0rtt), so no SCP operation is ever sent as 0-RTT early data. Connection migration when the client IP changes (quinn QUIC migration, RFC 9000 \u00a79 \u2014 PATH_CHALLENGE/PATH_RESPONSE). Profile-aware reconnect backoff from TransportProfile. No application PING/PONG \u2014 rely on QUIC native PING-frame keepalive (RFC 9000 \u00a719.2).",
       "acceptanceCriteria": [
-        "0-RTT connection resumption uses stored session tickets from prior connections",
+        "TLS 1.3 session resumption (1-RTT) uses stored session tickets from prior connections via a SessionTicketStore wired into the quinn/rustls client config (rustls::client::Resumption::store); 0-RTT early data is intentionally NOT enabled so non-idempotent operations (PUBLISH, DELETE, UNSUBSCRIBE) cannot ride 0-RTT and be replayed, per the 0-RTT safety classification in spec \u00a710.14.2",
         "Connection migration handles IP change without dropping active streams",
         "Reconnect backoff interval derived from TransportProfile (aggressive for server/desktop, conservative for mobile)",
         "No PING/PONG frames sent \u2014 QUIC native keepalive used instead",
@@ -379,12 +390,12 @@
         "Unit test: reconnect backoff follows profile-specified range"
       ],
       "actionItems": [
-        "Create connection.rs with QUIC connection state management",
-        "Implement session ticket storage and 0-RTT resumption",
+        "Create lifecycle.rs with QUIC connection lifecycle state (SessionTicketStore, QuicKeepaliveConfig, ReconnectBackoff, migration events)",
+        "Implement session ticket storage with export/import for persistence across restarts and wire it as the rustls Resumption::store (1-RTT resumption; 0-RTT early data NOT enabled per \u00a710.14.2)",
         "Wire quinn connection migration support",
         "Implement profile-aware reconnect backoff",
-        "Configure QUIC native keepalive instead of application PING/PONG",
-        "Write tests for reconnect backoff and session ticket persistence"
+        "Configure QUIC native PING-frame keepalive instead of application PING/PONG",
+        "Write tests for reconnect backoff range, session ticket export/import roundtrip, and connection-migration survival"
       ],
       "blockedBy": [
         "SCP-255"
@@ -1319,6 +1330,151 @@
       "details": {
         "phase": 2,
         "crate": "scp-transport"
+      }
+    },
+    {
+      "id": "SCP-299",
+      "title": "Implement native QUIC probe-and-fallback transport selection",
+      "gate": "gate-transport-7",
+      "priority": "P1",
+      "severity": "major",
+      "status": "done",
+      "files": [
+        "crates/scp-transport/src/selection.rs",
+        "crates/scp-transport/src/quic/adapter.rs",
+        "crates/scp-transport/src/lib.rs"
+      ],
+      "description": "Add a TransportSelector that transparently prefers QUIC over WebSocket on native (non-browser) clients when the relay advertises QUIC, per \u00a710.5.1 (\"Clients SHOULD prefer QUIC over WebSocket when both are available\") and \u00a710.14.3 item 4 (probe-and-fallback). On each connect the selector inspects the relay's advertised transports: when the list contains \"quic\" (case-insensitive), the quic feature is enabled, and the relay URL is a TLS scheme (wss:///https://), it probes QUIC with a bounded timeout via QuicAdapter::connect_url; on probe success it returns the QUIC adapter, otherwise it falls back to WebSocket and suppresses further QUIC probes for that relay until the next .well-known/scp refresh (\u00a710.14.3 item 4: \"without further QUIC attempts for that relay until the next .well-known/scp refresh\"). The selector is instance-scoped (no singletons or mutable module globals) and holds its own per-relay suppression set. QUIC client TLS uses a non-permissive verifier (own root store from Mozilla Web PKI trust anchors via webpki-roots; no accept-all/empty verifier) so an untrusted server certificate fails the handshake closed. Plaintext relays (ws://, http://, loopback) stay on WebSocket and are never probed. Wire is shared by all three connect-capable bridges (PyO3, napi, uniffi); cross-bridge parity is SCP-301, not this story.",
+      "acceptanceCriteria": [
+        "crates/scp-transport/src/selection.rs defines TransportSelector with a per-connect select_and_connect / select_and_connect_with_suppression API that returns a Box<dyn TransportAdapter>",
+        "QUIC is preferred only when advertised_transports contains \"quic\" (case-insensitive), the quic feature is enabled, and the URL is a TLS scheme: tests no_advertised_transports_means_no_quic, advertised_without_quic_means_no_quic, advertised_with_quic_on_tls_url_tries_quic, advertised_quic_case_insensitive, and quic_advertised_but_plaintext_url_stays_websocket pass",
+        "QUIC probe uses a 3-second timeout (QUIC_PROBE_TIMEOUT = Duration::from_secs(3)) per \u00a710.14.3 item 4",
+        "On probe failure the selector falls back to WebSocket and suppresses QUIC for that relay (is_quic_suppressed returns true; cleared by clear_suppression): test quic_probe_dead_port_falls_back_and_suppresses passes",
+        "QUIC client TLS supplies its own webpki-roots root store and never wires an accept-all/empty/permissive verifier (QuicAdapter::connect_url): the connect path builds a root store from webpki-roots and no DangerousClientConfig accept-all verifier appears in crates/scp-transport/src/quic/adapter.rs",
+        "TransportSelector is exported from crates/scp-transport/src/lib.rs (pub use selection::TransportSelector) and selection.rs declares no module-level static mut / lazy_static / static Mutex|RwLock|OnceLock (check-no-mutable-globals.sh passes for crates/scp-transport)"
+      ],
+      "actionItems": [
+        "Create selection.rs with TransportSelector, per-relay suppression set, and the 3-second QUIC probe constant",
+        "Implement should_try_quic (advertised + feature + TLS scheme) and the QUIC probe-and-fallback connect path",
+        "Wire QuicAdapter::connect_url with a webpki-roots-backed non-permissive rustls client config",
+        "Export TransportSelector from lib.rs",
+        "Write unit/integration tests covering advertisement gating, case-insensitivity, plaintext skip, probe timeout fallback, and suppression"
+      ],
+      "blockedBy": [
+        "SCP-257"
+      ],
+      "sources": [
+        {
+          "file": ".docs/specs/10-infrastructure-and-self-hosting.md",
+          "section": "### 10.5.1 Adapter Tiers"
+        },
+        {
+          "file": ".docs/specs/10-infrastructure-and-self-hosting.md",
+          "section": "### 10.14.3 Relay QUIC Support"
+        },
+        {
+          "file": ".docs/adrs/phase-2.md",
+          "section": "## ADR-037: Alternative Transport Bindings (QUIC, WebTransport, UDP/DTLS)"
+        }
+      ],
+      "details": {
+        "phase": 2,
+        "crate": "scp-transport"
+      }
+    },
+    {
+      "id": "SCP-300",
+      "title": "Implement connect-time relay transport discovery",
+      "gate": "gate-transport-7",
+      "priority": "P1",
+      "severity": "major",
+      "status": "done",
+      "files": [
+        "crates/scp-transport/src/discovery.rs",
+        "crates/scp-transport/src/selection.rs"
+      ],
+      "description": "Add a RelayTransportDiscovery cache that fetches and parses a relay's advertised transports from .well-known/scp (relay_config.transports) at connect time, feeding the TransportSelector (SCP-299) so QUIC selection works even when the caller has no pre-fetched advertised-transports list. Per \u00a710.5.1 (transport advertisement in .well-known/scp) and \u00a710.14.3 item 4 (refresh-bounded probing). The fetch is hardened: https-only (https_only(true)), no redirect following (reqwest::redirect::Policy::none() so a wss://user:pw@evil.com authority cannot redirect the discovery fetch off-host), a bounded timeout, and a bounded response body (oversized bodies rejected). All failure modes fail-open to the WebSocket baseline \u2014 a relay that serves no .well-known/scp, times out, 404s, redirects, returns an oversized/garbled body, or is plaintext resolves to \"no QUIC\" without erroring the connect. Results are cached per relay in a bounded LRU (MAX_CACHED_RELAYS) so repeated connects do not re-fetch; resolved entries are cached for the full TTL while transient failures are cached only briefly, and a fresh fetch is flagged so the selector can clear QUIC suppression only on a genuine .well-known/scp refresh. Connectivity into the selector is via select_and_connect_discovering*; the selection logic itself is SCP-299, not this story.",
+      "acceptanceCriteria": [
+        "crates/scp-transport/src/discovery.rs defines RelayTransportDiscovery that fetches and parses relay_config.transports from .well-known/scp at connect time: test fetches_and_parses_advertised_transports_over_https passes",
+        "Discovery fetch is https-only and refuses redirects: tests https_only_rejects_cleartext_target and redirect_is_refused_and_issues_no_second_request pass; the client is built with https_only(true) and reqwest::redirect::Policy::none()",
+        "Response body is bounded; an oversized body is rejected fail-open: test oversized_body_is_rejected_fail_open passes",
+        "Every fetch failure (timeout/404/redirect/parse/oversize/plaintext relay) fails open to the WebSocket baseline (resolves to no advertised QUIC, no error): tests fetch_failure_resolves_to_none_fail_open and plaintext_relay_resolves_to_none_without_fetch pass",
+        "Results are cached per relay in a bounded LRU (MAX_CACHED_RELAYS) that evicts the oldest beyond capacity, fetching once per relay: tests caches_per_relay_fetches_once and cache_evicts_oldest_beyond_capacity pass",
+        "Resolved entries are served for the full TTL and transient failures only briefly; an expired entry refreshes: tests resolved_none_caches_for_full_ttl, transient_failure_caches_briefly, and expired_entry_refreshes pass",
+        "RelayTransportDiscovery declares no module-level static mut / lazy_static / static Mutex|RwLock|OnceLock \u2014 its per-relay LRU cache is instance-owned (check-no-mutable-globals.sh passes for crates/scp-transport)"
+      ],
+      "actionItems": [
+        "Create discovery.rs with RelayTransportDiscovery, a bounded LRU keyed by relay URL, and DEFAULT/transient TTLs",
+        "Implement the hardened https-only, no-redirect, bounded-timeout, bounded-body .well-known/scp fetch and parse",
+        "Map wss://host:pw@.../https://... authorities to https://authority/.well-known/scp and skip plaintext relays",
+        "Fail open to WebSocket on every error path and flag fresh fetches for suppression-clear",
+        "Wire select_and_connect_discovering* in selection.rs to consult the cache",
+        "Write tests covering parse, https-only, redirect refusal, oversize rejection, fail-open, caching, eviction, and TTL behavior"
+      ],
+      "blockedBy": [
+        "SCP-299"
+      ],
+      "sources": [
+        {
+          "file": ".docs/specs/10-infrastructure-and-self-hosting.md",
+          "section": "### 10.5.1 Adapter Tiers"
+        },
+        {
+          "file": ".docs/specs/10-infrastructure-and-self-hosting.md",
+          "section": "### 10.14.3 Relay QUIC Support"
+        },
+        {
+          "file": ".docs/adrs/phase-2.md",
+          "section": "## ADR-037: Alternative Transport Bindings (QUIC, WebTransport, UDP/DTLS)"
+        }
+      ],
+      "details": {
+        "phase": 2,
+        "crate": "scp-transport"
+      }
+    },
+    {
+      "id": "SCP-301",
+      "title": "Route napi and uniffi connect sites through the QUIC transport selector",
+      "gate": "gate-transport-7",
+      "priority": "P1",
+      "severity": "major",
+      "status": "done",
+      "files": [
+        "crates/scp-ffi/napi/src/transport.rs",
+        "crates/scp-ffi/uniffi/src/bridge.rs"
+      ],
+      "description": "Bring the napi (Node/Bun TypeScript) and uniffi (Swift, Kotlin) bridges to parity with the PyO3 reference bridge for native QUIC transport selection. The PyO3 bridge (crates/scp-ffi/src/transport.rs) already routes its relay connect sites through the instance-scoped selector via bi.core.transport_selector().select_and_connect_discovering_with_suppression(...). This story routes the napi and uniffi connect sites through the same instance-scoped TransportSelector (SCP-299) and RelayTransportDiscovery (SCP-300) so Swift, Kotlin, and TypeScript native clients transparently prefer QUIC when a relay advertises it and fall back to WebSocket otherwise \u2014 with no SDK-surface API change. The selector is owned by the bridge instance (bi.core.transport_selector(), defined on the shared BridgeInstance in crates/scp-ffi/common/src/bridge_instance.rs), so QUIC suppression and discovery caches are per-instance, never singletons. WASM is browser-only and uses WebTransport (\u00a710.15), not native QUIC, so it is out of scope for this parity story.",
+      "acceptanceCriteria": [
+        "napi connect site routes through the instance selector: crates/scp-ffi/napi/src/transport.rs calls bi.core.transport_selector() and selector.select_and_connect_discovering_with_suppression(...) (grep returns >0 matches)",
+        "uniffi connect site routes through the instance selector: crates/scp-ffi/uniffi/src/bridge.rs calls bi.core.transport_selector() and selector.select_and_connect_discovering_with_suppression(...) (grep returns >0 matches)",
+        "Both bridges obtain the selector from the shared per-instance accessor BridgeInstance::transport_selector (crates/scp-ffi/common/src/bridge_instance.rs), not a freshly constructed or static selector \u2014 matching the PyO3 reference path in crates/scp-ffi/src/transport.rs",
+        "No SDK-facing connect API signature changes (selection is transparent): the napi/uniffi connect entry points keep their existing parameters",
+        "cargo build for the napi and uniffi bridges with the quic feature compiles without error"
+      ],
+      "actionItems": [
+        "Route the napi connect site in transport.rs through bi.core.transport_selector().select_and_connect_discovering_with_suppression(...)",
+        "Route the uniffi connect site in bridge.rs through bi.core.transport_selector().select_and_connect_discovering_with_suppression(...)",
+        "Drain and wire the selector's suppression receiver the same way the PyO3 reference bridge does",
+        "Verify napi and uniffi bridges compile with the quic feature"
+      ],
+      "blockedBy": [
+        "SCP-299",
+        "SCP-300"
+      ],
+      "sources": [
+        {
+          "file": ".docs/specs/10-infrastructure-and-self-hosting.md",
+          "section": "### 10.5.1 Adapter Tiers"
+        },
+        {
+          "file": ".docs/adrs/phase-2.md",
+          "section": "## ADR-037: Alternative Transport Bindings (QUIC, WebTransport, UDP/DTLS)"
+        }
+      ],
+      "details": {
+        "phase": 2,
+        "crate": "scp-ffi"
       }
     }
   ]


### PR DESCRIPTION
## Summary

Final step of the QUIC restoration (9-PR effort, #1742–#1750 all merged). Reconciles the `transport-expansion` PRD stories with the now-merged implementation and records the planning session.

SCP-254–257 were `status=done` for months while the `quic` feature didn't even compile — a false-done state. This makes the PRD tell the truth: every AC is now verified against a real test/impl, the one AC that couldn't be met as written is corrected (flowing down from spec), and the work that had **no story** gets one.

## Changes

**Corrected (artifact-flow: down from spec):**
- **SCP-256 AC1** — was "0-RTT connection resumption." We ship TLS 1.3 **session resumption (1-RTT)** via `SessionTicketStore`; 0-RTT early data is *intentionally disabled* so non-idempotent PUBLISH/DELETE/UNSUBSCRIBE can't be replayed (spec §10.14.2). AC1 reworded to state this accurately and cite §10.14.2.

**Verified now-genuinely-met (each AC traced to a real test/impl):**
- SCP-256 AC2 (migration) ← `crates/scp-transport/tests/quic_migration.rs` (PR-4a)
- SCP-257 AC1 (listener on TLS port) ← PR-3b; AC6 (cross-transport delivery) ← `crates/scp-node/tests/quic_cross_transport.rs` (PR-4b)
- SCP-255 AC6 (conformance) ← `crates/scp-transport/tests/quic_conformance.rs` + the `transport_conformance!` macro fix (PR-4a)

**New stories (the work had no PRD coverage):**
- **SCP-299** — native QUIC probe-and-fallback transport selection (PR-3a) — §10.5.1, §10.14.3, ADR-037
- **SCP-300** — connect-time relay transport discovery (PR-3c) — §10.5.1, §10.14.3, ADR-037
- **SCP-301** — route napi/uniffi connect sites through the selector (PR-3d) — §10.5.1, ADR-037

**Plus** the planning-session record (`.docs/planning-sessions/planning-session-07-quic-restoration.md`).

## Verification

- `python3.12 scripts/validate-prd.py` → **passed** (362 stories, 12 files)
- All cited source headings confirmed present in the spec/ADR.
- Each AC independently verified against the merged code/tests (orchestrator re-checked, not self-reported — the authoring agent's report was lost to a transient API error, so the reconciliation was re-verified by hand).