### PR TITLE
fix(ffi): surface dropped provenance fields in PyO3 dict + typed TS ProvenanceRecord decoder (closes #2031)

### DIFF
--- a/bindings/python/tests/test_real_ffi.py
+++ b/bindings/python/tests/test_real_ffi.py
@@ -928,6 +928,17 @@ class TestProvenance:
             None,
         )
         assert isinstance(result, dict)
+        # The dict surfaces every DataProvenance field, matching the NAPI/UniFFI
+        # bridges (parity with the canonical provenance record).
+        assert result["source_context"] == "source-ctx"
+        assert result["chain_depth"] == 0
+        # Discovery method mirrors the tagged wire shape; default is OutOfBand.
+        assert result["discovery_method"] == "OutOfBand"
+        # Economic provenance (§24.3.4, §19.6): present, null on this path since
+        # attach never mints a payment. ADR-060: amount is a decimal string.
+        assert result["payment_amount"] is None
+        assert result["payment_adapter"] is None
+        assert result["payment_receipt_id"] is None
 
     async def test_chain_depth(self, scp: SCP):
         # ADR-048 §1: pure helper now exposed as a module-level free fn.

--- a/bindings/typescript/src/provenance.ts
+++ b/bindings/typescript/src/provenance.ts
@@ -13,6 +13,9 @@
  * See spec section 24 (Provenance System) and ADR-019.
  */
 
+import { ValidationError } from "./errors";
+import { safeJsonParse } from "./internal/json-utils";
+
 // ---------------------------------------------------------------------------
 // Types
 // ---------------------------------------------------------------------------
@@ -57,4 +60,69 @@ export interface ProvenanceRecord {
   readonly paymentAdapter: string | null;
   /** Hex-encoded 32-byte receipt ID for payment verification, if any. */
   readonly paymentReceiptId: string | null;
+}
+
+// ---------------------------------------------------------------------------
+// Decoding
+// ---------------------------------------------------------------------------
+
+/**
+ * Decodes the raw snake_case JSON string returned by the native
+ * `provenanceAttach` bridge into a typed camelCase {@link ProvenanceRecord}.
+ *
+ * The wire shape is the bridge's canonical provenance record (identical across
+ * the PyO3, NAPI, and UniFFI bridges). This decoder converts it to the SDK's
+ * public camelCase surface, and — per ADR-060 — parses the `payment_amount`
+ * decimal string into a `bigint` so the full `u64` range survives exactly (a
+ * JS `number` would lose precision above 2^53).
+ *
+ * @param json - The raw JSON string from the native bridge.
+ * @returns The decoded, typed provenance record.
+ * @throws {ValidationError} If the JSON is malformed (`SCP-VALID-7001`) or a
+ *   field has an unexpected type (`SCP-VALID-7005`).
+ */
+export function decodeProvenanceRecord(json: string): ProvenanceRecord {
+  const raw = safeJsonParse(json, "provenanceAttach") as Record<string, unknown>;
+
+  const paymentAmountRaw = raw.payment_amount;
+  let paymentAmount: bigint | null;
+  if (paymentAmountRaw === null || paymentAmountRaw === undefined) {
+    paymentAmount = null;
+  } else if (typeof paymentAmountRaw === "string") {
+    try {
+      // ADR-060: the wire value is a canonical base-10 decimal string.
+      paymentAmount = BigInt(paymentAmountRaw);
+    } catch {
+      throw new ValidationError(
+        `provenance payment_amount is not a valid decimal string: ${paymentAmountRaw}`,
+        "SCP-VALID-7005",
+      );
+    }
+  } else {
+    throw new ValidationError(
+      `provenance payment_amount must be a decimal string or null, got ${typeof paymentAmountRaw}`,
+      "SCP-VALID-7005",
+    );
+  }
+
+  const chainPathRaw = raw.chain_path;
+  const chainPath =
+    chainPathRaw === null || chainPathRaw === undefined
+      ? null
+      : (chainPathRaw as readonly string[]);
+
+  return {
+    sourceContext: raw.source_context as string,
+    sourceType: raw.source_type as string,
+    chainDepth: raw.chain_depth as number,
+    counterparties: (raw.counterparties ?? []) as readonly string[],
+    ageSecs: raw.age_secs as number,
+    memoryScope: raw.memory_scope as string,
+    chainPath,
+    purpose: (raw.purpose ?? null) as string | null,
+    discoveryMethod: raw.discovery_method as DiscoveryMethod,
+    paymentAmount,
+    paymentAdapter: (raw.payment_adapter ?? null) as string | null,
+    paymentReceiptId: (raw.payment_receipt_id ?? null) as string | null,
+  };
 }

--- a/bindings/typescript/src/scp.ts
+++ b/bindings/typescript/src/scp.ts
@@ -41,6 +41,7 @@ import { ContextError, mapBridgeError, mapSagaError, ValidationError } from "./e
 import type { Identity } from "./identity";
 import { toCapabilityValidation } from "./internal/bridge";
 import { loadNativeAddon, type NativeAddon as RawNativeAddon } from "./internal/native";
+import { decodeProvenanceRecord, type ProvenanceRecord } from "./provenance";
 import type { Node, Relay } from "./server";
 import type {
   AttestationType,
@@ -3175,8 +3176,8 @@ export class SCP {
     discoveryMethod?: string,
     purpose?: string,
     counterpartyPolicy?: string,
-  ): string {
-    return (
+  ): ProvenanceRecord {
+    const raw = (
       this.#native.provenanceAttach as (
         sc: string,
         st: string,
@@ -3201,6 +3202,9 @@ export class SCP {
       purpose,
       counterpartyPolicy,
     );
+    // The native bridge returns the raw snake_case JSON wire string; decode it
+    // into the SDK's typed camelCase surface (ADR-060 `paymentAmount` bigint).
+    return decodeProvenanceRecord(raw);
   }
 
   provenanceCheckChainDepth(chainDepth: number, maxDepth?: number): boolean {

--- a/bindings/typescript/tests/provenance.test.ts
+++ b/bindings/typescript/tests/provenance.test.ts
@@ -1,0 +1,145 @@
+/**
+ * Tests for the provenance record decoder.
+ *
+ * Verifies that `decodeProvenanceRecord` converts the raw snake_case JSON wire
+ * string (as emitted by the native bridge) into the SDK's typed camelCase
+ * {@link ProvenanceRecord}, and — per ADR-060 — parses the `payment_amount`
+ * decimal string into a `bigint` that round-trips a > 2^53 value exactly.
+ */
+
+import { describe, expect, it } from "bun:test";
+import { ValidationError } from "../src/errors";
+import { decodeProvenanceRecord } from "../src/provenance";
+
+describe("decodeProvenanceRecord", () => {
+  it("maps every snake_case wire field to its camelCase counterpart", () => {
+    const wire = JSON.stringify({
+      source_context: "ctx-src",
+      source_type: "Persistent",
+      chain_depth: 2,
+      counterparties: ["did:dht:z6MkAlice", "did:dht:z6MkBob"],
+      age_secs: 42,
+      memory_scope: "Full",
+      chain_path: ["ctx-hop-1", "ctx-hop-2"],
+      purpose: "recipe sharing",
+      discovery_method: { SharedContext: "ctx-shared" },
+      payment_amount: "1000",
+      payment_adapter: "lightning",
+      payment_receipt_id: "ab".repeat(32),
+    });
+
+    const record = decodeProvenanceRecord(wire);
+
+    expect(record.sourceContext).toBe("ctx-src");
+    expect(record.sourceType).toBe("Persistent");
+    expect(record.chainDepth).toBe(2);
+    expect(record.counterparties).toEqual(["did:dht:z6MkAlice", "did:dht:z6MkBob"]);
+    expect(record.ageSecs).toBe(42);
+    expect(record.memoryScope).toBe("Full");
+    expect(record.chainPath).toEqual(["ctx-hop-1", "ctx-hop-2"]);
+    expect(record.purpose).toBe("recipe sharing");
+    expect(record.discoveryMethod).toEqual({ SharedContext: "ctx-shared" });
+    expect(record.paymentAmount).toBe(1000n);
+    expect(record.paymentAdapter).toBe("lightning");
+    expect(record.paymentReceiptId).toBe("ab".repeat(32));
+  });
+
+  it("round-trips a payment_amount above 2^53 exactly (ADR-060)", () => {
+    // 2^53 + 1 is the first integer a JS `number` cannot represent exactly.
+    const big = (2n ** 53n + 1n).toString();
+    const wire = JSON.stringify({
+      source_context: "ctx-src",
+      source_type: "Persistent",
+      chain_depth: 0,
+      counterparties: [],
+      age_secs: 0,
+      memory_scope: "Full",
+      chain_path: null,
+      purpose: null,
+      discovery_method: "OutOfBand",
+      payment_amount: big,
+      payment_adapter: "stripe",
+      payment_receipt_id: null,
+    });
+
+    const record = decodeProvenanceRecord(wire);
+
+    expect(record.paymentAmount).toBe(2n ** 53n + 1n);
+    // The value survives a full string round-trip with no precision loss.
+    expect(record.paymentAmount?.toString()).toBe(big);
+  });
+
+  it("round-trips the full u64 max exactly", () => {
+    const u64Max = (2n ** 64n - 1n).toString();
+    const wire = JSON.stringify({
+      source_context: "ctx-src",
+      source_type: "Persistent",
+      chain_depth: 0,
+      counterparties: [],
+      age_secs: 0,
+      memory_scope: "Full",
+      chain_path: null,
+      purpose: null,
+      discovery_method: "OutOfBand",
+      payment_amount: u64Max,
+      payment_adapter: null,
+      payment_receipt_id: null,
+    });
+
+    expect(decodeProvenanceRecord(wire).paymentAmount).toBe(2n ** 64n - 1n);
+  });
+
+  it("surfaces null payment fields as null", () => {
+    const wire = JSON.stringify({
+      source_context: "ctx-src",
+      source_type: "Persistent",
+      chain_depth: 0,
+      counterparties: [],
+      age_secs: 0,
+      memory_scope: "Full",
+      chain_path: null,
+      purpose: null,
+      discovery_method: "OutOfBand",
+      payment_amount: null,
+      payment_adapter: null,
+      payment_receipt_id: null,
+    });
+
+    const record = decodeProvenanceRecord(wire);
+
+    expect(record.paymentAmount).toBeNull();
+    expect(record.paymentAdapter).toBeNull();
+    expect(record.paymentReceiptId).toBeNull();
+    expect(record.chainPath).toBeNull();
+    expect(record.purpose).toBeNull();
+    expect(record.discoveryMethod).toBe("OutOfBand");
+  });
+
+  it("throws ValidationError on malformed JSON", () => {
+    expect(() => decodeProvenanceRecord("{not json}")).toThrow(ValidationError);
+  });
+
+  it("throws ValidationError when payment_amount is not a decimal string", () => {
+    const wire = JSON.stringify({
+      source_context: "ctx-src",
+      source_type: "Persistent",
+      chain_depth: 0,
+      counterparties: [],
+      age_secs: 0,
+      memory_scope: "Full",
+      chain_path: null,
+      purpose: null,
+      discovery_method: "OutOfBand",
+      payment_amount: "not-a-number",
+      payment_adapter: null,
+      payment_receipt_id: null,
+    });
+
+    expect(() => decodeProvenanceRecord(wire)).toThrow(ValidationError);
+  });
+
+  it("rejects a bare-number payment_amount (must be a decimal string)", () => {
+    const wire = '{"payment_amount": 1000, "discovery_method": "OutOfBand"}';
+    expect(() => decodeProvenanceRecord(wire)).toThrow(ValidationError);
+  });
+});

--- a/crates/scp-ffi/src/provenance.rs
+++ b/crates/scp-ffi/src/provenance.rs
@@ -406,6 +406,38 @@ fn provenance_to_dict<'py>(py: Python<'py>, prov: &DataProvenance) -> PyResult<B
     dict.set_item("memory_scope", format!("{:?}", prov.memory_scope))?;
     dict.set_item("chain_path", prov.chain_path.clone())?;
     dict.set_item("purpose", prov.purpose.as_deref())?;
+
+    // Discovery method (§24.2.3). Mirrors the tagged shape the NAPI/UniFFI
+    // bridges surface: the unit variant is a bare `"OutOfBand"` string; the
+    // context-bearing variants are single-key mappings keyed by the variant
+    // name, so the wire shape is identical across every bridge.
+    match &prov.discovery_method {
+        DiscoveryMethod::OutOfBand => dict.set_item("discovery_method", "OutOfBand")?,
+        DiscoveryMethod::SharedContext(ctx_id) => {
+            let dm = PyDict::new(py);
+            dm.set_item("SharedContext", ctx_id)?;
+            dict.set_item("discovery_method", dm)?;
+        }
+        DiscoveryMethod::Registry(ctx_id) => {
+            let dm = PyDict::new(py);
+            dm.set_item("Registry", ctx_id)?;
+            dict.set_item("discovery_method", dm)?;
+        }
+    }
+
+    // Economic provenance (§24.3.4, §19.6). ADR-060: a monetary `Amount`
+    // crosses the boundary as its canonical base-10 decimal string (never a
+    // bare number) so the full `u64` range survives exactly — matching the
+    // NAPI/UniFFI bridges. `None` surfaces as Python `None`.
+    dict.set_item(
+        "payment_amount",
+        prov.payment_amount.map(|a| a.0.to_string()),
+    )?;
+    dict.set_item("payment_adapter", prov.payment_adapter.as_deref())?;
+    dict.set_item(
+        "payment_receipt_id",
+        prov.payment_receipt_id.map(hex::encode),
+    )?;
     Ok(dict)
 }
 
@@ -688,6 +720,112 @@ mod tests {
         assert!(
             provenance_pseudonymize_counterparties(&prov_json.to_string(), "not-hex-zz").is_err()
         );
+    }
+
+    #[test]
+    fn provenance_to_dict_surfaces_payment_fields() {
+        use scp_core::economy::types::Amount;
+
+        pyo3::prepare_freethreaded_python();
+        Python::with_gil(|py| {
+            let prov = DataProvenance {
+                source_context: "ctx-src".to_string(),
+                source_type: SourceType::Persistent,
+                counterparties: vec!["did:dht:z6MkAlice".into()],
+                purpose: Some("paid data".to_string()),
+                discovery_method: DiscoveryMethod::SharedContext("ctx-shared".to_string()),
+                age: std::time::Duration::from_secs(0),
+                memory_scope: MemoryScope::Full,
+                chain_depth: 0,
+                chain_path: None,
+                // u64::MAX exercises the > 2^53 range that a bare JS number
+                // would lose — the decimal string must survive exactly.
+                payment_amount: Some(Amount::new(u64::MAX)),
+                payment_adapter: Some("lightning".to_string()),
+                payment_receipt_id: Some([0xAB; 32]),
+            };
+
+            let dict = provenance_to_dict(py, &prov).unwrap();
+
+            // Amount crosses as the canonical base-10 decimal string.
+            let amount: String = dict
+                .get_item("payment_amount")
+                .unwrap()
+                .unwrap()
+                .extract()
+                .unwrap();
+            assert_eq!(amount, u64::MAX.to_string());
+
+            let adapter: String = dict
+                .get_item("payment_adapter")
+                .unwrap()
+                .unwrap()
+                .extract()
+                .unwrap();
+            assert_eq!(adapter, "lightning");
+
+            // 32-byte receipt id surfaces hex-encoded (64 hex chars).
+            let receipt: String = dict
+                .get_item("payment_receipt_id")
+                .unwrap()
+                .unwrap()
+                .extract()
+                .unwrap();
+            assert_eq!(receipt, "ab".repeat(32));
+
+            // Discovery method mirrors the tagged wire shape.
+            let dm = dict.get_item("discovery_method").unwrap().unwrap();
+            let dm_dict = dm.downcast::<PyDict>().unwrap();
+            let shared: String = dm_dict
+                .get_item("SharedContext")
+                .unwrap()
+                .unwrap()
+                .extract()
+                .unwrap();
+            assert_eq!(shared, "ctx-shared");
+        });
+    }
+
+    #[test]
+    fn provenance_to_dict_none_payment_is_null() {
+        pyo3::prepare_freethreaded_python();
+        Python::with_gil(|py| {
+            let prov = DataProvenance {
+                source_context: "ctx-src".to_string(),
+                source_type: SourceType::Persistent,
+                counterparties: vec![],
+                purpose: None,
+                discovery_method: DiscoveryMethod::OutOfBand,
+                age: std::time::Duration::from_secs(0),
+                memory_scope: MemoryScope::Full,
+                chain_depth: 0,
+                chain_path: None,
+                payment_amount: None,
+                payment_adapter: None,
+                payment_receipt_id: None,
+            };
+
+            let dict = provenance_to_dict(py, &prov).unwrap();
+
+            // Absent payment surfaces as Python None for every field.
+            assert!(dict.get_item("payment_amount").unwrap().unwrap().is_none());
+            assert!(dict.get_item("payment_adapter").unwrap().unwrap().is_none());
+            assert!(
+                dict.get_item("payment_receipt_id")
+                    .unwrap()
+                    .unwrap()
+                    .is_none()
+            );
+
+            // Unit discovery variant surfaces as the bare string.
+            let dm: String = dict
+                .get_item("discovery_method")
+                .unwrap()
+                .unwrap()
+                .extract()
+                .unwrap();
+            assert_eq!(dm, "OutOfBand");
+        });
     }
 
     #[test]


### PR DESCRIPTION
Two pre-existing provenance-surface completeness gaps found during ADR-060 review.

- **PyO3 `provenance_attach` dict** (`crates/scp-ffi/src/provenance.rs`) omitted **four** `DataProvenance` fields relative to the napi/uniffi bridges: `payment_amount` (ADR-060 decimal string; `None`→`None`), `payment_adapter`, `payment_receipt_id` (hex), and `discovery_method` (tagged shape). All added, mirroring the canonical wire shape the other bridges emit.
- **TypeScript `ProvenanceRecord`** was a camelCase interface with no decoder while `provenanceAttach` returned raw snake_case JSON — the type didn't match the value. Added `decodeProvenanceRecord` (snake→camel; `payment_amount` decimal-string → `bigint`, bare-number rejected so >2^53 can't truncate) and `provenanceAttach` now returns the decoded object — matching the Python bridge + the SDK's established `_fromJson` convention. Transform helpers stay string-in/string-out (consistent with Python).

Swift/Kotlin (UniFFI struct) already carry these fields — no change needed.

Tests: PyO3 dict (u64::MAX exact decimal string, hex receipt, tagged discovery, all-None); Python real-FFI asserts every new key; TS round-trips `paymentAmount` at 2^53+1 and u64 max exactly + null/snake→camel/malformed/bare-number-reject.

Verified: full-feature clippy clean; scp-ffi provenance 17 pass; Python pytest 672; TS 713; check-sdk-coverage + check-error-codes pass.

Closes #2031.

🤖 Generated with [Claude Code](https://claude.com/claude-code)