### PR TITLE
feat(scp-client): single-threaded in-browser participant driver over scp-mls (ADR-057 Slice 2)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5057,6 +5057,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
+name = "scp-client"
+version = "0.1.0-beta.2"
+dependencies = [
+ "getrandom 0.2.17",
+ "getrandom 0.3.4",
+ "getrandom 0.4.2",
+ "openmls",
+ "scp-event-log",
+ "scp-mls",
+ "scp-primitives",
+ "scp-protocol",
+ "thiserror 2.0.18",
+ "tls_codec",
+ "uuid",
+]
+
+[[package]]
 name = "scp-core"
 version = "0.1.0-beta.2"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,7 @@ members = [
     "crates/scp-event-log",
     "crates/scp-protocol",
     "crates/scp-mls",
+    "crates/scp-client",
     "crates/scp-runtime",
     "crates/scp-core",
     "crates/scp-transport",

--- a/crates/scp-client/Cargo.toml
+++ b/crates/scp-client/Cargo.toml
@@ -1,0 +1,58 @@
+[package]
+name = "scp-client"
+version = "0.1.0-beta.2"
+description = "Single-threaded SCP participant driver over scp-mls — wasm32-safe, keys on-device (ADR-057 Slice 2)"
+edition.workspace = true
+repository.workspace = true
+license.workspace = true
+homepage.workspace = true
+
+[features]
+default = []
+# Enables non-production DID formats (did:key:, did:test:) in credential
+# construction, mirroring scp-mls/scp-protocol `testing`. Used by the
+# integration tests.
+testing = [
+    "scp-mls/testing",
+    "scp-protocol/testing",
+    "scp-primitives/testing",
+]
+
+[dependencies]
+# scp-client depends ONLY on the wasm-safe shared crates plus the openmls
+# stack. It MUST NOT depend on scp-runtime (tokio/actor orchestration) or
+# scp-identity (tokio-coupled custody/DHT) — the ADR-057 mechanical fence that
+# keeps the participant driver compilable to wasm32-unknown-unknown. All
+# protocol logic is called through scp-mls / scp-protocol / scp-event-log; this
+# crate re-derives nothing.
+scp-primitives = { path = "../scp-primitives", version = "=0.1.0-beta.2" }
+scp-protocol = { path = "../scp-protocol", version = "=0.1.0-beta.2" }
+scp-event-log = { path = "../scp-event-log", version = "=0.1.0-beta.2" }
+scp-mls = { path = "../scp-mls", version = "=0.1.0-beta.2" }
+
+# openmls is needed directly for the wire (de)serialization of KeyPackages and
+# MLS messages at the driver boundary (KeyPackageIn::tls_deserialize and
+# friends); scp-mls exposes its op surface in terms of these openmls types.
+openmls = { workspace = true, features = ["libcrux-provider", "js"] }
+tls_codec = "0.4"
+
+thiserror = { workspace = true }
+
+# wasm32 backends: mirror scp-mls/Cargo.toml so the driver compiles to wasm32.
+# The root .cargo/config.toml already sets getrandom_backend="wasm_js"
+# globally for the wasm32 target. See ADR-057 Prerequisite 1.
+[target.'cfg(target_arch = "wasm32")'.dependencies]
+getrandom = { version = "0.2", features = ["js"] }
+getrandom_03 = { package = "getrandom", version = "0.3", features = ["wasm_js"] }
+# getrandom 0.4 arrives transitively via the openmls libcrux provider and needs
+# its own wasm_js backend enabled (openmls's `js` feature only wires 0.3).
+getrandom_04 = { package = "getrandom", version = "0.4", features = ["wasm_js"] }
+uuid = { version = "1", features = ["v4", "js"] }
+
+[dev-dependencies]
+scp-primitives = { path = "../scp-primitives", features = ["testing"] }
+scp-protocol = { path = "../scp-protocol", features = ["testing"] }
+scp-mls = { path = "../scp-mls", features = ["testing"] }
+
+[lints]
+workspace = true

--- a/crates/scp-client/src/client.rs
+++ b/crates/scp-client/src/client.rs
@@ -1,0 +1,561 @@
+//! The single-threaded SCP participant driver.
+//!
+//! [`ScpClient`] is the in-tab participant: a per-context state map accessed
+//! synchronously, with op methods that sequence the shared `scp-mls` /
+//! `scp-protocol` / `scp-event-log` logic. It restores the deleted WASM
+//! bridge's proven *shape* (a per-context state map, op methods named
+//! `create_context` / `generate_key_package_for_join` / `add_member` /
+//! `join_context_encrypted` / `send_message` / `receive_message` /
+//! `drain_events` / `close_context`, and a pull-based event model) while
+//! calling shared protocol code for every body.
+//!
+//! Single-threaded throughout: no tokio, no actors. The driver owns its state
+//! by `&mut self`; there is no internal concurrency. A browser runs one of
+//! these per tab.
+//!
+//! # Scope fence (ADR-057)
+//!
+//! Participant message path ONLY: create / generate-key-package / add-member /
+//! join / send / receive-decrypt / process-commit / close, plus the event-log
+//! leaves for those events. No economy, governance voting, broadcast hosting,
+//! cross-context saga coordination, tools, discovery, or UCAN minting — those
+//! require always-on hosts and live node-side. The fence is enforced
+//! mechanically by the crate's dependency set (no `scp-runtime` /
+//! `scp-identity` / `tokio`).
+
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use openmls::prelude::{KeyPackageBundle, KeyPackageIn, MlsMessageOut, ProtocolVersion};
+use scp_event_log::{Event, EventType};
+use scp_mls::group::{
+    add_member, create_group, destroy_group, generate_key_package, join_group_from_bytes,
+    key_package_in_did,
+};
+use scp_mls::{InMemoryMlsProvider, ScpCredential, SignatureKeyPair};
+use scp_primitives::Clock;
+use scp_protocol::context::membership::ContextEvent;
+use scp_protocol::crypto::sender_keys::SenderKey;
+use tls_codec::{Deserialize as TlsDeserialize, Serialize as TlsSerialize};
+
+use crate::context::PerContextState;
+use crate::crypto_state::{ContextCryptoState, Inbound};
+use crate::error::ClientError;
+use crate::signer::Signer;
+use crate::storage::Storage;
+
+/// Pending join material a prospective member retains between generating its
+/// `KeyPackage` and processing the resulting Welcome.
+///
+/// `generate_key_package` produces a `(bundle, signer, provider)` triple; the
+/// public `KeyPackage` (serialized) is handed to the adder, but the matching
+/// private `signer` + `provider` MUST be retained by the joiner to process the
+/// Welcome. This struct holds that retained half, keyed by context id on the
+/// client.
+struct PendingJoin {
+    signer: SignatureKeyPair,
+    provider: InMemoryMlsProvider,
+}
+
+/// The result of adding a member: the wire bytes the driver must distribute,
+/// plus the convergent committer timestamp the adder stamped on its
+/// `MemberJoined` leaf.
+///
+/// `commit` goes to all *existing* members (they apply it via
+/// [`ScpClient::receive_message`], which classifies it as a control message and
+/// advances their MLS epoch). `welcome` goes to the *new* member (they apply it
+/// via [`ScpClient::join_context_encrypted`], passing `committer_timestamp_secs`
+/// so their mirrored `MemberJoined` leaf converges with the adder's).
+#[derive(Debug, Clone)]
+pub struct AddMemberOutput {
+    /// TLS-serialized MLS Commit for existing members.
+    pub commit: Vec<u8>,
+    /// TLS-serialized MLS Welcome for the new member.
+    pub welcome: Vec<u8>,
+    /// The adder's full event-log stream AFTER the add (the prior context
+    /// history plus the new `MemberJoined` leaf). The joiner replays this
+    /// verbatim to reconstruct a byte-identical log and converge to the same
+    /// Merkle root (§7.3.1 context-state import, §9.9.3 convergence).
+    pub event_log: Vec<Event>,
+    /// The adder's membership set after the add. The joiner adopts it so both
+    /// sides agree on who is in the context without re-deriving it.
+    pub members: Vec<String>,
+}
+
+/// The result of sending a message: the wire ciphertext, plus the convergent
+/// committer timestamp the sender stamped on its `MessageSent` leaf.
+///
+/// Every recipient MUST stamp the same `committer_timestamp_secs` on their
+/// own `MessageSent` leaf (passed to [`ScpClient::receive_message`]) so the
+/// leaves converge byte-for-byte across members (§9.9.3). The timestamp travels
+/// with the ciphertext exactly as a signed SCP envelope's `created_at` does on
+/// the native path.
+#[derive(Debug, Clone)]
+pub struct SendOutput {
+    /// TLS-serialized MLS ciphertext for delivery to peers.
+    pub ciphertext: Vec<u8>,
+    /// The convergent committer timestamp (Unix seconds) the sender stamped.
+    pub committer_timestamp_secs: u64,
+}
+
+/// The single-threaded SCP participant driver.
+pub struct ScpClient {
+    /// This participant's on-device DID identity.
+    signer: Arc<dyn Signer>,
+    /// Out-of-band snapshot storage (`IndexedDB` in a browser; in-memory here).
+    /// Held from construction so the dependency is explicit and the snapshot
+    /// seam is ready for a later slice without an API change.
+    #[allow(dead_code)]
+    storage: Arc<dyn Storage>,
+    /// Hardened time source. Used for committer-assigned event-log leaf
+    /// timestamps; in a browser this is the hardened clock (ADR-057
+    /// Prerequisite 1), never an un-captured `Date.now()`.
+    clock: Arc<dyn Clock>,
+    /// Per-context participant state, keyed by context id.
+    contexts: HashMap<String, PerContextState>,
+    /// Retained join material per context id, between key-package generation
+    /// and Welcome processing.
+    pending_joins: HashMap<String, PendingJoin>,
+}
+
+impl ScpClient {
+    /// Constructs a participant driver with the given on-device identity,
+    /// storage backend, and hardened clock.
+    #[must_use]
+    pub fn new(signer: Arc<dyn Signer>, storage: Arc<dyn Storage>, clock: Arc<dyn Clock>) -> Self {
+        Self {
+            signer,
+            storage,
+            clock,
+            contexts: HashMap::new(),
+            pending_joins: HashMap::new(),
+        }
+    }
+
+    /// This participant's DID.
+    #[must_use]
+    pub fn did(&self) -> &str {
+        self.signer.did()
+    }
+
+    /// Builds an [`ScpCredential`] for this participant's identity.
+    fn credential(&self) -> Result<ScpCredential, ClientError> {
+        Ok(ScpCredential::new(
+            self.signer.did().to_owned(),
+            None,
+            self.signer.signing_key_id(),
+        )?)
+    }
+
+    /// Returns the per-context state, or [`ClientError::UnknownContext`].
+    fn context_mut(&mut self, context_id: &str) -> Result<&mut PerContextState, ClientError> {
+        self.contexts
+            .get_mut(context_id)
+            .ok_or_else(|| ClientError::UnknownContext(context_id.to_owned()))
+    }
+
+    // ----------------------------------------------------------------------
+    // Lifecycle
+    // ----------------------------------------------------------------------
+
+    /// Creates a new encrypted context with this participant as sole member.
+    ///
+    /// Builds the MLS group (creator-only), seeds the §9.16 crypto state, and
+    /// appends the first event-log leaf (`ContextCreated`) stamped with the
+    /// creator's convergent creation timestamp.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`ClientError::ContextAlreadyExists`] if the id is already held,
+    /// or an [`ClientError::Mls`] / [`ClientError::EventLog`] if group creation
+    /// or the leaf append fails.
+    pub fn create_context(&mut self, context_id: &str) -> Result<(), ClientError> {
+        if self.contexts.contains_key(context_id) {
+            return Err(ClientError::ContextAlreadyExists(context_id.to_owned()));
+        }
+        let credential = self.credential()?;
+        let mls_group = create_group(&credential)?;
+        let crypto = ContextCryptoState::from_group(context_id, mls_group);
+        let creator_did = self.signer.did().to_owned();
+        let mut state = PerContextState::new(context_id, &creator_did, crypto);
+
+        // Convergent creation timestamp: the creator stamps it once; peers copy
+        // it when they import context state (a later slice). Here the creator is
+        // the only member, so it is simply this client's clock reading.
+        let created_at = self.clock.now_secs();
+        state.append_log_event(
+            EventType::ContextCreated,
+            &creator_did,
+            Vec::new(),
+            created_at,
+        )?;
+
+        self.contexts.insert(context_id.to_owned(), state);
+        Ok(())
+    }
+
+    /// Generates a single-use `KeyPackage` so this participant can be added to
+    /// `context_id` by an existing member.
+    ///
+    /// Returns the TLS-serialized public `KeyPackage` bytes to hand to the
+    /// adder. The matching private join material (signer + provider) is retained
+    /// internally, keyed by `context_id`, and consumed by
+    /// [`Self::join_context_encrypted`] when the Welcome arrives. Calling this
+    /// again for the same context replaces the prior pending material.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`ClientError::Mls`] if key-package generation fails, or
+    /// [`ClientError::Codec`] if the public key package cannot be serialized.
+    pub fn generate_key_package_for_join(
+        &mut self,
+        context_id: &str,
+    ) -> Result<Vec<u8>, ClientError> {
+        let credential = self.credential()?;
+        let (bundle, signer, provider): (KeyPackageBundle, _, InMemoryMlsProvider) =
+            generate_key_package(&credential)?;
+
+        let kp_bytes = bundle
+            .key_package()
+            .tls_serialize_detached()
+            .map_err(|e| ClientError::Codec(format!("serializing key package: {e}")))?;
+
+        self.pending_joins
+            .insert(context_id.to_owned(), PendingJoin { signer, provider });
+
+        Ok(kp_bytes)
+    }
+
+    /// Adds a member to `context_id` from their serialized `KeyPackage`.
+    ///
+    /// Produces the MLS Commit (for existing members) and Welcome (for the new
+    /// member), records the new member in the membership set, and appends a
+    /// `MemberJoined` event-log leaf. The new member's DID is recovered from the
+    /// key package's embedded SCP credential, so the caller does not supply it
+    /// separately.
+    ///
+    /// The returned [`AddMemberOutput`] carries the adder's full event-log
+    /// stream and membership snapshot so the joiner can replay them and converge
+    /// to the same Merkle root (§7.3.1 context-state import).
+    ///
+    /// # Errors
+    ///
+    /// Returns [`ClientError::UnknownContext`] if the context is not held,
+    /// [`ClientError::Codec`] if the key package cannot be deserialized, or
+    /// [`ClientError::Mls`] / [`ClientError::EventLog`] on MLS or leaf failure.
+    pub fn add_member(
+        &mut self,
+        context_id: &str,
+        key_package_bytes: &[u8],
+    ) -> Result<AddMemberOutput, ClientError> {
+        let new_member_did = key_package_member_did(key_package_bytes)?;
+        let timestamp = self.clock.now_secs();
+        let committer_did = self.signer.did().to_owned();
+
+        let state = self.context_mut(context_id)?;
+
+        let key_package_in = KeyPackageIn::tls_deserialize(&mut &*key_package_bytes)
+            .map_err(|e| ClientError::Codec(format!("deserializing key package: {e}")))?;
+
+        let result = add_member(&mut state.crypto.mls_group, key_package_in)?;
+        let commit = serialize_message(&result.commit)?;
+        let welcome = serialize_message(&result.welcome)?;
+
+        state.add_member_record(&new_member_did);
+        state.append_log_event(
+            EventType::MemberJoined,
+            &committer_did,
+            Vec::new(),
+            timestamp,
+        )?;
+
+        Ok(AddMemberOutput {
+            commit,
+            welcome,
+            event_log: state.events(),
+            members: state.members.clone(),
+        })
+    }
+
+    /// Joins `context_id` from a Welcome message, becoming an active member.
+    ///
+    /// Consumes the pending join material retained by a prior
+    /// [`Self::generate_key_package_for_join`] for this context, processes the
+    /// Welcome into an [`scp_mls::ScpMlsGroup`], builds the §9.16 crypto state,
+    /// and **replays the adder's event-log stream verbatim** so the joiner's log
+    /// is byte-identical to the adder's and converges to the same Merkle root
+    /// (§7.3.1, §9.9.3). The joiner does not synthesize its own join leaf — it
+    /// adopts the adder's, which already records the join.
+    ///
+    /// `prior_event_log` is [`AddMemberOutput::event_log`] from the adder;
+    /// `members` is [`AddMemberOutput::members`]. Both travel alongside the
+    /// Welcome.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`ClientError::Driver`] if there is no pending join material for
+    /// the context, [`ClientError::ContextAlreadyExists`] if already joined, or
+    /// [`ClientError::Mls`] / [`ClientError::EventLog`] on Welcome processing or
+    /// replay failure (a replay stream that does not chain cleanly is rejected).
+    pub fn join_context_encrypted(
+        &mut self,
+        context_id: &str,
+        welcome_bytes: &[u8],
+        prior_event_log: &[Event],
+        members: &[String],
+    ) -> Result<(), ClientError> {
+        if self.contexts.contains_key(context_id) {
+            return Err(ClientError::ContextAlreadyExists(context_id.to_owned()));
+        }
+        let pending = self.pending_joins.remove(context_id).ok_or_else(|| {
+            ClientError::Driver(format!(
+                "no pending key package for context '{context_id}'; call \
+                 generate_key_package_for_join first"
+            ))
+        })?;
+
+        // `join_group_from_bytes` is the wire-path variant: it deserializes the
+        // Welcome (as `MlsMessageIn`) internally, so the driver never has to
+        // name the inbound MLS message type.
+        let mls_group = join_group_from_bytes(welcome_bytes, pending.provider, pending.signer)?;
+        let crypto = ContextCryptoState::from_group(context_id, mls_group);
+        let self_did = self.signer.did().to_owned();
+
+        // Start from an EMPTY log and replay the adder's stream verbatim, so the
+        // joiner reconstructs a byte-identical log (identical leaves, identical
+        // root) rather than synthesizing fresh leaves at the wrong positions.
+        let mut state = PerContextState::new_empty(context_id, crypto);
+        for event in prior_event_log {
+            state.replay_event(event)?;
+        }
+
+        // Adopt the adder's membership snapshot; ensure self is present.
+        for member in members {
+            state.add_member_record(member);
+        }
+        state.add_member_record(&self_did);
+
+        self.contexts.insert(context_id.to_owned(), state);
+        Ok(())
+    }
+
+    // ----------------------------------------------------------------------
+    // Message path
+    // ----------------------------------------------------------------------
+
+    /// Encrypts and "sends" an application message in `context_id`.
+    ///
+    /// Runs the full §9.16 double-encryption pipeline, appends a `MessageSent`
+    /// event-log leaf (committer = this sender, convergent timestamp = this
+    /// sender's clock reading, which every recipient copies onto their
+    /// `MessageReceived`-driven leaf), increments this sender's sequence, and
+    /// returns the wire ciphertext for the transport to deliver to peers.
+    ///
+    /// There is no relay in the MVP; the returned bytes are handed directly to
+    /// recipients' [`Self::receive_message`] by the test harness "dumb pipe".
+    ///
+    /// # Errors
+    ///
+    /// Returns [`ClientError::UnknownContext`] if the context is not held, or
+    /// [`ClientError::Mls`] / [`ClientError::SenderKey`] /
+    /// [`ClientError::EventLog`] on a layer failure.
+    pub fn send_message(
+        &mut self,
+        context_id: &str,
+        plaintext: &[u8],
+    ) -> Result<SendOutput, ClientError> {
+        let sender_did = self.signer.did().to_owned();
+        let timestamp = self.clock.now_secs();
+        let state = self.context_mut(context_id)?;
+
+        let sequence = state.next_sequence(&sender_did);
+        let ciphertext = state
+            .crypto
+            .encrypt_message(plaintext, &sender_did, sequence)?;
+
+        state.append_log_event(EventType::MessageSent, &sender_did, Vec::new(), timestamp)?;
+
+        Ok(SendOutput {
+            ciphertext,
+            committer_timestamp_secs: timestamp,
+        })
+    }
+
+    /// Receives an inbound MLS message in `context_id`: decrypts it (or applies
+    /// it as a control commit), and buffers the resulting event.
+    ///
+    /// An application message produces a `MessageReceived` event (buffered for
+    /// [`Self::drain_events`]) and appends a `MessageSent` leaf stamped with the
+    /// supplied committer timestamp, so the receiver's log converges with the
+    /// sender's. A control message (commit/proposal) advances the MLS group
+    /// silently and produces no buffered event and no leaf (the membership leaf
+    /// for an add is recorded by the joiner's own join path).
+    ///
+    /// `committer_timestamp_secs` is the convergent timestamp the sender stamped
+    /// on its `MessageSent` leaf (transported alongside the ciphertext). For a
+    /// control message it is ignored.
+    ///
+    /// Returns `true` if an application message was decrypted and buffered,
+    /// `false` for a control message.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`ClientError::UnknownContext`] if the context is not held, or a
+    /// crypto/leaf error on failure.
+    pub fn receive_message(
+        &mut self,
+        context_id: &str,
+        ciphertext: &[u8],
+        committer_timestamp_secs: u64,
+    ) -> Result<bool, ClientError> {
+        let state = self.context_mut(context_id)?;
+        match state.crypto.decrypt_message(ciphertext)? {
+            Inbound::Application {
+                sender_did,
+                plaintext,
+            } => {
+                state.append_log_event(
+                    EventType::MessageSent,
+                    &sender_did,
+                    Vec::new(),
+                    committer_timestamp_secs,
+                )?;
+                state.push_event(ContextEvent::MessageReceived {
+                    sender_did: sender_did.into(),
+                    payload: plaintext,
+                });
+                Ok(true)
+            }
+            Inbound::Control { .. } => Ok(false),
+        }
+    }
+
+    /// Drains all buffered receive events for `context_id` in FIFO order.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`ClientError::UnknownContext`] if the context is not held.
+    pub fn drain_events(&mut self, context_id: &str) -> Result<Vec<ContextEvent>, ClientError> {
+        Ok(self.context_mut(context_id)?.drain_events())
+    }
+
+    /// Closes and removes `context_id`, destroying its crypto state.
+    ///
+    /// Destroying the MLS group releases the group key schedule, after which no
+    /// further message in this context can be decrypted by this participant
+    /// (forward secrecy — ADR-057 lose-device-lose-history). Returns
+    /// [`ClientError::UnknownContext`] if the context is not held.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`ClientError::UnknownContext`] if the context is not held.
+    pub fn close_context(&mut self, context_id: &str) -> Result<(), ClientError> {
+        let mut state = self
+            .contexts
+            .remove(context_id)
+            .ok_or_else(|| ClientError::UnknownContext(context_id.to_owned()))?;
+        destroy_group(&mut state.crypto.mls_group)?;
+        self.pending_joins.remove(context_id);
+        Ok(())
+    }
+
+    // ----------------------------------------------------------------------
+    // Sender-key exchange (out-of-band — see crate root MISSING SEAM note)
+    // ----------------------------------------------------------------------
+
+    /// Returns this participant's local sender-key bytes for `context_id`.
+    ///
+    /// The driver has no in-tab cross-member sender-key distribution path (a
+    /// pre-existing gap inherited from the deleted bridge; ADR-057 defers
+    /// HPKE-sealed distribution over the MLS `scp_wrapping_key` extension to a
+    /// later slice). For the MVP the caller hands these bytes to peers
+    /// out-of-band and they install them via [`Self::install_sender_key`].
+    ///
+    /// # Errors
+    ///
+    /// Returns [`ClientError::UnknownContext`] if the context is not held.
+    pub fn local_sender_key_bytes(&self, context_id: &str) -> Result<[u8; 32], ClientError> {
+        self.contexts
+            .get(context_id)
+            .map(|s| s.crypto.local_sender_key_bytes())
+            .ok_or_else(|| ClientError::UnknownContext(context_id.to_owned()))
+    }
+
+    /// Installs a peer's sender key for `context_id` (received out-of-band).
+    ///
+    /// See [`Self::local_sender_key_bytes`] for why distribution is out-of-band
+    /// in the MVP.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`ClientError::UnknownContext`] if the context is not held.
+    pub fn install_sender_key(
+        &mut self,
+        context_id: &str,
+        sender_did: &str,
+        key_bytes: [u8; 32],
+    ) -> Result<(), ClientError> {
+        let state = self.context_mut(context_id)?;
+        state
+            .crypto
+            .insert_sender_key(sender_did, SenderKey::from_bytes(key_bytes));
+        Ok(())
+    }
+
+    // ----------------------------------------------------------------------
+    // Queries
+    // ----------------------------------------------------------------------
+
+    /// Returns the member DIDs of `context_id`, or `None` if not held.
+    #[must_use]
+    pub fn member_dids(&self, context_id: &str) -> Option<Vec<String>> {
+        self.contexts.get(context_id).map(|s| s.members.clone())
+    }
+
+    /// Returns the event-log Merkle root for `context_id`, or `None` if not held.
+    #[must_use]
+    pub fn event_log_root(&self, context_id: &str) -> Option<[u8; 32]> {
+        self.contexts
+            .get(context_id)
+            .map(PerContextState::event_log_root)
+    }
+
+    /// Returns the event-log leaf count for `context_id`, or `None` if not held.
+    #[must_use]
+    pub fn event_log_leaf_count(&self, context_id: &str) -> Option<u64> {
+        self.contexts
+            .get(context_id)
+            .map(PerContextState::event_log_leaf_count)
+    }
+
+    /// Returns the event-log leaf hashes (sequence order) for `context_id`, or
+    /// `None` if not held.
+    ///
+    /// Used to assert the §9.9.3 per-leaf convergence property: two members'
+    /// leaves for the same logical event are byte-identical.
+    #[must_use]
+    pub fn event_log_leaf_hashes(&self, context_id: &str) -> Option<Vec<[u8; 32]>> {
+        self.contexts
+            .get(context_id)
+            .map(PerContextState::event_log_leaf_hashes)
+    }
+}
+
+/// Serializes an MLS message to wire bytes.
+fn serialize_message(message: &MlsMessageOut) -> Result<Vec<u8>, ClientError> {
+    message
+        .tls_serialize_detached()
+        .map_err(|e| ClientError::Codec(format!("serializing MLS message: {e}")))
+}
+
+/// Recovers the SCP DID embedded in a serialized key package's leaf credential.
+///
+/// The driver names the new member by reading their credential out of the key
+/// package, rather than trusting a separately-supplied DID, so the membership
+/// record and the MLS leaf cannot disagree.
+fn key_package_member_did(key_package_bytes: &[u8]) -> Result<String, ClientError> {
+    let key_package_in = KeyPackageIn::tls_deserialize(&mut &*key_package_bytes)
+        .map_err(|e| ClientError::Codec(format!("deserializing key package: {e}")))?;
+    let did = key_package_in_did(&key_package_in, ProtocolVersion::Mls10)?;
+    Ok(did)
+}

--- a/crates/scp-client/src/client.rs
+++ b/crates/scp-client/src/client.rs
@@ -417,13 +417,29 @@ impl ScpClient {
     /// ([`SendOutput::committer_timestamp_secs`]), or on the `MemberJoined`
     /// leaf for an add Commit ([`AddMemberOutput::committer_timestamp_secs`]).
     ///
+    // SECURITY (ADR-057, leaf-signing/custody slice): `committer_timestamp_secs`
+    // is presently an UNAUTHENTICATED value transported alongside the ciphertext.
+    // It is NOT bound to the MLS ciphertext (it is not part of the §9.16 AEAD
+    // AAD) and the event-log leaves it stamps are unsigned, so a hostile relay
+    // (or any in-path attacker) could forge or alter it and drive this receiver's
+    // `MessageSent` / `MemberJoined` leaf — and thus its Merkle root — away from
+    // the honest committer's, breaking convergence. The MVP "dumb pipe" is a
+    // trusted in-process test harness, so this is acceptable ONLY until a real
+    // relay/transport is wired. Before that wiring, this timestamp MUST be bound
+    // into a signed leaf or a signed transport envelope (so a recipient verifies
+    // the committer's signature over the timestamp) rather than trusted on the
+    // wire.
+    ///
     /// # Errors
     ///
     /// Returns [`ClientError::UnknownContext`] if the context is not held,
     /// [`ClientError::UnsupportedMembershipChange`] if the Commit removes a
-    /// member (Slice 2 has no convergent removal-leaf transport — the driver
-    /// refuses to merge silently rather than diverge), or a crypto/leaf error
-    /// on failure.
+    /// member (Slice 2 has no convergent removal-leaf transport). In that case
+    /// `scp-mls` rejected the Commit *before* merging, so the context's MLS
+    /// epoch, SCP membership, and event log are left mutually consistent
+    /// (pre-remove) and the context stays usable — the driver surfaces the gap
+    /// rather than half-applying it. Otherwise returns a crypto/leaf error on
+    /// failure.
     pub fn receive_message(
         &mut self,
         context_id: &str,
@@ -448,9 +464,8 @@ impl ScpClient {
                 });
                 Ok(true)
             }
-            Inbound::Commit {
-                sender_did: committer_did,
-                added_dids,
+            Inbound::UnsupportedMembershipChange {
+                sender_did: _committer_did,
                 removed_dids,
             } => {
                 // Slice 2 is the participant add path. A Commit that EVICTS a
@@ -460,19 +475,27 @@ impl ScpClient {
                 // transports one for adds). Merging it while dropping the
                 // membership leaf would silently diverge this member's log from
                 // the committer's — exactly the bug this method fixes for adds.
-                // Refuse loudly instead. Note the MLS group has ALREADY merged
-                // the commit inside `decrypt_message`; the context is left in a
-                // deliberately-failed state so the caller surfaces the gap
-                // rather than proceeding on a diverged log.
-                if !removed_dids.is_empty() {
-                    return Err(ClientError::UnsupportedMembershipChange(format!(
-                        "received a Commit removing {} member(s) ({}); convergent \
-                         removal is out of ADR-057 Slice 2 scope",
-                        removed_dids.len(),
-                        removed_dids.join(", ")
-                    )));
-                }
-
+                //
+                // FAIL-CLOSED WITHOUT SKEW: `scp-mls` already REJECTED this
+                // Commit *before* merging (it inspected the staged commit's
+                // Remove proposals and dropped the StagedCommit), so the MLS
+                // group is still on its pre-Commit epoch and this context's MLS
+                // state, SCP membership set, and event log all remain mutually
+                // consistent (pre-remove). The context is left fully usable; we
+                // simply surface the gap to the caller rather than silently
+                // diverging. The caller may keep using the context on the old
+                // epoch.
+                Err(ClientError::UnsupportedMembershipChange(format!(
+                    "received a Commit removing {} member(s) ({}); convergent \
+                     removal is out of ADR-057 Slice 2 scope",
+                    removed_dids.len(),
+                    removed_dids.join(", ")
+                )))
+            }
+            Inbound::Commit {
+                sender_did: committer_did,
+                added_dids,
+            } => {
                 // For each added member, append the identical convergent
                 // `MemberJoined` leaf the committer appended: actor = committer
                 // DID, timestamp = transported convergent T, empty payload. The
@@ -603,6 +626,25 @@ impl ScpClient {
         self.contexts
             .get(context_id)
             .map(PerContextState::event_log_leaf_hashes)
+    }
+
+    /// Returns the MLS group epoch for `context_id`.
+    ///
+    /// The MLS epoch advances on every applied Commit. It is exposed so callers
+    /// (and convergence/consistency tests) can observe that the MLS layer and the
+    /// SCP layer stay in step — e.g. that a rejected (Remove-bearing) Commit did
+    /// NOT half-advance the epoch while leaving membership/log behind.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`ClientError::UnknownContext`] if the context is not held, or
+    /// [`ClientError::Mls`] if the MLS group has been destroyed.
+    pub fn mls_epoch(&self, context_id: &str) -> Result<u64, ClientError> {
+        let state = self
+            .contexts
+            .get(context_id)
+            .ok_or_else(|| ClientError::UnknownContext(context_id.to_owned()))?;
+        Ok(state.crypto.mls_group.epoch()?)
     }
 }
 

--- a/crates/scp-client/src/client.rs
+++ b/crates/scp-client/src/client.rs
@@ -61,17 +61,29 @@ struct PendingJoin {
 /// plus the convergent committer timestamp the adder stamped on its
 /// `MemberJoined` leaf.
 ///
-/// `commit` goes to all *existing* members (they apply it via
-/// [`ScpClient::receive_message`], which classifies it as a control message and
-/// advances their MLS epoch). `welcome` goes to the *new* member (they apply it
-/// via [`ScpClient::join_context_encrypted`], passing `committer_timestamp_secs`
-/// so their mirrored `MemberJoined` leaf converges with the adder's).
+/// `commit` goes to all *existing* members. They apply it via
+/// [`ScpClient::receive_message`], which classifies it as a membership-changing
+/// Commit, advances their MLS epoch, and — using `committer_timestamp_secs`
+/// transported here exactly as [`SendOutput::committer_timestamp_secs`] is for
+/// messages — appends the identical `MemberJoined` leaf so their event log and
+/// membership set converge with the committer's and the joiner's.
+///
+/// `welcome` goes to the *new* member, who applies it via
+/// [`ScpClient::join_context_encrypted`] and replays `event_log` (which already
+/// contains the committer-stamped `MemberJoined` leaf), so the joiner's log is
+/// byte-identical to the committer's.
 #[derive(Debug, Clone)]
 pub struct AddMemberOutput {
     /// TLS-serialized MLS Commit for existing members.
     pub commit: Vec<u8>,
     /// TLS-serialized MLS Welcome for the new member.
     pub welcome: Vec<u8>,
+    /// The convergent committer timestamp (Unix seconds) the adder stamped on
+    /// its `MemberJoined` leaf. Transported to existing members alongside
+    /// `commit` so their mirrored `MemberJoined` leaf carries the SAME
+    /// timestamp and converges byte-for-byte (§9.9.3). The joiner does not need
+    /// it separately — its copy already rides inside `event_log`.
+    pub committer_timestamp_secs: u64,
     /// The adder's full event-log stream AFTER the add (the prior context
     /// history plus the new `MemberJoined` leaf). The joiner replays this
     /// verbatim to reconstruct a byte-identical log and converge to the same
@@ -272,6 +284,7 @@ impl ScpClient {
         Ok(AddMemberOutput {
             commit,
             welcome,
+            committer_timestamp_secs: timestamp,
             event_log: state.events(),
             members: state.members.clone(),
         })
@@ -381,27 +394,36 @@ impl ScpClient {
         })
     }
 
-    /// Receives an inbound MLS message in `context_id`: decrypts it (or applies
-    /// it as a control commit), and buffers the resulting event.
+    /// Receives an inbound MLS message in `context_id`: decrypts an application
+    /// message, or applies a membership-changing Commit, converging the event
+    /// log either way.
     ///
-    /// An application message produces a `MessageReceived` event (buffered for
-    /// [`Self::drain_events`]) and appends a `MessageSent` leaf stamped with the
-    /// supplied committer timestamp, so the receiver's log converges with the
-    /// sender's. A control message (commit/proposal) advances the MLS group
-    /// silently and produces no buffered event and no leaf (the membership leaf
-    /// for an add is recorded by the joiner's own join path).
+    /// - **Application message** → produces a `MessageReceived` event (buffered
+    ///   for [`Self::drain_events`]) and appends a `MessageSent` leaf stamped
+    ///   with the supplied `committer_timestamp_secs`, so the receiver's log
+    ///   converges with the sender's. Returns `true`.
+    /// - **Membership-changing Commit (add)** → advances the MLS epoch and, for
+    ///   each member the Commit adds, appends the SAME convergent
+    ///   `MemberJoined` leaf the committer appended — committer DID + the
+    ///   transported `committer_timestamp_secs` ([`AddMemberOutput::committer_timestamp_secs`])
+    ///   — and records the added member. This is what makes an EXISTING member's
+    ///   log and membership set converge with the committer's and the new
+    ///   joiner's in a multi-party context (§9.9.3). Returns `false` (no
+    ///   application payload was produced).
+    /// - **Bare proposal** → cached by `scp-mls`; no leaf, returns `false`.
     ///
-    /// `committer_timestamp_secs` is the convergent timestamp the sender stamped
-    /// on its `MessageSent` leaf (transported alongside the ciphertext). For a
-    /// control message it is ignored.
-    ///
-    /// Returns `true` if an application message was decrypted and buffered,
-    /// `false` for a control message.
+    /// `committer_timestamp_secs` is the convergent timestamp the committer
+    /// stamped: on a `MessageSent` leaf for an application message
+    /// ([`SendOutput::committer_timestamp_secs`]), or on the `MemberJoined`
+    /// leaf for an add Commit ([`AddMemberOutput::committer_timestamp_secs`]).
     ///
     /// # Errors
     ///
-    /// Returns [`ClientError::UnknownContext`] if the context is not held, or a
-    /// crypto/leaf error on failure.
+    /// Returns [`ClientError::UnknownContext`] if the context is not held,
+    /// [`ClientError::UnsupportedMembershipChange`] if the Commit removes a
+    /// member (Slice 2 has no convergent removal-leaf transport — the driver
+    /// refuses to merge silently rather than diverge), or a crypto/leaf error
+    /// on failure.
     pub fn receive_message(
         &mut self,
         context_id: &str,
@@ -426,7 +448,50 @@ impl ScpClient {
                 });
                 Ok(true)
             }
-            Inbound::Control { .. } => Ok(false),
+            Inbound::Commit {
+                sender_did: committer_did,
+                added_dids,
+                removed_dids,
+            } => {
+                // Slice 2 is the participant add path. A Commit that EVICTS a
+                // member has no convergent removal-leaf transport yet (there is
+                // no committer-side op that stamps a `MemberLeft` leaf with a
+                // convergent timestamp to transport, the way `add_member`
+                // transports one for adds). Merging it while dropping the
+                // membership leaf would silently diverge this member's log from
+                // the committer's — exactly the bug this method fixes for adds.
+                // Refuse loudly instead. Note the MLS group has ALREADY merged
+                // the commit inside `decrypt_message`; the context is left in a
+                // deliberately-failed state so the caller surfaces the gap
+                // rather than proceeding on a diverged log.
+                if !removed_dids.is_empty() {
+                    return Err(ClientError::UnsupportedMembershipChange(format!(
+                        "received a Commit removing {} member(s) ({}); convergent \
+                         removal is out of ADR-057 Slice 2 scope",
+                        removed_dids.len(),
+                        removed_dids.join(", ")
+                    )));
+                }
+
+                // For each added member, append the identical convergent
+                // `MemberJoined` leaf the committer appended: actor = committer
+                // DID, timestamp = transported convergent T, empty payload. The
+                // sequence + prev_hash are recomputed from this member's
+                // current log, which (by the convergence invariant) is at the
+                // same state the committer's was before the add — so the leaf is
+                // byte-identical. Then record the member in the membership set.
+                for added_did in &added_dids {
+                    state.append_log_event(
+                        EventType::MemberJoined,
+                        &committer_did,
+                        Vec::new(),
+                        committer_timestamp_secs,
+                    )?;
+                    state.add_member_record(added_did);
+                }
+                Ok(false)
+            }
+            Inbound::Proposal { .. } => Ok(false),
         }
     }
 

--- a/crates/scp-client/src/context.rs
+++ b/crates/scp-client/src/context.rs
@@ -1,0 +1,219 @@
+//! Per-context participant state.
+//!
+//! [`PerContextState`] is the driver's per-context record: the crypto state
+//! ([`ContextCryptoState`]), the canonical event log
+//! ([`scp_event_log::EventLog`]), the membership set with per-member message
+//! sequence counters, and the pull-based receive buffer of
+//! [`ContextEvent`](scp_protocol::context::membership::ContextEvent)s.
+//!
+//! It restores the deleted WASM bridge's `PerContextState` shape — a pull-based
+//! `drain_events` model and a committer-assigned event-log timestamp — while
+//! holding only the **participant message-path** fields (ADR-057 scope fence:
+//! no governance/economy/tools/broadcast state).
+
+use std::collections::{HashMap, VecDeque};
+
+use scp_event_log::tree::{GENESIS_PREV_HASH, append_unsigned_event, event_count, root};
+use scp_event_log::{DID, Event, EventLog, EventPayload, EventType};
+use scp_protocol::context::membership::ContextEvent;
+
+use crate::crypto_state::ContextCryptoState;
+
+/// Maximum events held in the pull-based receive buffer before the oldest is
+/// dropped (FIFO overflow). Mirrors the deleted bridge's `WASM_EVENT_BUFFER_CAP`
+/// and the native `PyO3` channel capacity, so a slow drainer cannot grow memory
+/// without bound.
+pub const EVENT_BUFFER_CAP: usize = 1000;
+
+/// Participant state for a single context.
+pub struct PerContextState {
+    /// MLS + sender-key crypto state (the §9.16 double-encryption pipeline).
+    pub crypto: ContextCryptoState,
+    /// Canonical Merkle event log (shared `scp-event-log` implementation). The
+    /// convergence property the MVP test asserts is a property of THIS log
+    /// being driven by shared append logic on both members.
+    pub event_log: EventLog,
+    /// Membership set: member DIDs in the context.
+    ///
+    /// Insertion-ordered is not required for convergence (the event log carries
+    /// order); a `Vec` keeps the set small and cheap for the MVP. Membership is
+    /// authoritative at the driver level for "who is in the context"; the MLS
+    /// tree is authoritative for who can derive keys.
+    pub members: Vec<String>,
+    /// Per-member next-outgoing message sequence number, keyed by member DID.
+    ///
+    /// This is ENCRYPTION state (the next sequence each sender will stamp), not
+    /// membership state. Seeded to 0 when a member joins/is added, and
+    /// incremented after each `send_message`.
+    pub member_sequence_numbers: HashMap<String, u64>,
+    /// Pull-based receive buffer. Drained by `ScpClient::drain_events`.
+    pub event_buffer: VecDeque<ContextEvent>,
+}
+
+impl PerContextState {
+    /// Creates fresh per-context state around an already-built crypto state and
+    /// a fresh event log for `context_id`, with `creator_did` as the sole
+    /// initial member (sequence 0).
+    #[must_use]
+    pub fn new(context_id: &str, creator_did: &str, crypto: ContextCryptoState) -> Self {
+        let mut member_sequence_numbers = HashMap::new();
+        member_sequence_numbers.insert(creator_did.to_owned(), 0);
+        Self {
+            crypto,
+            event_log: EventLog::new(context_id.to_owned()),
+            members: vec![creator_did.to_owned()],
+            member_sequence_numbers,
+            event_buffer: VecDeque::new(),
+        }
+    }
+
+    /// Creates fresh per-context state with an EMPTY event log and EMPTY
+    /// membership, for a joiner that will replay the adder's stream and adopt
+    /// the adder's membership snapshot.
+    #[must_use]
+    pub fn new_empty(context_id: &str, crypto: ContextCryptoState) -> Self {
+        Self {
+            crypto,
+            event_log: EventLog::new(context_id.to_owned()),
+            members: Vec::new(),
+            member_sequence_numbers: HashMap::new(),
+            event_buffer: VecDeque::new(),
+        }
+    }
+
+    /// Records a member in the context's membership set and seeds their
+    /// outgoing-sequence counter. A no-op if the member is already present.
+    pub fn add_member_record(&mut self, member_did: &str) {
+        if !self.members.iter().any(|m| m == member_did) {
+            self.members.push(member_did.to_owned());
+        }
+        self.member_sequence_numbers
+            .entry(member_did.to_owned())
+            .or_insert(0);
+    }
+
+    /// Returns and post-increments this member's next outgoing sequence number.
+    ///
+    /// Returns 0 (and seeds the counter) if the member has no counter yet.
+    pub fn next_sequence(&mut self, member_did: &str) -> u64 {
+        let entry = self
+            .member_sequence_numbers
+            .entry(member_did.to_owned())
+            .or_insert(0);
+        let seq = *entry;
+        *entry = entry.saturating_add(1);
+        seq
+    }
+
+    /// Pushes an event onto the receive buffer, evicting the oldest at capacity.
+    pub fn push_event(&mut self, event: ContextEvent) {
+        if self.event_buffer.len() >= EVENT_BUFFER_CAP {
+            self.event_buffer.pop_front();
+        }
+        self.event_buffer.push_back(event);
+    }
+
+    /// Drains all buffered receive events in FIFO order.
+    pub fn drain_events(&mut self) -> Vec<ContextEvent> {
+        self.event_buffer.drain(..).collect()
+    }
+
+    /// Returns the current event-log Merkle root.
+    #[must_use]
+    pub fn event_log_root(&self) -> [u8; 32] {
+        root(&self.event_log)
+    }
+
+    /// Returns the number of leaves (events) in the event log.
+    #[must_use]
+    pub const fn event_log_leaf_count(&self) -> u64 {
+        event_count(&self.event_log)
+    }
+
+    /// Returns a clone of the full ordered event stream.
+    ///
+    /// Used by the join path to hand a newly-added member the adder's prior log
+    /// so they can replay it and converge (§7.3.1 context-state import).
+    #[must_use]
+    pub fn events(&self) -> Vec<Event> {
+        self.event_log.events().to_vec()
+    }
+
+    /// Replays a verbatim event onto the log via the canonical append path.
+    ///
+    /// Unlike [`Self::append_log_event`], this does NOT recompute `sequence` or
+    /// `prev_hash` — it appends the event exactly as received, so the canonical
+    /// append validation ([`append_unsigned_event`]) enforces that the replayed
+    /// event chains correctly onto the current log. Replaying the adder's full
+    /// prior log this way reconstructs a byte-identical log on the joiner
+    /// (identical leaves and identical root), which is the §9.9.3 convergence
+    /// property realized by shared append code.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`scp_event_log::EventLogError`] if the event does not chain onto
+    /// the current log (sequence or `prev_hash` mismatch) — i.e. the replay
+    /// stream is out of order or does not start from this log's current head.
+    pub fn replay_event(&mut self, event: &Event) -> Result<(), scp_event_log::EventLogError> {
+        append_unsigned_event(&mut self.event_log, event)?;
+        Ok(())
+    }
+
+    /// Returns the event-log leaf hashes in sequence order.
+    ///
+    /// Each entry is the canonical leaf hash of the event at that sequence
+    /// position. Two members that recorded the same logical event with the same
+    /// committer-assigned inputs produce byte-identical leaf hashes here — the
+    /// per-leaf form of the §9.9.3 convergence property the participant driver
+    /// must satisfy across native and wasm32.
+    #[must_use]
+    pub fn event_log_leaf_hashes(&self) -> Vec<[u8; 32]> {
+        self.event_log.leaves().to_vec()
+    }
+
+    /// Appends a protocol event to the context's event log.
+    ///
+    /// Constructs a full [`Event`] with the correct sequence number and
+    /// `prev_hash` chain link, then delegates to
+    /// [`append_unsigned_event`]. The leaf carries an empty signature: the
+    /// driver MVP does not yet thread the on-device signing key into the leaf
+    /// (the leaf-signing seam is a later custody slice). The leaf *preimage*
+    /// (which excludes the signature) is what feeds the Merkle root, so an
+    /// unsigned leaf still converges byte-for-byte across members.
+    ///
+    /// `timestamp_secs` is the **committer-assigned** convergent leaf timestamp
+    /// (Unix seconds), matching the native runtime: every member that records
+    /// the same logical event stamps the SAME timestamp (the creator's, copied
+    /// by peers), NEVER each member's local `now()`. Per-member `now()` would
+    /// diverge the leaf preimage and break the equal-count / equal-root
+    /// convergence property a browser member and a native member must both
+    /// satisfy (§7.3.1, §9.9.3).
+    ///
+    /// # Errors
+    ///
+    /// Returns [`scp_event_log::EventLogError`] if the append fails (sequence
+    /// or `prev_hash` mismatch — unreachable here because both are computed
+    /// from the current log state).
+    pub fn append_log_event(
+        &mut self,
+        event_type: EventType,
+        actor_did: &str,
+        payload: Vec<u8>,
+        timestamp_secs: u64,
+    ) -> Result<(), scp_event_log::EventLogError> {
+        let sequence = event_count(&self.event_log);
+        let leaves = self.event_log.leaves();
+        let prev_hash = leaves.last().copied().unwrap_or(GENESIS_PREV_HASH);
+        let event = Event {
+            event_type,
+            actor_did: DID::from(actor_did.to_owned()),
+            timestamp: timestamp_secs,
+            sequence,
+            payload: EventPayload { data: payload },
+            prev_hash,
+            signature: vec![],
+        };
+        append_unsigned_event(&mut self.event_log, &event)?;
+        Ok(())
+    }
+}

--- a/crates/scp-client/src/crypto_state.rs
+++ b/crates/scp-client/src/crypto_state.rs
@@ -54,14 +54,16 @@ pub const INITIAL_SENDER_KEY_EPOCH: u64 = 1;
 ///
 /// Distinguishes an application message (carrying recovered plaintext and the
 /// sender DID) from a control message. A control message is further split into
-/// a **membership-changing Commit** (carrying the DIDs the Commit added/removed,
-/// recovered from the staged commit before merge — see
-/// [`decrypt_with_membership_changes`]) and a bare proposal. The driver maps an
-/// application message into a `MessageReceived` event, mirrors a Commit's
-/// membership changes onto its event log + membership set (so existing members
-/// converge with the committer and the new joiner), and treats a proposal as a
-/// silent cache.
-#[derive(Debug, Clone, PartialEq, Eq)]
+/// an **add-only membership-changing Commit** (carrying the DIDs the Commit
+/// added, recovered from the staged commit before merge — see
+/// [`decrypt_with_membership_changes`]), an **unsupported (Remove-bearing)
+/// Commit** that `scp-mls` rejected *without merging* (leaving MLS + SCP state
+/// consistent), and a bare proposal. The driver maps an application message into
+/// a `MessageReceived` event, mirrors an add Commit's membership change onto its
+/// event log + membership set (so existing members converge with the committer
+/// and the new joiner), maps the unsupported variant to a fail-closed error, and
+/// treats a proposal as a silent cache.
+#[derive(Clone, PartialEq, Eq)]
 pub enum Inbound {
     /// An application message: recovered plaintext plus the sender's DID.
     Application {
@@ -70,16 +72,27 @@ pub enum Inbound {
         /// The fully decrypted plaintext.
         plaintext: Vec<u8>,
     },
-    /// A Commit that advanced the group epoch. `scp-mls` has already merged it;
-    /// `added_dids` / `removed_dids` are the SCP DIDs the Commit's Add/Remove
-    /// proposals add and evict (in proposal order), for the driver to mirror
-    /// onto its SCP-layer membership + event log.
+    /// An **add-only** Commit that advanced the group epoch. `scp-mls` has
+    /// already merged it; `added_dids` are the SCP DIDs the Commit's Add
+    /// proposals add (in proposal order), for the driver to mirror onto its
+    /// SCP-layer membership + event log.
     Commit {
         /// The committer's DID, extracted from the MLS credential.
         sender_did: String,
         /// DIDs added by this Commit's Add proposals.
         added_dids: Vec<String>,
-        /// DIDs removed by this Commit's Remove proposals.
+    },
+    /// A Commit carrying one or more Remove proposals, which the participant
+    /// driver does not converge. `scp-mls` **dropped the staged commit without
+    /// merging**, so the MLS group is still on its pre-Commit epoch and remains
+    /// consistent with the driver's SCP-layer state. The driver maps this to a
+    /// fail-closed [`ClientError::UnsupportedMembershipChange`] without further
+    /// mutating state.
+    UnsupportedMembershipChange {
+        /// The committer's DID, extracted from the MLS credential.
+        sender_did: String,
+        /// DIDs the rejected Commit's Remove proposals would evict, read from
+        /// the pre-merge tree.
         removed_dids: Vec<String>,
     },
     /// A bare proposal cached by `scp-mls`; no membership change is committed.
@@ -87,6 +100,51 @@ pub enum Inbound {
         /// The sender's DID, extracted from the MLS credential.
         sender_did: String,
     },
+}
+
+impl std::fmt::Debug for Inbound {
+    /// Manual `Debug` that REDACTS the decrypted plaintext.
+    ///
+    /// Per ADR-057 the tab boundary is the plaintext boundary: a
+    /// `{:?}`-formatted [`Inbound::Application`] must never leak the recovered
+    /// cleartext into logs, panics, or test output. Only the byte length is
+    /// printed; the control variants forward their (non-secret) fields. Mirrors
+    /// the redacting `Debug` on the underlying [`InboundChange`].
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Application {
+                sender_did,
+                plaintext,
+            } => f
+                .debug_struct("Application")
+                .field("sender_did", sender_did)
+                .field(
+                    "plaintext",
+                    &format_args!("<redacted {} bytes>", plaintext.len()),
+                )
+                .finish(),
+            Self::Commit {
+                sender_did,
+                added_dids,
+            } => f
+                .debug_struct("Commit")
+                .field("sender_did", sender_did)
+                .field("added_dids", added_dids)
+                .finish(),
+            Self::UnsupportedMembershipChange {
+                sender_did,
+                removed_dids,
+            } => f
+                .debug_struct("UnsupportedMembershipChange")
+                .field("sender_did", sender_did)
+                .field("removed_dids", removed_dids)
+                .finish(),
+            Self::Proposal { sender_did } => f
+                .debug_struct("Proposal")
+                .field("sender_did", sender_did)
+                .finish(),
+        }
+    }
 }
 
 /// Combined MLS + sender-key state for a single context.
@@ -207,10 +265,14 @@ impl ContextCryptoState {
     /// pipeline, classifying it as application, membership-changing Commit, or
     /// bare proposal.
     ///
-    /// For a Commit or proposal the group state is advanced/cached by `scp-mls`
-    /// (a Commit is merged; its Add/Remove DIDs are recovered from the staged
-    /// commit before merge) and an [`Inbound::Commit`] / [`Inbound::Proposal`]
-    /// is returned immediately — the sender-key layer is not involved.
+    /// For a control message the sender-key layer is not involved:
+    /// - an **add-only Commit** is merged by `scp-mls` (its added DIDs recovered
+    ///   from the staged commit before merge) and [`Inbound::Commit`] is
+    ///   returned;
+    /// - a **Remove-bearing Commit** is rejected by `scp-mls` *without merging*
+    ///   (the group stays on its current epoch, MLS + SCP state consistent) and
+    ///   [`Inbound::UnsupportedMembershipChange`] is returned;
+    /// - a bare proposal is cached and [`Inbound::Proposal`] is returned.
     ///
     /// For an application message:
     /// 1. Parse the 16-byte `epoch || sequence` header — authoritative.
@@ -239,11 +301,18 @@ impl ContextCryptoState {
             InboundChange::Commit {
                 sender_did,
                 added_dids,
-                removed_dids,
             } => {
                 return Ok(Inbound::Commit {
                     sender_did,
                     added_dids,
+                });
+            }
+            InboundChange::UnsupportedMembershipChange {
+                sender_did,
+                removed_dids,
+            } => {
+                return Ok(Inbound::UnsupportedMembershipChange {
+                    sender_did,
                     removed_dids,
                 });
             }
@@ -411,11 +480,9 @@ mod tests {
             Inbound::Commit {
                 sender_did,
                 added_dids,
-                removed_dids,
             } => {
                 assert_eq!(sender_did, ALICE, "committer is Alice");
                 assert_eq!(added_dids, vec![BOB.to_owned()], "Bob's DID surfaced");
-                assert!(removed_dids.is_empty());
             }
             other => panic!("expected Inbound::Commit, got {other:?}"),
         }
@@ -485,6 +552,31 @@ mod tests {
         assert!(
             !bob.recv_sequence_tracker.contains_key(ALICE),
             "a ceiling-rejected message must not advance the replay tracker"
+        );
+    }
+
+    #[test]
+    fn debug_redacts_application_plaintext() {
+        // ADR-057: the tab boundary is the plaintext boundary. A `{:?}`-formatted
+        // Inbound::Application must print the byte length, NEVER the cleartext.
+        let secret = b"TOP-SECRET-PLAINTEXT-NEVER-LOG-ME";
+        let inbound = Inbound::Application {
+            sender_did: ALICE.to_owned(),
+            plaintext: secret.to_vec(),
+        };
+        let rendered = format!("{inbound:?}");
+        assert!(
+            !rendered.contains("TOP-SECRET-PLAINTEXT-NEVER-LOG-ME"),
+            "Debug must NOT leak the decrypted plaintext, got: {rendered}"
+        );
+        assert!(
+            rendered.contains("<redacted") && rendered.contains(&format!("{} bytes", secret.len())),
+            "Debug must report a redacted byte length, got: {rendered}"
+        );
+        // The sender DID is not secret and may be shown.
+        assert!(
+            rendered.contains(ALICE),
+            "sender DID may appear: {rendered}"
         );
     }
 }

--- a/crates/scp-client/src/crypto_state.rs
+++ b/crates/scp-client/src/crypto_state.rs
@@ -1,0 +1,409 @@
+//! Double-encryption (§9.16) orchestration for a single context.
+//!
+//! [`ContextCryptoState`] holds an MLS group ([`scp_mls::ScpMlsGroup`]) and a
+//! sender-key store, providing the full SCP double-encryption pipeline:
+//! sender-key encrypt → MLS encrypt (on send) and MLS decrypt → sender-key
+//! decrypt (on receive).
+//!
+//! This restores the *shape* of the deleted WASM bridge's `WasmCryptoState`
+//! (the pinned `1a3b41a5e^` restoration source named by ADR-057), but every
+//! body calls the **shared** `scp-mls` MLS state machine and the **shared**
+//! `scp_protocol::crypto::sender_keys` layer rather than a wasm-local
+//! re-implementation. There is exactly one MLS implementation and one
+//! sender-key implementation; this struct only sequences them.
+//!
+//! The sender-layer wire format mirrors the native runtime so a native member
+//! and a browser member cross-decrypt (§9.16.1):
+//!
+//! - Each MLS application plaintext is `epoch (8B BE) || sequence (8B BE) ||
+//!   sender_key_ciphertext` (the shared
+//!   [`build_sender_header`](scp_protocol::crypto::sender_keys::encrypt::build_sender_header)).
+//!   The `epoch` is this participant's monotonic per-context **sender-key
+//!   epoch** (§9.16.5: initialized to 1 on keygen, advanced only on
+//!   block/rotation — NOT on MLS epoch advances).
+//! - Recipients reconstruct the AEAD AAD from the parsed header (the header is
+//!   authoritative), enforce the epoch-poisoning ceiling
+//!   ([`MAX_EPOCH_ADVANCE`](scp_protocol::crypto::sender_keys::MAX_EPOCH_ADVANCE))
+//!   BEFORE recording the replay tracker, then reject replays/reorders via a
+//!   per-sender `(last_epoch, last_sequence)` tracker.
+
+use std::collections::HashMap;
+
+use scp_mls::ScpMlsGroup;
+use scp_mls::encrypt::{DecryptedContent, decrypt_with_sender_did, encrypt, serialize_ciphertext};
+use scp_protocol::crypto::sender_keys::encrypt::{
+    build_sender_header, decrypt_sender_layer, encrypt_sender_layer, parse_sender_header,
+};
+use scp_protocol::crypto::sender_keys::{
+    MAX_EPOCH_ADVANCE, SenderKey, SenderKeyStore, generate_sender_key,
+};
+
+use crate::error::ClientError;
+
+/// The sender-key epoch a freshly generated key starts at (§9.16.5).
+///
+/// Mirrors the native `MlsCryptoProvider`, which seeds `sender_key_epoch = 1`
+/// at keygen. Starting at 1 (not 0) keeps the first application message's
+/// 8-byte big-endian epoch prefix as `0x0000000000000001`, which can never
+/// collide with the 4-byte `SCPM_MAGIC` management prefix (§9.16.1).
+pub const INITIAL_SENDER_KEY_EPOCH: u64 = 1;
+
+/// The outcome of decrypting an inbound MLS message.
+///
+/// Distinguishes an application message (carrying recovered plaintext and the
+/// sender DID) from a control message (a commit/proposal that advanced or
+/// proposed group state but produced no user payload). The driver maps the
+/// former into a `MessageReceived` event and treats the latter as a silent
+/// group-state advance.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum Inbound {
+    /// An application message: recovered plaintext plus the sender's DID.
+    Application {
+        /// The sender's DID, extracted from the MLS credential.
+        sender_did: String,
+        /// The fully decrypted plaintext.
+        plaintext: Vec<u8>,
+    },
+    /// A control message (commit/proposal). The group state has already been
+    /// advanced/cached by `scp-mls`; no plaintext is produced.
+    Control {
+        /// The sender's DID, extracted from the MLS credential.
+        sender_did: String,
+    },
+}
+
+/// Combined MLS + sender-key state for a single context.
+///
+/// Owns the MLS group and this participant's sender key, plus the store of
+/// other members' sender keys and the receive-side replay tracker. The double
+/// encryption pipeline is:
+///
+/// **Send:** `plaintext` → sender-key encrypt → prepend header → MLS encrypt
+/// **Receive:** MLS decrypt → parse header → ceiling + replay → sender-key
+/// decrypt → `plaintext`
+pub struct ContextCryptoState {
+    /// The MLS group for this context (shared `scp-mls` type).
+    pub mls_group: ScpMlsGroup,
+    /// This participant's own sender key.
+    pub local_sender_key: SenderKey,
+    /// The raw `context_id` string this state belongs to. Used as the
+    /// [`SenderKeyStore`] outer key and as the AEAD-AAD context binding
+    /// (§9.16.1 binds the RAW string, matching native `seal`/`open`).
+    pub context_id: String,
+    /// This participant's monotonic sender-key epoch (§9.16.5). Initialized to
+    /// [`INITIAL_SENDER_KEY_EPOCH`]; advanced only on block/rotation. Fed into
+    /// BOTH the AEAD AAD and the 16-byte header on every send.
+    pub sender_key_epoch: u64,
+    /// Other participants' sender keys, keyed by `(context_id, sender_did)`.
+    pub sender_key_store: SenderKeyStore,
+    /// Receive-side replay detection: `sender_did → (last_epoch,
+    /// last_sequence)`. A message with `epoch < last_epoch` or `(epoch ==
+    /// last_epoch && sequence <= last_sequence)` is rejected (§9.16.1).
+    pub recv_sequence_tracker: HashMap<String, (u64, u64)>,
+}
+
+impl ContextCryptoState {
+    /// Builds crypto state around an already-constructed MLS group.
+    ///
+    /// Generates a fresh local sender key at [`INITIAL_SENDER_KEY_EPOCH`] and
+    /// starts with empty trackers (a fresh receive replay window — §9.16.1).
+    #[must_use]
+    pub fn from_group(context_id: impl Into<String>, mls_group: ScpMlsGroup) -> Self {
+        Self {
+            mls_group,
+            local_sender_key: generate_sender_key(),
+            context_id: context_id.into(),
+            sender_key_epoch: INITIAL_SENDER_KEY_EPOCH,
+            sender_key_store: SenderKeyStore::new(),
+            recv_sequence_tracker: HashMap::new(),
+        }
+    }
+
+    /// Returns a copy of this participant's local sender-key bytes.
+    ///
+    /// Used by the out-of-band sender-key exchange (the driver has no in-tab
+    /// cross-member sender-key distribution path — see ADR-057 and the
+    /// `MISSING SEAM` note in the crate root). A future distribution slice
+    /// replaces hand-off-by-copy with HPKE-sealed distribution over the MLS
+    /// tree's `scp_wrapping_key` extension (§9.16.1).
+    #[must_use]
+    pub const fn local_sender_key_bytes(&self) -> [u8; 32] {
+        *self.local_sender_key.as_bytes()
+    }
+
+    /// Records a remote member's sender key in the store.
+    ///
+    /// This installs a key the caller already trusts (the test harness "dumb
+    /// pipe" / a future distribution path). It does not advance the remote
+    /// sender's epoch high-water; that is advanced only by observing that
+    /// sender's message headers, and the receive ceiling tolerates the gap by
+    /// permitting up to [`MAX_EPOCH_ADVANCE`] above the stored high-water.
+    pub fn insert_sender_key(&mut self, sender_did: &str, key: SenderKey) {
+        let context_id = self.context_id.clone();
+        self.sender_key_store
+            .set_unchecked(&context_id, sender_did, key);
+    }
+
+    /// Encrypts a message through the full double-encryption pipeline.
+    ///
+    /// 1. Sender-key encrypt (AES-256-GCM, AAD binds the raw `context_id`,
+    ///    `sender_did`, `self.sender_key_epoch`, and `sequence`).
+    /// 2. Prepend the 16-byte `epoch || sequence` header (§9.16.1) — the epoch
+    ///    is `self.sender_key_epoch`, NOT the MLS group epoch.
+    /// 3. MLS-encrypt the framed result and TLS-serialize for transport.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`ClientError`] if either encryption layer or the wire
+    /// serialization fails.
+    pub fn encrypt_message(
+        &mut self,
+        plaintext: &[u8],
+        sender_did: &str,
+        sequence: u64,
+    ) -> Result<Vec<u8>, ClientError> {
+        let epoch = self.sender_key_epoch;
+        let context_id = self.context_id.clone();
+
+        // Layer 1: sender-key encrypt. The epoch bound into the AAD is the
+        // sender-key epoch (§9.16.5), matching the header below.
+        let sender_encrypted = encrypt_sender_layer(
+            &self.local_sender_key,
+            plaintext,
+            &context_id,
+            sender_did,
+            epoch,
+            sequence,
+        )?;
+
+        // Prepend the 16-byte epoch || sequence header (§9.16.1). The same
+        // `epoch` feeds the AAD and the header so the receiver reconstructs an
+        // identical AAD from the parsed header.
+        let with_header = build_sender_header(epoch, sequence, &sender_encrypted);
+
+        // Layer 2: MLS encrypt, then serialize the wire frame.
+        let mls_out = encrypt(&mut self.mls_group, &with_header)?;
+        Ok(serialize_ciphertext(&mls_out)?)
+    }
+
+    /// Decrypts an inbound MLS message through the full double-decryption
+    /// pipeline, classifying it as application or control.
+    ///
+    /// For a control message (commit/proposal) the group state is advanced by
+    /// `scp-mls` and [`Inbound::Control`] is returned immediately — the
+    /// sender-key layer is not involved.
+    ///
+    /// For an application message:
+    /// 1. Parse the 16-byte `epoch || sequence` header — authoritative.
+    /// 2. Enforce the epoch-poisoning ceiling (§9.16.1) BEFORE touching the
+    ///    replay tracker, so a `u64::MAX` header cannot poison it.
+    /// 3. Reject replays/reorders against the per-sender tracker.
+    /// 4. Sender-key-decrypt using the PARSED epoch/sequence, then record the
+    ///    tracker only on success.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`ClientError`] if MLS decryption fails, the header is
+    /// malformed, the epoch exceeds the ceiling, the message is a
+    /// replay/reorder, the sender's key is not in the store, or AEAD
+    /// verification fails.
+    pub fn decrypt_message(&mut self, ciphertext: &[u8]) -> Result<Inbound, ClientError> {
+        // Layer 2 (outer): MLS decrypt + classify. `scp-mls` merges any staged
+        // commit internally and surfaces the sender DID from the credential.
+        let decrypted = decrypt_with_sender_did(&mut self.mls_group, ciphertext)?;
+        let (sender_did, framed) = match decrypted {
+            DecryptedContent::Application {
+                plaintext,
+                sender_did,
+            } => (sender_did, plaintext),
+            DecryptedContent::Commit { sender_did } | DecryptedContent::Proposal { sender_did } => {
+                return Ok(Inbound::Control { sender_did });
+            }
+        };
+
+        let context_id = self.context_id.clone();
+
+        // Parse the authoritative epoch || sequence header.
+        let (epoch, sequence, sender_ciphertext) = parse_sender_header(&framed)?;
+
+        // Epoch-poisoning ceiling (§9.16.1), enforced BEFORE the replay tracker
+        // is touched. Without it a header carrying `epoch = u64::MAX` would
+        // advance the tracker and permanently lock out this sender (self-DoS /
+        // persistent per-receiver poisoning). Mirrors native `open`.
+        let stored_high_water = self.sender_key_store.epoch(&context_id, &sender_did);
+        let allowed_epoch_ceiling = stored_high_water.saturating_add(MAX_EPOCH_ADVANCE);
+        if epoch > allowed_epoch_ceiling {
+            return Err(ClientError::Driver(format!(
+                "sender key epoch {epoch} exceeds ceiling {allowed_epoch_ceiling} \
+                 (stored high-water {stored_high_water}, MAX_EPOCH_ADVANCE {MAX_EPOCH_ADVANCE})"
+            )));
+        }
+
+        // Replay/reorder detection. Reject epoch/sequence <= last seen for this
+        // sender (§9.16.1). Consulted BEFORE insert so a duplicate or older
+        // (epoch, sequence) is refused.
+        if let Some(&(last_epoch, last_seq)) = self.recv_sequence_tracker.get(&sender_did)
+            && (epoch < last_epoch || (epoch == last_epoch && sequence <= last_seq))
+        {
+            return Err(ClientError::Driver("replay or reorder detected".to_owned()));
+        }
+
+        // Look up the sender's key BEFORE recording the tracker, so a missing
+        // key does not advance the tracker (an undecryptable message is not
+        // "seen" for replay purposes).
+        let sender_key = self
+            .sender_key_store
+            .get(&context_id, &sender_did)
+            .ok_or_else(|| ClientError::Driver(format!("no sender key for DID '{sender_did}'")))?
+            .clone();
+
+        // Layer 1 (inner): sender-key decrypt using the PARSED epoch/sequence
+        // (the header is authoritative). The AAD binds the raw context_id
+        // string (§9.16.1), matching `encrypt_message` and native `seal`.
+        let plaintext = decrypt_sender_layer(
+            &sender_key,
+            sender_ciphertext,
+            &context_id,
+            &sender_did,
+            epoch,
+            sequence,
+        )?;
+
+        // Record the tracker only after a SUCCESSFUL decrypt, so a
+        // forged-but-undecryptable header cannot advance the replay floor.
+        self.recv_sequence_tracker
+            .insert(sender_did.clone(), (epoch, sequence));
+
+        Ok(Inbound::Application {
+            sender_did,
+            plaintext,
+        })
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::panic)]
+mod tests {
+    use super::*;
+    use openmls::prelude::KeyPackageIn;
+    use scp_mls::group::{add_member, create_group, generate_key_package, join_group};
+    use scp_mls::{ScpCredential, SignatureKeyPair};
+    use scp_primitives::SigningKeyId;
+    use tls_codec::{Deserialize as TlsDeserialize, Serialize as TlsSerialize};
+
+    const CTX: &str = "ctx-crypto-state-unit";
+    const ALICE: &str = "did:key:z6MkAliceCryptoStateUnitFixtureAAAAAAAAAAA";
+    const BOB: &str = "did:key:z6MkBobCryptoStateUnitFixtureBBBBBBBBBBBBB";
+
+    #[allow(clippy::unwrap_used)]
+    fn credential(did: &str) -> ScpCredential {
+        ScpCredential::new(did.to_owned(), None, SigningKeyId::Active).unwrap()
+    }
+
+    /// Builds Alice (creator) and Bob (Welcome-joined) crypto states sharing one
+    /// MLS group, with sender keys exchanged both ways.
+    #[allow(clippy::unwrap_used)]
+    fn alice_and_bob() -> (ContextCryptoState, ContextCryptoState) {
+        let mut alice =
+            ContextCryptoState::from_group(CTX, create_group(&credential(ALICE)).unwrap());
+
+        let (bundle, signer, provider): (_, SignatureKeyPair, _) =
+            generate_key_package(&credential(BOB)).unwrap();
+        let kp_bytes = bundle.key_package().tls_serialize_detached().unwrap();
+        let kp_in = KeyPackageIn::tls_deserialize(&mut &*kp_bytes).unwrap();
+        let result = add_member(&mut alice.mls_group, kp_in).unwrap();
+
+        let bob_group = join_group(&result.welcome, provider, signer).unwrap();
+        let mut bob = ContextCryptoState::from_group(CTX, bob_group);
+
+        // Exchange sender keys (out-of-band, mirroring the driver's MISSING SEAM).
+        bob.insert_sender_key(ALICE, SenderKey::from_bytes(alice.local_sender_key_bytes()));
+        alice.insert_sender_key(BOB, SenderKey::from_bytes(bob.local_sender_key_bytes()));
+        (alice, bob)
+    }
+
+    #[test]
+    #[allow(clippy::unwrap_used)]
+    fn full_double_encryption_round_trip() {
+        let (mut alice, mut bob) = alice_and_bob();
+        let ct = alice.encrypt_message(b"hello bob", ALICE, 0).unwrap();
+        match bob.decrypt_message(&ct).unwrap() {
+            Inbound::Application {
+                sender_did,
+                plaintext,
+            } => {
+                assert_eq!(sender_did, ALICE);
+                assert_eq!(plaintext, b"hello bob");
+            }
+            Inbound::Control { .. } => panic!("expected an application message"),
+        }
+        assert_eq!(bob.recv_sequence_tracker.get(ALICE), Some(&(1u64, 0u64)));
+    }
+
+    #[test]
+    #[allow(clippy::unwrap_used)]
+    fn replay_and_reorder_rejected() {
+        let (mut alice, mut bob) = alice_and_bob();
+        let ct1 = alice.encrypt_message(b"first", ALICE, 1).unwrap();
+        let ct2 = alice.encrypt_message(b"second", ALICE, 2).unwrap();
+        let ct1_dup = alice.encrypt_message(b"first-again", ALICE, 1).unwrap();
+
+        assert!(
+            bob.decrypt_message(&ct2).is_ok(),
+            "newer seq accepted first"
+        );
+        assert!(
+            bob.decrypt_message(&ct1).is_err(),
+            "older (epoch,seq) rejected as reorder/replay"
+        );
+        assert!(
+            bob.decrypt_message(&ct1_dup).is_err(),
+            "duplicate (epoch,seq) rejected"
+        );
+    }
+
+    #[test]
+    #[allow(clippy::unwrap_used)]
+    fn failed_decrypt_does_not_advance_tracker() {
+        // Bob lacks Alice's sender key, so the first decrypt fails at the inner
+        // layer and must not advance the replay floor.
+        let mut alice =
+            ContextCryptoState::from_group(CTX, create_group(&credential(ALICE)).unwrap());
+        let (bundle, signer, provider): (_, SignatureKeyPair, _) =
+            generate_key_package(&credential(BOB)).unwrap();
+        let kp_bytes = bundle.key_package().tls_serialize_detached().unwrap();
+        let kp_in = KeyPackageIn::tls_deserialize(&mut &*kp_bytes).unwrap();
+        let result = add_member(&mut alice.mls_group, kp_in).unwrap();
+        let bob_group = join_group(&result.welcome, provider, signer).unwrap();
+        let mut bob = ContextCryptoState::from_group(CTX, bob_group);
+
+        let ct = alice.encrypt_message(b"one", ALICE, 1).unwrap();
+        assert!(bob.decrypt_message(&ct).is_err(), "no sender key → fails");
+        assert!(
+            !bob.recv_sequence_tracker.contains_key(ALICE),
+            "a failed decrypt must not advance the tracker"
+        );
+
+        // After receiving the key out-of-band, a fresh send at seq 1 decrypts.
+        bob.insert_sender_key(ALICE, SenderKey::from_bytes(alice.local_sender_key_bytes()));
+        let ct_b = alice.encrypt_message(b"one-b", ALICE, 1).unwrap();
+        assert!(bob.decrypt_message(&ct_b).is_ok());
+    }
+
+    #[test]
+    #[allow(clippy::unwrap_used)]
+    fn epoch_poisoning_ceiling_rejects_and_does_not_advance_tracker() {
+        let (mut alice, mut bob) = alice_and_bob();
+        // Forge Alice's epoch to u64::MAX so her next header poisons the ceiling.
+        alice.sender_key_epoch = u64::MAX;
+        let poisoned = alice.encrypt_message(b"poison", ALICE, 0).unwrap();
+        assert!(
+            bob.decrypt_message(&poisoned).is_err(),
+            "epoch beyond store.epoch + MAX_EPOCH_ADVANCE must be rejected"
+        );
+        assert!(
+            !bob.recv_sequence_tracker.contains_key(ALICE),
+            "a ceiling-rejected message must not advance the replay tracker"
+        );
+    }
+}

--- a/crates/scp-client/src/crypto_state.rs
+++ b/crates/scp-client/src/crypto_state.rs
@@ -30,7 +30,9 @@
 use std::collections::HashMap;
 
 use scp_mls::ScpMlsGroup;
-use scp_mls::encrypt::{DecryptedContent, decrypt_with_sender_did, encrypt, serialize_ciphertext};
+use scp_mls::encrypt::{
+    InboundChange, decrypt_with_membership_changes, encrypt, serialize_ciphertext,
+};
 use scp_protocol::crypto::sender_keys::encrypt::{
     build_sender_header, decrypt_sender_layer, encrypt_sender_layer, parse_sender_header,
 };
@@ -51,10 +53,14 @@ pub const INITIAL_SENDER_KEY_EPOCH: u64 = 1;
 /// The outcome of decrypting an inbound MLS message.
 ///
 /// Distinguishes an application message (carrying recovered plaintext and the
-/// sender DID) from a control message (a commit/proposal that advanced or
-/// proposed group state but produced no user payload). The driver maps the
-/// former into a `MessageReceived` event and treats the latter as a silent
-/// group-state advance.
+/// sender DID) from a control message. A control message is further split into
+/// a **membership-changing Commit** (carrying the DIDs the Commit added/removed,
+/// recovered from the staged commit before merge — see
+/// [`decrypt_with_membership_changes`]) and a bare proposal. The driver maps an
+/// application message into a `MessageReceived` event, mirrors a Commit's
+/// membership changes onto its event log + membership set (so existing members
+/// converge with the committer and the new joiner), and treats a proposal as a
+/// silent cache.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum Inbound {
     /// An application message: recovered plaintext plus the sender's DID.
@@ -64,9 +70,20 @@ pub enum Inbound {
         /// The fully decrypted plaintext.
         plaintext: Vec<u8>,
     },
-    /// A control message (commit/proposal). The group state has already been
-    /// advanced/cached by `scp-mls`; no plaintext is produced.
-    Control {
+    /// A Commit that advanced the group epoch. `scp-mls` has already merged it;
+    /// `added_dids` / `removed_dids` are the SCP DIDs the Commit's Add/Remove
+    /// proposals add and evict (in proposal order), for the driver to mirror
+    /// onto its SCP-layer membership + event log.
+    Commit {
+        /// The committer's DID, extracted from the MLS credential.
+        sender_did: String,
+        /// DIDs added by this Commit's Add proposals.
+        added_dids: Vec<String>,
+        /// DIDs removed by this Commit's Remove proposals.
+        removed_dids: Vec<String>,
+    },
+    /// A bare proposal cached by `scp-mls`; no membership change is committed.
+    Proposal {
         /// The sender's DID, extracted from the MLS credential.
         sender_did: String,
     },
@@ -187,11 +204,13 @@ impl ContextCryptoState {
     }
 
     /// Decrypts an inbound MLS message through the full double-decryption
-    /// pipeline, classifying it as application or control.
+    /// pipeline, classifying it as application, membership-changing Commit, or
+    /// bare proposal.
     ///
-    /// For a control message (commit/proposal) the group state is advanced by
-    /// `scp-mls` and [`Inbound::Control`] is returned immediately — the
-    /// sender-key layer is not involved.
+    /// For a Commit or proposal the group state is advanced/cached by `scp-mls`
+    /// (a Commit is merged; its Add/Remove DIDs are recovered from the staged
+    /// commit before merge) and an [`Inbound::Commit`] / [`Inbound::Proposal`]
+    /// is returned immediately — the sender-key layer is not involved.
     ///
     /// For an application message:
     /// 1. Parse the 16-byte `epoch || sequence` header — authoritative.
@@ -209,15 +228,27 @@ impl ContextCryptoState {
     /// verification fails.
     pub fn decrypt_message(&mut self, ciphertext: &[u8]) -> Result<Inbound, ClientError> {
         // Layer 2 (outer): MLS decrypt + classify. `scp-mls` merges any staged
-        // commit internally and surfaces the sender DID from the credential.
-        let decrypted = decrypt_with_sender_did(&mut self.mls_group, ciphertext)?;
+        // commit internally (recovering its Add/Remove DIDs before the merge)
+        // and surfaces the sender DID from the credential.
+        let decrypted = decrypt_with_membership_changes(&mut self.mls_group, ciphertext)?;
         let (sender_did, framed) = match decrypted {
-            DecryptedContent::Application {
+            InboundChange::Application {
                 plaintext,
                 sender_did,
             } => (sender_did, plaintext),
-            DecryptedContent::Commit { sender_did } | DecryptedContent::Proposal { sender_did } => {
-                return Ok(Inbound::Control { sender_did });
+            InboundChange::Commit {
+                sender_did,
+                added_dids,
+                removed_dids,
+            } => {
+                return Ok(Inbound::Commit {
+                    sender_did,
+                    added_dids,
+                    removed_dids,
+                });
+            }
+            InboundChange::Proposal { sender_did } => {
+                return Ok(Inbound::Proposal { sender_did });
             }
         };
 
@@ -335,9 +366,59 @@ mod tests {
                 assert_eq!(sender_did, ALICE);
                 assert_eq!(plaintext, b"hello bob");
             }
-            Inbound::Control { .. } => panic!("expected an application message"),
+            other => panic!("expected an application message, got {other:?}"),
         }
         assert_eq!(bob.recv_sequence_tracker.get(ALICE), Some(&(1u64, 0u64)));
+    }
+
+    #[test]
+    #[allow(clippy::unwrap_used)]
+    fn decrypt_classifies_add_commit_with_added_did() {
+        // An EXISTING member decrypting an add-Commit must classify it as
+        // Inbound::Commit carrying the added DID, so the driver can mirror the
+        // MemberJoined leaf. Setup: Alice creates, adds Carol (Carol joins as
+        // the existing member), then Alice adds Bob and Carol processes that
+        // second Commit.
+        const CAROL: &str = "did:key:z6MkCarolCryptoStateUnitFixtureCCCCCCCCC";
+
+        let mut alice =
+            ContextCryptoState::from_group(CTX, create_group(&credential(ALICE)).unwrap());
+
+        // Carol joins as an existing member.
+        let (carol_bundle, carol_signer, carol_provider): (_, SignatureKeyPair, _) =
+            generate_key_package(&credential(CAROL)).unwrap();
+        let carol_kp_in = KeyPackageIn::tls_deserialize(
+            &mut &*carol_bundle.key_package().tls_serialize_detached().unwrap(),
+        )
+        .unwrap();
+        let add_carol = add_member(&mut alice.mls_group, carol_kp_in).unwrap();
+        let mut carol = ContextCryptoState::from_group(
+            CTX,
+            join_group(&add_carol.welcome, carol_provider, carol_signer).unwrap(),
+        );
+
+        // Alice adds Bob; Carol (existing member) processes the Commit.
+        let (bob_bundle, _bob_signer, _bob_provider): (_, SignatureKeyPair, _) =
+            generate_key_package(&credential(BOB)).unwrap();
+        let bob_kp_in = KeyPackageIn::tls_deserialize(
+            &mut &*bob_bundle.key_package().tls_serialize_detached().unwrap(),
+        )
+        .unwrap();
+        let add_bob = add_member(&mut alice.mls_group, bob_kp_in).unwrap();
+        let commit_bytes = add_bob.commit.tls_serialize_detached().unwrap();
+
+        match carol.decrypt_message(&commit_bytes).unwrap() {
+            Inbound::Commit {
+                sender_did,
+                added_dids,
+                removed_dids,
+            } => {
+                assert_eq!(sender_did, ALICE, "committer is Alice");
+                assert_eq!(added_dids, vec![BOB.to_owned()], "Bob's DID surfaced");
+                assert!(removed_dids.is_empty());
+            }
+            other => panic!("expected Inbound::Commit, got {other:?}"),
+        }
     }
 
     #[test]

--- a/crates/scp-client/src/error.rs
+++ b/crates/scp-client/src/error.rs
@@ -1,0 +1,49 @@
+//! Error types for the SCP participant driver.
+//!
+//! [`ClientError`] is the single error surfaced by every [`crate::ScpClient`]
+//! operation. It wraps the shared lower-layer errors ([`scp_mls::MlsError`],
+//! [`scp_protocol::crypto::sender_keys::SenderKeyError`],
+//! [`scp_event_log::EventLogError`]) via `#[from]` so the driver bodies can use
+//! `?` without re-deriving error taxonomies.
+
+use scp_event_log::EventLogError;
+use scp_mls::MlsError;
+use scp_protocol::crypto::sender_keys::SenderKeyError;
+
+/// Errors produced by the SCP participant driver.
+#[derive(Debug, thiserror::Error)]
+pub enum ClientError {
+    /// An MLS group operation failed (create/add/join/encrypt/decrypt/commit).
+    #[error("MLS error: {0}")]
+    Mls(#[from] MlsError),
+
+    /// A sender-key (§9.16) layer operation failed.
+    #[error("sender key error: {0}")]
+    SenderKey(#[from] SenderKeyError),
+
+    /// An event-log append or proof operation failed.
+    #[error("event log error: {0}")]
+    EventLog(#[from] EventLogError),
+
+    /// A TLS-codec (de)serialization of an MLS wire object failed.
+    #[error("MLS wire codec error: {0}")]
+    Codec(String),
+
+    /// The requested context is not known to this client.
+    #[error("unknown context: {0}")]
+    UnknownContext(String),
+
+    /// A context with the requested id already exists in this client.
+    #[error("context already exists: {0}")]
+    ContextAlreadyExists(String),
+
+    /// The decrypted MLS message was not an application message (it was a
+    /// commit or proposal) when an application message was expected.
+    #[error("expected application message, got control message")]
+    NotApplicationMessage,
+
+    /// A driver invariant was violated (e.g. missing sender key for a member
+    /// that is in the membership set, or a malformed driver argument).
+    #[error("driver error: {0}")]
+    Driver(String),
+}

--- a/crates/scp-client/src/error.rs
+++ b/crates/scp-client/src/error.rs
@@ -37,10 +37,13 @@ pub enum ClientError {
     #[error("context already exists: {0}")]
     ContextAlreadyExists(String),
 
-    /// The decrypted MLS message was not an application message (it was a
-    /// commit or proposal) when an application message was expected.
-    #[error("expected application message, got control message")]
-    NotApplicationMessage,
+    /// A received Commit carried a membership change the Slice 2 participant
+    /// driver does not converge — specifically a member removal, for which
+    /// there is no convergent removal-leaf transport yet. The driver returns
+    /// this rather than silently merging and diverging its event log from the
+    /// committer's (ADR-057 Slice 2 scope).
+    #[error("unsupported membership change: {0}")]
+    UnsupportedMembershipChange(String),
 
     /// A driver invariant was violated (e.g. missing sender key for a member
     /// that is in the membership set, or a malformed driver argument).

--- a/crates/scp-client/src/lib.rs
+++ b/crates/scp-client/src/lib.rs
@@ -1,0 +1,70 @@
+//! Single-threaded SCP participant driver (ADR-057 Slice 2).
+//!
+//! `scp-client` is the in-tab participant: a synchronous driver over the shared
+//! [`scp_mls`] MLS state machine, the shared [`scp_protocol`] sender-key layer,
+//! and the canonical [`scp_event_log`] Merkle log. It proves that the SCP
+//! participant path — create / join / add-member / send / receive-decrypt /
+//! process-commit / close, with the §9.16 double-encryption pipeline and the
+//! event-log leaves — runs **single-threaded** and **compiles to wasm32**,
+//! with no `scp-runtime` actor/tokio orchestration.
+//!
+//! # Relationship to the deleted WASM bridge
+//!
+//! This crate restores the *shape* of the WASM bridge removed by ADR-055
+//! (pinned at `1a3b41a5e^`): a per-context state map accessed synchronously,
+//! op methods of the same names, and a pull-based `drain_events` model. It does
+//! **not** restore the bridge's protocol *bodies* — those were a wasm-local
+//! re-implementation that had to stay byte-identical to native (the parity tax
+//! ADR-055 killed). Every body here calls shared [`scp_mls`] / [`scp_protocol`]
+//! / [`scp_event_log`] logic, so there is one implementation compiled to two
+//! targets, not two implementations to keep in lock-step.
+//!
+//! # Scope fence (ADR-057, mechanically enforced)
+//!
+//! The driver covers the **participant message path only**. Economy, governance
+//! voting, broadcast hosting, cross-context saga coordination, tools,
+//! discovery, and UCAN minting are node-side and out of scope — they require
+//! always-on hosts and would regrow the driver toward the deleted 15.5K-line
+//! manager. The fence is enforced **by the dependency graph**, not prose: this
+//! crate depends only on the wasm-safe shared crates plus the `openmls` stack
+//! and MUST NOT depend on `scp-runtime`, `scp-identity`, or `tokio`. Anything
+//! that needs those is, by construction, node-side.
+//!
+//! # Injected dependencies (keys on-device, storage abstracted)
+//!
+//! [`ScpClient`] is constructed with three injected dependencies:
+//! - a [`Signer`] — the on-device DID identity (a [`LocalSigner`] for the MVP;
+//!   a WebCrypto-callback custody backend in a later slice — the key never
+//!   enters wasm memory),
+//! - a [`Storage`] — out-of-band snapshot store ([`MemoryStorage`] for the MVP;
+//!   `IndexedDB` in a later slice),
+//! - a [`scp_primitives::Clock`] — the hardened time source for
+//!   committer-assigned event-log leaf timestamps (ADR-057 Prerequisite 1).
+//!
+//! # MISSING SEAM (cross-member sender-key distribution)
+//!
+//! The driver has **no in-tab path to distribute a member's §9.16 sender key to
+//! its peers**. This is a pre-existing gap inherited from the deleted bridge:
+//! `send_message` emits only the double-ciphertext, never the sender key.
+//! ADR-057 defers HPKE-sealed distribution over the MLS `scp_wrapping_key`
+//! leaf-node extension (already published by
+//! [`scp_mls::generate_key_package_with_wrapping_key`]) to a later slice. For
+//! the MVP, [`ScpClient::local_sender_key_bytes`] /
+//! [`ScpClient::install_sender_key`] expose the hand-off so a test harness — or
+//! a later distribution layer — can wire it; the integration test performs the
+//! exchange out-of-band over its "dumb pipe". This is a distribution gap, not a
+//! missing `scp-mls` MLS-op seam.
+
+mod client;
+mod context;
+mod crypto_state;
+mod error;
+mod signer;
+mod storage;
+
+pub use client::{AddMemberOutput, ScpClient, SendOutput};
+pub use context::PerContextState;
+pub use crypto_state::{ContextCryptoState, INITIAL_SENDER_KEY_EPOCH, Inbound};
+pub use error::ClientError;
+pub use signer::{LocalSigner, Signer};
+pub use storage::{MemoryStorage, Storage};

--- a/crates/scp-client/src/signer.rs
+++ b/crates/scp-client/src/signer.rs
@@ -1,0 +1,75 @@
+//! On-device identity for the participant driver.
+//!
+//! The [`Signer`] trait abstracts the participant's DID identity — the DID
+//! string and which verification-method key ([`SigningKeyId`]) it acts as. The
+//! driver uses it to construct the [`ScpCredential`](scp_mls::ScpCredential)
+//! embedded in MLS leaf nodes, so every MLS leaf (and every event-log leaf the
+//! driver appends) traces to the on-device human/agent DID.
+//!
+//! For the Slice-2 MVP the concrete impl is [`LocalSigner`], a plain struct
+//! holding the DID and key id. It is a trait — not a concrete type — precisely
+//! so a later slice can slot in a WebCrypto-callback custody backend (the key
+//! stays in JS/WebCrypto and never enters wasm memory, per ADR-057 component 3)
+//! without changing the driver.
+//!
+//! # Scope note (ADR-057)
+//!
+//! The ed25519 MLS signing key pair used for the MLS protocol itself is
+//! generated and held inside `scp-mls` (`generate_key_package` /
+//! `create_group`). This [`Signer`] models the *SCP DID* identity layer above
+//! it; the two are bridged through the `ScpCredential`. A future custody slice
+//! unifies them behind one on-device key boundary.
+
+use scp_primitives::SigningKeyId;
+
+/// The participant's on-device DID identity.
+///
+/// Implementations supply the DID string and the verification-method key id
+/// the participant acts as. They are cheap to clone-by-reference and are
+/// expected to be held behind an `Arc<dyn Signer>` in the driver.
+pub trait Signer: Send + Sync {
+    /// The participant's DID string (e.g. `did:dht:z6Mk…`).
+    fn did(&self) -> &str;
+
+    /// Which verification-method key this signer acts as.
+    fn signing_key_id(&self) -> SigningKeyId;
+}
+
+/// In-memory [`Signer`] for the MVP driver.
+///
+/// Holds the DID string and [`SigningKeyId`] directly. This is the
+/// development/test identity backend; a production browser client supplies a
+/// WebCrypto-callback custody backend instead (ADR-057 component 3).
+#[derive(Debug, Clone)]
+pub struct LocalSigner {
+    did: String,
+    signing_key_id: SigningKeyId,
+}
+
+impl LocalSigner {
+    /// Creates a new local signer for the given DID, acting as the given key.
+    #[must_use]
+    pub fn new(did: impl Into<String>, signing_key_id: SigningKeyId) -> Self {
+        Self {
+            did: did.into(),
+            signing_key_id,
+        }
+    }
+
+    /// Creates a new local signer for the given DID acting as the human's
+    /// active key ([`SigningKeyId::Active`]) — the common case.
+    #[must_use]
+    pub fn active(did: impl Into<String>) -> Self {
+        Self::new(did, SigningKeyId::Active)
+    }
+}
+
+impl Signer for LocalSigner {
+    fn did(&self) -> &str {
+        &self.did
+    }
+
+    fn signing_key_id(&self) -> SigningKeyId {
+        self.signing_key_id
+    }
+}

--- a/crates/scp-client/src/storage.rs
+++ b/crates/scp-client/src/storage.rs
@@ -1,0 +1,88 @@
+//! Storage abstraction for the participant driver.
+//!
+//! The [`Storage`] trait is a minimal synchronous key/value interface the
+//! driver uses to persist out-of-band snapshots (e.g. the in-memory MLS
+//! provider snapshot, per ADR-057 component 3, which a browser would back with
+//! `IndexedDB`). It is deliberately tiny and synchronous so it compiles to
+//! wasm32 and a browser backend can wrap an `IndexedDB` shim in a later slice.
+//!
+//! For the Slice-2 MVP the concrete impl is [`MemoryStorage`], a `HashMap`. The
+//! MVP message path does not yet snapshot through this — it is wired so the
+//! driver carries a storage handle from construction, keeping the dependency
+//! explicit and ready for Slice 3 (`IndexedDB`) without an API change.
+
+use std::collections::HashMap;
+use std::sync::Mutex;
+
+/// A minimal synchronous key/value store.
+///
+/// Keys and values are opaque byte strings. Implementations must be
+/// thread-safe (`Send + Sync`) so the driver can hold one behind an `Arc`.
+///
+/// The trait is intentionally infallible-by-value for `get` (returns
+/// `Option`) and fallible for the mutating operations, mirroring the shape a
+/// browser `IndexedDB`-backed implementation needs (writes can fail; a missing
+/// key is not an error).
+pub trait Storage: Send + Sync {
+    /// Returns the value stored under `key`, or `None` if absent.
+    fn get(&self, key: &str) -> Option<Vec<u8>>;
+
+    /// Stores `value` under `key`, overwriting any prior value.
+    ///
+    /// # Errors
+    ///
+    /// Returns a backend-specific error string if the write fails.
+    fn put(&self, key: &str, value: Vec<u8>) -> Result<(), String>;
+
+    /// Deletes the value stored under `key`. A no-op if the key is absent.
+    ///
+    /// # Errors
+    ///
+    /// Returns a backend-specific error string if the delete fails.
+    fn delete(&self, key: &str) -> Result<(), String>;
+}
+
+/// In-memory [`Storage`] for the MVP driver.
+///
+/// Backs the key/value store with a `HashMap` behind a `Mutex`. This is the
+/// development/test storage backend; a browser client supplies an
+/// `IndexedDB`-backed backend in a later slice (ADR-057 component 3).
+#[derive(Debug, Default)]
+pub struct MemoryStorage {
+    map: Mutex<HashMap<String, Vec<u8>>>,
+}
+
+impl MemoryStorage {
+    /// Creates a new, empty in-memory store.
+    #[must_use]
+    pub fn new() -> Self {
+        Self::default()
+    }
+}
+
+impl Storage for MemoryStorage {
+    fn get(&self, key: &str) -> Option<Vec<u8>> {
+        // A poisoned lock cannot corrupt a plain byte map; recover the guard.
+        let map = self
+            .map
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        map.get(key).cloned()
+    }
+
+    fn put(&self, key: &str, value: Vec<u8>) -> Result<(), String> {
+        self.map
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .insert(key.to_owned(), value);
+        Ok(())
+    }
+
+    fn delete(&self, key: &str) -> Result<(), String> {
+        self.map
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .remove(key);
+        Ok(())
+    }
+}

--- a/crates/scp-client/tests/multi_party_convergence.rs
+++ b/crates/scp-client/tests/multi_party_convergence.rs
@@ -29,7 +29,7 @@
 
 use std::sync::Arc;
 
-use scp_client::{LocalSigner, MemoryStorage, ScpClient, Storage};
+use scp_client::{ClientError, LocalSigner, MemoryStorage, ScpClient, Storage};
 use scp_primitives::{Clock, TestClock};
 use scp_protocol::context::membership::ContextEvent;
 
@@ -288,4 +288,158 @@ fn reciprocal_send_converges_via_transported_timestamp() {
         }
         other => panic!("expected MessageReceived, got {other:?}"),
     }
+}
+
+#[test]
+fn remove_commit_is_rejected_fail_closed_without_skew() {
+    // The regression test for Fix 1: a Remove-bearing Commit must be rejected by
+    // `receive_message` AND must leave the receiver's MLS group + SCP membership +
+    // event log mutually consistent (pre-remove). `scp-mls` now inspects the
+    // staged commit's Remove proposals and drops the StagedCommit WITHOUT merging,
+    // so the MLS epoch never half-advances while the SCP membership/log stay put.
+    //
+    // ADR-057 Slice 2 deliberately gives the participant `ScpClient` NO remove op
+    // (there is no convergent removal-leaf transport yet). To manufacture the very
+    // Remove-bearing Commit the driver must reject, this test drives ALICE as a
+    // raw `scp-mls` group (a dev-dependency) — exactly the wire bytes a hostile or
+    // out-of-scope committer could put on the wire — while BOB is a real
+    // `ScpClient` whose `receive_message` is the unit under test.
+    use openmls::prelude::{BasicCredential, KeyPackageIn};
+    use scp_mls::group::{add_member, create_group, generate_key_package, remove_member};
+    use scp_mls::{ScpCredential, SignatureKeyPair};
+    use scp_primitives::SigningKeyId;
+    use tls_codec::{Deserialize as TlsDeserialize, Serialize as TlsSerialize};
+
+    let alice_cred = ScpCredential::new(ALICE_DID.to_owned(), None, SigningKeyId::Active)
+        .expect("alice credential");
+    let mut alice_group = create_group(&alice_cred).expect("Alice's raw MLS group");
+
+    let mut bob = client_for(BOB_DID, 1_650_000_000);
+
+    // Bob's ScpClient mints its join KeyPackage (private half retained inside the
+    // client). Alice (raw group) adds Bob from that KeyPackage and Bob joins via
+    // the resulting Welcome, starting from an empty replay log.
+    let bob_kp_bytes = bob
+        .generate_key_package_for_join(CTX)
+        .expect("Bob key package");
+    let bob_kp_in = KeyPackageIn::tls_deserialize(&mut &*bob_kp_bytes).expect("bob kp deserialize");
+    let add_bob = add_member(&mut alice_group, bob_kp_in).expect("Alice adds Bob");
+    let bob_welcome = add_bob
+        .welcome
+        .tls_serialize_detached()
+        .expect("welcome bytes");
+    bob.join_context_encrypted(CTX, &bob_welcome, &[], &[ALICE_DID.to_owned()])
+        .expect("Bob joins Alice's raw group");
+
+    // Alice (raw group) adds Carol — a raw `scp-mls` member that exists only so
+    // Alice has someone to remove. Bob applies the add-Carol Commit through his
+    // ScpClient so Bob and Alice share the post-add epoch and Bob records Carol.
+    let carol_cred = ScpCredential::new(CAROL_DID.to_owned(), None, SigningKeyId::Active)
+        .expect("carol credential");
+    let (carol_bundle, _carol_signer, _carol_provider): (_, SignatureKeyPair, _) =
+        generate_key_package(&carol_cred).expect("carol key package");
+    let carol_kp_in = KeyPackageIn::tls_deserialize(
+        &mut &*carol_bundle
+            .key_package()
+            .tls_serialize_detached()
+            .expect("carol kp bytes"),
+    )
+    .expect("carol kp deserialize");
+    let add_carol = add_member(&mut alice_group, carol_kp_in).expect("Alice adds Carol");
+    let add_carol_commit = add_carol
+        .commit
+        .tls_serialize_detached()
+        .expect("add-carol commit bytes");
+    // Convergent timestamp the committer would have stamped (any value — this is
+    // the add path, which DOES converge and append a MemberJoined leaf on Bob).
+    let add_carol_ts = 1_700_000_500u64;
+    bob.receive_message(CTX, &add_carol_commit, add_carol_ts)
+        .expect("Bob processes the add-Carol commit");
+
+    // Snapshot Bob's pre-remove state: MLS epoch, SCP membership, log leaf count,
+    // and Merkle root. After the rejected remove these must ALL be unchanged.
+    let bob_epoch_before = bob.mls_epoch(CTX).expect("bob epoch");
+    let bob_leaf_count_before = bob.event_log_leaf_count(CTX);
+    let bob_root_before = bob.event_log_root(CTX);
+    let mut bob_members_before = bob.member_dids(CTX).expect("bob members");
+    bob_members_before.sort();
+    assert!(
+        bob_members_before.contains(&CAROL_DID.to_owned()),
+        "pre-remove: Carol is in Bob's membership set"
+    );
+
+    // Alice (raw group) builds a Commit removing Carol by her leaf index.
+    let carol_leaf = alice_group
+        .members()
+        .expect("alice members")
+        .into_iter()
+        .find(|m| {
+            BasicCredential::try_from(m.credential.clone())
+                .ok()
+                .and_then(|basic| ScpCredential::from_bytes(basic.identity()).ok())
+                .is_some_and(|cred| cred.did == CAROL_DID)
+        })
+        .map(|m| m.index)
+        .expect("Carol's leaf index");
+    let remove_carol = remove_member(&mut alice_group, carol_leaf).expect("Alice removes Carol");
+    let remove_carol_commit = remove_carol
+        .commit
+        .tls_serialize_detached()
+        .expect("remove-carol commit bytes");
+
+    // Bob receives the remove Commit. The committer timestamp is irrelevant — the
+    // Commit is rejected before any leaf would be stamped — so pass an arbitrary
+    // value to prove it is never consumed on the reject path.
+    let result = bob.receive_message(CTX, &remove_carol_commit, 1_700_000_999);
+
+    // (1) FAIL-LOUD: the driver surfaces UnsupportedMembershipChange naming Carol.
+    match result {
+        Err(ClientError::UnsupportedMembershipChange(msg)) => {
+            assert!(
+                msg.contains(CAROL_DID),
+                "the error must name the removed member, got: {msg}"
+            );
+        }
+        other => panic!("expected UnsupportedMembershipChange, got {other:?}"),
+    }
+
+    // (2) NO SKEW: Bob's MLS group did NOT half-advance — the Remove-bearing
+    // Commit was dropped BEFORE `merge_staged_commit`, so the MLS epoch is
+    // exactly what it was before. This is the crux of Fix 1: pre-fix the group
+    // merged (epoch advanced, Carol evicted from the tree) and only then errored,
+    // leaving MLS ahead of the SCP layer.
+    assert_eq!(
+        bob.mls_epoch(CTX).expect("bob epoch after"),
+        bob_epoch_before,
+        "a rejected remove must NOT advance Bob's MLS epoch (no half-merge)"
+    );
+
+    // (3) NO SKEW: Bob's SCP membership set is unchanged (Carol still listed —
+    // the driver did not evict her, since it never applied the Commit).
+    let mut bob_members_after = bob.member_dids(CTX).expect("bob members after");
+    bob_members_after.sort();
+    assert_eq!(
+        bob_members_after, bob_members_before,
+        "a rejected remove must NOT mutate Bob's SCP membership set"
+    );
+
+    // (4) NO SKEW: Bob's event log is unchanged (same leaf count, same root) —
+    // no membership leaf was appended or dropped.
+    assert_eq!(
+        bob.event_log_leaf_count(CTX),
+        bob_leaf_count_before,
+        "a rejected remove must NOT change Bob's event-log leaf count"
+    );
+    assert_eq!(
+        bob.event_log_root(CTX),
+        bob_root_before,
+        "a rejected remove must NOT change Bob's event-log Merkle root"
+    );
+
+    // The four no-skew assertions above prove the crux of Fix 1: MLS state and
+    // SCP state are LEFT MUTUALLY CONSISTENT (both pre-remove), because the
+    // Remove-bearing Commit was dropped before `merge_staged_commit` rather than
+    // merged-then-errored. (That the group also stays *encryptable* on its
+    // unchanged epoch after a rejected remove is proven at the MLS layer by the
+    // `scp-mls` unit test `decrypt_with_membership_changes_rejects_remove_without_merging`.)
 }

--- a/crates/scp-client/tests/multi_party_convergence.rs
+++ b/crates/scp-client/tests/multi_party_convergence.rs
@@ -1,0 +1,291 @@
+//! Multi-party event-log convergence over the single-threaded SCP participant
+//! driver (ADR-057 Slice 2).
+//!
+//! SCP contexts are inherently multi-party. This test exercises the property a
+//! 2-party test cannot: when an EXISTING member processes an MLS Commit that
+//! ADDS a new member, that existing member must append the identical convergent
+//! `MemberJoined` leaf the committer appended and the new joiner replayed — so
+//! all three members' event-log Merkle roots and membership sets converge.
+//!
+//! It proves two things the 2-party test left unproven:
+//!
+//! 1. **Existing-member add-Commit convergence** — Alice creates, adds Bob,
+//!    then adds Carol. Bob (an existing member, not the committer, not the
+//!    joiner) processes Alice's add-Carol Commit and converges his event-log
+//!    root + membership to Alice's and Carol's. This is the regression test for
+//!    the multi-party divergence bug: pre-fix, Bob's Control arm dropped the
+//!    add and his log/membership permanently diverged.
+//!
+//! 2. **Convergence rides on the transported timestamp, not local clocks** — a
+//!    reciprocal Bob → Alice send, where Bob stamps his OWN (deliberately
+//!    different) clock onto a `MessageSent` leaf, and Alice converges to Bob's
+//!    leaf via the transported `committer_timestamp_secs`. Because the three
+//!    members' clocks all differ, this can only converge if the convergent
+//!    timestamp travels with each message.
+
+// Integration tests assert on happy-path results; `expect`/`panic!` make the
+// failure messages legible. The workspace denies these in production code.
+#![allow(clippy::expect_used, clippy::panic)]
+
+use std::sync::Arc;
+
+use scp_client::{LocalSigner, MemoryStorage, ScpClient, Storage};
+use scp_primitives::{Clock, TestClock};
+use scp_protocol::context::membership::ContextEvent;
+
+const CTX: &str = "ctx-adr057-slice2-multi-party";
+const ALICE_DID: &str = "did:key:z6MkAliceMultiPartyFixtureKeyAAAAAAAAAAAAAA";
+const BOB_DID: &str = "did:key:z6MkBobMultiPartyFixtureKeyBBBBBBBBBBBBBBBB";
+const CAROL_DID: &str = "did:key:z6MkCarolMultiPartyFixtureKeyCCCCCCCCCCCCCC";
+
+/// Builds a fresh client for `did` over a fixed-time clock.
+fn client_for(did: &str, now_secs: u64) -> ScpClient {
+    let signer = Arc::new(LocalSigner::active(did));
+    let storage: Arc<dyn Storage> = Arc::new(MemoryStorage::new());
+    let clock: Arc<dyn Clock> = Arc::new(TestClock::new(now_secs));
+    ScpClient::new(signer, storage, clock)
+}
+
+/// Hands every pair of clients the other's sender key, out-of-band (the MISSING
+/// SEAM the crate root documents — there is no in-tab distribution path yet).
+fn exchange_sender_keys(clients: &mut [(&str, &mut ScpClient)]) {
+    let keys: Vec<(String, [u8; 32])> = clients
+        .iter()
+        .map(|(did, c)| {
+            (
+                (*did).to_owned(),
+                c.local_sender_key_bytes(CTX).expect("local sender key"),
+            )
+        })
+        .collect();
+    for (did, client) in clients.iter_mut() {
+        for (peer_did, key) in &keys {
+            if peer_did != did {
+                client
+                    .install_sender_key(CTX, peer_did, *key)
+                    .expect("install peer sender key");
+            }
+        }
+    }
+}
+
+#[test]
+fn three_party_add_commit_converges_across_all_members() {
+    // Three deliberately different local clocks: convergence must NOT depend on
+    // them agreeing — only on the convergent timestamp transported with each
+    // commit/message.
+    let mut alice = client_for(ALICE_DID, 1_700_000_000);
+    let mut bob = client_for(BOB_DID, 1_650_000_000);
+    let mut carol = client_for(CAROL_DID, 1_600_000_000);
+
+    // --- Alice creates the context. ---
+    alice.create_context(CTX).expect("Alice creates");
+
+    // --- Alice adds Bob. Bob joins via the Welcome + replay. ---
+    let bob_kp = bob
+        .generate_key_package_for_join(CTX)
+        .expect("Bob key package");
+    let add_bob = alice.add_member(CTX, &bob_kp).expect("Alice adds Bob");
+    bob.join_context_encrypted(CTX, &add_bob.welcome, &add_bob.event_log, &add_bob.members)
+        .expect("Bob joins");
+
+    assert_eq!(
+        bob.event_log_root(CTX),
+        alice.event_log_root(CTX),
+        "after the first add, Bob converges to Alice"
+    );
+
+    // --- Alice adds Carol. This is the multi-party case: Alice's add-Carol
+    // Commit must be processed by the EXISTING member Bob, who has to append the
+    // identical MemberJoined(Carol) leaf — not silently drop it. ---
+    let carol_kp = carol
+        .generate_key_package_for_join(CTX)
+        .expect("Carol key package");
+    let add_carol = alice.add_member(CTX, &carol_kp).expect("Alice adds Carol");
+
+    // Carol joins from the Welcome, replaying Alice's full log (which now
+    // includes both MemberJoined leaves).
+    carol
+        .join_context_encrypted(
+            CTX,
+            &add_carol.welcome,
+            &add_carol.event_log,
+            &add_carol.members,
+        )
+        .expect("Carol joins");
+
+    // Bob (existing member) processes Alice's add-Carol Commit. The convergent
+    // committer timestamp rides on the AddMemberOutput exactly as a message's
+    // does on SendOutput. `receive_message` returns `false` (no application
+    // payload), but its side effect — appending the convergent MemberJoined
+    // leaf and recording Carol — is what makes Bob converge. Pre-fix, this arm
+    // dropped the add: Bob stayed at 2 leaves with Carol missing and his root
+    // diverged from Alice's and Carol's.
+    let was_application = bob
+        .receive_message(CTX, &add_carol.commit, add_carol.committer_timestamp_secs)
+        .expect("Bob processes the add-Carol commit");
+    assert!(
+        !was_application,
+        "an add-Commit carries no application payload"
+    );
+
+    // === All three members converge: identical leaf count, identical leaf
+    // hashes, identical Merkle root, identical membership set. ===
+    assert_eq!(
+        alice.event_log_leaf_count(CTX),
+        Some(3),
+        "Alice: ContextCreated + MemberJoined(Bob) + MemberJoined(Carol)"
+    );
+    assert_eq!(
+        bob.event_log_leaf_count(CTX),
+        Some(3),
+        "Bob converged to 3 leaves after processing the add-Carol commit"
+    );
+    assert_eq!(
+        carol.event_log_leaf_count(CTX),
+        Some(3),
+        "Carol replayed all 3 leaves"
+    );
+
+    let alice_root = alice.event_log_root(CTX).expect("alice root");
+    let bob_root = bob.event_log_root(CTX).expect("bob root");
+    let carol_root = carol.event_log_root(CTX).expect("carol root");
+    assert_eq!(alice_root, bob_root, "Alice and Bob roots converge");
+    assert_eq!(alice_root, carol_root, "Alice and Carol roots converge");
+
+    let alice_leaves = alice.event_log_leaf_hashes(CTX).expect("alice leaves");
+    let bob_leaves = bob.event_log_leaf_hashes(CTX).expect("bob leaves");
+    let carol_leaves = carol.event_log_leaf_hashes(CTX).expect("carol leaves");
+    assert_eq!(
+        alice_leaves, bob_leaves,
+        "every leaf hash is byte-identical between Alice and Bob"
+    );
+    assert_eq!(
+        alice_leaves, carol_leaves,
+        "every leaf hash is byte-identical between Alice and Carol"
+    );
+
+    // Membership sets converge (order-insensitive).
+    let mut alice_members = alice.member_dids(CTX).expect("alice members");
+    let mut bob_members = bob.member_dids(CTX).expect("bob members");
+    let mut carol_members = carol.member_dids(CTX).expect("carol members");
+    alice_members.sort();
+    bob_members.sort();
+    carol_members.sort();
+    let expected = {
+        let mut v = vec![
+            ALICE_DID.to_owned(),
+            BOB_DID.to_owned(),
+            CAROL_DID.to_owned(),
+        ];
+        v.sort();
+        v
+    };
+    assert_eq!(alice_members, expected, "Alice sees all three members");
+    assert_eq!(
+        bob_members, expected,
+        "Bob's membership converged to all three"
+    );
+    assert_eq!(carol_members, expected, "Carol sees all three members");
+}
+
+#[test]
+fn reciprocal_send_converges_via_transported_timestamp() {
+    // Distinct clocks across all three members.
+    let mut alice = client_for(ALICE_DID, 1_700_000_000);
+    let mut bob = client_for(BOB_DID, 1_650_000_000);
+    let mut carol = client_for(CAROL_DID, 1_600_000_000);
+
+    alice.create_context(CTX).expect("Alice creates");
+
+    let bob_kp = bob
+        .generate_key_package_for_join(CTX)
+        .expect("Bob key package");
+    let add_bob = alice.add_member(CTX, &bob_kp).expect("Alice adds Bob");
+    bob.join_context_encrypted(CTX, &add_bob.welcome, &add_bob.event_log, &add_bob.members)
+        .expect("Bob joins");
+
+    let carol_kp = carol
+        .generate_key_package_for_join(CTX)
+        .expect("Carol key package");
+    let add_carol = alice.add_member(CTX, &carol_kp).expect("Alice adds Carol");
+    carol
+        .join_context_encrypted(
+            CTX,
+            &add_carol.welcome,
+            &add_carol.event_log,
+            &add_carol.members,
+        )
+        .expect("Carol joins");
+    bob.receive_message(CTX, &add_carol.commit, add_carol.committer_timestamp_secs)
+        .expect("Bob processes the add-Carol commit");
+
+    // All three converge before any application message.
+    assert_eq!(alice.event_log_root(CTX), bob.event_log_root(CTX));
+    assert_eq!(alice.event_log_root(CTX), carol.event_log_root(CTX));
+
+    // Out-of-band sender-key exchange among all three.
+    exchange_sender_keys(&mut [
+        (ALICE_DID, &mut alice),
+        (BOB_DID, &mut bob),
+        (CAROL_DID, &mut carol),
+    ]);
+
+    // --- Reciprocal send: BOB sends. Bob stamps the leaf with HIS OWN clock
+    // reading (1_650_000_000), distinct from Alice's and Carol's. The convergent
+    // timestamp rides on Bob's SendOutput. ---
+    let plaintext = b"hello from Bob, stamped with Bob's clock";
+    let bob_send = bob.send_message(CTX, plaintext).expect("Bob sends");
+    assert_eq!(
+        bob_send.committer_timestamp_secs, 1_650_000_000,
+        "Bob stamped the leaf with HIS clock, not Alice's or Carol's"
+    );
+
+    // Alice and Carol receive Bob's message and stamp the SAME transported
+    // timestamp onto their MessageSent leaf — NOT their own clocks.
+    assert!(
+        alice
+            .receive_message(CTX, &bob_send.ciphertext, bob_send.committer_timestamp_secs)
+            .expect("Alice receives Bob's message"),
+        "an application message"
+    );
+    assert!(
+        carol
+            .receive_message(CTX, &bob_send.ciphertext, bob_send.committer_timestamp_secs)
+            .expect("Carol receives Bob's message"),
+        "an application message"
+    );
+
+    // The MessageSent leaf converges across all three despite three different
+    // local clocks — proving convergence rides on the transported timestamp.
+    let alice_root = alice.event_log_root(CTX).expect("alice root");
+    let bob_root = bob.event_log_root(CTX).expect("bob root");
+    let carol_root = carol.event_log_root(CTX).expect("carol root");
+    assert_eq!(
+        alice_root, bob_root,
+        "Alice converged to Bob's leaf via the transported timestamp, not her clock"
+    );
+    assert_eq!(
+        alice_root, carol_root,
+        "Carol converged to Bob's leaf via the transported timestamp, not her clock"
+    );
+    assert_eq!(
+        alice.event_log_leaf_count(CTX),
+        Some(4),
+        "created + joined(Bob) + joined(Carol) + sent(Bob)"
+    );
+
+    // Alice and Carol each drained Bob's plaintext.
+    let alice_events = alice.drain_events(CTX).expect("alice drains");
+    assert_eq!(alice_events.len(), 1);
+    match &alice_events[0] {
+        ContextEvent::MessageReceived {
+            sender_did,
+            payload,
+        } => {
+            assert_eq!(sender_did.0, BOB_DID, "sender is Bob");
+            assert_eq!(payload.as_slice(), plaintext);
+        }
+        other => panic!("expected MessageReceived, got {other:?}"),
+    }
+}

--- a/crates/scp-client/tests/two_party_exchange.rs
+++ b/crates/scp-client/tests/two_party_exchange.rs
@@ -1,0 +1,186 @@
+//! Two-participant end-to-end message exchange over the single-threaded SCP
+//! participant driver (ADR-057 Slice 2).
+//!
+//! This is the Slice-2 milestone test: it drives two `ScpClient`s — Alice
+//! (creator) and Bob (joiner) — through the full participant message path with
+//! NO tokio, NO actors, NO `scp-runtime`. Everything runs synchronously on one
+//! thread; the "relay" is the test harness handing one client's output bytes
+//! directly to the other's input.
+//!
+//! It proves three properties:
+//! 1. **End-to-end exchange works single-threaded over `scp-mls`** — Bob
+//!    recovers Alice's exact plaintext through the §9.16 double-encryption
+//!    pipeline.
+//! 2. **Event-log convergence by shared code** — after the joiner replays the
+//!    adder's log and both exchange a message, their full event sequences are
+//!    byte-identical (every leaf hash AND the Merkle root match), the §9.9.3
+//!    convergence property. This holds because both sides run the same
+//!    `scp-event-log` append logic over the same committer-assigned inputs
+//!    (committer DID + the convergent timestamp that travels with each message),
+//!    even though their local clocks deliberately differ.
+//! 3. **Pull-based receive** — Bob drains a `MessageReceived` event carrying
+//!    the decrypted plaintext.
+
+// Integration tests assert on happy-path results; `expect`/`panic!` make the
+// failure messages legible. The workspace denies these in production code.
+#![allow(clippy::expect_used, clippy::panic)]
+
+use std::sync::Arc;
+
+use scp_client::{LocalSigner, MemoryStorage, ScpClient, Storage};
+use scp_primitives::{Clock, TestClock};
+use scp_protocol::context::membership::ContextEvent;
+
+const CTX: &str = "ctx-adr057-slice2-two-party";
+const ALICE_DID: &str = "did:key:z6MkAlice2PartyExchangeFixtureKeyAAAAAAAAAA";
+const BOB_DID: &str = "did:key:z6MkBob2PartyExchangeFixtureKeyBBBBBBBBBBBB";
+
+/// Builds a fresh client for `did` over a fixed-time clock. Each member's own
+/// leaf timestamps come from its clock, and the convergent timestamp that must
+/// match across members travels with the message (so the two clocks need not
+/// agree — but fixing them keeps the fixture deterministic).
+fn client_for(did: &str, now_secs: u64) -> ScpClient {
+    let signer = Arc::new(LocalSigner::active(did));
+    let storage: Arc<dyn Storage> = Arc::new(MemoryStorage::new());
+    let clock: Arc<dyn Clock> = Arc::new(TestClock::new(now_secs));
+    ScpClient::new(signer, storage, clock)
+}
+
+#[test]
+fn two_party_message_exchange_end_to_end() {
+    let alice_clock = 1_700_000_000u64;
+    // Deliberately give Bob a DIFFERENT local clock to prove convergence does
+    // not depend on the two members' clocks agreeing — only on the convergent
+    // timestamp that travels with each message.
+    let bob_clock = 1_650_000_000u64;
+
+    // --- Alice creates the context (MLS group + first event-log leaf). ---
+    let mut alice = client_for(ALICE_DID, alice_clock);
+    alice
+        .create_context(CTX)
+        .expect("Alice creates the context");
+
+    assert_eq!(
+        alice.member_dids(CTX).as_deref(),
+        Some(&[ALICE_DID.to_owned()][..])
+    );
+    assert_eq!(
+        alice.event_log_leaf_count(CTX),
+        Some(1),
+        "creation appends exactly the ContextCreated leaf"
+    );
+
+    // --- Bob generates a KeyPackage for joining and hands the public bytes to
+    // Alice (the matching private join material stays inside Bob's client). ---
+    let mut bob = client_for(BOB_DID, bob_clock);
+    let bob_key_package = bob
+        .generate_key_package_for_join(CTX)
+        .expect("Bob generates a key package");
+
+    // --- Alice adds Bob → Commit (existing members) + Welcome (Bob) + a
+    // MemberJoined leaf. The convergent committer timestamp rides on the
+    // returned output. ---
+    let add = alice
+        .add_member(CTX, &bob_key_package)
+        .expect("Alice adds Bob");
+
+    let mut alice_members = alice.member_dids(CTX).expect("alice has members");
+    alice_members.sort();
+    assert_eq!(
+        alice_members,
+        vec![ALICE_DID.to_owned(), BOB_DID.to_owned()]
+    );
+    assert_eq!(alice.event_log_leaf_count(CTX), Some(2));
+
+    // --- Bob joins from the Welcome and replays Alice's full prior log, so his
+    // log reconstructs byte-identically (§7.3.1 context-state import). In a
+    // two-member group Alice's Commit has no existing recipient to process. ---
+    bob.join_context_encrypted(CTX, &add.welcome, &add.event_log, &add.members)
+        .expect("Bob joins from the Welcome");
+
+    assert_eq!(
+        bob.event_log_leaf_count(CTX),
+        Some(2),
+        "Bob replayed Alice's log: ContextCreated + MemberJoined"
+    );
+    assert_eq!(
+        bob.event_log_root(CTX),
+        alice.event_log_root(CTX),
+        "after replay, Bob's root equals Alice's (full-log convergence)"
+    );
+
+    // --- Out-of-band sender-key exchange (the MISSING SEAM documented in the
+    // crate root): the driver has no in-tab sender-key distribution path, so the
+    // harness hands each side the other's sender key directly. ---
+    let alice_sk = alice.local_sender_key_bytes(CTX).expect("alice sender key");
+    let bob_sk = bob.local_sender_key_bytes(CTX).expect("bob sender key");
+    bob.install_sender_key(CTX, ALICE_DID, alice_sk)
+        .expect("Bob installs Alice's sender key");
+    alice
+        .install_sender_key(CTX, BOB_DID, bob_sk)
+        .expect("Alice installs Bob's sender key");
+
+    // --- Alice sends an application message: sender-layer encrypt + MLS encrypt
+    // + a MessageSent leaf. The convergent send timestamp rides on the output. ---
+    let plaintext = b"hello from Alice over a single-threaded SCP client";
+    let send = alice.send_message(CTX, plaintext).expect("Alice sends");
+
+    assert_eq!(
+        alice.event_log_leaf_count(CTX),
+        Some(3),
+        "Alice's log is now created + joined + sent"
+    );
+
+    // --- Bob receives + decrypts + records his MessageSent leaf using the same
+    // send timestamp, then drains the MessageReceived event. ---
+    let was_application = bob
+        .receive_message(CTX, &send.ciphertext, send.committer_timestamp_secs)
+        .expect("Bob receives the message");
+    assert!(was_application, "Alice's send is an application message");
+
+    let events = bob.drain_events(CTX).expect("Bob drains events");
+    assert_eq!(events.len(), 1, "exactly one received event is buffered");
+    match &events[0] {
+        ContextEvent::MessageReceived {
+            sender_did,
+            payload,
+        } => {
+            assert_eq!(sender_did.0, ALICE_DID, "the sender DID is Alice");
+            assert_eq!(
+                payload.as_slice(),
+                plaintext,
+                "Bob recovered Alice's exact plaintext"
+            );
+        }
+        other => panic!("expected MessageReceived, got {other:?}"),
+    }
+
+    // Draining again yields nothing (pull-based, FIFO, consumed).
+    assert!(bob.drain_events(CTX).expect("re-drain ok").is_empty());
+
+    // === Convergence (§9.9.3): after the exchange, Alice and Bob hold the
+    // identical event sequence [ContextCreated, MemberJoined, MessageSent], so
+    // their leaf hashes are byte-identical AND their Merkle roots are equal —
+    // despite their local clocks differing — because the convergent timestamp
+    // travelled with each message and both sides ran the same shared
+    // `scp-event-log` append logic. ===
+    let alice_leaves = alice.event_log_leaf_hashes(CTX).expect("alice leaves");
+    let bob_leaves = bob.event_log_leaf_hashes(CTX).expect("bob leaves");
+
+    assert_eq!(alice_leaves.len(), 3, "Alice: created + joined + sent");
+    assert_eq!(bob_leaves.len(), 3, "Bob: created + joined + sent");
+    assert_eq!(
+        alice_leaves, bob_leaves,
+        "every leaf hash is byte-identical across both members (convergence)"
+    );
+    assert_eq!(
+        alice.event_log_root(CTX),
+        bob.event_log_root(CTX),
+        "the Merkle roots converge byte-for-byte (§9.9.3)"
+    );
+
+    // --- Close tears down crypto state on both sides. ---
+    alice.close_context(CTX).expect("Alice closes");
+    bob.close_context(CTX).expect("Bob closes");
+    assert_eq!(alice.member_dids(CTX), None, "context is gone after close");
+}

--- a/crates/scp-mls/src/encrypt.rs
+++ b/crates/scp-mls/src/encrypt.rs
@@ -382,13 +382,16 @@ pub fn decrypt_with_sender_did(
 /// inbound MLS message.
 ///
 /// Returned by [`decrypt_with_membership_changes`]. For an application message
-/// the change is [`InboundChange::Application`]. For a Commit the change is
-/// [`InboundChange::Commit`], carrying the DIDs added and removed by the
-/// Commit's Add/Remove proposals — recovered from the staged commit *before* it
-/// is merged, so an existing member can mirror the committer's membership-leaf
-/// appends and converge. For a bare Proposal the change is
-/// [`InboundChange::Proposal`].
-#[derive(Debug, Clone, PartialEq, Eq)]
+/// the change is [`InboundChange::Application`]. For an **add-only** Commit the
+/// change is [`InboundChange::Commit`], carrying the DIDs added by the Commit's
+/// Add proposals — recovered from the staged commit *before* it is merged, then
+/// merged — so an existing member can mirror the committer's membership-leaf
+/// appends and converge. For a Commit that carries any **Remove** proposal the
+/// change is [`InboundChange::UnsupportedMembershipChange`]: the staged commit
+/// is dropped **without merging**, so the MLS group stays on its current epoch
+/// and remains consistent with the caller's SCP-layer state (fail-closed, not
+/// half-applied). For a bare Proposal the change is [`InboundChange::Proposal`].
+#[derive(Clone, PartialEq, Eq)]
 pub enum InboundChange {
     /// An application message carrying user plaintext and the sender DID.
     Application {
@@ -397,17 +400,39 @@ pub enum InboundChange {
         /// The sender's DID string extracted from the MLS credential.
         sender_did: String,
     },
-    /// A Commit that advanced the group epoch. `merge_staged_commit` has
-    /// already been called. `added_dids` and `removed_dids` are the SCP DIDs of
-    /// the members the Commit's Add/Remove proposals add and evict, recovered
-    /// from the staged commit (Add proposals' `KeyPackage` leaf credentials and
-    /// Remove proposals' pre-merge leaf credentials) before the merge.
+    /// An **add-only** Commit that advanced the group epoch.
+    /// `merge_staged_commit` has already been called. `added_dids` are the SCP
+    /// DIDs of the members the Commit's Add proposals add, recovered from the
+    /// staged commit's Add proposals' `KeyPackage` leaf credentials before the
+    /// merge.
+    ///
+    /// A Commit carrying any Remove proposal never reaches this variant — it is
+    /// surfaced as [`InboundChange::UnsupportedMembershipChange`] *without*
+    /// merging, so this variant only ever describes an applied, add-only epoch
+    /// advance.
     Commit {
         /// The committer's DID string extracted from the MLS credential.
         sender_did: String,
         /// DIDs added by this Commit's Add proposals, in proposal order.
         added_dids: Vec<String>,
-        /// DIDs removed by this Commit's Remove proposals, in proposal order.
+    },
+    /// A Commit that carries one or more Remove proposals, which this seam does
+    /// not converge.
+    ///
+    /// The staged commit was **dropped without merging**: the MLS group is left
+    /// on its current (pre-Commit) epoch, so MLS state and the caller's
+    /// SCP-layer state remain mutually consistent (pre-remove) rather than
+    /// half-advanced. The caller maps this to a fail-closed error; the group
+    /// stays usable on the old epoch.
+    ///
+    /// `removed_dids` are the SCP DIDs the Remove proposals would have evicted,
+    /// recovered from the *current* (pre-merge) group tree, so the caller can
+    /// report which members the rejected Commit targeted.
+    UnsupportedMembershipChange {
+        /// The committer's DID string extracted from the MLS credential.
+        sender_did: String,
+        /// DIDs the rejected Commit's Remove proposals would evict, in proposal
+        /// order, read from the pre-merge tree.
         removed_dids: Vec<String>,
     },
     /// A Proposal cached by `OpenMLS` during `process_message`. No plaintext and
@@ -416,6 +441,51 @@ pub enum InboundChange {
         /// The sender's DID string extracted from the MLS credential.
         sender_did: String,
     },
+}
+
+impl std::fmt::Debug for InboundChange {
+    /// Manual `Debug` that REDACTS the decrypted plaintext.
+    ///
+    /// Per ADR-057 the tab boundary is the plaintext boundary: a
+    /// `{:?}`-formatted [`InboundChange::Application`] must never leak the
+    /// recovered cleartext into logs, panics, or test output. Only the byte
+    /// length is printed; the control variants forward their (non-secret)
+    /// fields.
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Application {
+                plaintext,
+                sender_did,
+            } => f
+                .debug_struct("Application")
+                .field(
+                    "plaintext",
+                    &format_args!("<redacted {} bytes>", plaintext.len()),
+                )
+                .field("sender_did", sender_did)
+                .finish(),
+            Self::Commit {
+                sender_did,
+                added_dids,
+            } => f
+                .debug_struct("Commit")
+                .field("sender_did", sender_did)
+                .field("added_dids", added_dids)
+                .finish(),
+            Self::UnsupportedMembershipChange {
+                sender_did,
+                removed_dids,
+            } => f
+                .debug_struct("UnsupportedMembershipChange")
+                .field("sender_did", sender_did)
+                .field("removed_dids", removed_dids)
+                .finish(),
+            Self::Proposal { sender_did } => f
+                .debug_struct("Proposal")
+                .field("sender_did", sender_did)
+                .finish(),
+        }
+    }
 }
 
 /// Parses the SCP DID out of an MLS [`Credential`] (a `BasicCredential` whose
@@ -447,14 +517,20 @@ fn credential_to_did(credential: &Credential) -> Result<String, MlsError> {
 ///
 /// - **`ApplicationMessage`** → [`InboundChange::Application`] (plaintext +
 ///   sender DID), identical to [`decrypt_with_sender_did`].
-/// - **`StagedCommitMessage`** → the Add/Remove proposal DIDs are extracted from
-///   the staged commit **before** `merge_staged_commit` consumes it (the
-///   removed members' leaf credentials are still present in the *current* group
-///   tree pre-merge, and the added members' credentials are read from the Add
-///   proposals' `KeyPackage`s). The commit is then merged and
-///   [`InboundChange::Commit`] is returned. The `KeyPackage`s inside the Add
-///   proposals were already validated by `process_message` (it rejects a Commit
-///   carrying an invalid Add), so the recovered added DIDs are authenticated.
+/// - **`StagedCommitMessage`, add-only** → the added members' DIDs are read
+///   from the Add proposals' `KeyPackage` leaf credentials **before**
+///   `merge_staged_commit` consumes the staged commit, the commit is then
+///   merged, and [`InboundChange::Commit`] is returned. The `KeyPackage`s inside
+///   the Add proposals were already validated by `process_message` (it rejects a
+///   Commit carrying an invalid Add), so the recovered added DIDs are
+///   authenticated.
+/// - **`StagedCommitMessage` carrying any Remove** → the staged commit is
+///   **dropped without merging** and [`InboundChange::UnsupportedMembershipChange`]
+///   is returned. The removed members' DIDs are recovered from the *current*
+///   (pre-merge) tree for reporting, but `merge_staged_commit` is **never
+///   called**, so the MLS group stays on its current epoch and remains
+///   consistent with the caller's SCP-layer state (fail-closed, not
+///   half-applied). The caller can keep using the group on the old epoch.
 /// - **`ProposalMessage` / `ExternalJoinProposalMessage`** →
 ///   [`InboundChange::Proposal`]; `OpenMLS` caches the proposal, no membership
 ///   change is committed yet.
@@ -463,7 +539,10 @@ fn credential_to_did(credential: &Credential) -> Result<String, MlsError> {
 ///
 /// Returns [`MlsError::GroupDestroyed`] if the group has been destroyed,
 /// [`MlsError::DecryptionFailed`] if decryption or credential parsing fails, or
-/// [`MlsError::CommitProcessingFailed`] if the staged commit cannot be merged.
+/// [`MlsError::CommitProcessingFailed`] if an add-only staged commit cannot be
+/// merged. A Remove-bearing Commit does not error here — it is surfaced as
+/// [`InboundChange::UnsupportedMembershipChange`] without merging, leaving the
+/// group consistent.
 pub fn decrypt_with_membership_changes(
     group: &mut ScpMlsGroup,
     ciphertext: &[u8],
@@ -522,21 +601,16 @@ pub fn decrypt_with_membership_changes(
             sender_did,
         }),
         ProcessedMessageContent::StagedCommitMessage(staged_commit) => {
-            // Recover the added DIDs from the Add proposals' KeyPackage leaf
-            // credentials. These KeyPackages were validated by process_message
-            // (a Commit carrying an invalid Add is rejected above), so the DIDs
-            // are cryptographically authenticated, not advisory.
-            let mut added_dids = Vec::new();
-            for add in staged_commit.add_proposals() {
-                let did =
-                    credential_to_did(add.add_proposal().key_package().leaf_node().credential())?;
-                added_dids.push(did);
-            }
+            // Inspect the staged commit's proposals BEFORE merging. openmls lets
+            // us read `add_proposals()` / `remove_proposals()` off the
+            // StagedCommit while the group is still on its current epoch, so we
+            // can decide whether to merge WITHOUT first mutating MLS state.
 
             // Recover the removed DIDs by mapping each Remove proposal's leaf
             // index to that member's credential in the CURRENT tree — the
-            // removed leaf is still present until merge_staged_commit runs, so
-            // this lookup must happen BEFORE the merge below.
+            // removed leaf is still present pre-merge, and (critically) is read
+            // here BEFORE any merge so this lookup is valid whether or not we go
+            // on to merge.
             let mut removed_dids = Vec::new();
             {
                 let g = group.group.as_ref().ok_or(MlsError::GroupDestroyed)?;
@@ -555,7 +629,38 @@ pub fn decrypt_with_membership_changes(
                 }
             }
 
-            // Merge the staged commit to advance the group epoch (mirrors
+            // FAIL-CLOSED: a Remove-bearing Commit is unsupported by this seam.
+            // Reject it WITHOUT merging — drop the StagedCommit here, leaving the
+            // MLS group on its current epoch. MLS state and the caller's
+            // SCP-layer state stay mutually consistent (pre-remove); the group
+            // remains usable. Merging first and rejecting afterwards would
+            // advance the MLS epoch + evict the leaf while the caller's
+            // membership/log stayed put — an internal MLS-vs-SCP skew. We do not
+            // merge before we have decided the Commit is one we can converge.
+            if !removed_dids.is_empty() {
+                // `staged_commit` is dropped at the end of this block without
+                // ever being passed to `merge_staged_commit`, so the group is
+                // unchanged.
+                return Ok(InboundChange::UnsupportedMembershipChange {
+                    sender_did,
+                    removed_dids,
+                });
+            }
+
+            // Add-only Commit: recover the added DIDs from the Add proposals'
+            // KeyPackage leaf credentials. These KeyPackages were validated by
+            // process_message (a Commit carrying an invalid Add is rejected
+            // above), so the DIDs are cryptographically authenticated, not
+            // advisory.
+            let mut added_dids = Vec::new();
+            for add in staged_commit.add_proposals() {
+                let did =
+                    credential_to_did(add.add_proposal().key_package().leaf_node().credential())?;
+                added_dids.push(did);
+            }
+
+            // Only now — having confirmed the change is add-only and supported —
+            // merge the staged commit to advance the group epoch (mirrors
             // decrypt_with_sender_did — without this the group is corrupted).
             let g = group.group.as_mut().ok_or(MlsError::GroupDestroyed)?;
             g.merge_staged_commit(&group.provider, *staged_commit)
@@ -566,7 +671,6 @@ pub fn decrypt_with_membership_changes(
             Ok(InboundChange::Commit {
                 sender_did,
                 added_dids,
-                removed_dids,
             })
         }
         ProcessedMessageContent::ProposalMessage(_)
@@ -951,7 +1055,6 @@ mod tests {
             InboundChange::Commit {
                 sender_did,
                 added_dids,
-                removed_dids,
             } => {
                 assert_eq!(sender_did, "did:dht:z6Mkalice", "committer is Alice");
                 assert_eq!(
@@ -959,7 +1062,6 @@ mod tests {
                     vec!["did:dht:z6Mkcarol".to_owned()],
                     "the seam surfaces Carol's DID from the Add proposal"
                 );
-                assert!(removed_dids.is_empty(), "no removes in an add-only commit");
             }
             other => panic!("expected Commit change, got {other:?}"),
         }
@@ -970,11 +1072,12 @@ mod tests {
 
     #[test]
     #[allow(clippy::unwrap_used, clippy::panic)]
-    fn decrypt_with_membership_changes_surfaces_removed_did() {
+    fn decrypt_with_membership_changes_rejects_remove_without_merging() {
         // Alice creates, adds Bob and Carol, then removes Carol. The existing
-        // member Bob processes the remove Commit; the seam must surface Carol's
-        // DID from the pre-merge tree (the removed leaf is still present until
-        // the merge).
+        // member Bob processes the remove Commit; the seam must REJECT it as
+        // UnsupportedMembershipChange (surfacing Carol's DID from the pre-merge
+        // tree) WITHOUT merging — so Bob's MLS group stays on its current epoch
+        // and is left consistent (fail-closed, not half-applied).
         let alice_cred = test_credential("alice");
         let mut alice_group = create_group(&alice_cred).unwrap();
 
@@ -1012,22 +1115,41 @@ mod tests {
         let remove = crate::group::remove_member(&mut alice_group, carol_member.index).unwrap();
         let remove_bytes = remove.commit.tls_serialize_detached().unwrap();
 
+        // Bob is on epoch 2 (create + add-Bob + add-Carol = two epoch advances
+        // since his epoch-0 join: join epoch 1, add-Carol epoch 2). Capture it
+        // so we can prove the rejected remove did NOT advance it.
+        let bob_epoch_before = bob_group.epoch().unwrap();
+
         let change = decrypt_with_membership_changes(&mut bob_group, &remove_bytes).unwrap();
         match change {
-            InboundChange::Commit {
-                added_dids,
+            InboundChange::UnsupportedMembershipChange {
+                sender_did,
                 removed_dids,
-                ..
             } => {
-                assert!(added_dids.is_empty(), "no adds in a remove-only commit");
+                assert_eq!(sender_did, "did:dht:z6Mkalice", "committer is Alice");
                 assert_eq!(
                     removed_dids,
                     vec!["did:dht:z6Mkcarol".to_owned()],
                     "the seam surfaces Carol's DID from the pre-merge tree"
                 );
             }
-            other => panic!("expected Commit change, got {other:?}"),
+            other => panic!("expected UnsupportedMembershipChange, got {other:?}"),
         }
+
+        // FAIL-CLOSED, NOT half-applied: the remove Commit was dropped without
+        // merging, so Bob's MLS group is still on the SAME epoch it was before.
+        assert_eq!(
+            bob_group.epoch().unwrap(),
+            bob_epoch_before,
+            "a rejected remove-Commit must NOT advance the MLS epoch (no half-merge)"
+        );
+
+        // The group is still usable on the old epoch: Bob can still decrypt an
+        // application message Alice (still on the pre-remove epoch herself, since
+        // she committed the remove but Bob never applied it) — prove via a fresh
+        // Bob-side encrypt/serialize roundtrip that his group is intact.
+        let still_works = encrypt(&mut bob_group, b"post-reject").unwrap();
+        let _ = serialize_ciphertext(&still_works).unwrap();
     }
 
     #[test]
@@ -1047,6 +1169,27 @@ mod tests {
             }
             other => panic!("expected Application change, got {other:?}"),
         }
+    }
+
+    #[test]
+    fn inbound_change_debug_redacts_application_plaintext() {
+        // ADR-057: a `{:?}`-formatted InboundChange::Application must print the
+        // byte length, NEVER the decrypted cleartext (the tab is the plaintext
+        // boundary).
+        let secret = b"DO-NOT-LOG-THIS-DECRYPTED-PAYLOAD";
+        let change = InboundChange::Application {
+            plaintext: secret.to_vec(),
+            sender_did: "did:dht:z6Mkalice".to_owned(),
+        };
+        let rendered = format!("{change:?}");
+        assert!(
+            !rendered.contains("DO-NOT-LOG-THIS-DECRYPTED-PAYLOAD"),
+            "Debug must NOT leak the decrypted plaintext, got: {rendered}"
+        );
+        assert!(
+            rendered.contains("<redacted") && rendered.contains(&format!("{} bytes", secret.len())),
+            "Debug must report a redacted byte length, got: {rendered}"
+        );
     }
 
     mod proptest_tests {

--- a/crates/scp-mls/src/encrypt.rs
+++ b/crates/scp-mls/src/encrypt.rs
@@ -341,22 +341,16 @@ pub fn decrypt_with_sender_did(
     // Look up the sender's credential from the group member list and parse
     // the SCP credential to extract the DID.
     let g = group.group.as_ref().ok_or(MlsError::GroupDestroyed)?;
-    let sender_did = g
+    let sender_credential = g
         .members()
         .find(|m| m.index == sender_leaf_index)
+        .map(|m| m.credential)
         .ok_or_else(|| {
             MlsError::DecryptionFailed(format!(
                 "sender leaf index {sender_leaf_index:?} not found in group members"
             ))
-        })
-        .and_then(|m| {
-            let basic_cred = BasicCredential::try_from(m.credential).map_err(|e| {
-                MlsError::DecryptionFailed(format!("extracting BasicCredential: {e}"))
-            })?;
-            let scp_cred = crate::credential::ScpCredential::from_bytes(basic_cred.identity())
-                .map_err(|e| MlsError::DecryptionFailed(format!("parsing ScpCredential: {e}")))?;
-            Ok(scp_cred.did)
         })?;
+    let sender_did = credential_to_did(&sender_credential)?;
 
     // Dispatch based on the processed message content type.
     match processed.into_content() {
@@ -380,6 +374,204 @@ pub fn decrypt_with_sender_did(
             // Proposals are cached by OpenMLS automatically during
             // process_message — no explicit action needed.
             Ok(DecryptedContent::Proposal { sender_did })
+        }
+    }
+}
+
+/// The membership changes an existing member observes when it processes an
+/// inbound MLS message.
+///
+/// Returned by [`decrypt_with_membership_changes`]. For an application message
+/// the change is [`InboundChange::Application`]. For a Commit the change is
+/// [`InboundChange::Commit`], carrying the DIDs added and removed by the
+/// Commit's Add/Remove proposals — recovered from the staged commit *before* it
+/// is merged, so an existing member can mirror the committer's membership-leaf
+/// appends and converge. For a bare Proposal the change is
+/// [`InboundChange::Proposal`].
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum InboundChange {
+    /// An application message carrying user plaintext and the sender DID.
+    Application {
+        /// The decrypted payload bytes.
+        plaintext: Vec<u8>,
+        /// The sender's DID string extracted from the MLS credential.
+        sender_did: String,
+    },
+    /// A Commit that advanced the group epoch. `merge_staged_commit` has
+    /// already been called. `added_dids` and `removed_dids` are the SCP DIDs of
+    /// the members the Commit's Add/Remove proposals add and evict, recovered
+    /// from the staged commit (Add proposals' `KeyPackage` leaf credentials and
+    /// Remove proposals' pre-merge leaf credentials) before the merge.
+    Commit {
+        /// The committer's DID string extracted from the MLS credential.
+        sender_did: String,
+        /// DIDs added by this Commit's Add proposals, in proposal order.
+        added_dids: Vec<String>,
+        /// DIDs removed by this Commit's Remove proposals, in proposal order.
+        removed_dids: Vec<String>,
+    },
+    /// A Proposal cached by `OpenMLS` during `process_message`. No plaintext and
+    /// no committed membership change yet.
+    Proposal {
+        /// The sender's DID string extracted from the MLS credential.
+        sender_did: String,
+    },
+}
+
+/// Parses the SCP DID out of an MLS [`Credential`] (a `BasicCredential` whose
+/// identity payload is a `MessagePack`-encoded [`crate::credential::ScpCredential`]).
+///
+/// Shared by the sender-resolution paths and the membership-change recovery in
+/// [`decrypt_with_membership_changes`], so every place that names a member from
+/// an MLS leaf parses the credential identically.
+fn credential_to_did(credential: &Credential) -> Result<String, MlsError> {
+    let basic = BasicCredential::try_from(credential.clone())
+        .map_err(|e| MlsError::DecryptionFailed(format!("extracting BasicCredential: {e}")))?;
+    let scp_cred = crate::credential::ScpCredential::from_bytes(basic.identity())
+        .map_err(|e| MlsError::DecryptionFailed(format!("parsing ScpCredential: {e}")))?;
+    Ok(scp_cred.did)
+}
+
+/// Decrypts an inbound MLS message and, for a Commit, surfaces the membership
+/// changes it carries so an existing member can converge its SCP-layer state.
+///
+/// This is the existing-member counterpart of the joiner's
+/// [`crate::group::add_member`] path: the committer (adder) appends a
+/// `MemberJoined` event-log leaf and hands the new member the full log, while
+/// **existing** members learn of the add only by processing the Commit. To
+/// append the identical convergent membership leaf, an existing member needs
+/// the added member's DID — which [`decrypt_with_sender_did`] discarded. This
+/// function recovers it.
+///
+/// # Message Type Handling
+///
+/// - **`ApplicationMessage`** → [`InboundChange::Application`] (plaintext +
+///   sender DID), identical to [`decrypt_with_sender_did`].
+/// - **`StagedCommitMessage`** → the Add/Remove proposal DIDs are extracted from
+///   the staged commit **before** `merge_staged_commit` consumes it (the
+///   removed members' leaf credentials are still present in the *current* group
+///   tree pre-merge, and the added members' credentials are read from the Add
+///   proposals' `KeyPackage`s). The commit is then merged and
+///   [`InboundChange::Commit`] is returned. The `KeyPackage`s inside the Add
+///   proposals were already validated by `process_message` (it rejects a Commit
+///   carrying an invalid Add), so the recovered added DIDs are authenticated.
+/// - **`ProposalMessage` / `ExternalJoinProposalMessage`** →
+///   [`InboundChange::Proposal`]; `OpenMLS` caches the proposal, no membership
+///   change is committed yet.
+///
+/// # Errors
+///
+/// Returns [`MlsError::GroupDestroyed`] if the group has been destroyed,
+/// [`MlsError::DecryptionFailed`] if decryption or credential parsing fails, or
+/// [`MlsError::CommitProcessingFailed`] if the staged commit cannot be merged.
+pub fn decrypt_with_membership_changes(
+    group: &mut ScpMlsGroup,
+    ciphertext: &[u8],
+) -> Result<InboundChange, MlsError> {
+    if group.group.is_none() {
+        return Err(MlsError::GroupDestroyed);
+    }
+
+    let message_in = MlsMessageIn::tls_deserialize(&mut &*ciphertext)
+        .map_err(|e| MlsError::DecryptionFailed(format!("deserializing ciphertext: {e}")))?;
+
+    let protocol_message = message_in
+        .try_into_protocol_message()
+        .map_err(|e| MlsError::DecryptionFailed(format!("extracting protocol message: {e}")))?;
+
+    let g = group.group.as_mut().ok_or(MlsError::GroupDestroyed)?;
+    // NOTE (ADR-057 §Prereq-4): inert under wasm `panic=abort`; browser build
+    // must use `panic=unwind` (see the `decrypt` note above).
+    let process_result = catch_unwind(AssertUnwindSafe(|| {
+        g.process_message(&group.provider, protocol_message)
+    }));
+
+    let processed = match process_result {
+        Ok(Ok(msg)) => msg,
+        Ok(Err(e)) => return Err(MlsError::DecryptionFailed(e.to_string())),
+        Err(_) => {
+            return Err(MlsError::DecryptionFailed(
+                "OpenMLS panicked during message processing".to_string(),
+            ));
+        }
+    };
+
+    // Resolve the sender DID from their leaf credential before consuming the
+    // ProcessedMessage.
+    let sender = processed.sender().clone();
+    let Sender::Member(sender_leaf_index) = sender else {
+        return Err(MlsError::DecryptionFailed(
+            "sender is not a group member".to_string(),
+        ));
+    };
+    let g = group.group.as_ref().ok_or(MlsError::GroupDestroyed)?;
+    let sender_credential = g
+        .members()
+        .find(|m| m.index == sender_leaf_index)
+        .map(|m| m.credential)
+        .ok_or_else(|| {
+            MlsError::DecryptionFailed(format!(
+                "sender leaf index {sender_leaf_index:?} not found in group members"
+            ))
+        })?;
+    let sender_did = credential_to_did(&sender_credential)?;
+
+    match processed.into_content() {
+        ProcessedMessageContent::ApplicationMessage(app_msg) => Ok(InboundChange::Application {
+            plaintext: app_msg.into_bytes(),
+            sender_did,
+        }),
+        ProcessedMessageContent::StagedCommitMessage(staged_commit) => {
+            // Recover the added DIDs from the Add proposals' KeyPackage leaf
+            // credentials. These KeyPackages were validated by process_message
+            // (a Commit carrying an invalid Add is rejected above), so the DIDs
+            // are cryptographically authenticated, not advisory.
+            let mut added_dids = Vec::new();
+            for add in staged_commit.add_proposals() {
+                let did =
+                    credential_to_did(add.add_proposal().key_package().leaf_node().credential())?;
+                added_dids.push(did);
+            }
+
+            // Recover the removed DIDs by mapping each Remove proposal's leaf
+            // index to that member's credential in the CURRENT tree — the
+            // removed leaf is still present until merge_staged_commit runs, so
+            // this lookup must happen BEFORE the merge below.
+            let mut removed_dids = Vec::new();
+            {
+                let g = group.group.as_ref().ok_or(MlsError::GroupDestroyed)?;
+                for remove in staged_commit.remove_proposals() {
+                    let removed_index = remove.remove_proposal().removed();
+                    let credential = g
+                        .members()
+                        .find(|m| m.index == removed_index)
+                        .map(|m| m.credential)
+                        .ok_or_else(|| {
+                            MlsError::DecryptionFailed(format!(
+                                "removed leaf index {removed_index:?} not found in group members"
+                            ))
+                        })?;
+                    removed_dids.push(credential_to_did(&credential)?);
+                }
+            }
+
+            // Merge the staged commit to advance the group epoch (mirrors
+            // decrypt_with_sender_did — without this the group is corrupted).
+            let g = group.group.as_mut().ok_or(MlsError::GroupDestroyed)?;
+            g.merge_staged_commit(&group.provider, *staged_commit)
+                .map_err(|e| {
+                    MlsError::CommitProcessingFailed(format!("merging staged commit: {e}"))
+                })?;
+
+            Ok(InboundChange::Commit {
+                sender_did,
+                added_dids,
+                removed_dids,
+            })
+        }
+        ProcessedMessageContent::ProposalMessage(_)
+        | ProcessedMessageContent::ExternalJoinProposalMessage(_) => {
+            Ok(InboundChange::Proposal { sender_did })
         }
     }
 }
@@ -727,6 +919,133 @@ mod tests {
         );
         if let DecryptedContent::Application { plaintext: pt, .. } = content {
             assert_eq!(pt, plaintext, "must decrypt after Commit processing");
+        }
+    }
+
+    #[test]
+    #[allow(clippy::unwrap_used, clippy::panic)]
+    fn decrypt_with_membership_changes_surfaces_added_did() {
+        // Alice creates, adds Bob, then adds Carol. The existing member Bob
+        // processes Alice's add-Carol Commit and the seam must surface Carol's
+        // DID (recovered from the Add proposal's KeyPackage), so an existing
+        // member can mirror the committer's MemberJoined leaf and converge.
+        let alice_cred = test_credential("alice");
+        let mut alice_group = create_group(&alice_cred).unwrap();
+
+        let bob_cred = test_credential("bob");
+        let (bob_kp_bundle, bob_signer, bob_provider) = generate_key_package(&bob_cred).unwrap();
+        let bob_kp: KeyPackageIn = bob_kp_bundle.key_package().clone().into();
+        let add_bob = add_member(&mut alice_group, bob_kp).unwrap();
+        let mut bob_group = join_group(&add_bob.welcome, bob_provider, bob_signer).unwrap();
+
+        let carol_cred = test_credential("carol");
+        let (carol_kp_bundle, _carol_signer, _carol_provider) =
+            generate_key_package(&carol_cred).unwrap();
+        let carol_kp: KeyPackageIn = carol_kp_bundle.key_package().clone().into();
+        let add_carol = add_member(&mut alice_group, carol_kp).unwrap();
+
+        let commit_bytes = add_carol.commit.tls_serialize_detached().unwrap();
+        let change = decrypt_with_membership_changes(&mut bob_group, &commit_bytes).unwrap();
+
+        match change {
+            InboundChange::Commit {
+                sender_did,
+                added_dids,
+                removed_dids,
+            } => {
+                assert_eq!(sender_did, "did:dht:z6Mkalice", "committer is Alice");
+                assert_eq!(
+                    added_dids,
+                    vec!["did:dht:z6Mkcarol".to_owned()],
+                    "the seam surfaces Carol's DID from the Add proposal"
+                );
+                assert!(removed_dids.is_empty(), "no removes in an add-only commit");
+            }
+            other => panic!("expected Commit change, got {other:?}"),
+        }
+
+        // The merge advanced Bob's epoch (proves the commit was applied).
+        assert_eq!(bob_group.epoch().unwrap(), 2, "two adds → epoch 2");
+    }
+
+    #[test]
+    #[allow(clippy::unwrap_used, clippy::panic)]
+    fn decrypt_with_membership_changes_surfaces_removed_did() {
+        // Alice creates, adds Bob and Carol, then removes Carol. The existing
+        // member Bob processes the remove Commit; the seam must surface Carol's
+        // DID from the pre-merge tree (the removed leaf is still present until
+        // the merge).
+        let alice_cred = test_credential("alice");
+        let mut alice_group = create_group(&alice_cred).unwrap();
+
+        let bob_cred = test_credential("bob");
+        let (bob_kp_bundle, bob_signer, bob_provider) = generate_key_package(&bob_cred).unwrap();
+        let add_bob =
+            add_member(&mut alice_group, bob_kp_bundle.key_package().clone().into()).unwrap();
+        let mut bob_group = join_group(&add_bob.welcome, bob_provider, bob_signer).unwrap();
+
+        let carol_cred = test_credential("carol");
+        let (carol_kp_bundle, _carol_signer, _carol_provider) =
+            generate_key_package(&carol_cred).unwrap();
+        let add_carol = add_member(
+            &mut alice_group,
+            carol_kp_bundle.key_package().clone().into(),
+        )
+        .unwrap();
+        let add_carol_bytes = add_carol.commit.tls_serialize_detached().unwrap();
+        // Bob processes the add-Carol commit so his tree contains Carol.
+        decrypt_with_membership_changes(&mut bob_group, &add_carol_bytes).unwrap();
+
+        // Alice removes Carol.
+        let alice_own = alice_group.own_leaf_index().unwrap();
+        let members = alice_group.members().unwrap();
+        let carol_member = members
+            .iter()
+            .find(|m| {
+                m.index != alice_own && {
+                    let bc = BasicCredential::try_from(m.credential.clone()).unwrap();
+                    let sc = crate::credential::ScpCredential::from_bytes(bc.identity()).unwrap();
+                    sc.did == "did:dht:z6Mkcarol"
+                }
+            })
+            .unwrap();
+        let remove = crate::group::remove_member(&mut alice_group, carol_member.index).unwrap();
+        let remove_bytes = remove.commit.tls_serialize_detached().unwrap();
+
+        let change = decrypt_with_membership_changes(&mut bob_group, &remove_bytes).unwrap();
+        match change {
+            InboundChange::Commit {
+                added_dids,
+                removed_dids,
+                ..
+            } => {
+                assert!(added_dids.is_empty(), "no adds in a remove-only commit");
+                assert_eq!(
+                    removed_dids,
+                    vec!["did:dht:z6Mkcarol".to_owned()],
+                    "the seam surfaces Carol's DID from the pre-merge tree"
+                );
+            }
+            other => panic!("expected Commit change, got {other:?}"),
+        }
+    }
+
+    #[test]
+    #[allow(clippy::unwrap_used, clippy::panic)]
+    fn decrypt_with_membership_changes_application_variant() {
+        let (mut alice_group, mut bob_group) = setup_alice_bob();
+        let ct = encrypt(&mut alice_group, b"hi").unwrap();
+        let ct_bytes = serialize_ciphertext(&ct).unwrap();
+        let change = decrypt_with_membership_changes(&mut bob_group, &ct_bytes).unwrap();
+        match change {
+            InboundChange::Application {
+                plaintext,
+                sender_did,
+            } => {
+                assert_eq!(plaintext, b"hi");
+                assert!(sender_did.starts_with("did:dht:z6Mk"));
+            }
+            other => panic!("expected Application change, got {other:?}"),
         }
     }
 

--- a/crates/scp-mls/src/group.rs
+++ b/crates/scp-mls/src/group.rs
@@ -461,6 +461,50 @@ pub fn add_member(
     })
 }
 
+/// Extracts the SCP DID embedded in a `KeyPackage`'s leaf credential.
+///
+/// Reads the (unverified) `BasicCredential` from the key package's leaf node
+/// and parses it as an [`ScpCredential`] to recover the DID, validating only
+/// the protocol version first. This lets a driver name the member a key
+/// package belongs to *before* consuming the package in [`add_member`], so the
+/// membership record and the MLS leaf cannot disagree.
+///
+/// This is the standalone counterpart of the credential extraction
+/// `add_member` and `decrypt_with_sender_did` already perform internally; it
+/// exists so an in-browser participant driver (ADR-057) can read the joiner's
+/// DID off the wire-delivered key package without trusting a separately
+/// supplied DID.
+///
+/// The credential is read from the *unverified* key package. The DID is only
+/// as trustworthy as the subsequent [`add_member`] validation makes it: a
+/// malformed or mis-signed key package is rejected when it is actually added.
+/// Callers must treat the returned DID as advisory until the add succeeds.
+///
+/// # Errors
+///
+/// Returns [`MlsError::AddMemberFailed`] if the key package fails protocol
+/// version validation, [`MlsError::CredentialSerializationFailed`] if the leaf
+/// credential is not a parseable SCP `BasicCredential`.
+pub fn key_package_in_did(
+    key_package: &KeyPackageIn,
+    protocol_version: ProtocolVersion,
+) -> Result<String, MlsError> {
+    // A fresh in-memory provider supplies the crypto backend for validation;
+    // it holds no group state and is discarded.
+    let provider = InMemoryMlsProvider::default();
+    let verified = key_package
+        .clone()
+        .validate(provider.crypto(), protocol_version)
+        .map_err(|e| MlsError::AddMemberFailed(format!("key package validation: {e}")))?;
+
+    let credential = verified.leaf_node().credential().clone();
+    let basic = BasicCredential::try_from(credential).map_err(|e| {
+        MlsError::CredentialSerializationFailed(format!("extracting BasicCredential: {e}"))
+    })?;
+    let scp_cred = ScpCredential::from_bytes(basic.identity())?;
+    Ok(scp_cred.did)
+}
+
 /// The result of removing a member from an MLS group.
 ///
 /// Contains the Commit message that must be distributed to remaining members
@@ -983,5 +1027,24 @@ mod tests {
             SCP_CIPHERSUITE,
             "key package must use SCP ciphersuite"
         );
+    }
+
+    #[test]
+    #[allow(clippy::unwrap_used)]
+    fn key_package_in_did_recovers_embedded_did() {
+        // The DID a `key_package_in_did` reads must equal the DID the key
+        // package was generated for — proving a driver can name the joiner from
+        // the wire-delivered package without a separately supplied DID.
+        let cred = ScpCredential::new(
+            "did:dht:z6MkKeyPackageDidExtractFixture".to_string(),
+            None,
+            scp_primitives::SigningKeyId::Active,
+        )
+        .unwrap();
+        let (kp_bundle, _signer, _provider) = generate_key_package(&cred).unwrap();
+        let kp_in: KeyPackageIn = kp_bundle.key_package().clone().into();
+
+        let did = key_package_in_did(&kp_in, ProtocolVersion::Mls10).unwrap();
+        assert_eq!(did, "did:dht:z6MkKeyPackageDidExtractFixture");
     }
 }

--- a/crates/scp-mls/src/group.rs
+++ b/crates/scp-mls/src/group.rs
@@ -461,29 +461,33 @@ pub fn add_member(
     })
 }
 
-/// Extracts the SCP DID embedded in a `KeyPackage`'s leaf credential.
+/// Extracts the SCP DID embedded in a fully-validated `KeyPackage`'s leaf
+/// credential.
 ///
-/// Reads the (unverified) `BasicCredential` from the key package's leaf node
-/// and parses it as an [`ScpCredential`] to recover the DID, validating only
-/// the protocol version first. This lets a driver name the member a key
-/// package belongs to *before* consuming the package in [`add_member`], so the
-/// membership record and the MLS leaf cannot disagree.
+/// Runs `OpenMLS`'s full [`KeyPackageIn::validate`] — which verifies the leaf
+/// node signature, the key package signature, the protocol version, and the
+/// `Lifetime` — and only then reads the `BasicCredential` from the verified
+/// leaf node and parses it as an [`ScpCredential`] to recover the DID. The
+/// returned DID is therefore cryptographically authenticated: it is bound to a
+/// leaf node whose signature has been checked against the key package's own
+/// signature key, not merely deserialized from untrusted bytes. This lets a
+/// driver name the member a key package belongs to *before* consuming the
+/// package in [`add_member`], so the membership record and the MLS leaf cannot
+/// disagree.
 ///
 /// This is the standalone counterpart of the credential extraction
 /// `add_member` and `decrypt_with_sender_did` already perform internally; it
 /// exists so an in-browser participant driver (ADR-057) can read the joiner's
 /// DID off the wire-delivered key package without trusting a separately
-/// supplied DID.
-///
-/// The credential is read from the *unverified* key package. The DID is only
-/// as trustworthy as the subsequent [`add_member`] validation makes it: a
-/// malformed or mis-signed key package is rejected when it is actually added.
-/// Callers must treat the returned DID as advisory until the add succeeds.
+/// supplied DID. Because validation is identical to the one `add_member`
+/// performs, a key package this function accepts is one `add_member` will also
+/// accept (and vice versa) — there is no weaker "advisory" window.
 ///
 /// # Errors
 ///
-/// Returns [`MlsError::AddMemberFailed`] if the key package fails protocol
-/// version validation, [`MlsError::CredentialSerializationFailed`] if the leaf
+/// Returns [`MlsError::AddMemberFailed`] if the key package fails validation
+/// (bad signature, wrong protocol version, or an invalid/expired `Lifetime`),
+/// or [`MlsError::CredentialSerializationFailed`] if the validated leaf
 /// credential is not a parseable SCP `BasicCredential`.
 pub fn key_package_in_did(
     key_package: &KeyPackageIn,

--- a/crates/scp-mls/src/lib.rs
+++ b/crates/scp-mls/src/lib.rs
@@ -46,7 +46,7 @@ pub mod wrapping_extension;
 
 // Re-export primary public API types for convenience.
 pub use credential::ScpCredential;
-pub use encrypt::DecryptedContent;
+pub use encrypt::{DecryptedContent, InboundChange};
 pub use error::MlsError;
 
 // The MLS signing key pair appears in this crate's public op signatures

--- a/crates/scp-mls/src/lib.rs
+++ b/crates/scp-mls/src/lib.rs
@@ -48,11 +48,17 @@ pub mod wrapping_extension;
 pub use credential::ScpCredential;
 pub use encrypt::DecryptedContent;
 pub use error::MlsError;
+
+// The MLS signing key pair appears in this crate's public op signatures
+// (`generate_key_package` returns it; `join_group` consumes it). Re-export it so
+// consumers — notably the in-browser participant driver (ADR-057) — can name
+// the type without taking a direct dependency on `openmls_basic_credential`.
 pub use group::{
     AddMemberResult, RemoveMemberResult, SCP_CIPHERSUITE, ScpMlsGroup, add_member, create_group,
     create_group_with_wrapping_key, destroy_group, generate_key_package,
-    generate_key_package_with_wrapping_key, join_group, remove_member,
+    generate_key_package_with_wrapping_key, join_group, key_package_in_did, remove_member,
 };
+pub use openmls_basic_credential::SignatureKeyPair;
 pub use wrapping_extension::{
     SCP_WRAPPING_KEY_EXTENSION_TYPE, extract_member_wrapping_key, extract_own_wrapping_key,
     extract_wrapping_key, find_leaf_index_by_did, leaf_node_params_with_wrapping_key,


### PR DESCRIPTION
Implements **ADR-057** Slice 2: a wasm32-safe single-threaded participant DRIVER over the shared `scp-mls` crate — the proof that the participant path runs in-tab without `scp-runtime`'s actor/tokio orchestration. Builds on the merged ADR-057 (#1964) + scp-mls extraction (#1966).

## What it does
A new `crates/scp-client/` driving one or more contexts single-threaded over shared `scp-mls`/`scp-protocol`/`scp-event-log` (restores the deleted bridge's `manager`/`crypto-state` *shape*, bodies call shared code — no re-implementation):
- Participant message path: create / generate-keypackage / add-member / join (replay) / send / receive-decrypt / process-commit / close.
- §9.16 double-encryption pipeline (sender-layer → 16B `epoch‖seq` header → MLS), the epoch-poison ceiling + replay tracker, all via shared `scp_protocol::crypto::sender_keys` — no parity tax.
- **Multi-party convergence by replay**: leaf hashes bind `sequence`+`prev_hash`, so members can't independently mint identical leaves; the committer transports a convergent timestamp, existing members append the identical `MemberJoined` leaf (DID recovered from the *validated* add-proposal), and the chain-validated append (`prev_hash` linkage) rejects forged history. Proven by a **3-party** test (Alice→Bob→Carol; Bob converges on the add-Commit) + a reciprocal-send test with **different clocks per party**.
- Injected `Signer`/`Storage` traits (keys on-device; WebCrypto custody + IndexedDB slot in at Slice 3). Two minimal validated `scp-mls` seams added (`key_package_in_did`, `decrypt_with_membership_changes`).

## Verification
- **`cargo check -p scp-client --target wasm32-unknown-unknown` → exit 0.**
- **Mechanical fence:** `cargo tree -p scp-client` has no `scp-runtime`/`scp-identity`/`tokio` (ADR-057 dependency-direction invariant).
- Build/clippy(`-D warnings`)/fmt clean; tests pass (incl. 2-party, 3-party, reciprocal-clock, remove-guard, Debug-redaction).

## Reviews (double-zero)
cryptographer (APPROVE — pipeline faithful to canonical seal/open, validated DID recovery, no regression), bug-catcher (caught + verified-fixed a multi-party convergence HIGH), security-reviewer (keys never logged, fail-closed receive, no skew on the pre-merge remove-guard), completionist (scope fence held, complete-as-claimed).

## Scope fence
Participant path ONLY — no economy/governance/broadcast/saga/UCAN (node-side). Removes are guarded fail-closed (pre-merge reject, no MLS/SCP skew).

## Tracked follow-ups (not silently deferred)
- #1965 — route openmls KeyPackage Lifetime clock through the hardened Clock.
- #1975 — authenticate/bind the convergent committer timestamp before a real relay (signed leaf).
- #1976 — in-tab HPKE sender-key distribution over the MLS `scp_wrapping_key` extension.

Depends on ADR-057 (#1964) + scp-mls (#1966), both merged.