### PR TITLE
fix(ffi): wire ContextManager events to WebhookDispatcher in production across all node bridges (#1539)

### DIFF
--- a/.docs/specs/12-platform-bridge-connectors.md
+++ b/.docs/specs/12-platform-bridge-connectors.md
@@ -704,6 +704,19 @@ This annotation is attached to the SCP message's provenance chain, making it aud
 
 **Rate limiting.** The bridge SHOULD rate-limit outbound forwarding to respect platform API limits. Rate limits are platform-specific and configured per bridge instance. The bridge MUST NOT drop messages due to rate limiting — it queues them and delivers in order when rate limit windows reset.
 
+**Local-event webhook taxonomy.** Separately from platform forwarding, a bridge node MAY expose an outbound webhook dispatcher that notifies registered HTTP targets when context events occur locally on the node. This is the SCP-to-operator-tooling channel (distinct from the SCP-to-platform forwarding above): each local `ContextEvent` emitted by a context the node hosts is mapped to a webhook event with a stable, dot-separated `event_type` and a JSON payload. Delivery is best-effort and at-least-once; signing and headers follow the same conventions as the inbound webhook endpoint (§12.10.4). The defined event types are:
+
+| `event_type` | Emitted when | Payload fields |
+|--------------|--------------|----------------|
+| `message.received` | A message is received in the context | `sender_did` (string) |
+| `message.sent` | A message is sent in the context | `sender_did` (string), `sequence_number` (integer) |
+| `member.joined` | A member joins the context | `member_did` (string), `role_name` (string) |
+| `member.left` | A member leaves the context | `member_did` (string) |
+| `governance.action` | A governance action executes | `proposal_id` (hex string), `action_summary` (string), `executor_did` (string), `resulting_epoch` (integer), `target_did` (string or null) |
+| `context.event` | Any other context event (generic fallback) | `variant` (string — the event variant name) |
+
+The `context.event` generic fallback carries only the variant name so that new `ContextEvent` variants surface to webhook consumers without silent omission, while structured payloads are reserved for the explicitly enumerated, externally meaningful event types above. Payload fields contain only metadata — message content is never included in webhook payloads (export-policy enforcement and metadata stripping apply as described above).
+
 ### 12.10.6 Bridge Node Lifecycle
 
 The bridge node mediates between the platform's HTTP API and SCP protocol operations. The lifecycle is:

--- a/crates/scp-ffi/common/Cargo.toml
+++ b/crates/scp-ffi/common/Cargo.toml
@@ -24,7 +24,7 @@ custody = ["dep:scp-platform"]
 # Shared relay/node startup code for FFI bridges that need to spawn servers.
 # Requires scp-transport (relay), scp-node (application node), scp-platform
 # (in-memory testing backends), and tokio. Not available for WASM (ADR-034).
-server = ["dep:scp-transport", "dep:scp-node", "dep:scp-platform", "scp-platform/testing", "scp-platform/filesystem", "scp-platform/file", "dep:scp-identity", "dep:tokio", "dep:tracing", "dep:thiserror"]
+server = ["dep:scp-transport", "dep:scp-node", "dep:scp-platform", "scp-platform/testing", "scp-platform/filesystem", "scp-platform/file", "dep:scp-identity", "dep:tokio", "dep:tokio-util", "dep:tracing", "dep:thiserror"]
 
 [dependencies]
 scp-core = { path = "../../scp-core", optional = true }

--- a/crates/scp-ffi/common/src/server.rs
+++ b/crates/scp-ffi/common/src/server.rs
@@ -531,6 +531,30 @@ impl RunningNode {
         }
     }
 
+    /// Spawns a background task forwarding local `ContextManager` events to
+    /// this node's outbound webhook dispatcher (§12.10.5).
+    ///
+    /// The `events` receiver is obtained from
+    /// `ContextManager::subscribe_events()`. The returned
+    /// [`JoinHandle`](tokio::task::JoinHandle) owns the consumer task and MUST
+    /// be retained by a lifecycle owner (e.g. the bridge instance `JoinSet`)
+    /// so it is aborted on shutdown rather than leaked.
+    ///
+    /// See [`ApplicationNode::wire_context_events`](scp_node::ApplicationNode::wire_context_events).
+    #[must_use]
+    pub fn wire_context_events(
+        &self,
+        events: tokio::sync::broadcast::Receiver<(
+            String,
+            scp_core::context::membership::ContextEvent,
+        )>,
+    ) -> tokio::task::JoinHandle<()> {
+        match self {
+            Self::InMemory(n) => n.wire_context_events(events),
+            Self::Filesystem(n) => n.wire_context_events(events),
+        }
+    }
+
     /// Signals the node to stop (relay + background tasks).
     pub fn shutdown(&self) {
         match self {

--- a/crates/scp-ffi/common/src/server.rs
+++ b/crates/scp-ffi/common/src/server.rs
@@ -563,6 +563,47 @@ impl RunningNode {
         }
     }
 
+    /// Subscribes to the manager's event channel, wires the consumer into this
+    /// node's webhook dispatcher, and supervises the consumer under the bridge
+    /// instance's lifecycle (spec §12.10.5).
+    ///
+    /// This is the shared seam for all three non-WASM bridges (`PyO3`, `NAPI`,
+    /// `UniFFI`). Each bridge's node-startup path calls it once, after the
+    /// `ContextManager` is attached, passing the instance's `JoinSet` guard and
+    /// cancellation token. Consolidating the subscribe → wire → supervise block
+    /// here prevents per-bridge drift (the regression that reopened #1539, where
+    /// only `PyO3` was wired).
+    ///
+    /// Behavior:
+    /// - If the manager has no event channel (`subscribe_events()` returns
+    ///   `None`), wiring is skipped with a warning rather than panicking.
+    ///   Production managers always enable the channel (see each bridge's
+    ///   `build_context_manager`/`finalize_context_manager`), so this is purely
+    ///   defensive against a manager initialized by some other path.
+    /// - The consumer task runs until the broadcast channel closes (manager
+    ///   dropped) OR the bridge instance's cancellation token fires, at which
+    ///   point the consumer is aborted. This makes the consumer deterministically
+    ///   bound to the instance lifecycle rather than leaked as a detached task.
+    pub fn wire_and_supervise_context_events(
+        &self,
+        manager: &Arc<ContextManager>,
+        tasks: &mut tokio::task::JoinSet<()>,
+        cancel: tokio_util::sync::CancellationToken,
+    ) {
+        let Some(events) = manager.subscribe_events() else {
+            // Defensive: production managers always have the channel, but a
+            // ContextManager initialized by another path without it would
+            // return None. Skip wiring rather than panic.
+            tracing::warn!(
+                "wire_and_supervise_context_events: ContextManager has no event \
+                 channel — local context events will not reach the webhook dispatcher"
+            );
+            return;
+        };
+        let consumer = self.wire_context_events(events);
+        spawn_supervised_event_consumer(consumer, tasks, cancel);
+    }
+
     /// Activates HTTP broadcast projection with optional site configuration.
     ///
     /// # Errors
@@ -664,6 +705,39 @@ impl RunningNode {
             Self::Filesystem(n) => n.http_url().await,
         }
     }
+}
+
+/// Spawns a webhook-event `consumer` (from `ApplicationNode::wire_context_events`
+/// or [`RunningNode::wire_context_events`]) under the bridge instance's
+/// `JoinSet`, bound to its cancellation token.
+///
+/// This is the single shared supervision wire for all three non-WASM bridges
+/// (`PyO3` reference, `NAPI`, `UniFFI`). Each bridge subscribes to its
+/// `ContextManager` event channel and wires the consumer via its node, then
+/// hands the resulting `JoinHandle` here so the supervision policy lives in one
+/// place and cannot drift per-bridge (the failure mode that reopened #1539,
+/// where only `PyO3` was wired).
+///
+/// Lifecycle: the spawned guard task runs until either the consumer completes
+/// (the broadcast channel closed because the `ContextManager` was dropped) or
+/// `cancel` fires on bridge shutdown, at which point the consumer is aborted so
+/// it never outlives the instance as a detached task.
+pub fn spawn_supervised_event_consumer(
+    mut consumer: tokio::task::JoinHandle<()>,
+    tasks: &mut tokio::task::JoinSet<()>,
+    cancel: tokio_util::sync::CancellationToken,
+) {
+    tasks.spawn(async move {
+        tokio::select! {
+            // The consumer task runs until the broadcast channel closes.
+            _ = &mut consumer => {}
+            // On bridge shutdown, abort the consumer so it does not
+            // outlive the instance as a detached task.
+            () = cancel.cancelled() => {
+                consumer.abort();
+            }
+        }
+    });
 }
 
 // ---------------------------------------------------------------------------

--- a/crates/scp-ffi/napi/src/runtime.rs
+++ b/crates/scp-ffi/napi/src/runtime.rs
@@ -757,6 +757,31 @@ impl HandleInstance for crate::testing::NapiFullStackNode {
     }
 }
 
+/// Bounded capacity of the `ContextManager` event broadcast channel.
+///
+/// Every production `ContextManager` built here enables this channel so that
+/// local context events can be consumed by external sinks — notably the node's
+/// outbound webhook dispatcher (spec §12.10.5), wired in
+/// [`crate::server`] node startup. Lagging consumers drop the oldest events
+/// (logged, never panics); `1024` matches the documented default on
+/// [`ContextManager::with_event_channel`] and the `PyO3` reference bridge.
+const EVENT_CHANNEL_CAPACITY: usize = 1024;
+
+/// Enables the event broadcast channel on a freshly built `ContextManager` and
+/// wraps it in an `Arc`.
+///
+/// Mirrors the `PyO3` reference bridge's `build_context_manager`
+/// (`crates/scp-ffi/src/runtime.rs`): every production manager construction
+/// routes through here so the event channel is always present and
+/// `subscribe_events()` yields a receiver for the webhook dispatcher. When no
+/// consumer subscribes, emitting into the channel is a cheap no-op — the
+/// retained sender has no receivers, so `send` returns `Err` and the event is
+/// dropped without blocking context operations.
+fn finalize_context_manager(mut manager: ContextManager) -> Arc<ContextManager> {
+    manager.with_event_channel(EVENT_CHANNEL_CAPACITY);
+    Arc::new(manager)
+}
+
 /// Initializes the given bridge instance's [`ContextManager`] with production
 /// providers.
 ///
@@ -790,7 +815,7 @@ pub fn init_context_manager(bi: &NapiBridgeInstance, local_did: &str) {
     let transport = Box::new(scp_core::context::NotConfiguredTransportProvider);
     let event_log = event_log_provider_from_existing_repo(bi);
     let persistence = persistence_box_for_init(bi);
-    let cm_arc = Arc::new(ContextManager::with_persistence(
+    let cm_arc = finalize_context_manager(ContextManager::with_persistence(
         crypto,
         transport,
         event_log,
@@ -845,7 +870,7 @@ pub fn init_context_manager_with_local_transport(bi: &NapiBridgeInstance, local_
     let transport = Box::new(scp_core::context::LocalTransportProvider);
     let event_log = event_log_provider_from_existing_repo(bi);
     let persistence = persistence_box_for_init(bi);
-    let cm_arc = Arc::new(ContextManager::with_persistence(
+    let cm_arc = finalize_context_manager(ContextManager::with_persistence(
         crypto,
         transport,
         event_log,
@@ -897,7 +922,7 @@ pub fn init_context_manager_with_relay_transport(
     let transport = Box::new(scp_transport::RelayTransportProvider::new(adapter));
     let event_log = event_log_provider_from_existing_repo(bi);
     let persistence = persistence_box_for_init(bi);
-    let cm_arc = Arc::new(ContextManager::with_persistence(
+    let cm_arc = finalize_context_manager(ContextManager::with_persistence(
         crypto,
         transport,
         event_log,

--- a/crates/scp-ffi/napi/src/server.rs
+++ b/crates/scp-ffi/napi/src/server.rs
@@ -144,6 +144,34 @@ async fn auto_wire_context_manager(
     }
 }
 
+/// Wires the local `ContextManager` event channel into the node's outbound
+/// webhook dispatcher and supervises the consumer under the bridge instance's
+/// lifecycle (spec §12.10.5).
+///
+/// Mirrors the `PyO3` reference bridge (`crates/scp-ffi/src/server.rs`). The
+/// production `ContextManager` built by
+/// [`crate::runtime::finalize_context_manager`] always enables its event
+/// channel, so `subscribe_events()` yields a receiver. Delegates the
+/// subscribe → wire → supervise block to the shared
+/// [`RunningNode::wire_and_supervise_context_events`] seam so all three bridges
+/// stay in lockstep. The consumer is aborted on bridge shutdown via the
+/// instance cancellation token, so it never leaks as a detached task.
+///
+/// Best-effort: if the `ContextManager` is somehow absent, logs and skips
+/// rather than failing node startup.
+async fn wire_node_webhook_events(bi: &Arc<NapiBridgeInstance>, node: &RunningNode) {
+    let Ok(manager) = crate::runtime::context_manager(bi) else {
+        tracing::warn!(
+            "wire_node_webhook_events: no ContextManager attached — local context \
+             events will not reach the webhook dispatcher"
+        );
+        return;
+    };
+    let cancel = bi.core.cancel_token();
+    let mut tasks = bi.core.task_handle().await;
+    node.wire_and_supervise_context_events(manager, &mut tasks, cancel);
+}
+
 // ---------------------------------------------------------------------------
 // NapiRelayHandle
 // ---------------------------------------------------------------------------
@@ -593,9 +621,12 @@ pub(crate) async fn node_start_in_memory_on(
     let bridge_token = node.bridge_token_hex();
     auto_wire_context_manager(bi, &did, &relay_url, bridge_token).await;
 
+    let inner = RunningNode::InMemory(node);
+    wire_node_webhook_events(bi, &inner).await;
+
     increment_handle_count();
     Ok(NapiNodeHandle {
-        inner: RunningNode::InMemory(node),
+        inner,
         bi: Arc::clone(bi),
         instance_id: bi.instance_id(),
     })
@@ -629,9 +660,12 @@ pub(crate) async fn node_start_local_on(
     let bridge_token = node.bridge_token_hex();
     auto_wire_context_manager(bi, &did, &relay_url, bridge_token).await;
 
+    let inner = RunningNode::Filesystem(node);
+    wire_node_webhook_events(bi, &inner).await;
+
     increment_handle_count();
     Ok(NapiNodeHandle {
-        inner: RunningNode::Filesystem(node),
+        inner,
         bi: Arc::clone(bi),
         instance_id: bi.instance_id(),
     })
@@ -711,6 +745,28 @@ mod tests {
         assert!(!node.is_shutdown());
         node.shutdown();
         assert!(node.is_shutdown());
+    }
+
+    /// Regression guard for #1539 on Node/Bun: after node startup the
+    /// production `ContextManager` must have its event broadcast channel
+    /// enabled, so `subscribe_events()` yields a receiver. Before the fix,
+    /// `finalize_context_manager` did not run on this bridge and the channel
+    /// was `None`, so the webhook consumer could never be wired and local
+    /// context events never reached the dispatcher.
+    #[test]
+    fn node_startup_enables_context_event_channel() {
+        let scp = crate::scp::Scp::new().unwrap();
+        let node = rt().block_on(scp.node_start_in_memory(None)).unwrap();
+
+        let manager = crate::runtime::context_manager(&scp.inner)
+            .expect("ContextManager must be attached after node startup");
+        assert!(
+            manager.subscribe_events().is_some(),
+            "node startup must enable the ContextManager event channel so the \
+             webhook dispatcher consumer can subscribe (regression: #1539)"
+        );
+
+        node.shutdown();
     }
 
     #[test]

--- a/crates/scp-ffi/src/runtime.rs
+++ b/crates/scp-ffi/src/runtime.rs
@@ -1051,28 +1051,42 @@ fn build_event_log_provider(bi: &PyBridgeInstance) -> Box<dyn ContextEventLogPro
     }
 }
 
+/// Bounded capacity of the `ContextManager` event broadcast channel.
+///
+/// Every production `ContextManager` built here enables this channel so that
+/// local context events can be consumed by external sinks — notably the node's
+/// outbound webhook dispatcher (§12.10.5), wired in
+/// [`crate::server::auto_wire_context_manager`]. Lagging consumers drop the
+/// oldest events (logged, never panics); `1024` matches the documented default
+/// on [`ContextManager::with_event_channel`].
+const EVENT_CHANNEL_CAPACITY: usize = 1024;
+
 /// Constructs a `ContextManager` with or without persistence.
+///
+/// The event broadcast channel is always enabled (capacity
+/// [`EVENT_CHANNEL_CAPACITY`]) so downstream consumers — e.g. the node webhook
+/// dispatcher — can subscribe via `ContextManager::subscribe_events()`. When no
+/// consumer subscribes, emitting into the channel is a cheap no-op: the
+/// retained sender has no receivers, so `send` returns `Err` and the event is
+/// simply dropped without blocking context operations.
 fn build_context_manager(
     crypto: Box<dyn ContextCryptoProvider>,
     transport: Box<dyn ContextTransportProvider>,
     event_log: Box<dyn ContextEventLogProvider>,
     persistence: Option<Box<dyn ContextPersistence>>,
 ) -> Arc<ContextManager> {
-    match persistence {
-        Some(p) => Arc::new(ContextManager::with_persistence(
+    let mut manager = match persistence {
+        Some(p) => ContextManager::with_persistence(
             crypto,
             transport,
             event_log,
             p,
             not_configured_key_resolver(),
-        )),
-        None => Arc::new(ContextManager::new(
-            crypto,
-            transport,
-            event_log,
-            not_configured_key_resolver(),
-        )),
-    }
+        ),
+        None => ContextManager::new(crypto, transport, event_log, not_configured_key_resolver()),
+    };
+    manager.with_event_channel(EVENT_CHANNEL_CAPACITY);
+    Arc::new(manager)
 }
 
 // ---------------------------------------------------------------------------

--- a/crates/scp-ffi/src/server.rs
+++ b/crates/scp-ffi/src/server.rs
@@ -188,20 +188,11 @@ fn auto_wire_context_manager<S: scp_platform::Storage>(
             );
             return;
         };
-        let mut consumer = node.wire_context_events(events);
+        let consumer = node.wire_context_events(events);
         let cancel = bi.core.cancel_token();
         rt.block_on(async {
-            bi.core.task_handle().await.spawn(async move {
-                tokio::select! {
-                    // The consumer task runs until the broadcast channel closes.
-                    _ = &mut consumer => {}
-                    // On bridge shutdown, abort the consumer so it does not
-                    // outlive the instance as a detached task.
-                    () = cancel.cancelled() => {
-                        consumer.abort();
-                    }
-                }
-            });
+            let mut tasks = bi.core.task_handle().await;
+            scp_ffi_common::server::spawn_supervised_event_consumer(consumer, &mut tasks, cancel);
         });
     });
 }

--- a/crates/scp-ffi/src/server.rs
+++ b/crates/scp-ffi/src/server.rs
@@ -72,10 +72,16 @@ fn node_err(e: NodeError) -> PyErr {
 ///
 /// Best-effort: logs a warning if the relay connection fails rather than
 /// blocking node startup.
-fn auto_wire_context_manager(
+///
+/// After the `ContextManager` is initialized, this also spawns the local
+/// event consumer that forwards `ContextManager` events to the node's outbound
+/// webhook dispatcher (§12.10.5). The consumer task is owned by the bridge
+/// instance's `JoinSet`, so it is aborted on bridge shutdown and never leaks.
+fn auto_wire_context_manager<S: scp_platform::Storage>(
     bi: &crate::runtime::PyBridgeInstance,
     py: Python<'_>,
     rt: &tokio::runtime::Runtime,
+    node: &scp_node::ApplicationNode<S>,
     did: &str,
     relay_url: &str,
     bridge_token: Zeroizing<String>,
@@ -156,6 +162,47 @@ fn auto_wire_context_manager(
         if let Ok(mgr) = crate::runtime::context_manager(bi) {
             rt.block_on(mgr.register_local_did(did_owned.into()));
         }
+    });
+
+    // Wire local ContextManager events to the node's webhook dispatcher
+    // (§12.10.5). The ContextManager built by `build_context_manager` always
+    // enables its event channel, so `subscribe_events()` yields a receiver.
+    //
+    // Lifecycle: the consumer task is supervised by the bridge instance's
+    // JoinSet AND the instance cancellation token. On shutdown the JoinSet
+    // task wakes on `cancel.cancelled()` and aborts the inner consumer handle,
+    // so the consumer is stopped deterministically rather than detached. If the
+    // ContextManager is dropped first, the broadcast channel closes and the
+    // consumer returns on its own (`RecvError::Closed`).
+    py.allow_threads(|| {
+        let Ok(mgr) = crate::runtime::context_manager(bi) else {
+            return;
+        };
+        let Some(events) = mgr.subscribe_events() else {
+            // Defensive: production managers always have the channel, but a
+            // ContextManager initialized by another path without it would
+            // return None. Skip wiring rather than panic.
+            tracing::warn!(
+                "auto_wire_context_manager: ContextManager has no event channel — \
+                 local context events will not reach the webhook dispatcher"
+            );
+            return;
+        };
+        let mut consumer = node.wire_context_events(events);
+        let cancel = bi.core.cancel_token();
+        rt.block_on(async {
+            bi.core.task_handle().await.spawn(async move {
+                tokio::select! {
+                    // The consumer task runs until the broadcast channel closes.
+                    _ = &mut consumer => {}
+                    // On bridge shutdown, abort the consumer so it does not
+                    // outlive the instance as a detached task.
+                    () = cancel.cancelled() => {
+                        consumer.abort();
+                    }
+                }
+            });
+        });
     });
 }
 
@@ -618,7 +665,7 @@ impl crate::scp::PyScp {
         let did = node.identity().did().to_owned();
         let relay_url = format!("ws://127.0.0.1:{}/scp/v1", node.relay().bound_addr().port());
         let bridge_token = node.bridge_token_hex();
-        auto_wire_context_manager(bi, py, rt, &did, &relay_url, bridge_token);
+        auto_wire_context_manager(bi, py, rt, &node, &did, &relay_url, bridge_token);
 
         let instance_id = bi.core.instance_id();
         Ok(PyNodeHandle {
@@ -673,7 +720,7 @@ impl crate::scp::PyScp {
         let did = node.identity().did().to_owned();
         let relay_url = format!("ws://127.0.0.1:{}/scp/v1", node.relay().bound_addr().port());
         let bridge_token = node.bridge_token_hex();
-        auto_wire_context_manager(bi, py, rt, &did, &relay_url, bridge_token);
+        auto_wire_context_manager(bi, py, rt, &node, &did, &relay_url, bridge_token);
 
         let instance_id = bi.core.instance_id();
         Ok(PyNodeHandle {

--- a/crates/scp-ffi/uniffi/src/runtime.rs
+++ b/crates/scp-ffi/uniffi/src/runtime.rs
@@ -1040,6 +1040,16 @@ impl scp_core::context::manager::ContextPersistence for ArcContextPersistence {
     }
 }
 
+/// Bounded capacity of the `ContextManager` event broadcast channel.
+///
+/// Every production `ContextManager` built here enables this channel so that
+/// local context events can be consumed by external sinks — notably the node's
+/// outbound webhook dispatcher (spec §12.10.5), wired in
+/// [`crate::server`] node startup. Lagging consumers drop the oldest events
+/// (logged, never panics); `1024` matches the documented default on
+/// [`ContextManager::with_event_channel`] and the `PyO3` reference bridge.
+const EVENT_CHANNEL_CAPACITY: usize = 1024;
+
 /// Constructs a [`ContextManager`] with or without persistence.
 ///
 /// Mirrors the `PyO3` bridge's `build_context_manager` (`crates/scp-ffi/src/runtime.rs`).
@@ -1051,27 +1061,31 @@ impl scp_core::context::manager::ContextPersistence for ArcContextPersistence {
 /// [`scp_ffi_common::bridge_instance::CoreFields::persistence_arc_clone`]
 /// so the manager and the bridge mirror share the same backend — a
 /// single `SQLite` connection, not two.
+///
+/// The event broadcast channel is always enabled (capacity
+/// [`EVENT_CHANNEL_CAPACITY`]) so downstream consumers — e.g. the node webhook
+/// dispatcher — can subscribe via `ContextManager::subscribe_events()`. When no
+/// consumer subscribes, emitting into the channel is a cheap no-op: the
+/// retained sender has no receivers, so `send` returns `Err` and the event is
+/// simply dropped without blocking context operations.
 fn build_context_manager(
     crypto: Box<dyn ContextCryptoProvider>,
     transport: Box<dyn scp_core::context::builder::ContextTransportProvider>,
     event_log: Box<dyn ContextEventLogProvider>,
     persistence: Option<Arc<dyn scp_core::context::manager::ContextPersistence + Send + Sync>>,
 ) -> Arc<ContextManager> {
-    match persistence {
-        Some(shared) => Arc::new(ContextManager::with_persistence(
+    let mut manager = match persistence {
+        Some(shared) => ContextManager::with_persistence(
             crypto,
             transport,
             event_log,
             Box::new(ArcContextPersistence::new(shared)),
             not_configured_key_resolver(),
-        )),
-        None => Arc::new(ContextManager::new(
-            crypto,
-            transport,
-            event_log,
-            not_configured_key_resolver(),
-        )),
-    }
+        ),
+        None => ContextManager::new(crypto, transport, event_log, not_configured_key_resolver()),
+    };
+    manager.with_event_channel(EVENT_CHANNEL_CAPACITY);
+    Arc::new(manager)
 }
 
 // Phase D (#1695): module-level `context_manager`, `context_manager_expect`,

--- a/crates/scp-ffi/uniffi/src/server.rs
+++ b/crates/scp-ffi/uniffi/src/server.rs
@@ -177,6 +177,37 @@ async fn auto_wire_context_manager(
     }
 }
 
+/// Wires the local `ContextManager` event channel into the node's outbound
+/// webhook dispatcher and supervises the consumer under the bridge instance's
+/// lifecycle (spec §12.10.5).
+///
+/// Mirrors the `PyO3` reference bridge (`crates/scp-ffi/src/server.rs`). The
+/// production `ContextManager` built by
+/// [`build_context_manager`](crate::runtime) always enables its event channel,
+/// so `subscribe_events()` yields a receiver. Delegates the subscribe → wire →
+/// supervise block to the shared
+/// [`RunningNode::wire_and_supervise_context_events`] seam so all three bridges
+/// stay in lockstep. The consumer is aborted on bridge shutdown via the
+/// instance cancellation token, so it never leaks as a detached task.
+///
+/// Best-effort: if the `ContextManager` is somehow absent, logs and skips
+/// rather than failing node startup.
+async fn wire_node_webhook_events(
+    bi: &Arc<crate::runtime::UniffiBridgeInstance>,
+    node: &RunningNode,
+) {
+    let Ok(manager) = bi.context_manager_expect() else {
+        tracing::warn!(
+            "wire_node_webhook_events: no ContextManager attached — local context \
+             events will not reach the webhook dispatcher"
+        );
+        return;
+    };
+    let cancel = bi.core.cancel_token();
+    let mut tasks = bi.core.task_handle().await;
+    node.wire_and_supervise_context_events(manager, &mut tasks, cancel);
+}
+
 // ---------------------------------------------------------------------------
 // RelayHandle
 // ---------------------------------------------------------------------------
@@ -657,10 +688,13 @@ pub(crate) async fn node_start_in_memory_on(
     let bridge_token = node.bridge_token_hex();
     auto_wire_context_manager(bi, &did, &relay_url, bridge_token).await;
 
+    let inner = RunningNode::InMemory(node);
+    wire_node_webhook_events(bi, &inner).await;
+
     let instance_id = bi.core.instance_id();
     increment_handle_count();
     Ok(Arc::new(NodeHandle {
-        inner: RunningNode::InMemory(node),
+        inner,
         bi: Arc::clone(bi),
         instance_id,
     }))
@@ -698,10 +732,13 @@ pub(crate) async fn node_start_local_on(
     let bridge_token = node.bridge_token_hex();
     auto_wire_context_manager(bi, &did, &relay_url, bridge_token).await;
 
+    let inner = RunningNode::Filesystem(node);
+    wire_node_webhook_events(bi, &inner).await;
+
     let instance_id = bi.core.instance_id();
     increment_handle_count();
     Ok(Arc::new(NodeHandle {
-        inner: RunningNode::Filesystem(node),
+        inner,
         bi: Arc::clone(bi),
         instance_id,
     }))
@@ -762,6 +799,30 @@ mod tests {
         assert!(!node.is_shutdown());
         node.shutdown();
         assert!(node.is_shutdown());
+    }
+
+    /// Regression guard for #1539 on Swift/Kotlin: after node startup the
+    /// production `ContextManager` must have its event broadcast channel
+    /// enabled, so `subscribe_events()` yields a receiver. Before the fix,
+    /// `build_context_manager` did not enable the channel on this bridge and
+    /// it was `None`, so the webhook consumer could never be wired and local
+    /// context events never reached the dispatcher.
+    #[test]
+    fn node_startup_enables_context_event_channel() {
+        let scp = crate::scp::Scp::new();
+        let node = rt().block_on(scp.node_start_in_memory(None)).unwrap();
+
+        let manager = scp
+            .inner
+            .context_manager_expect()
+            .expect("ContextManager must be attached after node startup");
+        assert!(
+            manager.subscribe_events().is_some(),
+            "node startup must enable the ContextManager event channel so the \
+             webhook dispatcher consumer can subscribe (regression: #1539)"
+        );
+
+        node.shutdown();
     }
 
     #[test]

--- a/crates/scp-node/src/bridge_handlers.rs
+++ b/crates/scp-node/src/bridge_handlers.rs
@@ -81,7 +81,13 @@ pub struct BridgeState {
 
     /// Outbound webhook dispatcher for delivering context events
     /// to registered bridge webhook endpoints (spec §12.2.1).
-    pub webhook_dispatcher: crate::webhook::WebhookDispatcher,
+    ///
+    /// Wrapped in `Arc` so the same dispatcher instance can be shared with
+    /// the local-event consumer task spawned via
+    /// [`spawn_event_consumer`](crate::webhook::spawn_event_consumer). Both
+    /// the inbound HTTP relay path (`process_webhook_event`) and the local
+    /// `ContextManager` event channel feed this single dispatcher (§12.10.5).
+    pub webhook_dispatcher: Arc<crate::webhook::WebhookDispatcher>,
 }
 
 /// A stored emitted message for tracking purposes.
@@ -113,8 +119,19 @@ impl BridgeState {
             processed_event_ids: RwLock::new(HashSet::new()),
             messages: RwLock::new(Vec::new()),
             message_sequence: RwLock::new(0),
-            webhook_dispatcher: crate::webhook::WebhookDispatcher::new(),
+            webhook_dispatcher: Arc::new(crate::webhook::WebhookDispatcher::new()),
         }
+    }
+
+    /// Returns a clonable handle to the outbound webhook dispatcher.
+    ///
+    /// Used by the node-level event wiring to share the dispatcher with the
+    /// local-event consumer task ([`spawn_event_consumer`](crate::webhook::spawn_event_consumer)),
+    /// so `ContextManager`-originated events reach the same dispatcher as the
+    /// inbound HTTP relay path (§12.10.5).
+    #[must_use]
+    pub fn webhook_dispatcher(&self) -> Arc<crate::webhook::WebhookDispatcher> {
+        Arc::clone(&self.webhook_dispatcher)
     }
 }
 

--- a/crates/scp-node/src/lib.rs
+++ b/crates/scp-node/src/lib.rs
@@ -308,6 +308,55 @@ impl<S: Storage> ApplicationNode<S> {
         &self.state.relay_url
     }
 
+    /// Returns a clonable handle to this node's outbound webhook dispatcher.
+    ///
+    /// The dispatcher fans context events out to registered bridge webhook
+    /// endpoints (spec §12.2.1, §12.10.5). It is fed by two producers:
+    ///
+    /// 1. The inbound HTTP relay endpoint (`POST /v1/scp/bridge/webhook`),
+    ///    which reconciles platform-originated events.
+    /// 2. The local `ContextManager` event channel, wired via
+    ///    [`wire_context_events`](Self::wire_context_events).
+    #[must_use]
+    pub fn webhook_dispatcher(&self) -> Arc<crate::webhook::WebhookDispatcher> {
+        self.state.bridge_state.webhook_dispatcher()
+    }
+
+    /// Spawns a background task that forwards local `ContextManager` events to
+    /// this node's [`WebhookDispatcher`](crate::webhook::WebhookDispatcher).
+    ///
+    /// This is the production wire for SCP-to-platform webhook delivery
+    /// (§12.10.5): when a context the node hosts emits an event (message
+    /// received/sent, member joined/left, governance action), the event is
+    /// translated and dispatched to every registered webhook target matching
+    /// that context.
+    ///
+    /// The caller supplies a fresh broadcast receiver obtained from
+    /// `ContextManager::subscribe_events()`. The returned
+    /// [`JoinHandle`](tokio::task::JoinHandle) owns the consumer task; the
+    /// caller MUST retain or supervise it so the task is aborted on shutdown
+    /// (otherwise it runs until the `ContextManager` — and therefore the
+    /// broadcast sender — is dropped, which closes the channel and stops the
+    /// consumer cleanly).
+    ///
+    /// # Fail-safe
+    ///
+    /// Webhook delivery is best-effort. A slow or unreachable webhook endpoint
+    /// cannot block or crash context operations: the broadcast channel drops
+    /// the oldest events for lagging consumers (logged, never panics), and the
+    /// dispatcher performs HTTP I/O on its own spawned tasks with bounded
+    /// retries.
+    #[must_use]
+    pub fn wire_context_events(
+        &self,
+        events: tokio::sync::broadcast::Receiver<(
+            String,
+            scp_core::context::membership::ContextEvent,
+        )>,
+    ) -> tokio::task::JoinHandle<()> {
+        crate::webhook::spawn_event_consumer(events, self.webhook_dispatcher())
+    }
+
     /// Returns the TLS certificate resolver for ACME hot-reload.
     ///
     /// Returns `Some` in domain mode when TLS is active, `None` in

--- a/crates/scp-node/src/webhook.rs
+++ b/crates/scp-node/src/webhook.rs
@@ -349,6 +349,19 @@ impl WebhookDispatcher {
             .timeout(std::time::Duration::from_secs(10))
             .build()
             .unwrap_or_else(|_| reqwest::Client::new());
+        Self::with_client(client)
+    }
+
+    /// Creates a new empty dispatcher with a caller-provided HTTP client.
+    ///
+    /// Use this when the dispatcher must share a connection pool or a
+    /// specific TLS trust configuration with the rest of the application
+    /// (e.g. an integration harness that pins a self-signed root for a local
+    /// HTTPS webhook receiver). Production callers should prefer
+    /// [`new`](Self::new), which builds a hardened client with redirects
+    /// disabled (SSRF defense).
+    #[must_use]
+    pub fn with_client(client: reqwest::Client) -> Self {
         Self {
             targets: RwLock::new(HashMap::new()),
             client,

--- a/crates/scp-node/tests/webhook_event_wiring.rs
+++ b/crates/scp-node/tests/webhook_event_wiring.rs
@@ -1,0 +1,351 @@
+//! End-to-end integration test for the local-event → webhook wire (§12.10.5).
+//!
+//! Proves the production consumer path that connects `ContextManager` events to
+//! the outbound [`WebhookDispatcher`](scp_node::webhook::WebhookDispatcher):
+//!
+//! ```text
+//! ContextManager event channel (broadcast)
+//!   → spawn_event_consumer  (the production consumer task)
+//!     → map_context_event   (ContextEvent → event_type + payload)
+//!       → WebhookDispatcher::dispatch_event
+//!         → HTTPS POST with X-SCP-Signature (Ed25519)
+//! ```
+//!
+//! A real `tokio::sync::broadcast` channel — the exact type returned by
+//! `ContextManager::subscribe_events()` — feeds a `ContextEvent` into the
+//! consumer, and a local HTTPS capture server asserts the POST arrives with the
+//! correct event type, structured body, and a valid Ed25519 signature.
+//!
+//! The producer half (a live `ContextManager` emitting events on real context
+//! operations) is covered by the `event_channel_*` tests in `scp-runtime`; this
+//! test covers the node-side consumer wire that was previously unreachable in
+//! production.
+
+#![allow(clippy::unwrap_used, clippy::expect_used)]
+
+use std::net::SocketAddr;
+use std::sync::Arc;
+use std::time::Duration;
+
+use ed25519_dalek::{SigningKey, Verifier};
+use rustls::pki_types::{CertificateDer, PrivateKeyDer};
+use scp_core::context::membership::ContextEvent;
+use scp_identity::DID;
+use scp_node::webhook::{WebhookDispatcher, WebhookTarget, spawn_event_consumer};
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio::net::TcpListener;
+use tokio_rustls::TlsAcceptor;
+
+/// Captured webhook request: the raw HTTP request bytes received by the server.
+struct CapturedRequest {
+    raw: Vec<u8>,
+}
+
+impl CapturedRequest {
+    /// Returns the header value for `name` (case-insensitive), if present.
+    fn header(&self, name: &str) -> Option<String> {
+        let text = String::from_utf8_lossy(&self.raw);
+        for line in text.lines() {
+            if line.is_empty() {
+                break; // end of headers
+            }
+            if let Some((k, v)) = line.split_once(':')
+                && k.trim().eq_ignore_ascii_case(name)
+            {
+                return Some(v.trim().to_owned());
+            }
+        }
+        None
+    }
+
+    /// Returns the request body (everything after the blank line).
+    fn body(&self) -> Vec<u8> {
+        // Find the CRLFCRLF header/body boundary.
+        let needle = b"\r\n\r\n";
+        self.raw
+            .windows(needle.len())
+            .position(|w| w == needle)
+            .map(|pos| self.raw[pos + needle.len()..].to_vec())
+            .unwrap_or_default()
+    }
+}
+
+/// A running local HTTPS capture server.
+struct CaptureServer {
+    /// The hostname placed in the cert SAN and used in the webhook URL.
+    host: String,
+    /// The bound socket address (127.0.0.1:<port>).
+    addr: SocketAddr,
+    /// PEM-encoded self-signed certificate the client must trust.
+    cert_pem: String,
+    /// Resolves once the first request is captured.
+    captured: tokio::sync::oneshot::Receiver<CapturedRequest>,
+}
+
+/// Starts a local HTTPS server that captures the first POST and returns 200.
+///
+/// The certificate SAN is a non-resolvable hostname so that
+/// `WebhookDispatcher`'s SSRF DNS pre-resolution treats it as allowed (it does
+/// not resolve to any blocked IP), while the reqwest client reaches it via an
+/// explicit `.resolve()` override to 127.0.0.1.
+async fn start_capture_server() -> CaptureServer {
+    let host = "webhook.scp-test.invalid".to_owned();
+    let cert = rcgen::generate_simple_self_signed(vec![host.clone()]).unwrap();
+    let cert_pem = cert.cert.pem();
+    let key_der = PrivateKeyDer::Pkcs8(cert.signing_key.serialize_der().into());
+    let cert_der = CertificateDer::from(cert.cert.der().to_vec());
+
+    let server_config = rustls::ServerConfig::builder_with_provider(Arc::new(
+        rustls::crypto::ring::default_provider(),
+    ))
+    .with_protocol_versions(rustls::DEFAULT_VERSIONS)
+    .unwrap()
+    .with_no_client_auth()
+    .with_single_cert(vec![cert_der], key_der)
+    .unwrap();
+    let acceptor = TlsAcceptor::from(Arc::new(server_config));
+
+    let listener = TcpListener::bind(SocketAddr::from(([127, 0, 0, 1], 0)))
+        .await
+        .unwrap();
+    let addr = listener.local_addr().unwrap();
+
+    let (tx, rx) = tokio::sync::oneshot::channel::<CapturedRequest>();
+    let tx = Arc::new(tokio::sync::Mutex::new(Some(tx)));
+
+    tokio::spawn(async move {
+        loop {
+            let Ok((stream, _peer)) = listener.accept().await else {
+                continue;
+            };
+            let acceptor = acceptor.clone();
+            let tx = Arc::clone(&tx);
+            tokio::spawn(async move {
+                let Ok(mut tls) = acceptor.accept(stream).await else {
+                    return;
+                };
+                // Read until the full request (headers + body) has arrived.
+                // The body is small, so a single bounded read loop suffices.
+                let mut raw = Vec::new();
+                let mut buf = [0u8; 2048];
+                loop {
+                    match tls.read(&mut buf).await {
+                        // EOF (0 bytes) or read error: stop reading.
+                        Ok(0) | Err(_) => break,
+                        Ok(n) => {
+                            raw.extend_from_slice(&buf[..n]);
+                            // Stop once we have headers and a body terminator.
+                            if has_complete_request(&raw) {
+                                break;
+                            }
+                        }
+                    }
+                }
+                // Respond 200 OK so dispatch reports success.
+                let response = b"HTTP/1.1 200 OK\r\nContent-Length: 0\r\nConnection: close\r\n\r\n";
+                let _ = tls.write_all(response).await;
+                let _ = tls.flush().await;
+                let _ = tls.shutdown().await;
+                let sender = tx.lock().await.take();
+                if let Some(sender) = sender {
+                    let _ = sender.send(CapturedRequest { raw });
+                }
+            });
+        }
+    });
+
+    CaptureServer {
+        host,
+        addr,
+        cert_pem,
+        captured: rx,
+    }
+}
+
+/// Returns true once `raw` contains a full HTTP request with a body matching its
+/// declared `Content-Length` (or a terminated header block with no body).
+fn has_complete_request(raw: &[u8]) -> bool {
+    let needle = b"\r\n\r\n";
+    let Some(boundary) = raw.windows(needle.len()).position(|w| w == needle) else {
+        return false;
+    };
+    let header_text = String::from_utf8_lossy(&raw[..boundary]);
+    let declared_len = header_text
+        .lines()
+        .find_map(|l| {
+            let (k, v) = l.split_once(':')?;
+            k.trim()
+                .eq_ignore_ascii_case("content-length")
+                .then(|| v.trim().parse::<usize>().ok())
+                .flatten()
+        })
+        .unwrap_or(0);
+    let body_len = raw.len() - (boundary + needle.len());
+    body_len >= declared_len
+}
+
+/// Builds a reqwest client that trusts the capture server's self-signed cert and
+/// resolves the test hostname to the server's loopback address. Mirrors the
+/// production hardening (no redirects) but pins a local root instead of `WebPKI`.
+fn trusting_client(cert_pem: &str, host: &str, addr: SocketAddr) -> reqwest::Client {
+    let cert = reqwest::Certificate::from_pem(cert_pem.as_bytes()).unwrap();
+    reqwest::Client::builder()
+        .add_root_certificate(cert)
+        .redirect(reqwest::redirect::Policy::none())
+        .timeout(Duration::from_secs(10))
+        .resolve(host, addr)
+        .build()
+        .unwrap()
+}
+
+/// Full wire: a `ContextEvent` sent on the broadcast channel is consumed by the
+/// production [`spawn_event_consumer`], mapped, and dispatched as a signed HTTPS
+/// POST to a registered webhook target.
+#[tokio::test]
+async fn context_event_reaches_webhook_dispatcher_end_to_end() {
+    let server = start_capture_server().await;
+
+    // Dispatcher uses a client that trusts the local cert and resolves the test
+    // host to the capture server — everything else is production behavior.
+    let client = trusting_client(&server.cert_pem, &server.host, server.addr);
+    let dispatcher = Arc::new(WebhookDispatcher::with_client(client));
+
+    // Register a webhook target scoped to the context we will emit for.
+    let signing_key = SigningKey::from_bytes(&[7u8; 32]);
+    let verifying_key = signing_key.verifying_key();
+    let webhook_url = format!("https://{}:{}/hook", server.host, server.addr.port());
+    let registered = dispatcher
+        .register(
+            "bridge-under-test".to_owned(),
+            WebhookTarget {
+                url: webhook_url,
+                signing_key: signing_key.clone(),
+                context_ids: vec!["ctx-wire".to_owned()],
+            },
+        )
+        .await;
+    assert!(registered, "target registration should succeed");
+
+    // The exact channel type ContextManager::subscribe_events() hands out.
+    let (tx, rx) = tokio::sync::broadcast::channel::<(String, ContextEvent)>(1024);
+    let consumer = spawn_event_consumer(rx, Arc::clone(&dispatcher));
+
+    // Emit a MemberJoined event exactly as ContextManager::emit_event would.
+    tx.send((
+        "ctx-wire".to_owned(),
+        ContextEvent::MemberJoined {
+            member_did: DID::from("did:key:carol"),
+            role_name: "admin".to_owned(),
+        },
+    ))
+    .expect("send on broadcast channel");
+
+    // Await the captured request (bounded — fail fast if the wire is broken).
+    let captured = tokio::time::timeout(Duration::from_secs(10), server.captured)
+        .await
+        .expect("webhook should be delivered before timeout")
+        .expect("capture channel should yield a request");
+
+    // Tear down the consumer so the test does not leak the task.
+    consumer.abort();
+
+    // 1. Headers carry the signature contract (§12.10.2).
+    assert_eq!(
+        captured.header("content-type").as_deref(),
+        Some("application/json"),
+        "Content-Type must be application/json"
+    );
+    let sig_hex = captured
+        .header("x-scp-signature")
+        .expect("X-SCP-Signature header must be present");
+    let ts_str = captured
+        .header("x-scp-timestamp")
+        .expect("X-SCP-Timestamp header must be present");
+    let timestamp: u64 = ts_str.parse().expect("timestamp must be a u64");
+
+    // 2. Body is the mapped MemberJoined event (proves map_context_event ran).
+    let body = captured.body();
+    let body_json: serde_json::Value =
+        serde_json::from_slice(&body).expect("body must be valid JSON");
+    assert_eq!(
+        body_json["event_type"], "member.joined",
+        "MemberJoined must map to the member.joined webhook event type"
+    );
+    assert_eq!(body_json["context_id"], "ctx-wire");
+    assert_eq!(body_json["payload"]["member_did"], "did:key:carol");
+    assert_eq!(body_json["payload"]["role_name"], "admin");
+
+    // 3. The Ed25519 signature verifies over the domain-separated payload.
+    let sig_bytes = hex::decode(&sig_hex).expect("signature must be valid hex");
+    let signature =
+        ed25519_dalek::Signature::from_slice(&sig_bytes).expect("signature must be 64 bytes");
+    let mut signing_payload = Vec::new();
+    signing_payload.extend_from_slice(b"SCP-WEBHOOK-V1:");
+    signing_payload.extend_from_slice(&timestamp.to_be_bytes());
+    signing_payload.extend_from_slice(&body);
+    verifying_key
+        .verify(&signing_payload, &signature)
+        .expect("Ed25519 signature must verify");
+}
+
+/// A target scoped to a different context must NOT receive the event. Proves the
+/// consumer honors `WebhookDispatcher`'s per-context routing rather than
+/// fanning every event to every registered target.
+#[tokio::test]
+async fn consumer_respects_context_scoping() {
+    let server = start_capture_server().await;
+    let client = trusting_client(&server.cert_pem, &server.host, server.addr);
+    let dispatcher = Arc::new(WebhookDispatcher::with_client(client));
+
+    let signing_key = SigningKey::from_bytes(&[9u8; 32]);
+    let webhook_url = format!("https://{}:{}/hook", server.host, server.addr.port());
+    dispatcher
+        .register(
+            "other-context-bridge".to_owned(),
+            WebhookTarget {
+                url: webhook_url,
+                signing_key,
+                // Subscribed only to ctx-other, not ctx-wire.
+                context_ids: vec!["ctx-other".to_owned()],
+            },
+        )
+        .await;
+
+    let (tx, rx) = tokio::sync::broadcast::channel::<(String, ContextEvent)>(1024);
+    let consumer = spawn_event_consumer(rx, Arc::clone(&dispatcher));
+
+    tx.send((
+        "ctx-wire".to_owned(),
+        ContextEvent::MemberLeft {
+            member_did: DID::from("did:key:dave"),
+        },
+    ))
+    .expect("send on broadcast channel");
+
+    // The capture server must NOT receive a request: assert a short timeout
+    // elapses without delivery.
+    let result = tokio::time::timeout(Duration::from_millis(750), server.captured).await;
+    consumer.abort();
+    assert!(
+        result.is_err(),
+        "event for ctx-wire must not be delivered to a ctx-other-scoped target"
+    );
+}
+
+/// A lagging/closed channel must not panic the consumer. Sending after the
+/// receiver is wired, then dropping the sender, closes the channel and the
+/// consumer task completes cleanly (fail-safe behavior — §12.10.5 best-effort).
+#[tokio::test]
+async fn consumer_exits_cleanly_on_channel_close() {
+    let dispatcher = Arc::new(WebhookDispatcher::new());
+    let (tx, rx) = tokio::sync::broadcast::channel::<(String, ContextEvent)>(8);
+    let consumer = spawn_event_consumer(rx, dispatcher);
+
+    // Drop the sender → channel closes → consumer should return (not hang).
+    drop(tx);
+
+    tokio::time::timeout(Duration::from_secs(5), consumer)
+        .await
+        .expect("consumer must exit when the channel closes")
+        .expect("consumer task must not panic");
+}

--- a/crates/scp-testing/tests/integration/pipeline_wiring.rs
+++ b/crates/scp-testing/tests/integration/pipeline_wiring.rs
@@ -1021,6 +1021,39 @@ fn b3_webhook_dispatch_wired() {
         webhook_src.contains("validate_webhook_url"),
         "webhook module must include SSRF validation"
     );
+
+    // The consumer that bridges ContextManager events to the dispatcher must
+    // exist (§12.10.5). Without it, local context events can never reach
+    // registered webhooks — the dispatcher would only ever be fed by the
+    // inbound HTTP relay endpoint.
+    assert!(
+        webhook_src.contains("fn spawn_event_consumer"),
+        "webhook module must export spawn_event_consumer (local-event → dispatcher bridge)"
+    );
+    assert!(
+        webhook_src.contains("fn map_context_event"),
+        "webhook module must map ContextEvent variants to webhook event types"
+    );
+
+    // The consumer must be wired in production: the node exposes the wire, and
+    // the FFI node-startup path enables the ContextManager event channel and
+    // spawns the consumer. A string match here guards against the regression
+    // that reopened #1539 — the plumbing existing but never being connected.
+    assert!(
+        node_src.contains("fn wire_context_events"),
+        "ApplicationNode must expose wire_context_events to connect events to the dispatcher"
+    );
+    let ffi_server_src = include_str!("../../../../crates/scp-ffi/src/server.rs");
+    assert!(
+        ffi_server_src.contains("wire_context_events"),
+        "node startup must call wire_context_events so local events reach the webhook dispatcher"
+    );
+    let ffi_runtime_src = include_str!("../../../../crates/scp-ffi/src/runtime.rs");
+    assert!(
+        ffi_runtime_src.contains("with_event_channel"),
+        "production ContextManager construction must enable the event channel \
+         (otherwise subscribe_events yields None and no events are dispatched)"
+    );
 }
 
 // ===========================================================================

--- a/crates/scp-testing/tests/integration/pipeline_wiring.rs
+++ b/crates/scp-testing/tests/integration/pipeline_wiring.rs
@@ -1043,15 +1043,68 @@ fn b3_webhook_dispatch_wired() {
         node_src.contains("fn wire_context_events"),
         "ApplicationNode must expose wire_context_events to connect events to the dispatcher"
     );
+    // Every non-WASM bridge (PyO3 reference, NAPI, UniFFI) must independently
+    // (a) enable the ContextManager event channel at manager construction and
+    // (b) wire the consumer into the dispatcher at node startup. #1539 was first
+    // fixed only on PyO3; NAPI/UniFFI had structurally identical startup paths
+    // that were never wired, so local events never reached the dispatcher on
+    // Node/Bun/Swift/Kotlin. These per-bridge string matches guard against that
+    // drift recurring.
+    //
+    // The shared supervision seam (`spawn_supervised_event_consumer`) lives in
+    // `scp-ffi-common`; assert it exists so the consolidated wire cannot be
+    // silently inlined-and-diverged again.
+    let common_server_src = include_str!("../../../../crates/scp-ffi/common/src/server.rs");
+    assert!(
+        common_server_src.contains("fn spawn_supervised_event_consumer"),
+        "scp-ffi-common must expose the shared spawn_supervised_event_consumer \
+         supervision seam used by all bridges"
+    );
+    assert!(
+        common_server_src.contains("fn wire_and_supervise_context_events"),
+        "RunningNode must expose wire_and_supervise_context_events (shared \
+         subscribe → wire → supervise seam for NAPI + UniFFI)"
+    );
+
+    // PyO3 reference bridge.
     let ffi_server_src = include_str!("../../../../crates/scp-ffi/src/server.rs");
     assert!(
         ffi_server_src.contains("wire_context_events"),
-        "node startup must call wire_context_events so local events reach the webhook dispatcher"
+        "PyO3 node startup must call wire_context_events so local events reach \
+         the webhook dispatcher"
     );
     let ffi_runtime_src = include_str!("../../../../crates/scp-ffi/src/runtime.rs");
     assert!(
         ffi_runtime_src.contains("with_event_channel"),
-        "production ContextManager construction must enable the event channel \
+        "PyO3 production ContextManager construction must enable the event channel \
+         (otherwise subscribe_events yields None and no events are dispatched)"
+    );
+
+    // NAPI bridge (Node.js/Bun).
+    let napi_server_src = include_str!("../../../../crates/scp-ffi/napi/src/server.rs");
+    assert!(
+        napi_server_src.contains("wire_and_supervise_context_events"),
+        "NAPI node startup must wire ContextManager events into the webhook \
+         dispatcher (regression guard for #1539 on Node/Bun)"
+    );
+    let napi_runtime_src = include_str!("../../../../crates/scp-ffi/napi/src/runtime.rs");
+    assert!(
+        napi_runtime_src.contains("with_event_channel"),
+        "NAPI production ContextManager construction must enable the event channel \
+         (otherwise subscribe_events yields None and no events are dispatched)"
+    );
+
+    // UniFFI bridge (Swift/Kotlin).
+    let uniffi_server_src = include_str!("../../../../crates/scp-ffi/uniffi/src/server.rs");
+    assert!(
+        uniffi_server_src.contains("wire_and_supervise_context_events"),
+        "UniFFI node startup must wire ContextManager events into the webhook \
+         dispatcher (regression guard for #1539 on Swift/Kotlin)"
+    );
+    let uniffi_runtime_src = include_str!("../../../../crates/scp-ffi/uniffi/src/runtime.rs");
+    assert!(
+        uniffi_runtime_src.contains("with_event_channel"),
+        "UniFFI production ContextManager construction must enable the event channel \
          (otherwise subscribe_events yields None and no events are dispatched)"
     );
 }


### PR DESCRIPTION
## What
Connects local `ContextManager` events to the node's `WebhookDispatcher` **in production** on all three node-capable bridges (PyO3, NAPI, UniFFI). Closes the AC3 gap that reopened #1539.

## Why
PR #1673 built the dispatch machinery (`map_context_event`, signed delivery, retry, SSRF defenses) and the broadcast plumbing (`ContextManager.event_tx`, `with_event_channel`, `spawn_event_consumer`), but the producer/consumer were never connected in production: `event_tx` defaulted to `None` and the only setter + the consumer-spawn were test-only. Events emitted into a dead channel.

## How
- **Producer:** `build_context_manager` calls `with_event_channel(1024)` on every production `ContextManager` — PyO3 (`scp-ffi/src/runtime.rs`), NAPI (`finalize_context_manager`), UniFFI (`build_context_manager`).
- **Consumer:** node startup subscribes + spawns the supervised consumer at both `node_start_in_memory`/`node_start_local` on all three bridges.
- **Root-cause fix (anti-drift):** the subscribe→wire→supervise logic — previously inline in PyO3 only — is consolidated into `scp-ffi-common` (`spawn_supervised_event_consumer` + `RunningNode::wire_and_supervise_context_events`); PyO3 refactored onto it. A fix here now propagates to all bridges instead of being copy-pasted.
- **Lifecycle:** consumer supervised by the bridge `JoinSet` + cancellation token (`tokio::select!` aborts on shutdown — no leak); fail-safe (broadcast lag drops oldest, never blocks/panics context ops).
- **Spec:** added the local-event webhook **event-type table** to §12.10.5 documenting the 6 dispatched event types + payloads, so the in-code `(§12.10.5)` citations are accurate (was phantom-provenance-lite).
- **Enforcement:** `pipeline_wiring.rs` `b3_webhook_dispatch_wired` extended to assert the wire on all three bridges (mechanical guard against re-drift). WASM correctly excluded (no node/relay, ADR-034).

## Review & CI
security **SHIP**, bug-catcher **CLEAN**, alignment **ALIGNED** (AC3 satisfied on all bridges). Tests: node-level end-to-end (real broadcast channel → HTTPS capture → Ed25519 signature verified) + NAPI/UniFFI parity tests (`subscribe_events()` is `Some` post-startup). Full CI clippy + targeted tests + fmt green.

## Known separate gap (tracked)
`WebhookDispatcher::register` has **no production caller** — there's no FFI/SDK surface to register an *outbound* webhook target, so the prod target map is empty until that lands. That's a distinct consumer-side feature, tracked in **#1764** (the dispatcher is also fed by the existing inbound HTTP path, so this PR's producer-side wiring is independently correct).

Closes #1539

🤖 Generated with [Claude Code](https://claude.com/claude-code)