### PR TITLE
feat(saga): per-participant-context-set gating + granularity CI gate (ADR-049 §3a)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -290,6 +290,21 @@ jobs:
       - uses: actions/checkout@v5
       - run: bash scripts/check-class-s-fail-closed.sh
 
+  saga-gating-granularity:
+    needs: check-draft
+    name: Actor / saga gating granularity (ADR-049 §3a)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+      # Self-test MUST run first: it plants an instance-wide AtomicBool saga
+      # guard + a fake FFI saga export (must FAIL), correct per-set gating
+      # (must PASS), and a no-gating-at-all supervisor (must FAIL) — proving
+      # the gate is alive before we trust it on the real tree.
+      - name: Self-test gate
+        run: bash scripts/check-saga-gating-granularity.sh --self-test
+      - name: Real check
+        run: bash scripts/check-saga-gating-granularity.sh
+
   owned-identity-did:
     needs: check-draft
     name: Actor / OwnedIdentityDid capability check

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -110,7 +110,9 @@ Files: pipeline_wiring.rs, ffi_conformance.rs, sdk-capability-matrix.json,
 check-cross-layer.sh, check-protocol-deps.sh, check-protocol-sync.py,
 check-no-bridge-globals.sh, check-no-fallback-registry.sh,
 check-handle-affinity.sh, check_ready_coverage.rs (per-instance handle
-affinity enforcement), check-no-mutable-globals.sh,
+affinity enforcement),
+check-saga-gating-granularity.sh (ADR-049 §3a per-participant-context-set
+saga gating granularity), check-no-mutable-globals.sh,
 check-no-mutable-module-globals.py, check-no-ts-mutable-globals.sh,
 check-no-kotlin-mutable-globals.sh,
 bindings/swift/.swiftlint.yml (no_static_var / no_static_lazy_var rules),

--- a/crates/scp-runtime/src/context/standing_helpers.rs
+++ b/crates/scp-runtime/src/context/standing_helpers.rs
@@ -37,13 +37,23 @@ use crate::context::actor::deps::ActorDeps;
 // generate_standing_context_id (pure helper)
 // ---------------------------------------------------------------------------
 
-/// Generates a deterministic context ID for a standing context between two DIDs.
+/// Derives the **raw 32-byte digest** for a standing context between two DIDs.
 ///
-/// The ID is derived from both DIDs sorted lexicographically, ensuring the same
-/// context ID is generated regardless of which peer initiates. Uses a
-/// `standing:` prefix for namespace isolation and a truncated SHA-256 hash of
-/// the sorted DID pair for the unique portion.
-pub fn generate_standing_context_id(local_did: &DID, peer_did: &DID) -> String {
+/// This is the canonical saga-evidence / wire form of the standing-pair
+/// identity (spec §5.15.8: "the 32-byte `derived_context_id` used in saga
+/// evidence is the raw digest before prefix and hex"). The digest is computed
+/// over both DIDs sorted lexicographically, so it is symmetric:
+/// `derive(A, B) == derive(B, A)`.
+///
+/// [`generate_standing_context_id`] wraps this digest with the `"standing-"`
+/// display prefix + hex for the actor-registry key; the saga concurrency
+/// gating (ADR-049 §3a, spec §5.15.4) reserves the RAW-digest hex
+/// (`hex::encode(derive_standing_context_digest(..))`) so a standing-pair saga
+/// and a cross-context / broadcast saga that share the same standing context
+/// reserve the SAME canonical key and therefore overlap. Keeping the prefixed
+/// id and the raw digest derived from one shared body guarantees they cannot
+/// drift apart.
+pub fn derive_standing_context_digest(local_did: &DID, peer_did: &DID) -> [u8; 32] {
     let (a, b) = if local_did.as_ref() <= peer_did.as_ref() {
         (local_did.as_ref(), peer_did.as_ref())
     } else {
@@ -54,8 +64,23 @@ pub fn generate_standing_context_id(local_did: &DID, peer_did: &DID) -> String {
     hasher.update(a.as_bytes());
     hasher.update(b":");
     hasher.update(b.as_bytes());
-    let hash = hasher.finalize();
-    format!("standing-{}", hex::encode(hash))
+    hasher.finalize().into()
+}
+
+/// Generates a deterministic context ID for a standing context between two DIDs.
+///
+/// The ID is derived from both DIDs sorted lexicographically, ensuring the same
+/// context ID is generated regardless of which peer initiates. Uses a
+/// `standing-` prefix for namespace isolation and the lowercase hex of the
+/// 32-byte SHA-256 digest ([`derive_standing_context_digest`]) of the sorted
+/// DID pair for the unique portion. The prefixed string is the actor-registry
+/// key; the unprefixed raw digest is the saga-evidence / gating form
+/// (spec §5.15.8).
+pub fn generate_standing_context_id(local_did: &DID, peer_did: &DID) -> String {
+    format!(
+        "standing-{}",
+        hex::encode(derive_standing_context_digest(local_did, peer_did))
+    )
 }
 
 // ---------------------------------------------------------------------------

--- a/crates/scp-runtime/src/context/supervisor/mod.rs
+++ b/crates/scp-runtime/src/context/supervisor/mod.rs
@@ -51,6 +51,11 @@ pub use saga_prepared_state::{
     BroadcastHostingHandshakePrepared, CrossContextToolInvocationPrepared, SagaPreparedState,
     StandingPairCreatePrepared,
 };
+/// The per-saga participant-context-set reservation RAII guard. Exposed only
+/// under `test`/`testing` so integration tests can deterministically hold a
+/// saga's slots in flight (see `Supervisor::test_reserve_saga_context_set`).
+#[cfg(any(test, feature = "testing"))]
+pub use supervisor::SagaSetReservation;
 pub use supervisor::{
     ACTOR_MAILBOX_CAPACITY, CrashWindow, PendingSagaProjection, SagaInput, SagaOutput, Supervisor,
     SupervisorConfig,

--- a/crates/scp-runtime/src/context/supervisor/supervisor.rs
+++ b/crates/scp-runtime/src/context/supervisor/supervisor.rs
@@ -93,6 +93,11 @@ pub enum SagaInput {
     CrossContextToolInvocation {
         /// Calling context.
         caller_context_id: [u8; 32],
+        /// Target context that hosts the tool registration being invoked.
+        /// The saga spans BOTH the caller and the target context-actors, so
+        /// the gating reservation (ADR-049 §3a) needs the real 2-context set;
+        /// spec §6.2.4's cross-context tool-invoke transport needs it too.
+        target_context_id: [u8; 32],
         /// Calling identity.
         caller_did: DID,
         /// Tool registration to invoke.
@@ -106,6 +111,20 @@ pub enum SagaInput {
         broadcast_context_id: [u8; 32],
         /// Subscriber requesting hosting.
         subscriber_did: DID,
+    },
+    /// Test-only saga whose Prepare phases succeed and whose Commit phase
+    /// ALWAYS fails, so the FSM runs all the way to Committing, exhausts the
+    /// commit-retry budget, and lands in `NeedsRepair`. This is the ONLY way
+    /// to drive `start_saga` to a real `NeedsRepair` terminal while the three
+    /// production saga variants' Prepare/Commit dispatch is still spec-gapped
+    /// (Phase 2C) — it lets the gating tests assert that `NeedsRepair`
+    /// RELEASES the participant-context-set reservation (ADR-049 §3a, spec
+    /// §5.15.4). Gated behind `test`/`testing` so a production FFI build can
+    /// never construct or dispatch it.
+    #[cfg(any(test, feature = "testing"))]
+    TestForceNeedsRepair {
+        /// The single participant context this test saga reserves.
+        context_id: [u8; 32],
     },
 }
 
@@ -519,16 +538,69 @@ pub struct Supervisor {
     // supervisor now owns them directly; eagerly initialized in
     // [`Self::new`].
     // -----------------------------------------------------------------
-    /// Concurrent-saga guard. `true` iff a saga is currently in flight
-    /// (Initiated / PreparingA / PreparingB / Committing). A second
-    /// concurrent `start_saga` while the flag is `true` returns
+    /// Per-participant-context-set saga reservation (ADR-049 §3a, spec
+    /// §5.15.4). Holds the union of the participant-context IDs currently
+    /// reserved by all in-flight sagas. A saga reserves the WHOLE of its
+    /// participant context set ([`saga_participant_context_set`]) atomically
+    /// at [`Self::start_saga`] entry: if ANY id in the new set is already
+    /// present, the new saga's set OVERLAPS an in-flight saga and the start
+    /// returns
     /// [`ContextError::ActorBusy`](scp_protocol::context::ContextError::ActorBusy)
-    /// via the `SagaBusy` reason — the supervisor serializes sagas
-    /// supervisor-wide so the per-actor `saga_pending` slot never
-    /// contends. The atomic is set on `start_saga` entry (if currently
-    /// `false`) and cleared when the saga reaches a terminal state
-    /// (Committed, Aborted, NeedsRepair).
-    saga_pending_guard: std::sync::atomic::AtomicBool,
+    /// with a `SagaBusy` reason; otherwise the whole set is inserted and the
+    /// FSM runs. Two sagas with DISJOINT sets never contend and run
+    /// concurrently — replacing the prior supervisor-wide `AtomicBool` so one
+    /// slow or stuck saga can no longer deny the whole instance. The
+    /// reservation is released by the [`SagaSetReservation`] RAII guard on
+    /// EVERY terminal (Committed, Aborted, NeedsRepair) AND panic-unwind;
+    /// crucially, `NeedsRepair` RELEASES the slot (the divergence still
+    /// awaits operator repair, but a stuck saga must not wedge unrelated
+    /// ones — spec §5.15.4).
+    ///
+    /// In-memory only: this set is NOT rebuilt on restart, exactly matching
+    /// the prior `AtomicBool`'s restart behavior (a restarted supervisor
+    /// starts with no reservations). When PR-7/2D wires
+    /// [`Self::replay_unresolved_sagas`] at startup, it MUST rebuild
+    /// reservations for non-terminal unresolved journal entries — EXCLUDING
+    /// `NeedsRepair` entries, whose slots are deliberately released — so a
+    /// replay-driven re-drive of an in-flight saga re-takes its set before
+    /// the first post-restart `start_saga` can race it.
+    ///
+    /// CONCRETE REPLAY GAP PR-2D MUST CLOSE — the journal record for a
+    /// `CrossContextToolInvocation` (built by [`saga_input_participants`])
+    /// deliberately does NOT persist `target_context_id` ("Leave the journal
+    /// shape UNCHANGED"): it records only `{caller_context_id, caller_did,
+    /// tool_registration_id}`. But the gating set
+    /// ([`saga_participant_context_set`]) is `{caller, target}`. So a naïve
+    /// replay that rebuilds reservations from the journal record alone could
+    /// only re-reserve `{caller}`, NOT `{caller, target}` — leaving the
+    /// `target` context slot free and letting a fresh post-restart saga touch
+    /// it concurrently, defeating the §5.15.4 cross-context serialization for
+    /// the entire recovery window. PR-2D MUST therefore either (a) persist
+    /// `target_context_id` in the journal entry / the
+    /// `CrossContextToolInvocationPrepared` evidence so the full set is
+    /// reconstructible, OR (b) rehydrate the complete [`SagaInput`] on replay
+    /// and re-derive the set via [`saga_participant_context_set`] (the same
+    /// extractor `start_saga` calls) so the rebuilt reservation is the
+    /// COMPLETE `{caller, target}` set, not a caller-only subset. Whichever
+    /// PR-2D chooses, the rebuilt reservation MUST equal what `start_saga`
+    /// would have taken for that in-flight saga.
+    ///
+    /// The type is `std::sync::Mutex` (banned by `clippy.toml` for the
+    /// await-deadlock hazard) with a narrowly-scoped allow: the critical
+    /// section is purely synchronous (`lock()` → check-disjoint → insert /
+    /// remove → drop), and the guard is PROVABLY NEVER held across an
+    /// `.await` (see [`Self::try_reserve_context_set`] and
+    /// [`SagaSetReservation::drop`], neither of which awaits while holding
+    /// the guard). The clippy ban targets the suspend-thread-across-await
+    /// deadlock, which cannot occur here.
+    #[allow(
+        clippy::disallowed_types,
+        reason = "Synchronous critical section only; the guard is provably \
+                  never held across an .await (check-disjoint + insert, or \
+                  remove-on-drop, are all sync). The clippy ban targets \
+                  await-deadlock, which cannot occur here. ADR-049 §3a."
+    )]
+    reserved_saga_contexts: std::sync::Mutex<HashSet<String>>,
 
     // -----------------------------------------------------------------
     /// Monotonic spawn-generation counter. Incremented once per
@@ -586,6 +658,16 @@ impl Supervisor {
         saga_journal: Arc<dyn SagaJournal>,
         health_config: SupervisorConfig,
     ) -> Self {
+        // Synchronous critical section only; the guard is provably never held
+        // across an `.await` (check-disjoint + insert, or remove-on-drop, are
+        // all sync). The clippy ban targets await-deadlock, which cannot occur
+        // here. ADR-049 §3a. (Matches the `reserved_saga_contexts` field allow.)
+        #[allow(
+            clippy::disallowed_types,
+            reason = "Synchronous critical section only; the guard is provably \
+                      never held across an .await. ADR-049 §3a."
+        )]
+        let reserved_saga_contexts = std::sync::Mutex::new(HashSet::new());
         Self {
             actors: DashMap::new(),
             standing_contexts: ArcSwap::new(Arc::new(HashMap::new())),
@@ -611,7 +693,7 @@ impl Supervisor {
             event_tx: OnceLock::new(),
             task_set: OnceLock::new(),
             mls_storage: OnceLock::new(),
-            saga_pending_guard: std::sync::atomic::AtomicBool::new(false),
+            reserved_saga_contexts,
             // Generation 0 is never stamped onto a live actor (the first
             // spawn increments to 1 before stamping), so a default
             // `PerContextState::generation == 0` can never collide with a
@@ -4324,14 +4406,19 @@ impl Supervisor {
     /// entries on supervisor startup via
     /// [`Self::replay_unresolved_sagas`].
     ///
-    /// # Concurrent saga serialization
+    /// # Concurrent saga serialization (per participant-context set)
     ///
-    /// The supervisor serializes sagas supervisor-wide: a second
-    /// `start_saga` while one is in flight returns
+    /// Sagas are serialized at the granularity of their **participant
+    /// context set**, NOT supervisor-wide (ADR-049 §3a, spec §5.15.4). A
+    /// saga reserves the set of contexts it spans (computed by
+    /// `saga_participant_context_set`); a second `start_saga` whose set is
+    /// **disjoint** runs concurrently, while one whose set **overlaps**
+    /// (shares ≥1 context) returns
     /// [`ContextError::ActorBusy`](scp_protocol::context::ContextError::ActorBusy)
-    /// with a `SagaBusy` reason. The guard is a single atomic bool
-    /// (plan §"Cross-context saga protocol" step Prepare — concurrent
-    /// Prepare against the same supervisor is rejected).
+    /// with a `SagaBusy` reason. The reservation (`reserved_saga_contexts`)
+    /// is held by an RAII guard for the saga's lifetime and released on
+    /// EVERY terminal — Committed, Aborted, AND NeedsRepair — plus
+    /// panic-unwind, so a stuck saga never wedges unrelated disjoint sagas.
     ///
     /// # Unwired saga use cases (pending Phase 2C)
     ///
@@ -4346,36 +4433,43 @@ impl Supervisor {
     /// writes, phase transitions, timeout/retry accounting, terminal
     /// resolution — is fully implemented.
     ///
+    /// # Forward obligation — authorize the initiator BEFORE reserving (Phase 2C)
+    ///
+    /// Today every production [`SagaInput`] variant's Prepare dispatch returns
+    /// [`ContextError::NotImplemented`], and `start_saga` is reachable only from
+    /// in-process callers — never from attacker-influenceable FFI input — so the
+    /// reservation cannot be weaponized. That changes in Phase 2C, which wires
+    /// the real saga inputs and the block-until-terminal `start_*_saga` FFI
+    /// exports. At that point the reservation becomes attacker-reachable: a
+    /// malicious participant could name a VICTIM'S context id in a saga input and
+    /// reserve it (the overlap check would then deny the victim's own legitimate
+    /// saga — a targeted availability attack). Phase 2C MUST therefore verify
+    /// the initiator is authorized over EACH context id the saga names — a member
+    /// of, or capable on, that context — BEFORE
+    /// [`Self::try_reserve_context_set`] runs. This is a forward obligation, not
+    /// a runtime gap: it is unreachable until the FFI saga surface ships.
+    ///
     /// # Errors
     ///
-    /// - [`ContextError::ActorBusy`] if a saga is already in flight.
+    /// - [`ContextError::ActorBusy`] (a `SagaBusy` reason) if the new saga's
+    ///   participant context set overlaps an in-flight saga's reserved set.
+    ///   Disjoint sets run concurrently (ADR-049 §3a, spec §5.15.4).
     /// - [`ContextError::NotImplemented`] if the
     ///   [`SagaInput`] variant's prepare dispatch is not yet wired
     ///   (all 3 current variants, pending Phase 2C).
     /// - [`ContextError::InvalidState`] on journal I/O failure.
     pub async fn start_saga(&self, input: SagaInput) -> Result<SagaOutput, ContextError> {
-        use std::sync::atomic::Ordering;
-
-        // Concurrent-saga guard: CAS from false → true. If already
-        // true, the caller races an in-flight saga.
-        if self
-            .saga_pending_guard
-            .compare_exchange(false, true, Ordering::AcqRel, Ordering::Acquire)
-            .is_err()
-        {
-            return Err(ContextError::ActorBusy(
-                "Supervisor::start_saga — another saga is already in flight (SagaBusy)".to_owned(),
-            ));
-        }
-
-        // RAII guard: ensure the pending flag clears even if `run_saga_fsm`
-        // panics or unwinds. The prior implementation cleared the flag with
-        // a line of code after `.await` — a panic anywhere inside the FSM
-        // would leave the guard set, blocking every subsequent `start_saga`
-        // until process restart. Phase 1 fix-up of ADR-049
-        // (post-review-round-1). The guard type is defined at module
-        // scope below ([`SagaGuardReset`]).
-        let _guard = SagaGuardReset(&self.saga_pending_guard);
+        // Per-participant-context-set reservation (ADR-049 §3a, spec
+        // §5.15.4). Atomically reserve the saga's WHOLE participant context
+        // set: if it overlaps an in-flight saga's set, reject with a typed
+        // SagaBusy; otherwise insert the whole set and hold the RAII
+        // reservation for the FSM scope. The reservation Drop releases the
+        // set on EVERY terminal (Committed, Aborted, NeedsRepair) AND on a
+        // panic-unwind through `run_saga_fsm` — including the NeedsRepair arm,
+        // which returns control here so `_reservation` drops and the stuck
+        // saga does NOT wedge unrelated, disjoint sagas.
+        let context_set = saga_participant_context_set(&input);
+        let _reservation = self.try_reserve_context_set(&context_set)?;
 
         let saga_id = SagaId::new();
         let participants = saga_input_participants(&input);
@@ -4390,10 +4484,106 @@ impl Supervisor {
             )
             .await;
 
-        // `_guard` clears the flag on scope exit — including on the
-        // panic-unwind path through `run_saga_fsm`.
+        // `_reservation` releases the reserved context set on scope exit —
+        // including on the panic-unwind path through `run_saga_fsm`.
 
         fsm_result.map(|()| SagaOutput { saga_id })
+    }
+
+    /// Atomically reserve a saga's participant context set (ADR-049 §3a).
+    ///
+    /// One synchronous critical section over `reserved_saga_contexts`:
+    /// 1. If ANY id in `context_set` is already reserved, the new saga
+    ///    OVERLAPS an in-flight saga — return [`ContextError::ActorBusy`]
+    ///    with a `SagaBusy` reason WITHOUT mutating the reservation set.
+    /// 2. Otherwise insert the WHOLE set and return a [`SagaSetReservation`]
+    ///    RAII guard that removes exactly THESE ids on drop.
+    ///
+    /// The lock is acquired and released entirely within this synchronous
+    /// function (no `.await` while holding the guard), so it cannot suspend
+    /// a tokio worker thread across a yield point — the reason the
+    /// `std::sync::Mutex` use is sound despite the `clippy.toml` ban (see the
+    /// `reserved_saga_contexts` field's narrowly-scoped allow).
+    ///
+    /// A poisoned lock (a prior holder panicked mid-critical-section, which
+    /// the purely-synchronous body makes effectively impossible) is recovered
+    /// via `into_inner` rather than propagated, so a single panic elsewhere
+    /// cannot permanently wedge every future saga.
+    ///
+    /// # Errors
+    ///
+    /// [`ContextError::ActorBusy`] if the participant set overlaps an
+    /// in-flight saga's reserved set.
+    #[allow(
+        clippy::significant_drop_tightening,
+        reason = "The lock guard intentionally spans the overlap check AND the \
+                  insert loop — that atomic check-and-reserve IS the correctness \
+                  property (shortening it reintroduces a TOCTOU). ADR-049 §3a."
+    )]
+    fn try_reserve_context_set(
+        &self,
+        context_set: &[String],
+    ) -> Result<SagaSetReservation<'_>, ContextError> {
+        let mut reserved = self
+            .reserved_saga_contexts
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+
+        // Overlap check: a non-empty intersection with the in-flight set
+        // means a shared participant context — serialize (spec §5.15.4:
+        // "sharing a single context is sufficient to conflict").
+        if let Some(contended) = context_set.iter().find(|id| reserved.contains(*id)) {
+            return Err(ContextError::ActorBusy(format!(
+                "Supervisor::start_saga — participant context set overlaps an in-flight saga \
+                 at context {contended} (SagaBusy)"
+            )));
+        }
+
+        // Disjoint: reserve the whole set atomically under the same lock.
+        for id in context_set {
+            reserved.insert(id.clone());
+        }
+
+        Ok(SagaSetReservation {
+            reserved: &self.reserved_saga_contexts,
+            ids: context_set.to_vec(),
+        })
+    }
+
+    /// Test-only: deterministically reserve a saga's participant context set
+    /// and return the RAII reservation, so a test can hold a saga's slots
+    /// "in flight" without racing the (instantaneous, spec-gapped) FSM. This
+    /// exercises the SAME `try_reserve_context_set` critical section that
+    /// [`Self::start_saga`] uses, so the overlap / disjoint / release
+    /// semantics under test are the production ones, not a parallel mock.
+    ///
+    /// Returning the borrow-scoped [`SagaSetReservation`] lets the caller
+    /// drop it to release (mirroring a saga reaching a terminal state).
+    ///
+    /// # Errors
+    ///
+    /// [`ContextError::ActorBusy`] if the set overlaps an already-held set.
+    #[cfg(any(test, feature = "testing"))]
+    pub fn test_reserve_saga_context_set(
+        &self,
+        input: &SagaInput,
+    ) -> Result<SagaSetReservation<'_>, ContextError> {
+        let set = saga_participant_context_set(input);
+        self.try_reserve_context_set(&set)
+    }
+
+    /// Test-only: the CANONICAL gating reservation key a standing-pair saga
+    /// over `(local_did, peer_did)` reserves — the raw-digest hex
+    /// (`hex::encode(derive_standing_context_digest(..))`), NOT the
+    /// `"standing-"`-prefixed actor-registry id. Lets a cross-saga-type
+    /// overlap test feed the EXACT key a `StandingPairCreate` saga reserves
+    /// into a `CrossContextToolInvocation` saga's `[u8; 32]` context field,
+    /// proving overlap detection is pure set-membership across saga types
+    /// (ADR-049 §3a, spec §5.15.4 / §5.15.8).
+    #[cfg(any(test, feature = "testing"))]
+    #[must_use]
+    pub fn test_standing_pair_context_digest(local_did: &DID, peer_did: &DID) -> [u8; 32] {
+        crate::context::standing_helpers::derive_standing_context_digest(local_did, peer_did)
     }
 
     /// Replay unresolved sagas from the journal on supervisor startup
@@ -4619,6 +4809,11 @@ impl Supervisor {
                          hosting handshake protocol)"
                     )))
                 }
+                // Test-only: Prepare always SUCCEEDS so the FSM advances to
+                // Committing (where the test variant's Commit then fails,
+                // driving NeedsRepair).
+                #[cfg(any(test, feature = "testing"))]
+                SagaInput::TestForceNeedsRepair { .. } => Ok(()),
             }
         };
 
@@ -4680,6 +4875,13 @@ impl Supervisor {
                 | SagaInput::BroadcastHostingHandshake { .. } => Err(ContextError::NotImplemented(
                     "saga Commit — all 3 saga types' commit-side wiring deferred to commit \
                          11.5 per DEFERRED-commit-11-saga-use-cases.md"
+                        .to_owned(),
+                )),
+                // Test-only: Commit ALWAYS fails so `commit_with_retry`
+                // exhausts its budget and the FSM transitions to NeedsRepair.
+                #[cfg(any(test, feature = "testing"))]
+                SagaInput::TestForceNeedsRepair { .. } => Err(ContextError::InvalidState(
+                    "saga Commit — TestForceNeedsRepair always fails to drive NeedsRepair"
                         .to_owned(),
                 )),
             }
@@ -6829,16 +7031,43 @@ fn standing_outcome_error_sketch(err: &ContextError) -> ContextError {
 // Saga FSM helpers
 // ---------------------------------------------------------------------------
 
-/// RAII reset for [`Supervisor::saga_pending_guard`]. Ensures the pending
-/// flag clears on scope exit even if the FSM body panics. Phase 1 fix-up
-/// of ADR-049 (post-review-round-1) — the prior implementation cleared
-/// the flag with a line of code after `.await`, leaving the guard set on
-/// any unwind path.
-struct SagaGuardReset<'a>(&'a std::sync::atomic::AtomicBool);
+/// RAII release for a saga's per-participant-context-set reservation
+/// (ADR-049 §3a, spec §5.15.4). Holds the exact set of context IDs THIS
+/// saga reserved; on drop it synchronously re-locks
+/// [`Supervisor::reserved_saga_contexts`] and removes precisely those ids.
+///
+/// Drop fires on EVERY terminal path out of [`Supervisor::start_saga`] —
+/// Committed, Aborted, and NeedsRepair — AND on a panic-unwind through the
+/// FSM body. This is what makes `NeedsRepair` RELEASE the reservation: the
+/// FSM's NeedsRepair arm returns control to `start_saga`, so `_reservation`
+/// drops and the stuck saga's slots free immediately, even though the saga
+/// is not yet operator-resolved. A stuck saga therefore never wedges
+/// unrelated, disjoint sagas.
+///
+/// The drop body is purely synchronous (`lock()` → `remove` → unlock) and
+/// never awaits, so the `std::sync::Mutex` guard is never held across a
+/// yield point (see the `reserved_saga_contexts` field's allow). A poisoned
+/// lock is recovered via `into_inner` so a panic elsewhere cannot strand a
+/// reservation forever.
+#[allow(
+    clippy::disallowed_types,
+    reason = "Synchronous drop-time release only; the guard is never held \
+              across an .await. ADR-049 §3a."
+)]
+pub struct SagaSetReservation<'a> {
+    reserved: &'a std::sync::Mutex<HashSet<String>>,
+    ids: Vec<String>,
+}
 
-impl Drop for SagaGuardReset<'_> {
+impl Drop for SagaSetReservation<'_> {
     fn drop(&mut self) {
-        self.0.store(false, std::sync::atomic::Ordering::Release);
+        let mut reserved = self
+            .reserved
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        for id in &self.ids {
+            reserved.remove(id);
+        }
     }
 }
 
@@ -6864,6 +7093,12 @@ fn saga_input_participants(input: &SagaInput) -> Vec<String> {
         } => vec![local_did.to_string(), peer_did.to_string()],
         SagaInput::CrossContextToolInvocation {
             caller_context_id,
+            // `target_context_id` is part of the gating participant set
+            // (see `saga_participant_context_set`), NOT the journal
+            // provenance record: this extractor intentionally records only
+            // the caller side plus the DID + tool id. Leave the journal
+            // shape UNCHANGED.
+            target_context_id: _,
             caller_did,
             tool_registration_id,
         } => vec![
@@ -6880,7 +7115,83 @@ fn saga_input_participants(input: &SagaInput) -> Vec<String> {
             hex::encode(broadcast_context_id),
             subscriber_did.to_string(),
         ],
+        #[cfg(any(test, feature = "testing"))]
+        SagaInput::TestForceNeedsRepair { context_id } => vec![hex::encode(context_id)],
     }
+}
+
+/// The set of **participant context-actor IDs** a saga reserves for
+/// concurrency gating (ADR-049 §3a, spec §5.15.4).
+///
+/// This is a SIBLING of [`saga_input_participants`], NOT a replacement:
+/// `saga_input_participants` produces the journal-provenance record (a
+/// mixed bag of DIDs, context IDs, and tool IDs — the durable evidence of
+/// who took part). THIS function produces the strict set of *context
+/// actors* the saga spans, which is what the disjoint-vs-overlap
+/// reservation reasons over. A saga reserves the WHOLE set atomically;
+/// two sagas whose sets are disjoint run concurrently, while two whose
+/// sets share ≥1 context serialize (the shared context's slot is held).
+///
+/// Each variant's set is de-duplicated through a [`HashSet`] before being
+/// returned so a saga can never self-conflict (e.g. a degenerate
+/// cross-context invocation whose caller and target resolve to the same
+/// context id reserves that id ONCE, not twice).
+///
+/// # Canonical reservation key
+///
+/// Every variant reserves the **raw-digest hex** of each context it spans —
+/// `hex::encode([u8; 32])` — which is the canonical saga-evidence / wire form
+/// (spec §5.15.8: the `derived_context_id` is "the raw digest before prefix
+/// and hex"; §6.2.4 / §5.14.13 for the cross-context / broadcast wire ids).
+/// In particular `StandingPairCreate` reserves
+/// `hex::encode(derive_standing_context_digest(local, peer))` — the RAW digest,
+/// NOT the `"standing-"`-prefixed actor-registry id. The standing context still
+/// LIVES under the prefixed id in the actor registry; only the gating
+/// reservation key is canonicalized to the raw-digest hex so that a
+/// cross-context or broadcast saga which shares that same standing context
+/// reserves the IDENTICAL key and therefore OVERLAPS (defeating it otherwise
+/// would let two sagas touch the shared context concurrently, breaking the
+/// §5.15.4 serialization the §5.15.8 anti-griefing and §5.14.13 aggregate-cap
+/// arguments depend on).
+///
+/// - `StandingPairCreate` → the single deterministic standing-pair raw-digest
+///   hex (`derive_standing_context_digest`, the hex of spec §5.15.8's
+///   `derived_context_id`).
+/// - `CrossContextToolInvocation` → `{caller, target}` context ids.
+/// - `BroadcastHostingHandshake` → `{host, broadcast}` context ids.
+fn saga_participant_context_set(input: &SagaInput) -> Vec<String> {
+    let raw: Vec<String> = match input {
+        SagaInput::StandingPairCreate {
+            local_did,
+            peer_did,
+        } => vec![hex::encode(
+            crate::context::standing_helpers::derive_standing_context_digest(local_did, peer_did),
+        )],
+        SagaInput::CrossContextToolInvocation {
+            caller_context_id,
+            target_context_id,
+            ..
+        } => vec![
+            hex::encode(caller_context_id),
+            hex::encode(target_context_id),
+        ],
+        SagaInput::BroadcastHostingHandshake {
+            host_context_id,
+            broadcast_context_id,
+            ..
+        } => vec![
+            hex::encode(host_context_id),
+            hex::encode(broadcast_context_id),
+        ],
+        #[cfg(any(test, feature = "testing"))]
+        SagaInput::TestForceNeedsRepair { context_id } => vec![hex::encode(context_id)],
+    };
+    // De-dup: a saga must never self-conflict. Two ids that collapse to one
+    // (caller == target, host == broadcast) reserve a single slot.
+    let mut seen = HashSet::with_capacity(raw.len());
+    raw.into_iter()
+        .filter(|id| seen.insert(id.clone()))
+        .collect()
 }
 
 /// Classify whether a saga's journal evidence carries bearer bytes
@@ -6906,6 +7217,9 @@ const fn saga_input_is_secret_bearing(input: &SagaInput) -> bool {
         SagaInput::StandingPairCreate { .. }
         | SagaInput::CrossContextToolInvocation { .. }
         | SagaInput::BroadcastHostingHandshake { .. } => false,
+        // The test-only NeedsRepair driver carries no bearer material.
+        #[cfg(any(test, feature = "testing"))]
+        SagaInput::TestForceNeedsRepair { .. } => false,
     }
 }
 
@@ -7353,8 +7667,11 @@ mod tests {
             .unwrap_err();
         assert!(matches!(err, ContextError::NotImplemented(_)));
 
-        // Guard must be cleared after a saga terminates (even on
-        // NotImplemented abort) so a subsequent saga can start.
+        // The participant-context-set reservation must be RELEASED after a
+        // saga terminates (even on a NotImplemented abort) so a subsequent
+        // saga over the SAME set can reserve and start. This is the
+        // same-set sequential re-arm property: the RAII `SagaSetReservation`
+        // drop frees the slots on every terminal.
         let err2 = s
             .start_saga(SagaInput::StandingPairCreate {
                 local_did: DID("did:example:a".to_owned()),

--- a/crates/scp-runtime/tests/actor_saga_concurrent.rs
+++ b/crates/scp-runtime/tests/actor_saga_concurrent.rs
@@ -1,21 +1,24 @@
-//! Integration test for the ADR-049 commit-11 concurrent-saga
-//! serialization guard.
+//! Integration tests for the ADR-049 §3a / spec §5.15.4 per-participant-
+//! context-set saga concurrency gating.
 //!
-//! The supervisor serializes sagas supervisor-wide via a single atomic
-//! bool. A second `start_saga` while one is in flight returns
-//! [`ContextError::ActorBusy`](scp_protocol::context::ContextError::ActorBusy)
-//! with a `SagaBusy` reason (plan §"Cross-context saga protocol").
+//! A saga reserves the SET of participant context-actors it spans. Two
+//! sagas whose sets are DISJOINT run concurrently; a second saga whose set
+//! OVERLAPS (shares ≥1 context with) an in-flight saga is rejected with a
+//! typed [`ContextError::ActorBusy`](scp_protocol::context::ContextError::ActorBusy)
+//! carrying a `SagaBusy` reason. A `NeedsRepair` outcome RELEASES the
+//! reservation so a stuck saga cannot wedge unrelated, disjoint sagas.
 //!
-//! # Race structure
+//! # Determinism
 //!
-//! Because all 4 current [`SagaInput`] variants are spec-gapped
-//! (NotImplemented at Prepare dispatch), the FSM body is short —
-//! Initiated → PreparingA → Aborting → Aborted — and journal appends
-//! are the only `await` points. To exercise the guard we launch N
-//! concurrent tasks and count: at least one must succeed-to-
-//! NotImplemented (the saga ran to completion), and any others that
-//! observed the guard-set SHOULD return ActorBusy. The strict
-//! invariant we assert: `ok_count + busy_count == N`.
+//! The three production saga variants are spec-gapped (their Prepare
+//! dispatch returns `NotImplemented`), so a real saga over them terminates
+//! instantly via the PreparingA → Aborting → Aborted arm — too fast to hold
+//! "in flight" by racing. To test the gating semantics deterministically we
+//! use `Supervisor::test_reserve_saga_context_set`, which exercises the
+//! SAME `try_reserve_context_set` critical section that `start_saga` uses
+//! (not a parallel mock), and the test-only `SagaInput::TestForceNeedsRepair`
+//! variant, whose Commit always fails so the FSM drives a real `NeedsRepair`
+//! terminal.
 
 #![allow(
     clippy::unwrap_used,
@@ -92,76 +95,222 @@ fn test_supervisor() -> Arc<Supervisor> {
     ))
 }
 
-fn spec_gapped_input() -> SagaInput {
+/// A standing-pair saga between two DIDs. Its participant context set is
+/// the single deterministic standing-pair context id derived from the pair.
+fn standing_pair(a: &str, b: &str) -> SagaInput {
     SagaInput::StandingPairCreate {
-        local_did: DID("did:example:racer-a".to_owned()),
-        peer_did: DID("did:example:racer-b".to_owned()),
+        local_did: DID(a.to_owned()),
+        peer_did: DID(b.to_owned()),
     }
 }
 
-/// Two Prepares on the same supervisor: the guard admits at most one
-/// at a time. With the instantaneous NotImplemented FSM, the second
-/// Prepare MAY observe the guard clear — but across N=16 parallel
-/// tasks the total ok + busy count MUST equal N, and at least one
-/// must be ActorBusy under heavy concurrency.
-const N: usize = 16;
+/// A cross-context tool-invocation saga over the given caller/target
+/// contexts. Its participant context set is `{caller, target}`.
+fn cross_context(caller: [u8; 32], target: [u8; 32]) -> SagaInput {
+    SagaInput::CrossContextToolInvocation {
+        caller_context_id: caller,
+        target_context_id: target,
+        caller_did: DID("did:example:caller".to_owned()),
+        tool_registration_id: "tool-1".to_owned(),
+    }
+}
 
+fn ctx(byte: u8) -> [u8; 32] {
+    [byte; 32]
+}
+
+/// DISJOINT participant sets run concurrently: two sagas spanning entirely
+/// different contexts BOTH reach a terminal — NEITHER returns ActorBusy.
+/// Because the production variants are spec-gapped, "terminal" is the
+/// `NotImplemented` abort; the load-bearing assertion is the ABSENCE of
+/// ActorBusy, proving disjoint sets never serialize.
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
-async fn concurrent_sagas_serialize_via_guard() {
+async fn disjoint_participant_sets_run_concurrently() {
     let supervisor = test_supervisor();
 
-    let mut handles = Vec::with_capacity(N);
-    for _ in 0..N {
-        let sup = Arc::clone(&supervisor);
-        handles.push(tokio::spawn(async move {
-            sup.start_saga(spec_gapped_input()).await
-        }));
-    }
+    // Two cross-context sagas over fully disjoint context pairs:
+    //   saga 1: {0x01, 0x02}    saga 2: {0x03, 0x04}
+    let sup1 = Arc::clone(&supervisor);
+    let sup2 = Arc::clone(&supervisor);
+    let h1 = tokio::spawn(async move { sup1.start_saga(cross_context(ctx(1), ctx(2))).await });
+    let h2 = tokio::spawn(async move { sup2.start_saga(cross_context(ctx(3), ctx(4))).await });
 
-    let mut ok_count = 0usize;
-    let mut busy_count = 0usize;
-    for handle in handles {
-        match handle.await.unwrap() {
-            Err(ContextError::NotImplemented(_)) => ok_count += 1,
+    let r1 = h1.await.unwrap();
+    let r2 = h2.await.unwrap();
+
+    for r in [&r1, &r2] {
+        match r {
+            Err(ContextError::NotImplemented(_)) => {}
             Err(ContextError::ActorBusy(msg)) => {
-                assert!(
-                    msg.contains("SagaBusy") || msg.contains("already in flight"),
-                    "ActorBusy must mention SagaBusy or 'already in flight', got: {msg}"
-                );
-                busy_count += 1;
+                panic!("disjoint participant sets must NOT serialize — got ActorBusy: {msg}")
             }
-            other => panic!("unexpected start_saga result: {other:?}"),
+            other => panic!("unexpected disjoint-saga result: {other:?}"),
         }
     }
-    assert_eq!(
-        ok_count + busy_count,
-        N,
-        "every task must terminate as either NotImplemented-on-terminate or ActorBusy"
-    );
-    // Every saga eventually runs to terminate — a second caller's
-    // ActorBusy does NOT mean the saga is dropped; it just means this
-    // caller lost the race.
+}
+
+/// OVERLAPPING participant sets serialize: while one saga's set is held in
+/// flight, a second saga sharing ≥1 context returns ActorBusy with a
+/// `SagaBusy` reason. The in-flight saga is simulated deterministically by
+/// holding the reservation guard (the production gating critical section),
+/// because the spec-gapped FSM terminates too fast to race.
+#[tokio::test]
+async fn overlapping_participant_sets_reject_busy() {
+    let supervisor = test_supervisor();
+
+    // Hold saga 1's set {0x01, 0x02} in flight via the production
+    // reservation primitive.
+    let in_flight = cross_context(ctx(1), ctx(2));
+    let held = supervisor
+        .test_reserve_saga_context_set(&in_flight)
+        .expect("first reservation must succeed on an empty supervisor");
+
+    // Saga 2 shares context 0x02 (its set is {0x02, 0x09}) — must be
+    // rejected as SagaBusy.
+    let overlapping = cross_context(ctx(2), ctx(9));
+    let err = supervisor
+        .start_saga(overlapping)
+        .await
+        .expect_err("overlapping saga must be rejected while the set is held");
+    match err {
+        ContextError::ActorBusy(msg) => assert!(
+            msg.contains("SagaBusy"),
+            "overlap rejection must mention SagaBusy, got: {msg}"
+        ),
+        other => panic!("expected ActorBusy(SagaBusy), got: {other:?}"),
+    }
+
+    // Releasing saga 1's reservation lets the previously-overlapping set
+    // through (proves the rejection was the reservation, not some other
+    // failure).
+    drop(held);
+    let err2 = supervisor
+        .start_saga(cross_context(ctx(2), ctx(9)))
+        .await
+        .expect_err("after release the saga proceeds to its spec-gapped terminal");
     assert!(
-        ok_count >= 1,
-        "at least one saga must run to completion (ok_count >= 1)"
+        matches!(err2, ContextError::NotImplemented(_)),
+        "after release the overlapping set must reserve and run, got: {err2:?}"
     );
 }
 
-/// After the guard trips, a subsequent saga (once the first completes)
-/// must succeed: the guard is cleared on terminal resolution.
+/// A standing-pair saga and a CROSS-CONTEXT saga that touch the SAME context
+/// serialize — overlap detection is purely set-membership, not saga-type.
+///
+/// This is the FIX-1 regression guard: it genuinely crosses saga TYPES. A
+/// `StandingPairCreate` saga reserves the CANONICAL raw-digest hex of its
+/// standing context (spec §5.15.8 — the digest BEFORE the `"standing-"`
+/// prefix), and a `CrossContextToolInvocation` over that SAME raw digest must
+/// collide. If the standing-pair saga reserved the `"standing-"`-prefixed
+/// display id instead (the pre-FIX-1 bug), the cross-context saga's
+/// `hex::encode([u8; 32])` key would never equal the prefixed string, overlap
+/// would NOT be detected, and this assertion would FAIL — exactly the wedge
+/// FIX 1 closes.
 #[tokio::test]
-async fn guard_is_rearmed_after_each_saga_terminates() {
+async fn overlap_is_set_membership_across_saga_types() {
     let supervisor = test_supervisor();
-    // Run 5 sagas sequentially — every one must terminate with
-    // NotImplemented (not ActorBusy).
-    for _ in 0..5 {
+
+    // Hold a STANDING-PAIR saga in flight via the production reservation
+    // primitive. It reserves the canonical raw-digest hex of the pair's
+    // standing context.
+    let alice = DID("did:example:alice".to_owned());
+    let bob = DID("did:example:bob".to_owned());
+    let pair = standing_pair("did:example:alice", "did:example:bob");
+    let held = supervisor
+        .test_reserve_saga_context_set(&pair)
+        .expect("standing-pair reservation must succeed");
+
+    // Compute the EXACT raw 32-byte digest that the held standing-pair saga
+    // reserved (the canonical gating key), then name it as one leg of a
+    // CROSS-CONTEXT saga (a DIFFERENT saga type). The cross-context saga's
+    // `caller_context_id` is the standing context's raw digest; its
+    // `target_context_id` is an unrelated context. The shared raw digest forces
+    // an overlap across saga types.
+    let standing_digest = Supervisor::test_standing_pair_context_digest(&alice, &bob);
+    let err = supervisor
+        .start_saga(cross_context(standing_digest, ctx(9)))
+        .await
+        .expect_err("cross-context saga over the held standing context must collide");
+    match err {
+        ContextError::ActorBusy(msg) => assert!(
+            msg.contains("SagaBusy"),
+            "overlap rejection must mention SagaBusy, got: {msg}"
+        ),
+        other => panic!("expected ActorBusy(SagaBusy), got: {other:?}"),
+    }
+
+    // Releasing the standing-pair reservation lets the previously-overlapping
+    // cross-context saga through — proving the rejection WAS the shared raw
+    // digest (the reservation), not some unrelated failure.
+    drop(held);
+    let err2 = supervisor
+        .start_saga(cross_context(standing_digest, ctx(9)))
+        .await
+        .expect_err("after release the cross-context saga runs to its spec-gapped terminal");
+    assert!(
+        matches!(err2, ContextError::NotImplemented(_)),
+        "after release the cross-type set must reserve and run, got: {err2:?}"
+    );
+}
+
+/// `NeedsRepair` RELEASES the reservation: a saga driven to NeedsRepair
+/// (commit-retry-exhausted) frees its participant context set, so a second
+/// saga sharing that set reserves successfully — it does NOT get ActorBusy.
+/// This proves a stuck saga cannot wedge unrelated sagas (ADR-049 §3a, spec
+/// §5.15.4).
+///
+/// `start_paused` lets the 500ms/1s/2s commit-retry backoffs elapse in
+/// virtual time, so the test does not actually wait 3.5s.
+#[tokio::test(start_paused = true)]
+async fn needs_repair_releases_reservation() {
+    let supervisor = test_supervisor();
+
+    // Drive a saga over context 0x07 to NeedsRepair: its Prepare phases
+    // succeed and its Commit always fails, exhausting the retry budget. The
+    // FSM returns the typed NeedsRepair error to `start_saga`, whose RAII
+    // reservation then drops — releasing context 0x07.
+    let err = supervisor
+        .start_saga(SagaInput::TestForceNeedsRepair { context_id: ctx(7) })
+        .await
+        .expect_err("commit-retry-exhausted saga must return a NeedsRepair error");
+    // The terminal is NeedsRepair (commit failed) — surfaced as the typed
+    // commit error, NOT ActorBusy.
+    assert!(
+        !matches!(err, ContextError::ActorBusy(_)),
+        "a NeedsRepair saga must not surface as ActorBusy, got: {err:?}"
+    );
+
+    // A second saga sharing context 0x07 must now reserve successfully —
+    // proving the NeedsRepair terminal RELEASED the slot. If the slot were
+    // still held, this would return ActorBusy.
+    let err2 = supervisor
+        .start_saga(cross_context(ctx(7), ctx(8)))
+        .await
+        .expect_err("the follow-up saga runs to its spec-gapped terminal");
+    assert!(
+        matches!(err2, ContextError::NotImplemented(_)),
+        "NeedsRepair must release context 0x07 so a sharing saga reserves \
+         (no ActorBusy), got: {err2:?}"
+    );
+}
+
+/// Same-set sequential re-arm: running the SAME participant set N times in
+/// a row must succeed every time — each saga's terminal releases the
+/// reservation so the next over the identical set can reserve. (The prior
+/// supervisor-wide AtomicBool guaranteed this for ALL sagas; the per-set
+/// reservation must still guarantee it for same-set sequences.)
+#[tokio::test]
+async fn same_set_sequential_rearm() {
+    let supervisor = test_supervisor();
+    for i in 0..5 {
         let err = supervisor
-            .start_saga(spec_gapped_input())
+            .start_saga(cross_context(ctx(1), ctx(2)))
             .await
             .unwrap_err();
         assert!(
             matches!(err, ContextError::NotImplemented(_)),
-            "sequential sagas must all terminate — guard re-arm failed: got {err:?}"
+            "sequential same-set saga {i} must terminate (reservation re-arm \
+             failed) — got {err:?}"
         );
     }
 }

--- a/crates/scp-runtime/tests/shuttle_actor.rs
+++ b/crates/scp-runtime/tests/shuttle_actor.rs
@@ -10,8 +10,13 @@
 //! the shuttle dependency is wired in, this file compiles to an empty
 //! binary. The scaffold records the invariants we intend to check:
 //!
-//! 1. Saga coordinator guard admits at most one in-flight saga at a
-//!    time under all interleavings.
+//! 1. Saga concurrency is gated per-participant-context-set: a saga
+//!    reserves the SET of context-actors it spans, two sagas with
+//!    DISJOINT sets run concurrently, an OVERLAPPING set is rejected with
+//!    a typed `SagaBusy`, and every terminal (Committed / Aborted /
+//!    NeedsRepair) RELEASES the reserved set — so the reservation store is
+//!    empty once all sagas terminate, under all interleavings. (There is
+//!    no instance-wide single-saga guard.)
 //! 2. Journal append ordering is strictly monotonic even under task
 //!    preemption.
 //! 3. Crash-recovery replay is idempotent under arbitrary task
@@ -36,22 +41,36 @@
 // file compiles to an empty `main`-less test binary.
 #[cfg(feature = "shuttle")]
 mod shuttle_tests {
-    //! # Invariant 1 — guard admits at most one saga.
+    //! # Invariant 1 — every reservation is released on terminal.
+    //!
+    //! Saga concurrency is gated per-participant-context-set (ADR-049 §3a,
+    //! spec §5.15.4): a saga reserves the SET of context-actors it spans, and
+    //! each saga's terminal (Committed / Aborted / NeedsRepair) RELEASES its
+    //! reserved set. There is no instance-wide guard. The shuttle invariant is
+    //! therefore that the reservation store is EMPTY once all sagas terminate
+    //! — running the same participant set repeatedly must re-arm, and disjoint
+    //! sets must never serialize.
     //!
     //! ```ignore
     //! #[shuttle::test]
-    //! fn saga_guard_admits_one() {
+    //! fn reservations_release_on_terminal() {
     //!     let sup = Arc::new(test_supervisor());
     //!     let mut handles = vec![];
     //!     for _ in 0..4 {
     //!         let s = Arc::clone(&sup);
     //!         handles.push(shuttle::thread::spawn(move || {
+    //!             // Disjoint sets run concurrently; overlapping sets serialize
+    //!             // with a typed SagaBusy.
     //!             let _ = shuttle::future::block_on(s.start_saga(input()));
     //!         }));
     //!     }
     //!     for h in handles { h.join().unwrap(); }
-    //!     // guard must be cleared after all sagas terminate.
-    //!     assert!(!sup.saga_pending_guard.load(Ordering::SeqCst));
+    //!     // Invariant: once every saga has reached a terminal state, the
+    //!     // per-set reservation store holds NO ids — each terminal drops its
+    //!     // RAII `SagaSetReservation`, which removes exactly the set it took.
+    //!     // (The shuttle test asserts emptiness through whatever observation
+    //!     // surface the harness exposes — e.g. a follow-up `start_saga` over
+    //!     // the same set must succeed, proving the slot was released.)
     //! }
     //! ```
     //!

--- a/scripts/check-saga-gating-granularity.sh
+++ b/scripts/check-saga-gating-granularity.sh
@@ -1,0 +1,636 @@
+#!/usr/bin/env bash
+# check-saga-gating-granularity.sh — CI gate enforcing ADR-049 §3a's
+# per-participant-context-set saga concurrency GRANULARITY.
+#
+# ---------------------------------------------------------------------------
+# WHY THIS EXISTS
+# ---------------------------------------------------------------------------
+# ADR-049 §3a (and spec §5.15.4) require that cross-context sagas serialize at
+# the granularity of their PARTICIPANT CONTEXT SET, not supervisor-wide. A saga
+# reserves the set of context-actors it spans; two sagas with DISJOINT sets run
+# concurrently, and only an OVERLAP (a shared context) yields a typed SagaBusy.
+# A single instance-wide guard (the as-built `AtomicBool`) lets one slow or
+# stuck saga DoS every unrelated saga in the instance — and §3a's
+# block-until-terminal FFI saga surface would expose that wedge to every
+# binding. §3a therefore makes per-set gating a HARD, mechanically-enforced
+# prerequisite for the `start_*_saga` FFI exports.
+#
+# This gate is a GRANULARITY TRIPWIRE. It is NOT a proof of correctness and it
+# is NOT un-launderable: a sufficiently creative instance-wide wedge (an
+# obscure field name AND an obscure scalar type the lists below do not name)
+# could still slip past the negative scan. What it DOES do is (a) resist the
+# COMMON rename/retype laundering of an instance-wide guard
+# (`AtomicBool` → `Mutex<()>` → `Semaphore(1)` → a single `bool`/`u8`/count
+# field, under any of the usual saga/inflight/pending/busy/gate/guard field
+# names), and (b) POSITIVELY assert that the per-set reservation machinery is
+# present and wired (the `reserved_saga_contexts` store, the
+# `saga_participant_context_set` extractor, and an overlap-reject INSIDE
+# `try_reserve_context_set` that `start_saga` actually CALLS). The SEMANTIC
+# proof — disjoint sets run concurrently, an overlapping set is rejected
+# SagaBusy, the reservation key is the canonical raw digest, and NeedsRepair
+# releases the slot — lives in the `actor_saga_concurrent.rs` integration tests
+# that CI runs; this gate additionally asserts those proving test functions
+# exist by name so they cannot be silently deleted.
+#
+# ---------------------------------------------------------------------------
+# WHAT THIS CHECKS (on crates/scp-runtime/src/context/supervisor/supervisor.rs)
+# ---------------------------------------------------------------------------
+# NEGATIVE assertion — FAIL if a saga-concurrency `Supervisor` field of an
+#   instance-wide SCALAR type exists. Match the product of
+#   "saga-concurrency field name" × "instance-wide scalar type". The NAME match
+#   is widened beyond `saga*` to every plausible saga-concurrency field name
+#   (`saga`/`inflight`/`in_flight`/`pending`/`busy`/`gate`/`guard`), and the
+#   TYPE match is widened to every instance-wide scalar wedge:
+#       (saga|inflight|in_flight|pending|busy|gate|guard)[_a-z0-9]* : ...
+#         (Atomic(Bool|U8|U16|U32|U64|Usize|I8|I16|I32|I64|Isize)|Semaphore
+#          |Mutex<()>|Mutex<bool>|Mutex<u8>|Mutex<u16>|Mutex<u32>
+#          |Mutex<u64>|Mutex<usize>)
+#   A field whose NAME is one of those AND whose TYPE is one of those
+#   instance-wide scalars is exactly the wedge §3a forbids. The match is kept
+#   NAME-scoped (not a blanket type-ban) so a LEGIT non-saga Supervisor field of
+#   one of these types — e.g. `spawn_generation: AtomicU64` — is not flagged.
+#   `Mutex<HashSet<...>>` (the per-set reservation) is NOT a scalar and is
+#   deliberately allowed.
+#
+# POSITIVE assertions — FAIL if ANY of these is ABSENT (so deleting the guard
+#   entirely, i.e. NO gating, also fails — per-set gating must be PRESENT):
+#     (P1) the `reserved_saga_contexts` HashSet field (the per-set reservation
+#          store);
+#     (P2) the `saga_participant_context_set` extractor (computes the set a
+#          saga reserves);
+#     (P3) the overlap-reject: a `.contains(` membership check returning a
+#          `SagaBusy`/`ActorBusy` error, occurring INSIDE
+#          `fn try_reserve_context_set` (not merely somewhere in the file);
+#     (P4) `try_reserve_context_set` is CALLED in `fn start_saga` (the gate is
+#          on the start path, not dead code);
+#     (P5) `saga_participant_context_set` does NOT emit a `"standing-"`-prefixed
+#          literal into the reserved set (catches a FIX-1 regression that would
+#          reserve the display id instead of the canonical raw digest);
+#     (P6) the proving integration-test functions exist by name in
+#          `actor_saga_concurrent.rs` (the semantic proof CI runs).
+#
+# FFI ORDERING clause — if any `start_*_saga` export exists anywhere under
+#   `crates/scp-ffi/`, the NEGATIVE assertion MUST pass (no instance-wide saga
+#   guard may coexist with a shipped FFI saga surface). Today there are no such
+#   exports, so this clause is a vacuous pass that ARMS the prerequisite: the
+#   moment an FFI saga export lands, the negative assertion is load-bearing.
+#
+# ---------------------------------------------------------------------------
+# HOW TO FIX A FAILURE
+# ---------------------------------------------------------------------------
+# - Negative hit: you reintroduced an instance-wide saga guard. Replace it with
+#   per-participant-context-set reservation (reserve the saga's whole context
+#   set; reject only on overlap). See `Supervisor::try_reserve_context_set`.
+# - Positive miss: the per-set gating was removed or renamed. Restore the
+#   `reserved_saga_contexts` set, the `saga_participant_context_set` extractor,
+#   and the overlap-reject. Do NOT weaken this gate — fix the code.
+#
+# This script is in the CLAUDE.md NEVER-WEAKEN enforcement list. The only
+# legitimate edits are ADDITIVE (new assertions / wider coverage).
+#
+# ---------------------------------------------------------------------------
+# PORTABILITY
+# ---------------------------------------------------------------------------
+# Runs on macOS (BSD userland) and Linux (GNU userland). POSIX bash + grep +
+# find only. No ripgrep, no GNU-specific flags.
+#
+# Usage:
+#   bash scripts/check-saga-gating-granularity.sh            # real check
+#   bash scripts/check-saga-gating-granularity.sh --self-test # prove it's alive
+# Exit codes:
+#   0  — granularity correct (per-set gating present, no instance-wide guard)
+#   1  — a negative hit, a positive miss, or a self-test failure
+#   2  — invocation error (target file missing)
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$REPO_ROOT"
+
+# ---------------------------------------------------------------------------
+# TTY-aware coloring
+# ---------------------------------------------------------------------------
+if [[ -t 1 ]] && [[ -z "${NO_COLOR:-}" ]]; then
+    C_RED=$'\033[31m'
+    C_GREEN=$'\033[32m'
+    C_YELLOW=$'\033[33m'
+    C_DIM=$'\033[2m'
+    C_RESET=$'\033[0m'
+else
+    C_RED=""
+    C_GREEN=""
+    C_YELLOW=""
+    C_DIM=""
+    C_RESET=""
+fi
+
+SUPERVISOR_REL="crates/scp-runtime/src/context/supervisor/supervisor.rs"
+FFI_DIR="crates/scp-ffi"
+TESTS_REL="crates/scp-runtime/tests/actor_saga_concurrent.rs"
+
+# ---------------------------------------------------------------------------
+# Instance-wide scalar saga-guard regex (the NEGATIVE pattern). A field whose
+# NAME is a plausible saga-concurrency guard name and whose TYPE is an
+# instance-wide scalar guard.
+#
+#   (saga|inflight|in_flight|pending|busy|gate|guard)[_a-z0-9]*
+#                     — a field name that is, or begins with, one of the usual
+#                       saga-concurrency guard names
+#   [[:space:]]*:     — the field's `:` type separator
+#   .*                — any qualified path before the type
+#   (Atomic(Bool|U8|U16|U32|U64|Usize|I8|I16|I32|I64|Isize)|Semaphore
+#    |Mutex<\(\)>|Mutex<bool>|Mutex<u8>|Mutex<u16>|Mutex<u32>|Mutex<u64>
+#    |Mutex<usize>)
+#                     — the instance-wide scalar guard types: any small atomic
+#                       (signed OR unsigned), a Semaphore, or a Mutex over a
+#                       unit / bool / small unsigned scalar.
+#
+# `Mutex<HashSet<...>>` (the per-set reservation) is NOT a scalar and is
+# deliberately allowed. The name scoping keeps a LEGIT non-saga field of one of
+# these scalar types (e.g. `spawn_generation: AtomicU64`) from being flagged.
+# Uses a POSIX ERE (grep -E); `<`, `>`, `(`, `)` are escaped where they must be
+# literal.
+# ---------------------------------------------------------------------------
+NEG_NAME='(saga|inflight|in_flight|pending|busy|gate|guard)[_a-z0-9]*'
+NEG_TYPE='(Atomic(Bool|U8|U16|U32|U64|Usize|I8|I16|I32|I64|Isize)|Semaphore|Mutex<\(\)>|Mutex<bool>|Mutex<u8>|Mutex<u16>|Mutex<u32>|Mutex<u64>|Mutex<usize>)'
+NEG_PATTERN="${NEG_NAME}[[:space:]]*:[[:space:]]*.*${NEG_TYPE}"
+
+# ---------------------------------------------------------------------------
+# scan_negative <file> — print each line in <file> that declares an
+# instance-wide scalar saga guard (a NEGATIVE hit). Comments are NOT stripped
+# here on purpose: a doc-comment that merely MENTIONS `AtomicBool` would be a
+# false positive, so we additionally require the line to look like a FIELD
+# DECLARATION (contains a `:` type separator and is not a `//`/`///` comment
+# line). We strip line-comment tails first so a trailing `// ... AtomicBool`
+# note cannot trip the gate, then match the negative pattern on the code part.
+# ---------------------------------------------------------------------------
+scan_negative() {
+    local file="$1"
+    awk -v PAT="$NEG_PATTERN" '
+    {
+        line = $0
+        # Drop a //-comment tail so a code-free mention in a trailing comment
+        # is not matched. (Block comments spanning the field are not a concern:
+        # a field declaration is live code, not inside /* */.)
+        sub(/\/\/.*$/, "", line)
+        # Skip pure-comment / doc-comment lines outright.
+        stripped = line
+        sub(/^[[:space:]]+/, "", stripped)
+        if (stripped ~ /^\/?\*/ || stripped == "") next
+        if (line ~ PAT) {
+            t = line
+            sub(/^[[:space:]]+/, "", t)
+            sub(/[[:space:]]+$/, "", t)
+            printf("NEGHIT\t%d\t%s\n", NR, t)
+        }
+    }
+    ' "$file"
+}
+
+# ---------------------------------------------------------------------------
+# has_token <file> <fixed-string> — 0 if present, 1 if absent. Plain
+# fixed-string search (grep -F) so regex metachars in the token are literal.
+# ---------------------------------------------------------------------------
+has_token() {
+    grep -Fq -- "$2" "$1"
+}
+
+# ---------------------------------------------------------------------------
+# fn_body <file> <fn-name> — print the body of the FIRST `fn <fn-name>(` in
+# <file>, from the opening `{` to its matching `}`, by brace-depth counting.
+# Rust string/char literals can technically contain unbalanced braces; the
+# saga functions this gate inspects do not, so a plain brace count is
+# sufficient (and the gate is a tripwire, not a parser). Emits nothing if the
+# function is absent.
+# ---------------------------------------------------------------------------
+fn_body() {
+    local file="$1" fn="$2"
+    awk -v FN="fn ${fn}(" '
+    BEGIN { found = 0; depth = 0; started = 0 }
+    {
+        if (!found && index($0, FN) > 0) { found = 1 }
+        if (found) {
+            line = $0
+            n = length(line)
+            for (i = 1; i <= n; i++) {
+                c = substr(line, i, 1)
+                if (c == "{") { depth++; started = 1 }
+                else if (c == "}") { depth-- }
+            }
+            print line
+            if (started && depth <= 0) { exit }
+        }
+    }
+    ' "$file"
+}
+
+# ---------------------------------------------------------------------------
+# has_overlap_reject_in_reserve <file> — 0 if the overlap-reject lives INSIDE
+# `fn try_reserve_context_set`: a `.contains(` membership check AND a typed
+# `SagaBusy`/`ActorBusy` rejection, all within that function's body (P3). This
+# is stricter than "somewhere in the file": it pins the reject to the
+# reservation critical section. Returns 0 (present) or 1 (absent).
+# ---------------------------------------------------------------------------
+has_overlap_reject_in_reserve() {
+    local file="$1" body
+    body="$(fn_body "$file" 'try_reserve_context_set')"
+    [[ -n "$body" ]] || return 1
+    printf '%s' "$body" | grep -Fq -- '.contains(' || return 1
+    printf '%s' "$body" | grep -Fq -- 'SagaBusy' || return 1
+    printf '%s' "$body" | grep -Fq -- 'ActorBusy' || return 1
+    return 0
+}
+
+# ---------------------------------------------------------------------------
+# start_saga_calls_reserve <file> — 0 if `fn start_saga`'s body CALLS
+# `try_reserve_context_set(` (P4): the per-set gating is on the start path, not
+# dead code. Returns 0 (present) or 1 (absent).
+# ---------------------------------------------------------------------------
+start_saga_calls_reserve() {
+    local file="$1" body
+    body="$(fn_body "$file" 'start_saga')"
+    [[ -n "$body" ]] || return 1
+    printf '%s' "$body" | grep -Fq -- 'try_reserve_context_set(' || return 1
+    return 0
+}
+
+# ---------------------------------------------------------------------------
+# extractor_has_no_standing_prefix <file> — 0 if `fn saga_participant_context_set`
+# does NOT emit a `"standing-"`-prefixed literal into the reserved set (P5).
+# A FIX-1 regression would reserve the `"standing-"`-prefixed DISPLAY id instead
+# of the canonical raw-digest hex, so a `"standing-"` string literal (or a call
+# to `generate_standing_context_id`, which produces that prefix) appearing in
+# the extractor body is the tell. Returns 0 (clean) or 1 (regression present).
+# ---------------------------------------------------------------------------
+extractor_has_no_standing_prefix() {
+    local file="$1" body
+    body="$(fn_body "$file" 'saga_participant_context_set')"
+    # Absence of the function is a SEPARATE failure (P2); treat a missing body
+    # as "clean" here so P5 does not double-count it.
+    [[ -n "$body" ]] || return 0
+    if printf '%s' "$body" | grep -Eq -- '"standing-|generate_standing_context_id'; then
+        return 1
+    fi
+    return 0
+}
+
+# ---------------------------------------------------------------------------
+# tests_present <test-file> — 0 if ALL the proving integration-test functions
+# exist by name in <test-file> (P6). These carry the SEMANTIC proof (disjoint
+# concurrent, overlap busy, cross-type set-membership, NeedsRepair release)
+# that CI runs; this gate asserts they cannot be silently deleted. Returns 0
+# (all present) or 1 (any absent / file missing).
+# ---------------------------------------------------------------------------
+PROVING_TESTS=(
+    'disjoint_participant_sets_run_concurrently'
+    'overlapping_participant_sets_reject_busy'
+    'overlap_is_set_membership_across_saga_types'
+    'needs_repair_releases_reservation'
+)
+tests_present() {
+    local file="$1" t
+    [[ -f "$file" ]] || return 1
+    for t in "${PROVING_TESTS[@]}"; do
+        grep -Eq -- "fn[[:space:]]+${t}[[:space:]]*\(" "$file" || return 1
+    done
+    return 0
+}
+
+# ---------------------------------------------------------------------------
+# ffi_has_saga_export <dir> — 0 if any `start_*_saga` export exists under the
+# FFI dir, 1 otherwise. Matches `start_<anything>_saga` as a function-ish
+# identifier (fn / pub fn / #[uniffi] export / napi). The match is on the
+# IDENTIFIER token, so a doc reference also counts — conservative by design
+# (the FFI clause only TIGHTENS the negative assertion).
+# ---------------------------------------------------------------------------
+ffi_has_saga_export() {
+    local dir="$1"
+    [[ -d "$dir" ]] || return 1
+    # `start_*_saga` identifier anywhere under the FFI tree.
+    if grep -REq -- 'start_[A-Za-z0-9_]*_saga' "$dir" --include='*.rs' 2>/dev/null; then
+        return 0
+    fi
+    return 1
+}
+
+# ---------------------------------------------------------------------------
+# run_check <supervisor-file> <ffi-dir> <label> — run the full granularity
+# evaluation against the given target. Returns 0 PASS, 1 FAIL. Factored so the
+# self-test can drive it against synthetic fixtures.
+# ---------------------------------------------------------------------------
+run_check() {
+    local sup="$1"
+    local ffi_dir="$2"
+    local label="${3:-check}"
+    local testfile="${4:-$TESTS_REL}"
+
+    if [[ ! -f "$sup" ]]; then
+        printf '%serror:%s supervisor file %s does not exist\n' \
+            "$C_RED" "$C_RESET" "$sup" >&2
+        return 2
+    fi
+
+    local fail=0
+
+    printf '\n%ssaga-gating granularity %s:%s %s\n' \
+        "$C_DIM" "$label" "$C_RESET" "$sup"
+
+    # --- NEGATIVE: no instance-wide scalar saga guard -----------------------
+    local neg
+    neg="$(scan_negative "$sup" || true)"
+    if [[ -n "$neg" ]]; then
+        printf '\n%sFAILED (negative)%s: an instance-wide scalar saga-concurrency guard\n' \
+            "$C_RED" "$C_RESET" >&2
+        printf 'is present. ADR-049 §3a forbids supervisor-wide saga gating of ANY\n' >&2
+        printf 'scalar type — one stuck saga must not wedge unrelated, disjoint sagas.\n' >&2
+        printf 'Use per-participant-context-set reservation instead.\n' >&2
+        while IFS=$'\t' read -r tag ln txt; do
+            [[ "$tag" == "NEGHIT" ]] || continue
+            printf '      %s%s:%s%s  %s%s%s\n' \
+                "$C_DIM" "$sup" "$ln" "$C_RESET" "$C_YELLOW" "$txt" "$C_RESET" >&2
+        done <<< "$neg"
+        fail=1
+    fi
+
+    # --- FFI ORDERING clause -----------------------------------------------
+    # If any start_*_saga FFI export exists, the negative assertion MUST pass.
+    # (When it does pass, `fail` is already 0 from the negative block; this
+    # clause re-states the dependency and fails loudly if a guard coexists with
+    # an FFI saga export.)
+    if ffi_has_saga_export "$ffi_dir"; then
+        if [[ -n "$neg" ]]; then
+            printf '\n%sFAILED (FFI ordering)%s: a start_*_saga FFI export exists while an\n' \
+                "$C_RED" "$C_RESET" >&2
+            printf 'instance-wide saga guard is still present. §3a: the FFI saga surface\n' >&2
+            printf 'MUST NOT ship until per-set gating replaces the instance-wide guard.\n' >&2
+            fail=1
+        else
+            printf '%s  note:%s start_*_saga FFI export present; negative assertion is\n' \
+                "$C_DIM" "$C_RESET"
+            printf '%s       %s load-bearing and passes (no instance-wide guard).\n' \
+                "$C_DIM" "$C_RESET"
+        fi
+    else
+        printf '%s  note:%s no start_*_saga FFI export yet — FFI ordering clause armed\n' \
+            "$C_DIM" "$C_RESET"
+        printf '%s       %s (vacuous pass; prerequisite enforced the moment one lands).\n' \
+            "$C_DIM" "$C_RESET"
+    fi
+
+    # --- POSITIVE: per-set gating must be PRESENT ---------------------------
+    if ! has_token "$sup" 'reserved_saga_contexts'; then
+        printf '\n%sFAILED (positive P1)%s: the `reserved_saga_contexts` HashSet field is\n' \
+            "$C_RED" "$C_RESET" >&2
+        printf 'absent. Per-set gating must be PRESENT — removing the guard entirely\n' >&2
+        printf '(no gating) is also a failure. Restore the per-set reservation store.\n' >&2
+        fail=1
+    fi
+    if ! has_token "$sup" 'saga_participant_context_set'; then
+        printf '\n%sFAILED (positive P2)%s: the `saga_participant_context_set` extractor\n' \
+            "$C_RED" "$C_RESET" >&2
+        printf 'is absent. The reservation must reason over a saga'\''s participant CONTEXT\n' >&2
+        printf 'SET (so disjoint sets run concurrently). Restore the extractor.\n' >&2
+        fail=1
+    fi
+    if ! has_overlap_reject_in_reserve "$sup"; then
+        printf '\n%sFAILED (positive P3)%s: the overlap-reject is absent from\n' \
+            "$C_RED" "$C_RESET" >&2
+        printf '`fn try_reserve_context_set`. The reservation critical section must\n' >&2
+        printf 'reject an OVERLAPPING set with a typed SagaBusy/ActorBusy error via a\n' >&2
+        printf '`.contains(` membership check. Restore the overlap rejection there.\n' >&2
+        fail=1
+    fi
+    if ! start_saga_calls_reserve "$sup"; then
+        printf '\n%sFAILED (positive P4)%s: `fn start_saga` does not CALL\n' \
+            "$C_RED" "$C_RESET" >&2
+        printf '`try_reserve_context_set(`. Per-set gating must be on the start path,\n' >&2
+        printf 'not dead code. Reserve the participant context set in `start_saga`.\n' >&2
+        fail=1
+    fi
+    if ! extractor_has_no_standing_prefix "$sup"; then
+        printf '\n%sFAILED (positive P5)%s: `fn saga_participant_context_set` emits a\n' \
+            "$C_RED" "$C_RESET" >&2
+        printf '`"standing-"`-prefixed literal (or calls `generate_standing_context_id`)\n' >&2
+        printf 'into the reserved set. The standing-pair saga must reserve the CANONICAL\n' >&2
+        printf 'raw-digest hex (`derive_standing_context_digest`), not the prefixed\n' >&2
+        printf 'display id, or it cannot overlap a cross-context/broadcast saga over the\n' >&2
+        printf 'same standing context (spec §5.15.8). Reserve the raw digest.\n' >&2
+        fail=1
+    fi
+    if ! tests_present "$testfile"; then
+        printf '\n%sFAILED (positive P6)%s: a proving integration test is missing from\n' \
+            "$C_RED" "$C_RESET" >&2
+        printf '%s. The semantic proof (disjoint-concurrent, overlap-busy,\n' "$testfile" >&2
+        printf 'cross-type set-membership, NeedsRepair-release) must exist by name:\n' >&2
+        printf '  %s\n' "${PROVING_TESTS[*]}" >&2
+        fail=1
+    fi
+
+    return "$fail"
+}
+
+# ---------------------------------------------------------------------------
+# SELF-TEST — before trusting the gate on real code, prove it is not dead.
+# Build synthetic supervisor fixtures and assert the gate:
+#   (a) FAILS on an `saga*: AtomicBool` guard + a fake FFI start_*_saga export
+#       (negative hit + FFI ordering),
+#   (b) PASSES on the HashSet field + extractor + in-reserve overlap-reject +
+#       start_saga-calls-reserve + raw-digest key + proving tests, with NO
+#       instance-wide guard,
+#   (c) FAILS when the guard is deleted and NO per-set reservation exists
+#       (positive miss — absence-only must not pass),
+#   (d) FAILS on an `inflight_guard: AtomicBool` (the NEG name-prefix bypass:
+#       a non-`saga*`-named instance-wide wedge),
+#   (e) FAILS on a `saga_x: Mutex<u8>` (the NEG type-list bypass: a small-scalar
+#       Mutex instance-wide wedge).
+#   (f) FAILS on a `saga_x: AtomicI64` (the NEG signed-atomic bypass: a SIGNED
+#       atomic instance-wide wedge — same wedge as AtomicU64, just signed).
+# ---------------------------------------------------------------------------
+self_test() {
+    local fixt rc=0
+    fixt="$(mktemp -d)"
+
+    # A valid proving-test fixture so the P6 assertion passes for the fixtures
+    # that are SUPPOSED to pass (b) — and so the FAIL fixtures fail on THEIR
+    # intended assertion, not on a missing test file.
+    local tests_ok="$fixt/tests_ok.rs"
+    {
+        printf '#[tokio::test] async fn disjoint_participant_sets_run_concurrently() {}\n'
+        printf '#[tokio::test] async fn overlapping_participant_sets_reject_busy() {}\n'
+        printf '#[tokio::test] async fn overlap_is_set_membership_across_saga_types() {}\n'
+        printf '#[tokio::test] async fn needs_repair_releases_reservation() {}\n'
+    } > "$tests_ok"
+
+    # emit_good_supervisor <path> — a supervisor that satisfies EVERY positive
+    # assertion (P1 store, P2 extractor, P3 reject-in-reserve, P4 start_saga
+    # calls reserve, P5 raw-digest key / no "standing-" literal). The FAIL
+    # fixtures start from this and inject exactly ONE defect so the self-test
+    # proves the SPECIFIC assertion under test, not an incidental miss.
+    emit_good_supervisor() {
+        local path="$1"
+        {
+            printf 'struct Supervisor {\n'
+            printf '    // The per-set reservation store (NOT an instance-wide scalar).\n'
+            printf '    reserved_saga_contexts: std::sync::Mutex<HashSet<String>>,\n'
+            printf '    spawn_generation: std::sync::atomic::AtomicU64,\n'
+            printf '}\n'
+            printf 'fn saga_participant_context_set(input: &SagaInput) -> Vec<String> {\n'
+            printf '    vec![hex::encode(derive_standing_context_digest(a, b))]\n'
+            printf '}\n'
+            printf 'fn try_reserve_context_set(&self, set: &[String]) -> Result<R, E> {\n'
+            printf '    if set.iter().find(|id| reserved.contains(*id)).is_some() {\n'
+            printf '        return Err(ContextError::ActorBusy("... SagaBusy".into()));\n'
+            printf '    }\n'
+            printf '    Ok(reservation)\n'
+            printf '}\n'
+            printf 'pub async fn start_saga(&self, input: SagaInput) -> Result<O, E> {\n'
+            printf '    let set = saga_participant_context_set(&input);\n'
+            printf '    let _r = self.try_reserve_context_set(&set)?;\n'
+            printf '    Ok(out)\n'
+            printf '}\n'
+        } > "$path"
+    }
+
+    # ---- fixture (a): `saga*: AtomicBool` guard + fake FFI saga export -> FAIL
+    local sup_a="$fixt/sup_a.rs"
+    emit_good_supervisor "$sup_a"
+    # Inject the instance-wide wedge as a struct field (positives still present,
+    # so this proves the NEGATIVE alone fails even beside correct per-set gating).
+    printf 'struct Wedge { saga_pending_guard: std::sync::atomic::AtomicBool }\n' >> "$sup_a"
+    local ffi_a="$fixt/ffi_a"
+    mkdir -p "$ffi_a"
+    printf 'pub fn start_standing_saga() {}\n' > "$ffi_a/exports.rs"
+
+    if run_check "$sup_a" "$ffi_a" "self-test(a)" "$tests_ok" >/dev/null 2>&1; then
+        printf '%sSELF-TEST FAILED (a)%s: a saga*: AtomicBool guard + a start_*_saga FFI\n' \
+            "$C_RED" "$C_RESET" >&2
+        printf 'export was NOT rejected. The negative / FFI-ordering assertion is dead.\n' >&2
+        rc=1
+    fi
+
+    # ---- fixture (b): full correct per-set gating, no instance-wide guard -> PASS
+    local sup_b="$fixt/sup_b.rs"
+    emit_good_supervisor "$sup_b"
+    local ffi_b="$fixt/ffi_b"
+    mkdir -p "$ffi_b"
+    printf 'pub fn unrelated() {}\n' > "$ffi_b/exports.rs"
+
+    if ! run_check "$sup_b" "$ffi_b" "self-test(b)" "$tests_ok" >/dev/null 2>&1; then
+        printf '%sSELF-TEST FAILED (b)%s: correct per-set gating (store + extractor +\n' \
+            "$C_RED" "$C_RESET" >&2
+        printf 'reject-in-reserve + start_saga-calls-reserve + raw-digest key + proving\n' >&2
+        printf 'tests, no instance-wide guard) was wrongly rejected. The gate is over-eager.\n' >&2
+        rc=1
+    fi
+
+    # ---- fixture (c): guard deleted, NO per-set reservation -> FAIL ---------
+    # Absence of the instance-wide guard alone must NOT pass: per-set gating
+    # must be PRESENT (P1..P6).
+    local sup_c="$fixt/sup_c.rs"
+    {
+        printf 'struct Supervisor {\n'
+        printf '    spawn_generation: std::sync::atomic::AtomicU64,\n'
+        printf '}\n'
+        printf 'fn start_saga(&self) { /* no gating at all */ }\n'
+    } > "$sup_c"
+    local ffi_c="$fixt/ffi_c"
+    mkdir -p "$ffi_c"
+    printf 'pub fn unrelated() {}\n' > "$ffi_c/exports.rs"
+
+    if run_check "$sup_c" "$ffi_c" "self-test(c)" "$tests_ok" >/dev/null 2>&1; then
+        printf '%sSELF-TEST FAILED (c)%s: a supervisor with NO saga gating at all (guard\n' \
+            "$C_RED" "$C_RESET" >&2
+        printf 'deleted, no per-set reservation) was wrongly accepted. The POSITIVE\n' >&2
+        printf 'assertions are dead — absence-of-guard must not pass.\n' >&2
+        rc=1
+    fi
+
+    # ---- fixture (d): NEG name-prefix bypass — `inflight_guard: AtomicBool` ->
+    # FAIL. A non-`saga*`-named instance-wide wedge must still be caught now that
+    # the name match covers inflight/pending/busy/gate/guard. Positives present
+    # + a fake FFI saga export so the negative/FFI-ordering clause is live.
+    local sup_d="$fixt/sup_d.rs"
+    emit_good_supervisor "$sup_d"
+    printf 'struct Wedge { inflight_guard: std::sync::atomic::AtomicBool }\n' >> "$sup_d"
+    local ffi_d="$fixt/ffi_d"
+    mkdir -p "$ffi_d"
+    printf 'pub fn start_broadcast_saga() {}\n' > "$ffi_d/exports.rs"
+
+    if run_check "$sup_d" "$ffi_d" "self-test(d)" "$tests_ok" >/dev/null 2>&1; then
+        printf '%sSELF-TEST FAILED (d)%s: a non-saga-named instance-wide wedge\n' \
+            "$C_RED" "$C_RESET" >&2
+        printf '(`inflight_guard: AtomicBool`) slipped past the negative scan. The NEG\n' >&2
+        printf 'name match is too narrow — widen it to inflight/pending/busy/gate/guard.\n' >&2
+        rc=1
+    fi
+
+    # ---- fixture (e): NEG type-list bypass — `saga_x: Mutex<u8>` -> FAIL.
+    # A small-scalar Mutex is an instance-wide wedge the old type list missed.
+    local sup_e="$fixt/sup_e.rs"
+    emit_good_supervisor "$sup_e"
+    printf 'struct Wedge { saga_x: std::sync::Mutex<u8> }\n' >> "$sup_e"
+    local ffi_e="$fixt/ffi_e"
+    mkdir -p "$ffi_e"
+    printf 'pub fn start_tool_saga() {}\n' > "$ffi_e/exports.rs"
+
+    if run_check "$sup_e" "$ffi_e" "self-test(e)" "$tests_ok" >/dev/null 2>&1; then
+        printf '%sSELF-TEST FAILED (e)%s: a small-scalar Mutex wedge (`saga_x: Mutex<u8>`)\n' \
+            "$C_RED" "$C_RESET" >&2
+        printf 'slipped past the negative scan. The NEG type list is too narrow — cover\n' >&2
+        printf 'Mutex<u8|u16|u32|u64|usize> and the small atomics.\n' >&2
+        rc=1
+    fi
+
+    # ---- fixture (f): NEG signed-atomic bypass — `saga_x: AtomicI64` -> FAIL.
+    # A SIGNED atomic is the same instance-wide wedge as its unsigned twin: an
+    # in-set field name (`saga_x`) over a single instance-wide scalar counter.
+    # The old type list named only the UNSIGNED atomics, so `AtomicI64` (or any
+    # AtomicI8|I16|I32|I64|Isize) slipped through. Positives present + a fake FFI
+    # saga export so the negative/FFI-ordering clause is live.
+    local sup_f="$fixt/sup_f.rs"
+    emit_good_supervisor "$sup_f"
+    printf 'struct Wedge { saga_x: std::sync::atomic::AtomicI64 }\n' >> "$sup_f"
+    local ffi_f="$fixt/ffi_f"
+    mkdir -p "$ffi_f"
+    printf 'pub fn start_standing_saga() {}\n' > "$ffi_f/exports.rs"
+
+    if run_check "$sup_f" "$ffi_f" "self-test(f)" "$tests_ok" >/dev/null 2>&1; then
+        printf '%sSELF-TEST FAILED (f)%s: a signed-atomic wedge (`saga_x: AtomicI64`)\n' \
+            "$C_RED" "$C_RESET" >&2
+        printf 'slipped past the negative scan. The NEG type list named only the\n' >&2
+        printf 'UNSIGNED atomics — cover AtomicI8|I16|I32|I64|Isize too.\n' >&2
+        rc=1
+    fi
+
+    rm -rf "$fixt"
+    return "$rc"
+}
+
+# ---------------------------------------------------------------------------
+# Entry point
+# ---------------------------------------------------------------------------
+if [[ "${1:-}" == "--self-test" ]]; then
+    if self_test; then
+        printf '%sself-test:%s gate catches saga*/inflight-named instance-wide guards of\n' \
+            "$C_DIM" "$C_RESET"
+        printf '%s          %s atomic and small-scalar-Mutex types (+ FFI export), accepts\n' \
+            "$C_DIM" "$C_RESET"
+        printf '%s          %s correct per-set gating, and rejects no-gating-at-all.\n' \
+            "$C_DIM" "$C_RESET"
+        exit 0
+    fi
+    printf '%sThe saga-gating granularity gate is dead or mis-scoped — fix it.%s\n' \
+        "$C_RED" "$C_RESET" >&2
+    exit 1
+fi
+
+if run_check "$SUPERVISOR_REL" "$FFI_DIR" "scan"; then
+    printf '%sPASSED%s: saga concurrency is gated per-participant-context-set\n' \
+        "$C_GREEN" "$C_RESET"
+    printf '%s        %s (reserved_saga_contexts + saga_participant_context_set +\n' \
+        "$C_DIM" "$C_RESET"
+    printf '%s        %s overlap-reject), with no instance-wide saga guard. ADR-049 §3a.\n' \
+        "$C_DIM" "$C_RESET"
+    exit 0
+fi
+exit 1


### PR DESCRIPTION
**ADR-049 §3a Phase 2C, PR-2** — replaces the supervisor-wide `AtomicBool` saga guard with **per-participant-context-set gating**, the hard prerequisite §3a requires before any block-until-terminal `start_*_saga` FFI export ships. Stacked on #1806 (ContextMigration cut, merged).

## Behavior (spec §5.15.4 / §5.15.8)
- A saga reserves the **set of context-actors it spans** (`saga_participant_context_set`). Disjoint sets run **concurrently**; an overlapping set (shares ≥1 context) is rejected `SagaBusy`. One stuck saga no longer wedges the whole instance.
- **`NeedsRepair` releases the reservation** (RAII `SagaSetReservation` drops on every terminal — Committed/Aborted/NeedsRepair — and on panic-unwind), so a diverged saga can't deny unrelated contexts.
- **Canonical reservation key** = raw-digest hex. A shared `derive_standing_context_digest` helper backs both the `"standing-"`-prefixed registry id and the gating key, so a standing-pair saga and a cross-context/broadcast saga naming the same standing context **collide** (per §5.15.8 the saga form is the raw digest, not the prefixed display id).
- Adds `target_context_id` to `SagaInput::CrossContextToolInvocation` (the gating needs the real `{caller,target}` set; §6.2.4 requires the field).
- `std::sync::Mutex<HashSet<String>>` (the correct *synchronous* primitive — atomic check-and-reserve, provably never held across `.await`, panic-safe Drop release; narrowly-justified `#[allow(clippy::disallowed_types)]`).

## Mechanical CI gate (`scripts/check-saga-gating-granularity.sh`)
Granularity-keyed: **FAILS** if any instance-wide saga guard (any scalar `Atomic*`/`Semaphore`/`Mutex<scalar>`, any plausibly-saga name) coexists with saga dispatch, and **positively asserts** the per-set machinery is present (incl. no `"standing-"` key regression) and that the four proving integration tests exist. Self-testing (6 plant-and-catch fixtures, run before the real check in CI). Honest tripwire — the semantic proof lives in the named Rust tests; registered in the CLAUDE.md NEVER-WEAKEN list. The FFI-ordering clause is armed-but-vacuous until a `start_*_saga` export lands.

## Tests
Rewrote `actor_saga_concurrent.rs`: `disjoint_participant_sets_run_concurrently` (real negative control — fails under instance-wide gating), `overlapping_participant_sets_reject_busy`, `overlap_is_set_membership_across_saga_types` (cross-type collision — fails if the canonical-key fix is reverted), `needs_repair_releases_reservation` (drives a genuine NeedsRepair via a `cfg(testing)` force-fail variant), `same_set_sequential_rearm`.

## Deferred (documented forward obligations, unreachable today — all variants `NotImplemented`, no FFI saga surface)
- **Phase 2C**: authorize the initiator over each named context BEFORE reserving (else a malicious participant could reserve a victim's context).
- **PR-2D**: on startup replay, rebuild reservations for non-terminal entries (excluding NeedsRepair) and persist/rehydrate the full `{caller,target}` set.

Reviewed to double-zero across bug-catcher · black-hat · architecture · security · test-quality · alignment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Cross-layer exemptions
Both are internal SHA-256 context-id derivation helpers in `scp-runtime` (MLS keying + saga reservation keys). They are `pub` (not `pub(crate)`) solely because integration tests in `crates/scp-runtime/tests/` are separate compilation units that need them visible. Neither is SDK surface; `generate_standing_context_id` is pre-existing on main and has never been FFI-exported.

[cross-layer: pub-crate-visibility] derive_standing_context_digest
[cross-layer: pub-crate-visibility] generate_standing_context_id
