### PR TITLE
chore(deny): ignore RUSTSEC-2026-0176 (pyo3 nth/nth_back OOB read)

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -80,6 +80,22 @@ ignore = [
     # libcrux/openmls dependency chain). No runtime exposure; no upstream
     # fix available. Awaiting hax-lib migration off proc-macro-error2.
     "RUSTSEC-2026-0173",
+    # pyo3: out-of-bounds read in `nth` / `nth_back` for `PyList` and
+    # `PyTuple` iterators. Direct dependency, but patched only in pyo3
+    # >= 0.29 (a five-minor-version breaking migration from our 0.24).
+    # The vulnerable path is unreachable in SCP: the PyO3 bridge never
+    # applies `nth`/`nth_back` (nor `skip`/`step_by`/`rev`) to a
+    # `PyList`/`PyTuple` iterator. The sole `.nth()` in the codebase
+    # (scp-ffi/src/mcp.rs) is on a Rust `SplitWhitespace` string iterator
+    # (HTTP status-line parse), and there are zero `.nth_back()` sites.
+    # Inbound `PyList` values are only constructed (`PyList::new`/`empty`)
+    # or forward-iterated via `.iter()` (`next()`); `PyTuple` is never
+    # Rust-iterated. The one Rust-tuple extraction (`(u8, u8)` for
+    # min_protocol_version in scp-ffi/src/context.rs) is safe because
+    # pyo3's tuple/array `FromPyObject` uses indexed `get_borrowed_item`,
+    # not the iterator's `nth`/`nth_back`. Awaiting a feasible pyo3 0.29
+    # migration.
+    "RUSTSEC-2026-0176",
 ]
 
 # ── Bans ────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Why

`cargo deny check advisories` started failing **repo-wide** in merge-queue CI on a newly-published advisory: **RUSTSEC-2026-0176** — out-of-bounds *read* in `nth`/`nth_back` for pyo3 `PyList`/`PyTuple` iterators. Every PR's `merge_group` job fails on it (observed on #1788 and #1787). pyo3 is a direct dependency at **0.24.2**; the advisory is patched **only in pyo3 >= 0.29** — a five-minor-version breaking migration.

## Decision: justified ignore (defer the 0.29 migration)

The vulnerable path is **unreachable in SCP**, verified against both the bridge source and pyo3 0.24.2's own extraction internals:
- The PyO3 bridge never applies `nth`/`nth_back` (nor `skip`/`step_by`/`rev`) to a `PyList`/`PyTuple` iterator. The sole `.nth()` in the codebase (`scp-ffi/src/mcp.rs`) is on a Rust `SplitWhitespace` string iterator; **zero** `.nth_back()` sites.
- Inbound `PyList` values are only forward-iterated via `.iter()` (`next()`); `PyTuple` is never Rust-iterated.
- The one Rust-tuple extraction `(u8,u8)` (`scp-ffi/src/context.rs`, `min_protocol_version`) is safe because pyo3's tuple/array `FromPyObject` uses **indexed `get_borrowed_item`**, not the iterator's `nth`/`nth_back` (confirmed in `pyo3-0.24.2/src/types/tuple.rs`).

`scp-ffi` is the only pyo3-linked crate, bounding the surface. An OOB *read* triggered only within the in-process trusted Python SDK trust domain, with no reachable call site, does not warrant a forced five-minor breaking migration. This matches the established pattern of the ~14 sibling justified ignores; the pyo3 0.29 migration is tracked as separate work.

## Verification

- `cargo deny check advisories` → `advisories ok`
- Double-zero review (dependency-safety, security, bug-catcher exposure-hunt, alignment) — two consecutive clean full passes; unreachability verified directly + indirectly against pyo3 0.24.2 source.

🤖 Generated with [Claude Code](https://claude.com/claude-code)