### PR TITLE
ci(enforcement): ADR-052 construction-pattern checker + EncryptedStorage structural test (Phase B-P4)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -160,6 +160,18 @@ jobs:
       - run: pip install tree-sitter tree-sitter-rust
       - run: python3.12 scripts/check-protocol-sync.py
 
+  # ── Construction pattern (ADR-052) ──────────────────────────────────────
+  construction-pattern:
+    needs: check-draft
+    name: Construction pattern (ADR-052)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - run: python3.12 scripts/check-construction-pattern.py
+
   protocol-deps:
     needs: check-draft
     name: Protocol deps check

--- a/crates/scp-node/tests/encrypted_storage_seal.rs
+++ b/crates/scp-node/tests/encrypted_storage_seal.rs
@@ -1,0 +1,59 @@
+#![allow(clippy::missing_const_for_fn)]
+//! Structural tests for the `EncryptedStorage` seal and `Node` ZST invariant
+//! (ADR-052 / spec §17.5).
+//!
+//! Two invariants are verified here:
+//!
+//! 1. **`Node` is a zero-sized type.** `Node` is used exclusively as a
+//!    namespace for associated functions (`Node::start`,
+//!    `Node::start_for_testing`). A non-ZST would indicate a regression to a
+//!    stateful instantiated type, violating ADR-052 §AC-4 /
+//!    construction.md M5.
+//!
+//! 2. **`EncryptedStorage` extends `Storage` (supertrait check).** This is the
+//!    structural property that makes `where S: EncryptedStorage` a strictly
+//!    stronger bound than `where S: Storage` alone, forming the
+//!    encryption-at-rest guarantee enforced by `Node::start`
+//!    (`crates/scp-platform/src/encrypted.rs`). The assertion is expressed as
+//!    a function that fails to *compile* — not just to run — if
+//!    `EncryptedStorage: Storage` supertrait is ever severed. Unlike a comment
+//!    or a doc-note, a compile failure is machine-verified on every CI run.
+
+use scp_node::Node;
+use scp_platform::{EncryptedStorage, Storage};
+
+// ---------------------------------------------------------------------------
+// Compile-time supertrait assertion
+// ---------------------------------------------------------------------------
+
+/// Proves that `EncryptedStorage: Storage`.
+///
+/// If the `Storage` supertrait on `EncryptedStorage` is ever removed, the
+/// inner call `require_storage::<S>()` will fail to compile because
+/// `S: EncryptedStorage` alone will no longer imply `S: Storage`. This
+/// function is intentionally never called — it is purely a compile-time check.
+#[allow(dead_code)]
+fn _assert_encrypted_storage_extends_storage<S: EncryptedStorage>() {
+    const fn require_storage<T: Storage>() {}
+    require_storage::<S>();
+}
+
+// ---------------------------------------------------------------------------
+// Runtime structural assertions
+// ---------------------------------------------------------------------------
+
+/// `Node` must be a zero-sized type (ADR-052 §AC-4, construction.md M5).
+///
+/// `Node` is the public namespace ZST for `Node::start` and
+/// `Node::start_for_testing`. A non-zero size indicates a regression to a
+/// stateful struct — which would violate the unified construction pattern and
+/// expose internal state that should be private to `ApplicationNode`.
+#[test]
+fn node_is_zero_sized() {
+    assert_eq!(
+        std::mem::size_of::<Node>(),
+        0,
+        "Node must be a ZST (namespace for associated fns, ADR-052 §AC-4). \
+         A non-zero size indicates a regression to a stateful type."
+    );
+}

--- a/scripts/check-construction-pattern.py
+++ b/scripts/check-construction-pattern.py
@@ -1,0 +1,316 @@
+#!/usr/bin/env python3.12
+"""CI gate enforcing the ADR-052 Unified Construction Pattern.
+
+Scans construction module files for two classes of violation:
+
+M5 — Builder types and typestate markers are forbidden in construction modules.
+     A construction module is any file matching:
+       crates/*/src/config.rs
+       crates/*/src/self_host.rs
+       crates/*/src/*config*.rs
+     In those files, flag:
+       - Any `struct` whose name ends in `Builder`
+       - Any unit struct that carries a typestate-marker name: a name that
+         contains Has / No / With / Without / Unset (common typestate prefixes)
+         or appears as a generic bound in the same file.
+
+M1 — Boolean fields for semantic choices are forbidden in `pub struct *Config`
+     structs inside construction modules.  A field is flagged when:
+       - It is declared `pub <name>: bool` inside a struct whose name ends in
+         `Config`
+       - Its field name contains one of the semantic-choice heuristic keywords:
+         enable, disable, use, skip, allow, plaintext, supports, has_
+     An allowlist covers the small set of legitimate bool fields whose names
+     happen to trigger the heuristic but carry truly binary semantics (see
+     M1_BOOL_ALLOWLIST below).
+
+Usage
+-----
+    python3.12 scripts/check-construction-pattern.py
+
+Exit codes
+----------
+    0  — no violations found
+    1  — one or more violations found
+    2  — invocation error (run from repo root)
+
+Enforcement surface
+-------------------
+This script is listed in scripts/hooks/pretooluse-enforcement-files.sh and
+wired into CI (.github/workflows/ci.yml, job "construction-pattern").  It must
+NOT be modified to weaken checks; only additive changes (new rule coverage,
+new allowlist entries) are permitted.  See CLAUDE.md §enforcement files.
+
+ADR reference: ADR-052 in .docs/adrs/phase-2.md; standard:
+.docs/standards/construction.md (M1, M5).
+"""
+from __future__ import annotations
+
+import pathlib
+import re
+import sys
+
+# ---------------------------------------------------------------------------
+# Construction-module file patterns (relative to repo root)
+# ---------------------------------------------------------------------------
+
+# Globs that identify construction-module files — the M5 and M1 scan scope.
+# `self_host.rs` is not a *config* file but it is explicitly listed in the
+# construction standard as part of the managed construction surface.
+CONSTRUCTION_MODULE_GLOBS = [
+    "crates/*/src/config.rs",
+    "crates/*/src/self_host.rs",
+    "crates/*/src/*config*.rs",
+]
+
+# ---------------------------------------------------------------------------
+# M5 — Builder and typestate-marker allowlists
+# ---------------------------------------------------------------------------
+
+# Typestate-marker keyword prefixes.  A unit struct (`struct Foo;`) whose name
+# *starts with* one of these (at the start or at a CamelCase word boundary) is
+# considered a typestate marker.  We use regex to match at word boundaries
+# (start of name or preceded by a capital that opens a new CamelCase word).
+#
+# Examples that should match:  HasDomain  NoDomain  HasIdentity  WithTls
+#                               WithoutNat  UnsetCustody
+# Examples that must NOT match: Node  Nothing  Normalized  Holder  Notable
+TYPESTATE_PREFIX_RE = re.compile(
+    r"^(?:Has[A-Z]|No[A-Z]|With[A-Z]|Without[A-Z]|Unset[A-Z])"
+)
+
+# Struct names that are unconditionally allowed regardless of their shape or
+# naming convention.  Extend this set when a new legitimate pattern emerges.
+M5_STRUCT_ALLOWLIST: frozenset[str] = frozenset(
+    [
+        # ExplicitIdentity is a payload struct (the data for
+        # IdentitySource::Explicit), not a typestate marker.
+        "ExplicitIdentity",
+    ]
+)
+
+# ---------------------------------------------------------------------------
+# M1 — Bool-field semantic-choice heuristic
+# ---------------------------------------------------------------------------
+
+# Field-name fragments that suggest the bool encodes a semantic choice
+# (something that should be an enum variant, not a boolean flag).
+SEMANTIC_BOOL_FRAGMENTS = frozenset(
+    ["enable", "disable", "use", "skip", "allow", "plaintext", "supports", "has_"]
+)
+
+# Allowlist of (struct_name, field_name) pairs that are EXEMPT from M1.
+# Each entry documents why the bool is truly binary rather than a semantic
+# choice and therefore does NOT need an enum.
+M1_BOOL_ALLOWLIST: frozenset[tuple[str, str]] = frozenset(
+    [
+        # `http3` in a RelayConfig-family struct: HTTP/3 support is a pure
+        # on/off toggle.  If this field ever appears in a construction-module
+        # struct (none currently exist), it is exempt.
+        # ("RelayConfig", "http3"),
+        #
+        # Add future exemptions here as ("StructName", "field_name") tuples,
+        # each with a one-line rationale comment.
+    ]
+)
+
+# ---------------------------------------------------------------------------
+# Regex helpers
+# ---------------------------------------------------------------------------
+
+# Matches a struct definition line, capturing the struct name.
+# Handles: `pub struct Foo`, `struct Foo`, `pub(crate) struct Foo`.
+_STRUCT_DEF_RE = re.compile(r"^\s*(?:pub(?:\([^)]+\))?\s+)?struct\s+([A-Za-z][A-Za-z0-9_]*)")
+
+# Unit struct — struct with NO body (ends with `;` after the name, possibly
+# with a generic clause).  E.g. `struct HasDomain;` `pub struct NoDomain;`
+# `struct FooBuilder;`
+_UNIT_STRUCT_RE = re.compile(
+    r"^\s*(?:pub(?:\([^)]+\))?\s+)?struct\s+([A-Za-z][A-Za-z0-9_]*)(?:<[^>]*>)?\s*;"
+)
+
+# Matches a public field inside a struct body.
+# Group 1: field name.  Group 2: field type.
+# E.g. `    pub plaintext: bool,`
+#      `    pub enable_foo: bool,`
+_PUB_FIELD_RE = re.compile(r"^\s+pub\s+([A-Za-z][A-Za-z0-9_]*)\s*:\s*([A-Za-z][A-Za-z0-9_:<>, ]*)")
+
+# ---------------------------------------------------------------------------
+# Helper: is this struct name a typestate-marker name?
+# ---------------------------------------------------------------------------
+
+def _is_typestate_name(name: str) -> bool:
+    """Return True if the struct name looks like a typestate marker.
+
+    Matches names that START with Has/No/With/Without/Unset followed immediately
+    by an uppercase letter — the canonical CamelCase typestate-marker prefix
+    pattern.  This deliberately avoids false-positives on legitimate names like
+    ``Node`` (starts with No but ``d`` is lowercase) or ``Holder``.
+    """
+    return bool(TYPESTATE_PREFIX_RE.match(name))
+
+
+# ---------------------------------------------------------------------------
+# Helper: does this struct name end in Builder?
+# ---------------------------------------------------------------------------
+
+def _is_builder_name(name: str) -> bool:
+    return name.endswith("Builder")
+
+
+# ---------------------------------------------------------------------------
+# Helper: does this field name look like a semantic choice?
+# ---------------------------------------------------------------------------
+
+def _is_semantic_bool_field(field_name: str) -> bool:
+    lower = field_name.lower()
+    return any(frag in lower for frag in SEMANTIC_BOOL_FRAGMENTS)
+
+
+# ---------------------------------------------------------------------------
+# File scanner
+# ---------------------------------------------------------------------------
+
+def scan_file(path: pathlib.Path) -> list[str]:
+    """Scan a single construction-module file.
+
+    Returns a list of violation strings (empty means clean).
+    Each violation is of the form:
+        "<path>:<line>: <M-code> violation — <description>"
+    """
+    violations: list[str] = []
+
+    try:
+        text = path.read_text(encoding="utf-8", errors="replace")
+    except OSError as exc:
+        violations.append(f"{path}: ERROR — cannot read file: {exc}")
+        return violations
+
+    lines = text.splitlines()
+
+    # Track which struct we are currently inside (for M1 scope).
+    # We use a simple brace-depth counter: when depth goes to 0 we leave the
+    # struct, when we find a `pub struct *Config` we enter it.
+    # This is intentionally simpler than a full parser and sufficient because
+    # construction-module files follow the established coding standard.
+
+    current_config_struct: str | None = None  # name of the *Config struct we're in
+    brace_depth: int = 0  # depth relative to struct body open-brace
+
+    for lineno, raw in enumerate(lines, start=1):
+        line = raw
+
+        # ---------------------------------------------------------------
+        # M5 — Builder struct check
+        # ---------------------------------------------------------------
+        m = _STRUCT_DEF_RE.match(line)
+        if m:
+            struct_name = m.group(1)
+
+            if struct_name in M5_STRUCT_ALLOWLIST:
+                pass  # explicitly exempted — no check needed
+
+            elif _is_builder_name(struct_name):
+                violations.append(
+                    f"  {path}:{lineno}: M5 violation — struct {struct_name} "
+                    f"(Builder type in construction module)"
+                )
+
+            else:
+                # Unit-struct typestate marker?
+                um = _UNIT_STRUCT_RE.match(line)
+                if um:
+                    uname = um.group(1)
+                    if uname not in M5_STRUCT_ALLOWLIST and _is_typestate_name(uname):
+                        violations.append(
+                            f"  {path}:{lineno}: M5 violation — struct {uname}; "
+                            f"(typestate marker in construction module)"
+                        )
+
+        # ---------------------------------------------------------------
+        # M1 — Bool fields in *Config structs
+        # ---------------------------------------------------------------
+
+        # Track entering a *Config struct (update even if we also flagged M5
+        # above — we want both checks on the same pass).
+        struct_match = _STRUCT_DEF_RE.match(line)
+        if struct_match:
+            sname = struct_match.group(1)
+            if sname.endswith("Config"):
+                # We are entering a new Config struct context.
+                # Reset depth tracking — the `{` that opens the struct body
+                # may be on this line or a subsequent one; we start counting
+                # from the first `{` we see after the struct declaration.
+                current_config_struct = sname
+                brace_depth = 0
+
+        if current_config_struct is not None:
+            # Count braces in this line to track struct body scope.
+            for ch in line:
+                if ch == "{":
+                    brace_depth += 1
+                elif ch == "}":
+                    brace_depth -= 1
+                    if brace_depth <= 0:
+                        # Left the struct body.
+                        current_config_struct = None
+                        brace_depth = 0
+                        break  # rest of line is outside the struct
+
+            # Check for a `pub <field>: bool` inside the Config struct body.
+            if current_config_struct is not None and brace_depth > 0:
+                fm = _PUB_FIELD_RE.match(line)
+                if fm:
+                    field_name = fm.group(1)
+                    field_type = fm.group(2).strip().rstrip(",")
+                    # Only flag `bool` fields whose type is exactly `bool`.
+                    if field_type == "bool" and _is_semantic_bool_field(field_name):
+                        # Check allowlist.
+                        if (current_config_struct, field_name) not in M1_BOOL_ALLOWLIST:
+                            violations.append(
+                                f"  {path}:{lineno}: M1 violation — "
+                                f"{current_config_struct}.{field_name}: bool "
+                                f"(semantic bool field; use an enum variant instead)"
+                            )
+
+    return violations
+
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+def main() -> int:
+    repo_root = pathlib.Path(".")
+
+    # Verify we look like a repo root (cheap sanity check).
+    if not (repo_root / "Cargo.toml").exists():
+        print(
+            "ERROR: check-construction-pattern.py must be run from the repo root "
+            "(Cargo.toml not found).",
+            file=sys.stderr,
+        )
+        return 2
+
+    # Collect all construction-module files.
+    files: list[pathlib.Path] = []
+    for pattern in CONSTRUCTION_MODULE_GLOBS:
+        files.extend(repo_root.glob(pattern))
+    files = sorted(set(files))
+
+    # Run the scanner.
+    all_violations: list[str] = []
+    for f in files:
+        all_violations.extend(scan_file(f))
+
+    if all_violations:
+        print("FAIL: scripts/check-construction-pattern.py")
+        for v in all_violations:
+            print(v)
+        return 1
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/hooks/pretooluse-enforcement-files.sh
+++ b/scripts/hooks/pretooluse-enforcement-files.sh
@@ -39,6 +39,7 @@ PROTECTED_REPO_RELATIVE_PATHS=(
     "scripts/bridge-aliases.json"
     "scripts/check-pure-helpers.sh"
     "scripts/pure-helpers-allowlist.txt"
+    "scripts/check-construction-pattern.py"
     "scripts/hooks/pretooluse-enforcement-files.sh"
 )
 


### PR DESCRIPTION
## Summary

P4 (additive enforcement only) for the ADR-052 Unified Construction Pattern refactor. All three deliverables:

- **`scripts/check-construction-pattern.py`** — pure-stdlib Python 3.12 CI gate enforcing:
  - M5: no `*Builder` struct types or typestate marker structs in construction modules (`crates/*/src/config.rs`, `crates/*/src/self_host.rs`, `crates/*/src/*config*.rs`)
  - M1: no semantic bool fields (names containing `enable`/`disable`/`use`/`skip`/`allow`/`plaintext`/`supports`/`has_`) in `*Config` structs
  - Exits 0 on current main (all violations already removed in P1–P3); exits 1 with file + line on violations
  - Self-verifies on planted violations before commit

- **`crates/scp-node/tests/encrypted_storage_seal.rs`** — structural tests:
  - `node_is_zero_sized()`: asserts `size_of::<Node>() == 0` (M5 namespace-ZST invariant, ADR-052 §AC-4)
  - `_assert_encrypted_storage_extends_storage<S: EncryptedStorage>()`: dead-code function whose body calls `const fn require_storage<T: Storage>()`; **fails to compile** if the `Storage` supertrait is ever removed from `EncryptedStorage` — machine-verifying the encryption-at-rest seal (spec §17.5) on every CI run without trybuild

- **`.github/workflows/ci.yml`** — new `construction-pattern` job (stdlib Python, no pip installs; placed after `protocol-sync`)

- **`scripts/hooks/pretooluse-enforcement-files.sh`** — adds `scripts/check-construction-pattern.py` to the protected list (blocks in-band weakening at hook layer)

## Test plan

- [ ] `python3.12 scripts/check-construction-pattern.py` exits 0 on main (no violations)
- [ ] Planted `struct FooBuilder;` in a construction module → exits 1 with location
- [ ] `cargo test -p scp-node --test encrypted_storage_seal` → 1 passed, 0 failed
- [ ] Full CI clippy passes: `cargo clippy --workspace --all-targets --features scp-ffi-uniffi/allow_in_memory_custody,scp-ffi/allow_in_memory_custody,scp-ffi-napi/allow_in_memory_custody,scp-core/testing,scp-runtime/testing -- -D warnings`

🤖 Generated with [Claude Code](https://claude.com/claude-code)