### PR TITLE
chore(saga): cut SagaInput::ContextMigration custody-handover (code-layer; spec #1793 §4)

### DIFF
--- a/crates/scp-runtime/src/context/supervisor/mod.rs
+++ b/crates/scp-runtime/src/context/supervisor/mod.rs
@@ -48,8 +48,8 @@ pub use saga_journal::{
     SagaJournal, SagaState, SagaTerminalState,
 };
 pub use saga_prepared_state::{
-    BroadcastHostingHandshakePrepared, ContextMigrationPrepared,
-    CrossContextToolInvocationPrepared, SagaPreparedState, StandingPairCreatePrepared,
+    BroadcastHostingHandshakePrepared, CrossContextToolInvocationPrepared, SagaPreparedState,
+    StandingPairCreatePrepared,
 };
 pub use supervisor::{
     ACTOR_MAILBOX_CAPACITY, CrashWindow, PendingSagaProjection, SagaInput, SagaOutput, Supervisor,

--- a/crates/scp-runtime/src/context/supervisor/saga_journal.rs
+++ b/crates/scp-runtime/src/context/supervisor/saga_journal.rs
@@ -5,8 +5,8 @@
 //! # Trait
 //!
 //! [`SagaJournal`] is the supervisor's durable coordinator record for
-//! cross-actor sagas (standing-pair create, migration, cross-context tool
-//! invoke, broadcast hosting handshake). It exposes three operations per
+//! cross-actor sagas (standing-pair create, cross-context tool invoke,
+//! broadcast hosting handshake). It exposes three operations per
 //! spec §17.16.1:
 //!
 //! - [`SagaJournal::append`] — durably persist a state transition. Flushes
@@ -167,8 +167,10 @@ pub struct JournalEntry {
     /// operations they are DIDs. Interpretation is saga-type specific.
     pub participants: Vec<String>,
     /// Saga-type specific evidence — MessagePack-encoded `SagaPreparedState`.
-    /// Wrapped in [`Zeroizing`] so secret-bearing payloads (e.g. migration
-    /// commitments) zero on drop. See spec §9.4.3.
+    /// Wrapped in [`Zeroizing`] so any secret-bearing payload zeroes on drop.
+    /// No current saga is secret-bearing (all three journal public metadata
+    /// only); this is the §9.4.3 forward contract for any future
+    /// secret-bearing saga. See spec §9.4.3.
     pub evidence: Zeroizing<Vec<u8>>,
     /// Milliseconds since the UNIX epoch when the entry was appended.
     pub timestamp_ms: u64,

--- a/crates/scp-runtime/src/context/supervisor/saga_prepared_state.rs
+++ b/crates/scp-runtime/src/context/supervisor/saga_prepared_state.rs
@@ -9,50 +9,51 @@
 //! deliberate:
 //!
 //! - **Journal (durable, supervisor-side):** records *which* saga is in
-//!   *which* phase, plus a public commitment for secret-bearing sagas. Spec
-//!   §9.4.3 forbids the journal from holding bearer artifacts directly.
+//!   *which* phase, plus a public commitment for any secret-bearing saga.
+//!   Spec §9.4.3 forbids the journal from holding bearer artifacts
+//!   directly. No live saga is secret-bearing (see below); the commitment
+//!   path is dormant.
 //! - **`saga_pending` (actor-side):** holds the full evidence the actor
-//!   needs to apply the mutation at Commit time. For secret-bearing sagas
-//!   (migration), the bearer envelope sits here under `Zeroizing` so drop
-//!   zeros the bytes if the actor crashes before Commit.
+//!   needs to apply the mutation at Commit time. For a future
+//!   secret-bearing saga the bearer envelope would sit here under
+//!   `Zeroizing` so drop zeros the bytes if the actor crashes before
+//!   Commit; no current variant carries one.
 //!
-//! At Commit time the actor reconstructs the bearer from `saga_pending`,
-//! verifies the journal's commitment matches via SHA-256, then applies
-//! the mutation. If `saga_pending` rolled back beyond the prepared state
-//! (e.g. coalesced-snapshot crash window), Commit replay fails fast with
-//! `SagaCommitFailed` — no half-applied migration, no bearer reconstruction
-//! from the journal alone.
+//! At Commit time the actor reconstructs its evidence from `saga_pending`
+//! and applies the mutation. If `saga_pending` rolled back beyond the
+//! prepared state (e.g. coalesced-snapshot crash window), Commit replay
+//! fails fast with `SagaCommitFailed` — no half-applied mutation.
 //!
-//! # EXPLICIT NON-DERIVES on bearer-bearing variants
+//! # EXPLICIT NON-DERIVES — the §9.4.3 forward contract
 //!
 //! Per spec §9.4.3, any container holding bearer bytes MUST NOT be
 //! `Clone`, `Debug`, `Display`, `Serialize`, or `Deserialize`. The bearer
-//! field itself is wrapped in `Zeroizing<Vec<u8>>` so drop zeros the
+//! field itself would be wrapped in `Zeroizing<Vec<u8>>` so drop zeros the
 //! bytes; the wrapping struct must additionally refuse the trait set
 //! above so a misuse like `format!("{:?}", state)` cannot leak bytes
 //! into a log line, and a snapshot serializer cannot accidentally write
 //! the bearer to disk.
 //!
-//! [`ContextMigrationPrepared`] is the only variant whose containing
-//! struct currently bears this restriction. Future bearer-bearing saga
-//! types (none planned) would need the same discipline. The wrapping
-//! enum [`SagaPreparedState`] does NOT derive any of these traits either,
-//! because that would expose the inner bearer through the enum's auto-
-//! generated impls (e.g. derived `Debug` on the enum recurses into the
-//! variant's `Debug`, which would either fail to compile or leak).
+//! No current variant is bearer-bearing: the cross-identity custody
+//! handover — the only secret-bearing saga ever contemplated — was
+//! withdrawn (ADR-049 §4, tombstoned; it is a §5.11A.6 security violation,
+//! not a saga). The discipline above is the contract any *future*
+//! bearer-bearing saga type (none planned) MUST satisfy. The wrapping
+//! enum [`SagaPreparedState`] still does NOT derive any of these traits,
+//! preserving the static barrier so a future bearer variant cannot leak
+//! through the enum's auto-generated impls.
 //!
 //! See ADR-049 §3 (saga protocol), spec §9.4.3 (saga journal secret
 //! handling), and `crate::context::supervisor::identity_capability` for
 //! the analogous capability-token discipline.
 
 use scp_identity::DID;
-use zeroize::Zeroizing;
 
 // ---------------------------------------------------------------------------
-// Discriminated union over the 4 saga types defined by ADR-049 §3
+// Discriminated union over the 3 saga types defined by ADR-049 §3
 // ---------------------------------------------------------------------------
 
-/// Discriminated union over the 4 saga types defined by ADR-049 §3.
+/// Discriminated union over the 3 saga types defined by ADR-049 §3.
 ///
 /// Each variant carries every field needed to replay Commit deterministically
 /// from the Prepare-time snapshot. The shape is saga-type specific; see the
@@ -64,11 +65,6 @@ pub enum SagaPreparedState {
     /// Standing-pair creation between two identities. All public per spec
     /// §5.15.7; not secret-bearing.
     StandingPairCreate(StandingPairCreatePrepared),
-    /// Context migration between two identities (target-side). The
-    /// `CustodyHandover` envelope is the bearer artifact and is held here
-    /// under `Zeroizing`; the journal stores only a SHA-256 commitment per
-    /// spec §9.4.3.
-    ContextMigration(ContextMigrationPrepared),
     /// Cross-context tool invocation. The UCAN proof bytes are NOT carried
     /// here — only the proof's identifier — to keep the prepared-state non-
     /// secret-bearing.
@@ -103,54 +99,6 @@ pub struct StandingPairCreatePrepared {
     /// actor model in a later commit. Conformant serializations must round-
     /// trip through `CreationReceipt::to_bytes`/`from_bytes` (spec §5.15.7).
     pub creation_receipt_bytes: Vec<u8>,
-}
-
-// ---------------------------------------------------------------------------
-// Context migration (target-side) — secret-bearing
-// ---------------------------------------------------------------------------
-
-/// Staged state for a target-side context-migration saga.
-///
-/// **Bearer-bearing.** Per spec §9.4.3 the journal stores only
-/// `handover_commitment = SHA-256(domain_separator ‖ envelope ‖ nonce)`.
-/// The actual `CustodyHandover` envelope (the bearer) is held in this
-/// struct in actor-local memory under [`Zeroizing<Vec<u8>>`] so a Drop
-/// during a crash window zeros the bytes.
-///
-/// **Non-derives.** No `Clone`, no `Debug`, no `Display`, no `Serialize`,
-/// no `Deserialize` on this struct itself. The `Zeroizing` wrapper around
-/// `handover_envelope` is the runtime barrier; the trait restrictions
-/// here are the static barrier. Both layers are required by spec §9.4.3.
-///
-/// **Snapshot persistence.** When `PerContextState.saga_pending` is
-/// persisted as part of the actor's coalesced snapshot in a later commit,
-/// the snapshot serializer MUST hand-roll the encoding for this variant —
-/// it cannot use a derived `Serialize` because none exists. The serializer
-/// will route the bearer bytes through a `Zeroizing`-aware codec analogous
-/// to `JournalEntry`'s `EvidenceWire` pattern, and the snapshot backend
-/// MUST satisfy the at-rest-encryption requirement (§9.4.3) before the
-/// snapshot is allowed to host secret-bearing saga state.
-pub struct ContextMigrationPrepared {
-    /// The source context ID being migrated.
-    pub source_context_id: [u8; 32],
-    /// The DID of the source identity.
-    pub source_identity_did: DID,
-    /// `SHA-256(domain_separator ‖ envelope ‖ nonce)` per spec §9.4.3.
-    /// Must equal the value the supervisor recorded in the journal entry
-    /// for this saga; mismatch fails Commit fast.
-    pub handover_commitment: [u8; 32],
-    /// 32-byte `OsRng` nonce mixed into the commitment. Distinct per saga
-    /// instance; nonce reuse is a protocol violation.
-    pub handover_nonce: [u8; 32],
-    /// The `CustodyHandover` envelope bytes (canonical serialization, spec
-    /// §9.4.3). Held in `Zeroizing` so drop zeros the storage even on
-    /// panic / cancellation / early `?` return paths in the surrounding
-    /// handler.
-    pub handover_envelope: Zeroizing<Vec<u8>>,
-    /// Staged `MigrationImport` metadata — public fields only (no key
-    /// bytes). Concrete type is wired in when the migration handler
-    /// migrates to the actor model.
-    pub migration_import_metadata: Vec<u8>,
 }
 
 // ---------------------------------------------------------------------------
@@ -234,30 +182,6 @@ mod tests {
     }
 
     #[test]
-    fn context_migration_constructs() {
-        let envelope_bytes: Vec<u8> = (0..128u8).collect();
-        let state = SagaPreparedState::ContextMigration(ContextMigrationPrepared {
-            source_context_id: [2u8; 32],
-            source_identity_did: alice(),
-            handover_commitment: [3u8; 32],
-            handover_nonce: [4u8; 32],
-            handover_envelope: Zeroizing::new(envelope_bytes.clone()),
-            migration_import_metadata: vec![0xCC; 32],
-        });
-        match state {
-            SagaPreparedState::ContextMigration(inner) => {
-                assert_eq!(inner.source_context_id, [2u8; 32]);
-                assert_eq!(inner.source_identity_did, alice());
-                assert_eq!(inner.handover_commitment, [3u8; 32]);
-                assert_eq!(inner.handover_nonce, [4u8; 32]);
-                assert_eq!(&*inner.handover_envelope, &envelope_bytes[..]);
-                assert_eq!(inner.migration_import_metadata, vec![0xCC; 32]);
-            }
-            _ => panic!("wrong variant"),
-        }
-    }
-
-    #[test]
     fn cross_context_tool_invocation_constructs() {
         let state =
             SagaPreparedState::CrossContextToolInvocation(CrossContextToolInvocationPrepared {
@@ -297,100 +221,21 @@ mod tests {
         }
     }
 
-    /// `Zeroize` on the `Zeroizing<Vec<u8>>` envelope writes zeros into
-    /// the buffer in place. Verifies via the safe API: explicit `zeroize`
-    /// followed by reading the wrapper's contents.
+    /// Compile-time witnesses that the prepared-state types ARE
+    /// `Send + Sync` (required for `ActorDeps` movement into
+    /// `tokio::spawn`), the only auto-trait obligation they carry.
     ///
-    /// We do NOT use raw-pointer / use-after-free inspection here:
-    /// `crates/scp-runtime/src/lib.rs` is `#![forbid(unsafe_code)]`, so
-    /// raw-pointer inspection cannot live in this crate. The `zeroize`
-    /// crate's own Drop-zeros invariant is upstream-tested; what we need
-    /// to verify here is that
-    ///
-    ///   (a) the bearer field is wrapped in `Zeroizing<Vec<u8>>` (the
-    ///       only type we expose for it — any change is a compile error
-    ///       at every call site), and
-    ///   (b) explicit `zeroize()` succeeds and zeroes the bytes (which
-    ///       is what `Drop` would call).
-    ///
-    /// `Zeroizing<T>::drop` is documented by the `zeroize` crate as
-    /// calling `T::zeroize`. `Vec<u8>::zeroize` overwrites the storage
-    /// with zeros and truncates the length to 0. The combination of
-    /// those upstream-tested behaviors with the type-system witness
-    /// (`handover_envelope: Zeroizing<Vec<u8>>`) is the load-bearing
-    /// evidence that drop zeros the bytes.
-    #[test]
-    fn migration_prepared_envelope_zeroizes() {
-        use zeroize::Zeroize;
-
-        let sentinel: Vec<u8> = (1..=96u8).cycle().take(96).collect();
-        let mut prepared = ContextMigrationPrepared {
-            source_context_id: [0u8; 32],
-            source_identity_did: alice(),
-            handover_commitment: [0u8; 32],
-            handover_nonce: [0u8; 32],
-            handover_envelope: Zeroizing::new(sentinel.clone()),
-            migration_import_metadata: Vec::new(),
-        };
-
-        // Pre-zeroize: the wrapper holds the sentinel.
-        assert_eq!(&*prepared.handover_envelope, &sentinel[..]);
-
-        // Explicit zeroize via the trait `Zeroize`. This is what
-        // `Zeroizing::drop` calls during normal drop; calling it here
-        // exercises the same code path through the safe API.
-        prepared.handover_envelope.zeroize();
-
-        // Post-zeroize: `Vec<u8>::zeroize` truncates len to 0 AND
-        // overwrites the backing storage. We check len-0 here through
-        // the safe API; the storage-overwrite is the upstream-tested
-        // invariant of `Vec<u8>: Zeroize`.
-        assert_eq!(
-            prepared.handover_envelope.len(),
-            0,
-            "Zeroizing<Vec<u8>> wrapper must zero AND truncate the bearer \
-             envelope on zeroize() — required by spec §9.4.3",
-        );
-    }
-
-    /// Compile-time witness that the bearer field's type is exactly
-    /// `Zeroizing<Vec<u8>>`. If a future change weakens it (e.g. to
-    /// `Vec<u8>`), this assertion fails to compile because we destructure
-    /// against the exact type pattern.
-    ///
-    /// Combined with the runtime test above, this proves the spec §9.4.3
-    /// container discipline is enforced by the type system.
-    #[test]
-    fn migration_prepared_envelope_field_is_zeroizing_vec_u8() {
-        let prepared = ContextMigrationPrepared {
-            source_context_id: [0u8; 32],
-            source_identity_did: alice(),
-            handover_commitment: [0u8; 32],
-            handover_nonce: [0u8; 32],
-            handover_envelope: Zeroizing::new(vec![1u8, 2, 3]),
-            migration_import_metadata: Vec::new(),
-        };
-        // Destructure with explicit type binding — fails to compile if
-        // the field type changes from `Zeroizing<Vec<u8>>`.
-        let envelope: Zeroizing<Vec<u8>> = prepared.handover_envelope;
-        assert_eq!(&*envelope, &[1u8, 2, 3]);
-    }
-
-    /// Compile-time witnesses that bearer-bearing types do NOT implement
-    /// the forbidden traits. If any of these blocks below would compile,
-    /// it's a regression — the explicit non-derive discipline has been
-    /// silently broken (e.g. by adding `#[derive(Clone)]`).
-    ///
-    /// We don't have negative trait bounds in stable Rust, but we can
-    /// assert positively that the types ARE `Send + Sync` (required for
-    /// `ActorDeps` movement into `tokio::spawn`), which is the only
-    /// auto-trait obligation they carry.
+    /// The wrapping enum [`SagaPreparedState`] still does NOT derive
+    /// `Clone`, `Debug`, `Display`, `Serialize`, or `Deserialize`,
+    /// preserving the §9.4.3 static barrier so a future bearer-bearing
+    /// variant cannot leak through auto-generated impls. No current
+    /// variant is bearer-bearing (custody handover withdrawn — ADR-049
+    /// §4).
     #[test]
     fn types_are_send_sync() {
         const fn assert_send_sync<T: Send + Sync>() {}
         assert_send_sync::<SagaPreparedState>();
         assert_send_sync::<StandingPairCreatePrepared>();
-        assert_send_sync::<ContextMigrationPrepared>();
         assert_send_sync::<CrossContextToolInvocationPrepared>();
         assert_send_sync::<BroadcastHostingHandshakePrepared>();
     }

--- a/crates/scp-runtime/src/context/supervisor/supervisor.rs
+++ b/crates/scp-runtime/src/context/supervisor/supervisor.rs
@@ -71,13 +71,13 @@ pub const ACTOR_MAILBOX_CAPACITY: usize = 256;
 // SagaInput / SagaOutput — plan §"Cross-context saga protocol"
 // ---------------------------------------------------------------------------
 
-/// Input to `Supervisor::start_saga`. The variant enumerates the 4
+/// Input to `Supervisor::start_saga`. The variant enumerates the 3
 /// saga types defined in plan §"Cross-context saga protocol"
-/// (standing-pair create, migration, cross-context tool invoke,
-/// broadcast hosting handshake). Commit 6 lands the enum shape;
-/// real field sets arrive when each handler migrates.
+/// (standing-pair create, cross-context tool invoke, broadcast hosting
+/// handshake). Commit 6 lands the enum shape; real field sets arrive
+/// when each handler migrates.
 ///
-/// The type is a discriminated union so that adding a fifth saga type
+/// The type is a discriminated union so that adding a fourth saga type
 /// later is a compile error at every call site — the default branch is
 /// not permitted.
 pub enum SagaInput {
@@ -88,13 +88,6 @@ pub enum SagaInput {
         local_did: DID,
         /// The remote peer.
         peer_did: DID,
-    },
-    /// Context migration between two identities (target-side).
-    ContextMigration {
-        /// Source context ID.
-        source_context_id: [u8; 32],
-        /// Source identity.
-        source_identity_did: DID,
     },
     /// Cross-context tool invocation.
     CrossContextToolInvocation {
@@ -4340,25 +4333,25 @@ impl Supervisor {
     /// (plan §"Cross-context saga protocol" step Prepare — concurrent
     /// Prepare against the same supervisor is rejected).
     ///
-    /// # Spec-gapped saga use cases
+    /// # Unwired saga use cases (pending Phase 2C)
     ///
-    /// The 4 [`SagaInput`] variants (StandingPairCreate,
-    /// ContextMigration, CrossContextToolInvocation,
-    /// BroadcastHostingHandshake) each require protocol fill-in before
-    /// they can be wired — see
-    /// `.docs/adrs/DEFERRED-commit-11-saga-use-cases.md`. This method
-    /// drives the FSM generically; specific `SagaInput` arms return
-    /// [`ContextError::NotImplemented`] at the Prepare dispatch step.
-    /// The coordinator itself — journal writes, phase transitions,
-    /// timeout/retry accounting, terminal resolution — is fully
-    /// implemented.
+    /// The 3 [`SagaInput`] variants (StandingPairCreate,
+    /// CrossContextToolInvocation, BroadcastHostingHandshake) each have
+    /// their wire protocol specced (§5.15.8 / §6.2.4 / §5.14.13 +
+    /// ADR-049 §3a) but their Prepare/Commit dispatch is not yet wired
+    /// — see `.docs/adrs/DEFERRED-commit-11-saga-use-cases.md`. This
+    /// method drives the FSM generically; specific `SagaInput` arms
+    /// return [`ContextError::NotImplemented`] at the Prepare dispatch
+    /// step until Phase 2C wires them. The coordinator itself — journal
+    /// writes, phase transitions, timeout/retry accounting, terminal
+    /// resolution — is fully implemented.
     ///
     /// # Errors
     ///
     /// - [`ContextError::ActorBusy`] if a saga is already in flight.
     /// - [`ContextError::NotImplemented`] if the
-    ///   [`SagaInput`] variant requires spec-gapped prepare dispatch
-    ///   (all 4 current variants until commit 11.5).
+    ///   [`SagaInput`] variant's prepare dispatch is not yet wired
+    ///   (all 3 current variants, pending Phase 2C).
     /// - [`ContextError::InvalidState`] on journal I/O failure.
     pub async fn start_saga(&self, input: SagaInput) -> Result<SagaOutput, ContextError> {
         use std::sync::atomic::Ordering;
@@ -4527,7 +4520,7 @@ impl Supervisor {
         self.append_journal(&saga_id, SagaState::Initiated, &participants, 0, &[])
             .await?;
 
-        // 2. PreparingA — spec-gapped for every current SagaInput variant.
+        // 2. PreparingA — not yet wired for any current SagaInput variant.
         //    The prepare-dispatch returns NotImplemented and the FSM
         //    transitions directly to Aborted. This preserves the
         //    coordinator's observable behaviour (terminate with a typed
@@ -4589,9 +4582,9 @@ impl Supervisor {
     }
 
     /// Dispatch a single Prepare phase. Returns
-    /// [`ContextError::NotImplemented`] for all 4 current
-    /// [`SagaInput`] variants because prepare-dispatch is
-    /// spec-gapped — see
+    /// [`ContextError::NotImplemented`] for all 3 current
+    /// [`SagaInput`] variants because prepare-dispatch is not yet
+    /// wired (Phase 2C) — see
     /// `.docs/adrs/DEFERRED-commit-11-saga-use-cases.md`.
     ///
     /// The wrapper enforces the 30s per-phase timeout
@@ -4611,11 +4604,6 @@ impl Supervisor {
                     "saga Prepare{phase:?} — StandingPairCreate wiring deferred to commit 11.5 \
                      per DEFERRED-commit-11-saga-use-cases.md gap 1 (standing-pair 2-phase \
                      decomposition)"
-                ))),
-                SagaInput::ContextMigration { .. } => Err(ContextError::NotImplemented(format!(
-                    "saga Prepare{phase:?} — ContextMigration wiring deferred to commit 11.5 \
-                     per DEFERRED-commit-11-saga-use-cases.md gap 4 (migration CustodyHandover \
-                     envelope)"
                 ))),
                 SagaInput::CrossContextToolInvocation { .. } => {
                     Err(ContextError::NotImplemented(format!(
@@ -4688,10 +4676,9 @@ impl Supervisor {
         let dispatch_fut = async {
             match input {
                 SagaInput::StandingPairCreate { .. }
-                | SagaInput::ContextMigration { .. }
                 | SagaInput::CrossContextToolInvocation { .. }
                 | SagaInput::BroadcastHostingHandshake { .. } => Err(ContextError::NotImplemented(
-                    "saga Commit — all 4 saga types' commit-side wiring deferred to commit \
+                    "saga Commit — all 3 saga types' commit-side wiring deferred to commit \
                          11.5 per DEFERRED-commit-11-saga-use-cases.md"
                         .to_owned(),
                 )),
@@ -6875,13 +6862,6 @@ fn saga_input_participants(input: &SagaInput) -> Vec<String> {
             local_did,
             peer_did,
         } => vec![local_did.to_string(), peer_did.to_string()],
-        SagaInput::ContextMigration {
-            source_context_id,
-            source_identity_did,
-        } => vec![
-            hex::encode(source_context_id),
-            source_identity_did.to_string(),
-        ],
         SagaInput::CrossContextToolInvocation {
             caller_context_id,
             caller_did,
@@ -6904,12 +6884,29 @@ fn saga_input_participants(input: &SagaInput) -> Vec<String> {
 }
 
 /// Classify whether a saga's journal evidence carries bearer bytes
-/// (spec §9.4.3). Only [`SagaInput::ContextMigration`] is
-/// secret-bearing — the others are public-only. Secret-bearing sagas
-/// pass `true` to [`SagaJournal::mark_resolved`] so the journal
-/// synchronously overwrites evidence bytes on terminal resolution.
+/// (spec §9.4.3). No current [`SagaInput`] variant is secret-bearing:
+/// the cross-identity custody handover — the only secret-bearing saga
+/// ever contemplated — was withdrawn (ADR-049 §4, tombstoned; it is a
+/// §5.11A.6 security violation, not a saga). This function therefore
+/// returns `false` for every live input.
+///
+/// It is retained — not inlined to a constant `false` — as the §9.4.3
+/// forward-contract hook: the classification point on the start-saga
+/// path that any *future* secret-bearing saga MUST route through to
+/// pass `true` to [`SagaJournal::mark_resolved`] (which synchronously
+/// overwrites evidence bytes on terminal resolution). The secret-bearing
+/// journal machinery stays dormant behind it; all live callers pass
+/// `false`. NOTE: the crash-recovery path (`recover_saga_entry`)
+/// hardcodes `false` because a replayed [`JournalEntry`] does not carry
+/// its `SagaInput`; a future secret-bearing saga MUST additionally
+/// re-derive secret-bearing status there (e.g. from the persisted saga
+/// type) so recovery resolution also overwrites prior on-disk evidence.
 const fn saga_input_is_secret_bearing(input: &SagaInput) -> bool {
-    matches!(input, SagaInput::ContextMigration { .. })
+    match input {
+        SagaInput::StandingPairCreate { .. }
+        | SagaInput::CrossContextToolInvocation { .. }
+        | SagaInput::BroadcastHostingHandshake { .. } => false,
+    }
 }
 
 /// Shared timestamp helper. Duplicated from `saga_journal.rs` to avoid
@@ -7340,7 +7337,7 @@ mod tests {
 
     #[tokio::test]
     async fn start_saga_returns_not_implemented_for_spec_gapped_input() {
-        // All 4 current SagaInput variants are spec-gapped — the FSM
+        // All 3 current SagaInput variants are not yet wired — the FSM
         // journals Initiated + PreparingA then fails the Prepare
         // dispatch with NotImplemented, rolls back via abort_saga, and
         // returns the typed error. This exercises the coordinator


### PR DESCRIPTION
**Code-layer completion of the cross-identity custody-handover cut** that spec PR #1793 made at the spec/ADR layer (ADR-049 §4 tombstoned, DEFERRED Gap-4 RESOLVED-AS-WITHDRAWN, §9.4.3 re-scoped). This is the "separate code-correctness PR" the DEFERRED doc names — it flows up from code per the artifact-flow invariant. Unblocks ADR-049 Phase 2C (the saga FSM dispatch wiring) by removing the dead 4th variant before the three live sagas get wired.

## What's removed
- `SagaInput::ContextMigration` variant + its `dispatch_prepare_phase` / `dispatch_commit_phase` / `saga_input_participants` arms.
- `ContextMigrationPrepared` struct (the secret-bearing `Zeroizing` bearer artifact) + the `SagaPreparedState::ContextMigration` variant + its re-export.
- The three migration-specific bearer/zeroize unit tests.

## What's kept (deliberately)
- **The §9.4.3 secret-bearing journal apparatus** (`mark_resolved(secret_bearing)`, the `EvidenceWire`/`Zeroizing` synchronous on-disk overwrite path) — re-scoped spec §9.4.3 keeps it as the forward contract for any *future* secret-bearing saga. It stays dormant; all live callers pass `false`.
- `saga_input_is_secret_bearing` retained as the classification hook, rewritten from `matches!()` to an **exhaustive no-wildcard match** so a future `SagaInput` variant is a compile error until its author classifies it (mechanical forward contract).
- **No over-broad delete:** the legitimate §5.11A governance `ProposeContextMigration` / `ContextEvent::ContextMigration{Proposed,Started,Cancelled}` member-transition flow (a different operation — no key transfer) is untouched.

## Verification
- 4 files (`mod.rs`, `saga_journal.rs`, `saga_prepared_state.rs`, `supervisor.rs`), +87/−243; no Rust outside `scp-runtime/src/context/supervisor/`.
- Zero dangling refs to deleted symbols across `crates/`+`bindings/`+`fuzz/`; all `SagaInput` matches exhaustive; `cargo clippy --features testing -D warnings` clean; 16 saga lib + 12 saga integration tests pass.
- Reviewed to a clean full-roster bar (bug-catcher, alignment, security, simplifier): the deletion was substance-clean across all rounds; §9.4.3 apparatus confirmed intact, governance flow confirmed untouched.

Note: a pre-existing `spec_gapped`-named test helper/fn (a misnomer since #1793 landed the specs) is orthogonal to this cut and left for a separate terminology-cleanup pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
