### PR TITLE
fix(trust): attestation claim canonicalization to RFC-8785 JCS per §9.5.2 + I-JSON numeric bound + KAT Vector 34

### DIFF
--- a/.docs/specs/09-security-model.md
+++ b/.docs/specs/09-security-model.md
@@ -434,13 +434,13 @@ Note: `context_id` is not in the current signed hash (the request struct does no
 | 2 | `attestation_type` | 2-byte BE u16 (attestation type tag per `attestation_type_tag()`) |
 | 3 | `issuer` | 4-byte BE length + UTF-8 bytes (DID) |
 | 4 | `subject` | 4-byte BE length + UTF-8 bytes (DID) |
-| 5 | `claim` | 4-byte BE length + UTF-8 bytes (compact JSON — see note) |
+| 5 | `claim` | 4-byte BE length + UTF-8 bytes (RFC 8785 canonical JSON — see note) |
 | 6 | `evidence` | 4-byte BE length + raw bytes if present, or `SHA-256(0x00)` sentinel if absent |
 | 7 | `issued_at` | 8-byte BE u64 |
 | 8 | `expires_at` | 8-byte BE u64 if present, or `SHA-256(0x00)` sentinel if absent |
 | 9 | `revocation_status` | 4-byte BE length + MessagePack bytes of `RevocationStatus` enum |
 
-Note: the `claim` field uses compact JSON with no whitespace (equivalent to Python `json.dumps(separators=(',', ':'))`). JSON key ordering within claim objects is NOT guaranteed deterministic across implementations — claims with nested objects should use only flat key-value structures or pre-serialized byte strings. The `evidence` field, when present, is serialized as MessagePack bytes of the `AttestationEvidence` struct. The `revocation_status` field is always present (never absent) — `Active` serializes as a distinct MessagePack value from `Revoked{...}`. Including `revocation_status` in the signed scope prevents an intermediary from flipping Active↔Revoked without invalidating the signature (§7.4.1).
+Note: the `claim` field is serialized as **canonical JSON per RFC 8785 (JCS)** — compact form with no insignificant whitespace and object keys sorted deterministically. The serialization is byte-identical across all conforming implementations, including for nested objects; this is the same formal canonicalization standard cited for `GovernanceProposal` `action_bytes` below. **Numeric constraint (I-JSON, RFC 7493):** numeric values within `claim` MUST be within the IEEE-754 double-precision exactly-representable integer range (|n| ≤ 2^53); larger identifiers (e.g. 64-bit snowflake IDs) MUST be string-encoded. Rationale: RFC 8785 serializes numbers as ES6 doubles, so integer values beyond 2^53 are not injective — distinct values within one rounding class canonicalize to identical bytes, and a signature over one such claim validly covers every other claim in that class. The `evidence` field, when present, is serialized as MessagePack bytes of the `AttestationEvidence` struct. The `revocation_status` field is always present (never absent) — `Active` serializes as a distinct MessagePack value from `Revoked{...}`. Including `revocation_status` in the signed scope prevents an intermediary from flipping Active↔Revoked without invalidating the signature (§7.4.1).
 
 **ParticipationProfile** — domain: `"SCP-PARTICIPATION-PROFILE-V1:"`
 

--- a/.docs/specs/25-test-vectors.md
+++ b/.docs/specs/25-test-vectors.md
@@ -707,11 +707,11 @@ To verify an implementation against these test vectors:
 The Rust reference implementation can generate exact expected outputs for all vectors. Run the test vector generation tool:
 
 ```bash
-cargo test -p scp-core --test test_vectors -- --nocapture
+cargo test -p scp-runtime --test test_vectors -- --nocapture
 cargo test -p scp-event-log --test test_vectors -- --nocapture
 ```
 
-The test vector generation test is defined in `crates/scp-core/tests/test_vectors.rs` and `crates/scp-event-log/tests/test_vectors.rs`. These tests print hex-encoded intermediate and final values for each vector defined above.
+The test vector generation test is defined in `crates/scp-runtime/tests/test_vectors.rs` and `crates/scp-event-log/tests/test_vectors.rs`. These tests print hex-encoded intermediate and final values for each vector defined above.
 
 Independent implementations SHOULD run these tests against the Rust implementation to obtain the expected outputs, then embed those outputs in their own test suites.
 
@@ -777,3 +777,49 @@ Expected v2 pseudonym public key (epoch = 1):
 ```
 
 These vectors are mechanically enforced by the Rust known-answer test `derive_pseudonym_keypair_known_answer_vectors` in `crates/scp-platform/src/pseudonym.rs`.
+
+## 25.20 Trust Attestation Signing Vectors (§7.4.1, §9.5.2)
+
+Domain: `"SCP-ATTESTATION-V1:"`
+
+### Vector 34: Trust Attestation Signature
+
+The signing payload for the common attestation envelope (`trust::Attestation`, §7.4.1) uses the canonical hash construction from §9.5.1 with domain separator `"SCP-ATTESTATION-V1:"` and the §9.5.2 Attestation field order. The `claim` field is serialized as RFC 8785 (JCS) canonical JSON — sorted keys, no whitespace — so a claim constructed with any key insertion order yields identical bytes. Per the §9.5.2 I-JSON constraint, claim numeric values MUST be within |n| ≤ 2^53 (this vector's claim uses `42`). `evidence` and `revocation_status` are serialized as MessagePack (`rmp_serde::to_vec_named`). The renewal fields (`renewal_interval`, `renewed_at`) are excluded from the signed preimage (§9.5.2) and do not appear below.
+
+Note: this is the *signature* construction for the generic trust attestation envelope. It is distinct from the IdentityLinkAttestation signature (§25.13, domain `"SCP-IDENTITY-LINK-ATTESTATION-V1:"`, MessagePack claim) and from the attestation *ID* computation (§25.16, domain `"SCP-ATTESTATION-ID-V1:"`).
+
+```
+Input:
+  id:                "att-trust-001"
+  attestation_type:  Endorsement  (type tag 4 per attestation_type_tag())
+  issuer:            "did:dht:z6MkIssuer"
+  subject:           "did:dht:z6MkSubject"
+  claim:             {"level": "gold", "score": 42}
+                       JCS: {"level":"gold","score":42}  (27 bytes)
+  evidence:          absent (use absent sentinel)
+  issued_at:         1700000000
+  expires_at:        absent (no expiry — use absent sentinel)
+  revocation_status: RevocationStatus::Active
+                       msgpack: 0xa6 "Active"  (7 bytes)
+
+Canonical hash input:
+  "SCP-ATTESTATION-V1:"                          (19 bytes, no length prefix)
+  || BE32(13) || "att-trust-001"                  (4 + 13 = 17 bytes — id)
+  || BE16(4)                                      (2 bytes — attestation_type tag)
+  || BE32(18) || "did:dht:z6MkIssuer"            (4 + 18 = 22 bytes — issuer)
+  || BE32(19) || "did:dht:z6MkSubject"           (4 + 19 = 23 bytes — subject)
+  || BE32(27) || {"level":"gold","score":42}      (4 + 27 = 31 bytes — claim as JCS)
+  || SHA-256(0x00)                                 (32 bytes, raw — no length prefix — absent evidence sentinel)
+  || BE64(1700000000)                              (8 bytes — issued_at)
+  || SHA-256(0x00)                                 (32 bytes, raw — no length prefix — absent expires_at sentinel)
+  || BE32(7)  || msgpack(Active)                  (4 + 7 = 11 bytes — revocation_status as MessagePack)
+
+Total: 19 + 17 + 2 + 22 + 23 + 31 + 32 + 8 + 32 + 11 = 197 bytes
+
+Expected SHA-256 (= canonical_attestation_bytes output):
+  0x6d07c76821a2ae4dd830ca117aa9fd8e30232cca72459a4d129432f56d87a08c
+```
+
+The Ed25519 signature is computed over the 32-byte canonical hash. Sign with the reference key (§25.2) and verify per §25.17 step 5; Ed25519 is deterministic, so the reference implementation reproduces the same signature bytes on every run.
+
+This vector is mechanically enforced by `vector_34_trust_attestation_signature` in `crates/scp-runtime/tests/test_vectors.rs`, which pins the expected hash, reconstructs the preimage byte-for-byte, and verifies the signed attestation through the production `verify_attestation` path.

--- a/crates/scp-protocol/src/jcs.rs
+++ b/crates/scp-protocol/src/jcs.rs
@@ -5,17 +5,19 @@
 //! (`context::tools`), and the other structured-hash paths that call
 //! [`to_vec`] / [`to_string`] here.
 //!
-//! # Scope — one deliberate exception: attestation canonicalization
+//! # Scope
 //!
-//! JCS is **not** universal. `trust::attestation::canonical_attestation_bytes`
-//! (and `IdentityLinkAttestation::canonical_signing_bytes`) intentionally
-//! serialize their `claim` / `evidence` / `revocation_status` fields with
-//! `rmp_serde::to_vec_named` (`MessagePack`, named/sorted keys) instead of JCS.
-//! That choice is fixed by construction: it defines the on-the-wire attestation
-//! signature hash, so it cannot be migrated to JCS without changing the wire
-//! format. The scheme-per-path decision is documented in one place — on
-//! `canonical_attestation_bytes` — which is the authority for attestation
-//! canonicalization; this module governs the JCS paths.
+//! JCS is **not** universal — each signed structure's spec row assigns a
+//! serialization per field. `trust::attestation::canonical_attestation_bytes`
+//! uses JCS for the `claim` field (§9.5.2 Attestation row 5: compact JSON)
+//! and `rmp_serde::to_vec_named` (`MessagePack`, named keys) for `evidence`
+//! and `revocation_status`, which the §9.5.2 note explicitly sanctions for
+//! those two fields. `IdentityLinkAttestation::canonical_signing_bytes` is
+//! governed by a separate spec row (§3 identity, domain
+//! `SCP-IDENTITY-LINK-ATTESTATION-V1:`) that mandates `MessagePack` for its
+//! `claim`, `evidence`, and `revocation_status` sub-structures. The
+//! scheme-per-field decisions are documented on those functions; this module
+//! governs the JCS paths.
 
 /// Serializes a value to canonical JSON bytes per RFC 8785.
 ///

--- a/crates/scp-protocol/src/trust/attestation.rs
+++ b/crates/scp-protocol/src/trust/attestation.rs
@@ -59,6 +59,16 @@ pub struct Attestation {
     /// DID of the attestation subject.
     pub subject: DID,
     /// Type-specific claim data.
+    ///
+    /// Serialized into the signed preimage as RFC 8785 (JCS) canonical JSON
+    /// (§9.5.2). **I-JSON numeric constraint (RFC 7493):** numeric values in
+    /// the claim MUST be within the IEEE-754 double exactly-representable
+    /// integer range (|n| ≤ 2^53); larger identifiers (e.g. 64-bit snowflake
+    /// IDs, u64 counters) MUST be string-encoded by the caller. RFC 8785
+    /// serializes numbers as ES6 doubles, so integers beyond 2^53 are not
+    /// injective: distinct values in the same rounding class canonicalize to
+    /// identical bytes, and a signature over one such claim validly covers
+    /// every other claim in that class.
     pub claim: serde_json::Value,
     /// Optional evidence supporting the attestation.
     pub evidence: Option<AttestationEvidence>,
@@ -1152,6 +1162,18 @@ pub fn check_threshold_attestation(
 /// different spec row (§3 identity, domain
 /// `SCP-IDENTITY-LINK-ATTESTATION-V1:`) which mandates `MessagePack` for its
 /// `claim` as well — its scheme is independent of this function.
+///
+/// # I-JSON numeric constraint on `claim` (RFC 7493, per §9.5.2)
+///
+/// RFC 8785 serializes JSON numbers as ES6 IEEE-754 doubles, so claim
+/// integers outside |n| ≤ 2^53 are **not injective**: distinct values in the
+/// same f64 rounding class (e.g. `9007199254740993` and `9007199254740992`)
+/// canonicalize to identical bytes, producing identical preimages — a
+/// signature over one validly covers the other, and the substitution is
+/// undetectable. Callers MUST keep claim numeric values within |n| ≤ 2^53 and
+/// string-encode larger identifiers (snowflake IDs, u64 counters). This
+/// function does not reject out-of-range integers — the coercion is inherent
+/// to RFC 8785 and is pinned by test.
 ///
 /// # Errors
 ///
@@ -2312,6 +2334,65 @@ mod tests {
         assert_eq!(
             canonical, canonical_reordered,
             "claim key order must not change the canonical bytes (JCS sorts keys)"
+        );
+    }
+
+    /// Pins the documented RFC 8785 f64 rounding class for claim integers
+    /// beyond 2^53 (§9.5.2 I-JSON constraint, RFC 7493).
+    ///
+    /// RFC 8785 serializes JSON numbers as ES6 IEEE-754 doubles, so distinct
+    /// claim integers in the same f64 rounding class canonicalize to
+    /// IDENTICAL bytes — a signature over one validly covers the other. This
+    /// is inherent to RFC 8785 (not a defect in this implementation, and not
+    /// something to "fix" here): it is why §9.5.2 requires claim numeric
+    /// values to stay within |n| ≤ 2^53 and large identifiers (snowflake IDs,
+    /// u64 counters) to be string-encoded. The test makes the hazard visible
+    /// and pins the current behavior; the string-encoded forms of the same
+    /// values remain distinct.
+    #[test]
+    fn canonical_attestation_claim_integers_beyond_2_53_collide_per_rfc8785() {
+        let make = |claim: serde_json::Value| Attestation {
+            id: "att-claim-numeric".to_owned(),
+            attestation_type: AttestationType::Endorsement,
+            issuer: "did:key:issuer".into(),
+            subject: "did:key:subj".into(),
+            claim,
+            evidence: None,
+            issued_at: 1000,
+            expires_at: None,
+            renewal_interval: None,
+            renewed_at: None,
+            revocation_status: RevocationStatus::Active,
+            signature: vec![],
+        };
+
+        // 2^53 = 9007199254740992 is exactly representable as an f64;
+        // 2^53 + 1 = 9007199254740993 is NOT, and rounds to 2^53 under
+        // RFC 8785 / ES6 number serialization.
+        let att_exact = make(serde_json::json!({"id": 9_007_199_254_740_992_u64}));
+        let att_plus_one = make(serde_json::json!({"id": 9_007_199_254_740_993_u64}));
+
+        let canonical_exact = canonical_attestation_bytes(&att_exact).unwrap();
+        let canonical_plus_one = canonical_attestation_bytes(&att_plus_one).unwrap();
+
+        // Documented rounding-class collision: distinct claims differing only
+        // beyond f64 precision produce IDENTICAL canonical bytes, so one
+        // signature covers both. This is why §9.5.2 mandates string-encoding
+        // for identifiers beyond 2^53.
+        assert_eq!(
+            canonical_exact, canonical_plus_one,
+            "claim integers in the same f64 rounding class must canonicalize \
+             identically per RFC 8785 (documented §9.5.2 hazard)"
+        );
+
+        // The mandated mitigation preserves injectivity: string-encoded forms
+        // of the same two values yield distinct canonical bytes.
+        let att_exact_str = make(serde_json::json!({"id": "9007199254740992"}));
+        let att_plus_one_str = make(serde_json::json!({"id": "9007199254740993"}));
+        assert_ne!(
+            canonical_attestation_bytes(&att_exact_str).unwrap(),
+            canonical_attestation_bytes(&att_plus_one_str).unwrap(),
+            "string-encoded identifiers must remain distinct in the preimage"
         );
     }
 

--- a/crates/scp-protocol/src/trust/attestation.rs
+++ b/crates/scp-protocol/src/trust/attestation.rs
@@ -1132,16 +1132,26 @@ pub fn check_threshold_attestation(
 /// authenticity or freshness *security* decision. Only the fields listed above
 /// are authenticated.
 ///
-/// # Canonicalization scheme — `MessagePack` (not JCS)
+/// # Canonicalization scheme — per §9.5.2
 ///
-/// `claim`, `evidence`, and `revocation_status` are serialized with
-/// `rmp_serde::to_vec_named` (`MessagePack`, named/sorted keys) — **not** RFC
-/// 8785 JCS. This is intentional and matches
-/// `IdentityLinkAttestation::canonical_signing_bytes`. Attestation
-/// canonicalization is the one trust path that uses `MessagePack`; challenge
-/// preimages and other structured hashing use JCS (see the module doc on
-/// `crate::jcs`). Changing the scheme here would change the on-the-wire
-/// attestation hash, so it is fixed by construction.
+/// The §9.5.2 Attestation table assigns a serialization per field:
+///
+/// - `claim` — **compact JSON** (no whitespace, equivalent to Python
+///   `json.dumps(separators=(',', ':'))`), produced via [`crate::jcs::to_vec`]
+///   (RFC 8785 JCS). JCS emits exactly that compact form and additionally
+///   sorts object keys, which makes the preimage deterministic across
+///   implementations. This matches how the same §9.5.2 "compact JSON" phrase
+///   is implemented for `GovernanceProposal` `action_bytes`
+///   (`compute_proposal_id`) and `SignedVote` `vote_type`
+///   (`compute_vote_hash`).
+/// - `evidence` and `revocation_status` — `rmp_serde::to_vec_named`
+///   (`MessagePack`, named keys), as the §9.5.2 note explicitly sanctions for
+///   these two fields.
+///
+/// Note: `IdentityLinkAttestation::canonical_signing_bytes` is governed by a
+/// different spec row (§3 identity, domain
+/// `SCP-IDENTITY-LINK-ATTESTATION-V1:`) which mandates `MessagePack` for its
+/// `claim` as well — its scheme is independent of this function.
 ///
 /// # Errors
 ///
@@ -1173,12 +1183,13 @@ pub fn canonical_attestation_bytes(attestation: &Attestation) -> Result<Vec<u8>,
     // Field order per §9.5.2: id, attestation_type, issuer, subject, claim,
     // evidence, issued_at, expires_at, revocation_status.
     //
-    // Serialize claim as MessagePack (named/sorted keys) for deterministic
-    // ordering. Using `serde_json::Value::to_string()` would produce JSON
-    // with non-deterministic key ordering. This matches
-    // `IdentityLinkAttestation::canonical_signing_bytes` which also uses
-    // `rmp_serde::to_vec_named`.
-    let claim_bytes = rmp_serde::to_vec_named(&attestation.claim).map_err(|err| {
+    // Serialize claim as compact JSON per the §9.5.2 Attestation table
+    // (row 5: "compact JSON", equivalent to Python
+    // `json.dumps(separators=(',', ':'))`). RFC 8785 JCS produces exactly
+    // that compact form with deterministic (sorted) key ordering — the same
+    // implementation of the same spec phrase as `compute_proposal_id`
+    // (`action_bytes`) and `compute_vote_hash` (`vote_type`).
+    let claim_bytes = crate::jcs::to_vec(&attestation.claim).map_err(|err| {
         TrustError::CanonicalizationFailed {
             reason: format!("claim serialization failed: {err}"),
         }
@@ -2214,6 +2225,93 @@ mod tests {
         assert_ne!(
             bytes_a, bytes_b,
             "shifting bytes between id and issuer must produce different canonical bytes"
+        );
+    }
+
+    // -------------------------------------------------------------------
+    // §9.5.2 claim serialization scheme: compact JSON (RFC 8785 JCS)
+    // -------------------------------------------------------------------
+
+    /// Pins the §9.5.2 Attestation row-5 scheme: the signed preimage embeds
+    /// the `claim` as length-prefixed **compact JSON** (no whitespace, sorted
+    /// keys per RFC 8785 JCS) — not `MessagePack`.
+    #[test]
+    fn canonical_attestation_claim_is_length_prefixed_compact_json() {
+        use crate::crypto::canonical::{CanonicalField, canonical_hash_bytes};
+        use sha2::{Digest, Sha256};
+
+        let make = |claim: serde_json::Value| Attestation {
+            id: "att-claim-scheme".to_owned(),
+            attestation_type: AttestationType::Endorsement,
+            issuer: "did:key:issuer".into(),
+            subject: "did:key:subj".into(),
+            claim,
+            evidence: None,
+            issued_at: 1000,
+            expires_at: None,
+            renewal_interval: None,
+            renewed_at: None,
+            revocation_status: RevocationStatus::Active,
+            signature: vec![],
+        };
+
+        let att = make(serde_json::json!({"z": 2, "a": 1}));
+        let canonical = canonical_attestation_bytes(&att).unwrap();
+
+        // Expected claim bytes: compact JSON, keys sorted by Unicode code
+        // point (RFC 8785). Equivalent to Python
+        // json.dumps(separators=(',', ':')) for pre-sorted keys.
+        let claim_json: &[u8] = br#"{"a":1,"z":2}"#;
+
+        // Reconstruct the full §9.5.2 preimage with the compact-JSON claim
+        // embedded as a length-prefixed field, and assert the production
+        // digest commits to exactly these bytes.
+        let revocation_bytes = rmp_serde::to_vec_named(&att.revocation_status).unwrap();
+        let preimage = canonical_hash_bytes(
+            b"SCP-ATTESTATION-V1:",
+            &[
+                CanonicalField::VarBytes(att.id.as_bytes()),
+                CanonicalField::U16(super::super::attestation_type_tag(&att.attestation_type)),
+                CanonicalField::VarBytes(att.issuer.as_bytes()),
+                CanonicalField::VarBytes(att.subject.as_bytes()),
+                CanonicalField::VarBytes(claim_json),
+                CanonicalField::Absent,
+                CanonicalField::U64(att.issued_at),
+                CanonicalField::Absent,
+                CanonicalField::VarBytes(&revocation_bytes),
+            ],
+        )
+        .unwrap();
+
+        // The preimage embeds the length-prefixed compact-JSON claim bytes.
+        let mut expected_claim_field = Vec::new();
+        #[allow(clippy::cast_possible_truncation)]
+        expected_claim_field.extend_from_slice(&(claim_json.len() as u32).to_be_bytes());
+        expected_claim_field.extend_from_slice(claim_json);
+        assert!(
+            preimage
+                .windows(expected_claim_field.len())
+                .any(|window| window == expected_claim_field.as_slice()),
+            "preimage must embed the length-prefixed compact-JSON claim {:?}",
+            String::from_utf8_lossy(claim_json)
+        );
+
+        let expected_digest: [u8; 32] = Sha256::digest(&preimage).into();
+        assert_eq!(
+            canonical,
+            expected_digest.to_vec(),
+            "canonical_attestation_bytes must be the SHA-256 of the §9.5.2 \
+             preimage with the claim as compact JSON"
+        );
+
+        // Key-insertion order must not affect the preimage: JCS sorts object
+        // keys, so a semantically identical claim constructed in a different
+        // order yields byte-identical canonical bytes.
+        let att_reordered = make(serde_json::json!({"a": 1, "z": 2}));
+        let canonical_reordered = canonical_attestation_bytes(&att_reordered).unwrap();
+        assert_eq!(
+            canonical, canonical_reordered,
+            "claim key order must not change the canonical bytes (JCS sorts keys)"
         );
     }
 

--- a/crates/scp-runtime/tests/phase5_integration.rs
+++ b/crates/scp-runtime/tests/phase5_integration.rs
@@ -150,8 +150,10 @@ fn compute_attestation_canonical_bytes(attestation: &Attestation) -> Vec<u8> {
     let evidence_bytes = attestation.evidence.as_ref().map(|e| {
         rmp_serde::to_vec_named(e).expect("AttestationEvidence serialization is infallible")
     });
+    // Claim is compact JSON (RFC 8785 JCS) per §9.5.2 Attestation row 5;
+    // evidence/revocation_status stay MessagePack per the §9.5.2 note.
     let claim_bytes =
-        rmp_serde::to_vec_named(&attestation.claim).expect("claim serialization is infallible");
+        scp_protocol::jcs::to_vec(&attestation.claim).expect("claim serialization is infallible");
     let revocation_bytes = rmp_serde::to_vec_named(&attestation.revocation_status)
         .expect("RevocationStatus serialization is infallible");
 

--- a/crates/scp-runtime/tests/test_vectors.rs
+++ b/crates/scp-runtime/tests/test_vectors.rs
@@ -6,7 +6,7 @@
 //!
 //! Run with `--nocapture` to see hex-encoded intermediate and final values:
 //! ```bash
-//! cargo test -p scp-core --test test_vectors -- --nocapture
+//! cargo test -p scp-runtime --test test_vectors -- --nocapture
 //! ```
 
 #![allow(
@@ -1172,6 +1172,103 @@ fn vector_29_attestation_id() {
         attestation_id,
         "compute_id must match manual construction"
     );
+}
+
+// ---------------------------------------------------------------------------
+// §25.20 Trust Attestation Signing Vectors
+// ---------------------------------------------------------------------------
+
+#[test]
+fn vector_34_trust_attestation_signature() {
+    use scp_clock::TestClock;
+    use scp_protocol::trust::attestation::{
+        Attestation, DidPublicKeyResolver, RevocationStatus, canonical_attestation_bytes,
+        verify_attestation,
+    };
+    use scp_protocol::trust::{AttestationType, TrustError, attestation_type_tag};
+
+    /// Resolver returning the §25.2 reference public key for any DID.
+    struct RefResolver;
+    impl DidPublicKeyResolver for RefResolver {
+        fn resolve_public_key(&self, _did: &str) -> Result<Vec<u8>, TrustError> {
+            Ok(REF_PUBKEY.to_vec())
+        }
+    }
+
+    println!("=== Vector 34: Trust Attestation Signature ===");
+
+    // Construct the attestation per §25.20 spec inputs. The claim is built
+    // with keys in NON-sorted insertion order on purpose: RFC 8785 (JCS)
+    // sorts object keys, so insertion order must not affect the preimage.
+    let attestation = Attestation {
+        id: "att-trust-001".to_owned(),
+        attestation_type: AttestationType::Endorsement,
+        issuer: "did:dht:z6MkIssuer".into(),
+        subject: "did:dht:z6MkSubject".into(),
+        claim: serde_json::json!({"score": 42, "level": "gold"}),
+        evidence: None,
+        issued_at: 1_700_000_000,
+        expires_at: None,
+        renewal_interval: None,
+        renewed_at: None,
+        revocation_status: RevocationStatus::Active,
+        signature: Vec::new(),
+    };
+
+    // Production canonical bytes: the 32-byte SHA-256 of the §9.5.2 preimage.
+    let canonical = canonical_attestation_bytes(&attestation).unwrap();
+    print_vec("Trust attestation canonical hash", &canonical);
+
+    // §25.20 Vector 34: assert exact spec hex value.
+    assert_eq!(
+        hex(&canonical),
+        "6d07c76821a2ae4dd830ca117aa9fd8e30232cca72459a4d129432f56d87a08c",
+        "trust attestation canonical hash must match §25.20 Vector 34"
+    );
+
+    // Manual preimage reconstruction per §25.20 (mirrors the §9.5.2
+    // Attestation row order) to confirm the implementation's construction.
+    let claim_jcs: &[u8] = br#"{"level":"gold","score":42}"#; // RFC 8785: sorted keys
+    let revocation_bytes = rmp_serde::to_vec_named(&attestation.revocation_status).unwrap();
+    let mut buf = Vec::new();
+    buf.extend_from_slice(b"SCP-ATTESTATION-V1:");
+    buf.extend_from_slice(&(attestation.id.len() as u32).to_be_bytes());
+    buf.extend_from_slice(attestation.id.as_bytes());
+    // attestation_type: 2-byte BE u16 tag (Endorsement = 4).
+    assert_eq!(attestation_type_tag(&attestation.attestation_type), 4);
+    buf.extend_from_slice(&attestation_type_tag(&attestation.attestation_type).to_be_bytes());
+    buf.extend_from_slice(&(attestation.issuer.len() as u32).to_be_bytes());
+    buf.extend_from_slice(attestation.issuer.as_bytes());
+    buf.extend_from_slice(&(attestation.subject.len() as u32).to_be_bytes());
+    buf.extend_from_slice(attestation.subject.as_bytes());
+    buf.extend_from_slice(&(claim_jcs.len() as u32).to_be_bytes());
+    buf.extend_from_slice(claim_jcs);
+    buf.extend_from_slice(&ABSENT_SENTINEL); // absent evidence
+    buf.extend_from_slice(&attestation.issued_at.to_be_bytes());
+    buf.extend_from_slice(&ABSENT_SENTINEL); // absent expires_at
+    buf.extend_from_slice(&(revocation_bytes.len() as u32).to_be_bytes());
+    buf.extend_from_slice(&revocation_bytes);
+
+    println!("  Preimage length: {} bytes", buf.len());
+    assert_eq!(buf.len(), 197, "preimage must be 197 bytes per §25.20");
+
+    let manual_hash: [u8; 32] = Sha256::digest(&buf).into();
+    assert_eq!(
+        manual_hash.to_vec(),
+        canonical,
+        "canonical_attestation_bytes must match the manual §25.20 preimage construction"
+    );
+
+    // Sign the canonical hash with the §25.2 reference key and verify via the
+    // production verification path (per §25.17 step 5).
+    let signing_key = ed25519_dalek::SigningKey::from_bytes(&REF_SEED);
+    let mut signed = attestation;
+    signed.signature = signing_key.sign(&canonical).to_bytes().to_vec();
+    print_vec("Trust attestation signature", &signed.signature);
+
+    let clock = TestClock::new(1_700_000_001);
+    verify_attestation(&signed, &RefResolver, &clock)
+        .expect("trust attestation Vector 34 signature must verify");
 }
 
 // ---------------------------------------------------------------------------

--- a/crates/scp-testing/tests/integration/conformance.rs
+++ b/crates/scp-testing/tests/integration/conformance.rs
@@ -223,7 +223,8 @@ fn conf_004_agent_binding_attestation() {
     let agent_did = format!("did:key:{}", hex(&agent_key.verifying_key().to_bytes()));
 
     let claim = serde_json::json!({"platform": "agent-binding"});
-    let claim_bytes = rmp_serde::to_vec_named(&claim).expect("claim msgpack serialization");
+    // Claim is compact JSON (RFC 8785 JCS) per §9.5.2 Attestation row 5.
+    let claim_bytes = scp_core::jcs::to_vec(&claim).expect("claim compact-JSON serialization");
 
     print_step(1, "Create identity attestation binding agent to human");
     // RevocationStatus::Active serialized as MessagePack (named keys).

--- a/crates/scp-testing/tests/integration/trust.rs
+++ b/crates/scp-testing/tests/integration/trust.rs
@@ -181,7 +181,9 @@ fn make_signed_attestation(
     use scp_core::crypto::canonical::{CanonicalField, canonical_hash};
     use scp_core::trust::attestation_type_tag;
 
-    let claim_bytes = rmp_serde::to_vec_named(&att.claim).unwrap();
+    // Claim is compact JSON (RFC 8785 JCS) per §9.5.2 Attestation row 5;
+    // evidence/revocation_status stay MessagePack per the §9.5.2 note.
+    let claim_bytes = scp_core::jcs::to_vec(&att.claim).unwrap();
     let evidence_bytes = att
         .evidence
         .as_ref()


### PR DESCRIPTION
Inquisitor-audit finding (scar-tissue class): `canonical_attestation_bytes` serialized the `claim` field with MessagePack, diverging from §9.5.2 (row 5 mandates compact JSON; §9.5 explicitly rejects MessagePack for canonical hashing) — and a recent doc-comment had laundered the divergence as 'intentional' by citing `IdentityLinkAttestation`, which is actually governed by its own §03 spec row (where MessagePack IS sanctioned, pinned by Vector 26 — untouched).

**Code (spec governs → code fixed):**
- `claim` → `crate::jcs::to_vec` (RFC 8785 JCS), matching the governance siblings (`compute_proposal_id`/`compute_vote_hash`) that implement the identical spec phrase; `evidence`/`revocation_status` stay MessagePack (spec-sanctioned). Errors thread the existing CanonicalizationFailed pattern. All 5 ripple sites (test-helper preimage mirrors) updated; domain stays `SCP-ATTESTATION-V1` per repo precedent (governance kept its domains through the same migration).
- Honest doc rewrite in `jcs.rs` + `attestation.rs` (per-field scheme, IdentityLink distinction).

**Cryptographer review: construction SOUND**; its two MEDIUMs (spec-side) + one LOW fixed in-branch:
- **§9.5.2 row-5 rewritten**: names RFC 8785 JCS (mirroring the governance row); removes the stale `json.dumps` equivalence + false non-determinism disclaimer that would have led third-party implementers to byte-divergent preimages.
- **I-JSON (RFC 7493) numeric bound**: claim integers MUST be |n| ≤ 2^53, larger IDs string-encoded — RFC 8785 serializes numbers as ES6 doubles, so values beyond 2^53 are not injective (distinct claims in one rounding class share canonical bytes → one signature covers both). Constraint + consequence documented in spec and `Attestation::claim`/`canonical_attestation_bytes` docs; the rounding-class behavior is empirically PINNED by test (9007199254740993 vs …992 collide; string-encoded forms stay distinct). Note: this hazard is protocol-inherent to the spec's JSON choice — the old MessagePack masked it locally while carrying its own cross-implementation divergence.
- **KAT Vector 34** (§25.20): first byte-exact conformance fixture for `trust::Attestation` (197-byte preimage, digest `6d07c768…`, derived by running production code — never invented hex); implemented in `test_vectors.rs` with full preimage reconstruction + verify round-trip. Also corrected §25.18's nonexistent `scp-core --test test_vectors` reference → `scp-runtime`.

Pre-release: no deployed signatures, no migration code (repo policy). Event-log KATs byte-unaffected (212+10 pass).

Verified: scp-protocol 3078 pass; test_vectors 35 pass; full-feature workspace clippy clean; all bridge suites pass; check-error-codes PASS; validate-prd 370.

🤖 Generated with [Claude Code](https://claude.com/claude-code)