### PR TITLE
ci(enforcement): per-PR prod-config (no in-memory-custody) lib build lanes for pyo3 + uniffi

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -471,6 +471,66 @@ jobs:
           # must compile and pass without the testing affordances.
           cargo test -p scp-ffi-napi --features server
 
+  # Builds the pyo3 bridge (`scp-ffi`) in its PRODUCTION configuration: default
+  # features (`server` on) but WITHOUT `allow_in_memory_custody`. This is the
+  # config `build-matrix.yml` only exercises at release/tag time, so a PR could
+  # re-gate a production identity/SCPID/custody op behind the test-only
+  # `allow_in_memory_custody` feature — making it vanish from the production lib —
+  # and the regression would go unnoticed until release. This is the per-PR guard
+  # against that over-gating regression class. Build-only (lib + bins): the pyo3
+  # test suite assumes in-memory custody and does not compile in prod config, so
+  # a full prod-config test lane is a separate follow-up. The lib build still
+  # catches the bug class — a production op gated out of the lib won't compile.
+  rust-build-pyo3-production:
+    needs: changes
+    if: needs.changes.outputs.rust == 'true'
+    name: Rust / build (pyo3 production config)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Free disk space
+        run: |
+          sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghc /opt/hostedtoolcache/CodeQL
+          df -h /
+      - uses: actions/checkout@v5
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - uses: Swatinem/rust-cache@v2
+      - name: Build pyo3 bridge in production config (no in-memory custody)
+        run: |
+          # pyo3 links libpython, so LD_LIBRARY_PATH must point at LIBDIR.
+          export LD_LIBRARY_PATH="$(python3 -c 'import sysconfig; print(sysconfig.get_config_var("LIBDIR"))')${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}"
+          # Default features = production: `server` on, no `allow_in_memory_custody`.
+          cargo build -p scp-ffi --features server
+
+  # Builds the uniffi bridge (`scp-ffi-uniffi`) in its PRODUCTION configuration:
+  # default features (`server` on) but WITHOUT `allow_in_memory_custody`. Same
+  # guardrail rationale as the pyo3 lane above: `build-matrix.yml` only builds
+  # the mobile (iOS XCFramework / Android .aar) production libs at release time,
+  # so a PR could re-gate a production op behind the test-only feature and break
+  # the production lib unnoticed until release. This is the per-PR guard against
+  # that over-gating regression class. Build-only (lib + bins): the uniffi test
+  # suite assumes in-memory custody and does not compile in prod config, so a
+  # full prod-config test lane is a separate follow-up.
+  rust-build-uniffi-production:
+    needs: changes
+    if: needs.changes.outputs.rust == 'true'
+    name: Rust / build (uniffi production config)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Free disk space
+        run: |
+          sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghc /opt/hostedtoolcache/CodeQL
+          df -h /
+      - uses: actions/checkout@v5
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+      - name: Build uniffi bridge in production config (no in-memory custody)
+        run: |
+          # Default features = production: `server` on, no `allow_in_memory_custody`.
+          cargo build -p scp-ffi-uniffi --features server
+
   rust-doc:
     needs: changes
     if: needs.changes.outputs.rust == 'true'
@@ -1045,6 +1105,8 @@ jobs:
       - rust-clippy
       - rust-test
       - rust-test-napi-production
+      - rust-build-pyo3-production
+      - rust-build-uniffi-production
       - rust-doc
       - rust-deny
       - python-lint
@@ -1082,6 +1144,8 @@ jobs:
             "${{ needs.rust-clippy.result }}" \
             "${{ needs.rust-test.result }}" \
             "${{ needs.rust-test-napi-production.result }}" \
+            "${{ needs.rust-build-pyo3-production.result }}" \
+            "${{ needs.rust-build-uniffi-production.result }}" \
             "${{ needs.rust-doc.result }}" \
             "${{ needs.rust-deny.result }}" \
             "${{ needs.python-lint.result }}" \


### PR DESCRIPTION
## Guardrail rationale

PRs #1780–1788 were a cluster fixing production identity / SCPID / custody ops that had been gated behind the test-only `allow_in_memory_custody` feature and thus **vanished from production bridge builds**. A production op silently gated out of the prod lib is the regression class this PR guards against.

The napi bridge already has a per-PR lane (`rust-test-napi-production`) that builds it **without** `allow_in_memory_custody`. But **pyo3 (`scp-ffi`) and uniffi (`scp-ffi-uniffi`) had no equivalent per-PR lane** — `build-matrix.yml` only builds them at release/tag time. So a PR could re-gate a prod op behind the test-only feature and break the production lib, and it would go unnoticed until release.

## What the lanes do

Two new jobs, mirroring the `rust-test-napi-production` lane structure (`needs: changes`; `if: needs.changes.outputs.rust == 'true'`; free-disk; checkout@v5; rust-toolchain stable; rust-cache@v2):

- **`rust-build-pyo3-production`** — `cargo build -p scp-ffi --features server`. pyo3 links libpython, so the step exports `LD_LIBRARY_PATH=$LIBDIR` and includes `setup-python@v5` (3.12).
- **`rust-build-uniffi-production`** — `cargo build -p scp-ffi-uniffi --features server`. No Python needed.

Both build in **production config**: default `server` feature **without** `allow_in_memory_custody` / `scp-core/testing` / `scp-runtime/testing`. Both are wired into the `ci` aggregation job (`needs:` list **and** `results=(...)` array) so they actually gate merges.

Verified locally on the branch base: both `cargo build --features server` succeed today (exit 0). These lanes are green now and guard against future regressions of the over-gating class.

## Scope note

**Build-only** (lib + bins), not `cargo test`. The pyo3/uniffi **test** suites do not compile without `allow_in_memory_custody` (92 in-memory test sites in pyo3, 156 in uniffi assume it). Re-gating those suites behind `allow_in_memory_custody` to enable a full prod-config **test** lane — mirroring napi's already-gated suite — is a large separate follow-up, explicitly out of scope here. The lib build still catches the actual bug class: a production op gated out of the lib won't compile.

🤖 Generated with [Claude Code](https://claude.com/claude-code)