### PR TITLE
docs(runtime): correct handler-dispatch signature descriptions

### DIFF
--- a/crates/scp-runtime/src/context/README.md
+++ b/crates/scp-runtime/src/context/README.md
@@ -81,10 +81,12 @@ through `SupervisorHandle::start_saga` (see the saga coordinator).
 - `handlers/` — one module per command domain (`governance.rs`,
   `lifecycle.rs`, `messaging.rs`, `broadcast.rs`, `economy.rs`,
   `trust_recovery.rs`, `standing.rs`, `ttl_close.rs`, `tools.rs`,
-  `queries.rs`, `saga.rs`, `lifecycle_control.rs`). Each exposes a `dispatch`
+  `queries.rs`, `saga.rs`, `lifecycle_control.rs`). Most expose a `dispatch`
   taking `(&mut ClassSCell, &ActorDeps, SubCommand) -> Outcome<()>` — Class-S
   mutation flows through the cell's combinators, never a bare
-  `&mut PerContextState`.
+  `&mut PerContextState`. A few read-only domains (e.g. `standing`) take only
+  `(&ActorDeps, cmd) -> Outcome<()>`: they never mutate `PerContextState`, so
+  no `ClassSCell` is threaded through them.
 
 ### `*_helpers.rs` — domain logic bodies
 

--- a/crates/scp-runtime/src/context/actor/handlers/governance.rs
+++ b/crates/scp-runtime/src/context/actor/handlers/governance.rs
@@ -5,7 +5,7 @@
 //! # Dispatch shape
 //!
 //! The actor's `run()` loop invokes [`dispatch`] with `(&mut
-//! PerContextState, &ActorDeps, GovernanceCommand)`. Every governance
+//! ClassSCell, &ActorDeps, GovernanceCommand) -> Outcome<()>`. Every governance
 //! variant has an actor-shape handler (`handle_*_actor`) that reads
 //! and mutates `state.governance` directly through the actor-shape
 //! helpers in
@@ -54,7 +54,7 @@ pub const HANDLER_TIMEOUT: Duration = Duration::from_secs(30);
 ///
 /// Plan-conforming dispatch signature: matches the post-refactor actor
 /// `run()` loop's call shape
-/// (`handlers::governance::dispatch(state, deps, cmd).await`).
+/// (`handlers::governance::dispatch(cell, deps, cmd).await`).
 ///
 /// Every variant routes through an actor-shape `handle_*_actor` helper
 /// that reads or mutates `state.governance` directly through


### PR DESCRIPTION
Fix-forward for one imprecision a retroactive review found in #2095, plus a pre-existing stale doc-comment.

- `context/README.md`: "Each handler exposes a `dispatch` taking `(&mut ClassSCell, …)`" over-generalized — the read-only `standing` handler takes only `(&ActorDeps, cmd) -> Outcome<()>` (verified at `handlers/standing.rs:38`; it never mutates `PerContextState`). Reworded to "Most … a few read-only domains (e.g. `standing`) take only …".
- `handlers/governance.rs` module + fn doc-comments: stale `(&mut PerContextState, …)` → the real `(&mut ClassSCell, &ActorDeps, GovernanceCommand) -> Outcome<()>` (verified at `handlers/governance.rs:65`), and the fn's call-shape example `dispatch(state, …)` → `dispatch(cell, …)`.

Docs/comments only; `cargo check -p scp-runtime` clean, `cargo fmt --check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)