### PR TITLE
fix(actor): mark Class-C class_c_view mutations durable via Outcome.mutated (ADR-049 N1, PR-2)

### DIFF
--- a/crates/scp-runtime/src/context/actor/handlers/messaging.rs
+++ b/crates/scp-runtime/src/context/actor/handlers/messaging.rs
@@ -197,8 +197,19 @@ fn handle_seed_peer_pseudonym(
             Ok(())
         },
     );
+    // ADR-049 §Decision 9 / finding N1: the peer-registry insert is a coalesced
+    // Class-C mutation with NO co-located persist — its durability rides ENTIRELY
+    // on the run loop marking itself dirty from this handler's `mutated` flag. A
+    // successful insert therefore MUST report `ok_mutated`, else a ≤50 ms crash
+    // silently loses the seeded pseudonym. The reject arm
+    // (`NotPseudonymousContext`, a broadcast context with no peer registry) never
+    // touched the view, so it reports `err` (unmutated).
+    let outcome = match &result {
+        Ok(()) => Outcome::ok_mutated(()),
+        Err(e) => Outcome::err(outcome_error_sketch(e)),
+    };
     let _ = reply.send(result);
-    Outcome::ok(())
+    outcome
 }
 
 /// Handle [`MessagingCommand::TestInsertMember`] (actor-shape, test-only).
@@ -223,8 +234,16 @@ fn handle_test_insert_member(
     // add all route through the non-persisting `class_c_view`. A member ADD is a
     // coalesce-window-rollback-acceptable structural change (ADR-049 §9), not a
     // downward-auth GROW, so it needs no fail-closed Class-S persist.
+    // Pre-mutation gate: an inactive context rejects BEFORE any `class_c_view`
+    // write, so nothing was mutated (`err`, mutated:false). Split OUT of the
+    // closure below so this clean reject is distinguishable from a post-mutation
+    // failure.
+    if let Err(e) = crate::context::state::require_active(&cell.handle) {
+        let sketch = outcome_error_sketch(&e);
+        let _ = reply.send(Err(e));
+        return Outcome::err(sketch);
+    }
     let result = (|| {
-        crate::context::state::require_active(&cell.handle)?;
         let tokens = {
             let mut view = cell.class_c_view();
             let mut role_state = view.role_state_class_c_mut();
@@ -240,8 +259,20 @@ fn handle_test_insert_member(
         );
         Ok(())
     })();
+    // ADR-049 §Decision 9 / finding N1: the roster insert, role assignment, and
+    // membership add are coalesced Class-C mutations with NO co-located persist —
+    // durability rides on this handler's `mutated` flag. A `mutated:false` here
+    // silently lost the inserted member on a ≤50 ms crash. The `members_mut()`
+    // insert lands BEFORE the only fallible step (`system_assign_role`), so ANY
+    // error out of the closure is a PARTIAL mutation → `err_mutated` (persist the
+    // partial state so the coalesced flush keeps the snapshot in sync); success →
+    // `ok_mutated` so the member + role survive respawn.
+    let outcome = match &result {
+        Ok(()) => Outcome::ok_mutated(()),
+        Err(e) => Outcome::err_mutated(outcome_error_sketch(e)),
+    };
     let _ = reply.send(result);
-    Outcome::ok(())
+    outcome
 }
 
 /// Handle [`MessagingCommand::TestInstallAccessKey`] (actor-shape, test-only).

--- a/crates/scp-runtime/src/context/actor/handlers/saga.rs
+++ b/crates/scp-runtime/src/context/actor/handlers/saga.rs
@@ -934,10 +934,16 @@ async fn prepare_b(
     //     window increment is persisted by the SUBSEQUENT staging combinator (one
     //     persist covers window + nonce + slot). It runs AFTER the read-only
     //     rejects (a rejected call never consumes the budget) but BEFORE the
-    //     staging combinator, so a clean over-budget reject here surfaces as
-    //     `Outcome::err` (no slot staged), DISTINCT from a later persist failure's
-    //     `Outcome::err_mutated`. The over-budget / over-ceiling reject paths do
-    //     NOT mutate (no increment), so an un-persisted `Outcome::err` is correct.
+    //     staging combinator, so a clean reject here surfaces as `Outcome::err`
+    //     (no slot staged), DISTINCT from a later persist failure's
+    //     `Outcome::err_mutated`. The over-CEILING reject (13027) returns BEFORE
+    //     window materialization, so it makes no mutation at all. The over-BUDGET
+    //     reject (13026) DOES touch Class-C — it lazily materializes the inbound
+    //     window and `check_and_increment` may roll its counter — but only
+    //     idempotent, wall-clock-re-derivable state (deterministically rebuilt from
+    //     the inbound policy + clock on the next call), never a durable increment of
+    //     admitted volume. So an un-persisted `Outcome::err` is correct: the ≤50ms
+    //     coalesce-window rollback re-derives the identical window on the retry.
     if let Err(rej) =
         consume_inbound_interface_rate_limit(cell.class_c_view(), deps, &req.tool_registration_id)
     {
@@ -2011,14 +2017,15 @@ async fn commit_a(
         // Commit-A, refunding against the new instance's owned state would
         // corrupt the WRONG context. On a mismatch the helper voids only the
         // external escrow and consumes the ticket (mirrors `settle_tool_economy`).
-        crate::context::tools_helpers::rollback_tool_economy_generation_checked(
-            cell.class_c_view(),
-            deps,
-            req.reservation.reservation.generation,
-            req.reservation.reservation.ticket,
-        )
-        .await;
-        // ── COMMIT-A-REPLAY (idempotent Class-S remove, NO persist — SECURITY) ───
+        let class_c_economy_reversed =
+            crate::context::tools_helpers::rollback_tool_economy_generation_checked(
+                cell.class_c_view(),
+                deps,
+                req.reservation.reservation.generation,
+                req.reservation.reservation.ticket,
+            )
+            .await;
+        // ── COMMIT-A-REPLAY (idempotent Class-S remove, NO fail-closed persist — SECURITY) ───
         // The durable reversal record (if still present) was consumed at the
         // FIRST Commit-A; remove any straggler so it cannot reverse settled
         // state. A removal here is rare (the first Commit-A already removed it),
@@ -2033,7 +2040,25 @@ async fn commit_a(
         // rebuilt-irrelevant on respawn. It can never widen to a closure form.
         let _ = cell.clear_committed_reservation_idempotent(&req.saga_id);
         let _ = reply.send(Ok(()));
-        return Outcome::ok(());
+        // ADR-049 §Decision 9 / finding N1: on a GENERATION MATCH the
+        // generation-checked rollback above reversed Class-C economy bookkeeping
+        // (velocity / budget / hard-rate refund) through the non-persisting
+        // `class_c_view`, so its durability rides this handler's `mutated` flag —
+        // report `ok_mutated` to mark the actor dirty for the ordinary COALESCED
+        // best-effort persist. That is NOT the fail-closed write the Class-S
+        // straggler removal above deliberately rules out; a coalesced persist keeps
+        // this idempotent `Ok` re-ack infallible while still making the Class-C
+        // reversal durable. This branch is guarded-unreachable in today's FSM (a
+        // committed Commit-A leaves `prepared_a == None`, so a live reservation is
+        // not re-delivered on the same generation), but marking `mutated` keeps the
+        // handler correct-by-construction if that ever changes. On a generation
+        // MISMATCH the helper voided only external escrow and touched no Class-C
+        // field, so nothing local changed → `ok` (unmutated).
+        return if class_c_economy_reversed {
+            Outcome::ok_mutated(())
+        } else {
+            Outcome::ok(())
+        };
     }
 
     // Settle (capture) the escrow + outbound rate-limit reservation. The

--- a/crates/scp-runtime/src/context/actor/handlers/tools.rs
+++ b/crates/scp-runtime/src/context/actor/handlers/tools.rs
@@ -118,17 +118,16 @@ async fn handle_try_consume_hard_rate_limit(
 
     let (outcome, reply_result) = match tokio::time::timeout(HANDLER_TIMEOUT, consume_fut).await {
         Ok(consumed) => {
-            // `consumed == true` ⇒ token taken from the bucket OR the
-            // context is unknown (legacy pass-through contract). Both
-            // cases mutate observable state iff the context was known,
-            // so flag `ok_mutated` to be safe: a successful `true` on
-            // a known context is the dominant path.
-            let outcome = if consumed {
-                Outcome::ok_mutated(())
-            } else {
-                Outcome::ok(())
-            };
-            (outcome, Ok(consumed))
+            // `try_consume` writes Class-C on BOTH branches: a `true` consume
+            // debits the bucket; a `false` DENY still lazily materializes the
+            // limiter window and advances `last_refill` (a token refill). Both
+            // writes are idempotently re-derivable from the persisted anchor + the
+            // wall clock (never a loss, never fail-open), so the deny branch is
+            // durability-SAFE regardless of the flag. We still report `ok_mutated`
+            // UNCONDITIONALLY — mirroring `prepare_a`'s defensive reject posture —
+            // so the coalesced flush captures the refill write and a future audit
+            // does not re-flag the deny branch as a `mutated:false` Class-C site.
+            (Outcome::ok_mutated(()), Ok(consumed))
         }
         Err(_elapsed) => {
             let err = ContextError::TransportTimeout(format!(

--- a/crates/scp-runtime/src/context/actor/mod.rs
+++ b/crates/scp-runtime/src/context/actor/mod.rs
@@ -1258,4 +1258,161 @@ mod tests {
         handle.send_shutdown().await.expect("shutdown acks");
         actor_task.await.expect("actor task joins");
     }
+
+    /// Regression guard for ADR-049 finding **N1** (PR-2 caller audit): a handler
+    /// that mutates Class-C via `class_c_view()` but reports `Outcome::ok`
+    /// (`mutated:false`) leaves `dirty` clear, so the run loop's Arm-4 coalesce
+    /// tick never fires and the mutation is lost on crash.
+    ///
+    /// `SeedPeerPseudonym` was exactly such a handler: it records a peer routing
+    /// pseudonym into the `Pseudonymous` registry through `class_c_view()` (NO
+    /// co-located persist) and used to return `Outcome::ok`. The PR-2 fix makes it
+    /// report `Outcome::ok_mutated` on a successful insert.
+    ///
+    /// This uses the **coalesce-tick** model (like
+    /// [`coalesced_class_c_mutation_is_durable_across_coalesce_tick`]), NOT a
+    /// shutdown drain: the drain cannot validate a handler's `mutated` flag,
+    /// because the `Shutdown` handler ITSELF reports `mutated` and dirties the
+    /// actor, so the drain fires (persisting the whole live state, which already
+    /// carries the in-memory insert) regardless of the seed handler's flag. Here
+    /// the assertion runs while the actor is STILL LIVE, off the Arm-4 tick that
+    /// fires only when `dirty` is set — so with the pre-fix `Outcome::ok` handler
+    /// `dirty` stays false, the tick never fires, and `persisted.notified()` times
+    /// out in bounded virtual time (a genuine failure, empirically verified).
+    #[cfg(feature = "testing")]
+    #[tokio::test]
+    async fn coalesced_seed_peer_pseudonym_is_durable_across_coalesce_tick() {
+        let recorder = RecordingPersistence::new();
+        let deps = new_test_deps_with_persistence(Box::new(recorder.clone())).await;
+        // Pause AFTER building deps so `build_actor_deps` runs under real time and
+        // the actor's `last_persisted_at` is captured against the now-frozen clock.
+        tokio::time::pause();
+        let ctx = ctx_hex(0x53);
+        let member = "did:example:coalesced-seed-peer-member";
+        let pseudonym = [0x77u8; 32];
+        let state = writable_encrypted_state(0x53, member);
+
+        let (tx, rx) = mpsc::channel::<ContextCommand>(4);
+        let actor = ContextActor::new(state, deps, rx);
+        let actor_task = tokio::spawn(actor.run());
+        let handle = ContextActorHandle::from_sender(tx);
+
+        // Record a peer pseudonym — a coalesced Class-C mutation with NO co-located
+        // persist (routes through `class_c_view`). Awaiting the reply also proves
+        // the live in-memory insert succeeded.
+        handle
+            .send(|reply| {
+                ContextCommand::Messaging(MessagingCommand::SeedPeerPseudonym {
+                    context_id: ctx.clone(),
+                    member_did: scp_did::DID(member.to_owned()),
+                    pseudonym,
+                    reply,
+                })
+            })
+            .await
+            .expect("seed-peer-pseudonym round-trips through the state-owning actor");
+
+        // Advance past the coalescing window so Arm-4 fires while the actor is still
+        // running (NO shutdown/drain). With the pre-fix `Outcome::ok` handler
+        // `dirty` stays false, Arm-4 never fires, and this `notified()` times out.
+        tokio::time::advance(COALESCE_INTERVAL + std::time::Duration::from_millis(1)).await;
+        tokio::time::timeout(COALESCE_INTERVAL * 20, recorder.persisted.notified())
+            .await
+            .expect("Arm-4 coalesce tick must persist the seeded pseudonym within the window");
+
+        let snapshot = recorder
+            .last_snapshot()
+            .expect("the coalesce tick must have persisted a snapshot (ADR-049 §Decision 9 / N1)");
+        let registry = snapshot
+            .routing
+            .peer_registry()
+            .expect("the encrypted test context must persist a Pseudonymous peer registry");
+        assert_eq!(
+            registry.get(&scp_did::DID(member.to_owned())),
+            Some(&pseudonym),
+            "the coalesced peer-pseudonym mutation must be durable after the Arm-4 tick",
+        );
+
+        handle.send_shutdown().await.expect("shutdown acks");
+        actor_task.await.expect("actor task joins");
+    }
+
+    /// Regression guard for ADR-049 finding **N1** (PR-2): `TestInsertMember`
+    /// records a member — roster insert, `system_assign_role`, and membership add —
+    /// through `class_c_view()` with NO co-located persist, and used to return
+    /// `Outcome::ok` (`mutated:false`), so a `<=50ms` crash silently lost the
+    /// member. The PR-2 fix reports `Outcome::ok_mutated` on a successful insert.
+    ///
+    /// Same **coalesce-tick** model as the sibling pseudonym test (the assertion
+    /// runs while the actor is live, so the shutdown drain cannot mask a false
+    /// flag): with the pre-fix `Outcome::ok` handler `dirty` stays false, Arm-4
+    /// never fires, and `persisted.notified()` times out (empirically verified).
+    #[cfg(feature = "testing")]
+    #[tokio::test]
+    async fn coalesced_test_insert_member_is_durable_across_coalesce_tick() {
+        use scp_protocol::context::roles::{builtin_roles, default_ceiling};
+
+        let recorder = RecordingPersistence::new();
+        let deps = new_test_deps_with_persistence(Box::new(recorder.clone())).await;
+        tokio::time::pause();
+        let ctx = ctx_hex(0x54);
+        let admin = "did:example:coalesced-insert-admin";
+        let new_member = "did:example:coalesced-insert-member";
+        let mut state = writable_encrypted_state(0x54, admin);
+        // `TestInsertMember` calls `system_assign_role("member")`, which requires
+        // that role to be DEFINED within the context ceiling. The bare test fixture
+        // starts with an empty ceiling / no role definitions, so seed the standard
+        // ceiling + built-in roles (the same "member" role a real `create_context`
+        // installs) before driving the insert.
+        let ceiling = default_ceiling();
+        state
+            .role_state
+            .set_ceiling(ceiling.clone())
+            .expect("seed the default ceiling for the member role definition");
+        for role in builtin_roles(&ceiling) {
+            state
+                .role_state
+                .role_definitions
+                .insert(role.name.clone(), role);
+        }
+
+        let (tx, rx) = mpsc::channel::<ContextCommand>(4);
+        let actor = ContextActor::new(state, deps, rx);
+        let actor_task = tokio::spawn(actor.run());
+        let handle = ContextActorHandle::from_sender(tx);
+
+        // Insert a second member — a coalesced Class-C structural mutation with NO
+        // co-located persist. Awaiting the reply proves the live insert succeeded.
+        handle
+            .send(|reply| {
+                ContextCommand::Messaging(MessagingCommand::TestInsertMember {
+                    context_id: ctx.clone(),
+                    member_did: scp_did::DID(new_member.to_owned()),
+                    role: "member".to_owned(),
+                    reply,
+                })
+            })
+            .await
+            .expect("test-insert-member round-trips through the state-owning actor");
+
+        tokio::time::advance(COALESCE_INTERVAL + std::time::Duration::from_millis(1)).await;
+        tokio::time::timeout(COALESCE_INTERVAL * 20, recorder.persisted.notified())
+            .await
+            .expect("Arm-4 coalesce tick must persist the inserted member within the window");
+
+        let snapshot = recorder
+            .last_snapshot()
+            .expect("the coalesce tick must have persisted a snapshot (ADR-049 §Decision 9 / N1)");
+        assert!(
+            snapshot.role_state.members.contains(new_member),
+            "the coalesced role-state member insert must be durable after the Arm-4 tick",
+        );
+        assert!(
+            snapshot.membership.contains(new_member),
+            "the coalesced membership add must be durable after the Arm-4 tick",
+        );
+
+        handle.send_shutdown().await.expect("shutdown acks");
+        actor_task.await.expect("actor task joins");
+    }
 }


### PR DESCRIPTION
## What & why

PR-2 of the ADR-049 state-move remediation (finding **N1**). PR-1 (#2084) made the actor's coalesced Class-C persist real, keyed on the `dirty` flag set from each handler's `Outcome.mutated`. This PR fixes handlers that mutated Class-C state via `class_c_view()` but returned `mutated:false` — so their writes never set `dirty` and were **lost on crash** even after PR-1.

## The 3 durability fixes
- **`handle_seed_peer_pseudonym`** (messaging.rs): peer-registry insert now `ok_mutated` on the write path; `err` (unmutated) only on the pre-mutation `NotPseudonymousContext` reject.
- **`handle_test_insert_member`** (messaging.rs): `require_active` hoisted to a pre-mutation `err`; the insert-then-`system_assign_role` path returns `ok_mutated` / `err_mutated` (partial mutation must persist).
- **`commit_a` COMMIT-A-REPLAY** (saga.rs): `ok_mutated` iff `rollback_tool_economy_generation_checked` reports a generation-MATCH reversal (Class-C economy touched); gen-MISMATCH (external-void only) stays `ok`.

## Audit
Enumerated every non-test `class_c_view()` caller (~28 return-decision sites across the handler layer); all others already report `mutated:true` or return `mutated:false` only on pre-mutation / idempotent-wall-clock-re-derivation paths. Bucket (c) (Class-S laundered through class_c_view) is empty by the Decision-9 compile boundary. Boundary-respected: `broadcast.rs`/`commands.rs` (concurrent B2 change) untouched and independently verified clean.

Defense-in-depth: `handle_try_consume_hard_rate_limit` deny branch now returns `ok_mutated` (its refill write is idempotently re-derivable — durability-safe either way, marked for consistency).

## Tests (reviewed to double-zero)
Two durability regression tests on the **coalesce-tick model** — `coalesced_{seed_peer_pseudonym,test_insert_member}_is_durable_across_coalesce_tick`. A review caught that a final-drain-triggered test is a *false guard* (the Shutdown handler itself sets `dirty`, so the drain always fires regardless of the handler under test); these fire the Arm-4 coalesce tick *while the actor runs*, so only the handler's own `mutated` flag can trigger the persist. **Empirically proven**: reverting either handler to `Outcome::ok` makes its test fail with a bounded-timeout `Elapsed`, not pass.

## Verification
`cargo clippy` (rust-1.97.0, `-D warnings`) clean; `cargo fmt --all --check` clean; full lib suite **1906 passed, 0 failed**; Class-S enforcement + `persistence_ordering` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)