### PR TITLE
refactor(node): migrate all node-construction call sites to Node::start (ADR-052 Phase B-P2)

### DIFF
--- a/.docs/standards/construction.md
+++ b/.docs/standards/construction.md
@@ -45,12 +45,14 @@ A boolean parameter that selects between two named behaviors is a misuse-magnet:
 
 | Replace | With enum |
 |---|---|
-| `plaintext: bool` (site TLS) | `tls: TlsMode { SelfSigned, Acme { … }, Plaintext, Terminated }` |
+| `plaintext: bool` (site TLS) | `tls: TlsMode { SelfSigned, Acme { email: Option<String> }, Plaintext, Terminated }` |
 | `skip_nat: bool` + addressing flags | `reach: Reach { Domain{…}, NatTraversal, Tunnel{…}, Local }` |
 | `supports_bridge: bool` (relay) | `bridge: BridgeRole { Disabled, Enabled{…} }` (`Default = Disabled`) |
 | `in_memory: bool` (DHT publish) | `dht: DhtMode { Memory, Production{…} }` |
 
 Booleans that are genuinely binary state with no behavioral fork (e.g. `http3: bool` enabling an additional listener) are permitted, but the bar is high: if the choice has security or addressing consequences, it is an enum.
+
+The ACME contact email is optional: `TlsMode::Acme { email: None }` selects headless ACME (no contact email) — the legacy headless-server default for a domain node that sets no TLS options. `Some(e)` registers the ACME account with contact address `e`. The optionality changes no fail-safe property: ACME on any non-`Domain` reach is still a loud error regardless of the email.
 
 ### M2 — The security-critical choice is required or fail-safe-defaulted, never silently unsafe
 

--- a/crates/scp-ffi/common/src/server.rs
+++ b/crates/scp-ffi/common/src/server.rs
@@ -16,8 +16,8 @@ use scp_core::context::supervisor::Supervisor;
 use scp_identity::cache::SystemClock;
 use scp_identity::dht::DidDht;
 use scp_identity::{DidDocument, InMemoryDhtClient, ScpIdentity};
-use scp_node::NodeError;
-use scp_platform::testing::InMemoryStorage;
+use scp_node::{DhtMode, ExplicitIdentity, IdentitySource, Node, NodeConfig, NodeError, Reach};
+use scp_platform::testing::{InMemoryKeyCustody, InMemoryStorage};
 use scp_transport::native::server::{RelayConfig, RelayError, RelayServer, ShutdownHandle};
 use scp_transport::native::storage::{BlobStorageBackend, StorageError};
 use zeroize::Zeroizing;
@@ -301,17 +301,33 @@ pub async fn start_node_in_memory(
     let node = match identity {
         None => scp_node::ApplicationNode::dev(0).await?,
         Some(id) => {
-            use scp_node::{ApplicationNodeBuilder, SelfSignedTlsProvider};
-
-            ApplicationNodeBuilder::new()
-                .storage(InMemoryStorage::new())
-                .blob_storage(BlobStorageBackend::in_memory())
-                .domain("localhost")
-                .bind_addr(SocketAddr::from(([127, 0, 0, 1], 0)))
-                .tls_provider(Arc::new(SelfSignedTlsProvider::new("localhost")))
-                .identity(id.identity, id.document, id.did_method)
-                .build_for_testing()
-                .await?
+            // Migrated to the ADR-052 flat-config front door (Phase B-P2).
+            // The dropped explicit `SelfSignedTlsProvider::new("localhost")` is
+            // reproduced by the default `TlsMode::SelfSigned`. `Domain` is a
+            // publishing reach, so M2 requires `DhtMode::Production` (advisory
+            // in P1 — the in-memory DHT client publishes nothing).
+            Node::start_for_testing(NodeConfig {
+                bind_addr: Some(SocketAddr::from(([127, 0, 0, 1], 0))),
+                blob_storage: Some(BlobStorageBackend::in_memory()),
+                dht: DhtMode::Production,
+                ..NodeConfig::defaults(
+                    Reach::Domain {
+                        domain: "localhost".to_owned(),
+                    },
+                    // `Explicit` carries no custody, so `K` is unconstrained by
+                    // the variant; annotate it to the bridge's in-memory custody
+                    // type (matching `ApplicationNode::dev`'s `K`).
+                    IdentitySource::<InMemoryKeyCustody, ConcreteDidMethod>::Explicit(Box::new(
+                        ExplicitIdentity {
+                            identity: id.identity,
+                            document: id.document,
+                            did_method: id.did_method,
+                        },
+                    )),
+                    InMemoryStorage::new(),
+                )
+            })
+            .await?
         }
     };
 
@@ -369,7 +385,6 @@ pub async fn start_node_local(
     passphrase: Option<zeroize::Zeroizing<String>>,
 ) -> Result<scp_node::ApplicationNode<scp_platform::filesystem::FilesystemStorage>, ServerError> {
     use scp_identity::DidCache;
-    use scp_node::{ApplicationNodeBuilder, SelfSignedTlsProvider};
     use scp_platform::filesystem::FilesystemStorage;
 
     // Validate and ensure data directory exists.
@@ -395,20 +410,37 @@ pub async fn start_node_local(
     let storage = FilesystemStorage::new(&storage_dir)?;
     let blob_storage = BlobStorageBackend::redb(&blob_path)?;
 
-    // Build the node. The `.identity()` and `.identity_with_storage()` methods
-    // return different builder generic types, so we construct separate builder
-    // chains in each arm. The common builder prefix is duplicated because the
-    // storage values are moved into the builder.
+    // Build the node via the ADR-052 flat-config front door (Phase B-P2). The
+    // two identity arms differ only in their `IdentitySource`; the dropped
+    // explicit `SelfSignedTlsProvider::new("localhost")` is reproduced by the
+    // default `TlsMode::SelfSigned`. `Domain` is a publishing reach, so M2
+    // requires `DhtMode::Production` (advisory in P1 — the in-memory DHT client
+    // publishes nothing). The storage values are moved into the config, so the
+    // two arms each build their own config.
     let node = if let Some(id) = identity {
-        ApplicationNodeBuilder::new()
-            .storage(storage)
-            .blob_storage(blob_storage)
-            .domain("localhost")
-            .bind_addr(SocketAddr::from(([127, 0, 0, 1], 0)))
-            .tls_provider(Arc::new(SelfSignedTlsProvider::new("localhost")))
-            .identity(id.identity, id.document, id.did_method)
-            .build_for_testing()
-            .await?
+        Node::start_for_testing(NodeConfig {
+            bind_addr: Some(SocketAddr::from(([127, 0, 0, 1], 0))),
+            blob_storage: Some(blob_storage),
+            dht: DhtMode::Production,
+            ..NodeConfig::defaults(
+                Reach::Domain {
+                    domain: "localhost".to_owned(),
+                },
+                // `Explicit` carries no custody, so `K` is unconstrained by the
+                // variant; annotate it to the bridge's in-memory custody type
+                // (the persisted arm below uses `FileKeyCustody`, but the
+                // `Explicit` arm has no custody to derive `K` from).
+                IdentitySource::<InMemoryKeyCustody, ConcreteDidMethod>::Explicit(Box::new(
+                    ExplicitIdentity {
+                        identity: id.identity,
+                        document: id.document,
+                        did_method: id.did_method,
+                    },
+                )),
+                storage,
+            )
+        })
+        .await?
     } else {
         // Persistent key custody — keys survive process restarts.
         let passphrase = passphrase.ok_or(ServerError::MissingPassphrase)?;
@@ -425,15 +457,22 @@ pub async fn start_node_local(
             dht_client, cache, sign_fn,
         ));
 
-        ApplicationNodeBuilder::new()
-            .storage(storage)
-            .blob_storage(blob_storage)
-            .domain("localhost")
-            .bind_addr(SocketAddr::from(([127, 0, 0, 1], 0)))
-            .tls_provider(Arc::new(SelfSignedTlsProvider::new("localhost")))
-            .identity_with_storage(key_custody, did_method)
-            .build_for_testing()
-            .await?
+        Node::start_for_testing(NodeConfig {
+            bind_addr: Some(SocketAddr::from(([127, 0, 0, 1], 0))),
+            blob_storage: Some(blob_storage),
+            dht: DhtMode::Production,
+            ..NodeConfig::defaults(
+                Reach::Domain {
+                    domain: "localhost".to_owned(),
+                },
+                IdentitySource::Persisted {
+                    custody: key_custody,
+                    did_method,
+                },
+                storage,
+            )
+        })
+        .await?
     };
 
     tracing::info!(

--- a/crates/scp-node/src/config.rs
+++ b/crates/scp-node/src/config.rs
@@ -150,7 +150,11 @@ pub enum TlsMode {
     /// Provision a Let's Encrypt certificate via ACME for the reach's domain.
     Acme {
         /// Contact email for the ACME account registration.
-        email: String,
+        ///
+        /// Optional: `None` selects headless ACME (no contact email), the
+        /// legacy default for a domain node that sets no TLS options. `Some(e)`
+        /// registers the ACME account with the contact address `e`.
+        email: Option<String>,
     },
     /// Serve plaintext (no node-side TLS). Only valid on a non-`Domain` reach;
     /// `Reach::Domain` + `TlsMode::Plaintext` is a loud configuration error.
@@ -227,7 +231,7 @@ pub enum NatSlot {
 /// ```ignore
 /// let node = Node::start(NodeConfig {
 ///     dht: DhtMode::Production,
-///     tls: TlsMode::Acme { email: "admin@example.com".into() },
+///     tls: TlsMode::Acme { email: Some("admin@example.com".into()) },
 ///     ..NodeConfig::defaults(
 ///         Reach::Domain { domain: "example.com".into() },
 ///         IdentitySource::Generate { custody, did_method },
@@ -612,7 +616,15 @@ where
                 builder
             }
         }
-        TlsMode::Acme { email } => builder.acme_email(&email),
+        TlsMode::Acme { email } => match email {
+            // `Some(e)` registers the ACME account with contact email `e`.
+            Some(e) => builder.acme_email(&e),
+            // `None` applies no email setter: the builder's domain `build()`
+            // falls through to the default `AcmeProvider::new(domain)` with no
+            // contact email — the legacy headless-ACME default, reproduced
+            // exactly.
+            None => builder,
+        },
         TlsMode::Terminated => {
             if let Reach::Domain { domain } = reach {
                 // Domain + Terminated: install a no-network self-signed provider
@@ -1210,7 +1222,7 @@ mod tests {
         // M4: override one field while spreading defaults from separate values.
         let config = NodeConfig {
             tls: TlsMode::Acme {
-                email: "spread@example.com".to_owned(),
+                email: Some("spread@example.com".to_owned()),
             },
             ..NodeConfig::defaults(Reach::Local, generate_identity(), InMemoryStorage::new())
         };
@@ -1626,7 +1638,7 @@ mod tests {
         // strategy is needed.
         let result = Node::start_for_testing(NodeConfig {
             tls: TlsMode::Acme {
-                email: "admin@example.com".to_owned(),
+                email: Some("admin@example.com".to_owned()),
             },
             ..NodeConfig::defaults(Reach::Local, generate_identity(), InMemoryStorage::new())
         })
@@ -1665,7 +1677,7 @@ mod tests {
         ] {
             let result = Node::start_for_testing(NodeConfig {
                 tls: TlsMode::Acme {
-                    email: "admin@example.com".to_owned(),
+                    email: Some("admin@example.com".to_owned()),
                 },
                 ..NodeConfig::defaults(reach, generate_identity(), InMemoryStorage::new())
             })
@@ -1686,6 +1698,26 @@ mod tests {
                 "Acme×{reach_name} error must name the contradiction, got: {err}"
             );
         }
+    }
+
+    // --- Test: Acme { email: None } on a Domain reach is accepted (headless) ---
+
+    #[test]
+    fn acme_with_none_email_on_domain_is_accepted() {
+        // `TlsMode::Acme { email: None }` selects headless ACME — the legacy
+        // default for a domain node that sets no TLS options (the builder's
+        // domain `build()` falls through to `AcmeProvider::new(domain)` with no
+        // contact email). It must be a VALID config on a `Reach::Domain`
+        // (publishing) reach paired with `DhtMode::Production` — no loud error.
+        // We assert at the `validate_config` layer rather than building, because
+        // a real ACME provision would contact Let's Encrypt over the network;
+        // validation is the observable acceptance gate before any provisioning.
+        let reach = Reach::Domain {
+            domain: "config-acme-headless.example.com".to_owned(),
+        };
+        let tls = TlsMode::Acme { email: None };
+        validate_config(&reach, &tls, DhtMode::Production)
+            .expect("Domain + Acme { email: None } + Production must be a valid config");
     }
 
     // --- Test 21: Plaintext / Terminated on a non-Domain reach are no-op builds

--- a/crates/scp-node/src/config.rs
+++ b/crates/scp-node/src/config.rs
@@ -141,6 +141,14 @@ pub enum Reach {
 // ---------------------------------------------------------------------------
 
 /// How the node provisions TLS for its public listener (ADR-052 M1).
+///
+/// `TlsMode` is a **closed** selector: it exposes a fixed set of provisioning
+/// strategies and has no variant for injecting an arbitrary
+/// `Arc<dyn TlsProvider>`. This asymmetry with [`NatSlot`] — which intentionally
+/// offers a [`Custom`](NatSlot::Custom) open slot — is deliberate, per
+/// construction.md's "providers stay typed enum-selectors, never `dyn`" rule:
+/// TLS provisioning is fully covered by the variants below, so the type itself
+/// signals that callers select a strategy rather than supply their own.
 #[derive(Debug, Clone)]
 pub enum TlsMode {
     /// Generate and serve a self-signed certificate for the reach's domain.

--- a/crates/scp-node/src/lib.rs
+++ b/crates/scp-node/src/lib.rs
@@ -1520,14 +1520,27 @@ impl ApplicationNode<scp_platform::testing::InMemoryStorage> {
             dht_client, cache, sign_fn,
         ));
 
-        ApplicationNodeBuilder::new()
-            .storage(InMemoryStorage::new())
-            .domain("localhost")
-            .bind_addr(std::net::SocketAddr::from(([127, 0, 0, 1], port)))
-            .tls_provider(Arc::new(SelfSignedTlsProvider::new("localhost")))
-            .generate_identity_with(custody, did_method)
-            .build_for_testing()
-            .await
+        // Migrated to the ADR-052 flat-config front door (Phase B-P2). The
+        // dropped `.tls_provider(SelfSignedTlsProvider::new("localhost"))` is
+        // reproduced by the default `TlsMode::SelfSigned`, which installs a
+        // byte-identical self-signed provider for the `Domain` reach. `Domain`
+        // is a publishing reach, so M2 requires `DhtMode::Production`
+        // (advisory in P1 — the in-memory DHT client publishes nothing).
+        Node::start_for_testing(NodeConfig {
+            bind_addr: Some(SocketAddr::from(([127, 0, 0, 1], port))),
+            dht: DhtMode::Production,
+            ..NodeConfig::defaults(
+                Reach::Domain {
+                    domain: "localhost".to_owned(),
+                },
+                IdentitySource::Generate {
+                    custody,
+                    did_method,
+                },
+                InMemoryStorage::new(),
+            )
+        })
+        .await
     }
 }
 

--- a/crates/scp-node/src/main.rs
+++ b/crates/scp-node/src/main.rs
@@ -19,7 +19,6 @@
 use std::env;
 use std::net::SocketAddr;
 use std::path::PathBuf;
-use std::pin::Pin;
 use std::sync::Arc;
 
 use zeroize::Zeroizing;
@@ -27,7 +26,7 @@ use zeroize::Zeroizing;
 use scp_identity::cache::SystemClock;
 use scp_identity::dht::SequenceStore;
 use scp_identity::{DidCache, DidDht, InMemoryDhtClient, InMemorySequenceStore};
-use scp_node::{ApplicationNodeBuilder, TlsProvider};
+use scp_node::{DhtMode, IdentitySource, Node, NodeConfig, Reach, TlsMode};
 use scp_platform::EncryptedStorage;
 use scp_platform::sqlite::{SqliteKeyCustody, SqliteStorage};
 use scp_platform::testing::{InMemoryKeyCustody, InMemoryStorage};
@@ -245,33 +244,6 @@ fn resolve_storage_key_or_exit(storage_dir: &std::path::Path) -> Zeroizing<[u8; 
 // ---------------------------------------------------------------------------
 
 // `relay_config_from_env` is provided by `scp_transport::startup::relay_config_from_env`.
-
-// ---------------------------------------------------------------------------
-// Self-signed TLS provider (development mode)
-// ---------------------------------------------------------------------------
-
-/// TLS provider that generates a self-signed certificate for development.
-///
-/// Activated by `SCP_NODE_TLS_SELF_SIGNED=1`. NOT for production use.
-struct SelfSignedTlsProvider {
-    domain: String,
-}
-
-impl TlsProvider for SelfSignedTlsProvider {
-    fn provision(
-        &self,
-    ) -> Pin<
-        Box<
-            dyn std::future::Future<
-                    Output = Result<scp_node::tls::CertificateData, scp_node::tls::TlsError>,
-                > + Send
-                + '_,
-        >,
-    > {
-        let domain = self.domain.clone();
-        Box::pin(async move { scp_node::tls::generate_self_signed(&domain) })
-    }
-}
 
 // ---------------------------------------------------------------------------
 // Health check + shutdown signal
@@ -835,17 +807,21 @@ async fn run_node_with<
         scp_node::DEFAULT_PROJECTION_RATE_LIMIT,
     );
 
-    let mut builder = ApplicationNodeBuilder::new()
-        .storage(storage)
-        .domain(&domain)
-        .generate_identity_with(custody, did_method)
-        .bind_addr(SocketAddr::from(([127, 0, 0, 1], 0)))
-        .http_bind_addr(http_addr)
-        .projection_rate_limit(projection_rate);
-
-    if use_dns_provider {
+    // Decide TLS + DNS provider from the two env booleans BEFORE building the
+    // config (ADR-052 Phase B-P2). The three TLS arms map exactly onto the
+    // legacy builder branches:
+    //   - DNS provider on  → headless ACME (`Acme { email: None }`) + a DNS
+    //     subdomain provider. The legacy default supplied no `acme_email`, so
+    //     `None` reproduces it; the DNS provider overrides TLS during build()
+    //     after identity resolution, exactly as before.
+    //   - self-signed       → `TlsMode::SelfSigned` (the same self-signed cert
+    //     the dropped local `SelfSignedTlsProvider` produced).
+    //   - neither           → headless ACME (`Acme { email: None }`), the
+    //     legacy default that falls through to `AcmeProvider::new(domain)` with
+    //     no contact email.
+    let (tls, dns_provider) = if use_dns_provider {
         // DNS subdomain provider: derive domain from DID, register with DNS
-        // API for zero-config TLS (#642). The domain set above is overridden
+        // API for zero-config TLS (#642). The configured domain is overridden
         // during build() after identity resolution.
         let public_ip: std::net::IpAddr = env::var("SCP_NODE_PUBLIC_IP")
             .unwrap_or_else(|_| {
@@ -873,15 +849,39 @@ async fn run_node_with<
             port = port,
             "using DNS subdomain provider for zero-config TLS"
         );
-        builder = builder.dns_provider(dns_config);
+        (TlsMode::Acme { email: None }, Some(dns_config))
     } else if use_self_signed {
         tracing::info!(domain = %domain, "using self-signed TLS certificate (development mode)");
-        builder = builder.tls_provider(Arc::new(SelfSignedTlsProvider {
-            domain: domain.clone(),
-        }));
-    }
+        (TlsMode::SelfSigned, None)
+    } else {
+        // Legacy headless-ACME default (no contact email).
+        (TlsMode::Acme { email: None }, None)
+    };
 
-    let node = match builder.build().await {
+    // `Domain` is a publishing reach, so M2 requires `DhtMode::Production`
+    // (advisory in P1 — dropped before lowering, so no runtime behavior
+    // change). `run_node_with` is generic over `S: EncryptedStorage`, so the
+    // production `Node::start` (not `start_for_testing`) is the correct entry.
+    let node = match Node::start(NodeConfig {
+        tls,
+        dns_provider,
+        dht: DhtMode::Production,
+        bind_addr: Some(SocketAddr::from(([127, 0, 0, 1], 0))),
+        http_bind_addr: Some(http_addr),
+        projection_rate_limit: Some(projection_rate),
+        ..NodeConfig::defaults(
+            Reach::Domain {
+                domain: domain.clone(),
+            },
+            IdentitySource::Generate {
+                custody,
+                did_method,
+            },
+            storage,
+        )
+    })
+    .await
+    {
         Ok(n) => n,
         Err(e) => {
             tracing::error!(error = %e, "application node failed to build");

--- a/crates/scp-node/src/self_host.rs
+++ b/crates/scp-node/src/self_host.rs
@@ -41,7 +41,8 @@ use scp_platform::KeyCustody;
 use scp_platform::sqlite::{SqliteKeyCustody, SqliteStorage};
 use scp_platform::traits::Storage;
 
-use crate::{ApplicationNode, ApplicationNodeBuilder, PublicSurface, projection};
+use crate::config::{IdentitySource, NatSlot, Node, NodeConfig, Reach};
+use crate::{ApplicationNode, PublicSurface, projection};
 
 /// A single static asset to publish: HTTP path, content type, and body bytes.
 ///
@@ -1678,57 +1679,66 @@ async fn build_host_site_node<D: scp_identity::DidMethod + 'static>(
             ))
         })?;
 
-    // -- NAT strategy with RETAINED mapper handles for clean teardown. When
-    //    `skip_nat`, no mapper is constructed and the builder skips the probe. --
-    #[cfg(feature = "upnp")]
-    let (nat_strategy, upnp_mapper, natpmp_mapper): (
-        Option<Arc<dyn crate::NatStrategy>>,
-        OptionalPortMapper,
-        OptionalPortMapper,
-    ) = if skip_nat {
-        (None, None, None)
+    // -- Reach + DHT from `skip_nat`. A `skip_nat` host reaches only locally
+    //    (non-publishing → DhtMode::Memory); otherwise it NAT-traverses and
+    //    publishes a routable address (DhtMode::Production, M2). --
+    let (reach, dht) = if skip_nat {
+        (Reach::Local, DhtMode::Memory)
     } else {
-        let upnp: Arc<dyn scp_transport::nat::PortMapper> =
-            Arc::new(scp_transport::nat::UpnpPortMapper::new());
-        let natpmp: Arc<dyn scp_transport::nat::PortMapper> =
-            Arc::new(scp_transport::nat::NatPmpPortMapper::new());
-        let strategy = crate::DefaultNatStrategy::new(None, None)
-            .with_port_mapper(Arc::clone(&upnp))
-            .with_fallback_mapper(Arc::clone(&natpmp));
-        (
-            Some(Arc::new(strategy) as Arc<dyn crate::NatStrategy>),
-            Some(upnp),
-            Some(natpmp),
+        (Reach::NatTraversal, DhtMode::Production)
+    };
+
+    // -- NAT slot with RETAINED mapper handles for clean teardown. When
+    //    `skip_nat`, no mapper is constructed and the reach skips the probe;
+    //    `NatSlot::Auto` is correct there. When NOT `skip_nat` (upnp build),
+    //    `NatSlot::Custom(strategy)` carries the strategy and we KEEP the mapper
+    //    handles for teardown — `NatSlot::Auto` would lose them. --
+    #[cfg(feature = "upnp")]
+    let (nat, upnp_mapper, natpmp_mapper): (NatSlot, OptionalPortMapper, OptionalPortMapper) =
+        if skip_nat {
+            (NatSlot::Auto, None, None)
+        } else {
+            let upnp: Arc<dyn scp_transport::nat::PortMapper> =
+                Arc::new(scp_transport::nat::UpnpPortMapper::new());
+            let natpmp: Arc<dyn scp_transport::nat::PortMapper> =
+                Arc::new(scp_transport::nat::NatPmpPortMapper::new());
+            let strategy = crate::DefaultNatStrategy::new(None, None)
+                .with_port_mapper(Arc::clone(&upnp))
+                .with_fallback_mapper(Arc::clone(&natpmp));
+            (
+                NatSlot::Custom(Arc::new(strategy) as Arc<dyn crate::NatStrategy>),
+                Some(upnp),
+                Some(natpmp),
+            )
+        };
+    #[cfg(not(feature = "upnp"))]
+    let (nat, upnp_mapper, natpmp_mapper): (NatSlot, OptionalPortMapper, OptionalPortMapper) =
+        (NatSlot::Auto, None, None);
+
+    // `IdentitySource::Persisted` gives the self-host node a STABLE DID across
+    // restarts: it creates+persists the identity on first boot and reloads it
+    // thereafter from the root `node_storage`. `tls` defaults to
+    // `TlsMode::SelfSigned`, a no-op on a no-domain reach.
+    let config = NodeConfig {
+        dht,
+        nat,
+        http_bind_addr: Some(http_addr),
+        projection_rate_limit: Some(projection_rate_limit),
+        blob_storage: Some(blob_storage),
+        ..NodeConfig::defaults(
+            reach,
+            IdentitySource::Persisted {
+                custody,
+                did_method,
+            },
+            node_storage,
         )
     };
-    #[cfg(not(feature = "upnp"))]
-    let (upnp_mapper, natpmp_mapper): (OptionalPortMapper, OptionalPortMapper) = (None, None);
 
-    // `identity_with_storage` gives the self-host node a STABLE DID across
-    // restarts: it creates+persists the identity on first boot and reloads it
-    // thereafter from the root `node_storage`.
-    let builder = ApplicationNodeBuilder::new()
-        .storage(node_storage)
-        .blob_storage(blob_storage)
-        .identity_with_storage(custody, did_method)
-        .no_domain()
-        .http_bind_addr(http_addr)
-        .projection_rate_limit(projection_rate_limit);
-    #[cfg(feature = "upnp")]
-    let builder = match nat_strategy {
-        Some(strategy) => builder.nat_strategy(strategy),
-        None => builder,
-    };
-    let builder = if skip_nat {
-        builder.skip_nat_probe()
-    } else {
-        builder
-    };
-
-    match builder.build().await {
+    match Node::start(config).await {
         Ok(n) => Ok((Arc::new(n), upnp_mapper, natpmp_mapper)),
         Err(e) => {
-            // `build()` establishes the inbound port mapping during NAT tier
+            // `Node::start` establishes the inbound port mapping during NAT tier
             // selection and CAN still fail afterward, so release best-effort.
             release_self_host_mappings(upnp_mapper, natpmp_mapper, http_addr.port()).await;
             Err(HostSiteError::NodeBuild(e.to_string()))

--- a/crates/scp-node/tests/integration.rs
+++ b/crates/scp-node/tests/integration.rs
@@ -24,7 +24,7 @@ use scp_identity::cache::SystemClock;
 use scp_identity::dht::DidDht;
 use scp_identity::dht_client::InMemoryDhtClient;
 use scp_identity::{DidCache, DidMethod};
-use scp_node::{ApplicationNodeBuilder, TlsProvider};
+use scp_node::{DhtMode, IdentitySource, Node, NodeConfig, Reach};
 use scp_platform::testing::{InMemoryKeyCustody, InMemoryStorage};
 use scp_transport::native::protocol::{ClientMessage, RelayMessage};
 use tokio_tungstenite::tungstenite::client::IntoClientRequest;
@@ -44,29 +44,6 @@ fn relay_request(
             .expect("valid header value"),
     );
     request
-}
-
-/// Mock TLS provider that succeeds with a self-signed certificate.
-///
-/// Used in integration tests to avoid contacting a real ACME server.
-struct SucceedingTlsProvider {
-    domain: String,
-}
-
-impl TlsProvider for SucceedingTlsProvider {
-    fn provision(
-        &self,
-    ) -> std::pin::Pin<
-        Box<
-            dyn std::future::Future<
-                    Output = Result<scp_node::tls::CertificateData, scp_node::tls::TlsError>,
-                > + Send
-                + '_,
-        >,
-    > {
-        let domain = self.domain.clone();
-        Box::pin(async move { scp_node::tls::generate_self_signed(&domain) })
-    }
 }
 
 /// Concrete `DidDht` type used in tests (in-memory DHT and system clock).
@@ -93,17 +70,26 @@ async fn build_test_node() -> (
     let custody = Arc::new(InMemoryKeyCustody::new());
     let (dht_client, did_dht) = make_shared_dht(&custody);
 
-    let node = ApplicationNodeBuilder::new()
-        .storage(InMemoryStorage::new())
-        .domain("test.example.com")
-        .tls_provider(Arc::new(SucceedingTlsProvider {
-            domain: "test.example.com".to_owned(),
-        }))
-        .generate_identity_with(custody, Arc::new(did_dht))
-        .bind_addr(SocketAddr::from(([127, 0, 0, 1], 0)))
-        .build_for_testing()
-        .await
-        .expect("ApplicationNode should build successfully");
+    // Default `TlsMode::SelfSigned` reproduces the dropped local
+    // `SucceedingTlsProvider` (both generate a self-signed cert for the domain).
+    // `Domain` is a publishing reach → `DhtMode::Production` (M2; advisory in P1
+    // — the in-memory DHT client publishes nothing).
+    let node = Node::start_for_testing(NodeConfig {
+        bind_addr: Some(SocketAddr::from(([127, 0, 0, 1], 0))),
+        dht: DhtMode::Production,
+        ..NodeConfig::defaults(
+            Reach::Domain {
+                domain: "test.example.com".to_owned(),
+            },
+            IdentitySource::Generate {
+                custody,
+                did_method: Arc::new(did_dht),
+            },
+            InMemoryStorage::new(),
+        )
+    })
+    .await
+    .expect("ApplicationNode should build successfully");
 
     (node, dht_client)
 }
@@ -469,18 +455,26 @@ async fn build_test_node_with_dev_api() -> (
     let custody = Arc::new(InMemoryKeyCustody::new());
     let (dht_client, did_dht) = make_shared_dht(&custody);
 
-    let node = ApplicationNodeBuilder::new()
-        .storage(InMemoryStorage::new())
-        .domain("test.example.com")
-        .tls_provider(Arc::new(SucceedingTlsProvider {
-            domain: "test.example.com".to_owned(),
-        }))
-        .generate_identity_with(custody, Arc::new(did_dht))
-        .bind_addr(SocketAddr::from(([127, 0, 0, 1], 0)))
-        .local_api(SocketAddr::from(([127, 0, 0, 1], 0)))
-        .build_for_testing()
-        .await
-        .expect("ApplicationNode with dev API should build successfully");
+    // Same as `build_test_node` plus the dev API on an OS-assigned port
+    // (`local_api`). Default `TlsMode::SelfSigned` reproduces the dropped
+    // `SucceedingTlsProvider`; `Domain` → `DhtMode::Production` (M2).
+    let node = Node::start_for_testing(NodeConfig {
+        bind_addr: Some(SocketAddr::from(([127, 0, 0, 1], 0))),
+        local_api: Some(SocketAddr::from(([127, 0, 0, 1], 0))),
+        dht: DhtMode::Production,
+        ..NodeConfig::defaults(
+            Reach::Domain {
+                domain: "test.example.com".to_owned(),
+            },
+            IdentitySource::Generate {
+                custody,
+                did_method: Arc::new(did_dht),
+            },
+            InMemoryStorage::new(),
+        )
+    })
+    .await
+    .expect("ApplicationNode with dev API should build successfully");
 
     (node, dht_client)
 }

--- a/crates/scp-node/tests/integration.rs
+++ b/crates/scp-node/tests/integration.rs
@@ -61,21 +61,29 @@ fn make_shared_dht(custody: &Arc<InMemoryKeyCustody>) -> (Arc<InMemoryDhtClient>
     (dht_client, did_dht)
 }
 
-/// Helper: builds an `ApplicationNode` and returns it along with the shared
-/// DHT client (for client-side resolution tests).
-async fn build_test_node() -> (
+/// Shared `ApplicationNode` constructor for the integration tests.
+///
+/// The only axis the test nodes vary on is `local_api` (the dev API listener):
+/// the public-server tests leave it `None`, while the dev-API test enables it on
+/// an OS-assigned port. Everything else is identical, so both entry points
+/// delegate here.
+///
+/// Default `TlsMode::SelfSigned` reproduces the dropped local
+/// `SucceedingTlsProvider` (both generate a self-signed cert for the domain).
+/// `Domain` is a publishing reach → `DhtMode::Production` (M2; advisory in P1
+/// — the in-memory DHT client publishes nothing).
+async fn build_test_node_with(
+    local_api: Option<SocketAddr>,
+) -> (
     scp_node::ApplicationNode<InMemoryStorage>,
     Arc<InMemoryDhtClient>,
 ) {
     let custody = Arc::new(InMemoryKeyCustody::new());
     let (dht_client, did_dht) = make_shared_dht(&custody);
 
-    // Default `TlsMode::SelfSigned` reproduces the dropped local
-    // `SucceedingTlsProvider` (both generate a self-signed cert for the domain).
-    // `Domain` is a publishing reach → `DhtMode::Production` (M2; advisory in P1
-    // — the in-memory DHT client publishes nothing).
     let node = Node::start_for_testing(NodeConfig {
         bind_addr: Some(SocketAddr::from(([127, 0, 0, 1], 0))),
+        local_api,
         dht: DhtMode::Production,
         ..NodeConfig::defaults(
             Reach::Domain {
@@ -92,6 +100,15 @@ async fn build_test_node() -> (
     .expect("ApplicationNode should build successfully");
 
     (node, dht_client)
+}
+
+/// Helper: builds an `ApplicationNode` and returns it along with the shared
+/// DHT client (for client-side resolution tests).
+async fn build_test_node() -> (
+    scp_node::ApplicationNode<InMemoryStorage>,
+    Arc<InMemoryDhtClient>,
+) {
+    build_test_node_with(None).await
 }
 
 // =========================================================================
@@ -452,31 +469,7 @@ async fn build_test_node_with_dev_api() -> (
     scp_node::ApplicationNode<InMemoryStorage>,
     Arc<InMemoryDhtClient>,
 ) {
-    let custody = Arc::new(InMemoryKeyCustody::new());
-    let (dht_client, did_dht) = make_shared_dht(&custody);
-
-    // Same as `build_test_node` plus the dev API on an OS-assigned port
-    // (`local_api`). Default `TlsMode::SelfSigned` reproduces the dropped
-    // `SucceedingTlsProvider`; `Domain` → `DhtMode::Production` (M2).
-    let node = Node::start_for_testing(NodeConfig {
-        bind_addr: Some(SocketAddr::from(([127, 0, 0, 1], 0))),
-        local_api: Some(SocketAddr::from(([127, 0, 0, 1], 0))),
-        dht: DhtMode::Production,
-        ..NodeConfig::defaults(
-            Reach::Domain {
-                domain: "test.example.com".to_owned(),
-            },
-            IdentitySource::Generate {
-                custody,
-                did_method: Arc::new(did_dht),
-            },
-            InMemoryStorage::new(),
-        )
-    })
-    .await
-    .expect("ApplicationNode with dev API should build successfully");
-
-    (node, dht_client)
+    build_test_node_with(Some(SocketAddr::from(([127, 0, 0, 1], 0)))).await
 }
 
 /// Sends a raw HTTP/1.1 request to `addr` and returns the full response as a string.

--- a/crates/scp-node/tests/quic_cross_transport.rs
+++ b/crates/scp-node/tests/quic_cross_transport.rs
@@ -33,7 +33,7 @@ use scp_identity::DidCache;
 use scp_identity::InMemoryDhtClient;
 use scp_identity::cache::SystemClock;
 use scp_identity::dht::DidDht;
-use scp_node::{ApplicationNode, ApplicationNodeBuilder, SelfSignedTlsProvider};
+use scp_node::{ApplicationNode, DhtMode, IdentitySource, Node, NodeConfig, Reach};
 use scp_platform::testing::{InMemoryKeyCustody, InMemoryStorage};
 
 type TestDidDht = DidDht<InMemoryDhtClient, SystemClock>;
@@ -403,15 +403,25 @@ async fn build_tls_node(http_port: u16) -> ApplicationNode<InMemoryStorage> {
         dht_client, cache, sign_fn,
     ));
 
-    ApplicationNodeBuilder::new()
-        .storage(InMemoryStorage::new())
-        .domain("localhost")
-        .http_bind_addr(SocketAddr::from(([127, 0, 0, 1], http_port)))
-        .tls_provider(Arc::new(SelfSignedTlsProvider::new("localhost")))
-        .generate_identity_with(custody, did_method)
-        .build_for_testing()
-        .await
-        .expect("node build should succeed")
+    // Default `TlsMode::SelfSigned` reproduces the dropped explicit
+    // `SelfSignedTlsProvider::new("localhost")` (so a QUIC server config is
+    // provisioned). `Domain` → `DhtMode::Production` (M2; advisory in P1).
+    Node::start_for_testing(NodeConfig {
+        http_bind_addr: Some(SocketAddr::from(([127, 0, 0, 1], http_port))),
+        dht: DhtMode::Production,
+        ..NodeConfig::defaults(
+            Reach::Domain {
+                domain: "localhost".to_owned(),
+            },
+            IdentitySource::Generate {
+                custody,
+                did_method,
+            },
+            InMemoryStorage::new(),
+        )
+    })
+    .await
+    .expect("node build should succeed")
 }
 
 // ---------------------------------------------------------------------------

--- a/crates/scp-node/tests/quic_listener.rs
+++ b/crates/scp-node/tests/quic_listener.rs
@@ -26,7 +26,7 @@ use scp_identity::DidCache;
 use scp_identity::InMemoryDhtClient;
 use scp_identity::cache::SystemClock;
 use scp_identity::dht::DidDht;
-use scp_node::{ApplicationNode, ApplicationNodeBuilder, SelfSignedTlsProvider};
+use scp_node::{ApplicationNode, DhtMode, IdentitySource, Node, NodeConfig, Reach};
 use scp_platform::testing::{InMemoryKeyCustody, InMemoryStorage};
 
 type TestDidDht = DidDht<InMemoryDhtClient, SystemClock>;
@@ -130,15 +130,25 @@ async fn build_tls_node(http_port: u16) -> ApplicationNode<InMemoryStorage> {
         dht_client, cache, sign_fn,
     ));
 
-    ApplicationNodeBuilder::new()
-        .storage(InMemoryStorage::new())
-        .domain("localhost")
-        .http_bind_addr(SocketAddr::from(([127, 0, 0, 1], http_port)))
-        .tls_provider(Arc::new(SelfSignedTlsProvider::new("localhost")))
-        .generate_identity_with(custody, did_method)
-        .build_for_testing()
-        .await
-        .expect("node build should succeed")
+    // Default `TlsMode::SelfSigned` reproduces the dropped explicit
+    // `SelfSignedTlsProvider::new("localhost")` (so a QUIC server config is
+    // provisioned). `Domain` → `DhtMode::Production` (M2; advisory in P1).
+    Node::start_for_testing(NodeConfig {
+        http_bind_addr: Some(SocketAddr::from(([127, 0, 0, 1], http_port))),
+        dht: DhtMode::Production,
+        ..NodeConfig::defaults(
+            Reach::Domain {
+                domain: "localhost".to_owned(),
+            },
+            IdentitySource::Generate {
+                custody,
+                did_method,
+            },
+            InMemoryStorage::new(),
+        )
+    })
+    .await
+    .expect("node build should succeed")
 }
 
 /// Connects a QUIC client to `addr`, retrying until the listener is accepting

--- a/crates/scp-node/tests/self_host.rs
+++ b/crates/scp-node/tests/self_host.rs
@@ -40,8 +40,8 @@ use scp_identity::cache::SystemClock;
 use scp_identity::dht::DidDht;
 use scp_identity::dht_client::InMemoryDhtClient;
 use scp_node::{
-    ApplicationNode, ApplicationNodeBuilder, DeploySiteParams, NatStrategy, NodeError,
-    ReachabilityTier,
+    ApplicationNode, DeploySiteParams, DhtMode, IdentitySource, NatSlot, NatStrategy, Node,
+    NodeConfig, NodeError, Reach, ReachabilityTier,
 };
 use scp_platform::Storage;
 use scp_platform::sqlite::{SqliteKeyCustody, SqliteStorage};
@@ -133,18 +133,27 @@ async fn build_self_host_node() -> BuiltNode {
         scp_transport::native::storage::BlobStorageBackend::sqlite(&storage_dir.join("blobs"))
             .expect("sqlite blob storage should open");
 
-    // `.build()` requires `S: EncryptedStorage`, satisfied by `SqliteStorage`.
-    let node = ApplicationNodeBuilder::new()
-        .storage(node_storage)
-        .blob_storage(blob_storage)
-        .no_domain()
-        .nat_strategy(Arc::new(FixedTierNatStrategy))
-        .generate_identity_with(custody.clone(), did_method)
-        .bind_addr(SocketAddr::from(([127, 0, 0, 1], 0)))
-        .http_bind_addr(SocketAddr::from(([127, 0, 0, 1], 0)))
-        .build()
-        .await
-        .expect("no-domain node should build over encrypted SQLite storage");
+    // `Node::start` requires `S: EncryptedStorage`, satisfied by `SqliteStorage`.
+    // `NatTraversal` (no_domain) is a publishing reach → `DhtMode::Production`
+    // (M2; advisory in P1). The `FixedTierNatStrategy` is supplied via
+    // `NatSlot::Custom`.
+    let node = Node::start(NodeConfig {
+        nat: NatSlot::Custom(Arc::new(FixedTierNatStrategy)),
+        dht: DhtMode::Production,
+        bind_addr: Some(SocketAddr::from(([127, 0, 0, 1], 0))),
+        http_bind_addr: Some(SocketAddr::from(([127, 0, 0, 1], 0))),
+        blob_storage: Some(blob_storage),
+        ..NodeConfig::defaults(
+            Reach::NatTraversal,
+            IdentitySource::Generate {
+                custody: custody.clone(),
+                did_method,
+            },
+            node_storage,
+        )
+    })
+    .await
+    .expect("no-domain node should build over encrypted SQLite storage");
 
     assert!(
         node.identity().did().starts_with("did:dht:"),
@@ -747,20 +756,26 @@ async fn self_host_shares_single_root_storage_handle_and_serves() {
     //    as the fixed `build_self_host_node` does. `Arc<SqliteStorage>` implements
     //    `EncryptedStorage`, so the builder accepts it. This must NOT trip the
     //    advisory-lock conflict because there is only ONE underlying handle. --
-    let node = ApplicationNodeBuilder::new()
-        .storage(Arc::clone(&root_storage))
-        .blob_storage(blob_storage)
-        .no_domain()
-        .nat_strategy(Arc::new(FixedTierNatStrategy))
-        .generate_identity_with(custody.clone(), did_method)
-        .bind_addr(SocketAddr::from(([127, 0, 0, 1], 0)))
-        .http_bind_addr(SocketAddr::from(([127, 0, 0, 1], 0)))
-        .build()
-        .await
-        .expect(
-            "the node must build over the SHARED root storage handle without a \
-             lock conflict (os error 35)",
-        );
+    let node = Node::start(NodeConfig {
+        nat: NatSlot::Custom(Arc::new(FixedTierNatStrategy)),
+        dht: DhtMode::Production,
+        bind_addr: Some(SocketAddr::from(([127, 0, 0, 1], 0))),
+        http_bind_addr: Some(SocketAddr::from(([127, 0, 0, 1], 0))),
+        blob_storage: Some(blob_storage),
+        ..NodeConfig::defaults(
+            Reach::NatTraversal,
+            IdentitySource::Generate {
+                custody: custody.clone(),
+                did_method,
+            },
+            Arc::clone(&root_storage),
+        )
+    })
+    .await
+    .expect(
+        "the node must build over the SHARED root storage handle without a \
+         lock conflict (os error 35)",
+    );
 
     // -- Deploy the embedded site and assert it serves end to end. The
     //    sequence-store-like owner is passed in so it stays alive across the
@@ -889,19 +904,26 @@ async fn build_self_host_node_over_dir(dir: &std::path::Path) -> ApplicationNode
         scp_transport::native::storage::BlobStorageBackend::sqlite(&dir.join("blobs"))
             .expect("sqlite blob storage should open");
 
-    ApplicationNodeBuilder::new()
-        .storage(node_storage)
-        .blob_storage(blob_storage)
-        .no_domain()
-        .nat_strategy(Arc::new(FixedTierNatStrategy))
-        // The production `--self-host` identity wiring: load-or-create from the
-        // root storage so the DID is stable across restarts.
-        .identity_with_storage(custody, did_method)
-        .bind_addr(SocketAddr::from(([127, 0, 0, 1], 0)))
-        .http_bind_addr(SocketAddr::from(([127, 0, 0, 1], 0)))
-        .build()
-        .await
-        .expect("no-domain node should build over encrypted SQLite storage")
+    // The production `--self-host` identity wiring: `IdentitySource::Persisted`
+    // load-or-creates from the root storage so the DID is stable across
+    // restarts. `NatTraversal` (publishing) → `DhtMode::Production` (M2).
+    Node::start(NodeConfig {
+        nat: NatSlot::Custom(Arc::new(FixedTierNatStrategy)),
+        dht: DhtMode::Production,
+        bind_addr: Some(SocketAddr::from(([127, 0, 0, 1], 0))),
+        http_bind_addr: Some(SocketAddr::from(([127, 0, 0, 1], 0))),
+        blob_storage: Some(blob_storage),
+        ..NodeConfig::defaults(
+            Reach::NatTraversal,
+            IdentitySource::Persisted {
+                custody,
+                did_method,
+            },
+            node_storage,
+        )
+    })
+    .await
+    .expect("no-domain node should build over encrypted SQLite storage")
 }
 
 /// FIX A: two sequential builds over ONE storage path must yield the SAME DID.
@@ -992,20 +1014,27 @@ async fn skip_nat_probe_uses_loopback_relay_url_without_probing() {
     // A fixed HTTP bind port so we can assert the exact loopback relay URL.
     let http_port = 28444u16;
 
-    let node = ApplicationNodeBuilder::new()
-        .storage(node_storage)
-        .blob_storage(blob_storage)
-        .no_domain()
-        // If the probe is NOT skipped this strategy panics — a clean build proves
-        // skip_nat_probe short-circuited the probe.
-        .nat_strategy(Arc::new(PanicOnProbeNatStrategy))
-        .skip_nat_probe()
-        .identity_with_storage(custody, did_method)
-        .bind_addr(SocketAddr::from(([127, 0, 0, 1], 0)))
-        .http_bind_addr(SocketAddr::from(([127, 0, 0, 1], http_port)))
-        .build()
-        .await
-        .expect("no-domain node should build with the NAT probe skipped");
+    // `Reach::Local` skips the NAT probe (the flat-config equivalent of
+    // `no_domain().skip_nat_probe()`). Local is non-publishing → `DhtMode::Memory`
+    // (the default). The `PanicOnProbeNatStrategy` is still supplied via
+    // `NatSlot::Custom`: a clean build proves `Local` short-circuited the probe
+    // before `select_tier` was ever called.
+    let node = Node::start(NodeConfig {
+        nat: NatSlot::Custom(Arc::new(PanicOnProbeNatStrategy)),
+        bind_addr: Some(SocketAddr::from(([127, 0, 0, 1], 0))),
+        http_bind_addr: Some(SocketAddr::from(([127, 0, 0, 1], http_port))),
+        blob_storage: Some(blob_storage),
+        ..NodeConfig::defaults(
+            Reach::Local,
+            IdentitySource::Persisted {
+                custody,
+                did_method,
+            },
+            node_storage,
+        )
+    })
+    .await
+    .expect("no-domain node should build with the NAT probe skipped");
 
     assert_eq!(
         node.relay_url(),

--- a/crates/scp-testing/src/helpers.rs
+++ b/crates/scp-testing/src/helpers.rs
@@ -25,8 +25,8 @@ use scp_identity::dht_client::InMemoryDhtClient;
 use scp_identity::{DidDocument, ScpIdentity};
 use scp_node::tls;
 use scp_node::{
-    ApplicationNodeBuilder, HasDomain, HasIdentity, HasNoDomain, NatStrategy, NodeError,
-    ReachabilityTier, TlsProvider,
+    ApplicationNodeBuilder, DhtMode, HasDomain, HasIdentity, HasNoDomain, IdentitySource, NatSlot,
+    NatStrategy, NodeConfig, NodeError, Reach, ReachabilityTier, TlsProvider,
 };
 use scp_platform::testing::{InMemoryKeyCustody, InMemoryStorage};
 
@@ -152,6 +152,60 @@ pub fn test_no_domain_builder(
         .no_domain()
         .nat_strategy(Arc::new(MockNatStrategy { tier }))
         .generate_identity_with(custody, did_method)
+}
+
+/// Creates a domain-mode [`NodeConfig`] with all required fields set
+/// (ADR-052 flat-config equivalent of [`test_builder`]).
+///
+/// Uses in-memory backends and the default `TlsMode::SelfSigned` (the same
+/// self-signed certificate [`SucceedingTlsProvider`] produces on a `Domain`
+/// reach). `Domain` is a publishing reach, so `DhtMode::Production` satisfies
+/// the M2 validator (advisory — nothing is published with the in-memory DHT
+/// client). Drive it with `Node::start_for_testing(test_node_config()).await`.
+#[must_use]
+pub fn test_node_config() -> NodeConfig<InMemoryKeyCustody, TestDidDht, InMemoryStorage> {
+    let custody = Arc::new(InMemoryKeyCustody::new());
+    let did_method = Arc::new(make_test_dht(&custody));
+    NodeConfig {
+        dht: DhtMode::Production,
+        ..NodeConfig::defaults(
+            Reach::Domain {
+                domain: "test.example.com".to_owned(),
+            },
+            IdentitySource::Generate {
+                custody,
+                did_method,
+            },
+            InMemoryStorage::new(),
+        )
+    }
+}
+
+/// Creates a no-domain [`NodeConfig`] with a mock NAT strategy (ADR-052
+/// flat-config equivalent of [`test_no_domain_builder`]).
+///
+/// The provided [`ReachabilityTier`] determines how the node advertises itself
+/// (`UPnP`, STUN, or Bridge), supplied via `NatSlot::Custom`. `NatTraversal` is
+/// a publishing reach, so `DhtMode::Production` satisfies the M2 validator.
+/// Drive it with `Node::start_for_testing(test_no_domain_node_config(tier))`.
+#[must_use]
+pub fn test_no_domain_node_config(
+    tier: ReachabilityTier,
+) -> NodeConfig<InMemoryKeyCustody, TestDidDht, InMemoryStorage> {
+    let custody = Arc::new(InMemoryKeyCustody::new());
+    let did_method = Arc::new(make_test_dht(&custody));
+    NodeConfig {
+        dht: DhtMode::Production,
+        nat: NatSlot::Custom(Arc::new(MockNatStrategy { tier })),
+        ..NodeConfig::defaults(
+            Reach::NatTraversal,
+            IdentitySource::Generate {
+                custody,
+                did_method,
+            },
+            InMemoryStorage::new(),
+        )
+    }
 }
 
 /// Creates a test [`ScpIdentity`] and [`DidDocument`] using in-memory custody

--- a/crates/scp-testing/tests/integration/node.rs
+++ b/crates/scp-testing/tests/integration/node.rs
@@ -6,7 +6,7 @@
 //! `SucceedingTlsProvider`, `FailingTlsProvider`, `MockNatStrategy`, `FailingNatStrategy`,
 //! `create_test_identity`, and `ApplicationNode` accessors (relay, identity, storage, shutdown).
 
-use scp_node::ReachabilityTier;
+use scp_node::{DhtMode, IdentitySource, NatSlot, Node, NodeConfig, Reach, ReachabilityTier};
 use scp_testing::helpers;
 
 // ---------------------------------------------------------------------------
@@ -15,8 +15,7 @@ use scp_testing::helpers;
 
 #[tokio::test]
 async fn domain_mode_builder() {
-    let node = helpers::test_builder()
-        .build_for_testing()
+    let node = Node::start_for_testing(helpers::test_node_config())
         .await
         .expect("domain-mode build should succeed");
 
@@ -43,8 +42,7 @@ async fn no_domain_mode_builder() {
     let tier = ReachabilityTier::Bridge {
         bridge_url: "wss://bridge.example.com/scp/v1".to_owned(),
     };
-    let node = helpers::test_no_domain_builder(tier)
-        .build_for_testing()
+    let node = Node::start_for_testing(helpers::test_no_domain_node_config(tier))
         .await
         .expect("no-domain-mode build should succeed");
 
@@ -70,7 +68,12 @@ async fn failing_tls_falls_through_to_nat() {
     let custody = Arc::new(scp_platform::testing::InMemoryKeyCustody::new());
     let did_method = Arc::new(helpers::make_test_dht(&custody));
 
-    // TLS failure + no NAT strategy → build should fail because both paths fail.
+    // This test intentionally stays on the typestate builder: it injects a
+    // custom `Arc<dyn TlsProvider>` (`FailingTlsProvider`) to exercise the
+    // builder-internal TLS-fail → NAT-fallthrough path. `NodeConfig` has no
+    // representation for an arbitrary failing TLS provider (its `TlsMode` is a
+    // closed enum), so this builder-internal behavior has no flat-config form.
+    // TLS failure + failing NAT → build should fail because both paths fail.
     let result = scp_node::ApplicationNodeBuilder::new()
         .storage(InMemoryStorage::new())
         .domain("fail-tls.example.com")
@@ -105,13 +108,21 @@ async fn failing_nat_strategy() {
     let custody = Arc::new(scp_platform::testing::InMemoryKeyCustody::new());
     let did_method = Arc::new(helpers::make_test_dht(&custody));
 
-    let result = scp_node::ApplicationNodeBuilder::new()
-        .storage(InMemoryStorage::new())
-        .no_domain()
-        .nat_strategy(Arc::new(helpers::FailingNatStrategy))
-        .generate_identity_with(custody, did_method)
-        .build_for_testing()
-        .await;
+    // NatTraversal is a publishing reach → DhtMode::Production (M2). The
+    // `FailingNatStrategy` makes NAT tier selection fail, so the build must err.
+    let result = Node::start_for_testing(NodeConfig {
+        dht: DhtMode::Production,
+        nat: NatSlot::Custom(Arc::new(helpers::FailingNatStrategy)),
+        ..NodeConfig::defaults(
+            Reach::NatTraversal,
+            IdentitySource::Generate {
+                custody,
+                did_method,
+            },
+            InMemoryStorage::new(),
+        )
+    })
+    .await;
 
     match result {
         Ok(_) => panic!("build with FailingNatStrategy should fail"),
@@ -161,8 +172,7 @@ async fn create_test_identity() {
 
 #[tokio::test]
 async fn node_relay_url() {
-    let node = helpers::test_builder()
-        .build_for_testing()
+    let node = Node::start_for_testing(helpers::test_node_config())
         .await
         .expect("domain-mode build should succeed");
 
@@ -181,8 +191,7 @@ async fn node_relay_url() {
 
 #[tokio::test]
 async fn node_storage_access() {
-    let node = helpers::test_builder()
-        .build_for_testing()
+    let node = Node::start_for_testing(helpers::test_node_config())
         .await
         .expect("domain-mode build should succeed");
 
@@ -198,8 +207,7 @@ async fn node_storage_access() {
 
 #[tokio::test]
 async fn node_shutdown() {
-    let node = helpers::test_builder()
-        .build_for_testing()
+    let node = Node::start_for_testing(helpers::test_node_config())
         .await
         .expect("domain-mode build should succeed");
 

--- a/crates/scp-testing/tests/integration/sdk_usability.rs
+++ b/crates/scp-testing/tests/integration/sdk_usability.rs
@@ -23,7 +23,7 @@ use std::time::Duration;
 
 use futures::{SinkExt, StreamExt};
 use scp_core::envelope::create_outer_envelope;
-use scp_node::ReachabilityTier;
+use scp_node::{Node, ReachabilityTier};
 use scp_platform::testing::InMemoryStorage;
 use scp_testing::helpers;
 use scp_transport::native::protocol::{ClientMessage, RelayMessage};
@@ -60,16 +60,14 @@ async fn build_no_domain_node() -> scp_node::ApplicationNode<InMemoryStorage> {
     let tier = ReachabilityTier::Bridge {
         bridge_url: "wss://bridge.test.scp/scp/v1".to_owned(),
     };
-    helpers::test_no_domain_builder(tier)
-        .build_for_testing()
+    Node::start_for_testing(helpers::test_no_domain_node_config(tier))
         .await
         .expect("no-domain node should build")
 }
 
 /// Builds a domain-mode `ApplicationNode` with self-signed TLS (no real ACME).
 async fn build_domain_node() -> scp_node::ApplicationNode<InMemoryStorage> {
-    helpers::test_builder()
-        .build_for_testing()
+    Node::start_for_testing(helpers::test_node_config())
         .await
         .expect("domain-mode node should build")
 }


### PR DESCRIPTION
## Phase B-P2 of ADR-052 (Unified Construction Pattern)

Migrates **all external node-construction call sites** from the typestate `ApplicationNodeBuilder` to the flat-config `Node::start` / `Node::start_for_testing` entry points introduced in P1. This sets up P3 (deleting the typestate kernel). The builder is **retained** and fully callable for now — only external callers are redirected.

### Scope
- **Production sites migrated:** node binary run path (`main.rs::run_node_with`), `self_host.rs::build_host_site_node`, the two FFI free fns (`start_node_in_memory` / `start_node_local` in `scp-ffi/common/src/server.rs`), and `ApplicationNode::dev()`.
- **Test sites migrated:** `scp-testing` integration tests + new `NodeConfig`-returning helpers; `scp-node` integration tests (`integration.rs`, `quic_listener.rs`, `quic_cross_transport.rs`, `self_host.rs`).
- **Retained (P3 territory):** `ApplicationNodeBuilder`, typestate markers, `builder()`, `build()`, `build_for_testing()`, scp-node's own `#[cfg(test)]` unit tests, and the builder-returning test factories they consume.
- **Unchanged:** every FFI export signature and SDK wrapper — only the internal bodies of the `node_start_*` free fns changed. No enforcement file touched.

### Behavior preservation
Every site maps to a `NodeConfig` that preserves exact behavior (domain/identity/storage/NAT/TLS/ports/blob-storage). The advisory `dht` field is set to `DhtMode::Production` on publishing reaches (Domain/NatTraversal) solely to satisfy the M2 validator — it is dropped before lowering, so no runtime behavior changes.

### Surface change
`TlsMode::Acme { email: String }` → `TlsMode::Acme { email: Option<String> }`, to faithfully express the legacy headless-ACME default (a domain node that sets no TLS options registers ACME with no contact email). `None` applies no email setter, reproducing the prior default exactly. Construction standard updated to note the optionality.

### Intentional residual
`failing_tls_falls_through_to_nat` (scp-testing integration test) stays on the builder: it injects a custom `Arc<dyn TlsProvider>`, which the closed `TlsMode` selector cannot — and per construction.md's "providers stay typed enum-selectors, never dyn" rule, should not — express. Documented inline.

### Verification
- `cargo build --workspace` + CI clippy (all features) — zero warnings
- `cargo test` for scp-node / scp-ffi / scp-testing incl. quic + self_host integration — all pass
- `cargo fmt --all --check` — clean
- Residual `ApplicationNodeBuilder::new()` callers = only the sanctioned ones (config.rs internal lowering, lib.rs builder def + unit tests, retained test factories, the one GAP-D test)
- Full review roster (alignment, bug-catcher, api-design, simplifier) — double-zero clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)