### PR TITLE
refactor(ffi): extract callback-custody byte parsing to scp-ffi-common (#1543 F1)

### DIFF
--- a/crates/scp-ffi/Cargo.toml
+++ b/crates/scp-ffi/Cargo.toml
@@ -43,7 +43,7 @@ scp-core = { path = "../scp-core" }
 scp-identity = { path = "../scp-identity" }
 scp-primitives = { path = "../scp-primitives" }
 scp-event-log = { path = "../scp-event-log" }
-scp-ffi-common = { path = "common" }
+scp-ffi-common = { path = "common", features = ["custody"] }
 scp-node = { path = "../scp-node", features = ["allow_unencrypted_storage"], optional = true }
 scp-mcp = { path = "../scp-mcp" }
 scp-platform = { path = "../scp-platform", features = ["software_platform", "file", "testing", "encrypting", "filesystem", "sqlite"] }
@@ -68,7 +68,7 @@ zeroize = { workspace = true }
 [dev-dependencies]
 pyo3 = { version = "0.24.1", features = ["auto-initialize", "multiple-pymethods"] }
 tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }
-scp-ffi-common = { path = "common", features = ["testing"] }
+scp-ffi-common = { path = "common", features = ["testing", "custody"] }
 # Tests need InMemoryKeyCustody.
 scp-platform = { path = "../scp-platform", features = ["testing"] }
 tempfile = "3"

--- a/crates/scp-ffi/common/Cargo.toml
+++ b/crates/scp-ffi/common/Cargo.toml
@@ -15,6 +15,12 @@ resolvers = ["dep:scp-core", "dep:scp-identity", "dep:scp-event-log", "dep:scp-t
 # Enables the did:key:{hex} DID format in BridgeDidResolver. This is a
 # non-standard test convenience — production builds must resolve via did:dht:z.
 testing = ["resolvers"]
+# Shared callback-custody byte/string parsing helpers (custody_parse module).
+# Requires only scp-platform for the typed return values (KeyHandle,
+# PseudonymKeypair, PublicKey, PlatformError). Deliberately NOT folded into
+# `resolvers`: these are pure byte/string ops far lighter than the resolver
+# stack, and WASM does not use the callback-custody path (ADR-034).
+custody = ["dep:scp-platform"]
 # Shared relay/node startup code for FFI bridges that need to spawn servers.
 # Requires scp-transport (relay), scp-node (application node), scp-platform
 # (in-memory testing backends), and tokio. Not available for WASM (ADR-034).

--- a/crates/scp-ffi/common/src/custody_parse.rs
+++ b/crates/scp-ffi/common/src/custody_parse.rs
@@ -1,0 +1,242 @@
+//! Shared byte/string parsing helpers for the callback-custody adapters.
+//!
+//! The `PyO3`, napi-rs, and `UniFFI` bridges each adapt a caller-supplied
+//! `KeyCustodyProvider` (a Python object / JS callback record / `UniFFI`
+//! callback interface) to scp-platform's [`KeyCustody`] trait. The provider
+//! protocol speaks in raw byte arrays and opaque key-id strings; the adapters
+//! must translate those into the typed [`KeyHandle`] / [`PseudonymKeypair`] /
+//! `[u8; 32]` surface. That translation — and the error messages it produces on
+//! malformed provider returns — is mechanism-independent: it is identical
+//! across all three bridges.
+//!
+//! These free functions hold that shared logic so the three bridges cannot
+//! drift on either the parsing rules or the error-message text. The
+//! `method: &str` parameter names the originating custody operation in error
+//! messages (e.g. `"KeyCustodyProvider.derive_pseudonym returned ..."`),
+//! preserving the format the `PyO3` reference bridge established.
+//!
+//! Pure byte/string operations — no crypto, no I/O. Gated behind the `custody`
+//! feature (which pulls in `scp-platform` for the typed return values) rather
+//! than folded into `resolvers`, since the resolver stack is far heavier and
+//! WASM does not use the callback-custody path (ADR-034).
+//!
+//! See ADR-006 and the per-bridge `CallbackKeyCustody` adapters.
+
+use scp_platform::error::PlatformError;
+use scp_platform::traits::{KeyHandle, PseudonymKeypair, PublicKey};
+
+/// Parses a numeric key-id string (as returned by a `KeyCustodyProvider`) into
+/// a [`KeyHandle`].
+///
+/// # Errors
+///
+/// Returns [`PlatformError::CustodyError`] if `key_id` does not parse as a
+/// `u64`.
+pub fn parse_handle(method: &str, key_id: &str) -> Result<KeyHandle, PlatformError> {
+    key_id.parse::<u64>().map(KeyHandle::new).map_err(|_| {
+        PlatformError::CustodyError(format!(
+            "KeyCustodyProvider.{method} returned a non-numeric key_id: {key_id}"
+        ))
+    })
+}
+
+/// Coerces a 32-byte custody return into a fixed array.
+///
+/// # Errors
+///
+/// Returns [`PlatformError::CustodyError`] if `bytes` is not exactly 32 bytes.
+pub fn expect_32(method: &str, bytes: &[u8]) -> Result<[u8; 32], PlatformError> {
+    bytes.try_into().map_err(|_| {
+        PlatformError::CustodyError(format!(
+            "KeyCustodyProvider.{method} returned {} bytes, expected 32",
+            bytes.len()
+        ))
+    })
+}
+
+/// Unpacks a `derive_pseudonym`-style return (`[pubkey(32) || key_id_utf8]`)
+/// into a [`PseudonymKeypair`].
+///
+/// # Errors
+///
+/// Returns [`PlatformError::CustodyError`] if `bytes` is shorter than 33 bytes,
+/// the key-id portion is not valid UTF-8, or the key-id is not numeric.
+pub fn unpack_pseudonym(method: &str, bytes: &[u8]) -> Result<PseudonymKeypair, PlatformError> {
+    if bytes.len() < 33 {
+        return Err(PlatformError::CustodyError(format!(
+            "KeyCustodyProvider.{method} returned {} bytes, expected at least 33 \
+             (32 public key + key_id)",
+            bytes.len()
+        )));
+    }
+    let public_key_bytes = &bytes[..32];
+    let key_id_str = std::str::from_utf8(&bytes[32..]).map_err(|_| {
+        PlatformError::CustodyError(format!(
+            "KeyCustodyProvider.{method} key_id portion is not valid UTF-8"
+        ))
+    })?;
+    let key_id = parse_handle(method, key_id_str)?;
+    Ok(PseudonymKeypair {
+        public_key: PublicKey::new(public_key_bytes.to_vec()),
+        key_handle: key_id,
+    })
+}
+
+/// Builds the extended context-id input for a rotatable pseudonym derivation.
+///
+/// The callback-custody protocol exposes only a single `derive_pseudonym`
+/// method, so the rotatable variant is synthesized by appending the big-endian
+/// epoch and the `v2` domain separator to the caller-supplied `context_id`,
+/// then delegating to `derive_pseudonym`.
+///
+/// Layout: `context_id || epoch.to_be_bytes() (8) || b"scp-pseudonym-v2" (16)`.
+///
+/// This is the canonical recipe defined in `scp-platform`
+/// `KeyCustody::derive_rotatable_pseudonym` (traits.rs) — "all implementations
+/// MUST produce identical output" — so the byte ordering is fixed by the
+/// protocol, not by any single bridge. There is deliberately NO length
+/// separator between `context_id` and the epoch: the epoch is always exactly 8
+/// big-endian bytes appended directly after the caller-supplied `context_id`,
+/// and the trailing domain separator is a fixed 16-byte literal. A length
+/// prefix would change the produced bytes and is therefore a wire-format change
+/// that must originate upstream in the spec/ADR and `scp-platform` (and be
+/// applied identically across all bridges and the native custody backends) — it
+/// cannot be introduced here without breaking cross-bridge and over-time
+/// pseudonym derivation parity.
+#[must_use]
+pub fn extend_context_id_for_rotation(context_id: &[u8], epoch: u64) -> Vec<u8> {
+    let mut extended = context_id.to_vec();
+    extended.extend_from_slice(&epoch.to_be_bytes());
+    extended.extend_from_slice(b"scp-pseudonym-v2");
+    extended
+}
+
+#[cfg(test)]
+#[allow(clippy::expect_used, clippy::panic)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_handle_accepts_numeric() {
+        let handle = parse_handle("generate_keypair", "42").expect("numeric key_id parses");
+        assert_eq!(handle.id(), 42);
+    }
+
+    #[test]
+    fn parse_handle_rejects_non_numeric() {
+        let err = parse_handle("generate_keypair", "not-a-number")
+            .expect_err("non-numeric key_id is rejected");
+        match err {
+            PlatformError::CustodyError(msg) => {
+                assert_eq!(
+                    msg,
+                    "KeyCustodyProvider.generate_keypair returned a non-numeric key_id: not-a-number"
+                );
+            }
+            other => panic!("expected CustodyError, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn expect_32_accepts_exactly_32() {
+        let bytes = [7u8; 32];
+        let arr = expect_32("dh_agree", &bytes).expect("32 bytes coerces");
+        assert_eq!(arr, bytes);
+    }
+
+    #[test]
+    fn expect_32_rejects_wrong_length_with_exact_message() {
+        let bytes = [0u8; 31];
+        let err = expect_32("dh_agree", &bytes).expect_err("31 bytes is rejected");
+        match err {
+            PlatformError::CustodyError(msg) => {
+                assert_eq!(
+                    msg,
+                    "KeyCustodyProvider.dh_agree returned 31 bytes, expected 32"
+                );
+            }
+            other => panic!("expected CustodyError, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn unpack_pseudonym_accepts_pubkey_plus_key_id() {
+        let mut bytes = vec![0xABu8; 32];
+        bytes.extend_from_slice(b"123");
+        let pseudo = unpack_pseudonym("derive_pseudonym", &bytes).expect("valid pseudonym unpacks");
+        assert_eq!(pseudo.public_key.as_bytes(), &[0xABu8; 32]);
+        assert_eq!(pseudo.key_handle.id(), 123);
+    }
+
+    #[test]
+    fn unpack_pseudonym_rejects_short_input() {
+        let bytes = [0u8; 32]; // exactly 32 — no key_id, below the 33 minimum.
+        let err =
+            unpack_pseudonym("derive_pseudonym", &bytes).expect_err("32-byte input has no key_id");
+        match err {
+            PlatformError::CustodyError(msg) => {
+                assert_eq!(
+                    msg,
+                    "KeyCustodyProvider.derive_pseudonym returned 32 bytes, expected at least 33 \
+                     (32 public key + key_id)"
+                );
+            }
+            other => panic!("expected CustodyError, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn unpack_pseudonym_rejects_non_utf8_key_id() {
+        let mut bytes = vec![0u8; 32];
+        // 0xFF is an invalid UTF-8 lead byte.
+        bytes.push(0xFF);
+        let err =
+            unpack_pseudonym("derive_pseudonym", &bytes).expect_err("non-utf8 key_id is rejected");
+        match err {
+            PlatformError::CustodyError(msg) => {
+                assert_eq!(
+                    msg,
+                    "KeyCustodyProvider.derive_pseudonym key_id portion is not valid UTF-8"
+                );
+            }
+            other => panic!("expected CustodyError, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn unpack_pseudonym_rejects_non_numeric_key_id() {
+        let mut bytes = vec![0u8; 32];
+        bytes.extend_from_slice(b"xyz");
+        let err = unpack_pseudonym("derive_rotatable_pseudonym", &bytes)
+            .expect_err("non-numeric key_id is rejected");
+        match err {
+            PlatformError::CustodyError(msg) => {
+                assert_eq!(
+                    msg,
+                    "KeyCustodyProvider.derive_rotatable_pseudonym returned a non-numeric key_id: xyz"
+                );
+            }
+            other => panic!("expected CustodyError, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn extend_context_id_for_rotation_byte_layout() {
+        let context_id = b"ctx";
+        let epoch: u64 = 5;
+        let extended = extend_context_id_for_rotation(context_id, epoch);
+
+        // Layout: context_id || epoch_BE(8) || "scp-pseudonym-v2" (16 bytes).
+        let mut expected = Vec::new();
+        expected.extend_from_slice(b"ctx");
+        expected.extend_from_slice(&[0, 0, 0, 0, 0, 0, 0, 5]); // 5 as 8 big-endian bytes
+        expected.extend_from_slice(b"scp-pseudonym-v2");
+
+        assert_eq!(extended, expected);
+        assert_eq!(extended.len(), 3 + 8 + 16);
+        // Domain separator is exactly the trailing 16 bytes.
+        assert_eq!(&extended[extended.len() - 16..], b"scp-pseudonym-v2");
+        // Epoch occupies the 8 bytes immediately after context_id.
+        assert_eq!(&extended[3..11], &epoch.to_be_bytes());
+    }
+}

--- a/crates/scp-ffi/common/src/lib.rs
+++ b/crates/scp-ffi/common/src/lib.rs
@@ -96,6 +96,14 @@ pub fn html_escape_json(json: &str) -> String {
         .replace('\'', "\\u0027")
 }
 
+// Shared callback-custody byte/string parsing helpers (behind the `custody`
+// feature). Requires scp-platform for the typed return values. Used by the
+// PyO3, napi-rs, and UniFFI CallbackKeyCustody adapters; NOT folded into
+// `resolvers` because these are pure byte/string ops far lighter than the
+// resolver stack, and WASM does not use callback custody (ADR-034). See ADR-006.
+#[cfg(feature = "custody")]
+pub mod custody_parse;
+
 // Shared attestation construction pipeline for all non-WASM bridges.
 // Requires scp-core + scp-identity (behind `resolvers` feature). Not available for WASM.
 #[cfg(feature = "resolvers")]

--- a/crates/scp-ffi/napi/Cargo.toml
+++ b/crates/scp-ffi/napi/Cargo.toml
@@ -42,7 +42,7 @@ scp-media = { path = "../../scp-media" }
 scp-primitives = { path = "../../scp-primitives" }
 scp-identity = { path = "../../scp-identity" }
 scp-event-log = { path = "../../scp-event-log" }
-scp-ffi-common = { path = "../common" }
+scp-ffi-common = { path = "../common", features = ["custody"] }
 scp-node = { path = "../../scp-node", features = ["allow_unencrypted_storage"], optional = true }
 scp-platform = { path = "../../scp-platform", features = ["encrypting", "filesystem", "sqlite"] }
 scp-mcp = { path = "../../scp-mcp" }
@@ -53,7 +53,7 @@ tokio-util = { workspace = true }
 async-trait = { workspace = true }
 
 [dev-dependencies]
-scp-ffi-common = { path = "../common", features = ["testing"] }
+scp-ffi-common = { path = "../common", features = ["testing", "custody"] }
 tempfile = "3"
 # Provides weak C stubs for napi runtime symbols so the test binary
 # can link without a Node.js runtime. Kept as a dev-dependency so

--- a/crates/scp-ffi/napi/src/custody.rs
+++ b/crates/scp-ffi/napi/src/custody.rs
@@ -179,44 +179,6 @@ impl NapiCallbackKeyCustody {
         PlatformError::CustodyError(format!("KeyCustodyProvider.{method} raised: {e}"))
     }
 
-    fn parse_handle(method: &str, key_id: &str) -> Result<KeyHandle, PlatformError> {
-        key_id.parse::<u64>().map(KeyHandle::new).map_err(|_| {
-            PlatformError::CustodyError(format!(
-                "KeyCustodyProvider.{method} returned a non-numeric key_id: {key_id}"
-            ))
-        })
-    }
-
-    fn expect_32(method: &str, bytes: &[u8]) -> Result<[u8; 32], PlatformError> {
-        bytes.try_into().map_err(|_| {
-            PlatformError::CustodyError(format!(
-                "KeyCustodyProvider.{method} returned {} bytes, expected 32",
-                bytes.len()
-            ))
-        })
-    }
-
-    fn unpack_pseudonym(method: &str, bytes: &[u8]) -> Result<PseudonymKeypair, PlatformError> {
-        if bytes.len() < 33 {
-            return Err(PlatformError::CustodyError(format!(
-                "KeyCustodyProvider.{method} returned {} bytes, expected at least 33 \
-                 (32 public key + key_id)",
-                bytes.len()
-            )));
-        }
-        let public_key_bytes = &bytes[..32];
-        let key_id_str = std::str::from_utf8(&bytes[32..]).map_err(|_| {
-            PlatformError::CustodyError(format!(
-                "KeyCustodyProvider.{method} key_id portion is not valid UTF-8"
-            ))
-        })?;
-        let key_id = Self::parse_handle(method, key_id_str)?;
-        Ok(PseudonymKeypair {
-            public_key: PublicKey::new(public_key_bytes.to_vec()),
-            key_handle: key_id,
-        })
-    }
-
     /// Exports the raw Ed25519 signing key via the provider's
     /// `export_signing_key_bytes` callback.
     ///
@@ -235,7 +197,10 @@ impl NapiCallbackKeyCustody {
                 .await
                 .map_err(|e| Self::map_call_err("export_signing_key_bytes", &e))?,
         );
-        let arr = zeroize::Zeroizing::new(Self::expect_32("export_signing_key_bytes", &bytes)?);
+        let arr = zeroize::Zeroizing::new(scp_ffi_common::custody_parse::expect_32(
+            "export_signing_key_bytes",
+            &bytes,
+        )?);
         Ok(ed25519_dalek::SigningKey::from_bytes(&arr))
     }
 }
@@ -252,7 +217,7 @@ impl KeyCustody for NapiCallbackKeyCustody {
             .call_async(type_str)
             .await
             .map_err(|e| Self::map_call_err("generate_keypair", &e))?;
-        Self::parse_handle("generate_keypair", &key_id)
+        scp_ffi_common::custody_parse::parse_handle("generate_keypair", &key_id)
     }
 
     async fn sign(&self, key: &KeyHandle, data: &[u8]) -> Result<Signature, PlatformError> {
@@ -298,7 +263,9 @@ impl KeyCustody for NapiCallbackKeyCustody {
                 .await
                 .map_err(|e| Self::map_call_err("dh_agree", &e))?,
         );
-        Ok(SharedSecret::new(Self::expect_32("dh_agree", &shared)?))
+        Ok(SharedSecret::new(scp_ffi_common::custody_parse::expect_32(
+            "dh_agree", &shared,
+        )?))
     }
 
     async fn derive_pseudonym(
@@ -312,7 +279,7 @@ impl KeyCustody for NapiCallbackKeyCustody {
             .call_async((key.id().to_string(), context_id.to_vec()))
             .await
             .map_err(|e| Self::map_call_err("derive_pseudonym", &e))?;
-        Self::unpack_pseudonym("derive_pseudonym", &bytes)
+        scp_ffi_common::custody_parse::unpack_pseudonym("derive_pseudonym", &bytes)
     }
 
     async fn derive_rotatable_pseudonym(
@@ -324,30 +291,21 @@ impl KeyCustody for NapiCallbackKeyCustody {
         // Synthesize the rotatable variant by extending the context_id with
         // the big-endian epoch and the v2 domain separator, then delegating to
         // the single `derive_pseudonym` callback (matches the UniFFI/PyO3
-        // CallbackKeyCustody contract — keeps the JS surface to one method).
-        //
-        // Layout: `context_id || epoch_BE(8) || "scp-pseudonym-v2"`. This is the
-        // canonical recipe defined in `scp-platform` `KeyCustody::derive_rotatable_pseudonym`
-        // (traits.rs) — "all implementations MUST produce identical output" — so
-        // the byte ordering is fixed by the protocol, not by this bridge. There is
-        // deliberately NO length separator between `context_id` and the epoch: the
-        // epoch is always exactly 8 big-endian bytes appended directly after the
-        // caller-supplied `context_id`, and the trailing domain separator is a
-        // fixed 16-byte literal. A length prefix would change the produced bytes
-        // and is therefore a wire-format change that must originate upstream in the
-        // spec/ADR and `scp-platform` (and be applied identically across all four
-        // bridges and the native custody backends) — it cannot be introduced here
-        // without breaking cross-bridge and over-time pseudonym derivation parity.
-        let mut extended = context_id.to_vec();
-        extended.extend_from_slice(&pseudonym_epoch.to_be_bytes());
-        extended.extend_from_slice(b"scp-pseudonym-v2");
+        // CallbackKeyCustody contract — keeps the JS surface to one method). The
+        // canonical byte layout (`context_id || epoch_BE(8) || "scp-pseudonym-v2"`)
+        // lives in `scp_ffi_common::custody_parse::extend_context_id_for_rotation`,
+        // shared across all callback bridges so the wire format cannot drift.
+        let extended = scp_ffi_common::custody_parse::extend_context_id_for_rotation(
+            context_id,
+            pseudonym_epoch,
+        );
         let bytes = self
             .tsfns
             .derive_pseudonym
             .call_async((key.id().to_string(), extended))
             .await
             .map_err(|e| Self::map_call_err("derive_pseudonym", &e))?;
-        Self::unpack_pseudonym("derive_rotatable_pseudonym", &bytes)
+        scp_ffi_common::custody_parse::unpack_pseudonym("derive_rotatable_pseudonym", &bytes)
     }
 
     async fn ed25519_to_x25519_agree(
@@ -368,7 +326,7 @@ impl KeyCustody for NapiCallbackKeyCustody {
                 .await
                 .map_err(|e| Self::map_call_err("dh_agree", &e))?,
         );
-        Ok(SharedSecret::new(Self::expect_32(
+        Ok(SharedSecret::new(scp_ffi_common::custody_parse::expect_32(
             "ed25519_to_x25519_agree",
             &shared,
         )?))

--- a/crates/scp-ffi/src/custody.rs
+++ b/crates/scp-ffi/src/custody.rs
@@ -404,48 +404,6 @@ impl PyCallbackKeyCustody {
         Self { provider }
     }
 
-    /// Parses a numeric key-id string into a [`KeyHandle`].
-    fn parse_handle(method: &str, key_id: &str) -> Result<KeyHandle, PlatformError> {
-        key_id.parse::<u64>().map(KeyHandle::new).map_err(|_| {
-            PlatformError::CustodyError(format!(
-                "KeyCustodyProvider.{method} returned a non-numeric key_id: {key_id}"
-            ))
-        })
-    }
-
-    /// Coerces a 32-byte custody return into a fixed array.
-    fn expect_32(method: &str, bytes: &[u8]) -> Result<[u8; 32], PlatformError> {
-        bytes.try_into().map_err(|_| {
-            PlatformError::CustodyError(format!(
-                "KeyCustodyProvider.{method} returned {} bytes, expected 32",
-                bytes.len()
-            ))
-        })
-    }
-
-    /// Unpacks a `derive_pseudonym`-style return (`[pubkey(32) || key_id_utf8]`)
-    /// into a [`PseudonymKeypair`].
-    fn unpack_pseudonym(method: &str, bytes: &[u8]) -> Result<PseudonymKeypair, PlatformError> {
-        if bytes.len() < 33 {
-            return Err(PlatformError::CustodyError(format!(
-                "KeyCustodyProvider.{method} returned {} bytes, expected at least 33 \
-                 (32 public key + key_id)",
-                bytes.len()
-            )));
-        }
-        let public_key_bytes = &bytes[..32];
-        let key_id_str = std::str::from_utf8(&bytes[32..]).map_err(|_| {
-            PlatformError::CustodyError(format!(
-                "KeyCustodyProvider.{method} key_id portion is not valid UTF-8"
-            ))
-        })?;
-        let key_id = Self::parse_handle(method, key_id_str)?;
-        Ok(PseudonymKeypair {
-            public_key: PublicKey::new(public_key_bytes.to_vec()),
-            key_handle: key_id,
-        })
-    }
-
     /// Exports the raw Ed25519 signing key via the provider's
     /// `export_signing_key_bytes`.
     ///
@@ -468,7 +426,10 @@ impl PyCallbackKeyCustody {
             self.provider
                 .call_str("export_signing_key_bytes", &handle.id().to_string())?,
         );
-        let arr = zeroize::Zeroizing::new(Self::expect_32("export_signing_key_bytes", &bytes)?);
+        let arr = zeroize::Zeroizing::new(scp_ffi_common::custody_parse::expect_32(
+            "export_signing_key_bytes",
+            &bytes,
+        )?);
         Ok(ed25519_dalek::SigningKey::from_bytes(&arr))
     }
 }
@@ -480,7 +441,7 @@ impl KeyCustody for PyCallbackKeyCustody {
             KeyType::X25519 => "x25519".to_owned(),
         };
         let key_id: String = self.provider.call_str("generate_keypair", &type_str)?;
-        Self::parse_handle("generate_keypair", &key_id)
+        scp_ffi_common::custody_parse::parse_handle("generate_keypair", &key_id)
     }
 
     async fn sign(&self, key: &KeyHandle, data: &[u8]) -> Result<Signature, PlatformError> {
@@ -514,7 +475,9 @@ impl KeyCustody for PyCallbackKeyCustody {
             self.provider
                 .call_str_bytes("dh_agree", &key.id().to_string(), peer_public)?,
         );
-        Ok(SharedSecret::new(Self::expect_32("dh_agree", &shared)?))
+        Ok(SharedSecret::new(scp_ffi_common::custody_parse::expect_32(
+            "dh_agree", &shared,
+        )?))
     }
 
     async fn derive_pseudonym(
@@ -525,7 +488,7 @@ impl KeyCustody for PyCallbackKeyCustody {
         let bytes: Vec<u8> =
             self.provider
                 .call_str_bytes("derive_pseudonym", &key.id().to_string(), context_id)?;
-        Self::unpack_pseudonym("derive_pseudonym", &bytes)
+        scp_ffi_common::custody_parse::unpack_pseudonym("derive_pseudonym", &bytes)
     }
 
     async fn derive_rotatable_pseudonym(
@@ -537,27 +500,18 @@ impl KeyCustody for PyCallbackKeyCustody {
         // Match the UniFFI CallbackKeyCustody contract: the rotatable variant
         // is synthesized by extending the context_id with the big-endian epoch
         // and the v2 domain separator, then delegating to derive_pseudonym.
-        // Keeps the Python protocol surface to a single pseudonym method.
-        //
-        // Layout: `context_id || epoch_BE(8) || "scp-pseudonym-v2"`. This is the
-        // canonical recipe defined in `scp-platform` `KeyCustody::derive_rotatable_pseudonym`
-        // (traits.rs) — "all implementations MUST produce identical output" — so
-        // the byte ordering is fixed by the protocol, not by this bridge. There is
-        // deliberately NO length separator between `context_id` and the epoch: the
-        // epoch is always exactly 8 big-endian bytes appended directly after the
-        // caller-supplied `context_id`, and the trailing domain separator is a
-        // fixed 16-byte literal. A length prefix would change the produced bytes
-        // and is therefore a wire-format change that must originate upstream in the
-        // spec/ADR and `scp-platform` (and be applied identically across all four
-        // bridges and the native custody backends) — it cannot be introduced here
-        // without breaking cross-bridge and over-time pseudonym derivation parity.
-        let mut extended = context_id.to_vec();
-        extended.extend_from_slice(&pseudonym_epoch.to_be_bytes());
-        extended.extend_from_slice(b"scp-pseudonym-v2");
+        // Keeps the Python protocol surface to a single pseudonym method. The
+        // canonical byte layout (`context_id || epoch_BE(8) || "scp-pseudonym-v2"`)
+        // lives in `scp_ffi_common::custody_parse::extend_context_id_for_rotation`,
+        // shared across all callback bridges so the wire format cannot drift.
+        let extended = scp_ffi_common::custody_parse::extend_context_id_for_rotation(
+            context_id,
+            pseudonym_epoch,
+        );
         let bytes: Vec<u8> =
             self.provider
                 .call_str_bytes("derive_pseudonym", &key.id().to_string(), &extended)?;
-        Self::unpack_pseudonym("derive_rotatable_pseudonym", &bytes)
+        scp_ffi_common::custody_parse::unpack_pseudonym("derive_rotatable_pseudonym", &bytes)
     }
 
     async fn ed25519_to_x25519_agree(
@@ -577,7 +531,7 @@ impl KeyCustody for PyCallbackKeyCustody {
                 &ed25519_handle.id().to_string(),
                 peer_x25519_public,
             )?);
-        Ok(SharedSecret::new(Self::expect_32(
+        Ok(SharedSecret::new(scp_ffi_common::custody_parse::expect_32(
             "ed25519_to_x25519_agree",
             &shared,
         )?))

--- a/crates/scp-ffi/uniffi/Cargo.toml
+++ b/crates/scp-ffi/uniffi/Cargo.toml
@@ -41,7 +41,7 @@ scp-media = { path = "../../scp-media" }
 scp-primitives = { path = "../../scp-primitives" }
 scp-identity = { path = "../../scp-identity", features = ["production-dht"] }
 scp-event-log = { path = "../../scp-event-log" }
-scp-ffi-common = { path = "../common" }
+scp-ffi-common = { path = "../common", features = ["custody"] }
 scp-node = { path = "../../scp-node", features = ["allow_unencrypted_storage"], optional = true }
 hex = { workspace = true }
 sha2 = { workspace = true }

--- a/crates/scp-ffi/uniffi/src/bridge.rs
+++ b/crates/scp-ffi/uniffi/src/bridge.rs
@@ -462,7 +462,13 @@ impl CallbackKeyCustody {
             .export_signing_key_bytes(handle.id().to_string())
             .await
             .map_err(|e| PlatformError::CustodyError(e.to_string()))?;
-        let arr = scp_ffi_common::custody_parse::expect_32("export_signing_key_bytes", &key_bytes)?;
+        // Private seed material: wrap the parsed 32-byte array in `Zeroizing`
+        // so the intermediate seed buffer is wiped on drop, matching the PyO3
+        // and NAPI callback custody paths (ADR-006).
+        let arr = zeroize::Zeroizing::new(scp_ffi_common::custody_parse::expect_32(
+            "export_signing_key_bytes",
+            &key_bytes,
+        )?);
         Ok(ed25519_dalek::SigningKey::from_bytes(&arr))
     }
 }

--- a/crates/scp-ffi/uniffi/src/bridge.rs
+++ b/crates/scp-ffi/uniffi/src/bridge.rs
@@ -268,13 +268,9 @@ impl KeyCustody for CallbackKeyCustody {
             .generate_keypair(type_str)
             .await
             .map_err(|e| PlatformError::CustodyError(e.to_string()))?;
-        // Parse the returned key_id string as a u64 handle identifier.
-        let id: u64 = key_id.parse().map_err(|_| {
-            PlatformError::CustodyError(format!(
-                "KeyCustodyProvider::generate_keypair returned non-numeric key_id: {key_id}"
-            ))
-        })?;
-        Ok(KeyHandle::new(id))
+        // Parse the returned key_id string as a u64 handle identifier via the
+        // shared helper (unifies the error text with the PyO3/napi bridges).
+        scp_ffi_common::custody_parse::parse_handle("generate_keypair", &key_id)
     }
 
     async fn sign(&self, key: &KeyHandle, data: &[u8]) -> Result<Signature, PlatformError> {
@@ -312,15 +308,9 @@ impl KeyCustody for CallbackKeyCustody {
             .dh_agree(key.id().to_string(), peer_public.to_vec())
             .await
             .map_err(|e| PlatformError::CustodyError(e.to_string()))?;
-        if shared.len() != 32 {
-            return Err(PlatformError::CustodyError(format!(
-                "dh_agree returned {} bytes, expected 32",
-                shared.len()
-            )));
-        }
-        let mut arr = [0u8; 32];
-        arr.copy_from_slice(&shared);
-        Ok(SharedSecret::new(arr))
+        Ok(SharedSecret::new(scp_ffi_common::custody_parse::expect_32(
+            "dh_agree", &shared,
+        )?))
     }
 
     async fn derive_pseudonym(
@@ -334,28 +324,8 @@ impl KeyCustody for CallbackKeyCustody {
             .await
             .map_err(|e| PlatformError::CustodyError(e.to_string()))?;
         // The callback returns concatenated [public_key_bytes (32) || key_id_utf8].
-        if result_bytes.len() < 33 {
-            return Err(PlatformError::CustodyError(format!(
-                "derive_pseudonym returned {} bytes, expected at least 33 \
-                 (32 public key + key_id)",
-                result_bytes.len()
-            )));
-        }
-        let public_key_bytes = &result_bytes[..32];
-        let key_id_str = std::str::from_utf8(&result_bytes[32..]).map_err(|_| {
-            PlatformError::CustodyError(
-                "derive_pseudonym key_id portion is not valid UTF-8".to_owned(),
-            )
-        })?;
-        let key_id: u64 = key_id_str.parse().map_err(|_| {
-            PlatformError::CustodyError(format!(
-                "derive_pseudonym key_id is not numeric: {key_id_str}"
-            ))
-        })?;
-        Ok(PseudonymKeypair {
-            public_key: PublicKey::new(public_key_bytes.to_vec()),
-            key_handle: KeyHandle::new(key_id),
-        })
+        // Unpack via the shared helper (unifies error text with PyO3/napi).
+        scp_ffi_common::custody_parse::unpack_pseudonym("derive_pseudonym", &result_bytes)
     }
 
     async fn derive_rotatable_pseudonym(
@@ -365,12 +335,14 @@ impl KeyCustody for CallbackKeyCustody {
         pseudonym_epoch: u64,
     ) -> Result<PseudonymKeypair, PlatformError> {
         // Rotatable pseudonyms append the epoch to the context_id before
-        // delegating to derive_pseudonym. The domain separator difference
-        // ("scp-pseudonym-v2") is handled by the platform adapter.
-        // For the callback interface, we encode epoch into the context_id.
-        let mut extended = context_id.to_vec();
-        extended.extend_from_slice(&pseudonym_epoch.to_be_bytes());
-        extended.extend_from_slice(b"scp-pseudonym-v2");
+        // delegating to derive_pseudonym. The canonical byte layout
+        // (`context_id || epoch_BE(8) || "scp-pseudonym-v2"`) lives in
+        // `scp_ffi_common::custody_parse::extend_context_id_for_rotation`,
+        // shared across all callback bridges so the wire format cannot drift.
+        let extended = scp_ffi_common::custody_parse::extend_context_id_for_rotation(
+            context_id,
+            pseudonym_epoch,
+        );
 
         let result_bytes = self
             .provider
@@ -378,27 +350,8 @@ impl KeyCustody for CallbackKeyCustody {
             .await
             .map_err(|e| PlatformError::CustodyError(e.to_string()))?;
 
-        if result_bytes.len() < 33 {
-            return Err(PlatformError::CustodyError(format!(
-                "derive_rotatable_pseudonym returned {} bytes, expected at least 33",
-                result_bytes.len()
-            )));
-        }
-        let public_key_bytes = &result_bytes[..32];
-        let key_id_str = std::str::from_utf8(&result_bytes[32..]).map_err(|_| {
-            PlatformError::CustodyError(
-                "derive_rotatable_pseudonym key_id is not valid UTF-8".to_owned(),
-            )
-        })?;
-        let key_id: u64 = key_id_str.parse().map_err(|_| {
-            PlatformError::CustodyError(format!(
-                "derive_rotatable_pseudonym key_id is not numeric: {key_id_str}"
-            ))
-        })?;
-        Ok(PseudonymKeypair {
-            public_key: PublicKey::new(public_key_bytes.to_vec()),
-            key_handle: KeyHandle::new(key_id),
-        })
+        // Unpack via the shared helper (unifies error text with PyO3/napi).
+        scp_ffi_common::custody_parse::unpack_pseudonym("derive_rotatable_pseudonym", &result_bytes)
     }
 
     async fn ed25519_to_x25519_agree(
@@ -413,15 +366,10 @@ impl KeyCustody for CallbackKeyCustody {
             .dh_agree(ed25519_handle.id().to_string(), peer_x25519_public.to_vec())
             .await
             .map_err(|e| PlatformError::CustodyError(e.to_string()))?;
-        if shared.len() != 32 {
-            return Err(PlatformError::CustodyError(format!(
-                "ed25519_to_x25519_agree returned {} bytes, expected 32",
-                shared.len()
-            )));
-        }
-        let mut arr = [0u8; 32];
-        arr.copy_from_slice(&shared);
-        Ok(SharedSecret::new(arr))
+        Ok(SharedSecret::new(scp_ffi_common::custody_parse::expect_32(
+            "ed25519_to_x25519_agree",
+            &shared,
+        )?))
     }
 
     fn custody_type(&self, key: &KeyHandle) -> CustodyType {
@@ -514,12 +462,7 @@ impl CallbackKeyCustody {
             .export_signing_key_bytes(handle.id().to_string())
             .await
             .map_err(|e| PlatformError::CustodyError(e.to_string()))?;
-        let arr: [u8; 32] = key_bytes.try_into().map_err(|v: Vec<u8>| {
-            PlatformError::CustodyError(format!(
-                "export_signing_key_bytes returned {} bytes, expected 32",
-                v.len()
-            ))
-        })?;
+        let arr = scp_ffi_common::custody_parse::expect_32("export_signing_key_bytes", &key_bytes)?;
         Ok(ed25519_dalek::SigningKey::from_bytes(&arr))
     }
 }


### PR DESCRIPTION
## Summary

Batch-4 review follow-up **F1**: extracts the duplicated callback-custody byte/string parsing into a single shared, unit-tested module, eliminating per-bridge drift in security-relevant parsing of untrusted custody-provider outputs.

- New `scp_ffi_common::custody_parse` (behind a dedicated `custody` feature): `parse_handle`, `expect_32`, `unpack_pseudonym`, and a newly-named `extend_context_id_for_rotation` (the previously-inlined `context_id || epoch_BE(8) || "scp-pseudonym-v2"` rotation layout). Bodies copied verbatim from the PyO3 reference; 9 new unit tests.
- PyO3 (`scp-ffi`) + NAPI (`scp-ffi-napi`) delete their byte-identical local helpers and call the shared ones; UniFFI (`scp-ffi-uniffi`) replaces its inlined parsing in the 6 `CallbackKeyCustody` methods. All mechanism-specific `impl KeyCustody` plumbing (`Py<PyAny>` / `ThreadsafeFunction` / `Box<dyn KeyCustodyProvider>`) is kept.
- **Behavior-preserving except**: UniFFI custody error *strings* are unified to the PyO3/NAPI format (more informative — names the method + protocol). No test asserted the old UniFFI strings.
- Also wraps the UniFFI `export_ed25519_signing_key` seed in `Zeroizing` for defense-in-depth parity with PyO3/NAPI (closes a pre-existing zeroize gap in the rewired function).

WASM is out of scope — its custody is a JS-imported interface with no such helpers.

Part of the #1543 cross-bridge symmetry work (umbrella already closed by PR-E; this is a post-Batch-4 review follow-up).

## Review
bug-catcher CLEAN (byte-identical, no swapped args, feature-gated correctly), security-reviewer CLEAN (validation preserved, no leak, bounds correct).

## Verification
`cargo test -p scp-ffi-common --features custody` (306, +9 new) + scp-ffi/-napi/-uniffi custody suites green; `clippy --workspace --all-targets` (CI features) + `fmt` clean; `cargo check -p scp-ffi-common` (no custody) + `-p scp-ffi-wasm --target wasm32` confirm correct feature gating.

🤖 Generated with [Claude Code](https://claude.com/claude-code)