### PR TITLE
docs(ffi): Phase 4 wave 2 — FFI + platform READMEs to per-instance SCP/Supervisor model

### DIFF
--- a/crates/scp-ffi/README.md
+++ b/crates/scp-ffi/README.md
@@ -9,36 +9,62 @@ with this one.
 
 ## Architecture
 
-**ContextManager** (shared `Arc<ContextManager>` in `OnceLock`): Owns context
-lifecycle -- membership, roles, governance, broadcast, TTL. All `py_context_*`
-functions delegate here.
+**`SCP` class** (`scp.rs`): the Python SDK's sole user-facing entry point -- a
+`#[pyclass(name = "SCP", frozen)]` wrapper over a caller-owned
+`PyBridgeInstance`. Storage selection is **mandatory and fail-closed** (spec
+§17.6): the constructor requires a storage-config dict (`SCP({...})`, also
+spelled `SCP.with_storage({...})`) -- there is no zero-argument constructor and
+no default backend. Each call mints a fresh instance whose handles are
+affinity-stamped; there is no process-global bridge (the
+`DEFAULT_BRIDGE_INSTANCE` static was deleted in ADR-048 Phase D). See
+[ADR-049](../../.docs/adrs/ADR-049-actor-per-context.md) for the per-instance
+actor model and [construction.md](../../.docs/standards/construction.md)
+(ADR-052) for the mandatory-config API rule.
 
-**FfiBridgeState** (per-context, `DashMap`): FFI-only state that does not
-duplicate the ContextManager -- tool registry, event log, UCAN revocation list,
-nonce tracker, capability ceiling, tool handlers, message channels.
+**Supervisor** (shared `Arc<Supervisor>` on the per-bridge instance): owns
+context lifecycle -- membership, roles, governance, broadcast, TTL. It lives in
+the `CoreFields.supervisor` slot of `PyBridgeInstance` (not a process-global
+`OnceLock`), is built by `build_supervisor` in `runtime.rs` via
+`Supervisor::with_providers_and_journal(...)` (durable saga journal plus
+production MLS / transport / event-log providers), and is reached through
+`runtime::supervisor()`. All `py_context_*` functions delegate here. This
+replaced the previously-shared `Arc<ContextManager>`, now deleted (ADR-049
+actor-per-context).
 
-**Identity registry** (global `DashMap`): Maps DID strings to `ScpIdentity` +
-`InMemoryKeyCustody` + `DidDocument`. Private keys never cross FFI.
+**FfiBridgeState** (per-context, `OnceLock<DashMap<String, _>>`): FFI-only state
+that does not duplicate Supervisor state -- tool registry, event log, UCAN
+revocation list, nonce tracker, capability ceiling, tool handlers, message
+channels.
 
-A single multi-threaded tokio runtime (`OnceLock<Runtime>`) is created at
-module import. Sync bridge functions release the GIL via
+**Identity registry** (per-instance `Arc<DashMap<..>>` on `PyBridgeInstance`,
+**not** a process global): maps DID strings to `ScpIdentity` +
+`InMemoryKeyCustody` + `DidDocument`, reached via
+`runtime::identity_registry(bi)`. Private keys never cross FFI (ADR-006).
+
+A single multi-threaded tokio runtime (`RUNTIME`, an `OnceLock<Runtime>` in
+`lib.rs`) is created at module import. Sync bridge functions release the GIL via
 `py.allow_threads(|| rt.block_on(...))`.
 
 ## Modules
 
 | Module | Domain |
 |--------|--------|
+| `scp.rs` | The `SCP` `#[pyclass]` -- sole SDK entry point; mandatory storage-config constructor |
 | `bridge_adapters.rs` | Shared bridge adapter types for the UCAN validation pipeline |
 | `bridge_connector.rs` | Bridge connector operations (register, trust evaluation, shadow identities) |
 | `context.rs` | Context create, join, leave, close, send, receive |
 | `custody.rs` | `FfiKeyCustody` enum dispatch for `KeyCustody` trait (in-memory + file) |
 | `discovery.rs` | Context discovery (local + relay probe) |
+| `economy.rs` | Economic governance operations (exposed as `SCP` methods) |
 | `error.rs` | `ScpPyError` to Python exception mapping |
 | `event_log.rs` | Merkle event log query and verify |
 | `identity.rs` | DID create, load, resolve, rotate, migrate |
 | `mcp.rs` | MCP server/client (stdio + SSE), tool handlers |
+| `media.rs` | Media session lifecycle and signaling |
 | `provenance.rs` | Provenance attach and chain verification |
-| `runtime.rs` | Global registries (context, identity, relay, storage) |
+| `runtime.rs` | Per-instance state on `PyBridgeInstance` (supervisor slot, FFI bridge state, identity registry, transport, storage) |
+| `scpid.rs` | SCPID stateless DID authentication -- challenge, sign, verify (§3.11) |
+| `server.rs` | Relay / application-node server startup (wraps `scp-ffi-common::server`) |
 | `sync.rs` | Offline sync classification |
 | `tools.rs` | Tool register, invoke, verify |
 | `transport.rs` | Relay connect, disconnect, status |

--- a/crates/scp-ffi/napi/README.md
+++ b/crates/scp-ffi/napi/README.md
@@ -6,14 +6,24 @@ TypeScript package as its native backend.
 
 ## Architecture
 
-**Shared ContextManager**: A single `Arc<ContextManager>` (`OnceLock` in
-`runtime.rs`) owns all context lifecycle state -- membership, roles, governance,
-broadcast, TTL. Bridge functions delegate via `crate::runtime::context_manager()`.
+**`SCP` class + shared Supervisor**: The `#[napi(js_name = "SCP")] Scp` class
+(in `scp.rs`) is the caller-owned handle exposed to TypeScript; its
+`SCP.withStorage(configJson)` factory is fail-closed (spec §17.6) -- there is no
+zero-argument constructor. It owns a `NapiBridgeInstance` that holds a shared
+`Arc<Supervisor>` in its `BridgeInstanceCore.supervisor` slot; the Supervisor
+owns all context lifecycle state -- membership, roles, governance, broadcast,
+TTL. It is built by `build_supervisor_arc` in `runtime.rs` via
+`Supervisor::with_providers_and_journal(...)` (durable saga journal) and reached
+through `runtime::supervisor()`. This replaced the previously-shared
+`Arc<ContextManager>`, now deleted (see
+[ADR-049](../../../.docs/adrs/ADR-049-actor-per-context.md)). See
+[construction.md](../../../.docs/standards/construction.md) (ADR-052) for the
+mandatory-config API rule.
 
 **UCAN state registry**: A separate `DashMap<String, UcanContextState>` stores
 per-context UCAN validation state (revocation lists, nonce trackers, capability
-ceilings, event logs). This is not duplicated from the ContextManager -- the
-manager does not track UCAN revocation or nonces.
+ceilings, event logs). This is not duplicated from the Supervisor -- the
+Supervisor does not track UCAN revocation or nonces.
 
 **Tokio runtime**: Multi-threaded, created lazily via `OnceLock::get_or_init`.
 napi-rs `#[napi]` async functions run on this runtime and resolve JS Promises
@@ -28,15 +38,21 @@ released or the deadline elapses.
 
 | Module | Domain |
 |--------|--------|
+| `scp.rs` | The `SCP` `#[napi]` class -- caller-owned handle; `SCP.withStorage(config)` factory |
 | `bridge_connector.rs` | Bridge connector operations (register, trust evaluation, shadow identities) |
 | `context.rs` | Context lifecycle, membership, governance, broadcast, TTL, export/import |
+| `custody.rs` | `KeyCustody` enum dispatch for the napi bridge |
 | `discovery.rs` | Context discovery |
+| `economy.rs` | Economic governance operations |
 | `error.rs` | `ScpNapiError` to napi Error mapping |
 | `event_log.rs` | Merkle event log query and verify |
 | `identity.rs` | DID create (with optional agent key), load, resolve, migrate |
 | `mcp.rs` | MCP server/client bridge |
+| `media.rs` | Media session lifecycle and signaling |
 | `provenance.rs` | Provenance operations |
-| `runtime.rs` | ContextManager init, UCAN state registry |
+| `runtime.rs` | Per-instance `NapiBridgeInstance` state: supervisor slot + `build_supervisor_arc`, UCAN state registry |
+| `scpid.rs` | SCPID stateless DID authentication (§3.11) |
+| `server.rs` | Relay / application-node server startup (wraps `scp-ffi-common::server`) |
 | `sync.rs` | Offline sync classification |
 | `tools.rs` | Tool register, invoke, verify |
 | `transport.rs` | Relay connect, disconnect, status |

--- a/crates/scp-ffi/napi/src/scp.rs
+++ b/crates/scp-ffi/napi/src/scp.rs
@@ -1,7 +1,7 @@
 //! `#[napi] Scp` class — the caller-owned SCP instance exposed to TypeScript.
 //!
 //! `SCP` (exposed to TS as `SCP`) is the top-level SDK-facing handle that
-//! owns a `NapiBridgeInstance` — which in turn owns the `ContextManager`,
+//! owns a `NapiBridgeInstance` — which in turn owns the `Supervisor`,
 //! transport, and bridge-specific registries.
 //!
 //! Phase 4 PR 4 (#1549, ADR-048) completed the migration: the

--- a/crates/scp-ffi/uniffi/README.md
+++ b/crates/scp-ffi/uniffi/README.md
@@ -6,14 +6,26 @@ proc-macros (`#[uniffi::export]`). Consumed by the Swift SDK
 
 ## Architecture
 
-**Shared ContextManager**: Same pattern as PyO3 and NAPI -- a single
-`Arc<ContextManager>` in `OnceLock` owns all context lifecycle, membership,
-governance, broadcast, and TTL state. Bridge functions access it via
-`crate::runtime::context_manager()`.
+**`Scp` object + shared Supervisor**: Same per-instance pattern as PyO3 and
+NAPI. The `#[derive(uniffi::Object)] Scp` (in `scp.rs`) is the caller-owned
+handle exposed to Swift/Kotlin; its sole `#[uniffi::constructor] with_storage`
+takes a typed `StorageConfig` and is fail-closed (spec §17.6) -- there is no
+zero-argument constructor. `Scp` wraps a `UniffiBridgeInstance` that holds a
+shared `Arc<Supervisor>` in its `BridgeInstanceCore.supervisor` slot; the
+Supervisor owns all context lifecycle, membership, governance, broadcast, and
+TTL state. It is built by `build_supervisor` in `runtime.rs` via
+`Supervisor::with_providers_and_journal(...)` (durable saga journal) and reached
+through `self.core.try_supervisor()` / `has_supervisor()`. This replaced the
+previously-shared `Arc<ContextManager>`, now deleted (see
+[ADR-049](../../../.docs/adrs/ADR-049-actor-per-context.md)); there is no
+`context_manager()` accessor. See
+[construction.md](../../../.docs/standards/construction.md) (ADR-052) for the
+mandatory-config API rule.
 
-**Single bridge module**: All exports live in `bridge.rs` -- function groups
-for identity, context lifecycle, membership queries, governance, broadcast,
-TTL, tools, UCAN, event log, transport, discovery, provenance, trust, and sync.
+**Single bridge module**: All `#[uniffi::export]` free functions live in
+`bridge.rs` -- function groups for identity, context lifecycle, membership
+queries, governance, broadcast, TTL, tools, UCAN, event log, transport,
+discovery, provenance, trust, and sync.
 
 **Callback interfaces**: Platform-specific operations are injected from
 Swift/Kotlin via `#[uniffi::export(callback_interface)]` traits:
@@ -40,8 +52,10 @@ counter. `scp_shutdown(timeout_secs)` blocks until all handles are released.
 
 | File | Contents |
 |------|----------|
-| `bridge.rs` | All `#[uniffi::export]` functions and types |
-| `runtime.rs` | ContextManager initialization, UCAN state |
+| `scp.rs` | The `Scp` UniFFI object -- caller-owned handle; sole fail-closed `with_storage(StorageConfig)` constructor |
+| `bridge.rs` | All `#[uniffi::export]` free functions and types |
+| `runtime.rs` | `UniffiBridgeInstance`: supervisor slot + `build_supervisor`, storage selection, UCAN state |
+| `server.rs` | Relay / application-node server startup (wraps `scp-ffi-common::server`) |
 | `lib.rs` | Tokio runtime, handle counting, callback interface traits, UDL scaffolding |
 
 ## Build

--- a/crates/scp-platform/README.md
+++ b/crates/scp-platform/README.md
@@ -1,8 +1,47 @@
 # scp-platform
 
-Platform abstraction traits for [SCP](https://github.com/limn/scp) (Shared Context Protocol).
+Platform abstraction traits for [SCP](https://github.com/limn-works/scp) (Shared Context Protocol).
 
-Defines portable interfaces for key custody, storage, and device attestation. Includes optional concrete implementations behind feature flags (`software_platform`, `sqlite`, `file`, `encrypting`).
+This crate defines the portable interfaces that let the protocol core stay
+platform-agnostic: the runtime programs against these traits, and each host
+(Apple, Android, desktop, in-memory test) supplies a concrete implementation.
+Private key material lives behind `KeyCustody` and never leaves the platform
+boundary (ADR-006).
+
+## Traits (`traits.rs`, `encrypted.rs`)
+
+- **`KeyCustody`** — signing, Diffie-Hellman, and pseudonym derivation over
+  opaque key handles. Keys are created, used, and destroyed without their bytes
+  crossing the trait boundary.
+- **`PreRotationCustody`** — pre-generates and commits to the next signing key
+  for hash-committed key rotation.
+- **`DeviceAttestation`** — platform attestation (Apple App Attest, Android Play
+  Integrity) binding an identity to a genuine device.
+- **`Push`** — platform push delivery (`APNs` / FCM).
+- **`Storage`** — persistent key-value storage. `EncryptedStorage` is a sealed
+  marker sub-trait for backends that encrypt at rest.
+
+## Feature flags
+
+Concrete implementations are optional and gated so that a consumer pulls in only
+the platform code and dependencies it needs:
+
+| Feature | Provides |
+|---------|----------|
+| `software_platform` | In-process `Ed25519` / `X25519` crypto primitives (no HSM) |
+| `testing` | In-memory custody / attestation adapters for tests (implies `software_platform`, ADR-006) |
+| `sqlite` | `SQLCipher`-encrypted `Storage` with raw-key or `Argon2id`-passphrase key material (spec §17.6) |
+| `apple` | Apple `SQLCipher` storage adapter (key supplied from the Keychain) |
+| `file` | Encrypted file-backed key custody (`Argon2id` + `AES-256-GCM`) |
+| `filesystem` | Plain filesystem `Storage` adapter (spec §17.6) |
+| `encrypting` | `EncryptingAdapter` wrapping any `Storage` with `AES-256-GCM` per-value encryption |
+| `sync` | `SyncableStorage` wrapper adding a write-ahead changelog for P2P state sync |
+
+## Usage
+
+Most consumers depend on `scp-core` (which wires a platform implementation
+through the runtime). Depend on `scp-platform` directly only to implement a new
+host adapter or to select a specific storage / custody backend by feature.
 
 ## License
 


### PR DESCRIPTION
## Summary

ADR-049 **Phase 4 (wave 2)** — the FFI + platform crate READMEs, rewritten to the post-refactor per-instance `SCP` / `Supervisor` model (the prior READMEs still described the deleted `ContextManager` + global singletons).

## Changes
- **`crates/scp-ffi/README.md`** (PyO3), **`uniffi/README.md`**, **`napi/README.md`** — replace "shared `Arc<ContextManager>` in `OnceLock`" / `context_manager()` with the real model: a shared `Arc<Supervisor>` on the per-bridge instance (`PyBridgeInstance` / `UniffiBridgeInstance` / `NapiBridgeInstance`, `CoreFields.supervisor`), built by the bridge-local `build_supervisor*` → `Supervisor::with_providers_and_journal`, reached via `runtime::supervisor()` / `core.try_supervisor()`. Global registries → per-instance fields (e.g. PyO3's per-instance `identity_registry: Arc<DashMap>`). Add the `SCP` class as the headline entry point (mandatory fail-closed storage-config constructor; no zero-arg ctor) and the module rows that now exist (`scp.rs`, `scpid.rs`, `economy.rs`, `media.rs`, `server.rs`, …). Also fix a stale code doc-comment (`napi/src/scp.rs`: "owns the `ContextManager`" → `Supervisor`).
- **`crates/scp-platform/README.md`** — fix the broken repo link (`limn/scp` → `limn-works/scp`) and expand the stub to describe the real portable interfaces (`KeyCustody`, `PreRotationCustody`, `DeviceAttestation`, `Push`, `Storage`, sealed `EncryptedStorage`) + the 8 feature flags.
- `scp-protocol/README.md` untouched (already accurate). No `wasm/README.md`: the old `scp-ffi/wasm` bridge no longer exists on `main` (replaced by `scp-client-wasm`/`scp-client`, ADR-057) — nothing to edit, nothing fabricated.

## Review

Written from a **grep-verified ground-truth fact sheet** (anti-confabulation process); the writer additionally corrected two fact-sheet errors by reading the actual tree (the removed wasm bridge; the per-instance identity registry). Independently grep-audited: all cited symbols/traits/feature-flags verified against source, no stale claim presents `ContextManager` as current (residual mentions are explicit "now deleted" migration notes), scope confirmed (no `scp-runtime/*` or `scp-protocol/README` touched). Pre-commit fmt + clippy (incl. `doc_markdown` on the include_str'd scp-platform README) + protocol enforcement passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
