### PR TITLE
fix(provenance): unify FFI event-log provenance hash to rmp_serde + remove phantom RFC-8785 docs (§5.14.5/§24 + KAT V35)

### DIFF
--- a/.docs/specs/05-contexts.md
+++ b/.docs/specs/05-contexts.md
@@ -1523,7 +1523,7 @@ Ed25519_sign(active_signing_key_or_agent_signing_key, SHA-256(
 ```
 
 Where:
-- `provenance_hash = SHA256(serialize(provenance))` if present, or `SHA256(0x00)` if absent (same sentinel as InnerEnvelope, ADR-002).
+- `provenance_hash = SHA-256(serialize(provenance))` if present, or `SHA-256(0x00)` if absent (same sentinel as InnerEnvelope, ADR-002). `serialize` is the canonical provenance encoding defined in §24.3.3: positional MessagePack (`rmp_serde::to_vec`) over the `DataProvenance` struct in declaration field order. This is the same encoding used for the event-log provenance-hash leaves, so the value is identical whether computed on the signed broadcast path or the event-log path.
 - Variable-length fields (`context_id`, `author_did`) are 4-byte big-endian length-prefixed.
 - `version` is 2 bytes big-endian.
 - `sequence`, `key_epoch`, `timestamp` are 8 bytes big-endian.

--- a/.docs/specs/24-provenance-system.md
+++ b/.docs/specs/24-provenance-system.md
@@ -100,7 +100,18 @@ Example: data originates in context A, flows to context B (depth 0), then from B
 
 ### 24.3.3 Dual Recording
 
-Provenance is recorded in both the source and target contexts' event logs. The returned `DataProvenance` is a self-contained value that can be cloned for dual recording. This ensures that both sides of a cross-context data flow have an auditable record.
+Provenance is recorded in both the source and target contexts' event logs. The returned `DataProvenance` is a self-contained value that can be cloned for dual recording. This ensures that both sides of a cross-context data flow have an auditable record. The source context records a `ProvenanceAttached` event and the target context records a `ProvenanceReceived` event; each event's payload carries the provenance hash defined below.
+
+**Provenance hash encoding (normative).** Every provenance hash in the protocol -- the `provenance_hash` bound into the BroadcastEnvelope signature (§5.14.5), the equivalent inner-envelope hash, and the hash recorded in the `ProvenanceAttached` / `ProvenanceReceived` event-log payloads -- is computed as:
+
+```
+provenance_hash = SHA-256(rmp_serde::to_vec(provenance))   if provenance is present
+provenance_hash = SHA-256(0x00)                            if provenance is absent (sentinel, ADR-002)
+```
+
+where `provenance` is the `DataProvenance` record and `rmp_serde::to_vec` is positional (array-encoded) MessagePack in struct-declaration field order. The `DataProvenance` field order is: `source_context`, `source_type`, `counterparties`, `purpose`, `discovery_method`, `age`, `memory_scope`, `chain_depth`, `chain_path`, `payment_amount`, `payment_adapter`, `payment_receipt_id` (§24.2). JSON is **not** used on any provenance-hash path.
+
+This single encoding is deliberate: it makes the hash a context member records for a `DataProvenance` value in its event log bit-for-bit identical to the `provenance_hash` a broadcast author signs over the same value, and it matches the event-log leaf encoding (which serializes the wrapping `Event` with `rmp_serde::to_vec`). A third-party reimplementer MUST use exactly this encoding to reproduce protocol-conformant provenance hashes. The `SHA-256(0x00)` absent-sentinel distinguishes "no provenance" from any real provenance value. See §25 Vector 35 for the `DataProvenance` known-answer test.
 
 ### 24.3.4 Economic Provenance
 

--- a/.docs/specs/25-test-vectors.md
+++ b/.docs/specs/25-test-vectors.md
@@ -428,6 +428,35 @@ checkpoint.event_count == 9
 
 Reference implementation and assertions: `crates/scp-event-log/tests/test_vectors.rs` (`vector_32_typed_leaf_and_checkpoint_kat`, `vector_33_checkpoint_root_equals_tree_root_kat`). Regenerate with `cargo test -p scp-event-log --test test_vectors -- --nocapture`.
 
+### Vector 35: `DataProvenance` -> `provenance_hash` KAT (§24.3.3)
+
+Pins the canonical provenance-hash encoding — `SHA-256(rmp_serde::to_vec(DataProvenance))`, positional MessagePack in struct-declaration field order (§24.3.3). This is the single encoding used by the signed BroadcastEnvelope `provenance_hash` (§5.14.5), the inner-envelope provenance hash, and the FFI event-log `ProvenanceAttached` / `ProvenanceReceived` payloads — so this hash is identical whether computed on a signed path or recorded in an event log.
+
+```
+DataProvenance (all fields populated; field order per §24.2.1):
+  source_context:     "ctx-kat-provenance"
+  source_type:        Persistent
+  counterparties:     ["did:key:alice", "did:key:bob"]
+  purpose:            Some("kat")
+  discovery_method:   SharedContext("ctx-shared")
+  age:                300 s
+  memory_scope:       Full
+  chain_depth:        1
+  chain_path:         Some(["ctx-hop-1"])
+  payment_amount:     Some(1000)
+  payment_adapter:    Some("stripe")
+  payment_receipt_id: Some([0x11; 32])
+
+provenance_hash = SHA-256(rmp_serde::to_vec(DataProvenance))
+  = 0x12ea6cf53e3e2fe1c851214d6c9b1acf1338e835bcb91271c8bcdf04e553ce68
+
+Absent-provenance sentinel (ADR-002):
+  provenance_hash = SHA-256(0x00)
+  = 0x6e340b9cffb37a989ca544e6bb780a2c78901d3fb33738768511a30617afa01d
+```
+
+Reference implementation and assertions: `crates/scp-protocol/src/crypto/sender_keys/broadcast.rs` (`vector_35_data_provenance_hash_kat`). Regenerate with `cargo test -p scp-protocol vector_35_data_provenance_hash_kat -- --nocapture`.
+
 ## 25.9 Key Continuity Fingerprint Vectors (§9.11)
 
 Domain: `"SCP-KEY-CONTINUITY-V1:"`

--- a/crates/scp-ffi/napi/src/provenance.rs
+++ b/crates/scp-ffi/napi/src/provenance.rs
@@ -127,14 +127,19 @@ pub(crate) fn provenance_attach_on(
         None,
     );
 
-    // Compute provenance hash: SHA-256 of JSON-serialized provenance record.
-    let prov_json_bytes = serde_json::to_vec(&prov).map_err(|e| {
+    // Compute provenance hash: SHA-256 of the MessagePack-serialized provenance
+    // record (§24.3.3). Uses the same `rmp_serde::to_vec` encoding as the signed
+    // broadcast path
+    // (`scp_protocol::crypto::sender_keys::broadcast::compute_provenance_hash`)
+    // and the event-log leaf, so the logged hash matches the signed-path hash
+    // for identical input.
+    let prov_bytes = rmp_serde::to_vec(&prov).map_err(|e| {
         napi::Error::from(ScpNapiError::Validation {
             message: format!("failed to serialize provenance for hashing: {e}"),
             code: codes::VALID_7053.to_owned(),
         })
     })?;
-    let prov_hash: [u8; 32] = Sha256::digest(&prov_json_bytes).into();
+    let prov_hash: [u8; 32] = Sha256::digest(&prov_bytes).into();
 
     // Record ProvenanceAttached in the source context event log.
     // Best-effort: log warning if context not found (provenance_attach

--- a/crates/scp-ffi/src/provenance.rs
+++ b/crates/scp-ffi/src/provenance.rs
@@ -281,13 +281,17 @@ impl crate::scp::PyScp {
             None,
         );
 
-        // Compute provenance hash: SHA-256 of JSON-serialized provenance record.
-        let prov_json_bytes =
-            serde_json::to_vec(&prov).map_err(|e| ScpPyError::ValidationError {
-                message: format!("failed to serialize provenance for hashing: {e}"),
-                code: codes::VALID_7053.to_string(),
-            })?;
-        let prov_hash: [u8; 32] = Sha256::digest(&prov_json_bytes).into();
+        // Compute provenance hash: SHA-256 of the MessagePack-serialized
+        // provenance record (§24.3.3). Uses the same `rmp_serde::to_vec`
+        // encoding as the signed broadcast path
+        // (`scp_protocol::crypto::sender_keys::broadcast::compute_provenance_hash`)
+        // and the event-log leaf, so the logged hash matches the signed-path
+        // hash for identical input.
+        let prov_bytes = rmp_serde::to_vec(&prov).map_err(|e| ScpPyError::ValidationError {
+            message: format!("failed to serialize provenance for hashing: {e}"),
+            code: codes::VALID_7053.to_string(),
+        })?;
+        let prov_hash: [u8; 32] = Sha256::digest(&prov_bytes).into();
 
         // Record ProvenanceAttached in the source context event log.
         // Best-effort: log warning if context not found (provenance_attach

--- a/crates/scp-ffi/uniffi/src/bridge.rs
+++ b/crates/scp-ffi/uniffi/src/bridge.rs
@@ -16166,12 +16166,17 @@ impl Scp {
             None,
         );
 
-        // Compute provenance hash: SHA-256 of JSON-serialized provenance record.
-        let prov_json_bytes = serde_json::to_vec(&prov).map_err(|e| ScpError::Validation {
+        // Compute provenance hash: SHA-256 of the MessagePack-serialized
+        // provenance record (§24.3.3). Uses the same `rmp_serde::to_vec`
+        // encoding as the signed broadcast path
+        // (`scp_protocol::crypto::sender_keys::broadcast::compute_provenance_hash`)
+        // and the event-log leaf, so the logged hash matches the signed-path
+        // hash for identical input.
+        let prov_bytes = rmp_serde::to_vec(&prov).map_err(|e| ScpError::Validation {
             msg: format!("failed to serialize provenance for hashing: {e}"),
             code: codes::VALID_7053.to_owned(),
         })?;
-        let prov_hash: [u8; 32] = sha2::Sha256::digest(&prov_json_bytes).into();
+        let prov_hash: [u8; 32] = sha2::Sha256::digest(&prov_bytes).into();
 
         // Record ProvenanceAttached in the source context event log.
         if let Err(e) = uniffi_append_provenance_event_on(

--- a/crates/scp-protocol/src/crypto/sender_keys/broadcast.rs
+++ b/crates/scp-protocol/src/crypto/sender_keys/broadcast.rs
@@ -346,14 +346,19 @@ pub struct SealBroadcastParams<'a> {
 ///
 /// This mirrors [`compute_provenance_hash`](crate::envelope::inner) and uses
 /// the same serialization format (`MessagePack` via `rmp_serde::to_vec`) to ensure
-/// cross-envelope consistency.
+/// cross-site consistency.
 ///
-/// **Note on serialization format**: Uses `MessagePack` because this hash is
-/// covered by the broadcast `Ed25519` signature and verified within a single
-/// broadcast context — no cross-implementation parity needed. FFI bridges
-/// use canonical JSON (`serde_json::to_vec`) for provenance hashing that
-/// crosses implementation boundaries. See the doc comment on
-/// [`crate::envelope::inner::compute_provenance_hash`] for the full rationale.
+/// **Serialization format**: `SHA-256(rmp_serde::to_vec(&provenance))` over the
+/// [`crate::provenance::DataProvenance`] struct (positional `MessagePack`,
+/// struct-declaration field order), or `SHA-256(0x00)` when absent. This is the
+/// one protocol-wide provenance-hash encoding: the FFI event-log provenance-hash
+/// sites (`ProvenanceAttached` / `ProvenanceReceived`) serialize the same
+/// `DataProvenance` with the same call, so the FFI-logged hash equals this
+/// signed-path hash for identical input. No JSON is used on any provenance-hash
+/// path. See the doc comment on
+/// [`crate::envelope::inner::compute_provenance_hash`] for the full rationale,
+/// `.docs/specs/24-provenance-system.md` §24.3.3 for the normative rule, and
+/// `.docs/specs/25-test-vectors.md` Vector 35 for the KAT.
 ///
 /// Public so callers can compute the provenance hash externally for use in
 /// [`SigningPayloadFields::provenance_hash`] when constructing the signing
@@ -2076,5 +2081,53 @@ mod tests {
             0,
         );
         assert!(result.is_err(), "wrong author should fail HPKE open");
+    }
+
+    /// Spec §25 Vector 35: `DataProvenance` -> `provenance_hash` KAT.
+    ///
+    /// Pins the canonical provenance-hash encoding
+    /// (`SHA-256(rmp_serde::to_vec(DataProvenance))`, §24.3.3) against a fully
+    /// populated `DataProvenance` value. This is the same hash the FFI
+    /// event-log provenance sites record for `ProvenanceAttached` /
+    /// `ProvenanceReceived`, so a byte change here signals a cross-layer
+    /// provenance-hash divergence.
+    ///
+    /// Regenerate with:
+    /// `cargo test -p scp-protocol vector_35_data_provenance_hash_kat -- --nocapture`
+    #[test]
+    fn vector_35_data_provenance_hash_kat() {
+        use crate::economy::types::Amount;
+        use crate::provenance::{DataProvenance, DiscoveryMethod, SourceType};
+
+        let provenance = DataProvenance {
+            source_context: "ctx-kat-provenance".to_string(),
+            source_type: SourceType::Persistent,
+            counterparties: vec!["did:key:alice".into(), "did:key:bob".into()],
+            purpose: Some("kat".to_string()),
+            discovery_method: DiscoveryMethod::SharedContext("ctx-shared".to_string()),
+            age: std::time::Duration::from_mins(5),
+            memory_scope: crate::context::params::MemoryScope::Full,
+            chain_depth: 1,
+            chain_path: Some(vec!["ctx-hop-1".to_string()]),
+            payment_amount: Some(Amount(1000)),
+            payment_adapter: Some("stripe".to_string()),
+            payment_receipt_id: Some([0x11; 32]),
+        };
+
+        // Present-provenance hash: SHA-256(rmp_serde::to_vec(&provenance)).
+        let hash = compute_provenance_hash(Some(&provenance)).unwrap();
+        let hex = hex::encode(hash);
+        assert_eq!(
+            hex, "12ea6cf53e3e2fe1c851214d6c9b1acf1338e835bcb91271c8bcdf04e553ce68",
+            "provenance_hash KAT drift — see §25 Vector 35 / §24.3.3"
+        );
+
+        // Absent-provenance sentinel: SHA-256(0x00) (ADR-002).
+        let absent = compute_provenance_hash(None).unwrap();
+        let absent_hex = hex::encode(absent);
+        assert_eq!(
+            absent_hex, "6e340b9cffb37a989ca544e6bb780a2c78901d3fb33738768511a30617afa01d",
+            "absent-provenance sentinel is SHA-256(0x00)"
+        );
     }
 }

--- a/crates/scp-protocol/src/envelope/inner/mod.rs
+++ b/crates/scp-protocol/src/envelope/inner/mod.rs
@@ -467,18 +467,26 @@ pub const fn validate_inner_version(
 /// Computes `SHA-256(serialize(provenance))` if present, or `SHA-256(0x00)` if
 /// absent. Returns a fixed-size 32-byte array (SHA-256 output).
 ///
-/// **Serialization format**: This function uses `MessagePack` (`rmp_serde::to_vec`)
-/// because it operates on the inner envelope path where the hash is covered by
-/// the `Ed25519` signature and verified within a single MLS group — no
-/// cross-implementation parity is needed.
+/// **Serialization format**: This function serializes `provenance` with
+/// `MessagePack` (`rmp_serde::to_vec`), producing the positional (array-encoded)
+/// `MessagePack` form in struct-declaration field order, then hashes the bytes
+/// with SHA-256.
 ///
-/// **This is NOT the same as FFI bridge provenance hashing.** The FFI bridges
-/// (`PyO3`, NAPI, `UniFFI`) use `serde_json::to_vec` (canonical JSON) for
-/// provenance hashing because that hash crosses implementation boundaries
-/// (Rust ↔ Python ↔ TypeScript ↔ Swift ↔ Kotlin). The protocol rule is:
-/// **cross-implementation canonical hashing uses JSON (RFC 8785); `MessagePack`
-/// is for wire format only.** See `.docs/specs/05-contexts.md` §5.14 and
-/// `.docs/specs/25-test-vectors.md`.
+/// **Encoding is uniform across every provenance-hash site.** The same
+/// `SHA-256(rmp_serde::to_vec(..))` construction is used by the signed broadcast
+/// path ([`crate::crypto::sender_keys::broadcast::compute_provenance_hash`], over
+/// [`crate::provenance::DataProvenance`]), by this inner-envelope path (over the
+/// local [`Provenance`] struct), and by the FFI event-log provenance-hash sites
+/// that emit `ProvenanceAttached` / `ProvenanceReceived` (over `DataProvenance`).
+/// For a given struct value the resulting hash is therefore identical across
+/// these sites — the inner and broadcast/FFI sites operate on different structs
+/// (`Provenance` vs `DataProvenance`) but share the one encoding rule. That rule
+/// also matches the event-log leaf encoding, which serializes the wrapping
+/// `Event` with `rmp_serde::to_vec` (`scp-event-log`
+/// `tree::serialize_event_for_hashing`). No JSON is used on any provenance-hash
+/// path. See `.docs/specs/24-provenance-system.md` §24.3.3 for the normative
+/// rule and `.docs/specs/25-test-vectors.md` Vector 35 for the `DataProvenance`
+/// KAT.
 ///
 /// # Errors
 ///


### PR DESCRIPTION
Canonicalization-inventory finding (Part A′, cryptographer-approved). Two issues:

1. **Phantom provenance in docs:** the native provenance-hash doc-comments (`envelope/inner/mod.rs`, `crypto/sender_keys/broadcast.rs`) claimed the FFI hash uses "canonical JSON (RFC 8785)" and cited §5.14/§25 as authority — both citations don't contain the rule, and the FFI actually used plain `serde_json::to_vec` (declaration-order, NOT JCS). False claims + phantom citations removed.
2. **Encoding inconsistency:** the 3 FFI event-log provenance-hash sites (`scp-ffi/src/provenance.rs`, `napi`, `uniffi`) hashed `DataProvenance` with `serde_json::to_vec` while the two signed native paths and the event-log leaf that wraps the value both use `rmp_serde::to_vec` (positional). Unified the FFI sites to `rmp_serde::to_vec` — now bit-identical to `broadcast::compute_provenance_hash` for the same struct, closing a latent footgun where a future "does the logged provenance match the message's?" check would silently fail across encodings. Signed broadcast/inner paths untouched.
3. **Spec:** §5.14.5/§24 now state the real rule (`provenance_hash = SHA-256(rmp_serde positional of DataProvenance)`) so third-party reimplementers have an unambiguous target; **KAT Vector 35** added (derived from production run).

Pre-release: the `ProvenanceAttached`/`ProvenanceReceived` leaf value changes (no deployed data). Event-tree/checkpoint KATs unaffected. Verified: scp-protocol + event-log tests, V35 KAT, all bridge suites, full-feature clippy, validate-prd 370.

🤖 Generated with [Claude Code](https://claude.com/claude-code)