### PR TITLE
test(runtime): add the three ADR-049-mandated test targets (perf_baseline, cancel_safety, persistence_ordering)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,3 +45,8 @@ bindings/kotlin/scp-kt/src/main/kotlin/works/limn/scp/internal/
 bindings/python/tests/bridge_parity/helpers/kotlin_bridge_runner/.gradle/
 bindings/python/tests/bridge_parity/helpers/kotlin_bridge_runner/build/
 bindings/python/tests/bridge_parity/helpers/swift_bridge_runner/.build/
+
+# ADR-049 Decision 14 perf_baseline harness — per-environment runtime artifact
+# recorded by the default `--test perf_baseline` run; never committed (one box's
+# numbers must not become a cross-machine gate reference).
+crates/scp-runtime/tests/perf_baseline.json

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5610,6 +5610,7 @@ dependencies = [
  "scp-mls",
  "scp-platform",
  "scp-protocol",
+ "scp-testing",
  "serde",
  "serde_bytes",
  "serde_json",

--- a/crates/scp-runtime/Cargo.toml
+++ b/crates/scp-runtime/Cargo.toml
@@ -90,9 +90,29 @@ proptest = "1"
 scp-media = { path = "../scp-media" }
 static_assertions = { workspace = true }
 metrics-util = "0.19"
+# ADR-049 Decision 14 `perf_baseline` harness only. `scp-testing` re-exports the
+# `FullStackNetwork`/`FullStackNode` two-node MLS harness needed to drive the six
+# measured operations (notably `deliver_incoming`, which requires a genuine
+# second-member decryptable envelope). This is a DEV-only back-edge: dev-deps are
+# never part of the normal build graph, so it does NOT feed the
+# `scp-ffi → dep:scp-testing → scp-core{testing} → scp-runtime/testing` production
+# chain the feature-isolation comment above guards against.
+scp-testing = { path = "../scp-testing" }
 
 [[test]]
 name = "economy_integration"
+required-features = ["testing"]
+
+[[test]]
+name = "perf_baseline"
+required-features = ["testing"]
+
+[[test]]
+name = "cancel_safety"
+required-features = ["testing"]
+
+[[test]]
+name = "persistence_ordering"
 required-features = ["testing"]
 
 [[test]]

--- a/crates/scp-runtime/tests/cancel_safety.rs
+++ b/crates/scp-runtime/tests/cancel_safety.rs
@@ -1,0 +1,324 @@
+//! ADR-049 cancel-safety verification (`cargo test -p scp-runtime --test
+//! cancel_safety`, named by the ADR §Verification block).
+//!
+//! # What "cancel-safety" means here
+//!
+//! A future dropped (cancelled) mid-flight — because a `tokio::select!`
+//! branch lost the race or a `tokio::time::timeout` elapsed — MUST NOT leave
+//! partial/committed state or leak a reservation. This suite drives that
+//! property through TWO different surfaces under real tokio cancellation (a
+//! suspended future dropped in place — a distinct runtime path from the
+//! `?`-early-return and panic-unwind paths the `sequence.rs` unit tests
+//! already cover):
+//!
+//! 1. Cases 1 & 2 — the
+//!    [`SequenceReservation`](scp_runtime::context::actor::SequenceReservation)
+//!    RAII TYPE CONTRACT (ADR-049 §8 "`SequenceReservation` RAII": rollback
+//!    fires on `Drop` unless `commit()` ran; monotonicity "holds across
+//!    panics, cancellations, and early `?` returns"). These are
+//!    PRIMITIVE-LEVEL tests of the public guard type, NOT of the real send
+//!    path — see the honesty note below.
+//! 2. Case 3 — the `SagaSetReservation` per-participant-context-set saga
+//!    gating guard (ADR-049 §3a, spec §5.15.4), driven through the REAL
+//!    production reservation critical section (`try_reserve_context_set`) on
+//!    a real `Supervisor`. `start_saga` runs the FSM INLINE under the guard
+//!    (`run_saga(..).await`), so a saga future cancelled in-flight releases
+//!    its slot rather than wedging every overlapping saga with a leaked
+//!    `SagaBusy`.
+//!
+//! # Honesty note — Cases 1 & 2 do NOT drive the real send handler
+//!
+//! It is tempting to claim these witness "the cancellation arm of the real
+//! send path." They do not, and the code says why. The primary production
+//! send handler,
+//! [`handle_send_message`](../src/context/actor/handlers/messaging.rs), does
+//! NOT rely on `SequenceReservation`'s drop-on-cancel:
+//!
+//! - It `reserve()`s AND `commit()`s the actor-shape `send_tracker`
+//!   SYNCHRONOUSLY and adjacently (one `{ … }` block, no `.await` between),
+//!   BEFORE building the transport future. So no UNCOMMITTED reservation is
+//!   ever held across the transport await — a mid-await drop has nothing to
+//!   roll back.
+//! - It then awaits the transport under its OWN `tokio::time::timeout`
+//!   (`HANDLER_TIMEOUT`) and rolls the tracker back MANUALLY in the
+//!   `Ok(Err(..))` / `Err(_elapsed)` arms — arms that run only when `timeout`
+//!   RETURNS. The wire sequence in `messaging_helpers::send_message` is the
+//!   same shape: `MembershipState::next_sequence_number` then a MANUAL
+//!   `rollback_sequence_number` via the `SendAbort` token in post-await error
+//!   arms. Neither uses RAII drop-on-cancel.
+//!
+//! Consequently the real send handler cannot be turned into a
+//! drop-mid-await cancellation test that asserts a sequence rollback:
+//!
+//! - (a) There is no uncommitted guard across the await to roll back.
+//! - (b) EXTERNAL cancellation of the handler future runs NONE of the manual
+//!   rollback arms, so it would NOT roll the sequence back — asserting
+//!   "rolled back on cancel" against the real handler would assert a FALSE
+//!   property. The handler future is anyway never caller-cancellable
+//!   (block-until-terminal — see `ContextActorHandle::send`'s cancellation
+//!   docs); only an actor abort drops it, after which the COALESCED,
+//!   Class-C send-tracker bump is floored by the persisted snapshot on
+//!   respawn (ADR §8/§9), a durability property no in-process drop test can
+//!   observe.
+//! - (c) Even to invoke the handler at all requires a full
+//!   `ClassSCell` + `ActorDeps` fixture (MLS crypto, an enrolled-sender
+//!   membership, economy, event log, persistence, transport) plus a stalling
+//!   `ContextTransportProvider`; and the only cancel behaviour that fixture
+//!   could observe is the `HANDLER_TIMEOUT`-RETURN arm — a TIMEOUT test, not
+//!   a drop-mid-await test.
+//!
+//! So Cases 1 & 2 are scoped honestly as witnesses of the `SequenceReservation`
+//! TYPE contract's async-drop dimension — defense-in-depth for any future
+//! async caller that DOES hold an uncommitted guard across an await (the ADR
+//! §8 "cancellations" clause), and, for Case 2, the primitive analog of the
+//! real handler's commit-BEFORE-transport-await ordering. The load-bearing,
+//! production-path cancellation test in this file is Case 3.
+//!
+//! # Why each case is real and non-duplicate
+//!
+//! Each case was validated by transiently inverting its terminal assertion
+//! and confirming the test FAILS (recorded in the task report), so none is
+//! tautological. The existing coverage each case extends:
+//!
+//! - `sequence.rs` unit tests exercise SYNC scope-drop and `catch_unwind`
+//!   panic-unwind — never a tokio future dropped while suspended at an
+//!   `.await`. Cases 1 and 2 add ONLY that async-drop dimension of the guard
+//!   contract (the delta is the runtime drop path, not new rollback logic).
+//! - `supervisor.rs` / `actor_saga_coordinator.rs` cover overlap-while-held
+//!   and sequential re-arm (release on a NORMAL terminal) — never release
+//!   when the holding future is CANCELLED. Case 3 closes that gap against the
+//!   real critical section.
+//!
+//! Class-S mutation atomicity under cancellation (ADR §9 fail-closed) is NOT
+//! re-tested here: the actor processes each command to terminal regardless
+//! of caller cancellation (the reply oneshot receiver-drop is the only
+//! cancellation vector, and it only discards the reply — see the
+//! `ContextActorHandle::send` cancellation docs), and the mutation is guarded
+//! by the compile-time `ClassSCell` boundary (ADR §9 Enforcement), not by a
+//! runtime property a cancellation test could observe.
+
+#![allow(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    clippy::panic,
+    clippy::unreachable,
+    // Doc prose cites ADR/spec section titles unquoted for readability.
+    clippy::doc_markdown
+)]
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use scp_platform::testing::InMemoryStorage;
+use scp_protocol::context::ContextError;
+use scp_runtime::context::actor::{SendSequenceTracker, SequenceReservation};
+use scp_runtime::context::supervisor::{
+    ProtocolRepositorySagaJournal, SagaInput, SagaJournal, Supervisor, SupervisorConfig,
+};
+
+// ---------------------------------------------------------------------------
+// A cancellation window that is unambiguously mid-flight.
+//
+// `pending()` never resolves, so a future that awaits it is guaranteed to be
+// dropped WHILE SUSPENDED at that point — the reservation/guard it holds is
+// still outstanding (never committed / released by the normal path). This is
+// the exact "cancelled mid-flight" condition the ADR cares about; a future
+// that could resolve on its own would make "cancellation" unobservable.
+// ---------------------------------------------------------------------------
+
+/// Poll budget for the never-resolving branch before we cancel it. Small
+/// enough to keep the suite fast; the tests assert on the cancellation
+/// OUTCOME (`Elapsed` / the losing `select!` branch), not on wall-clock time.
+const CANCEL_AFTER: Duration = Duration::from_millis(25);
+
+// ---------------------------------------------------------------------------
+// Case 1 — a send future cancelled BEFORE commit rolls the sequence back.
+// ---------------------------------------------------------------------------
+
+/// PRIMITIVE-LEVEL contract test (see the module "Honesty note"): the public
+/// [`SequenceReservation`] guard's `Drop` rolls the tracker back when the
+/// holding future is CANCELLED between `reserve()` and `commit()`. This
+/// MODELS a hypothetical async caller that holds an uncommitted reservation
+/// across an await — the ADR-049 §8 "holds across … cancellations" clause,
+/// defense-in-depth for such a caller. The primary production send handler
+/// does NOT have this shape (it commits synchronously up-front), so this is a
+/// type-contract witness, not a real-send-path test. After rollback the slot
+/// must be released (no leaked sequence) AND reusable by the next reservation
+/// (no monotonicity gap the AAD byte-identity contract forbids).
+///
+/// Delta over `sequence.rs`: those unit tests roll back via synchronous
+/// scope-drop and `catch_unwind` panic-unwind; this adds ONLY the async-drop
+/// dimension — the real tokio runtime dropping a future suspended at an
+/// `.await` in place.
+#[tokio::test]
+async fn send_future_cancelled_before_commit_rolls_back_sequence() {
+    let mut tracker = SendSequenceTracker::new();
+
+    // Model an async caller that reserves, awaits, then would commit; cancel
+    // it at the await. The reservation is never committed (the `pending()`
+    // await never resolves, so `commit()` is unreachable).
+    let outcome = tokio::time::timeout(CANCEL_AFTER, async {
+        // AAD sequence is read pre-reserve per the byte-identity convention.
+        let aad_sequence = tracker.last_issued();
+        assert_eq!(aad_sequence, 0, "first send reads AAD sequence 0");
+
+        let reservation = SequenceReservation::reserve(&mut tracker);
+        assert_eq!(reservation.number(), 1, "first reservation is slot 1");
+
+        // A hypothetical await the reservation is held across — cancelled here.
+        std::future::pending::<()>().await;
+
+        reservation.commit(); // unreachable: pending() never resolves
+    })
+    .await;
+
+    assert!(
+        outcome.is_err(),
+        "the send future must be cancelled at the transport await, not resolve"
+    );
+
+    // The cancelled future was dropped -> the reservation's Drop ran -> the
+    // tracker rolled back. A leaked sequence would leave `last_issued() == 1`.
+    assert_eq!(
+        tracker.last_issued(),
+        0,
+        "a send cancelled before commit must not leak a sequence number"
+    );
+
+    // The freed slot is reusable: the retry reserves 1 again (no gap).
+    let retry = SequenceReservation::reserve(&mut tracker);
+    assert_eq!(
+        retry.number(),
+        1,
+        "the retry after cancellation reuses the freed slot (no monotonicity gap)"
+    );
+    retry.commit();
+    assert_eq!(tracker.last_issued(), 1, "the retry commit is permanent");
+}
+
+// ---------------------------------------------------------------------------
+// Case 2 — a send future cancelled AFTER commit keeps its sequence.
+// ---------------------------------------------------------------------------
+
+/// PRIMITIVE-LEVEL contract test and the primitive analog of the real
+/// handler's ordering. `handle_send_message` `commit()`s the sequence
+/// SYNCHRONOUSLY, THEN awaits the transport, and keeps the committed sequence
+/// on the success path — so the property that matters is: a
+/// [`SequenceReservation`] already `commit()`-ted and then cancelled at a
+/// POST-commit await must NOT roll back ("committed state stays committed" —
+/// `ContextActorHandle::send` cancellation docs; ADR §8). This models that
+/// commit-before-await ordering with the guard type directly. Cancellation is
+/// driven by a `tokio::select!` whose cancel branch wins, dropping the send
+/// branch at its post-commit await.
+///
+/// Delta: distinct property from Case 1 (the far side of the commit boundary)
+/// and a distinct cancellation driver (`select!` vs `timeout`). Like Case 1,
+/// it is a type-contract witness — see the module "Honesty note" for why the
+/// real send handler itself is not drivable as a cancellation test.
+#[tokio::test]
+async fn send_future_cancelled_after_commit_keeps_sequence() {
+    let mut tracker = SendSequenceTracker::new();
+
+    tokio::select! {
+        // The send branch: reserve, COMMIT, then suspend on a post-commit
+        // tail (e.g. best-effort bookkeeping). It never resolves, so the
+        // cancel branch always wins and drops it here — after the commit.
+        () = async {
+            let reservation = SequenceReservation::reserve(&mut tracker);
+            assert_eq!(reservation.number(), 1, "reservation is slot 1");
+            reservation.commit();
+            std::future::pending::<()>().await;
+        } => unreachable!("the post-commit tail never resolves"),
+        // The cancel branch: wins the race and cancels the send branch.
+        () = tokio::time::sleep(CANCEL_AFTER) => {}
+    }
+
+    // The send branch was dropped AFTER commit; the committed sequence must
+    // stand. A spurious rollback would leave `last_issued() == 0`.
+    assert_eq!(
+        tracker.last_issued(),
+        1,
+        "a committed sequence must survive cancellation of the post-commit tail"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Case 3 — a cancelled saga future releases its context-set reservation.
+// ---------------------------------------------------------------------------
+
+/// `Supervisor` fixture for the saga-reservation case. The reservation store
+/// under test is in-memory (a `Mutex<HashSet<..>>`) and never touches
+/// persistence or the journal, so the inert `NoopContextPersistence` +
+/// empty in-memory journal are sufficient — this mirrors `test_supervisor`
+/// in `tests/actor_saga_coordinator.rs` (integration test files cannot share
+/// a module, so the constructor is replicated).
+fn test_supervisor() -> Supervisor {
+    let persistence: Arc<dyn scp_runtime::context::persistence::ContextPersistence> =
+        Arc::new(scp_runtime::context::persistence::NoopContextPersistence);
+    let journal: Arc<dyn SagaJournal> = Arc::new(ProtocolRepositorySagaJournal::new(Arc::new(
+        InMemoryStorage::new(),
+    )));
+    Supervisor::new(persistence, journal, SupervisorConfig::default())
+}
+
+/// ADR-049 §3a / spec §5.15.4: a saga reserves its participant-context SET
+/// via `try_reserve_context_set`, and the `SagaSetReservation` RAII guard
+/// releases that set on scope exit. Because `start_saga` drives the FSM
+/// INLINE under the guard (`run_saga(..).await`), cancelling the saga future
+/// mid-flight drops the guard and MUST release the slot — otherwise a
+/// cancelled saga would wedge every overlapping saga with a leaked
+/// `SagaBusy`. This drives that release through real tokio cancellation.
+///
+/// The test reserves via `test_reserve_saga_context_set`, which exercises the
+/// SAME `try_reserve_context_set` critical section `start_saga` uses (not a
+/// mock), holds the reservation across a `pending()` await inside a
+/// `select!` branch, proves mid-flight that an OVERLAPPING reserve is
+/// rejected (so the slot is genuinely held), then lets the cancel branch drop
+/// the holder and asserts the overlapping reserve now SUCCEEDS.
+///
+/// Non-duplicate: existing tests cover overlap-while-held and release on a
+/// normal terminal / sequential re-arm; none release the set because the
+/// holding future was CANCELLED.
+#[tokio::test]
+async fn cancelled_saga_future_releases_context_set_reservation() {
+    let supervisor = test_supervisor();
+    // Identical inputs -> identical participant set -> they overlap.
+    let input = SagaInput::test_cross_context_for_gating([0x11; 32], [0x22; 32]);
+
+    tokio::select! {
+        // The saga branch: hold the participant set, prove overlap is
+        // rejected while held, then suspend forever so the cancel branch
+        // drops us with the reservation still outstanding.
+        () = async {
+            let _held = supervisor
+                .test_reserve_saga_context_set(&input)
+                .expect("initial reservation of a free set succeeds");
+
+            // While held, an overlapping saga must be rejected — proving the
+            // slot is genuinely reserved, so the post-cancel release below is
+            // a meaningful (non-vacuous) observation.
+            assert!(
+                matches!(
+                    supervisor.test_reserve_saga_context_set(&input),
+                    Err(ContextError::ActorBusy(_))
+                ),
+                "an overlapping set must be SagaBusy while the first is held in-flight"
+            );
+
+            // Suspend forever holding `_held` — the cancel branch drops this
+            // whole future (and with it the reservation guard) mid-flight.
+            std::future::pending::<()>().await;
+        } => unreachable!("the in-flight saga branch never resolves"),
+        () = tokio::time::sleep(CANCEL_AFTER) => {}
+    }
+
+    // The saga branch was dropped -> its `SagaSetReservation` Drop ran -> the
+    // set is released. A leaked reservation would keep this SagaBusy.
+    let reacquired = supervisor.test_reserve_saga_context_set(&input);
+    assert!(
+        reacquired.is_ok(),
+        "a cancelled saga must release its participant-context-set reservation, \
+         leaving the slot reservable; got {:?}",
+        reacquired.err()
+    );
+}

--- a/crates/scp-runtime/tests/perf_baseline.rs
+++ b/crates/scp-runtime/tests/perf_baseline.rs
@@ -1,0 +1,726 @@
+//! ADR-049 Decision 14 — performance **baseline** harness.
+//!
+//! Provenance: `.docs/adrs/ADR-049-actor-per-context.md`
+//! - `### 14. Performance regression as a rollback trigger`
+//! - `## Consequences` §Performance
+//!
+//! The ADR mandates a `cargo test -p scp-runtime --test perf_baseline` target
+//! that measures SIX operations at N = 1 / 4 / 16 (concurrency) and treats a
+//! **> 15 % regression on any (operation, N) pair** as rollback trigger #4.
+//! The six operations, and the two workload classes the ADR names:
+//!
+//! | operation             | driver                                                    | class                    |
+//! |-----------------------|-----------------------------------------------------------|--------------------------|
+//! | `handshake`           | real MLS welcome + keypackage + `add_member`              | crypto-dominated         |
+//! | `send_message`        | `Supervisor::send_message` (encrypt + fan-out)            | mixed                    |
+//! | `deliver_incoming`    | `Supervisor::deliver_commit_blob` (actor decrypt + merge) | mixed (read fast path)   |
+//! | `governance_propose`  | `Supervisor::propose_governance_action`                   | mixed (write slow path)  |
+//! | `broadcast_publish`   | `Supervisor::dispatch_broadcast_command_with_custody`     | overhead-dominated (mailbox) |
+//! | `broadcast_subscribe` | `Supervisor::dispatch_broadcast_command`                  | overhead-dominated (mailbox) |
+//!
+//! # Why the `scp-testing` `FullStackNetwork` harness
+//!
+//! `deliver_incoming` requires a genuine SECOND MLS member whose group state can
+//! decrypt an inbound envelope. Producing that (real Welcome / keypackage /
+//! sender-key / access-key exchange across two `Supervisor`s) is exactly what
+//! `scp_testing::fullstack::FullStackNetwork` already drives. Per ADR guidance
+//! ("do not hand-roll protocol setup if a harness exists") this target reuses it
+//! via a **dev-only** dependency (see the note in `crates/scp-runtime/Cargo.toml`).
+//! The harness is used only for untimed SETUP; every timed region calls the raw
+//! `Supervisor` operation directly, so the measurement is sensitive to a
+//! regression in the operation itself rather than diluted by harness overhead.
+//!
+//! # Methodology and the pass/fail gate
+//!
+//! For each (operation, N): spin up `N` independent contexts (each its own
+//! per-context actor — the unit the ADR-049 refactor makes concurrent), run
+//! `WARMUP` un-recorded rounds then `ROUNDS` recorded rounds, and in every round
+//! launch the operation on all `N` contexts CONCURRENTLY (real `JoinSet` tasks
+//! on a multi-thread runtime). Each individual operation's wall-clock is a
+//! sample; the recorded statistic is the **p50 (median)** over all samples —
+//! robust to CI scheduler jitter in a way a mean or p99 is not.
+//!
+//! Record-only by default; the gate is opt-in. The pass/fail comparison, when
+//! it runs, is **purely relative to a recorded baseline — never an absolute time
+//! threshold** (an absolute-timing assertion would flake in CI and is worthless):
+//!
+//! - **Default run** (no env vars): measure all pairs, (over)write the p50s to
+//!   `tests/perf_baseline.json`, print them, and always PASS — no assertion. This
+//!   is a per-environment reference artifact that can never flake on any hardware,
+//!   which is exactly why the JSON is git-ignored, not committed (committing one
+//!   machine's numbers is the machine-specific false-positive we avoid).
+//! - **Opt-in gate** (`SCP_PERF_GATE=1`): the deliberate same-environment
+//!   before/after comparison (Decision 14's intent). Baseline ABSENT → error,
+//!   telling the operator to record first. Baseline PRESENT → for every (op, N)
+//!   in it, assert `measured_p50 <= baseline_p50 * 1.15`. A measured pair absent
+//!   from the baseline (a newly added op vs a stale baseline) is skipped; a fresh
+//!   default run re-records. The gate never writes the baseline.
+//!
+//! Typical loop: run the default target to record a `before` baseline, apply the
+//! change under test, then run `SCP_PERF_GATE=1` on the same box to assert.
+//!
+//! A `NOISE_FLOOR_MICROS` guard suppresses the relative check when BOTH the
+//! baseline and the measurement sit below the floor: at tens-of-microseconds a
+//! 15 % band is pure scheduler noise, so gating it would be a false-positive
+//! machine. The check still fires the moment EITHER side crosses the floor, so a
+//! real regression (e.g. a mailbox op ballooning from 40 µs to 2 ms) is caught.
+//! This is a noise gate on the relative comparison, NOT an absolute-time gate:
+//! sub-floor pairs always pass.
+
+#![allow(
+    clippy::expect_used,
+    clippy::unwrap_used,
+    clippy::panic,
+    clippy::cast_precision_loss,
+    clippy::cast_possible_truncation,
+    clippy::cast_sign_loss,
+    clippy::too_many_lines,
+    clippy::large_futures
+)]
+
+use std::collections::BTreeMap;
+use std::path::PathBuf;
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+
+use scp_did::DID;
+use scp_platform::KeyHandle;
+use scp_platform::testing::InMemoryKeyCustody;
+use scp_protocol::context::context_id_bytes;
+use scp_protocol::context::governance::GovernanceAction;
+use scp_protocol::context::params::{
+    Capability, ContextMode, ContextParams, GovernanceModel, MemoryScope,
+};
+use scp_runtime::context::ContextHandle;
+use scp_runtime::context::actor::commands::{
+    BroadcastCommand, PublishBroadcastPayload, SubscribeBroadcastPayload,
+};
+use scp_runtime::context::supervisor::Supervisor;
+use scp_testing::fullstack::{FullStackNetwork, FullStackNode};
+
+// ---------------------------------------------------------------------------
+// Tuning constants — kept modest so the whole matrix runs in reasonable CI time.
+// ---------------------------------------------------------------------------
+
+/// Concurrency levels mandated by ADR-049 Decision 14.
+const CONCURRENCY_LEVELS: [usize; 3] = [1, 4, 16];
+/// Un-recorded rounds run before measurement to warm caches / JIT allocation.
+const WARMUP: usize = 2;
+/// Recorded rounds. Samples per (op, N) = `N * ROUNDS`.
+///
+/// Bounded by the protocol's per-sender hard anti-spam limiter (Matrix defaults:
+/// burst 10, 0.2 msg/s refill — `HardRateLimitConfig::default`, not
+/// param-configurable). Any principal that repeats a message-bearing op is
+/// capped at ~10 invocations inside the test's short wall-clock window, so the
+/// heaviest per-principal path (`deliver_incoming` setup = `WARMUP + ROUNDS + 1`
+/// Alice sends) must stay under that burst. `ROUNDS = 6` keeps every principal
+/// at ≤ 9 invocations with margin.
+const ROUNDS: usize = 6;
+/// Regression tolerance: a pair fails if `measured > baseline * TOLERANCE`.
+const TOLERANCE: f64 = 1.15;
+/// Below this (in microseconds) a 15 % band is scheduler noise; the relative
+/// check is suppressed while BOTH sides are sub-floor. See module docs. Set just
+/// under the overhead-dominated `broadcast_publish` p50 (~190 µs) so that path IS
+/// gated (the ADR names it as a mandatory workload class), while the deep
+/// sub-floor `broadcast_subscribe` (~65 µs, where a 15 % band is ~10 µs of pure
+/// scheduler noise) is measured + recorded but not relative-gated until a real
+/// regression pushes it across the floor.
+const NOISE_FLOOR_MICROS: f64 = 150.0;
+/// Fixed application payload used by send / deliver / broadcast measurements.
+const PAYLOAD: &[u8] = b"scp-adr049-perf-baseline-payload";
+
+// ---------------------------------------------------------------------------
+// Deterministic key derivation — MUST mirror `FullStackNode::did_to_seed` so a
+// custody key we mint for a broadcast author verifies against the network's
+// deterministic `#active` resolver.
+// ---------------------------------------------------------------------------
+
+fn did_to_seed(did: &DID) -> [u8; 32] {
+    use std::hash::{Hash, Hasher};
+    let mut hasher = std::collections::hash_map::DefaultHasher::new();
+    did.as_ref().hash(&mut hasher);
+    let h = hasher.finish();
+    let mut seed = [0u8; 32];
+    seed[..8].copy_from_slice(&h.to_le_bytes());
+    seed
+}
+
+/// Builds a well-formed, unique `did:dht:` identifier from stable components.
+fn make_did(kind: &str, instance: usize, slot: usize) -> String {
+    format!("did:dht:z6MkPerf{kind}i{instance}s{slot}")
+}
+
+// ---------------------------------------------------------------------------
+// Context parameter builders.
+// ---------------------------------------------------------------------------
+
+fn encrypted_ceiling() -> Vec<Capability> {
+    vec![
+        Capability::MessagesRead,
+        Capability::MessagesWrite,
+        Capability::RoleAssign,
+        Capability::MemberInvite,
+        Capability::MemberRemove,
+        Capability::GovernancePropose,
+        Capability::GovernanceVote,
+        Capability::ContextClose,
+    ]
+}
+
+/// Encrypted, single-admin context (handshake / send / deliver).
+fn encrypted_params() -> ContextParams {
+    ContextParams {
+        mode: ContextMode::Encrypted,
+        ceiling: encrypted_ceiling(),
+        ..ContextParams::default()
+    }
+}
+
+/// Encrypted context under a 2-of-2 threshold model so a lone proposer records a
+/// proposal WITHOUT crossing quorum (measures propose, never execute).
+fn governance_params(alice: &DID, bob: &DID) -> ContextParams {
+    ContextParams {
+        mode: ContextMode::Encrypted,
+        ceiling: encrypted_ceiling(),
+        governance: GovernanceModel::Threshold {
+            threshold: 2,
+            signers: vec![alice.clone(), bob.clone()],
+        },
+        ..ContextParams::default()
+    }
+}
+
+/// Open broadcast context. `MemoryScope::Full` is mandatory for broadcast
+/// (`validate_memory_scope_for_broadcast` rejects Ephemeral / Summary).
+fn broadcast_params() -> ContextParams {
+    ContextParams {
+        mode: ContextMode::Broadcast,
+        memory_scope: MemoryScope::Full,
+        ceiling: vec![Capability::MessagesRead, Capability::MessagesWrite],
+        ..ContextParams::default()
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Concurrency runner — the shared warmup/round/join scaffold.
+// ---------------------------------------------------------------------------
+
+/// Runs `WARMUP + ROUNDS` rounds; each round launches `op` on every instance
+/// concurrently as a spawned task and awaits all. Returns the per-operation
+/// wall-clock samples (microseconds) from the recorded rounds only.
+async fn run_measure<I, F, Fut>(instances: Vec<Arc<I>>, op: F) -> Vec<f64>
+where
+    I: Send + Sync + 'static,
+    F: Fn(Arc<I>, usize) -> Fut + Copy + Send + 'static,
+    Fut: std::future::Future<Output = Duration> + Send + 'static,
+{
+    let mut samples = Vec::with_capacity(instances.len() * ROUNDS);
+    for round in 0..(WARMUP + ROUNDS) {
+        let mut set = tokio::task::JoinSet::new();
+        for inst in &instances {
+            let inst = Arc::clone(inst);
+            set.spawn(op(inst, round));
+        }
+        let mut durations = Vec::with_capacity(instances.len());
+        while let Some(joined) = set.join_next().await {
+            durations.push(joined.expect("perf op task panicked"));
+        }
+        if round >= WARMUP {
+            samples.extend(durations.into_iter().map(|d| d.as_secs_f64() * 1e6));
+        }
+    }
+    samples
+}
+
+/// p50 (median) of a sample set, in whatever unit the samples carry.
+fn p50(mut samples: Vec<f64>) -> f64 {
+    assert!(!samples.is_empty(), "no samples collected");
+    samples.sort_by(f64::total_cmp);
+    samples[samples.len() / 2]
+}
+
+// ---------------------------------------------------------------------------
+// Per-operation instances + drivers.
+//
+// Each instance keeps its `FullStackNetwork` alive (it owns the shared key
+// exchange + node registry the harness routes through).
+// ---------------------------------------------------------------------------
+
+// -- handshake -------------------------------------------------------------
+
+struct HandshakeInst {
+    _network: FullStackNetwork,
+    creator: FullStackNode,
+    handle: ContextHandle,
+    joiner_dids: Vec<String>,
+}
+
+async fn setup_handshake(n: usize) -> Vec<Arc<HandshakeInst>> {
+    let mut instances = Vec::with_capacity(n);
+    for i in 0..n {
+        let network = FullStackNetwork::new();
+        let creator = network.create_node(&make_did("HsC", i, 0));
+        let handle = creator
+            .create_context(&format!("perf-handshake-{i}"), encrypted_params())
+            .await
+            .expect("create handshake context");
+        // One fresh joiner per round (an add cannot be replayed). Each joiner is
+        // registered in the network so the creator can mint its key package.
+        let mut joiner_dids = Vec::with_capacity(WARMUP + ROUNDS);
+        for r in 0..(WARMUP + ROUNDS) {
+            let did = make_did("HsJ", i, r);
+            let _joiner = network.create_node(&did);
+            joiner_dids.push(did);
+        }
+        instances.push(Arc::new(HandshakeInst {
+            _network: network,
+            creator,
+            handle,
+            joiner_dids,
+        }));
+    }
+    instances
+}
+
+async fn op_handshake(inst: Arc<HandshakeInst>, round: usize) -> Duration {
+    let joiner = inst.joiner_dids[round].clone();
+    let start = Instant::now();
+    inst.creator
+        .add_member(&inst.handle, &joiner)
+        .await
+        .expect("handshake add_member");
+    start.elapsed()
+}
+
+// -- send_message ----------------------------------------------------------
+
+struct SendInst {
+    _network: FullStackNetwork,
+    alice: FullStackNode,
+    handle: ContextHandle,
+}
+
+/// Builds a live two-member encrypted context (Alice + Bob joined) so sends
+/// have a real recipient to fan out to.
+async fn build_pair(
+    tag: &str,
+    i: usize,
+) -> (
+    FullStackNetwork,
+    FullStackNode,
+    FullStackNode,
+    ContextHandle,
+    String,
+) {
+    let network = FullStackNetwork::new();
+    let alice = network.create_node(&make_did(&format!("{tag}A"), i, 0));
+    let bob = network.create_node(&make_did(&format!("{tag}B"), i, 0));
+    let ctx_id = format!("perf-{tag}-{i}");
+    let handle = alice
+        .create_context(&ctx_id, encrypted_params())
+        .await
+        .expect("create pair context");
+    let bob_did = bob.did.as_ref().to_owned();
+    alice
+        .add_member(&handle, &bob_did)
+        .await
+        .expect("pair add_member");
+    bob.join_from_welcome(&ctx_id, &context_id_bytes(&ctx_id))
+        .await
+        .expect("bob joins pair");
+    // §9.10.4: seed Bob's per-member pseudonym routing ID into Alice's manager
+    // (production: Bob announces it). Without this an encrypted multi-member
+    // send fails closed with `PseudonymRegistryEmpty`.
+    alice
+        .manager
+        .seed_peer_pseudonym(&ctx_id, bob.did.clone(), [0x42u8; 32])
+        .await
+        .expect("seed bob pseudonym");
+    // The actor `deliver_incoming` path resolves the receiving member by
+    // intersecting context membership with the supervisor's registered local
+    // DIDs. The full-stack harness never registers one (its own receive tests
+    // decrypt at the crypto layer), so register Bob here for the actor path.
+    bob.manager
+        .register_local_did(bob.did.clone())
+        .await
+        .expect("register bob as local did");
+    (network, alice, bob, handle, ctx_id)
+}
+
+async fn setup_send(n: usize) -> Vec<Arc<SendInst>> {
+    let mut instances = Vec::with_capacity(n);
+    for i in 0..n {
+        let (network, alice, _bob, handle, _ctx) = build_pair("send", i).await;
+        instances.push(Arc::new(SendInst {
+            _network: network,
+            alice,
+            handle,
+        }));
+    }
+    instances
+}
+
+async fn op_send(inst: Arc<SendInst>, _round: usize) -> Duration {
+    let start = Instant::now();
+    inst.alice
+        .send_message(&inst.handle, PAYLOAD)
+        .await
+        .expect("send_message");
+    start.elapsed()
+}
+
+// -- deliver_incoming ------------------------------------------------------
+
+struct DeliverInst {
+    _network: FullStackNetwork,
+    bob: Arc<Supervisor>,
+    ctx_id: String,
+    envelopes: Vec<Vec<u8>>,
+}
+
+async fn setup_deliver(n: usize) -> Vec<Arc<DeliverInst>> {
+    let mut instances = Vec::with_capacity(n);
+    for i in 0..n {
+        let (network, alice, bob, handle, ctx_id) = build_pair("deliver", i).await;
+        let ctx_bytes = context_id_bytes(&ctx_id);
+
+        // Pre-generate one probe envelope + WARMUP+ROUNDS measured envelopes.
+        // Each Alice send yields exactly one captured ciphertext (single peer);
+        // delivering them in send order keeps the per-sender sequence monotonic.
+        let total = WARMUP + ROUNDS + 1;
+        let mut envelopes = Vec::with_capacity(total);
+        for _ in 0..total {
+            alice
+                .send_message(&handle, PAYLOAD)
+                .await
+                .expect("deliver setup: alice send");
+            let mut captured = alice.take_sent_ciphertexts();
+            assert_eq!(
+                captured.len(),
+                1,
+                "a single-peer encrypted send must capture exactly one ciphertext"
+            );
+            envelopes.push(captured.remove(0).1);
+        }
+        // Resolve Alice's sender key on Bob's shared provider before delivery.
+        bob.pickup_sender_keys(&ctx_id, &ctx_bytes)
+            .expect("bob picks up alice sender keys");
+
+        // Correctness probe (untimed): the actor deliver path must return real
+        // application content for a genuine inbound message.
+        let probe = envelopes.remove(0);
+        let delivered = bob
+            .manager
+            .deliver_commit_blob(&ctx_id, probe)
+            .await
+            .expect("probe deliver_commit_blob");
+        assert!(
+            matches!(delivered, Some((ref pt, _)) if pt.as_slice() == PAYLOAD),
+            "deliver_incoming must yield the real application payload; got {delivered:?}"
+        );
+
+        instances.push(Arc::new(DeliverInst {
+            _network: network,
+            bob: Arc::clone(&bob.manager),
+            ctx_id,
+            envelopes,
+        }));
+    }
+    instances
+}
+
+async fn op_deliver(inst: Arc<DeliverInst>, round: usize) -> Duration {
+    let envelope = inst.envelopes[round].clone();
+    let start = Instant::now();
+    inst.bob
+        .deliver_commit_blob(&inst.ctx_id, envelope)
+        .await
+        .expect("deliver_commit_blob");
+    start.elapsed()
+}
+
+// -- governance_propose ----------------------------------------------------
+
+struct ProposeInst {
+    _network: FullStackNetwork,
+    alice: FullStackNode,
+    ctx_id: String,
+    instance: usize,
+}
+
+async fn setup_propose(n: usize) -> Vec<Arc<ProposeInst>> {
+    let mut instances = Vec::with_capacity(n);
+    for i in 0..n {
+        let network = FullStackNetwork::new();
+        let alice = network.create_node(&make_did("GovA", i, 0));
+        let bob = network.create_node(&make_did("GovB", i, 0));
+        let ctx_id = format!("perf-propose-{i}");
+        alice
+            .create_context(&ctx_id, governance_params(&alice.did, &bob.did))
+            .await
+            .expect("create governance context");
+        instances.push(Arc::new(ProposeInst {
+            _network: network,
+            alice,
+            ctx_id,
+            instance: i,
+        }));
+    }
+    instances
+}
+
+async fn op_propose(inst: Arc<ProposeInst>, round: usize) -> Duration {
+    // A fresh target per round → a distinct pending proposal each time.
+    let action = GovernanceAction::AddMember {
+        did: DID::from(make_did("GovT", inst.instance, round)),
+        role: "member".to_owned(),
+    };
+    let start = Instant::now();
+    inst.alice
+        .propose_governance(&inst.ctx_id, action)
+        .await
+        .expect("propose_governance_action");
+    start.elapsed()
+}
+
+// -- broadcast_subscribe ---------------------------------------------------
+
+struct SubscribeInst {
+    _network: FullStackNetwork,
+    sup: Arc<Supervisor>,
+    ctx_id: String,
+    instance: usize,
+}
+
+async fn setup_broadcast(tag: &str, n: usize) -> Vec<(FullStackNetwork, FullStackNode, String)> {
+    let mut out = Vec::with_capacity(n);
+    for i in 0..n {
+        let network = FullStackNetwork::new();
+        let creator = network.create_node(&make_did(tag, i, 0));
+        let ctx_id = format!("perf-{tag}-{i}");
+        creator
+            .create_context(&ctx_id, broadcast_params())
+            .await
+            .expect("create broadcast context");
+        out.push((network, creator, ctx_id));
+    }
+    out
+}
+
+async fn setup_subscribe(n: usize) -> Vec<Arc<SubscribeInst>> {
+    let mut instances = Vec::with_capacity(n);
+    for (i, (network, creator, ctx_id)) in setup_broadcast("BSub", n).await.into_iter().enumerate()
+    {
+        instances.push(Arc::new(SubscribeInst {
+            sup: Arc::clone(&creator.manager),
+            _network: network,
+            ctx_id,
+            instance: i,
+        }));
+    }
+    instances
+}
+
+async fn op_subscribe(inst: Arc<SubscribeInst>, round: usize) -> Duration {
+    // A fresh subscriber each round → no idempotent-dedup short-circuit.
+    let subscriber = DID::from(make_did("BSubR", inst.instance, round));
+    let (tx, rx) = tokio::sync::oneshot::channel();
+    let cmd = BroadcastCommand::SubscribeBroadcast {
+        payload: Box::new(SubscribeBroadcastPayload {
+            context_id: inst.ctx_id.clone(),
+            subscriber_did: subscriber,
+            ucan: None,
+            timestamp: 1_700_000_000 + round as u64,
+        }),
+        reply: tx,
+    };
+    let start = Instant::now();
+    inst.sup
+        .dispatch_broadcast_command(cmd)
+        .await
+        .expect("dispatch subscribe");
+    rx.await
+        .expect("subscribe reply channel")
+        .expect("subscribe succeeds");
+    start.elapsed()
+}
+
+// -- broadcast_publish -----------------------------------------------------
+
+struct PublishInst {
+    _network: FullStackNetwork,
+    sup: Arc<Supervisor>,
+    ctx_id: String,
+    author: DID,
+    custody: InMemoryKeyCustody,
+    key: KeyHandle,
+}
+
+async fn setup_publish(n: usize) -> Vec<Arc<PublishInst>> {
+    let mut instances = Vec::with_capacity(n);
+    for (network, creator, ctx_id) in setup_broadcast("BPub", n).await {
+        // The creator is auto-registered as the broadcast author on create. Mint
+        // a custody key seeded to match the network resolver so the publish
+        // signature verifies.
+        let custody = InMemoryKeyCustody::new();
+        let key = custody.import_ed25519_key(&did_to_seed(&creator.did)).await;
+        instances.push(Arc::new(PublishInst {
+            author: creator.did.clone(),
+            sup: Arc::clone(&creator.manager),
+            _network: network,
+            ctx_id,
+            custody,
+            key,
+        }));
+    }
+    instances
+}
+
+async fn op_publish(inst: Arc<PublishInst>, _round: usize) -> Duration {
+    let (tx, rx) = tokio::sync::oneshot::channel();
+    let cmd = BroadcastCommand::PublishBroadcast {
+        payload: Box::new(PublishBroadcastPayload {
+            context_id: inst.ctx_id.clone(),
+            author_did: inst.author.clone(),
+            payload: PAYLOAD.to_vec(),
+            signing_key_handle: inst.key,
+        }),
+        reply: tx,
+    };
+    let start = Instant::now();
+    inst.sup
+        .dispatch_broadcast_command_with_custody(cmd, &inst.custody)
+        .await
+        .expect("dispatch publish");
+    rx.await
+        .expect("publish reply channel")
+        .expect("publish succeeds");
+    start.elapsed()
+}
+
+// ---------------------------------------------------------------------------
+// Baseline persistence + gate.
+// ---------------------------------------------------------------------------
+
+fn baseline_path() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("tests/perf_baseline.json")
+}
+
+fn key(op: &str, n: usize) -> String {
+    format!("{op}/N{n}")
+}
+
+/// Writes the baseline map as stable, pretty JSON (`BTreeMap` → sorted keys).
+fn write_baseline(map: &BTreeMap<String, f64>) {
+    let json = serde_json::to_string_pretty(map).expect("serialize baseline");
+    std::fs::write(baseline_path(), format!("{json}\n")).expect("write baseline");
+}
+
+fn read_baseline() -> Option<BTreeMap<String, f64>> {
+    let bytes = std::fs::read(baseline_path()).ok()?;
+    Some(serde_json::from_slice(&bytes).expect("parse existing perf_baseline.json"))
+}
+
+// ---------------------------------------------------------------------------
+// The mandated target.
+// ---------------------------------------------------------------------------
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn perf_baseline() {
+    // Measure every (operation, N) pair, recording p50 microseconds.
+    let mut measured: BTreeMap<String, f64> = BTreeMap::new();
+
+    for &n in &CONCURRENCY_LEVELS {
+        measured.insert(
+            key("handshake", n),
+            p50(run_measure(setup_handshake(n).await, op_handshake).await),
+        );
+        measured.insert(
+            key("send_message", n),
+            p50(run_measure(setup_send(n).await, op_send).await),
+        );
+        measured.insert(
+            key("deliver_incoming", n),
+            p50(run_measure(setup_deliver(n).await, op_deliver).await),
+        );
+        measured.insert(
+            key("governance_propose", n),
+            p50(run_measure(setup_propose(n).await, op_propose).await),
+        );
+        measured.insert(
+            key("broadcast_publish", n),
+            p50(run_measure(setup_publish(n).await, op_publish).await),
+        );
+        measured.insert(
+            key("broadcast_subscribe", n),
+            p50(run_measure(setup_subscribe(n).await, op_subscribe).await),
+        );
+    }
+
+    // Emit the measured table for operator visibility (visible with --nocapture).
+    println!("\nADR-049 perf_baseline — p50 wall-clock per (operation, N):");
+    for (k, v) in &measured {
+        println!("  {k:<26} {v:>12.1} µs");
+    }
+
+    // DEFAULT (no env): record the measured p50s and always PASS. This is a
+    // per-environment reference artifact, never an absolute-time assertion, so
+    // it can never flake on any hardware. The opt-in gate below is the deliberate
+    // same-environment before/after comparison (Decision 14's intent).
+    if std::env::var("SCP_PERF_GATE").is_err() {
+        write_baseline(&measured);
+        println!(
+            "\nRecorded {} (op, N) p50s to {} — record-only run, PASS.\n\
+             Set SCP_PERF_GATE=1 (after a record on this machine) to assert the \
+             >{:.0}% regression gate.",
+            measured.len(),
+            baseline_path().display(),
+            (TOLERANCE - 1.0) * 100.0,
+        );
+        return;
+    }
+
+    // OPT-IN GATE (`SCP_PERF_GATE=1`): compare against the previously recorded
+    // baseline on THIS machine. Absent baseline is an operator error, not a pass.
+    let baseline = read_baseline().unwrap_or_else(|| {
+        panic!(
+            "SCP_PERF_GATE=1 but no baseline at {} — run the default target once with no \
+             env vars to record it, then re-run with SCP_PERF_GATE=1 for the same-environment \
+             before/after comparison.",
+            baseline_path().display(),
+        )
+    });
+
+    let mut regressions: Vec<String> = Vec::new();
+    for (k, &m) in &measured {
+        // A measured pair absent from the baseline means the baseline is stale
+        // (a new op was added) — skip it here; a fresh default run re-records.
+        if let Some(&b) = baseline.get(k) {
+            // Suppress the relative check only while BOTH sides are sub-noise-floor
+            // (a 15% band at tens of µs is pure scheduler noise); fire it the
+            // instant either side crosses the floor.
+            if b.max(m) >= NOISE_FLOOR_MICROS && m > b * TOLERANCE {
+                regressions.push(format!(
+                    "  {k:<26} baseline {b:.1} µs → measured {m:.1} µs \
+                     ({:.1}% over, limit +{:.0}%)",
+                    (m / b - 1.0) * 100.0,
+                    (TOLERANCE - 1.0) * 100.0,
+                ));
+            }
+        }
+    }
+
+    assert!(
+        regressions.is_empty(),
+        "ADR-049 Decision 14 rollback trigger #4 — >{:.0}% perf regression on \
+         {} (operation, N) pair(s):\n{}\n\nIf this reflects an intentional change, \
+         re-record with a default (no-env) run.",
+        (TOLERANCE - 1.0) * 100.0,
+        regressions.len(),
+        regressions.join("\n"),
+    );
+    println!(
+        "\nSCP_PERF_GATE — all (operation, N) pairs within +{:.0}% of the recorded baseline — PASSED.",
+        (TOLERANCE - 1.0) * 100.0
+    );
+}

--- a/crates/scp-runtime/tests/persistence_ordering.rs
+++ b/crates/scp-runtime/tests/persistence_ordering.rs
@@ -1,0 +1,442 @@
+//! ADR-049 §9 persistence-ORDERING verification (`persistence_ordering`).
+//!
+//! ADR-049 (`.docs/adrs/ADR-049-actor-per-context.md`) names this test in its
+//! `## Verification` executable-checks list. It pins the §9
+//! *"never ack success unless durable"* ordering guarantee for **Class-S**
+//! (sync-persisted, security-critical) state, END-TO-END through the PUBLIC
+//! `Supervisor` actor API — the layer the combinator-level unit tests in
+//! `class_s.rs` do not exercise.
+//!
+//! ## What §9 requires (the invariant under test)
+//!
+//! > For Class-S state, a persist FAILURE must FAIL-CLOSED (the operation
+//! > returns an error) — never best-effort-swallow that returns `Ok`.
+//! > [Class-S state is] durably persisted synchronously BEFORE the mutating
+//! > operation returns success.
+//!
+//! Concretely, the durable write is a *precondition* of acknowledging success.
+//! That is a two-directional claim, and each direction needs its own case:
+//!
+//! 1. **ack ⟹ durable** (`class_s_mutation_commits_durably_before_acking_success`):
+//!    a Class-S mutation that returns `Ok` has ALREADY committed to the
+//!    persistence backend. Because `ContextPersistence::persist_context` is
+//!    awaited on the ack path before the handler replies, observing `Ok` proves
+//!    the durable snapshot already reflects the mutation.
+//! 2. **¬durable ⟹ ¬ack** (`class_s_mutation_persist_failure_fails_closed_and_withholds_durable_commit`):
+//!    if the durable write FAILS, the operation returns `Err` (fail-closed) and
+//!    the mutation is NOT observable as committed in the backend. Success is
+//!    withheld precisely because durability was not achieved.
+//!
+//! Neither direction alone is the guarantee: case 2 in isolation only says
+//! "a failing write fails," and case 1 in isolation only says "a good write
+//! commits." Together they pin the ORDERING — durability gates the ack.
+//!
+//! ## Why this is not a duplicate
+//!
+//! - The `class_s.rs` unit tests (`commit_keeps_mutation_and_surfaces_error_on_persist_failure`,
+//!   `keep_retains_mutation_on_persist_failure`, `restore_rolls_back_class_s_on_persist_failure`,
+//!   …) exercise the persist-on-commit COMBINATORS in ISOLATION against a hand-built
+//!   `ClassSCell` + fault-injected `ActorDeps`. They prove each combinator's
+//!   fail-closed contract, but not that a real governance operation dispatched
+//!   through the public `Supervisor` mailbox surfaces that `Err` all the way to the
+//!   caller and withholds the durable commit. This file exercises the whole
+//!   dispatch path (`Supervisor::propose_governance_action` →
+//!   actor → `dispatch_governance_action` → `execute_suspend_member` →
+//!   `commit_class_s_keep`), which the unit tests cannot reach.
+//! - `security_critical_state_is_class_s_or_m_not_coalesced` (also in `class_s.rs`)
+//!   is the FIELD-round-trip property — it proves every Class-S field SURVIVES a
+//!   snapshot round-trip. It says nothing about the temporal ORDERING of the
+//!   durable write relative to the caller ack. This file is the ORDERING
+//!   complement, not a re-run of the round-trip.
+//!
+//! The Class-S mutation exercised is member capability suspension
+//! (`GovernanceAction::SuspendCapability` → `execute_suspend_member`), a §9
+//! downward-authorization arm that persists **fail-closed** via
+//! `commit_class_s_keep`.
+
+// Gated on `testing`: the test drives `Supervisor::test_insert_member` and
+// `Supervisor::propose_governance_action`, both `#[cfg(feature = "testing")]`.
+// Gated via the Cargo.toml `[[test]] required-features = ["testing"]` entry
+// (matching every sibling gated integration test), so the mandated
+// `cargo test -p scp-runtime --test persistence_ordering --features testing`
+// runs the cases and a bare `cargo test` skips the target with a visible note.
+#![allow(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    clippy::panic,
+    clippy::disallowed_types,
+    clippy::doc_markdown
+)]
+
+use std::collections::HashMap;
+use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
+use std::sync::{Arc, Mutex};
+
+use scp_did::DID;
+use scp_protocol::context::builder::ContextCreationError;
+use scp_protocol::context::governance::{GovernanceAction, KeyResolver};
+use scp_protocol::context::params::{Capability, ContextParams, GovernanceModel};
+use scp_protocol::context::{ContextError, ContextState};
+use scp_runtime::context::builder::{ContextEventLogProvider, ContextTransportProvider};
+use scp_runtime::context::persistence::ContextPersistence;
+use scp_runtime::context::state::ContextSnapshot;
+use scp_runtime::context::supervisor::Supervisor;
+use scp_runtime::crypto::mls::provider::MlsCryptoProvider;
+
+// ---------------------------------------------------------------------------
+// RecordingPersistence — the fail-on-demand persistence fixture.
+// ---------------------------------------------------------------------------
+
+/// A `ContextPersistence` that records the last durably-COMMITTED snapshot per
+/// context and can be armed to FAIL every `persist_context` write on demand.
+///
+/// - `store` holds only snapshots whose write SUCCEEDED — a durable commit.
+///   A failed (armed) `persist_context` leaves `store` untouched, mirroring a
+///   real backend where a rejected write commits nothing.
+/// - `fail` is the arming toggle. When set, `persist_context` returns `Err`
+///   WITHOUT committing.
+/// - `persist_attempts` counts every `persist_context` CALL (committed or
+///   rejected), so a test can prove the handler actually reached the
+///   fail-closed persist on the ack path rather than skipping it.
+///
+/// State lives behind `Arc` so a `clone()` handed to the `Supervisor` and the
+/// clone the test retains share one backend. Reads (`load_context`) serve
+/// whatever was last committed, so restore paths behave like a durable backend
+/// that retains committed state across a failed write.
+#[derive(Clone, Default)]
+struct RecordingPersistence {
+    store: Arc<Mutex<HashMap<String, ContextSnapshot>>>,
+    fail: Arc<AtomicBool>,
+    persist_attempts: Arc<AtomicUsize>,
+}
+
+impl RecordingPersistence {
+    fn arm_failure(&self) {
+        self.fail.store(true, Ordering::SeqCst);
+    }
+
+    /// The last DURABLY-COMMITTED snapshot for `context_id`, if any.
+    fn committed(&self, context_id: &str) -> Option<ContextSnapshot> {
+        self.store.lock().unwrap().get(context_id).cloned()
+    }
+
+    fn attempts(&self) -> usize {
+        self.persist_attempts.load(Ordering::SeqCst)
+    }
+}
+
+#[async_trait::async_trait]
+impl ContextPersistence for RecordingPersistence {
+    async fn persist_context(
+        &self,
+        context_id: &str,
+        snapshot: &ContextSnapshot,
+    ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+        self.persist_attempts.fetch_add(1, Ordering::SeqCst);
+        if self.fail.load(Ordering::SeqCst) {
+            return Err("injected persist fault (persistence_ordering fixture)".into());
+        }
+        self.store
+            .lock()
+            .unwrap()
+            .insert(context_id.to_owned(), snapshot.clone());
+        Ok(())
+    }
+
+    async fn load_context(
+        &self,
+        context_id: &str,
+    ) -> Result<Option<ContextSnapshot>, Box<dyn std::error::Error + Send + Sync>> {
+        Ok(self.store.lock().unwrap().get(context_id).cloned())
+    }
+
+    async fn delete_context(
+        &self,
+        context_id: &str,
+    ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+        self.store.lock().unwrap().remove(context_id);
+        Ok(())
+    }
+
+    async fn list_persisted_contexts(
+        &self,
+    ) -> Result<Vec<String>, Box<dyn std::error::Error + Send + Sync>> {
+        Ok(self.store.lock().unwrap().keys().cloned().collect())
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Mock providers (mirrors governance_integration.rs).
+// ---------------------------------------------------------------------------
+
+#[derive(Default)]
+struct MockTransport;
+
+#[async_trait::async_trait]
+impl ContextTransportProvider for MockTransport {
+    fn is_connected(&self) -> bool {
+        true
+    }
+    async fn publish_context(
+        &self,
+        _id: &[u8; 32],
+        _params: &ContextParams,
+    ) -> Result<(), ContextCreationError> {
+        Ok(())
+    }
+    async fn delete_published(&self, _id: &[u8; 32]) -> Result<(), ContextCreationError> {
+        Ok(())
+    }
+    async fn send_message(
+        &self,
+        _id: &[u8; 32],
+        _encrypted_payload: &[u8],
+    ) -> Result<(), ContextError> {
+        Ok(())
+    }
+}
+
+#[derive(Default)]
+struct MockEventLog;
+
+#[async_trait::async_trait]
+impl ContextEventLogProvider for MockEventLog {
+    async fn init_event_log(&self, _id: &[u8; 32]) -> Result<(), ContextCreationError> {
+        Ok(())
+    }
+    async fn append_event(
+        &self,
+        _id: &[u8; 32],
+        _event: scp_event_log::EventType,
+        _actor_did: &str,
+        _payload: scp_event_log::EventPayload,
+        _timestamp_secs: u64,
+    ) -> Result<(), ContextCreationError> {
+        Ok(())
+    }
+    async fn destroy_event_log(&self, _id: &[u8; 32]) -> Result<(), ContextCreationError> {
+        Ok(())
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Key + DID helpers (mirrors governance_integration.rs).
+// ---------------------------------------------------------------------------
+
+fn did_to_seed(did: &DID) -> [u8; 32] {
+    let mut s = [0u8; 32];
+    let bytes = did.as_ref().as_bytes();
+    for (i, b) in bytes.iter().enumerate() {
+        s[i % 32] ^= *b;
+    }
+    s
+}
+
+fn mock_key_resolver() -> KeyResolver {
+    Arc::new(|did, _kid: scp_did::SigningKeyId| {
+        let seed = did_to_seed(did);
+        Some(ed25519_dalek::SigningKey::from_bytes(&seed).verifying_key())
+    })
+}
+
+fn signing_key_for_did(did: &DID) -> ed25519_dalek::SigningKey {
+    ed25519_dalek::SigningKey::from_bytes(&did_to_seed(did))
+}
+
+fn alice() -> DID {
+    DID::from("did:dht:z6MkAlice")
+}
+fn bob() -> DID {
+    DID::from("did:dht:z6MkBob")
+}
+
+/// Ceiling carrying the capabilities the suspension flow needs: `MemberBan`
+/// (authorizes the downward-auth suspension) and `GovernanceVote` (the
+/// capability that gets suspended off `bob`).
+fn suspension_ceiling() -> Vec<Capability> {
+    vec![
+        Capability::new("messages:read"),
+        Capability::new("messages:write"),
+        Capability::new("governance:propose"),
+        Capability::GovernanceVote,
+        Capability::MemberBan,
+    ]
+}
+
+/// Builds a `Supervisor` wired to `persistence`, mirroring
+/// `scp_runtime::context::test_supervisor` but injecting the caller's
+/// persistence provider (which `test_supervisor` hardcodes to `None`).
+fn build_supervisor(persistence: RecordingPersistence) -> Arc<Supervisor> {
+    let mls_storage: Arc<dyn scp_runtime::crypto::mls::storage_adapter::OpenMlsStorageAdapter> =
+        Arc::new(
+            scp_runtime::crypto::mls::storage_adapter::SpawnBlockingStorageAdapter::new(Arc::new(
+                scp_platform::testing::InMemoryStorage::new(),
+            )),
+        );
+    Supervisor::with_providers(
+        Arc::new(MlsCryptoProvider::new(
+            "did:dht:z6MkhaXgBZDvotDkL5257faiztiGiC2QtKLGpbnnEGta2doK".to_owned(),
+            Arc::new(scp_clock::SystemClock),
+        )),
+        Box::new(MockTransport),
+        Box::new(MockEventLog),
+        mock_key_resolver(),
+        Some(Box::new(persistence)),
+        None,
+        None,
+        None,
+        mls_storage,
+    )
+}
+
+/// Creates a SingleAdmin context with `alice` as admin and inserts `bob` as a
+/// plain member, so a later `SuspendCapability { did: bob, .. }` has a target.
+/// Returns once both durable commits (create + member insert) have landed.
+async fn setup_context_with_member(supervisor: &Arc<Supervisor>, ctx_id: &str) {
+    let params = ContextParams {
+        ceiling: suspension_ceiling(),
+        governance: GovernanceModel::SingleAdmin,
+        ..ContextParams::default()
+    };
+    let handle = supervisor
+        .create_context(ctx_id.into(), params, alice(), None)
+        .await
+        .expect("create_context should succeed while persistence is healthy");
+    assert_eq!(handle.state(), ContextState::Active);
+
+    supervisor
+        .test_insert_member(ctx_id, bob(), "member")
+        .await
+        .expect("test_insert_member should succeed while persistence is healthy");
+}
+
+/// The Class-S mutation under test: suspend `bob`'s `GovernanceVote` capability
+/// via a SingleAdmin governance proposal (auto-approves + auto-executes).
+async fn suspend_bob_governance_vote(
+    supervisor: &Arc<Supervisor>,
+    ctx_id: &str,
+) -> Result<(), ContextError> {
+    let sk = signing_key_for_did(&alice());
+    let action = GovernanceAction::SuspendCapability {
+        did: bob(),
+        capabilities: vec![Capability::GovernanceVote],
+    };
+    supervisor
+        .propose_governance_action(ctx_id, &alice(), action, &sk)
+        .await
+        .map(|_| ())
+}
+
+// ---------------------------------------------------------------------------
+// Case 1: ack ⟹ durable. A Class-S mutation that acks success has already
+// committed the mutation to the persistence backend.
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn class_s_mutation_commits_durably_before_acking_success() {
+    let persistence = RecordingPersistence::default();
+    let supervisor = build_supervisor(persistence.clone());
+    let ctx_id = "ctx-persist-ordering-positive";
+
+    setup_context_with_member(&supervisor, ctx_id).await;
+
+    // Baseline: the durable snapshot does NOT yet show bob suspended.
+    let before = persistence
+        .committed(ctx_id)
+        .expect("create + insert must have committed a durable snapshot");
+    assert!(
+        before.role_state.suspended_for(bob().as_ref()).is_none(),
+        "precondition: bob must not be suspended in the durable snapshot before the op"
+    );
+
+    // The Class-S mutation, with persistence HEALTHY.
+    suspend_bob_governance_vote(&supervisor, ctx_id)
+        .await
+        .expect("suspension must succeed while persistence is healthy");
+
+    // ORDERING: because the op returned Ok, the fail-closed persist awaited on
+    // its ack path has ALREADY committed the suspension to the backend.
+    let after = persistence
+        .committed(ctx_id)
+        .expect("a committed snapshot must exist after a successful Class-S mutation");
+    let suspended = after
+        .role_state
+        .suspended_for(bob().as_ref())
+        .expect("the durable snapshot backing the ack must record bob's suspension");
+    assert!(
+        suspended.contains(&Capability::GovernanceVote),
+        "the durable snapshot must carry the exact suspended capability (GovernanceVote), got {suspended:?}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Case 2: ¬durable ⟹ ¬ack. When the fail-closed persist FAILS, the operation
+// returns Err and the mutation is NOT observable as durably committed.
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn class_s_mutation_persist_failure_fails_closed_and_withholds_durable_commit() {
+    let persistence = RecordingPersistence::default();
+    let supervisor = build_supervisor(persistence.clone());
+    let ctx_id = "ctx-persist-ordering-failclosed";
+
+    setup_context_with_member(&supervisor, ctx_id).await;
+
+    // Snapshot the durable state (bob not suspended) and the attempt count
+    // right before arming the fault.
+    let durable_before = persistence
+        .committed(ctx_id)
+        .expect("create + insert must have committed a durable snapshot");
+    assert!(
+        durable_before
+            .role_state
+            .suspended_for(bob().as_ref())
+            .is_none(),
+        "precondition: bob must not be suspended in the durable snapshot before the op"
+    );
+    let attempts_before = persistence.attempts();
+
+    // Arm the backend to reject every subsequent write.
+    persistence.arm_failure();
+
+    // The Class-S mutation now cannot achieve durability.
+    let result = suspend_bob_governance_vote(&supervisor, ctx_id).await;
+
+    // FAIL-CLOSED: the operation returns Err — success is NOT acked when the
+    // durable write fails. §9: "a persist FAILURE must FAIL-CLOSED ... never
+    // best-effort-swallow that returns Ok."
+    match result {
+        Err(ContextError::PersistenceFailed(_)) => {}
+        other => panic!(
+            "Class-S suspension must FAIL-CLOSED with PersistenceFailed when the fail-closed \
+             persist fails; got {other:?}"
+        ),
+    }
+
+    // The handler actually REACHED the fail-closed persist on the ack path
+    // (rather than short-circuiting before it): at least one persist was
+    // attempted after arming the fault.
+    assert!(
+        persistence.attempts() > attempts_before,
+        "the operation must have ATTEMPTED the fail-closed persist (attempts must increase): \
+         before={attempts_before}, after={}",
+        persistence.attempts()
+    );
+
+    // NOT OBSERVABLE AS COMMITTED: the durable backend holds no committed
+    // snapshot recording bob's suspension — the last durable commit is
+    // unchanged from before the op. The in-memory mutation may persist
+    // (keep-direction), but it was NEVER acknowledged as durable, so a respawn
+    // from the durable snapshot would not see it.
+    let durable_after = persistence
+        .committed(ctx_id)
+        .expect("the pre-op committed snapshot must still be the durable state");
+    assert!(
+        durable_after
+            .role_state
+            .suspended_for(bob().as_ref())
+            .is_none(),
+        "the failed Class-S mutation must NOT be observable as durably committed: \
+         no committed snapshot may record bob's suspension"
+    );
+}


### PR DESCRIPTION
## What
Adds the three test targets ADR-049's **Verification** section + **Decision 14** mandate but that never existed (only `shuttle_actor` did). Audit finding **A5**. These are the guardrail net for the upcoming state-move / coalesced-persistence migration.

| Target | Grounds | What it drives |
|---|---|---|
| `persistence_ordering` | §9 fail-closed (durable BEFORE ack) | Real `Supervisor` dispatch + a fail-injecting `ContextPersistence`; asserts `ack ⟹ durable` and `¬durable ⟹ ¬ack` |
| `cancel_safety` | Decision 8 (RAII / cancellation) | A saga future cancelled in-flight releases its participant-context-set reservation (real `Supervisor` path) + `SequenceReservation` async-drop witnesses |
| `perf_baseline` | Decision 14 (perf rollback trigger) | Six ops × N=1/4/16 over **real MLS nodes** (`FullStackNetwork`), p50 |

## Notes for review
- **perf_baseline is record-only by default** (measures + records + passes — CI-safe on any hardware). The >15% regression gate is **opt-in** via `SCP_PERF_GATE=1`, for a deliberate same-environment before/after comparison (Decision 14's intent). The per-environment baseline JSON is **git-ignored, never committed** (avoids machine-specific false-positives).
- **`scp-testing` is a `[dev-dependencies]` edge only** — needed for `perf_baseline`'s two-node harness (`deliver_incoming` requires a real second MLS member). Verified inert w.r.t. the "forge" chain: `cargo build -p scp-runtime` does **not** pull scp-testing; the guard is about `testing`-feature leakage into FFI/production builds, which dev-deps don't touch.
- **cancel_safety honesty note:** the real send handler commits its sequence synchronously (no await between reserve/commit) and is block-until-terminal, so it is *not* a drop-on-cancel target — the test documents this and covers the genuine cancel-safety case (saga context-set release) rather than faking a send-path rollback.
- All three gated via `[[test]] required-features=["testing"]`. Each case proven non-tautological by transient assertion-inversion. Test-quality reviewed. No production code changed.

## Verify
- `cargo fmt -p scp-runtime --check` — clean
- `cargo clippy -p scp-runtime --test perf_baseline --test cancel_safety --test persistence_ordering --features testing -D warnings` — clean
- `cargo test -p scp-runtime --test perf_baseline --test cancel_safety --test persistence_ordering --features testing` — **6 passed** (3+1+2)
- `cargo build -p scp-runtime` (no features) — succeeds, scp-testing not pulled

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ja9JLEZrZFZ2jdFEejM9Es