### PR TITLE
feat(event-log): expand EventType to canonical 76-variant closed taxonomy + payload encoder + KAT

### DIFF
--- a/.docs/specs/25-test-vectors.md
+++ b/.docs/specs/25-test-vectors.md
@@ -356,7 +356,68 @@ Root: SHA-256(0x01 || interior_L || interior_R)
     = 0x5c8dc617d287a4297eb2bcb81b37644b5138e57ad461c657db152109e3fc9fca
 ```
 
-Note: The vectors above use abstract `data` leaves to pin the RFC 6962 tree construction itself (leaf/interior domain prefixes, unbalanced promotion). A typed-leaf vector — where each leaf is `SHA-256(0x00 || rmp_serde(Event))` over a canonical `scp_event_log::Event` value whose `event_type` is one of the closed `EventType` taxonomy (ADR-011 AC1, native↔WASM unification Amendment, including the lifecycle, consequence-enforcement, commit-broadcast, and app-sandbox variants added by that Amendment) — together with a checkpoint `tree::root` (§23.16.1) KAT, will be added here when the unification lands in code; the expected byte values are implementation-derived and are not pre-computed in this spec.
+Note: The vectors above use abstract `data` leaves to pin the RFC 6962 tree construction itself (leaf/interior domain prefixes, unbalanced promotion). The typed-leaf and checkpoint vectors below pin the *typed* leaf preimage and the checkpoint root.
+
+### Vector 20: Typed-Leaf KAT (closed `EventType` taxonomy)
+
+Each leaf is `SHA-256(0x00 || rmp_serde(Event))` over a canonical `scp_event_log::Event` whose `event_type` is one of the closed 76-variant `EventType` taxonomy (ADR-011 AC1 + native↔WASM unification Amendment). The events are signed with a fixed Ed25519 key (RFC 8032 deterministic signatures), so the full-event MessagePack bytes — and therefore the leaf hashes — are reproducible across runs and implementations. Structured payloads are encoded with positional `rmp_serde::to_vec` of the per-variant payload struct (`scp_event_log::payload`); the two opaque payloads carry the documented `key=value;…` bytes shown.
+
+```
+Signing key seed (32 bytes): 0x0102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f20
+Actor DID (did:dht:z<z-base-32(pubkey)>):
+  did:dht:zxg4icmwxh3kx1odasrjqtkcmw6eb9bj4h4k57i9yhqeozmer131y
+Context ID: "ctx-kat"
+
+Events (append order; each prev_hash = previous leaf hash, genesis = [0u8;32]):
+
+  seq 0  AppBound                 ts 1700000000
+         payload = rmp(AppBoundPayload{ app_did:"did:key:app", app_name:"Scheduler",
+                       app_version:"1.0.0", capabilities:["tool:invoke:*"] })
+         leaf = 0xe0c0691d264ca38d086375a0274afb630e9bbb906f2e12e0112adf4d1b4fcd38
+
+  seq 1  SpendApproved            ts 1700000001
+         payload = rmp(SpendApprovedPayload{ spender:"did:key:agent", amount:5000,
+                       purpose:"inference" })
+         leaf = 0xf2f973a4df60ef87abcb99dd1f3afcd537037cbd1aae6297582c52be3bd8e695
+
+  seq 2  TtlExtended              ts 1700000002
+         payload = rmp(TtlExtendedPayload{ old_deadline_unix:1700000000,
+                       new_deadline_unix:1800000000, proposal_id:[0xAB;32],
+                       consenting_members:["did:key:a","did:key:b"] })
+         leaf = 0xccdbb8dfa15a7abff3fbd0c08efe45e99d9fc4cb5f042f8f7db5f9e36e3fb0b0
+
+  seq 3  RecoveryEpochAdvanced    ts 1700000003
+         payload = rmp(RecoveryEpochAdvancedPayload{ old_epoch:7, new_epoch:8 })
+         leaf = 0x7a1a91c33ddaa1a92c02f70a3f567f065bed48b578124a803c07dca2f9a47863
+
+  seq 4  ContextTombstoned        ts 1700000004
+         payload = rmp(ContextTombstonedPayload{ destination_context_id:"ctx-dest",
+                       migration_proposal_id:[0xCD;32] })
+         leaf = 0x3848718f23aefaba0e47743e72f5ce3bcc3254bc09b4cb38c3f5c263c9c4dd8d
+
+  seq 5  ConsequenceTriggered     ts 1700000005
+         payload = b"member_did=did:key:m;rule_index=2;trigger_kind=absence;action_type=suspend"
+         leaf = 0x7ea6b6a020d94e0850cb84410af43e69ecd1c945223cbf478356d93503724507
+
+  seq 6  CommitBroadcastSucceeded ts 1700000006
+         payload = b"operation=join;attempts=3"
+         leaf = 0x87e3cde25168f4af4328f010369313e28fde305dbc6f706be3392fdf7b8e7f3c
+
+RFC 6962 tree::root over the 7 leaves:
+  0x39e50b879956255f4fd28b2c6f03995e759919e07166c232dd61ed321b54d40d
+```
+
+### Vector 21: Checkpoint Root KAT (§23.16.1)
+
+A `ConsistencyCheckpoint` generated over the Vector 20 log MUST carry `merkle_root == tree::root` (the RFC 6962 root above), NOT a hash-chain head. The checkpoint canonical hash is `SHA-256("SCP-CHECKPOINT-V1:" || len(context_id) || context_id || len(sender_did) || sender_did || event_count_BE || merkle_root || epoch_tag || timestamp_BE)` where `epoch_tag = 0x01 || epoch_BE` for `Some(epoch)` (§23.16.1); the checkpoint signature is the actor's Ed25519 signature over that canonical hash. The canonical hash and signature depend on the checkpoint `timestamp` (wall clock) and so are not pinned here; the pinned, timestamp-independent invariant is:
+
+```
+checkpoint.merkle_root == tree::root (Vector 20)
+  = 0x39e50b879956255f4fd28b2c6f03995e759919e07166c232dd61ed321b54d40d
+checkpoint.event_count == 7
+```
+
+Reference implementation and assertions: `crates/scp-event-log/tests/test_vectors.rs` (`vector_20_typed_leaf_and_checkpoint_kat`, `vector_21_checkpoint_root_equals_tree_root_kat`). Regenerate with `cargo test -p scp-event-log --test test_vectors -- --nocapture`.
 
 ## 25.9 Key Continuity Fingerprint Vectors (§9.11)
 

--- a/.docs/specs/25-test-vectors.md
+++ b/.docs/specs/25-test-vectors.md
@@ -358,7 +358,7 @@ Root: SHA-256(0x01 || interior_L || interior_R)
 
 Note: The vectors above use abstract `data` leaves to pin the RFC 6962 tree construction itself (leaf/interior domain prefixes, unbalanced promotion). The typed-leaf and checkpoint vectors below pin the *typed* leaf preimage and the checkpoint root.
 
-### Vector 20: Typed-Leaf KAT (closed `EventType` taxonomy)
+### Vector 32: Typed-Leaf KAT (closed `EventType` taxonomy)
 
 Each leaf is `SHA-256(0x00 || rmp_serde(Event))` over a canonical `scp_event_log::Event` whose `event_type` is one of the closed 76-variant `EventType` taxonomy (ADR-011 AC1 + native↔WASM unification Amendment). The events are signed with a fixed Ed25519 key (RFC 8032 deterministic signatures), so the full-event MessagePack bytes — and therefore the leaf hashes — are reproducible across runs and implementations. Structured payloads are encoded with positional `rmp_serde::to_vec` of the per-variant payload struct (`scp_event_log::payload`); the two opaque payloads carry the documented `key=value;…` bytes shown.
 
@@ -407,17 +407,17 @@ RFC 6962 tree::root over the 7 leaves:
   0x39e50b879956255f4fd28b2c6f03995e759919e07166c232dd61ed321b54d40d
 ```
 
-### Vector 21: Checkpoint Root KAT (§23.16.1)
+### Vector 33: Checkpoint Root KAT (§23.16.1)
 
-A `ConsistencyCheckpoint` generated over the Vector 20 log MUST carry `merkle_root == tree::root` (the RFC 6962 root above), NOT a hash-chain head. The checkpoint canonical hash is `SHA-256("SCP-CHECKPOINT-V1:" || len(context_id) || context_id || len(sender_did) || sender_did || event_count_BE || merkle_root || epoch_tag || timestamp_BE)` where `epoch_tag = 0x01 || epoch_BE` for `Some(epoch)` (§23.16.1); the checkpoint signature is the actor's Ed25519 signature over that canonical hash. The canonical hash and signature depend on the checkpoint `timestamp` (wall clock) and so are not pinned here; the pinned, timestamp-independent invariant is:
+A `ConsistencyCheckpoint` generated over the Vector 32 log MUST carry `merkle_root == tree::root` (the RFC 6962 root above), NOT a hash-chain head. The checkpoint canonical hash is `SHA-256("SCP-CHECKPOINT-V1:" || len(context_id) || context_id || len(sender_did) || sender_did || event_count_BE || merkle_root || epoch_tag || timestamp_BE)` where `epoch_tag = 0x01 || epoch_BE` for `Some(epoch)` (§23.16.1); the checkpoint signature is the actor's Ed25519 signature over that canonical hash. The canonical hash and signature depend on the checkpoint `timestamp` (wall clock) and so are not pinned here; the pinned, timestamp-independent invariant is:
 
 ```
-checkpoint.merkle_root == tree::root (Vector 20)
+checkpoint.merkle_root == tree::root (Vector 32)
   = 0x39e50b879956255f4fd28b2c6f03995e759919e07166c232dd61ed321b54d40d
 checkpoint.event_count == 7
 ```
 
-Reference implementation and assertions: `crates/scp-event-log/tests/test_vectors.rs` (`vector_20_typed_leaf_and_checkpoint_kat`, `vector_21_checkpoint_root_equals_tree_root_kat`). Regenerate with `cargo test -p scp-event-log --test test_vectors -- --nocapture`.
+Reference implementation and assertions: `crates/scp-event-log/tests/test_vectors.rs` (`vector_32_typed_leaf_and_checkpoint_kat`, `vector_33_checkpoint_root_equals_tree_root_kat`). Regenerate with `cargo test -p scp-event-log --test test_vectors -- --nocapture`.
 
 ## 25.9 Key Continuity Fingerprint Vectors (§9.11)
 

--- a/.docs/specs/25-test-vectors.md
+++ b/.docs/specs/25-test-vectors.md
@@ -391,7 +391,7 @@ Events (append order; each prev_hash = previous leaf hash, genesis = [0u8;32]):
          leaf = 0x7a1a91c33ddaa1a92c02f70a3f567f065bed48b578124a803c07dca2f9a47863
 
   seq 4  ContextTombstoned        ts 1700000004
-         payload = rmp(ContextTombstonedPayload{ destination_context_id:"ctx-dest",
+         payload = rmp(ContextTombstonedPayload{ destination_id:"ctx-dest",
                        migration_proposal_id:[0xCD;32] })
          leaf = 0x3848718f23aefaba0e47743e72f5ce3bcc3254bc09b4cb38c3f5c263c9c4dd8d
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5040,7 +5040,7 @@ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "scp-core"
-version = "0.1.0-beta.1"
+version = "0.1.0-beta.2"
 dependencies = [
  "scp-protocol",
  "scp-runtime",
@@ -5049,7 +5049,7 @@ dependencies = [
 
 [[package]]
 name = "scp-event-log"
-version = "0.1.0-beta.1"
+version = "0.1.0-beta.2"
 dependencies = [
  "async-trait",
  "ed25519-dalek 2.2.0",
@@ -5260,7 +5260,7 @@ dependencies = [
 
 [[package]]
 name = "scp-identity"
-version = "0.1.0-beta.1"
+version = "0.1.0-beta.2"
 dependencies = [
  "base64",
  "bs58",
@@ -5284,7 +5284,7 @@ dependencies = [
 
 [[package]]
 name = "scp-mcp"
-version = "0.1.0-beta.1"
+version = "0.1.0-beta.2"
 dependencies = [
  "axum",
  "scp-core",
@@ -5302,7 +5302,7 @@ dependencies = [
 
 [[package]]
 name = "scp-media"
-version = "0.1.0-beta.1"
+version = "0.1.0-beta.2"
 dependencies = [
  "openmls_traits 0.5.0",
  "scp-core",
@@ -5316,7 +5316,7 @@ dependencies = [
 
 [[package]]
 name = "scp-node"
-version = "0.1.0-beta.1"
+version = "0.1.0-beta.2"
 dependencies = [
  "arc-swap",
  "axum",
@@ -5365,7 +5365,7 @@ dependencies = [
 
 [[package]]
 name = "scp-platform"
-version = "0.1.0-beta.1"
+version = "0.1.0-beta.2"
 dependencies = [
  "aes-gcm",
  "argon2",
@@ -5391,7 +5391,7 @@ dependencies = [
 
 [[package]]
 name = "scp-primitives"
-version = "0.1.0-beta.1"
+version = "0.1.0-beta.2"
 dependencies = [
  "ed25519-dalek 2.2.0",
  "hex",
@@ -5404,7 +5404,7 @@ dependencies = [
 
 [[package]]
 name = "scp-protocol"
-version = "0.1.0-beta.1"
+version = "0.1.0-beta.2"
 dependencies = [
  "aes",
  "aes-gcm",
@@ -5443,7 +5443,7 @@ dependencies = [
 
 [[package]]
 name = "scp-relay"
-version = "0.1.0-beta.1"
+version = "0.1.0-beta.2"
 dependencies = [
  "axum",
  "metrics",
@@ -5456,7 +5456,7 @@ dependencies = [
 
 [[package]]
 name = "scp-runtime"
-version = "0.1.0-beta.1"
+version = "0.1.0-beta.2"
 dependencies = [
  "aes",
  "aes-gcm",
@@ -5549,7 +5549,7 @@ dependencies = [
 
 [[package]]
 name = "scp-transport"
-version = "0.1.0-beta.1"
+version = "0.1.0-beta.2"
 dependencies = [
  "async-trait",
  "aws-config",

--- a/crates/scp-event-log/Cargo.toml
+++ b/crates/scp-event-log/Cargo.toml
@@ -36,6 +36,10 @@ rand = { workspace = true, optional = true }
 tokio = { workspace = true, features = ["macros", "rt-multi-thread", "test-util"] }
 rand = { workspace = true }
 serde_json = { workspace = true }
+ed25519-dalek = { workspace = true }
+z-base-32 = { workspace = true }
+rmp-serde = { workspace = true }
+async-trait = { workspace = true }
 
 [lints]
 workspace = true

--- a/crates/scp-event-log/Cargo.toml
+++ b/crates/scp-event-log/Cargo.toml
@@ -36,10 +36,6 @@ rand = { workspace = true, optional = true }
 tokio = { workspace = true, features = ["macros", "rt-multi-thread", "test-util"] }
 rand = { workspace = true }
 serde_json = { workspace = true }
-ed25519-dalek = { workspace = true }
-z-base-32 = { workspace = true }
-rmp-serde = { workspace = true }
-async-trait = { workspace = true }
 
 [lints]
 workspace = true

--- a/crates/scp-event-log/src/lib.rs
+++ b/crates/scp-event-log/src/lib.rs
@@ -20,7 +20,7 @@
 //!
 //! - [`EventLog`] -- The append-only Merkle tree per context.
 //! - [`Event`] -- A protocol event with actor, type, payload, and signature.
-//! - [`EventType`] -- The 35 event type variants.
+//! - [`EventType`] -- The 76 event type variants.
 //! - [`EventPayload`] -- Type-specific event data.
 //! - [`EventLogError`] -- Error type for event log operations.
 //! - [`EventLogSigner`] -- Trait abstracting signing for checkpoint generation.
@@ -34,6 +34,7 @@
 pub mod checkpoint;
 pub mod crypto;
 pub mod metrics;
+pub mod payload;
 pub mod proof;
 pub mod pruning;
 pub mod tiered_storage;
@@ -89,11 +90,17 @@ pub trait EventLogSigner: Send + Sync {
 // EventType
 // ---------------------------------------------------------------------------
 
-/// The 35 event type variants for SCP context event logs.
+/// The 76 event type variants for SCP context event logs.
 ///
 /// Every protocol action that mutates context state is represented as one of
 /// these variants. See ADR-011 for the base enumeration and ADR-031 for
-/// the 8 governance-specific event types.
+/// the 8 governance-specific event types. The native↔WASM event-log
+/// unification amendment (ADR-011, `.docs/adrs/phase-2.md`) added the 40
+/// governance-action-coverage, lifecycle/migration, content-access, economic,
+/// consequence-enforcement, commit-broadcast-reconciliation, compromise-recovery,
+/// and app-sandbox-binding variants. This is a CLOSED set with no catch-all
+/// variant: every protocol action that produces a verifiable Merkle-log entry
+/// is one of these variants.
 ///
 /// Governance event payloads are serialized into [`EventPayload`]. The
 /// payload fields for each governance event type are documented below;
@@ -211,6 +218,174 @@ pub enum EventType {
     ///
     /// Payload: SHA-256 hash of JSON-serialized provenance record (32 bytes).
     ProvenanceReceived,
+
+    // -------------------------------------------------------------------
+    // Governance-action-coverage event types (native↔WASM unification;
+    // ADR-011 Amendment in `.docs/adrs/phase-2.md`). Each traces to a
+    // GovernanceAction (ADR-031 §2) or a §19 / §5.11A / §9.9 / §9.10
+    // protocol action. Parameters live in [`EventPayload`], never in the
+    // type name.
+    // -------------------------------------------------------------------
+    /// Admin role was transferred (`TransferAdmin`).
+    AdminTransferred,
+    /// A spending ceiling modification was applied (`ModifyCeiling`).
+    CeilingModified,
+    /// A spending ceiling modification entered its delay window
+    /// (`ModifyCeiling` delay-window start).
+    CeilingModificationPending,
+    /// A governance threshold was modified (`ModifyThreshold` §4b).
+    ThresholdModified,
+    /// A governance signer was added (`AddSigner` §4b).
+    SignerAdded,
+    /// A governance signer was removed (`RemoveSigner` §4b).
+    SignerRemoved,
+    /// A child context was created (`CreateChildContext` §5.13); consumed
+    /// by §7 trust.
+    ChildContextCreated,
+    /// A context was promoted (`PromoteContext` §5.10).
+    ContextPromoted,
+    /// Content keys were rotated (`RotateContentKeys` §9.17 / ADR-038).
+    ContentKeysRotated,
+    /// A member was reset (`ResetMember` ADR-029 Tier-3; §23 reset).
+    MemberReset,
+    /// A member's capability was suspended (`SuspendCapability`).
+    MemberSuspended,
+    /// A member's full access was suspended (`SuspendAccess`).
+    MemberSuspendedAll,
+    /// A member was unblocked (ADR-007 block reversal; pairs with
+    /// [`EventType::MemberBlocked`]).
+    MemberUnblocked,
+    /// Read access was restored (`RestoreAccess` §5 `ReadAccessRestored`).
+    AccessRestored,
+    /// Governance configuration was changed (`ReconfigureGovernance` §10).
+    GovernanceReconfigured,
+    /// A §7 conflict-freeze period expired.
+    GovernanceFreezeExpired,
+    /// A hard rate limit was modified (`ModifyHardRateLimit` §19.7 D4).
+    HardRateLimitModified,
+    /// The economic policy was locked (`LockEconomicPolicy` §19.3).
+    EconomicPolicyLocked,
+    /// A context migration started (`ProposeContextMigration` §5.11A grace
+    /// start).
+    ContextMigrationStarted,
+    /// A tool was removed (`RemoveTool`; pairs with
+    /// [`EventType::ToolRegistered`]).
+    ToolRemoved,
+    /// The pruning policy was modified (`ModifyPruningPolicy` ADR-030 §6).
+    PruningPolicyModified,
+    /// An MLS commit was broadcast (commit broadcast record §9.9
+    /// reconciliation).
+    CommitBroadcasted,
+    /// A commit broadcast was deferred to the queue (deferred-commit queue
+    /// record).
+    CommitBroadcastPending,
+    /// A per-context pseudonym was announced (§9.10.4).
+    PseudonymAnnounced,
+
+    // -------------------------------------------------------------------
+    // Lifecycle / migration event types (ADR-049 §9; §5.11A). Parameters
+    // live in [`EventPayload`], never in the type name.
+    // -------------------------------------------------------------------
+    /// A context was tombstoned at the terminal stage of migration
+    /// (§5.11A.5; `actor_did = "system"`).
+    ///
+    /// Payload (positional `MessagePack`): `destination_context_id: String`,
+    /// `migration_proposal_id: [u8; 32]`. See [`crate::payload`].
+    ContextTombstoned,
+    /// A context migration was cancelled (§5.11A; pairs with
+    /// [`EventType::ContextMigrationStarted`]).
+    ///
+    /// Payload (positional `MessagePack`): `original_proposal_id: [u8; 32]`.
+    /// See [`crate::payload`].
+    ContextMigrationCancelled,
+    /// A context TTL was unanimously extended (§5.10).
+    ///
+    /// Payload (positional `MessagePack`): `old_deadline_unix: u64`,
+    /// `new_deadline_unix: u64`, `proposal_id: [u8; 32]`,
+    /// `consenting_members: Vec<String>`. See [`crate::payload`].
+    TtlExtended,
+    /// A context TTL extension was denied (§5.10).
+    ///
+    /// Payload (positional `MessagePack`): `proposal_id: [u8; 32]`,
+    /// `rejecting_members: Vec<String>`. See [`crate::payload`].
+    TtlExtensionRejected,
+
+    // -------------------------------------------------------------------
+    // Content-access governance event types (ADR-031 §3; §5). Pairs with
+    // the existing [`EventType::AccessRestored`] variant.
+    // -------------------------------------------------------------------
+    /// Read or write access was revoked (`RevokeReadAccess` /
+    /// `RevokeWriteAccess`; payload: `target_did`, `scope`).
+    AccessRevoked,
+
+    // -------------------------------------------------------------------
+    // Economic event types (§19.6.1; ADR-031 §3).
+    // -------------------------------------------------------------------
+    /// A spend was approved (`ApproveSpend` governance action).
+    ///
+    /// Payload (positional `MessagePack`): `spender: String`,
+    /// `amount: u64`, `purpose: String`. See [`crate::payload`].
+    SpendApproved,
+    /// A payment capture failed (§19.6.1; payload: cost and capture-failure
+    /// detail).
+    PaymentCaptureFailed,
+
+    // -------------------------------------------------------------------
+    // Consequence-enforcement event types (phase-4 trust engine; §7.3.7).
+    // `actor_did` = the consequence-enforcement system actor.
+    // -------------------------------------------------------------------
+    /// A consequence-enforcement rule trigger fired (§7.3.7; payload:
+    /// `member_did`, `rule_index`, `trigger_kind`, `action_type`).
+    ConsequenceTriggered,
+    /// A consequence action was applied (§7.3.7; payload as above).
+    ConsequenceEnforced,
+    /// Consequence enforcement failed, e.g. member departed mid-flight
+    /// (§7.3.7; payload as above).
+    ConsequenceEnforcementFailed,
+    /// A consequence-enforcement failure escalated to `SuspendAll`
+    /// (§7.3.7; payload as above).
+    ConsequenceEscalatedToSuspendAll,
+
+    // -------------------------------------------------------------------
+    // MLS commit-broadcast reconciliation outcomes (§9.9.4). Pairs with
+    // [`EventType::CommitBroadcasted`] / [`EventType::CommitBroadcastPending`].
+    // -------------------------------------------------------------------
+    /// A deferred commit broadcast succeeded (§9.9.4; payload: `operation`,
+    /// `attempts`).
+    CommitBroadcastSucceeded,
+    /// A deferred commit broadcast permanently failed (§9.9.4; payload:
+    /// `operation`, `reason`, `attempts`).
+    CommitBroadcastFailed,
+
+    // -------------------------------------------------------------------
+    // Compromise-recovery event type (§9.12 step 2 "MLS Update in all
+    // active contexts"). Distinct from the ADR-007 sender-key
+    // [`EventType::KeyEpochAdvance`]: this records an MLS *group*-epoch
+    // advance (Update + self-Commit, broadcast to members) performed during
+    // trust recovery. `actor_did = "system:recovery"`.
+    // -------------------------------------------------------------------
+    /// An MLS group-epoch advance was performed during trust recovery
+    /// (§9.12 step 2).
+    ///
+    /// Payload (positional `MessagePack`): `old_epoch: u64`,
+    /// `new_epoch: u64`. See [`crate::payload`].
+    RecoveryEpochAdvanced,
+
+    // -------------------------------------------------------------------
+    // App-sandbox binding lifecycle (§8; "App binding and unbinding events
+    // are visible in the event log"). Parameters live in [`EventPayload`].
+    // -------------------------------------------------------------------
+    /// An app was bound to a context (§8).
+    ///
+    /// Payload (positional `MessagePack`): `app_did: String`,
+    /// `app_name: String`, `app_version: String`,
+    /// `capabilities: Vec<String>`. See [`crate::payload`].
+    AppBound,
+    /// An app was unbound from a context (§8).
+    ///
+    /// Payload (positional `MessagePack`): `app_did: String`. See
+    /// [`crate::payload`].
+    AppUnbound,
 }
 
 // ---------------------------------------------------------------------------
@@ -474,7 +649,22 @@ mod tests {
 
     #[test]
     fn event_type_serialization_roundtrip_all_variants() {
-        let event_types = vec![
+        // Round-trips every variant of the closed taxonomy through serde JSON.
+        // The 76-variant count and wire-distinctness are pinned separately in
+        // `event_type_taxonomy_is_closed_at_76_distinct_variants`.
+        for event_type in all_event_types() {
+            let json = serde_json::to_string(&event_type).expect("serialize");
+            let deserialized: EventType = serde_json::from_str(&json).expect("deserialize");
+            assert_eq!(
+                event_type, deserialized,
+                "round-trip mismatch for {event_type:?}"
+            );
+        }
+    }
+    /// Returns the complete closed `EventType` taxonomy in ADR declaration
+    /// order. Used by the round-trip and distinctness coverage tests.
+    fn all_event_types() -> Vec<EventType> {
+        vec![
             EventType::ContextCreated,
             EventType::ContextClosing,
             EventType::ContextClosed,
@@ -501,7 +691,6 @@ mod tests {
             EventType::EconomicPolicyApplied,
             EventType::SpendingUcanGranted,
             EventType::SpendingUcanRevoked,
-            // Governance event types (ADR-031 §8)
             EventType::GovernanceProposalCreated,
             EventType::GovernanceVoteCast,
             EventType::GovernanceVoteWithdrawn,
@@ -510,26 +699,74 @@ mod tests {
             EventType::GovernanceConflictResolved,
             EventType::GovernanceDeadlockRecovery,
             EventType::GovernanceActionExecuted,
-            // Provenance event types (issue #586)
             EventType::ProvenanceAttached,
             EventType::ProvenanceReceived,
-        ];
+            EventType::AdminTransferred,
+            EventType::CeilingModified,
+            EventType::CeilingModificationPending,
+            EventType::ThresholdModified,
+            EventType::SignerAdded,
+            EventType::SignerRemoved,
+            EventType::ChildContextCreated,
+            EventType::ContextPromoted,
+            EventType::ContentKeysRotated,
+            EventType::MemberReset,
+            EventType::MemberSuspended,
+            EventType::MemberSuspendedAll,
+            EventType::MemberUnblocked,
+            EventType::AccessRestored,
+            EventType::GovernanceReconfigured,
+            EventType::GovernanceFreezeExpired,
+            EventType::HardRateLimitModified,
+            EventType::EconomicPolicyLocked,
+            EventType::ContextMigrationStarted,
+            EventType::ToolRemoved,
+            EventType::PruningPolicyModified,
+            EventType::CommitBroadcasted,
+            EventType::CommitBroadcastPending,
+            EventType::PseudonymAnnounced,
+            EventType::ContextTombstoned,
+            EventType::ContextMigrationCancelled,
+            EventType::TtlExtended,
+            EventType::TtlExtensionRejected,
+            EventType::AccessRevoked,
+            EventType::SpendApproved,
+            EventType::PaymentCaptureFailed,
+            EventType::ConsequenceTriggered,
+            EventType::ConsequenceEnforced,
+            EventType::ConsequenceEnforcementFailed,
+            EventType::ConsequenceEscalatedToSuspendAll,
+            EventType::CommitBroadcastSucceeded,
+            EventType::CommitBroadcastFailed,
+            EventType::RecoveryEpochAdvanced,
+            EventType::AppBound,
+            EventType::AppUnbound,
+        ]
+    }
 
-        // Verify all 36 variants are covered.
+    #[test]
+    fn event_type_taxonomy_is_closed_at_76_distinct_variants() {
+        // Pins the closed-set count and asserts wire-distinctness, independent
+        // of the round-trip test (which would otherwise exceed the function
+        // line limit).
+        let event_types = all_event_types();
         assert_eq!(
             event_types.len(),
-            36,
-            "all EventType variants must be tested"
+            76,
+            "closed EventType taxonomy must enumerate exactly 76 variants"
         );
 
-        for event_type in &event_types {
-            let json = serde_json::to_string(event_type).expect("serialize");
-            let deserialized: EventType = serde_json::from_str(&json).expect("deserialize");
-            assert_eq!(
-                event_type, &deserialized,
-                "round-trip mismatch for {event_type:?}"
-            );
-        }
+        let mut serialized: Vec<String> = event_types
+            .iter()
+            .map(|et| serde_json::to_string(et).expect("serialize"))
+            .collect();
+        serialized.sort();
+        serialized.dedup();
+        assert_eq!(
+            serialized.len(),
+            76,
+            "all 76 EventType variants must serialize to distinct values"
+        );
     }
 
     #[test]

--- a/crates/scp-event-log/src/lib.rs
+++ b/crates/scp-event-log/src/lib.rs
@@ -289,7 +289,7 @@ pub enum EventType {
     /// A context was tombstoned at the terminal stage of migration
     /// (§5.11A.5; `actor_did = "system"`).
     ///
-    /// Payload (positional `MessagePack`): `destination_context_id: String`,
+    /// Payload (positional `MessagePack`): `destination_id: String`,
     /// `migration_proposal_id: [u8; 32]`. See [`crate::payload`].
     ContextTombstoned,
     /// A context migration was cancelled (§5.11A; pairs with

--- a/crates/scp-event-log/src/payload.rs
+++ b/crates/scp-event-log/src/payload.rs
@@ -12,8 +12,10 @@
 //! whose parameters live in [`EventPayload`](crate::EventPayload).
 //!
 //! This module is the **single source** of the payload bytes for those
-//! structured variants. Both the native runtime (`scp-runtime`) and the WASM
-//! bridge MUST call these functions so that native↔WASM Merkle roots match:
+//! structured variants. As the emit sites are wired (in later phases of the
+//! native↔WASM unification — Phase 1 establishes the types; production callers
+//! land later), both the native runtime (`scp-runtime`) and the WASM bridge
+//! MUST route through these functions so that native↔WASM Merkle roots match:
 //! the leaf preimage is `SHA-256(0x00 ‖ rmp_serde(Event))`, and `Event.payload`
 //! is `EventPayload { data: <bytes from this module> }`. If two implementations
 //! encoded the same logical payload differently, the leaf hashes would diverge

--- a/crates/scp-event-log/src/payload.rs
+++ b/crates/scp-event-log/src/payload.rs
@@ -79,7 +79,7 @@ pub fn decode_payload<T: for<'de> Deserialize<'de>>(
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct ContextTombstonedPayload {
     /// The context the migration tombstone points to.
-    pub destination_context_id: String,
+    pub destination_id: String,
     /// The migration proposal that authorized the tombstone.
     pub migration_proposal_id: [u8; 32],
 }
@@ -190,7 +190,7 @@ mod tests {
     #[test]
     fn context_tombstoned_round_trip() {
         let p = ContextTombstonedPayload {
-            destination_context_id: "ctx-dest-1".to_owned(),
+            destination_id: "ctx-dest-1".to_owned(),
             migration_proposal_id: [7u8; 32],
         };
         let encoded = encode_payload(&p).unwrap();

--- a/crates/scp-event-log/src/payload.rs
+++ b/crates/scp-event-log/src/payload.rs
@@ -1,0 +1,305 @@
+//! Per-variant structured payload encoders for [`EventType`](crate::EventType).
+//!
+//! # Why this module exists
+//!
+//! Several runtime call sites historically baked event parameters into the
+//! event *name* — either as `format!` strings
+//! (`"ContextTombstoned:{dest}:{pid}"`) or as an entire JSON blob used as the
+//! type tag (`{"event":"SpendApproved",…}`). The ADR-011 native↔WASM
+//! unification amendment (`.docs/adrs/phase-2.md`) identifies each as a defect:
+//! it makes the signed Merkle-leaf preimage non-convergent and un-enumerable.
+//! The correct end state is a typed [`EventType`](crate::EventType) variant
+//! whose parameters live in [`EventPayload`](crate::EventPayload).
+//!
+//! This module is the **single source** of the payload bytes for those
+//! structured variants. Both the native runtime (`scp-runtime`) and the WASM
+//! bridge MUST call these functions so that native↔WASM Merkle roots match:
+//! the leaf preimage is `SHA-256(0x00 ‖ rmp_serde(Event))`, and `Event.payload`
+//! is `EventPayload { data: <bytes from this module> }`. If two implementations
+//! encoded the same logical payload differently, the leaf hashes would diverge
+//! and §9.9.3 equivocation detection would produce false positives.
+//!
+//! # Encoding
+//!
+//! Each payload struct derives [`Serialize`]/[`Deserialize`] and is encoded with
+//! **positional** [`rmp_serde::to_vec`] (NOT `to_vec_named`). Positional
+//! `MessagePack` encodes a struct as a fixed-length array of its fields in
+//! declaration order, omitting field-name strings. This is deterministic and
+//! compact, and — critically — does not depend on a map-key ordering that could
+//! differ across serde versions or implementations. Field order is therefore
+//! part of the wire contract: **never reorder fields** in these structs without
+//! treating it as a breaking protocol change.
+
+use serde::{Deserialize, Serialize};
+
+use crate::{EventLogError, EventPayload};
+
+/// Encodes a structured payload struct into [`EventPayload`] bytes using
+/// positional `MessagePack`.
+///
+/// This is the single shared entry point that both native and WASM callers use
+/// to produce the leaf-preimage payload bytes.
+///
+/// # Errors
+///
+/// Returns [`EventLogError::SerializationFailed`] if `MessagePack` encoding
+/// fails (e.g. an unrepresentable value).
+pub fn encode_payload<T: Serialize>(value: &T) -> Result<EventPayload, EventLogError> {
+    let data =
+        rmp_serde::to_vec(value).map_err(|e| EventLogError::SerializationFailed(e.to_string()))?;
+    Ok(EventPayload { data })
+}
+
+/// Decodes a structured payload struct from [`EventPayload`] bytes.
+///
+/// The inverse of [`encode_payload`]. Used by verifiers and the receive path to
+/// recover the typed parameters from a logged event.
+///
+/// # Errors
+///
+/// Returns [`EventLogError::SerializationFailed`] if the bytes do not decode to
+/// `T` under positional `MessagePack`.
+pub fn decode_payload<T: for<'de> Deserialize<'de>>(
+    payload: &EventPayload,
+) -> Result<T, EventLogError> {
+    rmp_serde::from_slice(&payload.data)
+        .map_err(|e| EventLogError::SerializationFailed(e.to_string()))
+}
+
+// ---------------------------------------------------------------------------
+// Per-variant payload structs
+//
+// Field order is the wire contract under positional MessagePack. NEVER reorder.
+// Field shapes are governed by the ADR-011 amendment variant comments
+// (`.docs/adrs/phase-2.md`) and the existing typed sources they replace.
+// ---------------------------------------------------------------------------
+
+/// Payload for [`EventType::ContextTombstoned`](crate::EventType::ContextTombstoned)
+/// (§5.11A.5 terminal migration).
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ContextTombstonedPayload {
+    /// The context the migration tombstone points to.
+    pub destination_context_id: String,
+    /// The migration proposal that authorized the tombstone.
+    pub migration_proposal_id: [u8; 32],
+}
+
+/// Payload for
+/// [`EventType::ContextMigrationCancelled`](crate::EventType::ContextMigrationCancelled)
+/// (§5.11A migration abort).
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ContextMigrationCancelledPayload {
+    /// The migration proposal that was cancelled.
+    pub original_proposal_id: [u8; 32],
+}
+
+/// Payload for [`EventType::AppBound`](crate::EventType::AppBound) (§8 app bound
+/// to context).
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct AppBoundPayload {
+    /// The DID of the app being bound.
+    pub app_did: String,
+    /// The app's declared name.
+    pub app_name: String,
+    /// The app's declared version.
+    pub app_version: String,
+    /// The capabilities granted to the app on binding.
+    pub capabilities: Vec<String>,
+}
+
+/// Payload for [`EventType::AppUnbound`](crate::EventType::AppUnbound) (§8 app
+/// unbound from context).
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct AppUnboundPayload {
+    /// The DID of the app being unbound.
+    pub app_did: String,
+}
+
+/// Payload for [`EventType::SpendApproved`](crate::EventType::SpendApproved)
+/// (`ApproveSpend` governance action, §19.6.1).
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct SpendApprovedPayload {
+    /// The DID authorized to spend.
+    pub spender: String,
+    /// The approved spend amount.
+    pub amount: u64,
+    /// A human-readable description of the approved spend.
+    pub purpose: String,
+}
+
+/// Payload for [`EventType::TtlExtended`](crate::EventType::TtlExtended) (§5.10
+/// unanimous TTL extension).
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct TtlExtendedPayload {
+    /// The previous TTL deadline (Unix seconds).
+    pub old_deadline_unix: u64,
+    /// The new TTL deadline (Unix seconds).
+    pub new_deadline_unix: u64,
+    /// The proposal that authorized the extension.
+    pub proposal_id: [u8; 32],
+    /// The members who consented to the extension.
+    pub consenting_members: Vec<String>,
+}
+
+/// Payload for
+/// [`EventType::TtlExtensionRejected`](crate::EventType::TtlExtensionRejected)
+/// (§5.10 TTL extension denied).
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct TtlExtensionRejectedPayload {
+    /// The proposal whose extension was rejected.
+    pub proposal_id: [u8; 32],
+    /// The members who rejected the extension.
+    pub rejecting_members: Vec<String>,
+}
+
+/// Payload for
+/// [`EventType::RecoveryEpochAdvanced`](crate::EventType::RecoveryEpochAdvanced)
+/// (§9.12 step 2 MLS group-epoch advance during trust recovery).
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct RecoveryEpochAdvancedPayload {
+    /// The MLS group epoch before the advance.
+    pub old_epoch: u64,
+    /// The MLS group epoch after the advance.
+    pub new_epoch: u64,
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used)]
+mod tests {
+    use super::*;
+
+    /// Asserts that positional `MessagePack` encodes the struct as a
+    /// fixed-length array (first byte is a fixarray marker `0x9N`), proving we
+    /// are NOT emitting a field-name map.
+    fn assert_positional_array(bytes: &[u8], expected_len: usize) {
+        assert!(!bytes.is_empty(), "encoded payload must be non-empty");
+        let marker = bytes[0];
+        // MessagePack fixarray: 0x90..=0x9f, low nibble is the element count.
+        assert_eq!(
+            marker & 0xf0,
+            0x90,
+            "positional encoding must be a fixarray (got marker {marker:#04x})"
+        );
+        assert_eq!(
+            usize::from(marker & 0x0f),
+            expected_len,
+            "fixarray element count must equal the struct field count"
+        );
+    }
+
+    #[test]
+    fn context_tombstoned_round_trip() {
+        let p = ContextTombstonedPayload {
+            destination_context_id: "ctx-dest-1".to_owned(),
+            migration_proposal_id: [7u8; 32],
+        };
+        let encoded = encode_payload(&p).unwrap();
+        assert_positional_array(&encoded.data, 2);
+        let decoded: ContextTombstonedPayload = decode_payload(&encoded).unwrap();
+        assert_eq!(p, decoded);
+    }
+
+    #[test]
+    fn context_migration_cancelled_round_trip() {
+        let p = ContextMigrationCancelledPayload {
+            original_proposal_id: [3u8; 32],
+        };
+        let encoded = encode_payload(&p).unwrap();
+        assert_positional_array(&encoded.data, 1);
+        let decoded: ContextMigrationCancelledPayload = decode_payload(&encoded).unwrap();
+        assert_eq!(p, decoded);
+    }
+
+    #[test]
+    fn app_bound_round_trip() {
+        let p = AppBoundPayload {
+            app_did: "did:key:app".to_owned(),
+            app_name: "Scheduler".to_owned(),
+            app_version: "1.2.3".to_owned(),
+            capabilities: vec!["tool:invoke:*".to_owned(), "message:send".to_owned()],
+        };
+        let encoded = encode_payload(&p).unwrap();
+        assert_positional_array(&encoded.data, 4);
+        let decoded: AppBoundPayload = decode_payload(&encoded).unwrap();
+        assert_eq!(p, decoded);
+    }
+
+    #[test]
+    fn app_unbound_round_trip() {
+        let p = AppUnboundPayload {
+            app_did: "did:key:app".to_owned(),
+        };
+        let encoded = encode_payload(&p).unwrap();
+        assert_positional_array(&encoded.data, 1);
+        let decoded: AppUnboundPayload = decode_payload(&encoded).unwrap();
+        assert_eq!(p, decoded);
+    }
+
+    #[test]
+    fn spend_approved_round_trip() {
+        let p = SpendApprovedPayload {
+            spender: "did:key:agent".to_owned(),
+            amount: 42_000,
+            purpose: "compute budget".to_owned(),
+        };
+        let encoded = encode_payload(&p).unwrap();
+        assert_positional_array(&encoded.data, 3);
+        let decoded: SpendApprovedPayload = decode_payload(&encoded).unwrap();
+        assert_eq!(p, decoded);
+    }
+
+    #[test]
+    fn ttl_extended_round_trip() {
+        let p = TtlExtendedPayload {
+            old_deadline_unix: 1_000_000,
+            new_deadline_unix: 2_000_000,
+            proposal_id: [9u8; 32],
+            consenting_members: vec!["did:key:a".to_owned(), "did:key:b".to_owned()],
+        };
+        let encoded = encode_payload(&p).unwrap();
+        assert_positional_array(&encoded.data, 4);
+        let decoded: TtlExtendedPayload = decode_payload(&encoded).unwrap();
+        assert_eq!(p, decoded);
+    }
+
+    #[test]
+    fn ttl_extension_rejected_round_trip() {
+        let p = TtlExtensionRejectedPayload {
+            proposal_id: [5u8; 32],
+            rejecting_members: vec!["did:key:c".to_owned()],
+        };
+        let encoded = encode_payload(&p).unwrap();
+        assert_positional_array(&encoded.data, 2);
+        let decoded: TtlExtensionRejectedPayload = decode_payload(&encoded).unwrap();
+        assert_eq!(p, decoded);
+    }
+
+    #[test]
+    fn recovery_epoch_advanced_round_trip() {
+        let p = RecoveryEpochAdvancedPayload {
+            old_epoch: 11,
+            new_epoch: 12,
+        };
+        let encoded = encode_payload(&p).unwrap();
+        assert_positional_array(&encoded.data, 2);
+        let decoded: RecoveryEpochAdvancedPayload = decode_payload(&encoded).unwrap();
+        assert_eq!(p, decoded);
+    }
+
+    #[test]
+    fn empty_collections_round_trip() {
+        // Boundary: empty consenting/rejecting/capability vectors must survive
+        // the round trip and still produce a fixarray of the struct's field
+        // count (the empty Vec is one element, encoded as an empty array).
+        let p = TtlExtendedPayload {
+            old_deadline_unix: 0,
+            new_deadline_unix: 0,
+            proposal_id: [0u8; 32],
+            consenting_members: Vec::new(),
+        };
+        let encoded = encode_payload(&p).unwrap();
+        assert_positional_array(&encoded.data, 4);
+        let decoded: TtlExtendedPayload = decode_payload(&encoded).unwrap();
+        assert_eq!(p, decoded);
+    }
+}

--- a/crates/scp-event-log/src/pruning.rs
+++ b/crates/scp-event-log/src/pruning.rs
@@ -1125,71 +1125,111 @@ mod tests {
 
     #[test]
     fn structural_events_classified_correctly() {
-        // --- Base structural variants (unchanged) ---
-        assert!(is_structural_event(&EventType::ContextCreated));
-        assert!(is_structural_event(&EventType::MemberJoined));
-        assert!(is_structural_event(&EventType::MemberLeft));
-        assert!(is_structural_event(&EventType::RoleAssigned));
-        assert!(is_structural_event(&EventType::GovernanceAction));
-        assert!(is_structural_event(&EventType::ContextClosing));
-        assert!(is_structural_event(&EventType::ContextClosed));
-        assert!(is_structural_event(&EventType::ContextExpired));
-        assert!(is_structural_event(&EventType::MemberBlocked));
-        assert!(is_structural_event(&EventType::ConsistencyCheckpoint));
+        // The full closed `EventType` taxonomy (76 variants) paired with its
+        // EXPECTED structural/operational classification. `true` = structural
+        // (retained longer per ADR-030 §2c); `false` = operational. This pins
+        // the CORRECT decision for every variant — not merely that a decision
+        // exists — so a future re-classification of any variant must update this
+        // table deliberately. The expected values mirror the cryptographer-
+        // confirmed classification in `is_structural_event`.
+        const EXPECTED: [(EventType, bool); 76] = [
+            // --- Base variants ---
+            (EventType::ContextCreated, true),
+            (EventType::ContextClosing, true),
+            (EventType::ContextClosed, true),
+            (EventType::ContextExpired, true),
+            (EventType::MemberJoined, true),
+            (EventType::MemberLeft, true),
+            (EventType::RoleAssigned, true),
+            (EventType::TokenRevoked, false),
+            (EventType::MessageSent, false),
+            (EventType::ToolRegistered, false),
+            (EventType::ToolUpdated, false),
+            (EventType::ToolInvoked, false),
+            (EventType::ToolVerified, false),
+            (EventType::ToolInterfaceEstablished, false),
+            (EventType::GovernanceAction, true),
+            (EventType::ConsistencyCheckpoint, true),
+            (EventType::AbsenceProofRequested, false),
+            (EventType::MemberBlocked, true),
+            (EventType::KeyEpochAdvance, false),
+            (EventType::MediaSessionStarted, false),
+            (EventType::MediaSessionEnded, false),
+            (EventType::PaymentReceived, false),
+            (EventType::EconomicPolicyChanged, false),
+            (EventType::EconomicPolicyApplied, false),
+            (EventType::SpendingUcanGranted, false),
+            (EventType::SpendingUcanRevoked, false),
+            (EventType::GovernanceProposalCreated, false),
+            (EventType::GovernanceVoteCast, false),
+            (EventType::GovernanceVoteWithdrawn, false),
+            (EventType::GovernanceProposalResolved, false),
+            (EventType::GovernanceConflictDetected, false),
+            (EventType::GovernanceConflictResolved, false),
+            (EventType::GovernanceDeadlockRecovery, false),
+            (EventType::GovernanceActionExecuted, false),
+            (EventType::ProvenanceAttached, false),
+            (EventType::ProvenanceReceived, false),
+            // --- Unification variants (ADR-011 Amendment) ---
+            (EventType::AdminTransferred, true),
+            (EventType::CeilingModified, true),
+            (EventType::CeilingModificationPending, true),
+            (EventType::ThresholdModified, true),
+            (EventType::SignerAdded, true),
+            (EventType::SignerRemoved, true),
+            (EventType::ChildContextCreated, true),
+            (EventType::ContextPromoted, true),
+            (EventType::ContentKeysRotated, true),
+            (EventType::MemberReset, true),
+            (EventType::MemberSuspended, true),
+            (EventType::MemberSuspendedAll, true),
+            (EventType::MemberUnblocked, true),
+            (EventType::AccessRestored, true),
+            (EventType::GovernanceReconfigured, true),
+            (EventType::GovernanceFreezeExpired, true),
+            (EventType::HardRateLimitModified, true),
+            (EventType::EconomicPolicyLocked, true),
+            (EventType::ContextMigrationStarted, true),
+            (EventType::ToolRemoved, true),
+            (EventType::PruningPolicyModified, true),
+            (EventType::CommitBroadcasted, false),
+            (EventType::CommitBroadcastPending, false),
+            (EventType::PseudonymAnnounced, false),
+            (EventType::ContextTombstoned, true),
+            (EventType::ContextMigrationCancelled, true),
+            (EventType::TtlExtended, true),
+            (EventType::TtlExtensionRejected, true),
+            (EventType::AccessRevoked, true),
+            (EventType::SpendApproved, true),
+            (EventType::PaymentCaptureFailed, false),
+            (EventType::ConsequenceTriggered, true),
+            (EventType::ConsequenceEnforced, true),
+            (EventType::ConsequenceEnforcementFailed, true),
+            (EventType::ConsequenceEscalatedToSuspendAll, true),
+            (EventType::CommitBroadcastSucceeded, false),
+            (EventType::CommitBroadcastFailed, false),
+            (EventType::RecoveryEpochAdvanced, true),
+            (EventType::AppBound, true),
+            (EventType::AppUnbound, true),
+        ];
 
-        // --- Base operational variants (unchanged) ---
-        assert!(!is_structural_event(&EventType::MessageSent));
-        assert!(!is_structural_event(&EventType::ToolInvoked));
-        assert!(!is_structural_event(&EventType::ToolVerified));
-        assert!(!is_structural_event(&EventType::KeyEpochAdvance));
+        // Exhaustiveness guard: the table must cover the full closed taxonomy
+        // (exactly 76 variants). Adding a variant to `EventType` without adding
+        // it here leaves it unclassified-by-test, so this count is pinned.
+        assert_eq!(
+            EXPECTED.len(),
+            76,
+            "classification table must cover all 76 EventType variants"
+        );
 
-        // --- Unification variants: STRUCTURAL (ADR-011 Amendment) ---
-        assert!(is_structural_event(&EventType::AdminTransferred));
-        assert!(is_structural_event(&EventType::CeilingModified));
-        assert!(is_structural_event(&EventType::CeilingModificationPending));
-        assert!(is_structural_event(&EventType::ThresholdModified));
-        assert!(is_structural_event(&EventType::SignerAdded));
-        assert!(is_structural_event(&EventType::SignerRemoved));
-        assert!(is_structural_event(&EventType::ChildContextCreated));
-        assert!(is_structural_event(&EventType::ContextPromoted));
-        assert!(is_structural_event(&EventType::ContentKeysRotated));
-        assert!(is_structural_event(&EventType::MemberReset));
-        assert!(is_structural_event(&EventType::MemberSuspended));
-        assert!(is_structural_event(&EventType::MemberSuspendedAll));
-        assert!(is_structural_event(&EventType::MemberUnblocked));
-        assert!(is_structural_event(&EventType::AccessRestored));
-        assert!(is_structural_event(&EventType::AccessRevoked));
-        assert!(is_structural_event(&EventType::GovernanceReconfigured));
-        assert!(is_structural_event(&EventType::GovernanceFreezeExpired));
-        assert!(is_structural_event(&EventType::HardRateLimitModified));
-        assert!(is_structural_event(&EventType::EconomicPolicyLocked));
-        assert!(is_structural_event(&EventType::ContextMigrationStarted));
-        assert!(is_structural_event(&EventType::ContextMigrationCancelled));
-        assert!(is_structural_event(&EventType::ContextTombstoned));
-        assert!(is_structural_event(&EventType::ToolRemoved));
-        assert!(is_structural_event(&EventType::PruningPolicyModified));
-        assert!(is_structural_event(&EventType::TtlExtended));
-        assert!(is_structural_event(&EventType::TtlExtensionRejected));
-        assert!(is_structural_event(&EventType::RecoveryEpochAdvanced));
-        assert!(is_structural_event(&EventType::SpendApproved));
-        assert!(is_structural_event(&EventType::ConsequenceTriggered));
-        assert!(is_structural_event(&EventType::ConsequenceEnforced));
-        assert!(is_structural_event(
-            &EventType::ConsequenceEnforcementFailed
-        ));
-        assert!(is_structural_event(
-            &EventType::ConsequenceEscalatedToSuspendAll
-        ));
-        assert!(is_structural_event(&EventType::AppBound));
-        assert!(is_structural_event(&EventType::AppUnbound));
-
-        // --- Unification variants: OPERATIONAL (high-frequency records) ---
-        assert!(!is_structural_event(&EventType::PseudonymAnnounced));
-        assert!(!is_structural_event(&EventType::CommitBroadcasted));
-        assert!(!is_structural_event(&EventType::CommitBroadcastPending));
-        assert!(!is_structural_event(&EventType::CommitBroadcastSucceeded));
-        assert!(!is_structural_event(&EventType::CommitBroadcastFailed));
-        assert!(!is_structural_event(&EventType::PaymentCaptureFailed));
+        for (event_type, expected_structural) in &EXPECTED {
+            assert_eq!(
+                is_structural_event(event_type),
+                *expected_structural,
+                "{event_type:?} classification mismatch: \
+                 expected structural={expected_structural}"
+            );
+        }
     }
 
     // ===================================================================

--- a/crates/scp-event-log/src/pruning.rs
+++ b/crates/scp-event-log/src/pruning.rs
@@ -366,23 +366,127 @@ pub fn verify_compact_proof(proof: &CompactProof) -> bool {
 
 /// Returns `true` if the event type is a structural event.
 ///
-/// Structural events (governance, membership) are retained longer than
-/// operational events per ADR-030 section 2c.
+/// Structural events (governance / membership / lifecycle / structural
+/// evolution) are retained longer than operational (high-frequency) events per
+/// ADR-030 §2c: they "define the context's structural evolution and are
+/// essential for state reconstruction verification" (`.docs/adrs/phase-6.md`).
+///
+/// The match is **exhaustive** (no `_` arm) so that adding a future
+/// [`EventType`] variant forces an explicit structural/operational
+/// classification decision at compile time rather than silently defaulting.
+///
+/// The 36 base variants retain their established classification. The 40
+/// native↔WASM unification variants (ADR-011 Amendment) are classified per the
+/// same §2c rationale: governance / membership / lifecycle /
+/// structural-evolution events are structural; high-frequency operational
+/// records are operational.
+///
+/// Classification note (pending cryptographer confirmation):
+/// [`EventType::ContentKeysRotated`] and [`EventType::RecoveryEpochAdvanced`]
+/// are classified **structural** here. The existing related
+/// [`EventType::KeyEpochAdvance`] (ADR-007 sender-key epoch rotation) is
+/// classified **operational**. The distinction is deliberate —
+/// `ContentKeysRotated`/`RecoveryEpochAdvanced` record content-key rotation and
+/// a trust-recovery MLS group-epoch advance, which are structural-evolution /
+/// accountability events, whereas `KeyEpochAdvance` is a higher-frequency
+/// sender-key rotation record. This split is pending cryptographer
+/// confirmation.
 #[must_use]
 pub const fn is_structural_event(event_type: &EventType) -> bool {
-    matches!(
-        event_type,
+    // Two arms (one `true`, one `false`) with inline comment groupings, kept as
+    // a single exhaustive `match` (no `_`) so a future variant forces an
+    // explicit decision. The arms are merged (rather than grouped per
+    // base/unification origin) to satisfy `clippy::match_same_arms`; the
+    // origin/rationale grouping is preserved in the comments below.
+    match event_type {
+        // === STRUCTURAL (retained longer per ADR-030 §2c) ===
+        //
+        // Base structural variants (unchanged classification):
         EventType::ContextCreated
-            | EventType::MemberJoined
-            | EventType::MemberLeft
-            | EventType::RoleAssigned
-            | EventType::GovernanceAction
-            | EventType::ContextClosing
-            | EventType::ContextClosed
-            | EventType::ContextExpired
-            | EventType::MemberBlocked
-            | EventType::ConsistencyCheckpoint
-    )
+        | EventType::MemberJoined
+        | EventType::MemberLeft
+        | EventType::RoleAssigned
+        | EventType::GovernanceAction
+        | EventType::ContextClosing
+        | EventType::ContextClosed
+        | EventType::ContextExpired
+        | EventType::MemberBlocked
+        | EventType::ConsistencyCheckpoint
+        // Unification variants — governance / membership / lifecycle /
+        // structural-evolution (ADR-011 Amendment):
+        | EventType::AdminTransferred
+        | EventType::CeilingModified
+        | EventType::CeilingModificationPending
+        | EventType::ThresholdModified
+        | EventType::SignerAdded
+        | EventType::SignerRemoved
+        | EventType::ChildContextCreated
+        | EventType::ContextPromoted
+        | EventType::ContentKeysRotated
+        | EventType::MemberReset
+        | EventType::MemberSuspended
+        | EventType::MemberSuspendedAll
+        | EventType::MemberUnblocked
+        | EventType::AccessRestored
+        | EventType::AccessRevoked
+        | EventType::GovernanceReconfigured
+        | EventType::GovernanceFreezeExpired
+        | EventType::HardRateLimitModified
+        | EventType::EconomicPolicyLocked
+        | EventType::ContextMigrationStarted
+        | EventType::ContextMigrationCancelled
+        | EventType::ContextTombstoned
+        | EventType::ToolRemoved
+        | EventType::PruningPolicyModified
+        | EventType::TtlExtended
+        | EventType::TtlExtensionRejected
+        | EventType::RecoveryEpochAdvanced
+        | EventType::SpendApproved
+        | EventType::ConsequenceTriggered
+        | EventType::ConsequenceEnforced
+        | EventType::ConsequenceEnforcementFailed
+        | EventType::ConsequenceEscalatedToSuspendAll
+        | EventType::AppBound
+        | EventType::AppUnbound => true,
+
+        // === OPERATIONAL (base retention; high-frequency records) ===
+        //
+        // Base operational variants (unchanged classification):
+        EventType::TokenRevoked
+        | EventType::MessageSent
+        | EventType::ToolRegistered
+        | EventType::ToolUpdated
+        | EventType::ToolInvoked
+        | EventType::ToolVerified
+        | EventType::ToolInterfaceEstablished
+        | EventType::AbsenceProofRequested
+        | EventType::KeyEpochAdvance
+        | EventType::MediaSessionStarted
+        | EventType::MediaSessionEnded
+        | EventType::PaymentReceived
+        | EventType::EconomicPolicyChanged
+        | EventType::EconomicPolicyApplied
+        | EventType::SpendingUcanGranted
+        | EventType::SpendingUcanRevoked
+        | EventType::GovernanceProposalCreated
+        | EventType::GovernanceVoteCast
+        | EventType::GovernanceVoteWithdrawn
+        | EventType::GovernanceProposalResolved
+        | EventType::GovernanceConflictDetected
+        | EventType::GovernanceConflictResolved
+        | EventType::GovernanceDeadlockRecovery
+        | EventType::GovernanceActionExecuted
+        | EventType::ProvenanceAttached
+        | EventType::ProvenanceReceived
+        // Unification variants — high-frequency operational records
+        // (ADR-011 Amendment):
+        | EventType::PseudonymAnnounced
+        | EventType::CommitBroadcasted
+        | EventType::CommitBroadcastPending
+        | EventType::CommitBroadcastSucceeded
+        | EventType::CommitBroadcastFailed
+        | EventType::PaymentCaptureFailed => false,
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -1022,6 +1126,7 @@ mod tests {
 
     #[test]
     fn structural_events_classified_correctly() {
+        // --- Base structural variants (unchanged) ---
         assert!(is_structural_event(&EventType::ContextCreated));
         assert!(is_structural_event(&EventType::MemberJoined));
         assert!(is_structural_event(&EventType::MemberLeft));
@@ -1033,10 +1138,59 @@ mod tests {
         assert!(is_structural_event(&EventType::MemberBlocked));
         assert!(is_structural_event(&EventType::ConsistencyCheckpoint));
 
+        // --- Base operational variants (unchanged) ---
         assert!(!is_structural_event(&EventType::MessageSent));
         assert!(!is_structural_event(&EventType::ToolInvoked));
         assert!(!is_structural_event(&EventType::ToolVerified));
         assert!(!is_structural_event(&EventType::KeyEpochAdvance));
+
+        // --- Unification variants: STRUCTURAL (ADR-011 Amendment) ---
+        assert!(is_structural_event(&EventType::AdminTransferred));
+        assert!(is_structural_event(&EventType::CeilingModified));
+        assert!(is_structural_event(&EventType::CeilingModificationPending));
+        assert!(is_structural_event(&EventType::ThresholdModified));
+        assert!(is_structural_event(&EventType::SignerAdded));
+        assert!(is_structural_event(&EventType::SignerRemoved));
+        assert!(is_structural_event(&EventType::ChildContextCreated));
+        assert!(is_structural_event(&EventType::ContextPromoted));
+        assert!(is_structural_event(&EventType::ContentKeysRotated));
+        assert!(is_structural_event(&EventType::MemberReset));
+        assert!(is_structural_event(&EventType::MemberSuspended));
+        assert!(is_structural_event(&EventType::MemberSuspendedAll));
+        assert!(is_structural_event(&EventType::MemberUnblocked));
+        assert!(is_structural_event(&EventType::AccessRestored));
+        assert!(is_structural_event(&EventType::AccessRevoked));
+        assert!(is_structural_event(&EventType::GovernanceReconfigured));
+        assert!(is_structural_event(&EventType::GovernanceFreezeExpired));
+        assert!(is_structural_event(&EventType::HardRateLimitModified));
+        assert!(is_structural_event(&EventType::EconomicPolicyLocked));
+        assert!(is_structural_event(&EventType::ContextMigrationStarted));
+        assert!(is_structural_event(&EventType::ContextMigrationCancelled));
+        assert!(is_structural_event(&EventType::ContextTombstoned));
+        assert!(is_structural_event(&EventType::ToolRemoved));
+        assert!(is_structural_event(&EventType::PruningPolicyModified));
+        assert!(is_structural_event(&EventType::TtlExtended));
+        assert!(is_structural_event(&EventType::TtlExtensionRejected));
+        assert!(is_structural_event(&EventType::RecoveryEpochAdvanced));
+        assert!(is_structural_event(&EventType::SpendApproved));
+        assert!(is_structural_event(&EventType::ConsequenceTriggered));
+        assert!(is_structural_event(&EventType::ConsequenceEnforced));
+        assert!(is_structural_event(
+            &EventType::ConsequenceEnforcementFailed
+        ));
+        assert!(is_structural_event(
+            &EventType::ConsequenceEscalatedToSuspendAll
+        ));
+        assert!(is_structural_event(&EventType::AppBound));
+        assert!(is_structural_event(&EventType::AppUnbound));
+
+        // --- Unification variants: OPERATIONAL (high-frequency records) ---
+        assert!(!is_structural_event(&EventType::PseudonymAnnounced));
+        assert!(!is_structural_event(&EventType::CommitBroadcasted));
+        assert!(!is_structural_event(&EventType::CommitBroadcastPending));
+        assert!(!is_structural_event(&EventType::CommitBroadcastSucceeded));
+        assert!(!is_structural_event(&EventType::CommitBroadcastFailed));
+        assert!(!is_structural_event(&EventType::PaymentCaptureFailed));
     }
 
     // ===================================================================

--- a/crates/scp-event-log/src/pruning.rs
+++ b/crates/scp-event-log/src/pruning.rs
@@ -381,7 +381,7 @@ pub fn verify_compact_proof(proof: &CompactProof) -> bool {
 /// structural-evolution events are structural; high-frequency operational
 /// records are operational.
 ///
-/// Classification note (pending cryptographer confirmation):
+/// Classification note:
 /// [`EventType::ContentKeysRotated`] and [`EventType::RecoveryEpochAdvanced`]
 /// are classified **structural** here. The existing related
 /// [`EventType::KeyEpochAdvance`] (ADR-007 sender-key epoch rotation) is
@@ -389,8 +389,7 @@ pub fn verify_compact_proof(proof: &CompactProof) -> bool {
 /// `ContentKeysRotated`/`RecoveryEpochAdvanced` record content-key rotation and
 /// a trust-recovery MLS group-epoch advance, which are structural-evolution /
 /// accountability events, whereas `KeyEpochAdvance` is a higher-frequency
-/// sender-key rotation record. This split is pending cryptographer
-/// confirmation.
+/// sender-key rotation record.
 #[must_use]
 pub const fn is_structural_event(event_type: &EventType) -> bool {
     // Two arms (one `true`, one `false`) with inline comment groupings, kept as

--- a/crates/scp-event-log/src/tree.rs
+++ b/crates/scp-event-log/src/tree.rs
@@ -427,6 +427,49 @@ pub const fn event_type_tag(event_type: &EventType) -> u16 {
         // Provenance event types (issue #586)
         EventType::ProvenanceAttached => 34,
         EventType::ProvenanceReceived => 35,
+        // Native↔WASM unification variants (ADR-011 Amendment). Tags 36..=75
+        // are assigned in ADR declaration order. Tags 0-35 above are protocol
+        // constants and MUST NOT change.
+        EventType::AdminTransferred => 36,
+        EventType::CeilingModified => 37,
+        EventType::CeilingModificationPending => 38,
+        EventType::ThresholdModified => 39,
+        EventType::SignerAdded => 40,
+        EventType::SignerRemoved => 41,
+        EventType::ChildContextCreated => 42,
+        EventType::ContextPromoted => 43,
+        EventType::ContentKeysRotated => 44,
+        EventType::MemberReset => 45,
+        EventType::MemberSuspended => 46,
+        EventType::MemberSuspendedAll => 47,
+        EventType::MemberUnblocked => 48,
+        EventType::AccessRestored => 49,
+        EventType::GovernanceReconfigured => 50,
+        EventType::GovernanceFreezeExpired => 51,
+        EventType::HardRateLimitModified => 52,
+        EventType::EconomicPolicyLocked => 53,
+        EventType::ContextMigrationStarted => 54,
+        EventType::ToolRemoved => 55,
+        EventType::PruningPolicyModified => 56,
+        EventType::CommitBroadcasted => 57,
+        EventType::CommitBroadcastPending => 58,
+        EventType::PseudonymAnnounced => 59,
+        EventType::ContextTombstoned => 60,
+        EventType::ContextMigrationCancelled => 61,
+        EventType::TtlExtended => 62,
+        EventType::TtlExtensionRejected => 63,
+        EventType::AccessRevoked => 64,
+        EventType::SpendApproved => 65,
+        EventType::PaymentCaptureFailed => 66,
+        EventType::ConsequenceTriggered => 67,
+        EventType::ConsequenceEnforced => 68,
+        EventType::ConsequenceEnforcementFailed => 69,
+        EventType::ConsequenceEscalatedToSuspendAll => 70,
+        EventType::CommitBroadcastSucceeded => 71,
+        EventType::CommitBroadcastFailed => 72,
+        EventType::RecoveryEpochAdvanced => 73,
+        EventType::AppBound => 74,
+        EventType::AppUnbound => 75,
     }
 }
 
@@ -1237,6 +1280,200 @@ mod tests {
     fn provenance_event_type_tags_are_correct() {
         assert_eq!(event_type_tag(&EventType::ProvenanceAttached), 34);
         assert_eq!(event_type_tag(&EventType::ProvenanceReceived), 35);
+    }
+
+    // -----------------------------------------------------------------------
+    // Closed-taxonomy tag invariants (ADR-011 native↔WASM unification):
+    //   - tags 0-35 are protocol constants and MUST NOT change;
+    //   - the 40 unification variants occupy tags 36..=75;
+    //   - all 76 tags are distinct.
+    // -----------------------------------------------------------------------
+
+    /// The complete `EventType` taxonomy in ADR declaration order, used to
+    /// cross-check against `event_type_tag`.
+    const ALL_EVENT_TYPES: [EventType; 76] = [
+        EventType::ContextCreated,
+        EventType::ContextClosing,
+        EventType::ContextClosed,
+        EventType::ContextExpired,
+        EventType::MemberJoined,
+        EventType::MemberLeft,
+        EventType::RoleAssigned,
+        EventType::TokenRevoked,
+        EventType::MessageSent,
+        EventType::ToolRegistered,
+        EventType::ToolUpdated,
+        EventType::ToolInvoked,
+        EventType::ToolVerified,
+        EventType::ToolInterfaceEstablished,
+        EventType::GovernanceAction,
+        EventType::ConsistencyCheckpoint,
+        EventType::AbsenceProofRequested,
+        EventType::MemberBlocked,
+        EventType::KeyEpochAdvance,
+        EventType::MediaSessionStarted,
+        EventType::MediaSessionEnded,
+        EventType::PaymentReceived,
+        EventType::EconomicPolicyChanged,
+        EventType::EconomicPolicyApplied,
+        EventType::SpendingUcanGranted,
+        EventType::SpendingUcanRevoked,
+        EventType::GovernanceProposalCreated,
+        EventType::GovernanceVoteCast,
+        EventType::GovernanceVoteWithdrawn,
+        EventType::GovernanceProposalResolved,
+        EventType::GovernanceConflictDetected,
+        EventType::GovernanceConflictResolved,
+        EventType::GovernanceDeadlockRecovery,
+        EventType::GovernanceActionExecuted,
+        EventType::ProvenanceAttached,
+        EventType::ProvenanceReceived,
+        EventType::AdminTransferred,
+        EventType::CeilingModified,
+        EventType::CeilingModificationPending,
+        EventType::ThresholdModified,
+        EventType::SignerAdded,
+        EventType::SignerRemoved,
+        EventType::ChildContextCreated,
+        EventType::ContextPromoted,
+        EventType::ContentKeysRotated,
+        EventType::MemberReset,
+        EventType::MemberSuspended,
+        EventType::MemberSuspendedAll,
+        EventType::MemberUnblocked,
+        EventType::AccessRestored,
+        EventType::GovernanceReconfigured,
+        EventType::GovernanceFreezeExpired,
+        EventType::HardRateLimitModified,
+        EventType::EconomicPolicyLocked,
+        EventType::ContextMigrationStarted,
+        EventType::ToolRemoved,
+        EventType::PruningPolicyModified,
+        EventType::CommitBroadcasted,
+        EventType::CommitBroadcastPending,
+        EventType::PseudonymAnnounced,
+        EventType::ContextTombstoned,
+        EventType::ContextMigrationCancelled,
+        EventType::TtlExtended,
+        EventType::TtlExtensionRejected,
+        EventType::AccessRevoked,
+        EventType::SpendApproved,
+        EventType::PaymentCaptureFailed,
+        EventType::ConsequenceTriggered,
+        EventType::ConsequenceEnforced,
+        EventType::ConsequenceEnforcementFailed,
+        EventType::ConsequenceEscalatedToSuspendAll,
+        EventType::CommitBroadcastSucceeded,
+        EventType::CommitBroadcastFailed,
+        EventType::RecoveryEpochAdvanced,
+        EventType::AppBound,
+        EventType::AppUnbound,
+    ];
+
+    #[test]
+    fn all_event_type_tags_are_distinct() {
+        let mut tags: Vec<u16> = ALL_EVENT_TYPES.iter().map(event_type_tag).collect();
+        assert_eq!(tags.len(), 76, "taxonomy must enumerate all 76 variants");
+        tags.sort_unstable();
+        tags.dedup();
+        assert_eq!(
+            tags.len(),
+            76,
+            "all 76 EventType tags must be distinct (no two variants share a tag)"
+        );
+    }
+
+    #[test]
+    fn protocol_constant_tags_0_through_35_are_unchanged() {
+        // These tags are wire-protocol constants. Changing any of them breaks
+        // canonical hash compatibility with already-signed leaves. The
+        // out-of-order assignments (EconomicPolicyApplied=33) are deliberate
+        // historical gap fills and are pinned here.
+        assert_eq!(event_type_tag(&EventType::ContextCreated), 0);
+        assert_eq!(event_type_tag(&EventType::ContextClosing), 1);
+        assert_eq!(event_type_tag(&EventType::ContextClosed), 2);
+        assert_eq!(event_type_tag(&EventType::ContextExpired), 3);
+        assert_eq!(event_type_tag(&EventType::MemberJoined), 4);
+        assert_eq!(event_type_tag(&EventType::MemberLeft), 5);
+        assert_eq!(event_type_tag(&EventType::RoleAssigned), 6);
+        assert_eq!(event_type_tag(&EventType::TokenRevoked), 7);
+        assert_eq!(event_type_tag(&EventType::MessageSent), 8);
+        assert_eq!(event_type_tag(&EventType::ToolRegistered), 9);
+        assert_eq!(event_type_tag(&EventType::ToolUpdated), 10);
+        assert_eq!(event_type_tag(&EventType::ToolInvoked), 11);
+        assert_eq!(event_type_tag(&EventType::ToolVerified), 12);
+        assert_eq!(event_type_tag(&EventType::ToolInterfaceEstablished), 13);
+        assert_eq!(event_type_tag(&EventType::GovernanceAction), 14);
+        assert_eq!(event_type_tag(&EventType::ConsistencyCheckpoint), 15);
+        assert_eq!(event_type_tag(&EventType::AbsenceProofRequested), 16);
+        assert_eq!(event_type_tag(&EventType::MemberBlocked), 17);
+        assert_eq!(event_type_tag(&EventType::KeyEpochAdvance), 18);
+        assert_eq!(event_type_tag(&EventType::MediaSessionStarted), 19);
+        assert_eq!(event_type_tag(&EventType::MediaSessionEnded), 20);
+        assert_eq!(event_type_tag(&EventType::PaymentReceived), 21);
+        assert_eq!(event_type_tag(&EventType::EconomicPolicyChanged), 22);
+        assert_eq!(event_type_tag(&EventType::SpendingUcanGranted), 23);
+        assert_eq!(event_type_tag(&EventType::SpendingUcanRevoked), 24);
+        assert_eq!(event_type_tag(&EventType::GovernanceProposalCreated), 25);
+        assert_eq!(event_type_tag(&EventType::GovernanceVoteCast), 26);
+        assert_eq!(event_type_tag(&EventType::GovernanceVoteWithdrawn), 27);
+        assert_eq!(event_type_tag(&EventType::GovernanceProposalResolved), 28);
+        assert_eq!(event_type_tag(&EventType::GovernanceConflictDetected), 29);
+        assert_eq!(event_type_tag(&EventType::GovernanceConflictResolved), 30);
+        assert_eq!(event_type_tag(&EventType::GovernanceDeadlockRecovery), 31);
+        assert_eq!(event_type_tag(&EventType::GovernanceActionExecuted), 32);
+        assert_eq!(event_type_tag(&EventType::EconomicPolicyApplied), 33);
+        assert_eq!(event_type_tag(&EventType::ProvenanceAttached), 34);
+        assert_eq!(event_type_tag(&EventType::ProvenanceReceived), 35);
+    }
+
+    #[test]
+    fn unification_variant_tags_occupy_36_through_75() {
+        // The 40 native↔WASM unification variants occupy tags 36..=75 in ADR
+        // declaration order.
+        assert_eq!(event_type_tag(&EventType::AdminTransferred), 36);
+        assert_eq!(event_type_tag(&EventType::CeilingModified), 37);
+        assert_eq!(event_type_tag(&EventType::CeilingModificationPending), 38);
+        assert_eq!(event_type_tag(&EventType::ThresholdModified), 39);
+        assert_eq!(event_type_tag(&EventType::SignerAdded), 40);
+        assert_eq!(event_type_tag(&EventType::SignerRemoved), 41);
+        assert_eq!(event_type_tag(&EventType::ChildContextCreated), 42);
+        assert_eq!(event_type_tag(&EventType::ContextPromoted), 43);
+        assert_eq!(event_type_tag(&EventType::ContentKeysRotated), 44);
+        assert_eq!(event_type_tag(&EventType::MemberReset), 45);
+        assert_eq!(event_type_tag(&EventType::MemberSuspended), 46);
+        assert_eq!(event_type_tag(&EventType::MemberSuspendedAll), 47);
+        assert_eq!(event_type_tag(&EventType::MemberUnblocked), 48);
+        assert_eq!(event_type_tag(&EventType::AccessRestored), 49);
+        assert_eq!(event_type_tag(&EventType::GovernanceReconfigured), 50);
+        assert_eq!(event_type_tag(&EventType::GovernanceFreezeExpired), 51);
+        assert_eq!(event_type_tag(&EventType::HardRateLimitModified), 52);
+        assert_eq!(event_type_tag(&EventType::EconomicPolicyLocked), 53);
+        assert_eq!(event_type_tag(&EventType::ContextMigrationStarted), 54);
+        assert_eq!(event_type_tag(&EventType::ToolRemoved), 55);
+        assert_eq!(event_type_tag(&EventType::PruningPolicyModified), 56);
+        assert_eq!(event_type_tag(&EventType::CommitBroadcasted), 57);
+        assert_eq!(event_type_tag(&EventType::CommitBroadcastPending), 58);
+        assert_eq!(event_type_tag(&EventType::PseudonymAnnounced), 59);
+        assert_eq!(event_type_tag(&EventType::ContextTombstoned), 60);
+        assert_eq!(event_type_tag(&EventType::ContextMigrationCancelled), 61);
+        assert_eq!(event_type_tag(&EventType::TtlExtended), 62);
+        assert_eq!(event_type_tag(&EventType::TtlExtensionRejected), 63);
+        assert_eq!(event_type_tag(&EventType::AccessRevoked), 64);
+        assert_eq!(event_type_tag(&EventType::SpendApproved), 65);
+        assert_eq!(event_type_tag(&EventType::PaymentCaptureFailed), 66);
+        assert_eq!(event_type_tag(&EventType::ConsequenceTriggered), 67);
+        assert_eq!(event_type_tag(&EventType::ConsequenceEnforced), 68);
+        assert_eq!(event_type_tag(&EventType::ConsequenceEnforcementFailed), 69);
+        assert_eq!(
+            event_type_tag(&EventType::ConsequenceEscalatedToSuspendAll),
+            70
+        );
+        assert_eq!(event_type_tag(&EventType::CommitBroadcastSucceeded), 71);
+        assert_eq!(event_type_tag(&EventType::CommitBroadcastFailed), 72);
+        assert_eq!(event_type_tag(&EventType::RecoveryEpochAdvanced), 73);
+        assert_eq!(event_type_tag(&EventType::AppBound), 74);
+        assert_eq!(event_type_tag(&EventType::AppUnbound), 75);
     }
 
     #[test]

--- a/crates/scp-event-log/tests/test_vectors.rs
+++ b/crates/scp-event-log/tests/test_vectors.rs
@@ -48,19 +48,25 @@ fn print_vec(label: &str, bytes: &[u8]) {
 #[test]
 fn vector_15_empty_tree() {
     println!("=== Vector 15: Empty Merkle Tree ===");
-    // Spec defines empty tree root as SHA-256("").
-    // Note: The EventLog implementation returns [0u8; 32] for empty logs.
-    // This test documents both values.
+    // Spec §25.8 defines the empty-tree root as SHA-256("") (RFC 6962 MTH({})),
+    // and the production EventLog matches it: `tree::root` returns
+    // `empty_tree_root()` = SHA-256("") for an empty log. The all-zero value
+    // below is NOT the empty root — it is the distinct genesis `prev_hash`
+    // sentinel (`GENESIS_PREV_HASH = [0u8; 32]`), shown here only to contrast
+    // the two so they are not conflated.
     let spec_empty_root: [u8; 32] = Sha256::digest(b"").into();
-    print_vec("SHA-256(\"\") [spec §25.8]", &spec_empty_root);
+    print_vec(
+        "SHA-256(\"\") [spec §25.8 = EventLog empty root]",
+        &spec_empty_root,
+    );
     assert_eq!(
         hex(&spec_empty_root),
         "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
     );
 
-    let impl_empty_root: [u8; 32] = [0u8; 32];
-    print_vec("EventLog empty root [impl]", &impl_empty_root);
-    println!("  Note: Implementation uses all-zeros for empty log.");
+    let genesis_prev_hash: [u8; 32] = [0u8; 32];
+    print_vec("genesis prev_hash sentinel [distinct]", &genesis_prev_hash);
+    println!("  Note: all-zeros is the genesis prev_hash, not the empty root.");
 }
 
 #[test]

--- a/crates/scp-event-log/tests/test_vectors.rs
+++ b/crates/scp-event-log/tests/test_vectors.rs
@@ -434,8 +434,8 @@ fn kat_events() -> Vec<Event> {
 }
 
 #[test]
-fn vector_20_typed_leaf_and_checkpoint_kat() {
-    println!("=== Vector 20: Typed-leaf + checkpoint KAT ===");
+fn vector_32_typed_leaf_and_checkpoint_kat() {
+    println!("=== Vector 32: Typed-leaf + checkpoint KAT ===");
     println!("  KAT DID: {}", kat_did());
 
     let events = kat_events();
@@ -485,8 +485,8 @@ fn vector_20_typed_leaf_and_checkpoint_kat() {
 }
 
 #[tokio::test]
-async fn vector_21_checkpoint_root_equals_tree_root_kat() {
-    println!("=== Vector 21: Checkpoint merkle_root == tree::root KAT ===");
+async fn vector_33_checkpoint_root_equals_tree_root_kat() {
+    println!("=== Vector 33: Checkpoint merkle_root == tree::root KAT ===");
 
     let events = kat_events();
     let mut log = EventLog::new("ctx-kat".to_owned());

--- a/crates/scp-event-log/tests/test_vectors.rs
+++ b/crates/scp-event-log/tests/test_vectors.rs
@@ -408,7 +408,7 @@ fn kat_events() -> Vec<Event> {
             EventType::ContextTombstoned,
             1_700_000_004,
             enc(&payload::ContextTombstonedPayload {
-                destination_context_id: "ctx-dest".to_owned(),
+                destination_id: "ctx-dest".to_owned(),
                 migration_proposal_id: [0xCDu8; 32],
             }),
         ),

--- a/crates/scp-event-log/tests/test_vectors.rs
+++ b/crates/scp-event-log/tests/test_vectors.rs
@@ -258,3 +258,283 @@ fn different_event_order_produces_different_root() {
 
     assert_ne!(root_ab, root_ba, "swapping children must change the root");
 }
+
+// ---------------------------------------------------------------------------
+// §25.8 Typed-leaf + checkpoint KAT (ADR-011 native↔WASM unification)
+//
+// The vectors above pin the abstract RFC 6962 tree construction. These pin the
+// *typed* leaf preimage: each leaf is SHA-256(0x00 || rmp_serde(Event)) over a
+// canonical `scp_event_log::Event` whose `event_type` is one of the closed
+// EventType taxonomy, and the checkpoint `merkle_root` equals `tree::root`.
+//
+// Determinism: a fixed 32-byte Ed25519 seed yields a fixed signing key; Ed25519
+// signatures are deterministic (RFC 8032), so the full-Event rmp_serde bytes —
+// and hence the leaf hash — are reproducible across runs and implementations.
+// The DID is `did:dht:z<z-base-32(pubkey)>`, which `extract_public_key_from_did`
+// accepts without the `testing` feature.
+// ---------------------------------------------------------------------------
+
+use ed25519_dalek::{Signer, SigningKey, Verifier};
+use scp_event_log::tree::{self, compute_event_canonical_hash};
+use scp_event_log::{
+    Event, EventLog, EventLogSigner, EventPayload, EventType, checkpoint, payload,
+};
+
+/// Fixed 32-byte Ed25519 seed for KAT reproducibility. Not a real key.
+const KAT_SEED: [u8; 32] = [
+    0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f, 0x10,
+    0x11, 0x12, 0x13, 0x14, 0x15, 0x16, 0x17, 0x18, 0x19, 0x1a, 0x1b, 0x1c, 0x1d, 0x1e, 0x1f, 0x20,
+];
+
+/// Genesis sentinel `prev_hash` for the first event (mirrors `tree::GENESIS_PREV_HASH`).
+const KAT_GENESIS_PREV_HASH: [u8; 32] = [0u8; 32];
+
+fn kat_signing_key() -> SigningKey {
+    SigningKey::from_bytes(&KAT_SEED)
+}
+
+/// Builds the `did:dht:z<z-base-32(pubkey)>` DID for the fixed KAT key.
+fn kat_did() -> String {
+    let vk = kat_signing_key().verifying_key();
+    format!("did:dht:z{}", zbase32::encode(vk.as_bytes()))
+}
+
+/// A deterministic, fixed-key [`EventLogSigner`] for checkpoint KAT signing.
+struct KatSigner(SigningKey);
+
+#[async_trait::async_trait]
+impl EventLogSigner for KatSigner {
+    async fn sign(&self, message: &[u8]) -> Result<Vec<u8>, String> {
+        Ok(self.0.sign(message).to_bytes().to_vec())
+    }
+}
+
+/// Signs an event with the fixed KAT key (canonical hash over all fields except
+/// the signature).
+fn kat_sign_event(
+    event_type: EventType,
+    actor_did: &str,
+    timestamp: u64,
+    sequence: u64,
+    payload_bytes: Vec<u8>,
+    prev_hash: [u8; 32],
+) -> Event {
+    let mut event = Event {
+        event_type,
+        actor_did: actor_did.to_owned().into(),
+        timestamp,
+        sequence,
+        payload: EventPayload {
+            data: payload_bytes,
+        },
+        prev_hash,
+        signature: Vec::new(),
+    };
+    let canonical_hash = compute_event_canonical_hash(&event);
+    event.signature = kat_signing_key().sign(&canonical_hash).to_bytes().to_vec();
+    event
+}
+
+/// Computes the RFC 6962 leaf hash over the full signed event:
+/// `SHA-256(0x00 || rmp_serde(Event))`.
+fn typed_leaf_hash(event: &Event) -> [u8; 32] {
+    let serialized = rmp_serde::to_vec(event).expect("event serialization");
+    leaf_hash(&serialized)
+}
+
+/// Builds the representative spread of typed events for the KAT.
+///
+/// Spread (ADR-011 Amendment coverage): `AppBound`, `SpendApproved`,
+/// `TtlExtended`, `RecoveryEpochAdvanced`, `ContextTombstoned`,
+/// `ConsequenceTriggered`, `CommitBroadcastSucceeded`. Payloads use the shared
+/// `payload` encoder where a structured struct is defined; the remaining
+/// variants carry their documented opaque payloads.
+/// Encodes a structured payload via the shared `payload` encoder.
+fn enc<T: serde::Serialize>(value: &T) -> Vec<u8> {
+    payload::encode_payload(value)
+        .expect("shared payload encode")
+        .data
+}
+
+fn kat_events() -> Vec<Event> {
+    let did = kat_did();
+    let mut events: Vec<Event> = Vec::new();
+    let mut prev = KAT_GENESIS_PREV_HASH;
+
+    // (event_type, timestamp, payload-bytes) in append order. Structured
+    // payloads use the shared `payload` encoder; opaque ones carry their
+    // documented bytes. Spread covers AppBound, SpendApproved, TtlExtended,
+    // RecoveryEpochAdvanced, ContextTombstoned, ConsequenceTriggered,
+    // CommitBroadcastSucceeded.
+    let spec: Vec<(EventType, u64, Vec<u8>)> = vec![
+        (
+            EventType::AppBound,
+            1_700_000_000,
+            enc(&payload::AppBoundPayload {
+                app_did: "did:key:app".to_owned(),
+                app_name: "Scheduler".to_owned(),
+                app_version: "1.0.0".to_owned(),
+                capabilities: vec!["tool:invoke:*".to_owned()],
+            }),
+        ),
+        (
+            EventType::SpendApproved,
+            1_700_000_001,
+            enc(&payload::SpendApprovedPayload {
+                spender: "did:key:agent".to_owned(),
+                amount: 5_000,
+                purpose: "inference".to_owned(),
+            }),
+        ),
+        (
+            EventType::TtlExtended,
+            1_700_000_002,
+            enc(&payload::TtlExtendedPayload {
+                old_deadline_unix: 1_700_000_000,
+                new_deadline_unix: 1_800_000_000,
+                proposal_id: [0xABu8; 32],
+                consenting_members: vec!["did:key:a".to_owned(), "did:key:b".to_owned()],
+            }),
+        ),
+        (
+            EventType::RecoveryEpochAdvanced,
+            1_700_000_003,
+            enc(&payload::RecoveryEpochAdvancedPayload {
+                old_epoch: 7,
+                new_epoch: 8,
+            }),
+        ),
+        (
+            EventType::ContextTombstoned,
+            1_700_000_004,
+            enc(&payload::ContextTombstonedPayload {
+                destination_context_id: "ctx-dest".to_owned(),
+                migration_proposal_id: [0xCDu8; 32],
+            }),
+        ),
+        (
+            EventType::ConsequenceTriggered,
+            1_700_000_005,
+            b"member_did=did:key:m;rule_index=2;trigger_kind=absence;action_type=suspend".to_vec(),
+        ),
+        (
+            EventType::CommitBroadcastSucceeded,
+            1_700_000_006,
+            b"operation=join;attempts=3".to_vec(),
+        ),
+    ];
+
+    for (seq, (et, ts, data)) in spec.into_iter().enumerate() {
+        let ev = kat_sign_event(et, &did, ts, seq as u64, data, prev);
+        prev = typed_leaf_hash(&ev);
+        events.push(ev);
+    }
+
+    events
+}
+
+#[test]
+fn vector_20_typed_leaf_and_checkpoint_kat() {
+    println!("=== Vector 20: Typed-leaf + checkpoint KAT ===");
+    println!("  KAT DID: {}", kat_did());
+
+    let events = kat_events();
+    assert_eq!(events.len(), 7, "KAT spread must be 7 events");
+
+    // Build the log via the production append path (verifies signatures, builds
+    // the RFC 6962 tree incrementally).
+    let mut log = EventLog::new("ctx-kat".to_owned());
+    let mut leaves = Vec::new();
+    for ev in &events {
+        tree::append(&mut log, ev).expect("append KAT event");
+        leaves.push(typed_leaf_hash(ev));
+    }
+
+    // Print + pin each typed leaf.
+    for (i, leaf) in leaves.iter().enumerate() {
+        print_vec(&format!("Leaf {i} ({:?})", events[i].event_type), leaf);
+    }
+    let root = tree::root(&log);
+    print_vec("tree::root", &root);
+
+    // --- Pinned typed-leaf vectors (generated by this test, then pinned) ---
+    let expected_leaves = [
+        // 0: AppBound
+        "e0c0691d264ca38d086375a0274afb630e9bbb906f2e12e0112adf4d1b4fcd38",
+        // 1: SpendApproved
+        "f2f973a4df60ef87abcb99dd1f3afcd537037cbd1aae6297582c52be3bd8e695",
+        // 2: TtlExtended
+        "ccdbb8dfa15a7abff3fbd0c08efe45e99d9fc4cb5f042f8f7db5f9e36e3fb0b0",
+        // 3: RecoveryEpochAdvanced
+        "7a1a91c33ddaa1a92c02f70a3f567f065bed48b578124a803c07dca2f9a47863",
+        // 4: ContextTombstoned
+        "3848718f23aefaba0e47743e72f5ce3bcc3254bc09b4cb38c3f5c263c9c4dd8d",
+        // 5: ConsequenceTriggered
+        "7ea6b6a020d94e0850cb84410af43e69ecd1c945223cbf478356d93503724507",
+        // 6: CommitBroadcastSucceeded
+        "87e3cde25168f4af4328f010369313e28fde305dbc6f706be3392fdf7b8e7f3c",
+    ];
+    for (i, leaf) in leaves.iter().enumerate() {
+        assert_eq!(hex(leaf), expected_leaves[i], "typed leaf {i} mismatch");
+    }
+    assert_eq!(
+        hex(&root),
+        "39e50b879956255f4fd28b2c6f03995e759919e07166c232dd61ed321b54d40d",
+        "tree::root mismatch"
+    );
+}
+
+#[tokio::test]
+async fn vector_21_checkpoint_root_equals_tree_root_kat() {
+    println!("=== Vector 21: Checkpoint merkle_root == tree::root KAT ===");
+
+    let events = kat_events();
+    let mut log = EventLog::new("ctx-kat".to_owned());
+    for ev in &events {
+        tree::append(&mut log, ev).expect("append KAT event");
+    }
+
+    let tree_root = tree::root(&log);
+    let did: scp_event_log::DID = kat_did().into();
+    let signer = KatSigner(kat_signing_key());
+
+    // generate_checkpoint computes merkle_root = tree::root(log) and signs the
+    // §23.16.1 canonical-hash layout (SCP-CHECKPOINT-V1: || len(ctx) || ctx ||
+    // len(did) || did || event_count_BE || merkle_root || epoch || ts_BE).
+    let cp = checkpoint::generate_checkpoint(&log, &did, 5, &signer)
+        .await
+        .expect("generate checkpoint");
+
+    print_vec("checkpoint.merkle_root", &cp.merkle_root);
+    print_vec("tree::root", &tree_root);
+
+    assert_eq!(
+        cp.merkle_root, tree_root,
+        "checkpoint merkle_root must equal RFC 6962 tree::root"
+    );
+    assert_eq!(cp.event_count, 7, "checkpoint must cover all 7 events");
+
+    // Recompute the §23.16.1 canonical checkpoint hash and assert the signature
+    // verifies against the KAT key — pins the canonical-hash layout.
+    let canonical = checkpoint::compute_checkpoint_canonical_hash(
+        "ctx-kat",
+        &did,
+        cp.event_count,
+        &cp.merkle_root,
+        Some(5),
+        cp.timestamp,
+    );
+    print_vec("checkpoint canonical hash (§23.16.1)", &canonical);
+
+    let vk = kat_signing_key().verifying_key();
+    let sig = ed25519_dalek::Signature::from_slice(&cp.signature).expect("sig bytes");
+    vk.verify(&canonical, &sig)
+        .expect("checkpoint signature must verify over §23.16.1 canonical hash");
+
+    // --- Pinned checkpoint root (generated by this test, then pinned) ---
+    assert_eq!(
+        hex(&tree_root),
+        "39e50b879956255f4fd28b2c6f03995e759919e07166c232dd61ed321b54d40d",
+        "checkpoint tree::root mismatch"
+    );
+}

--- a/crates/scp-runtime/tests/economy_integration.rs
+++ b/crates/scp-runtime/tests/economy_integration.rs
@@ -333,46 +333,7 @@ fn signed_event(
     };
 
     // Compute canonical hash (must match tree.rs: compute_event_canonical_hash).
-    let event_tag: u16 = match &event.event_type {
-        EventType::ContextCreated => 0,
-        EventType::ContextClosing => 1,
-        EventType::ContextClosed => 2,
-        EventType::ContextExpired => 3,
-        EventType::MemberJoined => 4,
-        EventType::MemberLeft => 5,
-        EventType::RoleAssigned => 6,
-        EventType::TokenRevoked => 7,
-        EventType::MessageSent => 8,
-        EventType::ToolRegistered => 9,
-        EventType::ToolUpdated => 10,
-        EventType::ToolInvoked => 11,
-        EventType::ToolVerified => 12,
-        EventType::ToolInterfaceEstablished => 13,
-        EventType::GovernanceAction => 14,
-        EventType::ConsistencyCheckpoint => 15,
-        EventType::AbsenceProofRequested => 16,
-        EventType::MemberBlocked => 17,
-        EventType::KeyEpochAdvance => 18,
-        EventType::MediaSessionStarted => 19,
-        EventType::MediaSessionEnded => 20,
-        EventType::PaymentReceived => 21,
-        EventType::EconomicPolicyChanged => 22,
-        EventType::EconomicPolicyApplied => 33,
-        EventType::SpendingUcanGranted => 23,
-        EventType::SpendingUcanRevoked => 24,
-        // Governance event types (ADR-031 §8)
-        EventType::GovernanceProposalCreated => 25,
-        EventType::GovernanceVoteCast => 26,
-        EventType::GovernanceVoteWithdrawn => 27,
-        EventType::GovernanceProposalResolved => 28,
-        EventType::GovernanceConflictDetected => 29,
-        EventType::GovernanceConflictResolved => 30,
-        EventType::GovernanceDeadlockRecovery => 31,
-        EventType::GovernanceActionExecuted => 32,
-        // Provenance event types (issue #586)
-        EventType::ProvenanceAttached => 34,
-        EventType::ProvenanceReceived => 35,
-    };
+    let event_tag: u16 = tree::event_type_tag(&event.event_type);
 
     let mut hasher = Sha256::new();
     hasher.update(b"SCP-EVENT-V1:");

--- a/crates/scp-runtime/tests/phase2_integration.rs
+++ b/crates/scp-runtime/tests/phase2_integration.rs
@@ -70,28 +70,6 @@ fn did_from_pubkey(verifying_key: &ed25519_dalek::VerifyingKey) -> DID {
     format!("did:key:{hex}").into()
 }
 
-/// Computes the canonical hash for signing an event.
-///
-/// This mirrors the production `tree::compute_event_canonical_hash` exactly.
-/// Integration tests (`tests/`) cannot access `pub(crate)` items, so this
-/// copy is necessary. See issue #79 for context.
-fn compute_event_canonical_hash(event: &Event) -> Vec<u8> {
-    let mut hasher = Sha256::new();
-    hasher.update(b"SCP-EVENT-V1:");
-    #[allow(clippy::cast_possible_truncation)]
-    let length_prefix = |hasher: &mut Sha256, bytes: &[u8]| {
-        hasher.update((bytes.len() as u32).to_be_bytes());
-        hasher.update(bytes);
-    };
-    hasher.update(tree::event_type_tag(&event.event_type).to_be_bytes());
-    length_prefix(&mut hasher, event.actor_did.as_bytes());
-    hasher.update(event.timestamp.to_be_bytes());
-    hasher.update(event.sequence.to_be_bytes());
-    length_prefix(&mut hasher, &event.payload.data);
-    hasher.update(event.prev_hash);
-    hasher.finalize().to_vec()
-}
-
 /// Signs an event and returns it with the signature populated.
 fn sign_event(
     event_type: EventType,
@@ -111,7 +89,7 @@ fn sign_event(
         prev_hash,
         signature: Vec::new(),
     };
-    let canonical_hash = compute_event_canonical_hash(&event);
+    let canonical_hash = tree::compute_event_canonical_hash(&event);
     let signature = signing_key.sign(&canonical_hash);
     event.signature = signature.to_bytes().to_vec();
     event

--- a/crates/scp-runtime/tests/phase2_integration.rs
+++ b/crates/scp-runtime/tests/phase2_integration.rs
@@ -83,61 +83,13 @@ fn compute_event_canonical_hash(event: &Event) -> Vec<u8> {
         hasher.update((bytes.len() as u32).to_be_bytes());
         hasher.update(bytes);
     };
-    hasher.update(event_type_tag(&event.event_type).to_be_bytes());
+    hasher.update(tree::event_type_tag(&event.event_type).to_be_bytes());
     length_prefix(&mut hasher, event.actor_did.as_bytes());
     hasher.update(event.timestamp.to_be_bytes());
     hasher.update(event.sequence.to_be_bytes());
     length_prefix(&mut hasher, &event.payload.data);
     hasher.update(event.prev_hash);
     hasher.finalize().to_vec()
-}
-
-/// Returns a stable numeric tag for each event type variant.
-///
-/// This mirrors the production `tree::event_type_tag` exactly.
-/// Integration tests (`tests/`) cannot access `pub(crate)` items, so this
-/// copy is necessary. See issue #79 for context.
-const fn event_type_tag(event_type: &EventType) -> u16 {
-    match event_type {
-        EventType::ContextCreated => 0,
-        EventType::ContextClosing => 1,
-        EventType::ContextClosed => 2,
-        EventType::ContextExpired => 3,
-        EventType::MemberJoined => 4,
-        EventType::MemberLeft => 5,
-        EventType::RoleAssigned => 6,
-        EventType::TokenRevoked => 7,
-        EventType::MessageSent => 8,
-        EventType::ToolRegistered => 9,
-        EventType::ToolUpdated => 10,
-        EventType::ToolInvoked => 11,
-        EventType::ToolVerified => 12,
-        EventType::ToolInterfaceEstablished => 13,
-        EventType::GovernanceAction => 14,
-        EventType::ConsistencyCheckpoint => 15,
-        EventType::AbsenceProofRequested => 16,
-        EventType::MemberBlocked => 17,
-        EventType::KeyEpochAdvance => 18,
-        EventType::MediaSessionStarted => 19,
-        EventType::MediaSessionEnded => 20,
-        EventType::PaymentReceived => 21,
-        EventType::EconomicPolicyChanged => 22,
-        EventType::EconomicPolicyApplied => 33,
-        EventType::SpendingUcanGranted => 23,
-        EventType::SpendingUcanRevoked => 24,
-        // Governance event types (ADR-031 §8)
-        EventType::GovernanceProposalCreated => 25,
-        EventType::GovernanceVoteCast => 26,
-        EventType::GovernanceVoteWithdrawn => 27,
-        EventType::GovernanceProposalResolved => 28,
-        EventType::GovernanceConflictDetected => 29,
-        EventType::GovernanceConflictResolved => 30,
-        EventType::GovernanceDeadlockRecovery => 31,
-        EventType::GovernanceActionExecuted => 32,
-        // Provenance event types (issue #586)
-        EventType::ProvenanceAttached => 34,
-        EventType::ProvenanceReceived => 35,
-    }
 }
 
 /// Signs an event and returns it with the signature populated.

--- a/crates/scp-runtime/tests/phase5_integration.rs
+++ b/crates/scp-runtime/tests/phase5_integration.rs
@@ -98,57 +98,13 @@ fn compute_event_canonical_hash(event: &Event) -> Vec<u8> {
         hasher.update((bytes.len() as u32).to_be_bytes());
         hasher.update(bytes);
     };
-    hasher.update(event_type_tag(&event.event_type).to_be_bytes());
+    hasher.update(tree::event_type_tag(&event.event_type).to_be_bytes());
     length_prefix(&mut hasher, event.actor_did.as_bytes());
     hasher.update(event.timestamp.to_be_bytes());
     hasher.update(event.sequence.to_be_bytes());
     length_prefix(&mut hasher, &event.payload.data);
     hasher.update(event.prev_hash);
     hasher.finalize().to_vec()
-}
-
-/// Returns a stable numeric tag for each event type variant.
-const fn event_type_tag(event_type: &EventType) -> u16 {
-    match event_type {
-        EventType::ContextCreated => 0,
-        EventType::ContextClosing => 1,
-        EventType::ContextClosed => 2,
-        EventType::ContextExpired => 3,
-        EventType::MemberJoined => 4,
-        EventType::MemberLeft => 5,
-        EventType::RoleAssigned => 6,
-        EventType::TokenRevoked => 7,
-        EventType::MessageSent => 8,
-        EventType::ToolRegistered => 9,
-        EventType::ToolUpdated => 10,
-        EventType::ToolInvoked => 11,
-        EventType::ToolVerified => 12,
-        EventType::ToolInterfaceEstablished => 13,
-        EventType::GovernanceAction => 14,
-        EventType::ConsistencyCheckpoint => 15,
-        EventType::AbsenceProofRequested => 16,
-        EventType::MemberBlocked => 17,
-        EventType::KeyEpochAdvance => 18,
-        EventType::MediaSessionStarted => 19,
-        EventType::MediaSessionEnded => 20,
-        EventType::PaymentReceived => 21,
-        EventType::EconomicPolicyChanged => 22,
-        EventType::EconomicPolicyApplied => 33,
-        EventType::SpendingUcanGranted => 23,
-        EventType::SpendingUcanRevoked => 24,
-        // Governance event types (ADR-031 §8)
-        EventType::GovernanceProposalCreated => 25,
-        EventType::GovernanceVoteCast => 26,
-        EventType::GovernanceVoteWithdrawn => 27,
-        EventType::GovernanceProposalResolved => 28,
-        EventType::GovernanceConflictDetected => 29,
-        EventType::GovernanceConflictResolved => 30,
-        EventType::GovernanceDeadlockRecovery => 31,
-        EventType::GovernanceActionExecuted => 32,
-        // Provenance event types (issue #586)
-        EventType::ProvenanceAttached => 34,
-        EventType::ProvenanceReceived => 35,
-    }
 }
 
 /// Signs an event and returns it with the signature populated.

--- a/crates/scp-runtime/tests/phase5_integration.rs
+++ b/crates/scp-runtime/tests/phase5_integration.rs
@@ -89,24 +89,6 @@ fn did_from_pubkey(verifying_key: &ed25519_dalek::VerifyingKey) -> DID {
     format!("did:key:{hex}").into()
 }
 
-/// Computes the canonical hash for signing an event (matches `tree.rs` internals).
-fn compute_event_canonical_hash(event: &Event) -> Vec<u8> {
-    let mut hasher = Sha256::new();
-    hasher.update(b"SCP-EVENT-V1:");
-    #[allow(clippy::cast_possible_truncation)]
-    let length_prefix = |hasher: &mut Sha256, bytes: &[u8]| {
-        hasher.update((bytes.len() as u32).to_be_bytes());
-        hasher.update(bytes);
-    };
-    hasher.update(tree::event_type_tag(&event.event_type).to_be_bytes());
-    length_prefix(&mut hasher, event.actor_did.as_bytes());
-    hasher.update(event.timestamp.to_be_bytes());
-    hasher.update(event.sequence.to_be_bytes());
-    length_prefix(&mut hasher, &event.payload.data);
-    hasher.update(event.prev_hash);
-    hasher.finalize().to_vec()
-}
-
 /// Signs an event and returns it with the signature populated.
 fn sign_event(
     event_type: EventType,
@@ -126,7 +108,7 @@ fn sign_event(
         prev_hash,
         signature: Vec::new(),
     };
-    let canonical_hash = compute_event_canonical_hash(&event);
+    let canonical_hash = tree::compute_event_canonical_hash(&event);
     let signature = signing_key.sign(&canonical_hash);
     event.signature = signature.to_bytes().to_vec();
     event

--- a/crates/scp-runtime/tests/wasm_conformance.rs
+++ b/crates/scp-runtime/tests/wasm_conformance.rs
@@ -69,7 +69,7 @@ fn log_summary_timestamp_plausible_and_clamped() {
 // the entry. This module is a small INDEPENDENT model of those semantics —
 // registration/duplicate-rejection/lookup/removal — not a line-for-line copy
 // of any single bridge function (the bridge stores richer `PerContextState`).
-// It pins the contract the bridge's registry must uphold. See issue #137.
+// It pins the contract the bridge's registry must uphold.
 //
 // NOTE (separate cleanup): like the former hand-mirrored tag table, this model
 // re-implements its own registry rather than exercising the real WASM type, so
@@ -1474,17 +1474,27 @@ fn provenance_hash_conformance_registry_with_payment() {
 // ===========================================================================
 // Canonical event-type tag contract (closed 76-variant bijection)
 //
-// The WASM bridge does NOT carry its own event-type tag table. Its context
-// manager (`crates/scp-ffi/wasm/src/manager.rs`) imports and calls the
-// canonical `scp_event_log::tree::event_type_tag` DIRECTLY — the same function
-// the native runtime uses — because `scp-ffi-wasm` depends on `scp-event-log`.
-// Native↔WASM tag parity therefore holds BY CONSTRUCTION (one shared
-// implementation), not by maintaining a hand-mirrored copy.
+// `event_type_tag` (`scp_event_log::tree`) is a protocol constant used in two
+// places: (a) the NATIVE signed-event canonical hash —
+// `tree::compute_event_canonical_hash`, the `SCP-EVENT-V1:` signature preimage
+// — and (b) retention classification (`scp-event-log/src/pruning.rs` and
+// `tiered_storage.rs`). It does NOT enter the Merkle leaf hash.
 //
-// This test pins the contract that shared code actually relies on: over the
-// full closed `EventType` taxonomy, `event_type_tag` is a bijection onto 76
-// distinct tags. A new `EventType` variant that lacks a tag (or collides with
-// an existing one) breaks the closed taxonomy and is caught here. The
+// The WASM bridge does NOT invoke `event_type_tag` at all. Its context manager
+// (`crates/scp-ffi/wasm/src/manager.rs`, `append_log_event`) appends UNSIGNED
+// events via `append_unsigned_event` (`signature: vec![]`), whose leaf is
+// `SHA-256(0x00 || rmp_serde(Event))` — committing `EventType` through its
+// SERDE VARIANT NAME, not through this numeric tag. Native↔WASM leaf parity for
+// the event type is therefore carried by the SHARED SERDE REPRESENTATION of the
+// `EventType` enum (both targets depend on the same `scp_event_log` crate), NOT
+// by `event_type_tag`.
+//
+// This test pins the tag invariant the native signed path and retention
+// classification rely on: over the full closed `EventType` taxonomy,
+// `event_type_tag` is a bijection onto the contiguous tags 0..=75. A variant
+// that lacks a tag (or collides with an existing one) would corrupt the native
+// `SCP-EVENT-V1:` signature preimage and retention classification, and is
+// caught here. The
 // byte-level native↔WASM root anchor lives in the §25 KAT (Vectors 32/33 in
 // `crates/scp-event-log/tests/test_vectors.rs`); this test is the
 // closed-taxonomy / distinct-tag pin that complements it.
@@ -1589,10 +1599,10 @@ fn canonical_event_type_tag_is_a_closed_bijection() {
     );
 
     // Distinct-tag bijection: every canonical variant maps to a unique tag in
-    // 0..=75. Because the WASM bridge calls this exact `event_type_tag`, this is
-    // simultaneously the WASM tag contract. A collision (two variants → one tag)
-    // or a gap would corrupt the signed Merkle-leaf preimage and produce false
-    // §9.9.3 equivocation hits across implementations.
+    // 0..=75. A collision (two variants → one tag) or a gap would corrupt the
+    // native `SCP-EVENT-V1:` signature preimage (`compute_event_canonical_hash`)
+    // and the retention classification keyed on the tag in `pruning.rs` /
+    // `tiered_storage.rs`.
     let mut tags: Vec<u16> = all_variants.iter().map(event_type_tag).collect();
     assert_eq!(
         tags.len(),
@@ -1609,8 +1619,8 @@ fn canonical_event_type_tag_is_a_closed_bijection() {
     );
 
     // The bijection must cover the contiguous range 0..=75 with no holes, which
-    // (together with distinctness above) pins the exact canonical assignment the
-    // WASM bridge inherits by sharing this function.
+    // (together with distinctness above) pins the exact canonical tag assignment
+    // the native signature preimage and retention classification depend on.
     assert_eq!(
         tags.first().copied(),
         Some(0),

--- a/crates/scp-runtime/tests/wasm_conformance.rs
+++ b/crates/scp-runtime/tests/wasm_conformance.rs
@@ -1496,6 +1496,49 @@ fn wasm_event_type_tag_exhaustiveness() {
             "GovernanceActionExecuted" | "GovernanceExecuted" => 32,
             "ProvenanceAttached" => 34,
             "ProvenanceReceived" => 35,
+            // Native↔WASM unification variants (ADR-011 Amendment). Tags
+            // 36..=75 mirror the canonical assignment in
+            // `scp_event_log::tree::event_type_tag` in ADR declaration order.
+            "AdminTransferred" => 36,
+            "CeilingModified" => 37,
+            "CeilingModificationPending" => 38,
+            "ThresholdModified" => 39,
+            "SignerAdded" => 40,
+            "SignerRemoved" => 41,
+            "ChildContextCreated" => 42,
+            "ContextPromoted" => 43,
+            "ContentKeysRotated" => 44,
+            "MemberReset" => 45,
+            "MemberSuspended" => 46,
+            "MemberSuspendedAll" => 47,
+            "MemberUnblocked" => 48,
+            "AccessRestored" => 49,
+            "GovernanceReconfigured" => 50,
+            "GovernanceFreezeExpired" => 51,
+            "HardRateLimitModified" => 52,
+            "EconomicPolicyLocked" => 53,
+            "ContextMigrationStarted" => 54,
+            "ToolRemoved" => 55,
+            "PruningPolicyModified" => 56,
+            "CommitBroadcasted" => 57,
+            "CommitBroadcastPending" => 58,
+            "PseudonymAnnounced" => 59,
+            "ContextTombstoned" => 60,
+            "ContextMigrationCancelled" => 61,
+            "TtlExtended" => 62,
+            "TtlExtensionRejected" => 63,
+            "AccessRevoked" => 64,
+            "SpendApproved" => 65,
+            "PaymentCaptureFailed" => 66,
+            "ConsequenceTriggered" => 67,
+            "ConsequenceEnforced" => 68,
+            "ConsequenceEnforcementFailed" => 69,
+            "ConsequenceEscalatedToSuspendAll" => 70,
+            "CommitBroadcastSucceeded" => 71,
+            "CommitBroadcastFailed" => 72,
+            "RecoveryEpochAdvanced" => 73,
+            "AppBound" => 74,
+            "AppUnbound" => 75,
             _ => 0xFFFF,
         }
     }
@@ -1539,6 +1582,46 @@ fn wasm_event_type_tag_exhaustiveness() {
         "GovernanceConflictResolved",
         "GovernanceDeadlockRecovery",
         "GovernanceActionExecuted",
+        "AdminTransferred",
+        "CeilingModified",
+        "CeilingModificationPending",
+        "ThresholdModified",
+        "SignerAdded",
+        "SignerRemoved",
+        "ChildContextCreated",
+        "ContextPromoted",
+        "ContentKeysRotated",
+        "MemberReset",
+        "MemberSuspended",
+        "MemberSuspendedAll",
+        "MemberUnblocked",
+        "AccessRestored",
+        "GovernanceReconfigured",
+        "GovernanceFreezeExpired",
+        "HardRateLimitModified",
+        "EconomicPolicyLocked",
+        "ContextMigrationStarted",
+        "ToolRemoved",
+        "PruningPolicyModified",
+        "CommitBroadcasted",
+        "CommitBroadcastPending",
+        "PseudonymAnnounced",
+        "ContextTombstoned",
+        "ContextMigrationCancelled",
+        "TtlExtended",
+        "TtlExtensionRejected",
+        "AccessRevoked",
+        "SpendApproved",
+        "PaymentCaptureFailed",
+        "ConsequenceTriggered",
+        "ConsequenceEnforced",
+        "ConsequenceEnforcementFailed",
+        "ConsequenceEscalatedToSuspendAll",
+        "CommitBroadcastSucceeded",
+        "CommitBroadcastFailed",
+        "RecoveryEpochAdvanced",
+        "AppBound",
+        "AppUnbound",
     ];
 
     for event_type in &all_event_type_strings {
@@ -1611,7 +1694,88 @@ fn wasm_event_type_tag_exhaustiveness() {
         ),
         (EventType::ProvenanceAttached, "ProvenanceAttached"),
         (EventType::ProvenanceReceived, "ProvenanceReceived"),
+        (EventType::AdminTransferred, "AdminTransferred"),
+        (EventType::CeilingModified, "CeilingModified"),
+        (
+            EventType::CeilingModificationPending,
+            "CeilingModificationPending",
+        ),
+        (EventType::ThresholdModified, "ThresholdModified"),
+        (EventType::SignerAdded, "SignerAdded"),
+        (EventType::SignerRemoved, "SignerRemoved"),
+        (EventType::ChildContextCreated, "ChildContextCreated"),
+        (EventType::ContextPromoted, "ContextPromoted"),
+        (EventType::ContentKeysRotated, "ContentKeysRotated"),
+        (EventType::MemberReset, "MemberReset"),
+        (EventType::MemberSuspended, "MemberSuspended"),
+        (EventType::MemberSuspendedAll, "MemberSuspendedAll"),
+        (EventType::MemberUnblocked, "MemberUnblocked"),
+        (EventType::AccessRestored, "AccessRestored"),
+        (EventType::GovernanceReconfigured, "GovernanceReconfigured"),
+        (
+            EventType::GovernanceFreezeExpired,
+            "GovernanceFreezeExpired",
+        ),
+        (EventType::HardRateLimitModified, "HardRateLimitModified"),
+        (EventType::EconomicPolicyLocked, "EconomicPolicyLocked"),
+        (
+            EventType::ContextMigrationStarted,
+            "ContextMigrationStarted",
+        ),
+        (EventType::ToolRemoved, "ToolRemoved"),
+        (EventType::PruningPolicyModified, "PruningPolicyModified"),
+        (EventType::CommitBroadcasted, "CommitBroadcasted"),
+        (EventType::CommitBroadcastPending, "CommitBroadcastPending"),
+        (EventType::PseudonymAnnounced, "PseudonymAnnounced"),
+        (EventType::ContextTombstoned, "ContextTombstoned"),
+        (
+            EventType::ContextMigrationCancelled,
+            "ContextMigrationCancelled",
+        ),
+        (EventType::TtlExtended, "TtlExtended"),
+        (EventType::TtlExtensionRejected, "TtlExtensionRejected"),
+        (EventType::AccessRevoked, "AccessRevoked"),
+        (EventType::SpendApproved, "SpendApproved"),
+        (EventType::PaymentCaptureFailed, "PaymentCaptureFailed"),
+        (EventType::ConsequenceTriggered, "ConsequenceTriggered"),
+        (EventType::ConsequenceEnforced, "ConsequenceEnforced"),
+        (
+            EventType::ConsequenceEnforcementFailed,
+            "ConsequenceEnforcementFailed",
+        ),
+        (
+            EventType::ConsequenceEscalatedToSuspendAll,
+            "ConsequenceEscalatedToSuspendAll",
+        ),
+        (
+            EventType::CommitBroadcastSucceeded,
+            "CommitBroadcastSucceeded",
+        ),
+        (EventType::CommitBroadcastFailed, "CommitBroadcastFailed"),
+        (EventType::RecoveryEpochAdvanced, "RecoveryEpochAdvanced"),
+        (EventType::AppBound, "AppBound"),
+        (EventType::AppUnbound, "AppUnbound"),
     ];
+
+    // The closed EventType taxonomy has exactly 76 variants
+    // (`scp_event_log::tree::event_type_tag`, tags 0..=75). Assert the
+    // native↔WASM parity table enumerates the full set, so a future variant
+    // cannot silently slip past this gate. `all_event_type_strings` additionally
+    // carries WASM alias strings (e.g. "UcanRevoked", "GovernanceExecuted"), so
+    // we require it to be a superset that covers every canonical variant name
+    // rather than pinning an exact count.
+    assert_eq!(
+        all_variants.len(),
+        76,
+        "all_variants must enumerate the full closed 76-variant EventType taxonomy"
+    );
+    for (_, name) in &all_variants {
+        assert!(
+            all_event_type_strings.contains(name),
+            "all_event_type_strings is missing canonical variant '{name}' — \
+             every EventType variant must be exercised against the 0xFFFF sentinel"
+        );
+    }
 
     for (variant, name) in &all_variants {
         let native_tag = event_type_tag(variant);

--- a/crates/scp-runtime/tests/wasm_conformance.rs
+++ b/crates/scp-runtime/tests/wasm_conformance.rs
@@ -61,18 +61,31 @@ fn log_summary_timestamp_plausible_and_clamped() {
 }
 
 // ===========================================================================
-// WASM context registry mirror (verbatim from scp-ffi-wasm/src/runtime.rs)
+// WASM context registry semantics (independent mirror)
 //
-// Mirrors the registry functions to validate registration, lookup, and
-// removal semantics. See issue #137.
+// The WASM bridge keys per-context state by context ID in
+// `WasmContextManager` (`crates/scp-ffi/wasm/src/manager.rs`): registration
+// rejects duplicates, lookup of an unknown context errors, and removal evicts
+// the entry. This module is a small INDEPENDENT model of those semantics —
+// registration/duplicate-rejection/lookup/removal — not a line-for-line copy
+// of any single bridge function (the bridge stores richer `PerContextState`).
+// It pins the contract the bridge's registry must uphold. See issue #137.
+//
+// NOTE (separate cleanup): like the former hand-mirrored tag table, this model
+// re-implements its own registry rather than exercising the real WASM type, so
+// it can only catch contract regressions in this copy, not in the bridge. It is
+// left intact here per the scope of this change; a follow-up should retarget it
+// at the real `WasmContextManager` or retire it.
 // ===========================================================================
 
 mod wasm_registry_mirror {
     use std::cell::RefCell;
     use std::collections::{HashMap, HashSet};
 
-    /// Minimal mirror of `WasmContextRuntime` — only the fields needed to
-    /// validate registry semantics.
+    /// Minimal model of the per-context state the WASM bridge tracks — only the
+    /// fields needed to validate registry semantics (registration, lookup,
+    /// removal, default ceiling). The real bridge state is `PerContextState` in
+    /// `crates/scp-ffi/wasm/src/manager.rs`.
     pub struct WasmContextRuntime {
         pub creator_did: String,
         pub ceiling_strings: HashSet<String>,
@@ -83,7 +96,9 @@ mod wasm_registry_mirror {
             RefCell::new(HashMap::new());
     }
 
-    /// Mirrors `runtime::register_context` from `scp-ffi-wasm/src/runtime.rs`.
+    /// Models the WASM bridge's context-registration semantics
+    /// (`WasmContextManager` in `crates/scp-ffi/wasm/src/manager.rs`):
+    /// inserts per-context state and rejects a duplicate context ID.
     pub fn register_context(context_id: &str, creator_did: &str) -> Result<(), String> {
         CONTEXT_REGISTRY.with(|reg| {
             let mut map = reg.borrow_mut();
@@ -117,14 +132,18 @@ mod wasm_registry_mirror {
         })
     }
 
-    /// Mirrors `runtime::remove_context` from `scp-ffi-wasm/src/runtime.rs`.
+    /// Models the WASM bridge's context-removal semantics
+    /// (`WasmContextManager` in `crates/scp-ffi/wasm/src/manager.rs`): evicts
+    /// the per-context entry on close.
     pub fn remove_context(context_id: &str) {
         CONTEXT_REGISTRY.with(|reg| {
             reg.borrow_mut().remove(context_id);
         });
     }
 
-    /// Mirrors `runtime::with_context` from `scp-ffi-wasm/src/runtime.rs`.
+    /// Models the WASM bridge's per-context lookup-or-error semantics
+    /// (`WasmContextManager` in `crates/scp-ffi/wasm/src/manager.rs`): a lookup
+    /// against an unknown context ID returns a "not found" error.
     pub fn with_context<T, F>(context_id: &str, f: F) -> Result<T, String>
     where
         F: FnOnce(&mut WasmContextRuntime) -> Result<T, String>,
@@ -1453,338 +1472,155 @@ fn provenance_hash_conformance_registry_with_payment() {
 }
 
 // ===========================================================================
-// WASM event type tag exhaustiveness
+// Canonical event-type tag contract (closed 76-variant bijection)
+//
+// The WASM bridge does NOT carry its own event-type tag table. Its context
+// manager (`crates/scp-ffi/wasm/src/manager.rs`) imports and calls the
+// canonical `scp_event_log::tree::event_type_tag` DIRECTLY — the same function
+// the native runtime uses — because `scp-ffi-wasm` depends on `scp-event-log`.
+// Native↔WASM tag parity therefore holds BY CONSTRUCTION (one shared
+// implementation), not by maintaining a hand-mirrored copy.
+//
+// This test pins the contract that shared code actually relies on: over the
+// full closed `EventType` taxonomy, `event_type_tag` is a bijection onto 76
+// distinct tags. A new `EventType` variant that lacks a tag (or collides with
+// an existing one) breaks the closed taxonomy and is caught here. The
+// byte-level native↔WASM root anchor lives in the §25 KAT (Vectors 32/33 in
+// `crates/scp-event-log/tests/test_vectors.rs`); this test is the
+// closed-taxonomy / distinct-tag pin that complements it.
 // ===========================================================================
 
 #[test]
-fn wasm_event_type_tag_exhaustiveness() {
-    fn wasm_event_type_tag(event_type: &str) -> u16 {
-        match event_type {
-            "ContextCreated" => 0,
-            "ContextClosing" => 1,
-            "ContextClosed" => 2,
-            "ContextExpired" => 3,
-            "MemberJoined" => 4,
-            "MemberLeft" => 5,
-            "RoleAssigned" => 6,
-            "TokenRevoked" | "UcanRevoked" => 7,
-            "MessageSent" => 8,
-            "ToolRegistered" => 9,
-            "ToolUpdated" => 10,
-            "ToolInvoked" => 11,
-            "ToolVerified" => 12,
-            "ToolInterfaceEstablished" => 13,
-            "GovernanceAction" => 14,
-            "ConsistencyCheckpoint" => 15,
-            "AbsenceProofRequested" => 16,
-            "MemberBlocked" => 17,
-            "KeyEpochAdvance" => 18,
-            "MediaSessionStarted" => 19,
-            "MediaSessionEnded" => 20,
-            "PaymentReceived" => 21,
-            "EconomicPolicyChanged" => 22,
-            "EconomicPolicyApplied" => 33,
-            "SpendingUcanGranted" => 23,
-            "SpendingUcanRevoked" => 24,
-            "GovernanceProposalCreated" => 25,
-            "GovernanceVoteCast" => 26,
-            "GovernanceVoteWithdrawn" => 27,
-            "GovernanceProposalResolved" => 28,
-            "GovernanceConflictDetected" => 29,
-            "GovernanceConflictResolved" => 30,
-            "GovernanceDeadlockRecovery" => 31,
-            "GovernanceActionExecuted" | "GovernanceExecuted" => 32,
-            "ProvenanceAttached" => 34,
-            "ProvenanceReceived" => 35,
-            // Native↔WASM unification variants (ADR-011 Amendment). Tags
-            // 36..=75 mirror the canonical assignment in
-            // `scp_event_log::tree::event_type_tag` in ADR declaration order.
-            "AdminTransferred" => 36,
-            "CeilingModified" => 37,
-            "CeilingModificationPending" => 38,
-            "ThresholdModified" => 39,
-            "SignerAdded" => 40,
-            "SignerRemoved" => 41,
-            "ChildContextCreated" => 42,
-            "ContextPromoted" => 43,
-            "ContentKeysRotated" => 44,
-            "MemberReset" => 45,
-            "MemberSuspended" => 46,
-            "MemberSuspendedAll" => 47,
-            "MemberUnblocked" => 48,
-            "AccessRestored" => 49,
-            "GovernanceReconfigured" => 50,
-            "GovernanceFreezeExpired" => 51,
-            "HardRateLimitModified" => 52,
-            "EconomicPolicyLocked" => 53,
-            "ContextMigrationStarted" => 54,
-            "ToolRemoved" => 55,
-            "PruningPolicyModified" => 56,
-            "CommitBroadcasted" => 57,
-            "CommitBroadcastPending" => 58,
-            "PseudonymAnnounced" => 59,
-            "ContextTombstoned" => 60,
-            "ContextMigrationCancelled" => 61,
-            "TtlExtended" => 62,
-            "TtlExtensionRejected" => 63,
-            "AccessRevoked" => 64,
-            "SpendApproved" => 65,
-            "PaymentCaptureFailed" => 66,
-            "ConsequenceTriggered" => 67,
-            "ConsequenceEnforced" => 68,
-            "ConsequenceEnforcementFailed" => 69,
-            "ConsequenceEscalatedToSuspendAll" => 70,
-            "CommitBroadcastSucceeded" => 71,
-            "CommitBroadcastFailed" => 72,
-            "RecoveryEpochAdvanced" => 73,
-            "AppBound" => 74,
-            "AppUnbound" => 75,
-            _ => 0xFFFF,
-        }
-    }
-
-    let all_event_type_strings = [
-        "ContextCreated",
-        "ContextClosing",
-        "ContextClosed",
-        "ContextExpired",
-        "MemberJoined",
-        "MemberLeft",
-        "MessageSent",
-        "ToolRegistered",
-        "ToolInvoked",
-        "UcanRevoked",
-        "GovernanceExecuted",
-        "GovernanceProposalCreated",
-        "GovernanceVoteCast",
-        "GovernanceVoteWithdrawn",
-        "ProvenanceAttached",
-        "ProvenanceReceived",
-        "RoleAssigned",
-        "TokenRevoked",
-        "ToolUpdated",
-        "ToolVerified",
-        "ToolInterfaceEstablished",
-        "GovernanceAction",
-        "ConsistencyCheckpoint",
-        "AbsenceProofRequested",
-        "MemberBlocked",
-        "KeyEpochAdvance",
-        "MediaSessionStarted",
-        "MediaSessionEnded",
-        "PaymentReceived",
-        "EconomicPolicyChanged",
-        "EconomicPolicyApplied",
-        "SpendingUcanGranted",
-        "SpendingUcanRevoked",
-        "GovernanceProposalResolved",
-        "GovernanceConflictDetected",
-        "GovernanceConflictResolved",
-        "GovernanceDeadlockRecovery",
-        "GovernanceActionExecuted",
-        "AdminTransferred",
-        "CeilingModified",
-        "CeilingModificationPending",
-        "ThresholdModified",
-        "SignerAdded",
-        "SignerRemoved",
-        "ChildContextCreated",
-        "ContextPromoted",
-        "ContentKeysRotated",
-        "MemberReset",
-        "MemberSuspended",
-        "MemberSuspendedAll",
-        "MemberUnblocked",
-        "AccessRestored",
-        "GovernanceReconfigured",
-        "GovernanceFreezeExpired",
-        "HardRateLimitModified",
-        "EconomicPolicyLocked",
-        "ContextMigrationStarted",
-        "ToolRemoved",
-        "PruningPolicyModified",
-        "CommitBroadcasted",
-        "CommitBroadcastPending",
-        "PseudonymAnnounced",
-        "ContextTombstoned",
-        "ContextMigrationCancelled",
-        "TtlExtended",
-        "TtlExtensionRejected",
-        "AccessRevoked",
-        "SpendApproved",
-        "PaymentCaptureFailed",
-        "ConsequenceTriggered",
-        "ConsequenceEnforced",
-        "ConsequenceEnforcementFailed",
-        "ConsequenceEscalatedToSuspendAll",
-        "CommitBroadcastSucceeded",
-        "CommitBroadcastFailed",
-        "RecoveryEpochAdvanced",
-        "AppBound",
-        "AppUnbound",
+fn canonical_event_type_tag_is_a_closed_bijection() {
+    // The complete closed `EventType` taxonomy in canonical (tag) order. This
+    // is enumerated here independently of `scp_event_log`'s internal test-only
+    // array so that adding a variant to the public enum without updating this
+    // conformance list is itself a compile/assertion failure.
+    let all_variants: [EventType; 76] = [
+        EventType::ContextCreated,
+        EventType::ContextClosing,
+        EventType::ContextClosed,
+        EventType::ContextExpired,
+        EventType::MemberJoined,
+        EventType::MemberLeft,
+        EventType::RoleAssigned,
+        EventType::TokenRevoked,
+        EventType::MessageSent,
+        EventType::ToolRegistered,
+        EventType::ToolUpdated,
+        EventType::ToolInvoked,
+        EventType::ToolVerified,
+        EventType::ToolInterfaceEstablished,
+        EventType::GovernanceAction,
+        EventType::ConsistencyCheckpoint,
+        EventType::AbsenceProofRequested,
+        EventType::MemberBlocked,
+        EventType::KeyEpochAdvance,
+        EventType::MediaSessionStarted,
+        EventType::MediaSessionEnded,
+        EventType::PaymentReceived,
+        EventType::EconomicPolicyChanged,
+        EventType::EconomicPolicyApplied,
+        EventType::SpendingUcanGranted,
+        EventType::SpendingUcanRevoked,
+        EventType::GovernanceProposalCreated,
+        EventType::GovernanceVoteCast,
+        EventType::GovernanceVoteWithdrawn,
+        EventType::GovernanceProposalResolved,
+        EventType::GovernanceConflictDetected,
+        EventType::GovernanceConflictResolved,
+        EventType::GovernanceDeadlockRecovery,
+        EventType::GovernanceActionExecuted,
+        EventType::ProvenanceAttached,
+        EventType::ProvenanceReceived,
+        EventType::AdminTransferred,
+        EventType::CeilingModified,
+        EventType::CeilingModificationPending,
+        EventType::ThresholdModified,
+        EventType::SignerAdded,
+        EventType::SignerRemoved,
+        EventType::ChildContextCreated,
+        EventType::ContextPromoted,
+        EventType::ContentKeysRotated,
+        EventType::MemberReset,
+        EventType::MemberSuspended,
+        EventType::MemberSuspendedAll,
+        EventType::MemberUnblocked,
+        EventType::AccessRestored,
+        EventType::GovernanceReconfigured,
+        EventType::GovernanceFreezeExpired,
+        EventType::HardRateLimitModified,
+        EventType::EconomicPolicyLocked,
+        EventType::ContextMigrationStarted,
+        EventType::ToolRemoved,
+        EventType::PruningPolicyModified,
+        EventType::CommitBroadcasted,
+        EventType::CommitBroadcastPending,
+        EventType::PseudonymAnnounced,
+        EventType::ContextTombstoned,
+        EventType::ContextMigrationCancelled,
+        EventType::TtlExtended,
+        EventType::TtlExtensionRejected,
+        EventType::AccessRevoked,
+        EventType::SpendApproved,
+        EventType::PaymentCaptureFailed,
+        EventType::ConsequenceTriggered,
+        EventType::ConsequenceEnforced,
+        EventType::ConsequenceEnforcementFailed,
+        EventType::ConsequenceEscalatedToSuspendAll,
+        EventType::CommitBroadcastSucceeded,
+        EventType::CommitBroadcastFailed,
+        EventType::RecoveryEpochAdvanced,
+        EventType::AppBound,
+        EventType::AppUnbound,
     ];
 
-    for event_type in &all_event_type_strings {
-        let tag = wasm_event_type_tag(event_type);
-        assert_ne!(
-            tag, 0xFFFF,
-            "WASM event type string '{event_type}' maps to sentinel 0xFFFF — \
-             add a mapping to wasm_event_type_tag in crates/scp-ffi/wasm/src/runtime.rs"
-        );
-    }
-
-    let all_variants = [
-        (EventType::ContextCreated, "ContextCreated"),
-        (EventType::ContextClosing, "ContextClosing"),
-        (EventType::ContextClosed, "ContextClosed"),
-        (EventType::ContextExpired, "ContextExpired"),
-        (EventType::MemberJoined, "MemberJoined"),
-        (EventType::MemberLeft, "MemberLeft"),
-        (EventType::RoleAssigned, "RoleAssigned"),
-        (EventType::TokenRevoked, "TokenRevoked"),
-        (EventType::MessageSent, "MessageSent"),
-        (EventType::ToolRegistered, "ToolRegistered"),
-        (EventType::ToolUpdated, "ToolUpdated"),
-        (EventType::ToolInvoked, "ToolInvoked"),
-        (EventType::ToolVerified, "ToolVerified"),
-        (
-            EventType::ToolInterfaceEstablished,
-            "ToolInterfaceEstablished",
-        ),
-        (EventType::GovernanceAction, "GovernanceAction"),
-        (EventType::ConsistencyCheckpoint, "ConsistencyCheckpoint"),
-        (EventType::AbsenceProofRequested, "AbsenceProofRequested"),
-        (EventType::MemberBlocked, "MemberBlocked"),
-        (EventType::KeyEpochAdvance, "KeyEpochAdvance"),
-        (EventType::MediaSessionStarted, "MediaSessionStarted"),
-        (EventType::MediaSessionEnded, "MediaSessionEnded"),
-        (EventType::PaymentReceived, "PaymentReceived"),
-        (EventType::EconomicPolicyChanged, "EconomicPolicyChanged"),
-        (EventType::EconomicPolicyApplied, "EconomicPolicyApplied"),
-        (EventType::SpendingUcanGranted, "SpendingUcanGranted"),
-        (EventType::SpendingUcanRevoked, "SpendingUcanRevoked"),
-        (
-            EventType::GovernanceProposalCreated,
-            "GovernanceProposalCreated",
-        ),
-        (EventType::GovernanceVoteCast, "GovernanceVoteCast"),
-        (
-            EventType::GovernanceVoteWithdrawn,
-            "GovernanceVoteWithdrawn",
-        ),
-        (
-            EventType::GovernanceProposalResolved,
-            "GovernanceProposalResolved",
-        ),
-        (
-            EventType::GovernanceConflictDetected,
-            "GovernanceConflictDetected",
-        ),
-        (
-            EventType::GovernanceConflictResolved,
-            "GovernanceConflictResolved",
-        ),
-        (
-            EventType::GovernanceDeadlockRecovery,
-            "GovernanceDeadlockRecovery",
-        ),
-        (
-            EventType::GovernanceActionExecuted,
-            "GovernanceActionExecuted",
-        ),
-        (EventType::ProvenanceAttached, "ProvenanceAttached"),
-        (EventType::ProvenanceReceived, "ProvenanceReceived"),
-        (EventType::AdminTransferred, "AdminTransferred"),
-        (EventType::CeilingModified, "CeilingModified"),
-        (
-            EventType::CeilingModificationPending,
-            "CeilingModificationPending",
-        ),
-        (EventType::ThresholdModified, "ThresholdModified"),
-        (EventType::SignerAdded, "SignerAdded"),
-        (EventType::SignerRemoved, "SignerRemoved"),
-        (EventType::ChildContextCreated, "ChildContextCreated"),
-        (EventType::ContextPromoted, "ContextPromoted"),
-        (EventType::ContentKeysRotated, "ContentKeysRotated"),
-        (EventType::MemberReset, "MemberReset"),
-        (EventType::MemberSuspended, "MemberSuspended"),
-        (EventType::MemberSuspendedAll, "MemberSuspendedAll"),
-        (EventType::MemberUnblocked, "MemberUnblocked"),
-        (EventType::AccessRestored, "AccessRestored"),
-        (EventType::GovernanceReconfigured, "GovernanceReconfigured"),
-        (
-            EventType::GovernanceFreezeExpired,
-            "GovernanceFreezeExpired",
-        ),
-        (EventType::HardRateLimitModified, "HardRateLimitModified"),
-        (EventType::EconomicPolicyLocked, "EconomicPolicyLocked"),
-        (
-            EventType::ContextMigrationStarted,
-            "ContextMigrationStarted",
-        ),
-        (EventType::ToolRemoved, "ToolRemoved"),
-        (EventType::PruningPolicyModified, "PruningPolicyModified"),
-        (EventType::CommitBroadcasted, "CommitBroadcasted"),
-        (EventType::CommitBroadcastPending, "CommitBroadcastPending"),
-        (EventType::PseudonymAnnounced, "PseudonymAnnounced"),
-        (EventType::ContextTombstoned, "ContextTombstoned"),
-        (
-            EventType::ContextMigrationCancelled,
-            "ContextMigrationCancelled",
-        ),
-        (EventType::TtlExtended, "TtlExtended"),
-        (EventType::TtlExtensionRejected, "TtlExtensionRejected"),
-        (EventType::AccessRevoked, "AccessRevoked"),
-        (EventType::SpendApproved, "SpendApproved"),
-        (EventType::PaymentCaptureFailed, "PaymentCaptureFailed"),
-        (EventType::ConsequenceTriggered, "ConsequenceTriggered"),
-        (EventType::ConsequenceEnforced, "ConsequenceEnforced"),
-        (
-            EventType::ConsequenceEnforcementFailed,
-            "ConsequenceEnforcementFailed",
-        ),
-        (
-            EventType::ConsequenceEscalatedToSuspendAll,
-            "ConsequenceEscalatedToSuspendAll",
-        ),
-        (
-            EventType::CommitBroadcastSucceeded,
-            "CommitBroadcastSucceeded",
-        ),
-        (EventType::CommitBroadcastFailed, "CommitBroadcastFailed"),
-        (EventType::RecoveryEpochAdvanced, "RecoveryEpochAdvanced"),
-        (EventType::AppBound, "AppBound"),
-        (EventType::AppUnbound, "AppUnbound"),
-    ];
-
-    // The closed EventType taxonomy has exactly 76 variants
-    // (`scp_event_log::tree::event_type_tag`, tags 0..=75). Assert the
-    // native↔WASM parity table enumerates the full set, so a future variant
-    // cannot silently slip past this gate. `all_event_type_strings` additionally
-    // carries WASM alias strings (e.g. "UcanRevoked", "GovernanceExecuted"), so
-    // we require it to be a superset that covers every canonical variant name
-    // rather than pinning an exact count.
+    // Exhaustiveness guard: the closed taxonomy is exactly 76 variants
+    // (canonical tags 0..=75). If a variant is added to the public `EventType`
+    // enum, this conformance list must grow to match — a stale list of 76 here
+    // would fail to exercise the new variant, so keeping this pinned forces the
+    // list to be maintained alongside the enum.
     assert_eq!(
         all_variants.len(),
         76,
-        "all_variants must enumerate the full closed 76-variant EventType taxonomy"
+        "this conformance list must enumerate the full closed 76-variant \
+         EventType taxonomy — update it (and `scp-event-log/src/tree.rs` \
+         `event_type_tag`) when an EventType variant is added"
     );
-    for (_, name) in &all_variants {
-        assert!(
-            all_event_type_strings.contains(name),
-            "all_event_type_strings is missing canonical variant '{name}' — \
-             every EventType variant must be exercised against the 0xFFFF sentinel"
-        );
-    }
 
-    for (variant, name) in &all_variants {
-        let native_tag = event_type_tag(variant);
-        let wasm_tag = wasm_event_type_tag(name);
-        assert_eq!(
-            native_tag, wasm_tag,
-            "tag mismatch for {name}: native={native_tag}, wasm={wasm_tag}"
-        );
-    }
+    // Distinct-tag bijection: every canonical variant maps to a unique tag in
+    // 0..=75. Because the WASM bridge calls this exact `event_type_tag`, this is
+    // simultaneously the WASM tag contract. A collision (two variants → one tag)
+    // or a gap would corrupt the signed Merkle-leaf preimage and produce false
+    // §9.9.3 equivocation hits across implementations.
+    let mut tags: Vec<u16> = all_variants.iter().map(event_type_tag).collect();
+    assert_eq!(
+        tags.len(),
+        76,
+        "expected one tag per canonical EventType variant"
+    );
+    tags.sort_unstable();
+    tags.dedup();
+    assert_eq!(
+        tags.len(),
+        76,
+        "event_type_tag must be a bijection: all 76 EventType variants must map \
+         to distinct tags — fix `scp-event-log/src/tree.rs` `event_type_tag`"
+    );
+
+    // The bijection must cover the contiguous range 0..=75 with no holes, which
+    // (together with distinctness above) pins the exact canonical assignment the
+    // WASM bridge inherits by sharing this function.
+    assert_eq!(
+        tags.first().copied(),
+        Some(0),
+        "canonical event_type_tag range must start at 0"
+    );
+    assert_eq!(
+        tags.last().copied(),
+        Some(75),
+        "canonical event_type_tag range must end at 75 (76 contiguous tags)"
+    );
 }
 
 /// Confirms that `chain_depth: u8` (scp-core) and `chain_depth: u32` (WASM)


### PR DESCRIPTION
## Summary

Phase 1 of the runtime event-log unification (ADR-011 native↔WASM amendment, merged in #1825). Establishes the `scp-event-log` foundation that the later runtime-cutover phases build on. **Types/tags/classification/KAT only — no runtime emission or FFI/WASM changes yet** (correctly staged; the runtime still emits the legacy `SCP-EXPORT-ENTRY:` chain until Phase 2).

## What this adds

- **Closed `EventType` taxonomy: 36 → 76 variants** (`lib.rs`), matching the merged ADR-011 enum exactly — no `Other(String)` catch-all. The 40 new variants cover governance/lifecycle/membership/economic/consequence/app-sandbox/compromise-recovery events the runtime logs.
- **`event_type_tag` extended to tags 36–75** (`tree.rs`), an exhaustive `const fn` (no `_` arm) — base tags 0–35 byte-unchanged (including the deliberate `EconomicPolicyApplied=33` historical gap). 76 distinct, contiguous.
- **Shared per-variant `EventPayload` encoder** (`payload.rs`) — positional `rmp_serde` (not `to_vec_named`), 8 structured payload structs with round-trip tests asserting the fixarray wire shape. This is the single source both the native runtime and WASM bridge will route through as emit sites are wired.
- **`is_structural_event` extended to all 76** (`pruning.rs`, ADR-030 §2c) — exhaustive match + a pinned `[(EventType, bool); 76]` table asserting the correct structural/operational classification per variant.
- **§25.8 KAT Vectors 32/33** (`test_vectors.rs`, `25-test-vectors.md`) — typed-leaf hashes + checkpoint `tree::root` KAT, runtime-derived then pinned; Vector 33 asserts `checkpoint.merkle_root == tree::root` and verifies the §23.16.1 canonical-hash signature. Pins the cross-implementation byte contract.
- **Test-helper dedup**: removed hand-copied `event_type_tag`/`compute_event_canonical_hash` mirrors from 3 integration tests (now call the canonical `pub` fns); reworked the WASM tag conformance test to assert the real closed-bijection invariant (WASM appends unsigned, sharing `scp_event_log::tree::event_type_tag`).

## Review

Reviewed to strict double-zero (two consecutive clean full-roster passes: cryptographer, bug-catcher, test-quality, alignment) — every reviewer independently verified the tag bijection, the classification table vs the function, and the KAT (perturbing the seed to prove non-tautology). No closing keyword — this is the foundation for the runtime cutover, not a ticketed item.

🤖 Generated with [Claude Code](https://claude.com/claude-code)