### PR TITLE
fix(ffi): align PyO3/NAPI per-case trust error codes with UniFFI across all trust ops (closes #2007)

### DIFF
--- a/bindings/python/scp_sdk/trust.py
+++ b/bindings/python/scp_sdk/trust.py
@@ -1322,9 +1322,11 @@ def verify_participation_requirements(
     threshold/independence path) and MUST NOT treat a passing check as an
     authorization decision.
 
-    Success is indicated by returning without exception. Verification
-    failures raise ``RuntimeError`` with diagnostic details from the
-    Rust bridge.
+    Success is indicated by returning without exception. Failures raise the
+    bridge's native coded ``ValidationError`` (rooted at ``ScpError``); the
+    structured per-case ``SCP-VALID-*`` code is recoverable from the
+    exception's string form (the ``[CODE]``-prefixed message), so callers
+    branch on the code — never on error prose.
 
     Args:
         expected_subject: The DID of the agent being admitted. Profiles for
@@ -1334,9 +1336,14 @@ def verify_participation_requirements(
 
     Raises:
         ScpError: If the bridge module is not available.
-        RuntimeError: If verification fails (with diagnostic details
-            from ``ParticipationAdmissionError``).
-        ValueError: If JSON serialization or parsing fails.
+        ValidationError: Native bridge exception whose ``[SCP-VALID-NNNN]``-
+            prefixed message carries the per-case structured code:
+            ``SCP-VALID-7000`` for a malformed ``expected_subject`` DID;
+            ``SCP-VALID-7031`` / ``SCP-VALID-7030`` for malformed
+            requirements / profiles JSON (unreachable through this typed
+            wrapper, which always serializes valid JSON); and
+            ``SCP-VALID-7032`` for a failed admission check, with the
+            specific failure reason from ``ParticipationAdmissionError``.
     """
     bridge = _bridge()
 
@@ -1373,7 +1380,11 @@ def check_capability_requirements(
     §7.3.5 threshold/independence path) and do NOT treat success as an
     authorization decision.
 
-    Success is indicated by returning without exception.
+    Success is indicated by returning without exception. Failures raise the
+    bridge's native coded ``ValidationError`` (rooted at ``ScpError``); the
+    structured per-case ``SCP-VALID-*`` code is recoverable from the
+    exception's string form (the ``[CODE]``-prefixed message), so callers
+    branch on the code — never on error prose.
 
     Args:
         context_id: The context the agent is being admitted to.
@@ -1386,9 +1397,16 @@ def check_capability_requirements(
 
     Raises:
         ScpError: If the bridge module is not available.
-        RuntimeError: If an admission requirement is unmet (with diagnostic
-            details from ``AdmissionError``).
-        ValueError: If ``subject_did`` is malformed or JSON serialization fails.
+        ValidationError: Native bridge exception whose ``[SCP-VALID-NNNN]``-
+            prefixed message carries the per-case structured code:
+            ``SCP-VALID-7000`` for a malformed ``subject_did``;
+            ``SCP-VALID-7073`` / ``SCP-VALID-7074`` / ``SCP-VALID-7075`` for
+            malformed requirements / agent-capabilities /
+            challenge-verifications JSON (unreachable through this typed
+            wrapper, which always serializes valid JSON); ``SCP-VALID-7076``
+            for an unmet admission requirement, with the specific failure
+            reason from ``AdmissionError``; and ``SCP-VALID-7077`` for its
+            empty-subject variant.
     """
     bridge = _bridge()
 

--- a/bindings/python/tests/test_real_ffi.py
+++ b/bindings/python/tests/test_real_ffi.py
@@ -963,6 +963,77 @@ class TestTrust:
         except Exception:
             pass  # Expected without attestation infrastructure
 
+    async def test_participation_admission_error_codes_surface(self, scp: SCP):
+        """verify_participation_requirements failures carry per-case structured codes.
+
+        Cross-bridge parity (spec section 7.3.2.1): the PyO3 bridge emits the
+        same per-case ``SCP-VALID-*`` code the UniFFI/NAPI bridges emit for the
+        same logical failure, and the code is recoverable from the raised
+        native ``ValidationError``'s string form (the ``[CODE]``-prefixed
+        message), exactly as ``check_capability_requirements``'s codes surface.
+        """
+        from scp_sdk.trust import (
+            ParticipationFact,
+            ParticipationThreshold,
+            RequireParticipation,
+            verify_participation_requirements,
+        )
+
+        # SDK wrapper: a malformed subject DID fails boundary validation with
+        # the generic validation code shared by all three bridges.
+        with pytest.raises(_scp_core.ValidationError, match="SCP-VALID-7000"):
+            verify_participation_requirements("not-a-did", [], [])
+
+        # SDK wrapper: a requirement with no satisfying profiles fails the
+        # admission check itself, which carries its own per-case code.
+        requirement = RequireParticipation(
+            fact=ParticipationFact("ParticipationDuration"),
+            threshold=ParticipationThreshold("AtLeast", 1),
+            max_age_secs=3600,
+            min_contexts=0,
+        )
+        with pytest.raises(_scp_core.ValidationError, match="SCP-VALID-7032"):
+            verify_participation_requirements("did:key:alice", [requirement], [])
+
+        # Raw bridge: the per-position JSON parse codes (unreachable through
+        # the typed SDK wrapper, which always serializes valid JSON).
+        with pytest.raises(_scp_core.ValidationError, match="SCP-VALID-7031"):
+            _scp_core.verify_participation_requirements("did:key:alice", "not json", "[]")
+        with pytest.raises(_scp_core.ValidationError, match="SCP-VALID-7030"):
+            _scp_core.verify_participation_requirements("did:key:alice", "[]", "not json")
+
+    async def test_capability_admission_error_codes_surface(self, scp: SCP):
+        """check_capability_requirements failures carry per-case structured codes.
+
+        The reference pattern for cross-bridge structured codes (spec section
+        7.3.4.4): asserts the anchor op's codes stay recoverable the same way
+        the participation sibling's now are.
+        """
+        from scp_sdk.trust import check_capability_requirements
+
+        # SDK wrapper: a malformed subject DID fails boundary validation with
+        # the generic validation code shared by all three bridges.
+        with pytest.raises(_scp_core.ValidationError, match="SCP-VALID-7000"):
+            check_capability_requirements("ctx-real-ffi", "not-a-did", [], [], [])
+
+        # SDK wrapper: a self-attested requirement the agent lacks fails the
+        # admission check itself, which carries its own per-case code.
+        from scp_sdk.trust import CapabilityRequirement, VerificationLevel
+
+        requirement = CapabilityRequirement(
+            capability="scp:capability:schema-validation/v1",
+            verification_level=VerificationLevel("SelfAttested"),
+        )
+        with pytest.raises(_scp_core.ValidationError, match="SCP-VALID-7076"):
+            check_capability_requirements("ctx-real-ffi", "did:key:alice", [requirement], [], [])
+
+        # Raw bridge: the per-position JSON parse code (unreachable through
+        # the typed SDK wrapper, which always serializes valid JSON).
+        with pytest.raises(_scp_core.ValidationError, match="SCP-VALID-7073"):
+            _scp_core.check_capability_requirements(
+                "ctx-real-ffi", "did:key:alice", "not json", "[]", "[]"
+            )
+
     async def test_participation_record_reflects_governance_real_ffi(self, scp: SCP):
         """The typed participation record (§7.3.2) RECEIVES real leaf-derived facts.
 

--- a/crates/scp-ffi/napi/src/trust.rs
+++ b/crates/scp-ffi/napi/src/trust.rs
@@ -20,6 +20,7 @@ use crate::runtime::NapiBridgeInstance;
 
 /// Trust score query result.
 #[napi(object)]
+#[derive(Debug)]
 pub struct NapiTrustScoreResult {
     /// Number of message events attributed to the DID.
     pub message_count: i64,
@@ -31,6 +32,7 @@ pub struct NapiTrustScoreResult {
 
 /// Attestation verification result.
 #[napi(object)]
+#[derive(Debug)]
 pub struct NapiAttestationVerificationResult {
     /// Whether the attestation is valid.
     pub valid: bool,
@@ -42,6 +44,7 @@ pub struct NapiAttestationVerificationResult {
 
 /// Challenge creation result.
 #[napi(object)]
+#[derive(Debug)]
 pub struct NapiChallengeResult {
     /// The unique challenge ID (UUID v4).
     pub challenge_id: String,
@@ -59,6 +62,7 @@ pub struct NapiChallengeResult {
 /// number; lossless for these ranges, matching `NapiTrustScoreResult`);
 /// booleans/strings map directly. See ADR-017.
 #[napi(object)]
+#[derive(Debug)]
 pub struct NapiParticipationRecord {
     /// The DID whose participation is summarized.
     pub subject_did: String,
@@ -115,17 +119,12 @@ impl From<&scp_core::trust::ParticipationFacts> for NapiParticipationRecord {
 // Helper
 // ---------------------------------------------------------------------------
 
-fn validation_error(msg: &str) -> napi::Error {
-    napi::Error::from(ScpNapiError::Validation {
-        message: msg.to_owned(),
-        code: codes::VALID_7010.to_owned(),
-    })
-}
-
-/// Like [`validation_error`] but carries an explicit `SCP-VALID-*` code so a
-/// caller can surface the same specific code the UniFFI/PyO3 bridges emit for a
-/// given failure case (e.g. the per-case `check_capability_requirements` codes
-/// `SCP-VALID-7073`..=`SCP-VALID-7077`).
+/// Builds a bridge validation error carrying the explicit `SCP-VALID-*` code
+/// the UniFFI/PyO3 bridges emit for the same logical failure case (e.g. the
+/// per-case `check_capability_requirements` codes `VALID_7073`..=`VALID_7077`,
+/// or the `verify_participation_requirements` codes `VALID_7030`/`VALID_7031`/
+/// `VALID_7032`), so a TypeScript caller can branch on the same code a
+/// Python/Swift/Kotlin caller sees.
 fn coded_validation_error(msg: &str, code: &str) -> napi::Error {
     napi::Error::from(ScpNapiError::Validation {
         message: msg.to_owned(),
@@ -143,11 +142,20 @@ pub(crate) fn trust_query_score_on(
     did: String,
     context_id: String,
 ) -> napi::Result<NapiTrustScoreResult> {
+    // Per-argument codes match the UniFFI bridge (invalid DID → VALID_7010,
+    // invalid context id → VALID_7011) so the same logical failure carries
+    // the same code on every native bridge.
     if did.is_empty() {
-        return Err(validation_error("DID must not be empty"));
+        return Err(coded_validation_error(
+            "DID must not be empty",
+            codes::VALID_7010,
+        ));
     }
     if context_id.is_empty() {
-        return Err(validation_error("context_id must not be empty"));
+        return Err(coded_validation_error(
+            "context_id must not be empty",
+            codes::VALID_7011,
+        ));
     }
 
     let (message_count, governance_count) =
@@ -173,8 +181,15 @@ pub(crate) fn trust_verify_attestation_on(
     _bi: &NapiBridgeInstance,
     attestation_json: String,
 ) -> napi::Result<NapiAttestationVerificationResult> {
+    // VALID_7012 matches the UniFFI bridge's code for malformed attestation
+    // JSON so the same logical failure carries the same code on every bridge.
     let attestation: scp_core::trust::Attestation = serde_json::from_str(&attestation_json)
-        .map_err(|e| validation_error(&format!("failed to parse attestation JSON: {e}")))?;
+        .map_err(|e| {
+            coded_validation_error(
+                &format!("failed to parse attestation JSON: {e}"),
+                codes::VALID_7012,
+            )
+        })?;
 
     let resolver = scp_core::trust::IdentityDidPublicKeyResolver;
     let clock = scp_clock::SystemClock;
@@ -201,8 +216,12 @@ pub(crate) fn trust_create_challenge_on(
     _bi: &NapiBridgeInstance,
     target_did: String,
 ) -> napi::Result<NapiChallengeResult> {
+    // VALID_7013 matches the UniFFI bridge's code for an empty target DID.
     if target_did.is_empty() {
-        return Err(validation_error("target DID must not be empty"));
+        return Err(coded_validation_error(
+            "target DID must not be empty",
+            codes::VALID_7013,
+        ));
     }
 
     struct EphemeralSigner(ed25519_dalek::SigningKey);
@@ -226,10 +245,21 @@ pub(crate) fn trust_create_challenge_on(
         std::time::Duration::from_mins(5),
         &signer,
     )
-    .map_err(|e| validation_error(&format!("challenge creation failed: {e}")))?;
+    .map_err(|e| {
+        // VALID_7014 (creation failure) / VALID_7015 (serialization failure)
+        // match the UniFFI bridge's per-case codes.
+        coded_validation_error(
+            &format!("challenge creation failed: {e}"),
+            codes::VALID_7014,
+        )
+    })?;
 
-    let challenge_json = serde_json::to_string(&request)
-        .map_err(|e| validation_error(&format!("failed to serialize challenge: {e}")))?;
+    let challenge_json = serde_json::to_string(&request).map_err(|e| {
+        coded_validation_error(
+            &format!("failed to serialize challenge: {e}"),
+            codes::VALID_7015,
+        )
+    })?;
 
     Ok(NapiChallengeResult {
         challenge_id: request.challenge_id,
@@ -246,11 +276,23 @@ pub(crate) fn trust_verify_response_on(
     challenge_json: String,
     response_json: String,
 ) -> napi::Result<bool> {
+    // VALID_7016 (challenge position) / VALID_7017 (response position) match
+    // the UniFFI bridge's per-case codes for malformed JSON.
     let request: scp_core::trust::ChallengeRequest = serde_json::from_str(&challenge_json)
-        .map_err(|e| validation_error(&format!("failed to parse challenge JSON: {e}")))?;
+        .map_err(|e| {
+            coded_validation_error(
+                &format!("failed to parse challenge JSON: {e}"),
+                codes::VALID_7016,
+            )
+        })?;
 
     let response: scp_core::trust::ChallengeResponse = serde_json::from_str(&response_json)
-        .map_err(|e| validation_error(&format!("failed to parse response JSON: {e}")))?;
+        .map_err(|e| {
+            coded_validation_error(
+                &format!("failed to parse response JSON: {e}"),
+                codes::VALID_7017,
+            )
+        })?;
 
     let resolver = scp_core::trust::IdentityDidPublicKeyResolver;
     let clock = scp_clock::SystemClock;
@@ -296,16 +338,23 @@ pub(crate) fn verify_participation_requirements_on(
     scp_ffi_common::validate::validate_did(&expected_subject)
         .map_err(|e| napi::Error::from(ScpNapiError::from(e)))?;
 
+    // Per-case codes match the UniFFI bridge: malformed requirements JSON →
+    // VALID_7031, malformed profiles JSON → VALID_7030, failed admission
+    // check → VALID_7032 (below).
     let requirements: Vec<scp_core::trust::RequireParticipation> =
         serde_json::from_str(&requirements_json).map_err(|e| {
-            validation_error(&format!(
-                "failed to parse participation requirements JSON: {e}"
-            ))
+            coded_validation_error(
+                &format!("failed to parse participation requirements JSON: {e}"),
+                codes::VALID_7031,
+            )
         })?;
 
     let profiles: Vec<scp_core::trust::ParticipationProfile> = serde_json::from_str(&profile_json)
         .map_err(|e| {
-            validation_error(&format!("failed to parse participation profiles JSON: {e}"))
+            coded_validation_error(
+                &format!("failed to parse participation profiles JSON: {e}"),
+                codes::VALID_7030,
+            )
         })?;
 
     // Fail-closed clock: a pre-epoch host clock is an unrecoverable environment
@@ -320,7 +369,12 @@ pub(crate) fn verify_participation_requirements_on(
         &requirements,
         &profiles,
     )
-    .map_err(|e| validation_error(&format!("participation admission verification failed: {e}")))?;
+    .map_err(|e| {
+        coded_validation_error(
+            &format!("participation admission verification failed: {e}"),
+            codes::VALID_7032,
+        )
+    })?;
 
     Ok(())
 }
@@ -428,51 +482,85 @@ pub(crate) fn aggregate_trust_input_on(
     cached_attestations_json: String,
     challenge_results_json: String,
 ) -> napi::Result<String> {
+    // Per-argument codes match the UniFFI bridge's `aggregate_trust_input`
+    // (context id → VALID_7040, subject DID → VALID_7041, then one code per
+    // JSON input, VALID_7042..=VALID_7049) so the same logical failure
+    // carries the same code on every native bridge.
     if context_id.is_empty() {
-        return Err(validation_error("context_id must not be empty"));
+        return Err(coded_validation_error(
+            "context_id must not be empty",
+            codes::VALID_7040,
+        ));
     }
     if subject_did.is_empty() {
-        return Err(validation_error("subject DID must not be empty"));
+        return Err(coded_validation_error(
+            "subject DID must not be empty",
+            codes::VALID_7041,
+        ));
     }
 
-    let events: Vec<scp_event_log::Event> = serde_json::from_str(&events_json)
-        .map_err(|e| validation_error(&format!("failed to parse events JSON: {e}")))?;
+    let events: Vec<scp_event_log::Event> = serde_json::from_str(&events_json).map_err(|e| {
+        coded_validation_error(
+            &format!("failed to parse events JSON: {e}"),
+            codes::VALID_7042,
+        )
+    })?;
 
-    let merkle_root_vec: Vec<u8> = serde_json::from_str(&merkle_root_json)
-        .map_err(|e| validation_error(&format!("failed to parse merkle_root JSON: {e}")))?;
+    let merkle_root_vec: Vec<u8> = serde_json::from_str(&merkle_root_json).map_err(|e| {
+        coded_validation_error(
+            &format!("failed to parse merkle_root JSON: {e}"),
+            codes::VALID_7043,
+        )
+    })?;
     let merkle_root: [u8; 32] = merkle_root_vec.try_into().map_err(|v: Vec<u8>| {
-        validation_error(&format!(
-            "merkle_root must be exactly 32 bytes, got {}",
-            v.len()
-        ))
+        coded_validation_error(
+            &format!("merkle_root must be exactly 32 bytes, got {}", v.len()),
+            codes::VALID_7044,
+        )
     })?;
 
     let consequence_rules: Vec<scp_core::trust::ConsequenceRule> =
         serde_json::from_str(&consequence_rules_json).map_err(|e| {
-            validation_error(&format!("failed to parse consequence_rules JSON: {e}"))
+            coded_validation_error(
+                &format!("failed to parse consequence_rules JSON: {e}"),
+                codes::VALID_7045,
+            )
         })?;
 
     let threshold_requirements: std::collections::HashMap<
         scp_core::trust::AttestationType,
         scp_core::trust::ThresholdRequirement,
     > = serde_json::from_str(&threshold_requirements_json).map_err(|e| {
-        validation_error(&format!("failed to parse threshold_requirements JSON: {e}"))
+        coded_validation_error(
+            &format!("failed to parse threshold_requirements JSON: {e}"),
+            codes::VALID_7046,
+        )
     })?;
 
     let attestor_sets: std::collections::HashMap<
         scp_core::trust::AttestationType,
         Vec<scp_core::trust::AttestorInfo>,
-    > = serde_json::from_str(&attestor_sets_json)
-        .map_err(|e| validation_error(&format!("failed to parse attestor_sets JSON: {e}")))?;
+    > = serde_json::from_str(&attestor_sets_json).map_err(|e| {
+        coded_validation_error(
+            &format!("failed to parse attestor_sets JSON: {e}"),
+            codes::VALID_7047,
+        )
+    })?;
 
     let cached_attestations: Vec<scp_core::trust::aggregate::CachedAttestation> =
         serde_json::from_str(&cached_attestations_json).map_err(|e| {
-            validation_error(&format!("failed to parse cached_attestations JSON: {e}"))
+            coded_validation_error(
+                &format!("failed to parse cached_attestations JSON: {e}"),
+                codes::VALID_7048,
+            )
         })?;
 
     let challenge_results: Vec<scp_core::trust::ChallengeVerification> =
         serde_json::from_str(&challenge_results_json).map_err(|e| {
-            validation_error(&format!("failed to parse challenge_results JSON: {e}"))
+            coded_validation_error(
+                &format!("failed to parse challenge_results JSON: {e}"),
+                codes::VALID_7049,
+            )
         })?;
 
     // Route trust aggregation through this bridge instance's
@@ -501,7 +589,11 @@ pub(crate) fn aggregate_trust_input_on(
                 &threshold_requirements,
                 &attestor_sets,
             )
-            .map_err(|e| validation_error(&e.to_string()))
+            .map_err(|e| {
+                // VALID_7052 mirrors the UniFFI bridge's code for a failed
+                // trust aggregation.
+                coded_validation_error(&e.to_string(), codes::VALID_7052)
+            })
         }
         crate::runtime::ProtocolRepoVariant::Sqlite(repo) => {
             let handle = crate::runtime().handle().clone();
@@ -519,7 +611,11 @@ pub(crate) fn aggregate_trust_input_on(
                 &threshold_requirements,
                 &attestor_sets,
             )
-            .map_err(|e| validation_error(&e.to_string()))
+            .map_err(|e| {
+                // VALID_7052 mirrors the UniFFI bridge's code for a failed
+                // trust aggregation.
+                coded_validation_error(&e.to_string(), codes::VALID_7052)
+            })
         }
     }
 }
@@ -638,6 +734,12 @@ mod tests {
         let bi = test_bi();
         let result = trust_query_score_on(&bi, String::new(), "ctx".to_owned());
         assert!(result.is_err());
+        let msg = format!("{}", result.unwrap_err());
+        assert!(
+            msg.contains(codes::VALID_7010),
+            "expected {}, got: {msg}",
+            codes::VALID_7010
+        );
     }
 
     #[test]
@@ -645,6 +747,12 @@ mod tests {
         let bi = test_bi();
         let result = trust_query_score_on(&bi, "did:key:test".to_owned(), String::new());
         assert!(result.is_err());
+        let msg = format!("{}", result.unwrap_err());
+        assert!(
+            msg.contains(codes::VALID_7011),
+            "expected {}, got: {msg}",
+            codes::VALID_7011
+        );
     }
 
     #[test]
@@ -663,6 +771,12 @@ mod tests {
         let bi = test_bi();
         let result = trust_create_challenge_on(&bi, String::new());
         assert!(result.is_err());
+        let msg = format!("{}", result.unwrap_err());
+        assert!(
+            msg.contains(codes::VALID_7013),
+            "expected {}, got: {msg}",
+            codes::VALID_7013
+        );
     }
 
     #[test]
@@ -680,13 +794,42 @@ mod tests {
         let bi = test_bi();
         let result = trust_verify_attestation_on(&bi, "not json".to_owned());
         assert!(result.is_err());
+        let msg = format!("{}", result.unwrap_err());
+        assert!(
+            msg.contains(codes::VALID_7012),
+            "expected {}, got: {msg}",
+            codes::VALID_7012
+        );
     }
 
     #[test]
-    fn trust_verify_response_rejects_invalid_json() {
+    fn trust_verify_response_rejects_invalid_challenge_json() {
+        // Malformed JSON in the CHALLENGE position.
         let bi = test_bi();
         let result = trust_verify_response_on(&bi, "bad".to_owned(), "bad".to_owned());
         assert!(result.is_err());
+        let msg = format!("{}", result.unwrap_err());
+        assert!(
+            msg.contains(codes::VALID_7016),
+            "expected {}, got: {msg}",
+            codes::VALID_7016
+        );
+    }
+
+    #[test]
+    fn trust_verify_response_rejects_invalid_response_json() {
+        // Malformed JSON in the RESPONSE position: the challenge parses, so
+        // the failure is attributed to the response argument.
+        let bi = test_bi();
+        let challenge = trust_create_challenge_on(&bi, "did:key:target".to_owned()).unwrap();
+        let result = trust_verify_response_on(&bi, challenge.challenge_json, "bad".to_owned());
+        assert!(result.is_err());
+        let msg = format!("{}", result.unwrap_err());
+        assert!(
+            msg.contains(codes::VALID_7017),
+            "expected {}, got: {msg}",
+            codes::VALID_7017
+        );
     }
 
     #[test]
@@ -700,6 +843,12 @@ mod tests {
             "not json".to_owned(),
         );
         assert!(result.is_err());
+        let msg = format!("{}", result.unwrap_err());
+        assert!(
+            msg.contains(codes::VALID_7030),
+            "expected {}, got: {msg}",
+            codes::VALID_7030
+        );
     }
 
     #[test]
@@ -713,6 +862,33 @@ mod tests {
             "[]".to_owned(),
         );
         assert!(result.is_err());
+        let msg = format!("{}", result.unwrap_err());
+        assert!(
+            msg.contains(codes::VALID_7031),
+            "expected {}, got: {msg}",
+            codes::VALID_7031
+        );
+    }
+
+    #[test]
+    fn verify_participation_requirements_unmet_requirement_fails_with_admission_code() {
+        // A requirement with no satisfying profiles fails the admission check
+        // itself (not JSON parsing), which carries its own per-case code.
+        let bi = test_bi();
+        let requirements = r#"[{"fact":"ParticipationDuration","threshold":{"AtLeast":1},"max_age_secs":3600,"min_contexts":0}]"#;
+        let result = verify_participation_requirements_on(
+            &bi,
+            "did:key:alice".to_owned(),
+            requirements.to_owned(),
+            "[]".to_owned(),
+        );
+        assert!(result.is_err());
+        let msg = format!("{}", result.unwrap_err());
+        assert!(
+            msg.contains(codes::VALID_7032),
+            "expected {}, got: {msg}",
+            codes::VALID_7032
+        );
     }
 
     #[test]
@@ -737,6 +913,12 @@ mod tests {
             "[]".to_owned(),
         );
         assert!(result.is_err());
+        let msg = format!("{}", result.unwrap_err());
+        assert!(
+            msg.contains(codes::VALID_7000),
+            "expected {}, got: {msg}",
+            codes::VALID_7000
+        );
     }
 
     #[test]
@@ -1003,6 +1185,12 @@ mod tests {
             "[]".to_owned(),
         );
         assert!(result.is_err());
+        let msg = format!("{}", result.unwrap_err());
+        assert!(
+            msg.contains(codes::VALID_7040),
+            "expected {}, got: {msg}",
+            codes::VALID_7040
+        );
     }
 
     #[test]
@@ -1021,6 +1209,204 @@ mod tests {
             "[]".to_owned(),
         );
         assert!(result.is_err());
+        let msg = format!("{}", result.unwrap_err());
+        assert!(
+            msg.contains(codes::VALID_7042),
+            "expected {}, got: {msg}",
+            codes::VALID_7042
+        );
+    }
+
+    #[test]
+    fn aggregate_trust_input_rejects_empty_did() {
+        let bi = test_bi();
+        let result = aggregate_trust_input_on(
+            &bi,
+            "ctx-1".to_owned(),
+            String::new(),
+            "[]".to_owned(),
+            "[0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0]".to_owned(),
+            "[]".to_owned(),
+            "{}".to_owned(),
+            "{}".to_owned(),
+            "[]".to_owned(),
+            "[]".to_owned(),
+        );
+        assert!(result.is_err());
+        let msg = format!("{}", result.unwrap_err());
+        assert!(
+            msg.contains(codes::VALID_7041),
+            "expected {}, got: {msg}",
+            codes::VALID_7041
+        );
+    }
+
+    #[test]
+    fn aggregate_trust_input_rejects_invalid_merkle_root_json() {
+        let bi = test_bi();
+        let result = aggregate_trust_input_on(
+            &bi,
+            "ctx-1".to_owned(),
+            "did:key:test".to_owned(),
+            "[]".to_owned(),
+            "not json".to_owned(),
+            "[]".to_owned(),
+            "{}".to_owned(),
+            "{}".to_owned(),
+            "[]".to_owned(),
+            "[]".to_owned(),
+        );
+        assert!(result.is_err());
+        let msg = format!("{}", result.unwrap_err());
+        assert!(
+            msg.contains(codes::VALID_7043),
+            "expected {}, got: {msg}",
+            codes::VALID_7043
+        );
+    }
+
+    #[test]
+    fn aggregate_trust_input_rejects_wrong_length_merkle_root() {
+        let bi = test_bi();
+        let result = aggregate_trust_input_on(
+            &bi,
+            "ctx-1".to_owned(),
+            "did:key:test".to_owned(),
+            "[]".to_owned(),
+            "[0,0,0]".to_owned(),
+            "[]".to_owned(),
+            "{}".to_owned(),
+            "{}".to_owned(),
+            "[]".to_owned(),
+            "[]".to_owned(),
+        );
+        assert!(result.is_err());
+        let msg = format!("{}", result.unwrap_err());
+        assert!(
+            msg.contains(codes::VALID_7044),
+            "expected {}, got: {msg}",
+            codes::VALID_7044
+        );
+    }
+
+    #[test]
+    fn aggregate_trust_input_rejects_invalid_consequence_rules_json() {
+        let bi = test_bi();
+        let result = aggregate_trust_input_on(
+            &bi,
+            "ctx-1".to_owned(),
+            "did:key:test".to_owned(),
+            "[]".to_owned(),
+            "[0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0]".to_owned(),
+            "not json".to_owned(),
+            "{}".to_owned(),
+            "{}".to_owned(),
+            "[]".to_owned(),
+            "[]".to_owned(),
+        );
+        assert!(result.is_err());
+        let msg = format!("{}", result.unwrap_err());
+        assert!(
+            msg.contains(codes::VALID_7045),
+            "expected {}, got: {msg}",
+            codes::VALID_7045
+        );
+    }
+
+    #[test]
+    fn aggregate_trust_input_rejects_invalid_threshold_requirements_json() {
+        let bi = test_bi();
+        let result = aggregate_trust_input_on(
+            &bi,
+            "ctx-1".to_owned(),
+            "did:key:test".to_owned(),
+            "[]".to_owned(),
+            "[0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0]".to_owned(),
+            "[]".to_owned(),
+            "not json".to_owned(),
+            "{}".to_owned(),
+            "[]".to_owned(),
+            "[]".to_owned(),
+        );
+        assert!(result.is_err());
+        let msg = format!("{}", result.unwrap_err());
+        assert!(
+            msg.contains(codes::VALID_7046),
+            "expected {}, got: {msg}",
+            codes::VALID_7046
+        );
+    }
+
+    #[test]
+    fn aggregate_trust_input_rejects_invalid_attestor_sets_json() {
+        let bi = test_bi();
+        let result = aggregate_trust_input_on(
+            &bi,
+            "ctx-1".to_owned(),
+            "did:key:test".to_owned(),
+            "[]".to_owned(),
+            "[0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0]".to_owned(),
+            "[]".to_owned(),
+            "{}".to_owned(),
+            "not json".to_owned(),
+            "[]".to_owned(),
+            "[]".to_owned(),
+        );
+        assert!(result.is_err());
+        let msg = format!("{}", result.unwrap_err());
+        assert!(
+            msg.contains(codes::VALID_7047),
+            "expected {}, got: {msg}",
+            codes::VALID_7047
+        );
+    }
+
+    #[test]
+    fn aggregate_trust_input_rejects_invalid_cached_attestations_json() {
+        let bi = test_bi();
+        let result = aggregate_trust_input_on(
+            &bi,
+            "ctx-1".to_owned(),
+            "did:key:test".to_owned(),
+            "[]".to_owned(),
+            "[0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0]".to_owned(),
+            "[]".to_owned(),
+            "{}".to_owned(),
+            "{}".to_owned(),
+            "not json".to_owned(),
+            "[]".to_owned(),
+        );
+        assert!(result.is_err());
+        let msg = format!("{}", result.unwrap_err());
+        assert!(
+            msg.contains(codes::VALID_7048),
+            "expected {}, got: {msg}",
+            codes::VALID_7048
+        );
+    }
+
+    #[test]
+    fn aggregate_trust_input_rejects_invalid_challenge_results_json() {
+        let bi = test_bi();
+        let result = aggregate_trust_input_on(
+            &bi,
+            "ctx-1".to_owned(),
+            "did:key:test".to_owned(),
+            "[]".to_owned(),
+            "[0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0]".to_owned(),
+            "[]".to_owned(),
+            "{}".to_owned(),
+            "{}".to_owned(),
+            "[]".to_owned(),
+            "not json".to_owned(),
+        );
+        assert!(result.is_err());
+        let msg = format!("{}", result.unwrap_err());
+        assert!(
+            msg.contains(codes::VALID_7049),
+            "expected {}, got: {msg}",
+            codes::VALID_7049
+        );
     }
 
     #[test]

--- a/crates/scp-ffi/src/trust.rs
+++ b/crates/scp-ffi/src/trust.rs
@@ -35,10 +35,27 @@ use std::sync::Arc;
 
 use pyo3::prelude::*;
 use pyo3::types::PyDict;
+use scp_ffi_common::error_codes as codes;
 
 use crate::runtime::PyBridgeInstance;
 use crate::types::encode_hex;
-use crate::validate;
+
+// ---------------------------------------------------------------------------
+// Coded-error helper — cross-bridge error-code parity
+// ---------------------------------------------------------------------------
+
+/// Builds a bridge validation error carrying the specific `SCP-VALID-*` code
+/// the UniFFI/NAPI bridges emit for the same logical failure case, so a
+/// Python caller can branch on the same `.code` a Swift/Kotlin/TypeScript
+/// caller sees (e.g. the per-case `verify_participation_requirements` codes
+/// `VALID_7030`/`VALID_7031`/`VALID_7032`, or the trust-helper codes
+/// `VALID_7012..=VALID_7017`).
+fn coded_validation_error(message: String, code: &str) -> crate::error::ScpPyError {
+    crate::error::ScpPyError::ValidationError {
+        message,
+        code: code.to_owned(),
+    }
+}
 
 // ---------------------------------------------------------------------------
 // trust_query_score — per-bridge helper used by PyScp method
@@ -52,8 +69,14 @@ fn trust_query_score_impl(
     did: &str,
     context_id: &str,
 ) -> PyResult<Py<PyDict>> {
-    validate::validate_did(did)?;
-    validate::validate_context_id(context_id)?;
+    // Per-argument codes match the UniFFI bridge (invalid DID → VALID_7010,
+    // invalid context id → VALID_7011) so the same logical failure carries
+    // the same code on every native bridge. The PyO3 boundary additionally
+    // rejects malformed (non-empty) values under the same per-argument code.
+    scp_ffi_common::validate::validate_did(did)
+        .map_err(|e| coded_validation_error(e.message, codes::VALID_7010))?;
+    scp_ffi_common::validate::validate_context_id(context_id)
+        .map_err(|e| coded_validation_error(e.message, codes::VALID_7011))?;
 
     // Query the runtime registry for event counts. The event log stores leaf
     // hashes (Merkle tree), not full events. The runtime registry tracks
@@ -95,15 +118,17 @@ fn trust_query_score_impl(
 ///
 /// # Errors
 ///
-/// Returns `ScpError` if the JSON is malformed or cannot be parsed.
+/// Returns `ValidationError` with code `VALID_7012` (matching the UniFFI/NAPI
+/// bridges) if the JSON is malformed or cannot be parsed.
 #[pyfunction]
 #[pyo3(name = "trust_verify_attestation")]
 pub fn py_trust_verify_attestation(py: Python<'_>, attestation_json: &str) -> PyResult<Py<PyDict>> {
     let attestation: scp_core::trust::Attestation = serde_json::from_str(attestation_json)
         .map_err(|e| {
-            pyo3::exceptions::PyValueError::new_err(format!(
-                "failed to parse attestation JSON: {e}"
-            ))
+            coded_validation_error(
+                format!("failed to parse attestation JSON: {e}"),
+                codes::VALID_7012,
+            )
         })?;
 
     let resolver = scp_core::trust::IdentityDidPublicKeyResolver;
@@ -142,11 +167,17 @@ pub fn py_trust_verify_attestation(py: Python<'_>, attestation_json: &str) -> Py
 ///
 /// # Errors
 ///
-/// Returns `ScpError` if input validation or signing fails.
+/// Returns `ValidationError` with a per-case code matching the UniFFI/NAPI
+/// bridges: `VALID_7013` for an invalid target DID, `VALID_7014` if challenge
+/// creation fails, `VALID_7015` if serialization fails.
 #[pyfunction]
 #[pyo3(name = "trust_create_challenge")]
 pub fn py_trust_create_challenge(py: Python<'_>, target_did: &str) -> PyResult<Py<PyDict>> {
-    validate::validate_did(target_did)?;
+    // VALID_7013 matches the UniFFI bridge's code for an empty target DID;
+    // the PyO3 boundary additionally rejects malformed (non-empty) DIDs
+    // under the same per-argument code.
+    scp_ffi_common::validate::validate_did(target_did)
+        .map_err(|e| coded_validation_error(e.message, codes::VALID_7013))?;
 
     struct EphemeralSigner(ed25519_dalek::SigningKey);
     impl scp_core::trust::ChallengeSigner for EphemeralSigner {
@@ -172,11 +203,14 @@ pub fn py_trust_create_challenge(py: Python<'_>, target_did: &str) -> PyResult<P
         &signer,
     )
     .map_err(|e| {
-        pyo3::exceptions::PyRuntimeError::new_err(format!("challenge creation failed: {e}"))
+        coded_validation_error(format!("challenge creation failed: {e}"), codes::VALID_7014)
     })?;
 
     let challenge_json = serde_json::to_string(&request).map_err(|e| {
-        pyo3::exceptions::PyRuntimeError::new_err(format!("failed to serialize challenge: {e}"))
+        coded_validation_error(
+            format!("failed to serialize challenge: {e}"),
+            codes::VALID_7015,
+        )
     })?;
 
     let dict = PyDict::new(py);
@@ -201,18 +235,26 @@ pub fn py_trust_create_challenge(py: Python<'_>, target_did: &str) -> PyResult<P
 ///
 /// # Errors
 ///
-/// Returns `ScpError` if the JSON is malformed.
+/// Returns `ValidationError` with a per-case code matching the UniFFI/NAPI
+/// bridges: `VALID_7016` for malformed challenge JSON, `VALID_7017` for
+/// malformed response JSON.
 #[pyfunction]
 #[pyo3(name = "trust_verify_response")]
 pub fn py_trust_verify_response(challenge_json: &str, response_json: &str) -> PyResult<bool> {
     let request: scp_core::trust::ChallengeRequest =
         serde_json::from_str(challenge_json).map_err(|e| {
-            pyo3::exceptions::PyValueError::new_err(format!("failed to parse challenge JSON: {e}"))
+            coded_validation_error(
+                format!("failed to parse challenge JSON: {e}"),
+                codes::VALID_7016,
+            )
         })?;
 
     let response: scp_core::trust::ChallengeResponse = serde_json::from_str(response_json)
         .map_err(|e| {
-            pyo3::exceptions::PyValueError::new_err(format!("failed to parse response JSON: {e}"))
+            coded_validation_error(
+                format!("failed to parse response JSON: {e}"),
+                codes::VALID_7017,
+            )
         })?;
 
     let resolver = scp_core::trust::IdentityDidPublicKeyResolver;
@@ -264,9 +306,11 @@ pub fn py_trust_verify_response(challenge_json: &str, response_json: &str) -> Py
 ///
 /// # Errors
 ///
-/// Returns `PyValueError` if JSON parsing fails, or `PyRuntimeError` if
-/// participation admission verification fails (with the specific failure
-/// reason from `ParticipationAdmissionError`).
+/// Returns `ValidationError` with a per-case code matching the UniFFI/NAPI
+/// bridges: `VALID_7000` for an invalid `expected_subject` DID, `VALID_7031`
+/// for malformed requirements JSON, `VALID_7030` for malformed profiles JSON,
+/// and `VALID_7032` if participation admission verification fails (with the
+/// specific failure reason from `ParticipationAdmissionError`).
 #[pyfunction]
 #[pyo3(name = "verify_participation_requirements")]
 pub fn py_verify_participation_requirements(
@@ -274,20 +318,26 @@ pub fn py_verify_participation_requirements(
     requirements_json: &str,
     profile_json: &str,
 ) -> PyResult<()> {
-    validate::validate_did(expected_subject)?;
+    // VALID_7000 matches the UniFFI/NAPI bridges, which route this same
+    // check through the shared `scp_ffi_common::validate::ValidationError`
+    // conversion (generic validation code).
+    scp_ffi_common::validate::validate_did(expected_subject)
+        .map_err(|e| coded_validation_error(e.message, codes::VALID_7000))?;
 
     let requirements: Vec<scp_core::trust::RequireParticipation> =
         serde_json::from_str(requirements_json).map_err(|e| {
-            pyo3::exceptions::PyValueError::new_err(format!(
-                "failed to parse participation requirements JSON: {e}"
-            ))
+            coded_validation_error(
+                format!("failed to parse participation requirements JSON: {e}"),
+                codes::VALID_7031,
+            )
         })?;
 
     let profiles: Vec<scp_core::trust::ParticipationProfile> = serde_json::from_str(profile_json)
         .map_err(|e| {
-        pyo3::exceptions::PyValueError::new_err(format!(
-            "failed to parse participation profiles JSON: {e}"
-        ))
+        coded_validation_error(
+            format!("failed to parse participation profiles JSON: {e}"),
+            codes::VALID_7030,
+        )
     })?;
 
     // Fail-closed clock: a pre-epoch host clock is an unrecoverable environment
@@ -303,9 +353,13 @@ pub fn py_verify_participation_requirements(
         &profiles,
     )
     .map_err(|e| {
-        pyo3::exceptions::PyRuntimeError::new_err(format!(
-            "participation admission verification failed: {e}"
-        ))
+        // VALID_7032 mirrors the UniFFI bridge's code for a failed
+        // participation admission check, so every native bridge surfaces the
+        // identical code for the same logical failure.
+        coded_validation_error(
+            format!("participation admission verification failed: {e}"),
+            codes::VALID_7032,
+        )
     })?;
 
     Ok(())
@@ -348,9 +402,12 @@ pub fn py_verify_participation_requirements(
 ///
 /// # Errors
 ///
-/// Returns `PyValueError` if any JSON input is malformed or `subject_did` is
-/// not a valid DID, or `PyRuntimeError` if an admission requirement is unmet
-/// (with the specific reason from `AdmissionError`).
+/// Returns `ValidationError` with a per-case code matching the UniFFI/NAPI
+/// bridges: `VALID_7000` for an invalid `subject_did`, `VALID_7073`/
+/// `VALID_7074`/`VALID_7075` for malformed requirements / agent-capabilities /
+/// challenge-verifications JSON, and `VALID_7076`/`VALID_7077` if an
+/// admission requirement is unmet (with the specific reason from
+/// `AdmissionError`).
 #[pyfunction]
 #[pyo3(name = "check_capability_requirements")]
 pub fn py_check_capability_requirements(
@@ -360,30 +417,34 @@ pub fn py_check_capability_requirements(
     agent_capabilities_json: &str,
     challenge_verifications_json: &str,
 ) -> PyResult<()> {
-    validate::validate_did(subject_did)?;
+    // VALID_7000 matches the UniFFI/NAPI bridges, which route this same
+    // check through the shared `scp_ffi_common::validate::ValidationError`
+    // conversion (generic validation code).
+    scp_ffi_common::validate::validate_did(subject_did)
+        .map_err(|e| coded_validation_error(e.message, codes::VALID_7000))?;
 
     let requirements: Vec<scp_core::trust::CapabilityRequirement> =
         serde_json::from_str(requirements_json).map_err(|e| {
-            crate::error::ScpPyError::ValidationError {
-                message: format!("failed to parse capability requirements JSON: {e}"),
-                code: scp_ffi_common::error_codes::VALID_7073.to_owned(),
-            }
+            coded_validation_error(
+                format!("failed to parse capability requirements JSON: {e}"),
+                codes::VALID_7073,
+            )
         })?;
 
     let agent_capabilities: Vec<scp_core::trust::CapabilityUri> =
         serde_json::from_str(agent_capabilities_json).map_err(|e| {
-            crate::error::ScpPyError::ValidationError {
-                message: format!("failed to parse agent capabilities JSON: {e}"),
-                code: scp_ffi_common::error_codes::VALID_7074.to_owned(),
-            }
+            coded_validation_error(
+                format!("failed to parse agent capabilities JSON: {e}"),
+                codes::VALID_7074,
+            )
         })?;
 
     let challenge_verifications: Vec<scp_core::trust::ChallengeVerification> =
         serde_json::from_str(challenge_verifications_json).map_err(|e| {
-            crate::error::ScpPyError::ValidationError {
-                message: format!("failed to parse challenge verifications JSON: {e}"),
-                code: scp_ffi_common::error_codes::VALID_7075.to_owned(),
-            }
+            coded_validation_error(
+                format!("failed to parse challenge verifications JSON: {e}"),
+                codes::VALID_7075,
+            )
         })?;
 
     let resolver = scp_core::trust::IdentityDidPublicKeyResolver;
@@ -404,18 +465,14 @@ pub fn py_check_capability_requirements(
         // failure case: empty subject → 7077; missing capability /
         // verification-required → 7076.
         let code = match e {
-            scp_core::trust::AdmissionError::EmptySubjectDid => {
-                scp_ffi_common::error_codes::VALID_7077
-            }
+            scp_core::trust::AdmissionError::EmptySubjectDid => codes::VALID_7077,
             scp_core::trust::AdmissionError::MissingCapability { .. }
-            | scp_core::trust::AdmissionError::VerificationRequired { .. } => {
-                scp_ffi_common::error_codes::VALID_7076
-            }
+            | scp_core::trust::AdmissionError::VerificationRequired { .. } => codes::VALID_7076,
         };
-        crate::error::ScpPyError::ValidationError {
-            message: format!("capability admission verification failed: {e}"),
-            code: code.to_owned(),
-        }
+        coded_validation_error(
+            format!("capability admission verification failed: {e}"),
+            code,
+        )
     })?;
 
     Ok(())
@@ -451,59 +508,80 @@ fn aggregate_trust_input_impl(
     cached_attestations_json: &str,
     challenge_results_json: &str,
 ) -> PyResult<String> {
-    validate::validate_context_id(context_id)?;
-    validate::validate_did(subject_did)?;
+    // Per-argument codes match the UniFFI bridge's `aggregate_trust_input`
+    // (context id → VALID_7040, subject DID → VALID_7041, then one code per
+    // JSON input, VALID_7042..=VALID_7049) so the same logical failure
+    // carries the same code on every native bridge. The PyO3 boundary
+    // additionally rejects malformed (non-empty) ids under the same
+    // per-argument code.
+    scp_ffi_common::validate::validate_context_id(context_id)
+        .map_err(|e| coded_validation_error(e.message, codes::VALID_7040))?;
+    scp_ffi_common::validate::validate_did(subject_did)
+        .map_err(|e| coded_validation_error(e.message, codes::VALID_7041))?;
 
     // Parse all JSON inputs.
     let events: Vec<scp_event_log::Event> = serde_json::from_str(events_json).map_err(|e| {
-        pyo3::exceptions::PyValueError::new_err(format!("failed to parse events JSON: {e}"))
+        coded_validation_error(
+            format!("failed to parse events JSON: {e}"),
+            codes::VALID_7042,
+        )
     })?;
 
     let merkle_root_vec: Vec<u8> = serde_json::from_str(merkle_root_json).map_err(|e| {
-        pyo3::exceptions::PyValueError::new_err(format!("failed to parse merkle_root JSON: {e}"))
+        coded_validation_error(
+            format!("failed to parse merkle_root JSON: {e}"),
+            codes::VALID_7043,
+        )
     })?;
     let merkle_root: [u8; 32] = merkle_root_vec.try_into().map_err(|v: Vec<u8>| {
-        pyo3::exceptions::PyValueError::new_err(format!(
-            "merkle_root must be exactly 32 bytes, got {}",
-            v.len()
-        ))
+        coded_validation_error(
+            format!("merkle_root must be exactly 32 bytes, got {}", v.len()),
+            codes::VALID_7044,
+        )
     })?;
 
     let consequence_rules: Vec<scp_core::trust::ConsequenceRule> =
         serde_json::from_str(consequence_rules_json).map_err(|e| {
-            pyo3::exceptions::PyValueError::new_err(format!(
-                "failed to parse consequence_rules JSON: {e}"
-            ))
+            coded_validation_error(
+                format!("failed to parse consequence_rules JSON: {e}"),
+                codes::VALID_7045,
+            )
         })?;
 
     let threshold_requirements: std::collections::HashMap<
         scp_core::trust::AttestationType,
         scp_core::trust::ThresholdRequirement,
     > = serde_json::from_str(threshold_requirements_json).map_err(|e| {
-        pyo3::exceptions::PyValueError::new_err(format!(
-            "failed to parse threshold_requirements JSON: {e}"
-        ))
+        coded_validation_error(
+            format!("failed to parse threshold_requirements JSON: {e}"),
+            codes::VALID_7046,
+        )
     })?;
 
     let attestor_sets: std::collections::HashMap<
         scp_core::trust::AttestationType,
         Vec<scp_core::trust::AttestorInfo>,
     > = serde_json::from_str(attestor_sets_json).map_err(|e| {
-        pyo3::exceptions::PyValueError::new_err(format!("failed to parse attestor_sets JSON: {e}"))
+        coded_validation_error(
+            format!("failed to parse attestor_sets JSON: {e}"),
+            codes::VALID_7047,
+        )
     })?;
 
     let cached_attestations: Vec<scp_core::trust::aggregate::CachedAttestation> =
         serde_json::from_str(cached_attestations_json).map_err(|e| {
-            pyo3::exceptions::PyValueError::new_err(format!(
-                "failed to parse cached_attestations JSON: {e}"
-            ))
+            coded_validation_error(
+                format!("failed to parse cached_attestations JSON: {e}"),
+                codes::VALID_7048,
+            )
         })?;
 
     let challenge_results: Vec<scp_core::trust::ChallengeVerification> =
         serde_json::from_str(challenge_results_json).map_err(|e| {
-            pyo3::exceptions::PyValueError::new_err(format!(
-                "failed to parse challenge_results JSON: {e}"
-            ))
+            coded_validation_error(
+                format!("failed to parse challenge_results JSON: {e}"),
+                codes::VALID_7049,
+            )
         })?;
 
     aggregate_with_storage(
@@ -553,12 +631,13 @@ fn aggregate_with_storage(
     // SQLCipher store invisibly landed in an empty ephemeral store. See
     // `with_storage_py`.
     let provider = crate::runtime::get_storage(bi).map_err(|_| {
-        pyo3::exceptions::PyValueError::new_err(format!(
-            "{}: bridge storage not initialized — trust aggregation is \
+        coded_validation_error(
+            "bridge storage not initialized — trust aggregation is \
              unreachable until this PyBridgeInstance has allocated its \
-             storage provider (bridge init bug)",
-            scp_ffi_common::error_codes::VALID_7005
-        ))
+             storage provider (bridge init bug)"
+                .to_owned(),
+            codes::VALID_7005,
+        )
     })?;
     let handle = crate::runtime()?.handle().clone();
     // The aggregation logic lives ONCE in `run_aggregation` (generic over the
@@ -584,7 +663,10 @@ fn aggregate_with_storage(
         }
         StorageProvider::Sqlite(storage) => run_aggregation(Arc::clone(storage), handle, inputs),
     };
-    result.map_err(|e| pyo3::exceptions::PyRuntimeError::new_err(e.to_string()))
+    // VALID_7052 mirrors the UniFFI bridge's code for a failed trust
+    // aggregation, so every native bridge surfaces the identical code for
+    // the same logical failure.
+    result.map_err(|e| coded_validation_error(e.to_string(), codes::VALID_7052).into())
 }
 
 /// Owned + borrowed inputs for [`run_aggregation`], grouped to keep the generic
@@ -755,15 +837,20 @@ fn participation_record_impl(
 ) -> PyResult<PyParticipationRecord> {
     use crate::runtime::StorageProvider;
 
-    validate::validate_context_id(context_id)?;
-    validate::validate_did(subject_did)?;
+    // VALID_7000 matches the UniFFI/NAPI bridges, which route these same
+    // checks through the shared `scp_ffi_common::validate::ValidationError`
+    // conversion (generic validation code).
+    scp_ffi_common::validate::validate_context_id(context_id)
+        .map_err(|e| coded_validation_error(e.message, codes::VALID_7000))?;
+    scp_ffi_common::validate::validate_did(subject_did)
+        .map_err(|e| coded_validation_error(e.message, codes::VALID_7000))?;
 
     let cached_attestations: Vec<scp_core::trust::aggregate::CachedAttestation> =
         serde_json::from_str(cached_attestations_json).map_err(|e| {
-            crate::error::ScpPyError::ValidationError {
-                message: format!("failed to parse cached_attestations JSON: {e}"),
-                code: scp_ffi_common::error_codes::VALID_7059.to_owned(),
-            }
+            coded_validation_error(
+                format!("failed to parse cached_attestations JSON: {e}"),
+                codes::VALID_7059,
+            )
         })?;
 
     // Source verified attestations from this instance's persistent trust store
@@ -991,6 +1078,12 @@ mod tests {
             // Empty DID should fail validation.
             let result = default_scp().trust_query_score(py, "", "ctx-1");
             assert!(result.is_err());
+            let err_str = format!("{}", result.unwrap_err());
+            assert!(
+                err_str.contains(scp_ffi_common::error_codes::VALID_7010),
+                "expected {}, got: {err_str}",
+                scp_ffi_common::error_codes::VALID_7010
+            );
         });
     }
 
@@ -1001,6 +1094,12 @@ mod tests {
             // Empty context ID should fail validation.
             let result = default_scp().trust_query_score(py, "did:key:test", "");
             assert!(result.is_err());
+            let err_str = format!("{}", result.unwrap_err());
+            assert!(
+                err_str.contains(scp_ffi_common::error_codes::VALID_7011),
+                "expected {}, got: {err_str}",
+                scp_ffi_common::error_codes::VALID_7011
+            );
         });
     }
 
@@ -1024,6 +1123,12 @@ mod tests {
         Python::with_gil(|py| {
             let result = py_trust_verify_attestation(py, "not valid json");
             assert!(result.is_err());
+            let err_str = format!("{}", result.unwrap_err());
+            assert!(
+                err_str.contains(scp_ffi_common::error_codes::VALID_7012),
+                "expected {}, got: {err_str}",
+                scp_ffi_common::error_codes::VALID_7012
+            );
         });
     }
 
@@ -1033,6 +1138,12 @@ mod tests {
         Python::with_gil(|py| {
             let result = py_trust_create_challenge(py, "");
             assert!(result.is_err());
+            let err_str = format!("{}", result.unwrap_err());
+            assert!(
+                err_str.contains(scp_ffi_common::error_codes::VALID_7013),
+                "expected {}, got: {err_str}",
+                scp_ffi_common::error_codes::VALID_7013
+            );
         });
     }
 
@@ -1050,23 +1161,76 @@ mod tests {
     }
 
     #[test]
-    fn trust_verify_response_rejects_invalid_json() {
-        let result = py_trust_verify_response("bad", "bad");
-        assert!(result.is_err());
+    fn trust_verify_response_rejects_invalid_challenge_json() {
+        // Malformed JSON in the CHALLENGE position.
+        pyo3::prepare_freethreaded_python();
+        Python::with_gil(|_py| {
+            let result = py_trust_verify_response("bad", "bad");
+            assert!(result.is_err());
+            let err_str = format!("{}", result.unwrap_err());
+            assert!(
+                err_str.contains(scp_ffi_common::error_codes::VALID_7016),
+                "expected {}, got: {err_str}",
+                scp_ffi_common::error_codes::VALID_7016
+            );
+        });
+    }
+
+    #[test]
+    fn trust_verify_response_rejects_invalid_response_json() {
+        // Malformed JSON in the RESPONSE position: the challenge parses, so
+        // the failure is attributed to the response argument.
+        pyo3::prepare_freethreaded_python();
+        Python::with_gil(|py| {
+            let challenge = py_trust_create_challenge(py, "did:key:target").unwrap();
+            let challenge_json: String = challenge
+                .bind(py)
+                .get_item("challenge_json")
+                .unwrap()
+                .unwrap()
+                .extract()
+                .unwrap();
+            let result = py_trust_verify_response(&challenge_json, "bad");
+            assert!(result.is_err());
+            let err_str = format!("{}", result.unwrap_err());
+            assert!(
+                err_str.contains(scp_ffi_common::error_codes::VALID_7017),
+                "expected {}, got: {err_str}",
+                scp_ffi_common::error_codes::VALID_7017
+            );
+        });
     }
 
     #[test]
     fn verify_participation_requirements_rejects_invalid_profile_json() {
         // Malformed JSON in the PROFILE position (now the 3rd arg).
-        let result = py_verify_participation_requirements("did:key:alice", "[]", "not json");
-        assert!(result.is_err());
+        pyo3::prepare_freethreaded_python();
+        Python::with_gil(|_py| {
+            let result = py_verify_participation_requirements("did:key:alice", "[]", "not json");
+            assert!(result.is_err());
+            let err_str = format!("{}", result.unwrap_err());
+            assert!(
+                err_str.contains(scp_ffi_common::error_codes::VALID_7030),
+                "expected {}, got: {err_str}",
+                scp_ffi_common::error_codes::VALID_7030
+            );
+        });
     }
 
     #[test]
     fn verify_participation_requirements_rejects_invalid_requirements_json() {
         // Malformed JSON in the REQUIREMENTS position (now the 2nd arg).
-        let result = py_verify_participation_requirements("did:key:alice", "not json", "[]");
-        assert!(result.is_err());
+        pyo3::prepare_freethreaded_python();
+        Python::with_gil(|_py| {
+            let result = py_verify_participation_requirements("did:key:alice", "not json", "[]");
+            assert!(result.is_err());
+            let err_str = format!("{}", result.unwrap_err());
+            assert!(
+                err_str.contains(scp_ffi_common::error_codes::VALID_7031),
+                "expected {}, got: {err_str}",
+                scp_ffi_common::error_codes::VALID_7031
+            );
+        });
     }
 
     #[test]
@@ -1079,8 +1243,35 @@ mod tests {
     #[test]
     fn verify_participation_requirements_rejects_invalid_subject() {
         // A malformed subject DID is rejected at the FFI boundary.
-        let result = py_verify_participation_requirements("not-a-did", "[]", "[]");
-        assert!(result.is_err());
+        pyo3::prepare_freethreaded_python();
+        Python::with_gil(|_py| {
+            let result = py_verify_participation_requirements("not-a-did", "[]", "[]");
+            assert!(result.is_err());
+            let err_str = format!("{}", result.unwrap_err());
+            assert!(
+                err_str.contains(scp_ffi_common::error_codes::VALID_7000),
+                "expected {}, got: {err_str}",
+                scp_ffi_common::error_codes::VALID_7000
+            );
+        });
+    }
+
+    #[test]
+    fn verify_participation_requirements_unmet_requirement_fails_with_admission_code() {
+        // A requirement with no satisfying profiles fails the admission check
+        // itself (not JSON parsing), which carries its own per-case code.
+        pyo3::prepare_freethreaded_python();
+        Python::with_gil(|_py| {
+            let requirements = r#"[{"fact":"ParticipationDuration","threshold":{"AtLeast":1},"max_age_secs":3600,"min_contexts":0}]"#;
+            let result = py_verify_participation_requirements("did:key:alice", requirements, "[]");
+            assert!(result.is_err());
+            let err_str = format!("{}", result.unwrap_err());
+            assert!(
+                err_str.contains(scp_ffi_common::error_codes::VALID_7032),
+                "expected {}, got: {err_str}",
+                scp_ffi_common::error_codes::VALID_7032
+            );
+        });
     }
 
     // -- check_capability_requirements (§7.3.4.4, SCP-ACR-008) --
@@ -1136,15 +1327,29 @@ mod tests {
 
     #[test]
     fn check_capability_requirements_rejects_malformed_subject() {
+        pyo3::prepare_freethreaded_python();
         let result = py_check_capability_requirements("ctx-1", "not-a-did", "[]", "[]", "[]");
         assert!(result.is_err());
+        let err_str = format!("{}", result.unwrap_err());
+        assert!(
+            err_str.contains(scp_ffi_common::error_codes::VALID_7000),
+            "expected {}, got: {err_str}",
+            scp_ffi_common::error_codes::VALID_7000
+        );
     }
 
     #[test]
     fn check_capability_requirements_rejects_empty_subject() {
         // An empty subject is rejected at the FFI boundary (validate_did).
+        pyo3::prepare_freethreaded_python();
         let result = py_check_capability_requirements("ctx-1", "", "[]", "[]", "[]");
         assert!(result.is_err());
+        let err_str = format!("{}", result.unwrap_err());
+        assert!(
+            err_str.contains(scp_ffi_common::error_codes::VALID_7000),
+            "expected {}, got: {err_str}",
+            scp_ffi_common::error_codes::VALID_7000
+        );
     }
 
     #[test]
@@ -1275,6 +1480,12 @@ mod tests {
             "[]",
         );
         assert!(result.is_err());
+        let err_str = format!("{}", result.unwrap_err());
+        assert!(
+            err_str.contains(scp_ffi_common::error_codes::VALID_7042),
+            "expected {}, got: {err_str}",
+            scp_ffi_common::error_codes::VALID_7042
+        );
     }
 
     #[test]
@@ -1291,6 +1502,12 @@ mod tests {
             "[]",
         );
         assert!(result.is_err());
+        let err_str = format!("{}", result.unwrap_err());
+        assert!(
+            err_str.contains(scp_ffi_common::error_codes::VALID_7044),
+            "expected {}, got: {err_str}",
+            scp_ffi_common::error_codes::VALID_7044
+        );
     }
 
     #[test]
@@ -1307,24 +1524,212 @@ mod tests {
             "[]",
         );
         assert!(result.is_err());
+        let err_str = format!("{}", result.unwrap_err());
+        assert!(
+            err_str.contains(scp_ffi_common::error_codes::VALID_7041),
+            "expected {}, got: {err_str}",
+            scp_ffi_common::error_codes::VALID_7041
+        );
+    }
+
+    #[test]
+    fn aggregate_trust_input_rejects_empty_context() {
+        pyo3::prepare_freethreaded_python();
+        let result = default_scp().aggregate_trust_input(
+            "",
+            "did:key:test",
+            "[]",
+            "[0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0]",
+            "[]",
+            "{}",
+            "{}",
+            "[]",
+            "[]",
+        );
+        assert!(result.is_err());
+        let err_str = format!("{}", result.unwrap_err());
+        assert!(
+            err_str.contains(scp_ffi_common::error_codes::VALID_7040),
+            "expected {}, got: {err_str}",
+            scp_ffi_common::error_codes::VALID_7040
+        );
+    }
+
+    #[test]
+    fn aggregate_trust_input_rejects_invalid_merkle_root_json() {
+        pyo3::prepare_freethreaded_python();
+        let result = default_scp().aggregate_trust_input(
+            "ctx-1",
+            "did:key:test",
+            "[]",
+            "not json",
+            "[]",
+            "{}",
+            "{}",
+            "[]",
+            "[]",
+        );
+        assert!(result.is_err());
+        let err_str = format!("{}", result.unwrap_err());
+        assert!(
+            err_str.contains(scp_ffi_common::error_codes::VALID_7043),
+            "expected {}, got: {err_str}",
+            scp_ffi_common::error_codes::VALID_7043
+        );
+    }
+
+    #[test]
+    fn aggregate_trust_input_rejects_invalid_consequence_rules_json() {
+        pyo3::prepare_freethreaded_python();
+        let result = default_scp().aggregate_trust_input(
+            "ctx-1",
+            "did:key:test",
+            "[]",
+            "[0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0]",
+            "not json",
+            "{}",
+            "{}",
+            "[]",
+            "[]",
+        );
+        assert!(result.is_err());
+        let err_str = format!("{}", result.unwrap_err());
+        assert!(
+            err_str.contains(scp_ffi_common::error_codes::VALID_7045),
+            "expected {}, got: {err_str}",
+            scp_ffi_common::error_codes::VALID_7045
+        );
+    }
+
+    #[test]
+    fn aggregate_trust_input_rejects_invalid_threshold_requirements_json() {
+        pyo3::prepare_freethreaded_python();
+        let result = default_scp().aggregate_trust_input(
+            "ctx-1",
+            "did:key:test",
+            "[]",
+            "[0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0]",
+            "[]",
+            "not json",
+            "{}",
+            "[]",
+            "[]",
+        );
+        assert!(result.is_err());
+        let err_str = format!("{}", result.unwrap_err());
+        assert!(
+            err_str.contains(scp_ffi_common::error_codes::VALID_7046),
+            "expected {}, got: {err_str}",
+            scp_ffi_common::error_codes::VALID_7046
+        );
+    }
+
+    #[test]
+    fn aggregate_trust_input_rejects_invalid_attestor_sets_json() {
+        pyo3::prepare_freethreaded_python();
+        let result = default_scp().aggregate_trust_input(
+            "ctx-1",
+            "did:key:test",
+            "[]",
+            "[0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0]",
+            "[]",
+            "{}",
+            "not json",
+            "[]",
+            "[]",
+        );
+        assert!(result.is_err());
+        let err_str = format!("{}", result.unwrap_err());
+        assert!(
+            err_str.contains(scp_ffi_common::error_codes::VALID_7047),
+            "expected {}, got: {err_str}",
+            scp_ffi_common::error_codes::VALID_7047
+        );
+    }
+
+    #[test]
+    fn aggregate_trust_input_rejects_invalid_cached_attestations_json() {
+        pyo3::prepare_freethreaded_python();
+        let result = default_scp().aggregate_trust_input(
+            "ctx-1",
+            "did:key:test",
+            "[]",
+            "[0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0]",
+            "[]",
+            "{}",
+            "{}",
+            "not json",
+            "[]",
+        );
+        assert!(result.is_err());
+        let err_str = format!("{}", result.unwrap_err());
+        assert!(
+            err_str.contains(scp_ffi_common::error_codes::VALID_7048),
+            "expected {}, got: {err_str}",
+            scp_ffi_common::error_codes::VALID_7048
+        );
+    }
+
+    #[test]
+    fn aggregate_trust_input_rejects_invalid_challenge_results_json() {
+        pyo3::prepare_freethreaded_python();
+        let result = default_scp().aggregate_trust_input(
+            "ctx-1",
+            "did:key:test",
+            "[]",
+            "[0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0]",
+            "[]",
+            "{}",
+            "{}",
+            "[]",
+            "not json",
+        );
+        assert!(result.is_err());
+        let err_str = format!("{}", result.unwrap_err());
+        assert!(
+            err_str.contains(scp_ffi_common::error_codes::VALID_7049),
+            "expected {}, got: {err_str}",
+            scp_ffi_common::error_codes::VALID_7049
+        );
     }
 
     #[test]
     fn participation_record_validates_context_id() {
+        pyo3::prepare_freethreaded_python();
         let result = default_scp().participation_record("", "did:key:test", "[]");
         assert!(result.is_err());
+        let err_str = format!("{}", result.unwrap_err());
+        assert!(
+            err_str.contains(scp_ffi_common::error_codes::VALID_7000),
+            "expected {}, got: {err_str}",
+            scp_ffi_common::error_codes::VALID_7000
+        );
     }
 
     #[test]
     fn participation_record_validates_did() {
+        pyo3::prepare_freethreaded_python();
         let result = default_scp().participation_record("ctx-1", "not-a-did", "[]");
         assert!(result.is_err());
+        let err_str = format!("{}", result.unwrap_err());
+        assert!(
+            err_str.contains(scp_ffi_common::error_codes::VALID_7000),
+            "expected {}, got: {err_str}",
+            scp_ffi_common::error_codes::VALID_7000
+        );
     }
 
     #[test]
     fn participation_record_rejects_invalid_attestations_json() {
+        pyo3::prepare_freethreaded_python();
         let result = default_scp().participation_record("ctx-1", "did:key:test", "not json");
         assert!(result.is_err());
+        let err_str = format!("{}", result.unwrap_err());
+        assert!(
+            err_str.contains(scp_ffi_common::error_codes::VALID_7059),
+            "expected {}, got: {err_str}",
+            scp_ffi_common::error_codes::VALID_7059
+        );
     }
 
     /// The typed `PyParticipationRecord` surfaces every flattened fact from the

--- a/crates/scp-ffi/uniffi/src/bridge.rs
+++ b/crates/scp-ffi/uniffi/src/bridge.rs
@@ -17378,6 +17378,59 @@ mod tests {
         crate::scp::Scp::new_in_memory_for_test()
     }
 
+    /// Extracts the structured code from a `Validation` error, or a
+    /// diagnostic string for any other variant, so cross-bridge parity tests
+    /// can `assert_eq!` on the exact per-case `SCP-VALID-*` code the
+    /// PyO3/NAPI bridges assert for the same logical failure.
+    fn validation_code(err: &ScpError) -> String {
+        match err {
+            ScpError::Validation { code, .. } => code.clone(),
+            other => format!("non-validation error: {other:?}"),
+        }
+    }
+
+    // -- trust helper free functions (ADR-017 Layer 3) --
+
+    #[test]
+    fn trust_query_score_rejects_empty_did_with_code() {
+        let result = trust_query_score(String::new(), "ctx-1".to_owned());
+        assert_eq!(validation_code(&result.unwrap_err()), codes::VALID_7010);
+    }
+
+    #[test]
+    fn trust_query_score_rejects_empty_context_with_code() {
+        let result = trust_query_score("did:key:test".to_owned(), String::new());
+        assert_eq!(validation_code(&result.unwrap_err()), codes::VALID_7011);
+    }
+
+    #[test]
+    fn trust_verify_attestation_rejects_invalid_json_with_code() {
+        let result = trust_verify_attestation("not json".to_owned());
+        assert_eq!(validation_code(&result.unwrap_err()), codes::VALID_7012);
+    }
+
+    #[test]
+    fn trust_create_challenge_rejects_empty_did_with_code() {
+        let result = trust_create_challenge(String::new());
+        assert_eq!(validation_code(&result.unwrap_err()), codes::VALID_7013);
+    }
+
+    #[test]
+    fn trust_verify_response_rejects_invalid_challenge_json_with_code() {
+        // Malformed JSON in the CHALLENGE position.
+        let result = trust_verify_response("bad".to_owned(), "bad".to_owned());
+        assert_eq!(validation_code(&result.unwrap_err()), codes::VALID_7016);
+    }
+
+    #[test]
+    fn trust_verify_response_rejects_invalid_response_json_with_code() {
+        // Malformed JSON in the RESPONSE position: the challenge parses, so
+        // the failure is attributed to the response argument.
+        let challenge = trust_create_challenge("did:key:target".to_owned()).unwrap();
+        let result = trust_verify_response(challenge.challenge_json, "bad".to_owned());
+        assert_eq!(validation_code(&result.unwrap_err()), codes::VALID_7017);
+    }
+
     #[test]
     fn participation_record_rejects_empty_context() {
         let scp = scp_test();
@@ -17401,7 +17454,7 @@ mod tests {
             "did:key:test".to_owned(),
             "not json".to_owned(),
         );
-        assert!(result.is_err());
+        assert_eq!(validation_code(&result.unwrap_err()), codes::VALID_7059);
     }
 
     #[test]
@@ -17418,7 +17471,7 @@ mod tests {
     fn verify_participation_requirements_rejects_empty_subject() {
         let result =
             verify_participation_requirements(String::new(), "[]".to_owned(), "[]".to_owned());
-        assert!(result.is_err());
+        assert_eq!(validation_code(&result.unwrap_err()), codes::VALID_7000);
     }
 
     #[test]
@@ -17430,7 +17483,232 @@ mod tests {
             "[]".to_owned(),
             "[]".to_owned(),
         );
-        assert!(result.is_err());
+        assert_eq!(validation_code(&result.unwrap_err()), codes::VALID_7000);
+    }
+
+    #[test]
+    fn verify_participation_requirements_rejects_invalid_requirements_json() {
+        // Malformed JSON in the REQUIREMENTS position (2nd arg).
+        let result = verify_participation_requirements(
+            "did:key:alice".to_owned(),
+            "not json".to_owned(),
+            "[]".to_owned(),
+        );
+        assert_eq!(validation_code(&result.unwrap_err()), codes::VALID_7031);
+    }
+
+    #[test]
+    fn verify_participation_requirements_rejects_invalid_profile_json() {
+        // Malformed JSON in the PROFILE position (3rd arg).
+        let result = verify_participation_requirements(
+            "did:key:alice".to_owned(),
+            "[]".to_owned(),
+            "not json".to_owned(),
+        );
+        assert_eq!(validation_code(&result.unwrap_err()), codes::VALID_7030);
+    }
+
+    #[test]
+    fn verify_participation_requirements_unmet_requirement_fails_with_admission_code() {
+        // A requirement with no satisfying profiles fails the admission check
+        // itself (not JSON parsing), which carries its own per-case code.
+        let requirements = r#"[{"fact":"ParticipationDuration","threshold":{"AtLeast":1},"max_age_secs":3600,"min_contexts":0}]"#;
+        let result = verify_participation_requirements(
+            "did:key:alice".to_owned(),
+            requirements.to_owned(),
+            "[]".to_owned(),
+        );
+        assert_eq!(validation_code(&result.unwrap_err()), codes::VALID_7032);
+    }
+
+    // -- aggregate_trust_input (§7.3) per-case codes --
+
+    #[allow(clippy::too_many_arguments)]
+    fn aggregate_on_test_scp(
+        context_id: &str,
+        subject_did: &str,
+        events_json: &str,
+        merkle_root_json: &str,
+        consequence_rules_json: &str,
+        threshold_requirements_json: &str,
+        attestor_sets_json: &str,
+        cached_attestations_json: &str,
+        challenge_results_json: &str,
+    ) -> Result<String, ScpError> {
+        scp_test().aggregate_trust_input(
+            context_id.to_owned(),
+            subject_did.to_owned(),
+            events_json.to_owned(),
+            merkle_root_json.to_owned(),
+            consequence_rules_json.to_owned(),
+            threshold_requirements_json.to_owned(),
+            attestor_sets_json.to_owned(),
+            cached_attestations_json.to_owned(),
+            challenge_results_json.to_owned(),
+        )
+    }
+
+    const TEST_MERKLE_ROOT_JSON: &str =
+        "[0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0]";
+
+    #[test]
+    fn aggregate_trust_input_rejects_empty_context_with_code() {
+        let result = aggregate_on_test_scp(
+            "",
+            "did:key:test",
+            "[]",
+            TEST_MERKLE_ROOT_JSON,
+            "[]",
+            "{}",
+            "{}",
+            "[]",
+            "[]",
+        );
+        assert_eq!(validation_code(&result.unwrap_err()), codes::VALID_7040);
+    }
+
+    #[test]
+    fn aggregate_trust_input_rejects_empty_did_with_code() {
+        let result = aggregate_on_test_scp(
+            "ctx-1",
+            "",
+            "[]",
+            TEST_MERKLE_ROOT_JSON,
+            "[]",
+            "{}",
+            "{}",
+            "[]",
+            "[]",
+        );
+        assert_eq!(validation_code(&result.unwrap_err()), codes::VALID_7041);
+    }
+
+    #[test]
+    fn aggregate_trust_input_rejects_invalid_events_json_with_code() {
+        let result = aggregate_on_test_scp(
+            "ctx-1",
+            "did:key:test",
+            "not json",
+            TEST_MERKLE_ROOT_JSON,
+            "[]",
+            "{}",
+            "{}",
+            "[]",
+            "[]",
+        );
+        assert_eq!(validation_code(&result.unwrap_err()), codes::VALID_7042);
+    }
+
+    #[test]
+    fn aggregate_trust_input_rejects_invalid_merkle_root_json_with_code() {
+        let result = aggregate_on_test_scp(
+            "ctx-1",
+            "did:key:test",
+            "[]",
+            "not json",
+            "[]",
+            "{}",
+            "{}",
+            "[]",
+            "[]",
+        );
+        assert_eq!(validation_code(&result.unwrap_err()), codes::VALID_7043);
+    }
+
+    #[test]
+    fn aggregate_trust_input_rejects_wrong_length_merkle_root_with_code() {
+        let result = aggregate_on_test_scp(
+            "ctx-1",
+            "did:key:test",
+            "[]",
+            "[0,0,0]",
+            "[]",
+            "{}",
+            "{}",
+            "[]",
+            "[]",
+        );
+        assert_eq!(validation_code(&result.unwrap_err()), codes::VALID_7044);
+    }
+
+    #[test]
+    fn aggregate_trust_input_rejects_invalid_consequence_rules_json_with_code() {
+        let result = aggregate_on_test_scp(
+            "ctx-1",
+            "did:key:test",
+            "[]",
+            TEST_MERKLE_ROOT_JSON,
+            "not json",
+            "{}",
+            "{}",
+            "[]",
+            "[]",
+        );
+        assert_eq!(validation_code(&result.unwrap_err()), codes::VALID_7045);
+    }
+
+    #[test]
+    fn aggregate_trust_input_rejects_invalid_threshold_requirements_json_with_code() {
+        let result = aggregate_on_test_scp(
+            "ctx-1",
+            "did:key:test",
+            "[]",
+            TEST_MERKLE_ROOT_JSON,
+            "[]",
+            "not json",
+            "{}",
+            "[]",
+            "[]",
+        );
+        assert_eq!(validation_code(&result.unwrap_err()), codes::VALID_7046);
+    }
+
+    #[test]
+    fn aggregate_trust_input_rejects_invalid_attestor_sets_json_with_code() {
+        let result = aggregate_on_test_scp(
+            "ctx-1",
+            "did:key:test",
+            "[]",
+            TEST_MERKLE_ROOT_JSON,
+            "[]",
+            "{}",
+            "not json",
+            "[]",
+            "[]",
+        );
+        assert_eq!(validation_code(&result.unwrap_err()), codes::VALID_7047);
+    }
+
+    #[test]
+    fn aggregate_trust_input_rejects_invalid_cached_attestations_json_with_code() {
+        let result = aggregate_on_test_scp(
+            "ctx-1",
+            "did:key:test",
+            "[]",
+            TEST_MERKLE_ROOT_JSON,
+            "[]",
+            "{}",
+            "{}",
+            "not json",
+            "[]",
+        );
+        assert_eq!(validation_code(&result.unwrap_err()), codes::VALID_7048);
+    }
+
+    #[test]
+    fn aggregate_trust_input_rejects_invalid_challenge_results_json_with_code() {
+        let result = aggregate_on_test_scp(
+            "ctx-1",
+            "did:key:test",
+            "[]",
+            TEST_MERKLE_ROOT_JSON,
+            "[]",
+            "{}",
+            "{}",
+            "[]",
+            "not json",
+        );
+        assert_eq!(validation_code(&result.unwrap_err()), codes::VALID_7049);
     }
 
     // -- check_capability_requirements (§7.3.4.4, SCP-ACR-008) --


### PR DESCRIPTION
Completes the cross-bridge structured-error-code alignment started for `check_capability_requirements` in #2006: every trust op now emits the IDENTICAL per-case `SCP-VALID-70xx` code from all three bridges, so cross-language `.code` branching is reliable.

**Audit + fix (UniFFI = unchanged reference):**
- `verify_participation_requirements`: PyO3 raw exceptions → coded ValidationError 7000/7031/7030/7032; NAPI generic 7010 → per-case.
- `aggregate_trust_input`: all 12 positions aligned (7040/7041/7042–7049/7052) in PyO3 + NAPI (PyO3-only storage-uninit keeps its documented 7005 — no counterpart state in the other bridges).
- `trust_query_score`/`trust_verify_attestation`/`trust_create_challenge`/`trust_verify_response`: 7010–7017 per case.
- Deleted the NAPI `validation_error` helper that collapsed ~16 cases to 7010; all sites now `coded_validation_error(msg, codes::VALID_70xx)`.
- **Tests:** per-case code assertions for every failure case in all 3 bridges (UniFFI gets its first code-level assertions — additive); 2 pre-existing tests strengthened, none weakened; 2 real-FFI Python SDK tests prove the codes surface through `scp_sdk`.
- **Doc contract:** Python SDK docstrings corrected — the ops raise the native coded `ValidationError` (an `ScpError` subclass), not builtin `RuntimeError`/`ValueError` (bug-catcher finding; the docs now match the tests and code).

Reviewed: bug-catcher — one MEDIUM (the docstring contract, fixed in-branch); code-by-code verification of every converted site against the UniFFI reference came back clean, including the counterintuitive-but-consistent 7031/7030 ordering.

Verified: full-feature clippy clean; all bridge suites (415/298/211 + integration); production-config builds; `check-error-codes.sh` (2352); maturin+pytest **652 passed** incl. the wire-fresh napi parity lane; addon-backed bun real-napi 128 pass.

Closes #2007.

🤖 Generated with [Claude Code](https://claude.com/claude-code)