### PR TITLE
feat(saga): wire broadcast hosting-handshake saga dispatch (§5.14.13)

### DIFF
--- a/crates/scp-ffi/wasm/src/manager.rs
+++ b/crates/scp-ffi/wasm/src/manager.rs
@@ -6524,6 +6524,9 @@ impl WasmContextManager {
                 admission,
                 subscribers,
                 authors,
+                accepted_hosts: Vec::new(),
+                aggregate_cap:
+                    scp_protocol::context::broadcast::BroadcastHostingAggregateCap::default(),
             })
         });
 

--- a/crates/scp-protocol/src/context/broadcast/mod.rs
+++ b/crates/scp-protocol/src/context/broadcast/mod.rs
@@ -537,6 +537,84 @@ pub struct ReservedPublishApply {
 }
 
 // ---------------------------------------------------------------------------
+// Hosting aggregate cap (spec §5.14.13 "Aggregate cap value and derivation")
+// ---------------------------------------------------------------------------
+
+/// Default `aggregate_max_subscribers` (§5.14.13): ten per-host defaults.
+pub const DEFAULT_AGGREGATE_MAX_SUBSCRIBERS: u32 = 100_000;
+/// Inclusive permitted range for `aggregate_max_subscribers` (§5.14.13).
+pub const AGGREGATE_MAX_SUBSCRIBERS_RANGE: (u32, u32) = (1, 100_000_000);
+
+/// Default `aggregate_max_forward_rate_per_minute` (§5.14.13): ten per-host defaults.
+pub const DEFAULT_AGGREGATE_MAX_FORWARD_RATE_PER_MINUTE: u32 = 6_000;
+/// Inclusive permitted range for `aggregate_max_forward_rate_per_minute` (§5.14.13).
+pub const AGGREGATE_MAX_FORWARD_RATE_PER_MINUTE_RANGE: (u32, u32) = (1, 60_000_000);
+
+/// Default `max_grant_lifetime_ms` (§5.14.13): 7 days.
+pub const DEFAULT_MAX_GRANT_LIFETIME_MS: u64 = 604_800_000;
+/// Inclusive permitted range for `max_grant_lifetime_ms` (§5.14.13): up to 365 days.
+pub const MAX_GRANT_LIFETIME_MS_RANGE: (u64, u64) = (1, 31_536_000_000);
+
+/// The per-broadcast-context aggregate amplification ceiling (spec §5.14.13,
+/// *Aggregate cap value and derivation*).
+///
+/// Two cap fields are each summed across all of B's currently-live
+/// [`hosting_handshake::AcceptedHostSnapshotEntry`] records; `max_grant_lifetime_ms`
+/// is the B-imposed ceiling on any single grant's lifetime
+/// (`granted_config.expires_at_ms` is clamped to
+/// `min(requested, granted_at_ms + max_grant_lifetime_ms)`).
+///
+/// Raising any field beyond its default requires explicit governance, not a
+/// default-template grant — a longer lifetime or higher aggregate directly
+/// extends the bounded amplification residual (§5.14.13 *Epoch tracking and
+/// fail-closed forwarding*).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub struct BroadcastHostingAggregateCap {
+    /// Sum ceiling for `max_subscribers` across all live host grants.
+    pub aggregate_max_subscribers: u32,
+    /// Sum ceiling for `max_forward_rate_per_minute` across all live host grants.
+    pub aggregate_max_forward_rate_per_minute: u32,
+    /// Ceiling on any single grant's lifetime (`granted_at_ms` → `expires_at_ms`).
+    pub max_grant_lifetime_ms: u64,
+}
+
+impl Default for BroadcastHostingAggregateCap {
+    /// The §5.14.13 default-template aggregate cap.
+    fn default() -> Self {
+        Self {
+            aggregate_max_subscribers: DEFAULT_AGGREGATE_MAX_SUBSCRIBERS,
+            aggregate_max_forward_rate_per_minute: DEFAULT_AGGREGATE_MAX_FORWARD_RATE_PER_MINUTE,
+            max_grant_lifetime_ms: DEFAULT_MAX_GRANT_LIFETIME_MS,
+        }
+    }
+}
+
+/// Reason a hosting grant was refused at Prepare-B against the aggregate cap
+/// (spec §5.14.13).
+///
+/// Both caps are enforced **independently** — exceeding EITHER is a refusal;
+/// headroom in one is not fungible for the other.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum AggregateCapExceeded {
+    /// The requested grant's `max_subscribers`, added to the sum over all OTHER
+    /// live entries, would exceed `aggregate_max_subscribers`.
+    Subscribers {
+        /// The would-be total subscribers across all live grants including this one.
+        would_be_total: u64,
+        /// The configured `aggregate_max_subscribers` ceiling.
+        ceiling: u32,
+    },
+    /// The requested grant's `max_forward_rate_per_minute`, added to the sum over
+    /// all OTHER live entries, would exceed `aggregate_max_forward_rate_per_minute`.
+    ForwardRate {
+        /// The would-be total forward-rate across all live grants including this one.
+        would_be_total: u64,
+        /// The configured `aggregate_max_forward_rate_per_minute` ceiling.
+        ceiling: u32,
+    },
+}
+
+// ---------------------------------------------------------------------------
 // BroadcastContext
 // ---------------------------------------------------------------------------
 
@@ -560,6 +638,18 @@ pub struct BroadcastContext {
     subscribers: HashMap<String, SubscriberRecord>,
     /// Per-author broadcast key state, keyed by author DID.
     authors: HashMap<String, AuthorState>,
+    /// Durable accepted-host snapshot (spec §5.14.13), keyed by
+    /// `(host_context_id_hex, subscriber_did)`. **At-most-one-live invariant:**
+    /// a successful re-handshake for the same pair SUPERSEDES the prior entry.
+    /// This — not a re-presented grant — authorizes the host's §5.14.2 HPKE
+    /// pull. Part of B's broadcast-context state (§5.14.7); persisted on the
+    /// §5.15.3 sync-persisted path. **Class S** (its loss breaks grant
+    /// authorization + the at-most-one-live anti-replay invariant).
+    accepted_hosts: HashMap<(String, String), hosting_handshake::AcceptedHostSnapshotEntry>,
+    /// The per-broadcast-context aggregate amplification ceiling (spec §5.14.13).
+    /// Defaults to [`BroadcastHostingAggregateCap::default`]; raising any field
+    /// above its default is a governance decision, not a default-template change.
+    aggregate_cap: BroadcastHostingAggregateCap,
 }
 
 impl BroadcastContext {
@@ -582,6 +672,8 @@ impl BroadcastContext {
             admission,
             subscribers: HashMap::new(),
             authors: HashMap::new(),
+            accepted_hosts: HashMap::new(),
+            aggregate_cap: BroadcastHostingAggregateCap::default(),
         })
     }
 
@@ -1607,6 +1699,209 @@ impl BroadcastContext {
         self.authors.keys()
     }
 
+    // -----------------------------------------------------------------------
+    // Hosting handshake accepted-host snapshot (spec §5.14.13)
+    // -----------------------------------------------------------------------
+
+    /// The per-broadcast-context aggregate amplification ceiling (§5.14.13).
+    #[must_use]
+    pub const fn aggregate_cap(&self) -> BroadcastHostingAggregateCap {
+        self.aggregate_cap
+    }
+
+    /// Set the aggregate cap (a governance decision when raised above default,
+    /// §5.14.13). Used at context construction / governance time, not by the
+    /// handshake saga itself.
+    pub const fn set_aggregate_cap(&mut self, cap: BroadcastHostingAggregateCap) {
+        self.aggregate_cap = cap;
+    }
+
+    /// Look up the single live accepted-host entry for a `(host_context_id_hex,
+    /// subscriber_did)` pair (§5.14.13 at-most-one-live invariant). The §5.14.2
+    /// post-grant pull resolves on this.
+    #[must_use]
+    pub fn accepted_host(
+        &self,
+        host_context_id_hex: &str,
+        subscriber_did: &str,
+    ) -> Option<&hosting_handshake::AcceptedHostSnapshotEntry> {
+        self.accepted_hosts
+            .get(&(host_context_id_hex.to_owned(), subscriber_did.to_owned()))
+    }
+
+    /// The number of currently-live accepted-host entries.
+    #[must_use]
+    pub fn accepted_host_count(&self) -> usize {
+        self.accepted_hosts.len()
+    }
+
+    /// Check a requested grant against the aggregate amplification cap
+    /// (spec §5.14.13, *Aggregate cap value and derivation*).
+    ///
+    /// Sums `max_subscribers` (and `max_forward_rate_per_minute`) over all live
+    /// entries **other than any live entry for the requesting
+    /// `(host_context_id_hex, subscriber_did)` pair** (that prior entry, if
+    /// present, is superseded at Commit — it MUST be excluded so a renewal is
+    /// charged only the NET change), then adds the requested host's **clamped**
+    /// values. The two caps are enforced **independently**: exceeding EITHER is
+    /// a refusal.
+    ///
+    /// `Ok(())` means the grant fits both caps; `Err` carries which cap (and the
+    /// would-be total) was exceeded.
+    ///
+    /// # Errors
+    ///
+    /// [`AggregateCapExceeded`] if the requested grant would overshoot either
+    /// aggregate ceiling.
+    pub fn check_aggregate_cap(
+        &self,
+        host_context_id_hex: &str,
+        subscriber_did: &str,
+        requested_max_subscribers: u32,
+        requested_max_forward_rate_per_minute: u32,
+    ) -> Result<(), AggregateCapExceeded> {
+        let exclude = (host_context_id_hex.to_owned(), subscriber_did.to_owned());
+        // Sum over OTHER live entries (the requesting pair's prior entry, if any,
+        // is superseded at Commit — excluding it charges only the net change).
+        let (other_subs, other_rate): (u64, u64) = self
+            .accepted_hosts
+            .iter()
+            .filter(|(key, _)| **key != exclude)
+            .fold((0u64, 0u64), |(s, r), (_, entry)| {
+                (
+                    s + u64::from(entry.granted_config.max_subscribers),
+                    r + u64::from(entry.granted_config.max_forward_rate_per_minute),
+                )
+            });
+
+        let total_subs = other_subs + u64::from(requested_max_subscribers);
+        if total_subs > u64::from(self.aggregate_cap.aggregate_max_subscribers) {
+            return Err(AggregateCapExceeded::Subscribers {
+                would_be_total: total_subs,
+                ceiling: self.aggregate_cap.aggregate_max_subscribers,
+            });
+        }
+
+        let total_rate = other_rate + u64::from(requested_max_forward_rate_per_minute);
+        if total_rate > u64::from(self.aggregate_cap.aggregate_max_forward_rate_per_minute) {
+            return Err(AggregateCapExceeded::ForwardRate {
+                would_be_total: total_rate,
+                ceiling: self.aggregate_cap.aggregate_max_forward_rate_per_minute,
+            });
+        }
+
+        Ok(())
+    }
+
+    /// Insert or SUPERSEDE the accepted-host snapshot entry for its
+    /// `(host_context_id, subscriber_did)` pair at Commit (spec §5.14.13
+    /// at-most-one-live invariant). A re-handshake replaces the prior entry
+    /// (writing a fresh `saga_id`), so a replayed Commit of the OLD saga (whose
+    /// `saga_id` no longer matches the live entry) is a no-op.
+    ///
+    /// Returns `true` if this write LANDED a new/updated live entry, `false` if
+    /// the identical entry (same `saga_id`) was already live — making a replayed
+    /// Commit an observable no-op for idempotency.
+    pub fn upsert_accepted_host(
+        &mut self,
+        entry: hosting_handshake::AcceptedHostSnapshotEntry,
+    ) -> bool {
+        let key = (
+            hex::encode(entry.host_context_id),
+            entry.subscriber_did.clone(),
+        );
+        if self
+            .accepted_hosts
+            .get(&key)
+            .is_some_and(|live| *live == entry)
+        {
+            // Byte-identical replay of the same committed entry — no-op.
+            return false;
+        }
+        self.accepted_hosts.insert(key, entry);
+        true
+    }
+
+    /// Remove the live accepted-host entry for a pair (e.g. grant revocation).
+    /// Returns the removed entry, if any.
+    pub fn remove_accepted_host(
+        &mut self,
+        host_context_id_hex: &str,
+        subscriber_did: &str,
+    ) -> Option<hosting_handshake::AcceptedHostSnapshotEntry> {
+        self.accepted_hosts
+            .remove(&(host_context_id_hex.to_owned(), subscriber_did.to_owned()))
+    }
+
+    /// Validate a `messages:read` UCAN against THIS broadcast context, re-bound
+    /// to the presenting subscriber (spec §5.14.13 Prepare-B gated requirement;
+    /// §5.14.4 key-request validation). Used by the hosting-handshake saga's
+    /// Prepare-B for a **gated** broadcast context: an absent or invalid UCAN ⇒
+    /// the grant is refused. The full 11-step ADR-016 pipeline runs (signature,
+    /// delegation chain, expiry, **revocation**, capability match for
+    /// `messages:read`), so a token revoked between subscribe and handshake is
+    /// rejected here — the grant-time validation does NOT stand in for this
+    /// current re-check.
+    ///
+    /// # Errors
+    ///
+    /// [`ContextError::PermissionDenied`] if the UCAN fails any validation step.
+    pub fn validate_messages_read_ucan_public<D, N, R, P, S>(
+        &self,
+        token: &UcanToken,
+        ctx: &mut ValidationContext<'_, D, N, R, P, S>,
+    ) -> Result<(), ContextError>
+    where
+        D: DidResolver,
+        N: NonceTracker,
+        R: RevocationChecker,
+        P: ProofResolver,
+        S: BuildHasher,
+    {
+        validate_messages_read_ucan(token, &self.context_id, ctx)
+    }
+
+    /// The locally-controlled broadcast author DID whose `current_key_epoch`
+    /// the handshake captures at Prepare-B, if exactly one author is registered
+    /// and locally controlled. Returns `None` if there is no unambiguous local
+    /// author (the handshake saga resolves the author explicitly in that case).
+    #[must_use]
+    pub fn sole_author_did(&self) -> Option<&str> {
+        let mut iter = self.authors.keys();
+        let first = iter.next()?;
+        if iter.next().is_some() {
+            return None;
+        }
+        Some(first.as_str())
+    }
+
+    /// The current key epoch for a given broadcast author (§5.14.2), if registered.
+    #[must_use]
+    pub fn author_key_epoch(&self, author_did: &str) -> Option<u64> {
+        self.authors.get(author_did).map(|a| a.epoch)
+    }
+
+    /// Idempotently register a host representative as a subscriber at hosting-
+    /// handshake Commit (spec §5.14.13: registering, or idempotently
+    /// re-registering, the host representative under its handshake
+    /// `wrapping_pubkey`). Because the host representative already holds
+    /// `messages:read` (a Prepare-A precondition), an already-registered
+    /// subscriber DID is an idempotent update, NOT a duplicate-membership error
+    /// (mirroring `register_standing_context` idempotency, §5.15.8). The
+    /// `has_ucan` flag is set per the admission mode (gated requires a UCAN,
+    /// validated at Prepare-B).
+    pub fn register_host_subscriber(&mut self, subscriber_did: &str, registered_at: u64) {
+        let has_ucan = self.admission == BroadcastAdmission::Gated;
+        self.subscribers.insert(
+            subscriber_did.to_owned(),
+            SubscriberRecord {
+                subscriber_did: subscriber_did.to_owned(),
+                registered_at,
+                has_ucan,
+            },
+        );
+    }
+
     /// Creates a serializable snapshot of the broadcast context state.
     ///
     /// Captures authors (with key material and epochs), subscribers, and
@@ -1638,6 +1933,12 @@ impl BroadcastContext {
             admission: self.admission,
             subscribers: self.subscribers.clone(),
             authors,
+            // Accepted-host entries are serialized as a flat Vec (the
+            // `(host_id_hex, subscriber_did)` map key is derivable from each
+            // entry's `host_context_id` + `subscriber_did`), avoiding a
+            // tuple-keyed map that some serializers (JSON) cannot encode.
+            accepted_hosts: self.accepted_hosts.values().cloned().collect(),
+            aggregate_cap: self.aggregate_cap,
         }
     }
 
@@ -1665,11 +1966,27 @@ impl BroadcastContext {
             })
             .collect();
 
+        let accepted_hosts = snapshot
+            .accepted_hosts
+            .into_iter()
+            .map(|entry| {
+                (
+                    (
+                        hex::encode(entry.host_context_id),
+                        entry.subscriber_did.clone(),
+                    ),
+                    entry,
+                )
+            })
+            .collect();
+
         Self {
             context_id: snapshot.context_id,
             admission: snapshot.admission,
             subscribers: snapshot.subscribers,
             authors,
+            accepted_hosts,
+            aggregate_cap: snapshot.aggregate_cap,
         }
     }
 }
@@ -1701,6 +2018,16 @@ pub struct BroadcastContextSnapshot {
     pub subscribers: HashMap<String, SubscriberRecord>,
     /// Per-author broadcast key state, keyed by author DID.
     pub authors: HashMap<String, AuthorStateSnapshot>,
+    /// Durable accepted-host snapshot entries (spec §5.14.13). Serialized as a
+    /// flat list; the `(host_id_hex, subscriber_did)` map key is rebuilt from
+    /// each entry on restore. `#[serde(default)]` so a snapshot written before
+    /// hosting handshakes existed restores to an empty registry.
+    #[serde(default)]
+    pub accepted_hosts: Vec<hosting_handshake::AcceptedHostSnapshotEntry>,
+    /// Per-broadcast-context aggregate amplification ceiling (spec §5.14.13).
+    /// `#[serde(default)]` so an older snapshot restores to the default cap.
+    #[serde(default)]
+    pub aggregate_cap: BroadcastHostingAggregateCap,
 }
 
 /// Serializable snapshot of per-author broadcast key state.
@@ -5045,5 +5372,152 @@ mod tests {
         assert_eq!(decoded.wrapping_pubkey, reg.wrapping_pubkey);
         assert_eq!(decoded.timestamp, reg.timestamp);
         assert_eq!(decoded.signature, reg.signature);
+    }
+
+    // -----------------------------------------------------------------------
+    // Accepted-host snapshot + aggregate cap (spec §5.14.13)
+    // -----------------------------------------------------------------------
+
+    fn host_entry(
+        host: [u8; 32],
+        subscriber: &str,
+        max_subscribers: u32,
+        max_rate: u32,
+        saga_id: &str,
+    ) -> hosting_handshake::AcceptedHostSnapshotEntry {
+        hosting_handshake::AcceptedHostSnapshotEntry {
+            host_context_id: host,
+            subscriber_did: subscriber.to_owned(),
+            wrapping_pubkey: [0x44; 32],
+            granted_config: hosting_handshake::BroadcastHostConfig {
+                max_forward_rate_per_minute: max_rate,
+                max_subscribers,
+                forwarding_policy: hosting_handshake::ForwardingPolicy::Verbatim,
+                expires_at_ms: 1_700_000_100_000,
+            },
+            granted_at_ms: 1_700_000_000_000,
+            key_epoch_at_grant: 3,
+            saga_id: saga_id.to_owned(),
+        }
+    }
+
+    #[test]
+    fn accepted_host_upsert_and_lookup() {
+        let mut bc = make_open_ctx();
+        let host = [0x11; 32];
+        let entry = host_entry(host, "did:example:host-rep", 100, 60, "saga-1");
+        assert!(bc.upsert_accepted_host(entry.clone()));
+        // Byte-identical replay is an idempotent no-op.
+        assert!(!bc.upsert_accepted_host(entry));
+        let found = bc
+            .accepted_host(&hex::encode(host), "did:example:host-rep")
+            .expect("entry present");
+        assert_eq!(found.saga_id, "saga-1");
+        assert_eq!(bc.accepted_host_count(), 1);
+    }
+
+    #[test]
+    fn accepted_host_supersedes_same_pair() {
+        let mut bc = make_open_ctx();
+        let host = [0x11; 32];
+        bc.upsert_accepted_host(host_entry(host, "did:example:host-rep", 100, 60, "saga-1"));
+        // A re-handshake for the SAME pair supersedes (writes a fresh saga_id),
+        // never coexists — at-most-one-live invariant (§5.14.13).
+        bc.upsert_accepted_host(host_entry(host, "did:example:host-rep", 200, 120, "saga-2"));
+        assert_eq!(bc.accepted_host_count(), 1);
+        let live = bc
+            .accepted_host(&hex::encode(host), "did:example:host-rep")
+            .expect("entry present");
+        assert_eq!(live.saga_id, "saga-2");
+        assert_eq!(live.granted_config.max_subscribers, 200);
+    }
+
+    #[test]
+    fn aggregate_cap_excludes_requesting_pair_on_renewal() {
+        // A renewal for the SAME pair is charged only the NET change: the prior
+        // entry is excluded from the Prepare-B sum (§5.14.13).
+        let mut bc = make_open_ctx();
+        bc.set_aggregate_cap(BroadcastHostingAggregateCap {
+            aggregate_max_subscribers: 150,
+            aggregate_max_forward_rate_per_minute: 100,
+            max_grant_lifetime_ms: DEFAULT_MAX_GRANT_LIFETIME_MS,
+        });
+        let host = [0x11; 32];
+        bc.upsert_accepted_host(host_entry(host, "did:example:host-rep", 100, 60, "saga-1"));
+        // Renewal raising to 150 subs: prior 100 EXCLUDED, so total = 150 ≤ 150.
+        assert!(
+            bc.check_aggregate_cap(&hex::encode(host), "did:example:host-rep", 150, 80)
+                .is_ok(),
+            "renewal charged only net change must fit the cap"
+        );
+    }
+
+    #[test]
+    fn aggregate_cap_rejects_subscribers_overshoot() {
+        let mut bc = make_open_ctx();
+        bc.set_aggregate_cap(BroadcastHostingAggregateCap {
+            aggregate_max_subscribers: 150,
+            aggregate_max_forward_rate_per_minute: 100_000,
+            max_grant_lifetime_ms: DEFAULT_MAX_GRANT_LIFETIME_MS,
+        });
+        bc.upsert_accepted_host(host_entry([0x11; 32], "did:example:a", 100, 10, "saga-1"));
+        // A DIFFERENT pair requesting 60 more: 100 + 60 = 160 > 150.
+        let err = bc
+            .check_aggregate_cap(&hex::encode([0x22; 32]), "did:example:b", 60, 10)
+            .expect_err("must overshoot the subscriber cap");
+        assert!(matches!(
+            err,
+            AggregateCapExceeded::Subscribers {
+                would_be_total: 160,
+                ceiling: 150
+            }
+        ));
+    }
+
+    #[test]
+    fn aggregate_cap_rejects_rate_overshoot_independently() {
+        // Headroom in the subscriber cap is NOT fungible for the rate cap.
+        let mut bc = make_open_ctx();
+        bc.set_aggregate_cap(BroadcastHostingAggregateCap {
+            aggregate_max_subscribers: 1_000_000,
+            aggregate_max_forward_rate_per_minute: 100,
+            max_grant_lifetime_ms: DEFAULT_MAX_GRANT_LIFETIME_MS,
+        });
+        bc.upsert_accepted_host(host_entry([0x11; 32], "did:example:a", 1, 80, "saga-1"));
+        let err = bc
+            .check_aggregate_cap(&hex::encode([0x22; 32]), "did:example:b", 1, 60)
+            .expect_err("must overshoot the rate cap even with subscriber headroom");
+        assert!(matches!(
+            err,
+            AggregateCapExceeded::ForwardRate {
+                would_be_total: 140,
+                ceiling: 100
+            }
+        ));
+    }
+
+    #[test]
+    fn accepted_hosts_survive_snapshot_round_trip() {
+        let mut bc = make_open_ctx();
+        let host = [0x11; 32];
+        bc.upsert_accepted_host(host_entry(host, "did:example:host-rep", 100, 60, "saga-1"));
+        bc.set_aggregate_cap(BroadcastHostingAggregateCap {
+            aggregate_max_subscribers: 42,
+            aggregate_max_forward_rate_per_minute: 24,
+            max_grant_lifetime_ms: 1_000,
+        });
+        let snapshot = bc.to_snapshot();
+        let bytes = rmp_serde::to_vec_named(&snapshot).unwrap();
+        let decoded: BroadcastContextSnapshot = rmp_serde::from_slice(&bytes).unwrap();
+        let restored = BroadcastContext::from_snapshot(decoded);
+        assert_eq!(restored.accepted_host_count(), 1);
+        assert_eq!(
+            restored
+                .accepted_host(&hex::encode(host), "did:example:host-rep")
+                .map(|e| e.saga_id.clone()),
+            Some("saga-1".to_owned())
+        );
+        assert_eq!(restored.aggregate_cap().aggregate_max_subscribers, 42);
+        assert_eq!(restored.aggregate_cap().max_grant_lifetime_ms, 1_000);
     }
 }

--- a/crates/scp-runtime/src/context/actor/commands.rs
+++ b/crates/scp-runtime/src/context/actor/commands.rs
@@ -1741,11 +1741,16 @@ pub enum BroadcastCommand {
         reply: BroadcastAdmissionReply,
     },
 
-    /// Saga-initiator path for the broadcast-hosting handshake. Returns
-    /// [`ContextError::NotImplemented`] in commit 11 — the handshake
-    /// protocol (subscriber-to-host key exchange, host config negotiation,
-    /// §5.14.2 step 4 transport) is spec-gapped. See
-    /// `.docs/adrs/DEFERRED-commit-11-saga-use-cases.md`.
+    /// Single-actor mailbox stand-in for the broadcast-hosting handshake
+    /// (spec §5.14.13). The §5.14.13 saga IS implemented, but — like the
+    /// §6.2.4 cross-context tool saga — it is a cross-context (host +
+    /// broadcast) two-phase saga driven by the supervisor, whose sole
+    /// production entry point is
+    /// [`Supervisor::start_broadcast_hosting_handshake_saga`](crate::context::supervisor::supervisor::Supervisor::start_broadcast_hosting_handshake_saga)
+    /// (it supplies the per-call signing keys and mints the `SagaId`). This
+    /// single-actor variant therefore defers
+    /// ([`ContextError::NotImplemented`]): a cross-context saga cannot be
+    /// driven from one actor's mailbox.
     InitiateBroadcastHostingHandshake {
         /// Host context ID (32-byte hash).
         host_context_id: [u8; 32],
@@ -2680,6 +2685,50 @@ pub struct PreparedBFields {
     pub recorded_chain_depth: u8,
 }
 
+/// Output of the broadcast hosting-handshake Prepare-A handler (spec §5.14.13
+/// "Prepare-A"). The host-context actor confirms the context is Active and that
+/// the requester (`subscriber_did`) holds `messages:read` for B, stages the
+/// forwarding-registry entry, and returns the requester-signed
+/// [`BroadcastHostingRequest`](scp_protocol::context::broadcast::hosting_handshake::BroadcastHostingRequest)
+/// bytes (JCS) for the FSM to carry to Prepare-B. The request is signed with the
+/// requester's Active Signing Key supplied per-call (the actor holds no key,
+/// ADR-049).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct BroadcastPreparedAFields {
+    /// JCS bytes of the signed `BroadcastHostingRequest`.
+    pub request_bytes: Vec<u8>,
+}
+
+/// Output of the broadcast hosting-handshake Prepare-B handler (spec §5.14.13
+/// "Prepare-B", the authoritative side).
+///
+/// The broadcast-context actor validated the request signature (bound to
+/// `subscriber_did`), freshness + nonce-dedup, block-list, rate-limit,
+/// gated-UCAN, aggregate cap; clamped the config; captured the epoch /
+/// `granted_at_ms` / grant nonce + timestamp at the single Prepare-B instant;
+/// staged the prepared into `saga_pending`; and signed the
+/// [`BroadcastHostingGrant`](scp_protocol::context::broadcast::hosting_handshake::BroadcastHostingGrant).
+/// It surfaces the grant bytes (JCS) for the FSM to carry to Commit-A, plus the
+/// captured replay-deterministic values an auditor / the journal evidence reads.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct BroadcastPreparedBFields {
+    /// JCS bytes of the author-signed `BroadcastHostingGrant`.
+    pub grant_bytes: Vec<u8>,
+    /// The broadcast key epoch captured at Prepare-B (matches the grant's `current_key_epoch`).
+    pub key_epoch_at_grant: u64,
+    /// Wall-clock ms captured at Prepare-B.
+    pub granted_at_ms: u64,
+}
+
+/// Reply-channel type aliases for the broadcast hosting-handshake phases
+/// (spec §5.14.13). Factored out to satisfy `clippy::type_complexity`.
+pub type BroadcastPrepareAReply = oneshot::Sender<Result<BroadcastPreparedAFields, ContextError>>;
+/// Reply-channel type alias for the broadcast Prepare-B phase.
+pub type BroadcastPrepareBReply = oneshot::Sender<Result<BroadcastPreparedBFields, ContextError>>;
+/// Reply-channel type alias for the broadcast Commit-B phase (returns the
+/// author-signed grant bytes B returns to host A on Commit-A).
+pub type BroadcastCommitBReply = oneshot::Sender<Result<Vec<u8>, ContextError>>;
+
 /// Reply payload for [`SagaPhaseMessage::CommitBReserve`] (spec §6.2.4
 /// "Commit", split-execution model). The Commit-B phase is two actor
 /// round-trips with the non-`Send` tool executor running supervisor-side in
@@ -2959,6 +3008,103 @@ pub enum SagaPhaseMessage {
         signing_key: SigningKeyBytes,
         /// Oneshot reply channel.
         reply: oneshot::Sender<Result<(), ContextError>>,
+    },
+    /// Broadcast hosting-handshake Prepare-A (spec §5.14.13) — runs on the LOCAL
+    /// host-context actor. Confirms the host context is Active and the requester
+    /// (`subscriber_did`) holds `messages:read` for B, stages the
+    /// forwarding-registry entry, and builds + signs the
+    /// `BroadcastHostingRequest` with the requester's Active Signing Key
+    /// (`requester_signing_key`, supplied per-call — the actor holds no key).
+    /// Class-S fail-closed persist of the staged entry. Replies the signed
+    /// request bytes for the FSM to carry to Prepare-B.
+    BroadcastPrepareA {
+        /// Durable saga identifier (the staged-slot key).
+        saga_id: crate::context::supervisor::saga_journal::SagaId,
+        /// Host (relaying) context id (raw 32-byte digest) — the actor's own context.
+        host_context_id: [u8; 32],
+        /// Broadcast (hosted) context id (raw 32-byte digest).
+        broadcast_context_id: [u8; 32],
+        /// The host representative DID requesting hosting (holds `messages:read` for B).
+        subscriber_did: scp_identity::DID,
+        /// X25519 recipient key the post-grant broadcast key is sealed under.
+        wrapping_pubkey: [u8; 32],
+        /// JCS bytes of the requested `BroadcastHostConfig`.
+        requested_config_bytes: Vec<u8>,
+        /// `messages:read` UCAN — present iff B is a gated context.
+        ucan: Option<String>,
+        /// 16-byte freshness/anti-replay nonce (the grant echoes it).
+        nonce: [u8; 16],
+        /// Request send time in Unix milliseconds (freshness-checked at Prepare-B).
+        timestamp_ms: u64,
+        /// The requester's Active Signing Key. The actor holds NO key (ADR-049);
+        /// the FSM resolves the key authorized for `subscriber_did` and passes it
+        /// per-call. Zeroizes on drop.
+        requester_signing_key: SigningKeyBytes,
+        /// Oneshot reply channel. See [`BroadcastPrepareAReply`].
+        reply: BroadcastPrepareAReply,
+    },
+    /// Broadcast hosting-handshake Prepare-B (spec §5.14.13) — runs on the LOCAL
+    /// broadcast-context actor, the AUTHORITATIVE side. Validates the request
+    /// signature is bound to `subscriber_did`; freshness (§9.14 skew + the
+    /// broadcast author's bounded TTL'd nonce-dedup cache); block-list +
+    /// rate-limit; for a gated context the `messages:read` UCAN re-bound to
+    /// `subscriber_did`; clamps the config; checks the aggregate cap; captures
+    /// `current_key_epoch` / `granted_at_ms` / grant nonce + timestamp at the
+    /// single Prepare-B instant; stages the prepared into `saga_pending`; and
+    /// signs the `BroadcastHostingGrant` with the broadcast author's key
+    /// (`author_signing_key`, supplied per-call). Class-S fail-closed persist.
+    BroadcastPrepareB {
+        /// Durable saga identifier (the `saga_pending` key).
+        saga_id: crate::context::supervisor::saga_journal::SagaId,
+        /// Broadcast (hosted) context id (raw 32-byte digest) — the actor's own context.
+        broadcast_context_id: [u8; 32],
+        /// JCS bytes of the requester-signed `BroadcastHostingRequest` (from Prepare-A).
+        request_bytes: Vec<u8>,
+        /// The broadcast author's Active Signing Key — signs the grant. The actor
+        /// holds NO key (ADR-049); the FSM passes it per-call. Zeroizes on drop.
+        author_signing_key: SigningKeyBytes,
+        /// Oneshot reply channel. See [`BroadcastPrepareBReply`].
+        reply: BroadcastPrepareBReply,
+    },
+    /// Broadcast hosting-handshake Commit-B (spec §5.14.13) — runs on the LOCAL
+    /// broadcast-context actor. Persists the `AcceptedHostSnapshotEntry` on the
+    /// §5.15.3 sync-persisted path together with the `MemberJoined{subscriber}`
+    /// append (idempotently re-registering the host representative under its
+    /// handshake `wrapping_pubkey`); **NO key is pushed at Commit** — the
+    /// snapshot authorizes the host's later §5.14.2 HPKE pull. Returns the
+    /// byte-identical author-signed grant bytes B holds for return to host A.
+    /// Idempotent by `SagaId`: a replayed Commit re-acks the existing snapshot +
+    /// append and re-returns the byte-identical grant.
+    BroadcastCommitB {
+        /// Durable saga identifier (the staged-slot + snapshot anchor).
+        saga_id: crate::context::supervisor::saga_journal::SagaId,
+        /// Oneshot reply channel. See [`BroadcastCommitBReply`].
+        reply: BroadcastCommitBReply,
+    },
+    /// Broadcast hosting-handshake Commit-A (spec §5.14.13) — runs on the LOCAL
+    /// host-context actor. Persists the author-signed `BroadcastHostingGrant` as
+    /// durable proof of relay authorization and does host-registration.
+    /// Idempotent by `SagaId`: a re-sent Commit re-acks, delivering nothing new.
+    BroadcastCommitA {
+        /// Durable saga identifier (the staged-slot key).
+        saga_id: crate::context::supervisor::saga_journal::SagaId,
+        /// JCS bytes of the author-signed `BroadcastHostingGrant` (from Commit-B).
+        grant_bytes: Vec<u8>,
+        /// Oneshot reply channel.
+        reply: oneshot::Sender<Result<(), ContextError>>,
+    },
+    /// Broadcast hosting-handshake Commit-A witness check (spec §5.14.13 crash
+    /// recovery §17.16.4) — runs on the LOCAL host-context actor. READ-ONLY:
+    /// reports whether the durable grant proof for this `SagaId` is present in
+    /// `bcast_committed_grants` (i.e. Commit-A durably landed before a crash). The
+    /// FSM uses it on a `Committing` re-drive to resolve `Committed` (witness
+    /// present) vs `NeedsRepair`, without re-delivering a grant it no longer holds
+    /// the author key to re-sign (analogous to [`Self::CommitACheckWitness`]).
+    BroadcastCommitAReack {
+        /// Durable saga identifier (the `bcast_committed_grants` key).
+        saga_id: crate::context::supervisor::saga_journal::SagaId,
+        /// Oneshot reply: `true` iff Commit-A is durably recorded for this saga.
+        reply: oneshot::Sender<Result<bool, ContextError>>,
     },
 }
 

--- a/crates/scp-runtime/src/context/actor/handlers/broadcast.rs
+++ b/crates/scp-runtime/src/context/actor/handlers/broadcast.rs
@@ -31,16 +31,25 @@
 //! holds `&mut PerContextState` only briefly, and concurrent publishes
 //! each reserve a distinct sequence.
 //!
-//! # SAGA WIRING DEFERRED — see
-//! `.docs/adrs/DEFERRED-commit-11-saga-use-cases.md`.
+//! # Broadcast hosting-handshake saga (spec §5.14.13)
 //!
-//! The `InitiateBroadcastHostingHandshake` saga-initiator variant
-//! returns [`ContextError::NotImplemented`](scp_protocol::context::ContextError::NotImplemented)
-//! because broadcast hosting handshake protocol is spec-gapped — the
-//! spec does not yet define the subscriber→host key-exchange frames,
-//! host-config negotiation, or §5.14.2 step-4 transport. Until those
-//! land, the saga-initiator path returns
-//! `ContextError::NotImplemented`.
+//! The §5.14.13 broadcast hosting-handshake saga IS implemented. Like the
+//! §6.2.4 cross-context tool saga, it is a cross-context (host A + broadcast
+//! B) two-phase saga that the supervisor mints and drives — the FSM supplies
+//! the host representative's and broadcast author's per-call signing keys
+//! (ADR-049: the actor holds no signing key). Its sole production entry point
+//! is
+//! [`Supervisor::start_broadcast_hosting_handshake_saga`](crate::context::supervisor::supervisor::Supervisor::start_broadcast_hosting_handshake_saga);
+//! the per-phase Prepare/Commit work runs in
+//! [`crate::context::actor::handlers::broadcast_saga`].
+//!
+//! The single-actor mailbox variant `InitiateBroadcastHostingHandshake`
+//! therefore [`reply_saga_deferred`]s: a cross-context saga cannot be driven
+//! from one actor's mailbox (it carries neither the second context's signing
+//! key nor the supervisor handle that mints the `SagaId`). Callers reach the
+//! saga through the supervisor entry point above, exactly as the §6.2.4 tool
+//! saga's `InitiateCrossContextToolInvocation` mailbox variant defers to
+//! [`Supervisor::start_cross_context_tool_invocation_saga`](crate::context::supervisor::supervisor::Supervisor::start_cross_context_tool_invocation_saga).
 
 use std::time::Duration;
 

--- a/crates/scp-runtime/src/context/actor/handlers/broadcast_saga.rs
+++ b/crates/scp-runtime/src/context/actor/handlers/broadcast_saga.rs
@@ -1,0 +1,941 @@
+// Read-only actor helpers still take `&mut PerContextState` so their
+// handler futures capture `&mut T` (`T: Send`) rather than `&T`.
+#![allow(clippy::needless_pass_by_ref_mut)]
+
+//! Broadcast hosting-handshake saga phase handlers (spec §5.14.13).
+//!
+//! The supervisor FSM dispatches per-phase messages to a participant actor; this
+//! module implements every phase, each running on a LOCAL actor:
+//!
+//! - **Prepare-A** ([`prepare_a`]) — on the HOST-context actor. Confirms the
+//!   host context is Active and the requester (`subscriber_did`) holds
+//!   `messages:read` for B, stages the forwarding-registry entry, and builds +
+//!   signs the [`BroadcastHostingRequest`] with the requester's Active Signing
+//!   Key (supplied per-call — the actor holds no key, ADR-049). Class-S
+//!   fail-closed persist of the staged slot.
+//!
+//! - **Prepare-B** ([`prepare_b`]) — on the BROADCAST-context actor, the
+//!   AUTHORITATIVE side. In order: validate the request signature is bound to
+//!   `subscriber_did`; freshness (§9.14 skew + B's request-nonce dedup cache);
+//!   block-list; gated-context `messages:read` UCAN re-bound to `subscriber_did`
+//!   (B is authoritative — Prepare-A on the host cannot validate against B's
+//!   UCAN/revocation store); clamp the config (incl. the `expires_at_ms`
+//!   lifetime ceiling); aggregate cap. Then it captures `current_key_epoch`,
+//!   `granted_at_ms`, the grant `nonce`/`timestamp_ms` at the SINGLE Prepare-B
+//!   instant, signs the [`BroadcastHostingGrant`] (author key per-call), stages
+//!   the typed prepared into `saga_pending`, records the request nonce in the
+//!   dedup cache, and Class-S fail-closed persists.
+//!
+//! - **Commit-B** ([`commit_b`]) — on the BROADCAST-context actor. Persists the
+//!   [`AcceptedHostSnapshotEntry`] on the §5.15.3 sync-persisted path together
+//!   with the `MemberJoined{subscriber}` append (idempotently re-registering the
+//!   host representative under its handshake `wrapping_pubkey`). **NO key is
+//!   pushed** — the snapshot authorizes the host's later §5.14.2 HPKE pull.
+//!   Returns the byte-identical author-signed grant bytes. Idempotent by
+//!   `SagaId`.
+//!
+//! - **Commit-A** ([`commit_a`]) — on the HOST-context actor. Persists the
+//!   author-signed grant as durable proof of relay authorization + does
+//!   host-registration. Idempotent by `SagaId`.
+//!
+//! # Abort
+//!
+//! Abort is handled by the shared [`SagaPhaseMessage::Abort`](crate::context::actor::commands::SagaPhaseMessage::Abort)
+//! arm (`handlers::saga::abort`): it clears the staged `saga_pending` slot, no
+//! key, no snapshot, no append (§5.14.13 "Abort").
+//!
+//! # Error band
+//!
+//! Rejections surface as typed [`ContextError`]s carrying `SCP-SAGA-131xx`
+//! codes (the broadcast-hosting sub-block of the saga band; the leaf types use
+//! `13100-13102`, the runtime dispatch `13110-13199`).
+
+use scp_identity::DID;
+use scp_protocol::context::ContextError;
+use scp_protocol::context::broadcast::hosting_handshake::{
+    AcceptedHostSnapshotEntry, BroadcastHostConfig, BroadcastHostingGrant,
+    BroadcastHostingGrantFields, BroadcastHostingRequest, BroadcastHostingRequestFields,
+    ForwardingPolicy,
+};
+use scp_protocol::context::broadcast::{AggregateCapExceeded, BroadcastAdmission};
+use scp_protocol::context::roles::Capability;
+use scp_protocol::crypto::ucan::validate::{DEFAULT_CLOCK_SKEW_TOLERANCE_SECS, ValidationContext};
+
+use crate::context::actor::class_s::ClassSCell;
+use crate::context::actor::commands::{
+    BroadcastCommitBReply, BroadcastPrepareAReply, BroadcastPrepareBReply,
+    BroadcastPreparedAFields, BroadcastPreparedBFields, SagaPhaseMessage, SigningKeyBytes,
+};
+use crate::context::actor::deps::ActorDeps;
+use crate::context::actor::outcome::{Outcome, outcome_error_sketch};
+use crate::context::economy_logic::{ContextRevocationChecker, KeyResolverDidResolver};
+use crate::context::state::{context_id_to_bytes, require_active};
+use crate::context::supervisor::saga_journal::SagaId;
+use crate::context::supervisor::saga_prepared_state::{
+    BroadcastHostingHandshakePrepared, SagaPreparedState,
+};
+
+/// No-op nonce tracker for the gated-UCAN re-bind path. The cross-context
+/// ENVELOPE / request replay is owned separately by B's request-nonce dedup
+/// cache; the UCAN's OWN nonce is a long-lived delegation-proof concern that
+/// must not falsely trip replay on re-validation. Mirrors the accepted
+/// production `NoopNonceTracker` in `saga.rs` / `broadcast.rs`.
+struct NoopNonceTracker;
+impl scp_protocol::crypto::ucan::validate::NonceTracker for NoopNonceTracker {
+    fn check_replay(
+        &self,
+        _nonce: &str,
+        _token_expiry: u64,
+    ) -> Result<(), scp_protocol::crypto::ucan::UcanError> {
+        Ok(())
+    }
+    fn record(
+        &mut self,
+        _nonce: &str,
+        _token_expiry: u64,
+    ) -> Result<(), scp_protocol::crypto::ucan::UcanError> {
+        Ok(())
+    }
+}
+
+/// Dispatch a broadcast hosting-handshake [`SagaPhaseMessage`] against actor
+/// state. Routed here from `handlers::saga::dispatch`'s broadcast partition.
+pub(crate) async fn dispatch(
+    cell: &mut ClassSCell,
+    deps: &ActorDeps,
+    cmd: SagaPhaseMessage,
+) -> Outcome<()> {
+    match cmd {
+        SagaPhaseMessage::BroadcastPrepareA {
+            saga_id,
+            host_context_id,
+            broadcast_context_id,
+            subscriber_did,
+            wrapping_pubkey,
+            requested_config_bytes,
+            ucan,
+            nonce,
+            timestamp_ms,
+            requester_signing_key,
+            reply,
+        } => {
+            let req = BroadcastPrepareARequest {
+                saga_id,
+                host_context_id,
+                broadcast_context_id,
+                subscriber_did,
+                wrapping_pubkey,
+                requested_config_bytes,
+                ucan,
+                nonce,
+                timestamp_ms,
+                requester_signing_key,
+            };
+            prepare_a(cell, deps, req, reply).await
+        }
+        SagaPhaseMessage::BroadcastPrepareB {
+            saga_id,
+            broadcast_context_id,
+            request_bytes,
+            author_signing_key,
+            reply,
+        } => {
+            prepare_b(
+                cell,
+                deps,
+                &saga_id,
+                broadcast_context_id,
+                &request_bytes,
+                &author_signing_key,
+                reply,
+            )
+            .await
+        }
+        SagaPhaseMessage::BroadcastCommitB { saga_id, reply } => {
+            commit_b(cell, deps, &saga_id, reply).await
+        }
+        SagaPhaseMessage::BroadcastCommitA {
+            saga_id,
+            grant_bytes,
+            reply,
+        } => commit_a(cell, deps, &saga_id, &grant_bytes, reply).await,
+        SagaPhaseMessage::BroadcastCommitAReack { saga_id, reply } => {
+            // READ-ONLY crash-recovery witness check: report whether Commit-A's
+            // durable grant proof for this SagaId is present.
+            let present = cell.class_s.bcast_committed_grants.contains_key(&saga_id);
+            let _ = reply.send(Ok(present));
+            Outcome::ok(())
+        }
+        // The top-level `dispatch` router only forwards the four broadcast
+        // phases here; any other variant reaching this point is a router
+        // partition bug. Route it back through the xctx saga dispatcher (which
+        // owns those variants' reply shapes) rather than panicking (ADR-049 §10).
+        // Boxed because this is an indirect cycle back through `saga::dispatch`
+        // (statically unreachable in practice; the box satisfies the recursive
+        // async-fn requirement without a panic path).
+        other => Box::pin(super::saga::dispatch(cell, deps, other)).await,
+    }
+}
+
+/// Owned Prepare-A request fields (boxed payload destructure), so the dispatch
+/// router stays within the per-function argument budget.
+struct BroadcastPrepareARequest {
+    saga_id: SagaId,
+    host_context_id: [u8; 32],
+    broadcast_context_id: [u8; 32],
+    subscriber_did: DID,
+    wrapping_pubkey: [u8; 32],
+    requested_config_bytes: Vec<u8>,
+    ucan: Option<String>,
+    nonce: [u8; 16],
+    timestamp_ms: u64,
+    requester_signing_key: SigningKeyBytes,
+}
+
+// ---------------------------------------------------------------------------
+// Prepare-A (host side)
+// ---------------------------------------------------------------------------
+
+/// Prepare-A (spec §5.14.13) — runs on the HOST-context actor. Confirms the host
+/// context is Active and the requester holds `messages:read` for B, stages the
+/// forwarding-registry entry, signs the request, and Class-S fail-closed
+/// persists the staged slot.
+async fn prepare_a(
+    cell: &mut ClassSCell,
+    deps: &ActorDeps,
+    req: BroadcastPrepareARequest,
+    reply: BroadcastPrepareAReply,
+) -> Outcome<()> {
+    // (1) Host context Active.
+    if let Err(e) = require_active(&cell.handle) {
+        let sketch = outcome_error_sketch(&e);
+        let _ = reply.send(Err(e));
+        return Outcome::err(sketch);
+    }
+
+    // (2) The requester holds `messages:read` for B. The host representative is
+    //     a §5.14.3 subscriber of B holding `messages:read`; on the host-context
+    //     actor we confirm the requester is a known member of the host context
+    //     (the channel-authenticated initiator the supervisor bound) before
+    //     staging. The authoritative gated-UCAN / membership check against B
+    //     itself runs at Prepare-B (B is authoritative — §5.14.13).
+    let requester = req.subscriber_did.as_ref();
+    let holds_read = cell
+        .role_state
+        .member_capabilities
+        .get(requester)
+        .is_some_and(|caps| {
+            caps.contains(&Capability::MessagesRead) || caps.contains(&Capability::MessagesWrite)
+        })
+        || cell.membership.contains(requester);
+    if !holds_read {
+        let e = ContextError::PermissionDenied(format!(
+            "SCP-SAGA-13110: broadcast hosting Prepare-A — requester '{requester}' is not a \
+             member of the host context authorized to relay (messages:read required)"
+        ));
+        let sketch = outcome_error_sketch(&e);
+        let _ = reply.send(Err(e));
+        return Outcome::err(sketch);
+    }
+
+    // (3) Decode the requested config, build + sign the request with the
+    //     requester's Active Signing Key (supplied per-call).
+    let requested_config: BroadcastHostConfig =
+        match serde_json::from_slice(&req.requested_config_bytes) {
+            Ok(c) => c,
+            Err(e) => {
+                let err = ContextError::InvalidState(format!(
+                    "SCP-SAGA-13111: broadcast hosting Prepare-A — requested_config is not a \
+                     decodable BroadcastHostConfig: {e}"
+                ));
+                let sketch = outcome_error_sketch(&err);
+                let _ = reply.send(Err(err));
+                return Outcome::err(sketch);
+            }
+        };
+
+    let signing_key = req.requester_signing_key.to_signing_key();
+    let signed_request = match BroadcastHostingRequest::sign(
+        &signing_key,
+        BroadcastHostingRequestFields {
+            host_context_id: req.host_context_id,
+            broadcast_context_id: req.broadcast_context_id,
+            subscriber_did: req.subscriber_did.0.clone(),
+            wrapping_pubkey: req.wrapping_pubkey,
+            requested_config,
+            ucan: req.ucan.clone(),
+            nonce: req.nonce,
+            timestamp_ms: req.timestamp_ms,
+        },
+    ) {
+        Ok(r) => r,
+        Err(e) => {
+            let err = ContextError::CryptoFailed(format!(
+                "SCP-SAGA-13112: broadcast hosting Prepare-A — request signing failed: {e}"
+            ));
+            let sketch = outcome_error_sketch(&err);
+            let _ = reply.send(Err(err));
+            return Outcome::err(sketch);
+        }
+    };
+
+    let request_bytes = match scp_protocol::jcs::to_vec(&signed_request) {
+        Ok(b) => b,
+        Err(e) => {
+            let err = ContextError::CryptoFailed(format!(
+                "SCP-SAGA-13113: broadcast hosting Prepare-A — request serialization failed: {e}"
+            ));
+            let sketch = outcome_error_sketch(&err);
+            let _ = reply.send(Err(err));
+            return Outcome::err(sketch);
+        }
+    };
+
+    // (4) Stage the host-side forwarding-registry entry into `saga_pending`
+    //     (Class S — its loss before Commit must roll the saga back cleanly). On
+    //     the host side the prepared records the public ids + the wrapping key;
+    //     the granted-config / epoch fields are B-side and left as the request's
+    //     for the host record (the host record is its own staged forwarding
+    //     entry, not the authoritative grant snapshot).
+    let prepared = BroadcastHostingHandshakePrepared {
+        host_context_id: req.host_context_id,
+        broadcast_context_id: req.broadcast_context_id,
+        subscriber_did: req.subscriber_did.clone(),
+        wrapping_pubkey: req.wrapping_pubkey,
+        // The host stages no authoritative grant values; these are filled by B at
+        // Prepare-B and delivered to the host as the signed grant at Commit-A.
+        key_epoch_at_grant: 0,
+        granted_at_ms: 0,
+        grant_nonce: req.nonce,
+        grant_timestamp_ms: req.timestamp_ms,
+        broadcast_host_config_bytes: req.requested_config_bytes.clone(),
+    };
+
+    // Stage under a fail-closed Class-S persist that AUTO-RESTORES the Class-S
+    // sub-struct (incl. `saga_pending`) on persist failure, so a host-side
+    // Prepare-A whose persist did not land rolls the staged slot back cleanly
+    // and a retry re-stages (no orphaned forwarding registration).
+    let host_hex = hex::encode(req.host_context_id);
+    let saga_id = req.saga_id.clone();
+    if let Err(persist_err) = cell.commit_class_s_restore(deps, &host_hex, |mut view| {
+        view.class_s_mut().saga_pending.insert(
+            saga_id.clone(),
+            SagaPreparedState::BroadcastHostingHandshake(prepared),
+        );
+        Ok::<(), ContextError>(())
+    }) {
+        let sketch = outcome_error_sketch(&persist_err);
+        let _ = reply.send(Err(persist_err));
+        return Outcome::err(sketch);
+    }
+
+    let _ = reply.send(Ok(BroadcastPreparedAFields { request_bytes }));
+    Outcome::ok_mutated(())
+}
+
+// ---------------------------------------------------------------------------
+// Prepare-B (broadcast side, authoritative)
+// ---------------------------------------------------------------------------
+
+/// Prepare-B (spec §5.14.13) — runs on the BROADCAST-context actor.
+async fn prepare_b(
+    cell: &mut ClassSCell,
+    deps: &ActorDeps,
+    saga_id: &SagaId,
+    broadcast_context_id: [u8; 32],
+    request_bytes: &[u8],
+    author_signing_key: &SigningKeyBytes,
+    reply: BroadcastPrepareBReply,
+) -> Outcome<()> {
+    match prepare_b_inner(
+        cell,
+        deps,
+        saga_id,
+        broadcast_context_id,
+        request_bytes,
+        author_signing_key,
+    )
+    .await
+    {
+        Ok((fields, mutated)) => {
+            let _ = reply.send(Ok(fields));
+            if mutated {
+                Outcome::ok_mutated(())
+            } else {
+                Outcome::ok(())
+            }
+        }
+        Err((e, mutated)) => {
+            let sketch = outcome_error_sketch(&e);
+            let _ = reply.send(Err(e));
+            if mutated {
+                Outcome::err_mutated(sketch)
+            } else {
+                Outcome::err(sketch)
+            }
+        }
+    }
+}
+
+/// Prepare-B body. Returns `(fields, mutated)` on accept; `(error, mutated)` on
+/// reject. `mutated` is `true` only once Class-S state has been touched.
+#[allow(clippy::too_many_lines)] // the full ordered §5.14.13 Prepare-B gate set
+async fn prepare_b_inner(
+    cell: &mut ClassSCell,
+    deps: &ActorDeps,
+    saga_id: &SagaId,
+    broadcast_context_id: [u8; 32],
+    request_bytes: &[u8],
+    author_signing_key: &SigningKeyBytes,
+) -> Result<(BroadcastPreparedBFields, bool), (ContextError, bool)> {
+    let no_mut = |e: ContextError| (e, false);
+
+    // (0) Context Active + decode the request.
+    require_active(&cell.handle).map_err(no_mut)?;
+    let request: BroadcastHostingRequest = serde_json::from_slice(request_bytes).map_err(|e| {
+        no_mut(ContextError::InvalidState(format!(
+            "SCP-SAGA-13120: broadcast hosting Prepare-B — request is not a decodable \
+             BroadcastHostingRequest: {e}"
+        )))
+    })?;
+
+    // Target-context binding: the request's broadcast_context_id MUST equal B's
+    // own context (so a request for a different B cannot induce a side effect).
+    if request.broadcast_context_id != broadcast_context_id {
+        return Err(no_mut(ContextError::InvalidState(format!(
+            "SCP-SAGA-13121: broadcast hosting Prepare-B — request broadcast_context_id does \
+             not match this broadcast context '{}'",
+            hex::encode(broadcast_context_id)
+        ))));
+    }
+
+    // (1) Signature bound to subscriber_did. The Active Signing Key for
+    //     subscriber_did is resolved via DID resolution; the request is valid
+    //     only if signed by the DID it claims.
+    let subscriber_did = DID(request.subscriber_did.clone());
+    let subscriber_key = (deps.key_resolver)(
+        &subscriber_did,
+        scp_protocol::identity::SigningKeyId::Active,
+    )
+    .ok_or_else(|| {
+        no_mut(ContextError::PermissionDenied(format!(
+            "SCP-SAGA-13122: broadcast hosting Prepare-B — cannot resolve the Active Signing \
+             Key for requester '{subscriber_did}' (DID resolution failed)"
+        )))
+    })?;
+    request.verify(&subscriber_key).map_err(|e| {
+        no_mut(ContextError::PermissionDenied(format!(
+            "SCP-SAGA-13123: broadcast hosting Prepare-B — request signature does not verify \
+             against the Active Signing Key of '{subscriber_did}': {e}"
+        )))
+    })?;
+
+    // (2) Freshness: timestamp within §9.14 skew. (Read-only — the nonce-dedup
+    //     check + record run together under the single fail-closed persist
+    //     below so an accepted nonce is durably recorded.)
+    let now_ms = deps.clock.now_millis();
+    let now_secs = deps.clock.now_secs();
+    let skew_ms = DEFAULT_CLOCK_SKEW_TOLERANCE_SECS.saturating_mul(1000);
+    let within_skew = request.timestamp_ms <= now_ms.saturating_add(skew_ms)
+        && request.timestamp_ms >= now_ms.saturating_sub(skew_ms);
+    if !within_skew {
+        return Err(no_mut(ContextError::PermissionDenied(format!(
+            "SCP-SAGA-13124: broadcast hosting Prepare-B — request timestamp {} is outside the \
+             clock-skew tolerance (now {now_ms} ms)",
+            request.timestamp_ms
+        ))));
+    }
+    // Nonce-dedup READ (the record happens under the persist below). A seen
+    // nonce is a replay — reject before any side effect.
+    if cell
+        .class_s
+        .bcast_request_nonce_dedup
+        .is_replayed_read(&request.nonce, now_secs)
+    {
+        return Err(no_mut(ContextError::PermissionDenied(
+            "SCP-SAGA-13125: broadcast hosting Prepare-B — request nonce already seen (replay)"
+                .to_owned(),
+        )));
+    }
+
+    // (3) Resolve B's sole local broadcast author (whose epoch / block list / key
+    //     this grant rides) + (4) block-list + (5) gated-UCAN + (6) clamp +
+    //     (7) aggregate cap. All read-only; performed before staging.
+    let forwarding_policy_ok;
+    let granted_config;
+    let key_epoch_at_grant;
+    {
+        let bc = cell.broadcast_context.as_ref().ok_or_else(|| {
+            no_mut(ContextError::MembershipFailed(
+                "SCP-SAGA-13126: broadcast hosting Prepare-B — not a broadcast context".to_owned(),
+            ))
+        })?;
+
+        // The locally-controlled broadcast author whose epoch is captured.
+        let author_did = bc
+            .author_dids()
+            .find(|did| deps.local_dids.load().contains(&DID((*did).clone())))
+            .cloned()
+            .ok_or_else(|| {
+                no_mut(ContextError::PermissionDenied(
+                    "SCP-SAGA-13127: broadcast hosting Prepare-B — no locally-controlled \
+                     broadcast author to authorize the grant"
+                        .to_owned(),
+                ))
+            })?;
+
+        // (4) Block-list: a blocked DID is refused.
+        if bc.is_blocked(&author_did, subscriber_did.as_ref()) {
+            return Err(no_mut(ContextError::PermissionDenied(format!(
+                "SCP-SAGA-13128: broadcast hosting Prepare-B — requester '{subscriber_did}' is \
+                 blocked by author '{author_did}'"
+            ))));
+        }
+
+        // (5) Gated context: validate the request's `messages:read` UCAN re-bound
+        //     to subscriber_did (B is authoritative — current, unrevoked check).
+        if bc.admission() == BroadcastAdmission::Gated {
+            let ucan_str = request.ucan.as_deref().ok_or_else(|| {
+                no_mut(ContextError::PermissionDenied(
+                    "SCP-SAGA-13129: broadcast hosting Prepare-B — gated broadcast requires a \
+                     messages:read UCAN; none presented (Unauthorized)"
+                        .to_owned(),
+                ))
+            })?;
+            validate_gated_read_ucan(cell, deps, bc, ucan_str, &subscriber_did)?;
+        }
+
+        // (6) Clamp the requested config into B's permitted ranges → granted.
+        //     The `expires_at_ms` lifetime ceiling (granted_at_ms +
+        //     max_grant_lifetime_ms) is applied after capturing granted_at_ms.
+        let mut clamped = BroadcastHostConfig::clamp(&request.requested_config);
+        let cap = bc.aggregate_cap();
+        // Lower bound: expires_at_ms MUST be strictly greater than granted_at_ms
+        // (a born-expired grant is rejected, not clamped — §5.14.13).
+        if clamped.expires_at_ms <= now_ms {
+            return Err(no_mut(ContextError::PermissionDenied(format!(
+                "SCP-SAGA-13130: broadcast hosting Prepare-B — requested expires_at_ms {} is \
+                 not strictly after the Prepare-B clock {now_ms} (ConfigInvalid)",
+                clamped.expires_at_ms
+            ))));
+        }
+        // Upper bound: clamp down to granted_at_ms + max_grant_lifetime_ms.
+        let lifetime_ceiling = now_ms.saturating_add(cap.max_grant_lifetime_ms);
+        if clamped.expires_at_ms > lifetime_ceiling {
+            clamped.expires_at_ms = lifetime_ceiling;
+        }
+
+        // (7) Aggregate cap — sum over OTHER live entries (excluding this pair).
+        bc.check_aggregate_cap(
+            &hex::encode(request.host_context_id),
+            subscriber_did.as_ref(),
+            clamped.max_subscribers,
+            clamped.max_forward_rate_per_minute,
+        )
+        .map_err(|e| no_mut(aggregate_cap_error(&e)))?;
+
+        // forwarding_policy: a routing-stripped policy must not break the signed
+        // §5.14.5 envelope verification. Both ForwardingPolicy variants preserve
+        // the inner signed envelope by construction (RoutingStripped touches only
+        // outer-envelope routing hints), so any well-formed policy is admissible.
+        forwarding_policy_ok = matches!(
+            clamped.forwarding_policy,
+            ForwardingPolicy::Verbatim | ForwardingPolicy::RoutingStripped
+        );
+        key_epoch_at_grant = bc.author_key_epoch(&author_did).unwrap_or(0);
+        granted_config = clamped;
+    }
+    if !forwarding_policy_ok {
+        return Err(no_mut(ContextError::InvalidState(
+            "SCP-SAGA-13131: broadcast hosting Prepare-B — grant forwarding_policy would break \
+             §5.14.5 envelope verification"
+                .to_owned(),
+        )));
+    }
+
+    // (8) Capture the replay-deterministic values at the SINGLE Prepare-B
+    //     instant and sign the grant.
+    let granted_at_ms = now_ms;
+    let grant_nonce = request.nonce; // echoes the request's nonce (never freshly drawn)
+    let grant_timestamp_ms = granted_at_ms;
+    let author_sk = author_signing_key.to_signing_key();
+    let grant = BroadcastHostingGrant::sign(
+        &author_sk,
+        BroadcastHostingGrantFields {
+            host_context_id: request.host_context_id,
+            broadcast_context_id: request.broadcast_context_id,
+            subscriber_did: request.subscriber_did.clone(),
+            wrapping_pubkey: request.wrapping_pubkey,
+            granted_config: granted_config.clone(),
+            current_key_epoch: key_epoch_at_grant,
+            nonce: grant_nonce,
+            timestamp_ms: grant_timestamp_ms,
+        },
+    )
+    .map_err(|e| {
+        no_mut(ContextError::CryptoFailed(format!(
+            "SCP-SAGA-13132: broadcast hosting Prepare-B — grant signing failed: {e}"
+        )))
+    })?;
+    let grant_bytes = scp_protocol::jcs::to_vec(&grant).map_err(|e| {
+        no_mut(ContextError::CryptoFailed(format!(
+            "SCP-SAGA-13133: broadcast hosting Prepare-B — grant serialization failed: {e}"
+        )))
+    })?;
+    let granted_config_bytes = granted_config.to_jcs().map_err(|e| {
+        no_mut(ContextError::CryptoFailed(format!(
+            "SCP-SAGA-13134: broadcast hosting Prepare-B — granted_config JCS failed: {e}"
+        )))
+    })?;
+
+    // (9) Stage the typed prepared + record the request nonce under ONE
+    //     fail-closed Class-S persist with OPPOSITE rollback directions:
+    //       (a) `bcast_request_nonce_dedup.record` — KEEP on persist failure
+    //           (un-recording re-opens the §5.14.13 replay window).
+    //       (b) `saga_pending.insert` — RESTORE on persist failure (a slot that
+    //           did not durably land must be removed so a retry re-stages).
+    let prepared = BroadcastHostingHandshakePrepared {
+        host_context_id: request.host_context_id,
+        broadcast_context_id: request.broadcast_context_id,
+        subscriber_did,
+        wrapping_pubkey: request.wrapping_pubkey,
+        key_epoch_at_grant,
+        granted_at_ms,
+        grant_nonce,
+        grant_timestamp_ms,
+        broadcast_host_config_bytes: granted_config_bytes,
+    };
+
+    let broadcast_hex = hex::encode(broadcast_context_id);
+    let nonce = request.nonce;
+    let staged_saga_id = saga_id.clone();
+    if let Err(persist_err) = cell.commit_class_s_keep_restore_split(
+        deps,
+        &broadcast_hex,
+        |class_s| class_s.saga_pending.keys().cloned().collect::<Vec<_>>(),
+        |mut view| {
+            let class_s = view.class_s_mut();
+            class_s.bcast_request_nonce_dedup.evict_expired(now_secs);
+            class_s.bcast_request_nonce_dedup.record(nonce, now_secs);
+            class_s.saga_pending.insert(
+                staged_saga_id.clone(),
+                SagaPreparedState::BroadcastHostingHandshake(prepared),
+            );
+            Ok::<(), ContextError>(())
+        },
+        |class_s, keys_before| {
+            class_s.saga_pending.retain(|k, _| keys_before.contains(k));
+        },
+    ) {
+        return Err((persist_err, true));
+    }
+
+    Ok((
+        BroadcastPreparedBFields {
+            grant_bytes,
+            key_epoch_at_grant,
+            granted_at_ms,
+        },
+        true,
+    ))
+}
+
+/// Validate a gated-context `messages:read` UCAN re-bound to the presenting
+/// subscriber, against THIS broadcast context (spec §5.14.13 / §5.14.4). Runs
+/// the full ADR-016 pipeline (signature, delegation chain, **revocation**,
+/// expiry, capability match), so a token revoked between subscribe and
+/// handshake is refused here.
+fn validate_gated_read_ucan(
+    cell: &ClassSCell,
+    deps: &ActorDeps,
+    bc: &scp_protocol::context::broadcast::BroadcastContext,
+    ucan_str: &str,
+    subscriber_did: &DID,
+) -> Result<(), (ContextError, bool)> {
+    let token = scp_protocol::crypto::ucan::validate::parse_ucan(ucan_str).map_err(|e| {
+        (
+            ContextError::PermissionDenied(format!(
+                "SCP-SAGA-13135: broadcast hosting Prepare-B — gated UCAN is not parseable: {e} \
+                 (Unauthorized)"
+            )),
+            false,
+        )
+    })?;
+    let ceiling = cell.role_state.ceiling().to_ucan_string_set();
+    let creator_did = cell.role_state.creator_did.clone();
+    let revoked = cell.governance.revoked_spending_ucan_cids.clone();
+    let did_resolver = KeyResolverDidResolver::new(&deps.key_resolver);
+    let revocation_checker = ContextRevocationChecker {
+        revoked_cids: &revoked,
+    };
+    let mut nonce_tracker = NoopNonceTracker;
+    let mut ctx = ValidationContext {
+        did_resolver: &did_resolver,
+        nonce_tracker: &mut nonce_tracker,
+        revocation_checker: &revocation_checker,
+        proof_resolver: &cell.xctx_ucan_proofs,
+        ceiling: &ceiling,
+        context_creator_did: &creator_did,
+        // Re-bind to the requester: the token's audience MUST be subscriber_did.
+        presenting_agent_did: subscriber_did.as_ref(),
+        clock_skew_tolerance_secs: DEFAULT_CLOCK_SKEW_TOLERANCE_SECS,
+        clock: deps.clock.as_ref(),
+    };
+    bc.validate_messages_read_ucan_public(&token, &mut ctx)
+        .map_err(|e| {
+            (
+                ContextError::PermissionDenied(format!(
+                    "SCP-SAGA-13135: broadcast hosting Prepare-B — gated messages:read UCAN \
+                     re-validation failed (re-bound to '{subscriber_did}'): {e} (Unauthorized)"
+                )),
+                false,
+            )
+        })
+}
+
+/// Map an [`AggregateCapExceeded`] to a typed `SCP-SAGA-13136` rejection.
+fn aggregate_cap_error(e: &AggregateCapExceeded) -> ContextError {
+    let detail = match e {
+        AggregateCapExceeded::Subscribers {
+            would_be_total,
+            ceiling,
+        } => format!("subscribers {would_be_total} > aggregate ceiling {ceiling}"),
+        AggregateCapExceeded::ForwardRate {
+            would_be_total,
+            ceiling,
+        } => format!("forward-rate {would_be_total} > aggregate ceiling {ceiling}"),
+    };
+    ContextError::PermissionDenied(format!(
+        "SCP-SAGA-13136: broadcast hosting Prepare-B — aggregate cap exceeded ({detail}) \
+         (AggregateCapExceeded)"
+    ))
+}
+
+// ---------------------------------------------------------------------------
+// Commit-B (broadcast side)
+// ---------------------------------------------------------------------------
+
+/// Commit-B (spec §5.14.13) — runs on the BROADCAST-context actor. Persists the
+/// `AcceptedHostSnapshotEntry` + the `MemberJoined{subscriber}` append on the
+/// sync-persisted path; returns the byte-identical author-signed grant bytes.
+/// Idempotent by `SagaId`.
+async fn commit_b(
+    cell: &mut ClassSCell,
+    deps: &ActorDeps,
+    saga_id: &SagaId,
+    reply: BroadcastCommitBReply,
+) -> Outcome<()> {
+    match commit_b_inner(cell, deps, saga_id).await {
+        Ok(grant_bytes) => {
+            let _ = reply.send(Ok(grant_bytes));
+            Outcome::ok_mutated(())
+        }
+        Err(e) => {
+            let sketch = outcome_error_sketch(&e);
+            let _ = reply.send(Err(e));
+            Outcome::err(sketch)
+        }
+    }
+}
+
+async fn commit_b_inner(
+    cell: &mut ClassSCell,
+    deps: &ActorDeps,
+    saga_id: &SagaId,
+) -> Result<Vec<u8>, ContextError> {
+    // Resolve the staged prepared (Class S). Absence ⇒ a replayed Commit whose
+    // saga was already cleared, OR a Commit with no Prepare — fail fast.
+    let prepared = match cell.class_s.saga_pending.get(saga_id) {
+        Some(SagaPreparedState::BroadcastHostingHandshake(p)) => clone_prepared(p),
+        Some(_) => {
+            return Err(ContextError::InvalidState(format!(
+                "SCP-SAGA-13140: broadcast hosting Commit-B — staged slot for saga '{}' is not a \
+                 broadcast hosting handshake",
+                saga_id.0
+            )));
+        }
+        None => {
+            return Err(ContextError::InvalidState(format!(
+                "SCP-SAGA-13141: broadcast hosting Commit-B — no staged prepared for saga '{}' \
+                 (Prepare-B did not land or was already committed)",
+                saga_id.0
+            )));
+        }
+    };
+
+    let granted_config: BroadcastHostConfig =
+        serde_json::from_slice(&prepared.broadcast_host_config_bytes).map_err(|e| {
+            ContextError::InvalidState(format!(
+                "SCP-SAGA-13142: broadcast hosting Commit-B — staged granted_config is not \
+                 decodable: {e}"
+            ))
+        })?;
+
+    let entry = AcceptedHostSnapshotEntry {
+        host_context_id: prepared.host_context_id,
+        subscriber_did: prepared.subscriber_did.0.clone(),
+        wrapping_pubkey: prepared.wrapping_pubkey,
+        granted_config,
+        granted_at_ms: prepared.granted_at_ms,
+        key_epoch_at_grant: prepared.key_epoch_at_grant,
+        saga_id: saga_id.0.clone(),
+    };
+
+    // Re-sign the byte-identical grant from the staged replay-deterministic
+    // values so Commit-B returns the SAME grant on a crash replay. The grant is
+    // signed by the broadcast author; on a replay the author key is NOT
+    // available to Commit-B (it rode Prepare-B), so the grant bytes must be
+    // reconstructable from staged state WITHOUT re-signing. We therefore return
+    // the grant the FSM already holds (from Prepare-B's reply) — Commit-B does
+    // not re-sign. Instead Commit-B's reply is the grant bytes the FSM passes
+    // back; the FSM is the byte-source. Commit-B persists the snapshot + append
+    // and acks; the grant returned here is reconstructed from the snapshot for
+    // the FSM's convenience, but the AUTHORITATIVE grant the host holds is the
+    // one B signed at Prepare-B and the FSM forwards. We return the staged
+    // grant config bytes so the FSM can confirm consistency. (Grant bytes are
+    // carried by the FSM from Prepare-B; see the supervisor.)
+    let context_id = cell.handle.context_id().to_owned();
+    let context_id_bytes = context_id_to_bytes(&context_id);
+    let subscriber_did = prepared.subscriber_did.clone();
+    let granted_at_secs = prepared.granted_at_ms / 1000;
+
+    // Persist the AcceptedHostSnapshotEntry (Class S — §5.15.3 sync path) +
+    // idempotently register the host representative as a subscriber + clear the
+    // staged slot, all under ONE fail-closed persist. The broadcast snapshot
+    // (carrying accepted_hosts) is persisted fail-closed inside this closure.
+    let staged_id = saga_id.clone();
+    let entry_for_persist = entry.clone();
+    let subscriber_for_persist = subscriber_did.clone();
+    // Commit-B runs under the fail-closed Class-S combinator (the accepted-host
+    // snapshot + MemberJoined append + slot clear are §5.15.3 sync-persisted).
+    // The `ClassSMut` view's `rest_mut()` reaches the whole `&mut
+    // PerContextState` (sound here precisely because the combinator persists
+    // fail-closed), so the broadcast-context + membership Class-C mutations and
+    // the Class-S slot clear all land atomically under ONE persist.
+    cell.commit_class_s_keep(deps, &context_id, |mut view| {
+        let granted_at_ms = entry_for_persist.granted_at_ms;
+        let state = view.rest_mut();
+        // (a) Upsert the accepted-host snapshot entry + idempotently register
+        //     the host representative as a subscriber under its handshake
+        //     wrapping_pubkey (an already-registered subscriber is an idempotent
+        //     update, NOT a duplicate-membership error — §5.14.13).
+        {
+            let bc = state.broadcast_context.as_mut().ok_or_else(|| {
+                ContextError::MembershipFailed(
+                    "SCP-SAGA-13143: broadcast hosting Commit-B — not a broadcast context"
+                        .to_owned(),
+                )
+            })?;
+            bc.upsert_accepted_host(entry_for_persist.clone());
+            bc.register_host_subscriber(subscriber_for_persist.as_ref(), granted_at_ms / 1000);
+        }
+        // (b) MemberJoined{subscriber} into the membership roster (idempotent —
+        //     add_member overwrites an existing entry).
+        state.membership.add_member(
+            subscriber_for_persist.clone(),
+            "subscriber".to_owned(),
+            vec![],
+        );
+        // (c) Clear the staged slot (Commit consumed it).
+        state.class_s.saga_pending.remove(&staged_id);
+        Ok::<(), ContextError>(())
+    })?;
+
+    // Persist the broadcast snapshot fail-closed (the accepted_hosts registry is
+    // sync-persisted per §5.15.3). A failure here means the snapshot did not
+    // durably land — surface it so the FSM retries the idempotent Commit.
+    if let Some(bc) = cell.broadcast_context.as_ref() {
+        let snapshot = bc.to_snapshot();
+        deps.persistence
+            .persist_broadcast(&context_id, &snapshot)
+            .map_err(|e| {
+                ContextError::InvalidState(format!(
+                    "SCP-SAGA-13144: broadcast hosting Commit-B — fail-closed broadcast snapshot \
+                     persist failed: {e}"
+                ))
+            })?;
+    }
+
+    // MemberJoined event-log append (§5.14.3). Committer-assigned leaf timestamp
+    // = the convergent granted_at instant (seconds), so honest members converge.
+    deps.event_log.append_context_event(
+        &context_id_bytes,
+        scp_event_log::EventType::MemberJoined,
+        subscriber_did.as_ref(),
+        granted_at_secs,
+    )?;
+
+    // Return the snapshot-derived grant bytes purely as a consistency echo; the
+    // AUTHORITATIVE grant the host receives is the Prepare-B-signed grant the
+    // FSM carries to Commit-A.
+    scp_protocol::jcs::to_vec(&entry).map_err(|e| {
+        ContextError::CryptoFailed(format!(
+            "SCP-SAGA-13145: broadcast hosting Commit-B — snapshot echo serialization failed: {e}"
+        ))
+    })
+}
+
+// ---------------------------------------------------------------------------
+// Commit-A (host side)
+// ---------------------------------------------------------------------------
+
+/// Commit-A (spec §5.14.13) — runs on the HOST-context actor. Persists the
+/// author-signed grant as durable relay-authorization proof + clears the staged
+/// host slot. Idempotent by `SagaId`.
+async fn commit_a(
+    cell: &mut ClassSCell,
+    deps: &ActorDeps,
+    saga_id: &SagaId,
+    grant_bytes: &[u8],
+    reply: tokio::sync::oneshot::Sender<Result<(), ContextError>>,
+) -> Outcome<()> {
+    // Decode + sanity-check the grant (it is non-secret durable proof).
+    if let Err(e) = serde_json::from_slice::<BroadcastHostingGrant>(grant_bytes) {
+        let err = ContextError::InvalidState(format!(
+            "SCP-SAGA-13150: broadcast hosting Commit-A — grant is not a decodable \
+             BroadcastHostingGrant: {e}"
+        ));
+        let sketch = outcome_error_sketch(&err);
+        let _ = reply.send(Err(err));
+        return Outcome::err(sketch);
+    }
+
+    // Persist the grant as durable proof (the host's forwarding registry) +
+    // clear the staged host slot. Idempotent by SagaId: a replay re-acks.
+    let context_id = cell.handle.context_id().to_owned();
+    let staged_id = saga_id.clone();
+    let grant_owned = grant_bytes.to_vec();
+    if let Err(persist_err) = cell.commit_class_s_keep(deps, &context_id, |mut view| {
+        let class_s = view.class_s_mut();
+        // Record the grant as durable relay-authorization proof keyed by SagaId.
+        class_s
+            .bcast_committed_grants
+            .insert(staged_id.clone(), grant_owned.clone());
+        class_s.saga_pending.remove(&staged_id);
+        Ok::<(), ContextError>(())
+    }) {
+        let sketch = outcome_error_sketch(&persist_err);
+        let _ = reply.send(Err(persist_err));
+        return Outcome::err_mutated(sketch);
+    }
+
+    let _ = reply.send(Ok(()));
+    Outcome::ok_mutated(())
+}
+
+/// Clone a [`BroadcastHostingHandshakePrepared`] (the live type is non-`Clone`
+/// because the wrapping enum carries the §9.4.3 non-derive barrier; this is a
+/// field-wise copy of the public, non-bearer broadcast prepared).
+fn clone_prepared(p: &BroadcastHostingHandshakePrepared) -> BroadcastHostingHandshakePrepared {
+    BroadcastHostingHandshakePrepared {
+        host_context_id: p.host_context_id,
+        broadcast_context_id: p.broadcast_context_id,
+        subscriber_did: p.subscriber_did.clone(),
+        wrapping_pubkey: p.wrapping_pubkey,
+        key_epoch_at_grant: p.key_epoch_at_grant,
+        granted_at_ms: p.granted_at_ms,
+        grant_nonce: p.grant_nonce,
+        grant_timestamp_ms: p.grant_timestamp_ms,
+        broadcast_host_config_bytes: p.broadcast_host_config_bytes.clone(),
+    }
+}

--- a/crates/scp-runtime/src/context/actor/handlers/mod.rs
+++ b/crates/scp-runtime/src/context/actor/handlers/mod.rs
@@ -28,6 +28,7 @@
 )]
 
 pub mod broadcast;
+pub mod broadcast_saga;
 pub mod economy;
 pub mod governance;
 pub mod lifecycle;

--- a/crates/scp-runtime/src/context/actor/handlers/saga.rs
+++ b/crates/scp-runtime/src/context/actor/handlers/saga.rs
@@ -181,6 +181,15 @@ pub(crate) async fn dispatch(
     cmd: SagaPhaseMessage,
 ) -> Outcome<()> {
     match cmd {
+        // Broadcast hosting-handshake phases (spec §5.14.13) route to their own
+        // handler module to keep this router and the xctx bodies separate.
+        broadcast @ (SagaPhaseMessage::BroadcastPrepareA { .. }
+        | SagaPhaseMessage::BroadcastPrepareB { .. }
+        | SagaPhaseMessage::BroadcastCommitB { .. }
+        | SagaPhaseMessage::BroadcastCommitA { .. }
+        | SagaPhaseMessage::BroadcastCommitAReack { .. }) => {
+            crate::context::actor::handlers::broadcast_saga::dispatch(cell, deps, broadcast).await
+        }
         // Prepare arms (slice 3b) route to a dedicated helper to keep this
         // router within the per-function line budget.
         prepare @ (SagaPhaseMessage::PrepareA { .. } | SagaPhaseMessage::PrepareB { .. }) => {
@@ -260,6 +269,15 @@ async fn dispatch_prepare_phase(
         SagaPhaseMessage::Abort { reply, .. } => misrouted(reply, "Abort"),
         SagaPhaseMessage::EmitDivergenceMarker { reply, .. } => {
             misrouted(reply, "EmitDivergenceMarker")
+        }
+        // Broadcast phases are partitioned to `broadcast_saga::dispatch` and
+        // never reach this xctx prepare router. Statically unreachable.
+        SagaPhaseMessage::BroadcastPrepareA { reply, .. } => misrouted(reply, "BroadcastPrepareA"),
+        SagaPhaseMessage::BroadcastPrepareB { reply, .. } => misrouted(reply, "BroadcastPrepareB"),
+        SagaPhaseMessage::BroadcastCommitB { reply, .. } => misrouted(reply, "BroadcastCommitB"),
+        SagaPhaseMessage::BroadcastCommitA { reply, .. } => misrouted(reply, "BroadcastCommitA"),
+        SagaPhaseMessage::BroadcastCommitAReack { reply, .. } => {
+            misrouted(reply, "BroadcastCommitAReack")
         }
     }
 }
@@ -347,6 +365,16 @@ async fn dispatch_commit_phase(
         // shape (NEVER panic — ADR-049 §10 handler panic ban).
         SagaPhaseMessage::PrepareA { reply, .. } => misrouted(reply, "PrepareA"),
         SagaPhaseMessage::PrepareB { reply, .. } => misrouted(reply, "PrepareB"),
+        // Broadcast hosting-handshake phases are partitioned to
+        // `broadcast_saga::dispatch` in the top-level `dispatch` router and
+        // never reach here. Statically unreachable; misroute per reply shape.
+        SagaPhaseMessage::BroadcastPrepareA { reply, .. } => misrouted(reply, "BroadcastPrepareA"),
+        SagaPhaseMessage::BroadcastPrepareB { reply, .. } => misrouted(reply, "BroadcastPrepareB"),
+        SagaPhaseMessage::BroadcastCommitB { reply, .. } => misrouted(reply, "BroadcastCommitB"),
+        SagaPhaseMessage::BroadcastCommitA { reply, .. } => misrouted(reply, "BroadcastCommitA"),
+        SagaPhaseMessage::BroadcastCommitAReack { reply, .. } => {
+            misrouted(reply, "BroadcastCommitAReack")
+        }
     }
 }
 

--- a/crates/scp-runtime/src/context/actor/mod.rs
+++ b/crates/scp-runtime/src/context/actor/mod.rs
@@ -745,8 +745,27 @@ impl ContextActor {
             ContextCommand::SagaPhase(
                 SagaPhaseMessage::CommitA { reply, .. }
                 | SagaPhaseMessage::Abort { reply, .. }
-                | SagaPhaseMessage::EmitDivergenceMarker { reply, .. },
+                | SagaPhaseMessage::EmitDivergenceMarker { reply, .. }
+                | SagaPhaseMessage::BroadcastCommitA { reply, .. },
             ) => {
+                ack_not_impl(reply, "saga_phase");
+            }
+            // Broadcast hosting-handshake phases reply distinct outcome shapes
+            // (Prepare-A → BroadcastPreparedAFields, Prepare-B →
+            // BroadcastPreparedBFields, Commit-B → grant bytes), so each is acked
+            // separately on the skeleton (stateless) actor.
+            ContextCommand::SagaPhase(SagaPhaseMessage::BroadcastPrepareA { reply, .. }) => {
+                ack_not_impl(reply, "saga_phase");
+            }
+            ContextCommand::SagaPhase(SagaPhaseMessage::BroadcastPrepareB { reply, .. }) => {
+                ack_not_impl(reply, "saga_phase");
+            }
+            ContextCommand::SagaPhase(SagaPhaseMessage::BroadcastCommitB { reply, .. }) => {
+                ack_not_impl(reply, "saga_phase");
+            }
+            ContextCommand::SagaPhase(SagaPhaseMessage::BroadcastCommitAReack {
+                reply, ..
+            }) => {
                 ack_not_impl(reply, "saga_phase");
             }
             ContextCommand::LifecycleControl(LifecycleControlCommand::Pause { reply }) => {

--- a/crates/scp-runtime/src/context/actor/state.rs
+++ b/crates/scp-runtime/src/context/actor/state.rs
@@ -888,6 +888,45 @@ pub struct ClassSState {
         SagaId,
         crate::context::supervisor::saga_prepared_state::CallerReservationRecord,
     >,
+
+    /// Broadcast-side (B-owned) anti-replay nonce-dedup cache for the broadcast
+    /// hosting-handshake `BroadcastHostingRequest` (spec §5.14.13 "Freshness",
+    /// mirroring §6.2.2 discovery discipline). Keyed by the request's 16-byte
+    /// `nonce`; bounded 10,000-entry / 5-minute-TTL / oldest-first eviction (the
+    /// same [`NonceDedup`] discipline as [`Self::xctx_nonce_dedup`]).
+    ///
+    /// **The broadcast author — the Prepare-B verifying party — owns this
+    /// cache.** The freshness/replay state lives where the authorization
+    /// decision is made: Prepare-A runs on the host's actor and cannot
+    /// authoritatively dedup against B's state. Prepare-B rejects a duplicate
+    /// `nonce` and records a fresh one on accept. Only the REQUEST is
+    /// dedup-checked — the grant's `nonce` echoes the request's and is never
+    /// independently dedup'd (§5.14.13 "Freshness").
+    ///
+    /// **Class-S persisted — crash survival is load-bearing.** Captured into the
+    /// Class-S snapshot and rehydrated on restore: a crash between accept and the
+    /// coalesce-window persist would clear the seen-nonce set and re-open the
+    /// §5.14.13 replay window (a captured signed request replayed into repeated
+    /// re-grants). Distinct from [`Self::xctx_nonce_dedup`] (the cross-context
+    /// tool-saga envelope cache) so the two protocols' replay state never
+    /// cross-contaminate.
+    pub(crate) bcast_request_nonce_dedup: NonceDedup,
+
+    /// Host-side (A-owned) durable proof of relay authorization for committed
+    /// broadcast hosting handshakes, keyed by `SagaId` (spec §5.14.13 Commit-A:
+    /// "A persists it as its durable proof of relay authorization"). Commit-A
+    /// inserts the author-signed `BroadcastHostingGrant` bytes (JCS) here as the
+    /// idempotency witness; a replayed Commit-A finds the witness and re-acks
+    /// without re-persisting. The host can present this author-signed grant to
+    /// prove which recipient key the author empowered (amplification-
+    /// accountability non-repudiation).
+    ///
+    /// **Class S** — synchronously persisted fail-closed (ADR-049 §9), the same
+    /// `SagaId`-witness discipline as [`Self::xctx_committed_invocations`]: a
+    /// crash that rolled the witness back behind an acked Commit-A would lose the
+    /// durable relay-authorization proof. Survives same-node restore; dropped on
+    /// cross-node export/import (a foreign saga must never drive local replay).
+    pub(crate) bcast_committed_grants: std::collections::HashMap<SagaId, Vec<u8>>,
 }
 
 /// Lossless, `Clone`-able mirror of [`ClassSState`] (ADR-049 §9).
@@ -925,6 +964,13 @@ pub struct ClassSStateSnapshot {
         SagaId,
         crate::context::supervisor::saga_prepared_state::CallerReservationRecord,
     >,
+    /// `(nonce → first-seen-secs)` entries of [`ClassSState::bcast_request_nonce_dedup`].
+    pub(crate) bcast_request_nonce_dedup_entries: HashMap<[u8; 16], u64>,
+    /// TTL of [`ClassSState::bcast_request_nonce_dedup`], captured so restore
+    /// rebuilds the same replay window via [`NonceDedup::from_entries_with_ttl`].
+    pub(crate) bcast_request_nonce_dedup_ttl_secs: u64,
+    /// Mirror of [`ClassSState::bcast_committed_grants`].
+    pub(crate) bcast_committed_grants: std::collections::HashMap<SagaId, Vec<u8>>,
 }
 
 #[allow(
@@ -953,6 +999,9 @@ impl ClassSState {
             xctx_committed_outputs: self.xctx_committed_outputs.clone(),
             xctx_committed_invocations: self.xctx_committed_invocations.clone(),
             xctx_caller_reservations: self.xctx_caller_reservations.clone(),
+            bcast_request_nonce_dedup_entries: self.bcast_request_nonce_dedup.entries(),
+            bcast_request_nonce_dedup_ttl_secs: self.bcast_request_nonce_dedup.ttl_secs(),
+            bcast_committed_grants: self.bcast_committed_grants.clone(),
         }
     }
 
@@ -972,6 +1021,11 @@ impl ClassSState {
         self.xctx_committed_outputs = snap.xctx_committed_outputs;
         self.xctx_committed_invocations = snap.xctx_committed_invocations;
         self.xctx_caller_reservations = snap.xctx_caller_reservations;
+        self.bcast_request_nonce_dedup = NonceDedup::from_entries_with_ttl(
+            snap.bcast_request_nonce_dedup_entries,
+            snap.bcast_request_nonce_dedup_ttl_secs,
+        );
+        self.bcast_committed_grants = snap.bcast_committed_grants;
     }
 }
 
@@ -1456,6 +1510,13 @@ impl PerContextState {
                 xctx_committed_outputs: HashMap::new(),
                 xctx_committed_invocations: std::collections::HashSet::new(),
                 xctx_caller_reservations: std::collections::HashMap::new(),
+                // Same production TTL discipline as `xctx_nonce_dedup` (strictly
+                // longer than the freshness skew) so the broadcast handshake's
+                // anti-replay window matches prod in handler tests.
+                bcast_request_nonce_dedup: NonceDedup::with_ttl(
+                    crate::context::actor::handlers::saga::SAGA_NONCE_DEDUP_TTL_SECS,
+                ),
+                bcast_committed_grants: HashMap::new(),
             },
             pending_broadcast_publishes: HashMap::new(),
             welcome_scratchpad: None,
@@ -1685,7 +1746,11 @@ mod tests {
             xctx_committed_outputs,
             xctx_committed_invocations,
             xctx_caller_reservations,
+            bcast_request_nonce_dedup,
+            bcast_committed_grants,
         } = class_s;
+        let _ = &bcast_request_nonce_dedup;
+        let _ = &bcast_committed_grants;
 
         // Identity + lifetime.
         assert_eq!(context_id, [3u8; 32]);
@@ -1807,6 +1872,8 @@ mod tests {
                     xctx_committed_outputs: _,
                     xctx_committed_invocations: _,
                     xctx_caller_reservations: _,
+                    bcast_request_nonce_dedup: _,
+                    bcast_committed_grants: _,
                 },
             pending_broadcast_publishes: _,
             welcome_scratchpad: _,

--- a/crates/scp-runtime/src/context/broadcast_helpers.rs
+++ b/crates/scp-runtime/src/context/broadcast_helpers.rs
@@ -877,5 +877,10 @@ fn build_snapshot_from_state(state: &PerContextState) -> crate::context::state::
         xctx_caller_reservations:
             crate::context::messaging_helpers::xctx_caller_reservations_snapshot(state),
         xctx_nonce_dedup: crate::context::messaging_helpers::xctx_nonce_dedup_snapshot(state),
+        bcast_request_nonce_dedup:
+            crate::context::messaging_helpers::bcast_request_nonce_dedup_snapshot(state),
+        bcast_committed_grants: crate::context::messaging_helpers::bcast_committed_grants_snapshot(
+            state,
+        ),
     }
 }

--- a/crates/scp-runtime/src/context/export_import.rs
+++ b/crates/scp-runtime/src/context/export_import.rs
@@ -819,6 +819,10 @@ fn strip_snapshot_for_public(snapshot: &ContextSnapshot) -> Result<ContextSnapsh
         // B's freshness/replay cache has no authority on a foreign node and a
         // fresh node starts its own replay window — dropped from the export.
         xctx_nonce_dedup: HashMap::new(),
+        // Broadcast hosting-handshake request dedup cache — same drop-on-export
+        // discipline (§5.14.13 freshness state is local to the granting node).
+        bcast_request_nonce_dedup: HashMap::new(),
+        bcast_committed_grants: HashMap::new(),
     })
 }
 
@@ -1015,6 +1019,10 @@ mod tests {
             // B's freshness/replay cache has no authority on a foreign node and
             // a fresh node starts its own replay window — dropped from export.
             xctx_nonce_dedup: HashMap::new(),
+            // Broadcast hosting-handshake request dedup cache — dropped on
+            // export for the same local-authority reason (§5.14.13).
+            bcast_request_nonce_dedup: HashMap::new(),
+            bcast_committed_grants: HashMap::new(),
         }
     }
 

--- a/crates/scp-runtime/src/context/lifecycle_helpers.rs
+++ b/crates/scp-runtime/src/context/lifecycle_helpers.rs
@@ -1533,6 +1533,13 @@ pub async fn create_context(
             xctx_nonce_dedup: scp_protocol::crypto::sender_keys::NonceDedup::with_ttl(
                 crate::context::actor::handlers::saga::SAGA_NONCE_DEDUP_TTL_SECS,
             ),
+            // Broadcast hosting-handshake request anti-replay cache (spec
+            // §5.14.13 "Freshness"): fresh on create, same TTL discipline as the
+            // cross-context dedup above.
+            bcast_request_nonce_dedup: scp_protocol::crypto::sender_keys::NonceDedup::with_ttl(
+                crate::context::actor::handlers::saga::SAGA_NONCE_DEDUP_TTL_SECS,
+            ),
+            bcast_committed_grants: HashMap::new(),
         },
         pending_broadcast_publishes: HashMap::new(),
         welcome_scratchpad: None,
@@ -2207,6 +2214,13 @@ pub async fn import_context(
             xctx_nonce_dedup: scp_protocol::crypto::sender_keys::NonceDedup::with_ttl(
                 crate::context::actor::handlers::saga::SAGA_NONCE_DEDUP_TTL_SECS,
             ),
+            // Broadcast hosting-handshake request anti-replay cache (spec
+            // §5.14.13 "Freshness"): fresh on create, same TTL discipline as the
+            // cross-context dedup above.
+            bcast_request_nonce_dedup: scp_protocol::crypto::sender_keys::NonceDedup::with_ttl(
+                crate::context::actor::handlers::saga::SAGA_NONCE_DEDUP_TTL_SECS,
+            ),
+            bcast_committed_grants: HashMap::new(),
         },
         pending_broadcast_publishes: HashMap::new(),
         welcome_scratchpad: None,
@@ -2711,6 +2725,20 @@ pub async fn restore_context(
             // abort can reverse the caller deduction + void the escrow from the
             // record. Dropped on cross-node import (caller economy is local).
             xctx_caller_reservations: ctx_snapshot.xctx_caller_reservations,
+            // ADR-049 §9 Class S: same-node restore REHYDRATES B's broadcast
+            // hosting-handshake request anti-replay cache (spec §5.14.13
+            // "Freshness") so a crash inside the dedup TTL cannot re-open a
+            // captured-signed-request replay. Cross-node import drops it (the
+            // snapshot field is empty). Rehydrated with the same SAGA dedup TTL.
+            bcast_request_nonce_dedup:
+                scp_protocol::crypto::sender_keys::NonceDedup::from_entries_with_ttl(
+                    ctx_snapshot.bcast_request_nonce_dedup,
+                    crate::context::actor::handlers::saga::SAGA_NONCE_DEDUP_TTL_SECS,
+                ),
+            // ADR-049 §9 Class S: same-node restore REHYDRATES the host-side
+            // durable hosting-grant proofs (spec §5.14.13 Commit-A). Cross-node
+            // import drops them (the snapshot field is empty).
+            bcast_committed_grants: ctx_snapshot.bcast_committed_grants,
         },
         pending_broadcast_publishes: HashMap::new(),
         welcome_scratchpad: None,

--- a/crates/scp-runtime/src/context/manager_methods.rs
+++ b/crates/scp-runtime/src/context/manager_methods.rs
@@ -372,5 +372,10 @@ pub fn snapshot_context(ctx: &PerContextState) -> ContextSnapshot {
         xctx_caller_reservations:
             crate::context::messaging_helpers::xctx_caller_reservations_snapshot(ctx),
         xctx_nonce_dedup: crate::context::messaging_helpers::xctx_nonce_dedup_snapshot(ctx),
+        bcast_request_nonce_dedup:
+            crate::context::messaging_helpers::bcast_request_nonce_dedup_snapshot(ctx),
+        bcast_committed_grants: crate::context::messaging_helpers::bcast_committed_grants_snapshot(
+            ctx,
+        ),
     }
 }

--- a/crates/scp-runtime/src/context/messaging_helpers.rs
+++ b/crates/scp-runtime/src/context/messaging_helpers.rs
@@ -2615,6 +2615,8 @@ pub fn build_snapshot_from_state(
         // the caller deduction + void the escrow without the in-memory carrier.
         xctx_caller_reservations: xctx_caller_reservations_snapshot(state),
         xctx_nonce_dedup: xctx_nonce_dedup_snapshot(state),
+        bcast_request_nonce_dedup: bcast_request_nonce_dedup_snapshot(state),
+        bcast_committed_grants: bcast_committed_grants_snapshot(state),
     }
 }
 
@@ -2722,6 +2724,26 @@ pub(in crate::context) fn xctx_nonce_dedup_snapshot(
     state: &PerContextState,
 ) -> std::collections::HashMap<[u8; 16], u64> {
     state.class_s.xctx_nonce_dedup.entries()
+}
+
+/// Build the Class-S snapshot projection of the actor's B-owned broadcast
+/// hosting-handshake request nonce-dedup cache (spec §5.14.13 "Freshness";
+/// ADR-049 §9). Same crash-survival discipline as [`xctx_nonce_dedup_snapshot`]:
+/// persisting it makes the request-replay window survive a restart; same-node
+/// restore rehydrates it, cross-node export/import drops it to empty.
+pub(in crate::context) fn bcast_request_nonce_dedup_snapshot(
+    state: &PerContextState,
+) -> std::collections::HashMap<[u8; 16], u64> {
+    state.class_s.bcast_request_nonce_dedup.entries()
+}
+
+/// Build the Class-S snapshot projection of the host-side durable broadcast
+/// hosting-grant proofs (spec §5.14.13 Commit-A; ADR-049 §9). Same crash-survival
+/// discipline as the other Class-S saga witnesses.
+pub(in crate::context) fn bcast_committed_grants_snapshot(
+    state: &PerContextState,
+) -> std::collections::HashMap<crate::context::supervisor::saga_journal::SagaId, Vec<u8>> {
+    state.class_s.bcast_committed_grants.clone()
 }
 
 // ---------------------------------------------------------------------------

--- a/crates/scp-runtime/src/context/providers/persistence.rs
+++ b/crates/scp-runtime/src/context/providers/persistence.rs
@@ -237,6 +237,8 @@ mod tests {
             xctx_committed_invocations: std::collections::HashSet::new(),
             xctx_caller_reservations: std::collections::HashMap::new(),
             xctx_nonce_dedup: std::collections::HashMap::new(),
+            bcast_request_nonce_dedup: std::collections::HashMap::new(),
+            bcast_committed_grants: std::collections::HashMap::new(),
         }
     }
 

--- a/crates/scp-runtime/src/context/state.rs
+++ b/crates/scp-runtime/src/context/state.rs
@@ -1097,6 +1097,31 @@ pub struct ContextSnapshot {
     /// snapshots deserialize as an empty cache.
     #[serde(default)]
     pub xctx_nonce_dedup: HashMap<[u8; 16], u64>,
+
+    /// Broadcast-side (B-owned) anti-replay nonce-dedup cache for the broadcast
+    /// hosting-handshake `BroadcastHostingRequest` (spec §5.14.13 "Freshness"),
+    /// keyed by the request's 16-byte `nonce`.
+    ///
+    /// **Class S** — synchronously-persisted, fail-closed, mirroring
+    /// [`Self::xctx_nonce_dedup`]. If it reinitialized empty on restore, an actor
+    /// crash inside the TTL window would let an attacker re-submit a captured
+    /// signed `BroadcastHostingRequest` into repeated re-grants. Same-node
+    /// restore REHYDRATES it (TTL rebuilt from `SAGA_NONCE_DEDUP_TTL_SECS`);
+    /// cross-node import / `strip_snapshot_for_public` DROP it to empty — B's
+    /// freshness state has no authority on a foreign node. `#[serde(default)]`
+    /// so legacy / stripped snapshots deserialize as an empty cache.
+    #[serde(default)]
+    pub bcast_request_nonce_dedup: HashMap<[u8; 16], u64>,
+
+    /// Host-side (A-owned) durable proof of relay authorization for committed
+    /// broadcast hosting handshakes, keyed by `SagaId` string → author-signed
+    /// `BroadcastHostingGrant` bytes (spec §5.14.13 Commit-A). **Class S** —
+    /// synchronously persisted, so a crash after an acked Commit-A does not lose
+    /// the relay-authorization proof. Same-node restore rehydrates it; cross-node
+    /// import / strip DROP it (a foreign saga must never drive local replay).
+    /// `#[serde(default)]` so legacy / stripped snapshots deserialize as empty.
+    #[serde(default)]
+    pub bcast_committed_grants: HashMap<crate::context::supervisor::saga_journal::SagaId, Vec<u8>>,
 }
 
 /// Default routing variant for degraded / pre-routing-field snapshots.

--- a/crates/scp-runtime/src/context/supervisor/handle.rs
+++ b/crates/scp-runtime/src/context/supervisor/handle.rs
@@ -81,7 +81,10 @@ impl SupervisorHandle {
     /// See `Supervisor::start_saga`. Commit 6: always
     /// [`ContextError::NotImplemented`].
     pub async fn start_saga(&self, input: SagaInput) -> Result<SagaOutput, ContextError> {
-        self.supervisor.start_saga(input).await
+        // `Box::pin` the FSM future: the saga driver now carries two optional
+        // per-saga contexts (cross-context + broadcast), pushing the future over
+        // the `large_futures` lint threshold when held inline (clippy).
+        Box::pin(self.supervisor.start_saga(input)).await
     }
 
     /// Snapshot the local-DIDs set. Returned as an `Arc` so callers read

--- a/crates/scp-runtime/src/context/supervisor/saga_prepared_state.rs
+++ b/crates/scp-runtime/src/context/supervisor/saga_prepared_state.rs
@@ -381,21 +381,146 @@ impl CrossContextToolInvocationPrepared {
 // Broadcast hosting handshake
 // ---------------------------------------------------------------------------
 
-/// Staged state for a broadcast-hosting-handshake saga.
+/// Staged state for a broadcast-hosting-handshake saga (spec §5.14.13
+/// `BroadcastHostingHandshakePrepared` field table).
 ///
-/// **Not bearer-bearing.** Public per spec §5.14.2: the host context, the
-/// broadcast context, the subscriber DID, and the negotiated host config
-/// (encoded opaquely here pending the broadcast handler's migration).
+/// **Not bearer-bearing.** Every field is PUBLIC per spec §5.14.13 (the
+/// broadcast key is delivered out-of-band post-Commit via the §5.14.2 HPKE
+/// pull, never through this saga). `mark_resolved(secret_bearing=false)`.
+///
+/// # Replay-deterministic fields captured at the single Prepare-B instant
+///
+/// The B-side captures `key_epoch_at_grant`, `granted_at_ms`, `grant_nonce`,
+/// `grant_timestamp_ms`, and the clamped `broadcast_host_config_bytes` ALL at
+/// the one Prepare-B instant precisely so a Commit replayed after a crash
+/// re-sends the BYTE-IDENTICAL author-signed `BroadcastHostingGrant` (whose
+/// preimage covers `RawBytes16(nonce)`, `U64(timestamp_ms)`, `U64(current_key_epoch)`,
+/// and `VarBytes(jcs(granted_config))`) and writes the ORIGINAL epoch /
+/// `granted_at_ms` into the snapshot — never a later (advanced) epoch or a
+/// fresh-clock variant divergent from the copy the host received on the first
+/// Commit attempt (§5.14.13 *Prepare / Commit / Abort*, *staged-field rows*).
+///
+/// # Serialization
+///
+/// Deliberately NOT `Serialize` (the wrapping [`SagaPreparedState`] enum carries
+/// the §9.4.3 non-derive barrier). Journal evidence is produced via the explicit
+/// [`BroadcastHostingHandshakePreparedWire`] mirror, reached through
+/// [`BroadcastHostingHandshakePrepared::to_evidence_bytes`] /
+/// [`BroadcastHostingHandshakePrepared::from_evidence_bytes`], mirroring the
+/// [`CrossContextToolInvocationPrepared`] discipline above.
 pub struct BroadcastHostingHandshakePrepared {
-    /// The hosting context ID.
+    /// The hosting (relaying) context ID — raw 32-byte digest (§5.14.13 id-form).
     pub host_context_id: [u8; 32],
-    /// The broadcast context ID being hosted.
+    /// The broadcast (hosted) context ID — raw 32-byte digest.
     pub broadcast_context_id: [u8; 32],
-    /// The subscriber DID requesting hosting.
+    /// The host representative DID requesting hosting (holds `messages:read` for B).
     pub subscriber_did: DID,
-    /// Encoded `BroadcastHostConfig` bytes. Concrete type is wired in
-    /// when the broadcast handler migrates to the actor model.
+    /// The X25519 recipient key the post-grant broadcast key is sealed under,
+    /// echoed from the request and bound into the author-signed grant. The
+    /// §5.14.2 delivery MUST seal ONLY to this grant-committed key.
+    pub wrapping_pubkey: [u8; 32],
+    /// The broadcast key epoch captured at Prepare-B and bound into the grant's
+    /// `current_key_epoch`; staged so a replayed Commit writes a snapshot
+    /// `key_epoch_at_grant` matching the already-signed grant, not a later epoch.
+    pub key_epoch_at_grant: u64,
+    /// Wall-clock ms captured at Prepare-B; staged so a replayed Commit writes
+    /// the same `granted_at_ms` as the original (a fresh clock read would make
+    /// the persisted snapshot non-deterministic across replays).
+    pub granted_at_ms: u64,
+    /// The grant's 16-byte `nonce` (echoes the request's `nonce`, never freshly
+    /// drawn); staged so a replayed Commit re-sends the byte-identical grant.
+    pub grant_nonce: [u8; 16],
+    /// The grant's `timestamp_ms` captured at the same Prepare-B instant; staged
+    /// for the identical replay-determinism reason as `grant_nonce`.
+    pub grant_timestamp_ms: u64,
+    /// JCS (RFC 8785) of the CLAMPED, authoritative `granted_config` — the exact
+    /// `BroadcastHostConfig` B signs into the grant and persists into the
+    /// `AcceptedHostSnapshotEntry`, NOT the pre-clamp `requested_config`.
     pub broadcast_host_config_bytes: Vec<u8>,
+}
+
+/// `Serialize`/`Deserialize` wire mirror of the **public** fields of
+/// [`BroadcastHostingHandshakePrepared`], used to produce the journal
+/// `evidence` (spec §5.14.13 "Public-metadata journaling": the `MessagePack` of
+/// the public staged fields). The actor-side
+/// [`BroadcastHostingHandshakePrepared`] is deliberately non-`Serialize`
+/// because the wrapping [`SagaPreparedState`] enum carries the §9.4.3
+/// non-derive barrier; this explicit mirror is the sanctioned serialization
+/// path, matching the [`CrossContextToolInvocationPreparedWire`] discipline
+/// above.
+///
+/// All fields are public plan-metadata classified **public** — there is no
+/// §9.4.3 secret commitment (`mark_resolved(secret_bearing=false)`). `DID` is
+/// carried as its canonical string.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub(in crate::context) struct BroadcastHostingHandshakePreparedWire {
+    /// The raw 32-byte hosting context id.
+    pub host_context_id: [u8; 32],
+    /// The raw 32-byte broadcast context id.
+    pub broadcast_context_id: [u8; 32],
+    /// `subscriber_did.0`.
+    pub subscriber_did: String,
+    /// The grant-committed X25519 recipient key.
+    pub wrapping_pubkey: [u8; 32],
+    /// Prepare-B-captured broadcast key epoch (matches the grant's `current_key_epoch`).
+    pub key_epoch_at_grant: u64,
+    /// Prepare-B-captured wall-clock ms.
+    pub granted_at_ms: u64,
+    /// The grant's echoed 16-byte nonce.
+    pub grant_nonce: [u8; 16],
+    /// The grant's `timestamp_ms`.
+    pub grant_timestamp_ms: u64,
+    /// JCS of the clamped `granted_config`.
+    pub broadcast_host_config_bytes: Vec<u8>,
+}
+
+impl BroadcastHostingHandshakePrepared {
+    /// Encode the public prepared state to its journal `evidence` bytes —
+    /// `MessagePack` of the [`BroadcastHostingHandshakePreparedWire`] mirror
+    /// (spec §5.14.13 "Public-metadata journaling"). Classified **public**; the
+    /// supervisor wraps these bytes in the standard `Zeroizing` envelope for
+    /// uniformity only.
+    ///
+    /// # Errors
+    ///
+    /// Returns the `rmp_serde` encode error string if serialization fails.
+    pub(in crate::context) fn to_evidence_bytes(&self) -> Result<Vec<u8>, String> {
+        let wire = BroadcastHostingHandshakePreparedWire {
+            host_context_id: self.host_context_id,
+            broadcast_context_id: self.broadcast_context_id,
+            subscriber_did: self.subscriber_did.0.clone(),
+            wrapping_pubkey: self.wrapping_pubkey,
+            key_epoch_at_grant: self.key_epoch_at_grant,
+            granted_at_ms: self.granted_at_ms,
+            grant_nonce: self.grant_nonce,
+            grant_timestamp_ms: self.grant_timestamp_ms,
+            broadcast_host_config_bytes: self.broadcast_host_config_bytes.clone(),
+        };
+        rmp_serde::to_vec_named(&wire).map_err(|e| format!("encode: {e}"))
+    }
+
+    /// Decode public prepared state from its journal `evidence` bytes,
+    /// reversing [`Self::to_evidence_bytes`].
+    ///
+    /// # Errors
+    ///
+    /// Returns the `rmp_serde` decode error string if `bytes` is not a valid
+    /// `MessagePack` encoding of the wire mirror.
+    pub(in crate::context) fn from_evidence_bytes(bytes: &[u8]) -> Result<Self, String> {
+        let wire: BroadcastHostingHandshakePreparedWire =
+            rmp_serde::from_slice(bytes).map_err(|e| format!("decode: {e}"))?;
+        Ok(Self {
+            host_context_id: wire.host_context_id,
+            broadcast_context_id: wire.broadcast_context_id,
+            subscriber_did: DID(wire.subscriber_did),
+            wrapping_pubkey: wire.wrapping_pubkey,
+            key_epoch_at_grant: wire.key_epoch_at_grant,
+            granted_at_ms: wire.granted_at_ms,
+            grant_nonce: wire.grant_nonce,
+            grant_timestamp_ms: wire.grant_timestamp_ms,
+            broadcast_host_config_bytes: wire.broadcast_host_config_bytes,
+        })
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -487,8 +612,11 @@ pub struct CrossContextToolInvocationSnapshot {
 }
 
 /// Public snapshot payload for
-/// [`SagaPreparedState::BroadcastHostingHandshake`] (§5.14.2; all fields
+/// [`SagaPreparedState::BroadcastHostingHandshake`] (§5.14.13; all fields
 /// public, not bearer-bearing).
+///
+/// Mirrors the staged-state field table so a same-node crash-recovery restore
+/// re-drives a byte-identical Commit.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct BroadcastHostingHandshakeSnapshot {
     /// The raw 32-byte hosting context id.
@@ -497,8 +625,17 @@ pub struct BroadcastHostingHandshakeSnapshot {
     pub broadcast_context_id: [u8; 32],
     /// `subscriber_did.0`.
     pub subscriber_did: String,
-    /// Encoded `BroadcastHostConfig` bytes (opaque pending the broadcast
-    /// handler's actor migration).
+    /// The grant-committed X25519 recipient key.
+    pub wrapping_pubkey: [u8; 32],
+    /// Prepare-B-captured broadcast key epoch.
+    pub key_epoch_at_grant: u64,
+    /// Prepare-B-captured wall-clock ms.
+    pub granted_at_ms: u64,
+    /// The grant's echoed 16-byte nonce.
+    pub grant_nonce: [u8; 16],
+    /// The grant's `timestamp_ms`.
+    pub grant_timestamp_ms: u64,
+    /// JCS of the clamped `granted_config`.
     pub broadcast_host_config_bytes: Vec<u8>,
 }
 
@@ -536,6 +673,11 @@ impl SagaPreparedStateSnapshot {
                     host_context_id: inner.host_context_id,
                     broadcast_context_id: inner.broadcast_context_id,
                     subscriber_did: inner.subscriber_did.0.clone(),
+                    wrapping_pubkey: inner.wrapping_pubkey,
+                    key_epoch_at_grant: inner.key_epoch_at_grant,
+                    granted_at_ms: inner.granted_at_ms,
+                    grant_nonce: inner.grant_nonce,
+                    grant_timestamp_ms: inner.grant_timestamp_ms,
                     broadcast_host_config_bytes: inner.broadcast_host_config_bytes.clone(),
                 })
             }
@@ -573,6 +715,11 @@ impl SagaPreparedStateSnapshot {
                     host_context_id: snap.host_context_id,
                     broadcast_context_id: snap.broadcast_context_id,
                     subscriber_did: DID(snap.subscriber_did),
+                    wrapping_pubkey: snap.wrapping_pubkey,
+                    key_epoch_at_grant: snap.key_epoch_at_grant,
+                    granted_at_ms: snap.granted_at_ms,
+                    grant_nonce: snap.grant_nonce,
+                    grant_timestamp_ms: snap.grant_timestamp_ms,
                     broadcast_host_config_bytes: snap.broadcast_host_config_bytes,
                 })
             }
@@ -875,24 +1022,56 @@ mod tests {
         assert_eq!(back, wire);
     }
 
+    fn sample_broadcast_prepared() -> BroadcastHostingHandshakePrepared {
+        BroadcastHostingHandshakePrepared {
+            host_context_id: [6u8; 32],
+            broadcast_context_id: [7u8; 32],
+            subscriber_did: bob(),
+            wrapping_pubkey: [0x44; 32],
+            key_epoch_at_grant: 9,
+            granted_at_ms: 1_700_000_000_123,
+            grant_nonce: [0x55; 16],
+            grant_timestamp_ms: 1_700_000_000_123,
+            broadcast_host_config_bytes: vec![0xDD; 48],
+        }
+    }
+
     #[test]
     fn broadcast_hosting_handshake_constructs() {
-        let state =
-            SagaPreparedState::BroadcastHostingHandshake(BroadcastHostingHandshakePrepared {
-                host_context_id: [6u8; 32],
-                broadcast_context_id: [7u8; 32],
-                subscriber_did: bob(),
-                broadcast_host_config_bytes: vec![0xDD; 48],
-            });
+        let state = SagaPreparedState::BroadcastHostingHandshake(sample_broadcast_prepared());
         match state {
             SagaPreparedState::BroadcastHostingHandshake(inner) => {
                 assert_eq!(inner.host_context_id, [6u8; 32]);
                 assert_eq!(inner.broadcast_context_id, [7u8; 32]);
                 assert_eq!(inner.subscriber_did, bob());
+                assert_eq!(inner.wrapping_pubkey, [0x44; 32]);
+                assert_eq!(inner.key_epoch_at_grant, 9);
+                assert_eq!(inner.granted_at_ms, 1_700_000_000_123);
+                assert_eq!(inner.grant_nonce, [0x55; 16]);
+                assert_eq!(inner.grant_timestamp_ms, 1_700_000_000_123);
                 assert_eq!(inner.broadcast_host_config_bytes, vec![0xDD; 48]);
             }
             _ => panic!("wrong variant"),
         }
+    }
+
+    #[test]
+    fn broadcast_hosting_evidence_round_trips_all_fields() {
+        let original = sample_broadcast_prepared();
+        let bytes = original.to_evidence_bytes().unwrap();
+        let back = BroadcastHostingHandshakePrepared::from_evidence_bytes(&bytes).unwrap();
+        assert_eq!(back.host_context_id, original.host_context_id);
+        assert_eq!(back.broadcast_context_id, original.broadcast_context_id);
+        assert_eq!(back.subscriber_did, original.subscriber_did);
+        assert_eq!(back.wrapping_pubkey, original.wrapping_pubkey);
+        assert_eq!(back.key_epoch_at_grant, original.key_epoch_at_grant);
+        assert_eq!(back.granted_at_ms, original.granted_at_ms);
+        assert_eq!(back.grant_nonce, original.grant_nonce);
+        assert_eq!(back.grant_timestamp_ms, original.grant_timestamp_ms);
+        assert_eq!(
+            back.broadcast_host_config_bytes,
+            original.broadcast_host_config_bytes
+        );
     }
 
     /// Compile-time witnesses that the prepared-state types ARE
@@ -983,6 +1162,11 @@ mod tests {
                 host_context_id: [0x3Cu8; 32],
                 broadcast_context_id: [0x4Du8; 32],
                 subscriber_did: bob(),
+                wrapping_pubkey: [0x7Eu8; 32],
+                key_epoch_at_grant: 11,
+                granted_at_ms: 1_700_222_333_444,
+                grant_nonce: [0x6Fu8; 16],
+                grant_timestamp_ms: 1_700_222_333_444,
                 broadcast_host_config_bytes: vec![0xAB, 0xCD, 0xEF],
             });
         let mirror = SagaPreparedStateSnapshot::from_prepared(&prepared);
@@ -994,6 +1178,11 @@ mod tests {
                 assert_eq!(inner.host_context_id, [0x3Cu8; 32]);
                 assert_eq!(inner.broadcast_context_id, [0x4Du8; 32]);
                 assert_eq!(inner.subscriber_did, bob());
+                assert_eq!(inner.wrapping_pubkey, [0x7Eu8; 32]);
+                assert_eq!(inner.key_epoch_at_grant, 11);
+                assert_eq!(inner.granted_at_ms, 1_700_222_333_444);
+                assert_eq!(inner.grant_nonce, [0x6Fu8; 16]);
+                assert_eq!(inner.grant_timestamp_ms, 1_700_222_333_444);
                 assert_eq!(inner.broadcast_host_config_bytes, vec![0xAB, 0xCD, 0xEF]);
             }
             _ => panic!("wrong variant after rehydrate"),

--- a/crates/scp-runtime/src/context/supervisor/supervisor.rs
+++ b/crates/scp-runtime/src/context/supervisor/supervisor.rs
@@ -201,10 +201,13 @@ impl RestoredContexts {
 /// the target/caller Active Signing Keys the FSM needs (Agent-first API tenet:
 /// a required choice the type system can enforce must not be skippable). The
 /// generic `start_saga` therefore only ever receives the publicly-constructible
-/// variants (`StandingPairCreate` / `BroadcastHostingHandshake`, both
-/// `NotImplemented` today). External pattern-matching on
-/// `CrossContextToolInvocation { .. }` is still allowed; only construction is
-/// sealed.
+/// variants (`StandingPairCreate` — `NotImplemented` today — and
+/// `BroadcastHostingHandshake`, whose §5.14.13 saga IS wired but, like the tool
+/// saga, is driven through its dedicated
+/// [`Supervisor::start_broadcast_hosting_handshake_saga`] entry point so the FSM
+/// receives the per-call signing keys; plain `start_saga` on it is a misuse).
+/// External pattern-matching on `CrossContextToolInvocation { .. }` is still
+/// allowed; only construction is sealed.
 pub enum SagaInput {
     /// Standing-pair creation between two identities. Full field set
     /// arrives with `handlers/standing.rs` in commit 11.
@@ -909,6 +912,87 @@ pub struct SagaSigningKeys<'a> {
     /// The caller context's Active Signing Key. Signs the CALLER-side divergence
     /// marker on `NeedsRepair`.
     pub caller: &'a ed25519_dalek::SigningKey,
+}
+
+/// The wire request a §5.14.13 broadcast hosting-handshake saga rides, named so
+/// the call site cannot transpose the two `[u8; 32]` context ids.
+pub struct BroadcastHostingHandshakeRequest {
+    /// Raw 32-byte id of the host (relaying) context.
+    pub host_context_id: [u8; 32],
+    /// Raw 32-byte id of the broadcast (hosted) context.
+    pub broadcast_context_id: [u8; 32],
+    /// The host representative DID requesting hosting (holds `messages:read` for B).
+    pub subscriber_did: DID,
+    /// X25519 recipient key the post-grant broadcast key is sealed under.
+    pub wrapping_pubkey: [u8; 32],
+    /// JCS bytes of the requested `BroadcastHostConfig`.
+    pub requested_config_bytes: Vec<u8>,
+    /// `messages:read` UCAN — present iff B is a gated context.
+    pub ucan: Option<String>,
+    /// 16-byte freshness/anti-replay nonce (the grant echoes it).
+    pub nonce: [u8; 16],
+    /// Request send time in Unix milliseconds (freshness-checked at Prepare-B).
+    pub timestamp_ms: u64,
+}
+
+/// The two Active Signing Keys a §5.14.13 broadcast hosting-handshake saga signs
+/// under, named by role so the call site cannot transpose them (the same
+/// confused-deputy guard as [`SagaSigningKeys`]).
+///
+/// The keys are held by reference (the entry point clones each into the
+/// FSM-carried context); they are capabilities, NOT envelope data.
+#[derive(Debug, Clone, Copy)]
+pub struct BroadcastHostingSigningKeys<'a> {
+    /// The host representative's Active Signing Key (signs the request at Prepare-A).
+    pub subscriber: &'a ed25519_dalek::SigningKey,
+    /// The broadcast author's signing key (signs the grant at Prepare-B).
+    pub author: &'a ed25519_dalek::SigningKey,
+}
+
+/// FSM-carried context for a broadcast hosting-handshake saga (spec §5.14.13),
+/// the broadcast analogue of [`CrossContextSagaCtx`]. Threaded through
+/// `run_saga` / `run_saga_fsm` / the prepare/commit dispatch alongside the
+/// xctx ctx. Far simpler than the xctx ctx: no executor, no escrow, no
+/// divergence-marker dual-log — the broadcast saga is public-metadata-only.
+struct BroadcastSagaCtx {
+    /// Raw 32-byte host (relaying) context id (A's own context).
+    host_context_id: [u8; 32],
+    /// Raw 32-byte broadcast (hosted) context id (B's own context).
+    broadcast_context_id: [u8; 32],
+    /// The host representative DID requesting hosting.
+    subscriber_did: DID,
+    /// X25519 recipient key the post-grant broadcast key is sealed under.
+    wrapping_pubkey: [u8; 32],
+    /// JCS bytes of the requested `BroadcastHostConfig`.
+    requested_config_bytes: Vec<u8>,
+    /// `messages:read` UCAN — present iff B is a gated context.
+    ucan: Option<String>,
+    /// 16-byte freshness/anti-replay nonce.
+    nonce: [u8; 16],
+    /// Request send time in Unix milliseconds.
+    timestamp_ms: u64,
+    /// The host representative's Active Signing Key (signs the request).
+    subscriber_signing_key: ed25519_dalek::SigningKey,
+    /// The broadcast author's signing key (signs the grant).
+    author_signing_key: ed25519_dalek::SigningKey,
+    /// JCS bytes of the requester-signed request, held after Prepare-A so
+    /// Prepare-B can validate it.
+    prepared_a_request: Option<Vec<u8>>,
+    /// JCS bytes of the author-signed grant + captured replay-deterministic
+    /// values, held after Prepare-B so Commit-A can deliver the grant and the
+    /// journal evidence can be rebuilt.
+    prepared_b: Option<BroadcastPreparedBCarry>,
+}
+
+/// Prepare-B carry: the author-signed grant bytes + the captured replay-
+/// deterministic values (key epoch / granted_at_ms) the journal evidence reads.
+struct BroadcastPreparedBCarry {
+    /// JCS bytes of the author-signed `BroadcastHostingGrant`.
+    grant_bytes: Vec<u8>,
+    /// The broadcast key epoch captured at Prepare-B.
+    key_epoch_at_grant: u64,
+    /// Wall-clock ms captured at Prepare-B.
+    granted_at_ms: u64,
 }
 
 // ---------------------------------------------------------------------------
@@ -4790,10 +4874,11 @@ impl Supervisor {
     /// [`KeyCustody`](scp_platform::KeyCustody) reference that cannot
     /// cross the actor mailbox (RPITIT trait, not `dyn`-safe); use
     /// [`Self::dispatch_broadcast_command_with_custody`] for publish.
-    /// The saga-initiator variant
-    /// (`InitiateBroadcastHostingHandshake`) returns
-    /// [`ContextError::NotImplemented`] during the commit-11 window —
-    /// see `.docs/adrs/DEFERRED-commit-11-saga-use-cases.md`.
+    /// The single-actor mailbox variant `InitiateBroadcastHostingHandshake`
+    /// returns [`ContextError::NotImplemented`]: the §5.14.13 saga IS
+    /// implemented but is supervisor-driven (cross-context, per-call signing
+    /// keys) via [`Self::start_broadcast_hosting_handshake_saga`], not
+    /// reachable from a single actor's mailbox.
     ///
     /// # Errors
     ///
@@ -5084,19 +5169,21 @@ impl Supervisor {
     /// EVERY terminal — Committed, Aborted, AND NeedsRepair — plus
     /// panic-unwind, so a stuck saga never wedges unrelated disjoint sagas.
     ///
-    /// # Unwired saga use cases (pending Phase 2C)
+    /// # Saga inputs requiring a dedicated entry point
     ///
-    /// `StandingPairCreate` and `BroadcastHostingHandshake` remain spec-gapped
-    /// (their Prepare dispatch returns [`ContextError::NotImplemented`]; the FSM
-    /// transitions through `Initiated → PreparingA → Aborting → Aborted` and
-    /// surfaces the typed error). `CrossContextToolInvocation` is the wired
-    /// variant — its end-to-end Prepare/Commit dispatch over the two co-resident
-    /// participant actors lands here (spec §6.2.4); drive it via
-    /// [`Self::start_cross_context_tool_invocation_saga`], which supplies the
-    /// supervisor-side tool executor and the target's Active Signing Key.
-    /// Calling `start_saga` directly with a `CrossContextToolInvocation` input
-    /// (no executor / signing key) is a misuse: the FSM aborts at Prepare with a
-    /// typed error because it has no way to execute the tool or sign the receipt.
+    /// `StandingPairCreate` remains spec-gapped (its Prepare dispatch returns
+    /// [`ContextError::NotImplemented`]; the FSM transitions through
+    /// `Initiated → PreparingA → Aborting → Aborted` and surfaces the typed
+    /// error). The two live sagas — `CrossContextToolInvocation` (spec §6.2.4)
+    /// and `BroadcastHostingHandshake` (spec §5.14.13) — are fully wired but
+    /// require their dedicated entry points, which supply the per-call signing
+    /// keys (and, for the tool saga, the supervisor-side executor) that plain
+    /// `start_saga` cannot: drive them via
+    /// [`Self::start_cross_context_tool_invocation_saga`] and
+    /// [`Self::start_broadcast_hosting_handshake_saga`] respectively. Calling
+    /// `start_saga` directly with either input (no executor / signing key
+    /// context) is a misuse: the FSM aborts at Prepare with a typed error
+    /// because it has no way to execute the tool / sign the receipt or grant.
     ///
     /// The coordinator itself — journal writes, phase transitions, timeout/retry
     /// accounting, terminal resolution, per-participant-context-set gating — is
@@ -5108,7 +5195,8 @@ impl Supervisor {
     ///   participant context set overlaps an in-flight saga's reserved set.
     ///   Disjoint sets run concurrently (ADR-049 §3a, spec §5.15.4).
     /// - [`ContextError::NotImplemented`] for the spec-gapped
-    ///   `StandingPairCreate` / `BroadcastHostingHandshake` inputs.
+    ///   `StandingPairCreate` input, or for either live saga input dispatched
+    ///   through plain `start_saga` without its dedicated entry point's context.
     /// - [`ContextError::InvalidState`] on journal I/O failure.
     pub async fn start_saga(&self, input: SagaInput) -> Result<SagaOutput, ContextError> {
         // Per-participant-context-set reservation (ADR-049 §3a, spec §5.15.4):
@@ -5120,7 +5208,7 @@ impl Supervisor {
         // dispatch aborts with a typed error.
         let context_set = saga_participant_context_set(&input);
         let reservation = self.try_reserve_context_set(&context_set)?;
-        self.run_saga(input, None, reservation).await
+        Box::pin(self.run_saga(input, None, None, reservation)).await
     }
 
     /// Drive a cross-context tool-invocation saga (spec §6.2.4) end-to-end
@@ -5325,7 +5413,95 @@ impl Supervisor {
         // under it.
         let context_set = saga_participant_context_set(&saga_input);
         let reservation = self.try_reserve_context_set(&context_set)?;
-        self.run_saga(saga_input, Some(ctx), reservation).await
+        Box::pin(self.run_saga(saga_input, Some(ctx), None, reservation)).await
+    }
+
+    /// Drive a broadcast hosting-handshake saga (spec §5.14.13) end-to-end over
+    /// the two co-resident participant actors (host context A + broadcast
+    /// context B). Mirrors [`Self::start_cross_context_tool_invocation_saga`].
+    ///
+    /// The actor holds no signing key (ADR-049); the FSM supplies the host
+    /// representative's Active Signing Key (signs the request at Prepare-A) and
+    /// the broadcast author's signing key (signs the grant at Prepare-B)
+    /// per-call. Authorize-before-reserve (forward obligation): the initiator is
+    /// authorized over EACH named context BEFORE the saga set is reserved, so a
+    /// participant cannot reserve (and thereby deny) a victim's context.
+    ///
+    /// # Errors
+    ///
+    /// - [`ContextError::PermissionDenied`] if the initiator is not authorized
+    ///   over the host or broadcast context it names.
+    /// - [`ContextError::ActorBusy`] if the participant set overlaps an in-flight
+    ///   saga (the `{host, broadcast}` reservation; ADR-049 §3a).
+    /// - propagates the FSM's terminal error on Abort / `NeedsRepair`.
+    pub async fn start_broadcast_hosting_handshake_saga(
+        &self,
+        request: BroadcastHostingHandshakeRequest,
+        signing_keys: BroadcastHostingSigningKeys<'_>,
+    ) -> Result<SagaOutput, ContextError> {
+        let BroadcastHostingHandshakeRequest {
+            host_context_id,
+            broadcast_context_id,
+            subscriber_did,
+            wrapping_pubkey,
+            requested_config_bytes,
+            ucan,
+            nonce,
+            timestamp_ms,
+        } = request;
+
+        // Authorize-before-reserve gate 1 (host axis): the initiator MUST be a
+        // member of the host context it names (the host representative relaying
+        // B's content to the host's own members). Reject WITHOUT reserving.
+        let host_hex = hex::encode(host_context_id);
+        if !self.is_member(&host_hex, subscriber_did.as_ref()).await {
+            return Err(ContextError::PermissionDenied(format!(
+                "SCP-SAGA-13162: broadcast hosting saga initiator '{subscriber_did}' is not a \
+                 member of host context '{host_hex}' — not authorized to relay over it"
+            )));
+        }
+
+        // Authorize-before-reserve gate 2 (broadcast axis): the initiator MUST
+        // hold `messages:read` for B (be a registered §5.14.3 subscriber).
+        // Reject WITHOUT reserving so a non-subscriber cannot reserve (and
+        // thereby wedge) the victim's broadcast context's saga slot before any
+        // B-side check ran (those run inside Prepare-B, AFTER reservation).
+        let broadcast_hex = hex::encode(broadcast_context_id);
+        if !self
+            .is_member(&broadcast_hex, subscriber_did.as_ref())
+            .await
+        {
+            return Err(ContextError::PermissionDenied(format!(
+                "SCP-SAGA-13163: broadcast hosting saga initiator '{subscriber_did}' is not a \
+                 subscriber of broadcast context '{broadcast_hex}' — not authorized to request \
+                 hosting (and not authorized to reserve its saga slot)"
+            )));
+        }
+
+        let ctx = BroadcastSagaCtx {
+            host_context_id,
+            broadcast_context_id,
+            subscriber_did: subscriber_did.clone(),
+            wrapping_pubkey,
+            requested_config_bytes,
+            ucan,
+            nonce,
+            timestamp_ms,
+            subscriber_signing_key: signing_keys.subscriber.clone(),
+            author_signing_key: signing_keys.author.clone(),
+            prepared_a_request: None,
+            prepared_b: None,
+        };
+
+        let saga_input = SagaInput::BroadcastHostingHandshake {
+            host_context_id,
+            broadcast_context_id,
+            subscriber_did,
+        };
+
+        let context_set = saga_participant_context_set(&saga_input);
+        let reservation = self.try_reserve_context_set(&context_set)?;
+        Box::pin(self.run_saga(saga_input, None, Some(ctx), reservation)).await
     }
 
     /// Shared start-saga driver: run the FSM under an ALREADY-acquired
@@ -5342,6 +5518,7 @@ impl Supervisor {
         &self,
         input: SagaInput,
         xctx: Option<CrossContextSagaCtx<'_>>,
+        bctx: Option<BroadcastSagaCtx>,
         _reservation: SagaSetReservation<'_>,
     ) -> Result<SagaOutput, ContextError> {
         let saga_id = SagaId::new();
@@ -5349,6 +5526,7 @@ impl Supervisor {
         let secret_bearing = saga_input_is_secret_bearing(&input);
 
         let mut xctx = xctx;
+        let mut bctx = bctx;
         let fsm_result = self
             .run_saga_fsm(
                 saga_id.clone(),
@@ -5356,6 +5534,7 @@ impl Supervisor {
                 participants.clone(),
                 secret_bearing,
                 xctx.as_mut(),
+                bctx.as_mut(),
             )
             .await;
 
@@ -5945,12 +6124,15 @@ impl Supervisor {
     /// only a genuinely-unresolvable divergence (one-sided commit / unreachable
     /// side / non-reconstructible entry) stays `NeedsRepair` for operator repair.
     async fn recover_committing_entry(&self, entry: &JournalEntry) {
-        let resolution = match Self::reconstruct_xctx_prepared(entry) {
-            Some(prepared) => {
-                self.redrive_xctx_commit_in_progress(&entry.saga_id, &prepared)
-                    .await
-            }
-            None => CommitInProgressResolution::NeedsRepair,
+        let resolution = if let Some(prepared) = Self::reconstruct_xctx_prepared(entry) {
+            self.redrive_xctx_commit_in_progress(&entry.saga_id, &prepared)
+                .await
+        } else if let Some(bcast) = Self::reconstruct_bcast_prepared(entry) {
+            // Broadcast hosting-handshake Commit-in-progress re-drive (§5.14.13).
+            self.redrive_bcast_commit_in_progress(&entry.saga_id, &bcast)
+                .await
+        } else {
+            CommitInProgressResolution::NeedsRepair
         };
         match resolution {
             CommitInProgressResolution::Committed => {
@@ -6027,6 +6209,99 @@ impl Supervisor {
             return None;
         }
         CrossContextToolInvocationPrepared::from_evidence_bytes(entry.evidence.as_slice()).ok()
+    }
+
+    /// Reconstruct a broadcast hosting-handshake saga's prepared state from a
+    /// journal entry's `evidence` (spec §5.14.13 "Crash recovery §17.16.4").
+    ///
+    /// The evidence is the `MessagePack` of the
+    /// [`BroadcastHostingHandshakePrepared`](crate::context::supervisor::saga_prepared_state::BroadcastHostingHandshakePrepared)
+    /// wire — carrying both context ids + the replay-deterministic captured
+    /// values (grant epoch / `granted_at_ms` / nonce / timestamp + clamped config
+    /// bytes). Returns `None` if the entry is not a broadcast hosting saga (its
+    /// evidence does not decode as the broadcast wire — the distinct field-name
+    /// set keeps it from colliding with the xctx wire).
+    fn reconstruct_bcast_prepared(
+        entry: &JournalEntry,
+    ) -> Option<crate::context::supervisor::saga_prepared_state::BroadcastHostingHandshakePrepared>
+    {
+        use crate::context::supervisor::saga_prepared_state::BroadcastHostingHandshakePrepared;
+        if entry.evidence.is_empty() {
+            return None;
+        }
+        BroadcastHostingHandshakePrepared::from_evidence_bytes(entry.evidence.as_slice()).ok()
+    }
+
+    /// §17.16.4 Commit-in-progress re-drive for a broadcast hosting-handshake
+    /// saga: re-send the idempotent Commit-B (re-acks the durable
+    /// `AcceptedHostSnapshotEntry` + `MemberJoined` append, no double-delivery)
+    /// then Commit-A (re-acks the durable grant proof). Both idempotent by
+    /// `SagaId`. Returns the resolution so the caller journals the right terminal.
+    async fn redrive_bcast_commit_in_progress(
+        &self,
+        saga_id: &SagaId,
+        prepared: &crate::context::supervisor::saga_prepared_state::BroadcastHostingHandshakePrepared,
+    ) -> CommitInProgressResolution {
+        use crate::context::actor::commands::SagaPhaseMessage;
+
+        // Commit-B: re-ack the durable snapshot + append (idempotent by SagaId).
+        let broadcast_hex = hex::encode(prepared.broadcast_context_id);
+        let Some(broadcast_actor) = self.lookup(&broadcast_hex) else {
+            tracing::warn!(
+                saga_id = %saga_id.0,
+                context = %broadcast_hex,
+                "broadcast hosting saga recovery — Commit-in-progress re-drive: broadcast actor \
+                 unreachable; operator repair required"
+            );
+            return CommitInProgressResolution::NeedsRepair;
+        };
+        let commit_b_saga_id = saga_id.clone();
+        if broadcast_actor
+            .send(move |reply| {
+                ContextCommand::SagaPhase(SagaPhaseMessage::BroadcastCommitB {
+                    saga_id: commit_b_saga_id,
+                    reply,
+                })
+            })
+            .await
+            .is_err()
+        {
+            return CommitInProgressResolution::NeedsRepair;
+        }
+
+        // Commit-A: re-deliver the byte-identical grant (reconstructed from the
+        // journaled config bytes + captured epoch/timestamp). The grant the host
+        // holds is the one B signed at Prepare-B; on a cross-process replay the
+        // author key is gone, so we re-build the grant from the staged actor-side
+        // record on B is the authoritative source. Here, lacking the live ctx, we
+        // re-drive Commit-A against the host's durable grant witness: the host's
+        // `bcast_committed_grants` is keyed by SagaId and idempotently re-acked.
+        let host_hex = hex::encode(prepared.host_context_id);
+        let Some(host_actor) = self.lookup(&host_hex) else {
+            return CommitInProgressResolution::NeedsRepair;
+        };
+        // The host already holds the grant under this SagaId (Commit-A landed
+        // before the crash) OR it is re-delivered. A replayed Commit-A with empty
+        // grant bytes is a no-op iff the witness exists; to keep the re-drive
+        // self-contained we re-send the grant bytes B holds. Since the live ctx
+        // is gone, B is the grant source — but B's grant is not journaled here
+        // (only the config bytes are). The host's durable witness IS the proof, so
+        // a Commit-A whose witness is already present re-acks regardless of the
+        // re-sent bytes. Send empty bytes ⇒ the host re-acks from its witness if
+        // present, else this is a genuine divergence (NeedsRepair).
+        let host_commit_saga_id = saga_id.clone();
+        let witnessed = host_actor
+            .send(move |reply| {
+                ContextCommand::SagaPhase(SagaPhaseMessage::BroadcastCommitAReack {
+                    saga_id: host_commit_saga_id,
+                    reply,
+                })
+            })
+            .await;
+        match witnessed {
+            Ok(true) => CommitInProgressResolution::Committed,
+            Ok(false) | Err(_) => CommitInProgressResolution::NeedsRepair,
+        }
     }
 
     /// Returns the caller context id (raw-digest hex) named in a journal
@@ -6377,6 +6652,7 @@ impl Supervisor {
         participants: Vec<String>,
         secret_bearing: bool,
         mut xctx: Option<&mut CrossContextSagaCtx<'_>>,
+        mut bctx: Option<&mut BroadcastSagaCtx>,
     ) -> Result<(), ContextError> {
         // 1. Initiated
         self.append_journal(&saga_id, SagaState::Initiated, &participants, 0, &[])
@@ -6391,7 +6667,13 @@ impl Supervisor {
             .await?;
 
         let phase_a = self
-            .dispatch_prepare_phase(&saga_id, input, SagaPhase::A, xctx.as_deref_mut())
+            .dispatch_prepare_phase(
+                &saga_id,
+                input,
+                SagaPhase::A,
+                xctx.as_deref_mut(),
+                bctx.as_deref_mut(),
+            )
             .await;
         if let Err(err) = phase_a {
             self.abort_saga(
@@ -6400,6 +6682,7 @@ impl Supervisor {
                 2,
                 secret_bearing,
                 xctx.as_deref_mut(),
+                bctx.as_deref_mut(),
             )
             .await?;
             return Err(err);
@@ -6415,9 +6698,8 @@ impl Supervisor {
         //    gap. At PreparingB the caller-asserted nonce/depth stand in for B's
         //    recorded values (B records them inside Prepare-B); the Committing
         //    append below re-journals with B's authoritative recorded provenance.
-        let preparing_b_evidence = xctx
-            .as_deref()
-            .and_then(|ctx| Self::xctx_prepared_evidence_bytes(input, ctx));
+        let preparing_b_evidence =
+            Self::saga_prepared_evidence_bytes(input, xctx.as_deref(), bctx.as_deref());
         self.append_journal(
             &saga_id,
             SagaState::PreparingB,
@@ -6428,7 +6710,13 @@ impl Supervisor {
         .await?;
 
         let phase_b = self
-            .dispatch_prepare_phase(&saga_id, input, SagaPhase::B, xctx.as_deref_mut())
+            .dispatch_prepare_phase(
+                &saga_id,
+                input,
+                SagaPhase::B,
+                xctx.as_deref_mut(),
+                bctx.as_deref_mut(),
+            )
             .await;
         if let Err(err) = phase_b {
             self.abort_saga(
@@ -6437,6 +6725,7 @@ impl Supervisor {
                 3,
                 secret_bearing,
                 xctx.as_deref_mut(),
+                bctx.as_deref_mut(),
             )
             .await?;
             return Err(err);
@@ -6448,9 +6737,8 @@ impl Supervisor {
         //    Commit-in-progress crash-recovery replay (§17.16.4) reconstructs
         //    the staged `CrossContextToolInvocationPrepared` from THIS evidence
         //    to re-drive the idempotent Commit.
-        let committing_evidence = xctx
-            .as_deref()
-            .and_then(|ctx| Self::xctx_prepared_evidence_bytes(input, ctx));
+        let committing_evidence =
+            Self::saga_prepared_evidence_bytes(input, xctx.as_deref(), bctx.as_deref());
         self.append_journal(
             &saga_id,
             SagaState::Committing,
@@ -6461,7 +6749,7 @@ impl Supervisor {
         .await?;
 
         let commit_result = self
-            .commit_with_retry(&saga_id, input, xctx.as_deref_mut())
+            .commit_with_retry(&saga_id, input, xctx.as_deref_mut(), bctx)
             .await;
         match commit_result {
             Ok(()) => {
@@ -6478,52 +6766,61 @@ impl Supervisor {
                 Ok(())
             }
             Err(err) => {
-                // Commit retry exhausted — NeedsRepair (spec §6.2.4
-                // "commit_with_retry exhausts (3×) → NeedsRepair").
-                self.append_journal(&saga_id, SagaState::NeedsRepair, &participants, 4, &[])
+                self.handle_commit_failure(&saga_id, &participants, &err, xctx)
                     .await?;
-                // §17.16.4 operator-alerting metric: a saga reached the
-                // NeedsRepair terminal and requires operator repair.
-                crate::metrics::record_saga_repair_needed();
-                tracing::error!(
-                    saga_id = %saga_id,
-                    %err,
-                    "saga coordinator — commit retry exhausted, saga in NeedsRepair"
-                );
-                // Dual event-log recording (spec §6.2.4): on NeedsRepair both
-                // sides MUST emit a signed `CrossContextDivergenceMarker` (into
-                // each available log, or the supervisor-level repair journal if
-                // a side is unreachable) so a one-sided commit is durably
-                // auditable. Cross-context only; the test / spec-gapped inputs
-                // carry no `xctx`. Marks the ctx so `run_saga`'s tail leaves the
-                // escrow RESERVED (NOT auto-voided) for operator repair.
-                if let Some(ctx) = xctx {
-                    ctx.reached_needs_repair = true;
-                    // Extract the owned divergence plan SYNCHRONOUSLY (no `&ctx`
-                    // borrow crosses the `.await` — the ctx's boxed executor is
-                    // non-`Sync`), then emit. A `None` plan ⇒ Commit-B never
-                    // landed (no committed side, no divergence to mark).
-                    if let Some(plan) = Self::divergence_marker_plan(ctx) {
-                        Box::pin(self.emit_divergence_markers(&saga_id, plan)).await;
-                    } else {
-                        tracing::warn!(
-                            saga_id = %saga_id,
-                            "cross-context saga NeedsRepair with NO committed side (Commit-B never \
-                             landed); logs are clean, no divergence marker required"
-                        );
-                    }
-                }
                 Err(err)
             }
         }
+    }
+
+    /// Commit-retry exhaustion handler (spec §6.2.4 "commit_with_retry exhausts
+    /// (3×) → NeedsRepair"). Journals the `NeedsRepair` terminal, alerts, and —
+    /// for a cross-context saga — emits the dual divergence markers (the
+    /// broadcast saga is public-metadata-only and emits no divergence marker;
+    /// its `bctx` carries no committed-side dual-log). Extracted from
+    /// [`Self::run_saga_fsm`] to keep that function within the line budget.
+    async fn handle_commit_failure(
+        &self,
+        saga_id: &SagaId,
+        participants: &[String],
+        err: &ContextError,
+        xctx: Option<&mut CrossContextSagaCtx<'_>>,
+    ) -> Result<(), ContextError> {
+        self.append_journal(saga_id, SagaState::NeedsRepair, participants, 4, &[])
+            .await?;
+        crate::metrics::record_saga_repair_needed();
+        tracing::error!(
+            saga_id = %saga_id,
+            %err,
+            "saga coordinator — commit retry exhausted, saga in NeedsRepair"
+        );
+        // Dual event-log recording (spec §6.2.4): on NeedsRepair both sides MUST
+        // emit a signed `CrossContextDivergenceMarker`. Cross-context only; the
+        // test / spec-gapped / broadcast inputs carry no `xctx`. Marks the ctx so
+        // `run_saga`'s tail leaves the escrow RESERVED (NOT auto-voided).
+        if let Some(ctx) = xctx {
+            ctx.reached_needs_repair = true;
+            if let Some(plan) = Self::divergence_marker_plan(ctx) {
+                Box::pin(self.emit_divergence_markers(saga_id, plan)).await;
+            } else {
+                tracing::warn!(
+                    saga_id = %saga_id,
+                    "cross-context saga NeedsRepair with NO committed side (Commit-B never \
+                     landed); logs are clean, no divergence marker required"
+                );
+            }
+        }
+        Ok(())
     }
 
     /// Dispatch a single Prepare phase under the 30s per-phase timeout
     /// ([ADR-049](crate) §7; a timeout maps to
     /// [`ContextError::TransportTimeout`]).
     ///
-    /// `StandingPairCreate` / `BroadcastHostingHandshake` are spec-gapped
-    /// (return [`ContextError::NotImplemented`]). For
+    /// `StandingPairCreate` is spec-gapped (returns
+    /// [`ContextError::NotImplemented`]); `BroadcastHostingHandshake` (spec
+    /// §5.14.13) routes its per-phase message to the host (Prepare-A) and
+    /// broadcast (Prepare-B) actors via `bctx`. For
     /// `CrossContextToolInvocation` the FSM routes the per-phase message to the
     /// co-resident participant actor and threads the reply into `xctx`:
     /// Prepare-A → caller actor → hold `PreparedAFields`; Prepare-B → target
@@ -6536,6 +6833,7 @@ impl Supervisor {
         input: &SagaInput,
         phase: SagaPhase,
         xctx: Option<&mut CrossContextSagaCtx<'_>>,
+        bctx: Option<&mut BroadcastSagaCtx>,
     ) -> Result<(), ContextError> {
         const PHASE_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(30);
 
@@ -6560,11 +6858,17 @@ impl Supervisor {
                     }
                 }
                 SagaInput::BroadcastHostingHandshake { .. } => {
-                    Err(ContextError::NotImplemented(format!(
-                        "saga Prepare{phase:?} — BroadcastHostingHandshake wiring deferred to \
-                         commit 11.5 per DEFERRED-commit-11-saga-use-cases.md gap 3 (broadcast \
-                         hosting handshake protocol)"
-                    )))
+                    let Some(ctx) = bctx else {
+                        return Err(ContextError::InvalidState(format!(
+                            "SCP-SAGA-13160: saga Prepare{phase:?} — BroadcastHostingHandshake \
+                             requires the supervisor-side signing keys; call \
+                             start_broadcast_hosting_handshake_saga, not start_saga"
+                        )));
+                    };
+                    match phase {
+                        SagaPhase::A => self.dispatch_bcast_prepare_a(saga_id, ctx).await,
+                        SagaPhase::B => self.dispatch_bcast_prepare_b(saga_id, ctx).await,
+                    }
                 }
                 // Test-only: Prepare always SUCCEEDS so the FSM advances to
                 // Committing (where the test variant's Commit then fails,
@@ -6672,6 +6976,251 @@ impl Supervisor {
         Ok(())
     }
 
+    /// Broadcast hosting-handshake Prepare-A (spec §5.14.13, host side): resolve
+    /// the co-resident host actor, send [`SagaPhaseMessage::BroadcastPrepareA`]
+    /// (with the requester's Active Signing Key per-call), and hold the returned
+    /// signed request bytes in `ctx` for Prepare-B.
+    async fn dispatch_bcast_prepare_a(
+        &self,
+        saga_id: &SagaId,
+        ctx: &mut BroadcastSagaCtx,
+    ) -> Result<(), ContextError> {
+        use crate::context::actor::commands::{SagaPhaseMessage, SigningKeyBytes};
+
+        let host_hex = hex::encode(ctx.host_context_id);
+        let actor = self.lookup(&host_hex).ok_or_else(|| {
+            ContextError::ContextNotRegistered(format!(
+                "SCP-SAGA-13164: broadcast hosting Prepare-A — host context '{host_hex}' is not a \
+                 co-resident actor (cross-node child-bridge transport is future work)"
+            ))
+        })?;
+
+        let saga_id = saga_id.clone();
+        let host_context_id = ctx.host_context_id;
+        let broadcast_context_id = ctx.broadcast_context_id;
+        let subscriber_did = ctx.subscriber_did.clone();
+        let wrapping_pubkey = ctx.wrapping_pubkey;
+        let requested_config_bytes = ctx.requested_config_bytes.clone();
+        let ucan = ctx.ucan.clone();
+        let nonce = ctx.nonce;
+        let timestamp_ms = ctx.timestamp_ms;
+        let requester_signing_key = SigningKeyBytes::from_signing_key(&ctx.subscriber_signing_key);
+
+        let prepared = actor
+            .send(move |reply| {
+                ContextCommand::SagaPhase(SagaPhaseMessage::BroadcastPrepareA {
+                    saga_id,
+                    host_context_id,
+                    broadcast_context_id,
+                    subscriber_did,
+                    wrapping_pubkey,
+                    requested_config_bytes,
+                    ucan,
+                    nonce,
+                    timestamp_ms,
+                    requester_signing_key,
+                    reply,
+                })
+            })
+            .await?;
+        ctx.prepared_a_request = Some(prepared.request_bytes);
+        Ok(())
+    }
+
+    /// Broadcast hosting-handshake Prepare-B (spec §5.14.13, broadcast side): the
+    /// authoritative side. Resolve the co-resident broadcast actor, send
+    /// [`SagaPhaseMessage::BroadcastPrepareB`] (with the request bytes from
+    /// Prepare-A + the broadcast author's signing key per-call), and hold the
+    /// returned signed grant bytes + captured values in `ctx`.
+    async fn dispatch_bcast_prepare_b(
+        &self,
+        saga_id: &SagaId,
+        ctx: &mut BroadcastSagaCtx,
+    ) -> Result<(), ContextError> {
+        use crate::context::actor::commands::{SagaPhaseMessage, SigningKeyBytes};
+
+        let broadcast_hex = hex::encode(ctx.broadcast_context_id);
+        let actor = self.lookup(&broadcast_hex).ok_or_else(|| {
+            ContextError::ContextNotRegistered(format!(
+                "SCP-SAGA-13165: broadcast hosting Prepare-B — broadcast context '{broadcast_hex}' \
+                 is not a co-resident actor (cross-node child-bridge transport is future work)"
+            ))
+        })?;
+
+        let request_bytes = ctx.prepared_a_request.clone().ok_or_else(|| {
+            ContextError::InvalidState(
+                "SCP-SAGA-13166: broadcast hosting Prepare-B — no Prepare-A request bytes staged \
+                 (FSM ordering invariant violated)"
+                    .to_owned(),
+            )
+        })?;
+
+        let saga_id = saga_id.clone();
+        let broadcast_context_id = ctx.broadcast_context_id;
+        let author_signing_key = SigningKeyBytes::from_signing_key(&ctx.author_signing_key);
+
+        let prepared = actor
+            .send(move |reply| {
+                ContextCommand::SagaPhase(SagaPhaseMessage::BroadcastPrepareB {
+                    saga_id,
+                    broadcast_context_id,
+                    request_bytes,
+                    author_signing_key,
+                    reply,
+                })
+            })
+            .await?;
+        ctx.prepared_b = Some(BroadcastPreparedBCarry {
+            grant_bytes: prepared.grant_bytes,
+            key_epoch_at_grant: prepared.key_epoch_at_grant,
+            granted_at_ms: prepared.granted_at_ms,
+        });
+        Ok(())
+    }
+
+    /// Broadcast hosting-handshake Commit (spec §5.14.13): Commit-B then Commit-A.
+    /// B persists the snapshot + `MemberJoined` append (NO key pushed) and acks;
+    /// A persists the author-signed grant as durable relay-authorization proof.
+    /// Idempotent by `SagaId`.
+    async fn dispatch_bcast_commit(
+        &self,
+        saga_id: &SagaId,
+        ctx: &BroadcastSagaCtx,
+    ) -> Result<(), ContextError> {
+        use crate::context::actor::commands::SagaPhaseMessage;
+
+        // Commit-B (broadcast side): persist the AcceptedHostSnapshotEntry +
+        // MemberJoined append; B re-confirms it holds the staged grant.
+        let broadcast_hex = hex::encode(ctx.broadcast_context_id);
+        let broadcast_actor = self.lookup(&broadcast_hex).ok_or_else(|| {
+            ContextError::ContextNotRegistered(format!(
+                "SCP-SAGA-13167: broadcast hosting Commit-B — broadcast context '{broadcast_hex}' \
+                 is not a co-resident actor"
+            ))
+        })?;
+        let commit_b_saga_id = saga_id.clone();
+        let _snapshot_echo = broadcast_actor
+            .send(move |reply| {
+                ContextCommand::SagaPhase(SagaPhaseMessage::BroadcastCommitB {
+                    saga_id: commit_b_saga_id,
+                    reply,
+                })
+            })
+            .await?;
+
+        // Commit-A (host side): deliver the AUTHORITATIVE author-signed grant
+        // (from Prepare-B) for the host to persist as durable relay proof.
+        let grant_bytes = ctx
+            .prepared_b
+            .as_ref()
+            .map(|p| p.grant_bytes.clone())
+            .ok_or_else(|| {
+                ContextError::InvalidState(
+                    "SCP-SAGA-13168: broadcast hosting Commit-A — no Prepare-B grant bytes staged \
+                     (FSM ordering invariant violated)"
+                        .to_owned(),
+                )
+            })?;
+        let host_hex = hex::encode(ctx.host_context_id);
+        let host_actor = self.lookup(&host_hex).ok_or_else(|| {
+            ContextError::ContextNotRegistered(format!(
+                "SCP-SAGA-13169: broadcast hosting Commit-A — host context '{host_hex}' is not a \
+                 co-resident actor"
+            ))
+        })?;
+        let host_commit_saga_id = saga_id.clone();
+        host_actor
+            .send(move |reply| {
+                ContextCommand::SagaPhase(SagaPhaseMessage::BroadcastCommitA {
+                    saga_id: host_commit_saga_id,
+                    grant_bytes,
+                    reply,
+                })
+            })
+            .await?;
+        Ok(())
+    }
+
+    /// Broadcast hosting-handshake abort (spec §5.14.13 "Abort"): send
+    /// [`SagaPhaseMessage::Abort`] (reservation `None`) to whichever side(s)
+    /// prepared so the staged `saga_pending` slot is dropped. No key, no
+    /// snapshot, no append. Best-effort + idempotent (a side that never prepared
+    /// is a no-op).
+    async fn abort_bcast_participants(&self, saga_id: &SagaId, ctx: &BroadcastSagaCtx) {
+        use crate::context::actor::commands::SagaPhaseMessage;
+
+        for ctx_id in [ctx.host_context_id, ctx.broadcast_context_id] {
+            let hex = hex::encode(ctx_id);
+            let Some(actor) = self.lookup(&hex) else {
+                continue;
+            };
+            let abort_saga_id = saga_id.clone();
+            let _ = actor
+                .send(move |reply| {
+                    ContextCommand::SagaPhase(SagaPhaseMessage::Abort {
+                        saga_id: abort_saga_id,
+                        reservation: None,
+                        reply,
+                    })
+                })
+                .await;
+        }
+    }
+
+    /// Compute the journal `evidence` bytes for whichever saga-type context is
+    /// present (cross-context OR broadcast hosting), for crash-recovery replay.
+    /// At most one context is `Some`; `None` for the test / spec-gapped inputs.
+    fn saga_prepared_evidence_bytes(
+        input: &SagaInput,
+        xctx: Option<&CrossContextSagaCtx<'_>>,
+        bctx: Option<&BroadcastSagaCtx>,
+    ) -> Option<Vec<u8>> {
+        xctx.and_then(|ctx| Self::xctx_prepared_evidence_bytes(input, ctx))
+            .or_else(|| bctx.and_then(|ctx| Self::bcast_prepared_evidence_bytes(input, ctx)))
+    }
+
+    /// Build the §5.14.13 broadcast hosting-handshake journal evidence bytes for
+    /// crash-recovery replay. Returns `None` unless the saga is a
+    /// `BroadcastHostingHandshake`. Mirrors [`Self::xctx_prepared_evidence_bytes`].
+    fn bcast_prepared_evidence_bytes(input: &SagaInput, ctx: &BroadcastSagaCtx) -> Option<Vec<u8>> {
+        use crate::context::supervisor::saga_prepared_state::BroadcastHostingHandshakePrepared;
+        if !matches!(input, SagaInput::BroadcastHostingHandshake { .. }) {
+            return None;
+        }
+        // Pre-Prepare-B the captured values are not yet known; use the request's
+        // nonce/timestamp and zero epoch/granted_at (the PreparingB-state replay
+        // arm aborts and never re-drives a Commit, so it does not read them). Post
+        // Prepare-B, the captured grant values are journaled so a Commit-in-
+        // progress replay reconstructs the byte-identical grant + snapshot.
+        let (key_epoch_at_grant, granted_at_ms, grant_nonce, grant_timestamp_ms) = ctx
+            .prepared_b
+            .as_ref()
+            .map_or((0, 0, ctx.nonce, ctx.timestamp_ms), |p| {
+                // Post-Prepare-B: the staged actor-side prepared carries the
+                // authoritative captured values; the supervisor mirror records
+                // the request nonce/timestamp (the grant echoes the request
+                // nonce, and the grant timestamp == granted_at_ms).
+                (
+                    p.key_epoch_at_grant,
+                    p.granted_at_ms,
+                    ctx.nonce,
+                    p.granted_at_ms,
+                )
+            });
+        let prepared = BroadcastHostingHandshakePrepared {
+            host_context_id: ctx.host_context_id,
+            broadcast_context_id: ctx.broadcast_context_id,
+            subscriber_did: ctx.subscriber_did.clone(),
+            wrapping_pubkey: ctx.wrapping_pubkey,
+            key_epoch_at_grant,
+            granted_at_ms,
+            grant_nonce,
+            grant_timestamp_ms,
+            broadcast_host_config_bytes: ctx.requested_config_bytes.clone(),
+        };
+        prepared.to_evidence_bytes().ok()
+    }
+
     /// Commit with 3x retry: 500ms, 1s, 2s. Returns the final error after
     /// retries are exhausted (→ `NeedsRepair`). The `TestForceNeedsRepair`
     /// variant always fails (driving the retry-exhaustion path); a wired
@@ -6681,6 +7230,7 @@ impl Supervisor {
         saga_id: &SagaId,
         input: &SagaInput,
         mut xctx: Option<&mut CrossContextSagaCtx<'_>>,
+        mut bctx: Option<&mut BroadcastSagaCtx>,
     ) -> Result<(), ContextError> {
         const BACKOFFS: &[std::time::Duration] = &[
             std::time::Duration::from_millis(500),
@@ -6694,7 +7244,7 @@ impl Supervisor {
                 tokio::time::sleep(*backoff).await;
             }
             match self
-                .dispatch_commit_phase(saga_id, input, xctx.as_deref_mut())
+                .dispatch_commit_phase(saga_id, input, xctx.as_deref_mut(), bctx.as_deref_mut())
                 .await
             {
                 Ok(()) => return Ok(()),
@@ -6719,25 +7269,37 @@ impl Supervisor {
     ///
     /// For a wired `CrossContextToolInvocation` this drives the §6.2.4 Commit:
     /// Commit-B reserve → run the executor supervisor-side → Commit-B settle →
-    /// Commit-A, ordered B then A. `StandingPairCreate` /
-    /// `BroadcastHostingHandshake` stay `NotImplemented`; `TestForceNeedsRepair`
+    /// Commit-A, ordered B then A. `BroadcastHostingHandshake` (spec §5.14.13)
+    /// drives Commit-B (snapshot + `MemberJoined` append, no key pushed) then
+    /// Commit-A (host persists the author-signed grant) via `bctx`.
+    /// `StandingPairCreate` stays `NotImplemented`; `TestForceNeedsRepair`
     /// always fails.
     async fn dispatch_commit_phase(
         &self,
         saga_id: &SagaId,
         input: &SagaInput,
         xctx: Option<&mut CrossContextSagaCtx<'_>>,
+        bctx: Option<&mut BroadcastSagaCtx>,
     ) -> Result<(), ContextError> {
         const PHASE_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(30);
 
         let dispatch_fut = async {
             match input {
-                SagaInput::StandingPairCreate { .. }
-                | SagaInput::BroadcastHostingHandshake { .. } => Err(ContextError::NotImplemented(
-                    "saga Commit — StandingPairCreate / BroadcastHostingHandshake commit-side \
-                         wiring deferred per DEFERRED-commit-11-saga-use-cases.md"
+                SagaInput::StandingPairCreate { .. } => Err(ContextError::NotImplemented(
+                    "saga Commit — StandingPairCreate commit-side wiring deferred per \
+                         DEFERRED-commit-11-saga-use-cases.md"
                         .to_owned(),
                 )),
+                SagaInput::BroadcastHostingHandshake { .. } => {
+                    let Some(ctx) = bctx else {
+                        return Err(ContextError::InvalidState(
+                            "SCP-SAGA-13161: saga Commit — BroadcastHostingHandshake requires the \
+                             supervisor-side signing keys (start_saga misuse)"
+                                .to_owned(),
+                        ));
+                    };
+                    self.dispatch_bcast_commit(saga_id, ctx).await
+                }
                 SagaInput::CrossContextToolInvocation { .. } => {
                     let Some(ctx) = xctx else {
                         return Err(ContextError::InvalidState(
@@ -7052,7 +7614,7 @@ impl Supervisor {
         // receipt's `output_jcs` is the exact preimage of the signed
         // `output_hash`, so A hashes precisely what B signed.
         let output_for_a = receipt.output_jcs.clone();
-        let commit_a_saga_id = saga_id.clone();
+        let host_commit_saga_id = saga_id.clone();
         let caller_context_id = ctx.caller_context_id;
         let caller_did = ctx.caller_did.clone();
         let target_context_id = ctx.target_context_id;
@@ -7072,7 +7634,7 @@ impl Supervisor {
         let send_result = caller
             .send_recover_on_failure(move |reply| {
                 ContextCommand::SagaPhase(SagaPhaseMessage::CommitA {
-                    saga_id: commit_a_saga_id,
+                    saga_id: host_commit_saga_id,
                     reservation: Box::new(reservation),
                     caller_context_id,
                     caller_did,
@@ -7547,6 +8109,7 @@ impl Supervisor {
         next_seq: u64,
         secret_bearing: bool,
         xctx: Option<&mut CrossContextSagaCtx<'_>>,
+        bctx: Option<&mut BroadcastSagaCtx>,
     ) -> Result<(), ContextError> {
         // Release any staged participant reservations FIRST — BEFORE the
         // `Aborting` journal transition — so the terminal marker is never
@@ -7565,6 +8128,16 @@ impl Supervisor {
             // economy to reverse, so the terminal marker is always safe.
             None => CallerAbortReversal::SettledOrAbsent,
         };
+
+        // Broadcast hosting-handshake abort (spec §5.14.13 "Abort"): drop both
+        // staged entries (host forwarding-registry slot + broadcast staged
+        // snapshot). No key, no snapshot persist, no append. The broadcast saga
+        // stages NO caller-side local economy, so the terminal marker is always
+        // safe — `Abort { reservation: None }` to each side clears its staged
+        // `saga_pending` slot (idempotent no-op if a side never prepared).
+        if let Some(ctx) = bctx {
+            self.abort_bcast_participants(saga_id, ctx).await;
+        }
 
         // If the caller's local-economy reversal could NOT be confirmed (the
         // re-drive ALSO failed under persistent backpressure / a closed inbox),
@@ -12014,6 +12587,8 @@ mod tests {
             xctx_committed_invocations: std::collections::HashSet::new(),
             xctx_caller_reservations: HashMap::new(),
             xctx_nonce_dedup: HashMap::new(),
+            bcast_request_nonce_dedup: HashMap::new(),
+            bcast_committed_grants: HashMap::new(),
         }
     }
 
@@ -18086,6 +18661,7 @@ mod tests {
                 3,
                 /*secret_bearing=*/ false,
                 Some(&mut ctx),
+                None,
             )
             .await
             .expect("abort_saga returns Ok (best-effort, non-terminal on outstanding reversal)");
@@ -19571,5 +20147,452 @@ mod tests {
             .reservation
             .ticket
             .consume_abandoning_escrow();
+    }
+
+    // =======================================================================
+    // Broadcast hosting-handshake saga (spec §5.14.13)
+    // =======================================================================
+
+    mod broadcast_hosting {
+        use super::*;
+        use scp_protocol::context::broadcast::hosting_handshake::{
+            BroadcastHostConfig, ForwardingPolicy,
+        };
+        use scp_protocol::context::broadcast::{
+            BroadcastAdmission, BroadcastContext, BroadcastHostingAggregateCap,
+        };
+
+        const HOST_CTX: [u8; 32] = [0xB1u8; 32];
+        const BCAST_CTX: [u8; 32] = [0xB2u8; 32];
+
+        fn subscriber_signing_key() -> ed25519_dalek::SigningKey {
+            ed25519_dalek::SigningKey::from_bytes(&[0x51u8; 32])
+        }
+        fn author_signing_key() -> ed25519_dalek::SigningKey {
+            ed25519_dalek::SigningKey::from_bytes(&[0x52u8; 32])
+        }
+
+        /// A supervisor that resolves `subscriber_did` → the subscriber key and
+        /// `author_did` → the author key (so Prepare-B can verify the request and
+        /// the host can verify the grant), with the broadcast author registered
+        /// as a local DID (so Prepare-B's local-author resolution succeeds).
+        async fn bcast_supervisor(subscriber_did: &str, author_did: &str) -> Arc<Supervisor> {
+            let sub_key = subscriber_signing_key().verifying_key();
+            let auth_key = author_signing_key().verifying_key();
+            let subscriber_owned = subscriber_did.to_owned();
+            let author_owned = author_did.to_owned();
+            let crypto = Arc::new(crate::crypto::mls::provider::MlsCryptoProvider::new(
+                "did:dht:z6MktestBcastSaga".to_owned(),
+            ));
+            let transport: Box<dyn crate::context::builder::ContextTransportProvider> =
+                Box::new(crate::context::builder::NotConfiguredTransportProvider);
+            let key_resolver: KeyResolver = Arc::new(move |did: &DID, _| {
+                if did.as_ref() == subscriber_owned {
+                    Some(sub_key)
+                } else if did.as_ref() == author_owned {
+                    Some(auth_key)
+                } else {
+                    None
+                }
+            });
+            let mls_storage: Arc<dyn crate::crypto::mls::storage_adapter::OpenMlsStorageAdapter> =
+                Arc::new(
+                    crate::crypto::mls::storage_adapter::SpawnBlockingStorageAdapter::new(
+                        Arc::new(InMemoryStorage::new()),
+                    ),
+                );
+            let sup = Supervisor::with_providers(
+                crypto,
+                transport,
+                Box::new(TestEventLog),
+                key_resolver,
+                Some(Box::new(MapPersistence::default())),
+                None,
+                None,
+                None,
+                mls_storage,
+            );
+            // Register the broadcast author as a local DID so Prepare-B can
+            // resolve the locally-controlled author whose epoch it captures.
+            sup.register_local_did(DID(author_did.to_owned()))
+                .await
+                .expect("register local author");
+            sup
+        }
+
+        /// Host-context state: the requester (`subscriber_did`) is a member
+        /// holding `messages:read` (so Prepare-A's authorization passes).
+        async fn host_state(subscriber_did: &str) -> crate::context::actor::state::PerContextState {
+            use scp_protocol::context::roles::Capability;
+            let mut st = crate::context::actor::state::PerContextState::new_for_test_encrypted(
+                HOST_CTX,
+                1_700_000_000,
+                DID("did:example:host-admin".to_owned()),
+            );
+            st.handle
+                .transition_to(&scp_protocol::context::ContextState::Active)
+                .await
+                .expect("active");
+            st.membership.add_member(
+                DID(subscriber_did.to_owned()),
+                "member".to_owned(),
+                Vec::new(),
+            );
+            st.role_state.members.insert(subscriber_did.to_owned());
+            let mut caps = std::collections::HashSet::new();
+            caps.insert(Capability::MessagesRead);
+            st.role_state
+                .member_capabilities
+                .insert(subscriber_did.to_owned(), caps);
+            st
+        }
+
+        /// Broadcast-context state: a locally-controlled author registered (its
+        /// epoch the grant rides), the requester registered as a member/subscriber
+        /// (so the `is_member` gate-2 passes). `admission` selects open vs gated.
+        async fn broadcast_state(
+            subscriber_did: &str,
+            author_did: &str,
+            admission: BroadcastAdmission,
+            aggregate_cap: Option<BroadcastHostingAggregateCap>,
+        ) -> crate::context::actor::state::PerContextState {
+            let bcast_hex = hex::encode(BCAST_CTX);
+            let mut st = crate::context::actor::state::PerContextState::new_for_test_broadcast(
+                BCAST_CTX,
+                1_700_000_000,
+                DID("did:example:bcast-admin".to_owned()),
+            );
+            st.handle
+                .transition_to(&scp_protocol::context::ContextState::Active)
+                .await
+                .expect("active");
+            let mut bc = BroadcastContext::new(
+                bcast_hex,
+                &scp_protocol::context::ContextMode::Broadcast,
+                admission,
+            )
+            .expect("broadcast context constructs");
+            bc.add_author(author_did).expect("author registers");
+            if let Some(cap) = aggregate_cap {
+                bc.set_aggregate_cap(cap);
+            }
+            st.broadcast_context = Some(bc);
+            st.membership.add_member(
+                DID(subscriber_did.to_owned()),
+                "subscriber".to_owned(),
+                Vec::new(),
+            );
+            st.role_state.members.insert(subscriber_did.to_owned());
+            st
+        }
+
+        async fn spawn_pair(
+            supervisor: &Arc<Supervisor>,
+            host: crate::context::actor::state::PerContextState,
+            bcast: crate::context::actor::state::PerContextState,
+        ) {
+            let host_deps = supervisor
+                .build_actor_deps(&DID("did:example:bcast-host-owner".to_owned()))
+                .await
+                .expect("host deps");
+            supervisor
+                .spawn_actor_with_state(host, host_deps, None)
+                .await
+                .expect("spawn host actor");
+            let bcast_deps = supervisor
+                .build_actor_deps(&DID("did:example:bcast-b-owner".to_owned()))
+                .await
+                .expect("bcast deps");
+            supervisor
+                .spawn_actor_with_state(bcast, bcast_deps, None)
+                .await
+                .expect("spawn broadcast actor");
+        }
+
+        fn config_bytes(policy: ForwardingPolicy, expires_at_ms: u64) -> Vec<u8> {
+            BroadcastHostConfig {
+                max_forward_rate_per_minute: 600,
+                max_subscribers: 100,
+                forwarding_policy: policy,
+                expires_at_ms,
+            }
+            .to_jcs()
+            .expect("config jcs")
+        }
+
+        fn request(
+            sup: &Arc<Supervisor>,
+            subscriber_did: &str,
+            ucan: Option<String>,
+            policy: ForwardingPolicy,
+        ) -> BroadcastHostingHandshakeRequest {
+            let now = sup.clock_ref().expect("clock").now_millis();
+            BroadcastHostingHandshakeRequest {
+                host_context_id: HOST_CTX,
+                broadcast_context_id: BCAST_CTX,
+                subscriber_did: DID(subscriber_did.to_owned()),
+                wrapping_pubkey: [0x44u8; 32],
+                requested_config_bytes: config_bytes(policy, now + 3_600_000),
+                ucan,
+                nonce: [0x55u8; 16],
+                timestamp_ms: now,
+            }
+        }
+
+        /// Two-context happy path: Prepare-A → Prepare-B → Commit-B → Commit-A.
+        /// The accepted-host snapshot is persisted, a `MemberJoined` is appended,
+        /// the host holds the signed grant, and NO key is delivered at Commit.
+        #[cfg(feature = "testing")]
+        #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+        async fn happy_path_commits_no_key_delivered() {
+            let subscriber = "did:dht:z6MkBcastSub";
+            let author = "did:dht:z6MkBcastAuthor";
+            let sup = bcast_supervisor(subscriber, author).await;
+            let host = host_state(subscriber).await;
+            let bcast = broadcast_state(subscriber, author, BroadcastAdmission::Open, None).await;
+            Box::pin(spawn_pair(&sup, host, bcast)).await;
+
+            let sub_sk = subscriber_signing_key();
+            let auth_sk = author_signing_key();
+            let out = sup
+                .start_broadcast_hosting_handshake_saga(
+                    request(&sup, subscriber, None, ForwardingPolicy::Verbatim),
+                    BroadcastHostingSigningKeys {
+                        subscriber: &sub_sk,
+                        author: &auth_sk,
+                    },
+                )
+                .await
+                .expect("broadcast hosting saga must commit");
+            // No receipt/output is surfaced (broadcast saga delivers no key at
+            // Commit — the key rides the out-of-band §5.14.2 pull, authorized by
+            // the durable accepted-host snapshot).
+            assert!(out.receipt.is_none() && out.output.is_none());
+
+            // The host holds the author-signed grant as durable relay proof: a
+            // Commit-A re-ack witness check returns `true`.
+            let host_actor = sup.lookup(&hex::encode(HOST_CTX)).expect("host actor");
+            let witness_saga_id = out.saga_id.clone();
+            let present = host_actor
+                .send(
+                    move |reply: tokio::sync::oneshot::Sender<Result<bool, ContextError>>| {
+                        ContextCommand::SagaPhase(
+                            crate::context::actor::commands::SagaPhaseMessage::BroadcastCommitAReack {
+                                saga_id: witness_saga_id,
+                                reply,
+                            },
+                        )
+                    },
+                )
+                .await
+                .expect("witness check");
+            assert!(present, "Commit-A must leave a durable grant proof");
+        }
+
+        /// Abort: a request with a bad signature is rejected at Prepare-B; no
+        /// snapshot, append, or key results, and the saga aborts.
+        #[cfg(feature = "testing")]
+        #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+        async fn bad_signature_aborts() {
+            let subscriber = "did:dht:z6MkBcastSubBad";
+            let author = "did:dht:z6MkBcastAuthorBad";
+            let sup = bcast_supervisor(subscriber, author).await;
+            let host = host_state(subscriber).await;
+            let bcast = broadcast_state(subscriber, author, BroadcastAdmission::Open, None).await;
+            Box::pin(spawn_pair(&sup, host, bcast)).await;
+
+            // Sign the request with the WRONG key (not subscriber's) → Prepare-B
+            // signature verification fails ⇒ abort.
+            let wrong_sk = ed25519_dalek::SigningKey::from_bytes(&[0x99u8; 32]);
+            let auth_sk = author_signing_key();
+            let result = sup
+                .start_broadcast_hosting_handshake_saga(
+                    request(&sup, subscriber, None, ForwardingPolicy::Verbatim),
+                    BroadcastHostingSigningKeys {
+                        subscriber: &wrong_sk,
+                        author: &auth_sk,
+                    },
+                )
+                .await;
+            assert!(
+                result.is_err(),
+                "a request signed by the wrong key must abort the saga"
+            );
+        }
+
+        /// Adversarial replay: a second saga reusing the same nonce is rejected
+        /// at Prepare-B (the request-nonce dedup cache), so a captured signed
+        /// request cannot be replayed into a second grant.
+        #[cfg(feature = "testing")]
+        #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+        async fn replayed_nonce_is_rejected() {
+            let subscriber = "did:dht:z6MkBcastSubReplay";
+            let author = "did:dht:z6MkBcastAuthorReplay";
+            let sup = bcast_supervisor(subscriber, author).await;
+            let host = host_state(subscriber).await;
+            let bcast = broadcast_state(subscriber, author, BroadcastAdmission::Open, None).await;
+            Box::pin(spawn_pair(&sup, host, bcast)).await;
+
+            let sub_sk = subscriber_signing_key();
+            let auth_sk = author_signing_key();
+            // First handshake commits (records the nonce).
+            sup.start_broadcast_hosting_handshake_saga(
+                request(&sup, subscriber, None, ForwardingPolicy::Verbatim),
+                BroadcastHostingSigningKeys {
+                    subscriber: &sub_sk,
+                    author: &auth_sk,
+                },
+            )
+            .await
+            .expect("first handshake commits");
+            // A second handshake reusing the SAME nonce ([0x55; 16]) is a replay
+            // ⇒ rejected at Prepare-B ⇒ saga aborts.
+            let replay = sup
+                .start_broadcast_hosting_handshake_saga(
+                    request(&sup, subscriber, None, ForwardingPolicy::Verbatim),
+                    BroadcastHostingSigningKeys {
+                        subscriber: &sub_sk,
+                        author: &auth_sk,
+                    },
+                )
+                .await;
+            assert!(
+                replay.is_err(),
+                "a request reusing a seen nonce must be rejected as a replay"
+            );
+        }
+
+        /// Adversarial gated-UCAN: a gated broadcast context with an absent UCAN
+        /// is rejected at Prepare-B (Unauthorized).
+        #[cfg(feature = "testing")]
+        #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+        async fn gated_without_ucan_aborts() {
+            let subscriber = "did:dht:z6MkBcastSubGated";
+            let author = "did:dht:z6MkBcastAuthorGated";
+            let sup = bcast_supervisor(subscriber, author).await;
+            let host = host_state(subscriber).await;
+            let bcast = broadcast_state(subscriber, author, BroadcastAdmission::Gated, None).await;
+            Box::pin(spawn_pair(&sup, host, bcast)).await;
+
+            let sub_sk = subscriber_signing_key();
+            let auth_sk = author_signing_key();
+            // Gated context but NO ucan presented ⇒ rejected at Prepare-B.
+            let result = sup
+                .start_broadcast_hosting_handshake_saga(
+                    request(&sup, subscriber, None, ForwardingPolicy::Verbatim),
+                    BroadcastHostingSigningKeys {
+                        subscriber: &sub_sk,
+                        author: &auth_sk,
+                    },
+                )
+                .await;
+            assert!(
+                result.is_err(),
+                "a gated broadcast with no messages:read UCAN must abort at Prepare-B"
+            );
+        }
+
+        /// Aggregate cap: a grant overshooting the aggregate subscriber ceiling
+        /// is rejected at Prepare-B (AggregateCapExceeded), side-effect-free.
+        #[cfg(feature = "testing")]
+        #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+        async fn aggregate_cap_overshoot_aborts() {
+            let subscriber = "did:dht:z6MkBcastSubCap";
+            let author = "did:dht:z6MkBcastAuthorCap";
+            let sup = bcast_supervisor(subscriber, author).await;
+            let host = host_state(subscriber).await;
+            // Aggregate cap below the requested 100 subscribers ⇒ overshoot.
+            let cap = BroadcastHostingAggregateCap {
+                aggregate_max_subscribers: 50,
+                aggregate_max_forward_rate_per_minute: 1_000_000,
+                max_grant_lifetime_ms:
+                    scp_protocol::context::broadcast::DEFAULT_MAX_GRANT_LIFETIME_MS,
+            };
+            let bcast =
+                broadcast_state(subscriber, author, BroadcastAdmission::Open, Some(cap)).await;
+            Box::pin(spawn_pair(&sup, host, bcast)).await;
+
+            let sub_sk = subscriber_signing_key();
+            let auth_sk = author_signing_key();
+            let result = sup
+                .start_broadcast_hosting_handshake_saga(
+                    request(&sup, subscriber, None, ForwardingPolicy::Verbatim),
+                    BroadcastHostingSigningKeys {
+                        subscriber: &sub_sk,
+                        author: &auth_sk,
+                    },
+                )
+                .await;
+            assert!(
+                result.is_err(),
+                "a grant overshooting the aggregate cap must abort at Prepare-B"
+            );
+        }
+
+        /// Non-member initiator is rejected BEFORE the saga set is reserved
+        /// (authorize-before-reserve forward obligation, §5.14.13).
+        #[cfg(feature = "testing")]
+        #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+        async fn non_member_initiator_rejected_before_reserve() {
+            let subscriber = "did:dht:z6MkBcastSubAuthz";
+            let author = "did:dht:z6MkBcastAuthorAuthz";
+            let sup = bcast_supervisor(subscriber, author).await;
+            // Host state where the requester is NOT a member.
+            let host = crate::context::actor::state::PerContextState::new_for_test_encrypted(
+                HOST_CTX,
+                1_700_000_000,
+                DID("did:example:host-admin".to_owned()),
+            );
+            host.handle
+                .transition_to(&scp_protocol::context::ContextState::Active)
+                .await
+                .expect("active");
+            let bcast = broadcast_state(subscriber, author, BroadcastAdmission::Open, None).await;
+            Box::pin(spawn_pair(&sup, host, bcast)).await;
+
+            let sub_sk = subscriber_signing_key();
+            let auth_sk = author_signing_key();
+            let result = sup
+                .start_broadcast_hosting_handshake_saga(
+                    request(&sup, subscriber, None, ForwardingPolicy::Verbatim),
+                    BroadcastHostingSigningKeys {
+                        subscriber: &sub_sk,
+                        author: &auth_sk,
+                    },
+                )
+                .await;
+            assert!(matches!(result, Err(ContextError::PermissionDenied(_))));
+        }
+
+        /// The signed grant round-trips: a `routing-stripped` policy still
+        /// produces a verifiable author-signed grant (the §5.14.6 author
+        /// signature on forwarded envelopes is independent of the grant policy;
+        /// the grant itself verifies under the author key).
+        #[cfg(feature = "testing")]
+        #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+        async fn routing_stripped_grant_verifies() {
+            let subscriber = "did:dht:z6MkBcastSubStrip";
+            let author = "did:dht:z6MkBcastAuthorStrip";
+            let sup = bcast_supervisor(subscriber, author).await;
+            let host = host_state(subscriber).await;
+            let bcast = broadcast_state(subscriber, author, BroadcastAdmission::Open, None).await;
+            Box::pin(spawn_pair(&sup, host, bcast)).await;
+
+            let sub_sk = subscriber_signing_key();
+            let auth_sk = author_signing_key();
+            sup.start_broadcast_hosting_handshake_saga(
+                request(&sup, subscriber, None, ForwardingPolicy::RoutingStripped),
+                BroadcastHostingSigningKeys {
+                    subscriber: &sub_sk,
+                    author: &auth_sk,
+                },
+            )
+            .await
+            .expect("routing-stripped handshake commits");
+            // The grant the host holds verifies under the author's key — the
+            // author signature survives independent of the forwarding policy.
+            // (Asserted at the leaf-type level by `grant_round_trip_sign_verify`
+            // in hosting_handshake.rs; a routing-stripped grant commits here.)
+        }
     }
 }

--- a/crates/scp-runtime/src/context/trust_recovery_helpers.rs
+++ b/crates/scp-runtime/src/context/trust_recovery_helpers.rs
@@ -567,5 +567,10 @@ fn build_snapshot_from_state(state: &PerContextState) -> crate::context::state::
         xctx_caller_reservations:
             crate::context::messaging_helpers::xctx_caller_reservations_snapshot(state),
         xctx_nonce_dedup: crate::context::messaging_helpers::xctx_nonce_dedup_snapshot(state),
+        bcast_request_nonce_dedup:
+            crate::context::messaging_helpers::bcast_request_nonce_dedup_snapshot(state),
+        bcast_committed_grants: crate::context::messaging_helpers::bcast_committed_grants_snapshot(
+            state,
+        ),
     }
 }

--- a/crates/scp-runtime/src/context/ttl_close_helpers.rs
+++ b/crates/scp-runtime/src/context/ttl_close_helpers.rs
@@ -649,6 +649,11 @@ fn build_snapshot_from_state(state: &PerContextState) -> crate::context::state::
         xctx_caller_reservations:
             crate::context::messaging_helpers::xctx_caller_reservations_snapshot(state),
         xctx_nonce_dedup: crate::context::messaging_helpers::xctx_nonce_dedup_snapshot(state),
+        bcast_request_nonce_dedup:
+            crate::context::messaging_helpers::bcast_request_nonce_dedup_snapshot(state),
+        bcast_committed_grants: crate::context::messaging_helpers::bcast_committed_grants_snapshot(
+            state,
+        ),
     }
 }
 

--- a/crates/scp-runtime/src/store/context.rs
+++ b/crates/scp-runtime/src/store/context.rs
@@ -1586,6 +1586,9 @@ mod tests {
             admission: BroadcastAdmission::Open,
             subscribers,
             authors,
+            accepted_hosts: Vec::new(),
+            aggregate_cap: scp_protocol::context::broadcast::BroadcastHostingAggregateCap::default(
+            ),
         }
     }
 
@@ -1768,6 +1771,8 @@ mod tests {
             xctx_committed_invocations: std::collections::HashSet::new(),
             xctx_caller_reservations: std::collections::HashMap::new(),
             xctx_nonce_dedup: std::collections::HashMap::new(),
+            bcast_request_nonce_dedup: std::collections::HashMap::new(),
+            bcast_committed_grants: std::collections::HashMap::new(),
         }
     }
 

--- a/crates/scp-testing/tests/integration/persistence.rs
+++ b/crates/scp-testing/tests/integration/persistence.rs
@@ -95,6 +95,8 @@ fn make_broadcast_snapshot(context_id: &str) -> BroadcastContextSnapshot {
         admission: BroadcastAdmission::Open,
         subscribers,
         authors,
+        accepted_hosts: Vec::new(),
+        aggregate_cap: scp_core::context::broadcast::BroadcastHostingAggregateCap::default(),
     }
 }
 

--- a/crates/scp-testing/tests/integration/persistence_advanced.rs
+++ b/crates/scp-testing/tests/integration/persistence_advanced.rs
@@ -84,6 +84,8 @@ fn make_broadcast_snapshot(context_id: &str) -> BroadcastContextSnapshot {
         admission: BroadcastAdmission::Open,
         subscribers,
         authors,
+        accepted_hosts: Vec::new(),
+        aggregate_cap: scp_core::context::broadcast::BroadcastHostingAggregateCap::default(),
     }
 }
 

--- a/crates/scp-testing/tests/integration/protocol_repository.rs
+++ b/crates/scp-testing/tests/integration/protocol_repository.rs
@@ -393,6 +393,8 @@ async fn broadcast_state_store_load_roundtrip() {
         admission: BroadcastAdmission::Open,
         subscribers,
         authors,
+        accepted_hosts: Vec::new(),
+        aggregate_cap: scp_core::context::broadcast::BroadcastHostingAggregateCap::default(),
     };
 
     store.store_broadcast_state(ctx, &snapshot).await.unwrap();


### PR DESCRIPTION
## Summary

Implements the **broadcast hosting-handshake saga** (§5.14.13) — the second of the two real cross-context sagas — replacing the supervisor-FSM `NotImplemented` arms with full Prepare/Commit/Abort dispatch. A host context agrees to relay a broadcast context's content to its own members; this establishes state in two contexts (host forwarding registry + broadcast accepted-host snapshot), so it runs as a cross-context saga under §5.15.4.

## What's wired
- **Protocol types** (`scp-protocol/context/broadcast/hosting_handshake.rs`, +474): signed `BroadcastHostingRequest`/`BroadcastHostingGrant`, `BroadcastHostConfig`, `AcceptedHostSnapshotEntry`, with the two distinct §9.5.1 field-enumerated signing preimages (`SCP-BCAST-HOST-REQ-V1:` / `SCP-BCAST-HOST-GRANT-V1:`) and the `OptVarBytes(ucan)` optional-field rule.
- **Actor-side phase handlers** (`broadcast_saga.rs`, +941): `prepare_a`/`prepare_b`/`commit_b`/`commit_a`.
- **Supervisor FSM dispatch** + `start_broadcast_hosting_handshake_saga` entry (authorize-before-reserve on both axes, per-participant-context-set gating).
- §5.14.13 elements: freshness window + request-nonce dedup, `BroadcastHostConfig` clamp (`expires_at_ms` lower-bound reject + lifetime-ceiling clamp), aggregate amplification cap (both axes), gated-UCAN re-bind to `subscriber_did` at the authoritative Prepare-B, HPKE post-grant key delivery left out-of-band, `AcceptedHostSnapshotEntry` at-most-one-live supersede + `saga_id` replay anchor.

The `InitiateBroadcastHostingHandshake` single-actor mailbox arm intentionally stays `reply_saga_deferred` — matching the §6.2.4 cross-context tool saga reference pattern (a cross-context saga is supervisor-driven, not mailbox-driven, per ADR-049 §3a).

## Tests & gates
10 broadcast-saga tests (happy-path/no-key-at-commit, bad-sig abort, gated-without-UCAN abort, aggregate-cap overshoot, non-member-rejected-before-reserve, replay rejection, routing-stripped, 3 evidence round-trips). Full CI clippy `-D warnings` clean; `cargo test -p scp-runtime` 2308/0; saga-gating granularity + cross-layer + protocol-deps gates pass; zero enforcement files edited.

Rebased cleanly onto current main (zero conflicts). Note: a small re-rebase will be needed once #1896 (standing-pair saga cut) lands.