### PR TITLE
docs: reconcile metadata routing ID to keyed §9.10.4.B form

### DIFF
--- a/.docs/adrs/phase-1.md
+++ b/.docs/adrs/phase-1.md
@@ -593,7 +593,7 @@ Implement a WebSocket-based store-and-forward relay server and its corresponding
    - Delivery receipt. Client acknowledges receipt of a blob.
    - The relay MAY use ACKs from all known subscribers to garbage-collect blobs before TTL expiry.
 
-**Context metadata retrieval:** Contexts publish their parameters (capability ceiling, governance policy, roles, TTL, memory scope, etc.) to a publicly derivable routing ID: `metadata_routing_id = SHA-256(context_id || "scp-metadata")`. Any participant can SUBSCRIBE or QUERY this routing ID to inspect a context's parameters before joining. The metadata blob is a signed, unencrypted envelope containing the context's `ContextParameters` struct (spec §5.3). This enables the "legibility before opt-in" tenet — informed consent is mechanical, not social.
+**Context metadata retrieval:** Contexts publish their parameters (capability ceiling, governance policy, roles, TTL, memory scope, etc.) to a keyed routing ID: `metadata_routing_id = HMAC-SHA256(context_metadata_key, context_id || "scp-metadata-v2")` (§9.10.4.B). Holders of the context's `context_metadata_key` can SUBSCRIBE or QUERY this routing ID to inspect a context's parameters before joining; the key is distributed per §9.10.4.B (creation, invitations, and discoverable-context entries), so non-discoverable contexts are not enumerable. The metadata blob is a signed, unencrypted envelope containing the context's `ContextParameters` struct (spec §5.3). This enables the "legibility before opt-in" tenet — informed consent is mechanical, not social.
 
 **Relay server requirements:**
 

--- a/.docs/prds/main.json
+++ b/.docs/prds/main.json
@@ -1229,7 +1229,7 @@
       ],
       "details": {
         "relayOperatorConfig": "Published out-of-band. Defaults: max_blob_size 262144, max_blob_ttl 604800, max_subscriptions_per_connection 100, max_query_limit 1000, rate_limit_publish 60/min, rate_limit_subscribe 20/min, idle_timeout 90s.",
-        "contextMetadata": "Contexts publish parameters to publicly derivable routing ID: metadata_routing_id = SHA-256(context_id || \"scp-metadata\"). Any participant can SUBSCRIBE or QUERY to inspect context parameters before joining. Metadata blob is signed, unencrypted envelope containing ContextParameters struct (spec §5.3). Enables legibility-before-opt-in tenet.",
+        "contextMetadata": "Contexts publish parameters to publicly derivable routing ID: metadata_routing_id = HMAC-SHA256(context_metadata_key, context_id || \"scp-metadata-v2\") (§9.10.4.B). Holders of the context_metadata_key can SUBSCRIBE or QUERY to inspect context parameters before joining; non-discoverable contexts are not publicly enumerable. Metadata blob is signed, unencrypted envelope containing ContextParameters struct (spec §5.3). Enables legibility-before-opt-in tenet.",
         "connectionRecovery": "Client-side: reconnect with exponential backoff (1s, 2s, 4s, 8s, 16s, 30s cap). Re-issue SUBSCRIBE with since = last received stored_at minus 5-second overlap. Deduplicate via blob_id. Relay maintains no per-client state across connections."
       },
       "result": "Implemented relay server (storage.rs + server.rs) with WebSocket handling, subscription registry, TTL expiry, backfill, PING/PONG. 30 tests."

--- a/.docs/prds/main.json
+++ b/.docs/prds/main.json
@@ -1229,7 +1229,7 @@
       ],
       "details": {
         "relayOperatorConfig": "Published out-of-band. Defaults: max_blob_size 262144, max_blob_ttl 604800, max_subscriptions_per_connection 100, max_query_limit 1000, rate_limit_publish 60/min, rate_limit_subscribe 20/min, idle_timeout 90s.",
-        "contextMetadata": "Contexts publish parameters to publicly derivable routing ID: metadata_routing_id = HMAC-SHA256(context_metadata_key, context_id || \"scp-metadata-v2\") (§9.10.4.B). Holders of the context_metadata_key can SUBSCRIBE or QUERY to inspect context parameters before joining; non-discoverable contexts are not publicly enumerable. Metadata blob is signed, unencrypted envelope containing ContextParameters struct (spec §5.3). Enables legibility-before-opt-in tenet.",
+        "contextMetadata": "Contexts publish parameters to a keyed routing ID: metadata_routing_id = HMAC-SHA256(context_metadata_key, context_id || \"scp-metadata-v2\") (§9.10.4.B). Holders of the context_metadata_key can SUBSCRIBE or QUERY to inspect context parameters before joining; non-discoverable contexts are not publicly enumerable. Metadata blob is signed, unencrypted envelope containing ContextParameters struct (spec §5.3). Enables legibility-before-opt-in tenet.",
         "connectionRecovery": "Client-side: reconnect with exponential backoff (1s, 2s, 4s, 8s, 16s, 30s cap). Re-issue SUBSCRIBE with since = last received stored_at minus 5-second overlap. Deduplicate via blob_id. Relay maintains no per-client state across connections."
       },
       "result": "Implemented relay server (storage.rs + server.rs) with WebSocket handling, subscription registry, TTL expiry, backfill, PING/PONG. 30 tests."

--- a/.docs/spec-extraction-plan.md
+++ b/.docs/spec-extraction-plan.md
@@ -784,7 +784,7 @@ Processing order (dependencies first):
 16. **Define all key derivation operations**:
     - Routing ID from context key (HKDF)
     - DID routing ID (SHA-256("scp:did:" || did_string))
-    - Metadata routing ID (SHA-256(context_id || "scp-metadata"))
+    - Metadata routing ID (HMAC-SHA256(context_metadata_key, context_id || "scp-metadata-v2"), §9.10.4.B)
     - Broadcast routing ID (SHA-256(context_id))
     - Sender key wrapping (HPKE, domain "scp-sender-key-v1")
     - Content key wrapping (AES-256-KW)

--- a/.docs/specs/03-identity.md
+++ b/.docs/specs/03-identity.md
@@ -478,7 +478,7 @@ private_state_routing_id = HKDF-SHA-256(
 
 HKDF (RFC 5869) is used instead of plain SHA-256 to prevent the relay from computing the `routing_id` from a known DID string. With plain `SHA-256("scp:private:" || did_string)`, any relay that knows a DID could identify which routing ID holds that identity's private state, enabling targeted censorship or surveillance. The HKDF derivation requires `identity_key_material` (the `#0` public key bytes), which the relay does not possess unless it has previously resolved the DID — and even then, the derivation is not obvious without knowing the salt and info strings. This provides pseudonymity for private state storage relative to relays that have not correlated the identity.
 
-The domain separation (`"scp-private-state-v1"` info string and `"scp-private-state-salt-v1"` salt) prevents collision with other routing ID derivation schemes: DID document routing uses `SHA-256("scp:did:" || did_string)` (§3.10.2), encrypted context routing uses HKDF from identity key material with `"scp-pseudonym"` (§9.10.4), broadcast context routing uses `SHA-256(context_id)` (§5.14), and context metadata routing uses `SHA-256(context_id || "scp-metadata")` (§5.7).
+The domain separation (`"scp-private-state-v1"` info string and `"scp-private-state-salt-v1"` salt) prevents collision with other routing ID derivation schemes: DID document routing uses `SHA-256("scp:did:" || did_string)` (§3.10.2), encrypted context routing uses HKDF from identity key material with `"scp-pseudonym"` (§9.10.4), broadcast context routing uses `SHA-256(context_id)` (§5.14), and context metadata routing uses `HMAC-SHA256(context_metadata_key, context_id || "scp-metadata-v2")` (§9.10.4.B).
 
 The `IdentityPrivateState` service endpoint in the DID document (see below) lists which relays store the private state. The `routing_id` tells the SDK how to address those blobs on those relays.
 
@@ -779,7 +779,7 @@ DID documents are published to SCP relays using the existing relay operations de
 did_routing_id = SHA-256("scp:did:" || did_string)
 ```
 
-The `"scp:did:"` domain separator prevents collision with other routing ID derivation schemes in the protocol: encrypted context routing IDs use HKDF from identity key material (§9.10.4), broadcast context routing IDs use `SHA-256(context_id)` (§5.14), and context metadata routing IDs use `SHA-256(context_id || "scp-metadata")` (§5.7). The domain separator ensures that a DID string can never produce a routing ID that collides with a context ID or metadata address.
+The `"scp:did:"` domain separator prevents collision with other routing ID derivation schemes in the protocol: encrypted context routing IDs use HKDF from identity key material (§9.10.4), broadcast context routing IDs use `SHA-256(context_id)` (§5.14), and context metadata routing IDs use `HMAC-SHA256(context_metadata_key, context_id || "scp-metadata-v2")` (§9.10.4.B). The domain separator ensures that a DID string can never produce a routing ID that collides with a context ID or metadata address.
 
 **Publication** uses the existing PUBLISH operation (ADR-004):
 

--- a/.docs/specs/05-contexts.md
+++ b/.docs/specs/05-contexts.md
@@ -318,15 +318,15 @@ When a template ID is present, the joining party can evaluate the context with a
 
 ### 5.7.1 Metadata Publication and Retrieval
 
-Contexts publish their parameters to a publicly derivable routing address, enabling pre-join inspection per the legibility principle (§1). The metadata routing address is derived deterministically from the context ID:
+Contexts publish their parameters to a metadata routing address that authorized parties can derive, enabling pre-join inspection per the legibility principle (§1). The address uses a keyed construction (§9.10.4.B) so it is NOT publicly derivable from the context ID alone — preventing context enumeration — while remaining derivable by members and authorized prospective members who hold the context's `context_metadata_key`:
 
 ```
-metadata_routing_id = SHA-256(context_id || "scp-metadata")
+metadata_routing_id = HMAC-SHA256(context_metadata_key, context_id || "scp-metadata-v2")
 ```
 
 Published metadata includes structural fields (always) and operational fields filtered by `MetadataVisibilityPolicy`. Fields with `MemberOnly` visibility are omitted from the published metadata record. Members retrieve full metadata through the context's internal state, not the public metadata record.
 
-Prospective members retrieve context parameters by subscribing to the `metadata_routing_id` on the relay without joining the context. The metadata record is signed by a current context admin, enabling verification of authenticity without membership. This makes the legibility guarantee mechanical — any identity with the context ID can derive the metadata address and inspect the context's visible parameters before deciding whether to join.
+Prospective members retrieve context parameters by subscribing to the `metadata_routing_id` on the relay without joining the context. The metadata record is signed by a current context admin, enabling verification of authenticity without membership. This makes the legibility guarantee mechanical for authorized parties: any holder of the `context_metadata_key` can derive the metadata address and inspect the context's visible parameters before deciding whether to join. The `context_metadata_key` is distributed per §9.10.4.B — generated at context creation, included (encrypted) in invitations, and published in the context entry for discoverable contexts. Non-discoverable contexts keep the key private, so their existence and metadata are not enumerable by parties who merely know or guess the context ID.
 
 Metadata updates (e.g., governance-driven ceiling modifications in `governed` contexts) are republished to the same routing address. Relays treat metadata records as standard relay messages — no special relay-side logic is required.
 

--- a/crates/scp-identity/src/resolution.rs
+++ b/crates/scp-identity/src/resolution.rs
@@ -5,7 +5,7 @@
 //! The `"scp:did:"` domain separator prevents collision with other routing ID
 //! derivation schemes: encrypted context routing IDs (HKDF, §9.10.4), broadcast
 //! context routing IDs (`SHA-256(context_id)`, §5.14), and context metadata
-//! routing IDs (`SHA-256(context_id || "scp-metadata")`, §5.7).
+//! routing IDs (`HMAC-SHA256(context_metadata_key, context_id || "scp-metadata-v2")`, §9.10.4.B).
 //!
 //! # Relay-Based Resolution (SCP-240)
 //!
@@ -35,7 +35,7 @@ use crate::{IdentityError, cache::Clock};
 ///
 /// Prevents collision with context routing IDs (HKDF from identity key material,
 /// §9.10.4), broadcast routing IDs (`SHA-256(context_id)`, §5.14), and context
-/// metadata routing IDs (`SHA-256(context_id || "scp-metadata")`, §5.7).
+/// metadata routing IDs (`HMAC-SHA256(context_metadata_key, context_id || "scp-metadata-v2")`, §9.10.4.B).
 const DID_ROUTING_DOMAIN_SEPARATOR: &[u8] = b"scp:did:";
 
 /// Derives the relay routing ID for a DID string.

--- a/crates/scp-protocol/src/context/metadata.rs
+++ b/crates/scp-protocol/src/context/metadata.rs
@@ -36,7 +36,7 @@ pub type Ed25519Signature = Vec<u8>;
 /// A signed context metadata record published for pre-join inspection.
 ///
 /// Metadata records are published to the context's metadata routing address
-/// (`SHA-256(context_id || "scp-metadata")`, spec §5.7.1). They carry both
+/// (`HMAC-SHA256(context_metadata_key, context_id || "scp-metadata-v2")`, spec §9.10.4.B). They carry both
 /// structural fields (always visible) and operational fields (filtered by
 /// `MetadataVisibilityPolicy`).
 ///


### PR DESCRIPTION
## Summary

Fixes an internal spec/doc-comment inconsistency surfaced during #1551 review: the **metadata routing ID** (for pre-join context-metadata inspection) was described two contradictory ways. The governing security model **§9.10.4.B** mandates a **keyed** derivation `HMAC-SHA256(context_metadata_key, context_id || "scp-metadata-v2")` and explicitly rejects the unkeyed `SHA-256(context_id || "scp-metadata")` as a context-enumeration oracle — but §5.7.1 and several cross-references still described the unkeyed form (and framed "any identity with the context ID can derive the metadata address" as the legibility feature).

**No code implements either form** — the metadata-inspection feature is unbuilt; the contradiction was purely documentation. This aligns all downstream prose/doc-comments to the governing §9.10.4.B keyed form (artifact-flow: spec governs; §9.10.4.B was already keyed and is unchanged here).

## Changes
- **`05-contexts.md` §5.7.1** — keyed derivation; legibility correctly reframed (derivable by members + authorized prospective members holding `context_metadata_key`; discoverable contexts publish the key for open legibility; non-discoverable contexts stay unenumerable). Tenet preserved for discoverable contexts.
- **`03-identity.md`** (×2 non-collision cross-refs), **`phase-1.md`**, **PRD `contextMetadata`**, **`spec-extraction-plan.md`** — keyed form, repointed to §9.10.4.B.
- **`scp-identity/src/resolution.rs`** (×2) + **`scp-protocol/src/context/metadata.rs`** doc-comments — keyed cross-refs (comment-only; compiles clean).

## Verification
- `validate-prd.py` passes (362 stories); `cargo fmt` + `cargo check -p scp-identity -p scp-protocol` clean (doc-comment edits).
- Only residual unkeyed mentions are the legitimate §9.10.4.B threat/rejection statements and historical `.docs/audits/*` records (point-in-time, left as history).
- Reviewed (alignment, chronicler): aligned/accurate; both non-blocking nits fixed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)