### PR TITLE
ci(release): fix release.yml workflow parse failure (heredoc indentation)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -567,19 +567,19 @@ jobs:
             cp "$artifact/index.node" "$pkg_dir/index.node"
 
             cat > "$pkg_dir/package.json" <<JSON
-{
-  "name": "${pkg_name}",
-  "version": "${{ env.VERSION }}",
-  "description": "${os} ${cpu} native addon for @limn-works/scp-ts",
-  "os": ["${os}"],
-  "cpu": ["${cpu}"],
-  "main": "index.node",
-  "files": ["index.node"],
-  "license": "MIT OR Apache-2.0",
-  "repository": { "type": "git", "url": "https://github.com/limn/scp" },
-  "publishConfig": { "access": "public" }
-}
-JSON
+          {
+            "name": "${pkg_name}",
+            "version": "${{ env.VERSION }}",
+            "description": "${os} ${cpu} native addon for @limn-works/scp-ts",
+            "os": ["${os}"],
+            "cpu": ["${cpu}"],
+            "main": "index.node",
+            "files": ["index.node"],
+            "license": "MIT OR Apache-2.0",
+            "repository": { "type": "git", "url": "https://github.com/limn/scp" },
+            "publishConfig": { "access": "public" }
+          }
+          JSON
 
             echo "Publishing ${pkg_name}@${{ env.VERSION }}…"
             npm publish "$pkg_dir" --access public


### PR DESCRIPTION
## Problem

`release.yml` fails at the **workflow-file parse stage** on every push (0-second runs, zero jobs scheduled — GitHub reports "This run likely failed because of a workflow file issue"). This has been red on `main` since **2026-06-18**.

## Root cause

In the *"Publish per-platform NAPI packages"* step, the `cat > package.json <<JSON` heredoc body and closing delimiter were dedented to column 0 — below the `run: |` block-scalar indent (10 spaces, set by the `declare` line). A YAML literal block scalar ends as soon as a line is indented *less* than the first content line, so YAML terminated the scalar at the `{` and failed to parse the whole file.

Introduced by `500dcc4c2` (2026-06-18, "wire per-platform NAPI packages into build + publish pipeline"). **Not** related to the Class-S / #1862 work — that merged four days later and touched zero workflow files.

Note: the release pipeline triggers on `workflow_dispatch` only, so the actual release never ran from these failures — but the parse error produced a noisy red check on **every** branch/merge-queue push.

## Fix

Re-indent the heredoc so it satisfies **both** layers simultaneously:
- body + closing delimiter sit at the 10-space block indent → YAML keeps them as scalar content (parses);
- after YAML strips the 10-space block indent, the closing `JSON` lands at **column 0** → the unquoted shell heredoc terminates correctly.

## Validation

- `python3.12 -c "yaml.safe_load(...)"` → parses OK.
- `actionlint` → **no** heredoc-termination errors (SC1039/SC1072/SC1073/SC1009 gone); no errors at all (remaining output is pre-existing SC2086 style/info, untouched here).
- Post-YAML-strip simulation confirms the closing `JSON` is at column 0 (heredoc terminates) — caught and corrected an intermediate fix that parsed YAML but left the delimiter indented (which would have silently broken the shell heredoc at runtime).

🤖 Generated with [Claude Code](https://claude.com/claude-code)