### PR TITLE
refactor(actor): delete dead Placeholder command variants (ADR-049 Phase 2G)

### DIFF
--- a/.docs/adrs/DEFERRED-commit-11-saga-use-cases.md
+++ b/.docs/adrs/DEFERRED-commit-11-saga-use-cases.md
@@ -15,15 +15,18 @@ not a saga and does not exist; broadcast hosting handshake was **WITHDRAWN**
 (2026-06-25) as a category error; and standing-pair creation was
 reclassified as single-context async creation, also not a saga.)*
 
-**What commit 11 DOES land.**
+**What commit 11 DOES land** *(historical snapshot — the mechanism
+names below describe the tree as it stood at commit 11; the
+`ContextManager` and `MutationStateView` types were both deleted by the
+later actor migration commits)*.
 - Full `ContextCommand` sub-enum extension for standing / tools /
-  broadcast — one variant per public `ContextManager` method
-  (excluding generic-executor methods that cannot cross the actor
-  mailbox).
+  broadcast — one variant per public method on the then-current
+  `ContextManager` (excluding generic-executor methods that cannot
+  cross the actor mailbox).
 - Shim-callable handler implementations in
-  `crates/scp-runtime/src/context/actor/handlers/{standing,tools,broadcast}.rs`
-  wired through `MutationStateView`, delegating byte-identically to
-  `ContextManager`.
+  `crates/scp-runtime/src/context/actor/handlers/{standing,tools,broadcast}.rs`,
+  wired at the time through the since-deleted `MutationStateView`,
+  delegating byte-identically to the since-deleted `ContextManager`.
 - `Supervisor::dispatch_{standing,tools,broadcast}_command` plus
   `dispatch_broadcast_command_with_custody` for the publish path.
 - Saga coordinator FSM in `Supervisor::start_saga` — the full
@@ -93,7 +96,7 @@ applied by the joining peer on Welcome receipt), reached via the
 idempotent `standing_context` get-or-create path. The spec leads the
 implementation, so this single-context-async creation path **is not yet
 wired** (§5.15.8: "the standing-pair creation path is not yet wired") —
-the saga-shaped `InitiateStandingPairCreate` variant and its `NotImplemented` reply are gone; the surviving not-yet-wired surface is the single-context-async creation path itself (its `reply_not_implemented` placeholder in `handlers/standing.rs`, pending wiring — consistent with exit criterion 2 below).
+the saga-shaped `InitiateStandingPairCreate` variant and its `NotImplemented` reply are gone; the surviving not-yet-wired surface is the single-context-async creation path itself: the idempotent `standing_context` get-or-create path exists, but its full standing-pair creation protocol (peer KeyPackage fetch + `add_member` + Welcome + consent-on-receipt) remains unwired per §5.15.8, consistent with exit criterion 2 below.
 
 ## Gap 2 — Cross-context tool invocation transport
 
@@ -125,10 +128,10 @@ context but not the cross-context forwarding path:
 `Supervisor::start_cross_context_tool_invocation_saga` (running
 supervisor-side); the dead `ToolsCommand::InitiateCrossContextToolInvocation`
 mailbox variant and its `NotImplemented` reply have been deleted. Note:
-`ContextManager::invoke_tool_with_economy` is, for a separate reason, not
+`Supervisor::invoke_tool_with_economy` is, for a separate reason, not
 a command variant — its generic `F: FnOnce(Value) -> Fut` executor closure
-carries no `Send` bound and so cannot cross the actor mailbox; it continues
-to run on the direct manager surface (FFI bridges invoke it inline).
+carries no `Send` bound and so cannot cross the actor mailbox; it runs
+supervisor-side (FFI bridges invoke it inline).
 
 ## Gap 3 — Broadcast hosting handshake protocol
 
@@ -247,21 +250,22 @@ async/poll wait model having been withdrawn with Gap 4 per ADR-049 §3a.)
 > `tool_invoke_cross_context_saga`, block-until-terminal, in all three
 > bridges); criterion 5 (SDK wrappers for each language target); and the
 > saga side of criterion 3 (the §6.2.4 integration tests). **Pending:** the
-> single-context-async standing-pair **wiring** — criterion 2's replacement
-> of the `reply_not_implemented` placeholder in `handlers/standing.rs`, plus
-> its criterion-3 test — remains unwired by design (the spec leads; §5.15.8
-> records "the standing-pair creation path is not yet wired," so there is no
-> live divergence to reconcile).
+> single-context-async standing-pair **wiring** — criterion 2's full
+> standing-pair creation protocol (peer KeyPackage fetch + `add_member` +
+> Welcome + consent-on-receipt) on the idempotent `standing_context`
+> get-or-create path, plus its criterion-3 test — remains unwired by design
+> (the spec leads; §5.15.8 records "the standing-pair creation path is not
+> yet wired," so there is no live divergence to reconcile).
 
 1. A spec update (.docs/specs/ or a new ADR) filling in the **2** spec
    gaps (Gaps 1–2) with canonical wire formats and state-machine tables —
    Gap 1 being the §5.15.8 single-context-async standing-pair spec (not
    a saga) and Gap 2 the one live saga. (Gaps 3–4 are withdrawn, not
    specced; Gap 5 is the FFI surface, item 4 below.)
-2. Replacement of the `reply_not_implemented` placeholder in
-   `handlers/standing.rs` with a real dispatch — the
-   single-context-async `create` + `add_member` + Welcome path for
-   standing-pair. (No `tools` handler placeholder: the one live saga,
+2. Wiring the single-context-async standing-pair creation path into a
+   real dispatch — get-or-create via `standing_context` + peer KeyPackage
+   fetch + `add_member` + Welcome + consent-on-receipt. (No `tools`
+   handler placeholder: the one live saga,
    §6.2.4 cross-context tool invocation, is produced supervisor-side by
    `start_cross_context_tool_invocation_saga`, not via an actor-mailbox
    handler. No migration or broadcast-hosting handler — Gaps 3–4

--- a/crates/scp-runtime/src/context/actor/class_s.rs
+++ b/crates/scp-runtime/src/context/actor/class_s.rs
@@ -48,7 +48,7 @@
 //! [`ClassSCell`] owns the [`PerContextState`] and exposes:
 //!
 //! - **Reads** via [`Deref`] — `&*cell` / `cell.<field>` yields `&PerContextState`.
-//!   There is deliberately **no [`DerefMut`]**: you cannot obtain a
+//!   There is deliberately **no [`DerefMut`](std::ops::DerefMut)**: you cannot obtain a
 //!   `&mut PerContextState` by writing `&mut cell.<field>` or `*cell = …`. That is
 //!   the compile-time hook, and it is now in force for the THREE privatized
 //!   Class-S fields (`PerContextState.class_s`, `GovernanceState.class_s`, and
@@ -120,7 +120,7 @@
 //! whole-struct `&mut` if one were ever handed out — but none is). Field
 //! privatization (`PerContextState.class_s` / `GovernanceState.class_s` are now
 //! `pub(in crate::context)`) closes the LAST whole-`&mut` reach that DID exist —
-//! the deleted [`ClassSCell::state_mut`] escape hatch and [`ClassSMut`]'s
+//! the deleted `ClassSCell::state_mut` escape hatch and [`ClassSMut`]'s
 //! `pub(crate)` reach — NOT this view, which was already airtight.
 //! - `*_then_append` — persist fail-closed AFTER `f`, then run an async `after`
 //!   step that appends a derived record to an EXTERNAL durable sink (the event
@@ -217,7 +217,7 @@
 //!   §9-safe by the OBLIGATION of the combinator/caller that reaches it (NOT by
 //!   impossibility):
 //!   - **(A) the consequence-only view.** [`ClassCMut::consequence_split`] (itself
-//!     reachable from the best-effort [`ClassCMut::class_c_view`]) yields a
+//!     reachable from the best-effort `ClassSCell::class_c_view`) yields a
 //!     [`ConsequenceRoleStateMut`], the role view that DOES expose
 //!     `suspend_capabilities` / `suspend_all`. A `ClassCMut` holder CAN therefore
 //!     reach a GROW — and the §9 guarantee is that the consequence caller persists

--- a/crates/scp-runtime/src/context/actor/commands.rs
+++ b/crates/scp-runtime/src/context/actor/commands.rs
@@ -22,15 +22,17 @@
 //! vector (drop-the-receiver = discard the outcome without rolling back
 //! committed state — see plan §"Cancel-safety check").
 //!
-//! # Minimal variant surface (this commit)
+//! # Variant surface
 //!
-//! Commit 6 lands the enum SHAPE. Each sub-enum carries one or two
-//! placeholder variants whose handlers return
-//! `ContextError::NotImplemented(..)` via
-//! [`Outcome::err`](crate::context::actor::Outcome::err). Commits 7-11
-//! extend each sub-enum with real variants as the corresponding handler
-//! migrates off the legacy `ContextManager`; the dispatch loop shape is
-//! stable from this commit forward.
+//! Each sub-enum carries its real, domain-specific command variants;
+//! there are no placeholder variants. The actor mailbox has no
+//! `NotImplemented` scaffolding on the live dispatch path — the
+//! state-owning [`ContextActor`](crate::context::actor::ContextActor)
+//! routes every command through `dispatch_state` to its real handler.
+//! The only remaining `ContextError::NotImplemented(..)` producer is the
+//! test-only `skeleton_dispatch` path, which acks the mailbox contract
+//! for state-less skeleton actors and returns
+//! [`Outcome::err`](crate::context::actor::Outcome::err).
 //!
 //! # Naming
 //!
@@ -69,7 +71,7 @@ pub type DeliverIncomingReply = oneshot::Sender<Result<DeliverOutcome, ContextEr
 /// Reply-channel type alias for [`MessagingCommand::DrainEvents`]. The
 /// reply carries the drained `ContextEvent` vector — empty iff the
 /// context is unknown (matches the legacy
-/// [`ContextManager::drain_events`](crate::context::supervisor::Supervisor::drain_events)
+/// [`Supervisor::drain_events`](crate::context::supervisor::Supervisor::drain_events)
 /// "soft-default on unknown context" contract). Factored out to satisfy
 /// `clippy::type_complexity`.
 pub type DrainEventsReply =
@@ -124,7 +126,7 @@ pub enum ContextCommand {
 }
 
 // ---------------------------------------------------------------------------
-// Placeholder sub-enums
+// Command sub-enums
 // ---------------------------------------------------------------------------
 
 /// Payload for [`MessagingCommand::SendMessage`]. Boxed inside the
@@ -172,26 +174,18 @@ pub struct SendMessagePayload {
 /// the ADR-049 commit ladder (see `handlers/messaging.rs`). Variants
 /// cover the hot-path send + deliver operations; sender-key rotation,
 /// distribute/remove, sender-key request handling, and sender-key
-/// management messages all stay on the legacy `ContextManager` surface
-/// until commits 10-11 per the plan row-6 scope.
+/// management messages are served directly by the crypto provider —
+/// `crypto/mls/provider.rs` methods (invoked internally by the runtime's
+/// lifecycle/governance/blocking helpers) plus
+/// `crypto/sender_keys/key_protocol.rs` free functions (additionally
+/// re-exported to the FFI boundary via `scp-core`), not command variants
+/// traversing the command-dispatch shim — until they migrate to
+/// `MessagingCommand` variants in commits 10-11 per the plan row-6 scope.
 pub enum MessagingCommand {
-    /// Placeholder — reserved for Phase 2 actor-mailbox wiring of
-    /// ADR-049 (post-review-round-1 plan). Used by the actor's
-    /// `run()` skeleton dispatch as a no-op handshake target so the
-    /// mailbox machinery exercises end-to-end without a real
-    /// command. Handler replies
-    /// [`ContextError::NotImplemented`](scp_protocol::context::ContextError::NotImplemented)
-    /// and returns `Outcome::err`.
-    Placeholder {
-        /// Oneshot reply channel. Handler stub sends
-        /// `Err(ContextError::NotImplemented(..))` back.
-        reply: oneshot::Sender<Result<(), ContextError>>,
-    },
-
     /// Encrypts and transmits a message within an active context.
     ///
     /// Mirrors the legacy
-    /// [`ContextManager::send_message`](crate::context::supervisor::Supervisor::send_message)
+    /// [`Supervisor::send_message`](crate::context::supervisor::Supervisor::send_message)
     /// signature exactly: the handler delegates to that method for
     /// byte-identical envelope construction, inner-signature signing,
     /// sender-key sealing, MLS encryption, and transport fan-out.
@@ -228,7 +222,7 @@ pub enum MessagingCommand {
     /// management message.
     ///
     /// Mirrors the legacy
-    /// [`ContextManager::deliver_incoming`](crate::context::messaging_helpers::deliver_incoming)
+    /// [`messaging_helpers::deliver_incoming`](crate::context::messaging_helpers::deliver_incoming)
     /// signature. Used by the relay subscription loop; the return type
     /// matches the bridge's per-event dispatch pattern.
     ///
@@ -257,7 +251,7 @@ pub enum MessagingCommand {
     /// Drain the per-context receive buffer.
     ///
     /// Mirrors the legacy
-    /// [`ContextManager::drain_events`](crate::context::supervisor::Supervisor::drain_events)
+    /// [`Supervisor::drain_events`](crate::context::supervisor::Supervisor::drain_events)
     /// signature: empties the receive buffer and returns the drained
     /// events. The legacy method returns an empty `Vec` on unknown
     /// context; the dispatch shim preserves that contract by surfacing
@@ -309,7 +303,7 @@ pub enum MessagingCommand {
     /// other members of a context.
     ///
     /// Mirrors the legacy
-    /// [`ContextManager::send_pseudonym_announcement`](crate::context::messaging_helpers::send_pseudonym_announcement)
+    /// [`messaging_helpers::send_pseudonym_announcement`](crate::context::messaging_helpers::send_pseudonym_announcement)
     /// signature exactly: the handler delegates to that method which
     /// in turn wraps the announcement payload and routes it through
     /// `send_message`. Best-effort — the legacy method returns no
@@ -383,7 +377,7 @@ pub enum MessagingCommand {
     /// broadcast channel).
     ///
     /// Mirrors the legacy
-    /// [`ContextManager::report_degraded_mode`](crate::context::supervisor::Supervisor::report_degraded_mode)
+    /// [`Supervisor::report_degraded_mode`](crate::context::supervisor::Supervisor::report_degraded_mode)
     /// signature: a fire-and-forget side-effect on the messaging path's
     /// receive-buffer state. The reply channel carries `Ok(())` once the
     /// emit completes (or no-ops on `Match` / `IncompatibleMajor`
@@ -595,9 +589,8 @@ pub type ImportContextReply = oneshot::Sender<Result<crate::context::ContextHand
 /// [`ContextParams`](scp_protocol::context::params::ContextParams)
 /// being ~1KB.
 pub struct CreateContextPayload {
-    /// Context identifier (plain string; the legacy
-    /// `ContextManager::create_context` derives the 32-byte hash
-    /// internally).
+    /// Context identifier (plain string; the `Supervisor::create_context`
+    /// entry point derives the 32-byte hash internally).
     pub context_id: String,
     /// Creation-time parameters — governance model, ceiling, TTL,
     /// economic policy, etc.
@@ -681,28 +674,15 @@ pub struct RestoreContextPayload {
 /// [`PerContextState`](crate::context::actor::state::PerContextState).
 ///
 /// **Create / join.** `CreateContext` / `JoinContext` route directly through
-/// [`ContextManager::create_context`](crate::context::supervisor::Supervisor::create_context)
-/// / [`ContextManager::join_context`](crate::context::supervisor::Supervisor::join_context).
+/// [`Supervisor::create_context`](crate::context::supervisor::Supervisor::create_context)
+/// / [`Supervisor::join_context`](crate::context::supervisor::Supervisor::join_context).
 /// Neither is a saga entry point: standing-pair creation is single-context
 /// async creation (not a 2-phase saga; spec §5.15.8), and cross-identity
 /// context migration was withdrawn (ADR-049 §4). The sole cross-context saga
 /// is tool invocation (§6.2.4), driven from the supervisor, not this enum.
 pub enum LifecycleCommand {
-    /// Placeholder — reserved for Phase 2 actor-mailbox wiring of
-    /// ADR-049 (post-review-round-1 plan). Used by the actor's
-    /// `run()` skeleton dispatch as a no-op handshake target so the
-    /// mailbox machinery exercises end-to-end without a real
-    /// command. Handler replies
-    /// [`ContextError::NotImplemented`](scp_protocol::context::ContextError::NotImplemented)
-    /// and returns `Outcome::err`.
-    Placeholder {
-        /// Oneshot reply channel. Handler stub sends
-        /// `Err(ContextError::NotImplemented(..))` back.
-        reply: oneshot::Sender<Result<(), ContextError>>,
-    },
-
     /// Creates a new MLS-backed (or broadcast-mode) context. Mirrors
-    /// [`ContextManager::create_context`](crate::context::supervisor::Supervisor::create_context).
+    /// [`Supervisor::create_context`](crate::context::supervisor::Supervisor::create_context).
     ///
     /// Standing-pair creation also routes through `create_context` — it is
     /// single-context async creation (not a saga-prepare flow; spec §5.15.8),
@@ -719,7 +699,7 @@ pub enum LifecycleCommand {
     },
 
     /// Joins an existing context. Mirrors
-    /// [`ContextManager::join_context`](crate::context::supervisor::Supervisor::join_context).
+    /// [`Supervisor::join_context`](crate::context::supervisor::Supervisor::join_context).
     ///
     /// The caller is the MLS `KeyPackage` owner (`key_package.owner_did`).
     /// `spending_ucan` is the optional UCAN for the economy layer's
@@ -735,7 +715,7 @@ pub enum LifecycleCommand {
     },
 
     /// Removes a member from an active context. Mirrors
-    /// [`ContextManager::leave_context`](crate::context::supervisor::Supervisor::leave_context).
+    /// [`Supervisor::leave_context`](crate::context::supervisor::Supervisor::leave_context).
     ///
     /// Self-removal (`caller_did == member_did`) is always permitted;
     /// removing another member requires the `MemberRemove` capability
@@ -748,7 +728,7 @@ pub enum LifecycleCommand {
     },
 
     /// Initiates cooperative context closure. Mirrors
-    /// [`ContextManager::close_context`](crate::context::lifecycle_helpers::close_context)
+    /// [`lifecycle_helpers::close_context`](crate::context::lifecycle_helpers::close_context)
     /// (not `close_context_with_key` — the latter is an internal
     /// optimization for checkpoint generation; commit 9 exposes the
     /// public surface through the command enum).
@@ -833,7 +813,7 @@ pub enum LifecycleCommand {
 
     /// Generate and store a per-member access key for explicit
     /// lifecycle management (§9.17.2 step 1). Mirrors
-    /// [`ContextManager::generate_context_access_key`](crate::context::queries_helpers::generate_context_access_key).
+    /// [`queries_helpers::generate_context_access_key`](crate::context::queries_helpers::generate_context_access_key).
     ///
     /// Requires `ContextClose` capability on the caller. Overwrites any
     /// existing key for the same `(context_id, member_did)` pair.
@@ -850,7 +830,7 @@ pub enum LifecycleCommand {
 
     /// Revoke (remove) a member's access key from the context's
     /// access key store (§9.17.2 step 3, ADR-038). Mirrors
-    /// [`ContextManager::revoke_context_access_key`](crate::context::queries_helpers::revoke_context_access_key).
+    /// [`queries_helpers::revoke_context_access_key`](crate::context::queries_helpers::revoke_context_access_key).
     ///
     /// Requires `ContextClose` capability on the caller.
     RevokeContextAccessKey {
@@ -896,8 +876,8 @@ pub enum LifecycleCommand {
     ///
     /// Mirrors the per-context body of the legacy
     /// `flush_all_contexts_legacy` (which iterated the supervisor's
-    /// `contexts` DashMap and took a per-context lock with
-    /// [`FLUSH_LOCK_BUDGET`](crate::context::lifecycle_helpers::FLUSH_LOCK_BUDGET)).
+    /// `contexts` DashMap and took a per-context lock with the
+    /// since-deleted `FLUSH_LOCK_BUDGET`).
     /// The actor path needs no separate lock budget — the actor's own
     /// dispatch loop serializes by construction, so the command sits in
     /// the mailbox until the actor is idle. The handler builds a snapshot
@@ -960,7 +940,8 @@ pub enum LifecycleCommand {
     /// removal). The actor owns its state, so the handler reads
     /// `state.receive_buffer.len()` directly with no cross-actor lock.
     ///
-    /// Read-only: the handler returns an [`Outcome`] with `mutated =
+    /// Read-only: the handler returns an
+    /// [`Outcome`](crate::context::actor::Outcome) with `mutated =
     /// false`.
     ReportBufferLen {
         /// Oneshot reply channel carrying this actor's receive-buffer
@@ -1107,18 +1088,8 @@ pub struct ExecuteGovernanceActionPayload {
 /// mirrors the manager methods that accept them, not the actions
 /// themselves.
 pub enum GovernanceCommand {
-    /// Placeholder — reserved for Phase 2 actor-mailbox wiring of
-    /// ADR-049 (post-review-round-1 plan). Used as a no-op
-    /// handshake target by mailbox tests so the end-to-end dispatch
-    /// pipe is exercised without a real command. Handler replies
-    /// [`ContextError::NotImplemented`](scp_protocol::context::ContextError::NotImplemented).
-    Placeholder {
-        /// Oneshot reply channel.
-        reply: oneshot::Sender<Result<(), ContextError>>,
-    },
-
     /// Submits a governance proposal — unchecked variant. Mirrors
-    /// [`ContextManager::propose_governance_action`](crate::context::supervisor::Supervisor::propose_governance_action).
+    /// [`Supervisor::propose_governance_action`](crate::context::supervisor::Supervisor::propose_governance_action).
     /// Accepts the proposer DID + action + signing key without a
     /// capability pre-check (the governance engine enforces eligibility
     /// internally). For `SingleAdmin` contexts the proposal is auto-
@@ -1133,7 +1104,7 @@ pub enum GovernanceCommand {
     },
 
     /// Submits a governance proposal — checked variant. Mirrors
-    /// [`ContextManager::propose_governance_action_checked`](crate::context::supervisor::Supervisor::propose_governance_action_checked).
+    /// [`Supervisor::propose_governance_action_checked`](crate::context::supervisor::Supervisor::propose_governance_action_checked).
     /// Validates the proposer's `GovernancePropose` capability inside
     /// the same lock as the proposal submission (no TOCTOU).
     ProposeGovernanceActionChecked {
@@ -1145,7 +1116,7 @@ pub enum GovernanceCommand {
     },
 
     /// Casts a vote on a pending proposal. Mirrors
-    /// [`ContextManager::vote_on_proposal`](crate::context::supervisor::Supervisor::vote_on_proposal).
+    /// [`Supervisor::vote_on_proposal`](crate::context::supervisor::Supervisor::vote_on_proposal).
     /// `approve == true` is an approval vote; `false` is rejection.
     VoteOnProposal {
         /// Boxed owned payload.
@@ -1159,7 +1130,7 @@ pub enum GovernanceCommand {
     },
 
     /// Casts an approval vote with explicit capability pre-check.
-    /// Mirrors [`ContextManager::approve_governance_proposal`](crate::context::governance_helpers::approve_governance_proposal).
+    /// Mirrors [`governance_helpers::approve_governance_proposal`](crate::context::governance_helpers::approve_governance_proposal).
     /// The reply carries only the resulting status (the legacy method
     /// discards the event list by convention — see its implementation).
     ApproveGovernanceProposal {
@@ -1172,7 +1143,7 @@ pub enum GovernanceCommand {
     },
 
     /// Casts a rejection vote with explicit capability pre-check.
-    /// Mirrors [`ContextManager::reject_governance_proposal`](crate::context::governance_helpers::reject_governance_proposal).
+    /// Mirrors [`governance_helpers::reject_governance_proposal`](crate::context::governance_helpers::reject_governance_proposal).
     RejectGovernanceProposal {
         /// Boxed owned payload.
         payload: Box<VoteOnProposalPayload>,
@@ -1183,7 +1154,7 @@ pub enum GovernanceCommand {
     },
 
     /// Withdraws a previously cast vote. Mirrors
-    /// [`ContextManager::withdraw_governance_vote`](crate::context::supervisor::Supervisor::withdraw_governance_vote).
+    /// [`Supervisor::withdraw_governance_vote`](crate::context::supervisor::Supervisor::withdraw_governance_vote).
     /// No signing key — withdrawal is the voter's privileged operation
     /// on their own vote per the governance engine's trait contract.
     WithdrawGovernanceVote {
@@ -1200,7 +1171,7 @@ pub enum GovernanceCommand {
     },
 
     /// Executes an already-approved governance proposal. Mirrors
-    /// [`ContextManager::execute_governance_action`](crate::context::governance_helpers::execute_governance_action).
+    /// [`governance_helpers::execute_governance_action`](crate::context::governance_helpers::execute_governance_action).
     /// Caller MUST pass a proposal whose status is
     /// [`ProposalStatus::Approved`](scp_protocol::context::governance::ProposalStatus);
     /// the legacy method enforces the gate.
@@ -1213,7 +1184,7 @@ pub enum GovernanceCommand {
     },
 
     /// Reads a single proposal by ID. Mirrors
-    /// [`ContextManager::get_proposal`](crate::context::supervisor::Supervisor::get_proposal).
+    /// [`Supervisor::get_proposal`](crate::context::supervisor::Supervisor::get_proposal).
     GetProposal {
         /// Context identifier string.
         context_id: String,
@@ -1226,7 +1197,7 @@ pub enum GovernanceCommand {
     },
 
     /// Lists all proposals for a context. Mirrors
-    /// [`ContextManager::list_proposals`](crate::context::supervisor::Supervisor::list_proposals).
+    /// [`Supervisor::list_proposals`](crate::context::supervisor::Supervisor::list_proposals).
     ListProposals {
         /// Context identifier string.
         context_id: String,
@@ -1238,7 +1209,7 @@ pub enum GovernanceCommand {
 
     /// Applies a pending ceiling modification whose notification period
     /// has expired. Mirrors
-    /// [`ContextManager::apply_pending_ceiling_modification`](crate::context::governance_helpers::apply_pending_ceiling_modification).
+    /// [`governance_helpers::apply_pending_ceiling_modification`](crate::context::governance_helpers::apply_pending_ceiling_modification).
     /// Returns `true` iff a pending modification was applied.
     ApplyPendingCeilingModification {
         /// Context identifier string.
@@ -1252,7 +1223,7 @@ pub enum GovernanceCommand {
 
     /// Applies a pending economic-policy change whose notification
     /// period has expired. Mirrors
-    /// [`ContextManager::apply_pending_economic_policy_change`](crate::context::governance_helpers::apply_pending_economic_policy_change).
+    /// [`governance_helpers::apply_pending_economic_policy_change`](crate::context::governance_helpers::apply_pending_economic_policy_change).
     /// Returns `true` iff a pending change was applied.
     ApplyPendingEconomicPolicyChange {
         /// Context identifier string.
@@ -1265,7 +1236,7 @@ pub enum GovernanceCommand {
 
     /// Tombstones a migrated context after the grace period expires.
     /// Mirrors
-    /// [`ContextManager::tombstone_migrated_context`](crate::context::governance_helpers::tombstone_migrated_context).
+    /// [`governance_helpers::tombstone_migrated_context`](crate::context::governance_helpers::tombstone_migrated_context).
     TombstoneMigratedContext {
         /// Context identifier string.
         context_id: String,
@@ -1274,7 +1245,7 @@ pub enum GovernanceCommand {
     },
 
     /// Returns the migration state for a context if one exists. Mirrors
-    /// [`ContextManager::migration_state`](crate::context::governance_helpers::migration_state).
+    /// [`governance_helpers::migration_state`](crate::context::governance_helpers::migration_state).
     ///
     /// This is read-only; the handler returns
     /// [`Outcome::ok`](crate::context::actor::Outcome::ok) and reports
@@ -1289,7 +1260,7 @@ pub enum GovernanceCommand {
 
     /// Acknowledges and clears a commit-fault marker for a context
     /// (PR #1606 C6). Mirrors
-    /// [`ContextManager::acknowledge_commit_fault`](crate::context::governance_helpers::acknowledge_commit_fault).
+    /// [`governance_helpers::acknowledge_commit_fault`](crate::context::governance_helpers::acknowledge_commit_fault).
     AcknowledgeCommitFault {
         /// Context identifier string.
         context_id: String,
@@ -1476,23 +1447,25 @@ pub struct UnsubscribeBroadcastPayload {
 ///
 /// # KeyCustody plumbing
 ///
-/// The legacy
-/// [`ContextManager::publish_broadcast`](crate::context::broadcast_helpers::publish_broadcast)
-/// takes a `custody: &impl KeyCustody + &KeyHandle` pair; the
-/// [`KeyCustody`](scp_platform::KeyCustody) trait uses RPITIT and is
-/// NOT `dyn`-safe, so it cannot cross the actor mailbox. Instead:
+/// Signing a broadcast envelope needs the caller's
+/// [`KeyCustody`](scp_platform::KeyCustody) backend; the trait uses
+/// RPITIT and is NOT `dyn`-safe, so it cannot cross the actor mailbox.
+/// Instead:
 ///
 /// - The command carries only the
 ///   [`KeyHandle`](scp_platform::KeyHandle) (an opaque reference that
 ///   IS `Send + Sync + Clone`).
-/// - The shim-dispatch entry point
-///   [`Supervisor::dispatch_broadcast_command`](crate::context::supervisor::supervisor::Supervisor::dispatch_broadcast_command)
-///   is generic over the concrete custody type, and the shim extracts
-///   the `KeyHandle` from the command and passes both to
-///   [`ContextManager::publish_broadcast`](crate::context::broadcast_helpers::publish_broadcast).
-/// - For the post-refactor actor loop (commit 12+), the custody is
-///   available via the actor's bridge-instance reference; the actor
-///   body resolves the custody from the instance and signs inline.
+/// - The custody-generic entry point
+///   [`Supervisor::dispatch_broadcast_command_with_custody`](crate::context::supervisor::supervisor::Supervisor::dispatch_broadcast_command_with_custody)
+///   drives the two-phase publish path: the actor reserves the
+///   sequence via
+///   [`broadcast_helpers::reserve_broadcast_publish`](crate::context::broadcast_helpers::reserve_broadcast_publish)
+///   and returns the signing-payload digest, the supervisor signs with
+///   the caller's custody OUTSIDE the actor, then the actor seals via
+///   [`broadcast_helpers::apply_broadcast_publish`](crate::context::broadcast_helpers::apply_broadcast_publish).
+/// - Dispatching this variant directly on the actor mailbox is
+///   rejected with a typed error pointing at the custody-generic
+///   entry point (see `handlers/broadcast.rs`).
 pub struct PublishBroadcastPayload {
     /// Context identifier string.
     pub context_id: String,
@@ -1579,26 +1552,19 @@ pub struct BroadcastBlockPayload {
 /// `PublishBroadcast` / `PublishBroadcastContent` each require the
 /// caller's [`KeyCustody`](scp_platform::KeyCustody) backend to sign the
 /// broadcast envelope — the custody trait uses RPITIT and cannot cross
-/// an actor mailbox. For commit 11 the non-saga variants store only the
-/// [`KeyHandle`](scp_platform::KeyHandle); the handler reaches back to
-/// the attached [`Supervisor`](crate::context::supervisor::Supervisor)
-/// for the custody reference, matching the bridge-level wiring the
-/// legacy method uses today.
+/// an actor mailbox. The variants store only the
+/// [`KeyHandle`](scp_platform::KeyHandle) and are dispatched through
+/// the custody-generic
+/// [`Supervisor::dispatch_broadcast_command_with_custody`](crate::context::supervisor::supervisor::Supervisor::dispatch_broadcast_command_with_custody),
+/// which drives the custody-free two-phase
+/// `ReserveBroadcastPublish` / `ApplyBroadcastPublish` mailbox commands
+/// and signs with the caller's custody between the two phases, outside
+/// the actor.
 pub enum BroadcastCommand {
-    /// Placeholder — reserved for Phase 2 actor-mailbox wiring of
-    /// ADR-049 (post-review-round-1 plan). Used as a no-op
-    /// handshake target by mailbox tests so the end-to-end dispatch
-    /// pipe is exercised without a real command. Handler replies
-    /// [`ContextError::NotImplemented`](scp_protocol::context::ContextError::NotImplemented).
-    Placeholder {
-        /// Oneshot reply channel.
-        reply: oneshot::Sender<Result<(), ContextError>>,
-    },
-
     /// Subscribe a DID to a broadcast context. Mirrors
-    /// [`ContextManager::subscribe_broadcast`](crate::context::broadcast_helpers::subscribe_broadcast).
+    /// [`broadcast_helpers::subscribe_broadcast`](crate::context::broadcast_helpers::subscribe_broadcast).
     ///
-    /// The validation-context-generic variant on `ContextManager` carries
+    /// The validation-context-generic form of that helper carries
     /// a `ValidationContext<'_, D, N, R, P, S>` parameter; the actor
     /// command surface passes `None` for that slot to match the default
     /// unvalidated path. Gated contexts with a UCAN still route through
@@ -1611,7 +1577,7 @@ pub enum BroadcastCommand {
     },
 
     /// Unsubscribe a DID from a broadcast context. Mirrors
-    /// [`ContextManager::unsubscribe_broadcast`](crate::context::broadcast_helpers::unsubscribe_broadcast).
+    /// [`broadcast_helpers::unsubscribe_broadcast`](crate::context::broadcast_helpers::unsubscribe_broadcast).
     UnsubscribeBroadcast {
         /// Boxed owned payload.
         payload: Box<UnsubscribeBroadcastPayload>,
@@ -1619,8 +1585,11 @@ pub enum BroadcastCommand {
         reply: UnsubscribeBroadcastReply,
     },
 
-    /// Publish raw bytes to a broadcast context. Mirrors
-    /// [`ContextManager::publish_broadcast`](crate::context::broadcast_helpers::publish_broadcast).
+    /// Publish raw bytes to a broadcast context. Dispatched via the
+    /// custody-generic supervisor path, which drives the two-phase
+    /// [`broadcast_helpers::reserve_broadcast_publish`](crate::context::broadcast_helpers::reserve_broadcast_publish)
+    /// / [`broadcast_helpers::apply_broadcast_publish`](crate::context::broadcast_helpers::apply_broadcast_publish)
+    /// pair — see the enum-level key-custody handoff docs.
     PublishBroadcast {
         /// Boxed owned payload.
         payload: Box<PublishBroadcastPayload>,
@@ -1629,8 +1598,11 @@ pub enum BroadcastCommand {
     },
 
     /// Publish structured [`BroadcastContent`](scp_protocol::context::broadcast_content::BroadcastContent)
-    /// to a broadcast context. Mirrors
-    /// [`ContextManager::publish_broadcast_content`](crate::context::broadcast_helpers::publish_broadcast_content).
+    /// to a broadcast context. Serializes the content, then follows the
+    /// same custody-generic two-phase
+    /// [`broadcast_helpers::reserve_broadcast_publish`](crate::context::broadcast_helpers::reserve_broadcast_publish)
+    /// / [`broadcast_helpers::apply_broadcast_publish`](crate::context::broadcast_helpers::apply_broadcast_publish)
+    /// path as [`Self::PublishBroadcast`].
     PublishBroadcastContent {
         /// Boxed owned payload.
         payload: Box<PublishBroadcastContentPayload>,
@@ -1673,7 +1645,7 @@ pub enum BroadcastCommand {
 
     /// Block a subscriber from receiving future broadcasts from a
     /// specific author. Mirrors
-    /// [`ContextManager::block_broadcast_subscriber`](crate::context::broadcast_helpers::block_broadcast_subscriber).
+    /// [`broadcast_helpers::block_broadcast_subscriber`](crate::context::broadcast_helpers::block_broadcast_subscriber).
     BlockBroadcastSubscriber {
         /// Boxed owned payload.
         payload: Box<BroadcastBlockPayload>,
@@ -1682,7 +1654,7 @@ pub enum BroadcastCommand {
     },
 
     /// Unblock a previously blocked subscriber. Mirrors
-    /// [`ContextManager::unblock_broadcast_subscriber`](crate::context::broadcast_helpers::unblock_broadcast_subscriber).
+    /// [`broadcast_helpers::unblock_broadcast_subscriber`](crate::context::broadcast_helpers::unblock_broadcast_subscriber).
     UnblockBroadcastSubscriber {
         /// Boxed owned payload.
         payload: Box<BroadcastBlockPayload>,
@@ -1691,7 +1663,7 @@ pub enum BroadcastCommand {
     },
 
     /// Evaluate a subscriber's broadcast-key request. Mirrors
-    /// [`ContextManager::handle_broadcast_key_request`](crate::context::broadcast_helpers::handle_broadcast_key_request).
+    /// [`broadcast_helpers::handle_broadcast_key_request`](crate::context::broadcast_helpers::handle_broadcast_key_request).
     ///
     /// Read-mostly (no per-context mutation) — handler reports
     /// `mutated: false`.
@@ -1712,7 +1684,7 @@ pub enum BroadcastCommand {
     },
 
     /// Return the subscriber count for a broadcast context. Mirrors
-    /// [`ContextManager::broadcast_subscriber_count`](crate::context::broadcast_helpers::broadcast_subscriber_count).
+    /// [`broadcast_helpers::broadcast_subscriber_count`](crate::context::broadcast_helpers::broadcast_subscriber_count).
     /// Read-only. `Ok(None)` iff the context is unknown or not broadcast.
     BroadcastSubscriberCount {
         /// Context identifier string.
@@ -1722,7 +1694,7 @@ pub enum BroadcastCommand {
     },
 
     /// Membership predicate — `true` iff `did` is a subscriber. Mirrors
-    /// [`ContextManager::is_broadcast_subscriber`](crate::context::broadcast_helpers::is_broadcast_subscriber).
+    /// [`broadcast_helpers::is_broadcast_subscriber`](crate::context::broadcast_helpers::is_broadcast_subscriber).
     /// Read-only.
     IsBroadcastSubscriber {
         /// Context identifier string.
@@ -1734,7 +1706,7 @@ pub enum BroadcastCommand {
     },
 
     /// Return the broadcast context's admission policy. Mirrors
-    /// [`ContextManager::broadcast_admission`](crate::context::broadcast_helpers::broadcast_admission).
+    /// [`broadcast_helpers::broadcast_admission`](crate::context::broadcast_helpers::broadcast_admission).
     /// Read-only. `Ok(None)` iff the context is unknown or not broadcast.
     BroadcastAdmission {
         /// Context identifier string.
@@ -1768,19 +1740,9 @@ pub type VerifyPaymentReceiptsReply = oneshot::Sender<
 /// internally rather than calling the helpers directly; commit 10
 /// lands only the public surface.
 pub enum EconomyCommand {
-    /// Placeholder — reserved for Phase 2 actor-mailbox wiring of
-    /// ADR-049 (post-review-round-1 plan). Used as a no-op
-    /// handshake target by mailbox tests so the end-to-end dispatch
-    /// pipe is exercised without a real command. Handler replies
-    /// [`ContextError::NotImplemented`](scp_protocol::context::ContextError::NotImplemented).
-    Placeholder {
-        /// Oneshot reply channel.
-        reply: oneshot::Sender<Result<(), ContextError>>,
-    },
-
     /// Verifies a batch of payment receipts against the configured
     /// payment adapter. Mirrors
-    /// [`ContextManager::verify_payment_receipts`](crate::context::economy_helpers::verify_payment_receipts).
+    /// [`economy_helpers::verify_payment_receipts`](crate::context::economy_helpers::verify_payment_receipts).
     ///
     /// Read-only — the handler returns
     /// [`Outcome::ok`](crate::context::actor::Outcome::ok) and reports
@@ -1863,18 +1825,8 @@ pub struct RecoveryNotifyContactPayload {
 /// checkpoints + cosignatures, compromise-recovery epoch advance, and
 /// recovery notifications (spec §9.12).
 pub enum TrustRecoveryCommand {
-    /// Placeholder — reserved for Phase 2 actor-mailbox wiring of
-    /// ADR-049 (post-review-round-1 plan). Used as a no-op
-    /// handshake target by mailbox tests so the end-to-end dispatch
-    /// pipe is exercised without a real command. Handler replies
-    /// [`ContextError::NotImplemented`](scp_protocol::context::ContextError::NotImplemented).
-    Placeholder {
-        /// Oneshot reply channel.
-        reply: oneshot::Sender<Result<(), ContextError>>,
-    },
-
     /// Creates a governance-aware checkpoint for a context. Mirrors
-    /// [`ContextManager::create_governance_checkpoint`](crate::context::trust_recovery_helpers::create_governance_checkpoint).
+    /// [`trust_recovery_helpers::create_governance_checkpoint`](crate::context::trust_recovery_helpers::create_governance_checkpoint).
     CreateGovernanceCheckpoint {
         /// Boxed owned payload.
         payload: Box<CreateGovernanceCheckpointPayload>,
@@ -1886,7 +1838,7 @@ pub enum TrustRecoveryCommand {
 
     /// Adds a cosignature to an existing checkpoint and re-evaluates
     /// attestation status. Mirrors
-    /// [`ContextManager::add_checkpoint_cosignature`](crate::context::trust_recovery_helpers::add_checkpoint_cosignature).
+    /// [`trust_recovery_helpers::add_checkpoint_cosignature`](crate::context::trust_recovery_helpers::add_checkpoint_cosignature).
     ///
     /// The caller supplies a mutable checkpoint (by owned value) and
     /// the cosignature; the handler applies the cosignature on success
@@ -1916,7 +1868,7 @@ pub enum TrustRecoveryCommand {
 
     /// Advances the MLS epoch for a context as part of compromise
     /// recovery (spec §9.12 step 2). Mirrors
-    /// [`ContextManager::recovery_advance_epoch`](crate::context::trust_recovery_helpers::recovery_advance_epoch).
+    /// [`trust_recovery_helpers::recovery_advance_epoch`](crate::context::trust_recovery_helpers::recovery_advance_epoch).
     RecoveryAdvanceEpoch {
         /// Context identifier string.
         context_id: String,
@@ -1926,7 +1878,7 @@ pub enum TrustRecoveryCommand {
 
     /// Sends a recovery notification directly through a named context
     /// (spec §9.12 step 5 — context already known). Mirrors
-    /// [`ContextManager::recovery_send_notification`](crate::context::trust_recovery_helpers::recovery_send_notification).
+    /// [`trust_recovery_helpers::recovery_send_notification`](crate::context::trust_recovery_helpers::recovery_send_notification).
     RecoverySendNotification {
         /// Boxed owned payload (carries the signing key bytes).
         payload: Box<RecoverySendNotificationPayload>,
@@ -1936,7 +1888,7 @@ pub enum TrustRecoveryCommand {
 
     /// Sends a recovery notification to a contact DID by finding a
     /// shared context. Mirrors
-    /// [`ContextManager::recovery_notify_contact`](crate::context::trust_recovery_helpers::recovery_notify_contact).
+    /// [`trust_recovery_helpers::recovery_notify_contact`](crate::context::trust_recovery_helpers::recovery_notify_contact).
     RecoveryNotifyContact {
         /// Boxed owned payload (carries the signing key bytes).
         payload: Box<RecoveryNotifyContactPayload>,
@@ -1948,28 +1900,18 @@ pub enum TrustRecoveryCommand {
 /// See [`ContextCommand::Standing`]. Real variants cover the public
 /// methods on [`crate::context::standing_helpers`].
 pub enum StandingCommand {
-    /// Placeholder — reserved for Phase 2 actor-mailbox wiring of
-    /// ADR-049 (post-review-round-1 plan). Used as a no-op
-    /// handshake target by mailbox tests so the end-to-end dispatch
-    /// pipe is exercised without a real command. Handler replies
-    /// [`ContextError::NotImplemented`](scp_protocol::context::ContextError::NotImplemented).
-    Placeholder {
-        /// Oneshot reply channel.
-        reply: oneshot::Sender<Result<(), ContextError>>,
-    },
-
     /// Get-or-create a standing bilateral context between two identities
-    /// (spec §5.12.4 — contact graph). Mirrors
-    /// [`ContextManager::standing_context`](crate::context::standing_helpers::standing_context).
+    /// (spec §5.12.6 — contact graph). Mirrors the supervisor's
+    /// `Supervisor::standing_context` get-or-create method.
     ///
-    /// Idempotent at the legacy-method level — a concurrent call
+    /// Idempotent at the underlying-method level — a concurrent call
     /// returning `Active` or `Creating` surfaces the same context ID
     /// without error.
     ///
     /// # Not a saga
     ///
     /// The method internally calls
-    /// [`ContextManager::create_context`](crate::context::supervisor::Supervisor::create_context).
+    /// [`Supervisor::create_context`](crate::context::supervisor::Supervisor::create_context).
     /// Standing-pair creation is single-context async creation (create +
     /// add_member + Welcome + consent-on-receipt; spec §5.15.8) routed
     /// directly through that path — NOT a 2-phase-commit saga FSM.
@@ -1979,14 +1921,14 @@ pub enum StandingCommand {
         /// Remote peer DID.
         peer_did: scp_identity::DID,
         /// Oneshot reply channel. `Ok(String)` carries the
-        /// deterministic standing context ID; the legacy method returns
-        /// the same ID whether the context already existed or was
-        /// freshly created.
+        /// deterministic standing context ID; the underlying method
+        /// returns the same ID whether the context already existed or
+        /// was freshly created.
         reply: oneshot::Sender<Result<String, ContextError>>,
     },
 
     /// Returns the number of tracked standing contexts. Mirrors
-    /// [`ContextManager::standing_context_count`](crate::context::standing_helpers::standing_context_count).
+    /// [`standing_helpers::standing_context_count`](crate::context::standing_helpers::standing_context_count).
     /// Read-only.
     StandingContextCount {
         /// Oneshot reply channel.
@@ -1995,7 +1937,7 @@ pub enum StandingCommand {
 
     /// Returns `true` iff a standing context exists for the given peer.
     /// Mirrors
-    /// [`ContextManager::has_standing_context`](crate::context::standing_helpers::has_standing_context).
+    /// [`standing_helpers::has_standing_context`](crate::context::standing_helpers::has_standing_context).
     /// Read-only.
     HasStandingContext {
         /// Candidate peer DID.
@@ -2005,7 +1947,7 @@ pub enum StandingCommand {
     },
 
     /// Registers an existing context as a standing context. Mirrors
-    /// [`ContextManager::register_standing_context`](crate::context::standing_helpers::register_standing_context).
+    /// [`standing_helpers::register_standing_context`](crate::context::standing_helpers::register_standing_context).
     /// Called during SDK init to restore the contact-graph index from a
     /// persisted snapshot.
     RegisterStandingContext {
@@ -2016,7 +1958,7 @@ pub enum StandingCommand {
     },
 
     /// Reconnects transport for every standing context. Mirrors
-    /// [`ContextManager::reconnect_all_standing`](crate::context::standing_helpers::reconnect_all_standing).
+    /// [`standing_helpers::reconnect_all_standing`](crate::context::standing_helpers::reconnect_all_standing).
     /// Returns the number of contexts that were successfully
     /// reconnected.
     ReconnectAllStanding {
@@ -2085,19 +2027,6 @@ pub struct TtlTimerPayload {
 /// synchronously. Full timer-owning actor logic migrates with plan row
 /// 11.
 pub enum TtlCloseCommand {
-    /// Placeholder — reserved for Phase 2 actor-mailbox wiring of
-    /// ADR-049 (post-review-round-1 plan). Used by the actor's
-    /// `run()` skeleton dispatch as a no-op handshake target so the
-    /// mailbox machinery exercises end-to-end without a real
-    /// command. Handler replies
-    /// [`ContextError::NotImplemented`](scp_protocol::context::ContextError::NotImplemented)
-    /// and returns `Outcome::err`.
-    Placeholder {
-        /// Oneshot reply channel. Handler stub sends
-        /// `Err(ContextError::NotImplemented(..))` back.
-        reply: oneshot::Sender<Result<(), ContextError>>,
-    },
-
     /// Fires a single TTL tick on THIS actor: evaluate whether the
     /// context's TTL has elapsed and, if so, run the close pipeline on the
     /// actor-owned state.
@@ -2193,7 +2122,7 @@ pub enum TtlCloseCommand {
 
 /// See [`ContextCommand::Tools`]. Real variants cover every public
 /// method on [`crate::context::tools_helpers`] EXCEPT
-/// [`ContextManager::invoke_tool_with_economy`](crate::context::supervisor::Supervisor::invoke_tool_with_economy)
+/// [`Supervisor::invoke_tool_with_economy`](crate::context::supervisor::Supervisor::invoke_tool_with_economy)
 /// — that method is the cross-context tool-invocation entry and carries
 /// a generic executor closure `F: FnOnce(Value) -> Fut` which cannot
 /// cross the actor mailbox. The cross-context saga itself is wired (§6.2.4,
@@ -2210,19 +2139,9 @@ pub enum TtlCloseCommand {
 /// [`crate::context::tools_helpers`] migrate here because they are the
 /// supervisor-observable tool surface.
 pub enum ToolsCommand {
-    /// Placeholder — reserved for Phase 2 actor-mailbox wiring of
-    /// ADR-049 (post-review-round-1 plan). Used as a no-op
-    /// handshake target by mailbox tests so the end-to-end dispatch
-    /// pipe is exercised without a real command. Handler replies
-    /// [`ContextError::NotImplemented`](scp_protocol::context::ContextError::NotImplemented).
-    Placeholder {
-        /// Oneshot reply channel.
-        reply: oneshot::Sender<Result<(), ContextError>>,
-    },
-
     /// Try to consume one hard-rate-limit token for the given
     /// `(context_id, did)` pair (async variant). Mirrors
-    /// [`ContextManager::try_consume_hard_rate_limit`](crate::context::tools_helpers::try_consume_hard_rate_limit).
+    /// [`tools_helpers::try_consume_hard_rate_limit`](crate::context::tools_helpers::try_consume_hard_rate_limit).
     ///
     /// Reply carries `Ok(true)` iff a token was consumed or the context
     /// is unknown (pass-through contract on unknown contexts — matches
@@ -2240,7 +2159,7 @@ pub enum ToolsCommand {
     },
 
     /// Refund one hard-rate-limit token (async variant). Mirrors
-    /// [`ContextManager::refund_hard_rate_limit`](crate::context::tools_helpers::refund_hard_rate_limit).
+    /// [`tools_helpers::refund_hard_rate_limit`](crate::context::tools_helpers::refund_hard_rate_limit).
     /// No-op on unknown context.
     RefundHardRateLimit {
         /// Context identifier string.
@@ -2308,11 +2227,14 @@ pub enum ToolsCommand {
 /// Commit 7 lands the real read variants. Commit 12c.7 deletes the
 /// transitional `QueryStateView` borrow adapter and routes the
 /// `&PerContextState` + shared event-log provider directly into the
-/// query handler. Variants that mutate state (even if they live in
-/// `manager/queries.rs` today — `drain_events`, access-key management,
-/// `compare_remote_checkpoint`, `prove_event_*`, etc.) are NOT migrated
-/// here and continue to route through the legacy `ContextManager` until
-/// their respective handler commits (8-11).
+/// query handler. Variants that mutate state (`drain_events`, access-key
+/// management, `compare_remote_checkpoint`, etc.) are NOT migrated here —
+/// they are carried by their own command families
+/// (`MessagingCommand::DrainEvents` / `::CompareRemoteCheckpoint`, the
+/// `LifecycleCommand` access-key variants) and reach the runtime through
+/// the command-dispatch shim. Read-only Merkle proofs (`prove_event_*`)
+/// are NOT commands at all: they are served directly by free functions in
+/// `queries_helpers` (provider-backed), with no command variant.
 pub enum QueriesCommand {
     /// Current lifecycle [`ContextState`](scp_protocol::context::ContextState)
     /// for this actor's context. Read-only — the handler reads the
@@ -2367,7 +2289,7 @@ pub enum QueriesCommand {
         /// Context identifier string.
         context_id: String,
         /// Oneshot reply channel. `Ok(None)` iff the context is unknown
-        /// (matches the legacy `ContextManager::member_count` contract).
+        /// (matches the `Supervisor::member_count` contract).
         reply: oneshot::Sender<Result<Option<usize>, ContextError>>,
     },
     /// Membership predicate — `true` iff `did` is currently a member.
@@ -2582,8 +2504,9 @@ pub enum QueriesCommand {
 ///
 /// Carries the `Send` reservation handles the caller-context actor staged but
 /// did NOT apply: the escrow + outbound rate-limit reservation rolled into the
-/// existing [`ToolEconomyReservation`]. The supervisor FSM (slice 5) holds this
-/// across the saga; the [`ToolEconomyReservation`]'s
+/// existing [`ToolEconomyReservation`](crate::context::tools_helpers::ToolEconomyReservation).
+/// The supervisor FSM (slice 5) holds this across the saga; the
+/// [`ToolEconomyReservation`](crate::context::tools_helpers::ToolEconomyReservation)'s
 /// `#[must_use]` drop guard releases the held escrow/rate-limit on every
 /// terminal non-commit path (abort, timeout, panic — spec §6.2.4 "Reservation
 /// release on every terminal path"). On Commit-A the FSM settles it.
@@ -2787,7 +2710,8 @@ pub enum CommitBReserveOutcome {
     /// receipt are re-emitted verbatim. The FSM skips the executor and treats
     /// this as a Commit-B success.
     AlreadyCommitted {
-        /// The original signed receipt bytes (JCS of [`CrossContextToolReceipt`]).
+        /// The original signed receipt bytes (JCS of
+        /// [`CrossContextToolReceipt`](scp_protocol::context::tools::CrossContextToolReceipt)).
         receipt: Vec<u8>,
         /// The captured tool output bytes (the receipt's `output_jcs`).
         output_bytes: Vec<u8>,
@@ -2805,7 +2729,8 @@ pub enum CommitBReserveOutcome {
 /// `tool_invoked_event_id` — and the tool is NOT re-invoked.
 #[derive(Debug)]
 pub struct CommitBSettleOutcome {
-    /// The target's signed receipt bytes (JCS of [`CrossContextToolReceipt`]).
+    /// The target's signed receipt bytes (JCS of
+    /// [`CrossContextToolReceipt`](scp_protocol::context::tools::CrossContextToolReceipt)).
     pub receipt: Vec<u8>,
     /// The captured tool output bytes the FSM forwards to Commit-A.
     pub output_bytes: Vec<u8>,
@@ -2934,7 +2859,9 @@ pub enum SagaPhaseMessage {
     ///
     /// Durably captures the output keyed by `SagaId` (so a later replay
     /// re-emits it), `SagaId`-idempotently appends `ToolInvoked` → a stable
-    /// `tool_invoked_event_id`, signs the [`CrossContextToolReceipt`] over the
+    /// `tool_invoked_event_id`, signs the
+    /// [`CrossContextToolReceipt`](scp_protocol::context::tools::CrossContextToolReceipt)
+    /// over the
     /// staged `recorded_nonce` / `recorded_chain_depth` / `recorded_timestamp_ms`
     /// plus `output_hash` plus the event id using `target_signing_key`, Class-S
     /// sync-persists fail-closed, and replies the receipt + output bytes. A
@@ -3174,16 +3101,10 @@ mod tests {
         assert!(!cmd.is_shutdown());
 
         let (tx, _rx) = oneshot::channel();
-        let cmd = ContextCommand::Messaging(MessagingCommand::Placeholder { reply: tx });
+        let cmd = ContextCommand::Queries(QueriesCommand::MemberCount {
+            context_id: "ctx".to_owned(),
+            reply: tx,
+        });
         assert!(!cmd.is_shutdown());
-    }
-
-    #[test]
-    fn sub_enum_placeholders_carry_reply_channels() {
-        // Compile-time witness: every placeholder variant carries a
-        // oneshot reply channel with the expected type.
-        let (tx, rx) = oneshot::channel::<Result<(), ContextError>>();
-        let _ = ContextCommand::Messaging(MessagingCommand::Placeholder { reply: tx });
-        drop(rx);
     }
 }

--- a/crates/scp-runtime/src/context/actor/deps.rs
+++ b/crates/scp-runtime/src/context/actor/deps.rs
@@ -20,28 +20,28 @@
 //! # Commit 12a.5 expansion
 //!
 //! Commit 12a.5 of ADR-049 (pre-work for handler body migration)
-//! extends the bundle with every cross-cutting collaborator the legacy
-//! `ContextManager` handler submodules reach via `self.X`:
+//! extended the bundle with every cross-cutting collaborator the
+//! deleted `ContextManager` handler submodules reached via `self.X`:
 //!
-//! - `clock` — wall-clock source. Legacy: `ContextManager::clock`.
+//! - `clock` — wall-clock source. Formerly `ContextManager::clock`.
 //! - `event_tx` — optional fan-out channel for external `ContextEvent`
-//!   subscribers (webhook dispatcher in `scp-node`). Legacy:
+//!   subscribers (webhook dispatcher in `scp-node`). Formerly
 //!   `ContextManager::event_tx`. `Option` because not every embedder
-//!   wires a subscriber; legacy treats `None` as "drop silently."
+//!   wires a subscriber; the legacy handler treated `None` as "drop silently."
 //! - `key_resolver` — DID → Ed25519 verifying-key map used by UCAN /
-//!   governance vote verification. Legacy: `ContextManager::key_resolver`.
+//!   governance vote verification. Formerly `ContextManager::key_resolver`.
 //! - `payment_adapter` — optional economy adapter for the 9-step paid
-//!   action flow (spec §19.2.2). Legacy:
+//!   action flow (spec §19.2.2). Formerly
 //!   `ContextManager::payment_adapter`. `Option` because "free context"
 //!   is a valid configuration.
 //!
 //! # Commit 12b.2a expansion
 //!
 //! Commit 12b.2a of ADR-049 (actor-owned-state infrastructure) adds one
-//! additional cross-cutting collaborator that handler bodies need once
-//! they stop delegating to `ContextManager`:
+//! additional cross-cutting collaborator that handler bodies needed once
+//! they stopped delegating to the legacy manager:
 //!
-//! - `local_dids` — `Arc<ArcSwap<HashSet<DID>>>`. Legacy:
+//! - `local_dids` — `Arc<ArcSwap<HashSet<DID>>>`. Formerly
 //!   `ContextManager::local_dids` (`RwLock<HashSet<DID>>`). Rewritten to
 //!   `ArcSwap` here because the read path is on the hot path of every
 //!   `deliver_incoming` (resolve local member for sender-key layer) —
@@ -77,15 +77,15 @@
 //!   directly"). Cross-context work goes through
 //!   `SupervisorHandle::start_saga`.
 //! - `task_set` / `next_generation` — supervisor-scoped lifecycle
-//!   state that migrates with the actor run-loop in commit 12b/c.
+//!   state, held on the supervisor side.
 //! - `consequence_rules` — per-context state stored in `PerContextState`,
 //!   not a cross-cutting dep.
 //!
-//! The new fields are wired on the supervisor side at actor-spawn time
-//! (shim wiring lives behind the `testing` feature until the legacy
-//! manager is deleted in commit 12). Handler bodies do not yet read the
-//! new fields — 12b+ performs the mechanical migration from
-//! `view.manager().foo` → `deps.foo`.
+//! These `ActorDeps` fields are wired on the supervisor side at
+//! actor-spawn time and read directly by the handler bodies — e.g.
+//! `deps.event_tx` in governance, `deps.payment_adapter` in saga, and
+//! `deps.local_dids` in queries. The former `view.manager().foo`
+//! indirection and the legacy manager it reached through are gone.
 
 use std::collections::HashSet;
 use std::sync::Arc;
@@ -125,7 +125,7 @@ use crate::economy::adapter::PaymentAdapterDyn;
 /// hold its own clones of the individual handles.
 pub struct ActorDeps {
     /// MLS crypto provider — owns the per-context MLS group + sender-key
-    /// state map. Legacy: `ContextManager::crypto`. Held on
+    /// state map. Formerly `ContextManager::crypto`. Held on
     /// [`Supervisor`](crate::context::supervisor::Supervisor) directly
     /// during the helper-migration window; cloned into each actor's
     /// `ActorDeps` at spawn time so handler bodies can call
@@ -162,7 +162,7 @@ pub struct ActorDeps {
     /// actor's `OpenMlsBackend` is per-actor but reads/writes the same
     /// underlying KV via this adapter).
     pub mls_storage: Arc<dyn OpenMlsStorageAdapter>,
-    /// Wall-clock source. Legacy: `ContextManager::clock`
+    /// Wall-clock source. Formerly `ContextManager::clock`
     /// (`Arc<dyn scp_primitives::Clock>`, default
     /// [`scp_primitives::SystemClock`]). Every handler that computes
     /// pricing windows, velocity tracking, TTL comparisons, UCAN expiry
@@ -172,36 +172,37 @@ pub struct ActorDeps {
     pub clock: Arc<dyn Clock>,
     /// Optional fan-out channel for `(context_id, ContextEvent)` pairs
     /// sent to external subscribers (the webhook dispatcher in
-    /// `scp-node`, SDK event streams). Legacy:
+    /// `scp-node`, SDK event streams). Formerly
     /// `ContextManager::event_tx`. `None` in embedders that do not
     /// subscribe to context events — handlers check `Option::is_some`
-    /// before sending and drop silently otherwise, matching legacy.
+    /// before sending and drop silently otherwise, matching the legacy behavior.
     ///
     /// Lagging receivers lose events (bounded channel) — delivery is
     /// best-effort.
     pub event_tx: Option<tokio::sync::broadcast::Sender<(String, ContextEvent)>>,
     /// DID → Ed25519 verifying-key resolver used by governance vote
     /// verification (spec §5.9, ADR-031) and UCAN proof validation.
-    /// Legacy: `ContextManager::key_resolver` (typealias
+    /// Formerly `ContextManager::key_resolver` (typealias
     /// `Arc<dyn Fn(&DID) -> Option<VerifyingKey> + Send + Sync>`).
     pub key_resolver: KeyResolver,
     /// Optional economy adapter for the 9-step paid action flow
-    /// (spec §19.2.2). Legacy: `ContextManager::payment_adapter`.
+    /// (spec §19.2.2). Formerly `ContextManager::payment_adapter`.
     /// `None` for "free context" configurations — handlers skip the
     /// escrow path and fall through to budget-only enforcement.
     pub payment_adapter: Option<Arc<dyn PaymentAdapterDyn>>,
     /// DIDs controlled by the local node/SDK. `ArcSwap` for lock-free
-    /// reads on every `deliver_incoming` (resolve local member). Legacy:
-    /// [`crate::context::supervisor::Supervisor::local_dids`]
-    /// (`RwLock<HashSet<DID>>`). The actor model hoists this to the
-    /// supervisor so every actor shares the same snapshot without each
-    /// one carrying its own `RwLock` — the `Arc<ArcSwap<_>>` is
-    /// clone-cheap and every actor gets a snapshot reference at spawn
-    /// time.
+    /// reads on every `deliver_incoming` (resolve local member).
+    /// Sourced from
+    /// [`crate::context::supervisor::Supervisor::local_dids`]: the
+    /// actor model hoists this set to the supervisor (it was a
+    /// per-manager `RwLock<HashSet<DID>>` before the actor refactor)
+    /// so every actor shares the same snapshot without each one
+    /// carrying its own lock — the `Arc<ArcSwap<_>>` is clone-cheap
+    /// and every actor gets a snapshot reference at spawn time.
     ///
     /// Added in commit 12b.2a of ADR-049. Read by the messaging
-    /// handler's `deliver_incoming` body (landing 12b.2b) to resolve
-    /// which local DID the incoming envelope addresses.
+    /// handler's `deliver_incoming` body to resolve which local DID
+    /// the incoming envelope addresses.
     pub local_dids: Arc<ArcSwap<HashSet<DID>>>,
     /// Unforgeable capability token proving which identity owns this
     /// actor (ADR-049 §5). Minted fresh per-actor at spawn time in

--- a/crates/scp-runtime/src/context/actor/handle.rs
+++ b/crates/scp-runtime/src/context/actor/handle.rs
@@ -330,7 +330,19 @@ impl ContextActorHandle {
 #[allow(clippy::unwrap_used, clippy::expect_used, clippy::panic)]
 mod tests {
     use super::*;
-    use crate::context::actor::commands::MessagingCommand;
+    use crate::context::actor::commands::QueriesCommand;
+
+    /// Build the read-only smoke-test command used across these plumbing
+    /// tests: a `MemberCount` query is side-effect-free and carries a
+    /// unit-shaped `Result<Option<usize>, _>` reply, so it exercises the
+    /// mailbox/handle machinery without invoking any real handler here
+    /// (these tests use hand-rolled pseudo-actors, not the dispatch loop).
+    fn smoke_query(reply: oneshot::Sender<Result<Option<usize>, ContextError>>) -> ContextCommand {
+        ContextCommand::Queries(QueriesCommand::MemberCount {
+            context_id: "smoke".to_owned(),
+            reply,
+        })
+    }
 
     #[test]
     fn send_timeout_is_30_seconds() {
@@ -346,7 +358,7 @@ mod tests {
         drop(rx);
         let handle = ContextActorHandle::from_sender(tx);
         let err = handle
-            .send(|reply| ContextCommand::Messaging(MessagingCommand::Placeholder { reply }))
+            .send(smoke_query)
             .await
             .expect_err("closed mailbox must error");
         match err {
@@ -367,11 +379,7 @@ mod tests {
         let (tx, rx) = mpsc::channel::<ContextCommand>(1);
         drop(rx);
         let handle = ContextActorHandle::from_sender(tx);
-        let result: Result<(), _> = handle
-            .send_recover_on_failure(|reply| {
-                ContextCommand::Messaging(MessagingCommand::Placeholder { reply })
-            })
-            .await;
+        let result: Result<Option<usize>, _> = handle.send_recover_on_failure(smoke_query).await;
         let (err, recovered) = result.expect_err("closed mailbox must error");
         match err {
             ContextError::ActorBusy(msg) => {
@@ -383,7 +391,7 @@ mod tests {
         assert!(
             matches!(
                 *cmd,
-                ContextCommand::Messaging(MessagingCommand::Placeholder { .. })
+                ContextCommand::Queries(QueriesCommand::MemberCount { .. })
             ),
             "the recovered command must be the SAME command we attempted to send"
         );
@@ -395,17 +403,13 @@ mod tests {
         let (tx, mut rx) = mpsc::channel::<ContextCommand>(1);
         let handle = ContextActorHandle::from_sender(tx);
         let actor = tokio::spawn(async move {
-            if let Some(ContextCommand::Messaging(MessagingCommand::Placeholder { reply })) =
+            if let Some(ContextCommand::Queries(QueriesCommand::MemberCount { reply, .. })) =
                 rx.recv().await
             {
-                let _ = reply.send(Ok(()));
+                let _ = reply.send(Ok(None));
             }
         });
-        let result: Result<(), _> = handle
-            .send_recover_on_failure(|reply| {
-                ContextCommand::Messaging(MessagingCommand::Placeholder { reply })
-            })
-            .await;
+        let result: Result<Option<usize>, _> = handle.send_recover_on_failure(smoke_query).await;
         assert!(result.is_ok(), "delivered command must return Ok");
         actor.await.unwrap();
     }
@@ -418,16 +422,14 @@ mod tests {
 
         let actor_task = tokio::spawn(async move {
             let cmd = rx.recv().await.expect("actor received a command");
-            if let ContextCommand::Messaging(MessagingCommand::Placeholder { reply }) = cmd {
-                let _ = reply.send(Ok(()));
+            if let ContextCommand::Queries(QueriesCommand::MemberCount { reply, .. }) = cmd {
+                let _ = reply.send(Ok(None));
             } else {
                 panic!("unexpected command variant");
             }
         });
 
-        let result: Result<(), ContextError> = handle
-            .send(|reply| ContextCommand::Messaging(MessagingCommand::Placeholder { reply }))
-            .await;
+        let result: Result<Option<usize>, ContextError> = handle.send(smoke_query).await;
         assert!(result.is_ok(), "roundtrip must succeed, got {result:?}");
         actor_task.await.unwrap();
     }

--- a/crates/scp-runtime/src/context/actor/handlers/broadcast.rs
+++ b/crates/scp-runtime/src/context/actor/handlers/broadcast.rs
@@ -14,7 +14,7 @@
 //!
 //! # Publish + key-custody plumbing (two-phase reservation)
 //!
-//! The publish entry points on `ContextManager` take
+//! The publish entry points in `broadcast_helpers` take
 //! `custody: &impl KeyCustody`. Because
 //! [`KeyCustody`](scp_platform::KeyCustody) uses RPITIT (not
 //! `dyn`-safe), the actor mailbox cannot carry a custody reference
@@ -73,7 +73,6 @@ async fn dispatch_inner(
     cmd: BroadcastCommand,
 ) -> Outcome<()> {
     match cmd {
-        BroadcastCommand::Placeholder { reply } => reply_not_implemented(reply),
         BroadcastCommand::SubscribeBroadcast { payload, reply } => {
             handle_subscribe_broadcast(cell, deps, *payload, reply).await
         }
@@ -563,12 +562,4 @@ fn outcome_error_sketch(err: &ContextError) -> ContextError {
         ContextError::NotImplemented(msg) => ContextError::NotImplemented(msg.clone()),
         other => ContextError::CryptoFailed(format!("{other}")),
     }
-}
-
-fn reply_not_implemented(reply: oneshot::Sender<Result<(), ContextError>>) -> Outcome<()> {
-    const MSG: &str = "BroadcastCommand::Placeholder — real variants migrate in commit 11 of \
-                       ADR-049; Placeholder retained for commit-6 compile stability and \
-                       deleted in commit 12 with the shim";
-    let _ = reply.send(Err(ContextError::NotImplemented(MSG.to_owned())));
-    Outcome::err(ContextError::NotImplemented(MSG.to_owned()))
 }

--- a/crates/scp-runtime/src/context/actor/handlers/economy.rs
+++ b/crates/scp-runtime/src/context/actor/handlers/economy.rs
@@ -18,8 +18,6 @@ use crate::context::actor::commands::EconomyCommand;
 use crate::context::actor::deps::ActorDeps;
 use crate::context::actor::outcome::Outcome;
 use crate::economy::receipt::ReceiptVerificationError;
-use scp_protocol::context::ContextError;
-use tokio::sync::oneshot;
 
 /// Per-call transport budget for economy handlers. Plan §"Transport
 /// timeouts inside actor handlers": 30 seconds.
@@ -47,7 +45,6 @@ pub(crate) async fn dispatch(
 
 async fn dispatch_inner(deps: &ActorDeps, cmd: EconomyCommand) -> Outcome<()> {
     match cmd {
-        EconomyCommand::Placeholder { reply } => reply_not_implemented(reply),
         EconomyCommand::VerifyPaymentReceipts { receipts, reply } => {
             handle_verify_payment_receipts(deps, *receipts, reply).await
         }
@@ -90,11 +87,4 @@ async fn handle_verify_payment_receipts(
     let _ = reply.send(results);
     // Verify payment receipts is a pure read — mutated=false.
     Outcome::ok(())
-}
-
-fn reply_not_implemented(reply: oneshot::Sender<Result<(), ContextError>>) -> Outcome<()> {
-    const MSG: &str = "EconomyCommand::Placeholder — mailbox-pipe smoke target; \
-                       no real work performed";
-    let _ = reply.send(Err(ContextError::NotImplemented(MSG.to_owned())));
-    Outcome::err(ContextError::NotImplemented(MSG.to_owned()))
 }

--- a/crates/scp-runtime/src/context/actor/handlers/governance.rs
+++ b/crates/scp-runtime/src/context/actor/handlers/governance.rs
@@ -12,8 +12,7 @@
 //! [`crate::context::governance_helpers`](crate::context::governance_helpers).
 //! The migration-window shim — `dispatch_from_shim` and the
 //! supervisor-shape `handle_*` helpers — has been deleted at Phase 2A
-//! finalization. The `Placeholder` variant remains as the mailbox-test
-//! handshake target.
+//! finalization.
 //!
 //! # Transport-timeout budget
 //!
@@ -76,11 +75,8 @@ pub(crate) async fn dispatch(
     Box::pin(dispatch_state(cell, deps, cmd)).await
 }
 
-/// Actor-shape variant dispatch. Every governance variant now takes
-/// state + deps directly. Only the no-op `Placeholder` variant
-/// (commit-6 mailbox-test handshake) returns `NotImplemented`
-/// synchronously; deleted with the `Placeholder` itself at Phase 2A
-/// finalization.
+/// Actor-shape variant dispatch. Every governance variant takes
+/// state + deps directly.
 #[allow(
     clippy::too_many_lines,
     reason = "exhaustive GovernanceCommand match — splitting loses the \
@@ -213,9 +209,6 @@ async fn dispatch_state(
         GovernanceCommand::StartTimeoutTask { reply } => {
             handle_start_timeout_task_actor(cell, deps, reply).await
         }
-        // Placeholder is a no-op handshake target reserved for mailbox
-        // tests. Returns NotImplemented synchronously; no state mutation.
-        GovernanceCommand::Placeholder { reply } => reply_not_implemented(reply),
     }
 }
 
@@ -755,14 +748,6 @@ async fn handle_apply_pending_economic_policy_change_actor(
     };
     let _ = reply.send(reply_result);
     outcome
-}
-
-fn reply_not_implemented(reply: oneshot::Sender<Result<(), ContextError>>) -> Outcome<()> {
-    const MSG: &str = "GovernanceCommand::Placeholder — real variants migrate in commit 10 of \
-                       ADR-049; Placeholder retained for commit-6 compile stability and \
-                       deleted in commit 12 with the shim";
-    let _ = reply.send(Err(ContextError::NotImplemented(MSG.to_owned())));
-    Outcome::err(ContextError::NotImplemented(MSG.to_owned()))
 }
 
 // ---------------------------------------------------------------------------

--- a/crates/scp-runtime/src/context/actor/handlers/lifecycle.rs
+++ b/crates/scp-runtime/src/context/actor/handlers/lifecycle.rs
@@ -87,7 +87,6 @@ async fn dispatch_actor_inner(
     cmd: LifecycleCommand,
 ) -> Outcome<()> {
     match cmd {
-        LifecycleCommand::Placeholder { reply } => reply_not_implemented(reply),
         LifecycleCommand::CreateContext { payload, reply } => {
             // Bootstrap variant must not reach the actor. The
             // supervisor routes Create / Import / Restore through
@@ -483,14 +482,6 @@ fn outcome_error_sketch(err: &ContextError) -> ContextError {
         ContextError::InvalidState(msg) => ContextError::InvalidState(msg.clone()),
         other => ContextError::CryptoFailed(format!("{other}")),
     }
-}
-
-fn reply_not_implemented(reply: oneshot::Sender<Result<(), ContextError>>) -> Outcome<()> {
-    const MSG: &str = "LifecycleCommand::Placeholder — placeholder handshake \
-                       variant; real lifecycle command handling is not routed \
-                       through this arm";
-    let _ = reply.send(Err(ContextError::NotImplemented(MSG.to_owned())));
-    Outcome::err(ContextError::NotImplemented(MSG.to_owned()))
 }
 
 // ---------------------------------------------------------------------------

--- a/crates/scp-runtime/src/context/actor/handlers/lifecycle_control.rs
+++ b/crates/scp-runtime/src/context/actor/handlers/lifecycle_control.rs
@@ -8,18 +8,18 @@
 //! plan section titles in quoted form.
 #![allow(clippy::doc_markdown, clippy::too_long_first_doc_paragraph)]
 //!
-//! These handlers respond to supervisor-originated Pause / Resume /
-//! Shutdown / PersistSync commands. Commit 6 lands the dispatch stub
-//! that ACKS with `Ok(())` for the lifecycle control commands — the
-//! `BridgeInstanceCore::suspend()` default trait method sends `Pause`
-//! and `PersistSync` against the actor handle and expects an ack so
-//! the suspend flow completes.
+//! These handlers respond to supervisor-originated Pause / Shutdown /
+//! PersistSync / PrepareForReplace commands, running on actor-owned
+//! state: `Pause` flips `lifecycle_state` to `Closing` and `Shutdown`
+//! flips it to `Closed` through the actor's Class-C view (ADR-049 §9).
 //!
-//! The ack-with-`Ok` (rather than `NotImplemented`) keeps the suspend
-//! path from erroring out during commit 6. Actual persist-sync logic
-//! migrates in commit 11; before that, the handler has no persist
-//! buffer to flush because no state mutation has happened through the
-//! actor path yet.
+//! `PersistSync` acks with `Ok(())` (rather than `NotImplemented`) so
+//! the `BridgeInstanceCore::suspend()` default trait method — which
+//! sends `Pause` then `PersistSync` against the actor handle and
+//! expects acks — can complete its suspend sequence. That arm is a
+//! no-op today: handler mutations persist synchronously through the
+//! per-handler persistence helpers, so there is no separate actor-side
+//! persist buffer for `PersistSync` to flush.
 
 use scp_protocol::context::{ContextError, ContextState};
 
@@ -31,10 +31,10 @@ use crate::context::actor::state::ContextLifecycleState;
 
 /// Dispatch a [`LifecycleControlCommand`] against actor state.
 ///
-/// Commit 6 handles lifecycle control commands synchronously and with
-/// an `Ok` reply so the bridge's `suspend()` default body can complete.
-/// The state mutations (e.g. flipping `lifecycle_state` to `Closing`)
-/// are minimal and locally-owned — no persistence, no transport.
+/// Handles lifecycle control commands synchronously and with an `Ok`
+/// reply so the bridge's `suspend()` default body can complete. The
+/// state mutations (e.g. flipping `lifecycle_state` to `Closing`) are
+/// minimal and locally-owned — no persistence, no transport.
 pub(crate) async fn dispatch(
     cell: &mut ClassSCell,
     deps: &ActorDeps,
@@ -50,9 +50,10 @@ pub(crate) async fn dispatch(
             Outcome::ok_mutated(())
         }
         LifecycleControlCommand::PersistSync { reply } => {
-            // Commit 6: nothing to persist through the actor path yet
-            // because the legacy `ContextManager` still owns mutating
-            // paths. Acking with Ok matches the eventual semantics —
+            // Nothing to persist through a dedicated actor-side buffer:
+            // handler mutations persist synchronously via the
+            // per-handler persistence helpers, so no pending buffer
+            // remains to flush. Acking with Ok matches the semantics —
             // "persist buffer is empty, sync returns immediately".
             let _ = reply.send(Ok(()));
             Outcome::ok(())

--- a/crates/scp-runtime/src/context/actor/handlers/messaging.rs
+++ b/crates/scp-runtime/src/context/actor/handlers/messaging.rs
@@ -5,31 +5,31 @@
 //!
 //! # Phase 2A.7 — actor-shape dispatch
 //!
-//! The handler's primary entry point [`dispatch`] takes
-//! `(&mut PerContextState, &ActorDeps, &mut SendSequenceTracker,
-//! MessagingCommand)` and routes every variant through
-//! [`crate::context::messaging_helpers`] (the actor-shape messaging
-//! helpers). The shim entry point [`dispatch_from_shim`] remains during
-//! Phase 2A and routes through [`crate::context::messaging_helpers_legacy`]
-//! for callers that arrive via the supervisor mailbox-fallback path
-//! before a per-context actor exists.
+//! The handler's sole entry point [`dispatch`] takes
+//! `(&mut ClassSCell, &ActorDeps, MessagingCommand)` and routes every
+//! variant through [`crate::context::messaging_helpers`] (the
+//! actor-shape messaging helpers). The migration-window shim entry
+//! point (`dispatch_from_shim`) and the `messaging_helpers_legacy`
+//! module it routed through were deleted in Phase 2A finalization —
+//! `Supervisor::dispatch_command` is mailbox-only, and a missing actor
+//! surfaces a typed lookup-miss error.
 //!
 //! # Send-sequence tracker
 //!
-//! `send_tracker` is the actor-owned RAII rollback mechanism for
+//! `state.send_tracker` is the actor-owned RAII rollback mechanism for
 //! sequence reservations
 //! ([`SequenceReservation`](crate::context::actor::SequenceReservation)).
 //! The wire sequence is still driven by
-//! `MembershipState::next_sequence_number` inside the helper body
-//! during Phase 2A — `send_tracker` runs in parallel and rolls back
-//! on early `?` returns, transport timeouts, and crypto errors.
-//! Phase 2A finalization rewires the wire sequence onto `send_tracker`
+//! `MembershipState::next_sequence_number` inside the helper body —
+//! `send_tracker` runs in parallel and rolls back on early `?`
+//! returns, transport timeouts, and crypto errors. A follow-on Phase 2
+//! sub-chunk rewires the wire sequence onto `send_tracker`
 //! exclusively.
 //!
 //! # Transport-timeout budget
 //!
-//! [`HANDLER_TIMEOUT`] is the handler-level budget. The legacy
-//! `ContextManager` methods do not carry their own deadline — this is
+//! [`HANDLER_TIMEOUT`] is the handler-level budget. The predecessor
+//! monolithic context methods did not carry their own deadline — this is
 //! the new behaviour introduced by ADR-049 §7. 30 seconds matches the
 //! plan's "every transport and storage call inside a handler wraps
 //! `tokio::time::timeout(30s, ...)`" contract.
@@ -66,7 +66,6 @@ pub(crate) async fn dispatch(
     cmd: MessagingCommand,
 ) -> Outcome<()> {
     match cmd {
-        MessagingCommand::Placeholder { reply } => reply_not_implemented(reply),
         MessagingCommand::SendMessage { payload, reply } => {
             let p = *payload;
             // SendMessage reaches the spending-nonce leaf
@@ -271,10 +270,10 @@ async fn handle_send_message(
     // before the cell-taking `send_message` call.
     let mut view = cell.class_c_view();
     // Step 1: reserve + commit a sequence number against the
-    // actor-owned tracker. The Phase 2A wire sequence is still driven
-    // by `MembershipState::next_sequence_number` inside the helper —
+    // actor-owned tracker. The wire sequence is still driven by
+    // `MembershipState::next_sequence_number` inside the helper —
     // `send_tracker` is the actor-shape parallel that becomes
-    // authoritative in Phase 2A finalization. We commit the
+    // authoritative in a follow-on Phase 2 sub-chunk. We commit the
     // reservation BEFORE the helper call (not after) because the
     // helper takes `&mut state` which would conflict with an active
     // `&mut state.send_tracker` reservation guard. On failure we
@@ -752,13 +751,4 @@ fn outcome_error_sketch(err: &ContextError) -> ContextError {
         ContextError::ContextNotActive => ContextError::ContextNotActive,
         other => ContextError::CryptoFailed(format!("{other}")),
     }
-}
-
-fn reply_not_implemented(reply: oneshot::Sender<Result<(), ContextError>>) -> Outcome<()> {
-    const MSG: &str = "MessagingCommand::Placeholder — real variants \
-                       SendMessage/DeliverIncoming land in commit 8 of ADR-049; \
-                       Placeholder retained for commit-6 compile stability and \
-                       deleted in commit 12 with the shim";
-    let _ = reply.send(Err(ContextError::NotImplemented(MSG.to_owned())));
-    Outcome::err(ContextError::NotImplemented(MSG.to_owned()))
 }

--- a/crates/scp-runtime/src/context/actor/handlers/mod.rs
+++ b/crates/scp-runtime/src/context/actor/handlers/mod.rs
@@ -2,25 +2,34 @@
 //!
 //! Each submodule implements the handlers for one sub-enum of
 //! [`ContextCommand`](crate::context::actor::commands::ContextCommand).
-//! The dispatch entry point is a free `dispatch` function taking
-//! `(&mut PerContextState, &ActorDeps, SubCommand)` and returning an
+//! The dispatch entry point is a free `dispatch` function taking the
+//! actor-owned state cell and deps (`(&mut ClassSCell, &ActorDeps,
+//! SubCommand)` — `standing` takes deps only, its state being
+//! supervisor-scoped) and returning an
 //! [`Outcome`](crate::context::actor::outcome::Outcome).
 //!
-//! # Commit 6 scope
+//! # Dispatch shape
 //!
-//! Every submodule carries a `dispatch` stub that returns
-//! `Outcome::err(ContextError::NotImplemented(..))`. Real handler
-//! bodies migrate off `ContextManager` in commits 7-11; commit 6 lands
-//! only the dispatch shape so the actor's main loop compiles.
+//! Every submodule owns a real actor-shape `dispatch` that operates on
+//! the actor-owned state and awaits MLS/HPKE/transport/persistence
+//! operations, with two carve-outs: `queries` is read-only by
+//! construction, and the custody-bearing broadcast publish variants
+//! are rejected on the mailbox in favor of the supervisor's
+//! custody-generic two-phase path (see `broadcast.rs`). The
+//! migration-window stub bodies (which replied `NotImplemented`) have
+//! been deleted; the only surviving `NotImplemented` producer is the
+//! state-less
+//! [`ContextActor::skeleton_dispatch`](crate::context::actor::ContextActor)
+//! path exercised by the actor's smoke tests.
 //!
 //! # `unused_async` allow, scoped module-wide
 //!
-//! The dispatch signature is `async fn` by contract — handler bodies
-//! await MLS/HPKE/transport/persistence operations. The commit-6 stubs
-//! do not `await` because every variant returns `NotImplemented`
-//! synchronously. Allowing `clippy::unused_async` at the module level
-//! preserves the real signature so migrating handlers in later commits
-//! does not force a signature change at every call site.
+//! The dispatch signature is `async fn` by contract — most handler
+//! bodies await MLS/HPKE/transport/persistence operations. A few
+//! read-only variants complete synchronously; allowing
+//! `clippy::unused_async` at the module level keeps the uniform
+//! `async fn dispatch` signature across every submodule so the actor's
+//! main loop calls them identically.
 #![allow(
     clippy::unused_async,
     clippy::doc_markdown,

--- a/crates/scp-runtime/src/context/actor/handlers/standing.rs
+++ b/crates/scp-runtime/src/context/actor/handlers/standing.rs
@@ -1,6 +1,6 @@
 //! Standing-pair handlers — see
 //! [`StandingCommand`](crate::context::actor::commands::StandingCommand)
-//! and spec §5.15.7.
+//! and spec §5.12.6 (contact graph) / §5.15.8 (standing-pair creation).
 //!
 //! # Phase 2A.2 — actor-shape dispatch
 //!
@@ -13,8 +13,12 @@
 //! `Supervisor::dispatch_standing_direct` in
 //! [`crate::context::supervisor::supervisor`].
 //!
-//! The `StandingContext` get-or-create variant still routes through the
-//! legacy path, which is idempotent by construction.
+//! The `StandingContext` get-or-create variant is likewise
+//! supervisor-scoped: it always dispatches supervisor-direct through
+//! `Supervisor::dispatch_standing_direct` →
+//! `Supervisor::standing_context` (idempotent by construction) and
+//! never lands on a per-context actor mailbox — see the routing-error
+//! arm in [`dispatch`].
 
 use std::time::Duration;
 
@@ -37,7 +41,6 @@ pub async fn dispatch(deps: &ActorDeps, cmd: StandingCommand) -> Outcome<()> {
 
 async fn dispatch_inner(deps: &ActorDeps, cmd: StandingCommand) -> Outcome<()> {
     match cmd {
-        StandingCommand::Placeholder { reply } => reply_not_implemented(reply),
         StandingCommand::StandingContext { reply, .. } => {
             // `StandingContext` get-or-create is supervisor-scoped and is
             // ALWAYS dispatched supervisor-direct through
@@ -117,7 +120,7 @@ async fn handle_has_standing_context(
 }
 
 /// Handle [`StandingCommand::RegisterStandingContext`] — delegates to
-/// [`ContextManager::register_standing_context`](crate::context::standing_helpers::register_standing_context)
+/// [`standing_helpers::register_standing_context`](crate::context::standing_helpers::register_standing_context)
 /// under a 30s timeout. Always mutating.
 async fn handle_register_standing_context(
     deps: &ActorDeps,
@@ -147,7 +150,7 @@ async fn handle_register_standing_context(
 }
 
 /// Handle [`StandingCommand::ReconnectAllStanding`] — delegates to
-/// [`ContextManager::reconnect_all_standing`](crate::context::standing_helpers::reconnect_all_standing)
+/// [`standing_helpers::reconnect_all_standing`](crate::context::standing_helpers::reconnect_all_standing)
 /// under a 30s timeout. Always mutating.
 async fn handle_reconnect_all_standing(
     deps: &ActorDeps,
@@ -193,12 +196,4 @@ fn outcome_error_sketch(err: &ContextError) -> ContextError {
         ContextError::NotImplemented(msg) => ContextError::NotImplemented(msg.clone()),
         other => ContextError::CryptoFailed(format!("{other}")),
     }
-}
-
-fn reply_not_implemented(reply: oneshot::Sender<Result<(), ContextError>>) -> Outcome<()> {
-    const MSG: &str = "StandingCommand::Placeholder — real variants migrate in commit 11 of \
-                       ADR-049; Placeholder retained for commit-6 compile stability and \
-                       deleted in commit 12 with the shim";
-    let _ = reply.send(Err(ContextError::NotImplemented(MSG.to_owned())));
-    Outcome::err(ContextError::NotImplemented(MSG.to_owned()))
 }

--- a/crates/scp-runtime/src/context/actor/handlers/tools.rs
+++ b/crates/scp-runtime/src/context/actor/handlers/tools.rs
@@ -52,7 +52,6 @@ pub(crate) async fn dispatch(
     cmd: ToolsCommand,
 ) -> Outcome<()> {
     match cmd {
-        ToolsCommand::Placeholder { reply } => reply_not_implemented(reply),
         ToolsCommand::TryConsumeHardRateLimit {
             did,
             now_secs,
@@ -258,12 +257,4 @@ async fn handle_settle_tool_economy(
 
     let _ = reply.send(reply_result);
     outcome
-}
-
-fn reply_not_implemented(reply: oneshot::Sender<Result<(), ContextError>>) -> Outcome<()> {
-    const MSG: &str = "ToolsCommand::Placeholder — real variants migrate in commit 11 of \
-                       ADR-049; Placeholder retained for commit-6 compile stability and \
-                       deleted in commit 12 with the shim";
-    let _ = reply.send(Err(ContextError::NotImplemented(MSG.to_owned())));
-    Outcome::err(ContextError::NotImplemented(MSG.to_owned()))
 }

--- a/crates/scp-runtime/src/context/actor/handlers/trust_recovery.rs
+++ b/crates/scp-runtime/src/context/actor/handlers/trust_recovery.rs
@@ -8,16 +8,18 @@
 //! `(&mut PerContextState, &ActorDeps, TrustRecoveryCommand)` and routes
 //! per-context variants to the migrated state-owning helpers in
 //! [`crate::context::trust_recovery_helpers`]. The cross-context
-//! `RecoveryNotifyContact` variant cannot be handled inside one actor's
-//! mailbox turn because it scans every context for shared membership;
-//! that variant is rejected here with a `NotImplemented` reply (the
-//! supervisor's [`dispatch_trust_recovery_command`] routes it through
-//! [`Supervisor::dispatch_trust_recovery_direct`] before the
-//! per-context mailbox lookup).
+//! `RecoveryNotifyContact` variant drives a shared-context scan and
+//! fan-out through the actor's `ActorDeps` bundle
+//! (see [`handle_recovery_notify_contact`]); the supervisor's
+//! [`dispatch_trust_recovery_command`](crate::context::supervisor::Supervisor::dispatch_trust_recovery_command)
+//! intercepts it and routes it through the supervisor-side
+//! `Supervisor::dispatch_trust_recovery_direct` before the
+//! per-context mailbox lookup, so the actor arm is the direct-path
+//! twin rather than a rejection stub.
 //!
 //! The handler-side shim (`dispatch_from_shim`) was deleted in Phase 2A
 //! finalization. The no-mailbox-context fallback now lives on
-//! [`Supervisor::dispatch_trust_recovery_direct`](crate::context::supervisor::Supervisor::dispatch_trust_recovery_direct).
+//! `Supervisor::dispatch_trust_recovery_direct`.
 //!
 //! Each per-call invocation is wrapped in a 30-second
 //! [`tokio::time::timeout`] budget per ADR-049 §7.
@@ -41,17 +43,16 @@ pub const HANDLER_TIMEOUT: Duration = Duration::from_secs(30);
 
 /// Dispatch a [`TrustRecoveryCommand`] against actor-owned state.
 ///
-/// # `RecoveryNotifyContact` and `Placeholder`
+/// # `RecoveryNotifyContact`
 ///
-/// `RecoveryNotifyContact` requires cross-context fan-out and is not
-/// handled inside an actor's mailbox turn — it is intercepted by
+/// `RecoveryNotifyContact` requires cross-context fan-out. The
+/// supervisor's
 /// [`Supervisor::dispatch_trust_recovery_command`](crate::context::supervisor::Supervisor::dispatch_trust_recovery_command)
-/// and routed through the cross-context direct path before any
-/// per-context actor lookup. If a caller mistakenly routes it here,
-/// the handler replies [`ContextError::NotImplemented`].
-///
-/// `Placeholder` exists for mailbox-pipe smoke tests and replies
-/// `NotImplemented` by design.
+/// intercepts it and routes it through the cross-context direct path
+/// before any per-context actor lookup; the arm here is the actor-shape
+/// twin that performs the same shared-context scan and fan-out via
+/// [`handle_recovery_notify_contact`] when a command does reach the
+/// mailbox.
 pub(crate) async fn dispatch(
     cell: &mut ClassSCell,
     deps: &ActorDeps,
@@ -66,7 +67,6 @@ async fn dispatch_inner(
     cmd: TrustRecoveryCommand,
 ) -> Outcome<()> {
     match cmd {
-        TrustRecoveryCommand::Placeholder { reply } => reply_not_implemented(reply),
         TrustRecoveryCommand::CreateGovernanceCheckpoint { payload, reply } => {
             handle_create_governance_checkpoint(cell, deps, *payload, reply).await
         }
@@ -341,11 +341,4 @@ fn outcome_error_sketch(err: &ContextError) -> ContextError {
         ContextError::NotImplemented(msg) => ContextError::NotImplemented(msg.clone()),
         other => ContextError::CryptoFailed(format!("{other}")),
     }
-}
-
-fn reply_not_implemented(reply: oneshot::Sender<Result<(), ContextError>>) -> Outcome<()> {
-    const MSG: &str = "TrustRecoveryCommand::Placeholder — mailbox-pipe smoke target; \
-                       no real work performed";
-    let _ = reply.send(Err(ContextError::NotImplemented(MSG.to_owned())));
-    Outcome::err(ContextError::NotImplemented(MSG.to_owned()))
 }

--- a/crates/scp-runtime/src/context/actor/handlers/ttl_close.rs
+++ b/crates/scp-runtime/src/context/actor/handlers/ttl_close.rs
@@ -30,8 +30,8 @@
 //!
 //! # Transport-timeout budget
 //!
-//! [`HANDLER_TIMEOUT`] is the handler-level budget. The legacy
-//! `ContextManager` methods do not carry their own deadline — this is
+//! [`HANDLER_TIMEOUT`] is the handler-level budget. The predecessor
+//! monolithic context methods did not carry their own deadline — this is
 //! the new behaviour introduced by ADR-049 §7. 30 seconds matches the
 //! plan's "every transport and storage call inside a handler wraps
 //! `tokio::time::timeout(30s, ...)`" contract.
@@ -64,7 +64,6 @@ pub(crate) async fn dispatch(
     cmd: TtlCloseCommand,
 ) -> Outcome<()> {
     match cmd {
-        TtlCloseCommand::Placeholder { reply } => reply_not_implemented(reply),
         TtlCloseCommand::FireTimer { reply } => handle_fire_timer(cell, deps, reply).await,
         TtlCloseCommand::StartTtlTimer { payload, reply } => {
             let p = *payload;
@@ -412,14 +411,4 @@ fn outcome_error_sketch(err: &ContextError) -> ContextError {
         ContextError::EventLogFailed(msg) => ContextError::EventLogFailed(msg.clone()),
         other => ContextError::CryptoFailed(format!("{other}")),
     }
-}
-
-fn reply_not_implemented(reply: oneshot::Sender<Result<(), ContextError>>) -> Outcome<()> {
-    const MSG: &str = "TtlCloseCommand::Placeholder — real variants \
-                       StartTtlTimer/ExtendTtl/ResetTtlTimer/ExecuteTtlClose/\
-                       FinalizeClose are wired; Placeholder retained for actor \
-                       run-loop skeleton-handshake stability and deleted in \
-                       Phase 2A finalization with the shim";
-    let _ = reply.send(Err(ContextError::NotImplemented(MSG.to_owned())));
-    Outcome::err(ContextError::NotImplemented(MSG.to_owned()))
 }

--- a/crates/scp-runtime/src/context/actor/mod.rs
+++ b/crates/scp-runtime/src/context/actor/mod.rs
@@ -32,8 +32,9 @@
 //!   mailbox wrapper.
 //! - [`deps::ActorDeps`] — capability-reduced dependency bundle.
 //! - [`state::PerContextState`] — the owned state payload.
-//! - [`handlers`] — per-domain dispatch stubs (commits 7-11 migrate the
-//!   real handlers off `ContextManager`).
+//! - [`handlers`] — per-domain dispatch handlers. Each owns the real
+//!   actor-shape dispatch for its domain, operating on the actor's owned
+//!   state (`&mut ClassSCell`) and capability-reduced [`deps::ActorDeps`].
 
 pub mod class_s;
 pub mod commands;
@@ -80,9 +81,9 @@ use tokio::sync::mpsc;
 const COALESCE_INTERVAL: Duration = Duration::from_millis(50);
 
 /// Encode a 32-byte context ID as lowercase hex. Matches the string
-/// form used throughout the legacy `ContextManager` shim so the
-/// actor's `context_id` field is interchangeable with the shim's
-/// `ctx_id: &str` parameter.
+/// form used throughout the supervisor-side dispatch shim
+/// (`Supervisor::dispatch_*_command`) so the actor's `context_id`
+/// field is interchangeable with the shim's `ctx_id: &str` argument.
 fn hex_encode_context_id(id: &[u8; 32]) -> String {
     let mut s = String::with_capacity(64);
     for byte in id {
@@ -96,11 +97,14 @@ fn hex_encode_context_id(id: &[u8; 32]) -> String {
 /// Per-context actor. Owns one [`PerContextState`] by move and processes
 /// commands from its inbox one at a time.
 ///
-/// See plan §"ContextActor" for the full shape. Commit 6 lands the
-/// skeleton — the `run()` loop compiles and dispatches to the handler
-/// stubs; the real timer arms, persistence coalescing, and governance
-/// timeout fire-and-forget work lands alongside the handler migrations
-/// in commits 7-11.
+/// See plan §"ContextActor" for the full shape. The `run()` loop
+/// dispatches state-bearing commands through `dispatch_state` to the
+/// real per-domain handlers. Some run-loop arms remain no-ops pending
+/// the Phase 2 finalization sub-chunks that retire the supervisor-side
+/// timer/persistence paths — TTL expiry and governance timeouts are
+/// driven by the supervisor's timer `task_set`, and persistence flows
+/// through the per-handler persistence helpers, until those paths
+/// migrate onto the actor's owned state.
 pub struct ContextActor {
     /// Stable context identifier. Kept as a `String` alongside
     /// [`PerContextState::context_id`] for tracing / logging — the
@@ -111,66 +115,67 @@ pub struct ContextActor {
     /// [`ContextActorHandle`].
     inbox: mpsc::Receiver<ContextCommand>,
     /// Owned per-context state. `Some` for actors constructed via
-    /// [`Self::new`] with a full state payload (12b.2a infrastructure
-    /// path, exercised by 12b.2b handlers). `None` for skeleton actors
-    /// constructed via [`Self::new_skeleton`] — these are the pre-
-    /// 12b.2a test fixtures and the shim-era `spawn_actor` path whose
-    /// dispatch continues to route through
-    /// [`crate::context::supervisor::supervisor::Supervisor::dispatch_command`]
-    /// against the legacy `ContextManager`.
+    /// [`Self::new`] with a full state payload — the production path:
+    /// every production spawn
+    /// ([`crate::context::supervisor::supervisor::Supervisor::spawn_actor_with_state`])
+    /// carries `Some(state)`. `None` only for skeleton actors
+    /// constructed via the test-only [`Self::new_skeleton`].
     ///
-    /// Two-mode is bounded: once 12b.2b flips all handler dispatch to
-    /// the actor path, every spawn carries `Some(state)` and this
-    /// field becomes non-`Option`.
+    /// State-owning actors consume the state on every command: the
+    /// run-loop's `dispatch` threads it as `&mut ClassSCell` through
+    /// `dispatch_state` into the real per-domain handler. Only
+    /// skeleton actors (state = `None`) fall through to
+    /// `skeleton_dispatch`, the sole surviving `NotImplemented`
+    /// producer.
     ///
-    /// Read into handler bodies as `&mut self.state` in 12b.2b+. The
-    /// 12b.2a dispatch loop does not yet consume the state — it still
-    /// ACKs with `Err(NotImplemented)` via the skeleton dispatch —
-    /// because migrating one handler without the others silently
-    /// breaks the nine remaining shim handlers (see
-    /// `.docs/adrs/ADR-049-actor-per-context.md` §Commit ladder
-    /// row 12b.2a rationale).
-    #[allow(dead_code)] // read by 12b.2b handler bodies
+    /// Two-mode is bounded: this field becomes non-`Option` when the
+    /// test-only skeleton apparatus is retired in a follow-on chunk.
+    // read by the run-loop's dispatch/dispatch_state path
     state: Option<class_s::ClassSCell>,
     /// Owned dependency bundle. `Some` / `None` mirrors [`Self::state`]
     /// — the two are always both `Some` or both `None`. Two-mode is
     /// bounded identically.
-    #[allow(dead_code)] // read by 12b.2b handler bodies
+    // read by the run-loop's dispatch/dispatch_state path
     deps: Option<deps::ActorDeps>,
-    /// TTL expiry interval timer. Armed at actor construction when the
-    /// context's TTL configuration demands it; `None` for contexts
-    /// without TTL and for skeleton-mode actors. Drives the
-    /// `handlers/ttl_close.rs` expiry path once the run-loop grows a
-    /// `select!` TTL arm in 12b.2b+.
-    #[allow(dead_code)] // read by 12b.2b+ run-loop
+    /// TTL expiry interval timer. `None` until the supervisor-side TTL
+    /// timer path (`task_set`-spawned timers that mailbox
+    /// `TtlCloseCommand::FireTimer`) migrates onto the run-loop's
+    /// `select!` TTL arm in a follow-on Phase 2 sub-chunk; the arm and
+    /// its no-op `on_ttl_tick` body exist so that migration is purely
+    /// additive.
+    // read by the run-loop's TTL select! arm
     ttl_timer: Option<tokio::time::Interval>,
-    /// Governance proposal timeout deadline. Armed on governance
-    /// proposal creation; fires once and is rearmed if a subsequent
-    /// proposal lands. Driven by the handler migration in 12b.2b+.
+    /// Governance proposal timeout deadline. `None` until the
+    /// supervisor-side governance timeout path migrates onto the
+    /// run-loop's `select!` arm in a follow-on Phase 2 sub-chunk (the
+    /// arm and its no-op `on_governance_timeout` body exist so that
+    /// migration is purely additive).
     ///
     /// Note — `tokio::time::Sleep` is `!Unpin` so the field holds a
     /// pinned box. Constructing the future upfront (even unused)
     /// keeps the run-loop's `select!` arm shape stable as the
     /// migration lands.
-    #[allow(dead_code)] // read by 12b.2b+ run-loop
+    // read by the run-loop's governance select! arm
     governance_timeout: Option<std::pin::Pin<Box<tokio::time::Sleep>>>,
     /// Unix-ms instant of the last successful coalesced persist. The
     /// run-loop's persistence arm compares `now() - last_persisted_at`
     /// against the coalescing window (250 ms per plan
     /// §"Persistence coalescing") before issuing a snapshot write.
     /// Initialized to "now" at actor construction.
-    #[allow(dead_code)] // read by 12b.2b+ run-loop
+    // read by the run-loop's persistence coalesce arm
     last_persisted_at: std::time::Instant,
     /// Dirty flag set when any handler's [`outcome::Outcome`] carries
     /// `mutated: true`. Cleared after a successful coalesced persist.
     /// Initialized `false` at actor construction.
-    #[allow(dead_code)] // read by 12b.2b+ run-loop
+    // read by the run-loop's persistence coalesce arm
     dirty: bool,
-    /// **TRANSITIONAL — Phase 2A shim dispatch period.** Held so the
-    /// actor's `run()` loop can route commands through the
-    /// per-handler `dispatch_from_shim` entry points which still take
-    /// `&Supervisor`. Removed when handler bodies migrate to the
-    /// `(&mut PerContextState, &ActorDeps)` signature in Phase 2B-2I.
+    /// Full-supervisor pointer captured at construction. Today its
+    /// only read is the `dispatch` pre-check that partitions
+    /// state-owning actors from skeleton actors — handler bodies reach
+    /// the supervisor through the capability-reduced
+    /// [`deps::ActorDeps::supervisor`] handle instead. Removed when
+    /// the test-only skeleton apparatus is retired in a follow-on
+    /// chunk.
     ///
     /// Sourced from [`deps::ActorDeps::supervisor`] via
     /// [`crate::context::supervisor::SupervisorHandle::shim_supervisor`]
@@ -183,14 +188,12 @@ pub struct ContextActor {
 
 impl ContextActor {
     /// Construct a fresh actor that owns [`PerContextState`] and
-    /// [`ActorDeps`] directly (ADR-049 commit 12b.2a infrastructure
-    /// path).
+    /// [`ActorDeps`] directly (introduced by ADR-049 commit 12b.2a).
     ///
-    /// This is the production constructor — every
-    /// [`crate::context::supervisor::supervisor::Supervisor::spawn_actor`]
-    /// call that migrates state out of the legacy `ContextManager` /
-    /// `MlsCryptoProvider` uses this constructor to hand the drained
-    /// state into the actor task.
+    /// This is the production constructor. The owned-state spawn path
+    /// [`crate::context::supervisor::supervisor::Supervisor::spawn_actor_with_state`]
+    /// uses it to hand drained `PerContextState` + `ActorDeps` into the
+    /// actor task, making the actor their sole owner.
     ///
     /// Visibility is `pub(in crate::context)` — only
     /// `crate::context::supervisor::supervisor` constructs actors
@@ -212,10 +215,10 @@ impl ContextActor {
     /// The canonical context ID lives on `state.context_id` as
     /// `[u8; 32]`. The actor's `String` copy is derived at
     /// construction-time by hex-encoding the 32-byte hash, which
-    /// matches the string form `ContextManager` uses throughout the
-    /// shim. Callers therefore do not need to pass `context_id`
+    /// matches the string form used throughout the supervisor-side
+    /// dispatch shim. Callers therefore do not need to pass `context_id`
     /// separately — it is sourced from the state payload.
-    #[allow(dead_code)] // first production caller is 12b.2b
+    #[allow(dead_code)] // production caller: Supervisor::spawn_actor_with_state
     pub(in crate::context) fn new(
         state: state::PerContextState,
         deps: deps::ActorDeps,
@@ -223,9 +226,8 @@ impl ContextActor {
     ) -> Self {
         let context_id = hex_encode_context_id(&state.context_id);
         // Capture the shim-supervisor pointer before moving `deps` into
-        // the actor: the run loop's transitional handler dispatch needs
-        // an `Arc<Supervisor>` it can pass into the per-handler
-        // `dispatch_from_shim` entry points.
+        // the actor: `dispatch` reads its presence to partition
+        // state-owning actors from skeleton actors.
         let shim_supervisor = Some(deps.supervisor.shim_supervisor());
         Self {
             context_id,
@@ -245,27 +247,22 @@ impl ContextActor {
     }
 
     /// Construct a skeleton actor without state or deps. Used by the
-    /// pre-12b.2a test fixtures and by
+    /// module's unit-test fixtures and by the dead-code / test-only
     /// [`crate::context::supervisor::supervisor::Supervisor::spawn_actor`]
-    /// for contexts whose state still lives on the legacy
-    /// `ContextManager` (every production context during the
-    /// 12b.2a → 12b.2b window).
+    /// path. No production context uses the skeleton — production spawns
+    /// state-owning actors via [`Self::new`].
     ///
     /// The skeleton's `run()` loop drains commands from the inbox and
-    /// ACKs each with the same `Err(NotImplemented)` response the
-    /// pre-12b.2a dispatch produced. This is deliberate: flipping the
-    /// dispatch path for one handler while state still lives on the
-    /// manager would silently break the other nine shim handlers. See
-    /// `.docs/adrs/ADR-049-actor-per-context.md` §Commit ladder row
-    /// 12b.2b for the atomic migration plan.
+    /// ACKs each with `Err(NotImplemented)` via `skeleton_dispatch` —
+    /// the sole surviving `NotImplemented` producer, since a skeleton
+    /// actor carries no state for the real handlers to operate on.
     ///
     /// Visibility matches [`Self::new`]: `pub(in crate::context)`.
     ///
-    /// `dead_code` allow: the first production caller is 12b.2b's
-    /// atomic messaging migration, which deletes the skeleton path
-    /// and routes every spawn through [`Self::new`] with real state.
-    /// Until then this constructor is test-only for the module's
-    /// existing unit tests.
+    /// `dead_code` allow: no production caller. Production spawns
+    /// state-owning actors via [`Self::new`]; this skeleton constructor
+    /// is exercised only by the module's existing unit tests, pending
+    /// removal of the skeleton apparatus in a follow-on chunk.
     #[allow(dead_code)]
     pub(in crate::context) fn new_skeleton(
         context_id: String,
@@ -280,9 +277,8 @@ impl ContextActor {
             governance_timeout: None,
             // `Instant::now()` initializes the coalescing window even
             // though the skeleton dispatch never reads it — avoids
-            // carrying a magic-value sentinel. When 12b.2b removes the
-            // skeleton path this field is populated identically via
-            // [`Self::new`].
+            // carrying a magic-value sentinel. State-owning actors
+            // populate this field identically via [`Self::new`].
             last_persisted_at: Instant::now(),
             dirty: false,
             shim_supervisor: None,
@@ -303,21 +299,19 @@ impl ContextActor {
     ///
     /// # State-owning vs. skeleton-mode actors
     ///
-    /// State-owning actors (constructed via [`Self::new`]) carry both
-    /// `state` and `deps`. The dispatch routes each command to the
-    /// matching handler module's transitional `dispatch_from_shim` entry
-    /// point — those still take `&Supervisor`, sourced from
-    /// `deps.supervisor.shim_supervisor()` at construction. Phase 2B-2I
-    /// migrates each handler to the
-    /// `(&mut PerContextState, &ActorDeps)` signature; when a domain
-    /// migrates, its arm in `dispatch_state` flips to call the
-    /// state-owning `dispatch` entry point.
+    /// State-owning actors (constructed via [`Self::new`] — the
+    /// production shape) carry both `state` and `deps`. The dispatch
+    /// routes each command through `dispatch_state` into the matching
+    /// handler module's actor-shape `dispatch` entry point, which
+    /// operates on the actor-owned state cell and the
+    /// capability-reduced deps.
     ///
-    /// Skeleton-mode actors (constructed via [`Self::new_skeleton`])
-    /// carry no state or deps — they fall through to the synchronous
-    /// `skeleton_dispatch` path that ACKs every command with
-    /// `NotImplemented`. This preserves the pre-Phase-2A test fixtures'
-    /// behaviour while the production path migrates.
+    /// Skeleton-mode actors (constructed via the test-only
+    /// [`Self::new_skeleton`]) carry no state or deps — they fall
+    /// through to the synchronous `skeleton_dispatch` path that ACKs
+    /// every command with `NotImplemented`. This preserves the
+    /// pre-Phase-2A test fixtures' behaviour; no production spawn uses
+    /// it.
     pub async fn run(mut self) {
         // Kick the persistence coalesce timer off the floor: the first
         // mutation will set `dirty = true`, then the `select!` arm
@@ -423,13 +417,10 @@ impl ContextActor {
         }
     }
 
-    /// Dispatch a single command to its matching handler. The
-    /// transitional implementation routes through
-    /// `handlers::X::dispatch_from_shim` for handlers that have not
-    /// yet migrated to the `(&mut PerContextState, &ActorDeps)`
-    /// signature; the few that have migrated
-    /// (`lifecycle_control`, `saga`) take the actor-owned state
-    /// directly.
+    /// Dispatch a single command to its matching handler: takes the
+    /// actor-owned state/deps and threads them through
+    /// `dispatch_state` into the per-domain actor-shape `dispatch`
+    /// entry points.
     ///
     /// Skeleton-mode actors (no state/deps) fall through to
     /// `skeleton_dispatch` and ACK every variant with
@@ -449,12 +440,10 @@ impl ContextActor {
         // missing field after that point is an internal invariant
         // violation and should fail loudly, not degrade to skeleton
         // dispatch. The `shim_supervisor` field is not consumed here —
-        // every handler reaches the supervisor through
-        // `deps.supervisor` (the capability-reduced
-        // [`SupervisorHandle`](crate::context::supervisor::SupervisorHandle))
-        // and individual handler bodies call `shim_supervisor()` on the
-        // handle when they need the legacy `Arc<Supervisor>` for
-        // unmigrated paths.
+        // its presence was checked above, and every handler reaches
+        // the supervisor through `deps.supervisor` (the
+        // capability-reduced
+        // [`SupervisorHandle`](crate::context::supervisor::SupervisorHandle)).
         let (mut cell, deps) = {
             #[allow(clippy::expect_used)]
             (
@@ -502,10 +491,9 @@ impl ContextActor {
         match cmd {
             ContextCommand::Messaging(sub) => {
                 // Phase 2A.7 — messaging domain migrated to the
-                // actor-shape handler. Supervisor dispatch still falls
-                // back to `dispatch_from_shim` when no per-context
-                // actor exists for the target context during the
-                // migration window. The send-sequence tracker
+                // actor-shape handler. `Supervisor::dispatch_command`
+                // is mailbox-only: a missing actor surfaces a typed
+                // lookup-miss error. The send-sequence tracker
                 // (`state.send_tracker`) is reserved internally inside
                 // the handler.
                 handlers::messaging::dispatch(cell, deps, sub).await
@@ -513,26 +501,24 @@ impl ContextActor {
             ContextCommand::Lifecycle(sub) => {
                 // Phase 2A.9 — lifecycle domain migrated to actor-shape
                 // for per-context commands (`JoinContext`,
-                // `LeaveContext`, `CloseContext`, `ExportContext`).
-                // Bootstrap commands (`CreateContext`, `RestoreContext`,
-                // `ImportContext`) and access-key commands stay on the
-                // shim path inside `handlers::lifecycle::dispatch`
-                // because they construct fresh state or live in
-                // queries_helpers. `_supervisor` is unused on this arm
-                // because the shim escape happens through the
-                // capability-reduced handle inside the dispatch body.
+                // `LeaveContext`, `CloseContext`, `ExportContext`) and
+                // access-key commands (actor-shape helpers in
+                // queries_helpers). Bootstrap commands (`CreateContext`,
+                // `RestoreContext`, `ImportContext`) construct fresh
+                // state and are handled supervisor-side by
+                // `Supervisor::dispatch_lifecycle_direct` before any
+                // actor exists; reaching this arm with one (an actor
+                // already registered — a re-create attempt) surfaces a
+                // typed `InvalidState` inside the handler.
                 Box::pin(handlers::lifecycle::dispatch(cell, deps, sub)).await
             }
             ContextCommand::Governance(sub) => {
-                // Phase 2A.8 — governance domain partially migrated to
-                // actor-shape. Migrated variants take the actor-shape
-                // path off `state` + `deps`; unmigrated variants fall
-                // through to the legacy lock-and-call path via
-                // `deps.supervisor.shim_supervisor()` inside the
-                // handler. `_supervisor` is unused on this arm because
-                // the escape happens through the capability-reduced
-                // handle. Removed in Phase 2A finalization with the
-                // rest of the supervisor shim.
+                // Phase 2A.8 — governance domain fully migrated to
+                // actor-shape: every variant reads/mutates
+                // `state.governance` through the actor-shape helpers.
+                // `Supervisor::dispatch_governance_command` is
+                // mailbox-only (typed `ContextNotRegistered` when no
+                // actor is registered).
                 Box::pin(handlers::governance::dispatch(cell, deps, sub)).await
             }
             ContextCommand::Broadcast(sub) => {
@@ -544,10 +530,10 @@ impl ContextActor {
             }
             ContextCommand::Economy(sub) => {
                 // Phase 2A.3 — economy domain migrated to the
-                // actor-shape handler. Supervisor dispatch still falls
-                // back to `dispatch_from_shim` for callers that do not
-                // have a target context actor during the migration
-                // window.
+                // actor-shape handler. Supervisor dispatch falls
+                // through to its supervisor-side
+                // `dispatch_economy_direct` when a receipt batch has
+                // no single owning context actor.
                 handlers::economy::dispatch(cell, deps, sub).await
             }
             ContextCommand::TrustRecovery(sub) => {
@@ -562,26 +548,26 @@ impl ContextActor {
             }
             ContextCommand::Standing(sub) => {
                 // Phase 2A.2 — standing domain migrated to the
-                // actor-shape handler. Supervisor dispatch still falls
-                // back to `dispatch_from_shim` when a standing command
-                // has no target context actor during the migration
-                // window.
+                // actor-shape handler. Supervisor-scoped variants (and
+                // commands with no registered target actor) route
+                // through the supervisor-side
+                // `dispatch_standing_direct` instead of this arm.
                 Box::pin(handlers::standing::dispatch(deps, sub)).await
             }
             ContextCommand::TtlClose(sub) => {
                 // Phase 2A.6 — TTL-close domain migrated to the
-                // actor-shape handler. Supervisor dispatch still falls
-                // back to `dispatch_from_shim` when no per-context
-                // actor exists for the target context during the
-                // migration window.
+                // actor-shape handler.
+                // `Supervisor::dispatch_ttl_close_command` is
+                // mailbox-only: a missing actor surfaces a typed
+                // lookup-miss error.
                 handlers::ttl_close::dispatch(cell, deps, sub).await
             }
             ContextCommand::Tools(sub) => {
                 // Phase 2A.4 -- tools domain migrated to the
                 // actor-shape handler for mailbox-routed hard-rate
-                // helpers. Supervisor dispatch still falls back to
-                // `dispatch_from_shim` for missing actors during the
-                // migration window.
+                // helpers. `Supervisor::dispatch_tools_command` is
+                // mailbox-first: a missing actor surfaces a typed
+                // error on the command's reply oneshot.
                 handlers::tools::dispatch(cell, deps, sub).await
             }
             // Phase 2A.10 — queries domain migrated to the actor-shape
@@ -621,11 +607,13 @@ impl ContextActor {
         }
     }
 
-    /// Drive the TTL-timer arm. Phase 2A leaves the body empty: the
-    /// legacy `ContextManager` continues to drive TTL expiry through
-    /// its own spawned timer until a future Phase 2 sub-chunk migrates
-    /// the timer onto the actor's owned state. The arm exists here so
-    /// future migration is purely additive.
+    /// Drive the TTL-timer arm. Phase 2A leaves the body empty: TTL
+    /// expiry is driven by the supervisor's timer `task_set`, which
+    /// spawns a per-context TTL timer that mailboxes
+    /// `TtlCloseCommand::FireTimer` to this actor — until a future
+    /// Phase 2 sub-chunk moves the timer onto the actor's own
+    /// `ttl_timer` arm. The arm exists here so that migration is purely
+    /// additive.
     ///
     /// `_state`/`_deps` allow: future migrations read them; for now the
     /// method is a no-op.
@@ -644,31 +632,34 @@ impl ContextActor {
         // actor's owned state in a follow-on Phase 2 sub-chunk.
     }
 
-    /// Persistence coalesce: write the current state's snapshot.
-    /// Phase 2A delegates to the supervisor's persistence backend if
-    /// the actor owns deps; skeleton-mode is a no-op.
+    /// Persistence coalesce arm. Phase 2A no-op: durable writes still
+    /// flow through the per-handler persistence helpers, so this arm
+    /// only clears the `dirty` flag (see body).
     #[allow(clippy::unused_async, clippy::needless_pass_by_ref_mut)]
     async fn persist_snapshot(&mut self) {
         // The state-owning persist path is wired in a follow-on Phase 2
         // sub-chunk together with the snapshot-shape contract on
         // `PerContextState`. For Phase 2A the run loop's coalesce arm
         // simply clears `dirty` so the loop does not spin; durable
-        // writes continue to flow through the legacy
-        // `ContextManager::persist_context_snapshot` path until the
-        // migration completes.
+        // writes flow through the per-handler persistence helpers
+        // (writing to the injected `ContextPersistence` provider
+        // synchronously within each handler) until the migration
+        // completes.
     }
 
-    /// Skeleton dispatch — matches every variant and ACKs via the
-    /// embedded `oneshot::Sender`. Commits 7-11 replace this with the
-    /// real four-arm `tokio::select!` dispatch described in plan
-    /// §"ContextActor".
+    /// Skeleton dispatch — the test-only path for state-less skeleton
+    /// actors. Matches every variant and ACKs via the embedded
+    /// `oneshot::Sender`. The real, state-owning actor does not use this:
+    /// its `run()` loop routes commands through `dispatch_state` to the
+    /// per-domain handlers described in plan §"ContextActor".
     ///
     /// The function body is a flat `match` on the outer
-    /// [`ContextCommand`] variants. Each arm routes to the matching
-    /// handler stub's dispatch path, which replies `NotImplemented` and
-    /// returns `Outcome::err`. Taking `Outcome` and ignoring it is fine
-    /// for the skeleton — the real actor (commits 7-11) uses the
-    /// `Outcome::mutated` flag to flip `self.dirty`.
+    /// [`ContextCommand`] variants. Each arm replies `NotImplemented` and
+    /// returns `Outcome::err`, since a skeleton actor carries no
+    /// `&mut PerContextState` for the real handlers to operate on.
+    /// Discarding the `Outcome` is fine for the skeleton — only the real
+    /// `dispatch_state` path reads the `Outcome::mutated` flag to flip
+    /// `self.dirty`.
     ///
     /// Lifecycle-control commands use a dedicated fast path that acks
     /// with `Ok(())` so the bridge's `BridgeInstanceCore::suspend()`
@@ -678,12 +669,13 @@ impl ContextActor {
     #[allow(clippy::needless_pass_by_value)] // consumed by the dispatch
     fn skeleton_dispatch(cmd: ContextCommand) {
         // Route every variant to its matching handler's oneshot-ack so
-        // callers learn the outcome even while the real state is owned
-        // by the legacy `ContextManager`. We MUST route the oneshot
-        // sender out of the variant — synchronously, in this function
-        // — because the real handler modules take a
+        // callers learn the outcome even though a skeleton actor owns no
+        // state (commands for such contexts are handled by the
+        // supervisor-side dispatch shim, not the actor). We MUST route
+        // the oneshot sender out of the variant — synchronously, in
+        // this function — because the real handler modules take a
         // `&mut PerContextState` which the skeleton actor does not
-        // carry yet. Reproducing the ack shape inline keeps the
+        // carry. Reproducing the ack shape inline keeps the
         // skeleton's mailbox contract (`send -> ack`) intact.
         fn ack_not_impl<T>(
             reply: tokio::sync::oneshot::Sender<Result<T, ContextError>>,
@@ -712,8 +704,8 @@ impl ContextActor {
             // immediately that the actor did not own the state to
             // answer. The real answer path lives on
             // `Supervisor::dispatch_query`, which bypasses this skeleton
-            // by talking to the legacy `ContextManager` under the query
-            // shim. The skeleton only sees query commands if a caller
+            // and resolves the query on the supervisor side under the
+            // query shim. The skeleton only sees query commands if a caller
             // mistakenly routes through the actor's mailbox — the real
             // FFI dispatch goes through `Supervisor::dispatch_query`.
             ContextCommand::Queries(q) => Self::skeleton_dispatch_queries(q),
@@ -759,9 +751,8 @@ impl ContextActor {
                 ack_ok(reply);
             }
             ContextCommand::LifecycleControl(LifecycleControlCommand::PersistSync { reply }) => {
-                // Ack Ok — nothing to persist through the actor path
-                // yet (the legacy `ContextManager` still owns mutating
-                // paths until commit 12). Semantically equivalent to
+                // Ack Ok — a skeleton actor owns no state, so there is
+                // nothing to persist. Semantically equivalent to
                 // "flush buffer is empty, nothing to write".
                 ack_ok(reply);
             }
@@ -808,7 +799,6 @@ impl ContextActor {
             ))));
         }
         match sub {
-            MessagingCommand::Placeholder { reply } => ack_not_impl(reply, "messaging"),
             MessagingCommand::SendMessage { reply, .. } => {
                 ack_not_impl(
                     reply,
@@ -980,7 +970,6 @@ impl ContextActor {
             ))));
         }
         match sub {
-            LifecycleCommand::Placeholder { reply } => ack_not_impl(reply, "lifecycle"),
             // `CreateContext` carries a `ContextCreationError` reply
             // (not `ContextError`); surface an equivalent
             // `CreationFailed` stub so the typed result's error
@@ -1080,7 +1069,6 @@ impl ContextActor {
             ))));
         }
         match sub {
-            GovernanceCommand::Placeholder { reply } => ack_not_impl(reply, "governance"),
             GovernanceCommand::ProposeGovernanceAction { reply, .. } => ack_not_impl(
                 reply,
                 "governance::propose_governance_action (use Supervisor::dispatch_governance_command during commits 10-11)",
@@ -1171,16 +1159,7 @@ impl ContextActor {
     /// [`crate::context::supervisor::supervisor::Supervisor::dispatch_economy_command`]
     /// (ADR-049 commit 10).
     fn skeleton_dispatch_economy(sub: EconomyCommand) {
-        fn ack_not_impl<T>(
-            reply: tokio::sync::oneshot::Sender<Result<T, ContextError>>,
-            which: &'static str,
-        ) {
-            let _ = reply.send(Err(ContextError::NotImplemented(format!(
-                "{which} — migrates in the matching handler commit of ADR-049"
-            ))));
-        }
         match sub {
-            EconomyCommand::Placeholder { reply } => ack_not_impl(reply, "economy"),
             // `VerifyPaymentReceipts` carries a `Vec<Result<..>>` reply
             // (not `Result<.., ContextError>`); synthesize an empty
             // reply so the mailbox contract is preserved even for the
@@ -1212,7 +1191,6 @@ impl ContextActor {
             ))));
         }
         match sub {
-            TrustRecoveryCommand::Placeholder { reply } => ack_not_impl(reply, "trust_recovery"),
             TrustRecoveryCommand::CreateGovernanceCheckpoint { reply, .. } => ack_not_impl(
                 reply,
                 "trust_recovery::create_governance_checkpoint (use Supervisor::dispatch_trust_recovery_command during commits 10-11)",
@@ -1254,7 +1232,6 @@ impl ContextActor {
             ))));
         }
         match sub {
-            TtlCloseCommand::Placeholder { reply } => ack_not_impl(reply, "ttl_close"),
             TtlCloseCommand::FireTimer { reply } => ack_not_impl(
                 reply,
                 "ttl_close::fire_timer (use Supervisor::dispatch_ttl_close_command)",
@@ -1299,7 +1276,6 @@ impl ContextActor {
             ))));
         }
         match sub {
-            StandingCommand::Placeholder { reply } => ack_not_impl(reply, "standing"),
             StandingCommand::StandingContext { reply, .. } => ack_not_impl(
                 reply,
                 "standing::standing_context (use Supervisor::dispatch_standing_command during commit 11)",
@@ -1339,7 +1315,6 @@ impl ContextActor {
             ))));
         }
         match sub {
-            ToolsCommand::Placeholder { reply } => ack_not_impl(reply, "tools"),
             ToolsCommand::TryConsumeHardRateLimit { reply, .. } => ack_not_impl(
                 reply,
                 "tools::try_consume_hard_rate_limit (use Supervisor::dispatch_tools_command during commit 11)",
@@ -1375,7 +1350,6 @@ impl ContextActor {
             ))));
         }
         match sub {
-            BroadcastCommand::Placeholder { reply } => ack_not_impl(reply, "broadcast"),
             BroadcastCommand::SubscribeBroadcast { reply, .. } => ack_not_impl(
                 reply,
                 "broadcast::subscribe_broadcast (use Supervisor::dispatch_broadcast_command during commit 11)",
@@ -1443,14 +1417,22 @@ mod tests {
     use tokio::sync::mpsc;
 
     #[tokio::test]
-    async fn actor_acks_placeholder_command_with_not_implemented() {
+    async fn skeleton_actor_acks_query_with_not_implemented() {
         let (tx, rx) = mpsc::channel::<ContextCommand>(1);
         let actor = ContextActor::new_skeleton("ctx-42".to_owned(), rx);
         let actor_handle = tokio::spawn(actor.run());
 
         let handle = ContextActorHandle::from_sender(tx);
+        // A skeleton actor owns no state, so every command — including a
+        // read-only query — acks `NotImplemented` through the synchronous
+        // skeleton-dispatch path.
         let err = handle
-            .send(|reply| ContextCommand::Messaging(MessagingCommand::Placeholder { reply }))
+            .send(|reply| {
+                ContextCommand::Queries(QueriesCommand::MemberCount {
+                    context_id: "ctx-42".to_owned(),
+                    reply,
+                })
+            })
             .await
             .unwrap_err();
         assert!(matches!(err, ContextError::NotImplemented(_)));
@@ -1487,7 +1469,12 @@ mod tests {
         handle.send_pause().await.unwrap();
         // Actor is still running; a subsequent command is processed.
         let err = handle
-            .send(|reply| ContextCommand::Messaging(MessagingCommand::Placeholder { reply }))
+            .send(|reply| {
+                ContextCommand::Queries(QueriesCommand::MemberCount {
+                    context_id: "ctx-1".to_owned(),
+                    reply,
+                })
+            })
             .await
             .unwrap_err();
         assert!(matches!(err, ContextError::NotImplemented(_)));
@@ -1591,10 +1578,10 @@ mod tests {
         }
     }
 
-    /// Assemble a supervisor-backed `ActorDeps` bundle for the
-    /// `actor_with_state_acks_placeholder_with_not_implemented` test.
-    /// Extracted so the test function stays below the `too_many_lines`
-    /// clippy threshold.
+    /// Assemble a supervisor-backed `ActorDeps` bundle shared by the
+    /// state-bearing actor tests (the four `direct_*` announcement tests
+    /// and `actor_with_state_answers_read_query`). Extracted so each test
+    /// function stays below the `too_many_lines` clippy threshold.
     async fn new_test_deps() -> deps::ActorDeps {
         use crate::context::supervisor::supervisor::Supervisor;
         use scp_identity::DID;
@@ -1870,10 +1857,10 @@ mod tests {
     }
 
     /// `ContextActor::new` constructs an actor that owns `PerContextState`
-    /// + `ActorDeps` directly (12b.2a infrastructure path). The dispatch
-    /// loop's behaviour is unchanged in 12b.2a (still ACKs
-    /// `NotImplemented`); this test just asserts the struct is
-    /// constructible and the run-loop processes commands.
+    /// + `ActorDeps` directly and routes commands through the state-owning
+    /// `dispatch_state` path. This test asserts the struct is constructible
+    /// and the run-loop processes commands by round-tripping a read-only
+    /// member-count query and observing a concrete answer.
     ///
     /// Integration-level coverage of the full
     /// `build_actor_deps_from_attached` path lives in
@@ -1882,7 +1869,7 @@ mod tests {
     /// `crates/scp-runtime/src/context/supervisor/supervisor.rs`; this
     /// unit test focuses on the actor struct's constructor + run-loop.
     #[tokio::test]
-    async fn actor_with_state_acks_placeholder_with_not_implemented() {
+    async fn actor_with_state_answers_read_query() {
         let deps = new_test_deps().await;
         let state = state::PerContextState::new_for_test_encrypted(
             [0x42u8; 32],
@@ -1895,15 +1882,28 @@ mod tests {
         let actor_task = tokio::spawn(actor.run());
 
         let handle = ContextActorHandle::from_sender(tx);
-        // Skeleton dispatch still fires in 12b.2a — actor owns state
-        // + deps, but the run loop has not yet been rewired to read
-        // them. Assert the `NotImplemented` ACK proves the loop picks
-        // up commands from the inbox.
-        let err = handle
-            .send(|reply| ContextCommand::Messaging(MessagingCommand::Placeholder { reply }))
+        // The state-owning actor answers a read-only query on owned state,
+        // proving the run loop picks commands up from the inbox and routes
+        // them through the actor-shape queries handler.
+        let count = handle
+            .send(|reply| {
+                ContextCommand::Queries(QueriesCommand::MemberCount {
+                    context_id: hex_encode_context_id(&[0x42u8; 32]),
+                    reply,
+                })
+            })
             .await
-            .unwrap_err();
-        assert!(matches!(err, ContextError::NotImplemented(_)));
+            .expect("member-count query round-trips through the state-owning actor");
+        // The test fixture (`new_for_test_encrypted`) seeds the admin DID into
+        // `governance`, not into `membership`, so the roster is empty and
+        // `MemberCount` (which reads `state.membership.count()`) answers the
+        // exact count 0 — not merely "some" count.
+        assert_eq!(
+            count,
+            Some(0),
+            "the owning actor answers MemberCount with the exact roster count \
+             (empty test fixture ⇒ 0)"
+        );
 
         handle.send_shutdown().await.unwrap();
         actor_task.await.unwrap();

--- a/crates/scp-runtime/src/context/actor/state.rs
+++ b/crates/scp-runtime/src/context/actor/state.rs
@@ -9,59 +9,58 @@
 //!
 //! Per ADR-049 §1 (`ContextActor owns state by move`) and plan
 //! §"ContextActor", this module defines the SHAPE of the state an actor
-//! owns across the commit-12 migration off `ContextManager`.
+//! owns — the state model the commit-12 migration moved off the
+//! now-deleted `ContextManager`.
 //!
 //! # Split from `manager/mod.rs`
 //!
-//! The legacy `ContextManager` carries its own `pub(crate)
-//! PerContextState` in the deleted `crate::context::manager` module —
+//! The legacy `ContextManager` carried its own `pub(crate)
+//! PerContextState` in the now-deleted `crate::context::manager` module —
 //! that type was consumed through
-//! the `per-context-state Mutex` lock-based model that ADR-049 deletes.
+//! the `per-context-state Mutex` lock-based model that ADR-049 deleted.
 //! The actor's state type here is a SUPERSET-COMPATIBLE shape: every field
-//! the legacy struct owns is represented here (so commit 12b+ handler-body
-//! migrations move calls mechanically off `manager.field` onto
-//! `state.field`), plus the new per-actor fields (`saga_pending`,
+//! the legacy struct owned is represented here (so the commit 12b+
+//! handler-body migrations moved calls mechanically off `manager.field`
+//! onto `state.field`), plus the new per-actor fields (`saga_pending`,
 //! `welcome_scratchpad`, `send_tracker`, `recv_tracker`, split mode
 //! state) that the legacy struct did not own.
 //!
-//! The two types coexist during the commit ladder (commit 6 through
-//! commit 12). The legacy `state::PerContextState` remains
-//! byte-identical — no changes to it apart from the `pub(crate)` field
-//! elevations commit 12a adds so the actor can name the sub-struct types.
-//! Commits 12b-12c migrate handler bodies to take `&mut
-//! actor::PerContextState`. Commit 12d deletes the legacy
-//! `ContextManager`, at which point the legacy type is removed in the
-//! same mechanical pass.
+//! The two types coexisted through the commit ladder (commit 6 through
+//! commit 12); the legacy state struct stayed byte-identical apart from
+//! the `pub(crate)` field elevations commit 12a added so the actor could
+//! name the sub-struct types. Commits 12b-12c migrated handler bodies to
+//! take `&mut actor::PerContextState`. Commit 12d deleted the legacy
+//! `ContextManager`; the legacy state type was removed in the same
+//! mechanical pass.
 //!
-//! # Commit 12a — fields-only
+//! # Origin — the fields-only landing
 //!
-//! Commit 12a populates [`PerContextState`], [`ContextCryptoState`], and
-//! [`BroadcastState`] with every field the legacy manager's
-//! [`crate::context::state::PerContextState`] +
-//! `MlsCryptoProvider::contexts[ctx_id]` owns. No handler body moves
-//! here — the shim still delegates through `ContextManager` via
-//! `view.manager()`. The purpose is to give 12b+ a complete field-set
-//! destination so each handler migration is a mechanical move from
-//! `manager.foo` to `state.foo`.
+//! [`PerContextState`], [`ContextCryptoState`], and [`BroadcastState`]
+//! first landed as a fields-only mirror of every field the legacy
+//! manager's own `PerContextState` + `MlsCryptoProvider::contexts[ctx_id]`
+//! owned, giving the handler migration a complete field-set destination so
+//! each move off `manager.foo` onto `state.foo` was mechanical. That
+//! migration is complete: the handlers read and mutate this actor-owned
+//! state directly, and the legacy manager and its `Supervisor::dispatch_*`
+//! method bodies no longer exist.
 //!
 //! The MLS group handle on [`ContextCryptoState`] is `Option<ScpMlsGroup>`
 //! (not `ScpMlsGroup` non-optional as the legacy provider held it),
 //! because actors spawn before any MLS state is constructed — Create /
-//! Join handlers in 12b+ populate it. This is the only shape divergence
-//! from legacy; all other fields are stored in the same type the legacy
-//! manager uses.
+//! Join handlers populate it. This is the only shape divergence from the
+//! legacy layout; all other fields are stored in the same types the
+//! legacy manager used.
 //!
 //! # Construction
 //!
-//! This commit does NOT wire production construction — the production
-//! construction path still lives on `ContextManager` and hands the shim
-//! a legacy `state::PerContextState`. Commit 12b (messaging handler
-//! migration) is the first production call site that constructs an
-//! [`actor::PerContextState`](PerContextState). Until then the test
+//! Production construction now goes through
+//! `Supervisor::spawn_actor_with_state`, which hands each
+//! [`ContextActor`](crate::context::actor::ContextActor) its owned
+//! [`actor::PerContextState`](PerContextState). The test
 //! constructors [`PerContextState::new_for_test_encrypted`] and
-//! [`PerContextState::new_for_test_broadcast`] are the only call sites
-//! and exist to prove the shape is both structurally complete and
-//! constructible from minimum inputs.
+//! [`PerContextState::new_for_test_broadcast`] additionally build the
+//! state from minimum inputs to prove the shape is both structurally
+//! complete and constructible.
 
 use std::collections::{HashMap, HashSet, VecDeque};
 use std::sync::Arc;
@@ -450,7 +449,7 @@ pub struct ContextCryptoState {
     ///
     /// [`PerContextState::recv_tracker`](PerContextState::recv_tracker)
     /// is the actor-shape per-member WIRE-sequence tracker used by the
-    /// ContextManager-level reorder / delivery path. This field is the
+    /// per-context reorder / delivery path. This field is the
     /// MLS sender-key layer `(epoch, sequence)` pair that [`open`]
     /// reads in the provider (see provider.rs:1211-1221 for the
     /// authoritative algorithm). Commit 12b.2 migrates that deliver-
@@ -563,7 +562,7 @@ impl Default for ContextCryptoState {
 ///
 /// Exactly one variant is present per context; there is no `Option` or
 /// "unknown" state. Constructors build the correct variant from
-/// [`crate::context::state::ContextModeState`]-equivalent mode information at
+/// [`ContextModeState`]-equivalent mode information at
 /// creation / join / restore time.
 ///
 /// `DID` is `#[serde(transparent)]` over `String`, so the serialized wire
@@ -984,34 +983,32 @@ impl ClassSState {
 ///
 /// Field set is the contract the plan's handler signatures rely on
 /// (§"ContextActor" dispatch loop + §"Submodule organization"). Every
-/// field listed here is populated by commits 12b+ in production; the
+/// field is populated in production by the actor-shape handlers; the
 /// [`Self::new_for_test_encrypted`] / [`Self::new_for_test_broadcast`]
 /// fixtures default the rest for test use.
 ///
-/// # Field-for-field parity with legacy
+/// # Field-for-field parity with the deleted legacy state
 ///
-/// Commit 12a mirrors every field on
-/// [`crate::context::state::PerContextState`] so 12b+ handler-body
-/// migrations move calls mechanically off `manager.foo` onto
-/// `state.foo`. The new-per-actor fields at the bottom of the struct
-/// (`send_tracker`, `recv_tracker`, `saga_pending`, `welcome_scratchpad`,
-/// `lifecycle_state`, `mode`) have no legacy equivalent — they replace
-/// the `per-context-state Mutex` lock-based model.
+/// This struct owns every field the now-deleted legacy per-context state
+/// carried, so the completed handler-body migration moved each call
+/// mechanically off `manager.foo` onto `state.foo`. The new-per-actor
+/// fields at the bottom of the struct (`send_tracker`, `recv_tracker`,
+/// `saga_pending`, `welcome_scratchpad`, `lifecycle_state`, `mode`) have
+/// no legacy equivalent — they replace the `per-context-state Mutex`
+/// lock-based model.
 ///
-/// # Dead-code in commit 12a
+/// # Field readers
 ///
-/// The 12a fields-only commit populates every field but wires no
-/// handler callers — the `view.manager()` shim still delegates to
-/// `ContextManager` for every mutation. Per-field `#[allow(dead_code)]`
-/// markers are intentionally NOT applied: the struct-level
-/// `#[allow(dead_code)]` below covers unused private-type fields
-/// (`governance`, `epoch`, `access`, `ttl`) until 12b+ handlers read
-/// them. All other fields are already reachable via their `pub`
-/// accessors from existing shim or test code.
-#[allow(
-    dead_code,
-    reason = "Commit 12a of ADR-049 is fields-only; 12b+ handler migrations wire the first production readers of `governance`/`epoch`/`access`/`ttl`. See `.docs/adrs/ADR-049-actor-per-context.md` §Commit ladder."
-)]
+/// Every field is read and mutated directly by the actor-shape handlers
+/// and their helper modules — there is no dead code here, and no
+/// `#[allow(dead_code)]` is applied. The private-type sub-state fields
+/// are all live: `governance` (e.g. `handlers/governance.rs` off
+/// `state.governance.engine`, and `handlers/lifecycle.rs` cancelling
+/// `state.governance.timeout_task`), `epoch` (`handlers/trust_recovery.rs`
+/// reading `state.epoch.mls_epoch`), `ttl` (`handlers/lifecycle.rs`
+/// cancelling `state.ttl.timer`), and `access` (the governance,
+/// messaging, and queries helpers reading `state.access.access_key_store`
+/// and `state.access.read_exclusion_list`).
 pub struct PerContextState {
     // -----------------------------------------------------------------
     // Identity + lifetime fields

--- a/crates/scp-runtime/src/context/supervisor/handle.rs
+++ b/crates/scp-runtime/src/context/supervisor/handle.rs
@@ -370,18 +370,19 @@ impl SupervisorHandle {
         .await;
     }
 
-    /// **TRANSITIONAL — shim dispatch period only.** Returns the inner
-    /// `Arc<Supervisor>` so the actor's `run()` loop can route commands
-    /// through the legacy `dispatch_from_shim` handler entry points
-    /// during the Phase 2A → 2I migration window. Removed when handlers
-    /// are migrated to the `(&mut PerContextState, &ActorDeps)`
-    /// signature in the per-domain rows of Phase 2.
+    /// Returns the inner `Arc<Supervisor>`. The legacy
+    /// `dispatch_from_shim` handler entry points this escape hatch fed
+    /// were deleted in Phase 2A finalization; its one remaining caller
+    /// is `ContextActor::new`, which captures the pointer so the
+    /// actor's `dispatch` can partition state-owning actors from
+    /// test-only skeleton actors. Removed together with the skeleton
+    /// apparatus in a follow-on chunk.
     ///
     /// Visibility is `pub(in crate::context)` so only code within the
-    /// `context` module tree (the actor's run loop) can call this.
-    /// Handler bodies under `actor/handlers/` MUST NOT call this — they
-    /// receive the supervisor via the explicit `&Supervisor` parameter
-    /// of their `dispatch_from_shim` entry point.
+    /// `context` module tree can call this. Handler bodies under
+    /// `actor/handlers/` MUST NOT call this — they reach the
+    /// supervisor through the capability-reduced [`SupervisorHandle`]
+    /// on `ActorDeps`.
     #[must_use]
     #[allow(dead_code)]
     pub(in crate::context) fn shim_supervisor(&self) -> Arc<Supervisor> {

--- a/crates/scp-runtime/src/context/supervisor/supervisor.rs
+++ b/crates/scp-runtime/src/context/supervisor/supervisor.rs
@@ -2514,7 +2514,7 @@ impl Supervisor {
             return Ok(Box::pin(self.dispatch_lifecycle_direct(cmd)).await);
         }
         // Per-context variants (Join / Leave / Close / Export +
-        // access-key generate / revoke / restore + Placeholder) all
+        // access-key generate / revoke / restore) all
         // carry a `context_id` and have a registered actor after
         // bootstrap spawn. Mailbox-first routes to the actor's
         // `dispatch_state` loop which executes the actor-shape handler.
@@ -2569,12 +2569,6 @@ impl Supervisor {
         const LIFECYCLE_TIMEOUT: std::time::Duration = Supervisor::LIFECYCLE_TIMEOUT;
 
         match cmd {
-            LifecycleCommand::Placeholder { reply } => {
-                const MSG: &str =
-                    "LifecycleCommand::Placeholder — handshake target; no production work";
-                let _ = reply.send(Err(ContextError::NotImplemented(MSG.to_owned())));
-                Outcome::err(ContextError::NotImplemented(MSG.to_owned()))
-            }
             LifecycleCommand::CreateContext { payload, reply } => {
                 let p = *payload;
                 let context_id = p.context_id.clone();
@@ -2992,7 +2986,7 @@ impl Supervisor {
         let Some(ctx_id) = Self::ttl_close_command_context_id(&cmd) else {
             return Err(ContextError::ContextNotRegistered(
                 "dispatch_ttl_close_command — variant has no per-context routing target \
-                 (Placeholder); mailbox-only after Phase 2A finalization"
+                 (FireTimer resolves its own actor); mailbox-only after Phase 2A finalization"
                     .to_owned(),
             ));
         };
@@ -3018,11 +3012,10 @@ impl Supervisor {
     /// mailbox via [`Self::dispatch_via_mailbox`]. The actor's `run()`
     /// loop pulls the command, dispatches it through the actor-shape
     /// `dispatch(state, deps, cmd)` entry point, and writes the typed
-    /// reply on the command's embedded oneshot. The `Placeholder`
-    /// variant (mailbox handshake target — no `context_id`) returns
-    /// [`ContextError::ContextNotRegistered`] from this method when no
-    /// per-context routing target exists; the no-op reply is otherwise
-    /// produced by the actor-side `dispatch_state` arm.
+    /// reply on the command's embedded oneshot. Sweep / timeout-task
+    /// variants carry no `context_id` and are dispatched per-actor by
+    /// the iterating helpers rather than this routed entry point; they
+    /// return [`ContextError::ContextNotRegistered`] from this method.
     ///
     /// # Errors
     ///
@@ -3050,7 +3043,7 @@ impl Supervisor {
         let Some(ctx_id) = Self::governance_command_context_id(&cmd) else {
             return Err(ContextError::ContextNotRegistered(
                 "dispatch_governance_command — variant has no per-context routing target \
-                 (Placeholder / cross-context); mailbox-only after Phase 2A finalization"
+                 (sweep / timeout-task use the iterating helpers); mailbox-only after Phase 2A finalization"
                     .to_owned(),
             ));
         };
@@ -3129,14 +3122,12 @@ impl Supervisor {
     /// [`EconomyCommand::VerifyPaymentReceipts`] batch carries the same
     /// `Some(context_id)`. Returns `None` for:
     ///
-    /// - [`EconomyCommand::Placeholder`] (no target).
     /// - Empty receipt batches (no target).
     /// - Heterogeneous batches whose receipts straddle multiple contexts
     ///   (no single owning actor).
     /// - Batches containing any relay-level receipt (`context_id == None`).
     fn economy_command_context_id(cmd: &EconomyCommand) -> Option<&str> {
         match cmd {
-            EconomyCommand::Placeholder { .. } => None,
             EconomyCommand::VerifyPaymentReceipts { receipts, .. } => {
                 let mut iter = receipts.iter();
                 let first = iter.next()?.context_id.as_ref()?;
@@ -3180,12 +3171,6 @@ impl Supervisor {
         const ECONOMY_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(30);
 
         match cmd {
-            EconomyCommand::Placeholder { reply } => {
-                const MSG: &str =
-                    "EconomyCommand::Placeholder — mailbox-pipe smoke target; no production work";
-                let _ = reply.send(Err(ContextError::NotImplemented(MSG.to_owned())));
-                Outcome::err(ContextError::NotImplemented(MSG.to_owned()))
-            }
             EconomyCommand::VerifyPaymentReceipts { receipts, reply } => {
                 let receipts = *receipts;
                 let verify_fut = async {
@@ -3273,11 +3258,10 @@ impl Supervisor {
     /// Extract the `context_id` borrow from a [`TrustRecoveryCommand`]
     /// when one is present. Returns `None` for variants that cannot be
     /// routed through a per-context actor mailbox
-    /// (`Placeholder`, `RecoveryNotifyContact`).
+    /// (`RecoveryNotifyContact`).
     fn trust_recovery_command_context_id(cmd: &TrustRecoveryCommand) -> Option<&str> {
         match cmd {
-            TrustRecoveryCommand::Placeholder { .. }
-            | TrustRecoveryCommand::RecoveryNotifyContact { .. } => None,
+            TrustRecoveryCommand::RecoveryNotifyContact { .. } => None,
             TrustRecoveryCommand::CreateGovernanceCheckpoint { payload, .. } => {
                 Some(payload.context_id.as_str())
             }
@@ -3386,8 +3370,8 @@ impl Supervisor {
     }
 
     /// Direct supervisor-scoped dispatch for [`TrustRecoveryCommand`]
-    /// variants that have no per-context actor target (`Placeholder`,
-    /// `RecoveryNotifyContact`) or whose actor is not registered
+    /// variants that have no per-context actor target
+    /// (`RecoveryNotifyContact`) or whose actor is not registered
     /// (`CreateGovernanceCheckpoint` / `AddCheckpointCosignature` /
     /// `RecoveryAdvanceEpoch` / `RecoverySendNotification` —
     /// unregistered-context fallback).
@@ -3423,12 +3407,6 @@ impl Supervisor {
         const TRUST_RECOVERY_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(30);
 
         match cmd {
-            TrustRecoveryCommand::Placeholder { reply } => {
-                const MSG: &str = "TrustRecoveryCommand::Placeholder — mailbox-pipe smoke target; \
-                                   no production work";
-                let _ = reply.send(Err(ContextError::NotImplemented(MSG.to_owned())));
-                Outcome::err(ContextError::NotImplemented(MSG.to_owned()))
-            }
             TrustRecoveryCommand::RecoveryNotifyContact { payload, reply } => {
                 let recovering_did = payload.recovering_did.clone();
                 let signing_key = payload.signing_key.to_signing_key();
@@ -3822,14 +3800,13 @@ impl Supervisor {
             self.actors.insert(ctx_id.clone(), handle.clone());
         }
 
-        // Spawn the actor's dispatch loop. During the 12b.2a → 12b.2b
-        // window the existing no-state `spawn_actor` signature routes
-        // through [`ContextActor::new_skeleton`] — the state still
-        // lives on `ContextManager`, and the shim dispatch (see
-        // [`Self::dispatch_command`] family) continues to delegate
-        // there. [`Self::spawn_actor_with_state`] is the post-12b.2a
-        // path that takes owned state + deps and constructs a
-        // state-carrying actor via [`ContextActor::new`].
+        // Spawn the actor's dispatch loop. This state-less `spawn_actor`
+        // path constructs the actor via [`ContextActor::new_skeleton`],
+        // whose `run()` loop ACKs every command through
+        // `skeleton_dispatch`. It is dead-code / test-only: production
+        // bootstrap spawns state-owning actors via
+        // [`Self::spawn_actor_with_state`] (constructed via
+        // [`ContextActor::new`]), which own their context state directly.
         let inbox = rx;
         tokio::spawn(async move {
             Box::pin(crate::context::actor::ContextActor::new_skeleton(ctx_id, inbox).run()).await;
@@ -4699,7 +4676,7 @@ impl Supervisor {
     /// row 11).
     ///
     /// Same shape as [`Self::dispatch_governance_command`]. Covers the
-    /// contact-graph (standing context) paths from spec §5.12.4.
+    /// contact-graph (standing context) paths from spec §5.12.6.
     ///
     /// # Errors
     ///
@@ -4741,12 +4718,6 @@ impl Supervisor {
         const STANDING_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(30);
 
         match cmd {
-            StandingCommand::Placeholder { reply } => {
-                const MSG: &str =
-                    "StandingCommand::Placeholder — handshake target; no production work";
-                let _ = reply.send(Err(ContextError::NotImplemented(MSG.to_owned())));
-                Outcome::err(ContextError::NotImplemented(MSG.to_owned()))
-            }
             StandingCommand::StandingContext {
                 local_did,
                 peer_did,
@@ -4855,9 +4826,7 @@ impl Supervisor {
         // on the actor. Reaching the fallback means no actor is
         // registered for the target context — surface a typed
         // `ContextNotRegistered` on the command's reply oneshot.
-        if let Some(ctx_id) = Self::tools_command_context_id(&cmd)
-            && let Some(actor) = self.lookup(ctx_id)
-        {
+        if let Some(actor) = self.lookup(Self::tools_command_context_id(&cmd)) {
             return Self::dispatch_via_mailbox(&actor, ContextCommand::Tools(cmd)).await;
         }
 
@@ -4906,16 +4875,9 @@ impl Supervisor {
 
     /// Reply to a [`ToolsCommand`] whose target context has no registered
     /// actor with a typed [`ContextError::ContextNotRegistered`] on the
-    /// variant's reply oneshot. The placeholder variant keeps its own typed
-    /// reply.
+    /// variant's reply oneshot.
     fn reply_tools_not_registered(cmd: ToolsCommand) -> Outcome<()> {
         match cmd {
-            ToolsCommand::Placeholder { reply } => {
-                const MSG: &str =
-                    "ToolsCommand::Placeholder — handshake target; no production work";
-                let _ = reply.send(Err(ContextError::NotImplemented(MSG.to_owned())));
-                Outcome::err(ContextError::NotImplemented(MSG.to_owned()))
-            }
             ToolsCommand::TryConsumeHardRateLimit {
                 context_id, reply, ..
             } => {
@@ -4966,18 +4928,12 @@ impl Supervisor {
     ///
     /// Per-context variants (subscribe/unsubscribe/block/unblock/key
     /// request/queries) get a typed [`ContextError::ContextNotRegistered`]
-    /// on their reply oneshot. The custody-bound publish variants, the
-    /// two-phase reserve/apply/release variants, and the placeholder keep
-    /// their own typed replies (these never reach a per-context actor
-    /// through this no-custody router).
+    /// on their reply oneshot. The custody-bound publish variants and the
+    /// two-phase reserve/apply/release variants keep their own typed
+    /// replies (these never reach a per-context actor through this
+    /// no-custody router).
     fn reply_broadcast_not_registered(cmd: BroadcastCommand) -> Outcome<()> {
         match cmd {
-            BroadcastCommand::Placeholder { reply } => {
-                const MSG: &str =
-                    "BroadcastCommand::Placeholder — handshake target; no production work";
-                let _ = reply.send(Err(ContextError::NotImplemented(MSG.to_owned())));
-                Outcome::err(ContextError::NotImplemented(MSG.to_owned()))
-            }
             BroadcastCommand::SubscribeBroadcast { payload, reply } => {
                 let err = ContextError::ContextNotRegistered(payload.context_id.clone());
                 let sketch = standing_outcome_error_sketch(&err);
@@ -5482,8 +5438,10 @@ impl Supervisor {
     /// "channel-authenticated identity" requirement, before any value is passed
     /// into this entry point. This is a forward obligation tied to the deferred
     /// FFI surface (mirroring the ADR-049 §3a forward-obligation discipline and
-    /// the CLAUDE.md integration checklist: function → ContextManager → FFI →
-    /// SDK → `pipeline_wiring` assertion). It is recorded here as the upstream
+    /// the CLAUDE.md integration checklist: function → manager-surface method —
+    /// today the `Supervisor`, the checklist's wording predating the
+    /// `ContextManager` deletion — → FFI → SDK → `pipeline_wiring` assertion).
+    /// It is recorded here as the upstream
     /// anchor; the co-resident core path does not yet have an untrusted leg, so
     /// the obligation lands with the wiring, not in this function.
     ///
@@ -9751,12 +9709,13 @@ impl Supervisor {
     /// receive buffer via the actor mailbox, leaving every other buffered
     /// event in place and in order.
     ///
-    /// The reconnection driver uses this instead of [`drain_events`] so
-    /// that application traffic (messages, membership changes) buffered
-    /// during catch-up is preserved for the SDK's normal receive polling
-    /// rather than being silently discarded. Same soft-default contract as
-    /// [`drain_events`]: returns an empty `Vec` on unknown context, mailbox
-    /// enqueue failure, or dropped reply channel.
+    /// The reconnection driver uses this instead of
+    /// [`Self::drain_events`] so that application traffic (messages,
+    /// membership changes) buffered during catch-up is preserved for
+    /// the SDK's normal receive polling rather than being silently
+    /// discarded. Same soft-default contract as [`Self::drain_events`]:
+    /// returns an empty `Vec` on unknown context, mailbox enqueue
+    /// failure, or dropped reply channel.
     #[must_use]
     pub async fn drain_equivocation_alerts(&self, context_id: &str) -> Vec<ContextEvent> {
         let (tx, rx) = tokio::sync::oneshot::channel();
@@ -10883,8 +10842,7 @@ impl Supervisor {
 
     /// Extract the target context_id from a [`LifecycleCommand`].
     ///
-    /// Returns `None` for [`LifecycleCommand::Placeholder`] (no target)
-    /// and [`LifecycleCommand::ImportContext`] (the export envelope
+    /// Returns `None` for [`LifecycleCommand::ImportContext`] (the export envelope
     /// carries the canonical 32-byte hash, not a string context_id —
     /// the legacy `import_context` derives the string from the
     /// envelope's params; until the lifecycle handler is rewritten to
@@ -10917,13 +10875,12 @@ impl Supervisor {
             // `import_context` helper derives it from the envelope's
             // params. The dispatch helper routes ImportContext through
             // the direct-shim path until the lifecycle handler is
-            // rewritten to surface that derivation. Placeholder has no
-            // target at all. Sweep commands (`FlushSnapshot`,
-            // `ShutdownSelf`) are dispatched per-actor by the
-            // supervisor's iterating entry points in `lifecycle_helpers`;
-            // routing target is decided at the iteration site.
+            // rewritten to surface that derivation. Sweep commands
+            // (`FlushSnapshot`, `ShutdownSelf`) are dispatched per-actor
+            // by the supervisor's iterating entry points in
+            // `lifecycle_helpers`; routing target is decided at the
+            // iteration site.
             LifecycleCommand::ImportContext { .. }
-            | LifecycleCommand::Placeholder { .. }
             | LifecycleCommand::FlushSnapshot { .. }
             | LifecycleCommand::ShutdownSelf { .. }
             | LifecycleCommand::ReportBufferLen { .. } => None,
@@ -10961,8 +10918,8 @@ impl Supervisor {
                 Some(payload.context_id.as_str())
             }
             // PublishBroadcast / PublishBroadcastContent need
-            // KeyCustody on the shim; Placeholder has no string target
-            // for this router.
+            // KeyCustody on the shim, so they have no string target for
+            // this custody-free router.
             _ => None,
         }
     }
@@ -10973,8 +10930,9 @@ impl Supervisor {
     /// helper can route through the per-context actor's mailbox. The
     /// boxed-payload variants (`StartTtlTimer` / `ResetTtlTimer` /
     /// `ExecuteTtlClose` / `FinalizeClose`) destructure their payloads to
-    /// expose the embedded `context_id`. Only [`TtlCloseCommand::Placeholder`]
-    /// returns `None` (no target).
+    /// expose the embedded `context_id`. Only [`TtlCloseCommand::FireTimer`]
+    /// returns `None` (it resolves its own actor and has no routable
+    /// `context_id` field).
     const fn ttl_close_command_context_id(cmd: &TtlCloseCommand) -> Option<&str> {
         match cmd {
             TtlCloseCommand::ExtendTtl { context_id, .. } => Some(context_id.as_str()),
@@ -10986,8 +10944,8 @@ impl Supervisor {
             // TTL timer task resolves the actor itself via
             // [`Self::lookup`] and mailboxes the command through the
             // returned handle, so it never routes through
-            // `dispatch_ttl_close_command`. `Placeholder` has no target.
-            TtlCloseCommand::FireTimer { .. } | TtlCloseCommand::Placeholder { .. } => None,
+            // `dispatch_ttl_close_command`.
+            TtlCloseCommand::FireTimer { .. } => None,
         }
     }
 
@@ -10996,8 +10954,8 @@ impl Supervisor {
     /// Every per-context variant — including the boxed-payload propose
     /// / vote / execute variants — surfaces its `context_id` so the
     /// dispatch helper can route through the per-context actor's
-    /// mailbox. Only [`GovernanceCommand::Placeholder`] returns `None`
-    /// (no target).
+    /// mailbox. The sweep / timeout-task variants return `None` (no
+    /// routable target — see the arm comment).
     fn governance_command_context_id(cmd: &GovernanceCommand) -> Option<&str> {
         match cmd {
             GovernanceCommand::GetProposal { context_id, .. }
@@ -11028,8 +10986,7 @@ impl Supervisor {
             // decided at the iteration site (one command per known
             // actor). Returning `None` here keeps `dispatch_governance_command`
             // from accepting them — sweeps must use the iterating helpers.
-            GovernanceCommand::Placeholder { .. }
-            | GovernanceCommand::EvaluatePeriodicConsequences { .. }
+            GovernanceCommand::EvaluatePeriodicConsequences { .. }
             | GovernanceCommand::ProcessPendingCommits { .. }
             | GovernanceCommand::EvaluateTimeouts { .. }
             // `StartTimeoutTask` is dispatched directly to the owning
@@ -11043,7 +11000,7 @@ impl Supervisor {
     /// Extract the target context_id from a [`StandingCommand`].
     ///
     /// Every current variant is supervisor-scoped (get-or-create / count /
-    /// has / register / reconnect-all / placeholder): they touch the
+    /// has / register / reconnect-all): they touch the
     /// supervisor's standing index or the get-or-create path directly, not a
     /// pre-existing per-context actor's state, so they return `None` and
     /// dispatch routes them to the SupervisorHandle.
@@ -11067,7 +11024,6 @@ impl Supervisor {
             // exactly like the other supervisor-scoped standing-index
             // variants below.
             StandingCommand::StandingContext { .. }
-            | StandingCommand::Placeholder { .. }
             | StandingCommand::StandingContextCount { .. }
             | StandingCommand::HasStandingContext { .. }
             | StandingCommand::RegisterStandingContext { .. }
@@ -11076,13 +11032,12 @@ impl Supervisor {
     }
 
     /// Extract the target context_id from a [`ToolsCommand`].
-    const fn tools_command_context_id(cmd: &ToolsCommand) -> Option<&str> {
+    const fn tools_command_context_id(cmd: &ToolsCommand) -> &str {
         match cmd {
             ToolsCommand::TryConsumeHardRateLimit { context_id, .. }
             | ToolsCommand::RefundHardRateLimit { context_id, .. }
             | ToolsCommand::ReserveToolEconomy { context_id, .. }
-            | ToolsCommand::SettleToolEconomy { context_id, .. } => Some(context_id.as_str()),
-            ToolsCommand::Placeholder { .. } => None,
+            | ToolsCommand::SettleToolEconomy { context_id, .. } => context_id.as_str(),
         }
     }
 
@@ -12068,15 +12023,28 @@ mod tests {
             "actor must be registered under hex-encoded context id"
         );
 
-        // Handle is alive — send a placeholder messaging command and
-        // observe the skeleton dispatch's `NotImplemented` ack. This
-        // exercises both the mpsc plumbing and the
-        // `ContextActor::new` + `run()` happy path.
-        let err = handle
-            .send(|reply| ContextCommand::Messaging(MessagingCommand::Placeholder { reply }))
+        // Handle is alive — send a read-only member-count query and
+        // observe the actor answer it. This exercises both the mpsc
+        // plumbing and the `ContextActor::new` + `run()` happy path.
+        let count = handle
+            .send(|reply| {
+                ContextCommand::Queries(QueriesCommand::MemberCount {
+                    context_id: expected_ctx_key.clone(),
+                    reply,
+                })
+            })
             .await
-            .expect_err("skeleton dispatch still ACKs NotImplemented in 12b.2a");
-        assert!(matches!(err, ContextError::NotImplemented(_)));
+            .expect("member-count query round-trips through the live actor");
+        // The test fixture (`new_for_test_encrypted`) seeds the admin DID into
+        // `governance`, not into `membership`, so the roster is empty and
+        // `MemberCount` (which reads `state.membership.count()`) answers the
+        // exact count 0 — not merely "some" count.
+        assert_eq!(
+            count,
+            Some(0),
+            "the owning actor answers MemberCount with the exact roster count \
+             (empty test fixture ⇒ 0)"
+        );
 
         // Cleanly shut down.
         handle.send_shutdown().await.unwrap();
@@ -12425,10 +12393,15 @@ mod tests {
         );
 
         // The actor must still be alive after the reject — prove it by
-        // issuing a follow-up command and observing a reply (not an
-        // ActorBusy/closed-inbox error).
-        let followup: Result<(), ContextError> = handle
-            .send(|reply| ContextCommand::Messaging(MessagingCommand::Placeholder { reply }))
+        // issuing a follow-up read-only query and observing a reply (not
+        // an ActorBusy/closed-inbox error).
+        let followup: Result<Option<usize>, ContextError> = handle
+            .send(|reply| {
+                ContextCommand::Queries(QueriesCommand::MemberCount {
+                    context_id: hex::encode(ctx_id_bytes),
+                    reply,
+                })
+            })
             .await;
         assert!(
             !matches!(followup, Err(ContextError::ActorBusy(_))),
@@ -12486,8 +12459,13 @@ mod tests {
         // The actor claimed itself terminal and exits — a follow-up send
         // must observe the closed inbox. (The supervisor despawns the
         // dead handle in the import path; here we just prove termination.)
-        let followup: Result<(), ContextError> = handle
-            .send(|reply| ContextCommand::Messaging(MessagingCommand::Placeholder { reply }))
+        let followup: Result<Option<usize>, ContextError> = handle
+            .send(|reply| {
+                ContextCommand::Queries(QueriesCommand::MemberCount {
+                    context_id: ctx_key.clone(),
+                    reply,
+                })
+            })
             .await;
         assert!(
             matches!(followup, Err(ContextError::ActorBusy(_))),
@@ -13857,7 +13835,8 @@ mod tests {
         let result = sup
             .dispatch_command(
                 &ctx_key,
-                crate::context::actor::commands::MessagingCommand::Placeholder {
+                crate::context::actor::commands::MessagingCommand::DrainEvents {
+                    context_id: ctx_key.clone(),
                     reply: tokio::sync::oneshot::channel().0,
                 },
             )
@@ -13937,7 +13916,8 @@ mod tests {
         let result = sup
             .dispatch_command(
                 &ctx_key,
-                crate::context::actor::commands::MessagingCommand::Placeholder {
+                crate::context::actor::commands::MessagingCommand::DrainEvents {
+                    context_id: ctx_key.clone(),
                     reply: tokio::sync::oneshot::channel().0,
                 },
             )


### PR DESCRIPTION
## Summary

Delivers the **`Placeholder`-variant-resolution half** of ADR-049 Phase 2G: deletes the dead actor-mailbox `Placeholder` command variants that were scaffolding from the commit-6 enum-shape landing, and migrates the tests that leaned on them onto real commands. No production behavior changes — the placeholder variants were never reachable on any live dispatch path (real per-domain handlers already own the work; the only remaining `NotImplemented` producer is the intentional test-only `skeleton_dispatch` path).

> **Scope note:** Phase 2G (#18) is a two-part item — (a) delete the take-and-merge `send_tracker` shim, and (b) resolve the residual `Placeholder`/`NotImplemented` variants. **This PR is part (b) only.** Part (a) (`messaging.rs` wire-sequence still driven by `MembershipState::next_sequence_number` with `send_tracker` running in parallel) is untouched and remains live; **#18 stays open** for it. No closing keyword is used here.

## What it does

- **Deletes 8 dead `Placeholder` command variants** across the per-domain sub-enums (broadcast, economy, governance, lifecycle, messaging, standing, tools, trust_recovery, ttl_close) and their dead dispatch arms in `commands.rs` / `handlers/mod.rs` / `supervisor.rs`, plus the single-caller `reply_not_implemented` helpers.
- **Migrates the one messaging smoke-test placeholder** to a real read-only command: the tests that acked a placeholder now drive `QueriesCommand::MemberCount` (via a shared `smoke_query` helper), and the 2 poison-recovery tests drive `MessagingCommand::DrainEvents` (an empty-buffer-drain smoke-ping — harmless at both sites: rejected pre-execution when the actor is poisoned, drains a fresh empty buffer on the recovered actor).
- **Simplifies** `tools_command_context_id: Option<&str> → &str` (the `None` arm only ever fed a placeholder), collapsing a `let`-chain at the call site.
- **Reconciles stale doc-comments** left by the earlier commit-6→11 scaffolding narrative in `commands.rs` / `actor/mod.rs`, and removes three now-dangling references in `DEFERRED-commit-11-saga-use-cases.md` to the deleted `handlers/standing.rs reply_not_implemented` symbol. The DEFERRED reword preserves the accurate status — standing-pair single-context-async creation is reached via the idempotent `standing_context` get-or-create path, whose full protocol (peer KeyPackage fetch + `add_member` + Welcome + consent-on-receipt) remains unwired per §5.15.8 — without pointing at a deleted symbol or over-claiming that path is wired.

Net: **15 files, +212 / −419.**

## Verification

- `cargo fmt --all --check` — clean
- Full-feature workspace clippy (`--all-targets`, `-D warnings`, all bridge/testing features) — 0 warnings
- `cargo nextest run -p scp-runtime --features testing` — **2159 passed**, 2 skipped (incl. both `DrainEvents` poison-recovery tests and the migrated `smoke_query` tests)
- `cargo doc -p scp-runtime --no-deps` — no new broken intra-doc links
- No enforcement files touched; no issue-number references in source.

## Follow-up (not this PR)

The ~747-line test-only `skeleton_dispatch` apparatus (`new_skeleton` + 11 per-domain `skeleton_dispatch_*` mirrors, `spawn_actor` marked `#[allow(dead_code)]`) is the last commit-6→12 migration scaffolding, kept reachable only by 4 lifecycle fixtures. Converging it onto state-bearing fixtures + deleting the apparatus is a clean next chunk, tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
