### PR TITLE
fix(ffi): make presenting_agent_did a required non-Option field on ucan_validate/ucan_evaluate (PyO3, NAPI)

### DIFF
--- a/bindings/python/scp_sdk/_scp_core.pyi
+++ b/bindings/python/scp_sdk/_scp_core.pyi
@@ -764,15 +764,15 @@ class SCP:
         context_id: Any,
         token: Any,
         capability: Any,
-        presenting_agent_did: Any = ...,
+        presenting_agent_did: Any,
         proof_tokens: Any = ...,
     ) -> Any: ...
     def ucan_evaluate(
         self,
         context_id: Any,
         token: Any,
-        capability: Any = ...,
-        presenting_agent_did: Any = ...,
+        capability: Any,
+        presenting_agent_did: Any,
         proof_tokens: Any = ...,
     ) -> Any: ...
     def __repr__(self) -> str: ...

--- a/bindings/python/tests/test_real_ffi.py
+++ b/bindings/python/tests/test_real_ffi.py
@@ -601,12 +601,13 @@ class TestUcan:
             pass  # May fail depending on implementation state
 
     async def test_ucan_validate_fails_closed_without_presenting_agent(self, scp: SCP):
-        """The ENFORCING ucan_validate gate rejects an absent presenting agent.
+        """The ENFORCING ucan_validate gate requires a presenting agent.
 
-        Symmetric with the diagnostic ucan_evaluate gate: defaulting the
-        presenting agent to the token's own ``aud`` would make the step-5
-        audience check a tautology and inflate trust. The fail-closed check fires
-        before token parse, so any well-formed token string reaches it.
+        ``presenting_agent_did`` is a REQUIRED (non-optional) parameter: it is
+        never defaulted to the token's own ``aud`` (which would make the step-5
+        audience check a tautology and inflate trust). Omitting it is a
+        ``TypeError`` at the PyO3 boundary; an empty/whitespace value is trimmed
+        and rejected by ``validate_did`` as an invalid DID before token parse.
         """
         alice = await scp.identity_create(CustodyType.IN_MEMORY)
         handle = scp._native.context_create(
@@ -617,11 +618,13 @@ class TestUcan:
                 "governance": "single_admin",
             },
         )
-        # Omitted presenting agent → rejected.
-        with pytest.raises(Exception, match="presenting_agent_did is required"):
+        # Omitted presenting agent → the parameter is required, so PyO3 raises
+        # TypeError for the missing positional argument (no silent aud default).
+        with pytest.raises(TypeError):
             scp._native.ucan_validate(handle.context_id, "header.payload.sig", "messages:read")
-        # Empty / whitespace presenting agent → also rejected.
-        with pytest.raises(Exception, match="presenting_agent_did is required"):
+        # Empty / whitespace presenting agent → trimmed, then rejected as an
+        # invalid DID (empty after trim).
+        with pytest.raises(Exception, match="DID"):
             scp._native.ucan_validate(
                 handle.context_id, "header.payload.sig", "messages:read", "   "
             )

--- a/bindings/typescript/tests/real-napi.test.ts
+++ b/bindings/typescript/tests/real-napi.test.ts
@@ -650,11 +650,13 @@ if (!napiAvailable || createNativeBridge === null || rawAddon === null) {
       const token = await napi.ucanMint(ctx, member.did, ["messages:read"]);
       const fullUri = token.capabilities[0] as string;
 
-      // No presenting agent → the gate MUST reject rather than default the
+      // Empty presenting agent → the gate MUST reject rather than default the
       // audience check to the token's own `aud` (which would be a tautology that
-      // inflates trust). The fail-closed check fires before nonce recording, so
-      // the token's nonce is NOT consumed and the control call below still works.
-      await expect(napi.ucanValidate(ctx, token.encoded, fullUri)).rejects.toThrow();
+      // inflates trust). presenting_agent_did is a required (non-optional)
+      // parameter; an empty string is rejected by validate_did. The fail-closed
+      // check fires before nonce recording, so the token's nonce is NOT consumed
+      // and the control call below still works.
+      await expect(napi.ucanValidate(ctx, token.encoded, fullUri, "")).rejects.toThrow();
 
       // Control: supplying the subject (the token's audience) passes.
       await napi.ucanValidate(ctx, token.encoded, fullUri, member.did);

--- a/crates/scp-ffi/napi/src/scp.rs
+++ b/crates/scp-ffi/napi/src/scp.rs
@@ -3100,7 +3100,7 @@ impl Scp {
         handle: &NapiContextHandle,
         token: String,
         capability: String,
-        presenting_agent_did: Option<String>,
+        presenting_agent_did: String,
         proof_tokens: Option<Vec<String>>,
     ) -> napi::Result<()> {
         crate::napi_check_handle!(&self.inner.core, handle);
@@ -3133,7 +3133,7 @@ impl Scp {
         handle: &NapiContextHandle,
         token: String,
         capability: Option<String>,
-        presenting_agent_did: Option<String>,
+        presenting_agent_did: String,
         proof_tokens: Option<Vec<String>>,
     ) -> napi::Result<crate::ucan::NapiCapabilityValidation> {
         crate::napi_check_handle!(&self.inner.core, handle);

--- a/crates/scp-ffi/napi/src/ucan.rs
+++ b/crates/scp-ffi/napi/src/ucan.rs
@@ -251,32 +251,19 @@ pub(crate) async fn ucan_validate_on(
     handle: &NapiContextHandle,
     token: String,
     capability: String,
-    presenting_agent_did: Option<String>,
+    presenting_agent_did: String,
     proof_tokens: Option<Vec<String>>,
 ) -> napi::Result<()> {
     crate::napi_check_handle!(&bi.core, handle);
     validate_ucan_token(&token).map_err(|e| napi::Error::from(ScpNapiError::from(e)))?;
     validate_capability_uri(&capability).map_err(|e| napi::Error::from(ScpNapiError::from(e)))?;
 
-    // FAIL CLOSED (no silent security default): require an explicit presenting
-    // agent DID instead of defaulting to the token's own `aud` (which would make
-    // the step-5 audience check tautological and inflate trust). Validated as a
-    // pure input before any state lookup / token parse — mirrors
-    // `ucan_evaluate_on`.
-    let agent_did = presenting_agent_did
-        .as_deref()
-        .map(str::trim)
-        .filter(|did| !did.is_empty())
-        .ok_or_else(|| {
-            napi::Error::from(ScpNapiError::Validation {
-                message: "presenting_agent_did is required: ucan_validate will not default to \
-                          the token's audience"
-                    .to_owned(),
-                code: codes::VALID_7010.to_owned(),
-            })
-        })?;
-    // Input hygiene parity with the PyO3 reference: validate the trimmed
-    // presenting agent DID before any state lookup / token parse.
+    // FAIL CLOSED (no silent security default): `presenting_agent_did` is a
+    // REQUIRED parameter — never defaulted to the token's own `aud` (which would
+    // make the step-5 audience check tautological and inflate trust). Validated as
+    // a pure input before any state lookup / token parse — mirrors
+    // `ucan_evaluate_on`. `validate_did` rejects an empty/whitespace value.
+    let agent_did = presenting_agent_did.trim();
     validate_did(agent_did).map_err(|e| napi::Error::from(ScpNapiError::from(e)))?;
 
     // Ensure the context's persistent runtime state (RevocationList, NonceTracker)
@@ -353,13 +340,13 @@ pub(crate) async fn ucan_validate_on(
 /// validity with no invoked-capability grant-match challenge (mirroring
 /// `evaluate_ucan(None, ..)`); `Some` additionally requires the token grants it.
 ///
-/// FAIL CLOSED: `presenting_agent_did` is required (no silent security default).
-/// When it is `None` or empty this returns a validation error rather than
-/// defaulting to the token's own `aud` — defaulting would make the step-5
-/// audience check a tautological self-check (`aud == aud`) that does NOT bind the
-/// token to any external subject, so a token addressed to someone else would
-/// report `signatures_valid` (trust inflation). The SDK trust path always passes
-/// the subject; raw diagnostic callers must now pass an explicit presenting agent.
+/// FAIL CLOSED: `presenting_agent_did` is a REQUIRED (non-optional) parameter (no
+/// silent security default). It is never defaulted to the token's own `aud` —
+/// defaulting would make the step-5 audience check a tautological self-check
+/// (`aud == aud`) that does NOT bind the token to any external subject, so a token
+/// addressed to someone else would report `signatures_valid` (trust inflation). An
+/// empty/whitespace value is rejected by `validate_did`. The SDK trust path always
+/// passes the subject; raw diagnostic callers must pass an explicit presenting agent.
 #[allow(clippy::unused_async)] // napi-rs requires async for Promise return
 #[allow(clippy::needless_pass_by_value)] // napi-rs requires owned String/Option<Vec>
 pub(crate) async fn ucan_evaluate_on(
@@ -367,7 +354,7 @@ pub(crate) async fn ucan_evaluate_on(
     handle: &NapiContextHandle,
     token: String,
     capability: Option<String>,
-    presenting_agent_did: Option<String>,
+    presenting_agent_did: String,
     proof_tokens: Option<Vec<String>>,
 ) -> napi::Result<NapiCapabilityValidation> {
     crate::napi_check_handle!(&bi.core, handle);
@@ -379,24 +366,12 @@ pub(crate) async fn ucan_evaluate_on(
         validate_capability_uri(cap).map_err(|e| napi::Error::from(ScpNapiError::from(e)))?;
     }
 
-    // FAIL CLOSED (no silent security default): require an explicit presenting
-    // agent DID instead of defaulting to the token's own `aud` (which would make
-    // the step-5 audience check tautological and inflate trust). Validated as a
-    // pure input before any state lookup.
-    let agent_did = presenting_agent_did
-        .as_deref()
-        .map(str::trim)
-        .filter(|did| !did.is_empty())
-        .ok_or_else(|| {
-            napi::Error::from(ScpNapiError::Validation {
-                message: "presenting_agent_did is required: ucan_evaluate will not default to \
-                          the token's audience"
-                    .to_owned(),
-                code: codes::VALID_7010.to_owned(),
-            })
-        })?;
-    // Input hygiene parity with the PyO3 reference: validate the trimmed
-    // presenting agent DID before any state lookup / token parse.
+    // FAIL CLOSED (no silent security default): `presenting_agent_did` is a
+    // REQUIRED parameter — never defaulted to the token's own `aud` (which would
+    // make the step-5 audience check tautological and inflate trust). Validated as
+    // a pure input before any state lookup. `validate_did` rejects an
+    // empty/whitespace value.
+    let agent_did = presenting_agent_did.trim();
     validate_did(agent_did).map_err(|e| napi::Error::from(ScpNapiError::from(e)))?;
 
     // Ensure the context's persistent runtime state (RevocationList, NonceTracker)
@@ -1497,12 +1472,13 @@ mod tests {
         );
     }
 
-    /// SECURITY (Finding 2). `ucan_evaluate` MUST reject an omitted
+    /// SECURITY (Finding 2). `ucan_evaluate` MUST reject an empty/whitespace
     /// `presenting_agent_did` rather than defaulting to the token's own `aud`.
-    /// The check is a pure-input gate before context lookup / token parse, so a
-    /// dummy token suffices.
+    /// Omission is impossible — the parameter is a required non-`Option` `String`,
+    /// so the type system enforces presence. The check is a pure-input gate before
+    /// context lookup / token parse, so a dummy token suffices.
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-    async fn ucan_evaluate_requires_presenting_agent_did() {
+    async fn ucan_evaluate_rejects_empty_presenting_agent_did() {
         let bi = std::sync::Arc::new(crate::runtime::NapiBridgeInstance::new_napi());
         let handle = crate::context::NapiContextHandle::test_active_on(
             &bi,
@@ -1510,26 +1486,12 @@ mod tests {
             "did:dht:z6MkCreator".to_owned(),
         );
 
-        let omitted = ucan_evaluate_on(
-            &bi,
-            &handle,
-            "header.payload.sig".to_owned(),
-            None,
-            None,
-            None,
-        )
-        .await;
-        assert!(
-            omitted.is_err(),
-            "ucan_evaluate must fail closed when presenting_agent_did is omitted"
-        );
-
         let empty = ucan_evaluate_on(
             &bi,
             &handle,
             "header.payload.sig".to_owned(),
             None,
-            Some("   ".to_owned()),
+            "   ".to_owned(),
             None,
         )
         .await;
@@ -1540,11 +1502,13 @@ mod tests {
     }
 
     /// SECURITY (symmetric gate hardening). The ENFORCING `ucan_validate` gate
-    /// MUST reject an omitted / empty `presenting_agent_did` rather than
-    /// defaulting to the token's own `aud`. Pure-input gate before context
-    /// lookup / token parse, so a dummy token suffices.
+    /// MUST reject an empty/whitespace `presenting_agent_did` rather than
+    /// defaulting to the token's own `aud`. Omission is impossible — the parameter
+    /// is a required non-`Option` `String`, so the type system enforces presence.
+    /// Pure-input gate before context lookup / token parse, so a dummy token
+    /// suffices.
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-    async fn ucan_validate_requires_presenting_agent_did() {
+    async fn ucan_validate_rejects_empty_presenting_agent_did() {
         let bi = std::sync::Arc::new(crate::runtime::NapiBridgeInstance::new_napi());
         let handle = crate::context::NapiContextHandle::test_active_on(
             &bi,
@@ -1552,26 +1516,12 @@ mod tests {
             "did:dht:z6MkCreator".to_owned(),
         );
 
-        let omitted = ucan_validate_on(
-            &bi,
-            &handle,
-            "header.payload.sig".to_owned(),
-            "messages:write".to_owned(),
-            None,
-            None,
-        )
-        .await;
-        assert!(
-            omitted.is_err(),
-            "ucan_validate must fail closed when presenting_agent_did is omitted"
-        );
-
         let empty = ucan_validate_on(
             &bi,
             &handle,
             "header.payload.sig".to_owned(),
             "messages:write".to_owned(),
-            Some("   ".to_owned()),
+            "   ".to_owned(),
             None,
         )
         .await;

--- a/crates/scp-ffi/src/ucan.rs
+++ b/crates/scp-ffi/src/ucan.rs
@@ -246,13 +246,14 @@ impl crate::scp::PyScp {
     /// * `token` -- The encoded UCAN token string (JWT format).
     /// * `capability` -- The required capability URI (e.g.,
     ///   `"scp:ctx:abc123/messages:write"`).
-    /// * `presenting_agent_did` -- REQUIRED. The DID of the agent presenting the
-    ///   token. FAIL CLOSED (no silent security default): when it is absent or
-    ///   empty this method returns a validation error rather than defaulting to
+    /// * `presenting_agent_did` -- REQUIRED (non-optional). The DID of the agent
+    ///   presenting the token. It is a required parameter — never defaulted to
     ///   the token's own `aud`. Defaulting would make the step-5 audience check a
     ///   tautological self-check (`aud == aud`) that does NOT bind the token to
     ///   any external subject, so a token addressed to someone else would pass
-    ///   (trust inflation). Mirrors the diagnostic `ucan_evaluate` gate.
+    ///   (trust inflation). An empty/whitespace value is rejected by
+    ///   `validate_did` (it is not a valid `did:` string). Mirrors the diagnostic
+    ///   `ucan_evaluate` gate.
     /// * `proof_tokens` -- Optional. List of encoded parent UCAN token strings
     ///   for delegation chain verification. Required when validating delegated
     ///   tokens with non-empty proof chains.
@@ -264,33 +265,28 @@ impl crate::scp::PyScp {
     /// insufficient capabilities, revoked token, nonce replay, etc.
     ///
     /// See ADR-016 §5 for the full 11-step validation specification.
-    #[pyo3(signature = (context_id, token, capability, presenting_agent_did=None, proof_tokens=None))]
+    #[pyo3(signature = (context_id, token, capability, presenting_agent_did, proof_tokens=None))]
     #[allow(clippy::needless_pass_by_value)] // PyO3 requires owned Option<Vec<String>> for method arguments.
     pub fn ucan_validate(
         &self,
         context_id: &str,
         token: &str,
         capability: &str,
-        presenting_agent_did: Option<&str>,
+        presenting_agent_did: &str,
         proof_tokens: Option<Vec<String>>,
     ) -> PyResult<()> {
         let bi = &*self.inner;
         validate::validate_context_id(context_id)?;
         validate::validate_ucan_token(token)?;
         validate::validate_capability_uri(capability)?;
-        // FAIL CLOSED (no silent security default): the presenting agent DID must
-        // be supplied explicitly. Defaulting to the token's own `aud` would make
-        // the step-5 audience check tautological (`aud == aud`), inflating trust
-        // for a token addressed to someone else. Mirrors `ucan_evaluate`.
-        let presenting_agent_did = presenting_agent_did
-            .map(str::trim)
-            .filter(|did| !did.is_empty())
-            .ok_or_else(|| {
-                ScpPyError::validation(
-                    "presenting_agent_did is required: ucan_validate will not default to the \
-                     token's audience",
-                )
-            })?;
+        // FAIL CLOSED (no silent security default): the presenting agent DID is a
+        // REQUIRED parameter (never defaulted to the token's own `aud`, which
+        // would make the step-5 audience check tautological and inflate trust for
+        // a token addressed to someone else). Trimmed for input hygiene (parity
+        // with `ucan_evaluate_on`/NAPI); `validate_did` then rejects an empty or
+        // whitespace-only value (not a valid `did:` string). Mirrors
+        // `ucan_evaluate`.
+        let presenting_agent_did = presenting_agent_did.trim();
         validate::validate_did(presenting_agent_did)?;
         if let Some(ref tokens) = proof_tokens {
             for t in tokens {
@@ -305,7 +301,7 @@ impl crate::scp::PyScp {
             ScpPyError::ucan(format!("invalid capability URI '{capability}': {e}"))
         })?;
 
-        // Presenting agent DID is required (fail-closed above) — never the token aud.
+        // Presenting agent DID is a required parameter — never the token aud.
         let agent_did = presenting_agent_did;
 
         // Build proof resolver from optional proof tokens.
@@ -360,14 +356,14 @@ impl crate::scp::PyScp {
     /// `context_id`, `token`, optional `capability`, REQUIRED
     /// `presenting_agent_did`, and optional `proof_tokens` for delegation chains.
     ///
-    /// FAIL CLOSED: `presenting_agent_did` is required (no silent security
-    /// default). When it is absent or empty this method returns a validation
-    /// error rather than defaulting to the token's own `aud` — defaulting would
-    /// make the step-5 audience check a tautological self-check (`aud == aud`)
-    /// that does NOT bind the token to any external subject, so a token addressed
-    /// to someone else would report `signatures_valid` (trust inflation). The SDK
-    /// trust path always passes the subject; raw diagnostic callers must now pass
-    /// an explicit presenting agent.
+    /// FAIL CLOSED: `presenting_agent_did` is a REQUIRED (non-optional) parameter
+    /// (no silent security default). It is never defaulted to the token's own
+    /// `aud` — defaulting would make the step-5 audience check a tautological
+    /// self-check (`aud == aud`) that does NOT bind the token to any external
+    /// subject, so a token addressed to someone else would report
+    /// `signatures_valid` (trust inflation). An empty/whitespace value is rejected
+    /// by `validate_did`. The SDK trust path always passes the subject; raw
+    /// diagnostic callers must pass an explicit presenting agent.
     ///
     /// `capability` is OPTIONAL. When omitted (or empty), the token is evaluated
     /// for INTRINSIC validity only — no specific capability is challenged, so the
@@ -390,14 +386,14 @@ impl crate::scp::PyScp {
     /// reported via the returned booleans, not as exceptions.
     ///
     /// See ADR-016 §5 and `CapabilityValidation` in scp-core.
-    #[pyo3(signature = (context_id, token, capability=None, presenting_agent_did=None, proof_tokens=None))]
+    #[pyo3(signature = (context_id, token, capability, presenting_agent_did, proof_tokens=None))]
     #[allow(clippy::needless_pass_by_value)] // PyO3 requires owned Option<Vec<String>> for method arguments.
     pub fn ucan_evaluate(
         &self,
         context_id: &str,
         token: &str,
         capability: Option<&str>,
-        presenting_agent_did: Option<&str>,
+        presenting_agent_did: &str,
         proof_tokens: Option<Vec<String>>,
     ) -> PyResult<PyCapabilityValidation> {
         let bi = &*self.inner;
@@ -409,19 +405,13 @@ impl crate::scp::PyScp {
         if let Some(cap) = capability {
             validate::validate_capability_uri(cap)?;
         }
-        // FAIL CLOSED (no silent security default): the presenting agent DID must
-        // be supplied explicitly. Defaulting to the token's own `aud` would make
-        // the step-5 audience check tautological (`aud == aud`), inflating trust
-        // for a token addressed to someone else.
-        let presenting_agent_did = presenting_agent_did
-            .map(str::trim)
-            .filter(|did| !did.is_empty())
-            .ok_or_else(|| {
-                ScpPyError::validation(
-                    "presenting_agent_did is required: ucan_evaluate will not default to the \
-                     token's audience",
-                )
-            })?;
+        // FAIL CLOSED (no silent security default): the presenting agent DID is a
+        // REQUIRED parameter (never defaulted to the token's own `aud`, which
+        // would make the step-5 audience check tautological and inflate trust for
+        // a token addressed to someone else). Trimmed for input hygiene (parity
+        // with NAPI); `validate_did` then rejects an empty or whitespace-only
+        // value (not a valid `did:` string).
+        let presenting_agent_did = presenting_agent_did.trim();
         validate::validate_did(presenting_agent_did)?;
         if let Some(ref tokens) = proof_tokens {
             for t in tokens {
@@ -441,7 +431,7 @@ impl crate::scp::PyScp {
             })
             .transpose()?;
 
-        // The presenting agent DID was validated and required above (fail-closed).
+        // The presenting agent DID is a required parameter, validated above.
         let agent_did = presenting_agent_did;
 
         // Build proof resolver from optional proof tokens.
@@ -1055,26 +1045,14 @@ mod tests {
     // ucan_evaluate fail-closed audience (no silent self-default)
     // -----------------------------------------------------------------------
 
-    /// SECURITY (Finding 2). `ucan_evaluate` MUST reject an omitted
-    /// `presenting_agent_did` rather than defaulting to the token's own `aud`
-    /// (which would make the audience check tautological and inflate trust). The
-    /// check fires before context lookup, so no registered context is needed.
-    #[test]
-    fn ucan_evaluate_requires_presenting_agent_did() {
-        let scp = crate::scp::PyScp::new_in_memory_for_test();
-        let result = scp.ucan_evaluate("ctx-1", "header.payload.sig", None, None, None);
-        assert!(
-            result.is_err(),
-            "ucan_evaluate must fail closed when presenting_agent_did is omitted"
-        );
-    }
-
-    /// An empty/whitespace `presenting_agent_did` is treated as absent and also
-    /// fails closed.
+    /// An empty/whitespace `presenting_agent_did` is rejected by `validate_did`
+    /// (it is not a valid `did:` string). Omission is impossible — the parameter
+    /// is a required non-`Option` `&str`, so the type system enforces presence.
+    /// The check fires before context lookup, so no registered context is needed.
     #[test]
     fn ucan_evaluate_rejects_empty_presenting_agent_did() {
         let scp = crate::scp::PyScp::new_in_memory_for_test();
-        let result = scp.ucan_evaluate("ctx-1", "header.payload.sig", None, Some("   "), None);
+        let result = scp.ucan_evaluate("ctx-1", "header.payload.sig", None, "   ", None);
         assert!(
             result.is_err(),
             "ucan_evaluate must fail closed when presenting_agent_did is empty"
@@ -1086,33 +1064,14 @@ mod tests {
     // with the diagnostic `ucan_evaluate` gate above.
     // -----------------------------------------------------------------------
 
-    /// SECURITY. The ENFORCING `ucan_validate` gate MUST reject an omitted
-    /// `presenting_agent_did` rather than defaulting to the token's own `aud`
-    /// (which would make the step-5 audience check tautological and inflate
-    /// trust). The check fires before context lookup, so no registered context is
-    /// needed.
-    #[test]
-    fn ucan_validate_requires_presenting_agent_did() {
-        let scp = crate::scp::PyScp::new_in_memory_for_test();
-        let result = scp.ucan_validate("ctx-1", "header.payload.sig", "messages:write", None, None);
-        assert!(
-            result.is_err(),
-            "ucan_validate must fail closed when presenting_agent_did is omitted"
-        );
-    }
-
-    /// An empty/whitespace `presenting_agent_did` is treated as absent and also
-    /// fails closed on the enforcing gate.
+    /// An empty/whitespace `presenting_agent_did` is rejected by `validate_did`
+    /// on the enforcing gate. Omission is impossible — the parameter is a required
+    /// non-`Option` `&str`, so the type system enforces presence.
     #[test]
     fn ucan_validate_rejects_empty_presenting_agent_did() {
         let scp = crate::scp::PyScp::new_in_memory_for_test();
-        let result = scp.ucan_validate(
-            "ctx-1",
-            "header.payload.sig",
-            "messages:write",
-            Some("   "),
-            None,
-        );
+        let result =
+            scp.ucan_validate("ctx-1", "header.payload.sig", "messages:write", "   ", None);
         assert!(
             result.is_err(),
             "ucan_validate must fail closed when presenting_agent_did is empty"


### PR DESCRIPTION
Makes `presenting_agent_did` a **required, non-`Option`** parameter on `ucan_validate` and `ucan_evaluate` in the PyO3 and NAPI bridges, converting a body-only runtime check into a type-enforced contract. It is semantically required today (the C3c audience-binding security fix — it must NOT default to the token's `aud`), but was exposed as `Option`, so the type advertised it as omittable and an LLM author could write a call that only fails at runtime. Per the agent-first tenet (no silent security defaults; required choices are required fields).

UniFFI already used required `String`; all four SDK wrappers already require it; the WASM bridge #1917 centered on was removed per ADR-055 — so only PyO3 + NAPI + the `.pyi` stub + their Rust tests remained. `capability` on `ucan_evaluate` stays `Option`-typed. `.trim()` restored on both bridges for PyO3↔NAPI parity. The `_requires_` (omitted-arg) tests became type-impossible and were removed; the `_rejects_empty_` tests are kept/updated.

Verified: full-feature clippy clean; `scp-ffi` ucan 21 + `scp-ffi-napi` ucan 26 pass; Python `pytest` 643 passed; TS `bun test` 651 passed.

Closes #1993, closes #1917.

🤖 Generated with [Claude Code](https://claude.com/claude-code)