### PR TITLE
docs(runtime): Phase 4 — runtime architecture docs (README rewrite + CLAUDE.md + context/mls READMEs)

### DIFF
--- a/crates/scp-runtime/CLAUDE.md
+++ b/crates/scp-runtime/CLAUDE.md
@@ -88,11 +88,12 @@ Actor futures are `tokio::spawn`'d, so **everything the actor awaits must be
   process. When you need byte-blob storage inside a handler, reach it through
   a bridge that already owns a concrete `Arc<S>` — never try to add
   `dyn Storage` to `ActorDeps`.
-- Not every backend is async. `RecoveryBackend` (`identity/recovery.rs`) is a
-  **synchronous** trait; its production impl (`ProductionRecoveryBackend`)
-  bridges sync→async internally via a sanctioned `block_in_place` +
-  `Handle::block_on` hop (`block_on_async`). That hop is one of the
-  allow-listed sites in the ratchet below.
+- `RecoveryBackend` (`identity/recovery.rs`) is the one `Send`-rule exception:
+  it is the SOLE `#[async_trait(?Send)]` provider trait (every other
+  ActorDeps-resident provider trait is a plain `Send` `#[async_trait]`). Its
+  production impl (`ProductionRecoveryBackend`) `.await`s the supervisor mailbox
+  directly. It is driven at the FFI boundary on a single task, never
+  `tokio::spawn`'d, so its futures need not be `Send`.
 
 ## Invariant 3 — capability reduction (who can reach what)
 
@@ -114,9 +115,8 @@ Actor futures are `tokio::spawn`'d, so **everything the actor awaits must be
 ADR-049 removes the sync-bridge pattern that made `current_thread` runtimes
 panic. `scripts/check-block-in-place.py` is an AST **ratchet**: each in-scope
 file has a baseline count that may only drop. New sites are budget-0 and fail
-CI. Genuinely-needed sync→async seams (e.g. `RecoveryBackend`, the OpenMLS
-sync `StorageProvider` bridge in `crypto/mls/storage.rs`) are inline
-allow-listed. If you find yourself reaching for `block_in_place`, you almost
+CI. Genuinely-needed sync→async seams (e.g. the OpenMLS sync `StorageProvider`
+bridge in `crypto/mls/storage.rs`) are inline allow-listed. If you find yourself reaching for `block_in_place`, you almost
 certainly want `spawn_blocking` at the seam instead (see
 `SpawnBlockingStorageAdapter`).
 

--- a/crates/scp-runtime/CLAUDE.md
+++ b/crates/scp-runtime/CLAUDE.md
@@ -1,0 +1,142 @@
+# scp-runtime — agent map
+
+You are modifying SCP's async runtime. This is a map, not a manual: it tells
+you where things live and which invariants will bite you. Read the root
+`CLAUDE.md` first; it governs. Then read `.docs/adrs/ADR-049-actor-per-context.md`
+— every concept below traces to a numbered decision in it.
+
+## The one thing to understand: actor-per-context
+
+One `tokio` task per live context (`ContextActor`), owning its
+`PerContextState` by move. No locks on context state. A `Supervisor` (a plain
+struct — deliberately not an actor) owns the registry of actor mailboxes and
+every provider, and coordinates the one cross-context saga. Handlers mutate
+state; the actor decides when to persist.
+
+```
+caller → Supervisor::method (lock-free lookup) → ContextActorHandle mailbox
+       → ContextActor::run() select! → handlers/<domain>::dispatch
+       → &mut PerContextState (via ClassSCell) → coalesced or fail-closed persist
+```
+
+Where it lives:
+
+- `src/context/supervisor/` — `Supervisor` (registry + saga coordinator),
+  `SupervisorHandle` (the capability-reduced view actors hold), the saga
+  journal, the per-identity key-package actor.
+- `src/context/actor/` — `ContextActor` + `run()` loop (`mod.rs`), the
+  `ContextCommand` outer enum + 12 sub-enums (`commands.rs`), the mailbox
+  wrapper (`handle.rs`), `PerContextState` (`state.rs`), `ClassSCell`
+  (`class_s.rs`), `ActorDeps` (`deps.rs`), and `handlers/` (one module per
+  command domain).
+- `src/context/*_helpers.rs` — the domain logic bodies (governance,
+  lifecycle, messaging, trust_recovery, broadcast, …) that handlers call.
+- `src/crypto/mls/` — the MLS subsystem (`src/crypto/mls/README.md`).
+
+See `src/context/README.md` for the full `context/` tree.
+
+## Invariant 1 — Class-S (fail-closed) vs Class-C (coalesced) persistence
+
+ADR-049 §9 splits persistence into two classes, and getting this wrong is a
+security bug, not a performance one:
+
+- **Class-C (coalesced, best-effort).** Ordinary state. The actor's `run()`
+  loop marks state dirty (`Outcome { mutated: true }`) and writes one
+  snapshot per coalescing window (`COALESCE_INTERVAL`). A crash can lose the
+  last window; that is acceptable for Class-C fields.
+- **Class-S (fail-closed).** Security-critical fields — spending-nonce
+  consumption, executed-proposals, downward-authorization transitions, saga
+  reservation slots. A mutation MUST be durable **before** it is acknowledged
+  to the caller: a coalesced ack would let a crash roll back a mutation the
+  caller already observed as committed, re-opening a replay / re-spend /
+  re-grant window.
+
+This is enforced by the **type system**, not a scanner. `ClassSCell`
+(`actor/class_s.rs`) wraps `PerContextState`, exposes `Deref` (reads) but
+**no `DerefMut`**, and the three Class-S fields are privatized. The only way
+to mutate them is through the cell's combinators, each of which persists
+fail-closed by construction:
+
+- `commit_class_s_keep` — keep the mutation on persist failure (e.g. a
+  consumed replay nonce must not be un-recorded).
+- `commit_class_s_restore` — roll back on persist failure.
+- `commit_class_s_compensating` / `commit_class_s_keep_compensating` — plus an
+  async undo of an external effect (e.g. void an escrow).
+- `commit_class_s_then_append` — fail-closed persist followed by a durable
+  external append (event log).
+- `commit_class_c_best_effort` — the Class-C path; hands out a **field-granular**
+  `ClassCMut` view that is airtight by construction (it holds no whole
+  `&mut PerContextState`, so no Class-S mutation is even nameable through it).
+
+If you add a Class-S field or a new persist shape, do it through a combinator.
+Do not reintroduce a `state_mut` escape hatch or a source-text scanner — the
+retired scanner was non-convergent (a lesson the module doc-comment records).
+
+## Invariant 2 — Send-discipline for provider traits
+
+Actor futures are `tokio::spawn`'d, so **everything the actor awaits must be
+`Send`**. That constraint shapes every provider trait:
+
+- MLS/HPKE/storage backends (`MlsBackend`, `HpkeBackend`,
+  `OpenMlsStorageAdapter`) are `#[async_trait]` (which desugars to
+  `Send`-boxed futures) with a `Send + Sync` supertrait, and are dyn-erased
+  as `Arc<dyn …>` so one instance is shared across every actor.
+- `scp_platform::Storage` uses return-position `impl Trait` (RPITIT) and is
+  therefore **not** dyn-compatible — you cannot write `Arc<dyn Storage>`.
+  That is exactly why `OpenMlsStorageAdapter` exists: a dyn-compatible
+  `#[async_trait]` wrapper over a concrete `S: Storage`, erased once per
+  process. When you need byte-blob storage inside a handler, reach it through
+  a bridge that already owns a concrete `Arc<S>` — never try to add
+  `dyn Storage` to `ActorDeps`.
+- Not every backend is async. `RecoveryBackend` (`identity/recovery.rs`) is a
+  **synchronous** trait; its production impl (`ProductionRecoveryBackend`)
+  bridges sync→async internally via a sanctioned `block_in_place` +
+  `Handle::block_on` hop (`block_on_async`). That hop is one of the
+  allow-listed sites in the ratchet below.
+
+## Invariant 3 — capability reduction (who can reach what)
+
+- Actors hold a `SupervisorHandle`, never `Arc<Supervisor>`. The handle
+  exposes no accessor returning a `ContextActorHandle`, so **an actor cannot
+  reach a sibling actor** — cross-context work goes through
+  `SupervisorHandle::start_saga` (ADR-049 §5). Keep it that way: do not add a
+  handle method that hands back an actor handle or the raw supervisor.
+- Per-identity operations take `&OwnedIdentityDid`, not `&DID`.
+  `OwnedIdentityDid` (`supervisor/identity_capability.rs`) is an unforgeable
+  token: its constructor is `pub(super)` and its field is private, so only
+  supervisor-module code can mint one for a given DID. `supervisor/mod.rs`
+  carries `#![deny(unsafe_code)]` + `#![deny(non_local_definitions)]` (closing
+  the body-nested-`impl` forge vector) and a `compile_fail` doctest tripwire.
+  Do not weaken those, and do not add a second minter of any form.
+
+## Invariant 4 — no `block_in_place` / `block_on` in the actor scope
+
+ADR-049 removes the sync-bridge pattern that made `current_thread` runtimes
+panic. `scripts/check-block-in-place.py` is an AST **ratchet**: each in-scope
+file has a baseline count that may only drop. New sites are budget-0 and fail
+CI. Genuinely-needed sync→async seams (e.g. `RecoveryBackend`, the OpenMLS
+sync `StorageProvider` bridge in `crypto/mls/storage.rs`) are inline
+allow-listed. If you find yourself reaching for `block_in_place`, you almost
+certainly want `spawn_blocking` at the seam instead (see
+`SpawnBlockingStorageAdapter`).
+
+## Adding a new protocol feature — integration checklist
+
+A new runtime capability is not "done" when the core function compiles. Follow
+the root `CLAUDE.md` **Integration checklist**: the function must be reachable
+from a `Supervisor` method, exported from every applicable FFI bridge, wrapped
+in each SDK, asserted in `pipeline_wiring.rs`, and reflected in the SDK
+capability matrix. An empty cell means the plan is incomplete. Never edit an
+enforcement file (listed in the root `CLAUDE.md`) to make a check pass — fix
+the code.
+
+## Pointers
+
+- `.docs/adrs/ADR-049-actor-per-context.md` — the model, every decision.
+- `.docs/lessons/tokio-mutex-blocking-lock-in-runtime.md`,
+  `.docs/lessons/lock-free-read-invariant.md` — concurrency lessons.
+- `.docs/lessons/ast-gate-checks-definition-not-name-resolution.md` — why the
+  Class-S scanner was retired for a type-system guard.
+- `src/context/README.md`, `src/crypto/mls/README.md` — module maps.
+- `#![warn(missing_docs)]` is crate-wide (`lib.rs`); keep new public items
+  documented.

--- a/crates/scp-runtime/README.md
+++ b/crates/scp-runtime/README.md
@@ -62,7 +62,10 @@ use scp_protocol::context::{ContextParams, ContextState};
 // `event_log` are boxed provider trait objects; `key_resolver` maps a DID +
 // verification method to its Ed25519 verifying key (ADR-039).
 let supervisor = test_supervisor(
-    Arc::new(MlsCryptoProvider::new("did:dht:z6Mk...creator".to_owned())),
+    Arc::new(MlsCryptoProvider::new(
+        "did:dht:z6Mk...creator".to_owned(),
+        Arc::new(scp_clock::SystemClock),
+    )),
     Box::new(my_transport_provider),
     Box::new(my_event_log_provider),
     my_key_resolver,
@@ -78,7 +81,7 @@ let handle = supervisor
     )
     .await?;
 
-assert_eq!(handle.try_read_state(), Some(ContextState::Active));
+assert_eq!(handle.state(), ContextState::Active);
 ```
 
 ## Send a message

--- a/crates/scp-runtime/README.md
+++ b/crates/scp-runtime/README.md
@@ -2,171 +2,163 @@
 
 Async runtime orchestration for [SCP](https://github.com/limn-works/scp) (Shared Context Protocol).
 
-Implements context lifecycle management (`ContextManager`), MLS group encryption (`OpenMLS` wrapper), UCAN minting, governance timeout enforcement, persistence bridges, tool invocation, and async identity operations. Depends on `scp-protocol` for pure sync types and `scp-platform` for platform abstraction traits.
+`scp-runtime` is where SCP's stateful, `tokio`-driven logic lives: context
+lifecycle, MLS group encryption, UCAN minting, governance, the cross-context
+saga coordinator, and the persistence bridges. It depends on `scp-protocol`
+for pure sync types and `scp-platform` for platform abstraction traits
+(key custody, storage). Transport is injected, never hard-wired.
+
+## The concurrency model — actor-per-context (ADR-049)
+
+The runtime runs **one `tokio` task per live context**. That task (a
+`ContextActor`) owns its `PerContextState` by move and mutates it inside a
+command-dispatch loop — there are no interior locks on context state, and no
+two tasks ever touch the same context. This replaced an older lock-based
+`ContextManager` whose 4 lock types and scattered `relock_context` sites were
+"correct by discipline"; the actor model makes single-writer ownership a
+structural property instead. Read `.docs/adrs/ADR-049-actor-per-context.md`
+for the full rationale and the decisions referenced throughout these docs.
+
+Three types anchor the model:
+
+- **`Supervisor`** — a plain struct (not an actor) that owns the actor
+  registry and every injected provider. Lookups are lock-free
+  (`DashMap::get` + `ArcSwap::load`) because they sit on the hot path of
+  every public call; a mailbox hop per lookup would be too expensive
+  (Decision 2, Decision 12). It is also the cross-context **saga
+  coordinator**.
+- **`ContextActor`** — the per-context task. Its `run()` loop is a
+  `tokio::select!` over four arms: inbox command, TTL timer, governance
+  timeout, and the coalesced-persistence tick (Decision 1).
+- **`SupervisorHandle`** — a capability-reduced view of the `Supervisor`
+  handed to each actor. It exposes no way to reach a sibling actor's handle;
+  cross-context work must go through `SupervisorHandle::start_saga`
+  (Decision 5). This is what makes "actor A cannot send to actor B directly"
+  a compile-time guarantee, not a convention.
+
+> **Migration note.** ADR-049 lands over a long commit ladder. Some domain
+> handlers still route through a transitional `&Supervisor` "shim" dispatch
+> while their bodies migrate to the `(&mut PerContextState, &ActorDeps)`
+> signature. The public API (`Supervisor::create_context`, `send_message`,
+> …) is stable; the shim is an internal detail on its way out. See
+> `src/context/README.md` and `CLAUDE.md` in this crate for the current map.
 
 ## Quick Start
 
-```rust,ignore
-use scp_core::context::{
-    ContextManager, ContextParams, LocalTransportProvider,
-};
-use scp_core::context::providers::MerkleEventLogProvider;
-
-// Build a ContextManager with defaults.
-//   - LocalTransportProvider: all operations succeed locally (no relay).
-//   - MerkleEventLogProvider: in-memory Merkle-chained event log.
-//   - No persistence: state lives in memory only.
-let manager = ContextManager::builder()
-    .crypto(Box::new(my_crypto_provider))
-    .build()
-    .expect("crypto is the only required provider");
-```
-
-## With Persistence (crash recovery)
-
-Pass an `EncryptedStorage` implementation to `.storage()` and the builder auto-wires
-`ProtocolRepository`, context persistence, and event log persistence:
+The `Supervisor` is the single entry point. In production, FFI bridges build
+one via `Supervisor::with_providers_and_journal` (durable saga journal). Tests
+and local setups use the `test_supervisor` convenience constructor, which
+wires an in-memory MLS storage backend and no-op persistence:
 
 ```rust,ignore
-use scp_platform::encrypting_adapter::EncryptingAdapter;
-use scp_platform::testing::InMemoryStorage;
-use zeroize::Zeroizing;
+use std::sync::Arc;
+use scp_runtime::context::test_supervisor;
+use scp_runtime::crypto::mls::provider::MlsCryptoProvider;
+use scp_protocol::context::{ContextParams, ContextState};
 
-let key = Zeroizing::new([0x42u8; 32]); // your encryption key
-let storage = EncryptingAdapter::new(InMemoryStorage::new(), key);
+// `test_supervisor` returns an `Arc<Supervisor>` with the given providers and
+// an in-memory MLS store (a dev/test opt-in — production supplies a real
+// `Storage`). `crypto` is a shared `Arc<MlsCryptoProvider>`; `transport` and
+// `event_log` are boxed provider trait objects; `key_resolver` maps a DID +
+// verification method to its Ed25519 verifying key (ADR-039).
+let supervisor = test_supervisor(
+    Arc::new(MlsCryptoProvider::new("did:dht:z6Mk...creator".to_owned())),
+    Box::new(my_transport_provider),
+    Box::new(my_event_log_provider),
+    my_key_resolver,
+);
 
-let manager = ContextManager::builder()
-    .crypto(Box::new(my_crypto_provider))
-    .storage(storage)   // auto-wires persistence + event log
-    .build()
-    .expect("crypto is the only required provider");
-```
-
-For production, replace `InMemoryStorage` with `SqliteStorage` or
-`AppleStorage`. The builder handles the rest.
-
-## Create a Context
-
-```rust,ignore
-let params = ContextParams::default(); // encrypted mode, 7-day TTL
-
-let handle = manager
-    .create_context("my-context-1".into(), params, "did:dht:z6Mk...creator".into())
+// Create a context. Returns a `ContextHandle` in `Active` state.
+let handle = supervisor
+    .create_context(
+        "my-context-1".into(),
+        ContextParams::default(),      // encrypted mode, default TTL
+        "did:dht:z6Mk...creator".into(),
+        None,                          // local pseudonym (§9.10.4)
+    )
     .await?;
 
-assert_eq!(handle.state(), ContextState::Active);
+assert_eq!(handle.try_read_state(), Some(ContextState::Active));
 ```
 
-## Send a Message
+## Send a message
+
+`send_message` takes a `MessageSigner` that binds the signing key to the
+persona stamped on the wire — `Active` for human-originated sends, `Agent`
+for agent-autonomous sends (ADR-039). The single enum prevents the key and
+the persona from ever diverging:
 
 ```rust,ignore
-manager
+use scp_runtime::context::supervisor::MessageSigner;
+
+supervisor
     .send_message(
         &handle,
         &"did:dht:z6Mk...sender".into(),
         b"hello world",
-        Some(&signing_key),
-        // ADR-039: sign under `#active` (human) or `#agent` (agent).
-        scp_did::SigningKeyId::Active,
-        None, // source provenance
-        None, // spending UCAN
+        MessageSigner::Active(&signing_key),  // or MessageSigner::Agent(&key)
+        None,   // source provenance (cross-context attribution)
+        None,   // spending UCAN (paid contexts)
     )
     .await?;
 ```
 
-## Read Event Log Entries
+## Production assembly and crash recovery
 
-The `ContextEventLogProvider` trait includes `event_log_entries()` for
-reading entries through a trait object — no need to downcast:
-
-```rust,ignore
-use scp_core::context::ContextEventLogProvider;
-
-// Works through Box<dyn ContextEventLogProvider>:
-let entries = event_log_provider
-    .event_log_entries(&context_id_bytes)?
-    .unwrap_or_default();
-
-for entry in &entries {
-    println!("{}: {}", entry.timestamp, entry.event);
-}
-```
-
-## Persist and Restore
-
-When `.storage()` or `.persistence()` is set, the manager persists context
-state after every mutation (best-effort). To restore after a process
-restart:
+Production bridges call `Supervisor::with_providers_and_journal`, passing a
+`DurableProviders` value. Its only non-test constructor derives **both** the
+durable saga journal and the MLS storage adapter from **one** `Storage`
+handle, so the "same backend for journal and state" invariant is enforced by
+the type system rather than by convention. After construction, restore
+persisted contexts and replay any crash-orphaned saga journal entries in one
+call:
 
 ```rust,ignore
-// Same storage backend as before (same database file / same in-memory state).
-let manager = ContextManager::builder()
-    .crypto(Box::new(my_crypto_provider))
-    .storage(storage)
-    .build()?;
-
-// Restore all previously persisted contexts, then replay any crash-orphaned
-// saga-journal entries (the public restore-then-replay startup entry point).
-manager.restore_on_startup().await?;
+// Restore every persisted context, THEN replay unresolved sagas. The ordering
+// (spec §17.16.4) is enforced by construction: `replay_unresolved_sagas`
+// requires a `RestoredContexts` witness that only `restore_all_contexts` can
+// mint, so replay-before-restore does not compile.
+let restored = supervisor.restore_on_startup().await?;
 ```
 
-## Manual Provider Assembly
-
-If you need full control (custom transport, custom event log), use the
-raw constructors instead of the builder:
-
-```rust,ignore
-use scp_core::context::ContextManager;
-use scp_core::context::governance::KeyResolver;
-
-let key_resolver: KeyResolver = Arc::new(|did, signing_key_id| {
-    // Map (DID, verification method) to the Ed25519 verifying key.
-    // `signing_key_id` selects `#active` (human) vs `#agent` (agent) per
-    // ADR-039 — resolve the key for the requested verification method.
-    None
-});
-
-// Without persistence:
-let manager = ContextManager::new(
-    Box::new(my_crypto),
-    Box::new(my_transport),
-    Box::new(my_event_log),
-    key_resolver,
-);
-
-// With persistence:
-let manager = ContextManager::with_persistence(
-    Box::new(my_crypto),
-    Box::new(my_transport),
-    Box::new(my_event_log),
-    Box::new(my_persistence),
-    key_resolver,
-);
-```
-
-## Type Hierarchy
+## Type hierarchy
 
 ```text
 Platform layer (scp-platform)
-  Storage trait              async key-value store
-  EncryptedStorage trait     sealed — use EncryptingAdapter<S> to wrap any Storage
+  Storage trait              async key-value store (RPITIT — NOT dyn-compatible)
+  EncryptedStorage trait     sealed — wrap any Storage via EncryptingAdapter<S>
 
-Runtime layer (scp-runtime)
-  ProtocolRepository<S>           typed domain wrapper over Storage (100+ async methods)
-  ProtocolRepositoryContextBridge<S>    sync bridge: ProtocolRepository → ContextPersistence trait
-  ProtocolRepositoryEventLogBridge<S>   sync bridge: ProtocolRepository → EventLogPersistence trait
+Runtime — the actor model (scp-runtime::context)
+  Supervisor                 plain-struct actor registry + saga coordinator;
+                             owns every provider; lock-free reads
+  SupervisorHandle           capability-reduced Supervisor view held by actors
+                             (no sibling-actor access; start_saga only)
+  ContextActor               one tokio task per context; run() select! loop
+  ClassSCell                 fail-closed-persist wrapper around PerContextState
+                             (no DerefMut — Class-S mutation only via combinators)
+  PerContextState            the owned per-context state payload
+  ActorDeps                  non-state deps moved into the actor task
+                             (crypto, transport, event log, mls/hpke backends,
+                              SupervisorHandle, clock, key_resolver, …)
 
-Provider layer (scp-runtime::context)
-  ContextCryptoProvider      MLS group + sender key operations
+Provider traits (injected, dyn-erased)
   ContextTransportProvider   relay connectivity + message sending
   ContextEventLogProvider    event log init/append/read/export/import
   ContextPersistence         context snapshot persist/load/delete
+  MlsBackend / HpkeBackend   async #[async_trait] MLS + HPKE primitive surfaces
+  OpenMlsStorageAdapter      dyn-compatible async KV under the OpenMLS bridge
 
-Convenience types
-  LocalTransportProvider     no-op transport (single-user / local-only apps)
-  MerkleEventLogProvider     production event log with optional persistence
-  ContextManagerBuilder      progressive assembly with sensible defaults
+Convenience
+  MlsCryptoProvider          production ContextCryptoProvider (OpenMLS + HPKE)
+  MerkleEventLogProvider     Merkle event log with optional persistence
+  test_supervisor            in-memory Supervisor for tests/local setups
 ```
+
+## Crate-internal maps
+
+- `CLAUDE.md` (this crate) — agent-facing map for modifying the runtime.
+- `src/context/README.md` — the `context/` module tree and command flow.
+- `src/crypto/mls/README.md` — the MLS subsystem.
 
 ## License
 

--- a/crates/scp-runtime/src/context/README.md
+++ b/crates/scp-runtime/src/context/README.md
@@ -1,0 +1,116 @@
+# `context/` — the actor runtime
+
+This module is the heart of `scp-runtime`: the actor-per-context concurrency
+model (ADR-049). One `tokio` task per live context owns its state by move; a
+`Supervisor` owns the registry of those tasks and every provider. If you are
+new here, read `.docs/adrs/ADR-049-actor-per-context.md` and this crate's
+`CLAUDE.md`, then use the map below.
+
+## How a command flows
+
+Every public runtime operation is a message to one context's actor:
+
+```
+Supervisor::send_message(&handle, …)          // src/context/supervisor/supervisor.rs
+  └─ lock-free lookup: actors.get(context_id) // DashMap — no mailbox hop to find the actor
+  └─ ContextActorHandle::send(command)         // actor/handle.rs — bounded mpsc, send-with-timeout
+        │  (command carries a oneshot::Sender for the reply)
+        ▼
+ContextActor::run() tokio::select!            // actor/mod.rs
+  └─ dispatch(command)  →  handlers::<domain>::dispatch(&mut PerContextState, &ActorDeps, sub)
+        │                                       // actor/handlers/*.rs
+        └─ handler body calls the domain logic in ../<domain>_helpers.rs
+        └─ mutates PerContextState through the ClassSCell combinators
+        └─ returns Outcome { result, mutated } ; reply is sent on the oneshot
+  └─ if mutated: mark dirty → coalesced snapshot on the persistence tick
+     (Class-S mutations persist fail-closed inline, before the reply)
+```
+
+The caller `await`s the oneshot reply, so `Supervisor::method(...).await`
+reads like an ordinary async call even though the work happened on the actor
+task. Cross-context work never crosses actor-to-actor directly — it goes
+through `SupervisorHandle::start_saga` (see the saga coordinator).
+
+## The submodule tree
+
+### `supervisor/` — registry + coordination
+
+- `supervisor.rs` — the `Supervisor` struct. Lock-free reads
+  (`DashMap`/`ArcSwap`) behind a single `write_lock` for mutations
+  (Decision 2/12). Owns the injected providers (`crypto`, `transport`,
+  `event_log`, persistence, clock, `key_resolver`, payment adapter, MLS
+  storage) in `OnceLock` slots populated by `with_providers` /
+  `with_providers_and_journal`. Hosts the public API surface
+  (`create_context`, `send_message`, `restore_on_startup`, …) and the
+  cross-context saga FSM.
+- `handle.rs` — `SupervisorHandle`, the capability-reduced view actors hold.
+  No accessor returns a sibling actor's handle (`start_saga` only).
+- `identity_capability.rs` — `OwnedIdentityDid`, the unforgeable per-identity
+  token (`pub(in crate::context)` to name, `pub(super)` to mint). The module
+  denies `unsafe_code` and `non_local_definitions`.
+- `saga_journal.rs` — the durable append-only saga journal trait +
+  `ProtocolRepositorySagaJournal` production impl.
+- `saga_prepared_state.rs` — the per-actor Prepare-phase staged mutation.
+- `key_package_actor.rs` — the per-identity `KeyPackageStoreActor` (its own
+  mailbox), separate from context actors.
+
+### `actor/` — the per-context task
+
+- `mod.rs` — `ContextActor` and its `run()` `select!` loop (inbox / TTL timer
+  / governance timeout / coalesced-persistence tick).
+- `commands.rs` — the `ContextCommand` outer enum and its 12 domain
+  sub-enums (Messaging, Lifecycle, Governance, Broadcast, Economy,
+  TrustRecovery, Standing, TtlClose, Tools, Queries, SagaPhase,
+  LifecycleControl). Each variant carries its reply channel.
+- `handle.rs` — `ContextActorHandle`, the caller-side bounded-mailbox wrapper
+  (send-with-timeout).
+- `class_s.rs` — `ClassSCell`, the fail-closed-persist wrapper around
+  `PerContextState` (Class-S vs Class-C; see `CLAUDE.md`).
+- `state.rs` — `PerContextState`, the owned per-context payload (identity,
+  membership, roles/ceiling, event log, mode-specific state, governance,
+  crypto state, …).
+- `deps.rs` — `ActorDeps`, the non-state resources moved into the task
+  (providers, backends, `SupervisorHandle`, clock, key_resolver, …).
+- `sequence.rs` — `SequenceReservation`, the RAII send-sequence guard (rolls
+  back on drop, durable on `commit()`).
+- `outcome.rs` — `Outcome<T> { result, mutated }`, the handler return type
+  that tells the actor when to mark state dirty.
+- `handlers/` — one module per command domain (`governance.rs`,
+  `lifecycle.rs`, `messaging.rs`, `broadcast.rs`, `economy.rs`,
+  `trust_recovery.rs`, `standing.rs`, `ttl_close.rs`, `tools.rs`,
+  `queries.rs`, `saga.rs`, `lifecycle_control.rs`). Each exposes a `dispatch`
+  taking `(&mut PerContextState, &ActorDeps, SubCommand) -> Outcome`.
+
+### `*_helpers.rs` — domain logic bodies
+
+The substance of each domain lives beside the actor, in large helper modules
+that the handlers call: `governance_helpers.rs`, `lifecycle_helpers.rs`,
+`messaging_helpers.rs`, `trust_recovery_helpers.rs`, `broadcast_helpers.rs`,
+`economy_helpers.rs` / `economy_logic.rs`, `queries_helpers.rs`,
+`tools_helpers.rs`, `standing_helpers.rs`, `ttl.rs` / `ttl_close_helpers.rs`.
+Keeping the bodies here keeps the handler modules thin dispatch shells. The
+MLS commit-broadcast retry queue (§9 fail-closed, see
+`src/crypto/mls/README.md`) lives in `governance_helpers.rs` +
+`state.rs`.
+
+### Supporting modules
+
+- `config.rs` — `ContextConfig` / `ContextCreation`, the flat options object
+  behind `Supervisor::create` (ADR-052 construction standard).
+- `builder.rs` — the provider trait definitions (`ContextTransportProvider`,
+  `ContextEventLogProvider`, and the local/no-op provider impls).
+- `providers/` — production provider impls (`MerkleEventLogProvider`,
+  the `ProtocolRepository` persistence bridges).
+- `export_import.rs`, `persistence.rs`, `key_destruction.rs`, `policy.rs`,
+  `app_sandbox.rs`, `governance/`, `tools/` — feature-specific surfaces.
+- `mod.rs` — `ContextHandle` (the thread-safe lifecycle handle callers hold)
+  and the `test_supervisor` convenience constructor.
+
+## Transitional shim
+
+During the ADR-049 handler migration, some domains still route through a
+`&Supervisor` "shim" dispatch (`dispatch_from_shim`) rather than the final
+`(&mut PerContextState, &ActorDeps)` signature. Both paths run inside the same
+actor task and mailbox; the shim is an internal migration artifact, not a
+second concurrency model. New handler work should target the owned-state
+signature.

--- a/crates/scp-runtime/src/crypto/mls/README.md
+++ b/crates/scp-runtime/src/crypto/mls/README.md
@@ -1,0 +1,112 @@
+# `crypto/mls/` — the MLS subsystem
+
+Every SCP context maps to exactly one MLS (Messaging Layer Security, RFC 9420)
+group. This module wraps `OpenMLS` and layers SCP's own concerns on top:
+DID-bearing credentials, per-author sender keys, HPKE wrapping-key
+distribution, epoch grace windows, and fail-closed commit broadcast. The
+single ciphersuite is `MLS_128_DHKEMX25519_AES128GCM_SHA256_Ed25519` — no
+negotiation (ADR-001).
+
+## The injected-backend shape (ADR-049 §6)
+
+The provider is split so the actor runtime can share stateless primitives and
+inject test doubles:
+
+- **`MlsCryptoProvider`** (`provider.rs`) — the concrete
+  `ContextCryptoProvider`. It owns the per-context crypto state (lock-free
+  `DashMap`s + `ArcSwap` wrapping keys per Decision 12) and orchestrates group
+  operations, but delegates every raw MLS/HPKE primitive to two injected
+  trait objects:
+  - `mls_backend: Arc<dyn MlsBackend>` (`backend.rs`)
+  - `hpke_backend: Arc<dyn HpkeBackend>` (`../hpke_backend.rs`)
+  Build the production provider with `MlsCryptoProvider::new(local_did)`
+  (wires `ProductionMlsBackend` + `ProductionHpkeBackend`); tests inject
+  failure-driven mocks via `MlsCryptoProvider::with_backends`.
+- **`ProductionMlsBackend`** (`production_backend.rs`) — a stateless struct
+  that delegates each primitive to the `group` / `encrypt` / `ratchet` free
+  functions. It is byte-identical to the pre-refactor inline `OpenMLS` calls
+  by design (the migration must not perturb wire bytes).
+- **`MlsBackend` / `HpkeBackend`** are `#[async_trait]`, `Send + Sync`, and
+  dyn-compatible so one `Arc<dyn …>` is shared across every context actor.
+  This is a hard requirement: actor futures are `tokio::spawn`'d, so the
+  primitives they await must produce `Send` futures. See this crate's
+  `CLAUDE.md` for the full Send-discipline.
+
+## Storage: `OpenMlsStorageAdapter` (`storage_adapter.rs`)
+
+`OpenMLS`'s own `StorageProvider` is a **sync** trait. The platform `Storage`
+trait, meanwhile, uses return-position `impl Trait` and is **not**
+dyn-compatible (`Arc<dyn Storage>` will not compile). `OpenMlsStorageAdapter`
+resolves both problems:
+
+- It is an `#[async_trait]` keyed blob store (`store` / `retrieve` / `delete`)
+  that **is** dyn-compatible, so `Arc<dyn OpenMlsStorageAdapter>` clones into
+  every actor's `ActorDeps`.
+- `SpawnBlockingStorageAdapter<S>` is the production impl over any concrete
+  `S: Storage`. It is erased once per process to the trait object. The name
+  signals its role in the sync→async seam: the sync `StorageProvider` bridge
+  (`storage.rs`) wraps each adapter call so sync-heavy backends (e.g.
+  `rusqlite`) do not pin async worker threads — replacing the old
+  `block_in_place` pattern that made `current_thread` runtimes panic.
+
+`storage.rs` is the OpenMLS `StorageProvider` bridge itself (an allow-listed
+sync-bridge site in the `block_in_place` ratchet).
+
+## The crypto model at a glance
+
+- **`group.rs`** — group lifecycle: `create_group`, `add_member`,
+  `remove_member`, `destroy_group`, key-package generation. Every op advances
+  the MLS epoch and emits Commit / Welcome / `GroupInfo` bytes.
+- **`credential.rs`** — `ScpCredential`, the DID + UCAN payload carried in the
+  MLS `LeafNode`.
+- **`encrypt.rs`** — application message seal/open. Membership-tag
+  verification, generation-number replay tracking, and forward secrecy are
+  enforced by `OpenMLS` internally.
+- **`ratchet.rs`** — epoch advancement (Commit processing) and MLS `Update`
+  proposals for post-compromise security.
+- **`epoch_grace.rs`** — `EpochGraceStore`. When a Commit advances the epoch,
+  old-epoch key material is retained briefly so in-flight messages under the
+  prior epoch still decrypt.
+- **Sender keys** (`sender_keys/`, sibling module) — per-author AES-256-GCM
+  keys distributed via HPKE using the X25519 **wrapping key** each member
+  publishes in its `LeafNode` `scp_wrapping_key` extension
+  (`wrapping_extension.rs`, §9.16.1). The provider holds each identity's
+  wrapping keypair in `ArcSwap` so rotation is atomic and old secret material
+  is zeroized on last-`Arc` drop.
+
+## §9 fail-closed commit broadcast
+
+An MLS Commit (member removal, content-key rotation, member reset, leave)
+mutates **local** group state before it can be broadcast to the group. If the
+transport send fails after the local mutation, the epoch has already advanced
+locally — silently dropping the broadcast would fork the group. SCP handles
+this with a persistent retry queue that fail-closes rather than diverges. The
+queue orchestration lives in the context layer (it needs `ActorDeps` transport
++ persistence), not in `crypto/mls/` — the MLS backend only produces the
+Commit bytes:
+
+- **`try_broadcast_commit_or_enqueue`** (`context/governance_helpers.rs`) —
+  attempts the broadcast; on failure enqueues a `PendingCommit`
+  (`context/state.rs`) carrying the serialized Commit bytes, routing ID, the
+  logical `CommitOperation`, and retry bookkeeping. Retries use exponential
+  backoff (`COMMIT_RETRY_BACKOFFS`), bounded by `MAX_COMMIT_RETRIES` (20),
+  `MAX_COMMIT_AGE_SECS` (1 h), and `MAX_PENDING_COMMITS` (50). The queue is
+  persisted so retries survive process restart.
+- On budget exhaustion the context **fail-closes**: a `CommitFaultMarker` is
+  set. While it is set, `check_commit_fault` makes all governance and
+  lifecycle mutations return `ContextError::CommitBroadcastFault`.
+- **`acknowledge_commit_fault`** (`context/governance_helpers.rs`) is the
+  operator escape hatch that clears the marker after intervention.
+
+The `CommitBroadcastPending` / `Succeeded` / `Failed` events are surfaced as
+local `ContextEvent`s only — per the ADR-011-amendment exclusion taxonomy they
+are per-committer bookkeeping and are **not** appended to the convergent
+Merkle event log (§9.9.3).
+
+## Where this sits
+
+`MlsCryptoProvider` is injected into the `Supervisor` at construction and
+cloned into each `ContextActor`'s `ActorDeps` (`Arc<MlsCryptoProvider>`), so
+handler bodies call `seal` / `open` / `advance_epoch` without reaching back
+through the supervisor. See `../../context/README.md` for the actor model and
+this crate's `CLAUDE.md` for the injection + Send-discipline rules.

--- a/crates/scp-runtime/src/crypto/mls/README.md
+++ b/crates/scp-runtime/src/crypto/mls/README.md
@@ -101,7 +101,13 @@ Commit bytes:
     process restart.
   - **`keep_broadcast_failure`** — async; runs `apply_broadcast_failure` inside
     a second `commit_class_s_keep` so the failure bookkeeping fail-closes
-    (persists before ack) rather than being lost on a coalesced tick.
+    (persists before ack) rather than being lost on a coalesced tick. Only the
+    four safety-gated / forward-secrecy sites — `execute_remove_member`,
+    `execute_rotate_content_keys`, `leave_context`, `recovery_advance_epoch` —
+    fail-close this way; the two best-effort sites (`execute_add_member`,
+    `execute_reset_member`) apply the *same* failure value **coalesced** via
+    `class_c_view()` / `ClassCMut` (Class-C), not fail-closed — see the context
+    layer + `crates/scp-runtime/CLAUDE.md` for the authoritative site list.
 - On budget exhaustion the context **fail-closes**: a `CommitFaultMarker` is
   set. While it is set, `check_commit_fault` makes all governance and
   lifecycle mutations return `ContextError::CommitBroadcastFault`.

--- a/crates/scp-runtime/src/crypto/mls/README.md
+++ b/crates/scp-runtime/src/crypto/mls/README.md
@@ -19,8 +19,9 @@ inject test doubles:
   trait objects:
   - `mls_backend: Arc<dyn MlsBackend>` (`backend.rs`)
   - `hpke_backend: Arc<dyn HpkeBackend>` (`../hpke_backend.rs`)
-  Build the production provider with `MlsCryptoProvider::new(local_did)`
-  (wires `ProductionMlsBackend` + `ProductionHpkeBackend`); tests inject
+  Build the production provider with `MlsCryptoProvider::new(local_did, clock)`
+  — `clock` is an `Arc<dyn scp_clock::Clock>` (e.g. `Arc::new(SystemClock)`) —
+  which wires `ProductionMlsBackend` + `ProductionHpkeBackend`; tests inject
   failure-driven mocks via `MlsCryptoProvider::with_backends`.
 - **`ProductionMlsBackend`** (`production_backend.rs`) — a stateless struct
   that delegates each primitive to the `group` / `encrypt` / `ratchet` free
@@ -85,13 +86,22 @@ queue orchestration lives in the context layer (it needs `ActorDeps` transport
 + persistence), not in `crypto/mls/` — the MLS backend only produces the
 Commit bytes:
 
-- **`try_broadcast_commit_or_enqueue`** (`context/governance_helpers.rs`) —
-  attempts the broadcast; on failure enqueues a `PendingCommit`
-  (`context/state.rs`) carrying the serialized Commit bytes, routing ID, the
-  logical `CommitOperation`, and retry bookkeeping. Retries use exponential
-  backoff (`COMMIT_RETRY_BACKOFFS`), bounded by `MAX_COMMIT_RETRIES` (20),
-  `MAX_COMMIT_AGE_SECS` (1 h), and `MAX_PENDING_COMMITS` (50). The queue is
-  persisted so retries survive process restart.
+- The broadcast is a three-function split (`context/governance_helpers.rs`) so
+  the async transport send stays out of the fail-closed Class-S persist closure:
+  - **`try_broadcast_commit`** — async, send-only; it touches no
+    `PerContextState` and returns `Option<BroadcastFailure>` (`None` on success,
+    `Some(..)` carrying the retry payload on transport failure).
+  - **`apply_broadcast_failure`** — synchronous; applies that payload by
+    enqueuing a `PendingCommit` (`context/state.rs`) carrying the serialized
+    Commit bytes, routing ID, the logical `CommitOperation`, and retry
+    bookkeeping, or setting the `commit_fault` marker when the queue is full.
+    Retries use exponential backoff (`COMMIT_RETRY_BACKOFFS`), bounded by
+    `MAX_COMMIT_RETRIES` (20), `MAX_COMMIT_AGE_SECS` (1 h), and
+    `MAX_PENDING_COMMITS` (50). The queue is persisted so retries survive
+    process restart.
+  - **`keep_broadcast_failure`** — async; runs `apply_broadcast_failure` inside
+    a second `commit_class_s_keep` so the failure bookkeeping fail-closes
+    (persists before ack) rather than being lost on a coalesced tick.
 - On budget exhaustion the context **fail-closes**: a `CommitFaultMarker` is
   set. While it is set, `check_commit_fault` makes all governance and
   lifecycle mutations return `ContextError::CommitBroadcastFault`.


### PR DESCRIPTION
## Summary

ADR-049 **Phase 4** — the runtime crate's architecture documentation, rewritten to the actor-per-context model now that the refactor's code is fully landed.

## Deliverables
- **`crates/scp-runtime/README.md` — major rewrite.** The prior README's Quick Start / Type Hierarchy were built on the **deleted `ContextManager`** and its non-existent constructors. Rebuilt on the real API: `Supervisor` / `test_supervisor` / `with_providers`, `create_context`, `send_message(… MessageSigner::Active …)`, `MlsCryptoProvider::new(local_did, clock)`, `handle.state()`, lock-free reads, async provider traits.
- **`crates/scp-runtime/CLAUDE.md` — new, agent-facing map.** Actor model + mailbox dispatch, Class-S (fail-closed) vs Class-C (coalesced) persist, Send-discipline (`RecoveryBackend` is the sole `#[async_trait(?Send)]` provider trait; all others plain Send), capability reduction, the `block_in_place` ratchet + gates.
- **`crates/scp-runtime/src/context/README.md`** — the `context/` module tree + command flow (`SupervisorHandle` → mailbox → handler → `&mut PerContextState` → persist).
- **`crates/scp-runtime/src/crypto/mls/README.md`** — the MLS subsystem: `MlsCryptoProvider` + injected backends, `SpawnBlockingStorageAdapter`, and the §9 fail-closed commit-broadcast retry (noting only the safety-gated sites fail-close; add/reset coalesce).

## Review

Written → **independent grep-accuracy audit** (found 6 citation errors, all from a pre-PR-3 mental model — deleted `try_broadcast_commit_or_enqueue`, `RecoveryBackend` "synchronous", missing `clock` arg, fabricated `try_read_state`) → **corrected + grep-verified** (all stale markers 0; clock arg matches the authoritative test pattern verbatim) → **chronicler** (SHIP: consistent with the lessons set, all cross-links resolve, `cargo doc` introduces no new broken links). The bulk of the doc set audited **OK** on first pass; the errors were confined to the async/broadcast/recovery claims.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
