### PR TITLE
fix(contexts): enforce ceiling-entry grammar — no silent custom wildcard (§5.3.1.1)

### DIFF
--- a/crates/scp-ffi/common/src/validate.rs
+++ b/crates/scp-ffi/common/src/validate.rs
@@ -737,12 +737,28 @@ pub fn validate_governance_action_strings(
         GovernanceAction::CreateChildContext { params } => {
             validate_context_params_strings(params)?;
         }
+        GovernanceAction::ModifyCeiling { new_ceiling } => {
+            // Ceiling-entry grammar enforcement at the FFI boundary (spec
+            // §5.3.1.1), defense-in-depth on top of the runtime construction
+            // invariant (`ContextRoleState::set_ceiling`) and the propose-time
+            // check in `execute_modify_ceiling`. A malformed ceiling proposal is
+            // rejected before it ever reaches the `ContextManager`. Validate the
+            // PARSED enum (`validate_as_ceiling_entry`), the canonical form the
+            // runtime enforces, so the boundary check and the enforced parse agree
+            // (BLACK-003).
+            for cap in new_ceiling {
+                cap.validate_as_ceiling_entry().map_err(|e| {
+                    ValidationError::new(format!(
+                        "ModifyCeiling: malformed ceiling entry (spec §5.3.1.1): {e}"
+                    ))
+                })?;
+            }
+        }
         // Variants without user-controlled string fields.
         GovernanceAction::RemoveMember { reason: None, .. }
         | GovernanceAction::CloseContext { reason: None, .. }
         | GovernanceAction::RotateContentKeys { reason: None, .. }
         | GovernanceAction::RemoveTool { .. }
-        | GovernanceAction::ModifyCeiling { .. }
         | GovernanceAction::ExtendTtl { .. }
         | GovernanceAction::TransferAdmin { .. }
         | GovernanceAction::RevokeAccess { .. }
@@ -1692,6 +1708,43 @@ mod tests {
         };
         let err = validate_governance_action_strings(&action).unwrap_err();
         assert!(err.message.contains("HTML-special character"));
+    }
+
+    #[test]
+    fn governance_action_modify_ceiling_rejects_malformed_entry() {
+        use scp_protocol::context::governance::GovernanceAction;
+        use scp_protocol::context::roles::Capability;
+
+        // A no-colon custom is a malformed ceiling entry (spec §5.3.1.1).
+        let action = GovernanceAction::ModifyCeiling {
+            new_ceiling: vec![
+                Capability::MessagesRead,
+                Capability::Custom("payments".to_owned()),
+            ],
+        };
+        let err = validate_governance_action_strings(&action).unwrap_err();
+        assert!(
+            err.message.contains("malformed ceiling entry"),
+            "expected a malformed-ceiling-entry rejection, got: {}",
+            err.message
+        );
+    }
+
+    #[test]
+    fn governance_action_modify_ceiling_accepts_wellformed_entries() {
+        use scp_protocol::context::governance::GovernanceAction;
+        use scp_protocol::context::roles::Capability;
+
+        let action = GovernanceAction::ModifyCeiling {
+            new_ceiling: vec![
+                Capability::MessagesRead,
+                Capability::Custom("payments:approve".to_owned()),
+                Capability::Custom("billing:*".to_owned()),
+                Capability::ToolInvokeAll,
+            ],
+        };
+        validate_governance_action_strings(&action)
+            .expect("well-formed ceiling entries must pass the boundary validator");
     }
 
     // -- Fixed-length byte narrowing --

--- a/crates/scp-ffi/napi/src/runtime.rs
+++ b/crates/scp-ffi/napi/src/runtime.rs
@@ -1515,6 +1515,20 @@ pub fn ensure_registered(
             .map(scp_core::context::roles::Capability::ucan_capability_name)
             .collect::<HashSet<String>>()
     } else {
+        // Ceiling-entry grammar enforcement (spec §5.3.1.1) on the raw user
+        // strings BEFORE they are normalized into the UCAN ceiling string set.
+        // Rejects malformed entries at the bridge boundary (e.g. a no-colon
+        // `payments`, which `Capability::new` + `ucan_capability_name` would
+        // otherwise silently widen to `payments:*`) rather than storing a
+        // broadened entry.
+        for entry in &handle_ceiling {
+            scp_core::context::roles::validate_ceiling_entry(entry).map_err(|e| {
+                ScpNapiError::Validation {
+                    message: e.to_string(),
+                    code: codes::VALID_7000.to_owned(),
+                }
+            })?;
+        }
         handle_ceiling
             .into_iter()
             .map(|s| scp_core::context::roles::Capability::new(&s).ucan_capability_name())

--- a/crates/scp-ffi/napi/src/runtime.rs
+++ b/crates/scp-ffi/napi/src/runtime.rs
@@ -1515,19 +1515,25 @@ pub fn ensure_registered(
             .map(scp_core::context::roles::Capability::ucan_capability_name)
             .collect::<HashSet<String>>()
     } else {
-        // Ceiling-entry grammar enforcement (spec §5.3.1.1) on the raw user
-        // strings BEFORE they are normalized into the UCAN ceiling string set.
-        // Rejects malformed entries at the bridge boundary (e.g. a no-colon
-        // `payments`, which `Capability::new` + `ucan_capability_name` would
-        // otherwise silently widen to `payments:*`) rather than storing a
-        // broadened entry.
+        // Ceiling-entry grammar enforcement (spec §5.3.1.1) on each user entry
+        // BEFORE it is normalized into the UCAN ceiling string set. Validate the
+        // PARSED enum (`Capability::new(entry).validate_as_ceiling_entry()`) — NOT
+        // the raw string — so the validation checks EXACTLY the capability that
+        // gets enforced. `Capability::new` strips a `custom:` prefix: the raw
+        // string `"custom:payments"` has one colon (would pass a raw-string check)
+        // but parses to `Custom("payments")`, whose enforced form
+        // (`ucan_capability_name` → `payments:payments`) corresponds to a no-colon
+        // custom that `validate_as_ceiling_entry` REJECTS. Routing through the
+        // parsed enum keeps the raw-string validation and the enforced parse in
+        // agreement on one canonical form (BLACK-003), and still rejects a
+        // no-colon `payments` that would otherwise be widened to `payments:*`.
         for entry in &handle_ceiling {
-            scp_core::context::roles::validate_ceiling_entry(entry).map_err(|e| {
-                ScpNapiError::Validation {
+            scp_core::context::roles::Capability::new(entry)
+                .validate_as_ceiling_entry()
+                .map_err(|e| ScpNapiError::Validation {
                     message: e.to_string(),
                     code: codes::VALID_7000.to_owned(),
-                }
-            })?;
+                })?;
         }
         handle_ceiling
             .into_iter()

--- a/crates/scp-ffi/src/runtime.rs
+++ b/crates/scp-ffi/src/runtime.rs
@@ -1520,6 +1520,16 @@ pub fn register_ffi_state(
                     .map(scp_core::context::roles::Capability::ucan_capability_name)
                     .collect::<HashSet<String>>()
             } else {
+                // Ceiling-entry grammar enforcement (spec §5.3.1.1) on the raw
+                // user strings BEFORE they are normalized into the UCAN ceiling
+                // string set. Rejects malformed entries at the bridge boundary
+                // (e.g. a no-colon `payments`, which `Capability::new` +
+                // `ucan_capability_name` would otherwise silently widen to
+                // `payments:*`) rather than storing a broadened entry.
+                for entry in user_ceiling {
+                    scp_core::context::roles::validate_ceiling_entry(entry)
+                        .map_err(|e| ScpPyError::context(e.to_string()))?;
+                }
                 user_ceiling
                     .iter()
                     .map(|s| scp_core::context::roles::Capability::new(s).ucan_capability_name())
@@ -3018,6 +3028,56 @@ mod tests {
             !Arc::ptr_eq(&first_manager, second_manager),
             "second bi must hold a distinct ContextManager — not the first's"
         );
+    }
+
+    /// `register_context` rejects a malformed ceiling entry (spec §5.3.1.1) at
+    /// the bridge boundary: a single-token custom (`payments`) and stray-wildcard
+    /// entries (`*:*`, `*:read`) and a multi-colon entry are all rejected, and NO
+    /// FFI state is stored. Proves the `PyO3` reference bridge does not silently
+    /// widen a no-colon custom into `payments:*`.
+    #[test]
+    fn register_context_rejects_malformed_ceiling_entry() {
+        for bad in [
+            "payments",
+            "*:*",
+            "*:read",
+            "payments:read:write",
+            "payments:wr*",
+        ] {
+            let bi = PyBridgeInstance::new_py();
+            let ctx_id = unique_ctx_id("bad-ceiling");
+            let creator = "did:dht:z6MkBadCeiling";
+            let user_ceiling = vec!["messages:read".to_owned(), (*bad).to_owned()];
+            let err = register_context(&bi, &ctx_id, creator, &user_ceiling)
+                .expect_err("malformed ceiling entry must be rejected");
+            assert!(
+                err.to_string().contains("InvalidCeilingCategory"),
+                "expected InvalidCeilingCategory for {bad:?}, got: {err}"
+            );
+            // Defense-in-depth: no FFI state was stored for the rejected context.
+            assert!(
+                with_ffi_state(&bi, &ctx_id, |_| Ok::<(), ScpPyError>(())).is_err(),
+                "rejected context must not have stored FFI state for {bad:?}"
+            );
+        }
+    }
+
+    /// `register_context` accepts a well-formed custom ceiling entry, an explicit
+    /// `{resource}:*` wildcard, and the parameterized `tool:invoke:{tool_id}`
+    /// built-in.
+    #[test]
+    fn register_context_accepts_wellformed_custom_ceiling() {
+        for good in ["payments:approve", "payments:*", "tool:invoke:calc"] {
+            let bi = PyBridgeInstance::new_py();
+            let ctx_id = unique_ctx_id("good-ceiling");
+            let creator = "did:dht:z6MkGoodCeiling";
+            let user_ceiling = vec!["messages:read".to_owned(), (*good).to_owned()];
+            let result = register_context(&bi, &ctx_id, creator, &user_ceiling);
+            assert!(
+                result.is_ok(),
+                "well-formed ceiling {good:?} must be accepted: {result:?}"
+            );
+        }
     }
 
     // -----------------------------------------------------------------------

--- a/crates/scp-ffi/src/runtime.rs
+++ b/crates/scp-ffi/src/runtime.rs
@@ -1520,14 +1520,23 @@ pub fn register_ffi_state(
                     .map(scp_core::context::roles::Capability::ucan_capability_name)
                     .collect::<HashSet<String>>()
             } else {
-                // Ceiling-entry grammar enforcement (spec §5.3.1.1) on the raw
-                // user strings BEFORE they are normalized into the UCAN ceiling
-                // string set. Rejects malformed entries at the bridge boundary
-                // (e.g. a no-colon `payments`, which `Capability::new` +
-                // `ucan_capability_name` would otherwise silently widen to
-                // `payments:*`) rather than storing a broadened entry.
+                // Ceiling-entry grammar enforcement (spec §5.3.1.1) on each user
+                // entry BEFORE it is normalized into the UCAN ceiling string set.
+                // Validate the PARSED enum (`Capability::new(entry)
+                // .validate_as_ceiling_entry()`) — NOT the raw string — so the
+                // validation checks EXACTLY the capability that gets enforced.
+                // `Capability::new` strips a `custom:` prefix: the raw string
+                // `"custom:payments"` has one colon (would pass a raw-string check)
+                // but parses to `Custom("payments")`, whose enforced form
+                // (`ucan_capability_name` → `payments:payments`) corresponds to a
+                // no-colon custom that `validate_as_ceiling_entry` REJECTS. Routing
+                // through the parsed enum keeps the raw-string validation and the
+                // enforced parse in agreement on one canonical form (BLACK-003), and
+                // still rejects a no-colon `payments` that would otherwise be widened
+                // to `payments:*`.
                 for entry in user_ceiling {
-                    scp_core::context::roles::validate_ceiling_entry(entry)
+                    scp_core::context::roles::Capability::new(entry)
+                        .validate_as_ceiling_entry()
                         .map_err(|e| ScpPyError::context(e.to_string()))?;
                 }
                 user_ceiling

--- a/crates/scp-ffi/src/runtime.rs
+++ b/crates/scp-ffi/src/runtime.rs
@@ -3072,11 +3072,25 @@ mod tests {
     }
 
     /// `register_context` accepts a well-formed custom ceiling entry, an explicit
-    /// `{resource}:*` wildcard, and the parameterized `tool:invoke:{tool_id}`
-    /// built-in.
+    /// `{resource}:*` wildcard, the parameterized `tool:invoke:{tool_id}`
+    /// built-in, and a built-in supplied in its canonical UCAN wire spelling
+    /// (`tool_invoke:*`, `context_child:create`, `bridging:*`,
+    /// `tool_invoke:{id}`). Pins the regression where a UCAN-form built-in entry
+    /// — the canonical stored ceiling spelling — was misparsed to a `Custom`
+    /// lookalike and rejected with `InvalidCeilingCategory`.
     #[test]
     fn register_context_accepts_wellformed_custom_ceiling() {
-        for good in ["payments:approve", "payments:*", "tool:invoke:calc"] {
+        for good in [
+            "payments:approve",
+            "payments:*",
+            "tool:invoke:calc",
+            "tool:invoke:*",
+            "context:child:create",
+            "tool_invoke:*",
+            "tool_invoke:calc",
+            "context_child:create",
+            "bridging:*",
+        ] {
             let bi = PyBridgeInstance::new_py();
             let ctx_id = unique_ctx_id("good-ceiling");
             let creator = "did:dht:z6MkGoodCeiling";

--- a/crates/scp-ffi/uniffi/src/runtime.rs
+++ b/crates/scp-ffi/uniffi/src/runtime.rs
@@ -978,8 +978,17 @@ impl UniffiBridgeInstance {
                 .map(scp_core::context::roles::Capability::ucan_capability_name)
                 .collect::<HashSet<String>>()
         } else {
+            // Ceiling-entry grammar enforcement (spec §5.3.1.1). This per-instance
+            // UCAN-state cache is populated AFTER `context_create` already routed
+            // through the runtime creation gate (`lifecycle_helpers::create_context`
+            // → `ContextRoleState::new`), which rejects any malformed ceiling — so
+            // every surviving entry is well-formed. As infallible defense-in-depth,
+            // a malformed entry is SKIPPED rather than normalized: this forecloses
+            // the silent broadening where a no-colon `payments` would become
+            // `payments:*` via `Capability::new` + `ucan_capability_name`.
             ceiling
                 .iter()
+                .filter(|s| scp_core::context::roles::validate_ceiling_entry(s).is_ok())
                 .map(|s| scp_core::context::roles::Capability::new(s).ucan_capability_name())
                 .collect::<HashSet<String>>()
         };

--- a/crates/scp-ffi/uniffi/src/runtime.rs
+++ b/crates/scp-ffi/uniffi/src/runtime.rs
@@ -986,9 +986,24 @@ impl UniffiBridgeInstance {
             // a malformed entry is SKIPPED rather than normalized: this forecloses
             // the silent broadening where a no-colon `payments` would become
             // `payments:*` via `Capability::new` + `ucan_capability_name`.
+            //
+            // Filter on the PARSED enum (`Capability::new(s)
+            // .validate_as_ceiling_entry()`) — NOT the raw string — so the
+            // accept/skip decision uses EXACTLY the capability that gets enforced
+            // (and mapped via `ucan_capability_name` on the next line). The runtime
+            // gate validates the same parsed-enum form, so this filter never skips
+            // an entry the runtime accepted nor keeps one it rejected. Validating
+            // the raw string instead would diverge on a prefix-stripped custom: the
+            // raw `"custom:payments"` passes a raw-string check but parses to
+            // `Custom("payments")` (enforced `payments:payments`), a no-colon custom
+            // the parsed-enum check correctly rejects (BLACK-003).
             ceiling
                 .iter()
-                .filter(|s| scp_core::context::roles::validate_ceiling_entry(s).is_ok())
+                .filter(|s| {
+                    scp_core::context::roles::Capability::new(s)
+                        .validate_as_ceiling_entry()
+                        .is_ok()
+                })
                 .map(|s| scp_core::context::roles::Capability::new(s).ucan_capability_name())
                 .collect::<HashSet<String>>()
         };

--- a/crates/scp-ffi/wasm/src/manager.rs
+++ b/crates/scp-ffi/wasm/src/manager.rs
@@ -1445,6 +1445,24 @@ impl WasmContextManager {
             });
         }
 
+        // Ceiling-entry grammar enforcement (spec §5.3.1.1). The WASM bridge does
+        // NOT route ceiling construction through `ContextRoleState::new` (the
+        // native enforcement point), so it validates each user-supplied ceiling
+        // entry here against the SAME canonical grammar validator. This forecloses
+        // a malformed entry being normalized into the ceiling string set — in
+        // particular it prevents any silent broadening, since a no-colon custom
+        // (e.g. `payments`) and stray-`*` entries (`*:*`, `*:read`) are rejected
+        // rather than normalized. Built-in defaults (empty ceiling) are
+        // well-formed by construction and skip per-entry validation.
+        for entry in &ceiling {
+            scp_protocol::context::roles::validate_ceiling_entry(entry).map_err(|e| {
+                ScpWasmError::Validation {
+                    message: e.to_string(),
+                    code: codes::VALID_7000.to_owned(),
+                }
+            })?;
+        }
+
         let ceiling_strings = Self::build_ceiling_strings(&ceiling);
 
         // Parse and validate minProtocolVersion from params (spec §13.4).
@@ -8771,6 +8789,87 @@ mod tests {
             !mgr.contexts.contains_key("ctx-paid"),
             "rejected paid context must not appear in the registry"
         );
+    }
+
+    /// `create_context` rejects a malformed ceiling entry (spec §5.3.1.1)
+    /// BEFORE any state mutation (the ceiling-grammar gate runs ahead of the
+    /// time-dependent creation path), and nothing is inserted into the registry.
+    /// A single-token custom (`payments`) and a stray-wildcard (`*:*`) are both
+    /// rejected — proving the WASM bridge does NOT silently normalize/broaden
+    /// them into the ceiling.
+    #[test]
+    fn test_wasm_context_create_rejects_malformed_ceiling_entry() {
+        for bad_entry in [
+            "payments",
+            "*:*",
+            "*:read",
+            "payments:read:write",
+            "payments:wr*",
+        ] {
+            let mut mgr = WasmContextManager::new();
+            let creator = "did:dht:zcreator";
+            let params = serde_json::json!({
+                "mode": "Encrypted",
+                "ceiling": ["messages:read", bad_entry],
+                "ceilingPolicy": "immutable",
+                "governance": "single_admin",
+                "economicPolicy": free_policy_json(),
+            });
+
+            let err = mgr
+                .create_context("ctx-bad-ceiling", creator, &params)
+                .expect_err("create_context must reject malformed ceiling entry");
+
+            match err {
+                ScpWasmError::Validation {
+                    ref code,
+                    ref message,
+                } => {
+                    assert_eq!(code, codes::VALID_7000);
+                    assert!(
+                        message.contains("InvalidCeilingCategory"),
+                        "expected InvalidCeilingCategory for {bad_entry:?}, got: {message}"
+                    );
+                }
+                other => panic!("expected Validation error for {bad_entry:?}, got: {other:?}"),
+            }
+
+            assert!(
+                !mgr.contexts.contains_key("ctx-bad-ceiling"),
+                "rejected context must not appear in the registry for {bad_entry:?}"
+            );
+        }
+    }
+
+    /// `create_context` accepts a well-formed custom ceiling entry and an
+    /// explicit `{resource}:*` wildcard at the grammar gate (the gate passes;
+    /// downstream creation is covered by the conformance suite under a real JS
+    /// host). We assert the gate does not reject these well-formed entries by
+    /// confirming the error, if any, is NOT an `InvalidCeilingCategory`.
+    #[test]
+    fn test_wasm_context_create_accepts_wellformed_custom_ceiling() {
+        for good_entry in ["payments:approve", "payments:*", "tool:invoke:calc"] {
+            let mut mgr = WasmContextManager::new();
+            let creator = "did:dht:zcreator";
+            let params = serde_json::json!({
+                "mode": "Encrypted",
+                "ceiling": ["messages:read", good_entry],
+                "ceilingPolicy": "immutable",
+                "governance": "single_admin",
+                "economicPolicy": free_policy_json(),
+            });
+            // The grammar gate must NOT reject well-formed entries. (The accept
+            // path may still error later on the native time stub — that is not a
+            // ceiling-grammar rejection.)
+            if let Err(ScpWasmError::Validation { code, message }) =
+                mgr.create_context("ctx-good-ceiling", creator, &params)
+            {
+                assert!(
+                    !(code == codes::VALID_7000 && message.contains("InvalidCeilingCategory")),
+                    "well-formed entry {good_entry:?} must not be rejected by the grammar gate: {message}"
+                );
+            }
+        }
     }
 
     /// **C2-B:** `create_context` accepts a free economic policy. The

--- a/crates/scp-ffi/wasm/src/manager.rs
+++ b/crates/scp-ffi/wasm/src/manager.rs
@@ -252,6 +252,149 @@ const WASM_PROPOSAL_DEADLINE_MS: f64 = 3_600_000.0;
 // (§5.14.2 cohesion invariant — broadcast keys stored alongside context data).
 
 // ---------------------------------------------------------------------------
+// ValidatedCeilingStrings — the single validated WASM ceiling constructor
+// ---------------------------------------------------------------------------
+
+/// A capability ceiling stored as canonical UCAN-form `{resource}:{action}`
+/// strings, where EVERY entry is well-formed per the ceiling-entry grammar
+/// (spec §5.3.1.1) — guaranteed BY THE TYPE.
+///
+/// ADR-034: the WASM bridge does not use the native [`CapabilityCeiling`] type
+/// (it stores UCAN strings, not `Capability` enums), so this newtype gives the
+/// WASM path the analogous type-level guarantee the native validating
+/// `Deserialize` gives there. Its inner set is PRIVATE; the ONLY ways to build a
+/// non-empty value are the three validating constructors below, so a WASM
+/// ceiling cannot be set without parsing+validating+formatting each entry through
+/// the SAME canonical scp-protocol grammar both bridges share. Reads go through
+/// [`Deref`] to `&HashSet<String>`, so a `ValidatedCeilingStrings` is a drop-in
+/// for the prior `HashSet<String>` on every read path.
+///
+/// All three constructors converge on the SAME canonical UCAN form:
+/// - [`from_colon_entries`](Self::from_colon_entries) (create): parses the
+///   user's colon-form input via [`Capability::new`], validates the parsed enum
+///   via [`Capability::validate_as_ceiling_entry`], formats via
+///   [`Capability::ucan_capability_name`].
+/// - [`from_capabilities`](Self::from_capabilities) (ModifyCeiling): validates
+///   the already-parsed enum and formats via [`Capability::ucan_capability_name`].
+/// - [`from_ucan_strings`](Self::from_ucan_strings) (import): the entries are
+///   already UCAN form (a signed peer export), validated via
+///   [`validate_ucan_ceiling_string`] and stored verbatim (already canonical).
+///
+/// Because create parses colon-form `custom:payments:approve` → `Custom(
+/// "payments:approve")` → `payments:approve` (NOT the raw-string
+/// `custom_payments:approve` the old `build_ceiling_strings` produced), and
+/// import validates+stores the canonical UCAN form, create / modify / import all
+/// produce the byte-identical ceiling the native bridge stores.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub(crate) struct ValidatedCeilingStrings(HashSet<String>);
+
+impl ValidatedCeilingStrings {
+    /// Default WASM ceiling (used when create supplies no explicit ceiling).
+    ///
+    /// Matches `scp_protocol::context::roles::default_ceiling` mapped through
+    /// [`Capability::ucan_capability_name`], so the WASM default and the native
+    /// default are the same canonical UCAN-form set.
+    fn defaults() -> Self {
+        Self(
+            scp_protocol::context::roles::default_ceiling()
+                .iter()
+                .map(scp_protocol::context::roles::Capability::ucan_capability_name)
+                .collect(),
+        )
+    }
+
+    /// Builds a validated ceiling from user-supplied COLON-form entries (the
+    /// `create_context` path). An empty list yields [`Self::defaults`].
+    ///
+    /// # Errors
+    ///
+    /// Returns a `Validation` error on the first entry that is not a well-formed
+    /// ceiling entry per spec §5.3.1.1.
+    fn from_colon_entries(entries: &[String]) -> Result<Self, ScpWasmError> {
+        if entries.is_empty() {
+            return Ok(Self::defaults());
+        }
+        let mut set = HashSet::with_capacity(entries.len());
+        for entry in entries {
+            let cap = scp_protocol::context::roles::Capability::new(entry);
+            cap.validate_as_ceiling_entry()
+                .map_err(|e| ScpWasmError::Validation {
+                    message: e.to_string(),
+                    code: codes::VALID_7000.to_owned(),
+                })?;
+            set.insert(cap.ucan_capability_name());
+        }
+        Ok(Self(set))
+    }
+
+    /// Builds a validated ceiling from already-parsed [`Capability`] enums (the
+    /// `ModifyCeiling` governance path).
+    ///
+    /// # Errors
+    ///
+    /// Returns a `Validation` error on the first capability that is not a
+    /// well-formed ceiling entry per spec §5.3.1.1.
+    fn from_capabilities(
+        caps: &[scp_protocol::context::roles::Capability],
+    ) -> Result<Self, ScpWasmError> {
+        let mut set = HashSet::with_capacity(caps.len());
+        for cap in caps {
+            cap.validate_as_ceiling_entry()
+                .map_err(|e| ScpWasmError::Validation {
+                    message: e.to_string(),
+                    code: codes::VALID_7000.to_owned(),
+                })?;
+            set.insert(cap.ucan_capability_name());
+        }
+        Ok(Self(set))
+    }
+
+    /// Builds a validated ceiling from UCAN-form strings read from an UNTRUSTED,
+    /// deserialized peer export (the `import_context` path). Each entry is
+    /// validated via [`validate_ucan_ceiling_string`] (the UCAN-form counterpart
+    /// to the colon-form grammar) and stored verbatim — a conformant exporter's
+    /// strings are already canonical UCAN form, so this is idempotent; a
+    /// non-conformant peer's malformed or non-canonical (colon-form) entry is
+    /// REJECTED rather than poisoning the importer's ceiling.
+    ///
+    /// # Errors
+    ///
+    /// Returns a `Validation` error on the first entry that is not a well-formed
+    /// UCAN-form ceiling entry per spec §5.3.1.1.
+    fn from_ucan_strings<'a, I>(entries: I) -> Result<Self, ScpWasmError>
+    where
+        I: IntoIterator<Item = &'a String>,
+    {
+        let mut set = HashSet::new();
+        for entry in entries {
+            scp_protocol::context::roles::validate_ucan_ceiling_string(entry).map_err(|e| {
+                ScpWasmError::Validation {
+                    message: e.to_string(),
+                    code: codes::VALID_7000.to_owned(),
+                }
+            })?;
+            set.insert(entry.clone());
+        }
+        Ok(Self(set))
+    }
+
+    /// Test-only: insert a raw UCAN-form capability string, bypassing validation,
+    /// to simulate a corrupt/non-conformant stored ceiling.
+    #[cfg(test)]
+    fn test_insert(&mut self, capability: &str) {
+        self.0.insert(capability.to_owned());
+    }
+}
+
+impl std::ops::Deref for ValidatedCeilingStrings {
+    type Target = HashSet<String>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+// ---------------------------------------------------------------------------
 // PerContextState — per-context state
 // ---------------------------------------------------------------------------
 
@@ -269,8 +412,13 @@ pub(crate) struct PerContextState {
     creator_did: String,
     /// Context mode: "Encrypted" or "Broadcast".
     mode: String,
-    /// Capability ceiling as `{resource}:{action}` strings.
-    ceiling_strings: HashSet<String>,
+    /// Capability ceiling as canonical UCAN-form `{resource}:{action}` strings.
+    ///
+    /// Held as [`ValidatedCeilingStrings`] so it cannot be set without routing
+    /// through a validating constructor (create / modify / import) — a malformed
+    /// entry can never be stored, and all three write paths produce the
+    /// byte-identical canonical form the native bridge stores.
+    ceiling_strings: ValidatedCeilingStrings,
     /// Ceiling policy: "immutable" or "governed".
     ceiling_policy: String,
     /// TTL in seconds, if any.
@@ -838,10 +986,11 @@ impl PerContextState {
         self.consequence_rules.push(rule);
     }
 
-    /// Test-only: add a capability string to the context ceiling.
+    /// Test-only: add a raw capability string to the context ceiling, bypassing
+    /// validation (simulates a corrupt/non-conformant stored ceiling).
     #[cfg(test)]
     pub(crate) fn test_insert_ceiling(&mut self, capability: &str) {
-        self.ceiling_strings.insert(capability.to_owned());
+        self.ceiling_strings.test_insert(capability);
     }
 
     /// Test-only: set the governance model string (e.g. `"majority"`), so
@@ -1281,7 +1430,7 @@ pub(crate) fn make_bare_per_context_state(context_id: &str, creator_did: &str) -
         params_json: serde_json::Value::Null,
         creator_did: creator_did.to_owned(),
         mode: "Unencrypted".to_owned(),
-        ceiling_strings: HashSet::new(),
+        ceiling_strings: ValidatedCeilingStrings::default(),
         ceiling_policy: "immutable".to_owned(),
         ttl_seconds: None,
         promotion_policy: None,
@@ -1445,31 +1594,22 @@ impl WasmContextManager {
             });
         }
 
-        // Ceiling-entry grammar enforcement (spec §5.3.1.1). The WASM bridge does
-        // NOT route ceiling construction through `ContextRoleState::new` (the
-        // native enforcement point), so it validates each user-supplied ceiling
-        // entry here against the SAME canonical grammar validator. Validate the
-        // PARSED enum (`Capability::new(entry).validate_as_ceiling_entry()`) — NOT
-        // the raw string — so the WASM create path agrees with the native bridges
-        // and the WASM `ModifyCeiling` handler on one canonical parse (BLACK-003):
-        // `Capability::new` strips a `custom:` prefix, so the raw `"custom:payments"`
-        // (one colon, would pass a raw-string check) parses to `Custom("payments")`,
-        // a no-colon custom the parsed-enum check correctly REJECTS. This forecloses
-        // a malformed entry being normalized into the ceiling string set — in
-        // particular any silent broadening, since a no-colon custom (e.g. `payments`)
-        // and stray-`*` entries (`*:*`, `*:read`) are rejected rather than
-        // normalized. Built-in defaults (empty ceiling) are well-formed by
-        // construction and skip per-entry validation.
-        for entry in &ceiling {
-            scp_protocol::context::roles::Capability::new(entry)
-                .validate_as_ceiling_entry()
-                .map_err(|e| ScpWasmError::Validation {
-                    message: e.to_string(),
-                    code: codes::VALID_7000.to_owned(),
-                })?;
-        }
-
-        let ceiling_strings = Self::build_ceiling_strings(&ceiling);
+        // Ceiling-entry grammar enforcement (spec §5.3.1.1) AND canonical
+        // formatting in ONE step. The WASM bridge does NOT route ceiling
+        // construction through `ContextRoleState::new` (the native enforcement
+        // point), so it builds the ceiling through the single validated
+        // constructor `ValidatedCeilingStrings::from_colon_entries`, which parses
+        // each user-supplied colon-form entry via `Capability::new`, validates the
+        // PARSED enum via `validate_as_ceiling_entry`, and formats via
+        // `ucan_capability_name` — the SAME canonical parse+format the native
+        // bridges and the WASM `ModifyCeiling` handler use. This both rejects a
+        // malformed entry (no-colon `custom:payments` → `Custom("payments")`,
+        // stray-`*` `*:*`/`*:read`, multi-colon) AND stores the canonical form,
+        // closing the prior split where validation parsed the enum but the store
+        // formatted from the RAW string (`custom:payments:approve` stored as
+        // `custom_payments:approve` on WASM but `payments:approve` on native). An
+        // empty ceiling yields the canonical default set.
+        let ceiling_strings = ValidatedCeilingStrings::from_colon_entries(&ceiling)?;
 
         // Parse and validate minProtocolVersion from params (spec §13.4).
         // This mirrors the NAPI bridge's parsing in context_create. Malformed
@@ -2764,7 +2904,7 @@ impl WasmContextManager {
     ) -> Result<(HashSet<String>, String, HashSet<String>), ScpWasmError> {
         let ctx = self.require_context(context_id)?;
         Ok((
-            ctx.ceiling_strings.clone(),
+            (*ctx.ceiling_strings).clone(),
             ctx.creator_did.clone(),
             ctx.revoked_tokens.clone(),
         ))
@@ -3310,13 +3450,11 @@ impl WasmContextManager {
         context_id: &str,
         new_ceiling: &[scp_protocol::context::roles::Capability],
     ) -> Result<serde_json::Value, ScpWasmError> {
-        for cap in new_ceiling {
-            cap.validate_as_ceiling_entry()
-                .map_err(|e| ScpWasmError::Validation {
-                    message: e.to_string(),
-                    code: codes::VALID_7000.to_owned(),
-                })?;
-        }
+        // Validate + canonicalize the WHOLE replacement through the single
+        // validated constructor BEFORE any mutation, so a malformed proposed
+        // entry leaves the prior ceiling unchanged (fail-closed) and the stored
+        // form is byte-identical to native/create.
+        let validated = ValidatedCeilingStrings::from_capabilities(new_ceiling)?;
         let ctx = self.require_active_context_mut(context_id)?;
         if ctx.ceiling_policy != "governed" {
             return Err(ScpWasmError::Permission {
@@ -3324,10 +3462,7 @@ impl WasmContextManager {
                 code: codes::PERM_3000.to_owned(),
             });
         }
-        ctx.ceiling_strings = new_ceiling
-            .iter()
-            .map(|c| Self::capability_to_ucan_format(&c.name()))
-            .collect();
+        ctx.ceiling_strings = validated;
         Ok(serde_json::json!({"action": "ModifyCeiling"}))
     }
 
@@ -5833,42 +5968,6 @@ impl WasmContextManager {
         }
     }
 
-    /// Builds the capability ceiling string set from explicit ceiling entries
-    /// or defaults matching scp-core's UCAN `{resource}:{action}` format.
-    ///
-    /// Default capabilities use underscore-format for compound resources
-    /// (e.g. `"tool_invoke:*"`, `"tool:register"`) to match scp-core's
-    /// `Capability::ucan_capability_name()` output. This ensures UCAN ceiling
-    /// checks (step 8 of validation) pass when tokens minted by scp-core are
-    /// validated in the WASM bridge.
-    ///
-    /// User-provided ceiling strings are converted from colon-format to
-    /// UCAN format via [`capability_to_ucan_format`].
-    fn build_ceiling_strings(ceiling: &[String]) -> HashSet<String> {
-        if ceiling.is_empty() {
-            [
-                "messages:read",
-                "messages:write",
-                "tool:register",
-                "tool_invoke:*",
-                "role:assign",
-                "member:invite",
-                "member:remove",
-                "governance:propose",
-                "governance:vote",
-                "context:close",
-            ]
-            .iter()
-            .map(|s| (*s).to_owned())
-            .collect()
-        } else {
-            ceiling
-                .iter()
-                .map(|s| Self::capability_to_ucan_format(s))
-                .collect()
-        }
-    }
-
     /// Returns a reference to context state, or an error if not found.
     fn require_context(&self, context_id: &str) -> Result<&PerContextState, ScpWasmError> {
         self.contexts
@@ -6456,13 +6555,26 @@ impl WasmContextManager {
         // defense-in-depth HMAC. Forging `creation_timestamp_secs` therefore requires
         // the creator's signing key. §9.9.3 additionally requires the value verbatim
         // for cross-member/bridge convergence, so clamping is forbidden regardless.
+        // Ceiling-entry grammar enforcement on the IMPORTED, deserialized ceiling
+        // (spec §5.3.1.1). The snapshot is fully attacker-controlled: a valid
+        // signature authenticates the export's ORIGIN, not the WELL-FORMEDNESS of
+        // its payload, so a non-conformant peer could sign an export carrying a
+        // malformed (or non-canonical) ceiling string. Route every imported entry
+        // through the single validated constructor — `from_ucan_strings` validates
+        // each against the UCAN-form grammar and stores it canonically — so a
+        // malformed entry is REJECTED here rather than poisoning the importer's
+        // ceiling (closes BLACK-005, where the import previously copied the raw
+        // `ceiling_strings` with no validation). After this, WASM create / modify /
+        // import all produce the SAME canonical ceiling form.
+        let imported_ceiling = ValidatedCeilingStrings::from_ucan_strings(&snap.ceiling_strings)?;
+
         let now_ms_for_clamp = crate::time::now_ms();
         let ctx = PerContextState {
             state: snap.state.clone(),
             params_json: snap.params_json.clone(),
             creator_did: snap.creator_did.clone(),
             mode: snap.mode.clone(),
-            ceiling_strings: snap.ceiling_strings.iter().cloned().collect(),
+            ceiling_strings: imported_ceiling,
             ceiling_policy: snap.ceiling_policy.clone(),
             ttl_seconds: snap.ttl_seconds,
             promotion_policy: snap.promotion_policy.clone(),
@@ -7960,7 +8072,7 @@ mod tests {
             params_json: serde_json::json!({"mode": "Broadcast"}),
             creator_did: creator_did.to_owned(),
             mode: "Broadcast".to_owned(),
-            ceiling_strings: HashSet::new(),
+            ceiling_strings: ValidatedCeilingStrings::default(),
             ceiling_policy: "immutable".to_owned(),
             ttl_seconds: None,
             promotion_policy: None,
@@ -8072,7 +8184,7 @@ mod tests {
             params_json: serde_json::json!({}),
             creator_did: creator_did.to_owned(),
             mode: "Encrypted".to_owned(),
-            ceiling_strings: HashSet::new(),
+            ceiling_strings: ValidatedCeilingStrings::default(),
             ceiling_policy: "immutable".to_owned(),
             ttl_seconds: None,
             promotion_policy: None,
@@ -8914,6 +9026,148 @@ mod tests {
         }
     }
 
+    /// CREATE-PATH canonical-form parity: the single validated constructor the
+    /// WASM create path routes through (`ValidatedCeilingStrings::from_colon_entries`)
+    /// stores a `custom:`-prefixed multi-token entry as the IDENTICAL canonical
+    /// UCAN form the native bridge stores — closing the prior WASM create-store
+    /// split (the old `build_ceiling_strings` formatted from the RAW string and
+    /// stored `custom_payments:approve`, while native stores `payments:approve`).
+    /// Asserted at the constructor (create's only ceiling construction point)
+    /// because a full `create_context` trips the native time stub; the accept path
+    /// is covered end-to-end by the WASM conformance suite under a real JS host.
+    #[test]
+    fn test_wasm_create_path_canonical_form_matches_native() {
+        use scp_protocol::context::roles::Capability;
+
+        let entries = vec![
+            "messages:read".to_owned(),
+            "custom:payments:approve".to_owned(),
+            "tool:invoke:*".to_owned(),
+            "context:child:create".to_owned(),
+            "billing:*".to_owned(),
+        ];
+        let wasm_stored: HashSet<String> = ValidatedCeilingStrings::from_colon_entries(&entries)
+            .expect("well-formed colon entries must build")
+            .iter()
+            .cloned()
+            .collect();
+
+        // Native canonical form for the SAME logical entries: parse each via
+        // `Capability::new` (the native parse) and format via
+        // `ucan_capability_name` (the native ceiling string form).
+        let native_expected: HashSet<String> = entries
+            .iter()
+            .map(|e| Capability::new(e).ucan_capability_name())
+            .collect();
+
+        assert_eq!(
+            wasm_stored, native_expected,
+            "WASM create-path canonical ceiling form must equal native"
+        );
+        // The specific divergence the fix closes: `custom:payments:approve`
+        // stores as `payments:approve` (NOT the old `custom_payments:approve`).
+        assert!(
+            wasm_stored.contains("payments:approve"),
+            "custom:payments:approve must store as the canonical payments:approve"
+        );
+        assert!(
+            !wasm_stored.contains("custom_payments:approve"),
+            "the old raw-string formatting (custom_payments:approve) must be gone"
+        );
+    }
+
+    /// IMPORT PATH: `ValidatedCeilingStrings::from_ucan_strings` (the single
+    /// construction point `import_context` routes the untrusted, deserialized peer
+    /// `ceiling_strings` through, closing BLACK-005) ACCEPTS canonical UCAN-form
+    /// entries (idempotent — a conformant exporter's strings are already
+    /// canonical) and REJECTS malformed or non-canonical (colon-form) entries.
+    #[test]
+    fn test_wasm_import_ceiling_constructor_accepts_canonical_rejects_malformed() {
+        // Accept: canonical UCAN-form strings (incl. underscore built-in forms),
+        // stored idempotently.
+        let canonical = vec![
+            "messages:read".to_owned(),
+            "tool_invoke:*".to_owned(),
+            "context_child:create".to_owned(),
+            "payments:approve".to_owned(),
+            "billing:*".to_owned(),
+            "tool_invoke:calc".to_owned(),
+        ];
+        let stored: HashSet<String> = ValidatedCeilingStrings::from_ucan_strings(&canonical)
+            .expect("canonical UCAN-form ceiling must import")
+            .iter()
+            .cloned()
+            .collect();
+        let expected: HashSet<String> = canonical.iter().cloned().collect();
+        assert_eq!(
+            stored, expected,
+            "import must store canonical form verbatim"
+        );
+
+        // Reject: malformed, AND a non-canonical COLON-form built-in (which would
+        // otherwise diverge from the canonical UCAN form gate checks match).
+        for bad in [
+            "payments",                // no colon
+            "*:*",                     // stray wildcard resource
+            "a:b:c",                   // multi-colon custom
+            "custom_payments:approve", // underscore-resource custom (the create-bug spelling)
+            "tool:invoke:*",           // non-canonical COLON-form built-in
+            "context:child:create",    // non-canonical COLON-form built-in
+        ] {
+            let entries = vec!["messages:read".to_owned(), bad.to_owned()];
+            let err = ValidatedCeilingStrings::from_ucan_strings(&entries)
+                .expect_err("import must reject malformed/non-canonical entry");
+            match err {
+                ScpWasmError::Validation { ref code, .. } => assert_eq!(code, codes::VALID_7000),
+                other => panic!("expected Validation for {bad:?}, got {other:?}"),
+            }
+        }
+    }
+
+    /// All three WASM ceiling write constructors converge on the SAME canonical
+    /// form for the SAME logical ceiling — create (colon input) == modify
+    /// (Capability enums) == import (UCAN strings).
+    #[test]
+    fn test_wasm_ceiling_constructors_converge_on_canonical_form() {
+        use scp_protocol::context::roles::Capability;
+
+        let colon_input = vec![
+            "messages:read".to_owned(),
+            "custom:payments:approve".to_owned(),
+            "tool:invoke:*".to_owned(),
+        ];
+        let caps = vec![
+            Capability::MessagesRead,
+            Capability::Custom("payments:approve".to_owned()),
+            Capability::ToolInvokeAll,
+        ];
+        let ucan_input = vec![
+            "messages:read".to_owned(),
+            "payments:approve".to_owned(),
+            "tool_invoke:*".to_owned(),
+        ];
+
+        let from_create: HashSet<String> =
+            ValidatedCeilingStrings::from_colon_entries(&colon_input)
+                .unwrap()
+                .iter()
+                .cloned()
+                .collect();
+        let from_modify: HashSet<String> = ValidatedCeilingStrings::from_capabilities(&caps)
+            .unwrap()
+            .iter()
+            .cloned()
+            .collect();
+        let from_import: HashSet<String> = ValidatedCeilingStrings::from_ucan_strings(&ucan_input)
+            .unwrap()
+            .iter()
+            .cloned()
+            .collect();
+
+        assert_eq!(from_create, from_modify, "create and modify must converge");
+        assert_eq!(from_modify, from_import, "modify and import must converge");
+    }
+
     /// Build an ACTIVE, encrypted, `governed`-ceiling-policy context registered
     /// in a fresh manager, seeded with the given ceiling strings. Used to drive
     /// `dispatch_governance_action(ModifyCeiling)` directly in tests.
@@ -8927,7 +9181,10 @@ mod tests {
             params_json: serde_json::json!({"mode": "Encrypted"}),
             creator_did: creator_did.to_owned(),
             mode: "Encrypted".to_owned(),
-            ceiling_strings: ceiling.iter().map(|s| (*s).to_owned()).collect(),
+            ceiling_strings: ValidatedCeilingStrings::from_ucan_strings(
+                &ceiling.iter().map(|s| (*s).to_owned()).collect::<Vec<_>>(),
+            )
+            .expect("test seed ceiling strings must be well-formed UCAN form"),
             ceiling_policy: "governed".to_owned(),
             ttl_seconds: None,
             promotion_policy: None,
@@ -9027,12 +9284,14 @@ mod tests {
             .iter()
             .map(scp_protocol::context::roles::Capability::ucan_capability_name)
             .collect();
-        let wasm_stored = mgr
+        let wasm_stored: HashSet<String> = mgr
             .contexts
             .get("ctx-mc-ok")
             .unwrap()
             .ceiling_strings
-            .clone();
+            .iter()
+            .cloned()
+            .collect();
         assert_eq!(
             wasm_stored, native_expected,
             "native and WASM must store the SAME effective ceiling for the same \
@@ -9340,9 +9599,7 @@ mod tests {
         let mut state = make_bare_per_context_state(context_id, creator);
         // Admin capabilities are intersected with the ceiling, so grant
         // `governance:propose` in the ceiling to reach the proposal-id parse.
-        state
-            .ceiling_strings
-            .insert("governance:propose".to_owned());
+        state.test_insert_ceiling("governance:propose");
         mgr.contexts.insert(context_id.to_owned(), state);
 
         let action = GovernanceAction::ChangeRole {

--- a/crates/scp-ffi/wasm/src/manager.rs
+++ b/crates/scp-ffi/wasm/src/manager.rs
@@ -9241,7 +9241,7 @@ mod tests {
                 new_ceiling: vec![Capability::MessagesRead, malformed.clone()],
             };
             let err = mgr
-                .dispatch_governance_action("ctx-mc", &action)
+                .dispatch_governance_action("ctx-mc", &action, "did:dht:zcreator", 0)
                 .expect_err("malformed ModifyCeiling must be rejected");
             match err {
                 ScpWasmError::Validation { ref code, .. } => {
@@ -9278,6 +9278,8 @@ mod tests {
             &GovernanceAction::ModifyCeiling {
                 new_ceiling: new_ceiling.clone(),
             },
+            "did:dht:zcreator",
+            0,
         )
         .expect("well-formed ModifyCeiling must succeed");
 

--- a/crates/scp-ffi/wasm/src/manager.rs
+++ b/crates/scp-ffi/wasm/src/manager.rs
@@ -1448,19 +1448,25 @@ impl WasmContextManager {
         // Ceiling-entry grammar enforcement (spec §5.3.1.1). The WASM bridge does
         // NOT route ceiling construction through `ContextRoleState::new` (the
         // native enforcement point), so it validates each user-supplied ceiling
-        // entry here against the SAME canonical grammar validator. This forecloses
+        // entry here against the SAME canonical grammar validator. Validate the
+        // PARSED enum (`Capability::new(entry).validate_as_ceiling_entry()`) — NOT
+        // the raw string — so the WASM create path agrees with the native bridges
+        // and the WASM `ModifyCeiling` handler on one canonical parse (BLACK-003):
+        // `Capability::new` strips a `custom:` prefix, so the raw `"custom:payments"`
+        // (one colon, would pass a raw-string check) parses to `Custom("payments")`,
+        // a no-colon custom the parsed-enum check correctly REJECTS. This forecloses
         // a malformed entry being normalized into the ceiling string set — in
-        // particular it prevents any silent broadening, since a no-colon custom
-        // (e.g. `payments`) and stray-`*` entries (`*:*`, `*:read`) are rejected
-        // rather than normalized. Built-in defaults (empty ceiling) are
-        // well-formed by construction and skip per-entry validation.
+        // particular any silent broadening, since a no-colon custom (e.g. `payments`)
+        // and stray-`*` entries (`*:*`, `*:read`) are rejected rather than
+        // normalized. Built-in defaults (empty ceiling) are well-formed by
+        // construction and skip per-entry validation.
         for entry in &ceiling {
-            scp_protocol::context::roles::validate_ceiling_entry(entry).map_err(|e| {
-                ScpWasmError::Validation {
+            scp_protocol::context::roles::Capability::new(entry)
+                .validate_as_ceiling_entry()
+                .map_err(|e| ScpWasmError::Validation {
                     message: e.to_string(),
                     code: codes::VALID_7000.to_owned(),
-                }
-            })?;
+                })?;
         }
 
         let ceiling_strings = Self::build_ceiling_strings(&ceiling);
@@ -3286,6 +3292,45 @@ impl WasmContextManager {
         result
     }
 
+    /// Handles a `ModifyCeiling` governance action (BLACK-002).
+    ///
+    /// Ceiling-entry grammar enforcement (spec §5.3.1.1): the WASM bridge
+    /// re-implements the manager (ADR-034) and does NOT share the runtime
+    /// `ContextRoleState::set_ceiling` construction invariant, so it MUST validate
+    /// each entry here — exactly as the WASM create path does — before rebuilding
+    /// `ceiling_strings`. Validates the PARSED enum form
+    /// (`validate_as_ceiling_entry`), which is what `capability_to_ucan_format(&c
+    /// .name())` enforces, so the validation and the stored form agree (no silent
+    /// broadening of a malformed `Custom`). Rejects before any mutation: a
+    /// malformed `new_ceiling` leaves the prior ceiling unchanged, and native +
+    /// WASM therefore store the SAME effective ceiling for the same `ModifyCeiling`
+    /// action.
+    fn dispatch_modify_ceiling(
+        &mut self,
+        context_id: &str,
+        new_ceiling: &[scp_protocol::context::roles::Capability],
+    ) -> Result<serde_json::Value, ScpWasmError> {
+        for cap in new_ceiling {
+            cap.validate_as_ceiling_entry()
+                .map_err(|e| ScpWasmError::Validation {
+                    message: e.to_string(),
+                    code: codes::VALID_7000.to_owned(),
+                })?;
+        }
+        let ctx = self.require_active_context_mut(context_id)?;
+        if ctx.ceiling_policy != "governed" {
+            return Err(ScpWasmError::Permission {
+                message: "ceiling is immutable — cannot modify".to_owned(),
+                code: codes::PERM_3000.to_owned(),
+            });
+        }
+        ctx.ceiling_strings = new_ceiling
+            .iter()
+            .map(|c| Self::capability_to_ucan_format(&c.name()))
+            .collect();
+        Ok(serde_json::json!({"action": "ModifyCeiling"}))
+    }
+
     /// Dispatches a governance action to its handler.
     ///
     /// Split into multiple methods to satisfy the 100-line function limit.
@@ -3369,15 +3414,7 @@ impl WasmContextManager {
                 Ok(serde_json::json!({"action": "RemoveTool", "toolId": tool_id}))
             }
             GovernanceAction::ModifyCeiling { new_ceiling } => {
-                let ctx = self.require_active_context_mut(context_id)?;
-                if ctx.ceiling_policy != "governed" {
-                    return Err(ScpWasmError::Permission {
-                        message: "ceiling is immutable — cannot modify".to_owned(),
-                        code: codes::PERM_3000.to_owned(),
-                    });
-                }
-                ctx.ceiling_strings = new_ceiling.iter().map(|c| Self::capability_to_ucan_format(&c.name())).collect();
-                Ok(serde_json::json!({"action": "ModifyCeiling"}))
+                self.dispatch_modify_ceiling(context_id, new_ceiling)
             }
             GovernanceAction::CloseContext { .. } => {
                 let ctx = self.require_active_context_mut(context_id)?;
@@ -8805,6 +8842,11 @@ mod tests {
             "*:read",
             "payments:read:write",
             "payments:wr*",
+            // BLACK-003: `Capability::new("custom:payments")` strips the `custom:`
+            // prefix → `Custom("payments")`, a no-colon custom whose enforced form
+            // is rejected. Validating the parsed enum (this fix) rejects it here so
+            // the validation and the enforced parse agree.
+            "custom:payments",
         ] {
             let mut mgr = WasmContextManager::new();
             let creator = "did:dht:zcreator";
@@ -8870,6 +8912,132 @@ mod tests {
                 );
             }
         }
+    }
+
+    /// Build an ACTIVE, encrypted, `governed`-ceiling-policy context registered
+    /// in a fresh manager, seeded with the given ceiling strings. Used to drive
+    /// `dispatch_governance_action(ModifyCeiling)` directly in tests.
+    fn manager_with_governed_context(
+        context_id: &str,
+        creator_did: &str,
+        ceiling: &[&str],
+    ) -> WasmContextManager {
+        let ctx = PerContextState {
+            state: "active".to_owned(),
+            params_json: serde_json::json!({"mode": "Encrypted"}),
+            creator_did: creator_did.to_owned(),
+            mode: "Encrypted".to_owned(),
+            ceiling_strings: ceiling.iter().map(|s| (*s).to_owned()).collect(),
+            ceiling_policy: "governed".to_owned(),
+            ttl_seconds: None,
+            promotion_policy: None,
+            governance: "single_admin".to_owned(),
+            economic_policy: None,
+            tool_registry: ToolRegistry::new(),
+            tool_handlers: HashMap::new(),
+            event_log: EventLog::new(context_id.to_owned()),
+            revoked_tokens: HashSet::new(),
+            seen_nonces: HashMap::new(),
+            members: HashMap::new(),
+            event_buffer: VecDeque::new(),
+            executed_proposals: HashMap::new(),
+            suspended_capabilities: HashMap::new(),
+            read_exclusion_list: HashSet::new(),
+            broadcast_context: None,
+            sessions: HashMap::new(),
+            threshold_signers: Vec::new(),
+            threshold_value: 0,
+            tool_interfaces: Vec::new(),
+            governance_freeze: false,
+            pending_proposals: HashMap::new(),
+            resolved_proposals: HashMap::new(),
+            pruning_policy: None,
+            economic_policy_locked: false,
+            hard_rate_limit_config: None,
+            consequence_rules: Vec::new(),
+            cooldown_until: HashMap::new(),
+            crypto: None,
+            creation_timestamp_secs: 0,
+        };
+        let mut mgr = WasmContextManager::new();
+        mgr.contexts.insert(context_id.to_owned(), ctx);
+        mgr
+    }
+
+    /// WASM `ModifyCeiling` (BLACK-002) rejects a malformed proposed ceiling
+    /// entry (spec §5.3.1.1) and leaves the prior ceiling UNCHANGED — closing the
+    /// divergence where the handler rebuilt `ceiling_strings` with no validation.
+    #[test]
+    fn test_wasm_modify_ceiling_rejects_malformed_entry() {
+        for malformed in [
+            Capability::Custom("payments".to_owned()), // no colon
+            Capability::Custom("*:*".to_owned()),      // stray wildcard resource
+            Capability::Custom("a:b:c".to_owned()),    // multi-colon (3 segments)
+        ] {
+            let mut mgr =
+                manager_with_governed_context("ctx-mc", "did:dht:zcreator", &["messages:read"]);
+            let before = mgr.contexts.get("ctx-mc").unwrap().ceiling_strings.clone();
+            let action = GovernanceAction::ModifyCeiling {
+                new_ceiling: vec![Capability::MessagesRead, malformed.clone()],
+            };
+            let err = mgr
+                .dispatch_governance_action("ctx-mc", &action)
+                .expect_err("malformed ModifyCeiling must be rejected");
+            match err {
+                ScpWasmError::Validation { ref code, .. } => {
+                    assert_eq!(code, codes::VALID_7000);
+                }
+                other => panic!("expected Validation error for {malformed:?}, got: {other:?}"),
+            }
+            // Fail-closed: the prior ceiling is unchanged.
+            assert_eq!(
+                mgr.contexts.get("ctx-mc").unwrap().ceiling_strings,
+                before,
+                "a rejected malformed ModifyCeiling must leave the ceiling unchanged ({malformed:?})"
+            );
+        }
+    }
+
+    /// WASM `ModifyCeiling` accepts a well-formed proposed ceiling and stores the
+    /// SAME effective ceiling that the native bridge would for the same action —
+    /// closing the native/WASM divergence (BLACK-002). The native enforced form is
+    /// `Capability::ucan_capability_name`; the WASM stored form is
+    /// `capability_to_ucan_format(cap.name())`. For these entries the two agree.
+    #[test]
+    fn test_wasm_modify_ceiling_accepts_wellformed_and_matches_native() {
+        let mut mgr =
+            manager_with_governed_context("ctx-mc-ok", "did:dht:zcreator", &["messages:read"]);
+        let new_ceiling = vec![
+            Capability::MessagesRead,
+            Capability::Custom("payments:approve".to_owned()),
+            Capability::Custom("billing:*".to_owned()),
+            Capability::ToolInvokeAll,
+        ];
+        mgr.dispatch_governance_action(
+            "ctx-mc-ok",
+            &GovernanceAction::ModifyCeiling {
+                new_ceiling: new_ceiling.clone(),
+            },
+        )
+        .expect("well-formed ModifyCeiling must succeed");
+
+        // Native enforced ceiling string set for the SAME action: each capability
+        // mapped via `ucan_capability_name` (the native bridge ceiling form).
+        let native_expected: HashSet<String> = new_ceiling
+            .iter()
+            .map(scp_protocol::context::roles::Capability::ucan_capability_name)
+            .collect();
+        let wasm_stored = mgr
+            .contexts
+            .get("ctx-mc-ok")
+            .unwrap()
+            .ceiling_strings
+            .clone();
+        assert_eq!(
+            wasm_stored, native_expected,
+            "native and WASM must store the SAME effective ceiling for the same \
+             well-formed ModifyCeiling action"
+        );
     }
 
     /// **C2-B:** `create_context` accepts a free economic policy. The

--- a/crates/scp-ffi/wasm/src/manager.rs
+++ b/crates/scp-ffi/wasm/src/manager.rs
@@ -284,7 +284,10 @@ const WASM_PROPOSAL_DEADLINE_MS: f64 = 3_600_000.0;
 /// "payments:approve")` → `payments:approve` (NOT the raw-string
 /// `custom_payments:approve` the old `build_ceiling_strings` produced), and
 /// import validates+stores the canonical UCAN form, create / modify / import all
-/// produce the byte-identical ceiling the native bridge stores.
+/// produce the same canonical UCAN-string set the native bridge yields via
+/// [`Capability::ucan_capability_name`] (native stores `Capability` enums per
+/// ADR-034; the convergent property is this string projection, not the in-memory
+/// representation).
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
 pub(crate) struct ValidatedCeilingStrings(HashSet<String>);
 
@@ -303,6 +306,16 @@ impl ValidatedCeilingStrings {
         )
     }
 
+    /// Maps a [`CeilingEntryError`] into the canonical bridge validation error
+    /// (`SCP-VALID-7000`). Shared by all three validating constructors so the
+    /// reject surface is identical across the create / modify / import paths.
+    fn validation_error(e: scp_protocol::context::roles::CeilingEntryError) -> ScpWasmError {
+        ScpWasmError::Validation {
+            message: e.to_string(),
+            code: codes::VALID_7000.to_owned(),
+        }
+    }
+
     /// Builds a validated ceiling from user-supplied COLON-form entries (the
     /// `create_context` path). An empty list yields [`Self::defaults`].
     ///
@@ -318,10 +331,7 @@ impl ValidatedCeilingStrings {
         for entry in entries {
             let cap = scp_protocol::context::roles::Capability::new(entry);
             cap.validate_as_ceiling_entry()
-                .map_err(|e| ScpWasmError::Validation {
-                    message: e.to_string(),
-                    code: codes::VALID_7000.to_owned(),
-                })?;
+                .map_err(Self::validation_error)?;
             set.insert(cap.ucan_capability_name());
         }
         Ok(Self(set))
@@ -340,10 +350,7 @@ impl ValidatedCeilingStrings {
         let mut set = HashSet::with_capacity(caps.len());
         for cap in caps {
             cap.validate_as_ceiling_entry()
-                .map_err(|e| ScpWasmError::Validation {
-                    message: e.to_string(),
-                    code: codes::VALID_7000.to_owned(),
-                })?;
+                .map_err(Self::validation_error)?;
             set.insert(cap.ucan_capability_name());
         }
         Ok(Self(set))
@@ -367,12 +374,8 @@ impl ValidatedCeilingStrings {
     {
         let mut set = HashSet::new();
         for entry in entries {
-            scp_protocol::context::roles::validate_ucan_ceiling_string(entry).map_err(|e| {
-                ScpWasmError::Validation {
-                    message: e.to_string(),
-                    code: codes::VALID_7000.to_owned(),
-                }
-            })?;
+            scp_protocol::context::roles::validate_ucan_ceiling_string(entry)
+                .map_err(Self::validation_error)?;
             set.insert(entry.clone());
         }
         Ok(Self(set))

--- a/crates/scp-protocol/src/context/builder.rs
+++ b/crates/scp-protocol/src/context/builder.rs
@@ -233,6 +233,12 @@ pub enum ContextCreationError {
     )]
     BilateralPeerNotSupported,
 
+    /// A ceiling entry is not a recognized built-in category nor a well-formed
+    /// custom capability (spec §5.3.1.1). Surfaces the protocol's
+    /// `InvalidCeilingCategory` error so a malformed entry can never be stored.
+    #[error(transparent)]
+    InvalidCeilingCategory(#[from] crate::context::roles::CeilingEntryError),
+
     /// Generic creation failure with a descriptive message.
     #[error("context creation failed: {0}")]
     CreationFailed(String),

--- a/crates/scp-protocol/src/context/roles.rs
+++ b/crates/scp-protocol/src/context/roles.rs
@@ -603,10 +603,12 @@ const BUILTIN_CEILING_CATEGORIES: &[&str] = &[
 /// Error produced when a ceiling entry is not well-formed per the
 /// ceiling-entry grammar (spec §5.3.1.1).
 ///
-/// Surfaced at context creation: a malformed entry causes creation to fail and
-/// can never be stored in a [`CapabilityCeiling`]. The single variant carries
-/// the spec-named `InvalidCeilingCategory` semantics plus the offending entry
-/// and a human-readable reason for diagnostics.
+/// Surfaced at EVERY ceiling write — context creation
+/// ([`ContextRoleState::new`]) and the whole-ceiling mutator
+/// ([`ContextRoleState::set_ceiling`]) — so a malformed entry causes the write to
+/// fail and can never be stored in a [`CapabilityCeiling`] by construction. The
+/// single variant carries the spec-named `InvalidCeilingCategory` semantics plus
+/// the offending entry and a human-readable reason for diagnostics.
 #[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
 pub enum CeilingEntryError {
     /// A ceiling entry is neither a recognized built-in category (spec §5.3.1)
@@ -1422,8 +1424,30 @@ impl ContextRoleState {
     /// coalesce-window rollback of a ceiling tightening would silently re-widen the
     /// authorization envelope, which is why the WRITE is centralized here rather
     /// than via a public field.
-    pub fn set_ceiling(&mut self, ceiling: CapabilityCeiling) {
+    ///
+    /// WELL-FORMEDNESS CONSTRUCTION INVARIANT (spec §5.3.1.1): every ceiling entry
+    /// is validated against the canonical ceiling-entry grammar BEFORE the
+    /// replacement is stored. This is the SINGLE whole-ceiling write chokepoint for
+    /// the runtime, so routing the grammar check here makes "a malformed
+    /// `CapabilityCeiling` can never be stored" true by construction on EVERY
+    /// mutation path — not just at context creation
+    /// ([`ContextRoleState::new`](Self::new)). A malformed entry (single-token
+    /// custom, stray `*`, multi-colon, bad charset, control/HTML char, oversize, …)
+    /// is rejected with [`CeilingEntryError::InvalidCeilingCategory`] and the prior
+    /// ceiling is left UNCHANGED (fail-closed: a rejected write never widens or
+    /// poisons the authorization envelope).
+    ///
+    /// # Errors
+    ///
+    /// Returns [`CeilingEntryError::InvalidCeilingCategory`] if any entry of
+    /// `ceiling` is not a recognized built-in category nor a well-formed custom
+    /// capability. The receiver is not mutated on error.
+    pub fn set_ceiling(&mut self, ceiling: CapabilityCeiling) -> Result<(), CeilingEntryError> {
+        // Validate the WHOLE replacement before storing any of it, so a partially
+        // malformed ceiling cannot leave the state half-written.
+        ceiling.validate_entries()?;
         self.ceiling = ceiling;
+        Ok(())
     }
 
     /// TEST-ONLY mutable access to the ceiling (ADR-049 §9). Gated
@@ -3687,6 +3711,52 @@ mod tests {
             Capability::ToolInvoke("calc".to_owned()),
         ]);
         ContextRoleState::new("ctx-1", "did:scp:creator", ceiling, vec![], &clock).unwrap();
+    }
+
+    #[test]
+    fn set_ceiling_rejects_malformed_entry_and_leaves_prior_unchanged() {
+        // Construction invariant: `set_ceiling` validates the WHOLE replacement
+        // against the ceiling-entry grammar before storing, so a malformed
+        // `CapabilityCeiling` can never be stored via the mutation path either.
+        let clock = scp_primitives::SystemClock;
+        let initial = CapabilityCeiling::new([
+            Capability::MessagesRead,
+            Capability::Custom("payments:approve".to_owned()),
+        ]);
+        let mut state =
+            ContextRoleState::new("ctx-1", "did:scp:creator", initial.clone(), vec![], &clock)
+                .unwrap();
+
+        for malformed in [
+            Capability::Custom("payments".to_owned()), // no colon
+            Capability::Custom("*:*".to_owned()),      // stray wildcard resource
+            Capability::Custom("a:b:c".to_owned()),    // multi-colon (3 segments)
+        ] {
+            let bad = CapabilityCeiling::new([Capability::MessagesRead, malformed]);
+            assert!(matches!(
+                state.set_ceiling(bad),
+                Err(CeilingEntryError::InvalidCeilingCategory { .. })
+            ));
+            // Fail-closed: the prior ceiling is left UNCHANGED on a rejected write.
+            assert_eq!(state.ceiling(), &initial);
+        }
+    }
+
+    #[test]
+    fn set_ceiling_accepts_wellformed_replacement() {
+        let clock = scp_primitives::SystemClock;
+        let initial = CapabilityCeiling::new([Capability::MessagesRead]);
+        let mut state =
+            ContextRoleState::new("ctx-1", "did:scp:creator", initial, vec![], &clock).unwrap();
+
+        let replacement = CapabilityCeiling::new([
+            Capability::MessagesRead,
+            Capability::Custom("payments:approve".to_owned()),
+            Capability::Custom("billing:*".to_owned()),
+            Capability::ToolInvoke("calc".to_owned()),
+        ]);
+        state.set_ceiling(replacement.clone()).unwrap();
+        assert_eq!(state.ceiling(), &replacement);
     }
 
     #[test]

--- a/crates/scp-protocol/src/context/roles.rs
+++ b/crates/scp-protocol/src/context/roles.rs
@@ -115,21 +115,53 @@ pub enum Capability {
 impl Capability {
     /// Creates a capability from a string name.
     ///
-    /// Recognized names: `"messages:read"`, `"messages:write"`,
-    /// `"tool:invoke:*"`, `"tool:register"`, `"member:invite"`,
-    /// `"member:remove"`, `"role:assign"`, `"governance:propose"`,
-    /// `"governance:vote"`, `"context:close"`, `"context:child:create"`,
-    /// `"tool:interface"`, `"bridging"`, `"media:voice"`, `"media:video"`,
-    /// `"media:screen_share"`, `"member:ban"`, `"metadata:edit"`.
-    /// Names starting with `"tool:invoke:"` are parsed as `ToolInvoke(id)`.
+    /// A built-in capability is recognized in **either** of its two equivalent
+    /// spellings of the SAME enumerated category, so a built-in always parses to
+    /// its proper variant (never a [`Custom`](Self::Custom) lookalike):
+    ///
+    /// - **User-facing colon form** (spec §5.3.1 table): `"messages:read"`,
+    ///   `"messages:write"`, `"tool:invoke:*"`, `"tool:register"`,
+    ///   `"member:invite"`, `"member:remove"`, `"role:assign"`,
+    ///   `"governance:propose"`, `"governance:vote"`, `"context:close"`,
+    ///   `"context:child:create"`, `"tool:interface"`, `"bridging"`,
+    ///   `"media:voice"`, `"media:video"`, `"media:screen_share"`,
+    ///   `"member:ban"`, `"metadata:edit"`. Names starting with `"tool:invoke:"`
+    ///   parse as `ToolInvoke(id)`.
+    /// - **UCAN wire form** (the `{resource}:{action}` output of
+    ///   [`ucan_capability_name`](Self::ucan_capability_name), §7.3.4) — the
+    ///   spellings that differ from colon form because the resource is a
+    ///   multi-segment, underscore-joined token: `"tool_invoke:*"`
+    ///   (== `ToolInvokeAll`), `"tool_invoke:{id}"` (== `ToolInvoke(id)`),
+    ///   `"context_child:create"` (== `ChildContextCreate`), and `"bridging:*"`
+    ///   (== `Bridging`). Recognizing these is what lets a context's STORED
+    ///   ceiling (kept in canonical UCAN form) round-trip back to the proper
+    ///   built-in enum, and lets a UCAN-form ceiling entry resolve to the
+    ///   enumerated category it names rather than a `Custom` lookalike. There is
+    ///   no ambiguity: no well-formed custom ceiling entry contains a `_` in its
+    ///   resource (the custom grammar is kebab-only, §5.3.1.1), so a built-in's
+    ///   UCAN spelling can never collide with a valid custom.
+    ///
     /// Names starting with `"custom:"` are parsed as `Custom(remainder)`.
     /// Anything else maps to `Custom(name)`.
+    ///
+    /// [`name`](Self::name) and [`Display`](std::fmt::Display) always emit the
+    /// canonical colon form, so `new(name())` and `new(to_string())` round-trip.
     #[must_use]
     pub fn new(name: impl AsRef<str>) -> Self {
         match name.as_ref() {
+            // Built-in categories. Each arm lists the user-facing colon spelling
+            // (spec §5.3.1 table) AND, for the multi-segment built-ins, the
+            // equivalent UCAN wire spelling (the underscore-joined-resource output
+            // of `ucan_capability_name`, §7.3.4) — the two spellings of the SAME
+            // enumerated category. Recognizing the UCAN spelling is what lets a
+            // context's STORED ceiling (kept in canonical UCAN form) round-trip
+            // back to the proper built-in enum, and resolves a UCAN-form ceiling
+            // entry to its category instead of a `Custom` lookalike. No valid
+            // custom collides: the custom grammar is kebab-only (no `_` in the
+            // resource, §5.3.1.1).
             "messages:read" => Self::MessagesRead,
             "messages:write" => Self::MessagesWrite,
-            "tool:invoke:*" => Self::ToolInvokeAll,
+            "tool:invoke:*" | "tool_invoke:*" => Self::ToolInvokeAll,
             "tool:register" => Self::ToolRegister,
             "member:invite" => Self::MemberInvite,
             "member:remove" => Self::MemberRemove,
@@ -137,23 +169,26 @@ impl Capability {
             "governance:propose" => Self::GovernancePropose,
             "governance:vote" => Self::GovernanceVote,
             "context:close" => Self::ContextClose,
-            "context:child:create" => Self::ChildContextCreate,
+            "context:child:create" | "context_child:create" => Self::ChildContextCreate,
             "tool:interface" => Self::ToolInterface,
-            "bridging" => Self::Bridging,
+            "bridging" | "bridging:*" => Self::Bridging,
             "media:voice" => Self::MediaVoice,
             "media:video" => Self::MediaVideo,
             "media:screen_share" => Self::MediaScreenShare,
             "member:ban" => Self::MemberBan,
             "metadata:edit" => Self::MetadataEdit,
-            other => other.strip_prefix("tool:invoke:").map_or_else(
-                || {
-                    other.strip_prefix("custom:").map_or_else(
-                        || Self::Custom(other.to_owned()),
-                        |custom_name| Self::Custom(custom_name.to_owned()),
-                    )
-                },
-                |tool_id| Self::ToolInvoke(tool_id.to_owned()),
-            ),
+            other => other
+                .strip_prefix("tool:invoke:")
+                .or_else(|| other.strip_prefix("tool_invoke:"))
+                .map_or_else(
+                    || {
+                        other.strip_prefix("custom:").map_or_else(
+                            || Self::Custom(other.to_owned()),
+                            |custom_name| Self::Custom(custom_name.to_owned()),
+                        )
+                    },
+                    |tool_id| Self::ToolInvoke(tool_id.to_owned()),
+                ),
         }
     }
 
@@ -3877,6 +3912,107 @@ mod tests {
                 .validate_as_ceiling_entry()
                 .is_err()
         );
+    }
+
+    /// `Capability::new` recognizes a built-in in EITHER its colon spelling or
+    /// its UCAN wire spelling, always yielding the proper built-in variant (never
+    /// a `Custom` lookalike) — the multi-segment built-ins whose UCAN form differs
+    /// from colon form (`tool_invoke:*`, `tool_invoke:{id}`,
+    /// `context_child:create`, `bridging:*`) plus a representative sample of the
+    /// identical-spelling built-ins. Without this, a context's STORED (canonical
+    /// UCAN-form) ceiling re-parses to a `Custom` and fails re-validation
+    /// (`InvalidCeilingCategory: tool_invoke:* is malformed`), breaking context
+    /// creation / tool flow / cross-bridge parity.
+    #[test]
+    fn capability_new_parses_builtin_colon_and_ucan_spellings() {
+        // Colon spelling → built-in variant.
+        assert_eq!(Capability::new("tool:invoke:*"), Capability::ToolInvokeAll);
+        assert_eq!(
+            Capability::new("context:child:create"),
+            Capability::ChildContextCreate
+        );
+        assert_eq!(Capability::new("bridging"), Capability::Bridging);
+        assert_eq!(
+            Capability::new("tool:invoke:calc"),
+            Capability::ToolInvoke("calc".to_owned())
+        );
+
+        // UCAN wire spelling → the SAME built-in variant (not a Custom).
+        assert_eq!(Capability::new("tool_invoke:*"), Capability::ToolInvokeAll);
+        assert_eq!(
+            Capability::new("context_child:create"),
+            Capability::ChildContextCreate
+        );
+        assert_eq!(Capability::new("bridging:*"), Capability::Bridging);
+        assert_eq!(
+            Capability::new("tool_invoke:calc"),
+            Capability::ToolInvoke("calc".to_owned())
+        );
+
+        // Identical-spelling built-ins parse the same either way.
+        assert_eq!(Capability::new("messages:read"), Capability::MessagesRead);
+        assert_eq!(
+            Capability::new("media:screen_share"),
+            Capability::MediaScreenShare
+        );
+
+        // Every built-in's UCAN form round-trips back to its variant, so the
+        // canonical STORED ceiling form re-parses to the proper enum.
+        for cap in BUILTIN_CAPABILITIES {
+            let ucan = cap.ucan_capability_name();
+            assert_eq!(
+                &Capability::new(&ucan),
+                cap,
+                "UCAN form {ucan:?} must parse back to {cap:?}"
+            );
+        }
+    }
+
+    /// A built-in supplied in EITHER spelling is a valid ceiling entry; a
+    /// malformed custom is rejected in either parse. Mirrors the create-path
+    /// `Capability::new(entry).validate_as_ceiling_entry()` the bridges run, and
+    /// pins the regression: the canonical UCAN spellings (`tool_invoke:*`,
+    /// `context_child:create`, `bridging:*`, `tool_invoke:{id}`) and the
+    /// user-facing colon spellings must BOTH pass; underscore-resource customs and
+    /// stray-wildcard / multi-colon customs must still fail.
+    #[test]
+    fn ceiling_entry_accepts_builtin_either_spelling_rejects_malformed_custom() {
+        for good in [
+            // Colon spellings (spec §5.3.1 table / SDK input).
+            "messages:read",
+            "tool:invoke:*",
+            "tool:invoke:calc",
+            "context:child:create",
+            "bridging",
+            "media:screen_share",
+            // UCAN wire spellings (canonical stored form).
+            "tool_invoke:*",
+            "tool_invoke:calc",
+            "context_child:create",
+            "bridging:*",
+            // Well-formed customs.
+            "payments:approve",
+            "payments:*",
+        ] {
+            Capability::new(good)
+                .validate_as_ceiling_entry()
+                .unwrap_or_else(|e| panic!("ceiling entry {good:?} must be accepted: {e}"));
+        }
+
+        for bad in [
+            "payments",            // no-colon custom
+            "*:*",                 // stray wildcard resource
+            "*:read",              // stray wildcard resource
+            "payments:read:write", // multi-colon custom
+            "pay_ments:approve",   // underscore resource is NOT a valid custom
+            "tool_invoke:ca*lc",   // stray `*` in tool_id (UCAN form)
+            "tool:invoke:ca*lc",   // stray `*` in tool_id (colon form)
+        ] {
+            assert!(
+                Capability::new(bad).validate_as_ceiling_entry().is_err(),
+                "ceiling entry {bad:?} must be rejected"
+            );
+        }
     }
 
     /// `BUILTIN_CAPABILITIES` must list every non-parameterized built-in variant

--- a/crates/scp-protocol/src/context/roles.rs
+++ b/crates/scp-protocol/src/context/roles.rs
@@ -291,18 +291,29 @@ impl Capability {
                 std::borrow::Cow::Borrowed("edit"),
             ),
             Self::Custom(name) => {
-                // Custom capabilities may use either colon or underscore format.
-                // Split on the last colon to separate resource from action.
+                // Custom capabilities use the `{resource}:{action}` form. Split on
+                // the last colon to separate resource from action.
                 if let Some((resource, action)) = name.rsplit_once(':') {
                     (
                         std::borrow::Cow::Owned(resource.replace(':', "_")),
                         std::borrow::Cow::Borrowed(action),
                     )
                 } else {
-                    // No colon — treat entire name as resource with wildcard action.
+                    // No colon. Well-formed ceiling entries are validated at
+                    // context creation (`validate_ceiling_entry`, spec §5.3.1.1),
+                    // so a no-colon custom can NEVER reach this point as a stored
+                    // ceiling entry — it is rejected up front with
+                    // `InvalidCeilingCategory`. This branch therefore never
+                    // synthesizes the silent `name → name:*` wildcard that
+                    // previously widened a no-colon custom: a defensive fallback
+                    // maps the whole token to BOTH resource and action (a
+                    // concrete, non-wildcard `name:name`), so even if a no-colon
+                    // custom is constructed directly (e.g. in a test or via the
+                    // raw enum), it can match only that one exact capability and
+                    // can never grant `name:*`.
                     (
                         std::borrow::Cow::Borrowed(name.as_str()),
-                        std::borrow::Cow::Borrowed("*"),
+                        std::borrow::Cow::Borrowed(name.as_str()),
                     )
                 }
             }
@@ -330,6 +341,32 @@ impl Capability {
     pub fn ucan_capability_name(&self) -> String {
         let (resource, action) = self.ucan_resource_action();
         format!("{resource}:{action}")
+    }
+
+    /// Validates this capability as a ceiling entry against the ceiling-entry
+    /// grammar (spec §5.3.1.1).
+    ///
+    /// Built-in variants are well-formed by construction (they correspond to
+    /// rows of the §5.3.1 table). [`ToolInvoke`](Self::ToolInvoke) and
+    /// [`Custom`](Self::Custom) variants are reconstructed to their user-facing
+    /// entry string ([`name`](Self::name)) and validated via
+    /// [`validate_ceiling_entry`]. This is the enum-form entry point onto the
+    /// single canonical string validator, so a malformed custom (e.g. a no-colon
+    /// `Custom("payments")` or `Custom("*:*")`) is rejected at ceiling
+    /// construction rather than silently widened or stored.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`CeilingEntryError::InvalidCeilingCategory`] if this capability
+    /// would be a malformed ceiling entry.
+    pub fn validate_as_ceiling_entry(&self) -> Result<(), CeilingEntryError> {
+        match self {
+            // Built-in variants are well-formed by construction. `ToolInvoke(id)`
+            // and `Custom(_)` carry caller-supplied text, so route them through
+            // the canonical string grammar using their user-facing entry form.
+            Self::ToolInvoke(_) | Self::Custom(_) => validate_ceiling_entry(self.name().as_ref()),
+            _ => Ok(()),
+        }
     }
 }
 
@@ -487,6 +524,22 @@ impl CapabilityCeiling {
             .map(Capability::ucan_capability_name)
             .collect()
     }
+
+    /// Validates every entry in this ceiling against the ceiling-entry grammar
+    /// (spec §5.3.1.1). Called at context creation so a malformed entry cannot be
+    /// stored; the first malformed entry short-circuits with its error.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`CeilingEntryError::InvalidCeilingCategory`] for the first entry
+    /// that is not a recognized built-in category nor a well-formed custom
+    /// capability.
+    pub fn validate_entries(&self) -> Result<(), CeilingEntryError> {
+        for cap in &self.capabilities {
+            cap.validate_as_ceiling_entry()?;
+        }
+        Ok(())
+    }
 }
 
 /// Returns the default capability ceiling for new contexts.
@@ -508,6 +561,219 @@ pub fn default_ceiling() -> CapabilityCeiling {
         Capability::GovernanceVote,
         Capability::ContextClose,
     ])
+}
+
+// ---------------------------------------------------------------------------
+// Ceiling-entry grammar (spec §5.3.1.1)
+// ---------------------------------------------------------------------------
+
+/// Maximum byte length of a single ceiling entry string (spec §5.3.1.1 / §9.1A
+/// "String field validation"). Entries exceeding this cap are rejected.
+pub const MAX_CEILING_ENTRY_LENGTH: usize = 256;
+
+/// Maximum byte length of a `tool_id` in a parameterized `tool:invoke:{tool_id}`
+/// built-in entry (spec §5.4.1 `ToolRegistration.tool_id`, `max 128 chars`).
+const MAX_TOOL_ID_LENGTH: usize = 128;
+
+/// The exhaustive set of non-parameterized built-in capability category strings
+/// (spec §5.3.1 table). These are matched exactly and case-sensitively. The
+/// parameterized `tool:invoke:{tool_id}` and the resource wildcard
+/// `tool:invoke:*` are validated separately (see [`validate_ceiling_entry`]).
+const BUILTIN_CEILING_CATEGORIES: &[&str] = &[
+    "messages:read",
+    "messages:write",
+    "tool:register",
+    "tool:invoke:*",
+    "member:invite",
+    "member:remove",
+    "member:ban",
+    "role:assign",
+    "media:voice",
+    "media:video",
+    "media:screen_share",
+    "bridging",
+    "tool:interface",
+    "context:child:create",
+    "governance:propose",
+    "governance:vote",
+    "context:close",
+    "metadata:edit",
+];
+
+/// Error produced when a ceiling entry is not well-formed per the
+/// ceiling-entry grammar (spec §5.3.1.1).
+///
+/// Surfaced at context creation: a malformed entry causes creation to fail and
+/// can never be stored in a [`CapabilityCeiling`]. The single variant carries
+/// the spec-named `InvalidCeilingCategory` semantics plus the offending entry
+/// and a human-readable reason for diagnostics.
+#[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
+pub enum CeilingEntryError {
+    /// A ceiling entry is neither a recognized built-in category (spec §5.3.1)
+    /// nor a well-formed custom capability (spec §5.3.1.1). This is the
+    /// protocol's `InvalidCeilingCategory` error.
+    #[error("InvalidCeilingCategory: ceiling entry {entry:?} is malformed ({reason})")]
+    InvalidCeilingCategory {
+        /// The offending ceiling entry, exactly as supplied.
+        entry: String,
+        /// Why the entry is malformed (which grammar rule it violated).
+        reason: String,
+    },
+}
+
+impl CeilingEntryError {
+    /// Constructs an [`Self::InvalidCeilingCategory`] for `entry` with `reason`.
+    fn invalid(entry: &str, reason: impl Into<String>) -> Self {
+        Self::InvalidCeilingCategory {
+            entry: entry.to_owned(),
+            reason: reason.into(),
+        }
+    }
+}
+
+/// Returns `true` if every byte of `token` is in the kebab-case charset
+/// `[a-z0-9-]` and `token` is non-empty (spec §5.3.1.1). No `:`, no `*`, no
+/// whitespace, no uppercase — the charset is exact and closed.
+fn is_kebab_token(token: &str) -> bool {
+    !token.is_empty()
+        && token
+            .bytes()
+            .all(|b| b.is_ascii_lowercase() || b.is_ascii_digit() || b == b'-')
+}
+
+/// Returns `true` if every byte of `tool_id` is in the §5.4.1 `tool_id` charset
+/// `[a-z0-9_-]` and `tool_id` is non-empty. Differs from [`is_kebab_token`] by
+/// also permitting `_` (underscore), per §5.4.1.
+fn is_tool_id_token(tool_id: &str) -> bool {
+    !tool_id.is_empty()
+        && tool_id
+            .bytes()
+            .all(|b| b.is_ascii_lowercase() || b.is_ascii_digit() || b == b'-' || b == b'_')
+}
+
+/// Validates a single ceiling entry string against the ceiling-entry grammar.
+///
+/// This (spec §5.3.1.1) is the SINGLE canonical definition of "well-formed
+/// ceiling entry"; every construction and bridge path routes through it (via
+/// [`Capability::validate_as_ceiling_entry`] for enum-form entries) so a
+/// malformed entry can never be stored.
+///
+/// A well-formed entry is **exactly one** of:
+/// 1. a built-in category — exact, case-sensitive match against the §5.3.1
+///    table (including parameterized `tool:invoke:{tool_id}` and the resource
+///    wildcard `tool:invoke:*`);
+/// 2. a custom `{resource}:{action}` — exactly one colon; both tokens non-empty
+///    kebab-case `[a-z0-9-]+`;
+/// 3. an explicit resource wildcard `{resource}:*` — `{resource}` kebab-case;
+///    the action segment is the single literal `*`.
+///
+/// Everything else is rejected with [`CeilingEntryError::InvalidCeilingCategory`]:
+/// single-token customs (no colon, e.g. `payments`), a stray `*` anywhere except
+/// as a whole action segment (`*:*`, `*:read`, `pay*ments`, `payments:wr*`),
+/// more than one colon (`payments:read:write`), empty resource/action, characters
+/// outside the kebab charset, whitespace, control characters
+/// (U+0000–U+001F / U+007F–U+009F), HTML-special characters (`< > & " '`), and
+/// strings exceeding [`MAX_CEILING_ENTRY_LENGTH`] bytes. There is **no implicit
+/// or silent wildcard** — a wildcard must be written explicitly as `:*`.
+///
+/// # Errors
+///
+/// Returns [`CeilingEntryError::InvalidCeilingCategory`] if `entry` is not
+/// well-formed.
+pub fn validate_ceiling_entry(entry: &str) -> Result<(), CeilingEntryError> {
+    // Length cap (bytes), per §9.1A string-field validation.
+    if entry.len() > MAX_CEILING_ENTRY_LENGTH {
+        return Err(CeilingEntryError::invalid(
+            entry,
+            format!(
+                "exceeds maximum length of {MAX_CEILING_ENTRY_LENGTH} bytes (got {} bytes)",
+                entry.len()
+            ),
+        ));
+    }
+
+    // String sanitization (§9.1A): reject control chars, HTML-special chars, and
+    // any whitespace anywhere in the entry. This applies uniformly before any
+    // structural parse — a control char inside an otherwise built-in-looking
+    // string is still malformed.
+    for ch in entry.chars() {
+        if ch.is_control() {
+            return Err(CeilingEntryError::invalid(
+                entry,
+                "contains a control character (U+0000–U+001F / U+007F–U+009F)",
+            ));
+        }
+        if ch.is_whitespace() {
+            return Err(CeilingEntryError::invalid(entry, "contains whitespace"));
+        }
+        if matches!(ch, '<' | '>' | '&' | '"' | '\'') {
+            return Err(CeilingEntryError::invalid(
+                entry,
+                "contains an HTML-special character (< > & \" ')",
+            ));
+        }
+    }
+
+    // 1. Built-in categories: exact, case-sensitive match.
+    if BUILTIN_CEILING_CATEGORIES.contains(&entry) {
+        return Ok(());
+    }
+
+    // 1b. Parameterized built-in: `tool:invoke:{tool_id}` (the `*` form is in the
+    // table above). The tool_id follows §5.4.1's charset/length (allows `_`).
+    if let Some(tool_id) = entry.strip_prefix("tool:invoke:") {
+        // `tool:invoke:*` already matched as a built-in above; here tool_id is a
+        // concrete id and MUST NOT contain a `*`.
+        if tool_id.len() > MAX_TOOL_ID_LENGTH {
+            return Err(CeilingEntryError::invalid(
+                entry,
+                format!("tool_id exceeds maximum length of {MAX_TOOL_ID_LENGTH} bytes"),
+            ));
+        }
+        if is_tool_id_token(tool_id) {
+            return Ok(());
+        }
+        return Err(CeilingEntryError::invalid(
+            entry,
+            "tool_id must be a non-empty [a-z0-9_-] token (no '*', no ':', no whitespace)",
+        ));
+    }
+
+    // 2 & 3. Custom capability: EXACTLY ONE colon separating resource and action.
+    let Some((resource, action)) = entry.split_once(':') else {
+        return Err(CeilingEntryError::invalid(
+            entry,
+            "single-token custom (no colon); a custom capability must be \
+             resource:action and is never silently widened to a wildcard",
+        ));
+    };
+
+    // More than one colon is malformed (e.g. `payments:read:write`).
+    if action.contains(':') {
+        return Err(CeilingEntryError::invalid(
+            entry,
+            "more than one colon; a custom ceiling entry has exactly one colon",
+        ));
+    }
+
+    // The resource token is always a kebab-case token (never `*`).
+    if !is_kebab_token(resource) {
+        return Err(CeilingEntryError::invalid(
+            entry,
+            "resource must be a non-empty kebab-case [a-z0-9-] token (no '*', no whitespace)",
+        ));
+    }
+
+    // The action is either the single literal `*` (explicit wildcard) or a
+    // kebab-case token. A `*` as a substring (e.g. `wr*`) is never accepted.
+    if action == "*" || is_kebab_token(action) {
+        Ok(())
+    } else {
+        Err(CeilingEntryError::invalid(
+            entry,
+            "action must be a non-empty kebab-case [a-z0-9-] token or the single literal '*'",
+        ))
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -821,6 +1087,13 @@ pub enum RoleError {
     /// A context lifecycle error occurred during role assignment.
     #[error("context error: {0}")]
     Context(#[from] ContextError),
+
+    /// A ceiling entry supplied at context creation is not a recognized built-in
+    /// category nor a well-formed custom capability (spec §5.3.1.1). Surfaces the
+    /// protocol's `InvalidCeilingCategory` error so a malformed entry can never be
+    /// stored in the ceiling.
+    #[error(transparent)]
+    InvalidCeilingCategory(#[from] CeilingEntryError),
 }
 
 // ---------------------------------------------------------------------------
@@ -928,6 +1201,15 @@ impl ContextRoleState {
     ) -> Result<Self, RoleError> {
         let context_id = context_id.into();
         let creator_did = creator_did.into();
+
+        // Ceiling-entry grammar enforcement (spec §5.3.1.1). Every ceiling entry
+        // must be a recognized built-in category or a well-formed custom
+        // capability; a malformed entry (single-token custom, stray `*`,
+        // multi-colon, bad charset, control/HTML char, oversize, …) fails
+        // creation with `InvalidCeilingCategory` and is never stored. This is the
+        // single canonical enforcement point — every context-creation path routes
+        // through `ContextRoleState::new`.
+        ceiling.validate_entries()?;
 
         // Validate custom roles: name format + capabilities against ceiling.
         for role in &custom_roles {
@@ -3148,12 +3430,294 @@ mod tests {
 
     #[test]
     fn ceiling_with_custom_capability() {
+        // Custom ceiling entries are well-formed `{resource}:{action}` per
+        // §5.3.1.1 (no bare single-token customs).
         let ceiling = CapabilityCeiling::new([
             Capability::MessagesRead,
-            Capability::Custom("special-action".to_owned()),
+            Capability::Custom("special:action".to_owned()),
         ]);
-        assert!(ceiling.contains(&Capability::Custom("special-action".to_owned())));
-        assert!(!ceiling.contains(&Capability::Custom("other-action".to_owned())));
+        assert!(ceiling.contains(&Capability::Custom("special:action".to_owned())));
+        assert!(!ceiling.contains(&Capability::Custom("other:action".to_owned())));
+    }
+
+    // -----------------------------------------------------------------------
+    // Ceiling-entry grammar (spec §5.3.1.1)
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn ceiling_entry_accepts_wellformed_custom_and_wildcard() {
+        // Custom `{resource}:{action}` and explicit `{resource}:*` wildcard.
+        validate_ceiling_entry("payments:approve").unwrap();
+        validate_ceiling_entry("payments:*").unwrap();
+        validate_ceiling_entry("a-b-c:d-e-f").unwrap();
+        validate_ceiling_entry("r0:a0").unwrap();
+    }
+
+    #[test]
+    fn ceiling_entry_accepts_builtin_categories() {
+        for entry in [
+            "messages:read",
+            "messages:write",
+            "tool:register",
+            "tool:invoke:*",
+            "tool:invoke:calc",
+            "member:invite",
+            "member:remove",
+            "member:ban",
+            "role:assign",
+            "media:voice",
+            "media:video",
+            "media:screen_share",
+            "bridging",
+            "tool:interface",
+            "context:child:create",
+            "governance:propose",
+            "governance:vote",
+            "context:close",
+            "metadata:edit",
+        ] {
+            validate_ceiling_entry(entry)
+                .unwrap_or_else(|e| panic!("built-in {entry:?} must be accepted: {e}"));
+        }
+    }
+
+    #[test]
+    fn ceiling_entry_rejects_single_token_custom() {
+        // No colon, no action → malformed; never widened to `payments:*`.
+        assert!(matches!(
+            validate_ceiling_entry("payments"),
+            Err(CeilingEntryError::InvalidCeilingCategory { .. })
+        ));
+    }
+
+    #[test]
+    fn ceiling_entry_rejects_stray_wildcards() {
+        for entry in [
+            "*:*",
+            "*:read",
+            "pay*ments",
+            "payments:wr*",
+            "*",
+            "*:approve",
+        ] {
+            assert!(
+                matches!(
+                    validate_ceiling_entry(entry),
+                    Err(CeilingEntryError::InvalidCeilingCategory { .. })
+                ),
+                "entry {entry:?} must be rejected"
+            );
+        }
+    }
+
+    #[test]
+    fn ceiling_entry_rejects_multi_colon() {
+        assert!(matches!(
+            validate_ceiling_entry("payments:read:write"),
+            Err(CeilingEntryError::InvalidCeilingCategory { .. })
+        ));
+    }
+
+    #[test]
+    fn ceiling_entry_rejects_empty_segments() {
+        for entry in ["payments:", ":read", ":", ""] {
+            assert!(
+                matches!(
+                    validate_ceiling_entry(entry),
+                    Err(CeilingEntryError::InvalidCeilingCategory { .. })
+                ),
+                "entry {entry:?} must be rejected"
+            );
+        }
+    }
+
+    #[test]
+    fn ceiling_entry_rejects_bad_charset_and_whitespace() {
+        for entry in [
+            "Payments:approve",  // uppercase
+            "payments:Approve",  // uppercase action
+            "pay ments:approve", // internal whitespace
+            "payments:appr ove",
+            "payments :approve",
+            "pay_ments:approve", // underscore not in custom kebab charset
+            "payments:appr_ove",
+            "payménts:approve", // non-ASCII
+        ] {
+            assert!(
+                matches!(
+                    validate_ceiling_entry(entry),
+                    Err(CeilingEntryError::InvalidCeilingCategory { .. })
+                ),
+                "entry {entry:?} must be rejected"
+            );
+        }
+    }
+
+    #[test]
+    fn ceiling_entry_rejects_control_and_html_chars() {
+        for entry in [
+            "payments:appr\u{0000}ove",
+            "payments:appr\u{001f}ove",
+            "payments:appr\u{007f}ove",
+            "payments:appr\u{009f}ove",
+            "payments:<approve>",
+            "payments:appr&ove",
+            "payments:appr\"ove",
+            "payments:appr'ove",
+        ] {
+            assert!(
+                matches!(
+                    validate_ceiling_entry(entry),
+                    Err(CeilingEntryError::InvalidCeilingCategory { .. })
+                ),
+                "entry {entry:?} must be rejected"
+            );
+        }
+    }
+
+    #[test]
+    fn ceiling_entry_rejects_oversize() {
+        // 256 bytes is the cap; build a 257-byte well-charset entry.
+        let resource = "r";
+        let action = "a".repeat(MAX_CEILING_ENTRY_LENGTH); // r:aaa... → 1+1+256 = 258 bytes
+        let entry = format!("{resource}:{action}");
+        assert!(entry.len() > MAX_CEILING_ENTRY_LENGTH);
+        assert!(matches!(
+            validate_ceiling_entry(&entry),
+            Err(CeilingEntryError::InvalidCeilingCategory { .. })
+        ));
+        // A 256-byte entry at the boundary is accepted (well-formed kebab).
+        let at_cap = format!("r:{}", "a".repeat(MAX_CEILING_ENTRY_LENGTH - 2));
+        assert_eq!(at_cap.len(), MAX_CEILING_ENTRY_LENGTH);
+        validate_ceiling_entry(&at_cap).unwrap();
+    }
+
+    #[test]
+    fn ceiling_entry_rejects_tool_invoke_with_stray_wildcard() {
+        // `tool:invoke:*` is the only wildcard built-in; an embedded `*` in the
+        // tool_id is malformed.
+        assert!(matches!(
+            validate_ceiling_entry("tool:invoke:ca*lc"),
+            Err(CeilingEntryError::InvalidCeilingCategory { .. })
+        ));
+        assert!(matches!(
+            validate_ceiling_entry("tool:invoke:"),
+            Err(CeilingEntryError::InvalidCeilingCategory { .. })
+        ));
+    }
+
+    #[test]
+    fn capability_validate_as_ceiling_entry_rejects_malformed_custom() {
+        // Enum-form entry point onto the canonical validator.
+        assert!(
+            Capability::Custom("payments".to_owned())
+                .validate_as_ceiling_entry()
+                .is_err()
+        );
+        assert!(
+            Capability::Custom("*:*".to_owned())
+                .validate_as_ceiling_entry()
+                .is_err()
+        );
+        assert!(
+            Capability::Custom("payments:approve".to_owned())
+                .validate_as_ceiling_entry()
+                .is_ok()
+        );
+        assert!(
+            Capability::Custom("payments:*".to_owned())
+                .validate_as_ceiling_entry()
+                .is_ok()
+        );
+        // Built-ins are always well-formed.
+        assert!(Capability::MessagesRead.validate_as_ceiling_entry().is_ok());
+        assert!(
+            Capability::ToolInvokeAll
+                .validate_as_ceiling_entry()
+                .is_ok()
+        );
+        assert!(
+            Capability::ToolInvoke("calc".to_owned())
+                .validate_as_ceiling_entry()
+                .is_ok()
+        );
+        assert!(
+            Capability::ToolInvoke("ca*lc".to_owned())
+                .validate_as_ceiling_entry()
+                .is_err()
+        );
+    }
+
+    #[test]
+    fn ceiling_validate_entries_rejects_first_malformed() {
+        let ceiling = CapabilityCeiling::new([
+            Capability::MessagesRead,
+            Capability::Custom("payments".to_owned()),
+        ]);
+        assert!(matches!(
+            ceiling.validate_entries(),
+            Err(CeilingEntryError::InvalidCeilingCategory { .. })
+        ));
+    }
+
+    #[test]
+    fn context_role_state_new_rejects_malformed_ceiling_entry() {
+        // End-to-end: context creation fails (does not store) a malformed entry.
+        let clock = scp_primitives::SystemClock;
+        let ceiling = CapabilityCeiling::new([
+            Capability::MessagesRead,
+            Capability::Custom("payments".to_owned()),
+        ]);
+        let result = ContextRoleState::new("ctx-1", "did:scp:creator", ceiling, vec![], &clock);
+        assert!(matches!(
+            result,
+            Err(RoleError::InvalidCeilingCategory(
+                CeilingEntryError::InvalidCeilingCategory { .. }
+            ))
+        ));
+    }
+
+    #[test]
+    fn context_role_state_new_accepts_wellformed_custom_ceiling() {
+        let clock = scp_primitives::SystemClock;
+        let ceiling = CapabilityCeiling::new([
+            Capability::MessagesRead,
+            Capability::Custom("payments:approve".to_owned()),
+            Capability::Custom("billing:*".to_owned()),
+            Capability::ToolInvoke("calc".to_owned()),
+        ]);
+        ContextRoleState::new("ctx-1", "did:scp:creator", ceiling, vec![], &clock).unwrap();
+    }
+
+    #[test]
+    fn ceiling_mint_and_validate_agree_on_custom_action() {
+        // Mint-side: ucan string set for a well-formed custom `{resource}:{action}`.
+        let cap = Capability::Custom("payments:approve".to_owned());
+        let ceiling = CapabilityCeiling::new([cap.clone()]);
+        let ucan_set = ceiling.to_ucan_string_set();
+        // Validate-side: a UCAN capability URI for the same {resource}:{action}
+        // is within the ceiling.
+        let uri =
+            crate::crypto::ucan::capability::CapabilityUri::new("ctx-1", "payments", "approve");
+        assert!(uri.is_within_ceiling(&ucan_set));
+        // Mint-side enum check agrees: the exact capability is in the ceiling.
+        assert!(ceiling.contains(&cap));
+    }
+
+    #[test]
+    fn ceiling_mint_and_validate_agree_on_wildcard() {
+        // Explicit `{resource}:*` wildcard.
+        let cap = Capability::Custom("payments:*".to_owned());
+        let ceiling = CapabilityCeiling::new([cap]);
+        let ucan_set = ceiling.to_ucan_string_set();
+        // Validate-side: a concrete action under the wildcard resource is covered.
+        let uri =
+            crate::crypto::ucan::capability::CapabilityUri::new("ctx-1", "payments", "refund");
+        assert!(uri.is_within_ceiling(&ucan_set));
+        // A different resource is NOT covered (no resource wildcard).
+        let other =
+            crate::crypto::ucan::capability::CapabilityUri::new("ctx-1", "billing", "refund");
+        assert!(!other.is_within_ceiling(&ucan_set));
     }
 
     #[test]
@@ -3463,11 +4027,23 @@ mod tests {
     }
 
     #[test]
-    fn ucan_resource_action_custom_no_colons() {
+    fn ucan_resource_action_custom_no_colons_does_not_widen_to_wildcard() {
+        // Regression: a no-colon custom MUST NOT be silently widened to
+        // `{name}:*` (spec §5.3.1.1 — "no implicit or silent wildcard"). Such an
+        // entry is rejected at context creation (see
+        // `ceiling_entry_rejects_single_token_custom`); the residual
+        // `ucan_resource_action` fallback maps it to the concrete, non-wildcard
+        // `name:name` so even a directly-constructed no-colon custom can never
+        // grant `name:*`.
         let cap = Capability::Custom("single".to_owned());
         let (resource, action) = cap.ucan_resource_action();
         assert_eq!(resource.as_ref(), "single");
-        assert_eq!(action.as_ref(), "*");
+        assert_ne!(
+            action.as_ref(),
+            "*",
+            "no-colon custom must not widen to '*'"
+        );
+        assert_eq!(action.as_ref(), "single");
     }
 
     #[test]

--- a/crates/scp-protocol/src/context/roles.rs
+++ b/crates/scp-protocol/src/context/roles.rs
@@ -410,7 +410,37 @@ impl std::fmt::Display for Capability {
 /// opt-in contract (spec section 5.7).
 ///
 /// See ADR-009 acceptance criterion 1.
+///
+/// # Well-formedness is a construction *and* deserialization invariant
+///
+/// Every entry in a `CapabilityCeiling` is well-formed per the ceiling-entry
+/// grammar (spec §5.3.1.1) — this is guaranteed BY THE TYPE, not by callers
+/// remembering to validate. There are exactly two ways a value of this type can
+/// come into existence in production, and both route through
+/// [`validate_entries`](Self::validate_entries):
+///
+/// 1. **In-process construction.** The whole-ceiling writers
+///    ([`ContextRoleState::new`], [`ContextRoleState::set_ceiling`]) call
+///    [`validate_entries`](Self::validate_entries) before storing, so a malformed
+///    ceiling built with [`new`](Self::new) is rejected at the write.
+/// 2. **Deserialization (the FROM-BYTES path).** `Deserialize` is implemented via
+///    `#[serde(try_from = "CapabilityCeilingRaw")]`: the raw set is parsed first,
+///    then [`TryFrom`] runs [`validate_entries`](Self::validate_entries) and
+///    REJECTS the whole deserialization on the first malformed entry. This closes
+///    every untrusted byte loader by construction —
+///    `serde_json::from_str::<CapabilityCeiling>(malformed)` returns `Err`, and so
+///    does any struct that embeds one (e.g. [`ContextRoleState`], the signed
+///    context-export snapshot decoded by `rmp_serde::from_slice`). No per-loader
+///    re-validation is required: a signature authenticates an export's ORIGIN, not
+///    the WELL-FORMEDNESS of its payload, but the type now refuses to even
+///    materialize a malformed ceiling from bytes.
+///
+/// Serialization is unchanged — the field still emits a content-sorted array via
+/// [`serde_sorted_set`](crate::serde_util::serde_sorted_set), so the signed
+/// export digest is byte-stable and a valid ceiling round-trips to an identical
+/// value.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(try_from = "CapabilityCeilingRaw")]
 pub struct CapabilityCeiling {
     /// The set of capabilities permitted in this context.
     ///
@@ -429,6 +459,36 @@ pub struct CapabilityCeiling {
     /// it.
     #[serde(with = "crate::serde_util::serde_sorted_set")]
     pub(crate) capabilities: HashSet<Capability>,
+}
+
+/// Raw, UNVALIDATED deserialization mirror of [`CapabilityCeiling`].
+///
+/// This is the `#[serde(try_from)]` source type: serde deserializes the wire
+/// bytes into this struct (which carries NO well-formedness guarantee), then
+/// [`TryFrom<CapabilityCeilingRaw> for CapabilityCeiling`] runs
+/// [`CapabilityCeiling::validate_entries`] and rejects a malformed ceiling. It is
+/// PRIVATE and exists ONLY as the deserialization waypoint — no code constructs
+/// or stores a `CapabilityCeilingRaw`, so the validated [`CapabilityCeiling`]
+/// remains the single materializable form from bytes.
+#[derive(Deserialize)]
+struct CapabilityCeilingRaw {
+    #[serde(with = "crate::serde_util::serde_sorted_set")]
+    capabilities: HashSet<Capability>,
+}
+
+impl TryFrom<CapabilityCeilingRaw> for CapabilityCeiling {
+    type Error = CeilingEntryError;
+
+    /// Validates every deserialized entry against the ceiling-entry grammar
+    /// (spec §5.3.1.1) before producing a [`CapabilityCeiling`]. A malformed
+    /// entry fails the whole deserialization with [`CeilingEntryError`].
+    fn try_from(raw: CapabilityCeilingRaw) -> Result<Self, Self::Error> {
+        let ceiling = Self {
+            capabilities: raw.capabilities,
+        };
+        ceiling.validate_entries()?;
+        Ok(ceiling)
+    }
 }
 
 impl CapabilityCeiling {
@@ -633,6 +693,140 @@ impl CeilingEntryError {
     }
 }
 
+/// The exhaustive list of non-parameterized built-in [`Capability`] variants.
+///
+/// Single source of truth for "which capabilities are built-ins" — the
+/// parameterized [`Capability::ToolInvoke`] and [`Capability::Custom`] carry
+/// caller text and are validated through the grammar, so they are deliberately
+/// excluded here. Used by [`validate_ucan_ceiling_string`] to recognize the
+/// canonical UCAN-form spelling of every built-in (its
+/// [`Capability::ucan_capability_name`]). Adding a built-in variant is a compile
+/// error here only if this list is matched exhaustively; it is kept aligned with
+/// the enum by the `builtin_capabilities_list_is_exhaustive` test.
+const BUILTIN_CAPABILITIES: &[Capability] = &[
+    Capability::MessagesRead,
+    Capability::MessagesWrite,
+    Capability::ToolInvokeAll,
+    Capability::ToolRegister,
+    Capability::MemberInvite,
+    Capability::MemberRemove,
+    Capability::RoleAssign,
+    Capability::GovernancePropose,
+    Capability::GovernanceVote,
+    Capability::ContextClose,
+    Capability::ChildContextCreate,
+    Capability::ToolInterface,
+    Capability::Bridging,
+    Capability::MediaVoice,
+    Capability::MediaVideo,
+    Capability::MediaScreenShare,
+    Capability::MemberBan,
+    Capability::MetadataEdit,
+];
+
+/// Validates a ceiling entry supplied in **UCAN wire form**
+/// (`{resource}:{action}`, the output of [`Capability::ucan_capability_name`])
+/// against the ceiling-entry grammar (spec §5.3.1.1).
+///
+/// This is the import-path counterpart to [`validate_ceiling_entry`]. The two
+/// validators recognize the SAME set of capabilities but accept DIFFERENT
+/// spellings, because the two paths carry different vocabularies:
+///
+/// - [`validate_ceiling_entry`] validates **user-facing colon form** (e.g.
+///   `tool:invoke:*`, `context:child:create`) — what `create_context` /
+///   `ModifyCeiling` receive, where built-ins resolve to enum variants via
+///   [`Capability::new`] and skip the string grammar entirely.
+/// - This function validates **UCAN form** (e.g. `tool_invoke:*`,
+///   `context_child:create`) — what a context's stored ceiling string set and a
+///   signed export snapshot carry. A built-in's UCAN spelling can contain `_`
+///   (from a multi-segment resource), which the kebab grammar in
+///   [`validate_ceiling_entry`] deliberately forbids for *custom* entries, so a
+///   UCAN-form built-in must be recognized as a built-in rather than parsed as a
+///   custom.
+///
+/// A UCAN-form entry is well-formed iff it is **exactly one** of:
+/// 1. the [`Capability::ucan_capability_name`] of a non-parameterized built-in
+///    ([`BUILTIN_CAPABILITIES`]);
+/// 2. a parameterized `tool_invoke:{tool_id}` whose `tool_id` is a non-empty
+///    `[a-z0-9_-]` token (spec §5.4.1) — `tool_invoke:*` is already covered by
+///    rule 1 via [`Capability::ToolInvokeAll`];
+/// 3. a well-formed custom `{resource}:{action}` accepted by
+///    [`validate_ceiling_entry`] (a valid custom never contains a
+///    conversion-introduced `_`, since the grammar forbids multi-colon customs).
+///
+/// # Errors
+///
+/// Returns [`CeilingEntryError::InvalidCeilingCategory`] if `entry` is not a
+/// well-formed UCAN-form ceiling entry.
+pub fn validate_ucan_ceiling_string(entry: &str) -> Result<(), CeilingEntryError> {
+    // Length cap + sanitization first, identical to `validate_ceiling_entry`, so
+    // the two validators reject oversize/control/HTML/whitespace identically.
+    if entry.len() > MAX_CEILING_ENTRY_LENGTH {
+        return Err(CeilingEntryError::invalid(
+            entry,
+            format!(
+                "exceeds maximum length of {MAX_CEILING_ENTRY_LENGTH} bytes (got {} bytes)",
+                entry.len()
+            ),
+        ));
+    }
+    for ch in entry.chars() {
+        if ch.is_control() {
+            return Err(CeilingEntryError::invalid(
+                entry,
+                "contains a control character (U+0000–U+001F / U+007F–U+009F)",
+            ));
+        }
+        if ch.is_whitespace() {
+            return Err(CeilingEntryError::invalid(entry, "contains whitespace"));
+        }
+        if matches!(ch, '<' | '>' | '&' | '"' | '\'') {
+            return Err(CeilingEntryError::invalid(
+                entry,
+                "contains an HTML-special character (< > & \" ')",
+            ));
+        }
+    }
+
+    // 1. Built-in UCAN spelling — exact match against every built-in's
+    //    `ucan_capability_name()`.
+    if BUILTIN_CAPABILITIES
+        .iter()
+        .any(|c| c.ucan_capability_name() == entry)
+    {
+        return Ok(());
+    }
+
+    // 2. Parameterized `tool_invoke:{tool_id}` (UCAN form). `tool_invoke:*` is a
+    //    built-in handled above; here `tool_id` is a concrete id and MUST NOT
+    //    contain `*`.
+    if let Some(tool_id) = entry.strip_prefix("tool_invoke:") {
+        if tool_id.len() > MAX_TOOL_ID_LENGTH {
+            return Err(CeilingEntryError::invalid(
+                entry,
+                format!("tool_id exceeds maximum length of {MAX_TOOL_ID_LENGTH} bytes"),
+            ));
+        }
+        if is_tool_id_token(tool_id) {
+            return Ok(());
+        }
+        return Err(CeilingEntryError::invalid(
+            entry,
+            "tool_id must be a non-empty [a-z0-9_-] token (no '*', no ':', no whitespace)",
+        ));
+    }
+
+    // 3. Custom capability: a valid custom's UCAN form equals its colon form
+    //    (single colon, kebab resource — no conversion-introduced `_`), so the
+    //    shared custom grammar accepts it verbatim. We call the custom core
+    //    directly (NOT `validate_ceiling_entry`) so a non-canonical COLON-form
+    //    built-in (e.g. `tool:invoke:*`, `context:child:create`) is rejected on
+    //    the UCAN/import path — the stored vocabulary is strictly UCAN form, and
+    //    accepting a colon-form built-in here would let an import store a spelling
+    //    that diverges from the canonical form every gate check matches against.
+    validate_custom_ceiling_entry(entry)
+}
+
 /// Returns `true` if every byte of `token` is in the kebab-case charset
 /// `[a-z0-9-]` and `token` is non-empty (spec §5.3.1.1). No `:`, no `*`, no
 /// whitespace, no uppercase — the charset is exact and closed.
@@ -741,7 +935,31 @@ pub fn validate_ceiling_entry(entry: &str) -> Result<(), CeilingEntryError> {
         ));
     }
 
-    // 2 & 3. Custom capability: EXACTLY ONE colon separating resource and action.
+    // 2 & 3. Custom capability — delegated to the shared custom-grammar core so
+    // the colon-form (this function) and the UCAN-form
+    // ([`validate_ucan_ceiling_string`]) validators apply ONE definition of a
+    // well-formed custom entry.
+    validate_custom_ceiling_entry(entry)
+}
+
+/// Validates the CUSTOM `{resource}:{action}` portion of the ceiling-entry
+/// grammar (spec §5.3.1.1) — the rules shared by [`validate_ceiling_entry`]
+/// (colon form) and [`validate_ucan_ceiling_string`] (UCAN form) once the
+/// built-in and parameterized `tool*invoke` spellings have been excluded by the
+/// caller. A well-formed custom entry has EXACTLY ONE colon, a non-empty
+/// kebab-case `[a-z0-9-]+` resource, and an action that is either a kebab-case
+/// token or the single literal `*` (explicit wildcard). There is no silent
+/// widening — a no-colon token is rejected, not widened to a wildcard.
+///
+/// Note: a well-formed custom's UCAN spelling is byte-identical to its colon
+/// spelling (the resource is single-segment, so no `:`→`_` conversion occurs),
+/// which is why both validators can share this core.
+///
+/// # Errors
+///
+/// Returns [`CeilingEntryError::InvalidCeilingCategory`] if `entry` is not a
+/// well-formed custom ceiling entry.
+fn validate_custom_ceiling_entry(entry: &str) -> Result<(), CeilingEntryError> {
     let Some((resource, action)) = entry.split_once(':') else {
         return Err(CeilingEntryError::invalid(
             entry,
@@ -3672,6 +3890,87 @@ mod tests {
         );
     }
 
+    /// `BUILTIN_CAPABILITIES` must list every non-parameterized built-in variant
+    /// (everything except `ToolInvoke(_)` and `Custom(_)`). An exhaustive match
+    /// makes a newly-added built-in a compile error here, forcing it into the
+    /// list so `validate_ucan_ceiling_string` recognizes its UCAN spelling.
+    #[test]
+    fn builtin_capabilities_list_is_exhaustive() {
+        fn assert_listed(cap: &Capability) {
+            // Exhaustive match: a new variant breaks compilation here.
+            match cap {
+                Capability::ToolInvoke(_) | Capability::Custom(_) => {
+                    // Parameterized / custom — deliberately NOT in the built-in list.
+                }
+                Capability::MessagesRead
+                | Capability::MessagesWrite
+                | Capability::ToolInvokeAll
+                | Capability::ToolRegister
+                | Capability::MemberInvite
+                | Capability::MemberRemove
+                | Capability::RoleAssign
+                | Capability::GovernancePropose
+                | Capability::GovernanceVote
+                | Capability::ContextClose
+                | Capability::ChildContextCreate
+                | Capability::ToolInterface
+                | Capability::Bridging
+                | Capability::MediaVoice
+                | Capability::MediaVideo
+                | Capability::MediaScreenShare
+                | Capability::MemberBan
+                | Capability::MetadataEdit => {
+                    assert!(
+                        BUILTIN_CAPABILITIES.contains(cap),
+                        "built-in {cap:?} missing from BUILTIN_CAPABILITIES"
+                    );
+                }
+            }
+        }
+        for cap in BUILTIN_CAPABILITIES {
+            assert_listed(cap);
+        }
+        assert_eq!(
+            BUILTIN_CAPABILITIES.len(),
+            18,
+            "BUILTIN_CAPABILITIES should hold all 18 non-parameterized built-ins"
+        );
+    }
+
+    /// `validate_ucan_ceiling_string` accepts the canonical UCAN spelling of
+    /// every built-in (including the underscore forms `tool_invoke:*`,
+    /// `context_child:create`, `bridging:*`) plus parameterized tool invokes and
+    /// well-formed customs — and rejects malformed entries and non-canonical
+    /// COLON-form built-ins.
+    #[test]
+    fn validate_ucan_ceiling_string_accepts_canonical_and_rejects_malformed() {
+        // Every built-in's UCAN form round-trips through the UCAN validator.
+        for cap in BUILTIN_CAPABILITIES {
+            let ucan = cap.ucan_capability_name();
+            validate_ucan_ceiling_string(&ucan)
+                .unwrap_or_else(|e| panic!("built-in UCAN form {ucan:?} must validate: {e}"));
+        }
+        // Parameterized tool invoke + well-formed customs.
+        validate_ucan_ceiling_string("tool_invoke:calc").unwrap();
+        validate_ucan_ceiling_string("payments:approve").unwrap();
+        validate_ucan_ceiling_string("billing:*").unwrap();
+
+        // Malformed entries are rejected.
+        for bad in [
+            "payments",                // no colon
+            "*:*",                     // stray wildcard resource
+            "a:b:c",                   // multi-colon custom
+            "custom_payments:approve", // underscore-resource custom (the WASM-create bug spelling)
+            "tool:invoke:*",           // non-canonical COLON-form built-in
+            "context:child:create",    // non-canonical COLON-form built-in
+        ] {
+            assert!(
+                validate_ucan_ceiling_string(bad).is_err(),
+                "UCAN-form validator must reject {bad:?}"
+            );
+        }
+    }
+
     #[test]
     fn ceiling_validate_entries_rejects_first_malformed() {
         let ceiling = CapabilityCeiling::new([
@@ -3796,6 +4095,97 @@ mod tests {
         let json = serde_json::to_string(&ceiling).unwrap();
         let deserialized: CapabilityCeiling = serde_json::from_str(&json).unwrap();
         assert_eq!(ceiling, deserialized);
+    }
+
+    /// A well-formed custom ceiling round-trips through serialize → deserialize
+    /// to the identical value — the validating `Deserialize` (via
+    /// `#[serde(try_from)]`) is transparent to valid ceilings.
+    #[test]
+    fn ceiling_deserialize_accepts_and_roundtrips_wellformed_custom() {
+        let ceiling = CapabilityCeiling::new([
+            Capability::MessagesRead,
+            Capability::Custom("payments:approve".to_owned()),
+            Capability::Custom("billing:*".to_owned()),
+            Capability::ToolInvoke("calc".to_owned()),
+        ]);
+        let json = serde_json::to_string(&ceiling).unwrap();
+        let deserialized: CapabilityCeiling = serde_json::from_str(&json).unwrap();
+        assert_eq!(
+            ceiling, deserialized,
+            "a well-formed ceiling must deserialize to an identical value"
+        );
+    }
+
+    /// TYPE-LEVEL invariant: `serde_json::from_str::<CapabilityCeiling>` REJECTS a
+    /// ceiling carrying a malformed entry at DESERIALIZE time — so no untrusted
+    /// byte loader (import, restore, any future loader) can ever materialize a
+    /// malformed ceiling. The malformed value is built via the unchecked
+    /// constructor + test mutator (simulating a non-conformant peer's serialized
+    /// bytes), serialized, then deserialized.
+    #[test]
+    fn ceiling_deserialize_rejects_malformed_entry() {
+        for malformed in [
+            Capability::Custom("payments".to_owned()),      // no colon
+            Capability::Custom("*:*".to_owned()),           // stray wildcard resource
+            Capability::Custom("a:b:c".to_owned()),         // multi-colon (3 segments)
+            Capability::Custom("bad\u{7f}:cap".to_owned()), // control character
+        ] {
+            // `CapabilityCeiling::new` does NOT validate (validation happens at the
+            // write/deserialize boundary), so this constructs the malformed value a
+            // non-conformant peer could serialize.
+            let bad = CapabilityCeiling::new([Capability::MessagesRead, malformed.clone()]);
+            let json = serde_json::to_string(&bad).unwrap();
+            let result: Result<CapabilityCeiling, _> = serde_json::from_str(&json);
+            assert!(
+                result.is_err(),
+                "deserializing a ceiling with malformed entry {malformed:?} must fail; got {result:?}"
+            );
+        }
+    }
+
+    /// The validating `Deserialize` propagates through any struct that EMBEDS a
+    /// `CapabilityCeiling`: a `ContextRoleState` carrying a malformed ceiling is
+    /// rejected at deserialize (covering the signed context-export snapshot, which
+    /// embeds a `ContextRoleState`). No per-field re-validation is needed.
+    #[test]
+    fn context_role_state_deserialize_rejects_malformed_ceiling() {
+        let clock = scp_primitives::SystemClock;
+        let mut state = ContextRoleState::new(
+            "ctx-1",
+            "did:scp:creator",
+            CapabilityCeiling::new([Capability::MessagesRead]),
+            vec![],
+            &clock,
+        )
+        .unwrap();
+        // Inject a malformed entry into the backing set via the test mutator,
+        // simulating a corrupt/non-conformant serialized snapshot.
+        state
+            .ceiling_mut()
+            .capabilities_mut()
+            .insert(Capability::Custom("payments".to_owned()));
+        let json = serde_json::to_string(&state).unwrap();
+        let result: Result<ContextRoleState, _> = serde_json::from_str(&json);
+        assert!(
+            result.is_err(),
+            "deserializing a ContextRoleState with a malformed ceiling must fail; got a value"
+        );
+
+        // And a well-formed ContextRoleState still deserializes.
+        let good = ContextRoleState::new(
+            "ctx-1",
+            "did:scp:creator",
+            CapabilityCeiling::new([
+                Capability::MessagesRead,
+                Capability::Custom("payments:approve".to_owned()),
+            ]),
+            vec![],
+            &clock,
+        )
+        .unwrap();
+        let good_json = serde_json::to_string(&good).unwrap();
+        let _: ContextRoleState = serde_json::from_str(&good_json)
+            .expect("a well-formed ContextRoleState must deserialize");
     }
 
     #[test]

--- a/crates/scp-protocol/src/context/roles.rs
+++ b/crates/scp-protocol/src/context/roles.rs
@@ -759,34 +759,9 @@ const BUILTIN_CAPABILITIES: &[Capability] = &[
 /// Returns [`CeilingEntryError::InvalidCeilingCategory`] if `entry` is not a
 /// well-formed UCAN-form ceiling entry.
 pub fn validate_ucan_ceiling_string(entry: &str) -> Result<(), CeilingEntryError> {
-    // Length cap + sanitization first, identical to `validate_ceiling_entry`, so
-    // the two validators reject oversize/control/HTML/whitespace identically.
-    if entry.len() > MAX_CEILING_ENTRY_LENGTH {
-        return Err(CeilingEntryError::invalid(
-            entry,
-            format!(
-                "exceeds maximum length of {MAX_CEILING_ENTRY_LENGTH} bytes (got {} bytes)",
-                entry.len()
-            ),
-        ));
-    }
-    for ch in entry.chars() {
-        if ch.is_control() {
-            return Err(CeilingEntryError::invalid(
-                entry,
-                "contains a control character (U+0000–U+001F / U+007F–U+009F)",
-            ));
-        }
-        if ch.is_whitespace() {
-            return Err(CeilingEntryError::invalid(entry, "contains whitespace"));
-        }
-        if matches!(ch, '<' | '>' | '&' | '"' | '\'') {
-            return Err(CeilingEntryError::invalid(
-                entry,
-                "contains an HTML-special character (< > & \" ')",
-            ));
-        }
-    }
+    // Length cap + character sanitization (§9.1A), shared with the colon-form
+    // validator so both reject oversize/control/HTML/whitespace identically.
+    validate_ceiling_entry_charset(entry)?;
 
     // 1. Built-in UCAN spelling — exact match against every built-in's
     //    `ucan_capability_name()`.
@@ -825,6 +800,49 @@ pub fn validate_ucan_ceiling_string(entry: &str) -> Result<(), CeilingEntryError
     //    accepting a colon-form built-in here would let an import store a spelling
     //    that diverges from the canonical form every gate check matches against.
     validate_custom_ceiling_entry(entry)
+}
+
+/// Shared length-cap + character-sanitization prelude for BOTH ceiling-entry
+/// validators ([`validate_ceiling_entry`] colon form and
+/// [`validate_ucan_ceiling_string`] UCAN form), per §9.1A string-field
+/// validation. Rejects, before any structural parse: an entry exceeding
+/// [`MAX_CEILING_ENTRY_LENGTH`] bytes, any control character
+/// (U+0000–U+001F / U+007F–U+009F), any whitespace, and any HTML-special
+/// character (`< > & " '`). Both validators MUST reject these identically, so
+/// the check lives in one place.
+///
+/// # Errors
+///
+/// Returns [`CeilingEntryError::InvalidCeilingCategory`] if `entry` is oversize
+/// or contains a forbidden character.
+fn validate_ceiling_entry_charset(entry: &str) -> Result<(), CeilingEntryError> {
+    if entry.len() > MAX_CEILING_ENTRY_LENGTH {
+        return Err(CeilingEntryError::invalid(
+            entry,
+            format!(
+                "exceeds maximum length of {MAX_CEILING_ENTRY_LENGTH} bytes (got {} bytes)",
+                entry.len()
+            ),
+        ));
+    }
+    for ch in entry.chars() {
+        if ch.is_control() {
+            return Err(CeilingEntryError::invalid(
+                entry,
+                "contains a control character (U+0000–U+001F / U+007F–U+009F)",
+            ));
+        }
+        if ch.is_whitespace() {
+            return Err(CeilingEntryError::invalid(entry, "contains whitespace"));
+        }
+        if matches!(ch, '<' | '>' | '&' | '"' | '\'') {
+            return Err(CeilingEntryError::invalid(
+                entry,
+                "contains an HTML-special character (< > & \" ')",
+            ));
+        }
+    }
+    Ok(())
 }
 
 /// Returns `true` if every byte of `token` is in the kebab-case charset
@@ -877,38 +895,9 @@ fn is_tool_id_token(tool_id: &str) -> bool {
 /// Returns [`CeilingEntryError::InvalidCeilingCategory`] if `entry` is not
 /// well-formed.
 pub fn validate_ceiling_entry(entry: &str) -> Result<(), CeilingEntryError> {
-    // Length cap (bytes), per §9.1A string-field validation.
-    if entry.len() > MAX_CEILING_ENTRY_LENGTH {
-        return Err(CeilingEntryError::invalid(
-            entry,
-            format!(
-                "exceeds maximum length of {MAX_CEILING_ENTRY_LENGTH} bytes (got {} bytes)",
-                entry.len()
-            ),
-        ));
-    }
-
-    // String sanitization (§9.1A): reject control chars, HTML-special chars, and
-    // any whitespace anywhere in the entry. This applies uniformly before any
-    // structural parse — a control char inside an otherwise built-in-looking
-    // string is still malformed.
-    for ch in entry.chars() {
-        if ch.is_control() {
-            return Err(CeilingEntryError::invalid(
-                entry,
-                "contains a control character (U+0000–U+001F / U+007F–U+009F)",
-            ));
-        }
-        if ch.is_whitespace() {
-            return Err(CeilingEntryError::invalid(entry, "contains whitespace"));
-        }
-        if matches!(ch, '<' | '>' | '&' | '"' | '\'') {
-            return Err(CeilingEntryError::invalid(
-                entry,
-                "contains an HTML-special character (< > & \" ')",
-            ));
-        }
-    }
+    // Length cap + character sanitization (§9.1A), shared with the UCAN-form
+    // validator so both reject oversize/control/HTML/whitespace identically.
+    validate_ceiling_entry_charset(entry)?;
 
     // 1. Built-in categories: exact, case-sensitive match.
     if BUILTIN_CEILING_CATEGORIES.contains(&entry) {
@@ -4141,6 +4130,43 @@ mod tests {
                 "deserializing a ceiling with malformed entry {malformed:?} must fail; got {result:?}"
             );
         }
+    }
+
+    /// The TYPE-LEVEL invariant holds for `MessagePack` too, not just JSON: the
+    /// signed context-export snapshot is decoded via `rmp_serde::from_slice`, so
+    /// the validating `Deserialize` (`#[serde(try_from)]`) must reject a malformed
+    /// ceiling in BOTH the array (`to_vec`) and named-map (`to_vec_named`)
+    /// `MessagePack` encodings.
+    #[test]
+    fn ceiling_deserialize_rejects_malformed_entry_msgpack() {
+        let bad = CapabilityCeiling::new([
+            Capability::MessagesRead,
+            Capability::Custom("payments".to_owned()), // no colon — malformed
+        ]);
+
+        let array_bytes = rmp_serde::to_vec(&bad).expect("serialize (array) a value");
+        let array_result: Result<CapabilityCeiling, _> = rmp_serde::from_slice(&array_bytes);
+        assert!(
+            array_result.is_err(),
+            "rmp_serde (array) must reject a malformed ceiling at deserialize"
+        );
+
+        let named_bytes = rmp_serde::to_vec_named(&bad).expect("serialize (named) a value");
+        let named_result: Result<CapabilityCeiling, _> = rmp_serde::from_slice(&named_bytes);
+        assert!(
+            named_result.is_err(),
+            "rmp_serde (named) must reject a malformed ceiling at deserialize"
+        );
+
+        // And a well-formed ceiling still round-trips through MessagePack.
+        let good = CapabilityCeiling::new([
+            Capability::MessagesRead,
+            Capability::Custom("payments:approve".to_owned()),
+        ]);
+        let good_bytes = rmp_serde::to_vec_named(&good).expect("serialize a valid ceiling");
+        let decoded: CapabilityCeiling =
+            rmp_serde::from_slice(&good_bytes).expect("a valid ceiling round-trips via msgpack");
+        assert_eq!(good, decoded);
     }
 
     /// The validating `Deserialize` propagates through any struct that EMBEDS a

--- a/crates/scp-runtime/src/context/actor/class_s.rs
+++ b/crates/scp-runtime/src/context/actor/class_s.rs
@@ -5185,7 +5185,8 @@ impl ClassSCell
         let mut state = fresh_state(ctx_byte);
         state
             .role_state
-            .set_ceiling(scp_protocol::context::roles::CapabilityCeiling::new(caps));
+            .set_ceiling(scp_protocol::context::roles::CapabilityCeiling::new(caps))
+            .expect("well-formed test ceiling");
         state
     }
 
@@ -7364,6 +7365,111 @@ impl ClassSCell
         assert_eq!(
             cell.generation, 7,
             "generation seeded through set_generation_for_test"
+        );
+    }
+
+    // ------------------------------------------------------------------
+    // execute_modify_ceiling — propose-time ceiling-entry grammar gate
+    // (spec §5.3.1.1 / §5.3.2). A malformed proposed ceiling is rejected
+    // at PROPOSE/STAGE time (before the 72h notification window), and no
+    // pending modification is staged. A well-formed proposal stages.
+    // ------------------------------------------------------------------
+
+    /// Build an ACTIVE, `Governed`-ceiling-policy cell so `execute_modify_ceiling`
+    /// reaches its staging logic. The default `ContextParams` ceiling policy is
+    /// `Immutable`; ceiling modification requires `Governed`.
+    async fn active_governed_cell(ctx_byte: u8) -> ClassSCell {
+        let mut state = fresh_state(ctx_byte);
+        let params = scp_protocol::context::params::ContextParams {
+            ceiling_policy: scp_protocol::context::params::CeilingPolicy::Governed,
+            ..scp_protocol::context::params::ContextParams::default()
+        };
+        // Replace the handle with one carrying the Governed policy, then activate.
+        state.handle = crate::context::ContextHandle::new(ctx_hex(ctx_byte), params);
+        state
+            .handle
+            .transition_to(&crate::context::ContextState::Active)
+            .await
+            .expect("transition to Active");
+        ClassSCell::new(state)
+    }
+
+    fn ceiling_commit_meta() -> crate::context::governance_helpers::CommitMeta<'static> {
+        crate::context::governance_helpers::CommitMeta {
+            pid: [7u8; 32],
+            actor_did: "did:example:admin",
+            timestamp_secs: 1_700_000_000,
+        }
+    }
+
+    #[tokio::test]
+    async fn execute_modify_ceiling_rejects_malformed_proposal_at_propose_time() {
+        use scp_protocol::context::roles::Capability;
+
+        let deps = build_deps(Box::new(OkPersistence)).await;
+        let ctx_id = ctx_hex(0xC1);
+
+        // Each malformed entry must be rejected BEFORE staging.
+        for malformed in [
+            Capability::Custom("payments".to_owned()), // no colon
+            Capability::Custom("*:*".to_owned()),      // stray wildcard resource
+            Capability::Custom("a:b:c".to_owned()),    // multi-colon (3 segments)
+        ] {
+            let mut cell = active_governed_cell(0xC1).await;
+            let new_ceiling = vec![Capability::MessagesRead, malformed.clone()];
+            let res = crate::context::governance_helpers::execute_modify_ceiling(
+                &mut cell,
+                &deps,
+                &ctx_id,
+                &new_ceiling,
+                ceiling_commit_meta(),
+            );
+            assert!(
+                matches!(res, Err(ContextError::InvalidState(_))),
+                "malformed proposed ceiling entry {malformed:?} must be rejected at \
+                 propose time: {res:?}"
+            );
+            // Fail-closed: nothing was staged.
+            assert!(
+                cell.governance.pending_ceiling_modification.is_none(),
+                "a rejected malformed ceiling proposal must NOT stage a pending \
+                 modification (entry {malformed:?})"
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn execute_modify_ceiling_stages_wellformed_proposal() {
+        use scp_protocol::context::roles::Capability;
+
+        let deps = build_deps(Box::new(OkPersistence)).await;
+        let ctx_id = ctx_hex(0xC2);
+        let mut cell = active_governed_cell(0xC2).await;
+
+        let new_ceiling = vec![
+            Capability::MessagesRead,
+            Capability::Custom("payments:approve".to_owned()),
+            Capability::Custom("billing:*".to_owned()),
+        ];
+        let res = crate::context::governance_helpers::execute_modify_ceiling(
+            &mut cell,
+            &deps,
+            &ctx_id,
+            &new_ceiling,
+            ceiling_commit_meta(),
+        );
+        assert!(
+            res.is_ok(),
+            "well-formed ceiling proposal must stage: {res:?}"
+        );
+        let pending = cell
+            .governance
+            .pending_ceiling_modification
+            .as_ref()
+            .expect("well-formed proposal stages a pending modification");
+        assert_eq!(
+            pending.new_capabilities, new_ceiling,
+            "staged pending modification carries the proposed capabilities verbatim"
         );
     }
 }

--- a/crates/scp-runtime/src/context/actor/handlers/saga.rs
+++ b/crates/scp-runtime/src/context/actor/handlers/saga.rs
@@ -3023,7 +3023,8 @@ mod tests {
             .set_ceiling(scp_protocol::context::roles::CapabilityCeiling::new([
                 Capability::ToolInterface,
                 Capability::ToolInvokeAll,
-            ]));
+            ]))
+            .expect("well-formed built-in ceiling");
         st.governance.registered_tools.push(ToolRegistration {
             tool_id: TOOL.to_owned(),
             name: "Calculator".to_owned(),

--- a/crates/scp-runtime/src/context/governance_helpers.rs
+++ b/crates/scp-runtime/src/context/governance_helpers.rs
@@ -477,9 +477,23 @@ pub async fn apply_pending_ceiling_modification(
         let state = view.rest_mut();
         // ADR-049 §9: downward-auth ceiling WRITE via the named `set_ceiling`
         // mutator, inside this fail-closed-persisting `commit_class_s_keep`.
-        state.role_state.set_ceiling(CapabilityCeiling::new(
-            pending.new_capabilities.iter().cloned(),
-        ));
+        // `set_ceiling` re-validates the whole replacement against the
+        // ceiling-entry grammar (spec §5.3.1.1) before storing: the
+        // construction invariant holds even if a malformed pending modification
+        // somehow reached this apply step (it cannot — `execute_modify_ceiling`
+        // rejects malformed entries at propose/stage time — but the invariant is
+        // enforced by construction at the write, not assumed). On a rejected
+        // write the prior ceiling stays and the pending record is NOT cleared.
+        state
+            .role_state
+            .set_ceiling(CapabilityCeiling::new(
+                pending.new_capabilities.iter().cloned(),
+            ))
+            .map_err(|e| {
+                ContextError::InvalidState(format!(
+                    "pending ceiling modification has a malformed entry: {e}"
+                ))
+            })?;
         state.governance.pending_ceiling_modification = None;
         Ok(())
     })?;
@@ -1537,6 +1551,24 @@ pub fn execute_modify_ceiling(
     cell.commit_class_s_keep(deps, context_id, |mut view| {
         let state = view.rest_mut();
         require_active(&state.handle)?;
+
+        // Ceiling-entry grammar enforcement at PROPOSE/STAGE time (spec §5.3.1.1).
+        // Validate every proposed ceiling entry BEFORE staging it into
+        // `pending_ceiling_modification`, so a malformed proposal fails fast —
+        // rather than only at apply time, after the §5.3.2 notification window has
+        // elapsed. This is a reject-before-mutate guard: it returns `Err` from
+        // inside the `commit_class_s_keep` closure before any state is written, so
+        // no persist runs and the prior ceiling/pending state is untouched
+        // (fail-closed). The `set_ceiling` invariant at apply time
+        // (`apply_pending_ceiling_modification`) is the construction backstop; this
+        // is the fast-fail front door.
+        for cap in new_ceiling {
+            cap.validate_as_ceiling_entry().map_err(|e| {
+                ContextError::InvalidState(format!(
+                    "proposed ceiling entry is malformed (spec §5.3.1.1): {e}"
+                ))
+            })?;
+        }
 
         if !matches!(
             state.handle.params().ceiling_policy,

--- a/crates/scp-runtime/src/context/lifecycle_helpers.rs
+++ b/crates/scp-runtime/src/context/lifecycle_helpers.rs
@@ -1766,6 +1766,27 @@ pub async fn import_context(
         &export.snapshot.context_params.consequence_config,
     )?;
 
+    // Ceiling-entry grammar enforcement on the IMPORTED ceiling (spec §5.3.1.1).
+    // The imported `role_state` is taken from a DESERIALIZED, signed snapshot
+    // produced by an UNTRUSTED, possibly non-conformant peer. A conformant
+    // creator can never sign an export with a malformed ceiling (the local
+    // construction invariant in `ContextRoleState::new` / `set_ceiling` forbids
+    // storing one), but a NON-CONFORMANT peer's signed export could carry one. A
+    // valid signature authenticates the ORIGIN, not the WELL-FORMEDNESS of the
+    // payload — so we re-validate the ceiling after deserialization and reject a
+    // malformed one rather than letting a non-conformant peer poison a conformant
+    // importer's stored ceiling. This re-establishes the construction invariant on
+    // the import path (the snapshot bypasses `ContextRoleState::new`, building
+    // `PerContextState` directly below).
+    export
+        .snapshot
+        .role_state
+        .ceiling()
+        .validate_entries()
+        .map_err(|e| ContextError::ImportRejected {
+            reason: format!("imported context ceiling has a malformed entry (spec §5.3.1.1): {e}"),
+        })?;
+
     // §9.10.4: the import path is encrypted-only. Every imported context is
     // re-homed with `broadcast_context: None`, `mode = Encrypted`, and a
     // pseudonymous routing axis (see the `import_routing` construction below).
@@ -2366,6 +2387,23 @@ pub async fn restore_context(
         &ctx_snapshot.consequence_rules,
         &ctx_snapshot.context_params.consequence_config,
     )?;
+
+    // Ceiling-entry grammar enforcement on the RESTORED ceiling (spec §5.3.1.1).
+    // This is the self-respawn / process-restart path reading a LOCAL snapshot.
+    // The construction invariant (`ContextRoleState::new` / `set_ceiling`) means a
+    // malformed ceiling can never have been written to that snapshot in the first
+    // place, so this is defense-in-depth against on-disk corruption rather than an
+    // untrusted-peer threat. Reject a malformed restored ceiling rather than
+    // silently rehydrating an actor with a poisoned authorization envelope.
+    ctx_snapshot
+        .role_state
+        .ceiling()
+        .validate_entries()
+        .map_err(|e| {
+            ContextError::PersistenceFailed(format!(
+                "restore: persisted context ceiling has a malformed entry (spec §5.3.1.1): {e}"
+            ))
+        })?;
 
     let now_for_cooldown = deps.clock.now_secs();
     sanitize_cooldown_until(
@@ -3357,6 +3395,39 @@ mod restore_reconcile_tests {
         .expect("routing agreeing with mode must restore Ok");
     }
 
+    /// Restore must reject a persisted snapshot whose ceiling carries a malformed
+    /// entry (spec §5.3.1.1). The construction invariant means a malformed ceiling
+    /// can never have been written legitimately, so this is defense-in-depth
+    /// against on-disk corruption — a poisoned authorization envelope must not be
+    /// silently rehydrated.
+    #[tokio::test]
+    async fn restore_rejects_malformed_ceiling_entry() {
+        let (mut enc_snapshot, _) = harvest_snapshot(false).await;
+        let routing = enc_snapshot.routing.clone();
+        // Inject a malformed (no-colon) custom directly into the backing set via
+        // the test-only ceiling accessor, bypassing the construction invariant the
+        // way a corrupt on-disk snapshot would.
+        enc_snapshot
+            .role_state
+            .ceiling_mut()
+            .capabilities_mut()
+            .insert(scp_protocol::context::roles::Capability::Custom(
+                "payments".to_owned(),
+            ));
+        let err = restore_with(
+            enc_snapshot,
+            routing,
+            None,
+            "restore-case-malformed-ceiling",
+        )
+        .await
+        .expect_err("a malformed restored ceiling must fail closed");
+        assert!(
+            matches!(err, ContextError::PersistenceFailed(ref msg) if msg.contains("malformed")),
+            "expected a PersistenceFailed citing the malformed ceiling, got {err:?}"
+        );
+    }
+
     // -----------------------------------------------------------------------
     // ADR-049 §9 (round-7): paid-join money-ordering parity with the send path.
     // capture_join_payment (external escrow settlement) runs AFTER the
@@ -3679,7 +3750,8 @@ mod restore_reconcile_tests {
                 Capability::MemberInvite,
                 Capability::MessagesWrite,
                 Capability::MessagesRead,
-            ]));
+            ]))
+            .expect("well-formed built-in ceiling");
         state.governance.economic_policy = Some(scp_protocol::economy::types::EconomicPolicy {
             locked: false,
             cost_schedule: scp_protocol::economy::types::CostSchedule {

--- a/crates/scp-runtime/src/context/lifecycle_helpers.rs
+++ b/crates/scp-runtime/src/context/lifecycle_helpers.rs
@@ -1767,17 +1767,22 @@ pub async fn import_context(
     )?;
 
     // Ceiling-entry grammar enforcement on the IMPORTED ceiling (spec §5.3.1.1).
-    // The imported `role_state` is taken from a DESERIALIZED, signed snapshot
-    // produced by an UNTRUSTED, possibly non-conformant peer. A conformant
-    // creator can never sign an export with a malformed ceiling (the local
-    // construction invariant in `ContextRoleState::new` / `set_ceiling` forbids
-    // storing one), but a NON-CONFORMANT peer's signed export could carry one. A
-    // valid signature authenticates the ORIGIN, not the WELL-FORMEDNESS of the
-    // payload — so we re-validate the ceiling after deserialization and reject a
-    // malformed one rather than letting a non-conformant peer poison a conformant
-    // importer's stored ceiling. This re-establishes the construction invariant on
-    // the import path (the snapshot bypasses `ContextRoleState::new`, building
-    // `PerContextState` directly below).
+    // The imported `role_state` is taken from a signed snapshot produced by an
+    // UNTRUSTED, possibly non-conformant peer. A valid signature authenticates the
+    // ORIGIN, not the WELL-FORMEDNESS of the payload, so a non-conformant peer's
+    // signed export could carry a malformed ceiling.
+    //
+    // Defense layering: well-formedness is primarily a TYPE-LEVEL invariant —
+    // `CapabilityCeiling` has a validating `Deserialize` (`#[serde(try_from)]`),
+    // so a malformed ceiling fails to even materialize when an export is decoded
+    // FROM BYTES (`deserialize_export` / `rmp_serde::from_slice`). This explicit
+    // re-validation is the belt-and-suspenders guard for the IN-MEMORY entry
+    // point: `Supervisor::import_context` accepts an already-deserialized
+    // `ContextExport` value (no serde at that boundary), so a programmatically
+    // constructed export reaches here without crossing the validating
+    // `Deserialize`. We re-validate and reject a malformed ceiling rather than
+    // letting it poison a conformant importer's stored ceiling. (The snapshot
+    // bypasses `ContextRoleState::new`, building `PerContextState` directly below.)
     export
         .snapshot
         .role_state
@@ -2392,8 +2397,14 @@ pub async fn restore_context(
     // This is the self-respawn / process-restart path reading a LOCAL snapshot.
     // The construction invariant (`ContextRoleState::new` / `set_ceiling`) means a
     // malformed ceiling can never have been written to that snapshot in the first
-    // place, so this is defense-in-depth against on-disk corruption rather than an
-    // untrusted-peer threat. Reject a malformed restored ceiling rather than
+    // place, and `CapabilityCeiling`'s validating `Deserialize`
+    // (`#[serde(try_from)]`) rejects a malformed ceiling when a real on-disk
+    // provider decodes the snapshot FROM BYTES. This explicit check is the
+    // belt-and-suspenders guard for the IN-MEMORY path: a `ContextPersistence`
+    // provider's `load_context` hands back an already-typed `ContextSnapshot`
+    // value, which may not have crossed serde (e.g. an in-memory provider), so we
+    // re-validate here as defense-in-depth against on-disk corruption rather than
+    // an untrusted-peer threat. Reject a malformed restored ceiling rather than
     // silently rehydrating an actor with a poisoned authorization envelope.
     ctx_snapshot
         .role_state

--- a/crates/scp-runtime/src/context/lifecycle_helpers.rs
+++ b/crates/scp-runtime/src/context/lifecycle_helpers.rs
@@ -1379,9 +1379,19 @@ pub async fn create_context(
     )
     .await?;
     let ceiling = CapabilityCeiling::new(params.ceiling.iter().cloned());
+    // `ContextRoleState::new` enforces the ceiling-entry grammar (spec §5.3.1.1):
+    // a malformed entry fails here with `InvalidCeilingCategory`, preserved as a
+    // typed error so the bridges surface the protocol error verbatim rather than
+    // a flattened string.
     let role_state =
-        ContextRoleState::new(&context_id, &*creator_did, ceiling, vec![], &*deps.clock)
-            .map_err(|e| ContextCreationError::CreationFailed(e.to_string()))?;
+        ContextRoleState::new(&context_id, &*creator_did, ceiling, vec![], &*deps.clock).map_err(
+            |e| match e {
+                scp_protocol::context::roles::RoleError::InvalidCeilingCategory(inner) => {
+                    ContextCreationError::InvalidCeilingCategory(inner)
+                }
+                other => ContextCreationError::CreationFailed(other.to_string()),
+            },
+        )?;
     let mut membership = MembershipState::new();
     let creator_tokens = role_state
         .assignments

--- a/crates/scp-runtime/src/context/supervisor/supervisor.rs
+++ b/crates/scp-runtime/src/context/supervisor/supervisor.rs
@@ -11850,6 +11850,56 @@ mod tests {
         );
     }
 
+    /// A validly-signed export whose ceiling carries a MALFORMED entry (spec
+    /// §5.3.1.1) must be rejected with `ImportRejected`. A valid signature
+    /// authenticates the ORIGIN, not the WELL-FORMEDNESS of the payload — so a
+    /// non-conformant peer's signed export (which could carry a malformed ceiling
+    /// the local construction invariant would never produce) must not poison a
+    /// conformant importer. The export is signed by the creator key and presented
+    /// with the matching verifying key, so it passes signature verification;
+    /// rejection comes from the ceiling-grammar check inside `import_context`.
+    #[tokio::test]
+    async fn import_rejects_malformed_ceiling_entry() {
+        use ed25519_dalek::{Signer, SigningKey};
+
+        let supervisor = supervisor_with_providers();
+        let creator = "did:key:malformed-ceiling-import-creator";
+        let context_id = "malformed-ceiling-import-ctx";
+        let mut snapshot = import_test_snapshot(context_id, creator);
+        // Inject a malformed (no-colon) custom directly into the ceiling's backing
+        // set via the test-only accessor, simulating a non-conformant peer's
+        // export — the construction invariant forbids producing this legitimately.
+        snapshot.role_state.ceiling_mut().capabilities_mut().insert(
+            scp_protocol::context::roles::Capability::Custom("payments".to_owned()),
+        );
+        let event_log_data =
+            create_event_log_data(&[0x33u8; 32], &[scp_event_log::EventType::ContextCreated]);
+
+        let signing_key = SigningKey::from_bytes(&[9u8; 32]);
+        let export = crate::context::export_import::create_export(
+            snapshot,
+            event_log_data,
+            DID(creator.to_owned()),
+            crate::context::export_import::ExportScope::Full,
+            &scp_primitives::SystemClock,
+            |hash: &[u8; 32]| Ok::<_, std::convert::Infallible>(signing_key.sign(hash).to_bytes()),
+        )
+        .expect("build a valid signed export with a malformed ceiling");
+        let verifying_key = signing_key.verifying_key();
+
+        let result = supervisor
+            .import_context(export, &verifying_key, Some([0x42u8; 32]))
+            .await;
+        assert!(
+            matches!(
+                result,
+                Err(ContextError::ImportRejected { ref reason }) if reason.contains("malformed")
+            ),
+            "an export with a malformed ceiling entry must be rejected with \
+             ImportRejected; got {result:?}"
+        );
+    }
+
     // -----------------------------------------------------------------
     // Eviction-path coverage for the `ImportContext` dispatch arm.
     //
@@ -13891,7 +13941,8 @@ mod tests {
             .role_state
             .set_ceiling(scp_protocol::context::roles::CapabilityCeiling::new([
                 Capability::MemberBan,
-            ]));
+            ]))
+            .expect("well-formed built-in ceiling");
         state
             .role_state
             .member_capabilities
@@ -15383,7 +15434,8 @@ mod tests {
             .set_ceiling(scp_protocol::context::roles::CapabilityCeiling::new([
                 Capability::ToolInterface,
                 Capability::ToolInvokeAll,
-            ]));
+            ]))
+            .expect("well-formed built-in ceiling");
         // Established (both-approved) outbound interface caller→target for
         // XCTX_TOOL, so the target-axis authorize-before-reserve gate (gate 2)
         // passes. Source/target ids are the hex id-form §6.2.4 stores.
@@ -15436,7 +15488,8 @@ mod tests {
             .set_ceiling(scp_protocol::context::roles::CapabilityCeiling::new([
                 Capability::ToolInterface,
                 Capability::ToolInvokeAll,
-            ]));
+            ]))
+            .expect("well-formed built-in ceiling");
         st.governance.registered_tools.push(ToolRegistration {
             tool_id: XCTX_TOOL.to_owned(),
             name: "Calculator".to_owned(),


### PR DESCRIPTION
## Summary

Implements the ceiling-entry grammar enforcement defined in **spec §5.3.1.1** ("Ceiling-Entry Grammar"). A ceiling entry is now validated at context creation and a malformed entry can never be stored.

## What was malformed-accepted before

- **No-colon custom silently widened to a wildcard.** `Capability::ucan_resource_action` mapped a no-colon `Custom("payments")` to `("payments", "*")`, so a single-token custom in the ceiling became `payments:*` in the UCAN ceiling string set — granting an action wildcard the creator never wrote.
- **Stray `*` accepted as a custom.** `*:*`, `*:read`, etc. were accepted as `Custom` entries.
- **Bridge disagreement.** The native path widened no-colon customs to `:*`; the WASM path passed them through unchanged (`payments`). Same input, divergent ceilings.

## What's now rejected (grammar, all → `InvalidCeilingCategory`)

A ceiling entry must be **exactly one** of:
1. a **built-in category** — exact, case-sensitive §5.3.1 match (incl. `tool:invoke:{tool_id}` and `tool:invoke:*`);
2. a **custom `{resource}:{action}`** — exactly one colon; both tokens non-empty kebab-case `[a-z0-9-]+`;
3. an **explicit `{resource}:*` wildcard** — `{resource}` kebab-case; action segment is the single literal `*`.

Rejected: single-token custom (`payments`), `*` anywhere except a whole action segment (`*:*`, `*:read`, `pay*ments`, `payments:wr*`), more than one colon (`payments:read:write`), empty resource/action, non-kebab charset, whitespace, control chars (U+0000–U+001F / U+007F–U+009F), HTML-special (`< > & " '`), and entries > 256 bytes. **No implicit or silent wildcard.**

## Where validation runs

- **Single canonical validator** `validate_ceiling_entry` in `scp-protocol` (`context/roles.rs`) — the one definition of "well-formed", with `Capability::validate_as_ceiling_entry` (enum→string bridge) and `CapabilityCeiling::validate_entries`.
- **Native creation gate:** `ContextRoleState::new` validates the ceiling, so every native bridge (PyO3/UniFFI/NAPI) that routes through `lifecycle_helpers::create_context` rejects a malformed ceiling. The typed `InvalidCeilingCategory` is preserved through `ContextCreationError`.
- **WASM:** its own `create_context` (which does not use the runtime) calls the same canonical validator on each raw user string before normalization.
- **Bridge boundaries (defense-in-depth, no broadening):** PyO3 `register_ffi_state` and NAPI `ensure_registered` validate raw user strings before building their UCAN ceiling-string sets; UniFFI `ensure_ucan_registered` skips (never widens) any malformed entry.

## Mint ↔ validate parity

The silent `name → name:*` fallback is removed from `ucan_resource_action` (a no-colon custom now maps to the concrete, non-wildcard `name:name` — and is rejected up front regardless). With construction rejecting malformed customs, the mint-side (`CapabilityCeiling::contains` / `validate_role_definition`) and validate-side (`CapabilityUri::is_within_ceiling`) operate on well-formed entries and agree — tests prove parity for both a custom `{resource}:{action}` and a `{resource}:*` wildcard.

## Tests

- Updated the test that enshrined the old footgun (`ucan_resource_action_custom_no_colons`) to assert no implicit wildcard.
- Grammar accept/reject coverage: single-token, `*:*`, `*:read`, `pay*ments`, `payments:wr*`, multi-colon, empty segments, control/HTML chars, >256 bytes, whitespace; accept `payments:approve`, `payments:*`, built-ins incl. `tool:invoke:*` / `tool:invoke:calc` / `media:screen_share`.
- Enum- and ceiling-level validation, end-to-end `ContextRoleState::new` rejection + accept.
- Mint↔validate parity tests.
- Per-bridge create tests: WASM + PyO3 reject malformed entries (and store nothing); both accept well-formed customs/wildcards.

🤖 Generated with [Claude Code](https://claude.com/claude-code)