### PR TITLE
fix(ffi-napi): un-gate identity registry + callback custody for production

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -422,6 +422,39 @@ jobs:
           # the silent rot that broke the quic feature for months.
           cargo nextest run -p scp-transport --features quic,http3,udp,coap
 
+  # Exercises the napi bridge in its PRODUCTION configuration: default features
+  # (`server` on) but WITHOUT `allow_in_memory_custody` / `scp-core/testing` /
+  # `scp-runtime/testing`. This is the config the feature-free context-export
+  # tests target — `MlsCryptoProvider::validate_creator_identity` only accepts
+  # `did:dht:z*` identities here (no `did:test:` / `did:key:` test gate), so a
+  # callback-shaped custody signer must round-trip and fail-closed for real.
+  # Without this lane the production/bare napi test target could silently
+  # regress (stop compiling, or stop running the export tests) unnoticed.
+  rust-test-napi-production:
+    needs: changes
+    if: needs.changes.outputs.rust == 'true'
+    name: Rust / test (napi production config)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Free disk space
+        run: |
+          sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghc /opt/hostedtoolcache/CodeQL
+          df -h /
+      - uses: actions/checkout@v5
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - uses: Swatinem/rust-cache@v2
+      - name: Run napi tests in production config (no custody/testing features)
+        run: |
+          export LD_LIBRARY_PATH="$(python3 -c 'import sysconfig; print(sysconfig.get_config_var("LIBDIR"))')${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}"
+          # Default features = production: `server` on, no in-memory custody and
+          # no `scp-runtime`/`scp-core` `testing` gates. The feature-free
+          # context-export tests run here for real; the bare/production target
+          # must compile and pass without the testing affordances.
+          cargo test -p scp-ffi-napi --features server
+
   rust-doc:
     needs: changes
     if: needs.changes.outputs.rust == 'true'
@@ -995,6 +1028,7 @@ jobs:
       - rust-fmt
       - rust-clippy
       - rust-test
+      - rust-test-napi-production
       - rust-doc
       - rust-deny
       - python-lint
@@ -1031,6 +1065,7 @@ jobs:
             "${{ needs.rust-fmt.result }}" \
             "${{ needs.rust-clippy.result }}" \
             "${{ needs.rust-test.result }}" \
+            "${{ needs.rust-test-napi-production.result }}" \
             "${{ needs.rust-doc.result }}" \
             "${{ needs.rust-deny.result }}" \
             "${{ needs.python-lint.result }}" \

--- a/crates/scp-ffi/napi/Cargo.toml
+++ b/crates/scp-ffi/napi/Cargo.toml
@@ -44,7 +44,13 @@ scp-identity = { path = "../../scp-identity" }
 scp-event-log = { path = "../../scp-event-log" }
 scp-ffi-common = { path = "../common", features = ["custody"] }
 scp-node = { path = "../../scp-node", features = ["allow_unencrypted_storage"], optional = true }
-scp-platform = { path = "../../scp-platform", features = ["encrypting", "filesystem", "sqlite"] }
+# `testing` is enabled unconditionally (matching the PyO3 bridge) so the
+# identity registry, retained-custody state, and the cold-storage
+# `InMemoryPreRotationCustody` are available in production builds. These types
+# back the production callback-custody path (`identityCreateWithCustody`) —
+# `allow_in_memory_custody` remains a pure code-level gate over the in-memory
+# custody *backend* only, not over the registry/retention machinery. See ADR-006.
+scp-platform = { path = "../../scp-platform", features = ["testing", "encrypting", "filesystem", "sqlite"] }
 scp-mcp = { path = "../../scp-mcp" }
 scp-testing = { path = "../../scp-testing", optional = true }
 scp-transport = { path = "../../scp-transport" }

--- a/crates/scp-ffi/napi/src/context.rs
+++ b/crates/scp-ffi/napi/src/context.rs
@@ -4194,7 +4194,14 @@ fn parse_template_id_napi(
 #[allow(clippy::unwrap_used, clippy::expect_used, clippy::panic)]
 mod tests {
     use scp_core::context::ContextParams;
+    // Sole consumers are the `allow_in_memory_custody`-gated governance/role
+    // tests below; gate the import so the bare/production test target has no
+    // unused import.
+    #[cfg(feature = "allow_in_memory_custody")]
     use scp_core::context::governance::GovernanceAction;
+    // Consumed only by the `allow_in_memory_custody`-gated membership helper +
+    // test; gate the import so the bare/production test target is warning-clean.
+    #[cfg(feature = "allow_in_memory_custody")]
     use scp_core::context::membership::KeyPackage;
     use scp_core::context::params::Capability;
     // The feature-gated economy tests reference `codes::` directly (no
@@ -4207,6 +4214,10 @@ mod tests {
     use scp_identity::DID;
     use std::sync::Arc;
 
+    // Sole consumers are the `allow_in_memory_custody`-gated role-sync tests
+    // below; gate the import so the bare/production test target has no unused
+    // import.
+    #[cfg(feature = "allow_in_memory_custody")]
     use scp_ffi_common::test_helpers::approved_proposal;
 
     /// Test helper: dispatch `LifecycleCommand::CreateContext` through the
@@ -4236,7 +4247,9 @@ mod tests {
     }
 
     /// Test helper: dispatch `LifecycleCommand::JoinContext` through the
-    /// supervisor.
+    /// supervisor. Only the `allow_in_memory_custody`-gated membership tests
+    /// call it, so it is gated to keep the bare test target warning-clean.
+    #[cfg(feature = "allow_in_memory_custody")]
     async fn test_dispatch_join_context(
         bi: &crate::runtime::NapiBridgeInstance,
         handle: &scp_core::context::ContextHandle,
@@ -4261,7 +4274,9 @@ mod tests {
     }
 
     /// Test helper: dispatch `QueriesCommand::MemberCount` through the
-    /// supervisor.
+    /// supervisor. Only the `allow_in_memory_custody`-gated membership test
+    /// calls it, so it is gated to keep the bare test target warning-clean.
+    #[cfg(feature = "allow_in_memory_custody")]
     async fn test_dispatch_member_count(
         bi: &crate::runtime::NapiBridgeInstance,
         ctx_id: &str,
@@ -4279,7 +4294,10 @@ mod tests {
     }
 
     /// Test helper: dispatch `GovernanceCommand::ExecuteGovernanceAction`
-    /// through the supervisor.
+    /// through the supervisor. Only the `allow_in_memory_custody`-gated
+    /// role-sync tests call it, so it is gated to keep the bare test target
+    /// warning-clean.
+    #[cfg(feature = "allow_in_memory_custody")]
     async fn test_dispatch_execute_governance(
         bi: &crate::runtime::NapiBridgeInstance,
         ctx_id: &str,
@@ -4327,6 +4345,15 @@ mod tests {
     /// Verifies that member count queries return the live member
     /// count — not a hardcoded value.  After creation the count is 1 (the
     /// creator); after a join it becomes 2.
+    ///
+    /// Gated on `allow_in_memory_custody`: this test wires the supervisor with a
+    /// `did:test:` MLS identity (`init_supervisor_for_test_on`) and `did:key:`
+    /// member DIDs, which `MlsCryptoProvider::validate_creator_identity` only
+    /// accepts under `scp-runtime`'s `testing` feature (pulled in transitively
+    /// via `allow_in_memory_custody` → `dep:scp-testing` → `scp-core/testing`).
+    /// It is NOT part of the feature-free export surface; the production/bare
+    /// test target must not run it.
+    #[cfg(feature = "allow_in_memory_custody")]
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn member_count_reflects_actual_membership() {
         let bi = std::sync::Arc::new(crate::runtime::NapiBridgeInstance::new_napi());
@@ -4409,6 +4436,10 @@ mod tests {
     // Role state sync after governance (#560)
     // -----------------------------------------------------------------------
 
+    // Gated on `allow_in_memory_custody`: uses `did:test:` MLS identity +
+    // `did:key:` member DIDs, accepted only under `scp-runtime/testing`
+    // (transitively enabled by `allow_in_memory_custody`). Not feature-free.
+    #[cfg(feature = "allow_in_memory_custody")]
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn role_state_syncs_after_change_role() {
         let bi = std::sync::Arc::new(crate::runtime::NapiBridgeInstance::new_napi());
@@ -4461,6 +4492,10 @@ mod tests {
         crate::runtime::remove_context(&bi, &ctx_id);
     }
 
+    // Gated on `allow_in_memory_custody`: uses `did:test:` MLS identity +
+    // `did:key:` member DIDs, accepted only under `scp-runtime/testing`
+    // (transitively enabled by `allow_in_memory_custody`). Not feature-free.
+    #[cfg(feature = "allow_in_memory_custody")]
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn role_state_syncs_after_add_member() {
         let bi = std::sync::Arc::new(crate::runtime::NapiBridgeInstance::new_napi());
@@ -4507,6 +4542,10 @@ mod tests {
         crate::runtime::remove_context(&bi, &ctx_id);
     }
 
+    // Gated on `allow_in_memory_custody`: uses `did:test:` MLS identity +
+    // `did:key:` member DIDs, accepted only under `scp-runtime/testing`
+    // (transitively enabled by `allow_in_memory_custody`). Not feature-free.
+    #[cfg(feature = "allow_in_memory_custody")]
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn role_state_syncs_after_remove_member() {
         let bi = std::sync::Arc::new(crate::runtime::NapiBridgeInstance::new_napi());

--- a/crates/scp-ffi/napi/src/context.rs
+++ b/crates/scp-ffi/napi/src/context.rs
@@ -4197,6 +4197,12 @@ mod tests {
     use scp_core::context::governance::GovernanceAction;
     use scp_core::context::membership::KeyPackage;
     use scp_core::context::params::Capability;
+    // The feature-gated economy tests reference `codes::` directly (no
+    // `use super::*`); the ungated export tests reach `codes` through their
+    // in-fn `use super::*` glob (re-exporting the file-level alias). Gate the
+    // alias to its sole direct consumers so the ungated build does not see an
+    // unused import.
+    #[cfg(feature = "allow_in_memory_custody")]
     use scp_ffi_common::error_codes as codes;
     use scp_identity::DID;
     use std::sync::Arc;
@@ -5239,12 +5245,15 @@ mod tests {
         use scp_core::context::export_import::{deserialize_export, serialize_export};
 
         let bi = std::sync::Arc::new(crate::runtime::NapiBridgeInstance::new_napi());
-        crate::runtime::init_supervisor_for_test_on(&bi);
+        // Use a production-valid `did:dht:z*` MLS identity so context creation
+        // succeeds WITHOUT `scp-runtime/testing` — this test must genuinely
+        // exercise the no-in-memory-custody build, not the testing gate.
+        crate::runtime::init_production_supervisor_for_test_on(&bi);
         let sup = crate::runtime::supervisor(&bi).expect("supervisor initialized above");
         let sup = Arc::clone(sup);
 
         let custody = FakeExportCustody::new();
-        let creator = DID("did:key:z6MkCallbackExporter".to_owned());
+        let creator = DID("did:dht:z6MkCallbackExporter".to_owned());
         let ctx_id = format!("callback-export-{}", uuid::Uuid::new_v4());
 
         // `context:close` is required so the creator can close the context
@@ -5277,7 +5286,7 @@ mod tests {
         // identity). Success proves the callback-produced signature is
         // spec-valid (§23.16.8).
         let bi2 = std::sync::Arc::new(crate::runtime::NapiBridgeInstance::new_napi());
-        crate::runtime::init_supervisor_for_test_on(&bi2);
+        crate::runtime::init_production_supervisor_for_test_on(&bi2);
         let sup2 = crate::runtime::supervisor(&bi2).expect("supervisor initialized above");
         let sup2 = Arc::clone(sup2);
 
@@ -5323,9 +5332,12 @@ mod tests {
     async fn context_export_fails_closed_without_retained_custody() {
         use super::*;
         let bi = std::sync::Arc::new(crate::runtime::NapiBridgeInstance::new_napi());
-        crate::runtime::init_supervisor_for_test_on(&bi);
+        // Production-valid `did:dht:z*` MLS identity so context creation
+        // succeeds WITHOUT `scp-runtime/testing` — this test must run in the
+        // no-in-memory-custody build it documents.
+        crate::runtime::init_production_supervisor_for_test_on(&bi);
 
-        let creator = DID("did:key:z6MkNoCustodyExporter".to_owned());
+        let creator = DID("did:dht:z6MkNoCustodyExporter".to_owned());
         let ctx_id = format!("no-custody-export-{}", uuid::Uuid::new_v4());
         let params = ContextParams {
             ceiling: vec![Capability::new("context:close")],

--- a/crates/scp-ffi/napi/src/context.rs
+++ b/crates/scp-ffi/napi/src/context.rs
@@ -20,7 +20,6 @@ use scp_identity::DID;
 use scp_primitives::Clock;
 use tokio_util::sync::CancellationToken;
 
-#[cfg(feature = "allow_in_memory_custody")]
 use scp_platform::traits::KeyCustody;
 
 use scp_ffi_common::validate::validate_did;
@@ -116,11 +115,15 @@ pub struct NapiContextHandle {
     /// Retained custody for UCAN signing — shares the creator identity's
     /// `Arc<NapiKeyCustody>` so context-level signing uses the same key
     /// material (and works for callback-backed identities too).
-    #[cfg(feature = "allow_in_memory_custody")]
+    ///
+    /// Available in production (not feature-gated): in the production
+    /// callback-custody path this carries the creator identity's retained
+    /// `Arc<NapiKeyCustody::Callback>`. The field name is historical — it
+    /// backs any retained custody, not just in-memory. `None` when the context
+    /// creator was an externally loaded (DID-string-only) identity.
     pub(crate) in_memory_custody: Option<Arc<crate::custody::NapiKeyCustody>>,
-    /// Handle to the creator's active signing key for UCAN minting.
-    /// Only read inside `#[cfg(feature = "allow_in_memory_custody")]` blocks.
-    #[allow(dead_code)]
+    /// Handle to the creator's active signing key for UCAN minting and
+    /// context-export signing.
     pub(crate) signing_key: Option<scp_platform::traits::KeyHandle>,
     /// The scp-core `ContextHandle` for this context, used for manager delegation.
     pub(crate) core_handle: Option<ContextHandle>,
@@ -348,7 +351,6 @@ impl NapiContextHandle {
             promotion_policy: None,
             governance: "single_admin".to_owned(),
             economic_policy: None,
-            #[cfg(feature = "allow_in_memory_custody")]
             in_memory_custody: None,
             signing_key: None,
             core_handle: None,
@@ -389,7 +391,6 @@ pub struct NapiMessage {
 /// `KeyCustody::derive_pseudonym`. The pseudonym is used as the member's
 /// per-context routing ID for encrypted contexts, replacing the shared
 /// `context_routing_id` to prevent relay-side correlation.
-#[cfg(feature = "allow_in_memory_custody")]
 async fn derive_context_pseudonym(identity: &NapiIdentity, context_id: &str) -> Option<[u8; 32]> {
     let (scp_id, custody) = (
         identity.inner.scp_identity.as_ref()?,
@@ -401,12 +402,6 @@ async fn derive_context_pseudonym(identity: &NapiIdentity, context_id: &str) -> 
         .ok()?;
     let bytes: [u8; 32] = pseudonym.public_key.as_bytes().try_into().ok()?;
     Some(bytes)
-}
-
-/// Fallback for non-custody builds — always returns `None`.
-#[cfg(not(feature = "allow_in_memory_custody"))]
-async fn derive_context_pseudonym(_identity: &NapiIdentity, _context_id: &str) -> Option<[u8; 32]> {
-    None
 }
 
 // ---------------------------------------------------------------------------
@@ -457,7 +452,6 @@ pub(crate) async fn context_create_on(
     let economic_policy = params["economicPolicy"].as_str().map(str::to_owned);
 
     // Extract key custody and signing key from the identity handle.
-    #[cfg(feature = "allow_in_memory_custody")]
     let in_memory_custody = identity.inner.in_memory_custody.clone();
     let signing_key = identity
         .inner
@@ -631,7 +625,6 @@ pub(crate) async fn context_create_on(
         promotion_policy,
         governance,
         economic_policy,
-        #[cfg(feature = "allow_in_memory_custody")]
         in_memory_custody,
         signing_key,
         core_handle: Some(core_handle),
@@ -704,24 +697,17 @@ pub(crate) async fn context_join_on(
     // the pseudonym asynchronously — avoids block_on inside an async fn.
     let context_id = handle.context_id.clone();
     let local_pseudonym: Option<[u8; 32]> = {
-        #[cfg(feature = "allow_in_memory_custody")]
-        {
-            let custody_and_key = crate::runtime::with_identity(bi, &identity_did, |entry| {
-                Ok((entry.custody.clone(), entry.identity.identity_key))
-            })
-            .ok();
-            match custody_and_key {
-                Some((custody, identity_key)) => custody
-                    .derive_pseudonym(&identity_key, context_id.as_bytes())
-                    .await
-                    .ok()
-                    .and_then(|p| p.public_key.as_bytes().try_into().ok()),
-                None => None,
-            }
-        }
-        #[cfg(not(feature = "allow_in_memory_custody"))]
-        {
-            None
+        let custody_and_key = crate::runtime::with_identity(bi, &identity_did, |entry| {
+            Ok((entry.custody.clone(), entry.identity.identity_key))
+        })
+        .ok();
+        match custody_and_key {
+            Some((custody, identity_key)) => custody
+                .derive_pseudonym(&identity_key, context_id.as_bytes())
+                .await
+                .ok()
+                .and_then(|p| p.public_key.as_bytes().try_into().ok()),
+            None => None,
         }
     };
 
@@ -759,36 +745,33 @@ pub(crate) async fn context_join_on(
     // Best-effort: if signing key is not available, skip silently. Routes
     // through the ADR-049 commit-8 messaging shim.
     if local_pseudonym.is_some() {
-        #[cfg(feature = "allow_in_memory_custody")]
+        // Extract custody + key handle from registry (sync), then export
+        // the signing key asynchronously — avoids block_on inside async fn.
+        let custody_and_key = crate::runtime::with_identity(bi, &identity_did, |e| {
+            Ok((e.custody.clone(), e.identity.active_signing_key))
+        })
+        .ok();
+        if let Some((custody, key_handle)) = custody_and_key
+            && let Ok(sk) = custody.export_ed25519_signing_key(&key_handle).await
         {
-            // Extract custody + key handle from registry (sync), then export
-            // the signing key asynchronously — avoids block_on inside async fn.
-            let custody_and_key = crate::runtime::with_identity(bi, &identity_did, |e| {
-                Ok((e.custody.clone(), e.identity.active_signing_key))
-            })
-            .ok();
-            if let Some((custody, key_handle)) = custody_and_key
-                && let Ok(sk) = custody.export_ed25519_signing_key(&key_handle).await
-            {
-                use scp_core::context::actor::commands::{
-                    MessagingCommand, SendPseudonymAnnouncementPayload, SigningKeyBytes,
-                };
-                let sender_did = DID(identity_did.clone());
-                let ann_ctx_id = context_id.clone();
-                let ann_params = core_handle.params().clone();
-                let (tx, rx) = tokio::sync::oneshot::channel();
-                let cmd = MessagingCommand::SendPseudonymAnnouncement {
-                    payload: Box::new(SendPseudonymAnnouncementPayload {
-                        context_id: ann_ctx_id.clone(),
-                        params: ann_params,
-                        sender_did,
-                        signing_key: SigningKeyBytes::from_signing_key(&sk),
-                    }),
-                    reply: tx,
-                };
-                if sup.dispatch_command(&ann_ctx_id, cmd).await.is_ok() {
-                    let _ = rx.await;
-                }
+            use scp_core::context::actor::commands::{
+                MessagingCommand, SendPseudonymAnnouncementPayload, SigningKeyBytes,
+            };
+            let sender_did = DID(identity_did.clone());
+            let ann_ctx_id = context_id.clone();
+            let ann_params = core_handle.params().clone();
+            let (tx, rx) = tokio::sync::oneshot::channel();
+            let cmd = MessagingCommand::SendPseudonymAnnouncement {
+                payload: Box::new(SendPseudonymAnnouncementPayload {
+                    context_id: ann_ctx_id.clone(),
+                    params: ann_params,
+                    sender_did,
+                    signing_key: SigningKeyBytes::from_signing_key(&sk),
+                }),
+                reply: tx,
+            };
+            if sup.dispatch_command(&ann_ctx_id, cmd).await.is_ok() {
+                let _ = rx.await;
             }
         }
     }
@@ -956,7 +939,6 @@ pub(crate) async fn context_send_on(
     // Validate inner envelope signing via the retained KeyCustody
     // (SCP-214 criterion 6). Ensures the identity's active signing key
     // can produce a valid Ed25519 signature before sending.
-    #[cfg(feature = "allow_in_memory_custody")]
     if let (Some(custody), Some(signing_key)) = (&handle.in_memory_custody, handle.signing_key) {
         let context_id = handle.context_id.clone();
         let sender_did_str = identity_did.clone();
@@ -990,11 +972,7 @@ pub(crate) async fn context_send_on(
     // ContextManager can produce a valid inner envelope signature. Passing
     // None would cause the encrypted send path to fail with "signing key
     // required".
-    #[cfg(feature = "allow_in_memory_custody")]
     let resolved_signing_key = resolve_napi_signing_key(handle).await.ok();
-
-    #[cfg(not(feature = "allow_in_memory_custody"))]
-    let resolved_signing_key: Option<ed25519_dalek::SigningKey> = None;
 
     // Parse optional spending UCAN JWT into a UcanToken for AND-composition.
     let spending_ucan = spending_ucan_jwt
@@ -1921,65 +1899,50 @@ pub(crate) async fn broadcast_publish_on(
     let context_id = handle.context_id.clone();
     let author_did = DID(author_did);
 
-    #[cfg(feature = "allow_in_memory_custody")]
-    {
-        use scp_core::context::actor::commands::{BroadcastCommand, PublishBroadcastPayload};
-        let custody = handle.in_memory_custody.as_ref().ok_or_else(|| {
-            NapiError::from(ScpNapiError::Permission {
-                message: "broadcast publish requires key custody — create the identity with \
-                          identityCreate(\"in_memory\")"
-                    .to_owned(),
-                code: codes::PERM_3020.to_owned(),
-            })
-        })?;
-        let signing_key = handle.signing_key.ok_or_else(|| {
-            NapiError::from(ScpNapiError::Permission {
-                message: "broadcast publish requires a signing key — identity has no active \
-                          signing key handle"
-                    .to_owned(),
-                code: codes::PERM_3021.to_owned(),
-            })
-        })?;
-
-        // Route through the ADR-049 broadcast dispatch surface with custody.
-        // Publish requires the custody-bearing variant because the
-        // `KeyCustody` trait is not dyn-safe and cannot cross the actor
-        // mailbox.
-        let sup = crate::runtime::supervisor(bi)?;
-        let (tx, rx) = tokio::sync::oneshot::channel();
-        let cmd = BroadcastCommand::PublishBroadcast {
-            payload: Box::new(PublishBroadcastPayload {
-                context_id,
-                author_did,
-                payload,
-                signing_key_handle: signing_key,
-            }),
-            reply: tx,
-        };
-        sup.dispatch_broadcast_command_with_custody(cmd, custody.as_ref())
-            .await
-            .map_err(|e| {
-                napi::Error::from_reason(format!(
-                    "supervisor dispatch_broadcast_command_with_custody failed: {e}"
-                ))
-            })?;
-        rx.await
-            .map_err(|e| napi::Error::from_reason(format!("shim reply dropped: {e}")))?
-            .map_err(|e| NapiError::from(ScpNapiError::from(e)))?;
-    }
-
-    #[cfg(not(feature = "allow_in_memory_custody"))]
-    {
-        let _ = (context_id, author_did, payload);
-        return Err(NapiError::from(ScpNapiError::Permission {
-            message: "broadcast publish requires key custody — in_memory custody feature is \
-                      not enabled"
+    use scp_core::context::actor::commands::{BroadcastCommand, PublishBroadcastPayload};
+    let custody = handle.in_memory_custody.as_ref().ok_or_else(|| {
+        NapiError::from(ScpNapiError::Permission {
+            message: "broadcast publish requires key custody — this identity has no retained \
+                      custody (it was externally loaded)"
                 .to_owned(),
-            code: codes::PERM_3022.to_owned(),
-        }));
-    }
+            code: codes::PERM_3020.to_owned(),
+        })
+    })?;
+    let signing_key = handle.signing_key.ok_or_else(|| {
+        NapiError::from(ScpNapiError::Permission {
+            message: "broadcast publish requires a signing key — identity has no active \
+                      signing key handle"
+                .to_owned(),
+            code: codes::PERM_3021.to_owned(),
+        })
+    })?;
 
-    #[allow(unreachable_code)]
+    // Route through the ADR-049 broadcast dispatch surface with custody.
+    // Publish requires the custody-bearing variant because the
+    // `KeyCustody` trait is not dyn-safe and cannot cross the actor
+    // mailbox.
+    let sup = crate::runtime::supervisor(bi)?;
+    let (tx, rx) = tokio::sync::oneshot::channel();
+    let cmd = BroadcastCommand::PublishBroadcast {
+        payload: Box::new(PublishBroadcastPayload {
+            context_id,
+            author_did,
+            payload,
+            signing_key_handle: signing_key,
+        }),
+        reply: tx,
+    };
+    sup.dispatch_broadcast_command_with_custody(cmd, custody.as_ref())
+        .await
+        .map_err(|e| {
+            napi::Error::from_reason(format!(
+                "supervisor dispatch_broadcast_command_with_custody failed: {e}"
+            ))
+        })?;
+    rx.await
+        .map_err(|e| napi::Error::from_reason(format!("shim reply dropped: {e}")))?
+        .map_err(|e| NapiError::from(ScpNapiError::from(e)))?;
+
     Ok(())
 }
 
@@ -2072,10 +2035,7 @@ pub(crate) async fn broadcast_publish_asset_on(
     let deploy_id_str = deploy_id.as_ref().map_or_else(String::new, Clone::clone);
     // Clone etag when custody feature is enabled — it's needed again in the
     // return value after `content` consumes the clone.
-    #[cfg(feature = "allow_in_memory_custody")]
     let etag_for_metadata = etag.clone();
-    #[cfg(not(feature = "allow_in_memory_custody"))]
-    let etag_for_metadata = etag;
     let content = scp_core::context::BroadcastContent {
         version: scp_core::context::BROADCAST_CONTENT_VERSION,
         metadata: scp_core::context::ContentMetadata {
@@ -2088,80 +2048,64 @@ pub(crate) async fn broadcast_publish_asset_on(
         body: asset.body,
     };
 
-    #[cfg(feature = "allow_in_memory_custody")]
-    {
-        use scp_core::context::actor::commands::{
-            BroadcastCommand, PublishBroadcastContentPayload,
-        };
-        let custody = handle.in_memory_custody.as_ref().ok_or_else(|| {
-            NapiError::from(ScpNapiError::Permission {
-                message: "broadcast publish asset requires key custody — create the identity with \
-                          identityCreate(\"in_memory\")"
-                    .to_owned(),
-                code: codes::PERM_3020.to_owned(),
-            })
-        })?;
-        let signing_key = handle.signing_key.ok_or_else(|| {
-            NapiError::from(ScpNapiError::Permission {
-                message: "broadcast publish asset requires a signing key — identity has no active \
-                          signing key handle"
-                    .to_owned(),
-                code: codes::PERM_3021.to_owned(),
-            })
-        })?;
-
-        // Route through the ADR-049 commit-11 broadcast shim with custody.
-        let sup = crate::runtime::supervisor(bi)?;
-        let (tx, rx) = tokio::sync::oneshot::channel();
-        let cmd = BroadcastCommand::PublishBroadcastContent {
-            payload: Box::new(PublishBroadcastContentPayload {
-                context_id,
-                author_did: author_did_val,
-                content,
-                signing_key_handle: signing_key,
-            }),
-            reply: tx,
-        };
-        sup.dispatch_broadcast_command_with_custody(cmd, custody.as_ref())
-            .await
-            .map_err(|e| {
-                napi::Error::from_reason(format!(
-                    "supervisor dispatch_broadcast_command_with_custody failed: {e}"
-                ))
-            })?;
-        let envelope = rx
-            .await
-            .map_err(|e| napi::Error::from_reason(format!("shim reply dropped: {e}")))?
-            .map_err(|e| NapiError::from(ScpNapiError::from(e)))?;
-
-        let envelope_bytes = rmp_serde::to_vec_named(&envelope).map_err(|e| {
-            NapiError::from(ScpNapiError::Context {
-                message: format!("failed to serialize envelope for blob_id: {e}"),
-                code: codes::CTX_2043.to_owned(),
-            })
-        })?;
-        let blob_id = {
-            use sha2::{Digest, Sha256};
-            hex::encode(Sha256::digest(&envelope_bytes))
-        };
-
-        Ok(NapiPublishResult {
-            blob_id,
-            etag,
-            deploy_id: deploy_id_str,
-        })
-    }
-
-    #[cfg(not(feature = "allow_in_memory_custody"))]
-    {
-        let _ = (context_id, author_did_val, content, deploy_id_str);
-        Err(NapiError::from(ScpNapiError::Permission {
-            message: "broadcast publish asset requires key custody — in_memory custody feature is \
-                      not enabled"
+    use scp_core::context::actor::commands::{BroadcastCommand, PublishBroadcastContentPayload};
+    let custody = handle.in_memory_custody.as_ref().ok_or_else(|| {
+        NapiError::from(ScpNapiError::Permission {
+            message: "broadcast publish asset requires key custody — this identity has no \
+                      retained custody (it was externally loaded)"
                 .to_owned(),
-            code: codes::PERM_3022.to_owned(),
-        }))
-    }
+            code: codes::PERM_3020.to_owned(),
+        })
+    })?;
+    let signing_key = handle.signing_key.ok_or_else(|| {
+        NapiError::from(ScpNapiError::Permission {
+            message: "broadcast publish asset requires a signing key — identity has no active \
+                      signing key handle"
+                .to_owned(),
+            code: codes::PERM_3021.to_owned(),
+        })
+    })?;
+
+    // Route through the ADR-049 commit-11 broadcast shim with custody.
+    let sup = crate::runtime::supervisor(bi)?;
+    let (tx, rx) = tokio::sync::oneshot::channel();
+    let cmd = BroadcastCommand::PublishBroadcastContent {
+        payload: Box::new(PublishBroadcastContentPayload {
+            context_id,
+            author_did: author_did_val,
+            content,
+            signing_key_handle: signing_key,
+        }),
+        reply: tx,
+    };
+    sup.dispatch_broadcast_command_with_custody(cmd, custody.as_ref())
+        .await
+        .map_err(|e| {
+            napi::Error::from_reason(format!(
+                "supervisor dispatch_broadcast_command_with_custody failed: {e}"
+            ))
+        })?;
+    let envelope = rx
+        .await
+        .map_err(|e| napi::Error::from_reason(format!("shim reply dropped: {e}")))?
+        .map_err(|e| NapiError::from(ScpNapiError::from(e)))?;
+
+    let envelope_bytes = rmp_serde::to_vec_named(&envelope).map_err(|e| {
+        NapiError::from(ScpNapiError::Context {
+            message: format!("failed to serialize envelope for blob_id: {e}"),
+            code: codes::CTX_2043.to_owned(),
+        })
+    })?;
+    let blob_id = {
+        use sha2::{Digest, Sha256};
+        hex::encode(Sha256::digest(&envelope_bytes))
+    };
+
+    Ok(NapiPublishResult {
+        blob_id,
+        etag,
+        deploy_id: deploy_id_str,
+    })
 }
 
 /// Per-bridge-instance implementation of [`broadcast_publish_assets`].
@@ -2209,110 +2153,94 @@ pub(crate) async fn broadcast_publish_assets_on(
         })
     })?;
 
-    #[cfg(feature = "allow_in_memory_custody")]
-    {
-        use scp_core::context::actor::commands::{
-            BroadcastCommand, PublishBroadcastContentPayload,
-        };
-        let custody = handle.in_memory_custody.as_ref().ok_or_else(|| {
-            NapiError::from(ScpNapiError::Permission {
-                message: "broadcast publish assets requires key custody".to_owned(),
-                code: codes::PERM_3020.to_owned(),
-            })
-        })?;
-        let signing_key = handle.signing_key.ok_or_else(|| {
-            NapiError::from(ScpNapiError::Permission {
-                message: "broadcast publish assets requires a signing key".to_owned(),
-                code: codes::PERM_3021.to_owned(),
-            })
-        })?;
-
-        // Route each asset through the ADR-049 commit-11 broadcast shim
-        // with custody.
-        let sup = crate::runtime::supervisor(bi)?;
-        let mut results = Vec::with_capacity(assets.len());
-        for asset in assets {
-            let content_path = scp_core::context::ContentPath::new(asset.path).map_err(|e| {
-                NapiError::from(ScpNapiError::Context {
-                    message: format!("invalid path: {e}"),
-                    code: codes::CTX_2040.to_owned(),
-                })
-            })?;
-            let mime_type = scp_core::context::MimeType::new(asset.content_type).map_err(|e| {
-                NapiError::from(ScpNapiError::Context {
-                    message: format!("invalid content_type: {e}"),
-                    code: codes::CTX_2041.to_owned(),
-                })
-            })?;
-
-            let etag = scp_core::context::compute_etag(&asset.body);
-            let content = scp_core::context::BroadcastContent {
-                version: scp_core::context::BROADCAST_CONTENT_VERSION,
-                metadata: scp_core::context::ContentMetadata {
-                    path: Some(content_path),
-                    content_type: Some(mime_type),
-                    deploy_id: Some(deploy_id_val.clone()),
-                    etag: Some(etag.clone()),
-                    immutable: false,
-                },
-                body: asset.body,
-            };
-
-            let (tx, rx) = tokio::sync::oneshot::channel();
-            let cmd = BroadcastCommand::PublishBroadcastContent {
-                payload: Box::new(PublishBroadcastContentPayload {
-                    context_id: context_id.clone(),
-                    author_did: author_did_val.clone(),
-                    content,
-                    signing_key_handle: signing_key,
-                }),
-                reply: tx,
-            };
-            sup.dispatch_broadcast_command_with_custody(cmd, custody.as_ref())
-                .await
-                .map_err(|e| {
-                    napi::Error::from_reason(format!(
-                        "supervisor dispatch_broadcast_command_with_custody failed: {e}"
-                    ))
-                })?;
-            let envelope = rx
-                .await
-                .map_err(|e| napi::Error::from_reason(format!("shim reply dropped: {e}")))?
-                .map_err(|e| NapiError::from(ScpNapiError::from(e)))?;
-
-            let envelope_bytes = rmp_serde::to_vec_named(&envelope).map_err(|e| {
-                NapiError::from(ScpNapiError::Context {
-                    message: format!("failed to serialize envelope for blob_id: {e}"),
-                    code: codes::CTX_2043.to_owned(),
-                })
-            })?;
-            let blob_id = {
-                use sha2::{Digest, Sha256};
-                hex::encode(Sha256::digest(&envelope_bytes))
-            };
-
-            results.push(NapiPublishResult {
-                blob_id,
-                etag,
-                deploy_id: deploy_id_val.clone(),
-            });
-        }
-        Ok(NapiBatchPublishResult {
-            results,
-            deploy_id: deploy_id_val,
+    use scp_core::context::actor::commands::{BroadcastCommand, PublishBroadcastContentPayload};
+    let custody = handle.in_memory_custody.as_ref().ok_or_else(|| {
+        NapiError::from(ScpNapiError::Permission {
+            message: "broadcast publish assets requires key custody".to_owned(),
+            code: codes::PERM_3020.to_owned(),
         })
-    }
+    })?;
+    let signing_key = handle.signing_key.ok_or_else(|| {
+        NapiError::from(ScpNapiError::Permission {
+            message: "broadcast publish assets requires a signing key".to_owned(),
+            code: codes::PERM_3021.to_owned(),
+        })
+    })?;
 
-    #[cfg(not(feature = "allow_in_memory_custody"))]
-    {
-        let _ = (context_id, author_did_val, deploy_id_val, assets);
-        Err(NapiError::from(ScpNapiError::Permission {
-            message: "broadcast publish assets requires key custody — in_memory custody feature \
-                      is not enabled"
-                .to_owned(),
-            code: codes::PERM_3022.to_owned(),
-        }))
+    // Route each asset through the ADR-049 commit-11 broadcast shim
+    // with custody.
+    let sup = crate::runtime::supervisor(bi)?;
+    let mut results = Vec::with_capacity(assets.len());
+    for asset in assets {
+        let content_path = scp_core::context::ContentPath::new(asset.path).map_err(|e| {
+            NapiError::from(ScpNapiError::Context {
+                message: format!("invalid path: {e}"),
+                code: codes::CTX_2040.to_owned(),
+            })
+        })?;
+        let mime_type = scp_core::context::MimeType::new(asset.content_type).map_err(|e| {
+            NapiError::from(ScpNapiError::Context {
+                message: format!("invalid content_type: {e}"),
+                code: codes::CTX_2041.to_owned(),
+            })
+        })?;
+
+        let etag = scp_core::context::compute_etag(&asset.body);
+        let content = scp_core::context::BroadcastContent {
+            version: scp_core::context::BROADCAST_CONTENT_VERSION,
+            metadata: scp_core::context::ContentMetadata {
+                path: Some(content_path),
+                content_type: Some(mime_type),
+                deploy_id: Some(deploy_id_val.clone()),
+                etag: Some(etag.clone()),
+                immutable: false,
+            },
+            body: asset.body,
+        };
+
+        let (tx, rx) = tokio::sync::oneshot::channel();
+        let cmd = BroadcastCommand::PublishBroadcastContent {
+            payload: Box::new(PublishBroadcastContentPayload {
+                context_id: context_id.clone(),
+                author_did: author_did_val.clone(),
+                content,
+                signing_key_handle: signing_key,
+            }),
+            reply: tx,
+        };
+        sup.dispatch_broadcast_command_with_custody(cmd, custody.as_ref())
+            .await
+            .map_err(|e| {
+                napi::Error::from_reason(format!(
+                    "supervisor dispatch_broadcast_command_with_custody failed: {e}"
+                ))
+            })?;
+        let envelope = rx
+            .await
+            .map_err(|e| napi::Error::from_reason(format!("shim reply dropped: {e}")))?
+            .map_err(|e| NapiError::from(ScpNapiError::from(e)))?;
+
+        let envelope_bytes = rmp_serde::to_vec_named(&envelope).map_err(|e| {
+            NapiError::from(ScpNapiError::Context {
+                message: format!("failed to serialize envelope for blob_id: {e}"),
+                code: codes::CTX_2043.to_owned(),
+            })
+        })?;
+        let blob_id = {
+            use sha2::{Digest, Sha256};
+            hex::encode(Sha256::digest(&envelope_bytes))
+        };
+
+        results.push(NapiPublishResult {
+            blob_id,
+            etag,
+            deploy_id: deploy_id_val.clone(),
+        });
     }
+    Ok(NapiBatchPublishResult {
+        results,
+        deploy_id: deploy_id_val,
+    })
 }
 
 /// Per-bridge-instance implementation of [`broadcast_block_subscriber`].
@@ -2553,7 +2481,6 @@ pub(crate) async fn context_execute_governance_action_on(
 ///
 /// The NAPI handle retains `in_memory_custody` and `signing_key` (`KeyHandle`)
 /// from the creating identity. This function exports the raw key bytes.
-#[cfg(feature = "allow_in_memory_custody")]
 async fn resolve_napi_signing_key(
     handle: &NapiContextHandle,
 ) -> napi::Result<ed25519_dalek::SigningKey> {
@@ -2603,7 +2530,6 @@ async fn resolve_napi_signing_key(
 ///
 /// Returns `ScpNapiError::Context` (SCP-CTX-2040) if the context handle carries
 /// no retained custody or no active signing-key handle.
-#[cfg(feature = "allow_in_memory_custody")]
 fn resolve_napi_export_signer(
     handle: &NapiContextHandle,
 ) -> napi::Result<(
@@ -2668,12 +2594,10 @@ async fn resolve_napi_creator_verifying_key(
     // Pre-resolve the local verifying key (async) so the shared helper's sync
     // `local_custody` closure can return it without blocking. Only the public
     // verifying key is derived — private key material never leaves custody
-    // (ADR-006). When the feature is disabled there is no local registry, so
-    // the local key is always `None` and resolution relies on the DID resolver.
-    #[cfg(feature = "allow_in_memory_custody")]
+    // (ADR-006). Returns `None` when the creator DID is not a locally retained
+    // identity on this bridge instance, in which case resolution relies on the
+    // DID resolver.
     let local_key = resolve_napi_local_verifying_key(bi, creator_did).await;
-    #[cfg(not(feature = "allow_in_memory_custody"))]
-    let local_key: Option<ed25519_dalek::VerifyingKey> = None;
 
     scp_ffi_common::export_verify::resolve_export_verifying_key(
         resolver,
@@ -2696,7 +2620,6 @@ async fn resolve_napi_creator_verifying_key(
 /// method §23.16.8 designates as the export signer — and resolves its public
 /// half via [`KeyCustody::public_key`]. Only the public verifying key crosses
 /// out of custody; the private signing key is never materialized (ADR-006).
-#[cfg(feature = "allow_in_memory_custody")]
 async fn resolve_napi_local_verifying_key(
     bi: &NapiBridgeInstance,
     did: &str,
@@ -2756,85 +2679,68 @@ pub(crate) async fn context_governance_propose_on(
 
     let action_name = action.variant_name();
 
-    #[cfg(feature = "allow_in_memory_custody")]
-    {
-        use scp_core::context::actor::commands::{
-            GovernanceCommand, ProposeGovernanceActionPayload, SigningKeyBytes,
-        };
+    use scp_core::context::actor::commands::{
+        GovernanceCommand, ProposeGovernanceActionPayload, SigningKeyBytes,
+    };
 
-        let signing_key = resolve_napi_signing_key(handle).await?;
+    let signing_key = resolve_napi_signing_key(handle).await?;
 
-        let did = DID(proposer_did);
-        let context_id = handle.context_id.clone();
+    let did = DID(proposer_did);
+    let context_id = handle.context_id.clone();
 
-        // Route through the ADR-049 commit-10 governance shim
-        // ([`Supervisor::dispatch_governance_command`](scp_core::context::supervisor::Supervisor::dispatch_governance_command))
-        // rather than calling `ContextManager::propose_governance_action_checked`
-        // directly.
-        let sup = crate::runtime::supervisor(bi)?;
-        let (tx, rx) = tokio::sync::oneshot::channel();
-        let cmd = GovernanceCommand::ProposeGovernanceActionChecked {
-            payload: Box::new(ProposeGovernanceActionPayload {
-                context_id: context_id.clone(),
-                proposer_did: did,
-                action,
-                signing_key: SigningKeyBytes::from_signing_key(&signing_key),
-            }),
-            reply: tx,
-        };
-        sup.dispatch_governance_command(cmd).await.map_err(|e| {
+    // Route through the ADR-049 commit-10 governance shim
+    // ([`Supervisor::dispatch_governance_command`](scp_core::context::supervisor::Supervisor::dispatch_governance_command))
+    // rather than calling `ContextManager::propose_governance_action_checked`
+    // directly.
+    let sup = crate::runtime::supervisor(bi)?;
+    let (tx, rx) = tokio::sync::oneshot::channel();
+    let cmd = GovernanceCommand::ProposeGovernanceActionChecked {
+        payload: Box::new(ProposeGovernanceActionPayload {
+            context_id: context_id.clone(),
+            proposer_did: did,
+            action,
+            signing_key: SigningKeyBytes::from_signing_key(&signing_key),
+        }),
+        reply: tx,
+    };
+    sup.dispatch_governance_command(cmd).await.map_err(|e| {
+        NapiError::from(ScpNapiError::Context {
+            message: format!("supervisor dispatch_governance_command failed: {e}"),
+            code: codes::CTX_2041.to_owned(),
+        })
+    })?;
+    let outcome = rx
+        .await
+        .map_err(|e| {
             NapiError::from(ScpNapiError::Context {
-                message: format!("supervisor dispatch_governance_command failed: {e}"),
+                message: format!("governance proposal shim reply dropped: {e}"),
+                code: codes::CTX_2041.to_owned(),
+            })
+        })?
+        .map_err(|e| {
+            NapiError::from(ScpNapiError::Context {
+                message: format!("governance proposal failed: {e}"),
                 code: codes::CTX_2041.to_owned(),
             })
         })?;
-        let outcome = rx
-            .await
-            .map_err(|e| {
-                NapiError::from(ScpNapiError::Context {
-                    message: format!("governance proposal shim reply dropped: {e}"),
-                    code: codes::CTX_2041.to_owned(),
-                })
-            })?
-            .map_err(|e| {
-                NapiError::from(ScpNapiError::Context {
-                    message: format!("governance proposal failed: {e}"),
-                    code: codes::CTX_2041.to_owned(),
-                })
-            })?;
 
-        if let Err(e) = crate::runtime::sync_role_state_from_manager(bi, &context_id).await {
-            tracing::warn!(
-                context_id = %context_id,
-                action = action_name,
-                error = %e,
-                "failed to sync role state after governance proposal"
-            );
-        }
-
-        let result_str = outcome.execution_result.as_ref().map(|r| format!("{r:?}"));
-
-        let response = serde_json::json!({
-            "proposal_id": hex::encode(outcome.proposal.proposal_id),
-            "status": format!("{:?}", outcome.status),
-            "execution_result": result_str,
-        });
-        return Ok(response.to_string());
+    if let Err(e) = crate::runtime::sync_role_state_from_manager(bi, &context_id).await {
+        tracing::warn!(
+            context_id = %context_id,
+            action = action_name,
+            error = %e,
+            "failed to sync role state after governance proposal"
+        );
     }
 
-    #[cfg(not(feature = "allow_in_memory_custody"))]
-    {
-        let _ = (handle, action, action_name, proposer_did);
-        return Err(NapiError::from(ScpNapiError::Permission {
-            message: "governance proposal requires key custody — in_memory custody feature \
-                      is not enabled"
-                .to_owned(),
-            code: codes::CTX_2040.to_owned(),
-        }));
-    }
+    let result_str = outcome.execution_result.as_ref().map(|r| format!("{r:?}"));
 
-    #[allow(unreachable_code)]
-    Ok(String::new())
+    let response = serde_json::json!({
+        "proposal_id": hex::encode(outcome.proposal.proposal_id),
+        "status": format!("{:?}", outcome.status),
+        "execution_result": result_str,
+    });
+    Ok(response.to_string())
 }
 
 /// Per-bridge-instance implementation of [`context_governance_approve`].
@@ -2847,74 +2753,57 @@ pub(crate) async fn context_governance_approve_on(
     crate::napi_check_handle!(&bi.core, handle);
     let proposal_id = parse_napi_proposal_id(&proposal_id_hex)?;
 
-    #[cfg(feature = "allow_in_memory_custody")]
-    {
-        use scp_core::context::actor::commands::{
-            GovernanceCommand, SigningKeyBytes, VoteOnProposalPayload,
-        };
+    use scp_core::context::actor::commands::{
+        GovernanceCommand, SigningKeyBytes, VoteOnProposalPayload,
+    };
 
-        let signing_key = resolve_napi_signing_key(handle).await?;
+    let signing_key = resolve_napi_signing_key(handle).await?;
 
-        let did = DID(voter_did);
-        let context_id = handle.context_id.clone();
+    let did = DID(voter_did);
+    let context_id = handle.context_id.clone();
 
-        // Route through the ADR-049 governance dispatch surface.
-        let sup = crate::runtime::supervisor(bi)?;
-        let (tx, rx) = tokio::sync::oneshot::channel();
-        let cmd = GovernanceCommand::ApproveGovernanceProposal {
-            payload: Box::new(VoteOnProposalPayload {
-                context_id: context_id.clone(),
-                proposal_id,
-                voter_did: did,
-                signing_key: SigningKeyBytes::from_signing_key(&signing_key),
-            }),
-            reply: tx,
-        };
-        sup.dispatch_governance_command(cmd).await.map_err(|e| {
+    // Route through the ADR-049 governance dispatch surface.
+    let sup = crate::runtime::supervisor(bi)?;
+    let (tx, rx) = tokio::sync::oneshot::channel();
+    let cmd = GovernanceCommand::ApproveGovernanceProposal {
+        payload: Box::new(VoteOnProposalPayload {
+            context_id: context_id.clone(),
+            proposal_id,
+            voter_did: did,
+            signing_key: SigningKeyBytes::from_signing_key(&signing_key),
+        }),
+        reply: tx,
+    };
+    sup.dispatch_governance_command(cmd).await.map_err(|e| {
+        NapiError::from(ScpNapiError::Context {
+            message: format!("supervisor dispatch_governance_command failed: {e}"),
+            code: codes::CTX_2042.to_owned(),
+        })
+    })?;
+    let status = rx
+        .await
+        .map_err(|e| {
             NapiError::from(ScpNapiError::Context {
-                message: format!("supervisor dispatch_governance_command failed: {e}"),
+                message: format!("governance approval shim reply dropped: {e}"),
+                code: codes::CTX_2042.to_owned(),
+            })
+        })?
+        .map_err(|e| {
+            NapiError::from(ScpNapiError::Context {
+                message: format!("governance approval failed: {e}"),
                 code: codes::CTX_2042.to_owned(),
             })
         })?;
-        let status = rx
-            .await
-            .map_err(|e| {
-                NapiError::from(ScpNapiError::Context {
-                    message: format!("governance approval shim reply dropped: {e}"),
-                    code: codes::CTX_2042.to_owned(),
-                })
-            })?
-            .map_err(|e| {
-                NapiError::from(ScpNapiError::Context {
-                    message: format!("governance approval failed: {e}"),
-                    code: codes::CTX_2042.to_owned(),
-                })
-            })?;
 
-        if let Err(e) = crate::runtime::sync_role_state_from_manager(bi, &context_id).await {
-            tracing::warn!(
-                context_id = %context_id,
-                error = %e,
-                "failed to sync role state after governance approval"
-            );
-        }
-
-        return Ok(serde_json::json!({ "status": format!("{status:?}") }).to_string());
+    if let Err(e) = crate::runtime::sync_role_state_from_manager(bi, &context_id).await {
+        tracing::warn!(
+            context_id = %context_id,
+            error = %e,
+            "failed to sync role state after governance approval"
+        );
     }
 
-    #[cfg(not(feature = "allow_in_memory_custody"))]
-    {
-        let _ = (handle, proposal_id, voter_did);
-        return Err(NapiError::from(ScpNapiError::Permission {
-            message: "governance approval requires key custody — in_memory custody feature \
-                      is not enabled"
-                .to_owned(),
-            code: codes::CTX_2040.to_owned(),
-        }));
-    }
-
-    #[allow(unreachable_code)]
-    Ok(String::new())
+    Ok(serde_json::json!({ "status": format!("{status:?}") }).to_string())
 }
 
 /// Per-bridge-instance implementation of [`context_governance_reject`].
@@ -2927,73 +2816,56 @@ pub(crate) async fn context_governance_reject_on(
     crate::napi_check_handle!(&bi.core, handle);
     let proposal_id = parse_napi_proposal_id(&proposal_id_hex)?;
 
-    #[cfg(feature = "allow_in_memory_custody")]
-    {
-        use scp_core::context::actor::commands::{
-            GovernanceCommand, SigningKeyBytes, VoteOnProposalPayload,
-        };
-        let signing_key = resolve_napi_signing_key(handle).await?;
+    use scp_core::context::actor::commands::{
+        GovernanceCommand, SigningKeyBytes, VoteOnProposalPayload,
+    };
+    let signing_key = resolve_napi_signing_key(handle).await?;
 
-        let did = DID(voter_did);
-        let sup = crate::runtime::supervisor(bi)?;
-        let context_id = handle.context_id.clone();
+    let did = DID(voter_did);
+    let sup = crate::runtime::supervisor(bi)?;
+    let context_id = handle.context_id.clone();
 
-        // Route through the ADR-049 governance dispatch surface.
-        let (tx, rx) = tokio::sync::oneshot::channel();
-        let cmd = GovernanceCommand::RejectGovernanceProposal {
-            payload: Box::new(VoteOnProposalPayload {
-                context_id: context_id.clone(),
-                proposal_id,
-                voter_did: did,
-                signing_key: SigningKeyBytes::from_signing_key(&signing_key),
-            }),
-            reply: tx,
-        };
-        sup.dispatch_governance_command(cmd).await.map_err(|e| {
+    // Route through the ADR-049 governance dispatch surface.
+    let (tx, rx) = tokio::sync::oneshot::channel();
+    let cmd = GovernanceCommand::RejectGovernanceProposal {
+        payload: Box::new(VoteOnProposalPayload {
+            context_id: context_id.clone(),
+            proposal_id,
+            voter_did: did,
+            signing_key: SigningKeyBytes::from_signing_key(&signing_key),
+        }),
+        reply: tx,
+    };
+    sup.dispatch_governance_command(cmd).await.map_err(|e| {
+        NapiError::from(ScpNapiError::Context {
+            message: format!("supervisor dispatch_governance_command failed: {e}"),
+            code: codes::CTX_2043.to_owned(),
+        })
+    })?;
+    let status = rx
+        .await
+        .map_err(|e| {
             NapiError::from(ScpNapiError::Context {
-                message: format!("supervisor dispatch_governance_command failed: {e}"),
+                message: format!("governance reject shim reply dropped: {e}"),
+                code: codes::CTX_2043.to_owned(),
+            })
+        })?
+        .map_err(|e| {
+            NapiError::from(ScpNapiError::Context {
+                message: format!("governance rejection failed: {e}"),
                 code: codes::CTX_2043.to_owned(),
             })
         })?;
-        let status = rx
-            .await
-            .map_err(|e| {
-                NapiError::from(ScpNapiError::Context {
-                    message: format!("governance reject shim reply dropped: {e}"),
-                    code: codes::CTX_2043.to_owned(),
-                })
-            })?
-            .map_err(|e| {
-                NapiError::from(ScpNapiError::Context {
-                    message: format!("governance rejection failed: {e}"),
-                    code: codes::CTX_2043.to_owned(),
-                })
-            })?;
 
-        if let Err(e) = crate::runtime::sync_role_state_from_manager(bi, &context_id).await {
-            tracing::warn!(
-                context_id = %context_id,
-                error = %e,
-                "failed to sync role state after governance rejection"
-            );
-        }
-
-        return Ok(serde_json::json!({ "status": format!("{status:?}") }).to_string());
+    if let Err(e) = crate::runtime::sync_role_state_from_manager(bi, &context_id).await {
+        tracing::warn!(
+            context_id = %context_id,
+            error = %e,
+            "failed to sync role state after governance rejection"
+        );
     }
 
-    #[cfg(not(feature = "allow_in_memory_custody"))]
-    {
-        let _ = (handle, proposal_id, voter_did);
-        return Err(NapiError::from(ScpNapiError::Permission {
-            message: "governance rejection requires key custody — in_memory custody feature \
-                      is not enabled"
-                .to_owned(),
-            code: codes::CTX_2040.to_owned(),
-        }));
-    }
-
-    #[allow(unreachable_code)]
-    Ok(String::new())
+    Ok(serde_json::json!({ "status": format!("{status:?}") }).to_string())
 }
 
 /// Per-bridge-instance implementation of [`context_governance_withdraw`].
@@ -3720,11 +3592,11 @@ pub(crate) async fn context_reset_ttl_timer_on(
 /// `Supervisor::export_context` captures the unsigned snapshot from the actor
 /// and signs it here via the supplied closure (§23.16.8, ADR-050).
 ///
-/// The retained custody and signing-key handle live on the context handle, which
-/// is only compiled under `allow_in_memory_custody` (matching every other
-/// key-bearing path in this bridge, including the `identityCreateWithCustody`
-/// callback path). Without the feature the export is rejected fail-closed rather
-/// than emitting an unsigned (and thus unverifiable) export.
+/// The retained custody and signing-key handle live on the context handle. If
+/// the handle has no retained custody (e.g. the context creator was an
+/// externally loaded, DID-string-only identity), the export is rejected
+/// fail-closed by `resolve_napi_export_signer` (`CTX_2040`) rather than emitting
+/// an unsigned (and thus unverifiable) export.
 pub(crate) async fn context_export_on(
     bi: &NapiBridgeInstance,
     handle: &NapiContextHandle,
@@ -3733,23 +3605,6 @@ pub(crate) async fn context_export_on(
     let exporter_did = scp_identity::DID::from(handle.creator_did.clone());
     let sup = crate::runtime::supervisor(bi)?;
 
-    #[cfg(not(feature = "allow_in_memory_custody"))]
-    {
-        let _ = (sup, exporter_did);
-        return Err(NapiError::from(ScpNapiError::Permission {
-            message: "context export requires key custody to sign the snapshot \
-                      (§23.16.8) — in_memory custody feature is not enabled"
-                .to_owned(),
-            // This is a build/config permission condition (the signing capability
-            // is unavailable in this bundle), NOT a snapshot-signature failure.
-            // CTX_2093 is reserved for §23.16.8 signature verification rejection;
-            // tagging this config gate with it would make a caller catching 2093
-            // to detect a forged export misfire on a feature-disabled build.
-            code: codes::PERM_3001.to_owned(),
-        }));
-    }
-
-    #[cfg(feature = "allow_in_memory_custody")]
     {
         // Resolve the exporter identity's custody provider and `#active` signing
         // key handle (NOT a raw exported key). Signing the §23.16.8 snapshot
@@ -4513,7 +4368,6 @@ mod tests {
             promotion_policy: None,
             governance: "single_admin".to_owned(),
             economic_policy: None,
-            #[cfg(feature = "allow_in_memory_custody")]
             in_memory_custody: None,
             signing_key: None,
             core_handle: None,
@@ -5325,6 +5179,192 @@ mod tests {
         assert!(
             result.is_err(),
             "import of a tampered custody-signed export must be rejected"
+        );
+    }
+
+    // -----------------------------------------------------------------------
+    // Production callback-custody export sign chain (NO `allow_in_memory_custody`)
+    //
+    // These tests compile and run in the BARE production build. They prove the
+    // un-gated §23.16.8 export sign/verify chain works for a non-in-memory,
+    // callback-shaped signer (the `identityCreateWithCustody` keychain/HSM
+    // case) and that the fail-closed boundary is the ABSENCE of retained
+    // custody (CTX_2040 from `resolve_napi_export_signer`), not a build flag.
+    // -----------------------------------------------------------------------
+
+    /// A minimal Rust signer that stands in for a production callback custody
+    /// (`identityCreateWithCustody`): it can `sign` the §23.16.8 canonical
+    /// digest and expose its public verifying key, but holds NO in-memory
+    /// `KeyCustody` backend and intentionally cannot export raw key bytes — the
+    /// keychain/HSM shape. It is a plain Rust struct, not a `NapiKeyCustody`, so
+    /// it needs no live JS `Env`/`ThreadsafeFunction` and exercises the exact
+    /// fallible sign-closure shape `context_export_on` hands to
+    /// `Supervisor::export_context`.
+    struct FakeExportCustody {
+        signing_key: ed25519_dalek::SigningKey,
+    }
+
+    impl FakeExportCustody {
+        fn new() -> Self {
+            // Deterministic seed for reproducibility; a real callback custody
+            // would back this with a keychain/HSM private key.
+            Self {
+                signing_key: ed25519_dalek::SigningKey::from_bytes(&[7u8; 32]),
+            }
+        }
+
+        /// Mirrors `KeyCustody::sign` over the §23.16.8 digest. A real callback
+        /// custody can fail (the JS callback may throw), so the `Result` is part
+        /// of the contract even though this in-test signer is infallible.
+        #[allow(clippy::unnecessary_wraps)]
+        fn sign(&self, digest: &[u8; 32]) -> Result<[u8; 64], std::convert::Infallible> {
+            use ed25519_dalek::Signer;
+            Ok(self.signing_key.sign(digest).to_bytes())
+        }
+
+        fn verifying_key(&self) -> ed25519_dalek::VerifyingKey {
+            self.signing_key.verifying_key()
+        }
+    }
+
+    /// Drives the production export sign/verify chain with a non-in-memory
+    /// `FakeExportCustody` — the same `Supervisor::export_context` sign-closure +
+    /// `serialize_export` / `deserialize_export` + `Supervisor::import_context`
+    /// path that `context_export_on` / `context_import_on` delegate to. Proves a
+    /// callback-shaped (non-exportable) signer produces a spec-valid §23.16.8
+    /// signature that round-trips, and that a tampered snapshot is rejected.
+    /// Runs WITHOUT `allow_in_memory_custody`.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn callback_custody_export_round_trips_and_rejects_tamper_without_feature() {
+        use scp_core::context::export_import::{deserialize_export, serialize_export};
+
+        let bi = std::sync::Arc::new(crate::runtime::NapiBridgeInstance::new_napi());
+        crate::runtime::init_supervisor_for_test_on(&bi);
+        let sup = crate::runtime::supervisor(&bi).expect("supervisor initialized above");
+        let sup = Arc::clone(sup);
+
+        let custody = FakeExportCustody::new();
+        let creator = DID("did:key:z6MkCallbackExporter".to_owned());
+        let ctx_id = format!("callback-export-{}", uuid::Uuid::new_v4());
+
+        // `context:close` is required so the creator can close the context
+        // before reimport (import needs a terminal state).
+        let params = ContextParams {
+            ceiling: vec![Capability::new("context:close")],
+            ..ContextParams::default()
+        };
+        let handle = test_dispatch_create_context(&bi, &ctx_id, params, creator.clone()).await;
+
+        // Export: sign the §23.16.8 digest via the callback-shaped custody — the
+        // exact closure shape `context_export_on` passes to `export_context`.
+        let export = sup
+            .export_context(&ctx_id, creator.clone(), |digest: &[u8; 32]| {
+                custody.sign(digest)
+            })
+            .await
+            .expect("export_context should succeed via callback-shaped sign closure");
+        let data = serialize_export(&export).expect("serialize_export should succeed");
+        assert!(!data.is_empty(), "serialized export must not be empty");
+
+        // `handle` (the source context) is dropped — not needed past export.
+        let _ = handle;
+
+        // Import into a FRESH bridge instance (the realistic "transfer to
+        // another node" path) so the import does not collide with the live
+        // source context slot. The snapshot signature is verified against the
+        // creator's verifying key (the callback custody's public key — what
+        // `resolve_napi_local_verifying_key` returns for a registered callback
+        // identity). Success proves the callback-produced signature is
+        // spec-valid (§23.16.8).
+        let bi2 = std::sync::Arc::new(crate::runtime::NapiBridgeInstance::new_napi());
+        crate::runtime::init_supervisor_for_test_on(&bi2);
+        let sup2 = crate::runtime::supervisor(&bi2).expect("supervisor initialized above");
+        let sup2 = Arc::clone(sup2);
+
+        let round_tripped = deserialize_export(&data).expect("deserialize_export should succeed");
+        let imported = sup2
+            .import_context(round_tripped, &custody.verifying_key())
+            .await
+            .expect("import_context should accept the callback-signed snapshot");
+        assert_eq!(
+            imported.context_id(),
+            ctx_id,
+            "imported context id must match the exported one"
+        );
+
+        // Tamper: flip a byte inside the signed snapshot region so the
+        // recomputed §23.16.8 digest no longer matches the signature. Import
+        // MUST reject — proving the callback signature is load-bearing.
+        let mut tampered = data.clone();
+        let mid = tampered.len() / 2;
+        tampered[mid] ^= 0xFF;
+        let result = match deserialize_export(&tampered) {
+            Ok(export) => sup2
+                .import_context(export, &custody.verifying_key())
+                .await
+                .map(|_| ()),
+            // A flipped framing byte may fail deserialization outright — also a
+            // valid rejection of the tampered payload.
+            Err(e) => Err(e),
+        };
+        assert!(
+            result.is_err(),
+            "import of a tampered callback-signed export must be rejected"
+        );
+    }
+
+    /// Proves the fail-closed boundary is the ABSENCE of retained custody, not a
+    /// build feature: `context_export_on` on a `NapiContextHandle` whose
+    /// `in_memory_custody` is `None` (e.g. an externally loaded, DID-string-only
+    /// creator) is rejected with `CTX_2040` by `resolve_napi_export_signer` —
+    /// never with the old build-gate PERM-3001, and never an unsigned export.
+    /// Runs WITHOUT `allow_in_memory_custody`.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn context_export_fails_closed_without_retained_custody() {
+        use super::*;
+        let bi = std::sync::Arc::new(crate::runtime::NapiBridgeInstance::new_napi());
+        crate::runtime::init_supervisor_for_test_on(&bi);
+
+        let creator = DID("did:key:z6MkNoCustodyExporter".to_owned());
+        let ctx_id = format!("no-custody-export-{}", uuid::Uuid::new_v4());
+        let params = ContextParams {
+            ceiling: vec![Capability::new("context:close")],
+            ..ContextParams::default()
+        };
+        let core_handle = test_dispatch_create_context(&bi, &ctx_id, params, creator.clone()).await;
+
+        // Build a handle with NO retained custody — the externally-loaded shape.
+        let handle = NapiContextHandle {
+            context_id: ctx_id.clone(),
+            state: std::sync::Mutex::new(ContextState::Active),
+            creator_did: creator.0.clone(),
+            mode: "Encrypted".to_owned(),
+            ceiling: vec![],
+            ceiling_policy: "immutable".to_owned(),
+            ttl_seconds: None,
+            promotion_policy: None,
+            governance: "single_admin".to_owned(),
+            economic_policy: None,
+            in_memory_custody: None,
+            signing_key: None,
+            core_handle: Some(core_handle),
+            subscription_cancel: std::sync::Mutex::new(CancellationToken::new()),
+            subscription_active: Arc::new(std::sync::atomic::AtomicBool::new(false)),
+            bi: std::sync::Arc::clone(&bi),
+            instance_id: bi.instance_id(),
+        };
+
+        let err = super::context_export_on(&bi, &handle)
+            .await
+            .expect_err("export with no retained custody must fail closed");
+        let msg = format!("{err}");
+        assert!(
+            msg.contains(codes::CTX_2040),
+            "expected CTX_2040 (absent-custody fail-closed), got: {msg}"
+        );
+        assert!(
+            !msg.contains(codes::PERM_3001),
+            "must NOT use the removed build-gate PERM-3001 code, got: {msg}"
         );
     }
 }

--- a/crates/scp-ffi/napi/src/context.rs
+++ b/crates/scp-ffi/napi/src/context.rs
@@ -3605,51 +3605,49 @@ pub(crate) async fn context_export_on(
     let exporter_did = scp_identity::DID::from(handle.creator_did.clone());
     let sup = crate::runtime::supervisor(bi)?;
 
-    {
-        // Resolve the exporter identity's custody provider and `#active` signing
-        // key handle (NOT a raw exported key). Signing the §23.16.8 snapshot
-        // digest is delegated to `KeyCustody::sign`, which dispatches to whichever
-        // backend backs this identity — in-memory OR a JS callback custody
-        // (`identityCreateWithCustody`). This lets keychain/HSM-shaped callback
-        // providers — which implement `sign` but intentionally do NOT implement
-        // `exportSigningKeyBytes` — produce a signed export. Private key material
-        // never crosses the FFI boundary (ADR-006).
-        let (custody, key_handle) = resolve_napi_export_signer(handle)?;
+    // Resolve the exporter identity's custody provider and `#active` signing
+    // key handle (NOT a raw exported key). Signing the §23.16.8 snapshot
+    // digest is delegated to `KeyCustody::sign`, which dispatches to whichever
+    // backend backs this identity — in-memory OR a JS callback custody
+    // (`identityCreateWithCustody`). This lets keychain/HSM-shaped callback
+    // providers — which implement `sign` but intentionally do NOT implement
+    // `exportSigningKeyBytes` — produce a signed export. Private key material
+    // never crosses the FFI boundary (ADR-006).
+    let (custody, key_handle) = resolve_napi_export_signer(handle)?;
 
-        // `export_context`'s `sign` closure is synchronous, but custody `sign` is
-        // async (a callback custody awaits a JS `ThreadsafeFunction`). Bridge the
-        // two with `block_in_place` + `block_on` on the current multi-thread
-        // runtime — the same pattern used by `identity_create_link_attestation`
-        // (see `scp.rs`). `context_export_on` already runs on a tokio worker, so a
-        // runtime handle is always present here.
-        let rt = tokio::runtime::Handle::try_current().map_err(|e| {
-            NapiError::from(ScpNapiError::Context {
-                message: format!("context export requires a tokio runtime: {e}"),
-                code: codes::CTX_2030.to_owned(),
-            })
-        })?;
-
-        let export = sup
-            .export_context(&handle.context_id, exporter_did, |hash: &[u8; 32]| {
-                let signature =
-                    tokio::task::block_in_place(|| rt.block_on(custody.sign(&key_handle, hash)))?;
-                let bytes: [u8; 64] = signature.as_bytes().try_into().map_err(|_| {
-                    scp_platform::PlatformError::CustodyError(format!(
-                        "custody sign returned {} bytes, expected 64 (Ed25519)",
-                        signature.as_bytes().len()
-                    ))
-                })?;
-                Ok::<[u8; 64], scp_platform::PlatformError>(bytes)
-            })
-            .await
-            .map_err(|e| NapiError::from(ScpNapiError::from(e)))?;
-        scp_core::context::export_import::serialize_export(&export).map_err(|e| {
-            NapiError::from(ScpNapiError::Context {
-                message: format!("export serialization failed: {e}"),
-                code: codes::CTX_2030.to_owned(),
-            })
+    // `export_context`'s `sign` closure is synchronous, but custody `sign` is
+    // async (a callback custody awaits a JS `ThreadsafeFunction`). Bridge the
+    // two with `block_in_place` + `block_on` on the current multi-thread
+    // runtime — the same pattern used by `identity_create_link_attestation`
+    // (see `scp.rs`). `context_export_on` already runs on a tokio worker, so a
+    // runtime handle is always present here.
+    let rt = tokio::runtime::Handle::try_current().map_err(|e| {
+        NapiError::from(ScpNapiError::Context {
+            message: format!("context export requires a tokio runtime: {e}"),
+            code: codes::CTX_2030.to_owned(),
         })
-    }
+    })?;
+
+    let export = sup
+        .export_context(&handle.context_id, exporter_did, |hash: &[u8; 32]| {
+            let signature =
+                tokio::task::block_in_place(|| rt.block_on(custody.sign(&key_handle, hash)))?;
+            let bytes: [u8; 64] = signature.as_bytes().try_into().map_err(|_| {
+                scp_platform::PlatformError::CustodyError(format!(
+                    "custody sign returned {} bytes, expected 64 (Ed25519)",
+                    signature.as_bytes().len()
+                ))
+            })?;
+            Ok::<[u8; 64], scp_platform::PlatformError>(bytes)
+        })
+        .await
+        .map_err(|e| NapiError::from(ScpNapiError::from(e)))?;
+    scp_core::context::export_import::serialize_export(&export).map_err(|e| {
+        NapiError::from(ScpNapiError::Context {
+            message: format!("export serialization failed: {e}"),
+            code: codes::CTX_2030.to_owned(),
+        })
+    })
 }
 
 /// Per-bridge-instance implementation of [`context_import`].

--- a/crates/scp-ffi/napi/src/custody.rs
+++ b/crates/scp-ffi/napi/src/custody.rs
@@ -422,6 +422,22 @@ impl fmt::Debug for NapiKeyCustody {
 }
 
 impl NapiKeyCustody {
+    /// Returns the custody-type label for handle reporting (`"in_memory"` for
+    /// the in-memory test backend, `"callback"` for caller-provided callback
+    /// custody).
+    ///
+    /// This is a cheap, sync variant discriminator — distinct from the async
+    /// [`KeyCustody::custody_type`] trait method, which reports the
+    /// per-key-handle [`CustodyType`] (hardware/software/in-memory) the
+    /// underlying provider declares.
+    pub(crate) const fn custody_type_label(&self) -> &'static str {
+        match self {
+            #[cfg(feature = "allow_in_memory_custody")]
+            Self::InMemory(_) => "in_memory",
+            Self::Callback(_) => "callback",
+        }
+    }
+
     /// Exports the raw Ed25519 signing key for the given handle, dispatching
     /// through the active variant. Mirrors the inherent helper on the `PyO3`
     /// `FfiKeyCustody` enum (required by SCPID signing, event-log

--- a/crates/scp-ffi/napi/src/event_log.rs
+++ b/crates/scp-ffi/napi/src/event_log.rs
@@ -422,26 +422,13 @@ pub(crate) fn event_log_checkpoint_on(
     epoch: f64,
 ) -> napi::Result<NapiCheckpoint> {
     crate::napi_check_handle!(&bi.core, handle, identity);
-    #[cfg(not(feature = "allow_in_memory_custody"))]
-    {
-        let _ = (bi, &handle, &identity, &epoch);
-        Err(napi::Error::from(ScpNapiError::Permission {
-            message: "event log checkpoint requires key custody -- the in_memory custody path \
-                       is not available in this build. Enable allow_in_memory_custody \
-                       for dev/desktop use."
-                .to_owned(),
-            code: codes::PERM_3023.to_owned(),
-        }))
-    }
-
-    #[cfg(feature = "allow_in_memory_custody")]
     {
         crate::runtime::ensure_registered(bi, handle).map_err(napi::Error::from)?;
 
         let custody = identity.inner.in_memory_custody.as_ref().ok_or_else(|| {
             napi::Error::from(ScpNapiError::Permission {
-                message: "event log checkpoint requires key custody — create the identity \
-                      with in_memory custody (identity_create(\"in_memory\"))"
+                message: "event log checkpoint requires key custody — this identity has no \
+                      retained custody (it was externally loaded)"
                     .to_owned(),
                 code: codes::PERM_3023.to_owned(),
             })
@@ -506,19 +493,6 @@ pub(crate) fn event_log_checkpoint_by_did_on(
     epoch: f64,
 ) -> napi::Result<NapiCheckpoint> {
     crate::napi_check_handle!(&bi.core, handle);
-    #[cfg(not(feature = "allow_in_memory_custody"))]
-    {
-        let _ = (bi, &handle, &did, &epoch);
-        Err(napi::Error::from(ScpNapiError::Permission {
-            message: "event log checkpoint requires key custody -- the in_memory custody path \
-                       is not available in this build. Enable allow_in_memory_custody \
-                       for dev/desktop use."
-                .to_owned(),
-            code: codes::PERM_3023.to_owned(),
-        }))
-    }
-
-    #[cfg(feature = "allow_in_memory_custody")]
     {
         crate::runtime::ensure_registered(bi, handle).map_err(napi::Error::from)?;
 
@@ -576,7 +550,6 @@ pub(crate) fn event_log_checkpoint_by_did_on(
 /// Validates that an f64 epoch value is non-negative and returns it as u64.
 ///
 /// Returns `napi::Error` with `SCP-VALID-7040` if the value is negative.
-#[cfg(feature = "allow_in_memory_custody")]
 fn validate_non_negative_epoch(epoch: f64) -> napi::Result<u64> {
     if epoch < 0.0 || !epoch.is_finite() {
         return Err(napi::Error::from(ScpNapiError::Validation {
@@ -695,40 +668,34 @@ mod tests {
     // -----------------------------------------------------------------------
 
     #[test]
-    #[cfg(feature = "allow_in_memory_custody")]
     fn validate_epoch_accepts_zero() {
         assert_eq!(validate_non_negative_epoch(0.0).unwrap(), 0);
     }
 
     #[test]
-    #[cfg(feature = "allow_in_memory_custody")]
     fn validate_epoch_accepts_positive() {
         assert_eq!(validate_non_negative_epoch(42.0).unwrap(), 42);
     }
 
     #[test]
-    #[cfg(feature = "allow_in_memory_custody")]
     fn validate_epoch_rejects_negative() {
         let result = validate_non_negative_epoch(-1.0);
         assert!(result.is_err(), "negative epoch should error");
     }
 
     #[test]
-    #[cfg(feature = "allow_in_memory_custody")]
     fn validate_epoch_rejects_negative_infinity() {
         let result = validate_non_negative_epoch(f64::NEG_INFINITY);
         assert!(result.is_err(), "NEG_INFINITY epoch should error");
     }
 
     #[test]
-    #[cfg(feature = "allow_in_memory_custody")]
     fn validate_epoch_rejects_f64_min() {
         let result = validate_non_negative_epoch(f64::MIN);
         assert!(result.is_err(), "f64::MIN epoch should error");
     }
 
     #[test]
-    #[cfg(feature = "allow_in_memory_custody")]
     fn validate_epoch_negative_error_contains_code() {
         let result = validate_non_negative_epoch(-42.0);
         let err = result.unwrap_err();
@@ -742,14 +709,12 @@ mod tests {
     }
 
     #[test]
-    #[cfg(feature = "allow_in_memory_custody")]
     fn validate_epoch_rejects_nan() {
         let result = validate_non_negative_epoch(f64::NAN);
         assert!(result.is_err(), "NaN epoch should error");
     }
 
     #[test]
-    #[cfg(feature = "allow_in_memory_custody")]
     fn validate_epoch_rejects_positive_infinity() {
         let result = validate_non_negative_epoch(f64::INFINITY);
         assert!(result.is_err(), "INFINITY epoch should error");

--- a/crates/scp-ffi/napi/src/identity.rs
+++ b/crates/scp-ffi/napi/src/identity.rs
@@ -320,8 +320,9 @@ pub(crate) struct NapiIdentityInner {
 
 /// An SCP identity handle exposed to JavaScript (Node.js/Bun).
 ///
-/// Wraps the DID string and retains key material for in-memory custody paths.
-/// Platform custody paths use an injected `KeyCustodyProvider`.
+/// Wraps the DID string and retains key material for the in-memory (dev/test)
+/// custody path. The production custody path is `identityCreateWithCustody`,
+/// which injects a caller-supplied `KeyCustodyProvider` (keychain/HSM-backed).
 ///
 /// # JS usage
 ///

--- a/crates/scp-ffi/napi/src/identity.rs
+++ b/crates/scp-ffi/napi/src/identity.rs
@@ -28,10 +28,16 @@
 //!
 //! # Key custody
 //!
+//! The production custody path is `identityCreateWithCustody(provider)`, which
+//! wires a caller-supplied `KeyCustodyProvider` (keychain/HSM-backed). Identities
+//! created this way report `custodyType == "callback"`, since key material
+//! stays behind the provider and never enters this bridge's heap.
+//!
 //! `"in_memory"` custody stores key material in heap memory via
-//! `InMemoryKeyCustody`. This is suitable for testing and CLI usage but NOT
-//! for production on devices with HSM capability. Production callers should
-//! use `"platform"` custody, which requires a wired `KeyCustodyProvider`.
+//! `InMemoryKeyCustody`. It is dev/test-only and gated behind the
+//! `allow_in_memory_custody` feature; identities created this way report
+//! `custodyType == "in_memory"`. Externally loaded identities (DID-string only,
+//! no retained key material) report `custodyType == "external"`.
 //!
 //! See ADR-022 in `.docs/adrs/phase-4.md` and ADR-039.
 
@@ -960,7 +966,7 @@ impl NapiIdentity {
                 NapiError::from(ScpNapiError::Identity {
                     message: format!(
                         "{operation} requires retained crypto state — this identity was \
-                         externally loaded and has no in-memory key material"
+                         externally loaded and has no retained key material"
                     ),
                     code: codes::IDENT_1007.to_owned(),
                 })

--- a/crates/scp-ffi/napi/src/identity.rs
+++ b/crates/scp-ffi/napi/src/identity.rs
@@ -42,7 +42,6 @@ use napi::Error as NapiError;
 use napi_derive::napi;
 #[cfg(all(test, feature = "allow_in_memory_custody"))]
 use scp_identity::DidMethod;
-#[cfg(feature = "allow_in_memory_custody")]
 use scp_identity::{DhtClient, IdentityError};
 use scp_identity::{
     DidCache, DidDht, DidDocument, DualLayerResolver, InMemoryDhtClient, NoOpRelayQuerier,
@@ -134,7 +133,6 @@ pub(crate) fn ensure_did_resolver_initialized_on(bi: &crate::runtime::NapiBridge
 /// errors are logged but do not fail identity creation.
 ///
 /// See issue #1144.
-#[cfg(feature = "allow_in_memory_custody")]
 pub(crate) async fn publish_to_shared_dht_for(
     identity: &ScpIdentity,
     document: &DidDocument,
@@ -214,7 +212,6 @@ impl fmt::Debug for OpaqueInMemoryKeyCustody {
 /// a properly configured instance with the signing function wired to the
 /// custody's key material — dispatching through the enum so it works for both
 /// in-memory and callback custody.
-#[cfg(feature = "allow_in_memory_custody")]
 #[allow(clippy::type_complexity)]
 fn make_dht_with_signer(
     custody: &Arc<crate::custody::NapiKeyCustody>,
@@ -270,7 +267,11 @@ pub(crate) struct NapiIdentityInner {
     /// so it backs either an in-memory test key or a callback custody. Dropping
     /// the last `Arc` destroys all in-memory private keys. `None` for
     /// externally loaded identities (DID-string-only handles).
-    #[cfg(feature = "allow_in_memory_custody")]
+    ///
+    /// Available in production (not feature-gated): in the production
+    /// callback-custody path this holds the `Arc<NapiKeyCustody::Callback>`
+    /// so handle-based signing reaches the caller's custody. The field name
+    /// is historical — it backs any retained custody, not just in-memory.
     pub(crate) in_memory_custody: Option<Arc<crate::custody::NapiKeyCustody>>,
     /// Retained DID document for this identity.
     ///
@@ -424,18 +425,6 @@ impl NapiIdentity {
     #[napi]
     #[allow(clippy::unused_async)] // napi requires async for Promise return type
     pub async fn rotate_key(&self) -> napi::Result<Self> {
-        #[cfg(not(feature = "allow_in_memory_custody"))]
-        {
-            let _ = self;
-            Err(ScpNapiError::Identity {
-                message: "key rotation requires in-memory custody -- \
-                          enable allow_in_memory_custody"
-                    .to_owned(),
-                code: codes::IDENT_1007.to_owned(),
-            }
-            .into())
-        }
-        #[cfg(feature = "allow_in_memory_custody")]
         {
             let (scp_identity, custody, document) = self.extract_in_memory_state("rotateKey")?;
 
@@ -525,12 +514,6 @@ impl NapiIdentity {
     #[napi(js_name = "addAgentKey")]
     #[allow(clippy::unused_async)] // napi requires async for Promise return type
     pub async fn add_agent_key(&self) -> napi::Result<Self> {
-        #[cfg(not(feature = "allow_in_memory_custody"))]
-        {
-            let _ = self;
-            Err(ScpNapiError::Identity { message: "agent key operations require in-memory custody -- enable allow_in_memory_custody".to_owned(), code: codes::IDENT_1007.to_owned() }.into())
-        }
-        #[cfg(feature = "allow_in_memory_custody")]
         {
             let (scp_identity, custody, document) = self.extract_in_memory_state("addAgentKey")?;
 
@@ -620,12 +603,6 @@ impl NapiIdentity {
     #[napi(js_name = "rotateAgentKey")]
     #[allow(clippy::unused_async)] // napi requires async for Promise return type
     pub async fn rotate_agent_key(&self) -> napi::Result<Self> {
-        #[cfg(not(feature = "allow_in_memory_custody"))]
-        {
-            let _ = self;
-            Err(ScpNapiError::Identity { message: "agent key operations require in-memory custody -- enable allow_in_memory_custody".to_owned(), code: codes::IDENT_1007.to_owned() }.into())
-        }
-        #[cfg(feature = "allow_in_memory_custody")]
         {
             let (scp_identity, custody, document) =
                 self.extract_in_memory_state("rotateAgentKey")?;
@@ -715,12 +692,6 @@ impl NapiIdentity {
     #[napi(js_name = "removeAgentKey")]
     #[allow(clippy::unused_async)] // napi requires async for Promise return type
     pub async fn remove_agent_key(&self) -> napi::Result<Self> {
-        #[cfg(not(feature = "allow_in_memory_custody"))]
-        {
-            let _ = self;
-            Err(ScpNapiError::Identity { message: "agent key operations require in-memory custody -- enable allow_in_memory_custody".to_owned(), code: codes::IDENT_1007.to_owned() }.into())
-        }
-        #[cfg(feature = "allow_in_memory_custody")]
         {
             let (scp_identity, custody, document) =
                 self.extract_in_memory_state("removeAgentKey")?;
@@ -820,18 +791,6 @@ impl NapiIdentity {
     #[napi]
     #[allow(clippy::unused_async)] // napi requires async for Promise return type
     pub async fn migrate(&self) -> napi::Result<Self> {
-        #[cfg(not(feature = "allow_in_memory_custody"))]
-        {
-            let _ = self;
-            Err(ScpNapiError::Identity {
-                message: "identity migration requires in-memory custody -- \
-                          enable allow_in_memory_custody"
-                    .to_owned(),
-                code: codes::IDENT_1007.to_owned(),
-            }
-            .into())
-        }
-        #[cfg(feature = "allow_in_memory_custody")]
         {
             let (scp_identity, custody, document) = self.extract_in_memory_state("migrate")?;
 
@@ -944,7 +903,6 @@ impl NapiIdentity {
 /// Callers pass `identity.identity_key` (not `active_signing_key`): the
 /// WASM bridge has only one key per identity, so byte-exact cross-bridge
 /// parity requires every bridge to expose the DID-deriving identity key.
-#[cfg(feature = "allow_in_memory_custody")]
 pub(crate) async fn identity_verifying_key_hex(
     custody: &Arc<crate::custody::NapiKeyCustody>,
     handle: &scp_platform::traits::KeyHandle,
@@ -967,7 +925,6 @@ impl NapiIdentity {
 
     /// Returns the retained custody if this identity has live key material.
     /// Used by context creation for routing ID derivation (SCP-214).
-    #[cfg(feature = "allow_in_memory_custody")]
     #[allow(dead_code)]
     pub(crate) fn in_memory_custody(&self) -> Option<&crate::custody::NapiKeyCustody> {
         self.inner.in_memory_custody.as_deref()
@@ -987,7 +944,6 @@ impl NapiIdentity {
     /// error for externally loaded identities that have none. The custody is
     /// enum-dispatched so the agent-key paths work for both in-memory and
     /// callback-backed identities.
-    #[cfg(feature = "allow_in_memory_custody")]
     fn extract_in_memory_state(
         &self,
         operation: &str,

--- a/crates/scp-ffi/napi/src/identity.rs
+++ b/crates/scp-ffi/napi/src/identity.rs
@@ -432,71 +432,69 @@ impl NapiIdentity {
     #[napi]
     #[allow(clippy::unused_async)] // napi requires async for Promise return type
     pub async fn rotate_key(&self) -> napi::Result<Self> {
-        {
-            let (scp_identity, custody, document) = self.extract_in_memory_state("rotateKey")?;
+        let (scp_identity, custody, document) = self.extract_in_memory_state("rotateKey")?;
 
-            let bi = &self.inner.bi;
+        let bi = &self.inner.bi;
 
-            // Read attestations + pre-rotation state BEFORE async operation
-            // (entry guaranteed to exist). `rotate_active_key` does not touch
-            // the pre-rotation key, so we reuse the existing handle/custody.
-            let (existing_attestations, pre_rotation_handle, pre_rotation_custody) =
-                crate::runtime::with_identity(bi, &self.inner.did, |e| {
-                    Ok((
-                        e.identity_link_attestations.clone(),
-                        e.pre_rotation_handle,
-                        Arc::clone(&e.pre_rotation_custody),
-                    ))
-                })
-                .map_err(|e| {
-                    // Fail-fast rather than fabricate a synthetic
-                    // `(handle = 0, fresh empty custody)` pair: a fresh
-                    // empty custody would silently overwrite the
-                    // registered pre-rotation state, leaving the
-                    // identity un-migratable. Surface the real error
-                    // so the caller can recover.
-                    NapiError::from(e)
-                })?;
+        // Read attestations + pre-rotation state BEFORE async operation
+        // (entry guaranteed to exist). `rotate_active_key` does not touch
+        // the pre-rotation key, so we reuse the existing handle/custody.
+        let (existing_attestations, pre_rotation_handle, pre_rotation_custody) =
+            crate::runtime::with_identity(bi, &self.inner.did, |e| {
+                Ok((
+                    e.identity_link_attestations.clone(),
+                    e.pre_rotation_handle,
+                    Arc::clone(&e.pre_rotation_custody),
+                ))
+            })
+            .map_err(|e| {
+                // Fail-fast rather than fabricate a synthetic
+                // `(handle = 0, fresh empty custody)` pair: a fresh
+                // empty custody would silently overwrite the
+                // registered pre-rotation state, leaving the
+                // identity un-migratable. Surface the real error
+                // so the caller can recover.
+                NapiError::from(e)
+            })?;
 
-            let dht = make_dht_with_signer(&custody);
-            let (new_identity, new_document) = dht
-                .rotate_active_key(&scp_identity, &document, &*custody)
-                .await
-                .map_err(|e| NapiError::from(ScpNapiError::from(e)))?;
+        let dht = make_dht_with_signer(&custody);
+        let (new_identity, new_document) = dht
+            .rotate_active_key(&scp_identity, &document, &*custody)
+            .await
+            .map_err(|e| NapiError::from(ScpNapiError::from(e)))?;
 
-            let verifying_key_hex =
-                identity_verifying_key_hex(&custody, &new_identity.identity_key).await;
+        let verifying_key_hex =
+            identity_verifying_key_hex(&custody, &new_identity.identity_key).await;
 
-            // Update the identity registry with the rotated key handles.
-            crate::runtime::register_identity(
-                bi,
-                &new_identity.did,
-                crate::runtime::NapiIdentityEntry {
-                    identity: new_identity.clone(),
-                    custody: Arc::clone(&custody),
-                    document: new_document.clone(),
-                    identity_link_attestations: existing_attestations,
-                    pre_rotation_handle,
-                    pre_rotation_custody,
-                },
-            );
+        // Update the identity registry with the rotated key handles.
+        crate::runtime::register_identity(
+            bi,
+            &new_identity.did,
+            crate::runtime::NapiIdentityEntry {
+                identity: new_identity.clone(),
+                custody: Arc::clone(&custody),
+                document: new_document.clone(),
+                identity_link_attestations: existing_attestations,
+                pre_rotation_handle,
+                pre_rotation_custody,
+            },
+        );
 
-            let handle = Self {
-                inner: Arc::new(NapiIdentityInner {
-                    did: new_identity.did.clone(),
-                    custody_type: self.inner.custody_type.clone(),
-                    scp_identity: Some(new_identity),
-                    in_memory_custody: self.inner.in_memory_custody.clone(),
-                    document: Some(new_document),
-                    bi: Arc::clone(&self.inner.bi),
-                    verifying_key_hex,
-                    instance_id: self.inner.bi.instance_id(),
-                    rotation_event_json: None,
-                }),
-            };
-            increment_handle_count();
-            Ok(handle)
-        }
+        let handle = Self {
+            inner: Arc::new(NapiIdentityInner {
+                did: new_identity.did.clone(),
+                custody_type: self.inner.custody_type.clone(),
+                scp_identity: Some(new_identity),
+                in_memory_custody: self.inner.in_memory_custody.clone(),
+                document: Some(new_document),
+                bi: Arc::clone(&self.inner.bi),
+                verifying_key_hex,
+                instance_id: self.inner.bi.instance_id(),
+                rotation_event_json: None,
+            }),
+        };
+        increment_handle_count();
+        Ok(handle)
     }
 
     /// Adds an agent signing key to this identity (ADR-039).
@@ -521,71 +519,69 @@ impl NapiIdentity {
     #[napi(js_name = "addAgentKey")]
     #[allow(clippy::unused_async)] // napi requires async for Promise return type
     pub async fn add_agent_key(&self) -> napi::Result<Self> {
-        {
-            let (scp_identity, custody, document) = self.extract_in_memory_state("addAgentKey")?;
+        let (scp_identity, custody, document) = self.extract_in_memory_state("addAgentKey")?;
 
-            let bi = &self.inner.bi;
+        let bi = &self.inner.bi;
 
-            // Read attestations + pre-rotation state BEFORE async operation.
-            // `add_agent_key` does not touch the pre-rotation key.
-            let (existing_attestations, pre_rotation_handle, pre_rotation_custody) =
-                crate::runtime::with_identity(bi, &self.inner.did, |e| {
-                    Ok((
-                        e.identity_link_attestations.clone(),
-                        e.pre_rotation_handle,
-                        Arc::clone(&e.pre_rotation_custody),
-                    ))
-                })
-                .map_err(|e| {
-                    // Fail-fast rather than fabricate a synthetic
-                    // `(handle = 0, fresh empty custody)` pair: a fresh
-                    // empty custody would silently overwrite the
-                    // registered pre-rotation state, leaving the
-                    // identity un-migratable. Surface the real error
-                    // so the caller can recover.
-                    NapiError::from(e)
-                })?;
+        // Read attestations + pre-rotation state BEFORE async operation.
+        // `add_agent_key` does not touch the pre-rotation key.
+        let (existing_attestations, pre_rotation_handle, pre_rotation_custody) =
+            crate::runtime::with_identity(bi, &self.inner.did, |e| {
+                Ok((
+                    e.identity_link_attestations.clone(),
+                    e.pre_rotation_handle,
+                    Arc::clone(&e.pre_rotation_custody),
+                ))
+            })
+            .map_err(|e| {
+                // Fail-fast rather than fabricate a synthetic
+                // `(handle = 0, fresh empty custody)` pair: a fresh
+                // empty custody would silently overwrite the
+                // registered pre-rotation state, leaving the
+                // identity un-migratable. Surface the real error
+                // so the caller can recover.
+                NapiError::from(e)
+            })?;
 
-            let dht = make_dht_with_signer(&custody);
-            let (new_identity, new_document) = dht
-                .add_agent_key(&scp_identity, &document, &*custody)
-                .await
-                .map_err(|e| NapiError::from(ScpNapiError::from(e)))?;
+        let dht = make_dht_with_signer(&custody);
+        let (new_identity, new_document) = dht
+            .add_agent_key(&scp_identity, &document, &*custody)
+            .await
+            .map_err(|e| NapiError::from(ScpNapiError::from(e)))?;
 
-            let verifying_key_hex =
-                identity_verifying_key_hex(&custody, &new_identity.identity_key).await;
+        let verifying_key_hex =
+            identity_verifying_key_hex(&custody, &new_identity.identity_key).await;
 
-            // Update the identity registry with the new key state so that
-            // bridge functions (ucan_delegate, etc.) see the updated identity.
-            crate::runtime::register_identity(
-                bi,
-                &new_identity.did,
-                crate::runtime::NapiIdentityEntry {
-                    identity: new_identity.clone(),
-                    custody: Arc::clone(&custody),
-                    document: new_document.clone(),
-                    identity_link_attestations: existing_attestations,
-                    pre_rotation_handle,
-                    pre_rotation_custody,
-                },
-            );
+        // Update the identity registry with the new key state so that
+        // bridge functions (ucan_delegate, etc.) see the updated identity.
+        crate::runtime::register_identity(
+            bi,
+            &new_identity.did,
+            crate::runtime::NapiIdentityEntry {
+                identity: new_identity.clone(),
+                custody: Arc::clone(&custody),
+                document: new_document.clone(),
+                identity_link_attestations: existing_attestations,
+                pre_rotation_handle,
+                pre_rotation_custody,
+            },
+        );
 
-            let handle = Self {
-                inner: Arc::new(NapiIdentityInner {
-                    did: new_identity.did.clone(),
-                    custody_type: self.inner.custody_type.clone(),
-                    scp_identity: Some(new_identity),
-                    in_memory_custody: self.inner.in_memory_custody.clone(),
-                    document: Some(new_document),
-                    bi: Arc::clone(&self.inner.bi),
-                    verifying_key_hex,
-                    instance_id: self.inner.bi.instance_id(),
-                    rotation_event_json: None,
-                }),
-            };
-            increment_handle_count();
-            Ok(handle)
-        }
+        let handle = Self {
+            inner: Arc::new(NapiIdentityInner {
+                did: new_identity.did.clone(),
+                custody_type: self.inner.custody_type.clone(),
+                scp_identity: Some(new_identity),
+                in_memory_custody: self.inner.in_memory_custody.clone(),
+                document: Some(new_document),
+                bi: Arc::clone(&self.inner.bi),
+                verifying_key_hex,
+                instance_id: self.inner.bi.instance_id(),
+                rotation_event_json: None,
+            }),
+        };
+        increment_handle_count();
+        Ok(handle)
     }
 
     /// Rotates the agent signing key for this identity (ADR-039).
@@ -610,71 +606,68 @@ impl NapiIdentity {
     #[napi(js_name = "rotateAgentKey")]
     #[allow(clippy::unused_async)] // napi requires async for Promise return type
     pub async fn rotate_agent_key(&self) -> napi::Result<Self> {
-        {
-            let (scp_identity, custody, document) =
-                self.extract_in_memory_state("rotateAgentKey")?;
+        let (scp_identity, custody, document) = self.extract_in_memory_state("rotateAgentKey")?;
 
-            let bi = &self.inner.bi;
+        let bi = &self.inner.bi;
 
-            // Read attestations + pre-rotation state BEFORE async operation.
-            // `rotate_agent_key` does not touch the pre-rotation key.
-            let (existing_attestations, pre_rotation_handle, pre_rotation_custody) =
-                crate::runtime::with_identity(bi, &self.inner.did, |e| {
-                    Ok((
-                        e.identity_link_attestations.clone(),
-                        e.pre_rotation_handle,
-                        Arc::clone(&e.pre_rotation_custody),
-                    ))
-                })
-                .map_err(|e| {
-                    // Fail-fast rather than fabricate a synthetic
-                    // `(handle = 0, fresh empty custody)` pair: a fresh
-                    // empty custody would silently overwrite the
-                    // registered pre-rotation state, leaving the
-                    // identity un-migratable. Surface the real error
-                    // so the caller can recover.
-                    NapiError::from(e)
-                })?;
+        // Read attestations + pre-rotation state BEFORE async operation.
+        // `rotate_agent_key` does not touch the pre-rotation key.
+        let (existing_attestations, pre_rotation_handle, pre_rotation_custody) =
+            crate::runtime::with_identity(bi, &self.inner.did, |e| {
+                Ok((
+                    e.identity_link_attestations.clone(),
+                    e.pre_rotation_handle,
+                    Arc::clone(&e.pre_rotation_custody),
+                ))
+            })
+            .map_err(|e| {
+                // Fail-fast rather than fabricate a synthetic
+                // `(handle = 0, fresh empty custody)` pair: a fresh
+                // empty custody would silently overwrite the
+                // registered pre-rotation state, leaving the
+                // identity un-migratable. Surface the real error
+                // so the caller can recover.
+                NapiError::from(e)
+            })?;
 
-            let dht = make_dht_with_signer(&custody);
-            let (new_identity, new_document) = dht
-                .rotate_agent_key(&scp_identity, &document, &*custody)
-                .await
-                .map_err(|e| NapiError::from(ScpNapiError::from(e)))?;
+        let dht = make_dht_with_signer(&custody);
+        let (new_identity, new_document) = dht
+            .rotate_agent_key(&scp_identity, &document, &*custody)
+            .await
+            .map_err(|e| NapiError::from(ScpNapiError::from(e)))?;
 
-            let verifying_key_hex =
-                identity_verifying_key_hex(&custody, &new_identity.identity_key).await;
+        let verifying_key_hex =
+            identity_verifying_key_hex(&custody, &new_identity.identity_key).await;
 
-            // Update the identity registry with the rotated key state.
-            crate::runtime::register_identity(
-                bi,
-                &new_identity.did,
-                crate::runtime::NapiIdentityEntry {
-                    identity: new_identity.clone(),
-                    custody: Arc::clone(&custody),
-                    document: new_document.clone(),
-                    identity_link_attestations: existing_attestations,
-                    pre_rotation_handle,
-                    pre_rotation_custody,
-                },
-            );
+        // Update the identity registry with the rotated key state.
+        crate::runtime::register_identity(
+            bi,
+            &new_identity.did,
+            crate::runtime::NapiIdentityEntry {
+                identity: new_identity.clone(),
+                custody: Arc::clone(&custody),
+                document: new_document.clone(),
+                identity_link_attestations: existing_attestations,
+                pre_rotation_handle,
+                pre_rotation_custody,
+            },
+        );
 
-            let handle = Self {
-                inner: Arc::new(NapiIdentityInner {
-                    did: new_identity.did.clone(),
-                    custody_type: self.inner.custody_type.clone(),
-                    scp_identity: Some(new_identity),
-                    in_memory_custody: self.inner.in_memory_custody.clone(),
-                    document: Some(new_document),
-                    bi: Arc::clone(&self.inner.bi),
-                    verifying_key_hex,
-                    instance_id: self.inner.bi.instance_id(),
-                    rotation_event_json: None,
-                }),
-            };
-            increment_handle_count();
-            Ok(handle)
-        }
+        let handle = Self {
+            inner: Arc::new(NapiIdentityInner {
+                did: new_identity.did.clone(),
+                custody_type: self.inner.custody_type.clone(),
+                scp_identity: Some(new_identity),
+                in_memory_custody: self.inner.in_memory_custody.clone(),
+                document: Some(new_document),
+                bi: Arc::clone(&self.inner.bi),
+                verifying_key_hex,
+                instance_id: self.inner.bi.instance_id(),
+                rotation_event_json: None,
+            }),
+        };
+        increment_handle_count();
+        Ok(handle)
     }
 
     /// Removes the agent signing key from this identity (ADR-039).
@@ -699,71 +692,68 @@ impl NapiIdentity {
     #[napi(js_name = "removeAgentKey")]
     #[allow(clippy::unused_async)] // napi requires async for Promise return type
     pub async fn remove_agent_key(&self) -> napi::Result<Self> {
-        {
-            let (scp_identity, custody, document) =
-                self.extract_in_memory_state("removeAgentKey")?;
+        let (scp_identity, custody, document) = self.extract_in_memory_state("removeAgentKey")?;
 
-            let bi = &self.inner.bi;
+        let bi = &self.inner.bi;
 
-            // Read attestations + pre-rotation state BEFORE async operation.
-            // `remove_agent_key` does not touch the pre-rotation key.
-            let (existing_attestations, pre_rotation_handle, pre_rotation_custody) =
-                crate::runtime::with_identity(bi, &self.inner.did, |e| {
-                    Ok((
-                        e.identity_link_attestations.clone(),
-                        e.pre_rotation_handle,
-                        Arc::clone(&e.pre_rotation_custody),
-                    ))
-                })
-                .map_err(|e| {
-                    // Fail-fast rather than fabricate a synthetic
-                    // `(handle = 0, fresh empty custody)` pair: a fresh
-                    // empty custody would silently overwrite the
-                    // registered pre-rotation state, leaving the
-                    // identity un-migratable. Surface the real error
-                    // so the caller can recover.
-                    NapiError::from(e)
-                })?;
+        // Read attestations + pre-rotation state BEFORE async operation.
+        // `remove_agent_key` does not touch the pre-rotation key.
+        let (existing_attestations, pre_rotation_handle, pre_rotation_custody) =
+            crate::runtime::with_identity(bi, &self.inner.did, |e| {
+                Ok((
+                    e.identity_link_attestations.clone(),
+                    e.pre_rotation_handle,
+                    Arc::clone(&e.pre_rotation_custody),
+                ))
+            })
+            .map_err(|e| {
+                // Fail-fast rather than fabricate a synthetic
+                // `(handle = 0, fresh empty custody)` pair: a fresh
+                // empty custody would silently overwrite the
+                // registered pre-rotation state, leaving the
+                // identity un-migratable. Surface the real error
+                // so the caller can recover.
+                NapiError::from(e)
+            })?;
 
-            let dht = make_dht_with_signer(&custody);
-            let (new_identity, new_document) = dht
-                .remove_agent_key(&scp_identity, &document)
-                .await
-                .map_err(|e| NapiError::from(ScpNapiError::from(e)))?;
+        let dht = make_dht_with_signer(&custody);
+        let (new_identity, new_document) = dht
+            .remove_agent_key(&scp_identity, &document)
+            .await
+            .map_err(|e| NapiError::from(ScpNapiError::from(e)))?;
 
-            let verifying_key_hex =
-                identity_verifying_key_hex(&custody, &new_identity.identity_key).await;
+        let verifying_key_hex =
+            identity_verifying_key_hex(&custody, &new_identity.identity_key).await;
 
-            // Update the identity registry with the post-removal key state.
-            crate::runtime::register_identity(
-                bi,
-                &new_identity.did,
-                crate::runtime::NapiIdentityEntry {
-                    identity: new_identity.clone(),
-                    custody: Arc::clone(&custody),
-                    document: new_document.clone(),
-                    identity_link_attestations: existing_attestations,
-                    pre_rotation_handle,
-                    pre_rotation_custody,
-                },
-            );
+        // Update the identity registry with the post-removal key state.
+        crate::runtime::register_identity(
+            bi,
+            &new_identity.did,
+            crate::runtime::NapiIdentityEntry {
+                identity: new_identity.clone(),
+                custody: Arc::clone(&custody),
+                document: new_document.clone(),
+                identity_link_attestations: existing_attestations,
+                pre_rotation_handle,
+                pre_rotation_custody,
+            },
+        );
 
-            let handle = Self {
-                inner: Arc::new(NapiIdentityInner {
-                    did: new_identity.did.clone(),
-                    custody_type: self.inner.custody_type.clone(),
-                    scp_identity: Some(new_identity),
-                    in_memory_custody: self.inner.in_memory_custody.clone(),
-                    document: Some(new_document),
-                    bi: Arc::clone(&self.inner.bi),
-                    verifying_key_hex,
-                    instance_id: self.inner.bi.instance_id(),
-                    rotation_event_json: None,
-                }),
-            };
-            increment_handle_count();
-            Ok(handle)
-        }
+        let handle = Self {
+            inner: Arc::new(NapiIdentityInner {
+                did: new_identity.did.clone(),
+                custody_type: self.inner.custody_type.clone(),
+                scp_identity: Some(new_identity),
+                in_memory_custody: self.inner.in_memory_custody.clone(),
+                document: Some(new_document),
+                bi: Arc::clone(&self.inner.bi),
+                verifying_key_hex,
+                instance_id: self.inner.bi.instance_id(),
+                rotation_event_json: None,
+            }),
+        };
+        increment_handle_count();
+        Ok(handle)
     }
 
     /// Migrates this identity to a new DID (Layer 2 DID rotation, spec §9.12).
@@ -798,96 +788,94 @@ impl NapiIdentity {
     #[napi]
     #[allow(clippy::unused_async)] // napi requires async for Promise return type
     pub async fn migrate(&self) -> napi::Result<Self> {
-        {
-            let (scp_identity, custody, document) = self.extract_in_memory_state("migrate")?;
+        let (scp_identity, custody, document) = self.extract_in_memory_state("migrate")?;
 
-            let bi = &self.inner.bi;
+        let bi = &self.inner.bi;
 
-            // Read attestations + pre-rotation state BEFORE async operation
-            // (entry guaranteed to exist now).
-            let (existing_attestations, pre_rotation_handle, pre_rotation_custody) =
-                crate::runtime::with_identity(bi, &self.inner.did, |e| {
-                    Ok((
-                        e.identity_link_attestations.clone(),
-                        e.pre_rotation_handle,
-                        Arc::clone(&e.pre_rotation_custody),
-                    ))
-                })
-                .map_err(NapiError::from)?;
+        // Read attestations + pre-rotation state BEFORE async operation
+        // (entry guaranteed to exist now).
+        let (existing_attestations, pre_rotation_handle, pre_rotation_custody) =
+            crate::runtime::with_identity(bi, &self.inner.did, |e| {
+                Ok((
+                    e.identity_link_attestations.clone(),
+                    e.pre_rotation_handle,
+                    Arc::clone(&e.pre_rotation_custody),
+                ))
+            })
+            .map_err(NapiError::from)?;
 
-            // Spec §3.7 / §9.12 (Compromise Recovery Protocol): the
-            // pre-rotation key whose hash equals the published
-            // `pre_rotation_commitment` is the only key that satisfies the
-            // `SHA-256(revealed_key) == commitment` invariant verified by
-            // `verify_migration`. The committed pre-rotation key is held in
-            // cold-storage `pre_rotation_custody`, referenced by
-            // `pre_rotation_handle`.
-            let rotated_at = scp_primitives::SystemClock.now_secs();
+        // Spec §3.7 / §9.12 (Compromise Recovery Protocol): the
+        // pre-rotation key whose hash equals the published
+        // `pre_rotation_commitment` is the only key that satisfies the
+        // `SHA-256(revealed_key) == commitment` invariant verified by
+        // `verify_migration`. The committed pre-rotation key is held in
+        // cold-storage `pre_rotation_custody`, referenced by
+        // `pre_rotation_handle`.
+        let rotated_at = scp_primitives::SystemClock.now_secs();
 
-            let dht = make_dht_with_signer(&custody);
-            let scp_identity::MigrationOutcome {
-                new_identity,
-                new_document,
-                rotation_event,
-                new_pre_rotation_handle,
-            } = dht
-                .migrate_identity(
-                    &scp_identity,
-                    &document,
-                    &pre_rotation_handle,
-                    pre_rotation_custody.as_ref(),
-                    &*custody,
-                    rotated_at,
-                )
-                .await
-                .map_err(|e| NapiError::from(ScpNapiError::from(e)))?;
+        let dht = make_dht_with_signer(&custody);
+        let scp_identity::MigrationOutcome {
+            new_identity,
+            new_document,
+            rotation_event,
+            new_pre_rotation_handle,
+        } = dht
+            .migrate_identity(
+                &scp_identity,
+                &document,
+                &pre_rotation_handle,
+                pre_rotation_custody.as_ref(),
+                &*custody,
+                rotated_at,
+            )
+            .await
+            .map_err(|e| NapiError::from(ScpNapiError::from(e)))?;
 
-            let rotation_event_json = serde_json::to_string(&rotation_event).map_err(|e| {
-                NapiError::from(ScpNapiError::Identity {
-                    message: format!("failed to serialize rotation event: {e}"),
-                    code: codes::IDENT_1004.to_owned(),
-                })
-            })?;
+        let rotation_event_json = serde_json::to_string(&rotation_event).map_err(|e| {
+            NapiError::from(ScpNapiError::Identity {
+                message: format!("failed to serialize rotation event: {e}"),
+                code: codes::IDENT_1004.to_owned(),
+            })
+        })?;
 
-            let new_did = new_identity.did.clone();
+        let new_did = new_identity.did.clone();
 
-            let verifying_key_hex =
-                identity_verifying_key_hex(&custody, &new_identity.identity_key).await;
+        let verifying_key_hex =
+            identity_verifying_key_hex(&custody, &new_identity.identity_key).await;
 
-            // Remove the old identity and register the new one. The same
-            // pre-rotation custody Arc is reused (we don't mint a new
-            // custody per migration); only the handle changes to point at
-            // the freshly committed key.
-            crate::runtime::remove_identity(bi, &self.inner.did);
-            crate::runtime::register_identity(
-                bi,
-                &new_did,
-                crate::runtime::NapiIdentityEntry {
-                    identity: new_identity.clone(),
-                    custody: Arc::clone(&custody),
-                    document: new_document.clone(),
-                    identity_link_attestations: existing_attestations,
-                    pre_rotation_handle: new_pre_rotation_handle,
-                    pre_rotation_custody,
-                },
-            );
+        // Remove the old identity and register the new one. The same
+        // pre-rotation custody Arc is reused (we don't mint a new
+        // custody per migration); only the handle changes to point at
+        // the freshly committed key.
+        crate::runtime::remove_identity(bi, &self.inner.did);
+        crate::runtime::register_identity(
+            bi,
+            &new_did,
+            crate::runtime::NapiIdentityEntry {
+                identity: new_identity.clone(),
+                custody: Arc::clone(&custody),
+                document: new_document.clone(),
+                identity_link_attestations: existing_attestations,
+                pre_rotation_handle: new_pre_rotation_handle,
+                pre_rotation_custody,
+            },
+        );
 
-            let handle = Self {
-                inner: Arc::new(NapiIdentityInner {
-                    did: new_did,
-                    custody_type: self.inner.custody_type.clone(),
-                    scp_identity: Some(new_identity),
-                    in_memory_custody: self.inner.in_memory_custody.clone(),
-                    document: Some(new_document),
-                    bi: Arc::clone(&self.inner.bi),
-                    verifying_key_hex,
-                    instance_id: self.inner.bi.instance_id(),
-                    rotation_event_json: Some(rotation_event_json),
-                }),
-            };
-            increment_handle_count();
-            Ok(handle)
-        }
+        let handle = Self {
+            inner: Arc::new(NapiIdentityInner {
+                did: new_did,
+                custody_type: self.inner.custody_type.clone(),
+                scp_identity: Some(new_identity),
+                in_memory_custody: self.inner.in_memory_custody.clone(),
+                document: Some(new_document),
+                bi: Arc::clone(&self.inner.bi),
+                verifying_key_hex,
+                instance_id: self.inner.bi.instance_id(),
+                rotation_event_json: Some(rotation_event_json),
+            }),
+        };
+        increment_handle_count();
+        Ok(handle)
     }
 
     /// Returns the JSON-serialized `DidRotationEvent` if this handle was

--- a/crates/scp-ffi/napi/src/identity.rs
+++ b/crates/scp-ffi/napi/src/identity.rs
@@ -252,7 +252,7 @@ fn make_dht_with_signer(
 pub(crate) struct NapiIdentityInner {
     /// The DID string (e.g., `"did:dht:z6Mk..."`).
     pub(crate) did: String,
-    /// The custody type string: `"in_memory"`, `"platform"`, or `"software"`.
+    /// The custody type string: `"in_memory"`, `"callback"`, or `"external"`.
     pub(crate) custody_type: String,
     /// Retained `ScpIdentity` for in-memory custody paths.
     ///
@@ -341,7 +341,7 @@ impl NapiIdentity {
 
     /// Returns the custody type string for this identity.
     ///
-    /// One of: `"in_memory"`, `"platform"`, `"software"`.
+    /// One of: `"in_memory"`, `"callback"`, `"external"`.
     #[napi(getter, js_name = "custodyType")]
     #[must_use]
     pub fn custody_type(&self) -> String {

--- a/crates/scp-ffi/napi/src/identity.rs
+++ b/crates/scp-ffi/napi/src/identity.rs
@@ -974,8 +974,8 @@ impl NapiIdentity {
             .ok_or_else(|| {
                 NapiError::from(ScpNapiError::Identity {
                     message: format!(
-                        "{operation} requires in-memory custody — this identity uses \
-                         external custody"
+                        "{operation} requires retained key custody — this identity was \
+                         loaded without retained custody"
                     ),
                     code: codes::IDENT_1007.to_owned(),
                 })

--- a/crates/scp-ffi/napi/src/runtime.rs
+++ b/crates/scp-ffi/napi/src/runtime.rs
@@ -1216,6 +1216,41 @@ pub(crate) fn init_supervisor_for_test_on(bi: &NapiBridgeInstance) {
     bi.core.set_supervisor(supervisor_arc);
 }
 
+/// Like [`init_supervisor_for_test_on`] but wires the MLS provider with a
+/// production-valid `did:dht:z*` `local_did` instead of the `did:test:` value.
+///
+/// `MlsCryptoProvider::validate_creator_identity` only accepts `did:test:` /
+/// `did:key:` under `scp-runtime`'s `testing` feature; a `did:dht:z*` identity
+/// is accepted in plain production builds. Tests that exercise behavior which
+/// MUST hold WITHOUT the in-memory-custody / `testing` features (e.g. the
+/// custody-signed context-export path) use this so they genuinely run in the
+/// no-`testing` configuration rather than silently relying on the test gate.
+#[cfg(test)]
+pub(crate) fn init_production_supervisor_for_test_on(bi: &NapiBridgeInstance) {
+    if bi.core.has_supervisor() {
+        return;
+    }
+    let event_log = event_log_provider_from_existing_repo(bi);
+    let Some(mls_storage) = bi.mls_storage_ref().map(Arc::clone) else {
+        tracing::error!(
+            "init_production_supervisor_for_test_on: storage-before-supervisor precondition \
+             failed — no mls_storage backend on the bridge instance"
+        );
+        return;
+    };
+    let supervisor_arc = build_supervisor_arc(
+        Arc::new(scp_core::crypto::mls::provider::MlsCryptoProvider::new(
+            "did:dht:z6MkNapiBridgeProductionTest".to_owned(),
+        )),
+        Box::new(scp_core::context::LocalTransportProvider),
+        event_log,
+        Box::new(NapiBridgePersistence::new()),
+        mls_storage,
+    );
+
+    bi.core.set_supervisor(supervisor_arc);
+}
+
 // ---------------------------------------------------------------------------
 // BridgeInMemoryStorage — previously defined locally with identical code.
 // Consolidated in `scp-ffi-common::bridge_runtime` (#1447). Imported via

--- a/crates/scp-ffi/napi/src/runtime.rs
+++ b/crates/scp-ffi/napi/src/runtime.rs
@@ -1257,10 +1257,13 @@ fn init_supervisor_for_test_on_with_did(bi: &NapiBridgeInstance, local_did: &str
 
 /// Retained identity state for a single DID in the NAPI bridge.
 ///
-/// Stores the `ScpIdentity` (key handles), `InMemoryKeyCustody` (key
-/// material), and `DidDocument` so that bridge functions can look up any
-/// registered identity by DID — including `identity_load` and
-/// `identity_resolve` which need the document without DHT access (#1144 C6).
+/// Stores the `ScpIdentity` (key handles), retained custody — the
+/// [`NapiKeyCustody`](crate::custody::NapiKeyCustody) enum, either the
+/// `InMemory` test variant (key material) or the `Callback` production variant
+/// (delegating to a caller-supplied `KeyCustodyProvider`) — and `DidDocument`
+/// so that bridge functions can look up any registered identity by DID —
+/// including `identity_load` and `identity_resolve` which need the document
+/// without DHT access (#1144 C6).
 pub(crate) struct NapiIdentityEntry {
     /// The scp-core identity handle (DID string, key handles).
     pub(crate) identity: scp_identity::ScpIdentity,
@@ -1299,9 +1302,13 @@ pub(crate) fn identity_registry(bi: &NapiBridgeInstance) -> &DashMap<String, Nap
 
 /// Registers an identity in the bridge instance's identity registry.
 ///
-/// Called by `identity_create` and `identity_create_with_agent_key` after
-/// successfully creating an identity. Bridge functions (`ucan_delegate`)
-/// look up the retained `InMemoryKeyCustody` and `KeyHandle`s via
+/// Called by `identity_create`, `identity_create_with_agent_key`, and
+/// `identity_create_with_custody` after successfully creating an identity, and
+/// by the key-rotation and migration paths (`rotate_key`, `rotate_agent_key`,
+/// `migrate`) which re-register under the same or new DID. Bridge functions
+/// (`ucan_delegate`) look up the retained custody — the
+/// [`NapiKeyCustody`](crate::custody::NapiKeyCustody) enum (in-memory test
+/// variant or callback production variant) — and `KeyHandle`s via
 /// [`with_identity`].
 ///
 /// Overwrites any existing entry for the same DID (idempotent — supports

--- a/crates/scp-ffi/napi/src/runtime.rs
+++ b/crates/scp-ffi/napi/src/runtime.rs
@@ -192,14 +192,16 @@ pub struct NapiBridgeInstance {
     /// [`BridgeInstanceCore::bridge_specific_shutdown`].
     pub(crate) ucan_registry: Arc<DashMap<String, UcanContextState>>,
 
-    /// Retained identity state for in-memory custody DIDs.
+    /// Retained identity state for registered DIDs.
     ///
     /// Previously stored type-erased in `CoreFields::identity_registry`.
-    /// Feature-gated because only the `allow_in_memory_custody` build flag
-    /// pulls in [`OpaqueInMemoryKeyCustody`]. Cleared on shutdown — drops
-    /// the `Arc<OpaqueInMemoryKeyCustody>` values which zeroize their
-    /// underlying key material via `Drop`.
-    #[cfg(feature = "allow_in_memory_custody")]
+    /// Available in production (not feature-gated) so the callback-custody
+    /// path (`identity_create_with_custody`) can retain identity state,
+    /// mirroring the `PyO3` bridge. Entries hold an enum-dispatched
+    /// [`NapiKeyCustody`](crate::custody::NapiKeyCustody) — the `Callback`
+    /// variant in production, the `InMemory` variant only under
+    /// `allow_in_memory_custody`. Cleared on shutdown — dropping the entries
+    /// zeroizes any retained key material via the custody provider's `Drop`.
     pub(crate) identity_registry: Arc<DashMap<String, NapiIdentityEntry>>,
 
     /// Protocol repository used for trust aggregation + event log persistence.
@@ -340,7 +342,6 @@ impl NapiBridgeInstance {
         Self {
             core: CoreFields::new(),
             ucan_registry: Arc::new(DashMap::new()),
-            #[cfg(feature = "allow_in_memory_custody")]
             identity_registry: Arc::new(DashMap::new()),
             protocol_repository: ProtocolRepoVariant::InMemory(protocol_repository),
             mls_storage_backend: Some(mls_storage_backend),
@@ -369,7 +370,6 @@ impl NapiBridgeInstance {
         Self {
             core: CoreFields::with_persistence(persistence),
             ucan_registry: Arc::new(DashMap::new()),
-            #[cfg(feature = "allow_in_memory_custody")]
             identity_registry: Arc::new(DashMap::new()),
             protocol_repository: ProtocolRepoVariant::InMemory(protocol_repository),
             mls_storage_backend: Some(mls_storage_backend),
@@ -492,7 +492,6 @@ impl NapiBridgeInstance {
         Self {
             core: CoreFields::with_persistence_arc(persistence),
             ucan_registry: Arc::new(DashMap::new()),
-            #[cfg(feature = "allow_in_memory_custody")]
             identity_registry: Arc::new(DashMap::new()),
             protocol_repository,
             mls_storage_backend: Some(mls_storage_backend),
@@ -608,12 +607,12 @@ impl BridgeInstanceCore for NapiBridgeInstance {
     // gate `scripts/check-bridge-instance-lifecycle.py`.
 
     fn bridge_specific_shutdown(&self) {
-        // Clear typed registries. Dropping `Arc<OpaqueInMemoryKeyCustody>`
-        // values zeroizes any key material they hold via the custody
-        // provider's `Drop` impl (matching the behavior of the previous
-        // `clear_fn` closures).
+        // Clear typed registries. Dropping the `Arc<NapiKeyCustody>` values
+        // (callback custody in production, in-memory custody under
+        // `allow_in_memory_custody`) zeroizes any key material they hold via
+        // the custody provider's `Drop` impl (matching the behavior of the
+        // previous `clear_fn` closures).
         self.ucan_registry.clear();
-        #[cfg(feature = "allow_in_memory_custody")]
         self.identity_registry.clear();
         // Release the SQLite advisory lock on `{dir}/scp.db.lock` for the
         // `Sqlite` variant. Other `Arc<SqliteStorage>` holders
@@ -1237,7 +1236,6 @@ pub(crate) fn init_supervisor_for_test_on(bi: &NapiBridgeInstance) {
 /// material), and `DidDocument` so that bridge functions can look up any
 /// registered identity by DID — including `identity_load` and
 /// `identity_resolve` which need the document without DHT access (#1144 C6).
-#[cfg(feature = "allow_in_memory_custody")]
 pub(crate) struct NapiIdentityEntry {
     /// The scp-core identity handle (DID string, key handles).
     pub(crate) identity: scp_identity::ScpIdentity,
@@ -1270,7 +1268,6 @@ pub(crate) struct NapiIdentityEntry {
 ///
 /// The registry is a typed `Arc<DashMap<String, NapiIdentityEntry>>` field
 /// on [`NapiBridgeInstance`].
-#[cfg(feature = "allow_in_memory_custody")]
 pub(crate) fn identity_registry(bi: &NapiBridgeInstance) -> &DashMap<String, NapiIdentityEntry> {
     bi.identity_registry.as_ref()
 }
@@ -1284,7 +1281,6 @@ pub(crate) fn identity_registry(bi: &NapiBridgeInstance) -> &DashMap<String, Nap
 ///
 /// Overwrites any existing entry for the same DID (idempotent — supports
 /// key rotation where the same DID gets new key material).
-#[cfg(feature = "allow_in_memory_custody")]
 pub(crate) fn register_identity(bi: &NapiBridgeInstance, did: &str, entry: NapiIdentityEntry) {
     identity_registry(bi).insert(did.to_owned(), entry);
 }
@@ -1295,7 +1291,6 @@ pub(crate) fn register_identity(bi: &NapiBridgeInstance, did: &str, entry: NapiI
 /// The old entry is removed and its key material is dropped.
 ///
 /// Idempotent: no-op if the DID is not present.
-#[cfg(feature = "allow_in_memory_custody")]
 pub(crate) fn remove_identity(bi: &NapiBridgeInstance, did: &str) {
     identity_registry(bi).remove(did);
 }
@@ -1307,6 +1302,11 @@ pub(crate) fn remove_identity(bi: &NapiBridgeInstance, did: &str) {
 ///
 /// Provided as a cleanup mechanism for long-running processes alongside
 /// [`remove_identity`] which is unconditional.
+///
+/// Gated to match its sole consumer, the `Scp::identity_remove_if_present`
+/// method, which is itself gated behind `allow_in_memory_custody` (the
+/// in-memory-custody registry-teardown API surface, mirroring the `PyO3`
+/// bridge).
 #[cfg(feature = "allow_in_memory_custody")]
 #[must_use]
 pub(crate) fn remove_identity_if_present(bi: &NapiBridgeInstance, did: &str) -> bool {
@@ -1324,7 +1324,6 @@ pub(crate) fn remove_identity_if_present(bi: &NapiBridgeInstance, did: &str) -> 
 /// Returns `ScpNapiError::Identity` (SCP-IDENT-1001) if the DID is not found
 /// (the identity was not created via `identity_create` on this bridge).
 /// Aligned with the `PyO3` canonical bridge for cross-bridge parity.
-#[cfg(feature = "allow_in_memory_custody")]
 pub(crate) fn with_identity<T, F>(
     bi: &NapiBridgeInstance,
     did: &str,
@@ -1355,7 +1354,6 @@ where
 ///
 /// Returns `ScpNapiError::Identity` (SCP-IDENT-1001) if the DID is not found.
 /// Aligned with the `PyO3` canonical bridge for cross-bridge parity.
-#[cfg(feature = "allow_in_memory_custody")]
 pub(crate) fn with_identity_mut<T, F>(
     bi: &NapiBridgeInstance,
     did: &str,
@@ -1945,7 +1943,6 @@ mod tests {
             bi.ucan_registry.is_empty(),
             "ucan_registry must start empty"
         );
-        #[cfg(feature = "allow_in_memory_custody")]
         assert!(
             bi.identity_registry.is_empty(),
             "identity_registry must start empty"

--- a/crates/scp-ffi/napi/src/runtime.rs
+++ b/crates/scp-ffi/napi/src/runtime.rs
@@ -1189,31 +1189,7 @@ fn event_log_provider_from_existing_repo(
 /// First-call-wins semantics via `CoreFields::set_supervisor`.
 #[cfg(test)]
 pub(crate) fn init_supervisor_for_test_on(bi: &NapiBridgeInstance) {
-    if bi.core.has_supervisor() {
-        return;
-    }
-    let event_log = event_log_provider_from_existing_repo(bi);
-    // The in-memory `mls_storage` backend is populated at construction
-    // (the dev/test affordance, spec §17.6). Read it directly; a missing
-    // backend fails closed.
-    let Some(mls_storage) = bi.mls_storage_ref().map(Arc::clone) else {
-        tracing::error!(
-            "init_supervisor_for_test_on: storage-before-supervisor precondition failed — \
-             no mls_storage backend on the bridge instance"
-        );
-        return;
-    };
-    let supervisor_arc = build_supervisor_arc(
-        Arc::new(scp_core::crypto::mls::provider::MlsCryptoProvider::new(
-            "did:test:napi-bridge-test".to_owned(),
-        )),
-        Box::new(scp_core::context::LocalTransportProvider),
-        event_log,
-        Box::new(NapiBridgePersistence::new()),
-        mls_storage,
-    );
-
-    bi.core.set_supervisor(supervisor_arc);
+    init_supervisor_for_test_on_with_did(bi, "did:test:napi-bridge-test");
 }
 
 /// Like [`init_supervisor_for_test_on`] but wires the MLS provider with a
@@ -1227,20 +1203,34 @@ pub(crate) fn init_supervisor_for_test_on(bi: &NapiBridgeInstance) {
 /// no-`testing` configuration rather than silently relying on the test gate.
 #[cfg(test)]
 pub(crate) fn init_production_supervisor_for_test_on(bi: &NapiBridgeInstance) {
+    init_supervisor_for_test_on_with_did(bi, "did:dht:z6MkNapiBridgeProductionTest");
+}
+
+/// Shared body for the two test supervisor initializers above. Wires a
+/// per-instance `Supervisor` with test-only providers (local transport),
+/// using `local_did` as the MLS credential identity. First-call-wins via
+/// `has_supervisor`.
+///
+/// The in-memory `mls_storage` backend is populated at construction (the
+/// dev/test affordance, spec §17.6). Read it directly; a missing backend
+/// fails closed.
+#[cfg(test)]
+fn init_supervisor_for_test_on_with_did(bi: &NapiBridgeInstance, local_did: &str) {
     if bi.core.has_supervisor() {
         return;
     }
     let event_log = event_log_provider_from_existing_repo(bi);
     let Some(mls_storage) = bi.mls_storage_ref().map(Arc::clone) else {
         tracing::error!(
-            "init_production_supervisor_for_test_on: storage-before-supervisor precondition \
-             failed — no mls_storage backend on the bridge instance"
+            local_did,
+            "init_supervisor_for_test_on: storage-before-supervisor precondition failed — \
+             no mls_storage backend on the bridge instance"
         );
         return;
     };
     let supervisor_arc = build_supervisor_arc(
         Arc::new(scp_core::crypto::mls::provider::MlsCryptoProvider::new(
-            "did:dht:z6MkNapiBridgeProductionTest".to_owned(),
+            local_did.to_owned(),
         )),
         Box::new(scp_core::context::LocalTransportProvider),
         event_log,
@@ -1371,8 +1361,9 @@ where
         .get(did)
         .ok_or_else(|| ScpNapiError::Identity {
             message: format!(
-                "identity '{did}' not found in registry — was it created with \
-                 identityCreate(\"in_memory\") in this process?"
+                "identity '{did}' is not registered on this bridge instance — \
+                 create it via identityCreate / identityCreateWithCustody, or it \
+                 was loaded externally without retained custody"
             ),
             code: codes::IDENT_1001.to_owned(),
         })?;
@@ -1401,8 +1392,9 @@ where
         .get_mut(did)
         .ok_or_else(|| ScpNapiError::Identity {
             message: format!(
-                "identity '{did}' not found in registry — was it created with \
-                 identityCreate(\"in_memory\") in this process?"
+                "identity '{did}' is not registered on this bridge instance — \
+                 create it via identityCreate / identityCreateWithCustody, or it \
+                 was loaded externally without retained custody"
             ),
             code: codes::IDENT_1001.to_owned(),
         })?;

--- a/crates/scp-ffi/napi/src/scp.rs
+++ b/crates/scp-ffi/napi/src/scp.rs
@@ -3908,21 +3908,6 @@ impl Scp {
 }
 
 // ---------------------------------------------------------------------------
-// In-memory-custody-only `Scp` methods.
-//
-// These methods are gated behind `allow_in_memory_custody` because they
-// depend on an in-memory *backend* (the in-memory identity registry teardown
-// helpers and the `InMemoryDeviceAttestation` software attestation backend),
-// or on the full-stack in-memory test network. They live in a SEPARATE
-// `#[napi] impl Scp` block so napi-rs emits their `_c_callback` registration
-// only when the feature is enabled — a single gated method inside the main
-// `#[napi] impl` block would leave a dangling registration reference in
-// production builds.
-//
-// Production callback-custody parity (registry retention, SCPID signing, link
-// attestations) lives in the main `impl Scp` block above and is NOT gated,
-// mirroring the PyO3 reference bridge.
-// ---------------------------------------------------------------------------
 // Relay/node startup `#[napi] Scp` methods. Moved into a separate
 // `#[cfg(feature = "server")] #[napi] impl Scp` block so napi-rs emits their
 // `_c_callback` registration references ONLY when `server` is enabled. A
@@ -3965,6 +3950,22 @@ impl Scp {
     }
 }
 
+// ---------------------------------------------------------------------------
+// In-memory-custody-only `Scp` methods.
+//
+// These methods are gated behind `allow_in_memory_custody` because they
+// depend on an in-memory *backend* (the in-memory identity registry teardown
+// helpers and the `InMemoryDeviceAttestation` software attestation backend),
+// or on the full-stack in-memory test network. They live in a SEPARATE
+// `#[napi] impl Scp` block so napi-rs emits their `_c_callback` registration
+// only when the feature is enabled — a single gated method inside the main
+// `#[napi] impl` block would leave a dangling registration reference in
+// production builds.
+//
+// Production callback-custody parity (registry retention, SCPID signing, link
+// attestations) lives in the main `impl Scp` block above and is NOT gated,
+// mirroring the PyO3 reference bridge.
+// ---------------------------------------------------------------------------
 #[cfg(feature = "allow_in_memory_custody")]
 #[napi]
 impl Scp {

--- a/crates/scp-ffi/napi/src/scp.rs
+++ b/crates/scp-ffi/napi/src/scp.rs
@@ -661,12 +661,20 @@ impl Scp {
     ///
     /// `provider` is a JS object implementing the `KeyCustodyProvider` record
     /// (`generateKeypair`, `sign`, `getPublicKey`, `destroyKey`, `dhAgree`,
-    /// `derivePseudonym`, `exportSigningKeyBytes`, `custodyType`). Private key
-    /// material never crosses into the Rust core (ADR-006): every crypto op is
-    /// marshalled back to the Node.js event loop via threadsafe functions and
-    /// awaited. This is the Node/Bun equivalent of the `UniFFI` bridge's
-    /// `identity_create_with_custody`, used to back a DID with an OS keychain,
-    /// hardware token, or HSM wrapper.
+    /// `derivePseudonym`, `exportSigningKeyBytes`, `custodyType`). Sign,
+    /// Diffie-Hellman, and pseudonym-derivation operations keep the private key
+    /// inside the caller's custody — those keys are never imported into the Rust
+    /// core (ADR-006); each such op is marshalled back to the Node.js event loop
+    /// via threadsafe functions and awaited. The `exportSigningKeyBytes` callback
+    /// is the exception: the `SigningKeyBytes`-based signing paths (UCAN mint,
+    /// SCPID, event-log checkpoint, and the join-time pseudonym announcement)
+    /// currently pull the raw 32-byte Ed25519 seed into Rust ownership, where it
+    /// is held in `Zeroizing` for the duration of the operation and wiped on
+    /// drop. That raw-export surface is tracked for migration to
+    /// `KeyCustody::sign`; context export already signs via `KeyCustody::sign`
+    /// (§23.16.8) and never exports the raw seed. This is the Node/Bun equivalent
+    /// of the `UniFFI` bridge's `identity_create_with_custody`, used to back a DID
+    /// with an OS keychain, hardware token, or HSM wrapper.
     ///
     /// The callbacks run on the JS thread; the pre-rotation seed is generated
     /// locally (it never traverses the consumer callbacks), per ADR-006.
@@ -693,8 +701,13 @@ impl Scp {
         // retains the caller's callback custody so later signing / event-log /
         // SCPID operations reach it, mirroring the PyO3 reference bridge. The
         // cold-storage `InMemoryPreRotationCustody` is a separate substrate for
-        // the pre-rotation key only (ADR-003 §4b) — the caller's operational
-        // private keys never enter Rust ownership (ADR-006).
+        // the pre-rotation key only (ADR-003 §4b). Sign / Diffie-Hellman /
+        // pseudonym-derivation operations keep the caller's private keys in
+        // custody (never imported into Rust) per ADR-006; the
+        // `SigningKeyBytes`-based paths (UCAN mint, SCPID, event-log checkpoint,
+        // join-time pseudonym announcement) are the exception — they export the
+        // raw seed into Rust (held in `Zeroizing`, wiped on drop), a surface
+        // tracked for migration to `KeyCustody::sign`.
         use scp_identity::DidDht;
 
         use crate::identity::{NapiIdentityInner, ensure_did_resolver_initialized_on};

--- a/crates/scp-ffi/napi/src/scp.rs
+++ b/crates/scp-ffi/napi/src/scp.rs
@@ -25,6 +25,10 @@ use scp_ffi_common::error_codes as codes;
 use scp_identity::DidMethod as _;
 use scp_primitives::Clock as _;
 
+// `Buffer` is referenced only by the in-memory-custody-gated full-stack test
+// methods (`fullstackSendMessage` / `fullstackDecryptMessage`); production
+// `identity_create` uses the fully-qualified path for its `testing_seed` arg.
+#[cfg(feature = "allow_in_memory_custody")]
 use napi::bindgen_prelude::Buffer;
 
 use crate::context::{
@@ -42,6 +46,7 @@ use crate::runtime::{NapiBridgeInstance, SqliteKeyMaterial, StorageConfig};
 #[cfg(feature = "server")]
 use crate::server::{NapiNodeHandle, NapiRelayHandle};
 use crate::sync::NapiSyncPolicy;
+#[cfg(feature = "allow_in_memory_custody")]
 use crate::testing::NapiFullStackNode;
 use crate::tools::{NapiToolDefinition, NapiToolVerificationResult};
 use crate::transport::{NapiReliabilityScore, NapiTransportManager, NapiTransportStatus};
@@ -373,12 +378,18 @@ impl Scp {
     /// only valid for `"in_memory"` custody; other custody types reject
     /// it with `SCP-VALID-7009`.
     #[napi(js_name = "identityCreate")]
+    // napi-rs requires `async` for the Promise return type. Without the
+    // in-memory-custody backend the only `.await` (the `"in_memory"` arm) is
+    // compiled out, so the bare build sees an await-free async fn.
+    #[cfg_attr(not(feature = "allow_in_memory_custody"), allow(clippy::unused_async))]
     pub async fn identity_create(
         &self,
         custody: String,
         testing_seed: Option<napi::bindgen_prelude::Buffer>,
     ) -> napi::Result<crate::identity::NapiIdentity> {
-        use crate::identity::{NapiIdentityInner, ensure_did_resolver_initialized_on};
+        #[cfg(feature = "allow_in_memory_custody")]
+        use crate::identity::NapiIdentityInner;
+        use crate::identity::ensure_did_resolver_initialized_on;
 
         validate_custody_type(&custody).map_err(NapiError::from)?;
 
@@ -544,11 +555,17 @@ impl Scp {
     /// Same as [`Self::identity_create`] but the resulting identity also
     /// includes an `#agent` verification method in the DID document.
     #[napi(js_name = "identityCreateWithAgentKey")]
+    // napi-rs requires `async` for the Promise return type. Without the
+    // in-memory-custody backend the only `.await` (the `"in_memory"` arm) is
+    // compiled out, so the bare build sees an await-free async fn.
+    #[cfg_attr(not(feature = "allow_in_memory_custody"), allow(clippy::unused_async))]
     pub async fn identity_create_with_agent_key(
         &self,
         custody: String,
     ) -> napi::Result<crate::identity::NapiIdentity> {
-        use crate::identity::{NapiIdentityInner, ensure_did_resolver_initialized_on};
+        #[cfg(feature = "allow_in_memory_custody")]
+        use crate::identity::NapiIdentityInner;
+        use crate::identity::ensure_did_resolver_initialized_on;
 
         validate_custody_type(&custody).map_err(NapiError::from)?;
 
@@ -657,7 +674,6 @@ impl Scp {
         js_name = "identityCreateWithCustody",
         ts_return_type = "Promise<NapiIdentity>"
     )]
-    #[cfg_attr(not(feature = "allow_in_memory_custody"), allow(unused_variables))]
     pub fn identity_create_with_custody<'env>(
         &self,
         env: &'env Env,
@@ -672,87 +688,74 @@ impl Scp {
         // custody callbacks the creation flow invokes. (An `async fn` taking
         // the `Function`s directly cannot compile: its future would capture
         // the non-`Send` callbacks.)
+        //
+        // This is a PRODUCTION path (not feature-gated): the identity registry
+        // retains the caller's callback custody so later signing / event-log /
+        // SCPID operations reach it, mirroring the PyO3 reference bridge. The
+        // cold-storage `InMemoryPreRotationCustody` is a separate substrate for
+        // the pre-rotation key only (ADR-003 §4b) — the caller's operational
+        // private keys never enter Rust ownership (ADR-006).
+        use scp_identity::DidDht;
 
-        // The identity registry (which retains the callback custody so later
-        // signing / event-log / SCPID operations can reach it) is compiled
-        // only under `allow_in_memory_custody`, matching every other
-        // key-bearing identity path in this bridge.
-        #[cfg(not(feature = "allow_in_memory_custody"))]
-        {
-            return Err(ScpNapiError::Identity {
-                message: "identityCreateWithCustody requires the allow_in_memory_custody \
-                          build feature (the identity registry that retains the callback \
-                          custody is gated on it)"
-                    .to_owned(),
-                code: codes::IDENT_1008.to_owned(),
-            }
-            .into());
-        }
+        use crate::identity::{NapiIdentityInner, ensure_did_resolver_initialized_on};
 
-        #[cfg(feature = "allow_in_memory_custody")]
-        {
-            use scp_identity::DidDht;
+        let bi_arc = Arc::clone(&self.inner);
+        ensure_did_resolver_initialized_on(&bi_arc);
 
-            use crate::identity::{NapiIdentityInner, ensure_did_resolver_initialized_on};
+        // Promote the JS callbacks to threadsafe functions on the JS
+        // thread (consuming the non-Send `Function`s). A malformed
+        // provider fails fast here, before any DID-creation work.
+        let callback = crate::custody::NapiCallbackKeyCustody::from_provider(provider)?;
+        let key_custody = Arc::new(crate::custody::NapiKeyCustody::Callback(callback));
 
-            let bi_arc = Arc::clone(&self.inner);
-            ensure_did_resolver_initialized_on(&bi_arc);
+        env.spawn_future(async move {
+            let bi = &*bi_arc;
+            let pre_rotation_custody =
+                Arc::new(scp_platform::testing::InMemoryPreRotationCustody::new());
+            let dht = DidDht::new();
+            let (scp_identity, document, pre_rotation_handle) = dht
+                .create(&*key_custody, pre_rotation_custody.as_ref())
+                .await
+                .map_err(|e| NapiError::from(ScpNapiError::from(e)))?;
 
-            // Promote the JS callbacks to threadsafe functions on the JS
-            // thread (consuming the non-Send `Function`s). A malformed
-            // provider fails fast here, before any DID-creation work.
-            let callback = crate::custody::NapiCallbackKeyCustody::from_provider(provider)?;
-            let key_custody = Arc::new(crate::custody::NapiKeyCustody::Callback(callback));
+            let verifying_key_hex = crate::identity::identity_verifying_key_hex(
+                &key_custody,
+                &scp_identity.identity_key,
+            )
+            .await;
 
-            env.spawn_future(async move {
-                let bi = &*bi_arc;
-                let pre_rotation_custody =
-                    Arc::new(scp_platform::testing::InMemoryPreRotationCustody::new());
-                let dht = DidDht::new();
-                let (scp_identity, document, pre_rotation_handle) = dht
-                    .create(&*key_custody, pre_rotation_custody.as_ref())
-                    .await
-                    .map_err(|e| NapiError::from(ScpNapiError::from(e)))?;
+            crate::runtime::register_identity(
+                bi,
+                &scp_identity.did,
+                crate::runtime::NapiIdentityEntry {
+                    identity: scp_identity.clone(),
+                    custody: Arc::clone(&key_custody),
+                    document: document.clone(),
+                    identity_link_attestations: Vec::new(),
+                    pre_rotation_handle,
+                    pre_rotation_custody,
+                },
+            );
 
-                let verifying_key_hex = crate::identity::identity_verifying_key_hex(
-                    &key_custody,
-                    &scp_identity.identity_key,
-                )
+            crate::identity::publish_to_shared_dht_for(&scp_identity, &document, &key_custody)
                 .await;
 
-                crate::runtime::register_identity(
-                    bi,
-                    &scp_identity.did,
-                    crate::runtime::NapiIdentityEntry {
-                        identity: scp_identity.clone(),
-                        custody: Arc::clone(&key_custody),
-                        document: document.clone(),
-                        identity_link_attestations: Vec::new(),
-                        pre_rotation_handle,
-                        pre_rotation_custody,
-                    },
-                );
-
-                crate::identity::publish_to_shared_dht_for(&scp_identity, &document, &key_custody)
-                    .await;
-
-                let handle = crate::identity::NapiIdentity {
-                    inner: Arc::new(NapiIdentityInner {
-                        did: scp_identity.did.clone(),
-                        custody_type: "callback".to_owned(),
-                        scp_identity: Some(scp_identity),
-                        in_memory_custody: Some(key_custody),
-                        document: Some(document),
-                        bi: Arc::clone(&bi_arc),
-                        verifying_key_hex,
-                        instance_id: bi.instance_id(),
-                        rotation_event_json: None,
-                    }),
-                };
-                crate::increment_handle_count();
-                Ok(handle)
-            })
-        }
+            let handle = crate::identity::NapiIdentity {
+                inner: Arc::new(NapiIdentityInner {
+                    did: scp_identity.did.clone(),
+                    custody_type: "callback".to_owned(),
+                    scp_identity: Some(scp_identity),
+                    in_memory_custody: Some(key_custody),
+                    document: Some(document),
+                    bi: Arc::clone(&bi_arc),
+                    verifying_key_hex,
+                    instance_id: bi.instance_id(),
+                    rotation_event_json: None,
+                }),
+            };
+            crate::increment_handle_count();
+            Ok(handle)
+        })
     }
 
     /// Per-instance equivalent of `identity_load`.
@@ -774,36 +777,36 @@ impl Scp {
 
         let bi = &*self.inner;
 
-        #[cfg(feature = "allow_in_memory_custody")]
-        {
-            let local_result = crate::runtime::with_identity(bi, &did, |entry| {
-                Ok((
-                    entry.identity.clone(),
-                    Arc::clone(&entry.custody),
-                    entry.document.clone(),
-                ))
-            });
+        // Look the DID up in this instance's identity registry first. Hits for
+        // any locally created identity — in-memory or production callback
+        // custody — before falling back to DHT resolution.
+        let local_result = crate::runtime::with_identity(bi, &did, |entry| {
+            Ok((
+                entry.identity.clone(),
+                Arc::clone(&entry.custody),
+                entry.document.clone(),
+            ))
+        });
 
-            if let Ok((identity, custody, document)) = local_result {
-                let verifying_key_hex =
-                    crate::identity::identity_verifying_key_hex(&custody, &identity.identity_key)
-                        .await;
-                let handle = crate::identity::NapiIdentity {
-                    inner: Arc::new(NapiIdentityInner {
-                        did,
-                        custody_type: "in_memory".to_owned(),
-                        scp_identity: Some(identity),
-                        in_memory_custody: Some(custody),
-                        document: Some(document),
-                        bi: Arc::clone(&self.inner),
-                        verifying_key_hex,
-                        instance_id: bi.instance_id(),
-                        rotation_event_json: None,
-                    }),
-                };
-                crate::increment_handle_count();
-                return Ok(handle);
-            }
+        if let Ok((identity, custody, document)) = local_result {
+            let custody_type = custody.custody_type_label().to_owned();
+            let verifying_key_hex =
+                crate::identity::identity_verifying_key_hex(&custody, &identity.identity_key).await;
+            let handle = crate::identity::NapiIdentity {
+                inner: Arc::new(NapiIdentityInner {
+                    did,
+                    custody_type,
+                    scp_identity: Some(identity),
+                    in_memory_custody: Some(custody),
+                    document: Some(document),
+                    bi: Arc::clone(&self.inner),
+                    verifying_key_hex,
+                    instance_id: bi.instance_id(),
+                    rotation_event_json: None,
+                }),
+            };
+            crate::increment_handle_count();
+            return Ok(handle);
         }
 
         let dht = DidDht::new();
@@ -817,7 +820,6 @@ impl Scp {
                 did,
                 custody_type: "external".to_owned(),
                 scp_identity: None,
-                #[cfg(feature = "allow_in_memory_custody")]
                 in_memory_custody: None,
                 document: Some(document),
                 bi: Arc::clone(&self.inner),
@@ -849,11 +851,8 @@ impl Scp {
 
         let bi = &*self.inner;
 
-        #[cfg(feature = "allow_in_memory_custody")]
         let local_doc =
             crate::runtime::with_identity(bi, &did, |entry| Ok(entry.document.clone())).ok();
-        #[cfg(not(feature = "allow_in_memory_custody"))]
-        let local_doc: Option<scp_identity::DidDocument> = None;
 
         let document = if let Some(doc) = local_doc {
             doc
@@ -896,106 +895,7 @@ impl Scp {
         })
     }
 
-    /// Per-instance equivalent of `identity_remove`.
-    ///
-    /// Drops retained key material for the DID. Idempotent — succeeds
-    /// silently when the DID is a syntactically valid DID not present in
-    /// the registry.
-    ///
-    /// # Errors
-    ///
-    /// Throws a validation error when `did` is not a syntactically valid
-    /// DID, mirroring the `PyO3` reference bridge's `identity_remove`.
-    #[cfg(feature = "allow_in_memory_custody")]
-    #[napi(js_name = "identityRemove")]
-    pub fn identity_remove(&self, did: String) -> napi::Result<()> {
-        scp_ffi_common::validate::validate_did(&did)
-            .map_err(|e| NapiError::from(ScpNapiError::from(e)))?;
-        crate::runtime::remove_identity(&self.inner, &did);
-        Ok(())
-    }
-
-    /// Per-instance equivalent of `identity_remove_if_present`.
-    ///
-    /// Returns `true` if the identity was present and removed.
-    ///
-    /// # Errors
-    ///
-    /// Throws a validation error when `did` is not a syntactically valid
-    /// DID, mirroring the `PyO3` reference bridge's
-    /// `identity_remove_if_present`.
-    #[cfg(feature = "allow_in_memory_custody")]
-    #[napi(js_name = "identityRemoveIfPresent")]
-    pub fn identity_remove_if_present(&self, did: String) -> napi::Result<bool> {
-        scp_ffi_common::validate::validate_did(&did)
-            .map_err(|e| NapiError::from(ScpNapiError::from(e)))?;
-        Ok(crate::runtime::remove_identity_if_present(
-            &self.inner,
-            &did,
-        ))
-    }
-
-    /// Per-instance equivalent of `identity_attest_device`.
-    ///
-    /// The attestation is device-local; the DID argument is retained for
-    /// API symmetry with the free function.
-    #[cfg(feature = "allow_in_memory_custody")]
-    #[napi(js_name = "identityAttestDevice")]
-    pub async fn identity_attest_device(&self, did: String) -> napi::Result<String> {
-        use base64::Engine;
-        use scp_platform::testing::InMemoryDeviceAttestation;
-        use scp_platform::traits::DeviceAttestation;
-
-        // Retained for API symmetry (spec §9.3) — the attestation itself is
-        // device-local and doesn't consult the identity's key material.
-        let _ = (&self.inner, did);
-
-        let attestation = InMemoryDeviceAttestation::new();
-        let token = attestation.attest().await.map_err(|e| {
-            NapiError::from(ScpNapiError::Identity {
-                message: format!("device attestation failed: {e}"),
-                code: codes::IDENT_1010.to_owned(),
-            })
-        })?;
-        Ok(base64::engine::general_purpose::STANDARD.encode(token.as_bytes()))
-    }
-
-    /// Per-instance equivalent of `identity_verify_device_attestation`.
-    #[cfg(feature = "allow_in_memory_custody")]
-    #[napi(js_name = "identityVerifyDeviceAttestation")]
-    pub async fn identity_verify_device_attestation(
-        &self,
-        did: String,
-        token_base64: String,
-    ) -> napi::Result<bool> {
-        use base64::Engine;
-        use scp_platform::testing::InMemoryDeviceAttestation;
-        use scp_platform::traits::DeviceAttestation;
-
-        let _ = (&self.inner, did);
-
-        let token_bytes = base64::engine::general_purpose::STANDARD
-            .decode(&token_base64)
-            .map_err(|e| {
-                NapiError::from(ScpNapiError::Identity {
-                    message: format!("invalid base64 attestation token: {e}"),
-                    code: codes::IDENT_1011.to_owned(),
-                })
-            })?;
-
-        let token = scp_platform::traits::DeviceAttestationToken::new(token_bytes);
-        let attestation = InMemoryDeviceAttestation::new();
-
-        attestation.verify(&token).await.map_err(|e| {
-            NapiError::from(ScpNapiError::Identity {
-                message: format!("device attestation verification failed: {e}"),
-                code: codes::IDENT_1012.to_owned(),
-            })
-        })
-    }
-
     /// Per-instance equivalent of `identity_create_link_attestation`.
-    #[cfg(feature = "allow_in_memory_custody")]
     #[napi(js_name = "identityCreateLinkAttestation")]
     #[allow(clippy::unused_async)] // napi-rs requires async for Promise return
     pub async fn identity_create_link_attestation(
@@ -1097,7 +997,6 @@ impl Scp {
     }
 
     /// Per-instance equivalent of `identity_link_attestations`.
-    #[cfg(feature = "allow_in_memory_custody")]
     #[napi(js_name = "identityLinkAttestations")]
     pub fn identity_link_attestations(&self, did: String) -> napi::Result<String> {
         crate::runtime::with_identity(&self.inner, &did, |entry| {
@@ -1112,7 +1011,6 @@ impl Scp {
     }
 
     /// Per-instance equivalent of `identity_remove_link_attestation`.
-    #[cfg(feature = "allow_in_memory_custody")]
     #[napi(js_name = "identityRemoveLinkAttestation")]
     pub fn identity_remove_link_attestation(
         &self,
@@ -3437,46 +3335,6 @@ impl Scp {
         )
     }
 
-    // -------------------------------------------------------------------
-    // Server (feature-gated)
-    // -------------------------------------------------------------------
-
-    /// Per-instance equivalent of the free-function `relay_start_in_memory`.
-    #[cfg(feature = "server")]
-    #[napi(js_name = "relayStartInMemory")]
-    pub async fn relay_start_in_memory(&self) -> napi::Result<NapiRelayHandle> {
-        crate::server::relay_start_in_memory_on(&self.inner).await
-    }
-
-    /// Per-instance equivalent of the free-function `relay_start_local`.
-    #[cfg(feature = "server")]
-    #[napi(js_name = "relayStartLocal")]
-    pub async fn relay_start_local(&self, data_dir: String) -> napi::Result<NapiRelayHandle> {
-        crate::server::relay_start_local_on(&self.inner, data_dir).await
-    }
-
-    /// Per-instance equivalent of the free-function `node_start_in_memory`.
-    #[cfg(feature = "server")]
-    #[napi(js_name = "nodeStartInMemory")]
-    pub async fn node_start_in_memory(
-        &self,
-        identity_did: Option<String>,
-    ) -> napi::Result<NapiNodeHandle> {
-        crate::server::node_start_in_memory_on(&self.inner, identity_did).await
-    }
-
-    /// Per-instance equivalent of the free-function `node_start_local`.
-    #[cfg(feature = "server")]
-    #[napi(js_name = "nodeStartLocal")]
-    pub async fn node_start_local(
-        &self,
-        data_dir: String,
-        identity_did: Option<String>,
-        passphrase: Option<String>,
-    ) -> napi::Result<NapiNodeHandle> {
-        crate::server::node_start_local_on(&self.inner, data_dir, identity_did, passphrase).await
-    }
-
     // ====================================================================
     // #1549 Phase 4 PR 4 — sub-slice E: mcp/testing/media/provenance/sync
     // operations on SCP.
@@ -3592,113 +3450,6 @@ impl Scp {
     #[napi(js_name = "mcpGetStdioAllowlist")]
     pub fn mcp_get_stdio_allowlist(&self) -> napi::Result<NapiAllowlistState> {
         crate::mcp::mcp_get_stdio_allowlist_on(&self.inner)
-    }
-
-    // -------------------------------------------------------------------
-    // Testing (full-stack E2E harness)
-    // -------------------------------------------------------------------
-
-    /// Per-instance equivalent of the free-function `fullstack_create_node`.
-    #[napi(js_name = "fullstackCreateNode")]
-    #[must_use]
-    pub fn fullstack_create_node(&self, did: String) -> NapiFullStackNode {
-        crate::testing::fullstack_create_node_on(&self.inner, did)
-    }
-
-    /// Per-instance equivalent of the free-function `fullstack_reset_network`.
-    #[napi(js_name = "fullstackResetNetwork")]
-    pub fn fullstack_reset_network(&self) {
-        crate::testing::fullstack_reset_network_on(&self.inner);
-    }
-
-    /// Per-instance equivalent of the free-function `fullstack_create_context`.
-    #[napi(js_name = "fullstackCreateContext")]
-    pub fn fullstack_create_context(
-        &self,
-        node: &NapiFullStackNode,
-        context_id: String,
-        ceiling_json: String,
-    ) -> napi::Result<String> {
-        crate::napi_check_handle!(&self.inner.core, node);
-        crate::testing::fullstack_create_context_on(&self.inner, node, context_id, ceiling_json)
-    }
-
-    /// Per-instance equivalent of the free-function `fullstack_add_member`.
-    #[napi(js_name = "fullstackAddMember")]
-    pub fn fullstack_add_member(
-        &self,
-        node: &NapiFullStackNode,
-        context_id: String,
-        member_did: String,
-    ) -> napi::Result<()> {
-        crate::napi_check_handle!(&self.inner.core, node);
-        crate::testing::fullstack_add_member_on(&self.inner, node, context_id, member_did)
-    }
-
-    /// Per-instance equivalent of the free-function `fullstack_join_from_welcome`.
-    #[napi(js_name = "fullstackJoinFromWelcome")]
-    pub fn fullstack_join_from_welcome(
-        &self,
-        node: &NapiFullStackNode,
-        context_id: String,
-    ) -> napi::Result<()> {
-        crate::napi_check_handle!(&self.inner.core, node);
-        crate::testing::fullstack_join_from_welcome_on(&self.inner, node, context_id)
-    }
-
-    /// Per-instance equivalent of the free-function `fullstack_sync_sender_keys`.
-    #[napi(js_name = "fullstackSyncSenderKeys")]
-    pub fn fullstack_sync_sender_keys(
-        &self,
-        node_a: &NapiFullStackNode,
-        node_b: &NapiFullStackNode,
-        context_id: String,
-    ) -> napi::Result<()> {
-        crate::napi_check_handle!(&self.inner.core, node_a, node_b);
-        crate::testing::fullstack_sync_sender_keys_on(&self.inner, node_a, node_b, context_id)
-    }
-
-    /// Per-instance equivalent of the free-function `fullstack_send_message`.
-    #[napi(js_name = "fullstackSendMessage")]
-    pub fn fullstack_send_message(
-        &self,
-        node: &NapiFullStackNode,
-        context_id: String,
-        payload: Buffer,
-    ) -> napi::Result<Buffer> {
-        crate::napi_check_handle!(&self.inner.core, node);
-        crate::testing::fullstack_send_message_on(&self.inner, node, context_id, payload)
-    }
-
-    /// Per-instance equivalent of the free-function `fullstack_decrypt_message`.
-    #[napi(js_name = "fullstackDecryptMessage")]
-    pub fn fullstack_decrypt_message(
-        &self,
-        node: &NapiFullStackNode,
-        context_id: String,
-        ciphertext: Buffer,
-        sender_did: String,
-    ) -> napi::Result<Buffer> {
-        crate::napi_check_handle!(&self.inner.core, node);
-        crate::testing::fullstack_decrypt_message_on(
-            &self.inner,
-            node,
-            context_id,
-            ciphertext,
-            sender_did,
-        )
-    }
-
-    /// Per-instance equivalent of the free-function `fullstack_remove_member`.
-    #[napi(js_name = "fullstackRemoveMember")]
-    pub fn fullstack_remove_member(
-        &self,
-        node: &NapiFullStackNode,
-        context_id: String,
-        member_did: String,
-    ) -> napi::Result<()> {
-        crate::napi_check_handle!(&self.inner.core, node);
-        crate::testing::fullstack_remove_member_on(&self.inner, node, context_id, member_did)
     }
 
     // -------------------------------------------------------------------
@@ -4092,7 +3843,6 @@ impl Scp {
     /// cross-bridge parity harness. Only accepted when scp-core is built
     /// with the `testing` feature; production builds reject any non-`null`
     /// value via `SCP-VALID-7008`.
-    #[cfg(feature = "allow_in_memory_custody")]
     #[napi(js_name = "scpidSign")]
     pub fn scpid_sign(
         &self,
@@ -4141,6 +3891,265 @@ impl Scp {
         Self {
             inner: Arc::new(NapiBridgeInstance::new_napi()),
         }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// In-memory-custody-only `Scp` methods.
+//
+// These methods are gated behind `allow_in_memory_custody` because they
+// depend on an in-memory *backend* (the in-memory identity registry teardown
+// helpers and the `InMemoryDeviceAttestation` software attestation backend),
+// or on the full-stack in-memory test network. They live in a SEPARATE
+// `#[napi] impl Scp` block so napi-rs emits their `_c_callback` registration
+// only when the feature is enabled — a single gated method inside the main
+// `#[napi] impl` block would leave a dangling registration reference in
+// production builds.
+//
+// Production callback-custody parity (registry retention, SCPID signing, link
+// attestations) lives in the main `impl Scp` block above and is NOT gated,
+// mirroring the PyO3 reference bridge.
+// ---------------------------------------------------------------------------
+// Relay/node startup `#[napi] Scp` methods. Moved into a separate
+// `#[cfg(feature = "server")] #[napi] impl Scp` block so napi-rs emits their
+// `_c_callback` registration references ONLY when `server` is enabled. A
+// single `#[cfg(feature = "server")]`-gated `#[napi]` method inside the main
+// (ungated) `impl Scp` block would leave a dangling `_c_callback` symbol in
+// builds without the `server` feature (e.g. `--no-default-features`).
+#[cfg(feature = "server")]
+#[napi]
+impl Scp {
+    /// Per-instance equivalent of the free-function `relay_start_in_memory`.
+    #[napi(js_name = "relayStartInMemory")]
+    pub async fn relay_start_in_memory(&self) -> napi::Result<NapiRelayHandle> {
+        crate::server::relay_start_in_memory_on(&self.inner).await
+    }
+
+    /// Per-instance equivalent of the free-function `relay_start_local`.
+    #[napi(js_name = "relayStartLocal")]
+    pub async fn relay_start_local(&self, data_dir: String) -> napi::Result<NapiRelayHandle> {
+        crate::server::relay_start_local_on(&self.inner, data_dir).await
+    }
+
+    /// Per-instance equivalent of the free-function `node_start_in_memory`.
+    #[napi(js_name = "nodeStartInMemory")]
+    pub async fn node_start_in_memory(
+        &self,
+        identity_did: Option<String>,
+    ) -> napi::Result<NapiNodeHandle> {
+        crate::server::node_start_in_memory_on(&self.inner, identity_did).await
+    }
+
+    /// Per-instance equivalent of the free-function `node_start_local`.
+    #[napi(js_name = "nodeStartLocal")]
+    pub async fn node_start_local(
+        &self,
+        data_dir: String,
+        identity_did: Option<String>,
+        passphrase: Option<String>,
+    ) -> napi::Result<NapiNodeHandle> {
+        crate::server::node_start_local_on(&self.inner, data_dir, identity_did, passphrase).await
+    }
+}
+
+#[cfg(feature = "allow_in_memory_custody")]
+#[napi]
+impl Scp {
+    /// Per-instance equivalent of `identity_remove`.
+    ///
+    /// Drops retained key material for the DID. Idempotent — succeeds
+    /// silently when the DID is a syntactically valid DID not present in
+    /// the registry.
+    ///
+    /// # Errors
+    ///
+    /// Throws a validation error when `did` is not a syntactically valid
+    /// DID, mirroring the `PyO3` reference bridge's `identity_remove`.
+    #[napi(js_name = "identityRemove")]
+    pub fn identity_remove(&self, did: String) -> napi::Result<()> {
+        scp_ffi_common::validate::validate_did(&did)
+            .map_err(|e| NapiError::from(ScpNapiError::from(e)))?;
+        crate::runtime::remove_identity(&self.inner, &did);
+        Ok(())
+    }
+
+    /// Per-instance equivalent of `identity_remove_if_present`.
+    ///
+    /// Returns `true` if the identity was present and removed.
+    ///
+    /// # Errors
+    ///
+    /// Throws a validation error when `did` is not a syntactically valid
+    /// DID, mirroring the `PyO3` reference bridge's
+    /// `identity_remove_if_present`.
+    #[napi(js_name = "identityRemoveIfPresent")]
+    pub fn identity_remove_if_present(&self, did: String) -> napi::Result<bool> {
+        scp_ffi_common::validate::validate_did(&did)
+            .map_err(|e| NapiError::from(ScpNapiError::from(e)))?;
+        Ok(crate::runtime::remove_identity_if_present(
+            &self.inner,
+            &did,
+        ))
+    }
+
+    /// Per-instance equivalent of `identity_attest_device`.
+    ///
+    /// The attestation is device-local; the DID argument is retained for
+    /// API symmetry with the free function.
+    #[napi(js_name = "identityAttestDevice")]
+    pub async fn identity_attest_device(&self, did: String) -> napi::Result<String> {
+        use base64::Engine;
+        use scp_platform::testing::InMemoryDeviceAttestation;
+        use scp_platform::traits::DeviceAttestation;
+
+        // Retained for API symmetry (spec §9.3) — the attestation itself is
+        // device-local and doesn't consult the identity's key material.
+        let _ = (&self.inner, did);
+
+        let attestation = InMemoryDeviceAttestation::new();
+        let token = attestation.attest().await.map_err(|e| {
+            NapiError::from(ScpNapiError::Identity {
+                message: format!("device attestation failed: {e}"),
+                code: codes::IDENT_1010.to_owned(),
+            })
+        })?;
+        Ok(base64::engine::general_purpose::STANDARD.encode(token.as_bytes()))
+    }
+
+    /// Per-instance equivalent of `identity_verify_device_attestation`.
+    #[napi(js_name = "identityVerifyDeviceAttestation")]
+    pub async fn identity_verify_device_attestation(
+        &self,
+        did: String,
+        token_base64: String,
+    ) -> napi::Result<bool> {
+        use base64::Engine;
+        use scp_platform::testing::InMemoryDeviceAttestation;
+        use scp_platform::traits::DeviceAttestation;
+
+        let _ = (&self.inner, did);
+
+        let token_bytes = base64::engine::general_purpose::STANDARD
+            .decode(&token_base64)
+            .map_err(|e| {
+                NapiError::from(ScpNapiError::Identity {
+                    message: format!("invalid base64 attestation token: {e}"),
+                    code: codes::IDENT_1011.to_owned(),
+                })
+            })?;
+
+        let token = scp_platform::traits::DeviceAttestationToken::new(token_bytes);
+        let attestation = InMemoryDeviceAttestation::new();
+
+        attestation.verify(&token).await.map_err(|e| {
+            NapiError::from(ScpNapiError::Identity {
+                message: format!("device attestation verification failed: {e}"),
+                code: codes::IDENT_1012.to_owned(),
+            })
+        })
+    }
+
+    /// Per-instance equivalent of the free-function `fullstack_create_node`.
+    #[napi(js_name = "fullstackCreateNode")]
+    #[must_use]
+    pub fn fullstack_create_node(&self, did: String) -> NapiFullStackNode {
+        crate::testing::fullstack_create_node_on(&self.inner, did)
+    }
+
+    /// Per-instance equivalent of the free-function `fullstack_reset_network`.
+    #[napi(js_name = "fullstackResetNetwork")]
+    pub fn fullstack_reset_network(&self) {
+        crate::testing::fullstack_reset_network_on(&self.inner);
+    }
+
+    /// Per-instance equivalent of the free-function `fullstack_create_context`.
+    #[napi(js_name = "fullstackCreateContext")]
+    pub fn fullstack_create_context(
+        &self,
+        node: &NapiFullStackNode,
+        context_id: String,
+        ceiling_json: String,
+    ) -> napi::Result<String> {
+        crate::napi_check_handle!(&self.inner.core, node);
+        crate::testing::fullstack_create_context_on(&self.inner, node, context_id, ceiling_json)
+    }
+
+    /// Per-instance equivalent of the free-function `fullstack_add_member`.
+    #[napi(js_name = "fullstackAddMember")]
+    pub fn fullstack_add_member(
+        &self,
+        node: &NapiFullStackNode,
+        context_id: String,
+        member_did: String,
+    ) -> napi::Result<()> {
+        crate::napi_check_handle!(&self.inner.core, node);
+        crate::testing::fullstack_add_member_on(&self.inner, node, context_id, member_did)
+    }
+
+    /// Per-instance equivalent of the free-function `fullstack_join_from_welcome`.
+    #[napi(js_name = "fullstackJoinFromWelcome")]
+    pub fn fullstack_join_from_welcome(
+        &self,
+        node: &NapiFullStackNode,
+        context_id: String,
+    ) -> napi::Result<()> {
+        crate::napi_check_handle!(&self.inner.core, node);
+        crate::testing::fullstack_join_from_welcome_on(&self.inner, node, context_id)
+    }
+
+    /// Per-instance equivalent of the free-function `fullstack_sync_sender_keys`.
+    #[napi(js_name = "fullstackSyncSenderKeys")]
+    pub fn fullstack_sync_sender_keys(
+        &self,
+        node_a: &NapiFullStackNode,
+        node_b: &NapiFullStackNode,
+        context_id: String,
+    ) -> napi::Result<()> {
+        crate::napi_check_handle!(&self.inner.core, node_a, node_b);
+        crate::testing::fullstack_sync_sender_keys_on(&self.inner, node_a, node_b, context_id)
+    }
+
+    /// Per-instance equivalent of the free-function `fullstack_send_message`.
+    #[napi(js_name = "fullstackSendMessage")]
+    pub fn fullstack_send_message(
+        &self,
+        node: &NapiFullStackNode,
+        context_id: String,
+        payload: Buffer,
+    ) -> napi::Result<Buffer> {
+        crate::napi_check_handle!(&self.inner.core, node);
+        crate::testing::fullstack_send_message_on(&self.inner, node, context_id, payload)
+    }
+
+    /// Per-instance equivalent of the free-function `fullstack_decrypt_message`.
+    #[napi(js_name = "fullstackDecryptMessage")]
+    pub fn fullstack_decrypt_message(
+        &self,
+        node: &NapiFullStackNode,
+        context_id: String,
+        ciphertext: Buffer,
+        sender_did: String,
+    ) -> napi::Result<Buffer> {
+        crate::napi_check_handle!(&self.inner.core, node);
+        crate::testing::fullstack_decrypt_message_on(
+            &self.inner,
+            node,
+            context_id,
+            ciphertext,
+            sender_did,
+        )
+    }
+
+    /// Per-instance equivalent of the free-function `fullstack_remove_member`.
+    #[napi(js_name = "fullstackRemoveMember")]
+    pub fn fullstack_remove_member(
+        &self,
+        node: &NapiFullStackNode,
+        context_id: String,
+        member_did: String,
+    ) -> napi::Result<()> {
+        crate::napi_check_handle!(&self.inner.core, node);
+        crate::testing::fullstack_remove_member_on(&self.inner, node, context_id, member_did)
     }
 }
 

--- a/crates/scp-ffi/napi/src/scpid.rs
+++ b/crates/scp-ffi/napi/src/scpid.rs
@@ -10,12 +10,10 @@
 use scp_ffi_common::error_codes as codes;
 use std::time::Duration;
 
-#[cfg(feature = "allow_in_memory_custody")]
 use scp_core::identity::scpid_sign as core_sign;
 use scp_core::identity::{
     ScpIdChallenge, ScpIdResponse, scpid_challenge as core_challenge, scpid_verify as core_verify,
 };
-#[cfg(feature = "allow_in_memory_custody")]
 use scp_identity::SigningKeyId;
 
 use crate::error::ScpNapiError;
@@ -64,7 +62,6 @@ pub(crate) fn scpid_challenge_on(
 /// It is only accepted when scp-core is built with the `testing` feature
 /// (cross-bridge parity harness, ADR-046); production builds reject any
 /// non-`null` value.
-#[cfg(feature = "allow_in_memory_custody")]
 pub(crate) fn scpid_sign_on(
     bi: &NapiBridgeInstance,
     did: String,
@@ -196,7 +193,6 @@ pub(crate) fn scpid_verify_on(
 
 /// Parses a signing key ID string (`"#active"` or `"#agent"`) into a
 /// [`SigningKeyId`] enum.
-#[cfg(feature = "allow_in_memory_custody")]
 fn parse_signing_key_id(s: &str) -> napi::Result<SigningKeyId> {
     match s {
         "#active" => Ok(SigningKeyId::Active),
@@ -234,10 +230,15 @@ mod tests {
     use super::*;
     use crate::runtime::NapiBridgeInstance;
     use scp_ffi_common::error_codes as codes;
-    use std::sync::Arc;
 
+    // In-memory-custody-only helpers — used solely by the feature-gated
+    // `scpid_sign` tests that register an identity via the in-memory backend.
+    #[cfg(feature = "allow_in_memory_custody")]
     use scp_identity::resolver::DualLayerResolver;
+    #[cfg(feature = "allow_in_memory_custody")]
     use scp_identity::{DidCache, InMemoryDhtClient, NoOpRelayQuerier};
+    #[cfg(feature = "allow_in_memory_custody")]
+    use std::sync::Arc;
 
     fn test_bi() -> NapiBridgeInstance {
         NapiBridgeInstance::new_napi()

--- a/crates/scp-ffi/napi/src/server.rs
+++ b/crates/scp-ffi/napi/src/server.rs
@@ -519,10 +519,11 @@ impl Drop for NapiNodeHandle {
 ///
 /// # Errors
 ///
-/// Returns `napi::Error` if:
-/// - The `allow_in_memory_custody` feature is not enabled.
-/// - The DID is not found in the identity registry.
-#[cfg(feature = "allow_in_memory_custody")]
+/// Returns `napi::Error` if the DID is not found in the identity registry.
+///
+/// Works for any locally registered identity — in-memory OR a production
+/// callback custody (`identityCreateWithCustody`) — since signing dispatches
+/// through the enum-typed `NapiKeyCustody`.
 #[allow(clippy::type_complexity)]
 fn build_node_identity(bi: &NapiBridgeInstance, did: &str) -> napi::Result<NodeIdentity> {
     use std::sync::Arc;
@@ -576,13 +577,6 @@ fn build_node_identity(bi: &NapiBridgeInstance, did: &str) -> napi::Result<NodeI
         })
     })
     .map_err(napi::Error::from)
-}
-
-#[cfg(not(feature = "allow_in_memory_custody"))]
-fn build_node_identity(_bi: &NapiBridgeInstance, _did: &str) -> napi::Result<NodeIdentity> {
-    Err(NapiError::from_reason(
-        "identity portability requires in-memory custody — enable allow_in_memory_custody",
-    ))
 }
 
 // ---------------------------------------------------------------------------

--- a/crates/scp-ffi/napi/src/transport.rs
+++ b/crates/scp-ffi/napi/src/transport.rs
@@ -81,6 +81,11 @@ fn set_transport_manager_on(
 /// # Errors
 ///
 /// Returns `ScpNapiError::Transport` if the lock is poisoned.
+///
+/// Gated to match its sole caller, the `server`-gated node auto-wiring path
+/// in `server.rs` (`mod server` is `#[cfg(feature = "server")]`). Without the
+/// gate the function is dead code in `--no-default-features` builds.
+#[cfg(feature = "server")]
 pub(crate) fn set_transport_manager_arc_on(
     bi: &NapiBridgeInstance,
     manager: Arc<scp_transport::TransportManager>,

--- a/crates/scp-ffi/napi/src/transport.rs
+++ b/crates/scp-ffi/napi/src/transport.rs
@@ -927,6 +927,12 @@ mod tests {
     /// `transport_connect_on` must route through the instance selector and
     /// connect via WebSocket fallback against a relay that advertises no QUIC.
     /// After the call the bridge instance must own a transport manager.
+    ///
+    /// Requires the `server` feature: it spins up an in-memory relay via
+    /// `scp_ffi_common::server::start_relay_in_memory`, which only exists under
+    /// `#[cfg(feature = "server")]`. The bare (`--no-default-features`) test
+    /// target must still compile, so this fn is server-gated.
+    #[cfg(feature = "server")]
     #[test]
     fn transport_connect_routes_through_selector_ws_fallback() {
         let rt = crate::runtime();
@@ -960,6 +966,10 @@ mod tests {
 
     /// `transport_add_relay_on` must route through the instance selector and
     /// add a second WS-fallback adapter to the manager.
+    ///
+    /// Server-gated: depends on `scp_ffi_common::server::start_relay_in_memory`
+    /// (`#[cfg(feature = "server")]`), so the bare test target compiles.
+    #[cfg(feature = "server")]
     #[test]
     fn transport_add_relay_routes_through_selector_ws_fallback() {
         let rt = crate::runtime();
@@ -990,6 +1000,10 @@ mod tests {
 
     /// `configure_relay_transport_on` must route through the instance selector
     /// and install a `RelayTransportProvider` over the WS-fallback adapter.
+    ///
+    /// Server-gated: depends on `scp_ffi_common::server::start_relay_in_memory`
+    /// (`#[cfg(feature = "server")]`), so the bare test target compiles.
+    #[cfg(feature = "server")]
     #[test]
     fn configure_relay_transport_routes_through_selector_ws_fallback() {
         let rt = crate::runtime();

--- a/crates/scp-ffi/napi/src/ucan.rs
+++ b/crates/scp-ffi/napi/src/ucan.rs
@@ -4,7 +4,8 @@
 //!
 //! - `ucan_validate` — Validate a UCAN token for a required capability.
 //! - `ucan_mint` — Mint a new UCAN token for a context member with real
-//!   Ed25519 signing via `InMemoryKeyCustody`.
+//!   Ed25519 signing delegated to the creator identity's retained
+//!   `KeyCustody` (in-memory OR production callback custody).
 //! - `ucan_revoke` — Revoke a UCAN token.
 //!
 //! # Validation pipeline
@@ -30,7 +31,6 @@ use scp_ffi_common::error_codes as codes;
 use std::collections::HashMap;
 
 use napi_derive::napi;
-#[cfg(feature = "allow_in_memory_custody")]
 use scp_core::crypto::ucan::mint::{MintParams, mint_ucan};
 use scp_ffi_common::validate::{validate_capability_uri, validate_did, validate_ucan_token};
 
@@ -49,7 +49,6 @@ use scp_ffi_common::{
 use crate::context::NapiContextHandle;
 use crate::decrement_handle_count;
 use crate::error::ScpNapiError;
-#[cfg(feature = "allow_in_memory_custody")]
 use crate::increment_handle_count;
 use crate::runtime::NapiBridgeInstance;
 
@@ -296,98 +295,81 @@ pub(crate) async fn ucan_mint_on(
         }
     }
 
-    // In-memory custody is only available when `allow_in_memory_custody` is enabled.
-    #[cfg(not(feature = "allow_in_memory_custody"))]
-    {
-        let _ = (bi, &handle, &member_did, &capabilities, &proofs);
-        Err(napi::Error::from(ScpNapiError::Permission {
-            message: "UCAN minting requires key custody -- the in_memory custody path                       is not available in this build. Enable allow_in_memory_custody                       for dev/desktop use.".to_owned(),
+    // Extract key custody and signing key from the context handle. Available
+    // for any context whose creator identity retains custody — in-memory OR a
+    // production callback custody (`identityCreateWithCustody`).
+    let custody = handle.in_memory_custody.as_ref().ok_or_else(|| {
+        napi::Error::from(ScpNapiError::Permission {
+            message: "UCAN minting requires key custody — the context creator identity has no \
+                  retained custody (it was externally loaded)"
+                .to_owned(),
             code: codes::PERM_3023.to_owned(),
-        }))
-    }
+        })
+    })?;
+    let signing_key = handle.signing_key.ok_or_else(|| {
+        napi::Error::from(ScpNapiError::Permission {
+            message: "UCAN minting requires a signing key — the context creator identity \
+                  must have an active signing key"
+                .to_owned(),
+            code: codes::PERM_3023.to_owned(),
+        })
+    })?;
 
-    #[cfg(feature = "allow_in_memory_custody")]
-    {
-        // Extract key custody and signing key from the context handle.
-        let custody = handle.in_memory_custody.as_ref().ok_or_else(|| {
+    let creator_did = handle.creator_did();
+    let context_id = handle.context_id();
+
+    // Get ceiling from the context handle for mint-time enforcement (#339).
+    // Empty ceiling means the user passed `[]` — apply the default ceiling
+    // instead of `None` (which would mean unlimited). See #1419.
+    let ceiling_strings: std::collections::HashSet<String> = handle.ceiling().into_iter().collect();
+    let ceiling = Some(if ceiling_strings.is_empty() {
+        scp_core::context::roles::default_ceiling().to_ucan_string_set()
+    } else {
+        ceiling_strings
+    });
+
+    let params = MintParams {
+        issuer_did: &creator_did,
+        issuer_key: &signing_key,
+        audience_did: &member_did,
+        context_id: &context_id,
+        capabilities: &capabilities,
+        lifetime_secs: 3600, // 1 hour default
+        not_before: None,
+        proofs: proofs.unwrap_or_default(),
+        facts: None,
+        key_scope: None,
+        signing_key_id: None,
+        ceiling,
+    };
+
+    // Sign the token by delegating to the retained `KeyCustody` via scp-core.
+    // napi-rs async functions already run on the tokio runtime, so we can
+    // await directly without spawning a separate task.
+    let token = mint_ucan(&params, custody.as_ref(), &scp_primitives::SystemClock)
+        .await
+        .map_err(|e| {
             napi::Error::from(ScpNapiError::Permission {
-                message: "UCAN minting requires key custody — create the context with an \
-                      in_memory identity (identity_create(\"in_memory\"))"
-                    .to_owned(),
+                message: format!("UCAN minting failed: {e}"),
                 code: codes::PERM_3023.to_owned(),
             })
         })?;
-        let signing_key = handle.signing_key.ok_or_else(|| {
-            napi::Error::from(ScpNapiError::Permission {
-                message: "UCAN minting requires a signing key — the context creator identity \
-                      must have an active signing key"
-                    .to_owned(),
-                code: codes::PERM_3023.to_owned(),
-            })
-        })?;
 
-        let creator_did = handle.creator_did();
-        let context_id = handle.context_id();
-
-        // Get ceiling from the context handle for mint-time enforcement (#339).
-        // Empty ceiling means the user passed `[]` — apply the default ceiling
-        // instead of `None` (which would mean unlimited). See #1419.
-        let ceiling_strings: std::collections::HashSet<String> =
-            handle.ceiling().into_iter().collect();
-        let ceiling = Some(if ceiling_strings.is_empty() {
-            scp_core::context::roles::default_ceiling().to_ucan_string_set()
-        } else {
-            ceiling_strings
-        });
-
-        let params = MintParams {
-            issuer_did: &creator_did,
-            issuer_key: &signing_key,
-            audience_did: &member_did,
-            context_id: &context_id,
-            capabilities: &capabilities,
-            lifetime_secs: 3600, // 1 hour default
-            not_before: None,
-            proofs: proofs.unwrap_or_default(),
-            facts: None,
-            key_scope: None,
-            signing_key_id: None,
-            ceiling,
-        };
-
-        // Sign the token using the real InMemoryKeyCustody via scp-core.
-        // napi-rs async functions already run on the tokio runtime, so we
-        // can await directly without spawning a separate task.
-        let token = mint_ucan(&params, custody.as_ref(), &scp_primitives::SystemClock)
-            .await
-            .map_err(|e| {
-                napi::Error::from(ScpNapiError::Permission {
-                    message: format!("UCAN minting failed: {e}"),
-                    code: codes::PERM_3023.to_owned(),
-                })
-            })?;
-
-        let data = NapiUcanTokenData {
+    let data = NapiUcanTokenData {
         token_id: token.payload.nnc.clone(),
         issuer: token.payload.iss.clone(),
         audience: token.payload.aud.clone(),
-        capabilities: token
-            .payload
-            .att
-            .iter()
-            .map(|a| a.with.clone())
-            .collect(),
+        capabilities: token.payload.att.iter().map(|a| a.with.clone()).collect(),
         #[allow(clippy::cast_precision_loss)] // Unix timestamp seconds fit in f64 mantissa for centuries.
         expires_at: Some(token.payload.exp as f64),
     };
 
-        increment_handle_count();
-        Ok(NapiUcanToken {
-            data,
-            encoded: token.encoded,
-            instance_id: bi.instance_id(),
-        })
-    }
+    increment_handle_count();
+    Ok(NapiUcanToken {
+        data,
+        encoded: token.encoded,
+        instance_id: bi.instance_id(),
+    })
 }
 
 /// Per-bridge-instance implementation of [`ucan_delegate`].
@@ -409,26 +391,10 @@ pub(crate) async fn ucan_delegate_on(
         validate_capability_uri(cap).map_err(|e| napi::Error::from(ScpNapiError::from(e)))?;
     }
 
-    #[cfg(not(feature = "allow_in_memory_custody"))]
-    {
-        let _ = (
-            bi,
-            &handle,
-            &delegator_did,
-            &delegatee_did,
-            &parent_token,
-            &capabilities,
-        );
-        Err(napi::Error::from(ScpNapiError::Permission {
-            message: "UCAN delegation requires key custody -- the in_memory custody path \
-                       is not available in this build. Enable allow_in_memory_custody \
-                       for dev/desktop use."
-                .to_owned(),
-            code: codes::PERM_3023.to_owned(),
-        }))
-    }
-
-    #[cfg(feature = "allow_in_memory_custody")]
+    // Delegation is available for any context whose delegator identity retains
+    // custody — in-memory OR a production callback custody
+    // (`identityCreateWithCustody`). The delegator's key is looked up from the
+    // identity registry below (NOT the context creator's key).
     {
         use scp_core::crypto::ucan::Attenuation;
         use scp_core::crypto::ucan::mint::{DelegateParams, delegate_ucan};

--- a/crates/scp-ffi/napi/src/ucan.rs
+++ b/crates/scp-ffi/napi/src/ucan.rs
@@ -391,126 +391,123 @@ pub(crate) async fn ucan_delegate_on(
         validate_capability_uri(cap).map_err(|e| napi::Error::from(ScpNapiError::from(e)))?;
     }
 
+    use scp_core::crypto::ucan::Attenuation;
+    use scp_core::crypto::ucan::mint::{DelegateParams, delegate_ucan};
+    use scp_core::crypto::ucan::validate::parse_ucan;
+
     // Delegation is available for any context whose delegator identity retains
     // custody — in-memory OR a production callback custody
     // (`identityCreateWithCustody`). The delegator's key is looked up from the
     // identity registry below (NOT the context creator's key).
-    {
-        use scp_core::crypto::ucan::Attenuation;
-        use scp_core::crypto::ucan::mint::{DelegateParams, delegate_ucan};
-        use scp_core::crypto::ucan::validate::parse_ucan;
+    let context_id = handle.context_id();
 
-        let context_id = handle.context_id();
+    // Parse the parent token.
+    let parsed_parent = parse_ucan(&parent_token).map_err(ScpNapiError::from)?;
 
-        // Parse the parent token.
-        let parsed_parent = parse_ucan(&parent_token).map_err(ScpNapiError::from)?;
+    // Defense-in-depth: verify delegator DID matches parent token's audience.
+    // The delegator must be the audience of the parent token to form a valid
+    // delegation chain (iss/aud linkage). scp-core enforces this too, but
+    // catching it at the bridge level provides clearer error messages and
+    // matches the WASM bridge's defense-in-depth check.
+    if delegator_did != parsed_parent.payload.aud {
+        return Err(napi::Error::from(ScpNapiError::Permission {
+            message: format!(
+                "delegator DID '{}' does not match parent token audience '{}'",
+                delegator_did, parsed_parent.payload.aud
+            ),
+            code: codes::PERM_3023.to_owned(),
+        }));
+    }
 
-        // Defense-in-depth: verify delegator DID matches parent token's audience.
-        // The delegator must be the audience of the parent token to form a valid
-        // delegation chain (iss/aud linkage). scp-core enforces this too, but
-        // catching it at the bridge level provides clearer error messages and
-        // matches the WASM bridge's defense-in-depth check.
-        if delegator_did != parsed_parent.payload.aud {
-            return Err(napi::Error::from(ScpNapiError::Permission {
-                message: format!(
-                    "delegator DID '{}' does not match parent token audience '{}'",
-                    delegator_did, parsed_parent.payload.aud
-                ),
-                code: codes::PERM_3023.to_owned(),
-            }));
-        }
-
-        // Build attenuated capabilities from the capability URI strings.
-        // Use CapabilityUri::from_str for validated parsing instead of ad-hoc
-        // string splitting.
-        let attenuations: Vec<Attenuation> = capabilities
-            .iter()
-            .map(|cap| {
-                let cap_uri_str = if cap.starts_with("scp:ctx:") {
-                    cap.clone()
-                } else {
-                    format!("scp:ctx:{context_id}/{cap}")
-                };
-                let parsed: CapabilityUri =
-                    cap_uri_str
-                        .parse()
-                        .map_err(|e: CoreUcanError| ScpNapiError::Permission {
-                            message: format!("invalid capability URI '{cap_uri_str}': {e}"),
-                            code: codes::PERM_3023.to_owned(),
-                        })?;
-                Ok(Attenuation {
-                    with: cap_uri_str,
-                    can: parsed.action().to_owned(),
-                })
-            })
-            .collect::<Result<Vec<_>, ScpNapiError>>()
-            .map_err(napi::Error::from)?;
-
-        // Get ceiling from the context handle for delegation-time enforcement (#339).
-        // Empty ceiling means the user passed `[]` — apply the default ceiling
-        // instead of `None` (which would mean unlimited). See #1419.
-        let ceiling_strings: std::collections::HashSet<String> =
-            handle.ceiling().into_iter().collect();
-        let ceiling = Some(if ceiling_strings.is_empty() {
-            scp_core::context::roles::default_ceiling().to_ucan_string_set()
-        } else {
-            ceiling_strings
-        });
-
-        // Look up the DELEGATOR's identity from the global identity registry.
-        // This is critical: the delegation must be signed with the delegator's
-        // Ed25519 key, NOT the context creator's key. The previous code used
-        // `handle.signing_key` (the context creator's key), which would produce
-        // tokens with invalid signatures when the delegator is not the creator.
-        let token = crate::runtime::with_identity(bi, &delegator_did, |entry| {
-            let params = DelegateParams {
-                parent_token: &parsed_parent,
-                delegator_did: &delegator_did,
-                delegator_key: &entry.identity.active_signing_key,
-                delegatee_did: &delegatee_did,
-                attenuated_capabilities: &attenuations,
-                lifetime_secs: 3600,
-                facts: None,
-                key_scope: None,
-                signing_key_id: None,
-                ceiling: ceiling.clone(),
+    // Build attenuated capabilities from the capability URI strings.
+    // Use CapabilityUri::from_str for validated parsing instead of ad-hoc
+    // string splitting.
+    let attenuations: Vec<Attenuation> = capabilities
+        .iter()
+        .map(|cap| {
+            let cap_uri_str = if cap.starts_with("scp:ctx:") {
+                cap.clone()
+            } else {
+                format!("scp:ctx:{context_id}/{cap}")
             };
-
-            // napi-rs async functions run on the tokio runtime, but
-            // `with_identity` holds a DashMap ref guard (sync). Use
-            // `tokio::task::block_in_place` to avoid nesting block_on calls.
-            let rt_handle = tokio::runtime::Handle::current();
-            let result = tokio::task::block_in_place(|| {
-                rt_handle.block_on(async {
-                    delegate_ucan(
-                        &params,
-                        entry.custody.as_ref(),
-                        &scp_primitives::SystemClock,
-                    )
-                    .await
-                })
-            });
-
-            result.map_err(ScpNapiError::from)
+            let parsed: CapabilityUri =
+                cap_uri_str
+                    .parse()
+                    .map_err(|e: CoreUcanError| ScpNapiError::Permission {
+                        message: format!("invalid capability URI '{cap_uri_str}': {e}"),
+                        code: codes::PERM_3023.to_owned(),
+                    })?;
+            Ok(Attenuation {
+                with: cap_uri_str,
+                can: parsed.action().to_owned(),
+            })
         })
+        .collect::<Result<Vec<_>, ScpNapiError>>()
         .map_err(napi::Error::from)?;
 
-        let data = NapiUcanTokenData {
-            token_id: token.payload.nnc.clone(),
-            issuer: token.payload.iss.clone(),
-            audience: token.payload.aud.clone(),
-            capabilities: token.payload.att.iter().map(|a| a.with.clone()).collect(),
-            #[allow(clippy::cast_precision_loss)]
-            expires_at: Some(token.payload.exp as f64),
+    // Get ceiling from the context handle for delegation-time enforcement (#339).
+    // Empty ceiling means the user passed `[]` — apply the default ceiling
+    // instead of `None` (which would mean unlimited). See #1419.
+    let ceiling_strings: std::collections::HashSet<String> = handle.ceiling().into_iter().collect();
+    let ceiling = Some(if ceiling_strings.is_empty() {
+        scp_core::context::roles::default_ceiling().to_ucan_string_set()
+    } else {
+        ceiling_strings
+    });
+
+    // Look up the DELEGATOR's identity from the global identity registry.
+    // This is critical: the delegation must be signed with the delegator's
+    // Ed25519 key, NOT the context creator's key. The previous code used
+    // `handle.signing_key` (the context creator's key), which would produce
+    // tokens with invalid signatures when the delegator is not the creator.
+    let token = crate::runtime::with_identity(bi, &delegator_did, |entry| {
+        let params = DelegateParams {
+            parent_token: &parsed_parent,
+            delegator_did: &delegator_did,
+            delegator_key: &entry.identity.active_signing_key,
+            delegatee_did: &delegatee_did,
+            attenuated_capabilities: &attenuations,
+            lifetime_secs: 3600,
+            facts: None,
+            key_scope: None,
+            signing_key_id: None,
+            ceiling: ceiling.clone(),
         };
 
-        increment_handle_count();
-        Ok(NapiUcanToken {
-            data,
-            encoded: token.encoded,
-            instance_id: bi.instance_id(),
-        })
-    }
+        // napi-rs async functions run on the tokio runtime, but
+        // `with_identity` holds a DashMap ref guard (sync). Use
+        // `tokio::task::block_in_place` to avoid nesting block_on calls.
+        let rt_handle = tokio::runtime::Handle::current();
+        let result = tokio::task::block_in_place(|| {
+            rt_handle.block_on(async {
+                delegate_ucan(
+                    &params,
+                    entry.custody.as_ref(),
+                    &scp_primitives::SystemClock,
+                )
+                .await
+            })
+        });
+
+        result.map_err(ScpNapiError::from)
+    })
+    .map_err(napi::Error::from)?;
+
+    let data = NapiUcanTokenData {
+        token_id: token.payload.nnc.clone(),
+        issuer: token.payload.iss.clone(),
+        audience: token.payload.aud.clone(),
+        capabilities: token.payload.att.iter().map(|a| a.with.clone()).collect(),
+        #[allow(clippy::cast_precision_loss)]
+        expires_at: Some(token.payload.exp as f64),
+    };
+
+    increment_handle_count();
+    Ok(NapiUcanToken {
+        data,
+        encoded: token.encoded,
+        instance_id: bi.instance_id(),
+    })
 }
 
 /// Per-bridge-instance implementation of [`ucan_revoke`].


### PR DESCRIPTION
## NAPI production callback custody (un-gate)

Makes NAPI callback key custody (OS-keychain / hardware-token / HSM-backed identities via `identityCreateWithCustody`) usable in **production** (non-`allow_in_memory_custody`) builds — reaching parity with the PyO3 reference bridge and UniFFI.

### Problem
NAPI already had full callback-custody infrastructure, but the **identity registry that retains a created identity** (so later sign / SCPID / event-log / export ops reach its custody) was `#[cfg(feature = "allow_in_memory_custody")]`-gated — a test-only feature. So a production keychain identity could be *created* but not *retained*: `identityCreateWithCustody` hard-errored, and signing/checkpoint/export had `#[cfg(not(...))]` build-feature stubs. The bare NAPI build didn't even compile. PyO3's equivalent registry is ungated; this was an oversight that left a production capability behind a test flag.

### Change (mechanical un-gate, mirrors PyO3)
- **Registry/retention** (`runtime.rs`): un-gate the `identity_registry` field + accessors (`register_identity`/`with_identity[_mut]`/`remove_identity`) + `NapiIdentityEntry`. The in-memory custody *backend* (`NapiKeyCustody::InMemory` variant) and the network/fullstack test surfaces stay gated.
- **Create + sign chain** (`scp.rs`/`identity.rs`/`context.rs`/`event_log.rs`/`ucan.rs`/`scpid.rs`/`server.rs`): removed the `#[cfg(not(feature))]` build-stubs so production paths sign via `KeyCustody::sign`. Each now **fails closed on the absence of retained custody** (`CTX-2040`/`PERM-3023`/`IDENT-1001`/`IDENT-1007`) — the correct, stronger boundary — rather than on a build flag.
- **Bare-build fix:** in-memory-only and `server`-only `#[napi]` methods (`identityRemove*`, `identityAttestDevice*`, `fullstack*`, relay/node startup) moved into separate `#[cfg(feature=…)] #[napi] impl Scp` blocks so napi-rs emits no dangling `_c_callback` registration symbol in feature-reduced builds.
- **Dep:** added `testing` to NAPI's unconditional `scp-platform` dep (exactly as PyO3 does) so the production callback path's `InMemoryPreRotationCustody` substrate + registry types are available. This exposes only the *types*; the in-memory custody backend stays gated.
- **CI lane:** new `rust-test-napi-production` job runs `cargo test -p scp-ffi-napi --features server` (the production config — no `allow_in_memory_custody`/`testing`), mechanically guarding the bare/production target + the feature-free export tests against silent regression.

### Reconciliation with #1774 (signed context export) + #1775 (mandatory storage)
- #1774's custody-delegated `context_export` (signs via `KeyCustody::sign`, no raw-key export, §23.16.8) is preserved; only the build-feature `PERM-3001` early-return was removed.
- Rebased onto #1775; the mandatory-storage `SCP` constructor (spec §17.6, `SCP-STORAGE-8000`) is untouched and orthogonal — verified no storage-bypass.

### Production feature resolution (verified)
`cargo tree --features server` confirms `scp-core/testing`, `scp-runtime/testing`, and `allow_in_memory_custody` are all **off** in production: the in-memory custody backend is uninstantiable and the relaxed `did:test:`/`did:key:` MLS creator-validation is compiled out (`did:dht:z*` required). The DID is derived from the callback's own public key, so no impersonation.

### Reviews
Full review roster across two consecutive clean double-zero passes on the final rebased HEAD (security, black-hat, red-hat, white-hat, alignment, bug-catcher, api-design, simplifier — all SHIP/CLEAN/APPROVED/ALIGNED). Local CI green: workspace clippy + 9084 nextest + bare/default/feature napi clippy + the new production-config lane + error-codes + fmt.

### Follow-ups filed (tracked, non-blocking)
- **#1671** (amended) — migrate the remaining `SigningKeyBytes` raw-seed-export sign sites (UCAN mint / SCPID / event-log checkpoint / join-pseudonym) to `KeyCustody::sign` across NAPI + PyO3.
- **#1776** — reconcile the canonical error code for "operation requires retained signing custody" across NAPI/PyO3/UniFFI (NAPI CTX-2040 vs PyO3 IDENT-1001).
- **#1777** — production-grade `PreRotationCustody` substrate (currently `InMemoryPreRotationCustody` in the production path on all callback-custody bridges).
- **#1778** — NAPI `identity_attest_device` parity (emits a standalone attestation vs PyO3 attaching to the DID document).
- **#1779** — hoist NAPI `identity_remove` out of the gated impl block for PyO3 parity.

Supersedes the stale stacked PR #1763 (which was based on the pre-actor-model signed-export branch and is now obsolete).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
