### PR TITLE
ci: wire 4 structural gates into the required aggregate (closes #2012)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1103,6 +1103,10 @@ jobs:
       - fallback-registry
       - handle-affinity
       - no-panic-abort
+      - handler-no-panic
+      - saga-gating-granularity
+      - deleted-primitives
+      - bridge-instance-lifecycle
       - no-mutable-globals-rust
       - no-mutable-globals-python
       - no-mutable-globals-ts
@@ -1142,6 +1146,10 @@ jobs:
             "${{ needs.fallback-registry.result }}" \
             "${{ needs.handle-affinity.result }}" \
             "${{ needs.no-panic-abort.result }}" \
+            "${{ needs.handler-no-panic.result }}" \
+            "${{ needs.saga-gating-granularity.result }}" \
+            "${{ needs.deleted-primitives.result }}" \
+            "${{ needs.bridge-instance-lifecycle.result }}" \
             "${{ needs.no-mutable-globals-rust.result }}" \
             "${{ needs.no-mutable-globals-python.result }}" \
             "${{ needs.no-mutable-globals-ts.result }}" \


### PR DESCRIPTION
The required aggregate `ci` job omitted 4 structural gates from its `needs`/results list, so their failures ran but did not block merges: `handler-no-panic`, `saga-gating-granularity`, `deleted-primitives`, `bridge-instance-lifecycle`.

- Each gate verified green on current main via its exact CI invocation before wiring (no red gate wired in).
- All 4 added to both the `needs` array and the `needs.*.result` failure-aggregation array, immediately after `no-panic-abort` (the #1994 convention), identical order in both lists (programmatically cross-checked, 38==38 entries).
- Enforcement-expanding only; gate scripts/jobs untouched. YAML validated.

Re the "scratch failure blocks the aggregate" criterion: blocking is guaranteed by the same mechanism as the 34 pre-existing entries (any `failure`/`cancelled` result exits 1) — structurally verified rather than trip-tested to avoid 4 deliberate red queue runs.

Closes #2012.

🤖 Generated with [Claude Code](https://claude.com/claude-code)