### PR TITLE
fix(wasm): cryptographically evict removed members from the MLS group (cross-bridge RemoveMember parity)

### DIFF
--- a/bindings/typescript/src/internal/wasm.ts
+++ b/bindings/typescript/src/internal/wasm.ts
@@ -1098,6 +1098,13 @@ export function createWasmBridge(): Bridge {
       // Execute BY ID: the WASM runtime resolves the authoritative, tracked
       // proposal and dispatches its action. No caller-supplied action; the
       // executor and consequence subject are the tracked proposal's proposer.
+      //
+      // For RemoveMember the returned JSON carries a hex `commit` field. WASM has
+      // no internal transport (ADR-034) and never auto-broadcasts it, so the
+      // caller MUST relay this commit to the other context members or the MLS
+      // group silently forks (remaining members never learn of the eviction). An
+      // empty `commit` means no MLS commit was produced (broadcast/unencrypted
+      // context, or the removed member held no MLS leaf).
       return await wasm.context_execute_governance(handle, proposalIdHex);
     },
 

--- a/bindings/typescript/src/scp.ts
+++ b/bindings/typescript/src/scp.ts
@@ -1357,6 +1357,19 @@ export class SCP {
    * action, or status. An untracked / unapproved id is rejected. The executor
    * and consequence subject are resolved from the tracked proposal's proposer,
    * never from a caller-supplied DID.
+   *
+   * @returns A JSON string describing the action result. For membership-changing
+   * actions (`RemoveMember`) the JSON includes a `commit` field: a hex-encoded
+   * MLS Commit that evicts the removed member from the group key schedule.
+   *
+   * **Browser (WASM) callers MUST relay this `commit` to the other context
+   * members.** The WASM bridge has no internal transport (ADR-034) and performs
+   * no automatic broadcast or retry — unlike the native bridge, which
+   * auto-broadcasts the eviction commit. If a WASM caller does not distribute
+   * it, the MLS group silently forks: the remaining members never advance their
+   * epoch and never learn of the eviction. An empty `commit` string means no MLS
+   * commit was produced (broadcast/unencrypted context, or the removed member
+   * held no MLS leaf) and there is nothing to distribute.
    */
   async contextExecuteGovernanceAction(handle: unknown, proposalIdHex: string): Promise<string> {
     return await (

--- a/bindings/typescript/src/scp.ts
+++ b/bindings/typescript/src/scp.ts
@@ -1362,14 +1362,20 @@ export class SCP {
    * actions (`RemoveMember`) the JSON includes a `commit` field: a hex-encoded
    * MLS Commit that evicts the removed member from the group key schedule.
    *
-   * **Browser (WASM) callers MUST relay this `commit` to the other context
-   * members.** The WASM bridge has no internal transport (ADR-034) and performs
-   * no automatic broadcast or retry — unlike the native bridge, which
-   * auto-broadcasts the eviction commit. If a WASM caller does not distribute
-   * it, the MLS group silently forks: the remaining members never advance their
-   * epoch and never learn of the eviction. An empty `commit` string means no MLS
-   * commit was produced (broadcast/unencrypted context, or the removed member
-   * held no MLS leaf) and there is nothing to distribute.
+   * Commit distribution differs by backend:
+   * - **Native (NAPI) backend — this method.** This call routes through the
+   *   native addon, which has an internal transport and **auto-broadcasts** the
+   *   eviction `commit` to the other context members. The caller does not need
+   *   to relay it.
+   * - **Browser (WASM) backend.** The WASM bridge has no internal transport
+   *   (ADR-034) and performs no automatic broadcast or retry, so a WASM caller
+   *   **MUST relay the `commit`** it receives to the other context members. If
+   *   it does not, the MLS group silently forks: the remaining members never
+   *   advance their epoch and never learn of the eviction.
+   *
+   * Either way, an empty `commit` string means no MLS commit was produced
+   * (broadcast/unencrypted context, or the removed member held no MLS leaf) and
+   * there is nothing to distribute.
    */
   async contextExecuteGovernanceAction(handle: unknown, proposalIdHex: string): Promise<string> {
     return await (

--- a/crates/scp-ffi/wasm/src/context.rs
+++ b/crates/scp-ffi/wasm/src/context.rs
@@ -734,6 +734,19 @@ pub fn context_drain_events(handle: &WasmContextHandle) -> String {
 /// # Returns
 ///
 /// `Promise<string>` — resolves to a JSON result of the governance action.
+///
+/// For membership-changing actions (`RemoveMember`), the result JSON includes a
+/// `commit` field: a hex-encoded MLS Commit message that evicts the removed
+/// member from the group key schedule. **The caller MUST distribute this commit
+/// to the other context members via the relay.** The WASM bridge has no internal
+/// transport (ADR-034) and performs no automatic broadcast or retry — unlike the
+/// native runtime, which auto-broadcasts the eviction commit. If the caller does
+/// not relay it, the MLS group silently forks: the remaining members never
+/// advance their epoch, never learn of the eviction, and the removed member's
+/// key schedule stays valid for traffic those members keep producing on the old
+/// epoch. An empty `commit` string means no MLS commit was produced — the
+/// context is broadcast/unencrypted, or the removed member held no MLS leaf — and
+/// there is nothing to distribute.
 #[wasm_bindgen]
 pub fn context_execute_governance(handle: &WasmContextHandle, proposal_id_hex: String) -> Promise {
     if let Err(e) = validate_proposal_id_hex(&proposal_id_hex) {

--- a/crates/scp-ffi/wasm/src/crypto/group.rs
+++ b/crates/scp-ffi/wasm/src/crypto/group.rs
@@ -176,6 +176,50 @@ impl WasmMlsGroup {
             .map_err(|e| WasmCryptoError::RemoveMemberFailed(format!("serializing commit: {e}")))
     }
 
+    /// Returns the local member's own DID, decoded from the SCP credential in
+    /// the committer's own MLS leaf.
+    ///
+    /// Reads the leaf at [`MlsGroup::own_leaf_index`] — which is leaf 0 for the
+    /// group creator and a non-zero leaf for a member who joined via Welcome —
+    /// finds that member among [`MlsGroup::members`], decodes its
+    /// [`BasicCredential`] into a [`WasmScpCredential`], and returns the `did`.
+    /// No persistent state is required: the local DID is recovered from the
+    /// group itself at call time, so it is correct for the creator and any
+    /// Welcome-joined member alike.
+    ///
+    /// This is the WASM analogue of native's `self.local_did`
+    /// (`scp_runtime::crypto::mls::provider`), which the native
+    /// `MlsCryptoProvider::remove_member` short-circuits on at provider.rs:1041.
+    /// Deriving from the own leaf (rather than storing a field) keeps the two
+    /// construction paths — `create_group` and `join_from_welcome` — free of a
+    /// hand-maintained DID field that the join path could set wrong.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`WasmCryptoError::GroupDestroyed`] if the group has been
+    /// destroyed, or [`WasmCryptoError::RemoveMemberFailed`] if the own leaf's
+    /// credential cannot be located or decoded (it always should be — the
+    /// committer is a member of its own group).
+    pub fn own_did(&self) -> Result<String, WasmCryptoError> {
+        let g = self.group.as_ref().ok_or(WasmCryptoError::GroupDestroyed)?;
+        let own_index = g.own_leaf_index();
+        for member in g.members() {
+            if member.index != own_index {
+                continue;
+            }
+            let basic = BasicCredential::try_from(member.credential).map_err(|e| {
+                WasmCryptoError::RemoveMemberFailed(format!("decoding own leaf credential: {e}"))
+            })?;
+            let scp_cred = WasmScpCredential::from_bytes(basic.identity()).map_err(|e| {
+                WasmCryptoError::RemoveMemberFailed(format!("parsing own SCP credential: {e}"))
+            })?;
+            return Ok(scp_cred.did);
+        }
+        Err(WasmCryptoError::RemoveMemberFailed(
+            "own leaf not found among group members".to_string(),
+        ))
+    }
+
     /// Resolves the [`LeafNodeIndex`] of the group member whose SCP credential
     /// carries `member_did`, SKIPPING the local member's own leaf.
     ///
@@ -255,6 +299,35 @@ impl WasmMlsGroup {
     /// removed member can no longer derive the group key — rests on the MLS
     /// epoch advance, which only exists when the member actually held a leaf.
     ///
+    /// # Self-removal parity with native (two mechanisms)
+    ///
+    /// Native `MlsCryptoProvider::remove_member` funnels a self-removal to an
+    /// empty-commit no-op via TWO independent mechanisms, and this method now
+    /// mirrors BOTH:
+    /// 1. **Self-DID short-circuit** (native provider.rs:1041,
+    ///    `if member_did == self.local_did { return default }`): BEFORE any
+    ///    scan, an own-DID removal returns `Ok(Vec::new())`. WASM derives the
+    ///    local DID from the committer's own leaf via [`own_did`](Self::own_did)
+    ///    (no stored state). This additionally covers a pathological
+    ///    duplicate-DID tree (a SECOND leaf carrying the local DID): native
+    ///    evicts NEITHER leaf, so WASM must not either — the short-circuit
+    ///    returns before [`leaf_index_for_did`](Self::leaf_index_for_did) could
+    ///    resolve the non-own duplicate leaf and wrongly advance the epoch,
+    ///    diverging from native and breaking the §9.9.3 cross-platform
+    ///    `tree::root` convergence invariant.
+    /// 2. **Own-leaf skip in the scan** (native provider.rs:1060,
+    ///    `if member.index == own_index { continue; }`): retained in
+    ///    [`leaf_index_for_did`](Self::leaf_index_for_did). It handles the
+    ///    normal single-own-leaf self-removal even were the short-circuit
+    ///    absent, and keeps `OpenMLS` from rejecting `remove_member(own_index)`
+    ///    with `CannotRemoveSelf`.
+    ///
+    /// Either way, self-removal is an empty-commit no-op: the local member
+    /// abandons its own group state and the remaining members process the
+    /// removal via a relayed commit from another member, while the dispatch
+    /// layer strips governance + appends the `MemberLeft` leaf — matching
+    /// native's self-removal exactly.
+    ///
     /// # Errors
     ///
     /// Returns [`WasmCryptoError::GroupDestroyed`] if the group has been
@@ -263,6 +336,17 @@ impl WasmMlsGroup {
     /// MLS failures and must propagate so the dispatch layer can fail closed
     /// (keep the member rather than report a removal that did not cut the key).
     pub fn remove_member_by_did(&mut self, member_did: &str) -> Result<Vec<u8>, WasmCryptoError> {
+        // Self-DID short-circuit, mirroring native provider.rs:1041
+        // (`member_did == self.local_did`). The local DID is derived from the
+        // committer's own leaf, so this is correct for the creator and any
+        // Welcome-joined member. Returning BEFORE the scan also covers the
+        // pathological duplicate-DID tree: native evicts neither leaf, so this
+        // empty-commit no-op must not resolve a non-own duplicate leaf either.
+        // `own_did` propagates `GroupDestroyed` (group is None) as a genuine
+        // error.
+        if self.own_did()? == member_did {
+            return Ok(Vec::new());
+        }
         // `leaf_index_for_did` propagates `GroupDestroyed` (group is None) as a
         // genuine error; `Ok(None)` means the DID has no MLS leaf.
         let Some(leaf_index) = self.leaf_index_for_did(member_did)? else {
@@ -699,6 +783,143 @@ mod tests {
             alice_group.epoch().unwrap(),
             bob_epoch_before + 1,
             "evicting a non-self member must advance the MLS epoch"
+        );
+    }
+
+    #[test]
+    #[allow(clippy::unwrap_used, clippy::expect_used)]
+    fn own_did_returns_local_member_did_for_creator() {
+        // The creator occupies leaf 0; `own_did` must recover Alice's DID from
+        // her own leaf credential without any stored state.
+        let alice_cred = test_credential("alice");
+        let alice_group = WasmMlsGroup::create_group(&alice_cred).unwrap();
+        assert_eq!(
+            alice_group.own_did().unwrap(),
+            alice_cred.did,
+            "own_did must recover the creator's DID from her own leaf"
+        );
+    }
+
+    #[test]
+    #[allow(clippy::unwrap_used, clippy::expect_used)]
+    fn own_did_returns_joiner_did_for_welcome_joined_member() {
+        // A Welcome-joined member occupies a non-zero leaf; `own_did` must
+        // recover the JOINER's DID (Bob), not the creator's (Alice). This proves
+        // the self-DID short-circuit is correct on both construction paths.
+        let alice_cred = test_credential("alice");
+        let mut alice_group = WasmMlsGroup::create_group(&alice_cred).unwrap();
+
+        let bob_cred = test_credential("bob");
+        let (bob_kp_bytes, bob_holder) = WasmMlsGroup::generate_key_package(&bob_cred).unwrap();
+        let bob_kp_in = KeyPackageIn::tls_deserialize(&mut &*bob_kp_bytes).unwrap();
+        let (_commit, welcome_bytes) = alice_group.add_member(bob_kp_in).unwrap();
+
+        let bob_group = WasmMlsGroup::join_from_welcome(&welcome_bytes, bob_holder).unwrap();
+        assert_eq!(
+            bob_group.own_did().unwrap(),
+            bob_cred.did,
+            "own_did must recover the joiner's DID, not the creator's"
+        );
+    }
+
+    #[test]
+    #[allow(clippy::unwrap_used, clippy::expect_used)]
+    fn own_did_errors_on_destroyed_group() {
+        let alice_cred = test_credential("alice");
+        let mut alice_group = WasmMlsGroup::create_group(&alice_cred).unwrap();
+        alice_group.destroy();
+        let err = alice_group
+            .own_did()
+            .expect_err("own_did against a destroyed group must error");
+        assert!(
+            matches!(err, WasmCryptoError::GroupDestroyed),
+            "destroyed-group own_did must be GroupDestroyed, got {err:?}"
+        );
+    }
+
+    #[test]
+    #[allow(clippy::unwrap_used, clippy::expect_used)]
+    fn remove_member_by_did_short_circuits_on_self_did_before_scan() {
+        // The self-DID short-circuit (native provider.rs:1041) returns an
+        // empty-commit no-op BEFORE the leaf scan. On a single-member group
+        // there is no other leaf, so a removal of the OWN DID exercises the
+        // short-circuit path: empty commit, no epoch advance, no error.
+        let alice_cred = test_credential("alice");
+        let mut alice_group = WasmMlsGroup::create_group(&alice_cred).unwrap();
+
+        let epoch_before = alice_group.epoch().unwrap();
+        let commit = alice_group
+            .remove_member_by_did(&alice_cred.did)
+            .expect("self-DID removal must be an empty-commit no-op");
+        assert!(
+            commit.is_empty(),
+            "self-DID removal must produce an empty commit (no-op)"
+        );
+        assert_eq!(
+            alice_group.epoch().unwrap(),
+            epoch_before,
+            "self-DID removal must NOT advance the MLS epoch"
+        );
+    }
+
+    #[test]
+    #[allow(clippy::unwrap_used, clippy::expect_used)]
+    fn remove_member_by_did_self_did_does_not_evict_duplicate_leaf() {
+        // Pathological duplicate-DID tree: a SECOND leaf carries the local
+        // member's OWN DID. Native `MlsCryptoProvider::remove_member`
+        // short-circuits on `member_did == self.local_did` (provider.rs:1041)
+        // and evicts NEITHER leaf (empty no-op). WASM must match: the self-DID
+        // short-circuit returns before the scan, so the duplicate non-own leaf
+        // is NOT resolved or evicted and the epoch does NOT advance.
+        //
+        // The duplicate leaf is constructed via the normal add path with a
+        // credential carrying Alice's DID but a fresh signing key (a distinct
+        // KeyPackage). OpenMLS keys leaves by leaf-node/signature-key, not by
+        // SCP credential DID, so two leaves can legitimately carry the same DID.
+        let alice_cred = test_credential("alice");
+        let mut alice_group = WasmMlsGroup::create_group(&alice_cred).unwrap();
+
+        // A second credential with Alice's SAME DID but its own signing key.
+        let dup_cred = test_credential("alice");
+        assert_eq!(
+            dup_cred.did, alice_cred.did,
+            "the duplicate leaf must carry the local member's own DID"
+        );
+        let (dup_kp_bytes, _dup_holder) = WasmMlsGroup::generate_key_package(&dup_cred).unwrap();
+        let dup_kp_in = KeyPackageIn::tls_deserialize(&mut &*dup_kp_bytes).unwrap();
+        alice_group.add_member(dup_kp_in).unwrap();
+
+        // The group now has two leaves carrying Alice's DID (her own leaf 0 plus
+        // the added duplicate). The epoch advanced once for the add.
+        let epoch_after_add = alice_group.epoch().unwrap();
+
+        // Self-removal of Alice's own DID must be an empty-commit no-op: the
+        // short-circuit fires before the scan, so the duplicate leaf is left in
+        // place and the epoch does not advance — exactly as native would.
+        let commit = alice_group
+            .remove_member_by_did(&alice_cred.did)
+            .expect("self-DID removal in a dup-DID tree must be an empty no-op");
+        assert!(
+            commit.is_empty(),
+            "self-DID removal in a dup-DID tree must produce an empty commit"
+        );
+        assert_eq!(
+            alice_group.epoch().unwrap(),
+            epoch_after_add,
+            "self-DID removal must NOT advance the epoch — the duplicate leaf is \
+             NOT evicted, matching native's short-circuit"
+        );
+
+        // The duplicate leaf is still present: a NON-self scan (own-leaf skipped)
+        // still resolves Alice's DID to the duplicate's leaf index, proving the
+        // short-circuit — not an eviction — is what produced the no-op.
+        assert!(
+            alice_group
+                .leaf_index_for_did(&alice_cred.did)
+                .unwrap()
+                .is_some(),
+            "the duplicate leaf carrying the local DID must still be present \
+             (own-leaf skip resolves it; the short-circuit did not evict it)"
         );
     }
 

--- a/crates/scp-ffi/wasm/src/crypto/group.rs
+++ b/crates/scp-ffi/wasm/src/crypto/group.rs
@@ -840,10 +840,20 @@ mod tests {
     #[test]
     #[allow(clippy::unwrap_used, clippy::expect_used)]
     fn remove_member_by_did_short_circuits_on_self_did_before_scan() {
-        // The self-DID short-circuit (native provider.rs:1041) returns an
-        // empty-commit no-op BEFORE the leaf scan. On a single-member group
-        // there is no other leaf, so a removal of the OWN DID exercises the
-        // short-circuit path: empty commit, no epoch advance, no error.
+        // Self-removal on a SINGLE-member group: an own-DID removal is an
+        // empty-commit no-op (empty commit, no epoch advance, no error).
+        //
+        // NOTE — this test does NOT discriminate the self-DID short-circuit
+        // (native provider.rs:1041) from the own-leaf skip in
+        // `leaf_index_for_did` (native provider.rs:1060). On a single-member
+        // group both mechanisms independently yield the same empty no-op: even
+        // with the short-circuit removed, the own-leaf skip alone makes
+        // `leaf_index_for_did(own_did)` return `None`, so the result is
+        // identical. The test that actually isolates the short-circuit is
+        // `remove_member_by_did_self_did_does_not_evict_duplicate_leaf`, where a
+        // duplicate non-own leaf carries the local DID: only the short-circuit
+        // (returning BEFORE the scan) prevents that duplicate from being
+        // resolved and evicted. This test covers the common-case no-op shape.
         let alice_cred = test_credential("alice");
         let mut alice_group = WasmMlsGroup::create_group(&alice_cred).unwrap();
 

--- a/crates/scp-ffi/wasm/src/crypto/group.rs
+++ b/crates/scp-ffi/wasm/src/crypto/group.rs
@@ -177,17 +177,34 @@ impl WasmMlsGroup {
     }
 
     /// Resolves the [`LeafNodeIndex`] of the group member whose SCP credential
-    /// carries `member_did`.
+    /// carries `member_did`, SKIPPING the local member's own leaf.
     ///
-    /// Scans every current group member, decodes each member's
+    /// Scans every current group member EXCEPT the committer's own leaf
+    /// (`MlsGroup::own_leaf_index`), decodes each member's
     /// [`BasicCredential`] into a [`WasmScpCredential`], and returns the leaf
-    /// index of the first member whose `did` matches. Returns `Ok(None)` when
-    /// no current member carries that DID.
+    /// index of the first OTHER member whose `did` matches. Returns `Ok(None)`
+    /// when no other current member carries that DID — including the case where
+    /// `member_did` is the local member's OWN DID (self-removal).
     ///
-    /// Mirrors native `find_leaf_index_by_did`
-    /// (`scp_runtime::crypto::mls::wrapping_extension`): MLS does not key its
-    /// tree by DID, so removal-by-DID must map the SCP identity to its leaf
-    /// before calling [`remove_member`](Self::remove_member).
+    /// Mirrors native `MlsCryptoProvider::remove_member`
+    /// (`scp_runtime::crypto::mls::provider`, provider.rs:1041/1060), which
+    /// combines a self-DID short-circuit (`member_did == self.local_did` ->
+    /// empty-commit no-op) and an own-leaf skip in the scan
+    /// (`if member.index == own_index { continue; }`). Both funnel self-removal
+    /// to the same outcome: an empty-commit NO-OP. Skipping the own leaf here
+    /// makes an own-DID lookup return `Ok(None)`, which
+    /// [`remove_member_by_did`](Self::remove_member_by_did) turns into the
+    /// empty-commit no-op — the local member abandons its own group state and
+    /// the remaining members process the removal via the relayed commit from
+    /// another member. If the own leaf were NOT skipped, `OpenMLS` would reject
+    /// `remove_member(own_index)` with `CannotRemoveSelf`, the dispatch layer
+    /// would fail closed, and the member would be KEPT with no `MemberLeft` /
+    /// `GovernanceActionExecuted` leaf — divergent from native's self-removal
+    /// (which proceeds to strip governance + append both leaves), breaking the
+    /// §9.9.3 cross-platform `tree::root` convergence invariant.
+    ///
+    /// MLS does not key its tree by DID, so removal-by-DID must map the SCP
+    /// identity to its leaf before calling [`remove_member`](Self::remove_member).
     ///
     /// # Errors
     ///
@@ -198,7 +215,17 @@ impl WasmMlsGroup {
         member_did: &str,
     ) -> Result<Option<LeafNodeIndex>, WasmCryptoError> {
         let g = self.group.as_ref().ok_or(WasmCryptoError::GroupDestroyed)?;
+        // The committer's own leaf — `MlsGroup::own_leaf_index` is infallible on
+        // the raw OpenMLS group. Skip it so a self-DID removal resolves to
+        // `None` (empty-commit no-op), mirroring native's own-index skip +
+        // self no-op (provider.rs:1041/1060). Do NOT hardcode index 0: the
+        // creator is leaf 0 but a member who JOINED via Welcome occupies a
+        // different leaf.
+        let own_index = g.own_leaf_index();
         for member in g.members() {
+            if member.index == own_index {
+                continue;
+            }
             if let Ok(basic) = BasicCredential::try_from(member.credential.clone())
                 && let Ok(scp_cred) = WasmScpCredential::from_bytes(basic.identity())
                 && scp_cred.did == member_did
@@ -541,19 +568,24 @@ mod tests {
         let bob_kp_in = KeyPackageIn::tls_deserialize(&mut &*bob_kp_bytes).unwrap();
         alice_group.add_member(bob_kp_in).unwrap();
 
-        // Bob's DID resolves to a real leaf index (the second leaf — Alice is
-        // the creator at leaf 0).
-        let bob_index = alice_group
+        // Bob's DID (a NON-self member) resolves to a real leaf index (the
+        // second leaf — Alice is the creator at leaf 0). The own-leaf skip must
+        // NOT affect resolution of OTHER members.
+        let _bob_index = alice_group
             .leaf_index_for_did(&bob_cred.did)
             .unwrap()
             .expect("Bob's DID must resolve to an MLS leaf after add");
-        let alice_index = alice_group
-            .leaf_index_for_did(&alice_cred.did)
-            .unwrap()
-            .expect("Alice's DID must resolve to her own leaf");
-        assert_ne!(
-            bob_index, alice_index,
-            "Alice and Bob must occupy distinct leaves"
+
+        // Alice's OWN DID resolves to None — `leaf_index_for_did` skips the
+        // committer's own leaf, mirroring native `MlsCryptoProvider::
+        // remove_member` (own-index skip + self no-op, provider.rs:1041/1060).
+        // This is what funnels a self-removal to the empty-commit no-op.
+        assert!(
+            alice_group
+                .leaf_index_for_did(&alice_cred.did)
+                .unwrap()
+                .is_none(),
+            "the local member's OWN DID must resolve to None (own leaf skipped)"
         );
 
         // A DID that is not a member resolves to None (not an error).
@@ -609,6 +641,64 @@ mod tests {
             alice_group.epoch().unwrap(),
             epoch_before,
             "a missing-leaf removal must NOT advance the MLS epoch"
+        );
+    }
+
+    #[test]
+    #[allow(clippy::unwrap_used, clippy::expect_used)]
+    fn remove_member_by_did_is_noop_for_self_did() {
+        // Self-removal parity with native `MlsCryptoProvider::remove_member`:
+        // when the removed DID is the local member's OWN DID, the own leaf is
+        // skipped, so `leaf_index_for_did` returns `None` and
+        // `remove_member_by_did` is an empty-commit NO-OP (epoch unchanged).
+        // OpenMLS would otherwise reject `remove_member(own_index)` with
+        // `CannotRemoveSelf`; mirroring native, dispatch instead proceeds to
+        // strip governance + append the `MemberLeft` leaf.
+        let alice_cred = test_credential("alice");
+        let mut alice_group = WasmMlsGroup::create_group(&alice_cred).unwrap();
+
+        // Add Bob so the group has more than one leaf — proves the no-op is
+        // specifically the own-leaf skip, not "single-member group" behaviour.
+        let bob_cred = test_credential("bob");
+        let (bob_kp_bytes, _bob_holder) = WasmMlsGroup::generate_key_package(&bob_cred).unwrap();
+        let bob_kp_in = KeyPackageIn::tls_deserialize(&mut &*bob_kp_bytes).unwrap();
+        alice_group.add_member(bob_kp_in).unwrap();
+
+        // Alice's own DID resolves to None (own leaf skipped).
+        assert!(
+            alice_group
+                .leaf_index_for_did(&alice_cred.did)
+                .unwrap()
+                .is_none(),
+            "the local member's own DID must resolve to None (own leaf skipped)"
+        );
+
+        let epoch_before = alice_group.epoch().unwrap();
+        let commit = alice_group
+            .remove_member_by_did(&alice_cred.did)
+            .expect("self-removal must be an empty-commit no-op, not an error");
+        assert!(
+            commit.is_empty(),
+            "self-removal must produce an empty commit (no-op)"
+        );
+        assert_eq!(
+            alice_group.epoch().unwrap(),
+            epoch_before,
+            "self-removal must NOT advance the MLS epoch"
+        );
+
+        // Bob (a NON-self member) still resolves + evicts normally — the
+        // own-leaf skip must not affect other members.
+        let bob_epoch_before = alice_group.epoch().unwrap();
+        let bob_commit = alice_group.remove_member_by_did(&bob_cred.did).unwrap();
+        assert!(
+            !bob_commit.is_empty(),
+            "evicting a non-self member must still produce a commit"
+        );
+        assert_eq!(
+            alice_group.epoch().unwrap(),
+            bob_epoch_before + 1,
+            "evicting a non-self member must advance the MLS epoch"
         );
     }
 

--- a/crates/scp-ffi/wasm/src/crypto/group.rs
+++ b/crates/scp-ffi/wasm/src/crypto/group.rs
@@ -213,21 +213,45 @@ impl WasmMlsGroup {
     /// TLS-serialized commit that evicts them from the MLS group.
     ///
     /// Resolves the DID to its leaf via [`leaf_index_for_did`](Self::leaf_index_for_did)
-    /// and delegates to [`remove_member`](Self::remove_member). The governance
-    /// layer has ALREADY verified the member is in the context before calling
-    /// this, so a missing MLS leaf is a real native↔WASM state divergence — it
-    /// fails loudly rather than silently skipping the cryptographic eviction
-    /// (the removed member would otherwise keep the group key schedule).
+    /// and delegates to [`remove_member`](Self::remove_member).
+    ///
+    /// A missing MLS leaf is a NO-OP, not an error: it returns an empty commit
+    /// (`Ok(Vec::new())`) and logs a warning to the browser console. This matches native
+    /// `MlsCryptoProvider::remove_member`, which returns
+    /// `RemoveMemberOutput::default()` (empty commit) for a member with no MLS
+    /// leaf. The governance/`WasmContextManager` layer is authoritative for
+    /// membership; the crypto layer only manages MLS group state. A member who
+    /// is in the context's membership set but was never MLS-added (or is the
+    /// local member under a different DID in a multi-identity environment) is
+    /// removed from membership by the dispatch layer regardless, and there is
+    /// no MLS key schedule to advance. The eviction security property — a
+    /// removed member can no longer derive the group key — rests on the MLS
+    /// epoch advance, which only exists when the member actually held a leaf.
     ///
     /// # Errors
     ///
     /// Returns [`WasmCryptoError::GroupDestroyed`] if the group has been
-    /// destroyed, or [`WasmCryptoError::RemoveMemberFailed`] if no MLS leaf
-    /// carries `member_did` or the underlying remove fails.
+    /// destroyed, or [`WasmCryptoError::RemoveMemberFailed`] if a leaf IS found
+    /// but the underlying remove/commit serialization fails. Those are genuine
+    /// MLS failures and must propagate so the dispatch layer can fail closed
+    /// (keep the member rather than report a removal that did not cut the key).
     pub fn remove_member_by_did(&mut self, member_did: &str) -> Result<Vec<u8>, WasmCryptoError> {
-        let leaf_index = self.leaf_index_for_did(member_did)?.ok_or_else(|| {
-            WasmCryptoError::RemoveMemberFailed(format!("no MLS leaf for DID '{member_did}'"))
-        })?;
+        // `leaf_index_for_did` propagates `GroupDestroyed` (group is None) as a
+        // genuine error; `Ok(None)` means the DID has no MLS leaf.
+        let Some(leaf_index) = self.leaf_index_for_did(member_did)? else {
+            // Diagnostic only — the no-op behaviour (empty commit) is the
+            // contract. `web_sys::console` is unavailable on non-wasm32 test
+            // targets, so gate the log to the browser build.
+            #[cfg(target_arch = "wasm32")]
+            web_sys::console::warn_1(
+                &format!(
+                    "[SCP] remove_member_by_did: member DID '{member_did}' not found in MLS \
+                     group leaf nodes — member may not have been MLS-added"
+                )
+                .into(),
+            );
+            return Ok(Vec::new());
+        };
         self.remove_member(&leaf_index)
     }
 
@@ -563,19 +587,48 @@ mod tests {
 
     #[test]
     #[allow(clippy::unwrap_used, clippy::expect_used)]
-    fn remove_member_by_did_errors_for_non_member() {
+    fn remove_member_by_did_is_noop_for_non_member() {
         let alice_cred = test_credential("alice");
         let mut alice_group = WasmMlsGroup::create_group(&alice_cred).unwrap();
 
-        // No member with this DID exists — governance would never reach here in
-        // production (it verifies membership first), so an MLS miss is a real
-        // divergence and must surface as an error, not a silent no-op.
-        let err = alice_group
+        let epoch_before = alice_group.epoch().unwrap();
+
+        // No member with this DID has an MLS leaf. This matches native
+        // `MlsCryptoProvider::remove_member`: a missing leaf is a NO-OP that
+        // returns an empty commit (the governance layer is authoritative for
+        // membership; the crypto layer only manages MLS state). It must NOT
+        // error and must NOT advance the epoch.
+        let commit = alice_group
             .remove_member_by_did("did:dht:z6MkGhostMember")
-            .expect_err("removing a non-member by DID must error");
+            .expect("missing-leaf removal must be a no-op, not an error");
         assert!(
-            matches!(err, WasmCryptoError::RemoveMemberFailed(_)),
-            "missing-leaf removal must be a RemoveMemberFailed error, got {err:?}"
+            commit.is_empty(),
+            "a missing-leaf removal must produce an empty commit (no-op)"
+        );
+        assert_eq!(
+            alice_group.epoch().unwrap(),
+            epoch_before,
+            "a missing-leaf removal must NOT advance the MLS epoch"
+        );
+    }
+
+    #[test]
+    #[allow(clippy::unwrap_used, clippy::expect_used)]
+    fn remove_member_by_did_errors_on_destroyed_group() {
+        let alice_cred = test_credential("alice");
+        let mut alice_group = WasmMlsGroup::create_group(&alice_cred).unwrap();
+
+        // A destroyed group (group is None) is a genuine MLS failure:
+        // `leaf_index_for_did` returns `GroupDestroyed`, which must propagate as
+        // an error so the dispatch layer fails closed (keeps the member) rather
+        // than reporting a removal that never cut the key.
+        alice_group.destroy();
+        let err = alice_group
+            .remove_member_by_did("did:dht:z6MkAnyone")
+            .expect_err("removal against a destroyed group must error");
+        assert!(
+            matches!(err, WasmCryptoError::GroupDestroyed),
+            "destroyed-group removal must be GroupDestroyed, got {err:?}"
         );
     }
 

--- a/crates/scp-ffi/wasm/src/crypto/group.rs
+++ b/crates/scp-ffi/wasm/src/crypto/group.rs
@@ -176,6 +176,61 @@ impl WasmMlsGroup {
             .map_err(|e| WasmCryptoError::RemoveMemberFailed(format!("serializing commit: {e}")))
     }
 
+    /// Resolves the [`LeafNodeIndex`] of the group member whose SCP credential
+    /// carries `member_did`.
+    ///
+    /// Scans every current group member, decodes each member's
+    /// [`BasicCredential`] into a [`WasmScpCredential`], and returns the leaf
+    /// index of the first member whose `did` matches. Returns `Ok(None)` when
+    /// no current member carries that DID.
+    ///
+    /// Mirrors native `find_leaf_index_by_did`
+    /// (`scp_runtime::crypto::mls::wrapping_extension`): MLS does not key its
+    /// tree by DID, so removal-by-DID must map the SCP identity to its leaf
+    /// before calling [`remove_member`](Self::remove_member).
+    ///
+    /// # Errors
+    ///
+    /// Returns [`WasmCryptoError::GroupDestroyed`] if the group has been
+    /// destroyed.
+    pub fn leaf_index_for_did(
+        &self,
+        member_did: &str,
+    ) -> Result<Option<LeafNodeIndex>, WasmCryptoError> {
+        let g = self.group.as_ref().ok_or(WasmCryptoError::GroupDestroyed)?;
+        for member in g.members() {
+            if let Ok(basic) = BasicCredential::try_from(member.credential.clone())
+                && let Ok(scp_cred) = WasmScpCredential::from_bytes(basic.identity())
+                && scp_cred.did == member_did
+            {
+                return Ok(Some(member.index));
+            }
+        }
+        Ok(None)
+    }
+
+    /// Removes the group member identified by `member_did`, returning the
+    /// TLS-serialized commit that evicts them from the MLS group.
+    ///
+    /// Resolves the DID to its leaf via [`leaf_index_for_did`](Self::leaf_index_for_did)
+    /// and delegates to [`remove_member`](Self::remove_member). The governance
+    /// layer has ALREADY verified the member is in the context before calling
+    /// this, so a missing MLS leaf is a real native↔WASM state divergence — it
+    /// fails loudly rather than silently skipping the cryptographic eviction
+    /// (the removed member would otherwise keep the group key schedule).
+    ///
+    /// # Errors
+    ///
+    /// Returns [`WasmCryptoError::GroupDestroyed`] if the group has been
+    /// destroyed, or [`WasmCryptoError::RemoveMemberFailed`] if no MLS leaf
+    /// carries `member_did` or the underlying remove fails.
+    pub fn remove_member_by_did(&mut self, member_did: &str) -> Result<Vec<u8>, WasmCryptoError> {
+        let leaf_index = self.leaf_index_for_did(member_did)?.ok_or_else(|| {
+            WasmCryptoError::RemoveMemberFailed(format!("no MLS leaf for DID '{member_did}'"))
+        })?;
+        self.remove_member(&leaf_index)
+    }
+
     /// Joins a group from a Welcome message.
     ///
     /// The `welcome_bytes` must be TLS-serialized `MlsMessageOut` bytes
@@ -449,6 +504,79 @@ mod tests {
 
         assert_eq!(alice_group.epoch().unwrap(), 1);
         assert_eq!(bob_group.epoch().unwrap(), 1);
+    }
+
+    #[test]
+    #[allow(clippy::unwrap_used, clippy::expect_used)]
+    fn leaf_index_for_did_resolves_added_member_and_remove_by_did_evicts() {
+        let alice_cred = test_credential("alice");
+        let mut alice_group = WasmMlsGroup::create_group(&alice_cred).unwrap();
+
+        let bob_cred = test_credential("bob");
+        let (bob_kp_bytes, _bob_holder) = WasmMlsGroup::generate_key_package(&bob_cred).unwrap();
+        let bob_kp_in = KeyPackageIn::tls_deserialize(&mut &*bob_kp_bytes).unwrap();
+        alice_group.add_member(bob_kp_in).unwrap();
+
+        // Bob's DID resolves to a real leaf index (the second leaf — Alice is
+        // the creator at leaf 0).
+        let bob_index = alice_group
+            .leaf_index_for_did(&bob_cred.did)
+            .unwrap()
+            .expect("Bob's DID must resolve to an MLS leaf after add");
+        let alice_index = alice_group
+            .leaf_index_for_did(&alice_cred.did)
+            .unwrap()
+            .expect("Alice's DID must resolve to her own leaf");
+        assert_ne!(
+            bob_index, alice_index,
+            "Alice and Bob must occupy distinct leaves"
+        );
+
+        // A DID that is not a member resolves to None (not an error).
+        assert!(
+            alice_group
+                .leaf_index_for_did("did:dht:z6MkNotAMember")
+                .unwrap()
+                .is_none(),
+            "a non-member DID must resolve to None"
+        );
+
+        // remove_member_by_did evicts Bob and advances the epoch.
+        let epoch_before = alice_group.epoch().unwrap();
+        let commit = alice_group.remove_member_by_did(&bob_cred.did).unwrap();
+        assert!(!commit.is_empty(), "eviction must produce a commit");
+        assert_eq!(
+            alice_group.epoch().unwrap(),
+            epoch_before + 1,
+            "removing a member must advance the MLS epoch"
+        );
+
+        // Bob is no longer resolvable after eviction.
+        assert!(
+            alice_group
+                .leaf_index_for_did(&bob_cred.did)
+                .unwrap()
+                .is_none(),
+            "the evicted member's DID must no longer resolve to a leaf"
+        );
+    }
+
+    #[test]
+    #[allow(clippy::unwrap_used, clippy::expect_used)]
+    fn remove_member_by_did_errors_for_non_member() {
+        let alice_cred = test_credential("alice");
+        let mut alice_group = WasmMlsGroup::create_group(&alice_cred).unwrap();
+
+        // No member with this DID exists — governance would never reach here in
+        // production (it verifies membership first), so an MLS miss is a real
+        // divergence and must surface as an error, not a silent no-op.
+        let err = alice_group
+            .remove_member_by_did("did:dht:z6MkGhostMember")
+            .expect_err("removing a non-member by DID must error");
+        assert!(
+            matches!(err, WasmCryptoError::RemoveMemberFailed(_)),
+            "missing-leaf removal must be a RemoveMemberFailed error, got {err:?}"
+        );
     }
 
     // NOTE: OpenMLS cannot decrypt your own messages. A two-party setup is

--- a/crates/scp-ffi/wasm/src/crypto/state.rs
+++ b/crates/scp-ffi/wasm/src/crypto/state.rs
@@ -131,12 +131,18 @@ impl WasmCryptoState {
     /// `MlsCrypto::remove_member` (called FIRST in
     /// `scp_runtime::context::governance_helpers::execute_remove_member`).
     ///
+    /// A member who is in the context's membership set but carries no MLS leaf
+    /// (e.g. never MLS-added) is a NO-OP that returns an empty commit — matching
+    /// native `MlsCryptoProvider::remove_member`, because the governance layer
+    /// is authoritative for membership and the crypto layer only manages MLS
+    /// state. See
+    /// [`WasmMlsGroup::remove_member_by_did`](super::group::WasmMlsGroup::remove_member_by_did).
+    ///
     /// # Errors
     ///
-    /// Returns an error if the group is destroyed or no MLS leaf carries the
-    /// given DID (governance verifies membership before calling, so a miss is a
-    /// real state divergence — see
-    /// [`WasmMlsGroup::remove_member_by_did`](super::group::WasmMlsGroup::remove_member_by_did)).
+    /// Returns an error if the group is destroyed, or if a leaf IS found but the
+    /// underlying remove/commit serialization fails — genuine MLS failures that
+    /// must propagate so the dispatch layer can fail closed (keep the member).
     pub fn governance_remove_from_group(
         &mut self,
         member_did: &str,

--- a/crates/scp-ffi/wasm/src/crypto/state.rs
+++ b/crates/scp-ffi/wasm/src/crypto/state.rs
@@ -135,7 +135,13 @@ impl WasmCryptoState {
     /// (e.g. never MLS-added) is a NO-OP that returns an empty commit — matching
     /// native `MlsCryptoProvider::remove_member`, because the governance layer
     /// is authoritative for membership and the crypto layer only manages MLS
-    /// state. See
+    /// state.
+    ///
+    /// Self-removal is likewise an empty-commit no-op, matching BOTH of native's
+    /// self-removal mechanisms: the self-DID short-circuit (provider.rs:1041)
+    /// and the own-leaf skip in the scan (provider.rs:1060). This holds even in
+    /// a pathological duplicate-DID tree — a second leaf carrying the local DID
+    /// is NOT evicted, mirroring native. See
     /// [`WasmMlsGroup::remove_member_by_did`](super::group::WasmMlsGroup::remove_member_by_did).
     ///
     /// # Errors
@@ -422,6 +428,41 @@ mod tests {
                 .unwrap(),
             post_plaintext,
             "a remaining member MUST still be able to decrypt after the eviction"
+        );
+    }
+
+    /// Governance-layer parity for native's self-DID short-circuit
+    /// (provider.rs:1041) in a pathological duplicate-DID tree. A second leaf
+    /// carries Alice's OWN DID; `governance_remove_from_group(own_did)` must be
+    /// an empty-commit no-op that does NOT evict the duplicate leaf and does NOT
+    /// advance the epoch — matching native, which evicts neither leaf.
+    #[test]
+    #[allow(clippy::unwrap_used, clippy::expect_used)]
+    fn governance_remove_self_did_no_op_in_dup_did_tree() {
+        let mut alice_state = WasmCryptoState::new_for_context(ALICE_DID).unwrap();
+
+        // Add a second leaf carrying Alice's SAME DID but a fresh signing key.
+        let dup_cred =
+            WasmScpCredential::new(ALICE_DID.to_string(), None, WasmSigningKeyId::Active).unwrap();
+        let (dup_kp_bytes, _dup_holder) = WasmMlsGroup::generate_key_package(&dup_cred).unwrap();
+        let dup_kp_in = KeyPackageIn::tls_deserialize(&mut &*dup_kp_bytes).unwrap();
+        alice_state.mls_group.add_member(dup_kp_in).unwrap();
+
+        let epoch_after_add = alice_state.mls_group.epoch().unwrap();
+
+        // Self-removal via the governance entry point is an empty no-op.
+        let commit = alice_state
+            .governance_remove_from_group(ALICE_DID)
+            .expect("self-DID governance removal in a dup-DID tree must be a no-op");
+        assert!(
+            commit.is_empty(),
+            "self-DID governance removal must produce an empty commit"
+        );
+        assert_eq!(
+            alice_state.mls_group.epoch().unwrap(),
+            epoch_after_add,
+            "self-DID governance removal must NOT advance the epoch (duplicate \
+             leaf NOT evicted, matching native's short-circuit)"
         );
     }
 

--- a/crates/scp-ffi/wasm/src/crypto/state.rs
+++ b/crates/scp-ffi/wasm/src/crypto/state.rs
@@ -160,11 +160,19 @@ impl WasmCryptoState {
     /// Mirrors native `MlsCrypto::rotate_sender_key` (spec §9.16.4): after a
     /// member is removed, the remaining members rotate their sender keys so the
     /// evicted member's knowledge of any prior sender key grants no future
-    /// plaintext. The freshly rotated key is lazily redistributed to current
-    /// members on the next send (the `local_sender_key` ships with the next
-    /// `encrypt_message`), so there is no separate sender-key delivery step on
-    /// WASM — the HPKE pending-redistribution queue native maintains is a
-    /// genuine no-op here, not a stub.
+    /// sender-layer plaintext. That is this rotation's entire security purpose —
+    /// denying the evicted member the sender layer.
+    ///
+    /// NOTE: this rotation does NOT, by itself, distribute the new key. WASM
+    /// `encrypt_message` emits only the double-ciphertext and never attaches
+    /// `local_sender_key`, so there is no cross-member sender-key distribution
+    /// path on this bridge for encrypted (non-broadcast) MLS contexts — that is
+    /// a pre-existing gap, separate from eviction. The operative lockout for the
+    /// evicted member is the MLS layer-2 eviction (epoch advance): once the
+    /// removal commit lands, the removed member can no longer derive the group
+    /// keys, so MLS decryption of any later message fails regardless of
+    /// sender-key state. The eviction security property therefore holds
+    /// independently of whether the rotated sender key is ever redistributed.
     pub fn governance_rotate_sender_key(&mut self) {
         // Eagerly zeroize the old key in place before overwriting, rather than
         // relying solely on the drop of the replaced value.
@@ -365,8 +373,11 @@ mod tests {
         // epoch's secrets. We leave Bob's stale state as-is (the realistic
         // adversary: he keeps his pre-eviction keys and tries to decrypt).
 
-        // Carol receives Alice's rotated sender key (lazy redistribution: in
-        // production it ships with the next send; here we hand it over).
+        // Carol receives Alice's rotated sender key. WASM has no cross-member
+        // sender-key distribution path for encrypted MLS contexts (a pre-existing
+        // gap), so the test hands the key over directly to isolate and prove the
+        // MLS-eviction security property: it must hold even when the rotated
+        // sender key IS available to a remaining member.
         carol_state.sender_key_store.insert(
             ALICE_DID.to_string(),
             SenderKey::from_bytes(*alice_state.local_sender_key.as_bytes()),

--- a/crates/scp-ffi/wasm/src/crypto/state.rs
+++ b/crates/scp-ffi/wasm/src/crypto/state.rs
@@ -122,6 +122,56 @@ impl WasmCryptoState {
         )?)
     }
 
+    /// Evicts a member from the MLS group by their DID.
+    ///
+    /// Returns the TLS-serialized commit that removes the member from the group
+    /// key schedule. This is the hard security boundary of governance member
+    /// removal: after this commit is processed, the evicted member can no longer
+    /// derive the group's encryption keys. Mirrors native
+    /// `MlsCrypto::remove_member` (called FIRST in
+    /// `scp_runtime::context::governance_helpers::execute_remove_member`).
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the group is destroyed or no MLS leaf carries the
+    /// given DID (governance verifies membership before calling, so a miss is a
+    /// real state divergence — see
+    /// [`WasmMlsGroup::remove_member_by_did`](super::group::WasmMlsGroup::remove_member_by_did)).
+    pub fn governance_remove_from_group(
+        &mut self,
+        member_did: &str,
+    ) -> Result<Vec<u8>, WasmCryptoError> {
+        self.mls_group.remove_member_by_did(member_did)
+    }
+
+    /// Drops the evicted member's stored sender key, zeroizing it if present.
+    ///
+    /// Mirrors native `MlsCrypto::remove_member_sender_key`: after a member is
+    /// removed, their sender key is no longer needed and is wiped from memory.
+    /// `SenderKey` is `ZeroizeOnDrop`, so removing it from the store zeroizes
+    /// the key material as it drops. A no-op if the member had no stored key.
+    pub fn governance_remove_sender_key(&mut self, member_did: &str) {
+        // The removed value is zeroized when it drops (SenderKey: ZeroizeOnDrop).
+        drop(self.sender_key_store.remove(member_did));
+    }
+
+    /// Rotates this participant's local sender key, zeroizing the old key.
+    ///
+    /// Mirrors native `MlsCrypto::rotate_sender_key` (spec §9.16.4): after a
+    /// member is removed, the remaining members rotate their sender keys so the
+    /// evicted member's knowledge of any prior sender key grants no future
+    /// plaintext. The freshly rotated key is lazily redistributed to current
+    /// members on the next send (the `local_sender_key` ships with the next
+    /// `encrypt_message`), so there is no separate sender-key delivery step on
+    /// WASM — the HPKE pending-redistribution queue native maintains is a
+    /// genuine no-op here, not a stub.
+    pub fn governance_rotate_sender_key(&mut self) {
+        // Eagerly zeroize the old key in place before overwriting, rather than
+        // relying solely on the drop of the replaced value.
+        self.local_sender_key.zeroize();
+        self.local_sender_key = generate_sender_key();
+    }
+
     /// Destroys all crypto state (MLS group + sender keys).
     ///
     /// Eagerly zeroizes the local sender key rather than waiting for
@@ -205,6 +255,157 @@ mod tests {
             .unwrap();
 
         assert_eq!(decrypted, plaintext);
+    }
+
+    const CAROL_DID: &str = "did:dht:z6MkCarol";
+
+    /// Security proof for governance member eviction: after Alice evicts Bob
+    /// from the MLS group and rotates her sender key, Bob's stale crypto state
+    /// can NO LONGER decrypt Alice's subsequent messages, while a still-present
+    /// member (Carol) can. This is the cross-cutting guarantee the WASM
+    /// `dispatch_remove_member` fix restores — previously WASM removed a member
+    /// from governance state but did zero MLS work, leaving the evicted member
+    /// able to decrypt.
+    ///
+    /// Three members are required because `OpenMLS` cannot decrypt its own
+    /// messages: Alice (creator) needs Carol to verify her own sends still work
+    /// for current members after the eviction.
+    #[test]
+    #[allow(clippy::unwrap_used)]
+    fn evicted_member_cannot_decrypt_after_removal_and_rotation() {
+        // Alice creates the context.
+        let mut alice_state = WasmCryptoState::new_for_context(ALICE_DID).unwrap();
+
+        // Alice adds Bob.
+        let bob_cred =
+            WasmScpCredential::new(BOB_DID.to_string(), None, WasmSigningKeyId::Active).unwrap();
+        let (bob_kp_bytes, bob_holder) = WasmMlsGroup::generate_key_package(&bob_cred).unwrap();
+        let bob_kp_in = KeyPackageIn::tls_deserialize(&mut &*bob_kp_bytes).unwrap();
+        let (_commit_bob, welcome_bob) = alice_state.mls_group.add_member(bob_kp_in).unwrap();
+        let bob_mls_group = WasmMlsGroup::join_from_welcome(&welcome_bob, bob_holder).unwrap();
+        let mut bob_state = WasmCryptoState {
+            mls_group: bob_mls_group,
+            local_sender_key: generate_sender_key(),
+            sender_key_store: HashMap::new(),
+        };
+
+        // Alice adds Carol. Bob must process Alice's add-Carol commit so his MLS
+        // group stays in lockstep with the group epoch up to the eviction.
+        let carol_cred =
+            WasmScpCredential::new(CAROL_DID.to_string(), None, WasmSigningKeyId::Active).unwrap();
+        let (carol_kp_bytes, carol_holder) =
+            WasmMlsGroup::generate_key_package(&carol_cred).unwrap();
+        let carol_kp_in = KeyPackageIn::tls_deserialize(&mut &*carol_kp_bytes).unwrap();
+        let (commit_carol, welcome_carol) = alice_state.mls_group.add_member(carol_kp_in).unwrap();
+        // Bob applies the add-Carol commit (a non-application message: it merges
+        // the staged commit and returns NotApplicationMessage).
+        assert!(
+            bob_state.mls_group.decrypt(&commit_carol).is_err(),
+            "processing a commit returns NotApplicationMessage, not plaintext"
+        );
+        let carol_mls_group =
+            WasmMlsGroup::join_from_welcome(&welcome_carol, carol_holder).unwrap();
+        let mut carol_state = WasmCryptoState {
+            mls_group: carol_mls_group,
+            local_sender_key: generate_sender_key(),
+            sender_key_store: HashMap::new(),
+        };
+
+        // Sender-key exchange: every member learns Alice's current sender key so
+        // they can decrypt her sends (the sender-key layer under MLS).
+        bob_state.sender_key_store.insert(
+            ALICE_DID.to_string(),
+            SenderKey::from_bytes(*alice_state.local_sender_key.as_bytes()),
+        );
+        carol_state.sender_key_store.insert(
+            ALICE_DID.to_string(),
+            SenderKey::from_bytes(*alice_state.local_sender_key.as_bytes()),
+        );
+
+        // Sanity: before eviction, both Bob and Carol can decrypt Alice's send.
+        let epoch_pre = alice_state.mls_group.epoch().unwrap();
+        let pre_plaintext = b"before eviction";
+        let pre_ct = alice_state
+            .encrypt_message(pre_plaintext, CTX_ID, ALICE_DID, epoch_pre, 0)
+            .unwrap();
+        // Bob and Carol each decrypt their own copy. Decryption mutates MLS
+        // state, so encrypt twice (once per recipient) at the same epoch/seq.
+        let pre_ct_carol = alice_state
+            .encrypt_message(pre_plaintext, CTX_ID, ALICE_DID, epoch_pre, 1)
+            .unwrap();
+        assert_eq!(
+            bob_state
+                .decrypt_message(&pre_ct, CTX_ID, ALICE_DID, epoch_pre, 0)
+                .unwrap(),
+            pre_plaintext,
+            "Bob must be able to decrypt before he is evicted"
+        );
+        assert_eq!(
+            carol_state
+                .decrypt_message(&pre_ct_carol, CTX_ID, ALICE_DID, epoch_pre, 1)
+                .unwrap(),
+            pre_plaintext,
+            "Carol must be able to decrypt before the eviction"
+        );
+
+        // --- The governance eviction: remove Bob from the MLS group, drop his
+        // sender key, and rotate Alice's sender key (mirrors native
+        // execute_remove_member ordering). ---
+        let evict_commit = alice_state.governance_remove_from_group(BOB_DID).unwrap();
+        alice_state.governance_remove_sender_key(BOB_DID);
+        alice_state.governance_rotate_sender_key();
+
+        // Carol applies the eviction commit so her MLS epoch tracks Alice's.
+        assert!(
+            carol_state.mls_group.decrypt(&evict_commit).is_err(),
+            "the eviction commit is a non-application message for Carol"
+        );
+        // Bob, were he honest, would also process the commit — but a removed
+        // member's processing of his own removal does not grant him the new
+        // epoch's secrets. We leave Bob's stale state as-is (the realistic
+        // adversary: he keeps his pre-eviction keys and tries to decrypt).
+
+        // Carol receives Alice's rotated sender key (lazy redistribution: in
+        // production it ships with the next send; here we hand it over).
+        carol_state.sender_key_store.insert(
+            ALICE_DID.to_string(),
+            SenderKey::from_bytes(*alice_state.local_sender_key.as_bytes()),
+        );
+
+        // Alice sends after the eviction at the new epoch.
+        let epoch_post = alice_state.mls_group.epoch().unwrap();
+        assert_eq!(
+            epoch_post,
+            epoch_pre + 1,
+            "the eviction commit must advance the MLS epoch"
+        );
+        let post_plaintext = b"after eviction - bob must not read this";
+        let post_ct = alice_state
+            .encrypt_message(post_plaintext, CTX_ID, ALICE_DID, epoch_post, 0)
+            .unwrap();
+
+        // SECURITY ASSERTION: Bob's stale state cannot decrypt — his MLS group
+        // is stuck at the old epoch and AEAD decryption fails on the new-epoch
+        // ciphertext.
+        assert!(
+            bob_state
+                .decrypt_message(&post_ct, CTX_ID, ALICE_DID, epoch_post, 0)
+                .is_err(),
+            "an evicted member MUST NOT be able to decrypt messages sent after \
+             his removal — this is the security boundary the MLS eviction restores"
+        );
+
+        // LIVENESS ASSERTION: Carol, still a member, decrypts Alice's send.
+        let post_ct_carol = alice_state
+            .encrypt_message(post_plaintext, CTX_ID, ALICE_DID, epoch_post, 1)
+            .unwrap();
+        assert_eq!(
+            carol_state
+                .decrypt_message(&post_ct_carol, CTX_ID, ALICE_DID, epoch_post, 1)
+                .unwrap(),
+            post_plaintext,
+            "a remaining member MUST still be able to decrypt after the eviction"
+        );
     }
 
     #[test]

--- a/crates/scp-ffi/wasm/src/manager.rs
+++ b/crates/scp-ffi/wasm/src/manager.rs
@@ -3158,7 +3158,17 @@ impl WasmContextManager {
         let (proposal_created_at, action) = proposal_created_at;
         let action = &action;
 
-        let result = self.dispatch_governance_action(context_id, action);
+        // `proposal_created_at` is the convergent committer-assigned leaf
+        // timestamp (the executed proposal's signed `created_at`). It is threaded
+        // into dispatch so the `RemoveMember` arm can append its OWN durable
+        // `MemberLeft` leaf with the SAME convergent timestamp the
+        // `GovernanceActionExecuted` leaf below uses — mirroring native's
+        // per-action `execute_remove_member`, which appends `MemberLeft` BEFORE
+        // `finalize_governance_action` appends `GovernanceActionExecuted`. Using
+        // `crate::time::now_secs()` here would diverge across members and break
+        // the §9.9.3 equal-count/equal-root equivocation invariant.
+        let result =
+            self.dispatch_governance_action(context_id, action, executor_did, proposal_created_at);
 
         // Roll back on failure.
         if result.is_err()
@@ -3265,6 +3275,15 @@ impl WasmContextManager {
         &mut self,
         context_id: &str,
         action: &GovernanceAction,
+        // The committing member (executor) — stamped as the convergence-critical
+        // `actor_did` on any per-action durable leaf this dispatch appends (e.g.
+        // the `MemberLeft` leaf for `RemoveMember`), byte-identical to native
+        // (§9.9.3; ADR-031 §8 "executor DID").
+        executor_did: &str,
+        // The convergent committer-assigned leaf timestamp (the executed
+        // proposal's signed `created_at`), used for any per-action durable leaf
+        // this dispatch appends — NEVER local `now()`.
+        timestamp_secs: u64,
     ) -> Result<serde_json::Value, ScpWasmError> {
         // Per-action CONTEXT-CEILING gate, identical to native's per-action
         // `ceiling.contains(&Capability::X)` gates in `dispatch_governance_action`
@@ -3290,7 +3309,7 @@ impl WasmContextManager {
                 self.dispatch_add_member(context_id, did, role)
             }
             GovernanceAction::RemoveMember { did, .. } => {
-                self.dispatch_remove_member(context_id, did)
+                self.dispatch_remove_member(context_id, did, executor_did, timestamp_secs)
             }
             GovernanceAction::ChangeRole { did, new_role } => {
                 let ctx = self.require_active_context_mut(context_id)?;
@@ -3432,6 +3451,8 @@ impl WasmContextManager {
         &mut self,
         context_id: &str,
         did: &str,
+        executor_did: &str,
+        timestamp_secs: u64,
     ) -> Result<serde_json::Value, ScpWasmError> {
         let ctx = self.require_active_context_mut(context_id)?;
         let removed = ctx
@@ -3448,10 +3469,56 @@ impl WasmContextManager {
         {
             let _ = bc.block_author(did);
         }
+
+        // MLS eviction is the HARD security boundary (mirrors native
+        // `execute_remove_member`, which removes from the MLS group FIRST). On
+        // an encrypted context: evict the member from the MLS group, drop their
+        // stored sender key, then rotate the local sender key so the removed
+        // member's knowledge of any prior sender key grants no future plaintext
+        // (§9.16.4). On a broadcast / unencrypted context (`crypto.is_none()`)
+        // there is no MLS group — the commit is empty, matching native's
+        // non-MLS no-op. The rotated `local_sender_key` is lazily redistributed
+        // on the next send, so there is no separate sender-key delivery step on
+        // WASM (the HPKE pending-redistribution queue native maintains is a
+        // genuine no-op here, not a stub).
+        let commit = if let Some(crypto) = ctx.crypto.as_mut() {
+            let commit =
+                crypto
+                    .governance_remove_from_group(did)
+                    .map_err(|e| ScpWasmError::Crypto {
+                        message: e.to_string(),
+                        code: codes::CRYPTO_4011.to_owned(),
+                    })?;
+            crypto.governance_remove_sender_key(did);
+            crypto.governance_rotate_sender_key();
+            commit
+        } else {
+            Vec::new()
+        };
+
+        // Buffer event for local subscribers (mirrors native's `emit`).
         ctx.push_event(ContextEvent::MemberLeft {
             member_did: DID(did.to_owned()),
         });
-        Ok(serde_json::json!({"action": "RemoveMember", "did": did}))
+
+        // Durable `MemberLeft` leaf — appended BEFORE the wrapper's
+        // `GovernanceActionExecuted` leaf, matching native's ordering
+        // (`execute_remove_member` appends `MemberLeft` inside the commit closure;
+        // `finalize_governance_action` appends `GovernanceActionExecuted` after).
+        // The leaf carries the convergent committer-assigned `executor_did` +
+        // `timestamp_secs` and an EMPTY payload, byte-identical to native's
+        // `append_context_event(EventType::MemberLeft, actor_did, timestamp_secs)`
+        // (which uses `EventPayload::default()`). The target DID lives in the
+        // buffer event only, never in the durable leaf (§9.9.3).
+        ctx.append_log_event(EventType::MemberLeft, executor_did, b"", timestamp_secs);
+
+        // Return the eviction commit (hex) so the relay can distribute it to the
+        // remaining members; empty for non-MLS contexts.
+        Ok(serde_json::json!({
+            "action": "RemoveMember",
+            "did": did,
+            "commit": crate::runtime::encode_hex(&commit),
+        }))
     }
 
     /// Handles governance actions that don't fit in the primary dispatch.
@@ -9369,6 +9436,118 @@ mod tests {
         assert!(
             format!("{err:?}").contains("already been executed"),
             "replay rejection should name the executed proposal, got: {err:?}"
+        );
+    }
+
+    /// WASM half of the split cross-impl KAT for governance `RemoveMember`
+    /// (the native half is `cross_impl_remove_member_leaf_is_empty_and_precedes_executed`
+    /// in `crates/scp-runtime/tests/wasm_conformance.rs`). Drives the REAL
+    /// `execute_governance_action` path for a `RemoveMember` proposal and pins,
+    /// from the durable log:
+    /// - the `MemberLeft` leaf payload is EMPTY (the removed DID is buffer-only),
+    /// - its `actor_did` is the EXECUTOR (not the removed member),
+    /// - its `timestamp` is the convergent `proposal.created_at` (not local
+    ///   `now()`),
+    /// - it is appended BEFORE the `GovernanceActionExecuted` leaf.
+    ///
+    /// These are byte-for-byte the invariants native's `execute_remove_member` /
+    /// `finalize_governance_action` produce; a regression in any of them would
+    /// diverge the cross-platform `tree::root` and false-positive §9.9.3
+    /// equivocation.
+    #[test]
+    fn remove_member_appends_empty_member_left_leaf_before_executed_wasm() {
+        use scp_event_log::EventType;
+        use scp_protocol::context::governance::{
+            GovernanceAction, GovernanceProposal, ProposalStatus, SignedVote, VoteType,
+        };
+
+        let context_id = "ctx-wasm-remove";
+        let proposer = "did:dht:z6MkWasmRemoveProposer";
+        let removed = "did:dht:z6MkWasmRemoveTarget";
+        let proposal_id = "beadfeed000000000000000000000000000000000000000000000000000000ff";
+        let created_at = 1_700_600_700_u64;
+
+        let mut ctx = make_bare_per_context_state(context_id, proposer);
+        ctx.test_insert_member(removed, "member");
+        // RemoveMember is NOT ceiling-gated at dispatch (authorization is at
+        // propose time) — see `dispatch_ceiling_capability`, so no ceiling seed
+        // is required here.
+
+        let action = GovernanceAction::RemoveMember {
+            did: DID::from(removed.to_owned()),
+            reason: None,
+        };
+        let proposal = GovernanceProposal {
+            proposal_id: {
+                let bytes = hex::decode(proposal_id).unwrap();
+                let mut arr = [0u8; 32];
+                arr[..bytes.len().min(32)].copy_from_slice(&bytes[..bytes.len().min(32)]);
+                arr
+            },
+            context_id: context_id.to_owned(),
+            proposer_did: DID::from(proposer.to_owned()),
+            action,
+            status: ProposalStatus::Approved,
+            created_at,
+            voting_deadline: created_at + 3600,
+            approvals: vec![SignedVote {
+                voter_did: DID::from(proposer.to_owned()),
+                vote: VoteType::Approve,
+                timestamp: created_at,
+                signature: Vec::new(),
+            }],
+            rejections: Vec::new(),
+            created_at_epoch: None,
+        };
+        ctx.test_insert_resolved_proposal(proposal_id.to_owned(), proposal);
+
+        let mut mgr = WasmContextManager::new();
+        mgr.test_insert_context(context_id, ctx);
+
+        let resolved_proposer = mgr
+            .proposal_proposer_did(context_id, proposal_id)
+            .expect("proposer resolvable");
+        mgr.execute_governance_action(context_id, proposer, &resolved_proposer, proposal_id)
+            .expect("approved RemoveMember proposal must execute");
+
+        let events = mgr.test_context_event_log_events(context_id);
+
+        let member_left = events
+            .iter()
+            .find(|e| e.event_type == EventType::MemberLeft)
+            .expect("a durable MemberLeft leaf must be appended on RemoveMember");
+        assert!(
+            member_left.payload.data.is_empty(),
+            "the MemberLeft leaf payload must be empty (the removed DID is buffer-only)"
+        );
+        assert_eq!(
+            member_left.actor_did.as_ref(),
+            resolved_proposer,
+            "the MemberLeft leaf actor_did must be the executor, not the removed member"
+        );
+        assert_ne!(
+            member_left.actor_did.as_ref(),
+            removed,
+            "the MemberLeft leaf must NOT be stamped with the removed member's DID"
+        );
+        assert_eq!(
+            member_left.timestamp, created_at,
+            "the MemberLeft leaf timestamp must be the convergent proposal.created_at, \
+             never local now()"
+        );
+
+        let member_left_pos = events
+            .iter()
+            .position(|e| e.event_type == EventType::MemberLeft)
+            .expect("MemberLeft present");
+        let executed_pos = events
+            .iter()
+            .position(|e| e.event_type == EventType::GovernanceActionExecuted)
+            .expect("GovernanceActionExecuted present");
+        assert!(
+            member_left_pos < executed_pos,
+            "the MemberLeft leaf must precede the GovernanceActionExecuted leaf, \
+             matching native execute_remove_member ordering"
         );
     }
 }

--- a/crates/scp-ffi/wasm/src/manager.rs
+++ b/crates/scp-ffi/wasm/src/manager.rs
@@ -3476,13 +3476,21 @@ impl WasmContextManager {
         // crypto cuts succeed). On an encrypted context: evict the member from
         // the MLS group, drop their stored sender key, then rotate the local
         // sender key so the removed member's knowledge of any prior sender key
-        // grants no future plaintext (§9.16.4). On a broadcast / unencrypted
-        // context (`crypto.is_none()`) there is no MLS group — the commit is
-        // empty, matching native's non-MLS no-op.
+        // grants no future plaintext (§9.16.4). When there is no MLS
+        // state (`crypto.is_none()` — a broadcast / unencrypted context, or one
+        // whose crypto was destroyed by a prior self-leave) there is no MLS
+        // group, so the commit is empty, matching native's non-MLS no-op.
         //
-        // Fail-closed: if ANY of these crypto steps errors (a destroyed group,
-        // or a governance member with no MLS leaf), this returns `Err` while the
-        // member is STILL fully present in `ctx.members` and broadcast state.
+        // A governance member with NO MLS leaf is NOT a failure: it is a no-op
+        // returning an empty commit (matching native `MlsCryptoProvider::
+        // remove_member`), so dispatch PROCEEDS to strip membership + append the
+        // `MemberLeft` leaf. The governance layer is authoritative for
+        // membership; the crypto layer only manages MLS state.
+        //
+        // Fail-closed: if ANY of these crypto steps errors with a GENUINE MLS
+        // failure (a destroyed group, or a commit-serialization failure on a
+        // leaf that WAS found), this returns `Err` while the member is STILL
+        // fully present in `ctx.members` and broadcast state.
         // The removal is therefore atomic at the security boundary — there is no
         // window where the member is gone from governance yet still able to
         // derive the group keys. The caller's only rollback
@@ -3523,6 +3531,19 @@ impl WasmContextManager {
         // safe to strip governance and broadcast state. Capture the role before
         // removing so broadcast-author cleanup can still see it.
         let removed_role = ctx.members.remove(did).map(|m| m.role);
+
+        // Drop all per-DID state the removed member left behind, mirroring
+        // native `execute_remove_member`'s role_state / access cleanup (which
+        // strips `role_state.members`, `assignments`, `member_capabilities`, the
+        // access key store entry, and the pseudonym routing entry). WASM models
+        // the per-member authorization state as `suspended_capabilities` (a
+        // demotion record keyed by DID) and the CEK-exclusion state as
+        // `read_exclusion_list`. Leaving either behind is a stale-desync
+        // foothold: a DID later re-admitted under the same string would inherit
+        // a phantom suspension or read-exclusion. Both are no-ops if absent.
+        ctx.suspended_capabilities.remove(did);
+        ctx.read_exclusion_list.remove(did);
+
         // If the ejected member was an author in a broadcast context, clean up
         // their broadcast state (destroys broadcast key).
         if removed_role.as_deref() == Some("author")
@@ -9571,6 +9592,27 @@ mod tests {
              never local now()"
         );
 
+        // Exactly ONE MemberLeft and exactly ONE GovernanceActionExecuted leaf.
+        // Locking the equal-count invariant guards against a duplicate append
+        // (which `find`/`position` below would silently tolerate) diverging the
+        // cross-platform `tree::root`.
+        let member_left_count = events
+            .iter()
+            .filter(|e| e.event_type == EventType::MemberLeft)
+            .count();
+        assert_eq!(
+            member_left_count, 1,
+            "RemoveMember must append EXACTLY one MemberLeft leaf, got {member_left_count}"
+        );
+        let executed_count = events
+            .iter()
+            .filter(|e| e.event_type == EventType::GovernanceActionExecuted)
+            .count();
+        assert_eq!(
+            executed_count, 1,
+            "RemoveMember must append EXACTLY one GovernanceActionExecuted leaf, got {executed_count}"
+        );
+
         let member_left_pos = events
             .iter()
             .position(|e| e.event_type == EventType::MemberLeft)
@@ -9586,37 +9628,124 @@ mod tests {
         );
     }
 
-    /// Fail-closed-keep proof for `dispatch_remove_member`: when MLS eviction
-    /// FAILS, the member MUST remain fully present in `ctx.members` (and the log
-    /// must NOT gain a `MemberLeft` leaf), so no window opens where the member is
-    /// gone from governance yet can still derive the group keys.
+    /// Native parity: a governance member who carries NO MLS leaf is removed
+    /// CLEANLY (not kept). This matches native `MlsCryptoProvider::remove_member`,
+    /// which treats a missing leaf as a no-op (empty commit), so
+    /// `execute_remove_member` PROCEEDS to strip membership and append the
+    /// `MemberLeft` leaf — the governance layer is authoritative for membership.
     ///
-    /// The failure is forced deterministically through the REAL crypto path: the
-    /// context's MLS group has only the creator's leaf, so a governance member
-    /// who carries no MLS leaf triggers `governance_remove_from_group` ->
-    /// `remove_member_by_did` -> `RemoveMemberFailed`. With the fail-closed-keep
-    /// ordering, the early `Err` leaves governance state untouched; with the old
-    /// strip-first ordering the member would already be gone — the exact
-    /// decryption-after-removal hole the MLS eviction fix closes.
+    /// The context's MLS group has only the creator's leaf, so the governance
+    /// member `removed` has no MLS leaf. `dispatch_remove_member` must return Ok
+    /// with an EMPTY commit, the member must be gone from `ctx.members`, and a
+    /// durable `MemberLeft` leaf must be appended.
+    #[test]
+    fn remove_member_with_no_mls_leaf_is_removed_cleanly() {
+        use scp_event_log::EventType;
+
+        let context_id = "ctx-wasm-remove-noleaf";
+        let creator = "did:dht:z6MkWasmNoLeafCreator";
+        // A governance member with NO MLS leaf: present in `ctx.members` but
+        // never added to the single-creator MLS group below.
+        let removed = "did:dht:z6MkWasmNoLeafTarget";
+        let executor = creator;
+        let timestamp_secs = 1_700_700_700_u64;
+
+        let mut ctx = make_bare_per_context_state(context_id, creator);
+        ctx.crypto = Some(
+            crate::crypto::WasmCryptoState::new_for_context(creator)
+                .expect("MLS group creation must succeed for the test fixture"),
+        );
+        ctx.test_insert_member(removed, "member");
+        // Seed per-DID state to prove the F5 cleanup runs on this path too.
+        ctx.suspended_capabilities_insert(removed, "messages:write".to_owned());
+        ctx.read_exclusion_list.insert(removed.to_owned());
+        assert!(
+            ctx.members.contains_key(removed),
+            "precondition: the target must be a governance member before removal"
+        );
+
+        let mut mgr = WasmContextManager::new();
+        mgr.test_insert_context(context_id, ctx);
+
+        let result = mgr
+            .dispatch_remove_member(context_id, removed, executor, timestamp_secs)
+            .expect("a governance member with no MLS leaf must be removed cleanly (native parity)");
+
+        // The MLS layer produced no commit (no leaf to evict) — empty hex.
+        assert_eq!(
+            result["commit"].as_str(),
+            Some(""),
+            "a member with no MLS leaf yields an empty commit (no-op eviction)"
+        );
+
+        let ctx_after = mgr
+            .contexts
+            .get(context_id)
+            .expect("context must still be registered after removal");
+        assert!(
+            !ctx_after.members.contains_key(removed),
+            "the governance member must be removed from ctx.members (native parity)"
+        );
+        // F5: per-DID state must be cleaned up.
+        assert!(
+            ctx_after.test_suspended_capabilities(removed).is_none(),
+            "the removed member's suspended_capabilities entry must be cleaned up"
+        );
+        assert!(
+            !ctx_after.read_exclusion_list.contains(removed),
+            "the removed member's read_exclusion_list entry must be cleaned up"
+        );
+
+        // A durable MemberLeft leaf must be appended.
+        let events = mgr.test_context_event_log_events(context_id);
+        let member_left = events
+            .iter()
+            .find(|e| e.event_type == EventType::MemberLeft)
+            .expect("a MemberLeft leaf must be appended when a no-leaf member is removed");
+        assert!(
+            member_left.payload.data.is_empty(),
+            "the MemberLeft leaf payload must be empty (the removed DID is buffer-only)"
+        );
+        assert_eq!(
+            member_left.actor_did.as_ref(),
+            executor,
+            "the MemberLeft leaf actor_did must be the executor"
+        );
+        assert_eq!(
+            member_left.timestamp, timestamp_secs,
+            "the MemberLeft leaf timestamp must be the committer-assigned timestamp"
+        );
+    }
+
+    /// Fail-closed-keep proof for `dispatch_remove_member`: when MLS eviction
+    /// fails with a GENUINE MLS error, the member MUST remain fully present in
+    /// `ctx.members` (and the log must NOT gain a `MemberLeft` leaf), so no
+    /// window opens where the member is gone from governance yet can still
+    /// derive the group keys.
+    ///
+    /// The genuine error is forced by DESTROYING the MLS group (group is None):
+    /// `governance_remove_from_group` -> `remove_member_by_did` ->
+    /// `leaf_index_for_did` -> `GroupDestroyed`. (A missing leaf is NOT a
+    /// genuine error after the native-parity fix — it is a no-op — so a real
+    /// fail-closed case requires a real MLS failure.) With the fail-closed-keep
+    /// ordering, the early `Err` leaves governance state untouched.
     #[test]
     fn remove_member_keeps_governance_state_when_mls_eviction_fails() {
         use scp_event_log::EventType;
 
         let context_id = "ctx-wasm-remove-failclosed";
         let creator = "did:dht:z6MkWasmFailClosedCreator";
-        // A governance member with NO MLS leaf: present in `ctx.members` but
-        // never added to the single-creator MLS group below.
         let removed = "did:dht:z6MkWasmFailClosedTarget";
         let executor = creator;
         let timestamp_secs = 1_700_700_700_u64;
 
         let mut ctx = make_bare_per_context_state(context_id, creator);
-        // Real MLS crypto with the creator as the sole leaf. `removed` is in
-        // governance but absent from the MLS group, so eviction must fail.
-        ctx.crypto = Some(
-            crate::crypto::WasmCryptoState::new_for_context(creator)
-                .expect("MLS group creation must succeed for the test fixture"),
-        );
+        let mut crypto = crate::crypto::WasmCryptoState::new_for_context(creator)
+            .expect("MLS group creation must succeed for the test fixture");
+        // Destroy the MLS group so any eviction attempt hits GroupDestroyed — a
+        // genuine MLS failure (not a missing-leaf no-op).
+        crypto.mls_group.destroy();
+        ctx.crypto = Some(crypto);
         ctx.test_insert_member(removed, "member");
         assert!(
             ctx.members.contains_key(removed),
@@ -9628,9 +9757,9 @@ mod tests {
 
         let result = mgr.dispatch_remove_member(context_id, removed, executor, timestamp_secs);
 
-        // The MLS eviction failed, so the handler must return Err...
+        // The MLS eviction failed with a genuine error, so the handler must Err...
         let err = result.expect_err(
-            "dispatch_remove_member must fail when MLS eviction of a non-leaf member fails",
+            "dispatch_remove_member must fail when MLS eviction hits a genuine MLS error",
         );
         assert!(
             matches!(err, ScpWasmError::Crypto { .. }),
@@ -9660,6 +9789,152 @@ mod tests {
         assert!(
             !events.iter().any(|e| e.event_type == EventType::MemberLeft),
             "no MemberLeft leaf may be appended when MLS eviction fails"
+        );
+    }
+
+    /// F6: encrypted-path commit hex round-trips. With a REAL second MLS member,
+    /// `dispatch_remove_member` must return a non-empty hex `commit` that
+    /// `hex::decode`s to the eviction commit bytes — the relay-distribution
+    /// surface the JS caller is obligated to broadcast.
+    #[test]
+    #[allow(clippy::unwrap_used, clippy::expect_used)]
+    fn remove_member_encrypted_path_returns_decodable_commit_hex() {
+        use openmls::prelude::KeyPackageIn;
+        use tls_codec::Deserialize as _;
+
+        let context_id = "ctx-wasm-remove-commit";
+        let creator = "did:dht:z6MkWasmCommitCreator";
+        // The second member's DID — must match the credential embedded in the
+        // MLS leaf so `leaf_index_for_did` resolves it.
+        let bob_did = "did:dht:z6MkWasmCommitBob";
+        let executor = creator;
+        let timestamp_secs = 1_700_800_800_u64;
+
+        let mut ctx = make_bare_per_context_state(context_id, creator);
+        let mut crypto = crate::crypto::WasmCryptoState::new_for_context(creator)
+            .expect("MLS group creation must succeed");
+
+        // Add Bob as a REAL MLS leaf via the standard key-package + add flow.
+        let bob_cred = crate::crypto::WasmScpCredential::new(
+            bob_did.to_owned(),
+            None,
+            crate::crypto::WasmSigningKeyId::Active,
+        )
+        .unwrap();
+        let (bob_kp_bytes, _bob_holder) =
+            crate::crypto::WasmMlsGroup::generate_key_package(&bob_cred).unwrap();
+        let bob_kp_in =
+            KeyPackageIn::tls_deserialize(&mut &*bob_kp_bytes).expect("key package deserializes");
+        crypto.mls_group.add_member(bob_kp_in).unwrap();
+
+        ctx.crypto = Some(crypto);
+        ctx.test_insert_member(bob_did, "member");
+
+        let mut mgr = WasmContextManager::new();
+        mgr.test_insert_context(context_id, ctx);
+
+        let result = mgr
+            .dispatch_remove_member(context_id, bob_did, executor, timestamp_secs)
+            .expect("removing a real MLS member must succeed");
+
+        let commit_hex = result["commit"]
+            .as_str()
+            .expect("the result JSON must carry a string commit field");
+        assert!(
+            !commit_hex.is_empty(),
+            "evicting a real MLS member must produce a non-empty commit"
+        );
+        let commit_bytes = hex::decode(commit_hex)
+            .expect("the commit field must be valid hex of the commit bytes");
+        assert!(
+            !commit_bytes.is_empty(),
+            "the decoded commit must be non-empty MLS commit bytes"
+        );
+
+        // The member is gone and Bob no longer resolves to a leaf.
+        let ctx_after = mgr
+            .contexts
+            .get(context_id)
+            .expect("context still registered");
+        assert!(
+            !ctx_after.members.contains_key(bob_did),
+            "the evicted member must be removed from ctx.members"
+        );
+        assert!(
+            ctx_after
+                .crypto
+                .as_ref()
+                .unwrap()
+                .mls_group
+                .leaf_index_for_did(bob_did)
+                .unwrap()
+                .is_none(),
+            "the evicted member's DID must no longer resolve to an MLS leaf"
+        );
+    }
+
+    /// F7: broadcast / `crypto.is_none()` path. A broadcast-author context with
+    /// an "author" member and no MLS crypto: `dispatch_remove_member` must run
+    /// the `block_author` cleanup, return an EMPTY commit, and still append a
+    /// `MemberLeft` leaf.
+    #[test]
+    #[allow(clippy::unwrap_used, clippy::expect_used)]
+    fn remove_member_broadcast_path_empty_commit_still_appends_leaf() {
+        use scp_event_log::EventType;
+
+        let context_id = "ctx-wasm-remove-broadcast";
+        let creator = "did:dht:z6MkWasmBroadcastCreator";
+        let author = "did:dht:z6MkWasmBroadcastAuthor";
+        let executor = creator;
+        let timestamp_secs = 1_700_900_900_u64;
+
+        let mut ctx = make_bare_per_context_state(context_id, creator);
+        // Broadcast context: a BroadcastContext is present, crypto is None.
+        ctx.broadcast_context = Some(make_broadcast(&[author], &[]));
+        ctx.crypto = None;
+        ctx.test_insert_member(author, "author");
+        assert!(
+            ctx.broadcast_context.as_ref().unwrap().is_author(author),
+            "precondition: the author must hold a broadcast key before removal"
+        );
+
+        let mut mgr = WasmContextManager::new();
+        mgr.test_insert_context(context_id, ctx);
+
+        let result = mgr
+            .dispatch_remove_member(context_id, author, executor, timestamp_secs)
+            .expect("removing an author from a broadcast context must succeed");
+
+        // (b) empty commit — no MLS group on a broadcast context.
+        assert_eq!(
+            result["commit"].as_str(),
+            Some(""),
+            "a broadcast (crypto.is_none) context produces an empty commit"
+        );
+
+        let ctx_after = mgr
+            .contexts
+            .get(context_id)
+            .expect("context still registered");
+        assert!(
+            !ctx_after.members.contains_key(author),
+            "the author must be removed from ctx.members"
+        );
+        // (a) block_author cleanup ran — the author's broadcast key is destroyed.
+        assert!(
+            !ctx_after
+                .broadcast_context
+                .as_ref()
+                .unwrap()
+                .is_author(author),
+            "block_author cleanup must run: the removed author must no longer hold a broadcast key"
+        );
+
+        // (c) a MemberLeft leaf is still appended.
+        let events = mgr.test_context_event_log_events(context_id);
+        assert!(
+            events.iter().any(|e| e.event_type == EventType::MemberLeft),
+            "a MemberLeft leaf must be appended even on the broadcast/empty-commit path"
         );
     }
 }

--- a/crates/scp-ffi/wasm/src/manager.rs
+++ b/crates/scp-ffi/wasm/src/manager.rs
@@ -9873,6 +9873,93 @@ mod tests {
         );
     }
 
+    /// Self-removal parity: a governance `RemoveMember` that targets the
+    /// local/creator DID on a REAL encrypted context must behave like native's
+    /// self-removal — an EMPTY commit (the own MLS leaf is skipped, so eviction
+    /// is a no-op) while dispatch STILL PROCEEDS to strip the member from
+    /// `ctx.members`, clean F5 per-DID state, and append a `MemberLeft` leaf.
+    ///
+    /// This is the divergence regression guard: before the own-leaf skip,
+    /// `leaf_index_for_did` resolved the creator's own leaf, `OpenMLS` rejected
+    /// `remove_member(own_index)` with `CannotRemoveSelf`, dispatch failed
+    /// closed, and the member was KEPT with NO `MemberLeft` leaf — diverging
+    /// from native (which removes the member + appends the leaf), breaking the
+    /// §9.9.3 cross-platform `tree::root` + membership convergence invariant.
+    #[test]
+    #[allow(clippy::unwrap_used, clippy::expect_used)]
+    fn remove_member_self_did_encrypted_empty_commit_strips_and_appends_leaf() {
+        use scp_event_log::EventType;
+
+        let context_id = "ctx-wasm-remove-self";
+        // The creator IS the local MLS member (leaf 0) and the removal target.
+        let creator = "did:dht:z6MkWasmSelfRemovalCreator";
+        let executor = creator;
+        let timestamp_secs = 1_701_000_000_u64;
+
+        let mut ctx = make_bare_per_context_state(context_id, creator);
+        let crypto = crate::crypto::WasmCryptoState::new_for_context(creator)
+            .expect("MLS group creation must succeed");
+        ctx.crypto = Some(crypto);
+        // Seed F5 per-DID state for the creator so we can prove it is cleaned up.
+        ctx.test_insert_suspended_capability(creator, "tool:invoke:calculator");
+        assert!(
+            ctx.test_suspended_capabilities(creator).is_some(),
+            "precondition: the creator must hold a suspended-capabilities entry"
+        );
+
+        let mut mgr = WasmContextManager::new();
+        mgr.test_insert_context(context_id, ctx);
+
+        let result = mgr
+            .dispatch_remove_member(context_id, creator, executor, timestamp_secs)
+            .expect("self-removal on an encrypted context must succeed (empty-commit no-op)");
+
+        // EMPTY commit — the own MLS leaf is skipped, so eviction is a no-op
+        // (matching native's self-removal short-circuit).
+        assert_eq!(
+            result["commit"].as_str(),
+            Some(""),
+            "self-removal must produce an EMPTY commit (own leaf skipped — no eviction)"
+        );
+
+        let ctx_after = mgr
+            .contexts
+            .get(context_id)
+            .expect("context still registered");
+
+        // Member removed from ctx.members despite the empty commit.
+        assert!(
+            !ctx_after.members.contains_key(creator),
+            "self-removal must strip the member from ctx.members even though the commit is empty"
+        );
+
+        // F5 per-DID state cleaned.
+        assert!(
+            ctx_after.test_suspended_capabilities(creator).is_none(),
+            "self-removal must clean the removed member's suspended_capabilities entry"
+        );
+
+        // A durable MemberLeft leaf must be appended (native parity).
+        let events = mgr.test_context_event_log_events(context_id);
+        let member_left = events
+            .iter()
+            .find(|e| e.event_type == EventType::MemberLeft)
+            .expect("a MemberLeft leaf must be appended on self-removal (native parity)");
+        assert!(
+            member_left.payload.data.is_empty(),
+            "the MemberLeft leaf payload must be empty (the removed DID is buffer-only)"
+        );
+        assert_eq!(
+            member_left.actor_did.as_ref(),
+            executor,
+            "the MemberLeft leaf actor_did must be the executor (the self-removing member)"
+        );
+        assert_eq!(
+            member_left.timestamp, timestamp_secs,
+            "the MemberLeft leaf timestamp must be the committer-assigned timestamp"
+        );
+    }
+
     /// F7: broadcast / `crypto.is_none()` path. A broadcast-author context with
     /// an "author" member and no MLS crypto: `dispatch_remove_member` must run
     /// the `block_author` cleanup, return an EMPTY commit, and still append a

--- a/crates/scp-ffi/wasm/src/manager.rs
+++ b/crates/scp-ffi/wasm/src/manager.rs
@@ -3498,17 +3498,13 @@ impl WasmContextManager {
         // strip must not happen until eviction has actually succeeded; a retry
         // after a transient failure is safe.
         //
-        // The rotated `local_sender_key` denies the EVICTED member any future
-        // sender-layer plaintext, but the operative lockout for the evicted
-        // member is the MLS layer-2 eviction (epoch advance) itself: once the
-        // commit lands, the removed member can no longer derive the group keys,
-        // so MLS decryption of any later message fails regardless of sender-key
-        // state. WASM has no sender-key cross-member distribution path for
-        // encrypted (non-broadcast) MLS contexts — the rotated key is NOT
-        // attached to subsequent sends (`encrypt_message` emits only the
-        // double-ciphertext). That distribution gap is pre-existing and
-        // orthogonal to eviction; the eviction security property holds without
-        // it because the MLS epoch advance is the lockout.
+        // The operative lockout for the evicted member is the MLS layer-2
+        // eviction (epoch advance) itself: once the commit lands, the removed
+        // member can no longer derive the group keys, so MLS decryption of any
+        // later message fails. The sender-key rotation's role, and why WASM's
+        // missing cross-member sender-key distribution path is orthogonal to the
+        // eviction security property, are explained in full at
+        // `WasmCryptoState::governance_rotate_sender_key` (crypto/state.rs).
         //
         // Scope the `ctx.crypto.as_mut()` borrow tightly so the later
         // `ctx.members` / `ctx.broadcast_context` mutations can re-borrow `ctx`.

--- a/crates/scp-ffi/wasm/src/manager.rs
+++ b/crates/scp-ffi/wasm/src/manager.rs
@@ -3455,32 +3455,55 @@ impl WasmContextManager {
         timestamp_secs: u64,
     ) -> Result<serde_json::Value, ScpWasmError> {
         let ctx = self.require_active_context_mut(context_id)?;
-        let removed = ctx
-            .members
-            .remove(did)
-            .ok_or_else(|| ScpWasmError::Context {
+
+        // Existence check WITHOUT removing — the governance strip is deferred
+        // until AFTER the MLS eviction succeeds (fail-closed-keep ordering;
+        // mirrors native `execute_remove_member`, which checks
+        // `membership.contains(did)` before the MLS boundary and only strips
+        // membership once the crypto cuts have all succeeded). Preserves the
+        // exact `CTX_2015` not-found semantics.
+        if !ctx.members.contains_key(did) {
+            return Err(ScpWasmError::Context {
                 message: format!("member '{did}' not found"),
                 code: codes::CTX_2015.to_owned(),
-            })?;
-        // If the ejected member was an author in a broadcast context,
-        // clean up their broadcast state (destroys broadcast key).
-        if removed.role == "author"
-            && let Some(ref mut bc) = ctx.broadcast_context
-        {
-            let _ = bc.block_author(did);
+            });
         }
 
-        // MLS eviction is the HARD security boundary (mirrors native
-        // `execute_remove_member`, which removes from the MLS group FIRST). On
-        // an encrypted context: evict the member from the MLS group, drop their
-        // stored sender key, then rotate the local sender key so the removed
-        // member's knowledge of any prior sender key grants no future plaintext
-        // (§9.16.4). On a broadcast / unencrypted context (`crypto.is_none()`)
-        // there is no MLS group — the commit is empty, matching native's
-        // non-MLS no-op. The rotated `local_sender_key` is lazily redistributed
-        // on the next send, so there is no separate sender-key delivery step on
-        // WASM (the HPKE pending-redistribution queue native maintains is a
-        // genuine no-op here, not a stub).
+        // MLS eviction is the HARD security boundary and MUST run FIRST, BEFORE
+        // any governance/broadcast state is stripped (mirrors native
+        // `execute_remove_member`, which removes from the MLS group first and
+        // strips membership only inside the fail-closed-keep closure after the
+        // crypto cuts succeed). On an encrypted context: evict the member from
+        // the MLS group, drop their stored sender key, then rotate the local
+        // sender key so the removed member's knowledge of any prior sender key
+        // grants no future plaintext (§9.16.4). On a broadcast / unencrypted
+        // context (`crypto.is_none()`) there is no MLS group — the commit is
+        // empty, matching native's non-MLS no-op.
+        //
+        // Fail-closed: if ANY of these crypto steps errors (a destroyed group,
+        // or a governance member with no MLS leaf), this returns `Err` while the
+        // member is STILL fully present in `ctx.members` and broadcast state.
+        // The removal is therefore atomic at the security boundary — there is no
+        // window where the member is gone from governance yet still able to
+        // derive the group keys. The caller's only rollback
+        // (`execute_governance_action`) does not restore `ctx.members`, so the
+        // strip must not happen until eviction has actually succeeded; a retry
+        // after a transient failure is safe.
+        //
+        // The rotated `local_sender_key` denies the EVICTED member any future
+        // sender-layer plaintext, but the operative lockout for the evicted
+        // member is the MLS layer-2 eviction (epoch advance) itself: once the
+        // commit lands, the removed member can no longer derive the group keys,
+        // so MLS decryption of any later message fails regardless of sender-key
+        // state. WASM has no sender-key cross-member distribution path for
+        // encrypted (non-broadcast) MLS contexts — the rotated key is NOT
+        // attached to subsequent sends (`encrypt_message` emits only the
+        // double-ciphertext). That distribution gap is pre-existing and
+        // orthogonal to eviction; the eviction security property holds without
+        // it because the MLS epoch advance is the lockout.
+        //
+        // Scope the `ctx.crypto.as_mut()` borrow tightly so the later
+        // `ctx.members` / `ctx.broadcast_context` mutations can re-borrow `ctx`.
         let commit = if let Some(crypto) = ctx.crypto.as_mut() {
             let commit =
                 crypto
@@ -3495,6 +3518,18 @@ impl WasmContextManager {
         } else {
             Vec::new()
         };
+
+        // MLS eviction succeeded (or there was no MLS group) — only NOW is it
+        // safe to strip governance and broadcast state. Capture the role before
+        // removing so broadcast-author cleanup can still see it.
+        let removed_role = ctx.members.remove(did).map(|m| m.role);
+        // If the ejected member was an author in a broadcast context, clean up
+        // their broadcast state (destroys broadcast key).
+        if removed_role.as_deref() == Some("author")
+            && let Some(ref mut bc) = ctx.broadcast_context
+        {
+            let _ = bc.block_author(did);
+        }
 
         // Buffer event for local subscribers (mirrors native's `emit`).
         ctx.push_event(ContextEvent::MemberLeft {
@@ -9548,6 +9583,83 @@ mod tests {
             member_left_pos < executed_pos,
             "the MemberLeft leaf must precede the GovernanceActionExecuted leaf, \
              matching native execute_remove_member ordering"
+        );
+    }
+
+    /// Fail-closed-keep proof for `dispatch_remove_member`: when MLS eviction
+    /// FAILS, the member MUST remain fully present in `ctx.members` (and the log
+    /// must NOT gain a `MemberLeft` leaf), so no window opens where the member is
+    /// gone from governance yet can still derive the group keys.
+    ///
+    /// The failure is forced deterministically through the REAL crypto path: the
+    /// context's MLS group has only the creator's leaf, so a governance member
+    /// who carries no MLS leaf triggers `governance_remove_from_group` ->
+    /// `remove_member_by_did` -> `RemoveMemberFailed`. With the fail-closed-keep
+    /// ordering, the early `Err` leaves governance state untouched; with the old
+    /// strip-first ordering the member would already be gone — the exact
+    /// decryption-after-removal hole the MLS eviction fix closes.
+    #[test]
+    fn remove_member_keeps_governance_state_when_mls_eviction_fails() {
+        use scp_event_log::EventType;
+
+        let context_id = "ctx-wasm-remove-failclosed";
+        let creator = "did:dht:z6MkWasmFailClosedCreator";
+        // A governance member with NO MLS leaf: present in `ctx.members` but
+        // never added to the single-creator MLS group below.
+        let removed = "did:dht:z6MkWasmFailClosedTarget";
+        let executor = creator;
+        let timestamp_secs = 1_700_700_700_u64;
+
+        let mut ctx = make_bare_per_context_state(context_id, creator);
+        // Real MLS crypto with the creator as the sole leaf. `removed` is in
+        // governance but absent from the MLS group, so eviction must fail.
+        ctx.crypto = Some(
+            crate::crypto::WasmCryptoState::new_for_context(creator)
+                .expect("MLS group creation must succeed for the test fixture"),
+        );
+        ctx.test_insert_member(removed, "member");
+        assert!(
+            ctx.members.contains_key(removed),
+            "precondition: the target must be a governance member before removal"
+        );
+
+        let mut mgr = WasmContextManager::new();
+        mgr.test_insert_context(context_id, ctx);
+
+        let result = mgr.dispatch_remove_member(context_id, removed, executor, timestamp_secs);
+
+        // The MLS eviction failed, so the handler must return Err...
+        let err = result.expect_err(
+            "dispatch_remove_member must fail when MLS eviction of a non-leaf member fails",
+        );
+        assert!(
+            matches!(err, ScpWasmError::Crypto { .. }),
+            "the failure must surface as a crypto eviction error, got {err:?}"
+        );
+
+        // ...and CRITICALLY the member must STILL be in governance state
+        // (fail-closed-keep). A retry is safe; no decryption-after-removal hole.
+        let ctx_after = mgr
+            .contexts
+            .get(context_id)
+            .expect("context must still be registered after a failed removal");
+        assert!(
+            ctx_after.members.contains_key(removed),
+            "FAIL-CLOSED: a member whose MLS eviction failed MUST remain in \
+             ctx.members — removing them from governance while they stay in the \
+             MLS group reopens the decryption-after-removal hole"
+        );
+        assert_eq!(
+            ctx_after.test_member_role(removed),
+            Some("member"),
+            "the kept member's role must be unchanged after the failed removal"
+        );
+
+        // No durable MemberLeft leaf may be emitted on a failed removal.
+        let events = mgr.test_context_event_log_events(context_id);
+        assert!(
+            !events.iter().any(|e| e.event_type == EventType::MemberLeft),
+            "no MemberLeft leaf may be appended when MLS eviction fails"
         );
     }
 }

--- a/crates/scp-runtime/tests/wasm_conformance.rs
+++ b/crates/scp-runtime/tests/wasm_conformance.rs
@@ -2382,6 +2382,110 @@ fn cross_impl_governance_proposal_vote_leaf_is_empty() {
     }
 }
 
+/// The durable `MemberLeft` leaf a governance `RemoveMember` mints carries an
+/// EMPTY canonical payload, and is appended BEFORE the `GovernanceActionExecuted`
+/// leaf (§9.9.3).
+///
+/// Native `execute_remove_member` (`governance_helpers.rs`) appends `MemberLeft`
+/// via `append_context_event` (`EventPayload::default()`, `data: []`) stamped
+/// with the COMMITTING member (`CommitMeta.actor_did` = executor) and the
+/// convergent `timestamp_secs` — NOT the removed member's DID, which lives only
+/// in the buffer-only `ContextEvent`. `finalize_governance_action` then appends
+/// `GovernanceActionExecuted` AFTER, so the durable order is `MemberLeft` then
+/// `GovernanceActionExecuted`.
+///
+/// The WASM bridge (`crates/scp-ffi/wasm/src/manager.rs`,
+/// `dispatch_remove_member` + the `execute_governance_action` wrapper) mirrors
+/// this exactly: it appends an empty-payload `MemberLeft` leaf with the executor
+/// DID + the convergent `proposal_created_at` inside dispatch, then the wrapper
+/// appends `GovernanceActionExecuted`. A WASM regression that stamped the target
+/// DID into the leaf, used a non-empty payload, used local `now()`, or reversed
+/// the order would diverge the cross-platform `tree::root` and false-positive
+/// §9.9.3 equivocation. This test drives native's REAL durable appends in the
+/// `execute_remove_member` order and pins both the empty `MemberLeft` payload and
+/// the `MemberLeft`-before-`GovernanceActionExecuted` ordering. (The scp-runtime
+/// test crate cannot dev-depend on the `scp-ffi-wasm` cdylib, so the WASM side
+/// asserts the same empty-payload + ordering invariants in its own crate's
+/// `dispatch_remove_member` tests.)
+#[test]
+fn cross_impl_remove_member_leaf_is_empty_and_precedes_executed() {
+    use scp_event_log::EventPayload;
+    use scp_protocol::context::governance::GovernanceAction;
+    use scp_runtime::context::builder::ContextEventLogProvider;
+    use scp_runtime::context::providers::MerkleEventLogProvider;
+
+    let ctx: [u8; 32] = [0x6d; 32];
+    let executor_did = "did:dht:z6MkRemoveExecutor";
+    let removed_did = "did:dht:z6MkRemovedTarget";
+    let ts = 1_700_000_000_u64;
+
+    let log = MerkleEventLogProvider::new();
+    log.init_event_log(&ctx).unwrap();
+
+    // Drive native's REAL appends in `execute_remove_member` order:
+    // 1) the empty-payload `MemberLeft` leaf via `append_context_event`
+    //    (stamped with the EXECUTOR, not the removed member),
+    log.append_context_event(&ctx, EventType::MemberLeft, executor_did, ts)
+        .unwrap();
+    // 2) then the `GovernanceActionExecuted` leaf via the shared payload
+    //    producer (what `finalize_governance_action` appends afterwards).
+    let action = GovernanceAction::RemoveMember {
+        did: scp_identity::DID::from(removed_did.to_owned()),
+        reason: None,
+    };
+    let target_did = action
+        .target_did()
+        .map(|d| d.as_ref().to_owned())
+        .unwrap_or_default();
+    let action_type = action.variant_name().to_owned();
+    let executed_payload = gov_action_executed_payload_bytes(&target_did, &action_type);
+    log.append_context_event_with_payload(
+        &ctx,
+        EventType::GovernanceActionExecuted,
+        executor_did,
+        EventPayload {
+            data: executed_payload,
+        },
+        ts,
+    )
+    .unwrap();
+
+    let entries = log.event_log_entries(&ctx).unwrap().unwrap();
+
+    // The `MemberLeft` leaf carries an EMPTY payload.
+    let member_left = entries
+        .iter()
+        .find(|e| e.event_type == EventType::MemberLeft)
+        .expect("MemberLeft leaf must be present");
+    assert!(
+        member_left.payload.data.is_empty(),
+        "the durable MemberLeft canonical leaf payload MUST be empty (§9.9.3) — \
+         the removed member's DID is buffer-only, never part of the durable leaf"
+    );
+    assert_eq!(
+        member_left.actor_did.as_ref(),
+        executor_did,
+        "the MemberLeft leaf actor_did MUST be the committing member (executor), \
+         not the removed member — matching native CommitMeta.actor_did"
+    );
+
+    // Ordering: `MemberLeft` precedes `GovernanceActionExecuted`.
+    let member_left_pos = entries
+        .iter()
+        .position(|e| e.event_type == EventType::MemberLeft)
+        .expect("MemberLeft present");
+    let executed_pos = entries
+        .iter()
+        .position(|e| e.event_type == EventType::GovernanceActionExecuted)
+        .expect("GovernanceActionExecuted present");
+    assert!(
+        member_left_pos < executed_pos,
+        "the durable MemberLeft leaf MUST precede the GovernanceActionExecuted \
+         leaf, matching native execute_remove_member / finalize_governance_action \
+         ordering — WASM must append in the same order for cross-platform root parity"
+    );
+}
+
 /// Canonical `TokenRevoked` leaf payload — JSON `{token_cid, revoker_did,
 /// context_id}`. Produced by the SHARED
 /// `scp_protocol::crypto::ucan::revoke::token_revoked_payload` that BOTH the

--- a/crates/scp-runtime/tests/wasm_conformance.rs
+++ b/crates/scp-runtime/tests/wasm_conformance.rs
@@ -2401,12 +2401,15 @@ fn cross_impl_governance_proposal_vote_leaf_is_empty() {
 /// appends `GovernanceActionExecuted`. A WASM regression that stamped the target
 /// DID into the leaf, used a non-empty payload, used local `now()`, or reversed
 /// the order would diverge the cross-platform `tree::root` and false-positive
-/// §9.9.3 equivocation. This test drives native's REAL durable appends in the
-/// `execute_remove_member` order and pins both the empty `MemberLeft` payload and
-/// the `MemberLeft`-before-`GovernanceActionExecuted` ordering. (The scp-runtime
-/// test crate cannot dev-depend on the `scp-ffi-wasm` cdylib, so the WASM side
-/// asserts the same empty-payload + ordering invariants in its own crate's
-/// `dispatch_remove_member` tests.)
+/// §9.9.3 equivocation. This test REPLAYS the two appends that
+/// `execute_remove_member` performs, in that order (the empty `MemberLeft` leaf
+/// then `GovernanceActionExecuted`), and pins both the empty `MemberLeft` payload
+/// and the `MemberLeft`-before-`GovernanceActionExecuted` ordering. It does NOT
+/// invoke `execute_remove_member` itself: the scp-runtime test crate cannot
+/// dev-depend on the `scp-ffi-wasm` cdylib, and the helper lives behind the actor
+/// machinery — native's real-path ordering is covered by the native governance
+/// tests, while the WASM side asserts the same empty-payload + ordering
+/// invariants in its own crate's `dispatch_remove_member` tests.
 #[test]
 fn cross_impl_remove_member_leaf_is_empty_and_precedes_executed() {
     use scp_event_log::EventPayload;
@@ -2422,7 +2425,8 @@ fn cross_impl_remove_member_leaf_is_empty_and_precedes_executed() {
     let log = MerkleEventLogProvider::new();
     log.init_event_log(&ctx).unwrap();
 
-    // Drive native's REAL appends in `execute_remove_member` order:
+    // Replay the two appends `execute_remove_member` performs, in that order
+    // (this test does not invoke `execute_remove_member` itself):
     // 1) the empty-payload `MemberLeft` leaf via `append_context_event`
     //    (stamped with the EXECUTOR, not the removed member),
     log.append_context_event(&ctx, EventType::MemberLeft, executor_did, ts)

--- a/crates/scp-runtime/tests/wasm_conformance.rs
+++ b/crates/scp-runtime/tests/wasm_conformance.rs
@@ -2490,6 +2490,126 @@ fn cross_impl_remove_member_leaf_is_empty_and_precedes_executed() {
     );
 }
 
+/// SELF-REMOVAL parity: a governance `RemoveMember` that targets the local /
+/// committing member's OWN DID mints the SAME durable leaf shape as removing
+/// any other member — an empty `MemberLeft` leaf (stamped with the executor, who
+/// here equals the removed member) appended BEFORE `GovernanceActionExecuted`,
+/// exactly one of each.
+///
+/// Native self-removal (`MlsCryptoProvider::remove_member`, provider.rs:1041/1060)
+/// short-circuits the MLS eviction to an empty-commit no-op (own-index skip +
+/// self no-op) but still PROCEEDS through `execute_remove_member` to strip
+/// governance + append `MemberLeft`, then `finalize_governance_action` appends
+/// `GovernanceActionExecuted`. The WASM bridge mirrors this: with the own-leaf
+/// skip in `leaf_index_for_did`, an own-DID removal resolves to `None` →
+/// empty-commit no-op → `dispatch_remove_member` strips membership + appends the
+/// same two leaves (covered by the WASM crate's
+/// `remove_member_self_did_encrypted_empty_commit_strips_and_appends_leaf`
+/// dispatch test). A WASM regression that failed closed on self-removal would
+/// append ZERO leaves where native appends TWO, diverging the cross-platform
+/// `tree::root` and membership set. This test REPLAYS the native append sequence
+/// for the self-targeting case (`removed_did == executor_did`) and pins the
+/// empty-payload `MemberLeft`, the executor `actor_did`, the exactly-one-each
+/// leaf counts, and the `MemberLeft`-before-`GovernanceActionExecuted` ordering.
+#[test]
+fn cross_impl_self_removal_leaf_is_empty_and_precedes_executed() {
+    use scp_event_log::EventPayload;
+    use scp_protocol::context::governance::GovernanceAction;
+    use scp_runtime::context::builder::ContextEventLogProvider;
+    use scp_runtime::context::providers::MerkleEventLogProvider;
+
+    let ctx: [u8; 32] = [0x5e; 32];
+    // Self-removal: the executor IS the removed member (the creator removing
+    // themselves, or any self-targeting approved proposal).
+    let self_did = "did:dht:z6MkSelfRemovingMember";
+    let ts = 1_700_000_500_u64;
+
+    let log = MerkleEventLogProvider::new();
+    log.init_event_log(&ctx).unwrap();
+
+    // Replay the two appends native's self-removal performs, in order:
+    // 1) the empty-payload `MemberLeft` leaf, stamped with the EXECUTOR — which
+    //    for self-removal equals the removed member.
+    log.append_context_event(&ctx, EventType::MemberLeft, self_did, ts)
+        .unwrap();
+    // 2) then `GovernanceActionExecuted` via the shared payload producer.
+    let action = GovernanceAction::RemoveMember {
+        did: scp_identity::DID::from(self_did.to_owned()),
+        reason: None,
+    };
+    let target_did = action
+        .target_did()
+        .map(|d| d.as_ref().to_owned())
+        .unwrap_or_default();
+    let action_type = action.variant_name().to_owned();
+    let executed_payload = gov_action_executed_payload_bytes(&target_did, &action_type);
+    log.append_context_event_with_payload(
+        &ctx,
+        EventType::GovernanceActionExecuted,
+        self_did,
+        EventPayload {
+            data: executed_payload,
+        },
+        ts,
+    )
+    .unwrap();
+
+    let entries = log.event_log_entries(&ctx).unwrap().unwrap();
+
+    // The `MemberLeft` leaf carries an EMPTY payload and is stamped with the
+    // executor (== the self-removing member).
+    let member_left = entries
+        .iter()
+        .find(|e| e.event_type == EventType::MemberLeft)
+        .expect("MemberLeft leaf must be present on self-removal");
+    assert!(
+        member_left.payload.data.is_empty(),
+        "the self-removal MemberLeft canonical leaf payload MUST be empty (§9.9.3)"
+    );
+    assert_eq!(
+        member_left.actor_did.as_ref(),
+        self_did,
+        "the self-removal MemberLeft leaf actor_did MUST be the executor (the \
+         self-removing member)"
+    );
+
+    // Exactly ONE MemberLeft and exactly ONE GovernanceActionExecuted leaf —
+    // self-removal mints the SAME count as any other removal (not zero, which a
+    // fail-closed WASM regression would produce).
+    let member_left_count = entries
+        .iter()
+        .filter(|e| e.event_type == EventType::MemberLeft)
+        .count();
+    assert_eq!(
+        member_left_count, 1,
+        "self-removal must append EXACTLY one MemberLeft leaf, got {member_left_count}"
+    );
+    let executed_count = entries
+        .iter()
+        .filter(|e| e.event_type == EventType::GovernanceActionExecuted)
+        .count();
+    assert_eq!(
+        executed_count, 1,
+        "self-removal must append EXACTLY one GovernanceActionExecuted leaf, got {executed_count}"
+    );
+
+    // Ordering: `MemberLeft` precedes `GovernanceActionExecuted`.
+    let member_left_pos = entries
+        .iter()
+        .position(|e| e.event_type == EventType::MemberLeft)
+        .expect("MemberLeft present");
+    let executed_pos = entries
+        .iter()
+        .position(|e| e.event_type == EventType::GovernanceActionExecuted)
+        .expect("GovernanceActionExecuted present");
+    assert!(
+        member_left_pos < executed_pos,
+        "the self-removal MemberLeft leaf MUST precede the GovernanceActionExecuted \
+         leaf, matching native ordering — WASM must append in the same order for \
+         cross-platform root parity"
+    );
+}
+
 /// Canonical `TokenRevoked` leaf payload — JSON `{token_cid, revoker_did,
 /// context_id}`. Produced by the SHARED
 /// `scp_protocol::crypto::ucan::revoke::token_revoked_payload` that BOTH the


### PR DESCRIPTION
## Summary

Closes a live cross-bridge **security divergence**: the WASM governance `RemoveMember` handler removed a member from governance state but did **zero MLS work** — the removed member retained the MLS group key schedule and could keep decrypting context traffic. The native bridge (`execute_remove_member`) removes the member from the MLS group **first**, as a hard security boundary. `check-bridge-symmetry.sh` cannot detect this (both bridges export the symbol; only the behavior diverged).

This makes the WASM bridge mirror native byte-for-byte for `RemoveMember`.

## What changed

- **Cryptographic eviction** (`crypto/group.rs`, `crypto/state.rs`): `leaf_index_for_did` + `remove_member_by_did` scan the OpenMLS group, decode each leaf credential, and evict the matching leaf (epoch advance), mirroring native `MlsCryptoProvider::remove_member`. `governance_remove_from_group` / `governance_remove_sender_key` / `governance_rotate_sender_key` perform MLS eviction + sender-key cut + sender-key rotation (§9.16.4, zeroize + CSPRNG).
- **Fail-closed ordering** (`manager.rs` `dispatch_remove_member`): existence check → MLS eviction FIRST → strip governance/per-DID state (`suspended_capabilities`, `read_exclusion_list`) → durable `MemberLeft` leaf. A genuine MLS error keeps the member fully in governance (no decryption-after-removal window).
- **Missing-leaf no-op** matching native `#1294`: a governance member with no MLS leaf is removed cleanly (empty commit), not errored.
- **Self-removal parity**: own-leaf skip (`own_leaf_index`) + self-DID short-circuit (`own_did()`), mirroring native's two mechanisms (`provider.rs:1041`/`:1060`), including the duplicate-DID-leaf case — self-removal is an empty-commit no-op that strips + appends, byte-identical to native.
- **Durable `MemberLeft` Merkle leaf** (`scp_event_log`): empty payload, executor `actor_did`, convergent committer-assigned `proposal.created_at` timestamp (never local `now()`), appended before `GovernanceActionExecuted`. Restores cross-platform `tree::root` convergence (§9.9.3 / §7.3.1).
- **Eviction commit** returned (hex) to the JS caller for relay distribution. WASM has no internal transport (ADR-034), so — unlike the native bridge, which auto-broadcasts via `try_broadcast_commit_or_enqueue` — the WASM caller MUST relay the commit. Documented per-backend at all three layers (`context.rs`, `internal/wasm.ts`, `scp.ts`).

## Testing

- `cargo test -p scp-ffi-wasm --lib` — 379 pass, incl. a 3-party MLS proof that an evicted member cannot decrypt post-eviction while a remaining member can, fail-closed-keep on a genuine MLS error, missing-leaf clean removal, self-removal / dup-DID no-op, `own_did` derivation (creator + Welcome-joiner), and an encrypted-path commit-hex round-trip.
- `cargo test -p scp-runtime --test wasm_conformance --features testing` — 57 pass, incl. new cross-impl `MemberLeft` leaf-parity KATs (remove + self-removal).
- `cargo test -p scp-runtime --test governance_integration --features testing` — 58 pass.
- Full-workspace CI clippy (all features), wasm32 clippy, `cargo fmt --all --check`, bridge-symmetry (0 findings), error-codes, TS `bun run check` + `bun run lint` — all clean.

## Out of scope (pre-existing, tracked separately)

- WASM governance `AddMember` does no MLS work / appends no `MemberJoined` leaf — the AddMember sibling of this divergence (#206 / #1877).
- WASM has no commit-relay retry/auto-broadcast backstop — an ADR-034 consequence (WASM has no internal transport); liveness, not confidentiality. Belongs to the WASM-transport story.

## Review

Reviewed to **double-zero** (two consecutive fully-clean full-roster passes): security, cryptographer, black-hat, red-hat, bug-catcher, test-quality, simplifier, api-design, alignment. Two HIGH findings (strip-before-evict ordering; self-removal cross-impl divergence) were found and fixed during review; adversarial probes ultimately failed to break the eviction property.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
