### PR TITLE
fix(crypto): conform key distribution to RFC 9180 HPKE (§9.5)

### DIFF
--- a/.claude/agent-memory/cryptographer/MEMORY.md
+++ b/.claude/agent-memory/cryptographer/MEMORY.md
@@ -2,6 +2,8 @@
 
 ## Project: SCP Protocol Core
 
+- [HPKE RFC 9180 conformance](hpke-rfc9180-conformance.md) — FIXED the custom-ECIES finding: one hand-impl RFC 9180 core in scp-protocol/src/crypto/hpke.rs (A.1 KAT + hpke-rs oracle), custody Decap variant, 60->48 wire, all 5 paths conformed; C5 platform custody verified OK
+
 ### Merkle Tree (event_log/)
 - RFC 6962 domain separation: leaf=SHA-256(0x00||data), interior=SHA-256(0x01||left||right)
 - Consistent across tree.rs, proof.rs, checkpoint.rs, metrics.rs, phase2_integration.rs

--- a/.claude/agent-memory/cryptographer/hpke-rfc9180-conformance.md
+++ b/.claude/agent-memory/cryptographer/hpke-rfc9180-conformance.md
@@ -1,0 +1,110 @@
+# HPKE RFC 9180 Conformance (implemented 2026-06-13, branch fix/hpke-rfc9180-conformance)
+
+## FINAL INDEPENDENT GATE @498292b95 (2026-06-13): SHIP
+- Fresh read of full 22-file diff. hpke.rs conforms (LabeledExtract uses Some(salt)=empty-string per RFC5869 not zero-block; DHKEM kem_context=enc||pkRm KEM-suite-id; KeySchedule_base mode 0x00 HPKE-suite-id; seq-0 nonce=base_nonce). A.1 KATs assert genuine RFC intermediate values. 32 hpke tests green; oracle 3/3 (bidir+custody); wasm32 clean (hpke-rs dev-dep gated).
+- No surviving old construction (derive_aead_key/HPKE_DOMAIN_TAG/SCP-HPKE-V1/hkdf_derive_key/aes128gcm_* = 0 matches). 60->48 wire consistent. 5 distinct BE32-len-prefixed info separators + §9.18.2 registry complete. Custody open_with_external_dh binds enc||pkRm, documented contract. Zeroization complete at all custody/recovery sites (hkdf PRK limitation documented).
+- Consuming-path tests green (--features testing): hpke_backend 8, access wire 28, sender key_protocol 27, recovery psk 45.
+- NON-BLOCKING: spec S5 "device-enroll" purpose only "psk-rotate" wired (pre-existing separate flow, not regression); rotate_psk early-return len!=32 skips new_psk.zeroize (minor stack wipe miss); scp-runtime lib-test needs --features testing (unrelated TestInducePanic cfg, not in diff).
+
+
+
+Replaced the five hand-rolled custom-ECIES key-distribution constructions (mislabeled "HPKE")
+with ONE correct, hand-implemented RFC 9180 Base-mode single-shot core. Supersedes the
+hpke-custom-ecies-finding.md finding (now FIXED).
+
+## The core: crates/scp-protocol/src/crypto/hpke.rs
+- Suite: DHKEM(X25519, HKDF-SHA256) 0x0020 / HKDF-SHA256 0x0001 / AES-128-GCM 0x0001, Base mode.
+- Single-shot only: every seal generates fresh ephemeral, one Seal at seq 0 => nonce = base_nonce
+  (no ComputeNonce increment ever exercised).
+- Public API: `seal(recipient_pk, info, aad, pt) -> (enc:[u8;32], ct:Vec<u8>)`,
+  `open(recipient_sk, enc, info, aad, ct)`, `custody::open_with_external_dh(dh, pkRm, enc, info, aad, ct)`.
+  `seal_with_ephemeral` is `#[cfg(test)] pub(crate)` — fixed-skEm KAT injection only.
+- Labeled KDF over RustCrypto hkdf/sha2/aes-gcm + x25519-dalek (zero new prod deps, wasm32-clean).
+  KEM suite_id="KEM"||0x0020; HPKE suite_id="HPKE"||kem||kdf||aead. LabeledExtract uses
+  `Hkdf::extract(Some(salt),...)` (NOT None — None gives all-zero salt block, wrong per RFC).
+  LabeledExpand uses `Hkdf::from_prk`. KeySchedule_base: mode 0x00, empty psk/psk_id.
+- KAT: RFC 9180 Appendix A.1, transcribed from the RFC text (rfc-editor.org/rfc/rfc9180.txt).
+  seq-0 ct = f938558b5d72f1a23810b4be2ab4f84331acc02fc97babc53a52ae8218a355a96d8770ac83d07bea87e13c512a
+  (MATCHED the plan §11-C2 prior exactly). Asserts intermediate shared_secret/key/base_nonce too.
+  Custody-path KAT (DH(skRm,enc)) also pinned.
+- Oracle: hpke-rs 0.6 dev-dep (tests/hpke_oracle.rs, #![cfg(not(wasm32))]). Types via
+  `hpke_rs::hpke_types::{Aead,Kdf,Kem}Algorithm`, `Hpke::<HpkeRustCrypto>::new(Mode::Base, DhKem25519,
+  HkdfSha256, Aes128Gcm)`. Bidirectional. GOTCHA: hpke-rs `open` rejects EMPTY plaintext as
+  InvalidInput (bytes_to_option maps empty->None) — our-seal->ref-open test must use >=1 byte pt;
+  empty is covered by our own roundtrip + ref-seal->our-open direction.
+
+## Custody Decap (C1)
+- open_with_external_dh under hpke::custody submodule (NOT top-level). Caller contract (load-bearing):
+  dh = KeyCustody::dh_agree(handle, enc), pkRm = KeyCustody::public_key(handle) — SAME handle, SAME enc.
+  Binds enc||pkRm via kem_context => closes the UKS gap the legacy raw-DH-export paths had.
+- SharedSecret::as_bytes() returns &[u8;32] (deref with `*`, NOT try_into). PublicKey::as_bytes()
+  returns &[u8] (use try_into). traits.rs:182/250/277.
+
+## Wire change: 60 -> 48 bytes
+- SenderKeyResponse.hpke_sealed_key [u8;60]->[u8;48]; serde_hpke_sealed_60 -> serde_hpke_sealed_48.
+  60 was nonce(12)+ct(32)+tag(16); 48 is ct(32)+tag(16), nonce internal per RFC 9180.
+- handle_bridge_shadow_key_request 60->48. provider.rs 4 sites. AccessKeyResponse uses Vec (flexible).
+
+## Call sites (all now route through hpke::)
+- scp-protocol: key_protocol_verify hpke_seal/open_sender_key; envelope_seal ecies_seal/open ->
+  hpke_seal_invitation/hpke_open_invitation (removed redundant eph-pub-in-AAD, RFC binds via kem_context);
+  broadcast.rs NEW build_broadcast_key_hpke_info/aad + seal_broadcast_key_to_subscriber/open_broadcast_key.
+- scp-runtime: key_protocol.rs + access_keys/wire.rs custody-open via open_with_external_dh; recovery.rs
+  PSK now HPKE AES-128 (was salted-HKDF AES-256), info "scp-private-state-v1"||len(did)||did||"psk-rotate",
+  empty aad, wire enc(32)||ct(48)=80B; PskRotationParams gained `did`; added unwrap_psk_for_device.
+  hpke_backend.rs trait fixed: seal->(enc,ct), unseal+aad, ProductionHpkeBackend is thin shim over core.
+  Deleted derive_aead_key + HPKE_DOMAIN_TAG "SCP-HPKE-V1:" (code-invented, in no spec).
+
+## C5 — platform custody public_key for X25519: BOTH CORRECT, no fix needed
+- Swift AppleKeyCustody.publicKey (AppleKeyCustody.swift:620-624): X25519 handle ->
+  Curve25519.KeyAgreement.PrivateKey(rawRepresentation:).publicKey.rawRepresentation (raw 32B). Test exists.
+- Kotlin AndroidKeyCustody (platform/AndroidKeyCustody.kt:790-808): X25519 always SOFTWARE,
+  softwareKeyOps.publicKey -> X25519PublicKeyParameters.encoded (raw 32B). dhAgree validates key type.
+
+## Spec edits landed first (artifact-flow): S1 broadcast len-prefixes (05-contexts §5.14.2),
+## S2 registry rows (09 §9.18.3), S3 invitation HPKE (05 §5.12.3.1), S4 custody-Decap wording
+## (09 §9.16.2), S5 psk-rotate purpose (03 §3.7.2).
+
+## C4 (NOT done here — orchestrator's): file the broadcast pull-protocol wiring story (SCP-227).
+## The broadcast seal/open HELPERS exist now but have no production caller yet (dead until wired).
+
+## Re-audit @609fd7caa (2026-06-13) — VERDICT: 1 LOW + 2 NIT, no CRITICAL/HIGH/MED
+- hpke.rs core verified line-by-line vs RFC 9180: LabeledExtract/Expand, kem/hpke suite_id, DHKEM
+  ExtractAndExpand (eae_prk + kem_context=enc||pkRm), KeySchedule_base (psk_id_hash/info_hash/secret/
+  key/base_nonce, mode 0x00), seq-0 nonce=base_nonce. CORRECT.
+- A.1 KATs are GENUINE RFC 9180 A.1.1 values (info/skEm/enc/skRm/pkRm/SS/key/base_nonce/ct all verified).
+  14 lib KATs + 3 hpke-rs oracle tests pass (both directions + custody). Oracle is real, not a no-op.
+- LOW (zeroization): runtime custody open sites copy raw DH into BARE [u8;32] not Zeroizing:
+  access_keys/wire.rs:381 `let dh_bytes: [u8;32] = *dh.as_bytes();` and
+  sender_keys/key_protocol.rs:347 same. hpke.rs core wraps every such copy in Zeroizing (lines 362/388/407);
+  runtime forwarding regresses it. SharedSecret zeroizes on drop but the explicit byte copy escapes.
+  Neither file imports Zeroizing. recovery.rs unwrap_psk plaintext Vec also unzeroed (key_bytes moved to SenderKey).
+- NIT: scp-private-state-v1 string shared by PSK HPKE info (recovery.rs:661) AND private_state.rs:265
+  routing-ID HKDF. NOT a real collision (different salt/labels/suite_id/layout; never same KDF invocation)
+  but an audit smell.
+- NIT: key_protocol_verify.rs:64 docstring omits length-prefixes from abbreviated info description;
+  actual build_hpke_info (line 710) IS correctly BE32 length-prefixed.
+- WASM interop: NO drift. scp-protocol (where hpke.rs lives) compiles wasm32 and WASM re-exports it
+  (sender_key.rs:7). ADR-034 reimpl constraint is for scp-runtime/tokio, not scp-protocol HPKE.
+- Custody open_with_external_dh soundness CONFIRMED: enc||pkRm bound into SS; wrong dh/pkRm/enc => clean
+  AEAD tag failure only, no oracle (identical error string). custody_wrong_pkrm_fails proves pkRm binding.
+- Invitation AAD removal of eph-pubkey SAFE: enc flows kem_context->SS->key; tampered_enc_fails proves it.
+- Unplanned touches (platform/traits.rs, context/membership.rs): doc-comment-only (ECIES->HPKE), correct.
+
+## Review-fix round APPLIED (2026-06-13, commits 6ef4a47/6d3153f/6448e05/f44ea06 on branch)
+- FIX1 (zeroize regression) DONE: wire.rs open_access_key_response + key_protocol.rs
+  open_sender_key_response now `Zeroizing::new(*dh.as_bytes())` and recovered plaintext Vec
+  wrapped in Zeroizing; recovery.rs unwrap_psk_for_device plaintext wrapped too. Both files now
+  `use zeroize::Zeroizing`. NOTE: &Zeroizing<[u8;32]> deref-coerces to &[u8;32] at the open call
+  site (Zeroizing: Deref) — call sites unchanged, builds clean.
+- FIX3 (stale docstring) DONE: key_protocol_verify.rs HPKE_INFO_PREFIX docstring now shows the BE32
+  length prefixes matching build_hpke_info.
+- FIX4 (field parity / bounded deser) DONE: AccessKeyResponse.hpke_sealed_key changed from
+  Vec<u8>+serde_bytes to [u8;48] with serde_hpke_sealed_48 (matches SenderKeyResponse). VERIFIED
+  invariant: AccessKey is [u8;32], open enforces 32-byte plaintext => ct always 48 (32+16 GCM tag).
+  Producer converts seal Vec via try_into with explicit length-check error.
+- FIX2 (broadcast test gap) DONE: added 4 ciphertext-level negatives to broadcast.rs tests:
+  tamper-ct, tamper-enc, wrong-recipient, and cross-path domain sep (seal under sender-key info/aad,
+  prove open_broadcast_key rejects at AEAD). Kept the assert_ne! builder tests. GOTCHA: pre-commit
+  clippy hook enforces clippy::similar_names — subscriber_a/_b_secret rejected; renamed to
+  recipient_secret/intruder_secret.

--- a/.docs/specs/03-identity.md
+++ b/.docs/specs/03-identity.md
@@ -680,7 +680,14 @@ Existing device (Device A) enrolls new device (Device B):
 8. Device B can now decrypt and append to the private state event log.
 ```
 
-**HPKE suite.** Device enrollment and PSK distribution use DHKEM(X25519, HKDF-SHA256), HKDF-SHA256, AES-128-GCM — the same HPKE suite as MLS (§9.5) and sender key distribution (§9.16.2). The `info` parameter includes the domain separator `"scp-private-state-v1"` concatenated with the DID and purpose string to prevent cross-protocol confusion with sender key HPKE (`"scp-sender-key-v1"`) or access key HPKE (`"scp-access-key-v1"`).
+**HPKE suite.** Device enrollment and PSK distribution use DHKEM(X25519, HKDF-SHA256), HKDF-SHA256, AES-128-GCM — the same HPKE suite as MLS (§9.5) and sender key distribution (§9.16.2). The `info` parameter includes the domain separator `"scp-private-state-v1"` concatenated with the DID and purpose string to prevent cross-protocol confusion with sender key HPKE (`"scp-sender-key-v1"`) or access key HPKE (`"scp-access-key-v1"`). The full `info` construction is `"scp-private-state-v1" || len(did) || did || purpose`, where `did` is preceded by a 4-byte big-endian unsigned length prefix (per §9.5.1 encoding rules) and `purpose` is a fixed-version UTF-8 string with no length prefix. The `aad` is empty (the `info` already binds the DID, and a fresh HPKE context — fresh encapsulation — is used per device, so there is no cross-recipient substitution surface).
+
+**Purpose strings.** Two purposes are defined, distinguishing the two flows that wrap a PSK to a device key:
+
+- `"device-enroll"` — initial PSK distribution when a device is enrolled (the flow above) and during trusted-device / social recovery (recovery IS enrollment, §3.3).
+- `"psk-rotate"` — re-wrapping a freshly generated PSK to all remaining enrolled devices when a `PskRotated` event is emitted: on device removal (above) and on compromise recovery key rotation (§9.12 step 6).
+
+The purpose string binds each HPKE ciphertext to its flow, so a `device-enroll` wrap cannot be opened in a `psk-rotate` context (different `info` produces a different HPKE key schedule, causing AEAD failure).
 
 **Device removal:**
 

--- a/.docs/specs/05-contexts.md
+++ b/.docs/specs/05-contexts.md
@@ -807,6 +807,15 @@ MetadataSnapshot {
 3. If accepted, process `welcome_message` via MLS to join the group (Encrypted contexts) or initialize subscriber state (Broadcast contexts).
 4. Use `context_metadata_key` to derive the metadata routing ID for ongoing metadata retrieval.
 
+**HPKE encryption.** The serialized `InvitationBundle` (and, symmetrically, the `JoinResponse` of §5.12.3.2) is encrypted to the recipient with HPKE Base mode (RFC 9180) using the SCP HPKE suite (§9.5): DHKEM(X25519, HKDF-SHA256), HKDF-SHA256, AES-128-GCM. The recipient X25519 public key is derived from their Ed25519 identity key via RFC 7748 birational mapping. The HPKE `info` and `aad` parameters are:
+
+```
+info = "scp-invitation-v1" || len(context_id) || context_id || len(creator_did) || creator_did
+aad  = "scp-invitation-aad-v1" || len(context_id) || context_id || len(creator_did) || creator_did
+```
+
+Where `context_id` and `creator_did` are UTF-8 bytes, each preceded by a 4-byte big-endian unsigned length prefix (`len(...)`) per the §9.5.1 encoding rules. The wire output is `(enc, ct)` where `enc` is the 32-byte HPKE encapsulated key and `ct` is the AEAD ciphertext-and-tag — the RFC 9180 KEM context binds `enc` into the key schedule (`kem_context = enc || pkRm`, RFC 9180 §4.1), so `enc` is NOT additionally carried in `aad`. The `"scp-invitation-v1"` / `"scp-invitation-aad-v1"` domain separators are distinct from sender-key (`"scp-sender-key-v1"`), access-key (`"scp-access-key-v1"`), broadcast-key (`"scp-broadcast-key-v1"`), and private-state (`"scp-private-state-v1"`) HPKE strings.
+
 #### 5.12.3.2 JoinResponse Wire Format
 
 After accepting an invitation bundle, the invitee sends a join response back to the creator via the relay. The response is serialized as MessagePack and encrypted to the creator's public key.
@@ -1395,11 +1404,11 @@ Each author holds an AES-256-GCM broadcast key with a monotonic epoch counter. T
 **HPKE parameters for broadcast key distribution.** Broadcast key distribution uses HPKE Base mode (RFC 9180) with the same suite as sender key distribution (§9.16.2): DHKEM(X25519, HKDF-SHA256), HKDF-SHA256, AES-128-GCM. The `info` and `aad` parameters use a distinct domain separator:
 
 ```
-info = "scp-broadcast-key-v1" || context_id || author_did || epoch_bytes
-aad  = context_id || author_did || epoch_bytes
+info = "scp-broadcast-key-v1" || len(context_id) || context_id || len(author_did) || author_did || epoch_bytes
+aad  = len(context_id) || context_id || len(author_did) || author_did || epoch_bytes
 ```
 
-Where `context_id` and `author_did` are UTF-8 bytes and `epoch_bytes` is the 8-byte big-endian encoding of the broadcast key epoch. The `"scp-broadcast-key-v1"` domain separator is distinct from `"scp-sender-key-v1"` (encrypted contexts) and `"scp-access-key-v1"` (content access keys), preventing cross-protocol key confusion. The three domain separators ensure that an HPKE ciphertext produced in one protocol cannot be replayed in another — different `info` values produce different HPKE key schedules.
+Where `context_id` and `author_did` are UTF-8 bytes, each preceded by a 4-byte big-endian unsigned length prefix (`len(...)`) per the §9.5.1 encoding rules, and `epoch_bytes` is the 8-byte big-endian encoding of the broadcast key epoch (fixed-width, no length prefix needed). The length prefixes prevent boundary-shift ambiguity, where a `context_id` suffix could masquerade as an `author_did` prefix — matching the sender-key (§9.16.2) and access-key (§9.17.1) `info`/`aad` constructions. The `"scp-broadcast-key-v1"` domain separator is distinct from `"scp-sender-key-v1"` (encrypted contexts) and `"scp-access-key-v1"` (content access keys), preventing cross-protocol key confusion. The three domain separators ensure that an HPKE ciphertext produced in one protocol cannot be replayed in another — different `info` values produce different HPKE key schedules.
 
 ### 5.14.3 Subscriber Registration
 

--- a/.docs/specs/09-security-model.md
+++ b/.docs/specs/09-security-model.md
@@ -1285,8 +1285,8 @@ This suite matches the MLS ciphersuite (§9.5) and the DID-to-DID HPKE suite, mi
 
 **Open (recipient-side):**
 
-1. Call `SetupBaseR(enc, wrapping_secret_key, info)` (RFC 9180 §5.1.1) to obtain `recipient_context`, where `enc` is the `ephemeral_pubkey` from the response. The wrapping secret key is computed inside the `KeyCustody` boundary via `dh_agree(wrapping_key_handle, enc)`.
-2. Call `recipient_context.Open(aad, ct)` to recover `sender_key_bytes`, where `ct` is the `hpke_sealed_key` from the response.
+1. Compute the KEM Diffie-Hellman output `dh = DH(wrapping_secret_key, enc)` inside the `KeyCustody` boundary via `dh_agree(wrapping_key_handle, enc)`, where `enc` is the `ephemeral_pubkey` from the response. The wrapping private key never leaves custody — only the raw `dh` output (and the recipient's own public key `pkRm`, obtained via `KeyCustody::public_key(wrapping_key_handle)`) cross the boundary. RFC 9180 DHKEM Decap then completes outside custody: `shared_secret = ExtractAndExpand(dh, enc || pkRm)` (RFC 9180 §4.1), binding both `enc` and `pkRm` into the KEM shared secret. This is equivalent to `SetupBaseR(enc, wrapping_secret_key, info)` (RFC 9180 §5.1.1) for software-held keys, but splits the single non-extractable scalar multiplication into custody while keeping the rest of Decap + KeySchedule in software.
+2. Run `KeySchedule_base` over `shared_secret` and `info` to derive the AEAD `key`/`base_nonce`, then `Open(aad, ct)` to recover `sender_key_bytes`, where `ct` is the `hpke_sealed_key` from the response.
 
 **`info` parameter (domain separation):**
 
@@ -1618,6 +1618,11 @@ This section consolidates all HKDF labels, HPKE info prefixes, HMAC domain strin
 |-------------|----------|-------------|----------------|
 | `"scp-sender-key-v1"` | Sender key HPKE encapsulation | `"scp-sender-key-v1" \|\| BE32(len(context_id)) \|\| context_id \|\| BE32(len(sender_did)) \|\| sender_did \|\| epoch_BE` | §9.16.2 |
 | `"scp-access-key-v1"` | Access key HPKE encapsulation | `"scp-access-key-v1" \|\| BE32(len(context_id)) \|\| context_id \|\| BE32(len(member_did)) \|\| member_did \|\| epoch_bytes` | §9.17.1 |
+| `"scp-broadcast-key-v1"` | Broadcast key HPKE encapsulation | `"scp-broadcast-key-v1" \|\| BE32(len(context_id)) \|\| context_id \|\| BE32(len(author_did)) \|\| author_did \|\| epoch_bytes` | §5.14.2 |
+| `"scp-invitation-v1"` | Invitation/join HPKE encapsulation | `"scp-invitation-v1" \|\| BE32(len(context_id)) \|\| context_id \|\| BE32(len(creator_did)) \|\| creator_did` | §5.12.3.1 |
+| `"scp-private-state-v1"` | PSK distribution HPKE encapsulation | `"scp-private-state-v1" \|\| BE32(len(did)) \|\| did \|\| purpose` where `purpose` ∈ {`"device-enroll"`, `"psk-rotate"`} | §3.7.2 |
+
+`"scp-invitation-aad-v1"` is an AEAD-AAD domain string (not an HPKE `info` prefix): `aad = "scp-invitation-aad-v1" \|\| BE32(len(context_id)) \|\| context_id \|\| BE32(len(creator_did)) \|\| creator_did` (§5.12.3.1). The broadcast-key and access-key `aad` strings reuse the `info` field encoding without the domain-separator prefix (§5.14.2, §9.17.1).
 
 **HKDF labels** — used in HKDF-SHA-256 `salt` or `info` parameters:
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5415,6 +5415,8 @@ dependencies = [
  "getrandom 0.3.4",
  "hex",
  "hkdf",
+ "hpke-rs",
+ "hpke-rs-rust-crypto",
  "jsonschema",
  "lru 0.16.3",
  "metrics",

--- a/crates/scp-platform/src/traits.rs
+++ b/crates/scp-platform/src/traits.rs
@@ -459,7 +459,7 @@ pub trait KeyCustody: Send + Sync {
     /// then performs X25519 DH with the peer's X25519 public key. The private key never
     /// leaves the custody boundary.
     ///
-    /// Used for ECIES decryption of invitation bundles (spec §5.12.3).
+    /// Used for RFC 9180 HPKE decryption of invitation bundles (spec §5.12.3.1).
     ///
     /// # Errors
     ///

--- a/crates/scp-protocol/Cargo.toml
+++ b/crates/scp-protocol/Cargo.toml
@@ -54,6 +54,13 @@ rmp-serde = { workspace = true }
 proptest = "1"
 scp-primitives = { path = "../scp-primitives" }
 scp-event-log = { path = "../scp-event-log", features = ["testing"] }
+# RFC 9180 reference implementation — used ONLY as a cross-validation oracle
+# for the hand-implemented `crypto::hpke` core. Already present in Cargo.lock
+# via openmls; dev-deps never ship in production or wasm32 builds. MPL-2.0
+# (allowed in deny.toml). Gated #[cfg(not(target_arch = "wasm32"))] in the
+# oracle test so `cargo check --target wasm32` is unaffected.
+hpke-rs = "0.6"
+hpke-rs-rust-crypto = "0.6"
 
 [lints]
 workspace = true

--- a/crates/scp-protocol/src/context/membership.rs
+++ b/crates/scp-protocol/src/context/membership.rs
@@ -552,12 +552,12 @@ pub enum ContextEvent {
     },
     /// An MLS Welcome was generated for a newly added member.
     ///
-    /// The application layer must ECIES-encrypt and deliver it to the
-    /// joiner's personal routing ID (spec §5.12.3, issue #1311).
+    /// The application layer must HPKE-encrypt (RFC 9180, §5.12.3.1) and
+    /// deliver it to the joiner's personal routing ID (spec §5.12.3).
     WelcomeGenerated {
-        /// Context ID for ECIES domain binding.
+        /// Context ID for HPKE `info`/`aad` domain binding.
         context_id: String,
-        /// DID of the context creator (for ECIES domain binding).
+        /// DID of the context creator (for HPKE `info`/`aad` domain binding).
         creator_did: DID,
         /// DID of the member being invited.
         member_did: DID,

--- a/crates/scp-protocol/src/crypto/envelope_seal.rs
+++ b/crates/scp-protocol/src/crypto/envelope_seal.rs
@@ -77,7 +77,7 @@ pub fn ed25519_pubkey_to_x25519(ed25519_pub: &[u8; 32]) -> Result<[u8; 32], Enve
     Ok(verifying_key.to_montgomery().to_bytes())
 }
 
-/// Builds the HKDF info string for invitation ECIES.
+/// Builds the HPKE `info` string for invitation HPKE (§5.12.3.1).
 /// Format: `"scp-invitation-v1" || len(context_id) || context_id || len(creator_did) || creator_did`
 fn build_invitation_info(context_id: &str, creator_did: &str) -> Vec<u8> {
     let mut info = Vec::new();

--- a/crates/scp-protocol/src/crypto/envelope_seal.rs
+++ b/crates/scp-protocol/src/crypto/envelope_seal.rs
@@ -1,25 +1,23 @@
-//! Generalized ECIES envelope seal/open for arbitrary-length payloads.
+//! RFC 9180 HPKE envelope seal/open for arbitrary-length payloads.
 //!
-//! Reuses the HKDF-SHA256 + AES-128-GCM construction from `sender_keys/key_protocol.rs`
-//! but with variable-length plaintext and invitation-specific domain separators.
-//! Used for invitation bundle and join response encryption (spec §5.12.3).
+//! Used for invitation bundle and join response encryption (spec §5.12.3.1),
+//! over the shared [`crate::crypto::hpke`] core (RFC 9180 Base mode, §9.5).
+//! The invitation-specific `info`/`aad` domain separators distinguish these
+//! ciphertexts from sender-key, access-key, broadcast-key, and private-state
+//! HPKE.
 
 use sha2::{Digest, Sha256};
-use x25519_dalek::{EphemeralSecret, PublicKey as X25519Pub};
-use zeroize::Zeroizing;
 
-use super::sender_keys::key_protocol_verify::{
-    aes128gcm_decrypt, aes128gcm_encrypt, hkdf_derive_key,
-};
+use crate::crypto::hpke;
 
 /// Errors from envelope seal/open operations.
 #[derive(Debug, thiserror::Error)]
 pub enum EnvelopeSealError {
-    /// ECIES encryption failed.
-    #[error("ECIES encryption failed: {0}")]
+    /// HPKE encryption failed.
+    #[error("HPKE encryption failed: {0}")]
     SealFailed(String),
-    /// ECIES decryption failed.
-    #[error("ECIES decryption failed: {0}")]
+    /// HPKE decryption failed.
+    #[error("HPKE decryption failed: {0}")]
     OpenFailed(String),
 }
 
@@ -89,96 +87,75 @@ fn build_invitation_info(context_id: &str, creator_did: &str) -> Vec<u8> {
     info
 }
 
-/// Builds the AES-GCM AAD for invitation ECIES (distinct from HKDF info).
-/// Format: `"scp-invitation-aad-v1" || len(context_id) || context_id || len(creator_did) || creator_did || ephemeral_pubkey[32]`
+/// Builds the AEAD AAD for invitation HPKE (distinct from the HPKE `info`).
+/// Format: `"scp-invitation-aad-v1" || len(context_id) || context_id || len(creator_did) || creator_did`
 ///
-/// Including the ephemeral public key in the AAD binds the ciphertext to
-/// the specific DH exchange, preventing ephemeral key substitution attacks.
-fn build_invitation_aad(context_id: &str, creator_did: &str, ephemeral_pub: &[u8; 32]) -> Vec<u8> {
+/// The ephemeral public key (`enc`) is NOT carried in the AAD: RFC 9180 binds
+/// `enc` into the key schedule via `kem_context = enc || pkRm` (§4.1), so an
+/// ephemeral-key substitution already produces a different derived key and
+/// fails AEAD verification. Including `enc` in the AAD would be redundant (and
+/// caused a build-AAD-before-enc-exists ordering wart). See spec §5.12.3.1.
+fn build_invitation_aad(context_id: &str, creator_did: &str) -> Vec<u8> {
     let mut aad = Vec::new();
     aad.extend_from_slice(b"scp-invitation-aad-v1");
     append_length_prefixed(&mut aad, context_id.as_bytes());
     append_length_prefixed(&mut aad, creator_did.as_bytes());
-    aad.extend_from_slice(ephemeral_pub);
     aad
 }
 
-/// ECIES-seals an arbitrary-length payload to a recipient's X25519 public key.
+/// HPKE-seals an arbitrary-length payload to a recipient's X25519 public key
+/// (RFC 9180 Base mode, §5.12.3.1).
 ///
-/// Returns `(sealed_bytes, ephemeral_pubkey)` where `sealed_bytes` = `nonce || ciphertext || tag`.
-/// Uses HKDF-SHA256 + AES-128-GCM, matching the sender key ECIES construction.
+/// Returns `(sealed, enc)` where `sealed` is the HPKE ciphertext
+/// (`ciphertext || tag`) and `enc` is the 32-byte HPKE encapsulated key. There
+/// is no external nonce — the AEAD nonce is derived internally by RFC 9180.
 ///
 /// # Errors
 ///
-/// Returns [`EnvelopeSealError::SealFailed`] if encryption fails.
-pub fn ecies_seal(
+/// Returns [`EnvelopeSealError::SealFailed`] if HPKE sealing fails.
+pub fn hpke_seal_invitation(
     plaintext: &[u8],
     recipient_x25519_pub: &[u8; 32],
     context_id: &str,
     creator_did: &str,
 ) -> Result<(Vec<u8>, [u8; 32]), EnvelopeSealError> {
-    let ephemeral_secret = EphemeralSecret::random_from_rng(rand::rngs::OsRng);
-    let ephemeral_public = X25519Pub::from(&ephemeral_secret);
-    let ephemeral_pub_bytes = ephemeral_public.to_bytes();
-
-    let recipient_key = X25519Pub::from(*recipient_x25519_pub);
-    let shared_secret = ephemeral_secret.diffie_hellman(&recipient_key);
-
     let info = build_invitation_info(context_id, creator_did);
-    let aad = build_invitation_aad(context_id, creator_did, &ephemeral_pub_bytes);
+    let aad = build_invitation_aad(context_id, creator_did);
 
-    // x25519-dalek v2 SharedSecret implements Zeroize + zeroize(drop) when the
-    // zeroize feature is enabled (which it is). Wrapping in Zeroizing is
-    // defense-in-depth — ensures zeroing even if the feature is ever removed.
-    let shared_bytes = Zeroizing::new(*shared_secret.as_bytes());
-    let aes_key = hkdf_derive_key(shared_bytes.as_ref(), &info)
+    let (enc, ct) = hpke::seal(recipient_x25519_pub, &info, &aad, plaintext)
         .map_err(|e| EnvelopeSealError::SealFailed(e.to_string()))?;
 
-    let sealed = aes128gcm_encrypt(&aes_key, plaintext, &aad)
-        .map_err(|e| EnvelopeSealError::SealFailed(e.to_string()))?;
-
-    Ok((sealed, ephemeral_pub_bytes))
+    Ok((ct, enc))
 }
 
-/// ECIES-opens a sealed payload using a local X25519 secret key.
+/// HPKE-opens a sealed payload using a local (software-held) X25519 secret key.
 ///
-/// The `ephemeral_pub` is the sender's ephemeral X25519 public key from the seal operation.
+/// The `ephemeral_pub` is the HPKE encapsulated key (`enc`) from the seal
+/// operation.
 ///
 /// # Errors
 ///
-/// Returns [`EnvelopeSealError::OpenFailed`] if decryption fails (wrong key, tampered
-/// ciphertext, wrong context/DID binding).
-pub fn ecies_open(
+/// Returns [`EnvelopeSealError::OpenFailed`] if HPKE open fails (wrong key,
+/// tampered ciphertext/enc, wrong context/DID binding).
+pub fn hpke_open_invitation(
     sealed: &[u8],
     ephemeral_pub: &[u8; 32],
     local_x25519_secret: &[u8; 32],
     context_id: &str,
     creator_did: &str,
 ) -> Result<Vec<u8>, EnvelopeSealError> {
-    let ephemeral_key = X25519Pub::from(*ephemeral_pub);
-    // Wrap the dereferenced secret in Zeroizing so the stack copy is zeroed
-    // on drop (StaticSecret::from consumes by value, creating a second copy).
-    let secret_copy = Zeroizing::new(*local_x25519_secret);
-    let local_secret = x25519_dalek::StaticSecret::from(*secret_copy);
-    let shared_secret = local_secret.diffie_hellman(&ephemeral_key);
-
     let info = build_invitation_info(context_id, creator_did);
-    let aad = build_invitation_aad(context_id, creator_did, ephemeral_pub);
+    let aad = build_invitation_aad(context_id, creator_did);
 
-    // x25519-dalek v2 SharedSecret implements Zeroize + zeroize(drop) when the
-    // zeroize feature is enabled (which it is). Wrapping in Zeroizing is
-    // defense-in-depth — ensures zeroing even if the feature is ever removed.
-    let shared_bytes = Zeroizing::new(*shared_secret.as_bytes());
-    let aes_key = hkdf_derive_key(shared_bytes.as_ref(), &info)
-        .map_err(|e| EnvelopeSealError::OpenFailed(e.to_string()))?;
-
-    aes128gcm_decrypt(&aes_key, sealed, &aad)
+    hpke::open(local_x25519_secret, ephemeral_pub, &info, &aad, sealed)
         .map_err(|e| EnvelopeSealError::OpenFailed(e.to_string()))
 }
 
 #[cfg(test)]
 #[allow(clippy::unwrap_used, clippy::expect_used, clippy::panic)]
 mod tests {
+    use x25519_dalek::PublicKey as X25519Pub;
+
     use super::*;
 
     #[test]
@@ -188,9 +165,9 @@ mod tests {
 
         let plaintext = b"hello world, this is an invitation bundle";
         let (sealed, eph_pub) =
-            ecies_seal(plaintext, public.as_bytes(), "ctx-123", "did:dht:z6MkAlice").unwrap();
+            hpke_seal_invitation(plaintext, public.as_bytes(), "ctx-123", "did:dht:z6MkAlice").unwrap();
 
-        let recovered = ecies_open(
+        let recovered = hpke_open_invitation(
             &sealed,
             &eph_pub,
             &secret.to_bytes(),
@@ -207,7 +184,7 @@ mod tests {
         let secret = x25519_dalek::StaticSecret::random_from_rng(rand::rngs::OsRng);
         let public = X25519Pub::from(&secret);
 
-        let (sealed, eph_pub) = ecies_seal(
+        let (sealed, eph_pub) = hpke_seal_invitation(
             b"payload",
             public.as_bytes(),
             "ctx-123",
@@ -215,7 +192,7 @@ mod tests {
         )
         .unwrap();
 
-        let result = ecies_open(
+        let result = hpke_open_invitation(
             &sealed,
             &eph_pub,
             &secret.to_bytes(),
@@ -230,7 +207,7 @@ mod tests {
         let secret = x25519_dalek::StaticSecret::random_from_rng(rand::rngs::OsRng);
         let public = X25519Pub::from(&secret);
 
-        let (sealed, eph_pub) = ecies_seal(
+        let (sealed, eph_pub) = hpke_seal_invitation(
             b"payload",
             public.as_bytes(),
             "ctx-123",
@@ -238,7 +215,7 @@ mod tests {
         )
         .unwrap();
 
-        let result = ecies_open(
+        let result = hpke_open_invitation(
             &sealed,
             &eph_pub,
             &secret.to_bytes(),
@@ -269,7 +246,7 @@ mod tests {
         let bob_x25519_pub = ed25519_pubkey_to_x25519(&bob_verifying.to_bytes()).unwrap();
 
         // Alice seals
-        let (sealed, eph_pub) = ecies_seal(
+        let (sealed, eph_pub) = hpke_seal_invitation(
             b"welcome message",
             &bob_x25519_pub,
             "ctx-abc",
@@ -282,7 +259,7 @@ mod tests {
         let bob_x25519_secret = x25519_dalek::StaticSecret::from(bob_scalar_bytes);
 
         // Bob opens
-        let recovered = ecies_open(
+        let recovered = hpke_open_invitation(
             &sealed,
             &eph_pub,
             &bob_x25519_secret.to_bytes(),
@@ -311,7 +288,7 @@ mod tests {
 
         // 10KB payload (larger than Welcome messages typically)
         let plaintext = vec![0x42u8; 10_000];
-        let (sealed, eph_pub) = ecies_seal(
+        let (sealed, eph_pub) = hpke_seal_invitation(
             &plaintext,
             public.as_bytes(),
             "ctx-large",
@@ -319,7 +296,7 @@ mod tests {
         )
         .unwrap();
 
-        let recovered = ecies_open(
+        let recovered = hpke_open_invitation(
             &sealed,
             &eph_pub,
             &secret.to_bytes(),

--- a/crates/scp-protocol/src/crypto/envelope_seal.rs
+++ b/crates/scp-protocol/src/crypto/envelope_seal.rs
@@ -165,7 +165,8 @@ mod tests {
 
         let plaintext = b"hello world, this is an invitation bundle";
         let (sealed, eph_pub) =
-            hpke_seal_invitation(plaintext, public.as_bytes(), "ctx-123", "did:dht:z6MkAlice").unwrap();
+            hpke_seal_invitation(plaintext, public.as_bytes(), "ctx-123", "did:dht:z6MkAlice")
+                .unwrap();
 
         let recovered = hpke_open_invitation(
             &sealed,

--- a/crates/scp-protocol/src/crypto/hpke.rs
+++ b/crates/scp-protocol/src/crypto/hpke.rs
@@ -1,0 +1,746 @@
+//! RFC 9180 HPKE — Base-mode single-shot, one suite, hand-implemented.
+//!
+//! This is the single, authoritative HPKE core for all SCP key-distribution
+//! paths (sender keys §9.16.2, access keys §9.17.1, broadcast keys §5.14.2,
+//! invitations §5.12.3.1, PSK distribution §3.7.2). It implements exactly one
+//! RFC 9180 ciphersuite — the SCP suite (§9.5):
+//!
+//! - KEM:  `DHKEM(X25519, HKDF-SHA256)` — suite id `0x0020`
+//! - KDF:  `HKDF-SHA256`               — suite id `0x0001`
+//! - AEAD: `AES-128-GCM`               — suite id `0x0001`
+//!
+//! Only the **single-shot Base mode** is implemented: each [`seal`] generates a
+//! fresh ephemeral keypair, the HPKE context performs exactly one `Seal`
+//! (sequence number 0), so the AEAD nonce is always `base_nonce` (no sequence
+//! counter, no `ComputeNonce` increment is ever exercised). This matches the
+//! protocol: every key-distribution operation creates a fresh HPKE context.
+//!
+//! # Why hand-implemented
+//!
+//! The labeled-KDF composition layer (`LabeledExtract`/`LabeledExpand`, DHKEM
+//! `ExtractAndExpand`, `KeySchedule_base`) is the precise layer that five prior
+//! hand-rolled "HPKE" copies got wrong (they skipped DHKEM `ExtractAndExpand`
+//! and `KeySchedule`, used a custom `info`, and put a random nonce on the
+//! wire). Re-implementing it here — over the RustCrypto-family `hkdf`/`sha2`/`aes-gcm`
+//! and `x25519-dalek` primitives already in this crate — keeps the wasm32
+//! artifact free of extra transitive crates and makes the construction fully
+//! auditable. Correctness is pinned by the RFC 9180 Appendix A.1 known-answer
+//! tests (including intermediate values) and cross-validated against the
+//! `hpke-rs` reference implementation as a dev-dependency oracle.
+//!
+//! # Custody Decap
+//!
+//! For recipient secret keys held inside a `KeyCustody` boundary, the raw
+//! X25519 DH scalar multiplication happens in custody and only the DH output
+//! crosses the boundary. [`custody::open_with_external_dh`] completes RFC 9180
+//! DHKEM Decap + `KeySchedule` + AEAD open from that DH output plus the
+//! recipient public key. See that function's documentation for the strict
+//! caller contract.
+//!
+//! # Zeroization
+//!
+//! All secret intermediates (`dh`, `eae_prk`, `shared_secret`, `secret`,
+//! `key`, `base_nonce`, and the seq-0 AEAD nonce derived from it) are wrapped
+//! in [`Zeroizing`] for their full memory lifetime. `x25519-dalek`
+//! `EphemeralSecret`/`SharedSecret` zeroize on drop with the in-tree `zeroize`
+//! feature; each `.as_bytes()` copy is wrapped in [`Zeroizing`]. NOTE:
+//! `hkdf::Hkdf<Sha256>` does not zeroize its internal PRK/HMAC state on drop —
+//! a known, accepted, codebase-wide limitation of the RustCrypto-family `hkdf` crate;
+//! no custom wrapper is added.
+
+use aes_gcm::aead::{Aead, KeyInit, Payload};
+use aes_gcm::{Aes128Gcm, Nonce};
+use hkdf::Hkdf;
+use rand::rngs::OsRng;
+use sha2::Sha256;
+use x25519_dalek::{EphemeralSecret, PublicKey as X25519Pub, StaticSecret};
+use zeroize::Zeroizing;
+
+// ---------------------------------------------------------------------------
+// Suite constants
+// ---------------------------------------------------------------------------
+
+/// KEM id for `DHKEM(X25519, HKDF-SHA256)` — RFC 9180 §7.1.
+pub const HPKE_KEM_ID: u16 = 0x0020;
+
+/// KDF id for `HKDF-SHA256` — RFC 9180 §7.2.
+pub const HPKE_KDF_ID: u16 = 0x0001;
+
+/// AEAD id for `AES-128-GCM` — RFC 9180 §7.3.
+pub const HPKE_AEAD_ID: u16 = 0x0001;
+
+/// Length of the X25519 encapsulated key (`enc`), bytes.
+pub const HPKE_ENC_LEN: usize = 32;
+
+/// AEAD tag length: `ct.len() == pt.len() + HPKE_TAG_LEN`.
+pub const HPKE_TAG_LEN: usize = 16;
+
+/// AEAD key length (`Nk` for AES-128-GCM), bytes.
+const HPKE_AEAD_KEY_LEN: usize = 16;
+
+/// AEAD nonce length (`Nn` for AES-128-GCM), bytes.
+const HPKE_AEAD_NONCE_LEN: usize = 12;
+
+/// DHKEM shared-secret length (`Nsecret` for DHKEM(X25519, HKDF-SHA256)), bytes.
+const HPKE_NSECRET: usize = 32;
+
+/// X25519 raw scalar/point length, bytes.
+const X25519_LEN: usize = 32;
+
+/// RFC 9180 §4 version label, prefixed to every labeled-KDF input.
+const HPKE_VERSION_LABEL: &[u8] = b"HPKE-v1";
+
+// ---------------------------------------------------------------------------
+// Errors
+// ---------------------------------------------------------------------------
+
+/// Errors produced by the HPKE core.
+#[derive(Debug, thiserror::Error)]
+pub enum HpkeError {
+    /// A key (recipient public, ephemeral, or DH output) was malformed.
+    #[error("invalid HPKE key material: {0}")]
+    InvalidKey(String),
+
+    /// AEAD open failed: tag mismatch, wrong key, wrong `info`/`aad`, tampered
+    /// ciphertext, or (for the custody variant) wrong `dh`/`pkRm`/`enc`.
+    #[error("HPKE open failed: {0}")]
+    OpenFailed(String),
+
+    /// AEAD seal failed (operationally unreachable for AES-128-GCM with a
+    /// valid key and nonce).
+    #[error("HPKE seal failed: {0}")]
+    SealFailed(String),
+}
+
+// ---------------------------------------------------------------------------
+// Labeled KDF (RFC 9180 §4)
+// ---------------------------------------------------------------------------
+
+/// Builds the KEM `suite_id`: `"KEM" || I2OSP(kem_id, 2)` (RFC 9180 §4.1).
+fn kem_suite_id() -> [u8; 5] {
+    let mut id = [0u8; 5];
+    id[0..3].copy_from_slice(b"KEM");
+    id[3..5].copy_from_slice(&HPKE_KEM_ID.to_be_bytes());
+    id
+}
+
+/// Builds the HPKE `suite_id`:
+/// `"HPKE" || I2OSP(kem_id, 2) || I2OSP(kdf_id, 2) || I2OSP(aead_id, 2)`
+/// (RFC 9180 §5.1).
+fn hpke_suite_id() -> [u8; 10] {
+    let mut id = [0u8; 10];
+    id[0..4].copy_from_slice(b"HPKE");
+    id[4..6].copy_from_slice(&HPKE_KEM_ID.to_be_bytes());
+    id[6..8].copy_from_slice(&HPKE_KDF_ID.to_be_bytes());
+    id[8..10].copy_from_slice(&HPKE_AEAD_ID.to_be_bytes());
+    id
+}
+
+/// `LabeledExtract(salt, label, ikm)` (RFC 9180 §4):
+/// `Extract(salt, "HPKE-v1" || suite_id || label || ikm)`.
+///
+/// Returns the HKDF PRK (32 bytes for HKDF-SHA256). `suite_id` is the caller's
+/// (KEM vs HPKE) suite identifier.
+fn labeled_extract(salt: &[u8], suite_id: &[u8], label: &[u8], ikm: &[u8]) -> Zeroizing<[u8; 32]> {
+    // labeled_ikm = "HPKE-v1" || suite_id || label || ikm
+    let mut labeled_ikm = Zeroizing::new(Vec::with_capacity(
+        HPKE_VERSION_LABEL.len() + suite_id.len() + label.len() + ikm.len(),
+    ));
+    labeled_ikm.extend_from_slice(HPKE_VERSION_LABEL);
+    labeled_ikm.extend_from_slice(suite_id);
+    labeled_ikm.extend_from_slice(label);
+    labeled_ikm.extend_from_slice(ikm);
+
+    // HKDF-Extract(salt, IKM) = HMAC(salt, IKM); hkdf crate exposes this via
+    // Hkdf::extract (salt None == all-zero salt block, which is NOT what we
+    // want — RFC 9180 uses an explicit possibly-empty salt). Pass Some(salt)
+    // so an empty salt is the empty byte string per HKDF (RFC 5869 §2.2).
+    let (prk, _hk) = Hkdf::<Sha256>::extract(Some(salt), &labeled_ikm);
+    let mut out = Zeroizing::new([0u8; 32]);
+    out.copy_from_slice(&prk);
+    out
+}
+
+/// `LabeledExpand(prk, label, info, L)` (RFC 9180 §4):
+/// `Expand(prk, I2OSP(L, 2) || "HPKE-v1" || suite_id || label || info, L)`.
+///
+/// Writes exactly `out.len()` bytes; `out.len()` is the RFC's `L`.
+fn labeled_expand(
+    prk: &[u8; 32],
+    suite_id: &[u8],
+    label: &[u8],
+    info: &[u8],
+    out: &mut [u8],
+) -> Result<(), HpkeError> {
+    let l = u16::try_from(out.len())
+        .map_err(|_| HpkeError::SealFailed("HPKE expand length exceeds u16".to_owned()))?;
+
+    // labeled_info = I2OSP(L, 2) || "HPKE-v1" || suite_id || label || info
+    let mut labeled_info = Vec::with_capacity(
+        2 + HPKE_VERSION_LABEL.len() + suite_id.len() + label.len() + info.len(),
+    );
+    labeled_info.extend_from_slice(&l.to_be_bytes());
+    labeled_info.extend_from_slice(HPKE_VERSION_LABEL);
+    labeled_info.extend_from_slice(suite_id);
+    labeled_info.extend_from_slice(label);
+    labeled_info.extend_from_slice(info);
+
+    // HKDF-Expand from an existing PRK: reconstruct the HKDF state from the PRK.
+    let hk = Hkdf::<Sha256>::from_prk(prk)
+        .map_err(|e| HpkeError::SealFailed(format!("HKDF from_prk: {e}")))?;
+    hk.expand(&labeled_info, out)
+        .map_err(|e| HpkeError::SealFailed(format!("HKDF expand: {e}")))
+}
+
+// ---------------------------------------------------------------------------
+// DHKEM (RFC 9180 §4.1)
+// ---------------------------------------------------------------------------
+
+/// DHKEM `ExtractAndExpand(dh, kem_context)` (RFC 9180 §4.1):
+/// `eae_prk = LabeledExtract("", "eae_prk", dh)`;
+/// `shared_secret = LabeledExpand(eae_prk, "shared_secret", kem_context, Nsecret)`.
+///
+/// Uses the **KEM** suite id. Returns the 32-byte KEM shared secret.
+fn dhkem_extract_and_expand(
+    dh: &[u8; X25519_LEN],
+    kem_context: &[u8],
+) -> Result<Zeroizing<[u8; HPKE_NSECRET]>, HpkeError> {
+    let suite_id = kem_suite_id();
+    let eae_prk = labeled_extract(b"", &suite_id, b"eae_prk", dh);
+    let mut shared_secret = Zeroizing::new([0u8; HPKE_NSECRET]);
+    labeled_expand(
+        &eae_prk,
+        &suite_id,
+        b"shared_secret",
+        kem_context,
+        shared_secret.as_mut(),
+    )?;
+    Ok(shared_secret)
+}
+
+// ---------------------------------------------------------------------------
+// KeySchedule (RFC 9180 §5.1, mode_base)
+// ---------------------------------------------------------------------------
+
+/// AEAD material derived from `KeySchedule_base`.
+struct KeyScheduleOutput {
+    key: Zeroizing<[u8; HPKE_AEAD_KEY_LEN]>,
+    base_nonce: Zeroizing<[u8; HPKE_AEAD_NONCE_LEN]>,
+}
+
+/// RFC 9180 §5.1 `KeySchedule(mode_base, shared_secret, info, psk="", psk_id="")`.
+///
+/// Derives the AEAD `key` and `base_nonce`. The `mode` byte is `0x00`
+/// (`mode_base`). Uses the **HPKE** suite id. The exporter secret is not derived
+/// (SCP never uses HPKE export).
+fn key_schedule_base(
+    shared_secret: &[u8; HPKE_NSECRET],
+    info: &[u8],
+) -> Result<KeyScheduleOutput, HpkeError> {
+    let suite_id = hpke_suite_id();
+
+    // psk_id_hash = LabeledExtract("", "psk_id_hash", default_psk_id="")
+    let psk_id_hash = labeled_extract(b"", &suite_id, b"psk_id_hash", b"");
+    // info_hash = LabeledExtract("", "info_hash", info)
+    let info_hash = labeled_extract(b"", &suite_id, b"info_hash", info);
+
+    // key_schedule_context = mode || psk_id_hash || info_hash
+    let mut ks_context = Vec::with_capacity(1 + psk_id_hash.len() + info_hash.len());
+    ks_context.push(0x00); // mode_base
+    ks_context.extend_from_slice(psk_id_hash.as_ref());
+    ks_context.extend_from_slice(info_hash.as_ref());
+
+    // secret = LabeledExtract(shared_secret, "secret", default_psk="")
+    let secret = labeled_extract(shared_secret, &suite_id, b"secret", b"");
+
+    // key = LabeledExpand(secret, "key", key_schedule_context, Nk)
+    let mut key = Zeroizing::new([0u8; HPKE_AEAD_KEY_LEN]);
+    labeled_expand(&secret, &suite_id, b"key", &ks_context, key.as_mut())?;
+
+    // base_nonce = LabeledExpand(secret, "base_nonce", key_schedule_context, Nn)
+    let mut base_nonce = Zeroizing::new([0u8; HPKE_AEAD_NONCE_LEN]);
+    labeled_expand(
+        &secret,
+        &suite_id,
+        b"base_nonce",
+        &ks_context,
+        base_nonce.as_mut(),
+    )?;
+
+    Ok(KeyScheduleOutput { key, base_nonce })
+}
+
+// ---------------------------------------------------------------------------
+// AEAD (seq 0 only)
+// ---------------------------------------------------------------------------
+
+/// Seals `pt` with AES-128-GCM at sequence number 0 (`nonce == base_nonce`).
+fn aead_seal(ks: &KeyScheduleOutput, aad: &[u8], pt: &[u8]) -> Result<Vec<u8>, HpkeError> {
+    let cipher = Aes128Gcm::new_from_slice(ks.key.as_ref())
+        .map_err(|e| HpkeError::SealFailed(format!("AES-128-GCM key: {e}")))?;
+    // seq 0: nonce = base_nonce XOR 0 = base_nonce. Hold the nonce in a
+    // Zeroizing copy so it is not a bare unzeroed stack value.
+    let nonce_bytes: Zeroizing<[u8; HPKE_AEAD_NONCE_LEN]> = Zeroizing::new(*ks.base_nonce);
+    cipher
+        .encrypt(
+            Nonce::from_slice(nonce_bytes.as_ref()),
+            Payload { msg: pt, aad },
+        )
+        .map_err(|e| HpkeError::SealFailed(e.to_string()))
+}
+
+/// Opens `ct` with AES-128-GCM at sequence number 0 (`nonce == base_nonce`).
+fn aead_open(ks: &KeyScheduleOutput, aad: &[u8], ct: &[u8]) -> Result<Vec<u8>, HpkeError> {
+    let cipher = Aes128Gcm::new_from_slice(ks.key.as_ref())
+        .map_err(|e| HpkeError::OpenFailed(format!("AES-128-GCM key: {e}")))?;
+    let nonce_bytes: Zeroizing<[u8; HPKE_AEAD_NONCE_LEN]> = Zeroizing::new(*ks.base_nonce);
+    cipher
+        .decrypt(
+            Nonce::from_slice(nonce_bytes.as_ref()),
+            Payload { msg: ct, aad },
+        )
+        .map_err(|e| HpkeError::OpenFailed(e.to_string()))
+}
+
+// ---------------------------------------------------------------------------
+// Public single-shot API
+// ---------------------------------------------------------------------------
+
+/// Single-shot Base-mode HPKE seal.
+///
+/// Generates a fresh ephemeral X25519 keypair, performs DHKEM Encap to the
+/// recipient public key, runs `KeySchedule_base`, and AEAD-seals `pt` at
+/// sequence 0.
+///
+/// Returns `(enc, ct)` where `enc` is the 32-byte encapsulated key (the
+/// ephemeral public key) and `ct` is `ciphertext || tag` (`pt.len() + 16`
+/// bytes). Every SCP wire format carries `enc` as its own field, so the tuple
+/// shape requires zero reassembly at call sites.
+///
+/// # Errors
+///
+/// [`HpkeError::SealFailed`] if KDF or AEAD encryption fails (operationally
+/// unreachable with valid inputs).
+pub fn seal(
+    recipient_pk: &[u8; 32],
+    info: &[u8],
+    aad: &[u8],
+    pt: &[u8],
+) -> Result<([u8; HPKE_ENC_LEN], Vec<u8>), HpkeError> {
+    let ephemeral = EphemeralSecret::random_from_rng(OsRng);
+    let enc = X25519Pub::from(&ephemeral);
+    seal_with_ephemeral_secret(ephemeral, enc, recipient_pk, info, aad, pt)
+}
+
+/// Single-shot Base-mode HPKE open with a **software-held** recipient secret.
+///
+/// `pkRm` (the recipient public key needed for `kem_context = enc || pkRm`) is
+/// derived internally from `recipient_sk` via the X25519 basepoint
+/// multiplication. For custody-held secrets use
+/// [`custody::open_with_external_dh`] instead.
+///
+/// # Errors
+///
+/// [`HpkeError::InvalidKey`] if `enc` is not a valid X25519 point usable for
+/// DH; [`HpkeError::OpenFailed`] if KDF or AEAD verification fails (wrong key,
+/// wrong `info`/`aad`, tampered `enc`/`ct`).
+pub fn open(
+    recipient_sk: &[u8; 32],
+    enc: &[u8; HPKE_ENC_LEN],
+    info: &[u8],
+    aad: &[u8],
+    ct: &[u8],
+) -> Result<Vec<u8>, HpkeError> {
+    // Recipient static secret (zeroize-on-drop) and its public key (pkRm).
+    let sk_copy = Zeroizing::new(*recipient_sk);
+    let sk = StaticSecret::from(*sk_copy);
+    let pk_rm = X25519Pub::from(&sk);
+
+    // DHKEM Decap: dh = DH(skR, enc).
+    let enc_pub = X25519Pub::from(*enc);
+    let dh = sk.diffie_hellman(&enc_pub);
+    let dh_bytes = Zeroizing::new(*dh.as_bytes());
+
+    decap_and_open(&dh_bytes, &pk_rm.to_bytes(), enc, info, aad, ct)
+}
+
+/// Deterministic seal core, exercised by the RFC 9180 A.1 KATs.
+///
+/// `#[cfg(test)]` + `pub(crate)` ONLY: a deterministic ephemeral is a footgun
+/// if reachable from production; it exists solely to inject the fixed RFC 9180
+/// A.1 `skEm` into the known-answer tests.
+#[cfg(test)]
+pub(crate) fn seal_with_ephemeral(
+    eph_sk: [u8; 32],
+    recipient_pk: &[u8; 32],
+    info: &[u8],
+    aad: &[u8],
+    pt: &[u8],
+) -> Result<([u8; HPKE_ENC_LEN], Vec<u8>), HpkeError> {
+    // Build a StaticSecret from the fixed scalar-seed bytes. x25519-dalek
+    // StaticSecret::from clamps on use; RFC 9180 A.1 skEm is already a valid
+    // X25519 secret, so this reproduces enc/pkEm exactly.
+    let sk_copy = Zeroizing::new(eph_sk);
+    let static_sk = StaticSecret::from(*sk_copy);
+    let enc = X25519Pub::from(&static_sk);
+    let recipient = X25519Pub::from(*recipient_pk);
+    let dh = static_sk.diffie_hellman(&recipient);
+    let dh_bytes = Zeroizing::new(*dh.as_bytes());
+    finish_seal(&dh_bytes, &enc.to_bytes(), recipient_pk, info, aad, pt)
+}
+
+// ---------------------------------------------------------------------------
+// Internal seal/decap helpers
+// ---------------------------------------------------------------------------
+
+/// Encap + `KeySchedule` + AEAD seal from an `EphemeralSecret`.
+fn seal_with_ephemeral_secret(
+    ephemeral: EphemeralSecret,
+    enc: X25519Pub,
+    recipient_pk: &[u8; 32],
+    info: &[u8],
+    aad: &[u8],
+    pt: &[u8],
+) -> Result<([u8; HPKE_ENC_LEN], Vec<u8>), HpkeError> {
+    let recipient = X25519Pub::from(*recipient_pk);
+    let dh = ephemeral.diffie_hellman(&recipient);
+    let dh_bytes = Zeroizing::new(*dh.as_bytes());
+    finish_seal(&dh_bytes, &enc.to_bytes(), recipient_pk, info, aad, pt)
+}
+
+/// Shared Encap tail: `kem_context = enc || pkR`, `ExtractAndExpand`,
+/// `KeySchedule`, AEAD seal.
+fn finish_seal(
+    dh_bytes: &[u8; X25519_LEN],
+    enc_bytes: &[u8; HPKE_ENC_LEN],
+    recipient_pk: &[u8; 32],
+    info: &[u8],
+    aad: &[u8],
+    pt: &[u8],
+) -> Result<([u8; HPKE_ENC_LEN], Vec<u8>), HpkeError> {
+    // kem_context = enc || pkRm
+    let mut kem_context = [0u8; HPKE_ENC_LEN + 32];
+    kem_context[..HPKE_ENC_LEN].copy_from_slice(enc_bytes);
+    kem_context[HPKE_ENC_LEN..].copy_from_slice(recipient_pk);
+
+    let shared_secret = dhkem_extract_and_expand(dh_bytes, &kem_context)?;
+    let ks = key_schedule_base(&shared_secret, info)?;
+    let ct = aead_seal(&ks, aad, pt)?;
+    Ok((*enc_bytes, ct))
+}
+
+/// Shared Decap tail: `kem_context = enc || pkRm`, `ExtractAndExpand`,
+/// `KeySchedule`, AEAD open. `dh_bytes` is `DH(skR, enc)`.
+fn decap_and_open(
+    dh_bytes: &[u8; X25519_LEN],
+    recipient_pk: &[u8; 32],
+    enc: &[u8; HPKE_ENC_LEN],
+    info: &[u8],
+    aad: &[u8],
+    ct: &[u8],
+) -> Result<Vec<u8>, HpkeError> {
+    let mut kem_context = [0u8; HPKE_ENC_LEN + 32];
+    kem_context[..HPKE_ENC_LEN].copy_from_slice(enc);
+    kem_context[HPKE_ENC_LEN..].copy_from_slice(recipient_pk);
+
+    let shared_secret = dhkem_extract_and_expand(dh_bytes, &kem_context)?;
+    let ks = key_schedule_base(&shared_secret, info)?;
+    aead_open(&ks, aad, ct)
+}
+
+// ---------------------------------------------------------------------------
+// Custody Decap variant
+// ---------------------------------------------------------------------------
+
+/// HPKE open paths for recipient keys held inside a `KeyCustody` boundary.
+pub mod custody {
+    use super::{HPKE_ENC_LEN, HpkeError, X25519_LEN, decap_and_open};
+
+    /// Single-shot Base-mode HPKE open where the KEM Diffie-Hellman output was
+    /// computed inside a `KeyCustody` boundary.
+    ///
+    /// RFC 9180 DHKEM Decap is `shared_secret = ExtractAndExpand(dh, enc ||
+    /// pkRm)` where `dh = DH(skR, enc)`. The scalar multiplication `DH(skR,
+    /// enc)` is the only step that must touch the non-extractable recipient
+    /// secret; everything after it (`ExtractAndExpand`, `KeySchedule`, AEAD open)
+    /// is pure. This function takes that custody-computed `dh` plus the
+    /// recipient public key `pkRm` and completes the open in software, so the
+    /// wrapping private key never leaves custody.
+    ///
+    /// # Caller contract (load-bearing — read this)
+    ///
+    /// The ONLY sound inputs are, for one and the same custody key handle `h`
+    /// and one and the same encapsulated key `enc`:
+    ///
+    /// - `dh` = `KeyCustody::dh_agree(h, enc)` — the raw X25519 DH output for
+    ///   `h` against this exact `enc`.
+    /// - `recipient_pk` (`pkRm`) = `KeyCustody::public_key(h)` — the X25519
+    ///   public key of that same handle `h`.
+    /// - `enc` — the exact encapsulated key the seal produced and the same one
+    ///   passed to `dh_agree`.
+    ///
+    /// Same handle, same `enc`, throughout. A mismatched `dh`, `pkRm`, or `enc`
+    /// fails closed (AEAD tag mismatch), but indistinguishably from a
+    /// wrong-key error — there is no separate signal. Binding `enc || pkRm`
+    /// into the shared secret (which the legacy hand-rolled paths did NOT do)
+    /// closes the unknown-key-share gap: a ciphertext sealed to one recipient
+    /// cannot be reinterpreted as sealed to another.
+    ///
+    /// # Errors
+    ///
+    /// [`HpkeError::OpenFailed`] if the KDF or AEAD verification fails (wrong
+    /// `dh`/`pkRm`/`enc`/`info`/`aad`, or tampered `ct`).
+    pub fn open_with_external_dh(
+        dh: &[u8; X25519_LEN],
+        recipient_pk: &[u8; 32],
+        enc: &[u8; HPKE_ENC_LEN],
+        info: &[u8],
+        aad: &[u8],
+        ct: &[u8],
+    ) -> Result<Vec<u8>, HpkeError> {
+        decap_and_open(dh, recipient_pk, enc, info, aad, ct)
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Tests — RFC 9180 Appendix A.1 KATs + roundtrips + negatives
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used, clippy::panic)]
+mod tests {
+    use super::*;
+
+    // RFC 9180 Appendix A.1 — DHKEM(X25519, HKDF-SHA256), HKDF-SHA256,
+    // AES-128-GCM, Base mode. Values transcribed verbatim from
+    // https://www.rfc-editor.org/rfc/rfc9180#appendix-A.1
+    const A1_INFO: &str = "4f6465206f6e2061204772656369616e2055726e";
+    const A1_SKEM: &str = "52c4a758a802cd8b936eceea314432798d5baf2d7e9235dc084ab1b9cfa2f736";
+    const A1_PKEM: &str = "37fda3567bdbd628e88668c3c8d7e97d1d1253b6d4ea6d44c150f741f1bf4431";
+    const A1_SKRM: &str = "4612c550263fc8ad58375df3f557aac531d26850903e55a9f23f21d8534e8ac8";
+    const A1_PKRM: &str = "3948cfe0ad1ddb695d780e59077195da6c56506b027329794ab02bca80815c4d";
+    const A1_SHARED_SECRET: &str =
+        "fe0e18c9f024ce43799ae393c7e8fe8fce9d218875e8227b0187c04e7d2ea1fc";
+    const A1_KEY: &str = "4531685d41d65f03dc48f6b8302c05b0";
+    const A1_BASE_NONCE: &str = "56d890e5accaaf011cff4b7d";
+    // seq 0
+    const A1_PT: &str = "4265617574792069732074727574682c20747275746820626561757479";
+    const A1_AAD: &str = "436f756e742d30";
+    const A1_CT: &str = "f938558b5d72f1a23810b4be2ab4f84331acc02fc97babc53a52ae8218a355a96d8770ac83d07bea87e13c512a";
+
+    fn unhex(s: &str) -> Vec<u8> {
+        hex::decode(s).unwrap()
+    }
+
+    fn arr32(s: &str) -> [u8; 32] {
+        unhex(s).try_into().unwrap()
+    }
+
+    /// A.1: `enc` / `pkEm` derived from the fixed `skEm` matches the RFC.
+    #[test]
+    fn a1_enc_matches() {
+        let sk = arr32(A1_SKEM);
+        let static_sk = StaticSecret::from(sk);
+        let enc = X25519Pub::from(&static_sk);
+        assert_eq!(
+            hex::encode(enc.to_bytes()),
+            A1_PKEM,
+            "A.1 enc/pkEm mismatch"
+        );
+    }
+
+    /// A.1: DHKEM `ExtractAndExpand` reproduces the RFC `shared_secret`.
+    #[test]
+    fn a1_shared_secret_matches() {
+        // dh = DH(skEm, pkRm)
+        let static_sk = StaticSecret::from(arr32(A1_SKEM));
+        let pk_rm = X25519Pub::from(arr32(A1_PKRM));
+        let dh = static_sk.diffie_hellman(&pk_rm);
+
+        // kem_context = enc || pkRm
+        let mut kem_context = Vec::new();
+        kem_context.extend_from_slice(&unhex(A1_PKEM));
+        kem_context.extend_from_slice(&unhex(A1_PKRM));
+
+        let ss = dhkem_extract_and_expand(dh.as_bytes(), &kem_context).unwrap();
+        assert_eq!(
+            hex::encode(ss.as_ref()),
+            A1_SHARED_SECRET,
+            "A.1 shared_secret mismatch"
+        );
+    }
+
+    /// A.1: `KeySchedule_base` reproduces the RFC `key` and `base_nonce`.
+    #[test]
+    fn a1_key_schedule_matches() {
+        let shared_secret: [u8; HPKE_NSECRET] = unhex(A1_SHARED_SECRET).try_into().unwrap();
+        let info = unhex(A1_INFO);
+        let ks = key_schedule_base(&shared_secret, &info).unwrap();
+        assert_eq!(hex::encode(ks.key.as_ref()), A1_KEY, "A.1 key mismatch");
+        assert_eq!(
+            hex::encode(ks.base_nonce.as_ref()),
+            A1_BASE_NONCE,
+            "A.1 base_nonce mismatch"
+        );
+    }
+
+    /// A.1: full deterministic seal (fixed `skEm`) reproduces `enc` and the
+    /// seq-0 ciphertext byte-for-byte.
+    #[test]
+    fn a1_seal_seq0_matches() {
+        let info = unhex(A1_INFO);
+        let aad = unhex(A1_AAD);
+        let pt = unhex(A1_PT);
+        let pk_rm = arr32(A1_PKRM);
+
+        let (enc, ct) = seal_with_ephemeral(arr32(A1_SKEM), &pk_rm, &info, &aad, &pt).unwrap();
+        assert_eq!(hex::encode(enc), A1_PKEM, "A.1 seal enc mismatch");
+        assert_eq!(hex::encode(&ct), A1_CT, "A.1 seal ct mismatch");
+    }
+
+    /// A.1: software `open` recovers the plaintext from the RFC vector.
+    #[test]
+    fn a1_open_recovers_pt() {
+        let info = unhex(A1_INFO);
+        let aad = unhex(A1_AAD);
+        let enc = arr32(A1_PKEM);
+        let ct = unhex(A1_CT);
+        let sk_rm = arr32(A1_SKRM);
+
+        let pt = open(&sk_rm, &enc, &info, &aad, &ct).unwrap();
+        assert_eq!(hex::encode(&pt), A1_PT, "A.1 open plaintext mismatch");
+    }
+
+    /// A.1: custody-path open (external DH = `DH(skRm, enc)`) recovers the
+    /// plaintext from the same RFC vector.
+    #[test]
+    fn a1_custody_open_recovers_pt() {
+        let info = unhex(A1_INFO);
+        let aad = unhex(A1_AAD);
+        let enc = arr32(A1_PKEM);
+        let ct = unhex(A1_CT);
+        let pk_rm = arr32(A1_PKRM);
+
+        // Simulate KeyCustody::dh_agree(handle, enc) = DH(skRm, enc).
+        let sk_rm = StaticSecret::from(arr32(A1_SKRM));
+        let enc_pub = X25519Pub::from(enc);
+        let dh = sk_rm.diffie_hellman(&enc_pub);
+
+        let pt =
+            custody::open_with_external_dh(dh.as_bytes(), &pk_rm, &enc, &info, &aad, &ct).unwrap();
+        assert_eq!(
+            hex::encode(&pt),
+            A1_PT,
+            "A.1 custody open plaintext mismatch"
+        );
+    }
+
+    /// Randomized roundtrip: software seal → software open.
+    #[test]
+    fn roundtrip_seal_open() {
+        let sk = StaticSecret::random_from_rng(OsRng);
+        let pk = X25519Pub::from(&sk);
+
+        for len in [0usize, 1, 16, 32, 64, 1000] {
+            let pt = vec![0xA5u8; len];
+            let info = b"scp-test-info";
+            let aad = b"scp-test-aad";
+            let (enc, ct) = seal(&pk.to_bytes(), info, aad, &pt).unwrap();
+            assert_eq!(ct.len(), pt.len() + HPKE_TAG_LEN);
+            let got = open(&sk.to_bytes(), &enc, info, aad, &ct).unwrap();
+            assert_eq!(got, pt, "roundtrip len {len}");
+        }
+    }
+
+    /// Randomized roundtrip: software seal → custody-path open.
+    #[test]
+    fn roundtrip_seal_custody_open() {
+        let sk = StaticSecret::random_from_rng(OsRng);
+        let pk = X25519Pub::from(&sk);
+        let pt = b"the quick brown fox jumps over the lazy dog";
+        let info = b"info";
+        let aad = b"aad";
+
+        let (enc, ct) = seal(&pk.to_bytes(), info, aad, pt).unwrap();
+
+        let enc_pub = X25519Pub::from(enc);
+        let dh = sk.diffie_hellman(&enc_pub);
+        let got =
+            custody::open_with_external_dh(dh.as_bytes(), &pk.to_bytes(), &enc, info, aad, &ct)
+                .unwrap();
+        assert_eq!(got.as_slice(), pt);
+    }
+
+    /// Negative: tampered ciphertext fails.
+    #[test]
+    fn tampered_ct_fails() {
+        let sk = StaticSecret::random_from_rng(OsRng);
+        let pk = X25519Pub::from(&sk);
+        let (enc, mut ct) = seal(&pk.to_bytes(), b"i", b"a", b"secret").unwrap();
+        ct[0] ^= 0x01;
+        assert!(open(&sk.to_bytes(), &enc, b"i", b"a", &ct).is_err());
+    }
+
+    /// Negative: tampered `enc` fails.
+    #[test]
+    fn tampered_enc_fails() {
+        let sk = StaticSecret::random_from_rng(OsRng);
+        let pk = X25519Pub::from(&sk);
+        let (mut enc, ct) = seal(&pk.to_bytes(), b"i", b"a", b"secret").unwrap();
+        enc[0] ^= 0x01;
+        assert!(open(&sk.to_bytes(), &enc, b"i", b"a", &ct).is_err());
+    }
+
+    /// Negative: wrong recipient key fails.
+    #[test]
+    fn wrong_recipient_fails() {
+        let sk = StaticSecret::random_from_rng(OsRng);
+        let pk = X25519Pub::from(&sk);
+        let wrong = StaticSecret::random_from_rng(OsRng);
+        let (enc, ct) = seal(&pk.to_bytes(), b"i", b"a", b"secret").unwrap();
+        assert!(open(&wrong.to_bytes(), &enc, b"i", b"a", &ct).is_err());
+    }
+
+    /// Negative: wrong `info` (domain separation) fails.
+    #[test]
+    fn wrong_info_fails() {
+        let sk = StaticSecret::random_from_rng(OsRng);
+        let pk = X25519Pub::from(&sk);
+        let (enc, ct) = seal(&pk.to_bytes(), b"info-a", b"a", b"secret").unwrap();
+        assert!(open(&sk.to_bytes(), &enc, b"info-b", b"a", &ct).is_err());
+    }
+
+    /// Negative: wrong `aad` fails.
+    #[test]
+    fn wrong_aad_fails() {
+        let sk = StaticSecret::random_from_rng(OsRng);
+        let pk = X25519Pub::from(&sk);
+        let (enc, ct) = seal(&pk.to_bytes(), b"i", b"aad-a", b"secret").unwrap();
+        assert!(open(&sk.to_bytes(), &enc, b"i", b"aad-b", &ct).is_err());
+    }
+
+    /// Negative: custody open with the wrong `pkRm` (right `dh`) fails — the
+    /// `kem_context` binding catches the mismatch.
+    #[test]
+    fn custody_wrong_pkrm_fails() {
+        let sk = StaticSecret::random_from_rng(OsRng);
+        let pk = X25519Pub::from(&sk);
+        let (enc, ct) = seal(&pk.to_bytes(), b"i", b"a", b"secret").unwrap();
+
+        let enc_pub = X25519Pub::from(enc);
+        let dh = sk.diffie_hellman(&enc_pub);
+
+        let wrong_pk = X25519Pub::from(&StaticSecret::random_from_rng(OsRng));
+        assert!(
+            custody::open_with_external_dh(
+                dh.as_bytes(),
+                &wrong_pk.to_bytes(),
+                &enc,
+                b"i",
+                b"a",
+                &ct
+            )
+            .is_err()
+        );
+    }
+}

--- a/crates/scp-protocol/src/crypto/mod.rs
+++ b/crates/scp-protocol/src/crypto/mod.rs
@@ -8,6 +8,7 @@ mod bip39_wordlist;
 pub mod canonical;
 pub mod ed25519;
 pub mod envelope_seal;
+pub mod hpke;
 pub mod key_continuity;
 pub mod sender_keys;
 pub mod tofu;

--- a/crates/scp-protocol/src/crypto/sender_keys/broadcast.rs
+++ b/crates/scp-protocol/src/crypto/sender_keys/broadcast.rs
@@ -827,8 +827,9 @@ const BROADCAST_KEY_HPKE_INFO_PREFIX: &[u8] = b"scp-broadcast-key-v1";
 pub fn build_broadcast_key_hpke_info(context_id: &str, author_did: &str, epoch: u64) -> Vec<u8> {
     let ctx = context_id.as_bytes();
     let did = author_did.as_bytes();
-    let mut info =
-        Vec::with_capacity(BROADCAST_KEY_HPKE_INFO_PREFIX.len() + 4 + ctx.len() + 4 + did.len() + 8);
+    let mut info = Vec::with_capacity(
+        BROADCAST_KEY_HPKE_INFO_PREFIX.len() + 4 + ctx.len() + 4 + did.len() + 8,
+    );
     info.extend_from_slice(BROADCAST_KEY_HPKE_INFO_PREFIX);
     #[allow(clippy::cast_possible_truncation)] // context_id/DID lengths << u32::MAX
     let ctx_len = ctx.len() as u32;

--- a/crates/scp-protocol/src/crypto/sender_keys/broadcast.rs
+++ b/crates/scp-protocol/src/crypto/sender_keys/broadcast.rs
@@ -1823,4 +1823,148 @@ mod tests {
         let b = build_broadcast_key_hpke_info("a", "bc", 0);
         assert_ne!(a, b);
     }
+
+    #[test]
+    fn broadcast_key_hpke_rejects_tampered_ciphertext() {
+        // Flipping a single ciphertext bit must make the AEAD open fail.
+        use x25519_dalek::{PublicKey as X25519Pub, StaticSecret};
+
+        let key = generate_broadcast_key("did:dht:author");
+        let subscriber_secret = StaticSecret::random_from_rng(OsRng);
+        let subscriber_pub = X25519Pub::from(&subscriber_secret);
+
+        let (mut ct, enc) = seal_broadcast_key_to_subscriber(
+            key.key(),
+            &subscriber_pub.to_bytes(),
+            "ctx-broadcast",
+            "did:dht:author",
+            0,
+        )
+        .unwrap();
+
+        ct[0] ^= 0x01;
+
+        let result = open_broadcast_key(
+            &ct,
+            &enc,
+            &subscriber_secret.to_bytes(),
+            "ctx-broadcast",
+            "did:dht:author",
+            0,
+        );
+        assert!(result.is_err(), "tampered ciphertext must fail HPKE open");
+    }
+
+    #[test]
+    fn broadcast_key_hpke_rejects_tampered_enc() {
+        // Flipping a bit of the encapsulated key changes the recovered DH
+        // shared secret, so the AEAD open must fail.
+        use x25519_dalek::{PublicKey as X25519Pub, StaticSecret};
+
+        let key = generate_broadcast_key("did:dht:author");
+        let subscriber_secret = StaticSecret::random_from_rng(OsRng);
+        let subscriber_pub = X25519Pub::from(&subscriber_secret);
+
+        let (ct, mut enc) = seal_broadcast_key_to_subscriber(
+            key.key(),
+            &subscriber_pub.to_bytes(),
+            "ctx-broadcast",
+            "did:dht:author",
+            0,
+        )
+        .unwrap();
+
+        enc[0] ^= 0x01;
+
+        let result = open_broadcast_key(
+            &ct,
+            &enc,
+            &subscriber_secret.to_bytes(),
+            "ctx-broadcast",
+            "did:dht:author",
+            0,
+        );
+        assert!(result.is_err(), "tampered enc must fail HPKE open");
+    }
+
+    #[test]
+    fn broadcast_key_hpke_rejects_wrong_recipient() {
+        // Sealing to subscriber A's pubkey and opening with subscriber B's
+        // secret must fail: B's DH yields a different shared secret.
+        use x25519_dalek::{PublicKey as X25519Pub, StaticSecret};
+
+        let key = generate_broadcast_key("did:dht:author");
+
+        let recipient_secret = StaticSecret::random_from_rng(OsRng);
+        let recipient_pub = X25519Pub::from(&recipient_secret);
+        let intruder_secret = StaticSecret::random_from_rng(OsRng);
+
+        let (ct, enc) = seal_broadcast_key_to_subscriber(
+            key.key(),
+            &recipient_pub.to_bytes(),
+            "ctx-broadcast",
+            "did:dht:author",
+            0,
+        )
+        .unwrap();
+
+        let result = open_broadcast_key(
+            &ct,
+            &enc,
+            &intruder_secret.to_bytes(),
+            "ctx-broadcast",
+            "did:dht:author",
+            0,
+        );
+        assert!(
+            result.is_err(),
+            "opening with the wrong recipient secret must fail HPKE open"
+        );
+    }
+
+    #[test]
+    fn broadcast_key_hpke_rejects_sender_key_domain_ciphertext() {
+        // Real cross-path domain separation: seal a 32-byte payload using the
+        // SENDER-KEY info/aad builders, then attempt to open it with the
+        // BROADCAST info/aad. The AEAD must reject the mismatched info/aad —
+        // this proves enforcement at the ciphertext level, not just that the
+        // two info strings differ.
+        use x25519_dalek::{PublicKey as X25519Pub, StaticSecret};
+
+        use super::super::key_protocol_verify::{
+            build_hpke_aad as build_sender_key_hpke_aad,
+            build_hpke_info as build_sender_key_hpke_info,
+        };
+
+        let subscriber_secret = StaticSecret::random_from_rng(OsRng);
+        let subscriber_pub = X25519Pub::from(&subscriber_secret);
+
+        let payload = [0x42u8; 32];
+
+        // Seal under the SENDER-KEY domain (different info prefix + aad).
+        let sender_info = build_sender_key_hpke_info("ctx-broadcast", "did:dht:author", 0);
+        let sender_aad = build_sender_key_hpke_aad("ctx-broadcast", "did:dht:author", 0);
+        let (enc, ct) = crate::crypto::hpke::seal(
+            &subscriber_pub.to_bytes(),
+            &sender_info,
+            &sender_aad,
+            &payload,
+        )
+        .unwrap();
+
+        // Attempt to open it as a BROADCAST key (broadcast info/aad) on the
+        // same keypair + enc + ct. The AEAD must reject the wrong info/aad.
+        let result = open_broadcast_key(
+            &ct,
+            &enc,
+            &subscriber_secret.to_bytes(),
+            "ctx-broadcast",
+            "did:dht:author",
+            0,
+        );
+        assert!(
+            result.is_err(),
+            "a sender-key-domain ciphertext must not open as a broadcast key"
+        );
+    }
 }

--- a/crates/scp-protocol/src/crypto/sender_keys/broadcast.rs
+++ b/crates/scp-protocol/src/crypto/sender_keys/broadcast.rs
@@ -810,6 +810,127 @@ impl BroadcastReplayDetector {
 }
 
 // ---------------------------------------------------------------------------
+// Broadcast key distribution (RFC 9180 HPKE, §5.14.2)
+// ---------------------------------------------------------------------------
+
+/// HPKE `info` domain separator for broadcast-key distribution (§5.14.2).
+const BROADCAST_KEY_HPKE_INFO_PREFIX: &[u8] = b"scp-broadcast-key-v1";
+
+/// Builds the HPKE `info` for broadcast-key distribution (spec §5.14.2).
+///
+/// Format: `"scp-broadcast-key-v1" || BE32(len(context_id)) || context_id || BE32(len(author_did)) || author_did || epoch_BE`.
+/// Variable-length fields carry 4-byte big-endian length prefixes (§9.5.1) to
+/// prevent boundary-shift ambiguity, matching the sender-key (§9.16.2) and
+/// access-key (§9.17.1) `info` constructions. Distinct from those domain
+/// separators to prevent cross-protocol key confusion.
+#[must_use]
+pub fn build_broadcast_key_hpke_info(context_id: &str, author_did: &str, epoch: u64) -> Vec<u8> {
+    let ctx = context_id.as_bytes();
+    let did = author_did.as_bytes();
+    let mut info =
+        Vec::with_capacity(BROADCAST_KEY_HPKE_INFO_PREFIX.len() + 4 + ctx.len() + 4 + did.len() + 8);
+    info.extend_from_slice(BROADCAST_KEY_HPKE_INFO_PREFIX);
+    #[allow(clippy::cast_possible_truncation)] // context_id/DID lengths << u32::MAX
+    let ctx_len = ctx.len() as u32;
+    info.extend_from_slice(&ctx_len.to_be_bytes());
+    info.extend_from_slice(ctx);
+    #[allow(clippy::cast_possible_truncation)]
+    let did_len = did.len() as u32;
+    info.extend_from_slice(&did_len.to_be_bytes());
+    info.extend_from_slice(did);
+    info.extend_from_slice(&epoch.to_be_bytes());
+    info
+}
+
+/// Builds the HPKE `aad` for broadcast-key distribution (spec §5.14.2).
+///
+/// Format: `BE32(len(context_id)) || context_id || BE32(len(author_did)) || author_did || epoch_BE`
+/// — the same encoding as the `info`, without the domain-separator prefix.
+#[must_use]
+pub fn build_broadcast_key_hpke_aad(context_id: &str, author_did: &str, epoch: u64) -> Vec<u8> {
+    let ctx = context_id.as_bytes();
+    let did = author_did.as_bytes();
+    let mut aad = Vec::with_capacity(4 + ctx.len() + 4 + did.len() + 8);
+    #[allow(clippy::cast_possible_truncation)] // context_id/DID lengths << u32::MAX
+    let ctx_len = ctx.len() as u32;
+    aad.extend_from_slice(&ctx_len.to_be_bytes());
+    aad.extend_from_slice(ctx);
+    #[allow(clippy::cast_possible_truncation)]
+    let did_len = did.len() as u32;
+    aad.extend_from_slice(&did_len.to_be_bytes());
+    aad.extend_from_slice(did);
+    aad.extend_from_slice(&epoch.to_be_bytes());
+    aad
+}
+
+/// HPKE-seals a 32-byte broadcast key to a subscriber's X25519 wrapping pubkey
+/// (RFC 9180 Base mode, §5.14.2).
+///
+/// Returns `(ct, enc)` where `ct` is the HPKE ciphertext (`ciphertext || tag`,
+/// 48 bytes) and `enc` is the 32-byte HPKE encapsulated key. The AEAD nonce is
+/// internal per RFC 9180. `context_id`/`author_did`/`epoch` are bound into both
+/// `info` and `aad` to prevent cross-context/cross-author/cross-epoch replay.
+///
+/// # Errors
+///
+/// Returns [`SenderKeyError::HpkeEncryptionFailed`] if HPKE sealing fails.
+pub fn seal_broadcast_key_to_subscriber(
+    broadcast_key: &SenderKey,
+    subscriber_wrapping_pub: &[u8; 32],
+    context_id: &str,
+    author_did: &str,
+    epoch: u64,
+) -> Result<(Vec<u8>, [u8; 32]), SenderKeyError> {
+    let info = build_broadcast_key_hpke_info(context_id, author_did, epoch);
+    let aad = build_broadcast_key_hpke_aad(context_id, author_did, epoch);
+
+    let (enc, ct) = crate::crypto::hpke::seal(
+        subscriber_wrapping_pub,
+        &info,
+        &aad,
+        broadcast_key.as_bytes(),
+    )
+    .map_err(|e| SenderKeyError::HpkeEncryptionFailed(e.to_string()))?;
+
+    Ok((ct, enc))
+}
+
+/// HPKE-opens a sealed broadcast key using a software-held X25519 wrapping
+/// secret (RFC 9180 Base mode, §5.14.2).
+///
+/// `enc` is the HPKE encapsulated key from
+/// [`seal_broadcast_key_to_subscriber`]. Custody-held wrapping keys must use
+/// [`crate::crypto::hpke::custody::open_with_external_dh`].
+///
+/// # Errors
+///
+/// Returns [`SenderKeyError::HpkeDecryptionFailed`] if HPKE open fails or the
+/// recovered plaintext is not exactly 32 bytes.
+pub fn open_broadcast_key(
+    sealed: &[u8],
+    enc: &[u8; 32],
+    wrapping_secret: &[u8; 32],
+    context_id: &str,
+    author_did: &str,
+    epoch: u64,
+) -> Result<SenderKey, SenderKeyError> {
+    let info = build_broadcast_key_hpke_info(context_id, author_did, epoch);
+    let aad = build_broadcast_key_hpke_aad(context_id, author_did, epoch);
+
+    let plaintext = crate::crypto::hpke::open(wrapping_secret, enc, &info, &aad, sealed)
+        .map_err(|e| SenderKeyError::HpkeDecryptionFailed(e.to_string()))?;
+
+    let key_bytes: [u8; 32] = plaintext.as_slice().try_into().map_err(|_| {
+        SenderKeyError::HpkeDecryptionFailed(format!(
+            "decrypted broadcast key must be 32 bytes, got {}",
+            plaintext.len()
+        ))
+    })?;
+
+    Ok(SenderKey::from_bytes(key_bytes))
+}
+
+// ---------------------------------------------------------------------------
 // Tests
 // ---------------------------------------------------------------------------
 
@@ -1616,5 +1737,89 @@ mod tests {
             let decrypted = test_open(&key, &envelope).unwrap();
             prop_assert_eq!(plaintext, decrypted);
         }
+    }
+
+    // -------------------------------------------------------------------
+    // Broadcast key distribution (RFC 9180 HPKE, §5.14.2)
+    // -------------------------------------------------------------------
+
+    #[test]
+    fn broadcast_key_hpke_distribution_roundtrip() {
+        use x25519_dalek::{PublicKey as X25519Pub, StaticSecret};
+
+        let key = generate_broadcast_key("did:dht:author");
+        let subscriber_secret = StaticSecret::random_from_rng(OsRng);
+        let subscriber_pub = X25519Pub::from(&subscriber_secret);
+
+        let (ct, enc) = seal_broadcast_key_to_subscriber(
+            key.key(),
+            &subscriber_pub.to_bytes(),
+            "ctx-broadcast",
+            "did:dht:author",
+            0,
+        )
+        .unwrap();
+
+        // ct is exactly 48 bytes: 32-byte key + 16-byte AEAD tag.
+        assert_eq!(ct.len(), 48);
+
+        let recovered = open_broadcast_key(
+            &ct,
+            &enc,
+            &subscriber_secret.to_bytes(),
+            "ctx-broadcast",
+            "did:dht:author",
+            0,
+        )
+        .unwrap();
+        assert_eq!(recovered.as_bytes(), key.key().as_bytes());
+    }
+
+    #[test]
+    fn broadcast_key_hpke_rejects_wrong_context() {
+        use x25519_dalek::{PublicKey as X25519Pub, StaticSecret};
+
+        let key = generate_broadcast_key("did:dht:author");
+        let subscriber_secret = StaticSecret::random_from_rng(OsRng);
+        let subscriber_pub = X25519Pub::from(&subscriber_secret);
+
+        let (ct, enc) = seal_broadcast_key_to_subscriber(
+            key.key(),
+            &subscriber_pub.to_bytes(),
+            "ctx-A",
+            "did:dht:author",
+            0,
+        )
+        .unwrap();
+
+        // Open under a different context_id — wrong info/aad → AEAD failure.
+        let result = open_broadcast_key(
+            &ct,
+            &enc,
+            &subscriber_secret.to_bytes(),
+            "ctx-B",
+            "did:dht:author",
+            0,
+        );
+        assert!(result.is_err(), "wrong context should fail HPKE open");
+    }
+
+    #[test]
+    fn broadcast_key_hpke_info_distinct_from_sender_key() {
+        // Domain separation: broadcast-key info prefix must differ from the
+        // sender-key prefix so a sender-key ciphertext cannot open as a
+        // broadcast key over the same keypair.
+        let info = build_broadcast_key_hpke_info("ctx", "did:dht:author", 1);
+        assert!(info.starts_with(b"scp-broadcast-key-v1"));
+        assert!(!info.starts_with(b"scp-sender-key-v1"));
+    }
+
+    #[test]
+    fn broadcast_key_hpke_info_length_prefixes_prevent_boundary_shift() {
+        // ("ab", "c") and ("a", "bc") must produce distinct info despite the
+        // same concatenated bytes — length prefixes disambiguate.
+        let a = build_broadcast_key_hpke_info("ab", "c", 0);
+        let b = build_broadcast_key_hpke_info("a", "bc", 0);
+        assert_ne!(a, b);
     }
 }

--- a/crates/scp-protocol/src/crypto/sender_keys/key_protocol_verify.rs
+++ b/crates/scp-protocol/src/crypto/sender_keys/key_protocol_verify.rs
@@ -2,8 +2,13 @@
 //! key distribution protocol.
 //!
 //! This module contains all **sync, platform-independent** items from the
-//! sender key protocol: constants, wire types, HPKE helpers, hash helpers,
-//! signature verification, nonce deduplication, and block list expansion.
+//! sender key protocol: constants, wire types, HPKE context-binding helpers,
+//! hash helpers, signature verification, nonce deduplication, and block list
+//! expansion.
+//!
+//! Sender key distribution is sealed/opened with RFC 9180 HPKE via the shared
+//! [`crate::crypto::hpke`] core; the `build_hpke_info`/`build_hpke_aad`
+//! helpers below supply the §9.16.2 domain-separated `info`/`aad`.
 //!
 //! Async signing operations that depend on `KeyCustody` remain in
 //! `key_protocol` (in `scp-runtime`).
@@ -11,21 +16,16 @@
 use std::collections::{HashMap, HashSet};
 use std::hash::BuildHasher;
 
-use aes_gcm::aead::{Aead, Payload};
-use aes_gcm::{Aes128Gcm, KeyInit, Nonce};
-use hkdf::Hkdf;
-use rand::RngCore;
 use rand::rngs::OsRng;
 use serde::{Deserialize, Serialize};
-use sha2::Sha256;
-use x25519_dalek::{EphemeralSecret, PublicKey as X25519Pub};
-use zeroize::Zeroizing;
+use x25519_dalek::{PublicKey as X25519Pub, StaticSecret};
 
 #[cfg(test)]
 use super::generate_sender_key;
 use super::{SenderKey, SenderKeyError};
+use crate::crypto::hpke;
 use crate::identity::SigningKeyId;
-use crate::serde_util::{serde_hpke_sealed_60, serde_pubkey_32, serde_signature_64};
+use crate::serde_util::{serde_hpke_sealed_48, serde_pubkey_32, serde_signature_64};
 
 // ---------------------------------------------------------------------------
 // Wrapping keypair generation (§9.16.1)
@@ -46,7 +46,6 @@ use crate::serde_util::{serde_hpke_sealed_60, serde_pubkey_32, serde_signature_6
 /// See spec §9.16.1.
 #[must_use]
 pub fn generate_wrapping_keypair() -> ([u8; 32], [u8; 32]) {
-    use x25519_dalek::StaticSecret;
     let secret = StaticSecret::random_from_rng(OsRng);
     let public = X25519Pub::from(&secret);
     (public.to_bytes(), secret.to_bytes())
@@ -55,9 +54,6 @@ pub fn generate_wrapping_keypair() -> ([u8; 32], [u8; 32]) {
 // ---------------------------------------------------------------------------
 // Constants
 // ---------------------------------------------------------------------------
-
-/// AES-128-GCM nonce size in bytes.
-pub const HPKE_NONCE_SIZE: usize = 12;
 
 /// Maximum size of a serialized [`SenderKeyDistributionMessage`] in bytes (64 KiB).
 ///
@@ -154,7 +150,11 @@ pub struct SenderKeyRequest {
 /// Response containing HPKE-encrypted sender key material.
 ///
 /// Sent as an MLS application message back to the requester. The sender
-/// key is encrypted using HPKE: ephemeral X25519 ECDH + HKDF + AES-128-GCM.
+/// key is sealed with RFC 9180 HPKE Base mode (§9.5, §9.16.2): the
+/// `ephemeral_pubkey` carries the HPKE encapsulated key (`enc`) and
+/// `hpke_sealed_key` carries the AEAD ciphertext (`ct = ciphertext || tag`).
+/// The AEAD nonce is derived internally by RFC 9180 (`base_nonce` at
+/// sequence 0) — there is NO external nonce on the wire.
 ///
 /// The [`request_nonce`][SenderKeyResponse::request_nonce] field echoes the
 /// nonce from the corresponding [`SenderKeyRequest`] to bind the response to
@@ -165,11 +165,12 @@ pub struct SenderKeyResponse {
     pub sender_did: String,
     /// The epoch of the distributed key.
     pub epoch: u64,
-    /// HPKE-sealed sender key bytes (AES-128-GCM nonce || ciphertext || tag).
-    /// Exactly 60 bytes: nonce (12) + encrypted key (32) + tag (16).
-    #[serde(with = "serde_hpke_sealed_60")]
-    pub hpke_sealed_key: [u8; 60],
-    /// The ephemeral X25519 public key used in the HPKE encapsulation.
+    /// HPKE ciphertext (`ct = ciphertext || tag`), 48 bytes: encrypted key
+    /// (32) + AES-128-GCM tag (16). The AEAD nonce is internal per RFC 9180.
+    #[serde(with = "serde_hpke_sealed_48")]
+    pub hpke_sealed_key: [u8; 48],
+    /// The HPKE encapsulated key (`enc`, a 32-byte ephemeral X25519 public
+    /// key) used to derive the KEM shared secret.
     #[serde(with = "serde_pubkey_32")]
     pub ephemeral_pubkey: [u8; 32],
     /// Echo of the request nonce from [`SenderKeyRequest::nonce`], binding
@@ -598,19 +599,20 @@ where
 // HPKE open (non-custody variant)
 // ---------------------------------------------------------------------------
 
-/// Decrypts an HPKE-sealed sender key using the raw X25519 wrapping secret
-/// key bytes.
+/// Opens an HPKE-sealed sender key using the raw X25519 wrapping secret key
+/// bytes (RFC 9180 Base mode, §9.16.2).
 ///
-/// This is the non-custody variant of
-/// `key_protocol::open_sender_key_response` (in `scp-runtime`) for use when the
-/// wrapping secret key is held in software (e.g., in
-/// `MlsCryptoProvider`) rather
-/// than inside a `KeyCustody` boundary.
+/// This is the non-custody (software-key) variant of
+/// `key_protocol::open_sender_key_response` (in `scp-runtime`), for use when
+/// the wrapping secret key is held in software (e.g. in `MlsCryptoProvider`)
+/// rather than inside a `KeyCustody` boundary. Custody-held keys must use
+/// [`crate::crypto::hpke::custody::open_with_external_dh`].
 ///
 /// # Arguments
 ///
-/// * `sealed` - The HPKE-sealed key bytes (`nonce || ciphertext || tag`).
-/// * `ephemeral_pubkey` - The sender's ephemeral X25519 public key.
+/// * `sealed` - The HPKE ciphertext `ct` (`ciphertext || tag`).
+/// * `ephemeral_pubkey` - The HPKE encapsulated key `enc` (sender's ephemeral
+///   X25519 public key).
 /// * `wrapping_secret` - The recipient's X25519 wrapping secret key (32 bytes).
 /// * `context_id` - The SCP context identifier (hex string).
 /// * `sender_did` - The DID of the sender.
@@ -618,8 +620,9 @@ where
 ///
 /// # Errors
 ///
-/// Returns [`SenderKeyError::HpkeDecryptionFailed`] if ECDH, KDF, or AEAD
-/// decryption fails.
+/// Returns [`SenderKeyError::HpkeDecryptionFailed`] if HPKE open fails (wrong
+/// key, wrong `info`/`aad`, or tampered `enc`/`ct`), or if the recovered
+/// plaintext is not exactly 32 bytes.
 pub fn hpke_open_sender_key(
     sealed: &[u8],
     ephemeral_pubkey: &[u8; 32],
@@ -628,17 +631,11 @@ pub fn hpke_open_sender_key(
     sender_did: &str,
     epoch: u64,
 ) -> Result<SenderKey, SenderKeyError> {
-    use x25519_dalek::StaticSecret;
-
-    let secret = StaticSecret::from(*wrapping_secret);
-    let ephemeral_pub = X25519Pub::from(*ephemeral_pubkey);
-    let shared_secret = secret.diffie_hellman(&ephemeral_pub);
-
     let info = build_hpke_info(context_id, sender_did, epoch);
     let aad = build_hpke_aad(context_id, sender_did, epoch);
 
-    let aes_key = hkdf_derive_key(shared_secret.as_bytes(), &info)?;
-    let plaintext = aes128gcm_decrypt(&aes_key, sealed, &aad)?;
+    let plaintext = hpke::open(wrapping_secret, ephemeral_pubkey, &info, &aad, sealed)
+        .map_err(|e| SenderKeyError::HpkeDecryptionFailed(e.to_string()))?;
 
     let key_bytes: [u8; 32] = plaintext.as_slice().try_into().map_err(|_| {
         SenderKeyError::HpkeDecryptionFailed(format!(
@@ -752,22 +749,23 @@ pub fn build_hpke_aad(context_id: &str, sender_did: &str, epoch: u64) -> Vec<u8>
 }
 
 // ---------------------------------------------------------------------------
-// HPKE helpers
+// HPKE seal (RFC 9180 Base mode, §9.16.2)
 // ---------------------------------------------------------------------------
 
-/// HPKE-seals a 32-byte sender key to a recipient's X25519 wrapping pubkey.
+/// HPKE-seals a 32-byte sender key to a recipient's X25519 wrapping pubkey
+/// (RFC 9180 Base mode via [`crate::crypto::hpke`]).
 ///
-/// Returns `(sealed_bytes, ephemeral_pubkey)` where `sealed_bytes` is
-/// `nonce || ciphertext || tag` (60 bytes for 32-byte plaintext) and
-/// `ephemeral_pubkey` is the 32-byte X25519 public key used for ECDH.
+/// Returns `(sealed_ct, enc)` where `sealed_ct` is the HPKE ciphertext
+/// (`ciphertext || tag`, 48 bytes for a 32-byte plaintext) and `enc` is the
+/// 32-byte HPKE encapsulated key (the ephemeral X25519 public key). There is
+/// NO external nonce — the AEAD nonce is derived internally by RFC 9180.
 ///
-/// Context binding: both info and AAD include `context_id`, `sender_did`,
+/// Context binding: both `info` and `aad` include `context_id`, `sender_did`,
 /// and `epoch` to prevent cross-context/cross-epoch replay (§9.16.2).
 ///
 /// # Errors
 ///
-/// Returns [`SenderKeyError::HpkeEncryptionFailed`] if HKDF or AES-128-GCM
-/// encryption fails.
+/// Returns [`SenderKeyError::HpkeEncryptionFailed`] if HPKE sealing fails.
 pub fn hpke_seal_sender_key(
     plaintext: &[u8; 32],
     recipient_pub: &[u8; 32],
@@ -775,114 +773,13 @@ pub fn hpke_seal_sender_key(
     sender_did: &str,
     epoch: u64,
 ) -> Result<(Vec<u8>, [u8; 32]), SenderKeyError> {
-    // 1. Generate ephemeral X25519 keypair.
-    let ephemeral_secret = EphemeralSecret::random_from_rng(OsRng);
-    let ephemeral_public = X25519Pub::from(&ephemeral_secret);
-
-    // 2. ECDH between ephemeral secret and recipient's wrapping pubkey.
-    let recipient_key = X25519Pub::from(*recipient_pub);
-    let shared_secret = ephemeral_secret.diffie_hellman(&recipient_key);
-
-    // 3. Build context-bound info and AAD (§9.16.2).
     let info = build_hpke_info(context_id, sender_did, epoch);
     let aad = build_hpke_aad(context_id, sender_did, epoch);
 
-    // 4. HKDF to derive 16-byte AES-128-GCM key (zeroized on drop).
-    let aes_key = hkdf_derive_key(shared_secret.as_bytes(), &info)?;
-
-    // 5. AES-128-GCM encrypt with AAD.
-    let sealed = aes128gcm_encrypt(&aes_key, plaintext, &aad)?;
-
-    Ok((sealed, ephemeral_public.to_bytes()))
-}
-
-/// Derives a 16-byte AES-128-GCM key from a 32-byte shared secret using
-/// HKDF-SHA256.
-///
-/// The returned key is wrapped in [`Zeroizing`] so the derived key material
-/// is zeroed on drop (defense-in-depth, see issue #82).
-///
-/// # Errors
-///
-/// Returns [`SenderKeyError::HpkeEncryptionFailed`] if HKDF expansion fails.
-pub fn hkdf_derive_key(
-    shared_secret: &[u8],
-    info: &[u8],
-) -> Result<Zeroizing<[u8; 16]>, SenderKeyError> {
-    let hk = Hkdf::<Sha256>::new(None, shared_secret);
-    let mut okm = Zeroizing::new([0u8; 16]);
-    hk.expand(info, okm.as_mut())
-        .map_err(|e| SenderKeyError::HpkeEncryptionFailed(e.to_string()))?;
-    Ok(okm)
-}
-
-/// Encrypts `plaintext` with AES-128-GCM. Returns `nonce || ciphertext || tag`.
-///
-/// # Errors
-///
-/// Returns [`SenderKeyError::HpkeEncryptionFailed`] if AES-128-GCM encryption fails.
-pub fn aes128gcm_encrypt(
-    key: &[u8; 16],
-    plaintext: &[u8],
-    aad: &[u8],
-) -> Result<Vec<u8>, SenderKeyError> {
-    let cipher = Aes128Gcm::new_from_slice(key)
+    let (enc, ct) = hpke::seal(recipient_pub, &info, &aad, plaintext)
         .map_err(|e| SenderKeyError::HpkeEncryptionFailed(e.to_string()))?;
 
-    let mut nonce_bytes = [0u8; HPKE_NONCE_SIZE];
-    OsRng.fill_bytes(&mut nonce_bytes);
-    let nonce = Nonce::from_slice(&nonce_bytes);
-
-    let ciphertext = cipher
-        .encrypt(
-            nonce,
-            Payload {
-                msg: plaintext,
-                aad,
-            },
-        )
-        .map_err(|e| SenderKeyError::HpkeEncryptionFailed(e.to_string()))?;
-
-    let mut output = Vec::with_capacity(HPKE_NONCE_SIZE + ciphertext.len());
-    output.extend_from_slice(&nonce_bytes);
-    output.extend_from_slice(&ciphertext);
-    Ok(output)
-}
-
-/// Decrypts AES-128-GCM ciphertext of the form `nonce || ciphertext || tag`.
-///
-/// # Errors
-///
-/// Returns [`SenderKeyError::HpkeDecryptionFailed`] if the sealed data is too
-/// short or AES-128-GCM authentication fails.
-pub fn aes128gcm_decrypt(
-    key: &[u8; 16],
-    sealed: &[u8],
-    aad: &[u8],
-) -> Result<Vec<u8>, SenderKeyError> {
-    if sealed.len() < HPKE_NONCE_SIZE {
-        return Err(SenderKeyError::HpkeDecryptionFailed(format!(
-            "sealed data too short: {} bytes, minimum {}",
-            sealed.len(),
-            HPKE_NONCE_SIZE
-        )));
-    }
-
-    let (nonce_bytes, encrypted) = sealed.split_at(HPKE_NONCE_SIZE);
-    let nonce = Nonce::from_slice(nonce_bytes);
-
-    let cipher = Aes128Gcm::new_from_slice(key)
-        .map_err(|e| SenderKeyError::HpkeDecryptionFailed(e.to_string()))?;
-
-    cipher
-        .decrypt(
-            nonce,
-            Payload {
-                msg: encrypted,
-                aad,
-            },
-        )
-        .map_err(|e| SenderKeyError::HpkeDecryptionFailed(e.to_string()))
+    Ok((ct, enc))
 }
 
 // ---------------------------------------------------------------------------
@@ -1066,8 +963,9 @@ pub struct BridgeShadowKeyParams<'a> {
 ///
 /// # Returns
 ///
-/// `(hpke_sealed_key, ephemeral_public_key)` -- The HPKE-wrapped sender
-/// key and the ephemeral public key for ECDH reconstruction.
+/// `(hpke_sealed_key, enc)` -- The HPKE ciphertext (`ct = ciphertext || tag`,
+/// 48 bytes) and the HPKE encapsulated key (`enc`, 32-byte ephemeral X25519
+/// public key). The AEAD nonce is internal per RFC 9180.
 ///
 /// # Errors
 ///
@@ -1075,7 +973,7 @@ pub struct BridgeShadowKeyParams<'a> {
 pub fn handle_bridge_shadow_key_request(
     requester_wrapping_pubkey: &[u8; 32],
     params: &BridgeShadowKeyParams<'_>,
-) -> Result<([u8; 60], [u8; 32]), SenderKeyError> {
+) -> Result<([u8; 48], [u8; 32]), SenderKeyError> {
     let (sealed_vec, ephemeral_pub) = hpke_seal_sender_key(
         params.shadow_sender_key.as_bytes(),
         requester_wrapping_pubkey,
@@ -1084,15 +982,13 @@ pub fn handle_bridge_shadow_key_request(
         0, // Shadow keys are initial distribution (epoch 0)
     )?;
 
-    // Convert to fixed-size array.
-    let mut sealed_arr = [0u8; 60];
-    if sealed_vec.len() != 60 {
-        return Err(SenderKeyError::HpkeEncryptionFailed(format!(
-            "expected 60 bytes from HPKE seal, got {}",
+    // Convert to fixed-size array (32-byte key + 16-byte AEAD tag = 48 bytes).
+    let sealed_arr: [u8; 48] = sealed_vec.as_slice().try_into().map_err(|_| {
+        SenderKeyError::HpkeEncryptionFailed(format!(
+            "expected 48 bytes from HPKE seal, got {}",
             sealed_vec.len()
-        )));
-    }
-    sealed_arr.copy_from_slice(&sealed_vec);
+        ))
+    })?;
 
     Ok((sealed_arr, ephemeral_pub))
 }
@@ -1150,21 +1046,27 @@ mod tests {
         let sender = "did:dht:alice";
         let epoch = 1u64;
 
-        let recipient_secret = x25519_dalek::StaticSecret::random_from_rng(OsRng);
+        let recipient_secret = StaticSecret::random_from_rng(OsRng);
         let recipient_public = X25519Pub::from(&recipient_secret);
 
         let (sealed, ephemeral_pub) =
             hpke_seal_sender_key(&plaintext, &recipient_public.to_bytes(), ctx, sender, epoch)
                 .unwrap();
 
-        let ephemeral_key = X25519Pub::from(ephemeral_pub);
-        let shared = recipient_secret.diffie_hellman(&ephemeral_key);
-        let info = build_hpke_info(ctx, sender, epoch);
-        let aad = build_hpke_aad(ctx, sender, epoch);
-        let aes_key = hkdf_derive_key(shared.as_bytes(), &info).unwrap();
-        let recovered = aes128gcm_decrypt(&aes_key, &sealed, &aad).unwrap();
+        // ct is exactly 48 bytes: 32-byte key + 16-byte AEAD tag.
+        assert_eq!(sealed.len(), 48);
 
-        assert_eq!(recovered.as_slice(), &plaintext);
+        let recovered = hpke_open_sender_key(
+            &sealed,
+            &ephemeral_pub,
+            &recipient_secret.to_bytes(),
+            ctx,
+            sender,
+            epoch,
+        )
+        .unwrap();
+
+        assert_eq!(recovered.as_bytes(), &plaintext);
     }
 
     #[test]
@@ -1174,25 +1076,82 @@ mod tests {
         let sender = "did:dht:alice";
         let epoch = 1u64;
 
-        let recipient_secret = x25519_dalek::StaticSecret::random_from_rng(OsRng);
+        let recipient_secret = StaticSecret::random_from_rng(OsRng);
         let recipient_public = X25519Pub::from(&recipient_secret);
 
-        let wrong_secret = x25519_dalek::StaticSecret::random_from_rng(OsRng);
+        let wrong_secret = StaticSecret::random_from_rng(OsRng);
 
         let (sealed, ephemeral_pub) =
             hpke_seal_sender_key(&plaintext, &recipient_public.to_bytes(), ctx, sender, epoch)
                 .unwrap();
 
-        let ephemeral_key = X25519Pub::from(ephemeral_pub);
-        let shared = wrong_secret.diffie_hellman(&ephemeral_key);
-        let info = build_hpke_info(ctx, sender, epoch);
-        let aad = build_hpke_aad(ctx, sender, epoch);
-        let aes_key = hkdf_derive_key(shared.as_bytes(), &info).unwrap();
-        let result = aes128gcm_decrypt(&aes_key, &sealed, &aad);
+        let result = hpke_open_sender_key(
+            &sealed,
+            &ephemeral_pub,
+            &wrong_secret.to_bytes(),
+            ctx,
+            sender,
+            epoch,
+        );
+
+        assert!(result.is_err(), "wrong recipient should fail HPKE open");
+    }
+
+    #[test]
+    fn hpke_rejects_tampered_ciphertext() {
+        let plaintext = [0x11u8; 32];
+        let ctx = "ctx-test";
+        let sender = "did:dht:alice";
+        let epoch = 7u64;
+
+        let recipient_secret = StaticSecret::random_from_rng(OsRng);
+        let recipient_public = X25519Pub::from(&recipient_secret);
+
+        let (mut sealed, ephemeral_pub) =
+            hpke_seal_sender_key(&plaintext, &recipient_public.to_bytes(), ctx, sender, epoch)
+                .unwrap();
+        sealed[0] ^= 0x01;
 
         assert!(
-            result.is_err(),
-            "wrong recipient should fail AEAD decryption"
+            hpke_open_sender_key(
+                &sealed,
+                &ephemeral_pub,
+                &recipient_secret.to_bytes(),
+                ctx,
+                sender,
+                epoch,
+            )
+            .is_err(),
+            "tampered ciphertext should fail AEAD verification"
+        );
+    }
+
+    #[test]
+    fn hpke_rejects_tampered_enc() {
+        let plaintext = [0x22u8; 32];
+        let ctx = "ctx-test";
+        let sender = "did:dht:alice";
+        let epoch = 9u64;
+
+        let recipient_secret = StaticSecret::random_from_rng(OsRng);
+        let recipient_public = X25519Pub::from(&recipient_secret);
+
+        let (sealed, mut ephemeral_pub) =
+            hpke_seal_sender_key(&plaintext, &recipient_public.to_bytes(), ctx, sender, epoch)
+                .unwrap();
+        ephemeral_pub[0] ^= 0x01;
+
+        assert!(
+            hpke_open_sender_key(
+                &sealed,
+                &ephemeral_pub,
+                &recipient_secret.to_bytes(),
+                ctx,
+                sender,
+                epoch,
+            )
+            .is_err(),
+            "tampered enc should fail HPKE open"
         );
     }
 
@@ -1217,7 +1176,7 @@ mod tests {
         let plaintext = [0xEFu8; 32];
         let sender = "did:dht:alice";
         let epoch = 1u64;
-        let recipient_secret = x25519_dalek::StaticSecret::random_from_rng(OsRng);
+        let recipient_secret = StaticSecret::random_from_rng(OsRng);
         let recipient_public = X25519Pub::from(&recipient_secret);
 
         let (sealed, ephemeral_pub) = hpke_seal_sender_key(
@@ -1229,16 +1188,16 @@ mod tests {
         )
         .unwrap();
 
-        let ephemeral_key = X25519Pub::from(ephemeral_pub);
-        let shared = recipient_secret.diffie_hellman(&ephemeral_key);
-        let wrong_info = build_hpke_info("ctx-B", sender, epoch);
-        let wrong_aad = build_hpke_aad("ctx-B", sender, epoch);
-        let aes_key = hkdf_derive_key(shared.as_bytes(), &wrong_info).unwrap();
-        let result = aes128gcm_decrypt(&aes_key, &sealed, &wrong_aad);
-        assert!(
-            result.is_err(),
-            "wrong context_id should fail AEAD decryption"
+        // Open with a different context_id — wrong info/aad → AEAD failure.
+        let result = hpke_open_sender_key(
+            &sealed,
+            &ephemeral_pub,
+            &recipient_secret.to_bytes(),
+            "ctx-B",
+            sender,
+            epoch,
         );
+        assert!(result.is_err(), "wrong context_id should fail HPKE open");
     }
 
     #[test]
@@ -1246,7 +1205,7 @@ mod tests {
         let plaintext = [0xDDu8; 32];
         let ctx = "ctx-test";
         let epoch = 1u64;
-        let recipient_secret = x25519_dalek::StaticSecret::random_from_rng(OsRng);
+        let recipient_secret = StaticSecret::random_from_rng(OsRng);
         let recipient_public = X25519Pub::from(&recipient_secret);
 
         let (sealed, ephemeral_pub) = hpke_seal_sender_key(
@@ -1258,16 +1217,15 @@ mod tests {
         )
         .unwrap();
 
-        let ephemeral_key = X25519Pub::from(ephemeral_pub);
-        let shared = recipient_secret.diffie_hellman(&ephemeral_key);
-        let wrong_info = build_hpke_info(ctx, "did:dht:bob", epoch);
-        let wrong_aad = build_hpke_aad(ctx, "did:dht:bob", epoch);
-        let aes_key = hkdf_derive_key(shared.as_bytes(), &wrong_info).unwrap();
-        let result = aes128gcm_decrypt(&aes_key, &sealed, &wrong_aad);
-        assert!(
-            result.is_err(),
-            "wrong sender_did should fail AEAD decryption"
+        let result = hpke_open_sender_key(
+            &sealed,
+            &ephemeral_pub,
+            &recipient_secret.to_bytes(),
+            ctx,
+            "did:dht:bob",
+            epoch,
         );
+        assert!(result.is_err(), "wrong sender_did should fail HPKE open");
     }
 
     #[test]
@@ -1275,19 +1233,21 @@ mod tests {
         let plaintext = [0xBBu8; 32];
         let ctx = "ctx-test";
         let sender = "did:dht:alice";
-        let recipient_secret = x25519_dalek::StaticSecret::random_from_rng(OsRng);
+        let recipient_secret = StaticSecret::random_from_rng(OsRng);
         let recipient_public = X25519Pub::from(&recipient_secret);
 
         let (sealed, ephemeral_pub) =
             hpke_seal_sender_key(&plaintext, &recipient_public.to_bytes(), ctx, sender, 1).unwrap();
 
-        let ephemeral_key = X25519Pub::from(ephemeral_pub);
-        let shared = recipient_secret.diffie_hellman(&ephemeral_key);
-        let wrong_info = build_hpke_info(ctx, sender, 2);
-        let wrong_aad = build_hpke_aad(ctx, sender, 2);
-        let aes_key = hkdf_derive_key(shared.as_bytes(), &wrong_info).unwrap();
-        let result = aes128gcm_decrypt(&aes_key, &sealed, &wrong_aad);
-        assert!(result.is_err(), "wrong epoch should fail AEAD decryption");
+        let result = hpke_open_sender_key(
+            &sealed,
+            &ephemeral_pub,
+            &recipient_secret.to_bytes(),
+            ctx,
+            sender,
+            2,
+        );
+        assert!(result.is_err(), "wrong epoch should fail HPKE open");
     }
 
     // -------------------------------------------------------------------
@@ -1643,9 +1603,9 @@ mod tests {
 
     #[test]
     fn hpke_sealed_key_wrong_length_rejected_on_deser() {
-        // hpke_sealed_key is now [u8; 60] — length is enforced at the type
-        // level by serde_hpke_sealed_60. Verify deserialization rejects wrong
-        // sizes (#347).
+        // hpke_sealed_key is [u8; 48] (RFC 9180 ct = 32-byte key + 16-byte
+        // tag) — length is enforced at the type level by serde_hpke_sealed_48.
+        // Verify deserialization rejects wrong sizes (#347).
         #[derive(serde::Serialize)]
         struct FakeResponse {
             sender_did: String,
@@ -1658,34 +1618,34 @@ mod tests {
             request_nonce: [u8; REQUEST_NONCE_SIZE],
         }
 
-        // 59 bytes — too short.
+        // 47 bytes — too short.
         let fake_short = FakeResponse {
             sender_did: "did:dht:alice".to_owned(),
             epoch: 1,
-            hpke_sealed_key: vec![0u8; 59],
+            hpke_sealed_key: vec![0u8; 47],
             ephemeral_pubkey: [0u8; 32],
             request_nonce: [0u8; REQUEST_NONCE_SIZE],
         };
         let serialized = rmp_serde::to_vec_named(&fake_short).unwrap();
         let result = rmp_serde::from_slice::<SenderKeyResponse>(&serialized);
-        assert!(result.is_err(), "should reject 59-byte sealed key");
+        assert!(result.is_err(), "should reject 47-byte sealed key");
         let err = result.unwrap_err().to_string();
         assert!(
-            err.contains("60-byte HPKE sealed key"),
-            "error should mention 60-byte: {err}"
+            err.contains("48-byte HPKE sealed key"),
+            "error should mention 48-byte: {err}"
         );
 
-        // 61 bytes — too long.
+        // 49 bytes — too long.
         let fake_long = FakeResponse {
             sender_did: "did:dht:alice".to_owned(),
             epoch: 1,
-            hpke_sealed_key: vec![0u8; 61],
+            hpke_sealed_key: vec![0u8; 49],
             ephemeral_pubkey: [0u8; 32],
             request_nonce: [0u8; REQUEST_NONCE_SIZE],
         };
         let serialized_long = rmp_serde::to_vec_named(&fake_long).unwrap();
         let result_long = rmp_serde::from_slice::<SenderKeyResponse>(&serialized_long);
-        assert!(result_long.is_err(), "should reject 61-byte sealed key");
+        assert!(result_long.is_err(), "should reject 49-byte sealed key");
     }
 
     #[test]
@@ -1780,7 +1740,7 @@ mod tests {
         let response = SenderKeyResponse {
             sender_did: "did:dht:alice".to_owned(),
             epoch: 3,
-            hpke_sealed_key: [0x44; 60],
+            hpke_sealed_key: [0x44; 48],
             ephemeral_pubkey: [0x55; 32],
             request_nonce: [0x66; REQUEST_NONCE_SIZE],
         };
@@ -1869,7 +1829,7 @@ mod tests {
         let response = SenderKeyResponse {
             sender_did: "did:dht:alice".to_owned(),
             epoch: 2,
-            hpke_sealed_key: [0xEE; 60],
+            hpke_sealed_key: [0xEE; 48],
             ephemeral_pubkey: [0xFF; 32],
             request_nonce: [0x11; REQUEST_NONCE_SIZE],
         };
@@ -1880,7 +1840,7 @@ mod tests {
             SenderKeyDistributionMessage::KeyResponse(r) => {
                 assert_eq!(r.sender_did, "did:dht:alice");
                 assert_eq!(r.epoch, 2);
-                assert_eq!(r.hpke_sealed_key, [0xEE; 60]);
+                assert_eq!(r.hpke_sealed_key, [0xEE; 48]);
             }
             other => panic!("expected KeyResponse, got {other:?}"),
         }
@@ -1929,7 +1889,7 @@ mod tests {
         let response = SenderKeyDistributionMessage::KeyResponse(SenderKeyResponse {
             sender_did: "did:dht:alice".to_owned(),
             epoch: 1,
-            hpke_sealed_key: [0; 60],
+            hpke_sealed_key: [0; 48],
             ephemeral_pubkey: [0; 32],
             request_nonce: [0; REQUEST_NONCE_SIZE],
         });
@@ -1978,17 +1938,20 @@ mod tests {
         let (sealed, ephemeral_pub) =
             handle_bridge_shadow_key_request(&recipient_pub, &params).unwrap();
 
-        // Unwrap: ECDH with recipient secret and ephemeral public.
-        let recipient_static = x25519_dalek::StaticSecret::from(recipient_secret);
-        let eph_pub = x25519_dalek::PublicKey::from(ephemeral_pub);
-        let shared = recipient_static.diffie_hellman(&eph_pub);
-        let info = build_hpke_info("ctx-bridge-test", "shadow:bridge-001:user-alice", 0);
-        let aad = build_hpke_aad("ctx-bridge-test", "shadow:bridge-001:user-alice", 0);
-        let aes_key = hkdf_derive_key(shared.as_bytes(), &info).unwrap();
+        // ct is exactly 48 bytes: 32-byte key + 16-byte AEAD tag.
+        assert_eq!(sealed.len(), 48);
 
-        let decrypted = aes128gcm_decrypt(&aes_key, &sealed, &aad).unwrap();
-        assert_eq!(decrypted.len(), 32);
-        assert_eq!(&decrypted[..], shadow_key.as_bytes());
+        // Unwrap via the HPKE open path (epoch 0 for shadow keys).
+        let recovered = hpke_open_sender_key(
+            &sealed,
+            &ephemeral_pub,
+            &recipient_secret,
+            "ctx-bridge-test",
+            "shadow:bridge-001:user-alice",
+            0,
+        )
+        .unwrap();
+        assert_eq!(recovered.as_bytes(), shadow_key.as_bytes());
     }
 
     #[test]
@@ -2096,7 +2059,7 @@ mod tests {
         let response = SenderKeyResponse {
             sender_did: "did:dht:alice".to_owned(),
             epoch: 3,
-            hpke_sealed_key: [0x44; 60],
+            hpke_sealed_key: [0x44; 48],
             ephemeral_pubkey: [0x55; 32],
             request_nonce: [0x66; REQUEST_NONCE_SIZE],
         };

--- a/crates/scp-protocol/src/crypto/sender_keys/key_protocol_verify.rs
+++ b/crates/scp-protocol/src/crypto/sender_keys/key_protocol_verify.rs
@@ -702,7 +702,7 @@ impl NonceDedup {
 // HPKE context binding helpers (§9.16.2)
 // ---------------------------------------------------------------------------
 
-/// Builds the HPKE `info` parameter for sender-key ECIES encryption (spec §9.16.2).
+/// Builds the HPKE `info` parameter for sender-key HPKE encryption (spec §9.16.2).
 ///
 /// Contains a fixed prefix, context ID, sender DID, and epoch — length-prefixed to
 /// prevent boundary-shift collisions.
@@ -726,7 +726,7 @@ pub fn build_hpke_info(context_id: &str, sender_did: &str, epoch: u64) -> Vec<u8
     info
 }
 
-/// Builds the HPKE `aad` (additional authenticated data) for sender-key ECIES encryption (spec §9.16.2).
+/// Builds the HPKE `aad` (additional authenticated data) for sender-key HPKE encryption (spec §9.16.2).
 ///
 /// Contains context ID, sender DID, and epoch — length-prefixed to prevent
 /// boundary-shift collisions.

--- a/crates/scp-protocol/src/crypto/sender_keys/key_protocol_verify.rs
+++ b/crates/scp-protocol/src/crypto/sender_keys/key_protocol_verify.rs
@@ -61,7 +61,9 @@ pub fn generate_wrapping_keypair() -> ([u8; 32], [u8; 32]) {
 pub const MAX_SENDER_KEY_MESSAGE_SIZE: usize = 65_536;
 
 /// HKDF info domain separator for sender key HPKE encryption (§9.16.2).
-/// The full info string is `"scp-sender-key-v1" || context_id || sender_did || epoch_BE`.
+/// The full info string is length-prefixed (see [`build_hpke_info`]):
+/// `"scp-sender-key-v1" || BE32(len(context_id)) || context_id ||
+/// BE32(len(sender_did)) || sender_did || BE64(epoch)`.
 const HPKE_INFO_PREFIX: &[u8] = b"scp-sender-key-v1";
 
 /// Grace period in seconds during which the old key should still be accepted

--- a/crates/scp-protocol/src/crypto/sender_keys/mod.rs
+++ b/crates/scp-protocol/src/crypto/sender_keys/mod.rs
@@ -32,9 +32,11 @@ use zeroize::{Zeroize, ZeroizeOnDrop};
 
 pub use broadcast::{
     BroadcastEnvelope, BroadcastKey, BroadcastKeyEpochAdvance, BroadcastReplayDetector,
-    SealBroadcastParams, SigningPayloadFields, build_broadcast_signing_payload,
-    compute_provenance_hash, generate_broadcast_key, generate_broadcast_nonce, open_broadcast,
-    open_broadcast_trusted, rotate_broadcast_key, seal_broadcast, validate_broadcast_version,
+    SealBroadcastParams, SigningPayloadFields, build_broadcast_key_hpke_aad,
+    build_broadcast_key_hpke_info, build_broadcast_signing_payload, compute_provenance_hash,
+    generate_broadcast_key, generate_broadcast_nonce, open_broadcast, open_broadcast_key,
+    open_broadcast_trusted, rotate_broadcast_key, seal_broadcast, seal_broadcast_key_to_subscriber,
+    validate_broadcast_version,
 };
 pub use encrypt::{decrypt_sender_layer, encrypt_sender_layer};
 // build_sender_header, parse_sender_header, and SENDER_HEADER_SIZE are wire-format

--- a/crates/scp-protocol/src/serde_util.rs
+++ b/crates/scp-protocol/src/serde_util.rs
@@ -9,7 +9,7 @@
 //! - [`serde_signature_64`] — Ed25519 signatures (exactly 64 bytes)
 //! - [`serde_hash_32`] — SHA-256 hashes (exactly 32 bytes)
 //! - [`serde_pubkey_32`] — X25519 / Ed25519 public keys (exactly 32 bytes)
-//! - [`serde_hpke_sealed_60`] — HPKE-sealed sender key (exactly 60 bytes)
+//! - [`serde_hpke_sealed_48`] — HPKE-sealed sender key (exactly 48 bytes)
 //!
 //! # Bounded variable-size
 //!
@@ -149,32 +149,33 @@ pub mod serde_pubkey_32 {
     }
 }
 
-/// Serde module for `[u8; 60]` fields (HPKE-sealed sender keys).
+/// Serde module for `[u8; 48]` fields (HPKE-sealed sender keys).
 ///
-/// The HPKE-sealed sender key is exactly 60 bytes: AES-128-GCM nonce (12) +
-/// encrypted sender key (32) + authentication tag (16). Using a fixed-size
-/// array prevents allocation of arbitrarily large buffers from malicious input.
+/// The HPKE ciphertext is exactly 48 bytes: encrypted sender key (32) +
+/// AES-128-GCM authentication tag (16). The AEAD nonce is internal per RFC
+/// 9180 — it is NOT carried on the wire. Using a fixed-size array prevents
+/// allocation of arbitrarily large buffers from malicious input.
 #[allow(clippy::missing_errors_doc)] // Serde trait impls — error semantics are self-evident.
-pub mod serde_hpke_sealed_60 {
+pub mod serde_hpke_sealed_48 {
     use serde::{self, Deserializer, Serializer};
 
-    /// Serializes a 60-byte HPKE-sealed sender key as compact binary.
-    pub fn serialize<S>(bytes: &[u8; 60], serializer: S) -> Result<S::Ok, S::Error>
+    /// Serializes a 48-byte HPKE-sealed sender key as compact binary.
+    pub fn serialize<S>(bytes: &[u8; 48], serializer: S) -> Result<S::Ok, S::Error>
     where
         S: Serializer,
     {
         serde_bytes::serialize(bytes.as_slice(), serializer)
     }
 
-    /// Deserializes exactly 60 bytes as an HPKE-sealed sender key.
-    pub fn deserialize<'de, D>(deserializer: D) -> Result<[u8; 60], D::Error>
+    /// Deserializes exactly 48 bytes as an HPKE-sealed sender key.
+    pub fn deserialize<'de, D>(deserializer: D) -> Result<[u8; 48], D::Error>
     where
         D: Deserializer<'de>,
     {
         let v: Vec<u8> = serde_bytes::deserialize(deserializer)?;
         v.try_into().map_err(|v: Vec<u8>| {
             serde::de::Error::custom(format!(
-                "expected 60-byte HPKE sealed key, got {} bytes",
+                "expected 48-byte HPKE sealed key, got {} bytes",
                 v.len()
             ))
         })
@@ -767,12 +768,12 @@ mod tests {
         );
     }
 
-    // --- hpke_sealed_60 tests ---
+    // --- hpke_sealed_48 tests ---
 
     #[derive(Debug, serde::Serialize, serde::Deserialize)]
-    struct HpkeSealed60Wrapper {
-        #[serde(with = "serde_hpke_sealed_60")]
-        sealed: [u8; 60],
+    struct HpkeSealed48Wrapper {
+        #[serde(with = "serde_hpke_sealed_48")]
+        sealed: [u8; 48],
     }
 
     #[derive(Debug, serde::Serialize, serde::Deserialize)]
@@ -782,33 +783,33 @@ mod tests {
     }
 
     #[test]
-    fn hpke_sealed_60_roundtrip() {
-        let wrapper = HpkeSealed60Wrapper { sealed: [0xAB; 60] };
+    fn hpke_sealed_48_roundtrip() {
+        let wrapper = HpkeSealed48Wrapper { sealed: [0xAB; 48] };
         let serialized = rmp_serde::to_vec_named(&wrapper).unwrap();
-        let deserialized: HpkeSealed60Wrapper = rmp_serde::from_slice(&serialized).unwrap();
-        assert_eq!(deserialized.sealed, [0xAB; 60]);
+        let deserialized: HpkeSealed48Wrapper = rmp_serde::from_slice(&serialized).unwrap();
+        assert_eq!(deserialized.sealed, [0xAB; 48]);
     }
 
     #[test]
-    fn hpke_sealed_60_rejects_wrong_size() {
+    fn hpke_sealed_48_rejects_wrong_size() {
         let bad = BadHpkeSealedWrapper {
-            sealed: vec![0u8; 59],
+            sealed: vec![0u8; 47],
         };
         let serialized = rmp_serde::to_vec_named(&bad).unwrap();
-        let result = rmp_serde::from_slice::<HpkeSealed60Wrapper>(&serialized);
+        let result = rmp_serde::from_slice::<HpkeSealed48Wrapper>(&serialized);
         assert!(result.is_err());
         let err = result.unwrap_err().to_string();
         assert!(
-            err.contains("60-byte HPKE sealed key"),
-            "error should mention 60-byte: {err}"
+            err.contains("48-byte HPKE sealed key"),
+            "error should mention 48-byte: {err}"
         );
 
-        // 61 bytes — too long
+        // 49 bytes — too long
         let bad_long = BadHpkeSealedWrapper {
-            sealed: vec![0u8; 61],
+            sealed: vec![0u8; 49],
         };
         let serialized_long = rmp_serde::to_vec_named(&bad_long).unwrap();
-        let result = rmp_serde::from_slice::<HpkeSealed60Wrapper>(&serialized_long);
+        let result = rmp_serde::from_slice::<HpkeSealed48Wrapper>(&serialized_long);
         assert!(result.is_err());
     }
 

--- a/crates/scp-protocol/tests/hpke_oracle.rs
+++ b/crates/scp-protocol/tests/hpke_oracle.rs
@@ -1,0 +1,141 @@
+//! Cross-validation of `scp_protocol::crypto::hpke` against the `hpke-rs`
+//! RFC 9180 reference implementation.
+//!
+//! These tests are the independent backstop for the hand-implemented HPKE
+//! core: any transcription or composition error that the Appendix A.1 KATs
+//! somehow miss would surface here as an interop failure against a separate
+//! codebase. `hpke-rs` is a dev-dependency only — it never ships in
+//! production or wasm32 builds — and this whole file is gated off wasm32.
+#![cfg(not(target_arch = "wasm32"))]
+#![allow(clippy::unwrap_used, clippy::panic)]
+
+use hpke_rs::hpke_types::{AeadAlgorithm, KdfAlgorithm, KemAlgorithm};
+use hpke_rs::{Hpke, HpkePrivateKey, HpkePublicKey, Mode};
+use hpke_rs_rust_crypto::HpkeRustCrypto;
+use rand::rngs::OsRng;
+use scp_protocol::crypto::hpke;
+use x25519_dalek::{PublicKey as X25519Pub, StaticSecret};
+
+/// Construct the SCP suite under the `hpke-rs` reference implementation:
+/// DHKEM(X25519, HKDF-SHA256) / HKDF-SHA256 / AES-128-GCM, Base mode.
+fn ref_hpke() -> Hpke<HpkeRustCrypto> {
+    Hpke::<HpkeRustCrypto>::new(
+        Mode::Base,
+        KemAlgorithm::DhKem25519,
+        KdfAlgorithm::HkdfSha256,
+        AeadAlgorithm::Aes128Gcm,
+    )
+}
+
+fn fresh_keypair() -> (StaticSecret, [u8; 32]) {
+    let sk = StaticSecret::random_from_rng(OsRng);
+    let pk = X25519Pub::from(&sk).to_bytes();
+    (sk, pk)
+}
+
+/// Our `seal` → reference `open`. Run across several input shapes.
+///
+/// NOTE: empty-plaintext is intentionally NOT exercised in this direction —
+/// `hpke-rs`'s `open` rejects an empty recovered plaintext as `InvalidInput`
+/// (its `bytes_to_option` maps an empty result to `None`; see hpke-rs lib.rs
+/// §1101). That is a quirk of the reference receiver, not of our seal: the
+/// empty case is covered by our in-crate roundtrip KAT and by the
+/// reference→ours direction below.
+#[test]
+fn our_seal_opens_under_reference() {
+    let cases: &[(&[u8], &[u8], &[u8])] = &[
+        (b"", b"", b"x"),
+        (
+            b"scp-sender-key-v1",
+            b"aad",
+            b"32-byte-payload-padded-to-len!!!",
+        ),
+        (b"info", b"", &[0xAB; 100]),
+        (b"\x00\x01\x02", b"\xff\xfe", b"x"),
+    ];
+
+    for (idx, (info, aad, pt)) in cases.iter().enumerate() {
+        let (sk, pk) = fresh_keypair();
+        let (enc, ct) = hpke::seal(&pk, info, aad, pt).unwrap();
+
+        let reference = ref_hpke();
+        let recovered = reference
+            .open(
+                &enc,
+                &HpkePrivateKey::new(sk.to_bytes().to_vec()),
+                info,
+                aad,
+                &ct,
+                None,
+                None,
+                None,
+            )
+            .unwrap_or_else(|e| panic!("case {idx}: reference open failed: {e:?}"));
+        assert_eq!(recovered.as_slice(), *pt, "case {idx}: plaintext mismatch");
+    }
+}
+
+/// Reference `seal` → our `open`. Run across several input shapes.
+#[test]
+fn reference_seal_opens_under_ours() {
+    let cases: &[(&[u8], &[u8], &[u8])] = &[
+        (b"", b"", b""),
+        (b"scp-access-key-v1", b"aad-bytes", b"the quick brown fox"),
+        (b"info", b"", &[0x5A; 257]),
+        (b"\x10\x20", b"\x30", b"yz"),
+    ];
+
+    for (idx, (info, aad, pt)) in cases.iter().enumerate() {
+        let (sk, pk) = fresh_keypair();
+
+        let mut reference = ref_hpke();
+        let (enc, ct) = reference
+            .seal(
+                &HpkePublicKey::new(pk.to_vec()),
+                info,
+                aad,
+                pt,
+                None,
+                None,
+                None,
+            )
+            .unwrap_or_else(|e| panic!("case {idx}: reference seal failed: {e:?}"));
+
+        let enc_arr: [u8; 32] = enc.as_slice().try_into().unwrap();
+        let recovered = hpke::open(&sk.to_bytes(), &enc_arr, info, aad, &ct).unwrap();
+        assert_eq!(recovered.as_slice(), *pt, "case {idx}: plaintext mismatch");
+    }
+}
+
+/// Reference `seal` → our custody-path `open` (external DH). Confirms the
+/// custody Decap variant interops with the reference too.
+#[test]
+fn reference_seal_opens_under_custody() {
+    let (sk, pk) = fresh_keypair();
+    let info = b"scp-broadcast-key-v1";
+    let aad = b"ctx||author||epoch";
+    let pt = b"broadcast key material 32 bytes!";
+
+    let mut reference = ref_hpke();
+    let (enc, ct) = reference
+        .seal(
+            &HpkePublicKey::new(pk.to_vec()),
+            info,
+            aad,
+            pt,
+            None,
+            None,
+            None,
+        )
+        .unwrap();
+    let enc_arr: [u8; 32] = enc.as_slice().try_into().unwrap();
+
+    // Simulate KeyCustody::dh_agree(handle, enc) = DH(skR, enc) and
+    // KeyCustody::public_key(handle) = pkR.
+    let enc_pub = X25519Pub::from(enc_arr);
+    let dh = sk.diffie_hellman(&enc_pub);
+
+    let recovered =
+        hpke::custody::open_with_external_dh(dh.as_bytes(), &pk, &enc_arr, info, aad, &ct).unwrap();
+    assert_eq!(recovered.as_slice(), pt);
+}

--- a/crates/scp-runtime/src/crypto/access_keys/wire.rs
+++ b/crates/scp-runtime/src/crypto/access_keys/wire.rs
@@ -1,40 +1,33 @@
 //! Wire types and HPKE distribution protocol for access keys.
 //!
-//! Access keys are distributed via the same pull-based HPKE protocol as
-//! sender keys (§9.16.2), but with a distinct domain separator
-//! (`"scp-access-key-v1"`) to prevent cross-protocol key confusion.
+//! Access keys are distributed via the same pull-based RFC 9180 HPKE protocol
+//! as sender keys (§9.16.2), but with a distinct domain separator
+//! (`"scp-access-key-v1"`) to prevent cross-protocol key confusion. Sealing and
+//! opening go through the shared [`scp_protocol::crypto::hpke`] core.
 //!
 //! Protocol flow:
 //! 1. New member sends [`AccessKeyRequest`] with ephemeral X25519 wrapping
 //!    pubkey, signature, nonce, and timestamp for replay protection.
-//! 2. Key holder verifies the request and HPKE-encrypts the access key.
+//! 2. Key holder verifies the request and HPKE-seals the access key.
 //! 3. Key holder responds with [`AccessKeyResponse`] containing the sealed
-//!    key and ephemeral pubkey.
-//! 4. Requester decrypts via [`open_access_key_response`].
+//!    ciphertext (`ct`) and the HPKE encapsulated key (`enc`).
+//! 4. Requester opens via [`open_access_key_response`].
 //!
 //! See ADR-038 §2 and spec §9.17.1.
 
-use aes_gcm::aead::{Aead, Payload};
-use aes_gcm::{Aes128Gcm, KeyInit, Nonce};
-use hkdf::Hkdf;
 use rand::RngCore;
 use rand::rngs::OsRng;
 use serde::{Deserialize, Serialize};
-use sha2::Sha256;
-use x25519_dalek::{EphemeralSecret, PublicKey as X25519Pub};
-use zeroize::Zeroizing;
 
 use scp_platform::traits::{KeyCustody, KeyHandle, KeyType};
 use scp_primitives::Clock;
 
 use scp_protocol::crypto::access_keys::{AccessKey, AccessKeyError};
+use scp_protocol::crypto::hpke;
 
 // ---------------------------------------------------------------------------
 // Constants
 // ---------------------------------------------------------------------------
-
-/// AES-128-GCM nonce size in bytes.
-const HPKE_NONCE_SIZE: usize = 12;
 
 /// Size of the cryptographic nonce in access key requests (bytes).
 const ACCESS_KEY_NONCE_SIZE: usize = 16;
@@ -101,9 +94,10 @@ pub struct AccessKeyRequest {
 
 /// Response containing HPKE-encrypted access key material.
 ///
-/// Sent back to the requester. The access key is encrypted using HPKE:
-/// ephemeral X25519 ECDH + HKDF-SHA256 + AES-128-GCM, with the
-/// `"scp-access-key-v1"` domain separator.
+/// Sent back to the requester. The access key is sealed with RFC 9180 HPKE
+/// Base mode (DHKEM(X25519, HKDF-SHA256) / HKDF-SHA256 / AES-128-GCM) under
+/// the `"scp-access-key-v1"` domain separator. The AEAD nonce is internal per
+/// RFC 9180 — there is no external nonce on the wire.
 ///
 /// See spec §9.17.1 and ADR-038 §2.
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -114,10 +108,10 @@ pub struct AccessKeyResponse {
     pub member_did: String,
     /// The epoch of the distributed access key.
     pub epoch: u64,
-    /// HPKE-sealed access key bytes (AES-128-GCM nonce || ciphertext || tag).
+    /// HPKE ciphertext (`ct = ciphertext || tag`, 48 bytes for a 32-byte key).
     #[serde(with = "serde_bytes")]
     pub hpke_sealed_key: Vec<u8>,
-    /// The ephemeral X25519 public key used in the HPKE encapsulation.
+    /// HPKE encapsulated key (`enc`, the 32-byte ephemeral X25519 public key).
     #[serde(with = "serde_bytes")]
     pub ephemeral_pubkey: Vec<u8>,
 }
@@ -311,7 +305,8 @@ pub fn handle_access_key_request(
         ))
     })?;
 
-    // HPKE seal with access-key-specific info string and AAD binding.
+    // HPKE seal with access-key-specific info string and AAD binding
+    // (RFC 9180 Base mode via the shared hpke core).
     let info = build_hpke_info(
         access_key.context_id(),
         access_key.member_did(),
@@ -322,14 +317,15 @@ pub fn handle_access_key_request(
         access_key.member_did(),
         access_key.epoch(),
     );
-    let (sealed, ephemeral_pub) = hpke_seal(access_key.as_bytes(), &wrapping_bytes, &info, &aad)?;
+    let (enc, sealed) = hpke::seal(&wrapping_bytes, &info, &aad, access_key.as_bytes())
+        .map_err(|e| AccessKeyError::HpkeEncryptionFailed(e.to_string()))?;
 
     let response = AccessKeyResponse {
         context_id: access_key.context_id().to_owned(),
         member_did: access_key.member_did().to_owned(),
         epoch: access_key.epoch(),
         hpke_sealed_key: sealed,
-        ephemeral_pubkey: ephemeral_pub.to_vec(),
+        ephemeral_pubkey: enc.to_vec(),
     };
 
     // Record the nonce only after the request has been fully validated and
@@ -344,51 +340,68 @@ pub fn handle_access_key_request(
 // Response handling (requester side)
 // ---------------------------------------------------------------------------
 
-/// Decrypts an [`AccessKeyResponse`] using the requester's wrapping key
-/// handle inside the [`KeyCustody`] boundary.
+/// Opens an [`AccessKeyResponse`] using the requester's wrapping key handle
+/// inside the [`KeyCustody`] boundary (RFC 9180 HPKE Base mode, §9.17.1).
 ///
-/// The shared secret is computed via `key_custody.dh_agree(wrapping_key_handle,
-/// ephemeral_pk)` so the wrapping private key never leaves custody. KDF +
-/// AEAD decryption then recovers the access key in software.
+/// The KEM Diffie-Hellman output is computed inside custody via
+/// `key_custody.dh_agree(wrapping_key_handle, enc)` so the wrapping private key
+/// never leaves the boundary; `pkRm` is fetched via
+/// `key_custody.public_key(wrapping_key_handle)`. DHKEM Decap
+/// (`ExtractAndExpand(dh, enc || pkRm)`), `KeySchedule_base`, and the AEAD open
+/// then complete in software via
+/// [`scp_protocol::crypto::hpke::custody::open_with_external_dh`].
 ///
 /// # Errors
 ///
-/// Returns [`AccessKeyError::KeyCustodyError`] if the DH agreement fails.
-/// Returns [`AccessKeyError::HpkeDecryptionFailed`] if AEAD decryption fails.
+/// Returns [`AccessKeyError::KeyCustodyError`] if the DH agreement or
+/// public-key lookup fails. Returns [`AccessKeyError::HpkeDecryptionFailed`]
+/// if HPKE open fails or the recovered plaintext is not exactly 32 bytes.
 pub async fn open_access_key_response(
     key_custody: &impl KeyCustody,
     wrapping_key_handle: &KeyHandle,
     response: &AccessKeyResponse,
 ) -> Result<AccessKey, AccessKeyError> {
-    let ephemeral_bytes: [u8; 32] =
-        response
-            .ephemeral_pubkey
-            .as_slice()
-            .try_into()
-            .map_err(|_| {
-                AccessKeyError::HpkeDecryptionFailed(format!(
-                    "ephemeral pubkey must be 32 bytes, got {}",
-                    response.ephemeral_pubkey.len()
-                ))
-            })?;
+    let enc: [u8; 32] = response
+        .ephemeral_pubkey
+        .as_slice()
+        .try_into()
+        .map_err(|_| {
+            AccessKeyError::HpkeDecryptionFailed(format!(
+                "ephemeral pubkey must be 32 bytes, got {}",
+                response.ephemeral_pubkey.len()
+            ))
+        })?;
 
-    // Compute shared secret inside custody boundary.
-    let shared_secret = key_custody
-        .dh_agree(wrapping_key_handle, &ephemeral_bytes)
+    // Compute the KEM DH output inside the custody boundary (same handle,
+    // same enc — the only sound inputs to open_with_external_dh).
+    let dh = key_custody
+        .dh_agree(wrapping_key_handle, &enc)
         .await
         .map_err(|e| AccessKeyError::KeyCustodyError(e.to_string()))?;
+    let dh_bytes: [u8; 32] = *dh.as_bytes();
 
-    // Build info string with access-key-specific domain separator.
+    // Fetch pkRm for the same handle (kem_context = enc || pkRm).
+    let pk_rm = key_custody
+        .public_key(wrapping_key_handle)
+        .await
+        .map_err(|e| AccessKeyError::KeyCustodyError(e.to_string()))?;
+    let pk_rm_bytes: [u8; 32] = pk_rm.as_bytes().try_into().map_err(|_| {
+        AccessKeyError::KeyCustodyError("wrapping public key must be 32 bytes".to_owned())
+    })?;
+
+    // Build context-bound info and AAD (§9.17.1).
     let info = build_hpke_info(&response.context_id, &response.member_did, response.epoch);
-
-    // Derive AES-128-GCM key from shared secret (zeroized on drop).
-    let aes_key = hkdf_derive_key(shared_secret.as_bytes(), &info)?;
-
-    // Build AAD to verify context binding during decryption.
     let aad = build_hpke_aad(&response.context_id, &response.member_did, response.epoch);
 
-    // Decrypt the sealed access key.
-    let plaintext = aes128gcm_decrypt(&aes_key, &response.hpke_sealed_key, &aad)?;
+    let plaintext = hpke::custody::open_with_external_dh(
+        &dh_bytes,
+        &pk_rm_bytes,
+        &enc,
+        &info,
+        &aad,
+        &response.hpke_sealed_key,
+    )
+    .map_err(|e| AccessKeyError::HpkeDecryptionFailed(e.to_string()))?;
 
     let key_bytes: [u8; 32] = plaintext.as_slice().try_into().map_err(|_| {
         AccessKeyError::HpkeDecryptionFailed(format!(
@@ -434,109 +447,6 @@ fn build_hpke_info(context_id: &str, member_did: &str, epoch: u64) -> Vec<u8> {
     info.extend_from_slice(member_did.as_bytes());
     info.extend_from_slice(&epoch.to_be_bytes());
     info
-}
-
-/// HPKE seal: encrypts `plaintext` to `recipient_pub` using ephemeral X25519
-/// ECDH + HKDF-SHA256 + AES-128-GCM with access-key-specific info string.
-///
-/// `aad` is bound to the AEAD tag as Additional Authenticated Data,
-/// preventing ciphertext relocation across contexts or members.
-///
-/// Returns `(sealed_bytes, ephemeral_public_key)`.
-fn hpke_seal(
-    plaintext: &[u8; 32],
-    recipient_pub: &[u8; 32],
-    info: &[u8],
-    aad: &[u8],
-) -> Result<(Vec<u8>, [u8; 32]), AccessKeyError> {
-    // 1. Generate ephemeral X25519 keypair.
-    let ephemeral_secret = EphemeralSecret::random_from_rng(OsRng);
-    let ephemeral_public = X25519Pub::from(&ephemeral_secret);
-
-    // 2. ECDH between ephemeral secret and recipient's wrapping pubkey.
-    let recipient_key = X25519Pub::from(*recipient_pub);
-    let shared_secret = ephemeral_secret.diffie_hellman(&recipient_key);
-
-    // 3. HKDF to derive 16-byte AES-128-GCM key (zeroized on drop).
-    let aes_key = hkdf_derive_key(shared_secret.as_bytes(), info)?;
-
-    // 4. AES-128-GCM encrypt with AAD binding.
-    let sealed = aes128gcm_encrypt(&aes_key, plaintext, aad)?;
-
-    Ok((sealed, ephemeral_public.to_bytes()))
-}
-
-/// Derives a 16-byte AES-128-GCM key from a 32-byte shared secret using
-/// HKDF-SHA256 with the access-key-specific info string.
-///
-/// The returned key is wrapped in [`Zeroizing`] so the derived key material
-/// is zeroed on drop (defense-in-depth).
-fn hkdf_derive_key(
-    shared_secret: &[u8],
-    info: &[u8],
-) -> Result<Zeroizing<[u8; 16]>, AccessKeyError> {
-    let hk = Hkdf::<Sha256>::new(None, shared_secret);
-    let mut okm = Zeroizing::new([0u8; 16]);
-    hk.expand(info, okm.as_mut())
-        .map_err(|e| AccessKeyError::HpkeEncryptionFailed(e.to_string()))?;
-    Ok(okm)
-}
-
-/// Encrypts `plaintext` with AES-128-GCM using `aad` as Additional
-/// Authenticated Data. Returns `nonce || ciphertext || tag`.
-fn aes128gcm_encrypt(
-    key: &[u8; 16],
-    plaintext: &[u8],
-    aad: &[u8],
-) -> Result<Vec<u8>, AccessKeyError> {
-    let cipher = Aes128Gcm::new_from_slice(key)
-        .map_err(|e| AccessKeyError::HpkeEncryptionFailed(e.to_string()))?;
-
-    let mut nonce_bytes = [0u8; HPKE_NONCE_SIZE];
-    OsRng.fill_bytes(&mut nonce_bytes);
-    let nonce = Nonce::from_slice(&nonce_bytes);
-
-    let ciphertext = cipher
-        .encrypt(
-            nonce,
-            Payload {
-                msg: plaintext,
-                aad,
-            },
-        )
-        .map_err(|e| AccessKeyError::HpkeEncryptionFailed(e.to_string()))?;
-
-    let mut output = Vec::with_capacity(HPKE_NONCE_SIZE + ciphertext.len());
-    output.extend_from_slice(&nonce_bytes);
-    output.extend_from_slice(&ciphertext);
-    Ok(output)
-}
-
-/// Decrypts AES-128-GCM ciphertext of the form `nonce || ciphertext || tag`,
-/// verifying `aad` as Additional Authenticated Data.
-fn aes128gcm_decrypt(key: &[u8; 16], sealed: &[u8], aad: &[u8]) -> Result<Vec<u8>, AccessKeyError> {
-    if sealed.len() < HPKE_NONCE_SIZE {
-        return Err(AccessKeyError::HpkeDecryptionFailed(format!(
-            "sealed data too short: {} bytes, minimum {HPKE_NONCE_SIZE}",
-            sealed.len(),
-        )));
-    }
-
-    let (nonce_bytes, encrypted) = sealed.split_at(HPKE_NONCE_SIZE);
-    let nonce = Nonce::from_slice(nonce_bytes);
-
-    let cipher = Aes128Gcm::new_from_slice(key)
-        .map_err(|e| AccessKeyError::HpkeDecryptionFailed(e.to_string()))?;
-
-    cipher
-        .decrypt(
-            nonce,
-            Payload {
-                msg: encrypted,
-                aad,
-            },
-        )
-        .map_err(|e| AccessKeyError::HpkeDecryptionFailed(e.to_string()))
 }
 
 /// Builds Additional Authenticated Data (AAD) for access key HPKE
@@ -623,6 +533,8 @@ fn verify_ed25519_signature(
 #[cfg(test)]
 #[allow(clippy::unwrap_used, clippy::expect_used)]
 mod tests {
+    use x25519_dalek::{PublicKey as X25519Pub, StaticSecret};
+
     use super::*;
     use scp_protocol::crypto::access_keys::generate_access_key;
     use scp_protocol::crypto::sender_keys::NonceDedup;
@@ -779,61 +691,61 @@ mod tests {
 
     #[test]
     fn hpke_seal_open_roundtrip() {
-        // Generate a simulated wrapping keypair.
-        let wrapping_secret = EphemeralSecret::random_from_rng(OsRng);
+        // Generate a simulated wrapping keypair (software-held).
+        let wrapping_secret = StaticSecret::random_from_rng(OsRng);
         let wrapping_public = X25519Pub::from(&wrapping_secret);
 
         let access_key = generate_access_key("ctx-1", "did:dht:alice");
         let info = build_hpke_info("ctx-1", "did:dht:alice", 0);
         let aad = build_hpke_aad("ctx-1", "did:dht:alice", 0);
 
-        // Seal.
-        let (sealed, ephemeral_pub) = hpke_seal(
-            access_key.as_bytes(),
-            &wrapping_public.to_bytes(),
-            &info,
-            &aad,
-        )
-        .unwrap();
+        // Seal via the shared RFC 9180 HPKE core.
+        let (enc, sealed) =
+            hpke::seal(&wrapping_public.to_bytes(), &info, &aad, access_key.as_bytes()).unwrap();
 
-        // Derive shared secret on the requester side.
-        let ephemeral_key = X25519Pub::from(ephemeral_pub);
-        let shared_secret = wrapping_secret.diffie_hellman(&ephemeral_key);
+        // ct is exactly 48 bytes: 32-byte key + 16-byte AEAD tag.
+        assert_eq!(sealed.len(), 48);
 
-        // Derive AES key and decrypt.
-        let aes_key = hkdf_derive_key(shared_secret.as_bytes(), &info).unwrap();
-        let plaintext = aes128gcm_decrypt(&aes_key, &sealed, &aad).unwrap();
+        // Open with the software-held secret.
+        let plaintext = hpke::open(&wrapping_secret.to_bytes(), &enc, &info, &aad, &sealed).unwrap();
 
         assert_eq!(plaintext.len(), 32);
         assert_eq!(plaintext.as_slice(), access_key.as_bytes());
     }
 
     #[test]
-    fn hpke_seal_produces_nonce_plus_ciphertext_plus_tag() {
-        let wrapping_secret = EphemeralSecret::random_from_rng(OsRng);
+    fn hpke_seal_produces_ciphertext_plus_tag() {
+        let wrapping_secret = StaticSecret::random_from_rng(OsRng);
         let wrapping_public = X25519Pub::from(&wrapping_secret);
         let info = build_hpke_info("ctx-1", "did:dht:alice", 0);
         let aad = build_hpke_aad("ctx-1", "did:dht:alice", 0);
 
         let key_bytes = [42u8; 32];
-        let (sealed, _) = hpke_seal(&key_bytes, &wrapping_public.to_bytes(), &info, &aad).unwrap();
+        let (_enc, sealed) = hpke::seal(&wrapping_public.to_bytes(), &info, &aad, &key_bytes).unwrap();
 
-        // nonce (12) + plaintext (32) + tag (16) = 60
-        assert_eq!(sealed.len(), HPKE_NONCE_SIZE + 32 + 16);
+        // RFC 9180: ct = plaintext (32) + AEAD tag (16) = 48. No external nonce.
+        assert_eq!(sealed.len(), 32 + 16);
     }
 
     #[test]
-    fn hpke_different_info_produces_different_keys() {
-        // Same shared secret but different info strings should produce
-        // different derived keys.
-        let shared_secret = [42u8; 32];
+    fn hpke_different_info_produces_different_ciphertext() {
+        // Sealing the same key under different info strings (different context)
+        // must not cross-open: a ciphertext sealed with info_a fails to open
+        // with info_b.
+        let wrapping_secret = StaticSecret::random_from_rng(OsRng);
+        let wrapping_public = X25519Pub::from(&wrapping_secret);
         let info_a = build_hpke_info("ctx-a", "did:dht:alice", 0);
+        let aad_a = build_hpke_aad("ctx-a", "did:dht:alice", 0);
         let info_b = build_hpke_info("ctx-b", "did:dht:alice", 0);
+        let aad_b = build_hpke_aad("ctx-b", "did:dht:alice", 0);
 
-        let key_a = hkdf_derive_key(&shared_secret, &info_a).unwrap();
-        let key_b = hkdf_derive_key(&shared_secret, &info_b).unwrap();
+        let (enc, sealed) =
+            hpke::seal(&wrapping_public.to_bytes(), &info_a, &aad_a, &[42u8; 32]).unwrap();
 
-        assert_ne!(*key_a, *key_b);
+        assert!(
+            hpke::open(&wrapping_secret.to_bytes(), &enc, &info_b, &aad_b, &sealed).is_err(),
+            "different info/aad must fail to open"
+        );
     }
 
     // -----------------------------------------------------------------------
@@ -1029,8 +941,9 @@ mod tests {
         let signing_key = SigningKey::generate(&mut OsRng);
         let verifying_key = signing_key.verifying_key();
 
-        // 2. Generate X25519 wrapping keypair for the requester.
-        let wrapping_secret = EphemeralSecret::random_from_rng(OsRng);
+        // 2. Generate X25519 wrapping keypair for the requester (software-held
+        //    StaticSecret so the test can run the software `hpke::open` path).
+        let wrapping_secret = StaticSecret::random_from_rng(OsRng);
         let wrapping_public = X25519Pub::from(&wrapping_secret);
 
         let timestamp = 1_700_000_000_u64;
@@ -1078,15 +991,13 @@ mod tests {
         assert_eq!(response.member_did, "did:dht:alice");
         assert_eq!(response.epoch, 0);
 
-        // 7. Decrypt the response (requester side) -- manual HPKE open.
-        let ephemeral_bytes: [u8; 32] = response.ephemeral_pubkey.as_slice().try_into().unwrap();
-        let ephemeral_key = X25519Pub::from(ephemeral_bytes);
-        let shared_secret = wrapping_secret.diffie_hellman(&ephemeral_key);
-
+        // 7. Open the response (requester side) via the software HPKE path.
+        let enc: [u8; 32] = response.ephemeral_pubkey.as_slice().try_into().unwrap();
         let info = build_hpke_info("ctx-1", "did:dht:alice", 0);
-        let aes_key = hkdf_derive_key(shared_secret.as_bytes(), &info).unwrap();
         let aad = build_hpke_aad("ctx-1", "did:dht:alice", 0);
-        let plaintext = aes128gcm_decrypt(&aes_key, &response.hpke_sealed_key, &aad).unwrap();
+        let plaintext =
+            hpke::open(&wrapping_secret.to_bytes(), &enc, &info, &aad, &response.hpke_sealed_key)
+                .unwrap();
 
         let recovered_bytes: [u8; 32] = plaintext.as_slice().try_into().unwrap();
         assert_eq!(recovered_bytes, original_key_bytes);
@@ -1114,7 +1025,7 @@ mod tests {
         let signing_key = SigningKey::generate(&mut OsRng);
         let verifying_key = signing_key.verifying_key();
 
-        let wrapping_secret = EphemeralSecret::random_from_rng(OsRng);
+        let wrapping_secret = StaticSecret::random_from_rng(OsRng);
         let wrapping_public = X25519Pub::from(&wrapping_secret);
 
         let timestamp = 1_700_000_000_u64;

--- a/crates/scp-runtime/src/crypto/access_keys/wire.rs
+++ b/crates/scp-runtime/src/crypto/access_keys/wire.rs
@@ -18,6 +18,7 @@
 use rand::RngCore;
 use rand::rngs::OsRng;
 use serde::{Deserialize, Serialize};
+use zeroize::Zeroizing;
 
 use scp_platform::traits::{KeyCustody, KeyHandle, KeyType};
 use scp_primitives::Clock;
@@ -378,7 +379,7 @@ pub async fn open_access_key_response(
         .dh_agree(wrapping_key_handle, &enc)
         .await
         .map_err(|e| AccessKeyError::KeyCustodyError(e.to_string()))?;
-    let dh_bytes: [u8; 32] = *dh.as_bytes();
+    let dh_bytes: Zeroizing<[u8; 32]> = Zeroizing::new(*dh.as_bytes());
 
     // Fetch pkRm for the same handle (kem_context = enc || pkRm).
     let pk_rm = key_custody
@@ -393,15 +394,17 @@ pub async fn open_access_key_response(
     let info = build_hpke_info(&response.context_id, &response.member_did, response.epoch);
     let aad = build_hpke_aad(&response.context_id, &response.member_did, response.epoch);
 
-    let plaintext = hpke::custody::open_with_external_dh(
-        &dh_bytes,
-        &pk_rm_bytes,
-        &enc,
-        &info,
-        &aad,
-        &response.hpke_sealed_key,
-    )
-    .map_err(|e| AccessKeyError::HpkeDecryptionFailed(e.to_string()))?;
+    let plaintext = Zeroizing::new(
+        hpke::custody::open_with_external_dh(
+            &dh_bytes,
+            &pk_rm_bytes,
+            &enc,
+            &info,
+            &aad,
+            &response.hpke_sealed_key,
+        )
+        .map_err(|e| AccessKeyError::HpkeDecryptionFailed(e.to_string()))?,
+    );
 
     let key_bytes: [u8; 32] = plaintext.as_slice().try_into().map_err(|_| {
         AccessKeyError::HpkeDecryptionFailed(format!(

--- a/crates/scp-runtime/src/crypto/access_keys/wire.rs
+++ b/crates/scp-runtime/src/crypto/access_keys/wire.rs
@@ -700,14 +700,20 @@ mod tests {
         let aad = build_hpke_aad("ctx-1", "did:dht:alice", 0);
 
         // Seal via the shared RFC 9180 HPKE core.
-        let (enc, sealed) =
-            hpke::seal(&wrapping_public.to_bytes(), &info, &aad, access_key.as_bytes()).unwrap();
+        let (enc, sealed) = hpke::seal(
+            &wrapping_public.to_bytes(),
+            &info,
+            &aad,
+            access_key.as_bytes(),
+        )
+        .unwrap();
 
         // ct is exactly 48 bytes: 32-byte key + 16-byte AEAD tag.
         assert_eq!(sealed.len(), 48);
 
         // Open with the software-held secret.
-        let plaintext = hpke::open(&wrapping_secret.to_bytes(), &enc, &info, &aad, &sealed).unwrap();
+        let plaintext =
+            hpke::open(&wrapping_secret.to_bytes(), &enc, &info, &aad, &sealed).unwrap();
 
         assert_eq!(plaintext.len(), 32);
         assert_eq!(plaintext.as_slice(), access_key.as_bytes());
@@ -721,7 +727,8 @@ mod tests {
         let aad = build_hpke_aad("ctx-1", "did:dht:alice", 0);
 
         let key_bytes = [42u8; 32];
-        let (_enc, sealed) = hpke::seal(&wrapping_public.to_bytes(), &info, &aad, &key_bytes).unwrap();
+        let (_enc, sealed) =
+            hpke::seal(&wrapping_public.to_bytes(), &info, &aad, &key_bytes).unwrap();
 
         // RFC 9180: ct = plaintext (32) + AEAD tag (16) = 48. No external nonce.
         assert_eq!(sealed.len(), 32 + 16);
@@ -995,9 +1002,14 @@ mod tests {
         let enc: [u8; 32] = response.ephemeral_pubkey.as_slice().try_into().unwrap();
         let info = build_hpke_info("ctx-1", "did:dht:alice", 0);
         let aad = build_hpke_aad("ctx-1", "did:dht:alice", 0);
-        let plaintext =
-            hpke::open(&wrapping_secret.to_bytes(), &enc, &info, &aad, &response.hpke_sealed_key)
-                .unwrap();
+        let plaintext = hpke::open(
+            &wrapping_secret.to_bytes(),
+            &enc,
+            &info,
+            &aad,
+            &response.hpke_sealed_key,
+        )
+        .unwrap();
 
         let recovered_bytes: [u8; 32] = plaintext.as_slice().try_into().unwrap();
         assert_eq!(recovered_bytes, original_key_bytes);

--- a/crates/scp-runtime/src/crypto/access_keys/wire.rs
+++ b/crates/scp-runtime/src/crypto/access_keys/wire.rs
@@ -418,15 +418,16 @@ pub async fn open_access_key_response(
         .map_err(|e| AccessKeyError::HpkeDecryptionFailed(e.to_string()))?,
     );
 
-    let key_bytes: [u8; 32] = plaintext.as_slice().try_into().map_err(|_| {
-        AccessKeyError::HpkeDecryptionFailed(format!(
-            "decrypted key must be 32 bytes, got {}",
-            plaintext.len()
-        ))
-    })?;
+    let key_bytes: Zeroizing<[u8; 32]> =
+        Zeroizing::new(plaintext.as_slice().try_into().map_err(|_| {
+            AccessKeyError::HpkeDecryptionFailed(format!(
+                "decrypted key must be 32 bytes, got {}",
+                plaintext.len()
+            ))
+        })?);
 
     Ok(AccessKey::from_parts(
-        key_bytes,
+        *key_bytes,
         response.context_id.clone(),
         response.member_did.clone(),
         response.epoch,

--- a/crates/scp-runtime/src/crypto/access_keys/wire.rs
+++ b/crates/scp-runtime/src/crypto/access_keys/wire.rs
@@ -109,9 +109,11 @@ pub struct AccessKeyResponse {
     pub member_did: String,
     /// The epoch of the distributed access key.
     pub epoch: u64,
-    /// HPKE ciphertext (`ct = ciphertext || tag`, 48 bytes for a 32-byte key).
-    #[serde(with = "serde_bytes")]
-    pub hpke_sealed_key: Vec<u8>,
+    /// HPKE ciphertext (`ct = ciphertext || tag`, exactly 48 bytes: a 32-byte
+    /// access key plus the 16-byte AES-128-GCM tag). Fixed-size so deserialize
+    /// cannot allocate an arbitrarily large buffer from malicious input.
+    #[serde(with = "scp_protocol::serde_util::serde_hpke_sealed_48")]
+    pub hpke_sealed_key: [u8; 48],
     /// HPKE encapsulated key (`enc`, the 32-byte ephemeral X25519 public key).
     #[serde(with = "serde_bytes")]
     pub ephemeral_pubkey: Vec<u8>,
@@ -318,8 +320,18 @@ pub fn handle_access_key_request(
         access_key.member_did(),
         access_key.epoch(),
     );
-    let (enc, sealed) = hpke::seal(&wrapping_bytes, &info, &aad, access_key.as_bytes())
+    let (enc, sealed_vec) = hpke::seal(&wrapping_bytes, &info, &aad, access_key.as_bytes())
         .map_err(|e| AccessKeyError::HpkeEncryptionFailed(e.to_string()))?;
+
+    // Convert to fixed-size array. The HPKE seal always returns exactly 48
+    // bytes (ciphertext 32 + AES-128-GCM tag 16) for a 32-byte access key;
+    // the AEAD nonce is internal per RFC 9180.
+    let sealed: [u8; 48] = sealed_vec.try_into().map_err(|v: Vec<u8>| {
+        AccessKeyError::HpkeEncryptionFailed(format!(
+            "HPKE seal produced {} bytes, expected 48",
+            v.len()
+        ))
+    })?;
 
     let response = AccessKeyResponse {
         context_id: access_key.context_id().to_owned(),
@@ -570,7 +582,7 @@ mod tests {
             context_id: "ctx-1".to_owned(),
             member_did: "did:dht:alice".to_owned(),
             epoch: 5,
-            hpke_sealed_key: vec![1, 2, 3, 4],
+            hpke_sealed_key: [0x11; 48],
             ephemeral_pubkey: vec![0u8; 32],
         };
         let json = serde_json::to_string(&response).unwrap();
@@ -603,7 +615,7 @@ mod tests {
             context_id: "ctx-2".to_owned(),
             member_did: "did:dht:bob".to_owned(),
             epoch: 10,
-            hpke_sealed_key: vec![5, 6, 7, 8],
+            hpke_sealed_key: [0x55; 48],
             ephemeral_pubkey: vec![99u8; 32],
         };
         let bytes = rmp_serde::to_vec(&response).unwrap();

--- a/crates/scp-runtime/src/crypto/hpke_backend.rs
+++ b/crates/scp-runtime/src/crypto/hpke_backend.rs
@@ -5,17 +5,18 @@
 //! # Trait
 //!
 //! [`HpkeBackend`] is the narrow HPKE + wrapping-key primitive surface used by
-//! the sender-key and access-key distribution layers. It replaces the
-//! HPKE-flavoured methods that lived on the 26-method `ContextCryptoProvider`.
-//! The trait is `Send + Sync` and `#[async_trait]` so it is dyn-compatible
-//! (`Arc<dyn HpkeBackend>` lives in `ActorDeps`).
+//! the sender-key and access-key distribution layers. It is the ADR-049 §6
+//! actor seam (an `Arc<dyn HpkeBackend>` lives in `ActorDeps`). The trait is
+//! `Send + Sync` and `#[async_trait]` so it is dyn-compatible.
 //!
 //! Three methods:
 //!
-//! - [`HpkeBackend::seal`] — HPKE single-shot seal. Returns
-//!   `enc (32 bytes) || aead_nonce (12) || ciphertext || tag`.
-//! - [`HpkeBackend::unseal`] — inverse of `seal`. Returns the plaintext on
-//!   successful AEAD verification.
+//! - [`HpkeBackend::seal`] — RFC 9180 single-shot Base-mode seal. Returns
+//!   `(enc, ct)`: the 32-byte HPKE encapsulated key and the AEAD ciphertext
+//!   (`ciphertext || tag`). There is no external nonce — RFC 9180 derives the
+//!   AEAD nonce internally (`base_nonce` at sequence 0).
+//! - [`HpkeBackend::unseal`] — inverse of `seal` for a software-held recipient
+//!   secret.
 //! - [`HpkeBackend::generate_wrapping_keypair`] — fresh X25519 keypair.
 //!
 //! # RFC 9180 parameters
@@ -27,33 +28,21 @@
 //! These match the SCP ciphersuite (spec §9.5 — AES-128-GCM for parity with
 //! the MLS ciphersuite's 128-bit security bound).
 //!
-//! `aad` is passed through to the AEAD as empty bytes; callers that need
-//! context-binding bake the binding into the `info` input. This keeps the
-//! trait surface narrow and consistent with RFC 9180 §5.1.1 "single-shot
-//! API".
-//!
-//! # Cancel-safety
-//!
-//! All three methods are cancel-safe — they allocate a small amount of state
-//! (ephemeral keypair, derived AEAD key, nonce) that is dropped on cancellation
-//! without leaking secret material outside the future. `Zeroizing` wraps every
-//! secret-byte copy for its entire memory lifetime.
+//! `info` and `aad` are both passed through to the shared HPKE core; callers
+//! that need context-binding bake the binding into `info`/`aad` (per §9.16.2 /
+//! §9.17.1).
 //!
 //! # Production impl
 //!
-//! [`ProductionHpkeBackend`] is a zero-sized struct that implements the full
-//! RFC 9180 Base-mode construction. State-free: safe to share via `Arc`
-//! across every actor in the process.
+//! [`ProductionHpkeBackend`] is a zero-sized struct that delegates to the
+//! authoritative RFC 9180 core in [`scp_protocol::crypto::hpke`]. State-free:
+//! safe to share via `Arc` across every actor in the process.
 
 use async_trait::async_trait;
-use rand::RngCore;
 use rand::rngs::OsRng;
 use zeroize::Zeroizing;
 
-use aes_gcm::aead::{Aead, KeyInit, Payload};
-use aes_gcm::{Aes128Gcm, Nonce};
-use hkdf::Hkdf;
-use sha2::Sha256;
+use scp_protocol::crypto::hpke;
 use x25519_dalek::{PublicKey as X25519Pub, StaticSecret};
 
 // ---------------------------------------------------------------------------
@@ -67,56 +56,26 @@ pub enum HpkeError {
     #[error("invalid key material: {0}")]
     InvalidKey(String),
 
-    /// HKDF key expansion failed. This is operationally only reachable on
-    /// output length overflow; treated as a programmer error.
-    #[error("key derivation failed: {0}")]
-    KeyDerivationFailed(String),
+    /// HPKE seal failed (operationally unreachable for AES-128-GCM with a
+    /// valid key and nonce).
+    #[error("HPKE seal failed: {0}")]
+    SealFailed(String),
 
-    /// AEAD seal or unseal failed (tag mismatch, wrong key, truncated
-    /// ciphertext).
-    #[error("aead failure: {0}")]
-    AeadFailure(String),
-
-    /// The ciphertext was shorter than the minimum envelope size
-    /// (`enc || nonce || tag`).
-    #[error("ciphertext too short")]
-    CiphertextTooShort,
+    /// HPKE open failed (tag mismatch, wrong key, wrong `info`/`aad`, tampered
+    /// `enc`/`ct`).
+    #[error("HPKE open failed: {0}")]
+    OpenFailed(String),
 }
 
 // ---------------------------------------------------------------------------
 // Constants
 // ---------------------------------------------------------------------------
 
-/// KEM suite id for `DHKEM(X25519, HKDF-SHA256)` — RFC 9180 §7.1.
-const HPKE_KEM_ID: u16 = 0x0020;
-
-/// KDF suite id for `HKDF-SHA256` — RFC 9180 §7.2.
-const HPKE_KDF_ID: u16 = 0x0001;
-
-/// AEAD suite id for `AES-128-GCM` — RFC 9180 §7.3.
-const HPKE_AEAD_ID: u16 = 0x0001;
-
 /// X25519 public-key size (RFC 7748 §5).
 const X25519_PUBLIC_KEY_LEN: usize = 32;
 
 /// X25519 secret-key size (RFC 7748 §5).
 const X25519_SECRET_KEY_LEN: usize = 32;
-
-/// Derived AEAD key size (AES-128 per RFC 9180 §7.3 row 0x0001).
-const HPKE_AEAD_KEY_LEN: usize = 16;
-
-/// AEAD nonce size for AES-GCM (RFC 9180 §7.3 + RFC 5116).
-const HPKE_AEAD_NONCE_LEN: usize = 12;
-
-/// Minimum ciphertext envelope size: `enc || nonce || tag` (with empty pt).
-const HPKE_MIN_CIPHERTEXT_LEN: usize =
-    X25519_PUBLIC_KEY_LEN + HPKE_AEAD_NONCE_LEN + 16 /* GCM tag */;
-
-/// "SCP-HPKE-SEAL-V1" — domain separator on the HKDF input, keeping SCP HPKE
-/// output distinct from any other HKDF derivation that uses the same KEM
-/// shared secret (defence-in-depth; the `info` parameter is caller-controlled
-/// so we anchor our own prefix).
-const HPKE_DOMAIN_TAG: &[u8] = b"SCP-HPKE-V1:";
 
 // ---------------------------------------------------------------------------
 // Trait
@@ -129,34 +88,37 @@ const HPKE_DOMAIN_TAG: &[u8] = b"SCP-HPKE-V1:";
 /// actor boundaries. All operations are cancel-safe.
 #[async_trait]
 pub trait HpkeBackend: Send + Sync {
-    /// Seals `pt` to `recipient_pub` using the SCP HPKE suite and `info` for
-    /// key derivation. Returns `enc (32 B) || nonce (12 B) || ct || tag`.
+    /// RFC 9180 single-shot Base-mode seal of `pt` to `recipient_pub` under
+    /// `info` and `aad`. Returns `(enc, ct)`: the 32-byte encapsulated key and
+    /// the AEAD ciphertext (`ciphertext || tag`).
     ///
     /// # Errors
     ///
-    /// Returns [`HpkeError::KeyDerivationFailed`] if HKDF expansion fails;
-    /// [`HpkeError::AeadFailure`] if AEAD encryption fails (not reachable for
-    /// AES-128-GCM with a valid key and nonce).
+    /// Returns [`HpkeError::SealFailed`] if the HPKE seal fails (operationally
+    /// unreachable with valid inputs).
     async fn seal(
         &self,
         recipient_pub: &[u8; X25519_PUBLIC_KEY_LEN],
         info: &[u8],
+        aad: &[u8],
         pt: &[u8],
-    ) -> Result<Vec<u8>, HpkeError>;
+    ) -> Result<(Vec<u8>, Vec<u8>), HpkeError>;
 
-    /// Unseals `ct` using `recipient_secret` and `info`. Returns the
-    /// plaintext on successful AEAD verification.
+    /// RFC 9180 single-shot Base-mode open of `ct` (with encapsulated key
+    /// `enc`) using a software-held `recipient_secret`, under `info`/`aad`.
+    /// Returns the plaintext on successful AEAD verification.
     ///
     /// # Errors
     ///
-    /// Returns [`HpkeError::CiphertextTooShort`] if `ct` is below the
-    /// minimum envelope length; [`HpkeError::KeyDerivationFailed`] if HKDF
-    /// expansion fails; [`HpkeError::AeadFailure`] if AEAD verification fails
-    /// (wrong key, tampered ciphertext).
+    /// Returns [`HpkeError::InvalidKey`] if `enc` is the wrong length;
+    /// [`HpkeError::OpenFailed`] if HPKE open fails (wrong key, wrong
+    /// `info`/`aad`, tampered `enc`/`ct`).
     async fn unseal(
         &self,
         recipient_secret: &[u8; X25519_SECRET_KEY_LEN],
+        enc: &[u8],
         info: &[u8],
+        aad: &[u8],
         ct: &[u8],
     ) -> Result<Vec<u8>, HpkeError>;
 
@@ -178,8 +140,8 @@ pub trait HpkeBackend: Send + Sync {
 /// Production [`HpkeBackend`] implementation.
 ///
 /// Stateless; safe to share via `Arc` across all actors in the process.
-/// Implements the RFC 9180 Base-mode single-shot API with
-/// `DHKEM(X25519, HKDF-SHA256) / HKDF-SHA256 / AES-128-GCM`.
+/// A thin delegating shim over the authoritative RFC 9180 Base-mode core in
+/// [`scp_protocol::crypto::hpke`].
 #[derive(Debug, Default, Clone, Copy)]
 pub struct ProductionHpkeBackend;
 
@@ -197,79 +159,31 @@ impl HpkeBackend for ProductionHpkeBackend {
         &self,
         recipient_pub: &[u8; X25519_PUBLIC_KEY_LEN],
         info: &[u8],
+        aad: &[u8],
         pt: &[u8],
-    ) -> Result<Vec<u8>, HpkeError> {
-        // 1. Generate the ephemeral sender keypair and derive the KEM shared
-        //    secret. `StaticSecret` (rather than `EphemeralSecret`) is used so
-        //    the secret bytes can be zeroized on drop through `Zeroizing`.
-        let ephemeral = StaticSecret::random_from_rng(OsRng);
-        let enc = X25519Pub::from(&ephemeral); // ephemeral public = RFC 9180 `enc`
-        let kem_shared = ephemeral.diffie_hellman(&X25519Pub::from(*recipient_pub));
-        let kem_shared_secret: Zeroizing<[u8; 32]> = Zeroizing::new(kem_shared.to_bytes());
-
-        // 2. Derive the AEAD key via HKDF-SHA256 with a domain-separated info.
-        let key = derive_aead_key(&kem_shared_secret, info)?;
-
-        // 3. AEAD seal. Nonce is fresh from OsRng per operation — no
-        //    counter-based scheme (safe against reuse even on concurrent seals
-        //    with the same key).
-        let mut nonce_bytes = [0u8; HPKE_AEAD_NONCE_LEN];
-        OsRng.fill_bytes(&mut nonce_bytes);
-        let cipher = Aes128Gcm::new_from_slice(&*key)
-            .map_err(|e| HpkeError::InvalidKey(format!("AES-128-GCM key length: {e}")))?;
-        let ciphertext = cipher
-            .encrypt(
-                Nonce::from_slice(&nonce_bytes),
-                Payload { msg: pt, aad: &[] },
-            )
-            .map_err(|e| HpkeError::AeadFailure(e.to_string()))?;
-
-        // 4. Concatenate `enc || nonce || ciphertext || tag`. Total length is
-        //    32 + 12 + pt.len() + 16.
-        let mut out =
-            Vec::with_capacity(X25519_PUBLIC_KEY_LEN + HPKE_AEAD_NONCE_LEN + ciphertext.len());
-        out.extend_from_slice(enc.as_bytes());
-        out.extend_from_slice(&nonce_bytes);
-        out.extend_from_slice(&ciphertext);
-        Ok(out)
+    ) -> Result<(Vec<u8>, Vec<u8>), HpkeError> {
+        let (enc, ct) = hpke::seal(recipient_pub, info, aad, pt)
+            .map_err(|e| HpkeError::SealFailed(e.to_string()))?;
+        Ok((enc.to_vec(), ct))
     }
 
     async fn unseal(
         &self,
         recipient_secret: &[u8; X25519_SECRET_KEY_LEN],
+        enc: &[u8],
         info: &[u8],
+        aad: &[u8],
         ct: &[u8],
     ) -> Result<Vec<u8>, HpkeError> {
-        if ct.len() < HPKE_MIN_CIPHERTEXT_LEN {
-            return Err(HpkeError::CiphertextTooShort);
-        }
-
-        // 1. Split `enc || nonce || ct || tag`.
-        let (enc_bytes, rest) = ct.split_at(X25519_PUBLIC_KEY_LEN);
-        let (nonce_bytes, ct_and_tag) = rest.split_at(HPKE_AEAD_NONCE_LEN);
-
-        // 2. Re-derive the KEM shared secret.
-        let mut enc_arr = [0u8; X25519_PUBLIC_KEY_LEN];
-        enc_arr.copy_from_slice(enc_bytes);
-        let recipient_sk = Zeroizing::new(StaticSecret::from(*recipient_secret));
-        let kem_shared = recipient_sk.diffie_hellman(&X25519Pub::from(enc_arr));
-        let kem_shared_secret: Zeroizing<[u8; 32]> = Zeroizing::new(kem_shared.to_bytes());
-
-        // 3. Re-derive the AEAD key.
-        let key = derive_aead_key(&kem_shared_secret, info)?;
-
-        // 4. AEAD open.
-        let cipher = Aes128Gcm::new_from_slice(&*key)
-            .map_err(|e| HpkeError::InvalidKey(format!("AES-128-GCM key length: {e}")))?;
-        cipher
-            .decrypt(
-                Nonce::from_slice(nonce_bytes),
-                Payload {
-                    msg: ct_and_tag,
-                    aad: &[],
-                },
-            )
-            .map_err(|e| HpkeError::AeadFailure(e.to_string()))
+        let enc_arr: [u8; hpke::HPKE_ENC_LEN] = enc.try_into().map_err(|_| {
+            HpkeError::InvalidKey(format!(
+                "HPKE enc must be {} bytes, got {}",
+                hpke::HPKE_ENC_LEN,
+                enc.len()
+            ))
+        })?;
+        hpke::open(recipient_secret, &enc_arr, info, aad, ct)
+            .map_err(|e| HpkeError::OpenFailed(e.to_string()))
     }
 
     async fn generate_wrapping_keypair(&self) -> Result<(Vec<u8>, Zeroizing<Vec<u8>>), HpkeError> {
@@ -283,51 +197,6 @@ impl HpkeBackend for ProductionHpkeBackend {
 }
 
 // ---------------------------------------------------------------------------
-// Internal key-derivation helper
-// ---------------------------------------------------------------------------
-
-/// Derive the AEAD key from the KEM shared secret and caller-provided `info`.
-///
-/// Construction mirrors RFC 9180 §5.1.1 `KeySchedule(mode_base, shared_secret,
-/// info)` but is implemented directly on top of HKDF-SHA256 rather than
-/// through a third-party HPKE crate. This keeps the workspace dep graph
-/// lean and the construction auditable. The suite-id triple is encoded as
-/// `KEM_ID(BE16) || KDF_ID(BE16) || AEAD_ID(BE16)` in the HKDF salt region to
-/// domain-separate outputs across suite choices.
-///
-/// The final HKDF `info` input is:
-///
-/// ```text
-///   HPKE_DOMAIN_TAG || KEM_ID || KDF_ID || AEAD_ID || caller_info_len (BE32) || caller_info
-/// ```
-///
-/// and the HKDF salt is empty (RFC 9180 Base mode). Output length is 16 bytes
-/// (AES-128-GCM key).
-fn derive_aead_key(
-    kem_shared_secret: &[u8; 32],
-    caller_info: &[u8],
-) -> Result<Zeroizing<[u8; HPKE_AEAD_KEY_LEN]>, HpkeError> {
-    let hk = Hkdf::<Sha256>::new(None, kem_shared_secret);
-
-    // Build the structured info input.
-    let mut hkdf_info =
-        Vec::with_capacity(HPKE_DOMAIN_TAG.len() + 2 + 2 + 2 + 4 + caller_info.len());
-    hkdf_info.extend_from_slice(HPKE_DOMAIN_TAG);
-    hkdf_info.extend_from_slice(&HPKE_KEM_ID.to_be_bytes());
-    hkdf_info.extend_from_slice(&HPKE_KDF_ID.to_be_bytes());
-    hkdf_info.extend_from_slice(&HPKE_AEAD_ID.to_be_bytes());
-    #[allow(clippy::cast_possible_truncation)]
-    let info_len = caller_info.len() as u32;
-    hkdf_info.extend_from_slice(&info_len.to_be_bytes());
-    hkdf_info.extend_from_slice(caller_info);
-
-    let mut okm = Zeroizing::new([0u8; HPKE_AEAD_KEY_LEN]);
-    hk.expand(&hkdf_info, &mut *okm)
-        .map_err(|e| HpkeError::KeyDerivationFailed(e.to_string()))?;
-    Ok(okm)
-}
-
-// ---------------------------------------------------------------------------
 // Tests
 // ---------------------------------------------------------------------------
 
@@ -336,27 +205,32 @@ fn derive_aead_key(
 mod tests {
     use super::*;
 
-    /// Round-trips ten `(info, plaintext)` pairs with a fresh keypair per
-    /// pair. Verifies seal/unseal is functionally inverse over a range of
-    /// inputs: empty plaintext, empty info, non-empty info, varying pt length.
+    /// Round-trips ten `(info, aad, plaintext)` triples with a fresh keypair
+    /// per case. Verifies seal/unseal is functionally inverse over a range of
+    /// inputs and that the ciphertext is exactly `pt.len() + 16` (no external
+    /// nonce on the wire).
     #[tokio::test]
-    async fn seal_unseal_roundtrip_ten_pairs() {
+    async fn seal_unseal_roundtrip_ten_cases() {
         let backend = ProductionHpkeBackend::new();
 
-        let cases: Vec<(Vec<u8>, Vec<u8>)> = vec![
-            (b"info-0".to_vec(), b"".to_vec()),
-            (b"".to_vec(), b"hello".to_vec()),
-            (b"info-2".to_vec(), b"short".to_vec()),
-            (b"info-3".to_vec(), vec![0xAB; 32]),
-            (b"info-4".to_vec(), vec![0u8; 1]),
-            (b"info-5".to_vec(), (0..=255u8).collect()),
-            (b"info-6".to_vec(), vec![0xFF; 1024]),
-            (b"info-7".to_vec(), b"the quick brown fox".to_vec()),
-            (b"info-8".to_vec(), vec![0x11, 0x22, 0x33, 0x44]),
-            (b"info-9".to_vec(), vec![0u8; 4096]),
+        let cases: Vec<(Vec<u8>, Vec<u8>, Vec<u8>)> = vec![
+            (b"info-0".to_vec(), b"aad-0".to_vec(), b"hello".to_vec()),
+            (b"".to_vec(), b"".to_vec(), b"x".to_vec()),
+            (b"info-2".to_vec(), b"".to_vec(), b"short".to_vec()),
+            (b"info-3".to_vec(), b"a3".to_vec(), vec![0xAB; 32]),
+            (b"info-4".to_vec(), b"a4".to_vec(), vec![0u8; 1]),
+            (b"info-5".to_vec(), b"a5".to_vec(), (0..=255u8).collect()),
+            (b"info-6".to_vec(), b"a6".to_vec(), vec![0xFF; 1024]),
+            (
+                b"info-7".to_vec(),
+                b"a7".to_vec(),
+                b"the quick brown fox".to_vec(),
+            ),
+            (b"info-8".to_vec(), b"a8".to_vec(), vec![0x11, 0x22, 0x33, 0x44]),
+            (b"info-9".to_vec(), b"a9".to_vec(), vec![0u8; 4096]),
         ];
 
-        for (idx, (info, pt)) in cases.iter().enumerate() {
+        for (idx, (info, aad, pt)) in cases.iter().enumerate() {
             let (pk_vec, sk_vec) = backend.generate_wrapping_keypair().await.unwrap();
             assert_eq!(pk_vec.len(), X25519_PUBLIC_KEY_LEN, "case {idx}: pk length");
             assert_eq!(sk_vec.len(), X25519_SECRET_KEY_LEN, "case {idx}: sk length");
@@ -366,23 +240,36 @@ mod tests {
             let mut sk = [0u8; X25519_SECRET_KEY_LEN];
             sk.copy_from_slice(&sk_vec);
 
-            let ct = backend.seal(&pk, info, pt).await.unwrap();
-
-            // Minimum envelope: enc (32) + nonce (12) + tag (16) = 60 bytes.
-            assert!(
-                ct.len() >= HPKE_MIN_CIPHERTEXT_LEN,
-                "case {idx}: ciphertext too short ({})",
-                ct.len(),
-            );
+            let (enc, ct) = backend.seal(&pk, info, aad, pt).await.unwrap();
+            assert_eq!(enc.len(), hpke::HPKE_ENC_LEN, "case {idx}: enc length");
             assert_eq!(
                 ct.len(),
-                X25519_PUBLIC_KEY_LEN + HPKE_AEAD_NONCE_LEN + pt.len() + 16,
-                "case {idx}: ciphertext length mismatch",
+                pt.len() + hpke::HPKE_TAG_LEN,
+                "case {idx}: ct length (no external nonce)",
             );
 
-            let recovered = backend.unseal(&sk, info, &ct).await.unwrap();
+            let recovered = backend.unseal(&sk, &enc, info, aad, &ct).await.unwrap();
             assert_eq!(&recovered, pt, "case {idx}: plaintext mismatch");
         }
+    }
+
+    /// A delegation KAT: a ciphertext produced by the backend opens with the
+    /// `scp_protocol::crypto::hpke` core directly (proving the backend is a
+    /// faithful shim, not a divergent re-implementation).
+    #[tokio::test]
+    async fn backend_output_opens_with_core() {
+        let backend = ProductionHpkeBackend::new();
+        let (pk_vec, sk_vec) = backend.generate_wrapping_keypair().await.unwrap();
+        let mut pk = [0u8; X25519_PUBLIC_KEY_LEN];
+        pk.copy_from_slice(&pk_vec);
+        let mut sk = [0u8; X25519_SECRET_KEY_LEN];
+        sk.copy_from_slice(&sk_vec);
+
+        let (enc, ct) = backend.seal(&pk, b"info", b"aad", b"payload").await.unwrap();
+        let enc_arr: [u8; 32] = enc.as_slice().try_into().unwrap();
+
+        let recovered = hpke::open(&sk, &enc_arr, b"info", b"aad", &ct).unwrap();
+        assert_eq!(recovered.as_slice(), b"payload");
     }
 
     /// Generated X25519 keypair has the expected byte shape (32/32) and the
@@ -400,11 +287,9 @@ mod tests {
         assert_eq!(rederived.as_bytes().as_slice(), pk.as_slice());
     }
 
-    /// Unsealing with a different secret key yields [`HpkeError::AeadFailure`]
-    /// (not plaintext). Confirms the AEAD is properly authenticating the
-    /// KEM-derived key.
+    /// Unsealing with a different secret key yields [`HpkeError::OpenFailed`].
     #[tokio::test]
-    async fn wrong_key_unseal_fails_with_aead_error() {
+    async fn wrong_key_unseal_fails() {
         let backend = ProductionHpkeBackend::new();
 
         let (pk_vec, _sk_vec) = backend.generate_wrapping_keypair().await.unwrap();
@@ -415,17 +300,16 @@ mod tests {
         let mut sk2 = [0u8; X25519_SECRET_KEY_LEN];
         sk2.copy_from_slice(&sk2_vec);
 
-        let ct = backend.seal(&pk, b"info", b"secret").await.unwrap();
+        let (enc, ct) = backend.seal(&pk, b"info", b"aad", b"secret").await.unwrap();
 
-        let err = backend.unseal(&sk2, b"info", &ct).await.unwrap_err();
-        assert!(
-            matches!(err, HpkeError::AeadFailure(_)),
-            "expected AEAD failure, got {err:?}",
-        );
+        let err = backend
+            .unseal(&sk2, &enc, b"info", b"aad", &ct)
+            .await
+            .unwrap_err();
+        assert!(matches!(err, HpkeError::OpenFailed(_)), "got {err:?}");
     }
 
-    /// Tampered ciphertext (bit-flip inside the AEAD portion) fails with
-    /// [`HpkeError::AeadFailure`].
+    /// Tampered ciphertext fails with [`HpkeError::OpenFailed`].
     #[tokio::test]
     async fn tampered_ciphertext_fails() {
         let backend = ProductionHpkeBackend::new();
@@ -435,31 +319,31 @@ mod tests {
         let mut sk = [0u8; X25519_SECRET_KEY_LEN];
         sk.copy_from_slice(&sk_vec);
 
-        let mut ct = backend.seal(&pk, b"info", b"hello").await.unwrap();
-        // Flip a bit in the ciphertext portion (skip enc 32 + nonce 12).
-        let idx = X25519_PUBLIC_KEY_LEN + HPKE_AEAD_NONCE_LEN;
-        ct[idx] ^= 0x01;
+        let (enc, mut ct) = backend.seal(&pk, b"info", b"aad", b"hello").await.unwrap();
+        ct[0] ^= 0x01;
 
-        let err = backend.unseal(&sk, b"info", &ct).await.unwrap_err();
-        assert!(matches!(err, HpkeError::AeadFailure(_)));
+        let err = backend
+            .unseal(&sk, &enc, b"info", b"aad", &ct)
+            .await
+            .unwrap_err();
+        assert!(matches!(err, HpkeError::OpenFailed(_)));
     }
 
-    /// Ciphertext shorter than the minimum envelope returns
-    /// [`HpkeError::CiphertextTooShort`].
+    /// Wrong-length `enc` returns [`HpkeError::InvalidKey`].
     #[tokio::test]
-    async fn ciphertext_too_short_rejected() {
+    async fn wrong_length_enc_rejected() {
         let backend = ProductionHpkeBackend::new();
         let (_pk, sk_vec) = backend.generate_wrapping_keypair().await.unwrap();
         let mut sk = [0u8; X25519_SECRET_KEY_LEN];
         sk.copy_from_slice(&sk_vec);
         let err = backend
-            .unseal(&sk, b"info", &[0u8; HPKE_MIN_CIPHERTEXT_LEN - 1])
+            .unseal(&sk, &[0u8; 31], b"info", b"aad", &[0u8; 48])
             .await
             .unwrap_err();
-        assert!(matches!(err, HpkeError::CiphertextTooShort));
+        assert!(matches!(err, HpkeError::InvalidKey(_)));
     }
 
-    /// Using a different `info` for unseal fails (HKDF domain-separation).
+    /// Using a different `info` for unseal fails (HPKE domain-separation).
     #[tokio::test]
     async fn info_mismatch_fails() {
         let backend = ProductionHpkeBackend::new();
@@ -469,8 +353,29 @@ mod tests {
         let mut sk = [0u8; X25519_SECRET_KEY_LEN];
         sk.copy_from_slice(&sk_vec);
 
-        let ct = backend.seal(&pk, b"info-a", b"payload").await.unwrap();
-        let err = backend.unseal(&sk, b"info-b", &ct).await.unwrap_err();
-        assert!(matches!(err, HpkeError::AeadFailure(_)));
+        let (enc, ct) = backend.seal(&pk, b"info-a", b"aad", b"payload").await.unwrap();
+        let err = backend
+            .unseal(&sk, &enc, b"info-b", b"aad", &ct)
+            .await
+            .unwrap_err();
+        assert!(matches!(err, HpkeError::OpenFailed(_)));
+    }
+
+    /// Using a different `aad` for unseal fails.
+    #[tokio::test]
+    async fn aad_mismatch_fails() {
+        let backend = ProductionHpkeBackend::new();
+        let (pk_vec, sk_vec) = backend.generate_wrapping_keypair().await.unwrap();
+        let mut pk = [0u8; X25519_PUBLIC_KEY_LEN];
+        pk.copy_from_slice(&pk_vec);
+        let mut sk = [0u8; X25519_SECRET_KEY_LEN];
+        sk.copy_from_slice(&sk_vec);
+
+        let (enc, ct) = backend.seal(&pk, b"info", b"aad-a", b"payload").await.unwrap();
+        let err = backend
+            .unseal(&sk, &enc, b"info", b"aad-b", &ct)
+            .await
+            .unwrap_err();
+        assert!(matches!(err, HpkeError::OpenFailed(_)));
     }
 }

--- a/crates/scp-runtime/src/crypto/hpke_backend.rs
+++ b/crates/scp-runtime/src/crypto/hpke_backend.rs
@@ -226,7 +226,11 @@ mod tests {
                 b"a7".to_vec(),
                 b"the quick brown fox".to_vec(),
             ),
-            (b"info-8".to_vec(), b"a8".to_vec(), vec![0x11, 0x22, 0x33, 0x44]),
+            (
+                b"info-8".to_vec(),
+                b"a8".to_vec(),
+                vec![0x11, 0x22, 0x33, 0x44],
+            ),
             (b"info-9".to_vec(), b"a9".to_vec(), vec![0u8; 4096]),
         ];
 
@@ -265,7 +269,10 @@ mod tests {
         let mut sk = [0u8; X25519_SECRET_KEY_LEN];
         sk.copy_from_slice(&sk_vec);
 
-        let (enc, ct) = backend.seal(&pk, b"info", b"aad", b"payload").await.unwrap();
+        let (enc, ct) = backend
+            .seal(&pk, b"info", b"aad", b"payload")
+            .await
+            .unwrap();
         let enc_arr: [u8; 32] = enc.as_slice().try_into().unwrap();
 
         let recovered = hpke::open(&sk, &enc_arr, b"info", b"aad", &ct).unwrap();
@@ -353,7 +360,10 @@ mod tests {
         let mut sk = [0u8; X25519_SECRET_KEY_LEN];
         sk.copy_from_slice(&sk_vec);
 
-        let (enc, ct) = backend.seal(&pk, b"info-a", b"aad", b"payload").await.unwrap();
+        let (enc, ct) = backend
+            .seal(&pk, b"info-a", b"aad", b"payload")
+            .await
+            .unwrap();
         let err = backend
             .unseal(&sk, &enc, b"info-b", b"aad", &ct)
             .await
@@ -371,7 +381,10 @@ mod tests {
         let mut sk = [0u8; X25519_SECRET_KEY_LEN];
         sk.copy_from_slice(&sk_vec);
 
-        let (enc, ct) = backend.seal(&pk, b"info", b"aad-a", b"payload").await.unwrap();
+        let (enc, ct) = backend
+            .seal(&pk, b"info", b"aad-a", b"payload")
+            .await
+            .unwrap();
         let err = backend
             .unseal(&sk, &enc, b"info", b"aad-b", &ct)
             .await

--- a/crates/scp-runtime/src/crypto/mls/provider.rs
+++ b/crates/scp-runtime/src/crypto/mls/provider.rs
@@ -1144,9 +1144,9 @@ impl MlsCryptoProvider {
                 )
                 .map_err(|e| ContextError::CryptoFailed(format!("HPKE seal failed: {e}")))?;
 
-            let sealed: [u8; 60] = sealed_vec.try_into().map_err(|v: Vec<u8>| {
+            let sealed: [u8; 48] = sealed_vec.try_into().map_err(|v: Vec<u8>| {
                 ContextError::CryptoFailed(format!(
-                    "HPKE seal produced {} bytes, expected 60",
+                    "HPKE seal produced {} bytes, expected 48",
                     v.len()
                 ))
             })?;
@@ -1280,12 +1280,12 @@ impl MlsCryptoProvider {
 
             match seal_result {
                 Ok((sealed_vec, ephemeral_pub)) => {
-                    let sealed: [u8; 60] = match sealed_vec.try_into() {
+                    let sealed: [u8; 48] = match sealed_vec.try_into() {
                         Ok(s) => s,
                         Err(v) => {
                             tracing::warn!(
                                 member_did = %member_did,
-                                "HPKE seal produced {} bytes, expected 60 — skipping",
+                                "HPKE seal produced {} bytes, expected 48 — skipping",
                                 v.len()
                             );
                             continue;
@@ -1528,8 +1528,8 @@ impl MlsCryptoProvider {
             )
             .map_err(|e| ContextError::CryptoFailed(format!("HPKE seal failed: {e}")))?;
 
-        let sealed: [u8; 60] = sealed_vec.try_into().map_err(|v: Vec<u8>| {
-            ContextError::CryptoFailed(format!("HPKE seal produced {} bytes, expected 60", v.len()))
+        let sealed: [u8; 48] = sealed_vec.try_into().map_err(|v: Vec<u8>| {
+            ContextError::CryptoFailed(format!("HPKE seal produced {} bytes, expected 48", v.len()))
         })?;
 
         let response = SenderKeyResponse {
@@ -3314,7 +3314,7 @@ mod tests {
                 0,
             )
             .unwrap();
-        let sealed: [u8; 60] = sealed_vec.try_into().unwrap();
+        let sealed: [u8; 48] = sealed_vec.try_into().unwrap();
 
         let response = SenderKeyResponse {
             sender_did: TEST_DID.to_string(),

--- a/crates/scp-runtime/src/crypto/sender_keys/key_protocol.rs
+++ b/crates/scp-runtime/src/crypto/sender_keys/key_protocol.rs
@@ -16,6 +16,7 @@ use std::hash::BuildHasher;
 
 use rand::RngCore;
 use rand::rngs::OsRng;
+use zeroize::Zeroizing;
 
 use scp_platform::traits::{KeyCustody, KeyHandle, KeyType};
 
@@ -344,7 +345,7 @@ pub async fn open_sender_key_response(
         .dh_agree(wrapping_key_handle, &enc)
         .await
         .map_err(|e| SenderKeyError::KeyCustodyError(e.to_string()))?;
-    let dh_bytes: [u8; 32] = *dh.as_bytes();
+    let dh_bytes: Zeroizing<[u8; 32]> = Zeroizing::new(*dh.as_bytes());
 
     // Fetch pkRm for the same handle, needed for kem_context = enc || pkRm.
     let pk_rm = key_custody
@@ -359,15 +360,17 @@ pub async fn open_sender_key_response(
     let info = build_hpke_info(context_id, &response.sender_did, response.epoch);
     let aad = build_hpke_aad(context_id, &response.sender_did, response.epoch);
 
-    let plaintext = scp_protocol::crypto::hpke::custody::open_with_external_dh(
-        &dh_bytes,
-        &pk_rm_bytes,
-        &enc,
-        &info,
-        &aad,
-        &response.hpke_sealed_key,
-    )
-    .map_err(|e| SenderKeyError::HpkeDecryptionFailed(e.to_string()))?;
+    let plaintext = Zeroizing::new(
+        scp_protocol::crypto::hpke::custody::open_with_external_dh(
+            &dh_bytes,
+            &pk_rm_bytes,
+            &enc,
+            &info,
+            &aad,
+            &response.hpke_sealed_key,
+        )
+        .map_err(|e| SenderKeyError::HpkeDecryptionFailed(e.to_string()))?,
+    );
 
     let key_bytes: [u8; 32] = plaintext.as_slice().try_into().map_err(|_| {
         SenderKeyError::HpkeDecryptionFailed(format!(

--- a/crates/scp-runtime/src/crypto/sender_keys/key_protocol.rs
+++ b/crates/scp-runtime/src/crypto/sender_keys/key_protocol.rs
@@ -207,11 +207,12 @@ pub async fn request_sender_key(
 ///
 /// # HPKE Assembly
 ///
-/// 1. Generate ephemeral X25519 keypair (software-generated).
-/// 2. ECDH between ephemeral secret and requester's wrapping pubkey.
-/// 3. HKDF-SHA256 to derive a 16-byte AES-128-GCM encryption key.
-/// 4. AES-128-GCM encrypt the sender key bytes.
-/// 5. Include the ephemeral public key in the response.
+/// Seals via RFC 9180 HPKE Base mode (§9.16.2) through the shared
+/// `scp_protocol::crypto::hpke` core: a fresh ephemeral keypair performs
+/// DHKEM Encap to the requester's wrapping pubkey, `KeySchedule_base` derives
+/// the AEAD key/nonce, and a single seq-0 `Seal` produces the 48-byte
+/// ciphertext. The `ephemeral_pubkey` (HPKE `enc`) is returned in the
+/// response; there is no external nonce.
 ///
 /// # Errors
 ///
@@ -278,11 +279,12 @@ pub async fn handle_sender_key_request<S: BuildHasher + Sync>(
         params.epoch,
     )?;
 
-    // Convert to fixed-size array. hpke_seal always returns exactly 60 bytes
-    // (nonce 12 + ciphertext 32 + tag 16) for a 32-byte plaintext input.
-    let sealed: [u8; 60] = sealed_vec.try_into().map_err(|v: Vec<u8>| {
+    // Convert to fixed-size array. The HPKE seal always returns exactly 48
+    // bytes (ciphertext 32 + AES-128-GCM tag 16) for a 32-byte plaintext;
+    // the AEAD nonce is internal per RFC 9180.
+    let sealed: [u8; 48] = sealed_vec.try_into().map_err(|v: Vec<u8>| {
         SenderKeyError::HpkeEncryptionFailed(format!(
-            "HPKE seal produced {} bytes, expected 60",
+            "HPKE seal produced {} bytes, expected 48",
             v.len()
         ))
     })?;
@@ -310,43 +312,62 @@ pub async fn handle_sender_key_request<S: BuildHasher + Sync>(
 // Open sender key response (requester side) — async custody variant
 // ---------------------------------------------------------------------------
 
-/// Decrypts a [`SenderKeyResponse`] using the requester's wrapping key handle
-/// inside the [`KeyCustody`] boundary.
+/// Opens a [`SenderKeyResponse`] using the requester's wrapping key handle
+/// inside the [`KeyCustody`] boundary (RFC 9180 HPKE Base mode, §9.16.2).
 ///
-/// The shared secret is computed via `key_custody.dh_agree(wrapping_key_handle,
-/// ephemeral_pk)` so the wrapping private key never leaves custody. KDF + AEAD
-/// decryption then recovers the sender key in software.
+/// The KEM Diffie-Hellman output is computed inside custody via
+/// `key_custody.dh_agree(wrapping_key_handle, enc)`, so the wrapping private
+/// key never leaves the boundary. The recipient public key `pkRm` is fetched
+/// via `key_custody.public_key(wrapping_key_handle)`. RFC 9180 DHKEM Decap
+/// (`ExtractAndExpand(dh, enc || pkRm)`), `KeySchedule_base`, and the AEAD open
+/// then complete in software via
+/// [`scp_protocol::crypto::hpke::custody::open_with_external_dh`].
 ///
 /// # Errors
 ///
-/// Returns [`SenderKeyError::KeyCustodyError`] if the DH agreement fails.
-/// Returns [`SenderKeyError::HpkeDecryptionFailed`] if AEAD decryption fails.
+/// Returns [`SenderKeyError::KeyCustodyError`] if the DH agreement or
+/// public-key lookup fails. Returns [`SenderKeyError::HpkeDecryptionFailed`]
+/// if HPKE open fails (wrong key/`info`/`aad`, tampered `enc`/`ct`) or the
+/// recovered plaintext is not exactly 32 bytes.
 pub async fn open_sender_key_response(
     key_custody: &impl KeyCustody,
     wrapping_key_handle: &KeyHandle,
     context_id: &str,
     response: &SenderKeyResponse,
 ) -> Result<SenderKey, SenderKeyError> {
-    // hpke_sealed_key is [u8; 60] — length is enforced at the type level
-    // (nonce 12 + ciphertext 32 + AES-128-GCM tag 16 = 60 bytes).
-    // The ephemeral public key is already validated as [u8; 32] by serde.
-    let ephemeral_bytes: [u8; 32] = response.ephemeral_pubkey;
+    // The ephemeral public key (HPKE `enc`) is validated as [u8; 32] by serde.
+    let enc: [u8; 32] = response.ephemeral_pubkey;
 
-    // Compute shared secret inside custody boundary.
-    let shared_secret = key_custody
-        .dh_agree(wrapping_key_handle, &ephemeral_bytes)
+    // Compute the KEM DH output inside the custody boundary (same handle,
+    // same enc — the only sound inputs to open_with_external_dh).
+    let dh = key_custody
+        .dh_agree(wrapping_key_handle, &enc)
         .await
         .map_err(|e| SenderKeyError::KeyCustodyError(e.to_string()))?;
+    let dh_bytes: [u8; 32] = *dh.as_bytes();
+
+    // Fetch pkRm for the same handle, needed for kem_context = enc || pkRm.
+    let pk_rm = key_custody
+        .public_key(wrapping_key_handle)
+        .await
+        .map_err(|e| SenderKeyError::KeyCustodyError(e.to_string()))?;
+    let pk_rm_bytes: [u8; 32] = pk_rm.as_bytes().try_into().map_err(|_| {
+        SenderKeyError::KeyCustodyError("wrapping public key must be 32 bytes".to_owned())
+    })?;
 
     // Build context-bound info and AAD (§9.16.2) using response fields.
     let info = build_hpke_info(context_id, &response.sender_did, response.epoch);
     let aad = build_hpke_aad(context_id, &response.sender_did, response.epoch);
 
-    // Derive AES-128-GCM key from shared secret (zeroized on drop).
-    let aes_key = hkdf_derive_key(shared_secret.as_bytes(), &info)?;
-
-    // Decrypt the sealed sender key with AAD verification.
-    let plaintext = aes128gcm_decrypt(&aes_key, &response.hpke_sealed_key, &aad)?;
+    let plaintext = scp_protocol::crypto::hpke::custody::open_with_external_dh(
+        &dh_bytes,
+        &pk_rm_bytes,
+        &enc,
+        &info,
+        &aad,
+        &response.hpke_sealed_key,
+    )
+    .map_err(|e| SenderKeyError::HpkeDecryptionFailed(e.to_string()))?;
 
     let key_bytes: [u8; 32] = plaintext.as_slice().try_into().map_err(|_| {
         SenderKeyError::HpkeDecryptionFailed(format!(

--- a/crates/scp-runtime/src/crypto/sender_keys/key_protocol.rs
+++ b/crates/scp-runtime/src/crypto/sender_keys/key_protocol.rs
@@ -372,14 +372,15 @@ pub async fn open_sender_key_response(
         .map_err(|e| SenderKeyError::HpkeDecryptionFailed(e.to_string()))?,
     );
 
-    let key_bytes: [u8; 32] = plaintext.as_slice().try_into().map_err(|_| {
-        SenderKeyError::HpkeDecryptionFailed(format!(
-            "decrypted key must be 32 bytes, got {}",
-            plaintext.len()
-        ))
-    })?;
+    let key_bytes: Zeroizing<[u8; 32]> =
+        Zeroizing::new(plaintext.as_slice().try_into().map_err(|_| {
+            SenderKeyError::HpkeDecryptionFailed(format!(
+                "decrypted key must be 32 bytes, got {}",
+                plaintext.len()
+            ))
+        })?);
 
-    Ok(SenderKey::from_bytes(key_bytes))
+    Ok(SenderKey::from_bytes(*key_bytes))
 }
 
 // ---------------------------------------------------------------------------

--- a/crates/scp-runtime/src/identity/recovery.rs
+++ b/crates/scp-runtime/src/identity/recovery.rs
@@ -1193,15 +1193,12 @@ impl RecoveryBackend for ProductionRecoveryBackend {
         let mut new_psk = [0u8; 32];
         rand::rngs::OsRng.fill_bytes(&mut new_psk);
 
-        // For each eligible device, wrap the PSK using X25519 ECDH:
-        // 1. Generate ephemeral X25519 keypair
-        // 2. ECDH with device's public key to get shared secret
-        // 3. HKDF-SHA256 to derive AES-256-GCM wrapping key
-        // 4. AES-256-GCM encrypt the PSK (random nonce)
-        // 5. Output: ephemeral_pubkey || nonce || ciphertext || tag
-        //
-        // This ensures only the holder of the device's X25519 private key
-        // can recover the shared secret and unwrap the PSK.
+        // For each eligible device, wrap the new PSK via RFC 9180 HPKE Base
+        // mode (§3.7.2): DHKEM(X25519, HKDF-SHA256) Encap to the device key,
+        // AES-128-GCM seal under info "scp-private-state-v1" || len(did) ||
+        // did || "psk-rotate". Output is enc(32) || ct(48) = 80 bytes; the
+        // AEAD nonce is internal per RFC 9180. Only the holder of the device's
+        // X25519 private key can complete Decap and unwrap the PSK.
         let mut wrapped_psks: Vec<Vec<u8>> = Vec::with_capacity(eligible_devices.len());
         for device_pk in &eligible_devices {
             // Device public key must be exactly 32 bytes (X25519).

--- a/crates/scp-runtime/src/identity/recovery.rs
+++ b/crates/scp-runtime/src/identity/recovery.rs
@@ -1172,7 +1172,7 @@ impl RecoveryBackend for ProductionRecoveryBackend {
         // The wrapped PSKs are distributed as a recovery notification.
 
         use rand::RngCore as _;
-        use zeroize::Zeroize as _;
+        use zeroize::Zeroizing;
 
         // Filter out the compromised device, if any.
         let eligible_devices: Vec<&[u8]> = params
@@ -1192,9 +1192,12 @@ impl RecoveryBackend for ProductionRecoveryBackend {
             return false;
         }
 
-        // Generate a fresh PSK (32 bytes of random data).
-        let mut new_psk = [0u8; 32];
-        rand::rngs::OsRng.fill_bytes(&mut new_psk);
+        // Generate a fresh PSK (32 bytes of random data). Held in `Zeroizing`
+        // so the plaintext PSK is wiped on drop regardless of which return
+        // path is taken (including the early `device_pk.len() != 32` reject
+        // below), preserving forward secrecy of the rotated key.
+        let mut new_psk = Zeroizing::new([0u8; 32]);
+        rand::rngs::OsRng.fill_bytes(new_psk.as_mut());
 
         // For each eligible device, wrap the new PSK via RFC 9180 HPKE Base
         // mode (§3.7.2): DHKEM(X25519, HKDF-SHA256) Encap to the device key,
@@ -1211,13 +1214,15 @@ impl RecoveryBackend for ProductionRecoveryBackend {
             let mut pk_bytes = [0u8; 32];
             pk_bytes.copy_from_slice(device_pk);
             match wrap_psk_for_device(&new_psk, &pk_bytes, &params.did) {
+                // `&new_psk` deref-coerces `&Zeroizing<[u8; 32]>` to `&[u8; 32]`.
                 Some(wrapped) => wrapped_psks.push(wrapped),
                 None => return false,
             }
         }
 
-        // Zeroize the plaintext PSK now that all devices have wrapped copies.
-        new_psk.zeroize();
+        // The plaintext PSK is wiped automatically when `new_psk` (a
+        // `Zeroizing<[u8; 32]>`) is dropped at end of scope — no explicit
+        // call needed, and every early return is now covered too.
 
         // Distribute the wrapped PSKs as a recovery notification via the
         // context manager. Each entry in the serialized payload corresponds

--- a/crates/scp-runtime/src/identity/recovery.rs
+++ b/crates/scp-runtime/src/identity/recovery.rs
@@ -297,6 +297,11 @@ pub struct ContactNotification {
 /// via HPKE) and optionally a compromised device to exclude.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct PskRotationParams {
+    /// The identity DID. Bound into the HPKE `info` for each wrapped PSK
+    /// (`"scp-private-state-v1" || len(did) || did || "psk-rotate"`, §3.7.2),
+    /// preventing a wrap intended for one identity from opening under another.
+    pub did: String,
+
     /// X25519 public keys of all enrolled devices.
     pub enrolled_device_pubkeys: Vec<Vec<u8>>,
 
@@ -649,59 +654,78 @@ pub fn identity_key_rotation_outcome(
 }
 
 // ---------------------------------------------------------------------------
-// PSK wrapping helper
+// PSK wrapping helper (RFC 9180 HPKE, §3.7.2)
 // ---------------------------------------------------------------------------
 
-/// Wraps a 32-byte PSK for a single device using X25519 ECDH + HKDF + AES-256-GCM.
+/// HPKE `info` domain separator for PSK distribution (§3.7.2).
+const PSK_HPKE_INFO_PREFIX: &[u8] = b"scp-private-state-v1";
+
+/// Purpose string for PSK rotation re-wraps (§3.7.2, spec edit S5).
+const PSK_PURPOSE_ROTATE: &[u8] = b"psk-rotate";
+
+/// Wire length of a wrapped PSK: HPKE `enc` (32) || `ct` (48) = 80 bytes.
+const WRAPPED_PSK_LEN: usize = 32 + 48;
+
+/// Builds the §3.7.2 PSK HPKE `info`:
+/// `"scp-private-state-v1" || BE32(len(did)) || did || purpose`.
 ///
-/// Returns `Some(wrapped)` on success where `wrapped` is
-/// `[32 bytes ephemeral_pubkey || 12 bytes nonce || ciphertext+tag]`,
-/// or `None` if any crypto operation fails.
-fn wrap_psk_for_device(psk: &[u8; 32], device_pk: &[u8; 32]) -> Option<Vec<u8>> {
-    use aes_gcm::aead::Aead as _;
-    use aes_gcm::{Aes256Gcm, KeyInit as _, Nonce};
-    use rand::RngCore as _;
-    use x25519_dalek::{EphemeralSecret, PublicKey as X25519Pub};
-    use zeroize::Zeroize as _;
+/// `did` carries a 4-byte big-endian length prefix (§9.5.1); `purpose` is a
+/// fixed-version UTF-8 string with no length prefix. The `aad` is empty — the
+/// `info` binds the DID and a fresh HPKE context is used per device, so there
+/// is no cross-recipient substitution surface.
+fn build_psk_hpke_info(did: &str, purpose: &[u8]) -> Vec<u8> {
+    let did_bytes = did.as_bytes();
+    let mut info =
+        Vec::with_capacity(PSK_HPKE_INFO_PREFIX.len() + 4 + did_bytes.len() + purpose.len());
+    info.extend_from_slice(PSK_HPKE_INFO_PREFIX);
+    #[allow(clippy::cast_possible_truncation)] // DID length << u32::MAX
+    let did_len = did_bytes.len() as u32;
+    info.extend_from_slice(&did_len.to_be_bytes());
+    info.extend_from_slice(did_bytes);
+    info.extend_from_slice(purpose);
+    info
+}
 
-    let device_public = X25519Pub::from(*device_pk);
+/// Wraps a 32-byte PSK for a single device via RFC 9180 HPKE Base mode
+/// (§3.7.2). AES-128-GCM (the X25519 KEM is the ~128-bit floor; §9.5).
+///
+/// Returns `Some(wrapped)` where `wrapped` is `enc(32) || ct(48)` = 80 bytes,
+/// or `None` if HPKE sealing fails. The `info` binds the identity `did` and
+/// the `purpose` string (`"psk-rotate"` for rotation re-wraps); `aad` is empty.
+fn wrap_psk_for_device(psk: &[u8; 32], device_pk: &[u8; 32], did: &str) -> Option<Vec<u8>> {
+    let info = build_psk_hpke_info(did, PSK_PURPOSE_ROTATE);
+    let (enc, ct) = scp_protocol::crypto::hpke::seal(device_pk, &info, &[], psk).ok()?;
 
-    // 1. Generate ephemeral X25519 keypair.
-    let ephemeral_secret = EphemeralSecret::random_from_rng(rand::rngs::OsRng);
-    let ephemeral_public = X25519Pub::from(&ephemeral_secret);
+    let mut wrapped = Vec::with_capacity(WRAPPED_PSK_LEN);
+    wrapped.extend_from_slice(&enc);
+    wrapped.extend_from_slice(&ct);
+    Some(wrapped)
+}
 
-    // 2. ECDH: shared_secret = ephemeral_secret * device_public.
-    let shared_secret = ephemeral_secret.diffie_hellman(&device_public);
-
-    // 3. HKDF-SHA256 to derive a 32-byte AES-256-GCM key.
-    let hk = hkdf::Hkdf::<sha2::Sha256>::new(Some(b"scp-psk-wrap-v1"), shared_secret.as_bytes());
-    let mut wrapping_key = [0u8; 32];
-    if hk.expand(b"psk-wrapping", &mut wrapping_key).is_err() {
+/// Unwraps a PSK wrapped by [`wrap_psk_for_device`] using a software-held
+/// device X25519 secret (RFC 9180 HPKE Base mode, §3.7.2).
+///
+/// This is the device-side open counterpart of the PSK distribution protocol:
+/// a device that receives a `PskRotated` / `DeviceWrappedPsk` entry recovers
+/// the new PSK with this function. `wrapped` is `enc(32) || ct(48)`.
+///
+/// Device keys are custody-held per §3.7.2; callers holding a custody handle
+/// should instead compute the DH inside custody and call
+/// [`scp_protocol::crypto::hpke::custody::open_with_external_dh`] with the same
+/// `info` (`"scp-private-state-v1" || len(did) || did || "psk-rotate"`).
+///
+/// Returns `None` if the wire layout is wrong (not 80 bytes) or HPKE open
+/// fails (wrong device key, wrong `did`, or tampered ciphertext).
+pub fn unwrap_psk_for_device(wrapped: &[u8], device_sk: &[u8; 32], did: &str) -> Option<[u8; 32]> {
+    if wrapped.len() != WRAPPED_PSK_LEN {
         return None;
     }
+    let enc: [u8; 32] = wrapped[..32].try_into().ok()?;
+    let ct = &wrapped[32..];
 
-    // 4. AES-256-GCM encrypt the PSK with a random nonce.
-    let cipher = Aes256Gcm::new((&wrapping_key).into());
-    let mut nonce_bytes = [0u8; 12];
-    rand::rngs::OsRng.fill_bytes(&mut nonce_bytes);
-    let nonce = Nonce::from_slice(&nonce_bytes);
-
-    let Ok(ciphertext) = cipher.encrypt(nonce, psk.as_ref()) else {
-        wrapping_key.zeroize();
-        return None;
-    };
-
-    // Zeroize the wrapping key after use.
-    wrapping_key.zeroize();
-
-    // 5. Prepend ephemeral public key and nonce so the recipient can
-    // perform the reverse ECDH + decrypt.
-    // Format: [32 bytes ephemeral_pubkey || 12 bytes nonce || ciphertext+tag]
-    let mut wrapped = Vec::with_capacity(32 + 12 + ciphertext.len());
-    wrapped.extend_from_slice(ephemeral_public.as_bytes());
-    wrapped.extend_from_slice(&nonce_bytes);
-    wrapped.extend_from_slice(&ciphertext);
-    Some(wrapped)
+    let info = build_psk_hpke_info(did, PSK_PURPOSE_ROTATE);
+    let plaintext = scp_protocol::crypto::hpke::open(device_sk, &enc, &info, &[], ct).ok()?;
+    plaintext.as_slice().try_into().ok()
 }
 
 // ---------------------------------------------------------------------------
@@ -1186,7 +1210,7 @@ impl RecoveryBackend for ProductionRecoveryBackend {
             }
             let mut pk_bytes = [0u8; 32];
             pk_bytes.copy_from_slice(device_pk);
-            match wrap_psk_for_device(&new_psk, &pk_bytes) {
+            match wrap_psk_for_device(&new_psk, &pk_bytes, &params.did) {
                 Some(wrapped) => wrapped_psks.push(wrapped),
                 None => return false,
             }
@@ -1551,6 +1575,7 @@ mod tests {
         let key_rotation = active_key_rotation_outcome(&did("did:dht:alice"), 2000);
         let contacts = HashSet::from([did("did:dht:bob"), did("did:dht:carol")]);
         let psk_params = PskRotationParams {
+            did: "did:dht:zRecoveryTestIdentity".to_owned(),
             enrolled_device_pubkeys: vec![vec![1u8; 32], vec![2u8; 32]],
             compromised_device_pubkey: None,
         };
@@ -1583,6 +1608,7 @@ mod tests {
             identity_key_rotation_outcome(&did("did:dht:alice"), did("did:dht:alice-new"), 3000);
         let contacts = HashSet::from([did("did:dht:bob")]);
         let psk_params = PskRotationParams {
+            did: "did:dht:zRecoveryTestIdentity".to_owned(),
             enrolled_device_pubkeys: vec![vec![1u8; 32]],
             compromised_device_pubkey: None,
         };
@@ -1667,6 +1693,7 @@ mod tests {
 
         // Device 2 is compromised.
         let psk_params = PskRotationParams {
+            did: "did:dht:zRecoveryTestIdentity".to_owned(),
             enrolled_device_pubkeys: vec![vec![1u8; 32], vec![2u8; 32], vec![3u8; 32]],
             compromised_device_pubkey: Some(vec![2u8; 32]),
         };
@@ -1695,6 +1722,7 @@ mod tests {
         let contacts = HashSet::new();
 
         let psk_params = PskRotationParams {
+            did: "did:dht:zRecoveryTestIdentity".to_owned(),
             enrolled_device_pubkeys: vec![vec![1u8; 32]],
             compromised_device_pubkey: Some(vec![1u8; 32]),
         };
@@ -1806,6 +1834,7 @@ mod tests {
         let alice = did("did:dht:alice");
         let contacts = HashSet::from([did("did:dht:bob"), did("did:dht:carol")]);
         let psk_params = PskRotationParams {
+            did: "did:dht:zRecoveryTestIdentity".to_owned(),
             enrolled_device_pubkeys: vec![vec![1u8; 32], vec![2u8; 32]],
             compromised_device_pubkey: None,
         };
@@ -1927,6 +1956,7 @@ mod tests {
     #[test]
     fn psk_rotation_params_serialization_roundtrip() {
         let params = PskRotationParams {
+            did: "did:dht:zRecoveryTestIdentity".to_owned(),
             enrolled_device_pubkeys: vec![vec![1u8; 32], vec![2u8; 32]],
             compromised_device_pubkey: Some(vec![2u8; 32]),
         };
@@ -2187,6 +2217,7 @@ mod tests {
         let backend = ProductionRecoveryBackend::new(manager, test_signing_key());
 
         let params = PskRotationParams {
+            did: "did:dht:zRecoveryTestIdentity".to_owned(),
             enrolled_device_pubkeys: vec![vec![1u8; 32], vec![2u8; 32]],
             compromised_device_pubkey: None,
         };
@@ -2202,6 +2233,7 @@ mod tests {
         let backend = ProductionRecoveryBackend::new(manager, test_signing_key());
 
         let params = PskRotationParams {
+            did: "did:dht:zRecoveryTestIdentity".to_owned(),
             enrolled_device_pubkeys: vec![vec![1u8; 32], vec![2u8; 32], vec![3u8; 32]],
             compromised_device_pubkey: Some(vec![2u8; 32]),
         };
@@ -2220,6 +2252,7 @@ mod tests {
 
         // All devices compromised.
         let params = PskRotationParams {
+            did: "did:dht:zRecoveryTestIdentity".to_owned(),
             enrolled_device_pubkeys: vec![vec![1u8; 32]],
             compromised_device_pubkey: Some(vec![1u8; 32]),
         };
@@ -2283,6 +2316,7 @@ mod tests {
         let key_rotation = active_key_rotation_outcome(&alice, 2000);
         let contacts = HashSet::from([bob]);
         let psk_params = PskRotationParams {
+            did: "did:dht:zRecoveryTestIdentity".to_owned(),
             enrolled_device_pubkeys: vec![vec![1u8; 32], vec![2u8; 32]],
             compromised_device_pubkey: None,
         };
@@ -2325,6 +2359,7 @@ mod tests {
         let key_rotation = identity_key_rotation_outcome(&alice, did("did:dht:alice-new"), 3000);
         let contacts = HashSet::from([bob, carol]);
         let psk_params = PskRotationParams {
+            did: "did:dht:zRecoveryTestIdentity".to_owned(),
             enrolled_device_pubkeys: vec![vec![1u8; 32]],
             compromised_device_pubkey: None,
         };
@@ -2390,33 +2425,56 @@ mod tests {
     }
 
     // -----------------------------------------------------------------------
-    // wrap_psk_for_device unit tests
+    // wrap_psk_for_device / unwrap_psk_for_device unit tests (RFC 9180, §3.7.2)
     // -----------------------------------------------------------------------
 
     #[test]
-    fn psk_wrapping_nonce_is_random_not_deterministic() {
+    fn psk_wrapping_is_80_bytes_with_fresh_enc() {
         use x25519_dalek::{PublicKey as X25519Pub, StaticSecret};
 
         let device_secret = StaticSecret::random_from_rng(rand::rngs::OsRng);
         let device_public = X25519Pub::from(&device_secret);
         let psk = [0xABu8; 32];
+        let did = "did:dht:zPskTest";
 
         let wrapped1 =
-            super::wrap_psk_for_device(&psk, device_public.as_bytes()).expect("wrap 1 failed");
+            super::wrap_psk_for_device(&psk, device_public.as_bytes(), did).expect("wrap 1 failed");
         let wrapped2 =
-            super::wrap_psk_for_device(&psk, device_public.as_bytes()).expect("wrap 2 failed");
+            super::wrap_psk_for_device(&psk, device_public.as_bytes(), did).expect("wrap 2 failed");
 
-        // Nonce lives at bytes 32..44. Two wrappings of the same PSK for the
-        // same device must produce different nonces (random, not derived).
-        let nonce1 = &wrapped1[32..44];
-        let nonce2 = &wrapped2[32..44];
-        assert_ne!(nonce1, nonce2, "nonce must be random, not deterministic");
+        // Wire layout: enc(32) || ct(48) = 80 bytes. No external nonce.
+        assert_eq!(wrapped1.len(), 80);
+        assert_eq!(wrapped2.len(), 80);
+
+        // Each wrap uses a fresh ephemeral keypair → the encapsulated key
+        // (`enc`, bytes 0..32) differs every time, even for the same PSK and
+        // device. This is what makes each HPKE context single-use.
+        assert_ne!(
+            &wrapped1[..32],
+            &wrapped2[..32],
+            "enc must be fresh per wrap"
+        );
     }
 
     #[test]
-    fn psk_wrapping_roundtrip_with_random_nonce() {
-        use aes_gcm::aead::Aead as _;
-        use aes_gcm::{Aes256Gcm, KeyInit as _, Nonce};
+    fn psk_wrapping_roundtrip() {
+        use x25519_dalek::{PublicKey as X25519Pub, StaticSecret};
+
+        let device_secret = StaticSecret::random_from_rng(rand::rngs::OsRng);
+        let device_public = X25519Pub::from(&device_secret);
+        let psk = [0x42u8; 32];
+        let did = "did:dht:zPskTest";
+
+        let wrapped = super::wrap_psk_for_device(&psk, device_public.as_bytes(), did)
+            .expect("wrap failed");
+
+        let recovered = super::unwrap_psk_for_device(&wrapped, &device_secret.to_bytes(), did)
+            .expect("unwrap failed");
+        assert_eq!(recovered, psk, "roundtrip mismatch");
+    }
+
+    #[test]
+    fn psk_unwrapping_rejects_wrong_did() {
         use x25519_dalek::{PublicKey as X25519Pub, StaticSecret};
 
         let device_secret = StaticSecret::random_from_rng(rand::rngs::OsRng);
@@ -2424,30 +2482,48 @@ mod tests {
         let psk = [0x42u8; 32];
 
         let wrapped =
-            super::wrap_psk_for_device(&psk, device_public.as_bytes()).expect("wrap failed");
+            super::wrap_psk_for_device(&psk, device_public.as_bytes(), "did:dht:zAlice")
+                .expect("wrap failed");
 
-        // Parse the wire format: [32 ephemeral_pk || 12 nonce || ciphertext+tag]
-        assert!(wrapped.len() > 44, "wrapped output too short");
-        let ephemeral_pk = X25519Pub::from({
-            let mut buf = [0u8; 32];
-            buf.copy_from_slice(&wrapped[..32]);
-            buf
-        });
-        let nonce = Nonce::from_slice(&wrapped[32..44]);
-        let ciphertext = &wrapped[44..];
+        // A different DID changes the HPKE info → AEAD open fails.
+        assert!(
+            super::unwrap_psk_for_device(&wrapped, &device_secret.to_bytes(), "did:dht:zBob")
+                .is_none(),
+            "wrong DID must fail to unwrap"
+        );
+    }
 
-        // Reverse: ECDH with device_secret * ephemeral_pk → HKDF → decrypt.
-        let shared_secret = device_secret.diffie_hellman(&ephemeral_pk);
-        let hk =
-            hkdf::Hkdf::<sha2::Sha256>::new(Some(b"scp-psk-wrap-v1"), shared_secret.as_bytes());
-        let mut wrapping_key = [0u8; 32];
-        hk.expand(b"psk-wrapping", &mut wrapping_key)
-            .expect("hkdf expand failed");
+    #[test]
+    fn psk_unwrapping_rejects_wrong_device_and_tamper() {
+        use x25519_dalek::{PublicKey as X25519Pub, StaticSecret};
 
-        let cipher = Aes256Gcm::new((&wrapping_key).into());
-        let recovered = cipher
-            .decrypt(nonce, ciphertext)
-            .expect("decryption failed");
-        assert_eq!(recovered.as_slice(), &psk, "roundtrip mismatch");
+        let device_secret = StaticSecret::random_from_rng(rand::rngs::OsRng);
+        let device_public = X25519Pub::from(&device_secret);
+        let wrong_secret = StaticSecret::random_from_rng(rand::rngs::OsRng);
+        let psk = [0x42u8; 32];
+        let did = "did:dht:zPskTest";
+
+        let wrapped = super::wrap_psk_for_device(&psk, device_public.as_bytes(), did)
+            .expect("wrap failed");
+
+        // Wrong device key.
+        assert!(
+            super::unwrap_psk_for_device(&wrapped, &wrong_secret.to_bytes(), did).is_none(),
+            "wrong device key must fail"
+        );
+
+        // Tampered ciphertext.
+        let mut tampered = wrapped.clone();
+        tampered[40] ^= 0x01;
+        assert!(
+            super::unwrap_psk_for_device(&tampered, &device_secret.to_bytes(), did).is_none(),
+            "tampered ciphertext must fail"
+        );
+
+        // Wrong length.
+        assert!(
+            super::unwrap_psk_for_device(&wrapped[..79], &device_secret.to_bytes(), did).is_none(),
+            "wrong length must fail"
+        );
     }
 }

--- a/crates/scp-runtime/src/identity/recovery.rs
+++ b/crates/scp-runtime/src/identity/recovery.rs
@@ -716,6 +716,7 @@ fn wrap_psk_for_device(psk: &[u8; 32], device_pk: &[u8; 32], did: &str) -> Optio
 ///
 /// Returns `None` if the wire layout is wrong (not 80 bytes) or HPKE open
 /// fails (wrong device key, wrong `did`, or tampered ciphertext).
+#[must_use]
 pub fn unwrap_psk_for_device(wrapped: &[u8], device_sk: &[u8; 32], did: &str) -> Option<[u8; 32]> {
     if wrapped.len() != WRAPPED_PSK_LEN {
         return None;
@@ -2462,8 +2463,8 @@ mod tests {
         let psk = [0x42u8; 32];
         let did = "did:dht:zPskTest";
 
-        let wrapped = super::wrap_psk_for_device(&psk, device_public.as_bytes(), did)
-            .expect("wrap failed");
+        let wrapped =
+            super::wrap_psk_for_device(&psk, device_public.as_bytes(), did).expect("wrap failed");
 
         let recovered = super::unwrap_psk_for_device(&wrapped, &device_secret.to_bytes(), did)
             .expect("unwrap failed");
@@ -2478,9 +2479,8 @@ mod tests {
         let device_public = X25519Pub::from(&device_secret);
         let psk = [0x42u8; 32];
 
-        let wrapped =
-            super::wrap_psk_for_device(&psk, device_public.as_bytes(), "did:dht:zAlice")
-                .expect("wrap failed");
+        let wrapped = super::wrap_psk_for_device(&psk, device_public.as_bytes(), "did:dht:zAlice")
+            .expect("wrap failed");
 
         // A different DID changes the HPKE info → AEAD open fails.
         assert!(
@@ -2500,8 +2500,8 @@ mod tests {
         let psk = [0x42u8; 32];
         let did = "did:dht:zPskTest";
 
-        let wrapped = super::wrap_psk_for_device(&psk, device_public.as_bytes(), did)
-            .expect("wrap failed");
+        let wrapped =
+            super::wrap_psk_for_device(&psk, device_public.as_bytes(), did).expect("wrap failed");
 
         // Wrong device key.
         assert!(

--- a/crates/scp-runtime/src/identity/recovery.rs
+++ b/crates/scp-runtime/src/identity/recovery.rs
@@ -725,7 +725,9 @@ pub fn unwrap_psk_for_device(wrapped: &[u8], device_sk: &[u8; 32], did: &str) ->
     let ct = &wrapped[32..];
 
     let info = build_psk_hpke_info(did, PSK_PURPOSE_ROTATE);
-    let plaintext = scp_protocol::crypto::hpke::open(device_sk, &enc, &info, &[], ct).ok()?;
+    let plaintext = zeroize::Zeroizing::new(
+        scp_protocol::crypto::hpke::open(device_sk, &enc, &info, &[], ct).ok()?,
+    );
     plaintext.as_slice().try_into().ok()
 }
 

--- a/crates/scp-runtime/src/identity/recovery.rs
+++ b/crates/scp-runtime/src/identity/recovery.rs
@@ -702,35 +702,6 @@ fn wrap_psk_for_device(psk: &[u8; 32], device_pk: &[u8; 32], did: &str) -> Optio
     Some(wrapped)
 }
 
-/// Unwraps a PSK wrapped by [`wrap_psk_for_device`] using a software-held
-/// device X25519 secret (RFC 9180 HPKE Base mode, §3.7.2).
-///
-/// This is the device-side open counterpart of the PSK distribution protocol:
-/// a device that receives a `PskRotated` / `DeviceWrappedPsk` entry recovers
-/// the new PSK with this function. `wrapped` is `enc(32) || ct(48)`.
-///
-/// Device keys are custody-held per §3.7.2; callers holding a custody handle
-/// should instead compute the DH inside custody and call
-/// [`scp_protocol::crypto::hpke::custody::open_with_external_dh`] with the same
-/// `info` (`"scp-private-state-v1" || len(did) || did || "psk-rotate"`).
-///
-/// Returns `None` if the wire layout is wrong (not 80 bytes) or HPKE open
-/// fails (wrong device key, wrong `did`, or tampered ciphertext).
-#[must_use]
-pub fn unwrap_psk_for_device(wrapped: &[u8], device_sk: &[u8; 32], did: &str) -> Option<[u8; 32]> {
-    if wrapped.len() != WRAPPED_PSK_LEN {
-        return None;
-    }
-    let enc: [u8; 32] = wrapped[..32].try_into().ok()?;
-    let ct = &wrapped[32..];
-
-    let info = build_psk_hpke_info(did, PSK_PURPOSE_ROTATE);
-    let plaintext = zeroize::Zeroizing::new(
-        scp_protocol::crypto::hpke::open(device_sk, &enc, &info, &[], ct).ok()?,
-    );
-    plaintext.as_slice().try_into().ok()
-}
-
 // ---------------------------------------------------------------------------
 // ProductionRecoveryBackend — real implementation of RecoveryBackend
 // ---------------------------------------------------------------------------
@@ -2430,8 +2401,39 @@ mod tests {
     }
 
     // -----------------------------------------------------------------------
-    // wrap_psk_for_device / unwrap_psk_for_device unit tests (RFC 9180, §3.7.2)
+    // wrap_psk_for_device unit tests (RFC 9180, §3.7.2)
+    //
+    // These verify the PRODUCTION wrap path (`wrap_psk_for_device`, called by
+    // `rotate_psk`). The device-side open counterpart is exercised here by
+    // calling `scp_protocol::crypto::hpke::open` directly against the wrapped
+    // wire (`enc(32) || ct(48)`), reconstructing the §3.7.2 `info` via the
+    // shared `build_psk_hpke_info` helper that the production wrap also uses.
+    // Opening through `hpke::open` keeps every negative ciphertext-level: a
+    // real AEAD verification failure, not a builder-string comparison.
     // -----------------------------------------------------------------------
+
+    /// Device-side open of a wrapped PSK, mirroring what a device that receives
+    /// a `PskRotated` / `DeviceWrappedPsk` entry does: split `enc(32) || ct(48)`,
+    /// rebuild the §3.7.2 `info`, and HPKE-open with the device X25519 secret.
+    ///
+    /// Returns `None` on wrong wire length, invalid `enc`, or any HPKE/AEAD
+    /// failure (wrong device key, wrong `did`, tampered ciphertext) — exactly
+    /// the failure surface the negatives below assert against.
+    fn open_wrapped_psk(wrapped: &[u8], device_sk: &[u8; 32], did: &str) -> Option<[u8; 32]> {
+        if wrapped.len() != super::WRAPPED_PSK_LEN {
+            return None;
+        }
+        let enc: [u8; 32] = wrapped[..32].try_into().ok()?;
+        let ct = &wrapped[32..];
+
+        // Reconstruct the §3.7.2 info via the SAME helper the production wrap
+        // uses, so the test cannot drift from the wrap's info construction.
+        let info = super::build_psk_hpke_info(did, super::PSK_PURPOSE_ROTATE);
+        let plaintext = zeroize::Zeroizing::new(
+            scp_protocol::crypto::hpke::open(device_sk, &enc, &info, &[], ct).ok()?,
+        );
+        plaintext.as_slice().try_into().ok()
+    }
 
     #[test]
     fn psk_wrapping_is_80_bytes_with_fresh_enc() {
@@ -2470,16 +2472,17 @@ mod tests {
         let psk = [0x42u8; 32];
         let did = "did:dht:zPskTest";
 
+        // Production wrap → device-side open via hpke::open must recover the PSK.
         let wrapped =
             super::wrap_psk_for_device(&psk, device_public.as_bytes(), did).expect("wrap failed");
 
-        let recovered = super::unwrap_psk_for_device(&wrapped, &device_secret.to_bytes(), did)
-            .expect("unwrap failed");
+        let recovered =
+            open_wrapped_psk(&wrapped, &device_secret.to_bytes(), did).expect("open failed");
         assert_eq!(recovered, psk, "roundtrip mismatch");
     }
 
     #[test]
-    fn psk_unwrapping_rejects_wrong_did() {
+    fn psk_opening_rejects_wrong_did() {
         use x25519_dalek::{PublicKey as X25519Pub, StaticSecret};
 
         let device_secret = StaticSecret::random_from_rng(rand::rngs::OsRng);
@@ -2491,14 +2494,13 @@ mod tests {
 
         // A different DID changes the HPKE info → AEAD open fails.
         assert!(
-            super::unwrap_psk_for_device(&wrapped, &device_secret.to_bytes(), "did:dht:zBob")
-                .is_none(),
-            "wrong DID must fail to unwrap"
+            open_wrapped_psk(&wrapped, &device_secret.to_bytes(), "did:dht:zBob").is_none(),
+            "wrong DID must fail to open"
         );
     }
 
     #[test]
-    fn psk_unwrapping_rejects_wrong_device_and_tamper() {
+    fn psk_opening_rejects_wrong_device_and_tamper() {
         use x25519_dalek::{PublicKey as X25519Pub, StaticSecret};
 
         let device_secret = StaticSecret::random_from_rng(rand::rngs::OsRng);
@@ -2512,7 +2514,7 @@ mod tests {
 
         // Wrong device key.
         assert!(
-            super::unwrap_psk_for_device(&wrapped, &wrong_secret.to_bytes(), did).is_none(),
+            open_wrapped_psk(&wrapped, &wrong_secret.to_bytes(), did).is_none(),
             "wrong device key must fail"
         );
 
@@ -2520,13 +2522,13 @@ mod tests {
         let mut tampered = wrapped.clone();
         tampered[40] ^= 0x01;
         assert!(
-            super::unwrap_psk_for_device(&tampered, &device_secret.to_bytes(), did).is_none(),
+            open_wrapped_psk(&tampered, &device_secret.to_bytes(), did).is_none(),
             "tampered ciphertext must fail"
         );
 
         // Wrong length.
         assert!(
-            super::unwrap_psk_for_device(&wrapped[..79], &device_secret.to_bytes(), did).is_none(),
+            open_wrapped_psk(&wrapped[..79], &device_secret.to_bytes(), did).is_none(),
             "wrong length must fail"
         );
     }

--- a/crates/scp-runtime/tests/forward_compatibility_conformance.rs
+++ b/crates/scp-runtime/tests/forward_compatibility_conformance.rs
@@ -1020,7 +1020,7 @@ mod access_key_types {
             context_id: "ctx-access-test".to_string(),
             member_did: "did:dht:member".to_string(),
             epoch: 5,
-            hpke_sealed_key: vec![0xEE; 48],
+            hpke_sealed_key: [0xEE; 48],
             ephemeral_pubkey: vec![0xFF; 32],
         };
         let bytes = rmp_serde::to_vec_named(&response).unwrap();
@@ -1036,7 +1036,7 @@ mod access_key_types {
         assert_eq!(decoded.context_id, "ctx-access-test");
         assert_eq!(decoded.member_did, "did:dht:member");
         assert_eq!(decoded.epoch, 5);
-        assert_eq!(decoded.hpke_sealed_key, vec![0xEE; 48]);
+        assert_eq!(decoded.hpke_sealed_key, [0xEE; 48]);
         assert_eq!(decoded.ephemeral_pubkey, vec![0xFF; 32]);
     }
 }

--- a/crates/scp-runtime/tests/forward_compatibility_conformance.rs
+++ b/crates/scp-runtime/tests/forward_compatibility_conformance.rs
@@ -717,7 +717,7 @@ mod sender_key_types {
         let response = SenderKeyResponse {
             sender_did: "did:dht:sender".to_string(),
             epoch: 3,
-            hpke_sealed_key: [0xEE; 60],
+            hpke_sealed_key: [0xEE; 48],
             ephemeral_pubkey: [0xFF; 32],
             request_nonce: [0xAA; 16],
         };
@@ -1020,7 +1020,7 @@ mod access_key_types {
             context_id: "ctx-access-test".to_string(),
             member_did: "did:dht:member".to_string(),
             epoch: 5,
-            hpke_sealed_key: vec![0xEE; 60],
+            hpke_sealed_key: vec![0xEE; 48],
             ephemeral_pubkey: vec![0xFF; 32],
         };
         let bytes = rmp_serde::to_vec_named(&response).unwrap();
@@ -1036,7 +1036,7 @@ mod access_key_types {
         assert_eq!(decoded.context_id, "ctx-access-test");
         assert_eq!(decoded.member_did, "did:dht:member");
         assert_eq!(decoded.epoch, 5);
-        assert_eq!(decoded.hpke_sealed_key, vec![0xEE; 60]);
+        assert_eq!(decoded.hpke_sealed_key, vec![0xEE; 48]);
         assert_eq!(decoded.ephemeral_pubkey, vec![0xFF; 32]);
     }
 }

--- a/crates/scp-testing/tests/integration/compromise_recovery.rs
+++ b/crates/scp-testing/tests/integration/compromise_recovery.rs
@@ -154,6 +154,7 @@ async fn compromise_tier_active_signing() {
     let kr = active_key_rotation_outcome(&alice, 2000);
     let contacts = HashSet::from([did("did:dht:bob")]);
     let psk_params = PskRotationParams {
+        did: "did:dht:zRecoveryTestIdentity".to_owned(),
         enrolled_device_pubkeys: vec![vec![1u8; 32], vec![2u8; 32]],
         compromised_device_pubkey: None,
     };
@@ -196,6 +197,7 @@ async fn compromise_tier_identity_key() {
     let kr = identity_key_rotation_outcome(&alice, alice_new.clone(), 3000);
     let contacts = HashSet::from([did("did:dht:bob"), did("did:dht:carol")]);
     let psk_params = PskRotationParams {
+        did: "did:dht:zRecoveryTestIdentity".to_owned(),
         enrolled_device_pubkeys: vec![vec![1u8; 32]],
         compromised_device_pubkey: None,
     };
@@ -509,6 +511,7 @@ async fn recovery_result_with_rejoin_context() {
 async fn psk_rotation_params() {
     // Without compromised device.
     let params_clean = PskRotationParams {
+        did: "did:dht:zRecoveryTestIdentity".to_owned(),
         enrolled_device_pubkeys: vec![vec![0xAA; 32], vec![0xBB; 32], vec![0xCC; 32]],
         compromised_device_pubkey: None,
     };
@@ -517,6 +520,7 @@ async fn psk_rotation_params() {
 
     // With compromised device excluded.
     let params_compromised = PskRotationParams {
+        did: "did:dht:zRecoveryTestIdentity".to_owned(),
         enrolled_device_pubkeys: vec![vec![0xAA; 32], vec![0xBB; 32], vec![0xCC; 32]],
         compromised_device_pubkey: Some(vec![0xBB; 32]),
     };
@@ -662,6 +666,7 @@ async fn recovery_with_psk_rotation_failure() {
     let orch = CompromiseRecoveryOrchestrator::new(alice.clone(), vec![]);
     let kr = active_key_rotation_outcome(&alice, 9000);
     let psk_params = PskRotationParams {
+        did: "did:dht:zRecoveryTestIdentity".to_owned(),
         enrolled_device_pubkeys: vec![vec![1u8; 32]],
         compromised_device_pubkey: Some(vec![1u8; 32]),
     };


### PR DESCRIPTION
## What

Replaces SCP's key-distribution cryptography — which was **five independently hand-rolled HKDF-ECIES constructions mislabeled as RFC 9180 HPKE** — with one correct, pure RFC 9180 Base-mode single-shot HPKE core (`crates/scp-protocol/src/crypto/hpke.rs`), used by every path: sender-key (§9.16.2), access-key (§9.17), invitation bundle (§5.12.3), device-PSK (§3.7.2), and broadcast key (§5.14.2).

## Why

The as-built `ProductionHpkeBackend` + the five live paths used the raw X25519 DH output directly as HKDF IKM — skipping RFC 9180 DHKEM `ExtractAndExpand`, never binding `enc‖pkRm`, and shipping an external on-wire nonce — while the doc-comments and spec §9.5 both claimed "RFC 9180". Cryptographically sound in isolation, but **non-conformant, non-interoperable, and falsely documented**: any SDK that trusted the spec and used a real RFC 9180 library would silently fail to interoperate on key distribution. The five copies had also drifted apart from each other.

## How

- **One core, hand-implemented** (labeled `Extract`/`Expand`, DHKEM `ExtractAndExpand`, `KeySchedule_base`, single-shot seal/open) over in-tree RustCrypto primitives. `hpke-rs` cannot serve this because custody-held recipient keys complete Decap *outside* the `KeyCustody` boundary (raw DH from `dh_agree`, `pkRm` from `public_key`), and `hpke-rs`'s DHKEM internals are private — so the custody Decap variant lives at `hpke::custody::open_with_external_dh`.
- **Pinned to RFC 9180 Appendix A.1 known-answer tests** (asserting intermediate `shared_secret`/`key`/`base_nonce`, not just round-trip) **and cross-validated against `hpke-rs` 0.6 as a dev-dependency oracle** (both directions + custody path).
- All five custom constructions **deleted** and routed through the core (`derive_aead_key`/`HPKE_DOMAIN_TAG`/`hkdf_derive_key`/`aes128gcm_*` → gone, zero surviving references — no downgrade target).
- Wire HPKE ciphertext field **60 → 48 bytes** (external nonce removed; nonce is internal per RFC 9180). `AccessKeyResponse.hpke_sealed_key` tightened `Vec<u8>` → `[u8; 48]` (bounded deserialize).
- PSK device-wrap conformed to spec §3.7.2 (HPKE AES-128-GCM, DID-bound `info`) — was salted-HKDF AES-256-GCM matching no spec.
- All recovered-secret and DH intermediates `Zeroizing`-wrapped on every return path.

## Spec edits (clarifications, flagged in-diff)

S1 §5.14.2 broadcast `info`/`aad` BE32 length prefixes · S2 §9.18.2 separator registry rows · S3 §5.12.3 invitation construction · S4 §9.16.2 custody-Decap wording · S5 §3.7.2 PSK rotation purpose. Spec commits land first per the artifact-flow invariant.

## Review

Five-agent comprehensive review (cryptographer / security / bug-catcher / test-quality / black-hat) → fixes → three-agent delta review → fixes → final independent cryptographer gate: **SHIP** (all 7 criteria pass). CI green locally: exact all-features clippy clean; 14 RFC 9180 KATs + 3 oracle + 2970 scp-protocol + 368 scp-runtime crypto + full workspace tests; wasm32 check clean. Rebased onto current `main` (merge-base == origin/main).

## Follow-ups (NOT in this PR)

- [ ] **Broadcast HPKE pull-protocol wiring** — conformant seal/open helpers land here, but the end-to-end relay distribution path is still unimplemented (it returned raw key bytes). Separate story (ref **SCP-227**) with the FFI/SDK integration checklist.
- [ ] **PSK `"device-enroll"` purpose** — defined in §3.7.2; only `"psk-rotate"` is wired (the initial-enrollment flow is separate and pre-existing).
- [ ] Confirm sender/access-key response authenticity (claimed `sender_did`/`member_did` vs authenticated MLS sender) is enforced at the deliver layer — pre-existing, outside this diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Cross-layer exemptions

The new/renamed HPKE construction primitives are internal crypto (under `crates/scp-protocol/src/crypto/`), not SDK surface — the SDK operates at the context/key-distribution-operation level, never raw HPKE:

[cross-layer: internal-crypto] seal
[cross-layer: internal-crypto] open
[cross-layer: internal-crypto] hpke_seal_invitation
[cross-layer: internal-crypto] hpke_open_invitation

`hpke::seal`/`open` are called cross-crate by scp-runtime's key-distribution paths; `hpke_seal_invitation`/`hpke_open_invitation` are the invitation-bundle crypto primitives (renamed from the prior `ecies_*` and conformed to RFC 9180). The device-side `unwrap_psk_for_device` is intentionally NOT added here — it has no production caller until the PSK-distribution receive path is wired, so it lands with that story rather than as dead public API.
