### PR TITLE
refactor(saga): delete dead supervisor scaffolding + corpus-wide actor-migration doc-scrub

### DIFF
--- a/crates/scp-runtime/src/context/actor/handlers/lifecycle.rs
+++ b/crates/scp-runtime/src/context/actor/handlers/lifecycle.rs
@@ -17,8 +17,8 @@
 //! construct fresh `PerContextState` and cannot be routed against a
 //! per-context actor that does not yet exist. They are handled by
 //! [`Supervisor::dispatch_lifecycle_direct`](crate::context::supervisor::supervisor::Supervisor)
-//! which delegates to the designated-legacy bootstrap helpers in
-//! [`crate::context::lifecycle_helpers_legacy`]. If a bootstrap variant
+//! which delegates to the actor-shape bootstrap helpers in
+//! [`crate::context::lifecycle_helpers`]. If a bootstrap variant
 //! reaches this actor-shape dispatch (because an actor is already
 //! registered for the target context_id — a re-create attempt), the
 //! handler surfaces `ContextError::InvalidState` on the reply oneshot.

--- a/crates/scp-runtime/src/context/actor/handlers/lifecycle.rs
+++ b/crates/scp-runtime/src/context/actor/handlers/lifecycle.rs
@@ -486,9 +486,9 @@ fn outcome_error_sketch(err: &ContextError) -> ContextError {
 }
 
 fn reply_not_implemented(reply: oneshot::Sender<Result<(), ContextError>>) -> Outcome<()> {
-    const MSG: &str = "LifecycleCommand::Placeholder — placeholder variant; \
-                       real variants land in commit 9 / Phase 2A.9 of \
-                       ADR-049";
+    const MSG: &str = "LifecycleCommand::Placeholder — placeholder handshake \
+                       variant; real lifecycle command handling is not routed \
+                       through this arm";
     let _ = reply.send(Err(ContextError::NotImplemented(MSG.to_owned())));
     Outcome::err(ContextError::NotImplemented(MSG.to_owned()))
 }

--- a/crates/scp-runtime/src/context/lifecycle_helpers.rs
+++ b/crates/scp-runtime/src/context/lifecycle_helpers.rs
@@ -6,9 +6,9 @@
 //! This module hosts lifecycle-domain helpers that operate on actor-owned
 //! [`PerContextState`](crate::context::state::PerContextState) and
 //! capability-reduced [`ActorDeps`](crate::context::actor::deps::ActorDeps).
-//! The legacy `&Supervisor` lock-and-call bodies live in
-//! [`crate::context::lifecycle_helpers_legacy`] until Phase 2A
-//! finalization removes the shim fallback.
+//! Phase 2A finalization deleted the legacy `&Supervisor` lock-and-call
+//! bodies (and the shim fallback); every lifecycle command now runs
+//! through these actor-shape helpers.
 //!
 //! # Pipeline shape
 //!
@@ -49,21 +49,25 @@
 //! - [`load_persisted_context_state`] — load context snapshot and broadcast state from persistence.
 //! - [`restore_context`] — rebuild `PerContextState` from snapshot + register + start governance timeout + spawn TTL.
 //!
-//! `finalize_create` reaches the designated-legacy
-//! `start_governance_timeout_task_legacy` via the shim escape (see
-//! [`SupervisorHandle::shim_supervisor`](crate::context::supervisor::handle::SupervisorHandle::shim_supervisor))
-//! because that helper iterates the contexts `DashMap` and stays
-//! legacy-shape until the per-context governance-timeout actor lands.
+//! `finalize_create` installs the governance-timeout task via
+//! [`governance_helpers::start_governance_timeout_task`](crate::context::governance_helpers::start_governance_timeout_task),
+//! which mailboxes
+//! [`GovernanceCommand::StartTimeoutTask`](crate::context::actor::commands::GovernanceCommand::StartTimeoutTask)
+//! to the freshly-spawned per-context actor — no shim escape, no
+//! `DashMap` iteration.
 //!
-//! # Designated-legacy supervisor-scoped iteration helpers
+//! # Supervisor-iterating sweep entry points
 //!
-//! These iterate the contexts `DashMap` and inherently cannot move to
-//! actor-owned shape — they live ONLY in
-//! [`crate::context::lifecycle_helpers_legacy`]:
+//! These iterate the actor registry
+//! ([`Supervisor::actor_ids`](crate::context::supervisor::Supervisor::actor_ids),
+//! NOT a legacy `contexts` `DashMap`) and dispatch one typed sweep
+//! command per actor through the per-context mailbox. They live in this
+//! module:
 //!
-//! - `restore_all_contexts_legacy`
-//! - `flush_all_contexts_legacy` / `flush_all_contexts_sync_legacy`
-//! - `shutdown_all_contexts_legacy` / `shutdown_all_contexts_sync_legacy`
+//! - [`restore_all_contexts`] (iterates persistence snapshots — no
+//!   actors exist before restore)
+//! - [`flush_all_contexts`] / [`flush_all_contexts_sync`]
+//! - [`shutdown_all_contexts`] / [`shutdown_all_contexts_sync`]
 
 #![allow(clippy::significant_drop_tightening)]
 
@@ -97,10 +101,10 @@ use crate::context::ttl::{self, CloseResult, TtlTimer};
 // ADR-049 Phase 2A finalization keystone (commit 12 phase 2A finalization
 // — type unification, single PerContextState): the prior alias to the
 // legacy struct was deleted alongside the struct itself. Every bootstrap
-// call site now constructs the unified `PerContextState` directly. The
-// contexts DashMap is still the production source of truth — subsequent
-// finalization commits delete the DashMap and route bootstrap through
-// `spawn_actor_with_state`.
+// call site now constructs the unified `PerContextState` directly and
+// hands it to `spawn_actor_with_state`; the spawned actor OWNS the state
+// and registers its handle in the supervisor registry. There is no legacy
+// contexts `DashMap` — the actor registry is the single source of truth.
 
 // ---------------------------------------------------------------------------
 // §9.10.4 routing construction helpers
@@ -2793,8 +2797,8 @@ pub async fn restore_context(
 // Supervisor-iterating sweep entry points (Phase 2A finalization)
 // ===========================================================================
 //
-// These are the non-legacy replacements for the `_legacy` lifecycle
-// sweep helpers in `lifecycle_helpers_legacy.rs`. Each iterates
+// These replaced the now-deleted legacy lifecycle sweep helpers
+// (the `lifecycle_helpers_legacy` module is gone). Each iterates
 // [`Supervisor::actor_ids`](crate::context::supervisor::Supervisor::actor_ids)
 // (the actor registry — NOT the legacy `Supervisor::contexts` DashMap)
 // and dispatches one typed sweep command per actor via the per-actor
@@ -2806,7 +2810,7 @@ pub async fn restore_context(
 // payload from snapshot and calls `Supervisor::restore_context`,
 // which routes the bootstrap variant through
 // `dispatch_lifecycle_direct` (the only legitimate caller of the
-// bootstrap-shape legacy helpers per ADR-049 §7 allowlist).
+// bootstrap-shape helpers per ADR-049 §7 allowlist).
 //
 // Per-actor sweep bodies live in
 // [`crate::context::actor::handlers::lifecycle`] as `handle_*_actor`

--- a/crates/scp-runtime/src/context/supervisor/handle.rs
+++ b/crates/scp-runtime/src/context/supervisor/handle.rs
@@ -60,15 +60,11 @@ pub struct SupervisorHandle {
 
 impl SupervisorHandle {
     /// Wrap an `Arc<Supervisor>`. Visible only to supervisor-module
-    /// code; the bridge instance constructs one at actor spawn time
-    /// (commit 11 wires this through), and handlers receive the handle
-    /// via `ActorDeps` at dispatch time.
-    ///
-    /// `dead_code` allow: commit 6 lands the constructor; the first
-    /// production caller lands with the `BridgeInstance` integration
-    /// in commit 11. The allow is removed then.
+    /// code; the supervisor constructs one in
+    /// [`Supervisor::build_actor_deps`](crate::context::supervisor::Supervisor)
+    /// at actor-spawn time, and handlers receive the handle via
+    /// `ActorDeps` at dispatch time.
     #[must_use]
-    #[allow(dead_code)]
     pub(in crate::context::supervisor) const fn wrap(supervisor: Arc<Supervisor>) -> Self {
         Self { supervisor }
     }

--- a/crates/scp-runtime/src/context/supervisor/handle.rs
+++ b/crates/scp-runtime/src/context/supervisor/handle.rs
@@ -74,8 +74,8 @@ impl SupervisorHandle {
     ///
     /// # Errors
     ///
-    /// See `Supervisor::start_saga`. Commit 6: always
-    /// [`ContextError::NotImplemented`].
+    /// Errors propagate from `Supervisor::start_saga` — the saga
+    /// terminal/abort mapping.
     pub async fn start_saga(&self, input: SagaInput) -> Result<SagaOutput, ContextError> {
         self.supervisor.start_saga(input).await
     }
@@ -400,9 +400,8 @@ impl SupervisorHandle {
     /// in [`crate::context::lifecycle_helpers`] (`create_context`,
     /// `restore_context`, `import_context`) call this after building the
     /// actor-shape state so production paths populate
-    /// `Supervisor::actors` instead of going through the legacy
-    /// contexts-map insert. Subsequent finalization commits delete the
-    /// legacy DashMap once every consumer is ported.
+    /// `Supervisor::actors`, the sole context registry; there is no
+    /// legacy contexts-map.
     ///
     /// # Visibility
     ///
@@ -703,8 +702,8 @@ impl SupervisorHandle {
 //
 // Any method added to this impl that returns `ContextActorHandle`,
 // `Arc<Supervisor>`, `&Supervisor`, or `&mut Supervisor` breaks the
-// capability-reduction contract. Plan §"Mechanical enforcement" adds a
-// CI grep-ban against those return types in this file in commit 12.
+// capability-reduction contract. The contract is maintained by this
+// documented rule plus review — there is no CI grep-ban for it.
 
 // ---------------------------------------------------------------------------
 // Forbidden trait impls — compile-time checklist
@@ -717,8 +716,8 @@ impl SupervisorHandle {
 //   Arc out past the capability boundary.
 //
 // These are documentation, not static assertions — Rust has no
-// "forbid impl of trait X" attribute. The CI grep-ban landing in
-// commit 12 is the mechanical enforcement.
+// "forbid impl of trait X" attribute. The rule is upheld by review,
+// not a CI grep-ban.
 
 // Compile-time witness that `SupervisorHandle` is `Send + Sync` — the
 // handle rides inside `ActorDeps`, which is moved into `tokio::spawn`.

--- a/crates/scp-runtime/src/context/supervisor/mod.rs
+++ b/crates/scp-runtime/src/context/supervisor/mod.rs
@@ -141,7 +141,6 @@ pub use saga_prepared_state::{
 pub use supervisor::SagaSetReservation;
 pub use supervisor::{
     ACTOR_MAILBOX_CAPACITY, CrashWindow, CrossContextToolInvocationRequest, DurableProviders,
-    MessageSigner, PendingSagaProjection, RestoredContexts, SagaAbortReason,
-    SagaDivergenceRepairRecord, SagaError, SagaInput, SagaOutput, SagaSigningKeys, Supervisor,
-    SupervisorConfig,
+    MessageSigner, RestoredContexts, SagaAbortReason, SagaDivergenceRepairRecord, SagaError,
+    SagaInput, SagaOutput, SagaSigningKeys, Supervisor, SupervisorConfig,
 };

--- a/crates/scp-runtime/src/context/supervisor/supervisor.rs
+++ b/crates/scp-runtime/src/context/supervisor/supervisor.rs
@@ -730,8 +730,9 @@ fn decode_repair_records_evidence(bytes: &[u8]) -> Result<Vec<SagaDivergenceRepa
 
 /// Supervisor configuration. Currently a reserved placeholder with no
 /// tunables wired; saga phase timeouts and respawn-budget windows are
-/// derived from associated constants on [`Supervisor`] rather than this
-/// struct.
+/// derived from code constants (`Supervisor::LIFECYCLE_TIMEOUT`, the
+/// function-local `PHASE_TIMEOUT`, and the module-level
+/// [`CRASH_WINDOW_MS`]) rather than this struct.
 #[derive(Clone, Debug, Default)]
 pub struct SupervisorConfig {
     /// Reserved for future configuration; placeholder field so the
@@ -1554,10 +1555,12 @@ impl Supervisor {
     /// factory once at construction time; the returned `Arc<Supervisor>`
     /// is the only handle they hold.
     ///
-    /// Saga journal + supervisor-level persistence wire to no-op stubs
-    /// the test-only `for_query_shim` path uses — saga orchestration
-    /// is not yet active (it lands with Phase 2's actor wiring), and
-    /// the supervisor's own persistence slot is wired to a no-op
+    /// This test/legacy constructor wires a no-op saga journal
+    /// ([`NoopSagaJournal`]), so the saga coordinator runs but never
+    /// durably journals — durable saga journalling requires
+    /// [`Self::with_providers_and_journal`] (the path every production
+    /// bridge takes). The supervisor's own persistence slot is wired to a
+    /// no-op
     /// [`NoopContextPersistence`](crate::context::persistence::NoopContextPersistence)
     /// when `persistence` is `None`.
     ///
@@ -2460,10 +2463,11 @@ impl Supervisor {
     /// - **Bootstrap variants** (`CreateContext`, `ImportContext`,
     ///   `RestoreContext`) always route through
     ///   [`Self::dispatch_lifecycle_direct`], which delegates to the
-    ///   designated-legacy `&Supervisor`-shape helpers in
-    ///   [`crate::context::lifecycle_helpers_legacy`]. These helpers
-    ///   construct fresh `PerContextState` and (on dual-write) spawn
-    ///   the per-context actor as part of the bootstrap handshake.
+    ///   actor-shape helpers in
+    ///   [`crate::context::lifecycle_helpers`]. These helpers
+    ///   construct fresh `PerContextState` and spawn the per-context
+    ///   actor as part of the bootstrap handshake (the actor owns the
+    ///   state; there is no legacy `contexts` `DashMap` write).
     /// - **Per-context variants** (`JoinContext`, `LeaveContext`,
     ///   `CloseContext`, `ExportContext`,
     ///   `GenerateContextAccessKey`, `RevokeContextAccessKey`,
@@ -2495,7 +2499,7 @@ impl Supervisor {
     ) -> Result<Outcome<()>, ContextError> {
         // ADR-049 Phase 2A finalization — bootstrap variants always
         // route through `dispatch_lifecycle_direct`. They construct
-        // fresh state (and, on dual-write, spawn the actor); the
+        // fresh state and spawn the per-context actor; the
         // mailbox-first check would either no-op for a fresh context
         // (no actor yet) or recurse against the existing actor on a
         // re-create attempt — neither produces correct semantics. The
@@ -2512,7 +2516,7 @@ impl Supervisor {
         // Per-context variants (Join / Leave / Close / Export +
         // access-key generate / revoke / restore + Placeholder) all
         // carry a `context_id` and have a registered actor after
-        // bootstrap dual-write. Mailbox-first routes to the actor's
+        // bootstrap spawn. Mailbox-first routes to the actor's
         // `dispatch_state` loop which executes the actor-shape handler.
         if let Some(ctx_id) = Self::lifecycle_command_context_id(&cmd)
             && let Some(actor) = self.lookup(ctx_id)
@@ -2521,7 +2525,7 @@ impl Supervisor {
         }
         // Per-context variant for which no actor is registered — the
         // `Supervisor::contexts` DashMap fallback (and its handler-side
-        // `dispatch_from_shim`) were deleted in this session. Surface
+        // `dispatch_from_shim`) were deleted in Phase 2A finalization. Surface
         // the typed error on the reply oneshot via the direct path's
         // unreachable-arm sketch so the caller gets a defined response.
         Ok(Box::pin(self.dispatch_lifecycle_direct(cmd)).await)
@@ -2544,17 +2548,17 @@ impl Supervisor {
     /// get-or-spawned, both since the storage-foundation reshape) and
     /// delegate to the actor-shape helpers in
     /// [`crate::context::lifecycle_helpers`]. Those helpers spawn the
-    /// per-context actor (`spawn_actor_for_context`) while continuing to
-    /// dual-write the legacy `contexts` `DashMap` during the ADR-049
-    /// Phase 2A transition window. Building deps requires
+    /// per-context actor that OWNS the freshly built `PerContextState`
+    /// and register its handle in the supervisor registry — there is no
+    /// legacy `contexts` `DashMap` write. Building deps requires
     /// `self: &Arc<Self>` so the spawned actor and its handle wrap the
     /// same supervisor instance.
     ///
     /// **Per-context variants** (Join / Leave / Close / Export +
-    /// access-key generate / revoke / restore) still delegate to the
-    /// designated-legacy `&Supervisor`-shape helpers in
-    /// [`crate::context::lifecycle_helpers_legacy`]; they reach this
-    /// method only when no actor is registered for the target context.
+    /// access-key generate / revoke / restore) reach this method only
+    /// when no actor is registered for the target context; their arms
+    /// surface `ContextNotRegistered` on the variant's oneshot, since
+    /// post-Step-B every valid context has a registered actor.
     #[allow(clippy::too_many_lines)] // flat match over every lifecycle variant
     async fn dispatch_lifecycle_direct(self: &Arc<Self>, cmd: LifecycleCommand) -> Outcome<()> {
         // Single source of truth: derive from the associated `Self::
@@ -2590,7 +2594,8 @@ impl Supervisor {
                 // supervisor's provider slots, scoped to the creator's
                 // identity for KeyPackageStore resolution) and delegates
                 // to `lifecycle_helpers::create_context`, which spawns the
-                // per-context actor (and dual-writes the legacy DashMap).
+                // per-context actor that OWNS the fresh state (no legacy
+                // `contexts` DashMap write).
                 let deps = match self.build_actor_deps(&p.creator_did).await {
                     Ok(deps) => deps,
                     Err(e) => {
@@ -3002,7 +3007,7 @@ impl Supervisor {
         Self::dispatch_via_mailbox(&actor, ContextCommand::TtlClose(cmd)).await
     }
 
-    /// Dispatch a [`GovernanceCommand`] through the migration shim
+    /// Dispatch a [`GovernanceCommand`] to its per-context actor's mailbox
     /// (ADR-049 commit 10 / plan row 10).
     ///
     /// Contract (byte-identical to the legacy
@@ -3060,7 +3065,7 @@ impl Supervisor {
         Self::dispatch_via_mailbox(&actor, ContextCommand::Governance(cmd)).await
     }
 
-    /// Dispatch an [`EconomyCommand`] through the migration shim
+    /// Dispatch an [`EconomyCommand`] to its per-context actor's mailbox
     /// (ADR-049 commit 10 / plan row 10).
     ///
     /// Same shape as [`Self::dispatch_governance_command`]. The
@@ -3226,7 +3231,7 @@ impl Supervisor {
         }
     }
 
-    /// Dispatch a [`TrustRecoveryCommand`] through the migration shim
+    /// Dispatch a [`TrustRecoveryCommand`] to its per-context actor's mailbox
     /// (ADR-049 commit 10 / plan row 10).
     ///
     /// Same shape as [`Self::dispatch_governance_command`]. Covers the
@@ -3246,10 +3251,12 @@ impl Supervisor {
         // Phase 2A.1 of ADR-049 — trust_recovery is the first migrated
         // helper domain. Route per-context variants to the per-context
         // actor mailbox when one is registered; otherwise fall through
-        // to `dispatch_trust_recovery_direct` which delegates to the
-        // designated-legacy lock-shaped helpers. The cross-context
+        // to `dispatch_trust_recovery_direct`, whose per-context arms
+        // surface `ContextNotRegistered` (post-Step-B every valid
+        // context has a registered actor). The cross-context
         // `RecoveryNotifyContact` variant has no `context_id` to look
-        // up — it always flows through the direct fan-out path.
+        // up — it always flows through the direct fan-out path
+        // (`recovery_notify_contact`).
         //
         // `Box::pin` — `CreateGovernanceCheckpoint`'s payload carries
         // multiple 32-byte hashes + a variable-length Ed25519 signature
@@ -3750,16 +3757,15 @@ impl Supervisor {
     /// through `SupervisorHandle`; see plan §"ActorDeps and
     /// SupervisorHandle".
     ///
-    /// `dead_code` allow: the first production call site is commit 7's
-    /// query-path migration, which routes FFI-bridge lookups through
-    /// `Supervisor::lookup(ctx).send(QueriesCommand::...)`.
+    /// Every per-context dispatch method routes through this accessor
+    /// (`self.lookup(ctx).send(...)`), as do the per-actor sweep entry
+    /// points in `governance_helpers` / `lifecycle_helpers`.
     ///
     /// Visibility widened to `pub(in crate::context)` at Phase 2A
     /// finalization (sweep helper relocation) so the sweep entry
     /// points in `governance_helpers` / `lifecycle_helpers` can route
     /// per-actor sweep commands through the mailbox.
     #[must_use]
-    #[allow(dead_code)]
     pub(in crate::context) fn lookup(&self, ctx_id: &str) -> Option<ContextActorHandle> {
         self.actors.get(ctx_id).map(|r| r.value().clone())
     }
@@ -3774,9 +3780,9 @@ impl Supervisor {
     /// this once per sweep and dispatch one command per `context_id`.
     ///
     /// Added at Phase 2A finalization (sweep helper relocation) so the
-    /// sweep entry points have a way to enumerate the actor registry
-    /// without reaching for the legacy `contexts` DashMap (which is
-    /// scheduled for deletion in a subsequent session).
+    /// sweep entry points enumerate the actor registry directly. The
+    /// actor registry is the only context map — there is no legacy
+    /// `contexts` DashMap.
     #[must_use]
     pub(in crate::context) fn actor_ids(&self) -> Vec<String> {
         self.actors.iter().map(|e| e.key().clone()).collect()
@@ -3791,14 +3797,15 @@ impl Supervisor {
     /// `create_context` / `restore_context` time. Code outside
     /// `crate::context::` has no way to spawn an actor.
     ///
-    /// Commit 6 delivers the mailbox wiring; the actor's `run()` body
-    /// uses the stubbed dispatch in
-    /// [`crate::context::actor::ContextActor`]. Commit 7 onward
-    /// replaces the stubs with real handlers.
+    /// This is the no-state SKELETON spawn path: it constructs the actor
+    /// via [`ContextActor::new_skeleton`], whose `run()` loop drains the
+    /// mailbox and ACKs every command through `skeleton_dispatch`
+    /// (`NotImplemented`). The real per-domain handlers run on the
+    /// state-owning actor spawned via [`Self::spawn_actor_with_state`].
     ///
-    /// `dead_code` allow: the first production call site is commit 9's
-    /// lifecycle handler (create_context spawns an actor). Until then
-    /// only the unit tests here exercise the method.
+    /// `dead_code` allow: production bootstrap uses
+    /// [`Self::spawn_actor_with_state`], so this skeleton spawn is
+    /// exercised only by the unit tests in this module.
     #[allow(dead_code)]
     pub(in crate::context) async fn spawn_actor(
         &self,
@@ -3857,23 +3864,22 @@ impl Supervisor {
     /// # Visibility
     ///
     /// `pub(in crate::context)` — the only production caller is the
-    /// lifecycle handler's create / restore / import path (landing
-    /// in commit 12b.2b). External callers (FFI bridges,
-    /// downstream crates) reach the actor through
+    /// lifecycle handler's create / restore / import path. External
+    /// callers (FFI bridges, downstream crates) reach the actor through
     /// [`Self::dispatch_command`] or the
     /// [`crate::context::supervisor::handle::SupervisorHandle`] /
     /// [`crate::context::actor::deps::ActorDeps::supervisor`]
     /// capabilities — never directly.
     ///
-    /// # Scope — infrastructure only
+    /// # Dispatch
     ///
-    /// Commit 12b.2a wires the signature and registry insertion.
-    /// The spawned actor's `run()` loop currently delegates every
-    /// command variant to the skeleton dispatch (same fallback as
-    /// [`ContextActor::new_skeleton`]) — migrating real handler
-    /// bodies onto `&mut self.state` + `&self.deps` is 12b.2b's
-    /// atomic transition across all nine handler submodules.
-    ///
+    /// The spawned actor OWNS its `PerContextState` + `ActorDeps`, so its
+    /// `run()` loop dispatches every command variant to the real
+    /// per-domain handlers via
+    /// [`ContextActor::dispatch_state`](crate::context::actor::ContextActor)
+    /// (`&mut self.state` + `&self.deps`) — not the skeleton dispatch
+    /// path, which is reserved for the no-state
+    /// [`ContextActor::new_skeleton`] actors.
     ///
     /// # Errors
     ///
@@ -4693,8 +4699,10 @@ impl Supervisor {
         self.crash_windows.remove(context_id);
     }
 
-    /// Dispatch a [`StandingCommand`] through the migration shim
-    /// (ADR-049 commit 11 / plan row 11).
+    /// Dispatch a [`StandingCommand`] — mailbox-first for variants that
+    /// map to an existing per-context actor, otherwise the supervisor-
+    /// scoped `dispatch_standing_direct` path (ADR-049 commit 11 / plan
+    /// row 11).
     ///
     /// Same shape as [`Self::dispatch_governance_command`]. Covers the
     /// contact-graph (standing context) paths from spec §5.12.4.
@@ -4822,7 +4830,7 @@ impl Supervisor {
         }
     }
 
-    /// Dispatch a [`ToolsCommand`] through the migration shim
+    /// Dispatch a [`ToolsCommand`] to its per-context actor's mailbox
     /// (ADR-049 commit 11 / plan row 11).
     ///
     /// Covers the hard-rate-limit consume / refund helpers that FFI
@@ -11818,9 +11826,11 @@ mod tests {
         let s = test_supervisor();
         let _handle = s.spawn_actor("ctx-42".to_owned(), None).await;
         assert!(s.lookup("ctx-42").is_some());
-        // Second spawn with the same ID overwrites: duplicate-spawn
-        // overwrite is intentional, and duplicate-spawn detection is a
-        // watchdog responsibility (ADR-049 §10).
+        // Second spawn with the same ID overwrites: the skeleton
+        // `spawn_actor` overwrites by design. Duplicate-spawn rejection
+        // is enforced in the owned-state `spawn_actor_with_state` path
+        // (first-writer-wins `CreationFailed`), covered by
+        // `spawn_actor_with_state_rejects_duplicate_context_id`.
         let _handle2 = s.spawn_actor("ctx-42".to_owned(), None).await;
         assert!(s.lookup("ctx-42").is_some());
     }

--- a/crates/scp-runtime/src/context/supervisor/supervisor.rs
+++ b/crates/scp-runtime/src/context/supervisor/supervisor.rs
@@ -2410,8 +2410,8 @@ impl Supervisor {
         Ok(self.dispatch_queries_direct(cmd))
     }
 
-    /// Dispatch a mutating [`MessagingCommand`] through the migration
-    /// shim (ADR-049 commit 8 / plan row 8).
+    /// Dispatch a mutating [`MessagingCommand`] to its per-context
+    /// actor's mailbox (ADR-049 commit 8 / plan row 8).
     ///
     /// Routes the command through the per-context actor's mailbox via
     /// [`Self::dispatch_via_mailbox`]. The actor's `run()` loop pulls
@@ -2958,23 +2958,23 @@ impl Supervisor {
         }
     }
 
-    /// Dispatch a mutating [`TtlCloseCommand`] through the migration
-    /// shim (ADR-049 commit 9 / plan row 9).
+    /// Dispatch a mutating [`TtlCloseCommand`] to its per-context
+    /// actor's mailbox (ADR-049 commit 9 / plan row 9).
     ///
-    /// Same shape as [`Self::dispatch_lifecycle_command`] — handlers
-    /// take the attached manager directly, wrap delegated
-    /// [`Supervisor`](crate::context::supervisor::Supervisor) calls
-    /// in [`tokio::time::timeout`] with a 30s budget, and relay the
-    /// typed result through the variant's oneshot.
+    /// Routes the command through the per-context actor's mailbox via
+    /// [`Self::dispatch_via_mailbox`]. The actor's `run()` loop pulls the
+    /// command and dispatches it via the actor-shape `dispatch(state,
+    /// deps, cmd)` entry point. The handler wraps delegated
+    /// [`Supervisor`](crate::context::supervisor::Supervisor) calls in
+    /// [`tokio::time::timeout`] with a 30s budget, and relays the typed
+    /// result through the variant's oneshot.
     ///
     /// # TTL-timer ownership
     ///
-    /// The post-refactor architecture turns the TTL timer into a
-    /// `select!` arm in the actor's `run()` loop. Commit 9 keeps the
-    /// timer spawned inside the legacy `ContextManager`; this dispatch
-    /// method routes caller-initiated extend/reset/finalize/explicit-
-    /// expiry commands synchronously. Full timer-owning actor logic
-    /// arrives with plan row 11.
+    /// The TTL timer is a `select!` arm in the actor's `run()` loop.
+    /// This dispatch method routes caller-initiated
+    /// extend/reset/finalize/explicit-expiry commands through that
+    /// actor's mailbox.
     ///
     /// # Errors
     ///
@@ -4842,7 +4842,7 @@ impl Supervisor {
     /// are borrowed (non-`'static`) `&ed25519_dalek::SigningKey`
     /// references that cannot move into a `'static` mailbox message,
     /// even though its executor is itself `Send + 'static`. Note that
-    /// [`ContextManager::invoke_tool_with_economy`](crate::context::supervisor::Supervisor::invoke_tool_with_economy)
+    /// [`Supervisor::invoke_tool_with_economy`](crate::context::supervisor::Supervisor::invoke_tool_with_economy)
     /// is not migrated here for a distinct reason: its generic executor
     /// closure carries no `Send` bound, so it cannot cross the actor
     /// mailbox at all.
@@ -8505,9 +8505,9 @@ impl Supervisor {
     // every context (`flush_all_*`, `restore_all_contexts`,
     // `shutdown_all_contexts`).
     //
-    // Each method is a thin shim — it resolves the attached manager
-    // and forwards. Deleted in commit 12 alongside the rest of the
-    // shim when the supervisor owns these surfaces directly.
+    // Each method forwards to its `*_helpers` free function
+    // (`queries_helpers` / `lifecycle_helpers`), which holds the
+    // supervisor-wide implementation. There is no manager indirection.
     // ---------------------------------------------------------------
 
     /// Register a DID as locally controlled by this node / SDK.
@@ -8862,21 +8862,17 @@ impl Supervisor {
     // -------------------------------------------------------------------
     // ADR-049 commit 12c.9g.3 — FFI passthrough surface.
     //
-    // The 4 FFI bridges (PyO3, NAPI, UniFFI, common) used to dereference
-    // an `Arc<ContextManager>` and invoke methods directly. After commit
-    // 12c.9g.3 they hold an `Arc<Supervisor>` only. The methods below
-    // mirror the small subset of `ContextManager` methods that the
-    // bridge functions actually call (membership queries, event-log
-    // probes, hard-rate-limit consumption, broadcast key resolution,
-    // tool invocation, lifecycle creation in tests).
+    // The 4 FFI bridges (PyO3, NAPI, UniFFI, common) hold an
+    // `Arc<Supervisor>` and invoke the methods below directly. They cover
+    // the small subset of supervisor operations the bridge functions
+    // actually call (membership queries, event-log probes, hard-rate-
+    // limit consumption, broadcast key resolution, tool invocation,
+    // lifecycle creation in tests).
     //
     // Each method is intentionally a thin one-liner over the equivalent
-    // `*_helpers::X(&self, ...)` free function or the legacy
-    // `ContextManager::X` method (resolved via
-    // `with_providers()`). The thin layer keeps the FFI rewire
-    // mechanical: bridge call sites change exactly one identifier
-    // (`mgr.X` → `supervisor.X`). When `manager/` is deleted in commit
-    // 12c.9g.4, the manager-fallback methods below become direct helper
+    // `*_helpers::X(&self, ...)` free function (or, where the op has a
+    // per-context actor, the mailbox-routed dispatch). There is no
+    // `ContextManager` indirection — these are direct helper / mailbox
     // calls.
     // -------------------------------------------------------------------
 
@@ -11337,14 +11333,13 @@ impl SagaJournal for NoopSagaJournal {
 }
 
 // ---------------------------------------------------------------------------
-// Shim helpers — synthesise the "context unknown" fallback reply for each
-// query variant. Matches the legacy `ContextManager::foo()` defaults
-// byte-for-byte. Deleted in commit 12 with the shim itself.
+// Soft-default helpers — synthesise the "context unknown" reply for each
+// query variant when no per-context actor is registered.
 // ---------------------------------------------------------------------------
 
-/// Send the legacy soft-default reply on a query variant's oneshot when
-/// the context isn't registered. Mirrors each legacy method's
-/// unknown-context return value exactly.
+/// Send the "context unknown" soft-default reply on a query variant's
+/// oneshot when the context isn't registered. Synthesises the documented
+/// unknown-context return value for each query variant.
 #[allow(clippy::cognitive_complexity)] // flat variant dispatch
 fn reply_with_soft_default(cmd: QueriesCommand) {
     match cmd {

--- a/crates/scp-runtime/src/context/supervisor/supervisor.rs
+++ b/crates/scp-runtime/src/context/supervisor/supervisor.rs
@@ -22,14 +22,13 @@
 //!   the above. Reads are lock-free; the mutex prevents lost writes
 //!   when two callers race a `store` on the same `ArcSwap`.
 //!
-//! # Commit 6 scope
+//! # Scope
 //!
-//! The struct lands with `new`, `lookup`, `spawn_actor`, and the saga
-//! `start_saga` entry point. Every method that migrates the real
-//! semantics lives behind a
-//! [`ContextError::NotImplemented`](scp_protocol::context::ContextError::NotImplemented)
-//! stub — saga orchestration migrates with `handlers/standing.rs` and
-//! the related cross-context paths in commit 11.
+//! The supervisor implements the actor registry (`new`, `lookup`,
+//! `spawn_actor`) and the saga coordinator (`start_saga` → `run_saga` →
+//! `run_saga_fsm`) per ADR-049. Per-context operations dispatch through
+//! the per-context actor mailbox; cross-context tool invocation runs as a
+//! durable-journalled saga FSM. No migration stubs remain.
 
 use std::collections::{HashMap, HashSet, VecDeque};
 use std::sync::{Arc, OnceLock};
@@ -729,9 +728,10 @@ fn decode_repair_records_evidence(bytes: &[u8]) -> Result<Vec<SagaDivergenceRepa
 // Supervisor configuration + crash tracking
 // ---------------------------------------------------------------------------
 
-/// Supervisor configuration. Cheap defaults for commit 6; real fields
-/// (saga phase timeouts, respawn budget windows) materialize alongside
-/// the saga migration in commit 11.
+/// Supervisor configuration. Currently a reserved placeholder with no
+/// tunables wired; saga phase timeouts and respawn-budget windows are
+/// derived from associated constants on [`Supervisor`] rather than this
+/// struct.
 #[derive(Clone, Debug, Default)]
 pub struct SupervisorConfig {
     /// Reserved for future configuration; placeholder field so the
@@ -969,17 +969,6 @@ fn spawn_kp_actor_watchdog_task(
     });
 }
 
-/// Placeholder saga state stored in `pending_sagas` between Prepare and
-/// Commit/Abort. Commit 6 keeps this opaque; the real state shape lives
-/// in the per-saga-type `SagaPreparedState` variants.
-#[derive(Debug)]
-pub struct PendingSagaProjection {
-    /// Reserved; the real in-memory projection of the saga FSM lands
-    /// alongside the handler migrations in commit 11.
-    #[allow(dead_code)]
-    reserved: (),
-}
-
 /// Flat, named-field request for
 /// [`Supervisor::start_cross_context_tool_invocation_saga`] (spec §6.2.4).
 ///
@@ -1152,12 +1141,6 @@ pub struct Supervisor {
     /// Lock order is always `bootstrap_spawn_lock` → `write_lock`, never the
     /// reverse.
     pub(crate) bootstrap_spawn_lock: tokio::sync::Mutex<()>,
-    /// Pending sagas keyed by saga ID; projection of the durable
-    /// journal for fast lookup.
-    // Operational in Phase 2 of post-review-round-1 plan (saga FSM real
-    // Prepare/Commit dispatch + watchdog).
-    #[allow(dead_code)]
-    pub(in crate::context::supervisor) pending_sagas: DashMap<SagaId, PendingSagaProjection>,
     /// Durable saga journal (plan §"Cross-context saga protocol").
     pub(in crate::context::supervisor) saga_journal: Arc<dyn SagaJournal>,
     /// Per-identity `KeyPackageStoreActor` handles.
@@ -1515,7 +1498,6 @@ impl Supervisor {
             persistence,
             write_lock: tokio::sync::Mutex::new(()),
             bootstrap_spawn_lock: tokio::sync::Mutex::new(()),
-            pending_sagas: DashMap::new(),
             saga_journal,
             key_package_stores: DashMap::new(),
             health_config,
@@ -8869,21 +8851,6 @@ impl Supervisor {
         Ok(())
     }
 
-    /// Persist supervisor-level state (standing_contexts, local_dids,
-    /// wrapping_keys) ahead of a shutdown or resume. Commit 6 stubs;
-    /// full path lands with the `BridgeInstance` integration in commit
-    /// 11.
-    ///
-    /// # Errors
-    ///
-    /// Commit 6: always `ContextError::NotImplemented`.
-    #[allow(clippy::unused_async)] // signature matches the real commit-11 handler's shape
-    pub async fn persist_state(&self) -> Result<(), ContextError> {
-        Err(ContextError::NotImplemented(
-            "Supervisor::persist_state — migrates in commit 11 of ADR-049".to_owned(),
-        ))
-    }
-
     // -------------------------------------------------------------------
     // ADR-049 commit 12c.9g.3 — FFI passthrough surface.
     //
@@ -10388,15 +10355,14 @@ impl Supervisor {
     /// stamp can never disagree with the key that signed. Every send path
     /// requires a key, so the signer is non-optional.
     ///
-    /// Phase 2A finalization — every per-context method on `Supervisor`
-    /// builds a typed `ContextCommand` carrying an embedded reply
-    /// oneshot, enqueues it via [`Self::dispatch_command`], and awaits
-    /// the actor's typed reply. The dispatch helper routes through the
-    /// per-context actor mailbox when one is registered, falling back
-    /// to the legacy lock-and-call shim during the migration window
-    /// when no actor has been spawned yet (a state that disappears once
-    /// the legacy `*_helpers_legacy::*_legacy` bodies are deleted in
-    /// the next session).
+    /// Every per-context method on `Supervisor` builds a typed
+    /// `ContextCommand` carrying an embedded reply oneshot, enqueues it
+    /// via [`Self::dispatch_command`], and awaits the actor's typed
+    /// reply. Dispatch is mailbox-only: the command routes through the
+    /// per-context actor mailbox, and when no actor is registered for the
+    /// target context the call returns a lookup-miss
+    /// [`ContextError`](scp_protocol::context::ContextError) on the reply
+    /// oneshot rather than mutating supervisor state directly.
     ///
     /// # Errors
     ///
@@ -11848,20 +11814,13 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn persist_state_returns_not_implemented() {
-        let s = test_supervisor();
-        let err = s.persist_state().await.unwrap_err();
-        assert!(matches!(err, ContextError::NotImplemented(_)));
-    }
-
-    #[tokio::test]
     async fn spawn_actor_registers_handle_under_write_lock() {
         let s = test_supervisor();
         let _handle = s.spawn_actor("ctx-42".to_owned(), None).await;
         assert!(s.lookup("ctx-42").is_some());
-        // Second spawn with the same ID overwrites (commit 6 semantics —
-        // duplicate-spawn detection is a watchdog responsibility and
-        // lands with the panic-recovery path in commit 11).
+        // Second spawn with the same ID overwrites: duplicate-spawn
+        // overwrite is intentional, and duplicate-spawn detection is a
+        // watchdog responsibility (ADR-049 §10).
         let _handle2 = s.spawn_actor("ctx-42".to_owned(), None).await;
         assert!(s.lookup("ctx-42").is_some());
     }

--- a/crates/scp-runtime/src/context/supervisor/supervisor.rs
+++ b/crates/scp-runtime/src/context/supervisor/supervisor.rs
@@ -3843,17 +3843,11 @@ impl Supervisor {
     /// [`ActorDeps`](crate::context::actor::ActorDeps) directly
     /// (ADR-049 commit 12).
     ///
-    /// This is the post-refactor spawn path: the supervisor's caller
-    /// drains state from the legacy `ContextManager` and
-    /// `MlsCryptoProvider` via
-    /// [`crate::context::supervisor::Supervisor::take_context_state`]
-    /// +
-    /// [`crate::crypto::mls::provider::MlsCryptoProvider::take_crypto_state`],
-    /// assembles the actor-side `PerContextState` using the drained
-    /// fields, and hands the state + deps bundle into this method.
-    /// The spawned actor becomes the sole owner; subsequent
-    /// manager/provider calls for the same context return the typed
-    /// "taken by actor" errors.
+    /// This is the owned-state spawn path. The lifecycle bootstrap caller
+    /// (create / restore / import in
+    /// [`crate::context::lifecycle_helpers`]) builds a fresh actor-shape
+    /// `PerContextState` and hands the state + deps bundle into this
+    /// method. The spawned actor becomes the sole owner of that state.
     ///
     /// The returned [`ContextActorHandle`] is registered in the
     /// supervisor's `actors` map under the same `write_lock` that


### PR DESCRIPTION
## Summary

Two things, both confined to the supervisor and its doc-comments (no behavior change):

### 1. Delete dead commit-6-era scaffolding (No-stubs tenet)
- `Supervisor::persist_state()` — a live `NotImplemented` stub ("migrates in commit 11") with **zero production callers**; its only caller was its own assertion test. Durability is already fully covered by per-context incremental persist (`persist_state_fail_closed`/`_best_effort` + `restore_all_contexts`), the durable `SagaJournal`, and `mls_storage` — a supervisor-level batch persist is obsolete (verified: no ADR-049 commitment to it).
- `pending_sagas: DashMap<SagaId, PendingSagaProjection>` + the `PendingSagaProjection` struct + its `mod.rs` re-export — declared and initialized but **never read or written**; in-flight saga state lives in the `SagaJournal` + typed `SagaPreparedState`.

### 2. Corpus-wide actor-migration doc-scrub
The Phase-2A actor migration + the ContextManager→Supervisor migration left stale doc-comments throughout `supervisor.rs`/`handle.rs`/sibling lifecycle files describing **deleted machinery as live** or **delivered work as pending**. All reconciled to current reality (each reword verified against the function body):
- Saga FSM is active (`start_saga → run_saga → run_saga_fsm`); dropped "not yet active / lands with Phase 2" and "Commit 6: always NotImplemented".
- `ContextManager` type + `manager/` dir are **deleted** — dropped all "resolves the attached manager", "legacy ContextManager::X", "When manager/ is deleted in commit 12", and "Deleted in commit 12" prose over what is now live present-tense helper code.
- Legacy `contexts` DashMap is gone — dropped "dual-write the legacy contexts DashMap".
- Removed broken intra-doc links to the deleted `lifecycle_helpers_legacy` module and the deleted `take_context_state` (latent rustdoc-CI breaks; net −3 broken links).
- Corrected a false citation: duplicate-spawn rejection is first-writer-wins `CreationFailed` in `spawn_actor_with_state`, **not** a watchdog/ADR-049-§10 responsibility.
- handle.rs: the capability-reduction contract is maintained by the documented rule + review — there is **no** "commit 12 CI grep-ban" (the claim was false). Adding that mechanical gate is tracked in **#1978**.

## Verification
- `cargo fmt --all --check`, full-feature workspace clippy (`-D warnings`) — clean
- `cargo nextest run -p scp-runtime --features testing` — **2158/2158 pass**
- `cargo doc` — net −3 broken intra-doc links, zero new

## Review
Reviewed to double-zero across deletion-soundness (bug-catcher / inquisitor / alignment / completionist — all SOUND/SAFE) and doc-accuracy + corpus-completeness (alignment ALIGNED: every reworded claim verified; completionist: all residual stale sites enumerated and fixed). Follow-up #1978 tracks the SupervisorHandle capability-reduction grep-ban.

🤖 Generated with [Claude Code](https://claude.com/claude-code)