### PR TITLE
fix(pseudonym): canonical cross-platform rotatable (v2) pseudonym + §25.19 KAT across all SDKs (#1551 Stage B)

### DIFF
--- a/bindings/kotlin/scp-kt-android/src/main/kotlin/works/limn/scp/android/platform/AndroidKeyCustody.kt
+++ b/bindings/kotlin/scp-kt-android/src/main/kotlin/works/limn/scp/android/platform/AndroidKeyCustody.kt
@@ -27,11 +27,11 @@ import android.security.keystore.KeyGenParameterSpec
 import android.security.keystore.KeyProperties
 import androidx.security.crypto.EncryptedSharedPreferences
 import androidx.security.crypto.MasterKeys
+import java.nio.ByteBuffer
+import java.nio.ByteOrder
 import java.security.KeyPairGenerator
 import java.security.KeyStore
 import java.security.Signature
-import java.nio.ByteBuffer
-import java.nio.ByteOrder
 import java.security.spec.NamedParameterSpec
 import java.util.UUID
 import java.util.concurrent.ConcurrentHashMap

--- a/bindings/kotlin/scp-kt-android/src/main/kotlin/works/limn/scp/android/platform/AndroidKeyCustody.kt
+++ b/bindings/kotlin/scp-kt-android/src/main/kotlin/works/limn/scp/android/platform/AndroidKeyCustody.kt
@@ -30,6 +30,8 @@ import androidx.security.crypto.MasterKeys
 import java.security.KeyPairGenerator
 import java.security.KeyStore
 import java.security.Signature
+import java.nio.ByteBuffer
+import java.nio.ByteOrder
 import java.security.spec.NamedParameterSpec
 import java.util.UUID
 import java.util.concurrent.ConcurrentHashMap
@@ -143,7 +145,7 @@ class AndroidKeyCustody internal constructor(
      *
      * Used to enforce type safety in [sign] and [dhAgree] operations.
      */
-    private val softwareKeyTypes = ConcurrentHashMap<String, KeyType>()
+    internal val softwareKeyTypes = ConcurrentHashMap<String, KeyType>()
 
     /**
      * Delegate for Bouncy Castle software key operations.
@@ -344,7 +346,7 @@ class AndroidKeyCustody internal constructor(
      * @throws ScpException with code `SCP-CRYPTO-4003` if the identity key is not Ed25519.
      */
     override fun derivePseudonym(keyHandle: KeyHandle, contextId: ByteArray): PseudonymKeyHandle {
-        // Enforce Ed25519 type for the source identity key
+        // Enforce Ed25519 type for the source identity key.
         if (keyHandle.custodyType == CustodyType.SOFTWARE) {
             val storedType = softwareKeyTypes[keyHandle.id]
             if (storedType != null && storedType != KeyType.ED25519) {
@@ -360,11 +362,94 @@ class AndroidKeyCustody internal constructor(
         // only the key holder can compute pseudonyms.
         val pseudonymSecret = derivePseudonymSecret(keyHandle)
 
+        // v1 HMAC body: contextId || "scp-pseudonym".
         val mac = Mac.getInstance("HmacSHA256")
         mac.init(SecretKeySpec(pseudonymSecret, "HmacSHA256"))
         pseudonymSecret.fill(0) // zeroize after use
         mac.update(contextId)
         mac.update("scp-pseudonym".toByteArray(Charsets.UTF_8))
+        val seed = mac.doFinal()
+
+        // Derive Ed25519 keypair from seed using FixedSecureRandom for determinism.
+        val pseudonymKeypair = Ed25519KeyPairGenerator().apply {
+            init(Ed25519KeyGenerationParameters(FixedSecureRandom(seed)))
+        }.generateKeyPair()
+        seed.fill(0) // zeroize after use
+
+        val pseudonymId = UUID.randomUUID().toString()
+        softwareKeys[pseudonymId] = pseudonymKeypair
+        softwareKeyTypes[pseudonymId] = KeyType.ED25519
+
+        return PseudonymKeyHandle(
+            id = pseudonymId,
+            custodyType = CustodyType.SOFTWARE,
+        )
+    }
+
+    /**
+     * Derives a deterministic, context-scoped, epoch-rotatable Ed25519 pseudonym keypair.
+     *
+     * Identical to [derivePseudonym] except the big-endian u64 epoch and the v2 domain
+     * separator are folded into the HMAC body, yielding an independent, unlinkable
+     * pseudonym per epoch for the same identity and context.
+     *
+     * ## Algorithm (spec section 9.10.4.A, rotatable variant):
+     *
+     *   1. Derive `pseudonymSecret` exactly as in [derivePseudonym] (HKDF for software
+     *      keys, TEE-sign for hardware keys).
+     *   2. Compute `seed = HMAC-SHA256(pseudonymSecret, contextId || BE64(epoch) ||
+     *      "scp-pseudonym-v2")`. The `BE64(epoch)` term is the 8-byte big-endian encoding
+     *      of [pseudonymEpoch].
+     *   3. Derive an Ed25519 keypair from the first 32 bytes of `seed`.
+     *
+     * The `"scp-pseudonym-v2"` separator differs from v1's `"scp-pseudonym"`, so a v2
+     * pseudonym at any epoch never collides with the v1 [derivePseudonym] output.
+     *
+     * Matches the Rust `derive_rotatable_pseudonym()` in `scp-platform/src/pseudonym.rs`
+     * (and the file/sqlite custody backends) so software-custody pseudonyms are identical
+     * across platforms. The hardware (TEE) path is device-local by design.
+     *
+     * @param keyHandle Handle to the identity Ed25519 key (source for derivation).
+     * @param contextId Raw context ID bytes.
+     * @param pseudonymEpoch Rotation epoch counter, mixed in as a big-endian u64.
+     * @return [PseudonymKeyHandle] referencing the derived signing key.
+     * @throws ScpException with code `SCP-CRYPTO-4001` if the identity key is not found.
+     * @throws ScpException with code `SCP-CRYPTO-4003` if the identity key is not Ed25519.
+     */
+    override fun deriveRotatablePseudonym(
+        keyHandle: KeyHandle,
+        contextId: ByteArray,
+        pseudonymEpoch: Long,
+    ): PseudonymKeyHandle {
+        // Enforce Ed25519 type for the source identity key.
+        if (keyHandle.custodyType == CustodyType.SOFTWARE) {
+            val storedType = softwareKeyTypes[keyHandle.id]
+            if (storedType != null && storedType != KeyType.ED25519) {
+                throw ScpException(
+                    "deriveRotatablePseudonym requires an Ed25519 key; " +
+                        "handle '${keyHandle.id}' is X25519",
+                    "SCP-CRYPTO-4003",
+                )
+            }
+        }
+
+        // Derive pseudonym_secret: HKDF for software keys, TEE-sign for hardware keys.
+        // Both approaches prevent the membership enumeration oracle (spec §9.10.4.A):
+        // only the key holder can compute pseudonyms.
+        val pseudonymSecret = derivePseudonymSecret(keyHandle)
+
+        // v2 HMAC body: contextId || BE64(epoch) || "scp-pseudonym-v2". The distinct domain
+        // separator means v2 at any epoch never collides with the v1 derivePseudonym output.
+        val epochBe = ByteBuffer.allocate(Long.SIZE_BYTES)
+            .order(ByteOrder.BIG_ENDIAN)
+            .putLong(pseudonymEpoch)
+            .array()
+        val mac = Mac.getInstance("HmacSHA256")
+        mac.init(SecretKeySpec(pseudonymSecret, "HmacSHA256"))
+        pseudonymSecret.fill(0) // zeroize after use
+        mac.update(contextId)
+        mac.update(epochBe)
+        mac.update("scp-pseudonym-v2".toByteArray(Charsets.UTF_8))
         val seed = mac.doFinal()
 
         // Derive Ed25519 keypair from seed using FixedSecureRandom for determinism.

--- a/bindings/kotlin/scp-kt-android/src/main/kotlin/works/limn/scp/android/platform/Types.kt
+++ b/bindings/kotlin/scp-kt-android/src/main/kotlin/works/limn/scp/android/platform/Types.kt
@@ -288,6 +288,38 @@ interface KeyCustodyProvider {
     fun derivePseudonym(keyHandle: KeyHandle, contextId: ByteArray): PseudonymKeyHandle
 
     /**
+     * Derive a deterministic, context-scoped, epoch-rotatable pseudonym keypair.
+     *
+     * Identical to [derivePseudonym] except the per-epoch domain separator and the
+     * big-endian epoch counter are mixed into the HMAC body, so each epoch yields an
+     * independent, unlinkable pseudonym for the same identity and context (spec
+     * §9.10.4.A). The HMAC key is the private-derived `pseudonym_secret`, NEVER the
+     * public key (public-key keying would be a membership-enumeration oracle):
+     *   1. `seed = HMAC-SHA256(pseudonym_secret, contextId || BE64(epoch) || "scp-pseudonym-v2")`
+     *   2. `pseudonym_keypair = Ed25519_keygen(seed[0..32])`  // RFC-8032 seed
+     *
+     * The `"scp-pseudonym-v2"` domain separator differs from v1's `"scp-pseudonym"`,
+     * so v2 at any epoch never collides with the v1 [derivePseudonym] output.
+     *
+     * Software custody: `pseudonym_secret = HKDF-SHA256(ed25519_private_seed,
+     * salt="scp-pseudonym-secret-v1")` — cross-platform deterministic. Hardware
+     * custody: a device-local secret inside the secure boundary — device-local
+     * by design (not identical across devices).
+     *
+     * @param keyHandle Handle to the identity Ed25519 key.
+     * @param contextId Raw context ID bytes.
+     * @param pseudonymEpoch Rotation epoch counter, mixed in as a big-endian u64.
+     * @return A [PseudonymKeyHandle] to the derived signing key.
+     * @throws ScpException with code `SCP-CRYPTO-4001` if key not found.
+     * @throws ScpException with code `SCP-CRYPTO-4003` if key is not Ed25519.
+     */
+    fun deriveRotatablePseudonym(
+        keyHandle: KeyHandle,
+        contextId: ByteArray,
+        pseudonymEpoch: Long,
+    ): PseudonymKeyHandle
+
+    /**
      * Export the raw Ed25519 private key bytes (32 bytes) for a key handle.
      *
      * Required for governance vote signing, which needs the raw signing key

--- a/bindings/kotlin/scp-kt-android/src/test/kotlin/works/limn/scp/android/platform/AndroidKeyCustodyTest.kt
+++ b/bindings/kotlin/scp-kt-android/src/test/kotlin/works/limn/scp/android/platform/AndroidKeyCustodyTest.kt
@@ -13,6 +13,8 @@
 package works.limn.scp.android.platform
 
 import android.content.SharedPreferences
+import org.bouncycastle.crypto.AsymmetricCipherKeyPair
+import org.bouncycastle.crypto.params.Ed25519PrivateKeyParameters
 import org.bouncycastle.crypto.params.Ed25519PublicKeyParameters
 import org.bouncycastle.crypto.signers.Ed25519Signer
 import org.junit.jupiter.api.Assertions.assertArrayEquals
@@ -771,5 +773,92 @@ class AndroidKeyCustodyTest {
             assertTrue(prefs.contains(identityPrefsKey))
             assertTrue(!prefs.contains(pseudonymPrefsKey))
         }
+    }
+
+    // -------------------------------------------------------------------
+    // Known-answer tests for pseudonym derivation (spec §25.19)
+    //
+    // Pins the software-custody Ed25519 pseudonym public key bytes for fixed
+    // identity seeds and context "context-alpha", proving the Kotlin adapter
+    // matches the cross-platform recipe shared with the Rust core and the other
+    // SDK bindings:
+    //   pseudonym_secret = HKDF-SHA256(seed, salt="scp-pseudonym-secret-v1")
+    //   v1 seed          = HMAC-SHA256(secret, ctx || "scp-pseudonym")
+    //   v2 seed          = HMAC-SHA256(secret, ctx || BE64(epoch) || "scp-pseudonym-v2")
+    //   pseudonym_pubkey = Ed25519_keygen(seed[0..32]).public_key
+    // -------------------------------------------------------------------
+
+    @Nested
+    inner class PseudonymKnownAnswerVectors {
+
+        @Test
+        fun `vector 30 static and rotatable pseudonyms match spec bytes`() {
+            assertVectorMatches(
+                seed = ByteArray(32) { 0x01 },
+                expectedV1 = "fddc04882a48aa39888f6dbec622f9c5aa6f06b2e40820a69a2e0e89b5f09ac2",
+                expectedV2Epoch1 = "43e50a947c4b2be44f871e309c7edc64afaf4207b9a589c9b01f61c01158090f",
+            )
+        }
+
+        @Test
+        fun `vector 31 static and rotatable pseudonyms match spec bytes`() {
+            // seed = 0x9d, then 0x01, 0x02, ... 0x1f (31 ascending bytes after the lead).
+            val seed = ByteArray(32) { i -> if (i == 0) 0x9d.toByte() else i.toByte() }
+            assertVectorMatches(
+                seed = seed,
+                expectedV1 = "ff6e2e909a008318f97bb2c26c1d787ceb9aa2996f746766335e10ba7e2213cc",
+                expectedV2Epoch1 = "edd47319719e2350d1db9488e0189f2405267d7dc243489cfd9aa6f3ac3fc639",
+            )
+        }
+
+        /**
+         * Injects a fixed identity seed, then asserts that v1 [derivePseudonym] and v2
+         * [AndroidKeyCustody.deriveRotatablePseudonym] (epoch 1) over context "context-alpha"
+         * produce the spec-pinned public key bytes, and that v1 and v2 are distinct.
+         */
+        private fun assertVectorMatches(
+            seed: ByteArray,
+            expectedV1: String,
+            expectedV2Epoch1: String,
+        ) {
+            val identityHandle = injectSoftwareEd25519(seed)
+            val contextAlpha = "context-alpha".toByteArray(Charsets.UTF_8)
+
+            val v1Pseudonym = custody.derivePseudonym(identityHandle, contextAlpha)
+            val v1Hex = pseudonymPublicKeyHex(v1Pseudonym)
+            assertEquals(expectedV1, v1Hex)
+
+            val v2Pseudonym = custody.deriveRotatablePseudonym(identityHandle, contextAlpha, 1L)
+            val v2Hex = pseudonymPublicKeyHex(v2Pseudonym)
+            assertEquals(expectedV2Epoch1, v2Hex)
+
+            assertNotEquals(v1Hex, v2Hex)
+        }
+
+        /**
+         * Inserts a deterministic software Ed25519 identity key built from [seed] directly
+         * into the custody's internal software-key maps, returning a [KeyHandle] for it.
+         *
+         * Bypasses [AndroidKeyCustody.generateKeypair] (which uses a random seed) so the KAT
+         * can pin a known identity seed (§25.19 vectors). Software path only — JVM unit tests
+         * cannot reach the Android Keystore hardware path.
+         */
+        private fun injectSoftwareEd25519(seed: ByteArray): KeyHandle {
+            val privateParams = Ed25519PrivateKeyParameters(seed, 0)
+            val publicParams = privateParams.generatePublicKey()
+            val keyId = "kat-${seed.toHexString().take(8)}"
+            custody.softwareKeys[keyId] = AsymmetricCipherKeyPair(publicParams, privateParams)
+            custody.softwareKeyTypes[keyId] = KeyType.ED25519
+            return KeyHandle(id = keyId, custodyType = CustodyType.SOFTWARE)
+        }
+
+        /** Resolves a derived pseudonym handle to its lowercase-hex public key bytes. */
+        private fun pseudonymPublicKeyHex(pseudonym: PseudonymKeyHandle): String =
+            custody.publicKey(
+                KeyHandle(id = pseudonym.id, custodyType = pseudonym.custodyType),
+            ).toHexString()
+
+        private fun ByteArray.toHexString(): String =
+            joinToString("") { byte -> "%02x".format(byte) }
     }
 }

--- a/bindings/python/scp_sdk/scp.py
+++ b/bindings/python/scp_sdk/scp.py
@@ -101,11 +101,46 @@ class KeyCustodyProvider(Protocol):
         ...
 
     def derive_pseudonym(self, key_id: str, context_id: bytes) -> bytes:
-        """Derive a context-scoped pseudonym keypair.
+        """Derive a context-scoped pseudonym keypair (v1, static).
 
         Returns ``public_key_bytes (32) || key_id_utf8`` — the 32-byte
         pseudonym public key concatenated with the UTF-8 numeric id of the
         derived signing key.
+
+        Canonical recipe (all custody backends MUST produce identical bytes)::
+
+            pseudonym_secret = HKDF-SHA256(
+                ikm=ed25519_private_seed, salt=b"scp-pseudonym-secret-v1",
+                info=b"", length=32)
+            seed = HMAC-SHA256(pseudonym_secret, context_id + b"scp-pseudonym")
+            pseudonym_keypair = Ed25519_keygen(seed[:32])
+        """
+        ...
+
+    def derive_rotatable_pseudonym(
+        self, key_id: str, context_id: bytes, pseudonym_epoch: int
+    ) -> bytes:
+        """Derive a rotatable, epoch-scoped pseudonym keypair (v2).
+
+        Returns the same ``public_key_bytes (32) || key_id_utf8`` shape as
+        :meth:`derive_pseudonym`. Including the rotation epoch in the HMAC
+        derivation produces a different pseudonym per epoch within the same
+        context, mitigating relay-side pseudonym correlation.
+
+        Canonical recipe (all custody backends MUST produce identical bytes)::
+
+            pseudonym_secret = HKDF-SHA256(
+                ikm=ed25519_private_seed, salt=b"scp-pseudonym-secret-v1",
+                info=b"", length=32)
+            seed = HMAC-SHA256(
+                pseudonym_secret,
+                context_id + pseudonym_epoch.to_bytes(8, "big")
+                + b"scp-pseudonym-v2")
+            pseudonym_keypair = Ed25519_keygen(seed[:32])
+
+        The ``"scp-pseudonym-v2"`` domain separator differs from the v1
+        ``"scp-pseudonym"`` so epoch 0 produces a distinct pseudonym from the
+        static v1 derivation.
         """
         ...
 

--- a/bindings/python/tests/pseudonym_recipe.py
+++ b/bindings/python/tests/pseudonym_recipe.py
@@ -1,0 +1,173 @@
+"""Canonical software-custody pseudonym derivation (spec §9.10.4.A, §25.19).
+
+Pure-Python, stdlib-only reference implementation of the cross-platform
+per-context pseudonym recipe that every SCP custody backend MUST reproduce
+byte-for-byte (Rust ``crates/scp-platform/src/pseudonym.rs`` plus the per-bridge
+custody callbacks; the TypeScript, Swift, and Kotlin SDKs implement the same
+recipe). It exists so the Python KAT and the Python custody test fixture share
+one canonical algorithm rather than re-deriving it (and risking drift) in each.
+
+The CI Python interpreter has neither PyNaCl nor ``cryptography`` installed, so
+HKDF/HMAC come from :mod:`hashlib`/:mod:`hmac` and Ed25519 public-key derivation
+is a compact RFC 8032 implementation. No native extension is required, so this
+module — and any test that imports it — runs under plain ``pytest``.
+
+Recipe (matching the Rust core)::
+
+    pseudonym_secret = HKDF-SHA256(
+        ikm=ed25519_private_seed (32 bytes),
+        salt=b"scp-pseudonym-secret-v1", info=b"", length=32)
+    seed_v1 = HMAC-SHA256(pseudonym_secret, context_id + b"scp-pseudonym")
+    seed_v2 = HMAC-SHA256(
+        pseudonym_secret,
+        context_id + pseudonym_epoch.to_bytes(8, "big") + b"scp-pseudonym-v2")
+    pseudonym_public_key = Ed25519_keygen(seed[:32]).public_key
+
+The blob returned by the custody callbacks is ``public_key_bytes (32) ||
+key_id_utf8``; the helpers here return the same shape so they can stand in for a
+real custody backend.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import hmac
+
+# Domain-separation constants — byte-for-byte identical to the Rust core.
+PSEUDONYM_SECRET_SALT = b"scp-pseudonym-secret-v1"
+PSEUDONYM_V1_INFO = b"scp-pseudonym"
+PSEUDONYM_V2_INFO = b"scp-pseudonym-v2"
+
+# ---------------------------------------------------------------------------
+# Minimal pure-Python Ed25519 (RFC 8032) public-key derivation — stdlib only.
+# Reference implementation (SUPERCOP-derived). Used solely to turn a 32-byte
+# context seed into its Ed25519 public key; not exercised by production code.
+# ---------------------------------------------------------------------------
+
+_q = 2**255 - 19
+_d = (-121665 * pow(121666, _q - 2, _q)) % _q
+_I = pow(2, (_q - 1) // 4, _q)
+
+
+def _inv(x: int) -> int:
+    return pow(x, _q - 2, _q)
+
+
+def _xrecover(y: int) -> int:
+    xx = (y * y - 1) * _inv(_d * y * y + 1)
+    x = pow(xx, (_q + 3) // 8, _q)
+    if (x * x - xx) % _q != 0:
+        x = (x * _I) % _q
+    if x % 2 != 0:
+        x = _q - x
+    return x
+
+
+_By = (4 * _inv(5)) % _q
+_Bx = _xrecover(_By)
+_B = (_Bx % _q, _By % _q)
+
+
+def _edwards(p: tuple[int, int], q: tuple[int, int]) -> tuple[int, int]:
+    x1, y1 = p
+    x2, y2 = q
+    x3 = (x1 * y2 + x2 * y1) * _inv(1 + _d * x1 * x2 * y1 * y2)
+    y3 = (y1 * y2 + x1 * x2) * _inv(1 - _d * x1 * x2 * y1 * y2)
+    return (x3 % _q, y3 % _q)
+
+
+def _scalarmult(p: tuple[int, int], e: int) -> tuple[int, int]:
+    if e == 0:
+        return (0, 1)
+    q = _scalarmult(p, e // 2)
+    q = _edwards(q, q)
+    if e & 1:
+        q = _edwards(q, p)
+    return q
+
+
+def _encodepoint(p: tuple[int, int]) -> bytes:
+    x, y = p
+    bits = y | ((x & 1) << 255)
+    return bits.to_bytes(32, "little")
+
+
+def _bit(h: bytes, i: int) -> int:
+    return (h[i // 8] >> (i % 8)) & 1
+
+
+def ed25519_public_key(seed: bytes) -> bytes:
+    """Derive the 32-byte Ed25519 public key from a 32-byte RFC 8032 seed."""
+    h = hashlib.sha512(seed).digest()
+    a = 2**254 + sum(2**i * _bit(h, i) for i in range(3, 254))
+    return _encodepoint(_scalarmult(_B, a))
+
+
+# ---------------------------------------------------------------------------
+# HKDF-SHA256 (RFC 5869) — stdlib only.
+# ---------------------------------------------------------------------------
+
+
+def hkdf_sha256(ikm: bytes, salt: bytes, info: bytes, length: int) -> bytes:
+    """RFC 5869 HKDF-SHA256: extract-then-expand to ``length`` bytes."""
+    prk = hmac.new(salt, ikm, hashlib.sha256).digest()
+    okm = b""
+    block = b""
+    counter = 1
+    while len(okm) < length:
+        block = hmac.new(prk, block + info + bytes([counter]), hashlib.sha256).digest()
+        okm += block
+        counter += 1
+    return okm[:length]
+
+
+# ---------------------------------------------------------------------------
+# Canonical pseudonym derivation.
+# ---------------------------------------------------------------------------
+
+
+def pseudonym_secret(ed25519_seed: bytes) -> bytes:
+    """Derive the 32-byte ``pseudonym_secret`` from an Ed25519 private seed."""
+    return hkdf_sha256(ed25519_seed, PSEUDONYM_SECRET_SALT, b"", 32)
+
+
+def canonical_pseudonym_seed(ed25519_seed: bytes, context_id: bytes) -> bytes:
+    """Return the v1 (static) 32-byte context seed for a context."""
+    secret = pseudonym_secret(ed25519_seed)
+    return hmac.new(secret, bytes(context_id) + PSEUDONYM_V1_INFO, hashlib.sha256).digest()
+
+
+def canonical_rotatable_pseudonym_seed(
+    ed25519_seed: bytes, context_id: bytes, pseudonym_epoch: int
+) -> bytes:
+    """Return the v2 (rotatable) 32-byte context seed for a context + epoch."""
+    secret = pseudonym_secret(ed25519_seed)
+    data = bytes(context_id) + pseudonym_epoch.to_bytes(8, "big") + PSEUDONYM_V2_INFO
+    return hmac.new(secret, data, hashlib.sha256).digest()
+
+
+def canonical_pseudonym_public_key(ed25519_seed: bytes, context_id: bytes) -> bytes:
+    """Return the 32-byte v1 pseudonym public key (the §25.19 KAT target)."""
+    return ed25519_public_key(canonical_pseudonym_seed(ed25519_seed, context_id))
+
+
+def canonical_rotatable_pseudonym_public_key(
+    ed25519_seed: bytes, context_id: bytes, pseudonym_epoch: int
+) -> bytes:
+    """Return the 32-byte v2 pseudonym public key (the §25.19 KAT target)."""
+    return ed25519_public_key(
+        canonical_rotatable_pseudonym_seed(ed25519_seed, context_id, pseudonym_epoch)
+    )
+
+
+def canonical_pseudonym_blob(ed25519_seed: bytes, context_id: bytes, key_id: str) -> bytes:
+    """Return the v1 custody blob: ``public_key (32) || key_id_utf8``."""
+    return canonical_pseudonym_public_key(ed25519_seed, context_id) + key_id.encode("utf-8")
+
+
+def canonical_rotatable_pseudonym_blob(
+    ed25519_seed: bytes, context_id: bytes, pseudonym_epoch: int, key_id: str
+) -> bytes:
+    """Return the v2 custody blob: ``public_key (32) || key_id_utf8``."""
+    public_key = canonical_rotatable_pseudonym_public_key(ed25519_seed, context_id, pseudonym_epoch)
+    return public_key + key_id.encode("utf-8")

--- a/bindings/python/tests/test_identity_create_with_custody.py
+++ b/bindings/python/tests/test_identity_create_with_custody.py
@@ -24,6 +24,13 @@ import hashlib
 
 import pytest
 
+from .pseudonym_recipe import (
+    canonical_pseudonym_blob,
+    canonical_pseudonym_seed,
+    canonical_rotatable_pseudonym_blob,
+    canonical_rotatable_pseudonym_seed,
+)
+
 # ---------------------------------------------------------------------------
 # Minimal pure-Python Ed25519 (RFC 8032) — stdlib only.
 # Reference implementation (SUPERCOP-derived). Used solely to back the test
@@ -149,11 +156,27 @@ class _FakeKeychain:
         return hashlib.sha256(self._seeds[key_id] + bytes(peer_public)).digest()
 
     def derive_pseudonym(self, key_id: str, context_id: bytes) -> bytes:
-        seed = hashlib.sha256(self._seeds[key_id] + bytes(context_id)).digest()
+        # Canonical v1 recipe (§9.10.4.A): HKDF-derived secret, then
+        # HMAC(context_id || "scp-pseudonym"). Register the derived signing
+        # key under a fresh id and return ``public_key (32) || key_id_utf8``.
+        seed = canonical_pseudonym_seed(self._seeds[key_id], context_id)
         kid = str(self._next)
         self._next += 1
         self._seeds[kid] = seed
-        return ed25519_publickey(seed) + kid.encode("utf-8")
+        return canonical_pseudonym_blob(self._seeds[key_id], context_id, kid)
+
+    def derive_rotatable_pseudonym(
+        self, key_id: str, context_id: bytes, pseudonym_epoch: int
+    ) -> bytes:
+        # Canonical v2 recipe (§9.10.4.A): HMAC(context_id || epoch_BE ||
+        # "scp-pseudonym-v2"). Same blob shape as the v1 path.
+        seed = canonical_rotatable_pseudonym_seed(self._seeds[key_id], context_id, pseudonym_epoch)
+        kid = str(self._next)
+        self._next += 1
+        self._seeds[kid] = seed
+        return canonical_rotatable_pseudonym_blob(
+            self._seeds[key_id], context_id, pseudonym_epoch, kid
+        )
 
     def export_signing_key_bytes(self, key_id: str) -> bytes:
         return self._seeds[key_id]

--- a/bindings/python/tests/test_pseudonym_kat.py
+++ b/bindings/python/tests/test_pseudonym_kat.py
@@ -1,0 +1,78 @@
+"""Byte-level Known-Answer Test (KAT) for per-context pseudonym derivation.
+
+Spec §9.10.4.A (algorithm) and §25.19 vectors 30 & 31 (pinned outputs).
+
+Software-custody pseudonym derivation is cross-platform deterministic: every
+SDK (Rust, Swift, Kotlin, TypeScript, Python) MUST reproduce the exact
+public-key bytes the spec pins for a given identity seed, ``context_id``, and
+epoch. This test exercises the pure-Python canonical recipe in
+:mod:`tests.pseudonym_recipe` and asserts the resulting bytes equal the spec
+literals — both the static (v1) and rotatable (v2, epoch 1) keys, plus a
+v1-vs-v2 distinctness check.
+
+The recipe is stdlib-only (HKDF/HMAC via :mod:`hashlib`/:mod:`hmac`, Ed25519 via
+a compact RFC 8032 implementation), so this KAT runs under plain ``pytest`` with
+no native extension built.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from .pseudonym_recipe import (
+    canonical_pseudonym_public_key,
+    canonical_rotatable_pseudonym_public_key,
+)
+
+# §25.19 context_id, shared by both vectors.
+CONTEXT_ALPHA = b"context-alpha"
+
+# §25.19 vectors. Seeds and expected public keys taken verbatim from the spec.
+# Each entry: (name, ed25519_seed, v1_pubkey_hex, v2_epoch1_pubkey_hex).
+VECTORS = [
+    (
+        "Vector 30 (seed 0x01 x 32)",
+        bytes([0x01] * 32),
+        "fddc04882a48aa39888f6dbec622f9c5aa6f06b2e40820a69a2e0e89b5f09ac2",
+        "43e50a947c4b2be44f871e309c7edc64afaf4207b9a589c9b01f61c01158090f",
+    ),
+    (
+        "Vector 31 (seed 0x9d,0x01..0x1f)",
+        bytes([0x9D]) + bytes(range(0x01, 0x20)),
+        "ff6e2e909a008318f97bb2c26c1d787ceb9aa2996f746766335e10ba7e2213cc",
+        "edd47319719e2350d1db9488e0189f2405267d7dc243489cfd9aa6f3ac3fc639",
+    ),
+]
+
+
+@pytest.mark.parametrize(("name", "seed", "v1_hex", "v2_hex"), VECTORS)
+def test_v1_static_pseudonym_matches_spec(name: str, seed: bytes, v1_hex: str, v2_hex: str) -> None:
+    """The v1 (static) pseudonym public key matches the §25.19 literal."""
+    public_key = canonical_pseudonym_public_key(seed, CONTEXT_ALPHA)
+    assert public_key.hex() == v1_hex, name
+
+
+@pytest.mark.parametrize(("name", "seed", "v1_hex", "v2_hex"), VECTORS)
+def test_v2_rotatable_pseudonym_matches_spec(
+    name: str, seed: bytes, v1_hex: str, v2_hex: str
+) -> None:
+    """The v2 (rotatable, epoch 1) pseudonym public key matches §25.19."""
+    public_key = canonical_rotatable_pseudonym_public_key(seed, CONTEXT_ALPHA, 1)
+    assert public_key.hex() == v2_hex, name
+
+
+@pytest.mark.parametrize(("name", "seed", "v1_hex", "v2_hex"), VECTORS)
+def test_v1_and_v2_derive_distinct_keys(name: str, seed: bytes, v1_hex: str, v2_hex: str) -> None:
+    """The v1 and v2 derivations yield distinct keys (domain separation)."""
+    v1 = canonical_pseudonym_public_key(seed, CONTEXT_ALPHA)
+    v2 = canonical_rotatable_pseudonym_public_key(seed, CONTEXT_ALPHA, 1)
+    assert v1 != v2, name
+
+
+def test_both_spec_vectors_present_and_well_formed() -> None:
+    """Both §25.19 vectors are present and produce 32-byte public keys."""
+    assert len(VECTORS) == 2
+    for _name, seed, _v1, _v2 in VECTORS:
+        assert len(seed) == 32
+        assert len(canonical_pseudonym_public_key(seed, CONTEXT_ALPHA)) == 32
+        assert len(canonical_rotatable_pseudonym_public_key(seed, CONTEXT_ALPHA, 1)) == 32

--- a/bindings/swift/Sources/SCP/Internal/ScpBindings.swift
+++ b/bindings/swift/Sources/SCP/Internal/ScpBindings.swift
@@ -11955,7 +11955,7 @@ public protocol KeyCustodyProvider: AnyObject, Sendable {
      * 1. `seed = HMAC-SHA256(pseudonym_secret, context_id || "scp-pseudonym")`
      * 2. `pseudonym_keypair = Ed25519_keygen(seed[0..32])`  // seed is an RFC-8032 Ed25519 seed
      *
-     * The HMAC key is the 32-byte `pseudonym_secret`, NEVER the public key --
+     * The HMAC key is the 32-byte `pseudonym_secret`, NEVER the public key —
      * public key bytes would be a membership-enumeration oracle (§9.10.4.A).
      * For software custody, `pseudonym_secret = HKDF-SHA256(ed25519_private_seed,
      * salt="scp-pseudonym-secret-v1")`, which is cross-platform deterministic
@@ -11968,6 +11968,40 @@ public protocol KeyCustodyProvider: AnyObject, Sendable {
      * The bridge unpacks this into a `PseudonymKeypair`.
      */
     func derivePseudonym(keyId: String, contextId: Data) async throws  -> Data
+    
+    /**
+     * Derive a rotatable (epoch-versioned) per-context pseudonym keypair.
+     *
+     * Canonical recipe (spec §9.10.4.A / §9.10.4.1): the HMAC key is the
+     * private-derived `pseudonym_secret` (HKDF over the Ed25519 private seed),
+     * NEVER the public key.
+     * `seed = HMAC-SHA256(pseudonym_secret, context_id || BE64(pseudonym_epoch) || "scp-pseudonym-v2")`;
+     * `keypair = Ed25519_keygen(seed[0..32])` (RFC-8032 seed). Returns
+     * `[pseudonym_public_key_bytes (32) || key_id_utf8]`.
+     *
+     * The `pseudonym_epoch` is passed through to the provider so it performs
+     * the canonical v2 derivation itself. Bridges MUST NOT synthesize a
+     * `context_id || BE64(epoch) || "scp-pseudonym-v2"` preimage and feed it to
+     * the v1 `derive_pseudonym` — that double-appends the v1 domain separator
+     * (`"scp-pseudonym"`) and diverges from the Rust reference.
+     *
+     * # Default
+     *
+     * Rust-side providers that do not rotate return `ScpError::Context`
+     * (SCP-CTX-2050) indicating the method is not implemented. Platform SDK
+     * adapters (Swift `AppleKeyCustody`, Kotlin `AndroidKeyCustody`) override
+     * this with real implementations.
+     *
+     * **Note:** `UniFFI` callback interfaces require foreign implementations to
+     * define all methods. The generated Swift protocol / Kotlin interface will
+     * include this method. The default here applies only to Rust-side callers.
+     *
+     * # Errors
+     *
+     * Returns `ScpError` if the key is not found, is not an Ed25519 key, or the
+     * provider does not support rotatable pseudonyms.
+     */
+    func deriveRotatablePseudonym(keyId: String, contextId: Data, pseudonymEpoch: UInt64) async throws  -> Data
     
     /**
      * Export the raw Ed25519 private key bytes (32 bytes) for `key_id`.
@@ -12246,6 +12280,53 @@ fileprivate struct UniffiCallbackInterfaceKeyCustodyProvider {
                 return try await uniffiObj.derivePseudonym(
                      keyId: try FfiConverterString.lift(keyId),
                      contextId: try FfiConverterData.lift(contextId)
+                )
+            }
+
+            let uniffiHandleSuccess = { (returnValue: Data) in
+                uniffiFutureCallback(
+                    uniffiCallbackData,
+                    UniffiForeignFutureStructRustBuffer(
+                        returnValue: FfiConverterData.lower(returnValue),
+                        callStatus: RustCallStatus()
+                    )
+                )
+            }
+            let uniffiHandleError = { (statusCode, errorBuf) in
+                uniffiFutureCallback(
+                    uniffiCallbackData,
+                    UniffiForeignFutureStructRustBuffer(
+                        returnValue: RustBuffer.empty(),
+                        callStatus: RustCallStatus(code: statusCode, errorBuf: errorBuf)
+                    )
+                )
+            }
+            let uniffiForeignFuture = uniffiTraitInterfaceCallAsyncWithError(
+                makeCall: makeCall,
+                handleSuccess: uniffiHandleSuccess,
+                handleError: uniffiHandleError,
+                lowerError: FfiConverterTypeScpError_lower
+            )
+            uniffiOutReturn.pointee = uniffiForeignFuture
+        },
+        deriveRotatablePseudonym: { (
+            uniffiHandle: UInt64,
+            keyId: RustBuffer,
+            contextId: RustBuffer,
+            pseudonymEpoch: UInt64,
+            uniffiFutureCallback: @escaping UniffiForeignFutureCompleteRustBuffer,
+            uniffiCallbackData: UInt64,
+            uniffiOutReturn: UnsafeMutablePointer<UniffiForeignFuture>
+        ) in
+            let makeCall = {
+                () async throws -> Data in
+                guard let uniffiObj = try? FfiConverterCallbackInterfaceKeyCustodyProvider.handleMap.get(handle: uniffiHandle) else {
+                    throw UniffiInternalError.unexpectedStaleHandle
+                }
+                return try await uniffiObj.deriveRotatablePseudonym(
+                     keyId: try FfiConverterString.lift(keyId),
+                     contextId: try FfiConverterData.lift(contextId),
+                     pseudonymEpoch: try FfiConverterUInt64.lift(pseudonymEpoch)
                 )
             }
 
@@ -15300,13 +15381,16 @@ private let initializationResult: InitializationResult = {
     if (uniffi_scp_ffi_uniffi_checksum_method_keycustodyprovider_dh_agree() != 52565) {
         return InitializationResult.apiChecksumMismatch
     }
-    if (uniffi_scp_ffi_uniffi_checksum_method_keycustodyprovider_derive_pseudonym() != 45052) {
+    if (uniffi_scp_ffi_uniffi_checksum_method_keycustodyprovider_derive_pseudonym() != 38646) {
         return InitializationResult.apiChecksumMismatch
     }
-    if (uniffi_scp_ffi_uniffi_checksum_method_keycustodyprovider_export_signing_key_bytes() != 26569) {
+    if (uniffi_scp_ffi_uniffi_checksum_method_keycustodyprovider_derive_rotatable_pseudonym() != 25367) {
         return InitializationResult.apiChecksumMismatch
     }
-    if (uniffi_scp_ffi_uniffi_checksum_method_keycustodyprovider_custody_type() != 59116) {
+    if (uniffi_scp_ffi_uniffi_checksum_method_keycustodyprovider_export_signing_key_bytes() != 55617) {
+        return InitializationResult.apiChecksumMismatch
+    }
+    if (uniffi_scp_ffi_uniffi_checksum_method_keycustodyprovider_custody_type() != 30807) {
         return InitializationResult.apiChecksumMismatch
     }
     if (uniffi_scp_ffi_uniffi_checksum_method_messagelistener_on_message() != 11557) {

--- a/bindings/swift/Sources/SCP/Platform/AppleKeyCustody.swift
+++ b/bindings/swift/Sources/SCP/Platform/AppleKeyCustody.swift
@@ -847,6 +847,125 @@ public extension AppleKeyCustody {
         }
     }
 
+    // MARK: deriveRotatablePseudonym
+
+    /// Derives a deterministic, context-scoped, epoch-rotatable Ed25519
+    /// pseudonym keypair.
+    ///
+    /// This is the v2 (rotatable) counterpart to ``derivePseudonym(_:contextId:)``.
+    /// It binds an additional 64-bit `pseudonymEpoch` into the derivation so a
+    /// member can rotate their context pseudonym (e.g. on a re-key event)
+    /// without changing their identity key.
+    ///
+    /// ## Algorithm (spec §9.10.4.1):
+    /// 1. Retrieve the Ed25519 private key bytes for `keyHandle` from Keychain.
+    /// 2. Derive `pseudonym_secret = HKDF-SHA256(ikm: private_key_bytes,
+    ///    salt: "scp-pseudonym-secret-v1", info: "", len: 32)` — identical to
+    ///    the v1 secret, so a single identity key feeds both derivations.
+    /// 3. Compute `seed = HMAC-SHA256(pseudonym_secret,
+    ///    contextId || BE64(pseudonymEpoch) || "scp-pseudonym-v2")`. The epoch is
+    ///    serialized as 8 big-endian bytes and the `"-v2"` domain separator keeps
+    ///    v2 outputs disjoint from v1 (`"scp-pseudonym"`).
+    /// 4. Derive an Ed25519 keypair from the first 32 bytes of `seed`.
+    /// 5. Store the derived private key in Keychain under a deterministic handle
+    ///    that also binds the epoch + `"v2"`, so it occupies a distinct slot from
+    ///    the v1 handle and from other epochs.
+    /// 6. Return a ``PseudonymResult`` with the 32-byte public key and the handle.
+    ///
+    /// **CRITICAL:** As in v1, the HMAC key is the private-derived
+    /// `pseudonym_secret`, never the public key — public-key keying would be a
+    /// membership-enumeration oracle. The `pseudonym_secret` is unknowable
+    /// without the identity private key.
+    ///
+    /// The derivation is deterministic: the same `keyHandle` + `contextId` +
+    /// `pseudonymEpoch` triple always produces the same pseudonym public key.
+    ///
+    /// - Parameters:
+    ///   - keyHandle: The UUID handle for the **identity** Ed25519 key (source
+    ///     key material for the derivation).
+    ///   - contextId: The raw context ID bytes used as the first HMAC message
+    ///     segment.
+    ///   - pseudonymEpoch: The rotation epoch, serialized as 8 big-endian bytes.
+    /// - Returns: A ``PseudonymResult`` containing the 32-byte pseudonym public
+    ///   key and an opaque handle to the derived signing key in Keychain.
+    /// - Throws: ``PlatformError/wrongKeyType(_:)`` if `keyHandle` is X25519,
+    ///   ``PlatformError/keyNotFound(_:)`` if the handle is unknown,
+    ///   ``PlatformError/biometricAuthenticationFailed(_:)`` if biometric
+    ///   gating is active and authentication fails,
+    ///   ``PlatformError/keychainError(_:)`` for Keychain failures,
+    ///   ``PlatformError/custodyError(_:)`` for HMAC or keygen failures.
+    ///
+    /// See ADR-025 Key custody, spec §9.10.4.1, and
+    /// `derive_pseudonym_keypair` in `scp-platform/src/pseudonym.rs` for the
+    /// canonical Rust reference implementation.
+    @concurrent
+    func deriveRotatablePseudonym(
+        _ keyHandle: String,
+        contextId: Data,
+        pseudonymEpoch: UInt64
+    ) async throws -> PseudonymResult {
+        let storedType = try fetchKeyType(for: keyHandle)
+        guard storedType == .ed25519 else {
+            throw PlatformError.wrongKeyType(
+                "deriveRotatablePseudonym requires an Ed25519 key; handle '\(keyHandle)' is X25519"
+            )
+        }
+
+        var privateKeyBytes = try fetchPrivateKeyBytes(for: keyHandle)
+        defer { privateKeyBytes.resetBytes(in: 0 ..< privateKeyBytes.count) }
+
+        // Epoch serialized as 8 big-endian bytes (matches Rust `u64::to_be_bytes`).
+        let epochBytes = withUnsafeBytes(of: pseudonymEpoch.bigEndian) { Data($0) }
+
+        do {
+            // Derive pseudonym_secret from private key via HKDF-SHA256 (identical
+            // to the v1 secret). This prevents membership enumeration attacks:
+            // only the key holder can compute pseudonyms.
+            let pseudonymSecret = HKDF<SHA256>.deriveKey(
+                inputKeyMaterial: SymmetricKey(data: privateKeyBytes),
+                salt: Data("scp-pseudonym-secret-v1".utf8),
+                info: Data(),
+                outputByteCount: 32
+            )
+
+            // HMAC-SHA256(pseudonym_secret, contextId || BE64(epoch) || "scp-pseudonym-v2")
+            var hmac = HMAC<SHA256>(key: pseudonymSecret)
+            hmac.update(data: contextId)
+            hmac.update(data: epochBytes)
+            hmac.update(data: Data("scp-pseudonym-v2".utf8))
+            let seed = Data(hmac.finalize())
+
+            // Derive Ed25519 keypair from the 32-byte HMAC-SHA256 output.
+            let pseudonymKey = try Curve25519.Signing.PrivateKey(rawRepresentation: seed.prefix(32))
+            let pseudonymPublicKey = pseudonymKey.publicKey.rawRepresentation
+
+            // Deterministic handle bound to epoch + "v2" so it occupies a distinct
+            // Keychain slot from the v1 handle and from other epochs:
+            // HMAC-SHA256(key_handle_utf8, contextId || BE64(epoch) || "scp-pseudonym-handle-v2")
+            let handleHmacKey = SymmetricKey(data: Data(keyHandle.utf8))
+            var handleHmac = HMAC<SHA256>(key: handleHmacKey)
+            handleHmac.update(data: contextId)
+            handleHmac.update(data: epochBytes)
+            handleHmac.update(data: Data("scp-pseudonym-handle-v2".utf8))
+            let pseudonymHandle = Data(handleHmac.finalize()).map { String(format: "%02x", $0) }.joined()
+
+            try storePrivateKeyBytes(
+                pseudonymKey.rawRepresentation,
+                for: pseudonymHandle,
+                keyType: .ed25519,
+                publicKeyBytes: pseudonymPublicKey
+            )
+
+            return PseudonymResult(publicKey: pseudonymPublicKey, handle: pseudonymHandle)
+        } catch let platformErr as PlatformError {
+            throw platformErr
+        } catch {
+            throw PlatformError.custodyError(
+                "Ed25519 rotatable pseudonym key derivation failed: \(error.localizedDescription)"
+            )
+        }
+    }
+
     // MARK: exportSigningKeyBytes
 
     /// Exports the raw 32-byte Ed25519 private key bytes for governance vote

--- a/bindings/swift/Tests/SCPTests/Platform/AppleKeyCustodyTests.swift
+++ b/bindings/swift/Tests/SCPTests/Platform/AppleKeyCustodyTests.swift
@@ -4,11 +4,13 @@
 // Apple Keychain backend. Each test creates keys with unique handles
 // and cleans up after itself to prevent Keychain pollution.
 //
-// The pseudonym derivation golden vector test verifies cross-platform
+// The pseudonym derivation known-answer test verifies cross-platform
 // determinism with the canonical Rust reference implementation
-// (`InMemoryKeyCustody` in `scp-platform/src/testing/key_custody.rs`).
+// (`derive_pseudonym_keypair` in `scp-platform/src/pseudonym.rs`), asserting
+// the literal spec §25.19 vectors for both the static (v1) and rotatable (v2)
+// derivations.
 //
-// ## Pseudonym derivation (spec §9.10.4.A)
+// ## Pseudonym derivation (spec §9.10.4.A, §9.10.4.1)
 //
 // The HMAC key is a private-derived `pseudonym_secret`, NEVER the public key
 // (public-key keying would be a membership-enumeration oracle). For software
@@ -18,7 +20,12 @@
 // pseudonym is device-local by design. The earlier ADR-027 amendment proposing
 // public-key keying was rejected.
 //
-// See spec §9.10.4.A, ADR-025 (Apple Platform Adapter), and ADR-006 (KeyCustody trait).
+// v1 (static):   seed = HMAC-SHA256(pseudonym_secret, contextId || "scp-pseudonym")
+// v2 (rotatable): seed = HMAC-SHA256(pseudonym_secret,
+//                          contextId || BE64(epoch) || "scp-pseudonym-v2")
+//
+// See spec §9.10.4.A, §9.10.4.1, §25.19, ADR-025 (Apple Platform Adapter), and
+// ADR-006 (KeyCustody trait).
 
 #if os(iOS) || os(macOS)
 
@@ -297,68 +304,6 @@
             try await custody.destroyKey(pseudonym.handle)
         }
 
-        /// Cross-platform golden-value test for pseudonym derivation.
-        ///
-        /// Verifies that the Swift `AppleKeyCustody.derivePseudonym` produces
-        /// the same pseudonym public key as the Rust `InMemoryKeyCustody`
-        /// reference implementation for the same inputs.
-        ///
-        /// The golden vector uses:
-        /// - Identity key seed: 0x00...01 (31 zeros, then 0x01)
-        /// - Context ID: "test" (4 bytes UTF-8)
-        /// - Algorithm: HKDF-SHA256 derives pseudonym_secret from private key,
-        ///   then HMAC-SHA256(pseudonym_secret, context_id || "scp-pseudonym")
-        ///
-        /// This test imports a known private key into the Keychain, derives the
-        /// pseudonym, and compares the result against the reference algorithm
-        /// computed locally.
-        @Test("derivePseudonym cross-platform golden vector (spec section 9.10.4.A)")
-        func derivePseudonymGoldenVector() async throws {
-            // Known identity key seed: 0x00...01 (31 zeros, then 0x01).
-            var seedBytes = Data(repeating: 0, count: 32)
-            seedBytes[31] = 1
-            let contextId = Data("test".utf8)
-
-            // Derive the public key from the seed for metadata caching.
-            let signingKey = try Curve25519.Signing.PrivateKey(rawRepresentation: seedBytes)
-            let publicKeyBytes = signingKey.publicKey.rawRepresentation
-
-            // Store the known seed as an Ed25519 private key in Keychain.
-            let handle = UUID().uuidString
-            try custody.storePrivateKeyBytes(
-                seedBytes, for: handle, keyType: .ed25519, publicKeyBytes: publicKeyBytes
-            )
-
-            // Compute expected pseudonym using the reference algorithm directly:
-            // Step 1: pseudonym_secret = HKDF-SHA256(ikm: private_key, salt: "scp-pseudonym-secret-v1", info: "", len: 32)
-            let pseudonymSecret = HKDF<SHA256>.deriveKey(
-                inputKeyMaterial: SymmetricKey(data: seedBytes),
-                salt: Data("scp-pseudonym-secret-v1".utf8),
-                info: Data(),
-                outputByteCount: 32
-            )
-            // Step 2: seed = HMAC-SHA256(pseudonym_secret, context_id || "scp-pseudonym")
-            var hmac = CryptoKit.HMAC<SHA256>(key: pseudonymSecret)
-            hmac.update(data: contextId)
-            hmac.update(data: Data("scp-pseudonym".utf8))
-            let expectedSeed = Data(hmac.finalize())
-
-            let expectedKey = try Curve25519.Signing.PrivateKey(rawRepresentation: expectedSeed.prefix(32))
-            let expectedPublicKey = expectedKey.publicKey.rawRepresentation
-
-            // Derive pseudonym through AppleKeyCustody
-            let pseudonym = try await custody.derivePseudonym(handle, contextId: contextId)
-
-            #expect(
-                pseudonym.publicKey == expectedPublicKey,
-                "pseudonym public key must match reference HKDF+HMAC-SHA256 algorithm output"
-            )
-
-            // Cleanup
-            try await custody.destroyKey(handle)
-            try await custody.destroyKey(pseudonym.handle)
-        }
-
         // MARK: - custodyType
 
         @Test("custodyType returns 'software' for all keys")
@@ -388,6 +333,182 @@
             try await custody.destroyKey(handle1)
             try await custody.destroyKey(handle2)
             try await custody.destroyKey(handle3)
+        }
+    }
+
+    // MARK: - Rotatable Pseudonym Tests
+
+    /// Tests for the v2 (rotatable, epoch-bound) pseudonym derivation and the
+    /// cross-platform §25.19 known-answer vectors covering both v1 and v2.
+    struct AppleKeyCustodyRotatablePseudonymTests {
+        /// Shared custody instance using default Keychain (no access group).
+        private let custody = AppleKeyCustody(accessGroup: nil)
+
+        @Test("deriveRotatablePseudonym is deterministic for same inputs")
+        func deriveRotatablePseudonymDeterministic() async throws {
+            let handle = try await custody.generateKeypair(keyType: "ed25519")
+            let contextId = Data("test-context".utf8)
+
+            let first = try await custody.deriveRotatablePseudonym(
+                handle, contextId: contextId, pseudonymEpoch: 1
+            )
+            let second = try await custody.deriveRotatablePseudonym(
+                handle, contextId: contextId, pseudonymEpoch: 1
+            )
+
+            #expect(
+                first.publicKey == second.publicKey,
+                "same identity key + same context_id + same epoch = same pseudonym public key"
+            )
+
+            // Cleanup
+            try await custody.destroyKey(handle)
+            try await custody.destroyKey(first.handle)
+            // second.handle is deterministic and equals first.handle, so already destroyed
+        }
+
+        @Test("deriveRotatablePseudonym produces different keys for different epochs")
+        func deriveRotatablePseudonymDifferentEpochs() async throws {
+            let handle = try await custody.generateKeypair(keyType: "ed25519")
+            let contextId = Data("rotating-context".utf8)
+
+            let epoch1 = try await custody.deriveRotatablePseudonym(
+                handle, contextId: contextId, pseudonymEpoch: 1
+            )
+            let epoch2 = try await custody.deriveRotatablePseudonym(
+                handle, contextId: contextId, pseudonymEpoch: 2
+            )
+
+            #expect(
+                epoch1.publicKey != epoch2.publicKey,
+                "different epochs must produce different pseudonyms"
+            )
+            #expect(
+                epoch1.handle != epoch2.handle,
+                "different epochs must occupy distinct Keychain handle slots"
+            )
+
+            // Cleanup
+            try await custody.destroyKey(handle)
+            try await custody.destroyKey(epoch1.handle)
+            try await custody.destroyKey(epoch2.handle)
+        }
+
+        @Test("deriveRotatablePseudonym with X25519 key throws wrongKeyType")
+        func deriveRotatablePseudonymX25519Fails() async throws {
+            let handle = try await custody.generateKeypair(keyType: "x25519")
+            await #expect(throws: PlatformError.self) {
+                _ = try await custody.deriveRotatablePseudonym(
+                    handle, contextId: Data("ctx".utf8), pseudonymEpoch: 1
+                )
+            }
+            // Cleanup
+            try await custody.destroyKey(handle)
+        }
+
+        /// Cross-platform known-answer test (KAT) for pseudonym derivation.
+        ///
+        /// Asserts the Swift `AppleKeyCustody` pseudonym derivations reproduce
+        /// the canonical spec §25.19 vectors byte-for-byte, proving the Swift
+        /// adapter is wire-compatible with the Rust `derive_pseudonym_keypair`
+        /// reference (`scp-platform/src/pseudonym.rs`) across all SDKs.
+        ///
+        /// Both vectors use `context_id = "context-alpha"` (ASCII). For each
+        /// identity seed the test asserts:
+        /// - v1 (`derivePseudonym`) public key equals the literal §25.19 hex.
+        /// - v2 epoch 1 (`deriveRotatablePseudonym`) public key equals the
+        ///   literal §25.19 hex.
+        /// - v1 ≠ v2 (domain separation between `"scp-pseudonym"` and
+        ///   `"scp-pseudonym-v2"`).
+        @Test("pseudonym derivation matches §25.19 known-answer vectors")
+        func pseudonymKnownAnswerVectors() async throws {
+            let contextId = Data("context-alpha".utf8)
+
+            // §25.19 V30: identity seed = 0x01 repeated 32 times.
+            let seedV30 = Data(repeating: 0x01, count: 32)
+            let v1ExpectedV30 = try hexToData(
+                "fddc04882a48aa39888f6dbec622f9c5aa6f06b2e40820a69a2e0e89b5f09ac2"
+            )
+            let v2ExpectedV30 = try hexToData(
+                "43e50a947c4b2be44f871e309c7edc64afaf4207b9a589c9b01f61c01158090f"
+            )
+
+            // §25.19 V31: identity seed = 0x9D, then 0x01, 0x02, ..., 0x1F.
+            var seedV31 = Data([0x9D])
+            seedV31.append(contentsOf: [UInt8](1 ... 31))
+            let v1ExpectedV31 = try hexToData(
+                "ff6e2e909a008318f97bb2c26c1d787ceb9aa2996f746766335e10ba7e2213cc"
+            )
+            let v2ExpectedV31 = try hexToData(
+                "edd47319719e2350d1db9488e0189f2405267d7dc243489cfd9aa6f3ac3fc639"
+            )
+
+            for (seedBytes, v1Expected, v2Expected) in [
+                (seedV30, v1ExpectedV30, v2ExpectedV30),
+                (seedV31, v1ExpectedV31, v2ExpectedV31)
+            ] {
+                #expect(seedBytes.count == 32, "identity seed must be 32 bytes")
+
+                // Derive the public key from the seed for metadata caching.
+                let signingKey = try Curve25519.Signing.PrivateKey(rawRepresentation: seedBytes)
+                let publicKeyBytes = signingKey.publicKey.rawRepresentation
+
+                // Store the known seed as an Ed25519 identity key in Keychain.
+                let handle = UUID().uuidString
+                try custody.storePrivateKeyBytes(
+                    seedBytes, for: handle, keyType: .ed25519, publicKeyBytes: publicKeyBytes
+                )
+
+                // v1 (static) pseudonym.
+                let staticPseudonym = try await custody.derivePseudonym(handle, contextId: contextId)
+                #expect(
+                    staticPseudonym.publicKey == v1Expected,
+                    "v1 pseudonym public key must match the §25.19 KAT vector"
+                )
+
+                // v2 (rotatable) pseudonym at epoch 1.
+                let rotatablePseudonym = try await custody.deriveRotatablePseudonym(
+                    handle, contextId: contextId, pseudonymEpoch: 1
+                )
+                #expect(
+                    rotatablePseudonym.publicKey == v2Expected,
+                    "v2 (epoch=1) pseudonym public key must match the §25.19 KAT vector"
+                )
+
+                // Domain separation: v1 and v2 must differ.
+                #expect(
+                    staticPseudonym.publicKey != rotatablePseudonym.publicKey,
+                    "v1 and v2 derivations must differ (domain separation)"
+                )
+
+                // Cleanup
+                try await custody.destroyKey(handle)
+                try await custody.destroyKey(staticPseudonym.handle)
+                try await custody.destroyKey(rotatablePseudonym.handle)
+            }
+        }
+
+        // MARK: - Helpers
+
+        /// Decodes an even-length lowercase hex string into raw bytes.
+        ///
+        /// Used to load the literal §25.19 known-answer vectors without any
+        /// self-derivation, so a regression in the derivation cannot mask itself.
+        private func hexToData(_ hex: String) throws -> Data {
+            guard hex.count % 2 == 0 else {
+                throw PlatformError.custodyError("hex string must have even length")
+            }
+            var data = Data(capacity: hex.count / 2)
+            var index = hex.startIndex
+            while index < hex.endIndex {
+                let next = hex.index(index, offsetBy: 2)
+                guard let byte = UInt8(hex[index ..< next], radix: 16) else {
+                    throw PlatformError.custodyError("invalid hex byte in '\(hex)'")
+                }
+                data.append(byte)
+                index = next
+            }
+            return data
         }
     }
 

--- a/bindings/typescript/src/scp.ts
+++ b/bindings/typescript/src/scp.ts
@@ -292,6 +292,18 @@ export interface KeyCustodyProvider {
    */
   derivePseudonym(keyId: string, contextId: Uint8Array): Uint8Array;
   /**
+   * Derive a rotatable (epoch-versioned) context-scoped pseudonym keypair.
+   * Identical layout to {@link derivePseudonym} — returns
+   * `publicKey(32) || keyIdUtf8` — but the derivation mixes the big-endian
+   * 64-bit `pseudonymEpoch` and a distinct domain separator so rotating the
+   * epoch yields an unlinkable new keypair (spec §9.10.4.A).
+   */
+  deriveRotatablePseudonym(
+    keyId: string,
+    contextId: Uint8Array,
+    pseudonymEpoch: bigint,
+  ): Uint8Array;
+  /**
    * Return the 32 raw Ed25519 private-seed bytes for `keyId`. Required for
    * governance vote signing; hardware-bound custody should throw.
    */
@@ -470,10 +482,10 @@ export class SCP {
    */
   async identityCreateWithCustody(provider: KeyCustodyProvider): Promise<Identity> {
     // Validate provider completeness up front. The byte-converting adapter
-    // below always supplies all eight closures, so a provider missing a method
+    // below always supplies all nine closures, so a provider missing a method
     // would otherwise surface only later as a cryptic native "oneshot canceled"
     // failure. Checking here makes the returned promise reject early with a
-    // clear, actionable error. Mirrors the eight methods on KeyCustodyProvider.
+    // clear, actionable error. Mirrors the nine methods on KeyCustodyProvider.
     const REQUIRED = [
       "generateKeypair",
       "sign",
@@ -481,6 +493,7 @@ export class SCP {
       "destroyKey",
       "dhAgree",
       "derivePseudonym",
+      "deriveRotatablePseudonym",
       "exportSigningKeyBytes",
       "custodyType",
     ] as const;
@@ -516,6 +529,11 @@ export class SCP {
         Array.from(provider.dhAgree(keyId, Uint8Array.from(peerPublic))),
       derivePseudonym: ([keyId, contextId]: [string, number[]]): number[] =>
         Array.from(provider.derivePseudonym(keyId, Uint8Array.from(contextId))),
+      // The Rust `(String, Vec<u8>, u64)` tuple likewise arrives as a single
+      // `[keyId, contextId, epoch]` array; the `u64` epoch crosses as a JS
+      // `bigint` (the field's declared `ts_type`).
+      deriveRotatablePseudonym: ([keyId, contextId, epoch]: [string, number[], bigint]): number[] =>
+        Array.from(provider.deriveRotatablePseudonym(keyId, Uint8Array.from(contextId), epoch)),
       exportSigningKeyBytes: (keyId: string): number[] =>
         Array.from(provider.exportSigningKeyBytes(keyId)),
       custodyType: (keyId: string): string => provider.custodyType(keyId),

--- a/bindings/typescript/tests/identity-create-with-custody.test.ts
+++ b/bindings/typescript/tests/identity-create-with-custody.test.ts
@@ -53,19 +53,22 @@ class CryptoKeychain implements KeyCustodyProvider {
     return kid;
   }
 
-  #keyObject(keyId: string): crypto.KeyObject {
-    const seed = this.#seeds.get(keyId);
-    if (seed === undefined) throw new Error(`unknown key id: ${keyId}`);
-    // Reconstruct an Ed25519 private key from the raw 32-byte seed via the
-    // standard PKCS8 DER encoding. Node's OKP JWK import requires the public
-    // `x` too; the PKCS8 form needs only the seed.
+  // Reconstruct an Ed25519 private key from a raw 32-byte seed via the standard
+  // PKCS8 DER encoding. Node's OKP JWK import requires the public `x` too; the
+  // PKCS8 form needs only the seed.
+  #keyObjectFromSeed(seed: Uint8Array): crypto.KeyObject {
     const der = Buffer.concat([
       // 16-byte Ed25519 PKCS8 prefix + 32-byte seed = valid PKCS8 DER.
       Buffer.from("302e020100300506032b657004220420", "hex"),
       Buffer.from(seed),
     ]);
-    const priv = crypto.createPrivateKey({ key: der, format: "der", type: "pkcs8" });
-    return priv;
+    return crypto.createPrivateKey({ key: der, format: "der", type: "pkcs8" });
+  }
+
+  #keyObject(keyId: string): crypto.KeyObject {
+    const seed = this.#seeds.get(keyId);
+    if (seed === undefined) throw new Error(`unknown key id: ${keyId}`);
+    return this.#keyObjectFromSeed(seed);
   }
 
   sign(keyId: string, message: Uint8Array): Uint8Array {
@@ -92,25 +95,60 @@ class CryptoKeychain implements KeyCustodyProvider {
     return new Uint8Array(h.digest());
   }
 
-  derivePseudonym(keyId: string, contextId: Uint8Array): Uint8Array {
-    const seed = this.#seeds.get(keyId) ?? new Uint8Array(32);
-    const h = crypto.createHash("sha256");
-    h.update(Buffer.from(seed));
-    h.update(Buffer.from(contextId));
-    const pseudoSeed = h.digest(); // 32 bytes
-    // Reconstruct the derived Ed25519 key from the seed via PKCS8 DER (the OKP
-    // JWK import path requires the public `x`; PKCS8 needs only the seed).
-    const der = Buffer.concat([
-      // 16-byte Ed25519 PKCS8 prefix + 32-byte seed = valid PKCS8 DER.
-      Buffer.from("302e020100300506032b657004220420", "hex"),
-      Buffer.from(pseudoSeed),
-    ]);
-    const priv = crypto.createPrivateKey({ key: der, format: "der", type: "pkcs8" });
-    const pubJwk = crypto.createPublicKey(priv).export({ format: "jwk" }) as { x: string };
+  // Canonical per-context pseudonym secret (spec §9.10.4.A / §25.19):
+  //   pseudonym_secret = HKDF-SHA256(ikm = seed, salt = "scp-pseudonym-secret-v1",
+  //                                  info = "", len = 32)
+  #pseudonymSecret(keyId: string): Buffer {
+    const seed = this.#seeds.get(keyId);
+    if (seed === undefined) throw new Error(`unknown key id: ${keyId}`);
+    return Buffer.from(
+      crypto.hkdfSync(
+        "sha256",
+        Buffer.from(seed),
+        Buffer.from("scp-pseudonym-secret-v1"),
+        Buffer.alloc(0),
+        32,
+      ),
+    );
+  }
+
+  // Register a derived 32-byte context seed as a fresh signing key and return
+  // `publicKey(32) || keyIdUtf8` — the wire layout the native bridge unpacks.
+  #pseudonymFromContextSeed(contextSeed: Buffer): Uint8Array {
+    const pubJwk = crypto
+      .createPublicKey(this.#keyObjectFromSeed(contextSeed))
+      .export({ format: "jwk" }) as { x: string };
     const pub = Buffer.from(pubJwk.x, "base64url");
     const kid = String(this.#next++);
-    this.#seeds.set(kid, new Uint8Array(pseudoSeed));
+    this.#seeds.set(kid, new Uint8Array(contextSeed));
     return new Uint8Array(Buffer.concat([pub, Buffer.from(kid, "utf-8")]));
+  }
+
+  derivePseudonym(keyId: string, contextId: Uint8Array): Uint8Array {
+    // v1 (static): context_seed = HMAC-SHA256(secret, context_id || "scp-pseudonym")
+    const data = Buffer.concat([Buffer.from(contextId), Buffer.from("scp-pseudonym")]);
+    const contextSeed = crypto
+      .createHmac("sha256", this.#pseudonymSecret(keyId))
+      .update(data)
+      .digest();
+    return this.#pseudonymFromContextSeed(contextSeed);
+  }
+
+  deriveRotatablePseudonym(
+    keyId: string,
+    contextId: Uint8Array,
+    pseudonymEpoch: bigint,
+  ): Uint8Array {
+    // v2 (rotatable): context_seed = HMAC-SHA256(
+    //   secret, context_id || BE64(epoch) || "scp-pseudonym-v2")
+    const be = Buffer.alloc(8);
+    be.writeBigUInt64BE(pseudonymEpoch);
+    const data = Buffer.concat([Buffer.from(contextId), be, Buffer.from("scp-pseudonym-v2")]);
+    const contextSeed = crypto
+      .createHmac("sha256", this.#pseudonymSecret(keyId))
+      .update(data)
+      .digest();
+    return this.#pseudonymFromContextSeed(contextSeed);
   }
 
   exportSigningKeyBytes(keyId: string): Uint8Array {

--- a/bindings/typescript/tests/pseudonym-kat.test.ts
+++ b/bindings/typescript/tests/pseudonym-kat.test.ts
@@ -1,0 +1,220 @@
+/**
+ * Byte-level Known-Answer Test (KAT) for cross-platform per-context pseudonym
+ * derivation (spec §9.10.4.A, §25.19 vectors 30 & 31).
+ *
+ * Software-custody pseudonym derivation is cross-platform deterministic: every
+ * SDK (Rust, Swift, Kotlin, TypeScript) MUST reproduce the exact public-key
+ * bytes the spec pins for a given identity seed, `context_id`, and epoch
+ * (§25.19). This test re-implements the canonical recipe in pure JS using
+ * `node:crypto` and asserts the resulting bytes equal the spec literals — both
+ * the static (v1) and rotatable (v2, epoch 1) keys.
+ *
+ * Canonical recipe (spec §25.19, matching `crates/scp-platform/src/pseudonym.rs`):
+ *   pseudonym_secret  = HKDF-SHA256(ikm = ed25519_seed, salt = "scp-pseudonym-secret-v1",
+ *                                   info = "", len = 32)
+ *   context_seed_v1   = HMAC-SHA256(secret, context_id || "scp-pseudonym")
+ *   context_seed_v2   = HMAC-SHA256(secret, context_id || BE64(epoch) || "scp-pseudonym-v2")
+ *   pseudonym_pub_key = Ed25519_keygen(context_seed[0..32]).public_key
+ *
+ * Pure JS — no native NAPI addon required — so it runs under plain `bun test`.
+ * The fixture is the same `KeyCustodyProvider` shape the bridge drives, proving
+ * the TS SDK's documented custody contract derives the canonical bytes.
+ */
+
+import { describe, expect, test } from "bun:test";
+import * as crypto from "node:crypto";
+
+import type { KeyCustodyProvider } from "../src/scp";
+
+// 16-byte Ed25519 PKCS8 DER prefix; prepended to a 32-byte seed yields a valid
+// PKCS8 encoding that `crypto.createPrivateKey` accepts (the OKP JWK import path
+// would additionally require the public `x`, which we do not have yet).
+const ED25519_PKCS8_PREFIX = Buffer.from("302e020100300506032b657004220420", "hex");
+
+const PSEUDONYM_SECRET_SALT = "scp-pseudonym-secret-v1";
+const PSEUDONYM_V1_INFO = "scp-pseudonym";
+const PSEUDONYM_V2_INFO = "scp-pseudonym-v2";
+
+/**
+ * Canonical software-custody fixture implementing {@link KeyCustodyProvider}.
+ *
+ * Keys are seeded deterministically via {@link storeSeed} so the KAT can pin a
+ * known identity seed (§25.19 vectors) rather than a random one.
+ */
+class CanonicalKeychain implements KeyCustodyProvider {
+  #seeds = new Map<string, Uint8Array>();
+  #next = 1;
+
+  /** Register a known 32-byte Ed25519 seed and return its opaque id. */
+  storeSeed(seed: Uint8Array): string {
+    const kid = String(this.#next++);
+    this.#seeds.set(kid, new Uint8Array(seed));
+    return kid;
+  }
+
+  generateKeypair(_keyType: string): string {
+    const { privateKey } = crypto.generateKeyPairSync("ed25519");
+    const jwk = privateKey.export({ format: "jwk" }) as { d: string };
+    return this.storeSeed(new Uint8Array(Buffer.from(jwk.d, "base64url")));
+  }
+
+  #keyObjectFromSeed(seed: Uint8Array): crypto.KeyObject {
+    const der = Buffer.concat([ED25519_PKCS8_PREFIX, Buffer.from(seed)]);
+    return crypto.createPrivateKey({ key: der, format: "der", type: "pkcs8" });
+  }
+
+  #publicKeyFromSeed(seed: Uint8Array): Buffer {
+    const jwk = crypto.createPublicKey(this.#keyObjectFromSeed(seed)).export({ format: "jwk" }) as {
+      x: string;
+    };
+    return Buffer.from(jwk.x, "base64url");
+  }
+
+  sign(keyId: string, message: Uint8Array): Uint8Array {
+    return new Uint8Array(crypto.sign(null, Buffer.from(message), this.#keyObject(keyId)));
+  }
+
+  #keyObject(keyId: string): crypto.KeyObject {
+    const seed = this.#seeds.get(keyId);
+    if (seed === undefined) throw new Error(`unknown key id: ${keyId}`);
+    return this.#keyObjectFromSeed(seed);
+  }
+
+  getPublicKey(keyId: string): Uint8Array {
+    const seed = this.#seeds.get(keyId);
+    if (seed === undefined) throw new Error(`unknown key id: ${keyId}`);
+    return new Uint8Array(this.#publicKeyFromSeed(seed));
+  }
+
+  destroyKey(keyId: string): void {
+    this.#seeds.delete(keyId);
+  }
+
+  dhAgree(keyId: string, peerPublic: Uint8Array): Uint8Array {
+    // Not exercised by the KAT; a deterministic stand-in keeps the surface
+    // complete (pseudonym derivation does not depend on it).
+    const seed = this.#seeds.get(keyId) ?? new Uint8Array(32);
+    return new Uint8Array(
+      crypto
+        .createHash("sha256")
+        .update(Buffer.from(seed))
+        .update(Buffer.from(peerPublic))
+        .digest(),
+    );
+  }
+
+  #pseudonymSecret(keyId: string): Buffer {
+    const seed = this.#seeds.get(keyId);
+    if (seed === undefined) throw new Error(`unknown key id: ${keyId}`);
+    return Buffer.from(
+      crypto.hkdfSync(
+        "sha256",
+        Buffer.from(seed),
+        Buffer.from(PSEUDONYM_SECRET_SALT),
+        Buffer.alloc(0),
+        32,
+      ),
+    );
+  }
+
+  #registerContextSeed(contextSeed: Buffer): Uint8Array {
+    const pub = this.#publicKeyFromSeed(contextSeed);
+    const kid = String(this.#next++);
+    this.#seeds.set(kid, new Uint8Array(contextSeed));
+    return new Uint8Array(Buffer.concat([pub, Buffer.from(kid, "utf-8")]));
+  }
+
+  derivePseudonym(keyId: string, contextId: Uint8Array): Uint8Array {
+    const data = Buffer.concat([Buffer.from(contextId), Buffer.from(PSEUDONYM_V1_INFO)]);
+    const contextSeed = crypto
+      .createHmac("sha256", this.#pseudonymSecret(keyId))
+      .update(data)
+      .digest();
+    return this.#registerContextSeed(contextSeed);
+  }
+
+  deriveRotatablePseudonym(
+    keyId: string,
+    contextId: Uint8Array,
+    pseudonymEpoch: bigint,
+  ): Uint8Array {
+    const be = Buffer.alloc(8);
+    be.writeBigUInt64BE(pseudonymEpoch);
+    const data = Buffer.concat([Buffer.from(contextId), be, Buffer.from(PSEUDONYM_V2_INFO)]);
+    const contextSeed = crypto
+      .createHmac("sha256", this.#pseudonymSecret(keyId))
+      .update(data)
+      .digest();
+    return this.#registerContextSeed(contextSeed);
+  }
+
+  exportSigningKeyBytes(keyId: string): Uint8Array {
+    const seed = this.#seeds.get(keyId);
+    if (seed === undefined) throw new Error(`unknown key id: ${keyId}`);
+    return new Uint8Array(seed);
+  }
+
+  custodyType(_keyId: string): string {
+    return "software";
+  }
+}
+
+// Extract the 32-byte public key from the `publicKey(32) || keyIdUtf8` blob the
+// provider returns.
+function pseudonymPublicKeyHex(blob: Uint8Array): string {
+  return Buffer.from(blob.subarray(0, 32)).toString("hex");
+}
+
+// §25.19 context_id, shared by both vectors.
+const CONTEXT_ALPHA = new Uint8Array(Buffer.from("context-alpha", "utf-8"));
+
+// §25.19 vectors. Seeds and expected public keys taken verbatim from the spec.
+interface Kat {
+  name: string;
+  seed: Uint8Array;
+  v1: string;
+  v2Epoch1: string;
+}
+
+const VECTORS: readonly Kat[] = [
+  {
+    name: "Vector 30 (seed 0x01 x 32)",
+    seed: new Uint8Array(Buffer.alloc(32, 0x01)),
+    v1: "fddc04882a48aa39888f6dbec622f9c5aa6f06b2e40820a69a2e0e89b5f09ac2",
+    v2Epoch1: "43e50a947c4b2be44f871e309c7edc64afaf4207b9a589c9b01f61c01158090f",
+  },
+  {
+    name: "Vector 31 (seed 0x9d,0x01..0x1f)",
+    seed: new Uint8Array(
+      Buffer.from("9d0102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f", "hex"),
+    ),
+    v1: "ff6e2e909a008318f97bb2c26c1d787ceb9aa2996f746766335e10ba7e2213cc",
+    v2Epoch1: "edd47319719e2350d1db9488e0189f2405267d7dc243489cfd9aa6f3ac3fc639",
+  },
+] as const;
+
+describe("per-context pseudonym derivation KAT (§25.19)", () => {
+  for (const vec of VECTORS) {
+    test(`${vec.name}: v1 static pseudonym matches spec bytes`, () => {
+      const kc = new CanonicalKeychain();
+      const keyId = kc.storeSeed(vec.seed);
+      const blob = kc.derivePseudonym(keyId, CONTEXT_ALPHA);
+      expect(pseudonymPublicKeyHex(blob)).toBe(vec.v1);
+    });
+
+    test(`${vec.name}: v2 rotatable pseudonym (epoch 1) matches spec bytes`, () => {
+      const kc = new CanonicalKeychain();
+      const keyId = kc.storeSeed(vec.seed);
+      const blob = kc.deriveRotatablePseudonym(keyId, CONTEXT_ALPHA, 1n);
+      expect(pseudonymPublicKeyHex(blob)).toBe(vec.v2Epoch1);
+    });
+
+    test(`${vec.name}: v1 and v2 derive distinct keys`, () => {
+      const kc = new CanonicalKeychain();
+      const keyId = kc.storeSeed(vec.seed);
+      const v1 = pseudonymPublicKeyHex(kc.derivePseudonym(keyId, CONTEXT_ALPHA));
+      const v2 = pseudonymPublicKeyHex(kc.deriveRotatablePseudonym(keyId, CONTEXT_ALPHA, 1n));
+      expect(v1).not.toBe(v2);
+    });
+  }
+});

--- a/crates/scp-ffi/common/src/custody_parse.rs
+++ b/crates/scp-ffi/common/src/custody_parse.rs
@@ -82,35 +82,6 @@ pub fn unpack_pseudonym(method: &str, bytes: &[u8]) -> Result<PseudonymKeypair, 
     })
 }
 
-/// Builds the extended context-id input for a rotatable pseudonym derivation.
-///
-/// The callback-custody protocol exposes only a single `derive_pseudonym`
-/// method, so the rotatable variant is synthesized by appending the big-endian
-/// epoch and the `v2` domain separator to the caller-supplied `context_id`,
-/// then delegating to `derive_pseudonym`.
-///
-/// Layout: `context_id || epoch.to_be_bytes() (8) || b"scp-pseudonym-v2" (16)`.
-///
-/// This is the canonical recipe defined in `scp-platform`
-/// `KeyCustody::derive_rotatable_pseudonym` (traits.rs) — the byte ordering of
-/// this preimage is fixed by the protocol (spec §9.10.4.1), not by any single
-/// bridge. There is deliberately NO length
-/// separator between `context_id` and the epoch: the epoch is always exactly 8
-/// big-endian bytes appended directly after the caller-supplied `context_id`,
-/// and the trailing domain separator is a fixed 16-byte literal. A length
-/// prefix would change the produced bytes and is therefore a wire-format change
-/// that must originate upstream in the spec/ADR and `scp-platform` (and be
-/// applied identically across all bridges and the native custody backends) — it
-/// cannot be introduced here without breaking cross-bridge and over-time
-/// pseudonym derivation parity.
-#[must_use]
-pub fn extend_context_id_for_rotation(context_id: &[u8], epoch: u64) -> Vec<u8> {
-    let mut extended = context_id.to_vec();
-    extended.extend_from_slice(&epoch.to_be_bytes());
-    extended.extend_from_slice(b"scp-pseudonym-v2");
-    extended
-}
-
 #[cfg(test)]
 #[allow(clippy::expect_used, clippy::panic)]
 mod tests {
@@ -218,25 +189,5 @@ mod tests {
             }
             other => panic!("expected CustodyError, got {other:?}"),
         }
-    }
-
-    #[test]
-    fn extend_context_id_for_rotation_byte_layout() {
-        let context_id = b"ctx";
-        let epoch: u64 = 5;
-        let extended = extend_context_id_for_rotation(context_id, epoch);
-
-        // Layout: context_id || epoch_BE(8) || "scp-pseudonym-v2" (16 bytes).
-        let mut expected = Vec::new();
-        expected.extend_from_slice(b"ctx");
-        expected.extend_from_slice(&[0, 0, 0, 0, 0, 0, 0, 5]); // 5 as 8 big-endian bytes
-        expected.extend_from_slice(b"scp-pseudonym-v2");
-
-        assert_eq!(extended, expected);
-        assert_eq!(extended.len(), 3 + 8 + 16);
-        // Domain separator is exactly the trailing 16 bytes.
-        assert_eq!(&extended[extended.len() - 16..], b"scp-pseudonym-v2");
-        // Epoch occupies the 8 bytes immediately after context_id.
-        assert_eq!(&extended[3..11], &epoch.to_be_bytes());
     }
 }

--- a/crates/scp-ffi/napi/src/custody.rs
+++ b/crates/scp-ffi/napi/src/custody.rs
@@ -69,6 +69,15 @@ pub struct NapiKeyCustodyProvider {
     /// `publicKey(32) || keyIdUtf8`.
     #[napi(ts_type = "(keyId: string, contextId: Uint8Array) => Uint8Array")]
     pub derive_pseudonym: Function<'static, (String, Vec<u8>), Vec<u8>>,
+    /// `(keyId: string, contextId: Uint8Array, pseudonymEpoch: bigint) => Uint8Array`
+    /// — canonical rotatable v2 pseudonym; returns `publicKey(32) || keyIdUtf8`.
+    /// The provider performs the canonical derivation (HMAC key is the
+    /// private-derived `pseudonym_secret`, domain `"scp-pseudonym-v2"`); the
+    /// bridge does NOT synthesize the preimage.
+    #[napi(
+        ts_type = "(keyId: string, contextId: Uint8Array, pseudonymEpoch: bigint) => Uint8Array"
+    )]
+    pub derive_rotatable_pseudonym: Function<'static, (String, Vec<u8>, u64), Vec<u8>>,
     /// `(keyId: string) => Uint8Array` — 32 raw private-seed bytes.
     #[napi(ts_type = "(keyId: string) => Uint8Array")]
     pub export_signing_key_bytes: Function<'static, String, Vec<u8>>,
@@ -99,6 +108,13 @@ struct CallbackTsfns {
         ThreadsafeFunction<(String, Vec<u8>), Vec<u8>, (String, Vec<u8>), napi::Status, false>,
     derive_pseudonym:
         ThreadsafeFunction<(String, Vec<u8>), Vec<u8>, (String, Vec<u8>), napi::Status, false>,
+    derive_rotatable_pseudonym: ThreadsafeFunction<
+        (String, Vec<u8>, u64),
+        Vec<u8>,
+        (String, Vec<u8>, u64),
+        napi::Status,
+        false,
+    >,
     export_signing_key_bytes: ThreadsafeFunction<String, Vec<u8>, String, napi::Status, false>,
     custody_type: ThreadsafeFunction<String, String, String, napi::Status, false>,
 }
@@ -158,6 +174,11 @@ impl NapiCallbackKeyCustody {
                     .build()?,
                 derive_pseudonym: provider
                     .derive_pseudonym
+                    .build_threadsafe_function()
+                    .weak::<false>()
+                    .build()?,
+                derive_rotatable_pseudonym: provider
+                    .derive_rotatable_pseudonym
                     .build_threadsafe_function()
                     .weak::<false>()
                     .build()?,
@@ -288,23 +309,20 @@ impl KeyCustody for NapiCallbackKeyCustody {
         context_id: &[u8],
         pseudonym_epoch: u64,
     ) -> Result<PseudonymKeypair, PlatformError> {
-        // Synthesize the rotatable variant by extending the context_id with
-        // the big-endian epoch and the v2 domain separator, then delegating to
-        // the single `derive_pseudonym` callback (matches the UniFFI/PyO3
-        // CallbackKeyCustody contract — keeps the JS surface to one method). The
-        // canonical byte layout (`context_id || epoch_BE(8) || "scp-pseudonym-v2"`)
-        // lives in `scp_ffi_common::custody_parse::extend_context_id_for_rotation`,
-        // shared across all callback bridges so the wire format cannot drift.
-        let extended = scp_ffi_common::custody_parse::extend_context_id_for_rotation(
-            context_id,
-            pseudonym_epoch,
-        );
+        // Canonical v2 recipe (spec §9.10.4.A / §9.10.4.1): the provider performs
+        // the rotatable derivation itself — seed = HMAC-SHA256(pseudonym_secret,
+        // context_id || BE64(pseudonym_epoch) || "scp-pseudonym-v2"); keypair =
+        // Ed25519_keygen(seed[0..32]). The epoch is threaded through to the
+        // provider rather than synthesized into the context_id bridge-side, so
+        // the v1 platform adapter does not re-append its own "scp-pseudonym"
+        // domain separator (which would corrupt the v2 domain). Mirrors the
+        // UniFFI / PyO3 CallbackKeyCustody contract.
         let bytes = self
             .tsfns
-            .derive_pseudonym
-            .call_async((key.id().to_string(), extended))
+            .derive_rotatable_pseudonym
+            .call_async((key.id().to_string(), context_id.to_vec(), pseudonym_epoch))
             .await
-            .map_err(|e| Self::map_call_err("derive_pseudonym", &e))?;
+            .map_err(|e| Self::map_call_err("derive_rotatable_pseudonym", &e))?;
         scp_ffi_common::custody_parse::unpack_pseudonym("derive_rotatable_pseudonym", &bytes)
     }
 

--- a/crates/scp-ffi/src/custody.rs
+++ b/crates/scp-ffi/src/custody.rs
@@ -231,13 +231,14 @@ impl PyKeyCustodyProvider {
     /// up-front by [`Self::validate`] so a malformed provider fails fast at
     /// the FFI boundary with a clear `ValidationError` rather than deep
     /// inside an async DID-creation flow.
-    const REQUIRED_METHODS: [&'static str; 8] = [
+    const REQUIRED_METHODS: [&'static str; 9] = [
         "sign",
         "get_public_key",
         "destroy_key",
         "generate_keypair",
         "dh_agree",
         "derive_pseudonym",
+        "derive_rotatable_pseudonym",
         "export_signing_key_bytes",
         "custody_type",
     ];
@@ -315,6 +316,34 @@ impl PyKeyCustodyProvider {
         })
     }
 
+    /// Calls `method_name(key_id, payload, epoch)` (payload as Python `bytes`,
+    /// epoch as a Python `int`) on the Python object under a fresh GIL and
+    /// extracts the result as `T`. Used by the rotatable-pseudonym path, which
+    /// must thread the epoch through to the provider so the provider performs
+    /// the canonical v2 derivation itself (no bridge-side preimage synthesis).
+    fn call_str_bytes_u64<T>(
+        &self,
+        method_name: &str,
+        key_id: &str,
+        payload: &[u8],
+        epoch: u64,
+    ) -> Result<T, PlatformError>
+    where
+        T: for<'py> pyo3::FromPyObject<'py>,
+    {
+        Python::with_gil(|py| {
+            let bytes = PyBytes::new(py, payload);
+            let result = self
+                .obj
+                .bind(py)
+                .call_method1(method_name, (key_id, bytes, epoch))
+                .map_err(|e| Self::call_err(method_name, &e))?;
+            result
+                .extract::<T>()
+                .map_err(|e| Self::type_err(method_name, &e))
+        })
+    }
+
     /// Calls `method_name(key_id)` for its side effect only, discarding the
     /// Python return value. Used for `destroy_key`, which returns `None`.
     fn call_str_void(&self, method_name: &str, key_id: &str) -> Result<(), PlatformError> {
@@ -384,6 +413,10 @@ impl FfiKeyCustody {
 /// - `dh_agree(key_id: str, peer_public: bytes) -> bytes` — 32 shared bytes.
 /// - `derive_pseudonym(key_id: str, context_id: bytes) -> bytes` —
 ///   `[public_key (32) || key_id_utf8]`.
+/// - `derive_rotatable_pseudonym(key_id: str, context_id: bytes, pseudonym_epoch: int) -> bytes`
+///   — `[public_key (32) || key_id_utf8]`. The provider performs the canonical
+///   v2 derivation (HMAC key is the private-derived `pseudonym_secret`, domain
+///   `"scp-pseudonym-v2"`); the bridge does NOT synthesize the preimage.
 /// - `export_signing_key_bytes(key_id: str) -> bytes` — 32 private seed bytes.
 /// - `custody_type(key_id: str) -> str` — `"hardware"` / `"software"` /
 ///   `"in_memory"`.
@@ -497,20 +530,22 @@ impl KeyCustody for PyCallbackKeyCustody {
         context_id: &[u8],
         pseudonym_epoch: u64,
     ) -> Result<PseudonymKeypair, PlatformError> {
-        // Match the UniFFI CallbackKeyCustody contract: the rotatable variant
-        // is synthesized by extending the context_id with the big-endian epoch
-        // and the v2 domain separator, then delegating to derive_pseudonym.
-        // Keeps the Python protocol surface to a single pseudonym method. The
-        // canonical byte layout (`context_id || epoch_BE(8) || "scp-pseudonym-v2"`)
-        // lives in `scp_ffi_common::custody_parse::extend_context_id_for_rotation`,
-        // shared across all callback bridges so the wire format cannot drift.
-        let extended = scp_ffi_common::custody_parse::extend_context_id_for_rotation(
+        // Canonical v2 recipe (spec §9.10.4.A / §9.10.4.1): the HMAC key is the
+        // private-derived `pseudonym_secret` (HKDF over the Ed25519 private
+        // seed), NEVER the public key. The provider performs the canonical
+        // derivation itself — seed = HMAC-SHA256(pseudonym_secret, context_id ||
+        // BE64(pseudonym_epoch) || "scp-pseudonym-v2"); keypair =
+        // Ed25519_keygen(seed[0..32]). The epoch is passed through directly
+        // rather than synthesized into the context_id bridge-side, so the v1
+        // platform adapter does not re-append its own "scp-pseudonym" domain
+        // separator (which would corrupt the v2 domain). Mirrors the UniFFI /
+        // napi CallbackKeyCustody contract.
+        let bytes: Vec<u8> = self.provider.call_str_bytes_u64(
+            "derive_rotatable_pseudonym",
+            &key.id().to_string(),
             context_id,
             pseudonym_epoch,
-        );
-        let bytes: Vec<u8> =
-            self.provider
-                .call_str_bytes("derive_pseudonym", &key.id().to_string(), &extended)?;
+        )?;
         scp_ffi_common::custody_parse::unpack_pseudonym("derive_rotatable_pseudonym", &bytes)
     }
 
@@ -642,6 +677,17 @@ class FakeCustody:
         self._seeds[kid] = d
         return d + kid.encode('utf-8')
 
+    def derive_rotatable_pseudonym(self, key_id, context_id, pseudonym_epoch):
+        # Canonical v2 preimage: context_id || BE64(epoch) || 'scp-pseudonym-v2'.
+        # The bridge passes the epoch through unmodified and does NOT append the
+        # v1 'scp-pseudonym' separator, so this provider owns the full recipe.
+        preimage = bytes(context_id) + pseudonym_epoch.to_bytes(8, 'big') + b'scp-pseudonym-v2'
+        d = hmac.new(self._seeds[key_id], preimage, hashlib.sha256).digest()
+        kid = str(self._next)
+        self._next += 1
+        self._seeds[kid] = d
+        return d + kid.encode('utf-8')
+
     def export_signing_key_bytes(self, key_id):
         return self._seeds[key_id]
 
@@ -717,6 +763,60 @@ class FakeCustody:
             .sign(&pseudo.key_handle, b"as pseudonym")
             .await
             .expect("sign with derived pseudonym handle");
+        assert_eq!(sig.as_bytes().len(), 64);
+    }
+
+    #[tokio::test]
+    async fn ffi_custody_callback_rotatable_pseudonym_threads_epoch() {
+        // The rotatable path must call the provider's
+        // `derive_rotatable_pseudonym(key_id, context_id, epoch)` directly,
+        // passing the RAW context_id and the epoch as a separate argument — NOT
+        // a bridge-synthesized `context_id || BE64(epoch) || "scp-pseudonym-v2"`
+        // preimage fed into v1 `derive_pseudonym`. The fake provider computes
+        // the canonical v2 preimage itself; this test reproduces that preimage
+        // out-of-band and confirms the bridge delivered the exact same inputs.
+        let custody = fake_callback_custody();
+        let handle = custody
+            .generate_keypair(KeyType::Ed25519)
+            .await
+            .expect("callback generate keypair");
+
+        let context_id = b"context-xyz";
+        let epoch: u64 = 7;
+        let pseudo = custody
+            .derive_rotatable_pseudonym(&handle, context_id, epoch)
+            .await
+            .expect("callback derive_rotatable_pseudonym");
+        assert_eq!(
+            pseudo.public_key.as_bytes().len(),
+            32,
+            "rotatable pseudonym public key is 32 bytes"
+        );
+
+        // Reproduce the fake provider's canonical v2 preimage. handle id 1 is the
+        // first generate_keypair; its seed is SHA-256("1").
+        use hmac::{Hmac, Mac};
+        use sha2::{Digest, Sha256};
+        let seed = Sha256::digest(handle.id().to_string().as_bytes());
+        let mut preimage = context_id.to_vec();
+        preimage.extend_from_slice(&epoch.to_be_bytes());
+        preimage.extend_from_slice(b"scp-pseudonym-v2");
+        let mut mac =
+            <Hmac<Sha256> as Mac>::new_from_slice(&seed).expect("HMAC accepts any key length");
+        mac.update(&preimage);
+        let expected_pubkey = mac.finalize().into_bytes();
+        assert_eq!(
+            pseudo.public_key.as_bytes(),
+            expected_pubkey.as_slice(),
+            "bridge must pass raw context_id + epoch (canonical v2), not a \
+             double-domain-appended preimage"
+        );
+
+        // The unpacked handle must be usable for a follow-up sign.
+        let sig = custody
+            .sign(&pseudo.key_handle, b"as rotatable pseudonym")
+            .await
+            .expect("sign with derived rotatable pseudonym handle");
         assert_eq!(sig.as_bytes().len(), 64);
     }
 

--- a/crates/scp-ffi/uniffi/src/bridge.rs
+++ b/crates/scp-ffi/uniffi/src/bridge.rs
@@ -334,19 +334,16 @@ impl KeyCustody for CallbackKeyCustody {
         context_id: &[u8],
         pseudonym_epoch: u64,
     ) -> Result<PseudonymKeypair, PlatformError> {
-        // Rotatable pseudonyms append the epoch to the context_id before
-        // delegating to derive_pseudonym. The canonical byte layout
-        // (`context_id || epoch_BE(8) || "scp-pseudonym-v2"`) lives in
-        // `scp_ffi_common::custody_parse::extend_context_id_for_rotation`,
-        // shared across all callback bridges so the wire format cannot drift.
-        let extended = scp_ffi_common::custody_parse::extend_context_id_for_rotation(
-            context_id,
-            pseudonym_epoch,
-        );
-
+        // Canonical v2 recipe (spec §9.10.4.A / §9.10.4.1): the provider performs
+        // the rotatable derivation itself — seed = HMAC-SHA256(pseudonym_secret,
+        // context_id || BE64(pseudonym_epoch) || "scp-pseudonym-v2"); keypair =
+        // Ed25519_keygen(seed[0..32]). The epoch is threaded through to the
+        // provider rather than synthesized into the context_id bridge-side, so
+        // the v1 platform adapter does not re-append its own "scp-pseudonym"
+        // domain separator (which would corrupt the v2 domain).
         let result_bytes = self
             .provider
-            .derive_pseudonym(key.id().to_string(), extended)
+            .derive_rotatable_pseudonym(key.id().to_string(), context_id.to_vec(), pseudonym_epoch)
             .await
             .map_err(|e| PlatformError::CustodyError(e.to_string()))?;
 

--- a/crates/scp-ffi/uniffi/src/lib.rs
+++ b/crates/scp-ffi/uniffi/src/lib.rs
@@ -382,6 +382,49 @@ pub trait KeyCustodyProvider: Send + Sync {
         context_id: Vec<u8>,
     ) -> Result<Vec<u8>, ScpError>;
 
+    /// Derive a rotatable (epoch-versioned) per-context pseudonym keypair.
+    ///
+    /// Canonical recipe (spec §9.10.4.A / §9.10.4.1): the HMAC key is the
+    /// private-derived `pseudonym_secret` (HKDF over the Ed25519 private seed),
+    /// NEVER the public key.
+    /// `seed = HMAC-SHA256(pseudonym_secret, context_id || BE64(pseudonym_epoch) || "scp-pseudonym-v2")`;
+    /// `keypair = Ed25519_keygen(seed[0..32])` (RFC-8032 seed). Returns
+    /// `[pseudonym_public_key_bytes (32) || key_id_utf8]`.
+    ///
+    /// The `pseudonym_epoch` is passed through to the provider so it performs
+    /// the canonical v2 derivation itself. Bridges MUST NOT synthesize a
+    /// `context_id || BE64(epoch) || "scp-pseudonym-v2"` preimage and feed it to
+    /// the v1 `derive_pseudonym` — that double-appends the v1 domain separator
+    /// (`"scp-pseudonym"`) and diverges from the Rust reference.
+    ///
+    /// # Default
+    ///
+    /// Rust-side providers that do not rotate return `ScpError::Context`
+    /// (SCP-CTX-2050) indicating the method is not implemented. Platform SDK
+    /// adapters (Swift `AppleKeyCustody`, Kotlin `AndroidKeyCustody`) override
+    /// this with real implementations.
+    ///
+    /// **Note:** `UniFFI` callback interfaces require foreign implementations to
+    /// define all methods. The generated Swift protocol / Kotlin interface will
+    /// include this method. The default here applies only to Rust-side callers.
+    ///
+    /// # Errors
+    ///
+    /// Returns `ScpError` if the key is not found, is not an Ed25519 key, or the
+    /// provider does not support rotatable pseudonyms.
+    async fn derive_rotatable_pseudonym(
+        &self,
+        key_id: String,
+        context_id: Vec<u8>,
+        pseudonym_epoch: u64,
+    ) -> Result<Vec<u8>, ScpError> {
+        let _ = (key_id, context_id, pseudonym_epoch);
+        Err(ScpError::Context {
+            msg: "derive_rotatable_pseudonym not implemented by this KeyCustodyProvider".to_owned(),
+            code: codes::CTX_2050.to_owned(),
+        })
+    }
+
     /// Export the raw Ed25519 private key bytes (32 bytes) for `key_id`.
     ///
     /// Required for governance vote signing, which uses `ed25519_dalek::SigningKey`

--- a/crates/scp-ffi/wasm/src/custody.rs
+++ b/crates/scp-ffi/wasm/src/custody.rs
@@ -109,4 +109,32 @@ extern "C" {
         key_id: &str,
         context_id: &[u8],
     ) -> Result<JsValue, JsValue>;
+
+    /// Derive a rotatable (epoch-versioned) pseudonym keypair.
+    ///
+    /// Canonical v2 recipe (spec §9.10.4.A / §9.10.4.1): the injected JS custody
+    /// MUST use
+    ///   seed = HMAC-SHA256(pseudonym_secret, context_id || BE64(pseudonym_epoch) || "scp-pseudonym-v2")
+    ///   Ed25519_keygen(seed[0..32])   // seed is an RFC-8032 Ed25519 seed
+    /// where pseudonym_secret = HKDF-SHA256(ed25519_private_seed,
+    /// salt="scp-pseudonym-secret-v1", info="", len=32). The HMAC key is the
+    /// private-derived pseudonym_secret, NEVER the public key (public key bytes
+    /// would be a membership-enumeration oracle, §9.10.4.A). The `v2` domain
+    /// separator differs from `v1`'s `"scp-pseudonym"` so epoch 0 does not
+    /// collide with the unversioned pseudonym. Returns a JS object:
+    /// { publicKeyBytes: Uint8Array, keyId: string }.
+    ///
+    /// HONEST NOTE: like `derivePseudonym`, this extern has NO runtime caller in
+    /// the WASM bridge — identity keys are generated Rust-side (`identity.rs` via
+    /// `OsRng`), and `JsKeyCustody` is an injection-point surface (ADR-022). This
+    /// method exists for extern-surface parity with the other three callback
+    /// bridges, so a future JS custody injection can supply canonical rotatable
+    /// pseudonyms without a signature change.
+    #[wasm_bindgen(method, catch, js_name = "deriveRotatablePseudonym")]
+    pub fn derive_rotatable_pseudonym(
+        this: &JsKeyCustody,
+        key_id: &str,
+        context_id: &[u8],
+        pseudonym_epoch: u64,
+    ) -> Result<JsValue, JsValue>;
 }


### PR DESCRIPTION
## Summary

Stage B of #1551 completes cross-platform per-context pseudonym parity. Stage A (#1755) pinned the v1 recipe + KAT vectors and purged phantom provenance; this stage fixes a **real cross-platform divergence in the rotatable (v2) pseudonym** and adds mechanical §25.19 KAT enforcement across every SDK.

### The bug (found during Stage B)
The rotatable (v2) pseudonym was computed via a **double-domain-append hack** in **all three callback bridges** (PyO3 `crates/scp-ffi/src/custody.rs`, UniFFI `crates/scp-ffi/uniffi/src/bridge.rs`, NAPI `crates/scp-ffi/napi/src/custody.rs`): each built `context_id || BE64(epoch) || "scp-pseudonym-v2"` and then called the **v1** `derive_pseudonym`, whose platform adapter appended `"scp-pseudonym"` again → final HMAC domain `…"scp-pseudonym-v2"||"scp-pseudonym"`, **not** the canonical `…"scp-pseudonym-v2"`. So Swift/Kotlin/TS v2 pseudonyms diverged from the Rust reference. (PyO3's concrete-custody path was already correct; only the callback path was affected.)

## Changes
- **Bridge:** added a canonical `derive_rotatable_pseudonym` to each callback trait/record — UniFFI `KeyCustodyProvider` (Rust default-errors `SCP-CTX-2050`, foreign SDKs override), NAPI `NapiKeyCustodyProvider` (`(String, Vec<u8>, u64)` tsfn), PyO3 callback (`REQUIRED_METHODS` 8→9), WASM `JsKeyCustody` extern (parity-only — no runtime caller, documented). Removed the now-dead `extend_context_id_for_rotation` helper + its test from `scp-ffi-common`.
- **SDKs:** canonical `deriveRotatablePseudonym` + **§25.19 KAT assertions (v1 + v2, vectors 30/31)** in Swift (`AppleKeyCustody`), Kotlin (`AndroidKeyCustody` + `Types.kt`), Python (`scp_sdk/scp.py` + tests), TypeScript (`scp.ts` + tests). Regenerated committed `ScpBindings.swift`.
- Canonical v2 = `HMAC-SHA256(pseudonym_secret, context_id || BE64(epoch) || "scp-pseudonym-v2")`, `pseudonym_secret = HKDF-SHA256(ed25519 private seed, salt="scp-pseudonym-secret-v1")` — the HMAC key is the private-derived secret, **never the public key** (§9.10.4.A enumeration-oracle defense). Ed25519 from `seed[0..32]` (RFC-8032 seed).

## Verification (all green)
- Rust: `cargo fmt`, full-workspace `clippy --all-targets` (CI features), bridge+platform tests (scp-platform/scp-ffi/uniffi/napi/common).
- Swift: `build-xcframework.sh` regen + `AppleKeyCustodyRotatablePseudonymTests` (§25.19 KAT) pass.
- Kotlin: `gradlew :scp-kt-android:test` + `detekt` pass.
- Python: pure-stdlib §25.19 KAT (7) + extension-backed custody integration (2) pass.
- TypeScript: `bun check`/`lint` + §25.19 KAT (6) pass.
- The §25.19 vectors are pinned **byte-identically** in the Rust anchor + all four SDKs (Python/TS independently recompute; Swift/Kotlin exercise the real platform adapter). Reviewed to **double-zero** (cryptographer, bug-catcher, security, api-design, alignment, simplifier).

## Follow-up (separately tracked, out of scope)
Metadata routing ID: spec §9.10.4.B mandates a *keyed* `HMAC-SHA256(context_metadata_key, …)` but code/§5.7 still use the unkeyed `SHA-256(context_id||"scp-metadata")` — a pre-existing enumeration-oracle gap in a different subsystem.

Closes #1551.

🤖 Generated with [Claude Code](https://claude.com/claude-code)