### PR TITLE
refactor(runtime): ADR-049 step-12d — delete vestigial ContextCryptoState::access_key_store dup field

### DIFF
--- a/crates/scp-runtime/src/context/actor/state.rs
+++ b/crates/scp-runtime/src/context/actor/state.rs
@@ -71,7 +71,6 @@ use scp_event_log::checkpoint::ConsistencyCheckpoint;
 use scp_protocol::context::broadcast::BroadcastContext as ProtocolBroadcastContext;
 use scp_protocol::context::membership::{MembershipState, ReceiveBuffer};
 use scp_protocol::context::roles::ContextRoleState;
-use scp_protocol::crypto::access_keys::AccessKeyStore;
 use scp_protocol::crypto::sender_keys::{NonceDedup, SenderKey, SenderKeyStore};
 use scp_protocol::crypto::ucan::validate::InMemoryProofResolver;
 use scp_protocol::envelope::{ReorderBuffer, SequenceTracker};
@@ -367,10 +366,7 @@ pub struct PendingBroadcastKeyRotation {
 
 /// State owned by an encrypted-mode (MLS) `ContextActor`. Mirrors the
 /// legacy `MlsCryptoProvider::contexts[ctx_id]`
-/// (`crate::crypto::mls::provider::ContextCryptoState`) field-for-field,
-/// plus the `AccessControlState.access_key_store` field which spec §9.17
-/// scopes to encrypted contexts only (broadcast contexts use the
-/// per-author AES-GCM layer in [`BroadcastState`] instead).
+/// (`crate::crypto::mls::provider::ContextCryptoState`) field-for-field.
 ///
 /// # MLS group is `Option<ScpMlsGroup>`, not `ScpMlsGroup`
 ///
@@ -472,19 +468,6 @@ pub struct ContextCryptoState {
     ///
     /// [`open`]: crate::crypto::mls::provider::MlsCryptoProvider::open
     pub recv_sequence_tracker: HashMap<String, (u64, u64)>,
-
-    /// Per-member access-key store for content-encryption-key wrapping
-    /// (spec §9.17, ADR-038). Scoped to encrypted contexts: legacy
-    /// stored this on
-    /// [`AccessControlState::access_key_store`](crate::context::state::AccessControlState)
-    /// on every `PerContextState` — per task §2, commit 12a hoists the
-    /// field to [`ContextCryptoState`] because it is encrypted-mode-
-    /// specific (broadcast contexts use the per-author AES-GCM layer
-    /// on [`BroadcastState`]). The [`AccessControlState`] field on
-    /// [`PerContextState`](PerContextState) remains populated for the
-    /// shim window so 12b+ handler migrations can pick whichever
-    /// storage site to authoritatively consolidate onto.
-    pub access_key_store: AccessKeyStore,
 }
 
 impl std::fmt::Debug for ContextCryptoState {
@@ -525,7 +508,6 @@ impl std::fmt::Debug for ContextCryptoState {
                 "recv_sequence_tracker",
                 &format_args!("[{} entries]", self.recv_sequence_tracker.len()),
             )
-            .field("access_key_store", &self.access_key_store)
             .finish()
     }
 }
@@ -541,7 +523,6 @@ impl Default for ContextCryptoState {
             nonce_dedup: NonceDedup::new(),
             member_wrapping_keys: HashMap::new(),
             recv_sequence_tracker: HashMap::new(),
-            access_key_store: AccessKeyStore::new(),
         }
     }
 }
@@ -1170,11 +1151,9 @@ pub struct PerContextState {
     /// elevated from private to `pub(crate)` by commit 12a; field
     /// visibility matches.
     ///
-    /// Note: per task §2, the `access_key_store` sub-field of this
-    /// struct is also duplicated on
-    /// [`ContextCryptoState::access_key_store`] — encrypted contexts
-    /// have both storage sites available; 12b+ handler migrations pick
-    /// one. 12d removes the unused one.
+    /// This is the sole authoritative storage site for the
+    /// `access_key_store`: commit 12d removed the vestigial duplicate
+    /// that briefly lived on [`ContextCryptoState`].
     pub(crate) access: AccessControlState,
 
     /// TTL timer + extension state (SCP-021). Mirrors legacy
@@ -1855,7 +1834,6 @@ mod tests {
             nonce_dedup,
             member_wrapping_keys,
             recv_sequence_tracker,
-            access_key_store,
         } = c;
 
         assert!(mls_group.is_none());
@@ -1869,7 +1847,6 @@ mod tests {
             recv_sequence_tracker.is_empty(),
             "recv_sequence_tracker starts empty",
         );
-        let _ = &access_key_store;
     }
 
     /// Exhaustive-destructure witness for [`BroadcastState`]. Catches

--- a/crates/scp-runtime/tests/actor_state_shape.rs
+++ b/crates/scp-runtime/tests/actor_state_shape.rs
@@ -153,7 +153,6 @@ fn context_crypto_state_default_exhaustive_field_witness() {
         nonce_dedup,
         member_wrapping_keys,
         recv_sequence_tracker,
-        access_key_store,
     } = c;
 
     // MLS group and sender key default to `None` per ADR-049 actor
@@ -174,7 +173,6 @@ fn context_crypto_state_default_exhaustive_field_witness() {
     // compiles only if the field exists.
     let _ = &sender_key_store;
     let _ = &nonce_dedup;
-    let _ = &access_key_store;
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## What

ADR-049 **step-12d** cleanup: delete the vestigial duplicate field `ContextCryptoState::access_key_store`. The authoritative copy — `AccessControlState::access_key_store` on `PerContextState.access`, which all real logic and the persisted `ContextSnapshot` use — is untouched.

## Why it's safe

The crypto-side copy had **zero readers**: `git grep '.crypto.access_key_store'` → 0. It was constructed only by `Default`, and `ContextCryptoState` is never built via a struct literal and never destructured field-wise by any airtight-borrow view (verified — unlike the sibling `members` field, there is no hidden `ClassCMut`-style structural consumer). `ContextCryptoState` does not derive `Serialize`/`Deserialize`, so the field was never on any wire/snapshot format — no persistence round-trip or migration impact.

Removed: the field + doc, its `Default` init, the `Debug` `.field(...)` line, both exhaustive-destructure witness tests (in-file + `tests/actor_state_shape.rs`), and the now-unused `AccessKeyStore` import; reconciled two stale doc-comments to name `AccessControlState::access_key_store` as the sole authoritative store.

The sibling `members` duplication (the other half of the "12d removes the unused one" note) is **not** touched here — analysis proved `members` is live (4 production write sites + `ClassCMut` plumbing + documented future-read intent), so its consolidation is a design change tracked in #2040, not a mechanical delete.

## Verification

- `cargo fmt --all --check` — clean
- Canonical all-features clippy `-D warnings` — clean
- `cargo nextest run -p scp-runtime -p scp-core` — 2212 passed
- Local double-zero: bug-catcher (struct-literal/destructure trap explicitly ruled out; compiled+tested) + completionist (complete at every layer; no serialization impact).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
