### PR TITLE
feat(ucan): enforce ceiling over all attestations (step 8) + structured evaluate_ucan

### DIFF
--- a/crates/scp-protocol/src/context/roles.rs
+++ b/crates/scp-protocol/src/context/roles.rs
@@ -12,7 +12,9 @@
 //! - [`CapabilityCeiling`] -- Immutable set of capabilities declared at context
 //!   creation.
 //! - [`RoleDefinition`] -- Named role mapping to a capability subset.
-//! - [`UcanToken`] -- Lightweight UCAN token representation for role-based access control in broadcast contexts.
+//! - [`UcanToken`] -- Lightweight UCAN token representation that populates the
+//!   local `member_capabilities` cache (spec §7.2.2 Tier 2). See the type docs
+//!   for why it carries no per-token signature.
 //! - [`RoleError`] -- Error type for role and capability operations.
 //!
 //! # Built-in Roles
@@ -1054,6 +1056,18 @@ pub fn assign_role(
         .ok_or_else(|| RoleError::RoleNotFound(role_name.to_owned()))?
         .clone();
 
+    // 3a. Mint-time ceiling enforcement (spec §7.2.1 step 8 — "the same
+    // all-attestations rule applies at mint time"). EVERY capability in the
+    // role definition must be within the context's immutable ceiling before any
+    // token is minted. Role definitions are ceiling-validated when they are
+    // built (RoleDefinition::new / ContextRoleState::new /
+    // validate_role_definition); this is the gate-local layer at mint time —
+    // the producer-side counterpart to UCAN validation step 8 on the consumer
+    // side — closing any path by which a role definition carrying an
+    // out-of-ceiling capability (e.g. one built via new_unchecked) could reach
+    // mint and emit out-of-ceiling attestations.
+    validate_role_definition(&role_def, &state.ceiling)?;
+
     // 4. Mint UCAN tokens for each capability in the role.
     let tokens = mint_role_tokens(
         &state.context_id,
@@ -1115,6 +1129,13 @@ pub fn system_assign_role(
         .get(role_name)
         .ok_or_else(|| RoleError::RoleNotFound(role_name.to_owned()))?
         .clone();
+
+    // 2a. Mint-time ceiling enforcement (spec §7.2.1 step 8 — "the same
+    // all-attestations rule applies at mint time"). EVERY capability in the
+    // role definition must be within the context's immutable ceiling before any
+    // token is minted, even on the system path. Mirrors the gate-local re-check
+    // in `assign_role`.
+    validate_role_definition(&role_def, &state.ceiling)?;
 
     // 3. Mint UCAN tokens for each capability in the role.
     let tokens = mint_role_tokens(
@@ -1267,8 +1288,20 @@ pub fn validate_role_definition(
 /// the ADR-009 token format: `iss` = creator DID, `aud` = member DID,
 /// `att` = capability attestation, `nnc` = unique nonce.
 ///
-/// Phase 2 stub: tokens are structurally correct but not cryptographically
-/// signed. Full signing will be added in SCP-024.
+/// These role tokens intentionally carry no per-token signature — this is a
+/// complete design decision, not a stub. See the [`UcanToken`] type docs for
+/// the full rationale (authority is grounded in the signed governance action,
+/// the tokens never cross a trust boundary, and they cannot enter the Tier-1
+/// JWT validation pipeline). Callers MUST NOT add an Ed25519 signature here.
+///
+/// Every capability in `role` is guaranteed to be within the context ceiling at
+/// every call site: the assignment paths ([`assign_role`],
+/// [`system_assign_role`]) run [`validate_role_definition`] against the ceiling
+/// immediately before minting, and the construction path
+/// ([`ContextRoleState::new`]) mints only the `admin` role, whose definition is
+/// already within the ceiling — a custom `admin` override is ceiling-validated
+/// at construction, and the built-in fallback ([`builtin_admin`]) derives its
+/// capabilities directly from the ceiling.
 fn mint_role_tokens(
     context_id: &str,
     creator_did: &str,
@@ -1926,6 +1959,110 @@ mod tests {
         assert!(state.member_has_capability("did:dht:alice", &Capability::MessagesRead));
         assert!(state.member_has_capability("did:dht:alice", &Capability::MessagesWrite));
         assert!(state.member_has_capability("did:dht:alice", &Capability::ToolInvokeAll));
+    }
+
+    #[test]
+    fn assign_role_rejects_role_definition_outside_ceiling() {
+        // Mint-time ceiling enforcement (spec §7.2.1 step 8): even if a role
+        // definition with an out-of-ceiling capability is introduced into
+        // `role_definitions` by any path, `assign_role` must reject it before
+        // minting and must NOT mutate the member's capabilities.
+        //
+        // Use `test_ceiling` (which includes RoleAssign) so the creator-admin
+        // passes the step-1 authorization check; the smuggled role then carries
+        // a Custom capability that is NOT in the ceiling, isolating the
+        // mint-time ceiling gate.
+        let ceiling = test_ceiling();
+        let mut state = ContextRoleState::new(
+            "ctx-1",
+            "did:dht:creator",
+            ceiling,
+            vec![],
+            &scp_primitives::SystemClock,
+        )
+        .unwrap();
+
+        state.members.insert("did:dht:alice".to_owned());
+
+        // Inject a role whose capability set exceeds the ceiling.
+        let out_of_ceiling = Capability::Custom("not-in-ceiling".to_owned());
+        let smuggled = RoleDefinition::new_unchecked(
+            "smuggled",
+            [Capability::MessagesWrite, out_of_ceiling.clone()]
+                .into_iter()
+                .collect(),
+        );
+        state
+            .role_definitions
+            .insert("smuggled".to_owned(), smuggled);
+
+        let result = assign_role(
+            &mut state,
+            "did:dht:alice",
+            "smuggled",
+            "did:dht:creator",
+            &scp_primitives::SystemClock,
+        );
+        assert!(
+            matches!(
+                result,
+                Err(RoleError::CapabilityOutsideCeiling { ref role, ref capability })
+                    if role == "smuggled" && *capability == out_of_ceiling
+            ),
+            "assign_role must reject an out-of-ceiling role definition at mint time: {result:?}"
+        );
+
+        // No tokens minted, no capabilities granted, no assignment recorded.
+        assert!(!state.member_has_capability("did:dht:alice", &Capability::RoleAssign));
+        assert!(!state.member_capabilities.contains_key("did:dht:alice"));
+        assert!(!state.assignments.contains_key("did:dht:alice"));
+    }
+
+    #[test]
+    fn system_assign_role_rejects_role_definition_outside_ceiling() {
+        // Same mint-time ceiling enforcement on the system (governance) path,
+        // which bypasses the RoleAssign authorization check but must NOT bypass
+        // the ceiling.
+        let ceiling = minimal_ceiling();
+        let mut state = ContextRoleState::new(
+            "ctx-1",
+            "did:dht:creator",
+            ceiling,
+            vec![],
+            &scp_primitives::SystemClock,
+        )
+        .unwrap();
+
+        state.members.insert("did:dht:alice".to_owned());
+
+        let smuggled = RoleDefinition::new_unchecked(
+            "smuggled",
+            [Capability::MessagesWrite, Capability::ContextClose]
+                .into_iter()
+                .collect(),
+        );
+        state
+            .role_definitions
+            .insert("smuggled".to_owned(), smuggled);
+
+        let result = system_assign_role(
+            &mut state,
+            "did:dht:alice",
+            "smuggled",
+            &scp_primitives::SystemClock,
+        );
+        assert!(
+            matches!(
+                result,
+                Err(RoleError::CapabilityOutsideCeiling { ref role, ref capability })
+                    if role == "smuggled" && *capability == Capability::ContextClose
+            ),
+            "system_assign_role must reject an out-of-ceiling role definition at mint time: {result:?}"
+        );
+
+        assert!(!state.member_has_capability("did:dht:alice", &Capability::ContextClose));
+        assert!(!state.member_capabilities.contains_key("did:dht:alice"));
+        assert!(!state.assignments.contains_key("did:dht:alice"));
     }
 
     #[test]

--- a/crates/scp-protocol/src/crypto/ucan/capability.rs
+++ b/crates/scp-protocol/src/crypto/ucan/capability.rs
@@ -759,6 +759,35 @@ mod tests {
         assert!(verify_ceiling_compliance(&[], &ceiling).is_ok());
     }
 
+    #[test]
+    fn multi_colon_custom_uri_action_keeps_remainder_and_fails_closed() {
+        // A custom capability URI with extra colons: from_str splits on the
+        // FIRST ':' between resource and action, so the action retains the
+        // remainder verbatim ("write:extra"). The ceiling membership test uses
+        // capability_name() ("messages:write:extra"), which is the same
+        // representation a ceiling entry would be built from — so the two agree.
+        let uri: CapabilityUri = "scp:ctx:abc/messages:write:extra".parse().unwrap();
+        assert_eq!(uri.resource(), "messages");
+        assert_eq!(uri.action(), "write:extra");
+        assert_eq!(uri.capability_name(), "messages:write:extra");
+
+        // Fail-closed: a ceiling that grants only the plain "messages:write"
+        // does NOT cover the multi-colon variant — the extra segment is treated
+        // as outside the ceiling, not silently truncated to a granted form.
+        let plain_ceiling: HashSet<String> = std::iter::once("messages:write".to_owned()).collect();
+        assert!(!uri.is_within_ceiling(&plain_ceiling));
+        let err =
+            verify_ceiling_compliance(std::slice::from_ref(&uri), &plain_ceiling).unwrap_err();
+        assert!(
+            matches!(err, UcanError::CapabilityOutsideCeiling(ref c) if c == "messages:write:extra")
+        );
+
+        // Only an exact ceiling entry for the full capability_name admits it.
+        let exact_ceiling: HashSet<String> =
+            std::iter::once("messages:write:extra".to_owned()).collect();
+        assert!(uri.is_within_ceiling(&exact_ceiling));
+    }
+
     // -----------------------------------------------------------------------
     // check_capability_match
     // -----------------------------------------------------------------------

--- a/crates/scp-protocol/src/crypto/ucan/validate.rs
+++ b/crates/scp-protocol/src/crypto/ucan/validate.rs
@@ -16,7 +16,7 @@
 //! 6. **Capability match** — Verify `att` includes required capability.
 //!    6b. **Category A enforcement** — If `kid` is `#agent`, reject Category A capabilities (ADR-039).
 //! 7. **Attenuation** — Verify delegations narrow or preserve.
-//! 8. **Ceiling** — Verify capability is within context ceiling.
+//! 8. **Ceiling** — Verify every granted capability is within context ceiling.
 //! 9. **Nonce** — Validate format, freshness, uniqueness.
 //! 10. **Revocation** — Verify token CID not in revocation list.
 //! 11. **Expiry** — Verify `exp > now` and `nbf <= now`.
@@ -435,6 +435,38 @@ pub fn parse_ucan(encoded: &str) -> Result<UcanToken, UcanError> {
     })
 }
 
+/// Parses a token's attestation set (`att`) into capability URIs.
+///
+/// This is the shared step-6 parse used by both [`validate_ucan`] (the
+/// enforcing gate) and [`evaluate_ucan`] (the diagnostic). Keeping it in one
+/// place ensures the two pipelines can never drift on how attestations are
+/// parsed.
+///
+/// SECURITY: fail-closed — any single unparseable attestation URI rejects the
+/// entire token. There is no `filter_map`/`ok()` that could silently drop a
+/// malformed attestation and let it escape a downstream check (e.g. the
+/// all-attestation ceiling check, step 8).
+///
+/// # Errors
+///
+/// Returns [`UcanError::MalformedToken`] if any attestation URI cannot be
+/// parsed into a [`CapabilityUri`].
+fn parse_granted_caps(token: &UcanToken) -> Result<Vec<CapabilityUri>, UcanError> {
+    token
+        .payload
+        .att
+        .iter()
+        .map(|att| {
+            att.with.parse::<CapabilityUri>().map_err(|_| {
+                UcanError::MalformedToken(format!(
+                    "unparseable capability URI in attestation: {}",
+                    att.with
+                ))
+            })
+        })
+        .collect()
+}
+
 // ---------------------------------------------------------------------------
 // Validation context
 // ---------------------------------------------------------------------------
@@ -499,7 +531,8 @@ pub struct ValidationContext<'a, D, N, R, P, S: BuildHasher> {
 /// 5. Verify audience matches presenting agent DID.
 /// 6. Verify token's `att` includes required capability.
 /// 7. Attenuation verification (delegation narrows only).
-/// 8. Verify capability is within context ceiling.
+/// 8. Verify every granted capability (the full `att` set) is within the
+///    context ceiling — not only the invoked capability (spec §7.2.1 step 8).
 /// 9. Nonce validation (format, freshness, uniqueness).
 /// 10. Revocation check (token CID not in revocation list).
 /// 11. Expiry verification (`exp > now`, `nbf <= now`, `exp <= now + 24h`).
@@ -540,20 +573,10 @@ where
     )?;
 
     // Step 4: Root issuer — verify root token's iss is context creator.
-    if root_issuer != ctx.context_creator_did {
-        return Err(UcanError::InvalidIssuer {
-            expected: ctx.context_creator_did.to_owned(),
-            actual: root_issuer,
-        });
-    }
+    verify_root_issuer(&root_issuer, ctx.context_creator_did)?;
 
     // Step 5: Audience — verify aud matches presenting agent.
-    if token.payload.aud != ctx.presenting_agent_did {
-        return Err(UcanError::AudienceMismatch {
-            expected: ctx.presenting_agent_did.to_owned(),
-            actual: token.payload.aud.clone(),
-        });
-    }
+    verify_audience(token, ctx.presenting_agent_did)?;
 
     // Steps 5a/5b: Key scope validation (ADR-039, SCP-AB-013).
     // Rejects self-delegation without key_scope and key_scope/kid mismatches.
@@ -561,19 +584,7 @@ where
 
     // Step 6: Capability match — verify att includes required capability.
     // SECURITY: fail-closed — any unparseable attestation URI rejects the entire token.
-    let granted_caps: Vec<CapabilityUri> = token
-        .payload
-        .att
-        .iter()
-        .map(|att| {
-            att.with.parse::<CapabilityUri>().map_err(|_| {
-                UcanError::MalformedToken(format!(
-                    "unparseable capability URI in attestation: {}",
-                    att.with
-                ))
-            })
-        })
-        .collect::<Result<Vec<_>, _>>()?;
+    let granted_caps = parse_granted_caps(token)?;
     check_capability_match(&granted_caps, required_capability)?;
 
     // Step 6b: Category A enforcement (ADR-039 Enforcement Stack layer 3).
@@ -587,8 +598,13 @@ where
         verify_attenuation(token, ctx.proof_resolver)?;
     }
 
-    // Step 8: Ceiling — verify capability is within context ceiling.
-    verify_ceiling_compliance(std::slice::from_ref(required_capability), ctx.ceiling)?;
+    // Step 8: Ceiling — verify EVERY capability the token grants is within the
+    // context's immutable capability ceiling, not only the invoked capability
+    // (spec §7.2.1 step 8). A token carrying any out-of-ceiling attestation is
+    // rejected even if the invoked capability is itself within the ceiling.
+    // `granted_caps` is the full parsed `att` set built in step 6; this makes
+    // step 8 consistent with step 6b (which already iterates all attestations).
+    verify_ceiling_compliance(&granted_caps, ctx.ceiling)?;
 
     // Step 9: Nonce — validate format, freshness, uniqueness.
     ctx.nonce_tracker
@@ -610,8 +626,267 @@ where
 }
 
 // ---------------------------------------------------------------------------
+// Structured, side-effect-free evaluation
+// ---------------------------------------------------------------------------
+
+/// A structured, per-stage summary of a UCAN token's validity.
+///
+/// Produced by [`evaluate_ucan`], this is the diagnostic counterpart to the
+/// fail-closed [`validate_ucan`] gate. It collapses the 11-step pipeline into
+/// six boolean fields suitable for surfacing a trust signal to an SDK consumer
+/// without enforcing (or mutating) anything.
+///
+/// # Dependency ordering
+///
+/// The pipeline is strictly ordered: each stage only runs if every prior stage
+/// passed. A field is `true` only if its stage ran *and* passed; every field
+/// for a stage at or after the first failure is `false` (those stages never
+/// ran, so nothing is known to be valid). This mirrors the short-circuit
+/// behavior of [`validate_ucan`].
+///
+/// # Side-effect freedom
+///
+/// Unlike [`validate_ucan`], evaluating a token records NO state — in
+/// particular the nonce is probed read-only (via
+/// [`NonceTracker::check_replay`]), never recorded. [`evaluate_ucan`] is safe
+/// to call repeatedly on the same token without consuming its nonce.
+///
+/// # Diagnostic accuracy caveats
+///
+/// Because this mirrors the enforcing pipeline's stage boundaries exactly, two
+/// consequences are worth surfacing to any consumer that acts on the fields:
+///
+/// - `signatures_valid` covers the WHOLE delegation chain, not just the leaf
+///   signature. Chain verification (step 3) validates every parent's signature,
+///   expiry, and revocation, so an otherwise-valid leaf whose *parent* is
+///   expired or revoked reports `signatures_valid: false` — not
+///   `time_bounds_valid: false` / `not_revoked: false` (those two fields
+///   reflect only the leaf token).
+/// - The result is a point-in-time snapshot and is NOT a promise that a
+///   subsequent [`validate_ucan`] will accept the token. `nonce_valid: true`
+///   and `not_revoked: true` can both flip to a rejection at enforcement time
+///   if, between the two calls, the nonce is recorded by another request or the
+///   token is revoked. Treat the booleans as a diagnostic signal, never as a
+///   pre-flight success guarantee.
+//
+// Six independent per-stage outcome flags is the mandated public shape of this
+// diagnostic result (one boolean per pipeline stage group). These are pure data
+// — not behavior-selecting flags — so a state machine / two-variant enums (what
+// `struct_excessive_bools` suggests) would obscure, not clarify, the API and
+// break the flat named-field shape the SDK trust signal consumes.
+#[allow(clippy::struct_excessive_bools)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct CapabilityValidation {
+    /// Step 1: the token parsed and its header validated, and the attestation
+    /// set parsed into capability URIs.
+    pub tokens_valid: bool,
+    /// Steps 2-7: signature, delegation chain, root issuer, audience, key
+    /// scope, capability grant-match, Category-A enforcement, and attenuation
+    /// all passed.
+    pub signatures_valid: bool,
+    /// Step 8 (all-attestation ceiling): every capability the token grants (the
+    /// full `att` set) is within the context's immutable capability ceiling
+    /// (spec §7.2.1 step 8). Reaching this stage already implies the step-6
+    /// invoked-capability grant-match passed (it runs inside the
+    /// `signatures_valid` stage), so a `true` here means BOTH the invoked
+    /// capability is granted AND no attestation exceeds the ceiling.
+    pub within_ceiling: bool,
+    /// Step 9: the nonce format, freshness, and uniqueness checks passed
+    /// (probed read-only — the nonce is NOT recorded).
+    pub nonce_valid: bool,
+    /// Step 10: the token's revocation CID is not on the context revocation
+    /// list.
+    pub not_revoked: bool,
+    /// Step 11: `exp`/`nbf` time bounds are valid (within clock-skew
+    /// tolerance).
+    pub time_bounds_valid: bool,
+}
+
+impl CapabilityValidation {
+    /// An all-`false` result — used as the starting point and returned when a
+    /// stage fails (every later stage is left `false` because it never ran).
+    const NONE: Self = Self {
+        tokens_valid: false,
+        signatures_valid: false,
+        within_ceiling: false,
+        nonce_valid: false,
+        not_revoked: false,
+        time_bounds_valid: false,
+    };
+}
+
+/// Evaluates a UCAN token against the 11-step pipeline and returns a structured
+/// [`CapabilityValidation`] summary instead of failing at the first error.
+///
+/// This is the diagnostic, **side-effect-free** counterpart to
+/// [`validate_ucan`]. It is intended for SDK trust signals: a caller can show a
+/// per-stage breakdown of why a token is (or is not) acceptable without
+/// enforcing the result and — critically — without consuming the token's nonce.
+///
+/// # Relationship to [`validate_ucan`]
+///
+/// - It calls the EXACT same sub-checks as [`validate_ucan`] (signature,
+///   delegation chain, issuer/audience, key scope, grant-match, Category-A,
+///   attenuation, all-attestation ceiling, revocation, expiry). No validation
+///   logic is duplicated.
+/// - The nonce step uses [`NonceTracker::check_replay`] (read-only). It NEVER
+///   calls [`NonceTracker::record`] / [`NonceTracker::check_and_record`], so
+///   the tracker is never mutated. Hence `ctx` is taken by shared reference.
+/// - Stages run in pipeline order and short-circuit: the returned struct sets
+///   a field `true` only for stages that ran and passed; the first failing
+///   stage and everything after it are `false`.
+///
+/// # Returns
+///
+/// Always returns a [`CapabilityValidation`] — it never returns an error, even
+/// for a token that fails every check. A token that cannot be parsed into the
+/// required inputs yields `tokens_valid: false` with all later fields `false`.
+#[must_use]
+pub fn evaluate_ucan<D, N, R, P, S>(
+    token: &UcanToken,
+    required_capability: &CapabilityUri,
+    ctx: &ValidationContext<'_, D, N, R, P, S>,
+) -> CapabilityValidation
+where
+    D: DidResolver,
+    N: NonceTracker,
+    R: RevocationChecker,
+    P: ProofResolver,
+    S: BuildHasher,
+{
+    let mut result = CapabilityValidation::NONE;
+
+    // Step 1: Parse — token is pre-parsed; validate the header and parse the
+    // attestation set into capability URIs (fail-closed on any unparseable
+    // URI, exactly as validate_ucan's step 6).
+    if token.header.validate().is_err() {
+        return result;
+    }
+    let Ok(granted_caps) = parse_granted_caps(token) else {
+        return result;
+    };
+    result.tokens_valid = true;
+
+    // Steps 2-7: signature, delegation chain + root issuer, audience, key
+    // scope, grant-match, Category-A, attenuation. Any failure stops here.
+    let sigs_ok = (|| -> Result<(), UcanError> {
+        // Step 2: signature.
+        verify_signature(token, ctx.did_resolver)?;
+
+        // Step 3: delegation chain (returns the root issuer DID).
+        let root_issuer = verify_delegation_chain(
+            token,
+            ctx.did_resolver,
+            ctx.proof_resolver,
+            ctx.revocation_checker,
+            ctx.clock_skew_tolerance_secs,
+            ctx.clock,
+        )?;
+
+        // Step 4: root issuer is the context creator.
+        verify_root_issuer(&root_issuer, ctx.context_creator_did)?;
+
+        // Step 5: audience matches the presenting agent.
+        verify_audience(token, ctx.presenting_agent_did)?;
+
+        // Steps 5a/5b: key scope.
+        validate_key_scope(token)?;
+
+        // Step 6: capability grant-match (the invoked capability).
+        check_capability_match(&granted_caps, required_capability)?;
+
+        // Step 6b: Category-A enforcement.
+        enforce_ucan_category_a(token, &granted_caps)?;
+
+        // Step 7: attenuation (no-op for root tokens).
+        if !token.payload.prf.is_empty() {
+            verify_attenuation(token, ctx.proof_resolver)?;
+        }
+
+        Ok(())
+    })()
+    .is_ok();
+    if !sigs_ok {
+        return result;
+    }
+    result.signatures_valid = true;
+
+    // Steps 6 + 8: within_ceiling reflects BOTH the invoked-capability
+    // grant-match (verified above as part of the signatures stage) AND the
+    // all-attestation ceiling check (spec §7.2.1 step 8). The grant-match
+    // already passed to reach here, so this stage is the all-att ceiling.
+    if verify_ceiling_compliance(&granted_caps, ctx.ceiling).is_err() {
+        return result;
+    }
+    result.within_ceiling = true;
+
+    // Step 9: nonce — READ-ONLY probe. This must never record the nonce, so
+    // evaluate_ucan is safe to call repeatedly on the same token.
+    if ctx
+        .nonce_tracker
+        .check_replay(&token.payload.nnc, token.payload.exp)
+        .is_err()
+    {
+        return result;
+    }
+    result.nonce_valid = true;
+
+    // Step 10: revocation.
+    let revocation_cid = compute_revocation_cid(&token.encoded);
+    if ctx.revocation_checker.is_revoked(&revocation_cid) {
+        return result;
+    }
+    result.not_revoked = true;
+
+    // Step 11: expiry / not-before bounds.
+    if verify_expiry(token, ctx.clock_skew_tolerance_secs, ctx.clock).is_ok() {
+        result.time_bounds_valid = true;
+    }
+
+    result
+}
+
+// ---------------------------------------------------------------------------
 // Individual validation steps
 // ---------------------------------------------------------------------------
+
+/// Step 4: Verify the delegation chain's root issuer is the context creator.
+///
+/// Shared by [`validate_ucan`] and [`evaluate_ucan`] so the root-issuer rule
+/// cannot drift between the enforcing gate and the diagnostic.
+///
+/// # Errors
+///
+/// Returns [`UcanError::InvalidIssuer`] if `root_issuer` is not the context
+/// creator DID.
+fn verify_root_issuer(root_issuer: &str, context_creator_did: &str) -> Result<(), UcanError> {
+    if root_issuer != context_creator_did {
+        return Err(UcanError::InvalidIssuer {
+            expected: context_creator_did.to_owned(),
+            actual: root_issuer.to_owned(),
+        });
+    }
+    Ok(())
+}
+
+/// Step 5: Verify the token's audience matches the presenting agent.
+///
+/// Shared by [`validate_ucan`] and [`evaluate_ucan`] so the audience rule
+/// cannot drift between the enforcing gate and the diagnostic.
+///
+/// # Errors
+///
+/// Returns [`UcanError::AudienceMismatch`] if `token.payload.aud` is not the
+/// presenting agent DID.
+fn verify_audience(token: &UcanToken, presenting_agent_did: &str) -> Result<(), UcanError> {
+    if token.payload.aud != presenting_agent_did {
+        return Err(UcanError::AudienceMismatch {
+            expected: presenting_agent_did.to_owned(),
+            actual: token.payload.aud.clone(),
+        });
+    }
+    Ok(())
+}
 
 /// Extracts the `scp_key_scope` value from a UCAN payload's facts.
 ///

--- a/crates/scp-runtime/tests/ucan_validate_integration.rs
+++ b/crates/scp-runtime/tests/ucan_validate_integration.rs
@@ -24,9 +24,9 @@ use scp_protocol::crypto::ucan::capability::CapabilityUri;
 use scp_protocol::crypto::ucan::nonce;
 use scp_protocol::crypto::ucan::revoke::compute_revocation_cid;
 use scp_protocol::crypto::ucan::validate::{
-    DEFAULT_CLOCK_SKEW_TOLERANCE_SECS, InMemoryDidResolver, InMemoryNonceTracker,
-    InMemoryProofResolver, InMemoryRevocationChecker, NonceTracker, ProofResolver,
-    ValidationContext, parse_ucan, validate_ucan,
+    CapabilityValidation, DEFAULT_CLOCK_SKEW_TOLERANCE_SECS, InMemoryDidResolver,
+    InMemoryNonceTracker, InMemoryProofResolver, InMemoryRevocationChecker, NonceTracker,
+    ProofResolver, ValidationContext, evaluate_ucan, parse_ucan, validate_ucan,
 };
 use scp_protocol::crypto::ucan::{Attenuation, UcanError, UcanHeader, UcanPayload, UcanToken};
 
@@ -1823,5 +1823,445 @@ async fn validate_ucan_scoped_ucan_cannot_be_exercised_by_wrong_key() {
     assert!(
         matches!(result, Err(UcanError::SignatureInvalid)),
         "scoped UCAN exercised by wrong key must fail: {result:?}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Step 8: All-attestation ceiling enforcement (spec §7.2.1 step 8)
+//
+// Step 8 enforces the ceiling over the token's ENTIRE attestation set, not
+// only the invoked capability. A token whose invoked capability is in-ceiling
+// but which smuggles an out-of-ceiling attestation must be rejected, and the
+// rejection must happen BEFORE the nonce is recorded (step 9).
+// ---------------------------------------------------------------------------
+
+/// Mints a multi-attestation token whose invoked cap is in-ceiling but which
+/// also carries an out-of-ceiling attestation, and asserts step 8 rejects it
+/// with `CapabilityOutsideCeiling`.
+#[tokio::test]
+async fn validate_ucan_step8_rejects_smuggled_out_of_ceiling_attestation() {
+    let (custody, key_handle, issuer_did, pk_bytes) = setup_identity().await;
+
+    // Token grants BOTH messages:write (invoked, in-ceiling) and role:assign
+    // (smuggled). Mint-time ceiling includes both so the token is well-formed
+    // and signed; the narrower validation ceiling below is what must reject it.
+    let caps = vec!["messages:write".to_owned(), "role:assign".to_owned()];
+    let mint_ceiling: HashSet<String> = ["messages:write".to_owned(), "role:assign".to_owned()]
+        .into_iter()
+        .collect();
+
+    let params = MintParams {
+        issuer_did: &issuer_did,
+        issuer_key: &key_handle,
+        audience_did: "did:dht:z6MkMember",
+        context_id: "ctx-step8",
+        capabilities: &caps,
+        lifetime_secs: 3600,
+        not_before: None,
+        proofs: vec![],
+        facts: None,
+        key_scope: None,
+        signing_key_id: None,
+        ceiling: Some(mint_ceiling),
+    };
+
+    let token = mint_ucan(&params, &custody, &scp_primitives::SystemClock)
+        .await
+        .unwrap();
+
+    let resolver = InMemoryDidResolver {
+        keys: std::iter::once((issuer_did.clone(), pk_bytes)).collect(),
+        kid_keys: std::collections::HashMap::new(),
+    };
+    let mut nonce_tracker = InMemoryNonceTracker::new();
+    let revocation_checker = InMemoryRevocationChecker::new();
+    let proof_resolver = InMemoryProofResolver::new();
+
+    // Validation ceiling allows messages:write but NOT role:assign.
+    let ceiling: HashSet<String> = std::iter::once("messages:write".to_owned()).collect();
+    let required_cap = CapabilityUri::new("ctx-step8", "messages", "write");
+
+    let mut ctx = build_context(
+        &resolver,
+        &mut nonce_tracker,
+        &revocation_checker,
+        &proof_resolver,
+        &ceiling,
+        &issuer_did,
+        "did:dht:z6MkMember",
+    );
+
+    let result = validate_ucan(&token, &required_cap, &mut ctx);
+    assert!(
+        matches!(result, Err(UcanError::CapabilityOutsideCeiling(ref c)) if c == "role:assign"),
+        "smuggled out-of-ceiling attestation must be rejected by step 8: {result:?}"
+    );
+}
+
+/// A multi-attestation token where every attestation is in-ceiling must pass.
+#[tokio::test]
+async fn validate_ucan_step8_accepts_multi_attestation_all_in_ceiling() {
+    let (custody, key_handle, issuer_did, pk_bytes) = setup_identity().await;
+
+    let caps = vec![
+        "messages:read".to_owned(),
+        "messages:write".to_owned(),
+        "tool_invoke:assistant".to_owned(),
+    ];
+
+    let params = MintParams {
+        issuer_did: &issuer_did,
+        issuer_key: &key_handle,
+        audience_did: "did:dht:z6MkMember",
+        context_id: "ctx-step8-ok",
+        capabilities: &caps,
+        lifetime_secs: 3600,
+        not_before: None,
+        proofs: vec![],
+        facts: None,
+        key_scope: None,
+        signing_key_id: None,
+        ceiling: None,
+    };
+
+    let token = mint_ucan(&params, &custody, &scp_primitives::SystemClock)
+        .await
+        .unwrap();
+
+    let resolver = InMemoryDidResolver {
+        keys: std::iter::once((issuer_did.clone(), pk_bytes)).collect(),
+        kid_keys: std::collections::HashMap::new(),
+    };
+    let mut nonce_tracker = InMemoryNonceTracker::new();
+    let revocation_checker = InMemoryRevocationChecker::new();
+    let proof_resolver = InMemoryProofResolver::new();
+    let ceiling = default_ceiling(); // contains all three caps
+    let required_cap = CapabilityUri::new("ctx-step8-ok", "messages", "write");
+
+    let mut ctx = build_context(
+        &resolver,
+        &mut nonce_tracker,
+        &revocation_checker,
+        &proof_resolver,
+        &ceiling,
+        &issuer_did,
+        "did:dht:z6MkMember",
+    );
+
+    let result = validate_ucan(&token, &required_cap, &mut ctx);
+    assert!(
+        result.is_ok(),
+        "multi-attestation token with all caps in-ceiling must pass: {result:?}"
+    );
+}
+
+/// A ceiling-violating token (rejected at step 8) must NOT consume its nonce:
+/// step 8 short-circuits before step 9 (`check_and_record`). Proven by
+/// validating the token (which must fail with `CapabilityOutsideCeiling`), then
+/// asserting the tracker's read-only `check_replay` still accepts that exact
+/// nonce afterward — which it could only do if step 9 never recorded it.
+#[tokio::test]
+async fn validate_ucan_ceiling_violation_does_not_consume_nonce() {
+    let (custody, key_handle, issuer_did, pk_bytes) = setup_identity().await;
+
+    let caps = vec!["messages:write".to_owned(), "role:assign".to_owned()];
+    let mint_ceiling: HashSet<String> = ["messages:write".to_owned(), "role:assign".to_owned()]
+        .into_iter()
+        .collect();
+
+    let params = MintParams {
+        issuer_did: &issuer_did,
+        issuer_key: &key_handle,
+        audience_did: "did:dht:z6MkMember",
+        context_id: "ctx-step8-nonce",
+        capabilities: &caps,
+        lifetime_secs: 3600,
+        not_before: None,
+        proofs: vec![],
+        facts: None,
+        key_scope: None,
+        signing_key_id: None,
+        ceiling: Some(mint_ceiling),
+    };
+
+    let token = mint_ucan(&params, &custody, &scp_primitives::SystemClock)
+        .await
+        .unwrap();
+
+    let resolver = InMemoryDidResolver {
+        keys: std::iter::once((issuer_did.clone(), pk_bytes)).collect(),
+        kid_keys: std::collections::HashMap::new(),
+    };
+    let mut nonce_tracker = InMemoryNonceTracker::new();
+    let revocation_checker = InMemoryRevocationChecker::new();
+    let proof_resolver = InMemoryProofResolver::new();
+    let ceiling: HashSet<String> = std::iter::once("messages:write".to_owned()).collect();
+    let required_cap = CapabilityUri::new("ctx-step8-nonce", "messages", "write");
+
+    // Validate: must fail at step 8 (ceiling), before step 9 records the nonce.
+    {
+        let mut ctx = build_context(
+            &resolver,
+            &mut nonce_tracker,
+            &revocation_checker,
+            &proof_resolver,
+            &ceiling,
+            &issuer_did,
+            "did:dht:z6MkMember",
+        );
+        let result = validate_ucan(&token, &required_cap, &mut ctx);
+        assert!(
+            matches!(result, Err(UcanError::CapabilityOutsideCeiling(_))),
+            "must be rejected by step 8: {result:?}"
+        );
+    }
+
+    // The token's nonce must NOT have been recorded — a read-only replay probe
+    // for that exact nonce still succeeds (would be NonceReused if step 9 had
+    // run and recorded it).
+    assert!(
+        nonce_tracker
+            .check_replay(&token.payload.nnc, token.payload.exp)
+            .is_ok(),
+        "ceiling-violating token must not have consumed its nonce (step 8 short-circuits before step 9)"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// evaluate_ucan: structured, side-effect-free evaluation
+// ---------------------------------------------------------------------------
+
+/// `evaluate_ucan` called twice on the same token must report `nonce_valid:
+/// true` BOTH times — proving it never records the nonce. As the regression
+/// guard's enforcement half, `validate_ucan` on the same token must throw
+/// `NonceReused` on the 2nd call — proving the gate DOES record.
+#[tokio::test]
+async fn evaluate_ucan_does_not_consume_nonce_but_validate_does() {
+    let (custody, key_handle, issuer_did, pk_bytes) = setup_identity().await;
+    let caps = vec!["messages:write".to_owned()];
+
+    let params = MintParams {
+        issuer_did: &issuer_did,
+        issuer_key: &key_handle,
+        audience_did: "did:dht:z6MkMember",
+        context_id: "ctx-eval-nonce",
+        capabilities: &caps,
+        lifetime_secs: 3600,
+        not_before: None,
+        proofs: vec![],
+        facts: None,
+        key_scope: None,
+        signing_key_id: None,
+        ceiling: None,
+    };
+
+    let token = mint_ucan(&params, &custody, &scp_primitives::SystemClock)
+        .await
+        .unwrap();
+
+    let resolver = InMemoryDidResolver {
+        keys: std::iter::once((issuer_did.clone(), pk_bytes)).collect(),
+        kid_keys: std::collections::HashMap::new(),
+    };
+    let mut nonce_tracker = InMemoryNonceTracker::new();
+    let revocation_checker = InMemoryRevocationChecker::new();
+    let proof_resolver = InMemoryProofResolver::new();
+    let ceiling = default_ceiling();
+    let required_cap = CapabilityUri::new("ctx-eval-nonce", "messages", "write");
+
+    // evaluate_ucan twice — read-only, so nonce_valid must be true both times.
+    {
+        let ctx = build_context(
+            &resolver,
+            &mut nonce_tracker,
+            &revocation_checker,
+            &proof_resolver,
+            &ceiling,
+            &issuer_did,
+            "did:dht:z6MkMember",
+        );
+        let first = evaluate_ucan(&token, &required_cap, &ctx);
+        let second = evaluate_ucan(&token, &required_cap, &ctx);
+        assert!(
+            first.nonce_valid && second.nonce_valid,
+            "evaluate_ucan must not consume the nonce: {first:?} {second:?}"
+        );
+        assert_eq!(
+            first, second,
+            "evaluate_ucan must be deterministic / side-effect-free"
+        );
+        assert!(
+            first
+                == CapabilityValidation {
+                    tokens_valid: true,
+                    signatures_valid: true,
+                    within_ceiling: true,
+                    nonce_valid: true,
+                    not_revoked: true,
+                    time_bounds_valid: true,
+                },
+            "fully valid token must evaluate all-true: {first:?}"
+        );
+    }
+
+    // validate_ucan DOES record: 1st passes, 2nd is NonceReused.
+    {
+        let mut ctx = build_context(
+            &resolver,
+            &mut nonce_tracker,
+            &revocation_checker,
+            &proof_resolver,
+            &ceiling,
+            &issuer_did,
+            "did:dht:z6MkMember",
+        );
+        let first = validate_ucan(&token, &required_cap, &mut ctx);
+        assert!(first.is_ok(), "first validate_ucan must pass: {first:?}");
+    }
+    {
+        let mut ctx = build_context(
+            &resolver,
+            &mut nonce_tracker,
+            &revocation_checker,
+            &proof_resolver,
+            &ceiling,
+            &issuer_did,
+            "did:dht:z6MkMember",
+        );
+        let second = validate_ucan(&token, &required_cap, &mut ctx);
+        assert!(
+            matches!(second, Err(UcanError::NonceReused(_))),
+            "second validate_ucan must reject the recorded nonce: {second:?}"
+        );
+    }
+}
+
+/// `evaluate_ucan` returns the correct per-field struct for a bad-signature
+/// token: parse succeeds (`tokens_valid`), but signature fails so
+/// `signatures_valid` and everything after are false.
+#[tokio::test]
+async fn evaluate_ucan_reports_bad_signature() {
+    let (custody, key_handle, issuer_did, _pk_bytes) = setup_identity().await;
+    let caps = vec!["messages:write".to_owned()];
+
+    let params = MintParams {
+        issuer_did: &issuer_did,
+        issuer_key: &key_handle,
+        audience_did: "did:dht:z6MkMember",
+        context_id: "ctx-eval-sig",
+        capabilities: &caps,
+        lifetime_secs: 3600,
+        not_before: None,
+        proofs: vec![],
+        facts: None,
+        key_scope: None,
+        signing_key_id: None,
+        ceiling: None,
+    };
+
+    let token = mint_ucan(&params, &custody, &scp_primitives::SystemClock)
+        .await
+        .unwrap();
+
+    // Resolver returns the WRONG public key for the issuer, so signature
+    // verification (step 2) fails while parsing (step 1) succeeds.
+    let wrong_pk = [0u8; 32];
+    let resolver = InMemoryDidResolver {
+        keys: std::iter::once((issuer_did.clone(), wrong_pk)).collect(),
+        kid_keys: std::collections::HashMap::new(),
+    };
+    let mut nonce_tracker = InMemoryNonceTracker::new();
+    let revocation_checker = InMemoryRevocationChecker::new();
+    let proof_resolver = InMemoryProofResolver::new();
+    let ceiling = default_ceiling();
+    let required_cap = CapabilityUri::new("ctx-eval-sig", "messages", "write");
+
+    let ctx = build_context(
+        &resolver,
+        &mut nonce_tracker,
+        &revocation_checker,
+        &proof_resolver,
+        &ceiling,
+        &issuer_did,
+        "did:dht:z6MkMember",
+    );
+
+    let result = evaluate_ucan(&token, &required_cap, &ctx);
+    assert_eq!(
+        result,
+        CapabilityValidation {
+            tokens_valid: true,
+            signatures_valid: false,
+            within_ceiling: false,
+            nonce_valid: false,
+            not_revoked: false,
+            time_bounds_valid: false,
+        },
+        "bad signature must report tokens_valid=true, rest false: {result:?}"
+    );
+}
+
+/// `evaluate_ucan` reports `within_ceiling: false` for a token carrying an
+/// out-of-ceiling attestation (signatures pass, ceiling fails, rest false).
+#[tokio::test]
+async fn evaluate_ucan_reports_out_of_ceiling_attestation() {
+    let (custody, key_handle, issuer_did, pk_bytes) = setup_identity().await;
+
+    let caps = vec!["messages:write".to_owned(), "role:assign".to_owned()];
+    let mint_ceiling: HashSet<String> = ["messages:write".to_owned(), "role:assign".to_owned()]
+        .into_iter()
+        .collect();
+
+    let params = MintParams {
+        issuer_did: &issuer_did,
+        issuer_key: &key_handle,
+        audience_did: "did:dht:z6MkMember",
+        context_id: "ctx-eval-ceiling",
+        capabilities: &caps,
+        lifetime_secs: 3600,
+        not_before: None,
+        proofs: vec![],
+        facts: None,
+        key_scope: None,
+        signing_key_id: None,
+        ceiling: Some(mint_ceiling),
+    };
+
+    let token = mint_ucan(&params, &custody, &scp_primitives::SystemClock)
+        .await
+        .unwrap();
+
+    let resolver = InMemoryDidResolver {
+        keys: std::iter::once((issuer_did.clone(), pk_bytes)).collect(),
+        kid_keys: std::collections::HashMap::new(),
+    };
+    let mut nonce_tracker = InMemoryNonceTracker::new();
+    let revocation_checker = InMemoryRevocationChecker::new();
+    let proof_resolver = InMemoryProofResolver::new();
+    let ceiling: HashSet<String> = std::iter::once("messages:write".to_owned()).collect();
+    let required_cap = CapabilityUri::new("ctx-eval-ceiling", "messages", "write");
+
+    let ctx = build_context(
+        &resolver,
+        &mut nonce_tracker,
+        &revocation_checker,
+        &proof_resolver,
+        &ceiling,
+        &issuer_did,
+        "did:dht:z6MkMember",
+    );
+
+    let result = evaluate_ucan(&token, &required_cap, &ctx);
+    assert_eq!(
+        result,
+        CapabilityValidation {
+            tokens_valid: true,
+            signatures_valid: true,
+            within_ceiling: false,
+            nonce_valid: false,
+            not_revoked: false,
+            time_bounds_valid: false,
+        },
+        "out-of-ceiling attestation must report within_ceiling=false: {result:?}"
     );
 }

--- a/crates/scp-runtime/tests/ucan_validate_integration.rs
+++ b/crates/scp-runtime/tests/ucan_validate_integration.rs
@@ -2265,3 +2265,142 @@ async fn evaluate_ucan_reports_out_of_ceiling_attestation() {
         "out-of-ceiling attestation must report within_ceiling=false: {result:?}"
     );
 }
+
+/// `evaluate_ucan` reports `not_revoked: false` for a token whose revocation
+/// CID is on the context revocation list. Revocation is step 10; everything
+/// before it (parse, signatures, ceiling, nonce) passes, and step 11 (expiry)
+/// never runs after revocation short-circuits, so `time_bounds_valid` stays
+/// false. This documents the actual short-circuit field mapping in
+/// `evaluate_ucan`.
+#[tokio::test]
+async fn evaluate_ucan_reports_revoked_token() {
+    let (custody, key_handle, issuer_did, pk_bytes) = setup_identity().await;
+    let caps = vec!["messages:write".to_owned()];
+
+    let params = MintParams {
+        issuer_did: &issuer_did,
+        issuer_key: &key_handle,
+        audience_did: "did:dht:z6MkMember",
+        context_id: "ctx-eval-revoke",
+        capabilities: &caps,
+        lifetime_secs: 3600,
+        not_before: None,
+        proofs: vec![],
+        facts: None,
+        key_scope: None,
+        signing_key_id: None,
+        ceiling: None,
+    };
+
+    let token = mint_ucan(&params, &custody, &scp_primitives::SystemClock)
+        .await
+        .unwrap();
+
+    // Revoke the token by inserting its content-hash CID into the checker.
+    let revocation_cid = compute_revocation_cid(&token.encoded);
+    let mut revocation_checker = InMemoryRevocationChecker::new();
+    revocation_checker.revoked.insert(revocation_cid);
+
+    let resolver = InMemoryDidResolver {
+        keys: std::iter::once((issuer_did.clone(), pk_bytes)).collect(),
+        kid_keys: std::collections::HashMap::new(),
+    };
+    let mut nonce_tracker = InMemoryNonceTracker::new();
+    let proof_resolver = InMemoryProofResolver::new();
+    let ceiling = default_ceiling();
+    let required_cap = CapabilityUri::new("ctx-eval-revoke", "messages", "write");
+
+    let ctx = build_context(
+        &resolver,
+        &mut nonce_tracker,
+        &revocation_checker,
+        &proof_resolver,
+        &ceiling,
+        &issuer_did,
+        "did:dht:z6MkMember",
+    );
+
+    let result = evaluate_ucan(&token, &required_cap, &ctx);
+    assert_eq!(
+        result,
+        CapabilityValidation {
+            tokens_valid: true,
+            signatures_valid: true,
+            within_ceiling: true,
+            nonce_valid: true,
+            not_revoked: false,
+            time_bounds_valid: false,
+        },
+        "revoked token must report not_revoked=false (and time_bounds_valid \
+         stays false because expiry never runs after revocation): {result:?}"
+    );
+}
+
+/// `evaluate_ucan` reports `time_bounds_valid: false` for an expired token.
+/// Expiry is the last step (11); everything before it passes, including
+/// `not_revoked: true`. This documents the actual field mapping in
+/// `evaluate_ucan`.
+#[tokio::test]
+async fn evaluate_ucan_reports_expired_token() {
+    let (custody, key_handle, issuer_did, pk_bytes) = setup_identity().await;
+    let caps = vec!["messages:write".to_owned()];
+
+    let params = MintParams {
+        issuer_did: &issuer_did,
+        issuer_key: &key_handle,
+        audience_did: "did:dht:z6MkMember",
+        context_id: "ctx-eval-expired",
+        capabilities: &caps,
+        lifetime_secs: 1, // Very short lifetime.
+        not_before: None,
+        proofs: vec![],
+        facts: None,
+        key_scope: None,
+        signing_key_id: None,
+        ceiling: None,
+    };
+
+    let token = mint_ucan(&params, &custody, &scp_primitives::SystemClock)
+        .await
+        .unwrap();
+
+    // Wait for the token to expire.
+    tokio::time::sleep(std::time::Duration::from_secs(2)).await;
+
+    let resolver = InMemoryDidResolver {
+        keys: std::iter::once((issuer_did.clone(), pk_bytes)).collect(),
+        kid_keys: std::collections::HashMap::new(),
+    };
+    let mut nonce_tracker = InMemoryNonceTracker::new();
+    let revocation_checker = InMemoryRevocationChecker::new();
+    let proof_resolver = InMemoryProofResolver::new();
+    let ceiling = default_ceiling();
+    let required_cap = CapabilityUri::new("ctx-eval-expired", "messages", "write");
+
+    let mut ctx = build_context(
+        &resolver,
+        &mut nonce_tracker,
+        &revocation_checker,
+        &proof_resolver,
+        &ceiling,
+        &issuer_did,
+        "did:dht:z6MkMember",
+    );
+    // Use zero tolerance so the 2-second expiry is detected.
+    ctx.clock_skew_tolerance_secs = 0;
+
+    let result = evaluate_ucan(&token, &required_cap, &ctx);
+    assert_eq!(
+        result,
+        CapabilityValidation {
+            tokens_valid: true,
+            signatures_valid: true,
+            within_ceiling: true,
+            nonce_valid: true,
+            not_revoked: true,
+            time_bounds_valid: false,
+        },
+        "expired token must report time_bounds_valid=false with all prior \
+         stages true: {result:?}"
+    );
+}

--- a/crates/scp-testing/tests/integration/pipeline_wiring.rs
+++ b/crates/scp-testing/tests/integration/pipeline_wiring.rs
@@ -122,11 +122,21 @@ const RECONNECT_DRIVER_SRC: &str =
 const HANDLERS_MESSAGING_SRC: &str =
     include_str!("../../../../crates/scp-runtime/src/context/actor/handlers/messaging.rs");
 
+// UCAN validation pipeline source — owns `validate_ucan`, the 11-step
+// capability authorization gate. The `ucan_step8_enforces_ceiling_over_all_att`
+// assertion below pins step 8 to checking the FULL parsed attestation set
+// (`&granted_caps`) against the ceiling — not just the invoked capability
+// (spec §7.2.1 step 8) — so a refactor cannot silently regress to
+// `from_ref(required_capability)`, which would let a token smuggle an
+// out-of-ceiling attestation past validation.
+const UCAN_VALIDATE_SRC: &str =
+    include_str!("../../../../crates/scp-protocol/src/crypto/ucan/validate.rs");
+
 // =========================================================================
 // RATCHET CONSTANTS — may only increase
 // Any decrease requires human approval
 // =========================================================================
-const MIN_ACTIVE_PIPELINE_ASSERTIONS: usize = 42;
+const MIN_ACTIVE_PIPELINE_ASSERTIONS: usize = 43;
 
 // ---------------------------------------------------------------------------
 // Function body extraction — brace-matching parser
@@ -1578,6 +1588,38 @@ fn b3_webhook_dispatch_wired() {
             && uniffi_runtime_src.contains("Some(event_tx)"),
         "UniFFI production Supervisor construction must enable the event channel \
          (otherwise subscribe_events yields None and no events are dispatched)"
+    );
+}
+
+// ===========================================================================
+// UCAN validation step 8 — all-attestation ceiling enforcement
+// ===========================================================================
+
+/// Step 8 of `validate_ucan` must enforce the ceiling over the token's FULL
+/// parsed attestation set (`&granted_caps`), not only the invoked capability
+/// (spec §7.2.1 step 8). Pins the fix against a silent regression to
+/// `from_ref(required_capability)`, which would allow a token to smuggle an
+/// out-of-ceiling attestation past validation.
+#[test]
+fn ucan_step8_enforces_ceiling_over_all_att() {
+    assert!(
+        fn_body_contains(
+            UCAN_VALIDATE_SRC,
+            "validate_ucan",
+            "verify_ceiling_compliance(&granted_caps,"
+        ),
+        "validate_ucan step 8 must call verify_ceiling_compliance over the full \
+         parsed attestation set (&granted_caps), per spec §7.2.1 step 8"
+    );
+    assert!(
+        !fn_body_contains(
+            UCAN_VALIDATE_SRC,
+            "validate_ucan",
+            "verify_ceiling_compliance(std::slice::from_ref(required_capability)"
+        ),
+        "validate_ucan step 8 must NOT scope the ceiling check to only the \
+         invoked capability — that lets a token smuggle an out-of-ceiling \
+         attestation (spec §7.2.1 step 8)"
     );
 }
 


### PR DESCRIPTION
## Summary

Implements spec §7.2.1 step 8 (merged in #1875): the capability ceiling is enforced over a token's **entire attestation set**, not only the invoked capability. Adds the producer-side (mint-time) counterpart and a side-effect-free structured diagnostic for SDK trust signals.

Core + tests only — no FFI bridge or SDK surface touched (that is a follow-up PR).

## Change 1 — step 8 enforces the ceiling over ALL attestations

`validate_ucan` step 8 previously checked only the invoked capability:

```rust
verify_ceiling_compliance(std::slice::from_ref(required_capability), ctx.ceiling)?;
```

It now checks the full parsed `att` set:

```rust
verify_ceiling_compliance(&granted_caps, ctx.ceiling)?;
```

`granted_caps` is the same parsed attestation list built at step 6, so step 8 is now consistent with step 6b (Category-A enforcement), which already iterates every attestation. A token whose invoked capability is in-ceiling but which smuggles an out-of-ceiling attestation is now rejected with `CapabilityOutsideCeiling`. Step 8 remains **before** the step-9 nonce record, so a ceiling-violating token never burns a nonce.

## Change 2 — side-effect-free structured `evaluate_ucan`

A diagnostic counterpart to the fail-closed `validate_ucan` gate, intended as an SDK trust signal. It runs the same 11-step pipeline but returns a structured `CapabilityValidation` (six per-stage booleans) instead of failing at the first error, and is **side-effect-free**:

- Takes `&ValidationContext` (compiler-enforced non-mutating — the nonce tracker cannot be recorded through a shared reference).
- Probes the nonce read-only via `NonceTracker::check_replay`; never records it. Safe to call repeatedly on the same token.
- Reuses the exact same sub-checks as `validate_ucan` (no duplicated validation logic) — shared `parse_granted_caps`, `verify_root_issuer`, `verify_audience` helpers, and the all-attestation `verify_ceiling_compliance`, so the gate and the diagnostic cannot drift.
- Documented as non-enforcing and point-in-time (e.g. `signatures_valid` covers the whole delegation chain; the booleans are not a pre-flight success guarantee).

## Change 3 — mint-time ceiling enforcement

`assign_role` and `system_assign_role` now run `validate_role_definition` against the ceiling immediately before minting — the producer-side counterpart to step 8 (spec: "the same all-attestations rule applies at mint time"). Role definitions are ceiling-validated at construction, but `RoleDefinition` has public fields and a `new_unchecked` constructor, so the invariant is **not** type-enforced; this gate-local check prevents a role definition carrying an out-of-ceiling capability from emitting out-of-ceiling attestations. It runs before any token mint and before any state mutation (no partial state on failure), and the system/governance path does not bypass it.

### Mint-time finding

The task asked to verify the mint path. `mint_role_tokens` lives in `crates/scp-protocol/src/context/roles.rs` (not `scp-runtime`). Before this change, neither `assign_role`/`system_assign_role` nor `mint_role_tokens` re-checked the ceiling at mint time — enforcement relied entirely on construction-time validation, which is bypassable via the public fields / `new_unchecked`. Change 3 closes that.

## Tests

- Step 8 rejects a token with an in-ceiling invoked cap but a smuggled out-of-ceiling attestation; accepts a multi-attestation token where all are in-ceiling.
- A ceiling-violating token does **not** consume its nonce (step 8 short-circuits before step 9).
- **Nonce-isolation regression guard:** `evaluate_ucan` called twice keeps `nonce_valid: true` both times (never records), while `validate_ucan` called twice throws `NonceReused` on the 2nd (the gate does record).
- `evaluate_ucan` per-field struct for fully-valid / bad-signature / out-of-ceiling tokens.
- Mint-time rejection on both `assign_role` and `system_assign_role` with no partial state.
- Fail-closed unit test for a multi-colon custom capability URI.
- Pipeline-wiring structural assertion pinning step 8 to `&granted_caps` (and forbidding regression to `from_ref(required_capability)`); ratchet 42→43.

## Verification

- `cargo build/clippy -p scp-protocol --all-targets -- -D warnings` clean; full-workspace CI clippy with all features clean; `cargo fmt --all --check` clean.
- `cargo test -p scp-protocol` — `2999 passed; 0 failed`.
- `cargo test -p scp-runtime --features testing --test ucan_validate_integration` — `37 passed; 0 failed`.
- `cargo test -p scp-testing --test pipeline_wiring` — `59 passed; 0 failed`.

## Reviewed

Two consecutive full-roster review passes (cryptographer, security, bug-catcher, alignment, simplifier, plus adversarial black-hat) — zero blockers, all minor doc/clarity items applied; incremental helper-extraction + doc edits independently re-verified behavior-preserving.

## Noted follow-ups (out of scope for this PR)

- Encapsulate `RoleDefinition` / `ContextRoleState.role_definitions` (private fields + validating accessor) so the ceiling invariant becomes type-enforced; the runtime mint-time check then becomes deletable redundancy. Do not remove the runtime check before that lands.
- Ceiling-string normalization on the UniFFI/WASM construction path can broaden a caller's intended ceiling (a no-colon input becomes an implicit `resource:*` wildcard). Fail-closed against attacker-authored attestation strings, separate subsystem; worth a single shared canonicalizer.