### PR TITLE
fix(ffi): drop custody shard guard before block_on in resolve_signing_key (closes #1940)

### DIFF
--- a/crates/scp-ffi/src/context.rs
+++ b/crates/scp-ffi/src/context.rs
@@ -1501,17 +1501,24 @@ pub(crate) fn resolve_signing_key(
     identity_did: &str,
 ) -> PyResult<ed25519_dalek::SigningKey> {
     let rt = crate::runtime()?;
-    crate::runtime::with_identity(bi, identity_did, |entry| {
-        let handle = entry.identity.active_signing_key;
-        let custody = entry.custody.clone();
-        rt.block_on(async move { custody.export_ed25519_signing_key(&handle).await })
-            .map_err(|e| {
-                crate::error::ScpPyError::context(format!(
-                    "failed to export signing key for governance: {e}"
-                ))
-            })
+    // Copy the key handle and clone the custody `Arc` OUT of the `with_identity`
+    // closure, then DROP the DashMap identity-registry shard guard (by exiting
+    // the closure) BEFORE the blocking async export. The `block_on` at the FFI
+    // sync boundary is the ADR-049 §12-14-exempt class and stays; the hazard is
+    // holding a sharded read guard across a (potentially slow / HSM-backed /
+    // callback) async export, which pins a runtime worker and blocks any writer
+    // of the same shard for its duration. The export operates only on the cloned
+    // `custody`/`handle` and never re-touches the registry, so the clone-then-drop
+    // reorder is sufficient — same shape as the DashMap-ref-before-await fixes
+    // elsewhere. See GitHub issue #1940.
+    let (custody, handle) = crate::runtime::with_identity(bi, identity_did, |entry| {
+        Ok((entry.custody.clone(), entry.identity.active_signing_key))
     })
-    .map_err(|e| PyRuntimeError::new_err(e.to_string()))
+    .map_err(|e| PyRuntimeError::new_err(e.to_string()))?;
+    rt.block_on(async move { custody.export_ed25519_signing_key(&handle).await })
+        .map_err(|e| {
+            PyRuntimeError::new_err(format!("failed to export signing key for governance: {e}"))
+        })
 }
 
 /// Helper: resolve the Ed25519 *verifying* key for an identity DID without


### PR DESCRIPTION
Closes #1940. `resolve_signing_key` (`crates/scp-ffi/src/context.rs`) held a DashMap identity-registry shard read guard across a blocking `rt.block_on(custody.export_ed25519_signing_key(...))` — pinning a runtime worker + blocking any writer of that shard for the export's duration (potentially slow / HSM-backed).

## Fix (minimal lock-hygiene reorder)
Clone the `Arc<custody>` + copy the `KeyHandle` (Copy) OUT of the `with_identity` closure, drop the shard guard (exit the closure), THEN `block_on` the async export. The export operates only on the clones and never re-touches the registry, so the reorder is sufficient — same shape `spawn_from_welcome` already uses. The `block_on` (FFI sync boundary, ADR-049-exempt) is unchanged. `resolve_context_signing_key` (saga path) delegates here, so it inherits the fix.

## Scope
Fixes only the signing-key export path #1940 names. Sibling `with_identity`-guard-across-`block_on` sites (`resolve_verifying_key`, pseudonym export, author-signing paths) filed as #2055 (each needs individual analysis).

## Gates
fmt · clippy `-D warnings` (all features) · `cargo nextest -p scp-ffi` (signing/identity/saga) **48 passed** · check-block-in-place (unchanged) · handle-affinity / bridge-symmetry / cross-layer / call-invariants all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)