### PR TITLE
test(ffi): de-flake shutdown_core_async_counts_panicked_tasks (timer-free clean task)

### DIFF
--- a/crates/scp-ffi/common/src/bridge_instance.rs
+++ b/crates/scp-ffi/common/src/bridge_instance.rs
@@ -4603,7 +4603,21 @@ mod tests {
             });
             tasks.spawn(async move {
                 // This one exits cleanly — must not be counted as panicked.
-                tokio::time::sleep(Duration::from_millis(1)).await;
+                //
+                // Uses `yield_now()` (one scheduler round-trip, then a clean
+                // exit) rather than a real-time `sleep`. A `sleep` here made
+                // the test flaky: the clean task then had to wait on the timer
+                // wheel to complete, and `drain_under_deadline` gates the
+                // outcome on a wall-clock deadline. Under CI scheduler
+                // starvation the drain could lose that race, flipping the
+                // outcome from `GracefulWithin` to `TimedOut` and blowing the
+                // `unreachable!` below — even though the panicked count itself
+                // is always correct. `yield_now()` completes without ever
+                // touching the timer wheel, so the drain finishes in a couple
+                // of poll cycles and never approaches the (generous) deadline,
+                // making the `GracefulWithin` outcome deterministic while still
+                // exercising a genuine clean-exit task the drain must not count.
+                tokio::task::yield_now().await;
             });
         }
         let outcome = instance


### PR DESCRIPTION
Closes #2085.

## Root cause (test synchronization — not a production bug)

`shutdown_core_async_counts_panicked_tasks` spawned a "clean exit" task that awaited a real-time `tokio::time::sleep(1ms)`. Completing it required the **timer wheel** to fire. `drain_under_deadline` gates its outcome (`GracefulWithin` vs `TimedOut`) on a wall-clock deadline, so under CI scheduler starvation the drain could still be `Pending` at the deadline, flipping `GracefulWithin` → `TimedOut` and tripping the test's `else { unreachable!() }` → `0 passed; 1 failed`.

Empirically confirmed with a temporary in-process stress harness: under a tight deadline the outcome flipped ~22% of the time, but **`panicked_tasks` was always exactly 2 whenever the outcome was `GracefulWithin`** — i.e. the production counting logic in `shutdown_core_async` is deterministic and correct; only the test's clean-task timing raced. Production code is **not** touched.

This matters operationally: the merge queue re-runs the full test suite on every merge-group commit, so this flake could spuriously eject unrelated PRs.

## Fix

Replace the clean task's `sleep(1ms)` with `tokio::task::yield_now().await` — it reaches terminal state in one scheduler round-trip without touching the timer wheel, so the drain finishes in a couple of poll cycles and never approaches the (generous 2s) deadline. The `GracefulWithin` outcome is now deterministic.

- Assertion `panicked_tasks == 2` unchanged; the clean-task-not-counted check preserved (still a genuine async task the drain joins as `Ok`).
- No retries, no assertion loosening, no bare `sleep`.

## Verification (rust-1.97.0)
- 250/250 consecutive passes under 1.5× CPU saturation.
- Full `bridge_instance::tests` module: 91 passed, 0 failed.
- `cargo clippy -p scp-ffi-common --all-targets -D warnings` clean; `cargo fmt --all --check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)