### PR TITLE
feat(node): PORT env override on self-host website example

### DIFF
--- a/crates/scp-node/examples/website.rs
+++ b/crates/scp-node/examples/website.rs
@@ -26,12 +26,15 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         skip_nat: true,
         dht_mode: DhtMode::Memory,
         // `PORT` overrides the bind port. The demo defaults to 8080 (not the
-        // conventional 8443) so it won't collide with a real node already
-        // bound to 8443. Unset or unparseable `PORT` falls back to 8080.
-        port: std::env::var("PORT")
-            .ok()
-            .and_then(|p| p.parse::<u16>().ok())
-            .unwrap_or(8080),
+        // conventional 8443) so it won't collide with a real node already bound
+        // to 8443. An unset `PORT` uses 8080 silently; a set-but-invalid `PORT`
+        // warns and falls back to 8080.
+        port: std::env::var("PORT").map_or(8080, |raw| {
+            raw.parse::<u16>().unwrap_or_else(|_| {
+                eprintln!("PORT={raw:?} is not a valid u16 port number; using 8080");
+                8080
+            })
+        }),
         ..Default::default()
     })
     .await?;

--- a/crates/scp-node/examples/website.rs
+++ b/crates/scp-node/examples/website.rs
@@ -1,6 +1,9 @@
 //! Host a static website on SCP. Run: `cargo run -p scp-node --example website`
 //! Then open the printed URL.
 //!
+//! Override the port with the `PORT` env var, e.g.
+//! `PORT=9000 cargo run -p scp-node --example website`.
+//!
 //! This is a safe LOCAL demo: it serves plain HTTP, skips all NAT/UPnP port
 //! mapping, and uses an in-memory DHT — so NO router port is opened and NOTHING
 //! is published to the network. (The listener binds `0.0.0.0`, so it is also
@@ -22,6 +25,13 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         plaintext: true,
         skip_nat: true,
         dht_mode: DhtMode::Memory,
+        // `PORT` overrides the bind port. The demo defaults to 8080 (not the
+        // conventional 8443) so it won't collide with a real node already
+        // bound to 8443. Unset or unparseable `PORT` falls back to 8080.
+        port: std::env::var("PORT")
+            .ok()
+            .and_then(|p| p.parse::<u16>().ok())
+            .unwrap_or(8080),
         ..Default::default()
     })
     .await?;


### PR DESCRIPTION
## Summary

Adds a `PORT` environment-variable override to the runnable self-host website example (`crates/scp-node/examples/website.rs`).

The example now sets `HostSiteOptions.port` by reading the `PORT` env var, parsing it as `u16`, and falling back to **8080** when `PORT` is unset or unparseable. Defaulting to 8080 (rather than the conventional 8443) lets a developer run the demo alongside a real node already bound to 8443.

The top-of-file `//!` doc comment now documents the override (`PORT=9000 cargo run -p scp-node --example website`). The existing safety wording about plaintext / skip-NAT / in-memory-DHT is unchanged.

## Scope

- Single file: `crates/scp-node/examples/website.rs` (+10 lines).
- No changes to `host_site` / `self_host.rs` / `HostSiteOptions` definitions.

## Validation

- `cargo fmt --check -p scp-node` — clean
- `cargo clippy -p scp-node --lib --examples -- -D warnings` — clean
- `cargo build -p scp-node --example website` — builds
- Ran `PORT=8088 cargo run -p scp-node --example website` and `curl http://127.0.0.1:8088/` returned **200**, confirming the example honors `PORT`.

> Note: `cargo clippy -p scp-node --all-targets` surfaces 3 pre-existing compilation errors in `crates/scp-node/tests/integration.rs` (`ApplicationNodeBuilder::build_for_testing` / `ApplicationNode::dev` no longer exist). These are present at the merge base (`0c8f0b065`) independent of this change and are out of scope for this example-only edit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)