### PR TITLE
fix(clock): time-discipline hygiene — panic=abort gate, fail-closed write-stamps, §9.14 knob docs (closes #1994)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -299,6 +299,21 @@ jobs:
       - uses: actions/checkout@v5
       - run: bash scripts/check-handler-no-panic.sh
 
+  no-panic-abort:
+    needs: check-draft
+    name: FFI / no panic=abort in cdylib profiles
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+      # Self-test MUST run first: it plants panic = "abort" in a scratch
+      # manifest (must be DETECTED) and confirms benign lines
+      # (panic = "unwind" / the clippy lint panic = "deny" / a comment) are
+      # NOT flagged — proving the gate is alive before we trust it on the tree.
+      - name: Self-test gate
+        run: bash scripts/check-no-panic-abort.sh --self-test
+      - name: Real check
+        run: bash scripts/check-no-panic-abort.sh
+
   saga-gating-granularity:
     needs: check-draft
     name: Actor / saga gating granularity (ADR-049 §3a)
@@ -1067,6 +1082,7 @@ jobs:
       - bridge-globals
       - fallback-registry
       - handle-affinity
+      - no-panic-abort
       - no-mutable-globals-rust
       - no-mutable-globals-python
       - no-mutable-globals-ts
@@ -1105,6 +1121,7 @@ jobs:
             "${{ needs.bridge-globals.result }}" \
             "${{ needs.fallback-registry.result }}" \
             "${{ needs.handle-affinity.result }}" \
+            "${{ needs.no-panic-abort.result }}" \
             "${{ needs.no-mutable-globals-rust.result }}" \
             "${{ needs.no-mutable-globals-python.result }}" \
             "${{ needs.no-mutable-globals-ts.result }}" \

--- a/crates/scp-ffi/common/src/resolvers.rs
+++ b/crates/scp-ffi/common/src/resolvers.rs
@@ -865,11 +865,7 @@ impl scp_core::crypto::ucan::revoke::RevocationEventLogger for BridgeRevocationE
             revoker_did,
         )?;
 
-        // Unix timestamp seconds fit in u64 for centuries.
-        #[allow(clippy::cast_possible_truncation)]
-        let timestamp = std::time::SystemTime::now()
-            .duration_since(std::time::UNIX_EPOCH)
-            .map_or(0, |d| d.as_secs());
+        let timestamp = scp_clock::Clock::now_secs(&scp_clock::SystemClock);
 
         let event = scp_event_log::Event {
             event_type: scp_event_log::EventType::TokenRevoked,

--- a/crates/scp-ffi/napi/src/context.rs
+++ b/crates/scp-ffi/napi/src/context.rs
@@ -2101,10 +2101,7 @@ pub(crate) async fn broadcast_subscribe_on(
     let sup = crate::runtime::supervisor(bi)?;
     let context_id = handle.context_id.clone();
     let did: DID = DID(subscriber_did);
-    let timestamp = std::time::SystemTime::now()
-        .duration_since(std::time::UNIX_EPOCH)
-        .unwrap_or_default()
-        .as_secs();
+    let timestamp = scp_clock::Clock::now_secs(&scp_clock::SystemClock);
 
     let (tx, rx) = tokio::sync::oneshot::channel();
     let cmd = BroadcastCommand::SubscribeBroadcast {

--- a/crates/scp-ffi/napi/src/provenance.rs
+++ b/crates/scp-ffi/napi/src/provenance.rs
@@ -330,10 +330,7 @@ fn append_provenance_event(
     event_type: scp_event_log::EventType,
     provenance_hash: &[u8; 32],
 ) -> napi::Result<()> {
-    #[allow(clippy::cast_possible_truncation)]
-    let timestamp = std::time::SystemTime::now()
-        .duration_since(std::time::UNIX_EPOCH)
-        .map_or(0, |d| d.as_secs());
+    let timestamp = scp_clock::Clock::now_secs(&scp_clock::SystemClock);
 
     crate::runtime::with_context(bi, context_id, |state| {
         let sequence = scp_event_log::tree::event_count(&state.core.event_log);

--- a/crates/scp-ffi/napi/src/tools.rs
+++ b/crates/scp-ffi/napi/src/tools.rs
@@ -241,9 +241,7 @@ pub(crate) async fn tool_register_on(
         test_vectors,
         operator_did: definition.operator_did.into(),
         cost,
-        registered_at: std::time::SystemTime::now()
-            .duration_since(std::time::UNIX_EPOCH)
-            .map_or(0, |d| d.as_secs()),
+        registered_at: scp_clock::Clock::now_secs(&scp_clock::SystemClock),
         signature: Vec::new(),
     };
 

--- a/crates/scp-ffi/src/context.rs
+++ b/crates/scp-ffi/src/context.rs
@@ -4074,10 +4074,7 @@ impl crate::scp::PyScp {
         let sup = sup.clone();
         let context_id = handle.context_id.clone();
         let did: scp_did::DID = subscriber_did.to_owned().into();
-        let timestamp = std::time::SystemTime::now()
-            .duration_since(std::time::UNIX_EPOCH)
-            .unwrap_or_default()
-            .as_secs();
+        let timestamp = scp_clock::Clock::now_secs(&scp_clock::SystemClock);
 
         rt.block_on(async move {
             use scp_core::context::actor::commands::{BroadcastCommand, SubscribeBroadcastPayload};

--- a/crates/scp-ffi/src/mcp.rs
+++ b/crates/scp-ffi/src/mcp.rs
@@ -878,9 +878,7 @@ impl ContextProvider for FfiBridgeProvider {
         // block_on`, or a dedicated `std::thread` with its own tiny
         // runtime depending on which regime the caller is in.
         let invoker_did_typed: scp_did::DID = agent_did.clone().into();
-        let now_secs = std::time::SystemTime::now()
-            .duration_since(std::time::UNIX_EPOCH)
-            .map_or(0, |d| d.as_secs());
+        let now_secs = scp_clock::Clock::now_secs(&scp_clock::SystemClock);
         let supervisor = crate::runtime::supervisor(&bi).map_err(|e| format!("{e}"))?;
         if !supervisor.try_consume_hard_rate_limit_from_any_context(
             context_id,
@@ -1027,11 +1025,7 @@ impl ContextProvider for FfiBridgeProvider {
 
         let payload_data = serde_json::to_vec(&tool_event).unwrap_or_default();
 
-        // Unix timestamp seconds fit in u64 for centuries.
-        #[allow(clippy::cast_possible_truncation)]
-        let timestamp = std::time::SystemTime::now()
-            .duration_since(std::time::UNIX_EPOCH)
-            .map_or(0, |d| d.as_secs());
+        let timestamp = scp_clock::Clock::now_secs(&scp_clock::SystemClock);
 
         // Re-acquire the DashMap lock briefly to append the event.
         // Returns (sequence, serialized_event_bytes) on success for

--- a/crates/scp-ffi/src/provenance.rs
+++ b/crates/scp-ffi/src/provenance.rs
@@ -340,10 +340,7 @@ fn append_provenance_event(
     event_type: scp_event_log::EventType,
     provenance_hash: &[u8; 32],
 ) -> PyResult<()> {
-    #[allow(clippy::cast_possible_truncation)]
-    let timestamp = std::time::SystemTime::now()
-        .duration_since(std::time::UNIX_EPOCH)
-        .map_or(0, |d| d.as_secs());
+    let timestamp = scp_clock::Clock::now_secs(&scp_clock::SystemClock);
 
     crate::runtime::with_context(bi, context_id, |rt| {
         let sequence = scp_event_log::tree::event_count(&rt.event_log);

--- a/crates/scp-ffi/src/tools.rs
+++ b/crates/scp-ffi/src/tools.rs
@@ -290,9 +290,7 @@ fn tool_register_impl(
         test_vectors,
         operator_did: operator_did.into(),
         cost,
-        registered_at: std::time::SystemTime::now()
-            .duration_since(std::time::UNIX_EPOCH)
-            .map_or(0, |d| d.as_secs()),
+        registered_at: scp_clock::Clock::now_secs(&scp_clock::SystemClock),
         signature: vec![],
     };
 

--- a/crates/scp-ffi/uniffi/src/bridge.rs
+++ b/crates/scp-ffi/uniffi/src/bridge.rs
@@ -4680,10 +4680,7 @@ impl scp_mcp::server::ContextProvider for McpUniFfiBridgeProvider {
 
         let payload_data = serde_json::to_vec(&tool_event).unwrap_or_default();
 
-        #[allow(clippy::cast_possible_truncation)]
-        let timestamp = std::time::SystemTime::now()
-            .duration_since(std::time::UNIX_EPOCH)
-            .map_or(0, |d| d.as_secs());
+        let timestamp = scp_clock::Clock::now_secs(&scp_clock::SystemClock);
 
         // Ensure UCAN state is registered before appending the event.
         if let Some(handle) = context_handle_registry(&bi).get(context_id) {
@@ -6536,10 +6533,7 @@ fn uniffi_append_provenance_event_on(
     event_type: scp_event_log::EventType,
     provenance_hash: &[u8; 32],
 ) -> Result<(), ScpError> {
-    #[allow(clippy::cast_possible_truncation)]
-    let timestamp = std::time::SystemTime::now()
-        .duration_since(std::time::UNIX_EPOCH)
-        .map_or(0, |d| d.as_secs());
+    let timestamp = scp_clock::Clock::now_secs(&scp_clock::SystemClock);
 
     bi.with_ucan_state(context_id, |state| {
         let sequence = scp_event_log::tree::event_count(&state.event_log);
@@ -12016,9 +12010,7 @@ impl Scp {
                     test_vectors,
                     operator_did: definition.operator_did.into(),
                     cost,
-                    registered_at: std::time::SystemTime::now()
-                        .duration_since(std::time::UNIX_EPOCH)
-                        .map_or(0, |d| d.as_secs()),
+                    registered_at: scp_clock::Clock::now_secs(&scp_clock::SystemClock),
                     signature: Vec::new(),
                 };
 

--- a/crates/scp-ffi/uniffi/src/bridge.rs
+++ b/crates/scp-ffi/uniffi/src/bridge.rs
@@ -10882,10 +10882,7 @@ impl Scp {
             .spawn(async move {
                 let sup = bi.context_manager_or_error()?;
                 let did: scp_did::DID = subscriber_did.into();
-                let timestamp = std::time::SystemTime::now()
-                    .duration_since(std::time::UNIX_EPOCH)
-                    .unwrap_or_default()
-                    .as_secs();
+                let timestamp = scp_clock::Clock::now_secs(&scp_clock::SystemClock);
 
                 use scp_core::context::actor::commands::{
                     BroadcastCommand, SubscribeBroadcastPayload,

--- a/crates/scp-protocol/src/crypto/ucan/validate.rs
+++ b/crates/scp-protocol/src/crypto/ucan/validate.rs
@@ -45,6 +45,11 @@ const MAX_EXPIRY_SECS: u64 = 24 * 60 * 60;
 /// Applied to `exp` and `nbf` checks in `verify_expiry` to accommodate
 /// NTP desynchronization between issuer and validator in distributed
 /// deployments.
+///
+/// Independent knob: the sibling skew tolerances in `envelope::validation`,
+/// `trust::challenge`, and `trust::participation` share this §9.14 5-minute
+/// default but are deliberately kept as distinct constants, not unified — each
+/// governs its own subsystem and may diverge if that subsystem's requirements do.
 pub const DEFAULT_CLOCK_SKEW_TOLERANCE_SECS: u64 = 5 * 60;
 
 /// Maximum delegation chain depth to prevent infinite loops.

--- a/crates/scp-protocol/src/envelope/validation.rs
+++ b/crates/scp-protocol/src/envelope/validation.rs
@@ -29,6 +29,10 @@ use super::inner::InnerEnvelope;
 ///
 /// Envelopes with timestamps more than this far in the future are rejected.
 /// Spec reference: §9.8.2(c).
+///
+/// Independent knob: shares the protocol-wide §9.14 5-minute skew default with
+/// `crypto::ucan::validate::DEFAULT_CLOCK_SKEW_TOLERANCE_SECS` and the trust
+/// skew tolerances, but is deliberately a distinct constant, not unified.
 pub const DEFAULT_CLOCK_SKEW_TOLERANCE_MS: u64 = 5 * 60 * 1_000;
 
 /// Default maximum message age: 7 days in milliseconds.

--- a/crates/scp-protocol/src/trust/challenge.rs
+++ b/crates/scp-protocol/src/trust/challenge.rs
@@ -405,6 +405,12 @@ const DEFAULT_VERIFICATION_TTL_SECS: u64 = 90 * 24 * 3600;
 /// bound (`completed_at >= now - timeout`) could be evaded by stamping an
 /// arbitrarily far-future `completed_at`. Set to 5 minutes to match the
 /// protocol-wide clock-skew tolerance (spec §9.14).
+///
+/// Independent knob: shares the §9.14 5-minute default with
+/// `crypto::ucan::validate::DEFAULT_CLOCK_SKEW_TOLERANCE_SECS`,
+/// `envelope::validation::DEFAULT_CLOCK_SKEW_TOLERANCE_MS`, and
+/// `trust::participation::MAX_PARTICIPATION_FUTURE_SKEW_SECS`, but is
+/// deliberately a distinct constant, not unified.
 const MAX_COMPLETION_FUTURE_SKEW_SECS: u64 = 5 * 60;
 
 // ---------------------------------------------------------------------------

--- a/crates/scp-protocol/src/trust/participation.rs
+++ b/crates/scp-protocol/src/trust/participation.rs
@@ -823,6 +823,11 @@ const PARTICIPATION_KEY_DOMAIN: &[u8] = b"scp-participation-statement-v1";
 /// where a trusted-but-misbehaving signer could keep a statement inside the
 /// `max_age_secs` freshness window indefinitely. 5 minutes, matching
 /// `challenge.rs`'s `MAX_COMPLETION_FUTURE_SKEW_SECS` and spec §9.14.
+///
+/// Independent knob: shares the §9.14 5-minute default with the UCAN
+/// (`crypto::ucan::validate::DEFAULT_CLOCK_SKEW_TOLERANCE_SECS`) and envelope
+/// (`envelope::validation::DEFAULT_CLOCK_SKEW_TOLERANCE_MS`) skew tolerances,
+/// but is deliberately a distinct constant, not unified.
 const MAX_PARTICIPATION_FUTURE_SKEW_SECS: u64 = 5 * 60;
 
 /// Derives a context-specific Ed25519 signing key for participation statements.

--- a/scripts/check-no-panic-abort.sh
+++ b/scripts/check-no-panic-abort.sh
@@ -1,0 +1,185 @@
+#!/usr/bin/env bash
+# check-no-panic-abort.sh — CI gate forbidding `panic = "abort"` in any cargo
+# profile that reaches the FFI cdylib crates.
+#
+# ---------------------------------------------------------------------------
+# WHY THIS EXISTS
+# ---------------------------------------------------------------------------
+# The three FFI bridges are compiled as `cdylib`s loaded into a host runtime:
+#
+#   crates/scp-ffi/        (scp-ffi        — PyO3,  loaded by CPython)
+#   crates/scp-ffi/napi/   (scp-ffi-napi   — napi,  loaded by Node/Bun)
+#   crates/scp-ffi/uniffi/ (scp-ffi-uniffi — UniFFI, loaded by Swift/Kotlin)
+#
+# PyO3, napi-rs, and UniFFI all catch a Rust `panic!` at the FFI boundary (via
+# stack UNWINDING) and convert it into a host-language exception. With the
+# `abort` panic strategy there is no unwinding: any panic — including one the
+# host was expected to catch and surface as an exception — instead raises
+# SIGABRT and kills the ENTIRE host process (the Python interpreter, the Node
+# event loop, the Swift/Kotlin app). That is both a reliability regression and
+# a denial-of-service amplifier (a single bad input that would have been a
+# catchable exception becomes a whole-process crash). `panic = "abort"` on a
+# profile that builds these cdylibs is therefore banned.
+#
+# ---------------------------------------------------------------------------
+# WHAT THIS CHECKS (bounded, sound, closed)
+# ---------------------------------------------------------------------------
+# Cargo honors `[profile.*]` tables ONLY in the workspace-root manifest; a
+# top-level `[profile.<name>] panic = "abort"` there applies to EVERY member,
+# including the FFI cdylibs. (`panic` is not a valid per-package profile
+# override key — cargo rejects it — so a root-level profile is the only way to
+# flip the strategy for these crates.) A member manifest's own `[profile.*]`
+# is ignored by cargo with a warning, but a `panic = "abort"` written there
+# signals the same mistaken intent, so we flag it too as defense-in-depth.
+#
+# The scan is a CLOSED set of at most four manifests:
+#   - Cargo.toml                         (workspace root — authoritative)
+#   - crates/scp-ffi/Cargo.toml          (scp-ffi)
+#   - crates/scp-ffi/napi/Cargo.toml     (scp-ffi-napi)
+#   - crates/scp-ffi/uniffi/Cargo.toml   (scp-ffi-uniffi)
+#
+# and a single exact pattern: a non-comment line reading `panic = "abort"`
+# (value `abort`, single or double quotes, arbitrary surrounding whitespace).
+# `panic = "abort"` is only valid TOML inside a `[profile.*]` table, so a
+# match anywhere in these manifests is unambiguously a forbidden profile
+# setting — no TOML section parsing is needed. The clippy lint
+# `panic = "deny"` (a different value, under `[workspace.lints.clippy]`) does
+# not match; a `#`-commented line does not match.
+#
+# This is NOT an open-ended denylist: it is a fixed file list matched against
+# one exact forbidden shape.
+#
+# ---------------------------------------------------------------------------
+# WHEN THIS RUNS
+# ---------------------------------------------------------------------------
+# On every PR (cheap, no build). It is ADDITIVE coverage — it does not replace
+# or weaken any existing enforcement script.
+#
+# ---------------------------------------------------------------------------
+# HOW TO FIX A FAILURE
+# ---------------------------------------------------------------------------
+# Remove the `panic = "abort"` setting. If a smaller binary or slightly faster
+# release build motivated it, it cannot apply workspace-wide while the FFI
+# cdylibs must unwind. Keep the default `unwind` strategy for any profile that
+# builds scp-ffi / scp-ffi-napi / scp-ffi-uniffi.
+#
+# ---------------------------------------------------------------------------
+# SELF-TEST
+# ---------------------------------------------------------------------------
+# `check-no-panic-abort.sh --self-test` proves the detector is alive: it plants
+# `panic = "abort"` in a scratch manifest (must be DETECTED), and confirms that
+# benign lines — `panic = "unwind"`, the clippy lint `panic = "deny"`, and a
+# commented `# panic = "abort"` — are NOT detected. It touches only a temp dir
+# and reverts itself. CI runs the self-test before the real check.
+set -euo pipefail
+
+# Anchor at the repository root so the relative manifest paths below are
+# invocation-directory-independent (works from any subdirectory).
+cd "$(git rev-parse --show-toplevel)"
+
+# Closed set of manifests whose profiles can reach the FFI cdylibs.
+MANIFESTS=(
+    "Cargo.toml"
+    "crates/scp-ffi/Cargo.toml"
+    "crates/scp-ffi/napi/Cargo.toml"
+    "crates/scp-ffi/uniffi/Cargo.toml"
+)
+
+# The single forbidden shape: a non-comment line setting the profile panic
+# strategy to "abort". Anchored at line start (after optional whitespace) so a
+# `#`-commented occurrence does not match; the value is pinned to `abort` so
+# the `panic = "deny"` clippy lint and a `panic = "unwind"` override do not
+# match.
+ABORT_RE='^[[:space:]]*panic[[:space:]]*=[[:space:]]*["'"'"']abort["'"'"']'
+
+# scan_manifest FILE
+#   Prints `FILE:LINENO:CONTENT` for every forbidden line; returns 0 if any
+#   were found, 1 if clean. Absent files are treated as clean (a bridge
+#   manifest could be relocated).
+scan_manifest() {
+    local file="$1"
+    [[ -f "$file" ]] || return 1
+    grep -nE "$ABORT_RE" "$file" | sed "s#^#${file}:#" && return 0
+    return 1
+}
+
+# run_check FILE...
+#   Scans every FILE argument; returns 1 if any forbidden line was found, 0 if
+#   all clean. (Written for the macOS system bash 3.2 — no namerefs.)
+run_check() {
+    local found=0
+    local file
+    for file in "$@"; do
+        if scan_manifest "$file"; then
+            found=1
+        fi
+    done
+    return "$found"
+}
+
+self_test() {
+    echo "check-no-panic-abort self-test..."
+    local tmp rc=0
+    tmp="$(mktemp -d)"
+
+    # Fixture 1: a profile with panic = "abort" — MUST be detected.
+    cat >"$tmp/bad.toml" <<'EOF'
+[profile.release]
+panic = "abort"
+EOF
+    if scan_manifest "$tmp/bad.toml" >/dev/null; then
+        echo "  [ok] detected panic = \"abort\""
+    else
+        echo "  [FAIL] self-test: forbidden panic = \"abort\" was NOT detected" >&2
+        rc=1
+    fi
+
+    # Fixture 2: benign lines — none MUST be detected.
+    cat >"$tmp/good.toml" <<'EOF'
+[profile.release]
+panic = "unwind"
+
+[workspace.lints.clippy]
+panic = "deny"
+
+# panic = "abort"   (a comment, not a setting)
+EOF
+    if scan_manifest "$tmp/good.toml" >/dev/null; then
+        echo "  [FAIL] self-test: a benign line was falsely detected:" >&2
+        scan_manifest "$tmp/good.toml" >&2 || true
+        rc=1
+    else
+        echo "  [ok] benign panic = \"unwind\" / \"deny\" / comment not flagged"
+    fi
+
+    rm -rf "$tmp"
+    if [[ "$rc" -eq 0 ]]; then
+        echo "check-no-panic-abort self-test PASSED"
+    fi
+    return "$rc"
+}
+
+main() {
+    if [[ "${1:-}" == "--self-test" ]]; then
+        self_test
+        return
+    fi
+
+    echo "Checking for forbidden panic = \"abort\" in FFI-reachable cargo profiles..."
+    if run_check "${MANIFESTS[@]}"; then
+        echo "check-no-panic-abort: OK (no panic = \"abort\" in FFI-reachable profiles)"
+        return 0
+    fi
+
+    cat >&2 <<'EOF'
+
+ERROR: `panic = "abort"` found in a cargo profile that reaches the FFI cdylib
+crates (scp-ffi / scp-ffi-napi / scp-ffi-uniffi). The `abort` strategy turns
+any Rust panic into a whole-host-process SIGABRT instead of a host-language
+exception at the FFI boundary. Remove it and keep the default `unwind`
+strategy. See the header of scripts/check-no-panic-abort.sh.
+EOF
+    return 1
+}
+
+main "$@"


### PR DESCRIPTION
Three-part clock/time-discipline hygiene pass.

**1. §9.14 skew constants — kept separate, documented.** The four local clock-skew-tolerance consts (`crypto/ucan/validate.rs`, `envelope/validation.rs`, `trust/challenge.rs`, `trust/participation.rs`) each get an "independent knob" doc-comment cross-referencing §9.14 — they deliberately share the 5-min default without being unified (a shared const would create false coupling between distinct knobs).

**2. `panic="abort"` CI gate.** New `scripts/check-no-panic-abort.sh` (bounded, closed scan of the workspace + 3 FFI crate manifests for a `panic = "abort"` profile line; `--self-test`) wired into `ci.yml` as `no-panic-abort` **and added to the required aggregate `ci` gate** so it blocks merges. The fail-closed freshness clock relies on `panic="unwind"` (panics caught at the FFI boundary per ADR-057) — this prevents a silent regression to `abort`.

**3. Fail-closed write-stamps.** Migrated all residual `SystemTime::now()…map_or(0, ..)` (10 sites) and `…unwrap_or_default().as_secs()` (3 sites) event-log/provenance WRITE-timestamps in `crates/scp-ffi/` to the fail-closed `scp_clock::Clock::now_secs(&SystemClock)` — so a clock error can't silently mis-stamp a record as epoch 0. Deliberately excluded 6 `.as_millis()` sites that seed a SHA-256 `deploy_id` hasher (ID entropy, not a recorded timestamp; u128→u64 would change the derivation).

Verified: full-feature clippy `-D warnings`, the three production-config builds, `cargo test` across scp-ffi/napi/uniffi, `check-error-codes.sh`, and the new `check-no-panic-abort.sh` (self-test + real) all green.

Closes #1994. (Follow-ups filed: #2012 aggregate-gate gap.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)