### PR TITLE
ADR-049 Decision-7 PR-3: async transport traits + fail-closed commit-broadcast durability (incl. §9.12 recovery)

### DIFF
--- a/crates/scp-runtime/examples/support/mod.rs
+++ b/crates/scp-runtime/examples/support/mod.rs
@@ -50,21 +50,26 @@ pub fn example_mls_storage()
 /// Mock transport provider — reports connected, all sends succeed silently.
 pub struct MockTransport;
 
+#[async_trait::async_trait]
 impl ContextTransportProvider for MockTransport {
     fn is_connected(&self) -> bool {
         true
     }
-    fn publish_context(
+    async fn publish_context(
         &self,
         _id: &[u8; 32],
         _params: &ContextParams,
     ) -> Result<(), ContextCreationError> {
         Ok(())
     }
-    fn delete_published(&self, _id: &[u8; 32]) -> Result<(), ContextCreationError> {
+    async fn delete_published(&self, _id: &[u8; 32]) -> Result<(), ContextCreationError> {
         Ok(())
     }
-    fn send_message(&self, _id: &[u8; 32], _encrypted_payload: &[u8]) -> Result<(), ContextError> {
+    async fn send_message(
+        &self,
+        _id: &[u8; 32],
+        _encrypted_payload: &[u8],
+    ) -> Result<(), ContextError> {
         Ok(())
     }
 }

--- a/crates/scp-runtime/src/context/actor/class_s.rs
+++ b/crates/scp-runtime/src/context/actor/class_s.rs
@@ -431,6 +431,28 @@ impl<'a> ClassSMut<'a> {
     pub(crate) const fn rest_mut(&mut self) -> &mut PerContextState {
         self.state
     }
+
+    /// The three disjoint Class-C `&mut` fields the MLS-Commit broadcast-failure
+    /// apply ([`crate::context::governance_helpers::apply_broadcast_failure`])
+    /// mutates, bundled so a caller can pass all three at once. The MIRROR of
+    /// [`ClassCMut::commit_broadcast_borrows`], but supplied from this
+    /// Class-S-capable view so the apply rides the owning combinator's
+    /// **fail-closed** persist: the safety-gated commit-broadcast sites
+    /// ([`crate::context::governance_helpers::keep_broadcast_failure`]) build the
+    /// borrows HERE — inside a `commit_class_s_keep` closure — rather than through
+    /// the coalesced `ClassCMut` view, so the `commit_fault` safety gate and the
+    /// `pending_commits` retry entry survive a crash before the ≤50 ms persist
+    /// tick. Each is a distinct field of the underlying `PerContextState`, so the
+    /// simultaneous `&mut` is sound by construction.
+    pub(crate) const fn commit_broadcast_borrows(
+        &mut self,
+    ) -> crate::context::governance_helpers::CommitBroadcastBorrows<'_> {
+        crate::context::governance_helpers::CommitBroadcastBorrows {
+            pending_commits: &mut self.state.pending_commits,
+            commit_fault: &mut self.state.commit_fault,
+            receive_buffer: &mut self.state.receive_buffer,
+        }
+    }
 }
 
 impl Deref for ClassSMut<'_> {

--- a/crates/scp-runtime/src/context/actor/class_s.rs
+++ b/crates/scp-runtime/src/context/actor/class_s.rs
@@ -2482,11 +2482,13 @@ impl<'a> ClassCMut<'a> {
         self.commit_fault
     }
 
-    /// The three disjoint Class-C `&mut` fields the MLS-Commit broadcast helper
-    /// ([`crate::context::governance_helpers::try_broadcast_commit_or_enqueue`])
+    /// The three disjoint Class-C `&mut` fields the MLS-Commit broadcast-failure
+    /// apply ([`crate::context::governance_helpers::apply_broadcast_failure`])
     /// mutates, bundled so a cell holder can pass all three at once. Each is a
     /// distinct field of this view, so the simultaneous `&mut` is sound by
-    /// construction; all three are Class-C / structural / best-effort.
+    /// construction. This view supplies them COALESCED (best-effort); the
+    /// safety-gated sites instead supply them from a `commit_class_s_keep`
+    /// `rest_mut()` view for a fail-closed persist.
     pub(crate) const fn commit_broadcast_borrows(
         &mut self,
     ) -> crate::context::governance_helpers::CommitBroadcastBorrows<'_> {

--- a/crates/scp-runtime/src/context/actor/handlers/broadcast.rs
+++ b/crates/scp-runtime/src/context/actor/handlers/broadcast.rs
@@ -454,6 +454,7 @@ async fn handle_apply_broadcast_publish(
             &p.signature,
             &p.payload,
         )
+        .await
     };
 
     let (outcome, reply_result) = match tokio::time::timeout(HANDLER_TIMEOUT, apply_fut).await {

--- a/crates/scp-runtime/src/context/actor/handlers/governance.rs
+++ b/crates/scp-runtime/src/context/actor/handlers/governance.rs
@@ -903,7 +903,7 @@ struct CommitRetryOutcome {
 /// with no `&state` borrow held. The actor's `dispatch_state` arm owns
 /// the `&mut state` borrow exclusively for the command's lifetime so
 /// no other command can interleave between Phase A and Phase B.
-fn compute_commit_retry_outcomes(
+async fn compute_commit_retry_outcomes(
     snapshot: &[crate::context::state::PendingCommit],
     now: u64,
     transport: &dyn crate::context::builder::ContextTransportProvider,
@@ -927,7 +927,10 @@ fn compute_commit_retry_outcomes(
             });
             continue;
         }
-        match transport.send_message(&pending.routing_id, &pending.commit_bytes) {
+        match transport
+            .send_message(&pending.routing_id, &pending.commit_bytes)
+            .await
+        {
             Ok(()) => {
                 outcomes.push(CommitRetryOutcome {
                     index: idx,
@@ -1103,7 +1106,7 @@ async fn handle_process_pending_commits_actor(
     let now = deps.clock.now_secs();
     let context_id = cell.handle.context_id().to_owned();
 
-    let outcomes = compute_commit_retry_outcomes(&snapshot, now, deps.transport.as_ref());
+    let outcomes = compute_commit_retry_outcomes(&snapshot, now, deps.transport.as_ref()).await;
     if outcomes.is_empty() {
         let _ = reply.send(Ok(()));
         return Outcome::ok(());

--- a/crates/scp-runtime/src/context/actor/handlers/messaging.rs
+++ b/crates/scp-runtime/src/context/actor/handlers/messaging.rs
@@ -45,7 +45,6 @@ use crate::context::actor::commands::MessagingCommand;
 use crate::context::actor::deps::ActorDeps;
 use crate::context::actor::outcome::Outcome;
 use crate::context::actor::sequence::SequenceReservation;
-use crate::context::actor::state::PerContextState;
 
 /// Per-call transport budget for mutation handlers. Plan §"Transport
 /// timeouts inside actor handlers": 30 seconds.
@@ -157,6 +156,7 @@ pub(crate) async fn dispatch(
             reply,
         } => {
             handle_build_local_checkpoint(cell, deps, &context_id, &sender_did, &signing_key, reply)
+                .await
         }
         MessagingCommand::CompareRemoteCheckpoint {
             context_id,
@@ -168,7 +168,7 @@ pub(crate) async fn dispatch(
             sender_did,
             signing_key,
             reply,
-        } => handle_send_heartbeat(&*cell, deps, &context_id, &sender_did, &signing_key, reply),
+        } => handle_send_heartbeat(cell, deps, &context_id, &sender_did, &signing_key, reply).await,
     }
 }
 
@@ -637,7 +637,7 @@ fn handle_report_degraded_mode(
 /// `tokio::time::timeout` wrapper required. Always replies
 /// `Ok(checkpoint)`; reports [`Outcome::ok_mutated`] because the
 /// checkpoint ring and counters changed.
-fn handle_build_local_checkpoint(
+async fn handle_build_local_checkpoint(
     cell: &mut crate::context::actor::class_s::ClassSCell,
     deps: &ActorDeps,
     context_id: &str,
@@ -679,7 +679,9 @@ fn handle_build_local_checkpoint(
         sender_did,
         &sk,
         &checkpoint,
-    ) {
+    )
+    .await
+    {
         tracing::warn!(
             context_id,
             error = %e,
@@ -744,17 +746,24 @@ fn handle_compare_remote_checkpoint(
 /// `Ok(())` on success, or the transport error if every fan-out send fails.
 /// The send does not mutate per-context state (it uses sequence `0` and
 /// touches no counters), so this reports [`Outcome::ok`] / [`Outcome::err`].
-fn handle_send_heartbeat(
-    state: &PerContextState,
+async fn handle_send_heartbeat(
+    cell: &mut crate::context::actor::class_s::ClassSCell,
     deps: &ActorDeps,
     context_id: &str,
     sender_did: &scp_did::DID,
     signing_key: &crate::context::actor::commands::SigningKeyBytes,
     reply: oneshot::Sender<Result<(), ContextError>>,
 ) -> Outcome<()> {
+    // Take `&mut ClassSCell` (Send) rather than `&PerContextState` (`!Sync`, so
+    // `&PerContextState` is `!Send`): this async handler holds the borrow across
+    // the `send_heartbeat` await, so the borrow must be `Send` for the spawned
+    // actor future. `send_heartbeat` reads the shared `&*cell` in its sync
+    // prelude (ADR-049 Decision 7).
     let sk = signing_key.to_signing_key();
-    let result =
-        crate::context::messaging_helpers::send_heartbeat(deps, state, context_id, sender_did, &sk);
+    let result = crate::context::messaging_helpers::send_heartbeat(
+        deps, &*cell, context_id, sender_did, &sk,
+    )
+    .await;
     match result {
         Ok(()) => {
             let _ = reply.send(Ok(()));

--- a/crates/scp-runtime/src/context/actor/handlers/messaging.rs
+++ b/crates/scp-runtime/src/context/actor/handlers/messaging.rs
@@ -746,6 +746,15 @@ fn handle_compare_remote_checkpoint(
 /// `Ok(())` on success, or the transport error if every fan-out send fails.
 /// The send does not mutate per-context state (it uses sequence `0` and
 /// touches no counters), so this reports [`Outcome::ok`] / [`Outcome::err`].
+// `needless_pass_by_ref_mut`: the `&mut ClassSCell` is only read (`&*cell`), but
+// the `&mut` is load-bearing for Send — this async handler holds the cell borrow
+// across the `send_heartbeat` await, and `&mut ClassSCell` is Send whereas
+// `&PerContextState` (`!Sync`) would be `!Send` and break the spawned actor
+// future. Same rationale as the module-level allow in the `*_helpers` modules.
+#[allow(
+    clippy::needless_pass_by_ref_mut,
+    reason = "&mut ClassSCell held across await must be Send; &PerContextState is !Send (ADR-049 Decision 7)"
+)]
 async fn handle_send_heartbeat(
     cell: &mut crate::context::actor::class_s::ClassSCell,
     deps: &ActorDeps,

--- a/crates/scp-runtime/src/context/actor/handlers/trust_recovery.rs
+++ b/crates/scp-runtime/src/context/actor/handlers/trust_recovery.rs
@@ -256,6 +256,7 @@ async fn handle_recovery_send_notification(
             p.sequence,
             &signing_key,
         )
+        .await
     };
 
     let (outcome, reply_result) = match tokio::time::timeout(HANDLER_TIMEOUT, send_fut).await {

--- a/crates/scp-runtime/src/context/agent_binding_pipeline_tests.rs
+++ b/crates/scp-runtime/src/context/agent_binding_pipeline_tests.rs
@@ -461,12 +461,13 @@ mod live_supervisor_send {
         }
     }
 
+    #[async_trait::async_trait]
     impl ContextTransportProvider for CapturingTransport {
         fn is_connected(&self) -> bool {
             true
         }
 
-        fn publish_context(
+        async fn publish_context(
             &self,
             _context_id: &[u8; 32],
             _params: &ContextParams,
@@ -474,11 +475,14 @@ mod live_supervisor_send {
             Ok(())
         }
 
-        fn delete_published(&self, _context_id: &[u8; 32]) -> Result<(), ContextCreationError> {
+        async fn delete_published(
+            &self,
+            _context_id: &[u8; 32],
+        ) -> Result<(), ContextCreationError> {
             Ok(())
         }
 
-        fn send_message(
+        async fn send_message(
             &self,
             context_id: &[u8; 32],
             encrypted_payload: &[u8],

--- a/crates/scp-runtime/src/context/broadcast_helpers.rs
+++ b/crates/scp-runtime/src/context/broadcast_helpers.rs
@@ -368,7 +368,7 @@ pub fn reserve_broadcast_publish(
 ///   context.
 /// - [`ContextError::CryptoFailed`] on a signature-length mismatch, an
 ///   epoch change between phases, or a seal failure.
-pub fn apply_broadcast_publish(
+pub async fn apply_broadcast_publish(
     cell: &mut ClassSCell,
     deps: &ActorDeps,
     context_id: &str,
@@ -404,6 +404,7 @@ pub fn apply_broadcast_publish(
         signature,
         payload,
     )
+    .await
 }
 
 /// Relay routing id under which a sealed broadcast envelope is published.
@@ -427,7 +428,7 @@ fn broadcast_publish_routing_id(context_id: &str) -> [u8; 32] {
 /// Inner apply body. Separated so the caller-facing
 /// [`apply_broadcast_publish`] can guarantee the reserved sequence is
 /// released on every error path.
-fn apply_guarded(
+async fn apply_guarded(
     cell: &mut ClassSCell,
     deps: &ActorDeps,
     context_id: &str,
@@ -468,7 +469,9 @@ fn apply_guarded(
 
     let envelope_bytes = rmp_serde::to_vec_named(&envelope)
         .map_err(|e| ContextError::CryptoFailed(format!("envelope serialization: {e}")))?;
-    deps.transport.send_message(routing_id, &envelope_bytes)?;
+    deps.transport
+        .send_message(routing_id, &envelope_bytes)
+        .await?;
 
     // `MessageSent` is no longer a durable Merkle leaf — per ADR-051 §6 / the
     // phase-2.md ADR-011 amendment exclusion taxonomy §2 it is a per-author,

--- a/crates/scp-runtime/src/context/builder.rs
+++ b/crates/scp-runtime/src/context/builder.rs
@@ -30,6 +30,21 @@ pub use scp_protocol::context::builder::{
 ///
 /// Implementors handle relay connectivity checks and context publication /
 /// deletion.
+///
+/// # Async discipline (ADR-049 Decision 7)
+///
+/// This is a partial-async trait. The transport-I/O methods (`publish_context`,
+/// `delete_published`, `send_message`, `send_to_routing_id`,
+/// `publish_key_package`) are `async` and `.await` the underlying async
+/// transport adapter directly — the `block_in_place` sync→async bridge in
+/// `scp-transport`'s `RelayTransportProvider` is deleted. The `is_connected`
+/// method stays **sync**: it reads an `AtomicBool` and touches no async I/O.
+/// This is the ADR's explicit `is_connected`-stays-sync carve-out.
+///
+/// Held as `Arc<dyn ContextTransportProvider>` inside `ActorDeps` (moved into
+/// `tokio::spawn`), so the async futures must be **Send** — plain
+/// `#[async_trait]`, not `?Send`.
+#[async_trait::async_trait]
 pub trait ContextTransportProvider: Send + Sync {
     /// Returns `true` if the transport layer is connected and at least one
     /// relay is reachable.
@@ -40,7 +55,7 @@ pub trait ContextTransportProvider: Send + Sync {
     /// # Errors
     ///
     /// Returns [`ContextCreationError`] if publication fails.
-    fn publish_context(
+    async fn publish_context(
         &self,
         context_id: &[u8; 32],
         params: &ContextParams,
@@ -52,7 +67,7 @@ pub trait ContextTransportProvider: Send + Sync {
     ///
     /// Returns [`ContextCreationError`] if deletion fails. Callers may
     /// ignore this error during rollback (best-effort).
-    fn delete_published(&self, context_id: &[u8; 32]) -> Result<(), ContextCreationError>;
+    async fn delete_published(&self, context_id: &[u8; 32]) -> Result<(), ContextCreationError>;
 
     // -- Messaging operations (SCP-020) ------------------------------------
 
@@ -61,7 +76,7 @@ pub trait ContextTransportProvider: Send + Sync {
     /// # Errors
     ///
     /// Returns [`ContextError::TransportFailed`] if sending fails.
-    fn send_message(
+    async fn send_message(
         &self,
         context_id: &[u8; 32],
         encrypted_payload: &[u8],
@@ -76,7 +91,7 @@ pub trait ContextTransportProvider: Send + Sync {
     /// # Errors
     ///
     /// Returns [`ContextError::TransportFailed`] if sending fails.
-    fn send_to_routing_id(
+    async fn send_to_routing_id(
         &self,
         _routing_id: &[u8; 32],
         _payload: &[u8],
@@ -114,7 +129,11 @@ pub trait ContextTransportProvider: Send + Sync {
     /// # Errors
     ///
     /// Returns [`ContextError::TransportFailed`] if publication fails.
-    fn publish_key_package(&self, _owner_did: &str, _kp_bytes: &[u8]) -> Result<(), ContextError> {
+    async fn publish_key_package(
+        &self,
+        _owner_did: &str,
+        _kp_bytes: &[u8],
+    ) -> Result<(), ContextError> {
         Err(ContextError::TransportFailed(
             "publish_key_package not supported".into(),
         ))
@@ -532,12 +551,13 @@ pub trait ContextEventLogProvider: Send + Sync {
 /// production builds and carries no failure-injection machinery.
 pub struct LocalTransportProvider;
 
+#[async_trait::async_trait]
 impl ContextTransportProvider for LocalTransportProvider {
     fn is_connected(&self) -> bool {
         true
     }
 
-    fn publish_context(
+    async fn publish_context(
         &self,
         _context_id: &[u8; 32],
         _params: &ContextParams,
@@ -545,11 +565,11 @@ impl ContextTransportProvider for LocalTransportProvider {
         Ok(())
     }
 
-    fn delete_published(&self, _context_id: &[u8; 32]) -> Result<(), ContextCreationError> {
+    async fn delete_published(&self, _context_id: &[u8; 32]) -> Result<(), ContextCreationError> {
         Ok(())
     }
 
-    fn send_message(
+    async fn send_message(
         &self,
         _context_id: &[u8; 32],
         _encrypted_payload: &[u8],
@@ -573,12 +593,13 @@ impl ContextTransportProvider for LocalTransportProvider {
 /// successfully when no relay is actually reachable.
 pub struct NotConfiguredTransportProvider;
 
+#[async_trait::async_trait]
 impl ContextTransportProvider for NotConfiguredTransportProvider {
     fn is_connected(&self) -> bool {
         false
     }
 
-    fn publish_context(
+    async fn publish_context(
         &self,
         _context_id: &[u8; 32],
         _params: &ContextParams,
@@ -590,7 +611,7 @@ impl ContextTransportProvider for NotConfiguredTransportProvider {
         ))
     }
 
-    fn delete_published(&self, _context_id: &[u8; 32]) -> Result<(), ContextCreationError> {
+    async fn delete_published(&self, _context_id: &[u8; 32]) -> Result<(), ContextCreationError> {
         Err(ContextCreationError::TransportFailed(
             "transport not configured — call transport_connect() to set up a relay \
              before deleting published contexts"
@@ -598,7 +619,7 @@ impl ContextTransportProvider for NotConfiguredTransportProvider {
         ))
     }
 
-    fn send_message(
+    async fn send_message(
         &self,
         _context_id: &[u8; 32],
         _encrypted_payload: &[u8],
@@ -723,7 +744,7 @@ impl CreationReceipt {
         if self.published {
             // Best-effort: relays are untrusted, orphaned blobs are encrypted
             // with destroyed keys.
-            let _ = transport.delete_published(context_id);
+            let _ = transport.delete_published(context_id).await;
         }
         if self.event_log.is_some() {
             let _ = event_log.destroy_event_log(context_id).await;
@@ -955,7 +976,7 @@ pub async fn create_context(
     // warning and continue.  The context won't be discoverable via
     // relay until a subsequent publish or sync, but all local state
     // (MLS group, sender key, event log) remains valid.
-    match transport.publish_context(&id_bytes, &params) {
+    match transport.publish_context(&id_bytes, &params).await {
         Ok(()) => {
             receipt.published = true;
         }
@@ -1057,21 +1078,22 @@ mod tests {
     const TEST_DID: &str = "did:dht:z6MkhaXgBZDvotDkL5257faiztiGiC2QtKLGpbnnEGta2doK";
 
     struct TestTransport;
+    #[async_trait::async_trait]
     impl ContextTransportProvider for TestTransport {
         fn is_connected(&self) -> bool {
             true
         }
-        fn publish_context(
+        async fn publish_context(
             &self,
             _: &[u8; 32],
             _: &ContextParams,
         ) -> Result<(), ContextCreationError> {
             Ok(())
         }
-        fn delete_published(&self, _: &[u8; 32]) -> Result<(), ContextCreationError> {
+        async fn delete_published(&self, _: &[u8; 32]) -> Result<(), ContextCreationError> {
             Ok(())
         }
-        fn send_message(&self, _: &[u8; 32], _: &[u8]) -> Result<(), ContextError> {
+        async fn send_message(&self, _: &[u8; 32], _: &[u8]) -> Result<(), ContextError> {
             Ok(())
         }
     }

--- a/crates/scp-runtime/src/context/governance_helpers.rs
+++ b/crates/scp-runtime/src/context/governance_helpers.rs
@@ -989,7 +989,9 @@ pub async fn execute_revoke(
             deps,
             context_id,
             &context_id_bytes,
-        ) {
+        )
+        .await
+        {
             tracing::warn!(
                 context_id = %context_id,
                 error = %e,
@@ -1244,29 +1246,34 @@ pub async fn execute_add_member(
                 deps.event_tx.as_ref(),
             );
         }
-
-        // ROOT FIX (parity with `execute_remove_member` / `execute_reset_member`):
-        // broadcast the MLS Commit to the EXISTING members. An MLS Add advances
-        // the group epoch exactly like a Remove, so without this the add's
-        // Commit was only buffered into the (broadcast-suppressed)
-        // `WelcomeGenerated` event and NEVER reached the group — every existing
-        // member desynced from the admin after any add. Routed through the same
-        // persistent retry queue (`try_broadcast_commit_or_enqueue`) as the
-        // remove/reset commits. A no-op when `commit_for_broadcast` is empty
-        // (the `cfg(test)` no-crypto pipeline).
-        if !commit_for_broadcast.is_empty() {
-            try_broadcast_commit_or_enqueue(
-                view.commit_broadcast_borrows(),
-                deps,
-                context_id,
-                commit_for_broadcast,
-                &CommitOperation::AddMember {
-                    target_did: did.clone(),
-                },
-            );
-        }
     })
     .await;
+
+    // ROOT FIX (parity with `execute_remove_member` / `execute_reset_member`):
+    // broadcast the MLS Commit to the EXISTING members. An MLS Add advances the
+    // group epoch exactly like a Remove, so without this the add's Commit was only
+    // buffered into the (broadcast-suppressed) `WelcomeGenerated` event and NEVER
+    // reached the group — every existing member desynced from the admin after any
+    // add. Routed through the same persistent retry queue
+    // (`try_broadcast_commit_or_enqueue`) as the remove/reset commits. A no-op
+    // when `commit_for_broadcast` is empty (the `cfg(test)` no-crypto pipeline).
+    //
+    // Hoisted AFTER the best-effort persist above (ADR-049 Decision 7 — transport
+    // is async and cannot be awaited inside the sync closure). The enqueue is
+    // Class-C (coalesced — picked up by the actor's persist tick), which is its
+    // correct class.
+    if !commit_for_broadcast.is_empty() {
+        try_broadcast_commit_or_enqueue(
+            cell.class_c_view().commit_broadcast_borrows(),
+            deps,
+            context_id,
+            commit_for_broadcast,
+            &CommitOperation::AddMember {
+                target_did: did.clone(),
+            },
+        )
+        .await;
+    }
 
     // Subject-bearing leaf (ADR-011 amendment): carry the *affected member*
     // (`did`) in the payload, not just `actor_did` (which on this admin-driven
@@ -1318,7 +1325,7 @@ pub async fn execute_remove_member(
     // where the fail-close `commit_fault` marker is set but NOT persisted before
     // the early return). All structural mutations + emit + broadcast + sender-
     // key drain ride the SAME fail-closed persist via `view.rest_mut()`.
-    let removed_role_name = cell
+    let (removed_role_name, remove_commit_bytes) = cell
         .commit_class_s_keep(deps, context_id, |mut view| {
             let state = view.rest_mut();
 
@@ -1353,7 +1360,7 @@ pub async fn execute_remove_member(
                     "remove_member_sender_key",
                     &e.to_string(),
                 )
-                .map(|()| String::new());
+                .map(|()| (String::new(), None));
             }
 
             if let Err(e) = deps.crypto.rotate_sender_key(&context_id_bytes) {
@@ -1365,7 +1372,7 @@ pub async fn execute_remove_member(
                     "rotate_sender_key",
                     &e.to_string(),
                 )
-                .map(|()| String::new());
+                .map(|()| (String::new(), None));
             }
 
             state.membership.remove_member(did);
@@ -1403,35 +1410,52 @@ pub async fn execute_remove_member(
                 deps,
             );
 
-            try_broadcast_commit_or_enqueue(
-                CommitBroadcastBorrows {
-                    pending_commits: &mut state.pending_commits,
-                    commit_fault: &mut state.commit_fault,
-                    receive_buffer: &mut state.receive_buffer,
-                },
-                deps,
-                context_id,
-                remove_output.commit_bytes,
-                &CommitOperation::RemoveMember {
-                    target_did: did.clone(),
-                },
-            );
-
-            // Phase 2A.9: drain_and_deliver_sender_keys is now actor-shape.
-            if let Err(e) = crate::context::lifecycle_helpers::drain_and_deliver_sender_keys(
-                deps,
-                context_id,
-                &context_id_bytes,
-            ) {
-                tracing::warn!(
-                    context_id = %context_id,
-                    error = %e,
-                    "failed to deliver rotated sender keys after member removal"
-                );
-            }
-            Ok(removed_role_name)
+            // Capture the removal Commit bytes; the ASYNC broadcast + sender-key
+            // delivery run AFTER the fail-closed persist, outside this sync
+            // `_keep` closure (ADR-049 Decision 7 — transport is async). `None`
+            // on the fail-close paths above, which skip the broadcast/drain
+            // exactly as the pre-hoist early returns did.
+            Ok((removed_role_name, Some(remove_output.commit_bytes)))
         })
         .await?;
+
+    // Async transport ops AFTER the Class-S removal persist (ADR-049 Decision 7:
+    // `ContextTransportProvider` is async and cannot be awaited inside the sync
+    // `_keep` closure above). The membership removal is already
+    // fail-closed-persisted; the Commit-broadcast enqueue is Class-C (coalesced —
+    // picked up by the actor's persist tick) and the sender-key delivery is
+    // best-effort. `remove_commit_bytes` is `Some` only on the success path (the
+    // fail-close paths return `None` and skip both, matching pre-hoist ordering);
+    // it is the removal Commit already produced under the crypto `Arc` (Class-M)
+    // inside the closure.
+    if let Some(remove_commit_bytes) = remove_commit_bytes {
+        try_broadcast_commit_or_enqueue(
+            cell.class_c_view().commit_broadcast_borrows(),
+            deps,
+            context_id,
+            remove_commit_bytes,
+            &CommitOperation::RemoveMember {
+                target_did: did.clone(),
+            },
+        )
+        .await;
+
+        // Phase 2A.9: drain_and_deliver_sender_keys is now actor-shape.
+        if let Err(e) = crate::context::lifecycle_helpers::drain_and_deliver_sender_keys(
+            deps,
+            context_id,
+            &context_id_bytes,
+        )
+        .await
+        {
+            tracing::warn!(
+                context_id = %context_id,
+                error = %e,
+                "failed to deliver rotated sender keys after member removal"
+            );
+        }
+    }
+
     // Subject-bearing leaf (ADR-011 amendment): carry the *affected member*
     // (`did`) and the role it held at departure, not just `actor_did` (the
     // executing admin). Participation `participation_duration_secs` (§7.3.2)
@@ -2441,7 +2465,8 @@ pub async fn execute_reset_member(
             target_did: did.clone(),
             is_remove: true,
         },
-    );
+    )
+    .await;
     try_broadcast_commit_or_enqueue(
         view.commit_broadcast_borrows(),
         deps,
@@ -2451,7 +2476,8 @@ pub async fn execute_reset_member(
             target_did: did.clone(),
             is_remove: false,
         },
-    );
+    )
+    .await;
 
     if let Err(e) = deps
         .crypto
@@ -2478,7 +2504,9 @@ pub async fn execute_reset_member(
         deps,
         context_id,
         &context_id_bytes,
-    ) {
+    )
+    .await
+    {
         tracing::warn!(
             context_id = %context_id,
             error = %e,
@@ -2722,75 +2750,85 @@ pub async fn execute_rotate_content_keys(
     // through `commit_class_s_keep` so it persists fail-closed (keep-direction:
     // on persist failure the rotation STAYS — reverting to the pre-rotation key
     // state after the rotation was acknowledged is the unsafe direction). The
-    // crypto/access-key mutations + emit + broadcast enqueue (Class-C) ride the
-    // SAME fail-closed persist via `view.rest_mut()`. Broadcast per-author key
-    // epochs now ride the Class-S `ContextSnapshot`, so the all-author key-epoch
-    // advance persists fail-closed atomically inside the combinator — the prior
-    // trailing best-effort `persist_broadcast_snapshot` is gone (§5.14.8).
-    cell.commit_class_s_keep(deps, context_id, |mut view| {
-        let state = view.rest_mut();
-        require_active(&state.handle)?;
+    // crypto/access-key mutations + emit ride the fail-closed persist via
+    // `view.rest_mut()`. The MLS-Commit broadcast ENQUEUE (Class-C) is hoisted to
+    // AFTER the persist (ADR-049 Decision 7 — transport is async and cannot be
+    // awaited inside the sync closure); it is coalesced, not fail-closed, which is
+    // its correct class. Broadcast per-author key epochs still ride the Class-S
+    // `ContextSnapshot`, so the all-author key-epoch advance persists fail-closed
+    // atomically inside the combinator — the prior trailing best-effort
+    // `persist_broadcast_snapshot` is gone (§5.14.8).
+    let rotate_commit_bytes = cell
+        .commit_class_s_keep(deps, context_id, |mut view| {
+            let state = view.rest_mut();
+            require_active(&state.handle)?;
 
-        let epoch_output = if let Some(ref mut bc) = state.broadcast_context {
-            bc.rotate_all_author_keys()?;
-            None
-        } else {
-            let epoch_out = deps.crypto.advance_epoch(&context_id_bytes)?;
+            let epoch_output = if let Some(ref mut bc) = state.broadcast_context {
+                bc.rotate_all_author_keys()?;
+                None
+            } else {
+                let epoch_out = deps.crypto.advance_epoch(&context_id_bytes)?;
 
-            let member_dids: Vec<String> = state
-                .membership
-                .member_dids()
-                .map(|d| d.0.clone())
-                .collect();
-            let current_epoch = state
-                .access
-                .access_key_store
-                .get_all(context_id)
-                .values()
-                .map(scp_protocol::crypto::access_keys::AccessKey::epoch)
-                .max()
-                .unwrap_or(0);
-            let did_refs: Vec<&str> = member_dids.iter().map(String::as_str).collect();
-            let rotation = crate::crypto::access_keys::lifecycle::rotate_all_access_keys(
-                context_id,
-                &did_refs,
-                current_epoch,
-            )
-            .map_err(|e| ContextError::CryptoFailed(e.to_string()))?;
-            for new_key in rotation.new_keys {
-                let did = new_key.member_did().to_owned();
-                state.access.access_key_store.set(context_id, &did, new_key);
-            }
-            Some(epoch_out)
-        };
+                let member_dids: Vec<String> = state
+                    .membership
+                    .member_dids()
+                    .map(|d| d.0.clone())
+                    .collect();
+                let current_epoch = state
+                    .access
+                    .access_key_store
+                    .get_all(context_id)
+                    .values()
+                    .map(scp_protocol::crypto::access_keys::AccessKey::epoch)
+                    .max()
+                    .unwrap_or(0);
+                let did_refs: Vec<&str> = member_dids.iter().map(String::as_str).collect();
+                let rotation = crate::crypto::access_keys::lifecycle::rotate_all_access_keys(
+                    context_id,
+                    &did_refs,
+                    current_epoch,
+                )
+                .map_err(|e| ContextError::CryptoFailed(e.to_string()))?;
+                for new_key in rotation.new_keys {
+                    let did = new_key.member_did().to_owned();
+                    state.access.access_key_store.set(context_id, &did, new_key);
+                }
+                Some(epoch_out)
+            };
 
-        emit(
-            state,
-            ContextEvent::ContentKeysRotated {
-                reason: reason.map(String::from),
-            },
-            context_id,
-            deps,
-        );
-
-        if let Some(epoch_out) = epoch_output {
-            try_broadcast_commit_or_enqueue(
-                CommitBroadcastBorrows {
-                    pending_commits: &mut state.pending_commits,
-                    commit_fault: &mut state.commit_fault,
-                    receive_buffer: &mut state.receive_buffer,
-                },
-                deps,
-                context_id,
-                epoch_out.commit_bytes,
-                &CommitOperation::RotateContentKeys {
+            emit(
+                state,
+                ContextEvent::ContentKeysRotated {
                     reason: reason.map(String::from),
                 },
+                context_id,
+                deps,
             );
-        }
-        Ok(())
-    })
-    .await?;
+
+            // Capture the epoch-advance Commit bytes (non-broadcast path); the ASYNC
+            // Commit broadcast runs AFTER the fail-closed persist, outside this sync
+            // `_keep` closure (ADR-049 Decision 7 — transport is async). `None` on
+            // the broadcast path (no MLS Commit) or when no epoch advance occurred.
+            Ok(epoch_output.map(|epoch_out| epoch_out.commit_bytes))
+        })
+        .await?;
+
+    // Async transport op AFTER the Class-S rotation persist (ADR-049 Decision 7).
+    // The key rotation is fail-closed-persisted; the Commit-broadcast enqueue is
+    // Class-C (coalesced — picked up by the actor's persist tick). The commit
+    // bytes were produced under the crypto `Arc` (Class-M) inside the closure.
+    if let Some(commit_bytes) = rotate_commit_bytes {
+        try_broadcast_commit_or_enqueue(
+            cell.class_c_view().commit_broadcast_borrows(),
+            deps,
+            context_id,
+            commit_bytes,
+            &CommitOperation::RotateContentKeys {
+                reason: reason.map(String::from),
+            },
+        )
+        .await;
+    }
 
     deps.event_log
         .append_context_event(
@@ -5339,7 +5377,7 @@ pub struct CommitBroadcastBorrows<'a> {
 /// (never a durable Merkle leaf — see the §9.9.3 note above), and the
 /// `receive_buffer` emit is a local `ContextEvent`. None requires a fail-closed
 /// persist, so the field-granular best-effort shape is sound.
-pub fn try_broadcast_commit_or_enqueue(
+pub async fn try_broadcast_commit_or_enqueue(
     borrows: CommitBroadcastBorrows<'_>,
     deps: &ActorDeps,
     context_id: &str,
@@ -5355,7 +5393,11 @@ pub fn try_broadcast_commit_or_enqueue(
         receive_buffer,
     } = borrows;
     let routing_id = scp_protocol::context::context_routing_id(context_id);
-    match deps.transport.send_message(&routing_id, &commit_bytes) {
+    match deps
+        .transport
+        .send_message(&routing_id, &commit_bytes)
+        .await
+    {
         Ok(()) => {}
         Err(e) => {
             let now = deps.clock.now_secs();

--- a/crates/scp-runtime/src/context/governance_helpers.rs
+++ b/crates/scp-runtime/src/context/governance_helpers.rs
@@ -5949,3 +5949,604 @@ pub fn translate_timeout_events(
 
     ctx_events
 }
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used)]
+mod commit_broadcast_retry_tests {
+    //! ADR-049 Decision 7, PR-3: pins the retry-queue bookkeeping split out of
+    //! the (now async) MLS-Commit broadcast.
+    //!
+    //! [`try_broadcast_commit`] performs ONLY the async transport send and, on
+    //! failure, builds a [`BroadcastFailure`] payload (it touches no state); the
+    //! synchronous [`apply_broadcast_failure`] applies that payload to the three
+    //! disjoint Class-C fields, preserving the `MAX_PENDING_COMMITS` cap →
+    //! `commit_fault` fail-close conversion; [`keep_broadcast_failure`] rides a
+    //! second `commit_class_s_keep` so the safety-gated call sites persist the
+    //! marker + retry entry FAIL-CLOSED (§9 / §9.9.3).
+    //!
+    //! NOTE (coverage boundary): the full call sites
+    //! ([`execute_remove_member`], [`execute_rotate_content_keys`],
+    //! [`recovery_advance_epoch`], [`leave_context`]) cannot be driven end-to-end
+    //! here — under the `cfg(test)` no-crypto pipeline the MLS Commit serializes
+    //! to EMPTY bytes, so `try_broadcast_commit` short-circuits to `None` and
+    //! never reaches the fail-closed enqueue. These tests therefore exercise the
+    //! extracted helpers directly with a manufactured `BroadcastFailure` (the
+    //! payload a real failed broadcast produces) plus a real failing transport,
+    //! and drive `keep_broadcast_failure` against a real `ClassSCell` +
+    //! failing/succeeding persistence to pin the fail-closed durability. The
+    //! surrounding governance/remove/rotate/leave suites cover the call-site
+    //! wiring.
+
+    use std::collections::VecDeque;
+    use std::sync::Arc;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    use scp_did::DID;
+    use scp_protocol::context::builder::ContextCreationError;
+    use scp_protocol::context::membership::{ContextEvent, ReceiveBuffer};
+    use scp_protocol::context::{ContextError, ContextParams};
+
+    use super::{
+        CommitBroadcastBorrows, apply_broadcast_failure, keep_broadcast_failure,
+        try_broadcast_commit,
+    };
+    use crate::context::actor::class_s::ClassSCell;
+    use crate::context::actor::deps::ActorDeps;
+    use crate::context::actor::state::PerContextState;
+    use crate::context::builder::{ContextEventLogProvider, ContextTransportProvider};
+    use crate::context::persistence::ContextPersistence;
+    use crate::context::state::{
+        CommitFaultMarker, CommitOperation, MAX_PENDING_COMMITS, PendingCommit,
+    };
+
+    const ADMIN: &str = "did:dht:z6MkAdminBroadcastRetry";
+    const TARGET: &str = "did:dht:z6MkTargetBroadcastRetry";
+    const CTX_BYTE: u8 = 0x7d;
+
+    /// 64-hex context id matching `[CTX_BYTE; 32]` (the form the code under test
+    /// hashes for the routing id and keys the persisted snapshot under).
+    fn ctx_hex() -> String {
+        hex::encode([CTX_BYTE; 32])
+    }
+
+    /// A transport that records every `send_message` call and either fails or
+    /// succeeds it, deterministically. `fail == true` mirrors an unreachable
+    /// relay (the case that produces a `BroadcastFailure`).
+    struct RecordingTransport {
+        sends: Arc<AtomicUsize>,
+        fail: bool,
+    }
+
+    #[async_trait::async_trait]
+    impl ContextTransportProvider for RecordingTransport {
+        fn is_connected(&self) -> bool {
+            !self.fail
+        }
+        async fn publish_context(
+            &self,
+            _: &[u8; 32],
+            _: &ContextParams,
+        ) -> Result<(), ContextCreationError> {
+            Ok(())
+        }
+        async fn delete_published(&self, _: &[u8; 32]) -> Result<(), ContextCreationError> {
+            Ok(())
+        }
+        async fn send_message(&self, _: &[u8; 32], _: &[u8]) -> Result<(), ContextError> {
+            self.sends.fetch_add(1, Ordering::SeqCst);
+            if self.fail {
+                Err(ContextError::TransportFailed("induced send failure".into()))
+            } else {
+                Ok(())
+            }
+        }
+    }
+
+    /// Minimal event-log provider whose reads are empty (mirrors the sibling
+    /// `TestEventLog` fixtures).
+    struct TestEventLog;
+    #[async_trait::async_trait]
+    impl ContextEventLogProvider for TestEventLog {
+        async fn init_event_log(&self, _: &[u8; 32]) -> Result<(), ContextCreationError> {
+            Ok(())
+        }
+        async fn append_event(
+            &self,
+            _: &[u8; 32],
+            _event_type: scp_event_log::EventType,
+            _actor_did: &str,
+            _payload: scp_event_log::EventPayload,
+            _timestamp_secs: u64,
+        ) -> Result<(), ContextCreationError> {
+            Ok(())
+        }
+        async fn destroy_event_log(&self, _: &[u8; 32]) -> Result<(), ContextCreationError> {
+            Ok(())
+        }
+    }
+
+    /// Persistence whose every `persist_context` SUCCEEDS, counting calls — lets
+    /// the fail-closed keep test assert the marker was actually persisted before
+    /// `keep_broadcast_failure` returned `Ok`.
+    struct CountingOkPersistence {
+        persists: Arc<AtomicUsize>,
+    }
+    #[async_trait::async_trait]
+    impl ContextPersistence for CountingOkPersistence {
+        async fn persist_context(
+            &self,
+            _: &str,
+            _: &crate::context::state::ContextSnapshot,
+        ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+            self.persists.fetch_add(1, Ordering::SeqCst);
+            Ok(())
+        }
+        async fn load_context(
+            &self,
+            _: &str,
+        ) -> Result<
+            Option<crate::context::state::ContextSnapshot>,
+            Box<dyn std::error::Error + Send + Sync>,
+        > {
+            Ok(None)
+        }
+        async fn delete_context(
+            &self,
+            _: &str,
+        ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+            Ok(())
+        }
+        async fn list_persisted_contexts(
+            &self,
+        ) -> Result<Vec<String>, Box<dyn std::error::Error + Send + Sync>> {
+            Ok(Vec::new())
+        }
+    }
+
+    /// Persistence whose every `persist_context` FAILS — the fail-closed path.
+    struct FailPersistence;
+    #[async_trait::async_trait]
+    impl ContextPersistence for FailPersistence {
+        async fn persist_context(
+            &self,
+            _: &str,
+            _: &crate::context::state::ContextSnapshot,
+        ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+            Err("induced persist failure".into())
+        }
+        async fn load_context(
+            &self,
+            _: &str,
+        ) -> Result<
+            Option<crate::context::state::ContextSnapshot>,
+            Box<dyn std::error::Error + Send + Sync>,
+        > {
+            Ok(None)
+        }
+        async fn delete_context(
+            &self,
+            _: &str,
+        ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+            Ok(())
+        }
+        async fn list_persisted_contexts(
+            &self,
+        ) -> Result<Vec<String>, Box<dyn std::error::Error + Send + Sync>> {
+            Ok(Vec::new())
+        }
+    }
+
+    /// Assemble an `ActorDeps` wired with the supplied transport and persistence
+    /// (and the minimal in-memory event log + MLS storage), mirroring the
+    /// `class_s`/`governance` fail-closed test fixtures.
+    async fn build_deps(
+        transport: Box<dyn ContextTransportProvider>,
+        persistence: Box<dyn ContextPersistence>,
+    ) -> ActorDeps {
+        use crate::context::supervisor::supervisor::Supervisor;
+        use scp_platform::testing::InMemoryStorage;
+
+        let crypto = Arc::new(crate::crypto::mls::provider::MlsCryptoProvider::new(
+            ADMIN.to_owned(),
+            Arc::new(scp_clock::SystemClock),
+        ));
+        let event_log: Box<dyn ContextEventLogProvider> = Box::new(TestEventLog);
+        let key_resolver: scp_protocol::context::governance::KeyResolver = Arc::new(|_, _| None);
+        let mls_storage: Arc<dyn crate::crypto::mls::storage_adapter::OpenMlsStorageAdapter> =
+            Arc::new(
+                crate::crypto::mls::storage_adapter::SpawnBlockingStorageAdapter::new(Arc::new(
+                    InMemoryStorage::new(),
+                )),
+            );
+        let clock: Arc<dyn scp_clock::Clock> = Arc::new(scp_clock::TestClock::new(1_700_000_000));
+        let supervisor = Supervisor::with_providers(
+            crypto,
+            transport,
+            event_log,
+            key_resolver,
+            Some(persistence),
+            None,
+            None,
+            Some(clock),
+            mls_storage,
+        );
+        supervisor
+            .build_actor_deps(&DID(ADMIN.to_owned()))
+            .await
+            .expect("build_actor_deps")
+    }
+
+    /// A fresh encrypted test state with an empty pending-commit queue.
+    fn fresh_state() -> PerContextState {
+        PerContextState::new_for_test_encrypted(
+            [CTX_BYTE; 32],
+            1_700_000_000,
+            DID(ADMIN.to_owned()),
+        )
+    }
+
+    fn remove_op() -> CommitOperation {
+        CommitOperation::RemoveMember {
+            target_did: DID(TARGET.to_owned()),
+        }
+    }
+
+    /// Produce a real `BroadcastFailure` by driving `try_broadcast_commit`
+    /// against a failing transport — the exact payload a failed broadcast hands
+    /// the caller to apply.
+    async fn make_failure(deps: &ActorDeps, op: &CommitOperation) -> super::BroadcastFailure {
+        try_broadcast_commit(deps, &ctx_hex(), b"commit-bytes".to_vec(), op)
+            .await
+            .expect("failing transport yields Some(BroadcastFailure)")
+    }
+
+    // -- Test 1: normal enqueue -------------------------------------------
+
+    /// At normal capacity `apply_broadcast_failure` pushes exactly one retry
+    /// entry, leaves `commit_fault` clear, and surfaces the local
+    /// `CommitBroadcastPending` event.
+    #[tokio::test]
+    async fn apply_broadcast_failure_enqueues_at_normal_capacity() {
+        let deps = build_deps(
+            Box::new(RecordingTransport {
+                sends: Arc::new(AtomicUsize::new(0)),
+                fail: true,
+            }),
+            Box::new(FailPersistence),
+        )
+        .await;
+        let op = remove_op();
+        let failure = make_failure(&deps, &op).await;
+
+        let mut pending: VecDeque<PendingCommit> = VecDeque::new();
+        let mut commit_fault: Option<CommitFaultMarker> = None;
+        let mut receive_buffer = ReceiveBuffer::new();
+
+        apply_broadcast_failure(
+            CommitBroadcastBorrows {
+                pending_commits: &mut pending,
+                commit_fault: &mut commit_fault,
+                receive_buffer: &mut receive_buffer,
+            },
+            &deps,
+            &ctx_hex(),
+            failure,
+        );
+
+        assert_eq!(pending.len(), 1, "exactly one retry entry enqueued");
+        assert_eq!(
+            pending[0].operation, op,
+            "the enqueued entry carries the source operation"
+        );
+        assert_eq!(pending[0].retry_count, 1, "first failure ⇒ retry_count 1");
+        assert!(
+            commit_fault.is_none(),
+            "commit_fault stays clear below the queue cap"
+        );
+        assert!(
+            receive_buffer
+                .drain()
+                .iter()
+                .any(|e| matches!(e, ContextEvent::CommitBroadcastPending { .. })),
+            "a local CommitBroadcastPending event is surfaced"
+        );
+    }
+
+    // -- Test 2: queue-full → commit_fault --------------------------------
+
+    /// A full queue converts the enqueue into a fail-close `CommitFaultMarker`
+    /// (queue-full reason) WITHOUT growing the queue — pins the cap logic that
+    /// moved into `apply_broadcast_failure`.
+    #[tokio::test]
+    async fn apply_broadcast_failure_full_queue_sets_commit_fault() {
+        let deps = build_deps(
+            Box::new(RecordingTransport {
+                sends: Arc::new(AtomicUsize::new(0)),
+                fail: true,
+            }),
+            Box::new(FailPersistence),
+        )
+        .await;
+        let failure = make_failure(&deps, &remove_op()).await;
+
+        // Pre-fill the queue to exactly the cap.
+        let filler = PendingCommit {
+            commit_bytes: vec![0x01, 0x02, 0x03],
+            routing_id: [0u8; 32],
+            operation: remove_op(),
+            first_attempt_at: 1_700_000_000,
+            retry_count: 1,
+            last_error: None,
+            next_attempt_at: 1_700_000_001,
+        };
+        let mut pending: VecDeque<PendingCommit> = VecDeque::new();
+        for _ in 0..MAX_PENDING_COMMITS {
+            pending.push_back(filler.clone());
+        }
+        assert_eq!(
+            pending.len(),
+            MAX_PENDING_COMMITS,
+            "queue seeded at the cap"
+        );
+
+        let mut commit_fault: Option<CommitFaultMarker> = None;
+        let mut receive_buffer = ReceiveBuffer::new();
+
+        apply_broadcast_failure(
+            CommitBroadcastBorrows {
+                pending_commits: &mut pending,
+                commit_fault: &mut commit_fault,
+                receive_buffer: &mut receive_buffer,
+            },
+            &deps,
+            &ctx_hex(),
+            failure,
+        );
+
+        assert_eq!(
+            pending.len(),
+            MAX_PENDING_COMMITS,
+            "a full queue must NOT grow past the cap"
+        );
+        let marker = commit_fault.expect("a full queue converts the enqueue to a commit_fault");
+        assert!(
+            marker.reason.contains("queue full"),
+            "the fault records the queue-full reason; got {:?}",
+            marker.reason
+        );
+        assert_eq!(
+            marker.operation,
+            remove_op(),
+            "the fault carries the dropped operation"
+        );
+        assert!(
+            receive_buffer
+                .drain()
+                .iter()
+                .any(|e| matches!(e, ContextEvent::CommitBroadcastFailed { .. })),
+            "a local CommitBroadcastFailed event is surfaced on queue-full"
+        );
+    }
+
+    // -- Test 3: try_broadcast_commit outcomes ----------------------------
+
+    /// A transport-send error yields `Some(BroadcastFailure)` whose label
+    /// matches the operation, after exactly one send attempt.
+    #[tokio::test]
+    async fn try_broadcast_commit_returns_failure_on_transport_error() {
+        let sends = Arc::new(AtomicUsize::new(0));
+        let deps = build_deps(
+            Box::new(RecordingTransport {
+                sends: Arc::clone(&sends),
+                fail: true,
+            }),
+            Box::new(FailPersistence),
+        )
+        .await;
+        let op = CommitOperation::RotateContentKeys { reason: None };
+
+        let failure = try_broadcast_commit(&deps, &ctx_hex(), b"bytes".to_vec(), &op)
+            .await
+            .expect("transport error yields Some(BroadcastFailure)");
+
+        assert_eq!(
+            failure.label,
+            op.label(),
+            "the surfaced label matches operation.label()"
+        );
+        assert_eq!(
+            failure.pending.operation, op,
+            "the retry payload carries the source operation"
+        );
+        assert_eq!(
+            sends.load(Ordering::SeqCst),
+            1,
+            "exactly one send attempted"
+        );
+    }
+
+    /// A successful send yields `None` after exactly one send attempt.
+    #[tokio::test]
+    async fn try_broadcast_commit_returns_none_on_success() {
+        let sends = Arc::new(AtomicUsize::new(0));
+        let deps = build_deps(
+            Box::new(RecordingTransport {
+                sends: Arc::clone(&sends),
+                fail: false,
+            }),
+            Box::new(FailPersistence),
+        )
+        .await;
+
+        let out = try_broadcast_commit(
+            &deps,
+            &ctx_hex(),
+            b"bytes".to_vec(),
+            &CommitOperation::RecoveryAdvanceEpoch,
+        )
+        .await;
+
+        assert!(out.is_none(), "a successful broadcast yields None");
+        assert_eq!(
+            sends.load(Ordering::SeqCst),
+            1,
+            "exactly one send attempted"
+        );
+    }
+
+    /// Empty commit bytes short-circuit to `None` WITHOUT attempting any send
+    /// (the `cfg(test)` no-crypto pipeline).
+    #[tokio::test]
+    async fn try_broadcast_commit_skips_empty_bytes_without_sending() {
+        let sends = Arc::new(AtomicUsize::new(0));
+        let deps = build_deps(
+            Box::new(RecordingTransport {
+                sends: Arc::clone(&sends),
+                fail: true,
+            }),
+            Box::new(FailPersistence),
+        )
+        .await;
+
+        let out = try_broadcast_commit(&deps, &ctx_hex(), Vec::new(), &remove_op()).await;
+
+        assert!(out.is_none(), "empty commit bytes is a no-op");
+        assert_eq!(
+            sends.load(Ordering::SeqCst),
+            0,
+            "no send is attempted for empty commit bytes"
+        );
+    }
+
+    // -- Test 4: keep_broadcast_failure fail-closed durability ------------
+
+    /// `keep_broadcast_failure` persists the retry entry FAIL-CLOSED: when the
+    /// persist succeeds it returns `Ok`, the marker is durable (persist ran),
+    /// and the entry is enqueued in the cell's `pending_commits`.
+    #[tokio::test]
+    async fn keep_broadcast_failure_persists_retry_entry_before_ok() {
+        let persists = Arc::new(AtomicUsize::new(0));
+        let deps = build_deps(
+            Box::new(RecordingTransport {
+                sends: Arc::new(AtomicUsize::new(0)),
+                fail: true,
+            }),
+            Box::new(CountingOkPersistence {
+                persists: Arc::clone(&persists),
+            }),
+        )
+        .await;
+        let failure = make_failure(&deps, &remove_op()).await;
+        let mut cell = ClassSCell::new(fresh_state());
+
+        let result = keep_broadcast_failure(&mut cell, &deps, &ctx_hex(), failure).await;
+
+        assert!(
+            result.is_ok(),
+            "a successful fail-closed persist returns Ok"
+        );
+        assert_eq!(
+            persists.load(Ordering::SeqCst),
+            1,
+            "the retry entry was persisted (fail-closed) before returning Ok"
+        );
+        assert_eq!(
+            cell.pending_commits.len(),
+            1,
+            "the retry entry is enqueued in the cell"
+        );
+        assert!(
+            cell.commit_fault.is_none(),
+            "a normal enqueue leaves commit_fault clear"
+        );
+    }
+
+    /// A FAILING persist inside `keep_broadcast_failure` surfaces
+    /// `PersistenceFailed` (never a silent `Ok`) AND retains the retry entry in
+    /// memory (keep-direction) so the coalesced tick re-attempts the write —
+    /// the fail-closed guarantee the async-broadcast split had to restore.
+    #[tokio::test]
+    async fn keep_broadcast_failure_surfaces_persist_error_and_retains_entry() {
+        let deps = build_deps(
+            Box::new(RecordingTransport {
+                sends: Arc::new(AtomicUsize::new(0)),
+                fail: true,
+            }),
+            Box::new(FailPersistence),
+        )
+        .await;
+        let failure = make_failure(&deps, &remove_op()).await;
+        let mut cell = ClassSCell::new(fresh_state());
+
+        let result = keep_broadcast_failure(&mut cell, &deps, &ctx_hex(), failure).await;
+
+        assert!(
+            matches!(result, Err(ContextError::PersistenceFailed(_))),
+            "a failing fail-closed persist must surface PersistenceFailed, not Ok; got {result:?}"
+        );
+        assert_eq!(
+            cell.pending_commits.len(),
+            1,
+            "the retry entry is RETAINED in memory (keep-direction) after the persist failure"
+        );
+    }
+
+    // -- Test 5 (unit-level recovery fail-close) --------------------------
+
+    /// The §9.12 post-compromise recovery epoch-advance commit rides the SAME
+    /// retry queue: a failed `RecoveryAdvanceEpoch` broadcast enqueues a pending
+    /// entry tagged `RecoveryAdvanceEpoch`. (The full `recovery_advance_epoch`
+    /// call site cannot be driven under the `cfg(test)` no-crypto pipeline — the
+    /// Commit serializes to empty bytes and short-circuits before the enqueue;
+    /// see the module NOTE. This pins the operation-tag invariant on the path
+    /// that IS reachable.)
+    #[tokio::test]
+    async fn recovery_advance_epoch_failure_enqueues_recovery_tagged_entry() {
+        let deps = build_deps(
+            Box::new(RecordingTransport {
+                sends: Arc::new(AtomicUsize::new(0)),
+                fail: true,
+            }),
+            Box::new(FailPersistence),
+        )
+        .await;
+        let failure = try_broadcast_commit(
+            &deps,
+            &ctx_hex(),
+            b"recovery-commit".to_vec(),
+            &CommitOperation::RecoveryAdvanceEpoch,
+        )
+        .await
+        .expect("failing transport yields Some(BroadcastFailure)");
+
+        let mut pending: VecDeque<PendingCommit> = VecDeque::new();
+        let mut commit_fault: Option<CommitFaultMarker> = None;
+        let mut receive_buffer = ReceiveBuffer::new();
+
+        apply_broadcast_failure(
+            CommitBroadcastBorrows {
+                pending_commits: &mut pending,
+                commit_fault: &mut commit_fault,
+                receive_buffer: &mut receive_buffer,
+            },
+            &deps,
+            &ctx_hex(),
+            failure,
+        );
+
+        assert_eq!(
+            pending.len(),
+            1,
+            "the recovery commit is enqueued for retry"
+        );
+        assert_eq!(
+            pending[0].operation,
+            CommitOperation::RecoveryAdvanceEpoch,
+            "the enqueued retry entry is tagged RecoveryAdvanceEpoch"
+        );
+        assert!(
+            commit_fault.is_none(),
+            "commit_fault stays clear below the queue cap"
+        );
+    }
+}

--- a/crates/scp-runtime/src/context/governance_helpers.rs
+++ b/crates/scp-runtime/src/context/governance_helpers.rs
@@ -1436,16 +1436,9 @@ pub async fn execute_remove_member(
     // removal Commit already produced under the crypto `Arc` (Class-M) inside the
     // closure.
     if let Some(remove_commit_bytes) = remove_commit_bytes {
-        // The broadcast is async; on FAILURE its retry-queue bookkeeping — the
-        // `commit_fault` safety-gate marker (`check_commit_fault` blocks
-        // send/lifecycle/governance) and the `pending_commits` entry that is the
-        // ONLY re-delivery of the removal Commit — MUST persist FAIL-CLOSED. A
-        // crash before the ≤50 ms coalesced tick would otherwise drop both,
-        // respawning the context "healthy" while members are stuck on a stale MLS
-        // epoch with no retry: silent, permanent group desync (ADR-049 §9). So the
-        // apply runs inside a SECOND `commit_class_s_keep` — the async broadcast
-        // itself cannot live in the sync `_keep` closure (Decision 7), but its
-        // fail-close bookkeeping can and does. The success path persists nothing.
+        // Broadcast async (Decision 7); on FAILURE the retry-queue bookkeeping is
+        // persisted FAIL-CLOSED via `keep_broadcast_failure` (removal Commit is a
+        // safety-gated site — see that helper's doc for why the second persist).
         if let Some(failure) = try_broadcast_commit(
             deps,
             context_id,
@@ -1456,21 +1449,7 @@ pub async fn execute_remove_member(
         )
         .await
         {
-            cell.commit_class_s_keep(deps, context_id, |mut view| {
-                let state = view.rest_mut();
-                apply_broadcast_failure(
-                    CommitBroadcastBorrows {
-                        pending_commits: &mut state.pending_commits,
-                        commit_fault: &mut state.commit_fault,
-                        receive_buffer: &mut state.receive_buffer,
-                    },
-                    deps,
-                    context_id,
-                    failure,
-                );
-                Ok(())
-            })
-            .await?;
+            keep_broadcast_failure(cell, deps, context_id, failure).await?;
         }
 
         // Phase 2A.9: drain_and_deliver_sender_keys is now actor-shape.
@@ -2856,14 +2835,10 @@ pub async fn execute_rotate_content_keys(
 
     // Async transport op AFTER the Class-S rotation persist (ADR-049 Decision 7).
     // The key rotation is fail-closed-persisted; the commit bytes were produced
-    // under the crypto `Arc` (Class-M) inside the closure. The broadcast is async;
-    // on FAILURE its retry-queue bookkeeping — the `commit_fault` safety-gate
-    // marker and the `pending_commits` entry that is the ONLY re-delivery of the
-    // epoch-advance Commit — MUST persist FAIL-CLOSED, else a crash before the
-    // ≤50 ms coalesced tick drops the gate and members desync on a stale epoch
-    // with no retry (ADR-049 §9). The apply therefore rides a SECOND
-    // `commit_class_s_keep`; the async broadcast cannot live in the sync closure
-    // (Decision 7), but its fail-close bookkeeping can. Success persists nothing.
+    // under the crypto `Arc` (Class-M) inside the closure. Broadcast async
+    // (Decision 7); on FAILURE the retry-queue bookkeeping is persisted
+    // FAIL-CLOSED via `keep_broadcast_failure` (epoch-advance is a safety-gated
+    // site — see that helper's doc for why the second persist).
     if let Some(commit_bytes) = rotate_commit_bytes
         && let Some(failure) = try_broadcast_commit(
             deps,
@@ -2875,21 +2850,7 @@ pub async fn execute_rotate_content_keys(
         )
         .await
     {
-        cell.commit_class_s_keep(deps, context_id, |mut view| {
-            let state = view.rest_mut();
-            apply_broadcast_failure(
-                CommitBroadcastBorrows {
-                    pending_commits: &mut state.pending_commits,
-                    commit_fault: &mut state.commit_fault,
-                    receive_buffer: &mut state.receive_buffer,
-                },
-                deps,
-                context_id,
-                failure,
-            );
-            Ok(())
-        })
-        .await?;
+        keep_broadcast_failure(cell, deps, context_id, failure).await?;
     }
 
     deps.event_log
@@ -5578,6 +5539,49 @@ pub fn apply_broadcast_failure(
         error = %error,
         "MLS commit broadcast failed; enqueued for persistent retry (PR #1606 C6)"
     );
+}
+
+/// Applies a failed MLS-Commit broadcast's retry-queue bookkeeping FAIL-CLOSED,
+/// inside a second [`commit_class_s_keep`](crate::context::actor::class_s::ClassSCell::commit_class_s_keep)
+/// so it survives a crash before the actor's ≤50 ms coalesced persist tick.
+///
+/// The single call the safety-gated commit-broadcast sites —
+/// [`execute_remove_member`], [`execute_rotate_content_keys`] (this module),
+/// [`recovery_advance_epoch`](crate::context::trust_recovery_helpers::recovery_advance_epoch)
+/// (§9.12 post-compromise recovery), and
+/// [`leave_context`](crate::context::lifecycle_helpers::leave_context) —
+/// make after [`try_broadcast_commit`] returns `Some(BroadcastFailure)`.
+///
+/// # Why the second fail-closed persist (ADR-049 §9 / §9.9.3)
+///
+/// The transport became async under ADR-049 Decision 7, so the broadcast can no
+/// longer be awaited inside the primary `commit_class_s_keep` closure that
+/// fail-closed-persisted the underlying mutation; it now runs AFTER it. Its
+/// failure bookkeeping, however — the `commit_fault` safety-gate marker
+/// ([`check_commit_fault`] blocks send/lifecycle/governance) and the
+/// `pending_commits` entry that is the ONLY re-delivery of the epoch-advancing
+/// Commit — is synchronous ([`apply_broadcast_failure`]) and DOES ride a second
+/// `commit_class_s_keep`. If instead it were only coalesced (a plain `ClassCMut`
+/// write), a crash between the broadcast failure and the next persist tick would
+/// drop BOTH: the context respawns "healthy" while remaining members are stuck on
+/// a stale MLS epoch with no retry queued — silent, permanent group desync. The
+/// success path persists nothing (there is no `BroadcastFailure` to apply).
+///
+/// `pub` (not `pub(crate)`) is the private-module convention here —
+/// `clippy::redundant_pub_crate` forbids `pub(crate)` in this non-`pub` module;
+/// the helper is not FFI-exported (reconciled via the cross-layer PR-body marker,
+/// like the sibling async transport helpers).
+pub async fn keep_broadcast_failure(
+    cell: &mut crate::context::actor::class_s::ClassSCell,
+    deps: &ActorDeps,
+    context_id: &str,
+    failure: BroadcastFailure,
+) -> Result<(), ContextError> {
+    cell.commit_class_s_keep(deps, context_id, |mut view| {
+        apply_broadcast_failure(view.commit_broadcast_borrows(), deps, context_id, failure);
+        Ok(())
+    })
+    .await
 }
 
 // ===========================================================================

--- a/crates/scp-runtime/src/context/governance_helpers.rs
+++ b/crates/scp-runtime/src/context/governance_helpers.rs
@@ -5951,7 +5951,16 @@ pub fn translate_timeout_events(
 }
 
 #[cfg(test)]
-#[allow(clippy::unwrap_used, clippy::expect_used)]
+#[allow(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    // Test-only capturing persistence: the `Mutex<Option<ContextSnapshot>>` is
+    // never held across `.await` (the write is a synchronous store inside the
+    // trait method), so a plain `std::sync::Mutex` is the right tool. The
+    // runtime's actor path bans it (ADR-049); test fixtures are exempt, mirroring
+    // the sibling `CapturingPersistence` in `lifecycle_helpers.rs`.
+    clippy::disallowed_types
+)]
 mod commit_broadcast_retry_tests {
     //! ADR-049 Decision 7, PR-3: pins the retry-queue bookkeeping split out of
     //! the (now async) MLS-Commit broadcast.
@@ -5973,13 +5982,25 @@ mod commit_broadcast_retry_tests {
     //! extracted helpers directly with a manufactured `BroadcastFailure` (the
     //! payload a real failed broadcast produces) plus a real failing transport,
     //! and drive `keep_broadcast_failure` against a real `ClassSCell` +
-    //! failing/succeeding persistence to pin the fail-closed durability. The
-    //! surrounding governance/remove/rotate/leave suites cover the call-site
-    //! wiring.
+    //! failing/succeeding persistence to pin the fail-closed durability.
+    //!
+    //! This is an ACCEPTED boundary, stated honestly: the surrounding
+    //! governance/remove/rotate/leave suites run under the SAME `cfg(test)`
+    //! no-crypto pipeline, so their Commits also serialize to empty bytes and
+    //! `try_broadcast_commit` short-circuits to `None` — they exercise only the
+    //! happy-path invocation of the broadcast helper, NOT the
+    //! failure→`keep_broadcast_failure` routing. Consequently the fail-closed
+    //! HELPER semantics (enqueue, cap→`commit_fault`, fail-closed persist) are
+    //! FULLY pinned by these unit tests, but each safety-gated SITE's CHOICE of
+    //! `keep_broadcast_failure` over the coalesced
+    //! `apply_broadcast_failure(class_c_view())` on the failure path is guarded
+    //! by CODE REVIEW — not structurally by a test — because the no-crypto
+    //! pipeline cannot manufacture the non-empty Commit those sites would need to
+    //! reach the failure branch.
 
     use std::collections::VecDeque;
-    use std::sync::Arc;
     use std::sync::atomic::{AtomicUsize, Ordering};
+    use std::sync::{Arc, Mutex};
 
     use scp_did::DID;
     use scp_protocol::context::builder::ContextCreationError;
@@ -6065,20 +6086,24 @@ mod commit_broadcast_retry_tests {
         }
     }
 
-    /// Persistence whose every `persist_context` SUCCEEDS, counting calls — lets
-    /// the fail-closed keep test assert the marker was actually persisted before
-    /// `keep_broadcast_failure` returned `Ok`.
+    /// Persistence whose every `persist_context` SUCCEEDS, counting calls and
+    /// capturing the LAST persisted snapshot — lets the fail-closed keep test
+    /// assert the marker was actually persisted before `keep_broadcast_failure`
+    /// returned `Ok`, and that the retry entry is IN the persisted snapshot (not
+    /// merely that a persist happened).
     struct CountingOkPersistence {
         persists: Arc<AtomicUsize>,
+        last_snapshot: Arc<Mutex<Option<crate::context::state::ContextSnapshot>>>,
     }
     #[async_trait::async_trait]
     impl ContextPersistence for CountingOkPersistence {
         async fn persist_context(
             &self,
             _: &str,
-            _: &crate::context::state::ContextSnapshot,
+            snapshot: &crate::context::state::ContextSnapshot,
         ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
             self.persists.fetch_add(1, Ordering::SeqCst);
+            *self.last_snapshot.lock().unwrap() = Some(snapshot.clone());
             Ok(())
         }
         async fn load_context(
@@ -6269,11 +6294,15 @@ mod commit_broadcast_retry_tests {
         .await;
         let failure = make_failure(&deps, &remove_op()).await;
 
-        // Pre-fill the queue to exactly the cap.
+        // Pre-fill the queue to exactly the cap. The fillers carry a DIFFERENT
+        // operation variant (`RotateContentKeys`) than the injected failure
+        // (`RemoveMember`), so the `commit_fault` marker's `operation` assertion
+        // below actually proves provenance — that the marker carries the DROPPED
+        // operation, not a filler.
         let filler = PendingCommit {
             commit_bytes: vec![0x01, 0x02, 0x03],
             routing_id: [0u8; 32],
-            operation: remove_op(),
+            operation: CommitOperation::RotateContentKeys { reason: None },
             first_attempt_at: 1_700_000_000,
             retry_count: 1,
             last_error: None,
@@ -6317,7 +6346,8 @@ mod commit_broadcast_retry_tests {
         assert_eq!(
             marker.operation,
             remove_op(),
-            "the fault carries the dropped operation"
+            "the fault carries the DROPPED operation (RemoveMember), not a filler \
+             (RotateContentKeys) — proving marker provenance"
         );
         assert!(
             receive_buffer
@@ -6426,6 +6456,7 @@ mod commit_broadcast_retry_tests {
     #[tokio::test]
     async fn keep_broadcast_failure_persists_retry_entry_before_ok() {
         let persists = Arc::new(AtomicUsize::new(0));
+        let last_snapshot = Arc::new(Mutex::new(None));
         let deps = build_deps(
             Box::new(RecordingTransport {
                 sends: Arc::new(AtomicUsize::new(0)),
@@ -6433,6 +6464,7 @@ mod commit_broadcast_retry_tests {
             }),
             Box::new(CountingOkPersistence {
                 persists: Arc::clone(&persists),
+                last_snapshot: Arc::clone(&last_snapshot),
             }),
         )
         .await;
@@ -6449,6 +6481,17 @@ mod commit_broadcast_retry_tests {
             persists.load(Ordering::SeqCst),
             1,
             "the retry entry was persisted (fail-closed) before returning Ok"
+        );
+        let snapshot = last_snapshot
+            .lock()
+            .unwrap()
+            .clone()
+            .expect("a snapshot was captured by the persist");
+        assert_eq!(
+            snapshot.pending_commits.len(),
+            1,
+            "the retry entry is actually IN the persisted snapshot, not merely \
+             that a persist happened"
         );
         assert_eq!(
             cell.pending_commits.len(),
@@ -6488,6 +6531,12 @@ mod commit_broadcast_retry_tests {
             cell.pending_commits.len(),
             1,
             "the retry entry is RETAINED in memory (keep-direction) after the persist failure"
+        );
+        assert!(
+            cell.commit_fault.is_none(),
+            "a persist failure must NOT spuriously trip the safety gate — only a \
+             full retry queue or retry exhaustion sets commit_fault (parity with \
+             the normal-capacity path)"
         );
     }
 

--- a/crates/scp-runtime/src/context/governance_helpers.rs
+++ b/crates/scp-runtime/src/context/governance_helpers.rs
@@ -1254,17 +1254,18 @@ pub async fn execute_add_member(
     // group epoch exactly like a Remove, so without this the add's Commit was only
     // buffered into the (broadcast-suppressed) `WelcomeGenerated` event and NEVER
     // reached the group — every existing member desynced from the admin after any
-    // add. Routed through the same persistent retry queue
-    // (`try_broadcast_commit_or_enqueue`) as the remove/reset commits. A no-op
-    // when `commit_for_broadcast` is empty (the `cfg(test)` no-crypto pipeline).
+    // add. Routed through the same persistent retry queue (`try_broadcast_commit`
+    // + `apply_broadcast_failure`) as the remove/reset commits. A no-op when
+    // `commit_for_broadcast` is empty (the `cfg(test)` no-crypto pipeline).
     //
     // Hoisted AFTER the best-effort persist above (ADR-049 Decision 7 — transport
-    // is async and cannot be awaited inside the sync closure). The enqueue is
-    // Class-C (coalesced — picked up by the actor's persist tick), which is its
-    // correct class.
-    if !commit_for_broadcast.is_empty() {
-        try_broadcast_commit_or_enqueue(
-            cell.class_c_view().commit_broadcast_borrows(),
+    // is async and cannot be awaited inside the sync closure). The broadcast is
+    // async; on failure the retry-queue bookkeeping is applied Class-C (coalesced
+    // — picked up by the actor's persist tick), which is this add's correct class
+    // (member-add is not a downward-authorization transition — parity with the
+    // pre-async `commit_class_c_best_effort` shape).
+    if !commit_for_broadcast.is_empty()
+        && let Some(failure) = try_broadcast_commit(
             deps,
             context_id,
             commit_for_broadcast,
@@ -1272,7 +1273,14 @@ pub async fn execute_add_member(
                 target_did: did.clone(),
             },
         )
-        .await;
+        .await
+    {
+        apply_broadcast_failure(
+            cell.class_c_view().commit_broadcast_borrows(),
+            deps,
+            context_id,
+            failure,
+        );
     }
 
     // Subject-bearing leaf (ADR-011 amendment): carry the *affected member*
@@ -1422,15 +1430,23 @@ pub async fn execute_remove_member(
     // Async transport ops AFTER the Class-S removal persist (ADR-049 Decision 7:
     // `ContextTransportProvider` is async and cannot be awaited inside the sync
     // `_keep` closure above). The membership removal is already
-    // fail-closed-persisted; the Commit-broadcast enqueue is Class-C (coalesced —
-    // picked up by the actor's persist tick) and the sender-key delivery is
-    // best-effort. `remove_commit_bytes` is `Some` only on the success path (the
-    // fail-close paths return `None` and skip both, matching pre-hoist ordering);
-    // it is the removal Commit already produced under the crypto `Arc` (Class-M)
-    // inside the closure.
+    // fail-closed-persisted; the sender-key delivery is best-effort.
+    // `remove_commit_bytes` is `Some` only on the success path (the fail-close
+    // paths return `None` and skip both, matching pre-hoist ordering); it is the
+    // removal Commit already produced under the crypto `Arc` (Class-M) inside the
+    // closure.
     if let Some(remove_commit_bytes) = remove_commit_bytes {
-        try_broadcast_commit_or_enqueue(
-            cell.class_c_view().commit_broadcast_borrows(),
+        // The broadcast is async; on FAILURE its retry-queue bookkeeping — the
+        // `commit_fault` safety-gate marker (`check_commit_fault` blocks
+        // send/lifecycle/governance) and the `pending_commits` entry that is the
+        // ONLY re-delivery of the removal Commit — MUST persist FAIL-CLOSED. A
+        // crash before the ≤50 ms coalesced tick would otherwise drop both,
+        // respawning the context "healthy" while members are stuck on a stale MLS
+        // epoch with no retry: silent, permanent group desync (ADR-049 §9). So the
+        // apply runs inside a SECOND `commit_class_s_keep` — the async broadcast
+        // itself cannot live in the sync `_keep` closure (Decision 7), but its
+        // fail-close bookkeeping can and does. The success path persists nothing.
+        if let Some(failure) = try_broadcast_commit(
             deps,
             context_id,
             remove_commit_bytes,
@@ -1438,7 +1454,24 @@ pub async fn execute_remove_member(
                 target_did: did.clone(),
             },
         )
-        .await;
+        .await
+        {
+            cell.commit_class_s_keep(deps, context_id, |mut view| {
+                let state = view.rest_mut();
+                apply_broadcast_failure(
+                    CommitBroadcastBorrows {
+                        pending_commits: &mut state.pending_commits,
+                        commit_fault: &mut state.commit_fault,
+                        receive_buffer: &mut state.receive_buffer,
+                    },
+                    deps,
+                    context_id,
+                    failure,
+                );
+                Ok(())
+            })
+            .await?;
+        }
 
         // Phase 2A.9: drain_and_deliver_sender_keys is now actor-shape.
         if let Err(e) = crate::context::lifecycle_helpers::drain_and_deliver_sender_keys(
@@ -2456,8 +2489,11 @@ pub async fn execute_reset_member(
         .add_member(&context_id_bytes, did, None)
         .map_err(|e| ContextError::MembershipFailed(e.to_string()))?;
 
-    try_broadcast_commit_or_enqueue(
-        view.commit_broadcast_borrows(),
+    // Member reset operates on a coalesced `ClassCMut` view (best-effort — parity
+    // with the pre-async shape; NOT a downward-authorization Class-S transition).
+    // The broadcasts are async; on failure the retry-queue bookkeeping is applied
+    // through the same coalesced view (`view.commit_broadcast_borrows()`).
+    if let Some(failure) = try_broadcast_commit(
         deps,
         context_id,
         remove_output.commit_bytes,
@@ -2466,9 +2502,11 @@ pub async fn execute_reset_member(
             is_remove: true,
         },
     )
-    .await;
-    try_broadcast_commit_or_enqueue(
-        view.commit_broadcast_borrows(),
+    .await
+    {
+        apply_broadcast_failure(view.commit_broadcast_borrows(), deps, context_id, failure);
+    }
+    if let Some(failure) = try_broadcast_commit(
         deps,
         context_id,
         add_output.commit_bytes,
@@ -2477,7 +2515,10 @@ pub async fn execute_reset_member(
             is_remove: false,
         },
     )
-    .await;
+    .await
+    {
+        apply_broadcast_failure(view.commit_broadcast_borrows(), deps, context_id, failure);
+    }
 
     if let Err(e) = deps
         .crypto
@@ -2814,12 +2855,17 @@ pub async fn execute_rotate_content_keys(
         .await?;
 
     // Async transport op AFTER the Class-S rotation persist (ADR-049 Decision 7).
-    // The key rotation is fail-closed-persisted; the Commit-broadcast enqueue is
-    // Class-C (coalesced — picked up by the actor's persist tick). The commit
-    // bytes were produced under the crypto `Arc` (Class-M) inside the closure.
-    if let Some(commit_bytes) = rotate_commit_bytes {
-        try_broadcast_commit_or_enqueue(
-            cell.class_c_view().commit_broadcast_borrows(),
+    // The key rotation is fail-closed-persisted; the commit bytes were produced
+    // under the crypto `Arc` (Class-M) inside the closure. The broadcast is async;
+    // on FAILURE its retry-queue bookkeeping — the `commit_fault` safety-gate
+    // marker and the `pending_commits` entry that is the ONLY re-delivery of the
+    // epoch-advance Commit — MUST persist FAIL-CLOSED, else a crash before the
+    // ≤50 ms coalesced tick drops the gate and members desync on a stale epoch
+    // with no retry (ADR-049 §9). The apply therefore rides a SECOND
+    // `commit_class_s_keep`; the async broadcast cannot live in the sync closure
+    // (Decision 7), but its fail-close bookkeeping can. Success persists nothing.
+    if let Some(commit_bytes) = rotate_commit_bytes
+        && let Some(failure) = try_broadcast_commit(
             deps,
             context_id,
             commit_bytes,
@@ -2827,7 +2873,23 @@ pub async fn execute_rotate_content_keys(
                 reason: reason.map(String::from),
             },
         )
-        .await;
+        .await
+    {
+        cell.commit_class_s_keep(deps, context_id, |mut view| {
+            let state = view.rest_mut();
+            apply_broadcast_failure(
+                CommitBroadcastBorrows {
+                    pending_commits: &mut state.pending_commits,
+                    commit_fault: &mut state.commit_fault,
+                    receive_buffer: &mut state.receive_buffer,
+                },
+                deps,
+                context_id,
+                failure,
+            );
+            Ok(())
+        })
+        .await?;
     }
 
     deps.event_log
@@ -3477,7 +3539,7 @@ pub async fn execute_cancel_context_migration(
 }
 
 // ---------------------------------------------------------------------------
-// try_broadcast_commit_or_enqueue (transitive helper, actor-shape)
+// try_broadcast_commit / apply_broadcast_failure (transitive helpers, actor-shape)
 // ---------------------------------------------------------------------------
 
 // ---------------------------------------------------------------------------
@@ -5325,20 +5387,22 @@ pub async fn execute_governance_action(
 }
 
 // ---------------------------------------------------------------------------
-// try_broadcast_commit_or_enqueue (transitive helper, actor-shape)
+// try_broadcast_commit / apply_broadcast_failure (transitive helpers, actor-shape)
 // ---------------------------------------------------------------------------
 
-/// The three disjoint Class-C `&mut` fields
-/// [`try_broadcast_commit_or_enqueue`] mutates, threaded as ONE struct so the
-/// caller holds all three at once (they are distinct fields of
-/// [`PerContextState`], so the borrow checker accepts the simultaneous `&mut`).
+/// The three disjoint Class-C `&mut` fields [`apply_broadcast_failure`] mutates,
+/// threaded as ONE struct so the caller holds all three at once (they are
+/// distinct fields of [`PerContextState`], so the borrow checker accepts the
+/// simultaneous `&mut`).
 ///
-/// Replaces the prior whole `&mut PerContextState` parameter: the broadcast
-/// helper touches ONLY the MLS Commit retry queue (`pending_commits`), the
+/// Replaces the prior whole `&mut PerContextState` parameter: the broadcast-
+/// failure apply touches ONLY the MLS Commit retry queue (`pending_commits`), the
 /// queue-full fail-close marker (`commit_fault`), and the local receive buffer
-/// (`receive_buffer`). All three are Class-C / structural / best-effort (no
-/// fail-closed persist; see the function's doc), so the field-granular borrow is
-/// sound — there is no whole-state `&mut` and no reach to any Class-S sub-struct.
+/// (`receive_buffer`). The borrow is field-granular and reaches no Class-S
+/// sub-struct; the DURABILITY class is the caller's choice — the safety-gated
+/// sites supply these from a `commit_class_s_keep` `rest_mut()` view (fail-closed
+/// persist of `pending_commits`/`commit_fault`), the best-effort sites from a
+/// coalesced `ClassCMut` view (see [`apply_broadcast_failure`]).
 pub struct CommitBroadcastBorrows<'a> {
     /// `&mut` to the MLS Commit retry queue (Class-C / §9.9.3).
     pub pending_commits: &'a mut std::collections::VecDeque<PendingCommit>,
@@ -5348,8 +5412,40 @@ pub struct CommitBroadcastBorrows<'a> {
     pub receive_buffer: &'a mut ReceiveBuffer,
 }
 
-/// Attempts to broadcast an MLS Commit and, on transport failure,
-/// enqueues the commit in the persistent retry queue (PR #1606 C6).
+/// The retry-queue bookkeeping an MLS-Commit broadcast requires when its
+/// transport send FAILS, returned by [`try_broadcast_commit`] so the CALLER
+/// applies it (via [`apply_broadcast_failure`]) in the correct durability class.
+///
+/// Splitting the failure bookkeeping OUT of the async transport send is what
+/// lets the safety-gated Class-S sites — `execute_remove_member`,
+/// `execute_rotate_content_keys` (this module) and `leave_context`
+/// (`lifecycle_helpers`) — persist the `commit_fault` marker + `pending_commits`
+/// enqueue FAIL-CLOSED even though the broadcast itself, being async under
+/// ADR-049 Decision 7, cannot run inside their synchronous `commit_class_s_keep`
+/// closure. The best-effort sites (`execute_add_member`, `execute_reset_member`)
+/// apply the identical value coalesced through a `ClassCMut` view.
+///
+/// Why fail-closed matters here: `commit_fault` is a SAFETY GATE
+/// ([`check_commit_fault`] blocks send/lifecycle/governance) and the
+/// `pending_commits` entry is the ONLY re-delivery of the epoch-advancing
+/// Commit. If a crash lands between a broadcast failure and the ≤50 ms coalesced
+/// persist tick, a coalesced-only write loses BOTH — the context respawns
+/// "healthy" while members are stuck on a stale MLS epoch with no retry queued:
+/// silent, permanent group desync (ADR-049 §9 / §9.9.3).
+pub struct BroadcastFailure {
+    /// The retry record to enqueue (or, when the queue is full at apply time,
+    /// the source of the fail-close [`CommitFaultMarker`]).
+    pending: PendingCommit,
+    /// Operation label for the surfaced local `ContextEvent`.
+    label: String,
+    /// Transport error string for the surfaced local `ContextEvent`.
+    error: String,
+}
+
+/// Attempts to broadcast an MLS Commit. Returns `None` on success (or an empty
+/// commit — the `cfg(test)` no-crypto pipeline); on transport failure returns
+/// `Some(BroadcastFailure)` describing the retry-queue bookkeeping the caller
+/// must persist via [`apply_broadcast_failure`].
 ///
 /// Per the phase-2.md ADR-011-amendment exclusion taxonomy (per-committer
 /// broadcast-retry bookkeeping), the commit-broadcast lifecycle events
@@ -5359,46 +5455,33 @@ pub struct CommitBroadcastBorrows<'a> {
 /// surfaced as local `ContextEvent`s only (first-attempt success is not
 /// surfaced); no durable consumer reads them.
 ///
-/// Infallible: a transport-send failure is absorbed into the persistent
-/// retry queue (or a `commit_fault` marker when the queue is full) rather
-/// than propagated. Dropping the durable commit-lifecycle appends removed the
-/// function's only `Result`-returning path.
+/// # No state mutation (ADR-049 §9 / Decision 7)
 ///
-/// # Field-granular borrows (ADR-049 §9)
-///
-/// Takes a [`CommitBroadcastBorrows`] — the THREE disjoint Class-C `&mut`
-/// fields it actually touches (`pending_commits`, `commit_fault`,
-/// `receive_buffer`) — rather than a whole `&mut PerContextState`. A cell holder
-/// supplies them from a non-persisting [`crate::context::actor::class_s::ClassCMut`]
-/// view (`view.commit_broadcast_borrows()`); a bare-`&mut state` caller supplies
-/// them by disjoint field borrow. All three fields are Class-C / structural and
-/// best-effort: the enqueue is a retry-queue bookkeeping insert, the
-/// `commit_fault` marker is the queue-full fail-close surfaced LOCALLY only
-/// (never a durable Merkle leaf — see the §9.9.3 note above), and the
-/// `receive_buffer` emit is a local `ContextEvent`. None requires a fail-closed
-/// persist, so the field-granular best-effort shape is sound.
-pub async fn try_broadcast_commit_or_enqueue(
-    borrows: CommitBroadcastBorrows<'_>,
+/// This function performs ONLY the async transport send and builds the retry
+/// payload; it touches NO `PerContextState` field. Applying that payload —
+/// enqueue into `pending_commits`, set the `commit_fault` marker, emit the local
+/// event — is deferred to the synchronous [`apply_broadcast_failure`] so the
+/// CALLER picks the durability class (fail-closed at the safety-gated Class-S
+/// sites, coalesced at the best-effort sites). This is the decoupling that
+/// restores fail-closed durability of the `commit_fault` safety gate after the
+/// transport became async and the broadcast could no longer live inside the
+/// sync `commit_class_s_keep` closure.
+pub async fn try_broadcast_commit(
     deps: &ActorDeps,
     context_id: &str,
     commit_bytes: Vec<u8>,
     operation: &CommitOperation,
-) {
+) -> Option<BroadcastFailure> {
     if commit_bytes.is_empty() {
-        return;
+        return None;
     }
-    let CommitBroadcastBorrows {
-        pending_commits,
-        commit_fault,
-        receive_buffer,
-    } = borrows;
     let routing_id = scp_protocol::context::context_routing_id(context_id);
     match deps
         .transport
         .send_message(&routing_id, &commit_bytes)
         .await
     {
-        Ok(()) => {}
+        Ok(()) => None,
         Err(e) => {
             let now = deps.clock.now_secs();
             let error_str = e.to_string();
@@ -5412,48 +5495,89 @@ pub async fn try_broadcast_commit_or_enqueue(
                 last_error: Some(error_str.clone()),
                 next_attempt_at: now.saturating_add(backoff),
             };
-            let label = operation.label();
-
-            // N2: Cap the pending commits queue.
-            if pending_commits.len() >= MAX_PENDING_COMMITS {
-                *commit_fault = Some(CommitFaultMarker {
-                    operation: operation.clone(),
-                    reason: format!("pending commit queue full ({MAX_PENDING_COMMITS} entries)"),
-                    retry_count: 1,
-                    failed_at: now,
-                });
-                emit_event_into(
-                    receive_buffer,
-                    ContextEvent::CommitBroadcastFailed {
-                        operation: label,
-                        reason: format!("queue full ({MAX_PENDING_COMMITS}): {error_str}"),
-                        attempts: 1,
-                    },
-                    context_id,
-                    deps.event_tx.as_ref(),
-                );
-                return;
-            }
-            pending_commits.push_back(pending);
-            let label_for_event = label.clone();
-            emit_event_into(
-                receive_buffer,
-                ContextEvent::CommitBroadcastPending {
-                    operation: label_for_event,
-                    error: error_str.clone(),
-                    attempt: 1,
-                },
-                context_id,
-                deps.event_tx.as_ref(),
-            );
-            tracing::warn!(
-                context_id = %context_id,
-                operation = %label,
-                error = %error_str,
-                "MLS commit broadcast failed; enqueued for persistent retry (PR #1606 C6)"
-            );
+            Some(BroadcastFailure {
+                pending,
+                label: operation.label(),
+                error: error_str,
+            })
         }
     }
+}
+
+/// Applies the retry-queue bookkeeping from a failed [`try_broadcast_commit`] to
+/// the three disjoint Class-C fields it touches (`pending_commits`,
+/// `commit_fault`, `receive_buffer`) and emits the surfaced local event.
+///
+/// SYNCHRONOUS by design: a caller runs it INSIDE a `commit_class_s_keep`
+/// closure (via `view.rest_mut()`) to persist the fields FAIL-CLOSED at the
+/// safety-gated sites, or against a coalesced `class_c_view()` / `ClassCMut` at
+/// the best-effort sites. The durability class is the CALLER's choice; this
+/// helper only mutates the borrowed fields.
+///
+/// # Field-granular borrows (ADR-049 §9)
+///
+/// Takes a [`CommitBroadcastBorrows`] — the THREE disjoint Class-C `&mut` fields
+/// rather than a whole `&mut PerContextState`.
+///
+/// Preserves the exact `MAX_PENDING_COMMITS` cap semantics: the length check
+/// runs HERE, holding the live `&mut pending_commits`, so a full queue converts
+/// the enqueue into a fail-close [`CommitFaultMarker`] instead — identical to the
+/// pre-async single-function behavior (§9.9.3).
+pub fn apply_broadcast_failure(
+    borrows: CommitBroadcastBorrows<'_>,
+    deps: &ActorDeps,
+    context_id: &str,
+    failure: BroadcastFailure,
+) {
+    let CommitBroadcastBorrows {
+        pending_commits,
+        commit_fault,
+        receive_buffer,
+    } = borrows;
+    let BroadcastFailure {
+        pending,
+        label,
+        error,
+    } = failure;
+
+    // N2: Cap the pending commits queue.
+    if pending_commits.len() >= MAX_PENDING_COMMITS {
+        *commit_fault = Some(CommitFaultMarker {
+            operation: pending.operation.clone(),
+            reason: format!("pending commit queue full ({MAX_PENDING_COMMITS} entries)"),
+            retry_count: 1,
+            failed_at: pending.first_attempt_at,
+        });
+        emit_event_into(
+            receive_buffer,
+            ContextEvent::CommitBroadcastFailed {
+                operation: label,
+                reason: format!("queue full ({MAX_PENDING_COMMITS}): {error}"),
+                attempts: 1,
+            },
+            context_id,
+            deps.event_tx.as_ref(),
+        );
+        return;
+    }
+    pending_commits.push_back(pending);
+    let label_for_event = label.clone();
+    emit_event_into(
+        receive_buffer,
+        ContextEvent::CommitBroadcastPending {
+            operation: label_for_event,
+            error: error.clone(),
+            attempt: 1,
+        },
+        context_id,
+        deps.event_tx.as_ref(),
+    );
+    tracing::warn!(
+        context_id = %context_id,
+        operation = %label,
+        error = %error,
+        "MLS commit broadcast failed; enqueued for persistent retry (PR #1606 C6)"
+    );
 }
 
 // ===========================================================================

--- a/crates/scp-runtime/src/context/governance_helpers.rs
+++ b/crates/scp-runtime/src/context/governance_helpers.rs
@@ -2468,10 +2468,25 @@ pub async fn execute_reset_member(
         .add_member(&context_id_bytes, did, None)
         .map_err(|e| ContextError::MembershipFailed(e.to_string()))?;
 
-    // Member reset operates on a coalesced `ClassCMut` view (best-effort — parity
-    // with the pre-async shape; NOT a downward-authorization Class-S transition).
-    // The broadcasts are async; on failure the retry-queue bookkeeping is applied
-    // through the same coalesced view (`view.commit_broadcast_borrows()`).
+    // Member reset operates on a coalesced `ClassCMut` view (best-effort). The
+    // broadcasts are async; on failure the retry-queue bookkeeping is applied
+    // through the same coalesced view (`view.commit_broadcast_borrows()`), so a
+    // crash before the ≤50 ms persist tick can drop the `commit_fault`/retry
+    // bookkeeping. RESIDUAL of coalescing here (be honest): a lost reset Commit
+    // leaves remaining members on an epoch where the reset member's OLD
+    // (rotated-out, possibly compromised) keys still decrypt until the Commit is
+    // re-delivered — the same desync class the safety-gated sites fail-close
+    // against. Coalesced is nonetheless the correct/defensible class for reset,
+    // for three reasons: (1) reset is a same-member key REFRESH — the member is
+    // removed and IMMEDIATELY re-added in the same operation and remains
+    // authorized throughout, so it is net-neutral versus a true `RemoveMember`
+    // (no authority is being withdrawn from anyone); (2) §9 classifies the
+    // membership effect as Class-M, not a downward-authorization Class-S
+    // transition, so it carries no §9 fail-closed obligation; and (3) it matches
+    // the pre-async coalesced `ClassCMut` shape exactly — coalescing here is
+    // parity, NOT a regression introduced by the async-transport hoist. (The
+    // fail-closed sites — remove/rotate/leave/recovery — genuinely withdraw
+    // authority or re-key away from a compromised party, which reset does not.)
     if let Some(failure) = try_broadcast_commit(
         deps,
         context_id,

--- a/crates/scp-runtime/src/context/lifecycle_helpers.rs
+++ b/crates/scp-runtime/src/context/lifecycle_helpers.rs
@@ -234,7 +234,7 @@ pub async fn leave_context(
     // through the whole `&mut PerContextState` the view hands back;
     // `try_broadcast_commit_or_enqueue` is passed only the three disjoint Class-C
     // fields it mutates (via `CommitBroadcastBorrows`), borrowed from that same state.
-    let (should_close, left_role_name) = cell
+    let (should_close, left_role_name, is_broadcast, mls_commit_bytes) = cell
         .commit_class_s_keep(deps, &context_id, |mut view| {
             let state = view.rest_mut();
 
@@ -259,7 +259,18 @@ pub async fn leave_context(
             // H9: MLS group removal FIRST (hard security boundary), then sender
             // key cleanup as best-effort. MLS removal is the cryptographic
             // enforcement; sender key removal is defense-in-depth (§9.16).
-            if !is_broadcast {
+            //
+            // Capture the removal Commit bytes here; the ASYNC transport ops
+            // (Commit broadcast, sender-key rotation + delivery) run AFTER the
+            // fail-closed persist below, outside this synchronous `_keep` closure
+            // (ADR-049 Decision 7 — `ContextTransportProvider` is now async and
+            // cannot be awaited inside the sync closure). The membership removal
+            // is fail-closed-persisted by the combinator; the Commit-broadcast
+            // enqueue is Class-C (coalesced) and the sender-key rotation/delivery
+            // are best-effort crypto/transport side-effects.
+            let mls_commit_bytes = if is_broadcast {
+                None
+            } else {
                 let remove_output = deps.crypto.remove_member(&context_id_bytes, member_did)?;
                 if let Err(e) = deps
                     .crypto
@@ -273,45 +284,8 @@ pub async fn leave_context(
                          sender key layer may retain stale key"
                     );
                 }
-
-                // Broadcast the MLS Commit to remaining members so they can
-                // advance their group epoch and ratchet key material. PR #1606
-                // C6: on transport failure, the commit is durably enqueued for
-                // retry.
-                governance_helpers::try_broadcast_commit_or_enqueue(
-                    governance_helpers::CommitBroadcastBorrows {
-                        pending_commits: &mut state.pending_commits,
-                        commit_fault: &mut state.commit_fault,
-                        receive_buffer: &mut state.receive_buffer,
-                    },
-                    deps,
-                    &context_id,
-                    remove_output.commit_bytes,
-                    &CommitOperation::LeaveContext {
-                        member_did: member_did.clone(),
-                    },
-                );
-
-                // Rotate the local sender key and distribute to remaining members
-                // (§9.16.4). M23: Non-fatal — MLS removal above is the hard
-                // security boundary. If rotation fails, log but continue.
-                if let Err(e) = deps.crypto.rotate_sender_key(&context_id_bytes) {
-                    tracing::warn!(
-                        context_id = %context_id,
-                        error = %e,
-                        "rotate_sender_key failed after leave — \
-                         remaining members retain old sender key"
-                    );
-                }
-                if let Err(e) = drain_and_deliver_sender_keys(deps, &context_id, &context_id_bytes)
-                {
-                    tracing::warn!(
-                        context_id = %context_id,
-                        error = %e,
-                        "failed to deliver rotated sender keys after leave"
-                    );
-                }
-            }
+                Some(remove_output.commit_bytes)
+            };
 
             // State check + membership removal -- the actor owns state for the
             // duration of this command, so no relock dance is required.
@@ -384,9 +358,54 @@ pub async fn leave_context(
 
             let should_close = state.membership.count() == 0;
 
-            Ok((should_close, left_role_name))
+            Ok((should_close, left_role_name, is_broadcast, mls_commit_bytes))
         })
         .await?;
+
+    // Async transport ops AFTER the Class-S removal persist (ADR-049 Decision 7:
+    // `ContextTransportProvider` is async and cannot be awaited inside the
+    // synchronous `_keep` closure above). The membership removal is already
+    // fail-closed-persisted; the MLS-Commit broadcast enqueue is Class-C
+    // (coalesced — picked up by the actor's persist tick) and the sender-key
+    // rotation + delivery are best-effort crypto/transport side-effects. The
+    // captured `mls_commit_bytes` is the removal Commit already produced under
+    // the crypto `Arc` (Class-M) inside the closure.
+    if !is_broadcast {
+        if let Some(commit_bytes) = mls_commit_bytes {
+            // Broadcast the MLS Commit to remaining members so they can advance
+            // their group epoch and ratchet key material. PR #1606 C6: on
+            // transport failure, the commit is durably enqueued for retry.
+            governance_helpers::try_broadcast_commit_or_enqueue(
+                cell.class_c_view().commit_broadcast_borrows(),
+                deps,
+                &context_id,
+                commit_bytes,
+                &CommitOperation::LeaveContext {
+                    member_did: member_did.clone(),
+                },
+            )
+            .await;
+        }
+
+        // Rotate the local sender key and distribute to remaining members
+        // (§9.16.4). M23: Non-fatal — MLS removal above is the hard security
+        // boundary. If rotation fails, log but continue.
+        if let Err(e) = deps.crypto.rotate_sender_key(&context_id_bytes) {
+            tracing::warn!(
+                context_id = %context_id,
+                error = %e,
+                "rotate_sender_key failed after leave — \
+                 remaining members retain old sender key"
+            );
+        }
+        if let Err(e) = drain_and_deliver_sender_keys(deps, &context_id, &context_id_bytes).await {
+            tracing::warn!(
+                context_id = %context_id,
+                error = %e,
+                "failed to deliver rotated sender keys after leave"
+            );
+        }
+    }
 
     // Append the `MemberLeft` Merkle leaf AFTER the Class-S removal persist.
     // Under ADR-049 Decision 7 `EventLogPersistence` is async, so this append
@@ -445,7 +464,7 @@ pub async fn leave_context(
 /// Returns a [`ContextError`] if the underlying drain call fails
 /// catastrophically. Per-recipient send failures are logged but not
 /// propagated (the receiver can recover via `SenderKeyRequest`).
-pub fn drain_and_deliver_sender_keys(
+pub async fn drain_and_deliver_sender_keys(
     deps: &ActorDeps,
     context_id: &str,
     context_id_bytes: &[u8; 32],
@@ -469,7 +488,7 @@ pub fn drain_and_deliver_sender_keys(
                 crate::context::messaging_helpers::DEFAULT_BLOB_TTL_SECS,
             ) {
                 Ok(sealed) => {
-                    if let Err(e) = deps.transport.send_message(&routing_id, &sealed) {
+                    if let Err(e) = deps.transport.send_message(&routing_id, &sealed).await {
                         tracing::warn!(target_did = %target_did, context_id = %context_id, error = %e, "failed to send rotated sender key");
                     }
                 }
@@ -946,7 +965,7 @@ pub async fn join_context(
     // Drain pending HPKE-sealed sender key distribution messages and
     // deliver them via the MLS management channel (§9.16.2). MLS-wrap
     // is mandatory — see comment on `drain_and_deliver_sender_keys`.
-    if let Err(e) = drain_and_deliver_sender_keys(deps, &context_id, &context_id_bytes) {
+    if let Err(e) = drain_and_deliver_sender_keys(deps, &context_id, &context_id_bytes).await {
         // Drain failed catastrophically — roll back MLS state, sender
         // key, escrow, and economy ticket so the join is fully aborted.
         let _ = deps.crypto.remove_member(&context_id_bytes, &member_did);
@@ -3284,21 +3303,22 @@ mod restore_reconcile_tests {
 
     /// Connected no-op transport — `create_context` publishes through it.
     struct OkTransport;
+    #[async_trait::async_trait]
     impl ContextTransportProvider for OkTransport {
         fn is_connected(&self) -> bool {
             true
         }
-        fn publish_context(
+        async fn publish_context(
             &self,
             _id: &[u8; 32],
             _params: &ContextParams,
         ) -> Result<(), ContextCreationError> {
             Ok(())
         }
-        fn delete_published(&self, _id: &[u8; 32]) -> Result<(), ContextCreationError> {
+        async fn delete_published(&self, _id: &[u8; 32]) -> Result<(), ContextCreationError> {
             Ok(())
         }
-        fn send_message(&self, _id: &[u8; 32], _payload: &[u8]) -> Result<(), ContextError> {
+        async fn send_message(&self, _id: &[u8; 32], _payload: &[u8]) -> Result<(), ContextError> {
             Ok(())
         }
     }

--- a/crates/scp-runtime/src/context/lifecycle_helpers.rs
+++ b/crates/scp-runtime/src/context/lifecycle_helpers.rs
@@ -231,9 +231,11 @@ pub async fn leave_context(
     // `MemberLeft` Merkle-leaf append and the close-on-empty transition (both now or
     // already async — under ADR-049 Decision 7 `EventLogPersistence` is async) run
     // AFTER the persist, outside the sync `_keep` closure. `check_commit_fault` reads
-    // through the whole `&mut PerContextState` the view hands back;
-    // `try_broadcast_commit_or_enqueue` is passed only the three disjoint Class-C
-    // fields it mutates (via `CommitBroadcastBorrows`), borrowed from that same state.
+    // through the whole `&mut PerContextState` the view hands back. The MLS-Commit
+    // broadcast also runs after this persist (async — Decision 7); on failure its
+    // `commit_fault`/`pending_commits` bookkeeping is applied FAIL-CLOSED via a
+    // second `commit_class_s_keep` (`apply_broadcast_failure`), because `commit_fault`
+    // is a safety gate that must survive a crash before the coalesced persist tick.
     let (should_close, left_role_name, is_broadcast, mls_commit_bytes) = cell
         .commit_class_s_keep(deps, &context_id, |mut view| {
             let state = view.rest_mut();
@@ -365,18 +367,26 @@ pub async fn leave_context(
     // Async transport ops AFTER the Class-S removal persist (ADR-049 Decision 7:
     // `ContextTransportProvider` is async and cannot be awaited inside the
     // synchronous `_keep` closure above). The membership removal is already
-    // fail-closed-persisted; the MLS-Commit broadcast enqueue is Class-C
-    // (coalesced — picked up by the actor's persist tick) and the sender-key
-    // rotation + delivery are best-effort crypto/transport side-effects. The
-    // captured `mls_commit_bytes` is the removal Commit already produced under
-    // the crypto `Arc` (Class-M) inside the closure.
+    // fail-closed-persisted; the MLS-Commit broadcast's failure bookkeeping is
+    // itself re-persisted FAIL-CLOSED (see below), while the sender-key rotation +
+    // delivery are best-effort crypto/transport side-effects. The captured
+    // `mls_commit_bytes` is the removal Commit already produced under the crypto
+    // `Arc` (Class-M) inside the closure.
     if !is_broadcast {
-        if let Some(commit_bytes) = mls_commit_bytes {
-            // Broadcast the MLS Commit to remaining members so they can advance
-            // their group epoch and ratchet key material. PR #1606 C6: on
-            // transport failure, the commit is durably enqueued for retry.
-            governance_helpers::try_broadcast_commit_or_enqueue(
-                cell.class_c_view().commit_broadcast_borrows(),
+        // Broadcast the MLS Commit to remaining members so they can advance their
+        // group epoch and ratchet key material. The broadcast is async (ADR-049
+        // Decision 7) and cannot run inside the sync `_keep` closure above. PR #1606
+        // C6: on transport FAILURE the retry-queue bookkeeping — the `commit_fault`
+        // safety-gate marker (`check_commit_fault` blocks send/lifecycle/governance)
+        // and the `pending_commits` entry that is the ONLY re-delivery of the removal
+        // Commit — MUST persist FAIL-CLOSED. A crash before the ≤50 ms coalesced tick
+        // would otherwise drop both, respawning the context "healthy" while remaining
+        // members are stuck on a stale MLS epoch with no retry: silent, permanent
+        // group desync (ADR-049 §9). The apply therefore rides a SECOND
+        // `commit_class_s_keep` (the async broadcast cannot; its fail-close
+        // bookkeeping can). The success path persists nothing.
+        if let Some(commit_bytes) = mls_commit_bytes
+            && let Some(failure) = governance_helpers::try_broadcast_commit(
                 deps,
                 &context_id,
                 commit_bytes,
@@ -384,7 +394,23 @@ pub async fn leave_context(
                     member_did: member_did.clone(),
                 },
             )
-            .await;
+            .await
+        {
+            cell.commit_class_s_keep(deps, &context_id, |mut view| {
+                let state = view.rest_mut();
+                governance_helpers::apply_broadcast_failure(
+                    governance_helpers::CommitBroadcastBorrows {
+                        pending_commits: &mut state.pending_commits,
+                        commit_fault: &mut state.commit_fault,
+                        receive_buffer: &mut state.receive_buffer,
+                    },
+                    deps,
+                    &context_id,
+                    failure,
+                );
+                Ok(())
+            })
+            .await?;
         }
 
         // Rotate the local sender key and distribute to remaining members

--- a/crates/scp-runtime/src/context/lifecycle_helpers.rs
+++ b/crates/scp-runtime/src/context/lifecycle_helpers.rs
@@ -374,17 +374,10 @@ pub async fn leave_context(
     // `Arc` (Class-M) inside the closure.
     if !is_broadcast {
         // Broadcast the MLS Commit to remaining members so they can advance their
-        // group epoch and ratchet key material. The broadcast is async (ADR-049
-        // Decision 7) and cannot run inside the sync `_keep` closure above. PR #1606
-        // C6: on transport FAILURE the retry-queue bookkeeping — the `commit_fault`
-        // safety-gate marker (`check_commit_fault` blocks send/lifecycle/governance)
-        // and the `pending_commits` entry that is the ONLY re-delivery of the removal
-        // Commit — MUST persist FAIL-CLOSED. A crash before the ≤50 ms coalesced tick
-        // would otherwise drop both, respawning the context "healthy" while remaining
-        // members are stuck on a stale MLS epoch with no retry: silent, permanent
-        // group desync (ADR-049 §9). The apply therefore rides a SECOND
-        // `commit_class_s_keep` (the async broadcast cannot; its fail-close
-        // bookkeeping can). The success path persists nothing.
+        // group epoch and ratchet key material. Broadcast async (ADR-049 Decision
+        // 7); on transport FAILURE the retry-queue bookkeeping is persisted
+        // FAIL-CLOSED via `keep_broadcast_failure` (member departure is a
+        // safety-gated site — see that helper's doc for why the second persist).
         if let Some(commit_bytes) = mls_commit_bytes
             && let Some(failure) = governance_helpers::try_broadcast_commit(
                 deps,
@@ -396,21 +389,7 @@ pub async fn leave_context(
             )
             .await
         {
-            cell.commit_class_s_keep(deps, &context_id, |mut view| {
-                let state = view.rest_mut();
-                governance_helpers::apply_broadcast_failure(
-                    governance_helpers::CommitBroadcastBorrows {
-                        pending_commits: &mut state.pending_commits,
-                        commit_fault: &mut state.commit_fault,
-                        receive_buffer: &mut state.receive_buffer,
-                    },
-                    deps,
-                    &context_id,
-                    failure,
-                );
-                Ok(())
-            })
-            .await?;
+            governance_helpers::keep_broadcast_failure(cell, deps, &context_id, failure).await?;
         }
 
         // Rotate the local sender key and distribute to remaining members

--- a/crates/scp-runtime/src/context/messaging_helpers.rs
+++ b/crates/scp-runtime/src/context/messaging_helpers.rs
@@ -1273,7 +1273,8 @@ pub async fn send_message(
         source_provenance,
         &send_routing_ids,
         MessageType::Content,
-    );
+    )
+    .await;
     if let Err(e) = phase2_result {
         // Keep-direction (ADR-049 §9): persist the burned nonce fail-closed
         // (via `&*cell`) BEFORE the existing escrow-void + ticket rollback. If the
@@ -1643,7 +1644,7 @@ fn deliver_checkpoint_message(
 /// Encrypts the payload and sends it via transport (Phase 2 of
 /// [`send_message`]).
 #[allow(clippy::too_many_arguments)]
-pub fn encrypt_and_send(
+pub async fn encrypt_and_send(
     deps: &ActorDeps,
     broadcast_envelope: Option<BroadcastEnvelope>,
     signer: MessageSigner<'_>,
@@ -1695,7 +1696,7 @@ pub fn encrypt_and_send(
     let mut last_err = None;
     let mut any_success = false;
     for rid in routing_ids {
-        match deps.transport.send_message(rid, &encrypted) {
+        match deps.transport.send_message(rid, &encrypted).await {
             Ok(()) => {
                 any_success = true;
                 crate::metrics::record_message_sent();
@@ -1746,22 +1747,19 @@ pub fn encrypt_and_send(
 /// every fan-out send fails. Callers that publish checkpoints opportunistically
 /// (the periodic-broadcast path in [`finalize_send`]) treat any error as
 /// best-effort and MUST NOT roll back the originating send.
-pub fn send_checkpoint(
-    deps: &ActorDeps,
+pub fn send_checkpoint<'d, 'c, 's, 'k, 'cp>(
+    deps: &'d ActorDeps,
     state: &PerContextState,
-    context_id: &str,
-    sender_did: &DID,
-    signing_key: &ed25519_dalek::SigningKey,
-    checkpoint: &scp_event_log::checkpoint::ConsistencyCheckpoint,
-) -> Result<(), ContextError> {
-    let message = CheckpointMessage {
-        tag: CHECKPOINT_PAYLOAD_TAG.to_owned(),
-        checkpoint: checkpoint.clone(),
-    };
-    let payload = rmp_serde::to_vec_named(&message).map_err(|e| {
-        ContextError::CryptoFailed(format!("checkpoint message serialization: {e}"))
-    })?;
-
+    context_id: &'c str,
+    sender_did: &'s DID,
+    signing_key: &'k ed25519_dalek::SigningKey,
+    checkpoint: &'cp scp_event_log::checkpoint::ConsistencyCheckpoint,
+) -> impl std::future::Future<Output = Result<(), ContextError>> + Send + use<'d, 'c, 's, 'k, 'cp> {
+    // SYNC PRELUDE (ADR-049 Decision 7 Send-discipline): read `&PerContextState`
+    // (which is `!Sync`) here and produce OWNED routing data, so the returned
+    // future does NOT capture the `state` lifetime and stays `Send` (mirrors
+    // `persist_state_best_effort`). `state` is deliberately absent from `use<>`.
+    //
     // Routing parallels the application-data send path (§9.10.4): broadcast
     // contexts address the derivable broadcast RID; encrypted contexts fan out
     // to each known peer pseudonym. An empty encrypted routing set (no peers
@@ -1785,23 +1783,34 @@ pub fn send_checkpoint(
         )
     };
 
-    encrypt_and_send(
-        deps,
-        broadcast_envelope,
-        // Consistency checkpoints are device/human-originated signals, not
-        // agent-autonomous messages — sign under `#active` (ADR-039).
-        MessageSigner::Active(signing_key),
-        context_id,
-        sender_did,
-        &payload,
-        &recipients_data,
-        // Checkpoints do not consume the application content sequence; the
-        // receive path dispatches them before the sequence tracker.
-        0,
-        None,
-        &routing_ids,
-        MessageType::ConsistencyCheckpoint,
-    )
+    async move {
+        let message = CheckpointMessage {
+            tag: CHECKPOINT_PAYLOAD_TAG.to_owned(),
+            checkpoint: checkpoint.clone(),
+        };
+        let payload = rmp_serde::to_vec_named(&message).map_err(|e| {
+            ContextError::CryptoFailed(format!("checkpoint message serialization: {e}"))
+        })?;
+
+        encrypt_and_send(
+            deps,
+            broadcast_envelope,
+            // Consistency checkpoints are device/human-originated signals, not
+            // agent-autonomous messages — sign under `#active` (ADR-039).
+            MessageSigner::Active(signing_key),
+            context_id,
+            sender_did,
+            &payload,
+            &recipients_data,
+            // Checkpoints do not consume the application content sequence; the
+            // receive path dispatches them before the sequence tracker.
+            0,
+            None,
+            &routing_ids,
+            MessageType::ConsistencyCheckpoint,
+        )
+        .await
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -1837,83 +1846,102 @@ pub fn send_checkpoint(
 /// any error as best-effort (a failed heartbeat is itself a suppression
 /// signal, surfaced separately by the receiver's gap detection) and MUST NOT
 /// tear down the subscription on a single failure.
-pub fn send_heartbeat(
-    deps: &ActorDeps,
+pub fn send_heartbeat<'d, 'c, 's, 'k>(
+    deps: &'d ActorDeps,
     state: &PerContextState,
-    context_id: &str,
-    sender_did: &DID,
-    signing_key: &ed25519_dalek::SigningKey,
-) -> Result<(), ContextError> {
+    context_id: &'c str,
+    sender_did: &'s DID,
+    signing_key: &'k ed25519_dalek::SigningKey,
+) -> impl std::future::Future<Output = Result<(), ContextError>> + Send + use<'d, 'c, 's, 'k> {
+    // SYNC PRELUDE (ADR-049 Decision 7 Send-discipline): the send-authorization
+    // gates and routing reads touch `&PerContextState` (`!Sync`) here and produce
+    // an OWNED `Result`, so the returned future does NOT capture the `state`
+    // lifetime and stays `Send` (mirrors `persist_state_best_effort` /
+    // `send_checkpoint`). `state` is deliberately absent from `use<>`.
+    //
     // Send-authorization gates, mirroring `send_message` (§9.9.2 routes a
     // heartbeat through the same write path, so it must clear the same write
     // gates). Without these a member whose `MessagesWrite` capability was
     // suspended or revoked could keep asserting liveness on the write path,
     // and a heartbeat racing a context close could slip through after the
     // context is no longer active.
-    //
-    // 1. The context must be active. A send racing context-close is rejected.
-    state::require_active(&state.handle)?;
-    // 2. Capability check (broadcast contexts have no per-member write
-    //    capability and address the public broadcast routing ID, exactly as in
-    //    `send_message`). A suspended capability surfaces a distinct message so
-    //    the scheduler's best-effort log is actionable.
-    if state.broadcast_context.is_none()
-        && !state
-            .role_state
-            .member_has_capability(sender_did.as_ref(), &Capability::MessagesWrite)
-    {
-        let is_suspended = state
-            .role_state
-            .suspended_for(sender_did.as_ref())
-            .is_some_and(|s| s.contains(&Capability::MessagesWrite));
-        let msg = if is_suspended {
-            format!("member {sender_did} write access has been revoked")
-        } else {
-            format!("member {sender_did} does not have messages:write capability")
-        };
-        return Err(ContextError::PermissionDenied(msg));
-    }
-
-    // Routing parallels the application-data and checkpoint send paths
-    // (§9.10.4): broadcast contexts address the derivable broadcast RID;
-    // encrypted contexts fan out to each known peer pseudonym. An empty
-    // encrypted routing set (no peers known yet) is a legitimate no-op —
-    // there is simply nobody to signal liveness to.
-    let (broadcast_envelope, recipients_data, routing_ids) = if state.broadcast_context.is_some() {
-        let broadcast_rid = scp_protocol::context::broadcast_routing_id(context_id);
-        (None, std::collections::HashMap::new(), vec![broadcast_rid])
-    } else {
-        let peer_pseudonyms: Vec<[u8; 32]> = state
-            .routing
-            .peer_registry()
-            .map(|reg| reg.values().copied().collect())
-            .unwrap_or_default();
+    type Prep = Result<
         (
-            None,
-            state.access.access_key_store.get_all(context_id),
-            peer_pseudonyms,
-        )
-    };
+            Option<BroadcastEnvelope>,
+            std::collections::HashMap<String, AccessKey>,
+            Vec<[u8; 32]>,
+        ),
+        ContextError,
+    >;
+    let prep: Prep = (|| {
+        // 1. The context must be active. A send racing context-close is rejected.
+        state::require_active(&state.handle)?;
+        // 2. Capability check (broadcast contexts have no per-member write
+        //    capability and address the public broadcast routing ID, exactly as
+        //    in `send_message`). A suspended capability surfaces a distinct
+        //    message so the scheduler's best-effort log is actionable.
+        if state.broadcast_context.is_none()
+            && !state
+                .role_state
+                .member_has_capability(sender_did.as_ref(), &Capability::MessagesWrite)
+        {
+            let is_suspended = state
+                .role_state
+                .suspended_for(sender_did.as_ref())
+                .is_some_and(|s| s.contains(&Capability::MessagesWrite));
+            let msg = if is_suspended {
+                format!("member {sender_did} write access has been revoked")
+            } else {
+                format!("member {sender_did} does not have messages:write capability")
+            };
+            return Err(ContextError::PermissionDenied(msg));
+        }
 
-    encrypt_and_send(
-        deps,
-        broadcast_envelope,
-        // Heartbeats are device/human-originated liveness beacons, not
-        // agent-autonomous messages — sign under `#active` (ADR-039).
-        MessageSigner::Active(signing_key),
-        context_id,
-        sender_did,
-        // Heartbeats carry NO user content — the empty payload is the whole
-        // point: a minimal liveness beacon, padded by the envelope machinery.
-        &[],
-        &recipients_data,
-        // Heartbeats do not consume the application content sequence; the
-        // receive path classifies them before the sequence tracker.
-        0,
-        None,
-        &routing_ids,
-        MessageType::Heartbeat,
-    )
+        // Routing parallels the application-data and checkpoint send paths
+        // (§9.10.4): broadcast contexts address the derivable broadcast RID;
+        // encrypted contexts fan out to each known peer pseudonym. An empty
+        // encrypted routing set (no peers known yet) is a legitimate no-op —
+        // there is simply nobody to signal liveness to.
+        Ok(if state.broadcast_context.is_some() {
+            let broadcast_rid = scp_protocol::context::broadcast_routing_id(context_id);
+            (None, std::collections::HashMap::new(), vec![broadcast_rid])
+        } else {
+            let peer_pseudonyms: Vec<[u8; 32]> = state
+                .routing
+                .peer_registry()
+                .map(|reg| reg.values().copied().collect())
+                .unwrap_or_default();
+            (
+                None,
+                state.access.access_key_store.get_all(context_id),
+                peer_pseudonyms,
+            )
+        })
+    })();
+
+    async move {
+        let (broadcast_envelope, recipients_data, routing_ids) = prep?;
+        encrypt_and_send(
+            deps,
+            broadcast_envelope,
+            // Heartbeats are device/human-originated liveness beacons, not
+            // agent-autonomous messages — sign under `#active` (ADR-039).
+            MessageSigner::Active(signing_key),
+            context_id,
+            sender_did,
+            // Heartbeats carry NO user content — the empty payload is the whole
+            // point: a minimal liveness beacon, padded by the envelope machinery.
+            &[],
+            &recipients_data,
+            // Heartbeats do not consume the application content sequence; the
+            // receive path classifies them before the sequence tracker.
+            0,
+            None,
+            &routing_ids,
+            MessageType::Heartbeat,
+        )
+        .await
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -2255,7 +2283,8 @@ pub async fn finalize_send(
         // Checkpoint tracking (§9.9.3).
         *view.checkpoint_events_since_mut() += 1;
     }
-    create_and_broadcast_checkpoint_if_due(cell, deps, context_id, sender_did, signing_key, now);
+    create_and_broadcast_checkpoint_if_due(cell, deps, context_id, sender_did, signing_key, now)
+        .await;
 
     // Reconcile the GROW-armed `downward_auth_sink` with the send's nonce `token`
     // so EXACTLY ONE fail-closed persist is owed on every branch (ADR-049 §9,
@@ -2301,7 +2330,7 @@ pub async fn finalize_send(
 /// consistency-monitoring artifact, not part of the message's delivery
 /// guarantee. A missing signing key (e.g. a context with no local custody)
 /// skips checkpoint creation entirely.
-fn create_and_broadcast_checkpoint_if_due(
+async fn create_and_broadcast_checkpoint_if_due(
     cell: &mut crate::context::actor::class_s::ClassSCell,
     deps: &ActorDeps,
     context_id: &str,
@@ -2332,7 +2361,7 @@ fn create_and_broadcast_checkpoint_if_due(
     };
     // `send_checkpoint` takes a SHARED `&PerContextState`, reachable via `&*cell`.
     if let Some(checkpoint) = due_checkpoint
-        && let Err(e) = send_checkpoint(deps, cell, context_id, sender_did, sk, &checkpoint)
+        && let Err(e) = send_checkpoint(deps, cell, context_id, sender_did, sk, &checkpoint).await
     {
         tracing::warn!(
             context_id,

--- a/crates/scp-runtime/src/context/state.rs
+++ b/crates/scp-runtime/src/context/state.rs
@@ -167,6 +167,17 @@ pub enum CommitOperation {
         /// The DID of the member who left.
         member_did: DID,
     },
+    /// Commit produced by `recovery_advance_epoch` — the spec §9.12 step-2
+    /// post-compromise recovery epoch advance (an MLS Update + self-Commit).
+    ///
+    /// Broadcasting this Commit is what re-keys the group away from the
+    /// compromised material: until remaining members process it they stay on
+    /// the compromised epoch and the excluded/compromised party retains read
+    /// access. It carries no reason/target payload — the epoch advance is fully
+    /// determined by the context state. Like the other epoch-advancing commits
+    /// it rides the persistent retry queue, so a dropped broadcast fail-closes
+    /// the context rather than silently completing recovery.
+    RecoveryAdvanceEpoch,
 }
 
 impl CommitOperation {
@@ -184,6 +195,7 @@ impl CommitOperation {
                 is_remove: false, ..
             } => "ResetMemberAdd".to_owned(),
             Self::LeaveContext { .. } => "LeaveContext".to_owned(),
+            Self::RecoveryAdvanceEpoch => "RecoveryAdvanceEpoch".to_owned(),
         }
     }
 }

--- a/crates/scp-runtime/src/context/state.rs
+++ b/crates/scp-runtime/src/context/state.rs
@@ -94,7 +94,7 @@ pub const MAX_COMMIT_AGE_SECS: u64 = 3600; // 1 hour
 /// Maximum number of pending commits allowed in the retry queue per context.
 ///
 /// Prevents unbounded memory growth during sustained transport outages.
-/// When this cap is reached, [`try_broadcast_commit_or_enqueue`](crate::context::governance_helpers::try_broadcast_commit_or_enqueue) sets the
+/// When this cap is reached, [`apply_broadcast_failure`](crate::context::governance_helpers::apply_broadcast_failure) sets the
 /// `commit_fault` marker immediately rather than enqueuing, fail-closing
 /// the context for operator attention.
 pub const MAX_PENDING_COMMITS: usize = 50;

--- a/crates/scp-runtime/src/context/supervisor/key_package_actor.rs
+++ b/crates/scp-runtime/src/context/supervisor/key_package_actor.rs
@@ -1066,7 +1066,7 @@ impl KeyPackageStoreActor {
                 let _ = reply.send(result);
             }
             KeyPackageCommand::Publish { reply } => {
-                let result = self.handle_publish();
+                let result = self.handle_publish().await;
                 let _ = reply.send(result);
             }
             KeyPackageCommand::ListPooled { reply } => {
@@ -1576,7 +1576,7 @@ impl KeyPackageStoreActor {
     /// happens). Idempotent: a `kp_ref` already published is skipped, and it is
     /// marked published only after the transport accepts it. An empty pool is a
     /// no-op success.
-    fn handle_publish(&mut self) -> Result<(), ContextError> {
+    async fn handle_publish(&mut self) -> Result<(), ContextError> {
         // Snapshot the refs+bytes to publish so we don't borrow `self.pool`
         // while mutating `published_refs`. The transport publish is sync.
         let to_publish: Vec<(KpRef, Vec<u8>)> = self
@@ -1592,6 +1592,7 @@ impl KeyPackageStoreActor {
             }
             self.transport
                 .publish_key_package(&owner_did, &public_bytes)
+                .await
                 .map_err(|e| {
                     ContextError::TransportFailed(format!("publishing key package: {e}"))
                 })?;

--- a/crates/scp-runtime/src/context/supervisor/key_package_actor_tests.rs
+++ b/crates/scp-runtime/src/context/supervisor/key_package_actor_tests.rs
@@ -3112,28 +3112,33 @@ impl RecordingTransport {
     }
 }
 
+#[async_trait::async_trait]
 impl ContextTransportProvider for RecordingTransport {
     fn is_connected(&self) -> bool {
         true
     }
-    fn publish_context(
+    async fn publish_context(
         &self,
         _context_id: &[u8; 32],
         _params: &ContextParams,
     ) -> Result<(), ContextCreationError> {
         Ok(())
     }
-    fn delete_published(&self, _context_id: &[u8; 32]) -> Result<(), ContextCreationError> {
+    async fn delete_published(&self, _context_id: &[u8; 32]) -> Result<(), ContextCreationError> {
         Ok(())
     }
-    fn send_message(
+    async fn send_message(
         &self,
         _context_id: &[u8; 32],
         _encrypted_payload: &[u8],
     ) -> Result<(), ContextError> {
         Ok(())
     }
-    fn publish_key_package(&self, owner_did: &str, _kp_bytes: &[u8]) -> Result<(), ContextError> {
+    async fn publish_key_package(
+        &self,
+        owner_did: &str,
+        _kp_bytes: &[u8],
+    ) -> Result<(), ContextError> {
         if self.fail.load(Ordering::Acquire) {
             return Err(ContextError::TransportFailed("injected".to_owned()));
         }

--- a/crates/scp-runtime/src/context/supervisor/spawn_from_welcome_tests.rs
+++ b/crates/scp-runtime/src/context/supervisor/spawn_from_welcome_tests.rs
@@ -2442,12 +2442,13 @@ struct BroadcastWatchTransport {
     saw_broadcast: Arc<std::sync::atomic::AtomicBool>,
 }
 
+#[async_trait::async_trait]
 impl ContextTransportProvider for BroadcastWatchTransport {
     fn is_connected(&self) -> bool {
         true
     }
 
-    fn publish_context(
+    async fn publish_context(
         &self,
         _context_id: &[u8; 32],
         _params: &ContextParams,
@@ -2455,14 +2456,14 @@ impl ContextTransportProvider for BroadcastWatchTransport {
         Ok(())
     }
 
-    fn delete_published(
+    async fn delete_published(
         &self,
         _context_id: &[u8; 32],
     ) -> Result<(), scp_protocol::context::builder::ContextCreationError> {
         Ok(())
     }
 
-    fn send_message(
+    async fn send_message(
         &self,
         context_id: &[u8; 32],
         encrypted_payload: &[u8],
@@ -2699,12 +2700,13 @@ async fn invite_member_by_non_admin_is_rejected() {
 /// Welcome can never be delivered.
 struct FatalDeliveryTransport;
 
+#[async_trait::async_trait]
 impl ContextTransportProvider for FatalDeliveryTransport {
     fn is_connected(&self) -> bool {
         true
     }
 
-    fn publish_context(
+    async fn publish_context(
         &self,
         _context_id: &[u8; 32],
         _params: &ContextParams,
@@ -2712,7 +2714,7 @@ impl ContextTransportProvider for FatalDeliveryTransport {
         Ok(())
     }
 
-    fn delete_published(
+    async fn delete_published(
         &self,
         _context_id: &[u8; 32],
     ) -> Result<(), scp_protocol::context::builder::ContextCreationError> {
@@ -2721,7 +2723,7 @@ impl ContextTransportProvider for FatalDeliveryTransport {
 
     // Commit broadcast succeeds (so both the add and the compensating remove
     // deliver their epoch Commits without enqueuing).
-    fn send_message(
+    async fn send_message(
         &self,
         _context_id: &[u8; 32],
         _encrypted_payload: &[u8],
@@ -2731,7 +2733,7 @@ impl ContextTransportProvider for FatalDeliveryTransport {
 
     // Invitation delivery fails FATALLY (not `TransportFailed`), so the invitee
     // gets nothing — this is the case that must trigger the compensating remove.
-    fn send_to_routing_id(
+    async fn send_to_routing_id(
         &self,
         _routing_id: &[u8; 32],
         _payload: &[u8],
@@ -3017,12 +3019,13 @@ struct AcceptingSendTransport {
     sends: Arc<std::sync::atomic::AtomicUsize>,
 }
 
+#[async_trait::async_trait]
 impl ContextTransportProvider for AcceptingSendTransport {
     fn is_connected(&self) -> bool {
         true
     }
 
-    fn publish_context(
+    async fn publish_context(
         &self,
         _context_id: &[u8; 32],
         _params: &ContextParams,
@@ -3030,14 +3033,14 @@ impl ContextTransportProvider for AcceptingSendTransport {
         Ok(())
     }
 
-    fn delete_published(
+    async fn delete_published(
         &self,
         _context_id: &[u8; 32],
     ) -> Result<(), scp_protocol::context::builder::ContextCreationError> {
         Ok(())
     }
 
-    fn send_message(
+    async fn send_message(
         &self,
         _context_id: &[u8; 32],
         encrypted_payload: &[u8],

--- a/crates/scp-runtime/src/context/supervisor/supervisor.rs
+++ b/crates/scp-runtime/src/context/supervisor/supervisor.rs
@@ -3600,13 +3600,15 @@ impl Supervisor {
             // has a digest-keyed MLS group at a non-zero MLS epoch.
             TrustRecoveryCommand::RecoverySendNotification { payload, reply } => {
                 let signing_key = payload.signing_key.to_signing_key();
-                let send_result = self.recovery_send_notification_direct(
-                    &payload.context_id,
-                    &payload.sender_did,
-                    &payload.payload,
-                    payload.sequence,
-                    &signing_key,
-                );
+                let send_result = self
+                    .recovery_send_notification_direct(
+                        &payload.context_id,
+                        &payload.sender_did,
+                        &payload.payload,
+                        payload.sequence,
+                        &signing_key,
+                    )
+                    .await;
                 match send_result {
                     Ok(()) => {
                         let _ = reply.send(Ok(()));
@@ -3671,7 +3673,7 @@ impl Supervisor {
     /// - [`ContextError::CryptoFailed`] if envelope signing or sealing
     ///   fails.
     /// - Any [`ContextError`] surfaced by the transport's `send_message`.
-    fn recovery_send_notification_direct(
+    async fn recovery_send_notification_direct(
         &self,
         context_id: &str,
         sender_did: &str,
@@ -3735,7 +3737,7 @@ impl Supervisor {
             300, // 5 minute blob TTL
         )?;
 
-        transport.send_message(&routing_id, &encrypted)?;
+        transport.send_message(&routing_id, &encrypted).await?;
 
         Ok(())
     }
@@ -9283,6 +9285,7 @@ impl Supervisor {
                                     )
                                 })?
                                 .publish_context(&context_id_bytes, &params)
+                                .await
                                 .map_err(|e| {
                                     ContextError::TransportFailed(format!(
                                         "reconnection failed for context {context_id}: {e}"
@@ -10803,7 +10806,10 @@ impl Supervisor {
             let routing_id = envelope_seal::derive_invitation_routing_id(invitee_did.as_ref());
             let delivered = match self.transport_ref() {
                 Some(transport) => {
-                    match transport.send_to_routing_id(&routing_id, &payload, INVITATION_TTL_SECS) {
+                    match transport
+                        .send_to_routing_id(&routing_id, &payload, INVITATION_TTL_SECS)
+                        .await
+                    {
                         Ok(()) => true,
                         // A transport that does not support routing-id delivery (or
                         // is offline) returns TransportFailed; this is NON-FATAL:
@@ -15834,13 +15840,15 @@ mod tests {
         assert_ne!(raw_bytes, digest);
 
         let signing_key = ed25519_dalek::SigningKey::from_bytes(&[0x11u8; 32]);
-        let result = sup.recovery_send_notification_direct(
-            &context_id,
-            "did:example:recovery-sender",
-            b"recovery-notification-payload",
-            1,
-            &signing_key,
-        );
+        let result = sup
+            .recovery_send_notification_direct(
+                &context_id,
+                "did:example:recovery-sender",
+                b"recovery-notification-payload",
+                1,
+                &signing_key,
+            )
+            .await;
 
         // The seal MUST have succeeded (state found under the digest), so the
         // method reaches the transport step and fails THERE with

--- a/crates/scp-runtime/src/context/trust_recovery_helpers.rs
+++ b/crates/scp-runtime/src/context/trust_recovery_helpers.rs
@@ -205,7 +205,8 @@ pub fn add_checkpoint_cosignature(
 /// which could leave this node at epoch N+1 believing recovery succeeded while
 /// remaining members stayed at epoch N still using the compromised keys (silent
 /// post-compromise desync). Recovery re-entry itself does NOT read `commit_fault`
-/// (that gate trips only on a full retry queue and only blocks
+/// (that gate trips on a full retry queue OR on retry exhaustion
+/// (`MAX_COMMIT_RETRIES`) in the retry drain, and only blocks
 /// send/lifecycle/governance), so the fail-close here cannot deadlock recovery.
 ///
 /// # No relock / generation gate

--- a/crates/scp-runtime/src/context/trust_recovery_helpers.rs
+++ b/crates/scp-runtime/src/context/trust_recovery_helpers.rs
@@ -227,6 +227,7 @@ pub async fn recovery_advance_epoch(
         if let Err(e) = deps
             .transport
             .send_message(&routing_id, &epoch_output.commit_bytes)
+            .await
         {
             tracing::warn!(
                 context_id = %context_id,
@@ -321,7 +322,7 @@ pub async fn recovery_advance_epoch(
 /// through `deps.crypto` (still supervisor-scoped during the migration
 /// window); transport delivery via `deps.transport`. Does NOT mutate
 /// `state`.
-pub fn recovery_send_notification(
+pub async fn recovery_send_notification(
     cell: &mut ClassSCell,
     deps: &ActorDeps,
     context_id: &str,
@@ -369,7 +370,7 @@ pub fn recovery_send_notification(
     )?;
 
     // Send via transport using the domain-separated routing ID.
-    deps.transport.send_message(&routing_id, &encrypted)?;
+    deps.transport.send_message(&routing_id, &encrypted).await?;
 
     Ok(())
 }

--- a/crates/scp-runtime/src/context/trust_recovery_helpers.rs
+++ b/crates/scp-runtime/src/context/trust_recovery_helpers.rs
@@ -55,7 +55,8 @@ use scp_protocol::context::governance::{
 use crate::context::actor::class_s::ClassSCell;
 use crate::context::actor::deps::ActorDeps;
 use crate::context::actor::state::PerContextState;
-use crate::context::state::{context_id_to_bytes, require_active};
+use crate::context::governance_helpers::{keep_broadcast_failure, try_broadcast_commit};
+use crate::context::state::{CommitOperation, context_id_to_bytes, require_active};
 
 // ---------------------------------------------------------------------------
 // 1. create_governance_checkpoint
@@ -192,6 +193,21 @@ pub fn add_checkpoint_cosignature(
 /// `deps.transport`; the epoch-advancement event is appended via
 /// `deps.event_log`.
 ///
+/// # Fail-closed broadcast (spec §9.12 / ADR-049 §9)
+///
+/// The epoch-advance Commit rides the SAME persistent retry queue as the other
+/// epoch-advancing commits: [`try_broadcast_commit`] +
+/// [`keep_broadcast_failure`]. On transport failure the `commit_fault`
+/// safety-gate marker and the `pending_commits` retry entry are persisted
+/// FAIL-CLOSED (a second `commit_class_s_keep`), and a second-persist failure
+/// aborts recovery with [`ContextError::PersistenceFailed`] — recovery is NOT
+/// acked unless the retry is durable. This replaces the former warn-and-drop,
+/// which could leave this node at epoch N+1 believing recovery succeeded while
+/// remaining members stayed at epoch N still using the compromised keys (silent
+/// post-compromise desync). Recovery re-entry itself does NOT read `commit_fault`
+/// (that gate trips only on a full retry queue and only blocks
+/// send/lifecycle/governance), so the fail-close here cannot deadlock recovery.
+///
 /// # No relock / generation gate
 ///
 /// The legacy version dropped the per-context lock around the MLS
@@ -220,21 +236,27 @@ pub async fn recovery_advance_epoch(
     //    fails the bookkeeping counter is NOT incremented.
     let epoch_output = deps.crypto.advance_epoch(&context_id_bytes)?;
 
-    // 2b. Broadcast the MLS Commit to all members so they can advance
-    //     their group epoch and ratchet key material.
-    if !epoch_output.commit_bytes.is_empty() {
-        let routing_id = scp_protocol::context::context_routing_id(context_id);
-        if let Err(e) = deps
-            .transport
-            .send_message(&routing_id, &epoch_output.commit_bytes)
-            .await
-        {
-            tracing::warn!(
-                context_id = %context_id,
-                error = %e,
-                "failed to broadcast recovery epoch advance MLS Commit"
-            );
-        }
+    // 2b. Broadcast the MLS Commit to all members so they advance their group
+    //     epoch and ratchet key material AWAY from the compromised keys. Broadcast
+    //     async (ADR-049 Decision 7); on FAILURE the retry-queue bookkeeping — the
+    //     `commit_fault` safety-gate marker and the `pending_commits` entry that is
+    //     the ONLY re-delivery of this Commit — is persisted FAIL-CLOSED via
+    //     `keep_broadcast_failure`. This is the highest-stakes safety-gated
+    //     broadcast in the system: a warn-and-drop here would leave the local node
+    //     at epoch N+1 believing recovery succeeded while remaining members stay at
+    //     epoch N still using the compromised keys — silent post-compromise desync
+    //     letting the excluded/compromised party retain read access (spec §9.12).
+    //     `try_broadcast_commit` no-ops on empty bytes (the cfg(test) no-crypto
+    //     pipeline), so no `is_empty` guard is needed here.
+    if let Some(failure) = try_broadcast_commit(
+        deps,
+        context_id,
+        epoch_output.commit_bytes,
+        &CommitOperation::RecoveryAdvanceEpoch,
+    )
+    .await
+    {
+        keep_broadcast_failure(cell, deps, context_id, failure).await?;
     }
 
     // 3. Re-validate after the crypto op to close the TOCTOU window

--- a/crates/scp-runtime/src/context/ttl.rs
+++ b/crates/scp-runtime/src/context/ttl.rs
@@ -689,7 +689,7 @@ pub async fn finalize_close(
             .destroy_sender_key(&context_id_bytes)
             .map_err(|e| ContextError::CryptoFailed(e.to_string()))?;
 
-        let _ = transport.delete_published(&context_id_bytes);
+        let _ = transport.delete_published(&context_id_bytes).await;
     }
 
     event_log
@@ -886,7 +886,7 @@ pub async fn try_ttl_expiry_cleanup(
         // keys are destroyed and the data is unreadable. Not tracked in the
         // bitmask since it is best-effort by design.
         if let Some(transport) = transport
-            && let Err(e) = transport.delete_published(&context_id_bytes)
+            && let Err(e) = transport.delete_published(&context_id_bytes).await
         {
             tracing::warn!(context_id = %context_id, error = %e,
                 "best-effort relay deletion failed after TTL expiry");
@@ -1350,24 +1350,25 @@ mod tests {
 
     struct NullTransport;
 
+    #[async_trait::async_trait]
     impl ContextTransportProvider for NullTransport {
         fn is_connected(&self) -> bool {
             true
         }
-        fn publish_context(
+        async fn publish_context(
             &self,
             _cid: &[u8; 32],
             _p: &ContextParams,
         ) -> Result<(), scp_protocol::context::builder::ContextCreationError> {
             Ok(())
         }
-        fn delete_published(
+        async fn delete_published(
             &self,
             _cid: &[u8; 32],
         ) -> Result<(), scp_protocol::context::builder::ContextCreationError> {
             Ok(())
         }
-        fn send_message(&self, _cid: &[u8; 32], _payload: &[u8]) -> Result<(), ContextError> {
+        async fn send_message(&self, _cid: &[u8; 32], _payload: &[u8]) -> Result<(), ContextError> {
             Ok(())
         }
     }

--- a/crates/scp-runtime/src/identity/recovery.rs
+++ b/crates/scp-runtime/src/identity/recovery.rs
@@ -1986,21 +1986,22 @@ mod tests {
         const TEST_DID: &str = "did:dht:z6MkhaXgBZDvotDkL5257faiztiGiC2QtKLGpbnnEGta2doK";
 
         struct TestTransport;
+        #[async_trait::async_trait]
         impl ContextTransportProvider for TestTransport {
             fn is_connected(&self) -> bool {
                 true
             }
-            fn publish_context(
+            async fn publish_context(
                 &self,
                 _: &[u8; 32],
                 _: &ContextParams,
             ) -> Result<(), ContextCreationError> {
                 Ok(())
             }
-            fn delete_published(&self, _: &[u8; 32]) -> Result<(), ContextCreationError> {
+            async fn delete_published(&self, _: &[u8; 32]) -> Result<(), ContextCreationError> {
                 Ok(())
             }
-            fn send_message(&self, _: &[u8; 32], _: &[u8]) -> Result<(), ContextError> {
+            async fn send_message(&self, _: &[u8; 32], _: &[u8]) -> Result<(), ContextError> {
                 Ok(())
             }
         }

--- a/crates/scp-runtime/tests/content_access_governance_integration.rs
+++ b/crates/scp-runtime/tests/content_access_governance_integration.rs
@@ -58,21 +58,26 @@ impl MockTransport {
     }
 }
 
+#[async_trait::async_trait]
 impl ContextTransportProvider for MockTransport {
     fn is_connected(&self) -> bool {
         self.connected.load(Ordering::Relaxed)
     }
-    fn publish_context(
+    async fn publish_context(
         &self,
         _id: &[u8; 32],
         _params: &ContextParams,
     ) -> Result<(), ContextCreationError> {
         Ok(())
     }
-    fn delete_published(&self, _id: &[u8; 32]) -> Result<(), ContextCreationError> {
+    async fn delete_published(&self, _id: &[u8; 32]) -> Result<(), ContextCreationError> {
         Ok(())
     }
-    fn send_message(&self, _id: &[u8; 32], _encrypted_payload: &[u8]) -> Result<(), ContextError> {
+    async fn send_message(
+        &self,
+        _id: &[u8; 32],
+        _encrypted_payload: &[u8],
+    ) -> Result<(), ContextError> {
         Ok(())
     }
 }

--- a/crates/scp-runtime/tests/content_access_integration.rs
+++ b/crates/scp-runtime/tests/content_access_integration.rs
@@ -106,21 +106,26 @@ impl MockTransport {
     }
 }
 
+#[async_trait::async_trait]
 impl ContextTransportProvider for MockTransport {
     fn is_connected(&self) -> bool {
         self.connected.load(Ordering::Relaxed)
     }
-    fn publish_context(
+    async fn publish_context(
         &self,
         _id: &[u8; 32],
         _params: &ContextParams,
     ) -> Result<(), ContextCreationError> {
         Ok(())
     }
-    fn delete_published(&self, _id: &[u8; 32]) -> Result<(), ContextCreationError> {
+    async fn delete_published(&self, _id: &[u8; 32]) -> Result<(), ContextCreationError> {
         Ok(())
     }
-    fn send_message(&self, _id: &[u8; 32], _encrypted_payload: &[u8]) -> Result<(), ContextError> {
+    async fn send_message(
+        &self,
+        _id: &[u8; 32],
+        _encrypted_payload: &[u8],
+    ) -> Result<(), ContextError> {
         Ok(())
     }
 }

--- a/crates/scp-runtime/tests/context_config_create.rs
+++ b/crates/scp-runtime/tests/context_config_create.rs
@@ -40,21 +40,26 @@ impl MockTransport {
     }
 }
 
+#[async_trait::async_trait]
 impl ContextTransportProvider for MockTransport {
     fn is_connected(&self) -> bool {
         self.connected.load(Ordering::Relaxed)
     }
-    fn publish_context(
+    async fn publish_context(
         &self,
         _id: &[u8; 32],
         _params: &ContextParams,
     ) -> Result<(), ContextCreationError> {
         Ok(())
     }
-    fn delete_published(&self, _id: &[u8; 32]) -> Result<(), ContextCreationError> {
+    async fn delete_published(&self, _id: &[u8; 32]) -> Result<(), ContextCreationError> {
         Ok(())
     }
-    fn send_message(&self, _id: &[u8; 32], _encrypted_payload: &[u8]) -> Result<(), ContextError> {
+    async fn send_message(
+        &self,
+        _id: &[u8; 32],
+        _encrypted_payload: &[u8],
+    ) -> Result<(), ContextError> {
         Ok(())
     }
 }

--- a/crates/scp-runtime/tests/event_channel_producer.rs
+++ b/crates/scp-runtime/tests/event_channel_producer.rs
@@ -50,21 +50,26 @@ impl MockTransport {
     }
 }
 
+#[async_trait::async_trait]
 impl ContextTransportProvider for MockTransport {
     fn is_connected(&self) -> bool {
         self.connected.load(Ordering::Relaxed)
     }
-    fn publish_context(
+    async fn publish_context(
         &self,
         _id: &[u8; 32],
         _params: &ContextParams,
     ) -> Result<(), ContextCreationError> {
         Ok(())
     }
-    fn delete_published(&self, _id: &[u8; 32]) -> Result<(), ContextCreationError> {
+    async fn delete_published(&self, _id: &[u8; 32]) -> Result<(), ContextCreationError> {
         Ok(())
     }
-    fn send_message(&self, _id: &[u8; 32], _encrypted_payload: &[u8]) -> Result<(), ContextError> {
+    async fn send_message(
+        &self,
+        _id: &[u8; 32],
+        _encrypted_payload: &[u8],
+    ) -> Result<(), ContextError> {
         Ok(())
     }
 }

--- a/crates/scp-runtime/tests/governance_integration.rs
+++ b/crates/scp-runtime/tests/governance_integration.rs
@@ -71,21 +71,26 @@ impl MockTransport {
     }
 }
 
+#[async_trait::async_trait]
 impl ContextTransportProvider for MockTransport {
     fn is_connected(&self) -> bool {
         self.connected.load(Ordering::Relaxed)
     }
-    fn publish_context(
+    async fn publish_context(
         &self,
         _id: &[u8; 32],
         _params: &ContextParams,
     ) -> Result<(), ContextCreationError> {
         Ok(())
     }
-    fn delete_published(&self, _id: &[u8; 32]) -> Result<(), ContextCreationError> {
+    async fn delete_published(&self, _id: &[u8; 32]) -> Result<(), ContextCreationError> {
         Ok(())
     }
-    fn send_message(&self, _id: &[u8; 32], _encrypted_payload: &[u8]) -> Result<(), ContextError> {
+    async fn send_message(
+        &self,
+        _id: &[u8; 32],
+        _encrypted_payload: &[u8],
+    ) -> Result<(), ContextError> {
         Ok(())
     }
 }

--- a/crates/scp-runtime/tests/pseudonym_routing_integration.rs
+++ b/crates/scp-runtime/tests/pseudonym_routing_integration.rs
@@ -71,21 +71,26 @@ impl RecordingTransport {
     }
 }
 
+#[async_trait::async_trait]
 impl ContextTransportProvider for RecordingTransport {
     fn is_connected(&self) -> bool {
         self.connected.load(Ordering::Relaxed)
     }
-    fn publish_context(
+    async fn publish_context(
         &self,
         _id: &[u8; 32],
         _params: &ContextParams,
     ) -> Result<(), ContextCreationError> {
         Ok(())
     }
-    fn delete_published(&self, _id: &[u8; 32]) -> Result<(), ContextCreationError> {
+    async fn delete_published(&self, _id: &[u8; 32]) -> Result<(), ContextCreationError> {
         Ok(())
     }
-    fn send_message(&self, id: &[u8; 32], _encrypted_payload: &[u8]) -> Result<(), ContextError> {
+    async fn send_message(
+        &self,
+        id: &[u8; 32],
+        _encrypted_payload: &[u8],
+    ) -> Result<(), ContextError> {
         self.routing_ids.lock().expect("lock").push(*id);
         Ok(())
     }
@@ -159,22 +164,23 @@ fn manager_with_transport(transport: Arc<RecordingTransport>) -> std::sync::Arc<
 /// inspect captured routing IDs after the supervisor sends.
 struct TransportShim(Arc<RecordingTransport>);
 
+#[async_trait::async_trait]
 impl ContextTransportProvider for TransportShim {
     fn is_connected(&self) -> bool {
         self.0.is_connected()
     }
-    fn publish_context(
+    async fn publish_context(
         &self,
         id: &[u8; 32],
         params: &ContextParams,
     ) -> Result<(), ContextCreationError> {
-        self.0.publish_context(id, params)
+        self.0.publish_context(id, params).await
     }
-    fn delete_published(&self, id: &[u8; 32]) -> Result<(), ContextCreationError> {
-        self.0.delete_published(id)
+    async fn delete_published(&self, id: &[u8; 32]) -> Result<(), ContextCreationError> {
+        self.0.delete_published(id).await
     }
-    fn send_message(&self, id: &[u8; 32], payload: &[u8]) -> Result<(), ContextError> {
-        self.0.send_message(id, payload)
+    async fn send_message(&self, id: &[u8; 32], payload: &[u8]) -> Result<(), ContextError> {
+        self.0.send_message(id, payload).await
     }
 }
 

--- a/crates/scp-testing/src/fullstack/node.rs
+++ b/crates/scp-testing/src/fullstack/node.rs
@@ -138,12 +138,13 @@ impl CapturingTransport {
     }
 }
 
+#[async_trait::async_trait]
 impl ContextTransportProvider for CapturingTransport {
     fn is_connected(&self) -> bool {
         true
     }
 
-    fn publish_context(
+    async fn publish_context(
         &self,
         _context_id: &[u8; 32],
         _params: &ContextParams,
@@ -151,11 +152,11 @@ impl ContextTransportProvider for CapturingTransport {
         Ok(())
     }
 
-    fn delete_published(&self, _context_id: &[u8; 32]) -> Result<(), ContextCreationError> {
+    async fn delete_published(&self, _context_id: &[u8; 32]) -> Result<(), ContextCreationError> {
         Ok(())
     }
 
-    fn send_message(
+    async fn send_message(
         &self,
         context_id: &[u8; 32],
         encrypted_payload: &[u8],

--- a/crates/scp-testing/tests/integration/persistence.rs
+++ b/crates/scp-testing/tests/integration/persistence.rs
@@ -880,21 +880,22 @@ mod mock_providers {
     }
 
     pub struct MockTransport;
+    #[async_trait::async_trait]
     impl ContextTransportProvider for MockTransport {
         fn is_connected(&self) -> bool {
             true
         }
-        fn publish_context(
+        async fn publish_context(
             &self,
             _ctx_id: &[u8; 32],
             _params: &ContextParams,
         ) -> Result<(), ContextCreationError> {
             Ok(())
         }
-        fn delete_published(&self, _ctx_id: &[u8; 32]) -> Result<(), ContextCreationError> {
+        async fn delete_published(&self, _ctx_id: &[u8; 32]) -> Result<(), ContextCreationError> {
             Ok(())
         }
-        fn send_message(
+        async fn send_message(
             &self,
             _ctx_id: &[u8; 32],
             _encrypted_payload: &[u8],

--- a/crates/scp-testing/tests/integration/tool_economy_wiring.rs
+++ b/crates/scp-testing/tests/integration/tool_economy_wiring.rs
@@ -148,21 +148,22 @@ impl MockTransport {
     }
 }
 
+#[async_trait::async_trait]
 impl ContextTransportProvider for MockTransport {
     fn is_connected(&self) -> bool {
         self.connected.load(Ordering::Relaxed)
     }
-    fn publish_context(
+    async fn publish_context(
         &self,
         _id: &[u8; 32],
         _params: &ContextParams,
     ) -> Result<(), ContextCreationError> {
         Ok(())
     }
-    fn delete_published(&self, _id: &[u8; 32]) -> Result<(), ContextCreationError> {
+    async fn delete_published(&self, _id: &[u8; 32]) -> Result<(), ContextCreationError> {
         Ok(())
     }
-    fn send_message(
+    async fn send_message(
         &self,
         _ctx_id: &[u8; 32],
         _encrypted_payload: &[u8],

--- a/crates/scp-transport/src/native/relay_persistence.rs
+++ b/crates/scp-transport/src/native/relay_persistence.rs
@@ -115,7 +115,9 @@ pub trait RelayPersistence: Send + Sync + fmt::Debug {
 // ---------------------------------------------------------------------------
 
 /// Bridges any [`Storage`](scp_platform::Storage) implementation to
-/// [`RelayPersistence`] using the sync-to-async bridge pattern.
+/// [`RelayPersistence`]. Being an async trait (ADR-049 Decision 7), each method
+/// `.await`s the async `Storage` backend directly — there is NO `block_in_place`
+/// sync→async bridge (the pattern PR-3 deleted).
 ///
 /// Key layout:
 /// - `relay/subscription/{routing_id_hex}` — marker value `b"1"`

--- a/crates/scp-transport/src/native/relay_persistence.rs
+++ b/crates/scp-transport/src/native/relay_persistence.rs
@@ -1,9 +1,11 @@
 //! Relay operational state persistence (SCP-PERSIST-066).
 //!
-//! Defines [`RelayPersistence`], a dyn-compatible trait for persisting relay
-//! operational state (subscriptions, rate limits) across relay restarts.
-//! Follows the same synchronous-trait-with-async-bridge pattern used by
-//! `ContextPersistence` in `scp-core`.
+//! Defines [`RelayPersistence`], a dyn-compatible **async** trait for
+//! persisting relay operational state (subscriptions, rate limits) across
+//! relay restarts. Follows the async-provider-trait pattern used by
+//! `ContextPersistence` / `EventLogPersistence` in `scp-core` (ADR-049
+//! Decision 7): the methods `.await` the async [`Storage`](scp_platform::Storage)
+//! backend directly — there is NO `block_in_place` sync→async bridge.
 //!
 //! The canonical implementation `StorageRelayPersistence` wraps any
 //! `Storage` implementation.
@@ -30,11 +32,18 @@ const RATE_LIMIT_PREFIX: &str = "relay/rate_limit/";
 
 /// Provider for persisting relay operational state across restarts.
 ///
-/// Implementors must be dyn-compatible (`Send + Sync`, synchronous methods).
-/// All methods are best-effort — the relay logs errors but does not abort
-/// operations when persistence fails.
+/// Implementors must be dyn-compatible (`Send + Sync`, async methods via
+/// `#[async_trait]`). All methods are best-effort — the relay logs errors but
+/// does not abort operations when persistence fails.
+///
+/// # Async discipline (ADR-049 Decision 7)
+///
+/// Plain `#[async_trait]` (Send), not `?Send`: the relay holds the provider as
+/// `Arc<dyn RelayPersistence>` and calls it from spawned async tasks, so the
+/// method futures must be `Send`.
 ///
 /// See SCP-PERSIST-066.
+#[async_trait::async_trait]
 pub trait RelayPersistence: Send + Sync + fmt::Debug {
     /// Records that `routing_id` has an active subscription.
     ///
@@ -44,7 +53,7 @@ pub trait RelayPersistence: Send + Sync + fmt::Debug {
     /// # Errors
     ///
     /// Returns an error if the storage backend fails.
-    fn persist_subscription(&self, routing_id: &[u8; 32]) -> Result<(), BoxError>;
+    async fn persist_subscription(&self, routing_id: &[u8; 32]) -> Result<(), BoxError>;
 
     /// Removes the subscription record for `routing_id`.
     ///
@@ -54,7 +63,7 @@ pub trait RelayPersistence: Send + Sync + fmt::Debug {
     /// # Errors
     ///
     /// Returns an error if the storage backend fails.
-    fn remove_subscription(&self, routing_id: &[u8; 32]) -> Result<(), BoxError>;
+    async fn remove_subscription(&self, routing_id: &[u8; 32]) -> Result<(), BoxError>;
 
     /// Loads all persisted routing IDs that had active subscriptions.
     ///
@@ -66,7 +75,7 @@ pub trait RelayPersistence: Send + Sync + fmt::Debug {
     /// # Errors
     ///
     /// Returns an error if the storage backend fails.
-    fn load_subscribed_routing_ids(&self) -> Result<Vec<[u8; 32]>, BoxError>;
+    async fn load_subscribed_routing_ids(&self) -> Result<Vec<[u8; 32]>, BoxError>;
 
     /// Persists rate limit state for an IP address.
     ///
@@ -75,7 +84,7 @@ pub trait RelayPersistence: Send + Sync + fmt::Debug {
     /// # Errors
     ///
     /// Returns an error if the storage backend fails.
-    fn persist_rate_limit(
+    async fn persist_rate_limit(
         &self,
         ip: &str,
         tokens: f64,
@@ -89,7 +98,7 @@ pub trait RelayPersistence: Send + Sync + fmt::Debug {
     /// # Errors
     ///
     /// Returns an error if the storage backend fails.
-    fn load_rate_limit(&self, ip: &str) -> Result<Option<(f64, u64)>, BoxError>;
+    async fn load_rate_limit(&self, ip: &str) -> Result<Option<(f64, u64)>, BoxError>;
 
     /// Deletes all persisted relay state.
     ///
@@ -98,7 +107,7 @@ pub trait RelayPersistence: Send + Sync + fmt::Debug {
     /// # Errors
     ///
     /// Returns an error if the storage backend fails.
-    fn clear_all(&self) -> Result<(), BoxError>;
+    async fn clear_all(&self) -> Result<(), BoxError>;
 }
 
 // ---------------------------------------------------------------------------
@@ -134,63 +143,50 @@ impl<S> StorageRelayPersistence<S> {
 }
 
 #[cfg(feature = "relay-persistence")]
+#[async_trait::async_trait]
 impl<S: scp_platform::Storage + 'static> RelayPersistence for StorageRelayPersistence<S> {
-    fn persist_subscription(&self, routing_id: &[u8; 32]) -> Result<(), BoxError> {
+    async fn persist_subscription(&self, routing_id: &[u8; 32]) -> Result<(), BoxError> {
         let key = format!("{}{}", SUBSCRIPTION_PREFIX, hex::encode(routing_id));
-        let storage = Arc::clone(&self.storage);
-        tokio::task::block_in_place(|| {
-            tokio::runtime::Handle::current().block_on(async {
-                storage
-                    .store(&key, b"1")
-                    .await
-                    .map_err(|e| -> BoxError { Box::new(e) })
-            })
-        })
+        self.storage
+            .store(&key, b"1")
+            .await
+            .map_err(|e| -> BoxError { Box::new(e) })
     }
 
-    fn remove_subscription(&self, routing_id: &[u8; 32]) -> Result<(), BoxError> {
+    async fn remove_subscription(&self, routing_id: &[u8; 32]) -> Result<(), BoxError> {
         let key = format!("{}{}", SUBSCRIPTION_PREFIX, hex::encode(routing_id));
-        let storage = Arc::clone(&self.storage);
-        tokio::task::block_in_place(|| {
-            tokio::runtime::Handle::current().block_on(async {
-                storage
-                    .delete(&key)
-                    .await
-                    .map_err(|e| -> BoxError { Box::new(e) })
-            })
-        })
+        self.storage
+            .delete(&key)
+            .await
+            .map_err(|e| -> BoxError { Box::new(e) })
     }
 
-    fn load_subscribed_routing_ids(&self) -> Result<Vec<[u8; 32]>, BoxError> {
-        let storage = Arc::clone(&self.storage);
-        tokio::task::block_in_place(|| {
-            tokio::runtime::Handle::current().block_on(async {
-                let keys = storage
-                    .list_keys(SUBSCRIPTION_PREFIX)
-                    .await
-                    .map_err(|e| -> BoxError { Box::new(e) })?;
+    async fn load_subscribed_routing_ids(&self) -> Result<Vec<[u8; 32]>, BoxError> {
+        let keys = self
+            .storage
+            .list_keys(SUBSCRIPTION_PREFIX)
+            .await
+            .map_err(|e| -> BoxError { Box::new(e) })?;
 
-                let mut routing_ids = Vec::with_capacity(keys.len());
-                for key in keys {
-                    let hex_part =
-                        key.strip_prefix(SUBSCRIPTION_PREFIX)
-                            .ok_or_else(|| -> BoxError {
-                                format!("unexpected key without prefix: {key}").into()
-                            })?;
-                    let bytes = hex::decode(hex_part).map_err(|e| -> BoxError { Box::new(e) })?;
-                    if bytes.len() != 32 {
-                        continue; // skip malformed entries
-                    }
-                    let mut routing_id = [0u8; 32];
-                    routing_id.copy_from_slice(&bytes);
-                    routing_ids.push(routing_id);
-                }
-                Ok(routing_ids)
-            })
-        })
+        let mut routing_ids = Vec::with_capacity(keys.len());
+        for key in keys {
+            let hex_part = key
+                .strip_prefix(SUBSCRIPTION_PREFIX)
+                .ok_or_else(|| -> BoxError {
+                    format!("unexpected key without prefix: {key}").into()
+                })?;
+            let bytes = hex::decode(hex_part).map_err(|e| -> BoxError { Box::new(e) })?;
+            if bytes.len() != 32 {
+                continue; // skip malformed entries
+            }
+            let mut routing_id = [0u8; 32];
+            routing_id.copy_from_slice(&bytes);
+            routing_ids.push(routing_id);
+        }
+        Ok(routing_ids)
     }
 
-    fn persist_rate_limit(
+    async fn persist_rate_limit(
         &self,
         ip: &str,
         tokens: f64,
@@ -206,18 +202,13 @@ impl<S: scp_platform::Storage + 'static> RelayPersistence for StorageRelayPersis
         let key = format!("{RATE_LIMIT_PREFIX}{ip}");
         let value = rmp_serde::to_vec(&(tokens, window_start_secs))
             .map_err(|e| -> BoxError { Box::new(e) })?;
-        let storage = Arc::clone(&self.storage);
-        tokio::task::block_in_place(|| {
-            tokio::runtime::Handle::current().block_on(async {
-                storage
-                    .store(&key, &value)
-                    .await
-                    .map_err(|e| -> BoxError { Box::new(e) })
-            })
-        })
+        self.storage
+            .store(&key, &value)
+            .await
+            .map_err(|e| -> BoxError { Box::new(e) })
     }
 
-    fn load_rate_limit(&self, ip: &str) -> Result<Option<(f64, u64)>, BoxError> {
+    async fn load_rate_limit(&self, ip: &str) -> Result<Option<(f64, u64)>, BoxError> {
         // Validate IP to prevent key injection.
         let _: std::net::IpAddr = ip.parse().map_err(|e| -> BoxError {
             Box::new(std::io::Error::new(
@@ -226,40 +217,31 @@ impl<S: scp_platform::Storage + 'static> RelayPersistence for StorageRelayPersis
             ))
         })?;
         let key = format!("{RATE_LIMIT_PREFIX}{ip}");
-        let storage = Arc::clone(&self.storage);
-        tokio::task::block_in_place(|| {
-            tokio::runtime::Handle::current().block_on(async {
-                let data = storage
-                    .retrieve(&key)
-                    .await
-                    .map_err(|e| -> BoxError { Box::new(e) })?;
-                match data {
-                    Some(bytes) => {
-                        let (tokens, window): (f64, u64) = rmp_serde::from_slice(&bytes)
-                            .map_err(|e| -> BoxError { Box::new(e) })?;
-                        Ok(Some((tokens, window)))
-                    }
-                    None => Ok(None),
-                }
-            })
-        })
+        let data = self
+            .storage
+            .retrieve(&key)
+            .await
+            .map_err(|e| -> BoxError { Box::new(e) })?;
+        match data {
+            Some(bytes) => {
+                let (tokens, window): (f64, u64) =
+                    rmp_serde::from_slice(&bytes).map_err(|e| -> BoxError { Box::new(e) })?;
+                Ok(Some((tokens, window)))
+            }
+            None => Ok(None),
+        }
     }
 
-    fn clear_all(&self) -> Result<(), BoxError> {
-        let storage = Arc::clone(&self.storage);
-        tokio::task::block_in_place(|| {
-            tokio::runtime::Handle::current().block_on(async {
-                storage
-                    .delete_prefix(SUBSCRIPTION_PREFIX)
-                    .await
-                    .map_err(|e| -> BoxError { Box::new(e) })?;
-                storage
-                    .delete_prefix(RATE_LIMIT_PREFIX)
-                    .await
-                    .map_err(|e| -> BoxError { Box::new(e) })?;
-                Ok(())
-            })
-        })
+    async fn clear_all(&self) -> Result<(), BoxError> {
+        self.storage
+            .delete_prefix(SUBSCRIPTION_PREFIX)
+            .await
+            .map_err(|e| -> BoxError { Box::new(e) })?;
+        self.storage
+            .delete_prefix(RATE_LIMIT_PREFIX)
+            .await
+            .map_err(|e| -> BoxError { Box::new(e) })?;
+        Ok(())
     }
 }
 
@@ -293,8 +275,9 @@ mod tests {
         }
     }
 
+    #[async_trait::async_trait]
     impl RelayPersistence for MockRelayPersistence {
-        fn persist_subscription(&self, routing_id: &[u8; 32]) -> Result<(), BoxError> {
+        async fn persist_subscription(&self, routing_id: &[u8; 32]) -> Result<(), BoxError> {
             let mut subs = self.subscriptions.lock().unwrap();
             if !subs.contains(routing_id) {
                 subs.push(*routing_id);
@@ -302,17 +285,17 @@ mod tests {
             Ok(())
         }
 
-        fn remove_subscription(&self, routing_id: &[u8; 32]) -> Result<(), BoxError> {
+        async fn remove_subscription(&self, routing_id: &[u8; 32]) -> Result<(), BoxError> {
             let mut subs = self.subscriptions.lock().unwrap();
             subs.retain(|id| id != routing_id);
             Ok(())
         }
 
-        fn load_subscribed_routing_ids(&self) -> Result<Vec<[u8; 32]>, BoxError> {
+        async fn load_subscribed_routing_ids(&self) -> Result<Vec<[u8; 32]>, BoxError> {
             Ok(self.subscriptions.lock().unwrap().clone())
         }
 
-        fn persist_rate_limit(
+        async fn persist_rate_limit(
             &self,
             ip: &str,
             tokens: f64,
@@ -325,91 +308,100 @@ mod tests {
             Ok(())
         }
 
-        fn load_rate_limit(&self, ip: &str) -> Result<Option<(f64, u64)>, BoxError> {
+        async fn load_rate_limit(&self, ip: &str) -> Result<Option<(f64, u64)>, BoxError> {
             Ok(self.rate_limits.lock().unwrap().get(ip).copied())
         }
 
-        fn clear_all(&self) -> Result<(), BoxError> {
+        async fn clear_all(&self) -> Result<(), BoxError> {
             self.subscriptions.lock().unwrap().clear();
             self.rate_limits.lock().unwrap().clear();
             Ok(())
         }
     }
 
-    #[test]
-    fn subscription_roundtrip() {
+    #[tokio::test]
+    async fn subscription_roundtrip() {
         let persistence = MockRelayPersistence::new();
         let routing_id = [0xAA; 32];
 
-        persistence.persist_subscription(&routing_id).unwrap();
-        let loaded = persistence.load_subscribed_routing_ids().unwrap();
+        persistence.persist_subscription(&routing_id).await.unwrap();
+        let loaded = persistence.load_subscribed_routing_ids().await.unwrap();
         assert_eq!(loaded, vec![routing_id]);
     }
 
-    #[test]
-    fn subscription_remove() {
+    #[tokio::test]
+    async fn subscription_remove() {
         let persistence = MockRelayPersistence::new();
         let routing_id = [0xAA; 32];
 
-        persistence.persist_subscription(&routing_id).unwrap();
-        persistence.remove_subscription(&routing_id).unwrap();
-        let loaded = persistence.load_subscribed_routing_ids().unwrap();
+        persistence.persist_subscription(&routing_id).await.unwrap();
+        persistence.remove_subscription(&routing_id).await.unwrap();
+        let loaded = persistence.load_subscribed_routing_ids().await.unwrap();
         assert!(loaded.is_empty());
     }
 
-    #[test]
-    fn subscription_idempotent() {
+    #[tokio::test]
+    async fn subscription_idempotent() {
         let persistence = MockRelayPersistence::new();
         let routing_id = [0xAA; 32];
 
-        persistence.persist_subscription(&routing_id).unwrap();
-        persistence.persist_subscription(&routing_id).unwrap();
-        let loaded = persistence.load_subscribed_routing_ids().unwrap();
+        persistence.persist_subscription(&routing_id).await.unwrap();
+        persistence.persist_subscription(&routing_id).await.unwrap();
+        let loaded = persistence.load_subscribed_routing_ids().await.unwrap();
         assert_eq!(loaded.len(), 1);
     }
 
-    #[test]
-    fn rate_limit_roundtrip() {
+    #[tokio::test]
+    async fn rate_limit_roundtrip() {
         let persistence = MockRelayPersistence::new();
         persistence
             .persist_rate_limit("192.168.1.1", 50.0, 1_000_000)
+            .await
             .unwrap();
-        let loaded = persistence.load_rate_limit("192.168.1.1").unwrap();
+        let loaded = persistence.load_rate_limit("192.168.1.1").await.unwrap();
         assert_eq!(loaded, Some((50.0, 1_000_000)));
     }
 
-    #[test]
-    fn rate_limit_missing_returns_none() {
+    #[tokio::test]
+    async fn rate_limit_missing_returns_none() {
         let persistence = MockRelayPersistence::new();
-        let loaded = persistence.load_rate_limit("10.0.0.1").unwrap();
+        let loaded = persistence.load_rate_limit("10.0.0.1").await.unwrap();
         assert_eq!(loaded, None);
     }
 
-    #[test]
-    fn clear_all_removes_everything() {
+    #[tokio::test]
+    async fn clear_all_removes_everything() {
         let persistence = MockRelayPersistence::new();
-        persistence.persist_subscription(&[0xBB; 32]).unwrap();
+        persistence.persist_subscription(&[0xBB; 32]).await.unwrap();
         persistence
             .persist_rate_limit("1.2.3.4", 10.0, 500)
+            .await
             .unwrap();
 
-        persistence.clear_all().unwrap();
+        persistence.clear_all().await.unwrap();
 
         assert!(
             persistence
                 .load_subscribed_routing_ids()
+                .await
                 .unwrap()
                 .is_empty()
         );
-        assert!(persistence.load_rate_limit("1.2.3.4").unwrap().is_none());
+        assert!(
+            persistence
+                .load_rate_limit("1.2.3.4")
+                .await
+                .unwrap()
+                .is_none()
+        );
     }
 
-    #[test]
-    fn trait_is_dyn_compatible() {
+    #[tokio::test]
+    async fn trait_is_dyn_compatible() {
         // Verify RelayPersistence can be used as a trait object.
         let persistence: Arc<dyn RelayPersistence> = Arc::new(MockRelayPersistence::new());
-        persistence.persist_subscription(&[0xCC; 32]).unwrap();
-        let loaded = persistence.load_subscribed_routing_ids().unwrap();
+        persistence.persist_subscription(&[0xCC; 32]).await.unwrap();
+        let loaded = persistence.load_subscribed_routing_ids().await.unwrap();
         assert_eq!(loaded.len(), 1);
     }
 }

--- a/crates/scp-transport/src/native/server.rs
+++ b/crates/scp-transport/src/native/server.rs
@@ -288,7 +288,7 @@ impl RelayServer {
     /// Best-effort -- logs warnings on failure and continues.
     async fn restore_persisted_subscriptions(&self) {
         if let Some(ref persistence) = self.persistence {
-            match persistence.load_subscribed_routing_ids() {
+            match persistence.load_subscribed_routing_ids().await {
                 Ok(routing_ids) => {
                     if !routing_ids.is_empty() {
                         tracing::info!(
@@ -938,7 +938,7 @@ async fn cleanup_connection_subscriptions(
     // Persist removal for routing IDs that no longer have any subscribers.
     if let Some(persistence) = persistence {
         for routing_id in &removed_ids {
-            if let Err(e) = persistence.remove_subscription(routing_id) {
+            if let Err(e) = persistence.remove_subscription(routing_id).await {
                 tracing::warn!(
                     error = %e,
                     routing_id = hex::encode(routing_id),
@@ -1261,7 +1261,7 @@ async fn handle_subscribe(
 
     // Persist subscription (best-effort, SCP-PERSIST-066).
     if let Some(persistence) = persistence
-        && let Err(e) = persistence.persist_subscription(&routing_id)
+        && let Err(e) = persistence.persist_subscription(&routing_id).await
     {
         tracing::warn!(
             error = %e,
@@ -1344,7 +1344,7 @@ async fn handle_unsubscribe(
     // routing ID. Other connections may still be subscribed.
     if routing_id_removed
         && let Some(persistence) = persistence
-        && let Err(e) = persistence.remove_subscription(&routing_id)
+        && let Err(e) = persistence.remove_subscription(&routing_id).await
     {
         tracing::warn!(
             error = %e,
@@ -2909,8 +2909,14 @@ mod tests {
         let routing_id_b = [0xBB; 32];
 
         // Persist subscriptions (simulates what the relay does on SUBSCRIBE).
-        persistence.persist_subscription(&routing_id_a).unwrap();
-        persistence.persist_subscription(&routing_id_b).unwrap();
+        persistence
+            .persist_subscription(&routing_id_a)
+            .await
+            .unwrap();
+        persistence
+            .persist_subscription(&routing_id_b)
+            .await
+            .unwrap();
 
         // Create a "restarted" relay with the same persistence.
         let config = RelayConfig {
@@ -2942,9 +2948,11 @@ mod tests {
         // Persist rate limit state (simulates periodic snapshots).
         persistence
             .persist_rate_limit("192.168.1.1", 42.5, 1_000_000)
+            .await
             .unwrap();
         persistence
             .persist_rate_limit("10.0.0.1", 99.0, 2_000_000)
+            .await
             .unwrap();
 
         // Create a "restarted" relay with the same persistence.
@@ -2959,10 +2967,10 @@ mod tests {
         let (_handle, _addr) = server.start().await.unwrap();
 
         // Rate limit state should be loadable from persistence after restart.
-        let rate1 = persistence.load_rate_limit("192.168.1.1").unwrap();
+        let rate1 = persistence.load_rate_limit("192.168.1.1").await.unwrap();
         assert_eq!(rate1, Some((42.5, 1_000_000)));
 
-        let rate2 = persistence.load_rate_limit("10.0.0.1").unwrap();
+        let rate2 = persistence.load_rate_limit("10.0.0.1").await.unwrap();
         assert_eq!(rate2, Some((99.0, 2_000_000)));
     }
 
@@ -2982,8 +2990,9 @@ mod tests {
         }
     }
 
+    #[async_trait::async_trait]
     impl RelayPersistence for MockRelayPersistence {
-        fn persist_subscription(
+        async fn persist_subscription(
             &self,
             routing_id: &[u8; 32],
         ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
@@ -2995,7 +3004,7 @@ mod tests {
             Ok(())
         }
 
-        fn remove_subscription(
+        async fn remove_subscription(
             &self,
             routing_id: &[u8; 32],
         ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
@@ -3006,13 +3015,13 @@ mod tests {
             Ok(())
         }
 
-        fn load_subscribed_routing_ids(
+        async fn load_subscribed_routing_ids(
             &self,
         ) -> Result<Vec<[u8; 32]>, Box<dyn std::error::Error + Send + Sync>> {
             Ok(self.subscriptions.lock().unwrap().clone())
         }
 
-        fn persist_rate_limit(
+        async fn persist_rate_limit(
             &self,
             ip: &str,
             tokens: f64,
@@ -3025,14 +3034,14 @@ mod tests {
             Ok(())
         }
 
-        fn load_rate_limit(
+        async fn load_rate_limit(
             &self,
             ip: &str,
         ) -> Result<Option<(f64, u64)>, Box<dyn std::error::Error + Send + Sync>> {
             Ok(self.rate_limits.lock().unwrap().get(ip).copied())
         }
 
-        fn clear_all(&self) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+        async fn clear_all(&self) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
             self.subscriptions.lock().unwrap().clear();
             self.rate_limits.lock().unwrap().clear();
             Ok(())

--- a/crates/scp-transport/src/provider.rs
+++ b/crates/scp-transport/src/provider.rs
@@ -1,30 +1,34 @@
 //! Production [`ContextTransportProvider`] wrapping `NativeRelayAdapter`.
 //!
-//! [`RelayTransportProvider`] implements the synchronous
+//! [`RelayTransportProvider`] implements the async
 //! [`ContextTransportProvider`] trait from `scp-core` by wrapping a
-//! `NativeRelayAdapter` (or any [`TransportAdapter`]) and bridging
-//! async transport operations to synchronous calls using
-//! `tokio::task::block_in_place`.
+//! `NativeRelayAdapter` (or any [`TransportAdapter`]) and `.await`ing the
+//! adapter's async transport operations directly.
 //!
-//! # Design
+//! # Design (ADR-049 Decision 7)
 //!
-//! The [`ContextTransportProvider`] trait methods are synchronous (`&self`)
-//! because they are called from within `ContextManager` operations that hold
-//! `Mutex` guards. The underlying transport operations are async, so this
-//! provider bridges the gap using `block_in_place` + `Handle::block_on`.
+//! The I/O [`ContextTransportProvider`] trait methods are `async` and simply
+//! `.await` the underlying async [`TransportAdapter`] — there is NO
+//! `block_in_place` / `Handle::block_on` sync→async bridge. Because every
+//! [`TransportAdapter`] method takes `&self`, the adapter is held behind a
+//! plain `Arc<A>` (no `Mutex`): concurrent sends share `&A` directly and the
+//! resulting futures stay `Send`, so the provider is safe to hold as
+//! `Arc<dyn ContextTransportProvider>` in `ActorDeps` (moved into
+//! `tokio::spawn`).
 //!
-//! The `is_connected` method tracks connection state via an `AtomicBool`
-//! that is set during construction or reconnection.
+//! The `is_connected` method stays **sync** — it tracks connection state via
+//! an `AtomicBool` set during construction or reconnection (ADR-049 Decision 7
+//! `is_connected`-stays-sync carve-out).
 //!
 //! # Thread Safety
 //!
-//! `RelayTransportProvider` is `Send + Sync`. The underlying adapter is
-//! stored in an `Arc<Mutex<_>>` to allow mutable access for send operations.
+//! `RelayTransportProvider` is `Send + Sync`. The underlying adapter is stored
+//! in an `Arc<A>`; all adapter operations take `&self`.
 //!
 //! See ADR-005 (transport abstraction), ADR-008 (context creation).
 
+use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};
-use std::sync::{Arc, Mutex};
 
 use scp_core::context::builder::{ContextCreationError, ContextTransportProvider};
 use scp_core::context::{ContextError, ContextParams};
@@ -61,8 +65,10 @@ const DEFAULT_BLOB_TTL: u32 = 3600;
 /// );
 /// ```
 pub struct RelayTransportProvider<A: TransportAdapter + Send + Sync + 'static> {
-    /// The underlying transport adapter.
-    adapter: Arc<Mutex<A>>,
+    /// The underlying transport adapter. Held behind a plain `Arc` (no
+    /// `Mutex`): every [`TransportAdapter`] method takes `&self`, so the
+    /// async provider methods share `&A` and `.await` directly.
+    adapter: Arc<A>,
     /// Whether the transport is currently connected.
     connected: AtomicBool,
 }
@@ -75,7 +81,7 @@ impl<A: TransportAdapter + Send + Sync + 'static> RelayTransportProvider<A> {
     #[must_use]
     pub fn new(adapter: A) -> Self {
         Self {
-            adapter: Arc::new(Mutex::new(adapter)),
+            adapter: Arc::new(adapter),
             connected: AtomicBool::new(true),
         }
     }
@@ -114,64 +120,21 @@ impl<A: TransportAdapter + Send + Sync + 'static> RelayTransportProvider<A> {
         }
     }
 
-    /// Bridge the async adapter `send` to the synchronous
-    /// [`ContextTransportProvider`] surface WITHOUT panicking on a
-    /// `current_thread` runtime.
+    /// `.await` the async adapter `send`, mapping a transport failure into a
+    /// typed [`ContextError::TransportFailed`].
     ///
-    /// `tokio::task::block_in_place` requires a multi-thread runtime: on a
-    /// `current_thread` runtime it PANICS (`can call blocking only when
-    /// running on the multi-threaded runtime`), and that panic is reachable
-    /// from production (any node driven by a `current_thread` runtime), so it
-    /// must be turned into a typed error rather than an unwind. We probe the
-    /// current runtime's flavor first and return
-    /// [`ContextError::TransportFailed`] on `current_thread`, only entering
-    /// `block_in_place` when the multi-thread flavor makes it safe.
-    fn send_blocking(&self, envelope: &OuterEnvelope) -> Result<BlobId, ContextError> {
-        // Shared runtime-flavor probe: `block_in_place` panics on a
-        // `current_thread` runtime (a reachable production crash), so guard it
-        // and surface a typed error. `op` is the description for the typed
-        // error messages.
-        require_multi_thread_runtime("send").map_err(ContextError::TransportFailed)?;
-        let adapter = Arc::clone(&self.adapter);
-        // ci-allow: block-on: multi-thread runtime only — flavor is checked
-        // above; current_thread returns a typed error instead of panicking.
-        // Sync ContextTransportProvider surface bridges to the async adapter
-        // here.
-        tokio::task::block_in_place(|| {
-            let guard = adapter
-                .lock()
-                .unwrap_or_else(std::sync::PoisonError::into_inner);
-            tokio::runtime::Handle::current().block_on(guard.send(envelope))
-        })
-        .map_err(|e| ContextError::TransportFailed(e.to_string()))
+    /// Every [`TransportAdapter`] method takes `&self`, so this shares `&A`
+    /// through the `Arc` and awaits the adapter future directly — no
+    /// `block_in_place`, and the future is `Send`.
+    async fn send_via_adapter(&self, envelope: &OuterEnvelope) -> Result<BlobId, ContextError> {
+        self.adapter
+            .send(envelope)
+            .await
+            .map_err(|e| ContextError::TransportFailed(e.to_string()))
     }
 }
 
-/// Probe the current tokio runtime and require the multi-thread flavor.
-///
-/// `tokio::task::block_in_place` PANICS on a `current_thread` runtime (a
-/// reachable production crash from any node driven by a `current_thread`
-/// runtime), so every sync→async bridge in this provider must check the flavor
-/// FIRST and return a typed error instead of unwinding. `op` names the
-/// operation for the error text (e.g. `"send"`, `"delete"`).
-///
-/// Returns `Ok(())` only on a multi-thread runtime; otherwise an `Err(String)`
-/// the caller maps into its own transport-error type.
-fn require_multi_thread_runtime(op: &str) -> Result<(), String> {
-    match tokio::runtime::Handle::try_current() {
-        Ok(handle) if handle.runtime_flavor() == tokio::runtime::RuntimeFlavor::MultiThread => {
-            Ok(())
-        }
-        Ok(_) => Err(format!(
-            "transport {op} requires a multi-thread tokio runtime; \
-             a current_thread runtime cannot bridge the sync→async boundary"
-        )),
-        Err(_) => Err(format!("transport {op} called outside a tokio runtime")),
-    }
-}
-
-// Nursery lint — false-positives on lock guards across block boundaries.
-#[allow(clippy::significant_drop_tightening)]
+#[async_trait::async_trait]
 impl<A: TransportAdapter + Send + Sync + 'static> ContextTransportProvider
     for RelayTransportProvider<A>
 {
@@ -179,7 +142,7 @@ impl<A: TransportAdapter + Send + Sync + 'static> ContextTransportProvider
         self.connected.load(Ordering::Acquire)
     }
 
-    fn publish_context(
+    async fn publish_context(
         &self,
         context_id: &[u8; 32],
         _params: &ContextParams,
@@ -189,46 +152,34 @@ impl<A: TransportAdapter + Send + Sync + 'static> ContextTransportProvider
         // published (they are exchanged via the invite/join flow). The
         // routing_id is the context_id itself (used by relays for routing).
         let envelope = Self::build_envelope(context_id.to_vec(), vec![0x00]);
-        self.send_blocking(&envelope)
+        self.send_via_adapter(&envelope)
+            .await
             .map(|_blob_id| ())
             .map_err(|e| ContextCreationError::TransportFailed(e.to_string()))
     }
 
-    fn delete_published(&self, context_id: &[u8; 32]) -> Result<(), ContextCreationError> {
+    async fn delete_published(&self, context_id: &[u8; 32]) -> Result<(), ContextCreationError> {
         let blob_id = BlobId::from_sha256(context_id);
-
-        // Shared runtime-flavor probe (see `require_multi_thread_runtime`):
-        // block_in_place panics on a current_thread runtime, so guard it and
-        // surface a typed error instead.
-        require_multi_thread_runtime("delete").map_err(ContextCreationError::TransportFailed)?;
-
-        let adapter = Arc::clone(&self.adapter);
-        let result = tokio::task::block_in_place(|| {
-            let guard = adapter
-                .lock()
-                .unwrap_or_else(std::sync::PoisonError::into_inner);
-            // ci-allow: block-on: multi-thread runtime only (flavor checked
-            // above); sync ContextTransportProvider surface bridges to the
-            // async adapter delete here.
-            tokio::runtime::Handle::current().block_on(guard.delete(&blob_id))
-        });
-
-        match result {
-            Ok(()) => Ok(()),
-            Err(e) => Err(ContextCreationError::TransportFailed(e.to_string())),
-        }
+        self.adapter
+            .delete(&blob_id)
+            .await
+            .map_err(|e| ContextCreationError::TransportFailed(e.to_string()))
     }
 
-    fn send_message(
+    async fn send_message(
         &self,
         context_id: &[u8; 32],
         encrypted_payload: &[u8],
     ) -> Result<(), ContextError> {
         let envelope = Self::build_envelope(context_id.to_vec(), encrypted_payload.to_vec());
-        self.send_blocking(&envelope).map(|_blob_id| ())
+        self.send_via_adapter(&envelope).await.map(|_blob_id| ())
     }
 
-    fn publish_key_package(&self, owner_did: &str, kp_bytes: &[u8]) -> Result<(), ContextError> {
+    async fn publish_key_package(
+        &self,
+        owner_did: &str,
+        kp_bytes: &[u8],
+    ) -> Result<(), ContextError> {
         // Route the published KeyPackage under the CANONICAL per-DID routing id
         // `derive_key_package_routing_id(owner_did)` (spec §5.12.3), so a peer
         // fetches this identity's KeyPackages with the SAME id the canonical
@@ -238,7 +189,7 @@ impl<A: TransportAdapter + Send + Sync + 'static> ContextTransportProvider
         // idempotent at the relay.
         let routing_id = derive_key_package_routing_id(owner_did);
         let envelope = Self::build_envelope(routing_id.to_vec(), kp_bytes.to_vec());
-        self.send_blocking(&envelope).map(|_blob_id| ())
+        self.send_via_adapter(&envelope).await.map(|_blob_id| ())
     }
 }
 
@@ -338,32 +289,33 @@ mod tests {
         assert!(provider.is_connected());
     }
 
-    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+    // Async provider methods run on a plain `current_thread` runtime — no
+    // `block_in_place`, so no multi-thread requirement (ADR-049 Decision 7).
+    #[tokio::test]
     async fn publish_context_sends_envelope() {
         let adapter = TestAdapter::new();
         let provider = RelayTransportProvider::new(adapter);
         let ctx_id = [1u8; 32];
 
-        let result = provider.publish_context(&ctx_id, &ContextParams::default());
+        let result = provider
+            .publish_context(&ctx_id, &ContextParams::default())
+            .await;
         assert!(result.is_ok());
 
-        let count = provider
-            .adapter
-            .lock()
-            .unwrap()
-            .send_count
-            .load(Ordering::Relaxed);
+        let count = provider.adapter.send_count.load(Ordering::Relaxed);
         assert_eq!(count, 1);
     }
 
-    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+    #[tokio::test]
     async fn publish_context_returns_error_on_send_failure() {
         let adapter = TestAdapter::new();
         adapter.fail_send.store(true, Ordering::Relaxed);
         let provider = RelayTransportProvider::new(adapter);
         let ctx_id = [2u8; 32];
 
-        let result = provider.publish_context(&ctx_id, &ContextParams::default());
+        let result = provider
+            .publish_context(&ctx_id, &ContextParams::default())
+            .await;
         assert!(result.is_err());
         assert!(matches!(
             result.unwrap_err(),
@@ -371,50 +323,40 @@ mod tests {
         ));
     }
 
-    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+    #[tokio::test]
     async fn delete_published_sends_delete() {
         let adapter = TestAdapter::new();
         let provider = RelayTransportProvider::new(adapter);
         let ctx_id = [3u8; 32];
 
-        let result = provider.delete_published(&ctx_id);
+        let result = provider.delete_published(&ctx_id).await;
         assert!(result.is_ok());
 
-        let count = provider
-            .adapter
-            .lock()
-            .unwrap()
-            .delete_count
-            .load(Ordering::Relaxed);
+        let count = provider.adapter.delete_count.load(Ordering::Relaxed);
         assert_eq!(count, 1);
     }
 
-    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+    #[tokio::test]
     async fn send_message_delivers_payload() {
         let adapter = TestAdapter::new();
         let provider = RelayTransportProvider::new(adapter);
         let ctx_id = [4u8; 32];
 
-        let result = provider.send_message(&ctx_id, b"encrypted-payload");
+        let result = provider.send_message(&ctx_id, b"encrypted-payload").await;
         assert!(result.is_ok());
 
-        let count = provider
-            .adapter
-            .lock()
-            .unwrap()
-            .send_count
-            .load(Ordering::Relaxed);
+        let count = provider.adapter.send_count.load(Ordering::Relaxed);
         assert_eq!(count, 1);
     }
 
-    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+    #[tokio::test]
     async fn send_message_returns_error_on_failure() {
         let adapter = TestAdapter::new();
         adapter.fail_send.store(true, Ordering::Relaxed);
         let provider = RelayTransportProvider::new(adapter);
         let ctx_id = [5u8; 32];
 
-        let result = provider.send_message(&ctx_id, b"data");
+        let result = provider.send_message(&ctx_id, b"data").await;
         assert!(result.is_err());
         assert!(matches!(
             result.unwrap_err(),

--- a/ratchet/block-in-place-count.json
+++ b/ratchet/block-in-place-count.json
@@ -1,6 +1,6 @@
 {
   "_comment": "Ratchet baseline for `tokio::task::block_in_place`, `.block_on(...)`, `Runtime::new()`, and sync-bridge macro wrappers in the actor-refactor scope (ADR-049). See scripts/check-block-in-place.py for scope, detection rules, and the inline allow-list directive `// ci-allow: block-on: <reason>`. Enforcement is PER-FILE: the gate fails when any file's count goes UP. The previous per-crate-aggregate baseline was gameable — an attacker could delete a legit site and add a new one within the same crate without detection. Per-file baselines close that gap. Test code (`**/tests/**` paths and `#[cfg(test)] mod` items) is excluded from counting. Allow-listed sites are excluded from counting and must carry a reason string.",
-  "_updated": "2026-07-07 (ADR-049 Decision 7 PR-2 — EventLogPersistence + ContextEventLogProvider converted to (partial-)async traits; the ProtocolRepositoryEventLogBridge sync→async shim in store/context.rs is deleted (4 block_in_place + 4 block_on) with ZERO new block_on added, tightening store/context.rs 8→0 and scp-runtime 22→14. The live counted scp-runtime total is now 8 (lifecycle_helpers flush pair + trust store); the 14 summary retains the pre-existing tools_helpers `_legacy` slack, removed when that shim is deleted. Builds on PR-1 (ContextPersistence async, store/context.rs 20→8) and PR-0 (recovery.rs 2→0).)",
+  "_updated": "2026-07-07 (ADR-049 Decision 7 PR-3 — ContextTransportProvider + RelayPersistence converted to async traits; the RelayTransportProvider sync→async bridge in scp-transport/src/provider.rs (2 block_in_place + 2 block_on + the require_multi_thread_runtime probe) and the 6 StorageRelayPersistence bridges in native/relay_persistence.rs (6 block_in_place + 6 block_on) are deleted — the impls now `.await` the async adapter / Storage directly. Tightened provider.rs 4→0, relay_persistence.rs 12→0, scp-transport aggregate 16→0. scp-transport now has ZERO block_in_place/block_on sites — this is the LAST block-in-place-deletion PR of Decision 7. Builds on PR-2 (EventLogPersistence async, store/context.rs 8→0), PR-1 (ContextPersistence async, store/context.rs 20→8) and PR-0 (recovery.rs 2→0). The remaining counted scp-runtime sites (lifecycle_helpers flush pair + trust store + the tools_helpers `_legacy` slack in the 14 summary) are out of scope for Decision 7's provider-trait conversion.)",
   "_context": "Pre-refactor state. scp-runtime counts are sync-in-async bridges in (now-deleted) ContextManager, MlsCryptoProvider, recovery, trust store, and per-context store. scp-transport counts are in the provider.rs sync-adapter bridge and native/relay_persistence.rs. scp-node has one site in the HTTP/3 request handler (sync trait method, legitimate and will be annotated once post-refactor patterns settle). The actor refactor eliminates every scp-runtime and scp-transport site listed below; the scp-node site may remain and be annotated with `// ci-allow: block-on: <reason>` in a later commit. Post-commit-12 file-rename mapping: `manager/mod.rs` (2 sites: flush_all_contexts_sync) → `lifecycle_helpers.rs`; `manager/tools.rs` (6 sites) → `tools_helpers.rs`. Site counts unchanged at the rename — the bodies are byte-identical hoists. Phase-2A actor-migration rename (2026-06): the 6 `tools_helpers.rs` blocking rate-limit variants moved verbatim into `tools_helpers_legacy.rs` (the actor-shape `tools_helpers.rs` is now block-free); the baseline entry moves files accordingly — net-zero coverage, removed entirely when the `_legacy` shim is deleted in Phase-2A finalization Step E. `lifecycle_helpers.rs:shutdown_all_contexts_sync` is annotated with `// ci-allow: block-on:` (ADR-049 §7 FFI sync-shutdown), so only the grandfathered `flush_all_contexts_sync` pair remains counted there.",
   "files": {
     "crates/scp-node/src/http.rs": 1,
@@ -8,13 +8,13 @@
     "crates/scp-runtime/src/identity/recovery.rs": 0,
     "crates/scp-runtime/src/store/context.rs": 0,
     "crates/scp-runtime/src/store/trust.rs": 6,
-    "crates/scp-transport/src/native/relay_persistence.rs": 12,
-    "crates/scp-transport/src/provider.rs": 4
+    "crates/scp-transport/src/native/relay_persistence.rs": 0,
+    "crates/scp-transport/src/provider.rs": 0
   },
   "crates": {
     "scp-node": 1,
     "scp-runtime": 14,
-    "scp-transport": 16
+    "scp-transport": 0
   },
   "_breakdown": {
     "scp-node": [
@@ -28,8 +28,8 @@
       "crates/scp-runtime/src/store/trust.rs:273-336 (6 block_on via stored Handle)"
     ],
     "scp-transport": [
-      "crates/scp-transport/src/provider.rs:141-214 (2 block_in_place + 2 block_on — send_blocking + delete_published sync→async bridges; the shared runtime-flavor probe is hoisted into require_multi_thread_runtime, dropping the prior count from 6)",
-      "crates/scp-transport/src/native/relay_persistence.rs:141-251 (6 block_in_place + 6 block_on)"
+      "crates/scp-transport/src/provider.rs: 0 live sites — ELIMINATED. The RelayTransportProvider sync→async bridge (send_blocking + delete_published, 2 block_in_place + 2 block_on) and the require_multi_thread_runtime probe were deleted when ContextTransportProvider became an async trait (ADR-049 Decision 7 PR-3); the impl now `.await`s the async adapter directly (adapter held behind Arc<A>, no Mutex, since every TransportAdapter method takes &self). Tightened 4→0.",
+      "crates/scp-transport/src/native/relay_persistence.rs: 0 live sites — ELIMINATED. The 6 StorageRelayPersistence bridges (6 block_in_place + 6 block_on) were deleted when RelayPersistence became an async trait (ADR-049 Decision 7 PR-3); the impl now `.await`s the async Storage backend directly. Tightened 12→0."
     ]
   }
 }


### PR DESCRIPTION
## Summary

Completes **ADR-049 Decision 7** — converting the provider traits to `#[async_trait]` and deleting every `block_in_place`/`block_on` sync→async bridge in the actor-per-context scope. This is the final transport-layer PR of Decision 7: `ContextTransportProvider` and `RelayPersistence` become async, the last 16 `block_in_place` sites in `scp-transport` are removed (ratchet → 0), and `RelayTransportProvider` drops its `Arc<Mutex<A>>` (needed only for the deleted sync bridge) for `Arc<A>`. With this, `current_thread` runtimes are viable across the transport path (`require_multi_thread_runtime` is deleted; provider tests flip from `flavor="multi_thread"` to plain `#[tokio::test]`).

Along the way it fixes a **safety-gate crash-durability regression the async conversion introduced**, and closes a **pre-existing HIGH post-compromise-recovery desync gap** in the same commit-broadcast machinery.

## The safety-gate fix (commit-broadcast fail-closed durability)

Making `ContextTransportProvider` async meant the MLS-Commit broadcast (`try_broadcast_commit_or_enqueue`) could no longer be awaited inside the synchronous `commit_class_s_keep` fail-closed persist closure, so it was hoisted to *after* the persist — which silently downgraded the on-failure `commit_fault` safety-gate marker + `pending_commits` retry entry to the coalesced (≤50 ms) `class_c_view()`. `commit_fault` gates send/lifecycle/governance (`check_commit_fault`); a crash in that window would drop the gate and the retry → the context respawns "healthy" while remaining members are stuck on a stale MLS epoch with no re-delivery: silent, permanent group desync.

Fix: split the helper into `try_broadcast_commit` (async, send-only, mutates no state, returns `Option<BroadcastFailure>`) and `apply_broadcast_failure` (sync, applies the bookkeeping), so the **caller** picks the durability class. The four safety-gated / forward-secrecy sites — `execute_remove_member`, `execute_rotate_content_keys`, `leave_context`, and `recovery_advance_epoch` — apply the failure inside a second `commit_class_s_keep` (fail-closed, via the shared `keep_broadcast_failure` helper). The two best-effort sites — `execute_add_member` (upward-auth) and `execute_reset_member` (same-member Class-M refresh) — stay coalesced, unchanged. `MAX_PENDING_COMMITS` / marker / `failed_at` semantics are byte-preserved (the queue-full check runs at apply time against the live queue).

## Pre-existing HIGH gap closed: §9.12 post-compromise recovery

Review surfaced that `recovery_advance_epoch` (spec §9.12 step-2 post-compromise recovery) advanced the MLS epoch locally then broadcast the re-key Commit with **warn-and-drop** on send failure — no retry, no gate, not even coalesced. This is the highest-stakes epoch-advancing broadcast in the system: a dropped Commit leaves the local node at epoch N+1 believing recovery succeeded while remaining members stay at epoch N **still using the compromised keys**, silently retaining the excluded party's read access. It was pre-existing (a direct `send_message`, always warn-and-drop) — but it was the one epoch-advancing in-runtime broadcast still defeating the fail-closed invariant, and the split above made the fix a clean reuse. Now routed through `try_broadcast_commit` + fail-closed `keep_broadcast_failure` with a `CommitOperation::RecoveryAdvanceEpoch` variant; the epoch-counter increment (a best-effort reporting mirror, not the encryption-authoritative epoch) stays coalesced by design.

## Tests

New `commit_broadcast_retry_tests` suite pins the fail-closed durability that silently regressed: `apply_broadcast_failure` (normal enqueue; queue-full→`commit_fault` at `MAX_PENDING_COMMITS`, with operation provenance), `try_broadcast_commit` (failure→`Some`/success→`None`/empty→`None` with zero sends), and `keep_broadcast_failure` against a real `ClassSCell` (success→persisted snapshot carries the entry; failing persist→`Err(PersistenceFailed)` with the entry retained in memory and the gate not spuriously tripped). The call-site failure→helper routing is an honestly-documented accepted boundary: the `cfg(test)` no-crypto pipeline serializes Commits to empty bytes, so the sites short-circuit before the enqueue; the fail-closed helper semantics are fully pinned and the site wiring is guarded by review.

## Review

Two-round double-zero. Round 1: architecture-reviewer (APPROVED — Decision 7 complete), bug-catcher, completionist (verified 6-site classification vs `main`), security-reviewer, simplifier, cryptographer (surfaced the §9.12 gap). Round 2 after the recovery fix + DRY extraction + tests: cryptographer (AIRTIGHT), security-reviewer (CLEAN), bug-catcher (CLEAN), test-quality-reviewer (Ship) — all a second consecutive zero.

## Follow-ups filed (out-of-scope residuals)

- **#2059** (hardening) — pre-enqueue `pending_commits` atomically with the mutation to close the residual two-persist crash window (carries the false-`commit_fault`-on-requeued-delivered-commit retry-model design question).
- **#2060** — verify `issue_mls_update` (§9.12 reconnection) out-of-layer Commit distribution has independent delivery assurance (caller-distributes; no in-runtime retry/gate by design).

## Gates (local)

`cargo fmt` · clippy `-D warnings` (all `allow_in_memory_custody` + `testing` features) · `cargo nextest --workspace` **9835 passed** · `check-block-in-place` (scp-transport → 0) · `check-saga-gating-granularity` · `check-handler-no-panic` · `check-deleted-primitives` · `check-cross-layer` (markers below).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


[cross-layer: pub-crate-visibility] apply_broadcast_publish
[cross-layer: pub-crate-visibility] try_broadcast_commit
[cross-layer: pub-crate-visibility] apply_broadcast_failure
[cross-layer: pub-crate-visibility] keep_broadcast_failure
[cross-layer: pub-crate-visibility] drain_and_deliver_sender_keys
[cross-layer: pub-crate-visibility] encrypt_and_send
[cross-layer: pub-crate-visibility] send_checkpoint
[cross-layer: pub-crate-visibility] send_heartbeat
[cross-layer: pub-crate-visibility] recovery_send_notification
