### PR TITLE
fix(registry): resolve VALID_7060-7065 double-booking — restore Discovery block, move Swift trust codes

### DIFF
--- a/bindings/swift/Sources/SCP/Trust.swift
+++ b/bindings/swift/Sources/SCP/Trust.swift
@@ -922,7 +922,7 @@ public extension SCP {
               let json = try JSONSerialization.jsonObject(with: data) as? [String: Any] else {
             throw ScpError.Validation(
                 msg: "failed to parse aggregation result JSON",
-                code: "SCP-VALID-7060"
+                code: "SCP-VALID-7093"
             )
         }
 
@@ -1419,7 +1419,7 @@ private func encodeTrustAdmissionJson(_ value: some Encodable) throws -> String 
     guard let json = String(data: data, encoding: .utf8) else {
         throw ScpError.Validation(
             msg: "failed to encode trust admission input as UTF-8 JSON",
-            code: "SCP-VALID-7061"
+            code: "SCP-VALID-7094"
         )
     }
     return json
@@ -1463,15 +1463,15 @@ public func encodeParticipationProfileJson(_ profiles: [ParticipationProfile]) t
     for profile in profiles {
         try requireByteLength(
             "ParticipationProfile", "eventLogRoot",
-            expected: 32, actual: profile.eventLogRoot, code: "SCP-VALID-7062"
+            expected: 32, actual: profile.eventLogRoot, code: "SCP-VALID-7095"
         )
         try requireByteLength(
             "ParticipationProfile", "signerPublicKey",
-            expected: 32, actual: profile.signerPublicKey, code: "SCP-VALID-7062"
+            expected: 32, actual: profile.signerPublicKey, code: "SCP-VALID-7095"
         )
         try requireByteLength(
             "ParticipationProfile", "signature",
-            expected: 64, actual: profile.signature, code: "SCP-VALID-7062"
+            expected: 64, actual: profile.signature, code: "SCP-VALID-7095"
         )
     }
     return try encodeTrustAdmissionJson(profiles)
@@ -1496,7 +1496,7 @@ public func encodeChallengeVerificationsJson(_ verifications: [ChallengeVerifica
     for verification in verifications {
         try requireByteLength(
             "ChallengeVerification", "verifierSignature",
-            expected: 64, actual: verification.verifierSignature, code: "SCP-VALID-7063"
+            expected: 64, actual: verification.verifierSignature, code: "SCP-VALID-7096"
         )
     }
     return try encodeTrustAdmissionJson(verifications)
@@ -1722,11 +1722,11 @@ public func encodeEventLogEntriesJson(_ events: [EventLogEntry]) throws -> Strin
     for event in events {
         try requireByteLength(
             "EventLogEntry", "prevHash",
-            expected: 32, actual: event.prevHash, code: "SCP-VALID-7064"
+            expected: 32, actual: event.prevHash, code: "SCP-VALID-7097"
         )
         try requireByteLength(
             "EventLogEntry", "signature",
-            expected: 64, actual: event.signature, code: "SCP-VALID-7064"
+            expected: 64, actual: event.signature, code: "SCP-VALID-7097"
         )
     }
     return try encodeTrustAdmissionJson(events)
@@ -1740,7 +1740,7 @@ public func encodeEventLogEntriesJson(_ events: [EventLogEntry]) throws -> Strin
 public func encodeMerkleRootJson(_ merkleRoot: [UInt8]) throws -> String {
     try requireByteLength(
         "AggregatedTrustInput", "merkleRoot",
-        expected: 32, actual: merkleRoot, code: "SCP-VALID-7064"
+        expected: 32, actual: merkleRoot, code: "SCP-VALID-7097"
     )
     return try encodeTrustAdmissionJson(merkleRoot)
 }
@@ -1977,7 +1977,7 @@ public func encodeAttestationJson(_ attestation: CachedAttestationEnvelope) thro
 public func encodeChallengeRequestJson(_ challenge: ChallengeRequest) throws -> String {
     try requireByteLength(
         "ChallengeRequest", "signature",
-        expected: 64, actual: challenge.signature, code: "SCP-VALID-7065"
+        expected: 64, actual: challenge.signature, code: "SCP-VALID-7098"
     )
     return try encodeTrustAdmissionJson(challenge)
 }
@@ -1990,7 +1990,7 @@ public func encodeChallengeRequestJson(_ challenge: ChallengeRequest) throws -> 
 public func encodeChallengeResponseJson(_ response: ChallengeResponse) throws -> String {
     try requireByteLength(
         "ChallengeResponse", "signature",
-        expected: 64, actual: response.signature, code: "SCP-VALID-7065"
+        expected: 64, actual: response.signature, code: "SCP-VALID-7098"
     )
     return try encodeTrustAdmissionJson(response)
 }

--- a/bindings/swift/Tests/SCPTests/TrustAdmissionTests.swift
+++ b/bindings/swift/Tests/SCPTests/TrustAdmissionTests.swift
@@ -266,7 +266,7 @@ final class TrustAdmissionEncoderTests: XCTestCase {
                 msg,
                 "ParticipationProfile.eventLogRoot must be exactly 32 elements, got 3"
             )
-            XCTAssertEqual(code, "SCP-VALID-7062")
+            XCTAssertEqual(code, "SCP-VALID-7095")
         }
     }
 
@@ -295,7 +295,7 @@ final class TrustAdmissionEncoderTests: XCTestCase {
                 msg,
                 "ChallengeVerification.verifierSignature must be exactly 64 elements, got 63"
             )
-            XCTAssertEqual(code, "SCP-VALID-7063")
+            XCTAssertEqual(code, "SCP-VALID-7096")
         }
     }
 

--- a/crates/scp-ffi/common/src/error_codes.rs
+++ b/crates/scp-ffi/common/src/error_codes.rs
@@ -24,6 +24,19 @@
 //! All FFI bridges (`PyO3`, napi-rs, `UniFFI`) import these constants
 //! instead of defining error code strings locally. This eliminates
 //! cross-bridge divergence and makes error code auditing trivial.
+//!
+//! # Uniqueness rule
+//!
+//! Every code number has exactly ONE meaning, defined by exactly ONE
+//! constant in this file, and the doc-comment on that constant is
+//! normative. Never re-label an existing constant's doc-comment to a new
+//! purpose and never emit an existing code for a different purpose from
+//! any layer (bridge or SDK wrapper) — codes already in this registry are
+//! taken even if no Rust code currently emits them (they may be emitted
+//! from SDK wrappers, e.g. Swift). New purposes get NEW numbers from the
+//! next free run in the band. `scripts/check-error-codes.sh` enforces
+//! that no code literal is defined twice in this file; cross-layer
+//! purpose drift must be caught in review against these doc-comments.
 
 // -------------------------------------------------------------------------
 // Identity (SCP-IDENT- 1000--1999)
@@ -811,24 +824,17 @@ pub const VALID_7057: &str = "SCP-VALID-7057";
 pub const VALID_7058: &str = "SCP-VALID-7058";
 /// Participation record validation error (§7.3.2).
 pub const VALID_7059: &str = "SCP-VALID-7059";
-/// Trust aggregation result-parse error (Swift-SDK-emitted: the typed
-/// `aggregateTrustInput` wrapper could not parse the bridge's result JSON).
+/// Discovery validation error.
 pub const VALID_7060: &str = "SCP-VALID-7060";
-/// Trust-admission input encoding error (Swift-SDK-emitted: the shared
-/// trust-admission encoder failed to produce UTF-8 JSON).
+/// Discovery member validation error.
 pub const VALID_7061: &str = "SCP-VALID-7061";
-/// `ParticipationProfile` byte-length validation error (Swift-SDK-emitted:
-/// `eventLogRoot`/`signerPublicKey` must be 32 bytes, `signature` 64 bytes).
+/// Discovery context validation error.
 pub const VALID_7062: &str = "SCP-VALID-7062";
-/// `ChallengeVerification` byte-length validation error (Swift-SDK-emitted:
-/// `verifierSignature` must be 64 bytes).
+/// Discovery register validation error.
 pub const VALID_7063: &str = "SCP-VALID-7063";
-/// Aggregate-trust-input byte-length validation error (Swift-SDK-emitted:
-/// `EventLogEntry.prevHash` and the Merkle root must be 32 bytes,
-/// `EventLogEntry.signature` 64 bytes).
+/// Discovery unregister validation error.
 pub const VALID_7064: &str = "SCP-VALID-7064";
-/// Challenge verify-input byte-length validation error (Swift-SDK-emitted:
-/// `ChallengeRequest`/`ChallengeResponse` `signature` must be 64 bytes).
+/// Discovery query validation error.
 pub const VALID_7065: &str = "SCP-VALID-7065";
 /// Discovery probe validation error.
 pub const VALID_7066: &str = "SCP-VALID-7066";
@@ -857,6 +863,25 @@ pub const VALID_7090: &str = "SCP-VALID-7090";
 pub const VALID_7091: &str = "SCP-VALID-7091";
 /// Discovery result validation error.
 pub const VALID_7092: &str = "SCP-VALID-7092";
+/// Trust aggregation result-parse error (Swift-SDK-emitted: the typed
+/// `aggregateTrustInput` wrapper could not parse the bridge's result JSON).
+pub const VALID_7093: &str = "SCP-VALID-7093";
+/// Trust-admission input encoding error (Swift-SDK-emitted: the shared
+/// trust-admission encoder failed to produce UTF-8 JSON).
+pub const VALID_7094: &str = "SCP-VALID-7094";
+/// `ParticipationProfile` byte-length validation error (Swift-SDK-emitted:
+/// `eventLogRoot`/`signerPublicKey` must be 32 bytes, `signature` 64 bytes).
+pub const VALID_7095: &str = "SCP-VALID-7095";
+/// `ChallengeVerification` byte-length validation error (Swift-SDK-emitted:
+/// `verifierSignature` must be 64 bytes).
+pub const VALID_7096: &str = "SCP-VALID-7096";
+/// Aggregate-trust-input byte-length validation error (Swift-SDK-emitted:
+/// `EventLogEntry.prevHash` and the Merkle root must be 32 bytes,
+/// `EventLogEntry.signature` 64 bytes).
+pub const VALID_7097: &str = "SCP-VALID-7097";
+/// Challenge verify-input byte-length validation error (Swift-SDK-emitted:
+/// `ChallengeRequest`/`ChallengeResponse` `signature` must be 64 bytes).
+pub const VALID_7098: &str = "SCP-VALID-7098";
 /// Handle/petname DID validation error.
 pub const VALID_7110: &str = "SCP-VALID-7110";
 /// Handle/petname alias validation error.

--- a/scripts/check-error-codes.sh
+++ b/scripts/check-error-codes.sh
@@ -5,6 +5,8 @@
 #           number in the allocated range (sdk-common.md).
 # Phase 2: Detects cross-bridge error code collisions — same code number
 #           used for semantically different errors.
+# Phase 3: Registry in-band uniqueness — each code literal is defined by
+#           exactly one constant in error_codes.rs (one number, one purpose).
 #
 # Canonical prefixes and ranges:
 #   SCP-IDENT-   1000-1999    SCP-CTX-     2000-2999
@@ -273,6 +275,31 @@ if [[ $COLLISION_COUNT -gt 0 ]]; then
     echo ""
     echo "Found $COLLISION_COUNT error code collision(s)."
     echo "Each error code number must have a single semantic meaning across all bridges."
+fi
+
+# ---------------------------------------------------------------------------
+# Phase 3: Registry in-band uniqueness.
+#
+# The registry (error_codes.rs) is the single source of truth mapping each
+# code number to one purpose (the constant's doc-comment is normative).
+# Assert that every quoted "SCP-...-NNNN" literal appears exactly once in
+# the registry file — a duplicate means two constants (two purposes) claim
+# the same number.
+# ---------------------------------------------------------------------------
+
+REGISTRY_FILE="crates/scp-ffi/common/src/error_codes.rs"
+if [[ -f "$REGISTRY_FILE" ]]; then
+    REGISTRY_DUPES=$(grep -oE '"SCP-[A-Z]+-[0-9]+"' "$REGISTRY_FILE" | sort | uniq -d || true)
+    if [[ -n "$REGISTRY_DUPES" ]]; then
+        while IFS= read -r dup; do
+            echo "VIOLATION: $REGISTRY_FILE: $dup is defined by more than one registry constant"
+            VIOLATIONS=$((VIOLATIONS + 1))
+        done <<< "$REGISTRY_DUPES"
+        echo "Each code number must map to exactly one registry constant/purpose."
+    fi
+else
+    echo "VIOLATION: registry file $REGISTRY_FILE not found"
+    VIOLATIONS=$((VIOLATIONS + 1))
 fi
 
 if [[ $VIOLATIONS -gt 0 ]]; then


### PR DESCRIPTION
Inquisitor-audit finding (scar-tissue class): the 7060–7066 registry block was deliberately reserved for Discovery (#1627), and **7060/7061/7062 are still emitted with Discovery meaning by production bridges** (`scp-ffi/src/discovery.rs:100/159/321`, uniffi `bridge.rs:7900`). The ADR-058 slices (#2015/#2019) wrongly relabeled the registry doc-comments and had the Swift SDK emit 7060–7065 for trust byte-length/encode errors — one code string, two subsystems, two contradictory documented meanings.

- Restores the original Discovery doc-comments on `VALID_7060–7066` verbatim.
- Adds fresh `VALID_7093–7098` constants for the six Swift-SDK trust purposes (range verified free repo-wide); repoints every `Trust.swift` emit site + test assertion (zero `706x` remain in Swift sources).
- **Prevention:** `check-error-codes.sh` Phase 3 (additive, bounded): registry in-band uniqueness — every code literal must be defined by exactly one registry constant, so a future double-book fails CI instead of passing range-checks.

Verified: check-error-codes PASS (2363), Phase-3 self-consistent; fmt + clippy (ffi-common/ffi/uniffi) clean; Swift XCFramework rebuilt, `swift test` 0 failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
