### PR TITLE
docs(adr049): Phase 4 — evergreen lessons + saga-needs-repair runbook + Project Map

### DIFF
--- a/.docs/lessons/actor-per-context-pattern.md
+++ b/.docs/lessons/actor-per-context-pattern.md
@@ -57,17 +57,19 @@ The cell has no `DerefMut` and no `state_mut()` escape hatch. This encodes ADR-0
 
 `ActorDeps` is moved into the spawned task, so **every field it carries must be `Send`** —
 including the `OwnedIdentityDid` capability token (`identity_capability.rs` ships a
-`token_is_send_sync` compile-time witness for exactly this reason; see
+`token_is_send_sync` `#[test]` asserting `Send + Sync` for exactly this reason; see
 `owned-identity-did-capability.md`). ADR-049 §153 (Decision 7) is the normative rule that
 follows: the provider traits an actor reaches through `ActorDeps` become `async` via
 plain `#[async_trait]` (dyn-compatible, `Send` futures) rather than RPITIT, and all
 `block_in_place` sync→async bridges are deleted. `SqliteStorage` wraps each `rusqlite` op
 in `spawn_blocking` instead of pinning a worker thread — see
 `spawn-blocking-for-sync-storage.md`, which covers the already-landed KV seam
-(`SpawnBlockingStorageAdapter`). This is a multi-PR rollout: at the current commit the
+(`SpawnBlockingStorageAdapter`). This was a multi-PR rollout, now complete: the
 runtime-facing `ContextTransportProvider` (`context/builder.rs`) and `RelayPersistence`
-(`scp-transport`) are still synchronous and their `block_in_place` bridges still present —
-the decision governs the direction, the bridges are deleted bridge-by-bridge, gated by
+(`scp-transport/src/native/relay_persistence.rs`) are both `#[async_trait]` now, and their
+`block_in_place` sync→async bridges are deleted (`ratchet/block-in-place-count.json` records
+`provider.rs: 0` / `relay_persistence.rs: 0`, and notes this is the LAST
+block-in-place-deletion PR of Decision 7). The deletions were gated bridge-by-bridge by
 `scripts/check-block-in-place.py` (see `ast-based-ci-enforcement.md`).
 
 The Send boundary is not uniform. A trait whose futures must cross the spawn boundary is
@@ -83,13 +85,36 @@ synchronous and fail-closed (`commit_class_s_keep`, `commit_class_s_restore`); t
 call) is a *separate* async combinator (`commit_class_s_compensating`,
 `commit_class_s_keep_compensating`). The state mutation + its durable record commit
 without an await in the critical section; the awaitable effect runs after, so a persist
-can never straddle an await point. The best-effort broadcast counterpart,
-`try_broadcast_commit_or_enqueue` (`context/governance_helpers.rs`), is deliberately
-Class-C: it takes only the three disjoint fields it touches
-(`CommitBroadcastBorrows { pending_commits, commit_fault, receive_buffer }`) from a
-non-persisting `class_c_view()`, and on transport failure enqueues a retry / sets a
-`commit_fault` gate rather than blocking a fail-closed persist behind the send. Keep the
-durable write synchronous; let the network hop be its own arm.
+can never straddle an await point.
+
+The MLS-Commit broadcast is the sharpest instance of the split — and it runs the *other* way
+from the escrow case above: here the awaitable step is the async terminal that touches **no**
+state, and the *durable* record is the synchronous part the caller places in whichever class
+its safety needs. Because `ContextTransportProvider` is now async (Decision 7), the broadcast
+can no longer be awaited inside the synchronous `commit_class_s_keep` closure that
+fail-closed-persisted the underlying mutation, so PR-3 split the failure bookkeeping OUT into
+three pieces (`context/governance_helpers.rs`):
+
+- `try_broadcast_commit` — the **async terminal**. `Send`, `&ActorDeps`,
+  `-> Option<BroadcastFailure>`; it performs ONLY the transport send and builds the retry
+  payload, mutating **no** `PerContextState` field.
+- `apply_broadcast_failure` — the **synchronous applier**. Given a `BroadcastFailure` and the
+  three disjoint Class-C `&mut` fields
+  (`CommitBroadcastBorrows { pending_commits, commit_fault, receive_buffer }`), it enqueues the
+  retry / trips the `commit_fault` gate / emits the local event, and touches nothing else — so
+  the **durability class is the caller's choice.**
+- `keep_broadcast_failure` — the safety-gated wrapper: a *second* `commit_class_s_keep` that
+  runs `apply_broadcast_failure` fail-closed (the second `commit_class_s_keep` in the operation).
+
+The caller picks the class. The safety-gated Class-S sites — `execute_remove_member`,
+`execute_rotate_content_keys`, `leave_context`, and `recovery_advance_epoch` (§9.12) — call
+`keep_broadcast_failure`, so the `commit_fault` safety-gate marker and the `pending_commits`
+retry entry persist FAIL-CLOSED; a crash between the send failure and the ≤50 ms coalesce tick
+would otherwise drop the only re-delivery of an epoch-advancing Commit — silent, permanent
+group desync. The best-effort sites — `execute_add_member`, `execute_reset_member` — apply the
+identical value COALESCED through a `class_c_view()` / `ClassCMut`. The async terminal stays
+out of every persist closure; the durable step is a plain synchronous applier the caller runs
+in its chosen class (ADR-049 §9 / Decision 7).
 
 ## Cross-refs
 

--- a/.docs/lessons/actor-per-context-pattern.md
+++ b/.docs/lessons/actor-per-context-pattern.md
@@ -1,0 +1,101 @@
+# One actor per context: state owned by move, not shared under a lock
+
+## The model
+
+Every live context is a `tokio::spawn`'d task that **owns its state by move**. The
+task is `ContextActor` (`crates/scp-runtime/src/context/actor/mod.rs`); the state it
+owns is `PerContextState` (`context/actor/state.rs`). Callers never touch the state
+directly — they send a `ContextCommand` down an `mpsc` inbox and await a reply on a
+`oneshot` embedded in the command. The registry that routes a `context_id` to its
+actor's mailbox is `Supervisor` (`context/supervisor/supervisor.rs`), whose
+`actors: DashMap<String, ContextActorHandle>` lookup is lock-free (`Supervisor::lookup`).
+
+The dispatch loop is a four-arm `tokio::select!` in `ContextActor::run`, `biased;` so
+shutdown wins ties: (1) inbox `recv`, (2) TTL timer, (3) governance-proposal timeout,
+(4) persistence-coalesce tick. One task, one `&mut PerContextState`, commands processed
+one at a time — so **within a context there is no shared mutable state and no lock to
+contend**. Cross-context reads that used to require a lock are now either lock-free
+snapshots on `Supervisor` (`standing_contexts: ArcSwap`, `local_dids: Arc<ArcSwap<…>>`)
+or another actor's mailbox.
+
+## The "before": `ContextManager`
+
+This replaced a monolithic `ContextManager` that held every context's `PerContextState`
+behind a per-context `Mutex` (a shared-lock, shared-state model). ADR-049 §1
+(`ContextActor owns state by move`) deleted it: at this commit `ContextManager` survives
+only as a doc reference (`context/state.rs`) and in migration-shim comments. The header
+of `context/actor/state.rs` narrates the field-for-field move off the legacy struct. The
+payoff is the lock-free read invariant — see `lock-free-read-invariant.md` (ADR-049 §12):
+a read on a hot path must never take `tokio::sync::RwLock`/`Mutex`; the actor model makes
+that structural, because per-context state is reached by mailbox, not by lock.
+
+## Class-S vs Class-C: the fail-closed / coalesced persist split
+
+`ContextActor::new` wraps the owned state in a `ClassSCell` (`context/actor/class_s.rs`)
+and hands it to handlers as `&mut ClassSCell` — **never** a bare `&mut PerContextState`.
+The cell has no `DerefMut` and no `state_mut()` escape hatch. This encodes ADR-049 §9's
+**two persistence classes** in the type system:
+
+- **Class-S (fail-closed).** A spending-nonce consume, an executed-proposal record, a
+  downward-authorization transition, a saga reservation slot — a mutation that must not be
+  acknowledged to a caller unless it is already durable, because a coalesced ack would let
+  a crash roll it back and re-open a replay/re-spend/re-grant window the caller already
+  observed as closed. These go through the synchronous `commit_class_s_keep` /
+  `commit_class_s_restore` combinators, which persist **before returning**. The three
+  privatized Class-S fields (`PerContextState.class_s`, `GovernanceState.class_s`,
+  `GovernanceState.revoked_spending_ucan_cids`) are `pub(in crate::context)`, so mutating
+  them outside a fail-closed combinator is a **compile error** — the discipline is the
+  type system's, not a source-text scanner's (a retired `check-class-s-fail-closed.sh`).
+  Deferred Class-S work rides a `#[must_use]` `ClassSCommitToken` whose drop message warns
+  that a dropped token leaves a burned nonce unpersisted.
+- **Class-C (coalesced, best-effort).** Structural state — the MLS-commit retry queue,
+  receive buffers, broadcast bookkeeping — mutates through `commit_class_c_best_effort` /
+  `class_c_view()`. The actor's run-loop coalesces these into one snapshot write per
+  `COALESCE_INTERVAL` (50 ms, ADR-049 §Decision 9) when `dirty == true`.
+
+## `#[async_trait]` Send-discipline (ADR-049 §153, Decision 7)
+
+`ActorDeps` is moved into the spawned task, so **every field it carries must be `Send`** —
+including the `OwnedIdentityDid` capability token (`identity_capability.rs` ships a
+`token_is_send_sync` compile-time witness for exactly this reason; see
+`owned-identity-did-capability.md`). ADR-049 §153 (Decision 7) is the normative rule that
+follows: the provider traits an actor reaches through `ActorDeps` become `async` via
+plain `#[async_trait]` (dyn-compatible, `Send` futures) rather than RPITIT, and all
+`block_in_place` sync→async bridges are deleted. `SqliteStorage` wraps each `rusqlite` op
+in `spawn_blocking` instead of pinning a worker thread — see
+`spawn-blocking-for-sync-storage.md`, which covers the already-landed KV seam
+(`SpawnBlockingStorageAdapter`). This is a multi-PR rollout: at the current commit the
+runtime-facing `ContextTransportProvider` (`context/builder.rs`) and `RelayPersistence`
+(`scp-transport`) are still synchronous and their `block_in_place` bridges still present —
+the decision governs the direction, the bridges are deleted bridge-by-bridge, gated by
+`scripts/check-block-in-place.py` (see `ast-based-ci-enforcement.md`).
+
+The Send boundary is not uniform. A trait whose futures must cross the spawn boundary is
+`Send`; a trait consumed on a caller-local, non-`Send` path can stay `?Send`. When a call
+must be `Send`-affine, the fix is often an **async/sync split**: keep the durable step
+synchronous and push the awaitable external effect to a separate arm.
+
+### Worked example — the split falls out of the persist discipline
+
+The `ClassSCell` combinator family is the split made concrete. The **durable persist** is
+synchronous and fail-closed (`commit_class_s_keep`, `commit_class_s_restore`); the
+**external side effect** a mutation triggers (voiding an escrow, a compensating network
+call) is a *separate* async combinator (`commit_class_s_compensating`,
+`commit_class_s_keep_compensating`). The state mutation + its durable record commit
+without an await in the critical section; the awaitable effect runs after, so a persist
+can never straddle an await point. The best-effort broadcast counterpart,
+`try_broadcast_commit_or_enqueue` (`context/governance_helpers.rs`), is deliberately
+Class-C: it takes only the three disjoint fields it touches
+(`CommitBroadcastBorrows { pending_commits, commit_fault, receive_buffer }`) from a
+non-persisting `class_c_view()`, and on transport failure enqueues a retry / sets a
+`commit_fault` gate rather than blocking a fail-closed persist behind the send. Keep the
+durable write synchronous; let the network hop be its own arm.
+
+## Cross-refs
+
+- ADR-049 §1 (actor owns state by move), §9 (Class-S/Class-C persistence), §153 / Decision 7
+  (async provider traits + `block_in_place` deletion), §Decision 9 (coalesce interval).
+- `lock-free-read-invariant.md` — why per-context state is reached by mailbox, not lock.
+- `owned-identity-did-capability.md` — the `Send` capability token in `ActorDeps`.
+- `spawn-blocking-for-sync-storage.md` — the sync-storage seam the Send-discipline needs.
+- `saga-prepare-commit-abort.md` — the one cross-actor protocol the mailbox model runs.

--- a/.docs/lessons/ast-based-ci-enforcement.md
+++ b/.docs/lessons/ast-based-ci-enforcement.md
@@ -1,0 +1,82 @@
+# AST / structural CI gates: check definitions, stay bounded, back the compiler up
+
+The actor-per-context refactor (ADR-049) ships a family of structural CI gates. They are
+worth understanding as a *class*, because they share one design and one set of failure
+modes. The terminal lesson from the sharpest of them —
+`ast-gate-checks-definition-not-name-resolution.md` — is a prerequisite; this lesson
+generalizes it to the whole roster.
+
+## The roster (what each asserts)
+
+- `scripts/check-block-in-place.py` — tree-sitter AST gate banning `block_in_place` /
+  `.block_on(…)` in the actor scope. Structural: it flags any identifier that *resolves to*
+  `block_in_place` at a call site, including aliased imports and fn-pointer rebinds tracked
+  through `let` declarations. Opt-outs are explicit inline allow-list directives.
+- `scripts/check-deleted-primitives.sh` — bans token patterns for primitives the refactor
+  deleted, so they cannot reappear (production *and* test scope). Ships with an **empty**
+  ban list and is populated only as the corresponding deletions land.
+- `scripts/check-construction-pattern.py` — ADR-052 unified-construction gate: forbids
+  `*Builder` types / typestate markers and boolean fields for semantic choices in
+  construction modules, with a named allowlist for the few legitimately-binary bools.
+- `scripts/check-call-invariants.py` — declarative call-precedence rules (from
+  `sdk-capability-matrix.json`): a caller matching a `fullmatch` regex must call a required
+  callee in-body (or one hop into a same-file helper). `fullmatch` is deliberate so a
+  sloppy pattern can't silently capture unrelated helpers.
+- `scripts/check-saga-gating-granularity.sh` — ADR-049 §3a: positively asserts the
+  per-participant-context-set reservation machinery is present *and* resists the common
+  rename/retype laundering of an instance-wide guard. Its own header states it is a
+  **tripwire, not a proof**.
+- `scripts/check-handle-affinity.sh` + `crates/scp-ffi/uniffi/tests/check_ready_coverage.rs`
+  — every FFI method taking a handle-typed parameter must call the per-bridge
+  handle-affinity check, so a handle minted by one instance cannot be used against another.
+
+## The three durable properties
+
+**1. Gates check a *definition*, never use-site name resolution.** A sound structural gate
+asserts facts about how something is *defined* — a type's visibility, its fields, its
+closed set of constructors, the presence of a required call token in a matching function.
+The moment a gate tries to answer "does *this argument* at *this call site* resolve to the
+trusted binding, unshadowed?" it is reimplementing the compiler's name resolution in an
+AST walker, which is an unbounded arms race. `ast-gate-checks-definition-not-name-resolution.md`
+is the full autopsy: a gate that crossed that line grew to 6,000+ lines over ~17 review
+passes and was ultimately deleted. Draw the line at the definition.
+
+**2. Sound and bounded = positive whitelist, fail-closed, not a growing denylist.** Per
+CLAUDE.md §"Guard against over-engineering and non-convergent enforcement," a gate must be
+*closed by construction*: a whitelist of permitted shapes that rejects anything else **by
+its kind**, not a denylist chasing "one more spelling" of a forbidden thing. The saga-gating
+gate resists laundering because it *positively* asserts the reservation store, the
+participant-set extractor, and the overlap-reject are wired — its header is candid that a
+sufficiently obscure field-name/type could still slip a negative-only scan. That candor is
+the point: a denylist is never complete; a whitelist is. And gates must **fail closed** —
+see `coverage-gates-must-fail-closed.md` and `fail-closed-gate-escape-hatch-must-be-verified.md`
+for how a gate that errors-open silently stops enforcing.
+
+**3. Gates are defense-in-depth, never the primary guarantee.** Where the type system,
+a compiler lint, or a cryptographic mechanism already enforces a property *soundly*, a
+weaker source-text re-check of the *same* property is **negative value** — a maintenance
+liability that rots against language-syntax evolution and gives false confidence. Before
+adding or growing a gate, ask CLAUDE.md's three questions: is it sound+bounded; does it
+redundantly re-check something already sound; is its cost proportionate? And ask the
+capstone question: *can the gate's own threat model defeat the gate?* If the only attacker
+is an insider with commit access, and that insider can equally edit the gate and its CI
+wiring, the gate adds zero marginal security — prefer the compiler (`OwnedIdentityDid` did
+exactly this: see `owned-identity-did-capability.md`).
+
+## The convergence signal
+
+**Review-pass count is diagnostic.** More than ~3 review passes on one gate that keep
+surfacing "a new spelling of the same bypass" means the *approach* is non-convergent — stop
+and reframe, do not grind. The correct merge-blocking bar for a defense-in-depth gate is a
+*compiling, mechanism-evading* counterexample, not a theoretical AST-spelling gap (least of
+all one that cannot compile). The `simplifier` review agent is charged with flagging this
+class as a BLOCKER; treat it as seriously as a correctness finding.
+
+## Cross-refs
+
+- `ast-gate-checks-definition-not-name-resolution.md` — the terminal, worked-through case.
+- `coverage-gates-must-fail-closed.md`, `fail-closed-gate-escape-hatch-must-be-verified.md`,
+  `suffix-matcher-becomes-bypass-when-gate-fails-closed.md` — fail-closed gate failure modes.
+- `owned-identity-did-capability.md` — a boundary held by the compiler, no gate.
+- CLAUDE.md §"Guard against over-engineering and non-convergent enforcement";
+  §"NEVER modify enforcement files to bypass failures."

--- a/.docs/lessons/ast-based-ci-enforcement.md
+++ b/.docs/lessons/ast-based-ci-enforcement.md
@@ -11,7 +11,10 @@ generalizes it to the whole roster.
 - `scripts/check-block-in-place.py` — tree-sitter AST gate banning `block_in_place` /
   `.block_on(…)` in the actor scope. Structural: it flags any identifier that *resolves to*
   `block_in_place` at a call site, including aliased imports and fn-pointer rebinds tracked
-  through `let` declarations. Opt-outs are explicit inline allow-list directives.
+  through `let` declarations. Opt-outs come two ways: explicit inline allow-list directives
+  (`// ci-allow: block-on: <reason>`) for individual sites, and wholesale file-scope
+  exclusions (`crypto/mls/storage.rs`, the `crates/scp-ffi/**` prefix) for boundaries that
+  require a sync→async bridge by construction.
 - `scripts/check-deleted-primitives.sh` — bans token patterns for primitives the refactor
   deleted, so they cannot reappear (production *and* test scope). Ships with an **empty**
   ban list and is populated only as the corresponding deletions land.

--- a/.docs/lessons/owned-identity-did-capability.md
+++ b/.docs/lessons/owned-identity-did-capability.md
@@ -1,0 +1,52 @@
+# `OwnedIdentityDid`: an unforgeable capability the compiler enforces
+
+## What it is
+
+`OwnedIdentityDid` (`context/supervisor/identity_capability.rs`) is the token that proves
+an actor's identity *owns* it. It is minted once per actor at spawn time inside
+`Supervisor::build_actor_deps`, held **by value** in `ActorDeps`, and passed **by
+reference** (`&OwnedIdentityDid`) to the `SupervisorHandle` methods that touch
+per-identity state. There is no `&DID`-keyed surface an actor can reach — the only
+identity an actor can read is the one that owns it. This is how cross-identity isolation
+(ADR-049 §5, spec §9.4.1) is enforced: not by runtime checks, but by making the wrong
+thing unconstructible.
+
+## Why it is unforgeable — and why there is no CI gate
+
+The guarantee "a token for a given DID only exists if supervisor-module code created it"
+rides on **two type-system facts**, not on a scanner:
+
+1. The constructor `issue_for_actor` is `pub(super)` — only supervisor-module code can
+   mint a token from a raw `DID`. Handler code in `context/actor/handlers/` cannot name the
+   path; the compiler refuses.
+2. The single field `did` is **private** — so no struct-literal `OwnedIdentityDid { did }`
+   is possible outside the module either.
+
+The struct's *name* is `pub(in crate::context)` (wider than the constructor) so that
+`ActorDeps` can hold it and handlers can take a `&`. That widening is safe precisely
+because (1) + (2) make **nameable ≠ constructible**: actor code can hold or borrow a
+token, but has no path to *mint* one. The struct must never be `pub`/`pub(crate)`.
+
+**Forbidden traits** (the header enumerates them, each with a reason): no `Clone`/`Copy`
+(would leak the capability), no `Serialize`/`Deserialize` (would smuggle it across a trust
+boundary), no `Default`/`From`/`Into` (fabrication without the blessed constructor), no
+`Hash`/`PartialEq`/`Eq`, no `Borrow`/`AsRef`/`Deref` (erodes the `&OwnedIdentityDid`
+contract), no `Debug`/`Display` (accidental logging of an identity token). The only two
+methods besides the mint are `reissue(&self)` — clones the *already-attested* DID for a
+spawned child, takes no `DID` param, so it cannot forge for an identity the caller does not
+already hold — and `as_did(&self) -> &DID`, read-only, which cannot reconstruct the proof.
+
+This capability deliberately has **no bespoke source-text CI gate**. The residual threat is
+an insider editing this one file — but that same insider could edit a scanner or its CI
+wiring, so a scanner adds *zero* marginal security over the type system, two module lints
+(`#![deny(unsafe_code)]` and `#![deny(non_local_definitions)]` in `supervisor/mod.rs`), and
+review of a tiny frozen file. That full reasoning — including why a 6,000-line scanner over
+this exact type was built and then deleted — is
+`ast-gate-checks-definition-not-name-resolution.md`. This lesson is its concrete
+capability; that lesson is the general rule.
+
+## Cross-refs
+
+- ADR-049 §5 (capability reduction), spec §9.4.1 (four-point unforgeability criterion).
+- `ast-gate-checks-definition-not-name-resolution.md` — why no scanner guards this file.
+- `actor-per-context-pattern.md` — the `Send` requirement on `ActorDeps` this token meets.

--- a/.docs/lessons/saga-prepare-commit-abort.md
+++ b/.docs/lessons/saga-prepare-commit-abort.md
@@ -1,0 +1,90 @@
+# The cross-context saga: prepare / commit / abort over two actors
+
+This lesson is about the *mechanism* — the FSM, its journal, and how a crash is
+reconciled. For the *admission* question — "should this even be a saga?" — read
+`saga-admission-and-topology-guards.md` first; it is not repeated here.
+
+## One saga survives
+
+There is exactly one cross-context saga in the system: **cross-context tool invocation**
+(spec §6.2.4). Three other arms that ADR-049 originally enumerated (custody handover,
+standing-pair creation, broadcast hosting) were category errors and were withdrawn — see
+the admission lesson. So everything below is written for the single surviving arm: the
+caller's economy reservation and the target's tool execution must be **both-or-neither**
+across two distinct context-actors.
+
+## The FSM
+
+The coordinator lives on the `Supervisor`; the durable record of *which saga is in which
+phase* is `SagaJournal` (`context/supervisor/saga_journal.rs`). The lifecycle is
+`SagaState` (same file):
+
+```
+Initiated → PreparingA → PreparingB → Committing → Committed
+                                    ↘ Aborting  → Aborted
+                                    ↘ NeedsRepair
+```
+
+`SagaState::is_terminal()` is true only for `Committed` and `Aborted`;
+`load_unresolved()` returns the latest entry per **non-terminal** saga, which is what
+crash recovery sweeps. `NeedsRepair` is deliberately **not** terminal — a saga that
+exhausts its commit-retry budget or lands one-sided parks here and stays visible to the
+recovery sweep until an operator resolves it. Operating a saga stuck in `NeedsRepair` is
+`.docs/runbooks/saga-needs-repair.md`.
+
+## Two records, one per side of the split
+
+The design deliberately keeps two separate durable records:
+
+- **The journal (supervisor-side, durable).** `JournalEntry` records the `SagaState`, the
+  `participants`, and a `Zeroizing<Vec<u8>>` `evidence` blob — public phase metadata only.
+  Spec §9.4.3 forbids the journal from holding bearer secrets; no live saga is
+  secret-bearing, so the commitment path is dormant. Each entry is length-prefixed +
+  CRC32-suffixed so a torn write is detected on load, not replayed.
+- **`saga_pending` (actor-side, in-memory).** `SagaPreparedState`
+  (`context/supervisor/saga_prepared_state.rs`) holds the full staged evidence an actor
+  needs to *apply* the mutation at Commit time; it lives in `PerContextState.saga_pending`
+  and is persisted only as part of the actor's coalesced snapshot.
+
+The per-phase handlers run on the participant actors (`context/actor/handlers/saga.rs`):
+
+- **Prepare-A** (`prepare_a`, caller actor) — validates the caller holds `tool:interface`
+  and is an allowed caller, **stages** (does not apply) the rate-limit decrement + escrow
+  reservation, Class-S sync-persists fail-closed, and replies the `Send` reservation
+  handles for the FSM to hold (RAII release on abort).
+- **Prepare-B** (`prepare_b`, target actor) — re-runs the full §7 validation *re-bound* to
+  the carried `caller_did` + `tool_registration_id` (the confused-deputy defense),
+  captures B-controlled provenance, stages the prepared record, Class-S sync-persists
+  fail-closed, then replies.
+- **Commit** — split `commit_b_reserve` → supervisor executes → `commit_b_settle`
+  (B records `ToolInvoked`, signs the receipt, durably captures output keyed by `SagaId`)
+  and `commit_a` (A re-acks from the durable witness, settles escrow). Every commit step is
+  **idempotent by `SagaId`** — a replayed Commit short-circuits.
+- **Abort** (`abort`) — releases the staged reservations, from the live RAII carrier or the
+  durable caller-reservation record on the crash-recovery path.
+- **Divergence marker** (`emit_divergence_marker`) — on a one-sided `NeedsRepair`, each
+  reachable side signs and appends its own marker to its own log.
+
+Prepare-phase rejections carry typed `SCP-SAGA-13xxx` codes (ADR-049 §3a).
+
+## Replay-from-Prepare is what makes crash recovery safe
+
+`saga_prepared_state.rs` states the determinism contract: at Commit time the actor
+reconstructs its evidence from `saga_pending` and applies the mutation; **if `saga_pending`
+rolled back beyond the prepared state** (e.g. a coalesced-snapshot crash window), Commit
+replay fails fast with `SagaCommitFailed` — no half-applied mutation. Combined with the
+Class-S fail-closed persist in both Prepare handlers (the caller deduction + reservation
+record land durably *before* the FSM appends the `PreparingB` journal entry), this gives
+the recovery invariant: a crash never leaves a partial commit — either the durable
+prepared state is intact and Commit re-drives idempotently, or it is gone and Commit
+refuses. `Supervisor::recover_saga_entry` dispatches each non-terminal state to its
+recovery arm on the strict restore-then-replay order enforced by
+`Supervisor::restore_on_startup`.
+
+## Cross-refs
+
+- `saga-admission-and-topology-guards.md` — the two guards a saga must pass to exist.
+- ADR-049 §3 (saga FSM), §3a (FFI surface + error band), §3b (admission criteria),
+  §6.2.4 area; spec §6.2.4 (the surviving arm), §9.4.3 (journal secret handling),
+  §17.16 (durable coordinator surface), §17.16.4 (crash-recovery sweep).
+- `.docs/runbooks/saga-needs-repair.md` — operating a `NeedsRepair` saga.

--- a/.docs/lessons/sequence-reservation-raii.md
+++ b/.docs/lessons/sequence-reservation-raii.md
@@ -1,0 +1,49 @@
+# Send-sequence reservation: the snapshot is the mechanism, RAII is belt-and-braces
+
+## The rule
+
+Per spec §5.15.7, a send-sequence number is *consumed* (becomes durable) **iff** its
+payload was handed to the transport. Any terminal outcome before transmit — a `?`-early
+return, a panic, a cancellation — MUST release the number back into the pool, or the next
+send skips a sequence and receivers reject the gap. The actor-side implementation is
+`SequenceReservation` in `context/actor/sequence.rs`.
+
+## Two mechanisms, layered
+
+Read the module `//!` header — it is explicit that there are two independent protections
+and which one is load-bearing:
+
+- **The snapshot is the actual mechanism (across crashes).** The per-context coalesced
+  snapshot is the floor: a respawned actor loads a snapshot that predates any in-flight
+  reservation, so `SendSequenceTracker` starts from the persisted high-water mark. This is
+  what protects monotonicity when the whole actor dies.
+- **RAII is belt-and-braces (within a lifetime).** `SequenceReservation` is a Drop guard:
+  drop rolls the counter back; an explicit `commit()` makes the reservation durable. It
+  closes the within-lifetime paths (panic, `?`, cancellation) that the snapshot floor does
+  not need to reason about, replacing the scattered `rollback_sequence_number` calls that
+  used to live in the legacy `manager/messaging.rs`.
+
+`SendSequenceTracker::reserve_next` post-increments and returns the reserved number;
+`rollback` decrements **iff** the rolled-back number is the head — only the *youngest*
+outstanding reservation may be rolled back, so a rollback can never re-use a number an
+in-flight younger reservation already holds. This mirrors, deliberately without semantic
+change, `MembershipState::rollback_sequence_number` in
+`crates/scp-protocol/src/context/membership.rs` (saturating subtract by 1).
+
+## The one pitfall: AAD uses the pre-increment value
+
+`SequenceReservation::reserve` returns the **post-increment** slot (first reservation
+returns `1`, not `0`). The legacy MLS sender-key `seal` AAD (spec §9.16.1, ADR-007) is
+**0-based** — it binds the *current* counter value, then increments. So a handler
+producing byte-identical wire output MUST read `SendSequenceTracker::last_issued()`
+**before** reserving to get the pre-increment value for the AAD, and only then call
+`SequenceReservation::reserve` to mark the slot consumed. The header spells out the exact
+ordering. Feeding `reservation.number()` as the AAD sequence instead of `last_issued()` is
+a byte-identity regression: receivers on the legacy decrypt path reject every message with
+an AAD mismatch. This is the sole known pitfall when migrating a handler off the legacy
+`seal`.
+
+## Cross-refs
+
+- Spec §5.15.7 (send-sequence reservation), §9.16.1 / ADR-007 (sender-key AAD binding).
+- `actor-per-context-pattern.md` — the coalesced snapshot that is the crash-recovery floor.

--- a/.docs/lessons/spawn-blocking-for-sync-storage.md
+++ b/.docs/lessons/spawn-blocking-for-sync-storage.md
@@ -41,13 +41,21 @@ extra hop there would be redundant for an already-async backend.
 genuine sync→async boundary, and the wrong cost for work that is already async — which is
 why the adapter does **not** re-wrap. The ban on `block_in_place` / `.block_on(…)` in the
 actor-refactor scope is mechanically enforced by `scripts/check-block-in-place.py` (an
-AST gate — see `ast-based-ci-enforcement.md`). The remaining legitimate sites — the
-legacy `crypto/mls/storage.rs` bridge and a handful of others still mid-migration — opt out
-via the gate's **inline allow-list directive**, an explicit per-site exemption rather than
-a silent exception; the count is ratcheted down (`ratchet/block-in-place-count.json`) as
-Decision-7 PRs delete each bridge. At the current commit the `scp-transport`
-`provider.rs` / `relay_persistence.rs` bridges and `crypto/mls/storage.rs` still hold
-`block_in_place` sites; the direction is single: toward zero.
+AST gate — see `ast-based-ci-enforcement.md`), which opts sites out two ways.
+`crypto/mls/storage.rs` — whose sync `OpenMLS` `StorageProvider` bridge (`sync_store` /
+`sync_retrieve` / `sync_delete`, ~:201/212/223) is the one place a `block_in_place` is still
+genuinely required — is a **wholesale file-scope exclusion** (`EXCLUDED_FILES` in the gate,
+alongside the `crates/scp-ffi/**` prefix), *not* an inline directive: it carries no
+`// ci-allow`. Individual sites elsewhere opt out with the gate's **inline allow-list
+directive** (`// ci-allow: block-on: <reason>`) — e.g. `shutdown_all_contexts_sync`'s FFI
+sync-shutdown path; the remaining still-counted sites (`lifecycle_helpers.rs`'s
+`flush_all_contexts_sync` pair, `store/trust.rs`, the `tools_helpers` `_legacy` slack, and
+the `scp-node` HTTP handler) are simply **ratchet-baselined** and driven toward zero
+(`ratchet/block-in-place-count.json`). At the current commit the `scp-transport`
+`provider.rs` / `relay_persistence.rs` bridges are **gone** (count `0` — the `block_in_place`
+tokens still in `provider.rs` are doc-comment prose, not calls); the only real
+`block_in_place` sites left in this lesson's storage scope are the three in
+`crypto/mls/storage.rs`.
 
 ## Cross-refs
 

--- a/.docs/lessons/spawn-blocking-for-sync-storage.md
+++ b/.docs/lessons/spawn-blocking-for-sync-storage.md
@@ -1,0 +1,57 @@
+# `spawn_blocking` for sync storage, not `block_in_place`
+
+## The problem
+
+`OpenMLS`'s `StorageProvider` is a **sync** trait — every method returns
+`Result<…, Self::Error>` with no async support. The SCP `Storage` backend underneath it is
+async (and, for the production `SqliteStorage`, wraps `rusqlite`, which is itself
+blocking). Bridging a sync caller to an async/blocking backend has two shapes, and only one
+is safe on a shared runtime:
+
+- **`block_in_place(|| handle.block_on(…))`** — the legacy bridge in
+  `crypto/mls/storage.rs`. It **pins the tokio worker thread** for the duration of the call
+  and **panics outright on a `current_thread` runtime**. Under load it starves the worker
+  pool; under `current_thread` it is a hard crash.
+- **`spawn_blocking`** — moves the blocking work to tokio's dedicated blocking pool,
+  freeing the async worker. One hop per call at the sync→async seam. This is the ADR-049
+  §7 / §153 (Decision 7) direction.
+
+## The seam that is already built
+
+`SpawnBlockingStorageAdapter<S>` (`crypto/mls/storage_adapter.rs`) is the landed adapter.
+It implements `OpenMlsStorageAdapter` — a **dyn-compatible** async KV surface
+(`store` / `retrieve` / `delete`, `#[async_trait]`-desugared to boxed futures) — over any
+`S: scp_platform::traits::Storage`. Dyn-compatibility is the whole point: `Storage` itself
+uses RPITIT and so **cannot** be `Arc<dyn Storage>` (the compiler refuses); the adapter
+erases to `Arc<dyn OpenMlsStorageAdapter>`, instantiated once per process and cloned into
+every actor's `ActorDeps`. The production MLS backend (`crypto/mls/production_backend.rs`,
+`ProductionMlsBackend`) drives its group store through this adapter.
+
+The name encodes the role: the sync `OpenMLS` `StorageProvider` bridge built on top of the
+adapter wraps **each** adapter call in a single `spawn_blocking`, so a sync-heavy backend
+(`SqliteStorage` over `rusqlite`) never pins an async worker when `OpenMLS` reaches for the
+KV store. The adapter forwards directly to the already-async `Storage` — the
+`spawn_blocking` hop lives at the sync `OpenMLS` seam, not inside the adapter, because an
+extra hop there would be redundant for an already-async backend.
+
+## Cost and enforcement
+
+`spawn_blocking` is not free: it is a thread-pool handoff plus a `JoinHandle` await
+(`OpenMlsStorageError` carries the join-failure case). It is the right cost for a
+genuine sync→async boundary, and the wrong cost for work that is already async — which is
+why the adapter does **not** re-wrap. The ban on `block_in_place` / `.block_on(…)` in the
+actor-refactor scope is mechanically enforced by `scripts/check-block-in-place.py` (an
+AST gate — see `ast-based-ci-enforcement.md`). The remaining legitimate sites — the
+legacy `crypto/mls/storage.rs` bridge and a handful of others still mid-migration — opt out
+via the gate's **inline allow-list directive**, an explicit per-site exemption rather than
+a silent exception; the count is ratcheted down (`ratchet/block-in-place-count.json`) as
+Decision-7 PRs delete each bridge. At the current commit the `scp-transport`
+`provider.rs` / `relay_persistence.rs` bridges and `crypto/mls/storage.rs` still hold
+`block_in_place` sites; the direction is single: toward zero.
+
+## Cross-refs
+
+- `tokio-mutex-blocking-lock-in-runtime.md` — the sibling rule: never `blocking_lock()` a
+  `tokio::sync::Mutex` from a runtime thread; the same "don't block the worker" principle.
+- `actor-per-context-pattern.md` — the Send-discipline that motivates async provider traits.
+- ADR-049 §7 (MLS storage), §153 / Decision 7 (async traits + `block_in_place` deletion).

--- a/.docs/runbooks/saga-needs-repair.md
+++ b/.docs/runbooks/saga-needs-repair.md
@@ -1,0 +1,90 @@
+# Runbook: a cross-context saga in `NeedsRepair`
+
+**Scope.** The single cross-context saga — cross-context tool invocation (spec §6.2.4) —
+has parked in the `NeedsRepair` state. This runbook covers detecting it, understanding why
+restart-driven replay resolves most cases automatically, and recognizing the residual
+cases that need a human. For the FSM and phase semantics, see
+`.docs/lessons/saga-prepare-commit-abort.md`.
+
+## Symptom
+
+A saga has landed in `SagaState::NeedsRepair` (`context/supervisor/saga_journal.rs`).
+`NeedsRepair` is **not** a terminal state — `SagaState::is_terminal()` returns true only
+for `Committed` and `Aborted` — so `SagaJournal::load_unresolved()` keeps returning the
+entry, and every process restart re-surfaces it until it resolves. A saga reaches
+`NeedsRepair` when:
+
+- Commit exhausted its retry budget (the state's own definition), or
+- recovery observed a genuinely-unresolvable divergence: a one-sided commit, or a
+  participant side that is unreachable (`Supervisor::recover_committing_entry`), or
+- an `Aborting` entry whose rollback never completed
+  (`Supervisor::recover_saga_entry`, the `Aborting` arm re-resolves to `NeedsRepair`).
+
+## Signal to alert on
+
+Metric: **`scp_saga_repair_needed_total`** (a counter, `crates/scp-runtime/src/metrics.rs`,
+emitted by `record_saga_repair_needed`). It increments whenever a saga lands in
+`NeedsRepair` **or** when the crash-recovery load sweep skips a corrupt / torn /
+undecodable / vanished journal entry (spec §17.16.4). Alert on any increase.
+
+Logs: each increment is paired with a `tracing::error!` carrying `saga_id`. The
+distinguishing messages:
+
+- `"saga recovery — NeedsRepair carryover; operator intervention required"`
+  (`recover_needs_repair_entry`) — a pre-existing `NeedsRepair` re-surfaced at this restart.
+- `"saga recovery — Aborting observed; marked NeedsRepair for operator review"` — a
+  rollback that did not finish.
+- A `load_unresolved` skip logged from `saga_journal.rs` — a corrupt/torn entry (the CRC32
+  + length-prefix check failed); this one is a **storage-integrity** signal, not a stuck
+  saga.
+
+Inspect the durable record directly by `saga_id`: journal entries live under the
+`saga_journal/{saga_id}/{seq_per_saga}` key namespace, append-only, latest entry wins.
+
+## How restart-driven replay recovers it (the primary path)
+
+There is **no `repair_saga(saga_id)` command** — repair is driven by process restart, not
+by a targeted call. On startup the sole recovery entry point is
+`Supervisor::restore_on_startup` (`context/supervisor/supervisor.rs`), which runs two sweeps
+in the order spec §17.16.4 requires, **restore then reconcile**:
+
+1. `restore_all_contexts` — rehydrate every persisted `Active` context's actor, so every
+   participant a recovery arm must drive is resident. (The order is enforced by the type
+   system: `replay_unresolved_sagas` requires the `RestoredContexts` witness that
+   `restore_all_contexts` returns, so "replay first" does not compile.)
+2. `replay_unresolved_sagas` → `recover_saga_entry` per non-terminal entry — **replay from
+   Prepare**, idempotent by `SagaId`:
+   - a `Committing` entry re-drives the idempotent Commit (**never** re-invoking the tool):
+     B re-acks its existing `ToolInvoked` and re-emits the stored output; A re-acks from the
+     durable `xctx_committed_invocations` witness. If both sides actually committed, the
+     saga resolves to `Committed` — a false `NeedsRepair` clears itself.
+   - a `PreparingA`/`PreparingB` entry re-drives the record-keyed caller reversal and
+     reaches terminal `Aborted` once the reversal is confirmed delivered.
+
+So the first operator action for most `NeedsRepair` alerts is simply: **confirm a clean
+process restart occurred and check whether the entry cleared.** A saga that was really
+two-sided-committed or fully compensated resolves without intervention on the next start.
+
+## When a human is actually needed
+
+The entry **stays** `NeedsRepair` across a restart only when replay cannot resolve it:
+
+- a genuinely one-sided commit (one participant committed, the other cannot be made to),
+- a participant context that failed to restore or whose persistence existence cannot be
+  confirmed (the reversal is left non-terminal, fail-closed, for the next start),
+- a non-reconstructible / corrupt journal entry surfaced by the load-sweep skip.
+
+For these, use the durable divergence account: `recover_needs_repair_entry` rehydrates any
+`saga_repair_records` carried in the entry's evidence, and each reachable side has appended
+its own signed `CrossContextDivergenceMarker` to its own log (the
+`emit_divergence_marker` handler). Reconcile from those records — confirm which side
+holds the committed effect and which the reservation — and settle the economy manually,
+then the entry can be marked resolved. A corrupt-entry skip is a **storage** problem: repair
+or restore the backing store before expecting recovery to progress.
+
+## Note
+
+A targeted, no-restart repair command (repair a single `saga_id` without a full
+restore-then-replay cycle) is a tracked future enhancement. Until it lands, restart-driven
+replay is the mechanism, and the manual reconciliation above is the fallback for the
+residual unresolvable cases.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -250,13 +250,14 @@ The orchestrator never writes code. It manages execution, maintains plan alignme
 ├── adrs/            # Architecture Decision Records (phase-1 through phase-6)
 ├── lessons/         # Evergreen learnings, grouped by topic
 ├── planning-sessions/
+├── runbooks/        # Operator runbooks (incident diagnosis + remediation)
 ├── scaffold/        # Per-language SDK build blueprints
 ├── specs/           # Product specs — what to build
 └── standards/       # Coding and workflow standards. NON-NEGOTIABLE
 
 crates/              # Rust workspace — the protocol core
 ├── scp-protocol/    # Pure sync protocol types (no tokio, compiles for wasm32)
-├── scp-runtime/     # Async orchestration (ContextManager, MLS, providers)
+├── scp-runtime/     # Async orchestration (Supervisor actor-per-context, MLS, providers)
 ├── scp-core/        # Facade re-exporting scp-protocol + scp-runtime
 ├── scp-ffi/         # FFI bridges — 3 targets, one codebase
 │   ├── src/         #   PyO3 (Python) — the REFERENCE bridge (100% coverage target)


### PR DESCRIPTION
## Summary

ADR-049 **Phase 4** documentation — the evergreen lessons and operator runbook capturing the actor-per-context refactor, plus a Project Map entry so the new `.docs/runbooks/` subtree is discoverable.

## Deliverables

**6 evergreen lessons** (`.docs/lessons/`), each grounded in landed code:
- `actor-per-context-pattern.md` — Supervisor / ClassSCell / PerContextState / mailbox model + the `#[async_trait]` Send-discipline, with the fail-closed commit-broadcast split (`try_broadcast_commit` → `apply_broadcast_failure` → `keep_broadcast_failure`) as the worked example.
- `saga-prepare-commit-abort.md` — the saga FSM + replay-from-Prepare determinism (cross-context tool invocation is the sole surviving saga).
- `sequence-reservation-raii.md` — `SequenceReservation`/`SendSequenceTracker` Drop-based release.
- `owned-identity-did-capability.md` — `OwnedIdentityDid` capability reduction (§5).
- `spawn-blocking-for-sync-storage.md` — `SpawnBlockingStorageAdapter` for OpenMLS's sync `StorageProvider` (§7).
- `ast-based-ci-enforcement.md` — the AST/structural gate scripts, positive-whitelist / fail-closed / convergence principles.

**Operator runbook** `.docs/runbooks/saga-needs-repair.md` — grounded in the real recovery surface (`Supervisor::restore_on_startup` replay-from-Prepare + `scp_saga_repair_needed_total` metric + `NeedsRepair` state). Documents honestly that there is no per-saga `repair_saga` command (restart-driven replay is the mechanism); a targeted no-restart command is tracked as a follow-up.

**Project Map** (`CLAUDE.md`) — adds the `.docs/runbooks/` entry and retires the stale `ContextManager` reference (→ `Supervisor actor-per-context`).

## Review

Written → **independent grep-accuracy audit** (caught + corrected pre-refactor confabulations in the async/broadcast/transport claims) → grep-verified → **chronicler** (SHIP: cross-links resolve, vocabulary consistent with the runtime architecture docs, deliverables complete, grounded not filler). Every cited symbol was verified against `origin/main` @ the merged Decision-7 tip.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
