### PR TITLE
chore(prd): mark SHB-007 done (follow-up to #1860)

### DIFF
--- a/.docs/prds/self-host-binary.json
+++ b/.docs/prds/self-host-binary.json
@@ -352,7 +352,7 @@
       "gate": "gate-self-host-1",
       "priority": "P1",
       "severity": "major",
-      "status": "pending",
+      "status": "done",
       "files": [
         "crates/scp-node/tests/self_host.rs",
         "crates/scp-node/src/lib.rs",


### PR DESCRIPTION
## Summary

One-line PRD follow-up to #1860: flips story **SHB-007** from `pending` → `done`.

SHB-007 ("verify the external participant shape over the existing public surface, no new admission control") was implemented and **merged in #1860**, and both of its acceptance criteria pass in CI there:

- `external_participant_access_is_cryptographic` — an external non-member reaches `/scp/v1` over `PublicSurface::Full` with no token, yet the relay's stored view is ciphertext (access stays cryptographic).
- `self_host_public_surface_excludes_relay_and_bridge` — SHB-005 isolation intact.

No stubs exist against the criteria. The status flip could not ride along in #1860 because the head branch was locked in the merge queue when the change was ready, so it lands here.

Scope: a single `status` field change in `.docs/prds/self-host-binary.json`; `scripts/validate-prd.py` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PMybrJMjfyEsiqmsaqFG4Q

---
_Generated by [Claude Code](https://claude.ai/code/session_01PMybrJMjfyEsiqmsaqFG4Q)_