### PR TITLE
fix(event-log): native↔WASM leaf actor_did convergence + WASM quorum-execute fix & ADR-031 executor attribution

### DIFF
--- a/crates/scp-event-log/src/lib.rs
+++ b/crates/scp-event-log/src/lib.rs
@@ -37,6 +37,7 @@ pub mod metrics;
 pub mod payload;
 pub mod proof;
 pub mod pruning;
+pub mod system_actors;
 pub mod tiered_storage;
 pub mod time;
 pub mod tree;

--- a/crates/scp-event-log/src/system_actors.rs
+++ b/crates/scp-event-log/src/system_actors.rs
@@ -1,0 +1,51 @@
+//! Convergence-critical system `actor_did` sentinels.
+//!
+//! Some Merkle event-log leaves are minted by the protocol machinery itself
+//! rather than by a member — e.g. a TTL timer firing, a cooperative close
+//! finalizing, a cross-context divergence marker, or a governance-consequence
+//! enforcement. These leaves carry a fixed *system* sentinel in the
+//! [`Event::actor_did`](crate::Event::actor_did) field instead of a real DID.
+//!
+//! # Byte-parity convergence contract (§9.9.3)
+//!
+//! The leaf hash is `SHA-256(0x00 ‖ rmp_serde(Event))`, and `actor_did` is part
+//! of the serialized [`Event`](crate::Event). For native (`scp-runtime`) and
+//! WASM (`scp-ffi-wasm`) honest members to mint **byte-identical** leaves for
+//! the same logical system event — the precondition for §9.9.3 equivocation
+//! detection across bridges — every implementation MUST stamp the **exact same
+//! sentinel string** for the same event class.
+//!
+//! These constants are the single source of truth for those sentinels. Both
+//! `scp-runtime` and `scp-ffi-wasm` depend on `scp-event-log`, so referencing
+//! them here makes cross-bridge convergence true *by construction* rather than
+//! by convention (a bare duplicated string literal in each crate is one typo
+//! away from a silent equivocation false-positive). Production sites in both
+//! bridges and the cross-impl parity KATs reference these consts.
+//!
+//! ADR-034 keeps WASM off `scp-core`/`scp-runtime`; `scp-event-log` is on the
+//! permitted shared-dependency list, so these consts respect that constraint.
+
+/// `actor_did` sentinel for a TTL-timer-driven `ContextExpired` leaf.
+///
+/// Stamped by the timer-fire path when a context's TTL elapses. Must be
+/// byte-identical across native and WASM (§9.9.3).
+pub const SYSTEM_TIMER_ACTOR: &str = "system:timer";
+
+/// `actor_did` sentinel for a cooperative-close `ContextClosed` leaf.
+///
+/// Stamped by the close-finalization path. Must be byte-identical across
+/// native and WASM (§9.9.3).
+pub const SYSTEM_CLOSE_ACTOR: &str = "system:close";
+
+/// `actor_did` sentinel for a saga `CrossContextDivergenceMarker` leaf.
+///
+/// Stamped by the cross-context saga machinery. Native-only leaf today, but
+/// hoisted here for a single source of truth and forward cross-bridge parity.
+pub const SYSTEM_SAGA_ACTOR: &str = "system:saga";
+
+/// `actor_did` sentinel for governance-consequence enforcement leaves.
+///
+/// Stamped when an automated governance consequence (rate-limit, freeze, etc.)
+/// is enforced on a subject. Must be byte-identical across native and WASM
+/// (§9.9.3).
+pub const SYSTEM_CONSEQUENCE_ACTOR: &str = "system";

--- a/crates/scp-ffi/wasm/src/consequence.rs
+++ b/crates/scp-ffi/wasm/src/consequence.rs
@@ -878,7 +878,7 @@ mod tests {
 // answer; together they prove the two impls emit byte-identical leaves.
 // ===========================================================================
 #[cfg(test)]
-#[allow(clippy::unwrap_used)]
+#[allow(clippy::unwrap_used, clippy::expect_used)]
 mod cross_impl_leaf_parity {
     /// `GovernanceActionExecuted`: WASM's real value extraction + shared
     /// `GovernanceActionExecutedPayload` + `encode_payload` (the exact code at
@@ -1135,5 +1135,154 @@ mod cross_impl_leaf_parity {
                  with an EMPTY payload (§9.9.3 native↔WASM parity)"
             );
         }
+    }
+
+    /// Reconstructs the native-reference leaf bytes for a single system event
+    /// from the SHARED `scp_event_log` primitives — the exact preimage native's
+    /// real producer (`ttl.rs`'s `handle_ttl_expiry` / `finalize_close`) feeds
+    /// `tree::append_unsigned_event`: `Event { event_type, actor_did,
+    /// timestamp, sequence: 0, payload: empty, prev_hash: GENESIS, signature:
+    /// [] }`. The leaf hash is `SHA-256(0x00 ‖ rmp_serde(Event))`, so a single
+    /// such append's `tree::root` is exactly that leaf hash. The WASM real
+    /// producer must reproduce this byte-for-byte.
+    #[cfg(test)]
+    fn native_reference_single_system_leaf_root(
+        context_id: &str,
+        event_type: scp_event_log::EventType,
+        actor_did: &str,
+        timestamp: u64,
+    ) -> [u8; 32] {
+        use scp_event_log::tree::{append_unsigned_event, root};
+        use scp_event_log::{DID, Event, EventLog, EventPayload};
+
+        let mut log = EventLog::new(context_id.to_owned());
+        let event = Event {
+            event_type,
+            actor_did: DID::from(actor_did.to_owned()),
+            timestamp,
+            sequence: 0,
+            payload: EventPayload { data: Vec::new() },
+            prev_hash: scp_event_log::tree::GENESIS_PREV_HASH,
+            signature: Vec::new(),
+        };
+        append_unsigned_event(&mut log, &event).expect("reference system leaf append");
+        root(&log)
+    }
+
+    /// §9.9.3 native↔WASM SYSTEM-LEAF parity. The WASM bridge's REAL producers
+    /// (`handle_ttl_expiry` → `ContextExpired`, `finalize_close` →
+    /// `ContextClosed`) MUST stamp the SAME descriptive `actor_did` sentinels
+    /// native's `ttl.rs` stamps (`"system:timer"` / `"system:close"`), at the
+    /// same convergent timestamp — so the same event produces a byte-identical
+    /// leaf hash and therefore an identical single-leaf Merkle root.
+    ///
+    /// A non-vacuity control proves the assertion bites: a leaf reconstructed
+    /// with the PRE-FIX sentinels (`""` for expiry, `"system"` for close) yields
+    /// a DIFFERENT root, i.e. the old WASM bytes diverged from native.
+    #[test]
+    fn cross_impl_system_leaf_actor_did_parity_wasm() {
+        use crate::manager::{WasmContextManager, make_bare_per_context_state};
+        use scp_event_log::EventType;
+
+        // ---- ContextExpired (TTL fire) ----
+        let creation = 1_700_000_000_u64;
+        let ttl = 86_400_u64;
+        let expiry_ts = creation + ttl; // the convergent deadline WASM stamps.
+
+        let expiry_ctx = "ctx-sysleaf-expiry";
+        let mut expiry_state = make_bare_per_context_state(expiry_ctx, "did:dht:zcreator");
+        expiry_state.test_set_creation_timestamp_secs(creation);
+        expiry_state.test_set_ttl_seconds(Some(ttl));
+        let mut expiry_mgr = WasmContextManager::new();
+        expiry_mgr.test_insert_context(expiry_ctx, expiry_state);
+        expiry_mgr
+            .handle_ttl_expiry(expiry_ctx)
+            .expect("real WASM ttl-expiry producer");
+
+        let expiry_leaves = expiry_mgr.test_context_event_log_events(expiry_ctx);
+        let expiry_leaf = expiry_leaves
+            .iter()
+            .find(|e| e.event_type == EventType::ContextExpired)
+            .expect("ContextExpired leaf present after handle_ttl_expiry");
+        assert_eq!(
+            expiry_leaf.actor_did.as_ref(),
+            "system:timer",
+            "WASM ContextExpired leaf MUST stamp the native sentinel \"system:timer\" (§9.9.3)"
+        );
+        assert_eq!(expiry_leaf.timestamp, expiry_ts);
+
+        // The WASM real-producer root equals the native-reference single-leaf
+        // root reconstructed from the shared primitives.
+        assert_eq!(
+            expiry_mgr.test_context_event_log_root(expiry_ctx),
+            native_reference_single_system_leaf_root(
+                expiry_ctx,
+                EventType::ContextExpired,
+                "system:timer",
+                expiry_ts,
+            ),
+            "WASM ContextExpired real-producer leaf MUST be byte-identical to native's \
+             \"system:timer\" reference leaf (§9.9.3 cross-bridge convergence)"
+        );
+        // Non-vacuity: the PRE-FIX empty sentinel would diverge.
+        assert_ne!(
+            expiry_mgr.test_context_event_log_root(expiry_ctx),
+            native_reference_single_system_leaf_root(
+                expiry_ctx,
+                EventType::ContextExpired,
+                "",
+                expiry_ts,
+            ),
+            "the pre-fix empty actor_did MUST diverge from the aligned \"system:timer\" leaf"
+        );
+
+        // ---- ContextClosed (finalize close) ----
+        let close_ctx = "ctx-sysleaf-close";
+        let mut close_state = make_bare_per_context_state(close_ctx, "did:dht:zcreator");
+        // `finalize_close` requires the context to be in the `closing` state.
+        close_state.test_set_state("closing");
+        let mut close_mgr = WasmContextManager::new();
+        close_mgr.test_insert_context(close_ctx, close_state);
+        close_mgr
+            .finalize_close(close_ctx)
+            .expect("real WASM finalize_close producer");
+
+        let close_leaves = close_mgr.test_context_event_log_events(close_ctx);
+        let close_leaf = close_leaves
+            .iter()
+            .find(|e| e.event_type == EventType::ContextClosed)
+            .expect("ContextClosed leaf present after finalize_close");
+        assert_eq!(
+            close_leaf.actor_did.as_ref(),
+            "system:close",
+            "WASM ContextClosed leaf MUST stamp the native sentinel \"system:close\" (§9.9.3)"
+        );
+
+        // `finalize_close` stamps `now_secs()`; pin the parity + non-vacuity at
+        // that landed timestamp (read back from the real leaf) so the leaf-byte
+        // comparison is independent of the test clock.
+        let close_ts = close_leaf.timestamp;
+        assert_eq!(
+            close_mgr.test_context_event_log_root(close_ctx),
+            native_reference_single_system_leaf_root(
+                close_ctx,
+                EventType::ContextClosed,
+                "system:close",
+                close_ts,
+            ),
+            "WASM ContextClosed real-producer leaf MUST be byte-identical to native's \
+             \"system:close\" reference leaf (§9.9.3 cross-bridge convergence)"
+        );
+        // Non-vacuity: the PRE-FIX `"system"` sentinel would diverge.
+        assert_ne!(
+            close_mgr.test_context_event_log_root(close_ctx),
+            native_reference_single_system_leaf_root(
+                close_ctx,
+                EventType::ContextClosed,
+                "system",
+                close_ts,
+            ),
+            "the pre-fix \"system\" actor_did MUST diverge from the aligned \"system:close\" leaf"
+        );
     }
 }

--- a/crates/scp-ffi/wasm/src/consequence.rs
+++ b/crates/scp-ffi/wasm/src/consequence.rs
@@ -1285,4 +1285,87 @@ mod cross_impl_leaf_parity {
             "the pre-fix \"system\" actor_did MUST diverge from the aligned \"system:close\" leaf"
         );
     }
+
+    /// §9.9.3 native↔WASM `GovernanceActionExecuted` EXECUTOR-stamp parity.
+    /// Drives the REAL WASM quorum-approval handlers: a 3-member `majority`
+    /// context (quorum = 2) where the proposer's self-vote is approval #1
+    /// (Pending) and a SECOND admin's approval is #2 — crossing quorum and
+    /// committing the action. The committing member (the quorum-crossing VOTER)
+    /// — NOT the proposer — MUST be stamped as the `GovernanceActionExecuted`
+    /// leaf `actor_did` (ADR-031 §8 "executor DID" / §7.3.1 "committing member"
+    /// / ADR-051 §6). Native's `vote_on_proposal_inner` stamps the same voter;
+    /// stamping the proposer (the pre-fix behavior) would diverge the leaf.
+    #[test]
+    fn cross_impl_governance_action_executed_stamps_executor_wasm() {
+        use crate::manager::{WasmContextManager, make_bare_per_context_state};
+        use scp_event_log::{DID, EventType};
+        use scp_protocol::context::governance::GovernanceAction;
+
+        let context_id = "ctx-gov-executor";
+        let proposer = "did:dht:z6MkProposer";
+        let voter = "did:dht:z6MkVoter";
+
+        // 3-member majority: quorum = 3/2 + 1 = 2. Proposer self-vote = #1
+        // (Pending); the voter's approval = #2 → crosses quorum → executes,
+        // with the VOTER as the committing member.
+        let mut ctx = make_bare_per_context_state(context_id, proposer);
+        ctx.test_set_governance("majority");
+        ctx.test_insert_member(proposer, "admin");
+        ctx.test_insert_member(voter, "admin");
+        ctx.test_insert_member("did:dht:z6MkMemberC", "admin");
+        ctx.test_insert_ceiling("governance:propose");
+        ctx.test_insert_ceiling("governance:vote");
+        // A target action distinct from both proposer and voter keeps the
+        // leaf actor (executor) unambiguously the voter, not the target.
+        ctx.test_insert_ceiling("role:assign");
+
+        let mut mgr = WasmContextManager::new();
+        mgr.test_insert_context(context_id, ctx);
+
+        let proposal_id = "deadbeef";
+        let action = GovernanceAction::ChangeRole {
+            did: DID::from("did:dht:z6MkMemberC".to_owned()),
+            new_role: "observer".to_owned(),
+        };
+
+        let propose_result = mgr
+            .propose_governance_action(context_id, proposer, proposal_id, &action)
+            .unwrap();
+        assert_eq!(
+            propose_result
+                .get("status")
+                .and_then(serde_json::Value::as_str),
+            Some("Pending"),
+            "proposer self-vote (1 of quorum 2) must leave the proposal Pending"
+        );
+
+        let approve_result = mgr
+            .approve_governance_proposal(context_id, proposal_id, voter)
+            .unwrap();
+        assert_eq!(
+            approve_result
+                .get("status")
+                .and_then(serde_json::Value::as_str),
+            Some("Approved"),
+            "voter approval crosses majority quorum (2 of 2) and commits the action"
+        );
+
+        let logged = mgr.test_context_event_log_events(context_id);
+        let executed_leaf = logged
+            .iter()
+            .find(|e| e.event_type == EventType::GovernanceActionExecuted)
+            .expect("GovernanceActionExecuted leaf present after quorum-crossing approval");
+        assert_eq!(
+            executed_leaf.actor_did.as_ref(),
+            voter,
+            "the GovernanceActionExecuted leaf actor_did MUST be the quorum-crossing executor \
+             (voter), NOT the proposer (§9.9.3 native↔WASM convergence; ADR-031 §8 executor DID)"
+        );
+        assert_ne!(
+            executed_leaf.actor_did.as_ref(),
+            proposer,
+            "non-vacuity: proposer != voter, so stamping the proposer would be a distinct \
+             (divergent) leaf actor_did"
+        );
+    }
 }

--- a/crates/scp-ffi/wasm/src/consequence.rs
+++ b/crates/scp-ffi/wasm/src/consequence.rs
@@ -1601,4 +1601,149 @@ mod cross_impl_leaf_parity {
              (divergent) leaf actor_did"
         );
     }
+
+    /// §9.9.3 native↔WASM ACCEPT-decision parity: an eligible voter who holds
+    /// `governance:vote` but LACKS the action capability (`role:assign`, here
+    /// suspended) crosses quorum and the action executes, minting EXACTLY ONE
+    /// `GovernanceActionExecuted` leaf with the voter as actor.
+    ///
+    /// This is the exact regression the per-member execute-time capability check
+    /// caused: native `execute_governance_action` performs NO per-member action
+    /// check (only status / context-id / replay / commit-fault), so native mints
+    /// one leaf. WASM previously gated on
+    /// `member_has_capability(voter, role:assign)` at execute, which a
+    /// vote-eligible-but-action-suspended voter fails — minting zero where native
+    /// mints one. `ChangeRole` has NO native per-action ceiling gate, so removing
+    /// the per-member check converges the decision: both mint exactly one leaf.
+    #[test]
+    fn cross_impl_nonadmin_voter_crosses_quorum_mints_one_leaf_wasm() {
+        use crate::manager::{WasmContextManager, make_bare_per_context_state};
+        use scp_event_log::{DID, EventType};
+        use scp_protocol::context::governance::GovernanceAction;
+
+        let context_id = "ctx-gov-vote-only-voter";
+        let proposer = "did:dht:z6MkProposer";
+        let voter = "did:dht:z6MkVoter";
+
+        // 3-member majority: quorum = 3/2 + 1 = 2. Proposer self-vote = #1
+        // (Pending); the voter's approval = #2 → crosses quorum → executes.
+        let mut ctx = make_bare_per_context_state(context_id, proposer);
+        ctx.test_set_governance("majority");
+        ctx.test_insert_member(proposer, "admin");
+        ctx.test_insert_member(voter, "admin");
+        ctx.test_insert_member("did:dht:z6MkMemberC", "admin");
+        ctx.test_insert_ceiling("governance:propose");
+        ctx.test_insert_ceiling("governance:vote");
+        ctx.test_insert_ceiling("role:assign");
+        // The voter is an ELIGIBLE VOTER (governance:vote intact) but LACKS the
+        // action capability: `role:assign` is suspended for them. The pre-fix
+        // per-member execute check tested exactly `member_has_capability(voter,
+        // role:assign)`, which now returns false (suspension is checked first),
+        // so it would have rejected and minted 0 leaves. `governance:vote` is
+        // NOT suspended, so voting still succeeds.
+        ctx.test_insert_suspended_capability(voter, "role:assign");
+
+        let mut mgr = WasmContextManager::new();
+        mgr.test_insert_context(context_id, ctx);
+
+        let proposal_id = "deadbeef";
+        let action = GovernanceAction::ChangeRole {
+            did: DID::from("did:dht:z6MkMemberC".to_owned()),
+            new_role: "observer".to_owned(),
+        };
+
+        mgr.propose_governance_action(context_id, proposer, proposal_id, &action)
+            .expect("propose by an admin proposer with governance:propose succeeds");
+
+        let approve_result = mgr
+            .approve_governance_proposal(context_id, proposal_id, voter)
+            .expect("vote-eligible voter (governance:vote intact) crosses quorum and commits");
+        assert_eq!(
+            approve_result
+                .get("status")
+                .and_then(serde_json::Value::as_str),
+            Some("Approved"),
+            "voter approval crosses majority quorum (2 of 2) and commits the action"
+        );
+
+        let logged = mgr.test_context_event_log_events(context_id);
+        let executed: Vec<_> = logged
+            .iter()
+            .filter(|e| e.event_type == EventType::GovernanceActionExecuted)
+            .collect();
+        assert_eq!(
+            executed.len(),
+            1,
+            "a vote-eligible voter lacking the action capability MUST still mint EXACTLY ONE \
+             GovernanceActionExecuted leaf — identical to native, which has no per-member \
+             execute-time check (§9.9.3; ADR-031 §8)"
+        );
+        assert_eq!(
+            executed[0].actor_did.as_ref(),
+            voter,
+            "the single GovernanceActionExecuted leaf actor_did is the quorum-crossing voter \
+             (executor), matching native"
+        );
+    }
+
+    /// §9.9.3 native↔WASM REJECT-decision parity: a governance action whose
+    /// required capability is NOT in the context ceiling is rejected IDENTICALLY
+    /// on both bridges — no `GovernanceActionExecuted` leaf is minted.
+    ///
+    /// `RevokeAccess` is gated on `member:ban` in native's `execute_revoke`
+    /// (`governance_helpers.rs`) via `ceiling.contains(&Capability::MemberBan)`.
+    /// `member:ban` is absent from the default ceiling, so native rejects when it
+    /// is not explicitly added. WASM now mirrors this with a per-action
+    /// CONTEXT-CEILING gate in `dispatch_governance_action`, so both reject and
+    /// neither mints a leaf.
+    #[test]
+    fn cross_impl_out_of_ceiling_action_rejected_wasm() {
+        use crate::manager::{WasmContextManager, make_bare_per_context_state};
+        use scp_event_log::DID;
+        use scp_event_log::EventType;
+        use scp_protocol::context::governance::{AccessScope, GovernanceAction};
+
+        let context_id = "ctx-gov-out-of-ceiling";
+        let admin = "did:dht:z6MkAdmin";
+        let target = "did:dht:z6MkTarget";
+
+        // SingleAdmin governance (quorum 0): the admin proposer auto-executes on
+        // propose, so the dispatch ceiling gate fires synchronously and the
+        // propose call surfaces the rejection.
+        let mut ctx = make_bare_per_context_state(context_id, admin);
+        ctx.test_set_governance("single_admin");
+        ctx.test_insert_member(admin, "admin");
+        ctx.test_insert_member(target, "member");
+        ctx.test_insert_ceiling("governance:propose");
+        ctx.test_insert_ceiling("governance:vote");
+        // Deliberately DO NOT insert "member:ban" into the ceiling — this is the
+        // out-of-ceiling condition. Native's `execute_revoke` rejects the same
+        // way (`ceiling.contains(&Capability::MemberBan)` is false).
+
+        let mut mgr = WasmContextManager::new();
+        mgr.test_insert_context(context_id, ctx);
+
+        let action = GovernanceAction::RevokeAccess {
+            did: DID::from(target.to_owned()),
+            access: AccessScope::Both,
+        };
+
+        let result = mgr.propose_governance_action(context_id, admin, "cafebabe", &action);
+        assert!(
+            result.is_err(),
+            "an out-of-ceiling RevokeAccess (member:ban not in ceiling) MUST be rejected — \
+             identical to native's per-action ceiling gate (§9.9.3; ADR-031 §8)"
+        );
+
+        let logged = mgr.test_context_event_log_events(context_id);
+        let executed = logged
+            .iter()
+            .filter(|e| e.event_type == EventType::GovernanceActionExecuted)
+            .count();
+        assert_eq!(
+            executed, 0,
+            "a rejected out-of-ceiling action MUST mint ZERO GovernanceActionExecuted leaves on \
+             both bridges"
+        );
+    }
 }

--- a/crates/scp-ffi/wasm/src/consequence.rs
+++ b/crates/scp-ffi/wasm/src/consequence.rs
@@ -1736,4 +1736,223 @@ mod cross_impl_leaf_parity {
              both bridges"
         );
     }
+
+    /// §9.9.3 native↔WASM REJECT-decision parity for `CreateChildContext`.
+    ///
+    /// Native gates `CreateChildContext` on `Capability::ChildContextCreate` in
+    /// `execute_create_child_context` (`governance_helpers.rs`) via
+    /// `ceiling.contains(&Capability::ChildContextCreate)`. The capability is
+    /// absent from the default ceiling, so an out-of-ceiling proposal is
+    /// rejected and mints ZERO leaves. WASM previously returned `None` (ungated)
+    /// for this action — executing it where native rejected — a §9.9.3
+    /// divergence AND a security gap (running an action outside the ceiling).
+    /// WASM now mirrors native: `dispatch_ceiling_capability` returns
+    /// `Some("context_child:create")` (the `ucan_capability_name()` form that
+    /// `ceiling_strings` stores).
+    #[test]
+    fn cross_impl_out_of_ceiling_create_child_context_rejected_wasm() {
+        use crate::manager::{WasmContextManager, make_bare_per_context_state};
+        use scp_event_log::EventType;
+        use scp_protocol::context::governance::GovernanceAction;
+
+        let context_id = "ctx-gov-child-out-of-ceiling";
+        let admin = "did:dht:z6MkAdmin";
+
+        let mut ctx = make_bare_per_context_state(context_id, admin);
+        ctx.test_set_governance("single_admin");
+        ctx.test_insert_member(admin, "admin");
+        ctx.test_insert_ceiling("governance:propose");
+        ctx.test_insert_ceiling("governance:vote");
+        // Deliberately DO NOT insert "context_child:create" — the out-of-ceiling
+        // condition. Native's `execute_create_child_context` rejects the same way.
+
+        let mut mgr = WasmContextManager::new();
+        mgr.test_insert_context(context_id, ctx);
+
+        // Shape mirrors the dispatch-roundtrip fixture in manager.rs tests.
+        let action: GovernanceAction = serde_json::from_value(serde_json::json!({
+            "CreateChildContext": {"params": {
+                "mode": "Encrypted", "ceiling": [], "ceiling_policy": "Immutable",
+                "promotion_policy": "NoPromotion", "roles": [], "tools": [],
+                "ttl": null, "memory_scope": "Ephemeral", "governance": "SingleAdmin",
+                "template_id": null
+            }}
+        }))
+        .expect("CreateChildContext action deserializes");
+
+        let result = mgr.propose_governance_action(context_id, admin, "cafef00d", &action);
+        assert!(
+            result.is_err(),
+            "an out-of-ceiling CreateChildContext (context_child:create not in ceiling) MUST be \
+             rejected — identical to native's per-action ceiling gate (§9.9.3; ADR-031 §8)"
+        );
+
+        let logged = mgr.test_context_event_log_events(context_id);
+        let executed = logged
+            .iter()
+            .filter(|e| e.event_type == EventType::GovernanceActionExecuted)
+            .count();
+        assert_eq!(
+            executed, 0,
+            "a rejected out-of-ceiling CreateChildContext MUST mint ZERO GovernanceActionExecuted \
+             leaves on both bridges"
+        );
+    }
+
+    /// §9.9.3 native↔WASM ACCEPT-decision parity for `CreateChildContext`: with
+    /// `context_child:create` IN the ceiling, the single-admin propose auto-
+    /// executes and mints EXACTLY ONE `GovernanceActionExecuted` leaf — matching
+    /// native, whose `execute_create_child_context` ceiling check passes.
+    #[test]
+    fn cross_impl_in_ceiling_create_child_context_executes_wasm() {
+        use crate::manager::{WasmContextManager, make_bare_per_context_state};
+        use scp_event_log::EventType;
+        use scp_protocol::context::governance::GovernanceAction;
+
+        let context_id = "ctx-gov-child-in-ceiling";
+        let admin = "did:dht:z6MkAdmin";
+
+        let mut ctx = make_bare_per_context_state(context_id, admin);
+        ctx.test_set_governance("single_admin");
+        ctx.test_insert_member(admin, "admin");
+        ctx.test_insert_ceiling("governance:propose");
+        ctx.test_insert_ceiling("governance:vote");
+        // In-ceiling: the UCAN-format string `ceiling_strings` stores for
+        // `ChildContextCreate` (`Capability::ucan_capability_name()`).
+        ctx.test_insert_ceiling("context_child:create");
+
+        let mut mgr = WasmContextManager::new();
+        mgr.test_insert_context(context_id, ctx);
+
+        let action: GovernanceAction = serde_json::from_value(serde_json::json!({
+            "CreateChildContext": {"params": {
+                "mode": "Encrypted", "ceiling": [], "ceiling_policy": "Immutable",
+                "promotion_policy": "NoPromotion", "roles": [], "tools": [],
+                "ttl": null, "memory_scope": "Ephemeral", "governance": "SingleAdmin",
+                "template_id": null
+            }}
+        }))
+        .expect("CreateChildContext action deserializes");
+
+        mgr.propose_governance_action(context_id, admin, "cafef00d", &action)
+            .expect("in-ceiling CreateChildContext auto-executes on single-admin propose");
+
+        let logged = mgr.test_context_event_log_events(context_id);
+        let executed = logged
+            .iter()
+            .filter(|e| e.event_type == EventType::GovernanceActionExecuted)
+            .count();
+        assert_eq!(
+            executed, 1,
+            "an in-ceiling CreateChildContext MUST mint EXACTLY ONE GovernanceActionExecuted leaf \
+             — identical to native (§9.9.3; ADR-031 §8)"
+        );
+    }
+
+    /// §9.9.3 native↔WASM REJECT-decision parity for `EstablishToolInterface`.
+    ///
+    /// Native gates this on `Capability::ToolInterface` in
+    /// `execute_establish_tool_interface` (`governance_helpers.rs`) via
+    /// `ceiling.contains(&Capability::ToolInterface)`. Absent from the default
+    /// ceiling, so an out-of-ceiling proposal is rejected and mints ZERO leaves.
+    /// WASM previously returned `None` (ungated) — the same divergence/security
+    /// gap as `CreateChildContext`. WASM now returns `Some("tool:interface")`.
+    #[test]
+    fn cross_impl_out_of_ceiling_establish_tool_interface_rejected_wasm() {
+        use crate::manager::{WasmContextManager, make_bare_per_context_state};
+        use scp_event_log::EventType;
+        use scp_protocol::context::governance::GovernanceAction;
+
+        let context_id = "ctx-gov-iface-out-of-ceiling";
+        let admin = "did:dht:z6MkAdmin";
+
+        let mut ctx = make_bare_per_context_state(context_id, admin);
+        ctx.test_set_governance("single_admin");
+        ctx.test_insert_member(admin, "admin");
+        ctx.test_insert_ceiling("governance:propose");
+        ctx.test_insert_ceiling("governance:vote");
+        // Deliberately DO NOT insert "tool:interface" — the out-of-ceiling
+        // condition. Native's `execute_establish_tool_interface` rejects likewise.
+
+        let mut mgr = WasmContextManager::new();
+        mgr.test_insert_context(context_id, ctx);
+
+        let action: GovernanceAction = serde_json::from_value(serde_json::json!({
+            "EstablishToolInterface": {"interface": {
+                "source_context": "ctx-src", "target_context": "ctx-tgt",
+                "tool_id": "tool-1", "rate_limit": null, "per_caller_rate_limit": null,
+                "approved_by_source": false, "approved_by_target": false,
+                "outbound_policy": null, "inbound_policy": null
+            }}
+        }))
+        .expect("EstablishToolInterface action deserializes");
+
+        let result = mgr.propose_governance_action(context_id, admin, "cafef00d", &action);
+        assert!(
+            result.is_err(),
+            "an out-of-ceiling EstablishToolInterface (tool:interface not in ceiling) MUST be \
+             rejected — identical to native's per-action ceiling gate (§9.9.3; ADR-031 §8)"
+        );
+
+        let logged = mgr.test_context_event_log_events(context_id);
+        let executed = logged
+            .iter()
+            .filter(|e| e.event_type == EventType::GovernanceActionExecuted)
+            .count();
+        assert_eq!(
+            executed, 0,
+            "a rejected out-of-ceiling EstablishToolInterface MUST mint ZERO \
+             GovernanceActionExecuted leaves on both bridges"
+        );
+    }
+
+    /// §9.9.3 native↔WASM ACCEPT-decision parity for `EstablishToolInterface`:
+    /// with `tool:interface` IN the ceiling, the single-admin propose auto-
+    /// executes and mints EXACTLY ONE `GovernanceActionExecuted` leaf — matching
+    /// native, whose `execute_establish_tool_interface` ceiling check passes.
+    #[test]
+    fn cross_impl_in_ceiling_establish_tool_interface_executes_wasm() {
+        use crate::manager::{WasmContextManager, make_bare_per_context_state};
+        use scp_event_log::EventType;
+        use scp_protocol::context::governance::GovernanceAction;
+
+        let context_id = "ctx-gov-iface-in-ceiling";
+        let admin = "did:dht:z6MkAdmin";
+
+        let mut ctx = make_bare_per_context_state(context_id, admin);
+        ctx.test_set_governance("single_admin");
+        ctx.test_insert_member(admin, "admin");
+        ctx.test_insert_ceiling("governance:propose");
+        ctx.test_insert_ceiling("governance:vote");
+        // In-ceiling: `Capability::ToolInterface` is 2-segment, so its
+        // `ucan_capability_name()` form equals its `name()` form: "tool:interface".
+        ctx.test_insert_ceiling("tool:interface");
+
+        let mut mgr = WasmContextManager::new();
+        mgr.test_insert_context(context_id, ctx);
+
+        let action: GovernanceAction = serde_json::from_value(serde_json::json!({
+            "EstablishToolInterface": {"interface": {
+                "source_context": "ctx-src", "target_context": "ctx-tgt",
+                "tool_id": "tool-1", "rate_limit": null, "per_caller_rate_limit": null,
+                "approved_by_source": false, "approved_by_target": false,
+                "outbound_policy": null, "inbound_policy": null
+            }}
+        }))
+        .expect("EstablishToolInterface action deserializes");
+
+        mgr.propose_governance_action(context_id, admin, "cafef00d", &action)
+            .expect("in-ceiling EstablishToolInterface auto-executes on single-admin propose");
+
+        let logged = mgr.test_context_event_log_events(context_id);
+        let executed = logged
+            .iter()
+            .filter(|e| e.event_type == EventType::GovernanceActionExecuted)
+            .count();
+        assert_eq!(
+            executed, 1,
+            "an in-ceiling EstablishToolInterface MUST mint EXACTLY ONE GovernanceActionExecuted \
+             leaf — identical to native (§9.9.3; ADR-031 §8)"
+        );
+    }
 }

--- a/crates/scp-ffi/wasm/src/consequence.rs
+++ b/crates/scp-ffi/wasm/src/consequence.rs
@@ -1152,21 +1152,11 @@ mod cross_impl_leaf_parity {
         actor_did: &str,
         timestamp: u64,
     ) -> [u8; 32] {
-        use scp_event_log::tree::{append_unsigned_event, root};
-        use scp_event_log::{DID, Event, EventLog, EventPayload};
-
-        let mut log = EventLog::new(context_id.to_owned());
-        let event = Event {
-            event_type,
-            actor_did: DID::from(actor_did.to_owned()),
-            timestamp,
-            sequence: 0,
-            payload: EventPayload { data: Vec::new() },
-            prev_hash: scp_event_log::tree::GENESIS_PREV_HASH,
-            signature: Vec::new(),
-        };
-        append_unsigned_event(&mut log, &event).expect("reference system leaf append");
-        root(&log)
+        // A system leaf is exactly a payload leaf with an EMPTY payload — the
+        // `EventPayload { data: Vec::new() }` an empty `&[]` produces is
+        // byte-identical, so forward to the payload reference to keep a single
+        // source of preimage truth.
+        native_reference_single_payload_leaf_root(context_id, event_type, actor_did, timestamp, &[])
     }
 
     /// Reconstructs the native-reference leaf bytes for a single

--- a/crates/scp-ffi/wasm/src/consequence.rs
+++ b/crates/scp-ffi/wasm/src/consequence.rs
@@ -1169,6 +1169,239 @@ mod cross_impl_leaf_parity {
         root(&log)
     }
 
+    /// Reconstructs the native-reference leaf bytes for a single
+    /// payload-bearing event (e.g. `GovernanceActionExecuted`) from the SHARED
+    /// `scp_event_log` primitives — the exact preimage native's real producer
+    /// (`finalize_governance_action`) feeds `tree::append_unsigned_event`. Same
+    /// shape as [`native_reference_single_system_leaf_root`] but with a non-empty
+    /// payload, so the full leaf bytes (`actor_did` + payload + timestamp) are
+    /// pinned, not just the `actor_did` field.
+    #[cfg(test)]
+    fn native_reference_single_payload_leaf_root(
+        context_id: &str,
+        event_type: scp_event_log::EventType,
+        actor_did: &str,
+        timestamp: u64,
+        payload: &[u8],
+    ) -> [u8; 32] {
+        use scp_event_log::tree::{append_unsigned_event, root};
+        use scp_event_log::{DID, Event, EventLog, EventPayload};
+
+        let mut log = EventLog::new(context_id.to_owned());
+        let event = Event {
+            event_type,
+            actor_did: DID::from(actor_did.to_owned()),
+            timestamp,
+            sequence: 0,
+            payload: EventPayload {
+                data: payload.to_vec(),
+            },
+            prev_hash: scp_event_log::tree::GENESIS_PREV_HASH,
+            signature: Vec::new(),
+        };
+        append_unsigned_event(&mut log, &event).expect("reference payload leaf append");
+        root(&log)
+    }
+
+    /// §9.9.3 native↔WASM DIRECT-EXECUTE `GovernanceActionExecuted` parity.
+    /// The direct-FFI execute entry (`context_execute_governance`) stamps the
+    /// proposal's PROPOSER as the leaf `actor_did` (the executor) — NOT the
+    /// caller (`initiator_did`) — matching the native direct-execute handler
+    /// (`handle_execute_governance_action_actor`), which sets
+    /// `executor_did = proposal.proposer_did`. This drives the exact manager
+    /// call the fixed direct entry performs (auth subject = caller, executor =
+    /// `proposal_proposer_did(...)`) and pins the FULL single-leaf root against
+    /// the native-reference leaf bytes, with a non-vacuity control proving the
+    /// PRE-FIX caller-stamp diverged.
+    #[test]
+    fn cross_impl_governance_action_executed_direct_stamps_proposer_wasm() {
+        use crate::manager::{WasmContextManager, make_bare_per_context_state};
+        use scp_event_log::{DID, EventType};
+        use scp_protocol::context::governance::{
+            GovernanceAction, GovernanceProposal, ProposalStatus, SignedVote, VoteType,
+        };
+
+        let context_id = "ctx-gov-direct-executor";
+        let proposer = "did:dht:z6MkDirectProposer";
+        let caller = "did:dht:z6MkDirectCaller"; // distinct from proposer
+        let proposal_id = "feedface";
+        let created_at = 1_700_500_500_u64;
+
+        // SingleAdmin context: the caller (an admin) executes directly. Both
+        // proposer and caller are admins so the caller's capability check
+        // passes while the executor (leaf actor_did) must still be the proposer.
+        let mut ctx = make_bare_per_context_state(context_id, proposer);
+        ctx.test_insert_member(caller, "admin");
+        ctx.test_insert_member("did:dht:z6MkDirectTarget", "member");
+        ctx.test_insert_ceiling("role:assign");
+
+        // A target distinct from both proposer and caller keeps the leaf actor
+        // unambiguously the proposer.
+        let action = GovernanceAction::ChangeRole {
+            did: DID::from("did:dht:z6MkDirectTarget".to_owned()),
+            new_role: "observer".to_owned(),
+        };
+
+        let proposal_id_bytes: [u8; 32] = {
+            let bytes = hex::decode(proposal_id).unwrap();
+            let mut arr = [0u8; 32];
+            let len = bytes.len().min(32);
+            arr[..len].copy_from_slice(&bytes[..len]);
+            arr
+        };
+        // Track the proposal as Approved (the direct-execute precondition).
+        let proposal = GovernanceProposal {
+            proposal_id: proposal_id_bytes,
+            context_id: context_id.to_owned(),
+            proposer_did: DID::from(proposer.to_owned()),
+            action: action.clone(),
+            status: ProposalStatus::Approved,
+            created_at,
+            voting_deadline: created_at + 3600,
+            approvals: vec![SignedVote {
+                voter_did: DID::from(proposer.to_owned()),
+                vote: VoteType::Approve,
+                timestamp: created_at,
+                signature: Vec::new(),
+            }],
+            rejections: Vec::new(),
+            created_at_epoch: None,
+        };
+        ctx.test_insert_resolved_proposal(proposal_id.to_owned(), proposal);
+
+        let mut mgr = WasmContextManager::new();
+        mgr.test_insert_context(context_id, ctx);
+
+        // EXACTLY what the fixed `context_execute_governance` direct entry does:
+        // resolve the proposer, then execute with auth-subject = caller,
+        // executor = proposer.
+        let resolved_proposer = mgr
+            .proposal_proposer_did(context_id, proposal_id)
+            .expect("proposer resolvable");
+        assert_eq!(resolved_proposer, proposer);
+        mgr.execute_governance_action(context_id, caller, &resolved_proposer, proposal_id, &action)
+            .expect("direct execute");
+
+        let logged = mgr.test_context_event_log_events(context_id);
+        let executed_leaf = logged
+            .iter()
+            .find(|e| e.event_type == EventType::GovernanceActionExecuted)
+            .expect("GovernanceActionExecuted leaf present after direct execute");
+        assert_eq!(
+            executed_leaf.actor_did.as_ref(),
+            proposer,
+            "direct-execute GovernanceActionExecuted leaf actor_did MUST be the proposal's \
+             proposer (the executor), NOT the caller (§9.9.3; native direct handler stamps \
+             proposal.proposer_did)"
+        );
+        assert_eq!(executed_leaf.timestamp, created_at);
+
+        // Full-leaf-bytes parity: the WASM real-producer root equals the
+        // native-reference leaf reconstructed from the shared primitives with
+        // the proposer actor, the convergent created_at, and the shared
+        // GovernanceActionExecutedPayload bytes.
+        let payload = WasmContextManager::encode_governance_action_executed_payload(
+            &action,
+            action.target_did(),
+        )
+        .expect("payload encodes");
+        assert_eq!(
+            mgr.test_context_event_log_root(context_id),
+            native_reference_single_payload_leaf_root(
+                context_id,
+                EventType::GovernanceActionExecuted,
+                proposer,
+                created_at,
+                &payload,
+            ),
+            "WASM direct-execute leaf MUST be byte-identical to native's proposer-stamped \
+             reference leaf (§9.9.3 cross-bridge convergence)"
+        );
+        // Non-vacuity: the PRE-FIX caller (initiator) stamp would diverge.
+        assert_ne!(
+            mgr.test_context_event_log_root(context_id),
+            native_reference_single_payload_leaf_root(
+                context_id,
+                EventType::GovernanceActionExecuted,
+                caller,
+                created_at,
+                &payload,
+            ),
+            "the pre-fix caller-stamped actor_did MUST diverge from the aligned proposer-stamped \
+             leaf"
+        );
+    }
+
+    /// §9.9.3 native↔WASM `ContextClosed` TTL-DEADLINE parity. A TTL-driven
+    /// close MUST stamp the CONVERGENT TTL deadline (`creation + ttl`) on the
+    /// `ContextClosed` leaf — NOT each member's local `now()` — matching native
+    /// `finalize_close`, which stamps `deadline_unix_secs` (= `creation + ttl`)
+    /// for a timer-armed context. Pins the full single-leaf root against the
+    /// native-reference leaf, with a non-vacuity control proving the PRE-FIX
+    /// `now_secs()` behavior diverged.
+    #[test]
+    fn cross_impl_context_closed_stamps_convergent_ttl_deadline_wasm() {
+        use crate::manager::{WasmContextManager, make_bare_per_context_state};
+        use scp_event_log::EventType;
+
+        let context_id = "ctx-close-ttl-deadline";
+        let creation = 1_700_000_000_u64;
+        let ttl = 86_400_u64;
+        let convergent_deadline = creation + ttl;
+
+        let mut state = make_bare_per_context_state(context_id, "did:dht:zcreator");
+        state.test_set_creation_timestamp_secs(creation);
+        state.test_set_ttl_seconds(Some(ttl));
+        // `finalize_close` requires the `closing` state.
+        state.test_set_state("closing");
+
+        let mut mgr = WasmContextManager::new();
+        mgr.test_insert_context(context_id, state);
+        mgr.finalize_close(context_id)
+            .expect("real WASM finalize_close producer");
+
+        let leaves = mgr.test_context_event_log_events(context_id);
+        let close_leaf = leaves
+            .iter()
+            .find(|e| e.event_type == EventType::ContextClosed)
+            .expect("ContextClosed leaf present after finalize_close");
+        assert_eq!(
+            close_leaf.timestamp, convergent_deadline,
+            "TTL-driven ContextClosed leaf MUST stamp the convergent creation+ttl deadline, \
+             NOT local now() (§9.9.3)"
+        );
+
+        // Full-leaf-bytes parity at the convergent deadline.
+        assert_eq!(
+            mgr.test_context_event_log_root(context_id),
+            native_reference_single_system_leaf_root(
+                context_id,
+                EventType::ContextClosed,
+                "system:close",
+                convergent_deadline,
+            ),
+            "WASM ContextClosed real-producer leaf MUST be byte-identical to native's reference \
+             leaf at the convergent TTL deadline (§9.9.3 cross-bridge convergence)"
+        );
+        // Non-vacuity: the PRE-FIX `now_secs()` timestamp would diverge from the
+        // convergent deadline (the test clock's `now` is not `creation + ttl`).
+        let local_now = crate::time::now_secs();
+        assert_ne!(
+            local_now, convergent_deadline,
+            "test precondition: local now must differ from the convergent deadline"
+        );
+        assert_ne!(
+            mgr.test_context_event_log_root(context_id),
+            native_reference_single_system_leaf_root(
+                context_id,
+                EventType::ContextClosed,
+                "system:close",
+                local_now,
+            ),
+            "the pre-fix now()-stamped close leaf MUST diverge from the convergent-deadline leaf"
+        );
+    }
+
     /// §9.9.3 native↔WASM SYSTEM-LEAF parity. The WASM bridge's REAL producers
     /// (`handle_ttl_expiry` → `ContextExpired`, `finalize_close` →
     /// `ContextClosed`) MUST stamp the SAME descriptive `actor_did` sentinels

--- a/crates/scp-ffi/wasm/src/context.rs
+++ b/crates/scp-ffi/wasm/src/context.rs
@@ -699,10 +699,15 @@ pub fn context_drain_events(handle: &WasmContextHandle) -> String {
 /// Delegates to `WasmContextManager::execute_governance_action`.
 /// All 24 `GovernanceAction` variants are dispatchable.
 ///
-/// Authorization is enforced: the `initiator_did` must be a member with
-/// the capability required for the specific governance action. For example,
-/// `RemoveMember` requires `member:remove` (admin-only by default),
-/// `ChangeRole` requires `role_assign:*`, etc.
+/// Authorization is NOT a per-member execute-time capability check. The
+/// proposal must already be `Approved` (enforced by `require_proposal_approved`)
+/// — authorization was established at propose/vote time (the proposer needs
+/// `governance:propose` and the action must be within the context ceiling).
+/// At dispatch, the per-action context-ceiling gate (`dispatch_ceiling_capability`)
+/// gates the ban/tool-register/child-context/tool-interface class on the
+/// context ceiling — NOT on the caller's role. `initiator_did` is the
+/// consequence subject, NOT capability-checked here. This mirrors the native
+/// runtime exactly (§9.9.3 native↔WASM convergence).
 ///
 /// # Arguments
 ///
@@ -765,10 +770,13 @@ pub fn context_execute_governance(
             // PROPOSER, NOT the caller `initiator_did` — matching the native
             // direct-execute handler, which stamps `proposal.proposer_did`
             // (§9.9.3 native↔WASM convergence; ADR-031 §8 "executor DID").
-            // `initiator_did` remains the AUTH SUBJECT (capability checked
-            // inside `execute_governance_action`); only the leaf actor_did
-            // converges to the proposer. Resolve the proposer from the tracked
-            // proposal the executed leaf is derived from.
+            // `initiator_did` is the CONSEQUENCE SUBJECT only — nothing inside
+            // `execute_governance_action` checks its capability. Safety derives
+            // from `require_proposal_approved` (status==Approved), the replay
+            // guard (`executed_proposals`), propose-time authorization, and the
+            // per-action context-ceiling gate (`dispatch_ceiling_capability`).
+            // Only the leaf actor_did converges to the proposer. Resolve the
+            // proposer from the tracked proposal the executed leaf is derived from.
             let executor_did = mgr.proposal_proposer_did(&context_id, &proposal_id)?;
             mgr.execute_governance_action(
                 &context_id,

--- a/crates/scp-ffi/wasm/src/context.rs
+++ b/crates/scp-ffi/wasm/src/context.rs
@@ -761,7 +761,22 @@ pub fn context_execute_governance(
         })?;
 
         let result = with_manager(|mgr| {
-            mgr.execute_governance_action(&context_id, &initiator_did, &proposal_id, &action)
+            // Direct-execute: the leaf actor_did (executor) is the proposal's
+            // PROPOSER, NOT the caller `initiator_did` — matching the native
+            // direct-execute handler, which stamps `proposal.proposer_did`
+            // (§9.9.3 native↔WASM convergence; ADR-031 §8 "executor DID").
+            // `initiator_did` remains the AUTH SUBJECT (capability checked
+            // inside `execute_governance_action`); only the leaf actor_did
+            // converges to the proposer. Resolve the proposer from the tracked
+            // proposal the executed leaf is derived from.
+            let executor_did = mgr.proposal_proposer_did(&context_id, &proposal_id)?;
+            mgr.execute_governance_action(
+                &context_id,
+                &initiator_did,
+                &executor_did,
+                &proposal_id,
+                &action,
+            )
         })
         .map_err(ScpWasmError::into_js)?;
 

--- a/crates/scp-ffi/wasm/src/manager.rs
+++ b/crates/scp-ffi/wasm/src/manager.rs
@@ -3091,34 +3091,28 @@ impl WasmContextManager {
                 arr
             };
             let target_did: Option<DID> = action.target_did().cloned();
-            ctx.push_event(ContextEvent::GovernanceActionExecuted {
-                proposal_id: proposal_id_bytes,
-                action_summary,
-                // The buffer event's `executor_did` is the COMMITTING member
-                // (the executor), NOT the auth-subject `initiator_did` —
-                // matching native `finalize_governance_action` (§9.9.3; ADR-031
-                // §8 / §7.3.1 / ADR-051 §6).
-                executor_did: DID(executor_did.to_owned()),
-                resulting_epoch: None,
-                target_did: target_did.clone(),
-            });
-            // Durable GovernanceActionExecuted leaf. The payload MUST be the
-            // shared `GovernanceActionExecutedPayload` (positional MessagePack
-            // via `encode_payload`) — byte-identical to the native runtime's
-            // `finalize_governance_action` construction — so cross-platform
-            // members derive equal Merkle roots (§9.9.3). `target_did` is the
-            // action's target (empty when untargeted); `action_type` is the
-            // `GovernanceAction` variant name.
+
+            // Encode the durable leaf payload FIRST, before any buffer event is
+            // pushed — matching native `finalize_governance_action`, which
+            // encodes the payload (`encode_payload(...)?`) BEFORE appending the
+            // leaf and BEFORE emitting the buffer `ContextEvent`. The payload
+            // MUST be the shared `GovernanceActionExecutedPayload` (positional
+            // MessagePack via `encode_payload`) — byte-identical to native — so
+            // cross-platform members derive equal Merkle roots (§9.9.3).
+            // `target_did` is the action's target (empty when untargeted);
+            // `action_type` is the `GovernanceAction` variant name.
             //
             // FAIL CLOSED on encode error (mirrors native's `map_err(...)?`):
-            // never write an EMPTY-payload leaf, which would diverge from the
-            // native leaf bytes and corrupt the convergent log. The dispatch has
-            // already mutated state and the proposal is recorded executed — the
-            // same position native is in when its `finalize_governance_action`
-            // encode fails (it returns Err and writes no leaf, leaving the
-            // executed marker set). Propagate the error identically.
+            // on failure return `Err` with NO buffer event and NO leaf — exactly
+            // native's position (it returns Err before `emit`, leaving the
+            // executed marker set). Doing the encode BEFORE `push_event` is what
+            // keeps the buffer-event side effect symmetric: a previous ordering
+            // pushed the buffer event first, so an encode failure left WASM with
+            // a buffer event native never emits.
             let executed_payload =
                 Self::encode_governance_action_executed_payload(action, target_did.as_ref())?;
+
+            // Durable GovernanceActionExecuted leaf.
             ctx.append_log_event(
                 EventType::GovernanceActionExecuted,
                 // Convergence-critical leaf `actor_did`: the COMMITTING member
@@ -3131,6 +3125,20 @@ impl WasmContextManager {
                 &executed_payload,
                 proposal_created_at,
             );
+
+            // Buffer event LAST, mirroring native's post-leaf `emit(...)`.
+            ctx.push_event(ContextEvent::GovernanceActionExecuted {
+                proposal_id: proposal_id_bytes,
+                action_summary,
+                // The buffer event's `executor_did` is the COMMITTING member
+                // (the executor), NOT the auth-subject `initiator_did` —
+                // matching native `finalize_governance_action` (§9.9.3; ADR-031
+                // §8 "executor DID" / spec §7.3.1 "committing member" /
+                // ADR-051 §6).
+                executor_did: DID(executor_did.to_owned()),
+                resulting_epoch: None,
+                target_did: target_did.clone(),
+            });
 
             // Evaluate and enforce consequence rules. Mirrors
             // `scp_runtime::context::manager::governance::

--- a/crates/scp-ffi/wasm/src/manager.rs
+++ b/crates/scp-ffi/wasm/src/manager.rs
@@ -6364,13 +6364,17 @@ impl WasmContextManager {
         // regardless of which member's timer fired or what its local clock read
         // — NOT each member's local `crate::time::now_secs()`, which would
         // diverge the leaf at equal event count and trip §9.9.3 equivocation
-        // detection across native/WASM. This mirrors native `finalize_close`
-        // (`ttl_close_helpers.rs`), which stamps
-        // `state.ttl.timer.deadline_unix_secs.unwrap_or_else(|| now_secs())`:
-        // `deadline_unix_secs` holds `creation + ttl` (auto-reflecting any
-        // TTL extension, which mutates `ttl_seconds` here / `deadline_unix_secs`
-        // there by the same delta), and falls back to the closer's clock only
-        // for a governance/explicit close of a no-TTL context. WASM mirrors that
+        // detection across native/WASM. This mirrors native: the convergent
+        // close timestamp is computed in the CALLER `ttl_close_helpers.rs`'s
+        // `finalize_close` as
+        // `state.ttl.timer.deadline_unix_secs.unwrap_or_else(|| now_secs())`
+        // and passed as the pre-computed `timestamp_secs` argument into
+        // `ttl::finalize_close` (`crates/scp-runtime/src/context/ttl.rs`), which
+        // stamps it onto the `ContextClosed` leaf. `deadline_unix_secs` holds
+        // `creation + ttl` (auto-reflecting any TTL extension, which mutates
+        // `ttl_seconds` here / `deadline_unix_secs` there by the same delta), and
+        // falls back to the closer's clock only for a governance/explicit close
+        // of a no-TTL context. WASM mirrors that
         // exactly via `convergent_ttl_deadline_secs(creation, ttl_seconds)`:
         // `Some(ttl) => creation + ttl`, else local `now_secs()`. Identical to
         // `handle_ttl_expiry`'s `expiry_leaf_secs` so a close and an expiry of

--- a/crates/scp-ffi/wasm/src/manager.rs
+++ b/crates/scp-ffi/wasm/src/manager.rs
@@ -4051,20 +4051,24 @@ impl WasmContextManager {
         );
 
         if meets_quorum {
-            // Remove from pending and execute.
+            // Move pending → resolved (marking Approved) BEFORE executing, so
+            // the proposal is still tracked when `execute_governance_action`
+            // resolves the convergent `GovernanceActionExecuted` leaf timestamp
+            // from `proposal.created_at` (it looks up pending-or-resolved). On
+            // auto-execute the proposer IS the committing member, so the
+            // executor is the proposer (matches native's propose auto-execute).
             let proposal = self
                 .contexts
                 .get_mut(context_id)
                 .and_then(|ctx| ctx.pending_proposals.remove(&pid));
             if let Some(mut p) = proposal {
                 let action_ref = p.action.clone();
-                let result =
-                    self.execute_governance_action(context_id, proposer_did, &pid, &action_ref)?;
-                // Move to resolved_proposals for later retrieval.
                 p.status = ProposalStatus::Approved;
                 if let Some(ctx) = self.contexts.get_mut(context_id) {
                     ctx.insert_resolved_proposal(pid.clone(), p);
                 }
+                let result =
+                    self.execute_governance_action(context_id, proposer_did, &pid, &action_ref)?;
                 return Ok(serde_json::json!({
                     "proposal_id": pid,
                     "status": "Approved",
@@ -4177,21 +4181,31 @@ impl WasmContextManager {
         let pid = proposal_id.to_owned();
 
         if meets_quorum {
-            // Remove from pending and execute.
+            // Move pending → resolved (marking Approved) BEFORE executing, so
+            // the proposal is still tracked when `execute_governance_action`
+            // resolves the convergent `GovernanceActionExecuted` leaf timestamp
+            // from `proposal.created_at` (it looks up pending-or-resolved). If
+            // it were removed first, execute would fail its
+            // proposal-is-tracked guard and could never mint the executed leaf.
             let proposal = self
                 .contexts
                 .get_mut(context_id)
                 .and_then(|ctx| ctx.pending_proposals.remove(&pid));
             if let Some(mut p) = proposal {
                 let action_ref = p.action.clone();
-                let proposer = p.proposer_did.0.clone();
-                let result =
-                    self.execute_governance_action(context_id, &proposer, &pid, &action_ref)?;
-                // Move to resolved_proposals for later retrieval.
                 p.status = ProposalStatus::Approved;
                 if let Some(ctx) = self.contexts.get_mut(context_id) {
                     ctx.insert_resolved_proposal(pid.clone(), p);
                 }
+                // The executor is the quorum-crossing VOTER (the committing
+                // member), NOT the proposer — `execute_governance_action`
+                // stamps `initiator_did` as the `GovernanceActionExecuted` leaf
+                // `actor_did` (ADR-031 §8 "executor DID" / §7.3.1 "committing
+                // member" / ADR-051 §6). Passing the proposer here would diverge
+                // the leaf from native's quorum path, which stamps the voter
+                // (§9.9.3 native↔WASM convergence).
+                let result =
+                    self.execute_governance_action(context_id, voter_did, &pid, &action_ref)?;
                 return Ok(serde_json::json!({
                     "status": "Approved",
                     "execution_result": result,

--- a/crates/scp-ffi/wasm/src/manager.rs
+++ b/crates/scp-ffi/wasm/src/manager.rs
@@ -2879,13 +2879,64 @@ impl WasmContextManager {
     /// `CapabilityCeiling::contains` uses exact set membership for these
     /// capabilities (only `ToolInvoke` has wildcard special-casing).
     fn dispatch_ceiling_capability(action: &GovernanceAction) -> Option<&'static str> {
+        // EXHAUSTIVE match over every `GovernanceAction` variant — NO wildcard.
+        // This MUST mirror, one-for-one, native's per-action ceiling gates
+        // (`state.role_state.ceiling.contains(&Capability::X)`) in
+        // `governance_helpers.rs`. The exhaustive match is closed-by-construction:
+        // a newly-added `GovernanceAction` variant becomes a COMPILE ERROR here,
+        // forcing the author to decide its ceiling gate explicitly rather than
+        // silently inheriting `None` (a `_ => None` wildcard is exactly why
+        // `CreateChildContext` and `EstablishToolInterface` were previously
+        // ungated in WASM while native rejected them — a §9.9.3 divergence and a
+        // security gap). Strings are exact `Capability::ucan_capability_name()`
+        // outputs (the form `ceiling_strings` stores) and are matched with EXACT
+        // membership against `ceiling_strings`, because native's
+        // `CapabilityCeiling::contains` uses exact set membership for all these
+        // capabilities (only `ToolInvoke` has wildcard special-casing).
         match action {
+            // member:ban — native: execute_suspend_member, execute_revoke,
+            // execute_restore_access, and the inline SuspendAccess arm in
+            // dispatch_governance_action (governance_helpers.rs).
             GovernanceAction::SuspendCapability { .. }
             | GovernanceAction::SuspendAccess { .. }
             | GovernanceAction::RevokeAccess { .. }
             | GovernanceAction::RestoreAccess { .. } => Some("member:ban"),
+            // tool:register — native: execute_register_tool.
             GovernanceAction::RegisterTool { .. } => Some("tool:register"),
-            _ => None,
+            // context_child:create — native: execute_create_child_context.
+            // `ChildContextCreate.name()` is the 3-segment "context:child:create",
+            // but `ceiling_strings` stores the UCAN form "context_child:create"
+            // (`Capability::ucan_capability_name()`), so we match on that.
+            GovernanceAction::CreateChildContext { .. } => Some("context_child:create"),
+            // tool:interface — native: execute_establish_tool_interface.
+            GovernanceAction::EstablishToolInterface { .. } => Some("tool:interface"),
+            // NOT ceiling-gated at dispatch in native — authorization is entirely
+            // at propose time. Returning `None` keeps WASM's accept/reject byte-
+            // identical to native (§9.9.3). Listed explicitly (no wildcard) so a
+            // future variant cannot silently default to ungated.
+            GovernanceAction::AddMember { .. }
+            | GovernanceAction::RemoveMember { .. }
+            | GovernanceAction::ChangeRole { .. }
+            | GovernanceAction::RemoveTool { .. }
+            | GovernanceAction::ModifyCeiling { .. }
+            | GovernanceAction::CloseContext { .. }
+            | GovernanceAction::ExtendTtl { .. }
+            | GovernanceAction::TransferAdmin { .. }
+            | GovernanceAction::ModifyPruningPolicy { .. }
+            | GovernanceAction::AddSigner { .. }
+            | GovernanceAction::RemoveSigner { .. }
+            | GovernanceAction::ModifyThreshold { .. }
+            | GovernanceAction::ResetMember { .. }
+            | GovernanceAction::ResolveConflict { .. }
+            | GovernanceAction::PromoteContext
+            | GovernanceAction::RotateContentKeys { .. }
+            | GovernanceAction::ReconfigureGovernance { .. }
+            | GovernanceAction::SetEconomicPolicy { .. }
+            | GovernanceAction::ApproveSpend { .. }
+            | GovernanceAction::LockEconomicPolicy
+            | GovernanceAction::ProposeContextMigration { .. }
+            | GovernanceAction::CancelContextMigration
+            | GovernanceAction::ModifyHardRateLimit { .. } => None,
         }
     }
 

--- a/crates/scp-ffi/wasm/src/manager.rs
+++ b/crates/scp-ffi/wasm/src/manager.rs
@@ -793,6 +793,27 @@ impl PerContextState {
         self.governance = model.to_owned();
     }
 
+    /// Test-only: set the lifecycle state string (e.g. `"closing"`), so
+    /// sibling-module cross-impl tests can drive `finalize_close`.
+    #[cfg(test)]
+    pub(crate) fn test_set_state(&mut self, state: &str) {
+        self.state = state.to_owned();
+    }
+
+    /// Test-only: set the convergent creation timestamp (seconds), the TTL
+    /// deadline base for `handle_ttl_expiry`.
+    #[cfg(test)]
+    pub(crate) fn test_set_creation_timestamp_secs(&mut self, secs: u64) {
+        self.creation_timestamp_secs = secs;
+    }
+
+    /// Test-only: set the TTL window (seconds). With a creation timestamp this
+    /// fixes the convergent `ContextExpired` leaf timestamp.
+    #[cfg(test)]
+    pub(crate) fn test_set_ttl_seconds(&mut self, ttl: Option<u64>) {
+        self.ttl_seconds = ttl;
+    }
+
     /// Inserts a resolved proposal, evicting the oldest (by `created_at`) if
     /// at [`WASM_RESOLVED_PROPOSAL_CAP`].
     fn insert_resolved_proposal(&mut self, id: String, proposal: GovernanceProposal) {
@@ -1247,6 +1268,17 @@ impl WasmContextManager {
         self.contexts
             .get(context_id)
             .map(|ctx| ctx.event_log_events().to_vec())
+            .unwrap_or_default()
+    }
+
+    /// Test-only: the current Merkle root of a registered context's event log.
+    /// Used by cross-impl system-leaf parity tests to compare the WASM
+    /// real-producer root against the native-reference single-leaf root.
+    #[cfg(test)]
+    pub(crate) fn test_context_event_log_root(&self, context_id: &str) -> [u8; 32] {
+        self.contexts
+            .get(context_id)
+            .map(PerContextState::test_event_log_root)
             .unwrap_or_default()
     }
 
@@ -5102,7 +5134,12 @@ impl WasmContextManager {
             None => crate::time::now_secs(),
         };
 
-        ctx.append_log_event(EventType::ContextExpired, "", b"", expiry_leaf_secs);
+        ctx.append_log_event(
+            EventType::ContextExpired,
+            "system:timer",
+            b"",
+            expiry_leaf_secs,
+        );
 
         Ok(())
     }
@@ -5848,8 +5885,16 @@ impl WasmContextManager {
             })
         });
 
-        // Clamp timestamps to `now` so snapshot forgery cannot push them
-        // into the future and evade TTL eviction.
+        // Clamp ONLY the anti-replay timestamps to `now` so snapshot forgery
+        // cannot push them into the future: the per-nonce `seen_nonces_v3`
+        // `inserted_at_ms` and the per-proposal `executed_at_ms` (both `.min(now)`
+        // below). `ttl_seconds` and `creation_timestamp_secs` are NOT clamped —
+        // `creation_timestamp_secs` is consumed VERBATIM (see the assignment
+        // further down) because the convergent TTL deadline base
+        // (`creation_timestamp_secs + ttl_seconds`) must be byte-identical across
+        // members and bridges (§9.9.3); clamping it would diverge the
+        // `ContextExpired` leaf. A forged future creation time only shortens the
+        // effective deadline (fail-safe), so it needs no clamp here.
         let now_ms_for_clamp = crate::time::now_ms();
         let ctx = PerContextState {
             state: snap.state.clone(),
@@ -6007,7 +6052,7 @@ impl WasmContextManager {
 
         ctx.append_log_event(
             EventType::ContextClosed,
-            "system",
+            "system:close",
             b"",
             // Convergent close instant (§7.3.1, §9.9.3).
             crate::time::now_secs(),

--- a/crates/scp-ffi/wasm/src/manager.rs
+++ b/crates/scp-ffi/wasm/src/manager.rs
@@ -2861,13 +2861,16 @@ impl WasmContextManager {
     /// This mirrors EXACTLY the native runtime's per-action ceiling gates in
     /// `dispatch_governance_action` / its per-action `execute_*` helpers
     /// (`governance_helpers.rs`), which gate on `ceiling.contains(&Capability::X)`
-    /// — NOT on the committing member's role. Native gates precisely these five:
+    /// — NOT on the committing member's role. Native gates precisely these seven
+    /// actions across four capabilities:
     ///
-    /// - `SuspendCapability` (`execute_suspend_member`)  → `member:ban`
-    /// - `SuspendAccess`     (inline `dispatch_governance_action`) → `member:ban`
-    /// - `RevokeAccess`      (`execute_revoke`)          → `member:ban`
-    /// - `RestoreAccess`     (`execute_restore_access`)  → `member:ban`
-    /// - `RegisterTool`      (`execute_register_tool`)   → `tool:register`
+    /// - `SuspendCapability`  (`execute_suspend_member`)        → `member:ban`
+    /// - `SuspendAccess`      (inline `dispatch_governance_action`) → `member:ban`
+    /// - `RevokeAccess`       (`execute_revoke`)                 → `member:ban`
+    /// - `RestoreAccess`      (`execute_restore_access`)         → `member:ban`
+    /// - `RegisterTool`       (`execute_register_tool`)          → `tool:register`
+    /// - `CreateChildContext` (`execute_create_child_context`)  → `context_child:create`
+    /// - `EstablishToolInterface` (`execute_establish_tool_interface`) → `tool:interface`
     ///
     /// All OTHER actions have NO per-action ceiling gate in native — their
     /// authorization is entirely at propose time. Returning `None` for them
@@ -3011,15 +3014,17 @@ impl WasmContextManager {
     /// Executes a governance action. Mirrors the native runtime's
     /// `execute_governance_action` (`governance_helpers.rs`).
     ///
-    /// Validates that the proposal is `Approved`, that the initiator has the
-    /// required capability for the action, that the proposal is not a replay,
-    /// dispatches to the appropriate action handler, and records the proposal
-    /// as executed.
+    /// Validates that the proposal is `Approved`, that the proposal is not a
+    /// replay, dispatches to the appropriate action handler (which applies the
+    /// per-action context-ceiling gate), and records the proposal as executed.
+    /// There is NO per-member capability check at execute time (matches native).
     ///
-    /// `initiator_did` is the AUTH SUBJECT — the member whose capability is
-    /// checked (and the consequence subject). `executor_did` is the COMMITTING
-    /// member — the DID stamped as the `GovernanceActionExecuted` leaf
-    /// `actor_did` and the buffer event `executor_did`. These are deliberately
+    /// `initiator_did` is the CONSEQUENCE SUBJECT — the member the action's
+    /// effect is attributed to. It is NOT capability-checked here; authorization
+    /// is enforced at propose/vote time and by the per-action ceiling gate at
+    /// dispatch. `executor_did` is the COMMITTING member — the DID stamped as
+    /// the `GovernanceActionExecuted` leaf `actor_did` and the buffer event
+    /// `executor_did`. These are deliberately
     /// SEPARATE (ADR-031 §8 "executor DID" / §7.3.1 "committing member" /
     /// ADR-051 §6): the native runtime takes the executor explicitly, and the
     /// leaf `actor_did` is convergence-critical (§9.9.3 native↔WASM byte parity).
@@ -6252,8 +6257,17 @@ impl WasmContextManager {
         // further down) because the convergent TTL deadline base
         // (`creation_timestamp_secs + ttl_seconds`) must be byte-identical across
         // members and bridges (§9.9.3); clamping it would diverge the
-        // `ContextExpired` leaf. A forged future creation time only shortens the
-        // effective deadline (fail-safe), so it needs no clamp here.
+        // `ContextExpired` leaf. Consuming it verbatim is safe NOT because of any
+        // fail-safe direction (a forged FUTURE creation time would in fact LENGTHEN
+        // `creation + ttl`, pushing the deadline later — the opposite of fail-safe).
+        // It is safe because by the time we reach this code the whole snapshot —
+        // `creation_timestamp_secs` included — has already been bound to the creator:
+        // `deserialize_and_verify_envelope` enforces `exporter_did == creator_did`,
+        // verifies the Ed25519 snapshot signature over the JCS-canonical snapshot
+        // against the creator DID's resolved key, and (for self-imports) the
+        // defense-in-depth HMAC. Forging `creation_timestamp_secs` therefore requires
+        // the creator's signing key. §9.9.3 additionally requires the value verbatim
+        // for cross-member/bridge convergence, so clamping is forbidden regardless.
         let now_ms_for_clamp = crate::time::now_ms();
         let ctx = PerContextState {
             state: snap.state.clone(),

--- a/crates/scp-ffi/wasm/src/manager.rs
+++ b/crates/scp-ffi/wasm/src/manager.rs
@@ -405,8 +405,17 @@ const WASM_REVOKED_TOKENS_CAP: usize = 100_000;
 /// Maximum number of executed proposals tracked per context before triggering eviction.
 const WASM_PROPOSAL_CAP: usize = 10_000;
 
-/// Executed proposal TTL in milliseconds (24 hours).
-const WASM_PROPOSAL_TTL_MS: f64 = 24.0 * 60.0 * 60.0 * 1000.0;
+/// Executed-proposal replay-protection TTL in milliseconds (14 days).
+///
+/// SECURITY-CRITICAL replay window. MUST mirror the native runtime's
+/// `EXECUTED_PROPOSALS_TTL_SECS` (`crates/scp-runtime/src/context/state.rs` =
+/// `14 * 24 * 60 * 60` seconds). A shorter WASM window would let a direct
+/// re-execute of a durably-resolved (`Approved`) proposal slip past the
+/// emptied replay guard after the window and mint a SECOND
+/// `GovernanceActionExecuted` leaf that native — guarding for the full 14 days
+/// (and by the `status == Approved` precondition) — would reject, diverging the
+/// log across bridges (§9.9.3). Keep this in lock-step with the native const.
+const WASM_PROPOSAL_TTL_MS: f64 = 14.0 * 24.0 * 60.0 * 60.0 * 1000.0;
 
 /// Maximum number of resolved (approved/rejected) proposals per context.
 /// When at capacity, the oldest entry (by `created_at`) is evicted.
@@ -684,16 +693,23 @@ impl PerContextState {
         action_type: &str,
         trigger_timestamp_secs: u64,
     ) {
-        // Native uses CONSEQUENCE_ACTOR_DID = "system" as the actor for these
-        // leaves so the `WarningCount` trigger's `actor_did != subject_did`
-        // requirement holds for recursive rule evaluation.
+        // Native uses CONSEQUENCE_ACTOR_DID = SYSTEM_CONSEQUENCE_ACTOR ("system")
+        // as the actor for these leaves so the `WarningCount` trigger's
+        // `actor_did != subject_did` requirement holds for recursive rule
+        // evaluation. The shared const guarantees byte-identical sentinels
+        // across native and WASM (§9.9.3 cross-bridge convergence).
         let payload = scp_event_log::payload::consequence_event_payload(
             subject_did,
             rule_index,
             trigger_kind,
             action_type,
         );
-        self.append_log_event(event_type, "system", &payload.data, trigger_timestamp_secs);
+        self.append_log_event(
+            event_type,
+            scp_event_log::system_actors::SYSTEM_CONSEQUENCE_ACTOR,
+            &payload.data,
+            trigger_timestamp_secs,
+        );
     }
 
     // ---- Test-only helpers (compiled away in release builds) -------------
@@ -793,6 +809,18 @@ impl PerContextState {
         self.governance = model.to_owned();
     }
 
+    /// Test-only: insert a resolved (e.g. `Approved`) proposal directly, so
+    /// sibling-module cross-impl tests can drive the direct-execute path
+    /// (which requires the proposal tracked-and-`Approved`).
+    #[cfg(test)]
+    pub(crate) fn test_insert_resolved_proposal(
+        &mut self,
+        id: String,
+        proposal: GovernanceProposal,
+    ) {
+        self.insert_resolved_proposal(id, proposal);
+    }
+
     /// Test-only: set the lifecycle state string (e.g. `"closing"`), so
     /// sibling-module cross-impl tests can drive `finalize_close`.
     #[cfg(test)]
@@ -829,6 +857,13 @@ impl PerContextState {
             }
         }
         self.resolved_proposals.insert(id, proposal);
+    }
+
+    /// Removes a resolved proposal by id. Used to roll back a pending →
+    /// resolved move when the subsequent governance dispatch fails, so the
+    /// proposal remains retriable (parity with native retry semantics).
+    fn remove_resolved_proposal(&mut self, id: &str) -> Option<GovernanceProposal> {
+        self.resolved_proposals.remove(id)
     }
 }
 
@@ -2847,24 +2882,116 @@ impl WasmContextManager {
         }
     }
 
-    /// Executes a governance action. Mirrors `ContextManager::execute_governance_action`.
+    /// Asserts that the proposal `proposal_id` is tracked and `Approved`.
     ///
-    /// Validates that the initiator has the required capability for the
-    /// action, that the proposal is not a replay, dispatches to the
-    /// appropriate action handler, and records the proposal as executed.
+    /// Mirrors the native runtime's `execute_governance_action` precondition,
+    /// which rejects any non-`Approved` proposal before dispatch. WASM enforces
+    /// the same so a (re-)execute of a pending / rejected / unknown proposal can
+    /// never mint a `GovernanceActionExecuted` leaf that native would not
+    /// (§9.9.3). The committed proposal lives in `resolved_proposals` with
+    /// status `Approved`; a still-`Pending` proposal in `pending_proposals` is
+    /// NOT executable via the execute path.
     ///
     /// # Errors
     ///
-    /// Returns an error if the context is not active, the initiator lacks
-    /// the required capability, the proposal was already executed, or the
-    /// action fails.
+    /// Returns an error if the context is not active or the proposal is not
+    /// `Approved`.
+    fn require_proposal_approved(
+        &mut self,
+        context_id: &str,
+        proposal_id: &str,
+    ) -> Result<(), ScpWasmError> {
+        let ctx = self.require_active_context_mut(context_id)?;
+        let status = ctx
+            .resolved_proposals
+            .get(proposal_id)
+            .or_else(|| ctx.pending_proposals.get(proposal_id))
+            .map(|p| p.status.clone());
+        if matches!(status, Some(ProposalStatus::Approved)) {
+            Ok(())
+        } else {
+            Err(ScpWasmError::Permission {
+                message: format!(
+                    "governance proposal '{proposal_id}' is not approved (status: {status:?}); \
+                     cannot execute"
+                ),
+                code: codes::PERM_3000.to_owned(),
+            })
+        }
+    }
+
+    /// Encodes the shared `GovernanceActionExecutedPayload` (positional
+    /// `MessagePack` via `encode_payload`) for the `GovernanceActionExecuted`
+    /// leaf — byte-identical to the native runtime's `finalize_governance_action`
+    /// construction so cross-platform members derive equal Merkle roots
+    /// (§9.9.3). `target_did` is the action's target (empty when untargeted);
+    /// `action_type` is the `GovernanceAction` variant name.
+    ///
+    /// # Errors
+    ///
+    /// FAILS CLOSED on encode error (mirrors native's `map_err(...)?`) so a
+    /// payload-encode failure never mints a divergent empty-payload leaf.
+    pub(crate) fn encode_governance_action_executed_payload(
+        action: &GovernanceAction,
+        target_did: Option<&DID>,
+    ) -> Result<Vec<u8>, ScpWasmError> {
+        scp_event_log::payload::encode_payload(
+            &scp_event_log::payload::GovernanceActionExecutedPayload {
+                target_did: target_did
+                    .map(|d| d.as_ref().to_owned())
+                    .unwrap_or_default(),
+                action_type: action.variant_name().to_owned(),
+            },
+        )
+        .map(|p| p.data)
+        .map_err(|e| ScpWasmError::Context {
+            message: format!("failed to encode GovernanceActionExecuted payload: {e}"),
+            code: codes::CTX_2001.to_owned(),
+        })
+    }
+
+    /// Executes a governance action. Mirrors the native runtime's
+    /// `execute_governance_action` (`governance_helpers.rs`).
+    ///
+    /// Validates that the proposal is `Approved`, that the initiator has the
+    /// required capability for the action, that the proposal is not a replay,
+    /// dispatches to the appropriate action handler, and records the proposal
+    /// as executed.
+    ///
+    /// `initiator_did` is the AUTH SUBJECT — the member whose capability is
+    /// checked (and the consequence subject). `executor_did` is the COMMITTING
+    /// member — the DID stamped as the `GovernanceActionExecuted` leaf
+    /// `actor_did` and the buffer event `executor_did`. These are deliberately
+    /// SEPARATE (ADR-031 §8 "executor DID" / §7.3.1 "committing member" /
+    /// ADR-051 §6): the native runtime takes the executor explicitly, and the
+    /// leaf `actor_did` is convergence-critical (§9.9.3 native↔WASM byte parity).
+    ///
+    /// - Quorum-approval path: `initiator_did == executor_did ==` the
+    ///   quorum-crossing voter (the committing member).
+    /// - Propose auto-execute (`SingleAdmin`) path: `initiator_did ==
+    ///   executor_did ==` the proposer (proposer == committer there).
+    /// - Direct-FFI execute path (`context_execute_governance`):
+    ///   `initiator_did ==` the caller (auth subject), `executor_did ==` the
+    ///   proposal's `proposer_did` — matching the native direct-execute handler
+    ///   which stamps `proposal.proposer_did` as the executor.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the context is not active, the proposal is not
+    /// `Approved`, the initiator lacks the required capability, the proposal
+    /// was already executed, the proposal is not tracked, or the action fails.
     pub fn execute_governance_action(
         &mut self,
         context_id: &str,
         initiator_did: &str,
+        executor_did: &str,
         proposal_id: &str,
         action: &GovernanceAction,
     ) -> Result<serde_json::Value, ScpWasmError> {
+        // Status precondition (mirrors native): a proposal must be `Approved`
+        // before it can be executed.
+        self.require_proposal_approved(context_id, proposal_id)?;
+
         // Authorization: check that initiator has the required capability
         // for this governance action. Matches close_context's pattern.
         {
@@ -2960,7 +3087,11 @@ impl WasmContextManager {
             ctx.push_event(ContextEvent::GovernanceActionExecuted {
                 proposal_id: proposal_id_bytes,
                 action_summary,
-                executor_did: DID(initiator_did.to_owned()),
+                // The buffer event's `executor_did` is the COMMITTING member
+                // (the executor), NOT the auth-subject `initiator_did` —
+                // matching native `finalize_governance_action` (§9.9.3; ADR-031
+                // §8 / §7.3.1 / ADR-051 §6).
+                executor_did: DID(executor_did.to_owned()),
                 resulting_epoch: None,
                 target_did: target_did.clone(),
             });
@@ -2971,20 +3102,25 @@ impl WasmContextManager {
             // members derive equal Merkle roots (§9.9.3). `target_did` is the
             // action's target (empty when untargeted); `action_type` is the
             // `GovernanceAction` variant name.
-            let executed_payload = scp_event_log::payload::encode_payload(
-                &scp_event_log::payload::GovernanceActionExecutedPayload {
-                    target_did: target_did
-                        .as_ref()
-                        .map(|d| d.as_ref().to_owned())
-                        .unwrap_or_default(),
-                    action_type: action.variant_name().to_owned(),
-                },
-            )
-            .map(|p| p.data)
-            .unwrap_or_default();
+            //
+            // FAIL CLOSED on encode error (mirrors native's `map_err(...)?`):
+            // never write an EMPTY-payload leaf, which would diverge from the
+            // native leaf bytes and corrupt the convergent log. The dispatch has
+            // already mutated state and the proposal is recorded executed — the
+            // same position native is in when its `finalize_governance_action`
+            // encode fails (it returns Err and writes no leaf, leaving the
+            // executed marker set). Propagate the error identically.
+            let executed_payload =
+                Self::encode_governance_action_executed_payload(action, target_did.as_ref())?;
             ctx.append_log_event(
                 EventType::GovernanceActionExecuted,
-                initiator_did,
+                // Convergence-critical leaf `actor_did`: the COMMITTING member
+                // (the executor), NOT the auth-subject `initiator_did`. For the
+                // direct-FFI execute path the executor is the proposal's
+                // proposer (resolved by the caller); for quorum/auto it is the
+                // voter/proposer respectively — byte-identical to native
+                // (§9.9.3; ADR-031 §8 "executor DID").
+                executor_did,
                 &executed_payload,
                 proposal_created_at,
             );
@@ -3971,18 +4107,12 @@ impl WasmContextManager {
             Self::governance_quorum(ctx)
         };
 
-        // SingleAdmin or quorum=0: auto-approve and execute immediately.
-        if required == 0 {
-            let result =
-                self.execute_governance_action(context_id, proposer_did, proposal_id, action)?;
-            return Ok(serde_json::json!({
-                "proposal_id": proposal_id,
-                "status": "Approved",
-                "execution_result": result,
-            }));
-        }
-
-        // Multi-admin: create pending proposal. Proposer's vote counts as first approval.
+        // Build the proposal up front so even the SingleAdmin / quorum=0
+        // auto-execute path TRACKS it before executing (required since
+        // `execute_governance_action` resolves the convergent
+        // `GovernanceActionExecuted` leaf timestamp from the still-tracked
+        // proposal's `created_at` AND enforces the `status == Approved`
+        // precondition — both fail if the proposal was never inserted).
         let now = crate::time::now_ms();
         #[allow(clippy::cast_sign_loss, clippy::cast_possible_truncation)]
         let now_secs = (now / 1000.0) as u64;
@@ -4013,6 +4143,46 @@ impl WasmContextManager {
             rejections: Vec::new(),
             created_at_epoch: None,
         };
+
+        // SingleAdmin or quorum=0: auto-approve and execute immediately. The
+        // proposer IS the committing member here, so the executor is the
+        // proposer (matches native's propose auto-execute). Insert the proposal
+        // as `Approved` into `resolved_proposals` BEFORE executing so it is
+        // tracked when `execute_governance_action` derives the convergent leaf
+        // timestamp and checks the status precondition.
+        if required == 0 {
+            let pid = proposal_id.to_owned();
+            let action_ref = proposal.action.clone();
+            let mut approved = proposal;
+            approved.status = ProposalStatus::Approved;
+            if let Some(ctx) = self.contexts.get_mut(context_id) {
+                ctx.insert_resolved_proposal(pid.clone(), approved);
+            }
+            match self.execute_governance_action(
+                context_id,
+                proposer_did,
+                proposer_did,
+                &pid,
+                &action_ref,
+            ) {
+                Ok(result) => {
+                    return Ok(serde_json::json!({
+                        "proposal_id": proposal_id,
+                        "status": "Approved",
+                        "execution_result": result,
+                    }));
+                }
+                Err(e) => {
+                    // Dispatch failed: drop the durably-resolved proposal so the
+                    // proposer can retry (parity with native retry semantics —
+                    // a failed execution must not strand the proposal).
+                    if let Some(ctx) = self.contexts.get_mut(context_id) {
+                        ctx.remove_resolved_proposal(&pid);
+                    }
+                    return Err(e);
+                }
+            }
+        }
 
         let ctx = self.require_active_context_mut(context_id)?;
 
@@ -4061,19 +4231,41 @@ impl WasmContextManager {
                 .contexts
                 .get_mut(context_id)
                 .and_then(|ctx| ctx.pending_proposals.remove(&pid));
-            if let Some(mut p) = proposal {
+            if let Some(p) = proposal {
                 let action_ref = p.action.clone();
-                p.status = ProposalStatus::Approved;
+                let pending_snapshot = p.clone();
+                let mut approved = p;
+                approved.status = ProposalStatus::Approved;
                 if let Some(ctx) = self.contexts.get_mut(context_id) {
-                    ctx.insert_resolved_proposal(pid.clone(), p);
+                    ctx.insert_resolved_proposal(pid.clone(), approved);
                 }
-                let result =
-                    self.execute_governance_action(context_id, proposer_did, &pid, &action_ref)?;
-                return Ok(serde_json::json!({
-                    "proposal_id": pid,
-                    "status": "Approved",
-                    "execution_result": result,
-                }));
+                // Proposer's own vote crossed quorum: proposer == committing
+                // member, so the executor is the proposer (auth subject and
+                // executor coincide here).
+                match self.execute_governance_action(
+                    context_id,
+                    proposer_did,
+                    proposer_did,
+                    &pid,
+                    &action_ref,
+                ) {
+                    Ok(result) => {
+                        return Ok(serde_json::json!({
+                            "proposal_id": pid,
+                            "status": "Approved",
+                            "execution_result": result,
+                        }));
+                    }
+                    Err(e) => {
+                        // Dispatch failed: roll back the pending → resolved move
+                        // so the proposal stays retriable (parity with native).
+                        if let Some(ctx) = self.contexts.get_mut(context_id) {
+                            ctx.remove_resolved_proposal(&pid);
+                            ctx.pending_proposals.insert(pid.clone(), pending_snapshot);
+                        }
+                        return Err(e);
+                    }
+                }
             }
         }
 
@@ -4191,25 +4383,52 @@ impl WasmContextManager {
                 .contexts
                 .get_mut(context_id)
                 .and_then(|ctx| ctx.pending_proposals.remove(&pid));
-            if let Some(mut p) = proposal {
+            if let Some(p) = proposal {
                 let action_ref = p.action.clone();
-                p.status = ProposalStatus::Approved;
+                // Retain the PRE-MOVE proposal (status `Pending`) so the
+                // pending → resolved move can be rolled back if dispatch fails.
+                let pending_snapshot = p.clone();
+                let mut approved = p;
+                approved.status = ProposalStatus::Approved;
                 if let Some(ctx) = self.contexts.get_mut(context_id) {
-                    ctx.insert_resolved_proposal(pid.clone(), p);
+                    ctx.insert_resolved_proposal(pid.clone(), approved);
                 }
                 // The executor is the quorum-crossing VOTER (the committing
                 // member), NOT the proposer — `execute_governance_action`
-                // stamps `initiator_did` as the `GovernanceActionExecuted` leaf
+                // stamps the executor as the `GovernanceActionExecuted` leaf
                 // `actor_did` (ADR-031 §8 "executor DID" / §7.3.1 "committing
-                // member" / ADR-051 §6). Passing the proposer here would diverge
-                // the leaf from native's quorum path, which stamps the voter
-                // (§9.9.3 native↔WASM convergence).
-                let result =
-                    self.execute_governance_action(context_id, voter_did, &pid, &action_ref)?;
-                return Ok(serde_json::json!({
-                    "status": "Approved",
-                    "execution_result": result,
-                }));
+                // member" / ADR-051 §6). The voter is both the auth subject and
+                // the executor here. Passing the proposer would diverge the leaf
+                // from native's quorum path, which stamps the voter (§9.9.3
+                // native↔WASM convergence).
+                match self.execute_governance_action(
+                    context_id,
+                    voter_did,
+                    voter_did,
+                    &pid,
+                    &action_ref,
+                ) {
+                    Ok(result) => {
+                        return Ok(serde_json::json!({
+                            "status": "Approved",
+                            "execution_result": result,
+                        }));
+                    }
+                    Err(e) => {
+                        // Dispatch failed. Roll back the pending → resolved move
+                        // so the proposal is retriable (matches native, which
+                        // leaves the proposal `Approved`-and-retriable: it never
+                        // durably resolves a proposal whose execution failed).
+                        // Without this, WASM would strand the proposal in
+                        // `resolved_proposals` (gone from `pending_proposals`),
+                        // unable to be re-executed.
+                        if let Some(ctx) = self.contexts.get_mut(context_id) {
+                            ctx.remove_resolved_proposal(&pid);
+                            ctx.pending_proposals.insert(pid.clone(), pending_snapshot);
+                        }
+                        return Err(e);
+                    }
+                }
             }
         }
 
@@ -4413,6 +4632,41 @@ impl WasmContextManager {
             })?;
 
         Ok(Self::proposal_to_json(proposal_id, proposal))
+    }
+
+    /// Returns the `proposer_did` of a tracked governance proposal (pending or
+    /// resolved), or an error if it is not found.
+    ///
+    /// Used by the direct-FFI execute path (`context_execute_governance`) to
+    /// resolve the proposal's proposer so it can be stamped as the
+    /// `GovernanceActionExecuted` leaf `actor_did` — the executor — matching the
+    /// native direct-execute handler, which stamps `proposal.proposer_did`
+    /// (§9.9.3 native↔WASM convergence; ADR-031 §8).
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the context or proposal is not found.
+    pub fn proposal_proposer_did(
+        &self,
+        context_id: &str,
+        proposal_id: &str,
+    ) -> Result<String, ScpWasmError> {
+        let ctx = self
+            .contexts
+            .get(context_id)
+            .ok_or_else(|| ScpWasmError::Context {
+                message: format!("context {context_id} not found"),
+                code: codes::CTX_2045.to_owned(),
+            })?;
+
+        ctx.pending_proposals
+            .get(proposal_id)
+            .or_else(|| ctx.resolved_proposals.get(proposal_id))
+            .map(|p| p.proposer_did.0.clone())
+            .ok_or_else(|| ScpWasmError::Context {
+                message: format!("proposal {proposal_id} not found"),
+                code: codes::CTX_2045.to_owned(),
+            })
     }
 
     /// Lists all governance proposals (pending and resolved) for a context.
@@ -5150,7 +5404,7 @@ impl WasmContextManager {
 
         ctx.append_log_event(
             EventType::ContextExpired,
-            "system:timer",
+            scp_event_log::system_actors::SYSTEM_TIMER_ACTOR,
             b"",
             expiry_leaf_secs,
         );
@@ -6064,12 +6318,33 @@ impl WasmContextManager {
         "closed".clone_into(&mut ctx.state);
         ctx.broadcast_context = None;
 
+        // Convergent `ContextClosed` leaf timestamp. For a TTL-driven close this
+        // MUST be the CONVERGENT TTL deadline (`creation_timestamp_secs +
+        // ttl_seconds`) — the identical absolute value every member computes
+        // regardless of which member's timer fired or what its local clock read
+        // — NOT each member's local `crate::time::now_secs()`, which would
+        // diverge the leaf at equal event count and trip §9.9.3 equivocation
+        // detection across native/WASM. This mirrors native `finalize_close`
+        // (`ttl_close_helpers.rs`), which stamps
+        // `state.ttl.timer.deadline_unix_secs.unwrap_or_else(|| now_secs())`:
+        // `deadline_unix_secs` holds `creation + ttl` (auto-reflecting any
+        // TTL extension, which mutates `ttl_seconds` here / `deadline_unix_secs`
+        // there by the same delta), and falls back to the closer's clock only
+        // for a governance/explicit close of a no-TTL context. WASM mirrors that
+        // exactly via `convergent_ttl_deadline_secs(creation, ttl_seconds)`:
+        // `Some(ttl) => creation + ttl`, else local `now_secs()`. Identical to
+        // `handle_ttl_expiry`'s `expiry_leaf_secs` so a close and an expiry of
+        // the same TTL context stamp the same convergent instant.
+        let close_leaf_secs = match ctx.ttl_seconds {
+            Some(ttl) => ctx.creation_timestamp_secs.saturating_add(ttl),
+            None => crate::time::now_secs(),
+        };
+
         ctx.append_log_event(
             EventType::ContextClosed,
-            "system:close",
+            scp_event_log::system_actors::SYSTEM_CLOSE_ACTOR,
             b"",
-            // Convergent close instant (§7.3.1, §9.9.3).
-            crate::time::now_secs(),
+            close_leaf_secs,
         );
 
         Ok(())

--- a/crates/scp-ffi/wasm/src/manager.rs
+++ b/crates/scp-ffi/wasm/src/manager.rs
@@ -787,6 +787,19 @@ impl PerContextState {
         self.suspended_capabilities.get(did)
     }
 
+    /// Test-only: suspend a single capability (UCAN-format string) for a
+    /// member, so sibling-module cross-impl tests can construct a member that
+    /// holds `governance:vote` (eligible voter) while lacking a specific action
+    /// capability (e.g. `role:assign`). Mirrors the production effect of
+    /// `apply_suspend` populating `suspended_capabilities`.
+    #[cfg(test)]
+    pub(crate) fn test_insert_suspended_capability(&mut self, did: &str, capability: &str) {
+        self.suspended_capabilities
+            .entry(did.to_owned())
+            .or_default()
+            .insert(capability.to_owned());
+    }
+
     /// Test-only: push a consequence rule onto the context's declared rules.
     #[cfg(test)]
     pub(crate) fn test_push_consequence_rule(
@@ -2841,44 +2854,38 @@ impl WasmContextManager {
     /// Maps each `GovernanceAction` variant to the capability that
     /// the initiator must hold. Uses the UCAN `{resource}:{action}` format,
     /// matching `member_has_capability` and the ceiling strings.
-    fn required_capability_for_action(action: &GovernanceAction) -> &'static str {
+    /// Returns the context-ceiling capability a governance action requires at
+    /// DISPATCH time, in WASM `ceiling_strings` (UCAN) format — or `None` if the
+    /// action is NOT ceiling-gated at dispatch.
+    ///
+    /// This mirrors EXACTLY the native runtime's per-action ceiling gates in
+    /// `dispatch_governance_action` / its per-action `execute_*` helpers
+    /// (`governance_helpers.rs`), which gate on `ceiling.contains(&Capability::X)`
+    /// — NOT on the committing member's role. Native gates precisely these five:
+    ///
+    /// - `SuspendCapability` (`execute_suspend_member`)  → `member:ban`
+    /// - `SuspendAccess`     (inline `dispatch_governance_action`) → `member:ban`
+    /// - `RevokeAccess`      (`execute_revoke`)          → `member:ban`
+    /// - `RestoreAccess`     (`execute_restore_access`)  → `member:ban`
+    /// - `RegisterTool`      (`execute_register_tool`)   → `tool:register`
+    ///
+    /// All OTHER actions have NO per-action ceiling gate in native — their
+    /// authorization is entirely at propose time. Returning `None` for them
+    /// keeps WASM's accept/reject decision byte-identical to native (§9.9.3).
+    ///
+    /// The strings are exact `Capability::ucan_capability_name()` outputs
+    /// (`member:ban`, `tool:register`) and are matched against `ceiling_strings`
+    /// with EXACT membership — no wildcard expansion — because native's
+    /// `CapabilityCeiling::contains` uses exact set membership for these
+    /// capabilities (only `ToolInvoke` has wildcard special-casing).
+    fn dispatch_ceiling_capability(action: &GovernanceAction) -> Option<&'static str> {
         match action {
-            GovernanceAction::AddMember { .. } | GovernanceAction::RestoreAccess { .. } => {
-                "member:invite"
-            }
-
-            GovernanceAction::RemoveMember { .. }
-            | GovernanceAction::SuspendCapability { .. }
+            GovernanceAction::SuspendCapability { .. }
             | GovernanceAction::SuspendAccess { .. }
             | GovernanceAction::RevokeAccess { .. }
-            | GovernanceAction::ResetMember { .. } => "member:remove",
-
-            GovernanceAction::ChangeRole { .. } => "role:assign",
-
-            GovernanceAction::RegisterTool { .. }
-            | GovernanceAction::RemoveTool { .. }
-            | GovernanceAction::EstablishToolInterface { .. } => "tool:register",
-
-            GovernanceAction::CloseContext { .. } => "context:close",
-
-            GovernanceAction::ModifyCeiling { .. }
-            | GovernanceAction::ExtendTtl { .. }
-            | GovernanceAction::TransferAdmin { .. }
-            | GovernanceAction::PromoteContext
-            | GovernanceAction::CreateChildContext { .. }
-            | GovernanceAction::ModifyPruningPolicy { .. }
-            | GovernanceAction::AddSigner { .. }
-            | GovernanceAction::RemoveSigner { .. }
-            | GovernanceAction::ModifyThreshold { .. }
-            | GovernanceAction::ResolveConflict { .. }
-            | GovernanceAction::RotateContentKeys { .. }
-            | GovernanceAction::ReconfigureGovernance { .. }
-            | GovernanceAction::SetEconomicPolicy { .. }
-            | GovernanceAction::ApproveSpend { .. }
-            | GovernanceAction::LockEconomicPolicy
-            | GovernanceAction::ModifyHardRateLimit { .. }
-            | GovernanceAction::ProposeContextMigration { .. }
-            | GovernanceAction::CancelContextMigration => "governance:propose",
+            | GovernanceAction::RestoreAccess { .. } => Some("member:ban"),
+            GovernanceAction::RegisterTool { .. } => Some("tool:register"),
+            _ => None,
         }
     }
 
@@ -2992,20 +2999,20 @@ impl WasmContextManager {
         // before it can be executed.
         self.require_proposal_approved(context_id, proposal_id)?;
 
-        // Authorization: check that initiator has the required capability
-        // for this governance action. Matches close_context's pattern.
-        {
-            let ctx = self.require_active_context_mut(context_id)?;
-            let required = Self::required_capability_for_action(action);
-            if !ctx.member_has_capability(initiator_did, required) {
-                return Err(ScpWasmError::Permission {
-                    message: format!(
-                        "member {initiator_did} does not have '{required}' capability required for this governance action"
-                    ),
-                    code: codes::PERM_3000.to_owned(),
-                });
-            }
-        }
+        // NO per-MEMBER capability check at execute time. The native runtime's
+        // `execute_governance_action` (`governance_helpers.rs`) gates ONLY on
+        // status==Approved, context-id match, replay (`executed_proposals`), and
+        // `check_commit_fault` — it performs NO per-member action-capability
+        // check at execute. Authorization is enforced at PROPOSE time
+        // (proposer needs `governance:propose` + action within ceiling) and, for
+        // the ban/tool-register class, by a per-action CONTEXT-CEILING gate
+        // inside `dispatch_governance_action` (matching native's per-action
+        // `ceiling.contains(&Capability::X)` gates). A per-member check here
+        // diverged from native: on the quorum path the committing member is the
+        // quorum-crossing VOTER, who only needs `governance:vote` — gating on the
+        // action capability (e.g. `role:assign`) would make WASM mint ZERO
+        // `GovernanceActionExecuted` leaves where native mints ONE, breaking
+        // §9.9.3 native↔WASM accept/reject convergence (ADR-031 §8).
 
         // Resolve the CONVERGENT `GovernanceActionExecuted` leaf timestamp
         // BEFORE dispatch, while the proposal is still tracked. This is the
@@ -3158,6 +3165,25 @@ impl WasmContextManager {
         context_id: &str,
         action: &GovernanceAction,
     ) -> Result<serde_json::Value, ScpWasmError> {
+        // Per-action CONTEXT-CEILING gate, identical to native's per-action
+        // `ceiling.contains(&Capability::X)` gates in `dispatch_governance_action`
+        // / the `execute_*` helpers (`governance_helpers.rs`). Gates on the
+        // CEILING only — NOT on the committing member's role — so an
+        // out-of-ceiling action is rejected byte-identically on both bridges and
+        // an in-ceiling action executes (and mints its leaves) on both (§9.9.3,
+        // ADR-031 §8). Actions with no native ceiling gate return `None` and skip
+        // this check (their authorization lives entirely at propose time).
+        if let Some(required) = Self::dispatch_ceiling_capability(action) {
+            let ctx = self.require_active_context(context_id)?;
+            if !ctx.ceiling_strings.contains(required) {
+                return Err(ScpWasmError::Permission {
+                    message: format!(
+                        "context ceiling does not include '{required}' capability required for this governance action"
+                    ),
+                    code: codes::PERM_3000.to_owned(),
+                });
+            }
+        }
         match action {
             GovernanceAction::AddMember { did, role } => {
                 self.dispatch_add_member(context_id, did, role)

--- a/crates/scp-ffi/wasm/src/manager.rs
+++ b/crates/scp-ffi/wasm/src/manager.rs
@@ -3257,7 +3257,11 @@ impl WasmContextManager {
             GovernanceAction::ExtendTtl { additional_secs } => {
                 let ctx = self.require_active_context_mut(context_id)?;
                 if let Some(ref mut ttl) = ctx.ttl_seconds {
-                    *ttl += additional_secs;
+                    // Saturating add for exact parity with native
+                    // `execute_extend_ttl` (`governance_helpers.rs`), which
+                    // extends the TTL with a saturating base — and for u64
+                    // overflow safety (a plain `+=` panics in debug builds).
+                    *ttl = ttl.saturating_add(*additional_secs);
                 }
                 Ok(serde_json::json!({"action": "ExtendTtl", "additionalSecs": additional_secs}))
             }
@@ -5396,7 +5400,9 @@ impl WasmContextManager {
                 })
             },
             |ttl| {
-                *ttl += additional_secs;
+                // Saturating add for parity with native `execute_extend_ttl`
+                // and u64 overflow safety (a plain `+=` panics in debug builds).
+                *ttl = ttl.saturating_add(additional_secs);
                 Ok(true)
             },
         )

--- a/crates/scp-runtime/src/context/actor/handlers/governance.rs
+++ b/crates/scp-runtime/src/context/actor/handlers/governance.rs
@@ -664,12 +664,19 @@ async fn handle_execute_governance_action_actor(
     let proposal = payload.proposal;
 
     let execute_fut = async move {
+        // Direct-execute command (no quorum-crossing voter in the payload): the
+        // executor is the proposer, matching the auto-execute convention where
+        // proposer == committer (ADR-031 §7.3.1 / §8). The quorum-approval path
+        // that distinguishes voter from proposer lives in
+        // `vote_on_proposal_inner`, not this direct entry point.
+        let executor_did = proposal.proposer_did.clone();
         Box::pin(
             crate::context::governance_helpers::execute_governance_action(
                 state,
                 deps,
                 &payload.context_id,
                 &proposal,
+                &executor_did,
             ),
         )
         .await

--- a/crates/scp-runtime/src/context/actor/handlers/governance.rs
+++ b/crates/scp-runtime/src/context/actor/handlers/governance.rs
@@ -666,7 +666,8 @@ async fn handle_execute_governance_action_actor(
     let execute_fut = async move {
         // Direct-execute command (no quorum-crossing voter in the payload): the
         // executor is the proposer, matching the auto-execute convention where
-        // proposer == committer (ADR-031 §7.3.1 / §8). The quorum-approval path
+        // proposer == committer (ADR-031 §8 "executor DID" / spec §7.3.1
+        // "committing member"). The quorum-approval path
         // that distinguishes voter from proposer lives in
         // `vote_on_proposal_inner`, not this direct entry point.
         let executor_did = proposal.proposer_did.clone();

--- a/crates/scp-runtime/src/context/actor/handlers/saga.rs
+++ b/crates/scp-runtime/src/context/actor/handlers/saga.rs
@@ -2136,7 +2136,7 @@ fn emit_divergence_marker(
     if let Err(err) = deps.event_log.append_context_event_with_payload(
         &state.context_id,
         scp_event_log::EventType::CrossContextDivergenceMarker,
-        "system:saga",
+        scp_event_log::system_actors::SYSTEM_SAGA_ACTOR,
         scp_event_log::EventPayload {
             data: marker_payload_bytes,
         },

--- a/crates/scp-runtime/src/context/actor/handlers/saga.rs
+++ b/crates/scp-runtime/src/context/actor/handlers/saga.rs
@@ -2136,7 +2136,7 @@ fn emit_divergence_marker(
     if let Err(err) = deps.event_log.append_context_event_with_payload(
         &state.context_id,
         scp_event_log::EventType::CrossContextDivergenceMarker,
-        "",
+        "system:saga",
         scp_event_log::EventPayload {
             data: marker_payload_bytes,
         },

--- a/crates/scp-runtime/src/context/governance_helpers.rs
+++ b/crates/scp-runtime/src/context/governance_helpers.rs
@@ -3133,8 +3133,15 @@ pub async fn propose_governance_action_inner(
     // immediately — unless invalidated by conflict or in freeze.
     let execution_result = if should_execute && !invalidated_by_conflict && !in_freeze {
         Some(
+            // Auto-execute (SingleAdmin / quorum==0): the proposer IS the
+            // committing member, so the executor is the proposer. Preserves the
+            // existing leaf bytes on this path.
             Box::pin(execute_governance_action(
-                state, deps, context_id, &proposal,
+                state,
+                deps,
+                context_id,
+                &proposal,
+                proposer_did,
             ))
             .await?,
         )
@@ -3439,8 +3446,14 @@ pub async fn vote_on_proposal_inner(
     if let Some(proposal) = proposal_for_execution {
         let in_freeze = state.governance.freeze.is_some();
         if !in_freeze && !invalidated_by_conflict {
+            // Quorum-approval path: the executor is THIS voter — the member
+            // whose approval crossed quorum and therefore committed the action
+            // (ADR-031 §7.3.1 "committing member"). This is the divergence-
+            // causing path: stamping the proposer here (the old behavior) made
+            // native disagree with WASM whenever proposer != quorum-crossing
+            // voter.
             Box::pin(execute_governance_action(
-                state, deps, context_id, &proposal,
+                state, deps, context_id, &proposal, voter_did,
             ))
             .await?;
         }
@@ -3969,9 +3982,15 @@ pub async fn dispatch_governance_action(
     deps: &ActorDeps,
     context_id: &str,
     proposal: &GovernanceProposal,
+    // The committing member (quorum-crossing voter, or proposer on
+    // auto-execute). Every per-action dispatch leaf (RoleAssigned,
+    // CeilingModified, etc.) is stamped with the executor — uniform with the
+    // `GovernanceActionExecuted` leaf and spec-correct per ADR-031 §8 /
+    // §7.3.1 / ADR-051 §6.
+    executor_did: &DID,
 ) -> Result<GovernanceActionResult, ContextError> {
     let pid = proposal.proposal_id;
-    let actor = proposal.proposer_did.as_ref();
+    let actor = executor_did.as_ref();
     // Committer-assigned leaf timestamp: the proposal's signed `created_at`.
     // The value is identical and tamper-evident for every member that
     // processes the signed proposal (convergent-by-construction), never local
@@ -4224,6 +4243,14 @@ pub fn finalize_governance_action(
     deps: &ActorDeps,
     context_id: &str,
     proposal: &GovernanceProposal,
+    // The committing member — the DID whose approval crossed quorum (or, for
+    // auto-execute, the proposer). Stamped as the `GovernanceActionExecuted`
+    // leaf `actor_did` and the event's `executor_did` per ADR-031 §8
+    // ("executor DID") / §7.3.1 ("committing member") / ADR-051 §6. This is
+    // DISTINCT from `proposal.proposer_did`, which remains the consequence
+    // SUBJECT below (a different semantic — see the consequence-evaluation
+    // block).
+    executor_did: &DID,
 ) -> Result<(), ContextError> {
     // For MLS-mutating actions (AddMember, RemoveMember, Revoke,
     // ResetMember), increment the epoch counter, place the old epoch into
@@ -4260,7 +4287,7 @@ pub fn finalize_governance_action(
     let executed_event = GovernanceEvent::GovernanceActionExecuted {
         proposal_id: proposal.proposal_id,
         action: Box::new(proposal.action.clone()),
-        executor_did: proposal.proposer_did.clone(),
+        executor_did: executor_did.clone(),
         resulting_epoch,
     };
 
@@ -4280,7 +4307,7 @@ pub fn finalize_governance_action(
     deps.event_log.append_context_event_with_payload(
         &context_id_bytes,
         governance_event_label(&executed_event),
-        proposal.proposer_did.as_ref(),
+        executor_did.as_ref(),
         executed_payload,
         // Committer-assigned timestamp: the proposal's signed `created_at` —
         // identical and tamper-evident for every member that processes the
@@ -4298,7 +4325,7 @@ pub fn finalize_governance_action(
     let gov_event = ContextEvent::GovernanceActionExecuted {
         proposal_id: proposal.proposal_id,
         action_summary,
-        executor_did: proposal.proposer_did.clone(),
+        executor_did: executor_did.clone(),
         resulting_epoch,
         target_did,
     };
@@ -4470,6 +4497,13 @@ pub async fn execute_governance_action(
     deps: &ActorDeps,
     context_id: &str,
     proposal: &GovernanceProposal,
+    // The committing member — the DID whose approval crossed quorum (quorum
+    // path) or the proposer (auto-execute / SingleAdmin). Threaded through to
+    // both `dispatch_governance_action` (per-action leaves) and
+    // `finalize_governance_action` (the `GovernanceActionExecuted` leaf +
+    // event `executor_did`). Spec: ADR-031 §8 "executor DID" / §7.3.1
+    // "committing member" / ADR-051 §6.
+    executor_did: &DID,
 ) -> Result<GovernanceActionResult, ContextError> {
     if !matches!(proposal.status, ProposalStatus::Approved) {
         return Err(ContextError::PermissionDenied(format!(
@@ -4515,22 +4549,23 @@ pub async fn execute_governance_action(
     // variant exists yet. Governance actions are free until the economy
     // spec adds a governance cost tier. Tracked by #1537.
 
-    let result = match dispatch_governance_action(state, deps, context_id, proposal).await {
-        Ok(r) => r,
-        Err(e) => {
-            // Roll back the executed marker on dispatch failure so the
-            // proposal can be retried (e.g. after a transient crypto
-            // error).
-            state
-                .governance
-                .class_s
-                .executed_proposals
-                .remove(&proposal.proposal_id);
-            return Err(e);
-        }
-    };
+    let result =
+        match dispatch_governance_action(state, deps, context_id, proposal, executor_did).await {
+            Ok(r) => r,
+            Err(e) => {
+                // Roll back the executed marker on dispatch failure so the
+                // proposal can be retried (e.g. after a transient crypto
+                // error).
+                state
+                    .governance
+                    .class_s
+                    .executed_proposals
+                    .remove(&proposal.proposal_id);
+                return Err(e);
+            }
+        };
 
-    finalize_governance_action(state, deps, context_id, proposal)?;
+    finalize_governance_action(state, deps, context_id, proposal, executor_did)?;
 
     Ok(result)
 }

--- a/crates/scp-runtime/src/context/governance_logic.rs
+++ b/crates/scp-runtime/src/context/governance_logic.rs
@@ -27,7 +27,8 @@ use super::state::{GovernanceState, PerContextState, context_id_to_bytes, emit_e
 /// also satisfies the `WarningCount` trigger's `actor_did != subject_did`
 /// requirement so subsequent rule evaluation can match prior enforcements
 /// against the same target.
-pub(super) const CONSEQUENCE_ACTOR_DID: &str = "system";
+pub(super) const CONSEQUENCE_ACTOR_DID: &str =
+    scp_event_log::system_actors::SYSTEM_CONSEQUENCE_ACTOR;
 
 // The canonical wire-stable `trigger_kind` / `action_type` labels and the
 // durable consequence-leaf payload bytes are produced by SHARED code so the

--- a/crates/scp-runtime/src/context/ttl.rs
+++ b/crates/scp-runtime/src/context/ttl.rs
@@ -676,7 +676,7 @@ pub async fn finalize_close(
     event_log.append_context_event(
         &context_id_bytes,
         scp_event_log::EventType::ContextClosed,
-        "system:close",
+        scp_event_log::system_actors::SYSTEM_CLOSE_ACTOR,
         timestamp_secs,
     )?;
 
@@ -873,7 +873,7 @@ pub async fn try_ttl_expiry_cleanup(
         match event_log.append_context_event(
             &context_id_bytes,
             scp_event_log::EventType::ContextExpired,
-            "system:timer",
+            scp_event_log::system_actors::SYSTEM_TIMER_ACTOR,
             expiry_deadline_secs,
         ) {
             Ok(()) => result.set_step(STEP_EVENT_LOGGED),

--- a/crates/scp-runtime/src/context/ttl.rs
+++ b/crates/scp-runtime/src/context/ttl.rs
@@ -1367,6 +1367,101 @@ mod tests {
         }
     }
 
+    /// Records the `(EventType, actor_did)` of every append so a test can
+    /// assert the real producer stamps the convergent system-leaf sentinel.
+    #[derive(Default)]
+    struct CapturingEventLog {
+        // Test-only capture buffer; the guard is never held across an `.await`
+        // (locked, pushed, and dropped synchronously inside `append_event`).
+        // Per `crates/scp-runtime/clippy.toml`, test-only `std::sync::Mutex`
+        // sites carry this allow.
+        #[allow(clippy::disallowed_types)]
+        appends: std::sync::Mutex<Vec<(scp_event_log::EventType, String)>>,
+    }
+
+    impl ContextEventLogProvider for CapturingEventLog {
+        fn init_event_log(
+            &self,
+            _cid: &[u8; 32],
+        ) -> Result<(), scp_protocol::context::builder::ContextCreationError> {
+            Ok(())
+        }
+        fn append_event(
+            &self,
+            _cid: &[u8; 32],
+            event: scp_event_log::EventType,
+            actor_did: &str,
+            _payload: scp_event_log::EventPayload,
+            _timestamp_secs: u64,
+        ) -> Result<(), scp_protocol::context::builder::ContextCreationError> {
+            self.appends
+                .lock()
+                .unwrap()
+                .push((event, actor_did.to_owned()));
+            Ok(())
+        }
+        fn destroy_event_log(
+            &self,
+            _cid: &[u8; 32],
+        ) -> Result<(), scp_protocol::context::builder::ContextCreationError> {
+            Ok(())
+        }
+    }
+
+    /// §9.9.3 native↔WASM convergence: the native `finalize_close` producer MUST
+    /// stamp the descriptive sentinel `"system:close"` on the `ContextClosed`
+    /// leaf so it is byte-identical to the WASM bridge's `finalize_close` leaf.
+    #[tokio::test]
+    async fn finalize_close_stamps_system_close_actor_did() {
+        let crypto = mk_crypto();
+        let transport = NullTransport;
+        let event_log = CapturingEventLog::default();
+        let handle = active_handle("ctx-close-actor", MemoryScope::Full).await;
+        handle.transition_to(&ContextState::Closing).await.unwrap();
+        finalize_close(
+            &handle,
+            crypto.as_ref(),
+            &transport,
+            &event_log,
+            1_700_000_000,
+        )
+        .await
+        .unwrap();
+
+        let appends = event_log.appends.lock().unwrap();
+        let closed = appends
+            .iter()
+            .find(|(e, _)| *e == scp_event_log::EventType::ContextClosed)
+            .expect("ContextClosed leaf must be appended by finalize_close");
+        assert_eq!(
+            closed.1, "system:close",
+            "native ContextClosed leaf MUST stamp \"system:close\" (§9.9.3 native↔WASM parity)"
+        );
+    }
+
+    /// §9.9.3 native↔WASM convergence: the native `handle_ttl_expiry` producer
+    /// MUST stamp the descriptive sentinel `"system:timer"` on the
+    /// `ContextExpired` leaf so it is byte-identical to the WASM bridge's leaf.
+    #[tokio::test]
+    async fn handle_ttl_expiry_stamps_system_timer_actor_did() {
+        let crypto = mk_crypto();
+        let event_log = CapturingEventLog::default();
+        let handle = active_handle("ctx-ttl-actor", MemoryScope::Full).await;
+        handle_ttl_expiry(&handle, crypto.as_ref(), &event_log, 1_700_000_000)
+            .await
+            .unwrap();
+
+        let appends = event_log.appends.lock().unwrap();
+        let expired = appends
+            .iter()
+            .find(|(e, _)| *e == scp_event_log::EventType::ContextExpired)
+            .expect("ContextExpired leaf must be appended by handle_ttl_expiry");
+        assert_eq!(
+            expired.1, "system:timer",
+            "native ContextExpired leaf MUST stamp \"system:timer\" (§9.9.3 native↔WASM parity)"
+        );
+    }
+
     async fn active_handle(context_id: &str, memory_scope: MemoryScope) -> ContextHandle {
         let params = ContextParams {
             memory_scope,

--- a/crates/scp-runtime/tests/governance_integration.rs
+++ b/crates/scp-runtime/tests/governance_integration.rs
@@ -563,6 +563,145 @@ async fn governance_action_executed_leaf_stamps_executor_not_proposer() {
 }
 
 // =========================================================================
+// §9.9.3 native↔WASM ACCEPT-decision parity: a quorum-crossing eligible voter
+// who is NOT the proposer and holds no per-action capability still causes the
+// action to execute and mint EXACTLY ONE GovernanceActionExecuted leaf.
+//
+// Native `execute_governance_action` performs NO per-member action-capability
+// check (only status / context-id / replay / commit-fault). The WASM bridge
+// previously gated on `member_has_capability(voter, action_cap)` at execute,
+// which a vote-eligible-but-action-less voter fails — minting 0 where native
+// mints 1. That per-member check has been removed from WASM so both bridges
+// mint exactly 1. This native test pins the "native mints 1" half (the WASM
+// half is `cross_impl_nonadmin_voter_crosses_quorum_mints_one_leaf_wasm`).
+// =========================================================================
+#[tokio::test]
+async fn governance_quorum_voter_without_action_capability_mints_one_leaf() {
+    let manager = new_manager_with_real_event_log();
+    let ctx_id = "ctx-majority-voter-no-action-cap";
+    let params = ContextParams {
+        ceiling: governance_ceiling(),
+        governance: GovernanceModel::Majority {
+            eligible_voters: vec![alice(), bob(), carol()],
+        },
+        ..ContextParams::default()
+    };
+    manager
+        .create_context(ctx_id.into(), params, alice(), None)
+        .await
+        .unwrap();
+
+    // ChangeRole has NO native per-action ceiling gate; `role:assign` is in the
+    // ceiling. `bob` is an eligible voter who is NOT a member and holds no
+    // per-action capability of his own — yet his quorum-crossing vote commits
+    // the action, because native does not check the committing member's
+    // action capability at execute.
+    let action = GovernanceAction::ChangeRole {
+        did: alice(),
+        new_role: "observer".into(),
+    };
+    let sk_alice = signing_key_for_did(&alice());
+
+    let (proposal, _events, _) = manager
+        .propose_governance_action(ctx_id, &alice(), action, &sk_alice)
+        .await
+        .unwrap();
+    assert_eq!(proposal.status, ProposalStatus::Pending);
+
+    // Alice's approval is #1 of quorum 2 — still Pending.
+    let (status_after_alice, _) = manager
+        .vote_on_proposal(ctx_id, &proposal.proposal_id, &alice(), true, &sk_alice)
+        .await
+        .unwrap();
+    assert_eq!(status_after_alice, ProposalStatus::Pending);
+
+    // Bob's approval is #2 — crosses majority quorum and COMMITS the action.
+    let sk_bob = signing_key_for_did(&bob());
+    let (status, _events) = manager
+        .vote_on_proposal(ctx_id, &proposal.proposal_id, &bob(), true, &sk_bob)
+        .await
+        .unwrap();
+    assert_eq!(status, ProposalStatus::Approved);
+
+    let ctx_bytes = scp_protocol::context::context_id_bytes(ctx_id);
+    let entries = manager
+        .event_log_entries(&ctx_bytes)
+        .unwrap()
+        .expect("event log must exist for an active context");
+    let executed = entries
+        .iter()
+        .filter(|e| e.event_type == scp_event_log::EventType::GovernanceActionExecuted)
+        .count();
+    assert_eq!(
+        executed, 1,
+        "native MUST mint EXACTLY ONE GovernanceActionExecuted leaf for a quorum-crossing voter \
+         lacking the action capability — the convergent target the WASM bridge must match (§9.9.3)"
+    );
+}
+
+// =========================================================================
+// §9.9.3 native↔WASM REJECT-decision parity: an action whose required
+// capability is NOT in the context ceiling is rejected, minting no
+// GovernanceActionExecuted leaf. `RevokeAccess` is gated on `member:ban` in
+// native (`execute_revoke`). With `member:ban` absent from the ceiling, native
+// rejects — the WASM bridge now applies the same per-action ceiling gate
+// (`cross_impl_out_of_ceiling_action_rejected_wasm`).
+// =========================================================================
+#[tokio::test]
+async fn governance_out_of_ceiling_action_rejected_native() {
+    let manager = new_manager_with_real_event_log();
+    let ctx_id = "ctx-single-admin-out-of-ceiling";
+    // Ceiling deliberately EXCLUDES `member:ban` (MemberBan).
+    let ceiling = vec![
+        Capability::new("messages:read"),
+        Capability::new("messages:write"),
+        Capability::new("role:assign"),
+        Capability::new("governance:propose"),
+        Capability::new("governance:vote"),
+        Capability::new("context:close"),
+    ];
+    let params = ContextParams {
+        ceiling,
+        governance: GovernanceModel::SingleAdmin,
+        ..ContextParams::default()
+    };
+    manager
+        .create_context(ctx_id.into(), params, alice(), None)
+        .await
+        .unwrap();
+
+    // SingleAdmin auto-executes on propose, so the per-action ceiling gate is
+    // reached synchronously and the propose call surfaces the rejection.
+    let action = GovernanceAction::RevokeAccess {
+        did: bob(),
+        access: AccessScope::Both,
+    };
+    let sk_alice = signing_key_for_did(&alice());
+    let result = manager
+        .propose_governance_action(ctx_id, &alice(), action, &sk_alice)
+        .await;
+    assert!(
+        result.is_err(),
+        "an out-of-ceiling RevokeAccess (member:ban not in ceiling) MUST be rejected by native — \
+         the convergent reject decision the WASM bridge must match (§9.9.3; ADR-031 §8)"
+    );
+
+    let ctx_bytes = scp_protocol::context::context_id_bytes(ctx_id);
+    let entries = manager
+        .event_log_entries(&ctx_bytes)
+        .unwrap()
+        .expect("event log must exist for an active context");
+    let executed = entries
+        .iter()
+        .filter(|e| e.event_type == scp_event_log::EventType::GovernanceActionExecuted)
+        .count();
+    assert_eq!(
+        executed, 0,
+        "a rejected out-of-ceiling action MUST mint ZERO GovernanceActionExecuted leaves on native"
+    );
+}
+
+// =========================================================================
 // AC-5: Unanimity — all members approve -> execute
 // =========================================================================
 

--- a/crates/scp-runtime/tests/governance_integration.rs
+++ b/crates/scp-runtime/tests/governance_integration.rs
@@ -461,6 +461,108 @@ async fn ac4_majority_propose_approve_execute() {
 }
 
 // =========================================================================
+// §9.9.3 native↔WASM convergence: GovernanceActionExecuted leaf actor_did is
+// the EXECUTOR (the quorum-crossing committing member), NOT the proposer.
+//
+// ADR-031 §8 ("executor DID") / §7.3.1 ("committing member") / ADR-051 §6.
+// The WASM bridge stamps `initiator_did` (the committing voter) on its
+// `GovernanceActionExecuted` leaf; native MUST do the same so the same logical
+// commit yields a byte-identical leaf actor_did — and therefore the same leaf
+// hash and Merkle root — across the two bridges. This drives the REAL native
+// quorum-approval path through the `Supervisor` with a REAL
+// `MerkleEventLogProvider`, then reads the landed leaf back out.
+// =========================================================================
+
+/// Like [`new_manager`] but wires a REAL `MerkleEventLogProvider` so the
+/// durable `GovernanceActionExecuted` leaf is actually recorded and can be
+/// queried via `Supervisor::event_log_entries`.
+fn new_manager_with_real_event_log() -> std::sync::Arc<Supervisor> {
+    use scp_runtime::context::providers::MerkleEventLogProvider;
+    scp_runtime::context::test_supervisor(
+        Arc::new(MlsCryptoProvider::new(
+            "did:dht:z6MkhaXgBZDvotDkL5257faiztiGiC2QtKLGpbnnEGta2doK".to_owned(),
+        )),
+        Box::new(MockTransport::connected()),
+        Box::new(MerkleEventLogProvider::new()),
+        mock_key_resolver(),
+    )
+}
+
+#[tokio::test]
+async fn governance_action_executed_leaf_stamps_executor_not_proposer() {
+    let manager = new_manager_with_real_event_log();
+    let ctx_id = "ctx-majority-executor-leaf";
+    let params = ContextParams {
+        ceiling: governance_ceiling(),
+        governance: GovernanceModel::Majority {
+            eligible_voters: vec![alice(), bob(), carol()],
+        },
+        ..ContextParams::default()
+    };
+    manager
+        .create_context(ctx_id.into(), params, alice(), None)
+        .await
+        .unwrap();
+
+    // The action target is irrelevant to the leaf actor_did, which is the
+    // EXECUTOR. `alice` is the sole member at this point (eligible_voters is
+    // governance config, not membership), so target her role. The leaf actor
+    // must still be the quorum-crossing voter `bob`, not `alice`.
+    let action = GovernanceAction::ChangeRole {
+        did: alice(),
+        new_role: "observer".into(),
+    };
+    let sk_alice = signing_key_for_did(&alice());
+
+    let (proposal, _events, _) = manager
+        .propose_governance_action(ctx_id, &alice(), action, &sk_alice)
+        .await
+        .unwrap();
+    assert_eq!(proposal.status, ProposalStatus::Pending);
+
+    // Alice's own approval is #1 of quorum 2 — still Pending.
+    let (status_after_alice, _) = manager
+        .vote_on_proposal(ctx_id, &proposal.proposal_id, &alice(), true, &sk_alice)
+        .await
+        .unwrap();
+    assert_eq!(status_after_alice, ProposalStatus::Pending);
+
+    // Bob's approval is #2 — crosses majority quorum and COMMITS the action.
+    // Bob is therefore the executor (committing member), not alice.
+    let sk_bob = signing_key_for_did(&bob());
+    let (status, _events) = manager
+        .vote_on_proposal(ctx_id, &proposal.proposal_id, &bob(), true, &sk_bob)
+        .await
+        .unwrap();
+    assert_eq!(status, ProposalStatus::Approved);
+
+    // Read the landed durable leaf back out of the real event log.
+    let ctx_bytes = scp_protocol::context::context_id_bytes(ctx_id);
+    let entries = manager
+        .event_log_entries(&ctx_bytes)
+        .unwrap()
+        .expect("event log must exist for an active context");
+    let executed_leaf = entries
+        .iter()
+        .find(|e| e.event_type == scp_event_log::EventType::GovernanceActionExecuted)
+        .expect("GovernanceActionExecuted leaf must be present after quorum-crossing approval");
+
+    assert_eq!(
+        executed_leaf.actor_did.as_ref(),
+        bob().as_ref(),
+        "the GovernanceActionExecuted leaf actor_did MUST be the quorum-crossing executor (bob), \
+         NOT the proposer (alice) — ADR-031 §8 executor DID; §9.9.3 native↔WASM convergence"
+    );
+    // Non-vacuity: alice (proposer) != bob (executor), so a proposer stamp
+    // would be a distinct, divergent leaf actor_did.
+    assert_ne!(
+        executed_leaf.actor_did.as_ref(),
+        alice().as_ref(),
+        "stamping the proposer would diverge from the WASM bridge, which stamps the committing voter"
+    );
+}
+
+// =========================================================================
 // AC-5: Unanimity — all members approve -> execute
 // =========================================================================
 

--- a/crates/scp-runtime/tests/governance_integration.rs
+++ b/crates/scp-runtime/tests/governance_integration.rs
@@ -702,6 +702,142 @@ async fn governance_out_of_ceiling_action_rejected_native() {
 }
 
 // =========================================================================
+// §9.9.3 native↔WASM REJECT-decision parity for `CreateChildContext`.
+// Native gates this on `Capability::ChildContextCreate` in
+// `execute_create_child_context` (`governance_helpers.rs`). With the capability
+// absent from the ceiling, native rejects and mints ZERO leaves — pinning the
+// convergent reject that the WASM bridge now also enforces
+// (`cross_impl_out_of_ceiling_create_child_context_rejected_wasm`). Previously
+// WASM EXECUTED this action (ungated), a §9.9.3 divergence and security gap.
+// =========================================================================
+#[tokio::test]
+async fn governance_out_of_ceiling_create_child_context_rejected_native() {
+    let manager = new_manager_with_real_event_log();
+    let ctx_id = "ctx-single-admin-child-out-of-ceiling";
+    // Ceiling deliberately EXCLUDES ChildContextCreate (context:child:create).
+    let ceiling = vec![
+        Capability::new("messages:read"),
+        Capability::new("messages:write"),
+        Capability::new("role:assign"),
+        Capability::new("governance:propose"),
+        Capability::new("governance:vote"),
+        Capability::new("context:close"),
+    ];
+    let params = ContextParams {
+        ceiling,
+        governance: GovernanceModel::SingleAdmin,
+        ..ContextParams::default()
+    };
+    manager
+        .create_context(ctx_id.into(), params, alice(), None)
+        .await
+        .unwrap();
+
+    // Built via serde to mirror the WASM KAT fixture exactly.
+    let action: GovernanceAction = serde_json::from_value(serde_json::json!({
+        "CreateChildContext": {"params": {
+            "mode": "Encrypted", "ceiling": [], "ceiling_policy": "Immutable",
+            "promotion_policy": "NoPromotion", "roles": [], "tools": [],
+            "ttl": null, "memory_scope": "Ephemeral", "governance": "SingleAdmin",
+            "template_id": null
+        }}
+    }))
+    .expect("CreateChildContext action deserializes");
+
+    let sk_alice = signing_key_for_did(&alice());
+    let result = manager
+        .propose_governance_action(ctx_id, &alice(), action, &sk_alice)
+        .await;
+    assert!(
+        result.is_err(),
+        "an out-of-ceiling CreateChildContext (context:child:create not in ceiling) MUST be \
+         rejected by native — the convergent reject the WASM bridge must match (§9.9.3; ADR-031 §8)"
+    );
+
+    let ctx_bytes = scp_protocol::context::context_id_bytes(ctx_id);
+    let entries = manager
+        .event_log_entries(&ctx_bytes)
+        .unwrap()
+        .expect("event log must exist for an active context");
+    let executed = entries
+        .iter()
+        .filter(|e| e.event_type == scp_event_log::EventType::GovernanceActionExecuted)
+        .count();
+    assert_eq!(
+        executed, 0,
+        "a rejected out-of-ceiling CreateChildContext MUST mint ZERO GovernanceActionExecuted \
+         leaves on native"
+    );
+}
+
+// =========================================================================
+// §9.9.3 native↔WASM REJECT-decision parity for `EstablishToolInterface`.
+// Native gates this on `Capability::ToolInterface` in
+// `execute_establish_tool_interface` (`governance_helpers.rs`). With the
+// capability absent from the ceiling, native rejects and mints ZERO leaves —
+// pinning the convergent reject the WASM bridge now also enforces
+// (`cross_impl_out_of_ceiling_establish_tool_interface_rejected_wasm`).
+// =========================================================================
+#[tokio::test]
+async fn governance_out_of_ceiling_establish_tool_interface_rejected_native() {
+    let manager = new_manager_with_real_event_log();
+    let ctx_id = "ctx-single-admin-iface-out-of-ceiling";
+    // Ceiling deliberately EXCLUDES ToolInterface (tool:interface).
+    let ceiling = vec![
+        Capability::new("messages:read"),
+        Capability::new("messages:write"),
+        Capability::new("role:assign"),
+        Capability::new("governance:propose"),
+        Capability::new("governance:vote"),
+        Capability::new("context:close"),
+    ];
+    let params = ContextParams {
+        ceiling,
+        governance: GovernanceModel::SingleAdmin,
+        ..ContextParams::default()
+    };
+    manager
+        .create_context(ctx_id.into(), params, alice(), None)
+        .await
+        .unwrap();
+
+    let action: GovernanceAction = serde_json::from_value(serde_json::json!({
+        "EstablishToolInterface": {"interface": {
+            "source_context": "ctx-src", "target_context": "ctx-tgt",
+            "tool_id": "tool-1", "rate_limit": null, "per_caller_rate_limit": null,
+            "approved_by_source": false, "approved_by_target": false,
+            "outbound_policy": null, "inbound_policy": null
+        }}
+    }))
+    .expect("EstablishToolInterface action deserializes");
+
+    let sk_alice = signing_key_for_did(&alice());
+    let result = manager
+        .propose_governance_action(ctx_id, &alice(), action, &sk_alice)
+        .await;
+    assert!(
+        result.is_err(),
+        "an out-of-ceiling EstablishToolInterface (tool:interface not in ceiling) MUST be \
+         rejected by native — the convergent reject the WASM bridge must match (§9.9.3; ADR-031 §8)"
+    );
+
+    let ctx_bytes = scp_protocol::context::context_id_bytes(ctx_id);
+    let entries = manager
+        .event_log_entries(&ctx_bytes)
+        .unwrap()
+        .expect("event log must exist for an active context");
+    let executed = entries
+        .iter()
+        .filter(|e| e.event_type == scp_event_log::EventType::GovernanceActionExecuted)
+        .count();
+    assert_eq!(
+        executed, 0,
+        "a rejected out-of-ceiling EstablishToolInterface MUST mint ZERO GovernanceActionExecuted \
+         leaves on native"
+    );
+}
+
+// =========================================================================
 // AC-5: Unanimity — all members approve -> execute
 // =========================================================================
 


### PR DESCRIPTION
Two commits making event-log leaf `actor_did` consistent across the native (scp-runtime) and WASM (scp-ffi/wasm) bridges, plus a real WASM functional fix uncovered along the way.

## Commit 1 — system-leaf actor_did convergence (real §9.9.3 fix)
Native and WASM stamped different `actor_did` on the same system leaves → different leaf hash → divergent Merkle root at equal event count in a mixed native+WASM context. Align WASM up to native's descriptive sentinels:
- `ContextExpired`: WASM `""` → `"system:timer"`.
- `ContextClosed`: WASM `"system"` → `"system:close"`.
- Native hygiene: `CrossContextDivergenceMarker` `""` → `"system:saga"` (native-only leaf).
- Fix a misleading WASM clamp doc-comment (names exactly which timestamps are clamped; creation/TTL are not).

## Commit 2 — WASM quorum-execute fix + ADR-031 executor attribution (NOT a convergence fix)
Investigating the governance-leaf actor surfaced that the original "actor_did divergence" premise was false (both bridges stamped the proposer, which is convergent). The real findings:
1. **WASM functional bug:** quorum-approved governance execution removed the proposal from `pending` *before* calling `execute_governance_action`, whose convergent-timestamp guard requires the proposal in `pending`-or-`resolved` — so it errored ("not tracked") and **never minted the `GovernanceActionExecuted` leaf**. Reorder to mark the proposal resolved before execute.
2. **ADR-031 attribution:** `GovernanceActionExecuted.actor_did` is now the **executor/committer** (ADR-031 `executor_did`; the proposer is recorded on the separate `GovernanceProposalCreated` leaf), on both bridges — quorum-crossing voter, or the proposer on auto-execute.

## Carved out (tracked separately, NOT in this PR)
- Consequence-subject divergence (native proposer vs WASM executor): #205.
- WASM per-action governance leaf count parity: #206.

Native↔WASM leaf-byte/root parity KATs added for both the system sentinels and the `GovernanceActionExecuted` executor stamping (with non-vacuity controls).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
