### PR TITLE
feat(swift): SDK wrapper for tool_invoke_cross_context_saga (PR-6c slice 3/4)

### DIFF
--- a/.docs/standards/sdk-capability-matrix.json
+++ b/.docs/standards/sdk-capability-matrix.json
@@ -587,11 +587,10 @@
           "python": true,
           "typescript": true,
           "kotlin": false,
-          "swift": false,
-          "notes": "The §6.2.4 atomic cross-context tool-invocation saga (ADR-049 §3a). Exported by all three native bridges — PyO3 tool_invoke_cross_context_saga, UniFFI tool_invoke_cross_context_saga, NAPI toolInvokeCrossContextSaga (js_name); see scripts/bridge-aliases.json (category tools). Each export binds the caller principal to the authenticated FFI identity (enforce_caller_principal_binding) before dispatching to Supervisor::start_cross_context_tool_invocation_saga, pinned by the pyo3/napi/uniffi saga-export assertions in pipeline_wiring.rs. The Python (SCP.tool_invoke_cross_context_saga) and TypeScript (SCP.toolInvokeCrossContextSaga) SDK wrappers are live; the remaining per-SDK wrapper methods are tracked by #1939 (the PR-6c SDK-wrapper slice).",
+          "swift": true,
+          "notes": "The §6.2.4 atomic cross-context tool-invocation saga (ADR-049 §3a). Exported by all three native bridges — PyO3 tool_invoke_cross_context_saga, UniFFI tool_invoke_cross_context_saga, NAPI toolInvokeCrossContextSaga (js_name); see scripts/bridge-aliases.json (category tools). Each export binds the caller principal to the authenticated FFI identity (enforce_caller_principal_binding) before dispatching to Supervisor::start_cross_context_tool_invocation_saga, pinned by the pyo3/napi/uniffi saga-export assertions in pipeline_wiring.rs. The Python (SCP.tool_invoke_cross_context_saga), TypeScript (SCP.toolInvokeCrossContextSaga), and Swift (Context.invokeToolCrossContextSaga) SDK wrappers are live; the remaining Kotlin wrapper is tracked by #1939 (the PR-6c SDK-wrapper slice).",
           "exemptions": {
-            "kotlin": "UniFFI bridge exports tool_invoke_cross_context_saga; the named public Kotlin SDK wrapper is tracked by #1939 (PR-6c SDK-wrapper slice, §6.2.4 / ADR-049 §3a).",
-            "swift": "UniFFI bridge exports tool_invoke_cross_context_saga; the named public Swift SDK wrapper is tracked by #1939 (PR-6c SDK-wrapper slice, §6.2.4 / ADR-049 §3a)."
+            "kotlin": "UniFFI bridge exports tool_invoke_cross_context_saga; the named public Kotlin SDK wrapper is tracked by #1939 (PR-6c SDK-wrapper slice, §6.2.4 / ADR-049 §3a)."
           }
         },
         {

--- a/bindings/swift/Sources/SCP/Internal/ScpBindings.swift
+++ b/bindings/swift/Sources/SCP/Internal/ScpBindings.swift
@@ -2890,7 +2890,10 @@ public protocol ScpProtocol: AnyObject, Sendable {
     /**
      * Per-instance equivalent of the free-function `restore_all_contexts`.
      *
-     * Routes through `&*self.inner`.
+     * Routes through `&*self.inner` and the supervisor-scope
+     * `restore_on_startup` (ADR-049), which restores contexts BEFORE
+     * replaying any crash-orphaned saga journal entries in the
+     * §17.16.4-required restore-then-replay order.
      */
     func restoreAllContexts() async throws  -> String
     
@@ -2904,8 +2907,8 @@ public protocol ScpProtocol: AnyObject, Sendable {
     /**
      * Resumes a suspended bridge instance.
      *
-     * Clears the suspended flag, then runs any per-bridge async work chained
-     * by the `BridgeInstanceCore::resume` override (transport reconnect
+     * Clears the suspended flag, then runs the async work in the
+     * `BridgeInstanceCore::resume` default body (transport reconnect
      * from pending relay URLs, persisted-context restoration).
      *
      * `UniFFI` generates a `suspend`/`async` method on Swift and Kotlin.
@@ -3041,6 +3044,91 @@ public protocol ScpProtocol: AnyObject, Sendable {
     func toolInvokeCrossContext(sourceHandle: ContextHandle, targetHandle: ContextHandle, toolId: String, inputJson: String, identity: Identity, ucanToken: String, chainDepth: UInt8, proofTokens: [String]?) async throws  -> String
     
     /**
+     * Invokes a tool across context boundaries as an atomic two-phase saga
+     * (spec §6.2.4, ADR-049 §3a).
+     *
+     * Unlike [`Self::tool_invoke_cross_context`] (the synchronous,
+     * single-context-side path), this drives the full §6.2.4 cross-context
+     * tool-invocation saga over the two CO-RESIDENT participant contexts
+     * (caller + target): Prepare-A / Prepare-B authorize and stage both sides,
+     * the tool executes EXACTLY ONCE supervisor-side at Commit-B, and each
+     * side records its own event-log entry. Both contexts MUST be co-resident
+     * in this bridge instance (the cross-node child-bridge transport is
+     * separate future work).
+     *
+     * # Caller authentication (normative — §6.2.4, ADR-049 §3a)
+     *
+     * `caller_did` is bound to the bridge-authenticated principal: it MUST be
+     * an identity THIS bridge instance hosts (created here via identity
+     * creation) AND a member of the caller context. A mismatch raises
+     * [`ScpError::SagaAborted`] (`SCP-SAGA-13050`) BEFORE the saga runs — the
+     * saga never observes an unauthenticated caller. The `asserted_nonce_hex`
+     * / `timestamp_ms` / `chain_depth` REMAIN caller-supplied freshness fields
+     * (the target validates them; they are not minted here).
+     *
+     * # Trust boundary (co-resident single-tenant only)
+     *
+     * The caller-principal binding (`enforce_caller_principal_binding`) treats
+     * "hosted in this bridge instance's identity custody registry" as the
+     * channel-authenticated principal. That equivalence holds ONLY for a
+     * single-tenant, co-resident SDK process. This surface MUST NOT be exposed
+     * across a trust boundary within one process: a multi-tenant host loading
+     * multiple users' identities into one bridge instance could assert any
+     * hosted `caller_did`, since the registry cannot distinguish which tenant
+     * is making the call. The future cross-node leg needs real channel auth
+     * (ADR-049 §3a forward obligation) — it cannot reuse "is hosted here" as
+     * the authenticated-principal proof.
+     *
+     * The caller/target context-id axes are bound by the instance-affine
+     * handle pre-check: `source_handle` / `target_handle` must have been minted
+     * by THIS bridge instance (a foreign handle is rejected) before the
+     * supervisor membership / tool-interface gates run.
+     *
+     * The receipt's signer-authorization — that the target key is
+     * governance-authorized to act for the target context (§6.2.4 "Signer
+     * authorization") — is a DOWNSTREAM receipt-consumer obligation verified
+     * when the receipt is consumed, NOT enforced at this export.
+     *
+     * # Arguments
+     *
+     * * `source_handle` — The initiating (caller) context handle.
+     * * `target_handle` — The executing (target) context handle.
+     * * `caller_did` — The initiator DID (bound to the bridge principal).
+     * * `tool_registration_id` — The tool to invoke across the interface.
+     * * `input_json` — Tool input as a JSON string (schema-checked
+     * target-side); parsed to a JSON value at the boundary.
+     * * `asserted_nonce_hex` — The 16-byte §6.2.4 envelope nonce as a 32-char
+     * hex string (the freshness/dedup token).
+     * * `timestamp_ms` — Caller-asserted send time (Unix ms; freshness check).
+     * * `chain_depth` — Caller-asserted inbound provenance depth (advisory;
+     * the target re-derives `+1`).
+     * * `ucan_proof_id` — Optional id of the spending UCAN proof, resolved
+     * target-side at Prepare-B. `None` for an ungated tool.
+     *
+     * # Returns
+     *
+     * A [`SagaResult`] on the committed terminal, carrying the
+     * supervisor-minted `saga_id`, the target's signed receipt bytes, and the
+     * captured tool-output bytes. The `saga_id` is supervisor-minted — it is
+     * never an input.
+     *
+     * # Errors
+     *
+     * Returns one of the typed saga errors — [`ScpError::SagaAborted`] (a
+     * Prepare-phase rejection — authorization, freshness, rate limit, or
+     * co-residency; carries `retry_after_ms`), [`ScpError::SagaNeedsRepair`]
+     * (Commit-retry exhausted — carries the durable `saga_id` operator-repair
+     * handle), or [`ScpError::SagaBusy`] (the participant context set
+     * overlapped an in-flight saga — §5.15.4). Returns [`ScpError::Validation`]
+     * if an id/DID/tool-id is malformed or `asserted_nonce_hex` does not
+     * decode to 16 bytes, and [`ScpError::Tool`] if `input_json` is not valid
+     * JSON.
+     *
+     * See spec §6.2.4 and ADR-049 §3a.
+     */
+    func toolInvokeCrossContextSaga(sourceHandle: ContextHandle, targetHandle: ContextHandle, callerDid: String, toolRegistrationId: String, inputJson: String, assertedNonceHex: String, timestampMs: UInt64, chainDepth: UInt8, ucanProofId: String?) async throws  -> SagaResult
+    
+    /**
      * Per-instance equivalent of the free-function `tool_register`.
      *
      * Routes through `&*self.inner`. Rejects any `ContextHandle` whose
@@ -3153,6 +3241,19 @@ public protocol ScpProtocol: AnyObject, Sendable {
      * `instance_id` does not match this `SCP`'s.
      */
     func ucanDelegate(handle: ContextHandle, delegatorDid: String, delegateeDid: String, parentToken: String, capabilities: [String]) async throws  -> UcanToken
+    
+    /**
+     * Diagnostic, read-only evaluation of a UCAN token.
+     *
+     * Counterpart to [`SCP::ucan_validate`]: runs the same 11-step ADR-016
+     * pipeline via `evaluate_ucan` but returns a structured
+     * [`CapabilityValidationRecord`] (six booleans) instead of failing at the
+     * first error, and never records the token's nonce (read-only probe).
+     *
+     * Routes through `&*self.inner`. Rejects any `ContextHandle` whose
+     * `instance_id` does not match this `SCP`'s.
+     */
+    func ucanEvaluate(handle: ContextHandle, token: String, capability: String, presentingAgentDid: String?, proofTokens: [String]?) async throws  -> CapabilityValidationRecord
     
     /**
      * Per-instance equivalent of the free-function `ucan_mint`.
@@ -5616,7 +5717,10 @@ open func relayStartLocal(dataDir: String)async throws  -> RelayHandle  {
     /**
      * Per-instance equivalent of the free-function `restore_all_contexts`.
      *
-     * Routes through `&*self.inner`.
+     * Routes through `&*self.inner` and the supervisor-scope
+     * `restore_on_startup` (ADR-049), which restores contexts BEFORE
+     * replaying any crash-orphaned saga journal entries in the
+     * §17.16.4-required restore-then-replay order.
      */
 open func restoreAllContexts()async throws  -> String  {
     return
@@ -5660,8 +5764,8 @@ open func restoreContext(contextId: String)async throws   {
     /**
      * Resumes a suspended bridge instance.
      *
-     * Clears the suspended flag, then runs any per-bridge async work chained
-     * by the `BridgeInstanceCore::resume` override (transport reconnect
+     * Clears the suspended flag, then runs the async work in the
+     * `BridgeInstanceCore::resume` default body (transport reconnect
      * from pending relay URLs, persisted-context restoration).
      *
      * `UniFFI` generates a `suspend`/`async` method on Swift and Kotlin.
@@ -5970,6 +6074,106 @@ open func toolInvokeCrossContext(sourceHandle: ContextHandle, targetHandle: Cont
 }
     
     /**
+     * Invokes a tool across context boundaries as an atomic two-phase saga
+     * (spec §6.2.4, ADR-049 §3a).
+     *
+     * Unlike [`Self::tool_invoke_cross_context`] (the synchronous,
+     * single-context-side path), this drives the full §6.2.4 cross-context
+     * tool-invocation saga over the two CO-RESIDENT participant contexts
+     * (caller + target): Prepare-A / Prepare-B authorize and stage both sides,
+     * the tool executes EXACTLY ONCE supervisor-side at Commit-B, and each
+     * side records its own event-log entry. Both contexts MUST be co-resident
+     * in this bridge instance (the cross-node child-bridge transport is
+     * separate future work).
+     *
+     * # Caller authentication (normative — §6.2.4, ADR-049 §3a)
+     *
+     * `caller_did` is bound to the bridge-authenticated principal: it MUST be
+     * an identity THIS bridge instance hosts (created here via identity
+     * creation) AND a member of the caller context. A mismatch raises
+     * [`ScpError::SagaAborted`] (`SCP-SAGA-13050`) BEFORE the saga runs — the
+     * saga never observes an unauthenticated caller. The `asserted_nonce_hex`
+     * / `timestamp_ms` / `chain_depth` REMAIN caller-supplied freshness fields
+     * (the target validates them; they are not minted here).
+     *
+     * # Trust boundary (co-resident single-tenant only)
+     *
+     * The caller-principal binding (`enforce_caller_principal_binding`) treats
+     * "hosted in this bridge instance's identity custody registry" as the
+     * channel-authenticated principal. That equivalence holds ONLY for a
+     * single-tenant, co-resident SDK process. This surface MUST NOT be exposed
+     * across a trust boundary within one process: a multi-tenant host loading
+     * multiple users' identities into one bridge instance could assert any
+     * hosted `caller_did`, since the registry cannot distinguish which tenant
+     * is making the call. The future cross-node leg needs real channel auth
+     * (ADR-049 §3a forward obligation) — it cannot reuse "is hosted here" as
+     * the authenticated-principal proof.
+     *
+     * The caller/target context-id axes are bound by the instance-affine
+     * handle pre-check: `source_handle` / `target_handle` must have been minted
+     * by THIS bridge instance (a foreign handle is rejected) before the
+     * supervisor membership / tool-interface gates run.
+     *
+     * The receipt's signer-authorization — that the target key is
+     * governance-authorized to act for the target context (§6.2.4 "Signer
+     * authorization") — is a DOWNSTREAM receipt-consumer obligation verified
+     * when the receipt is consumed, NOT enforced at this export.
+     *
+     * # Arguments
+     *
+     * * `source_handle` — The initiating (caller) context handle.
+     * * `target_handle` — The executing (target) context handle.
+     * * `caller_did` — The initiator DID (bound to the bridge principal).
+     * * `tool_registration_id` — The tool to invoke across the interface.
+     * * `input_json` — Tool input as a JSON string (schema-checked
+     * target-side); parsed to a JSON value at the boundary.
+     * * `asserted_nonce_hex` — The 16-byte §6.2.4 envelope nonce as a 32-char
+     * hex string (the freshness/dedup token).
+     * * `timestamp_ms` — Caller-asserted send time (Unix ms; freshness check).
+     * * `chain_depth` — Caller-asserted inbound provenance depth (advisory;
+     * the target re-derives `+1`).
+     * * `ucan_proof_id` — Optional id of the spending UCAN proof, resolved
+     * target-side at Prepare-B. `None` for an ungated tool.
+     *
+     * # Returns
+     *
+     * A [`SagaResult`] on the committed terminal, carrying the
+     * supervisor-minted `saga_id`, the target's signed receipt bytes, and the
+     * captured tool-output bytes. The `saga_id` is supervisor-minted — it is
+     * never an input.
+     *
+     * # Errors
+     *
+     * Returns one of the typed saga errors — [`ScpError::SagaAborted`] (a
+     * Prepare-phase rejection — authorization, freshness, rate limit, or
+     * co-residency; carries `retry_after_ms`), [`ScpError::SagaNeedsRepair`]
+     * (Commit-retry exhausted — carries the durable `saga_id` operator-repair
+     * handle), or [`ScpError::SagaBusy`] (the participant context set
+     * overlapped an in-flight saga — §5.15.4). Returns [`ScpError::Validation`]
+     * if an id/DID/tool-id is malformed or `asserted_nonce_hex` does not
+     * decode to 16 bytes, and [`ScpError::Tool`] if `input_json` is not valid
+     * JSON.
+     *
+     * See spec §6.2.4 and ADR-049 §3a.
+     */
+open func toolInvokeCrossContextSaga(sourceHandle: ContextHandle, targetHandle: ContextHandle, callerDid: String, toolRegistrationId: String, inputJson: String, assertedNonceHex: String, timestampMs: UInt64, chainDepth: UInt8, ucanProofId: String?)async throws  -> SagaResult  {
+    return
+        try  await uniffiRustCallAsync(
+            rustFutureFunc: {
+                uniffi_scp_ffi_uniffi_fn_method_scp_tool_invoke_cross_context_saga(
+                    self.uniffiClonePointer(),
+                    FfiConverterTypeContextHandle_lower(sourceHandle),FfiConverterTypeContextHandle_lower(targetHandle),FfiConverterString.lower(callerDid),FfiConverterString.lower(toolRegistrationId),FfiConverterString.lower(inputJson),FfiConverterString.lower(assertedNonceHex),FfiConverterUInt64.lower(timestampMs),FfiConverterUInt8.lower(chainDepth),FfiConverterOptionString.lower(ucanProofId)
+                )
+            },
+            pollFunc: ffi_scp_ffi_uniffi_rust_future_poll_rust_buffer,
+            completeFunc: ffi_scp_ffi_uniffi_rust_future_complete_rust_buffer,
+            freeFunc: ffi_scp_ffi_uniffi_rust_future_free_rust_buffer,
+            liftFunc: FfiConverterTypeSagaResult_lift,
+            errorHandler: FfiConverterTypeScpError_lift
+        )
+}
+    
+    /**
      * Per-instance equivalent of the free-function `tool_register`.
      *
      * Routes through `&*self.inner`. Rejects any `ContextHandle` whose
@@ -6242,6 +6446,34 @@ open func ucanDelegate(handle: ContextHandle, delegatorDid: String, delegateeDid
             completeFunc: ffi_scp_ffi_uniffi_rust_future_complete_pointer,
             freeFunc: ffi_scp_ffi_uniffi_rust_future_free_pointer,
             liftFunc: FfiConverterTypeUcanToken_lift,
+            errorHandler: FfiConverterTypeScpError_lift
+        )
+}
+    
+    /**
+     * Diagnostic, read-only evaluation of a UCAN token.
+     *
+     * Counterpart to [`SCP::ucan_validate`]: runs the same 11-step ADR-016
+     * pipeline via `evaluate_ucan` but returns a structured
+     * [`CapabilityValidationRecord`] (six booleans) instead of failing at the
+     * first error, and never records the token's nonce (read-only probe).
+     *
+     * Routes through `&*self.inner`. Rejects any `ContextHandle` whose
+     * `instance_id` does not match this `SCP`'s.
+     */
+open func ucanEvaluate(handle: ContextHandle, token: String, capability: String, presentingAgentDid: String?, proofTokens: [String]?)async throws  -> CapabilityValidationRecord  {
+    return
+        try  await uniffiRustCallAsync(
+            rustFutureFunc: {
+                uniffi_scp_ffi_uniffi_fn_method_scp_ucan_evaluate(
+                    self.uniffiClonePointer(),
+                    FfiConverterTypeContextHandle_lower(handle),FfiConverterString.lower(token),FfiConverterString.lower(capability),FfiConverterOptionString.lower(presentingAgentDid),FfiConverterOptionSequenceString.lower(proofTokens)
+                )
+            },
+            pollFunc: ffi_scp_ffi_uniffi_rust_future_poll_rust_buffer,
+            completeFunc: ffi_scp_ffi_uniffi_rust_future_complete_rust_buffer,
+            freeFunc: ffi_scp_ffi_uniffi_rust_future_free_rust_buffer,
+            liftFunc: FfiConverterTypeCapabilityValidationRecord_lift,
             errorHandler: FfiConverterTypeScpError_lift
         )
 }
@@ -7461,6 +7693,161 @@ public func FfiConverterTypeBridgeRegistrationResult_lift(_ buf: RustBuffer) thr
 #endif
 public func FfiConverterTypeBridgeRegistrationResult_lower(_ value: BridgeRegistrationResult) -> RustBuffer {
     return FfiConverterTypeBridgeRegistrationResult.lower(value)
+}
+
+
+/**
+ * Structured, side-effect-free result of evaluating a UCAN token.
+ *
+ * Mirrors scp-core's `CapabilityValidation` — the diagnostic counterpart to
+ * the fail-closed `ucan_validate` gate. Each boolean reflects whether the
+ * corresponding pipeline stage ran and passed; the pipeline short-circuits, so
+ * a field is `true` only if its stage AND every prior stage passed.
+ *
+ * Unlike `ucan_validate`, evaluation records NO state (the nonce is probed
+ * read-only, never recorded). See ADR-016.
+ */
+public struct CapabilityValidationRecord {
+    /**
+     * Step 1: the token parsed and its header/attestation set validated.
+     */
+    public var tokensValid: Bool
+    /**
+     * Steps 2-7: signature, delegation chain, root issuer, audience, key
+     * scope, capability grant-match, Category-A enforcement, and attenuation
+     * all passed (whole-chain).
+     */
+    public var signaturesValid: Bool
+    /**
+     * Step 8: every granted capability is within the context's ceiling.
+     */
+    public var withinCeiling: Bool
+    /**
+     * Step 9: nonce format, freshness, and uniqueness passed (probed
+     * read-only — the nonce is NOT recorded).
+     */
+    public var nonceValid: Bool
+    /**
+     * Step 10: the token's revocation CID is not on the revocation list.
+     */
+    public var notRevoked: Bool
+    /**
+     * Step 11: `exp`/`nbf` time bounds are valid (within clock-skew tolerance).
+     */
+    public var timeBoundsValid: Bool
+
+    // Default memberwise initializers are never public by default, so we
+    // declare one manually.
+    public init(
+        /**
+         * Step 1: the token parsed and its header/attestation set validated.
+         */tokensValid: Bool, 
+        /**
+         * Steps 2-7: signature, delegation chain, root issuer, audience, key
+         * scope, capability grant-match, Category-A enforcement, and attenuation
+         * all passed (whole-chain).
+         */signaturesValid: Bool, 
+        /**
+         * Step 8: every granted capability is within the context's ceiling.
+         */withinCeiling: Bool, 
+        /**
+         * Step 9: nonce format, freshness, and uniqueness passed (probed
+         * read-only — the nonce is NOT recorded).
+         */nonceValid: Bool, 
+        /**
+         * Step 10: the token's revocation CID is not on the revocation list.
+         */notRevoked: Bool, 
+        /**
+         * Step 11: `exp`/`nbf` time bounds are valid (within clock-skew tolerance).
+         */timeBoundsValid: Bool) {
+        self.tokensValid = tokensValid
+        self.signaturesValid = signaturesValid
+        self.withinCeiling = withinCeiling
+        self.nonceValid = nonceValid
+        self.notRevoked = notRevoked
+        self.timeBoundsValid = timeBoundsValid
+    }
+}
+
+#if compiler(>=6)
+extension CapabilityValidationRecord: Sendable {}
+#endif
+
+
+extension CapabilityValidationRecord: Equatable, Hashable {
+    public static func ==(lhs: CapabilityValidationRecord, rhs: CapabilityValidationRecord) -> Bool {
+        if lhs.tokensValid != rhs.tokensValid {
+            return false
+        }
+        if lhs.signaturesValid != rhs.signaturesValid {
+            return false
+        }
+        if lhs.withinCeiling != rhs.withinCeiling {
+            return false
+        }
+        if lhs.nonceValid != rhs.nonceValid {
+            return false
+        }
+        if lhs.notRevoked != rhs.notRevoked {
+            return false
+        }
+        if lhs.timeBoundsValid != rhs.timeBoundsValid {
+            return false
+        }
+        return true
+    }
+
+    public func hash(into hasher: inout Hasher) {
+        hasher.combine(tokensValid)
+        hasher.combine(signaturesValid)
+        hasher.combine(withinCeiling)
+        hasher.combine(nonceValid)
+        hasher.combine(notRevoked)
+        hasher.combine(timeBoundsValid)
+    }
+}
+
+
+
+#if swift(>=5.8)
+@_documentation(visibility: private)
+#endif
+public struct FfiConverterTypeCapabilityValidationRecord: FfiConverterRustBuffer {
+    public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> CapabilityValidationRecord {
+        return
+            try CapabilityValidationRecord(
+                tokensValid: FfiConverterBool.read(from: &buf), 
+                signaturesValid: FfiConverterBool.read(from: &buf), 
+                withinCeiling: FfiConverterBool.read(from: &buf), 
+                nonceValid: FfiConverterBool.read(from: &buf), 
+                notRevoked: FfiConverterBool.read(from: &buf), 
+                timeBoundsValid: FfiConverterBool.read(from: &buf)
+        )
+    }
+
+    public static func write(_ value: CapabilityValidationRecord, into buf: inout [UInt8]) {
+        FfiConverterBool.write(value.tokensValid, into: &buf)
+        FfiConverterBool.write(value.signaturesValid, into: &buf)
+        FfiConverterBool.write(value.withinCeiling, into: &buf)
+        FfiConverterBool.write(value.nonceValid, into: &buf)
+        FfiConverterBool.write(value.notRevoked, into: &buf)
+        FfiConverterBool.write(value.timeBoundsValid, into: &buf)
+    }
+}
+
+
+#if swift(>=5.8)
+@_documentation(visibility: private)
+#endif
+public func FfiConverterTypeCapabilityValidationRecord_lift(_ buf: RustBuffer) throws -> CapabilityValidationRecord {
+    return try FfiConverterTypeCapabilityValidationRecord.lift(buf)
+}
+
+#if swift(>=5.8)
+@_documentation(visibility: private)
+#endif
+public func FfiConverterTypeCapabilityValidationRecord_lower(_ value: CapabilityValidationRecord) -> RustBuffer {
+    return FfiConverterTypeCapabilityValidationRecord.lower(value)
 }
 
 
@@ -9729,6 +10116,146 @@ public func FfiConverterTypeReliabilityScoreRecord_lower(_ value: ReliabilitySco
 
 
 /**
+ * The committed terminal of a §6.2.4 cross-context tool-invocation saga
+ * (ADR-049 §3a).
+ *
+ * Returned by [`crate::scp::Scp::tool_invoke_cross_context_saga`] on a
+ * `Committed` terminal. Every NON-committed terminal raises one of the typed
+ * saga errors ([`ScpError::SagaAborted`] / [`ScpError::SagaNeedsRepair`] /
+ * [`ScpError::SagaBusy`]) instead.
+ *
+ * Carries the supervisor-minted `saga_id` plus — for the committed
+ * cross-context invocation — the target's signed receipt and the captured
+ * tool output (spec §6.2.4 "Receipt / response return path"). The `receipt`
+ * is the JCS-canonical `CrossContextToolReceipt` bytes; `output` is the
+ * receipt's canonical `output_jcs` bytes (the exact bytes the caller side
+ * recorded a hash of). Both are surfaced as `bytes` (Swift `Data` / Kotlin
+ * `ByteArray`) so a caller can verify the receipt signature and recompute
+ * `output_hash` without a re-serialization step.
+ *
+ * Generated as `data class SagaResult` (Kotlin) / `struct SagaResult` (Swift).
+ */
+public struct SagaResult {
+    /**
+     * The durable saga identifier (supervisor-minted, never a caller input).
+     */
+    public var sagaId: String
+    /**
+     * The target's signed `CrossContextToolReceipt` bytes (JCS), or `None`.
+     *
+     * The `receipt` is signed by the target context's LOCALLY-RESOLVED Active
+     * Signing Key (the key held by its registered handle on this instance).
+     * The in-saga receipt verification is INTEGRITY-ONLY: it verifies the
+     * signature against the very key the saga FSM handed to side B, NOT an
+     * independent resolution that that key is governance-authorized. A
+     * consumer that re-presents this `receipt` as cross-node provenance
+     * therefore MUST independently resolve that the signing key is the target
+     * context's governance-authorized Active Signing Key — especially once
+     * cross-node child-bridge transport lands, where a co-resident signer is
+     * trusted only within this instance.
+     */
+    public var receipt: Data?
+    /**
+     * The captured tool output bytes (the receipt's canonical `output_jcs`),
+     * or `None`.
+     */
+    public var output: Data?
+
+    // Default memberwise initializers are never public by default, so we
+    // declare one manually.
+    public init(
+        /**
+         * The durable saga identifier (supervisor-minted, never a caller input).
+         */sagaId: String, 
+        /**
+         * The target's signed `CrossContextToolReceipt` bytes (JCS), or `None`.
+         *
+         * The `receipt` is signed by the target context's LOCALLY-RESOLVED Active
+         * Signing Key (the key held by its registered handle on this instance).
+         * The in-saga receipt verification is INTEGRITY-ONLY: it verifies the
+         * signature against the very key the saga FSM handed to side B, NOT an
+         * independent resolution that that key is governance-authorized. A
+         * consumer that re-presents this `receipt` as cross-node provenance
+         * therefore MUST independently resolve that the signing key is the target
+         * context's governance-authorized Active Signing Key — especially once
+         * cross-node child-bridge transport lands, where a co-resident signer is
+         * trusted only within this instance.
+         */receipt: Data?, 
+        /**
+         * The captured tool output bytes (the receipt's canonical `output_jcs`),
+         * or `None`.
+         */output: Data?) {
+        self.sagaId = sagaId
+        self.receipt = receipt
+        self.output = output
+    }
+}
+
+#if compiler(>=6)
+extension SagaResult: Sendable {}
+#endif
+
+
+extension SagaResult: Equatable, Hashable {
+    public static func ==(lhs: SagaResult, rhs: SagaResult) -> Bool {
+        if lhs.sagaId != rhs.sagaId {
+            return false
+        }
+        if lhs.receipt != rhs.receipt {
+            return false
+        }
+        if lhs.output != rhs.output {
+            return false
+        }
+        return true
+    }
+
+    public func hash(into hasher: inout Hasher) {
+        hasher.combine(sagaId)
+        hasher.combine(receipt)
+        hasher.combine(output)
+    }
+}
+
+
+
+#if swift(>=5.8)
+@_documentation(visibility: private)
+#endif
+public struct FfiConverterTypeSagaResult: FfiConverterRustBuffer {
+    public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> SagaResult {
+        return
+            try SagaResult(
+                sagaId: FfiConverterString.read(from: &buf), 
+                receipt: FfiConverterOptionData.read(from: &buf), 
+                output: FfiConverterOptionData.read(from: &buf)
+        )
+    }
+
+    public static func write(_ value: SagaResult, into buf: inout [UInt8]) {
+        FfiConverterString.write(value.sagaId, into: &buf)
+        FfiConverterOptionData.write(value.receipt, into: &buf)
+        FfiConverterOptionData.write(value.output, into: &buf)
+    }
+}
+
+
+#if swift(>=5.8)
+@_documentation(visibility: private)
+#endif
+public func FfiConverterTypeSagaResult_lift(_ buf: RustBuffer) throws -> SagaResult {
+    return try FfiConverterTypeSagaResult.lift(buf)
+}
+
+#if swift(>=5.8)
+@_documentation(visibility: private)
+#endif
+public func FfiConverterTypeSagaResult_lower(_ value: SagaResult) -> RustBuffer {
+    return FfiConverterTypeSagaResult.lower(value)
+}
+
+
+/**
  * Shadow identity result record.
  *
  * Returned by `bridge_create_shadow`. Contains the details of a shadow
@@ -11632,6 +12159,73 @@ public enum ScpError: Swift.Error {
      */
     case Validation(msg: String, code: String
     )
+    /**
+     * A §6.2.4 cross-context tool-invocation saga aborted at a Prepare phase.
+     *
+     * Surfaces the `Aborted` terminal of
+     * `Supervisor::start_cross_context_tool_invocation_saga` (a §6.2.4
+     * authorization / freshness / rate-limit / co-residency rejection — also
+     * the §6.2.4 *Caller authentication* mismatch this bridge enforces before
+     * the saga runs). Carries the rate-limit back-off hint STRUCTURALLY
+     * (`retry_after_ms`): `Some(ms)` is the limiter's computed cooldown;
+     * `None` (NEVER `0`) means no precise back-off instant exists (a
+     * token-bucket hard limit, or a non-rate-limit rejection) — `0` would read
+     * as "retry immediately" and re-trip the same hard limit. `code` is the
+     * canonical `SCP-SAGA-13xxx` string. Maps to Swift `ScpError.SagaAborted`
+     * / Kotlin `ScpException.SagaAborted` (the `msg` field surfaces as the
+     * Swift `msg:` label — the `UniFFI` field-name convention every variant
+     * here follows).
+     */
+    case SagaAborted(
+        /**
+         * Human-readable detail (carries the `[SCP-SAGA-…]` prefix).
+         */msg: String, 
+        /**
+         * The canonical `SCP-SAGA-13xxx` code.
+         */code: String, 
+        /**
+         * Rate-limit back-off hint in milliseconds, or `None` (never `0`).
+         */retryAfterMs: UInt64?
+    )
+    /**
+     * A §6.2.4 saga exhausted its Commit retries and may have diverged.
+     *
+     * Surfaces the `NeedsRepair` terminal (Commit-retry exhausted — the saga
+     * may have PARTIALLY committed, a divergence; ADR-049 §3a). Carries the
+     * durable `saga_id` operator-repair handle (`SCP-SAGA-13065`). Maps to
+     * Swift `ScpError.SagaNeedsRepair` / Kotlin `ScpException.SagaNeedsRepair`.
+     */
+    case SagaNeedsRepair(
+        /**
+         * Human-readable detail (carries the `[SCP-SAGA-…]` prefix).
+         */msg: String, 
+        /**
+         * The canonical `SCP-SAGA-13065` code.
+         */code: String, 
+        /**
+         * The durable saga identifier — the operator-repair handle.
+         */sagaId: String
+    )
+    /**
+     * A §6.2.4 saga's participant context set overlapped an in-flight saga.
+     *
+     * Surfaces the `Busy` terminal (the participant context set overlapped an
+     * in-flight saga's set — spec §5.15.4 per-participant-context-set gating;
+     * retry with back-off). Carries the contended context id
+     * (`SCP-SAGA-13066`). Maps to Swift `ScpError.SagaBusy` / Kotlin
+     * `ScpException.SagaBusy`.
+     */
+    case SagaBusy(
+        /**
+         * Human-readable detail (carries the `[SCP-SAGA-…]` prefix).
+         */msg: String, 
+        /**
+         * The canonical `SCP-SAGA-13066` code.
+         */code: String, 
+        /**
+         * The shared context id that forced serialization.
+         */contendedContext: String
+    )
 }
 
 
@@ -11675,6 +12269,21 @@ public struct FfiConverterTypeScpError: FfiConverterRustBuffer {
         case 7: return .Validation(
             msg: try FfiConverterString.read(from: &buf), 
             code: try FfiConverterString.read(from: &buf)
+            )
+        case 8: return .SagaAborted(
+            msg: try FfiConverterString.read(from: &buf), 
+            code: try FfiConverterString.read(from: &buf), 
+            retryAfterMs: try FfiConverterOptionUInt64.read(from: &buf)
+            )
+        case 9: return .SagaNeedsRepair(
+            msg: try FfiConverterString.read(from: &buf), 
+            code: try FfiConverterString.read(from: &buf), 
+            sagaId: try FfiConverterString.read(from: &buf)
+            )
+        case 10: return .SagaBusy(
+            msg: try FfiConverterString.read(from: &buf), 
+            code: try FfiConverterString.read(from: &buf), 
+            contendedContext: try FfiConverterString.read(from: &buf)
             )
 
          default: throw UniffiInternalError.unexpectedEnumCase
@@ -11728,6 +12337,27 @@ public struct FfiConverterTypeScpError: FfiConverterRustBuffer {
             writeInt(&buf, Int32(7))
             FfiConverterString.write(msg, into: &buf)
             FfiConverterString.write(code, into: &buf)
+            
+        
+        case let .SagaAborted(msg,code,retryAfterMs):
+            writeInt(&buf, Int32(8))
+            FfiConverterString.write(msg, into: &buf)
+            FfiConverterString.write(code, into: &buf)
+            FfiConverterOptionUInt64.write(retryAfterMs, into: &buf)
+            
+        
+        case let .SagaNeedsRepair(msg,code,sagaId):
+            writeInt(&buf, Int32(9))
+            FfiConverterString.write(msg, into: &buf)
+            FfiConverterString.write(code, into: &buf)
+            FfiConverterString.write(sagaId, into: &buf)
+            
+        
+        case let .SagaBusy(msg,code,contendedContext):
+            writeInt(&buf, Int32(10))
+            FfiConverterString.write(msg, into: &buf)
+            FfiConverterString.write(code, into: &buf)
+            FfiConverterString.write(contendedContext, into: &buf)
             
         }
     }
@@ -15511,7 +16141,7 @@ private let initializationResult: InitializationResult = {
     if (uniffi_scp_ffi_uniffi_checksum_method_scp_event_log_checkpoint() != 31004) {
         return InitializationResult.apiChecksumMismatch
     }
-    if (uniffi_scp_ffi_uniffi_checksum_method_scp_event_log_checkpoint_by_did() != 25225) {
+    if (uniffi_scp_ffi_uniffi_checksum_method_scp_event_log_checkpoint_by_did() != 22488) {
         return InitializationResult.apiChecksumMismatch
     }
     if (uniffi_scp_ffi_uniffi_checksum_method_scp_event_log_query() != 26119) {
@@ -15688,13 +16318,13 @@ private let initializationResult: InitializationResult = {
     if (uniffi_scp_ffi_uniffi_checksum_method_scp_relay_start_local() != 7556) {
         return InitializationResult.apiChecksumMismatch
     }
-    if (uniffi_scp_ffi_uniffi_checksum_method_scp_restore_all_contexts() != 43499) {
+    if (uniffi_scp_ffi_uniffi_checksum_method_scp_restore_all_contexts() != 32770) {
         return InitializationResult.apiChecksumMismatch
     }
     if (uniffi_scp_ffi_uniffi_checksum_method_scp_restore_context() != 6223) {
         return InitializationResult.apiChecksumMismatch
     }
-    if (uniffi_scp_ffi_uniffi_checksum_method_scp_resume() != 24128) {
+    if (uniffi_scp_ffi_uniffi_checksum_method_scp_resume() != 42440) {
         return InitializationResult.apiChecksumMismatch
     }
     if (uniffi_scp_ffi_uniffi_checksum_method_scp_scope_deregister() != 49133) {
@@ -15739,6 +16369,9 @@ private let initializationResult: InitializationResult = {
     if (uniffi_scp_ffi_uniffi_checksum_method_scp_tool_invoke_cross_context() != 47346) {
         return InitializationResult.apiChecksumMismatch
     }
+    if (uniffi_scp_ffi_uniffi_checksum_method_scp_tool_invoke_cross_context_saga() != 59585) {
+        return InitializationResult.apiChecksumMismatch
+    }
     if (uniffi_scp_ffi_uniffi_checksum_method_scp_tool_register() != 65327) {
         return InitializationResult.apiChecksumMismatch
     }
@@ -15760,7 +16393,7 @@ private let initializationResult: InitializationResult = {
     if (uniffi_scp_ffi_uniffi_checksum_method_scp_transport_disconnect() != 45973) {
         return InitializationResult.apiChecksumMismatch
     }
-    if (uniffi_scp_ffi_uniffi_checksum_method_scp_transport_manager_status() != 45644) {
+    if (uniffi_scp_ffi_uniffi_checksum_method_scp_transport_manager_status() != 44390) {
         return InitializationResult.apiChecksumMismatch
     }
     if (uniffi_scp_ffi_uniffi_checksum_method_scp_transport_status() != 20055) {
@@ -15773,6 +16406,9 @@ private let initializationResult: InitializationResult = {
         return InitializationResult.apiChecksumMismatch
     }
     if (uniffi_scp_ffi_uniffi_checksum_method_scp_ucan_delegate() != 51192) {
+        return InitializationResult.apiChecksumMismatch
+    }
+    if (uniffi_scp_ffi_uniffi_checksum_method_scp_ucan_evaluate() != 64259) {
         return InitializationResult.apiChecksumMismatch
     }
     if (uniffi_scp_ffi_uniffi_checksum_method_scp_ucan_mint() != 2465) {

--- a/bindings/swift/Sources/SCP/Scp.swift
+++ b/bindings/swift/Sources/SCP/Scp.swift
@@ -1044,6 +1044,14 @@ public extension SCP {
         try await inner.toolInvokeCrossContext(sourceHandle: sourceHandle, targetHandle: targetHandle, toolId: toolId, inputJson: inputJson, identity: identity, ucanToken: ucanToken, chainDepth: chainDepth, proofTokens: proofTokens)
     }
 
+    // swiftlint:disable function_parameter_count
+    /// Forwards to ``Scp/toolInvokeCrossContextSaga`` on ``inner``.
+    func toolInvokeCrossContextSaga(sourceHandle: ContextHandle, targetHandle: ContextHandle, callerDid: String, toolRegistrationId: String, inputJson: String, assertedNonceHex: String, timestampMs: UInt64, chainDepth: UInt8, ucanProofId: String?) async throws -> SagaResult {
+        try await inner.toolInvokeCrossContextSaga(sourceHandle: sourceHandle, targetHandle: targetHandle, callerDid: callerDid, toolRegistrationId: toolRegistrationId, inputJson: inputJson, assertedNonceHex: assertedNonceHex, timestampMs: timestampMs, chainDepth: chainDepth, ucanProofId: ucanProofId)
+    }
+
+    // swiftlint:enable function_parameter_count
+
     /// Forwards to ``Scp/toolRegister`` on ``inner``.
     func toolRegister(handle: ContextHandle, definition: ToolDefinition) async throws -> String {
         try await inner.toolRegister(handle: handle, definition: definition)

--- a/bindings/swift/Sources/SCP/Tools.swift
+++ b/bindings/swift/Sources/SCP/Tools.swift
@@ -286,7 +286,9 @@ public extension Context {
     ///     authenticated FFI identity by the bridge).
     ///   - toolRegistrationId: The target tool's registration id.
     ///   - input: The tool input as serialized JSON data.
-    ///   - assertedNonceHex: The caller-asserted freshness nonce (hex).
+    ///   - assertedNonceHex: The caller-asserted freshness nonce, as 32 hex
+    ///     characters (16 bytes); the bridge rejects other lengths with a
+    ///     `Validation` error.
     ///   - timestampMs: The caller-asserted freshness timestamp
     ///     (milliseconds since epoch).
     ///   - chainDepth: The caller-asserted inbound chain depth (0 for a
@@ -301,6 +303,8 @@ public extension Context {
     ///   terminal; ``ScpError/Context(msg:code:)`` (`SCP-CTX-2001`) if the
     ///   source context is not active; ``ScpError/Tool(msg:code:)``
     ///   (`SCP-TOOL-6001`) if the input is not valid UTF-8;
+    ///   ``ScpError/Tool(msg:code:)`` (`SCP-TOOL-6002`, propagated from the
+    ///   bridge) if `input` is valid UTF-8 but not valid JSON;
     ///   ``ScpError/Validation(msg:code:)`` (propagated from the bridge) if
     ///   `assertedNonceHex` is not 16-byte hex, or `callerDid` /
     ///   `toolRegistrationId` is malformed; ``ScpError/Permission(msg:code:)``

--- a/bindings/swift/Sources/SCP/Tools.swift
+++ b/bindings/swift/Sources/SCP/Tools.swift
@@ -300,7 +300,12 @@ public extension Context {
     ///   ``ScpError/SagaBusy(msg:code:contendedContext:)`` on a non-committed
     ///   terminal; ``ScpError/Context(msg:code:)`` (`SCP-CTX-2001`) if the
     ///   source context is not active; ``ScpError/Tool(msg:code:)``
-    ///   (`SCP-TOOL-6001`) if the input is not valid UTF-8.
+    ///   (`SCP-TOOL-6001`) if the input is not valid UTF-8;
+    ///   ``ScpError/Validation(msg:code:)`` (propagated from the bridge) if
+    ///   `assertedNonceHex` is not 16-byte hex, or `callerDid` /
+    ///   `toolRegistrationId` is malformed; ``ScpError/Permission(msg:code:)``
+    ///   (`SCP-PERM-3030`, propagated from the bridge) if `targetContext` is a
+    ///   foreign / cross-instance handle.
     ///
     /// ## Provenance
     ///

--- a/bindings/swift/Sources/SCP/Tools.swift
+++ b/bindings/swift/Sources/SCP/Tools.swift
@@ -254,6 +254,94 @@ public extension Context {
         )
     }
 
+    /// Runs the §6.2.4 atomic cross-context tool-invocation saga.
+    ///
+    /// Delegates to the UniFFI ``toolInvokeCrossContextSaga`` bridge function.
+    /// Unlike ``invokeToolCrossContext(_:input:identity:targetContext:ucanToken:chainDepth:proofTokens:invokerDid:)``
+    /// (a single synchronous cross-context call), this drives the durable
+    /// two-phase saga to a terminal: the call blocks until the saga either
+    /// commits — resolving to a ``SagaResult`` carrying the supervisor-minted
+    /// ``SagaResult/sagaId`` plus the target's signed receipt and captured
+    /// output bytes — or reaches a typed terminal, surfaced directly as one of
+    /// the generated ``ScpError`` saga cases:
+    ///
+    /// - ``ScpError/SagaAborted(msg:code:retryAfterMs:)`` — a Prepare-phase
+    ///   rejection; `retryAfterMs` is the limiter's computed back-off, or `nil`
+    ///   (never `0`) when no precise back-off instant exists.
+    /// - ``ScpError/SagaNeedsRepair(msg:code:sagaId:)`` — Commit retries
+    ///   exhausted (a possible divergence); carries the durable `sagaId`
+    ///   operator-repair handle.
+    /// - ``ScpError/SagaBusy(msg:code:contendedContext:)`` — the participant
+    ///   context set overlapped an in-flight saga; carries the contended
+    ///   context id (retry with back-off).
+    ///
+    /// The `chainDepth` (`UInt8`) and `timestampMs` (`UInt64`) parameters
+    /// cannot encode an out-of-range or negative value, so no manual range
+    /// validation is performed — Swift's type system enforces the bridge's
+    /// `u8` / `u64` boundaries by construction.
+    ///
+    /// - Parameters:
+    ///   - targetContext: The ``Context`` hosting the target tool.
+    ///   - callerDid: The DID of the invoking principal (bound to the
+    ///     authenticated FFI identity by the bridge).
+    ///   - toolRegistrationId: The target tool's registration id.
+    ///   - input: The tool input as serialized JSON data.
+    ///   - assertedNonceHex: The caller-asserted freshness nonce (hex).
+    ///   - timestampMs: The caller-asserted freshness timestamp
+    ///     (milliseconds since epoch).
+    ///   - chainDepth: The caller-asserted inbound chain depth (0 for a
+    ///     direct invocation).
+    ///   - ucanProofId: Optional UCAN proof id authorizing the invocation.
+    /// - Returns: A ``SagaResult`` on a committed terminal — a faithful
+    ///   pass-through of the bridge result (`receipt` / `output` are surfaced
+    ///   exactly as returned, `nil` when absent, never synthesized).
+    /// - Throws: ``ScpError/SagaAborted(msg:code:retryAfterMs:)``,
+    ///   ``ScpError/SagaNeedsRepair(msg:code:sagaId:)``, or
+    ///   ``ScpError/SagaBusy(msg:code:contendedContext:)`` on a non-committed
+    ///   terminal; ``ScpError/Context(msg:code:)`` (`SCP-CTX-2001`) if the
+    ///   source context is not active; ``ScpError/Tool(msg:code:)``
+    ///   (`SCP-TOOL-6001`) if the input is not valid UTF-8.
+    ///
+    /// ## Provenance
+    ///
+    /// - Spec section 6.2.4 (Cross-Context Tool Invocation Saga)
+    /// - ADR-049 §3a (per-participant-context-set saga gating)
+    func invokeToolCrossContextSaga(
+        targetContext: Context,
+        callerDid: String,
+        toolRegistrationId: String,
+        input: Data,
+        assertedNonceHex: String,
+        timestampMs: UInt64,
+        chainDepth: UInt8,
+        ucanProofId: String? = nil
+    ) async throws -> SagaResult {
+        guard state == .active else {
+            throw ScpError.Context(
+                msg: "Source context is not active",
+                code: "SCP-CTX-2001"
+            )
+        }
+        guard let inputJson = String(data: input, encoding: .utf8) else {
+            throw ScpError.Tool(
+                msg: "Tool input is not valid UTF-8",
+                code: "SCP-TOOL-6001"
+            )
+        }
+        let targetHandle = targetContext.handle
+        return try await scp.toolInvokeCrossContextSaga(
+            sourceHandle: handle,
+            targetHandle: targetHandle,
+            callerDid: callerDid,
+            toolRegistrationId: toolRegistrationId,
+            inputJson: inputJson,
+            assertedNonceHex: assertedNonceHex,
+            timestampMs: timestampMs,
+            chainDepth: chainDepth,
+            ucanProofId: ucanProofId
+        )
+    }
+
     /// Creates a stateful tool session for repeated invocations.
     ///
     /// Delegates to the UniFFI ``toolSessionCreate`` bridge function.

--- a/bindings/swift/Tests/SCPTests/ToolSagaTests.swift
+++ b/bindings/swift/Tests/SCPTests/ToolSagaTests.swift
@@ -1,0 +1,272 @@
+@testable import SCP
+import XCTest
+
+/// Tests for the §6.2.4 cross-context tool-invocation saga SDK wrapper
+/// (`Context.invokeToolCrossContextSaga`, PR-6c slice 3/4, #1939).
+///
+/// The Swift SDK surfaces the generated UniFFI types directly: the saga
+/// terminal is the generated `SagaResult` (faithful nullable), and the
+/// non-committed terminals are the generated `ScpError.Saga*` cases. Unlike
+/// the Python/TS SDKs (which wrap untyped bridge errors into dedicated SDK
+/// classes), there is no re-mapping layer here — the wrapper just
+/// `async throws` and the typed error propagates. These tests therefore
+/// exercise:
+///   - the public type surface (SagaResult faithful pass-through incl. nil;
+///     the three typed ScpError.Saga* cases carrying their fields), and
+///   - the wrapper-layer guards that mirror the sibling
+///     `invokeToolCrossContext` (source-active + UTF-8 input), and
+///   - end-to-end argument forwarding through the real UniFFI bridge.
+///
+/// The suite links the Rust binary built with `allow_in_memory_custody`, so
+/// contexts and tool registration run against the real engine.
+final class ToolSagaTests: XCTestCase {
+    // Implicitly unwrapped because XCTest `setUp` initializes it before any
+    // test method runs — the XCTest lifecycle guarantees non-nil.
+    // swiftlint:disable:next implicitly_unwrapped_optional
+    var scp: SCP!
+
+    override func setUpWithError() throws {
+        try super.setUpWithError()
+        scp = try SCP(storage: .inMemory)
+    }
+
+    override func tearDown() async throws {
+        try await scp.shutdown(timeoutMillis: 1000)
+        scp = nil
+        try await super.tearDown()
+    }
+
+    // MARK: - Helpers
+
+    private func makeParams() -> ContextParams {
+        ContextParams(
+            mode: .encrypted,
+            ceiling: ["messages:read", "messages:write", "tool:invoke:*", "tool:register", "context:close"],
+            ceilingPolicy: .immutable,
+            governance: .singleAdmin,
+            memoryScope: .ephemeral,
+            ttlSeconds: 3600,
+            promotable: false,
+            minProtocolVersion: 0,
+            maxChainDepth: nil,
+            maxNestingDepth: nil,
+            sessionCap: nil,
+            economicPolicy: nil,
+            consequenceRulesJson: nil,
+            consequenceConfigJson: nil
+        )
+    }
+
+    private func makeContext(identity: Identity) async throws -> Context {
+        try await Context.create(scp: scp, identity: identity, params: makeParams())
+    }
+
+    /// 64 hex chars = 32 bytes — a well-formed asserted-nonce input.
+    private let nonceHex = String(repeating: "ab", count: 32)
+
+    private func nowMs() -> UInt64 {
+        UInt64(Date().timeIntervalSince1970 * 1000)
+    }
+
+    // MARK: - SagaResult (D3: faithful nullable pass-through)
+
+    /// A committed terminal carries the supervisor-minted `sagaId` plus the
+    /// signed receipt and captured output bytes verbatim.
+    func testSagaResultCarriesReceiptAndOutput() {
+        let receipt = Data([0x01, 0x02, 0x03])
+        let output = Data([0x04, 0x05])
+        let result = SagaResult(sagaId: "saga-1", receipt: receipt, output: output)
+
+        XCTAssertEqual(result.sagaId, "saga-1")
+        XCTAssertEqual(result.receipt, receipt)
+        XCTAssertEqual(result.output, output)
+    }
+
+    /// `receipt` and `output` are surfaced exactly as the bridge returns them
+    /// — `nil` when absent, never synthesized.
+    func testSagaResultPassesThroughNilReceiptAndOutput() {
+        let result = SagaResult(sagaId: "saga-2", receipt: nil, output: nil)
+
+        XCTAssertEqual(result.sagaId, "saga-2")
+        XCTAssertNil(result.receipt)
+        XCTAssertNil(result.output)
+    }
+
+    // MARK: - Typed terminals (D2: ScpError.Saga* surfaced directly)
+
+    /// `SagaAborted` carries `msg`, `code`, and the rate-limit back-off hint
+    /// `retryAfterMs` — a concrete cooldown when one exists.
+    func testSagaAbortedCarriesRetryAfter() {
+        let error = ScpError.SagaAborted(
+            msg: "[SCP-SAGA-13001] prepare rejected",
+            code: "SCP-SAGA-13001",
+            retryAfterMs: 1500
+        )
+        guard case let ScpError.SagaAborted(msg, code, retryAfterMs) = error else {
+            XCTFail("expected ScpError.SagaAborted, got \(error)")
+            return
+        }
+        XCTAssertEqual(msg, "[SCP-SAGA-13001] prepare rejected")
+        XCTAssertEqual(code, "SCP-SAGA-13001")
+        XCTAssertEqual(retryAfterMs, 1500)
+    }
+
+    /// `retryAfterMs` is `nil` (never `0`) when no precise back-off instant
+    /// exists — `0` would read as "retry immediately" and re-trip the limit.
+    func testSagaAbortedPreservesNilRetryAfter() {
+        let error = ScpError.SagaAborted(
+            msg: "[SCP-SAGA-13002] hard limit",
+            code: "SCP-SAGA-13002",
+            retryAfterMs: nil
+        )
+        guard case let ScpError.SagaAborted(_, _, retryAfterMs) = error else {
+            XCTFail("expected ScpError.SagaAborted, got \(error)")
+            return
+        }
+        XCTAssertNil(retryAfterMs)
+    }
+
+    /// `SagaNeedsRepair` carries the durable `sagaId` operator-repair handle.
+    func testSagaNeedsRepairCarriesSagaId() {
+        let error = ScpError.SagaNeedsRepair(
+            msg: "[SCP-SAGA-13065] commit retries exhausted",
+            code: "SCP-SAGA-13065",
+            sagaId: "saga-repair-7"
+        )
+        guard case let ScpError.SagaNeedsRepair(msg, code, sagaId) = error else {
+            XCTFail("expected ScpError.SagaNeedsRepair, got \(error)")
+            return
+        }
+        XCTAssertEqual(msg, "[SCP-SAGA-13065] commit retries exhausted")
+        XCTAssertEqual(code, "SCP-SAGA-13065")
+        XCTAssertEqual(sagaId, "saga-repair-7")
+    }
+
+    /// `SagaBusy` carries the contended context id that forced serialization.
+    func testSagaBusyCarriesContendedContext() {
+        let error = ScpError.SagaBusy(
+            msg: "[SCP-SAGA-13066] participant set overlap",
+            code: "SCP-SAGA-13066",
+            contendedContext: "ctx-shared-42"
+        )
+        guard case let ScpError.SagaBusy(msg, code, contendedContext) = error else {
+            XCTFail("expected ScpError.SagaBusy, got \(error)")
+            return
+        }
+        XCTAssertEqual(msg, "[SCP-SAGA-13066] participant set overlap")
+        XCTAssertEqual(code, "SCP-SAGA-13066")
+        XCTAssertEqual(contendedContext, "ctx-shared-42")
+    }
+
+    // MARK: - Wrapper guards (mirror the sibling invokeToolCrossContext)
+
+    /// A non-active source context is rejected before any bridge call with
+    /// `ScpError.Context` `SCP-CTX-2001`.
+    func testSagaRejectsInactiveSourceContext() async throws {
+        let identity = try await scp.identityCreate(custody: "in_memory")
+        let source = try await makeContext(identity: identity)
+        let target = try await makeContext(identity: identity)
+
+        try await source.close()
+
+        do {
+            // The source-active guard fires before the registration id is ever
+            // used, so a placeholder id is sufficient to exercise it.
+            _ = try await source.invokeToolCrossContextSaga(
+                targetContext: target,
+                callerDid: identity.did(),
+                toolRegistrationId: "placeholder-registration-id",
+                input: Data(#"{"city":"Berlin"}"#.utf8),
+                assertedNonceHex: nonceHex,
+                timestampMs: nowMs(),
+                chainDepth: 0
+            )
+            XCTFail("expected ScpError.Context for an inactive source context")
+        } catch let ScpError.Context(_, code) {
+            XCTAssertEqual(code, "SCP-CTX-2001")
+        }
+    }
+
+    /// Non-UTF-8 input is rejected at the wrapper boundary with
+    /// `ScpError.Tool` `SCP-TOOL-6001` (mirrors the sibling's UTF-8 guard).
+    func testSagaRejectsNonUtf8Input() async throws {
+        let identity = try await scp.identityCreate(custody: "in_memory")
+        let source = try await makeContext(identity: identity)
+        let target = try await makeContext(identity: identity)
+
+        // 0xFF is never a valid UTF-8 byte.
+        let badInput = Data([0xFF, 0xFE, 0xFD])
+
+        do {
+            // The UTF-8 guard fires before the registration id is used.
+            _ = try await source.invokeToolCrossContextSaga(
+                targetContext: target,
+                callerDid: identity.did(),
+                toolRegistrationId: "placeholder-registration-id",
+                input: badInput,
+                assertedNonceHex: nonceHex,
+                timestampMs: nowMs(),
+                chainDepth: 0
+            )
+            XCTFail("expected ScpError.Tool for non-UTF-8 input")
+        } catch let ScpError.Tool(_, code) {
+            XCTAssertEqual(code, "SCP-TOOL-6001")
+        }
+    }
+
+    // MARK: - End-to-end argument forwarding
+
+    /// With an active source and target, the wrapper forwards all arguments
+    /// past both guards into the real saga. Without bidirectional consent the
+    /// supervisor reaches a non-committed terminal, so the call surfaces a
+    /// typed `ScpError` — never the wrapper-layer guard codes. That proves the
+    /// nine arguments (both handles, `callerDid`, `toolRegistrationId`,
+    /// `inputJson`, nonce, timestamp, depth, optional proof) reach the bridge.
+    func testSagaForwardsArgumentsToBridge() async throws {
+        try scp.configureLocalTransport(localDid: "did:key:z6MkSwiftSagaForwardTest")
+        let identity = try await scp.identityCreate(custody: "in_memory")
+        let source = try await makeContext(identity: identity)
+        let target = try await makeContext(identity: identity)
+        let toolId = try await target.registerTool(weatherTool(operatorDid: identity.did()))
+
+        do {
+            let result = try await source.invokeToolCrossContextSaga(
+                targetContext: target,
+                callerDid: identity.did(),
+                toolRegistrationId: toolId,
+                input: Data(#"{"city":"Berlin","unit":"C"}"#.utf8),
+                assertedNonceHex: nonceHex,
+                timestampMs: nowMs(),
+                chainDepth: 0,
+                ucanProofId: nil
+            )
+            // A committed terminal (unlikely without consent setup) is still a
+            // valid forwarding outcome: the bridge produced a SagaResult.
+            XCTAssertFalse(result.sagaId.isEmpty, "committed saga must carry a sagaId")
+        } catch let ScpError.Context(_, code) {
+            XCTAssertNotEqual(code, "SCP-CTX-2001", "must forward past the source-active guard")
+        } catch let ScpError.Tool(_, code) {
+            XCTAssertNotEqual(code, "SCP-TOOL-6001", "must forward past the UTF-8 guard")
+        } catch {
+            // Any other ScpError (e.g. a typed Saga* terminal or a
+            // supervisor-side rejection) means the call reached the real
+            // bridge — the wrapper forwarded successfully.
+            XCTAssertTrue(error is ScpError, "expected a typed ScpError from the bridge, got \(error)")
+        }
+    }
+
+    // MARK: - Fixtures
+
+    private func weatherTool(operatorDid: String) -> ToolDefinition {
+        ToolDefinition(
+            name: "weather",
+            description: "Get current weather for a city",
+            inputSchemaJson: #"{"type":"object","properties":{"city":{"type":"string"},"unit":{"type":"string"}},"required":["city"]}"#,
+            outputSchemaJson: #"{"type":"object","properties":{"tempC":{"type":"number"},"condition":{"type":"string"}}}"#,
+            operatorDid: operatorDid,
+            testVectorsJson: "[]",
+            implementationHash: nil,
+            cost: nil
+        )
+    }
+}

--- a/bindings/swift/Tests/SCPTests/ToolSagaTests.swift
+++ b/bindings/swift/Tests/SCPTests/ToolSagaTests.swift
@@ -61,8 +61,8 @@ final class ToolSagaTests: XCTestCase {
         try await Context.create(scp: scp, identity: identity, params: makeParams())
     }
 
-    /// 64 hex chars = 32 bytes — a well-formed asserted-nonce input.
-    private let nonceHex = String(repeating: "ab", count: 32)
+    /// 32 hex chars = 16 bytes — a well-formed §6.2.4 asserted-nonce input.
+    private let nonceHex = String(repeating: "ab", count: 16)
 
     private func nowMs() -> UInt64 {
         UInt64(Date().timeIntervalSince1970 * 1000)

--- a/bindings/swift/Tests/SCPTests/ToolSagaTests.swift
+++ b/bindings/swift/Tests/SCPTests/ToolSagaTests.swift
@@ -222,6 +222,13 @@ final class ToolSagaTests: XCTestCase {
     /// typed `ScpError` — never the wrapper-layer guard codes. That proves the
     /// nine arguments (both handles, `callerDid`, `toolRegistrationId`,
     /// `inputJson`, nonce, timestamp, depth, optional proof) reach the bridge.
+    ///
+    /// This is a bridge-linkage smoke test: it confirms the call reaches the
+    /// real bridge past both wrapper guards, but does not assert per-argument
+    /// positional fidelity (a same-typed swap, e.g. `callerDid` ↔
+    /// `toolRegistrationId`, would not be caught here — that assurance lives in
+    /// the Rust/integration tests, since asserting it at this wrapper unit
+    /// layer would require committed-saga bidirectional-consent setup).
     func testSagaForwardsArgumentsToBridge() async throws {
         try scp.configureLocalTransport(localDid: "did:key:z6MkSwiftSagaForwardTest")
         let identity = try await scp.identityCreate(custody: "in_memory")

--- a/bindings/swift/Tests/SCPTests/ToolSagaTests.swift
+++ b/bindings/swift/Tests/SCPTests/ToolSagaTests.swift
@@ -2,7 +2,7 @@
 import XCTest
 
 /// Tests for the §6.2.4 cross-context tool-invocation saga SDK wrapper
-/// (`Context.invokeToolCrossContextSaga`, PR-6c slice 3/4, #1939).
+/// (`Context.invokeToolCrossContextSaga`, PR-6c slice 3/4).
 ///
 /// The Swift SDK surfaces the generated UniFFI types directly: the saga
 /// terminal is the generated `SagaResult` (faithful nullable), and the


### PR DESCRIPTION
## PR-6c slice 3/4 — Swift SDK wrapper for the §6.2.4 cross-context tool-invocation saga

Adds the Swift SDK wrapper over the merged UniFFI `tool_invoke_cross_context_saga` bridge export (PR-6b), flipping the `swift` cell of `(Tools, invoke_cross_context_saga)` to `true` in the capability matrix.

Refs #1939 (the PR-6c SDK-wrapper umbrella stays open — Kotlin slice 4/4 remains).

### What this adds
- **`Context.invokeToolCrossContextSaga(targetContext:callerDid:toolRegistrationId:input:assertedNonceHex:timestampMs:chainDepth:ucanProofId:) async throws -> SagaResult`** (`Tools.swift`) — the public idiomatic wrapper, plus an `SCP.toolInvokeCrossContextSaga` forwarding shim (`Scp.swift`).
- Mirrors the sibling `invokeToolCrossContext` exactly: source-context-active guard (`SCP-CTX-2001`) and UTF-8 input guard (`SCP-TOOL-6001`), both fail-safe before dispatch.
- **Surfaces the generated typed `ScpError.Saga*` cases directly** — `SagaAborted(retryAfterMs:)`, `SagaNeedsRepair(sagaId:)`, `SagaBusy(contendedContext:)` — with no re-mapping. UniFFI hands back faithful typed errors, so (unlike the Python/TS wrappers, which must reconstruct from untyped bridge errors) the wrapper just `async throws` and lets them propagate.
- **No manual range validation** — `chainDepth: UInt8` / `timestampMs: UInt64` make out-of-range/negative values unrepresentable by construction. This is the correct per-SDK idiom replacement for the Python/TS `SCP-VALID-7002` runtime checks (which exist only because those languages lack bounded integer types).
- Faithful `SagaResult` pass-through (`sagaId`, `receipt: Data?`, `output: Data?`) — `nil` preserved, never synthesized; `sagaId` is supervisor-minted (no caller-supplied saga-id parameter).

### Generated-binding catch-up (note for review)
The committed `ScpBindings.swift` had drifted from the current bridge surface, so this PR commits a **faithful `uniffi-bindgen` regeneration**. Besides the saga op + `SagaResult` + the three `ScpError.Saga*` cases, the regen also brings in the already-merged `ucan_evaluate`/`CapabilityValidationRecord` binding the stale file was missing (plus incidental checksum updates for four already-merged methods). A generated artifact must match the live bridge — hand-stripping would diverge from generator output. The `ucan_evaluate` **idiomatic SDK wrapper is intentionally NOT added** here (it stays deferred to the C3c SDK-parity follow-up); its capability-matrix exemption is left unchanged.

### Tests
`ToolSagaTests.swift` (9 tests, linking the real Rust engine): faithful `SagaResult` pass-through incl. `nil`; all three typed terminals with their fields (incl. `retryAfterMs == nil` never `0`); both wrapper guards (`SCP-CTX-2001` / `SCP-TOOL-6001`) exercised against the real engine; and an end-to-end bridge-linkage forwarding test (valid 16-byte nonce) that reaches the real saga past both guards.

### Review
Double-zero reviewed (two consecutive fully-clean full-roster passes): sdk-coverage, api-design, alignment, completionist, security, bug-catcher (mutation-tested), test-quality (mutation-tested — both wrapper guards proven load-bearing). `check-sdk-coverage.py` PASS; `swift build` / `swift test` (9/9) / `swiftformat --lint` / `swiftlint --strict` all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
