### PR TITLE
fix(clippy): resolve rust-1.97.0 lint regressions blocking the CI gate

### DIFF
--- a/crates/scp-ffi/src/tools.rs
+++ b/crates/scp-ffi/src/tools.rs
@@ -711,7 +711,7 @@ fn extract_cost(
 
     let cost_formula: Option<String> = dict
         .get_item("cost_formula")?
-        .and_then(|v| if v.is_none() { None } else { Some(v) })
+        .filter(|v| !v.is_none())
         .map(|v| v.extract())
         .transpose()?;
 

--- a/crates/scp-protocol/src/uri.rs
+++ b/crates/scp-protocol/src/uri.rs
@@ -202,12 +202,9 @@ fn parse_query_params(query: &str) -> Vec<(String, String)> {
         .split('&')
         .filter(|pair| !pair.is_empty())
         .filter_map(|pair| {
-            let (key, value) = if let Some(eq_pos) = pair.find('=') {
-                (&pair[..eq_pos], &pair[eq_pos + 1..])
-            } else {
-                // Parameters without values are ignored.
-                return None;
-            };
+            // Parameters without values are ignored.
+            let eq_pos = pair.find('=')?;
+            let (key, value) = (&pair[..eq_pos], &pair[eq_pos + 1..]);
             let decoded_key = percent_decode_str(key).decode_utf8_lossy().into_owned();
             let decoded_value = percent_decode_str(value).decode_utf8_lossy().into_owned();
             Some((decoded_key, decoded_value))

--- a/crates/scp-testing/tests/integration/fullstack.rs
+++ b/crates/scp-testing/tests/integration/fullstack.rs
@@ -864,7 +864,7 @@ async fn full_stack_relay_encrypted_roundtrip() {
     assert_eq!(blob_id.as_bytes().len(), 32, "blob_id must be 32 bytes");
     println!(
         "  [6] Published to relay (blob_id: {}...)",
-        &hex::encode(&blob_id.as_bytes()[..8])
+        hex::encode(&blob_id.as_bytes()[..8])
     );
 
     // 7. Bob receives envelope from the relay.


### PR DESCRIPTION
## Problem

The CI stable toolchain (`dtolnay/rust-toolchain@stable`) advanced to **rust-1.97.0**, which tightened three clippy lints against **preexisting** code. Under `-D warnings` this fails the `Rust / clippy` gate on **every** PR built after the bump — `main`'s last green CI run predates the bump, so it is "green" only by not having been re-tested. Currently blocking at least #2075 and #2077 (and any new PR).

## Fixes (mechanical, no behavior change)

| Lint | File | Fix |
|------|------|-----|
| `clippy::question_mark` | `scp-protocol/src/uri.rs:205` | if-let-else-`return None` → `?` in the query-param `filter_map` closure |
| `clippy::manual_filter` | `scp-ffi/src/tools.rs:714` | `and_then(\|v\| if v.is_none() { None } else { Some(v) })` → `.filter(\|v\| !v.is_none())` |
| `clippy::useless_borrows_in_formatting` | `scp-testing/tests/integration/fullstack.rs:867` | drop redundant `&` on a `hex::encode(..)` `println!` arg |

All three predate this branch (`uri.rs` is from the scp-protocol extraction #1570); none is introduced here.

## Verification

Reproduced CI exactly by installing rust-1.97.0 locally and running the full gate command:

```
cargo clippy --workspace --all-targets \
  --features scp-ffi-uniffi/allow_in_memory_custody,scp-ffi/allow_in_memory_custody,\
scp-ffi-napi/allow_in_memory_custody,scp-core/testing,scp-runtime/testing \
  -- -D warnings
```

→ **exit 0** (clean). `cargo fmt --all --check` clean.

Once merged, #2075 and #2077 rebase onto this and their `Rust / clippy` + `ci` checks go green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)