### PR TITLE
chore(enforce): ADR-049 Phase 2H — promote deleted-primitive bans + tokio::sync::Mutex disallowed-type with §Decision-12 allow-list

### DIFF
--- a/.docs/adrs/ADR-049-actor-per-context.md
+++ b/.docs/adrs/ADR-049-actor-per-context.md
@@ -269,16 +269,20 @@ Enforced via `crates/scp-runtime/clippy.toml`:
 ```toml
 disallowed-types = [
     { path = "tokio::sync::RwLock", reason = "ADR-049 §Decision 12: forbidden on read paths. Use OnceLock/ArcSwap/AtomicU64/DashMap." },
-    { path = "tokio::sync::Mutex",  reason = "ADR-049 §Decision 12: forbidden on read paths. Use ArcSwap+write_lock or Mutex<PerContextState>." },
+    { path = "tokio::sync::Mutex",  reason = "ADR-049 §Decision 12: forbidden on read paths. Use ArcSwap+write_lock or the actor-owned &mut PerContextState." },
 ]
 ```
 
-Allow-list (sites that legitimately use these primitives):
+Allow-list (sites that legitimately use these primitives). Every site below is a cold lifecycle / write-serialization / test path — never a per-command read or dispatch path — so each carries an `#[allow(clippy::disallowed_types, reason = "ADR-049 §Decision 12 allow-list: …")]` naming its specific justification, consistent with the operative "no lock on per-command read/dispatch paths" rule:
 
 - Actor-owned `Mutex<PerContextState>` (per-context mailbox holder).
-- `Supervisor::write_lock: tokio::sync::Mutex<()>` (write serialization for the ArcSwap+write_lock pattern).
+- `Supervisor::write_lock: tokio::sync::Mutex<()>` — the ArcSwap+write_lock write-serialization guard. Cold write path, not a per-command read.
+- `Supervisor::bootstrap_spawn_lock: tokio::sync::Mutex<()>` — serializes the same-id bootstrap-spawn sequence (all three lifecycle bootstrap variants: `create_context`, `import_context`, standing-recreate). Cold bootstrap path, not a per-command read.
+- `Supervisor::task_set: OnceLock<Arc<tokio::sync::Mutex<JoinSet<()>>>>` — guards the shared JoinSet of spawned TTL/governance-timeout tasks. Touched only on spawn/reap, never on a per-command read path (the `task_set_ref` accessor is likewise cold).
+- `ProductionMlsBackend::join_gate: tokio::sync::Mutex<()>` — serializes the `join_from_welcome` consumed-init-key retrieve→join→store sequence (TOCTOU guard). Acquired only on a join, not on a per-command read path.
 - OpenMLS storage adapter internals (sync upstream trait).
 - FFI sync boundaries.
+- Test-only mock/store locks in `#[cfg(test)]` modules — the mock OAuth provider (`bridge/oauth.rs`), the `InMemoryCredentialStore` (`economy/credentials.rs`), and the governance-engine share in the timeout-callback tests (`context/governance/timeout.rs`). Not runtime read paths.
 
 The clippy rule lands in commit 13 of the ADR-049 ladder (Phase 3 of the post-review-round-1 plan); commit 12 already conforms to the rule.
 

--- a/.docs/adrs/ADR-049-actor-per-context.md
+++ b/.docs/adrs/ADR-049-actor-per-context.md
@@ -273,9 +273,10 @@ disallowed-types = [
 ]
 ```
 
-Allow-list (sites that legitimately use these primitives). Every site below is a cold lifecycle / write-serialization / test path — never a per-command read or dispatch path — so each carries an `#[allow(clippy::disallowed_types, reason = "ADR-049 §Decision 12 allow-list: …")]` naming its specific justification, consistent with the operative "no lock on per-command read/dispatch paths" rule:
+The per-context actor owns its `PerContextState` **by move** (`&mut PerContextState`) — there is no interior lock on it at all. That owned-by-move design is *why* the read paths need no `Mutex`; it is not itself an `#[allow]` site (there is nothing to allow when there is no lock — `check-deleted-primitives.sh` in fact bans any `Mutex<PerContextState>`).
 
-- Actor-owned `Mutex<PerContextState>` (per-context mailbox holder).
+Allow-list (sites that actually carry a `tokio::sync::Mutex`). Every site below is a cold lifecycle / write-serialization / test path — never a per-command read or dispatch path — so each carries an `#[allow(clippy::disallowed_types, reason = "ADR-049 §Decision 12 allow-list: …")]` naming its specific justification, consistent with the operative "no lock on per-command read/dispatch paths" rule:
+
 - `Supervisor::write_lock: tokio::sync::Mutex<()>` — the ArcSwap+write_lock write-serialization guard. Cold write path, not a per-command read.
 - `Supervisor::bootstrap_spawn_lock: tokio::sync::Mutex<()>` — serializes the same-id bootstrap-spawn sequence (all three lifecycle bootstrap variants: `create_context`, `import_context`, standing-recreate). Cold bootstrap path, not a per-command read.
 - `Supervisor::task_set: OnceLock<Arc<tokio::sync::Mutex<JoinSet<()>>>>` — guards the shared JoinSet of spawned TTL/governance-timeout tasks. Touched only on spawn/reap, never on a per-command read path (the `task_set_ref` accessor is likewise cold).

--- a/crates/scp-runtime/clippy.toml
+++ b/crates/scp-runtime/clippy.toml
@@ -17,12 +17,16 @@
 # the actor refactor completes (commit 12), the only remaining
 # `std::sync::Mutex` uses are in code that is test-only.
 #
-# `tokio::sync::Mutex` is FORBIDDEN on read paths per ADR-049 §Decision 12
-# (a `Mutex` acquire costs ~4× an atomic load — see the OpenSSL #30659
-# evidence in the ADR). Actor-owned per-context state is serialized by the
-# command loop and needs no lock. The legitimate exceptions are the write
-# serialization / bootstrap / join-gate `Mutex<()>` guards and the
-# supervisor's `task_set` JoinSet holder; each such site carries an
+# `tokio::sync::Mutex` is FORBIDDEN on read paths per ADR-049 §Decision 12,
+# for the same lock-free-read-path invariant as the RwLock ban: a lock
+# acquired on a hot read path costs cycles a lock-free atomic load does not.
+# The ADR's empirical anchor (OpenSSL #30659) measured an rwlock *read*
+# acquire at ~4× an atomic load; the Mutex ban applies that same invariant
+# to Mutex — it is not a separate Mutex-specific ~4× measurement. Actor-owned
+# per-context state is serialized by the command loop and needs no lock. The
+# legitimate exceptions are the write serialization / bootstrap / join-gate
+# `Mutex<()>` guards and the supervisor's `task_set` JoinSet holder; each
+# such site carries an
 # `#[allow(clippy::disallowed_types, reason = "ADR-049 §Decision 12 allow-list: …")]`
 # annotation naming the specific reason. This is the sanctioned allow-list,
 # NOT a weakening of the ban.

--- a/crates/scp-runtime/clippy.toml
+++ b/crates/scp-runtime/clippy.toml
@@ -16,6 +16,21 @@
 # annotations with a pointer to the commit that deletes them. By the time
 # the actor refactor completes (commit 12), the only remaining
 # `std::sync::Mutex` uses are in code that is test-only.
+#
+# `tokio::sync::Mutex` is FORBIDDEN on read paths per ADR-049 §Decision 12
+# (a `Mutex` acquire costs ~4× an atomic load — see the OpenSSL #30659
+# evidence in the ADR). Actor-owned per-context state is serialized by the
+# command loop and needs no lock. The legitimate exceptions are the write
+# serialization / bootstrap / join-gate `Mutex<()>` guards and the
+# supervisor's `task_set` JoinSet holder; each such site carries an
+# `#[allow(clippy::disallowed_types, reason = "ADR-049 §Decision 12 allow-list: …")]`
+# annotation naming the specific reason. This is the sanctioned allow-list,
+# NOT a weakening of the ban.
+#
+# `tokio::sync::RwLock` is intentionally NOT banned yet: the legacy
+# `ContextHandle.inner: Arc<RwLock<ContextInner>>` still exists and its
+# removal is a separate unit of work. The ban lands once that handle is gone.
 disallowed-types = [
     { path = "std::sync::Mutex", reason = "Use tokio::sync::Mutex in runtime async code; actor-owned state needs no Mutex. See ADR-049." },
+    { path = "tokio::sync::Mutex", reason = "ADR-049 §Decision 12: forbidden on read paths. Use ArcSwap+write_lock, OnceLock/AtomicU64/DashMap, or the actor-owned &mut PerContextState. Sanctioned exceptions carry an #[allow(clippy::disallowed_types, reason = \"ADR-049 §Decision 12 allow-list: …\")]." },
 ]

--- a/crates/scp-runtime/src/bridge/oauth.rs
+++ b/crates/scp-runtime/src/bridge/oauth.rs
@@ -672,6 +672,10 @@ impl<H: OAuthHttpClient, S: BridgeCredentialStore> fmt::Debug for OAuthCredentia
     clippy::panic,
     clippy::significant_drop_tightening
 )]
+#[allow(
+    clippy::disallowed_types,
+    reason = "ADR-049 §Decision 12 allow-list: test-only mock OAuth provider records calls behind a tokio::sync::Mutex; not a runtime read path."
+)]
 mod tests {
     use std::sync::atomic::{AtomicU32, Ordering};
 

--- a/crates/scp-runtime/src/context/actor/commands.rs
+++ b/crates/scp-runtime/src/context/actor/commands.rs
@@ -2234,10 +2234,9 @@ pub enum ToolsCommand {
 /// the dispatch function sends the reply and returns
 /// `Outcome { mutated: false }`.
 ///
-/// Commit 7 lands the real read variants. Commit 12c.7 deletes the
-/// transitional `QueryStateView` borrow adapter and routes the
-/// `&PerContextState` + shared event-log provider directly into the
-/// query handler. Variants that mutate state (`drain_events`, access-key
+/// Commit 7 lands the real read variants. The query handler takes the
+/// `&PerContextState` + shared event-log provider directly, with no
+/// intervening borrow adapter. Variants that mutate state (`drain_events`, access-key
 /// management, `compare_remote_checkpoint`, etc.) are NOT migrated here —
 /// they are carried by their own command families
 /// (`MessagingCommand::DrainEvents` / `::CompareRemoteCheckpoint`, the

--- a/crates/scp-runtime/src/context/actor/deps.rs
+++ b/crates/scp-runtime/src/context/actor/deps.rs
@@ -76,8 +76,8 @@
 //!   capability contract (ADR §2: "Never ContextActor → ContextActor
 //!   directly"). Cross-context work goes through
 //!   `SupervisorHandle::start_saga`.
-//! - `task_set` / `next_generation` — supervisor-scoped lifecycle
-//!   state, held on the supervisor side.
+//! - `task_set` — supervisor-scoped lifecycle state, held on the
+//!   supervisor side.
 //! - `consequence_rules` — per-context state stored in `PerContextState`,
 //!   not a cross-cutting dep.
 //!

--- a/crates/scp-runtime/src/context/governance/timeout.rs
+++ b/crates/scp-runtime/src/context/governance/timeout.rs
@@ -1293,6 +1293,10 @@ mod tests {
         let proposal_id = proposal.proposal_id;
 
         // Wrap engine in shared state so the callback can access it.
+        #[allow(
+            clippy::disallowed_types,
+            reason = "ADR-049 §Decision 12 allow-list: test-only sharing of the governance engine into a timeout callback; not a runtime read path."
+        )]
         let engine = Arc::new(tokio::sync::Mutex::new(engine));
         let expired = Arc::new(AtomicBool::new(false));
 

--- a/crates/scp-runtime/src/context/supervisor/supervisor.rs
+++ b/crates/scp-runtime/src/context/supervisor/supervisor.rs
@@ -1197,6 +1197,10 @@ pub struct Supervisor {
     #[allow(dead_code)]
     pub(in crate::context::supervisor) persistence: Arc<dyn ContextPersistence>,
     /// Single-producer-multi-read write lock — plan §"Write path".
+    #[allow(
+        clippy::disallowed_types,
+        reason = "ADR-049 §Decision 12 allow-list: the ArcSwap+write_lock write-serialization guard. Cold write path (not a per-command read), so the Mutex acquire cost the ban targets does not apply."
+    )]
     pub(crate) write_lock: tokio::sync::Mutex<()>,
     /// Serializes the whole bootstrap-spawn sequence of ALL three lifecycle
     /// bootstrap variants — `create_context`, `import_context`, and
@@ -1214,6 +1218,10 @@ pub struct Supervisor {
     /// `spawn_actor_with_state`/`despawn_actor` (which take `write_lock`).
     /// Lock order is always `bootstrap_spawn_lock` → `write_lock`, never the
     /// reverse.
+    #[allow(
+        clippy::disallowed_types,
+        reason = "ADR-049 §Decision 12 allow-list: serializes the same-id bootstrap-spawn sequence. Cold bootstrap path (not a per-command read), so the Mutex acquire cost the ban targets does not apply."
+    )]
     pub(crate) bootstrap_spawn_lock: tokio::sync::Mutex<()>,
     /// Durable saga journal (plan §"Cross-context saga protocol").
     pub(in crate::context::supervisor) saga_journal: Arc<dyn SagaJournal>,
@@ -1293,6 +1301,10 @@ pub struct Supervisor {
     /// configured".
     event_tx: OnceLock<tokio::sync::broadcast::Sender<(String, ContextEvent)>>,
     /// Shared task set for TTL timers + governance timeouts.
+    #[allow(
+        clippy::disallowed_types,
+        reason = "ADR-049 §Decision 12 allow-list: guards the shared JoinSet of spawned TTL/governance-timeout tasks. Touched only on spawn/reap, never on a per-command read path."
+    )]
     task_set: OnceLock<Arc<tokio::sync::Mutex<tokio::task::JoinSet<()>>>>,
     /// OpenMLS storage adapter — the bridge's chosen Storage, erased once via
     /// `SpawnBlockingStorageAdapter`. Runtime NEVER defaults this. Lock-free
@@ -1564,14 +1576,29 @@ impl Supervisor {
                       never held across an .await. ADR-049 §3a."
         )]
         let reserved_saga_contexts = std::sync::Mutex::new(HashSet::new());
+        // ADR-049 §Decision 12 allow-list: the ArcSwap+write_lock and
+        // same-id bootstrap-spawn serialization guards. Cold write/bootstrap
+        // paths (not per-command reads), so the Mutex acquire cost the ban
+        // targets does not apply. Hoisted into `let`s to carry the `#[allow]`
+        // the same way `reserved_saga_contexts` above does.
+        #[allow(
+            clippy::disallowed_types,
+            reason = "ADR-049 §Decision 12 allow-list: ArcSwap+write_lock write-serialization guard; cold write path, not a per-command read."
+        )]
+        let write_lock = tokio::sync::Mutex::new(());
+        #[allow(
+            clippy::disallowed_types,
+            reason = "ADR-049 §Decision 12 allow-list: same-id bootstrap-spawn serialization guard; cold bootstrap path, not a per-command read."
+        )]
+        let bootstrap_spawn_lock = tokio::sync::Mutex::new(());
         Self {
             actors: DashMap::new(),
             standing_contexts: ArcSwap::new(Arc::new(HashMap::new())),
             local_dids: Arc::new(ArcSwap::new(Arc::new(HashSet::new()))),
             wrapping_keys: DashMap::new(),
             persistence,
-            write_lock: tokio::sync::Mutex::new(()),
-            bootstrap_spawn_lock: tokio::sync::Mutex::new(()),
+            write_lock,
+            bootstrap_spawn_lock,
             saga_journal,
             key_package_stores: DashMap::new(),
             health_config,
@@ -1796,9 +1823,12 @@ impl Supervisor {
         if let Some(tx) = event_tx {
             let _ = supervisor.event_tx.set(tx);
         }
-        let _ = supervisor.task_set.set(Arc::new(tokio::sync::Mutex::new(
-            tokio::task::JoinSet::new(),
-        )));
+        #[allow(
+            clippy::disallowed_types,
+            reason = "ADR-049 §Decision 12 allow-list: guards the shared JoinSet of spawned TTL/governance-timeout tasks; touched only on spawn/reap, not a per-command read."
+        )]
+        let task_set = Arc::new(tokio::sync::Mutex::new(tokio::task::JoinSet::new()));
+        let _ = supervisor.task_set.set(task_set);
         // A2 — attach the durable consumed-init-key set to the shared MLS
         // backend so `join_from_welcome` enforces the crypto-layer single-use
         // backstop on EVERY join path (independent of the KeyPackage actor's
@@ -1943,6 +1973,10 @@ impl Supervisor {
     /// Cheap reference to the supervisor's shared task-set. Returns
     /// `None` if [`Self::with_providers`] was not used.
     #[must_use]
+    #[allow(
+        clippy::disallowed_types,
+        reason = "ADR-049 §Decision 12 allow-list: exposes the shared TTL/governance-timeout JoinSet holder (see the `task_set` field); accessor is cold, not a per-command read."
+    )]
     pub(crate) fn task_set_ref(
         &self,
     ) -> Option<&Arc<tokio::sync::Mutex<tokio::task::JoinSet<()>>>> {

--- a/crates/scp-runtime/src/crypto/mls/production_backend.rs
+++ b/crates/scp-runtime/src/crypto/mls/production_backend.rs
@@ -122,6 +122,10 @@ pub struct ProductionMlsBackend {
     /// hot per-context dispatch path, so ADR-049 §12's "no `Mutex` on read
     /// paths" rule is not implicated (the gate is acquired only on a join,
     /// which is not a per-command-dispatch read).
+    #[allow(
+        clippy::disallowed_types,
+        reason = "ADR-049 §Decision 12 allow-list: serializes the join_from_welcome consumed-init-key retrieve→join→store sequence (TOCTOU guard). Acquired only on a join, not on a per-command read path."
+    )]
     join_gate: tokio::sync::Mutex<()>,
 }
 
@@ -151,10 +155,15 @@ impl ProductionMlsBackend {
     ///   group-leaf `Lifetime` stamping and validation (ADR-057 §Prereq-1).
     #[must_use]
     pub fn new(clock: Arc<dyn Clock>) -> Self {
+        #[allow(
+            clippy::disallowed_types,
+            reason = "ADR-049 §Decision 12 allow-list: constructs the join_from_welcome TOCTOU guard (see the `join_gate` field); acquired only on a join, not a per-command read."
+        )]
+        let join_gate = tokio::sync::Mutex::new(());
         Self {
             clock,
             consumed_init_key_store: OnceLock::new(),
-            join_gate: tokio::sync::Mutex::new(()),
+            join_gate,
         }
     }
 

--- a/crates/scp-runtime/src/economy/credentials.rs
+++ b/crates/scp-runtime/src/economy/credentials.rs
@@ -351,6 +351,10 @@ pub async fn retrieve_adapter_credential<S: AdapterCredentialStore>(
     clippy::manual_async_fn,
     clippy::significant_drop_tightening
 )]
+#[allow(
+    clippy::disallowed_types,
+    reason = "ADR-049 §Decision 12 allow-list: test-only InMemoryCredentialStore holds its map behind a tokio::sync::Mutex; not a runtime read path."
+)]
 mod tests {
     use std::collections::HashMap;
 

--- a/scripts/check-deleted-primitives.sh
+++ b/scripts/check-deleted-primitives.sh
@@ -106,12 +106,18 @@ BAN_ENTRIES=(
     "lock_context|crates/scp-runtime|*.rs|Actor-per-context refactor (ADR-049) deleted the per-context lock/relock primitives"
     "relock_context|crates/scp-runtime|*.rs|Actor-per-context refactor (ADR-049) deleted the per-context lock/relock primitives"
     "[^_]contexts_ref|crates/scp-runtime|*.rs|Actor-per-context refactor (ADR-049) deleted the contexts DashMap accessor"
+    "ContextGeneration|crates/scp-runtime|*.rs|Actor-per-context refactor deleted this (ADR-049)"
+    "next_generation|crates/scp-runtime|*.rs|Actor-per-context refactor deleted this (ADR-049)"
+    "take_send_tracker|crates/scp-runtime|*.rs|Actor-per-context refactor deleted the send-tracker take/merge primitives (ADR-049)"
+    "merge_send_tracker|crates/scp-runtime|*.rs|Actor-per-context refactor deleted the send-tracker take/merge primitives (ADR-049)"
+    "MutationStateView|crates/scp-runtime|*.rs|Actor-per-context refactor deleted the transitional mutation/query borrow adapters (ADR-049)"
+    "QueryStateView|crates/scp-runtime|*.rs|Actor-per-context refactor deleted the transitional mutation/query borrow adapters (ADR-049)"
 )
 
-# Example of the activated form for follow-on sessions:
+# Example of the activated form for the remaining, still-pending bans.
+# `RwLock<ContextInner>` waits on legacy `ContextHandle` removal; the
+# `pending_joins` ban waits on the 2F-residual join-path deletion.
 # BAN_ENTRIES+=(
-#     "ContextGeneration|crates/scp-runtime|*.rs|Actor-per-context refactor deleted this (ADR-049)"
-#     "next_generation|crates/scp-runtime|*.rs|Actor-per-context refactor deleted this (ADR-049)"
 #     "RwLock<ContextInner>|crates/scp-runtime|*.rs|Actor-per-context refactor deleted this (ADR-049)"
 #     "pending_joins|crates/scp-runtime/src/crypto|*.rs|Actor-per-context refactor deleted this (ADR-049)"
 # )


### PR DESCRIPTION
## What

ADR-049 **Phase 2H — lock-free-read enforcement activation.** Promotes the deleted-primitive grep-bans that are now safe, and adds the `tokio::sync::Mutex` half of the §Decision 12 `disallowed-types` ban with its sanctioned allow-list. Pure enforcement + doc; no behavior change.

## Grep-bans (`scripts/check-deleted-primitives.sh`)

Added 6 bans for primitives deleted by the actor refactor, each verified 0-ref in `crates/scp-runtime` (2 required scrubbing a stale doc-comment first): `ContextGeneration`, `take_send_tracker`, `merge_send_tracker`, `MutationStateView`, `next_generation`, `QueryStateView`. The still-live `RwLock<ContextInner>` and `pending_joins` bans remain deferred (blocked on the legacy `ContextHandle` removal and the 2F-residual join-path deletion respectively) — deliberately not banned prematurely.

## `tokio::sync::Mutex` disallowed-type (`crates/scp-runtime/clippy.toml`)

Added `tokio::sync::Mutex` to `disallowed-types` (the §Decision 12 lock-free-read invariant — no lock on per-command read/dispatch paths). Every live `tokio::sync::Mutex` site is a cold/lifecycle/test path and carries an `#[allow(clippy::disallowed_types, reason = "ADR-049 §Decision 12 allow-list: …")]`: `Supervisor::{write_lock, bootstrap_spawn_lock, task_set}`, `ProductionMlsBackend::join_gate`, and test-only mocks. The `tokio::sync::RwLock` half stays deferred (blocked by the legacy `ContextHandle.inner: Arc<RwLock<ContextInner>>`).

## ADR reconciliation

Expanded ADR-049 §Decision 12's written allow-list to enumerate every sanctioned site (it previously named only a subset), reconciled the first entry (which named the now-banned `Mutex<PerContextState>` — the as-built owns `PerContextState` by move, no interior lock), corrected a stale `&mut PerContextState` example, and fixed a `clippy.toml` comment that misattributed the OpenSSL rwlock-read ~4× figure to Mutex. Artifact now matches the code verbatim.

## Verification

- `cargo fmt --all --check` — clean
- Canonical all-features clippy `-D warnings` — clean
- `check-deleted-primitives.sh` — PASS (11 rules)
- `cargo nextest run -p scp-runtime -p scp-core` — 2212 passed
- Local review → double-zero (simplifier: sound-and-bounded; bug-catcher: compiled + verified hoists semantics-preserving, bans non-vacuous; alignment: aligned with §Decision 12, round-2 converged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
