### PR TITLE
ci(sdk-coverage): make the capability-coverage gate fail-closed

### DIFF
--- a/.docs/lessons/coverage-gates-must-fail-closed.md
+++ b/.docs/lessons/coverage-gates-must-fail-closed.md
@@ -8,8 +8,10 @@
 A capability/coverage gate that only **warns** when a matrix says "supported" but no
 implementing symbol can be found is not enforcement — it is a suggestion. Real parity
 gaps survive a warning. A coverage gate MUST exit non-zero unless, for every cell the
-matrix marks `true`, it finds **either** a statically verified implementing symbol **or**
-a reasoned, provenance-citing exemption.
+matrix marks `true`, it finds **either** a statically verified symbol **of the expected
+name** **or** a reasoned, provenance-citing exemption. (Name existence, not implementation:
+the gate confirms a symbol of the expected name exists, not that it implements the
+operation — several aliases map multiple matrix ops to one shared dispatcher symbol.)
 
 A coverage gate MUST NOT match symbols by suffix or substring. Loose matching admits
 fabricated names: a cell can claim an operation that does not exist and still "pass"

--- a/.docs/lessons/coverage-gates-must-fail-closed.md
+++ b/.docs/lessons/coverage-gates-must-fail-closed.md
@@ -1,0 +1,67 @@
+# Coverage Gates Must Fail Closed, and Must Not Match Symbols by Suffix/Substring
+
+**Date:** 2026-06-20
+**Source:** branch `fix/sdk-coverage-fail-closed-and-parity` — rewrite of `scripts/check-sdk-coverage.py`
+
+## The Rule
+
+A capability/coverage gate that only **warns** when a matrix says "supported" but no
+implementing symbol can be found is not enforcement — it is a suggestion. Real parity
+gaps survive a warning. A coverage gate MUST exit non-zero unless, for every cell the
+matrix marks `true`, it finds **either** a statically verified implementing symbol **or**
+a reasoned, provenance-citing exemption.
+
+A coverage gate MUST NOT match symbols by suffix or substring. Loose matching admits
+fabricated names: a cell can claim an operation that does not exist and still "pass"
+because some unrelated symbol happens to end with the same suffix.
+
+## Context
+
+The original `check-sdk-coverage.py` had two latent failures that let cross-SDK parity
+gaps (TypeScript identity-lifecycle methods, Python economy/discovery functions) ship
+undetected:
+
+1. **Warn-only on unmatched `true` cells.** A matrix cell marked `true` for an SDK that
+   had no implementing symbol produced a WARNING and a passing exit code. This is exactly
+   why TS parity gaps survived — the gate "passed" while the capability was absent.
+
+2. **Suffix/substring symbol matching.** The extractor matched a matrix operation against
+   any SDK symbol sharing a suffix. ~23 fabricated/non-existent operation names passed the
+   gate via suffix collision with real-but-unrelated symbols.
+
+## The Fix
+
+- **Fail-closed flip:** a `true` cell with no verified symbol **and** no
+  `coverage_exemptions[sdk]` entry → ERROR, exit 1 (was WARN/pass).
+- **Exact symbol verification:** removed suffix/substring matching. A match requires a
+  verified symbol from the `ALIASES` whitelist (extracted via tree-sitter, not raw text).
+- **`coverage_exemptions` escape hatch:** a per-SDK keyed map carrying a reason for cells
+  that are genuinely present but not statically matchable (e.g. Kotlin `addRelay` lives
+  only in the generated, non-git-tracked UniFFI binding whose backtick-quoted,
+  `@Throws`-annotated override methods the tree-sitter-kotlin grammar won't surface as
+  clean `function_declaration` nodes). Every exemption must cite durable provenance
+  (ADR / spec § / generated-file path + verification command).
+- **All-exempted guard:** at least one SDK per operation must be statically verified — an
+  operation cannot be exempted across the board (that would re-open the warn-only hole).
+- **Gate self-tests:** `scripts/test_check_sdk_coverage.py` negative-tests the gate itself
+  (strip an exemption OR fabricate a `true` op → both must exit 1). CI runs the self-tests
+  **before** the gate, so the extractor's own null-safety is guarded.
+- `scripts/check-sdk-coverage.py` added to the CLAUDE.md "NEVER modify enforcement files"
+  list — it is now load-bearing.
+
+## The Lesson
+
+When you add or rewrite a coverage/capability gate, design it closed by construction:
+
+1. Default verdict is FAIL. A cell passes only by producing a verified symbol or a
+   provenance-citing exemption. Never let "couldn't find it" resolve to "probably fine."
+2. Match exactly (whitelist of permitted symbols), never by suffix/substring — loose
+   matching lets fabricated capability claims slip through.
+3. Give the gate negative self-tests and run them in CI before the gate, so a regression
+   in the extractor can't silently weaken the gate to warn-only.
+4. Exemptions are not free passes: each must cite an ADR, spec section, or a generated
+   artifact path plus the command to verify it. An all-SDK exemption is itself a finding.
+
+See also `.docs/lessons/enforcement-wiring-gap.md` (enforcement helpers must be *called*,
+not just defined) and `.docs/lessons/ast-gate-checks-definition-not-name-resolution.md`
+(positive whitelist over open denylist).

--- a/.docs/standards/sdk-capability-matrix.json
+++ b/.docs/standards/sdk-capability-matrix.json
@@ -28,12 +28,13 @@
         {
           "name": "rotate_key",
           "python": true,
-          "typescript": true,
+          "typescript": false,
           "kotlin": false,
           "swift": false,
           "exemptions": {
-            "kotlin": "UniFFI bridge does not export rotate_key",
-            "swift": "UniFFI bridge does not export rotate_key"
+            "typescript": "Bridge plumbing exists (internal/native.ts, internal/wasm.ts identity_rotate_key) but no public SDK wrapper on the Identity class yet; the named public rotateKey() wrapper lands in the SDK-parity PR carved from the same bundled branch.",
+            "kotlin": "UniFFI bridge exports rotate_key; Kotlin SDK has no idiomatic wrapper exposing it yet",
+            "swift": "UniFFI bridge exports rotate_key (ScpBindings.swift open func rotateKey()); no public SDK wrapper written yet"
           }
         },
         {
@@ -53,23 +54,32 @@
         {
           "name": "add_agent_key",
           "python": true,
-          "typescript": true,
+          "typescript": false,
           "kotlin": true,
-          "swift": true
+          "swift": true,
+          "exemptions": {
+            "typescript": "Bridge plumbing exists (internal/native.ts addAgentKey, internal/wasm.ts identity_add_agent_key) but no public SDK wrapper on the Identity class yet; the named public addAgentKey() wrapper lands in the SDK-parity PR carved from the same bundled branch."
+          }
         },
         {
           "name": "rotate_agent_key",
           "python": true,
-          "typescript": true,
+          "typescript": false,
           "kotlin": true,
-          "swift": true
+          "swift": true,
+          "exemptions": {
+            "typescript": "Bridge plumbing exists (internal/native.ts rotateAgentKey) but no public SDK wrapper on the Identity class yet; the named public rotateAgentKey() wrapper lands in the SDK-parity PR carved from the same bundled branch."
+          }
         },
         {
           "name": "remove_agent_key",
           "python": true,
-          "typescript": true,
+          "typescript": false,
           "kotlin": true,
-          "swift": true
+          "swift": true,
+          "exemptions": {
+            "typescript": "Bridge plumbing exists (internal/native.ts removeAgentKey) but no public SDK wrapper on the Identity class yet; the named public removeAgentKey() wrapper lands in the SDK-parity PR carved from the same bundled branch."
+          }
         },
         {
           "name": "identity_remove",
@@ -90,9 +100,12 @@
         {
           "name": "migrate",
           "python": true,
-          "typescript": true,
+          "typescript": false,
           "kotlin": true,
-          "swift": true
+          "swift": true,
+          "exemptions": {
+            "typescript": "Bridge plumbing exists (internal/native.ts migrate, internal/wasm.ts identity_migrate) but no public SDK wrapper on the Identity class yet; the named public migrate() wrapper lands in the SDK-parity PR carved from the same bundled branch."
+          }
         },
         {
           "name": "resume_migration_publish",
@@ -622,10 +635,11 @@
         {
           "name": "evaluate_trust",
           "python": true,
-          "typescript": true,
+          "typescript": false,
           "kotlin": false,
           "swift": true,
           "exemptions": {
+            "typescript": "The public TS surface exposes verifyParticipationRequirements (scp.ts), not a named evaluateTrust wrapper; the named evaluateTrust() sugar lands in the SDK-parity PR carved from the same bundled branch.",
             "kotlin": "SDK does not expose evaluate_trust wrapper, only aggregate_trust_input"
           }
         },
@@ -1144,10 +1158,13 @@
         },
         {
           "name": "discover",
-          "python": true,
+          "python": false,
           "typescript": true,
           "kotlin": true,
-          "swift": true
+          "swift": true,
+          "exemptions": {
+            "python": "discovery.py exposes parse_address / create_query / normalize_address only; no named discover / discover_contexts / context_discover public function yet. The Python discovery wrapper lands in the SDK-parity PR carved from the same bundled branch."
+          }
         },
         {
           "name": "address_resolve",
@@ -1399,11 +1416,14 @@
         },
         {
           "name": "verify_payment_receipts",
-          "python": true,
+          "python": false,
           "typescript": true,
           "kotlin": true,
           "swift": true,
-          "notes": "Verifies payment receipts against the configured runtime payment adapter (verify_dyn per receipt) via EconomyCommand::VerifyPaymentReceipts. Implemented in pyo3/napi/uniffi + Python/TypeScript/Kotlin/Swift SDKs. WASM cannot link the async runtime payment adapter (ADR-034); the TS WASM bridge surfaces a fail-closed throw (SCP-ECON-12095)."
+          "notes": "Verifies payment receipts against the configured runtime payment adapter (verify_dyn per receipt) via EconomyCommand::VerifyPaymentReceipts. Implemented in pyo3/napi/uniffi + TypeScript/Kotlin/Swift SDKs. WASM cannot link the async runtime payment adapter (ADR-034); the TS WASM bridge surfaces a fail-closed throw (SCP-ECON-12095).",
+          "exemptions": {
+            "python": "economy.py exposes estimate_cost / policy helpers / evaluate_formula only; no named verify_payment_receipts public function yet. The Python verify_payment_receipts wrapper lands in the SDK-parity PR carved from the same bundled branch."
+          }
         },
         {
           "name": "enforce_economy_send_path",
@@ -1738,16 +1758,22 @@
         {
           "name": "register",
           "python": true,
-          "typescript": true,
+          "typescript": false,
           "kotlin": true,
-          "swift": true
+          "swift": true,
+          "exemptions": {
+            "typescript": "bridge_register is an internal Bridge interface method (bridgeRegister on the internal Bridge interface in bindings/typescript/src/internal/bridge.ts); it is not exposed as a named public SDK function — registration is handled at the FFI layer directly via the NAPI addon"
+          }
         },
         {
           "name": "evaluate_trust",
           "python": true,
-          "typescript": true,
+          "typescript": false,
           "kotlin": true,
-          "swift": true
+          "swift": true,
+          "exemptions": {
+            "typescript": "The public TS surface exposes verifyParticipationRequirements (scp.ts), not a named evaluateTrust wrapper; the named evaluateTrust() sugar lands in the SDK-parity PR carved from the same bundled branch."
+          }
         },
         {
           "name": "create_shadow",
@@ -1939,7 +1965,8 @@
          "exemptions": {}},
         {"name": "add_relay_url", "python": true, "typescript": true, "kotlin": true, "swift": true,
          "notes": "CoreFields::relay_url (Mutex<Option<String>>) replaced with relay_urls (Mutex<HashSet<String>>) in Phase 4 PR 3 (#1678, 2026-04-18). New accessors add_relay_url / remove_relay_url / pending_relay_urls; each per-bridge resume() iterates the HashSet and reconnects each URL. First reconnect failure surfaces as LifecycleError::ReconnectFailed { url, reason }; successfully-connected URLs remain in the pending set for retry.",
-         "exemptions": {}}
+         "exemptions": {},
+         "coverage_exemptions": {"kotlin": "Present in the UniFFI bridge as `addRelay` (generated from `crates/scp-ffi/uniffi/src/bridge.rs` \u2014 the `add_relay_url` export in TransportManager). The generated Kotlin file (`works.limn.scp.internal.uniffi.scp.TransportManager.addRelay`) is not git-tracked; verify via `cargo build -p scp-ffi-uniffi`. The generated file's backtick-quoted, @Throws-annotated override methods are not surfaced as clean function_declaration nodes by the tree-sitter-kotlin grammar the coverage extractor uses, so the symbol cannot be statically matched."}}
       ]
     }
   ],

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -142,6 +142,8 @@ jobs:
       # Other tree-sitter grammars remain unpinned to match the convention
       # used by the protocol-sync job below and minimize churn.
       - run: pip install 'pytest>=8,<10' 'tree-sitter-rust>=0.21,<0.25' tree-sitter tree-sitter-python tree-sitter-typescript tree-sitter-kotlin tree-sitter-swift
+      - name: Gate self-tests (extractor null-safety)
+        run: python3.12 -m pytest scripts/test_check_sdk_coverage.py -v
       - run: python3.12 scripts/check-sdk-coverage.py
       - run: python3.12 scripts/check-call-invariants.py
       - name: cfg-walker unit tests (regression guard for MAJOR-1/MINOR-1/MINOR-2)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -108,6 +108,7 @@ If any cell is empty, the plan is incomplete — expand scope or file dependent 
 
 **NEVER modify enforcement files to bypass failures.**
 Files: pipeline_wiring.rs, ffi_conformance.rs, sdk-capability-matrix.json,
+scripts/check-sdk-coverage.py,
 check-cross-layer.sh, check-protocol-deps.sh, check-protocol-sync.py,
 check-no-bridge-globals.sh, check-no-fallback-registry.sh,
 check-handle-affinity.sh, check_ready_coverage.rs (per-instance handle

--- a/scripts/check-sdk-coverage.py
+++ b/scripts/check-sdk-coverage.py
@@ -1551,8 +1551,30 @@ def main() -> int:
     expected_sdks = frozenset(sdks)
 
     for domain_entry in matrix.get("capabilities", []):
+        if not isinstance(domain_entry, dict):
+            print(
+                f"  ERROR: capabilities entry must be an object, "
+                f"got {type(domain_entry).__name__}."
+            )
+            errors += 1
+            continue
         domain = domain_entry.get("domain", "?")
-        for op in domain_entry.get("operations", []):
+        operations = domain_entry.get("operations", [])
+        if not isinstance(operations, list):
+            print(
+                f"  ERROR: {domain}: 'operations' must be an array, "
+                f"got {type(operations).__name__}."
+            )
+            errors += 1
+            continue
+        for op in operations:
+            if not isinstance(op, dict):
+                print(
+                    f"  ERROR: {domain}: operation entry must be an object, "
+                    f"got {type(op).__name__}."
+                )
+                errors += 1
+                continue
             op_name = op.get("name", "?")
             total_ops += 1
 

--- a/scripts/check-sdk-coverage.py
+++ b/scripts/check-sdk-coverage.py
@@ -2,10 +2,15 @@
 """check-sdk-coverage.py -- CI gate enforcing SDK capability matrix conformance.
 
 Reads `.docs/standards/sdk-capability-matrix.json` and validates:
-  1. Every entry marked `true` has a matching symbol name in the SDK source.
-     (Semantic correctness — that the symbol implements the capability — is a
+  1. Every entry marked `true` has a symbol of the expected name in the SDK
+     source. This is a NAME-EXISTENCE check only: it confirms a symbol with the
+     expected (or aliased) name exists — NOT that the symbol implements the
+     operation. Several aliases deliberately map multiple matrix operations to
+     one shared dispatcher symbol (e.g. governance `execute_*` ->
+     `executeGovernanceAction`), so a single symbol can satisfy many cells.
+     Semantic correctness — that the symbol implements the capability — is a
      human-review invariant enforced by code review of the enforcement-labeled
-     files, not by this gate.)
+     files, not by this gate.
   2. Every entry marked `false` has an `exemptions` entry with a reason.
 
 Detection strategy per SDK (AST-based via tree-sitter):
@@ -87,6 +92,17 @@ SDK_EXTENSIONS: dict[str, str] = {
 # Every entry has been verified against actual SDK source: the named symbol
 # exists (name-existence check). Semantic correctness is a human-review
 # invariant; the gate cannot verify that a symbol implements the capability.
+#
+# Why bare-named ops (no domain prefix in the matrix name) need explicit
+# entries: the matcher intentionally dropped the bare-`op_name` candidate to
+# close the suffix-collision hole (an unrelated `migrate` helper anywhere in
+# the codebase used to satisfy `Identity/migrate`). It now only auto-generates
+# DOMAIN-PREFIXED candidates. So any op whose real SDK symbol equals its bare
+# matrix name — or already carries its own sub-domain prefix in the matrix name
+# (e.g. `scpid_*`, `identity_remove`, `relay_start_in_memory`) — has no
+# auto-generated candidate that matches and MUST have an explicit alias here.
+# Do NOT "simplify" by deleting these entries: removing one re-opens a
+# fail-closed gap for that op.
 ALIASES: dict[tuple[str, str], dict[str, list[str]]] = {
     # Identity attestations carry the "Link" infix across all SDKs.
     ("Identity", "create_attestation"): {
@@ -962,8 +978,12 @@ ALIASES: dict[tuple[str, str], dict[str, list[str]]] = {
 
 
 def _node_text(node: "Node") -> str:
-    """Return the decoded text of a tree-sitter node, or '' if None."""
-    return (node.text or b"").decode("utf-8")
+    """Return the decoded text of a tree-sitter node, or '' if None.
+
+    Decodes with errors="replace" so an identifier node containing invalid
+    UTF-8 cannot raise and abort the whole run.
+    """
+    return (node.text or b"").decode("utf-8", "replace")
 
 
 # ---------------------------------------------------------------------------
@@ -1414,8 +1434,14 @@ def _collect_sdk_symbols(sdk: str) -> set[str]:
         except OSError:
             continue
 
-        tree = parser.parse(source)
-        file_symbols = extractor(tree.root_node)
+        # Parsing and extraction are wrapped too: a single unparseable file
+        # (grammar quirk, malformed source) must skip that file, not abort the
+        # whole run and silently weaken the gate to "no symbols extracted".
+        try:
+            tree = parser.parse(source)
+            file_symbols = extractor(tree.root_node)
+        except Exception:  # noqa: BLE001 - per-file robustness; skip and continue
+            continue
         all_symbols.update(file_symbols)
 
     return all_symbols
@@ -1429,8 +1455,8 @@ def _collect_sdk_symbols(sdk: str) -> set[str]:
 def _check_operation_in_sdk(
     sdk_symbols: set[str], sdk: str, domain: str, op_name: str
 ) -> bool:
-    """Check whether the SDK's extracted symbols contain code for this
-    operation.
+    """Check whether the SDK's extracted symbols contain a symbol of the
+    expected name for this operation.
 
     Strategy (in order):
       1. Explicit aliases from the ALIASES table
@@ -1491,8 +1517,21 @@ def main() -> int:
         print(f"FAIL: Matrix file not found: {MATRIX_PATH}", file=sys.stderr)
         return 1
 
-    with open(MATRIX_PATH, encoding="utf-8") as f:
-        matrix = json.load(f)
+    try:
+        with open(MATRIX_PATH, encoding="utf-8") as f:
+            matrix = json.load(f)
+    except (json.JSONDecodeError, OSError) as e:
+        print(f"FAIL: could not parse matrix {MATRIX_PATH}: {e}", file=sys.stderr)
+        return 1
+
+    # Validate matrix shape before touching it. A malformed top-level shape
+    # must produce a clean diagnostic and exit 1 — never an uncaught traceback.
+    if not isinstance(matrix, dict) or not isinstance(matrix.get("capabilities"), list):
+        print(
+            "FAIL: matrix must be an object with a 'capabilities' array.",
+            file=sys.stderr,
+        )
+        return 1
 
     # Pre-extract all SDK symbols via tree-sitter
     sdk_symbols: dict[str, set[str]] = {}
@@ -1534,6 +1573,25 @@ def main() -> int:
 
             exemptions = op.get("exemptions", {})
             coverage_exemptions = op.get("coverage_exemptions", {})
+
+            # Guard against malformed exemption blocks: a non-dict value would
+            # make the .items()/membership accesses below raise. Emit a clean
+            # ERROR and treat the block as empty (fail-closed: missing
+            # exemptions then surface as their own errors downstream).
+            if not isinstance(exemptions, dict):
+                print(
+                    f"  ERROR: {domain}/{op_name}: 'exemptions' must be an object, "
+                    f"got {type(exemptions).__name__}."
+                )
+                errors += 1
+                exemptions = {}
+            if not isinstance(coverage_exemptions, dict):
+                print(
+                    f"  ERROR: {domain}/{op_name}: 'coverage_exemptions' must be an "
+                    f"object, got {type(coverage_exemptions).__name__}."
+                )
+                errors += 1
+                coverage_exemptions = {}
 
             # Track per-op coverage state for the all-exempted check below.
             op_true_sdks: list[str] = []

--- a/scripts/check-sdk-coverage.py
+++ b/scripts/check-sdk-coverage.py
@@ -2,7 +2,10 @@
 """check-sdk-coverage.py -- CI gate enforcing SDK capability matrix conformance.
 
 Reads `.docs/standards/sdk-capability-matrix.json` and validates:
-  1. Every entry marked `true` has corresponding code in the SDK source.
+  1. Every entry marked `true` has a matching symbol name in the SDK source.
+     (Semantic correctness — that the symbol implements the capability — is a
+     human-review invariant enforced by code review of the enforcement-labeled
+     files, not by this gate.)
   2. Every entry marked `false` has an `exemptions` entry with a reason.
 
 Detection strategy per SDK (AST-based via tree-sitter):
@@ -11,7 +14,14 @@ Detection strategy per SDK (AST-based via tree-sitter):
   - Kotlin:      public class/function declarations in bindings/kotlin/scp-kt/src/main/kotlin/**/*.kt
   - Swift:       public func/class/struct/actor/extension in bindings/swift/Sources/SCP/**/*.swift
 
-Exit 0 if all checks pass, 1 if any `false` entry lacks an exemption.
+Exit 0 if all checks pass. Exit 1 if any of: required tree-sitter
+grammar is not installed (ImportError at startup), matrix file not
+found, `true` entry has no matching symbol and no coverage exemption,
+`false` entry lacks an exemption or has an empty exemption reason, a
+coverage_exemptions entry has a blank reason, a cell value is not
+true/false/null, an expected SDK key is absent from an operation entry,
+or every SDK claiming coverage for an operation is coverage-exempted
+with no statically-verified implementation.
 
 Usage: python3.12 scripts/check-sdk-coverage.py
 
@@ -74,31 +84,33 @@ SDK_EXTENSIONS: dict[str, str] = {
 
 # Explicit alias table: (domain, operation) -> {sdk: [search_strings]}
 # Only needed when the auto-generated patterns fail to match the actual code.
+# Every entry has been verified against actual SDK source: the named symbol
+# exists (name-existence check). Semantic correctness is a human-review
+# invariant; the gate cannot verify that a symbol implements the capability.
 ALIASES: dict[tuple[str, str], dict[str, list[str]]] = {
-    # Identity attestations use different names across SDKs
+    # Identity attestations carry the "Link" infix across all SDKs.
     ("Identity", "create_attestation"): {
+        "python": ["create_identity_link_attestation"],
+        "typescript": ["identityCreateLinkAttestation"],
         "kotlin": ["createLinkAttestation"],
-        "swift": ["createIdentityAttestation"],
+        "swift": ["identityCreateLinkAttestation", "createLinkAttestation"],
     },
     ("Identity", "list_attestations"): {
+        "python": ["identity_link_attestations"],
+        "typescript": ["identityLinkAttestations"],
         "kotlin": ["linkAttestations"],
-        "swift": ["listIdentityAttestations"],
+        "swift": ["identityLinkAttestations", "listLinkAttestations"],
     },
     ("Identity", "remove_attestation"): {
+        "python": ["remove_identity_link_attestation"],
+        "typescript": ["identityRemoveLinkAttestation"],
         "kotlin": ["removeLinkAttestation"],
-        "swift": ["removeIdentityAttestation"],
+        "swift": ["identityRemoveLinkAttestation"],
     },
-    # Note: renew_attestation is missing from TypeScript SDK entirely.
-    # The matrix should mark it false with exemption, not alias it.
     ("Identity", "verify_attestation"): {
         "kotlin": ["verifyLinkAttestation"],
     },
     # Context validation helpers
-    ("Context", "validate_params"): {
-        "python": ["validate_context_params"],
-        "typescript": ["validateContextParams"],
-        "kotlin": ["validateContextParams"],
-    },
     ("Context", "metadata_record_serialize"): {
         "python": ["metadata_record_to_json"],
         "typescript": ["metadataRecordToJson"],
@@ -113,15 +125,16 @@ ALIASES: dict[tuple[str, str], dict[str, list[str]]] = {
     },
     # Messaging -- send_message maps to send() or contextSend() depending on SDK
     ("Messaging", "send_message"): {
-        "python": ["send"],
-        "typescript": ["send"],
+        "python": ["send", "context_send"],
+        "typescript": ["send", "contextSend"],
         "kotlin": ["contextSend"],
         "swift": ["send"],
     },
     # Messaging -- subscribe maps to receive() or contextSubscribe()
     ("Messaging", "subscribe"): {
-        "python": ["receive"],
-        "typescript": ["receive"],
+        "python": ["receive", "context_receive"],
+        "typescript": ["receive", "contextSubscribe"],
+        "kotlin": ["subscribe"],
     },
     # Messaging -- validate_broadcast_key has _hex suffix in some SDKs
     ("Messaging", "validate_broadcast_key"): {
@@ -130,109 +143,171 @@ ALIASES: dict[tuple[str, str], dict[str, list[str]]] = {
         "kotlin": ["validateBroadcastKeyHex"],
         "swift": ["validateBroadcastKeyHex"],
     },
-    # Tools -- TypeScript uses domain-prefixed naming
-    ("Tools", "register"): {
-        "typescript": ["registerTool"],
-    },
-    ("Tools", "invoke"): {
-        "python": ["invoke"],
-        "typescript": ["invokeTool"],
-    },
-    ("Tools", "verify"): {
-        "python": ["verify"],
-        "typescript": ["verifyTool"],
-    },
-    ("Tools", "invoke_cross_context"): {
-        "typescript": ["toolInvokeCrossContext"],
-        "swift": ["toolInvokeCrossContext"],
-    },
-    ("Tools", "session_create"): {
-        "typescript": ["toolSessionCreate"],
-        "swift": ["toolSessionCreate"],
-    },
-    ("Tools", "session_invoke"): {
-        "typescript": ["toolSessionInvoke"],
-        "swift": ["toolSessionInvoke"],
-    },
-    ("Tools", "session_close"): {
-        "typescript": ["toolSessionClose"],
-        "swift": ["toolSessionClose"],
-    },
-    ("Tools", "interface_expose"): {
-        "typescript": ["exposeToolInterface"],
-        "swift": ["exposeToolInterface"],
-    },
-    ("Tools", "interface_accept"): {
-        "typescript": ["acceptToolInterface"],
-        "swift": ["acceptToolInterface"],
-    },
-    ("Tools", "interface_revoke"): {
-        "typescript": ["revokeToolInterface"],
-        "swift": ["revokeToolInterface"],
-    },
-    # Governance -- uses different naming in all SDKs
+    # Governance -- uses different naming in all SDKs.
+    # Per-action variants dispatch through one generic method; there is no
+    # per-variant symbol in any SDK (Python reference included).
     ("Governance", "execute_action"): {
-        "python": ["execute_governance_action"],
-        "typescript": ["executeGovernanceAction"],
+        "python": ["execute_governance_action", "governance_execute"],
+        "typescript": ["executeGovernanceAction", "contextExecuteGovernanceAction"],
         "kotlin": ["governanceExecute"],
         "swift": ["executeGovernanceAction"],
     },
     ("Governance", "propose_action"): {
-        "python": ["propose_governance_action"],
-        "typescript": ["proposeGovernanceAction"],
+        "python": ["propose_governance_action", "governance_propose"],
+        "typescript": ["proposeGovernanceAction", "contextGovernancePropose"],
         "kotlin": ["governancePropose"],
         "swift": ["proposeGovernanceAction"],
     },
     ("Governance", "approve_proposal"): {
-        "python": ["approve_governance_proposal"],
-        "typescript": ["approveGovernanceProposal"],
+        "python": ["approve_governance_proposal", "governance_approve"],
+        "typescript": ["approveGovernanceProposal", "contextGovernanceApprove"],
         "kotlin": ["governanceApprove"],
         "swift": ["approveGovernanceProposal"],
     },
     ("Governance", "reject_proposal"): {
-        "python": ["reject_governance_proposal"],
-        "typescript": ["rejectGovernanceProposal"],
+        "python": ["reject_governance_proposal", "governance_reject"],
+        "typescript": ["rejectGovernanceProposal", "contextGovernanceReject"],
         "kotlin": ["governanceReject"],
         "swift": ["rejectGovernanceProposal"],
     },
     ("Governance", "withdraw_vote"): {
-        "python": ["withdraw_governance_vote"],
-        "typescript": ["withdrawGovernanceVote"],
+        "python": ["withdraw_governance_vote", "governance_withdraw"],
+        "typescript": ["withdrawGovernanceVote", "contextGovernanceWithdraw"],
         "kotlin": ["governanceWithdraw"],
         "swift": ["withdrawGovernanceVote"],
     },
     ("Governance", "get_proposal"): {
         "python": ["get_governance_proposal"],
-        "typescript": ["getGovernanceProposal"],
+        "typescript": ["contextGovernanceGetProposal"],
     },
     ("Governance", "list_proposals"): {
         "python": ["list_governance_proposals"],
-        "typescript": ["listGovernanceProposals"],
+        "typescript": ["contextGovernanceListProposals"],
+    },
+    ("Governance", "apply_pending_ceiling_modification"): {
+        "python": ["apply_pending_ceiling_modification"],
+        "typescript": ["contextApplyPendingCeilingModification"],
+        "kotlin": ["applyPendingCeilingModification"],
+        "swift": ["applyPendingCeilingModification"],
+    },
+    ("Governance", "finalize_close"): {
+        "python": ["finalize_close"],
+        "typescript": ["contextFinalizeClose"],
+        "kotlin": ["finalizeClose"],
+        "swift": ["finalizeClose"],
+    },
+    ("Governance", "create_governance_checkpoint"): {
+        "python": ["create_governance_checkpoint"],
+        "typescript": ["contextCreateGovernanceCheckpoint"],
+        "kotlin": ["createGovernanceCheckpoint"],
+        "swift": ["createGovernanceCheckpoint"],
+    },
+    ("Governance", "add_checkpoint_cosignature"): {
+        "python": ["add_checkpoint_cosignature"],
+        "typescript": ["contextAddCheckpointCosignature"],
+        "kotlin": ["addCheckpointCosignature"],
+        "swift": ["addCheckpointCosignature"],
     },
     ("Governance", "member_count"): {
-        "python": ["member_count"],
+        "python": ["member_count", "context_member_count"],
+        "typescript": ["contextMemberCount"],
+        "kotlin": ["memberCount"],
         "swift": ["memberCount"],
     },
     ("Governance", "is_member"): {
-        "python": ["is_member"],
+        "python": ["is_member", "context_is_member"],
+        "typescript": ["contextIsMember"],
+        "kotlin": ["isMember"],
         "swift": ["isMember"],
     },
     ("Governance", "member_role"): {
+        "python": ["context_member_role"],
+        "typescript": ["contextMemberRole"],
+        "kotlin": ["memberRole"],
         "swift": ["memberRole"],
     },
-    # EventLog
+    # Governance rows whose method lives under context_* in Python / TypeScript.
+    ("Governance", "handle_ttl_expiry"): {
+        "python": ["context_handle_ttl_expiry"],
+        "typescript": ["contextHandleTtlExpiry"],
+        "swift": ["handleTtlExpiry"],
+    },
+    ("Governance", "propose_ttl_extension"): {
+        "python": ["context_propose_ttl_extension"],
+        "typescript": ["contextProposeTtlExtension"],
+        "swift": ["proposeTtlExtension"],
+    },
+    # Governance -- new GovernanceAction variants dispatched via the existing
+    # execute_action / propose_action entry points.
+    ("Governance", "execute_suspend_capability"): {
+        "python": ["execute_governance_action", "governance_execute"],
+        "typescript": ["executeGovernanceAction", "contextExecuteGovernanceAction"],
+        "kotlin": ["governanceExecute"],
+        "swift": ["executeGovernanceAction"],
+    },
+    ("Governance", "execute_suspend_access"): {
+        "python": ["execute_governance_action", "governance_execute"],
+        "typescript": ["executeGovernanceAction", "contextExecuteGovernanceAction"],
+        "kotlin": ["governanceExecute"],
+        "swift": ["executeGovernanceAction"],
+    },
+    ("Governance", "execute_revoke_access"): {
+        "python": ["execute_governance_action", "governance_execute"],
+        "typescript": ["executeGovernanceAction", "contextExecuteGovernanceAction"],
+        "kotlin": ["governanceExecute"],
+        "swift": ["executeGovernanceAction"],
+    },
+    ("Governance", "execute_restore_access"): {
+        "python": ["execute_governance_action", "governance_execute"],
+        "typescript": ["executeGovernanceAction", "contextExecuteGovernanceAction"],
+        "kotlin": ["governanceExecute"],
+        "swift": ["executeGovernanceAction"],
+    },
+    ("Governance", "execute_remove_member"): {
+        "python": ["execute_governance_action", "governance_execute"],
+        "typescript": ["executeGovernanceAction", "contextExecuteGovernanceAction"],
+        "kotlin": ["governanceExecute"],
+        "swift": ["executeGovernanceAction"],
+    },
+    ("Governance", "execute_rotate_content_keys"): {
+        "python": ["execute_governance_action", "governance_execute"],
+        "typescript": ["executeGovernanceAction", "contextExecuteGovernanceAction"],
+        "kotlin": ["governanceExecute"],
+        "swift": ["executeGovernanceAction"],
+    },
+    ("Governance", "propose_governance_action_checked"): {
+        "python": ["propose_governance_action", "governance_propose"],
+        "typescript": ["proposeGovernanceAction", "contextGovernancePropose"],
+        "kotlin": ["governancePropose"],
+        "swift": ["proposeGovernanceAction"],
+    },
+    # EventLog — all operations live on the SCP class under eventLog* prefix in TS
     ("EventLog", "query"): {
-        "python": ["query"],
+        "python": ["event_log_query"],
+        "typescript": ["eventLogQuery"],
         "kotlin": ["eventLogQuery"],
     },
     ("EventLog", "verify"): {
-        "python": ["verify"],
+        "python": ["event_log_verify"],
+        "typescript": ["eventLogVerify"],
+        "kotlin": ["verify"],
+        "swift": ["verify"],
     },
     ("EventLog", "checkpoint"): {
+        "python": ["Checkpoint"],
+        "typescript": ["eventLogCheckpoint"],
         "kotlin": ["eventLogCheckpoint"],
+        "swift": ["Checkpoint"],
+    },
+    ("EventLog", "checkpoint_by_did"): {
+        "python": ["event_log_checkpoint_by_did"],
+        "typescript": ["eventLogCheckpointByDid"],
+        "kotlin": ["eventLogCheckpointByDid"],
+        "swift": ["eventLogCheckpointByDid"],
     },
     ("EventLog", "signed_checkpoint"): {
-        "typescript": ["checkpoint"],
+        "python": ["SignedCheckpoint"],
+        "typescript": ["eventLogCheckpoint"],
         "kotlin": ["eventLogCheckpoint"],
         "swift": ["generateEventLogCheckpoint"],
     },
@@ -243,32 +318,52 @@ ALIASES: dict[tuple[str, str], dict[str, list[str]]] = {
     ("Transport", "status"): {
         "python": ["relay_status"],
     },
+    # configure_local_transport already carries partial domain prefix in the op
+    # name; the auto-generated domain_snake 'transport_configure_local_transport'
+    # is not what the SDKs expose.
+    ("Transport", "configure_local_transport"): {
+        "python": ["configure_local_transport"],
+        "typescript": ["configureLocalTransport"],
+        "kotlin": ["configureLocalTransport"],
+        "swift": ["configureLocalTransport"],
+    },
     # Media
     ("Media", "check_capability"): {
         "python": ["check_media_capability"],
     },
-    # Discovery
+    # Discovery -- discover is `discoverContexts` in TS, `discover` in Kotlin,
+    # and `contextDiscover` in Swift (generated UniFFI binding)
     ("Discovery", "discover"): {
+        "python": ["discover_contexts"],
         "typescript": ["discoverContexts"],
+        "kotlin": ["discover", "contextDiscover"],
+        "swift": ["contextDiscover"],
     },
     ("Discovery", "scope_register"): {
-        "swift": ["registerScope"],
+        "python": ["scope_register"],
+        "typescript": ["scopeRegister"],
+        "kotlin": ["scopeRegister"],
+        "swift": ["scopeRegister"],
     },
     ("Discovery", "scope_lookup"): {
-        "swift": ["lookupScope"],
+        "python": ["scope_lookup"],
+        "typescript": ["scopeLookup"],
+        "kotlin": ["scopeLookup"],
+        "swift": ["scopeLookup"],
     },
     ("Discovery", "scope_deregister"): {
-        "swift": ["deregisterScope"],
+        "python": ["scope_deregister"],
+        "typescript": ["scopeDeregister"],
+        "kotlin": ["scopeDeregister"],
+        "swift": ["scopeDeregister"],
     },
     # Sync
     ("Sync", "get_policy"): {
+        "python": ["get_policy"],
         "typescript": ["getSyncPolicy"],
     },
-    # Provenance
-    ("Provenance", "evaluate_quality"): {
-        "python": ["evaluate_provenance_quality"],
-        "typescript": ["evaluateProvenanceQuality"],
-        "swift": ["evaluateProvenanceQuality"],
+    ("Sync", "classify_offline"): {
+        "python": ["classify_offline"],
     },
     # UCAN -- TypeScript uses validateUcan/mintUcan/revokeUcan/delegateUcan
     ("UCAN", "validate"): {
@@ -286,79 +381,516 @@ ALIASES: dict[tuple[str, str], dict[str, list[str]]] = {
     # MCP
     ("MCP", "serve"): {
         "python": ["serve_mcp", "McpServer"],
+        "typescript": ["serve"],
+        "swift": ["serve"],
     },
     ("MCP", "connect_client"): {
         "python": ["McpClient"],
-        "typescript": ["connectMcp", "McpClient"],
-        "swift": ["McpClientHandle"],
+        "typescript": ["mcpClientConnectStdio", "mcpClientConnectSse"],
+        "swift": ["McpClient", "connect"],
     },
-    # Server -- methods live on Relay/Node classes
+    # Identity -- Swift uses bare method names without domain prefix
+    ("Identity", "add_agent_key"): {
+        "swift": ["addAgentKey"],
+    },
+    ("Identity", "rotate_agent_key"): {
+        "swift": ["rotateAgentKey"],
+    },
+    ("Identity", "remove_agent_key"): {
+        "swift": ["removeAgentKey"],
+    },
+    # Identity -- identity_remove / identity_remove_if_present already carry the
+    # domain prefix in the op name itself; the auto-generated domain_snake form
+    # would be 'identity_identity_remove' (double-prefix), so explicit aliases
+    # are required.
+    ("Identity", "identity_remove"): {
+        "python": ["identity_remove"],
+        "typescript": ["identityRemove"],
+        "kotlin": ["identityRemove"],
+        "swift": ["identityRemove"],
+    },
+    ("Identity", "identity_remove_if_present"): {
+        "python": ["identity_remove_if_present"],
+        "typescript": ["identityRemoveIfPresent"],
+        "kotlin": ["identityRemoveIfPresent"],
+        "swift": ["identityRemoveIfPresent"],
+    },
+    # Context -- bare method names used across SDKs
+    ("Context", "reconnect"): {
+        "python": ["reconnect"],
+        "typescript": ["reconnect"],
+        "kotlin": ["reconnect"],
+    },
+    ("Context", "set_economic_policy"): {
+        "python": ["set_economic_policy"],
+    },
+    ("Context", "get_economic_policy"): {
+        "python": ["get_economic_policy"],
+    },
+    ("Context", "validate_params"): {
+        "python": ["validate_context_params"],
+        "typescript": ["validateContextParams"],
+        "kotlin": ["validateContextParams"],
+        "swift": ["validateParams"],
+    },
+    ("Context", "validate_admission"): {
+        "python": ["validate_admission"],
+        "typescript": ["validateAdmission"],
+        "kotlin": ["validateAdmission"],
+        "swift": ["validateAdmission"],
+    },
+    ("Context", "evaluate_invitation"): {
+        "python": ["evaluate_invitation"],
+        "typescript": ["evaluateInvitation"],
+        "kotlin": ["evaluateInvitation"],
+        "swift": ["evaluateInvitation"],
+    },
+    ("Context", "validate_capability_declaration"): {
+        "python": ["validate_capability_declaration"],
+        "typescript": ["validateCapabilityDeclaration"],
+        "swift": ["validateCapabilityDeclaration"],
+    },
+    ("Context", "template_get_params"): {
+        "python": ["template_get_params"],
+        "typescript": ["templateGetParams"],
+        "kotlin": ["templateGetParams"],
+        "swift": ["templateGetParams"],
+    },
+    ("Context", "validate_against_template"): {
+        "python": ["validate_against_template"],
+        "typescript": ["validateAgainstTemplate"],
+        "kotlin": ["validateAgainstTemplate"],
+        "swift": ["validateAgainstTemplate"],
+    },
+    # Messaging -- broadcast operations use bare names in all SDKs
+    ("Messaging", "broadcast_subscribe"): {
+        "python": ["broadcast_subscribe"],
+        "typescript": ["broadcastSubscribe"],
+        "kotlin": ["broadcastSubscribe"],
+        "swift": ["broadcastSubscribe"],
+    },
+    ("Messaging", "broadcast_publish"): {
+        "python": ["broadcast_publish"],
+        "typescript": ["broadcastPublish"],
+        "kotlin": ["broadcastPublish"],
+        "swift": ["broadcastPublish"],
+    },
+    ("Messaging", "broadcast_publish_asset"): {
+        "python": ["broadcast_publish_asset"],
+        "typescript": ["broadcastPublishAsset"],
+        "kotlin": ["broadcastPublishAsset"],
+        "swift": ["broadcastPublishAsset"],
+    },
+    ("Messaging", "broadcast_publish_assets"): {
+        "python": ["broadcast_publish_assets"],
+        "typescript": ["broadcastPublishAssets"],
+        "kotlin": ["broadcastPublishAssets"],
+        "swift": ["broadcastPublishAssets"],
+    },
+    ("Messaging", "broadcast_block_subscriber"): {
+        "python": ["broadcast_block_subscriber"],
+        "typescript": ["broadcastBlockSubscriber"],
+        "kotlin": ["broadcastBlockSubscriber"],
+        "swift": ["broadcastBlockSubscriber"],
+    },
+    ("Messaging", "broadcast_unblock_subscriber"): {
+        "python": ["broadcast_unblock_subscriber"],
+        "typescript": ["broadcastUnblockSubscriber"],
+        "kotlin": ["broadcastUnblockSubscriber"],
+        "swift": ["broadcastUnblockSubscriber"],
+    },
+    ("Messaging", "broadcast_handle_key_request"): {
+        "python": ["broadcast_handle_key_request"],
+        "typescript": ["broadcastHandleKeyRequest"],
+        "kotlin": ["broadcastHandleKeyRequest"],
+        "swift": ["broadcastHandleKeyRequest"],
+    },
+    ("Messaging", "broadcast_open_key"): {
+        "python": ["broadcast_open_key"],
+        "typescript": ["broadcastOpenKey"],
+        "kotlin": ["broadcastOpenKey"],
+        "swift": ["broadcastOpenKey"],
+    },
+    # Tools -- Kotlin/Swift use bare method names without domain prefix
+    ("Tools", "register"): {
+        "python": ["tool_register"],
+        "typescript": ["toolRegister"],
+        "kotlin": ["register"],
+        "swift": ["register"],
+    },
+    ("Tools", "invoke"): {
+        "python": ["tool_invoke"],
+        "typescript": ["toolInvoke"],
+        "kotlin": ["invoke"],
+        "swift": ["invoke"],
+    },
+    ("Tools", "verify"): {
+        "python": ["tool_verify"],
+        "typescript": ["toolVerify"],
+        "kotlin": ["verify"],
+        "swift": ["verify"],
+    },
+    ("Tools", "invoke_cross_context"): {
+        "python": ["tool_invoke_cross_context"],
+        "typescript": ["toolInvokeCrossContext"],
+        "kotlin": ["invokeCrossContext"],
+        "swift": ["toolInvokeCrossContext"],
+    },
+    ("Tools", "session_create"): {
+        "python": ["tool_session_create"],
+        "typescript": ["toolSessionCreate"],
+        "kotlin": ["sessionCreate"],
+        "swift": ["toolSessionCreate"],
+    },
+    ("Tools", "session_invoke"): {
+        "python": ["tool_session_invoke"],
+        "typescript": ["toolSessionInvoke"],
+        "kotlin": ["sessionInvoke"],
+        "swift": ["toolSessionInvoke"],
+    },
+    ("Tools", "session_close"): {
+        "python": ["tool_session_close"],
+        "typescript": ["toolSessionClose"],
+        "kotlin": ["sessionClose"],
+        "swift": ["toolSessionClose"],
+    },
+    ("Tools", "interface_expose"): {
+        "python": ["tool_interface_expose"],
+        "typescript": ["toolInterfaceExpose"],
+        "kotlin": ["interfaceExpose"],
+        "swift": ["exposeToolInterface"],
+    },
+    ("Tools", "interface_accept"): {
+        "python": ["tool_interface_accept"],
+        "typescript": ["toolInterfaceAccept"],
+        "kotlin": ["interfaceAccept"],
+        "swift": ["acceptToolInterface"],
+    },
+    ("Tools", "interface_revoke"): {
+        "python": ["tool_interface_revoke"],
+        "typescript": ["toolInterfaceRevoke"],
+        "kotlin": ["interfaceRevoke"],
+        "swift": ["revokeToolInterface"],
+    },
+    # Trust -- bare names in all SDKs
+    ("Trust", "evaluate_trust"): {
+        "python": ["evaluate_trust"],
+        "typescript": ["evaluateTrust"],
+        "swift": ["evaluateTrust"],
+    },
+    ("Trust", "aggregate_trust_input"): {
+        "python": ["aggregate_trust_input"],
+        "typescript": ["aggregateTrustInput"],
+        "kotlin": ["aggregateTrustInput"],
+        "swift": ["aggregateTrustInput"],
+    },
+    ("Trust", "verify_participation_requirements"): {
+        "python": ["verify_participation_requirements"],
+        "typescript": ["verifyParticipationRequirements"],
+        "kotlin": ["verifyParticipationRequirements"],
+        "swift": ["verifyParticipationRequirements"],
+    },
+    # Discovery -- bare/different names across SDKs
+    ("Discovery", "parse_address"): {
+        "python": ["parse_address"],
+        "typescript": ["parseAddress"],
+    },
+    ("Discovery", "create_query"): {
+        "python": ["create_query"],
+        "typescript": ["createQuery"],
+    },
+    ("Discovery", "normalize_address"): {
+        "python": ["normalize_address"],
+        "typescript": ["normalizeAddress"],
+    },
+    ("Discovery", "address_resolve"): {
+        "python": ["address_resolve"],
+        "typescript": ["addressResolve"],
+        "kotlin": ["addressResolve"],
+        "swift": ["addressResolve"],
+    },
+    ("Discovery", "petname_set"): {
+        "python": ["petname_set"],
+        "typescript": ["petnameSet"],
+        "kotlin": ["petnameSet"],
+        "swift": ["petnameSet"],
+    },
+    ("Discovery", "petname_remove"): {
+        "python": ["petname_remove"],
+        "typescript": ["petnameRemove"],
+        "kotlin": ["petnameRemove"],
+        "swift": ["petnameRemove"],
+    },
+    ("Discovery", "petname_set_context"): {
+        "python": ["petname_set_context"],
+        "typescript": ["petnameSetContext"],
+        "kotlin": ["petnameSetContext"],
+        "swift": ["petnameSetContext"],
+    },
+    ("Discovery", "petname_remove_context"): {
+        "python": ["petname_remove_context"],
+        "typescript": ["petnameRemoveContext"],
+        "kotlin": ["petnameRemoveContext"],
+        "swift": ["petnameRemoveContext"],
+    },
+    ("Discovery", "petname_resolve_did"): {
+        "python": ["petname_resolve_did"],
+        "typescript": ["petnameResolveDid"],
+        "kotlin": ["petnameResolveDid"],
+        "swift": ["petnameResolveDid"],
+    },
+    ("Discovery", "petname_resolve_context"): {
+        "python": ["petname_resolve_context"],
+        "typescript": ["petnameResolveContext"],
+        "kotlin": ["petnameResolveContext"],
+        "swift": ["petnameResolveContext"],
+    },
+    ("Discovery", "petname_get_for_did"): {
+        "python": ["petname_get_for_did"],
+        "typescript": ["petnameGetForDid"],
+        "kotlin": ["petnameGetForDid"],
+        "swift": ["petnameGetForDid"],
+    },
+    ("Discovery", "petname_get_for_context"): {
+        "python": ["petname_get_for_context"],
+        "typescript": ["petnameGetForContext"],
+        "kotlin": ["petnameGetForContext"],
+        "swift": ["petnameGetForContext"],
+    },
+    ("Discovery", "petname_apply_event"): {
+        "python": ["petname_apply_event"],
+        "typescript": ["petnameApplyEvent"],
+        "kotlin": ["petnameApplyEvent"],
+        "swift": ["petnameApplyEvent"],
+    },
+    ("Discovery", "petname_did_count"): {
+        "python": ["petname_did_count"],
+        "typescript": ["petnameDidCount"],
+        "kotlin": ["petnameDidCount"],
+        "swift": ["petnameDidCount"],
+    },
+    ("Discovery", "petname_context_count"): {
+        "python": ["petname_context_count"],
+        "typescript": ["petnameContextCount"],
+        "kotlin": ["petnameContextCount"],
+        "swift": ["petnameContextCount"],
+    },
+    ("Discovery", "handle_register"): {
+        "python": ["handle_register"],
+        "typescript": ["handleRegister"],
+        "kotlin": ["handleRegister"],
+        "swift": ["handleRegister"],
+    },
+    ("Discovery", "handle_lookup"): {
+        "python": ["handle_lookup"],
+        "typescript": ["handleLookup"],
+        "kotlin": ["handleLookup"],
+        "swift": ["handleLookup"],
+    },
+    ("Discovery", "handle_deregister"): {
+        "python": ["handle_deregister"],
+        "typescript": ["handleDeregister"],
+        "kotlin": ["handleDeregister"],
+        "swift": ["handleDeregister"],
+    },
+    # Economy -- Python SDK uses bare names (no domain prefix)
+    ("Economy", "estimate_cost"): {
+        "python": ["estimate_cost"],
+    },
+    ("Economy", "policy_requires_payment"): {
+        "python": ["policy_requires_payment"],
+    },
+    ("Economy", "auto_accept_blocked"): {
+        "python": ["auto_accept_blocked"],
+    },
+    ("Economy", "check_policy_lock"): {
+        "python": ["check_policy_lock"],
+    },
+    ("Economy", "validate_policy_change"): {
+        "python": ["validate_policy_change"],
+    },
+    ("Economy", "evaluate_formula"): {
+        "python": ["evaluate_formula"],
+    },
+    # Sync -- Python uses bare get_policy (no domain prefix)
+    # (TypeScript getSyncPolicy is already in the entry above)
+    # Provenance -- Kotlin uses bare evaluateQuality
+    ("Provenance", "evaluate_quality"): {
+        "python": ["evaluate_provenance_quality"],
+        "typescript": ["evaluateProvenanceQuality"],
+        "kotlin": ["evaluateQuality"],
+        "swift": ["evaluateProvenanceQuality"],
+    },
+    # Media -- Python SDK uses bare names without domain prefix
+    ("Media", "initiate_session"): {
+        "python": ["initiate_session"],
+    },
+    ("Media", "activate_session"): {
+        "python": ["activate_session"],
+    },
+    ("Media", "join_session"): {
+        "python": ["join_session"],
+    },
+    ("Media", "end_session"): {
+        "python": ["end_session"],
+    },
+    ("Media", "create_offer"): {
+        "python": ["create_offer"],
+    },
+    ("Media", "create_answer"): {
+        "python": ["create_answer"],
+    },
+    ("Media", "create_ice_candidate"): {
+        "python": ["create_ice_candidate"],
+    },
+    ("Media", "create_session_end"): {
+        "python": ["create_session_end"],
+    },
+    ("Media", "send_signaling"): {
+        "python": ["send_signaling"],
+    },
+    ("Media", "verify_sender_attribution"): {
+        "python": ["verify_sender_attribution"],
+    },
+    # Auth -- scpid_* ops already carry the domain prefix in the op name;
+    # the auto-generated domain_snake form would be 'auth_scpid_*' (wrong).
+    ("Auth", "scpid_challenge"): {
+        "python": ["scpid_challenge"],
+        "typescript": ["scpidChallenge"],
+        "kotlin": ["scpidChallenge"],
+        "swift": ["scpidChallenge"],
+    },
+    ("Auth", "scpid_sign"): {
+        "python": ["scpid_sign"],
+        "typescript": ["scpidSign"],
+        "kotlin": ["scpidSign"],
+        "swift": ["scpidSign"],
+    },
+    ("Auth", "scpid_verify"): {
+        "python": ["scpid_verify"],
+        "typescript": ["scpidVerify"],
+        "kotlin": ["scpidVerify"],
+        "swift": ["scpidVerify"],
+    },
+    # Lifecycle -- suspend/resume use bare names in all SDKs
+    ("Lifecycle", "suspend"): {
+        "python": ["suspend"],
+        "typescript": ["suspend"],
+        "kotlin": ["suspendInstance"],
+        "swift": ["suspend"],
+    },
+    ("Lifecycle", "resume"): {
+        "python": ["resume"],
+        "typescript": ["resume"],
+        "kotlin": ["resume"],
+        "swift": ["resume"],
+    },
+    # Bridge -- Python uses bare 'register' and 'evaluate_trust'.
+    # TypeScript does not expose bridge_register as a named public SDK function
+    # (matrix: typescript=false); the entry below covers only the SDKs that do.
+    ("Bridge", "register"): {
+        "python": ["register"],
+    },
+    ("Bridge", "evaluate_trust"): {
+        "python": ["evaluate_trust"],
+    },
+    # Server -- Kotlin uses domain-prefixed bare names (e.g. relayStartInMemory);
+    # Python uses domain-prefixed snake_case (relay_start_in_memory);
+    # TypeScript uses domain-prefixed camelCase (relayStartInMemory).
+    # The op names already carry the sub-domain prefix (relay_/node_) so
+    # auto-generated domain_snake would be 'server_relay_start_in_memory' (wrong).
     ("Server", "relay_start_in_memory"): {
-        "python": ["start_in_memory"],
-        "typescript": ["startInMemory"],
+        "python": ["relay_start_in_memory", "start_in_memory"],
+        "typescript": ["relayStartInMemory", "startInMemory"],
+        "kotlin": ["relayStartInMemory"],
         "swift": ["startInMemory"],
     },
     ("Server", "relay_start_local"): {
-        "python": ["start_local"],
-        "typescript": ["startLocal"],
+        "python": ["relay_start_local", "start_local"],
+        "typescript": ["relayStartLocal", "startLocal"],
+        "kotlin": ["relayStartLocal"],
         "swift": ["startLocal"],
     },
     ("Server", "relay_shutdown"): {
         "python": ["shutdown"],
         "typescript": ["shutdown"],
+        "kotlin": ["relayShutdown"],
         "swift": ["shutdown"],
     },
     ("Server", "node_start_in_memory"): {
-        "python": ["start_in_memory"],
-        "typescript": ["startInMemory"],
+        "python": ["node_start_in_memory", "start_in_memory"],
+        "typescript": ["nodeStartInMemory", "startInMemory"],
+        "kotlin": ["nodeStartInMemory"],
         "swift": ["startInMemory"],
     },
     ("Server", "node_start_local"): {
-        "python": ["start_local"],
-        "typescript": ["startLocal"],
+        "python": ["node_start_local", "start_local"],
+        "typescript": ["nodeStartLocal", "startLocal"],
+        "kotlin": ["nodeStartLocal"],
         "swift": ["startLocal"],
     },
     ("Server", "node_shutdown"): {
         "python": ["shutdown"],
         "typescript": ["shutdown"],
+        "kotlin": ["nodeShutdown"],
         "swift": ["shutdown"],
     },
     ("Server", "node_enable_site_projection"): {
         "python": ["enable_site_projection"],
         "typescript": ["enableSiteProjection"],
+        "kotlin": ["nodeEnableSiteProjection"],
         "swift": ["enableSiteProjection"],
     },
     ("Server", "node_commit_deploy"): {
         "python": ["commit_deploy"],
         "typescript": ["commitDeploy"],
+        "kotlin": ["nodeCommitDeploy"],
         "swift": ["commitDeploy"],
     },
     ("Server", "node_rollback_deploy"): {
         "python": ["rollback_deploy"],
         "typescript": ["rollbackDeploy"],
+        "kotlin": ["nodeRollbackDeploy"],
         "swift": ["rollbackDeploy"],
     },
     ("Server", "node_disable_site_projection"): {
         "python": ["disable_site_projection"],
         "typescript": ["disableSiteProjection"],
+        "kotlin": ["nodeDisableSiteProjection"],
         "swift": ["disableSiteProjection"],
     },
     # Context -- receive needs mapping in Kotlin
     ("Context", "receive"): {
+        "typescript": ["contextSubscribe"],
         "kotlin": ["contextSubscribe"],
     },
     # Context -- consequence_rules surfaced via the existing create() and
     # context_create wrappers (parameter, not a separate function).
     ("Context", "create_with_consequence_rules"): {
-        "python": ["create"],
-        "typescript": ["create"],
+        "python": ["create", "context_create"],
+        "typescript": ["create", "contextCreate"],
         "swift": ["contextCreate"],
+    },
+    ("Context", "restore_context"): {
+        "python": ["restore_context"],
+        "typescript": ["contextRestore"],
+        "kotlin": ["restoreContext"],
+        "swift": ["restoreContext"],
+    },
+    ("Context", "restore_all_contexts"): {
+        "python": ["restore_all_contexts"],
+        "typescript": ["contextRestoreAll"],
+        "kotlin": ["restoreAllContexts"],
+        "swift": ["restoreAllContexts"],
+    },
+    ("Context", "import_context"): {
+        "swift": ["contextImport"],
     },
     # Messaging -- spending_ucan_jwt is a parameter on send() / context_send
     # exposed via existing wrappers in all four SDKs.
     ("Messaging", "send_with_spending_ucan"): {
-        "python": ["send"],
-        "typescript": ["send"],
+        "python": ["send", "context_send"],
+        "typescript": ["send", "contextSend"],
         "kotlin": ["contextSend"],
         "swift": ["send"],
     },
@@ -366,8 +898,8 @@ ALIASES: dict[tuple[str, str], dict[str, list[str]]] = {
     # Bridge drift documented in matrix notes; tree-sitter sees the wrapper
     # signature in PyO3, NAPI TS, and Swift surfaces.
     ("Messaging", "join_with_spending_ucan"): {
-        "python": ["join"],
-        "typescript": ["join"],
+        "python": ["join", "context_join"],
+        "typescript": ["join", "contextJoin"],
         "swift": ["joinContext"],
     },
     # Trust -- consequence rule validation is exercised via aggregate_trust_input
@@ -384,51 +916,54 @@ ALIASES: dict[tuple[str, str], dict[str, list[str]]] = {
         "kotlin": ["aggregateTrustInput"],
         "swift": ["aggregateTrustInput"],
     },
-    # Governance -- new GovernanceAction variants dispatched via the existing
-    # execute_action / propose_action entry points.
-    ("Governance", "execute_suspend_capability"): {
-        "python": ["execute_governance_action"],
-        "typescript": ["executeGovernanceAction"],
-        "kotlin": ["governanceExecute"],
-        "swift": ["executeGovernanceAction"],
+    # Lifecycle: constructor / property / factory naming across SDKs.
+    ("Lifecycle", "scp_new"): {
+        "python": ["SCP"],
+        "typescript": ["SCP"],
+        "swift": ["SCP"],
+        "kotlin": ["SCP"],
     },
-    ("Governance", "execute_suspend_access"): {
-        "python": ["execute_governance_action"],
-        "typescript": ["executeGovernanceAction"],
-        "kotlin": ["governanceExecute"],
-        "swift": ["executeGovernanceAction"],
+    ("Lifecycle", "scp_instance_id"): {
+        "python": ["instance_id"],
+        "typescript": ["instanceId"],
+        "swift": ["instanceId"],
+        "kotlin": ["instanceId"],
     },
-    ("Governance", "execute_revoke_access"): {
-        "python": ["execute_governance_action"],
-        "typescript": ["executeGovernanceAction"],
-        "kotlin": ["governanceExecute"],
-        "swift": ["executeGovernanceAction"],
+    ("Lifecycle", "scp_with_storage_in_memory"): {
+        "python": ["SCP"],
+        "typescript": ["SCP"],
+        "swift": ["withStorage", "SCP"],
+        "kotlin": ["withStorage", "SCP"],
     },
-    ("Governance", "execute_restore_access"): {
-        "python": ["execute_governance_action"],
-        "typescript": ["executeGovernanceAction"],
-        "kotlin": ["governanceExecute"],
-        "swift": ["executeGovernanceAction"],
+    ("Lifecycle", "with_storage_sqlite"): {
+        "python": ["SCP"],
+        "typescript": ["SCP"],
+        "swift": ["withStorage"],
+        "kotlin": ["withSqlite"],
     },
-    ("Governance", "execute_remove_member"): {
-        "python": ["execute_governance_action"],
-        "typescript": ["executeGovernanceAction"],
-        "kotlin": ["governanceExecute"],
-        "swift": ["executeGovernanceAction"],
+    ("Lifecycle", "shutdown_timeout"): {
+        "python": ["shutdown"],
+        "typescript": ["shutdown"],
+        "swift": ["shutdown"],
+        "kotlin": ["shutdown"],
     },
-    ("Governance", "execute_rotate_content_keys"): {
-        "python": ["execute_governance_action"],
-        "typescript": ["executeGovernanceAction"],
-        "kotlin": ["governanceExecute"],
-        "swift": ["executeGovernanceAction"],
-    },
-    ("Governance", "propose_governance_action_checked"): {
-        "python": ["propose_governance_action"],
-        "typescript": ["proposeGovernanceAction"],
-        "kotlin": ["governancePropose"],
-        "swift": ["proposeGovernanceAction"],
+    ("Lifecycle", "add_relay_url"): {
+        "python": ["transport_add_relay"],
+        "typescript": ["transportAddRelay", "configureRelayTransport"],
+        "swift": ["addRelay"],
+        "kotlin": ["addRelay"],
     },
 }
+
+
+# ---------------------------------------------------------------------------
+# Tree-sitter helpers
+# ---------------------------------------------------------------------------
+
+
+def _node_text(node: "Node") -> str:
+    """Return the decoded text of a tree-sitter node, or '' if None."""
+    return (node.text or b"").decode("utf-8")
 
 
 # ---------------------------------------------------------------------------
@@ -440,11 +975,6 @@ def _to_camel(snake: str) -> str:
     """Convert snake_case to camelCase."""
     parts = snake.split("_")
     return parts[0] + "".join(p.capitalize() for p in parts[1:])
-
-
-def _to_pascal(snake: str) -> str:
-    """Convert snake_case to PascalCase."""
-    return "".join(p.capitalize() for p in snake.split("_"))
 
 
 # ---------------------------------------------------------------------------
@@ -476,7 +1006,7 @@ def _get_func_name_from_definition(func_node: Node) -> str | None:
     """Extract the function/method name from a function_definition node."""
     for child in func_node.children:
         if child.type == "identifier":
-            return child.text.decode()
+            return _node_text(child) or None
     return None
 
 
@@ -510,7 +1040,7 @@ def _extract_python_class(class_node: Node, symbols: set[str]) -> None:
     class_name = None
     for child in class_node.children:
         if child.type == "identifier":
-            class_name = child.text.decode()
+            class_name = _node_text(child) or None
             break
     if not class_name:
         return
@@ -574,14 +1104,14 @@ def _extract_typescript_symbols(root_node: Node) -> set[str]:
             if sub.type == "function_declaration":
                 for fc in sub.children:
                     if fc.type == "identifier":
-                        symbols.add(fc.text.decode())
+                        symbols.add(_node_text(fc))
                         break
 
             elif sub.type == "class_declaration":
                 class_name = None
                 for fc in sub.children:
                     if fc.type == "type_identifier":
-                        class_name = fc.text.decode()
+                        class_name = _node_text(fc) or None
                         break
                 if class_name:
                     symbols.add(class_name)
@@ -592,7 +1122,7 @@ def _extract_typescript_symbols(root_node: Node) -> set[str]:
                                 if member.type == "method_definition":
                                     for mc in member.children:
                                         if mc.type == "property_identifier":
-                                            method_name = mc.text.decode()
+                                            method_name = _node_text(mc)
                                             symbols.add(f"{class_name}.{method_name}")
                                             symbols.add(method_name)
                                             break
@@ -601,7 +1131,7 @@ def _extract_typescript_symbols(root_node: Node) -> set[str]:
                                     # properties)
                                     for mc in member.children:
                                         if mc.type == "property_identifier":
-                                            symbols.add(mc.text.decode())
+                                            symbols.add(_node_text(mc))
                                             break
 
             elif sub.type == "lexical_declaration":
@@ -610,19 +1140,19 @@ def _extract_typescript_symbols(root_node: Node) -> set[str]:
                     if decl.type == "variable_declarator":
                         for dc in decl.children:
                             if dc.type == "identifier":
-                                symbols.add(dc.text.decode())
+                                symbols.add(_node_text(dc))
                                 break
 
             elif sub.type == "interface_declaration":
                 for fc in sub.children:
                     if fc.type == "type_identifier":
-                        symbols.add(fc.text.decode())
+                        symbols.add(_node_text(fc))
                         break
 
             elif sub.type == "type_alias_declaration":
                 for fc in sub.children:
                     if fc.type == "type_identifier":
-                        symbols.add(fc.text.decode())
+                        symbols.add(_node_text(fc))
                         break
 
             elif sub.type == "export_clause":
@@ -632,9 +1162,9 @@ def _extract_typescript_symbols(root_node: Node) -> set[str]:
                         ids = [c for c in spec.children if c.type == "identifier"]
                         if len(ids) >= 2:
                             # export { X as Y } -- the exported name is Y
-                            symbols.add(ids[1].text.decode())
+                            symbols.add(_node_text(ids[1]))
                         elif len(ids) == 1:
-                            symbols.add(ids[0].text.decode())
+                            symbols.add(_node_text(ids[0]))
 
     return symbols
 
@@ -649,7 +1179,7 @@ def _has_kotlin_visibility(node: Node, exclude: set[str]) -> bool:
         if child.type == "modifiers":
             for mod in child.children:
                 if mod.type == "visibility_modifier":
-                    vis_text = mod.text.decode().strip()
+                    vis_text = _node_text(mod).strip()
                     if vis_text in exclude:
                         return True
     return False
@@ -668,73 +1198,69 @@ def _extract_kotlin_symbols(root_node: Node) -> set[str]:
     """
     symbols: set[str] = set()
     exclude_vis = {"private", "internal"}
+    # Kotlin allows backtick-escaped identifiers (`` `addRelay` ``), and
+    # UniFFI-generated bindings backtick-quote every name. Strip the ticks so
+    # the captured symbol matches the plain operation name.
+    id_types = ("identifier", "simple_identifier")
 
-    def _process_class_body(class_name: str, body_node: Node) -> None:
-        """Extract methods from a class_body node."""
-        for member in body_node.children:
-            if member.type == "function_declaration":
-                if _has_kotlin_visibility(member, exclude_vis):
+    def _first_ident(node: Node) -> str | None:
+        for c in node.children:
+            if c.type in id_types:
+                return _node_text(c).strip("`") or None
+        return None
+
+    def _property_name(prop_node: Node) -> str | None:
+        # `val instanceId: ULong` -> property_declaration > variable_declaration
+        # > (simple_)identifier. Some grammars place the identifier directly.
+        for c in prop_node.children:
+            if c.type == "variable_declaration":
+                name = _first_ident(c)
+                if name:
+                    return name
+            if c.type in id_types:
+                return _node_text(c).strip("`") or None
+        return None
+
+    type_decls = ("class_declaration", "object_declaration", "interface_declaration")
+
+    def _walk(node: Node, class_name: str | None) -> None:
+        """Recursively collect public function/property names, tracking the
+        nearest enclosing type so methods land as both bare and `Type.method`.
+
+        Recursive (not just top-level + class_body) because UniFFI-generated
+        Kotlin nests the public API on interfaces and override-method bodies
+        whose container node types vary across the grammar; a depth-bounded
+        walk missed them (e.g. `TransportManager.addRelay`). Over-capture is
+        the safe failure mode for a fail-closed coverage gate.
+        """
+        for child in node.children:
+            t = child.type
+            if t == "function_declaration":
+                if not _has_kotlin_visibility(child, exclude_vis):
+                    name = _first_ident(child)
+                    if name:
+                        symbols.add(name)
+                        if class_name:
+                            symbols.add(f"{class_name}.{name}")
+                _walk(child, class_name)
+            elif t == "property_declaration":
+                if not _has_kotlin_visibility(child, exclude_vis):
+                    name = _property_name(child)
+                    if name:
+                        symbols.add(name)
+                        if class_name:
+                            symbols.add(f"{class_name}.{name}")
+            elif t in type_decls:
+                if _has_kotlin_visibility(child, exclude_vis):
                     continue
-                for mc in member.children:
-                    if mc.type == "identifier":
-                        method_name = mc.text.decode()
-                        symbols.add(f"{class_name}.{method_name}")
-                        symbols.add(method_name)
-                        break
+                cname = _first_ident(child)
+                if cname:
+                    symbols.add(cname)
+                _walk(child, cname)
+            else:
+                _walk(child, class_name)
 
-            elif member.type == "companion_object":
-                # companion object { fun create() ... }
-                for co_child in member.children:
-                    if co_child.type == "class_body":
-                        for co_member in co_child.children:
-                            if co_member.type == "function_declaration":
-                                if _has_kotlin_visibility(co_member, exclude_vis):
-                                    continue
-                                for mc in co_member.children:
-                                    if mc.type == "identifier":
-                                        method_name = mc.text.decode()
-                                        symbols.add(f"{class_name}.{method_name}")
-                                        symbols.add(method_name)
-                                        break
-
-            elif member.type in ("class_declaration", "object_declaration"):
-                # Nested class or object
-                if _has_kotlin_visibility(member, exclude_vis):
-                    continue
-                nested_name = None
-                for nc in member.children:
-                    if nc.type == "identifier":
-                        nested_name = nc.text.decode()
-                        break
-                if nested_name:
-                    symbols.add(nested_name)
-                    for nc in member.children:
-                        if nc.type == "class_body":
-                            _process_class_body(nested_name, nc)
-
-    for child in root_node.children:
-        if child.type == "function_declaration":
-            if _has_kotlin_visibility(child, exclude_vis):
-                continue
-            for fc in child.children:
-                if fc.type == "identifier":
-                    symbols.add(fc.text.decode())
-                    break
-
-        elif child.type in ("class_declaration", "object_declaration"):
-            if _has_kotlin_visibility(child, exclude_vis):
-                continue
-            class_name = None
-            for fc in child.children:
-                if fc.type == "identifier":
-                    class_name = fc.text.decode()
-                    break
-            if class_name:
-                symbols.add(class_name)
-                for fc in child.children:
-                    if fc.type == "class_body":
-                        _process_class_body(class_name, fc)
-
+    _walk(root_node, None)
     return symbols
 
 
@@ -757,7 +1283,7 @@ def _extract_swift_symbols(root_node: Node) -> set[str]:
             if child.type == "modifiers":
                 for mod in child.children:
                     if mod.type == "visibility_modifier":
-                        if mod.text.decode().strip() == "public":
+                        if _node_text(mod).strip() == "public":
                             return True
         return False
 
@@ -768,7 +1294,7 @@ def _extract_swift_symbols(root_node: Node) -> set[str]:
             if child.type == "modifiers":
                 for mod in child.children:
                     if mod.type == "visibility_modifier":
-                        if mod.text.decode().strip() in restrictive:
+                        if _node_text(mod).strip() in restrictive:
                             return True
         return False
 
@@ -776,12 +1302,12 @@ def _extract_swift_symbols(root_node: Node) -> set[str]:
         """Get the name of a class/struct/enum/actor/extension declaration."""
         for child in node.children:
             if child.type == "type_identifier":
-                return child.text.decode()
+                return _node_text(child) or None
             # Extensions use user_type > type_identifier
             if child.type == "user_type":
                 for uc in child.children:
                     if uc.type == "type_identifier":
-                        return uc.text.decode()
+                        return _node_text(uc) or None
         return None
 
     def _extract_methods_from_body(
@@ -801,7 +1327,7 @@ def _extract_swift_symbols(root_node: Node) -> set[str]:
                     continue
                 for mc in member.children:
                     if mc.type == "simple_identifier":
-                        method_name = mc.text.decode()
+                        method_name = _node_text(mc)
                         symbols.add(f"{type_name}.{method_name}")
                         symbols.add(method_name)
                         break
@@ -812,7 +1338,7 @@ def _extract_swift_symbols(root_node: Node) -> set[str]:
                 continue
             for fc in child.children:
                 if fc.type == "simple_identifier":
-                    symbols.add(fc.text.decode())
+                    symbols.add(_node_text(fc))
                     break
 
         elif child.type == "class_declaration":
@@ -840,7 +1366,7 @@ def _extract_swift_symbols(root_node: Node) -> set[str]:
             proto_name = None
             for fc in child.children:
                 if fc.type == "type_identifier":
-                    proto_name = fc.text.decode()
+                    proto_name = _node_text(fc) or None
                     break
             if proto_name:
                 symbols.add(proto_name)
@@ -850,7 +1376,7 @@ def _extract_swift_symbols(root_node: Node) -> set[str]:
                             if member.type == "protocol_function_declaration":
                                 for mc in member.children:
                                     if mc.type == "simple_identifier":
-                                        method_name = mc.text.decode()
+                                        method_name = _node_text(mc)
                                         symbols.add(f"{proto_name}.{method_name}")
                                         symbols.add(method_name)
                                         break
@@ -909,12 +1435,13 @@ def _check_operation_in_sdk(
     Strategy (in order):
       1. Explicit aliases from the ALIASES table
       2. Exact match against auto-generated name variants
-         (snake_case, camelCase, PascalCase, domain-prefixed)
-      3. Substring match: check if any symbol contains the operation name
-         as a component (handles cases like registerTool matching "register",
-         broadcastSubscribe matching "subscribe")
+         (snake_case, camelCase, domain-prefixed)
 
     Returns True if any check succeeds.
+
+    Note: suffix/substring matching was intentionally removed. It allowed
+    ~23 fabricated operation names to pass via suffix collision with common
+    verbs. All legitimate cross-SDK name mappings must be explicit in ALIASES.
     """
     # 1. Check explicit aliases first
     alias_key = (domain, op_name)
@@ -923,46 +1450,32 @@ def _check_operation_in_sdk(
             if alias in sdk_symbols:
                 return True
 
-    # 2. Generate name variants and check exact match
+    # 2. Generate name variants and check exact match.
+    #    Only domain-prefixed forms are checked here.  Bare op_name/camel/pascal
+    #    candidates were removed because they accepted any unrelated SDK symbol
+    #    that happened to share the operation name (e.g. a `migrate` helper
+    #    anywhere in the codebase satisfied `Identity/migrate`).  All legitimate
+    #    cross-SDK name irregularities — where the SDK uses a name that is not
+    #    the domain-prefixed form — must be registered in the ALIASES table above.
     camel = _to_camel(op_name)
-    pascal = _to_pascal(op_name)
 
     # Domain-prefixed variants
     domain_lower = domain.lower()
     domain_snake = f"{domain_lower}_{op_name}"
     domain_camel = _to_camel(domain_snake)
-    # py_ prefixed (PyO3 bridge naming convention)
-    py_prefixed = f"py_{op_name}"
 
     candidates = [
-        # Raw operation names
-        op_name,  # send_message
-        camel,  # sendMessage
-        pascal,  # SendMessage
         # Domain-prefixed
         domain_snake,  # messaging_send_message
         domain_camel,  # messagingSendMessage
-        py_prefixed,  # py_send_message
         # Class.method patterns — use domain name as-is from JSON
         # (preserves EventLog, UCAN, MCP casing)
         f"{domain}.{op_name}",  # EventLog.verify
-        f"{domain}.{camel}",  # EventLog.verify
+        f"{domain}.{camel}",
     ]
 
     for candidate in candidates:
         if candidate in sdk_symbols:
-            return True
-
-    # 3. Suffix match: check if any extracted symbol ENDS WITH the
-    #    operation's camelCase name. This handles domain-prefixed names
-    #    (e.g., registerTool for Tools/register) without matching across
-    #    domains (scopeRegister should NOT match Tools/register).
-    camel_lower = camel.lower()
-    for symbol in sdk_symbols:
-        if "." in symbol:
-            continue
-        sym_lower = symbol.lower()
-        if sym_lower.endswith(camel_lower):
             return True
 
     return False
@@ -989,18 +1502,52 @@ def main() -> int:
             print(f"  WARNING: No symbols extracted for {sdk} SDK at {SDK_PATHS[sdk]}")
 
     total_ops = 0
-    warnings = 0
     errors = 0
     missing_exemptions = 0
+    unmatched_true = 0
+    coverage_exempted = 0
+    all_exempted_ops = 0
 
     sdks = ("python", "typescript", "kotlin", "swift")
+    expected_sdks = frozenset(sdks)
 
     for domain_entry in matrix.get("capabilities", []):
         domain = domain_entry.get("domain", "?")
         for op in domain_entry.get("operations", []):
             op_name = op.get("name", "?")
             total_ops += 1
+
+            # Fail if any expected SDK key is absent entirely from this entry.
+            # A missing key is structurally different from false/null: it means
+            # the operation was never evaluated for that SDK, which is always
+            # an authoring gap (not a deliberate exemption).
+            present_sdks = expected_sdks.intersection(op.keys())
+            missing_sdks = expected_sdks - present_sdks
+            if missing_sdks:
+                for missing_sdk in sorted(missing_sdks):
+                    print(
+                        f"  ERROR: {domain}/{op_name} is missing SDK key "
+                        f"'{missing_sdk}' entirely — add a true/false entry "
+                        f"(and an exemption if false)."
+                    )
+                    errors += 1
+
             exemptions = op.get("exemptions", {})
+            coverage_exemptions = op.get("coverage_exemptions", {})
+
+            # Track per-op coverage state for the all-exempted check below.
+            op_true_sdks: list[str] = []
+            op_exempted_sdks: list[str] = []
+            op_verified_sdks: list[str] = []
+
+            # Validate that all coverage_exemptions reasons are non-empty strings.
+            for sdk, reason in coverage_exemptions.items():
+                if not isinstance(reason, str) or not reason.strip():
+                    print(
+                        f"  ERROR: {domain}/{op_name}: coverage_exemptions[{sdk}] has an "
+                        f"empty or blank reason — must cite a symbol name or ADR section."
+                    )
+                    errors += 1
 
             for sdk in sdks:
                 expected = op.get(sdk)
@@ -1008,18 +1555,42 @@ def main() -> int:
                     continue
 
                 if expected is True:
+                    op_true_sdks.append(sdk)
                     # AST check: does the SDK have a symbol for this?
                     found = _check_operation_in_sdk(
                         sdk_symbols[sdk], sdk, domain, op_name
                     )
-                    if not found:
+                    if found:
+                        op_verified_sdks.append(sdk)
+                        continue
+                    # Fail-closed: a capability marked present whose SDK symbol
+                    # cannot be located is a real gap (or a stale matrix entry)
+                    # UNLESS it carries an explicit, reasoned coverage exemption.
+                    # The escape hatch is for capabilities that genuinely exist
+                    # but resist static extraction (e.g. methods only in
+                    # generated bindings the AST grammar can't parse) — never a
+                    # silent pass. Resolve a real one of three ways: add the SDK
+                    # wrapper, add an ALIASES entry pointing at the real symbol,
+                    # or add a coverage_exemptions reason citing the symbol.
+                    if sdk in coverage_exemptions:
                         print(
-                            f"  WARNING: {domain}/{op_name} marked true for "
-                            f"{sdk} but AST could not find matching symbol"
+                            f"  NOTE: {domain}/{op_name} ({sdk}) coverage-exempt: "
+                            f"{coverage_exemptions[sdk]}"
                         )
-                        warnings += 1
+                        op_exempted_sdks.append(sdk)
+                        coverage_exempted += 1
+                    else:
+                        print(
+                            f"  ERROR: {domain}/{op_name} marked true for {sdk} "
+                            f"but no matching SDK symbol was found and no "
+                            f"coverage_exemptions reason is recorded. Add the "
+                            f"wrapper, an ALIASES entry, or a coverage_exemptions "
+                            f"reason."
+                        )
+                        unmatched_true += 1
+                        errors += 1
                 elif expected is False:
-                    # Must have an exemption
+                    # Must have an exemption with a non-empty reason string
                     if sdk not in exemptions:
                         print(
                             f"  ERROR: {domain}/{op_name} marked false for "
@@ -1027,30 +1598,88 @@ def main() -> int:
                         )
                         missing_exemptions += 1
                         errors += 1
+                    else:
+                        reason = exemptions.get(sdk, "")
+                        if not isinstance(reason, str) or not reason.strip():
+                            print(
+                                f"  ERROR: 'exemptions.{sdk}' for op '{domain}/{op_name}' "
+                                f"must be a non-empty string"
+                            )
+                            errors += 1
+                else:
+                    # Cell value is neither True, False, nor None (e.g. a
+                    # typo'd string "true" or an integer).  Reject it so
+                    # authoring errors don't silently fall through.
+                    print(
+                        f"  ERROR: {domain}/{op_name}: SDK '{sdk}' has unexpected cell value "
+                        f"{expected!r} — must be true, false, or null."
+                    )
+                    errors += 1
+
+            # All-exempted check: if every SDK that claims coverage for this
+            # operation has a coverage_exemption (and none was statically
+            # verified), there is no ground-truth verified implementation.
+            # This prevents a coverage_exemptions entry from acting as an
+            # unbounded prose bypass when ALL SDKs use one simultaneously.
+            # At least one SDK must have its symbol verified by static
+            # extraction for the exemptions to be legitimate.
+            if (
+                op_true_sdks
+                and not op_verified_sdks
+                and set(op_exempted_sdks) == set(op_true_sdks)
+            ):
+                print(
+                    f"  ERROR: All SDKs claiming coverage for {domain}/{op_name} "
+                    f"have coverage_exemptions with no statically-verified SDK — "
+                    f"coverage cannot be verified. Add an ALIASES entry or add the "
+                    f"missing wrapper so at least one SDK is statically confirmed."
+                )
+                all_exempted_ops += 1
+                errors += 1
+
+    # Floor guard: a coverage gate must never pass on an empty matrix. If the
+    # "capabilities" array is empty or missing, total_ops stays 0 and the loop
+    # above records no errors — without this guard a truncated/empty matrix
+    # would be reported as PASS, silently disabling the gate. This is a NEW
+    # assertion that expands coverage (it can only ADD a failure), never a
+    # bypass of an existing check.
+    if total_ops == 0:
+        print(
+            "FAIL: matrix produced zero operations — the 'capabilities' array is "
+            "empty or missing. A coverage gate cannot pass on an empty matrix.",
+            file=sys.stderr,
+        )
+        return 1
 
     # Summary
     print()
     print("=" * 60)
     print("SDK Capability Matrix Coverage Check")
     print("=" * 60)
-    print(f"  Matrix file:       {MATRIX_PATH}")
-    print(f"  Total operations:  {total_ops}")
-    print(f"  Warnings:          {warnings} (true entries with no AST match)")
-    print(f"  Errors:            {errors} (false entries with no exemption)")
+    print(f"  Matrix file:        {MATRIX_PATH}")
+    print(f"  Total operations:   {total_ops}")
+    print(
+        f"  Coverage-exempt:    {coverage_exempted} (present but not statically matchable)"
+    )
+    print(f"  Errors:             {errors}")
+    print(
+        f"    unmatched true:   {unmatched_true} (true but no symbol and no coverage exemption)"
+    )
+    print(f"    false w/o exempt: {missing_exemptions}")
+    print(
+        f"    all-exempted ops: {all_exempted_ops} (all true SDKs have exemptions, none verified)"
+    )
     print("=" * 60)
 
     if errors > 0:
-        print(f"\nFAIL: {missing_exemptions} false entries lack exemptions")
+        print(
+            f"\nFAIL: {errors} error(s) — {unmatched_true} unmatched true entr(ies), "
+            f"{missing_exemptions} false entr(ies) lacking exemptions, "
+            f"{all_exempted_ops} op(s) with all-exempted coverage (unverifiable)."
+        )
         return 1
 
-    if warnings > 0:
-        print(
-            f"\nPASS with {warnings} warnings. "
-            f"Review warnings -- they may indicate stale matrix entries."
-        )
-    else:
-        print("\nPASS: All entries validated.")
-
+    print("\nPASS: All matrix entries validated.")
     return 0
 
 

--- a/scripts/test_check_sdk_coverage.py
+++ b/scripts/test_check_sdk_coverage.py
@@ -1,0 +1,816 @@
+"""Self-tests for check-sdk-coverage.py.
+
+Covers:
+  1.  Gate exits 0 (PASS) on the real matrix.
+  2.  Gate exits 1 when a true entry has no matching symbol and no exemption
+      (unmatched-true path, isolated from missing-SDK-key errors).
+  2b. Gate exits 1 when a matrix SDK key is missing from the cell object
+      (missing-SDK-key path).
+  3.  _extract_python_symbols correctly extracts a function name via tree-sitter.
+  4.  _extract_python_symbols handles class with method names.
+  5.  Gate exits 0 when a true entry has a valid coverage_exemption and at
+      least one other SDK is statically verified.
+  6.  Gate exits 1 when every true cell for an op has a coverage_exemption but
+      none is statically verified (all-exempted guard).
+  7.  Gate exits 1 when a cell's coverage_exemptions reason is blank or missing.
+  8.  Gate exits 1 when a cell value is neither a boolean nor null (e.g. the
+      string "true" instead of a JSON boolean true).
+  9.  A bare op-name symbol does not satisfy a domain-prefixed operation
+      (regression guard for the domain-prefix-only enforcement).
+  10. ALIASES entries enable non-standard SDK symbol names to satisfy coverage.
+  11. The absence of an ALIASES entry causes coverage to fail for symbols that
+      require explicit mapping.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Locate the script under test
+# ---------------------------------------------------------------------------
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+SCRIPT = REPO_ROOT / "scripts" / "check-sdk-coverage.py"
+
+# ---------------------------------------------------------------------------
+# Load extraction helpers directly for unit tests.
+#
+# The script filename uses hyphens (check-sdk-coverage.py) which is not a
+# valid Python module name, so we load it via importlib.
+# ---------------------------------------------------------------------------
+
+_spec = importlib.util.spec_from_file_location("check_sdk_coverage", SCRIPT)
+assert _spec is not None and _spec.loader is not None
+_mod = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(_mod)  # type: ignore[attr-defined]
+
+_extract_python_symbols = _mod._extract_python_symbols
+
+# ---------------------------------------------------------------------------
+# Wrapper-script builder
+#
+# All integration tests drive the gate via a subprocess wrapper so they can
+# patch module-level constants (MATRIX_PATH, SDK_PATHS) before calling main().
+# ---------------------------------------------------------------------------
+
+_SCRIPT_PATH_STR = str(SCRIPT)
+
+
+def _build_wrapper(
+    tmp_path: Path,
+    matrix_path: Path,
+    sdk_paths: dict[str, Path] | None = None,
+) -> Path:
+    """Write a wrapper script that patches MATRIX_PATH (and optionally
+    SDK_PATHS) before invoking main(), and return its path.
+
+    Parameters
+    ----------
+    tmp_path:
+        Directory in which to write the wrapper.
+    matrix_path:
+        Synthetic matrix JSON file to use.
+    sdk_paths:
+        Optional mapping of SDK name → directory to use instead of the real
+        SDK source trees. Only the keys listed here are replaced; omitted keys
+        retain the gate's built-in defaults (which point at the live source).
+    """
+    patch_sdk_paths_lines: list[str] = []
+    if sdk_paths:
+        patch_sdk_paths_lines.append("_mod.SDK_PATHS.update({")
+        for sdk, path in sdk_paths.items():
+            patch_sdk_paths_lines.append(f"    {sdk!r}: Path({str(path)!r}),")
+        patch_sdk_paths_lines.append("})")
+
+    # Build the wrapper body as a list of lines to avoid indentation issues
+    # when injecting the optional SDK_PATHS patch block.
+    body_lines = [
+        "import sys",
+        "import importlib.util",
+        "from pathlib import Path",
+        "",
+        f"_spec = importlib.util.spec_from_file_location('check_sdk_coverage', {_SCRIPT_PATH_STR!r})",
+        "_mod = importlib.util.module_from_spec(_spec)",
+        "_spec.loader.exec_module(_mod)",
+        "",
+        f"_mod.MATRIX_PATH = Path({str(matrix_path)!r})",
+    ]
+    if patch_sdk_paths_lines:
+        body_lines.extend(patch_sdk_paths_lines)
+    body_lines.append("sys.exit(_mod.main())")
+
+    wrapper = tmp_path / "run_with_matrix.py"
+    wrapper.write_text("\n".join(body_lines) + "\n", encoding="utf-8")
+    return wrapper
+
+
+def _run_wrapper(wrapper: Path) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [sys.executable, str(wrapper)],
+        capture_output=True,
+        text=True,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Test 1: Gate passes on the real matrix
+# ---------------------------------------------------------------------------
+
+
+def test_gate_passes_on_real_matrix() -> None:
+    """Running the gate against the live matrix must exit 0."""
+    result = subprocess.run(
+        [sys.executable, str(SCRIPT)],
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0, (
+        f"Gate exited {result.returncode} on the real matrix.\n"
+        f"stdout:\n{result.stdout}\nstderr:\n{result.stderr}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Test 2: Gate exits 1 on a synthetic matrix with unmatched true entry
+#
+# Previous version: had only `python: True` and omitted typescript/kotlin/swift
+# entirely, producing 3 missing-SDK-key errors AND 1 unmatched-true error.
+# The test passed even when the unmatched-true branch was deleted (the
+# missing-SDK-key errors alone drove returncode=1).
+#
+# Fixed version: gives all 4 SDK keys.  python=True (no matching symbol, no
+# exemption).  The other three are false with valid exemptions.  The ONLY
+# error path that can fire is the unmatched-true check for python.
+# ---------------------------------------------------------------------------
+
+
+def test_gate_fails_on_unmatched_true_entry(tmp_path: Path) -> None:
+    """A `true` cell with no matching symbol and no coverage_exemption exits 1.
+
+    All four SDK keys are present so missing-SDK-key errors cannot mask the
+    property under test.  The three false cells each carry a valid exemption
+    so the only possible failure is the unmatched-true path for python.
+    """
+    synthetic_matrix = {
+        "capabilities": [
+            {
+                "domain": "Fake",
+                "operations": [
+                    {
+                        "name": "nonexistent_operation_zzzzzz",
+                        # python: true but the symbol won't exist anywhere
+                        "python": True,
+                        # Other SDKs: false + valid exemption string (no errors expected)
+                        "typescript": False,
+                        "kotlin": False,
+                        "swift": False,
+                        "exemptions": {
+                            "typescript": "Not yet implemented in TypeScript SDK",
+                            "kotlin": "Not yet implemented in Kotlin SDK",
+                            "swift": "Not yet implemented in Swift SDK",
+                        },
+                    }
+                ],
+            }
+        ]
+    }
+    matrix_file = tmp_path / "matrix.json"
+    matrix_file.write_text(json.dumps(synthetic_matrix), encoding="utf-8")
+
+    wrapper = _build_wrapper(tmp_path, matrix_file)
+    result = _run_wrapper(wrapper)
+
+    assert result.returncode == 1, (
+        f"Gate should have exited 1 for unmatched true entry, got {result.returncode}.\n"
+        f"stdout:\n{result.stdout}\nstderr:\n{result.stderr}"
+    )
+    # The gate prints this specific per-operation error line for unmatched-true cells.
+    # Assert on the exact phrase from the error branch (not the summary label, which
+    # appears on every run regardless of error count).
+    assert "no matching SDK symbol was found" in result.stdout, (
+        f"Expected unmatched-true error phrase 'no matching SDK symbol was found' in stdout.\n"
+        f"stdout:\n{result.stdout}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Test 2b: Gate exits 1 when a required SDK key is missing entirely
+# ---------------------------------------------------------------------------
+
+
+def test_gate_fails_on_missing_sdk_key(tmp_path: Path) -> None:
+    """An op that omits a required SDK key entirely must fail.
+
+    The gate distinguishes a missing key (authoring gap — never evaluated for
+    that SDK) from an explicit false entry (deliberate exemption).  A missing
+    key must produce a specific error and exit 1, regardless of other entries.
+    """
+    synthetic_matrix = {
+        "capabilities": [
+            {
+                "domain": "Fake",
+                "operations": [
+                    {
+                        "name": "missing_key_op_zzzzzz",
+                        # swift key is entirely absent — not false, not true
+                        "python": False,
+                        "typescript": False,
+                        "kotlin": False,
+                        # "swift" key deliberately omitted
+                        "exemptions": {
+                            "python": "Not yet implemented in Python SDK",
+                            "typescript": "Not yet implemented in TypeScript SDK",
+                            "kotlin": "Not yet implemented in Kotlin SDK",
+                        },
+                    }
+                ],
+            }
+        ]
+    }
+    matrix_file = tmp_path / "matrix.json"
+    matrix_file.write_text(json.dumps(synthetic_matrix), encoding="utf-8")
+
+    wrapper = _build_wrapper(tmp_path, matrix_file)
+    result = _run_wrapper(wrapper)
+
+    assert result.returncode == 1, (
+        f"Gate should have exited 1 for missing SDK key, got {result.returncode}.\n"
+        f"stdout:\n{result.stdout}\nstderr:\n{result.stderr}"
+    )
+    # The gate prints a per-op error that names the missing SDK key.
+    assert "missing SDK key" in result.stdout or "'swift'" in result.stdout, (
+        f"Expected missing-SDK-key error phrase in stdout.\nstdout:\n{result.stdout}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Test 3: _extract_python_symbols returns the correct name for a bare function
+# ---------------------------------------------------------------------------
+
+
+def test_extract_python_symbols_simple_function() -> None:
+    """_extract_python_symbols extracts 'hello' from 'def hello(): pass'."""
+    try:
+        import tree_sitter_python as tspython
+        from tree_sitter import Language, Parser
+    except ImportError:
+        pytest.skip("tree-sitter-python not installed")
+
+    parser = Parser(Language(tspython.language()))
+    source = b"def hello(): pass"
+    tree = parser.parse(source)
+    symbols = _extract_python_symbols(tree.root_node)
+    assert "hello" in symbols, f"Expected 'hello' in symbols, got: {symbols}"
+
+
+# ---------------------------------------------------------------------------
+# Test 4: _extract_python_symbols handles class with method
+# ---------------------------------------------------------------------------
+
+
+def test_extract_python_symbols_class_method() -> None:
+    """_extract_python_symbols collects class name and method names."""
+    try:
+        import tree_sitter_python as tspython
+        from tree_sitter import Language, Parser
+    except ImportError:
+        pytest.skip("tree-sitter-python not installed")
+
+    parser = Parser(Language(tspython.language()))
+    source = b"class Foo:\n    def bar(self): pass\n"
+    tree = parser.parse(source)
+    symbols = _extract_python_symbols(tree.root_node)
+    assert "Foo" in symbols, f"Expected 'Foo' in symbols, got: {symbols}"
+    assert "bar" in symbols, f"Expected 'bar' in symbols, got: {symbols}"
+    assert "Foo.bar" in symbols, f"Expected 'Foo.bar' in symbols, got: {symbols}"
+
+
+# ---------------------------------------------------------------------------
+# Test 5: Gate passes when a true entry has a valid coverage_exemption and
+#          at least one other SDK is statically verified.
+#
+# Setup:
+#   - python=True  — symbol NOT in the fake Python source; carries a
+#     coverage_exemptions entry with a non-empty reason.
+#   - typescript=True — symbol IS in the fake TypeScript source (statically
+#     verified); no exemption needed.
+#   - kotlin=False, swift=False — each with a valid exemption.
+#
+# The gate must exit 0: python's true cell is legitimately exempted, and
+# typescript provides the required ground-truth static verification, so the
+# all-exempted guard does not fire.
+# ---------------------------------------------------------------------------
+
+
+def test_gate_passes_with_valid_coverage_exemption(tmp_path: Path) -> None:
+    """Gate exits 0 when a true cell has a valid coverage_exemption and
+    another SDK provides static verification."""
+    # Create a fake TypeScript source file that exports the operation symbol.
+    # The gate no longer accepts bare camelCase ("verifiedOpZzz"); it requires
+    # the domain-prefixed form.  For domain="Fake", op="verified_op_zzz" the
+    # auto-generated camelCase candidate is "fakeVerifiedOpZzz"
+    # (_to_camel("fake_verified_op_zzz")).
+    ts_src_dir = tmp_path / "ts_src"
+    ts_src_dir.mkdir()
+    ts_file = ts_src_dir / "index.ts"
+    ts_file.write_text(
+        "export function fakeVerifiedOpZzz(): void {}\n",
+        encoding="utf-8",
+    )
+
+    # Create an empty Python source dir (python symbol will NOT be found).
+    py_src_dir = tmp_path / "py_src"
+    py_src_dir.mkdir()
+
+    synthetic_matrix = {
+        "capabilities": [
+            {
+                "domain": "Fake",
+                "operations": [
+                    {
+                        "name": "verified_op_zzz",
+                        # python: true but symbol absent — covered by exemption
+                        "python": True,
+                        # typescript: true and symbol IS present in fake source
+                        "typescript": True,
+                        "kotlin": False,
+                        "swift": False,
+                        "exemptions": {
+                            "kotlin": "Not yet implemented in Kotlin SDK",
+                            "swift": "Not yet implemented in Swift SDK",
+                        },
+                        "coverage_exemptions": {
+                            "python": "Symbol is generated at runtime by the PyO3 bridge — not statically extractable",
+                        },
+                    }
+                ],
+            }
+        ]
+    }
+    matrix_file = tmp_path / "matrix.json"
+    matrix_file.write_text(json.dumps(synthetic_matrix), encoding="utf-8")
+
+    wrapper = _build_wrapper(
+        tmp_path,
+        matrix_file,
+        sdk_paths={"python": py_src_dir, "typescript": ts_src_dir},
+    )
+    result = _run_wrapper(wrapper)
+
+    assert result.returncode == 0, (
+        f"Gate should have exited 0 for a valid coverage_exemption + "
+        f"statically-verified typescript, got {result.returncode}.\n"
+        f"stdout:\n{result.stdout}\nstderr:\n{result.stderr}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Test 6: Gate exits 1 when ALL true cells have coverage_exemptions and
+#          none is statically verified (all-exempted guard).
+#
+# Setup:
+#   - python=True  — symbol absent; carries a coverage_exemptions entry.
+#   - typescript=True — symbol also absent; carries a coverage_exemptions entry.
+#   - kotlin=False, swift=False — each with a valid exemption.
+#
+# No SDK is statically verified, so the all-exempted guard must fire
+# and the gate must exit 1.
+# ---------------------------------------------------------------------------
+
+
+def test_gate_fails_on_all_exempted_with_none_verified(tmp_path: Path) -> None:
+    """Gate exits 1 when every true cell carries a coverage_exemption but
+    none is statically verified."""
+    # Both Python and TypeScript source dirs are empty — no symbols extractable.
+    py_src_dir = tmp_path / "py_src"
+    py_src_dir.mkdir()
+    ts_src_dir = tmp_path / "ts_src"
+    ts_src_dir.mkdir()
+
+    synthetic_matrix = {
+        "capabilities": [
+            {
+                "domain": "Fake",
+                "operations": [
+                    {
+                        "name": "all_exempted_op_zzz",
+                        "python": True,
+                        "typescript": True,
+                        "kotlin": False,
+                        "swift": False,
+                        "exemptions": {
+                            "kotlin": "Not yet implemented in Kotlin SDK",
+                            "swift": "Not yet implemented in Swift SDK",
+                        },
+                        "coverage_exemptions": {
+                            "python": "Generated binding — not statically extractable",
+                            "typescript": "Generated binding — not statically extractable",
+                        },
+                    }
+                ],
+            }
+        ]
+    }
+    matrix_file = tmp_path / "matrix.json"
+    matrix_file.write_text(json.dumps(synthetic_matrix), encoding="utf-8")
+
+    wrapper = _build_wrapper(
+        tmp_path,
+        matrix_file,
+        sdk_paths={"python": py_src_dir, "typescript": ts_src_dir},
+    )
+    result = _run_wrapper(wrapper)
+
+    assert result.returncode == 1, (
+        f"Gate should have exited 1 for all-exempted op with no static verification, "
+        f"got {result.returncode}.\n"
+        f"stdout:\n{result.stdout}\nstderr:\n{result.stderr}"
+    )
+    # Verify the all-exempted guard fired (not a different error).
+    assert "all SDKs claiming coverage" in result.stdout.lower() or "all-exempted" in result.stdout.lower(), (
+        f"Expected all-exempted guard error phrase in stdout.\nstdout:\n{result.stdout}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Test 7: Gate exits 1 when a false entry's exemption reason is a non-string
+#          (e.g. a dict) or an empty/blank string.
+#
+# Setup:
+#   - python=True  — valid, a symbol IS present.
+#   - typescript=False — exemption value is a dict object (invalid format).
+#   - kotlin=False — exemption is an empty string (invalid).
+#   - swift=False — valid exemption string.
+#
+# The gate must reject the dict and blank exemption reasons.
+# ---------------------------------------------------------------------------
+
+
+def test_gate_fails_on_invalid_false_entry_exemption_reason(tmp_path: Path) -> None:
+    """Gate exits 1 when a false entry has a non-string or blank exemption reason."""
+    ts_src_dir = tmp_path / "ts_src"
+    ts_src_dir.mkdir()
+    ts_file = ts_src_dir / "index.ts"
+    # Provide the domain-prefixed symbol so typescript=True is statically
+    # verified.  For domain="Fake", op="invalid_exempt_op_zzz" the
+    # auto-generated candidate is "fakeInvalidExemptOpZzz".  The bare form
+    # "invalidExemptOpZzz" is NOT a valid candidate after the domain-prefix
+    # enforcement change, so only the prefixed form satisfies the gate.
+    ts_file.write_text(
+        "export function fakeInvalidExemptOpZzz(): void {}\n",
+        encoding="utf-8",
+    )
+
+    synthetic_matrix = {
+        "capabilities": [
+            {
+                "domain": "Fake",
+                "operations": [
+                    {
+                        "name": "invalid_exempt_op_zzz",
+                        "python": False,
+                        # typescript=True with symbol present (static verification)
+                        "typescript": True,
+                        "kotlin": False,
+                        "swift": False,
+                        "exemptions": {
+                            # dict object — invalid, must be a string
+                            "python": {"reason": "Not implemented"},
+                            # blank string — invalid
+                            "kotlin": "   ",
+                            # valid string
+                            "swift": "Not yet implemented in Swift SDK",
+                        },
+                    }
+                ],
+            }
+        ]
+    }
+    matrix_file = tmp_path / "matrix.json"
+    matrix_file.write_text(json.dumps(synthetic_matrix), encoding="utf-8")
+
+    wrapper = _build_wrapper(
+        tmp_path,
+        matrix_file,
+        sdk_paths={"typescript": ts_src_dir},
+    )
+    result = _run_wrapper(wrapper)
+
+    assert result.returncode == 1, (
+        f"Gate should have exited 1 for invalid exemption reasons, "
+        f"got {result.returncode}.\n"
+        f"stdout:\n{result.stdout}\nstderr:\n{result.stderr}"
+    )
+    # Assert both invalid cases are independently flagged — not just one.
+    assert "exemptions.python" in result.stdout and "must be a non-empty string" in result.stdout, (
+        f"Expected error for dict-valued 'exemptions.python' in stdout.\nstdout:\n{result.stdout}"
+    )
+    assert "exemptions.kotlin" in result.stdout, (
+        f"Expected error for blank-string 'exemptions.kotlin' in stdout.\nstdout:\n{result.stdout}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Test 8: Gate exits 1 when a cell value is not a boolean or null
+#
+# A typo'd string "true" (instead of JSON boolean true) must be rejected.
+# The gate's else-branch fires, emits "unexpected cell value", and exits 1.
+# This test is mutation-robust: removing the else-branch causes the string
+# cell to fall through silently, making returncode 0 and the assertion fail.
+# ---------------------------------------------------------------------------
+
+
+def test_gate_fails_on_unexpected_cell_value(tmp_path: Path) -> None:
+    """A cell value that is not a boolean or null must be rejected.
+
+    The string ``"true"`` is a common authoring mistake (JSON requires bare
+    ``true``, not the quoted form).  Without the else-branch, this silently
+    falls through and the capability appears unchecked.  With the branch,
+    the gate emits an 'unexpected cell value' error and exits 1.
+    """
+    synthetic_matrix = {
+        "capabilities": [
+            {
+                "domain": "Fake",
+                "operations": [
+                    {
+                        "name": "cell_value_op_zzz",
+                        # python uses the string "true" — a typo that must be rejected
+                        "python": "true",
+                        "typescript": False,
+                        "kotlin": False,
+                        "swift": False,
+                        "exemptions": {
+                            "typescript": "Not yet implemented in TypeScript SDK",
+                            "kotlin": "Not yet implemented in Kotlin SDK",
+                            "swift": "Not yet implemented in Swift SDK",
+                        },
+                    }
+                ],
+            }
+        ]
+    }
+    matrix_file = tmp_path / "matrix.json"
+    matrix_file.write_text(json.dumps(synthetic_matrix), encoding="utf-8")
+
+    wrapper = _build_wrapper(tmp_path, matrix_file)
+    result = _run_wrapper(wrapper)
+
+    assert result.returncode == 1, (
+        f"Gate should have exited 1 for unexpected cell value, got {result.returncode}.\n"
+        f"stdout:\n{result.stdout}\nstderr:\n{result.stderr}"
+    )
+    assert "unexpected cell value" in result.stdout, (
+        f"Expected 'unexpected cell value' error phrase in stdout.\nstdout:\n{result.stdout}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Test 9: Gate exits 1 when only the bare camelCase form is exported
+#          (domain-prefix-only enforcement regression test)
+#
+# The PR's core security fix removed bare-name candidates from
+# _check_operation_in_sdk.  Before the fix, exporting only the bare camel
+# form ("verifiedOpZzz") was accepted as coverage for "Fake/verified_op_zzz"
+# because the old code checked the bare camelCase candidate.  After the fix,
+# only the domain-prefixed form ("fakeVerifiedOpZzz") is accepted.
+#
+# This test MUST FAIL if bare-name candidates are re-added to
+# _check_operation_in_sdk (mutation-robustness property).
+# ---------------------------------------------------------------------------
+
+
+def test_bare_name_does_not_satisfy_domain_prefixed_op(tmp_path: Path) -> None:
+    """Exporting only the bare camelCase form must NOT satisfy a domain-prefixed op.
+
+    For domain="Fake", op="verified_op_zzz" the required SDK symbol is
+    "fakeVerifiedOpZzz" (domain-prefixed camelCase).  A file that exports only
+    "verifiedOpZzz" (bare form, no domain prefix) must cause the gate to exit 1
+    with 'no matching SDK symbol was found'.
+
+    Mutation test: re-adding a bare-camel candidate to _check_operation_in_sdk
+    would make this test fail (the bare form would satisfy the check and the
+    gate would exit 0 instead of 1).
+    """
+    ts_src_dir = tmp_path / "ts_src"
+    ts_src_dir.mkdir()
+    ts_file = ts_src_dir / "index.ts"
+    # Export ONLY the bare camel form — NOT the domain-prefixed "fakeVerifiedOpZzz".
+    ts_file.write_text(
+        "export function verifiedOpZzz(): void {}\n",
+        encoding="utf-8",
+    )
+
+    synthetic_matrix = {
+        "capabilities": [
+            {
+                "domain": "Fake",
+                "operations": [
+                    {
+                        "name": "verified_op_zzz",
+                        # typescript: True — symbol must be statically found
+                        "typescript": True,
+                        # Other SDKs: false + valid exemptions (no noise from them)
+                        "python": False,
+                        "kotlin": False,
+                        "swift": False,
+                        "exemptions": {
+                            "python": "Not yet implemented in Python SDK",
+                            "kotlin": "Not yet implemented in Kotlin SDK",
+                            "swift": "Not yet implemented in Swift SDK",
+                        },
+                    }
+                ],
+            }
+        ]
+    }
+    matrix_file = tmp_path / "matrix.json"
+    matrix_file.write_text(json.dumps(synthetic_matrix), encoding="utf-8")
+
+    wrapper = _build_wrapper(
+        tmp_path,
+        matrix_file,
+        sdk_paths={"typescript": ts_src_dir},
+    )
+    result = _run_wrapper(wrapper)
+
+    assert result.returncode == 1, (
+        f"Gate should have exited 1: bare 'verifiedOpZzz' must not satisfy "
+        f"domain-prefixed op 'Fake/verified_op_zzz'. Got {result.returncode}.\n"
+        f"stdout:\n{result.stdout}\nstderr:\n{result.stderr}"
+    )
+    assert "no matching SDK symbol was found" in result.stdout, (
+        f"Expected 'no matching SDK symbol was found' in stdout.\n"
+        f"stdout:\n{result.stdout}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Test 10: ALIASES table enables non-standard symbol names
+#
+# When an op's SDK symbol does not follow the auto-generated naming convention,
+# an explicit ALIASES entry allows the gate to find it.  This test verifies:
+#   a) With the alias present: gate exits 0 (custom symbol satisfies coverage)
+#   b) Without the alias:      gate exits 1 (custom symbol is not found)
+# ---------------------------------------------------------------------------
+
+
+def test_aliases_enable_non_standard_symbol_names(tmp_path: Path) -> None:
+    """ALIASES table entries enable coverage for non-standard symbol names.
+
+    Without an alias, a TypeScript export named "myCustomSymbol" does NOT
+    satisfy "Fake/custom_op" (which would need "fakeCustomOp" by convention).
+    With an alias mapping ("Fake", "custom_op") -> {"typescript": ["myCustomSymbol"]},
+    the gate accepts it and exits 0.
+    """
+    ts_src_dir = tmp_path / "ts_src"
+    ts_src_dir.mkdir()
+    ts_file = ts_src_dir / "index.ts"
+    # Export a non-standard symbol name (not the auto-generated "fakeCustomOp").
+    ts_file.write_text(
+        "export function myCustomSymbol(): void {}\n",
+        encoding="utf-8",
+    )
+
+    synthetic_matrix = {
+        "capabilities": [
+            {
+                "domain": "Fake",
+                "operations": [
+                    {
+                        "name": "custom_op",
+                        "typescript": True,
+                        "python": False,
+                        "kotlin": False,
+                        "swift": False,
+                        "exemptions": {
+                            "python": "Not yet implemented in Python SDK",
+                            "kotlin": "Not yet implemented in Kotlin SDK",
+                            "swift": "Not yet implemented in Swift SDK",
+                        },
+                    }
+                ],
+            }
+        ]
+    }
+    matrix_file = tmp_path / "matrix.json"
+    matrix_file.write_text(json.dumps(synthetic_matrix), encoding="utf-8")
+
+    # --- Part a: WITH the alias → gate must exit 0 ---
+    wrapper_with_alias = tmp_path / "run_with_alias.py"
+    wrapper_with_alias.write_text(
+        "\n".join([
+            "import sys",
+            "import importlib.util",
+            "from pathlib import Path",
+            "",
+            f"_spec = importlib.util.spec_from_file_location('check_sdk_coverage', {_SCRIPT_PATH_STR!r})",
+            "_mod = importlib.util.module_from_spec(_spec)",
+            "_spec.loader.exec_module(_mod)",
+            "",
+            f"_mod.MATRIX_PATH = Path({str(matrix_file)!r})",
+            f"_mod.SDK_PATHS.update({{'typescript': Path({str(ts_src_dir)!r})}})",
+            # Inject a custom alias so "myCustomSymbol" satisfies "Fake/custom_op"
+            "_mod.ALIASES[('Fake', 'custom_op')] = {'typescript': ['myCustomSymbol']}",
+            "sys.exit(_mod.main())",
+        ]) + "\n",
+        encoding="utf-8",
+    )
+    result_with = subprocess.run(
+        [sys.executable, str(wrapper_with_alias)],
+        capture_output=True,
+        text=True,
+    )
+    assert result_with.returncode == 0, (
+        f"Gate should exit 0 when ALIASES maps 'myCustomSymbol' for Fake/custom_op. "
+        f"Got {result_with.returncode}.\n"
+        f"stdout:\n{result_with.stdout}\nstderr:\n{result_with.stderr}"
+    )
+
+    # --- Part b: WITHOUT the alias → gate must exit 1 ---
+    wrapper_no_alias = tmp_path / "run_no_alias.py"
+    wrapper_no_alias.write_text(
+        "\n".join([
+            "import sys",
+            "import importlib.util",
+            "from pathlib import Path",
+            "",
+            f"_spec = importlib.util.spec_from_file_location('check_sdk_coverage', {_SCRIPT_PATH_STR!r})",
+            "_mod = importlib.util.module_from_spec(_spec)",
+            "_spec.loader.exec_module(_mod)",
+            "",
+            f"_mod.MATRIX_PATH = Path({str(matrix_file)!r})",
+            f"_mod.SDK_PATHS.update({{'typescript': Path({str(ts_src_dir)!r})}})",
+            # No alias added: "myCustomSymbol" is not a valid candidate for "Fake/custom_op"
+            "sys.exit(_mod.main())",
+        ]) + "\n",
+        encoding="utf-8",
+    )
+    result_without = subprocess.run(
+        [sys.executable, str(wrapper_no_alias)],
+        capture_output=True,
+        text=True,
+    )
+    assert result_without.returncode == 1, (
+        f"Gate should exit 1 when no ALIASES entry maps 'myCustomSymbol' for Fake/custom_op. "
+        f"Got {result_without.returncode}.\n"
+        f"stdout:\n{result_without.stdout}\nstderr:\n{result_without.stderr}"
+    )
+    assert "no matching SDK symbol was found" in result_without.stdout, (
+        f"Expected 'no matching SDK symbol was found' in stdout.\n"
+        f"stdout:\n{result_without.stdout}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Test 12: Gate exits 1 on an empty/missing "capabilities" array (floor guard)
+#
+# An empty matrix produces total_ops=0 and errors=0. Without the floor guard
+# the gate would print PASS and exit 0 — silently disabling coverage
+# enforcement against a truncated or empty matrix. The guard must make this
+# fail-closed (exit 1).
+# ---------------------------------------------------------------------------
+
+
+def test_gate_fails_on_empty_capabilities(tmp_path: Path) -> None:
+    """An empty 'capabilities' array must fail the gate, not pass it."""
+    matrix_file = tmp_path / "matrix.json"
+    matrix_file.write_text(json.dumps({"capabilities": []}), encoding="utf-8")
+
+    wrapper = _build_wrapper(tmp_path, matrix_file)
+    result = _run_wrapper(wrapper)
+
+    assert result.returncode == 1, (
+        f"Gate should have exited 1 on an empty matrix, got {result.returncode}.\n"
+        f"stdout:\n{result.stdout}\nstderr:\n{result.stderr}"
+    )
+    assert "zero operations" in result.stderr, (
+        f"Expected the empty-matrix floor-guard message in stderr.\n"
+        f"stderr:\n{result.stderr}"
+    )
+
+
+def test_gate_fails_on_missing_capabilities_key(tmp_path: Path) -> None:
+    """A matrix object lacking the 'capabilities' key must also fail closed."""
+    matrix_file = tmp_path / "matrix.json"
+    matrix_file.write_text(json.dumps({}), encoding="utf-8")
+
+    wrapper = _build_wrapper(tmp_path, matrix_file)
+    result = _run_wrapper(wrapper)
+
+    assert result.returncode == 1, (
+        f"Gate should have exited 1 on a matrix missing 'capabilities', "
+        f"got {result.returncode}.\n"
+        f"stdout:\n{result.stdout}\nstderr:\n{result.stderr}"
+    )
+    assert "zero operations" in result.stderr, (
+        f"Expected the empty-matrix floor-guard message in stderr.\n"
+        f"stderr:\n{result.stderr}"
+    )

--- a/scripts/test_check_sdk_coverage.py
+++ b/scripts/test_check_sdk_coverage.py
@@ -20,6 +20,9 @@ Covers:
   10. ALIASES entries enable non-standard SDK symbol names to satisfy coverage.
   11. The absence of an ALIASES entry causes coverage to fail for symbols that
       require explicit mapping.
+  12. Empty / missing 'capabilities' fail closed (floor + shape guards).
+  13. Matrix file not found / malformed JSON / wrong top-level shape / non-dict
+      coverage_exemptions all exit 1 with a clean diagnostic (no traceback).
 """
 
 from __future__ import annotations
@@ -434,9 +437,10 @@ def test_gate_fails_on_all_exempted_with_none_verified(tmp_path: Path) -> None:
         f"stdout:\n{result.stdout}\nstderr:\n{result.stderr}"
     )
     # Verify the all-exempted guard fired (not a different error).
-    assert "all SDKs claiming coverage" in result.stdout.lower() or "all-exempted" in result.stdout.lower(), (
-        f"Expected all-exempted guard error phrase in stdout.\nstdout:\n{result.stdout}"
-    )
+    assert (
+        "all SDKs claiming coverage" in result.stdout.lower()
+        or "all-exempted" in result.stdout.lower()
+    ), f"Expected all-exempted guard error phrase in stdout.\nstdout:\n{result.stdout}"
 
 
 # ---------------------------------------------------------------------------
@@ -509,7 +513,10 @@ def test_gate_fails_on_invalid_false_entry_exemption_reason(tmp_path: Path) -> N
         f"stdout:\n{result.stdout}\nstderr:\n{result.stderr}"
     )
     # Assert both invalid cases are independently flagged — not just one.
-    assert "exemptions.python" in result.stdout and "must be a non-empty string" in result.stdout, (
+    assert (
+        "exemptions.python" in result.stdout
+        and "must be a non-empty string" in result.stdout
+    ), (
         f"Expected error for dict-valued 'exemptions.python' in stdout.\nstdout:\n{result.stdout}"
     )
     assert "exemptions.kotlin" in result.stdout, (
@@ -706,21 +713,24 @@ def test_aliases_enable_non_standard_symbol_names(tmp_path: Path) -> None:
     # --- Part a: WITH the alias → gate must exit 0 ---
     wrapper_with_alias = tmp_path / "run_with_alias.py"
     wrapper_with_alias.write_text(
-        "\n".join([
-            "import sys",
-            "import importlib.util",
-            "from pathlib import Path",
-            "",
-            f"_spec = importlib.util.spec_from_file_location('check_sdk_coverage', {_SCRIPT_PATH_STR!r})",
-            "_mod = importlib.util.module_from_spec(_spec)",
-            "_spec.loader.exec_module(_mod)",
-            "",
-            f"_mod.MATRIX_PATH = Path({str(matrix_file)!r})",
-            f"_mod.SDK_PATHS.update({{'typescript': Path({str(ts_src_dir)!r})}})",
-            # Inject a custom alias so "myCustomSymbol" satisfies "Fake/custom_op"
-            "_mod.ALIASES[('Fake', 'custom_op')] = {'typescript': ['myCustomSymbol']}",
-            "sys.exit(_mod.main())",
-        ]) + "\n",
+        "\n".join(
+            [
+                "import sys",
+                "import importlib.util",
+                "from pathlib import Path",
+                "",
+                f"_spec = importlib.util.spec_from_file_location('check_sdk_coverage', {_SCRIPT_PATH_STR!r})",
+                "_mod = importlib.util.module_from_spec(_spec)",
+                "_spec.loader.exec_module(_mod)",
+                "",
+                f"_mod.MATRIX_PATH = Path({str(matrix_file)!r})",
+                f"_mod.SDK_PATHS.update({{'typescript': Path({str(ts_src_dir)!r})}})",
+                # Inject a custom alias so "myCustomSymbol" satisfies "Fake/custom_op"
+                "_mod.ALIASES[('Fake', 'custom_op')] = {'typescript': ['myCustomSymbol']}",
+                "sys.exit(_mod.main())",
+            ]
+        )
+        + "\n",
         encoding="utf-8",
     )
     result_with = subprocess.run(
@@ -737,20 +747,23 @@ def test_aliases_enable_non_standard_symbol_names(tmp_path: Path) -> None:
     # --- Part b: WITHOUT the alias → gate must exit 1 ---
     wrapper_no_alias = tmp_path / "run_no_alias.py"
     wrapper_no_alias.write_text(
-        "\n".join([
-            "import sys",
-            "import importlib.util",
-            "from pathlib import Path",
-            "",
-            f"_spec = importlib.util.spec_from_file_location('check_sdk_coverage', {_SCRIPT_PATH_STR!r})",
-            "_mod = importlib.util.module_from_spec(_spec)",
-            "_spec.loader.exec_module(_mod)",
-            "",
-            f"_mod.MATRIX_PATH = Path({str(matrix_file)!r})",
-            f"_mod.SDK_PATHS.update({{'typescript': Path({str(ts_src_dir)!r})}})",
-            # No alias added: "myCustomSymbol" is not a valid candidate for "Fake/custom_op"
-            "sys.exit(_mod.main())",
-        ]) + "\n",
+        "\n".join(
+            [
+                "import sys",
+                "import importlib.util",
+                "from pathlib import Path",
+                "",
+                f"_spec = importlib.util.spec_from_file_location('check_sdk_coverage', {_SCRIPT_PATH_STR!r})",
+                "_mod = importlib.util.module_from_spec(_spec)",
+                "_spec.loader.exec_module(_mod)",
+                "",
+                f"_mod.MATRIX_PATH = Path({str(matrix_file)!r})",
+                f"_mod.SDK_PATHS.update({{'typescript': Path({str(ts_src_dir)!r})}})",
+                # No alias added: "myCustomSymbol" is not a valid candidate for "Fake/custom_op"
+                "sys.exit(_mod.main())",
+            ]
+        )
+        + "\n",
         encoding="utf-8",
     )
     result_without = subprocess.run(
@@ -798,7 +811,11 @@ def test_gate_fails_on_empty_capabilities(tmp_path: Path) -> None:
 
 
 def test_gate_fails_on_missing_capabilities_key(tmp_path: Path) -> None:
-    """A matrix object lacking the 'capabilities' key must also fail closed."""
+    """A matrix object lacking the 'capabilities' key must also fail closed.
+
+    A missing 'capabilities' key is a shape violation: the top-level shape
+    check fires before the floor guard and emits the shape diagnostic.
+    """
     matrix_file = tmp_path / "matrix.json"
     matrix_file.write_text(json.dumps({}), encoding="utf-8")
 
@@ -810,7 +827,120 @@ def test_gate_fails_on_missing_capabilities_key(tmp_path: Path) -> None:
         f"got {result.returncode}.\n"
         f"stdout:\n{result.stdout}\nstderr:\n{result.stderr}"
     )
-    assert "zero operations" in result.stderr, (
-        f"Expected the empty-matrix floor-guard message in stderr.\n"
+    assert "must be an object with a 'capabilities' array" in result.stderr, (
+        f"Expected the matrix-shape diagnostic in stderr.\nstderr:\n{result.stderr}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Test 13: Gate exits 1 (clean diagnostic, not a traceback) when the matrix
+#          file is missing, malformed, or structurally wrong.
+# ---------------------------------------------------------------------------
+
+
+def test_gate_fails_on_matrix_file_not_found(tmp_path: Path) -> None:
+    """Pointing MATRIX_PATH at a nonexistent file must exit 1 cleanly."""
+    missing = tmp_path / "does_not_exist.json"
+    wrapper = _build_wrapper(tmp_path, missing)
+    result = _run_wrapper(wrapper)
+
+    assert result.returncode == 1, (
+        f"Gate should have exited 1 for a missing matrix file, "
+        f"got {result.returncode}.\n"
+        f"stdout:\n{result.stdout}\nstderr:\n{result.stderr}"
+    )
+    assert "not found" in result.stderr.lower(), (
+        f"Expected a 'not found' diagnostic in stderr.\nstderr:\n{result.stderr}"
+    )
+    assert "Traceback" not in result.stderr, (
+        f"Missing matrix must not surface a Python traceback.\nstderr:\n{result.stderr}"
+    )
+
+
+def test_gate_fails_on_malformed_json_matrix(tmp_path: Path) -> None:
+    """A matrix file containing invalid JSON must exit 1 cleanly (no traceback)."""
+    matrix_file = tmp_path / "matrix.json"
+    matrix_file.write_text("{ this is not valid json ]", encoding="utf-8")
+
+    wrapper = _build_wrapper(tmp_path, matrix_file)
+    result = _run_wrapper(wrapper)
+
+    assert result.returncode == 1, (
+        f"Gate should have exited 1 for malformed JSON, got {result.returncode}.\n"
+        f"stdout:\n{result.stdout}\nstderr:\n{result.stderr}"
+    )
+    assert "could not parse matrix" in result.stderr, (
+        f"Expected the parse-failure diagnostic in stderr.\nstderr:\n{result.stderr}"
+    )
+    assert "Traceback" not in result.stderr, (
+        f"Malformed JSON must not surface a Python traceback.\nstderr:\n{result.stderr}"
+    )
+
+
+def test_gate_fails_on_matrix_that_is_a_list(tmp_path: Path) -> None:
+    """A matrix whose top-level value is a list (not an object) must fail closed."""
+    matrix_file = tmp_path / "matrix.json"
+    matrix_file.write_text(json.dumps([{"domain": "Fake"}]), encoding="utf-8")
+
+    wrapper = _build_wrapper(tmp_path, matrix_file)
+    result = _run_wrapper(wrapper)
+
+    assert result.returncode == 1, (
+        f"Gate should have exited 1 for a list-valued matrix, "
+        f"got {result.returncode}.\n"
+        f"stdout:\n{result.stdout}\nstderr:\n{result.stderr}"
+    )
+    assert "must be an object with a 'capabilities' array" in result.stderr, (
+        f"Expected the matrix-shape diagnostic in stderr.\nstderr:\n{result.stderr}"
+    )
+
+
+def test_gate_fails_on_non_dict_coverage_exemptions(tmp_path: Path) -> None:
+    """A 'coverage_exemptions' value that is not an object must fail closed.
+
+    A non-dict coverage_exemptions block would make membership/.items()
+    accesses raise; the gate must instead emit a clean ERROR and exit 1.
+    """
+    synthetic_matrix = {
+        "capabilities": [
+            {
+                "domain": "Fake",
+                "operations": [
+                    {
+                        "name": "bad_cov_exempt_op_zzz",
+                        "python": False,
+                        "typescript": False,
+                        "kotlin": False,
+                        "swift": False,
+                        "exemptions": {
+                            "python": "Not yet implemented in Python SDK",
+                            "typescript": "Not yet implemented in TypeScript SDK",
+                            "kotlin": "Not yet implemented in Kotlin SDK",
+                            "swift": "Not yet implemented in Swift SDK",
+                        },
+                        # Invalid: must be an object, not a string.
+                        "coverage_exemptions": "this should be a dict",
+                    }
+                ],
+            }
+        ]
+    }
+    matrix_file = tmp_path / "matrix.json"
+    matrix_file.write_text(json.dumps(synthetic_matrix), encoding="utf-8")
+
+    wrapper = _build_wrapper(tmp_path, matrix_file)
+    result = _run_wrapper(wrapper)
+
+    assert result.returncode == 1, (
+        f"Gate should have exited 1 for non-dict coverage_exemptions, "
+        f"got {result.returncode}.\n"
+        f"stdout:\n{result.stdout}\nstderr:\n{result.stderr}"
+    )
+    assert "'coverage_exemptions' must be an" in result.stdout, (
+        f"Expected the non-dict coverage_exemptions diagnostic in stdout.\n"
+        f"stdout:\n{result.stdout}"
+    )
+    assert "Traceback" not in result.stderr, (
+        f"Non-dict coverage_exemptions must not surface a traceback.\n"
         f"stderr:\n{result.stderr}"
     )

--- a/scripts/test_check_sdk_coverage.py
+++ b/scripts/test_check_sdk_coverage.py
@@ -944,3 +944,90 @@ def test_gate_fails_on_non_dict_coverage_exemptions(tmp_path: Path) -> None:
         f"Non-dict coverage_exemptions must not surface a traceback.\n"
         f"stderr:\n{result.stderr}"
     )
+
+
+def test_gate_fails_on_non_dict_capabilities_entry(tmp_path: Path) -> None:
+    """A non-dict element of 'capabilities' must fail closed without a traceback.
+
+    A string (or other non-object) capabilities entry would make the
+    .get("domain")/.get("operations") accesses raise; the gate must instead
+    emit a clean ERROR and exit 1.
+    """
+    synthetic_matrix = {"capabilities": ["this should be an object"]}
+    matrix_file = tmp_path / "matrix.json"
+    matrix_file.write_text(json.dumps(synthetic_matrix), encoding="utf-8")
+
+    wrapper = _build_wrapper(tmp_path, matrix_file)
+    result = _run_wrapper(wrapper)
+
+    assert result.returncode == 1, (
+        f"Gate should have exited 1 for a non-dict capabilities entry, "
+        f"got {result.returncode}.\n"
+        f"stdout:\n{result.stdout}\nstderr:\n{result.stderr}"
+    )
+    assert "capabilities entry must be an object" in result.stdout, (
+        f"Expected the non-dict capabilities-entry diagnostic in stdout.\n"
+        f"stdout:\n{result.stdout}"
+    )
+    assert "Traceback" not in result.stderr, (
+        f"A non-dict capabilities entry must not surface a traceback.\n"
+        f"stderr:\n{result.stderr}"
+    )
+
+
+def test_gate_fails_on_non_list_operations(tmp_path: Path) -> None:
+    """A non-list 'operations' value must fail closed without a traceback.
+
+    A string (or other non-array) operations value would make the iteration
+    below raise (or iterate characters); the gate must instead emit a clean
+    ERROR and exit 1.
+    """
+    synthetic_matrix = {"capabilities": [{"domain": "Fake", "operations": "nope"}]}
+    matrix_file = tmp_path / "matrix.json"
+    matrix_file.write_text(json.dumps(synthetic_matrix), encoding="utf-8")
+
+    wrapper = _build_wrapper(tmp_path, matrix_file)
+    result = _run_wrapper(wrapper)
+
+    assert result.returncode == 1, (
+        f"Gate should have exited 1 for a non-list 'operations', "
+        f"got {result.returncode}.\n"
+        f"stdout:\n{result.stdout}\nstderr:\n{result.stderr}"
+    )
+    assert "'operations' must be an array" in result.stdout, (
+        f"Expected the non-list operations diagnostic in stdout.\n"
+        f"stdout:\n{result.stdout}"
+    )
+    assert "Traceback" not in result.stderr, (
+        f"A non-list 'operations' must not surface a traceback.\n"
+        f"stderr:\n{result.stderr}"
+    )
+
+
+def test_gate_fails_on_non_dict_operation_entry(tmp_path: Path) -> None:
+    """A non-dict element of 'operations' must fail closed without a traceback.
+
+    An integer (or other non-object) operation entry would make the
+    .get("name")/.keys() accesses raise; the gate must instead emit a clean
+    ERROR and exit 1.
+    """
+    synthetic_matrix = {"capabilities": [{"domain": "Fake", "operations": [123]}]}
+    matrix_file = tmp_path / "matrix.json"
+    matrix_file.write_text(json.dumps(synthetic_matrix), encoding="utf-8")
+
+    wrapper = _build_wrapper(tmp_path, matrix_file)
+    result = _run_wrapper(wrapper)
+
+    assert result.returncode == 1, (
+        f"Gate should have exited 1 for a non-dict operation entry, "
+        f"got {result.returncode}.\n"
+        f"stdout:\n{result.stdout}\nstderr:\n{result.stderr}"
+    )
+    assert "operation entry must be an object" in result.stdout, (
+        f"Expected the non-dict operation-entry diagnostic in stdout.\n"
+        f"stdout:\n{result.stdout}"
+    )
+    assert "Traceback" not in result.stderr, (
+        f"A non-dict operation entry must not surface a traceback.\n"
+        f"stderr:\n{result.stderr}"
+    )


### PR DESCRIPTION
## Scope

Makes the SDK capability-coverage gate (`scripts/check-sdk-coverage.py`) **fail-closed**. Carved out of the over-bundled `fix/sdk-coverage-fail-closed-and-parity` branch as its own atomic PR — this PR contains ONLY the gate-hardening work, not the SDK-parity wrappers.

### What changed

The gate could previously PASS on an empty / truncated / missing matrix (fail-open) and accepted fabricated operation names via suffix/substring collision. Now:

- **Floor guard:** `total_ops == 0` exits non-zero.
- **Unmatched `true` is fatal:** any `true` cell with no resolvable public SDK symbol (and no documented exemption) exits non-zero.
- **No more suffix/substring name matching** — closes the name-collision bypass; matching is now exact (modulo the explicit `ALIASES` table).
- **`coverage_exemptions` escape hatch** for generated symbols the tree-sitter extractors cannot statically match (e.g. UniFFI-generated Kotlin overrides), with documented per-SDK reasons.
- **946-line pytest suite** (`scripts/test_check_sdk_coverage.py`) with exit-code assertions and a mutation-aware regression guard.
- **CI wiring:** the gate self-tests run ahead of the gate itself (`.github/workflows/ci.yml`).
- **Enforcement registration:** `scripts/check-sdk-coverage.py` added to the enforcement-files list in `CLAUDE.md`.

A lesson (`.docs/lessons/coverage-gates-must-fail-closed.md`) captures the fail-open-vs-fail-closed reasoning.

## Verification (run off `origin/main`)

- Self-tests: `python3.12 -m pytest scripts/test_check_sdk_coverage.py` → **17 passed**.
- Gate: `python3.12 scripts/check-sdk-coverage.py` → **EXIT 0**, 223 operations, 0 errors.

The stricter gate did not pass cleanly against `origin/main`'s actual SDK surface at first: 10 matrix cells were marked `true` but resolve only against methods that land in the *parity* half of the split (they exist only as `internal/` bridge plumbing or as differently-named public symbols on `origin/main`). Each was set to `false` with a precise `exemptions` reason — the gate logic was **not** weakened, and no passing match was invented.

### Matrix cells flipped to `false` + exemption

| Op (section) | SDK | Reason |
|---|---|---|
| `rotate_key` (Identity) | typescript | bridge plumbing only (`internal/native.ts`, `internal/wasm.ts`); public `rotateKey()` wrapper lands in parity PR |
| `add_agent_key` (Identity) | typescript | bridge plumbing only (`internal/native.ts addAgentKey`); public wrapper in parity PR |
| `rotate_agent_key` (Identity) | typescript | bridge plumbing only (`internal/native.ts rotateAgentKey`); public wrapper in parity PR |
| `remove_agent_key` (Identity) | typescript | bridge plumbing only (`internal/native.ts removeAgentKey`); public wrapper in parity PR |
| `migrate` (Identity) | typescript | bridge plumbing only (`internal/native.ts migrate`, `internal/wasm.ts identity_migrate`); public wrapper in parity PR |
| `evaluate_trust` (Trust) | typescript | public surface exposes `verifyParticipationRequirements`, not a named `evaluateTrust`; sugar lands in parity PR |
| `register` (Bridge) | typescript | `bridge_register` is an internal `Bridge` interface method (`bridgeRegister` in `internal/bridge.ts`), not a named public SDK function — registration is handled at the FFI layer via the NAPI addon |
| `evaluate_trust` (Bridge) | typescript | same as Trust above |
| `discover` (Discovery) | python | `discovery.py` exposes parse/create/normalize only; no `discover`/`discover_contexts` public fn yet; wrapper in parity PR |
| `verify_payment_receipts` (Economy) | python | `economy.py` exposes cost/policy/formula helpers only; no public `verify_payment_receipts` fn yet; wrapper in parity PR |

These cells will flip back to `true` in the SDK-parity PR once the named public wrappers exist on `origin/main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
