### PR TITLE
feat(ffi): wire document-backed VM-aware governance KeyResolver into FFI bridges (ADR-039 / SCP-AB-021)

### DIFF
--- a/crates/scp-ffi/common/src/bridge_runtime.rs
+++ b/crates/scp-ffi/common/src/bridge_runtime.rs
@@ -97,7 +97,7 @@ pub fn document_vm_key_resolver(
 ) -> scp_core::context::governance::KeyResolver {
     std::sync::Arc::new(
         move |did: &scp_identity::DID, kid: scp_identity::SigningKeyId| {
-            did_resolver.verifying_key_for(did.as_ref(), kid).ok()
+            did_resolver.verifying_key_for(did, kid).ok()
         },
     )
 }

--- a/crates/scp-ffi/common/src/bridge_runtime.rs
+++ b/crates/scp-ffi/common/src/bridge_runtime.rs
@@ -71,6 +71,37 @@ pub fn not_configured_key_resolver() -> scp_core::context::governance::KeyResolv
     )
 }
 
+/// Builds a VM-aware governance [`KeyResolver`](scp_core::context::governance::KeyResolver)
+/// backed by a production [`IdentityBackedDidResolver`].
+///
+/// The returned closure resolves the voter's DID document live (cache-backed)
+/// and extracts the Ed25519 verifying key for the *exact* signing key the
+/// caller claims (`#active` or `#agent`, via
+/// [`IdentityBackedDidResolver::verifying_key_for`]). Governance vote signatures
+/// are therefore verified against the document-derived key rather than any
+/// key supplied by the caller (ADR-039 §3a).
+///
+/// Per the `KeyResolver` contract, any resolution failure — unknown DID,
+/// missing verification method, network-unavailable, downgrade, or a malformed
+/// key — collapses to `None` (the closure returns `Option`, not `Result`).
+/// `None` causes the governance engine to reject the vote, so failing closed
+/// here is the safe default.
+///
+/// Callers pass the bridge instance's resolver and receive a closure they
+/// cannot accidentally make collapse to the always-`None`
+/// [`not_configured_key_resolver`]: the only way to get this resolver is to
+/// already hold a real [`IdentityBackedDidResolver`].
+#[must_use]
+pub fn document_vm_key_resolver(
+    did_resolver: std::sync::Arc<IdentityBackedDidResolver>,
+) -> scp_core::context::governance::KeyResolver {
+    std::sync::Arc::new(
+        move |did: &scp_identity::DID, kid: scp_identity::SigningKeyId| {
+            did_resolver.verifying_key_for(did.as_ref(), kid).ok()
+        },
+    )
+}
+
 // ---------------------------------------------------------------------------
 // DID resolver helpers
 // ---------------------------------------------------------------------------

--- a/crates/scp-ffi/common/src/resolvers.rs
+++ b/crates/scp-ffi/common/src/resolvers.rs
@@ -386,6 +386,47 @@ impl IdentityBackedDidResolver {
             ))
         })
     }
+
+    /// Resolves the Ed25519 verifying key for a specific verification method on
+    /// a DID, used by governance vote-signature verification (ADR-039).
+    ///
+    /// Drives the same validated resolution pipeline as the trait
+    /// implementations — live (cache-backed) DID document resolution with BEP44
+    /// signature verification and self-certification, sequence-number rotation
+    /// tracking / downgrade prevention — then extracts the requested
+    /// verification method (`#active` or `#agent`, via
+    /// [`SigningKeyId::fragment`](scp_identity::SigningKeyId::fragment)) and
+    /// parses the public key bytes into an [`ed25519_dalek::VerifyingKey`].
+    ///
+    /// This is the VM-aware accessor the FFI `KeyResolver` closure wraps so the
+    /// governance engine verifies votes against the voter's *document-derived*
+    /// key for the exact signing key they claimed — not a caller-supplied key.
+    ///
+    /// # Errors
+    ///
+    /// - [`ResolutionError::NotFound`] — the DID could not be resolved.
+    /// - [`ResolutionError::InvalidDocument`] — the document failed validation,
+    ///   the requested verification method is absent, the key bytes could not be
+    ///   decoded, or the bytes are not a valid Ed25519 curve point.
+    /// - [`ResolutionError::NetworkUnavailable`] — all resolution layers were
+    ///   unreachable.
+    /// - [`ResolutionError::Revoked`] — the document carried a stale sequence
+    ///   number (possible downgrade attack).
+    pub fn verifying_key_for(
+        &self,
+        did: &str,
+        key_id: scp_identity::SigningKeyId,
+    ) -> Result<ed25519_dalek::VerifyingKey, ResolutionError> {
+        let resolved = self.resolve_sync(did)?;
+        self.check_sequence(did, resolved.seq)?;
+        let bytes = Self::extract_public_key(&resolved, key_id.fragment())?;
+        ed25519_dalek::VerifyingKey::from_bytes(&bytes).map_err(|e| {
+            ResolutionError::InvalidDocument(format!(
+                "verification method '#{}' for {did} is not a valid Ed25519 public key: {e}",
+                key_id.fragment()
+            ))
+        })
+    }
 }
 
 /// Implements `scp_core::crypto::ucan::validate::DidResolver` for production
@@ -924,6 +965,172 @@ mod tests {
         assert!(
             result.is_err(),
             "expected error for unknown DID via attestation resolver"
+        );
+    }
+
+    // -----------------------------------------------------------------------
+    // document_vm_key_resolver — VM-aware, document-derived governance resolver
+    // -----------------------------------------------------------------------
+
+    /// A resolvable identity seeded into a real DHT: the DID, the document's
+    /// `#active` and `#agent` verifying keys (the latter present only when the
+    /// document carries an `#agent` verification method).
+    struct SeededIdentity {
+        did: String,
+        active_vk: ed25519_dalek::VerifyingKey,
+        agent_vk: Option<ed25519_dalek::VerifyingKey>,
+    }
+
+    /// Builds a self-certifying, BEP44-signed DID document with `#active`
+    /// (always) and `#agent` (optional) verification methods, and publishes it
+    /// into `dht` so a [`DualLayerResolver`] can resolve and validate it.
+    ///
+    /// The DID is derived from the identity key, which also BEP44-signs the
+    /// document — exactly the production self-certification invariant
+    /// (`verify_self_certification`) the real resolver enforces.
+    #[allow(clippy::similar_names)]
+    async fn seed_identity(dht: &InMemoryDhtClient, with_agent: bool) -> SeededIdentity {
+        use scp_identity::DhtClient;
+
+        // All RNG-bound key generation and signing happens synchronously and is
+        // scoped into this block so the non-`Send` `ThreadRng` is dropped before
+        // the `.await` below (clippy::future_not_send).
+        let (did, identity_pk, active_vk, agent_vk, value, signature) = {
+            use ed25519_dalek::{Signer, SigningKey};
+
+            let mut rng = rand::thread_rng();
+            let identity_sk = SigningKey::generate(&mut rng);
+            let active_sk = SigningKey::generate(&mut rng);
+            let agent_sk = SigningKey::generate(&mut rng);
+
+            let identity_vk = identity_sk.verifying_key();
+            let active_vk = active_sk.verifying_key();
+            let agent_vk = agent_sk.verifying_key();
+
+            let did = format!("did:dht:z{}", zbase32::encode(identity_vk.as_bytes()));
+
+            // Pre-rotation commitment: SHA-256 of a random next identity key.
+            let pre_rotation_commitment: [u8; 32] = {
+                use sha2::{Digest, Sha256};
+                Sha256::digest(SigningKey::generate(&mut rng).verifying_key().as_bytes()).into()
+            };
+
+            let agent_key_bytes = with_agent.then(|| *agent_vk.as_bytes());
+            let doc = DidDocument::new_with_agent_key(
+                &did,
+                identity_vk.as_bytes(),
+                active_vk.as_bytes(),
+                &pre_rotation_commitment,
+                agent_key_bytes.as_ref().map(<[u8; 32]>::as_slice),
+            );
+
+            // BEP44-sign the serialized document with the identity key (seq = 1),
+            // matching DidDht::publish_document.
+            let value = doc.to_json().unwrap().into_bytes();
+            let signable = scp_identity::dht::bep44_signable(&value, 1);
+            let signature: [u8; 64] = identity_sk.sign(&signable).to_bytes();
+
+            (
+                did,
+                *identity_vk.as_bytes(),
+                active_vk,
+                agent_vk,
+                value,
+                signature,
+            )
+        };
+
+        // Publish under the identity public key.
+        dht.publish(&identity_pk, &signature, &value, 1)
+            .await
+            .unwrap();
+
+        SeededIdentity {
+            did,
+            active_vk,
+            agent_vk: with_agent.then_some(agent_vk),
+        }
+    }
+
+    /// Constructs an `IdentityBackedDidResolver` over a `DualLayerResolver`
+    /// backed by `dht`, wrapped for use as a governance key resolver.
+    fn identity_resolver_over(
+        dht: Arc<InMemoryDhtClient>,
+        handle: tokio::runtime::Handle,
+    ) -> Arc<IdentityBackedDidResolver> {
+        let relay = Arc::new(NoOpRelayQuerier);
+        let cache = Arc::new(DidCache::new());
+        let resolver = Arc::new(DualLayerResolver::new(relay, dht, cache, Vec::new()));
+        Arc::new(IdentityBackedDidResolver::new(resolver, handle))
+    }
+
+    #[test]
+    fn document_vm_key_resolver_is_document_derived_and_vm_aware() {
+        let rt = tokio::runtime::Builder::new_multi_thread()
+            .enable_all()
+            .build()
+            .unwrap();
+
+        let dht = Arc::new(InMemoryDhtClient::new());
+
+        // Seed one identity WITH an #agent key, and one WITHOUT.
+        let (with_agent, no_agent) = rt.block_on(async {
+            let with_agent = seed_identity(&dht, true).await;
+            let no_agent = seed_identity(&dht, false).await;
+            (with_agent, no_agent)
+        });
+
+        // Build the production VM-aware governance key resolver over the seeded DHT.
+        let did_resolver = identity_resolver_over(Arc::clone(&dht), rt.handle().clone());
+        let key_resolver = crate::bridge_runtime::document_vm_key_resolver(did_resolver);
+
+        // (DID, Active) → Some(vk) equal to the document's #active key.
+        let with_agent_did = scp_identity::DID::from(with_agent.did.clone());
+        let active = key_resolver(&with_agent_did, scp_identity::SigningKeyId::Active);
+        assert_eq!(
+            active,
+            Some(with_agent.active_vk),
+            "Active VM must resolve to the document's #active key"
+        );
+
+        // (DID, Agent) → Some(vk) equal to the document's #agent key, distinct
+        // from #active.
+        let agent = key_resolver(&with_agent_did, scp_identity::SigningKeyId::Agent);
+        assert_eq!(
+            agent,
+            with_agent.agent_vk,
+            "Agent VM must resolve to the document's #agent key"
+        );
+        assert_ne!(
+            agent,
+            Some(with_agent.active_vk),
+            "Agent and active keys must be distinct (proves VM-awareness)"
+        );
+
+        // (DID with no #agent VM, Agent) → None.
+        let no_agent_did = scp_identity::DID::from(no_agent.did.clone());
+        assert!(
+            key_resolver(&no_agent_did, scp_identity::SigningKeyId::Agent).is_none(),
+            "Agent VM lookup must fail closed when the document has no #agent key"
+        );
+        // Sanity: the no-agent identity still resolves its #active key.
+        assert_eq!(
+            key_resolver(&no_agent_did, scp_identity::SigningKeyId::Active),
+            Some(no_agent.active_vk),
+            "the no-agent identity must still resolve its #active key"
+        );
+
+        // (unknown DID, either VM) → None.
+        let unknown_pk: [u8; 32] = [0x11; 32];
+        let unknown_did =
+            scp_identity::DID::from(format!("did:dht:z{}", zbase32::encode(&unknown_pk)));
+        assert!(
+            key_resolver(&unknown_did, scp_identity::SigningKeyId::Active).is_none(),
+            "unknown DID (Active) must resolve to None"
+        );
+        assert!(
+            key_resolver(&unknown_did, scp_identity::SigningKeyId::Agent).is_none(),
+            "unknown DID (Agent) must resolve to None"
         );
     }
 }

--- a/crates/scp-ffi/common/src/resolvers.rs
+++ b/crates/scp-ffi/common/src/resolvers.rs
@@ -402,6 +402,34 @@ impl IdentityBackedDidResolver {
     /// governance engine verifies votes against the voter's *document-derived*
     /// key for the exact signing key they claimed — not a caller-supplied key.
     ///
+    /// Unlike the `DidResolver`/`DidPublicKeyResolver` trait-impl siblings
+    /// ([`resolve_public_key`](DidResolver::resolve_public_key) /
+    /// [`resolve_public_key_by_kid`](DidResolver::resolve_public_key_by_kid)),
+    /// which flatten failures into the foreign error types those traits require
+    /// ([`CoreUcanError`] / [`TrustError`]), this accessor returns the
+    /// structured, internal [`ResolutionError`] directly. It is the VM-aware
+    /// entry point for callers that want to branch on the *kind* of failure;
+    /// the [`document_vm_key_resolver`](crate::bridge_runtime::document_vm_key_resolver)
+    /// governance helper collapses every error variant to `None`.
+    ///
+    /// # Side effects
+    ///
+    /// This is **not** a pure read. [`check_sequence`](Self::check_sequence)
+    /// advances this resolver instance's per-DID rotation state
+    /// (`seen_sequences`) and may emit a [`DidRotatedEvent`] into
+    /// `rotation_events` when a higher sequence number is observed.
+    ///
+    /// # Downgrade protection
+    ///
+    /// The `check_sequence`/`seen_sequences` ratchet here is **per-resolver-
+    /// instance defense-in-depth**, not the load-bearing anti-rollback guard.
+    /// The authoritative, cross-consumer (in-process) anti-rollback guard is the
+    /// shared `DualLayerResolver`/`DidCache::cached_sequence` check performed
+    /// during document resolution. A future refactor MUST NOT delete the
+    /// cache-level guard on the assumption that this per-instance ratchet covers
+    /// it — it does not (it sees only the DIDs this one resolver instance has
+    /// observed).
+    ///
     /// # Errors
     ///
     /// - [`ResolutionError::NotFound`] — the DID could not be resolved.
@@ -414,10 +442,13 @@ impl IdentityBackedDidResolver {
     ///   number (possible downgrade attack).
     pub fn verifying_key_for(
         &self,
-        did: &str,
+        did: &scp_identity::DID,
         key_id: scp_identity::SigningKeyId,
     ) -> Result<ed25519_dalek::VerifyingKey, ResolutionError> {
+        let did = did.as_ref();
         let resolved = self.resolve_sync(did)?;
+        // Per-instance anti-rollback ratchet (defense-in-depth — see the
+        // "Downgrade protection" note above; the cache-level guard is load-bearing).
         self.check_sequence(did, resolved.seq)?;
         let bytes = Self::extract_public_key(&resolved, key_id.fragment())?;
         ed25519_dalek::VerifyingKey::from_bytes(&bytes).map_err(|e| {

--- a/crates/scp-ffi/napi/src/runtime.rs
+++ b/crates/scp-ffi/napi/src/runtime.rs
@@ -760,6 +760,15 @@ fn not_configured_key_resolver() -> scp_core::context::governance::KeyResolver {
     scp_ffi_common::bridge_runtime::not_configured_key_resolver()
 }
 
+/// Builds the production VM-aware governance key resolver from a DID resolver.
+///
+/// Delegates to [`scp_ffi_common::bridge_runtime::document_vm_key_resolver`].
+fn document_vm_key_resolver(
+    did_resolver: Arc<scp_ffi_common::IdentityBackedDidResolver>,
+) -> scp_core::context::governance::KeyResolver {
+    scp_ffi_common::bridge_runtime::document_vm_key_resolver(did_resolver)
+}
+
 /// Returns the per-instance
 /// [`Supervisor`](scp_core::context::supervisor::Supervisor) on the given
 /// bridge instance.
@@ -927,7 +936,14 @@ pub fn init_supervisor(bi: &NapiBridgeInstance, local_did: &str) {
         return;
     };
     let supervisor_arc =
-        build_supervisor_arc(crypto, transport, event_log, persistence, mls_storage);
+        build_supervisor_arc(
+            crypto,
+            transport,
+            event_log,
+            persistence,
+            mls_storage,
+            key_resolver_for(bi),
+        );
 
     bi.core.set_supervisor(supervisor_arc);
 }
@@ -983,6 +999,7 @@ fn build_supervisor_arc(
     event_log: Box<dyn ContextEventLogProvider>,
     persistence: Box<dyn ContextPersistence>,
     mls_storage: Arc<dyn scp_core::crypto::mls::storage_adapter::OpenMlsStorageAdapter>,
+    key_resolver: scp_core::context::governance::KeyResolver,
 ) -> Arc<scp_core::context::supervisor::Supervisor> {
     // Enable the event broadcast channel so `subscribe_events()` yields a
     // receiver for the node webhook dispatcher (§12.10.5). The unused receiver
@@ -992,13 +1009,25 @@ fn build_supervisor_arc(
         crypto,
         transport,
         event_log,
-        not_configured_key_resolver(),
+        key_resolver,
         Some(persistence),
         None,
         Some(event_tx),
         None,
         mls_storage,
     )
+}
+
+/// Selects the governance key resolver for this bridge instance.
+///
+/// Wires the production VM-aware document resolver when a DID resolver is
+/// configured; otherwise fails closed with the always-`None`
+/// [`not_configured_key_resolver`] so vote-signature verification is never
+/// silently permissive.
+fn key_resolver_for(bi: &NapiBridgeInstance) -> scp_core::context::governance::KeyResolver {
+    bi.core.did_resolver().map_or_else(not_configured_key_resolver, |r| {
+        document_vm_key_resolver(Arc::clone(r))
+    })
 }
 
 /// Returns a `Box<dyn ContextPersistence>` for `ContextManager::with_persistence`.
@@ -1054,7 +1083,14 @@ pub fn init_supervisor_with_local_transport(bi: &NapiBridgeInstance, local_did: 
         return;
     };
     let supervisor_arc =
-        build_supervisor_arc(crypto, transport, event_log, persistence, mls_storage);
+        build_supervisor_arc(
+            crypto,
+            transport,
+            event_log,
+            persistence,
+            mls_storage,
+            key_resolver_for(bi),
+        );
 
     bi.core.set_supervisor(supervisor_arc);
 }
@@ -1109,7 +1145,14 @@ pub fn init_supervisor_with_relay_transport(
         return;
     };
     let supervisor_arc =
-        build_supervisor_arc(crypto, transport, event_log, persistence, mls_storage);
+        build_supervisor_arc(
+            crypto,
+            transport,
+            event_log,
+            persistence,
+            mls_storage,
+            key_resolver_for(bi),
+        );
 
     bi.core.set_supervisor(supervisor_arc);
 }
@@ -1236,6 +1279,7 @@ fn init_supervisor_for_test_on_with_did(bi: &NapiBridgeInstance, local_did: &str
         event_log,
         Box::new(NapiBridgePersistence::new()),
         mls_storage,
+        key_resolver_for(bi),
     );
 
     bi.core.set_supervisor(supervisor_arc);

--- a/crates/scp-ffi/src/runtime.rs
+++ b/crates/scp-ffi/src/runtime.rs
@@ -1205,11 +1205,18 @@ fn build_supervisor(
     // is dropped immediately; the retained sender keeps the channel open so
     // later subscribers (wired at node startup) observe subsequent events.
     let (event_tx, _rx) = tokio::sync::broadcast::channel(EVENT_CHANNEL_CAPACITY);
+    // Wire the production VM-aware governance key resolver when a DID resolver
+    // is configured; otherwise fail closed with the always-`None` resolver so
+    // governance vote-signature verification is never silently permissive.
+    let key_resolver = bi.core.did_resolver().map_or_else(
+        not_configured_key_resolver,
+        |r| document_vm_key_resolver(std::sync::Arc::clone(r)),
+    );
     Ok(scp_core::context::supervisor::Supervisor::with_providers(
         crypto,
         transport,
         event_log,
-        not_configured_key_resolver(),
+        key_resolver,
         persistence,
         None,
         Some(event_tx),
@@ -1292,6 +1299,15 @@ where
 /// Delegates to [`scp_ffi_common::bridge_runtime::not_configured_key_resolver`].
 fn not_configured_key_resolver() -> scp_core::context::governance::KeyResolver {
     scp_ffi_common::bridge_runtime::not_configured_key_resolver()
+}
+
+/// Builds the production VM-aware governance key resolver from a DID resolver.
+///
+/// Delegates to [`scp_ffi_common::bridge_runtime::document_vm_key_resolver`].
+fn document_vm_key_resolver(
+    did_resolver: std::sync::Arc<scp_ffi_common::IdentityBackedDidResolver>,
+) -> scp_core::context::governance::KeyResolver {
+    scp_ffi_common::bridge_runtime::document_vm_key_resolver(did_resolver)
 }
 
 // ---------------------------------------------------------------------------

--- a/crates/scp-ffi/uniffi/src/runtime.rs
+++ b/crates/scp-ffi/uniffi/src/runtime.rs
@@ -798,6 +798,7 @@ impl UniffiBridgeInstance {
             event_log,
             persistence,
             mls_storage,
+            key_resolver_for_core(&self.core),
         );
 
         self.core.set_supervisor(supervisor_arc);
@@ -834,7 +835,14 @@ impl UniffiBridgeInstance {
             return;
         };
         let supervisor_arc =
-            build_supervisor(crypto, transport, event_log, persistence, mls_storage);
+            build_supervisor(
+                crypto,
+                transport,
+                event_log,
+                persistence,
+                mls_storage,
+                key_resolver_for_core(&self.core),
+            );
 
         self.core.set_supervisor(supervisor_arc);
     }
@@ -869,7 +877,14 @@ impl UniffiBridgeInstance {
             return;
         };
         let supervisor_arc =
-            build_supervisor(crypto, transport, event_log, persistence, mls_storage);
+            build_supervisor(
+                crypto,
+                transport,
+                event_log,
+                persistence,
+                mls_storage,
+                key_resolver_for_core(&self.core),
+            );
 
         self.core.set_supervisor(supervisor_arc);
     }
@@ -1154,6 +1169,15 @@ fn not_configured_key_resolver() -> scp_core::context::governance::KeyResolver {
     scp_ffi_common::bridge_runtime::not_configured_key_resolver()
 }
 
+/// Builds the production VM-aware governance key resolver from a DID resolver.
+///
+/// Delegates to [`scp_ffi_common::bridge_runtime::document_vm_key_resolver`].
+fn document_vm_key_resolver(
+    did_resolver: Arc<scp_ffi_common::IdentityBackedDidResolver>,
+) -> scp_core::context::governance::KeyResolver {
+    scp_ffi_common::bridge_runtime::document_vm_key_resolver(did_resolver)
+}
+
 /// Adapter that lets a shared `Arc<dyn ContextPersistence + Send + Sync>` be
 /// consumed by `ContextManager::with_persistence` which requires a `Box`.
 ///
@@ -1268,6 +1292,7 @@ fn build_supervisor(
     event_log: Box<dyn ContextEventLogProvider>,
     persistence: Option<Arc<dyn scp_core::context::persistence::ContextPersistence + Send + Sync>>,
     mls_storage: Arc<dyn scp_core::crypto::mls::storage_adapter::OpenMlsStorageAdapter>,
+    key_resolver: scp_core::context::governance::KeyResolver,
 ) -> Arc<scp_core::context::supervisor::Supervisor> {
     let persistence_box: Option<Box<dyn scp_core::context::persistence::ContextPersistence>> =
         persistence.map(|shared| {
@@ -1285,13 +1310,25 @@ fn build_supervisor(
         crypto,
         transport,
         event_log,
-        not_configured_key_resolver(),
+        key_resolver,
         persistence_box,
         None,
         Some(event_tx),
         None,
         mls_storage,
     )
+}
+
+/// Selects the governance key resolver for a bridge instance core.
+///
+/// Wires the production VM-aware document resolver when a DID resolver is
+/// configured; otherwise fails closed with the always-`None`
+/// [`not_configured_key_resolver`] so vote-signature verification is never
+/// silently permissive.
+fn key_resolver_for_core(core: &CoreFields) -> scp_core::context::governance::KeyResolver {
+    core.did_resolver().map_or_else(not_configured_key_resolver, |r| {
+        document_vm_key_resolver(Arc::clone(r))
+    })
 }
 
 // Phase D (#1695): module-level `context_manager`, `context_manager_expect`,

--- a/crates/scp-node/src/self_host.rs
+++ b/crates/scp-node/src/self_host.rs
@@ -449,6 +449,9 @@ where
     ));
     let event_log: Box<dyn scp_core::context::builder::ContextEventLogProvider> =
         Box::new(scp_core::context::providers::MerkleEventLogProvider::new());
+    // Fail-closed resolver: the VM-aware document resolver lives in scp-ffi-common,
+    // which depends on scp-node (cycle), so wiring it needs the resolver hoisted to
+    // a shared lower-layer crate. Tracked as an SCP-AB-021 follow-up.
     let key_resolver: scp_core::context::governance::KeyResolver =
         Arc::new(|_: &scp_identity::DID, _: scp_identity::SigningKeyId| None);
     let (event_tx, _event_rx) = tokio::sync::broadcast::channel(1000);


### PR DESCRIPTION
## Summary

Builds on #1852 (the runtime `#agent` persona slice). That slice made the receive-side `KeyResolver` VM-aware, but **every production resolver still returned `None`**, so `#agent`/`#active` key resolution only worked in in-crate tests. This wires a real **DID-document-backed, VM-aware** resolver into the FFI bridges.

> Stacked on #1852 — base is `claude/scp-network-architecture-7zq21l` so this diff shows only the resolver work. Merge after #1852.

## What changed

- **`IdentityBackedDidResolver::verifying_key_for(&DID, SigningKeyId) -> Result<VerifyingKey, ResolutionError>`** — reuses the existing private pipeline (`resolve_sync → check_sequence → extract_public_key(fragment) → VerifyingKey::from_bytes`), selecting the VM by the typed `SigningKeyId`. Runs the monotonic-sequence **downgrade check** before key use.
- **`document_vm_key_resolver(Arc<IdentityBackedDidResolver>) -> KeyResolver`** — a collapse-resistant constructor: callers pass the resolver and get a VM-aware closure they cannot accidentally make ignore the `SigningKeyId`.
- **Three FFI bridges (PyO3 / NAPI / UniFFI)** now build the resolver via `bi.core.did_resolver().map_or_else(not_configured_key_resolver, …)` — **fail-closed** when no DID resolver is configured. As a side benefit, governance-vote signature verification becomes document-backed too.
- **Direct, document-derived test** over real BEP44-signed self-certifying DID docs: `#active`/`#agent` resolve to the document's respective keys (and are distinct), missing `#agent` → `None`, unknown DID → `None`.

## Review

Full 6-lens roster — **zero blocking findings**: cryptographer SOUND (downgrade ordering, VM selection, key validation, non-vacuous test), security/bug-catcher/simplifier ZERO, black-hat/api-design APPROVED. LOW nits applied (`&DID` typed param; rustdoc on side-effects, error-shape, and the load-bearing cache-level downgrade guard).

## Deliberately deferred (tracked)

- **Node loopback resolver** stays fail-closed `None`: `scp-node` can't depend on `scp-ffi-common` (cycle). Resolved by **hoisting** `IdentityBackedDidResolver` to a Layer-1 crate → **#1854**.
- VM-selection exact-match hardening → **#1853**. Cold-start TOFU sequence-floor persistence → **#1855**.

Refs SCP-AB-021.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PMybrJMjfyEsiqmsaqFG4Q

---
_Generated by [Claude Code](https://claude.ai/code/session_01PMybrJMjfyEsiqmsaqFG4Q)_