### PR TITLE
docs(matrix): make attest_device / verify_device_attestation rows honest

### DIFF
--- a/.docs/standards/sdk-capability-matrix.json
+++ b/.docs/standards/sdk-capability-matrix.json
@@ -110,17 +110,27 @@
         },
         {
           "name": "attest_device",
-          "python": true,
-          "typescript": true,
+          "python": false,
+          "typescript": false,
           "kotlin": true,
-          "swift": true
+          "swift": true,
+          "notes": "Only wired DeviceAttestation backend is the software InMemoryDeviceAttestation; production hardware attestation (Apple App Attest / Android Key Attestation) is unimplemented (ADR-025 stub). PyO3 and NAPI gate identity_attest_device out of production builds entirely; the UniFFI bridge exports it but its impl fails closed (SCP-IDENT-1010) in bare/production builds. Present in the Swift/Kotlin surface but always denies until ADR-025 hardware attestation lands.",
+          "exemptions": {
+            "python": "identity_attest_device #[cfg(allow_in_memory_custody)]-gated out of production PyO3 builds; only wired backend is software InMemoryDeviceAttestation (ADR-025 hardware attestation unimplemented)",
+            "typescript": "lives in an #[cfg(allow_in_memory_custody)]-gated #[napi] impl block, absent from production NAPI builds (ADR-025)"
+          }
         },
         {
           "name": "verify_device_attestation",
-          "python": true,
-          "typescript": true,
+          "python": false,
+          "typescript": false,
           "kotlin": true,
-          "swift": true
+          "swift": true,
+          "notes": "Companion verify for device attestation; same gating as attest_device. Only wired backend is software InMemoryDeviceAttestation (ADR-025 hardware attestation unimplemented). PyO3/NAPI gate it out of production builds; UniFFI exports it but fails closed in bare builds.",
+          "exemptions": {
+            "python": "identity_verify_device_attestation #[cfg(allow_in_memory_custody)]-gated out of production PyO3 builds; only wired backend is software InMemoryDeviceAttestation (ADR-025 hardware attestation unimplemented)",
+            "typescript": "lives in an #[cfg(allow_in_memory_custody)]-gated #[napi] impl block, absent from production NAPI builds (ADR-025)"
+          }
         },
         {
           "name": "execute_recovery",


### PR DESCRIPTION
Makes two capability-matrix rows honest. `attest_device` and `verify_device_attestation` claimed all-SDK presence, but the ops are `#[cfg(allow_in_memory_custody)]`-gated in every bridge (only software `InMemoryDeviceAttestation` is wired; production App Attest / Key Attestation unimplemented per ADR-025). PyO3/NAPI gate them out of production builds (→ `python/typescript: false` + exemptions); UniFFI exports them but fails closed `SCP-IDENT-1010` (→ `kotlin/swift: true`, present-in-surface, documented in notes). Human-approved enforcement-file honesty correction. `check-sdk-coverage.py` 0 errors; bridge-symmetry 0 findings. Doc-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)