### PR TITLE
feat(ffi): native bridge exports of the §6.2.4 cross-context tool-invocation saga (PR-6b)

### DIFF
--- a/.docs/standards/sdk-capability-matrix.json
+++ b/.docs/standards/sdk-capability-matrix.json
@@ -583,6 +583,20 @@
           "swift": true
         },
         {
+          "name": "invoke_cross_context_saga",
+          "python": false,
+          "typescript": false,
+          "kotlin": false,
+          "swift": false,
+          "notes": "The §6.2.4 atomic cross-context tool-invocation saga (ADR-049 §3a). Exported by all three native bridges — PyO3 tool_invoke_cross_context_saga, UniFFI tool_invoke_cross_context_saga, NAPI toolInvokeCrossContextSaga (js_name); see scripts/bridge-aliases.json (category tools). Each export binds the caller principal to the authenticated FFI identity (enforce_caller_principal_binding) before dispatching to Supervisor::start_cross_context_tool_invocation_saga, pinned by the pyo3/napi/uniffi saga-export assertions in pipeline_wiring.rs. The public per-SDK wrapper methods land in PR-6c (the SDK-parity slice carved from the same #116 bundle).",
+          "exemptions": {
+            "python": "Bridge export exists (PyO3 tool_invoke_cross_context_saga); the named public SDK wrapper on the tools surface lands in PR-6c (SDK-parity slice, §6.2.4 / ADR-049 §3a).",
+            "typescript": "Bridge export exists (NAPI toolInvokeCrossContextSaga); the named public SDK wrapper on the tools surface lands in PR-6c (SDK-parity slice, §6.2.4 / ADR-049 §3a).",
+            "kotlin": "UniFFI bridge exports tool_invoke_cross_context_saga; the named public Kotlin SDK wrapper lands in PR-6c (SDK-parity slice, §6.2.4 / ADR-049 §3a).",
+            "swift": "UniFFI bridge exports tool_invoke_cross_context_saga; the named public Swift SDK wrapper lands in PR-6c (SDK-parity slice, §6.2.4 / ADR-049 §3a)."
+          }
+        },
+        {
           "name": "session_create",
           "python": true,
           "typescript": true,

--- a/.docs/standards/sdk-capability-matrix.json
+++ b/.docs/standards/sdk-capability-matrix.json
@@ -588,12 +588,12 @@
           "typescript": false,
           "kotlin": false,
           "swift": false,
-          "notes": "The §6.2.4 atomic cross-context tool-invocation saga (ADR-049 §3a). Exported by all three native bridges — PyO3 tool_invoke_cross_context_saga, UniFFI tool_invoke_cross_context_saga, NAPI toolInvokeCrossContextSaga (js_name); see scripts/bridge-aliases.json (category tools). Each export binds the caller principal to the authenticated FFI identity (enforce_caller_principal_binding) before dispatching to Supervisor::start_cross_context_tool_invocation_saga, pinned by the pyo3/napi/uniffi saga-export assertions in pipeline_wiring.rs. The public per-SDK wrapper methods land in PR-6c (the SDK-parity slice carved from the same #116 bundle).",
+          "notes": "The §6.2.4 atomic cross-context tool-invocation saga (ADR-049 §3a). Exported by all three native bridges — PyO3 tool_invoke_cross_context_saga, UniFFI tool_invoke_cross_context_saga, NAPI toolInvokeCrossContextSaga (js_name); see scripts/bridge-aliases.json (category tools). Each export binds the caller principal to the authenticated FFI identity (enforce_caller_principal_binding) before dispatching to Supervisor::start_cross_context_tool_invocation_saga, pinned by the pyo3/napi/uniffi saga-export assertions in pipeline_wiring.rs. The public per-SDK wrapper methods are tracked by #1939 (the PR-6c SDK-wrapper slice).",
           "exemptions": {
-            "python": "Bridge export exists (PyO3 tool_invoke_cross_context_saga); the named public SDK wrapper on the tools surface lands in PR-6c (SDK-parity slice, §6.2.4 / ADR-049 §3a).",
-            "typescript": "Bridge export exists (NAPI toolInvokeCrossContextSaga); the named public SDK wrapper on the tools surface lands in PR-6c (SDK-parity slice, §6.2.4 / ADR-049 §3a).",
-            "kotlin": "UniFFI bridge exports tool_invoke_cross_context_saga; the named public Kotlin SDK wrapper lands in PR-6c (SDK-parity slice, §6.2.4 / ADR-049 §3a).",
-            "swift": "UniFFI bridge exports tool_invoke_cross_context_saga; the named public Swift SDK wrapper lands in PR-6c (SDK-parity slice, §6.2.4 / ADR-049 §3a)."
+            "python": "Bridge export exists (PyO3 tool_invoke_cross_context_saga); the named public SDK wrapper on the tools surface is tracked by #1939 (PR-6c SDK-wrapper slice, §6.2.4 / ADR-049 §3a).",
+            "typescript": "Bridge export exists (NAPI toolInvokeCrossContextSaga); the named public SDK wrapper on the tools surface is tracked by #1939 (PR-6c SDK-wrapper slice, §6.2.4 / ADR-049 §3a).",
+            "kotlin": "UniFFI bridge exports tool_invoke_cross_context_saga; the named public Kotlin SDK wrapper is tracked by #1939 (PR-6c SDK-wrapper slice, §6.2.4 / ADR-049 §3a).",
+            "swift": "UniFFI bridge exports tool_invoke_cross_context_saga; the named public Swift SDK wrapper is tracked by #1939 (PR-6c SDK-wrapper slice, §6.2.4 / ADR-049 §3a)."
           }
         },
         {

--- a/bindings/typescript/tests/real-napi.test.ts
+++ b/bindings/typescript/tests/real-napi.test.ts
@@ -2021,9 +2021,8 @@ if (!napiAvailable || createNativeBridge === null || rawAddon === null) {
   // is a separate SDK-wrapper slice). So these tests reach it on the RAW
   // native instance the bridge already wraps, obtained via `__getNativeScp`
   // against the SAME `SCP` that minted the context handles. Using the same
-  // instance is mandatory: the per-instance handle-affinity guard (#1549
-  // Phase 4) rejects a handle minted by any other instance with
-  // SCP-PERM-3030.
+  // instance is mandatory: the per-instance handle-affinity guard rejects a
+  // handle minted by any other instance with SCP-PERM-3030.
   //
   // The signature crossing the addon boundary is:
   //   toolInvokeCrossContextSaga(

--- a/bindings/typescript/tests/real-napi.test.ts
+++ b/bindings/typescript/tests/real-napi.test.ts
@@ -20,7 +20,7 @@ import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 import { generateKeyPairSync } from "node:crypto";
 import { createRequire } from "node:module";
 import type { BridgeMode } from "../src/bridge";
-import { SCP } from "../src/scp";
+import { __getNativeScp, SCP } from "../src/scp";
 import type { Relay } from "../src/server";
 
 /**
@@ -2009,6 +2009,327 @@ if (!napiAvailable || createNativeBridge === null || rawAddon === null) {
         expect(r).toHaveProperty("etag");
         expect(r).toHaveProperty("deployId");
       }
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // 18. Cross-context tool-invocation saga (§6.2.4, ADR-049 §3a)
+  // ---------------------------------------------------------------------------
+  //
+  // The §6.2.4 saga export lives on the native `SCP` class as
+  // `toolInvokeCrossContextSaga` (NOT yet on the SDK `Bridge` wrapper — that
+  // is a separate SDK-wrapper slice). So these tests reach it on the RAW
+  // native instance the bridge already wraps, obtained via `__getNativeScp`
+  // against the SAME `SCP` that minted the context handles. Using the same
+  // instance is mandatory: the per-instance handle-affinity guard (#1549
+  // Phase 4) rejects a handle minted by any other instance with
+  // SCP-PERM-3030.
+  //
+  // The signature crossing the addon boundary is:
+  //   toolInvokeCrossContextSaga(
+  //     sourceHandle, targetHandle, callerDid, toolRegistrationId,
+  //     inputJson, assertedNonceHex, timestampMs: BigInt, chainDepth: u8,
+  //     ucanProofId?: string,
+  //   ) => Promise<{ sagaId, receipt?, output? }>
+  //
+  // What these cases pin is the JS-marshaling boundary the Rust-side napi
+  // test cannot exercise: the `BigInt` timestamp narrowing, the hex-nonce
+  // string, the `#[napi(object)] NapiSagaResult` (`saga_id`/`receipt`/`output`)
+  // round-trip, and — the load-bearing one — that a typed `SagaError` survives
+  // the collapse to a single `napi::Error` message string with its
+  // `SCP-SAGA-{code}` + parseable structured suffix intact, so the TypeScript
+  // error layer can reverse it.
+  describe("Cross-context tool-invocation saga (real NAPI)", () => {
+    // A 16-byte freshness nonce as the one canonical 32-char lowercase-hex
+    // wire form (§6.2.4 envelope nonce).
+    const NONCE_HEX = "0123456789abcdef0123456789abcdef";
+
+    // The deterministic, cross-bridge tool id form (`generate_tool_id(name)`).
+    const TOOL_NAME = "xctx_saga_ts_tool";
+    const TOOL_ID = `tool-${TOOL_NAME}`;
+
+    // A near-now Unix-ms timestamp as a JS `BigInt`. Prepare-B enforces a
+    // §9.14 ±5min skew, so a fixed historical value would abort with a skew
+    // error rather than reaching the terminal under test.
+    function nowMsBigInt(): bigint {
+      return BigInt(Date.now());
+    }
+
+    // Handle types, inferred from the bridge surface so this block needs no
+    // extra import. `napi.contextCreate` returns the raw native context handle
+    // (it carries `.contextId`); `napi.identityCreate` returns the raw native
+    // identity handle (it carries `.did`).
+    type IdentityHandle = Awaited<ReturnType<typeof napi.identityCreate>>;
+    type ContextHandle = Awaited<ReturnType<typeof napi.contextCreate>>;
+
+    // The native `toolInvokeCrossContextSaga` method as it crosses the addon
+    // boundary, read off the raw native SCP that minted every handle below.
+    // Using that exact instance is mandatory — the per-instance handle-affinity
+    // guard rejects a handle minted by any other instance (SCP-PERM-3030).
+    type SagaResult = { sagaId: string; receipt?: Uint8Array; output?: Uint8Array };
+    type SagaFn = (
+      sourceHandle: ContextHandle,
+      targetHandle: ContextHandle,
+      callerDid: string,
+      toolRegistrationId: string,
+      inputJson: string,
+      assertedNonceHex: string,
+      timestampMs: bigint,
+      chainDepth: number,
+      ucanProofId: string | undefined,
+    ) => Promise<SagaResult>;
+    function nativeSaga(): SagaFn {
+      const raw = __getNativeScp(scpInstance) as unknown as {
+        toolInvokeCrossContextSaga: SagaFn;
+      };
+      return raw.toolInvokeCrossContextSaga.bind(raw);
+    }
+
+    // Creates a caller (source) context A owned by `ownerDid`. A's ceiling
+    // carries `governance:propose` (so the admin can propose) and
+    // `tool:interface` (required by execute_establish_tool_interface's ceiling
+    // check). `contextCreate` mints a real 64-hex id so the ADR-056 saga
+    // chokepoint round-trips to A's actor.
+    async function createCallerContext(owner: IdentityHandle): Promise<ContextHandle> {
+      return napi.contextCreate(
+        owner,
+        JSON.stringify({
+          ceiling: [
+            "governance:propose",
+            "tool:interface",
+            "tools:invoke",
+            "messages:read",
+            "messages:write",
+          ],
+          governance: "single_admin",
+          memoryScope: "ephemeral",
+        }),
+      );
+    }
+
+    // Creates a target (executing) context B owned by `ownerDid`. B's ceiling
+    // carries `governance:propose` + `tool:register` so the saga tool can be
+    // registered into B's ACTOR governance state (the saga's Prepare-B reads
+    // the tool from there).
+    async function createTargetContext(owner: IdentityHandle): Promise<ContextHandle> {
+      return napi.contextCreate(
+        owner,
+        JSON.stringify({
+          ceiling: ["governance:propose", "tool:register"],
+          governance: "single_admin",
+          memoryScope: "ephemeral",
+        }),
+      );
+    }
+
+    // Externally-tagged `GovernanceAction::RegisterTool` for the saga tool.
+    // Two input + two output properties clear the §9.2.1 specificity floor of
+    // 2. `implementation_hash` is a 32-element JSON number array (serde expects
+    // a fixed `[u8; 32]`). `operator_did` is a required string (not nullable).
+    // Registering this into B's actor state via governance is what the saga's
+    // Prepare-B requires.
+    function registerToolActionJson(operatorDid: string): string {
+      return JSON.stringify({
+        RegisterTool: {
+          registration: {
+            tool_id: TOOL_ID,
+            name: TOOL_NAME,
+            description: `Tool: ${TOOL_NAME}`,
+            schema: {
+              input_schema: {
+                type: "object",
+                properties: { a: { type: "string" }, b: { type: "string" } },
+              },
+              output_schema: {
+                type: "object",
+                properties: { sum: { type: "number" }, ok: { type: "number" } },
+              },
+            },
+            implementation_hash: new Array(32).fill(0),
+            test_vectors: [],
+            operator_did: operatorDid,
+            cost: null,
+            registered_at: 0,
+            signature: [],
+          },
+        },
+      });
+    }
+
+    // Externally-tagged `GovernanceAction::EstablishToolInterface`, source=A,
+    // target=B, BOTH approvals true. The producer's gate 2 queries this
+    // bidirectionally-approved interface against the CALLER context A's actor
+    // governance state, so it is established IN A.
+    function establishInterfaceActionJson(ctxA: string, ctxB: string): string {
+      return JSON.stringify({
+        EstablishToolInterface: {
+          interface: {
+            source_context: ctxA,
+            target_context: ctxB,
+            tool_id: TOOL_ID,
+            rate_limit: null,
+            inbound_rate_limit: null,
+            per_caller_rate_limit: null,
+            approved_by_source: true,
+            approved_by_target: true,
+            outbound_policy: null,
+            inbound_policy: null,
+          },
+        },
+      });
+    }
+
+    // -----------------------------------------------------------------------
+    // 1. Method exists + argument marshaling.
+    //
+    // Drives the saga from a real authenticated caller (a member of context A)
+    // with a `BigInt` timestamp and a 32-char hex nonce, but WITHOUT an
+    // established interface. The producer's target-axis gate 2 then aborts with
+    // SCP-SAGA-13062 — which is exactly the point: a typed terminal (not a
+    // `TypeError` / native panic) proves the `BigInt`, the hex nonce, the two
+    // raw context handles, and the chain-depth `u8` all marshaled across the
+    // addon and the saga actually ran.
+    // -----------------------------------------------------------------------
+    test("is callable: BigInt timestamp + hex nonce marshal and the saga runs", async () => {
+      const owner = await napi.identityCreate("in_memory");
+      const ctxA = await createCallerContext(owner);
+      const ctxB = await createTargetContext(owner);
+
+      const promise = nativeSaga()(
+        ctxA,
+        ctxB,
+        owner.did,
+        TOOL_ID,
+        JSON.stringify({ a: "x", b: "y" }),
+        NONCE_HEX,
+        nowMsBigInt(),
+        1,
+        undefined,
+      );
+
+      // No established interface ⇒ the producer's gate 2 rejects. The
+      // rejection is a real `Error` carrying the typed saga code (NOT a
+      // synchronous TypeError from a failed BigInt/handle marshal).
+      let caught: unknown;
+      try {
+        await promise;
+        throw new Error("saga unexpectedly resolved without an established interface");
+      } catch (e) {
+        caught = e;
+      }
+      expect(caught).toBeInstanceOf(Error);
+      const message = (caught as Error).message;
+      expect(message).not.toMatch(/TypeError/);
+      // Target-axis gate (no interface) ⇒ SCP-SAGA-13062.
+      expect(message).toContain("SCP-SAGA-13062");
+    });
+
+    // -----------------------------------------------------------------------
+    // 2. Error-code surfacing — the key marshaling check.
+    //
+    // A caller_did that is NOT an identity hosted by this bridge instance
+    // trips the FFI-side §6.2.4 Caller-authentication binding BEFORE the saga
+    // runs, mapping to a typed `SagaAborted` with code SCP-SAGA-13050 and a
+    // `retry_after_ms = None` (rendered as the literal `null`). This proves the
+    // typed-SagaError → napi::Error → JS-Error-message mapping survives the
+    // boundary with both the code AND the parseable structured suffix intact.
+    // -----------------------------------------------------------------------
+    test("surfaces SCP-SAGA-13050 with a parseable structured suffix on a caller mismatch", async () => {
+      const owner = await napi.identityCreate("in_memory");
+      const ctxA = await createCallerContext(owner);
+      const ctxB = await createTargetContext(owner);
+
+      // A well-formed did:dht that this bridge instance does NOT host.
+      const foreignCallerDid = "did:dht:z6MkNeverHostedSagaCallerForMarshalTest";
+
+      let caught: unknown;
+      try {
+        await nativeSaga()(
+          ctxA,
+          ctxB,
+          foreignCallerDid,
+          TOOL_ID,
+          JSON.stringify({ a: "x", b: "y" }),
+          NONCE_HEX,
+          nowMsBigInt(),
+          1,
+          undefined,
+        );
+        throw new Error("saga unexpectedly resolved for a non-hosted caller");
+      } catch (e) {
+        caught = e;
+      }
+      expect(caught).toBeInstanceOf(Error);
+      const message = (caught as Error).message;
+      // The canonical caller-axis saga code.
+      expect(message).toContain("SCP-SAGA-13050");
+      // The structured back-off suffix is present and parseable: a plain
+      // (non-rate-limit) caller rejection carries no precise back-off, so it
+      // renders as the literal `null` — never coerced to `0`.
+      expect(message).toMatch(/\(retry_after_ms=null\)/);
+    });
+
+    // -----------------------------------------------------------------------
+    // 3. Committed terminal through the addon — result-object marshaling.
+    //
+    // Establishes the full saga precondition entirely through the addon's
+    // governance surface (no Rust-internal handler hook is reachable from JS):
+    //
+    //   - RegisterTool into B's ACTOR governance state (Prepare-B reads it).
+    //   - EstablishToolInterface (bidirectionally approved) into A (gate 2).
+    //
+    // No tool handler is registered (the only handler-attach path is
+    // Rust-internal `register_tool_handler`, not a napi export), so the
+    // supervisor-side executor runs the schema-echo fallback the FFI bridge
+    // builds — the producer captures whatever the executor returns as the
+    // signed `output_jcs`. The committed result object therefore marshals to a
+    // non-empty `sagaId`, a `receipt` Buffer, and an `output` Buffer that
+    // decodes to the echoed JSON.
+    // -----------------------------------------------------------------------
+    test("commits via governance-established interface and marshals the result object", async () => {
+      const owner = await napi.identityCreate("in_memory");
+      const ctxA = await createCallerContext(owner);
+      const ctxB = await createTargetContext(owner);
+
+      // Register the saga tool into B's actor governance state (auto-executes
+      // under single_admin). The tool's operator is the owner DID.
+      await napi.contextGovernancePropose(ctxB, registerToolActionJson(owner.did), owner.did);
+
+      // Establish the bidirectionally-approved interface in A (auto-executes
+      // under single_admin). The id-form fields compare on the raw 64-hex
+      // digest the handles carry.
+      await napi.contextGovernancePropose(
+        ctxA,
+        establishInterfaceActionJson(ctxA.contextId, ctxB.contextId),
+        owner.did,
+      );
+
+      const result = await nativeSaga()(
+        ctxA,
+        ctxB,
+        owner.did,
+        TOOL_ID,
+        JSON.stringify({ a: "x", b: "y" }),
+        NONCE_HEX,
+        nowMsBigInt(),
+        1,
+        undefined,
+      );
+
+      // The `#[napi(object)] NapiSagaResult` round-trips: a non-empty
+      // supervisor-minted saga id and the receipt/output buffers.
+      expect(typeof result.sagaId).toBe("string");
+      expect(result.sagaId.length).toBeGreaterThan(0);
+      expect(result.receipt).toBeInstanceOf(Uint8Array);
+      expect((result.receipt as Uint8Array).length).toBeGreaterThan(0);
+      expect(result.output).toBeInstanceOf(Uint8Array);
+
+      // The committed output decodes to the executor's (echo-fallback) JSON.
+      // Assert the parsed structure, not raw bytes, so a JCS-canonical
+      // encoding still passes: the echo carries the validated input back.
+      const decoded = JSON.parse(new TextDecoder().decode(result.output as Uint8Array));
+      expect(decoded).toBeTruthy();
+      expect(decoded.validated_input).toEqual({ a: "x", b: "y" });
     });
   });
 }

--- a/crates/scp-ffi/Cargo.toml
+++ b/crates/scp-ffi/Cargo.toml
@@ -76,10 +76,9 @@ tempfile = "3"
 [[test]]
 name = "e2e_bridge"
 path = "tests/e2e_bridge.rs"
-# `testing` enables the `scp-runtime/testing` saga-gating helpers
-# (`test_reserve_saga_context_set`) the cross-context saga `SagaBusy` test
-# exercises to hold a participant-context-set reservation in flight.
-required-features = ["allow_in_memory_custody", "testing"]
+# Needs `allow_in_memory_custody` for the in-memory custody/storage test
+# harness (`new_in_memory_for_test`, `scp-platform/testing`).
+required-features = ["allow_in_memory_custody"]
 
 [lints]
 workspace = true

--- a/crates/scp-ffi/Cargo.toml
+++ b/crates/scp-ffi/Cargo.toml
@@ -76,7 +76,10 @@ tempfile = "3"
 [[test]]
 name = "e2e_bridge"
 path = "tests/e2e_bridge.rs"
-required-features = ["allow_in_memory_custody"]
+# `testing` enables the `scp-runtime/testing` saga-gating helpers
+# (`test_reserve_saga_context_set`) the cross-context saga `SagaBusy` test
+# exercises to hold a participant-context-set reservation in flight.
+required-features = ["allow_in_memory_custody", "testing"]
 
 [lints]
 workspace = true

--- a/crates/scp-ffi/common/src/error_codes.rs
+++ b/crates/scp-ffi/common/src/error_codes.rs
@@ -969,3 +969,29 @@ pub const ECON_12091: &str = "SCP-ECON-12091";
 pub const ECON_12095: &str = "SCP-ECON-12095";
 /// Economy budget exceeded error.
 pub const ECON_12096: &str = "SCP-ECON-12096";
+
+// -------------------------------------------------------------------------
+// Cross-context tool-invocation saga (SCP-SAGA- 13000--13999)
+// -------------------------------------------------------------------------
+//
+// The §6.2.4 / ADR-049 §3a saga terminal codes the FFI saga surface maps the
+// typed `SagaError` onto. All registered in `.docs/standards/sdk-common.md`;
+// band-validated by `scripts/check-error-codes.sh` (13000--13999). The
+// `Aborted` arm's specific sub-code (e.g. 13050/13062/13067) is formatted
+// inline from the producer's numeric `code` discriminant — these named
+// constants pin the two FIXED terminal codes (`NeedsRepair`, `Busy`) plus the
+// caller-axis authorization code the bridge's channel-auth binding reuses.
+
+/// Saga caller-axis authorize-before-reserve rejection.
+///
+/// The initiator is not authorized to act over the named caller context. The
+/// bridge reuses this for its channel-auth binding (`caller_did` not hosted by
+/// this bridge instance, or not a member of `caller_context_id`) ⇒ a
+/// `Rejected`-flavored `SagaAborted`.
+pub const SAGA_13050: &str = "SCP-SAGA-13050";
+/// Saga `NeedsRepair` terminal — Commit-retry exhausted; the saga diverged and
+/// requires operator repair (carries the durable `saga_id`).
+pub const SAGA_13065: &str = "SCP-SAGA-13065";
+/// Saga `Busy` terminal — the participant context set overlapped an in-flight
+/// saga (per-participant-context-set gating, §5.15.4).
+pub const SAGA_13066: &str = "SCP-SAGA-13066";

--- a/crates/scp-ffi/common/src/lib.rs
+++ b/crates/scp-ffi/common/src/lib.rs
@@ -144,6 +144,15 @@ pub mod event_log;
 #[cfg(feature = "resolvers")]
 pub mod trust_store;
 
+// Canonical §6.2.4 SagaError decomposition shared across PyO3, napi-rs, and
+// UniFFI. Pins the `RateLimited → Option<u64>` read, the `None`-never-`0` rule,
+// and the `SCP-SAGA-{code}` formatting in ONE place so the three bridges'
+// `map_saga_error` cannot drift. Requires scp-core for
+// `scp_core::context::supervisor::SagaError` (behind `resolvers` feature). WASM
+// has no Supervisor and never drives the saga (ADR-034).
+#[cfg(feature = "resolvers")]
+pub mod saga_errors;
+
 // Shared broadcast key-distribution value-shape helpers (§5.14.2). The
 // Grant→sealed-JSON and sealed-JSON→raw-key seams are identical across PyO3,
 // napi-rs, and UniFFI; extracted here so the hand-populated author_did/context_id

--- a/crates/scp-ffi/common/src/saga_errors.rs
+++ b/crates/scp-ffi/common/src/saga_errors.rs
@@ -1,0 +1,238 @@
+//! Canonical `SagaError` decomposition shared by all FFI bridges.
+//!
+//! The §6.2.4 cross-context tool-invocation saga reaches one of three typed
+//! terminals on failure (`Aborted` / `NeedsRepair` / `Busy`). Every bridge
+//! (`PyO3`, napi-rs, `UniFFI`) must turn that terminal into its OWN typed
+//! error variant, reading every structured datum STRUCTURALLY off the
+//! variant — never by re-parsing a message string. Before this module each
+//! bridge inlined an identical decomposition: the same
+//! `SagaAbortReason::RateLimited → Option<u64>` read, the same
+//! `None`-never-coerced-to-`0` rule, the same `SCP-SAGA-{code}` numeric
+//! formatting, the same fixed terminal codes. Three copies of one
+//! classification let the bridges silently drift (mirroring the `UcanError`
+//! drift that motivated [`crate::ucan_errors`]).
+//!
+//! This module exposes one function — [`decompose_saga_error`] — that every
+//! bridge routes through. It returns a neutral [`SagaErrorParts`] carrying the
+//! already-formatted `SCP-SAGA-…` code, the message, and a [`SagaErrorKind`]
+//! holding only the per-terminal structured payload. Each bridge's
+//! `map_saga_error` becomes a thin 3-arm match from [`SagaErrorParts`] onto
+//! its own enum, carrying only the per-bridge field-label difference
+//! (`message:` vs `msg:`) and the napi-rs message-suffix encoding. Any change
+//! to the saga-error classification (the `RateLimited → Option`,
+//! `None`-never-`0`, or `SCP-SAGA-{code}` rules) happens here exactly once and
+//! propagates to every bridge.
+//!
+//! `SagaError` lives in `scp-core` (re-exported from `scp-runtime`), so this
+//! module is behind the `resolvers` feature — the same gate as the other
+//! scp-core-dependent shared adapters. WASM has no `Supervisor` and never
+//! drives the saga (ADR-034), so it does not compile this module.
+//!
+//! Provenance: §6.2.4 (cross-context tool-invocation saga) + ADR-049 §3a
+//! (atomic cross-context invocation, `RateLimited { retry_after_ms }` /
+//! `Rejected` abort reasons, `NeedsRepair` operator-repair handle).
+
+use crate::error_codes as codes;
+use scp_core::context::supervisor::{SagaAbortReason, SagaError};
+
+/// The per-terminal structured payload of a decomposed [`SagaError`], with the
+/// `SCP-SAGA-{code}` formatting and the `RateLimited → Option<u64>` /
+/// `None`-never-`0` classification already applied.
+///
+/// Holds ONLY the datum that differs per terminal; the shared `code` and
+/// `message` live on [`SagaErrorParts`]. Each bridge matches this kind onto its
+/// own error enum.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum SagaErrorKind {
+    /// A Prepare-phase abort (spec §6.2.4) — neither side committed.
+    ///
+    /// `retry_after_ms` is read directly off `SagaAbortReason::RateLimited`
+    /// (an `Option<u64>`); a plain `Rejected` carries `None`. `None` is
+    /// propagated, NEVER coerced to `Some(0)` — a `0` would read as "retry
+    /// immediately" and re-trip the same hard limit.
+    Aborted {
+        /// Rate-limit back-off hint in milliseconds, or `None` (never `0`).
+        retry_after_ms: Option<u64>,
+    },
+    /// Commit-retry exhausted — the saga diverged and requires operator repair
+    /// (ADR-049 §3a). Carries the durable saga identifier (the repair handle).
+    NeedsRepair {
+        /// The durable saga identifier — the operator-repair handle.
+        saga_id: String,
+    },
+    /// The participant context set overlapped an in-flight saga's set
+    /// (spec §5.15.4). Carries the contended context id.
+    Busy {
+        /// The shared context id that forced serialization.
+        contended_context: String,
+    },
+}
+
+/// The neutral, bridge-agnostic decomposition of a [`SagaError`] terminal.
+///
+/// Carries the canonical `SCP-SAGA-…` `code` (already formatted — for
+/// `Aborted` it is `SCP-SAGA-{numeric}`, for `NeedsRepair`/`Busy` it is the
+/// fixed terminal code), the human-readable `message`, and the per-terminal
+/// structured payload in `kind`. Each bridge's thin `map_saga_error` maps this
+/// onto its own typed error enum.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SagaErrorParts {
+    /// The per-terminal structured payload (`retry_after_ms` / `saga_id` /
+    /// `contended_context`).
+    pub kind: SagaErrorKind,
+    /// The canonical `SCP-SAGA-…` code string (already formatted).
+    pub code: String,
+    /// Human-readable detail (the underlying terminal's message).
+    pub message: String,
+}
+
+/// Decomposes a [`SagaError`] terminal into the neutral [`SagaErrorParts`]
+/// every FFI bridge maps onto its own typed error enum.
+///
+/// This is the SINGLE home of the saga-error classification:
+///
+/// - `Aborted { reason, code, message }` → `kind = Aborted { retry_after_ms }`
+///   where `retry_after_ms` is read directly off
+///   `SagaAbortReason::RateLimited` (an `Option<u64>`) and a plain `Rejected`
+///   carries `None`. `None` is propagated, NEVER coerced to `Some(0)`. `code`
+///   is formatted as the canonical `SCP-SAGA-{code}` string from the numeric
+///   discriminant.
+/// - `NeedsRepair { saga_id, message }` → `kind = NeedsRepair { saga_id }`,
+///   `code = SCP-SAGA-13065` (the durable operator-repair terminal).
+/// - `Busy { contended_context, message }` → `kind = Busy { contended_context }`,
+///   `code = SCP-SAGA-13066`.
+#[must_use]
+pub fn decompose_saga_error(err: SagaError) -> SagaErrorParts {
+    match err {
+        SagaError::Aborted {
+            reason,
+            code,
+            message,
+        } => {
+            let retry_after_ms = match reason {
+                SagaAbortReason::RateLimited { retry_after_ms } => retry_after_ms,
+                SagaAbortReason::Rejected => None,
+            };
+            SagaErrorParts {
+                kind: SagaErrorKind::Aborted { retry_after_ms },
+                code: format!("SCP-SAGA-{code}"),
+                message,
+            }
+        }
+        SagaError::NeedsRepair { saga_id, message } => SagaErrorParts {
+            kind: SagaErrorKind::NeedsRepair { saga_id: saga_id.0 },
+            code: codes::SAGA_13065.to_owned(),
+            message,
+        },
+        SagaError::Busy {
+            contended_context,
+            message,
+        } => SagaErrorParts {
+            kind: SagaErrorKind::Busy { contended_context },
+            code: codes::SAGA_13066.to_owned(),
+            message,
+        },
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use scp_core::context::supervisor::SagaId;
+
+    /// A rate-limited abort preserves `retry_after_ms = Some(ms)` STRUCTURALLY
+    /// and formats the producer's numeric `code` as the canonical
+    /// `SCP-SAGA-{code}` string.
+    #[test]
+    fn rate_limited_preserves_retry_after_ms_and_formats_code() {
+        let parts = decompose_saga_error(SagaError::Aborted {
+            reason: SagaAbortReason::RateLimited {
+                retry_after_ms: Some(2500),
+            },
+            code: 13026,
+            message: "inbound rate limit exceeded".to_owned(),
+        });
+        assert_eq!(parts.code, "SCP-SAGA-13026");
+        assert_eq!(parts.message, "inbound rate limit exceeded");
+        assert_eq!(
+            parts.kind,
+            SagaErrorKind::Aborted {
+                retry_after_ms: Some(2500),
+            }
+        );
+    }
+
+    /// A rate-limited abort with NO precise back-off instant preserves
+    /// `retry_after_ms = None` — NEVER coerced to `Some(0)` (a `0` would read
+    /// as "retry immediately" and re-trip the same hard limit). This is the
+    /// load-bearing classification rule, now tested ONCE here for all bridges.
+    #[test]
+    fn rate_limited_none_is_never_coerced_to_zero() {
+        let parts = decompose_saga_error(SagaError::Aborted {
+            reason: SagaAbortReason::RateLimited {
+                retry_after_ms: None,
+            },
+            code: 13026,
+            message: "hard limit, no precise back-off".to_owned(),
+        });
+        assert_eq!(
+            parts.kind,
+            SagaErrorKind::Aborted {
+                retry_after_ms: None,
+            },
+            "None must NOT be coerced to Some(0)"
+        );
+    }
+
+    /// A plain (non-rate-limit) `Rejected` abort carries `retry_after_ms = None`
+    /// and still formats the numeric `code`.
+    #[test]
+    fn rejected_has_no_retry_hint() {
+        let parts = decompose_saga_error(SagaError::Aborted {
+            reason: SagaAbortReason::Rejected,
+            code: 13050,
+            message: "caller not a member".to_owned(),
+        });
+        assert_eq!(parts.code, "SCP-SAGA-13050");
+        assert_eq!(
+            parts.kind,
+            SagaErrorKind::Aborted {
+                retry_after_ms: None,
+            }
+        );
+    }
+
+    /// `NeedsRepair` preserves the durable `saga_id` operator-repair handle and
+    /// the fixed terminal code `SCP-SAGA-13065`.
+    #[test]
+    fn needs_repair_preserves_saga_id_and_fixed_code() {
+        let parts = decompose_saga_error(SagaError::NeedsRepair {
+            saga_id: SagaId("saga-abc-123".to_owned()),
+            message: "commit retries exhausted".to_owned(),
+        });
+        assert_eq!(parts.code, codes::SAGA_13065);
+        assert_eq!(
+            parts.kind,
+            SagaErrorKind::NeedsRepair {
+                saga_id: "saga-abc-123".to_owned(),
+            }
+        );
+    }
+
+    /// `Busy` preserves the contended context id and the fixed terminal code
+    /// `SCP-SAGA-13066`.
+    #[test]
+    fn busy_preserves_contended_context_and_fixed_code() {
+        let parts = decompose_saga_error(SagaError::Busy {
+            contended_context: "ctx-shared-99".to_owned(),
+            message: "participant set overlaps an in-flight saga".to_owned(),
+        });
+        assert_eq!(parts.code, codes::SAGA_13066);
+        assert_eq!(
+            parts.kind,
+            SagaErrorKind::Busy {
+                contended_context: "ctx-shared-99".to_owned(),
+            }
+        );
+    }
+}

--- a/crates/scp-ffi/napi/src/error.rs
+++ b/crates/scp-ffi/napi/src/error.rs
@@ -111,6 +111,63 @@ pub enum ScpNapiError {
         /// Stable error code (e.g. `SCP-VALID-7001`).
         code: String,
     },
+
+    /// A §6.2.4 cross-context tool-invocation saga aborted at a Prepare phase
+    /// (ADR-049 §3a).
+    ///
+    /// napi-rs collapses every `ScpNapiError` to a single `napi::Error` whose
+    /// only payload is a message string (the TypeScript SDK reverses the
+    /// `[{code}]` prefix into a typed `ScpError`). So the load-bearing
+    /// structured datum — the rate-limit back-off hint — is appended to the
+    /// message in a machine-parseable `(retry_after_ms=…)` suffix that the TS
+    /// wrapper reads. `retry_after_ms` is rendered as a literal `null` when
+    /// `None` (NEVER `0`): a `0` would read as "retry immediately" and re-trip
+    /// the same hard limit. The field stays `Option<u64>` here so the value is
+    /// read STRUCTURALLY off `SagaAbortReason::RateLimited`, never re-parsed.
+    #[error(
+        "[{code}] saga aborted: {message} (retry_after_ms={})",
+        retry_after_ms.map_or_else(|| "null".to_owned(), |v| v.to_string())
+    )]
+    SagaAborted {
+        /// Human-readable detail.
+        message: String,
+        /// The canonical `SCP-SAGA-13xxx` code.
+        code: String,
+        /// Rate-limit back-off hint in milliseconds, or `None` (never `0`).
+        retry_after_ms: Option<u64>,
+    },
+
+    /// A §6.2.4 saga exhausted its Commit retries and may have diverged
+    /// (ADR-049 §3a).
+    ///
+    /// The durable `saga_id` operator-repair handle is appended to the message
+    /// in a machine-parseable `(saga_id=…)` suffix for the TS wrapper, and held
+    /// STRUCTURALLY in the variant.
+    #[error("[{code}] saga needs repair: {message} (saga_id={saga_id})")]
+    SagaNeedsRepair {
+        /// Human-readable detail.
+        message: String,
+        /// The canonical `SCP-SAGA-13065` code.
+        code: String,
+        /// The durable saga identifier — the operator-repair handle.
+        saga_id: String,
+    },
+
+    /// A §6.2.4 saga's participant context set overlapped an in-flight saga
+    /// (§5.15.4).
+    ///
+    /// The contended context id is appended to the message in a
+    /// machine-parseable `(contended_context=…)` suffix for the TS wrapper, and
+    /// held STRUCTURALLY in the variant.
+    #[error("[{code}] saga busy: {message} (contended_context={contended_context})")]
+    SagaBusy {
+        /// Human-readable detail.
+        message: String,
+        /// The canonical `SCP-SAGA-13066` code.
+        code: String,
+        /// The shared context id that forced serialization.
+        contended_context: String,
+    },
 }
 
 impl From<ScpNapiError> for napi::Error {

--- a/crates/scp-ffi/napi/src/runtime.rs
+++ b/crates/scp-ffi/napi/src/runtime.rs
@@ -1378,6 +1378,18 @@ pub(crate) fn identity_registry(bi: &NapiBridgeInstance) -> &DashMap<String, Nap
     bi.identity_registry.as_ref()
 }
 
+/// Returns `true` iff `did` is an identity hosted by this bridge instance.
+///
+/// The per-instance identity registry is populated only by the identity
+/// creation paths on THIS instance, so membership here is the co-resident
+/// bridge's notion of a "channel-authenticated principal". Used by the §6.2.4
+/// cross-context saga export's caller-principal binding (ADR-049 §3a) to reject
+/// an envelope-asserted caller that this instance does not host. Mirrors the
+/// `PyO3` reference `identity_registry_contains`.
+pub(crate) fn identity_registry_contains(bi: &NapiBridgeInstance, did: &str) -> bool {
+    identity_registry(bi).contains_key(did)
+}
+
 /// Registers an identity in the bridge instance's identity registry.
 ///
 /// Called by `identity_create`, `identity_create_with_agent_key`, and

--- a/crates/scp-ffi/napi/src/scp.rs
+++ b/crates/scp-ffi/napi/src/scp.rs
@@ -2852,6 +2852,107 @@ impl Scp {
         .await
     }
 
+    /// Invokes a tool across context boundaries as an atomic two-phase saga
+    /// (spec §6.2.4, ADR-049 §3a).
+    ///
+    /// Unlike [`Self::tool_invoke_cross_context`] (the synchronous,
+    /// single-context-side path), this drives the full §6.2.4 cross-context
+    /// tool-invocation saga over the two CO-RESIDENT participant contexts
+    /// (caller = `source_handle`, target = `target_handle`): Prepare-A /
+    /// Prepare-B authorize and stage both sides, the tool executes EXACTLY ONCE
+    /// supervisor-side at Commit-B, and each side records its own event-log
+    /// entry. Both contexts MUST be co-resident in this bridge instance.
+    ///
+    /// # Caller authentication (normative — §6.2.4, ADR-049 §3a)
+    ///
+    /// `caller_did` is bound to the bridge-authenticated principal: it MUST be
+    /// an identity THIS bridge instance hosts (created here via identity
+    /// creation) AND a member of the caller (`source_handle`) context. A
+    /// mismatch rejects the Promise with a `SagaAborted` error BEFORE the saga
+    /// runs — the saga never observes an unauthenticated caller. The
+    /// `asserted_nonce_hex` / `timestamp_ms` / `chain_depth` REMAIN
+    /// caller-supplied freshness fields (the target validates them).
+    ///
+    /// # Arguments
+    ///
+    /// * `source_handle` — The initiating (caller) context handle.
+    /// * `target_handle` — The executing (target) context handle.
+    /// * `caller_did` — The initiator DID (bound to the bridge principal).
+    /// * `tool_registration_id` — The tool to invoke across the interface.
+    /// * `input_json` — Tool input as a JSON string (schema-checked target-side).
+    /// * `asserted_nonce_hex` — The 16-byte §6.2.4 envelope nonce as a 32-char
+    ///   hex string (the freshness/dedup token).
+    /// * `timestamp_ms` — Caller-asserted send time (Unix ms; freshness check),
+    ///   passed as a JS `BigInt`.
+    /// * `chain_depth` — Caller-asserted inbound provenance depth (advisory).
+    /// * `ucan_proof_id` — Optional id of the spending UCAN proof, resolved
+    ///   target-side at Prepare-B. `null` for an ungated tool.
+    ///
+    /// # Returns
+    ///
+    /// A [`NapiSagaResult`](crate::tools::NapiSagaResult) on the committed
+    /// terminal, carrying the supervisor-minted `saga_id`, the target's signed
+    /// receipt bytes, and the captured tool-output bytes. The `saga_id` is
+    /// supervisor-minted — it is never an input.
+    ///
+    /// # Errors
+    ///
+    /// Rejects with a typed saga error — `SagaAborted` (a Prepare-phase
+    /// rejection — authorization, freshness, rate limit, or co-residency;
+    /// carries `retry_after_ms`), `SagaNeedsRepair` (Commit-retry exhausted —
+    /// carries the durable `saga_id`), or `SagaBusy` (the participant context
+    /// set overlapped an in-flight saga — §5.15.4). Rejects with a validation
+    /// error if an id/DID/tool-id is malformed or `asserted_nonce_hex` does not
+    /// decode to 16 bytes.
+    ///
+    /// See spec §6.2.4 and ADR-049 §3a.
+    #[napi(js_name = "toolInvokeCrossContextSaga")]
+    #[allow(clippy::too_many_arguments)]
+    pub async fn tool_invoke_cross_context_saga(
+        &self,
+        source_handle: &NapiContextHandle,
+        target_handle: &NapiContextHandle,
+        caller_did: String,
+        tool_registration_id: String,
+        input_json: String,
+        asserted_nonce_hex: String,
+        timestamp_ms: napi::bindgen_prelude::BigInt,
+        chain_depth: u8,
+        ucan_proof_id: Option<String>,
+    ) -> napi::Result<crate::tools::NapiSagaResult> {
+        crate::napi_check_handle!(&self.inner.core, source_handle, target_handle);
+
+        // `timestamp_ms` crosses as a JS `BigInt`. `BigInt::get_u64` returns
+        // `(signed, value, lossless)` — reject a negative or non-lossless
+        // input so a malformed freshness field fails closed at the boundary
+        // rather than wrapping into a bogus skew.
+        let (signed, timestamp_ms_u64, lossless) = timestamp_ms.get_u64();
+        if signed || !lossless {
+            return Err(napi::Error::from(ScpNapiError::Validation {
+                message:
+                    "timestamp_ms must fit in an unsigned 64-bit integer (non-negative, no loss)"
+                        .to_owned(),
+                code: codes::VALID_7001.to_owned(),
+            }));
+        }
+
+        // Box the impl future: the multi-phase saga it drives is large enough
+        // to trip `clippy::large_futures` when inlined into this method.
+        Box::pin(crate::tools::tool_invoke_cross_context_saga_on(
+            &self.inner,
+            source_handle,
+            target_handle,
+            caller_did,
+            tool_registration_id,
+            input_json,
+            asserted_nonce_hex,
+            timestamp_ms_u64,
+            chain_depth,
+            ucan_proof_id,
+        ))
+        .await
+    }
+
     /// Per-instance equivalent of the free-function `tool_session_create`.
     #[napi(js_name = "toolSessionCreate")]
     pub async fn tool_session_create(

--- a/crates/scp-ffi/napi/src/scp.rs
+++ b/crates/scp-ffi/napi/src/scp.rs
@@ -2873,6 +2873,30 @@ impl Scp {
     /// `asserted_nonce_hex` / `timestamp_ms` / `chain_depth` REMAIN
     /// caller-supplied freshness fields (the target validates them).
     ///
+    /// # Trust boundary (co-resident single-tenant only)
+    ///
+    /// The caller-principal binding (`enforce_caller_principal_binding`) treats
+    /// "hosted in this bridge instance's identity registry" as the
+    /// channel-authenticated principal. That equivalence holds ONLY for a
+    /// single-tenant, co-resident SDK process. This surface MUST NOT be exposed
+    /// across a trust boundary within one process: a multi-tenant host loading
+    /// multiple users' identities into one bridge instance could assert any
+    /// hosted `caller_did`, since the registry cannot distinguish which tenant
+    /// is making the call. The future cross-node leg needs real channel auth
+    /// (ADR-049 §3a forward obligation) — it cannot reuse "is hosted here" as
+    /// the authenticated-principal proof.
+    ///
+    /// The caller/target context-id axes are bound by the instance-affine
+    /// handle pre-check: `source_handle` / `target_handle` must have been minted
+    /// by THIS bridge instance (a foreign handle is rejected with
+    /// `SCP-PERM-3030`) before the supervisor membership / tool-interface gates
+    /// run.
+    ///
+    /// The receipt's signer-authorization — that the target key is
+    /// governance-authorized to act for the target context (§6.2.4 "Signer
+    /// authorization") — is a DOWNSTREAM receipt-consumer obligation verified
+    /// when the receipt is consumed, NOT enforced at this export.
+    ///
     /// # Arguments
     ///
     /// * `source_handle` — The initiating (caller) context handle.

--- a/crates/scp-ffi/napi/src/tools.rs
+++ b/crates/scp-ffi/napi/src/tools.rs
@@ -1840,7 +1840,7 @@ mod tests {
     ///
     /// Why this is necessary (test hermeticity): the production
     /// `ensure_did_resolver_initialized_on` path stores its `InMemoryDhtClient`
-    /// in the process-wide `SHARED_DHT_CLIENT` `OnceLock` (#1144, so
+    /// in the process-wide `SHARED_DHT_CLIENT` `OnceLock` (so
     /// cross-identity flows in one process share a DHT). The three co-located
     /// `xctx_saga` tests run concurrently under the default test harness; a
     /// sibling can win the `SHARED_DHT_CLIENT.set` (or mutate the shared DHT)

--- a/crates/scp-ffi/napi/src/tools.rs
+++ b/crates/scp-ffi/napi/src/tools.rs
@@ -1716,6 +1716,68 @@ mod tests {
         }
     }
 
+    // ------------------------------------------------------------------
+    // decode_asserted_nonce — the §6.2.4 envelope-nonce hex decoder is
+    // fail-closed on BOTH malformed-input arms. It is a pure hex-decode +
+    // length-check (no supervisor, no custody), so these live in the
+    // non-gated `mod tests` and run even in the no-feature lib build.
+    // VALID_7001 is shared across both arms, so each test also pins its
+    // arm-specific message substring (mirrors the UniFFI bridge's tests).
+    // ------------------------------------------------------------------
+
+    /// `decode_asserted_nonce` is fail-closed on non-hex input: it surfaces a
+    /// validation error (`SCP-VALID-7001`) with the non-hex arm's message —
+    /// the bridge never pads, truncates, or coerces a malformed envelope nonce.
+    #[test]
+    fn decode_asserted_nonce_non_hex_fails_closed() {
+        let err = decode_asserted_nonce("not-hex-at-all-zz")
+            .expect_err("non-hex must be rejected fail-closed");
+        let msg = format!("{err}");
+        assert!(
+            msg.contains(codes::VALID_7001),
+            "error should carry SCP-VALID-7001, got: {msg}"
+        );
+        // VALID_7001 is shared with the wrong-length arm; pin the non-hex arm
+        // specifically (mirrors how the wrong-length test asserts "16 bytes").
+        assert!(
+            msg.contains("is not valid hex"),
+            "must reject for the non-hex arm specifically; got: {msg}"
+        );
+    }
+
+    /// `decode_asserted_nonce` is fail-closed on a wrong-length input (valid hex
+    /// but 8 bytes, not 16): a wrong length is a malformed §6.2.4 envelope,
+    /// surfaced as a validation error (`SCP-VALID-7001`) — never padded or
+    /// truncated to fit.
+    #[test]
+    fn decode_asserted_nonce_wrong_length_fails_closed() {
+        // 8 bytes (16 hex chars), not 16.
+        let err = decode_asserted_nonce("0011223344556677")
+            .expect_err("a wrong-length nonce must be rejected fail-closed");
+        let msg = format!("{err}");
+        assert!(
+            msg.contains(codes::VALID_7001),
+            "error should carry SCP-VALID-7001, got: {msg}"
+        );
+        assert!(
+            msg.contains("exactly 16 bytes"),
+            "message must explain the 16-byte requirement, got: {msg}"
+        );
+    }
+
+    /// The happy path: a canonical 32-char hex nonce decodes to its 16 bytes
+    /// verbatim — pins the success contract locally alongside the fail-closed
+    /// arms.
+    #[test]
+    fn decode_asserted_nonce_accepts_canonical_32_hex_chars() {
+        let nonce = decode_asserted_nonce("000102030405060708090a0b0c0d0e0f")
+            .expect("a canonical 32-char hex nonce must decode");
+        assert_eq!(
+            nonce,
+            [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15]
+        );
+    }
+
     /// All §6.2.4 cross-context-tool saga binding tests and their pure-string /
     /// DHT / governance helpers live in this single submodule gated on
     /// `allow_in_memory_custody`. Gating the module (rather than each item)

--- a/crates/scp-ffi/napi/src/tools.rs
+++ b/crates/scp-ffi/napi/src/tools.rs
@@ -1716,107 +1716,118 @@ mod tests {
         }
     }
 
-    // ------------------------------------------------------------------
-    // End-to-end Committed terminal through the NAPI bridge.
-    //
-    // Mirrors the PyO3 e2e: an authenticated caller drives the §6.2.4
-    // cross-context tool-invocation saga to a real Committed terminal and the
-    // bridge returns the committed receipt + output bytes. The setup wires the
-    // two producer authorization axes:
-    //
-    //   1. Caller axis (gate 1): caller_did is hosted by this instance AND a
-    //      member of the CALLER (source) context A — satisfied by creating A
-    //      via the real context-create path with `owner` as single-admin.
-    //   2. Target axis (gate 2): a bidirectionally-approved ToolInterface
-    //      (approved_by_source && approved_by_target, source=A, target=B), which
-    //      the producer queries against A's actor governance state, established
-    //      IN A via a governance EstablishToolInterface action (auto-executed
-    //      under single_admin).
-    //
-    // Context B holds the tool registered into its ACTOR governance state (via a
-    // RegisterTool governance action — the saga's Prepare-B reads it from there)
-    // PLUS the FFI-side handler the executor snapshots and runs once at Commit-B.
-    // The handler returns `{"sum":42,"ok":1}`, which Commit-B validates against
-    // the registered numeric `{sum, ok}` output schema before committing.
-    //
-    // For hermeticity against the process-global `SHARED_DHT_CLIENT` `OnceLock`,
-    // the test installs its OWN per-instance resolver (over a caller-retained
-    // in-memory DHT) BEFORE the first `identity_create`, then explicitly seeds
-    // the owner's DID document into that resolver-visible store. The supervisor
-    // (built lazily on first `context_create_on`) snapshots that resolver, so
-    // governance vote verification resolves the proposer key through it without
-    // racing a concurrent sibling on the global. Prepare-B enforces a §9.14
-    // ±5min timestamp skew, so the invocation uses `SystemTime::now()`.
-    // ------------------------------------------------------------------
+    /// All §6.2.4 cross-context-tool saga binding tests and their pure-string /
+    /// DHT / governance helpers live in this single submodule gated on
+    /// `allow_in_memory_custody`. Gating the module (rather than each item)
+    /// covers every helper AND every future saga test added here by
+    /// construction, closing the no-feature `function is never used` regression
+    /// class: a saga test added without an explicit per-item `#[cfg(...)]` can
+    /// no longer silently reintroduce the no-feature compile warning.
+    #[cfg(feature = "allow_in_memory_custody")]
+    mod xctx_saga_tests {
+        use super::*;
 
-    /// Serializes a `RegisterTool` governance action for the saga tool. Mirrors
-    /// the registered schema: 2 input + 2 output properties (clears the §9.2.1
-    /// specificity floor of 2), numeric `{sum, ok}` output so Commit-B's
-    /// output-schema validation accepts the handler's response.
-    fn register_tool_action_json(tool_id: &str, tool_name: &str, owner: &str) -> String {
-        let impl_hash = serde_json::Value::from(vec![0u8; 32]);
-        let register_action = serde_json::json!({
-            "RegisterTool": {
-                "registration": {
-                    "tool_id": tool_id,
-                    "name": tool_name,
-                    "description": format!("Tool: {tool_name}"),
-                    "schema": {
-                        "input_schema": {
-                            "type": "object",
-                            "properties": {
-                                "a": {"type": "string"},
-                                "b": {"type": "string"}
+        // ------------------------------------------------------------------
+        // End-to-end Committed terminal through the NAPI bridge.
+        //
+        // Mirrors the PyO3 e2e: an authenticated caller drives the §6.2.4
+        // cross-context tool-invocation saga to a real Committed terminal and the
+        // bridge returns the committed receipt + output bytes. The setup wires the
+        // two producer authorization axes:
+        //
+        //   1. Caller axis (gate 1): caller_did is hosted by this instance AND a
+        //      member of the CALLER (source) context A — satisfied by creating A
+        //      via the real context-create path with `owner` as single-admin.
+        //   2. Target axis (gate 2): a bidirectionally-approved ToolInterface
+        //      (approved_by_source && approved_by_target, source=A, target=B), which
+        //      the producer queries against A's actor governance state, established
+        //      IN A via a governance EstablishToolInterface action (auto-executed
+        //      under single_admin).
+        //
+        // Context B holds the tool registered into its ACTOR governance state (via a
+        // RegisterTool governance action — the saga's Prepare-B reads it from there)
+        // PLUS the FFI-side handler the executor snapshots and runs once at Commit-B.
+        // The handler returns `{"sum":42,"ok":1}`, which Commit-B validates against
+        // the registered numeric `{sum, ok}` output schema before committing.
+        //
+        // For hermeticity against the process-global `SHARED_DHT_CLIENT` `OnceLock`,
+        // the test installs its OWN per-instance resolver (over a caller-retained
+        // in-memory DHT) BEFORE the first `identity_create`, then explicitly seeds
+        // the owner's DID document into that resolver-visible store. The supervisor
+        // (built lazily on first `context_create_on`) snapshots that resolver, so
+        // governance vote verification resolves the proposer key through it without
+        // racing a concurrent sibling on the global. Prepare-B enforces a §9.14
+        // ±5min timestamp skew, so the invocation uses `SystemTime::now()`.
+        // ------------------------------------------------------------------
+
+        /// Serializes a `RegisterTool` governance action for the saga tool. Mirrors
+        /// the registered schema: 2 input + 2 output properties (clears the §9.2.1
+        /// specificity floor of 2), numeric `{sum, ok}` output so Commit-B's
+        /// output-schema validation accepts the handler's response.
+        fn register_tool_action_json(tool_id: &str, tool_name: &str, owner: &str) -> String {
+            let impl_hash = serde_json::Value::from(vec![0u8; 32]);
+            let register_action = serde_json::json!({
+                "RegisterTool": {
+                    "registration": {
+                        "tool_id": tool_id,
+                        "name": tool_name,
+                        "description": format!("Tool: {tool_name}"),
+                        "schema": {
+                            "input_schema": {
+                                "type": "object",
+                                "properties": {
+                                    "a": {"type": "string"},
+                                    "b": {"type": "string"}
+                                }
+                            },
+                            "output_schema": {
+                                "type": "object",
+                                "properties": {
+                                    "sum": {"type": "number"},
+                                    "ok": {"type": "number"}
+                                }
                             }
                         },
-                        "output_schema": {
-                            "type": "object",
-                            "properties": {
-                                "sum": {"type": "number"},
-                                "ok": {"type": "number"}
-                            }
-                        }
-                    },
-                    "implementation_hash": impl_hash,
-                    "test_vectors": [],
-                    "operator_did": owner,
-                    "cost": null,
-                    "registered_at": 0,
-                    "signature": []
+                        "implementation_hash": impl_hash,
+                        "test_vectors": [],
+                        "operator_did": owner,
+                        "cost": null,
+                        "registered_at": 0,
+                        "signature": []
+                    }
                 }
-            }
-        });
-        serde_json::to_string(&register_action).unwrap()
-    }
+            });
+            serde_json::to_string(&register_action).unwrap()
+        }
 
-    /// Serializes the bidirectionally-approved `EstablishToolInterface`
-    /// governance action (source=A, target=B, BOTH approvals true).
-    fn establish_interface_action_json(ctx_a: &str, ctx_b: &str, tool_id: &str) -> String {
-        let action = serde_json::json!({
-            "EstablishToolInterface": {
-                "interface": {
-                    "source_context": ctx_a,
-                    "target_context": ctx_b,
-                    "tool_id": tool_id,
-                    "rate_limit": null,
-                    "inbound_rate_limit": null,
-                    "per_caller_rate_limit": null,
-                    "approved_by_source": true,
-                    "approved_by_target": true,
-                    "outbound_policy": null,
-                    "inbound_policy": null
+        /// Serializes the bidirectionally-approved `EstablishToolInterface`
+        /// governance action (source=A, target=B, BOTH approvals true).
+        fn establish_interface_action_json(ctx_a: &str, ctx_b: &str, tool_id: &str) -> String {
+            let action = serde_json::json!({
+                "EstablishToolInterface": {
+                    "interface": {
+                        "source_context": ctx_a,
+                        "target_context": ctx_b,
+                        "tool_id": tool_id,
+                        "rate_limit": null,
+                        "inbound_rate_limit": null,
+                        "per_caller_rate_limit": null,
+                        "approved_by_source": true,
+                        "approved_by_target": true,
+                        "outbound_policy": null,
+                        "inbound_policy": null
+                    }
                 }
-            }
-        });
-        serde_json::to_string(&action).unwrap()
-    }
+            });
+            serde_json::to_string(&action).unwrap()
+        }
 
-    /// The registered tool registration definition for context B's FFI-side
-    /// registry, matching the governance `RegisterTool` schema (2-in/2-out,
-    /// numeric `{sum, ok}` output) so the deterministic id agrees and the
-    /// handler's response validates at Commit-B.
-    fn build_napi_tool_def(tool_name: &str, owner: &str) -> NapiToolDefinition {
-        NapiToolDefinition {
+        /// The registered tool registration definition for context B's FFI-side
+        /// registry, matching the governance `RegisterTool` schema (2-in/2-out,
+        /// numeric `{sum, ok}` output) so the deterministic id agrees and the
+        /// handler's response validates at Commit-B.
+        fn build_napi_tool_def(tool_name: &str, owner: &str) -> NapiToolDefinition {
+            NapiToolDefinition {
             name: tool_name.to_owned(),
             description: format!("Tool: {tool_name}"),
             input_schema_json:
@@ -1830,531 +1841,535 @@ mod tests {
             operator_did: owner.to_owned(),
             cost: None,
         }
-    }
+        }
 
-    /// Installs a per-instance DID resolver backed by a caller-retained
-    /// in-memory DHT client on `bi` and returns that client, so the committed
-    /// e2e test can seed the owner's DID document into the SAME store the
-    /// supervisor's governance key resolver reads from — WITHOUT depending on
-    /// the process-global `SHARED_DHT_CLIENT` `OnceLock`.
-    ///
-    /// Why this is necessary (test hermeticity): the production
-    /// `ensure_did_resolver_initialized_on` path stores its `InMemoryDhtClient`
-    /// in the process-wide `SHARED_DHT_CLIENT` `OnceLock` (so
-    /// cross-identity flows in one process share a DHT). The three co-located
-    /// `xctx_saga` tests run concurrently under the default test harness; a
-    /// sibling can win the `SHARED_DHT_CLIENT.set` (or mutate the shared DHT)
-    /// first, so this test's owner DID document lands in / is read from a
-    /// resolver the committed test does not control, and governance vote
-    /// verification fails with `[SCP-CTX-2041] unknown voter: cannot resolve
-    /// public key for DID …`. Installing a FRESH per-instance resolver here,
-    /// BEFORE the first identity creation, makes `ensure_did_resolver_initialized_on`
-    /// a no-op (it short-circuits when a resolver is already present), so this
-    /// retained client is the one the supervisor snapshots — fully isolated from
-    /// the global. Mirrors the `UniFFI` bridge's `install_seedable_resolver`.
-    #[cfg(feature = "allow_in_memory_custody")]
-    fn install_seedable_resolver(
-        bi: &std::sync::Arc<crate::runtime::NapiBridgeInstance>,
-    ) -> std::sync::Arc<scp_identity::InMemoryDhtClient> {
-        let dht_client = std::sync::Arc::new(scp_identity::InMemoryDhtClient::new());
-        let resolver = std::sync::Arc::new(scp_identity::DualLayerResolver::new(
-            std::sync::Arc::new(scp_identity::NoOpRelayQuerier),
-            std::sync::Arc::clone(&dht_client),
-            std::sync::Arc::new(scp_identity::DidCache::new()),
-            Vec::new(),
-        ));
-        crate::runtime::init_did_resolver(bi, resolver, tokio::runtime::Handle::current());
-        dht_client
-    }
+        /// Installs a per-instance DID resolver backed by a caller-retained
+        /// in-memory DHT client on `bi` and returns that client, so the committed
+        /// e2e test can seed the owner's DID document into the SAME store the
+        /// supervisor's governance key resolver reads from — WITHOUT depending on
+        /// the process-global `SHARED_DHT_CLIENT` `OnceLock`.
+        ///
+        /// Why this is necessary (test hermeticity): the production
+        /// `ensure_did_resolver_initialized_on` path stores its `InMemoryDhtClient`
+        /// in the process-wide `SHARED_DHT_CLIENT` `OnceLock` (so
+        /// cross-identity flows in one process share a DHT). The three co-located
+        /// `xctx_saga` tests run concurrently under the default test harness; a
+        /// sibling can win the `SHARED_DHT_CLIENT.set` (or mutate the shared DHT)
+        /// first, so this test's owner DID document lands in / is read from a
+        /// resolver the committed test does not control, and governance vote
+        /// verification fails with `[SCP-CTX-2041] unknown voter: cannot resolve
+        /// public key for DID …`. Installing a FRESH per-instance resolver here,
+        /// BEFORE the first identity creation, makes `ensure_did_resolver_initialized_on`
+        /// a no-op (it short-circuits when a resolver is already present), so this
+        /// retained client is the one the supervisor snapshots — fully isolated from
+        /// the global. Mirrors the `UniFFI` bridge's `install_seedable_resolver`.
+        fn install_seedable_resolver(
+            bi: &std::sync::Arc<crate::runtime::NapiBridgeInstance>,
+        ) -> std::sync::Arc<scp_identity::InMemoryDhtClient> {
+            let dht_client = std::sync::Arc::new(scp_identity::InMemoryDhtClient::new());
+            let resolver = std::sync::Arc::new(scp_identity::DualLayerResolver::new(
+                std::sync::Arc::new(scp_identity::NoOpRelayQuerier),
+                std::sync::Arc::clone(&dht_client),
+                std::sync::Arc::new(scp_identity::DidCache::new()),
+                Vec::new(),
+            ));
+            crate::runtime::init_did_resolver(bi, resolver, tokio::runtime::Handle::current());
+            dht_client
+        }
 
-    /// Publishes `owner_identity`'s DID document into `dht_client` (the
-    /// resolver-visible store installed by [`install_seedable_resolver`]) by
-    /// signing the BEP44 record with the identity's retained in-memory custody.
-    /// Mirrors the production `publish_to_shared_dht_for` step so the
-    /// supervisor's governance key resolver can resolve the proposer key during
-    /// single-admin vote verification.
-    #[cfg(feature = "allow_in_memory_custody")]
-    async fn seed_owner_document_into_resolver(
-        owner_identity: &crate::identity::NapiIdentity,
-        dht_client: &std::sync::Arc<scp_identity::InMemoryDhtClient>,
-    ) {
-        use scp_identity::DhtClient as _;
-        use scp_platform::traits::KeyCustody as _;
+        /// Publishes `owner_identity`'s DID document into `dht_client` (the
+        /// resolver-visible store installed by [`install_seedable_resolver`]) by
+        /// signing the BEP44 record with the identity's retained in-memory custody.
+        /// Mirrors the production `publish_to_shared_dht_for` step so the
+        /// supervisor's governance key resolver can resolve the proposer key during
+        /// single-admin vote verification.
+        async fn seed_owner_document_into_resolver(
+            owner_identity: &crate::identity::NapiIdentity,
+            dht_client: &std::sync::Arc<scp_identity::InMemoryDhtClient>,
+        ) {
+            use scp_identity::DhtClient as _;
+            use scp_platform::traits::KeyCustody as _;
 
-        let inner = &owner_identity.inner;
-        let identity = inner
-            .scp_identity
-            .as_ref()
-            .expect("in-memory owner retains its ScpIdentity");
-        let document = inner
-            .document
-            .as_ref()
-            .expect("in-memory owner retains its DID document");
-        let custody = inner
-            .in_memory_custody
-            .as_ref()
-            .expect("in-memory owner retains its custody");
+            let inner = &owner_identity.inner;
+            let identity = inner
+                .scp_identity
+                .as_ref()
+                .expect("in-memory owner retains its ScpIdentity");
+            let document = inner
+                .document
+                .as_ref()
+                .expect("in-memory owner retains its DID document");
+            let custody = inner
+                .in_memory_custody
+                .as_ref()
+                .expect("in-memory owner retains its custody");
 
-        let doc_json = document.to_json().expect("document serializes to JSON");
-        let value = doc_json.as_bytes();
-        let public_key =
-            scp_identity::extract_public_key(&identity.did).expect("DID embeds the public key");
-        let seq: u64 = 1;
-        let signable = scp_identity::dht::bep44_signable(value, seq);
-        let sig_bytes = custody
-            .sign(&identity.identity_key, &signable)
-            .await
-            .expect("identity custody signs the BEP44 record")
-            .into_bytes();
-        let signature: [u8; 64] = sig_bytes.try_into().expect("Ed25519 signature is 64 bytes");
-        dht_client
-            .publish(&public_key, &signature, value, seq)
-            .await
-            .expect("publish into the resolver-visible store");
-    }
+            let doc_json = document.to_json().expect("document serializes to JSON");
+            let value = doc_json.as_bytes();
+            let public_key =
+                scp_identity::extract_public_key(&identity.did).expect("DID embeds the public key");
+            let seq: u64 = 1;
+            let signable = scp_identity::dht::bep44_signable(value, seq);
+            let sig_bytes = custody
+                .sign(&identity.identity_key, &signable)
+                .await
+                .expect("identity custody signs the BEP44 record")
+                .into_bytes();
+            let signature: [u8; 64] = sig_bytes.try_into().expect("Ed25519 signature is 64 bytes");
+            dht_client
+                .publish(&public_key, &signature, value, seq)
+                .await
+                .expect("publish into the resolver-visible store");
+        }
 
-    /// Full `Committed` terminal through the NAPI bridge: an authenticated
-    /// caller drives the §6.2.4 cross-context tool-invocation saga to a real
-    /// commit and the bridge returns the committed receipt + output bytes.
-    #[cfg(feature = "allow_in_memory_custody")]
-    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-    async fn xctx_saga_authenticated_caller_commits_via_governance_established_interface() {
-        let scp = crate::scp::Scp::new_in_memory_for_test();
-        let bi = std::sync::Arc::clone(&scp.inner);
+        /// Full `Committed` terminal through the NAPI bridge: an authenticated
+        /// caller drives the §6.2.4 cross-context tool-invocation saga to a real
+        /// commit and the bridge returns the committed receipt + output bytes.
+        #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+        async fn xctx_saga_authenticated_caller_commits_via_governance_established_interface() {
+            let scp = crate::scp::Scp::new_in_memory_for_test();
+            let bi = std::sync::Arc::clone(&scp.inner);
 
-        // Install a per-instance, caller-retained DID resolver BEFORE the first
-        // identity creation, so this test is hermetic against the process-global
-        // `SHARED_DHT_CLIENT` `OnceLock` a concurrent sibling `xctx_saga` test
-        // could win first (which otherwise leaves this owner's DID unresolvable
-        // → `[SCP-CTX-2041] unknown voter`). See `install_seedable_resolver`.
-        let resolver_dht = install_seedable_resolver(&bi);
+            // Install a per-instance, caller-retained DID resolver BEFORE the first
+            // identity creation, so this test is hermetic against the process-global
+            // `SHARED_DHT_CLIENT` `OnceLock` a concurrent sibling `xctx_saga` test
+            // could win first (which otherwise leaves this owner's DID unresolvable
+            // → `[SCP-CTX-2041] unknown voter`). See `install_seedable_resolver`.
+            let resolver_dht = install_seedable_resolver(&bi);
 
-        // Owner via the real identity-create path so it retains a real
-        // `ScpIdentity`, custody, and DID document. MUST precede the first
-        // context_create (which lazily builds the supervisor + snapshots the
-        // resolver installed above).
-        let owner_identity = scp
-            .identity_create("in_memory".to_owned(), None)
-            .await
-            .expect("identity_create should succeed");
-        let owner = owner_identity.inner.did.clone();
+            // Owner via the real identity-create path so it retains a real
+            // `ScpIdentity`, custody, and DID document. MUST precede the first
+            // context_create (which lazily builds the supervisor + snapshots the
+            // resolver installed above).
+            let owner_identity = scp
+                .identity_create("in_memory".to_owned(), None)
+                .await
+                .expect("identity_create should succeed");
+            let owner = owner_identity.inner.did.clone();
 
-        // Seed the owner's DID document into the per-instance resolver's store
-        // so governance vote verification (RegisterTool / EstablishToolInterface
-        // auto-execute under single_admin) can resolve the proposer's public
-        // key. Without this the resolver is empty and the propose below fails.
-        seed_owner_document_into_resolver(&owner_identity, &resolver_dht).await;
+            // Seed the owner's DID document into the per-instance resolver's store
+            // so governance vote verification (RegisterTool / EstablishToolInterface
+            // auto-execute under single_admin) can resolve the proposer's public
+            // key. Without this the resolver is empty and the propose below fails.
+            seed_owner_document_into_resolver(&owner_identity, &resolver_dht).await;
 
-        // Context A (caller/source): ceiling carries governance:propose (so the
-        // admin can propose) and tool:interface (required by
-        // execute_establish_tool_interface's ceiling check).
-        let params_a = serde_json::json!({
-            "ceiling": [
-                "governance:propose",
-                "tool:interface",
-                "tools:invoke",
-                "messages:read",
-                "messages:write"
-            ],
-            "governance": "single_admin",
-            "memoryScope": "ephemeral",
-        })
-        .to_string();
-        let handle_a = crate::context::context_create_on(&bi, &owner_identity, params_a)
-            .await
-            .expect("context_create A should succeed");
-        let ctx_a = handle_a.context_id();
+            // Context A (caller/source): ceiling carries governance:propose (so the
+            // admin can propose) and tool:interface (required by
+            // execute_establish_tool_interface's ceiling check).
+            let params_a = serde_json::json!({
+                "ceiling": [
+                    "governance:propose",
+                    "tool:interface",
+                    "tools:invoke",
+                    "messages:read",
+                    "messages:write"
+                ],
+                "governance": "single_admin",
+                "memoryScope": "ephemeral",
+            })
+            .to_string();
+            let handle_a = crate::context::context_create_on(&bi, &owner_identity, params_a)
+                .await
+                .expect("context_create A should succeed");
+            let ctx_a = handle_a.context_id();
 
-        // Context B (target): ceiling carries governance:propose and
-        // tool:register so the saga tool can be registered into B's ACTOR
-        // governance state (the saga's Prepare-B reads it from there).
-        let params_b = serde_json::json!({
-            "ceiling": ["governance:propose", "tool:register"],
-            "governance": "single_admin",
-            "memoryScope": "ephemeral",
-        })
-        .to_string();
-        let handle_b = crate::context::context_create_on(&bi, &owner_identity, params_b)
-            .await
-            .expect("context_create B should succeed");
-        let ctx_b = handle_b.context_id();
+            // Context B (target): ceiling carries governance:propose and
+            // tool:register so the saga tool can be registered into B's ACTOR
+            // governance state (the saga's Prepare-B reads it from there).
+            let params_b = serde_json::json!({
+                "ceiling": ["governance:propose", "tool:register"],
+                "governance": "single_admin",
+                "memoryScope": "ephemeral",
+            })
+            .to_string();
+            let handle_b = crate::context::context_create_on(&bi, &owner_identity, params_b)
+                .await
+                .expect("context_create B should succeed");
+            let ctx_b = handle_b.context_id();
 
-        // Deterministic tool id shared across the actor registry, the interface,
-        // and the FFI-side handler.
-        let tool_name = "xctx_saga_commit_tool";
-        let tool_id = scp_ffi_common::tool_id::generate_tool_id(tool_name);
+            // Deterministic tool id shared across the actor registry, the interface,
+            // and the FFI-side handler.
+            let tool_name = "xctx_saga_commit_tool";
+            let tool_id = scp_ffi_common::tool_id::generate_tool_id(tool_name);
 
-        // Register the tool into B's ACTOR governance state.
-        let register_json = register_tool_action_json(&tool_id, tool_name, &owner);
-        crate::context::context_governance_propose_on(&bi, &handle_b, register_json, owner.clone())
+            // Register the tool into B's ACTOR governance state.
+            let register_json = register_tool_action_json(&tool_id, tool_name, &owner);
+            crate::context::context_governance_propose_on(
+                &bi,
+                &handle_b,
+                register_json,
+                owner.clone(),
+            )
             .await
             .expect("RegisterTool must auto-execute under single_admin");
 
-        // Register the tool into B's FFI-side registry (so register_tool_handler
-        // accepts it) and attach the deterministic handler the executor runs at
-        // Commit-B.
-        let ffi_tool_id = tool_register_on(&bi, &handle_b, build_napi_tool_def(tool_name, &owner))
-            .await
-            .expect("FFI tool_register should succeed");
-        assert_eq!(
-            ffi_tool_id, tool_id,
-            "FFI and governance tool ids must agree (deterministic generate_tool_id)"
-        );
-        let handler: crate::runtime::ToolHandler =
-            std::sync::Arc::new(|_input: serde_json::Value| {
-                Ok(serde_json::json!({"sum": 42, "ok": 1}))
-            });
-        crate::runtime::register_tool_handler(&bi, &ctx_b, &tool_id, handler)
-            .expect("register_tool_handler should succeed");
+            // Register the tool into B's FFI-side registry (so register_tool_handler
+            // accepts it) and attach the deterministic handler the executor runs at
+            // Commit-B.
+            let ffi_tool_id =
+                tool_register_on(&bi, &handle_b, build_napi_tool_def(tool_name, &owner))
+                    .await
+                    .expect("FFI tool_register should succeed");
+            assert_eq!(
+                ffi_tool_id, tool_id,
+                "FFI and governance tool ids must agree (deterministic generate_tool_id)"
+            );
+            let handler: crate::runtime::ToolHandler =
+                std::sync::Arc::new(|_input: serde_json::Value| {
+                    Ok(serde_json::json!({"sum": 42, "ok": 1}))
+                });
+            crate::runtime::register_tool_handler(&bi, &ctx_b, &tool_id, handler)
+                .expect("register_tool_handler should succeed");
 
-        // Establish the bidirectionally-approved interface in A via governance.
-        let interface_json = establish_interface_action_json(&ctx_a, &ctx_b, &tool_id);
-        let propose_result = crate::context::context_governance_propose_on(
-            &bi,
-            &handle_a,
-            interface_json,
-            owner.clone(),
-        )
-        .await
-        .expect("EstablishToolInterface must auto-execute under single_admin");
-        assert!(
-            !propose_result.is_empty(),
-            "governance_propose must return a non-empty result JSON"
-        );
-
-        // A near-now timestamp: Prepare-B enforces a §9.14 ±5min skew tolerance.
-        let now_ms = u64::try_from(
-            std::time::SystemTime::now()
-                .duration_since(std::time::UNIX_EPOCH)
-                .unwrap()
-                .as_millis(),
-        )
-        .unwrap();
-        // A 16-byte nonce as 32 lowercase-hex chars.
-        let nonce_hex = "0123456789abcdef0123456789abcdef".to_owned();
-
-        let result = Box::pin(tool_invoke_cross_context_saga_on(
-            &bi,
-            &handle_a,
-            &handle_b,
-            owner.clone(),
-            tool_id.clone(),
-            r#"{"a":"x","b":"y"}"#.to_owned(),
-            nonce_hex,
-            now_ms,
-            1,
-            None,
-        ))
-        .await
-        .expect("saga must reach Committed");
-
-        // Committed terminal: non-empty saga id + a receipt + output bytes.
-        assert!(
-            !result.saga_id.is_empty(),
-            "a committed saga must carry a non-empty saga id"
-        );
-        let receipt = result.receipt.expect("committed saga must carry a receipt");
-        assert!(!receipt.is_empty(), "receipt bytes must be non-empty");
-        let output_buf = result
-            .output
-            .expect("committed saga must carry output bytes");
-
-        // The committed output decodes to the handler's response (numeric, per
-        // the registered output schema). Assert the parsed values, not raw
-        // bytes, so a JCS-canonical encoding still passes.
-        let out: serde_json::Value =
-            serde_json::from_slice(output_buf.as_ref()).expect("output must be valid JSON");
-        assert_eq!(out["sum"], 42, "committed output sum must be the handler's");
-        assert_eq!(out["ok"], 1, "committed output ok must be the handler's");
-    }
-
-    // ------------------------------------------------------------------
-    // Caller-principal binding (§6.2.4 *Caller authentication*) — the two
-    // axes `enforce_caller_principal_binding` enforces at the NAPI seam,
-    // BEFORE the saga runs. These are the behavioral counterparts of the
-    // PyO3 `e2e_bridge.rs` axis-(a)/axis-(b) tests.
-    //
-    // MUTATION-RESISTANCE: the producer's own gate 1 ALSO rejects a
-    // non-member caller with SCP-SAGA-13050. Asserting only the code (as the
-    // TS addon test does) would PASS even if this bridge's binding were
-    // removed — the producer would surface 13050 anyway. So each test asserts
-    // the BRIDGE-UNIQUE message substring that `enforce_caller_principal_binding`
-    // emits and the producer never does:
-    //   axis (a): "is not an identity hosted by this bridge instance"
-    //   axis (b): "is hosted by this bridge but is not a member of"
-    // The producer's gate-1 message is "... is not a member of caller context
-    // '...' — not authorized to initiate over it", which contains neither.
-    // ------------------------------------------------------------------
-
-    /// Creates an ephemeral single-admin context owned by `owner_identity` whose
-    /// ceiling carries the saga-relevant capabilities. Mirrors the e2e setup but
-    /// without the tool/interface wiring the two binding-rejection tests never
-    /// reach (they abort at the caller gate before the producer runs).
-    #[cfg(feature = "allow_in_memory_custody")]
-    async fn create_saga_context(
-        bi: &std::sync::Arc<crate::runtime::NapiBridgeInstance>,
-        owner_identity: &crate::identity::NapiIdentity,
-    ) -> crate::context::NapiContextHandle {
-        let params = serde_json::json!({
-            "ceiling": [
-                "governance:propose",
-                "tool:interface",
-                "tool:register",
-                "tools:invoke",
-                "messages:read",
-                "messages:write"
-            ],
-            "governance": "single_admin",
-            "memoryScope": "ephemeral",
-        })
-        .to_string();
-        crate::context::context_create_on(bi, owner_identity, params)
-            .await
-            .expect("context_create should succeed")
-    }
-
-    /// (a) Caller-principal binding, hosted axis: a `caller_did` this bridge
-    /// instance does NOT host is rejected with `SagaAborted` (SCP-SAGA-13050)
-    /// BEFORE the saga runs. Asserts the bridge-unique axis-(a) substring so the
-    /// test fails if `enforce_caller_principal_binding`'s registry check is
-    /// removed (the producer's gate-1 message never carries this phrasing).
-    #[cfg(feature = "allow_in_memory_custody")]
-    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-    async fn xctx_saga_unhosted_caller_rejected_before_saga() {
-        let scp = crate::scp::Scp::new_in_memory_for_test();
-        let bi = std::sync::Arc::clone(&scp.inner);
-
-        let owner_identity = scp
-            .identity_create("in_memory".to_owned(), None)
-            .await
-            .expect("identity_create should succeed");
-
-        let handle_a = create_saga_context(&bi, &owner_identity).await;
-        let handle_b = create_saga_context(&bi, &owner_identity).await;
-        let tool_id = scp_ffi_common::tool_id::generate_tool_id("xctx_saga_unhosted_probe");
-
-        // A syntactically valid DID that was never created on this instance.
-        let unhosted_caller = "did:dht:z6MkUnhostedCallerPrincipal0001".to_owned();
-
-        let now_ms = u64::try_from(
-            std::time::SystemTime::now()
-                .duration_since(std::time::UNIX_EPOCH)
-                .unwrap()
-                .as_millis(),
-        )
-        .unwrap();
-
-        // `NapiSagaResult` is not `Debug`, so destructure the `Err` terminal
-        // explicitly rather than `expect_err`.
-        let Err(err) = Box::pin(tool_invoke_cross_context_saga_on(
-            &bi,
-            &handle_a,
-            &handle_b,
-            unhosted_caller,
-            tool_id,
-            r#"{"a":"x","b":"y"}"#.to_owned(),
-            "0123456789abcdef0123456789abcdef".to_owned(),
-            now_ms,
-            1,
-            None,
-        ))
-        .await
-        else {
-            panic!("an unhosted caller_did must be rejected before the saga runs")
-        };
-
-        let msg = format!("{err}");
-        assert!(
-            msg.contains(codes::SAGA_13050),
-            "expected caller-axis SCP-SAGA-13050, got: {msg}"
-        );
-        // BRIDGE-UNIQUE axis-(a) substring — the producer never emits it.
-        assert!(
-            msg.contains("is not an identity hosted by this bridge instance"),
-            "message must be the BRIDGE axis-(a) hosted-principal rejection (not a producer \
-             message), got: {msg}"
-        );
-    }
-
-    /// (b) Caller-principal binding, membership axis: a `caller_did` that IS
-    /// hosted by this bridge but is NOT a member of `caller_context_id` is
-    /// rejected with `SagaAborted` (SCP-SAGA-13050) BEFORE the saga runs. Asserts
-    /// the bridge-unique axis-(b) substring so the test fails if the bridge's
-    /// `is_member` check is removed — the producer's gate-1 message shares only
-    /// the bare "not a member of" phrasing, not this prefix.
-    #[cfg(feature = "allow_in_memory_custody")]
-    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-    async fn xctx_saga_hosted_non_member_caller_rejected() {
-        let scp = crate::scp::Scp::new_in_memory_for_test();
-        let bi = std::sync::Arc::clone(&scp.inner);
-
-        let owner_identity = scp
-            .identity_create("in_memory".to_owned(), None)
-            .await
-            .expect("identity_create should succeed");
-
-        // A SECOND hosted identity that is NOT a member of the caller context.
-        let stranger_identity = scp
-            .identity_create("in_memory".to_owned(), None)
-            .await
-            .expect("identity_create should succeed");
-        let stranger = stranger_identity.inner.did.clone();
-
-        // Contexts created by `owner` ⇒ `stranger` is hosted but not a member.
-        let handle_a = create_saga_context(&bi, &owner_identity).await;
-        let handle_b = create_saga_context(&bi, &owner_identity).await;
-        let tool_id = scp_ffi_common::tool_id::generate_tool_id("xctx_saga_nonmember_probe");
-
-        let now_ms = u64::try_from(
-            std::time::SystemTime::now()
-                .duration_since(std::time::UNIX_EPOCH)
-                .unwrap()
-                .as_millis(),
-        )
-        .unwrap();
-
-        // `NapiSagaResult` is not `Debug`, so destructure the `Err` terminal
-        // explicitly rather than `expect_err`.
-        let Err(err) = Box::pin(tool_invoke_cross_context_saga_on(
-            &bi,
-            &handle_a,
-            &handle_b,
-            stranger, // hosted, but not a member of caller context A
-            tool_id,
-            r#"{"a":"x","b":"y"}"#.to_owned(),
-            "0123456789abcdef0123456789abcdef".to_owned(),
-            now_ms,
-            1,
-            None,
-        ))
-        .await
-        else {
-            panic!("a hosted non-member caller must be rejected before the saga runs")
-        };
-
-        let msg = format!("{err}");
-        assert!(
-            msg.contains(codes::SAGA_13050),
-            "expected caller-axis SCP-SAGA-13050, got: {msg}"
-        );
-        // BRIDGE-UNIQUE axis-(b) substring — the producer's gate-1 message
-        // carries only the bare "not a member of" phrasing, not this prefix.
-        assert!(
-            msg.contains("is hosted by this bridge but is not a member of"),
-            "message must be the BRIDGE axis-(b) membership rejection (not the producer gate-1 \
-             message), got: {msg}"
-        );
-    }
-
-    /// (a, axis-isolated) Caller-principal binding, hosted-here axis as the SOLE
-    /// guard: a `caller_did` that IS a genuine member of `caller_context_id` (so
-    /// the membership axis (b) would PASS) but is NOT an identity hosted by this
-    /// bridge instance is STILL rejected with `SagaAborted` (SCP-SAGA-13050)
-    /// BEFORE the saga runs.
-    ///
-    /// This is the property `xctx_saga_unhosted_caller_rejected_before_saga`
-    /// cannot prove: that test's caller is BOTH unhosted AND a non-member, so
-    /// axis (b) (and the producer's gate 1) would reject it even if axis (a) were
-    /// deleted. Here the caller is inserted as a real member of `caller_ctx` via
-    /// `Supervisor::test_insert_member` (the actor-state membership injection
-    /// that bypasses the MLS Welcome a non-hosted DID could never complete), so
-    /// `supervisor.is_member` returns true and axis (b) passes the caller. The
-    /// ONLY thing that can reject it is axis (a): the caller DID was never
-    /// `identity_create`'d, so it is absent from this instance's identity
-    /// registry. The test therefore fails closed iff the bridge's
-    /// `identity_registry_contains` axis (a) check is removed, and is INDEPENDENT
-    /// of axis (b) by construction.
-    #[cfg(feature = "allow_in_memory_custody")]
-    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-    async fn xctx_saga_member_but_unhosted_caller_rejected_by_hosted_axis() {
-        let scp = crate::scp::Scp::new_in_memory_for_test();
-        let bi = std::sync::Arc::clone(&scp.inner);
-
-        // `owner` is a hosted identity used only to create the contexts.
-        let owner_identity = scp
-            .identity_create("in_memory".to_owned(), None)
-            .await
-            .expect("identity_create should succeed");
-
-        let handle_a = create_saga_context(&bi, &owner_identity).await;
-        let handle_b = create_saga_context(&bi, &owner_identity).await;
-        let ctx_a = handle_a.context_id();
-        let tool_id = scp_ffi_common::tool_id::generate_tool_id("xctx_saga_member_unhosted_probe");
-
-        // The caller is a syntactically valid DID that is NEVER `identity_create`'d
-        // (so the bridge's identity registry does NOT host it — axis (a) must
-        // reject), yet is injected as a genuine member of `caller_ctx` via the
-        // actor-state membership path (so `supervisor.is_member` returns true and
-        // axis (b) passes). `test_insert_member` is the test-only injection that
-        // records the member into role state exactly as an executed `AddMember`
-        // would, without the MLS Welcome a non-hosted DID could never complete.
-        let member_but_unhosted_caller = "did:dht:z6MkMemberButUnhostedCaller001".to_owned();
-        let supervisor = crate::runtime::supervisor(&bi).expect("supervisor must be initialized");
-        supervisor
-            .test_insert_member(
-                &ctx_a,
-                scp_identity::DID(member_but_unhosted_caller.clone()),
-                "member",
+            // Establish the bidirectionally-approved interface in A via governance.
+            let interface_json = establish_interface_action_json(&ctx_a, &ctx_b, &tool_id);
+            let propose_result = crate::context::context_governance_propose_on(
+                &bi,
+                &handle_a,
+                interface_json,
+                owner.clone(),
             )
             .await
-            .expect("test_insert_member should record the caller into caller_ctx membership");
+            .expect("EstablishToolInterface must auto-execute under single_admin");
+            assert!(
+                !propose_result.is_empty(),
+                "governance_propose must return a non-empty result JSON"
+            );
 
-        // Precondition: the supervisor MUST see the caller as a member of
-        // `caller_ctx` (axis (b) passes), while the bridge's identity registry
-        // does NOT host it (axis (a) is the sole remaining guard).
-        assert!(
+            // A near-now timestamp: Prepare-B enforces a §9.14 ±5min skew tolerance.
+            let now_ms = u64::try_from(
+                std::time::SystemTime::now()
+                    .duration_since(std::time::UNIX_EPOCH)
+                    .unwrap()
+                    .as_millis(),
+            )
+            .unwrap();
+            // A 16-byte nonce as 32 lowercase-hex chars.
+            let nonce_hex = "0123456789abcdef0123456789abcdef".to_owned();
+
+            let result = Box::pin(tool_invoke_cross_context_saga_on(
+                &bi,
+                &handle_a,
+                &handle_b,
+                owner.clone(),
+                tool_id.clone(),
+                r#"{"a":"x","b":"y"}"#.to_owned(),
+                nonce_hex,
+                now_ms,
+                1,
+                None,
+            ))
+            .await
+            .expect("saga must reach Committed");
+
+            // Committed terminal: non-empty saga id + a receipt + output bytes.
+            assert!(
+                !result.saga_id.is_empty(),
+                "a committed saga must carry a non-empty saga id"
+            );
+            let receipt = result.receipt.expect("committed saga must carry a receipt");
+            assert!(!receipt.is_empty(), "receipt bytes must be non-empty");
+            let output_buf = result
+                .output
+                .expect("committed saga must carry output bytes");
+
+            // The committed output decodes to the handler's response (numeric, per
+            // the registered output schema). Assert the parsed values, not raw
+            // bytes, so a JCS-canonical encoding still passes.
+            let out: serde_json::Value =
+                serde_json::from_slice(output_buf.as_ref()).expect("output must be valid JSON");
+            assert_eq!(out["sum"], 42, "committed output sum must be the handler's");
+            assert_eq!(out["ok"], 1, "committed output ok must be the handler's");
+        }
+
+        // ------------------------------------------------------------------
+        // Caller-principal binding (§6.2.4 *Caller authentication*) — the two
+        // axes `enforce_caller_principal_binding` enforces at the NAPI seam,
+        // BEFORE the saga runs. These are the behavioral counterparts of the
+        // PyO3 `e2e_bridge.rs` axis-(a)/axis-(b) tests.
+        //
+        // MUTATION-RESISTANCE: the producer's own gate 1 ALSO rejects a
+        // non-member caller with SCP-SAGA-13050. Asserting only the code (as the
+        // TS addon test does) would PASS even if this bridge's binding were
+        // removed — the producer would surface 13050 anyway. So each test asserts
+        // the BRIDGE-UNIQUE message substring that `enforce_caller_principal_binding`
+        // emits and the producer never does:
+        //   axis (a): "is not an identity hosted by this bridge instance"
+        //   axis (b): "is hosted by this bridge but is not a member of"
+        // The producer's gate-1 message is "... is not a member of caller context
+        // '...' — not authorized to initiate over it", which contains neither.
+        // ------------------------------------------------------------------
+
+        /// Creates an ephemeral single-admin context owned by `owner_identity` whose
+        /// ceiling carries the saga-relevant capabilities. Mirrors the e2e setup but
+        /// without the tool/interface wiring the two binding-rejection tests never
+        /// reach (they abort at the caller gate before the producer runs).
+        async fn create_saga_context(
+            bi: &std::sync::Arc<crate::runtime::NapiBridgeInstance>,
+            owner_identity: &crate::identity::NapiIdentity,
+        ) -> crate::context::NapiContextHandle {
+            let params = serde_json::json!({
+                "ceiling": [
+                    "governance:propose",
+                    "tool:interface",
+                    "tool:register",
+                    "tools:invoke",
+                    "messages:read",
+                    "messages:write"
+                ],
+                "governance": "single_admin",
+                "memoryScope": "ephemeral",
+            })
+            .to_string();
+            crate::context::context_create_on(bi, owner_identity, params)
+                .await
+                .expect("context_create should succeed")
+        }
+
+        /// (a) Caller-principal binding, hosted axis: a `caller_did` this bridge
+        /// instance does NOT host is rejected with `SagaAborted` (SCP-SAGA-13050)
+        /// BEFORE the saga runs. Asserts the bridge-unique axis-(a) substring so the
+        /// test fails if `enforce_caller_principal_binding`'s registry check is
+        /// removed (the producer's gate-1 message never carries this phrasing).
+        #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+        async fn xctx_saga_unhosted_caller_rejected_before_saga() {
+            let scp = crate::scp::Scp::new_in_memory_for_test();
+            let bi = std::sync::Arc::clone(&scp.inner);
+
+            let owner_identity = scp
+                .identity_create("in_memory".to_owned(), None)
+                .await
+                .expect("identity_create should succeed");
+
+            let handle_a = create_saga_context(&bi, &owner_identity).await;
+            let handle_b = create_saga_context(&bi, &owner_identity).await;
+            let tool_id = scp_ffi_common::tool_id::generate_tool_id("xctx_saga_unhosted_probe");
+
+            // A syntactically valid DID that was never created on this instance.
+            let unhosted_caller = "did:dht:z6MkUnhostedCallerPrincipal0001".to_owned();
+
+            let now_ms = u64::try_from(
+                std::time::SystemTime::now()
+                    .duration_since(std::time::UNIX_EPOCH)
+                    .unwrap()
+                    .as_millis(),
+            )
+            .unwrap();
+
+            // `NapiSagaResult` is not `Debug`, so destructure the `Err` terminal
+            // explicitly rather than `expect_err`.
+            let Err(err) = Box::pin(tool_invoke_cross_context_saga_on(
+                &bi,
+                &handle_a,
+                &handle_b,
+                unhosted_caller,
+                tool_id,
+                r#"{"a":"x","b":"y"}"#.to_owned(),
+                "0123456789abcdef0123456789abcdef".to_owned(),
+                now_ms,
+                1,
+                None,
+            ))
+            .await
+            else {
+                panic!("an unhosted caller_did must be rejected before the saga runs")
+            };
+
+            let msg = format!("{err}");
+            assert!(
+                msg.contains(codes::SAGA_13050),
+                "expected caller-axis SCP-SAGA-13050, got: {msg}"
+            );
+            // BRIDGE-UNIQUE axis-(a) substring — the producer never emits it.
+            assert!(
+                msg.contains("is not an identity hosted by this bridge instance"),
+                "message must be the BRIDGE axis-(a) hosted-principal rejection (not a producer \
+             message), got: {msg}"
+            );
+        }
+
+        /// (b) Caller-principal binding, membership axis: a `caller_did` that IS
+        /// hosted by this bridge but is NOT a member of `caller_context_id` is
+        /// rejected with `SagaAborted` (SCP-SAGA-13050) BEFORE the saga runs. Asserts
+        /// the bridge-unique axis-(b) substring so the test fails if the bridge's
+        /// `is_member` check is removed — the producer's gate-1 message shares only
+        /// the bare "not a member of" phrasing, not this prefix.
+        #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+        async fn xctx_saga_hosted_non_member_caller_rejected() {
+            let scp = crate::scp::Scp::new_in_memory_for_test();
+            let bi = std::sync::Arc::clone(&scp.inner);
+
+            let owner_identity = scp
+                .identity_create("in_memory".to_owned(), None)
+                .await
+                .expect("identity_create should succeed");
+
+            // A SECOND hosted identity that is NOT a member of the caller context.
+            let stranger_identity = scp
+                .identity_create("in_memory".to_owned(), None)
+                .await
+                .expect("identity_create should succeed");
+            let stranger = stranger_identity.inner.did.clone();
+
+            // Contexts created by `owner` ⇒ `stranger` is hosted but not a member.
+            let handle_a = create_saga_context(&bi, &owner_identity).await;
+            let handle_b = create_saga_context(&bi, &owner_identity).await;
+            let tool_id = scp_ffi_common::tool_id::generate_tool_id("xctx_saga_nonmember_probe");
+
+            let now_ms = u64::try_from(
+                std::time::SystemTime::now()
+                    .duration_since(std::time::UNIX_EPOCH)
+                    .unwrap()
+                    .as_millis(),
+            )
+            .unwrap();
+
+            // `NapiSagaResult` is not `Debug`, so destructure the `Err` terminal
+            // explicitly rather than `expect_err`.
+            let Err(err) = Box::pin(tool_invoke_cross_context_saga_on(
+                &bi,
+                &handle_a,
+                &handle_b,
+                stranger, // hosted, but not a member of caller context A
+                tool_id,
+                r#"{"a":"x","b":"y"}"#.to_owned(),
+                "0123456789abcdef0123456789abcdef".to_owned(),
+                now_ms,
+                1,
+                None,
+            ))
+            .await
+            else {
+                panic!("a hosted non-member caller must be rejected before the saga runs")
+            };
+
+            let msg = format!("{err}");
+            assert!(
+                msg.contains(codes::SAGA_13050),
+                "expected caller-axis SCP-SAGA-13050, got: {msg}"
+            );
+            // BRIDGE-UNIQUE axis-(b) substring — the producer's gate-1 message
+            // carries only the bare "not a member of" phrasing, not this prefix.
+            assert!(
+                msg.contains("is hosted by this bridge but is not a member of"),
+                "message must be the BRIDGE axis-(b) membership rejection (not the producer gate-1 \
+             message), got: {msg}"
+            );
+        }
+
+        /// (a, axis-isolated) Caller-principal binding, hosted-here axis as the SOLE
+        /// guard: a `caller_did` that IS a genuine member of `caller_context_id` (so
+        /// the membership axis (b) would PASS) but is NOT an identity hosted by this
+        /// bridge instance is STILL rejected with `SagaAborted` (SCP-SAGA-13050)
+        /// BEFORE the saga runs.
+        ///
+        /// This is the property `xctx_saga_unhosted_caller_rejected_before_saga`
+        /// cannot prove: that test's caller is BOTH unhosted AND a non-member, so
+        /// axis (b) (and the producer's gate 1) would reject it even if axis (a) were
+        /// deleted. Here the caller is inserted as a real member of `caller_ctx` via
+        /// `Supervisor::test_insert_member` (the actor-state membership injection
+        /// that bypasses the MLS Welcome a non-hosted DID could never complete), so
+        /// `supervisor.is_member` returns true and axis (b) passes the caller. The
+        /// ONLY thing that can reject it is axis (a): the caller DID was never
+        /// `identity_create`'d, so it is absent from this instance's identity
+        /// registry. The test therefore fails closed iff the bridge's
+        /// `identity_registry_contains` axis (a) check is removed, and is INDEPENDENT
+        /// of axis (b) by construction.
+        #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+        async fn xctx_saga_member_but_unhosted_caller_rejected_by_hosted_axis() {
+            let scp = crate::scp::Scp::new_in_memory_for_test();
+            let bi = std::sync::Arc::clone(&scp.inner);
+
+            // `owner` is a hosted identity used only to create the contexts.
+            let owner_identity = scp
+                .identity_create("in_memory".to_owned(), None)
+                .await
+                .expect("identity_create should succeed");
+
+            let handle_a = create_saga_context(&bi, &owner_identity).await;
+            let handle_b = create_saga_context(&bi, &owner_identity).await;
+            let ctx_a = handle_a.context_id();
+            let tool_id =
+                scp_ffi_common::tool_id::generate_tool_id("xctx_saga_member_unhosted_probe");
+
+            // The caller is a syntactically valid DID that is NEVER `identity_create`'d
+            // (so the bridge's identity registry does NOT host it — axis (a) must
+            // reject), yet is injected as a genuine member of `caller_ctx` via the
+            // actor-state membership path (so `supervisor.is_member` returns true and
+            // axis (b) passes). `test_insert_member` is the test-only injection that
+            // records the member into role state exactly as an executed `AddMember`
+            // would, without the MLS Welcome a non-hosted DID could never complete.
+            let member_but_unhosted_caller = "did:dht:z6MkMemberButUnhostedCaller001".to_owned();
+            let supervisor =
+                crate::runtime::supervisor(&bi).expect("supervisor must be initialized");
             supervisor
-                .is_member(&ctx_a, &member_but_unhosted_caller)
-                .await,
-            "precondition: caller must be a genuine member of caller_ctx so axis (b) passes"
-        );
-        assert!(
-            !crate::runtime::identity_registry_contains(&bi, &member_but_unhosted_caller),
-            "precondition: caller must NOT be hosted so axis (a) is the sole guard"
-        );
+                .test_insert_member(
+                    &ctx_a,
+                    scp_identity::DID(member_but_unhosted_caller.clone()),
+                    "member",
+                )
+                .await
+                .expect("test_insert_member should record the caller into caller_ctx membership");
 
-        let now_ms = u64::try_from(
-            std::time::SystemTime::now()
-                .duration_since(std::time::UNIX_EPOCH)
-                .unwrap()
-                .as_millis(),
-        )
-        .unwrap();
+            // Precondition: the supervisor MUST see the caller as a member of
+            // `caller_ctx` (axis (b) passes), while the bridge's identity registry
+            // does NOT host it (axis (a) is the sole remaining guard).
+            assert!(
+                supervisor
+                    .is_member(&ctx_a, &member_but_unhosted_caller)
+                    .await,
+                "precondition: caller must be a genuine member of caller_ctx so axis (b) passes"
+            );
+            assert!(
+                !crate::runtime::identity_registry_contains(&bi, &member_but_unhosted_caller),
+                "precondition: caller must NOT be hosted so axis (a) is the sole guard"
+            );
 
-        // `NapiSagaResult` is not `Debug`, so destructure the `Err` terminal
-        // explicitly rather than `expect_err`.
-        let Err(err) = Box::pin(tool_invoke_cross_context_saga_on(
-            &bi,
-            &handle_a,
-            &handle_b,
-            member_but_unhosted_caller, // member of caller_ctx, but NOT hosted
-            tool_id,
-            r#"{"a":"x","b":"y"}"#.to_owned(),
-            "0123456789abcdef0123456789abcdef".to_owned(),
-            now_ms,
-            1,
-            None,
-        ))
-        .await
-        else {
-            panic!("a member-but-unhosted caller must be rejected by axis (a) before the saga runs")
-        };
+            let now_ms = u64::try_from(
+                std::time::SystemTime::now()
+                    .duration_since(std::time::UNIX_EPOCH)
+                    .unwrap()
+                    .as_millis(),
+            )
+            .unwrap();
 
-        let msg = format!("{err}");
-        assert!(
-            msg.contains(codes::SAGA_13050),
-            "expected caller-axis SCP-SAGA-13050, got: {msg}"
-        );
-        // BRIDGE-UNIQUE axis-(a) substring. Because the caller IS a member, the
-        // membership axis (b) and the producer's gate 1 would BOTH pass — so the
-        // axis-(b) message ("is hosted by this bridge but is not a member of") can
-        // never appear here. The ONLY rejection that fits is axis (a). Asserting
-        // its exact substring makes this test fail closed iff
-        // `enforce_caller_principal_binding`'s `identity_registry_contains` check
-        // is removed.
-        assert!(
-            msg.contains("is not an identity hosted by this bridge instance"),
-            "message must be the BRIDGE axis-(a) hosted-here rejection, got: {msg}"
-        );
+            // `NapiSagaResult` is not `Debug`, so destructure the `Err` terminal
+            // explicitly rather than `expect_err`.
+            let Err(err) = Box::pin(tool_invoke_cross_context_saga_on(
+                &bi,
+                &handle_a,
+                &handle_b,
+                member_but_unhosted_caller, // member of caller_ctx, but NOT hosted
+                tool_id,
+                r#"{"a":"x","b":"y"}"#.to_owned(),
+                "0123456789abcdef0123456789abcdef".to_owned(),
+                now_ms,
+                1,
+                None,
+            ))
+            .await
+            else {
+                panic!(
+                    "a member-but-unhosted caller must be rejected by axis (a) before the saga runs"
+                )
+            };
+
+            let msg = format!("{err}");
+            assert!(
+                msg.contains(codes::SAGA_13050),
+                "expected caller-axis SCP-SAGA-13050, got: {msg}"
+            );
+            // BRIDGE-UNIQUE axis-(a) substring. Because the caller IS a member, the
+            // membership axis (b) and the producer's gate 1 would BOTH pass — so the
+            // axis-(b) message ("is hosted by this bridge but is not a member of") can
+            // never appear here. The ONLY rejection that fits is axis (a). Asserting
+            // its exact substring makes this test fail closed iff
+            // `enforce_caller_principal_binding`'s `identity_registry_contains` check
+            // is removed.
+            assert!(
+                msg.contains("is not an identity hosted by this bridge instance"),
+                "message must be the BRIDGE axis-(a) hosted-here rejection, got: {msg}"
+            );
+        }
     }
 }

--- a/crates/scp-ffi/napi/src/tools.rs
+++ b/crates/scp-ffi/napi/src/tools.rs
@@ -1739,12 +1739,14 @@ mod tests {
     // The handler returns `{"sum":42,"ok":1}`, which Commit-B validates against
     // the registered numeric `{sum, ok}` output schema before committing.
     //
-    // The owner is created via the real `identity_create` BEFORE the first
-    // `context_create_on` so its DID document is published into the per-instance
-    // resolver and the supervisor (built lazily on first create) snapshots that
-    // real resolver — governance vote verification resolves the proposer key
-    // through it. Prepare-B enforces a §9.14 ±5min timestamp skew, so the
-    // invocation uses `SystemTime::now()`.
+    // For hermeticity against the process-global `SHARED_DHT_CLIENT` `OnceLock`,
+    // the test installs its OWN per-instance resolver (over a caller-retained
+    // in-memory DHT) BEFORE the first `identity_create`, then explicitly seeds
+    // the owner's DID document into that resolver-visible store. The supervisor
+    // (built lazily on first `context_create_on`) snapshots that resolver, so
+    // governance vote verification resolves the proposer key through it without
+    // racing a concurrent sibling on the global. Prepare-B enforces a §9.14
+    // ±5min timestamp skew, so the invocation uses `SystemTime::now()`.
     // ------------------------------------------------------------------
 
     /// Serializes a `RegisterTool` governance action for the saga tool. Mirrors
@@ -1830,6 +1832,87 @@ mod tests {
         }
     }
 
+    /// Installs a per-instance DID resolver backed by a caller-retained
+    /// in-memory DHT client on `bi` and returns that client, so the committed
+    /// e2e test can seed the owner's DID document into the SAME store the
+    /// supervisor's governance key resolver reads from — WITHOUT depending on
+    /// the process-global `SHARED_DHT_CLIENT` `OnceLock`.
+    ///
+    /// Why this is necessary (test hermeticity): the production
+    /// `ensure_did_resolver_initialized_on` path stores its `InMemoryDhtClient`
+    /// in the process-wide `SHARED_DHT_CLIENT` `OnceLock` (#1144, so
+    /// cross-identity flows in one process share a DHT). The three co-located
+    /// `xctx_saga` tests run concurrently under the default test harness; a
+    /// sibling can win the `SHARED_DHT_CLIENT.set` (or mutate the shared DHT)
+    /// first, so this test's owner DID document lands in / is read from a
+    /// resolver the committed test does not control, and governance vote
+    /// verification fails with `[SCP-CTX-2041] unknown voter: cannot resolve
+    /// public key for DID …`. Installing a FRESH per-instance resolver here,
+    /// BEFORE the first identity creation, makes `ensure_did_resolver_initialized_on`
+    /// a no-op (it short-circuits when a resolver is already present), so this
+    /// retained client is the one the supervisor snapshots — fully isolated from
+    /// the global. Mirrors the `UniFFI` bridge's `install_seedable_resolver`.
+    #[cfg(feature = "allow_in_memory_custody")]
+    fn install_seedable_resolver(
+        bi: &std::sync::Arc<crate::runtime::NapiBridgeInstance>,
+    ) -> std::sync::Arc<scp_identity::InMemoryDhtClient> {
+        let dht_client = std::sync::Arc::new(scp_identity::InMemoryDhtClient::new());
+        let resolver = std::sync::Arc::new(scp_identity::DualLayerResolver::new(
+            std::sync::Arc::new(scp_identity::NoOpRelayQuerier),
+            std::sync::Arc::clone(&dht_client),
+            std::sync::Arc::new(scp_identity::DidCache::new()),
+            Vec::new(),
+        ));
+        crate::runtime::init_did_resolver(bi, resolver, tokio::runtime::Handle::current());
+        dht_client
+    }
+
+    /// Publishes `owner_identity`'s DID document into `dht_client` (the
+    /// resolver-visible store installed by [`install_seedable_resolver`]) by
+    /// signing the BEP44 record with the identity's retained in-memory custody.
+    /// Mirrors the production `publish_to_shared_dht_for` step so the
+    /// supervisor's governance key resolver can resolve the proposer key during
+    /// single-admin vote verification.
+    #[cfg(feature = "allow_in_memory_custody")]
+    async fn seed_owner_document_into_resolver(
+        owner_identity: &crate::identity::NapiIdentity,
+        dht_client: &std::sync::Arc<scp_identity::InMemoryDhtClient>,
+    ) {
+        use scp_identity::DhtClient as _;
+        use scp_platform::traits::KeyCustody as _;
+
+        let inner = &owner_identity.inner;
+        let identity = inner
+            .scp_identity
+            .as_ref()
+            .expect("in-memory owner retains its ScpIdentity");
+        let document = inner
+            .document
+            .as_ref()
+            .expect("in-memory owner retains its DID document");
+        let custody = inner
+            .in_memory_custody
+            .as_ref()
+            .expect("in-memory owner retains its custody");
+
+        let doc_json = document.to_json().expect("document serializes to JSON");
+        let value = doc_json.as_bytes();
+        let public_key =
+            scp_identity::extract_public_key(&identity.did).expect("DID embeds the public key");
+        let seq: u64 = 1;
+        let signable = scp_identity::dht::bep44_signable(value, seq);
+        let sig_bytes = custody
+            .sign(&identity.identity_key, &signable)
+            .await
+            .expect("identity custody signs the BEP44 record")
+            .into_bytes();
+        let signature: [u8; 64] = sig_bytes.try_into().expect("Ed25519 signature is 64 bytes");
+        dht_client
+            .publish(&public_key, &signature, value, seq)
+            .await
+            .expect("publish into the resolver-visible store");
+    }
+
     /// Full `Committed` terminal through the NAPI bridge: an authenticated
     /// caller drives the §6.2.4 cross-context tool-invocation saga to a real
     /// commit and the bridge returns the committed receipt + output bytes.
@@ -1839,15 +1922,28 @@ mod tests {
         let scp = crate::scp::Scp::new_in_memory_for_test();
         let bi = std::sync::Arc::clone(&scp.inner);
 
-        // Owner via the real identity-create path so its DID document is
-        // resolvable for governance vote verification. MUST precede the first
+        // Install a per-instance, caller-retained DID resolver BEFORE the first
+        // identity creation, so this test is hermetic against the process-global
+        // `SHARED_DHT_CLIENT` `OnceLock` a concurrent sibling `xctx_saga` test
+        // could win first (which otherwise leaves this owner's DID unresolvable
+        // → `[SCP-CTX-2041] unknown voter`). See `install_seedable_resolver`.
+        let resolver_dht = install_seedable_resolver(&bi);
+
+        // Owner via the real identity-create path so it retains a real
+        // `ScpIdentity`, custody, and DID document. MUST precede the first
         // context_create (which lazily builds the supervisor + snapshots the
-        // resolver).
+        // resolver installed above).
         let owner_identity = scp
             .identity_create("in_memory".to_owned(), None)
             .await
             .expect("identity_create should succeed");
         let owner = owner_identity.inner.did.clone();
+
+        // Seed the owner's DID document into the per-instance resolver's store
+        // so governance vote verification (RegisterTool / EstablishToolInterface
+        // auto-execute under single_admin) can resolve the proposer's public
+        // key. Without this the resolver is empty and the propose below fails.
+        seed_owner_document_into_resolver(&owner_identity, &resolver_dht).await;
 
         // Context A (caller/source): ceiling carries governance:propose (so the
         // admin can propose) and tool:interface (required by

--- a/crates/scp-ffi/napi/src/tools.rs
+++ b/crates/scp-ffi/napi/src/tools.rs
@@ -664,48 +664,40 @@ pub struct NapiSagaResult {
 }
 
 /// Maps a `SagaError` terminal (the typed §6.2.4 terminal space) onto the
-/// bridge's typed saga error variants, reading every structured datum
-/// STRUCTURALLY off the variant — never by re-parsing a message string.
+/// bridge's typed saga error variants.
 ///
-/// - `Aborted { reason, code, message }` → [`ScpNapiError::SagaAborted`].
-///   `retry_after_ms` is read directly off `SagaAbortReason::RateLimited` (an
-///   `Option<u64>`); a plain `Rejected` carries `None`. `None` is propagated,
-///   NEVER coerced to `0` (a `0` would read as "retry immediately" and re-trip
-///   the same hard limit). `code` is formatted as the canonical
-///   `SCP-SAGA-{code}` string from the numeric discriminant.
-/// - `NeedsRepair { saga_id, message }` → [`ScpNapiError::SagaNeedsRepair`]
-///   carrying the durable operator-repair handle (`SCP-SAGA-13065`).
-/// - `Busy { contended_context, message }` → [`ScpNapiError::SagaBusy`]
-///   (`SCP-SAGA-13066`).
+/// The decomposition — the `SagaAbortReason::RateLimited → Option<u64>` read,
+/// the `None`-never-coerced-to-`0` rule, and the `SCP-SAGA-{code}` formatting —
+/// lives ONCE in [`scp_ffi_common::saga_errors::decompose_saga_error`], unit-
+/// tested there, so the three bridges cannot drift. This function is the thin
+/// per-bridge tail that carries the napi-rs field labels (`message:`); the
+/// machine-parseable `(retry_after_ms=…)` / `(saga_id=…)` /
+/// `(contended_context=…)` message suffix the TS wrapper reverses is encoded by
+/// the `#[error(...)]` Display impl on [`ScpNapiError`], with `retry_after_ms`
+/// rendered as a literal `null` when `None` (never `0`):
+///
+/// - `Aborted` → [`ScpNapiError::SagaAborted`] (`retry_after_ms`, `None` never
+///   `0`, `SCP-SAGA-{code}`).
+/// - `NeedsRepair` → [`ScpNapiError::SagaNeedsRepair`] (durable repair handle,
+///   `SCP-SAGA-13065`).
+/// - `Busy` → [`ScpNapiError::SagaBusy`] (`SCP-SAGA-13066`).
 fn map_saga_error(err: scp_core::context::supervisor::SagaError) -> ScpNapiError {
-    use scp_core::context::supervisor::{SagaAbortReason, SagaError};
-    match err {
-        SagaError::Aborted {
-            reason,
-            code,
-            message,
-        } => {
-            let retry_after_ms = match reason {
-                SagaAbortReason::RateLimited { retry_after_ms } => retry_after_ms,
-                SagaAbortReason::Rejected => None,
-            };
-            ScpNapiError::SagaAborted {
-                message,
-                code: format!("SCP-SAGA-{code}"),
-                retry_after_ms,
-            }
-        }
-        SagaError::NeedsRepair { saga_id, message } => ScpNapiError::SagaNeedsRepair {
-            message,
-            code: codes::SAGA_13065.to_owned(),
-            saga_id: saga_id.0,
+    use scp_ffi_common::saga_errors::{SagaErrorKind, decompose_saga_error};
+    let parts = decompose_saga_error(err);
+    match parts.kind {
+        SagaErrorKind::Aborted { retry_after_ms } => ScpNapiError::SagaAborted {
+            message: parts.message,
+            code: parts.code,
+            retry_after_ms,
         },
-        SagaError::Busy {
-            contended_context,
-            message,
-        } => ScpNapiError::SagaBusy {
-            message,
-            code: codes::SAGA_13066.to_owned(),
+        SagaErrorKind::NeedsRepair { saga_id } => ScpNapiError::SagaNeedsRepair {
+            message: parts.message,
+            code: parts.code,
+            saga_id,
+        },
+        SagaErrorKind::Busy { contended_context } => ScpNapiError::SagaBusy {
+            message: parts.message,
+            code: parts.code,
             contended_context,
         },
     }
@@ -1631,31 +1623,36 @@ mod tests {
     // ------------------------------------------------------------------
     // map_saga_error — the bridge's typed-terminal → typed-error mapping.
     //
-    // The producer's actual terminal behavior (which SagaError a given saga
-    // run yields) is covered by the Committed e2e test below and in
-    // `scp-runtime`; here we test ONLY the bridge's mapping responsibility:
-    // that each typed `SagaError` becomes the right `ScpNapiError` variant with
-    // EVERY structured datum preserved STRUCTURALLY (read off the variant, never
-    // parsed from a message) and the canonical `SCP-SAGA-13xxx` code attached.
+    // The classification itself (the `RateLimited → Option<u64>` read, the
+    // `None`-never-`0` rule, the `SCP-SAGA-{code}` formatting, the fixed
+    // terminal codes) lives in `scp_ffi_common::saga_errors` and is unit-tested
+    // there for all three bridges. The producer's actual terminal behavior is
+    // covered by the Committed e2e test below and in `scp-runtime`. Here we
+    // test ONLY this bridge's thin tail: that each `SagaErrorKind` routes
+    // through `common` onto the right `ScpNapiError` variant, AND the
+    // napi-specific message-suffix Display encoding — the load-bearing
+    // `(retry_after_ms=null)` rendering for a `None` hint (never `0`) that the
+    // TS wrapper reverses, which `common` does not exercise.
     // ------------------------------------------------------------------
 
     use scp_core::context::supervisor::{
         SagaAbortReason, SagaError as CoreSagaError, SagaId as CoreSagaId,
     };
 
-    /// A rate-limited abort preserves `retry_after_ms = Some(ms)` STRUCTURALLY
-    /// and formats the producer's numeric `code` as the canonical
-    /// `SCP-SAGA-{code}` string.
+    /// `Aborted` routes through `common` onto `ScpNapiError::SagaAborted` with
+    /// the `SCP-SAGA-{code}` string and `retry_after_ms` carried structurally;
+    /// a `None` back-off hint stays `None` (never `Some(0)`) AND renders as the
+    /// literal `(retry_after_ms=null)` suffix the TS wrapper reverses.
     #[test]
-    fn map_saga_error_rate_limited_preserves_retry_after_ms() {
-        let mapped = map_saga_error(CoreSagaError::Aborted {
+    fn map_saga_error_aborted_routes_through_common_with_null_suffix() {
+        let some = map_saga_error(CoreSagaError::Aborted {
             reason: SagaAbortReason::RateLimited {
                 retry_after_ms: Some(2500),
             },
             code: 13026,
             message: "inbound rate limit exceeded".to_owned(),
         });
-        match mapped {
+        match some {
             ScpNapiError::SagaAborted {
                 code,
                 retry_after_ms,
@@ -1666,80 +1663,47 @@ mod tests {
             }
             other => panic!("expected SagaAborted, got {other:?}"),
         }
-    }
 
-    /// A rate-limited abort with NO precise back-off instant preserves
-    /// `retry_after_ms = None` — NEVER coerced to `Some(0)` — and renders the
-    /// message suffix as a literal `null` (a `0` would read as "retry
-    /// immediately" and re-trip the same hard limit).
-    #[test]
-    fn map_saga_error_rate_limited_none_is_not_zero() {
-        let mapped = map_saga_error(CoreSagaError::Aborted {
+        let none = map_saga_error(CoreSagaError::Aborted {
             reason: SagaAbortReason::RateLimited {
                 retry_after_ms: None,
             },
             code: 13026,
             message: "hard limit, no precise back-off".to_owned(),
         });
-        match &mapped {
+        match &none {
             ScpNapiError::SagaAborted { retry_after_ms, .. } => {
                 assert_eq!(*retry_after_ms, None, "None must NOT be coerced to Some(0)");
             }
             other => panic!("expected SagaAborted, got {other:?}"),
         }
         assert!(
-            mapped.to_string().contains("(retry_after_ms=null)"),
-            "None retry_after_ms must render as the literal `null`, not 0: {mapped}"
+            none.to_string().contains("(retry_after_ms=null)"),
+            "None retry_after_ms must render as the literal `null`, not 0: {none}"
         );
     }
 
-    /// A plain (non-rate-limit) `Rejected` abort carries `retry_after_ms = None`.
+    /// `NeedsRepair` / `Busy` route through `common` onto their napi-rs variants
+    /// with the fixed terminal codes and per-terminal datum carried.
     #[test]
-    fn map_saga_error_rejected_has_no_retry_hint() {
-        let mapped = map_saga_error(CoreSagaError::Aborted {
-            reason: SagaAbortReason::Rejected,
-            code: 13050,
-            message: "caller not a member".to_owned(),
-        });
-        match mapped {
-            ScpNapiError::SagaAborted {
-                code,
-                retry_after_ms,
-                ..
-            } => {
-                assert_eq!(code, "SCP-SAGA-13050");
-                assert_eq!(retry_after_ms, None);
-            }
-            other => panic!("expected SagaAborted, got {other:?}"),
-        }
-    }
-
-    /// `NeedsRepair` preserves the durable `saga_id` operator-repair handle and
-    /// the fixed terminal code `SCP-SAGA-13065`.
-    #[test]
-    fn map_saga_error_needs_repair_preserves_saga_id() {
-        let mapped = map_saga_error(CoreSagaError::NeedsRepair {
+    fn map_saga_error_needs_repair_and_busy_route_through_common() {
+        let repair = map_saga_error(CoreSagaError::NeedsRepair {
             saga_id: CoreSagaId("saga-abc-123".to_owned()),
             message: "commit retries exhausted".to_owned(),
         });
-        match mapped {
+        match repair {
             ScpNapiError::SagaNeedsRepair { code, saga_id, .. } => {
                 assert_eq!(code, codes::SAGA_13065);
                 assert_eq!(saga_id, "saga-abc-123");
             }
             other => panic!("expected SagaNeedsRepair, got {other:?}"),
         }
-    }
 
-    /// `Busy` preserves the contended context id and the fixed terminal code
-    /// `SCP-SAGA-13066`.
-    #[test]
-    fn map_saga_error_busy_preserves_contended_context() {
-        let mapped = map_saga_error(CoreSagaError::Busy {
+        let busy = map_saga_error(CoreSagaError::Busy {
             contended_context: "ctx-shared-99".to_owned(),
             message: "participant set overlaps an in-flight saga".to_owned(),
         });
-        match mapped {
+        match busy {
             ScpNapiError::SagaBusy {
                 code,
                 contended_context,

--- a/crates/scp-ffi/napi/src/tools.rs
+++ b/crates/scp-ffi/napi/src/tools.rs
@@ -2245,4 +2245,116 @@ mod tests {
              message), got: {msg}"
         );
     }
+
+    /// (a, axis-isolated) Caller-principal binding, hosted-here axis as the SOLE
+    /// guard: a `caller_did` that IS a genuine member of `caller_context_id` (so
+    /// the membership axis (b) would PASS) but is NOT an identity hosted by this
+    /// bridge instance is STILL rejected with `SagaAborted` (SCP-SAGA-13050)
+    /// BEFORE the saga runs.
+    ///
+    /// This is the property `xctx_saga_unhosted_caller_rejected_before_saga`
+    /// cannot prove: that test's caller is BOTH unhosted AND a non-member, so
+    /// axis (b) (and the producer's gate 1) would reject it even if axis (a) were
+    /// deleted. Here the caller is inserted as a real member of `caller_ctx` via
+    /// `Supervisor::test_insert_member` (the actor-state membership injection
+    /// that bypasses the MLS Welcome a non-hosted DID could never complete), so
+    /// `supervisor.is_member` returns true and axis (b) passes the caller. The
+    /// ONLY thing that can reject it is axis (a): the caller DID was never
+    /// `identity_create`'d, so it is absent from this instance's identity
+    /// registry. The test therefore fails closed iff the bridge's
+    /// `identity_registry_contains` axis (a) check is removed, and is INDEPENDENT
+    /// of axis (b) by construction.
+    #[cfg(feature = "allow_in_memory_custody")]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn xctx_saga_member_but_unhosted_caller_rejected_by_hosted_axis() {
+        let scp = crate::scp::Scp::new_in_memory_for_test();
+        let bi = std::sync::Arc::clone(&scp.inner);
+
+        // `owner` is a hosted identity used only to create the contexts.
+        let owner_identity = scp
+            .identity_create("in_memory".to_owned(), None)
+            .await
+            .expect("identity_create should succeed");
+
+        let handle_a = create_saga_context(&bi, &owner_identity).await;
+        let handle_b = create_saga_context(&bi, &owner_identity).await;
+        let ctx_a = handle_a.context_id();
+        let tool_id = scp_ffi_common::tool_id::generate_tool_id("xctx_saga_member_unhosted_probe");
+
+        // The caller is a syntactically valid DID that is NEVER `identity_create`'d
+        // (so the bridge's identity registry does NOT host it — axis (a) must
+        // reject), yet is injected as a genuine member of `caller_ctx` via the
+        // actor-state membership path (so `supervisor.is_member` returns true and
+        // axis (b) passes). `test_insert_member` is the test-only injection that
+        // records the member into role state exactly as an executed `AddMember`
+        // would, without the MLS Welcome a non-hosted DID could never complete.
+        let member_but_unhosted_caller = "did:dht:z6MkMemberButUnhostedCaller001".to_owned();
+        let supervisor = crate::runtime::supervisor(&bi).expect("supervisor must be initialized");
+        supervisor
+            .test_insert_member(
+                &ctx_a,
+                scp_identity::DID(member_but_unhosted_caller.clone()),
+                "member",
+            )
+            .await
+            .expect("test_insert_member should record the caller into caller_ctx membership");
+
+        // Precondition: the supervisor MUST see the caller as a member of
+        // `caller_ctx` (axis (b) passes), while the bridge's identity registry
+        // does NOT host it (axis (a) is the sole remaining guard).
+        assert!(
+            supervisor
+                .is_member(&ctx_a, &member_but_unhosted_caller)
+                .await,
+            "precondition: caller must be a genuine member of caller_ctx so axis (b) passes"
+        );
+        assert!(
+            !crate::runtime::identity_registry_contains(&bi, &member_but_unhosted_caller),
+            "precondition: caller must NOT be hosted so axis (a) is the sole guard"
+        );
+
+        let now_ms = u64::try_from(
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_millis(),
+        )
+        .unwrap();
+
+        // `NapiSagaResult` is not `Debug`, so destructure the `Err` terminal
+        // explicitly rather than `expect_err`.
+        let Err(err) = Box::pin(tool_invoke_cross_context_saga_on(
+            &bi,
+            &handle_a,
+            &handle_b,
+            member_but_unhosted_caller, // member of caller_ctx, but NOT hosted
+            tool_id,
+            r#"{"a":"x","b":"y"}"#.to_owned(),
+            "0123456789abcdef0123456789abcdef".to_owned(),
+            now_ms,
+            1,
+            None,
+        ))
+        .await
+        else {
+            panic!("a member-but-unhosted caller must be rejected by axis (a) before the saga runs")
+        };
+
+        let msg = format!("{err}");
+        assert!(
+            msg.contains(codes::SAGA_13050),
+            "expected caller-axis SCP-SAGA-13050, got: {msg}"
+        );
+        // BRIDGE-UNIQUE axis-(a) substring. Because the caller IS a member, the
+        // membership axis (b) and the producer's gate 1 would BOTH pass — so the
+        // axis-(b) message ("is hosted by this bridge but is not a member of") can
+        // never appear here. The ONLY rejection that fits is axis (a). Asserting
+        // its exact substring makes this test fail closed iff
+        // `enforce_caller_principal_binding`'s `identity_registry_contains` check
+        // is removed.
+        assert!(
+            msg.contains("is not an identity hosted by this bridge instance"),
+            "message must be the BRIDGE axis-(a) hosted-here rejection, got: {msg}"
+        );
+    }
 }

--- a/crates/scp-ffi/napi/src/tools.rs
+++ b/crates/scp-ffi/napi/src/tools.rs
@@ -1971,4 +1971,182 @@ mod tests {
         assert_eq!(out["sum"], 42, "committed output sum must be the handler's");
         assert_eq!(out["ok"], 1, "committed output ok must be the handler's");
     }
+
+    // ------------------------------------------------------------------
+    // Caller-principal binding (§6.2.4 *Caller authentication*) — the two
+    // axes `enforce_caller_principal_binding` enforces at the NAPI seam,
+    // BEFORE the saga runs. These are the behavioral counterparts of the
+    // PyO3 `e2e_bridge.rs` axis-(a)/axis-(b) tests.
+    //
+    // MUTATION-RESISTANCE: the producer's own gate 1 ALSO rejects a
+    // non-member caller with SCP-SAGA-13050. Asserting only the code (as the
+    // TS addon test does) would PASS even if this bridge's binding were
+    // removed — the producer would surface 13050 anyway. So each test asserts
+    // the BRIDGE-UNIQUE message substring that `enforce_caller_principal_binding`
+    // emits and the producer never does:
+    //   axis (a): "is not an identity hosted by this bridge instance"
+    //   axis (b): "is hosted by this bridge but is not a member of"
+    // The producer's gate-1 message is "... is not a member of caller context
+    // '...' — not authorized to initiate over it", which contains neither.
+    // ------------------------------------------------------------------
+
+    /// Creates an ephemeral single-admin context owned by `owner_identity` whose
+    /// ceiling carries the saga-relevant capabilities. Mirrors the e2e setup but
+    /// without the tool/interface wiring the two binding-rejection tests never
+    /// reach (they abort at the caller gate before the producer runs).
+    #[cfg(feature = "allow_in_memory_custody")]
+    async fn create_saga_context(
+        bi: &std::sync::Arc<crate::runtime::NapiBridgeInstance>,
+        owner_identity: &crate::identity::NapiIdentity,
+    ) -> crate::context::NapiContextHandle {
+        let params = serde_json::json!({
+            "ceiling": [
+                "governance:propose",
+                "tool:interface",
+                "tool:register",
+                "tools:invoke",
+                "messages:read",
+                "messages:write"
+            ],
+            "governance": "single_admin",
+            "memoryScope": "ephemeral",
+        })
+        .to_string();
+        crate::context::context_create_on(bi, owner_identity, params)
+            .await
+            .expect("context_create should succeed")
+    }
+
+    /// (a) Caller-principal binding, hosted axis: a `caller_did` this bridge
+    /// instance does NOT host is rejected with `SagaAborted` (SCP-SAGA-13050)
+    /// BEFORE the saga runs. Asserts the bridge-unique axis-(a) substring so the
+    /// test fails if `enforce_caller_principal_binding`'s registry check is
+    /// removed (the producer's gate-1 message never carries this phrasing).
+    #[cfg(feature = "allow_in_memory_custody")]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn xctx_saga_unhosted_caller_rejected_before_saga() {
+        let scp = crate::scp::Scp::new_in_memory_for_test();
+        let bi = std::sync::Arc::clone(&scp.inner);
+
+        let owner_identity = scp
+            .identity_create("in_memory".to_owned(), None)
+            .await
+            .expect("identity_create should succeed");
+
+        let handle_a = create_saga_context(&bi, &owner_identity).await;
+        let handle_b = create_saga_context(&bi, &owner_identity).await;
+        let tool_id = scp_ffi_common::tool_id::generate_tool_id("xctx_saga_unhosted_probe");
+
+        // A syntactically valid DID that was never created on this instance.
+        let unhosted_caller = "did:dht:z6MkUnhostedCallerPrincipal0001".to_owned();
+
+        let now_ms = u64::try_from(
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_millis(),
+        )
+        .unwrap();
+
+        // `NapiSagaResult` is not `Debug`, so destructure the `Err` terminal
+        // explicitly rather than `expect_err`.
+        let Err(err) = Box::pin(tool_invoke_cross_context_saga_on(
+            &bi,
+            &handle_a,
+            &handle_b,
+            unhosted_caller,
+            tool_id,
+            r#"{"a":"x","b":"y"}"#.to_owned(),
+            "0123456789abcdef0123456789abcdef".to_owned(),
+            now_ms,
+            1,
+            None,
+        ))
+        .await
+        else {
+            panic!("an unhosted caller_did must be rejected before the saga runs")
+        };
+
+        let msg = format!("{err}");
+        assert!(
+            msg.contains(codes::SAGA_13050),
+            "expected caller-axis SCP-SAGA-13050, got: {msg}"
+        );
+        // BRIDGE-UNIQUE axis-(a) substring — the producer never emits it.
+        assert!(
+            msg.contains("is not an identity hosted by this bridge instance"),
+            "message must be the BRIDGE axis-(a) hosted-principal rejection (not a producer \
+             message), got: {msg}"
+        );
+    }
+
+    /// (b) Caller-principal binding, membership axis: a `caller_did` that IS
+    /// hosted by this bridge but is NOT a member of `caller_context_id` is
+    /// rejected with `SagaAborted` (SCP-SAGA-13050) BEFORE the saga runs. Asserts
+    /// the bridge-unique axis-(b) substring so the test fails if the bridge's
+    /// `is_member` check is removed — the producer's gate-1 message shares only
+    /// the bare "not a member of" phrasing, not this prefix.
+    #[cfg(feature = "allow_in_memory_custody")]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn xctx_saga_hosted_non_member_caller_rejected() {
+        let scp = crate::scp::Scp::new_in_memory_for_test();
+        let bi = std::sync::Arc::clone(&scp.inner);
+
+        let owner_identity = scp
+            .identity_create("in_memory".to_owned(), None)
+            .await
+            .expect("identity_create should succeed");
+
+        // A SECOND hosted identity that is NOT a member of the caller context.
+        let stranger_identity = scp
+            .identity_create("in_memory".to_owned(), None)
+            .await
+            .expect("identity_create should succeed");
+        let stranger = stranger_identity.inner.did.clone();
+
+        // Contexts created by `owner` ⇒ `stranger` is hosted but not a member.
+        let handle_a = create_saga_context(&bi, &owner_identity).await;
+        let handle_b = create_saga_context(&bi, &owner_identity).await;
+        let tool_id = scp_ffi_common::tool_id::generate_tool_id("xctx_saga_nonmember_probe");
+
+        let now_ms = u64::try_from(
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_millis(),
+        )
+        .unwrap();
+
+        // `NapiSagaResult` is not `Debug`, so destructure the `Err` terminal
+        // explicitly rather than `expect_err`.
+        let Err(err) = Box::pin(tool_invoke_cross_context_saga_on(
+            &bi,
+            &handle_a,
+            &handle_b,
+            stranger, // hosted, but not a member of caller context A
+            tool_id,
+            r#"{"a":"x","b":"y"}"#.to_owned(),
+            "0123456789abcdef0123456789abcdef".to_owned(),
+            now_ms,
+            1,
+            None,
+        ))
+        .await
+        else {
+            panic!("a hosted non-member caller must be rejected before the saga runs")
+        };
+
+        let msg = format!("{err}");
+        assert!(
+            msg.contains(codes::SAGA_13050),
+            "expected caller-axis SCP-SAGA-13050, got: {msg}"
+        );
+        // BRIDGE-UNIQUE axis-(b) substring — the producer's gate-1 message
+        // carries only the bare "not a member of" phrasing, not this prefix.
+        assert!(
+            msg.contains("is hosted by this bridge but is not a member of"),
+            "message must be the BRIDGE axis-(b) membership rejection (not the producer gate-1 \
+             message), got: {msg}"
+        );
+    }
 }

--- a/crates/scp-ffi/napi/src/tools.rs
+++ b/crates/scp-ffi/napi/src/tools.rs
@@ -635,6 +635,381 @@ pub(crate) async fn tool_invoke_cross_context_on(
 }
 
 // ---------------------------------------------------------------------------
+// Cross-context tool-invocation saga (§6.2.4, ADR-049 §3a)
+// ---------------------------------------------------------------------------
+
+/// The committed terminal of a §6.2.4 cross-context tool-invocation saga.
+///
+/// Returned by [`Scp::tool_invoke_cross_context_saga`](crate::scp::Scp) on a
+/// `Committed` terminal. Every NON-committed terminal rejects the Promise with
+/// a typed saga error (`SagaAborted` / `SagaNeedsRepair` / `SagaBusy`) instead.
+///
+/// Carries the supervisor-minted `saga_id` plus — for the committed
+/// cross-context invocation — the target's signed receipt and the captured
+/// tool output (spec §6.2.4 "Receipt / response return path"). The `receipt`
+/// is the JCS-canonical `CrossContextToolReceipt` bytes; `output` is the
+/// receipt's canonical `output_jcs` bytes (the exact bytes the caller side
+/// recorded a hash of). Both are surfaced as JS `Buffer` so a caller can verify
+/// the receipt signature and recompute `output_hash` without a re-serialization
+/// step.
+#[napi(object)]
+pub struct NapiSagaResult {
+    /// The durable saga identifier (supervisor-minted, never a caller input).
+    pub saga_id: String,
+    /// The target's signed `CrossContextToolReceipt` bytes (JCS), or `None`.
+    pub receipt: Option<napi::bindgen_prelude::Buffer>,
+    /// The captured tool output bytes (the receipt's canonical `output_jcs`),
+    /// or `None`.
+    pub output: Option<napi::bindgen_prelude::Buffer>,
+}
+
+/// Maps a `SagaError` terminal (the typed §6.2.4 terminal space) onto the
+/// bridge's typed saga error variants, reading every structured datum
+/// STRUCTURALLY off the variant — never by re-parsing a message string.
+///
+/// - `Aborted { reason, code, message }` → [`ScpNapiError::SagaAborted`].
+///   `retry_after_ms` is read directly off `SagaAbortReason::RateLimited` (an
+///   `Option<u64>`); a plain `Rejected` carries `None`. `None` is propagated,
+///   NEVER coerced to `0` (a `0` would read as "retry immediately" and re-trip
+///   the same hard limit). `code` is formatted as the canonical
+///   `SCP-SAGA-{code}` string from the numeric discriminant.
+/// - `NeedsRepair { saga_id, message }` → [`ScpNapiError::SagaNeedsRepair`]
+///   carrying the durable operator-repair handle (`SCP-SAGA-13065`).
+/// - `Busy { contended_context, message }` → [`ScpNapiError::SagaBusy`]
+///   (`SCP-SAGA-13066`).
+fn map_saga_error(err: scp_core::context::supervisor::SagaError) -> ScpNapiError {
+    use scp_core::context::supervisor::{SagaAbortReason, SagaError};
+    match err {
+        SagaError::Aborted {
+            reason,
+            code,
+            message,
+        } => {
+            let retry_after_ms = match reason {
+                SagaAbortReason::RateLimited { retry_after_ms } => retry_after_ms,
+                SagaAbortReason::Rejected => None,
+            };
+            ScpNapiError::SagaAborted {
+                message,
+                code: format!("SCP-SAGA-{code}"),
+                retry_after_ms,
+            }
+        }
+        SagaError::NeedsRepair { saga_id, message } => ScpNapiError::SagaNeedsRepair {
+            message,
+            code: codes::SAGA_13065.to_owned(),
+            saga_id: saga_id.0,
+        },
+        SagaError::Busy {
+            contended_context,
+            message,
+        } => ScpNapiError::SagaBusy {
+            message,
+            code: codes::SAGA_13066.to_owned(),
+            contended_context,
+        },
+    }
+}
+
+/// Resolves the Active Signing Key the supervisor saga signs under for a
+/// co-resident context owned by `creator_did` — exported via the shared
+/// callback/in-memory custody path. The caller and target each resolve to their
+/// OWN creator's key so the receipt (target-signed) and each side's divergence
+/// marker (own-signed) are signed under the correct per-context Active Signing
+/// Key (spec §6.2.4 "Signer authorization": the receipt key MUST be the one
+/// authorized to act for `target_context_id`).
+///
+/// `creator_did` is read off the context HANDLE (`creator_did()`), the
+/// authoritative owner the handle was minted with — not via the UCAN-state
+/// registry, which a freshly-created context only populates lazily on its first
+/// UCAN/tool call. `context_id` is carried only for the error message.
+async fn resolve_context_signing_key(
+    bi: &crate::runtime::NapiBridgeInstance,
+    creator_did: &str,
+    context_id: &str,
+) -> napi::Result<ed25519_dalek::SigningKey> {
+    let (custody, key_handle) = crate::runtime::with_identity(bi, creator_did, |entry| {
+        Ok((entry.custody.clone(), entry.identity.active_signing_key))
+    })
+    .map_err(napi::Error::from)?;
+    custody
+        .export_ed25519_signing_key(&key_handle)
+        .await
+        .map_err(|e| {
+            napi::Error::from(ScpNapiError::Crypto {
+                message: format!(
+                    "cannot export the Active Signing Key for context '{context_id}' \
+                     (owner '{creator_did}') — a cross-context saga signs the receipt and \
+                     divergence markers with each context's own key: {e}"
+                ),
+                code: codes::CRYPTO_4001.to_owned(),
+            })
+        })
+}
+
+/// Decodes the §6.2.4 envelope nonce from its canonical 32-char hex form into
+/// the 16-byte value, FAIL-CLOSED.
+///
+/// The nonce is a 16-byte value carried as a hex string — the one canonical
+/// wire form (§6.2.4 wire envelope). Any other length is a malformed envelope,
+/// NOT a "pad it" situation. Both failure modes surface as a validation error.
+fn decode_asserted_nonce(asserted_nonce_hex: &str) -> napi::Result<[u8; 16]> {
+    let bytes = hex::decode(asserted_nonce_hex).map_err(|e| {
+        napi::Error::from(ScpNapiError::Validation {
+            message: format!(
+                "asserted_nonce_hex is not valid hex: {e} — supply the 16-byte §6.2.4 envelope \
+                 nonce as a 32-char lowercase-hex string"
+            ),
+            code: codes::VALID_7001.to_owned(),
+        })
+    })?;
+    <[u8; 16]>::try_from(bytes.as_slice()).map_err(|_| {
+        napi::Error::from(ScpNapiError::Validation {
+            message: format!(
+                "asserted_nonce_hex must decode to exactly 16 bytes (32 hex chars), got {} bytes",
+                bytes.len()
+            ),
+            code: codes::VALID_7001.to_owned(),
+        })
+    })
+}
+
+/// Enforces the §6.2.4 *Caller authentication* binding (normative — §6.2.4 +
+/// ADR-049 §3a) BEFORE the saga runs.
+///
+/// `caller_did` / `caller_context_id` MUST be the channel-authenticated
+/// identity of the transport leg, never an envelope-asserted free value. For
+/// the co-resident NAPI bridge the "channel-authenticated principal" is an
+/// identity THIS bridge instance hosts — one present in its per-instance
+/// identity registry (populated only by the identity-creation paths on this
+/// instance). Both axes are enforced here:
+///
+///   (a) `caller_did` is hosted/authenticated by this bridge instance, AND
+///   (b) `caller_did` is a member of the named `caller_context_id`.
+///
+/// A mismatch on either axis ⇒ a typed `Rejected`-flavored `SagaAborted` (the
+/// §6.2.4 "mismatch ⇒ Rejected" terminal), carrying the registered caller-axis
+/// code `SCP-SAGA-13050`. The supervisor's own gate 1 ALSO checks membership,
+/// but membership alone is necessary-not-sufficient (it does not prove the
+/// request leg is authenticated AS that member) — so axis (a) is the
+/// load-bearing addition this seam contributes. Enforcing here, before the
+/// entry point, also means the saga never observes an unauthenticated caller.
+async fn enforce_caller_principal_binding(
+    bi: &crate::runtime::NapiBridgeInstance,
+    supervisor: &std::sync::Arc<scp_core::context::supervisor::Supervisor>,
+    caller_context_id: &str,
+    caller_did: &str,
+) -> napi::Result<()> {
+    if !crate::runtime::identity_registry_contains(bi, caller_did) {
+        return Err(ScpNapiError::SagaAborted {
+            message: format!(
+                "caller_did '{caller_did}' is not an identity hosted by this bridge instance — \
+                 a cross-context saga's caller MUST be the channel-authenticated principal (an \
+                 identity created on this instance), not an envelope-asserted value (§6.2.4 \
+                 Caller authentication)"
+            ),
+            code: codes::SAGA_13050.to_owned(),
+            retry_after_ms: None,
+        }
+        .into());
+    }
+
+    if !supervisor.is_member(caller_context_id, caller_did).await {
+        return Err(ScpNapiError::SagaAborted {
+            message: format!(
+                "caller_did '{caller_did}' is hosted by this bridge but is not a member of \
+                 caller_context_id '{caller_context_id}' — not authorized to initiate a \
+                 cross-context saga over it (§6.2.4 Caller authentication)"
+            ),
+            code: codes::SAGA_13050.to_owned(),
+            retry_after_ms: None,
+        }
+        .into());
+    }
+    Ok(())
+}
+
+/// Per-bridge-instance implementation of the §6.2.4 cross-context
+/// tool-invocation saga export.
+///
+/// See [`Scp::tool_invoke_cross_context_saga`](crate::scp::Scp) for the full
+/// contract. The flow is, in order:
+///
+/// 1. **Validate inputs** (active handles; well-formed ids/dids/tool-id; the
+///    nonce decodes to `[u8; 16]`, fail-closed on a wrong length).
+/// 2. **Caller-principal binding (§6.2.4 *Caller authentication*, normative).**
+///    `caller_did` MUST be an identity THIS bridge instance hosts AND a member
+///    of `caller_context_id`. A mismatch ⇒ a typed `Rejected`-flavored
+///    `SagaAborted` BEFORE the saga runs. `nonce` / `timestamp` / `chain_depth`
+///    REMAIN caller-supplied freshness fields (the target validates them).
+/// 3. **Chokepoint (ADR-056).** Convert the caller/target id STRINGS → `[u8; 32]`
+///    via `scp_core::context::state::context_id_to_bytes` (decode-64-hex-else-
+///    SHA256). Raw `Sha256` of a 64-hex id would double-hash and miss the actor.
+/// 4. **Signing keys.** Resolve each co-resident context's Active Signing Key
+///    via the context's `creator_did`.
+/// 5. **Executor.** Snapshot the TARGET context's tool handler and build the
+///    `move |input| async {…}` closure the supervisor runs at Commit-B (echo
+///    fallback when no handler is registered, matching the synchronous path).
+/// 6. Await the producer; map the terminal `SagaError` → typed bridge error,
+///    `Committed` → [`NapiSagaResult`].
+#[allow(clippy::too_many_arguments)] // Flat §6.2.4 envelope — agent-first named params, no builder.
+pub(crate) async fn tool_invoke_cross_context_saga_on(
+    bi: &crate::runtime::NapiBridgeInstance,
+    source_handle: &NapiContextHandle,
+    target_handle: &NapiContextHandle,
+    caller_did: String,
+    tool_registration_id: String,
+    input_json: String,
+    asserted_nonce_hex: String,
+    asserted_timestamp_ms: u64,
+    asserted_chain_depth: u8,
+    ucan_proof_id: Option<String>,
+) -> napi::Result<NapiSagaResult> {
+    use scp_core::context::supervisor::{CrossContextToolInvocationRequest, SagaSigningKeys};
+
+    crate::napi_check_handle!(&bi.core, source_handle, target_handle);
+
+    let source_state = source_handle.state()?;
+    if source_state != "active" {
+        return Err(ScpNapiError::Tool {
+            message: format!(
+                "cannot start cross-context saga: caller context in {source_state:?} state"
+            ),
+            code: codes::TOOL_6010.to_owned(),
+        }
+        .into());
+    }
+    let target_state = target_handle.state()?;
+    if target_state != "active" {
+        return Err(ScpNapiError::Tool {
+            message: format!(
+                "cannot start cross-context saga: target context in {target_state:?} state"
+            ),
+            code: codes::TOOL_6011.to_owned(),
+        }
+        .into());
+    }
+
+    let caller_context_id = source_handle.context_id();
+    let target_context_id = target_handle.context_id();
+    let caller_creator_did = source_handle.creator_did();
+    let target_creator_did = target_handle.creator_did();
+
+    scp_ffi_common::validate::validate_context_id(&caller_context_id)
+        .map_err(|e| napi::Error::from(ScpNapiError::from(e)))?;
+    scp_ffi_common::validate::validate_context_id(&target_context_id)
+        .map_err(|e| napi::Error::from(ScpNapiError::from(e)))?;
+    validate_did(&caller_did).map_err(|e| napi::Error::from(ScpNapiError::from(e)))?;
+    validate_tool_id(&tool_registration_id)
+        .map_err(|e| napi::Error::from(ScpNapiError::from(e)))?;
+
+    let asserted_nonce = decode_asserted_nonce(&asserted_nonce_hex)?;
+    let input_value: serde_json::Value = serde_json::from_str(&input_json).map_err(|e| {
+        napi::Error::from(ScpNapiError::Tool {
+            message: format!("invalid input JSON: {e}"),
+            code: codes::TOOL_6002.to_owned(),
+        })
+    })?;
+
+    // Caller-principal binding (§6.2.4 *Caller authentication*) — BEFORE the
+    // saga runs, so the supervisor never observes an unauthenticated caller.
+    let supervisor = crate::runtime::supervisor(bi)?;
+    enforce_caller_principal_binding(bi, supervisor, &caller_context_id, &caller_did).await?;
+
+    // ----- Chokepoint (ADR-056): id STRING → [u8; 32] ------------------------
+    //
+    // MANDATORY: convert via the canonical cross-crate keying resolver, which
+    // decodes a real 64-hex id rather than re-hashing it. The producer does
+    // `hex::encode(wire)` for actor lookup, so a raw SHA-256 of a 64-hex id
+    // here would double-hash and key the wrong (non-existent) actor slot,
+    // surfacing as a spurious ContextNotRegistered abort.
+    let caller_context_bytes = scp_core::context::state::context_id_to_bytes(&caller_context_id);
+    let target_context_bytes = scp_core::context::state::context_id_to_bytes(&target_context_id);
+
+    // ----- Signing keys: each context's Active Signing Key -------------------
+    let target_signing_key =
+        resolve_context_signing_key(bi, &target_creator_did, &target_context_id).await?;
+    let caller_signing_key =
+        resolve_context_signing_key(bi, &caller_creator_did, &caller_context_id).await?;
+
+    // ----- Executor: snapshot the TARGET context's tool handler --------------
+    //
+    // Snapshot the registered handler closure (an `Arc<dyn Fn>` — cloning is a
+    // refcount bump) OUTSIDE the runtime call, then move it into the `FnOnce`
+    // executor the supervisor runs supervisor-side at Commit-B (off the actor
+    // mailbox). Falls back to a schema-only echo when no handler is registered,
+    // matching the synchronous cross-context path. A target context with no
+    // FFI-side UCAN/tool state yet registered (the lazy registry is unpopulated
+    // until its first tool/UCAN call) likewise carries no handler ⇒ echo. The
+    // supervisor validates the output against the tool's registered output
+    // schema at Commit-B, so the executor only produces the value.
+    let handler = crate::runtime::with_context(bi, &target_context_id, |rt| {
+        Ok(rt.tool_handlers.get(&tool_registration_id).cloned())
+    })
+    .unwrap_or(None);
+    let tool_id_for_echo = tool_registration_id.clone();
+    let target_ctx_for_echo = target_context_id.clone();
+    let caller_did_for_echo = caller_did.clone();
+    let executor = move |value: serde_json::Value| {
+        let handler = handler.clone();
+        let echo_input = value.clone();
+        async move {
+            handler.map_or_else(
+                || {
+                    Ok(serde_json::json!({
+                        "tool": tool_id_for_echo,
+                        "target_context": target_ctx_for_echo,
+                        "caller_did": caller_did_for_echo,
+                        "status": "validated",
+                        "input_valid": true,
+                        "validated_input": echo_input,
+                    }))
+                },
+                |h| {
+                    h(value).map_err(|e| {
+                        format!(
+                            "cross-context saga tool handler for '{tool_id_for_echo}' failed: {e}"
+                        )
+                    })
+                },
+            )
+        }
+    };
+
+    let request = CrossContextToolInvocationRequest {
+        caller_context_id: caller_context_bytes,
+        target_context_id: target_context_bytes,
+        caller_did: scp_primitives::DID(caller_did.clone()),
+        tool_registration_id: tool_registration_id.clone(),
+        ucan_proof_id,
+        input: input_value,
+        asserted_chain_depth,
+        asserted_nonce,
+        asserted_timestamp_ms,
+    };
+
+    // The producer drives a multi-phase saga; its future is large. Box it so
+    // the held state does not bloat this bridge method's own future
+    // (`clippy::large_futures`).
+    let output = Box::pin(supervisor.start_cross_context_tool_invocation_saga(
+        request,
+        SagaSigningKeys {
+            target: &target_signing_key,
+            caller: &caller_signing_key,
+        },
+        executor,
+    ))
+    .await
+    .map_err(map_saga_error)?;
+
+    Ok(NapiSagaResult {
+        saga_id: output.saga_id.0,
+        receipt: output.receipt.map(napi::bindgen_prelude::Buffer::from),
+        output: output.output.map(napi::bindgen_prelude::Buffer::from),
+    })
+}
+
+// ---------------------------------------------------------------------------
 // Stateful tool sessions (spec section 6.2.1)
 // ---------------------------------------------------------------------------
 
@@ -1043,7 +1418,7 @@ pub(crate) async fn tool_interface_revoke_on(
 // ---------------------------------------------------------------------------
 
 #[cfg(test)]
-#[allow(clippy::unwrap_used, clippy::expect_used)]
+#[allow(clippy::unwrap_used, clippy::expect_used, clippy::panic)]
 mod tests {
     use super::*;
     use scp_ffi_common::error_codes as codes;
@@ -1251,5 +1626,385 @@ mod tests {
 
         // Clean up global state.
         crate::runtime::remove_context(&bi, &ctx_id);
+    }
+
+    // ------------------------------------------------------------------
+    // map_saga_error — the bridge's typed-terminal → typed-error mapping.
+    //
+    // The producer's actual terminal behavior (which SagaError a given saga
+    // run yields) is covered by the Committed e2e test below and in
+    // `scp-runtime`; here we test ONLY the bridge's mapping responsibility:
+    // that each typed `SagaError` becomes the right `ScpNapiError` variant with
+    // EVERY structured datum preserved STRUCTURALLY (read off the variant, never
+    // parsed from a message) and the canonical `SCP-SAGA-13xxx` code attached.
+    // ------------------------------------------------------------------
+
+    use scp_core::context::supervisor::{
+        SagaAbortReason, SagaError as CoreSagaError, SagaId as CoreSagaId,
+    };
+
+    /// A rate-limited abort preserves `retry_after_ms = Some(ms)` STRUCTURALLY
+    /// and formats the producer's numeric `code` as the canonical
+    /// `SCP-SAGA-{code}` string.
+    #[test]
+    fn map_saga_error_rate_limited_preserves_retry_after_ms() {
+        let mapped = map_saga_error(CoreSagaError::Aborted {
+            reason: SagaAbortReason::RateLimited {
+                retry_after_ms: Some(2500),
+            },
+            code: 13026,
+            message: "inbound rate limit exceeded".to_owned(),
+        });
+        match mapped {
+            ScpNapiError::SagaAborted {
+                code,
+                retry_after_ms,
+                ..
+            } => {
+                assert_eq!(code, "SCP-SAGA-13026");
+                assert_eq!(retry_after_ms, Some(2500));
+            }
+            other => panic!("expected SagaAborted, got {other:?}"),
+        }
+    }
+
+    /// A rate-limited abort with NO precise back-off instant preserves
+    /// `retry_after_ms = None` — NEVER coerced to `Some(0)` — and renders the
+    /// message suffix as a literal `null` (a `0` would read as "retry
+    /// immediately" and re-trip the same hard limit).
+    #[test]
+    fn map_saga_error_rate_limited_none_is_not_zero() {
+        let mapped = map_saga_error(CoreSagaError::Aborted {
+            reason: SagaAbortReason::RateLimited {
+                retry_after_ms: None,
+            },
+            code: 13026,
+            message: "hard limit, no precise back-off".to_owned(),
+        });
+        match &mapped {
+            ScpNapiError::SagaAborted { retry_after_ms, .. } => {
+                assert_eq!(*retry_after_ms, None, "None must NOT be coerced to Some(0)");
+            }
+            other => panic!("expected SagaAborted, got {other:?}"),
+        }
+        assert!(
+            mapped.to_string().contains("(retry_after_ms=null)"),
+            "None retry_after_ms must render as the literal `null`, not 0: {mapped}"
+        );
+    }
+
+    /// A plain (non-rate-limit) `Rejected` abort carries `retry_after_ms = None`.
+    #[test]
+    fn map_saga_error_rejected_has_no_retry_hint() {
+        let mapped = map_saga_error(CoreSagaError::Aborted {
+            reason: SagaAbortReason::Rejected,
+            code: 13050,
+            message: "caller not a member".to_owned(),
+        });
+        match mapped {
+            ScpNapiError::SagaAborted {
+                code,
+                retry_after_ms,
+                ..
+            } => {
+                assert_eq!(code, "SCP-SAGA-13050");
+                assert_eq!(retry_after_ms, None);
+            }
+            other => panic!("expected SagaAborted, got {other:?}"),
+        }
+    }
+
+    /// `NeedsRepair` preserves the durable `saga_id` operator-repair handle and
+    /// the fixed terminal code `SCP-SAGA-13065`.
+    #[test]
+    fn map_saga_error_needs_repair_preserves_saga_id() {
+        let mapped = map_saga_error(CoreSagaError::NeedsRepair {
+            saga_id: CoreSagaId("saga-abc-123".to_owned()),
+            message: "commit retries exhausted".to_owned(),
+        });
+        match mapped {
+            ScpNapiError::SagaNeedsRepair { code, saga_id, .. } => {
+                assert_eq!(code, codes::SAGA_13065);
+                assert_eq!(saga_id, "saga-abc-123");
+            }
+            other => panic!("expected SagaNeedsRepair, got {other:?}"),
+        }
+    }
+
+    /// `Busy` preserves the contended context id and the fixed terminal code
+    /// `SCP-SAGA-13066`.
+    #[test]
+    fn map_saga_error_busy_preserves_contended_context() {
+        let mapped = map_saga_error(CoreSagaError::Busy {
+            contended_context: "ctx-shared-99".to_owned(),
+            message: "participant set overlaps an in-flight saga".to_owned(),
+        });
+        match mapped {
+            ScpNapiError::SagaBusy {
+                code,
+                contended_context,
+                ..
+            } => {
+                assert_eq!(code, codes::SAGA_13066);
+                assert_eq!(contended_context, "ctx-shared-99");
+            }
+            other => panic!("expected SagaBusy, got {other:?}"),
+        }
+    }
+
+    // ------------------------------------------------------------------
+    // End-to-end Committed terminal through the NAPI bridge.
+    //
+    // Mirrors the PyO3 e2e: an authenticated caller drives the §6.2.4
+    // cross-context tool-invocation saga to a real Committed terminal and the
+    // bridge returns the committed receipt + output bytes. The setup wires the
+    // two producer authorization axes:
+    //
+    //   1. Caller axis (gate 1): caller_did is hosted by this instance AND a
+    //      member of the CALLER (source) context A — satisfied by creating A
+    //      via the real context-create path with `owner` as single-admin.
+    //   2. Target axis (gate 2): a bidirectionally-approved ToolInterface
+    //      (approved_by_source && approved_by_target, source=A, target=B), which
+    //      the producer queries against A's actor governance state, established
+    //      IN A via a governance EstablishToolInterface action (auto-executed
+    //      under single_admin).
+    //
+    // Context B holds the tool registered into its ACTOR governance state (via a
+    // RegisterTool governance action — the saga's Prepare-B reads it from there)
+    // PLUS the FFI-side handler the executor snapshots and runs once at Commit-B.
+    // The handler returns `{"sum":42,"ok":1}`, which Commit-B validates against
+    // the registered numeric `{sum, ok}` output schema before committing.
+    //
+    // The owner is created via the real `identity_create` BEFORE the first
+    // `context_create_on` so its DID document is published into the per-instance
+    // resolver and the supervisor (built lazily on first create) snapshots that
+    // real resolver — governance vote verification resolves the proposer key
+    // through it. Prepare-B enforces a §9.14 ±5min timestamp skew, so the
+    // invocation uses `SystemTime::now()`.
+    // ------------------------------------------------------------------
+
+    /// Serializes a `RegisterTool` governance action for the saga tool. Mirrors
+    /// the registered schema: 2 input + 2 output properties (clears the §9.2.1
+    /// specificity floor of 2), numeric `{sum, ok}` output so Commit-B's
+    /// output-schema validation accepts the handler's response.
+    fn register_tool_action_json(tool_id: &str, tool_name: &str, owner: &str) -> String {
+        let impl_hash = serde_json::Value::from(vec![0u8; 32]);
+        let register_action = serde_json::json!({
+            "RegisterTool": {
+                "registration": {
+                    "tool_id": tool_id,
+                    "name": tool_name,
+                    "description": format!("Tool: {tool_name}"),
+                    "schema": {
+                        "input_schema": {
+                            "type": "object",
+                            "properties": {
+                                "a": {"type": "string"},
+                                "b": {"type": "string"}
+                            }
+                        },
+                        "output_schema": {
+                            "type": "object",
+                            "properties": {
+                                "sum": {"type": "number"},
+                                "ok": {"type": "number"}
+                            }
+                        }
+                    },
+                    "implementation_hash": impl_hash,
+                    "test_vectors": [],
+                    "operator_did": owner,
+                    "cost": null,
+                    "registered_at": 0,
+                    "signature": []
+                }
+            }
+        });
+        serde_json::to_string(&register_action).unwrap()
+    }
+
+    /// Serializes the bidirectionally-approved `EstablishToolInterface`
+    /// governance action (source=A, target=B, BOTH approvals true).
+    fn establish_interface_action_json(ctx_a: &str, ctx_b: &str, tool_id: &str) -> String {
+        let action = serde_json::json!({
+            "EstablishToolInterface": {
+                "interface": {
+                    "source_context": ctx_a,
+                    "target_context": ctx_b,
+                    "tool_id": tool_id,
+                    "rate_limit": null,
+                    "inbound_rate_limit": null,
+                    "per_caller_rate_limit": null,
+                    "approved_by_source": true,
+                    "approved_by_target": true,
+                    "outbound_policy": null,
+                    "inbound_policy": null
+                }
+            }
+        });
+        serde_json::to_string(&action).unwrap()
+    }
+
+    /// The registered tool registration definition for context B's FFI-side
+    /// registry, matching the governance `RegisterTool` schema (2-in/2-out,
+    /// numeric `{sum, ok}` output) so the deterministic id agrees and the
+    /// handler's response validates at Commit-B.
+    fn build_napi_tool_def(tool_name: &str, owner: &str) -> NapiToolDefinition {
+        NapiToolDefinition {
+            name: tool_name.to_owned(),
+            description: format!("Tool: {tool_name}"),
+            input_schema_json:
+                r#"{"type":"object","properties":{"a":{"type":"string"},"b":{"type":"string"}}}"#
+                    .to_owned(),
+            output_schema_json:
+                r#"{"type":"object","properties":{"sum":{"type":"number"},"ok":{"type":"number"}}}"#
+                    .to_owned(),
+            test_vectors_json: None,
+            implementation_hash: None,
+            operator_did: owner.to_owned(),
+            cost: None,
+        }
+    }
+
+    /// Full `Committed` terminal through the NAPI bridge: an authenticated
+    /// caller drives the §6.2.4 cross-context tool-invocation saga to a real
+    /// commit and the bridge returns the committed receipt + output bytes.
+    #[cfg(feature = "allow_in_memory_custody")]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn xctx_saga_authenticated_caller_commits_via_governance_established_interface() {
+        let scp = crate::scp::Scp::new_in_memory_for_test();
+        let bi = std::sync::Arc::clone(&scp.inner);
+
+        // Owner via the real identity-create path so its DID document is
+        // resolvable for governance vote verification. MUST precede the first
+        // context_create (which lazily builds the supervisor + snapshots the
+        // resolver).
+        let owner_identity = scp
+            .identity_create("in_memory".to_owned(), None)
+            .await
+            .expect("identity_create should succeed");
+        let owner = owner_identity.inner.did.clone();
+
+        // Context A (caller/source): ceiling carries governance:propose (so the
+        // admin can propose) and tool:interface (required by
+        // execute_establish_tool_interface's ceiling check).
+        let params_a = serde_json::json!({
+            "ceiling": [
+                "governance:propose",
+                "tool:interface",
+                "tools:invoke",
+                "messages:read",
+                "messages:write"
+            ],
+            "governance": "single_admin",
+            "memoryScope": "ephemeral",
+        })
+        .to_string();
+        let handle_a = crate::context::context_create_on(&bi, &owner_identity, params_a)
+            .await
+            .expect("context_create A should succeed");
+        let ctx_a = handle_a.context_id();
+
+        // Context B (target): ceiling carries governance:propose and
+        // tool:register so the saga tool can be registered into B's ACTOR
+        // governance state (the saga's Prepare-B reads it from there).
+        let params_b = serde_json::json!({
+            "ceiling": ["governance:propose", "tool:register"],
+            "governance": "single_admin",
+            "memoryScope": "ephemeral",
+        })
+        .to_string();
+        let handle_b = crate::context::context_create_on(&bi, &owner_identity, params_b)
+            .await
+            .expect("context_create B should succeed");
+        let ctx_b = handle_b.context_id();
+
+        // Deterministic tool id shared across the actor registry, the interface,
+        // and the FFI-side handler.
+        let tool_name = "xctx_saga_commit_tool";
+        let tool_id = scp_ffi_common::tool_id::generate_tool_id(tool_name);
+
+        // Register the tool into B's ACTOR governance state.
+        let register_json = register_tool_action_json(&tool_id, tool_name, &owner);
+        crate::context::context_governance_propose_on(&bi, &handle_b, register_json, owner.clone())
+            .await
+            .expect("RegisterTool must auto-execute under single_admin");
+
+        // Register the tool into B's FFI-side registry (so register_tool_handler
+        // accepts it) and attach the deterministic handler the executor runs at
+        // Commit-B.
+        let ffi_tool_id = tool_register_on(&bi, &handle_b, build_napi_tool_def(tool_name, &owner))
+            .await
+            .expect("FFI tool_register should succeed");
+        assert_eq!(
+            ffi_tool_id, tool_id,
+            "FFI and governance tool ids must agree (deterministic generate_tool_id)"
+        );
+        let handler: crate::runtime::ToolHandler =
+            std::sync::Arc::new(|_input: serde_json::Value| {
+                Ok(serde_json::json!({"sum": 42, "ok": 1}))
+            });
+        crate::runtime::register_tool_handler(&bi, &ctx_b, &tool_id, handler)
+            .expect("register_tool_handler should succeed");
+
+        // Establish the bidirectionally-approved interface in A via governance.
+        let interface_json = establish_interface_action_json(&ctx_a, &ctx_b, &tool_id);
+        let propose_result = crate::context::context_governance_propose_on(
+            &bi,
+            &handle_a,
+            interface_json,
+            owner.clone(),
+        )
+        .await
+        .expect("EstablishToolInterface must auto-execute under single_admin");
+        assert!(
+            !propose_result.is_empty(),
+            "governance_propose must return a non-empty result JSON"
+        );
+
+        // A near-now timestamp: Prepare-B enforces a §9.14 ±5min skew tolerance.
+        let now_ms = u64::try_from(
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_millis(),
+        )
+        .unwrap();
+        // A 16-byte nonce as 32 lowercase-hex chars.
+        let nonce_hex = "0123456789abcdef0123456789abcdef".to_owned();
+
+        let result = Box::pin(tool_invoke_cross_context_saga_on(
+            &bi,
+            &handle_a,
+            &handle_b,
+            owner.clone(),
+            tool_id.clone(),
+            r#"{"a":"x","b":"y"}"#.to_owned(),
+            nonce_hex,
+            now_ms,
+            1,
+            None,
+        ))
+        .await
+        .expect("saga must reach Committed");
+
+        // Committed terminal: non-empty saga id + a receipt + output bytes.
+        assert!(
+            !result.saga_id.is_empty(),
+            "a committed saga must carry a non-empty saga id"
+        );
+        let receipt = result.receipt.expect("committed saga must carry a receipt");
+        assert!(!receipt.is_empty(), "receipt bytes must be non-empty");
+        let output_buf = result
+            .output
+            .expect("committed saga must carry output bytes");
+
+        // The committed output decodes to the handler's response (numeric, per
+        // the registered output schema). Assert the parsed values, not raw
+        // bytes, so a JCS-canonical encoding still passes.
+        let out: serde_json::Value =
+            serde_json::from_slice(output_buf.as_ref()).expect("output must be valid JSON");
+        assert_eq!(out["sum"], 42, "committed output sum must be the handler's");
+        assert_eq!(out["ok"], 1, "committed output ok must be the handler's");
     }
 }

--- a/crates/scp-ffi/src/context.rs
+++ b/crates/scp-ffi/src/context.rs
@@ -1220,7 +1220,11 @@ fn build_core_context_params(
 /// provider and active signing key handle, and exports the raw
 /// `ed25519_dalek::SigningKey`. Required because the core governance
 /// lifecycle functions take `&SigningKey` directly.
-fn resolve_signing_key(
+///
+/// `pub(crate)` so the cross-context saga export in `tools.rs` can resolve
+/// each co-resident participant context's Active Signing Key (via that
+/// context's `creator_did`) without re-implementing the custody-export path.
+pub(crate) fn resolve_signing_key(
     bi: &crate::runtime::PyBridgeInstance,
     identity_did: &str,
 ) -> PyResult<ed25519_dalek::SigningKey> {

--- a/crates/scp-ffi/src/error.rs
+++ b/crates/scp-ffi/src/error.rs
@@ -78,6 +78,55 @@ pyo3::create_exception!(
     "Input validation failed (malformed data, schema mismatch, constraint violation)."
 );
 
+// Cross-context tool-invocation saga (§6.2.4, ADR-049 §3a) terminal errors.
+//
+// These three exceptions surface the typed
+// `Supervisor::start_cross_context_tool_invocation_saga` terminal space
+// (`SagaError`) WITHOUT the caller having to parse a message string: each
+// carries the structured terminal datum the §6.2.4 / ADR-049 §3a contract
+// makes load-bearing as a positional Python exception argument (read from
+// `e.args`, never re-parsed from the message text):
+//
+// - `SagaAbortedError(message, code, retry_after_ms)` — a Prepare-phase
+//   rejection (§6.2.4). `retry_after_ms` is the rate-limit back-off hint:
+//   an `int` of milliseconds when the tripped limiter can compute one, or
+//   `None` (NEVER `0`) when no precise back-off instant exists — `0` would
+//   read as "retry immediately" and re-trip the same hard limit. A plain
+//   (non-rate-limit) rejection also carries `None`.
+// - `SagaNeedsRepairError(message, code, saga_id)` — Commit-retry exhausted;
+//   the saga may have partially committed (a divergence). `saga_id` is the
+//   durable operator-repair handle.
+// - `SagaBusyError(message, code, contended_context)` — the participant
+//   context set overlapped an in-flight saga (§5.15.4). `contended_context`
+//   names the shared context id.
+//
+// `code` is the canonical `SCP-SAGA-13xxx` string and is ALSO embedded in
+// `message` (`"[SCP-SAGA-13xxx] …"`) so a flattened log line still
+// disambiguates by `grep`.
+pyo3::create_exception!(
+    scp_sdk,
+    SagaAbortedError,
+    ScpError,
+    "A cross-context tool-invocation saga aborted at a Prepare phase (§6.2.4). \
+     args = (message, code, retry_after_ms): retry_after_ms is an int of \
+     milliseconds or None (never 0)."
+);
+pyo3::create_exception!(
+    scp_sdk,
+    SagaNeedsRepairError,
+    ScpError,
+    "A cross-context tool-invocation saga exhausted its Commit retries and may \
+     have diverged (ADR-049 §3a). args = (message, code, saga_id): saga_id is \
+     the durable operator-repair handle."
+);
+pyo3::create_exception!(
+    scp_sdk,
+    SagaBusyError,
+    ScpError,
+    "A cross-context tool-invocation saga's participant context set overlapped \
+     an in-flight saga (§5.15.4). args = (message, code, contended_context)."
+);
+
 // ---------------------------------------------------------------------------
 // ScpPyError enum
 // ---------------------------------------------------------------------------
@@ -137,6 +186,43 @@ pub enum ScpPyError {
         /// Stable error code (e.g. `SCP-VALID-7001`).
         code: String,
     },
+    /// A §6.2.4 cross-context tool-invocation saga aborted at a Prepare phase.
+    ///
+    /// Maps to the Python `SagaAbortedError`. Carries the rate-limit back-off
+    /// hint STRUCTURALLY (`retry_after_ms`): `Some(ms)` is the limiter's
+    /// computed cooldown; `None` (NEVER `0`) means no precise back-off instant
+    /// (a token-bucket hard limit, or a non-rate-limit rejection).
+    SagaAborted {
+        /// Human-readable detail (carries the `[SCP-SAGA-…]` prefix).
+        message: String,
+        /// The canonical `SCP-SAGA-13xxx` code.
+        code: String,
+        /// Rate-limit back-off hint in milliseconds, or `None` (never `0`).
+        retry_after_ms: Option<u64>,
+    },
+    /// A §6.2.4 saga exhausted its Commit retries and may have diverged.
+    ///
+    /// Maps to the Python `SagaNeedsRepairError`. Carries the durable
+    /// `saga_id` operator-repair handle.
+    SagaNeedsRepair {
+        /// Human-readable detail (carries the `[SCP-SAGA-…]` prefix).
+        message: String,
+        /// The canonical `SCP-SAGA-13065` code.
+        code: String,
+        /// The durable saga identifier — the operator-repair handle.
+        saga_id: String,
+    },
+    /// A §6.2.4 saga's participant context set overlapped an in-flight saga.
+    ///
+    /// Maps to the Python `SagaBusyError`. Carries the contended context id.
+    SagaBusy {
+        /// Human-readable detail (carries the `[SCP-SAGA-…]` prefix).
+        message: String,
+        /// The canonical `SCP-SAGA-13066` code.
+        code: String,
+        /// The shared context id that forced serialization.
+        contended_context: String,
+    },
 }
 
 impl std::fmt::Display for ScpPyError {
@@ -159,6 +245,19 @@ impl std::fmt::Display for ScpPyError {
             }
             Self::ValidationError { message, code } => {
                 write!(f, "[{code}] validation error: {message}")
+            }
+            // Saga terminals embed the canonical SCP-SAGA-13xxx code so a
+            // flattened log line still `grep`-disambiguates; the structured
+            // datum (retry_after_ms / saga_id / contended_context) rides the
+            // exception args, not the message text.
+            Self::SagaAborted { message, code, .. } => {
+                write!(f, "[{code}] saga aborted: {message}")
+            }
+            Self::SagaNeedsRepair { message, code, .. } => {
+                write!(f, "[{code}] saga needs repair: {message}")
+            }
+            Self::SagaBusy { message, code, .. } => {
+                write!(f, "[{code}] saga busy: {message}")
             }
         }
     }
@@ -252,6 +351,27 @@ impl From<ScpPyError> for PyErr {
             ScpPyError::TransportError { .. } => TransportError::new_err(formatted),
             ScpPyError::UcanError { .. } => UcanError::new_err(formatted),
             ScpPyError::ValidationError { .. } => ValidationError::new_err(formatted),
+            // Saga terminals carry their structured datum as positional
+            // exception args so a Python caller reads `retry_after_ms` /
+            // `saga_id` / `contended_context` directly from `e.args[2]` —
+            // never by re-parsing the message text. `formatted` (carrying the
+            // `[SCP-SAGA-…]` prefix) is `args[0]`; the canonical code is
+            // `args[1]`. `retry_after_ms` maps `None` → Python `None`
+            // (NEVER `0`), preserving the §6.2.4 back-off semantics across
+            // the FFI boundary.
+            ScpPyError::SagaAborted {
+                code,
+                retry_after_ms,
+                ..
+            } => SagaAbortedError::new_err((formatted, code, retry_after_ms)),
+            ScpPyError::SagaNeedsRepair { code, saga_id, .. } => {
+                SagaNeedsRepairError::new_err((formatted, code, saga_id))
+            }
+            ScpPyError::SagaBusy {
+                code,
+                contended_context,
+                ..
+            } => SagaBusyError::new_err((formatted, code, contended_context)),
         }
     }
 }
@@ -775,6 +895,12 @@ pub fn register_exceptions(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add("TransportError", m.py().get_type::<TransportError>())?;
     m.add("UcanError", m.py().get_type::<UcanError>())?;
     m.add("ValidationError", m.py().get_type::<ValidationError>())?;
+    m.add("SagaAbortedError", m.py().get_type::<SagaAbortedError>())?;
+    m.add(
+        "SagaNeedsRepairError",
+        m.py().get_type::<SagaNeedsRepairError>(),
+    )?;
+    m.add("SagaBusyError", m.py().get_type::<SagaBusyError>())?;
     Ok(())
 }
 
@@ -928,5 +1054,89 @@ mod tests {
         )
         .into();
         assert_eq!(context_code_of(err), codes::CTX_2137);
+    }
+
+    // ------------------------------------------------------------------
+    // Saga terminal → Python exception: the structured datum MUST ride the
+    // exception args so a Python caller reads it directly (never by parsing
+    // the message text). args = (message, code, structured_field).
+    // ------------------------------------------------------------------
+
+    /// `SagaAborted` → `SagaAbortedError` carrying `retry_after_ms` as `args[2]`
+    /// (a Python `int` when `Some`).
+    #[test]
+    fn saga_aborted_maps_to_exception_with_retry_after_ms_arg() {
+        Python::with_gil(|py| {
+            pyo3::prepare_freethreaded_python();
+            let err: PyErr = ScpPyError::SagaAborted {
+                message: "rate limited".to_owned(),
+                code: "SCP-SAGA-13026".to_owned(),
+                retry_after_ms: Some(2500),
+            }
+            .into();
+            assert!(err.is_instance_of::<SagaAbortedError>(py));
+            let args = err.value(py).getattr("args").unwrap();
+            let code: String = args.get_item(1).unwrap().extract().unwrap();
+            assert_eq!(code, "SCP-SAGA-13026");
+            let retry: u64 = args.get_item(2).unwrap().extract().unwrap();
+            assert_eq!(retry, 2500);
+        });
+    }
+
+    /// `SagaAborted` with `retry_after_ms = None` → `args[2]` is Python `None`,
+    /// NEVER `0`.
+    #[test]
+    fn saga_aborted_none_retry_is_python_none_not_zero() {
+        Python::with_gil(|py| {
+            pyo3::prepare_freethreaded_python();
+            let err: PyErr = ScpPyError::SagaAborted {
+                message: "no back-off".to_owned(),
+                code: "SCP-SAGA-13026".to_owned(),
+                retry_after_ms: None,
+            }
+            .into();
+            let args = err.value(py).getattr("args").unwrap();
+            let retry = args.get_item(2).unwrap();
+            assert!(
+                retry.is_none(),
+                "retry_after_ms None must surface as Python None, not 0"
+            );
+        });
+    }
+
+    /// `SagaNeedsRepair` → `SagaNeedsRepairError` carrying `saga_id` as `args[2]`.
+    #[test]
+    fn saga_needs_repair_maps_to_exception_with_saga_id_arg() {
+        Python::with_gil(|py| {
+            pyo3::prepare_freethreaded_python();
+            let err: PyErr = ScpPyError::SagaNeedsRepair {
+                message: "diverged".to_owned(),
+                code: codes::SAGA_13065.to_owned(),
+                saga_id: "saga-xyz".to_owned(),
+            }
+            .into();
+            assert!(err.is_instance_of::<SagaNeedsRepairError>(py));
+            let args = err.value(py).getattr("args").unwrap();
+            let saga_id: String = args.get_item(2).unwrap().extract().unwrap();
+            assert_eq!(saga_id, "saga-xyz");
+        });
+    }
+
+    /// `SagaBusy` → `SagaBusyError` carrying `contended_context` as `args[2]`.
+    #[test]
+    fn saga_busy_maps_to_exception_with_contended_context_arg() {
+        Python::with_gil(|py| {
+            pyo3::prepare_freethreaded_python();
+            let err: PyErr = ScpPyError::SagaBusy {
+                message: "busy".to_owned(),
+                code: codes::SAGA_13066.to_owned(),
+                contended_context: "ctx-shared".to_owned(),
+            }
+            .into();
+            assert!(err.is_instance_of::<SagaBusyError>(py));
+            let args = err.value(py).getattr("args").unwrap();
+            let contended: String = args.get_item(2).unwrap().extract().unwrap();
+            assert_eq!(contended, "ctx-shared");
+        });
     }
 }

--- a/crates/scp-ffi/src/tools.rs
+++ b/crates/scp-ffi/src/tools.rs
@@ -948,48 +948,36 @@ fn tool_invoke_cross_context_impl(
 // ---------------------------------------------------------------------------
 
 /// Maps a `SagaError` terminal (the typed §6.2.4 terminal space) onto the
-/// bridge's typed saga error variants, reading every structured datum
-/// STRUCTURALLY off the variant — never by re-parsing a message string.
+/// bridge's typed saga error variants.
 ///
-/// - `Aborted { reason, code, message }` → [`ScpPyError::SagaAborted`].
-///   `retry_after_ms` is read directly off `SagaAbortReason::RateLimited`
-///   (an `Option<u64>`); a plain `Rejected` carries `None`. `None` is
-///   propagated, NEVER coerced to `0` (a `0` would read as "retry
-///   immediately" and re-trip the same hard limit). `code` is formatted as
-///   the canonical `SCP-SAGA-{code}` string from the numeric discriminant.
-/// - `NeedsRepair { saga_id, message }` → [`ScpPyError::SagaNeedsRepair`]
-///   carrying the durable operator-repair handle (`SCP-SAGA-13065`).
-/// - `Busy { contended_context, message }` → [`ScpPyError::SagaBusy`]
-///   (`SCP-SAGA-13066`).
+/// The decomposition — the `SagaAbortReason::RateLimited → Option<u64>` read,
+/// the `None`-never-coerced-to-`0` rule, and the `SCP-SAGA-{code}` formatting —
+/// lives ONCE in [`scp_ffi_common::saga_errors::decompose_saga_error`], unit-
+/// tested there, so the three bridges cannot drift. This function is the thin
+/// per-bridge tail that carries the `PyO3` field labels (`message:`):
+///
+/// - `Aborted` → [`ScpPyError::SagaAborted`] (`retry_after_ms`, `None` never
+///   `0`, `SCP-SAGA-{code}`).
+/// - `NeedsRepair` → [`ScpPyError::SagaNeedsRepair`] (durable repair handle,
+///   `SCP-SAGA-13065`).
+/// - `Busy` → [`ScpPyError::SagaBusy`] (`SCP-SAGA-13066`).
 fn map_saga_error(err: scp_core::context::supervisor::SagaError) -> ScpPyError {
-    use scp_core::context::supervisor::{SagaAbortReason, SagaError};
-    match err {
-        SagaError::Aborted {
-            reason,
-            code,
-            message,
-        } => {
-            let retry_after_ms = match reason {
-                SagaAbortReason::RateLimited { retry_after_ms } => retry_after_ms,
-                SagaAbortReason::Rejected => None,
-            };
-            ScpPyError::SagaAborted {
-                message,
-                code: format!("SCP-SAGA-{code}"),
-                retry_after_ms,
-            }
-        }
-        SagaError::NeedsRepair { saga_id, message } => ScpPyError::SagaNeedsRepair {
-            message,
-            code: codes::SAGA_13065.to_owned(),
-            saga_id: saga_id.0,
+    use scp_ffi_common::saga_errors::{SagaErrorKind, decompose_saga_error};
+    let parts = decompose_saga_error(err);
+    match parts.kind {
+        SagaErrorKind::Aborted { retry_after_ms } => ScpPyError::SagaAborted {
+            message: parts.message,
+            code: parts.code,
+            retry_after_ms,
         },
-        SagaError::Busy {
-            contended_context,
-            message,
-        } => ScpPyError::SagaBusy {
-            message,
-            code: codes::SAGA_13066.to_owned(),
+        SagaErrorKind::NeedsRepair { saga_id } => ScpPyError::SagaNeedsRepair {
+            message: parts.message,
+            code: parts.code,
+            saga_id,
+        },
+        SagaErrorKind::Busy { contended_context } => ScpPyError::SagaBusy {
+            message: parts.message,
+            code: parts.code,
             contended_context,
         },
     }
@@ -2556,29 +2544,33 @@ mod tests {
     // ------------------------------------------------------------------
     // map_saga_error — the bridge's typed-terminal → typed-error mapping.
     //
-    // The producer's actual terminal behavior (which SagaError a given saga
-    // run yields) is covered in `crates/scp-runtime`; here we test ONLY the
-    // bridge's mapping responsibility: that each typed `SagaError` becomes the
-    // right `ScpPyError` variant with EVERY structured datum preserved
-    // STRUCTURALLY (read off the variant, never parsed from a message) and the
-    // canonical `SCP-SAGA-13xxx` code attached.
+    // The classification itself (the `RateLimited → Option<u64>` read, the
+    // `None`-never-`0` rule, the `SCP-SAGA-{code}` formatting, the fixed
+    // terminal codes) lives in `scp_ffi_common::saga_errors` and is unit-tested
+    // there for all three bridges. The producer's actual terminal behavior is
+    // covered in `crates/scp-runtime`. Here we test ONLY this bridge's thin
+    // tail: that each `SagaErrorKind` routes through `common` onto the right
+    // `ScpPyError` variant with the shared `code`/`message` and the
+    // per-terminal datum (`retry_after_ms`/`saga_id`/`contended_context`)
+    // carried onto the PyO3 fields — including that `retry_after_ms = None` is
+    // preserved (never coerced to `Some(0)`).
     // ------------------------------------------------------------------
 
     use scp_core::context::supervisor::{SagaAbortReason, SagaError as CoreSagaError, SagaId};
 
-    /// A rate-limited abort preserves `retry_after_ms = Some(ms)` STRUCTURALLY
-    /// and formats the producer's numeric `code` as the canonical
-    /// `SCP-SAGA-{code}` string.
+    /// `Aborted` routes through `common` onto `ScpPyError::SagaAborted` with the
+    /// `SCP-SAGA-{code}` string and `retry_after_ms` carried structurally; a
+    /// `None` back-off hint stays `None` (never `Some(0)`).
     #[test]
-    fn map_saga_error_rate_limited_preserves_retry_after_ms() {
-        let mapped = map_saga_error(CoreSagaError::Aborted {
+    fn map_saga_error_aborted_routes_through_common() {
+        let some = map_saga_error(CoreSagaError::Aborted {
             reason: SagaAbortReason::RateLimited {
                 retry_after_ms: Some(2500),
             },
             code: 13026,
             message: "inbound rate limit exceeded".to_owned(),
         });
-        match mapped {
+        match some {
             ScpPyError::SagaAborted {
                 code,
                 retry_after_ms,
@@ -2589,21 +2581,15 @@ mod tests {
             }
             other => panic!("expected SagaAborted, got {other:?}"),
         }
-    }
 
-    /// A rate-limited abort with NO precise back-off instant preserves
-    /// `retry_after_ms = None` — NEVER coerced to `Some(0)` (a `0` would read
-    /// as "retry immediately" and re-trip the same hard limit).
-    #[test]
-    fn map_saga_error_rate_limited_none_is_not_zero() {
-        let mapped = map_saga_error(CoreSagaError::Aborted {
+        let none = map_saga_error(CoreSagaError::Aborted {
             reason: SagaAbortReason::RateLimited {
                 retry_after_ms: None,
             },
             code: 13026,
             message: "hard limit, no precise back-off".to_owned(),
         });
-        match mapped {
+        match none {
             ScpPyError::SagaAborted { retry_after_ms, .. } => {
                 assert_eq!(retry_after_ms, None, "None must NOT be coerced to Some(0)");
             }
@@ -2611,53 +2597,27 @@ mod tests {
         }
     }
 
-    /// A plain (non-rate-limit) `Rejected` abort carries `retry_after_ms = None`.
+    /// `NeedsRepair` / `Busy` route through `common` onto their `PyO3` variants
+    /// with the fixed terminal codes and per-terminal datum carried.
     #[test]
-    fn map_saga_error_rejected_has_no_retry_hint() {
-        let mapped = map_saga_error(CoreSagaError::Aborted {
-            reason: SagaAbortReason::Rejected,
-            code: 13050,
-            message: "caller not a member".to_owned(),
-        });
-        match mapped {
-            ScpPyError::SagaAborted {
-                code,
-                retry_after_ms,
-                ..
-            } => {
-                assert_eq!(code, "SCP-SAGA-13050");
-                assert_eq!(retry_after_ms, None);
-            }
-            other => panic!("expected SagaAborted, got {other:?}"),
-        }
-    }
-
-    /// `NeedsRepair` preserves the durable `saga_id` operator-repair handle and
-    /// the fixed terminal code `SCP-SAGA-13065`.
-    #[test]
-    fn map_saga_error_needs_repair_preserves_saga_id() {
-        let mapped = map_saga_error(CoreSagaError::NeedsRepair {
+    fn map_saga_error_needs_repair_and_busy_route_through_common() {
+        let repair = map_saga_error(CoreSagaError::NeedsRepair {
             saga_id: SagaId("saga-abc-123".to_owned()),
             message: "commit retries exhausted".to_owned(),
         });
-        match mapped {
+        match repair {
             ScpPyError::SagaNeedsRepair { code, saga_id, .. } => {
                 assert_eq!(code, codes::SAGA_13065);
                 assert_eq!(saga_id, "saga-abc-123");
             }
             other => panic!("expected SagaNeedsRepair, got {other:?}"),
         }
-    }
 
-    /// `Busy` preserves the contended context id and the fixed terminal code
-    /// `SCP-SAGA-13066`.
-    #[test]
-    fn map_saga_error_busy_preserves_contended_context() {
-        let mapped = map_saga_error(CoreSagaError::Busy {
+        let busy = map_saga_error(CoreSagaError::Busy {
             contended_context: "ctx-shared-99".to_owned(),
             message: "participant set overlaps an in-flight saga".to_owned(),
         });
-        match mapped {
+        match busy {
             ScpPyError::SagaBusy {
                 code,
                 contended_context,

--- a/crates/scp-ffi/src/tools.rs
+++ b/crates/scp-ffi/src/tools.rs
@@ -143,6 +143,53 @@ impl PyToolVerificationResult {
 }
 
 // ---------------------------------------------------------------------------
+// PySagaResult (§6.2.4 cross-context tool-invocation saga — committed terminal)
+// ---------------------------------------------------------------------------
+
+/// The committed terminal of a §6.2.4 cross-context tool-invocation saga.
+///
+/// Returned by [`PyScp::tool_invoke_cross_context_saga`] on a `Committed`
+/// terminal. Every NON-committed terminal raises a typed saga exception
+/// (`SagaAbortedError` / `SagaNeedsRepairError` / `SagaBusyError`) instead.
+///
+/// Carries the supervisor-minted `saga_id` plus — for the committed
+/// cross-context invocation — the target's signed receipt and the captured
+/// tool output (spec §6.2.4 "Receipt / response return path"). The `receipt`
+/// is the JCS-canonical `CrossContextToolReceipt` bytes; `output` is the
+/// receipt's canonical `output_jcs` bytes (the exact bytes the caller side
+/// recorded a hash of). Both are surfaced as Python `bytes` so a caller can
+/// verify the receipt signature and recompute `output_hash` without a
+/// re-serialization step.
+#[pyclass(name = "SagaResult")]
+#[derive(Debug, Clone)]
+pub struct PySagaResult {
+    /// The durable saga identifier (supervisor-minted, never a caller input).
+    #[pyo3(get)]
+    pub saga_id: String,
+
+    /// The target's signed `CrossContextToolReceipt` bytes (JCS), or `None`.
+    #[pyo3(get)]
+    pub receipt: Option<Vec<u8>>,
+
+    /// The captured tool output bytes (the receipt's canonical `output_jcs`),
+    /// or `None`.
+    #[pyo3(get)]
+    pub output: Option<Vec<u8>>,
+}
+
+#[pymethods]
+impl PySagaResult {
+    fn __repr__(&self) -> String {
+        format!(
+            "SagaResult(saga_id={:?}, receipt={} bytes, output={} bytes)",
+            self.saga_id,
+            self.receipt.as_ref().map_or(0, Vec::len),
+            self.output.as_ref().map_or(0, Vec::len),
+        )
+    }
+}
+
+// ---------------------------------------------------------------------------
 // Bridge helpers — per-bridge implementations used by PyScp methods
 // ---------------------------------------------------------------------------
 
@@ -897,6 +944,312 @@ fn tool_invoke_cross_context_impl(
 }
 
 // ---------------------------------------------------------------------------
+// Cross-context tool-invocation saga (§6.2.4, ADR-049 §3a)
+// ---------------------------------------------------------------------------
+
+/// Maps a `SagaError` terminal (the typed §6.2.4 terminal space) onto the
+/// bridge's typed saga error variants, reading every structured datum
+/// STRUCTURALLY off the variant — never by re-parsing a message string.
+///
+/// - `Aborted { reason, code, message }` → [`ScpPyError::SagaAborted`].
+///   `retry_after_ms` is read directly off `SagaAbortReason::RateLimited`
+///   (an `Option<u64>`); a plain `Rejected` carries `None`. `None` is
+///   propagated, NEVER coerced to `0` (a `0` would read as "retry
+///   immediately" and re-trip the same hard limit). `code` is formatted as
+///   the canonical `SCP-SAGA-{code}` string from the numeric discriminant.
+/// - `NeedsRepair { saga_id, message }` → [`ScpPyError::SagaNeedsRepair`]
+///   carrying the durable operator-repair handle (`SCP-SAGA-13065`).
+/// - `Busy { contended_context, message }` → [`ScpPyError::SagaBusy`]
+///   (`SCP-SAGA-13066`).
+fn map_saga_error(err: scp_core::context::supervisor::SagaError) -> ScpPyError {
+    use scp_core::context::supervisor::{SagaAbortReason, SagaError};
+    match err {
+        SagaError::Aborted {
+            reason,
+            code,
+            message,
+        } => {
+            let retry_after_ms = match reason {
+                SagaAbortReason::RateLimited { retry_after_ms } => retry_after_ms,
+                SagaAbortReason::Rejected => None,
+            };
+            ScpPyError::SagaAborted {
+                message,
+                code: format!("SCP-SAGA-{code}"),
+                retry_after_ms,
+            }
+        }
+        SagaError::NeedsRepair { saga_id, message } => ScpPyError::SagaNeedsRepair {
+            message,
+            code: codes::SAGA_13065.to_owned(),
+            saga_id: saga_id.0,
+        },
+        SagaError::Busy {
+            contended_context,
+            message,
+        } => ScpPyError::SagaBusy {
+            message,
+            code: codes::SAGA_13066.to_owned(),
+            contended_context,
+        },
+    }
+}
+
+/// Resolves the Active Signing Key the supervisor saga signs under for the
+/// co-resident context `context_id` — the key of the context's owning
+/// identity (`FfiBridgeState.creator_did`), exported via the shared custody
+/// path. The caller and target each resolve to their OWN creator's key so the
+/// receipt (target-signed) and each side's divergence marker (own-signed) are
+/// signed under the correct per-context Active Signing Key (spec §6.2.4
+/// "Signer authorization": the receipt key MUST be the one authorized to act
+/// for `target_context_id`).
+fn resolve_context_signing_key(
+    bi: &PyBridgeInstance,
+    context_id: &str,
+) -> PyResult<ed25519_dalek::SigningKey> {
+    let creator_did =
+        crate::runtime::with_context(bi, context_id, |rt| Ok(rt.creator_did.clone()))?;
+    crate::context::resolve_signing_key(bi, &creator_did)
+}
+
+/// Decodes the §6.2.4 envelope nonce from its canonical 32-char hex form into
+/// the 16-byte value, FAIL-CLOSED.
+///
+/// The nonce is a 16-byte value carried as a hex string — the one canonical
+/// wire form (§6.2.4 wire envelope). Any other length is a malformed envelope,
+/// NOT a "pad it" situation; and we never accept a Python int (which would
+/// invite an ambiguous endianness/width interpretation). Both failure modes
+/// surface as `ValidationError`.
+fn decode_asserted_nonce(asserted_nonce_hex: &str) -> PyResult<[u8; 16]> {
+    let bytes = hex::decode(asserted_nonce_hex).map_err(|e| ScpPyError::ValidationError {
+        message: format!(
+            "asserted_nonce_hex is not valid hex: {e} — supply the 16-byte §6.2.4 envelope \
+             nonce as a 32-char lowercase-hex string"
+        ),
+        code: codes::VALID_7001.to_owned(),
+    })?;
+    let nonce =
+        <[u8; 16]>::try_from(bytes.as_slice()).map_err(|_| ScpPyError::ValidationError {
+            message: format!(
+                "asserted_nonce_hex must decode to exactly 16 bytes (32 hex chars), got {} bytes",
+                bytes.len()
+            ),
+            code: codes::VALID_7001.to_owned(),
+        })?;
+    Ok(nonce)
+}
+
+/// Enforces the §6.2.4 *Caller authentication* binding (normative — §6.2.4 +
+/// ADR-049 §3a) BEFORE the saga runs.
+///
+/// `caller_did` / `caller_context_id` MUST be the channel-authenticated
+/// identity of the transport leg, never an envelope-asserted free value. For
+/// the co-resident `PyO3` bridge the "channel-authenticated principal" is an
+/// identity THIS bridge instance hosts — one present in its per-instance
+/// identity registry (populated only by `py_identity_create` on this
+/// instance). Both axes are enforced here:
+///
+///   (a) `caller_did` is hosted/authenticated by this bridge instance, AND
+///   (b) `caller_did` is a member of the named `caller_context_id`.
+///
+/// A mismatch on either axis ⇒ a typed `Rejected`-flavored `SagaAborted` (the
+/// §6.2.4 "mismatch ⇒ Rejected" terminal), carrying the registered caller-axis
+/// code `SCP-SAGA-13050`. The supervisor's own gate 1 ALSO checks membership,
+/// but membership alone is necessary-not-sufficient (it does not prove the
+/// request leg is authenticated AS that member) — so axis (a) is the
+/// load-bearing addition this seam contributes. Enforcing here, before the
+/// entry point, also means the saga never observes an unauthenticated caller.
+fn enforce_caller_principal_binding(
+    bi: &PyBridgeInstance,
+    supervisor: &std::sync::Arc<scp_core::context::supervisor::Supervisor>,
+    tokio_rt: &tokio::runtime::Runtime,
+    caller_context_id: &str,
+    caller_did: &str,
+) -> PyResult<()> {
+    if !crate::runtime::identity_registry_contains(bi, caller_did) {
+        return Err(ScpPyError::SagaAborted {
+            message: format!(
+                "caller_did '{caller_did}' is not an identity hosted by this bridge instance — \
+                 a cross-context saga's caller MUST be the channel-authenticated principal (an \
+                 identity created on this instance), not an envelope-asserted value (§6.2.4 \
+                 Caller authentication)"
+            ),
+            code: codes::SAGA_13050.to_owned(),
+            retry_after_ms: None,
+        }
+        .into());
+    }
+
+    let caller_is_member = tokio_rt.block_on(supervisor.is_member(caller_context_id, caller_did));
+    if !caller_is_member {
+        return Err(ScpPyError::SagaAborted {
+            message: format!(
+                "caller_did '{caller_did}' is hosted by this bridge but is not a member of \
+                 caller_context_id '{caller_context_id}' — not authorized to initiate a \
+                 cross-context saga over it (§6.2.4 Caller authentication)"
+            ),
+            code: codes::SAGA_13050.to_owned(),
+            retry_after_ms: None,
+        }
+        .into());
+    }
+    Ok(())
+}
+
+/// Implements the §6.2.4 cross-context tool-invocation saga export.
+///
+/// See [`PyScp::tool_invoke_cross_context_saga`] for the full contract. The
+/// flow is, in order:
+///
+/// 1. **Validate inputs** (well-formed ids/dids/tool-id; the nonce decodes to
+///    `[u8; 16]`, fail-closed on a wrong length — a hex string is the one
+///    canonical form).
+/// 2. **Caller-principal binding (§6.2.4 *Caller authentication*, normative).**
+///    `caller_did` MUST be an identity THIS bridge instance hosts/authenticated
+///    (present in the per-instance identity registry — the co-resident SDK
+///    seam's channel-authenticated principal) AND a member of
+///    `caller_context_id`. A mismatch ⇒ a typed `Rejected`-flavored
+///    `SagaAborted` BEFORE the saga runs (the saga never observes an
+///    unauthenticated caller). `nonce` / `timestamp` / `chain_depth` REMAIN
+///    caller-supplied freshness fields (the target B validates them — they are
+///    not minted here).
+/// 3. **Chokepoint (ADR-056).** Convert the caller/target id STRINGS → `[u8; 32]`
+///    via `scp_core::context::state::context_id_to_bytes` (decode-64-hex-else-
+///    SHA256). Raw `Sha256` of a 64-hex id would double-hash and miss the actor.
+/// 4. **Signing keys.** Resolve each co-resident context's Active Signing Key
+///    via the context's `creator_did`.
+/// 5. **Executor.** Snapshot the TARGET context's tool handler under
+///    [`with_context`](crate::runtime::with_context) and build the
+///    non-`Send`-safe `move |input| async {…}` closure the supervisor runs
+///    supervisor-side at Commit-B (mirrors `tool_invoke_impl`'s executor
+///    pattern).
+/// 6. [`block_on`](tokio::runtime::Runtime::block_on) the producer; map the
+///    terminal `SagaError` → typed bridge error, `Committed` →
+///    [`PySagaResult`].
+#[allow(clippy::too_many_arguments)] // Flat §6.2.4 envelope — agent-first named params, no builder.
+fn tool_invoke_cross_context_saga_impl(
+    bi: &PyBridgeInstance,
+    caller_context_id: &str,
+    target_context_id: &str,
+    caller_did: &str,
+    tool_registration_id: &str,
+    input: &Bound<'_, PyDict>,
+    asserted_nonce_hex: &str,
+    asserted_timestamp_ms: u64,
+    asserted_chain_depth: u8,
+    ucan_proof_id: Option<String>,
+) -> PyResult<PySagaResult> {
+    use scp_core::context::supervisor::{CrossContextToolInvocationRequest, SagaSigningKeys};
+
+    validate::validate_context_id(caller_context_id)?;
+    validate::validate_context_id(target_context_id)?;
+    validate::validate_did(caller_did)?;
+    validate::validate_tool_id(tool_registration_id)?;
+
+    let asserted_nonce = decode_asserted_nonce(asserted_nonce_hex)?;
+    let input_json = py_dict_to_json(input)?;
+
+    // Caller-principal binding (§6.2.4 *Caller authentication*) — BEFORE the
+    // saga runs, so the supervisor never observes an unauthenticated caller.
+    let supervisor = crate::runtime::supervisor(bi)?;
+    let tokio_rt = crate::runtime()?;
+    enforce_caller_principal_binding(bi, supervisor, tokio_rt, caller_context_id, caller_did)?;
+
+    // ----- Chokepoint (ADR-056): id STRING → [u8; 32] ------------------------
+    //
+    // MANDATORY: convert via the canonical cross-crate keying resolver, which
+    // decodes a real 64-hex id rather than re-hashing it. The producer does
+    // `hex::encode(wire)` for actor lookup, so a raw SHA-256 of a 64-hex id
+    // here would double-hash and key the wrong (non-existent) actor slot,
+    // surfacing as a spurious ContextNotRegistered abort.
+    let caller_context_bytes = scp_core::context::state::context_id_to_bytes(caller_context_id);
+    let target_context_bytes = scp_core::context::state::context_id_to_bytes(target_context_id);
+
+    // ----- Signing keys: each context's Active Signing Key -------------------
+    let target_signing_key = resolve_context_signing_key(bi, target_context_id)?;
+    let caller_signing_key = resolve_context_signing_key(bi, caller_context_id)?;
+
+    // ----- Executor: snapshot the TARGET context's tool handler --------------
+    //
+    // Mirrors `tool_invoke_impl`: snapshot the registered handler closure
+    // (an `Arc<dyn Fn>` — cloning is a refcount bump) OUTSIDE the runtime call,
+    // then move it into the `FnOnce` executor the supervisor runs
+    // supervisor-side at Commit-B (off the actor mailbox). Falls back to a
+    // schema-only echo when no handler is registered, matching the synchronous
+    // cross-context path. The supervisor validates the output against the
+    // tool's registered output schema at Commit-B, so the executor only
+    // produces the value.
+    let handler = crate::runtime::with_context(bi, target_context_id, |rt| {
+        Ok(rt.tool_handlers.get(tool_registration_id).cloned())
+    })?;
+    let tool_id_for_echo = tool_registration_id.to_owned();
+    let target_ctx_for_echo = target_context_id.to_owned();
+    let caller_did_for_echo = caller_did.to_owned();
+    let executor = move |value: serde_json::Value| {
+        let handler = handler.clone();
+        let echo_input = value.clone();
+        async move {
+            handler.map_or_else(
+                || {
+                    Ok(serde_json::json!({
+                        "tool": tool_id_for_echo,
+                        "target_context": target_ctx_for_echo,
+                        "caller_did": caller_did_for_echo,
+                        "status": "validated",
+                        "input_valid": true,
+                        "validated_input": echo_input,
+                    }))
+                },
+                |h| {
+                    h(value).map_err(|e| {
+                        format!(
+                            "cross-context saga tool handler for '{tool_id_for_echo}' failed: {e}"
+                        )
+                    })
+                },
+            )
+        }
+    };
+
+    let request = CrossContextToolInvocationRequest {
+        caller_context_id: caller_context_bytes,
+        target_context_id: target_context_bytes,
+        caller_did: scp_primitives::DID(caller_did.to_owned()),
+        tool_registration_id: tool_registration_id.to_owned(),
+        ucan_proof_id,
+        input: input_json,
+        asserted_chain_depth,
+        asserted_nonce,
+        asserted_timestamp_ms,
+    };
+
+    // Dispatch to the producer on the global multi-thread runtime. PyO3 calls
+    // are sync; the Python SDK wrapper invokes us off `asyncio.to_thread`, so
+    // we are NOT inside a tokio context and `block_on` is safe (matches
+    // `tool_invoke_impl`). The saga blocks until a terminal state.
+    let output = tokio_rt
+        .block_on(async {
+            supervisor
+                .start_cross_context_tool_invocation_saga(
+                    request,
+                    SagaSigningKeys {
+                        target: &target_signing_key,
+                        caller: &caller_signing_key,
+                    },
+                    executor,
+                )
+                .await
+        })
+        .map_err(map_saga_error)?;
+
+    Ok(PySagaResult {
+        saga_id: output.saga_id.0,
+        receipt: output.receipt,
+        output: output.output,
+    })
+}
+
+// ---------------------------------------------------------------------------
 // Stateful tool sessions (spec section 6.2.1)
 // ---------------------------------------------------------------------------
 
@@ -1503,6 +1856,101 @@ impl crate::scp::PyScp {
         )
     }
 
+    /// Invokes a tool across context boundaries as an atomic two-phase saga
+    /// (spec §6.2.4, ADR-049 §3a).
+    ///
+    /// Unlike [`Self::tool_invoke_cross_context`] (the synchronous,
+    /// single-context-side path), this drives the full §6.2.4 cross-context
+    /// tool-invocation saga over the two CO-RESIDENT participant contexts
+    /// (caller + target): Prepare-A / Prepare-B authorize and stage both
+    /// sides, the tool executes EXACTLY ONCE supervisor-side at Commit-B, and
+    /// each side records its own event-log entry. Both contexts MUST be
+    /// co-resident in this bridge instance (the cross-node child-bridge
+    /// transport is separate future work).
+    ///
+    /// # Caller authentication (normative — §6.2.4, ADR-049 §3a)
+    ///
+    /// `caller_did` is bound to the bridge-authenticated principal: it MUST be
+    /// an identity THIS bridge instance hosts (created here via identity
+    /// creation) AND a member of `caller_context_id`. A mismatch raises
+    /// `SagaAbortedError` BEFORE the saga runs — the saga never observes an
+    /// unauthenticated caller. The `asserted_nonce_hex` / `timestamp_ms` /
+    /// `chain_depth` REMAIN caller-supplied freshness fields (the target
+    /// validates them; they are not minted here).
+    ///
+    /// # Arguments
+    ///
+    /// * `caller_context_id` — The initiating (caller) context id.
+    /// * `target_context_id` — The executing (target) context id.
+    /// * `caller_did` — The initiator DID (bound to the bridge principal).
+    /// * `tool_registration_id` — The tool to invoke across the interface.
+    /// * `input` — Tool input (a Python dict; schema-checked target-side).
+    /// * `asserted_nonce_hex` — The 16-byte §6.2.4 envelope nonce as a
+    ///   32-char hex string (the freshness/dedup token).
+    /// * `timestamp_ms` — Caller-asserted send time (Unix ms; freshness check).
+    /// * `chain_depth` — Caller-asserted inbound provenance depth (advisory;
+    ///   the target re-derives `+1`).
+    /// * `ucan_proof_id` — Optional id of the spending UCAN proof, resolved
+    ///   target-side at Prepare-B. `None` for an ungated tool.
+    ///
+    /// # Returns
+    ///
+    /// A [`PySagaResult`] on the committed terminal, carrying the
+    /// supervisor-minted `saga_id`, the target's signed receipt bytes, and the
+    /// captured tool-output bytes. The `saga_id` is supervisor-minted — it is
+    /// never an input.
+    ///
+    /// # Errors
+    ///
+    /// Raises one of the typed saga exceptions — `SagaAbortedError` (a
+    /// Prepare-phase rejection — authorization, freshness, rate limit, or
+    /// co-residency; carries `retry_after_ms`), `SagaNeedsRepairError`
+    /// (Commit-retry exhausted — carries the durable `saga_id` operator-repair
+    /// handle), or `SagaBusyError` (the participant context set overlapped an
+    /// in-flight saga — §5.15.4). Raises `ValidationError` if an id/DID/tool-id
+    /// is malformed or `asserted_nonce_hex` does not decode to 16 bytes.
+    ///
+    /// See spec §6.2.4 and ADR-049 §3a.
+    #[pyo3(name = "tool_invoke_cross_context_saga")]
+    #[pyo3(signature = (
+        caller_context_id,
+        target_context_id,
+        caller_did,
+        tool_registration_id,
+        input,
+        asserted_nonce_hex,
+        timestamp_ms,
+        chain_depth,
+        ucan_proof_id=None,
+    ))]
+    #[allow(clippy::too_many_arguments)] // Flat §6.2.4 envelope — agent-first named params.
+    pub fn tool_invoke_cross_context_saga(
+        &self,
+        caller_context_id: &str,
+        target_context_id: &str,
+        caller_did: &str,
+        tool_registration_id: &str,
+        input: &Bound<'_, PyDict>,
+        asserted_nonce_hex: &str,
+        timestamp_ms: u64,
+        chain_depth: u8,
+        ucan_proof_id: Option<String>,
+    ) -> PyResult<PySagaResult> {
+        let bi = &*self.inner;
+        tool_invoke_cross_context_saga_impl(
+            bi,
+            caller_context_id,
+            target_context_id,
+            caller_did,
+            tool_registration_id,
+            input,
+            asserted_nonce_hex,
+            timestamp_ms,
+            chain_depth,
+            ucan_proof_id,
+        )
+    }
+
     /// Creates a stateful tool session.
     ///
     /// Sessions enable multi-turn workflows with state preservation across
@@ -1642,6 +2090,7 @@ impl crate::scp::PyScp {
 pub fn register_tools(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_class::<PyToolRegistration>()?;
     m.add_class::<PyToolVerificationResult>()?;
+    m.add_class::<PySagaResult>()?;
     Ok(())
 }
 
@@ -1650,7 +2099,7 @@ pub fn register_tools(m: &Bound<'_, PyModule>) -> PyResult<()> {
 // ---------------------------------------------------------------------------
 
 #[cfg(test)]
-#[allow(clippy::unwrap_used, clippy::expect_used)]
+#[allow(clippy::unwrap_used, clippy::expect_used, clippy::panic)]
 mod tests {
     use super::*;
     use scp_ffi_common::error_codes as codes;
@@ -2102,5 +2551,122 @@ mod tests {
 
         // Clean up global state.
         crate::runtime::remove_ffi_state(bi, &ctx_id);
+    }
+
+    // ------------------------------------------------------------------
+    // map_saga_error — the bridge's typed-terminal → typed-error mapping.
+    //
+    // The producer's actual terminal behavior (which SagaError a given saga
+    // run yields) is covered in `crates/scp-runtime`; here we test ONLY the
+    // bridge's mapping responsibility: that each typed `SagaError` becomes the
+    // right `ScpPyError` variant with EVERY structured datum preserved
+    // STRUCTURALLY (read off the variant, never parsed from a message) and the
+    // canonical `SCP-SAGA-13xxx` code attached.
+    // ------------------------------------------------------------------
+
+    use scp_core::context::supervisor::{SagaAbortReason, SagaError as CoreSagaError, SagaId};
+
+    /// A rate-limited abort preserves `retry_after_ms = Some(ms)` STRUCTURALLY
+    /// and formats the producer's numeric `code` as the canonical
+    /// `SCP-SAGA-{code}` string.
+    #[test]
+    fn map_saga_error_rate_limited_preserves_retry_after_ms() {
+        let mapped = map_saga_error(CoreSagaError::Aborted {
+            reason: SagaAbortReason::RateLimited {
+                retry_after_ms: Some(2500),
+            },
+            code: 13026,
+            message: "inbound rate limit exceeded".to_owned(),
+        });
+        match mapped {
+            ScpPyError::SagaAborted {
+                code,
+                retry_after_ms,
+                ..
+            } => {
+                assert_eq!(code, "SCP-SAGA-13026");
+                assert_eq!(retry_after_ms, Some(2500));
+            }
+            other => panic!("expected SagaAborted, got {other:?}"),
+        }
+    }
+
+    /// A rate-limited abort with NO precise back-off instant preserves
+    /// `retry_after_ms = None` — NEVER coerced to `Some(0)` (a `0` would read
+    /// as "retry immediately" and re-trip the same hard limit).
+    #[test]
+    fn map_saga_error_rate_limited_none_is_not_zero() {
+        let mapped = map_saga_error(CoreSagaError::Aborted {
+            reason: SagaAbortReason::RateLimited {
+                retry_after_ms: None,
+            },
+            code: 13026,
+            message: "hard limit, no precise back-off".to_owned(),
+        });
+        match mapped {
+            ScpPyError::SagaAborted { retry_after_ms, .. } => {
+                assert_eq!(retry_after_ms, None, "None must NOT be coerced to Some(0)");
+            }
+            other => panic!("expected SagaAborted, got {other:?}"),
+        }
+    }
+
+    /// A plain (non-rate-limit) `Rejected` abort carries `retry_after_ms = None`.
+    #[test]
+    fn map_saga_error_rejected_has_no_retry_hint() {
+        let mapped = map_saga_error(CoreSagaError::Aborted {
+            reason: SagaAbortReason::Rejected,
+            code: 13050,
+            message: "caller not a member".to_owned(),
+        });
+        match mapped {
+            ScpPyError::SagaAborted {
+                code,
+                retry_after_ms,
+                ..
+            } => {
+                assert_eq!(code, "SCP-SAGA-13050");
+                assert_eq!(retry_after_ms, None);
+            }
+            other => panic!("expected SagaAborted, got {other:?}"),
+        }
+    }
+
+    /// `NeedsRepair` preserves the durable `saga_id` operator-repair handle and
+    /// the fixed terminal code `SCP-SAGA-13065`.
+    #[test]
+    fn map_saga_error_needs_repair_preserves_saga_id() {
+        let mapped = map_saga_error(CoreSagaError::NeedsRepair {
+            saga_id: SagaId("saga-abc-123".to_owned()),
+            message: "commit retries exhausted".to_owned(),
+        });
+        match mapped {
+            ScpPyError::SagaNeedsRepair { code, saga_id, .. } => {
+                assert_eq!(code, codes::SAGA_13065);
+                assert_eq!(saga_id, "saga-abc-123");
+            }
+            other => panic!("expected SagaNeedsRepair, got {other:?}"),
+        }
+    }
+
+    /// `Busy` preserves the contended context id and the fixed terminal code
+    /// `SCP-SAGA-13066`.
+    #[test]
+    fn map_saga_error_busy_preserves_contended_context() {
+        let mapped = map_saga_error(CoreSagaError::Busy {
+            contended_context: "ctx-shared-99".to_owned(),
+            message: "participant set overlaps an in-flight saga".to_owned(),
+        });
+        match mapped {
+            ScpPyError::SagaBusy {
+                code,
+                contended_context,
+                ..
+            } => {
+                assert_eq!(code, codes::SAGA_13066);
+                assert_eq!(contended_context, "ctx-shared-99");
+            }
+            other => panic!("expected SagaBusy, got {other:?}"),
+        }
     }
 }

--- a/crates/scp-ffi/src/tools.rs
+++ b/crates/scp-ffi/src/tools.rs
@@ -1866,6 +1866,33 @@ impl crate::scp::PyScp {
     /// `chain_depth` REMAIN caller-supplied freshness fields (the target
     /// validates them; they are not minted here).
     ///
+    /// # Trust boundary (co-resident single-tenant only)
+    ///
+    /// The caller-principal binding (`enforce_caller_principal_binding`) treats
+    /// "hosted in this bridge instance's identity registry" as the
+    /// channel-authenticated principal. That equivalence holds ONLY for a
+    /// single-tenant, co-resident SDK process. This surface MUST NOT be exposed
+    /// across a trust boundary within one process: a multi-tenant host loading
+    /// multiple users' identities into one bridge instance could assert any
+    /// hosted `caller_did`, since the registry cannot distinguish which tenant
+    /// is making the call. The future cross-node leg needs real channel auth
+    /// (ADR-049 §3a forward obligation) — it cannot reuse "is hosted here" as
+    /// the authenticated-principal proof.
+    ///
+    /// On the `PyO3` string-id surface the caller/target context-id axes are
+    /// enforced by the supervisor gates — membership (`is_member`) for the
+    /// caller context and the governance-established tool-interface gate for the
+    /// target context — rather than the instance-affine handle pre-check the
+    /// NAPI/UniFFI handle-based surfaces apply. The authorization is equivalent;
+    /// the difference is only that this surface carries less pre-flight
+    /// defense-in-depth, matching the `PyO3` string-id idiom (the gates are the
+    /// authoritative check on both surfaces).
+    ///
+    /// The receipt's signer-authorization — that the target key is
+    /// governance-authorized to act for `target_context_id` (§6.2.4 "Signer
+    /// authorization") — is a DOWNSTREAM receipt-consumer obligation verified
+    /// when the receipt is consumed, NOT enforced at this export.
+    ///
     /// # Arguments
     ///
     /// * `caller_context_id` — The initiating (caller) context id.

--- a/crates/scp-ffi/tests/e2e_bridge.rs
+++ b/crates/scp-ffi/tests/e2e_bridge.rs
@@ -25,6 +25,7 @@ use std::sync::Once;
 use pyo3::prelude::*;
 use pyo3::types::{PyDict, PyList};
 
+use _scp_core::context::PyContextHandle;
 use _scp_core::custody::FfiKeyCustody;
 use _scp_core::runtime::{self, IdentityEntry, PyBridgeInstance};
 
@@ -1522,5 +1523,289 @@ fn xctx_saga_malformed_nonce_rejected_fail_closed() {
             err.to_string().contains("16 bytes"),
             "message must explain the 16-byte requirement, got: {err}"
         );
+    });
+}
+
+/// Reads a `PyContextHandle`'s `context_id` through its Python getter. The
+/// bridge's `context_create` generates the id internally and the Rust-level
+/// getter is `#[pymethods]`-private, so the id is read the same way a Python
+/// caller would: via the `context_id` attribute.
+fn handle_context_id(py: Python<'_>, handle: &PyContextHandle) -> String {
+    handle
+        .clone()
+        .into_pyobject(py)
+        .unwrap()
+        .getattr("context_id")
+        .unwrap()
+        .extract::<String>()
+        .unwrap()
+}
+
+/// Builds and wires the full saga precondition through the `PyO3` bridge:
+/// owner identity, caller context A, target context B, the tool registered into
+/// both B's actor governance state and the FFI-side registry (with a
+/// deterministic handler), and the bidirectionally-approved `ToolInterface`
+/// established in A. Returns `(scp, ctx_a, ctx_b, owner, tool_id)` so the
+/// `#[test]` body can invoke the saga and assert its terminal state. All setup
+/// lives here; every assertion stays in the test.
+///
+/// The setup mirrors the producer's two authorization axes
+/// (`start_cross_context_tool_invocation_saga`, supervisor.rs):
+///
+/// 1. **Caller axis (gate 1).** `caller_did` must be hosted by this bridge AND a
+///    member of the CALLER (source) context A. Creating A via `context_create`
+///    with `owner` as the single-admin creator satisfies both.
+/// 2. **Target axis (gate 2).** The producer requires a *bidirectionally
+///    approved* `ToolInterface` (`approved_by_source && approved_by_target`)
+///    that it queries against the CALLER context A's actor governance state
+///    (`has_established_tool_interface`, `queries_helpers.rs`) — NOT context B's.
+///    So the interface is established IN A, via a governance
+///    `EstablishToolInterface` action proposed by A's admin (auto-executed under
+///    `single_admin`). `execute_establish_tool_interface` (`governance_helpers.rs`)
+///    pushes the interface verbatim into A's `governance.tool_interfaces`, and
+///    additionally requires A's ceiling to contain `tool:interface` — which the
+///    admin role grants because A's ceiling lists it. The three id-form fields
+///    (`source_context` = A, `target_context` = B, `tool_id` = the registration
+///    id) are compared on the raw 64-hex digest form, so they must equal A/B/id
+///    exactly, with BOTH approvals `true`.
+///
+/// Context B holds the registered tool plus the handler the executor snapshots
+/// and runs once at Commit-B (`rt.tool_handlers.get(tool_id)`, tools.rs). The
+/// handler returns `{"sum": 42, "ok": 1}`, which Commit-B validates against the
+/// tool's registered numeric `{sum, ok}` output schema (from `build_tool_reg`)
+/// before committing. The committed output bytes therefore decode to that JSON.
+fn establish_xctx_saga_commit_preconditions(
+    py: Python<'_>,
+) -> (_scp_core::scp::PyScp, String, String, String, String) {
+    // Initializes the process-global tokio runtime the bridge methods
+    // (`identity_create`, `context_create`, `governance_propose`,
+    // `tool_invoke_cross_context_saga`) block on.
+    setup();
+    let scp = _scp_core::scp::PyScp::new_in_memory_for_test();
+    let bi = scp.bridge_instance();
+
+    // Create the owner via the bridge's real `identity_create` so its DID
+    // document is published into the per-instance resolver DHT, and so the
+    // resolver itself is initialized on the instance. Governance vote
+    // verification (even single_admin auto-execute) resolves the proposer's
+    // public key through that resolver — a registry-only test identity is
+    // unresolvable and fails with "unknown voter".
+    //
+    // This MUST precede `init_context_manager_for_test`: the supervisor
+    // snapshots `bi.did_resolver()` at build time, falling back to the
+    // always-`None` resolver if none is configured yet. Creating the
+    // identity first means the supervisor's governance key resolver is the
+    // real document-VM resolver that can see the published document.
+    let owner_identity = scp
+        .identity_create(py, "in_memory", None)
+        .unwrap()
+        .into_pyobject(py)
+        .unwrap();
+    let owner = owner_identity
+        .getattr("did")
+        .unwrap()
+        .extract::<String>()
+        .unwrap();
+
+    runtime::init_context_manager_for_test(bi);
+
+    // Context A (caller/source). Its ceiling carries the two load-bearing
+    // capabilities: `governance:propose` (so `owner`, as admin, can propose)
+    // and `tool:interface` (required by `execute_establish_tool_interface`'s
+    // ceiling check). The remaining entries are harmless. `context_create`
+    // generates a real 64-hex id, so the ADR-056 saga chokepoint round-trips
+    // to A's actor.
+    let params_a = PyDict::new(py);
+    let ceiling_a = PyList::new(
+        py,
+        [
+            "governance:propose",
+            "tool:interface",
+            "tools:invoke",
+            "messages:read",
+            "messages:write",
+        ],
+    )
+    .unwrap();
+    params_a.set_item("ceiling", ceiling_a).unwrap();
+    let handle_a = scp.context_create(&owner, &params_a.as_borrowed()).unwrap();
+    let ctx_a = handle_context_id(py, &handle_a);
+
+    // Context B (target). Its ceiling carries `governance:propose` and
+    // `tool:register` so the saga tool can be registered into B's ACTOR
+    // governance state (the saga's Prepare-B reads the tool from B's
+    // `governance.registered_tools`, not from the FFI-side registry).
+    let params_b = PyDict::new(py);
+    let ceiling_b = PyList::new(py, ["governance:propose", "tool:register"]).unwrap();
+    params_b.set_item("ceiling", ceiling_b).unwrap();
+    let handle_b = scp.context_create(&owner, &params_b.as_borrowed()).unwrap();
+    let ctx_b = handle_context_id(py, &handle_b);
+
+    // The tool id is the deterministic `generate_tool_id(name)` form shared
+    // by all bridges. The same id keys (a) B's actor `registered_tools`
+    // (saga Prepare-B), (b) the interface in A (saga gate 2), and (c) the
+    // FFI-side handler the executor snapshots at Commit-B.
+    let tool_name = "xctx_saga_commit_tool";
+    let tool_id = format!("tool-{tool_name}");
+
+    // Register the saga tool into B's ACTOR governance state so the saga's
+    // Prepare-B finds it.
+    let register_json = register_tool_action_json(&tool_id, tool_name, &owner);
+    scp.governance_propose(&handle_b, &owner, &register_json)
+        .expect("RegisterTool must auto-execute under single_admin");
+
+    // The executor snapshots the handler from the FFI-side `tool_handlers`
+    // at Commit-B. `register_tool_handler` requires the tool to exist in
+    // the FFI-side `tool_registry`, so register it there too (same id), then
+    // attach a deterministic handler returning the numeric `{sum, ok}`.
+    let reg = build_tool_reg(py, tool_name, &owner);
+    let ffi_tool_id = scp.tool_register(&ctx_b, &reg.as_borrowed()).unwrap();
+    assert_eq!(
+        ffi_tool_id, tool_id,
+        "FFI and governance tool ids must agree (deterministic generate_tool_id)"
+    );
+    let handler: runtime::ToolHandler =
+        Arc::new(|_input: serde_json::Value| Ok(serde_json::json!({"sum": 42, "ok": 1})));
+    runtime::register_tool_handler(bi, &ctx_b, &tool_id, handler).unwrap();
+
+    // Establish the bidirectionally-approved interface in A via governance.
+    let action_json = establish_interface_action_json(&ctx_a, &ctx_b, &tool_id);
+    let propose_result = scp
+        .governance_propose(&handle_a, &owner, &action_json)
+        .expect("EstablishToolInterface must auto-execute under single_admin");
+    assert!(
+        !propose_result.is_empty(),
+        "governance_propose must return a non-empty result JSON"
+    );
+
+    (scp, ctx_a, ctx_b, owner, tool_id)
+}
+
+/// Serializes a `RegisterTool` governance action for the saga tool. The schema
+/// mirrors `build_tool_reg`: 2 input + 2 output properties (clears the §9.2.1
+/// specificity floor of 2), numeric `{sum, ok}` output (so Commit-B's
+/// output-schema validation accepts the handler's response). `implementation_hash`
+/// is a fixed `[u8; 32]`; serde expects a 32-element JSON number array (the
+/// `json!` macro has no array-repeat sugar).
+fn register_tool_action_json(tool_id: &str, tool_name: &str, owner: &str) -> String {
+    let impl_hash = serde_json::Value::from(vec![0u8; 32]);
+    let register_action = serde_json::json!({
+        "RegisterTool": {
+            "registration": {
+                "tool_id": tool_id,
+                "name": tool_name,
+                "description": format!("Tool: {tool_name}"),
+                "schema": {
+                    "input_schema": {
+                        "type": "object",
+                        "properties": {
+                            "a": {"type": "string"},
+                            "b": {"type": "string"}
+                        }
+                    },
+                    "output_schema": {
+                        "type": "object",
+                        "properties": {
+                            "sum": {"type": "number"},
+                            "ok": {"type": "number"}
+                        }
+                    }
+                },
+                "implementation_hash": impl_hash,
+                "test_vectors": [],
+                "operator_did": owner,
+                "cost": null,
+                "registered_at": 0,
+                "signature": []
+            }
+        }
+    });
+    serde_json::to_string(&register_action).unwrap()
+}
+
+/// Serializes the bidirectionally-approved `EstablishToolInterface` governance
+/// action. Externally-tagged `GovernanceAction` (no serde rename) → the
+/// `EstablishToolInterface` variant wraps the `snake_case` `ToolInterface` struct;
+/// the `Option` fields render as JSON `null`.
+fn establish_interface_action_json(ctx_a: &str, ctx_b: &str, tool_id: &str) -> String {
+    let action = serde_json::json!({
+        "EstablishToolInterface": {
+            "interface": {
+                "source_context": ctx_a,
+                "target_context": ctx_b,
+                "tool_id": tool_id,
+                "rate_limit": null,
+                "inbound_rate_limit": null,
+                "per_caller_rate_limit": null,
+                "approved_by_source": true,
+                "approved_by_target": true,
+                "outbound_policy": null,
+                "inbound_policy": null
+            }
+        }
+    });
+    serde_json::to_string(&action).unwrap()
+}
+
+/// Full `Committed` terminal through the `PyO3` bridge: an authenticated caller
+/// drives the §6.2.4 cross-context tool-invocation saga to a real commit and
+/// the bridge returns the committed receipt + output bytes. See
+/// `establish_xctx_saga_commit_preconditions` for the setup it depends on.
+#[test]
+fn xctx_saga_authenticated_caller_commits_via_governance_established_interface() {
+    Python::with_gil(|py| {
+        let (scp, ctx_a, ctx_b, owner, tool_id) = establish_xctx_saga_commit_preconditions(py);
+
+        // Invoke the saga from A → B with the authenticated caller. The tool's
+        // input schema wants string `a`/`b`.
+        let input = PyDict::new(py);
+        input.set_item("a", "x").unwrap();
+        input.set_item("b", "y").unwrap();
+
+        // A near-now timestamp: Prepare-B enforces a §9.14 ±5min skew tolerance,
+        // so a fixed historical timestamp would abort with SCP-SAGA-13018.
+        let now_ms = u64::try_from(
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_millis(),
+        )
+        .unwrap();
+
+        let result = scp
+            .tool_invoke_cross_context_saga(
+                &ctx_a,
+                &ctx_b,
+                &owner,
+                &tool_id,
+                &input.as_borrowed(),
+                &nonce_hex(),
+                now_ms,
+                1,
+                None,
+            )
+            .expect("saga must reach Committed");
+
+        // Committed terminal: non-empty saga id + a receipt + output bytes.
+        assert!(
+            !result.saga_id.is_empty(),
+            "a committed saga must carry a non-empty saga id"
+        );
+        assert!(
+            result.receipt.is_some(),
+            "committed saga must carry a receipt"
+        );
+        assert!(
+            result.output.is_some(),
+            "committed saga must carry output bytes"
+        );
+
+        // The committed output decodes to the handler's response (numeric, per
+        // the registered output schema). Assert the parsed values, not raw
+        // bytes, so a JCS-canonical encoding still passes.
+        let out: serde_json::Value =
+            serde_json::from_slice(result.output.as_ref().unwrap()).unwrap();
+        assert_eq!(out["sum"], 42, "committed output sum must be the handler's");
+        assert_eq!(out["ok"], 1, "committed output ok must be the handler's");
     });
 }

--- a/crates/scp-ffi/tests/e2e_bridge.rs
+++ b/crates/scp-ffi/tests/e2e_bridge.rs
@@ -1399,9 +1399,18 @@ fn xctx_saga_hosted_non_member_caller_rejected() {
             msg.contains("SCP-SAGA-13050"),
             "expected caller-axis SCP-SAGA-13050, got: {msg}"
         );
+        // BRIDGE-UNIQUE axis-b substring. The producer's gate 1 ALSO rejects a
+        // non-member with SCP-SAGA-13050 and a message containing the bare
+        // "is not a member of caller" phrasing — so asserting only "not a member
+        // of" would PASS even if the PyO3 membership axis were removed (the
+        // producer's gate would surface the same code + substring). Asserting
+        // the bridge-unique "is hosted by this bridge but is not a member of"
+        // prefix (which the producer never emits) makes this test fail closed if
+        // the bridge's axis-b `is_member` check is deleted.
         assert!(
-            msg.contains("not a member of"),
-            "message must name the membership mismatch, got: {msg}"
+            msg.contains("is hosted by this bridge but is not a member of"),
+            "message must be the BRIDGE axis-b membership rejection (not the producer gate-1 \
+             message), got: {msg}"
         );
     });
 }

--- a/crates/scp-ffi/tests/e2e_bridge.rs
+++ b/crates/scp-ffi/tests/e2e_bridge.rs
@@ -1222,3 +1222,305 @@ fn cross_domain_identity_context_tool_eventlog_provenance() {
 // Validation of unknown storage `type` strings now happens at the Python
 // boundary in `crate::scp::PyScp::with_storage` (covered by
 // `bindings/python/tests/test_scp_class.py::test_with_storage_rejects_unknown_type`).
+
+// ============================================================================
+// Cross-context tool-invocation saga (§6.2.4, ADR-049 §3a) — PyO3 export
+// ============================================================================
+//
+// These tests exercise what the PyO3 bridge ADDS on top of the supervisor
+// producer (`start_cross_context_tool_invocation_saga`), whose committed /
+// abort / busy / rate-limit / co-residency paths are covered in
+// `crates/scp-runtime` integration tests (the full `Committed` path needs the
+// actor-state interface establishment those tests inject directly, which has
+// no bridge-public wiring). At the bridge layer the export's own
+// responsibilities are:
+//
+//   - the §6.2.4 *Caller authentication* binding (caller_did MUST be hosted by
+//     this bridge instance AND a member of caller_context_id) — rejected BEFORE
+//     the saga runs;
+//   - the ADR-056 chokepoint (a real 64-hex id decodes to the digest the
+//     producer's `hex::encode` lookup expects — it reaches the actor rather
+//     than double-hashing to a missing slot);
+//   - the participant-context-set gating surfaced as `SagaBusyError`;
+//   - fail-closed nonce decoding;
+//   - the typed terminal → typed Python exception mapping.
+
+/// A real 64-character lowercase-hex context id (32 bytes). The ADR-056
+/// chokepoint decodes such an id to its digest, and the producer's
+/// `hex::encode(digest)` actor lookup reproduces the SAME 64-hex string — so a
+/// context registered under this id is reachable by the saga. (The 32-hex
+/// `random_context_id` helper would hit the SHA-256 fallback and miss the
+/// actor.)
+fn random_64hex_context_id() -> String {
+    use rand::RngCore;
+    let mut bytes = [0u8; 32];
+    rand::thread_rng().fill_bytes(&mut bytes);
+    hex::encode(bytes)
+}
+
+/// Creates a co-resident context under a real 64-hex id (so the saga
+/// chokepoint round-trips to the actor). Mirrors [`create_test_context`] but
+/// with a caller-chosen id.
+fn create_test_context_with_id(bi: &PyBridgeInstance, creator_did: &str, context_id: &str) {
+    setup();
+    runtime::register_context(bi, context_id, creator_did, &[]).unwrap();
+
+    let rt = test_runtime();
+    let supervisor = runtime::supervisor(bi).unwrap().clone();
+    let creator = scp_identity::DID(creator_did.to_owned());
+    let ctx_id = context_id.to_owned();
+
+    rt.block_on(async move {
+        let params = scp_core::context::ContextParams::default();
+        supervisor
+            .create_context(ctx_id.clone(), params, creator.clone(), None)
+            .await
+            .unwrap();
+        supervisor.register_local_did(creator).await.unwrap();
+    });
+}
+
+/// Registers a minimal `{a,b} -> {sum,ok}` tool in `context_id`, returning the
+/// tool registration id. Reuses the shared [`build_tool_reg`] schema.
+fn register_saga_tool(
+    py: Python<'_>,
+    scp: &_scp_core::scp::PyScp,
+    context_id: &str,
+    operator_did: &str,
+) -> String {
+    let reg = build_tool_reg(py, "xctx_saga_tool", operator_did);
+    scp.tool_register(context_id, &reg.as_borrowed()).unwrap()
+}
+
+/// A valid 16-byte nonce as a 32-char hex string.
+fn nonce_hex() -> String {
+    "00112233445566778899aabbccddeeff".to_owned()
+}
+
+/// (a) Caller-principal binding: a `caller_did` this bridge instance does NOT
+/// host is rejected with `SagaAbortedError` (SCP-SAGA-13050) BEFORE the saga
+/// runs — the §6.2.4 *Caller authentication* channel-auth binding. The caller
+/// is a real well-formed DID that is simply not in this instance's registry.
+#[test]
+fn xctx_saga_unhosted_caller_rejected_before_saga() {
+    Python::with_gil(|py| {
+        let scp = _scp_core::scp::PyScp::new_in_memory_for_test();
+        runtime::init_context_manager_for_test(scp.bridge_instance());
+        let bi = scp.bridge_instance();
+
+        let owner = create_test_identity(bi);
+        let caller_ctx = random_64hex_context_id();
+        let target_ctx = random_64hex_context_id();
+        create_test_context_with_id(bi, &owner, &caller_ctx);
+        create_test_context_with_id(bi, &owner, &target_ctx);
+        let tool_id = register_saga_tool(py, &scp, &target_ctx, &owner);
+
+        // A syntactically valid DID that was never created on this instance.
+        let unhosted_caller = "did:dht:z6MkUnhostedCallerPrincipal0001";
+
+        let input = PyDict::new(py);
+        input.set_item("a", "x").unwrap();
+        input.set_item("b", "y").unwrap();
+
+        let err = scp
+            .tool_invoke_cross_context_saga(
+                &caller_ctx,
+                &target_ctx,
+                unhosted_caller,
+                &tool_id,
+                &input.as_borrowed(),
+                &nonce_hex(),
+                1_700_000_000_000,
+                1,
+                None,
+            )
+            .expect_err("an unhosted caller_did must be rejected before the saga runs");
+
+        assert!(
+            err.is_instance_of::<_scp_core::error::SagaAbortedError>(py),
+            "expected SagaAbortedError, got: {err}"
+        );
+        let msg = err.to_string();
+        assert!(
+            msg.contains("SCP-SAGA-13050"),
+            "expected caller-axis SCP-SAGA-13050, got: {msg}"
+        );
+        assert!(
+            msg.contains("not an identity hosted by this bridge"),
+            "message must name the hosted-principal mismatch, got: {msg}"
+        );
+    });
+}
+
+/// (b) Caller-principal binding, membership axis: a `caller_did` that IS hosted
+/// by this bridge but is NOT a member of `caller_context_id` is rejected with
+/// `SagaAbortedError` (SCP-SAGA-13050) BEFORE the saga runs.
+#[test]
+fn xctx_saga_hosted_non_member_caller_rejected() {
+    Python::with_gil(|py| {
+        let scp = _scp_core::scp::PyScp::new_in_memory_for_test();
+        runtime::init_context_manager_for_test(scp.bridge_instance());
+        let bi = scp.bridge_instance();
+
+        let owner = create_test_identity(bi);
+        // A SECOND hosted identity that is NOT a member of caller_ctx.
+        let stranger = create_test_identity(bi);
+        let caller_ctx = random_64hex_context_id();
+        let target_ctx = random_64hex_context_id();
+        create_test_context_with_id(bi, &owner, &caller_ctx);
+        create_test_context_with_id(bi, &owner, &target_ctx);
+        let tool_id = register_saga_tool(py, &scp, &target_ctx, &owner);
+
+        let input = PyDict::new(py);
+        input.set_item("a", "x").unwrap();
+        input.set_item("b", "y").unwrap();
+
+        let err = scp
+            .tool_invoke_cross_context_saga(
+                &caller_ctx,
+                &target_ctx,
+                &stranger, // hosted, but not a member of caller_ctx
+                &tool_id,
+                &input.as_borrowed(),
+                &nonce_hex(),
+                1_700_000_000_000,
+                1,
+                None,
+            )
+            .expect_err("a hosted non-member caller must be rejected before the saga runs");
+
+        assert!(
+            err.is_instance_of::<_scp_core::error::SagaAbortedError>(py),
+            "expected SagaAbortedError, got: {err}"
+        );
+        let msg = err.to_string();
+        assert!(
+            msg.contains("SCP-SAGA-13050"),
+            "expected caller-axis SCP-SAGA-13050, got: {msg}"
+        );
+        assert!(
+            msg.contains("not a member of"),
+            "message must name the membership mismatch, got: {msg}"
+        );
+    });
+}
+
+/// (c)+(e) Chokepoint + target-axis authorization: an authenticated caller
+/// (hosted + member) over REAL 64-hex contexts passes the bridge's
+/// channel-auth binding and the chokepoint round-trips to the actor — the saga
+/// then aborts at the supervisor's TARGET-axis gate (SCP-SAGA-13062: no
+/// established interface) rather than at the caller gate or with a spurious
+/// `ContextNotRegistered`. Reaching 13062 proves the digest keyed the right
+/// actor (had the chokepoint double-hashed, gate 1's `is_member` would have
+/// failed first with 13050).
+#[test]
+fn xctx_saga_authenticated_caller_reaches_target_axis_gate() {
+    Python::with_gil(|py| {
+        let scp = _scp_core::scp::PyScp::new_in_memory_for_test();
+        runtime::init_context_manager_for_test(scp.bridge_instance());
+        let bi = scp.bridge_instance();
+
+        let owner = create_test_identity(bi);
+        let caller_ctx = random_64hex_context_id();
+        let target_ctx = random_64hex_context_id();
+        create_test_context_with_id(bi, &owner, &caller_ctx);
+        create_test_context_with_id(bi, &owner, &target_ctx);
+        let tool_id = register_saga_tool(py, &scp, &target_ctx, &owner);
+
+        let input = PyDict::new(py);
+        input.set_item("a", "x").unwrap();
+        input.set_item("b", "y").unwrap();
+
+        let err = scp
+            .tool_invoke_cross_context_saga(
+                &caller_ctx,
+                &target_ctx,
+                &owner, // hosted AND a member of caller_ctx (its creator)
+                &tool_id,
+                &input.as_borrowed(),
+                &nonce_hex(),
+                1_700_000_000_000,
+                1,
+                None,
+            )
+            .expect_err("no established interface exists, so the target-axis gate aborts the saga");
+
+        assert!(
+            err.is_instance_of::<_scp_core::error::SagaAbortedError>(py),
+            "expected SagaAbortedError, got: {err}"
+        );
+        let msg = err.to_string();
+        assert!(
+            msg.contains("SCP-SAGA-13062"),
+            "expected target-axis SCP-SAGA-13062 (caller passed gate 1 — chokepoint reached the \
+             actor), got: {msg}"
+        );
+        assert!(
+            !msg.contains("SCP-SAGA-13050"),
+            "must NOT be the caller-axis reject — the authenticated caller passed gate 1, got: {msg}"
+        );
+    });
+}
+
+// (d) Participant-context-set gating → `SagaBusyError` (SCP-SAGA-13066): NOT
+// reachable from the bridge's PUBLIC surface. The producer evaluates the
+// target-axis interface gate (SCP-SAGA-13062) BEFORE it attempts the
+// participant-context-set reservation (supervisor.rs:
+// `start_cross_context_tool_invocation_saga` runs gate 1 → gate 2 → reserve).
+// Establishing the actor-state `ToolInterface` that gate 2 requires has no
+// bridge-public wiring (the bridge's `tool_interface_expose`/`accept` write
+// only the FFI-side copy, not the actor's `governance.tool_interfaces`), so a
+// bridge caller cannot pass gate 2 and therefore can never reach the
+// reservation step to observe `SagaBusy`. The producer's actual `SagaBusy`
+// terminal is covered in `crates/scp-runtime` integration tests; the bridge's
+// SOLE added responsibility for the Busy terminal is the typed-error mapping,
+// which is unit-tested directly in `tools.rs`
+// (`map_saga_error` → `SagaBusyError` with the structured `contended_context`).
+
+/// Fail-closed nonce decoding: a malformed `asserted_nonce_hex` (wrong length)
+/// raises `ValidationError` — the bridge does NOT pad, truncate, or accept any
+/// non-canonical form. The saga never runs.
+#[test]
+fn xctx_saga_malformed_nonce_rejected_fail_closed() {
+    Python::with_gil(|py| {
+        let scp = _scp_core::scp::PyScp::new_in_memory_for_test();
+        runtime::init_context_manager_for_test(scp.bridge_instance());
+        let bi = scp.bridge_instance();
+
+        let owner = create_test_identity(bi);
+        let caller_ctx = random_64hex_context_id();
+        let target_ctx = random_64hex_context_id();
+        create_test_context_with_id(bi, &owner, &caller_ctx);
+        create_test_context_with_id(bi, &owner, &target_ctx);
+        let tool_id = register_saga_tool(py, &scp, &target_ctx, &owner);
+
+        let input = PyDict::new(py);
+        input.set_item("a", "x").unwrap();
+        input.set_item("b", "y").unwrap();
+
+        // 8 bytes, not 16.
+        let short_nonce = "0011223344556677";
+        let err = scp
+            .tool_invoke_cross_context_saga(
+                &caller_ctx,
+                &target_ctx,
+                &owner,
+                &tool_id,
+                &input.as_borrowed(),
+                short_nonce,
+                1_700_000_000_000,
+                1,
+                None,
+            )
+            .expect_err("a wrong-length nonce must be rejected fail-closed");
+
+        assert!(
+            err.is_instance_of::<_scp_core::error::ValidationError>(py),
+            "expected ValidationError, got: {err}"
+        );
+        assert!(
+            err.to_string().contains("16 bytes"),
+            "message must explain the 16-byte requirement, got: {err}"
+        );
+    });
+}

--- a/crates/scp-ffi/tests/e2e_bridge.rs
+++ b/crates/scp-ffi/tests/e2e_bridge.rs
@@ -1415,6 +1415,106 @@ fn xctx_saga_hosted_non_member_caller_rejected() {
     });
 }
 
+/// (a, axis-isolated) Caller-principal binding, hosted-here axis as the SOLE
+/// guard: a `caller_did` that IS a genuine member of `caller_context_id` (so the
+/// membership axis (b) would PASS) but is NOT an identity hosted by this bridge
+/// instance is STILL rejected with `SagaAbortedError` (SCP-SAGA-13050) BEFORE
+/// the saga runs.
+///
+/// This is the property the `xctx_saga_unhosted_caller_rejected_before_saga`
+/// test cannot prove: that test's caller is BOTH unhosted AND a non-member, so
+/// axis (b) (and the producer's gate 1) would reject it even if axis (a) were
+/// deleted. Here the caller is a real member of `caller_ctx` — it CREATED
+/// `caller_ctx` (the creator is always a member, per
+/// `context_create_establishes_mls_group`), so `supervisor.is_member` returns
+/// true and axis (b) passes the caller. The ONLY thing that can reject it is
+/// axis (a): the caller DID was never `create_test_identity`'d, so it is absent
+/// from this instance's identity registry. The test therefore fails closed iff
+/// the bridge's `identity_registry_contains` axis (a) check is removed, and is
+/// INDEPENDENT of axis (b) by construction.
+#[test]
+fn xctx_saga_member_but_unhosted_caller_rejected_by_hosted_axis() {
+    Python::with_gil(|py| {
+        let scp = _scp_core::scp::PyScp::new_in_memory_for_test();
+        runtime::init_context_manager_for_test(scp.bridge_instance());
+        let bi = scp.bridge_instance();
+
+        // `owner` is a hosted identity used only to create the TARGET context and
+        // register the saga tool (the tool operator must be a member of B).
+        let owner = create_test_identity(bi);
+
+        // The caller is a syntactically valid DID that CREATES `caller_ctx` —
+        // making it a genuine member of `caller_ctx` (the creator is always a
+        // member) so the supervisor's membership axis (b) passes — but is NEVER
+        // registered as a hosted identity on this instance (no
+        // `create_test_identity`), so the bridge's identity registry does NOT
+        // contain it. Axis (a) must reject it.
+        let member_but_unhosted_caller = "did:dht:z6MkMemberButUnhostedCaller001".to_owned();
+
+        let caller_ctx = random_64hex_context_id();
+        let target_ctx = random_64hex_context_id();
+        // Caller context is CREATED BY the unhosted caller → caller is a member.
+        create_test_context_with_id(bi, &member_but_unhosted_caller, &caller_ctx);
+        create_test_context_with_id(bi, &owner, &target_ctx);
+        let tool_id = register_saga_tool(py, &scp, &target_ctx, &owner);
+
+        // Precondition: the supervisor MUST see the caller as a member of
+        // `caller_ctx` (axis (b) passes), while the bridge's identity registry
+        // does NOT host it (axis (a) is the sole remaining guard).
+        let rt = test_runtime();
+        let supervisor = runtime::supervisor(bi).unwrap().clone();
+        assert!(
+            rt.block_on(supervisor.is_member(&caller_ctx, &member_but_unhosted_caller)),
+            "precondition: caller must be a genuine member of caller_ctx so axis (b) passes"
+        );
+        assert!(
+            !runtime::identity_registry_contains(bi, &member_but_unhosted_caller),
+            "precondition: caller must NOT be hosted so axis (a) is the sole guard"
+        );
+
+        let input = PyDict::new(py);
+        input.set_item("a", "x").unwrap();
+        input.set_item("b", "y").unwrap();
+
+        let err = scp
+            .tool_invoke_cross_context_saga(
+                &caller_ctx,
+                &target_ctx,
+                &member_but_unhosted_caller, // member of caller_ctx, but NOT hosted
+                &tool_id,
+                &input.as_borrowed(),
+                &nonce_hex(),
+                1_700_000_000_000,
+                1,
+                None,
+            )
+            .expect_err(
+                "a member-but-unhosted caller must be rejected by axis (a) before the saga",
+            );
+
+        assert!(
+            err.is_instance_of::<_scp_core::error::SagaAbortedError>(py),
+            "expected SagaAbortedError, got: {err}"
+        );
+        let msg = err.to_string();
+        assert!(
+            msg.contains("SCP-SAGA-13050"),
+            "expected caller-axis SCP-SAGA-13050, got: {msg}"
+        );
+        // BRIDGE-UNIQUE axis-(a) substring. Because the caller IS a member, the
+        // membership axis (b) and the producer's gate 1 would BOTH pass — so the
+        // axis-(b) message ("is hosted by this bridge but is not a member of") can
+        // never appear here. The ONLY rejection that fits is axis (a). Asserting
+        // its exact substring makes this test fail closed iff
+        // `enforce_caller_principal_binding`'s `identity_registry_contains` check
+        // is removed.
+        assert!(
+            msg.contains("not an identity hosted by this bridge instance"),
+            "message must be the BRIDGE axis-(a) hosted-here rejection, got: {msg}"
+        );
+    });
+}
+
 /// (c)+(e) Chokepoint + target-axis authorization: an authenticated caller
 /// (hosted + member) over REAL 64-hex contexts passes the bridge's
 /// channel-auth binding and the chokepoint round-trips to the actor — the saga

--- a/crates/scp-ffi/uniffi/Cargo.toml
+++ b/crates/scp-ffi/uniffi/Cargo.toml
@@ -22,7 +22,14 @@ default = ["server"]
 # material in unprotected heap memory — suitable for testing, CLI, and desktop
 # contexts but NOT for production mobile builds (iOS/Android). Mobile CI MUST
 # NOT enable this feature. See GitHub issue #88 and ADR-006.
-allow_in_memory_custody = ["scp-platform/testing"]
+# `scp-core/testing` (→ `scp-runtime/testing`) mirrors the NAPI bridge, where
+# `allow_in_memory_custody` pulls `dep:scp-testing` → `scp-core/testing`. It
+# makes test-only actor affordances (e.g. `Supervisor::test_insert_member`,
+# used by the member-but-unhosted axis-a saga test) available whenever this
+# feature is on, so per-test `#[cfg(feature = "allow_in_memory_custody")]`
+# gating compiles AND runs under the documented per-crate test invocation
+# (`cargo test -p scp-ffi-uniffi --features allow_in_memory_custody`).
+allow_in_memory_custody = ["scp-platform/testing", "scp-core/testing"]
 # Shared relay/node startup code. Pulls in scp-node and scp-platform/filesystem.
 server = ["scp-ffi-common/server", "dep:scp-node"]
 # Testing-only affordances (see scp-ffi/Cargo.toml for rationale). MUST NOT

--- a/crates/scp-ffi/uniffi/src/bridge.rs
+++ b/crates/scp-ffi/uniffi/src/bridge.rs
@@ -21378,6 +21378,12 @@ mod tests {
     /// custody registry. The test therefore fails closed iff the bridge's
     /// `identity_custody_registry.contains_key` axis (a) check is removed, and is
     /// INDEPENDENT of axis (b) by construction.
+    ///
+    /// Gated on `allow_in_memory_custody`: that feature is what enables
+    /// `scp-core/testing` (hence `scp-runtime/testing`), which provides
+    /// `Supervisor::test_insert_member`. Mirrors the NAPI sibling
+    /// `xctx_saga_member_but_unhosted_caller_rejected_by_hosted_axis`.
+    #[cfg(feature = "allow_in_memory_custody")]
     #[tokio::test]
     async fn xctx_saga_member_but_unhosted_caller_is_rejected_axis_a() {
         let scp = scp_test();

--- a/crates/scp-ffi/uniffi/src/bridge.rs
+++ b/crates/scp-ffi/uniffi/src/bridge.rs
@@ -12253,6 +12253,29 @@ impl Scp {
     /// / `timestamp_ms` / `chain_depth` REMAIN caller-supplied freshness fields
     /// (the target validates them; they are not minted here).
     ///
+    /// # Trust boundary (co-resident single-tenant only)
+    ///
+    /// The caller-principal binding (`enforce_caller_principal_binding`) treats
+    /// "hosted in this bridge instance's identity custody registry" as the
+    /// channel-authenticated principal. That equivalence holds ONLY for a
+    /// single-tenant, co-resident SDK process. This surface MUST NOT be exposed
+    /// across a trust boundary within one process: a multi-tenant host loading
+    /// multiple users' identities into one bridge instance could assert any
+    /// hosted `caller_did`, since the registry cannot distinguish which tenant
+    /// is making the call. The future cross-node leg needs real channel auth
+    /// (ADR-049 §3a forward obligation) — it cannot reuse "is hosted here" as
+    /// the authenticated-principal proof.
+    ///
+    /// The caller/target context-id axes are bound by the instance-affine
+    /// handle pre-check: `source_handle` / `target_handle` must have been minted
+    /// by THIS bridge instance (a foreign handle is rejected) before the
+    /// supervisor membership / tool-interface gates run.
+    ///
+    /// The receipt's signer-authorization — that the target key is
+    /// governance-authorized to act for the target context (§6.2.4 "Signer
+    /// authorization") — is a DOWNSTREAM receipt-consumer obligation verified
+    /// when the receipt is consumed, NOT enforced at this export.
+    ///
     /// # Arguments
     ///
     /// * `source_handle` — The initiating (caller) context handle.

--- a/crates/scp-ffi/uniffi/src/bridge.rs
+++ b/crates/scp-ffi/uniffi/src/bridge.rs
@@ -21362,4 +21362,129 @@ mod tests {
             other => panic!("expected SagaAborted (axis b), got {other:?}"),
         }
     }
+
+    /// Caller-principal binding, axis (a) as the SOLE guard — a MEMBER-but-
+    /// UNHOSTED caller is STILL rejected by axis (a).
+    ///
+    /// This is the property `xctx_saga_unhosted_caller_did_is_rejected_axis_a`
+    /// cannot prove: that test's caller is BOTH unhosted AND a non-member, so
+    /// axis (b) (and the producer's gate 1) would reject it even if axis (a) were
+    /// deleted. Here the caller is injected as a genuine member of the caller
+    /// context via `Supervisor::test_insert_member` (the actor-state membership
+    /// injection that bypasses the MLS Welcome a non-hosted DID could never
+    /// complete), so `supervisor.is_member` returns true and axis (b) PASSES the
+    /// caller. The ONLY thing that can reject it is axis (a): the caller DID was
+    /// never `identity_create`'d, so it is absent from this instance's identity
+    /// custody registry. The test therefore fails closed iff the bridge's
+    /// `identity_custody_registry.contains_key` axis (a) check is removed, and is
+    /// INDEPENDENT of axis (b) by construction.
+    #[tokio::test]
+    async fn xctx_saga_member_but_unhosted_caller_is_rejected_axis_a() {
+        let scp = scp_test();
+        let bi = Arc::clone(&scp.inner);
+
+        let _resolver_dht = install_seedable_resolver(&bi);
+
+        // `owner` is a hosted identity used only to create the caller context.
+        let owner_identity = scp
+            .identity_create("in_memory".to_owned(), None)
+            .await
+            .expect("owner identity creation must succeed");
+
+        // A real, registered caller context owned by `owner`.
+        let handle_a = scp
+            .context_create(
+                Arc::clone(&owner_identity),
+                saga_context_params(&["governance:propose", "tools:invoke"]),
+            )
+            .await
+            .expect("caller context A must be created");
+        let ctx_a = handle_a.context_id.clone();
+
+        // The caller is a syntactically-valid DID that is NEVER `identity_create`'d
+        // (so the identity custody registry does NOT host it — axis (a) must
+        // reject), yet is injected as a genuine member of the caller context via
+        // the actor-state membership path (so `supervisor.is_member` returns true
+        // and axis (b) passes). `test_insert_member` records the member into role
+        // state exactly as an executed `AddMember` would, without the MLS Welcome
+        // a non-hosted DID could never complete.
+        let member_but_unhosted_caller = "did:dht:zzzzmemberbutunhostedcaller00001".to_owned();
+        let supervisor = Arc::clone(
+            bi.context_manager_or_error()
+                .expect("supervisor must be initialized"),
+        );
+        supervisor
+            .test_insert_member(
+                &ctx_a,
+                scp_identity::DID(member_but_unhosted_caller.clone()),
+                "member",
+            )
+            .await
+            .expect("test_insert_member should record the caller into caller_ctx membership");
+
+        // Precondition: the supervisor MUST see the caller as a member of the
+        // caller context (axis (b) passes), while the identity custody registry
+        // does NOT host it (axis (a) is the sole remaining guard).
+        assert!(
+            supervisor
+                .is_member(&ctx_a, &member_but_unhosted_caller)
+                .await,
+            "precondition: caller must be a genuine member of caller_ctx so axis (b) passes"
+        );
+        assert!(
+            !identity_custody_registry(&bi).contains_key(&member_but_unhosted_caller),
+            "precondition: caller must NOT be hosted so axis (a) is the sole guard"
+        );
+
+        let now_ms = u64::try_from(
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_millis(),
+        )
+        .unwrap();
+
+        // Reuse `handle_a` as the target handle too: the caller axis (a) check
+        // rejects before any target-side resolution, so the target handle is
+        // irrelevant to which axis trips — both handles are real and pass
+        // affinity.
+        let err = scp
+            .tool_invoke_cross_context_saga(
+                Arc::clone(&handle_a),
+                Arc::clone(&handle_a),
+                member_but_unhosted_caller, // member of caller_ctx, but NOT hosted
+                "tool-xctx_saga_member_unhosted".to_owned(),
+                serde_json::json!({"a": "x", "b": "y"}).to_string(),
+                saga_nonce_hex(),
+                now_ms,
+                1,
+                None,
+            )
+            .await
+            .expect_err("a member-but-unhosted caller must be rejected at axis (a)");
+
+        match err {
+            ScpError::SagaAborted { code, msg, .. } => {
+                assert_eq!(
+                    code,
+                    codes::SAGA_13050,
+                    "a member-but-unhosted caller (axis a) must abort with SCP-SAGA-13050"
+                );
+                // BRIDGE-UNIQUE axis-(a) substring. Because the caller IS a
+                // member, the membership axis (b) and the producer's gate 1 would
+                // BOTH pass — so the axis-(b) message ("is hosted by this bridge
+                // but is not a member of") can never appear here. The ONLY
+                // rejection that fits is axis (a). Asserting its exact substring
+                // makes this test fail closed iff
+                // `enforce_caller_principal_binding`'s
+                // `identity_custody_registry.contains_key` check is removed.
+                assert!(
+                    msg.contains("is not an identity hosted by this bridge instance"),
+                    "must be rejected by the bridge axis-(a) custody check (the sole guard for a \
+                     member caller), not the producer; got: {msg}"
+                );
+            }
+            other => panic!("expected SagaAborted (axis a), got {other:?}"),
+        }
+    }
 }

--- a/crates/scp-ffi/uniffi/src/bridge.rs
+++ b/crates/scp-ffi/uniffi/src/bridge.rs
@@ -987,6 +987,64 @@ pub enum ScpError {
     /// Input validation failed (malformed data, schema mismatch, constraint violation).
     #[error("validation error [{code}]: {msg}")]
     Validation { msg: String, code: String },
+
+    /// A §6.2.4 cross-context tool-invocation saga aborted at a Prepare phase.
+    ///
+    /// Surfaces the `Aborted` terminal of
+    /// `Supervisor::start_cross_context_tool_invocation_saga` (a §6.2.4
+    /// authorization / freshness / rate-limit / co-residency rejection — also
+    /// the §6.2.4 *Caller authentication* mismatch this bridge enforces before
+    /// the saga runs). Carries the rate-limit back-off hint STRUCTURALLY
+    /// (`retry_after_ms`): `Some(ms)` is the limiter's computed cooldown;
+    /// `None` (NEVER `0`) means no precise back-off instant exists (a
+    /// token-bucket hard limit, or a non-rate-limit rejection) — `0` would read
+    /// as "retry immediately" and re-trip the same hard limit. `code` is the
+    /// canonical `SCP-SAGA-13xxx` string. Maps to Swift `ScpError.SagaAborted`
+    /// / Kotlin `ScpException.SagaAborted` (the `msg` field surfaces as the
+    /// Swift `msg:` label — the `UniFFI` field-name convention every variant
+    /// here follows).
+    #[error("saga aborted [{code}]: {msg}")]
+    SagaAborted {
+        /// Human-readable detail (carries the `[SCP-SAGA-…]` prefix).
+        msg: String,
+        /// The canonical `SCP-SAGA-13xxx` code.
+        code: String,
+        /// Rate-limit back-off hint in milliseconds, or `None` (never `0`).
+        retry_after_ms: Option<u64>,
+    },
+
+    /// A §6.2.4 saga exhausted its Commit retries and may have diverged.
+    ///
+    /// Surfaces the `NeedsRepair` terminal (Commit-retry exhausted — the saga
+    /// may have PARTIALLY committed, a divergence; ADR-049 §3a). Carries the
+    /// durable `saga_id` operator-repair handle (`SCP-SAGA-13065`). Maps to
+    /// Swift `ScpError.SagaNeedsRepair` / Kotlin `ScpException.SagaNeedsRepair`.
+    #[error("saga needs repair [{code}]: {msg}")]
+    SagaNeedsRepair {
+        /// Human-readable detail (carries the `[SCP-SAGA-…]` prefix).
+        msg: String,
+        /// The canonical `SCP-SAGA-13065` code.
+        code: String,
+        /// The durable saga identifier — the operator-repair handle.
+        saga_id: String,
+    },
+
+    /// A §6.2.4 saga's participant context set overlapped an in-flight saga.
+    ///
+    /// Surfaces the `Busy` terminal (the participant context set overlapped an
+    /// in-flight saga's set — spec §5.15.4 per-participant-context-set gating;
+    /// retry with back-off). Carries the contended context id
+    /// (`SCP-SAGA-13066`). Maps to Swift `ScpError.SagaBusy` / Kotlin
+    /// `ScpException.SagaBusy`.
+    #[error("saga busy [{code}]: {msg}")]
+    SagaBusy {
+        /// Human-readable detail (carries the `[SCP-SAGA-…]` prefix).
+        msg: String,
+        /// The canonical `SCP-SAGA-13066` code.
+        code: String,
+        /// The shared context id that forced serialization.
+        contended_context: String,
+    },
 }
 
 // ---------------------------------------------------------------------------
@@ -1886,6 +1944,46 @@ pub struct ToolVerificationResult {
     pub passed: bool,
     /// Failure messages for vectors that did not pass. Empty on success.
     pub failures: Vec<String>,
+}
+
+/// The committed terminal of a §6.2.4 cross-context tool-invocation saga
+/// (ADR-049 §3a).
+///
+/// Returned by [`crate::scp::Scp::tool_invoke_cross_context_saga`] on a
+/// `Committed` terminal. Every NON-committed terminal raises one of the typed
+/// saga errors ([`ScpError::SagaAborted`] / [`ScpError::SagaNeedsRepair`] /
+/// [`ScpError::SagaBusy`]) instead.
+///
+/// Carries the supervisor-minted `saga_id` plus — for the committed
+/// cross-context invocation — the target's signed receipt and the captured
+/// tool output (spec §6.2.4 "Receipt / response return path"). The `receipt`
+/// is the JCS-canonical `CrossContextToolReceipt` bytes; `output` is the
+/// receipt's canonical `output_jcs` bytes (the exact bytes the caller side
+/// recorded a hash of). Both are surfaced as `bytes` (Swift `Data` / Kotlin
+/// `ByteArray`) so a caller can verify the receipt signature and recompute
+/// `output_hash` without a re-serialization step.
+///
+/// Generated as `data class SagaResult` (Kotlin) / `struct SagaResult` (Swift).
+#[derive(Debug, Clone, uniffi::Record)]
+pub struct SagaResult {
+    /// The durable saga identifier (supervisor-minted, never a caller input).
+    pub saga_id: String,
+    /// The target's signed `CrossContextToolReceipt` bytes (JCS), or `None`.
+    ///
+    /// The `receipt` is signed by the target context's LOCALLY-RESOLVED Active
+    /// Signing Key (the key held by its registered handle on this instance).
+    /// The in-saga receipt verification is INTEGRITY-ONLY: it verifies the
+    /// signature against the very key the saga FSM handed to side B, NOT an
+    /// independent resolution that that key is governance-authorized. A
+    /// consumer that re-presents this `receipt` as cross-node provenance
+    /// therefore MUST independently resolve that the signing key is the target
+    /// context's governance-authorized Active Signing Key — especially once
+    /// cross-node child-bridge transport lands, where a co-resident signer is
+    /// trusted only within this instance.
+    pub receipt: Option<Vec<u8>>,
+    /// The captured tool output bytes (the receipt's canonical `output_jcs`),
+    /// or `None`.
+    pub output: Option<Vec<u8>>,
 }
 
 /// Transport connection status.
@@ -5304,6 +5402,135 @@ async fn resolve_uniffi_signing_key(
             .to_owned(),
         code: codes::CTX_2040.to_owned(),
     })
+}
+
+// ---------------------------------------------------------------------------
+// Cross-context tool-invocation saga (§6.2.4, ADR-049 §3a) — bridge helpers
+// ---------------------------------------------------------------------------
+
+/// Maps a `SagaError` terminal (the typed §6.2.4 terminal space) onto the
+/// bridge's typed saga error variants, reading every structured datum
+/// STRUCTURALLY off the variant — never by re-parsing a message string.
+///
+/// - `Aborted { reason, code, message }` → [`ScpError::SagaAborted`].
+///   `retry_after_ms` is read directly off `SagaAbortReason::RateLimited`
+///   (an `Option<u64>`); a plain `Rejected` carries `None`. `None` is
+///   propagated, NEVER coerced to `0` (a `0` would read as "retry
+///   immediately" and re-trip the same hard limit). `code` is formatted as
+///   the canonical `SCP-SAGA-{code}` string from the numeric discriminant.
+/// - `NeedsRepair { saga_id, message }` → [`ScpError::SagaNeedsRepair`]
+///   carrying the durable operator-repair handle (`SCP-SAGA-13065`).
+/// - `Busy { contended_context, message }` → [`ScpError::SagaBusy`]
+///   (`SCP-SAGA-13066`).
+fn map_saga_error(err: scp_core::context::supervisor::SagaError) -> ScpError {
+    use scp_core::context::supervisor::{SagaAbortReason, SagaError};
+    match err {
+        SagaError::Aborted {
+            reason,
+            code,
+            message,
+        } => {
+            let retry_after_ms = match reason {
+                SagaAbortReason::RateLimited { retry_after_ms } => retry_after_ms,
+                SagaAbortReason::Rejected => None,
+            };
+            ScpError::SagaAborted {
+                msg: message,
+                code: format!("SCP-SAGA-{code}"),
+                retry_after_ms,
+            }
+        }
+        SagaError::NeedsRepair { saga_id, message } => ScpError::SagaNeedsRepair {
+            msg: message,
+            code: codes::SAGA_13065.to_owned(),
+            saga_id: saga_id.0,
+        },
+        SagaError::Busy {
+            contended_context,
+            message,
+        } => ScpError::SagaBusy {
+            msg: message,
+            code: codes::SAGA_13066.to_owned(),
+            contended_context,
+        },
+    }
+}
+
+/// Decodes the §6.2.4 envelope nonce from its canonical 32-char hex form into
+/// the 16-byte value, FAIL-CLOSED.
+///
+/// The nonce is a 16-byte value carried as a hex string — the one canonical
+/// wire form (§6.2.4 wire envelope). Any other length is a malformed envelope,
+/// NOT a "pad it" situation. Both failure modes surface as
+/// [`ScpError::Validation`] (`SCP-VALID-7001`).
+fn decode_asserted_nonce(asserted_nonce_hex: &str) -> Result<[u8; 16], ScpError> {
+    let bytes = hex::decode(asserted_nonce_hex).map_err(|e| ScpError::Validation {
+        msg: format!(
+            "asserted_nonce_hex is not valid hex: {e} — supply the 16-byte §6.2.4 envelope \
+             nonce as a 32-char lowercase-hex string"
+        ),
+        code: codes::VALID_7001.to_owned(),
+    })?;
+    <[u8; 16]>::try_from(bytes.as_slice()).map_err(|_| ScpError::Validation {
+        msg: format!(
+            "asserted_nonce_hex must decode to exactly 16 bytes (32 hex chars), got {} bytes",
+            bytes.len()
+        ),
+        code: codes::VALID_7001.to_owned(),
+    })
+}
+
+/// Enforces the §6.2.4 *Caller authentication* binding (normative — §6.2.4 +
+/// ADR-049 §3a) BEFORE the saga runs.
+///
+/// `caller_did` / `caller_context_id` MUST be the channel-authenticated
+/// identity of the transport leg, never an envelope-asserted free value. For
+/// the co-resident `UniFFI` bridge the "channel-authenticated principal" is an
+/// identity THIS bridge instance hosts — one present in its per-instance
+/// identity custody registry (populated only by `identity_create*` on this
+/// instance). Both axes are enforced here:
+///
+///   (a) `caller_did` is hosted/authenticated by this bridge instance, AND
+///   (b) `caller_did` is a member of the named `caller_context_id`.
+///
+/// A mismatch on either axis ⇒ a typed `Rejected`-flavored [`ScpError::SagaAborted`]
+/// (the §6.2.4 "mismatch ⇒ Rejected" terminal), carrying the registered
+/// caller-axis code `SCP-SAGA-13050`. The supervisor's own gate 1 ALSO checks
+/// membership, but membership alone is necessary-not-sufficient (it does not
+/// prove the request leg is authenticated AS that member) — so axis (a) is the
+/// load-bearing addition this seam contributes. Enforcing here, before the
+/// entry point, also means the saga never observes an unauthenticated caller.
+async fn enforce_caller_principal_binding(
+    bi: &Arc<crate::runtime::UniffiBridgeInstance>,
+    supervisor: &Arc<scp_core::context::supervisor::Supervisor>,
+    caller_context_id: &str,
+    caller_did: &str,
+) -> Result<(), ScpError> {
+    if !identity_custody_registry(bi).contains_key(caller_did) {
+        return Err(ScpError::SagaAborted {
+            msg: format!(
+                "caller_did '{caller_did}' is not an identity hosted by this bridge instance — \
+                 a cross-context saga's caller MUST be the channel-authenticated principal (an \
+                 identity created on this instance), not an envelope-asserted value (§6.2.4 \
+                 Caller authentication)"
+            ),
+            code: codes::SAGA_13050.to_owned(),
+            retry_after_ms: None,
+        });
+    }
+
+    if !supervisor.is_member(caller_context_id, caller_did).await {
+        return Err(ScpError::SagaAborted {
+            msg: format!(
+                "caller_did '{caller_did}' is hosted by this bridge but is not a member of \
+                 caller_context_id '{caller_context_id}' — not authorized to initiate a \
+                 cross-context saga over it (§6.2.4 Caller authentication)"
+            ),
+            code: codes::SAGA_13050.to_owned(),
+            retry_after_ms: None,
+        });
+    }
+    Ok(())
 }
 
 /// Signs the §23.16.8 context-export snapshot digest via the exporter
@@ -12012,6 +12239,229 @@ impl Scp {
             .await
             .map_err(|e| ScpError::Tool {
                 msg: format!("tokio task join error during cross-context invocation: {e}"),
+                code: codes::TOOL_6009.to_owned(),
+            })?
+    }
+
+    /// Invokes a tool across context boundaries as an atomic two-phase saga
+    /// (spec §6.2.4, ADR-049 §3a).
+    ///
+    /// Unlike [`Self::tool_invoke_cross_context`] (the synchronous,
+    /// single-context-side path), this drives the full §6.2.4 cross-context
+    /// tool-invocation saga over the two CO-RESIDENT participant contexts
+    /// (caller + target): Prepare-A / Prepare-B authorize and stage both sides,
+    /// the tool executes EXACTLY ONCE supervisor-side at Commit-B, and each
+    /// side records its own event-log entry. Both contexts MUST be co-resident
+    /// in this bridge instance (the cross-node child-bridge transport is
+    /// separate future work).
+    ///
+    /// # Caller authentication (normative — §6.2.4, ADR-049 §3a)
+    ///
+    /// `caller_did` is bound to the bridge-authenticated principal: it MUST be
+    /// an identity THIS bridge instance hosts (created here via identity
+    /// creation) AND a member of the caller context. A mismatch raises
+    /// [`ScpError::SagaAborted`] (`SCP-SAGA-13050`) BEFORE the saga runs — the
+    /// saga never observes an unauthenticated caller. The `asserted_nonce_hex`
+    /// / `timestamp_ms` / `chain_depth` REMAIN caller-supplied freshness fields
+    /// (the target validates them; they are not minted here).
+    ///
+    /// # Arguments
+    ///
+    /// * `source_handle` — The initiating (caller) context handle.
+    /// * `target_handle` — The executing (target) context handle.
+    /// * `caller_did` — The initiator DID (bound to the bridge principal).
+    /// * `tool_registration_id` — The tool to invoke across the interface.
+    /// * `input_json` — Tool input as a JSON string (schema-checked
+    ///   target-side); parsed to a JSON value at the boundary.
+    /// * `asserted_nonce_hex` — The 16-byte §6.2.4 envelope nonce as a 32-char
+    ///   hex string (the freshness/dedup token).
+    /// * `timestamp_ms` — Caller-asserted send time (Unix ms; freshness check).
+    /// * `chain_depth` — Caller-asserted inbound provenance depth (advisory;
+    ///   the target re-derives `+1`).
+    /// * `ucan_proof_id` — Optional id of the spending UCAN proof, resolved
+    ///   target-side at Prepare-B. `None` for an ungated tool.
+    ///
+    /// # Returns
+    ///
+    /// A [`SagaResult`] on the committed terminal, carrying the
+    /// supervisor-minted `saga_id`, the target's signed receipt bytes, and the
+    /// captured tool-output bytes. The `saga_id` is supervisor-minted — it is
+    /// never an input.
+    ///
+    /// # Errors
+    ///
+    /// Returns one of the typed saga errors — [`ScpError::SagaAborted`] (a
+    /// Prepare-phase rejection — authorization, freshness, rate limit, or
+    /// co-residency; carries `retry_after_ms`), [`ScpError::SagaNeedsRepair`]
+    /// (Commit-retry exhausted — carries the durable `saga_id` operator-repair
+    /// handle), or [`ScpError::SagaBusy`] (the participant context set
+    /// overlapped an in-flight saga — §5.15.4). Returns [`ScpError::Validation`]
+    /// if an id/DID/tool-id is malformed or `asserted_nonce_hex` does not
+    /// decode to 16 bytes, and [`ScpError::Tool`] if `input_json` is not valid
+    /// JSON.
+    ///
+    /// See spec §6.2.4 and ADR-049 §3a.
+    #[allow(clippy::too_many_arguments)] // Flat §6.2.4 envelope — agent-first named params, no builder.
+    pub async fn tool_invoke_cross_context_saga(
+        &self,
+        source_handle: Arc<ContextHandle>,
+        target_handle: Arc<ContextHandle>,
+        caller_did: String,
+        tool_registration_id: String,
+        input_json: String,
+        asserted_nonce_hex: String,
+        timestamp_ms: u64,
+        chain_depth: u8,
+        ucan_proof_id: Option<String>,
+    ) -> Result<SagaResult, ScpError> {
+        use scp_core::context::supervisor::{CrossContextToolInvocationRequest, SagaSigningKeys};
+
+        // Per-instance handle affinity: both participant handles MUST have been
+        // minted by THIS bridge instance (mirrors `tool_invoke_cross_context`).
+        // A foreign handle maps to `ScpError::Permission` (`SCP-PERM-3030`).
+        self.inner
+            .core
+            .check_handle(source_handle.instance_id())
+            .map_err(ScpError::from)?;
+        self.inner
+            .core
+            .check_handle(target_handle.instance_id())
+            .map_err(ScpError::from)?;
+
+        // Derive the participant id strings from the owned, instance-affine
+        // handles — never a caller-asserted free string. The `validate_*`
+        // calls below are harmless defense-in-depth over the derived ids.
+        let caller_context_id = source_handle.context_id.clone();
+        let target_context_id = target_handle.context_id.clone();
+
+        validate_context_id(&caller_context_id)?;
+        validate_context_id(&target_context_id)?;
+        validate_did(&caller_did)?;
+        validate_tool_id(&tool_registration_id)?;
+
+        let asserted_nonce = decode_asserted_nonce(&asserted_nonce_hex)?;
+        let input_value: serde_json::Value =
+            serde_json::from_str(&input_json).map_err(|e| ScpError::Tool {
+                msg: format!("invalid input JSON: {e}"),
+                code: codes::TOOL_6002.to_owned(),
+            })?;
+
+        let bi = Arc::clone(&self.inner);
+        runtime()
+            .spawn(async move {
+                // Caller-principal binding (§6.2.4 *Caller authentication*) —
+                // BEFORE the saga runs, so the supervisor never observes an
+                // unauthenticated caller. Clone the supervisor `Arc` out of the
+                // borrow so it outlives the later `bi`-borrowing helper calls
+                // and the `'static` executor.
+                let supervisor = Arc::clone(bi.context_manager_or_error()?);
+                enforce_caller_principal_binding(&bi, &supervisor, &caller_context_id, &caller_did)
+                    .await?;
+
+                // ----- Chokepoint (ADR-056): id STRING → [u8; 32] ------------
+                //
+                // MANDATORY: convert via the canonical cross-crate keying
+                // resolver, which decodes a real 64-hex id rather than
+                // re-hashing it. The producer does `hex::encode(wire)` for
+                // actor lookup, so a raw SHA-256 of a 64-hex id here would
+                // double-hash and key the wrong (non-existent) actor slot,
+                // surfacing as a spurious ContextNotRegistered abort.
+                let caller_context_bytes =
+                    scp_core::context::state::context_id_to_bytes(&caller_context_id);
+                let target_context_bytes =
+                    scp_core::context::state::context_id_to_bytes(&target_context_id);
+
+                // ----- Signing keys: each context's Active Signing Key -------
+                //
+                // Resolved DIRECTLY from the owned, instance-affine handles —
+                // no `context_handle_registry` lookup. Each context signs its
+                // own side (target → receipt; each → its own divergence
+                // marker) under its registered Active Signing Key.
+                let target_signing_key = resolve_uniffi_signing_key(&target_handle).await?;
+                let caller_signing_key = resolve_uniffi_signing_key(&source_handle).await?;
+
+                // ----- Executor: snapshot the TARGET context's tool handler --
+                //
+                // Mirrors `tool_invoke_cross_context`: snapshot the registered
+                // handler closure (an `Arc<dyn Fn>` — cloning is a refcount
+                // bump) OUTSIDE the runtime call, then move it into the
+                // `FnOnce` executor the supervisor runs supervisor-side at
+                // Commit-B (off the actor mailbox). Read directly off the
+                // owned `target_handle` — no DashMap `Ref` is held across the
+                // `tool_handlers.lock().await`. Falls back to a schema-only
+                // echo when no handler is registered, matching the synchronous
+                // cross-context path. The supervisor validates the output
+                // against the tool's registered output schema at Commit-B, so
+                // the executor only produces the value.
+                let handler = target_handle
+                    .tool_handlers
+                    .lock()
+                    .await
+                    .get(&tool_registration_id)
+                    .cloned();
+                let tool_id_for_echo = tool_registration_id.clone();
+                let target_ctx_for_echo = target_context_id.clone();
+                let caller_did_for_echo = caller_did.clone();
+                let executor = move |value: serde_json::Value| {
+                    let handler = handler.clone();
+                    let echo_input = value.clone();
+                    async move {
+                        handler.map_or_else(
+                            || {
+                                Ok(serde_json::json!({
+                                    "tool": tool_id_for_echo,
+                                    "target_context": target_ctx_for_echo,
+                                    "caller_did": caller_did_for_echo,
+                                    "status": "validated",
+                                    "input_valid": true,
+                                    "validated_input": echo_input,
+                                }))
+                            },
+                            |h| {
+                                h(value).map_err(|e| {
+                                    format!(
+                                        "cross-context saga tool handler for \
+                                         '{tool_id_for_echo}' failed: {e}"
+                                    )
+                                })
+                            },
+                        )
+                    }
+                };
+
+                let request = CrossContextToolInvocationRequest {
+                    caller_context_id: caller_context_bytes,
+                    target_context_id: target_context_bytes,
+                    caller_did: scp_identity::DID(caller_did),
+                    tool_registration_id,
+                    ucan_proof_id,
+                    input: input_value,
+                    asserted_chain_depth: chain_depth,
+                    asserted_nonce,
+                    asserted_timestamp_ms: timestamp_ms,
+                };
+
+                let output = supervisor
+                    .start_cross_context_tool_invocation_saga(
+                        request,
+                        SagaSigningKeys {
+                            target: &target_signing_key,
+                            caller: &caller_signing_key,
+                        },
+                        executor,
+                    )
+                    .await
+                    .map_err(map_saga_error)?;
+
+                Ok(SagaResult {
+                    saga_id: output.saga_id.0,
+                    receipt: output.receipt,
+                    output: output.output,
+                })
+            })
+            .await
+            .map_err(|e| ScpError::Tool {
+                msg: format!("tokio task join error during cross-context saga: {e}"),
                 code: codes::TOOL_6009.to_owned(),
             })?
     }
@@ -19992,5 +20442,937 @@ mod tests {
             err_str.contains(codes::IDENT_1017),
             "expected SCP-IDENT-1017, got: {err_str}"
         );
+    }
+
+    // ====================================================================
+    // Cross-context tool-invocation saga (§6.2.4, ADR-049 §3a) — UniFFI export
+    // ====================================================================
+    //
+    // The bridge's added responsibilities on top of the supervisor producer
+    // (`start_cross_context_tool_invocation_saga`) are: the typed terminal →
+    // typed `ScpError` mapping (`map_saga_error`), fail-closed nonce decoding
+    // (`decode_asserted_nonce`), and — exercised by the end-to-end test below —
+    // the §6.2.4 *Caller authentication* binding, the ADR-056 chokepoint, and
+    // per-context Active Signing Key resolution, driven to a real `Committed`
+    // terminal through a governance-established `ToolInterface`.
+
+    use scp_core::context::supervisor::{
+        SagaAbortReason, SagaError as CoreSagaError, SagaId as CoreSagaId,
+    };
+
+    /// `map_saga_error` — a rate-limited abort preserves `retry_after_ms =
+    /// Some(ms)` STRUCTURALLY and formats the numeric `code` as the canonical
+    /// `SCP-SAGA-{code}` string. The producer's actual terminal behavior is
+    /// covered in `scp-runtime`; here we test ONLY the bridge's mapping.
+    #[test]
+    fn map_saga_error_rate_limited_preserves_retry_after_ms() {
+        let mapped = map_saga_error(CoreSagaError::Aborted {
+            reason: SagaAbortReason::RateLimited {
+                retry_after_ms: Some(2500),
+            },
+            code: 13026,
+            message: "inbound rate limit exceeded".to_owned(),
+        });
+        match mapped {
+            ScpError::SagaAborted {
+                code,
+                retry_after_ms,
+                ..
+            } => {
+                assert_eq!(code, "SCP-SAGA-13026");
+                assert_eq!(retry_after_ms, Some(2500));
+            }
+            other => panic!("expected SagaAborted, got {other:?}"),
+        }
+    }
+
+    /// `map_saga_error` — a rate-limited abort with NO precise back-off instant
+    /// preserves `retry_after_ms = None`, NEVER coerced to `Some(0)` (a `0`
+    /// would read as "retry immediately" and re-trip the same hard limit).
+    #[test]
+    fn map_saga_error_rate_limited_none_is_not_zero() {
+        let mapped = map_saga_error(CoreSagaError::Aborted {
+            reason: SagaAbortReason::RateLimited {
+                retry_after_ms: None,
+            },
+            code: 13026,
+            message: "hard limit, no precise back-off".to_owned(),
+        });
+        match mapped {
+            ScpError::SagaAborted { retry_after_ms, .. } => {
+                assert_eq!(retry_after_ms, None, "None must NOT be coerced to Some(0)");
+            }
+            other => panic!("expected SagaAborted, got {other:?}"),
+        }
+    }
+
+    /// `map_saga_error` — a plain (non-rate-limit) `Rejected` abort carries
+    /// `retry_after_ms = None`.
+    #[test]
+    fn map_saga_error_rejected_has_no_retry_hint() {
+        let mapped = map_saga_error(CoreSagaError::Aborted {
+            reason: SagaAbortReason::Rejected,
+            code: 13050,
+            message: "caller not a member".to_owned(),
+        });
+        match mapped {
+            ScpError::SagaAborted {
+                code,
+                retry_after_ms,
+                ..
+            } => {
+                assert_eq!(code, "SCP-SAGA-13050");
+                assert_eq!(retry_after_ms, None);
+            }
+            other => panic!("expected SagaAborted, got {other:?}"),
+        }
+    }
+
+    /// `map_saga_error` — `NeedsRepair` preserves the durable `saga_id`
+    /// operator-repair handle and the fixed terminal code `SCP-SAGA-13065`.
+    #[test]
+    fn map_saga_error_needs_repair_preserves_saga_id() {
+        let mapped = map_saga_error(CoreSagaError::NeedsRepair {
+            saga_id: CoreSagaId("saga-abc-123".to_owned()),
+            message: "commit retries exhausted".to_owned(),
+        });
+        match mapped {
+            ScpError::SagaNeedsRepair { code, saga_id, .. } => {
+                assert_eq!(code, codes::SAGA_13065);
+                assert_eq!(saga_id, "saga-abc-123");
+            }
+            other => panic!("expected SagaNeedsRepair, got {other:?}"),
+        }
+    }
+
+    /// `map_saga_error` — `Busy` preserves the contended context id and the
+    /// fixed terminal code `SCP-SAGA-13066`.
+    #[test]
+    fn map_saga_error_busy_preserves_contended_context() {
+        let mapped = map_saga_error(CoreSagaError::Busy {
+            contended_context: "ctx-shared-99".to_owned(),
+            message: "participant set overlaps an in-flight saga".to_owned(),
+        });
+        match mapped {
+            ScpError::SagaBusy {
+                code,
+                contended_context,
+                ..
+            } => {
+                assert_eq!(code, codes::SAGA_13066);
+                assert_eq!(contended_context, "ctx-shared-99");
+            }
+            other => panic!("expected SagaBusy, got {other:?}"),
+        }
+    }
+
+    /// `decode_asserted_nonce` is fail-closed: a wrong-length input (8 bytes,
+    /// not 16) is a malformed §6.2.4 envelope, surfaced as `ScpError::Validation`
+    /// (`SCP-VALID-7001`) — the bridge does NOT pad, truncate, or accept any
+    /// non-canonical form.
+    #[test]
+    fn decode_asserted_nonce_wrong_length_fails_closed() {
+        // 8 bytes, not 16.
+        let err = decode_asserted_nonce("0011223344556677")
+            .expect_err("a wrong-length nonce must be rejected fail-closed");
+        match err {
+            ScpError::Validation { msg, code } => {
+                assert_eq!(code, codes::VALID_7001);
+                assert!(
+                    msg.contains("16 bytes"),
+                    "message must explain the 16-byte requirement, got: {msg}"
+                );
+            }
+            other => panic!("expected Validation, got {other:?}"),
+        }
+    }
+
+    /// `decode_asserted_nonce` is fail-closed on non-hex input too.
+    #[test]
+    fn decode_asserted_nonce_non_hex_fails_closed() {
+        let err = decode_asserted_nonce("not-hex-at-all-zz")
+            .expect_err("non-hex must be rejected fail-closed");
+        match err {
+            ScpError::Validation { code, msg } => {
+                assert_eq!(code, codes::VALID_7001);
+                // VALID_7001 is shared with the wrong-length arm; pin the
+                // non-hex arm specifically (mirrors how the wrong-length test
+                // asserts "16 bytes").
+                assert!(
+                    msg.contains("is not valid hex"),
+                    "must reject for the non-hex arm specifically; got: {msg}"
+                );
+            }
+            other => panic!("expected Validation, got {other:?}"),
+        }
+    }
+
+    /// A valid 16-byte nonce as a 32-char hex string.
+    fn saga_nonce_hex() -> String {
+        "00112233445566778899aabbccddeeff".to_owned()
+    }
+
+    /// Installs a resolver backed by a caller-retained in-memory DHT client on
+    /// `bi` and returns that client, so the e2e test can seed the owner's DID
+    /// document into the SAME store the supervisor's governance key resolver
+    /// reads from.
+    ///
+    /// Why this is test scaffolding, not a production gap masked: the `UniFFI`
+    /// bridge's `ensure_did_resolver_initialized_on` builds its resolver over a
+    /// FRESH, unretained `InMemoryDhtClient` and `identity_create` publishes the
+    /// minted document only to a throwaway local `DidDht` — in a unit harness
+    /// the bridge op "builds a fresh DHT per call, so its `resolve_did` cannot
+    /// see the create-time publish" (see `rotate_key_signer_is_wired_over_callback_custody`).
+    /// The cross-process E2E covers the wired path. To drive a REAL `Committed`
+    /// terminal in-crate — which requires the supervisor to resolve the
+    /// proposer's published key for governance vote verification — the test must
+    /// itself seed the document into a resolver-visible store, exactly the
+    /// `publish_to_resolver_dht_for` step the PyO3/NAPI production
+    /// `identity_create` performs. Installing the resolver BEFORE the first
+    /// identity creation makes `ensure_did_resolver_initialized_on` a no-op
+    /// (it skips when a resolver is already present), so this client is the one
+    /// the supervisor snapshots.
+    fn install_seedable_resolver(
+        bi: &Arc<crate::runtime::UniffiBridgeInstance>,
+    ) -> Arc<scp_identity::InMemoryDhtClient> {
+        let dht_client = Arc::new(scp_identity::InMemoryDhtClient::new());
+        let resolver = Arc::new(scp_identity::resolver::DualLayerResolver::new(
+            Arc::new(scp_identity::resolver::NoOpRelayQuerier),
+            Arc::clone(&dht_client),
+            Arc::new(scp_identity::DidCache::new()),
+            Vec::new(),
+        ));
+        bi.set_did_resolver(resolver, tokio::runtime::Handle::current());
+        dht_client
+    }
+
+    /// Publishes `owner_identity`'s DID document into `dht_client` (the
+    /// resolver-visible store) by signing the BEP44 record with the identity's
+    /// in-memory custody. Mirrors the production `publish_to_resolver_dht_for`
+    /// step so the supervisor's governance key resolver can resolve the proposer
+    /// key during single-admin vote verification.
+    async fn seed_owner_document_into_resolver(
+        owner_identity: &Identity,
+        dht_client: &Arc<scp_identity::InMemoryDhtClient>,
+    ) {
+        use scp_identity::dht_client::DhtClient as _;
+        use scp_platform::traits::KeyCustody as _;
+
+        let identity = owner_identity
+            .core_id
+            .as_ref()
+            .expect("in-memory owner retains its ScpIdentity");
+        let document = owner_identity
+            .core_document
+            .as_ref()
+            .expect("in-memory owner retains its DID document");
+        let custody = owner_identity
+            .in_memory_custody
+            .as_ref()
+            .expect("in-memory owner retains its custody");
+
+        let doc_json = document.to_json().expect("document serializes to JSON");
+        let value = doc_json.as_bytes();
+        let public_key =
+            scp_identity::extract_public_key(&identity.did).expect("DID embeds the public key");
+        let seq: u64 = 1;
+        let signable = scp_identity::dht::bep44_signable(value, seq);
+        let sig_bytes = custody
+            .0
+            .sign(&identity.identity_key, &signable)
+            .await
+            .expect("identity custody signs the BEP44 record")
+            .into_bytes();
+        let signature: [u8; 64] = sig_bytes.try_into().expect("Ed25519 signature is 64 bytes");
+        dht_client
+            .publish(&public_key, &signature, value, seq)
+            .await
+            .expect("publish into the resolver-visible store");
+    }
+
+    /// Builds a `ContextParams` carrying the given capability ceiling under
+    /// single-admin governance (so a governance proposal auto-executes), an
+    /// Encrypted context (the saga chokepoint round-trips a real 64-hex id), and
+    /// otherwise-default fields. Mirrors the `PyO3` e2e's `params_a` / `params_b`.
+    fn saga_context_params(ceiling: &[&str]) -> ContextParams {
+        ContextParams {
+            mode: ContextMode::Encrypted,
+            ceiling: ceiling.iter().map(|s| (*s).to_owned()).collect(),
+            ceiling_policy: CeilingPolicy::Immutable,
+            governance: GovernanceModel::SingleAdmin,
+            memory_scope: MemoryScope::Ephemeral,
+            ttl_seconds: 0,
+            promotable: false,
+            min_protocol_version: 0,
+            max_chain_depth: None,
+            max_nesting_depth: None,
+            session_cap: None,
+            economic_policy: None,
+            consequence_rules_json: None,
+            consequence_config_json: None,
+        }
+    }
+
+    /// The numeric `{sum, ok}` output schema the handler-backed e2e uses (2
+    /// output properties — clears the §9.2.1 specificity floor of 2 — so
+    /// Commit-B's output-schema validation accepts the `{sum:42, ok:1}`
+    /// handler response).
+    fn saga_numeric_output_schema() -> serde_json::Value {
+        serde_json::json!({
+            "type": "object",
+            "properties": {
+                "sum": {"type": "number"},
+                "ok": {"type": "number"}
+            }
+        })
+    }
+
+    /// A PERMISSIVE output schema (2 declared properties drawn from the
+    /// schema-only echo shape — `{status, input_valid}` — and NO `required` /
+    /// `additionalProperties:false`) so the no-handler echo object
+    /// (`{tool, target_context, caller_did, status, input_valid, validated_input}`)
+    /// validates at Commit-B. Used by the echo-fallback Committed test.
+    fn saga_permissive_echo_output_schema() -> serde_json::Value {
+        serde_json::json!({
+            "type": "object",
+            "properties": {
+                "status": {"type": "string"},
+                "input_valid": {"type": "boolean"}
+            }
+        })
+    }
+
+    /// Serializes a `RegisterTool` governance action for the saga tool carrying
+    /// the given `output_schema`. The input schema mirrors the `PyO3` e2e (2
+    /// input properties — clears the §9.2.1 specificity floor of 2).
+    /// `implementation_hash` is a fixed 32-byte array (serde wants a 32-element
+    /// JSON number array — `json!` has no array-repeat sugar).
+    fn saga_register_tool_action_json_with_output(
+        tool_id: &str,
+        tool_name: &str,
+        owner: &str,
+        output_schema: serde_json::Value,
+    ) -> String {
+        let impl_hash = serde_json::Value::from(vec![0u8; 32]);
+        let register_action = serde_json::json!({
+            "RegisterTool": {
+                "registration": {
+                    "tool_id": tool_id,
+                    "name": tool_name,
+                    "description": format!("Tool: {tool_name}"),
+                    "schema": {
+                        "input_schema": {
+                            "type": "object",
+                            "properties": {
+                                "a": {"type": "string"},
+                                "b": {"type": "string"}
+                            }
+                        },
+                        "output_schema": output_schema
+                    },
+                    "implementation_hash": impl_hash,
+                    "test_vectors": [],
+                    "operator_did": owner,
+                    "cost": null,
+                    "registered_at": 0,
+                    "signature": []
+                }
+            }
+        });
+        serde_json::to_string(&register_action).unwrap()
+    }
+
+    /// The handler-backed e2e's `RegisterTool` action (numeric `{sum, ok}`
+    /// output schema).
+    fn saga_register_tool_action_json(tool_id: &str, tool_name: &str, owner: &str) -> String {
+        saga_register_tool_action_json_with_output(
+            tool_id,
+            tool_name,
+            owner,
+            saga_numeric_output_schema(),
+        )
+    }
+
+    /// Serializes the bidirectionally-approved `EstablishToolInterface`
+    /// governance action (externally-tagged `GovernanceAction`; the
+    /// `snake_case` `ToolInterface` `Option` fields render as JSON `null`).
+    fn saga_establish_interface_action_json(ctx_a: &str, ctx_b: &str, tool_id: &str) -> String {
+        let action = serde_json::json!({
+            "EstablishToolInterface": {
+                "interface": {
+                    "source_context": ctx_a,
+                    "target_context": ctx_b,
+                    "tool_id": tool_id,
+                    "rate_limit": null,
+                    "inbound_rate_limit": null,
+                    "per_caller_rate_limit": null,
+                    "approved_by_source": true,
+                    "approved_by_target": true,
+                    "outbound_policy": null,
+                    "inbound_policy": null
+                }
+            }
+        });
+        serde_json::to_string(&action).unwrap()
+    }
+
+    /// Asserts a `governance_propose` result actually EXECUTED its action (not
+    /// merely returned a non-empty JSON — `governance_propose` serializes a
+    /// non-empty `{proposal_id, status, execution_result}` even on a non-executed
+    /// terminal). `governance_propose` serializes `status` as the `Debug` of
+    /// `ProposalStatus`; under single-admin the action auto-executes, so the
+    /// proposal resolves `Approved` and `execution_result` is `Some` (a non-null
+    /// JSON string). Both together prove the interface/registration was
+    /// established, not just proposed.
+    fn assert_governance_executed(propose_result: &str, what: &str) {
+        let parsed: serde_json::Value = serde_json::from_str(propose_result)
+            .unwrap_or_else(|e| panic!("{what}: governance_propose result must be JSON: {e}"));
+        let status = parsed["status"].as_str().unwrap_or_else(|| {
+            panic!("{what}: governance_propose result must carry a string status; got: {parsed}")
+        });
+        assert_eq!(
+            status, "Approved",
+            "{what}: single-admin proposal must auto-execute to Approved; got status {status:?} \
+             in {parsed}"
+        );
+        assert!(
+            !parsed["execution_result"].is_null(),
+            "{what}: an executed proposal must carry a non-null execution_result; got: {parsed}"
+        );
+    }
+
+    /// Full `Committed` terminal through the `UniFFI` bridge: an authenticated
+    /// caller drives the §6.2.4 cross-context tool-invocation saga (ADR-049 §3a)
+    /// to a real commit and the bridge returns the committed receipt + output
+    /// bytes.
+    ///
+    /// The setup mirrors the producer's two authorization axes
+    /// (`start_cross_context_tool_invocation_saga`):
+    ///
+    /// 1. **Caller axis (gate 1).** `caller_did` must be hosted by this bridge
+    ///    AND a member of the CALLER (source) context A. Creating A via
+    ///    `context_create` with `owner` as the single-admin creator satisfies
+    ///    both; creating `owner` via `identity_create` registers its custody
+    ///    (axis (a) of the bridge's caller-principal binding) and publishes its
+    ///    DID document into the per-instance resolver BEFORE the first
+    ///    `context_create` builds the supervisor (which snapshots that resolver
+    ///    for governance vote verification).
+    /// 2. **Target axis (gate 2).** The producer requires a *bidirectionally
+    ///    approved* `ToolInterface` queried against the CALLER context A's actor
+    ///    governance state — so it is established IN A via a governance
+    ///    `EstablishToolInterface` action (auto-executed under `single_admin`; A's
+    ///    ceiling carries `tool:interface` + `governance:propose`).
+    ///
+    /// Context B holds the tool in its ACTOR governance `registered_tools` (via
+    /// a `RegisterTool` action; saga Prepare-B reads it there) plus the FFI-side
+    /// handler the executor snapshots and runs once at Commit-B (returns
+    /// `{sum:42, ok:1}`, validated against the registered numeric output schema).
+    #[tokio::test]
+    async fn xctx_saga_authenticated_caller_commits_via_governance_established_interface() {
+        let scp = scp_test();
+        let bi = Arc::clone(&scp.inner);
+
+        // Install a seedable resolver BEFORE identity creation so its store is
+        // the one the supervisor snapshots; `identity_create`'s own resolver
+        // init then no-ops. See `install_seedable_resolver`.
+        let resolver_dht = install_seedable_resolver(&bi);
+
+        // Owner identity. Registers custody (axis (a) of the caller-principal
+        // binding) and mints the DID document.
+        let owner_identity = scp
+            .identity_create("in_memory".to_owned(), None)
+            .await
+            .expect("owner identity creation must succeed");
+        let owner = owner_identity.did.clone();
+
+        // Seed the owner's document into the resolver-visible store so the
+        // supervisor (built at the first `context_create` below) can resolve the
+        // proposer key during single-admin governance vote verification.
+        seed_owner_document_into_resolver(&owner_identity, &resolver_dht).await;
+
+        // Context A (caller/source): ceiling carries `governance:propose` (so
+        // owner-as-admin can propose) and `tool:interface` (required by
+        // `execute_establish_tool_interface`'s ceiling check).
+        let handle_a = scp
+            .context_create(
+                Arc::clone(&owner_identity),
+                saga_context_params(&[
+                    "governance:propose",
+                    "tool:interface",
+                    "tools:invoke",
+                    "messages:read",
+                    "messages:write",
+                ]),
+            )
+            .await
+            .expect("caller context A must be created");
+        let ctx_a = handle_a.context_id.clone();
+
+        // Context B (target): ceiling carries `governance:propose` and
+        // `tool:register` so the saga tool can be registered into B's ACTOR
+        // governance state.
+        let handle_b = scp
+            .context_create(
+                Arc::clone(&owner_identity),
+                saga_context_params(&["governance:propose", "tool:register"]),
+            )
+            .await
+            .expect("target context B must be created");
+        let ctx_b = handle_b.context_id.clone();
+
+        // The tool id is the deterministic `tool-{name}` form `tool_register`
+        // mints, also keying B's actor `registered_tools` and A's interface.
+        let tool_name = "xctx_saga_commit_tool";
+        let tool_id = format!("tool-{tool_name}");
+
+        // Register the saga tool into B's ACTOR governance state (saga Prepare-B
+        // reads the tool from there).
+        let register_json = saga_register_tool_action_json(&tool_id, tool_name, &owner);
+        let register_result = scp
+            .governance_propose(Arc::clone(&handle_b), owner.clone(), register_json)
+            .await
+            .expect("RegisterTool must auto-execute under single_admin");
+        assert_governance_executed(&register_result, "RegisterTool");
+
+        // Register the tool in B's FFI-side registry too (so the FFI schema
+        // matches the governance registration), then attach the deterministic
+        // handler the executor snapshots at Commit-B.
+        let definition = ToolDefinition {
+            name: tool_name.to_owned(),
+            description: format!("Tool: {tool_name}"),
+            input_schema_json: serde_json::json!({
+                "type": "object",
+                "properties": {
+                    "a": {"type": "string"},
+                    "b": {"type": "string"}
+                }
+            })
+            .to_string(),
+            output_schema_json: serde_json::json!({
+                "type": "object",
+                "properties": {
+                    "sum": {"type": "number"},
+                    "ok": {"type": "number"}
+                }
+            })
+            .to_string(),
+            operator_did: owner.clone(),
+            test_vectors_json: None,
+            implementation_hash: None,
+            cost: None,
+        };
+        let ffi_tool_id = scp
+            .tool_register(Arc::clone(&handle_b), definition)
+            .await
+            .expect("FFI-side tool registration must succeed");
+        assert_eq!(
+            ffi_tool_id, tool_id,
+            "FFI and governance tool ids must agree (deterministic tool-{{name}})"
+        );
+
+        // Register a real handler returning the numeric {sum, ok} the registered
+        // output schema accepts. In-crate `tool_handlers` access is `pub(crate)`,
+        // which is exactly why this Committed test lives in-crate.
+        let handler: std::sync::Arc<
+            dyn Fn(serde_json::Value) -> Result<serde_json::Value, String> + Send + Sync,
+        > = std::sync::Arc::new(|_input: serde_json::Value| {
+            Ok(serde_json::json!({"sum": 42, "ok": 1}))
+        });
+        context_handle_registry(&bi)
+            .get(&ctx_b)
+            .expect("target context B must be registered")
+            .tool_handlers
+            .lock()
+            .await
+            .insert(tool_id.clone(), handler);
+
+        // Establish the bidirectionally-approved interface in A via governance.
+        let establish_json = saga_establish_interface_action_json(&ctx_a, &ctx_b, &tool_id);
+        let propose_result = scp
+            .governance_propose(Arc::clone(&handle_a), owner.clone(), establish_json)
+            .await
+            .expect("EstablishToolInterface must auto-execute under single_admin");
+        assert_governance_executed(&propose_result, "EstablishToolInterface");
+
+        // A near-now timestamp: Prepare-B enforces a §9.14 ±5min skew tolerance,
+        // so a fixed historical timestamp would abort.
+        let now_ms = u64::try_from(
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_millis(),
+        )
+        .unwrap();
+
+        let input_json = serde_json::json!({"a": "x", "b": "y"}).to_string();
+
+        let result = scp
+            .tool_invoke_cross_context_saga(
+                Arc::clone(&handle_a),
+                Arc::clone(&handle_b),
+                owner,
+                tool_id,
+                input_json,
+                saga_nonce_hex(),
+                now_ms,
+                1,
+                None,
+            )
+            .await
+            .expect("saga must reach Committed");
+
+        // Committed terminal: non-empty saga id + a receipt + output bytes.
+        assert!(
+            !result.saga_id.is_empty(),
+            "a committed saga must carry a non-empty saga id"
+        );
+        assert!(
+            result.receipt.is_some(),
+            "committed saga must carry a receipt"
+        );
+        assert!(
+            result.output.is_some(),
+            "committed saga must carry output bytes"
+        );
+
+        // The committed output decodes to the handler's response (numeric, per
+        // the registered output schema). Assert the parsed values, not raw
+        // bytes, so a JCS-canonical encoding still passes.
+        let out: serde_json::Value =
+            serde_json::from_slice(result.output.as_ref().unwrap()).unwrap();
+        assert_eq!(out["sum"], 42, "committed output sum must be the handler's");
+        assert_eq!(out["ok"], 1, "committed output ok must be the handler's");
+    }
+
+    /// Full `Committed` terminal through the executor's NO-HANDLER echo
+    /// fallback. Identical to
+    /// [`xctx_saga_authenticated_caller_commits_via_governance_established_interface`]
+    /// EXCEPT no FFI tool handler is registered on context B — so the executor
+    /// takes its schema-only echo branch
+    /// (`{tool, target_context, caller_did, status, input_valid, validated_input}`).
+    /// The tool is registered with a PERMISSIVE output schema
+    /// (`{status, input_valid}`, no `required`/`additionalProperties:false`) in
+    /// BOTH the `RegisterTool` governance action and the FFI `ToolDefinition`, so
+    /// Commit-B's output-schema validation accepts the echo and the saga reaches
+    /// a real `Committed`. Proves the no-handler echo path commits end-to-end.
+    #[tokio::test]
+    async fn xctx_saga_commits_with_echo_fallback_when_no_handler_registered() {
+        let scp = scp_test();
+        let bi = Arc::clone(&scp.inner);
+
+        let resolver_dht = install_seedable_resolver(&bi);
+
+        let owner_identity = scp
+            .identity_create("in_memory".to_owned(), None)
+            .await
+            .expect("owner identity creation must succeed");
+        let owner = owner_identity.did.clone();
+
+        seed_owner_document_into_resolver(&owner_identity, &resolver_dht).await;
+
+        let handle_a = scp
+            .context_create(
+                Arc::clone(&owner_identity),
+                saga_context_params(&[
+                    "governance:propose",
+                    "tool:interface",
+                    "tools:invoke",
+                    "messages:read",
+                    "messages:write",
+                ]),
+            )
+            .await
+            .expect("caller context A must be created");
+        let ctx_a = handle_a.context_id.clone();
+
+        let handle_b = scp
+            .context_create(
+                Arc::clone(&owner_identity),
+                saga_context_params(&["governance:propose", "tool:register"]),
+            )
+            .await
+            .expect("target context B must be created");
+
+        let tool_name = "xctx_saga_echo_tool";
+        let tool_id = format!("tool-{tool_name}");
+
+        // Register the tool into B's ACTOR governance state with the PERMISSIVE
+        // output schema (so Prepare-B reads it AND Commit-B validates the echo
+        // against it).
+        let register_json = saga_register_tool_action_json_with_output(
+            &tool_id,
+            tool_name,
+            &owner,
+            saga_permissive_echo_output_schema(),
+        );
+        let register_result = scp
+            .governance_propose(Arc::clone(&handle_b), owner.clone(), register_json)
+            .await
+            .expect("RegisterTool must auto-execute under single_admin");
+        assert_governance_executed(&register_result, "RegisterTool (echo)");
+
+        // Register the tool in B's FFI-side registry with the SAME permissive
+        // output schema — but DO NOT attach a handler. The absence of a handler
+        // is what drives the executor's schema-only echo branch.
+        let definition = ToolDefinition {
+            name: tool_name.to_owned(),
+            description: format!("Tool: {tool_name}"),
+            input_schema_json: serde_json::json!({
+                "type": "object",
+                "properties": {
+                    "a": {"type": "string"},
+                    "b": {"type": "string"}
+                }
+            })
+            .to_string(),
+            output_schema_json: saga_permissive_echo_output_schema().to_string(),
+            operator_did: owner.clone(),
+            test_vectors_json: None,
+            implementation_hash: None,
+            cost: None,
+        };
+        let ffi_tool_id = scp
+            .tool_register(Arc::clone(&handle_b), definition)
+            .await
+            .expect("FFI-side tool registration must succeed");
+        assert_eq!(
+            ffi_tool_id, tool_id,
+            "FFI and governance tool ids must agree (deterministic tool-{{name}})"
+        );
+
+        // NO handler registered on context B: the executor must echo.
+
+        let establish_json =
+            saga_establish_interface_action_json(&ctx_a, &handle_b.context_id, &tool_id);
+        let propose_result = scp
+            .governance_propose(Arc::clone(&handle_a), owner.clone(), establish_json)
+            .await
+            .expect("EstablishToolInterface must auto-execute under single_admin");
+        assert_governance_executed(&propose_result, "EstablishToolInterface (echo)");
+
+        let now_ms = u64::try_from(
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_millis(),
+        )
+        .unwrap();
+
+        let input_json = serde_json::json!({"a": "x", "b": "y"}).to_string();
+
+        let result = scp
+            .tool_invoke_cross_context_saga(
+                Arc::clone(&handle_a),
+                Arc::clone(&handle_b),
+                owner,
+                tool_id,
+                input_json,
+                saga_nonce_hex(),
+                now_ms,
+                1,
+                None,
+            )
+            .await
+            .expect("echo-fallback saga must reach Committed");
+
+        assert!(
+            !result.saga_id.is_empty(),
+            "a committed saga must carry a non-empty saga id"
+        );
+        assert!(
+            result.receipt.is_some(),
+            "committed saga must carry a receipt"
+        );
+        assert!(
+            result.output.is_some(),
+            "committed saga must carry output bytes"
+        );
+
+        // The committed output is the executor's schema-only echo object, NOT a
+        // handler response: parse it and assert the echo-specific fields.
+        let out: serde_json::Value =
+            serde_json::from_slice(result.output.as_ref().unwrap()).unwrap();
+        assert_eq!(
+            out["status"], "validated",
+            "the no-handler echo carries status=\"validated\"; got: {out}"
+        );
+        assert_eq!(
+            out["input_valid"], true,
+            "the no-handler echo carries input_valid=true; got: {out}"
+        );
+    }
+
+    /// Caller-principal binding, axis (a) — an UNHOSTED caller is rejected.
+    ///
+    /// `source_handle` / `target_handle` are REAL registered handles (so the
+    /// per-instance handle-affinity check passes and the
+    /// `context_id_to_bytes`/`is_member` path is reachable), but `caller_did`
+    /// is a syntactically-valid `did:dht:…` string that was NEVER created on
+    /// this instance — so it is absent from the per-instance identity custody
+    /// registry. Axis (a) (`identity_custody_registry.contains_key`) trips
+    /// FIRST and the saga is aborted with `SCP-SAGA-13050` BEFORE the producer
+    /// runs — no governance/resolver scaffolding is needed. A valid nonce hex
+    /// and a near-now timestamp ensure the binding (not nonce/validation) is
+    /// the rejecting gate.
+    #[tokio::test]
+    async fn xctx_saga_unhosted_caller_did_is_rejected_axis_a() {
+        let scp = scp_test();
+        let bi = Arc::clone(&scp.inner);
+
+        // Seed a resolver before identity creation so `context_create`'s
+        // supervisor build snapshots a consistent resolver (mirrors the
+        // committed e2e). The binding rejects before any vote verification, so
+        // no document seeding is required for this negative path.
+        let _resolver_dht = install_seedable_resolver(&bi);
+
+        let owner_identity = scp
+            .identity_create("in_memory".to_owned(), None)
+            .await
+            .expect("owner identity creation must succeed");
+
+        // A real, registered caller context owned by `owner`.
+        let handle_a = scp
+            .context_create(
+                Arc::clone(&owner_identity),
+                saga_context_params(&["governance:propose", "tools:invoke"]),
+            )
+            .await
+            .expect("caller context A must be created");
+
+        // A syntactically-valid DID that was NEVER created on this instance —
+        // so it is not in the identity custody registry (axis (a)).
+        let unhosted_caller_did = "did:dht:zzzzunhostedcalleridnevercreated".to_owned();
+
+        let now_ms = u64::try_from(
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_millis(),
+        )
+        .unwrap();
+
+        // Reuse `handle_a` as the target handle too: the caller axis (a) check
+        // rejects before any target-side resolution, so the target handle is
+        // irrelevant to which axis trips — both handles are real and pass
+        // affinity.
+        let err = scp
+            .tool_invoke_cross_context_saga(
+                Arc::clone(&handle_a),
+                Arc::clone(&handle_a),
+                unhosted_caller_did,
+                "tool-xctx_saga_unhosted".to_owned(),
+                serde_json::json!({"a": "x", "b": "y"}).to_string(),
+                saga_nonce_hex(),
+                now_ms,
+                1,
+                None,
+            )
+            .await
+            .expect_err("an unhosted caller_did must be rejected at axis (a)");
+
+        match err {
+            ScpError::SagaAborted { code, msg, .. } => {
+                assert_eq!(
+                    code,
+                    codes::SAGA_13050,
+                    "an unhosted caller (axis a) must abort with SCP-SAGA-13050"
+                );
+                // The supervisor's own gate-1 ALSO emits SCP-SAGA-13050 for a
+                // non-member caller, so the code alone does NOT prove the BRIDGE
+                // axis-(a) custody check ran. Pin the bridge-unique message
+                // substring (absent from the supervisor gate-1 message) so this
+                // test fails if `enforce_caller_principal_binding`'s axis-(a)
+                // check were deleted and the producer's membership gate took over.
+                assert!(
+                    msg.contains("is not an identity hosted by this bridge instance"),
+                    "must be rejected by the bridge axis-(a) custody check, not the producer's \
+                     membership gate; got: {msg}"
+                );
+            }
+            other => panic!("expected SagaAborted (axis a), got {other:?}"),
+        }
+    }
+
+    /// Caller-principal binding, axis (b) — a HOSTED NON-MEMBER caller is
+    /// rejected.
+    ///
+    /// `stranger` IS created on this instance (so axis (a),
+    /// `identity_custody_registry.contains_key`, passes) but is NOT a member of
+    /// the caller context A (owned by `owner`). Axis (b)
+    /// (`supervisor.is_member`) trips and the saga aborts with `SCP-SAGA-13050`
+    /// BEFORE the producer runs.
+    #[tokio::test]
+    async fn xctx_saga_hosted_non_member_caller_is_rejected_axis_b() {
+        let scp = scp_test();
+        let bi = Arc::clone(&scp.inner);
+
+        let _resolver_dht = install_seedable_resolver(&bi);
+
+        let owner_identity = scp
+            .identity_create("in_memory".to_owned(), None)
+            .await
+            .expect("owner identity creation must succeed");
+
+        // A second hosted identity. `identity_create` registers its custody, so
+        // axis (a) of the binding passes for `stranger`.
+        let stranger_identity = scp
+            .identity_create("in_memory".to_owned(), None)
+            .await
+            .expect("stranger identity creation must succeed");
+        let stranger_did = stranger_identity.did.clone();
+
+        // Caller context A is owned by `owner`; `stranger` is NOT a member.
+        let handle_a = scp
+            .context_create(
+                Arc::clone(&owner_identity),
+                saga_context_params(&["governance:propose", "tools:invoke"]),
+            )
+            .await
+            .expect("caller context A must be created");
+
+        let now_ms = u64::try_from(
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_millis(),
+        )
+        .unwrap();
+
+        // Reuse `handle_a` as the target handle: axis (b) on the caller context
+        // rejects before any target-side resolution.
+        let err = scp
+            .tool_invoke_cross_context_saga(
+                Arc::clone(&handle_a),
+                Arc::clone(&handle_a),
+                stranger_did,
+                "tool-xctx_saga_non_member".to_owned(),
+                serde_json::json!({"a": "x", "b": "y"}).to_string(),
+                saga_nonce_hex(),
+                now_ms,
+                1,
+                None,
+            )
+            .await
+            .expect_err("a hosted non-member caller must be rejected at axis (b)");
+
+        match err {
+            ScpError::SagaAborted { code, msg, .. } => {
+                assert_eq!(
+                    code,
+                    codes::SAGA_13050,
+                    "a hosted non-member caller (axis b) must abort with SCP-SAGA-13050"
+                );
+                // The supervisor's gate-1 ALSO emits SCP-SAGA-13050 for a
+                // non-member caller, so pin the bridge-unique axis-(b) message
+                // substring (absent from the supervisor gate-1 message) to prove
+                // the BRIDGE binding rejected — not the producer's own gate.
+                assert!(
+                    msg.contains("is hosted by this bridge but is not a member of"),
+                    "must be rejected by the bridge axis-(b) binding, not the producer's gate; \
+                     got: {msg}"
+                );
+            }
+            other => panic!("expected SagaAborted (axis b), got {other:?}"),
+        }
     }
 }

--- a/crates/scp-ffi/uniffi/src/bridge.rs
+++ b/crates/scp-ffi/uniffi/src/bridge.rs
@@ -5409,48 +5409,36 @@ async fn resolve_uniffi_signing_key(
 // ---------------------------------------------------------------------------
 
 /// Maps a `SagaError` terminal (the typed §6.2.4 terminal space) onto the
-/// bridge's typed saga error variants, reading every structured datum
-/// STRUCTURALLY off the variant — never by re-parsing a message string.
+/// bridge's typed saga error variants.
 ///
-/// - `Aborted { reason, code, message }` → [`ScpError::SagaAborted`].
-///   `retry_after_ms` is read directly off `SagaAbortReason::RateLimited`
-///   (an `Option<u64>`); a plain `Rejected` carries `None`. `None` is
-///   propagated, NEVER coerced to `0` (a `0` would read as "retry
-///   immediately" and re-trip the same hard limit). `code` is formatted as
-///   the canonical `SCP-SAGA-{code}` string from the numeric discriminant.
-/// - `NeedsRepair { saga_id, message }` → [`ScpError::SagaNeedsRepair`]
-///   carrying the durable operator-repair handle (`SCP-SAGA-13065`).
-/// - `Busy { contended_context, message }` → [`ScpError::SagaBusy`]
-///   (`SCP-SAGA-13066`).
+/// The decomposition — the `SagaAbortReason::RateLimited → Option<u64>` read,
+/// the `None`-never-coerced-to-`0` rule, and the `SCP-SAGA-{code}` formatting —
+/// lives ONCE in [`scp_ffi_common::saga_errors::decompose_saga_error`], unit-
+/// tested there, so the three bridges cannot drift. This function is the thin
+/// per-bridge tail that carries the `UniFFI` field labels (`msg:`):
+///
+/// - `Aborted` → [`ScpError::SagaAborted`] (`retry_after_ms`, `None` never `0`,
+///   `SCP-SAGA-{code}`).
+/// - `NeedsRepair` → [`ScpError::SagaNeedsRepair`] (durable repair handle,
+///   `SCP-SAGA-13065`).
+/// - `Busy` → [`ScpError::SagaBusy`] (`SCP-SAGA-13066`).
 fn map_saga_error(err: scp_core::context::supervisor::SagaError) -> ScpError {
-    use scp_core::context::supervisor::{SagaAbortReason, SagaError};
-    match err {
-        SagaError::Aborted {
-            reason,
-            code,
-            message,
-        } => {
-            let retry_after_ms = match reason {
-                SagaAbortReason::RateLimited { retry_after_ms } => retry_after_ms,
-                SagaAbortReason::Rejected => None,
-            };
-            ScpError::SagaAborted {
-                msg: message,
-                code: format!("SCP-SAGA-{code}"),
-                retry_after_ms,
-            }
-        }
-        SagaError::NeedsRepair { saga_id, message } => ScpError::SagaNeedsRepair {
-            msg: message,
-            code: codes::SAGA_13065.to_owned(),
-            saga_id: saga_id.0,
+    use scp_ffi_common::saga_errors::{SagaErrorKind, decompose_saga_error};
+    let parts = decompose_saga_error(err);
+    match parts.kind {
+        SagaErrorKind::Aborted { retry_after_ms } => ScpError::SagaAborted {
+            msg: parts.message,
+            code: parts.code,
+            retry_after_ms,
         },
-        SagaError::Busy {
-            contended_context,
-            message,
-        } => ScpError::SagaBusy {
-            msg: message,
-            code: codes::SAGA_13066.to_owned(),
+        SagaErrorKind::NeedsRepair { saga_id } => ScpError::SagaNeedsRepair {
+            msg: parts.message,
+            code: parts.code,
+            saga_id,
+        },
+        SagaErrorKind::Busy { contended_context } => ScpError::SagaBusy {
+            msg: parts.message,
+            code: parts.code,
             contended_context,
         },
     }
@@ -20460,20 +20448,29 @@ mod tests {
         SagaAbortReason, SagaError as CoreSagaError, SagaId as CoreSagaId,
     };
 
-    /// `map_saga_error` — a rate-limited abort preserves `retry_after_ms =
-    /// Some(ms)` STRUCTURALLY and formats the numeric `code` as the canonical
-    /// `SCP-SAGA-{code}` string. The producer's actual terminal behavior is
-    /// covered in `scp-runtime`; here we test ONLY the bridge's mapping.
+    // The saga-error classification (the `RateLimited → Option<u64>` read, the
+    // `None`-never-`0` rule, the `SCP-SAGA-{code}` formatting, the fixed
+    // terminal codes) lives in `scp_ffi_common::saga_errors` and is unit-tested
+    // there for all three bridges. The producer's actual terminal behavior is
+    // covered in `scp-runtime`. The tests below cover ONLY this bridge's thin
+    // tail: that each `SagaErrorKind` routes through `common` onto the right
+    // `ScpError` variant with the shared `code`/`message` carried onto the
+    // `UniFFI` `msg:` field — including that `retry_after_ms = None` is
+    // preserved (never coerced to `Some(0)`).
+
+    /// `Aborted` routes through `common` onto `ScpError::SagaAborted` with the
+    /// `SCP-SAGA-{code}` string and `retry_after_ms` carried structurally; a
+    /// `None` back-off hint stays `None` (never `Some(0)`).
     #[test]
-    fn map_saga_error_rate_limited_preserves_retry_after_ms() {
-        let mapped = map_saga_error(CoreSagaError::Aborted {
+    fn map_saga_error_aborted_routes_through_common() {
+        let some = map_saga_error(CoreSagaError::Aborted {
             reason: SagaAbortReason::RateLimited {
                 retry_after_ms: Some(2500),
             },
             code: 13026,
             message: "inbound rate limit exceeded".to_owned(),
         });
-        match mapped {
+        match some {
             ScpError::SagaAborted {
                 code,
                 retry_after_ms,
@@ -20484,21 +20481,15 @@ mod tests {
             }
             other => panic!("expected SagaAborted, got {other:?}"),
         }
-    }
 
-    /// `map_saga_error` — a rate-limited abort with NO precise back-off instant
-    /// preserves `retry_after_ms = None`, NEVER coerced to `Some(0)` (a `0`
-    /// would read as "retry immediately" and re-trip the same hard limit).
-    #[test]
-    fn map_saga_error_rate_limited_none_is_not_zero() {
-        let mapped = map_saga_error(CoreSagaError::Aborted {
+        let none = map_saga_error(CoreSagaError::Aborted {
             reason: SagaAbortReason::RateLimited {
                 retry_after_ms: None,
             },
             code: 13026,
             message: "hard limit, no precise back-off".to_owned(),
         });
-        match mapped {
+        match none {
             ScpError::SagaAborted { retry_after_ms, .. } => {
                 assert_eq!(retry_after_ms, None, "None must NOT be coerced to Some(0)");
             }
@@ -20506,54 +20497,27 @@ mod tests {
         }
     }
 
-    /// `map_saga_error` — a plain (non-rate-limit) `Rejected` abort carries
-    /// `retry_after_ms = None`.
+    /// `NeedsRepair` / `Busy` route through `common` onto their `UniFFI`
+    /// variants with the fixed terminal codes and per-terminal datum carried.
     #[test]
-    fn map_saga_error_rejected_has_no_retry_hint() {
-        let mapped = map_saga_error(CoreSagaError::Aborted {
-            reason: SagaAbortReason::Rejected,
-            code: 13050,
-            message: "caller not a member".to_owned(),
-        });
-        match mapped {
-            ScpError::SagaAborted {
-                code,
-                retry_after_ms,
-                ..
-            } => {
-                assert_eq!(code, "SCP-SAGA-13050");
-                assert_eq!(retry_after_ms, None);
-            }
-            other => panic!("expected SagaAborted, got {other:?}"),
-        }
-    }
-
-    /// `map_saga_error` — `NeedsRepair` preserves the durable `saga_id`
-    /// operator-repair handle and the fixed terminal code `SCP-SAGA-13065`.
-    #[test]
-    fn map_saga_error_needs_repair_preserves_saga_id() {
-        let mapped = map_saga_error(CoreSagaError::NeedsRepair {
+    fn map_saga_error_needs_repair_and_busy_route_through_common() {
+        let repair = map_saga_error(CoreSagaError::NeedsRepair {
             saga_id: CoreSagaId("saga-abc-123".to_owned()),
             message: "commit retries exhausted".to_owned(),
         });
-        match mapped {
+        match repair {
             ScpError::SagaNeedsRepair { code, saga_id, .. } => {
                 assert_eq!(code, codes::SAGA_13065);
                 assert_eq!(saga_id, "saga-abc-123");
             }
             other => panic!("expected SagaNeedsRepair, got {other:?}"),
         }
-    }
 
-    /// `map_saga_error` — `Busy` preserves the contended context id and the
-    /// fixed terminal code `SCP-SAGA-13066`.
-    #[test]
-    fn map_saga_error_busy_preserves_contended_context() {
-        let mapped = map_saga_error(CoreSagaError::Busy {
+        let busy = map_saga_error(CoreSagaError::Busy {
             contended_context: "ctx-shared-99".to_owned(),
             message: "participant set overlaps an in-flight saga".to_owned(),
         });
-        match mapped {
+        match busy {
             ScpError::SagaBusy {
                 code,
                 contended_context,

--- a/crates/scp-ffi/uniffi/src/bridge.rs
+++ b/crates/scp-ffi/uniffi/src/bridge.rs
@@ -20619,6 +20619,7 @@ mod tests {
     /// identity creation makes `ensure_did_resolver_initialized_on` a no-op
     /// (it skips when a resolver is already present), so this client is the one
     /// the supervisor snapshots.
+    #[cfg(feature = "allow_in_memory_custody")]
     fn install_seedable_resolver(
         bi: &Arc<crate::runtime::UniffiBridgeInstance>,
     ) -> Arc<scp_identity::InMemoryDhtClient> {
@@ -20638,6 +20639,7 @@ mod tests {
     /// in-memory custody. Mirrors the production `publish_to_resolver_dht_for`
     /// step so the supervisor's governance key resolver can resolve the proposer
     /// key during single-admin vote verification.
+    #[cfg(feature = "allow_in_memory_custody")]
     async fn seed_owner_document_into_resolver(
         owner_identity: &Identity,
         dht_client: &Arc<scp_identity::InMemoryDhtClient>,
@@ -20854,6 +20856,7 @@ mod tests {
     /// a `RegisterTool` action; saga Prepare-B reads it there) plus the FFI-side
     /// handler the executor snapshots and runs once at Commit-B (returns
     /// `{sum:42, ok:1}`, validated against the registered numeric output schema).
+    #[cfg(feature = "allow_in_memory_custody")]
     #[tokio::test]
     async fn xctx_saga_authenticated_caller_commits_via_governance_established_interface() {
         let scp = scp_test();
@@ -21042,6 +21045,7 @@ mod tests {
     /// BOTH the `RegisterTool` governance action and the FFI `ToolDefinition`, so
     /// Commit-B's output-schema validation accepts the echo and the saga reaches
     /// a real `Committed`. Proves the no-handler echo path commits end-to-end.
+    #[cfg(feature = "allow_in_memory_custody")]
     #[tokio::test]
     async fn xctx_saga_commits_with_echo_fallback_when_no_handler_registered() {
         let scp = scp_test();
@@ -21201,6 +21205,7 @@ mod tests {
     /// runs — no governance/resolver scaffolding is needed. A valid nonce hex
     /// and a near-now timestamp ensure the binding (not nonce/validation) is
     /// the rejecting gate.
+    #[cfg(feature = "allow_in_memory_custody")]
     #[tokio::test]
     async fn xctx_saga_unhosted_caller_did_is_rejected_axis_a() {
         let scp = scp_test();
@@ -21288,6 +21293,7 @@ mod tests {
     /// the caller context A (owned by `owner`). Axis (b)
     /// (`supervisor.is_member`) trips and the saga aborts with `SCP-SAGA-13050`
     /// BEFORE the producer runs.
+    #[cfg(feature = "allow_in_memory_custody")]
     #[tokio::test]
     async fn xctx_saga_hosted_non_member_caller_is_rejected_axis_b() {
         let scp = scp_test();

--- a/crates/scp-ffi/uniffi/src/bridge.rs
+++ b/crates/scp-ffi/uniffi/src/bridge.rs
@@ -20594,909 +20594,916 @@ mod tests {
         }
     }
 
-    /// A valid 16-byte nonce as a 32-char hex string.
-    fn saga_nonce_hex() -> String {
-        "00112233445566778899aabbccddeeff".to_owned()
-    }
-
-    /// Installs a resolver backed by a caller-retained in-memory DHT client on
-    /// `bi` and returns that client, so the e2e test can seed the owner's DID
-    /// document into the SAME store the supervisor's governance key resolver
-    /// reads from.
-    ///
-    /// Why this is test scaffolding, not a production gap masked: the `UniFFI`
-    /// bridge's `ensure_did_resolver_initialized_on` builds its resolver over a
-    /// FRESH, unretained `InMemoryDhtClient` and `identity_create` publishes the
-    /// minted document only to a throwaway local `DidDht` — in a unit harness
-    /// the bridge op "builds a fresh DHT per call, so its `resolve_did` cannot
-    /// see the create-time publish" (see `rotate_key_signer_is_wired_over_callback_custody`).
-    /// The cross-process E2E covers the wired path. To drive a REAL `Committed`
-    /// terminal in-crate — which requires the supervisor to resolve the
-    /// proposer's published key for governance vote verification — the test must
-    /// itself seed the document into a resolver-visible store, exactly the
-    /// `publish_to_resolver_dht_for` step the PyO3/NAPI production
-    /// `identity_create` performs. Installing the resolver BEFORE the first
-    /// identity creation makes `ensure_did_resolver_initialized_on` a no-op
-    /// (it skips when a resolver is already present), so this client is the one
-    /// the supervisor snapshots.
+    /// All §6.2.4 cross-context-tool saga binding tests and their pure-string /
+    /// DHT / governance helpers live in this single submodule gated on
+    /// `allow_in_memory_custody`. Gating the module (rather than each item)
+    /// covers every helper AND every future saga test added here by
+    /// construction, closing the no-feature `function is never used` regression
+    /// class: a saga test added without an explicit per-item `#[cfg(...)]` can
+    /// no longer silently reintroduce the no-feature compile warning.
     #[cfg(feature = "allow_in_memory_custody")]
-    fn install_seedable_resolver(
-        bi: &Arc<crate::runtime::UniffiBridgeInstance>,
-    ) -> Arc<scp_identity::InMemoryDhtClient> {
-        let dht_client = Arc::new(scp_identity::InMemoryDhtClient::new());
-        let resolver = Arc::new(scp_identity::resolver::DualLayerResolver::new(
-            Arc::new(scp_identity::resolver::NoOpRelayQuerier),
-            Arc::clone(&dht_client),
-            Arc::new(scp_identity::DidCache::new()),
-            Vec::new(),
-        ));
-        bi.set_did_resolver(resolver, tokio::runtime::Handle::current());
-        dht_client
-    }
+    mod xctx_saga_tests {
+        use super::*;
 
-    /// Publishes `owner_identity`'s DID document into `dht_client` (the
-    /// resolver-visible store) by signing the BEP44 record with the identity's
-    /// in-memory custody. Mirrors the production `publish_to_resolver_dht_for`
-    /// step so the supervisor's governance key resolver can resolve the proposer
-    /// key during single-admin vote verification.
-    #[cfg(feature = "allow_in_memory_custody")]
-    async fn seed_owner_document_into_resolver(
-        owner_identity: &Identity,
-        dht_client: &Arc<scp_identity::InMemoryDhtClient>,
-    ) {
-        use scp_identity::dht_client::DhtClient as _;
-        use scp_platform::traits::KeyCustody as _;
-
-        let identity = owner_identity
-            .core_id
-            .as_ref()
-            .expect("in-memory owner retains its ScpIdentity");
-        let document = owner_identity
-            .core_document
-            .as_ref()
-            .expect("in-memory owner retains its DID document");
-        let custody = owner_identity
-            .in_memory_custody
-            .as_ref()
-            .expect("in-memory owner retains its custody");
-
-        let doc_json = document.to_json().expect("document serializes to JSON");
-        let value = doc_json.as_bytes();
-        let public_key =
-            scp_identity::extract_public_key(&identity.did).expect("DID embeds the public key");
-        let seq: u64 = 1;
-        let signable = scp_identity::dht::bep44_signable(value, seq);
-        let sig_bytes = custody
-            .0
-            .sign(&identity.identity_key, &signable)
-            .await
-            .expect("identity custody signs the BEP44 record")
-            .into_bytes();
-        let signature: [u8; 64] = sig_bytes.try_into().expect("Ed25519 signature is 64 bytes");
-        dht_client
-            .publish(&public_key, &signature, value, seq)
-            .await
-            .expect("publish into the resolver-visible store");
-    }
-
-    /// Builds a `ContextParams` carrying the given capability ceiling under
-    /// single-admin governance (so a governance proposal auto-executes), an
-    /// Encrypted context (the saga chokepoint round-trips a real 64-hex id), and
-    /// otherwise-default fields. Mirrors the `PyO3` e2e's `params_a` / `params_b`.
-    fn saga_context_params(ceiling: &[&str]) -> ContextParams {
-        ContextParams {
-            mode: ContextMode::Encrypted,
-            ceiling: ceiling.iter().map(|s| (*s).to_owned()).collect(),
-            ceiling_policy: CeilingPolicy::Immutable,
-            governance: GovernanceModel::SingleAdmin,
-            memory_scope: MemoryScope::Ephemeral,
-            ttl_seconds: 0,
-            promotable: false,
-            min_protocol_version: 0,
-            max_chain_depth: None,
-            max_nesting_depth: None,
-            session_cap: None,
-            economic_policy: None,
-            consequence_rules_json: None,
-            consequence_config_json: None,
+        /// A valid 16-byte nonce as a 32-char hex string.
+        fn saga_nonce_hex() -> String {
+            "00112233445566778899aabbccddeeff".to_owned()
         }
-    }
 
-    /// The numeric `{sum, ok}` output schema the handler-backed e2e uses (2
-    /// output properties — clears the §9.2.1 specificity floor of 2 — so
-    /// Commit-B's output-schema validation accepts the `{sum:42, ok:1}`
-    /// handler response).
-    fn saga_numeric_output_schema() -> serde_json::Value {
-        serde_json::json!({
-            "type": "object",
-            "properties": {
-                "sum": {"type": "number"},
-                "ok": {"type": "number"}
+        /// Installs a resolver backed by a caller-retained in-memory DHT client on
+        /// `bi` and returns that client, so the e2e test can seed the owner's DID
+        /// document into the SAME store the supervisor's governance key resolver
+        /// reads from.
+        ///
+        /// Why this is test scaffolding, not a production gap masked: the `UniFFI`
+        /// bridge's `ensure_did_resolver_initialized_on` builds its resolver over a
+        /// FRESH, unretained `InMemoryDhtClient` and `identity_create` publishes the
+        /// minted document only to a throwaway local `DidDht` — in a unit harness
+        /// the bridge op "builds a fresh DHT per call, so its `resolve_did` cannot
+        /// see the create-time publish" (see `rotate_key_signer_is_wired_over_callback_custody`).
+        /// The cross-process E2E covers the wired path. To drive a REAL `Committed`
+        /// terminal in-crate — which requires the supervisor to resolve the
+        /// proposer's published key for governance vote verification — the test must
+        /// itself seed the document into a resolver-visible store, exactly the
+        /// `publish_to_resolver_dht_for` step the PyO3/NAPI production
+        /// `identity_create` performs. Installing the resolver BEFORE the first
+        /// identity creation makes `ensure_did_resolver_initialized_on` a no-op
+        /// (it skips when a resolver is already present), so this client is the one
+        /// the supervisor snapshots.
+        fn install_seedable_resolver(
+            bi: &Arc<crate::runtime::UniffiBridgeInstance>,
+        ) -> Arc<scp_identity::InMemoryDhtClient> {
+            let dht_client = Arc::new(scp_identity::InMemoryDhtClient::new());
+            let resolver = Arc::new(scp_identity::resolver::DualLayerResolver::new(
+                Arc::new(scp_identity::resolver::NoOpRelayQuerier),
+                Arc::clone(&dht_client),
+                Arc::new(scp_identity::DidCache::new()),
+                Vec::new(),
+            ));
+            bi.set_did_resolver(resolver, tokio::runtime::Handle::current());
+            dht_client
+        }
+
+        /// Publishes `owner_identity`'s DID document into `dht_client` (the
+        /// resolver-visible store) by signing the BEP44 record with the identity's
+        /// in-memory custody. Mirrors the production `publish_to_resolver_dht_for`
+        /// step so the supervisor's governance key resolver can resolve the proposer
+        /// key during single-admin vote verification.
+        async fn seed_owner_document_into_resolver(
+            owner_identity: &Identity,
+            dht_client: &Arc<scp_identity::InMemoryDhtClient>,
+        ) {
+            use scp_identity::dht_client::DhtClient as _;
+            use scp_platform::traits::KeyCustody as _;
+
+            let identity = owner_identity
+                .core_id
+                .as_ref()
+                .expect("in-memory owner retains its ScpIdentity");
+            let document = owner_identity
+                .core_document
+                .as_ref()
+                .expect("in-memory owner retains its DID document");
+            let custody = owner_identity
+                .in_memory_custody
+                .as_ref()
+                .expect("in-memory owner retains its custody");
+
+            let doc_json = document.to_json().expect("document serializes to JSON");
+            let value = doc_json.as_bytes();
+            let public_key =
+                scp_identity::extract_public_key(&identity.did).expect("DID embeds the public key");
+            let seq: u64 = 1;
+            let signable = scp_identity::dht::bep44_signable(value, seq);
+            let sig_bytes = custody
+                .0
+                .sign(&identity.identity_key, &signable)
+                .await
+                .expect("identity custody signs the BEP44 record")
+                .into_bytes();
+            let signature: [u8; 64] = sig_bytes.try_into().expect("Ed25519 signature is 64 bytes");
+            dht_client
+                .publish(&public_key, &signature, value, seq)
+                .await
+                .expect("publish into the resolver-visible store");
+        }
+
+        /// Builds a `ContextParams` carrying the given capability ceiling under
+        /// single-admin governance (so a governance proposal auto-executes), an
+        /// Encrypted context (the saga chokepoint round-trips a real 64-hex id), and
+        /// otherwise-default fields. Mirrors the `PyO3` e2e's `params_a` / `params_b`.
+        fn saga_context_params(ceiling: &[&str]) -> ContextParams {
+            ContextParams {
+                mode: ContextMode::Encrypted,
+                ceiling: ceiling.iter().map(|s| (*s).to_owned()).collect(),
+                ceiling_policy: CeilingPolicy::Immutable,
+                governance: GovernanceModel::SingleAdmin,
+                memory_scope: MemoryScope::Ephemeral,
+                ttl_seconds: 0,
+                promotable: false,
+                min_protocol_version: 0,
+                max_chain_depth: None,
+                max_nesting_depth: None,
+                session_cap: None,
+                economic_policy: None,
+                consequence_rules_json: None,
+                consequence_config_json: None,
             }
-        })
-    }
+        }
 
-    /// A PERMISSIVE output schema (2 declared properties drawn from the
-    /// schema-only echo shape — `{status, input_valid}` — and NO `required` /
-    /// `additionalProperties:false`) so the no-handler echo object
-    /// (`{tool, target_context, caller_did, status, input_valid, validated_input}`)
-    /// validates at Commit-B. Used by the echo-fallback Committed test.
-    fn saga_permissive_echo_output_schema() -> serde_json::Value {
-        serde_json::json!({
-            "type": "object",
-            "properties": {
-                "status": {"type": "string"},
-                "input_valid": {"type": "boolean"}
-            }
-        })
-    }
-
-    /// Serializes a `RegisterTool` governance action for the saga tool carrying
-    /// the given `output_schema`. The input schema mirrors the `PyO3` e2e (2
-    /// input properties — clears the §9.2.1 specificity floor of 2).
-    /// `implementation_hash` is a fixed 32-byte array (serde wants a 32-element
-    /// JSON number array — `json!` has no array-repeat sugar).
-    fn saga_register_tool_action_json_with_output(
-        tool_id: &str,
-        tool_name: &str,
-        owner: &str,
-        output_schema: serde_json::Value,
-    ) -> String {
-        let impl_hash = serde_json::Value::from(vec![0u8; 32]);
-        let register_action = serde_json::json!({
-            "RegisterTool": {
-                "registration": {
-                    "tool_id": tool_id,
-                    "name": tool_name,
-                    "description": format!("Tool: {tool_name}"),
-                    "schema": {
-                        "input_schema": {
-                            "type": "object",
-                            "properties": {
-                                "a": {"type": "string"},
-                                "b": {"type": "string"}
-                            }
-                        },
-                        "output_schema": output_schema
-                    },
-                    "implementation_hash": impl_hash,
-                    "test_vectors": [],
-                    "operator_did": owner,
-                    "cost": null,
-                    "registered_at": 0,
-                    "signature": []
-                }
-            }
-        });
-        serde_json::to_string(&register_action).unwrap()
-    }
-
-    /// The handler-backed e2e's `RegisterTool` action (numeric `{sum, ok}`
-    /// output schema).
-    fn saga_register_tool_action_json(tool_id: &str, tool_name: &str, owner: &str) -> String {
-        saga_register_tool_action_json_with_output(
-            tool_id,
-            tool_name,
-            owner,
-            saga_numeric_output_schema(),
-        )
-    }
-
-    /// Serializes the bidirectionally-approved `EstablishToolInterface`
-    /// governance action (externally-tagged `GovernanceAction`; the
-    /// `snake_case` `ToolInterface` `Option` fields render as JSON `null`).
-    fn saga_establish_interface_action_json(ctx_a: &str, ctx_b: &str, tool_id: &str) -> String {
-        let action = serde_json::json!({
-            "EstablishToolInterface": {
-                "interface": {
-                    "source_context": ctx_a,
-                    "target_context": ctx_b,
-                    "tool_id": tool_id,
-                    "rate_limit": null,
-                    "inbound_rate_limit": null,
-                    "per_caller_rate_limit": null,
-                    "approved_by_source": true,
-                    "approved_by_target": true,
-                    "outbound_policy": null,
-                    "inbound_policy": null
-                }
-            }
-        });
-        serde_json::to_string(&action).unwrap()
-    }
-
-    /// Asserts a `governance_propose` result actually EXECUTED its action (not
-    /// merely returned a non-empty JSON — `governance_propose` serializes a
-    /// non-empty `{proposal_id, status, execution_result}` even on a non-executed
-    /// terminal). `governance_propose` serializes `status` as the `Debug` of
-    /// `ProposalStatus`; under single-admin the action auto-executes, so the
-    /// proposal resolves `Approved` and `execution_result` is `Some` (a non-null
-    /// JSON string). Both together prove the interface/registration was
-    /// established, not just proposed.
-    fn assert_governance_executed(propose_result: &str, what: &str) {
-        let parsed: serde_json::Value = serde_json::from_str(propose_result)
-            .unwrap_or_else(|e| panic!("{what}: governance_propose result must be JSON: {e}"));
-        let status = parsed["status"].as_str().unwrap_or_else(|| {
-            panic!("{what}: governance_propose result must carry a string status; got: {parsed}")
-        });
-        assert_eq!(
-            status, "Approved",
-            "{what}: single-admin proposal must auto-execute to Approved; got status {status:?} \
-             in {parsed}"
-        );
-        assert!(
-            !parsed["execution_result"].is_null(),
-            "{what}: an executed proposal must carry a non-null execution_result; got: {parsed}"
-        );
-    }
-
-    /// Full `Committed` terminal through the `UniFFI` bridge: an authenticated
-    /// caller drives the §6.2.4 cross-context tool-invocation saga (ADR-049 §3a)
-    /// to a real commit and the bridge returns the committed receipt + output
-    /// bytes.
-    ///
-    /// The setup mirrors the producer's two authorization axes
-    /// (`start_cross_context_tool_invocation_saga`):
-    ///
-    /// 1. **Caller axis (gate 1).** `caller_did` must be hosted by this bridge
-    ///    AND a member of the CALLER (source) context A. Creating A via
-    ///    `context_create` with `owner` as the single-admin creator satisfies
-    ///    both; creating `owner` via `identity_create` registers its custody
-    ///    (axis (a) of the bridge's caller-principal binding) and publishes its
-    ///    DID document into the per-instance resolver BEFORE the first
-    ///    `context_create` builds the supervisor (which snapshots that resolver
-    ///    for governance vote verification).
-    /// 2. **Target axis (gate 2).** The producer requires a *bidirectionally
-    ///    approved* `ToolInterface` queried against the CALLER context A's actor
-    ///    governance state — so it is established IN A via a governance
-    ///    `EstablishToolInterface` action (auto-executed under `single_admin`; A's
-    ///    ceiling carries `tool:interface` + `governance:propose`).
-    ///
-    /// Context B holds the tool in its ACTOR governance `registered_tools` (via
-    /// a `RegisterTool` action; saga Prepare-B reads it there) plus the FFI-side
-    /// handler the executor snapshots and runs once at Commit-B (returns
-    /// `{sum:42, ok:1}`, validated against the registered numeric output schema).
-    #[cfg(feature = "allow_in_memory_custody")]
-    #[tokio::test]
-    async fn xctx_saga_authenticated_caller_commits_via_governance_established_interface() {
-        let scp = scp_test();
-        let bi = Arc::clone(&scp.inner);
-
-        // Install a seedable resolver BEFORE identity creation so its store is
-        // the one the supervisor snapshots; `identity_create`'s own resolver
-        // init then no-ops. See `install_seedable_resolver`.
-        let resolver_dht = install_seedable_resolver(&bi);
-
-        // Owner identity. Registers custody (axis (a) of the caller-principal
-        // binding) and mints the DID document.
-        let owner_identity = scp
-            .identity_create("in_memory".to_owned(), None)
-            .await
-            .expect("owner identity creation must succeed");
-        let owner = owner_identity.did.clone();
-
-        // Seed the owner's document into the resolver-visible store so the
-        // supervisor (built at the first `context_create` below) can resolve the
-        // proposer key during single-admin governance vote verification.
-        seed_owner_document_into_resolver(&owner_identity, &resolver_dht).await;
-
-        // Context A (caller/source): ceiling carries `governance:propose` (so
-        // owner-as-admin can propose) and `tool:interface` (required by
-        // `execute_establish_tool_interface`'s ceiling check).
-        let handle_a = scp
-            .context_create(
-                Arc::clone(&owner_identity),
-                saga_context_params(&[
-                    "governance:propose",
-                    "tool:interface",
-                    "tools:invoke",
-                    "messages:read",
-                    "messages:write",
-                ]),
-            )
-            .await
-            .expect("caller context A must be created");
-        let ctx_a = handle_a.context_id.clone();
-
-        // Context B (target): ceiling carries `governance:propose` and
-        // `tool:register` so the saga tool can be registered into B's ACTOR
-        // governance state.
-        let handle_b = scp
-            .context_create(
-                Arc::clone(&owner_identity),
-                saga_context_params(&["governance:propose", "tool:register"]),
-            )
-            .await
-            .expect("target context B must be created");
-        let ctx_b = handle_b.context_id.clone();
-
-        // The tool id is the deterministic `tool-{name}` form `tool_register`
-        // mints, also keying B's actor `registered_tools` and A's interface.
-        let tool_name = "xctx_saga_commit_tool";
-        let tool_id = format!("tool-{tool_name}");
-
-        // Register the saga tool into B's ACTOR governance state (saga Prepare-B
-        // reads the tool from there).
-        let register_json = saga_register_tool_action_json(&tool_id, tool_name, &owner);
-        let register_result = scp
-            .governance_propose(Arc::clone(&handle_b), owner.clone(), register_json)
-            .await
-            .expect("RegisterTool must auto-execute under single_admin");
-        assert_governance_executed(&register_result, "RegisterTool");
-
-        // Register the tool in B's FFI-side registry too (so the FFI schema
-        // matches the governance registration), then attach the deterministic
-        // handler the executor snapshots at Commit-B.
-        let definition = ToolDefinition {
-            name: tool_name.to_owned(),
-            description: format!("Tool: {tool_name}"),
-            input_schema_json: serde_json::json!({
-                "type": "object",
-                "properties": {
-                    "a": {"type": "string"},
-                    "b": {"type": "string"}
-                }
-            })
-            .to_string(),
-            output_schema_json: serde_json::json!({
+        /// The numeric `{sum, ok}` output schema the handler-backed e2e uses (2
+        /// output properties — clears the §9.2.1 specificity floor of 2 — so
+        /// Commit-B's output-schema validation accepts the `{sum:42, ok:1}`
+        /// handler response).
+        fn saga_numeric_output_schema() -> serde_json::Value {
+            serde_json::json!({
                 "type": "object",
                 "properties": {
                     "sum": {"type": "number"},
                     "ok": {"type": "number"}
                 }
             })
-            .to_string(),
-            operator_did: owner.clone(),
-            test_vectors_json: None,
-            implementation_hash: None,
-            cost: None,
-        };
-        let ffi_tool_id = scp
-            .tool_register(Arc::clone(&handle_b), definition)
-            .await
-            .expect("FFI-side tool registration must succeed");
-        assert_eq!(
-            ffi_tool_id, tool_id,
-            "FFI and governance tool ids must agree (deterministic tool-{{name}})"
-        );
+        }
 
-        // Register a real handler returning the numeric {sum, ok} the registered
-        // output schema accepts. In-crate `tool_handlers` access is `pub(crate)`,
-        // which is exactly why this Committed test lives in-crate.
-        let handler: std::sync::Arc<
-            dyn Fn(serde_json::Value) -> Result<serde_json::Value, String> + Send + Sync,
-        > = std::sync::Arc::new(|_input: serde_json::Value| {
-            Ok(serde_json::json!({"sum": 42, "ok": 1}))
-        });
-        context_handle_registry(&bi)
-            .get(&ctx_b)
-            .expect("target context B must be registered")
-            .tool_handlers
-            .lock()
-            .await
-            .insert(tool_id.clone(), handler);
-
-        // Establish the bidirectionally-approved interface in A via governance.
-        let establish_json = saga_establish_interface_action_json(&ctx_a, &ctx_b, &tool_id);
-        let propose_result = scp
-            .governance_propose(Arc::clone(&handle_a), owner.clone(), establish_json)
-            .await
-            .expect("EstablishToolInterface must auto-execute under single_admin");
-        assert_governance_executed(&propose_result, "EstablishToolInterface");
-
-        // A near-now timestamp: Prepare-B enforces a §9.14 ±5min skew tolerance,
-        // so a fixed historical timestamp would abort.
-        let now_ms = u64::try_from(
-            std::time::SystemTime::now()
-                .duration_since(std::time::UNIX_EPOCH)
-                .unwrap()
-                .as_millis(),
-        )
-        .unwrap();
-
-        let input_json = serde_json::json!({"a": "x", "b": "y"}).to_string();
-
-        let result = scp
-            .tool_invoke_cross_context_saga(
-                Arc::clone(&handle_a),
-                Arc::clone(&handle_b),
-                owner,
-                tool_id,
-                input_json,
-                saga_nonce_hex(),
-                now_ms,
-                1,
-                None,
-            )
-            .await
-            .expect("saga must reach Committed");
-
-        // Committed terminal: non-empty saga id + a receipt + output bytes.
-        assert!(
-            !result.saga_id.is_empty(),
-            "a committed saga must carry a non-empty saga id"
-        );
-        assert!(
-            result.receipt.is_some(),
-            "committed saga must carry a receipt"
-        );
-        assert!(
-            result.output.is_some(),
-            "committed saga must carry output bytes"
-        );
-
-        // The committed output decodes to the handler's response (numeric, per
-        // the registered output schema). Assert the parsed values, not raw
-        // bytes, so a JCS-canonical encoding still passes.
-        let out: serde_json::Value =
-            serde_json::from_slice(result.output.as_ref().unwrap()).unwrap();
-        assert_eq!(out["sum"], 42, "committed output sum must be the handler's");
-        assert_eq!(out["ok"], 1, "committed output ok must be the handler's");
-    }
-
-    /// Full `Committed` terminal through the executor's NO-HANDLER echo
-    /// fallback. Identical to
-    /// [`xctx_saga_authenticated_caller_commits_via_governance_established_interface`]
-    /// EXCEPT no FFI tool handler is registered on context B — so the executor
-    /// takes its schema-only echo branch
-    /// (`{tool, target_context, caller_did, status, input_valid, validated_input}`).
-    /// The tool is registered with a PERMISSIVE output schema
-    /// (`{status, input_valid}`, no `required`/`additionalProperties:false`) in
-    /// BOTH the `RegisterTool` governance action and the FFI `ToolDefinition`, so
-    /// Commit-B's output-schema validation accepts the echo and the saga reaches
-    /// a real `Committed`. Proves the no-handler echo path commits end-to-end.
-    #[cfg(feature = "allow_in_memory_custody")]
-    #[tokio::test]
-    async fn xctx_saga_commits_with_echo_fallback_when_no_handler_registered() {
-        let scp = scp_test();
-        let bi = Arc::clone(&scp.inner);
-
-        let resolver_dht = install_seedable_resolver(&bi);
-
-        let owner_identity = scp
-            .identity_create("in_memory".to_owned(), None)
-            .await
-            .expect("owner identity creation must succeed");
-        let owner = owner_identity.did.clone();
-
-        seed_owner_document_into_resolver(&owner_identity, &resolver_dht).await;
-
-        let handle_a = scp
-            .context_create(
-                Arc::clone(&owner_identity),
-                saga_context_params(&[
-                    "governance:propose",
-                    "tool:interface",
-                    "tools:invoke",
-                    "messages:read",
-                    "messages:write",
-                ]),
-            )
-            .await
-            .expect("caller context A must be created");
-        let ctx_a = handle_a.context_id.clone();
-
-        let handle_b = scp
-            .context_create(
-                Arc::clone(&owner_identity),
-                saga_context_params(&["governance:propose", "tool:register"]),
-            )
-            .await
-            .expect("target context B must be created");
-
-        let tool_name = "xctx_saga_echo_tool";
-        let tool_id = format!("tool-{tool_name}");
-
-        // Register the tool into B's ACTOR governance state with the PERMISSIVE
-        // output schema (so Prepare-B reads it AND Commit-B validates the echo
-        // against it).
-        let register_json = saga_register_tool_action_json_with_output(
-            &tool_id,
-            tool_name,
-            &owner,
-            saga_permissive_echo_output_schema(),
-        );
-        let register_result = scp
-            .governance_propose(Arc::clone(&handle_b), owner.clone(), register_json)
-            .await
-            .expect("RegisterTool must auto-execute under single_admin");
-        assert_governance_executed(&register_result, "RegisterTool (echo)");
-
-        // Register the tool in B's FFI-side registry with the SAME permissive
-        // output schema — but DO NOT attach a handler. The absence of a handler
-        // is what drives the executor's schema-only echo branch.
-        let definition = ToolDefinition {
-            name: tool_name.to_owned(),
-            description: format!("Tool: {tool_name}"),
-            input_schema_json: serde_json::json!({
+        /// A PERMISSIVE output schema (2 declared properties drawn from the
+        /// schema-only echo shape — `{status, input_valid}` — and NO `required` /
+        /// `additionalProperties:false`) so the no-handler echo object
+        /// (`{tool, target_context, caller_did, status, input_valid, validated_input}`)
+        /// validates at Commit-B. Used by the echo-fallback Committed test.
+        fn saga_permissive_echo_output_schema() -> serde_json::Value {
+            serde_json::json!({
                 "type": "object",
                 "properties": {
-                    "a": {"type": "string"},
-                    "b": {"type": "string"}
+                    "status": {"type": "string"},
+                    "input_valid": {"type": "boolean"}
                 }
             })
-            .to_string(),
-            output_schema_json: saga_permissive_echo_output_schema().to_string(),
-            operator_did: owner.clone(),
-            test_vectors_json: None,
-            implementation_hash: None,
-            cost: None,
-        };
-        let ffi_tool_id = scp
-            .tool_register(Arc::clone(&handle_b), definition)
-            .await
-            .expect("FFI-side tool registration must succeed");
-        assert_eq!(
-            ffi_tool_id, tool_id,
-            "FFI and governance tool ids must agree (deterministic tool-{{name}})"
-        );
+        }
 
-        // NO handler registered on context B: the executor must echo.
+        /// Serializes a `RegisterTool` governance action for the saga tool carrying
+        /// the given `output_schema`. The input schema mirrors the `PyO3` e2e (2
+        /// input properties — clears the §9.2.1 specificity floor of 2).
+        /// `implementation_hash` is a fixed 32-byte array (serde wants a 32-element
+        /// JSON number array — `json!` has no array-repeat sugar).
+        fn saga_register_tool_action_json_with_output(
+            tool_id: &str,
+            tool_name: &str,
+            owner: &str,
+            output_schema: serde_json::Value,
+        ) -> String {
+            let impl_hash = serde_json::Value::from(vec![0u8; 32]);
+            let register_action = serde_json::json!({
+                "RegisterTool": {
+                    "registration": {
+                        "tool_id": tool_id,
+                        "name": tool_name,
+                        "description": format!("Tool: {tool_name}"),
+                        "schema": {
+                            "input_schema": {
+                                "type": "object",
+                                "properties": {
+                                    "a": {"type": "string"},
+                                    "b": {"type": "string"}
+                                }
+                            },
+                            "output_schema": output_schema
+                        },
+                        "implementation_hash": impl_hash,
+                        "test_vectors": [],
+                        "operator_did": owner,
+                        "cost": null,
+                        "registered_at": 0,
+                        "signature": []
+                    }
+                }
+            });
+            serde_json::to_string(&register_action).unwrap()
+        }
 
-        let establish_json =
-            saga_establish_interface_action_json(&ctx_a, &handle_b.context_id, &tool_id);
-        let propose_result = scp
-            .governance_propose(Arc::clone(&handle_a), owner.clone(), establish_json)
-            .await
-            .expect("EstablishToolInterface must auto-execute under single_admin");
-        assert_governance_executed(&propose_result, "EstablishToolInterface (echo)");
-
-        let now_ms = u64::try_from(
-            std::time::SystemTime::now()
-                .duration_since(std::time::UNIX_EPOCH)
-                .unwrap()
-                .as_millis(),
-        )
-        .unwrap();
-
-        let input_json = serde_json::json!({"a": "x", "b": "y"}).to_string();
-
-        let result = scp
-            .tool_invoke_cross_context_saga(
-                Arc::clone(&handle_a),
-                Arc::clone(&handle_b),
-                owner,
+        /// The handler-backed e2e's `RegisterTool` action (numeric `{sum, ok}`
+        /// output schema).
+        fn saga_register_tool_action_json(tool_id: &str, tool_name: &str, owner: &str) -> String {
+            saga_register_tool_action_json_with_output(
                 tool_id,
-                input_json,
-                saga_nonce_hex(),
-                now_ms,
-                1,
-                None,
+                tool_name,
+                owner,
+                saga_numeric_output_schema(),
             )
-            .await
-            .expect("echo-fallback saga must reach Committed");
+        }
 
-        assert!(
-            !result.saga_id.is_empty(),
-            "a committed saga must carry a non-empty saga id"
-        );
-        assert!(
-            result.receipt.is_some(),
-            "committed saga must carry a receipt"
-        );
-        assert!(
-            result.output.is_some(),
-            "committed saga must carry output bytes"
-        );
+        /// Serializes the bidirectionally-approved `EstablishToolInterface`
+        /// governance action (externally-tagged `GovernanceAction`; the
+        /// `snake_case` `ToolInterface` `Option` fields render as JSON `null`).
+        fn saga_establish_interface_action_json(ctx_a: &str, ctx_b: &str, tool_id: &str) -> String {
+            let action = serde_json::json!({
+                "EstablishToolInterface": {
+                    "interface": {
+                        "source_context": ctx_a,
+                        "target_context": ctx_b,
+                        "tool_id": tool_id,
+                        "rate_limit": null,
+                        "inbound_rate_limit": null,
+                        "per_caller_rate_limit": null,
+                        "approved_by_source": true,
+                        "approved_by_target": true,
+                        "outbound_policy": null,
+                        "inbound_policy": null
+                    }
+                }
+            });
+            serde_json::to_string(&action).unwrap()
+        }
 
-        // The committed output is the executor's schema-only echo object, NOT a
-        // handler response: parse it and assert the echo-specific fields.
-        let out: serde_json::Value =
-            serde_json::from_slice(result.output.as_ref().unwrap()).unwrap();
-        assert_eq!(
-            out["status"], "validated",
-            "the no-handler echo carries status=\"validated\"; got: {out}"
-        );
-        assert_eq!(
-            out["input_valid"], true,
-            "the no-handler echo carries input_valid=true; got: {out}"
-        );
-    }
+        /// Asserts a `governance_propose` result actually EXECUTED its action (not
+        /// merely returned a non-empty JSON — `governance_propose` serializes a
+        /// non-empty `{proposal_id, status, execution_result}` even on a non-executed
+        /// terminal). `governance_propose` serializes `status` as the `Debug` of
+        /// `ProposalStatus`; under single-admin the action auto-executes, so the
+        /// proposal resolves `Approved` and `execution_result` is `Some` (a non-null
+        /// JSON string). Both together prove the interface/registration was
+        /// established, not just proposed.
+        fn assert_governance_executed(propose_result: &str, what: &str) {
+            let parsed: serde_json::Value = serde_json::from_str(propose_result)
+                .unwrap_or_else(|e| panic!("{what}: governance_propose result must be JSON: {e}"));
+            let status = parsed["status"].as_str().unwrap_or_else(|| {
+                panic!(
+                    "{what}: governance_propose result must carry a string status; got: {parsed}"
+                )
+            });
+            assert_eq!(
+                status, "Approved",
+                "{what}: single-admin proposal must auto-execute to Approved; got status {status:?} \
+             in {parsed}"
+            );
+            assert!(
+                !parsed["execution_result"].is_null(),
+                "{what}: an executed proposal must carry a non-null execution_result; got: {parsed}"
+            );
+        }
 
-    /// Caller-principal binding, axis (a) — an UNHOSTED caller is rejected.
-    ///
-    /// `source_handle` / `target_handle` are REAL registered handles (so the
-    /// per-instance handle-affinity check passes and the
-    /// `context_id_to_bytes`/`is_member` path is reachable), but `caller_did`
-    /// is a syntactically-valid `did:dht:…` string that was NEVER created on
-    /// this instance — so it is absent from the per-instance identity custody
-    /// registry. Axis (a) (`identity_custody_registry.contains_key`) trips
-    /// FIRST and the saga is aborted with `SCP-SAGA-13050` BEFORE the producer
-    /// runs — no governance/resolver scaffolding is needed. A valid nonce hex
-    /// and a near-now timestamp ensure the binding (not nonce/validation) is
-    /// the rejecting gate.
-    #[cfg(feature = "allow_in_memory_custody")]
-    #[tokio::test]
-    async fn xctx_saga_unhosted_caller_did_is_rejected_axis_a() {
-        let scp = scp_test();
-        let bi = Arc::clone(&scp.inner);
+        /// Full `Committed` terminal through the `UniFFI` bridge: an authenticated
+        /// caller drives the §6.2.4 cross-context tool-invocation saga (ADR-049 §3a)
+        /// to a real commit and the bridge returns the committed receipt + output
+        /// bytes.
+        ///
+        /// The setup mirrors the producer's two authorization axes
+        /// (`start_cross_context_tool_invocation_saga`):
+        ///
+        /// 1. **Caller axis (gate 1).** `caller_did` must be hosted by this bridge
+        ///    AND a member of the CALLER (source) context A. Creating A via
+        ///    `context_create` with `owner` as the single-admin creator satisfies
+        ///    both; creating `owner` via `identity_create` registers its custody
+        ///    (axis (a) of the bridge's caller-principal binding) and publishes its
+        ///    DID document into the per-instance resolver BEFORE the first
+        ///    `context_create` builds the supervisor (which snapshots that resolver
+        ///    for governance vote verification).
+        /// 2. **Target axis (gate 2).** The producer requires a *bidirectionally
+        ///    approved* `ToolInterface` queried against the CALLER context A's actor
+        ///    governance state — so it is established IN A via a governance
+        ///    `EstablishToolInterface` action (auto-executed under `single_admin`; A's
+        ///    ceiling carries `tool:interface` + `governance:propose`).
+        ///
+        /// Context B holds the tool in its ACTOR governance `registered_tools` (via
+        /// a `RegisterTool` action; saga Prepare-B reads it there) plus the FFI-side
+        /// handler the executor snapshots and runs once at Commit-B (returns
+        /// `{sum:42, ok:1}`, validated against the registered numeric output schema).
+        #[tokio::test]
+        async fn xctx_saga_authenticated_caller_commits_via_governance_established_interface() {
+            let scp = scp_test();
+            let bi = Arc::clone(&scp.inner);
 
-        // Seed a resolver before identity creation so `context_create`'s
-        // supervisor build snapshots a consistent resolver (mirrors the
-        // committed e2e). The binding rejects before any vote verification, so
-        // no document seeding is required for this negative path.
-        let _resolver_dht = install_seedable_resolver(&bi);
+            // Install a seedable resolver BEFORE identity creation so its store is
+            // the one the supervisor snapshots; `identity_create`'s own resolver
+            // init then no-ops. See `install_seedable_resolver`.
+            let resolver_dht = install_seedable_resolver(&bi);
 
-        let owner_identity = scp
-            .identity_create("in_memory".to_owned(), None)
-            .await
-            .expect("owner identity creation must succeed");
+            // Owner identity. Registers custody (axis (a) of the caller-principal
+            // binding) and mints the DID document.
+            let owner_identity = scp
+                .identity_create("in_memory".to_owned(), None)
+                .await
+                .expect("owner identity creation must succeed");
+            let owner = owner_identity.did.clone();
 
-        // A real, registered caller context owned by `owner`.
-        let handle_a = scp
-            .context_create(
-                Arc::clone(&owner_identity),
-                saga_context_params(&["governance:propose", "tools:invoke"]),
+            // Seed the owner's document into the resolver-visible store so the
+            // supervisor (built at the first `context_create` below) can resolve the
+            // proposer key during single-admin governance vote verification.
+            seed_owner_document_into_resolver(&owner_identity, &resolver_dht).await;
+
+            // Context A (caller/source): ceiling carries `governance:propose` (so
+            // owner-as-admin can propose) and `tool:interface` (required by
+            // `execute_establish_tool_interface`'s ceiling check).
+            let handle_a = scp
+                .context_create(
+                    Arc::clone(&owner_identity),
+                    saga_context_params(&[
+                        "governance:propose",
+                        "tool:interface",
+                        "tools:invoke",
+                        "messages:read",
+                        "messages:write",
+                    ]),
+                )
+                .await
+                .expect("caller context A must be created");
+            let ctx_a = handle_a.context_id.clone();
+
+            // Context B (target): ceiling carries `governance:propose` and
+            // `tool:register` so the saga tool can be registered into B's ACTOR
+            // governance state.
+            let handle_b = scp
+                .context_create(
+                    Arc::clone(&owner_identity),
+                    saga_context_params(&["governance:propose", "tool:register"]),
+                )
+                .await
+                .expect("target context B must be created");
+            let ctx_b = handle_b.context_id.clone();
+
+            // The tool id is the deterministic `tool-{name}` form `tool_register`
+            // mints, also keying B's actor `registered_tools` and A's interface.
+            let tool_name = "xctx_saga_commit_tool";
+            let tool_id = format!("tool-{tool_name}");
+
+            // Register the saga tool into B's ACTOR governance state (saga Prepare-B
+            // reads the tool from there).
+            let register_json = saga_register_tool_action_json(&tool_id, tool_name, &owner);
+            let register_result = scp
+                .governance_propose(Arc::clone(&handle_b), owner.clone(), register_json)
+                .await
+                .expect("RegisterTool must auto-execute under single_admin");
+            assert_governance_executed(&register_result, "RegisterTool");
+
+            // Register the tool in B's FFI-side registry too (so the FFI schema
+            // matches the governance registration), then attach the deterministic
+            // handler the executor snapshots at Commit-B.
+            let definition = ToolDefinition {
+                name: tool_name.to_owned(),
+                description: format!("Tool: {tool_name}"),
+                input_schema_json: serde_json::json!({
+                    "type": "object",
+                    "properties": {
+                        "a": {"type": "string"},
+                        "b": {"type": "string"}
+                    }
+                })
+                .to_string(),
+                output_schema_json: serde_json::json!({
+                    "type": "object",
+                    "properties": {
+                        "sum": {"type": "number"},
+                        "ok": {"type": "number"}
+                    }
+                })
+                .to_string(),
+                operator_did: owner.clone(),
+                test_vectors_json: None,
+                implementation_hash: None,
+                cost: None,
+            };
+            let ffi_tool_id = scp
+                .tool_register(Arc::clone(&handle_b), definition)
+                .await
+                .expect("FFI-side tool registration must succeed");
+            assert_eq!(
+                ffi_tool_id, tool_id,
+                "FFI and governance tool ids must agree (deterministic tool-{{name}})"
+            );
+
+            // Register a real handler returning the numeric {sum, ok} the registered
+            // output schema accepts. In-crate `tool_handlers` access is `pub(crate)`,
+            // which is exactly why this Committed test lives in-crate.
+            let handler: std::sync::Arc<
+                dyn Fn(serde_json::Value) -> Result<serde_json::Value, String> + Send + Sync,
+            > = std::sync::Arc::new(|_input: serde_json::Value| {
+                Ok(serde_json::json!({"sum": 42, "ok": 1}))
+            });
+            context_handle_registry(&bi)
+                .get(&ctx_b)
+                .expect("target context B must be registered")
+                .tool_handlers
+                .lock()
+                .await
+                .insert(tool_id.clone(), handler);
+
+            // Establish the bidirectionally-approved interface in A via governance.
+            let establish_json = saga_establish_interface_action_json(&ctx_a, &ctx_b, &tool_id);
+            let propose_result = scp
+                .governance_propose(Arc::clone(&handle_a), owner.clone(), establish_json)
+                .await
+                .expect("EstablishToolInterface must auto-execute under single_admin");
+            assert_governance_executed(&propose_result, "EstablishToolInterface");
+
+            // A near-now timestamp: Prepare-B enforces a §9.14 ±5min skew tolerance,
+            // so a fixed historical timestamp would abort.
+            let now_ms = u64::try_from(
+                std::time::SystemTime::now()
+                    .duration_since(std::time::UNIX_EPOCH)
+                    .unwrap()
+                    .as_millis(),
             )
-            .await
-            .expect("caller context A must be created");
+            .unwrap();
 
-        // A syntactically-valid DID that was NEVER created on this instance —
-        // so it is not in the identity custody registry (axis (a)).
-        let unhosted_caller_did = "did:dht:zzzzunhostedcalleridnevercreated".to_owned();
+            let input_json = serde_json::json!({"a": "x", "b": "y"}).to_string();
 
-        let now_ms = u64::try_from(
-            std::time::SystemTime::now()
-                .duration_since(std::time::UNIX_EPOCH)
-                .unwrap()
-                .as_millis(),
-        )
-        .unwrap();
+            let result = scp
+                .tool_invoke_cross_context_saga(
+                    Arc::clone(&handle_a),
+                    Arc::clone(&handle_b),
+                    owner,
+                    tool_id,
+                    input_json,
+                    saga_nonce_hex(),
+                    now_ms,
+                    1,
+                    None,
+                )
+                .await
+                .expect("saga must reach Committed");
 
-        // Reuse `handle_a` as the target handle too: the caller axis (a) check
-        // rejects before any target-side resolution, so the target handle is
-        // irrelevant to which axis trips — both handles are real and pass
-        // affinity.
-        let err = scp
-            .tool_invoke_cross_context_saga(
-                Arc::clone(&handle_a),
-                Arc::clone(&handle_a),
-                unhosted_caller_did,
-                "tool-xctx_saga_unhosted".to_owned(),
-                serde_json::json!({"a": "x", "b": "y"}).to_string(),
-                saga_nonce_hex(),
-                now_ms,
-                1,
-                None,
+            // Committed terminal: non-empty saga id + a receipt + output bytes.
+            assert!(
+                !result.saga_id.is_empty(),
+                "a committed saga must carry a non-empty saga id"
+            );
+            assert!(
+                result.receipt.is_some(),
+                "committed saga must carry a receipt"
+            );
+            assert!(
+                result.output.is_some(),
+                "committed saga must carry output bytes"
+            );
+
+            // The committed output decodes to the handler's response (numeric, per
+            // the registered output schema). Assert the parsed values, not raw
+            // bytes, so a JCS-canonical encoding still passes.
+            let out: serde_json::Value =
+                serde_json::from_slice(result.output.as_ref().unwrap()).unwrap();
+            assert_eq!(out["sum"], 42, "committed output sum must be the handler's");
+            assert_eq!(out["ok"], 1, "committed output ok must be the handler's");
+        }
+
+        /// Full `Committed` terminal through the executor's NO-HANDLER echo
+        /// fallback. Identical to
+        /// [`xctx_saga_authenticated_caller_commits_via_governance_established_interface`]
+        /// EXCEPT no FFI tool handler is registered on context B — so the executor
+        /// takes its schema-only echo branch
+        /// (`{tool, target_context, caller_did, status, input_valid, validated_input}`).
+        /// The tool is registered with a PERMISSIVE output schema
+        /// (`{status, input_valid}`, no `required`/`additionalProperties:false`) in
+        /// BOTH the `RegisterTool` governance action and the FFI `ToolDefinition`, so
+        /// Commit-B's output-schema validation accepts the echo and the saga reaches
+        /// a real `Committed`. Proves the no-handler echo path commits end-to-end.
+        #[tokio::test]
+        async fn xctx_saga_commits_with_echo_fallback_when_no_handler_registered() {
+            let scp = scp_test();
+            let bi = Arc::clone(&scp.inner);
+
+            let resolver_dht = install_seedable_resolver(&bi);
+
+            let owner_identity = scp
+                .identity_create("in_memory".to_owned(), None)
+                .await
+                .expect("owner identity creation must succeed");
+            let owner = owner_identity.did.clone();
+
+            seed_owner_document_into_resolver(&owner_identity, &resolver_dht).await;
+
+            let handle_a = scp
+                .context_create(
+                    Arc::clone(&owner_identity),
+                    saga_context_params(&[
+                        "governance:propose",
+                        "tool:interface",
+                        "tools:invoke",
+                        "messages:read",
+                        "messages:write",
+                    ]),
+                )
+                .await
+                .expect("caller context A must be created");
+            let ctx_a = handle_a.context_id.clone();
+
+            let handle_b = scp
+                .context_create(
+                    Arc::clone(&owner_identity),
+                    saga_context_params(&["governance:propose", "tool:register"]),
+                )
+                .await
+                .expect("target context B must be created");
+
+            let tool_name = "xctx_saga_echo_tool";
+            let tool_id = format!("tool-{tool_name}");
+
+            // Register the tool into B's ACTOR governance state with the PERMISSIVE
+            // output schema (so Prepare-B reads it AND Commit-B validates the echo
+            // against it).
+            let register_json = saga_register_tool_action_json_with_output(
+                &tool_id,
+                tool_name,
+                &owner,
+                saga_permissive_echo_output_schema(),
+            );
+            let register_result = scp
+                .governance_propose(Arc::clone(&handle_b), owner.clone(), register_json)
+                .await
+                .expect("RegisterTool must auto-execute under single_admin");
+            assert_governance_executed(&register_result, "RegisterTool (echo)");
+
+            // Register the tool in B's FFI-side registry with the SAME permissive
+            // output schema — but DO NOT attach a handler. The absence of a handler
+            // is what drives the executor's schema-only echo branch.
+            let definition = ToolDefinition {
+                name: tool_name.to_owned(),
+                description: format!("Tool: {tool_name}"),
+                input_schema_json: serde_json::json!({
+                    "type": "object",
+                    "properties": {
+                        "a": {"type": "string"},
+                        "b": {"type": "string"}
+                    }
+                })
+                .to_string(),
+                output_schema_json: saga_permissive_echo_output_schema().to_string(),
+                operator_did: owner.clone(),
+                test_vectors_json: None,
+                implementation_hash: None,
+                cost: None,
+            };
+            let ffi_tool_id = scp
+                .tool_register(Arc::clone(&handle_b), definition)
+                .await
+                .expect("FFI-side tool registration must succeed");
+            assert_eq!(
+                ffi_tool_id, tool_id,
+                "FFI and governance tool ids must agree (deterministic tool-{{name}})"
+            );
+
+            // NO handler registered on context B: the executor must echo.
+
+            let establish_json =
+                saga_establish_interface_action_json(&ctx_a, &handle_b.context_id, &tool_id);
+            let propose_result = scp
+                .governance_propose(Arc::clone(&handle_a), owner.clone(), establish_json)
+                .await
+                .expect("EstablishToolInterface must auto-execute under single_admin");
+            assert_governance_executed(&propose_result, "EstablishToolInterface (echo)");
+
+            let now_ms = u64::try_from(
+                std::time::SystemTime::now()
+                    .duration_since(std::time::UNIX_EPOCH)
+                    .unwrap()
+                    .as_millis(),
             )
-            .await
-            .expect_err("an unhosted caller_did must be rejected at axis (a)");
+            .unwrap();
 
-        match err {
-            ScpError::SagaAborted { code, msg, .. } => {
-                assert_eq!(
-                    code,
-                    codes::SAGA_13050,
-                    "an unhosted caller (axis a) must abort with SCP-SAGA-13050"
-                );
-                // The supervisor's own gate-1 ALSO emits SCP-SAGA-13050 for a
-                // non-member caller, so the code alone does NOT prove the BRIDGE
-                // axis-(a) custody check ran. Pin the bridge-unique message
-                // substring (absent from the supervisor gate-1 message) so this
-                // test fails if `enforce_caller_principal_binding`'s axis-(a)
-                // check were deleted and the producer's membership gate took over.
-                assert!(
-                    msg.contains("is not an identity hosted by this bridge instance"),
-                    "must be rejected by the bridge axis-(a) custody check, not the producer's \
+            let input_json = serde_json::json!({"a": "x", "b": "y"}).to_string();
+
+            let result = scp
+                .tool_invoke_cross_context_saga(
+                    Arc::clone(&handle_a),
+                    Arc::clone(&handle_b),
+                    owner,
+                    tool_id,
+                    input_json,
+                    saga_nonce_hex(),
+                    now_ms,
+                    1,
+                    None,
+                )
+                .await
+                .expect("echo-fallback saga must reach Committed");
+
+            assert!(
+                !result.saga_id.is_empty(),
+                "a committed saga must carry a non-empty saga id"
+            );
+            assert!(
+                result.receipt.is_some(),
+                "committed saga must carry a receipt"
+            );
+            assert!(
+                result.output.is_some(),
+                "committed saga must carry output bytes"
+            );
+
+            // The committed output is the executor's schema-only echo object, NOT a
+            // handler response: parse it and assert the echo-specific fields.
+            let out: serde_json::Value =
+                serde_json::from_slice(result.output.as_ref().unwrap()).unwrap();
+            assert_eq!(
+                out["status"], "validated",
+                "the no-handler echo carries status=\"validated\"; got: {out}"
+            );
+            assert_eq!(
+                out["input_valid"], true,
+                "the no-handler echo carries input_valid=true; got: {out}"
+            );
+        }
+
+        /// Caller-principal binding, axis (a) — an UNHOSTED caller is rejected.
+        ///
+        /// `source_handle` / `target_handle` are REAL registered handles (so the
+        /// per-instance handle-affinity check passes and the
+        /// `context_id_to_bytes`/`is_member` path is reachable), but `caller_did`
+        /// is a syntactically-valid `did:dht:…` string that was NEVER created on
+        /// this instance — so it is absent from the per-instance identity custody
+        /// registry. Axis (a) (`identity_custody_registry.contains_key`) trips
+        /// FIRST and the saga is aborted with `SCP-SAGA-13050` BEFORE the producer
+        /// runs — no governance/resolver scaffolding is needed. A valid nonce hex
+        /// and a near-now timestamp ensure the binding (not nonce/validation) is
+        /// the rejecting gate.
+        #[tokio::test]
+        async fn xctx_saga_unhosted_caller_did_is_rejected_axis_a() {
+            let scp = scp_test();
+            let bi = Arc::clone(&scp.inner);
+
+            // Seed a resolver before identity creation so `context_create`'s
+            // supervisor build snapshots a consistent resolver (mirrors the
+            // committed e2e). The binding rejects before any vote verification, so
+            // no document seeding is required for this negative path.
+            let _resolver_dht = install_seedable_resolver(&bi);
+
+            let owner_identity = scp
+                .identity_create("in_memory".to_owned(), None)
+                .await
+                .expect("owner identity creation must succeed");
+
+            // A real, registered caller context owned by `owner`.
+            let handle_a = scp
+                .context_create(
+                    Arc::clone(&owner_identity),
+                    saga_context_params(&["governance:propose", "tools:invoke"]),
+                )
+                .await
+                .expect("caller context A must be created");
+
+            // A syntactically-valid DID that was NEVER created on this instance —
+            // so it is not in the identity custody registry (axis (a)).
+            let unhosted_caller_did = "did:dht:zzzzunhostedcalleridnevercreated".to_owned();
+
+            let now_ms = u64::try_from(
+                std::time::SystemTime::now()
+                    .duration_since(std::time::UNIX_EPOCH)
+                    .unwrap()
+                    .as_millis(),
+            )
+            .unwrap();
+
+            // Reuse `handle_a` as the target handle too: the caller axis (a) check
+            // rejects before any target-side resolution, so the target handle is
+            // irrelevant to which axis trips — both handles are real and pass
+            // affinity.
+            let err = scp
+                .tool_invoke_cross_context_saga(
+                    Arc::clone(&handle_a),
+                    Arc::clone(&handle_a),
+                    unhosted_caller_did,
+                    "tool-xctx_saga_unhosted".to_owned(),
+                    serde_json::json!({"a": "x", "b": "y"}).to_string(),
+                    saga_nonce_hex(),
+                    now_ms,
+                    1,
+                    None,
+                )
+                .await
+                .expect_err("an unhosted caller_did must be rejected at axis (a)");
+
+            match err {
+                ScpError::SagaAborted { code, msg, .. } => {
+                    assert_eq!(
+                        code,
+                        codes::SAGA_13050,
+                        "an unhosted caller (axis a) must abort with SCP-SAGA-13050"
+                    );
+                    // The supervisor's own gate-1 ALSO emits SCP-SAGA-13050 for a
+                    // non-member caller, so the code alone does NOT prove the BRIDGE
+                    // axis-(a) custody check ran. Pin the bridge-unique message
+                    // substring (absent from the supervisor gate-1 message) so this
+                    // test fails if `enforce_caller_principal_binding`'s axis-(a)
+                    // check were deleted and the producer's membership gate took over.
+                    assert!(
+                        msg.contains("is not an identity hosted by this bridge instance"),
+                        "must be rejected by the bridge axis-(a) custody check, not the producer's \
                      membership gate; got: {msg}"
-                );
+                    );
+                }
+                other => panic!("expected SagaAborted (axis a), got {other:?}"),
             }
-            other => panic!("expected SagaAborted (axis a), got {other:?}"),
         }
-    }
 
-    /// Caller-principal binding, axis (b) — a HOSTED NON-MEMBER caller is
-    /// rejected.
-    ///
-    /// `stranger` IS created on this instance (so axis (a),
-    /// `identity_custody_registry.contains_key`, passes) but is NOT a member of
-    /// the caller context A (owned by `owner`). Axis (b)
-    /// (`supervisor.is_member`) trips and the saga aborts with `SCP-SAGA-13050`
-    /// BEFORE the producer runs.
-    #[cfg(feature = "allow_in_memory_custody")]
-    #[tokio::test]
-    async fn xctx_saga_hosted_non_member_caller_is_rejected_axis_b() {
-        let scp = scp_test();
-        let bi = Arc::clone(&scp.inner);
+        /// Caller-principal binding, axis (b) — a HOSTED NON-MEMBER caller is
+        /// rejected.
+        ///
+        /// `stranger` IS created on this instance (so axis (a),
+        /// `identity_custody_registry.contains_key`, passes) but is NOT a member of
+        /// the caller context A (owned by `owner`). Axis (b)
+        /// (`supervisor.is_member`) trips and the saga aborts with `SCP-SAGA-13050`
+        /// BEFORE the producer runs.
+        #[tokio::test]
+        async fn xctx_saga_hosted_non_member_caller_is_rejected_axis_b() {
+            let scp = scp_test();
+            let bi = Arc::clone(&scp.inner);
 
-        let _resolver_dht = install_seedable_resolver(&bi);
+            let _resolver_dht = install_seedable_resolver(&bi);
 
-        let owner_identity = scp
-            .identity_create("in_memory".to_owned(), None)
-            .await
-            .expect("owner identity creation must succeed");
+            let owner_identity = scp
+                .identity_create("in_memory".to_owned(), None)
+                .await
+                .expect("owner identity creation must succeed");
 
-        // A second hosted identity. `identity_create` registers its custody, so
-        // axis (a) of the binding passes for `stranger`.
-        let stranger_identity = scp
-            .identity_create("in_memory".to_owned(), None)
-            .await
-            .expect("stranger identity creation must succeed");
-        let stranger_did = stranger_identity.did.clone();
+            // A second hosted identity. `identity_create` registers its custody, so
+            // axis (a) of the binding passes for `stranger`.
+            let stranger_identity = scp
+                .identity_create("in_memory".to_owned(), None)
+                .await
+                .expect("stranger identity creation must succeed");
+            let stranger_did = stranger_identity.did.clone();
 
-        // Caller context A is owned by `owner`; `stranger` is NOT a member.
-        let handle_a = scp
-            .context_create(
-                Arc::clone(&owner_identity),
-                saga_context_params(&["governance:propose", "tools:invoke"]),
+            // Caller context A is owned by `owner`; `stranger` is NOT a member.
+            let handle_a = scp
+                .context_create(
+                    Arc::clone(&owner_identity),
+                    saga_context_params(&["governance:propose", "tools:invoke"]),
+                )
+                .await
+                .expect("caller context A must be created");
+
+            let now_ms = u64::try_from(
+                std::time::SystemTime::now()
+                    .duration_since(std::time::UNIX_EPOCH)
+                    .unwrap()
+                    .as_millis(),
             )
-            .await
-            .expect("caller context A must be created");
+            .unwrap();
 
-        let now_ms = u64::try_from(
-            std::time::SystemTime::now()
-                .duration_since(std::time::UNIX_EPOCH)
-                .unwrap()
-                .as_millis(),
-        )
-        .unwrap();
+            // Reuse `handle_a` as the target handle: axis (b) on the caller context
+            // rejects before any target-side resolution.
+            let err = scp
+                .tool_invoke_cross_context_saga(
+                    Arc::clone(&handle_a),
+                    Arc::clone(&handle_a),
+                    stranger_did,
+                    "tool-xctx_saga_non_member".to_owned(),
+                    serde_json::json!({"a": "x", "b": "y"}).to_string(),
+                    saga_nonce_hex(),
+                    now_ms,
+                    1,
+                    None,
+                )
+                .await
+                .expect_err("a hosted non-member caller must be rejected at axis (b)");
 
-        // Reuse `handle_a` as the target handle: axis (b) on the caller context
-        // rejects before any target-side resolution.
-        let err = scp
-            .tool_invoke_cross_context_saga(
-                Arc::clone(&handle_a),
-                Arc::clone(&handle_a),
-                stranger_did,
-                "tool-xctx_saga_non_member".to_owned(),
-                serde_json::json!({"a": "x", "b": "y"}).to_string(),
-                saga_nonce_hex(),
-                now_ms,
-                1,
-                None,
-            )
-            .await
-            .expect_err("a hosted non-member caller must be rejected at axis (b)");
-
-        match err {
-            ScpError::SagaAborted { code, msg, .. } => {
-                assert_eq!(
-                    code,
-                    codes::SAGA_13050,
-                    "a hosted non-member caller (axis b) must abort with SCP-SAGA-13050"
-                );
-                // The supervisor's gate-1 ALSO emits SCP-SAGA-13050 for a
-                // non-member caller, so pin the bridge-unique axis-(b) message
-                // substring (absent from the supervisor gate-1 message) to prove
-                // the BRIDGE binding rejected — not the producer's own gate.
-                assert!(
-                    msg.contains("is hosted by this bridge but is not a member of"),
-                    "must be rejected by the bridge axis-(b) binding, not the producer's gate; \
+            match err {
+                ScpError::SagaAborted { code, msg, .. } => {
+                    assert_eq!(
+                        code,
+                        codes::SAGA_13050,
+                        "a hosted non-member caller (axis b) must abort with SCP-SAGA-13050"
+                    );
+                    // The supervisor's gate-1 ALSO emits SCP-SAGA-13050 for a
+                    // non-member caller, so pin the bridge-unique axis-(b) message
+                    // substring (absent from the supervisor gate-1 message) to prove
+                    // the BRIDGE binding rejected — not the producer's own gate.
+                    assert!(
+                        msg.contains("is hosted by this bridge but is not a member of"),
+                        "must be rejected by the bridge axis-(b) binding, not the producer's gate; \
                      got: {msg}"
-                );
+                    );
+                }
+                other => panic!("expected SagaAborted (axis b), got {other:?}"),
             }
-            other => panic!("expected SagaAborted (axis b), got {other:?}"),
         }
-    }
 
-    /// Caller-principal binding, axis (a) as the SOLE guard — a MEMBER-but-
-    /// UNHOSTED caller is STILL rejected by axis (a).
-    ///
-    /// This is the property `xctx_saga_unhosted_caller_did_is_rejected_axis_a`
-    /// cannot prove: that test's caller is BOTH unhosted AND a non-member, so
-    /// axis (b) (and the producer's gate 1) would reject it even if axis (a) were
-    /// deleted. Here the caller is injected as a genuine member of the caller
-    /// context via `Supervisor::test_insert_member` (the actor-state membership
-    /// injection that bypasses the MLS Welcome a non-hosted DID could never
-    /// complete), so `supervisor.is_member` returns true and axis (b) PASSES the
-    /// caller. The ONLY thing that can reject it is axis (a): the caller DID was
-    /// never `identity_create`'d, so it is absent from this instance's identity
-    /// custody registry. The test therefore fails closed iff the bridge's
-    /// `identity_custody_registry.contains_key` axis (a) check is removed, and is
-    /// INDEPENDENT of axis (b) by construction.
-    ///
-    /// Gated on `allow_in_memory_custody`: that feature is what enables
-    /// `scp-core/testing` (hence `scp-runtime/testing`), which provides
-    /// `Supervisor::test_insert_member`. Mirrors the NAPI sibling
-    /// `xctx_saga_member_but_unhosted_caller_rejected_by_hosted_axis`.
-    #[cfg(feature = "allow_in_memory_custody")]
-    #[tokio::test]
-    async fn xctx_saga_member_but_unhosted_caller_is_rejected_axis_a() {
-        let scp = scp_test();
-        let bi = Arc::clone(&scp.inner);
+        /// Caller-principal binding, axis (a) as the SOLE guard — a MEMBER-but-
+        /// UNHOSTED caller is STILL rejected by axis (a).
+        ///
+        /// This is the property `xctx_saga_unhosted_caller_did_is_rejected_axis_a`
+        /// cannot prove: that test's caller is BOTH unhosted AND a non-member, so
+        /// axis (b) (and the producer's gate 1) would reject it even if axis (a) were
+        /// deleted. Here the caller is injected as a genuine member of the caller
+        /// context via `Supervisor::test_insert_member` (the actor-state membership
+        /// injection that bypasses the MLS Welcome a non-hosted DID could never
+        /// complete), so `supervisor.is_member` returns true and axis (b) PASSES the
+        /// caller. The ONLY thing that can reject it is axis (a): the caller DID was
+        /// never `identity_create`'d, so it is absent from this instance's identity
+        /// custody registry. The test therefore fails closed iff the bridge's
+        /// `identity_custody_registry.contains_key` axis (a) check is removed, and is
+        /// INDEPENDENT of axis (b) by construction.
+        ///
+        /// Gated on `allow_in_memory_custody`: that feature is what enables
+        /// `scp-core/testing` (hence `scp-runtime/testing`), which provides
+        /// `Supervisor::test_insert_member`. Mirrors the NAPI sibling
+        /// `xctx_saga_member_but_unhosted_caller_rejected_by_hosted_axis`.
+        #[tokio::test]
+        async fn xctx_saga_member_but_unhosted_caller_is_rejected_axis_a() {
+            let scp = scp_test();
+            let bi = Arc::clone(&scp.inner);
 
-        let _resolver_dht = install_seedable_resolver(&bi);
+            let _resolver_dht = install_seedable_resolver(&bi);
 
-        // `owner` is a hosted identity used only to create the caller context.
-        let owner_identity = scp
-            .identity_create("in_memory".to_owned(), None)
-            .await
-            .expect("owner identity creation must succeed");
+            // `owner` is a hosted identity used only to create the caller context.
+            let owner_identity = scp
+                .identity_create("in_memory".to_owned(), None)
+                .await
+                .expect("owner identity creation must succeed");
 
-        // A real, registered caller context owned by `owner`.
-        let handle_a = scp
-            .context_create(
-                Arc::clone(&owner_identity),
-                saga_context_params(&["governance:propose", "tools:invoke"]),
-            )
-            .await
-            .expect("caller context A must be created");
-        let ctx_a = handle_a.context_id.clone();
+            // A real, registered caller context owned by `owner`.
+            let handle_a = scp
+                .context_create(
+                    Arc::clone(&owner_identity),
+                    saga_context_params(&["governance:propose", "tools:invoke"]),
+                )
+                .await
+                .expect("caller context A must be created");
+            let ctx_a = handle_a.context_id.clone();
 
-        // The caller is a syntactically-valid DID that is NEVER `identity_create`'d
-        // (so the identity custody registry does NOT host it — axis (a) must
-        // reject), yet is injected as a genuine member of the caller context via
-        // the actor-state membership path (so `supervisor.is_member` returns true
-        // and axis (b) passes). `test_insert_member` records the member into role
-        // state exactly as an executed `AddMember` would, without the MLS Welcome
-        // a non-hosted DID could never complete.
-        let member_but_unhosted_caller = "did:dht:zzzzmemberbutunhostedcaller00001".to_owned();
-        let supervisor = Arc::clone(
-            bi.context_manager_or_error()
-                .expect("supervisor must be initialized"),
-        );
-        supervisor
-            .test_insert_member(
-                &ctx_a,
-                scp_identity::DID(member_but_unhosted_caller.clone()),
-                "member",
-            )
-            .await
-            .expect("test_insert_member should record the caller into caller_ctx membership");
-
-        // Precondition: the supervisor MUST see the caller as a member of the
-        // caller context (axis (b) passes), while the identity custody registry
-        // does NOT host it (axis (a) is the sole remaining guard).
-        assert!(
+            // The caller is a syntactically-valid DID that is NEVER `identity_create`'d
+            // (so the identity custody registry does NOT host it — axis (a) must
+            // reject), yet is injected as a genuine member of the caller context via
+            // the actor-state membership path (so `supervisor.is_member` returns true
+            // and axis (b) passes). `test_insert_member` records the member into role
+            // state exactly as an executed `AddMember` would, without the MLS Welcome
+            // a non-hosted DID could never complete.
+            let member_but_unhosted_caller = "did:dht:zzzzmemberbutunhostedcaller00001".to_owned();
+            let supervisor = Arc::clone(
+                bi.context_manager_or_error()
+                    .expect("supervisor must be initialized"),
+            );
             supervisor
-                .is_member(&ctx_a, &member_but_unhosted_caller)
-                .await,
-            "precondition: caller must be a genuine member of caller_ctx so axis (b) passes"
-        );
-        assert!(
-            !identity_custody_registry(&bi).contains_key(&member_but_unhosted_caller),
-            "precondition: caller must NOT be hosted so axis (a) is the sole guard"
-        );
+                .test_insert_member(
+                    &ctx_a,
+                    scp_identity::DID(member_but_unhosted_caller.clone()),
+                    "member",
+                )
+                .await
+                .expect("test_insert_member should record the caller into caller_ctx membership");
 
-        let now_ms = u64::try_from(
-            std::time::SystemTime::now()
-                .duration_since(std::time::UNIX_EPOCH)
-                .unwrap()
-                .as_millis(),
-        )
-        .unwrap();
+            // Precondition: the supervisor MUST see the caller as a member of the
+            // caller context (axis (b) passes), while the identity custody registry
+            // does NOT host it (axis (a) is the sole remaining guard).
+            assert!(
+                supervisor
+                    .is_member(&ctx_a, &member_but_unhosted_caller)
+                    .await,
+                "precondition: caller must be a genuine member of caller_ctx so axis (b) passes"
+            );
+            assert!(
+                !identity_custody_registry(&bi).contains_key(&member_but_unhosted_caller),
+                "precondition: caller must NOT be hosted so axis (a) is the sole guard"
+            );
 
-        // Reuse `handle_a` as the target handle too: the caller axis (a) check
-        // rejects before any target-side resolution, so the target handle is
-        // irrelevant to which axis trips — both handles are real and pass
-        // affinity.
-        let err = scp
-            .tool_invoke_cross_context_saga(
-                Arc::clone(&handle_a),
-                Arc::clone(&handle_a),
-                member_but_unhosted_caller, // member of caller_ctx, but NOT hosted
-                "tool-xctx_saga_member_unhosted".to_owned(),
-                serde_json::json!({"a": "x", "b": "y"}).to_string(),
-                saga_nonce_hex(),
-                now_ms,
-                1,
-                None,
+            let now_ms = u64::try_from(
+                std::time::SystemTime::now()
+                    .duration_since(std::time::UNIX_EPOCH)
+                    .unwrap()
+                    .as_millis(),
             )
-            .await
-            .expect_err("a member-but-unhosted caller must be rejected at axis (a)");
+            .unwrap();
 
-        match err {
-            ScpError::SagaAborted { code, msg, .. } => {
-                assert_eq!(
-                    code,
-                    codes::SAGA_13050,
-                    "a member-but-unhosted caller (axis a) must abort with SCP-SAGA-13050"
-                );
-                // BRIDGE-UNIQUE axis-(a) substring. Because the caller IS a
-                // member, the membership axis (b) and the producer's gate 1 would
-                // BOTH pass — so the axis-(b) message ("is hosted by this bridge
-                // but is not a member of") can never appear here. The ONLY
-                // rejection that fits is axis (a). Asserting its exact substring
-                // makes this test fail closed iff
-                // `enforce_caller_principal_binding`'s
-                // `identity_custody_registry.contains_key` check is removed.
-                assert!(
-                    msg.contains("is not an identity hosted by this bridge instance"),
-                    "must be rejected by the bridge axis-(a) custody check (the sole guard for a \
+            // Reuse `handle_a` as the target handle too: the caller axis (a) check
+            // rejects before any target-side resolution, so the target handle is
+            // irrelevant to which axis trips — both handles are real and pass
+            // affinity.
+            let err = scp
+                .tool_invoke_cross_context_saga(
+                    Arc::clone(&handle_a),
+                    Arc::clone(&handle_a),
+                    member_but_unhosted_caller, // member of caller_ctx, but NOT hosted
+                    "tool-xctx_saga_member_unhosted".to_owned(),
+                    serde_json::json!({"a": "x", "b": "y"}).to_string(),
+                    saga_nonce_hex(),
+                    now_ms,
+                    1,
+                    None,
+                )
+                .await
+                .expect_err("a member-but-unhosted caller must be rejected at axis (a)");
+
+            match err {
+                ScpError::SagaAborted { code, msg, .. } => {
+                    assert_eq!(
+                        code,
+                        codes::SAGA_13050,
+                        "a member-but-unhosted caller (axis a) must abort with SCP-SAGA-13050"
+                    );
+                    // BRIDGE-UNIQUE axis-(a) substring. Because the caller IS a
+                    // member, the membership axis (b) and the producer's gate 1 would
+                    // BOTH pass — so the axis-(b) message ("is hosted by this bridge
+                    // but is not a member of") can never appear here. The ONLY
+                    // rejection that fits is axis (a). Asserting its exact substring
+                    // makes this test fail closed iff
+                    // `enforce_caller_principal_binding`'s
+                    // `identity_custody_registry.contains_key` check is removed.
+                    assert!(
+                        msg.contains("is not an identity hosted by this bridge instance"),
+                        "must be rejected by the bridge axis-(a) custody check (the sole guard for a \
                      member caller), not the producer; got: {msg}"
-                );
+                    );
+                }
+                other => panic!("expected SagaAborted (axis a), got {other:?}"),
             }
-            other => panic!("expected SagaAborted (axis a), got {other:?}"),
         }
     }
 }

--- a/crates/scp-testing/tests/integration/ffi_conformance.rs
+++ b/crates/scp-testing/tests/integration/ffi_conformance.rs
@@ -1381,7 +1381,12 @@ fn discovery_and_provenance_coverage() {
 // `evaluate_ucan`, returns a structured CapabilityValidation; never records the
 // nonce) is exposed across all three bridges. Pure coverage
 // expansion, not a swap for the removed `economy_adjust_relay_price`.
-const MIN_PARITY_OPERATIONS: usize = 105;
+//
+// Subsequently RAISED 105 -> 106 by the `tool_invoke_cross_context_saga` op:
+// the §6.2.4 atomic cross-context tool-invocation saga (ADR-049 §3a), exposed
+// across all three native bridges (PyO3 / UniFFI / NAPI). Pure coverage
+// expansion, not a swap for the removed `economy_adjust_relay_price`.
+const MIN_PARITY_OPERATIONS: usize = 106;
 
 // ---------------------------------------------------------------------------
 // Ratchet meta-tests — detect weakening of enforcement

--- a/crates/scp-testing/tests/integration/pipeline_wiring.rs
+++ b/crates/scp-testing/tests/integration/pipeline_wiring.rs
@@ -164,7 +164,13 @@ const NAPI_UCAN_SRC: &str = include_str!("../../../../crates/scp-ffi/napi/src/uc
 // C2 economy fail-closed gate, ucan_evaluate routing) lost their subject and
 // were removed. This is a deleted-target cleanup, not a weakening of the
 // remaining native/PyO3/NAPI/UniFFI assertions.
-const MIN_ACTIVE_PIPELINE_ASSERTIONS: usize = 41;
+// Raised 41 -> 44 when the §6.2.4 cross-context tool-invocation saga export
+// (ADR-049 §3a) was wired through all three native bridges: one per-bridge
+// structural assertion (PyO3 / NAPI / UniFFI) pins each export body to the
+// caller-principal binding, the ADR-056 `context_id_to_bytes` keying chokepoint,
+// AND the `start_cross_context_tool_invocation_saga` producer. Pure coverage
+// expansion locking the new export wiring into the ratchet floor.
+const MIN_ACTIVE_PIPELINE_ASSERTIONS: usize = 44;
 
 // ---------------------------------------------------------------------------
 // Function body extraction — brace-matching parser
@@ -2279,6 +2285,169 @@ fn uniffi_ucan_evaluate_routes_to_core_evaluate_ucan() {
         fn_body_contains(UNIFFI_BRIDGE_SRC, "ucan_evaluate", "evaluate_ucan("),
         "UniFFI ucan_evaluate must call the shared core evaluate_ucan pipeline, \
          not re-implement capability evaluation locally"
+    );
+}
+
+// ===========================================================================
+// §6.2.4 cross-context tool-invocation saga — FFI export wiring (ADR-049 §3a)
+// ===========================================================================
+//
+// Each native bridge's `tool_invoke_cross_context_saga` export MUST, before the
+// saga can run:
+//   (a) bind the caller principal — `enforce_caller_principal_binding`, which
+//       authenticates the hosted caller via `identity_registry_contains` and
+//       `is_member` (ADR-049 §3a:94 normative: caller_did/caller_context bound
+//       to the authenticated FFI principal, NOT an envelope-asserted value);
+//   (b) convert the caller/target id STRING → [u8; 32] through the canonical
+//       ADR-056 keying chokepoint `context_id_to_bytes` (a raw re-hash would
+//       double-hash a 64-hex id and key a non-existent actor slot); and
+//   (c) dispatch to the merged producer
+//       `start_cross_context_tool_invocation_saga`.
+//
+// These pin the bridge bodies so a refactor cannot silently sever any of the
+// three from the export — e.g. drop the principal binding (replay/forgery),
+// re-hash the id (spurious ContextNotRegistered), or bypass the saga producer.
+// The principal-binding helper that wraps `identity_registry_contains` +
+// `is_member` is itself pinned (the export → helper edge), so the named tokens
+// cannot be satisfied by an unrelated sibling's substring.
+
+#[test]
+fn pyo3_saga_export_wires_binding_chokepoint_and_producer() {
+    assert!(
+        fn_body_contains(
+            PYO3_TOOLS_SRC,
+            "tool_invoke_cross_context_saga_impl",
+            "enforce_caller_principal_binding(",
+        ),
+        "PyO3 cross-context saga export must bind the caller principal via \
+         enforce_caller_principal_binding before invoking the saga (ADR-049 §3a)"
+    );
+    assert!(
+        fn_body_contains(
+            PYO3_TOOLS_SRC,
+            "tool_invoke_cross_context_saga_impl",
+            "context_id_to_bytes(",
+        ),
+        "PyO3 cross-context saga export must convert ids via the ADR-056 \
+         context_id_to_bytes keying chokepoint, not re-hash them"
+    );
+    assert!(
+        fn_body_contains(
+            PYO3_TOOLS_SRC,
+            "tool_invoke_cross_context_saga_impl",
+            "start_cross_context_tool_invocation_saga(",
+        ),
+        "PyO3 cross-context saga export must dispatch to the producer \
+         start_cross_context_tool_invocation_saga"
+    );
+    // The principal-binding helper itself must authenticate the hosted caller
+    // (registry membership + context membership), so the (a) edge is meaningful.
+    assert!(
+        fn_body_contains(
+            PYO3_TOOLS_SRC,
+            "enforce_caller_principal_binding",
+            "identity_registry_contains",
+        ) && fn_body_contains(
+            PYO3_TOOLS_SRC,
+            "enforce_caller_principal_binding",
+            "is_member",
+        ),
+        "PyO3 enforce_caller_principal_binding must check identity_registry_contains \
+         AND is_member (authenticated-principal binding, ADR-049 §3a:94)"
+    );
+}
+
+#[test]
+fn napi_saga_export_wires_binding_chokepoint_and_producer() {
+    assert!(
+        fn_body_contains(
+            NAPI_TOOLS_SRC,
+            "tool_invoke_cross_context_saga_on",
+            "enforce_caller_principal_binding(",
+        ),
+        "NAPI cross-context saga export must bind the caller principal via \
+         enforce_caller_principal_binding before invoking the saga (ADR-049 §3a)"
+    );
+    assert!(
+        fn_body_contains(
+            NAPI_TOOLS_SRC,
+            "tool_invoke_cross_context_saga_on",
+            "context_id_to_bytes(",
+        ),
+        "NAPI cross-context saga export must convert ids via the ADR-056 \
+         context_id_to_bytes keying chokepoint, not re-hash them"
+    );
+    assert!(
+        fn_body_contains(
+            NAPI_TOOLS_SRC,
+            "tool_invoke_cross_context_saga_on",
+            "start_cross_context_tool_invocation_saga(",
+        ),
+        "NAPI cross-context saga export must dispatch to the producer \
+         start_cross_context_tool_invocation_saga"
+    );
+    assert!(
+        fn_body_contains(
+            NAPI_TOOLS_SRC,
+            "enforce_caller_principal_binding",
+            "identity_registry_contains",
+        ) && fn_body_contains(
+            NAPI_TOOLS_SRC,
+            "enforce_caller_principal_binding",
+            "is_member",
+        ),
+        "NAPI enforce_caller_principal_binding must check identity_registry_contains \
+         AND is_member (authenticated-principal binding, ADR-049 §3a:94)"
+    );
+}
+
+#[test]
+fn uniffi_saga_export_wires_binding_chokepoint_and_producer() {
+    assert!(
+        fn_body_contains(
+            UNIFFI_BRIDGE_SRC,
+            "tool_invoke_cross_context_saga",
+            "enforce_caller_principal_binding(",
+        ),
+        "UniFFI cross-context saga export must bind the caller principal via \
+         enforce_caller_principal_binding before invoking the saga (ADR-049 §3a)"
+    );
+    assert!(
+        fn_body_contains(
+            UNIFFI_BRIDGE_SRC,
+            "tool_invoke_cross_context_saga",
+            "context_id_to_bytes(",
+        ),
+        "UniFFI cross-context saga export must convert ids via the ADR-056 \
+         context_id_to_bytes keying chokepoint, not re-hash them"
+    );
+    assert!(
+        fn_body_contains(
+            UNIFFI_BRIDGE_SRC,
+            "tool_invoke_cross_context_saga",
+            "start_cross_context_tool_invocation_saga(",
+        ),
+        "UniFFI cross-context saga export must dispatch to the producer \
+         start_cross_context_tool_invocation_saga"
+    );
+    // UniFFI authenticates the hosted caller against the per-instance custody
+    // registry (`identity_custody_registry(bi).contains_key`) rather than the
+    // PyO3/NAPI `identity_registry_contains` helper — a per-SDK idiom difference,
+    // same authenticated-principal property. Both legs (registry presence +
+    // context membership via `is_member`) must be present.
+    assert!(
+        fn_body_contains(
+            UNIFFI_BRIDGE_SRC,
+            "enforce_caller_principal_binding",
+            "identity_custody_registry",
+        ) && fn_body_contains(
+            UNIFFI_BRIDGE_SRC,
+            "enforce_caller_principal_binding",
+            "is_member",
+        ),
+        "UniFFI enforce_caller_principal_binding must check the per-instance \
+         identity_custody_registry AND is_member (authenticated-principal \
+         binding, ADR-049 §3a:94)"
     );
 }
 

--- a/scripts/bridge-aliases.json
+++ b/scripts/bridge-aliases.json
@@ -381,6 +381,19 @@
       ]
     },
     {
+      "canonical": "tool_invoke_cross_context_saga",
+      "category": "tools",
+      "pyo3": [
+        "tool_invoke_cross_context_saga"
+      ],
+      "uniffi": [
+        "tool_invoke_cross_context_saga"
+      ],
+      "napi": [
+        "tool_invoke_cross_context_saga"
+      ]
+    },
+    {
       "canonical": "tool_session_create",
       "category": "tools",
       "pyo3": [


### PR DESCRIPTION
## Scope

Native FFI exports of the **§6.2.4 cross-context tool-invocation saga** (`tool_invoke_cross_context_saga`) across the three native bridges — PyO3, NAPI, UniFFI — dispatching to the pre-existing runtime producer `Supervisor::start_cross_context_tool_invocation_saga` (ADR-049 §3a FFI Saga Surface).

WASM is N/A (no Supervisor; in-browser backend removed by #1942/#1945, ADR-034/ADR-055). SDK wrappers (Python/TS/Swift/Kotlin) are deferred to **#1939 (PR-6c)** — the capability-matrix cells are `false` with per-SDK exemptions citing it.

## What's included

- **3 bridge exports** → the producer, no FSM reimplementation. Block-until-terminal; `SagaId` supervisor-minted, never caller input.
- **Caller-principal binding** (`enforce_caller_principal_binding`, before the producer on every bridge): axis-a = `caller_did` hosted on this bridge instance (channel-authenticated, the load-bearing addition over the supervisor's membership gate); axis-b = `is_member`. Mismatch ⇒ typed `SagaAborted`/`SCP-SAGA-13050`. The producer independently re-gates (gate-1 membership, gate-2 established-interface), authorize-before-reserve.
- **ADR-056 chokepoint** `context_id_to_bytes` for caller/target id → wire bytes (decode-64-hex-else-SHA256), avoiding the double-hash actor-miss.
- **Shared, single-home error classification** `scp_ffi_common::saga_errors::decompose_saga_error` → typed `SagaAborted{retry_after_ms}`/`SagaNeedsRepair{saga_id}`/`SagaBusy{contended_context}`. Read structurally off the `SagaError` variant (never message-parsed); `retry_after_ms` stays `Option<u64>`, never coerced to `0`. New codes `SCP-SAGA-13050/13065/13066` in the registered band.
- **Per-bridge nonce decode** fail-closed (non-hex + exactly-16-bytes → `SCP-VALID-7001`).
- **Enforcement (additive only):** 3 new `pipeline_wiring` body assertions (binding → chokepoint → producer per bridge), `MIN_ACTIVE_PIPELINE_ASSERTIONS` 41→44, `MIN_PARITY_OPERATIONS` 105→106, `bridge-aliases.json` + `sdk-capability-matrix.json` entries.
- **Tests:** per-bridge committed (real `Committed`, decoded handler output), axis-a/axis-b binding (mutation-resistant via bridge-unique substrings), member-but-unhosted axis-a isolation, nonce fail-closed, plus TS addon-backed contract tests. Saga test clusters gated in a single `#[cfg(feature = "allow_in_memory_custody")] mod xctx_saga_tests` (closed-by-construction no-feature build hygiene).

## Review

Converged to strict double-zero (two consecutive fully-clean full-roster reviews: security, cryptographer, black-hat, bug-catcher, alignment, api-design, simplifier, completionist, test-quality — black-hat/test-quality/bug-catcher in isolated worktrees). Production saga path verified sound throughout; black-hat found no production-reachable break.

## Follow-ups (non-blocking, filed)

- #1946 — test-hardening (PyO3 non-hex nonce, pure axis-a isolation e2e, `decode_asserted_nonce`→common dedup)
- #1947 — pre-existing no-feature `--all-targets` lane (lifecycle.rs `required-features`; stale WASM comment in `error_codes.rs`)
- #1948 — harden `validate_did` to W3C did-core idchar (defense-in-depth; #116 not vulnerable)
- #1949 — core `SagaOutput` receipt-on-commit clarity

🤖 Generated with [Claude Code](https://claude.com/claude-code)