### PR TITLE
feat(kotlin): SDK wrapper for tool_invoke_cross_context_saga (PR-6c slice 4/4)

### DIFF
--- a/.docs/standards/sdk-capability-matrix.json
+++ b/.docs/standards/sdk-capability-matrix.json
@@ -586,12 +586,9 @@
           "name": "invoke_cross_context_saga",
           "python": true,
           "typescript": true,
-          "kotlin": false,
+          "kotlin": true,
           "swift": true,
-          "notes": "The §6.2.4 atomic cross-context tool-invocation saga (ADR-049 §3a). Exported by all three native bridges — PyO3 tool_invoke_cross_context_saga, UniFFI tool_invoke_cross_context_saga, NAPI toolInvokeCrossContextSaga (js_name); see scripts/bridge-aliases.json (category tools). Each export binds the caller principal to the authenticated FFI identity (enforce_caller_principal_binding) before dispatching to Supervisor::start_cross_context_tool_invocation_saga, pinned by the pyo3/napi/uniffi saga-export assertions in pipeline_wiring.rs. The Python (SCP.tool_invoke_cross_context_saga), TypeScript (SCP.toolInvokeCrossContextSaga), and Swift (Context.invokeToolCrossContextSaga) SDK wrappers are live; the remaining Kotlin wrapper is tracked by #1939 (the PR-6c SDK-wrapper slice).",
-          "exemptions": {
-            "kotlin": "UniFFI bridge exports tool_invoke_cross_context_saga; the named public Kotlin SDK wrapper is tracked by #1939 (PR-6c SDK-wrapper slice, §6.2.4 / ADR-049 §3a)."
-          }
+          "notes": "The §6.2.4 atomic cross-context tool-invocation saga (ADR-049 §3a). Exported by all three native bridges — PyO3 tool_invoke_cross_context_saga, UniFFI tool_invoke_cross_context_saga, NAPI toolInvokeCrossContextSaga (js_name); see scripts/bridge-aliases.json (category tools). Each export binds the caller principal to the authenticated FFI identity (enforce_caller_principal_binding) before dispatching to Supervisor::start_cross_context_tool_invocation_saga, pinned by the pyo3/napi/uniffi saga-export assertions in pipeline_wiring.rs. All four SDK wrappers are live: Python (SCP.tool_invoke_cross_context_saga), TypeScript (SCP.toolInvokeCrossContextSaga), Swift (Context.invokeToolCrossContextSaga), and Kotlin (SCP.toolInvokeCrossContextSaga / ToolBridge.invokeCrossContextSaga)."
         },
         {
           "name": "session_create",

--- a/bindings/kotlin/scp-kt-android/src/test/kotlin/works/limn/scp/android/ScpViewModelTest.kt
+++ b/bindings/kotlin/scp-kt-android/src/test/kotlin/works/limn/scp/android/ScpViewModelTest.kt
@@ -275,6 +275,18 @@ private class TestNativeBindings : NativeBindings {
         chainDepth: Int,
         proofTokens: List<String>?,
     ): String = ""
+    @Suppress("LongParameterList")
+    override fun toolInvokeCrossContextSaga(
+        sourceContextHandle: Long,
+        targetContextHandle: Long,
+        callerDid: String,
+        toolRegistrationId: String,
+        inputJson: String,
+        assertedNonceHex: String,
+        timestampMs: Long,
+        chainDepth: Int,
+        ucanProofId: String?,
+    ): String = ""
     override fun toolVerify(contextHandle: Long, toolId: String): String =
         """{"tool_id":"$toolId","passed":false,"failures":[]}"""
     override fun toolInterfaceExpose(

--- a/bindings/kotlin/scp-kt/src/main/kotlin/works/limn/scp/Scp.kt
+++ b/bindings/kotlin/scp-kt/src/main/kotlin/works/limn/scp/Scp.kt
@@ -44,6 +44,7 @@ import uniffi.scp.MessageListener
 import uniffi.scp.Proof
 import uniffi.scp.PublishResult
 import uniffi.scp.ReconnectReport
+import uniffi.scp.SagaResult
 import uniffi.scp.SqliteKeyMaterial
 import uniffi.scp.StorageConfig
 import uniffi.scp.SyncPolicyResult
@@ -1552,6 +1553,62 @@ class SCP internal constructor(
             ucanToken = ucanToken,
             chainDepth = chainDepth,
             proofTokens = proofTokens,
+        )
+
+    /**
+     * Runs the §6.2.4 atomic cross-context tool-invocation saga (ADR-049 §3a).
+     *
+     * Forwards 1:1 to [NativeScp.toolInvokeCrossContextSaga] on [inner]. The
+     * call blocks until the saga reaches a terminal state: it returns a
+     * [SagaResult] on commit (carrying the supervisor-minted `sagaId` plus the
+     * target's signed receipt and captured output, each `null` when absent and
+     * never synthesized), or throws a typed [uniffi.scp.ScpException] for a
+     * non-committed terminal — `ScpException.SagaAborted` (the saga was
+     * rejected before running; carries an optional `retryAfterMs` back-off
+     * hint), `ScpException.SagaNeedsRepair` (commit retries exhausted; carries
+     * the durable `sagaId` operator-repair handle), or `ScpException.SagaBusy`
+     * (the participant context set is contended; carries the
+     * `contendedContext` id). Bridge-surfaced `ScpException.Validation` and
+     * `ScpException.Permission` errors also propagate unchanged.
+     *
+     * This is a flat 1:1 forward: the caller principal is bound to the
+     * authenticated FFI identity inside the bridge, and all argument
+     * validation (including the asserted-nonce hex and the u64/u8 numeric
+     * bounds enforced by [ULong]/[UByte]) is performed by the Rust core. The
+     * 9-argument arity is dictated by the bridge op.
+     *
+     * @param sourceHandle The calling (source) context handle.
+     * @param targetHandle The context holding the tool to invoke.
+     * @param callerDid The invoking principal's DID.
+     * @param toolRegistrationId The target tool's cross-context registration id.
+     * @param inputJson JSON-encoded tool input.
+     * @param assertedNonceHex The asserted replay-protection nonce as hex.
+     * @param timestampMs The invocation timestamp in milliseconds.
+     * @param chainDepth Current cross-context chain depth (0 for first hop).
+     * @param ucanProofId Optional UCAN proof id for delegation-chain traversal.
+     */
+    @Suppress("LongParameterList")
+    suspend fun toolInvokeCrossContextSaga(
+        sourceHandle: ContextHandle,
+        targetHandle: ContextHandle,
+        callerDid: String,
+        toolRegistrationId: String,
+        inputJson: String,
+        assertedNonceHex: String,
+        timestampMs: ULong,
+        chainDepth: UByte,
+        ucanProofId: String?,
+    ): SagaResult =
+        inner.toolInvokeCrossContextSaga(
+            sourceHandle = sourceHandle,
+            targetHandle = targetHandle,
+            callerDid = callerDid,
+            toolRegistrationId = toolRegistrationId,
+            inputJson = inputJson,
+            assertedNonceHex = assertedNonceHex,
+            timestampMs = timestampMs,
+            chainDepth = chainDepth,
+            ucanProofId = ucanProofId,
         )
 
     /** Forwards to [NativeScp.toolRegister] on [inner]. */

--- a/bindings/kotlin/scp-kt/src/main/kotlin/works/limn/scp/bridge/CoroutineBridge.kt
+++ b/bindings/kotlin/scp-kt/src/main/kotlin/works/limn/scp/bridge/CoroutineBridge.kt
@@ -913,6 +913,41 @@ interface ToolBindings {
     ): String
 
     /**
+     * Runs the §6.2.4 atomic cross-context tool-invocation saga (ADR-049 §3a).
+     *
+     * Blocks until the saga reaches a terminal state. On commit returns the
+     * JSON-encoded saga result; otherwise throws a [BridgeException] carrying
+     * the typed `SCP-SAGA-13xxx` terminal code (aborted/needs-repair/busy) or
+     * a bridge-surfaced validation/permission code.
+     *
+     * @param sourceContextHandle Opaque handle for the calling (source) context.
+     * @param targetContextHandle Opaque handle for the context holding the tool.
+     * @param callerDid The invoking principal's DID.
+     * @param toolRegistrationId The target tool's cross-context registration id.
+     * @param inputJson JSON-encoded tool input.
+     * @param assertedNonceHex The asserted replay-protection nonce as hex.
+     * @param timestampMs The invocation timestamp in milliseconds.
+     * @param chainDepth Current cross-context chain depth (0 for first hop),
+     *   range 0-255 (ADR-043, spec §24.4).
+     * @param ucanProofId Optional UCAN proof id for delegation-chain traversal.
+     * @return JSON-encoded saga result.
+     * @throws BridgeException with a `SCP-SAGA-13xxx` code on a non-committed
+     *   terminal, or a bridge validation/permission code.
+     */
+    @Suppress("LongParameterList") // FFI bridge — must match UniFFI export signature
+    fun toolInvokeCrossContextSaga(
+        sourceContextHandle: Long,
+        targetContextHandle: Long,
+        callerDid: String,
+        toolRegistrationId: String,
+        inputJson: String,
+        assertedNonceHex: String,
+        timestampMs: Long,
+        chainDepth: Int,
+        ucanProofId: String?,
+    ): String
+
+    /**
      * Creates a stateful tool session (spec section 6.2.1).
      *
      * Sessions enable multi-turn workflows with state preservation across
@@ -1855,6 +1890,51 @@ class ToolBridge internal constructor(
                 ucanToken,
                 chainDepth,
                 proofTokens,
+            )
+        }
+
+    /**
+     * Run the §6.2.4 atomic cross-context tool-invocation saga (ADR-049 §3a).
+     *
+     * Blocks until the saga reaches a terminal state. On commit returns the
+     * JSON-encoded saga result; a non-committed terminal throws a
+     * [BridgeException] carrying the typed `SCP-SAGA-13xxx` code.
+     *
+     * @param sourceContextHandle Handle for the calling (source) context.
+     * @param targetContextHandle Handle for the context holding the tool.
+     * @param callerDid The invoking principal's DID.
+     * @param toolRegistrationId The target tool's cross-context registration id.
+     * @param inputJson JSON-encoded tool input.
+     * @param assertedNonceHex The asserted replay-protection nonce as hex.
+     * @param timestampMs The invocation timestamp in milliseconds.
+     * @param chainDepth Current cross-context chain depth (0 for first hop),
+     *   range 0-255 (ADR-043, spec §24.4).
+     * @param ucanProofId Optional UCAN proof id for delegation-chain traversal.
+     * @return JSON-encoded saga result.
+     */
+    @Suppress("LongParameterList") // FFI bridge — must match UniFFI export signature
+    suspend fun invokeCrossContextSaga(
+        sourceContextHandle: Long,
+        targetContextHandle: Long,
+        callerDid: String,
+        toolRegistrationId: String,
+        inputJson: String,
+        assertedNonceHex: String,
+        timestampMs: Long,
+        chainDepth: Int,
+        ucanProofId: String? = null,
+    ): String =
+        bridge.ffiCall {
+            bindings.toolInvokeCrossContextSaga(
+                sourceContextHandle,
+                targetContextHandle,
+                callerDid,
+                toolRegistrationId,
+                inputJson,
+                assertedNonceHex,
+                timestampMs,
+                chainDepth,
+                ucanProofId,
             )
         }
 

--- a/bindings/kotlin/scp-kt/src/test/kotlin/works/limn/scp/ToolSagaTest.kt
+++ b/bindings/kotlin/scp-kt/src/test/kotlin/works/limn/scp/ToolSagaTest.kt
@@ -18,7 +18,7 @@
 //     (argument forwarding + BridgeException propagation), and
 //   - end-to-end argument forwarding through the real UniFFI bridge.
 //
-// Provenance: #1939 PR-6c slice 4/4. §6.2.4 / ADR-049 §3a. ADR-026/ADR-028.
+// Provenance: PR-6c slice 4/4. §6.2.4 / ADR-049 §3a. ADR-026/ADR-028.
 
 package works.limn.scp
 

--- a/bindings/kotlin/scp-kt/src/test/kotlin/works/limn/scp/ToolSagaTest.kt
+++ b/bindings/kotlin/scp-kt/src/test/kotlin/works/limn/scp/ToolSagaTest.kt
@@ -315,8 +315,8 @@ class ToolSagaTest {
                     // supervisor-side rejection) means the call reached the
                     // real bridge — the wrapper forwarded successfully.
                     assertTrue(
-                        e.message?.isNotEmpty() ?: true,
-                        "expected a typed ScpException from the bridge",
+                        e.message!!.contains("code="),
+                        "expected a typed ScpException carrying a code= detail",
                     )
                 }
             } finally {

--- a/bindings/kotlin/scp-kt/src/test/kotlin/works/limn/scp/ToolSagaTest.kt
+++ b/bindings/kotlin/scp-kt/src/test/kotlin/works/limn/scp/ToolSagaTest.kt
@@ -1,0 +1,376 @@
+// ToolSagaTest.kt — SDK-wrapper tests for the §6.2.4 cross-context
+// tool-invocation saga (ADR-049 §3a, PR-6c slice 4/4).
+//
+// The Kotlin SDK surfaces the generated UniFFI types directly: the saga
+// terminal is the generated `SagaResult` (faithful nullable), and the
+// non-committed terminals are the generated `ScpException.Saga*` cases.
+// Unlike the Python/TS SDKs (which wrap untyped bridge errors into dedicated
+// SDK classes), there is no re-mapping layer here — the `Scp` shim forwards
+// 1:1 and the typed error propagates. Mirroring the Kotlin sibling
+// `toolInvokeCrossContext`, the wrapper carries NO client-side guards: input
+// is already a `String`, and the u64/u8 numeric bounds are enforced by
+// `ULong`/`UByte`, so all validation lives in the Rust core.
+//
+// This suite exercises:
+//   - the public type surface (SagaResult faithful pass-through incl. null;
+//     the three typed ScpException.Saga* cases carrying their fields),
+//   - the flat `ToolBridge.invokeCrossContextSaga` conformance symbol
+//     (argument forwarding + BridgeException propagation), and
+//   - end-to-end argument forwarding through the real UniFFI bridge.
+//
+// Provenance: #1939 PR-6c slice 4/4. §6.2.4 / ADR-049 §3a. ADR-026/ADR-028.
+
+package works.limn.scp
+
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.TestDispatcher
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Assumptions.assumeTrue
+import org.junit.jupiter.api.BeforeAll
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import uniffi.scp.CeilingPolicy
+import uniffi.scp.ContextMode
+import uniffi.scp.ContextParams
+import uniffi.scp.GovernanceModel
+import uniffi.scp.MemoryScope
+import uniffi.scp.SagaResult
+import uniffi.scp.ScpException
+import uniffi.scp.StorageConfig
+import uniffi.scp.ToolDefinition
+import works.limn.scp.bridge.BridgeException
+import works.limn.scp.bridge.CoroutineBridge
+import works.limn.scp.conformance.ConformanceStubBindings
+import kotlin.test.assertContentEquals
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+import kotlin.test.fail
+import kotlin.time.Duration.Companion.seconds
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class ToolSagaTest {
+    companion object {
+        private var nativeAvailable = false
+        private var skipReason = ""
+
+        @JvmStatic
+        @BeforeAll
+        fun probeNativeLibrary() {
+            try {
+                Class.forName("uniffi.scp.ScpKt")
+                Class.forName("uniffi.scp.Scp\$Companion")
+                nativeAvailable = true
+            } catch (e: ClassNotFoundException) {
+                skipReason = "UniFFI bindings not available: ${e.message}"
+            } catch (e: UnsatisfiedLinkError) {
+                skipReason = "Native library link error: ${e.message}"
+            } catch (e: ExceptionInInitializerError) {
+                skipReason = "Native library init error: ${e.cause?.message ?: e.message}"
+            } catch (e: NoClassDefFoundError) {
+                skipReason = "Native library class not found: ${e.message}"
+            }
+        }
+
+        /** 32 hex chars = 16 bytes — a well-formed §6.2.4 asserted-nonce input. */
+        private const val NONCE_HEX = "abababababababababababababababab"
+    }
+
+    private lateinit var stubBindings: ConformanceStubBindings
+    private lateinit var bridge: CoroutineBridge
+    private lateinit var testDispatcher: TestDispatcher
+
+    @BeforeEach
+    fun setUp() {
+        stubBindings = ConformanceStubBindings()
+        testDispatcher = StandardTestDispatcher()
+        bridge =
+            CoroutineBridge(
+                nativeBindings = stubBindings,
+                ioDispatcher = testDispatcher,
+                cpuDispatcher = testDispatcher,
+            )
+    }
+
+    // ── SagaResult: faithful nullable pass-through ────────────────────────
+
+    /**
+     * A committed terminal carries the supervisor-minted `sagaId` plus the
+     * signed receipt and captured output bytes verbatim.
+     */
+    @Test
+    fun `SagaResult carries receipt and output`() {
+        val receipt = byteArrayOf(0x01, 0x02, 0x03)
+        val output = byteArrayOf(0x04, 0x05)
+        val result = SagaResult(sagaId = "saga-1", receipt = receipt, output = output)
+
+        assertEquals("saga-1", result.sagaId)
+        assertContentEquals(receipt, result.receipt)
+        assertContentEquals(output, result.output)
+    }
+
+    /**
+     * `receipt` and `output` are surfaced exactly as the bridge returns them —
+     * `null` when absent, never synthesized.
+     */
+    @Test
+    fun `SagaResult passes through null receipt and output`() {
+        val result = SagaResult(sagaId = "saga-2", receipt = null, output = null)
+
+        assertEquals("saga-2", result.sagaId)
+        assertNull(result.receipt)
+        assertNull(result.output)
+    }
+
+    // ── Typed terminals: ScpException.Saga* surfaced directly ─────────────
+
+    /**
+     * `SagaAborted` carries `msg`, `code`, and the rate-limit back-off hint
+     * `retryAfterMs` — a concrete cooldown when one exists.
+     */
+    @Test
+    fun `SagaAborted carries retryAfter`() {
+        val error =
+            ScpException.SagaAborted(
+                msg = "[SCP-SAGA-13001] prepare rejected",
+                code = "SCP-SAGA-13001",
+                retryAfterMs = 1500uL,
+            )
+
+        assertEquals("[SCP-SAGA-13001] prepare rejected", error.msg)
+        assertEquals("SCP-SAGA-13001", error.code)
+        assertEquals(1500uL, error.retryAfterMs)
+    }
+
+    /**
+     * `retryAfterMs` is `null` (never `0`) when no precise back-off instant
+     * exists — `0` would read as "retry immediately" and re-trip the limit.
+     */
+    @Test
+    fun `SagaAborted preserves null retryAfter`() {
+        val error =
+            ScpException.SagaAborted(
+                msg = "[SCP-SAGA-13002] hard limit",
+                code = "SCP-SAGA-13002",
+                retryAfterMs = null,
+            )
+
+        assertNull(error.retryAfterMs)
+    }
+
+    /** `SagaNeedsRepair` carries the durable `sagaId` operator-repair handle. */
+    @Test
+    fun `SagaNeedsRepair carries sagaId`() {
+        val error =
+            ScpException.SagaNeedsRepair(
+                msg = "[SCP-SAGA-13065] commit retries exhausted",
+                code = "SCP-SAGA-13065",
+                sagaId = "saga-repair-7",
+            )
+
+        assertEquals("[SCP-SAGA-13065] commit retries exhausted", error.msg)
+        assertEquals("SCP-SAGA-13065", error.code)
+        assertEquals("saga-repair-7", error.sagaId)
+    }
+
+    /** `SagaBusy` carries the contended context id that forced serialization. */
+    @Test
+    fun `SagaBusy carries contendedContext`() {
+        val error =
+            ScpException.SagaBusy(
+                msg = "[SCP-SAGA-13066] participant set overlap",
+                code = "SCP-SAGA-13066",
+                contendedContext = "ctx-shared-42",
+            )
+
+        assertEquals("[SCP-SAGA-13066] participant set overlap", error.msg)
+        assertEquals("SCP-SAGA-13066", error.code)
+        assertEquals("ctx-shared-42", error.contendedContext)
+    }
+
+    // ── Flat ToolBridge.invokeCrossContextSaga conformance ────────────────
+
+    /**
+     * The coverage symbol `ToolBridge.invokeCrossContextSaga` dispatches on IO
+     * and forwards all nine arguments to the bridge verbatim, returning the
+     * JSON result unchanged.
+     */
+    @Test
+    fun `invokeCrossContextSaga forwards all arguments and returns result`() =
+        runTest(testDispatcher) {
+            stubBindings.toolInvokeCrossContextSagaResult = """{"saga_id":"saga-xyz"}"""
+            val result =
+                bridge.tools.invokeCrossContextSaga(
+                    sourceContextHandle = 1L,
+                    targetContextHandle = 2L,
+                    callerDid = "did:key:zCaller",
+                    toolRegistrationId = "reg-001",
+                    inputJson = """{"city":"Berlin"}""",
+                    assertedNonceHex = NONCE_HEX,
+                    timestampMs = 1_700_000_000_000L,
+                    chainDepth = 0,
+                    ucanProofId = "proof-1",
+                )
+
+            assertEquals("""{"saga_id":"saga-xyz"}""", result)
+            assertEquals(
+                listOf(
+                    "1",
+                    "2",
+                    "did:key:zCaller",
+                    "reg-001",
+                    """{"city":"Berlin"}""",
+                    NONCE_HEX,
+                    "1700000000000",
+                    "0",
+                    "proof-1",
+                ),
+                stubBindings.lastSagaArgs,
+            )
+        }
+
+    /**
+     * A configured bridge error propagates out of the coverage symbol as a
+     * [BridgeException] carrying the typed `SCP-SAGA-13xxx` code.
+     */
+    @Test
+    fun `invokeCrossContextSaga propagates configured BridgeException`() =
+        runTest(testDispatcher) {
+            stubBindings.toolInvokeCrossContextSagaError =
+                BridgeException("participant set overlap", "SCP-SAGA-13066")
+            try {
+                bridge.tools.invokeCrossContextSaga(
+                    sourceContextHandle = 1L,
+                    targetContextHandle = 2L,
+                    callerDid = "did:key:zCaller",
+                    toolRegistrationId = "reg-001",
+                    inputJson = "{}",
+                    assertedNonceHex = NONCE_HEX,
+                    timestampMs = 1_700_000_000_000L,
+                    chainDepth = 0,
+                )
+                fail("expected BridgeException for a configured saga error")
+            } catch (e: BridgeException) {
+                assertEquals("SCP-SAGA-13066", e.code)
+            }
+        }
+
+    // ── End-to-end argument forwarding through the real bridge ────────────
+
+    /**
+     * With an active source and target, the `Scp` shim forwards all arguments
+     * into the real saga. Without bidirectional consent the supervisor reaches
+     * a non-committed terminal, so the call surfaces a typed [ScpException] —
+     * proving the nine arguments (both handles, `callerDid`,
+     * `toolRegistrationId`, `inputJson`, nonce, timestamp, depth, optional
+     * proof) reach the real bridge.
+     *
+     * This is a bridge-linkage smoke test: it confirms the call reaches the
+     * real bridge, but does not assert per-argument positional fidelity (a
+     * same-typed swap would not be caught here — that assurance lives in the
+     * Rust/integration tests, since asserting it at this wrapper unit layer
+     * would require committed-saga bidirectional-consent setup).
+     */
+    @Test
+    fun `toolInvokeCrossContextSaga reaches the real saga and surfaces a typed ScpException`() {
+        assumeTrue(nativeAvailable, skipReason)
+        runBlocking {
+            val scp = SCP(StorageConfig.InMemory)
+            try {
+                scp.configureLocalTransport(localDid = "did:key:z6MkKotlinSagaForwardTest")
+                val identity = scp.identityCreate(custody = "in_memory")
+                val source = scp.contextCreate(identity = identity, params = makeParams())
+                val target = scp.contextCreate(identity = identity, params = makeParams())
+                val toolId =
+                    scp.toolRegister(
+                        handle = target,
+                        definition = weatherTool(operatorDid = identity.did()),
+                    )
+
+                try {
+                    val result =
+                        scp.toolInvokeCrossContextSaga(
+                            sourceHandle = source,
+                            targetHandle = target,
+                            callerDid = identity.did(),
+                            toolRegistrationId = toolId,
+                            inputJson = """{"city":"Berlin","unit":"C"}""",
+                            assertedNonceHex = NONCE_HEX,
+                            timestampMs = System.currentTimeMillis().toULong(),
+                            chainDepth = 0.toUByte(),
+                            ucanProofId = null,
+                        )
+                    // A committed terminal (unlikely without consent setup) is
+                    // still a valid forwarding outcome: the bridge produced a
+                    // SagaResult carrying a non-empty supervisor-minted sagaId.
+                    assertTrue(
+                        result.sagaId.isNotEmpty(),
+                        "committed saga must carry a sagaId",
+                    )
+                } catch (e: ScpException) {
+                    // Any typed ScpException (a Saga* terminal or a
+                    // supervisor-side rejection) means the call reached the
+                    // real bridge — the wrapper forwarded successfully.
+                    assertTrue(
+                        e.message?.isNotEmpty() ?: true,
+                        "expected a typed ScpException from the bridge",
+                    )
+                }
+            } finally {
+                val shutdownBridge =
+                    CoroutineBridge(
+                        nativeBindings = ConformanceStubBindings(),
+                        ioDispatcher = Dispatchers.IO,
+                        cpuDispatcher = Dispatchers.Default,
+                    )
+                scp.shutdown(shutdownBridge, 1.seconds)
+            }
+        }
+    }
+
+    // ── Fixtures ──────────────────────────────────────────────────────────
+
+    private fun makeParams(): ContextParams =
+        ContextParams(
+            mode = ContextMode.ENCRYPTED,
+            ceiling =
+                listOf(
+                    "messages:read",
+                    "messages:write",
+                    "tool:invoke:*",
+                    "tool:register",
+                    "context:close",
+                ),
+            ceilingPolicy = CeilingPolicy.IMMUTABLE,
+            governance = GovernanceModel.SINGLE_ADMIN,
+            memoryScope = MemoryScope.EPHEMERAL,
+            ttlSeconds = 3600uL,
+            promotable = false,
+            minProtocolVersion = 0.toUShort(),
+            maxChainDepth = null,
+            maxNestingDepth = null,
+            sessionCap = null,
+            economicPolicy = null,
+            consequenceRulesJson = null,
+            consequenceConfigJson = null,
+        )
+
+    private fun weatherTool(operatorDid: String): ToolDefinition =
+        ToolDefinition(
+            name = "weather",
+            description = "Get current weather for a city",
+            inputSchemaJson =
+                """{"type":"object","properties":{"city":{"type":"string"},""" +
+                    """"unit":{"type":"string"}},"required":["city"]}""",
+            outputSchemaJson =
+                """{"type":"object","properties":{"tempC":{"type":"number"},""" +
+                    """"condition":{"type":"string"}}}""",
+            operatorDid = operatorDid,
+            testVectorsJson = "[]",
+            implementationHash = null,
+            cost = null,
+        )
+}

--- a/bindings/kotlin/scp-kt/src/test/kotlin/works/limn/scp/ToolSagaTest.kt
+++ b/bindings/kotlin/scp-kt/src/test/kotlin/works/limn/scp/ToolSagaTest.kt
@@ -233,6 +233,46 @@ class ToolSagaTest {
         }
 
     /**
+     * The optional `ucanProofId` is forwarded verbatim when absent: a `null`
+     * proof reaches the bridge as `null` (recorded by the stub as the literal
+     * `"null"` via `toString()`), never coerced to an empty or sentinel proof.
+     * The other eight arguments still forward in order.
+     */
+    @Test
+    fun `invokeCrossContextSaga forwards null ucanProofId`() =
+        runTest(testDispatcher) {
+            stubBindings.toolInvokeCrossContextSagaResult = """{"saga_id":"saga-xyz"}"""
+            val result =
+                bridge.tools.invokeCrossContextSaga(
+                    sourceContextHandle = 1L,
+                    targetContextHandle = 2L,
+                    callerDid = "did:key:zCaller",
+                    toolRegistrationId = "reg-001",
+                    inputJson = """{"city":"Berlin"}""",
+                    assertedNonceHex = NONCE_HEX,
+                    timestampMs = 1_700_000_000_000L,
+                    chainDepth = 0,
+                    ucanProofId = null,
+                )
+
+            assertEquals("""{"saga_id":"saga-xyz"}""", result)
+            assertEquals(
+                listOf(
+                    "1",
+                    "2",
+                    "did:key:zCaller",
+                    "reg-001",
+                    """{"city":"Berlin"}""",
+                    NONCE_HEX,
+                    "1700000000000",
+                    "0",
+                    "null",
+                ),
+                stubBindings.lastSagaArgs,
+            )
+        }
+
+    /**
      * A configured bridge error propagates out of the coverage symbol as a
      * [BridgeException] carrying the typed `SCP-SAGA-13xxx` code.
      */

--- a/bindings/kotlin/scp-kt/src/test/kotlin/works/limn/scp/bridge/CoroutineBridgeTest.kt
+++ b/bindings/kotlin/scp-kt/src/test/kotlin/works/limn/scp/bridge/CoroutineBridgeTest.kt
@@ -1348,6 +1348,21 @@ class StubNativeBindings : NativeBindings {
         return toolInvokeCrossContextResult
     }
 
+    var toolInvokeCrossContextSagaResult = """{"saga_id":"saga-stub"}"""
+
+    @Suppress("LongParameterList")
+    override fun toolInvokeCrossContextSaga(
+        sourceContextHandle: Long,
+        targetContextHandle: Long,
+        callerDid: String,
+        toolRegistrationId: String,
+        inputJson: String,
+        assertedNonceHex: String,
+        timestampMs: Long,
+        chainDepth: Int,
+        ucanProofId: String?,
+    ): String = toolInvokeCrossContextSagaResult
+
     override fun toolSessionCreate(
         contextHandle: Long,
         toolId: String,

--- a/bindings/kotlin/scp-kt/src/test/kotlin/works/limn/scp/conformance/ConformanceStubBindings.kt
+++ b/bindings/kotlin/scp-kt/src/test/kotlin/works/limn/scp/conformance/ConformanceStubBindings.kt
@@ -59,6 +59,9 @@ class ConformanceStubBindings : NativeBindings {
     var toolVerifyError: BridgeException? = null
     var toolInvokeCrossContextResult: String = """{"cross_context":"ok"}"""
     var toolInvokeCrossContextError: BridgeException? = null
+    var toolInvokeCrossContextSagaResult: String = """{"saga_id":"saga-001"}"""
+    var toolInvokeCrossContextSagaError: BridgeException? = null
+    var lastSagaArgs: List<String>? = null
     var toolSessionCreateResult: String = "session-001"
     var toolSessionCreateError: BridgeException? = null
     var toolSessionInvokeResult: String = """{"session":"ok"}"""
@@ -391,6 +394,34 @@ class ConformanceStubBindings : NativeBindings {
         return toolInvokeCrossContextResult
     }
 
+    @Suppress("LongParameterList")
+    override fun toolInvokeCrossContextSaga(
+        sourceContextHandle: Long,
+        targetContextHandle: Long,
+        callerDid: String,
+        toolRegistrationId: String,
+        inputJson: String,
+        assertedNonceHex: String,
+        timestampMs: Long,
+        chainDepth: Int,
+        ucanProofId: String?,
+    ): String {
+        lastSagaArgs =
+            listOf(
+                sourceContextHandle.toString(),
+                targetContextHandle.toString(),
+                callerDid,
+                toolRegistrationId,
+                inputJson,
+                assertedNonceHex,
+                timestampMs.toString(),
+                chainDepth.toString(),
+                ucanProofId.toString(),
+            )
+        toolInvokeCrossContextSagaError?.let { throw it }
+        return toolInvokeCrossContextSagaResult
+    }
+
     override fun toolSessionCreate(
         contextHandle: Long,
         toolId: String,
@@ -531,6 +562,9 @@ class ConformanceStubBindings : NativeBindings {
         toolVerifyError = null
         toolInvokeCrossContextResult = """{"cross_context":"ok"}"""
         toolInvokeCrossContextError = null
+        toolInvokeCrossContextSagaResult = """{"saga_id":"saga-001"}"""
+        toolInvokeCrossContextSagaError = null
+        lastSagaArgs = null
         toolSessionCreateResult = "session-001"
         toolSessionCreateError = null
         toolSessionInvokeResult = """{"session":"ok"}"""


### PR DESCRIPTION
## PR-6c slice 4/4 (final) — Kotlin SDK wrapper for the §6.2.4 cross-context tool-invocation saga

Adds the Kotlin SDK wrapper over the merged UniFFI `tool_invoke_cross_context_saga` bridge export, completing the four-SDK arc for the §6.2.4 saga op.

Closes #1939.

With this slice all four SDK wrappers are live, so the capability-matrix `(Tools, invoke_cross_context_saga)` entry flips `kotlin: false → true` and the per-SDK `exemptions` object is removed entirely (all four cells now `true`).

### What this adds (two surfaces, mirroring the existing sibling `invoke_cross_context`)
- **`SCP.toolInvokeCrossContextSaga(...) : SagaResult`** (`Scp.kt`) — the real typed shim: `suspend`, forwards all 9 params 1:1 (named args, so a positional swap is a compile error) to the generated `NativeScp.toolInvokeCrossContextSaga`, returns the faithful `SagaResult(sagaId, receipt: ByteArray?, output: ByteArray?)` directly, and lets the generated typed terminals `ScpException.SagaAborted(retryAfterMs: ULong?)` / `SagaNeedsRepair(sagaId)` / `SagaBusy(contendedContext)` propagate with **no re-mapping layer**. Like Swift (and unlike Python/TS, which must re-wrap untyped bridge errors), Kotlin shares the UniFFI bridge and surfaces the typed errors directly — eliminating an entire class of string-parse / phantom-authz drift by construction.
- **`ToolBridge.invokeCrossContextSaga(...) : String`** + **`ToolBindings.toolInvokeCrossContextSaga(...)`** (`CoroutineBridge.kt`) — the flat, UniFFI-free conformance/coverage surface (`Long`/`Int`/JSON `String`, `BridgeException`) via `bridge.ffiCall`, mirroring the sibling. This is the symbol the SDK-coverage gate keys off.

Uses flat `ffiCall` (not `ffiCallSuspend`) on the conformance path — matching the sibling exactly; the real suspension is the `Scp.kt` shim awaiting the generated `suspend fun`. No client-side guards and no manual range validation (`ULong`/`UByte` enforce the u64/u8 bounds by construction; all semantic validation lives in the Rust core), consistent with the Kotlin sibling.

### No generated binding committed
Kotlin's UniFFI bindings (`…/internal/`) are gitignored and regenerated by Gradle at build time, so — unlike the Swift slice — there is **no committed generated file**. The three `NativeBindings` test-stub implementors (`ConformanceStubBindings`, `StubNativeBindings`, `TestNativeBindings`) all gain the new interface override so the test/android source sets compile.

### Tests
`ToolSagaTest.kt` (10 tests, linking the real Rust engine): faithful `SagaResult` pass-through incl. nulls; all three typed terminals with their fields (incl. `retryAfterMs == null` never `0`); flat `ToolBridge` conformance with a 9-distinct-arg positional `lastSagaArgs` assertion (catches drop/swap), a `BridgeException`-propagation test, and a null-`ucanProofId` forwarding test; and a real-engine end-to-end bridge-linkage smoke test (valid 16-byte nonce).

### Review
Double-zero reviewed (two consecutive fully-clean full-roster passes): sdk-coverage, api-design, alignment, completionist, security, bug-catcher, test-quality. `check-sdk-coverage.py` PASS; the Kotlin suite ran 10/10 green (skipped=0, e2e hit the real engine) via `./gradlew :scp-kt:test`, with detekt + ktlint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
