### PR TITLE
fix(crypto): bind raw context_id string in sender-layer AAD per §9.16.1 [#1909 Phase 1]

### DIFF
--- a/crates/scp-ffi/napi/src/testing.rs
+++ b/crates/scp-ffi/napi/src/testing.rs
@@ -301,18 +301,24 @@ pub(crate) fn fullstack_sync_sender_keys_on(
         })?;
 
     // Both pick up the other's key from the exchange.
-    node_a.inner.pickup_sender_keys(&ctx_bytes).map_err(|e| {
-        napi::Error::from(ScpNapiError::Crypto {
-            message: format!("failed to pick up sender keys for A: {e}"),
-            code: codes::CRYPTO_4058.to_owned(),
-        })
-    })?;
-    node_b.inner.pickup_sender_keys(&ctx_bytes).map_err(|e| {
-        napi::Error::from(ScpNapiError::Crypto {
-            message: format!("failed to pick up sender keys for B: {e}"),
-            code: codes::CRYPTO_4059.to_owned(),
-        })
-    })?;
+    node_a
+        .inner
+        .pickup_sender_keys(&context_id, &ctx_bytes)
+        .map_err(|e| {
+            napi::Error::from(ScpNapiError::Crypto {
+                message: format!("failed to pick up sender keys for A: {e}"),
+                code: codes::CRYPTO_4058.to_owned(),
+            })
+        })?;
+    node_b
+        .inner
+        .pickup_sender_keys(&context_id, &ctx_bytes)
+        .map_err(|e| {
+            napi::Error::from(ScpNapiError::Crypto {
+                message: format!("failed to pick up sender keys for B: {e}"),
+                code: codes::CRYPTO_4059.to_owned(),
+            })
+        })?;
 
     Ok(())
 }

--- a/crates/scp-ffi/src/testing.rs
+++ b/crates/scp-ffi/src/testing.rs
@@ -293,16 +293,22 @@ fn fullstack_sync_sender_keys_impl(
         })?;
 
     // Both pick up the other's key.
-    node_a.inner.pickup_sender_keys(&ctx_bytes).map_err(|e| {
-        pyo3::exceptions::PyRuntimeError::new_err(format!(
-            "failed to pick up sender keys for A: {e}"
-        ))
-    })?;
-    node_b.inner.pickup_sender_keys(&ctx_bytes).map_err(|e| {
-        pyo3::exceptions::PyRuntimeError::new_err(format!(
-            "failed to pick up sender keys for B: {e}"
-        ))
-    })?;
+    node_a
+        .inner
+        .pickup_sender_keys(&context_id, &ctx_bytes)
+        .map_err(|e| {
+            pyo3::exceptions::PyRuntimeError::new_err(format!(
+                "failed to pick up sender keys for A: {e}"
+            ))
+        })?;
+    node_b
+        .inner
+        .pickup_sender_keys(&context_id, &ctx_bytes)
+        .map_err(|e| {
+            pyo3::exceptions::PyRuntimeError::new_err(format!(
+                "failed to pick up sender keys for B: {e}"
+            ))
+        })?;
 
     Ok(())
 }

--- a/crates/scp-protocol/src/crypto/sender_keys/encrypt.rs
+++ b/crates/scp-protocol/src/crypto/sender_keys/encrypt.rs
@@ -262,6 +262,56 @@ mod tests {
     }
 
     #[test]
+    fn raw_context_string_aad_differs_from_hex_of_hash() {
+        // §9.16.1 / §9.5.1: the AAD binds the RAW context_id string. A peer
+        // that (incorrectly) bound `hex(SHA-256(context_id))` would produce a
+        // different AAD and fail to interoperate. This pins that the two are
+        // distinct AAD values: a ciphertext sealed with the raw string cannot
+        // be opened with the hex-of-hash string, and vice versa.
+        let key = generate_sender_key();
+        let plaintext = b"interop-sensitive payload";
+
+        // The hex of SHA-256(raw) — exactly what native used to bind (#1909).
+        let hex_of_hash = hex::encode(crate::context::context_id_bytes(TEST_CTX));
+        assert_ne!(
+            hex_of_hash, TEST_CTX,
+            "the hex-of-hash and the raw string must be distinct AAD inputs"
+        );
+
+        // Sealed with the RAW string (the spec value).
+        let ct_raw =
+            encrypt_sender_layer(&key, plaintext, TEST_CTX, TEST_DID, TEST_EPOCH, TEST_SEQ)
+                .unwrap();
+        // Opening with the hex-of-hash string fails — wrong AAD.
+        assert!(
+            decrypt_sender_layer(&key, &ct_raw, &hex_of_hash, TEST_DID, TEST_EPOCH, TEST_SEQ)
+                .is_err(),
+            "raw-sealed ciphertext must NOT open under the hex-of-hash AAD"
+        );
+        // Opening with the raw string succeeds — the spec round-trip.
+        assert_eq!(
+            decrypt_sender_layer(&key, &ct_raw, TEST_CTX, TEST_DID, TEST_EPOCH, TEST_SEQ).unwrap(),
+            plaintext,
+        );
+
+        // Symmetric direction: sealed with the hex-of-hash string cannot open
+        // under the raw string.
+        let ct_hex = encrypt_sender_layer(
+            &key,
+            plaintext,
+            &hex_of_hash,
+            TEST_DID,
+            TEST_EPOCH,
+            TEST_SEQ,
+        )
+        .unwrap();
+        assert!(
+            decrypt_sender_layer(&key, &ct_hex, TEST_CTX, TEST_DID, TEST_EPOCH, TEST_SEQ).is_err(),
+            "hex-sealed ciphertext must NOT open under the raw-string AAD"
+        );
+    }
+
+    #[test]
     fn truncated_ciphertext_fails() {
         let key = generate_sender_key();
         let result =

--- a/crates/scp-runtime/src/context/agent_binding_pipeline_tests.rs
+++ b/crates/scp-runtime/src/context/agent_binding_pipeline_tests.rs
@@ -247,7 +247,7 @@ fn receive_via_verify_and_unwrap(
     resolver: &KeyResolver,
     bob_access_key: &AccessKey,
 ) -> Result<Vec<u8>, ContextError> {
-    let opened = match bob_provider.open(ctx_bytes, blob)? {
+    let opened = match bob_provider.open(ctx_bytes, ctx_str, blob)? {
         scp_protocol::context::builder::OpenResult::Application(env) => *env,
         other => {
             return Err(ContextError::CryptoFailed(format!(
@@ -644,7 +644,7 @@ mod live_supervisor_send {
         // `FullStackNode::decrypt_message`).
         for (_routing_id, blob) in bootstrap_blobs {
             match bob
-                .open(&ctx_bytes, &blob)
+                .open(&ctx_bytes, ctx_id, &blob)
                 .expect("bob opens bootstrap blob")
             {
                 OpenResult::Management {
@@ -746,7 +746,7 @@ mod live_supervisor_send {
         // Open the captured wire blob on Bob's provider and read the persona
         // straight off the recovered inner envelope.
         match bob
-            .open(&ctx_bytes, ciphertext)
+            .open(&ctx_bytes, ctx_id, ciphertext)
             .expect("bob opens the app blob")
         {
             OpenResult::Application(env) => {

--- a/crates/scp-runtime/src/context/messaging_helpers.rs
+++ b/crates/scp-runtime/src/context/messaging_helpers.rs
@@ -2739,7 +2739,9 @@ pub fn decrypt_and_dispatch(
     encrypted_blob: &[u8],
 ) -> Result<Option<scp_protocol::context::builder::OpenedEnvelope>, ContextError> {
     let decrypt_start = std::time::Instant::now();
-    let open_result = deps.crypto.open(context_id_bytes, encrypted_blob)?;
+    let open_result = deps
+        .crypto
+        .open(context_id_bytes, context_id, encrypted_blob)?;
     crate::metrics::record_decrypt_duration(decrypt_start.elapsed());
 
     match open_result {

--- a/crates/scp-runtime/src/crypto/mls/provider.rs
+++ b/crates/scp-runtime/src/crypto/mls/provider.rs
@@ -1570,11 +1570,23 @@ impl MlsCryptoProvider {
         blob_ttl: u32,
     ) -> Result<Vec<u8>, ContextError> {
         self.with_context(context_id, |state| {
-            // Use hex-encoded context_id bytes as AAD context string, matching
-            // the decrypt path in `open` which also uses `hex::encode(context_id)`.
-            // `seal_envelope` uses `inner.context_id` (the original string), which
-            // would cause an AAD mismatch on the receive side.
-            let ctx_str = hex::encode(context_id);
+            // The sender-layer AEAD AAD MUST bind the RAW `context_id` string
+            // (UTF-8, 4-byte BE length prefix) per spec §9.16.1 + §9.5.1 — not
+            // the hex encoding of its 32-byte hash. WASM binds the raw string;
+            // binding anything else here breaks native↔WASM interop and the
+            // spec contract. The raw string is carried on the inner envelope.
+            let ctx_str = inner.context_id.as_str();
+
+            // Defense in depth: the supplied 32-byte `context_id` MUST be the
+            // SHA-256 of the inner envelope's `context_id` string. If they
+            // diverge, the AAD would bind a string unrelated to the routing /
+            // store keying, so fail closed rather than emit an unverifiable
+            // ciphertext. (No panic/unwrap — clippy denies them on this path.)
+            if scp_protocol::context::context_id_bytes(ctx_str) != *context_id {
+                return Err(ContextError::CryptoFailed(
+                    "inner envelope context_id does not hash to the supplied context_id".into(),
+                ));
+            }
 
             // 1. Serialize inner envelope to MessagePack.
             let serialized = rmp_serde::to_vec_named(inner).map_err(|e| {
@@ -1583,13 +1595,13 @@ impl MlsCryptoProvider {
 
             // 2. Sender key encrypt (AES-256-GCM, ADR-007).
             // AAD binds context_id, sender_did, epoch, and sequence to prevent
-            // ciphertext relocation. Uses hex-encoded context_id bytes for
-            // consistency with the decrypt path.
+            // ciphertext relocation. Binds the RAW context_id string per
+            // §9.16.1 so the receive side (and WASM) can reconstruct it.
             let sender_encrypted =
                 scp_protocol::crypto::sender_keys::encrypt::encrypt_sender_layer(
                     &state.sender_key,
                     &serialized,
-                    &ctx_str,
+                    ctx_str,
                     &self.local_did,
                     state.sender_key_epoch,
                     state.send_sequence,
@@ -1649,10 +1661,21 @@ impl MlsCryptoProvider {
     pub fn open(
         &self,
         context_id: &[u8; 32],
+        context_id_str: &str,
         outer_bytes: &[u8],
     ) -> Result<scp_protocol::context::builder::OpenResult, ContextError> {
         self.with_context(context_id, |state| {
-            let ctx_str = hex::encode(context_id);
+            // Hex of the 32-byte id — the LOCAL sender-key store key (matches
+            // every other store call site). NOT the AAD value.
+            let ctx_id_hex = hex::encode(context_id);
+
+            // The sender-layer AEAD AAD binds the RAW `context_id_str`
+            // (§9.16.1), not this hex. The two are reconciled on the Application
+            // path below: a `context_id_str` that does not hash to
+            // `context_id` would bind an AAD no legitimate sealer produced, so
+            // AEAD verification fails closed. Control/Management messages never
+            // reach the sender-layer AEAD, so they are unaffected by the value
+            // of `context_id_str`.
 
             // Step 0: Deserialize outer envelope to extract MLS ciphertext.
             let outer: scp_protocol::envelope::outer::OuterEnvelope =
@@ -1693,7 +1716,7 @@ impl MlsCryptoProvider {
                     // Step 2: Look up the sender's key from the sender key store.
                     let sender_key = state
                         .sender_key_store
-                        .get(&ctx_str, &sender_did)
+                        .get(&ctx_id_hex, &sender_did)
                         .cloned()
                         .ok_or_else(|| {
                             ContextError::CryptoFailed("sender key lookup failed".into())
@@ -1706,10 +1729,12 @@ impl MlsCryptoProvider {
                         )
                         .map_err(|e| ContextError::CryptoFailed(e.to_string()))?;
                     // Epoch/sequence from header — see send_message comment about AAD.
+                    // The AAD binds the RAW context_id string per §9.16.1 (NOT
+                    // the hex store key), matching the `seal` / WASM encode path.
                     let decrypted = scp_protocol::crypto::sender_keys::decrypt_sender_layer(
                         &sender_key,
                         sender_ciphertext,
-                        &ctx_str,
+                        context_id_str,
                         &sender_did,
                         epoch,
                         sequence,
@@ -1727,7 +1752,7 @@ impl MlsCryptoProvider {
                     // `process_incoming_sender_key` path enforces the same
                     // ceiling on key distributions; this mirrors that bound
                     // on the message receive path so the two cannot diverge.
-                    let stored_high_water = state.sender_key_store.epoch(&ctx_str, &sender_did);
+                    let stored_high_water = state.sender_key_store.epoch(&ctx_id_hex, &sender_did);
                     let allowed_epoch_ceiling = stored_high_water.saturating_add(MAX_EPOCH_ADVANCE);
                     if epoch > allowed_epoch_ceiling {
                         return Err(ContextError::CryptoFailed(format!(
@@ -4222,10 +4247,17 @@ mod tests {
     /// MLS group via the provider-level Welcome flow, exchange Alice's
     /// sender key, and return both providers ready for `seal()` /
     /// `open()`. Used by the H9 ceiling tests.
+    /// String whose SHA-256 is the `context_id` returned by
+    /// [`setup_alice_bob_two_party`]. The sender-layer AEAD AAD binds the raw
+    /// context-id string (§9.16.1), and both `seal` and `open` assert the
+    /// supplied 32-byte id is `context_id_bytes(ctx_str)`, so the fixture must
+    /// derive its id from a real string rather than an arbitrary 32-byte value.
+    const TEST_CTX_STR: &str = "h9-ceiling-ctx";
+
     fn setup_alice_bob_two_party() -> (MlsCryptoProvider, MlsCryptoProvider, [u8; 32], String) {
         let alice_did = TEST_DID;
         let bob_did = "did:dht:z6MkBobBobBobBobBobBobBobBobBobBobBobBobBo";
-        let context_id = make_context_id();
+        let context_id = scp_protocol::context::context_id_bytes(TEST_CTX_STR);
 
         let alice = MlsCryptoProvider::new(alice_did.to_string());
         alice.create_mls_group(&context_id).unwrap();
@@ -4263,7 +4295,7 @@ mod tests {
     /// `open()`, signature verification is deferred to `ContextManager`),
     /// so an arbitrary key suffices for the H9 receive-ceiling tests.
     fn build_test_inner(
-        context_id: &[u8; 32],
+        context_id_str: &str,
         sender_did: &str,
         epoch_field: u64,
         sequence_field: u64,
@@ -4271,7 +4303,7 @@ mod tests {
         let sk = ed25519_dalek::SigningKey::from_bytes(&[7u8; 32]);
         let params = crate::envelope::inner::InnerEnvelopeParams {
             version: crate::envelope::inner::SCP_INNER_ENVELOPE_VERSION,
-            context_id: &hex::encode(context_id),
+            context_id: context_id_str,
             sender_did,
             epoch: epoch_field,
             generation: 0,
@@ -4313,12 +4345,12 @@ mod tests {
 
         force_alice_sender_key_epoch(&alice, &ctx_id, u64::MAX);
 
-        let inner = build_test_inner(&ctx_id, &alice_did, 0, 0);
+        let inner = build_test_inner(TEST_CTX_STR, &alice_did, 0, 0);
         let routing_id = ctx_routing_id(&ctx_id);
         let sealed = alice.seal(&ctx_id, &inner, &routing_id, 300).unwrap();
 
         let err = bob
-            .open(&ctx_id, &sealed)
+            .open(&ctx_id, TEST_CTX_STR, &sealed)
             .expect_err("u64::MAX epoch must be rejected by the H9 ceiling");
         match err {
             ContextError::CryptoFailed(msg) => {
@@ -4353,12 +4385,12 @@ mod tests {
 
         force_alice_sender_key_epoch(&alice, &ctx_id, 1002);
 
-        let inner = build_test_inner(&ctx_id, &alice_did, 0, 0);
+        let inner = build_test_inner(TEST_CTX_STR, &alice_did, 0, 0);
         let routing_id = ctx_routing_id(&ctx_id);
         let sealed = alice.seal(&ctx_id, &inner, &routing_id, 300).unwrap();
 
         let err = bob
-            .open(&ctx_id, &sealed)
+            .open(&ctx_id, TEST_CTX_STR, &sealed)
             .expect_err("epoch one past the ceiling must be rejected");
         match err {
             ContextError::CryptoFailed(msg) => {
@@ -4380,12 +4412,12 @@ mod tests {
 
         force_alice_sender_key_epoch(&alice, &ctx_id, 1001);
 
-        let inner = build_test_inner(&ctx_id, &alice_did, 0, 0);
+        let inner = build_test_inner(TEST_CTX_STR, &alice_did, 0, 0);
         let routing_id = ctx_routing_id(&ctx_id);
         let sealed = alice.seal(&ctx_id, &inner, &routing_id, 300).unwrap();
 
         let result = bob
-            .open(&ctx_id, &sealed)
+            .open(&ctx_id, TEST_CTX_STR, &sealed)
             .expect("epoch == ceiling must be accepted (boundary inclusive)");
         match result {
             scp_protocol::context::builder::OpenResult::Application(env) => {
@@ -4410,16 +4442,18 @@ mod tests {
         let (alice, bob, ctx_id, alice_did) = setup_alice_bob_two_party();
 
         let routing_id = ctx_routing_id(&ctx_id);
-        let inner1 = build_test_inner(&ctx_id, &alice_did, 0, 0);
-        let inner2 = build_test_inner(&ctx_id, &alice_did, 0, 1);
+        let inner1 = build_test_inner(TEST_CTX_STR, &alice_did, 0, 0);
+        let inner2 = build_test_inner(TEST_CTX_STR, &alice_did, 0, 1);
 
         // Two sequential seals at Alice's natural epoch=1, sequence
         // increments handled by `seal()` itself.
         let sealed1 = alice.seal(&ctx_id, &inner1, &routing_id, 300).unwrap();
         let sealed2 = alice.seal(&ctx_id, &inner2, &routing_id, 300).unwrap();
 
-        bob.open(&ctx_id, &sealed1).expect("first seal must open");
-        bob.open(&ctx_id, &sealed2).expect("second seal must open");
+        bob.open(&ctx_id, TEST_CTX_STR, &sealed1)
+            .expect("first seal must open");
+        bob.open(&ctx_id, TEST_CTX_STR, &sealed2)
+            .expect("second seal must open");
 
         let entry = bob.contexts.get(&ctx_id).unwrap();
         let state = entry.value();
@@ -4430,6 +4464,58 @@ mod tests {
             .expect("tracker must be populated by happy-path opens");
         assert_eq!(epoch, 1, "epoch should be Alice's natural epoch");
         assert_eq!(seq, 1, "sequence should advance to the second message");
+    }
+
+    #[test]
+    fn seal_open_binds_raw_context_id_string_not_hex() {
+        // §9.16.1: the sender-layer AEAD AAD MUST bind the RAW context_id
+        // string (UTF-8, BE32 length-prefixed), NOT the hex encoding of its
+        // 32-byte hash. This is the #1909 fix and the WASM↔native interop
+        // contract. Proof: a `seal`ed message opens with the raw string but
+        // FAILS to open when the hex-of-bytes string is supplied as the AAD
+        // source — the exact value native used to (incorrectly) bind.
+        let (alice, bob, ctx_id, alice_did) = setup_alice_bob_two_party();
+        let routing_id = ctx_routing_id(&ctx_id);
+
+        // Two independently-sealed messages. MLS forward secrecy deletes the
+        // per-message decryption secret on the FIRST `open` of a given
+        // ciphertext, so the negative and positive cases must each consume
+        // their own freshly-sealed blob — re-opening one blob twice would fail
+        // at the MLS layer for an unrelated (forward-secrecy) reason.
+        let inner1 = build_test_inner(TEST_CTX_STR, &alice_did, 0, 0);
+        let inner2 = build_test_inner(TEST_CTX_STR, &alice_did, 0, 1);
+        let sealed_neg = alice.seal(&ctx_id, &inner1, &routing_id, 300).unwrap();
+        let sealed_pos = alice.seal(&ctx_id, &inner2, &routing_id, 300).unwrap();
+
+        // Negative: opening with the hex-of-bytes string rebuilds the OLD
+        // (spec-violating) AAD, so the sender-layer AEAD verification fails.
+        // The MLS layer decrypts first (proving the failure is the AAD, not
+        // membership), then `decrypt_sender_layer` rejects the wrong AAD.
+        let hex_ctx = hex::encode(ctx_id);
+        let err = bob
+            .open(&ctx_id, &hex_ctx, &sealed_neg)
+            .expect_err("opening with the hex-of-bytes AAD string must fail AEAD verification");
+        match err {
+            ContextError::CryptoFailed(msg) => {
+                assert!(
+                    msg.contains("authentication") || msg.contains("Authentication"),
+                    "expected an AEAD authentication failure, got: {msg}"
+                );
+            }
+            other => panic!("expected CryptoFailed, got {other:?}"),
+        }
+
+        // Positive: opening the second blob with the RAW context_id string
+        // (the spec value) succeeds, proving the AAD binds the raw string.
+        let opened = bob
+            .open(&ctx_id, TEST_CTX_STR, &sealed_pos)
+            .expect("opening with the raw context_id string (spec AAD) must succeed");
+        match opened {
+            scp_protocol::context::builder::OpenResult::Application(env) => {
+                assert_eq!(env.sender_did, alice_did);
+            }
+            other => panic!("expected Application, got {other:?}"),
+        }
     }
 
     #[test]
@@ -4444,12 +4530,12 @@ mod tests {
 
         // First, advance the receive tracker to (1, 1) via two
         // legitimate messages.
-        let inner_a = build_test_inner(&ctx_id, &alice_did, 0, 0);
-        let inner_b = build_test_inner(&ctx_id, &alice_did, 0, 1);
+        let inner_a = build_test_inner(TEST_CTX_STR, &alice_did, 0, 0);
+        let inner_b = build_test_inner(TEST_CTX_STR, &alice_did, 0, 1);
         let sealed_a = alice.seal(&ctx_id, &inner_a, &routing_id, 300).unwrap();
         let sealed_b = alice.seal(&ctx_id, &inner_b, &routing_id, 300).unwrap();
-        bob.open(&ctx_id, &sealed_a).unwrap();
-        bob.open(&ctx_id, &sealed_b).unwrap();
+        bob.open(&ctx_id, TEST_CTX_STR, &sealed_a).unwrap();
+        bob.open(&ctx_id, TEST_CTX_STR, &sealed_b).unwrap();
 
         // Now force Alice's send_sequence backwards and re-seal. The
         // resulting header has (epoch=1, sequence=0) which is below
@@ -4461,11 +4547,11 @@ mod tests {
             let state = entry.value_mut();
             state.send_sequence = 0;
         }
-        let inner_replay = build_test_inner(&ctx_id, &alice_did, 0, 0);
+        let inner_replay = build_test_inner(TEST_CTX_STR, &alice_did, 0, 0);
         let sealed_replay = alice
             .seal(&ctx_id, &inner_replay, &routing_id, 300)
             .unwrap();
-        let err = bob.open(&ctx_id, &sealed_replay).expect_err(
+        let err = bob.open(&ctx_id, TEST_CTX_STR, &sealed_replay).expect_err(
             "lower-sequence message at the same epoch must still be rejected as replay",
         );
         match err {
@@ -4487,10 +4573,10 @@ mod tests {
             let state = entry.value_mut();
             state.send_sequence = 5;
         }
-        let inner_lower = build_test_inner(&ctx_id, &alice_did, 0, 0);
+        let inner_lower = build_test_inner(TEST_CTX_STR, &alice_did, 0, 0);
         let sealed_lower = alice.seal(&ctx_id, &inner_lower, &routing_id, 300).unwrap();
         let err = bob
-            .open(&ctx_id, &sealed_lower)
+            .open(&ctx_id, TEST_CTX_STR, &sealed_lower)
             .expect_err("lower-epoch message must still be rejected as reorder");
         match err {
             ContextError::CryptoFailed(msg) => {
@@ -4586,7 +4672,7 @@ mod tests {
         let (alice, _bob, ctx_id, alice_did) = setup_alice_bob_two_party();
         let _owned = alice.take_crypto_state(&ctx_id).unwrap();
 
-        let inner = build_test_inner(&ctx_id, &alice_did, 0, 0);
+        let inner = build_test_inner(TEST_CTX_STR, &alice_did, 0, 0);
         let routing_id = ctx_routing_id(&ctx_id);
 
         let err = alice
@@ -4608,14 +4694,14 @@ mod tests {
 
         // Seal a message via alice BEFORE taking the state so we
         // have a valid ciphertext to feed into bob's open.
-        let inner = build_test_inner(&ctx_id, &alice_did, 0, 0);
+        let inner = build_test_inner(TEST_CTX_STR, &alice_did, 0, 0);
         let routing_id = ctx_routing_id(&ctx_id);
         let sealed = alice.seal(&ctx_id, &inner, &routing_id, 300).unwrap();
 
         // Now take bob's state — open on bob's side should error.
         let _owned = bob.take_crypto_state(&ctx_id).unwrap();
         let err = bob
-            .open(&ctx_id, &sealed)
+            .open(&ctx_id, TEST_CTX_STR, &sealed)
             .expect_err("open on a taken context must error");
         match err {
             ContextError::CryptoFailed(msg) => {
@@ -4805,7 +4891,7 @@ mod tests {
 
         // Bob opens the same blob and recovers the application plaintext,
         // proving the zeroed routing_id does not break delivery.
-        let opened = bob.open(&ctx_id, &wire).unwrap();
+        let opened = bob.open(&ctx_id, ctx_str, &wire).unwrap();
         match opened {
             scp_protocol::context::builder::OpenResult::Application(env) => {
                 assert_eq!(
@@ -4828,14 +4914,18 @@ mod tests {
     /// over-broadly zero the control seal sites.
     #[test]
     fn control_message_seal_still_embeds_context_routing_id() {
-        let (alice, _bob, ctx_id, alice_did) = setup_alice_bob_two_party();
+        // The context id must be derived from a real string: `seal` binds the
+        // raw `inner.context_id` into the AEAD AAD (§9.16.1) and asserts the
+        // supplied 32-byte id is its SHA-256, so a hex-of-bytes inner id (which
+        // is not the preimage of `ctx_id`) would be rejected.
+        let ctx_str = "ctx-control-routing-id";
+        let (alice, _bob, ctx_id, alice_did) = setup_two_party_for_ctx_string(ctx_str);
         let sk = ed25519_dalek::SigningKey::from_bytes(&[7u8; 32]);
-        let ctx_str = hex::encode(ctx_id);
 
         // Mirror the control-path inner envelope (Recovery message type).
         let params = crate::envelope::inner::InnerEnvelopeParams {
             version: scp_protocol::envelope::SCP_PROTOCOL_VERSION,
-            context_id: &ctx_str,
+            context_id: ctx_str,
             sender_did: &alice_did,
             epoch: 0,
             generation: 0,
@@ -4850,7 +4940,7 @@ mod tests {
 
         // Control path passes `context_routing_id` to `seal` (as in
         // trust_recovery_helpers / supervisor / lifecycle_helpers).
-        let control_rid = scp_protocol::context::context_routing_id(&ctx_str);
+        let control_rid = scp_protocol::context::context_routing_id(ctx_str);
         let wire = alice.seal(&ctx_id, &inner, &control_rid, 300).unwrap();
 
         let decoded = scp_protocol::envelope::outer::OuterEnvelope::from_bytes(&wire).unwrap();

--- a/crates/scp-runtime/src/crypto/mls/provider.rs
+++ b/crates/scp-runtime/src/crypto/mls/provider.rs
@@ -1665,6 +1665,20 @@ impl MlsCryptoProvider {
         outer_bytes: &[u8],
     ) -> Result<scp_protocol::context::builder::OpenResult, ContextError> {
         self.with_context(context_id, |state| {
+            // Defense in depth (symmetry with `seal`): the supplied 32-byte
+            // `context_id` MUST be the SHA-256 of `context_id_str`. If they
+            // diverge, the AAD reconstructed below from `context_id_str` would
+            // bind a string unrelated to the routing / store keying, so fail
+            // fast here rather than relying on the AEAD layer to reject it.
+            // Unreachable from current callers (both are derived from one
+            // string) but cheap fail-closed insurance. (No panic/unwrap —
+            // clippy denies them on this path.)
+            if scp_protocol::context::context_id_bytes(context_id_str) != *context_id {
+                return Err(ContextError::CryptoFailed(
+                    "context_id_str does not hash to the supplied context_id".into(),
+                ));
+            }
+
             // Hex of the 32-byte id — the LOCAL sender-key store key (matches
             // every other store call site). NOT the AAD value.
             let ctx_id_hex = hex::encode(context_id);
@@ -4487,19 +4501,22 @@ mod tests {
         let sealed_neg = alice.seal(&ctx_id, &inner1, &routing_id, 300).unwrap();
         let sealed_pos = alice.seal(&ctx_id, &inner2, &routing_id, 300).unwrap();
 
-        // Negative: opening with the hex-of-bytes string rebuilds the OLD
-        // (spec-violating) AAD, so the sender-layer AEAD verification fails.
-        // The MLS layer decrypts first (proving the failure is the AAD, not
-        // membership), then `decrypt_sender_layer` rejects the wrong AAD.
+        // Negative: opening with the hex-of-bytes string supplies a
+        // `context_id_str` that does NOT hash to `context_id` (the hex of the
+        // 32-byte id is not its SHA-256 preimage). `open`'s fail-fast guard —
+        // the mirror of `seal`'s hash-consistency assert — rejects this BEFORE
+        // any MLS/AEAD work, so the OLD (spec-violating) hex AAD can never even
+        // be reconstructed. This is strictly stronger than letting the AEAD
+        // layer reject it: a mismatched id/string pair is refused at the door.
         let hex_ctx = hex::encode(ctx_id);
         let err = bob
             .open(&ctx_id, &hex_ctx, &sealed_neg)
-            .expect_err("opening with the hex-of-bytes AAD string must fail AEAD verification");
+            .expect_err("opening with a context_id_str that does not hash to context_id must fail");
         match err {
             ContextError::CryptoFailed(msg) => {
                 assert!(
-                    msg.contains("authentication") || msg.contains("Authentication"),
-                    "expected an AEAD authentication failure, got: {msg}"
+                    msg.contains("does not hash to the supplied context_id"),
+                    "expected the fail-fast hash-consistency rejection, got: {msg}"
                 );
             }
             other => panic!("expected CryptoFailed, got {other:?}"),
@@ -4515,6 +4532,47 @@ mod tests {
                 assert_eq!(env.sender_did, alice_did);
             }
             other => panic!("expected Application, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn open_rejects_context_id_str_that_does_not_hash_to_context_id() {
+        // Defense-in-depth symmetry with `seal`: `open` asserts the supplied
+        // 32-byte `context_id` is `context_id_bytes(context_id_str)` and fails
+        // CLOSED if they diverge. This guard fires at the very top of `open`,
+        // BEFORE any outer-envelope deserialization, MLS decrypt, or
+        // sender-layer AEAD work — so the rejection is the fast-path
+        // hash-consistency error, distinct from an AEAD authentication failure.
+        let (_alice, bob, ctx_id, _alice_did) = setup_alice_bob_two_party();
+
+        // A `context_id_str` whose SHA-256 is NOT `ctx_id`. (`ctx_id` is the
+        // hash of TEST_CTX_STR; any other string hashes elsewhere.)
+        let mismatched_ctx_str = "definitely-not-the-real-context-string";
+        assert_ne!(
+            scp_protocol::context::context_id_bytes(mismatched_ctx_str),
+            ctx_id,
+            "test precondition: the mismatched string must not hash to ctx_id"
+        );
+
+        // The outer bytes are deliberately garbage: the guard must reject the
+        // mismatched id/string pair BEFORE it ever attempts to deserialize or
+        // decrypt them. If the guard did not fire first, this call would
+        // instead surface an "outer envelope deserialization" error — proving
+        // by its absence that the fail-fast assert ran ahead of the AEAD layer.
+        let bogus_outer = [0xABu8; 64];
+        let err = bob
+            .open(&ctx_id, mismatched_ctx_str, &bogus_outer)
+            .expect_err("open must reject a context_id_str that does not hash to context_id");
+
+        match err {
+            ContextError::CryptoFailed(msg) => {
+                assert_eq!(
+                    msg, "context_id_str does not hash to the supplied context_id",
+                    "expected the fail-fast hash-consistency rejection, not an AEAD or \
+                     deserialization failure, got: {msg}"
+                );
+            }
+            other => panic!("expected CryptoFailed, got {other:?}"),
         }
     }
 

--- a/crates/scp-testing/src/fullstack/crypto.rs
+++ b/crates/scp-testing/src/fullstack/crypto.rs
@@ -203,6 +203,7 @@ impl E2eCryptoProvider {
     /// processing fails.
     pub fn process_pending_commits(
         &self,
+        context_id_str: &str,
         context_id: &[u8; 32],
     ) -> Result<(), scp_core::context::ContextError> {
         let commits = {
@@ -212,7 +213,7 @@ impl E2eCryptoProvider {
         for commit_bytes in commits {
             let wrapped =
                 super::node::wrap_raw_mls_message(&hex::encode(context_id), commit_bytes)?;
-            match self.provider.open(context_id, &wrapped)? {
+            match self.provider.open(context_id, context_id_str, &wrapped)? {
                 // A Commit advances the epoch and surfaces as a control
                 // message — no payload is produced.
                 scp_core::context::builder::OpenResult::Control => {}
@@ -282,6 +283,7 @@ impl E2eCryptoProvider {
     /// or sender-key processing fails.
     pub fn pickup_sender_key_messages(
         &self,
+        context_id_str: &str,
         context_id: &[u8; 32],
     ) -> Result<(), scp_core::context::ContextError> {
         let messages = {
@@ -289,7 +291,7 @@ impl E2eCryptoProvider {
             exchange.take_sender_key_messages(context_id, self.local_did.as_ref())
         };
         for wrapped in messages {
-            match self.provider.open(context_id, &wrapped)? {
+            match self.provider.open(context_id, context_id_str, &wrapped)? {
                 scp_core::context::builder::OpenResult::Management {
                     sender_did,
                     payload,

--- a/crates/scp-testing/src/fullstack/node.rs
+++ b/crates/scp-testing/src/fullstack/node.rs
@@ -421,8 +421,10 @@ impl FullStackNode {
     ) -> Result<(), ContextError> {
         self.crypto.join_from_welcome(context_id)?;
         self.crypto.pickup_access_keys(context_id_str);
-        self.crypto.pickup_sender_key_messages(context_id)?;
-        self.crypto.process_pending_commits(context_id)?;
+        self.crypto
+            .pickup_sender_key_messages(context_id_str, context_id)?;
+        self.crypto
+            .process_pending_commits(context_id_str, context_id)?;
         Ok(())
     }
 
@@ -560,11 +562,17 @@ impl FullStackNode {
     /// application envelope.
     pub fn open_inner_envelope(
         &self,
+        context_id_str: &str,
         context_id: &[u8; 32],
         ciphertext: &[u8],
     ) -> Result<scp_core::envelope::inner::InnerEnvelope, ContextError> {
-        self.crypto.process_pending_commits(context_id)?;
-        match self.crypto.provider.open(context_id, ciphertext)? {
+        self.crypto
+            .process_pending_commits(context_id_str, context_id)?;
+        match self
+            .crypto
+            .provider
+            .open(context_id, context_id_str, ciphertext)?
+        {
             scp_core::context::builder::OpenResult::Application(env) => Ok(env.inner),
             scp_core::context::builder::OpenResult::Control => {
                 Err(ContextError::CryptoFailed("open returned Control".into()))
@@ -599,11 +607,16 @@ impl FullStackNode {
         sender_did: &str,
     ) -> Result<Vec<u8>, ContextError> {
         // Apply any pending epoch-advance commits to sync the MLS epoch.
-        self.crypto.process_pending_commits(context_id)?;
+        self.crypto
+            .process_pending_commits(context_id_str, context_id)?;
 
         // Open: outer envelope → MLS decrypt → sender-key decrypt → inner
         // envelope → strip padding → integrity check.
-        let opened = match self.crypto.provider.open(context_id, ciphertext)? {
+        let opened = match self
+            .crypto
+            .provider
+            .open(context_id, context_id_str, ciphertext)?
+        {
             scp_core::context::builder::OpenResult::Application(env) => *env,
             scp_core::context::builder::OpenResult::Control => {
                 return Err(ContextError::CryptoFailed("open returned Control".into()));
@@ -661,8 +674,13 @@ impl FullStackNode {
     /// # Errors
     ///
     /// Propagates [`ContextError`] from the crypto provider.
-    pub fn pickup_sender_keys(&self, context_id: &[u8; 32]) -> Result<(), ContextError> {
-        self.crypto.pickup_sender_key_messages(context_id)
+    pub fn pickup_sender_keys(
+        &self,
+        context_id_str: &str,
+        context_id: &[u8; 32],
+    ) -> Result<(), ContextError> {
+        self.crypto
+            .pickup_sender_key_messages(context_id_str, context_id)
     }
 
     /// Drains events for a context.

--- a/crates/scp-testing/tests/integration/fullstack.rs
+++ b/crates/scp-testing/tests/integration/fullstack.rs
@@ -236,9 +236,15 @@ async fn fullstack_heartbeat_send_does_not_advance_application_sequence() {
     );
 
     // Open each captured inner envelope (peer side) and classify it.
-    let inner0 = bob.open_inner_envelope(&ctx_bytes, &sent[0].1).unwrap();
-    let inner_hb = bob.open_inner_envelope(&ctx_bytes, &sent[1].1).unwrap();
-    let inner2 = bob.open_inner_envelope(&ctx_bytes, &sent[2].1).unwrap();
+    let inner0 = bob
+        .open_inner_envelope(ctx_id, &ctx_bytes, &sent[0].1)
+        .unwrap();
+    let inner_hb = bob
+        .open_inner_envelope(ctx_id, &ctx_bytes, &sent[1].1)
+        .unwrap();
+    let inner2 = bob
+        .open_inner_envelope(ctx_id, &ctx_bytes, &sent[2].1)
+        .unwrap();
 
     // AC2: the middle send is a heartbeat — heartbeat discriminator, no
     // content. (Empty user payload survives as a minimal wrapped+padded blob,

--- a/crates/scp-testing/tests/integration/welcome_delivery.rs
+++ b/crates/scp-testing/tests/integration/welcome_delivery.rs
@@ -29,7 +29,12 @@ use scp_core::crypto::mls::provider::MlsCryptoProvider;
 fn cross_process_welcome_delivery() {
     let alice_did = "did:dht:z6MkAliceAliceAliceAliceAliceAliceAliceAlic";
     let bob_did = "did:dht:z6MkBobBobBobBobBobBobBobBobBobBobBobBobBo";
-    let context_id = [0x42u8; 32];
+    // Derive the 32-byte id from a real string: `seal` binds the raw
+    // `inner.context_id` string into the AEAD AAD (§9.16.1) and asserts the
+    // supplied id is its SHA-256, and `open` rebuilds the same AAD from the
+    // raw string passed alongside the id.
+    let context_id_str = "cross-process-welcome-ctx";
+    let context_id = scp_core::context::context_id_bytes(context_id_str);
 
     // Create Alice's and Bob's crypto providers (separate "processes").
     let alice_crypto = MlsCryptoProvider::new(alice_did.to_string());
@@ -93,7 +98,7 @@ fn cross_process_welcome_delivery() {
     let sk = ed25519_dalek::SigningKey::from_bytes(&[42u8; 32]);
     let params = scp_core::envelope::inner::InnerEnvelopeParams {
         version: scp_core::envelope::SCP_PROTOCOL_VERSION,
-        context_id: &hex::encode(context_id),
+        context_id: context_id_str,
         sender_did: alice_did,
         epoch: 0,
         generation: 0,
@@ -105,14 +110,16 @@ fn cross_process_welcome_delivery() {
         signing_key_id: scp_identity::SigningKeyId::Active,
     };
     let inner = scp_core::envelope::inner::sign::create_inner_envelope_raw(&params, &sk).unwrap();
-    let routing_id = scp_core::context::context_routing_id(&hex::encode(context_id));
+    let routing_id = scp_core::context::context_routing_id(context_id_str);
     let sealed = alice_crypto
         .seal(&context_id, &inner, &routing_id, 300)
         .unwrap();
 
     // Bob opens Alice's message — proves the full pipeline works:
     // MLS Welcome join + sender key distribution + seal + open.
-    let open_result = bob_crypto.open(&context_id, &sealed).unwrap();
+    let open_result = bob_crypto
+        .open(&context_id, context_id_str, &sealed)
+        .unwrap();
     let envelope = match open_result {
         scp_core::context::builder::OpenResult::Application(env) => env,
         other => panic!("expected Application, got {other:?}"),
@@ -139,7 +146,8 @@ fn cross_process_welcome_delivery() {
 fn join_time_sender_key_distribution_uses_management_channel() {
     let alice_did = "did:dht:z6MkAliceAliceAliceAliceAliceAliceAliceAlic";
     let bob_did = "did:dht:z6MkBobBobBobBobBobBobBobBobBobBobBobBobBo";
-    let context_id = [0x33u8; 32];
+    let context_id_str = "sender-key-mgmt-channel-ctx";
+    let context_id = scp_core::context::context_id_bytes(context_id_str);
 
     let alice_crypto = MlsCryptoProvider::new(alice_did.to_string());
     let bob_crypto = MlsCryptoProvider::new(bob_did.to_string());
@@ -176,14 +184,14 @@ fn join_time_sender_key_distribution_uses_management_channel() {
     // The fix: each pending distribution MUST be MLS-wrapped before
     // being posted to transport. This is what `drain_and_deliver_sender_keys`
     // does internally — we exercise the same path here.
-    let routing_id = scp_core::context::context_routing_id(&hex::encode(context_id));
+    let routing_id = scp_core::context::context_routing_id(context_id_str);
     let (target_did, raw_distribution) = pending.into_iter().next().unwrap();
     assert_eq!(target_did, bob_did);
 
     // Sanity check the pre-fix shape: the raw distribution bytes are NOT
     // a valid OuterEnvelope. Bob's `open()` would error if we sent them
     // as-is via `transport.send_message`.
-    let bare_open = bob_crypto.open(&context_id, &raw_distribution);
+    let bare_open = bob_crypto.open(&context_id, context_id_str, &raw_distribution);
     assert!(
         bare_open.is_err(),
         "raw HPKE distribution bytes must not deserialize as OuterEnvelope — \
@@ -197,7 +205,9 @@ fn join_time_sender_key_distribution_uses_management_channel() {
 
     // Bob's `open()` MUST recognize the wrapped payload as Management,
     // surfacing the inner HPKE bytes for `process_incoming_sender_key`.
-    let open_result = bob_crypto.open(&context_id, &wrapped).unwrap();
+    let open_result = bob_crypto
+        .open(&context_id, context_id_str, &wrapped)
+        .unwrap();
     let payload = match open_result {
         scp_core::context::builder::OpenResult::Management {
             sender_did,


### PR DESCRIPTION
## Summary

**Phase 1 of #1909** (part of #1877 native↔WASM convergence): a native-only spec-conformance fix on the live sender-layer crypto wire path.

Spec §9.16.1 defines the sender-key AES-256-GCM AAD as `BE32(len(context_id)) || context_id || BE32(len(sender_did)) || sender_did || epoch_BE8 || sequence_BE8`, where `context_id` is **raw UTF-8 with a 4-byte big-endian length prefix** (§9.5.1 variable-length-bytes encoding). Native instead bound `hex::encode(SHA-256(context_id))` — a spec violation, and the reason WASM↔native sender-layer interop is impossible (WASM already binds the raw string via the shared `build_sender_aad`).

This converges **native** to the spec (correct code→spec direction):

- **`seal`** now feeds the raw `inner.context_id` string to `build_sender_aad` (was `hex::encode(context_id)`).
- **`open`** gains a `context_id_str: &str` parameter and builds the AAD from it; the `hex(context_id)` is retained **only** as the sender-key-store lookup key (the store is hex-keyed). The string is threaded from every caller — the production path (`messaging_helpers.rs::decrypt_and_dispatch`) already derives both the 32-byte id and the string from one trusted local `context_id`.
- Both `seal` and `open` assert `context_id_bytes(str) == *context_id` (fail-closed `CryptoFailed`, no panic) — binding the AAD string to the routing/store id at the source. The `open` assert is symmetric defense-in-depth (a future buggy internal caller fails fast with a clear error rather than a silent AEAD drop).

`build_sender_aad` (shared with WASM) is unchanged. The §9.16.2 HPKE `info` path (already raw string) is untouched. Pre-release ⇒ no migration; `seal`+`open` flip atomically (no native-native break window).

## Scope boundary

Phase 1 is the **native AAD correctness flip only**. It does **not** yet achieve WASM↔native interop — that also requires the WASM-side epoch-semantics + replay-tracker convergence in **Phase 2** (see #1909). So `Refs`, not `Closes`. A normative §25 sender-layer AAD KAT pinning the raw-string form belongs with the Phase-2 interop closeout.

## Tests

- `seal_open_binds_raw_context_id_string_not_hex` (provider.rs) — raw string opens; a non-preimage string is rejected fail-fast at the guard (uses two seals to account for MLS forward secrecy).
- `open_rejects_context_id_str_that_does_not_hash_to_context_id` (provider.rs) — proves the `open` guard fires before envelope/AEAD work (error-discrimination via garbage outer bytes).
- `raw_context_string_aad_differs_from_hex_of_hash` (encrypt.rs) — AEAD-level proof that a hex-AAD does not verify against a raw-sealed message (and vice versa), retaining that coverage independent of the provider guard.
- All `open` callers threaded; FFI (`scp-ffi`, `scp-ffi-napi`) testing helpers updated.

## Verification

- CI clippy (all features, `-D warnings`), `cargo fmt --check` — clean.
- Full workspace `cargo nextest` (CI features) — **9883 passed, 0 failed**.
- Reviewed to double-zero (cryptographer, black-hat, bug-catcher, alignment): AAD now spec-exact and byte-identical to WASM; the `open` assert is sound (fail-closed + fail-fast, no DoS/bypass — black-hat 6 probes incl. a 10k-malformed-open check); confused-deputy not exploitable (string is trusted local routing state, never wire); spec-faithful per §9.16.1/§9.5.1.

Refs #1877
Refs #1909