### PR TITLE
chore(enforce): ADR-049 §Decision-12 — blanket tokio::sync::RwLock ban (PR2)

### DIFF
--- a/crates/scp-runtime/clippy.toml
+++ b/crates/scp-runtime/clippy.toml
@@ -31,15 +31,19 @@
 # annotation naming the specific reason. This is the sanctioned allow-list,
 # NOT a weakening of the ban.
 #
-# `tokio::sync::RwLock` is not yet banned here. The legacy
+# `tokio::sync::RwLock` is banned here (ADR-049 §Decision 12 PR2). The legacy
 # `ContextHandle.inner: Arc<RwLock<ContextInner>>` read-path lock has been
 # eliminated (it is now a lock-free `Arc<ArcSwap<ContextState>>`; see
-# `context::ContextHandle`), and `check-deleted-primitives.sh` bans the
-# `RwLock<ContextInner>` shape from reappearing. The blanket
-# `tokio::sync::RwLock` `disallowed-types` ban lands as a separate follow-up
-# (ADR-049 §Decision 12 PR2) so it can sweep any remaining `RwLock` sites in
-# one focused pass.
+# `context::ContextHandle`, ADR-049 §Decision 12 / #2047), and
+# `check-deleted-primitives.sh` bans the `RwLock<ContextInner>` shape from
+# reappearing. The credential store's read-path `tokio::sync::RwLock` was
+# migrated to `std::sync::RwLock` (#2044). With both blockers cleared,
+# scp-runtime is free of `tokio::sync::RwLock`, so the blanket
+# `disallowed-types` ban is now landed to keep it that way — same lock-free
+# read-path invariant as the Mutex ban. Sanctioned exceptions (should any
+# arise) carry an `#[allow(clippy::disallowed_types, reason = "…")]`.
 disallowed-types = [
     { path = "std::sync::Mutex", reason = "Use tokio::sync::Mutex in runtime async code; actor-owned state needs no Mutex. See ADR-049." },
     { path = "tokio::sync::Mutex", reason = "ADR-049 §Decision 12: forbidden on read paths. Use ArcSwap+write_lock, OnceLock/AtomicU64/DashMap, or the actor-owned &mut PerContextState. Sanctioned exceptions carry an #[allow(clippy::disallowed_types, reason = \"ADR-049 §Decision 12 allow-list: …\")]." },
+    { path = "tokio::sync::RwLock", reason = "ADR-049 §Decision 12: forbidden on read paths. Use ArcSwap+write_lock, OnceLock/AtomicU64/DashMap, or the actor-owned &mut PerContextState. Sanctioned exceptions carry an #[allow(clippy::disallowed_types, reason = \"ADR-049 §Decision 12 allow-list: …\")]." },
 ]


### PR DESCRIPTION
## What

Adds `tokio::sync::RwLock` to the `disallowed-types` allow-list-backed ban in `crates/scp-runtime/clippy.toml`, and flips the clippy.toml comment block from "deferred to PR2" to landed.

This is the sanctioned kind of enforcement change: **adding a new ban entry** (expanding coverage). No `#[allow]`s were added to force it — scp-runtime is already free of `tokio::sync::RwLock`.

## Why now — both blockers cleared

The blanket ban was deliberately deferred (PR2) until the last two read-path `tokio::sync::RwLock` consumers in scp-runtime were removed:

1. **ContextInner removal (#2047):** the legacy `ContextHandle.inner: Arc<RwLock<ContextInner>>` read-path lock is now a lock-free `Arc<ArcSwap<ContextState>>`. `check-deleted-primitives.sh` already bans the `RwLock<ContextInner>` shape from reappearing.
2. **Credential store migration (#2044):** the credential store's `tokio::sync::RwLock` was migrated to `std::sync::RwLock` (all locked ops are sync, none held across `.await`).

With both cleared, `grep -rn "tokio::sync::RwLock" crates/scp-runtime/src/` returns **0 sites**, so the blanket ban is safe to activate and keeps the crate that way. Same lock-free read-path invariant as the existing `tokio::sync::Mutex` ban (ADR-049 §Decision-12; empirical anchor OpenSSL #30659, ~4× an atomic load on read acquire).

## Verification

- `grep -rn "tokio::sync::RwLock" crates/scp-runtime/src/` → 0 sites (incl. no grouped/aliased imports).
- Full CI clippy line passes clean: `cargo clippy --workspace --all-targets --features scp-ffi-uniffi/allow_in_memory_custody,scp-ffi/allow_in_memory_custody,scp-ffi-napi/allow_in_memory_custody,scp-core/testing,scp-runtime/testing -- -D warnings`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)