### PR TITLE
feat(governance): keyless TrustedVoteIngest path sharing the signed tally [#1900 PR-2a]

### DIFF
--- a/crates/scp-core/src/lib.rs
+++ b/crates/scp-core/src/lib.rs
@@ -102,7 +102,21 @@ pub mod context {
         verify_etag,
     };
     pub mod governance {
-        pub use scp_protocol::context::governance::*;
+        // Explicit re-export of every public `governance` symbol EXCEPT
+        // `TrustedVoteIngest`. The keyless trusted-ingest trait is intentionally
+        // namable only from `scp-protocol` directly (the WASM bridge depends on
+        // `scp-protocol`, not this facade); a glob `*` would leak it into the
+        // native facade and undermine that omission.
+        pub use scp_protocol::context::governance::{
+            AccessScope, CheckpointAttestationStatus, CheckpointSchedule, ConflictResolution,
+            ContextCheckpoint, CosignedCheckpoint, DeadlockJustification, EventTypeRetention,
+            GovernanceAction, GovernanceContext, GovernanceEngine, GovernanceError,
+            GovernanceEvent, GovernanceModelConfig, GovernanceProposal, GovernanceReconfigAction,
+            KeyResolver, ProposalId, ProposalStatus, PruningPolicy, RejectionReason, SignedVote,
+            SingleAdminEngine, SizeBasedPolicy, TimeBasedPolicy, VoteType, actions_conflict,
+            compute_proposal_id, majority, mls_integration, multisig, sign_vote, unanimity,
+            verify_proposal_votes, verify_vote,
+        };
         pub use scp_runtime::context::governance::timeout;
     }
     pub mod tools {

--- a/crates/scp-protocol/src/context/governance/majority.rs
+++ b/crates/scp-protocol/src/context/governance/majority.rs
@@ -319,6 +319,119 @@ impl MajorityVoteEngine {
         proposal.approvals.iter().any(|v| v.voter_did == *voter)
             || proposal.rejections.iter().any(|v| v.voter_did == *voter)
     }
+
+    /// Record an already-built vote and run the tally.
+    ///
+    /// Shared by the signed [`GovernanceEngine::approve`] /
+    /// [`GovernanceEngine::reject`] path and the keyless
+    /// [`TrustedVoteIngest`](super::TrustedVoteIngest) path. This helper begins
+    /// **after** any signature verification: the signed path verifies the vote
+    /// against the voter's DID-resolved key before calling this; the keyless
+    /// path supplies an empty-signature vote.
+    ///
+    /// The shared portion matches the original control flow exactly: the
+    /// eligibility check, the precondition block (pending check, deadline flag,
+    /// single-vote dedup), the deferral to `resolve()` when the deadline has
+    /// passed, the push into `approvals`/`rejections`, the `VoteCast` event, and
+    /// the inline early-resolution (`approvals * 2 > eligible` for an approval,
+    /// `rejections >= eligible.div_ceil(2)` for a rejection).
+    fn record_vote_and_resolve(
+        &mut self,
+        proposal_id: &ProposalId,
+        voter: &DID,
+        signed_vote: super::SignedVote,
+        vote: VoteType,
+        context: &GovernanceContext,
+    ) -> Result<(ProposalStatus, Vec<GovernanceEvent>), GovernanceError> {
+        // Verify voter is eligible.
+        if !self.eligible_voter_dids.contains(voter) {
+            return Err(GovernanceError::NotEligible(format!(
+                "{voter} is not an eligible voter"
+            )));
+        }
+
+        // Validate preconditions with an immutable borrow. We store a flag
+        // for deadline expiry so we can call self.resolve() after the borrow
+        // ends (resolve needs &mut self).
+        let past_deadline = {
+            let proposal = self.proposals.get(proposal_id).ok_or_else(|| {
+                GovernanceError::ProposalNotFound {
+                    id: hex::encode(proposal_id),
+                }
+            })?;
+
+            if !proposal.status.is_pending() {
+                return Err(GovernanceError::ProposalNotPending {
+                    status: format!("{:?}", proposal.status),
+                });
+            }
+
+            let expired = context.now >= proposal.voting_deadline;
+            if !expired && Self::has_voted(proposal, voter) {
+                return Err(GovernanceError::AlreadyVoted);
+            }
+            expired
+        };
+
+        // Handle deadline expiry (self.resolve needs &mut self).
+        if past_deadline {
+            return self.resolve(proposal_id, context);
+        }
+
+        let eligible = self.eligible_voter_dids.len();
+
+        // Capture the vote discriminant before moving `vote` into the VoteCast
+        // event below, so we only consume the value once (the original
+        // approve/reject paths each handled a single, statically-known variant).
+        let is_approve = matches!(vote, VoteType::Approve);
+
+        let proposal = self.proposals.get_mut(proposal_id).ok_or_else(|| {
+            GovernanceError::ProposalNotFound {
+                id: hex::encode(proposal_id),
+            }
+        })?;
+
+        if is_approve {
+            proposal.approvals.push(signed_vote);
+        } else {
+            proposal.rejections.push(signed_vote);
+        }
+
+        let mut events = vec![GovernanceEvent::VoteCast {
+            proposal_id: *proposal_id,
+            voter_did: voter.clone(),
+            vote,
+        }];
+
+        // Check for early resolution after recording the vote.
+        if is_approve {
+            // Early approval: absolute majority of all eligible voters.
+            let approvals = proposal.approvals.len();
+            if approvals * 2 > eligible {
+                proposal.status = ProposalStatus::Approved;
+                events.push(GovernanceEvent::ProposalResolved {
+                    proposal_id: *proposal_id,
+                    status: ProposalStatus::Approved,
+                });
+            }
+        } else {
+            // Early rejection: enough rejections to make approval impossible.
+            let rejections = proposal.rejections.len();
+            let rejection_threshold = eligible.div_ceil(2);
+            if rejections >= rejection_threshold {
+                let status = ProposalStatus::Rejected {
+                    reason: RejectionReason::MajorityRejected,
+                };
+                proposal.status = status.clone();
+                events.push(GovernanceEvent::ProposalResolved {
+                    proposal_id: *proposal_id,
+                    status,
+                });
+            }
+        }
+
+        Ok((proposal.status.clone(), events))
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -390,42 +503,7 @@ impl GovernanceEngine for MajorityVoteEngine {
         context: &GovernanceContext,
         signing_key: &ed25519_dalek::SigningKey,
     ) -> Result<(ProposalStatus, Vec<GovernanceEvent>), GovernanceError> {
-        // Verify voter is eligible.
-        if !self.eligible_voter_dids.contains(voter) {
-            return Err(GovernanceError::NotEligible(format!(
-                "{voter} is not an eligible voter"
-            )));
-        }
-
-        // Validate preconditions with an immutable borrow. We store a flag
-        // for deadline expiry so we can call self.resolve() after the borrow
-        // ends (resolve needs &mut self).
-        let past_deadline = {
-            let proposal = self.proposals.get(proposal_id).ok_or_else(|| {
-                GovernanceError::ProposalNotFound {
-                    id: hex::encode(proposal_id),
-                }
-            })?;
-
-            if !proposal.status.is_pending() {
-                return Err(GovernanceError::ProposalNotPending {
-                    status: format!("{:?}", proposal.status),
-                });
-            }
-
-            let expired = context.now >= proposal.voting_deadline;
-            if !expired && Self::has_voted(proposal, voter) {
-                return Err(GovernanceError::AlreadyVoted);
-            }
-            expired
-        };
-
-        // Handle deadline expiry (self.resolve needs &mut self).
-        if past_deadline {
-            return self.resolve(proposal_id, context);
-        }
-
-        // Record the signed vote. Get mutable reference for mutation.
+        // Build and sign the vote.
         let signed_vote = sign_vote(
             proposal_id,
             &VoteType::Approve,
@@ -435,6 +513,8 @@ impl GovernanceEngine for MajorityVoteEngine {
         )?;
 
         // Verify the vote signature against the voter's DID-resolved key.
+        // This MUST stay strictly before record_vote_and_resolve: the signed
+        // path counts a vote only after its signature is verified.
         let resolved_key = (self.key_resolver)(voter, SigningKeyId::Active).ok_or_else(|| {
             GovernanceError::UnknownVoter {
                 did: voter.to_string(),
@@ -447,34 +527,7 @@ impl GovernanceEngine for MajorityVoteEngine {
             }
         })?;
 
-        let proposal = self.proposals.get_mut(proposal_id).ok_or_else(|| {
-            GovernanceError::ProposalNotFound {
-                id: hex::encode(proposal_id),
-            }
-        })?;
-
-        proposal.approvals.push(signed_vote);
-
-        let mut events = vec![GovernanceEvent::VoteCast {
-            proposal_id: *proposal_id,
-            voter_did: voter.clone(),
-            vote: VoteType::Approve,
-        }];
-
-        // Check for early resolution after recording the vote.
-        let eligible = self.eligible_voter_dids.len();
-        let approvals = proposal.approvals.len();
-
-        // Early approval: absolute majority of all eligible voters.
-        if approvals * 2 > eligible {
-            proposal.status = ProposalStatus::Approved;
-            events.push(GovernanceEvent::ProposalResolved {
-                proposal_id: *proposal_id,
-                status: ProposalStatus::Approved,
-            });
-        }
-
-        Ok((proposal.status.clone(), events))
+        self.record_vote_and_resolve(proposal_id, voter, signed_vote, VoteType::Approve, context)
     }
 
     fn reject(
@@ -484,41 +537,7 @@ impl GovernanceEngine for MajorityVoteEngine {
         context: &GovernanceContext,
         signing_key: &ed25519_dalek::SigningKey,
     ) -> Result<(ProposalStatus, Vec<GovernanceEvent>), GovernanceError> {
-        // Verify voter is eligible.
-        if !self.eligible_voter_dids.contains(voter) {
-            return Err(GovernanceError::NotEligible(format!(
-                "{voter} is not an eligible voter"
-            )));
-        }
-
-        // Validate preconditions with an immutable borrow. Store deadline
-        // flag so we can call self.resolve() after the borrow ends.
-        let past_deadline = {
-            let proposal = self.proposals.get(proposal_id).ok_or_else(|| {
-                GovernanceError::ProposalNotFound {
-                    id: hex::encode(proposal_id),
-                }
-            })?;
-
-            if !proposal.status.is_pending() {
-                return Err(GovernanceError::ProposalNotPending {
-                    status: format!("{:?}", proposal.status),
-                });
-            }
-
-            let expired = context.now >= proposal.voting_deadline;
-            if !expired && Self::has_voted(proposal, voter) {
-                return Err(GovernanceError::AlreadyVoted);
-            }
-            expired
-        };
-
-        // Handle deadline expiry (self.resolve needs &mut self).
-        if past_deadline {
-            return self.resolve(proposal_id, context);
-        }
-
-        // Record the signed vote. Get mutable reference for mutation.
+        // Build and sign the rejection vote.
         let signed_vote = sign_vote(
             proposal_id,
             &VoteType::Reject,
@@ -528,6 +547,8 @@ impl GovernanceEngine for MajorityVoteEngine {
         )?;
 
         // Verify the vote signature against the voter's DID-resolved key.
+        // This MUST stay strictly before record_vote_and_resolve: the signed
+        // path counts a vote only after its signature is verified.
         let resolved_key = (self.key_resolver)(voter, SigningKeyId::Active).ok_or_else(|| {
             GovernanceError::UnknownVoter {
                 did: voter.to_string(),
@@ -540,37 +561,7 @@ impl GovernanceEngine for MajorityVoteEngine {
             }
         })?;
 
-        let proposal = self.proposals.get_mut(proposal_id).ok_or_else(|| {
-            GovernanceError::ProposalNotFound {
-                id: hex::encode(proposal_id),
-            }
-        })?;
-
-        proposal.rejections.push(signed_vote);
-
-        let mut events = vec![GovernanceEvent::VoteCast {
-            proposal_id: *proposal_id,
-            voter_did: voter.clone(),
-            vote: VoteType::Reject,
-        }];
-
-        // Check for early rejection: enough rejections to make approval impossible.
-        let eligible = self.eligible_voter_dids.len();
-        let rejections = proposal.rejections.len();
-        let rejection_threshold = eligible.div_ceil(2);
-
-        if rejections >= rejection_threshold {
-            let status = ProposalStatus::Rejected {
-                reason: RejectionReason::MajorityRejected,
-            };
-            proposal.status = status.clone();
-            events.push(GovernanceEvent::ProposalResolved {
-                proposal_id: *proposal_id,
-                status,
-            });
-        }
-
-        Ok((proposal.status.clone(), events))
+        self.record_vote_and_resolve(proposal_id, voter, signed_vote, VoteType::Reject, context)
     }
 
     fn resolve(
@@ -718,6 +709,48 @@ impl GovernanceEngine for MajorityVoteEngine {
         } else {
             Ok(CheckpointAttestationStatus::PartiallyAttested)
         }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// TrustedVoteIngest implementation (ADR-034 keyless path)
+// ---------------------------------------------------------------------------
+
+impl super::TrustedVoteIngest for MajorityVoteEngine {
+    fn ingest_approve(
+        &mut self,
+        proposal_id: &ProposalId,
+        voter: &DID,
+        context: &GovernanceContext,
+    ) -> Result<(ProposalStatus, Vec<GovernanceEvent>), GovernanceError> {
+        // Keyless: build an empty-signature vote and feed it through the same
+        // tally as the signed path. No sign_vote, no verify_vote — the caller
+        // is responsible for authenticating the vote out-of-band (see the
+        // TrustedVoteIngest contract). The timestamp is read from
+        // GovernanceContext::now, the same clock the signed path uses. The vote
+        // is tallied against the engine's frozen eligible_voter_dids.
+        let signed_vote = super::SignedVote {
+            voter_did: voter.clone(),
+            vote: VoteType::Approve,
+            timestamp: context.now,
+            signature: Vec::new(),
+        };
+        self.record_vote_and_resolve(proposal_id, voter, signed_vote, VoteType::Approve, context)
+    }
+
+    fn ingest_reject(
+        &mut self,
+        proposal_id: &ProposalId,
+        voter: &DID,
+        context: &GovernanceContext,
+    ) -> Result<(ProposalStatus, Vec<GovernanceEvent>), GovernanceError> {
+        let signed_vote = super::SignedVote {
+            voter_did: voter.clone(),
+            vote: VoteType::Reject,
+            timestamp: context.now,
+            signature: Vec::new(),
+        };
+        self.record_vote_and_resolve(proposal_id, voter, signed_vote, VoteType::Reject, context)
     }
 }
 
@@ -2375,5 +2408,186 @@ mod tests {
 
         let (proposal, _) = engine.propose(&alice(), action, &ctx, &sk_alice()).unwrap();
         assert_eq!(proposal.status, ProposalStatus::Pending);
+    }
+
+    // -----------------------------------------------------------------------
+    // TrustedVoteIngest (keyless, ADR-034) — Majority
+    // -----------------------------------------------------------------------
+
+    use crate::context::governance::TrustedVoteIngest;
+
+    #[test]
+    fn ingest_approve_reaches_absolute_majority() {
+        // 3 voters: two ingested approvals -> absolute majority (2*2 > 3) ->
+        // Approved. (Majority does not auto-count the proposer.)
+        let mut engine = default_engine(three_voters());
+        let ctx = test_context(&three_voters(), T0);
+        let proposal = propose_add_member(&mut engine, &alice(), &ctx, &sk_alice());
+        let pid = proposal.proposal_id;
+
+        let (status, _) = engine.ingest_approve(&pid, &alice(), &ctx).expect("ingest");
+        assert_eq!(status, ProposalStatus::Pending);
+
+        let (status, events) = engine.ingest_approve(&pid, &bob(), &ctx).expect("ingest");
+        assert_eq!(status, ProposalStatus::Approved);
+        assert_eq!(events.len(), 2); // VoteCast + ProposalResolved
+
+        // Recorded ingested votes carry empty signatures.
+        let p = engine.get_proposal(&pid).expect("found");
+        assert_eq!(p.approvals.len(), 2);
+        assert!(p.approvals[0].signature.is_empty());
+        assert!(p.approvals[1].signature.is_empty());
+    }
+
+    #[test]
+    fn ingest_stays_pending_below_majority() {
+        // 5 voters: two ingested approvals is not an absolute majority
+        // (2*2 = 4, not > 5) and the deadline has not passed -> Pending.
+        let voters = all_five();
+        let mut engine = default_engine(voters.clone());
+        let ctx = test_context(&voters, T0);
+        let proposal = propose_add_member(&mut engine, &alice(), &ctx, &sk_alice());
+        let pid = proposal.proposal_id;
+
+        engine.ingest_approve(&pid, &alice(), &ctx).expect("ingest");
+        let (status, _) = engine.ingest_approve(&pid, &bob(), &ctx).expect("ingest");
+        assert_eq!(status, ProposalStatus::Pending);
+    }
+
+    #[test]
+    fn ingest_reject_reaches_early_rejection() {
+        // 3 voters: two ingested rejections >= ceil(3/2) = 2 -> early rejection.
+        let mut engine = default_engine(three_voters());
+        let ctx = test_context(&three_voters(), T0);
+        let proposal = propose_add_member(&mut engine, &alice(), &ctx, &sk_alice());
+        let pid = proposal.proposal_id;
+
+        let (status, _) = engine.ingest_reject(&pid, &alice(), &ctx).expect("ingest");
+        assert_eq!(status, ProposalStatus::Pending);
+
+        let (status, _) = engine.ingest_reject(&pid, &bob(), &ctx).expect("ingest");
+        assert_eq!(
+            status,
+            ProposalStatus::Rejected {
+                reason: RejectionReason::MajorityRejected
+            }
+        );
+    }
+
+    #[test]
+    fn ingest_tallies_against_frozen_eligible_set() {
+        // The engine's frozen eligible_voter_dids is the denominator regardless
+        // of any external membership notion. The engine is frozen at 3 voters;
+        // the GovernanceContext lists a DIFFERENT (larger) membership. Two
+        // ingested approvals still reach absolute majority of the FROZEN set
+        // (2*2 > 3), proving the context membership is not consulted.
+        let mut engine = default_engine(three_voters());
+        // Context advertises five members, but the engine's frozen set is three.
+        let ctx = test_context(&all_five(), T0);
+        let proposal = propose_add_member(&mut engine, &alice(), &ctx, &sk_alice());
+        let pid = proposal.proposal_id;
+
+        engine.ingest_approve(&pid, &alice(), &ctx).expect("ingest");
+        let (status, _) = engine.ingest_approve(&pid, &bob(), &ctx).expect("ingest");
+        // Would still be pending if the denominator were 5 (4 !> 5); Approved
+        // confirms the frozen denominator of 3 is used.
+        assert_eq!(status, ProposalStatus::Approved);
+    }
+
+    #[test]
+    fn ingest_approve_rejects_non_eligible() {
+        let mut engine = default_engine(three_voters());
+        let ctx = test_context(&three_voters(), T0);
+        let proposal = propose_add_member(&mut engine, &alice(), &ctx, &sk_alice());
+
+        // Dave is not in the frozen eligible voter set.
+        let result = engine.ingest_approve(&proposal.proposal_id, &dave(), &ctx);
+        assert!(matches!(
+            result.unwrap_err(),
+            GovernanceError::NotEligible(_)
+        ));
+    }
+
+    #[test]
+    fn ingest_approve_rejects_already_voted() {
+        let mut engine = default_engine(three_voters());
+        let ctx = test_context(&three_voters(), T0);
+        let proposal = propose_add_member(&mut engine, &alice(), &ctx, &sk_alice());
+        let pid = proposal.proposal_id;
+
+        engine.ingest_approve(&pid, &alice(), &ctx).expect("ingest");
+        let result = engine.ingest_approve(&pid, &alice(), &ctx);
+        assert!(matches!(result.unwrap_err(), GovernanceError::AlreadyVoted));
+    }
+
+    #[test]
+    fn ingest_approve_rejects_terminal_proposal() {
+        let mut engine = default_engine(three_voters());
+        let ctx = test_context(&three_voters(), T0);
+        let proposal = propose_add_member(&mut engine, &alice(), &ctx, &sk_alice());
+        let pid = proposal.proposal_id;
+
+        // Drive to Approved (2 of 3).
+        engine.ingest_approve(&pid, &alice(), &ctx).expect("ingest");
+        let (status, _) = engine.ingest_approve(&pid, &bob(), &ctx).expect("ingest");
+        assert_eq!(status, ProposalStatus::Approved);
+
+        let result = engine.ingest_approve(&pid, &carol(), &ctx);
+        assert!(matches!(
+            result.unwrap_err(),
+            GovernanceError::ProposalNotPending { .. }
+        ));
+    }
+
+    #[test]
+    fn ingest_approve_past_deadline_triggers_resolve() {
+        // Mirrors approve_past_deadline_triggers_resolve for the keyless path:
+        // a post-deadline ingest defers to resolve(). One vote / 3 eligible =
+        // 3333 bps < 5000 quorum -> InsufficientParticipation.
+        let mut engine = default_engine(three_voters());
+        let ctx = test_context(&three_voters(), T0);
+        let proposal = propose_add_member(&mut engine, &alice(), &ctx, &sk_alice());
+        let pid = proposal.proposal_id;
+
+        engine.ingest_approve(&pid, &alice(), &ctx).expect("ingest");
+
+        let ctx_late = test_context(&three_voters(), T0 + WINDOW + 1);
+        let (status, _) = engine
+            .ingest_approve(&pid, &bob(), &ctx_late)
+            .expect("resolve");
+        assert_eq!(
+            status,
+            ProposalStatus::Rejected {
+                reason: RejectionReason::InsufficientParticipation
+            }
+        );
+    }
+
+    #[test]
+    fn ingest_and_signed_paths_reach_identical_status() {
+        let ctx = test_context(&three_voters(), T0);
+
+        // Signed path: alice + bob approve -> absolute majority -> Approved.
+        let mut signed = default_engine(three_voters());
+        let sp = propose_add_member(&mut signed, &alice(), &ctx, &sk_alice());
+        signed
+            .approve(&sp.proposal_id, &alice(), &ctx, &sk_alice())
+            .expect("approve");
+        let (signed_status, _) = signed
+            .approve(&sp.proposal_id, &bob(), &ctx, &sk_bob())
+            .expect("approve");
+
+        // Ingest path: same sequence, keyless.
+        let mut ingested = default_engine(three_voters());
+        let ip = propose_add_member(&mut ingested, &alice(), &ctx, &sk_alice());
+        ingested
+            .ingest_approve(&ip.proposal_id, &alice(), &ctx)
+            .expect("ingest");
+        let (ingest_status, _) = ingested
+            .ingest_approve(&ip.proposal_id, &bob(), &ctx)
+            .expect("ingest");
+
+        assert_eq!(signed_status, ingest_status);
+        assert_eq!(signed_status, ProposalStatus::Approved);
     }
 }

--- a/crates/scp-protocol/src/context/governance/majority.rs
+++ b/crates/scp-protocol/src/context/governance/majority.rs
@@ -320,29 +320,31 @@ impl MajorityVoteEngine {
             || proposal.rejections.iter().any(|v| v.voter_did == *voter)
     }
 
-    /// Record an already-built vote and run the tally.
+    /// Run the pre-vote guard checks.
     ///
-    /// Shared by the signed [`GovernanceEngine::approve`] /
-    /// [`GovernanceEngine::reject`] path and the keyless
-    /// [`TrustedVoteIngest`](super::TrustedVoteIngest) path. This helper begins
-    /// **after** any signature verification: the signed path verifies the vote
-    /// against the voter's DID-resolved key before calling this; the keyless
-    /// path supplies an empty-signature vote.
+    /// This is the portion that MUST run **before** any signing or signature
+    /// verification on the signed path, so that a double vote is caught as
+    /// `AlreadyVoted` regardless of which key signed the second attempt, and an
+    /// ineligible voter is rejected as `NotEligible` rather than
+    /// `InvalidSignature`. The checks and their error variants match the
+    /// original pre-refactor `approve`/`reject` exactly: eligibility
+    /// (`NotEligible`), proposal existence (`ProposalNotFound`), pending state
+    /// (`ProposalNotPending`), then the deadline branch.
     ///
-    /// The shared portion matches the original control flow exactly: the
-    /// eligibility check, the precondition block (pending check, deadline flag,
-    /// single-vote dedup), the deferral to `resolve()` when the deadline has
-    /// passed, the push into `approvals`/`rejections`, the `VoteCast` event, and
-    /// the inline early-resolution (`approvals * 2 > eligible` for an approval,
-    /// `rejections >= eligible.div_ceil(2)` for a rejection).
-    fn record_vote_and_resolve(
+    /// Majority-specific subtlety: a past-deadline vote does **not** error.
+    /// Exactly as the original control flow, it auto-resolves the proposal via
+    /// `resolve()` **without recording a vote and without signing**, returning
+    /// the resolution as [`PrecheckOutcome::Resolved`](super::PrecheckOutcome::Resolved)
+    /// so the caller short-circuits. The single-vote dedup (`AlreadyVoted`) is
+    /// only evaluated when the deadline has **not** passed — matching the
+    /// original `!expired && Self::has_voted(..)` guard. Takes `&mut self`
+    /// because the early-resolve transitions proposal state.
+    fn precheck_vote(
         &mut self,
         proposal_id: &ProposalId,
         voter: &DID,
-        signed_vote: super::SignedVote,
-        vote: VoteType,
         context: &GovernanceContext,
-    ) -> Result<(ProposalStatus, Vec<GovernanceEvent>), GovernanceError> {
+    ) -> Result<super::PrecheckOutcome, GovernanceError> {
         // Verify voter is eligible.
         if !self.eligible_voter_dids.contains(voter) {
             return Err(GovernanceError::NotEligible(format!(
@@ -373,11 +375,37 @@ impl MajorityVoteEngine {
             expired
         };
 
-        // Handle deadline expiry (self.resolve needs &mut self).
+        // Handle deadline expiry (self.resolve needs &mut self). Auto-resolve
+        // WITHOUT recording a vote or signing — the caller returns this result.
         if past_deadline {
-            return self.resolve(proposal_id, context);
+            return Ok(super::PrecheckOutcome::Resolved(
+                self.resolve(proposal_id, context)?,
+            ));
         }
 
+        Ok(super::PrecheckOutcome::Proceed)
+    }
+
+    /// Record an already-checked, already-verified vote and run the inline
+    /// early-resolution.
+    ///
+    /// Runs **after** `precheck_vote` (and, on the signed path, after signature
+    /// verification): pushes the vote into `approvals`/`rejections`, emits the
+    /// `VoteCast` event, and applies the inline early-resolution
+    /// (`approvals * 2 > eligible` for an approval, `rejections >=
+    /// eligible.div_ceil(2)` for a rejection). No unverified vote ever reaches
+    /// this point on the signed path — the keyless
+    /// [`TrustedVoteIngest`](super::TrustedVoteIngest) path supplies an
+    /// empty-signature vote by contract. The deadline has already been handled
+    /// by `precheck_vote`, so the proposal here is guaranteed not past-deadline.
+    fn push_and_resolve(
+        &mut self,
+        proposal_id: &ProposalId,
+        voter: &DID,
+        signed_vote: super::SignedVote,
+        vote: VoteType,
+        _context: &GovernanceContext,
+    ) -> Result<(ProposalStatus, Vec<GovernanceEvent>), GovernanceError> {
         let eligible = self.eligible_voter_dids.len();
 
         // Capture the vote discriminant before moving `vote` into the VoteCast
@@ -503,6 +531,16 @@ impl GovernanceEngine for MajorityVoteEngine {
         context: &GovernanceContext,
         signing_key: &ed25519_dalek::SigningKey,
     ) -> Result<(ProposalStatus, Vec<GovernanceEvent>), GovernanceError> {
+        // Guards run BEFORE sign/verify: a double vote must be caught as
+        // AlreadyVoted (and an ineligible voter as NotEligible) regardless of
+        // which key signed the attempt. Majority additionally short-circuits a
+        // past-deadline vote by auto-resolving WITHOUT recording a vote or
+        // signing — exactly as the original control flow did.
+        match self.precheck_vote(proposal_id, voter, context)? {
+            super::PrecheckOutcome::Proceed => {}
+            super::PrecheckOutcome::Resolved(resolution) => return Ok(resolution),
+        }
+
         // Build and sign the vote.
         let signed_vote = sign_vote(
             proposal_id,
@@ -513,8 +551,8 @@ impl GovernanceEngine for MajorityVoteEngine {
         )?;
 
         // Verify the vote signature against the voter's DID-resolved key.
-        // This MUST stay strictly before record_vote_and_resolve: the signed
-        // path counts a vote only after its signature is verified.
+        // This MUST stay strictly before push_and_resolve: the signed path
+        // counts a vote only after its signature is verified.
         let resolved_key = (self.key_resolver)(voter, SigningKeyId::Active).ok_or_else(|| {
             GovernanceError::UnknownVoter {
                 did: voter.to_string(),
@@ -527,7 +565,7 @@ impl GovernanceEngine for MajorityVoteEngine {
             }
         })?;
 
-        self.record_vote_and_resolve(proposal_id, voter, signed_vote, VoteType::Approve, context)
+        self.push_and_resolve(proposal_id, voter, signed_vote, VoteType::Approve, context)
     }
 
     fn reject(
@@ -537,6 +575,12 @@ impl GovernanceEngine for MajorityVoteEngine {
         context: &GovernanceContext,
         signing_key: &ed25519_dalek::SigningKey,
     ) -> Result<(ProposalStatus, Vec<GovernanceEvent>), GovernanceError> {
+        // Guards run BEFORE sign/verify (see `approve`).
+        match self.precheck_vote(proposal_id, voter, context)? {
+            super::PrecheckOutcome::Proceed => {}
+            super::PrecheckOutcome::Resolved(resolution) => return Ok(resolution),
+        }
+
         // Build and sign the rejection vote.
         let signed_vote = sign_vote(
             proposal_id,
@@ -547,8 +591,8 @@ impl GovernanceEngine for MajorityVoteEngine {
         )?;
 
         // Verify the vote signature against the voter's DID-resolved key.
-        // This MUST stay strictly before record_vote_and_resolve: the signed
-        // path counts a vote only after its signature is verified.
+        // This MUST stay strictly before push_and_resolve: the signed path
+        // counts a vote only after its signature is verified.
         let resolved_key = (self.key_resolver)(voter, SigningKeyId::Active).ok_or_else(|| {
             GovernanceError::UnknownVoter {
                 did: voter.to_string(),
@@ -561,7 +605,7 @@ impl GovernanceEngine for MajorityVoteEngine {
             }
         })?;
 
-        self.record_vote_and_resolve(proposal_id, voter, signed_vote, VoteType::Reject, context)
+        self.push_and_resolve(proposal_id, voter, signed_vote, VoteType::Reject, context)
     }
 
     fn resolve(
@@ -723,19 +767,17 @@ impl super::TrustedVoteIngest for MajorityVoteEngine {
         voter: &DID,
         context: &GovernanceContext,
     ) -> Result<(ProposalStatus, Vec<GovernanceEvent>), GovernanceError> {
-        // Keyless: build an empty-signature vote and feed it through the same
-        // tally as the signed path. No sign_vote, no verify_vote — the caller
-        // is responsible for authenticating the vote out-of-band (see the
-        // TrustedVoteIngest contract). The timestamp is read from
-        // GovernanceContext::now, the same clock the signed path uses. The vote
-        // is tallied against the engine's frozen eligible_voter_dids.
-        let signed_vote = super::SignedVote {
-            voter_did: voter.clone(),
-            vote: VoteType::Approve,
-            timestamp: context.now,
-            signature: Vec::new(),
-        };
-        self.record_vote_and_resolve(proposal_id, voter, signed_vote, VoteType::Approve, context)
+        // Keyless: run the same guards, then push an empty-signature vote
+        // through the same tally as the signed path. No sign_vote, no
+        // verify_vote — the caller is responsible for authenticating the vote
+        // out-of-band (see the TrustedVoteIngest contract). A past-deadline
+        // ingest short-circuits to the auto-resolution from precheck.
+        match self.precheck_vote(proposal_id, voter, context)? {
+            super::PrecheckOutcome::Proceed => {}
+            super::PrecheckOutcome::Resolved(resolution) => return Ok(resolution),
+        }
+        let signed_vote = super::build_unsigned_vote(voter, VoteType::Approve, context.now);
+        self.push_and_resolve(proposal_id, voter, signed_vote, VoteType::Approve, context)
     }
 
     fn ingest_reject(
@@ -744,13 +786,12 @@ impl super::TrustedVoteIngest for MajorityVoteEngine {
         voter: &DID,
         context: &GovernanceContext,
     ) -> Result<(ProposalStatus, Vec<GovernanceEvent>), GovernanceError> {
-        let signed_vote = super::SignedVote {
-            voter_did: voter.clone(),
-            vote: VoteType::Reject,
-            timestamp: context.now,
-            signature: Vec::new(),
-        };
-        self.record_vote_and_resolve(proposal_id, voter, signed_vote, VoteType::Reject, context)
+        match self.precheck_vote(proposal_id, voter, context)? {
+            super::PrecheckOutcome::Proceed => {}
+            super::PrecheckOutcome::Resolved(resolution) => return Ok(resolution),
+        }
+        let signed_vote = super::build_unsigned_vote(voter, VoteType::Reject, context.now);
+        self.push_and_resolve(proposal_id, voter, signed_vote, VoteType::Reject, context)
     }
 }
 
@@ -2589,5 +2630,61 @@ mod tests {
 
         assert_eq!(signed_status, ingest_status);
         assert_eq!(signed_status, ProposalStatus::Approved);
+    }
+
+    // -----------------------------------------------------------------------
+    // Guard ordering: dedup and eligibility precede signature verification.
+    //
+    // Mirrors the scp-runtime agent-binding scenario at the engine layer:
+    // the guards (NotEligible / AlreadyVoted) MUST run BEFORE sign/verify so a
+    // double vote is caught as a double vote regardless of which key signed it,
+    // and an ineligible voter is rejected as NotEligible rather than
+    // InvalidSignature.
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn second_vote_same_did_different_key_is_already_voted_not_invalid_sig() {
+        // Three eligible voters: a single approval keeps the proposal Pending
+        // (1 * 2 > 3 is false), so the dedup guard is exercised on the second
+        // vote rather than being short-circuited by early resolution. Bob's DID
+        // resolves to sk_bob only; his second attempt uses a different (wrong)
+        // key (sk_carol). The AlreadyVoted dedup must fire before signature
+        // verification.
+        let mut engine = default_engine(three_voters());
+        let ctx = test_context(&three_voters(), T0);
+        let proposal = propose_add_member(&mut engine, &alice(), &ctx, &sk_alice());
+        let pid = proposal.proposal_id;
+
+        // First vote: valid (sk_bob matches the resolver's entry for bob).
+        let (status, _) = engine.approve(&pid, &bob(), &ctx, &sk_bob()).expect("ok");
+        assert_eq!(
+            status,
+            ProposalStatus::Pending,
+            "1 approval of 3 stays pending"
+        );
+
+        // Second vote: same DID, different (wrong) signing key.
+        let result = engine.approve(&pid, &bob(), &ctx, &sk_carol());
+        assert!(
+            matches!(result.unwrap_err(), GovernanceError::AlreadyVoted),
+            "dedup must precede signature verification (expected AlreadyVoted, not InvalidSignature)"
+        );
+    }
+
+    #[test]
+    fn ineligible_voter_with_invalid_sig_is_not_eligible_not_invalid_sig() {
+        // Dave is NOT an eligible voter. He votes with a key that does not
+        // match his DID-resolved key. The eligibility check (NotEligible) must
+        // run before signature verification.
+        let mut engine = default_engine(three_voters());
+        let ctx = test_context(&three_voters(), T0);
+        let proposal = propose_add_member(&mut engine, &alice(), &ctx, &sk_alice());
+
+        // Dave is not eligible; sign with a mismatched key (sk_carol).
+        let result = engine.approve(&proposal.proposal_id, &dave(), &ctx, &sk_carol());
+        assert!(
+            matches!(result.unwrap_err(), GovernanceError::NotEligible(_)),
+            "eligibility must precede signature verification (expected NotEligible)"
+        );
     }
 }

--- a/crates/scp-protocol/src/context/governance/mod.rs
+++ b/crates/scp-protocol/src/context/governance/mod.rs
@@ -893,6 +893,46 @@ pub struct SignedVote {
     pub signature: Ed25519Signature,
 }
 
+/// Outcome of an engine's pre-vote guard checks (`precheck_vote`).
+///
+/// The guard checks (eligibility, proposal existence, pending state, deadline,
+/// single-vote dedup) run **before** any signing or signature verification, so
+/// that a double vote is caught as `AlreadyVoted` regardless of which key signed
+/// it. Most engines only ever return [`Proceed`](PrecheckOutcome::Proceed) from
+/// a successful precheck. The majority engine additionally short-circuits a
+/// past-deadline vote by auto-resolving the proposal **without recording a vote
+/// and without signing** — that case is carried by
+/// [`Resolved`](PrecheckOutcome::Resolved) so the caller returns the resolution
+/// directly.
+pub(super) enum PrecheckOutcome {
+    /// Guards passed; the caller should build the vote, (for the signed path)
+    /// sign and verify it, then call `push_and_resolve`.
+    Proceed,
+    /// The proposal was auto-resolved during precheck (majority past-deadline).
+    /// The caller returns this status and its events directly, recording no
+    /// vote and performing no signing or verification.
+    Resolved((ProposalStatus, Vec<GovernanceEvent>)),
+}
+
+/// Build an unsigned (empty-signature) [`SignedVote`] for the keyless
+/// [`TrustedVoteIngest`] path.
+///
+/// Used by every engine's `ingest_approve` / `ingest_reject` implementation to
+/// construct the vote that is fed through the shared post-verify tally. The
+/// signature is deliberately empty (`Vec::new()`): the keyless path performs no
+/// signing and no verification — the caller is responsible for authenticating
+/// the vote out-of-band (see [`TrustedVoteIngest`]). The `now` argument is read
+/// from [`GovernanceContext::now`], the same clock the signed path uses, so no
+/// independent clock is introduced.
+pub(super) fn build_unsigned_vote(voter: &DID, vote: VoteType, now: u64) -> SignedVote {
+    SignedVote {
+        voter_did: voter.clone(),
+        vote,
+        timestamp: now,
+        signature: Vec::new(),
+    }
+}
+
 // ---------------------------------------------------------------------------
 // RejectionReason
 // ---------------------------------------------------------------------------

--- a/crates/scp-protocol/src/context/governance/mod.rs
+++ b/crates/scp-protocol/src/context/governance/mod.rs
@@ -985,12 +985,20 @@ pub struct GovernanceProposal {
     pub action: GovernanceAction,
     /// Current lifecycle status.
     ///
-    /// **Invariant:** When `status` is [`ProposalStatus::Approved`], all vote
-    /// signatures in [`approvals`](Self::approvals) have been cryptographically
-    /// verified against the voter's DID-resolved public key via the engine's
-    /// [`KeyResolver`]. Code that receives an `Approved` proposal can trust
-    /// that every approval vote is authentic — no further signature checks
-    /// are needed.
+    /// **Invariant (signed path only):** When a proposal is resolved through
+    /// the signed [`GovernanceEngine::approve`] / [`GovernanceEngine::reject`]
+    /// path and reaches [`ProposalStatus::Approved`], all vote signatures in
+    /// [`approvals`](Self::approvals) have been cryptographically verified
+    /// against the voter's DID-resolved public key via the engine's
+    /// [`KeyResolver`]. Code that receives such an `Approved` proposal can trust
+    /// that every approval vote is authentic — no further signature checks are
+    /// needed.
+    ///
+    /// **This invariant does NOT hold** for proposals resolved via the keyless
+    /// [`TrustedVoteIngest`] path (the WASM bridge, ADR-034). That path performs
+    /// no signature verification and records votes with an empty signature; the
+    /// caller is responsible for authenticating votes out-of-band. See
+    /// [`TrustedVoteIngest`] for the full security contract.
     pub status: ProposalStatus,
     /// Unix timestamp (seconds) when the proposal was created.
     pub created_at: u64,
@@ -1490,6 +1498,115 @@ pub trait GovernanceEngine: Send + Sync {
         cosignatures: &[CosignedCheckpoint],
         checkpoint_hash: &[u8; 32],
     ) -> Result<CheckpointAttestationStatus, GovernanceError>;
+}
+
+// ---------------------------------------------------------------------------
+// TrustedVoteIngest trait
+// ---------------------------------------------------------------------------
+
+/// Keyless, caller-trusted vote ingestion for FFI bridges that hold no signing
+/// key and no [`KeyResolver`] (the WASM bridge, ADR-034).
+///
+/// # Purpose
+///
+/// The WASM bridge runs with no-key custody (ADR-034): it cannot sign votes and
+/// has no resolver to verify signatures against. To let WASM reuse the *exact*
+/// quorum-tally logic of the signed governance engines — rather than
+/// maintaining a divergent re-implementation that could disagree with native on
+/// when a proposal reaches `Approved`/`Rejected` — this trait exposes a keyless
+/// ingestion path that runs the identical tally after the caller has already
+/// authenticated the vote out-of-band.
+///
+/// This trait is deliberately **separate** from [`GovernanceEngine`] and is
+/// **not** a method on it. Native code accesses engines via
+/// `Box<dyn GovernanceEngine>`, which does not have `ingest_*` in scope, so the
+/// native signed path cannot be bypassed: native always runs
+/// `approve`/`reject`, which verify every signature before counting it.
+///
+/// # Caller contract (MUST hold before calling)
+///
+/// The caller is trusted to assert *which eligible member* voted. It is **not**
+/// trusted to bypass eligibility, dedup, or finality (those are still enforced
+/// by the shared tally — see below). Before invoking `ingest_approve` /
+/// `ingest_reject`, the caller MUST have authenticated:
+///
+/// 1. **Caller identity == `voter`.** The process invoking ingestion is acting
+///    on behalf of exactly the DID passed as `voter`.
+/// 2. **`voter` holds `governance:vote` in THIS context.** The voter is
+///    authorized to vote on proposals in `context`'s context (UCAN-validated by
+///    the caller).
+/// 3. **`proposal_id` scoping.** The `proposal_id` belongs to this context and
+///    this engine instance.
+///
+/// # Security properties
+///
+/// This path performs **NO signature verification** and records a vote with an
+/// **empty signature** (`signature: Vec::new()`). Consequently, the
+/// [`GovernanceProposal::status`] `== Approved ⟹ all vote signatures verified`
+/// invariant does **NOT** hold for any proposal resolved via this path.
+///
+/// The shared tally still enforces eligibility (`NotEligible`), single-vote
+/// dedup (`AlreadyVoted`), the voting deadline (`VotingWindowExpired`), and
+/// terminal-state finality (`ProposalNotPending`). "Caller-trusted" means
+/// trusted only to assert *which* eligible member voted — never to bypass these
+/// invariants.
+///
+/// # Residual risk and compensating control
+///
+/// A malicious same-origin caller can assert a vote for any eligible member
+/// without that member's signature. This is an inherent property of ADR-034
+/// no-key custody: a host that can fabricate ingestion calls is already inside
+/// the trust boundary of its own browser origin. The compensating control is
+/// §9.9.3 equivocation / Merkle-root convergence: a native participant running
+/// the genuine signed path would reject the unverifiable vote and never reach
+/// `Approved` on it, so the event-log roots of the keyless caller and any
+/// honest signed participant diverge and the equivocation is detectable.
+///
+/// The timestamp recorded on the ingested vote is read from
+/// [`GovernanceContext::now`] — the same clock the signed path uses — so no
+/// independent clock is introduced.
+pub trait TrustedVoteIngest {
+    /// Ingest a caller-authenticated approval vote without signature
+    /// verification, then run the shared tally.
+    ///
+    /// Builds a [`SignedVote`] with an empty signature for `voter` and feeds it
+    /// through the identical record-and-resolve path used by the signed
+    /// `approve` flow (minus signing and verification). Returns the resulting
+    /// status and events.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`GovernanceError`] under the same conditions the signed path
+    /// would after verification succeeds: `NotEligible` if `voter` is not in
+    /// the engine's frozen eligible set, `ProposalNotFound` if `proposal_id` is
+    /// unknown, `ProposalNotPending` if the proposal is terminal,
+    /// `VotingWindowExpired` past the deadline, or `AlreadyVoted` on a repeat
+    /// vote.
+    fn ingest_approve(
+        &mut self,
+        proposal_id: &ProposalId,
+        voter: &DID,
+        context: &GovernanceContext,
+    ) -> Result<(ProposalStatus, Vec<GovernanceEvent>), GovernanceError>;
+
+    /// Ingest a caller-authenticated rejection vote without signature
+    /// verification, then run the shared tally.
+    ///
+    /// Builds a [`SignedVote`] with an empty signature for `voter` and feeds it
+    /// through the identical record-and-resolve path used by the signed
+    /// `reject` flow (minus signing and verification). Returns the resulting
+    /// status and events.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`GovernanceError`] under the same conditions as
+    /// [`ingest_approve`](Self::ingest_approve).
+    fn ingest_reject(
+        &mut self,
+        proposal_id: &ProposalId,
+        voter: &DID,
+        context: &GovernanceContext,
+    ) -> Result<(ProposalStatus, Vec<GovernanceEvent>), GovernanceError>;
 }
 
 // ---------------------------------------------------------------------------

--- a/crates/scp-protocol/src/context/governance/mod.rs
+++ b/crates/scp-protocol/src/context/governance/mod.rs
@@ -905,7 +905,7 @@ pub struct SignedVote {
 /// [`Resolved`](PrecheckOutcome::Resolved) so the caller returns the resolution
 /// directly.
 pub(super) enum PrecheckOutcome {
-    /// Guards passed; the caller should build the vote, (for the signed path)
+    /// Guards passed; the caller should build the vote (for the signed path),
     /// sign and verify it, then call `push_and_resolve`.
     Proceed,
     /// The proposal was auto-resolved during precheck (majority past-deadline).

--- a/crates/scp-protocol/src/context/governance/multisig.rs
+++ b/crates/scp-protocol/src/context/governance/multisig.rs
@@ -216,25 +216,27 @@ impl ThresholdEngine {
         Ok((new_status, events))
     }
 
-    /// Record an already-built vote and run the tally.
+    /// Run the pre-vote guard checks.
     ///
-    /// Shared by the signed [`GovernanceEngine::approve`] /
-    /// [`GovernanceEngine::reject`] path and the keyless
-    /// [`TrustedVoteIngest`](super::TrustedVoteIngest) path. This helper begins
-    /// **after** any signature verification: the signed path verifies the vote
-    /// against the voter's DID-resolved key before calling this; the keyless
-    /// path supplies an empty-signature vote. The shared portion is the
-    /// eligibility check, pending check, deadline guard, single-vote dedup, the
-    /// push into `approvals`/`rejections`, the `VoteCast` event, and the
-    /// resolve.
-    fn record_vote_and_resolve(
-        &mut self,
+    /// This is the portion that MUST run **before** any signing or signature
+    /// verification on the signed path, so that a double vote is caught as
+    /// `AlreadyVoted` regardless of which key signed the second attempt, and an
+    /// ineligible voter is rejected as `NotEligible` rather than
+    /// `InvalidSignature`. The checks and their error variants match the
+    /// original pre-refactor `approve`/`reject` exactly: eligibility
+    /// (`NotEligible`), proposal existence (`ProposalNotFound`), pending state
+    /// (`ProposalNotPending`), deadline (`VotingWindowExpired`), single-vote
+    /// dedup (`AlreadyVoted`).
+    ///
+    /// Threshold treats a past-deadline vote as `VotingWindowExpired` (no
+    /// auto-resolve), so this only ever returns
+    /// [`PrecheckOutcome::Proceed`](super::PrecheckOutcome::Proceed) on success.
+    fn precheck_vote(
+        &self,
         proposal_id: &ProposalId,
         voter: &DID,
-        signed_vote: super::SignedVote,
-        vote: VoteType,
         context: &GovernanceContext,
-    ) -> Result<(ProposalStatus, Vec<GovernanceEvent>), GovernanceError> {
+    ) -> Result<super::PrecheckOutcome, GovernanceError> {
         // Voter must be a signer.
         if !self.is_signer(voter) {
             return Err(GovernanceError::NotEligible(
@@ -268,7 +270,27 @@ impl ThresholdEngine {
             return Err(GovernanceError::AlreadyVoted);
         }
 
-        // Key is guaranteed present because we just looked it up via `get()` above.
+        Ok(super::PrecheckOutcome::Proceed)
+    }
+
+    /// Record an already-checked, already-verified vote and run the tally.
+    ///
+    /// Runs **after** `precheck_vote` (and, on the signed path, after signature
+    /// verification): pushes the vote into `approvals`/`rejections`, emits the
+    /// `VoteCast` event, and resolves. No unverified vote ever reaches this
+    /// point on the signed path — the keyless
+    /// [`TrustedVoteIngest`](super::TrustedVoteIngest) path supplies an
+    /// empty-signature vote by contract.
+    fn push_and_resolve(
+        &mut self,
+        proposal_id: &ProposalId,
+        voter: &DID,
+        signed_vote: super::SignedVote,
+        vote: VoteType,
+        context: &GovernanceContext,
+    ) -> Result<(ProposalStatus, Vec<GovernanceEvent>), GovernanceError> {
+        // Key is guaranteed present: precheck_vote looked it up and we hold
+        // `&mut self` continuously since then.
         if let Some(proposal_mut) = self.proposals.get_mut(proposal_id) {
             match vote {
                 VoteType::Approve => proposal_mut.approvals.push(signed_vote),
@@ -407,6 +429,15 @@ impl GovernanceEngine for ThresholdEngine {
         context: &GovernanceContext,
         signing_key: &ed25519_dalek::SigningKey,
     ) -> Result<(ProposalStatus, Vec<GovernanceEvent>), GovernanceError> {
+        // Guards run BEFORE sign/verify: a double vote must be caught as
+        // AlreadyVoted (and an ineligible voter as NotEligible) regardless of
+        // which key signed the attempt. Threshold never early-resolves in
+        // precheck, so Proceed is the only success outcome.
+        match self.precheck_vote(proposal_id, voter, context)? {
+            super::PrecheckOutcome::Proceed => {}
+            super::PrecheckOutcome::Resolved(resolution) => return Ok(resolution),
+        }
+
         // Build and sign the vote.
         let vote = sign_vote(
             proposal_id,
@@ -417,8 +448,8 @@ impl GovernanceEngine for ThresholdEngine {
         )?;
 
         // Verify the vote signature against the voter's DID-resolved key.
-        // This MUST stay strictly before record_vote_and_resolve: the signed
-        // path counts a vote only after its signature is verified.
+        // This MUST stay strictly before push_and_resolve: the signed path
+        // counts a vote only after its signature is verified.
         let resolved_key = (self.key_resolver)(voter, SigningKeyId::Active).ok_or_else(|| {
             GovernanceError::UnknownVoter {
                 did: voter.to_string(),
@@ -431,7 +462,7 @@ impl GovernanceEngine for ThresholdEngine {
             }
         })?;
 
-        self.record_vote_and_resolve(proposal_id, voter, vote, VoteType::Approve, context)
+        self.push_and_resolve(proposal_id, voter, vote, VoteType::Approve, context)
     }
 
     fn reject(
@@ -441,6 +472,12 @@ impl GovernanceEngine for ThresholdEngine {
         context: &GovernanceContext,
         signing_key: &ed25519_dalek::SigningKey,
     ) -> Result<(ProposalStatus, Vec<GovernanceEvent>), GovernanceError> {
+        // Guards run BEFORE sign/verify (see `approve`).
+        match self.precheck_vote(proposal_id, voter, context)? {
+            super::PrecheckOutcome::Proceed => {}
+            super::PrecheckOutcome::Resolved(resolution) => return Ok(resolution),
+        }
+
         // Build and sign the rejection vote.
         let vote = sign_vote(
             proposal_id,
@@ -451,8 +488,8 @@ impl GovernanceEngine for ThresholdEngine {
         )?;
 
         // Verify the vote signature against the voter's DID-resolved key.
-        // This MUST stay strictly before record_vote_and_resolve: the signed
-        // path counts a vote only after its signature is verified.
+        // This MUST stay strictly before push_and_resolve: the signed path
+        // counts a vote only after its signature is verified.
         let resolved_key = (self.key_resolver)(voter, SigningKeyId::Active).ok_or_else(|| {
             GovernanceError::UnknownVoter {
                 did: voter.to_string(),
@@ -465,7 +502,7 @@ impl GovernanceEngine for ThresholdEngine {
             }
         })?;
 
-        self.record_vote_and_resolve(proposal_id, voter, vote, VoteType::Reject, context)
+        self.push_and_resolve(proposal_id, voter, vote, VoteType::Reject, context)
     }
 
     fn withdraw_vote(
@@ -679,18 +716,16 @@ impl super::TrustedVoteIngest for ThresholdEngine {
         voter: &DID,
         context: &GovernanceContext,
     ) -> Result<(ProposalStatus, Vec<GovernanceEvent>), GovernanceError> {
-        // Keyless: build an empty-signature vote and feed it through the same
-        // tally as the signed path. No sign_vote, no verify_vote — the caller
-        // is responsible for authenticating the vote out-of-band (see the
-        // TrustedVoteIngest contract). The timestamp is read from
-        // GovernanceContext::now, the same clock the signed path uses.
-        let signed_vote = super::SignedVote {
-            voter_did: voter.clone(),
-            vote: VoteType::Approve,
-            timestamp: context.now,
-            signature: Vec::new(),
-        };
-        self.record_vote_and_resolve(proposal_id, voter, signed_vote, VoteType::Approve, context)
+        // Keyless: run the same guards, then push an empty-signature vote
+        // through the same tally as the signed path. No sign_vote, no
+        // verify_vote — the caller is responsible for authenticating the vote
+        // out-of-band (see the TrustedVoteIngest contract).
+        match self.precheck_vote(proposal_id, voter, context)? {
+            super::PrecheckOutcome::Proceed => {}
+            super::PrecheckOutcome::Resolved(resolution) => return Ok(resolution),
+        }
+        let signed_vote = super::build_unsigned_vote(voter, VoteType::Approve, context.now);
+        self.push_and_resolve(proposal_id, voter, signed_vote, VoteType::Approve, context)
     }
 
     fn ingest_reject(
@@ -699,13 +734,12 @@ impl super::TrustedVoteIngest for ThresholdEngine {
         voter: &DID,
         context: &GovernanceContext,
     ) -> Result<(ProposalStatus, Vec<GovernanceEvent>), GovernanceError> {
-        let signed_vote = super::SignedVote {
-            voter_did: voter.clone(),
-            vote: VoteType::Reject,
-            timestamp: context.now,
-            signature: Vec::new(),
-        };
-        self.record_vote_and_resolve(proposal_id, voter, signed_vote, VoteType::Reject, context)
+        match self.precheck_vote(proposal_id, voter, context)? {
+            super::PrecheckOutcome::Proceed => {}
+            super::PrecheckOutcome::Resolved(resolution) => return Ok(resolution),
+        }
+        let signed_vote = super::build_unsigned_vote(voter, VoteType::Reject, context.now);
+        self.push_and_resolve(proposal_id, voter, signed_vote, VoteType::Reject, context)
     }
 }
 
@@ -1978,5 +2012,66 @@ mod tests {
 
         assert_eq!(signed_status, ingest_status);
         assert_eq!(signed_status, ProposalStatus::Approved);
+    }
+
+    // -----------------------------------------------------------------------
+    // Guard ordering: dedup and eligibility precede signature verification.
+    //
+    // Mirrors the scp-runtime agent-binding scenario at the engine layer:
+    // the guards (NotEligible / AlreadyVoted) MUST run BEFORE sign/verify so a
+    // double vote is caught as a double vote regardless of which key signed it,
+    // and an ineligible voter is rejected as NotEligible rather than
+    // InvalidSignature.
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn second_vote_same_did_different_key_is_already_voted_not_invalid_sig() {
+        // Bob's DID resolves to sk_bob's key only. Bob approves once with the
+        // matching key (valid), then approves again with a DIFFERENT key
+        // (sk_carol) that does NOT match his DID-resolved key. The second
+        // attempt would fail signature verification — but the AlreadyVoted
+        // dedup runs first, so it is caught as a double vote.
+        let mut engine =
+            ThresholdEngine::new(vec![alice(), bob(), carol()], 3, 86_400, mock_resolver())
+                .expect("valid");
+        let ctx = test_context();
+
+        let (proposal, _) = engine
+            .propose(&alice(), default_action(), &ctx, &sk_alice())
+            .expect("propose ok");
+        let pid = proposal.proposal_id;
+
+        // First vote: valid (sk_bob matches the resolver's entry for bob).
+        engine.approve(&pid, &bob(), &ctx, &sk_bob()).expect("ok");
+
+        // Second vote: same DID, different (wrong) signing key.
+        let result = engine.approve(&pid, &bob(), &ctx, &sk_carol());
+        assert!(
+            matches!(result.unwrap_err(), GovernanceError::AlreadyVoted),
+            "dedup must precede signature verification (expected AlreadyVoted, not InvalidSignature)"
+        );
+    }
+
+    #[test]
+    fn ineligible_voter_with_invalid_sig_is_not_eligible_not_invalid_sig() {
+        // Dave is NOT a signer. He votes with a key that does not match his
+        // DID-resolved key. The eligibility check (NotEligible) must run before
+        // signature verification, so the error is NotEligible — not
+        // InvalidSignature / UnknownVoter.
+        let mut engine =
+            ThresholdEngine::new(vec![alice(), bob(), carol()], 2, 86_400, mock_resolver())
+                .expect("valid");
+        let ctx = test_context();
+
+        let (proposal, _) = engine
+            .propose(&alice(), default_action(), &ctx, &sk_alice())
+            .expect("propose ok");
+
+        // Dave is not in the signer set; sign with a mismatched key (sk_carol).
+        let result = engine.approve(&proposal.proposal_id, &dave(), &ctx, &sk_carol());
+        assert!(
+            matches!(result.unwrap_err(), GovernanceError::NotEligible(_)),
+            "eligibility must precede signature verification (expected NotEligible)"
+        );
     }
 }

--- a/crates/scp-protocol/src/context/governance/multisig.rs
+++ b/crates/scp-protocol/src/context/governance/multisig.rs
@@ -289,8 +289,11 @@ impl ThresholdEngine {
         vote: VoteType,
         context: &GovernanceContext,
     ) -> Result<(ProposalStatus, Vec<GovernanceEvent>), GovernanceError> {
-        // Key is guaranteed present: precheck_vote looked it up and we hold
-        // `&mut self` continuously since then.
+        // `precheck_vote` already validated the proposal exists, is pending, and
+        // within the deadline. We re-acquire it via `get_mut` here; in the
+        // single-threaded `&mut self` flow it cannot have been removed in
+        // between, so the `if let Some(..)` simply no-ops on the impossible
+        // absence rather than panicking.
         if let Some(proposal_mut) = self.proposals.get_mut(proposal_id) {
             match vote {
                 VoteType::Approve => proposal_mut.approvals.push(signed_vote),

--- a/crates/scp-protocol/src/context/governance/multisig.rs
+++ b/crates/scp-protocol/src/context/governance/multisig.rs
@@ -215,6 +215,79 @@ impl ThresholdEngine {
 
         Ok((new_status, events))
     }
+
+    /// Record an already-built vote and run the tally.
+    ///
+    /// Shared by the signed [`GovernanceEngine::approve`] /
+    /// [`GovernanceEngine::reject`] path and the keyless
+    /// [`TrustedVoteIngest`](super::TrustedVoteIngest) path. This helper begins
+    /// **after** any signature verification: the signed path verifies the vote
+    /// against the voter's DID-resolved key before calling this; the keyless
+    /// path supplies an empty-signature vote. The shared portion is the
+    /// eligibility check, pending check, deadline guard, single-vote dedup, the
+    /// push into `approvals`/`rejections`, the `VoteCast` event, and the
+    /// resolve.
+    fn record_vote_and_resolve(
+        &mut self,
+        proposal_id: &ProposalId,
+        voter: &DID,
+        signed_vote: super::SignedVote,
+        vote: VoteType,
+        context: &GovernanceContext,
+    ) -> Result<(ProposalStatus, Vec<GovernanceEvent>), GovernanceError> {
+        // Voter must be a signer.
+        if !self.is_signer(voter) {
+            return Err(GovernanceError::NotEligible(
+                "voter is not in the signer set".to_owned(),
+            ));
+        }
+
+        let proposal =
+            self.proposals
+                .get(proposal_id)
+                .ok_or_else(|| GovernanceError::ProposalNotFound {
+                    id: hex::encode(proposal_id),
+                })?;
+
+        // Must be pending.
+        if !proposal.status.is_pending() {
+            return Err(GovernanceError::ProposalNotPending {
+                status: format!("{:?}", proposal.status),
+            });
+        }
+
+        // Deadline guard -- reject votes after the voting window.
+        if context.now >= proposal.voting_deadline {
+            return Err(GovernanceError::VotingWindowExpired {
+                id: hex::encode(proposal_id),
+            });
+        }
+
+        // Must not have already voted.
+        if Self::has_voted(proposal, voter) {
+            return Err(GovernanceError::AlreadyVoted);
+        }
+
+        // Key is guaranteed present because we just looked it up via `get()` above.
+        if let Some(proposal_mut) = self.proposals.get_mut(proposal_id) {
+            match vote {
+                VoteType::Approve => proposal_mut.approvals.push(signed_vote),
+                VoteType::Reject => proposal_mut.rejections.push(signed_vote),
+            }
+        }
+
+        let mut events = vec![GovernanceEvent::VoteCast {
+            proposal_id: *proposal_id,
+            voter_did: voter.clone(),
+            vote,
+        }];
+
+        // Resolve after vote.
+        let (status, resolve_events) = self.resolve_proposal(proposal_id, context.now)?;
+        events.extend(resolve_events);
+
+        Ok((status, events))
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -334,40 +407,7 @@ impl GovernanceEngine for ThresholdEngine {
         context: &GovernanceContext,
         signing_key: &ed25519_dalek::SigningKey,
     ) -> Result<(ProposalStatus, Vec<GovernanceEvent>), GovernanceError> {
-        // Voter must be a signer.
-        if !self.is_signer(voter) {
-            return Err(GovernanceError::NotEligible(
-                "voter is not in the signer set".to_owned(),
-            ));
-        }
-
-        let proposal =
-            self.proposals
-                .get(proposal_id)
-                .ok_or_else(|| GovernanceError::ProposalNotFound {
-                    id: hex::encode(proposal_id),
-                })?;
-
-        // Must be pending.
-        if !proposal.status.is_pending() {
-            return Err(GovernanceError::ProposalNotPending {
-                status: format!("{:?}", proposal.status),
-            });
-        }
-
-        // Bug 1 fix: deadline guard -- reject votes after the voting window.
-        if context.now >= proposal.voting_deadline {
-            return Err(GovernanceError::VotingWindowExpired {
-                id: hex::encode(proposal_id),
-            });
-        }
-
-        // Must not have already voted.
-        if Self::has_voted(proposal, voter) {
-            return Err(GovernanceError::AlreadyVoted);
-        }
-
-        // Record the signed vote.
+        // Build and sign the vote.
         let vote = sign_vote(
             proposal_id,
             &VoteType::Approve,
@@ -377,6 +417,8 @@ impl GovernanceEngine for ThresholdEngine {
         )?;
 
         // Verify the vote signature against the voter's DID-resolved key.
+        // This MUST stay strictly before record_vote_and_resolve: the signed
+        // path counts a vote only after its signature is verified.
         let resolved_key = (self.key_resolver)(voter, SigningKeyId::Active).ok_or_else(|| {
             GovernanceError::UnknownVoter {
                 did: voter.to_string(),
@@ -389,22 +431,7 @@ impl GovernanceEngine for ThresholdEngine {
             }
         })?;
 
-        // Key is guaranteed present because we just looked it up via `get()` above.
-        if let Some(proposal_mut) = self.proposals.get_mut(proposal_id) {
-            proposal_mut.approvals.push(vote);
-        }
-
-        let mut events = vec![GovernanceEvent::VoteCast {
-            proposal_id: *proposal_id,
-            voter_did: voter.clone(),
-            vote: VoteType::Approve,
-        }];
-
-        // Resolve after vote.
-        let (status, resolve_events) = self.resolve_proposal(proposal_id, context.now)?;
-        events.extend(resolve_events);
-
-        Ok((status, events))
+        self.record_vote_and_resolve(proposal_id, voter, vote, VoteType::Approve, context)
     }
 
     fn reject(
@@ -414,40 +441,7 @@ impl GovernanceEngine for ThresholdEngine {
         context: &GovernanceContext,
         signing_key: &ed25519_dalek::SigningKey,
     ) -> Result<(ProposalStatus, Vec<GovernanceEvent>), GovernanceError> {
-        // Voter must be a signer.
-        if !self.is_signer(voter) {
-            return Err(GovernanceError::NotEligible(
-                "voter is not in the signer set".to_owned(),
-            ));
-        }
-
-        let proposal =
-            self.proposals
-                .get(proposal_id)
-                .ok_or_else(|| GovernanceError::ProposalNotFound {
-                    id: hex::encode(proposal_id),
-                })?;
-
-        // Must be pending.
-        if !proposal.status.is_pending() {
-            return Err(GovernanceError::ProposalNotPending {
-                status: format!("{:?}", proposal.status),
-            });
-        }
-
-        // Bug 1 fix: deadline guard -- reject votes after the voting window.
-        if context.now >= proposal.voting_deadline {
-            return Err(GovernanceError::VotingWindowExpired {
-                id: hex::encode(proposal_id),
-            });
-        }
-
-        // Must not have already voted.
-        if Self::has_voted(proposal, voter) {
-            return Err(GovernanceError::AlreadyVoted);
-        }
-
-        // Record the signed rejection vote.
+        // Build and sign the rejection vote.
         let vote = sign_vote(
             proposal_id,
             &VoteType::Reject,
@@ -457,6 +451,8 @@ impl GovernanceEngine for ThresholdEngine {
         )?;
 
         // Verify the vote signature against the voter's DID-resolved key.
+        // This MUST stay strictly before record_vote_and_resolve: the signed
+        // path counts a vote only after its signature is verified.
         let resolved_key = (self.key_resolver)(voter, SigningKeyId::Active).ok_or_else(|| {
             GovernanceError::UnknownVoter {
                 did: voter.to_string(),
@@ -469,22 +465,7 @@ impl GovernanceEngine for ThresholdEngine {
             }
         })?;
 
-        // Key is guaranteed present because we just looked it up via `get()` above.
-        if let Some(proposal_mut) = self.proposals.get_mut(proposal_id) {
-            proposal_mut.rejections.push(vote);
-        }
-
-        let mut events = vec![GovernanceEvent::VoteCast {
-            proposal_id: *proposal_id,
-            voter_did: voter.clone(),
-            vote: VoteType::Reject,
-        }];
-
-        // Resolve after vote.
-        let (status, resolve_events) = self.resolve_proposal(proposal_id, context.now)?;
-        events.extend(resolve_events);
-
-        Ok((status, events))
+        self.record_vote_and_resolve(proposal_id, voter, vote, VoteType::Reject, context)
     }
 
     fn withdraw_vote(
@@ -684,6 +665,47 @@ impl GovernanceEngine for ThresholdEngine {
         } else {
             Ok(CheckpointAttestationStatus::PartiallyAttested)
         }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// TrustedVoteIngest implementation (ADR-034 keyless path)
+// ---------------------------------------------------------------------------
+
+impl super::TrustedVoteIngest for ThresholdEngine {
+    fn ingest_approve(
+        &mut self,
+        proposal_id: &ProposalId,
+        voter: &DID,
+        context: &GovernanceContext,
+    ) -> Result<(ProposalStatus, Vec<GovernanceEvent>), GovernanceError> {
+        // Keyless: build an empty-signature vote and feed it through the same
+        // tally as the signed path. No sign_vote, no verify_vote — the caller
+        // is responsible for authenticating the vote out-of-band (see the
+        // TrustedVoteIngest contract). The timestamp is read from
+        // GovernanceContext::now, the same clock the signed path uses.
+        let signed_vote = super::SignedVote {
+            voter_did: voter.clone(),
+            vote: VoteType::Approve,
+            timestamp: context.now,
+            signature: Vec::new(),
+        };
+        self.record_vote_and_resolve(proposal_id, voter, signed_vote, VoteType::Approve, context)
+    }
+
+    fn ingest_reject(
+        &mut self,
+        proposal_id: &ProposalId,
+        voter: &DID,
+        context: &GovernanceContext,
+    ) -> Result<(ProposalStatus, Vec<GovernanceEvent>), GovernanceError> {
+        let signed_vote = super::SignedVote {
+            voter_did: voter.clone(),
+            vote: VoteType::Reject,
+            timestamp: context.now,
+            signature: Vec::new(),
+        };
+        self.record_vote_and_resolve(proposal_id, voter, signed_vote, VoteType::Reject, context)
     }
 }
 
@@ -1780,5 +1802,181 @@ mod tests {
 
         let (proposal, _) = engine.propose(&alice(), action, &ctx, &sk_alice()).unwrap();
         assert_eq!(proposal.status, ProposalStatus::Pending);
+    }
+
+    // -----------------------------------------------------------------------
+    // TrustedVoteIngest (keyless, ADR-034) — Threshold
+    // -----------------------------------------------------------------------
+
+    use crate::context::governance::TrustedVoteIngest;
+
+    /// Helper: seed a pending proposal via a signed propose, returning its id.
+    fn ingest_seed_proposal(engine: &mut ThresholdEngine, ctx: &GovernanceContext) -> ProposalId {
+        let (proposal, _) = engine
+            .propose(&alice(), default_action(), ctx, &sk_alice())
+            .expect("propose ok");
+        proposal.proposal_id
+    }
+
+    #[test]
+    fn ingest_approve_reaches_threshold() {
+        // 2-of-3: proposer (alice) is already counted; bob's ingested approval
+        // reaches the threshold.
+        let mut engine =
+            ThresholdEngine::new(vec![alice(), bob(), carol()], 2, 86_400, mock_resolver())
+                .expect("valid");
+        let ctx = test_context();
+        let pid = ingest_seed_proposal(&mut engine, &ctx);
+
+        let (status, events) = engine
+            .ingest_approve(&pid, &bob(), &ctx)
+            .expect("ingest ok");
+        assert_eq!(status, ProposalStatus::Approved);
+        // VoteCast + ProposalResolved.
+        assert_eq!(events.len(), 2);
+
+        // The recorded vote carries an empty signature.
+        let p = engine.get_proposal(&pid).expect("found");
+        assert_eq!(p.approvals.len(), 2);
+        assert!(p.approvals[1].signature.is_empty());
+        assert_eq!(p.approvals[1].voter_did, bob());
+    }
+
+    #[test]
+    fn ingest_stays_pending_when_threshold_not_met() {
+        // 3-of-3: proposer + one ingested approval is still short of quorum.
+        let mut engine =
+            ThresholdEngine::new(vec![alice(), bob(), carol()], 3, 86_400, mock_resolver())
+                .expect("valid");
+        let ctx = test_context();
+        let pid = ingest_seed_proposal(&mut engine, &ctx);
+
+        let (status, _) = engine
+            .ingest_approve(&pid, &bob(), &ctx)
+            .expect("ingest ok");
+        assert_eq!(status, ProposalStatus::Pending);
+    }
+
+    #[test]
+    fn ingest_reject_makes_approval_impossible() {
+        // 2-of-3: two rejections make approval impossible.
+        let mut engine =
+            ThresholdEngine::new(vec![alice(), bob(), carol()], 2, 86_400, mock_resolver())
+                .expect("valid");
+        let ctx = test_context();
+        let pid = ingest_seed_proposal(&mut engine, &ctx);
+
+        let (status, _) = engine.ingest_reject(&pid, &bob(), &ctx).expect("ingest ok");
+        assert_eq!(status, ProposalStatus::Pending);
+
+        let (status, _) = engine
+            .ingest_reject(&pid, &carol(), &ctx)
+            .expect("ingest ok");
+        assert_eq!(
+            status,
+            ProposalStatus::Rejected {
+                reason: RejectionReason::ApprovalImpossible
+            }
+        );
+    }
+
+    #[test]
+    fn ingest_approve_rejects_non_signer() {
+        let mut engine =
+            ThresholdEngine::new(vec![alice(), bob(), carol()], 2, 86_400, mock_resolver())
+                .expect("valid");
+        let ctx = test_context();
+        let pid = ingest_seed_proposal(&mut engine, &ctx);
+
+        // Dave is not in the frozen signer set.
+        let result = engine.ingest_approve(&pid, &dave(), &ctx);
+        assert!(matches!(
+            result.unwrap_err(),
+            GovernanceError::NotEligible(_)
+        ));
+    }
+
+    #[test]
+    fn ingest_approve_rejects_already_voted() {
+        let mut engine =
+            ThresholdEngine::new(vec![alice(), bob(), carol()], 3, 86_400, mock_resolver())
+                .expect("valid");
+        let ctx = test_context();
+        let pid = ingest_seed_proposal(&mut engine, &ctx);
+
+        engine
+            .ingest_approve(&pid, &bob(), &ctx)
+            .expect("ingest ok");
+        let result = engine.ingest_approve(&pid, &bob(), &ctx);
+        assert!(matches!(result.unwrap_err(), GovernanceError::AlreadyVoted));
+    }
+
+    #[test]
+    fn ingest_approve_rejects_terminal_proposal() {
+        // Drive to Approved (2-of-3), then ingest again -> ProposalNotPending.
+        let mut engine =
+            ThresholdEngine::new(vec![alice(), bob(), carol()], 2, 86_400, mock_resolver())
+                .expect("valid");
+        let ctx = test_context();
+        let pid = ingest_seed_proposal(&mut engine, &ctx);
+
+        let (status, _) = engine
+            .ingest_approve(&pid, &bob(), &ctx)
+            .expect("ingest ok");
+        assert_eq!(status, ProposalStatus::Approved);
+
+        let result = engine.ingest_approve(&pid, &carol(), &ctx);
+        assert!(matches!(
+            result.unwrap_err(),
+            GovernanceError::ProposalNotPending { .. }
+        ));
+    }
+
+    #[test]
+    fn ingest_approve_rejects_after_deadline() {
+        let mut engine =
+            ThresholdEngine::new(vec![alice(), bob(), carol()], 2, 86_400, mock_resolver())
+                .expect("valid");
+        let ctx = test_context();
+        let pid = ingest_seed_proposal(&mut engine, &ctx);
+
+        let expired_ctx = test_context_at(ctx.now + 86_400);
+        let result = engine.ingest_approve(&pid, &bob(), &expired_ctx);
+        assert!(matches!(
+            result.unwrap_err(),
+            GovernanceError::VotingWindowExpired { .. }
+        ));
+    }
+
+    #[test]
+    fn ingest_and_signed_paths_reach_identical_status() {
+        // Same config + same vote sequence -> identical final ProposalStatus
+        // whether votes arrive via the signed approve path or the keyless
+        // ingest path.
+        let ctx = test_context();
+
+        // Signed path: alice proposes, bob approves -> Approved.
+        let mut signed =
+            ThresholdEngine::new(vec![alice(), bob(), carol()], 2, 86_400, mock_resolver())
+                .expect("valid");
+        let (sp, _) = signed
+            .propose(&alice(), default_action(), &ctx, &sk_alice())
+            .expect("propose");
+        let (signed_status, _) = signed
+            .approve(&sp.proposal_id, &bob(), &ctx, &sk_bob())
+            .expect("approve");
+
+        // Ingest path: alice proposes (still signed — propose is unchanged),
+        // bob's approval arrives keyless.
+        let mut ingested =
+            ThresholdEngine::new(vec![alice(), bob(), carol()], 2, 86_400, mock_resolver())
+                .expect("valid");
+        let ip = ingest_seed_proposal(&mut ingested, &ctx);
+        let (ingest_status, _) = ingested
+            .ingest_approve(&ip, &bob(), &ctx)
+            .expect("ingest ok");
+
+        assert_eq!(signed_status, ingest_status);
+        assert_eq!(signed_status, ProposalStatus::Approved);
     }
 }

--- a/crates/scp-protocol/src/context/governance/multisig.rs
+++ b/crates/scp-protocol/src/context/governance/multisig.rs
@@ -292,13 +292,17 @@ impl ThresholdEngine {
         // `precheck_vote` already validated the proposal exists, is pending, and
         // within the deadline. We re-acquire it via `get_mut` here; in the
         // single-threaded `&mut self` flow it cannot have been removed in
-        // between, so the `if let Some(..)` simply no-ops on the impossible
-        // absence rather than panicking.
-        if let Some(proposal_mut) = self.proposals.get_mut(proposal_id) {
-            match vote {
-                VoteType::Approve => proposal_mut.approvals.push(signed_vote),
-                VoteType::Reject => proposal_mut.rejections.push(signed_vote),
+        // between, so the absence is impossible. We nonetheless fail loud with
+        // `ProposalNotFound` (mirroring `MajorityVoteEngine::push_and_resolve`)
+        // rather than silently mis-tallying on the impossible `None`.
+        let proposal_mut = self.proposals.get_mut(proposal_id).ok_or_else(|| {
+            GovernanceError::ProposalNotFound {
+                id: hex::encode(proposal_id),
             }
+        })?;
+        match vote {
+            VoteType::Approve => proposal_mut.approvals.push(signed_vote),
+            VoteType::Reject => proposal_mut.rejections.push(signed_vote),
         }
 
         let mut events = vec![GovernanceEvent::VoteCast {
@@ -438,6 +442,9 @@ impl GovernanceEngine for ThresholdEngine {
         // precheck, so Proceed is the only success outcome.
         match self.precheck_vote(proposal_id, voter, context)? {
             super::PrecheckOutcome::Proceed => {}
+            // Unreachable for this engine: `precheck_vote` returns `VotingWindowExpired`
+            // past-deadline rather than auto-resolving. This arm exists only for
+            // call-site uniformity with the majority engine.
             super::PrecheckOutcome::Resolved(resolution) => return Ok(resolution),
         }
 
@@ -478,6 +485,9 @@ impl GovernanceEngine for ThresholdEngine {
         // Guards run BEFORE sign/verify (see `approve`).
         match self.precheck_vote(proposal_id, voter, context)? {
             super::PrecheckOutcome::Proceed => {}
+            // Unreachable for this engine: `precheck_vote` returns `VotingWindowExpired`
+            // past-deadline rather than auto-resolving. This arm exists only for
+            // call-site uniformity with the majority engine.
             super::PrecheckOutcome::Resolved(resolution) => return Ok(resolution),
         }
 
@@ -725,6 +735,9 @@ impl super::TrustedVoteIngest for ThresholdEngine {
         // out-of-band (see the TrustedVoteIngest contract).
         match self.precheck_vote(proposal_id, voter, context)? {
             super::PrecheckOutcome::Proceed => {}
+            // Unreachable for this engine: `precheck_vote` returns `VotingWindowExpired`
+            // past-deadline rather than auto-resolving. This arm exists only for
+            // call-site uniformity with the majority engine.
             super::PrecheckOutcome::Resolved(resolution) => return Ok(resolution),
         }
         let signed_vote = super::build_unsigned_vote(voter, VoteType::Approve, context.now);
@@ -739,6 +752,9 @@ impl super::TrustedVoteIngest for ThresholdEngine {
     ) -> Result<(ProposalStatus, Vec<GovernanceEvent>), GovernanceError> {
         match self.precheck_vote(proposal_id, voter, context)? {
             super::PrecheckOutcome::Proceed => {}
+            // Unreachable for this engine: `precheck_vote` returns `VotingWindowExpired`
+            // past-deadline rather than auto-resolving. This arm exists only for
+            // call-site uniformity with the majority engine.
             super::PrecheckOutcome::Resolved(resolution) => return Ok(resolution),
         }
         let signed_vote = super::build_unsigned_vote(voter, VoteType::Reject, context.now);

--- a/crates/scp-protocol/src/context/governance/unanimity.rs
+++ b/crates/scp-protocol/src/context/governance/unanimity.rs
@@ -275,13 +275,17 @@ impl UnanimityEngine {
         // `precheck_vote` already validated the proposal exists, is pending, and
         // within the deadline. We re-acquire it via `get_mut` here; in the
         // single-threaded `&mut self` flow it cannot have been removed in
-        // between, so the `if let Some(..)` simply no-ops on the impossible
-        // absence rather than panicking.
-        if let Some(proposal_mut) = self.proposals.get_mut(proposal_id) {
-            match vote {
-                VoteType::Approve => proposal_mut.approvals.push(signed_vote),
-                VoteType::Reject => proposal_mut.rejections.push(signed_vote),
+        // between, so the absence is impossible. We nonetheless fail loud with
+        // `ProposalNotFound` (mirroring `MajorityVoteEngine::push_and_resolve`)
+        // rather than silently mis-tallying on the impossible `None`.
+        let proposal_mut = self.proposals.get_mut(proposal_id).ok_or_else(|| {
+            GovernanceError::ProposalNotFound {
+                id: hex::encode(proposal_id),
             }
+        })?;
+        match vote {
+            VoteType::Approve => proposal_mut.approvals.push(signed_vote),
+            VoteType::Reject => proposal_mut.rejections.push(signed_vote),
         }
 
         let mut events = vec![GovernanceEvent::VoteCast {
@@ -420,6 +424,9 @@ impl GovernanceEngine for UnanimityEngine {
         // precheck, so Proceed is the only success outcome.
         match self.precheck_vote(proposal_id, voter, context)? {
             super::PrecheckOutcome::Proceed => {}
+            // Unreachable for this engine: `precheck_vote` returns `VotingWindowExpired`
+            // past-deadline rather than auto-resolving. This arm exists only for
+            // call-site uniformity with the majority engine.
             super::PrecheckOutcome::Resolved(resolution) => return Ok(resolution),
         }
 
@@ -460,6 +467,9 @@ impl GovernanceEngine for UnanimityEngine {
         // Guards run BEFORE sign/verify (see `approve`).
         match self.precheck_vote(proposal_id, voter, context)? {
             super::PrecheckOutcome::Proceed => {}
+            // Unreachable for this engine: `precheck_vote` returns `VotingWindowExpired`
+            // past-deadline rather than auto-resolving. This arm exists only for
+            // call-site uniformity with the majority engine.
             super::PrecheckOutcome::Resolved(resolution) => return Ok(resolution),
         }
 
@@ -706,6 +716,9 @@ impl super::TrustedVoteIngest for UnanimityEngine {
         // out-of-band (see the TrustedVoteIngest contract).
         match self.precheck_vote(proposal_id, voter, context)? {
             super::PrecheckOutcome::Proceed => {}
+            // Unreachable for this engine: `precheck_vote` returns `VotingWindowExpired`
+            // past-deadline rather than auto-resolving. This arm exists only for
+            // call-site uniformity with the majority engine.
             super::PrecheckOutcome::Resolved(resolution) => return Ok(resolution),
         }
         let signed_vote = super::build_unsigned_vote(voter, VoteType::Approve, context.now);
@@ -720,6 +733,9 @@ impl super::TrustedVoteIngest for UnanimityEngine {
     ) -> Result<(ProposalStatus, Vec<GovernanceEvent>), GovernanceError> {
         match self.precheck_vote(proposal_id, voter, context)? {
             super::PrecheckOutcome::Proceed => {}
+            // Unreachable for this engine: `precheck_vote` returns `VotingWindowExpired`
+            // past-deadline rather than auto-resolving. This arm exists only for
+            // call-site uniformity with the majority engine.
             super::PrecheckOutcome::Resolved(resolution) => return Ok(resolution),
         }
         let signed_vote = super::build_unsigned_vote(voter, VoteType::Reject, context.now);

--- a/crates/scp-protocol/src/context/governance/unanimity.rs
+++ b/crates/scp-protocol/src/context/governance/unanimity.rs
@@ -272,8 +272,11 @@ impl UnanimityEngine {
         vote: VoteType,
         context: &GovernanceContext,
     ) -> Result<(ProposalStatus, Vec<GovernanceEvent>), GovernanceError> {
-        // Key is guaranteed present: precheck_vote looked it up and we hold
-        // `&mut self` continuously since then.
+        // `precheck_vote` already validated the proposal exists, is pending, and
+        // within the deadline. We re-acquire it via `get_mut` here; in the
+        // single-threaded `&mut self` flow it cannot have been removed in
+        // between, so the `if let Some(..)` simply no-ops on the impossible
+        // absence rather than panicking.
         if let Some(proposal_mut) = self.proposals.get_mut(proposal_id) {
             match vote {
                 VoteType::Approve => proposal_mut.approvals.push(signed_vote),

--- a/crates/scp-protocol/src/context/governance/unanimity.rs
+++ b/crates/scp-protocol/src/context/governance/unanimity.rs
@@ -198,6 +198,79 @@ impl UnanimityEngine {
 
         Ok((new_status, events))
     }
+
+    /// Record an already-built vote and run the tally.
+    ///
+    /// Shared by the signed [`GovernanceEngine::approve`] /
+    /// [`GovernanceEngine::reject`] path and the keyless
+    /// [`TrustedVoteIngest`](super::TrustedVoteIngest) path. This helper begins
+    /// **after** any signature verification: the signed path verifies the vote
+    /// against the voter's DID-resolved key before calling this; the keyless
+    /// path supplies an empty-signature vote. The shared portion is the
+    /// eligibility check, pending check, deadline guard, single-vote dedup, the
+    /// push into `approvals`/`rejections`, the `VoteCast` event, and the
+    /// resolve (a single rejection vetoes immediately).
+    fn record_vote_and_resolve(
+        &mut self,
+        proposal_id: &ProposalId,
+        voter: &DID,
+        signed_vote: super::SignedVote,
+        vote: VoteType,
+        context: &GovernanceContext,
+    ) -> Result<(ProposalStatus, Vec<GovernanceEvent>), GovernanceError> {
+        // Voter must be in the voter set.
+        if !self.is_voter(voter) {
+            return Err(GovernanceError::NotEligible(
+                "voter is not in the voter set".to_owned(),
+            ));
+        }
+
+        let proposal =
+            self.proposals
+                .get(proposal_id)
+                .ok_or_else(|| GovernanceError::ProposalNotFound {
+                    id: hex::encode(proposal_id),
+                })?;
+
+        // Must be pending.
+        if !proposal.status.is_pending() {
+            return Err(GovernanceError::ProposalNotPending {
+                status: format!("{:?}", proposal.status),
+            });
+        }
+
+        // Deadline guard -- reject votes after the voting window.
+        if context.now >= proposal.voting_deadline {
+            return Err(GovernanceError::VotingWindowExpired {
+                id: hex::encode(proposal_id),
+            });
+        }
+
+        // Must not have already voted.
+        if Self::has_voted(proposal, voter) {
+            return Err(GovernanceError::AlreadyVoted);
+        }
+
+        // Key is guaranteed present because we just looked it up via `get()` above.
+        if let Some(proposal_mut) = self.proposals.get_mut(proposal_id) {
+            match vote {
+                VoteType::Approve => proposal_mut.approvals.push(signed_vote),
+                VoteType::Reject => proposal_mut.rejections.push(signed_vote),
+            }
+        }
+
+        let mut events = vec![GovernanceEvent::VoteCast {
+            proposal_id: *proposal_id,
+            voter_did: voter.clone(),
+            vote,
+        }];
+
+        // Resolve after vote -- a single rejection triggers immediate veto.
+        let (status, resolve_events) = self.resolve_proposal(proposal_id, context.now)?;
+        events.extend(resolve_events);
+
+        Ok((status, events))
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -316,40 +389,7 @@ impl GovernanceEngine for UnanimityEngine {
         context: &GovernanceContext,
         signing_key: &ed25519_dalek::SigningKey,
     ) -> Result<(ProposalStatus, Vec<GovernanceEvent>), GovernanceError> {
-        // Voter must be in the voter set.
-        if !self.is_voter(voter) {
-            return Err(GovernanceError::NotEligible(
-                "voter is not in the voter set".to_owned(),
-            ));
-        }
-
-        let proposal =
-            self.proposals
-                .get(proposal_id)
-                .ok_or_else(|| GovernanceError::ProposalNotFound {
-                    id: hex::encode(proposal_id),
-                })?;
-
-        // Must be pending.
-        if !proposal.status.is_pending() {
-            return Err(GovernanceError::ProposalNotPending {
-                status: format!("{:?}", proposal.status),
-            });
-        }
-
-        // Deadline guard -- reject votes after the voting window.
-        if context.now >= proposal.voting_deadline {
-            return Err(GovernanceError::VotingWindowExpired {
-                id: hex::encode(proposal_id),
-            });
-        }
-
-        // Must not have already voted.
-        if Self::has_voted(proposal, voter) {
-            return Err(GovernanceError::AlreadyVoted);
-        }
-
-        // Record the signed vote.
+        // Build and sign the vote.
         let vote = sign_vote(
             proposal_id,
             &VoteType::Approve,
@@ -359,6 +399,8 @@ impl GovernanceEngine for UnanimityEngine {
         )?;
 
         // Verify the vote signature against the voter's DID-resolved key.
+        // This MUST stay strictly before record_vote_and_resolve: the signed
+        // path counts a vote only after its signature is verified.
         let resolved_key = (self.key_resolver)(voter, SigningKeyId::Active).ok_or_else(|| {
             GovernanceError::UnknownVoter {
                 did: voter.to_string(),
@@ -371,22 +413,7 @@ impl GovernanceEngine for UnanimityEngine {
             }
         })?;
 
-        // Key is guaranteed present because we just looked it up via `get()` above.
-        if let Some(proposal_mut) = self.proposals.get_mut(proposal_id) {
-            proposal_mut.approvals.push(vote);
-        }
-
-        let mut events = vec![GovernanceEvent::VoteCast {
-            proposal_id: *proposal_id,
-            voter_did: voter.clone(),
-            vote: VoteType::Approve,
-        }];
-
-        // Resolve after vote.
-        let (status, resolve_events) = self.resolve_proposal(proposal_id, context.now)?;
-        events.extend(resolve_events);
-
-        Ok((status, events))
+        self.record_vote_and_resolve(proposal_id, voter, vote, VoteType::Approve, context)
     }
 
     fn reject(
@@ -396,40 +423,7 @@ impl GovernanceEngine for UnanimityEngine {
         context: &GovernanceContext,
         signing_key: &ed25519_dalek::SigningKey,
     ) -> Result<(ProposalStatus, Vec<GovernanceEvent>), GovernanceError> {
-        // Voter must be in the voter set.
-        if !self.is_voter(voter) {
-            return Err(GovernanceError::NotEligible(
-                "voter is not in the voter set".to_owned(),
-            ));
-        }
-
-        let proposal =
-            self.proposals
-                .get(proposal_id)
-                .ok_or_else(|| GovernanceError::ProposalNotFound {
-                    id: hex::encode(proposal_id),
-                })?;
-
-        // Must be pending.
-        if !proposal.status.is_pending() {
-            return Err(GovernanceError::ProposalNotPending {
-                status: format!("{:?}", proposal.status),
-            });
-        }
-
-        // Deadline guard -- reject votes after the voting window.
-        if context.now >= proposal.voting_deadline {
-            return Err(GovernanceError::VotingWindowExpired {
-                id: hex::encode(proposal_id),
-            });
-        }
-
-        // Must not have already voted.
-        if Self::has_voted(proposal, voter) {
-            return Err(GovernanceError::AlreadyVoted);
-        }
-
-        // Record the signed rejection vote.
+        // Build and sign the rejection vote.
         let vote = sign_vote(
             proposal_id,
             &VoteType::Reject,
@@ -439,6 +433,8 @@ impl GovernanceEngine for UnanimityEngine {
         )?;
 
         // Verify the vote signature against the voter's DID-resolved key.
+        // This MUST stay strictly before record_vote_and_resolve: the signed
+        // path counts a vote only after its signature is verified.
         let resolved_key = (self.key_resolver)(voter, SigningKeyId::Active).ok_or_else(|| {
             GovernanceError::UnknownVoter {
                 did: voter.to_string(),
@@ -451,22 +447,7 @@ impl GovernanceEngine for UnanimityEngine {
             }
         })?;
 
-        // Key is guaranteed present because we just looked it up via `get()` above.
-        if let Some(proposal_mut) = self.proposals.get_mut(proposal_id) {
-            proposal_mut.rejections.push(vote);
-        }
-
-        let mut events = vec![GovernanceEvent::VoteCast {
-            proposal_id: *proposal_id,
-            voter_did: voter.clone(),
-            vote: VoteType::Reject,
-        }];
-
-        // Resolve after vote -- single rejection triggers immediate veto.
-        let (status, resolve_events) = self.resolve_proposal(proposal_id, context.now)?;
-        events.extend(resolve_events);
-
-        Ok((status, events))
+        self.record_vote_and_resolve(proposal_id, voter, vote, VoteType::Reject, context)
     }
 
     fn withdraw_vote(
@@ -665,6 +646,47 @@ impl GovernanceEngine for UnanimityEngine {
         } else {
             Ok(CheckpointAttestationStatus::PartiallyAttested)
         }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// TrustedVoteIngest implementation (ADR-034 keyless path)
+// ---------------------------------------------------------------------------
+
+impl super::TrustedVoteIngest for UnanimityEngine {
+    fn ingest_approve(
+        &mut self,
+        proposal_id: &ProposalId,
+        voter: &DID,
+        context: &GovernanceContext,
+    ) -> Result<(ProposalStatus, Vec<GovernanceEvent>), GovernanceError> {
+        // Keyless: build an empty-signature vote and feed it through the same
+        // tally as the signed path. No sign_vote, no verify_vote — the caller
+        // is responsible for authenticating the vote out-of-band (see the
+        // TrustedVoteIngest contract). The timestamp is read from
+        // GovernanceContext::now, the same clock the signed path uses.
+        let signed_vote = super::SignedVote {
+            voter_did: voter.clone(),
+            vote: VoteType::Approve,
+            timestamp: context.now,
+            signature: Vec::new(),
+        };
+        self.record_vote_and_resolve(proposal_id, voter, signed_vote, VoteType::Approve, context)
+    }
+
+    fn ingest_reject(
+        &mut self,
+        proposal_id: &ProposalId,
+        voter: &DID,
+        context: &GovernanceContext,
+    ) -> Result<(ProposalStatus, Vec<GovernanceEvent>), GovernanceError> {
+        let signed_vote = super::SignedVote {
+            voter_did: voter.clone(),
+            vote: VoteType::Reject,
+            timestamp: context.now,
+            signature: Vec::new(),
+        };
+        self.record_vote_and_resolve(proposal_id, voter, signed_vote, VoteType::Reject, context)
     }
 }
 
@@ -1937,5 +1959,176 @@ mod tests {
 
         let (proposal, _) = engine.propose(&alice(), action, &ctx, &sk_alice()).unwrap();
         assert_eq!(proposal.status, ProposalStatus::Pending);
+    }
+
+    // -----------------------------------------------------------------------
+    // TrustedVoteIngest (keyless, ADR-034) — Unanimity
+    // -----------------------------------------------------------------------
+
+    use crate::context::governance::TrustedVoteIngest;
+
+    /// Helper: seed a pending proposal via a signed propose, returning its id.
+    fn ingest_seed_proposal(engine: &mut UnanimityEngine, ctx: &GovernanceContext) -> ProposalId {
+        let (proposal, _) = engine
+            .propose(&alice(), default_action(), ctx, &sk_alice())
+            .expect("propose ok");
+        proposal.proposal_id
+    }
+
+    #[test]
+    fn ingest_all_approve_reaches_unanimity() {
+        // 3 voters: proposer (alice) + bob + carol all approve -> Approved.
+        let mut engine =
+            UnanimityEngine::new(vec![alice(), bob(), carol()], 86_400, mock_resolver())
+                .expect("valid");
+        let ctx = test_context();
+        let pid = ingest_seed_proposal(&mut engine, &ctx);
+
+        let (status, _) = engine
+            .ingest_approve(&pid, &bob(), &ctx)
+            .expect("ingest ok");
+        assert_eq!(status, ProposalStatus::Pending);
+
+        let (status, events) = engine
+            .ingest_approve(&pid, &carol(), &ctx)
+            .expect("ingest ok");
+        assert_eq!(status, ProposalStatus::Approved);
+        assert_eq!(events.len(), 2);
+
+        // Recorded ingested votes carry empty signatures.
+        let p = engine.get_proposal(&pid).expect("found");
+        assert_eq!(p.approvals.len(), 3);
+        assert!(p.approvals[1].signature.is_empty());
+        assert!(p.approvals[2].signature.is_empty());
+    }
+
+    #[test]
+    fn ingest_stays_pending_when_not_all_approved() {
+        let mut engine =
+            UnanimityEngine::new(vec![alice(), bob(), carol()], 86_400, mock_resolver())
+                .expect("valid");
+        let ctx = test_context();
+        let pid = ingest_seed_proposal(&mut engine, &ctx);
+
+        // Only bob approves; carol has not -> still pending.
+        let (status, _) = engine
+            .ingest_approve(&pid, &bob(), &ctx)
+            .expect("ingest ok");
+        assert_eq!(status, ProposalStatus::Pending);
+    }
+
+    #[test]
+    fn ingest_reject_breaks_unanimity() {
+        let mut engine =
+            UnanimityEngine::new(vec![alice(), bob(), carol()], 86_400, mock_resolver())
+                .expect("valid");
+        let ctx = test_context();
+        let pid = ingest_seed_proposal(&mut engine, &ctx);
+
+        // A single rejection vetoes immediately.
+        let (status, _) = engine.ingest_reject(&pid, &bob(), &ctx).expect("ingest ok");
+        assert_eq!(
+            status,
+            ProposalStatus::Rejected {
+                reason: RejectionReason::UnanimityBroken { rejector: bob() }
+            }
+        );
+    }
+
+    #[test]
+    fn ingest_approve_rejects_non_voter() {
+        let mut engine =
+            UnanimityEngine::new(vec![alice(), bob(), carol()], 86_400, mock_resolver())
+                .expect("valid");
+        let ctx = test_context();
+        let pid = ingest_seed_proposal(&mut engine, &ctx);
+
+        // Dave is not in the frozen voter set.
+        let result = engine.ingest_approve(&pid, &dave(), &ctx);
+        assert!(matches!(
+            result.unwrap_err(),
+            GovernanceError::NotEligible(_)
+        ));
+    }
+
+    #[test]
+    fn ingest_approve_rejects_already_voted() {
+        let mut engine =
+            UnanimityEngine::new(vec![alice(), bob(), carol()], 86_400, mock_resolver())
+                .expect("valid");
+        let ctx = test_context();
+        let pid = ingest_seed_proposal(&mut engine, &ctx);
+
+        // Alice already voted as proposer.
+        let result = engine.ingest_approve(&pid, &alice(), &ctx);
+        assert!(matches!(result.unwrap_err(), GovernanceError::AlreadyVoted));
+    }
+
+    #[test]
+    fn ingest_approve_rejects_terminal_proposal() {
+        let mut engine =
+            UnanimityEngine::new(vec![alice(), bob(), carol()], 86_400, mock_resolver())
+                .expect("valid");
+        let ctx = test_context();
+        let pid = ingest_seed_proposal(&mut engine, &ctx);
+
+        // Bob rejects -> terminal.
+        engine.ingest_reject(&pid, &bob(), &ctx).expect("ingest ok");
+
+        let result = engine.ingest_approve(&pid, &carol(), &ctx);
+        assert!(matches!(
+            result.unwrap_err(),
+            GovernanceError::ProposalNotPending { .. }
+        ));
+    }
+
+    #[test]
+    fn ingest_approve_rejects_after_deadline() {
+        let mut engine =
+            UnanimityEngine::new(vec![alice(), bob(), carol()], 86_400, mock_resolver())
+                .expect("valid");
+        let ctx = test_context();
+        let pid = ingest_seed_proposal(&mut engine, &ctx);
+
+        let expired_ctx = test_context_at(ctx.now + 86_400);
+        let result = engine.ingest_approve(&pid, &bob(), &expired_ctx);
+        assert!(matches!(
+            result.unwrap_err(),
+            GovernanceError::VotingWindowExpired { .. }
+        ));
+    }
+
+    #[test]
+    fn ingest_and_signed_paths_reach_identical_status() {
+        let ctx = test_context();
+
+        // Signed path: alice proposes, bob + carol approve -> Approved.
+        let mut signed =
+            UnanimityEngine::new(vec![alice(), bob(), carol()], 86_400, mock_resolver())
+                .expect("valid");
+        let (sp, _) = signed
+            .propose(&alice(), default_action(), &ctx, &sk_alice())
+            .expect("propose");
+        signed
+            .approve(&sp.proposal_id, &bob(), &ctx, &sk_bob())
+            .expect("approve");
+        let (signed_status, _) = signed
+            .approve(&sp.proposal_id, &carol(), &ctx, &sk_carol())
+            .expect("approve");
+
+        // Ingest path: same sequence, keyless approvals.
+        let mut ingested =
+            UnanimityEngine::new(vec![alice(), bob(), carol()], 86_400, mock_resolver())
+                .expect("valid");
+        let ip = ingest_seed_proposal(&mut ingested, &ctx);
+        ingested
+            .ingest_approve(&ip, &bob(), &ctx)
+            .expect("ingest ok");
+        let (ingest_status, _) = ingested
+            .ingest_approve(&ip, &carol(), &ctx)
+            .expect("ingest ok");
+
+        assert_eq!(signed_status, ingest_status);
+        assert_eq!(signed_status, ProposalStatus::Approved);
     }
 }

--- a/crates/scp-protocol/src/context/governance/unanimity.rs
+++ b/crates/scp-protocol/src/context/governance/unanimity.rs
@@ -199,25 +199,27 @@ impl UnanimityEngine {
         Ok((new_status, events))
     }
 
-    /// Record an already-built vote and run the tally.
+    /// Run the pre-vote guard checks.
     ///
-    /// Shared by the signed [`GovernanceEngine::approve`] /
-    /// [`GovernanceEngine::reject`] path and the keyless
-    /// [`TrustedVoteIngest`](super::TrustedVoteIngest) path. This helper begins
-    /// **after** any signature verification: the signed path verifies the vote
-    /// against the voter's DID-resolved key before calling this; the keyless
-    /// path supplies an empty-signature vote. The shared portion is the
-    /// eligibility check, pending check, deadline guard, single-vote dedup, the
-    /// push into `approvals`/`rejections`, the `VoteCast` event, and the
-    /// resolve (a single rejection vetoes immediately).
-    fn record_vote_and_resolve(
-        &mut self,
+    /// This is the portion that MUST run **before** any signing or signature
+    /// verification on the signed path, so that a double vote is caught as
+    /// `AlreadyVoted` regardless of which key signed the second attempt, and an
+    /// ineligible voter is rejected as `NotEligible` rather than
+    /// `InvalidSignature`. The checks and their error variants match the
+    /// original pre-refactor `approve`/`reject` exactly: eligibility
+    /// (`NotEligible`), proposal existence (`ProposalNotFound`), pending state
+    /// (`ProposalNotPending`), deadline (`VotingWindowExpired`), single-vote
+    /// dedup (`AlreadyVoted`).
+    ///
+    /// Unanimity treats a past-deadline vote as `VotingWindowExpired` (no
+    /// auto-resolve), so this only ever returns
+    /// [`PrecheckOutcome::Proceed`](super::PrecheckOutcome::Proceed) on success.
+    fn precheck_vote(
+        &self,
         proposal_id: &ProposalId,
         voter: &DID,
-        signed_vote: super::SignedVote,
-        vote: VoteType,
         context: &GovernanceContext,
-    ) -> Result<(ProposalStatus, Vec<GovernanceEvent>), GovernanceError> {
+    ) -> Result<super::PrecheckOutcome, GovernanceError> {
         // Voter must be in the voter set.
         if !self.is_voter(voter) {
             return Err(GovernanceError::NotEligible(
@@ -251,7 +253,27 @@ impl UnanimityEngine {
             return Err(GovernanceError::AlreadyVoted);
         }
 
-        // Key is guaranteed present because we just looked it up via `get()` above.
+        Ok(super::PrecheckOutcome::Proceed)
+    }
+
+    /// Record an already-checked, already-verified vote and run the tally.
+    ///
+    /// Runs **after** `precheck_vote` (and, on the signed path, after signature
+    /// verification): pushes the vote into `approvals`/`rejections`, emits the
+    /// `VoteCast` event, and resolves (a single rejection vetoes immediately).
+    /// No unverified vote ever reaches this point on the signed path — the
+    /// keyless [`TrustedVoteIngest`](super::TrustedVoteIngest) path supplies an
+    /// empty-signature vote by contract.
+    fn push_and_resolve(
+        &mut self,
+        proposal_id: &ProposalId,
+        voter: &DID,
+        signed_vote: super::SignedVote,
+        vote: VoteType,
+        context: &GovernanceContext,
+    ) -> Result<(ProposalStatus, Vec<GovernanceEvent>), GovernanceError> {
+        // Key is guaranteed present: precheck_vote looked it up and we hold
+        // `&mut self` continuously since then.
         if let Some(proposal_mut) = self.proposals.get_mut(proposal_id) {
             match vote {
                 VoteType::Approve => proposal_mut.approvals.push(signed_vote),
@@ -389,6 +411,15 @@ impl GovernanceEngine for UnanimityEngine {
         context: &GovernanceContext,
         signing_key: &ed25519_dalek::SigningKey,
     ) -> Result<(ProposalStatus, Vec<GovernanceEvent>), GovernanceError> {
+        // Guards run BEFORE sign/verify: a double vote must be caught as
+        // AlreadyVoted (and an ineligible voter as NotEligible) regardless of
+        // which key signed the attempt. Unanimity never early-resolves in
+        // precheck, so Proceed is the only success outcome.
+        match self.precheck_vote(proposal_id, voter, context)? {
+            super::PrecheckOutcome::Proceed => {}
+            super::PrecheckOutcome::Resolved(resolution) => return Ok(resolution),
+        }
+
         // Build and sign the vote.
         let vote = sign_vote(
             proposal_id,
@@ -399,8 +430,8 @@ impl GovernanceEngine for UnanimityEngine {
         )?;
 
         // Verify the vote signature against the voter's DID-resolved key.
-        // This MUST stay strictly before record_vote_and_resolve: the signed
-        // path counts a vote only after its signature is verified.
+        // This MUST stay strictly before push_and_resolve: the signed path
+        // counts a vote only after its signature is verified.
         let resolved_key = (self.key_resolver)(voter, SigningKeyId::Active).ok_or_else(|| {
             GovernanceError::UnknownVoter {
                 did: voter.to_string(),
@@ -413,7 +444,7 @@ impl GovernanceEngine for UnanimityEngine {
             }
         })?;
 
-        self.record_vote_and_resolve(proposal_id, voter, vote, VoteType::Approve, context)
+        self.push_and_resolve(proposal_id, voter, vote, VoteType::Approve, context)
     }
 
     fn reject(
@@ -423,6 +454,12 @@ impl GovernanceEngine for UnanimityEngine {
         context: &GovernanceContext,
         signing_key: &ed25519_dalek::SigningKey,
     ) -> Result<(ProposalStatus, Vec<GovernanceEvent>), GovernanceError> {
+        // Guards run BEFORE sign/verify (see `approve`).
+        match self.precheck_vote(proposal_id, voter, context)? {
+            super::PrecheckOutcome::Proceed => {}
+            super::PrecheckOutcome::Resolved(resolution) => return Ok(resolution),
+        }
+
         // Build and sign the rejection vote.
         let vote = sign_vote(
             proposal_id,
@@ -433,8 +470,8 @@ impl GovernanceEngine for UnanimityEngine {
         )?;
 
         // Verify the vote signature against the voter's DID-resolved key.
-        // This MUST stay strictly before record_vote_and_resolve: the signed
-        // path counts a vote only after its signature is verified.
+        // This MUST stay strictly before push_and_resolve: the signed path
+        // counts a vote only after its signature is verified.
         let resolved_key = (self.key_resolver)(voter, SigningKeyId::Active).ok_or_else(|| {
             GovernanceError::UnknownVoter {
                 did: voter.to_string(),
@@ -447,7 +484,7 @@ impl GovernanceEngine for UnanimityEngine {
             }
         })?;
 
-        self.record_vote_and_resolve(proposal_id, voter, vote, VoteType::Reject, context)
+        self.push_and_resolve(proposal_id, voter, vote, VoteType::Reject, context)
     }
 
     fn withdraw_vote(
@@ -660,18 +697,16 @@ impl super::TrustedVoteIngest for UnanimityEngine {
         voter: &DID,
         context: &GovernanceContext,
     ) -> Result<(ProposalStatus, Vec<GovernanceEvent>), GovernanceError> {
-        // Keyless: build an empty-signature vote and feed it through the same
-        // tally as the signed path. No sign_vote, no verify_vote — the caller
-        // is responsible for authenticating the vote out-of-band (see the
-        // TrustedVoteIngest contract). The timestamp is read from
-        // GovernanceContext::now, the same clock the signed path uses.
-        let signed_vote = super::SignedVote {
-            voter_did: voter.clone(),
-            vote: VoteType::Approve,
-            timestamp: context.now,
-            signature: Vec::new(),
-        };
-        self.record_vote_and_resolve(proposal_id, voter, signed_vote, VoteType::Approve, context)
+        // Keyless: run the same guards, then push an empty-signature vote
+        // through the same tally as the signed path. No sign_vote, no
+        // verify_vote — the caller is responsible for authenticating the vote
+        // out-of-band (see the TrustedVoteIngest contract).
+        match self.precheck_vote(proposal_id, voter, context)? {
+            super::PrecheckOutcome::Proceed => {}
+            super::PrecheckOutcome::Resolved(resolution) => return Ok(resolution),
+        }
+        let signed_vote = super::build_unsigned_vote(voter, VoteType::Approve, context.now);
+        self.push_and_resolve(proposal_id, voter, signed_vote, VoteType::Approve, context)
     }
 
     fn ingest_reject(
@@ -680,13 +715,12 @@ impl super::TrustedVoteIngest for UnanimityEngine {
         voter: &DID,
         context: &GovernanceContext,
     ) -> Result<(ProposalStatus, Vec<GovernanceEvent>), GovernanceError> {
-        let signed_vote = super::SignedVote {
-            voter_did: voter.clone(),
-            vote: VoteType::Reject,
-            timestamp: context.now,
-            signature: Vec::new(),
-        };
-        self.record_vote_and_resolve(proposal_id, voter, signed_vote, VoteType::Reject, context)
+        match self.precheck_vote(proposal_id, voter, context)? {
+            super::PrecheckOutcome::Proceed => {}
+            super::PrecheckOutcome::Resolved(resolution) => return Ok(resolution),
+        }
+        let signed_vote = super::build_unsigned_vote(voter, VoteType::Reject, context.now);
+        self.push_and_resolve(proposal_id, voter, signed_vote, VoteType::Reject, context)
     }
 }
 


### PR DESCRIPTION
## Summary

Second slice of #1900 (WASM governance quorum/voter-eligibility convergence), part of the #1877 native↔WASM convergence program. This is the **scp-protocol engine slice** — it adds the keyless vote-ingestion path that the WASM bridge (which holds no signing keys, ADR-034) will adopt in the follow-on PR-2b, **without changing native behavior**.

### What it does

- **New `TrustedVoteIngest` trait** (`ingest_approve` / `ingest_reject`) — the caller-trusted, no-signing-key counterpart to the signed `approve` / `reject`. It records an empty-signature vote and runs the **exact same** quorum tally as the signed path. This is what makes native and WASM converge on one tally implementation rather than two divergent ones.
- **Deliberately separate from `GovernanceEngine`**, implemented only on the three multi-party engines (Threshold/Majority/Unanimity). Native holds engines as `Box<dyn GovernanceEngine>`, whose vtable has no `ingest_*` — so the keyless path is **unreachable from native by construction** (compile-proven `E0599` during review). `scp-core`'s facade re-export was tightened to an explicit list excluding `TrustedVoteIngest` (the WASM bridge depends on scp-protocol directly, so it's unaffected).
- **Shared `precheck_vote` + `push_and_resolve` extraction.** Guards (eligibility → exists → pending → deadline → dedup) run strictly **before** sign/verify; verification runs strictly **before** the vote is counted. Both the signed and keyless paths funnel through the same guards and the same tally, so the keyless path cannot skip eligibility/dedup/deadline/finality — it is trusted only to assert *which eligible member* voted.

### Security model

- Native's "`status == Approved` ⟹ every counted vote cryptographically verified" guarantee is **preserved** — verified-before-count holds on the signed path for `approve`/`reject` and the implicit proposer vote in `propose`, across all three engines.
- The relaxed invariant for keyless-ingested proposals is **explicitly scoped** in the `GovernanceProposal::status` doc and the `TrustedVoteIngest` caller contract (caller MUST authenticate identity == voter, the `governance:vote` capability, and proposal scoping). The residual (a same-origin caller fabricating a vote for an eligible member) is an inherent ADR-034 property whose compensating control is §9.9.3 equivocation / Merkle-root divergence — documented, with a watch-item flagged for the PR-2b WASM wiring.

## Scope boundary

This slice lands the engine path **ahead of its consumer** — there is no WASM caller yet (the WASM bridge adopts it in PR-2b, where the frozen-eligible-set state, collapse-on-import, and withdraw-gating fixes also land). So `Refs`, not `Closes`: #1900's full quorum/voter-eligibility convergence completes in PR-2b.

## Tests

Per engine: ingest quorum-reached / stays-pending / opposite-vote, `NotEligible`, `AlreadyVoted`, terminal `ProposalNotPending`, deadline, majority frozen-eligible-set denominator, and a **signed-vs-ingest parity** test asserting both paths reach the identical `ProposalStatus`. The existing forged-signature regression oracles pass unmodified (the extraction kept verify strictly before counting). A regression caught mid-review — a guard-after-verify reorder that surfaced `InvalidSignature` instead of `AlreadyVoted` for an agent-binding double-vote — was root-caused and fixed (guards before verify, verify before count).

## Verification

- CI clippy (all features, `-D warnings`), wasm32 clippy, `cargo fmt --check` — clean.
- Full workspace `cargo nextest` (CI features) — **9880 passed, 0 failed**.
- Reviewed to double-zero (bug-catcher, security-reviewer, black-hat, api-design-reviewer, simplifier) — two consecutive fully-clean full-roster passes; black-hat compile-proved native cannot reach the keyless path.

## Follow-ups

- #1918 — extract the pre-existing (not introduced here) identical multisig/unanimity `precheck_vote`/`push_and_resolve` into shared helpers; deferred to keep this commit line-for-line auditable against the original control flow.

Refs #1877
Refs #1900