### PR TITLE
feat(python): SDK wrapper for tool_invoke_cross_context_saga (PR-6c slice 1/4)

### DIFF
--- a/.docs/standards/sdk-capability-matrix.json
+++ b/.docs/standards/sdk-capability-matrix.json
@@ -584,13 +584,12 @@
         },
         {
           "name": "invoke_cross_context_saga",
-          "python": false,
+          "python": true,
           "typescript": false,
           "kotlin": false,
           "swift": false,
-          "notes": "The §6.2.4 atomic cross-context tool-invocation saga (ADR-049 §3a). Exported by all three native bridges — PyO3 tool_invoke_cross_context_saga, UniFFI tool_invoke_cross_context_saga, NAPI toolInvokeCrossContextSaga (js_name); see scripts/bridge-aliases.json (category tools). Each export binds the caller principal to the authenticated FFI identity (enforce_caller_principal_binding) before dispatching to Supervisor::start_cross_context_tool_invocation_saga, pinned by the pyo3/napi/uniffi saga-export assertions in pipeline_wiring.rs. The public per-SDK wrapper methods are tracked by #1939 (the PR-6c SDK-wrapper slice).",
+          "notes": "The §6.2.4 atomic cross-context tool-invocation saga (ADR-049 §3a). Exported by all three native bridges — PyO3 tool_invoke_cross_context_saga, UniFFI tool_invoke_cross_context_saga, NAPI toolInvokeCrossContextSaga (js_name); see scripts/bridge-aliases.json (category tools). Each export binds the caller principal to the authenticated FFI identity (enforce_caller_principal_binding) before dispatching to Supervisor::start_cross_context_tool_invocation_saga, pinned by the pyo3/napi/uniffi saga-export assertions in pipeline_wiring.rs. The Python SDK wrapper SCP.tool_invoke_cross_context_saga is live (PR-6c slice PY); the remaining per-SDK wrapper methods are tracked by #1939 (the PR-6c SDK-wrapper slice).",
           "exemptions": {
-            "python": "Bridge export exists (PyO3 tool_invoke_cross_context_saga); the named public SDK wrapper on the tools surface is tracked by #1939 (PR-6c SDK-wrapper slice, §6.2.4 / ADR-049 §3a).",
             "typescript": "Bridge export exists (NAPI toolInvokeCrossContextSaga); the named public SDK wrapper on the tools surface is tracked by #1939 (PR-6c SDK-wrapper slice, §6.2.4 / ADR-049 §3a).",
             "kotlin": "UniFFI bridge exports tool_invoke_cross_context_saga; the named public Kotlin SDK wrapper is tracked by #1939 (PR-6c SDK-wrapper slice, §6.2.4 / ADR-049 §3a).",
             "swift": "UniFFI bridge exports tool_invoke_cross_context_saga; the named public Swift SDK wrapper is tracked by #1939 (PR-6c SDK-wrapper slice, §6.2.4 / ADR-049 §3a)."

--- a/bindings/python/scp_sdk/__init__.py
+++ b/bindings/python/scp_sdk/__init__.py
@@ -76,6 +76,9 @@ from scp_sdk.errors import (
     ContextError,
     CryptoError,
     IdentityError,
+    SagaAbortedError,
+    SagaBusyError,
+    SagaNeedsRepairError,
     ScpError,
     ToolError,
     TransportError,
@@ -136,6 +139,7 @@ from scp_sdk.scp import (
 from scp_sdk.server import Node, Relay
 from scp_sdk.sync import classify_offline, get_policy, run_sync
 from scp_sdk.tools import (
+    SagaResult,
     TestVector,
     ToolCost,
     ToolDefinition,
@@ -227,6 +231,10 @@ __all__ = [
     "Relay",
     "RequireParticipation",
     "RevocationStatus",
+    "SagaAbortedError",
+    "SagaBusyError",
+    "SagaNeedsRepairError",
+    "SagaResult",
     "ScpError",
     "ScpIdAuthentication",
     "ScpIdChallenge",

--- a/bindings/python/scp_sdk/_scp_core.pyi
+++ b/bindings/python/scp_sdk/_scp_core.pyi
@@ -74,9 +74,56 @@ class ValidationError(ScpError):
 
     ...
 
+# Cross-context tool-invocation saga (§6.2.4 / ADR-049 §3a) terminal errors.
+# Each carries the structured terminal datum as a positional ``args`` entry
+# (``args = (message, code, datum)``), read structurally — never re-parsed
+# from the message text.
+
+class SagaAbortedError(ScpError):
+    """A §6.2.4 saga aborted at a Prepare phase.
+
+    ``args = (message, code, retry_after_ms)``: ``retry_after_ms`` is an
+    ``int`` of milliseconds or ``None`` (never ``0``).
+    """
+
+    ...
+
+class SagaNeedsRepairError(ScpError):
+    """A §6.2.4 saga exhausted its Commit retries and may have diverged.
+
+    ``args = (message, code, saga_id)``: ``saga_id`` is the durable
+    operator-repair handle.
+    """
+
+    ...
+
+class SagaBusyError(ScpError):
+    """A §6.2.4 saga's participant context set overlapped an in-flight saga.
+
+    ``args = (message, code, contended_context)``: ``contended_context`` is
+    the shared context id.
+    """
+
+    ...
+
 # ---------------------------------------------------------------------------
 # Bridge value types (crates/scp-ffi/src/{identity,context,ucan,...}.rs)
 # ---------------------------------------------------------------------------
+
+class SagaResult:
+    """The committed terminal of a §6.2.4 cross-context tool-invocation saga.
+
+    Returned by :meth:`SCP.tool_invoke_cross_context_saga` on a ``Committed``
+    terminal; every non-committed terminal raises a typed saga exception.
+    """
+
+    @property
+    def saga_id(self) -> str: ...
+    @property
+    def receipt(self) -> bytes | None: ...
+    @property
+    def output(self) -> bytes | None: ...
+    def __repr__(self) -> str: ...
 
 class PyIdentity:
     """An SCP identity handle.
@@ -632,6 +679,18 @@ class SCP:
         chain_depth: Any,
         proof_tokens: Any = ...,
     ) -> Any: ...
+    def tool_invoke_cross_context_saga(
+        self,
+        caller_context_id: Any,
+        target_context_id: Any,
+        caller_did: Any,
+        tool_registration_id: Any,
+        input: Any,
+        asserted_nonce_hex: Any,
+        timestamp_ms: Any,
+        chain_depth: Any,
+        ucan_proof_id: Any = ...,
+    ) -> SagaResult: ...
     def tool_register(self, context_id: Any, registration: Any) -> Any: ...
     def tool_session_close(self, context_id: Any, session_id: Any) -> Any: ...
     def tool_session_create(

--- a/bindings/python/scp_sdk/errors.py
+++ b/bindings/python/scp_sdk/errors.py
@@ -124,7 +124,7 @@ class SagaAbortedError(ToolError):
             "retry immediately" and re-trip the same hard limit.
     """
 
-    _default_code: str = "SCP-SAGA-13050"
+    _default_code: str = "SCP-SAGA-13067"
 
     def __init__(
         self,

--- a/bindings/python/scp_sdk/errors.py
+++ b/bindings/python/scp_sdk/errors.py
@@ -101,6 +101,120 @@ class ValidationError(ScpError):
 
 
 # ---------------------------------------------------------------------------
+# Cross-context tool-invocation saga (§6.2.4 / ADR-049 §3a) terminal errors.
+# ---------------------------------------------------------------------------
+#
+# These three subclasses surface the typed terminal space of the §6.2.4
+# cross-context tool-invocation saga. Each carries the structured terminal
+# datum the contract makes load-bearing as a NAMED attribute, read
+# structurally from the bridge exception's ``args`` (never re-parsed from
+# the message text). The bridge (``_scp_core``) raises exception classes
+# that share these names; :func:`_saga_terminal_from_bridge` translates a
+# bridge terminal into the matching SDK class below, preserving the datum.
+
+
+class SagaAbortedError(ToolError):
+    """A §6.2.4 saga aborted at a Prepare phase (authorization, freshness,
+    rate limit, or co-residency).
+
+    Attributes:
+        retry_after_ms: Rate-limit back-off hint in milliseconds when the
+            tripped limiter can compute one, or ``None`` when no precise
+            back-off instant exists. NEVER ``0`` — ``0`` would read as
+            "retry immediately" and re-trip the same hard limit.
+    """
+
+    _default_code: str = "SCP-SAGA-13050"
+
+    def __init__(
+        self,
+        message: str,
+        code: str | None = None,
+        retry_after_ms: int | None = None,
+    ) -> None:
+        super().__init__(message, code)
+        #: Rate-limit back-off hint in ms, or ``None`` (never ``0``).
+        self.retry_after_ms: int | None = retry_after_ms
+
+
+class SagaNeedsRepairError(ToolError):
+    """A §6.2.4 saga exhausted its Commit retries and may have diverged
+    (a partial commit requiring operator repair).
+
+    Attributes:
+        saga_id: The durable operator-repair handle for the diverged saga.
+    """
+
+    _default_code: str = "SCP-SAGA-13065"
+
+    def __init__(
+        self,
+        message: str,
+        code: str | None = None,
+        saga_id: str = "",
+    ) -> None:
+        super().__init__(message, code)
+        #: Durable operator-repair handle for the diverged saga.
+        self.saga_id: str = saga_id
+
+
+class SagaBusyError(ToolError):
+    """A §6.2.4 saga's participant context set overlapped an in-flight saga
+    (per-participant-context-set gating, §5.15.4).
+
+    Attributes:
+        contended_context: The shared context id that overlapped an
+            in-flight saga.
+    """
+
+    _default_code: str = "SCP-SAGA-13066"
+
+    def __init__(
+        self,
+        message: str,
+        code: str | None = None,
+        contended_context: str = "",
+    ) -> None:
+        super().__init__(message, code)
+        #: The shared context id that overlapped an in-flight saga.
+        self.contended_context: str = contended_context
+
+
+def _saga_terminal_from_bridge(exc: BaseException) -> ScpError | None:
+    """Translate a bridge saga terminal exception into its SDK class.
+
+    Dispatches on the bridge exception's class *name* (so a mocked bridge
+    works without the native extension) and reads the structured terminal
+    datum positionally from ``exc.args`` — ``args[0]`` is the message,
+    ``args[1]`` the ``SCP-SAGA-13xxx`` code, and ``args[2]`` the typed
+    datum (``retry_after_ms`` / ``saga_id`` / ``contended_context``). The
+    datum is read STRUCTURALLY, never parsed from the message string.
+
+    Returns the matching SDK exception, or ``None`` if ``exc`` is not one
+    of the three saga terminals (so the caller re-raises it unchanged).
+    """
+    args = exc.args
+    message = str(args[0]) if args else str(exc)
+    code = args[1] if len(args) > 1 and isinstance(args[1], str) else None
+    datum = args[2] if len(args) > 2 else None
+
+    name = type(exc).__name__
+    if name == "SagaAbortedError":
+        # retry_after_ms is an int of milliseconds or None (never 0).
+        retry_after_ms = datum if isinstance(datum, int) and not isinstance(datum, bool) else None
+        return SagaAbortedError(message, code=code, retry_after_ms=retry_after_ms)
+    if name == "SagaNeedsRepairError":
+        return SagaNeedsRepairError(
+            message, code=code, saga_id=str(datum) if datum is not None else ""
+        )
+    if name == "SagaBusyError":
+        return SagaBusyError(
+            message, code=code, contended_context=str(datum) if datum is not None else ""
+        )
+    return None
+
+
+# ---------------------------------------------------------------------------
 # Mapping from bridge error variant names to SDK exceptions.
 # ---------------------------------------------------------------------------
 
@@ -123,6 +237,9 @@ __all__ = [
     "ContextError",
     "CryptoError",
     "IdentityError",
+    "SagaAbortedError",
+    "SagaBusyError",
+    "SagaNeedsRepairError",
     "ScpError",
     "ToolError",
     "TransportError",

--- a/bindings/python/scp_sdk/errors.py
+++ b/bindings/python/scp_sdk/errors.py
@@ -194,7 +194,7 @@ def _saga_terminal_from_bridge(exc: BaseException) -> ScpError | None:
     of the three saga terminals (so the caller re-raises it unchanged).
     """
     args = exc.args
-    message = str(args[0]) if args else str(exc)
+    message = str(args[0]) if len(args) > 0 else str(exc)
     code = args[1] if len(args) > 1 and isinstance(args[1], str) else None
     datum = args[2] if len(args) > 2 else None
 

--- a/bindings/python/scp_sdk/scp.py
+++ b/bindings/python/scp_sdk/scp.py
@@ -44,10 +44,13 @@ import asyncio
 import logging
 import math
 from types import TracebackType
-from typing import Any, Literal, Protocol, TypedDict, runtime_checkable
+from typing import TYPE_CHECKING, Any, Literal, Protocol, TypedDict, runtime_checkable
 
 from scp_sdk.errors import ScpError
 from scp_sdk.types import CustodyType
+
+if TYPE_CHECKING:
+    from scp_sdk.tools import SagaResult
 
 logger = logging.getLogger("scp_sdk")
 
@@ -2034,6 +2037,84 @@ class SCP:
             ucan_token,
             chain_depth,
             proof_tokens,
+        )
+
+    async def tool_invoke_cross_context_saga(
+        self,
+        caller_context_id: str,
+        target_context_id: str,
+        caller_did: str,
+        tool_registration_id: str,
+        input: dict[str, Any],
+        asserted_nonce_hex: str,
+        timestamp_ms: int,
+        chain_depth: int,
+        ucan_proof_id: str | None = None,
+    ) -> SagaResult:
+        """Run the §6.2.4 atomic cross-context tool-invocation saga.
+
+        Delegates to ``_scp_core.SCP.tool_invoke_cross_context_saga``. The
+        saga either commits — returning a :class:`~scp_sdk.tools.SagaResult`
+        carrying the supervisor-minted ``saga_id`` plus the target's signed
+        receipt and captured output bytes — or reaches a typed terminal,
+        which is re-raised as one of the SDK saga exceptions:
+
+        - :class:`~scp_sdk.errors.SagaAbortedError` — a Prepare-phase
+          rejection; carries ``retry_after_ms`` (``None``, never ``0``,
+          when no precise back-off exists).
+        - :class:`~scp_sdk.errors.SagaNeedsRepairError` — Commit retries
+          exhausted; carries the durable ``saga_id`` repair handle.
+        - :class:`~scp_sdk.errors.SagaBusyError` — the participant context
+          set overlapped an in-flight saga; carries ``contended_context``.
+
+        Validates ``chain_depth`` is an integer in the closed range
+        ``0..255`` (u8 on the bridge side) and ``timestamp_ms`` is a
+        non-negative integer. Both reject ``bool`` (Python's ``bool``
+        passes ``isinstance(..., int)``) and floats, matching the bridge's
+        ``u8`` / ``u64`` boundaries. See spec §6.2.4 and ADR-049 §3a.
+        """
+        from scp_sdk.errors import ValidationError, _saga_terminal_from_bridge
+        from scp_sdk.tools import SagaResult
+
+        if (
+            isinstance(chain_depth, bool)
+            or not isinstance(chain_depth, int)
+            or chain_depth < 0
+            or chain_depth > 255
+        ):
+            raise ValidationError(
+                f"chain_depth must be an integer in range 0-255, got {chain_depth!r}",
+                code="SCP-VALID-7002",
+            )
+        if isinstance(timestamp_ms, bool) or not isinstance(timestamp_ms, int) or timestamp_ms < 0:
+            raise ValidationError(
+                f"timestamp_ms must be a non-negative integer, got {timestamp_ms!r}",
+                code="SCP-VALID-7002",
+            )
+
+        try:
+            native_result = await asyncio.to_thread(
+                self._native.tool_invoke_cross_context_saga,
+                caller_context_id,
+                target_context_id,
+                caller_did,
+                tool_registration_id,
+                input,
+                asserted_nonce_hex,
+                timestamp_ms,
+                chain_depth,
+                ucan_proof_id,
+            )
+        except Exception as exc:
+            translated = _saga_terminal_from_bridge(exc)
+            if translated is None:
+                raise
+            raise translated from exc
+
+        return SagaResult(
+            saga_id=native_result.saga_id,
+            receipt=native_result.receipt,
+            output=native_result.output,
         )
 
     async def tool_register(self, context_id: str, registration: dict[str, Any]) -> Any:

--- a/bindings/python/scp_sdk/tools.py
+++ b/bindings/python/scp_sdk/tools.py
@@ -148,6 +148,32 @@ class ToolDefinition:
 # ---------------------------------------------------------------------------
 
 
+@dataclass(frozen=True)
+class SagaResult:
+    """The committed terminal of a §6.2.4 cross-context tool-invocation saga.
+
+    Returned by :meth:`scp_sdk.SCP.tool_invoke_cross_context_saga` only on a
+    ``Committed`` terminal — every non-committed terminal raises a typed saga
+    exception (:class:`~scp_sdk.errors.SagaAbortedError`,
+    :class:`~scp_sdk.errors.SagaNeedsRepairError`, or
+    :class:`~scp_sdk.errors.SagaBusyError`) instead.
+
+    The fields are a faithful pass-through of the bridge result: ``receipt``
+    and ``output`` are surfaced exactly as the bridge returns them (``None``
+    when absent — never synthesized). See spec §6.2.4 and ADR-049 §3a.
+    """
+
+    #: The durable saga identifier (supervisor-minted, never a caller input).
+    saga_id: str
+
+    #: The target's signed ``CrossContextToolReceipt`` bytes (JCS), or ``None``.
+    receipt: bytes | None = None
+
+    #: The captured tool output bytes (the receipt's canonical ``output_jcs``),
+    #: or ``None``.
+    output: bytes | None = None
+
+
 # ---------------------------------------------------------------------------
 # Stateful tool sessions (spec section 6.2.1)
 # ---------------------------------------------------------------------------
@@ -159,6 +185,7 @@ class ToolDefinition:
 
 
 __all__ = [
+    "SagaResult",
     "TestVector",
     "ToolCost",
     "ToolDefinition",

--- a/bindings/python/tests/test_tools.py
+++ b/bindings/python/tests/test_tools.py
@@ -559,6 +559,64 @@ class TestSagaAbortedTranslation:
         assert exc_info.value.code == "SCP-SAGA-13067"
         assert exc_info.value.message == "aborted"
 
+    async def test_abort_non_string_code_arg_falls_back_to_generic_default(self) -> None:
+        """A bridge terminal whose ``args[1]`` is a non-string (a 2-tuple
+        ``(message, datum)`` with no code slot) MUST NOT surface that value as
+        the error ``code`` — it falls back to the ``SCP-SAGA-13067`` default.
+
+        The translator guards the code read with ``isinstance(args[1], str)``;
+        without it the int ``1500`` (a datum, not a code) would become the
+        ``code``. The production bridge always sends a string code, so this
+        pins the defensive guard against a malformed-arity bridge terminal.
+        """
+        from scp_sdk.errors import SagaAbortedError
+
+        scp = _make_scp(_native_raising(_BridgeSagaAborted("rate limited", 1500)))
+
+        with pytest.raises(SagaAbortedError) as exc_info:
+            await _invoke_saga(scp)
+
+        # ``1500`` sits at args[1] (the code slot) but is not a string, so it is
+        # neither read as the code nor (being absent from args[2]) as a back-off.
+        assert exc_info.value.code == "SCP-SAGA-13067"
+        assert exc_info.value.retry_after_ms is None
+
+    async def test_abort_empty_args_falls_back_without_index_error(self) -> None:
+        """A bridge terminal raised with NO args translates cleanly: the
+        message read is guarded by ``if args else str(exc)`` so it never
+        indexes ``args[0]`` out of range, and the code/back-off fall back.
+
+        Dropping the ``if args`` guard would raise ``IndexError`` on the empty
+        tuple instead of producing a typed SDK terminal; this pins it.
+        """
+        from scp_sdk.errors import SagaAbortedError
+
+        scp = _make_scp(_native_raising(_BridgeSagaAborted()))
+
+        with pytest.raises(SagaAbortedError) as exc_info:
+            await _invoke_saga(scp)
+
+        assert exc_info.value.code == "SCP-SAGA-13067"
+        assert exc_info.value.retry_after_ms is None
+
+    async def test_translated_saga_error_chains_original_bridge_cause(self) -> None:
+        """The wrapper re-raises the typed SDK terminal ``from`` the bridge
+        exception, so ``__cause__`` preserves the original for debugging.
+
+        Dropping the ``from exc`` clause would leave ``__cause__`` as ``None``
+        (only the implicit ``__context__`` would be set); this pins the
+        explicit cause chain.
+        """
+        from scp_sdk.errors import SagaAbortedError
+
+        bridge_exc = _BridgeSagaAborted("rate limited", "SCP-SAGA-13067", 1500)
+        scp = _make_scp(_native_raising(bridge_exc))
+
+        with pytest.raises(SagaAbortedError) as exc_info:
+            await _invoke_saga(scp)
+
+        assert exc_info.value.__cause__ is bridge_exc
+
 
 class TestSagaNeedsRepairTranslation:
     """Commit-retry exhaustion → SDK SagaNeedsRepairError, saga_id preserved."""

--- a/bindings/python/tests/test_tools.py
+++ b/bindings/python/tests/test_tools.py
@@ -519,6 +519,25 @@ class TestSagaAbortedTranslation:
         assert exc_info.value.retry_after_ms is not None
         assert exc_info.value.code == "SCP-SAGA-13067"
 
+    async def test_abort_without_code_falls_back_to_generic_default(self) -> None:
+        """A bridge abort that omits the code (1-tuple ``args``) surfaces the
+        generic ``SCP-SAGA-13067`` class default — never a more specific code.
+
+        The bridge always supplies an explicit ``SCP-SAGA-13xxx`` code; this
+        exercises the ``code is None`` translation branch so the class default
+        stays load-bearing (the generic abort code, not a Prepare-reason code).
+        """
+        from scp_sdk.errors import SagaAbortedError
+
+        scp = _make_scp(_native_raising(_BridgeSagaAborted("rejected")))
+
+        with pytest.raises(SagaAbortedError) as exc_info:
+            await _invoke_saga(scp)
+
+        assert exc_info.value.code == "SCP-SAGA-13067"
+        assert exc_info.value.retry_after_ms is None
+        assert exc_info.value.message == "rejected"
+
 
 class TestSagaNeedsRepairTranslation:
     """Commit-retry exhaustion → SDK SagaNeedsRepairError, saga_id preserved."""

--- a/bindings/python/tests/test_tools.py
+++ b/bindings/python/tests/test_tools.py
@@ -538,6 +538,27 @@ class TestSagaAbortedTranslation:
         assert exc_info.value.retry_after_ms is None
         assert exc_info.value.message == "rejected"
 
+    async def test_abort_bool_datum_is_not_coerced_to_retry(self) -> None:
+        """A bridge abort whose datum is a ``bool`` MUST NOT be read as a
+        back-off hint — ``retry_after_ms`` stays ``None``.
+
+        ``bool`` is a subclass of ``int`` in Python, so ``isinstance(True, int)``
+        is ``True``; without the ``and not isinstance(datum, bool)`` guard the
+        translation would coerce ``True`` into the int ``1`` and surface a
+        bogus 1 ms back-off. This pins that guard load-bearing.
+        """
+        from scp_sdk.errors import SagaAbortedError
+
+        scp = _make_scp(_native_raising(_BridgeSagaAborted("aborted", "SCP-SAGA-13067", True)))
+
+        with pytest.raises(SagaAbortedError) as exc_info:
+            await _invoke_saga(scp)
+
+        # The bool datum is rejected structurally: not ``True``, not ``1``.
+        assert exc_info.value.retry_after_ms is None
+        assert exc_info.value.code == "SCP-SAGA-13067"
+        assert exc_info.value.message == "aborted"
+
 
 class TestSagaNeedsRepairTranslation:
     """Commit-retry exhaustion → SDK SagaNeedsRepairError, saga_id preserved."""
@@ -712,3 +733,24 @@ class TestSagaTimestampValidation:
             await _invoke_saga(scp, timestamp_ms=False)  # type: ignore[arg-type]
         assert exc_info.value.code == "SCP-VALID-7002"
         scp._native.tool_invoke_cross_context_saga.assert_not_called()
+
+
+class TestSagaErrorTaxonomy:
+    """The three §6.2.4 saga terminals are ``ToolError`` subclasses.
+
+    Cross-context tool invocation is a TOOL operation, so its terminal
+    failures live under :class:`ToolError` — a caller that catches
+    ``ToolError`` catches all three. Re-parenting any of them (e.g. to a
+    bare ``ScpError``) would silently break that contract; these pin it.
+    """
+
+    def test_saga_errors_are_tool_errors(self) -> None:
+        from scp_sdk.errors import (
+            SagaAbortedError,
+            SagaBusyError,
+            SagaNeedsRepairError,
+        )
+
+        assert issubclass(SagaAbortedError, ToolError)
+        assert issubclass(SagaNeedsRepairError, ToolError)
+        assert issubclass(SagaBusyError, ToolError)

--- a/bindings/python/tests/test_tools.py
+++ b/bindings/python/tests/test_tools.py
@@ -388,7 +388,13 @@ def _committed_native(
     return native
 
 
-async def _invoke_saga(scp: MagicMock, *, chain_depth: int = 0, timestamp_ms: int = _DUMMY_TS_MS):
+async def _invoke_saga(
+    scp: MagicMock,
+    *,
+    chain_depth: int = 0,
+    timestamp_ms: int = _DUMMY_TS_MS,
+    ucan_proof_id: str | None = None,
+):
     from scp_sdk.scp import SCP
 
     return await SCP.tool_invoke_cross_context_saga(
@@ -401,6 +407,7 @@ async def _invoke_saga(scp: MagicMock, *, chain_depth: int = 0, timestamp_ms: in
         _DUMMY_NONCE_HEX,
         timestamp_ms,
         chain_depth,
+        ucan_proof_id,
     )
 
 
@@ -447,6 +454,25 @@ class TestSagaHappyPath:
             42,
             7,
             None,
+        )
+
+    async def test_native_forwards_ucan_proof_id(self) -> None:
+        """A non-default ``ucan_proof_id`` is forwarded as the 9th positional arg."""
+        native = _committed_native()
+        scp = _make_scp(native)
+
+        await _invoke_saga(scp, ucan_proof_id="some-proof-id")
+
+        native.tool_invoke_cross_context_saga.assert_called_once_with(
+            _DUMMY_CTX_CALLER,
+            _DUMMY_CTX_TGT,
+            _DUMMY_DID,
+            _DUMMY_REG_ID,
+            {"a": 1},
+            _DUMMY_NONCE_HEX,
+            _DUMMY_TS_MS,
+            0,
+            "some-proof-id",
         )
 
 
@@ -559,30 +585,36 @@ class TestSagaChainDepthValidation:
         with pytest.raises(ValidationError, match="chain_depth") as exc_info:
             await _invoke_saga(scp, chain_depth=-1)
         assert exc_info.value.code == "SCP-VALID-7002"
+        # Fail-fast: validation MUST reject before the side-effectful saga fires.
+        scp._native.tool_invoke_cross_context_saga.assert_not_called()
 
     async def test_chain_depth_256_rejected(self) -> None:
         scp = _make_scp(_committed_native())
         with pytest.raises(ValidationError, match="chain_depth") as exc_info:
             await _invoke_saga(scp, chain_depth=256)
         assert exc_info.value.code == "SCP-VALID-7002"
+        scp._native.tool_invoke_cross_context_saga.assert_not_called()
 
     async def test_chain_depth_float_rejected(self) -> None:
         scp = _make_scp(_committed_native())
         with pytest.raises(ValidationError, match="chain_depth") as exc_info:
             await _invoke_saga(scp, chain_depth=1.5)  # type: ignore[arg-type]
         assert exc_info.value.code == "SCP-VALID-7002"
+        scp._native.tool_invoke_cross_context_saga.assert_not_called()
 
     async def test_chain_depth_bool_true_rejected(self) -> None:
         scp = _make_scp(_committed_native())
         with pytest.raises(ValidationError, match="chain_depth") as exc_info:
             await _invoke_saga(scp, chain_depth=True)  # type: ignore[arg-type]
         assert exc_info.value.code == "SCP-VALID-7002"
+        scp._native.tool_invoke_cross_context_saga.assert_not_called()
 
     async def test_chain_depth_bool_false_rejected(self) -> None:
         scp = _make_scp(_committed_native())
         with pytest.raises(ValidationError, match="chain_depth") as exc_info:
             await _invoke_saga(scp, chain_depth=False)  # type: ignore[arg-type]
         assert exc_info.value.code == "SCP-VALID-7002"
+        scp._native.tool_invoke_cross_context_saga.assert_not_called()
 
 
 class TestSagaTimestampValidation:
@@ -598,15 +630,28 @@ class TestSagaTimestampValidation:
         with pytest.raises(ValidationError, match="timestamp_ms") as exc_info:
             await _invoke_saga(scp, timestamp_ms=-1)
         assert exc_info.value.code == "SCP-VALID-7002"
+        # Fail-fast: validation MUST reject before the side-effectful saga fires.
+        scp._native.tool_invoke_cross_context_saga.assert_not_called()
 
     async def test_timestamp_float_rejected(self) -> None:
         scp = _make_scp(_committed_native())
         with pytest.raises(ValidationError, match="timestamp_ms") as exc_info:
             await _invoke_saga(scp, timestamp_ms=1.5)  # type: ignore[arg-type]
         assert exc_info.value.code == "SCP-VALID-7002"
+        scp._native.tool_invoke_cross_context_saga.assert_not_called()
 
     async def test_timestamp_bool_true_rejected(self) -> None:
         scp = _make_scp(_committed_native())
         with pytest.raises(ValidationError, match="timestamp_ms") as exc_info:
             await _invoke_saga(scp, timestamp_ms=True)  # type: ignore[arg-type]
         assert exc_info.value.code == "SCP-VALID-7002"
+        scp._native.tool_invoke_cross_context_saga.assert_not_called()
+
+    async def test_timestamp_bool_false_rejected(self) -> None:
+        # ``False == 0`` but a bool is still rejected: the u64 boundary takes
+        # the type, not the numeric value.
+        scp = _make_scp(_committed_native())
+        with pytest.raises(ValidationError, match="timestamp_ms") as exc_info:
+            await _invoke_saga(scp, timestamp_ms=False)  # type: ignore[arg-type]
+        assert exc_info.value.code == "SCP-VALID-7002"
+        scp._native.tool_invoke_cross_context_saga.assert_not_called()

--- a/bindings/python/tests/test_tools.py
+++ b/bindings/python/tests/test_tools.py
@@ -350,3 +350,263 @@ class TestToolsExports:
         from scp_sdk import tools
 
         assert "TestVector" in tools.__all__
+
+    def test_saga_result_exported(self) -> None:
+        from scp_sdk import tools
+
+        assert "SagaResult" in tools.__all__
+
+
+# ---------------------------------------------------------------------------
+# Cross-context tool-invocation saga (§6.2.4 / ADR-049 §3a)
+# SCP.tool_invoke_cross_context_saga
+# ---------------------------------------------------------------------------
+
+_DUMMY_CTX_CALLER = "ctx-caller-001"
+_DUMMY_NONCE_HEX = "0123456789abcdef0123456789abcdef"
+_DUMMY_TS_MS = 1_700_000_000_000
+_DUMMY_REG_ID = "reg-tool-007"
+
+
+def _committed_native(
+    saga_id: str = "saga-committed-001",
+    receipt: bytes | None = b"receipt-bytes",
+    output: bytes | None = b"output-bytes",
+) -> MagicMock:
+    """Build a mock ``_native`` whose saga call returns a committed result.
+
+    The committed terminal is a ``SimpleNamespace`` (not a bare ``MagicMock``)
+    so the wrapper reads concrete ``saga_id`` / ``receipt`` / ``output``
+    values rather than auto-generated mock attributes.
+    """
+    from types import SimpleNamespace
+
+    native = MagicMock()
+    native.tool_invoke_cross_context_saga.return_value = SimpleNamespace(
+        saga_id=saga_id, receipt=receipt, output=output
+    )
+    return native
+
+
+async def _invoke_saga(scp: MagicMock, *, chain_depth: int = 0, timestamp_ms: int = _DUMMY_TS_MS):
+    from scp_sdk.scp import SCP
+
+    return await SCP.tool_invoke_cross_context_saga(
+        scp,
+        _DUMMY_CTX_CALLER,
+        _DUMMY_CTX_TGT,
+        _DUMMY_DID,
+        _DUMMY_REG_ID,
+        {"a": 1},
+        _DUMMY_NONCE_HEX,
+        timestamp_ms,
+        chain_depth,
+    )
+
+
+class TestSagaHappyPath:
+    """A committed saga returns a faithful :class:`SagaResult` pass-through."""
+
+    async def test_committed_returns_saga_result(self) -> None:
+        from scp_sdk.tools import SagaResult
+
+        scp = _make_scp(_committed_native())
+
+        result = await _invoke_saga(scp)
+
+        assert isinstance(result, SagaResult)
+        assert result.saga_id == "saga-committed-001"
+        assert result.receipt == b"receipt-bytes"
+        assert result.output == b"output-bytes"
+
+    async def test_committed_passes_through_null_receipt_and_output(self) -> None:
+        """``None`` receipt/output are surfaced verbatim — never synthesized."""
+        from scp_sdk.tools import SagaResult
+
+        scp = _make_scp(_committed_native(receipt=None, output=None))
+
+        result = await _invoke_saga(scp)
+
+        assert isinstance(result, SagaResult)
+        assert result.receipt is None
+        assert result.output is None
+
+    async def test_native_called_with_forwarded_arguments(self) -> None:
+        native = _committed_native()
+        scp = _make_scp(native)
+
+        await _invoke_saga(scp, chain_depth=7, timestamp_ms=42)
+
+        native.tool_invoke_cross_context_saga.assert_called_once_with(
+            _DUMMY_CTX_CALLER,
+            _DUMMY_CTX_TGT,
+            _DUMMY_DID,
+            _DUMMY_REG_ID,
+            {"a": 1},
+            _DUMMY_NONCE_HEX,
+            42,
+            7,
+            None,
+        )
+
+
+# Bridge-shaped terminal exceptions: same NAMES the PyO3 bridge raises, with
+# the structured datum carried positionally in ``args[2]``. The wrapper
+# dispatches by class name and reads ``args`` structurally.
+_BridgeSagaAborted = type("SagaAbortedError", (Exception,), {})
+_BridgeSagaNeedsRepair = type("SagaNeedsRepairError", (Exception,), {})
+_BridgeSagaBusy = type("SagaBusyError", (Exception,), {})
+
+
+def _native_raising(exc: BaseException) -> MagicMock:
+    native = MagicMock()
+    native.tool_invoke_cross_context_saga.side_effect = exc
+    return native
+
+
+class TestSagaAbortedTranslation:
+    """Prepare-phase abort → SDK SagaAbortedError, retry_after_ms preserved."""
+
+    async def test_abort_without_backoff_preserves_none(self) -> None:
+        from scp_sdk.errors import SagaAbortedError
+
+        scp = _make_scp(_native_raising(_BridgeSagaAborted("rejected", "SCP-SAGA-13050", None)))
+
+        with pytest.raises(SagaAbortedError) as exc_info:
+            await _invoke_saga(scp)
+
+        # The back-off hint MUST survive as ``None`` — never coerced to ``0``
+        # (``0`` would read as "retry immediately" and re-trip the limiter).
+        assert exc_info.value.retry_after_ms is None
+        assert exc_info.value.code == "SCP-SAGA-13050"
+        assert exc_info.value.message == "rejected"
+
+    async def test_abort_with_backoff_preserves_int(self) -> None:
+        from scp_sdk.errors import SagaAbortedError
+
+        scp = _make_scp(_native_raising(_BridgeSagaAborted("rate limited", "SCP-SAGA-13067", 1500)))
+
+        with pytest.raises(SagaAbortedError) as exc_info:
+            await _invoke_saga(scp)
+
+        assert exc_info.value.retry_after_ms == 1500
+        assert exc_info.value.retry_after_ms is not None
+        assert exc_info.value.code == "SCP-SAGA-13067"
+
+
+class TestSagaNeedsRepairTranslation:
+    """Commit-retry exhaustion → SDK SagaNeedsRepairError, saga_id preserved."""
+
+    async def test_needs_repair_preserves_saga_id(self) -> None:
+        from scp_sdk.errors import SagaNeedsRepairError
+
+        scp = _make_scp(
+            _native_raising(_BridgeSagaNeedsRepair("diverged", "SCP-SAGA-13065", "saga-repair-abc"))
+        )
+
+        with pytest.raises(SagaNeedsRepairError) as exc_info:
+            await _invoke_saga(scp)
+
+        assert exc_info.value.saga_id == "saga-repair-abc"
+        assert exc_info.value.code == "SCP-SAGA-13065"
+
+
+class TestSagaBusyTranslation:
+    """Participant-set overlap → SDK SagaBusyError, contended_context preserved."""
+
+    async def test_busy_preserves_contended_context(self) -> None:
+        from scp_sdk.errors import SagaBusyError
+
+        scp = _make_scp(
+            _native_raising(_BridgeSagaBusy("busy", "SCP-SAGA-13066", "ctx-shared-xyz"))
+        )
+
+        with pytest.raises(SagaBusyError) as exc_info:
+            await _invoke_saga(scp)
+
+        assert exc_info.value.contended_context == "ctx-shared-xyz"
+        assert exc_info.value.code == "SCP-SAGA-13066"
+
+
+class TestSagaNonSagaErrorPassthrough:
+    """A non-saga bridge exception is re-raised unchanged (not swallowed)."""
+
+    async def test_unrelated_exception_reraised(self) -> None:
+        sentinel = RuntimeError("unrelated boom")
+        scp = _make_scp(_native_raising(sentinel))
+
+        with pytest.raises(RuntimeError, match="unrelated boom") as exc_info:
+            await _invoke_saga(scp)
+
+        assert exc_info.value is sentinel
+
+
+class TestSagaChainDepthValidation:
+    """chain_depth must be an int in 0-255 (saga wrapper mirrors the sync one)."""
+
+    async def test_chain_depth_zero_accepted(self) -> None:
+        scp = _make_scp(_committed_native())
+        result = await _invoke_saga(scp, chain_depth=0)
+        assert result.saga_id == "saga-committed-001"
+
+    async def test_chain_depth_255_accepted(self) -> None:
+        scp = _make_scp(_committed_native())
+        result = await _invoke_saga(scp, chain_depth=255)
+        assert result.saga_id == "saga-committed-001"
+
+    async def test_chain_depth_negative_rejected(self) -> None:
+        scp = _make_scp(_committed_native())
+        with pytest.raises(ValidationError, match="chain_depth") as exc_info:
+            await _invoke_saga(scp, chain_depth=-1)
+        assert exc_info.value.code == "SCP-VALID-7002"
+
+    async def test_chain_depth_256_rejected(self) -> None:
+        scp = _make_scp(_committed_native())
+        with pytest.raises(ValidationError, match="chain_depth") as exc_info:
+            await _invoke_saga(scp, chain_depth=256)
+        assert exc_info.value.code == "SCP-VALID-7002"
+
+    async def test_chain_depth_float_rejected(self) -> None:
+        scp = _make_scp(_committed_native())
+        with pytest.raises(ValidationError, match="chain_depth") as exc_info:
+            await _invoke_saga(scp, chain_depth=1.5)  # type: ignore[arg-type]
+        assert exc_info.value.code == "SCP-VALID-7002"
+
+    async def test_chain_depth_bool_true_rejected(self) -> None:
+        scp = _make_scp(_committed_native())
+        with pytest.raises(ValidationError, match="chain_depth") as exc_info:
+            await _invoke_saga(scp, chain_depth=True)  # type: ignore[arg-type]
+        assert exc_info.value.code == "SCP-VALID-7002"
+
+    async def test_chain_depth_bool_false_rejected(self) -> None:
+        scp = _make_scp(_committed_native())
+        with pytest.raises(ValidationError, match="chain_depth") as exc_info:
+            await _invoke_saga(scp, chain_depth=False)  # type: ignore[arg-type]
+        assert exc_info.value.code == "SCP-VALID-7002"
+
+
+class TestSagaTimestampValidation:
+    """timestamp_ms must be a non-negative int (rejects bool/float/negative)."""
+
+    async def test_timestamp_zero_accepted(self) -> None:
+        scp = _make_scp(_committed_native())
+        result = await _invoke_saga(scp, timestamp_ms=0)
+        assert result.saga_id == "saga-committed-001"
+
+    async def test_timestamp_negative_rejected(self) -> None:
+        scp = _make_scp(_committed_native())
+        with pytest.raises(ValidationError, match="timestamp_ms") as exc_info:
+            await _invoke_saga(scp, timestamp_ms=-1)
+        assert exc_info.value.code == "SCP-VALID-7002"
+
+    async def test_timestamp_float_rejected(self) -> None:
+        scp = _make_scp(_committed_native())
+        with pytest.raises(ValidationError, match="timestamp_ms") as exc_info:
+            await _invoke_saga(scp, timestamp_ms=1.5)  # type: ignore[arg-type]
+        assert exc_info.value.code == "SCP-VALID-7002"
+
+    async def test_timestamp_bool_true_rejected(self) -> None:
+        scp = _make_scp(_committed_native())
+        with pytest.raises(ValidationError, match="timestamp_ms") as exc_info:
+            await _invoke_saga(scp, timestamp_ms=True)  # type: ignore[arg-type]
+        assert exc_info.value.code == "SCP-VALID-7002"

--- a/bindings/python/tests/test_tools.py
+++ b/bindings/python/tests/test_tools.py
@@ -583,11 +583,12 @@ class TestSagaAbortedTranslation:
 
     async def test_abort_empty_args_falls_back_without_index_error(self) -> None:
         """A bridge terminal raised with NO args translates cleanly: the
-        message read is guarded by ``if args else str(exc)`` so it never
-        indexes ``args[0]`` out of range, and the code/back-off fall back.
+        message read is guarded by ``str(args[0]) if len(args) > 0 else
+        str(exc)`` so it never indexes ``args[0]`` out of range, and the
+        code/back-off fall back.
 
-        Dropping the ``if args`` guard would raise ``IndexError`` on the empty
-        tuple instead of producing a typed SDK terminal; this pins it.
+        Dropping the ``len(args) > 0`` guard would raise ``IndexError`` on the
+        empty tuple instead of producing a typed SDK terminal; this pins it.
         """
         from scp_sdk.errors import SagaAbortedError
 

--- a/bindings/python/tests/test_tools.py
+++ b/bindings/python/tests/test_tools.py
@@ -555,6 +555,25 @@ class TestSagaNeedsRepairTranslation:
         assert exc_info.value.saga_id == "saga-repair-abc"
         assert exc_info.value.code == "SCP-SAGA-13065"
 
+    async def test_needs_repair_without_code_falls_back_to_generic_default(self) -> None:
+        """A bridge needs-repair that omits the code (1-tuple ``args``) surfaces
+        the ``SCP-SAGA-13065`` class default, and a missing datum yields ``""``.
+
+        The bridge always supplies an explicit code; this exercises the
+        ``code is None`` translation branch so the class default stays
+        load-bearing (a typo in ``_default_code`` would otherwise pass).
+        """
+        from scp_sdk.errors import SagaNeedsRepairError
+
+        scp = _make_scp(_native_raising(_BridgeSagaNeedsRepair("needs repair")))
+
+        with pytest.raises(SagaNeedsRepairError) as exc_info:
+            await _invoke_saga(scp)
+
+        assert exc_info.value.code == "SCP-SAGA-13065"
+        assert exc_info.value.saga_id == ""
+        assert exc_info.value.message == "needs repair"
+
 
 class TestSagaBusyTranslation:
     """Participant-set overlap → SDK SagaBusyError, contended_context preserved."""
@@ -571,6 +590,25 @@ class TestSagaBusyTranslation:
 
         assert exc_info.value.contended_context == "ctx-shared-xyz"
         assert exc_info.value.code == "SCP-SAGA-13066"
+
+    async def test_busy_without_code_falls_back_to_generic_default(self) -> None:
+        """A bridge busy that omits the code (1-tuple ``args``) surfaces the
+        ``SCP-SAGA-13066`` class default, and a missing datum yields ``""``.
+
+        The bridge always supplies an explicit code; this exercises the
+        ``code is None`` translation branch so the class default stays
+        load-bearing (a typo in ``_default_code`` would otherwise pass).
+        """
+        from scp_sdk.errors import SagaBusyError
+
+        scp = _make_scp(_native_raising(_BridgeSagaBusy("busy")))
+
+        with pytest.raises(SagaBusyError) as exc_info:
+            await _invoke_saga(scp)
+
+        assert exc_info.value.code == "SCP-SAGA-13066"
+        assert exc_info.value.contended_context == ""
+        assert exc_info.value.message == "busy"
 
 
 class TestSagaNonSagaErrorPassthrough:

--- a/scripts/check-sdk-coverage.py
+++ b/scripts/check-sdk-coverage.py
@@ -552,6 +552,12 @@ ALIASES: dict[tuple[str, str], dict[str, list[str]]] = {
         "kotlin": ["invokeCrossContext"],
         "swift": ["toolInvokeCrossContext"],
     },
+    ("Tools", "invoke_cross_context_saga"): {
+        "python": ["tool_invoke_cross_context_saga"],
+        "typescript": ["toolInvokeCrossContextSaga"],
+        "kotlin": ["invokeCrossContextSaga"],
+        "swift": ["toolInvokeCrossContextSaga"],
+    },
     ("Tools", "session_create"): {
         "python": ["tool_session_create"],
         "typescript": ["toolSessionCreate"],


### PR DESCRIPTION
## Scope

Python SDK wrapper for the §6.2.4 cross-context tool-invocation saga (`tool_invoke_cross_context_saga`) — **slice 1 of 4** of the SDK-wrapper rollout (#1939). Wraps the native PyO3 bridge op landed in PR-6b. TypeScript / Swift / Kotlin slices follow separately; their capability-matrix cells stay `false` with exemptions citing #1939.

This is the SDK-wrapper layer (integration-checklist item 3) + capability matrix (item 5) for the §6.2.4 saga. Producer + native bridge exports + pipeline assertions already landed (PR-6b).

## Changes (8 files, Python-only; production Rust untouched)

- **`scp_sdk/scp.py`** — `async def tool_invoke_cross_context_saga(...)`: validates `chain_depth` (u8 0–255) and `timestamp_ms` (u64 non-negative), both rejecting `bool`/`float` with `SCP-VALID-7002` **before** dispatch (fail-fast); forwards all 9 params positionally to `self._native.tool_invoke_cross_context_saga` via `asyncio.to_thread` (block-until-terminal per ADR-049 §3a); translates bridge saga terminals; returns `SagaResult`.
- **`scp_sdk/errors.py`** — three typed exceptions under `ToolError`: `SagaAbortedError(.retry_after_ms)`, `SagaNeedsRepairError(.saga_id)`, `SagaBusyError(.contended_context)`; `_saga_terminal_from_bridge` reads the structured datum **positionally from `args[2]`** (never message-parsed). Default codes: Aborted `SCP-SAGA-13067` (generic abort — **not** the specific membership-reject 13050, which would be a phantom-authz claim), NeedsRepair `13065`, Busy `13066`. `retry_after_ms` is never coerced `None→0`, and a `bool` datum is rejected (avoids `True→1ms` hot-loop backoff).
- **`scp_sdk/tools.py`** — frozen `SagaResult{saga_id, receipt: bytes|None, output: bytes|None}`, faithful nullable pass-through (no synthesis).
- **`scp_sdk/_scp_core.pyi`**, **`__init__.py`** — native stubs + public exports.
- **`tests/test_tools.py`** — 54 saga tests (happy path, null pass-through, full 9-arg forwarding incl. non-default `ucan_proof_id`, all three typed-error translations with structured fields, non-saga re-raise identity, chain_depth+timestamp validation with `assert_not_called` fail-fast, all three default-code fallbacks via the `code is None` branch, retry bool-datum guard, `ToolError` taxonomy, non-string-code guard, empty-args `IndexError` guard, `raise ... from exc` cause chain).
- **`.docs/standards/sdk-capability-matrix.json`** — flips only the Python `(Tools, invoke_cross_context_saga)` cell `false→true`, removes only the Python exemption (ts/kotlin/swift stay `false` with #1939 exemptions).
- **`scripts/check-sdk-coverage.py`** — additive ALIASES entry (expanding coverage; no existing assertion weakened).

## Review

Double-zero: two consecutive fully-clean full-roster reviews (sdk-coverage, api-design, alignment, completionist, simplifier, security, bug-catcher, test-quality). Convergence certified by the simplifier. Mutation-tested: 14/14 load-bearing assertions caught.

Follow-ups (non-blocking, captured in #1953): u8/u64 validation DRY helper, name-dispatch conformance test, pre-existing SDK-wide double-`[code]`-prefix, and optional hardening items.

Refs #1939 (parent — remains open for the TS/Swift/Kotlin slices).