### PR TITLE
fix(trust): convergent evidence-window for convergent consequence triggers (§9.9.3)

### DIFF
--- a/crates/scp-ffi/wasm/src/consequence.rs
+++ b/crates/scp-ffi/wasm/src/consequence.rs
@@ -87,8 +87,22 @@ pub fn dispatch_consequences_for_subject(
     // tool-rate triggers MUST read those events from the receive buffer
     // (Source 2) — local, per-receiver flow control needs no convergence.
     let triggered: Vec<TriggeredConsequence> = {
+        // Convergent window anchor for convergent-trigger rules: max timestamp of
+        // the Source-1 durable log (`event_log_events`), taken BEFORE the buffer
+        // merge — never from the merged set, which mixes in Source-2 buffer events
+        // carrying local-clock estimated timestamps. This mirrors the native
+        // runtime's `event_log_entries_for_consequences` `convergent_now` so both
+        // produce a byte-identical durable `ConsequenceTriggered` leaf under skewed
+        // local clocks (§9.9.3). Empty log -> `now_secs` fallback (no convergent-
+        // trigger evidence exists to anchor).
+        let convergent_now = ctx
+            .event_log_events()
+            .iter()
+            .map(|e| e.timestamp)
+            .max()
+            .unwrap_or(now_secs);
         let events = merged_consequence_events(ctx, now_secs);
-        evaluate_consequence_rules(&rules, &events, subject_did, now_secs)
+        evaluate_consequence_rules(&rules, &events, subject_did, now_secs, convergent_now)
     };
 
     let mut dispatcher = WasmConsequenceDispatcher { ctx };

--- a/crates/scp-protocol/src/trust/consequence.rs
+++ b/crates/scp-protocol/src/trust/consequence.rs
@@ -430,7 +430,13 @@ pub struct ConsequenceRule {
     pub threshold: u64,
 
     /// The time window (in seconds) within which events are counted. Only
-    /// events with timestamps in `[now - window, now]` are considered.
+    /// events whose timestamp falls in `[anchor - window, anchor]` are
+    /// considered, where `anchor` depends on the trigger's convergence
+    /// ([`is_convergent_trigger`]): a **convergent** trigger (`WarningCount`,
+    /// `Custom`) anchors on the convergent event-log timestamp so its durable
+    /// leaf is byte-identical across skewed members (§9.9.3); a
+    /// **non-convergent** trigger (`MessageVelocity`, `ToolRateExceeded`)
+    /// anchors on the evaluating member's local clock, as local flow control.
     pub window: Duration,
 }
 
@@ -664,7 +670,7 @@ pub struct ConsequenceEvidence {
 /// Returned by [`evaluate_consequence_rules`] when a rule's trigger condition
 /// is met. Contains the index of the rule that fired, the action to take,
 /// and the events that constituted the triggering evidence.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct TriggeredConsequence {
     /// Index of the rule in the original rules slice that was triggered.
     pub rule_index: usize,
@@ -925,8 +931,20 @@ pub fn merge_consequence_events(
 ///   `&[Event]` rather than `&EventLog` because `EventLog` stores only leaf
 ///   hashes, not full events.
 /// - `subject_did` -- The DID of the participant being evaluated.
-/// - `now` -- The current time as a Unix timestamp in seconds. Used to compute
-///   the time window boundary for each rule.
+/// - `now` -- The current time as a Unix timestamp in seconds, read from the
+///   evaluating member's **local** clock. Used to compute the evidence window
+///   boundary for **non-convergent** triggers ([`is_convergent_trigger`] is
+///   `false`: `MessageVelocity`, `ToolRateExceeded`), which are local flow
+///   control and never mint a durable leaf, so a local-clock window is sound.
+/// - `convergent_now` -- The convergent window anchor (Unix seconds) used for
+///   **convergent** triggers ([`is_convergent_trigger`] is `true`: `WarningCount`,
+///   `Custom`). It must be the max timestamp of the convergent **Source-1
+///   durable log entries** — NOT a local clock, and NOT derived from the
+///   post-merge `events` (which include Source-2 buffer events carrying
+///   local-clock estimated timestamps). Anchoring convergent triggers to the
+///   convergent log makes the evidence window — and hence the durable
+///   `ConsequenceTriggered` leaf — byte-identical across honest members with
+///   skewed local clocks, eliminating the §9.9.3 equivocation false positive.
 ///
 /// # Returns
 ///
@@ -936,7 +954,12 @@ pub fn merge_consequence_events(
 /// # Design Notes
 ///
 /// - Pure computation -- no side effects, no storage.
-/// - The `now` parameter is passed explicitly (rather than using a `Clock`
+/// - The window anchor splits on the trigger's convergence: convergent triggers
+///   use `convergent_now` (window `[convergent_now - window, convergent_now]`),
+///   non-convergent triggers use the local `now` (window `[now - window, now]`).
+///   Everything downstream (`matches_trigger`, evidence collection, threshold,
+///   `convergent_consequence_timestamp`) is unchanged.
+/// - The clock parameters are passed explicitly (rather than using a `Clock`
 ///   trait) for simplicity and testability, following the pattern established
 ///   by `compute_participation_record`.
 /// - Custom triggers match `GovernanceAction` events whose payload starts
@@ -949,17 +972,27 @@ pub fn evaluate_consequence_rules(
     events: &[Event],
     subject_did: &str,
     now: u64,
+    convergent_now: u64,
 ) -> Vec<TriggeredConsequence> {
     let mut triggered = Vec::new();
 
     for (rule_index, rule) in rules.iter().enumerate() {
-        let window_start = now.saturating_sub(rule.window.as_secs());
+        // Convergent-trigger consequences mint a durable Merkle leaf, so their
+        // evidence window must anchor on the convergent log (`convergent_now`),
+        // not the evaluating member's skewed local clock. Non-convergent triggers
+        // are local flow control and keep the local-clock window.
+        let window_anchor = if is_convergent_trigger(&rule.trigger) {
+            convergent_now
+        } else {
+            now
+        };
+        let window_start = window_anchor.saturating_sub(rule.window.as_secs());
 
         let evidence: Vec<ConsequenceEvidence> = events
             .iter()
             .filter(|event| {
                 // Time window filter.
-                event.timestamp >= window_start && event.timestamp <= now
+                event.timestamp >= window_start && event.timestamp <= window_anchor
             })
             .filter(|event| matches_trigger(&rule.trigger, event, subject_did))
             .map(|event| ConsequenceEvidence {
@@ -1524,7 +1557,7 @@ mod tests {
             make_event(EventType::MessageSent, "did:key:alice", 960, 2, vec![]),
         ];
 
-        let result = evaluate_consequence_rules(&rules, &events, "did:key:alice", 1000);
+        let result = evaluate_consequence_rules(&rules, &events, "did:key:alice", 1000, 1000);
 
         assert_eq!(result.len(), 1);
         assert_eq!(result[0].rule_index, 0);
@@ -1557,7 +1590,7 @@ mod tests {
             })
             .collect();
 
-        let result = evaluate_consequence_rules(&rules, &events, "did:key:alice", 1000);
+        let result = evaluate_consequence_rules(&rules, &events, "did:key:alice", 1000, 1000);
 
         assert_eq!(result.len(), 1);
         assert_eq!(result[0].action, suspend_all());
@@ -1599,7 +1632,7 @@ mod tests {
             ),
         ];
 
-        let result = evaluate_consequence_rules(&rules, &events, "did:key:alice", 1000);
+        let result = evaluate_consequence_rules(&rules, &events, "did:key:alice", 1000, 1000);
 
         assert_eq!(result.len(), 1);
         assert_eq!(
@@ -1609,6 +1642,109 @@ mod tests {
             }
         );
         assert_eq!(result[0].evidence.len(), 2);
+    }
+
+    /// Convergence pin (§9.9.3): a convergent-trigger rule (`WarningCount`)
+    /// evaluated by two honest members with the SAME convergent `events` but
+    /// DIFFERENT local clocks (`now_a` vs `now_b`) MUST produce byte-identical
+    /// results — including the same `convergent_consequence_timestamp` — as long
+    /// as both anchor on the SAME `convergent_now` (the max timestamp of the
+    /// convergent durable log). Before the fix, the evidence window keyed on the
+    /// local `now`, so skewed members selected different evidence subsets of the
+    /// same convergent events and minted divergent durable leaves.
+    #[test]
+    fn convergent_window_anchor_converges_under_skewed_local_clocks() {
+        let rules = vec![ConsequenceRule {
+            trigger: ConsequenceTrigger::WarningCount,
+            action: ConsequenceAction::AssignRole {
+                to_role: "observer".to_owned(),
+            },
+            threshold: 2,
+            window: Duration::from_mins(5),
+        }];
+
+        let payload =
+            serde_json::to_vec(&serde_json::json!({"target_did": "did:key:alice"})).unwrap();
+
+        // Identical convergent governance-action evidence on both members.
+        let events = vec![
+            make_event(
+                EventType::GovernanceAction,
+                "did:key:admin",
+                800,
+                0,
+                payload.clone(),
+            ),
+            make_event(
+                EventType::GovernanceAction,
+                "did:key:moderator",
+                900,
+                1,
+                payload,
+            ),
+        ];
+
+        // Same convergent anchor (max log timestamp), skewed LOCAL clocks.
+        let convergent_now = 1000;
+        let now_a = 1000;
+        let now_b = 1250;
+
+        let result_a =
+            evaluate_consequence_rules(&rules, &events, "did:key:alice", now_a, convergent_now);
+        let result_b =
+            evaluate_consequence_rules(&rules, &events, "did:key:alice", now_b, convergent_now);
+
+        // Byte-identical triggered set — the durable leaf converges.
+        assert_eq!(result_a, result_b);
+        assert_eq!(result_a.len(), 1);
+        assert_eq!(result_a[0].evidence.len(), 2);
+        // The convergent leaf timestamp (highest-sequence evidence) is identical.
+        assert_eq!(
+            convergent_consequence_timestamp(&result_a[0]),
+            convergent_consequence_timestamp(&result_b[0]),
+        );
+    }
+
+    /// Non-vacuity control for
+    /// [`convergent_window_anchor_converges_under_skewed_local_clocks`]: if the
+    /// anchor itself were skewed (the pre-fix behaviour, here simulated by
+    /// passing each member's LOCAL clock AS `convergent_now`), an event whose
+    /// timestamp lies BETWEEN the two anchors falls inside one member's window
+    /// and outside the other's — so the results DIVERGE. This proves the
+    /// convergence in the positive test comes from the shared anchor, not from
+    /// the evidence happening to fall in every window regardless.
+    #[test]
+    fn convergent_window_skewed_anchor_diverges() {
+        let rules = vec![ConsequenceRule {
+            trigger: ConsequenceTrigger::WarningCount,
+            action: ConsequenceAction::AssignRole {
+                to_role: "observer".to_owned(),
+            },
+            threshold: 1,
+            window: Duration::from_mins(5),
+        }];
+
+        let payload =
+            serde_json::to_vec(&serde_json::json!({"target_did": "did:key:alice"})).unwrap();
+
+        // A single convergent event at ts=1100 — between the two skewed anchors.
+        let events = vec![make_event(
+            EventType::GovernanceAction,
+            "did:key:admin",
+            1100,
+            0,
+            payload,
+        )];
+
+        // Pre-fix simulation: anchor == local clock. Window = 300s.
+        //   anchor_a = 1000 -> window [700, 1000]  -> 1100 EXCLUDED -> no trigger
+        //   anchor_b = 1250 -> window [950, 1250]  -> 1100 INCLUDED -> trigger
+        let result_a = evaluate_consequence_rules(&rules, &events, "did:key:alice", 1000, 1000);
+        let result_b = evaluate_consequence_rules(&rules, &events, "did:key:alice", 1250, 1250);
+
+        assert_ne!(result_a, result_b);
+        assert_eq!(result_a.len(), 0);
+        assert_eq!(result_b.len(), 1);
     }
 
     /// The `WarningCount` trigger must match events whose payload is a typed
@@ -1660,12 +1796,12 @@ mod tests {
             ),
         ];
 
-        let result = evaluate_consequence_rules(&rules, &events, "did:key:alice", 1000);
+        let result = evaluate_consequence_rules(&rules, &events, "did:key:alice", 1000, 1000);
         assert_eq!(result.len(), 1, "typed payloads must drive WarningCount");
         assert_eq!(result[0].evidence.len(), 2);
 
         // A different subject must NOT match.
-        let none = evaluate_consequence_rules(&rules, &events, "did:key:bob", 1000);
+        let none = evaluate_consequence_rules(&rules, &events, "did:key:bob", 1000, 1000);
         assert!(none.is_empty(), "typed payload target_did must be exact");
     }
 
@@ -1687,7 +1823,7 @@ mod tests {
             make_event(EventType::MessageSent, "did:key:alice", 960, 1, vec![]),
         ];
 
-        let result = evaluate_consequence_rules(&rules, &events, "did:key:alice", 1000);
+        let result = evaluate_consequence_rules(&rules, &events, "did:key:alice", 1000, 1000);
 
         assert_eq!(result.len(), 1);
         assert_eq!(result[0].evidence.len(), 2);
@@ -1711,7 +1847,7 @@ mod tests {
             make_event(EventType::MessageSent, "did:key:alice", 960, 1, vec![]),
         ];
 
-        let result = evaluate_consequence_rules(&rules, &events, "did:key:alice", 1000);
+        let result = evaluate_consequence_rules(&rules, &events, "did:key:alice", 1000, 1000);
 
         assert!(result.is_empty());
     }
@@ -1736,7 +1872,7 @@ mod tests {
             make_event(EventType::MessageSent, "did:key:alice", 960, 3, vec![]),
         ];
 
-        let result = evaluate_consequence_rules(&rules, &events, "did:key:alice", 1000);
+        let result = evaluate_consequence_rules(&rules, &events, "did:key:alice", 1000, 1000);
         assert!(result.is_empty());
     }
 
@@ -1760,7 +1896,7 @@ mod tests {
             make_event(EventType::MessageSent, "did:key:bob", 965, 3, vec![]),
         ];
 
-        let result = evaluate_consequence_rules(&rules, &events, "did:key:alice", 1000);
+        let result = evaluate_consequence_rules(&rules, &events, "did:key:alice", 1000, 1000);
         assert!(result.is_empty());
     }
 
@@ -1797,7 +1933,7 @@ mod tests {
             ),
         ];
 
-        let result = evaluate_consequence_rules(&rules, &events, "did:key:alice", 1000);
+        let result = evaluate_consequence_rules(&rules, &events, "did:key:alice", 1000, 1000);
 
         assert_eq!(result.len(), 2);
         assert_eq!(result[0].rule_index, 0);
@@ -1817,7 +1953,7 @@ mod tests {
             window: Duration::from_mins(1),
         }];
 
-        let result = evaluate_consequence_rules(&rules, &[], "did:key:alice", 1000);
+        let result = evaluate_consequence_rules(&rules, &[], "did:key:alice", 1000, 1000);
         assert!(result.is_empty());
     }
 
@@ -1831,7 +1967,7 @@ mod tests {
             vec![],
         )];
 
-        let result = evaluate_consequence_rules(&[], &events, "did:key:alice", 1000);
+        let result = evaluate_consequence_rules(&[], &events, "did:key:alice", 1000, 1000);
         assert!(result.is_empty());
     }
 

--- a/crates/scp-runtime/src/context/actor/handlers/governance.rs
+++ b/crates/scp-runtime/src/context/actor/handlers/governance.rs
@@ -777,7 +777,9 @@ fn handle_evaluate_periodic_consequences_actor(
     let context_id = state.handle.context_id().to_owned();
     let member_dids: Vec<scp_identity::DID> =
         state.membership.members().map(|m| m.did.clone()).collect();
-    let events = event_log_entries_for_consequences(
+    // Periodic sweep: one convergent window anchor shared across all members
+    // so every honest member's durable consequence leaf converges (§9.9.3).
+    let (events, convergent_now) = event_log_entries_for_consequences(
         &state.receive_buffer,
         &context_id,
         now,
@@ -786,7 +788,8 @@ fn handle_evaluate_periodic_consequences_actor(
 
     let mut results: Vec<(scp_identity::DID, Vec<TriggeredConsequence>)> = Vec::new();
     for member_did in member_dids {
-        let triggered = evaluate_consequence_rules(&rules, &events, member_did.as_ref(), now);
+        let triggered =
+            evaluate_consequence_rules(&rules, &events, member_did.as_ref(), now, convergent_now);
         if !triggered.is_empty() {
             results.push((member_did, triggered));
         }

--- a/crates/scp-runtime/src/context/governance_helpers.rs
+++ b/crates/scp-runtime/src/context/governance_helpers.rs
@@ -3176,7 +3176,9 @@ fn actor_check_proposer_eligibility(
         let merkle_root = event_log
             .event_log_merkle_root(&context_id_bytes)
             .unwrap_or([0u8; 32]);
-        let events =
+        // Participation-record path consumes only the merged event set;
+        // `convergent_now` (the consequence window anchor) is unused here.
+        let (events, _convergent_now) =
             event_log_entries_for_consequences(&state.receive_buffer, &context_id, now, event_log);
         if !events.is_empty() {
             match compute_participation_record(
@@ -4321,7 +4323,9 @@ pub fn finalize_governance_action(
         let now = deps.clock.now_secs();
         let rules = state.governance.consequence_rules.clone();
         if !rules.is_empty() {
-            let buf_events = event_log_entries_for_consequences(
+            // Proposer and target share one merged event set and one convergent
+            // window anchor so both evaluations are convergent across members.
+            let (buf_events, convergent_now) = event_log_entries_for_consequences(
                 &state.receive_buffer,
                 context_id,
                 now,
@@ -4332,6 +4336,7 @@ pub fn finalize_governance_action(
                 &buf_events,
                 proposal.proposer_did.as_ref(),
                 now,
+                convergent_now,
             );
             let triggered_target = if let Some(target) = proposal.action.target_did()
                 && target != &proposal.proposer_did
@@ -4343,6 +4348,7 @@ pub fn finalize_governance_action(
                         &buf_events,
                         target.as_ref(),
                         now,
+                        convergent_now,
                     ),
                 ))
             } else {
@@ -4397,7 +4403,8 @@ pub fn finalize_governance_action(
     // Update participation record after governance action (#1530).
     {
         let now = deps.clock.now_secs();
-        let gov_events = event_log_entries_for_consequences(
+        // Participation-record path: only the merged event set is consumed.
+        let (gov_events, _convergent_now) = event_log_entries_for_consequences(
             &state.receive_buffer,
             context_id,
             now,

--- a/crates/scp-runtime/src/context/governance_logic.rs
+++ b/crates/scp-runtime/src/context/governance_logic.rs
@@ -610,12 +610,23 @@ fn emit_failure_escalation(
 /// Takes a borrowed [`ReceiveBuffer`] directly so the caller may build it from
 /// sub-borrows of the unified [`PerContextState`] (ADR-049 §Decision 1) without
 /// holding the whole state across the merge.
+///
+/// Returns `(merged_events, convergent_now)` where `convergent_now` is the max
+/// timestamp of the **Source-1 durable log entries**, computed BEFORE the buffer
+/// merge. This is the convergent window anchor for convergent-trigger consequence
+/// rules in
+/// [`evaluate_consequence_rules`](scp_protocol::trust::consequence::evaluate_consequence_rules):
+/// it must derive from the convergent log alone, never from the merged set
+/// (which mixes in Source-2 buffer events carrying local-clock estimated
+/// timestamps and would therefore be skew-dependent and unsound). An empty log
+/// has no convergent-trigger evidence, so `convergent_now` falls back to `now`
+/// (the window is then irrelevant: no convergent events can match it).
 pub fn event_log_entries_for_consequences(
     receive_buffer: &ReceiveBuffer,
     context_id: &str,
     now: u64,
     event_log: &dyn crate::context::builder::ContextEventLogProvider,
-) -> Vec<scp_event_log::Event> {
+) -> (Vec<scp_event_log::Event>, u64) {
     // Source 1: Full event log history (persisted, with real timestamps and
     // actor_did). Acquired here from the provider; an unreadable/empty log
     // yields an empty slice (the merge then reflects only Source 2).
@@ -625,14 +636,21 @@ pub fn event_log_entries_for_consequences(
         Ok(None) | Err(_) => Vec::new(),
     };
 
+    // Convergent window anchor: max timestamp of the Source-1 durable log,
+    // captured BEFORE the merge. Empty log -> `now` fallback (sound: no
+    // convergent-trigger evidence exists to anchor).
+    let convergent_now = log_entries.iter().map(|e| e.timestamp).max().unwrap_or(now);
+
     // Source 2: the receive buffer. Delegate the convergence-critical merge
     // (projection + buffer gates) to the shared function so native and WASM
     // stay byte-identical.
-    scp_protocol::trust::consequence::merge_consequence_events(
+    let merged = scp_protocol::trust::consequence::merge_consequence_events(
         &log_entries,
         receive_buffer.event_log_entries(),
         now,
-    )
+    );
+
+    (merged, convergent_now)
 }
 
 #[cfg(test)]
@@ -860,7 +878,8 @@ mod convergence_tests {
     /// `Custom` triggers match) in the merged consequence-evaluation event list.
     fn governance_bucket_count(buffer: &ReceiveBuffer) -> usize {
         let (log, ctx) = convergent_log();
-        let merged = event_log_entries_for_consequences(buffer, &ctx, 1_700_000_100, &log);
+        let (merged, _convergent_now) =
+            event_log_entries_for_consequences(buffer, &ctx, 1_700_000_100, &log);
         merged
             .iter()
             .filter(|e| e.event_type == EventType::GovernanceAction)
@@ -921,7 +940,8 @@ mod convergence_tests {
             .duration_since(std::time::UNIX_EPOCH)
             .expect("clock")
             .as_secs();
-        let merged = event_log_entries_for_consequences(&buffer, &context_id_str, now, &log);
+        let (merged, _convergent_now) =
+            event_log_entries_for_consequences(&buffer, &context_id_str, now, &log);
         let message_count = merged
             .iter()
             .filter(|e| e.event_type == EventType::MessageSent)

--- a/crates/scp-runtime/src/context/governance_logic.rs
+++ b/crates/scp-runtime/src/context/governance_logic.rs
@@ -647,8 +647,12 @@ pub fn event_log_entries_for_consequences(
     // the identical evidence set, eliminating the prior local-clock divergence that
     // caused false-positive §9.9.3 equivocation against honest members. It does NOT,
     // on its own, stop a malicious committer/quorum from future-dating governance
-    // actions to widen this window and mint a convergent `ConsequenceTriggered`
-    // against a victim. That residual is admin/quorum-gated (the governance actions
+    // actions in EITHER direction: (amplification) widen this window to sweep in
+    // extra evidence and mint a convergent `ConsequenceTriggered` against a victim,
+    // OR (suppression) push the max far ahead so `window_start` slides PAST genuine
+    // older evidence, dropping an attacker's own earned warnings out of the window
+    // to evade a consequence. Both share this root and the same fix.
+    // That residual is admin/quorum-gated (the governance actions
     // are real, signed, and attributable) and is the open tail of the convergent-
     // wall-clock RFC: bounding committer-assigned timestamps non-forgeably (BFT
     // median-time / accountability) is deferred to that work. A local-clock ceiling

--- a/crates/scp-runtime/src/context/governance_logic.rs
+++ b/crates/scp-runtime/src/context/governance_logic.rs
@@ -639,6 +639,22 @@ pub fn event_log_entries_for_consequences(
     // Convergent window anchor: max timestamp of the Source-1 durable log,
     // captured BEFORE the merge. Empty log -> `now` fallback (sound: no
     // convergent-trigger evidence exists to anchor).
+    //
+    // SECURITY (accepted limitation — convergent, not yet non-forgeable):
+    // these Source-1 leaf timestamps are committer-assigned (`proposal.created_at`,
+    // signature-bound but proposer-chosen and NOT future-bounded). Anchoring on
+    // their max makes the evidence window CONVERGENT — every honest member selects
+    // the identical evidence set, eliminating the prior local-clock divergence that
+    // caused false-positive §9.9.3 equivocation against honest members. It does NOT,
+    // on its own, stop a malicious committer/quorum from future-dating governance
+    // actions to widen this window and mint a convergent `ConsequenceTriggered`
+    // against a victim. That residual is admin/quorum-gated (the governance actions
+    // are real, signed, and attributable) and is the open tail of the convergent-
+    // wall-clock RFC: bounding committer-assigned timestamps non-forgeably (BFT
+    // median-time / accountability) is deferred to that work. A local-clock ceiling
+    // here would reintroduce the divergence this fix removes (the consequence
+    // outcome is a convergent durable leaf, not a local application gate), so it is
+    // deliberately NOT applied.
     let convergent_now = log_entries.iter().map(|e| e.timestamp).max().unwrap_or(now);
 
     // Source 2: the receive buffer. Delegate the convergence-critical merge

--- a/crates/scp-runtime/src/context/lifecycle_logic.rs
+++ b/crates/scp-runtime/src/context/lifecycle_logic.rs
@@ -241,12 +241,15 @@ pub fn post_join_bookkeeping(
     let merkle_root = event_log
         .event_log_merkle_root(&context_id_bytes)
         .unwrap_or([0u8; 32]);
-    let join_events = super::governance_logic::event_log_entries_for_consequences(
-        receive_buffer,
-        context_id,
-        now,
-        event_log,
-    );
+    // Participation-record path consumes only the merged event set;
+    // the consequence window anchor is not used here.
+    let (join_events, _convergent_now) =
+        super::governance_logic::event_log_entries_for_consequences(
+            receive_buffer,
+            context_id,
+            now,
+            event_log,
+        );
     if !join_events.is_empty()
         && let Ok(record) = scp_protocol::trust::participation::compute_participation_record(
             &join_events,

--- a/crates/scp-runtime/src/context/messaging_helpers.rs
+++ b/crates/scp-runtime/src/context/messaging_helpers.rs
@@ -691,13 +691,20 @@ pub fn run_buffered_post_delivery(
 
     let consequence_rules: Vec<ConsequenceRule> = state.governance.consequence_rules.clone();
     if !consequence_rules.is_empty() {
-        let events = crate::context::governance_logic::event_log_entries_for_consequences(
-            &state.receive_buffer,
-            context_id,
+        let (events, convergent_now) =
+            crate::context::governance_logic::event_log_entries_for_consequences(
+                &state.receive_buffer,
+                context_id,
+                now,
+                event_log,
+            );
+        let triggered = evaluate_consequence_rules(
+            &consequence_rules,
+            &events,
+            sender_did,
             now,
-            event_log,
+            convergent_now,
         );
-        let triggered = evaluate_consequence_rules(&consequence_rules, &events, sender_did, now);
         let member_did = DID(sender_did.to_owned());
         let mut split = crate::context::governance_logic::ConsequenceStateSplit {
             governance: &mut state.governance,
@@ -1832,15 +1839,21 @@ pub fn finalize_send(
     );
 
     // Consequence enforcement.
-    let send_events = crate::context::governance_logic::event_log_entries_for_consequences(
-        &state.receive_buffer,
-        context_id,
-        now,
-        &*deps.event_log,
-    );
+    let (send_events, convergent_now) =
+        crate::context::governance_logic::event_log_entries_for_consequences(
+            &state.receive_buffer,
+            context_id,
+            now,
+            &*deps.event_log,
+        );
     let consequence_rules: Vec<ConsequenceRule> = state.governance.consequence_rules.clone();
-    let send_triggered =
-        evaluate_consequence_rules(&consequence_rules, &send_events, sender_did.as_ref(), now);
+    let send_triggered = evaluate_consequence_rules(
+        &consequence_rules,
+        &send_events,
+        sender_did.as_ref(),
+        now,
+        convergent_now,
+    );
     {
         let mut split = crate::context::governance_logic::ConsequenceStateSplit {
             governance: &mut state.governance,
@@ -2638,15 +2651,20 @@ pub fn deliver_message_and_drain_buffered(
             let consequence_rules: Vec<ConsequenceRule> =
                 state.governance.consequence_rules.clone();
             if !consequence_rules.is_empty() {
-                let recv_events =
+                let (recv_events, convergent_now) =
                     crate::context::governance_logic::event_log_entries_for_consequences(
                         &state.receive_buffer,
                         context_id,
                         now,
                         &*deps.event_log,
                     );
-                let recv_triggered =
-                    evaluate_consequence_rules(&consequence_rules, &recv_events, sender_did, now);
+                let recv_triggered = evaluate_consequence_rules(
+                    &consequence_rules,
+                    &recv_events,
+                    sender_did,
+                    now,
+                    convergent_now,
+                );
                 let recv_member_did = DID(sender_did.to_owned());
                 let mut split = crate::context::governance_logic::ConsequenceStateSplit {
                     governance: &mut state.governance,
@@ -2751,14 +2769,20 @@ pub fn deliver_message_and_drain_buffered(
     }
     let consequence_rules: Vec<ConsequenceRule> = state.governance.consequence_rules.clone();
     if !consequence_rules.is_empty() {
-        let recv_events = crate::context::governance_logic::event_log_entries_for_consequences(
-            &state.receive_buffer,
-            context_id,
+        let (recv_events, convergent_now) =
+            crate::context::governance_logic::event_log_entries_for_consequences(
+                &state.receive_buffer,
+                context_id,
+                now,
+                &*deps.event_log,
+            );
+        let recv_triggered = evaluate_consequence_rules(
+            &consequence_rules,
+            &recv_events,
+            sender_did,
             now,
-            &*deps.event_log,
+            convergent_now,
         );
-        let recv_triggered =
-            evaluate_consequence_rules(&consequence_rules, &recv_events, sender_did, now);
         let recv_member_did = DID(sender_did.to_owned());
         let mut split = crate::context::governance_logic::ConsequenceStateSplit {
             governance: &mut state.governance,

--- a/crates/scp-runtime/src/context/tools/invoke.rs
+++ b/crates/scp-runtime/src/context/tools/invoke.rs
@@ -145,6 +145,12 @@ pub struct ToolEconomyContext<'a, S: BuildHasher = std::hash::RandomState> {
     pub now: u64,
     /// Event log entries for consequence evaluation.
     pub events: &'a [scp_event_log::Event],
+    /// Convergent window anchor (max timestamp of the Source-1 durable log,
+    /// captured before the buffer merge). Anchors the evidence window for
+    /// convergent-trigger consequence rules so the durable leaf is byte-identical
+    /// across skewed members (§9.9.3); derived from the same call to
+    /// `event_log_entries_for_consequences` that produced `events`.
+    pub convergent_now: u64,
     /// Participation cache for proposer eligibility evaluation.
     pub participation_cache: &'a mut std::collections::HashMap<
         String,
@@ -581,6 +587,7 @@ fn economy_post_check<S: BuildHasher>(
         invoker_did,
         economy.context_id,
         economy.now,
+        economy.convergent_now,
         economy.participation_cache,
         economy.consequence_rules,
     )
@@ -816,6 +823,7 @@ pub fn post_tool_invocation_bookkeeping<S: std::hash::BuildHasher>(
     invoker_did: &DID,
     context_id: &str,
     now: u64,
+    convergent_now: u64,
     participation_cache: &mut std::collections::HashMap<
         String,
         scp_protocol::trust::participation::ParticipationRecord,
@@ -839,7 +847,13 @@ pub fn post_tool_invocation_bookkeeping<S: std::hash::BuildHasher>(
     // Evaluate consequence rules after tool execution (#1531).
     // The caller is responsible for enforcing triggered consequences via
     // enforce_triggered_consequences on the PerContextState.
-    evaluate_consequence_rules(consequence_rules, events, invoker_did.as_ref(), now)
+    evaluate_consequence_rules(
+        consequence_rules,
+        events,
+        invoker_did.as_ref(),
+        now,
+        convergent_now,
+    )
 }
 
 /// Validates the spending side of AND-composition for paid tool invocations
@@ -1934,6 +1948,7 @@ mod tests {
             context_id: "ctx-invoke-test",
             now: 0,
             events: &[],
+            convergent_now: 0,
             participation_cache: &mut participation,
             consequence_rules: &[],
             payment_adapter: None,

--- a/crates/scp-runtime/src/context/tools_helpers.rs
+++ b/crates/scp-runtime/src/context/tools_helpers.rs
@@ -516,12 +516,13 @@ pub async fn reserve_tool_economy(
     let consequence_rules = state.governance.consequence_rules.clone();
     let message_pricing = state.governance.message_pricing.clone();
 
-    let events_snapshot = crate::context::governance_logic::event_log_entries_for_consequences(
-        &state.receive_buffer,
-        context_id,
-        now_secs,
-        event_log.as_ref(),
-    );
+    let (events_snapshot, convergent_now) =
+        crate::context::governance_logic::event_log_entries_for_consequences(
+            &state.receive_buffer,
+            context_id,
+            now_secs,
+            event_log.as_ref(),
+        );
 
     let mut participation_cache: HashMap<
         String,
@@ -536,6 +537,7 @@ pub async fn reserve_tool_economy(
             context_id,
             now: now_secs,
             events: &events_snapshot,
+            convergent_now,
             participation_cache: &mut participation_cache,
             consequence_rules: &consequence_rules,
             payment_adapter: payment_adapter.clone(),
@@ -752,7 +754,7 @@ pub async fn settle_tool_economy_capture(
     let payment_adapter = deps.payment_adapter.clone();
 
     let now = clock.now_secs();
-    let events_for_consequences =
+    let (events_for_consequences, convergent_now) =
         crate::context::governance_logic::event_log_entries_for_consequences(
             &state.receive_buffer,
             context_id,
@@ -766,6 +768,7 @@ pub async fn settle_tool_economy_capture(
         invoker_did,
         context_id,
         now,
+        convergent_now,
         &mut state.governance.participation_cache,
         &consequence_rules,
     );

--- a/crates/scp-testing/tests/integration/trust.rs
+++ b/crates/scp-testing/tests/integration/trust.rs
@@ -499,7 +499,7 @@ async fn consequence_rules_evaluation() {
         make_event(EventType::ToolInvoked, alice, 990, 4, b"tool-b".to_vec()),
     ];
 
-    let triggered = evaluate_consequence_rules(&rules, &events, alice, 1000);
+    let triggered = evaluate_consequence_rules(&rules, &events, alice, 1000, 1000);
 
     assert_eq!(triggered.len(), 2);
     assert_eq!(triggered[0].rule_index, 0);


### PR DESCRIPTION
evaluate_consequence_rules selected evidence with a LOCAL-clock window, so two skewed members chose different evidence subsets of the same convergent events → divergent ConsequenceTriggered leaf. For convergent triggers (WarningCount/Custom) anchor the window on convergent_now (max Source-1 durable-log timestamp, taken before the buffer merge); keep local-clock windows for velocity/rate. Threaded through all 8 native callers + WASM dispatch. Tests: positive convergence + non-vacuity negative control.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
**Accepted limitation (tracked):** the convergent anchor is built from committer-assigned (proposer-chosen, not future-bounded) leaf timestamps, so it is convergent but not non-forgeable — a malicious admin/quorum could future-date governance actions to amplify or suppress a `ConsequenceTriggered`. Documented in-code (both directions); tracked in #1861; the real fix is the convergent-wall-clock RFC (discussions/1844). A local-clock ceiling would reintroduce the divergence this PR removes, so it is deliberately not applied.
