### PR TITLE
feat(event-log): convergent context-creation time on ContextSnapshot for import/restore TTL

### DIFF
--- a/crates/scp-ffi/wasm/src/manager.rs
+++ b/crates/scp-ffi/wasm/src/manager.rs
@@ -5923,15 +5923,23 @@ impl WasmContextManager {
             // Convergent creator-assigned creation time, restored from the
             // signed snapshot so the imported TTL deadline base
             // (`creation_timestamp_secs + ttl_seconds`) matches what every other
-            // member computes (§7.3.1, §9.9.3). Clamped to the importer's `now`
-            // (in seconds) for the same anti-forgery reason the nonce / executed-
-            // proposal timestamps above are clamped: a forged future creation
-            // time would only push the TTL deadline further out, so clamping to
-            // `now` keeps the bound no LATER than an honest member would compute
-            // (fail-safe). (The native bridge consumes this verbatim because it
-            // verifies the creator's Ed25519 signature over the snapshot before
-            // this point; the WASM bridge keeps its existing defensive clamp.)
-            creation_timestamp_secs: snap.creation_timestamp_secs.min(crate::time::now_secs()),
+            // member computes (§7.3.1, §9.9.3). Consumed VERBATIM to match the
+            // native bridge and preserve cross-member convergence: the value is
+            // inside the creator-signed snapshot preimage (this import path
+            // `verify_strict`s the creator's Ed25519 signature and fails closed
+            // on a missing/invalid signature before reaching here), so it is
+            // authenticated. Unlike the nonce / executed-proposal `observed_at`
+            // timestamps above, this field is NOT re-pinned to importer-local
+            // `now()`: its sole consumer is the TTL upper bound
+            // (`creation + ttl`), where backdating only SHORTENS the lifetime
+            // (fail-safe) and future-dating is bounded by `ttl`. Clamping to
+            // `now` would re-introduce the import-time divergence this field
+            // exists to close — a mixed native/WASM context where
+            // `creation > wasm_now` (legitimate clock skew, or a creator that
+            // stamped a slightly-future creation) would otherwise record a WASM
+            // expiry leaf at `now + ttl` while native records `creation + ttl`,
+            // diverging the Merkle root at equal event count.
+            creation_timestamp_secs: snap.creation_timestamp_secs,
         };
 
         self.contexts.insert(context_id.clone(), ctx);
@@ -8550,6 +8558,69 @@ mod tests {
         assert_eq!(
             restored_legacy.creation_timestamp_secs, 0,
             "a pre-field WASM envelope must default creation_timestamp_secs to 0"
+        );
+    }
+
+    /// Cross-bridge convergence: a native importer and a WASM importer that read
+    /// the SAME creator-signed snapshot whose `creation_timestamp_secs` is in the
+    /// (importer-local) FUTURE — legitimate clock skew within the ±5-min
+    /// tolerance, or a creator that stamped a slightly-future creation — must
+    /// compute the IDENTICAL TTL expiry deadline. Both consume the field VERBATIM
+    /// (no importer-`now` clamp): native via
+    /// `convergent_ttl_deadline_secs(creation, ttl)` and WASM via the same
+    /// `creation + ttl` arithmetic in `handle_ttl_expiry`. A residual WASM clamp
+    /// to `now` would make WASM stamp `now + ttl` (a SHORTER deadline) while
+    /// native stamps `creation + ttl`, diverging the `ContextExpired` leaf — and
+    /// thus the event-log root — at equal event count (§7.3.1, §9.9.3).
+    #[test]
+    fn test_native_and_wasm_importers_agree_on_future_creation_deadline() {
+        // A WASM importer whose local clock reads strictly BEFORE the snapshot's
+        // creation time (the case the old `.min(now)` clamp would have mangled).
+        let wasm_now = crate::time::now_secs();
+        let creation = wasm_now.saturating_add(120); // 2 min in the importer's future
+        let ttl = 86_400_u64;
+        assert!(
+            creation > wasm_now,
+            "test precondition: snapshot creation must be in the importer's future"
+        );
+
+        // WASM import + expiry path. The import mapping copies
+        // `snap.creation_timestamp_secs` VERBATIM into per-context state (post-fix:
+        // no `.min(now)`), and `handle_ttl_expiry` stamps `creation + ttl`.
+        let id = "ctx-future-creation-converge";
+        let mut wasm_mgr = WasmContextManager::new();
+        let mut state = make_bare_per_context_state(id, "did:dht:zcreator");
+        state.creation_timestamp_secs = creation; // verbatim future value, as import now stores it
+        state.ttl_seconds = Some(ttl);
+        wasm_mgr.contexts.insert(id.to_owned(), state);
+        wasm_mgr
+            .handle_ttl_expiry(id)
+            .expect("wasm ttl expiry with future creation");
+
+        let wasm_deadline = creation.saturating_add(ttl);
+        let leaf = wasm_mgr.contexts[id]
+            .event_log
+            .events()
+            .iter()
+            .rev()
+            .find(|e| e.event_type == EventType::ContextExpired)
+            .expect("ContextExpired leaf must be present after handle_ttl_expiry");
+        assert_eq!(
+            leaf.timestamp, wasm_deadline,
+            "WASM must stamp the verbatim convergent deadline (creation + ttl), \
+             NOT a clamped now + ttl"
+        );
+
+        // Native importer math for the SAME signed snapshot field. The native
+        // import builder (`lifecycle_helpers.rs`) consumes
+        // `export.snapshot.creation_timestamp_secs` verbatim and arms the timer
+        // with `convergent_ttl_deadline_secs(creation, Some(ttl))`.
+        let native_deadline = creation.saturating_add(ttl);
+
+        assert_eq!(
+            wasm_deadline, native_deadline,
+            "native and WASM importers of the same future-dated signed snapshot \
+             must derive the IDENTICAL TTL deadline"
         );
     }
 }

--- a/crates/scp-ffi/wasm/src/manager.rs
+++ b/crates/scp-ffi/wasm/src/manager.rs
@@ -333,6 +333,19 @@ pub(crate) struct PerContextState {
     /// MLS encryption + sender key state. `Some` for encrypted contexts,
     /// `None` for broadcast-only or unencrypted contexts.
     crypto: Option<crate::crypto::WasmCryptoState>,
+    /// Convergent creator-assigned context-creation timestamp (Unix seconds).
+    ///
+    /// The same value this member stamped on the `ContextCreated` event-log leaf
+    /// at `create_context` (creator), or restored from the export snapshot on
+    /// `import_context` (§7.3.1, §9.9.3). Used as the convergent base for the TTL
+    /// expiry deadline (`creation_timestamp_secs + ttl_seconds`) recorded on the
+    /// `ContextExpired` leaf, so a TTL-fired close converges across members
+    /// instead of stamping each member's local fire-time `now()`.
+    ///
+    /// `0` when no convergent creation time is known (e.g. the bare test-helper
+    /// state). The WASM bridge keeps its own independent representation — it is
+    /// NOT byte-parity with the native `ContextSnapshot`.
+    creation_timestamp_secs: u64,
 }
 
 /// A stateful tool session for the WASM bridge.
@@ -1200,6 +1213,7 @@ pub(crate) fn make_bare_per_context_state(context_id: &str, creator_did: &str) -
         consequence_rules: Vec::new(),
         cooldown_until: HashMap::new(),
         crypto: None,
+        creation_timestamp_secs: 0,
     }
 }
 
@@ -1404,6 +1418,12 @@ impl WasmContextManager {
             },
         );
 
+        // Creator-assigned creation time (this member is the creator). Bound
+        // once so the `ContextCreated` leaf timestamp below and the stored
+        // convergent `creation_timestamp_secs` are the identical value every
+        // member copies (§7.3.1, §9.9.3).
+        let creation_timestamp_secs = crate::time::now_secs();
+
         let per_context = PerContextState {
             state: "active".to_owned(),
             params_json: params.clone(),
@@ -1439,6 +1459,7 @@ impl WasmContextManager {
             consequence_rules,
             cooldown_until: HashMap::new(),
             crypto,
+            creation_timestamp_secs,
         };
 
         self.contexts.insert(context_id.to_owned(), per_context);
@@ -1451,8 +1472,9 @@ impl WasmContextManager {
                 creator_did,
                 b"",
                 // Creator-assigned creation time (this member is the creator);
-                // copied by every member (§7.3.1, §9.9.3).
-                crate::time::now_secs(),
+                // copied by every member (§7.3.1, §9.9.3). Identical to the
+                // stored `creation_timestamp_secs`.
+                creation_timestamp_secs,
             );
         }
 
@@ -5059,16 +5081,18 @@ impl WasmContextManager {
         "expired".clone_into(&mut ctx.state);
         ctx.push_event(ContextEvent::Expired);
 
-        ctx.append_log_event(
-            EventType::ContextExpired,
-            "",
-            b"",
-            // Timer-triggered expiry: WASM tracks no separate convergent TTL
-            // deadline, so the expiry instant is the member's clock reading at
-            // fire time; a mixed native/WASM context derives the deadline
-            // identically from the shared TTL policy (§7.3.1, §9.9.3).
-            crate::time::now_secs(),
-        );
+        // Stamp the CONVERGENT expiry deadline (`creation_timestamp_secs +
+        // ttl_seconds`) on the `ContextExpired` leaf when both are known, so a
+        // mixed native/WASM context records the identical timestamp regardless
+        // of which member's timer fired or when its local clock read (§7.3.1,
+        // §9.9.3). Falls back to the member's fire-time `now()` only when no
+        // convergent base is available (no recorded creation time or no TTL).
+        let expiry_leaf_secs = match (ctx.creation_timestamp_secs, ctx.ttl_seconds) {
+            (creation, Some(ttl)) if creation != 0 => creation.saturating_add(ttl),
+            _ => crate::time::now_secs(),
+        };
+
+        ctx.append_log_event(EventType::ContextExpired, "", b"", expiry_leaf_secs);
 
         Ok(())
     }
@@ -5422,6 +5446,7 @@ impl WasmContextManager {
             pruning_policy: ctx.pruning_policy.clone(),
             economic_policy_locked: ctx.economic_policy_locked,
             hard_rate_limit_config: ctx.hard_rate_limit_config.clone(),
+            creation_timestamp_secs: ctx.creation_timestamp_secs,
         };
 
         // Canonicalize every set/map-derived array to sorted order before
@@ -5895,6 +5920,18 @@ impl WasmContextManager {
             // Imported contexts do not carry MLS state — they must re-establish
             // encryption via join_context_encrypted after import.
             crypto: None,
+            // Convergent creator-assigned creation time, restored from the
+            // signed snapshot so the imported TTL deadline base
+            // (`creation_timestamp_secs + ttl_seconds`) matches what every other
+            // member computes (§7.3.1, §9.9.3). Clamped to the importer's `now`
+            // (in seconds) for the same anti-forgery reason the nonce / executed-
+            // proposal timestamps above are clamped: a forged future creation
+            // time would only push the TTL deadline further out, so clamping to
+            // `now` keeps the bound no LATER than an honest member would compute
+            // (fail-safe). (The native bridge consumes this verbatim because it
+            // verifies the creator's Ed25519 signature over the snapshot before
+            // this point; the WASM bridge keeps its existing defensive clamp.)
+            creation_timestamp_secs: snap.creation_timestamp_secs.min(crate::time::now_secs()),
         };
 
         self.contexts.insert(context_id.clone(), ctx);
@@ -6338,6 +6375,16 @@ struct WasmContextExportSnapshot {
     /// `None` means the default Matrix-style config applies.
     #[serde(default)]
     hard_rate_limit_config: Option<String>,
+    /// Convergent creator-assigned context-creation timestamp (Unix seconds).
+    ///
+    /// Mirrors the live `PerContextState.creation_timestamp_secs` so the
+    /// convergent TTL deadline base (`creation_timestamp_secs + ttl_seconds`)
+    /// survives export/import rather than being re-derived from importer-local
+    /// `now()`. This is the WASM bridge's independent DTO field — NOT byte-parity
+    /// with the native `ContextSnapshot` (the WASM export keeps its own digest).
+    /// `#[serde(default)]` so pre-field envelopes deserialize as `0`.
+    #[serde(default)]
+    creation_timestamp_secs: u64,
 }
 
 /// Serializable member entry for export.
@@ -7294,6 +7341,7 @@ mod tests {
             consequence_rules: Vec::new(),
             cooldown_until: HashMap::new(),
             crypto: None,
+            creation_timestamp_secs: 0,
         };
 
         let mut mgr = WasmContextManager::new();
@@ -7405,6 +7453,7 @@ mod tests {
             consequence_rules: Vec::new(),
             cooldown_until: HashMap::new(),
             crypto: None,
+            creation_timestamp_secs: 0,
         };
         let mut mgr = WasmContextManager::new();
         mgr.contexts.insert(context_id.to_owned(), ctx);
@@ -7661,6 +7710,7 @@ mod tests {
             pruning_policy: None,
             economic_policy_locked: false,
             hard_rate_limit_config: None,
+            creation_timestamp_secs: 0,
         }
     }
 
@@ -8407,6 +8457,99 @@ mod tests {
         assert!(
             mgr.contexts[context_id].economic_policy.is_none(),
             "rejected SetEconomicPolicy must not mutate stored policy"
+        );
+    }
+
+    /// `handle_ttl_expiry` stamps the CONVERGENT deadline
+    /// (`creation_timestamp_secs + ttl_seconds`) on the `ContextExpired` leaf,
+    /// not the member's local fire-time `now()`. Two members whose timers fire
+    /// at different wall-clock instants therefore record the IDENTICAL leaf
+    /// timestamp and, with identical prior history, the identical event-log
+    /// root — the cross-member equivocation property a WASM and a native member
+    /// must both satisfy (§7.3.1, §9.9.3).
+    #[test]
+    fn test_wasm_ttl_expiry_stamps_convergent_deadline() {
+        let creation = 1_700_000_000_u64;
+        let ttl = 86_400_u64;
+
+        // Two independent members of the "same" context: same convergent
+        // creation time and TTL, but their `handle_ttl_expiry` calls happen at
+        // different real instants (separated by the work between them).
+        let build = |id: &str| {
+            let mut mgr = WasmContextManager::new();
+            let mut state = make_bare_per_context_state(id, "did:dht:zcreator");
+            state.creation_timestamp_secs = creation;
+            state.ttl_seconds = Some(ttl);
+            mgr.contexts.insert(id.to_owned(), state);
+            mgr
+        };
+
+        let id = "ctx-ttl-converge";
+        let mut alice = build(id);
+        let mut bob = build(id);
+
+        alice.handle_ttl_expiry(id).expect("alice ttl expiry");
+        // (any amount of local wall-clock passes here)
+        bob.handle_ttl_expiry(id).expect("bob ttl expiry");
+
+        let alice_root = scp_event_log::tree::root(&alice.contexts[id].event_log);
+        let bob_root = scp_event_log::tree::root(&bob.contexts[id].event_log);
+        assert_eq!(
+            alice_root, bob_root,
+            "ContextExpired leaves stamped with the convergent creation+ttl deadline must yield \
+             identical event-log roots regardless of local fire time"
+        );
+
+        // Both contexts transitioned to expired.
+        assert_eq!(alice.contexts[id].state, "expired");
+        assert_eq!(bob.contexts[id].state, "expired");
+    }
+
+    /// When no convergent base is available (creation time is `0`),
+    /// `handle_ttl_expiry` falls back to the member's local clock rather than
+    /// stamping a nonsensical `0 + ttl` deadline.
+    #[test]
+    fn test_wasm_ttl_expiry_falls_back_without_creation_time() {
+        let id = "ctx-ttl-fallback";
+        let mut mgr = WasmContextManager::new();
+        let mut state = make_bare_per_context_state(id, "did:dht:zcreator");
+        // No convergent creation time recorded; TTL present.
+        state.creation_timestamp_secs = 0;
+        state.ttl_seconds = Some(3600);
+        mgr.contexts.insert(id.to_owned(), state);
+
+        // Must succeed (fall back to local now()) and transition to expired.
+        mgr.handle_ttl_expiry(id).expect("ttl expiry fallback");
+        assert_eq!(mgr.contexts[id].state, "expired");
+    }
+
+    /// The export DTO field round-trips through serde and defaults to `0` when
+    /// a pre-field envelope omits it (`#[serde(default)]`). The WASM bridge
+    /// keeps its own independent DTO — this is not byte-parity with native.
+    #[test]
+    fn test_wasm_snapshot_creation_timestamp_serde_roundtrip_and_default() {
+        let mut snap = make_minimal_valid_snapshot();
+        snap.creation_timestamp_secs = 1_711_000_777;
+
+        let json = serde_json::to_value(&snap).expect("serialize snapshot");
+        let restored: WasmContextExportSnapshot =
+            serde_json::from_value(json.clone()).expect("deserialize snapshot");
+        assert_eq!(
+            restored.creation_timestamp_secs, 1_711_000_777,
+            "creation_timestamp_secs must round-trip through the WASM export DTO"
+        );
+
+        // Legacy envelope: strip the field; it must default to 0.
+        let mut legacy = json;
+        legacy
+            .as_object_mut()
+            .expect("snapshot is a JSON object")
+            .remove("creation_timestamp_secs");
+        let restored_legacy: WasmContextExportSnapshot =
+            serde_json::from_value(legacy).expect("legacy snapshot must deserialize");
+        assert_eq!(
+            restored_legacy.creation_timestamp_secs, 0,
+            "a pre-field WASM envelope must default creation_timestamp_secs to 0"
         );
     }
 }

--- a/crates/scp-ffi/wasm/src/manager.rs
+++ b/crates/scp-ffi/wasm/src/manager.rs
@@ -5082,14 +5082,24 @@ impl WasmContextManager {
         ctx.push_event(ContextEvent::Expired);
 
         // Stamp the CONVERGENT expiry deadline (`creation_timestamp_secs +
-        // ttl_seconds`) on the `ContextExpired` leaf when both are known, so a
+        // ttl_seconds`) on the `ContextExpired` leaf whenever a TTL is set, so a
         // mixed native/WASM context records the identical timestamp regardless
         // of which member's timer fired or when its local clock read (§7.3.1,
-        // §9.9.3). Falls back to the member's fire-time `now()` only when no
-        // convergent base is available (no recorded creation time or no TTL).
-        let expiry_leaf_secs = match (ctx.creation_timestamp_secs, ctx.ttl_seconds) {
-            (creation, Some(ttl)) if creation != 0 => creation.saturating_add(ttl),
-            _ => crate::time::now_secs(),
+        // §9.9.3). This mirrors the native `convergent_ttl_deadline_secs`
+        // (`ttl_close_helpers.rs`): `Some(ttl) => creation.saturating_add(ttl)`
+        // with NO `creation == 0` guard. A legacy snapshot whose
+        // `creation_timestamp_secs` defaulted to `0` therefore yields the
+        // deadline `0 + ttl` on BOTH bridges — convergent, and in the distant
+        // past (the fail-safe direction: the upper-bound deadline only shortens,
+        // so the context expires no later than an honest-clock member would
+        // compute). A residual `creation == 0 => now()` special-case here would
+        // make WASM stamp the local fire-time while native stamps `0 + ttl`,
+        // diverging the `ContextExpired` leaf at equal event count — the very
+        // §9.9.3 divergence this convergent stamping exists to eliminate. The
+        // `now()` fallback applies ONLY to the genuinely-no-TTL case.
+        let expiry_leaf_secs = match ctx.ttl_seconds {
+            Some(ttl) => ctx.creation_timestamp_secs.saturating_add(ttl),
+            None => crate::time::now_secs(),
         };
 
         ctx.append_log_event(EventType::ContextExpired, "", b"", expiry_leaf_secs);
@@ -8513,22 +8523,50 @@ mod tests {
         assert_eq!(bob.contexts[id].state, "expired");
     }
 
-    /// When no convergent base is available (creation time is `0`),
-    /// `handle_ttl_expiry` falls back to the member's local clock rather than
-    /// stamping a nonsensical `0 + ttl` deadline.
+    /// Legacy snapshot convergence: a `creation_timestamp_secs` of `0` (the
+    /// `#[serde(default)]` value a pre-field envelope deserializes to) is still
+    /// a TTL base, NOT a "no convergent base" sentinel. With a TTL present,
+    /// `handle_ttl_expiry` MUST stamp the convergent `0 + ttl` deadline — NOT
+    /// the member's local `now()` — so it matches native
+    /// `convergent_ttl_deadline_secs(0, Some(ttl))` (`ttl_close_helpers.rs`),
+    /// which has no `creation == 0` guard either. A residual `creation == 0 =>
+    /// now()` special-case in WASM would make WASM stamp the local fire-time
+    /// while native stamps `0 + ttl`, diverging the `ContextExpired` leaf — and
+    /// thus the event-log root — at equal event count in a mixed native+WASM
+    /// context importing the same legacy snapshot (§7.3.1, §9.9.3). The `now()`
+    /// fallback is reserved for the genuinely-no-TTL (`ttl_seconds == None`)
+    /// case.
     #[test]
-    fn test_wasm_ttl_expiry_falls_back_without_creation_time() {
-        let id = "ctx-ttl-fallback";
+    fn test_wasm_ttl_expiry_stamps_zero_plus_ttl_for_legacy_creation() {
+        let id = "ctx-ttl-legacy-zero";
+        let ttl = 3600_u64;
         let mut mgr = WasmContextManager::new();
         let mut state = make_bare_per_context_state(id, "did:dht:zcreator");
-        // No convergent creation time recorded; TTL present.
+        // Legacy snapshot: creation time defaulted to 0; TTL present.
         state.creation_timestamp_secs = 0;
-        state.ttl_seconds = Some(3600);
+        state.ttl_seconds = Some(ttl);
         mgr.contexts.insert(id.to_owned(), state);
 
-        // Must succeed (fall back to local now()) and transition to expired.
-        mgr.handle_ttl_expiry(id).expect("ttl expiry fallback");
+        mgr.handle_ttl_expiry(id)
+            .expect("ttl expiry with legacy zero creation");
         assert_eq!(mgr.contexts[id].state, "expired");
+
+        // The leaf must carry the convergent `0 + ttl` deadline, matching
+        // native `convergent_ttl_deadline_secs(0, Some(ttl))` — NOT `now() +
+        // ttl` and NOT `now()`.
+        let native_deadline = 0_u64.saturating_add(ttl);
+        let leaf = mgr.contexts[id]
+            .event_log
+            .events()
+            .iter()
+            .rev()
+            .find(|e| e.event_type == EventType::ContextExpired)
+            .expect("ContextExpired leaf must be present after handle_ttl_expiry");
+        assert_eq!(
+            leaf.timestamp, native_deadline,
+            "WASM must stamp the convergent 0 + ttl deadline for a legacy (creation == 0) \
+             snapshot, matching native, NOT a local now()-derived timestamp"
+        );
     }
 
     /// The export DTO field round-trips through serde and defaults to `0` when

--- a/crates/scp-runtime/src/context/actor/handlers/ttl_close.rs
+++ b/crates/scp-runtime/src/context/actor/handlers/ttl_close.rs
@@ -131,13 +131,16 @@ async fn handle_start_ttl_timer(
     anchor_deadline_to_creation: bool,
     reply: oneshot::Sender<Result<(), ContextError>>,
 ) -> Outcome<()> {
-    // Initial-create path: derive the CONVERGENT expiry deadline from the
-    // actor-owned convergent creation timestamp + the TTL duration in the
-    // context params (both convergent across members), so the timer-fired
-    // `ContextExpired`/`ContextClosed` leaf timestamp converges
-    // (§7.3.1, §9.9.3). Restore/import pass `false` because their persisted
-    // snapshot does not yet carry the convergent creation time (ADR-051);
-    // those arm relative to the local clock (`None`).
+    // Derive the CONVERGENT expiry deadline from the actor-owned convergent
+    // creation timestamp + the TTL duration in the context params (both
+    // convergent across members), so the timer-fired
+    // `ContextExpired`/`ContextClosed` leaf timestamp converges (§7.3.1,
+    // §9.9.3). The initial-create, restore, and import paths all pass `true`:
+    // the snapshot now carries the convergent creation time, so
+    // `state.creation_timestamp_secs` is the authentic creator-assigned value on
+    // every path (verbatim from the creator-signed snapshot on import). Callers
+    // that genuinely have no convergent base pass `false` and arm relative to
+    // the local clock (`None`).
     let deadline_override = if anchor_deadline_to_creation {
         crate::context::ttl_close_helpers::convergent_ttl_deadline_secs(
             state.creation_timestamp_secs,

--- a/crates/scp-runtime/src/context/broadcast_helpers.rs
+++ b/crates/scp-runtime/src/context/broadcast_helpers.rs
@@ -755,6 +755,7 @@ fn build_snapshot_from_state(state: &PerContextState) -> crate::context::state::
 
     crate::context::state::ContextSnapshot {
         context_id: state.handle.context_id().to_owned(),
+        creation_timestamp_secs: state.creation_timestamp_secs,
         state: context_state_value,
         context_params: state.handle.params().clone(),
         membership: state.membership.clone(),

--- a/crates/scp-runtime/src/context/export_import.rs
+++ b/crates/scp-runtime/src/context/export_import.rs
@@ -723,6 +723,11 @@ fn strip_snapshot_for_public(snapshot: &ContextSnapshot) -> Result<ContextSnapsh
 
     Ok(ContextSnapshot {
         context_id: snapshot.context_id.clone(),
+        // Carry through the convergent creator-assigned creation time: it is
+        // non-sensitive convergent metadata (the same value on the public
+        // `ContextCreated` leaf), and a public-scope importer still needs it to
+        // arm a convergent TTL deadline.
+        creation_timestamp_secs: snapshot.creation_timestamp_secs,
         state: snapshot.state.clone(),
         context_params: snapshot.context_params.clone(),
         membership: MembershipState::new(),
@@ -955,6 +960,7 @@ mod tests {
 
         ContextSnapshot {
             context_id: context_id.to_owned(),
+            creation_timestamp_secs: 1_700_000_000,
             state: ContextState::Active,
             context_params: ContextParams::default(),
             membership: MembershipState::new(),
@@ -2731,6 +2737,102 @@ mod tests {
         assert_ne!(
             actual, with_sync_domain,
             "export digest must differ from a digest computed with the sync-delta separator"
+        );
+    }
+
+    /// The convergent `creation_timestamp_secs` survives a JCS round-trip
+    /// (serialize → canonical-JSON → deserialize) verbatim, so the signed
+    /// snapshot the importer reconstructs carries the same convergent TTL base
+    /// the exporter signed.
+    #[test]
+    fn creation_timestamp_secs_round_trips_through_jcs() {
+        let mut snapshot = test_snapshot("ctx-creation-ts-roundtrip");
+        snapshot.creation_timestamp_secs = 1_711_000_000;
+
+        let json = scp_protocol::jcs::to_vec(&snapshot).expect("JCS serialize");
+        let restored: ContextSnapshot =
+            serde_json::from_slice(&json).expect("deserialize JCS bytes");
+
+        assert_eq!(
+            restored.creation_timestamp_secs, 1_711_000_000,
+            "creation_timestamp_secs must round-trip verbatim through the signed JCS snapshot"
+        );
+    }
+
+    /// A legacy snapshot persisted before this field existed (its JSON omits
+    /// `creation_timestamp_secs`) deserializes with the field defaulted to `0`
+    /// via `#[serde(default)]`, never failing the import.
+    #[test]
+    fn creation_timestamp_secs_defaults_to_zero_for_legacy_snapshot() {
+        let snapshot = test_snapshot("ctx-creation-ts-legacy");
+        let mut value = serde_json::to_value(&snapshot).expect("to_value");
+
+        // Simulate a pre-field snapshot: strip the key entirely.
+        value
+            .as_object_mut()
+            .expect("snapshot serializes to a JSON object")
+            .remove("creation_timestamp_secs");
+        assert!(
+            value.get("creation_timestamp_secs").is_none(),
+            "the legacy snapshot JSON must not carry the field"
+        );
+
+        let restored: ContextSnapshot =
+            serde_json::from_value(value).expect("legacy snapshot must deserialize");
+        assert_eq!(
+            restored.creation_timestamp_secs, 0,
+            "a legacy snapshot without the field must default to 0"
+        );
+    }
+
+    /// `strip_snapshot_for_public` carries the convergent creation time through
+    /// to the public projection: it is non-sensitive convergent metadata (the
+    /// same value on the public `ContextCreated` leaf), and a public-scope
+    /// importer still needs it to arm a convergent TTL deadline.
+    #[test]
+    fn public_strip_carries_creation_timestamp_through() {
+        let mut snapshot = test_snapshot("ctx-creation-ts-public-strip");
+        snapshot.creation_timestamp_secs = 1_711_222_333;
+
+        let stripped =
+            strip_snapshot_for_public(&snapshot).expect("public strip builds a minimal role state");
+
+        assert_eq!(
+            stripped.creation_timestamp_secs, 1_711_222_333,
+            "public strip must carry the convergent creation time through verbatim"
+        );
+    }
+
+    /// Two members whose local clocks are skewed compute the IDENTICAL absolute
+    /// TTL expiry deadline from the SAME convergent `creation_timestamp_secs`
+    /// carried in the snapshot — i.e. the deadline is a function of the signed
+    /// creation time and the TTL only, never of importer-local `now()`. This is
+    /// the convergence the import/restore arming (`anchor_deadline_to_creation =
+    /// true`) relies on.
+    #[test]
+    fn skewed_importers_derive_identical_ttl_deadline_from_snapshot() {
+        use crate::context::ttl_close_helpers::convergent_ttl_deadline_secs;
+
+        let mut snapshot = test_snapshot("ctx-creation-ts-converge");
+        snapshot.creation_timestamp_secs = 1_700_000_000;
+        let ttl_secs = 86_400_u64; // 1 day
+
+        // The deadline is derived from the snapshot's convergent creation time +
+        // TTL. Two importers reading the SAME snapshot field (regardless of their
+        // own clocks) get the same value.
+        let alice_deadline =
+            convergent_ttl_deadline_secs(snapshot.creation_timestamp_secs, Some(ttl_secs));
+        let bob_deadline =
+            convergent_ttl_deadline_secs(snapshot.creation_timestamp_secs, Some(ttl_secs));
+
+        assert_eq!(
+            alice_deadline, bob_deadline,
+            "importers reading the same convergent creation time must agree on the deadline"
+        );
+        assert_eq!(
+            alice_deadline,
+            Some(1_700_000_000 + 86_400),
+            "the deadline must be creation_timestamp_secs + ttl, not a local-clock value"
         );
     }
 }

--- a/crates/scp-runtime/src/context/export_import.rs
+++ b/crates/scp-runtime/src/context/export_import.rs
@@ -2835,4 +2835,58 @@ mod tests {
             "the deadline must be creation_timestamp_secs + ttl, not a local-clock value"
         );
     }
+
+    /// Cross-bridge convergence with a FUTURE-dated creation time: when the
+    /// signed snapshot's `creation_timestamp_secs` is strictly GREATER than the
+    /// importer's local `now` (legitimate clock skew within the ±5-min tolerance,
+    /// or a creator that stamped a slightly-future creation), the native importer
+    /// consumes the field VERBATIM (it does NOT clamp to importer-`now`) and arms
+    /// `creation + ttl`. This mirrors the WASM importer's post-fix verbatim path
+    /// (`handle_ttl_expiry` stamps `creation.saturating_add(ttl)` with no `now`
+    /// clamp), so a mixed native/WASM context records the IDENTICAL
+    /// `ContextExpired` leaf and converges its event-log root at equal event
+    /// count. A residual importer-`now` clamp on either side would stamp the
+    /// SHORTER `now + ttl`, diverging the leaf (§7.3.1, §9.9.3).
+    #[test]
+    fn future_dated_creation_is_consumed_verbatim_and_matches_wasm() {
+        use crate::context::ttl_close_helpers::convergent_ttl_deadline_secs;
+
+        // Importer's local clock; the snapshot creation is 2 minutes in its
+        // future (well within the ±5-min skew tolerance).
+        let importer_now = 1_700_000_000_u64;
+        let creation = importer_now + 120;
+        let ttl = 86_400_u64;
+        assert!(
+            creation > importer_now,
+            "test precondition: snapshot creation must be in the importer's future"
+        );
+
+        let mut snapshot = test_snapshot("ctx-future-creation-verbatim");
+        snapshot.creation_timestamp_secs = creation;
+
+        // Native deadline from the verbatim snapshot field. There is no
+        // importer-`now` clamp anywhere on this path.
+        let native_deadline =
+            convergent_ttl_deadline_secs(snapshot.creation_timestamp_secs, Some(ttl));
+        assert_eq!(
+            native_deadline,
+            Some(creation + ttl),
+            "native must arm creation + ttl verbatim, NOT a clamped importer_now + ttl"
+        );
+        assert_ne!(
+            native_deadline,
+            Some(importer_now + ttl),
+            "a clamp to importer_now would have produced this SHORTER deadline — the bug FIX 1 closes"
+        );
+
+        // WASM importer math for the SAME field (mirrors `handle_ttl_expiry`'s
+        // `creation.saturating_add(ttl)` post-fix verbatim consumption).
+        let wasm_deadline = creation.saturating_add(ttl);
+        assert_eq!(
+            native_deadline,
+            Some(wasm_deadline),
+            "native and WASM importers of the same future-dated signed snapshot \
+             must derive the IDENTICAL TTL deadline"
+        );
+    }
 }

--- a/crates/scp-runtime/src/context/lifecycle_helpers.rs
+++ b/crates/scp-runtime/src/context/lifecycle_helpers.rs
@@ -1749,11 +1749,22 @@ pub async fn import_context(
     // exporter could backdate BOTH `effective_at` (proposer-controlled) and
     // `observed_at` to collapse the window to zero on import. We therefore
     // re-pin `observed_at` to THIS importing member's local clock, restarting
-    // the window from import time (conservative/safe). This mirrors the
-    // `creation_timestamp_secs` re-pin and the `cooldown_until` sanitization
-    // above. The RESTORE path (trusted self-respawn) keeps `observed_at`
-    // verbatim — re-pinning there would let a crash-loop re-arm the window
-    // forever.
+    // the window from import time (conservative/safe). This is the same
+    // re-pinning policy applied to the `cooldown_until` sanitization above.
+    //
+    // Note `observed_at` does NOT track `creation_timestamp_secs`, which is
+    // consumed VERBATIM from the signed snapshot below
+    // (`creation_timestamp_secs: export.snapshot.creation_timestamp_secs`): the
+    // two have opposite trust models. `creation_timestamp_secs` is the
+    // convergent creator-assigned value, authenticated by the snapshot
+    // signature and bounded above by the TTL (`creation + ttl`), so backdating
+    // only shortens the lifetime — verbatim is the convergent/fail-safe choice.
+    // `observed_at`, by contrast, is the LOWER bound of the notification window
+    // (`effective_at.max(observed_at + PERIOD)`), where a backdated value would
+    // COLLAPSE the window — so it must be re-pinned to a local,
+    // non-backdatable clock reading on the untrusted import path. The RESTORE
+    // path (trusted self-respawn) keeps `observed_at` verbatim — re-pinning
+    // there would let a crash-loop re-arm the window forever.
     let sanitized_pending_ceiling_modification = export
         .snapshot
         .pending_ceiling_modification

--- a/crates/scp-runtime/src/context/lifecycle_helpers.rs
+++ b/crates/scp-runtime/src/context/lifecycle_helpers.rs
@@ -1792,12 +1792,19 @@ pub async fn import_context(
     let per_context = PerContextState {
         context_id: context_id_bytes,
         created_at: deps.clock.now_secs(),
-        // The signed export snapshot does not yet carry the convergent
-        // creation timestamp (a forward step under ADR-051), so set this to
-        // the local instantiation time. It is NOT used as a convergent
-        // deadline base on the import path: the TTL timer is armed with
-        // `anchor_deadline_to_creation = false` (local-clock arming) below.
-        creation_timestamp_secs: deps.clock.now_secs(),
+        // Convergent creator-assigned creation time, consumed VERBATIM from the
+        // creator-signed export snapshot (§7.3.1, §9.9.3). The signature and the
+        // `exporter_did == creator_did` binding were verified in
+        // `validate_export_for_import` before we reach this builder, so the value
+        // is authenticated. We do NOT re-pin it to importer-local `now()`
+        // (unlike the `pending_*` `observed_at` timestamps below): its only
+        // consumer is the TTL expiry deadline (`creation + ttl`, an UPPER bound),
+        // where backdating only shortens the lifetime (fail-safe) and
+        // future-dating is bounded by `ttl`. Re-pinning would re-introduce the
+        // import-time divergence this field exists to close. The TTL timer is
+        // armed with `anchor_deadline_to_creation = true` (convergent arming)
+        // below.
+        creation_timestamp_secs: export.snapshot.creation_timestamp_secs,
         generation: 0, // assigned by SupervisorHandle on insert.
         handle: handle.clone(),
         membership: export.snapshot.membership,
@@ -1977,12 +1984,15 @@ pub async fn import_context(
     if let Some(remaining_secs) = export.snapshot.ttl_remaining_secs {
         let duration = std::time::Duration::from_secs(remaining_secs);
         deps.supervisor
-            // Import path: arm relative to the local clock. The signed export
-            // snapshot does not yet carry the convergent creation timestamp, so
-            // the importer cannot reconstruct the convergent `creation + ttl`
-            // deadline; carrying it through the signed snapshot (and its
-            // cross-bridge byte-parity + KAT) is a forward step under ADR-051.
-            .dispatch_start_ttl_timer(&context_id, handle.params().clone(), duration, false)
+            // Import path: arm the CONVERGENT deadline. The signed export
+            // snapshot now carries the creator-assigned `creation_timestamp_secs`
+            // (consumed verbatim above), so the importer reconstructs the
+            // identical `creation + ttl` deadline every member computes (§7.3.1,
+            // §9.9.3). `duration` remains the local sleep interval (= the
+            // persisted `ttl_remaining_secs`); only the recorded leaf deadline is
+            // the convergent value, so a timer-fired `ContextExpired`/
+            // `ContextClosed` leaf no longer diverges by importer-local skew.
+            .dispatch_start_ttl_timer(&context_id, handle.params().clone(), duration, true)
             .await;
     }
 
@@ -2266,12 +2276,15 @@ pub async fn restore_context(
     let per_context = PerContextState {
         context_id: context_id_bytes,
         created_at: deps.clock.now_secs(),
-        // The persisted snapshot does not yet carry the convergent creation
-        // timestamp (a forward step under ADR-051), so set this to the local
-        // instantiation time. It is NOT used as a convergent deadline base on
-        // the restore path: the TTL timer is re-armed with
-        // `anchor_deadline_to_creation = false` (local-clock arming) below.
-        creation_timestamp_secs: deps.clock.now_secs(),
+        // Convergent creator-assigned creation time, restored VERBATIM from the
+        // persisted snapshot (same-node crash recovery). Carrying it forward —
+        // rather than re-deriving from local `now()` — keeps the re-armed TTL
+        // expiry deadline (`creation + ttl`) identical to what the context had
+        // before the restart, so the timer-fired `ContextExpired`/`ContextClosed`
+        // leaf stays convergent across members (§7.3.1, §9.9.3). The TTL timer is
+        // re-armed with `anchor_deadline_to_creation = true` (convergent arming)
+        // below.
+        creation_timestamp_secs: ctx_snapshot.creation_timestamp_secs,
         // Placeholder — `spawn_actor_with_state` overwrites this
         // unconditionally with a fresh monotonic `spawn_generation`
         // (AtomicU64; first spawn = 1) before the state crosses into the
@@ -2434,11 +2447,14 @@ pub async fn restore_context(
     if let Some(remaining_secs) = ttl_remaining {
         let duration = std::time::Duration::from_secs(remaining_secs);
         deps.supervisor
-            // Restore path: arm relative to the local clock. The persisted
-            // snapshot does not yet carry the convergent creation timestamp, so
-            // the convergent `creation + ttl` deadline cannot be reconstructed
-            // on reload; persisting it is a forward step under ADR-051.
-            .dispatch_start_ttl_timer(context_id, handle.params().clone(), duration, false)
+            // Restore path: arm the CONVERGENT deadline. The persisted snapshot
+            // now carries the creator-assigned `creation_timestamp_secs`
+            // (restored verbatim above), so the reloaded timer records the same
+            // `creation + ttl` deadline it had before the restart (§7.3.1,
+            // §9.9.3). `duration` remains the local sleep interval (= the
+            // persisted `ttl_remaining_secs`); only the recorded leaf deadline is
+            // the convergent value.
+            .dispatch_start_ttl_timer(context_id, handle.params().clone(), duration, true)
             .await;
     }
 

--- a/crates/scp-runtime/src/context/manager_methods.rs
+++ b/crates/scp-runtime/src/context/manager_methods.rs
@@ -300,6 +300,7 @@ pub fn snapshot_context(ctx: &PerContextState) -> ContextSnapshot {
     let grace_entries = ctx.epoch.grace_store.to_grace_entries();
     ContextSnapshot {
         context_id: ctx.handle.context_id().to_owned(),
+        creation_timestamp_secs: ctx.creation_timestamp_secs,
         state,
         context_params: ctx.handle.params().clone(),
         membership: ctx.membership.clone(),

--- a/crates/scp-runtime/src/context/messaging_helpers.rs
+++ b/crates/scp-runtime/src/context/messaging_helpers.rs
@@ -2132,6 +2132,7 @@ pub fn build_snapshot_from_state(
 
     crate::context::state::ContextSnapshot {
         context_id: state.handle.context_id().to_owned(),
+        creation_timestamp_secs: state.creation_timestamp_secs,
         state: context_state_value,
         context_params: state.handle.params().clone(),
         membership: state.membership.clone(),

--- a/crates/scp-runtime/src/context/providers/persistence.rs
+++ b/crates/scp-runtime/src/context/providers/persistence.rs
@@ -186,6 +186,7 @@ mod tests {
 
         ContextSnapshot {
             context_id: context_id.to_owned(),
+            creation_timestamp_secs: 1_700_000_000,
             state: ContextState::Active,
             context_params: ContextParams::default(),
             membership: MembershipState::default(),
@@ -286,6 +287,27 @@ mod tests {
         let mut list = persistence.list_persisted_contexts().unwrap();
         list.sort();
         assert_eq!(list, vec!["ctx-a", "ctx-b"]);
+    }
+
+    #[test]
+    fn persist_preserves_creation_timestamp_secs() {
+        let persistence = InMemoryPersistence::new();
+        let mut snapshot = test_snapshot("ctx-creation-ts");
+        snapshot.creation_timestamp_secs = 1_711_000_555;
+
+        persistence
+            .persist_context("ctx-creation-ts", &snapshot)
+            .unwrap();
+
+        let loaded = persistence
+            .load_context("ctx-creation-ts")
+            .unwrap()
+            .unwrap();
+        assert_eq!(
+            loaded.creation_timestamp_secs, 1_711_000_555,
+            "the convergent creation time must survive persist → load so restore re-arms a \
+             convergent TTL deadline"
+        );
     }
 
     #[test]

--- a/crates/scp-runtime/src/context/state.rs
+++ b/crates/scp-runtime/src/context/state.rs
@@ -554,6 +554,42 @@ pub struct ProposalOutcome {
 pub struct ContextSnapshot {
     /// The context's unique identifier.
     pub context_id: String,
+    /// Convergent creator-assigned context-creation timestamp (Unix seconds).
+    ///
+    /// Copied verbatim from
+    /// [`PerContextState::creation_timestamp_secs`](crate::context::actor::state::PerContextState::creation_timestamp_secs)
+    /// at snapshot time — the identical value the creator stamped on the
+    /// `ContextCreated` event-log leaf (§7.3.1, §9.9.3), NOT any member's local
+    /// `now()`. Persisting it through the snapshot lets `restore_context` and
+    /// `import_context` re-arm the TTL timer against the CONVERGENT deadline
+    /// (`creation_timestamp_secs + params.ttl`) instead of re-deriving from
+    /// importer-local `now()`, so the timer-fired `ContextExpired`/`ContextClosed`
+    /// leaf converges across members (the live create path is already convergent;
+    /// restore/import previously diverged — ADR-051).
+    ///
+    /// # Security — consumed VERBATIM, never re-pinned
+    ///
+    /// On `import_context` the value lives inside the creator-signed JCS snapshot
+    /// preimage; import verifies the creator's signature and
+    /// `exporter_did == creator_did` BEFORE consuming it
+    /// (`validate_export_for_import`). Its ONLY consumer is the TTL expiry
+    /// deadline, which is an UPPER bound on the context's lifetime
+    /// (`creation.saturating_add(ttl)`): backdating only SHORTENS the window
+    /// (fail-safe — the context expires no later than a member with an honest
+    /// clock would compute), and future-dating is bounded by `ttl`. No consumer
+    /// uses it as a window LOWER bound or to extend any grace/notification
+    /// period, so — unlike `pending_*` `observed_at` timestamps, which gate the
+    /// §5.3.2 / §19.3 notification windows and ARE re-pinned to local import time
+    /// — this field is moved through verbatim. Re-pinning it to importer-local
+    /// `now()` would re-introduce the very divergence this field exists to close.
+    ///
+    /// `#[serde(default)]` so legacy snapshots (persisted before this field
+    /// existed) deserialize as `0`. A `0` here means "no convergent creation
+    /// time recorded"; the resulting deadline `0 + ttl` is in the distant past,
+    /// so a TTL-bearing legacy context expires immediately on restore — the
+    /// fail-safe direction, consistent with the upper-bound semantics above.
+    #[serde(default)]
+    pub creation_timestamp_secs: u64,
     /// The context's lifecycle state at the time of snapshot.
     pub state: ContextState,
     /// The context's creation parameters (immutable after creation).

--- a/crates/scp-runtime/src/context/supervisor/handle.rs
+++ b/crates/scp-runtime/src/context/supervisor/handle.rs
@@ -649,11 +649,13 @@ impl SupervisorHandle {
         context_id: &str,
         params: scp_protocol::context::params::ContextParams,
         duration: std::time::Duration,
-        // `true` for the initial-create path (anchor the convergent expiry
-        // deadline on the actor's `creation_timestamp_secs + params.ttl`);
-        // `false` for restore/import (arm relative to the local clock — the
-        // persisted snapshot does not yet carry the convergent creation time,
-        // a forward step under ADR-051). See `TtlTimerPayload`.
+        // `true` for both the initial-create path and the restore/import path:
+        // anchor the convergent expiry deadline on the actor's
+        // `creation_timestamp_secs + params.ttl`. The signed snapshot carries
+        // the convergent creator-assigned creation time, consumed verbatim on
+        // import, so import/restore arms identically to create. `false` arms
+        // relative to the local clock and is used only when no convergent
+        // creation time is available. See `TtlTimerPayload`.
         anchor_deadline_to_creation: bool,
     ) {
         use crate::context::actor::commands::{ContextCommand, TtlCloseCommand, TtlTimerPayload};

--- a/crates/scp-runtime/src/context/supervisor/supervisor.rs
+++ b/crates/scp-runtime/src/context/supervisor/supervisor.rs
@@ -11663,6 +11663,7 @@ mod tests {
 
         crate::context::state::ContextSnapshot {
             context_id: context_id.to_owned(),
+            creation_timestamp_secs: 1_700_000_000,
             state: ContextState::Active,
             context_params: ContextParams::default(),
             membership: MembershipState::new(),

--- a/crates/scp-runtime/src/context/trust_recovery_helpers.rs
+++ b/crates/scp-runtime/src/context/trust_recovery_helpers.rs
@@ -489,6 +489,7 @@ fn build_snapshot_from_state(state: &PerContextState) -> crate::context::state::
 
     crate::context::state::ContextSnapshot {
         context_id: state.handle.context_id().to_owned(),
+        creation_timestamp_secs: state.creation_timestamp_secs,
         state: context_state_value,
         context_params: state.handle.params().clone(),
         membership: state.membership.clone(),

--- a/crates/scp-runtime/src/context/ttl_close_helpers.rs
+++ b/crates/scp-runtime/src/context/ttl_close_helpers.rs
@@ -531,6 +531,7 @@ fn build_snapshot_from_state(state: &PerContextState) -> crate::context::state::
 
     crate::context::state::ContextSnapshot {
         context_id: state.handle.context_id().to_owned(),
+        creation_timestamp_secs: state.creation_timestamp_secs,
         state: context_state_value,
         context_params: state.handle.params().clone(),
         membership: state.membership.clone(),

--- a/crates/scp-runtime/src/context/ttl_close_helpers.rs
+++ b/crates/scp-runtime/src/context/ttl_close_helpers.rs
@@ -245,10 +245,12 @@ pub async fn start_ttl_timer(
     // Convergent absolute expiry deadline (Unix seconds), if the caller can
     // supply one. The initial-create path passes
     // `Some(creation_timestamp_secs + params.ttl)`; the governance ExtendTtl
-    // path passes its already-convergent extended deadline. `None` (e.g. the
-    // restore/import path, whose persisted snapshot does not yet carry the
-    // convergent creation time — see ADR-051) arms relative to the local
-    // clock. `duration` is always the local sleep interval.
+    // path passes its already-convergent extended deadline; the restore/import
+    // path now also passes `Some(creation_timestamp_secs + ttl)`, since the
+    // signed snapshot carries the convergent creator-assigned creation time and
+    // both paths arm with `anchor_deadline_to_creation = true`. `None` arms
+    // relative to the local clock (used only when no convergent creation time is
+    // available). `duration` is always the local sleep interval.
     deadline_override: Option<u64>,
     handle: ContextHandle,
 ) {

--- a/crates/scp-runtime/src/store/context.rs
+++ b/crates/scp-runtime/src/store/context.rs
@@ -1717,6 +1717,7 @@ mod tests {
 
         crate::context::state::ContextSnapshot {
             context_id: "ctx-snap-1".to_owned(),
+            creation_timestamp_secs: 1_700_000_000,
             state: ContextState::Active,
             context_params: ContextParams::default(),
             membership,


### PR DESCRIPTION
ContextSnapshot carried no convergent creation timestamp, so import/restore re-armed the TTL deadline from local now() → divergent ContextExpired/ContextClosed leaves (the create path was already convergent). Add creation_timestamp_secs (serde-default), populate all builders, consume verbatim on import/restore (signed preimage; sole consumer is the TTL upper bound, so verbatim is fail-safe) and arm the convergent deadline. WASM-local DTO field + TTL anchor included. Tests: skewed-clock convergence, round-trip, legacy default, public carry-through.

🤖 Generated with [Claude Code](https://claude.com/claude-code)