### PR TITLE
refactor(test): consolidate 3 counting PaymentAdapter test doubles into shared CountingPaymentAdapter

### DIFF
--- a/crates/scp-runtime/src/context/actor/handlers/saga.rs
+++ b/crates/scp-runtime/src/context/actor/handlers/saga.rs
@@ -5279,125 +5279,6 @@ mod tests {
     // every terminal path") — the PreparingB-crash over-charge / escrow-leak fix.
     // -----------------------------------------------------------------------
 
-    /// A [`PaymentAdapter`](crate::economy::adapter::PaymentAdapter) that counts
-    /// `void` calls so cross-context-saga reversal / `NeedsRepair` tests can assert
-    /// whether an external escrow hold was voided
-    /// ([`void_external_and_consume`](crate::context::tools_helpers::ToolEconomyTicket::void_external_and_consume))
-    /// or held for operator repair
-    /// ([`hold_external_for_repair`](crate::context::tools_helpers::ToolEconomyTicket::hold_external_for_repair)).
-    struct VoidCountingPaymentAdapter {
-        voided: Arc<std::sync::atomic::AtomicUsize>,
-    }
-
-    impl crate::economy::adapter::PaymentAdapter for VoidCountingPaymentAdapter {
-        fn adapter_id(&self) -> &'static str {
-            "void-counting"
-        }
-        fn capabilities(&self) -> crate::economy::adapter::AdapterCapabilities {
-            crate::economy::adapter::AdapterCapabilities {
-                supported_currencies: vec![scp_protocol::economy::types::CurrencyCode::from("USD")],
-                supports_streaming: false,
-                supports_batch_auth: false,
-                supports_single_step: false,
-                min_amount: None,
-                max_amount: None,
-                typical_settlement_ms: 0,
-                requires_facilitator: false,
-            }
-        }
-        async fn authorize(
-            &self,
-            from_did: &DID,
-            to_did: &DID,
-            amount: scp_protocol::economy::types::Amount,
-            currency: scp_protocol::economy::types::CurrencyCode,
-            _metadata: crate::economy::adapter::PaymentMetadata,
-        ) -> Result<
-            crate::economy::adapter::PaymentAuthorization,
-            crate::economy::adapter::PaymentError,
-        > {
-            Ok(crate::economy::adapter::PaymentAuthorization {
-                auth_id: [7u8; 32],
-                payer: from_did.clone(),
-                payee: to_did.clone(),
-                amount,
-                currency,
-                adapter_id: "void-counting".to_owned(),
-                created_at: 1_000_000,
-                expires_at: 2_000_000,
-                adapter_state: vec![],
-            })
-        }
-        async fn capture(
-            &self,
-            auth: &crate::economy::adapter::PaymentAuthorization,
-        ) -> Result<crate::economy::adapter::PaymentReceipt, crate::economy::adapter::PaymentError>
-        {
-            Ok(crate::economy::adapter::PaymentReceipt {
-                receipt_id: [9u8; 32],
-                payer: auth.payer.clone(),
-                payee: auth.payee.clone(),
-                amount: auth.amount,
-                currency: auth.currency,
-                action_type: scp_protocol::economy::types::PaidActionType::ToolInvoke,
-                context_id: None,
-                adapter_id: "void-counting".to_owned(),
-                adapter_proof: vec![],
-                timestamp: 1_000_001,
-                signature: vec![],
-                // Synthetic test receipt: never appended to the canonical Merkle
-                // log, so it is not anchored (matches `PaymentReceipt`'s unanchored
-                // default; the field lies outside the signed payload).
-                anchored: false,
-            })
-        }
-        async fn void(
-            &self,
-            _auth: &crate::economy::adapter::PaymentAuthorization,
-        ) -> Result<(), crate::economy::adapter::PaymentError> {
-            self.voided
-                .fetch_add(1, std::sync::atomic::Ordering::SeqCst);
-            Ok(())
-        }
-        async fn verify_authorization(
-            &self,
-            _auth: &crate::economy::adapter::PaymentAuthorization,
-        ) -> Result<(), crate::economy::adapter::PaymentError> {
-            Ok(())
-        }
-        async fn verify(
-            &self,
-            _receipt: &crate::economy::adapter::PaymentReceipt,
-        ) -> Result<
-            crate::economy::adapter::VerificationResult,
-            crate::economy::adapter::PaymentError,
-        > {
-            Ok(crate::economy::adapter::VerificationResult {
-                valid: true,
-                adapter_id: "void-counting".to_owned(),
-                verified_amount: scp_protocol::economy::types::Amount(0),
-                verified_currency: scp_protocol::economy::types::CurrencyCode::from("USD"),
-                verification_timestamp: 1_000_002,
-            })
-        }
-        async fn refund(
-            &self,
-            _receipt: &crate::economy::adapter::PaymentReceipt,
-            _amount: Option<scp_protocol::economy::types::Amount>,
-        ) -> Result<
-            crate::economy::adapter::RefundConfirmation,
-            crate::economy::adapter::PaymentError,
-        > {
-            Ok(crate::economy::adapter::RefundConfirmation {
-                refund_id: [0u8; 32],
-                original_receipt_id: [9u8; 32],
-                refunded_amount: scp_protocol::economy::types::Amount(0),
-                currency: scp_protocol::economy::types::CurrencyCode::from("USD"),
-                adapter_proof: vec![],
-            })
-        }
-    }
-
     /// Build deps carrying a payment adapter (the default `build_deps` passes
     /// `None`), so a reversal that voids the external escrow can be observed.
     async fn build_deps_with_payment(
@@ -5608,8 +5489,9 @@ mod tests {
         let caller = DID(CALLER.to_owned());
         let voided = Arc::new(std::sync::atomic::AtomicUsize::new(0));
         let adapter: Arc<dyn crate::economy::adapter::PaymentAdapterDyn> =
-            Arc::new(VoidCountingPaymentAdapter {
+            Arc::new(crate::economy::adapter::CountingPaymentAdapter {
                 voided: Arc::clone(&voided),
+                ..Default::default()
             });
         let deps =
             build_deps_with_payment(CALLER.to_owned(), issuer.verifying_key(), adapter).await;

--- a/crates/scp-runtime/src/context/lifecycle_helpers.rs
+++ b/crates/scp-runtime/src/context/lifecycle_helpers.rs
@@ -3516,124 +3516,6 @@ mod restore_reconcile_tests {
         }
     }
 
-    /// A `PaymentAdapter` that records whether `capture` or `void` was invoked,
-    /// so the money-ordering test can assert the escrow was VOIDED (not
-    /// captured) when the fail-closed persist fails. (Implementing the
-    /// non-dyn `PaymentAdapter` trait yields `PaymentAdapterDyn` via the
-    /// blanket impl.)
-    struct RecordingPaymentAdapter {
-        captured: Arc<std::sync::atomic::AtomicUsize>,
-        voided: Arc<std::sync::atomic::AtomicUsize>,
-    }
-
-    impl crate::economy::adapter::PaymentAdapter for RecordingPaymentAdapter {
-        fn adapter_id(&self) -> &str {
-            "recording"
-        }
-        fn capabilities(&self) -> crate::economy::adapter::AdapterCapabilities {
-            crate::economy::adapter::AdapterCapabilities {
-                supported_currencies: vec![scp_protocol::economy::types::CurrencyCode::from("USD")],
-                supports_streaming: false,
-                supports_batch_auth: false,
-                supports_single_step: false,
-                min_amount: None,
-                max_amount: None,
-                typical_settlement_ms: 0,
-                requires_facilitator: false,
-            }
-        }
-        async fn authorize(
-            &self,
-            payer: &DID,
-            payee: &DID,
-            amount: scp_protocol::economy::types::Amount,
-            currency: scp_protocol::economy::types::CurrencyCode,
-            _metadata: crate::economy::adapter::PaymentMetadata,
-        ) -> Result<
-            crate::economy::adapter::PaymentAuthorization,
-            crate::economy::adapter::PaymentError,
-        > {
-            Ok(crate::economy::adapter::PaymentAuthorization {
-                auth_id: [7u8; 32],
-                payer: payer.clone(),
-                payee: payee.clone(),
-                amount,
-                currency,
-                adapter_id: "recording".to_owned(),
-                created_at: 1_000_000,
-                expires_at: 2_000_000,
-                adapter_state: vec![],
-            })
-        }
-        async fn capture(
-            &self,
-            auth: &crate::economy::adapter::PaymentAuthorization,
-        ) -> Result<crate::economy::adapter::PaymentReceipt, crate::economy::adapter::PaymentError>
-        {
-            self.captured
-                .fetch_add(1, std::sync::atomic::Ordering::SeqCst);
-            Ok(crate::economy::adapter::PaymentReceipt {
-                receipt_id: [9u8; 32],
-                payer: auth.payer.clone(),
-                payee: auth.payee.clone(),
-                amount: auth.amount,
-                currency: auth.currency,
-                action_type: scp_protocol::economy::types::PaidActionType::ContextJoin,
-                context_id: None,
-                adapter_id: "recording".to_owned(),
-                adapter_proof: vec![],
-                timestamp: 1_000_001,
-                anchored: false,
-                signature: vec![],
-            })
-        }
-        async fn void(
-            &self,
-            _auth: &crate::economy::adapter::PaymentAuthorization,
-        ) -> Result<(), crate::economy::adapter::PaymentError> {
-            self.voided
-                .fetch_add(1, std::sync::atomic::Ordering::SeqCst);
-            Ok(())
-        }
-        async fn verify_authorization(
-            &self,
-            _auth: &crate::economy::adapter::PaymentAuthorization,
-        ) -> Result<(), crate::economy::adapter::PaymentError> {
-            Ok(())
-        }
-        async fn verify(
-            &self,
-            _receipt: &crate::economy::adapter::PaymentReceipt,
-        ) -> Result<
-            crate::economy::adapter::VerificationResult,
-            crate::economy::adapter::PaymentError,
-        > {
-            Ok(crate::economy::adapter::VerificationResult {
-                valid: true,
-                adapter_id: "recording".to_owned(),
-                verified_amount: scp_protocol::economy::types::Amount(0),
-                verified_currency: scp_protocol::economy::types::CurrencyCode::from("USD"),
-                verification_timestamp: 1_000_002,
-            })
-        }
-        async fn refund(
-            &self,
-            _receipt: &crate::economy::adapter::PaymentReceipt,
-            _amount: Option<scp_protocol::economy::types::Amount>,
-        ) -> Result<
-            crate::economy::adapter::RefundConfirmation,
-            crate::economy::adapter::PaymentError,
-        > {
-            Ok(crate::economy::adapter::RefundConfirmation {
-                refund_id: [0u8; 32],
-                original_receipt_id: [9u8; 32],
-                refunded_amount: scp_protocol::economy::types::Amount(0),
-                currency: scp_protocol::economy::types::CurrencyCode::from("USD"),
-                adapter_proof: vec![],
-            })
-        }
-    }
-
     /// Derive a `did:key` DID + matching signing key (the same convention the
     /// FFI tool-economy harness uses), so a `key_resolver` can resolve the
     /// issuer's verifying key for spending-UCAN signature verification.
@@ -3754,7 +3636,7 @@ mod restore_reconcile_tests {
         let captured = Arc::new(std::sync::atomic::AtomicUsize::new(0));
         let voided = Arc::new(std::sync::atomic::AtomicUsize::new(0));
         let payment_adapter: Arc<dyn crate::economy::adapter::PaymentAdapterDyn> =
-            Arc::new(RecordingPaymentAdapter {
+            Arc::new(crate::economy::adapter::CountingPaymentAdapter {
                 captured: Arc::clone(&captured),
                 voided: Arc::clone(&voided),
             });
@@ -4126,7 +4008,7 @@ mod restore_reconcile_tests {
         let captured = Arc::new(std::sync::atomic::AtomicUsize::new(0));
         let voided = Arc::new(std::sync::atomic::AtomicUsize::new(0));
         let payment_adapter: Arc<dyn crate::economy::adapter::PaymentAdapterDyn> =
-            Arc::new(RecordingPaymentAdapter {
+            Arc::new(crate::economy::adapter::CountingPaymentAdapter {
                 captured: Arc::clone(&captured),
                 voided: Arc::clone(&voided),
             });

--- a/crates/scp-runtime/src/context/supervisor/supervisor.rs
+++ b/crates/scp-runtime/src/context/supervisor/supervisor.rs
@@ -21291,99 +21291,6 @@ mod tests {
         // consumed (held for repair), not leaked.
     }
 
-    /// A payment adapter that counts `void` calls via a shared
-    /// [`AtomicUsize`](std::sync::atomic::AtomicUsize). The escrow-drain path's
-    /// only externally-observable difference between HOLD and VOID is whether it
-    /// reaches `void_dyn` → [`PaymentAdapter::void`]; this adapter records that
-    /// so the two branches are distinguishable with a NON-EMPTY escrow. Every
-    /// other method is an inert success.
-    struct EscrowVoidCountingAdapter {
-        voids: Arc<std::sync::atomic::AtomicUsize>,
-    }
-    impl crate::economy::adapter::PaymentAdapter for EscrowVoidCountingAdapter {
-        fn adapter_id(&self) -> &'static str {
-            "void-counting"
-        }
-        fn capabilities(&self) -> crate::economy::adapter::AdapterCapabilities {
-            crate::economy::adapter::AdapterCapabilities {
-                supported_currencies: vec![scp_protocol::economy::types::CurrencyCode::from("USD")],
-                supports_streaming: false,
-                supports_batch_auth: false,
-                supports_single_step: false,
-                min_amount: None,
-                max_amount: None,
-                typical_settlement_ms: 0,
-                requires_facilitator: false,
-            }
-        }
-        async fn authorize(
-            &self,
-            payer: &DID,
-            payee: &DID,
-            amount: scp_protocol::economy::types::Amount,
-            currency: scp_protocol::economy::types::CurrencyCode,
-            _metadata: crate::economy::adapter::PaymentMetadata,
-        ) -> Result<
-            crate::economy::adapter::PaymentAuthorization,
-            crate::economy::adapter::PaymentError,
-        > {
-            Ok(void_counting_auth(payer, payee, amount, currency))
-        }
-        async fn verify_authorization(
-            &self,
-            _auth: &crate::economy::adapter::PaymentAuthorization,
-        ) -> Result<(), crate::economy::adapter::PaymentError> {
-            Ok(())
-        }
-        async fn capture(
-            &self,
-            _auth: &crate::economy::adapter::PaymentAuthorization,
-        ) -> Result<crate::economy::adapter::PaymentReceipt, crate::economy::adapter::PaymentError>
-        {
-            Err(crate::economy::adapter::PaymentError::AdapterError(
-                "capture not exercised by the drain path".into(),
-            ))
-        }
-        async fn void(
-            &self,
-            _auth: &crate::economy::adapter::PaymentAuthorization,
-        ) -> Result<(), crate::economy::adapter::PaymentError> {
-            self.voids.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
-            Ok(())
-        }
-        async fn verify(
-            &self,
-            _receipt: &crate::economy::adapter::PaymentReceipt,
-        ) -> Result<
-            crate::economy::adapter::VerificationResult,
-            crate::economy::adapter::PaymentError,
-        > {
-            Ok(crate::economy::adapter::VerificationResult {
-                valid: true,
-                adapter_id: "void-counting".to_owned(),
-                verified_amount: scp_protocol::economy::types::Amount(0),
-                verified_currency: scp_protocol::economy::types::CurrencyCode::from("USD"),
-                verification_timestamp: 0,
-            })
-        }
-        async fn refund(
-            &self,
-            _receipt: &crate::economy::adapter::PaymentReceipt,
-            _amount: Option<scp_protocol::economy::types::Amount>,
-        ) -> Result<
-            crate::economy::adapter::RefundConfirmation,
-            crate::economy::adapter::PaymentError,
-        > {
-            Ok(crate::economy::adapter::RefundConfirmation {
-                refund_id: [0u8; 32],
-                original_receipt_id: [0u8; 32],
-                refunded_amount: scp_protocol::economy::types::Amount(0),
-                currency: scp_protocol::economy::types::CurrencyCode::from("USD"),
-                adapter_proof: vec![],
-            })
-        }
-    }
-
     fn void_counting_auth(
         payer: &DID,
         payee: &DID,
@@ -21403,8 +21310,9 @@ mod tests {
         }
     }
 
-    /// A supervisor whose `payment_adapter_ref()` returns a
-    /// [`EscrowVoidCountingAdapter`] wired over the shared counter, so the REAL
+    /// A supervisor whose `payment_adapter_ref()` returns a shared
+    /// [`CountingPaymentAdapter`](crate::economy::adapter::CountingPaymentAdapter)
+    /// wired over the shared void counter, so the REAL
     /// `drain_terminal_reservation` void path is observable.
     fn supervisor_with_void_counter(
         voids: &Arc<std::sync::atomic::AtomicUsize>,
@@ -21423,9 +21331,11 @@ mod tests {
                     InMemoryStorage::new(),
                 )),
             );
-        let payment_adapter: Arc<dyn PaymentAdapterDyn> = Arc::new(EscrowVoidCountingAdapter {
-            voids: Arc::clone(voids),
-        });
+        let payment_adapter: Arc<dyn PaymentAdapterDyn> =
+            Arc::new(crate::economy::adapter::CountingPaymentAdapter {
+                voided: Arc::clone(voids),
+                ..Default::default()
+            });
         Supervisor::with_providers(
             crypto,
             transport,

--- a/crates/scp-runtime/src/economy/adapter.rs
+++ b/crates/scp-runtime/src/economy/adapter.rs
@@ -677,3 +677,145 @@ impl PaymentAdapter for NoOpPaymentAdapter {
         })
     }
 }
+
+// ---------------------------------------------------------------------------
+// CountingPaymentAdapter — test-only counting implementation.
+// ---------------------------------------------------------------------------
+
+/// A [`PaymentAdapter`] that counts `capture` and `void` invocations.
+///
+/// Uses shared [`AtomicUsize`](std::sync::atomic::AtomicUsize) counters so
+/// money-ordering and escrow-drain tests can assert whether an escrow was
+/// CAPTURED, VOIDED, or merely HELD. Every other method is an inert success
+/// returning a synthetic value.
+///
+/// Construct with the two counters cloned in, then read the originals after
+/// exercising the code under test:
+///
+/// ```ignore
+/// let captured = std::sync::Arc::new(std::sync::atomic::AtomicUsize::new(0));
+/// let voided = std::sync::Arc::new(std::sync::atomic::AtomicUsize::new(0));
+/// let adapter = CountingPaymentAdapter {
+///     captured: std::sync::Arc::clone(&captured),
+///     voided: std::sync::Arc::clone(&voided),
+/// };
+/// // ... drive the escrow path over `adapter` ...
+/// assert_eq!(voided.load(std::sync::atomic::Ordering::SeqCst), 1);
+/// ```
+///
+/// Consumers that only observe one branch can leave the other counter at its
+/// default via `..Default::default()`.
+///
+/// `capture` returns `Ok` (incrementing `captured`); the drain/void path never
+/// calls it, so callers that only exercise voids are unaffected. Selection of
+/// this adapter is by injected reference (`payment_adapter_ref()`), never by
+/// [`adapter_id`](PaymentAdapter::adapter_id) string match, so the id is fixed.
+///
+/// Gated behind `#[cfg(any(test, feature = "testing"))]` to prevent accidental
+/// use in production code.
+#[cfg(any(test, feature = "testing"))]
+#[derive(Default)]
+pub struct CountingPaymentAdapter {
+    /// Incremented once per [`PaymentAdapter::capture`] call.
+    pub captured: std::sync::Arc<std::sync::atomic::AtomicUsize>,
+    /// Incremented once per [`PaymentAdapter::void`] call.
+    pub voided: std::sync::Arc<std::sync::atomic::AtomicUsize>,
+}
+
+#[cfg(any(test, feature = "testing"))]
+#[allow(clippy::unnecessary_literal_bound, clippy::similar_names)]
+impl PaymentAdapter for CountingPaymentAdapter {
+    fn adapter_id(&self) -> &str {
+        "counting"
+    }
+
+    fn capabilities(&self) -> AdapterCapabilities {
+        AdapterCapabilities {
+            supported_currencies: vec![CurrencyCode(*b"USD\0")],
+            supports_streaming: false,
+            supports_batch_auth: false,
+            supports_single_step: false,
+            min_amount: None,
+            max_amount: None,
+            typical_settlement_ms: 0,
+            requires_facilitator: false,
+        }
+    }
+
+    async fn authorize(
+        &self,
+        payer: &DID,
+        payee: &DID,
+        amount: Amount,
+        currency: CurrencyCode,
+        _metadata: PaymentMetadata,
+    ) -> Result<PaymentAuthorization, PaymentError> {
+        Ok(PaymentAuthorization {
+            auth_id: [7u8; 32],
+            payer: payer.clone(),
+            payee: payee.clone(),
+            amount,
+            currency,
+            adapter_id: "counting".to_owned(),
+            created_at: 1_000_000,
+            expires_at: 2_000_000,
+            adapter_state: Vec::new(),
+        })
+    }
+
+    async fn capture(&self, auth: &PaymentAuthorization) -> Result<PaymentReceipt, PaymentError> {
+        self.captured
+            .fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+        Ok(PaymentReceipt {
+            receipt_id: [9u8; 32],
+            payer: auth.payer.clone(),
+            payee: auth.payee.clone(),
+            amount: auth.amount,
+            currency: auth.currency,
+            action_type: PaidActionType::ToolInvoke,
+            context_id: None,
+            adapter_id: "counting".to_owned(),
+            adapter_proof: Vec::new(),
+            timestamp: 1_000_001,
+            // Synthetic test receipt: never appended to the canonical Merkle
+            // log, so it is not anchored (matches `PaymentReceipt`'s unanchored
+            // default; the field lies outside the signed payload).
+            anchored: false,
+            signature: Vec::new(),
+        })
+    }
+
+    async fn void(&self, _auth: &PaymentAuthorization) -> Result<(), PaymentError> {
+        self.voided
+            .fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+        Ok(())
+    }
+
+    async fn verify_authorization(&self, _auth: &PaymentAuthorization) -> Result<(), PaymentError> {
+        Ok(())
+    }
+
+    async fn verify(&self, _receipt: &PaymentReceipt) -> Result<VerificationResult, PaymentError> {
+        Ok(VerificationResult {
+            valid: true,
+            adapter_id: "counting".to_owned(),
+            verified_amount: Amount(0),
+            verified_currency: CurrencyCode(*b"USD\0"),
+            verification_timestamp: 1_000_002,
+        })
+    }
+
+    async fn refund(
+        &self,
+        _receipt: &PaymentReceipt,
+        _amount: Option<Amount>,
+    ) -> Result<RefundConfirmation, PaymentError> {
+        Ok(RefundConfirmation {
+            refund_id: [0u8; 32],
+            original_receipt_id: [9u8; 32],
+            refunded_amount: Amount(0),
+            currency: CurrencyCode(*b"USD\0"),
+            adapter_proof: Vec::new(),
+        })
+    }
+}


### PR DESCRIPTION
## Summary

Consolidates the three near-duplicate counting `PaymentAdapter` test doubles in `scp-runtime` into one shared `CountingPaymentAdapter { captured, voided }`, placed beside `NoOpPaymentAdapter` in `crates/scp-runtime/src/economy/adapter.rs` under the identical `#[cfg(any(test, feature = "testing"))]` gate. Removes ~330 lines of triplicated 8-method trait boilerplate (net **−184 lines**) and the earlier `VoidCountingPaymentAdapter`/`EscrowVoidCountingAdapter` exact-name collision (both were `"void-counting"`). Test-only; **no production impact, no behavior change**.

Closes #1985.

## Removed → repointed
- `VoidCountingPaymentAdapter` (`actor/handlers/saga.rs`), `EscrowVoidCountingAdapter` (`supervisor.rs`), `RecordingPaymentAdapter` (`lifecycle_helpers.rs`) → all now `crate::economy::adapter::CountingPaymentAdapter`.
- Superset counters (`captured` + `voided`, `Arc<AtomicUsize>`, `#[derive(Default)]`); single-branch consumers use `..Default::default()`. No config field needed — `capture` returning `Ok` serves all three (the old supervisor `capture -> Err` was a dead defensive marker; the drain path never calls `capture`, verified).

## Verification
- `cargo fmt --all --check`, full-feature workspace clippy (`-D warnings`) — clean
- `cargo nextest run -p scp-runtime --features testing` — **2160 pass, 0 fail** (every prior assertion intact + still meaningful)
- `rg 'VoidCountingPaymentAdapter|EscrowVoidCountingAdapter|RecordingPaymentAdapter' crates/` → 0 hits

## Review
Double-zero: simplifier (genuine dedup, minimal shape, correct shared home, behavior-neutral repointing incl. `CurrencyCode::from("USD")` ≡ null-padded bytes), bug-catcher (all 5 risk vectors verified behavior-preserving — `capture` Err→Ok dead on drain path, counters/assertions meaningful, `adapter_id` selection-neutral, `Arc`-sharing correct, cfg-gating correct).

🤖 Generated with [Claude Code](https://claude.com/claude-code)