### PR TITLE
chore(deny): ignore RUSTSEC-2026-0177 (pyo3 new_closure Sync bound)

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -96,6 +96,16 @@ ignore = [
     # not the iterator's `nth`/`nth_back`. Awaiting a feasible pyo3 0.29
     # migration.
     "RUSTSEC-2026-0176",
+    # pyo3: missing `Sync` bound on `PyCFunction::new_closure` closures.
+    # Direct dependency; the bound was added only in pyo3 >= 0.29 (the same
+    # five-minor-version breaking migration from our 0.24 noted above). The
+    # advisory's hazard is a *non-Sync* closure capture executed concurrently
+    # across a GIL `Python::detach`. SCP's only two `new_closure` sites
+    # (scp-ffi/src/context.rs, exposing the Rust ed25519 signer to Python)
+    # capture solely `Sync` state — `Arc<ed25519_dalek::SigningKey>` (Send +
+    # Sync) and `Vec<u8>` — so the missing-bound exploit condition cannot be
+    # met by our usage. Awaiting a feasible pyo3 0.29 migration.
+    "RUSTSEC-2026-0177",
 ]
 
 # ── Bans ────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
A newly-published advisory **RUSTSEC-2026-0177** ("Missing `Sync` bound on `PyCFunction::new_closure` closures") on our pinned `pyo3 0.24.2` is failing `Rust / deny` on `main` and every open PR (the `Sync` bound was added only in pyo3 0.29 — a five-minor-version breaking migration, the same one tracked for RUSTSEC-2026-0176/#1789).

**Assessment — non-applicable to our usage.** The advisory's hazard is a *non-`Sync`* closure capture executed concurrently across a GIL `Python::detach`. SCP has exactly two `PyCFunction::new_closure` sites (`crates/scp-ffi/src/context.rs:6875,6887`, exposing the Rust ed25519 signer to Python); both capture only **`Sync`** state — `Arc<ed25519_dalek::SigningKey>` (Send + Sync) and `Vec<u8>` — so the missing-bound exploit condition cannot be met. pyo3 0.29 adds the bound to *prevent* non-`Sync` captures, which ours already aren't.

Adds the ignore to `deny.toml` with that rationale (matching the existing 0176 entry), pending the pyo3 0.29 migration. `cargo deny check advisories` → `advisories ok` locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)