### PR TITLE
fix(outlet): follow-up cleanup — live domain-uniqueness entry + PRD story prose rename

### DIFF
--- a/.docs/prds/main.json
+++ b/.docs/prds/main.json
@@ -1386,7 +1386,7 @@
         "`ContextState` enum with variants: `Creating`, `Active`, `Closing`, `Closed`, `Expired` — derives Debug, Clone, PartialEq, Eq, Serialize, Deserialize",
         "Valid transitions enforced: `Creating -> Active` (MLS group formed, initial parameters committed, context published), `Active -> Closing` (close initiated by admin or close-capable role), `Active -> Expired` (TTL elapsed, automatic, no governance override), `Closing -> Closed` (all members processed final events, summary generated if applicable, keys destroyed)",
         "Invalid transitions return error: `Closed -> *` (terminal), `Expired -> *` (terminal), `Creating -> Closing` (never active, just drop), `Closing -> Active` (no re-opening)",
-        "`ContextParams` struct with fields: mode (ContextMode), ceiling (Vec<Capability>), ceiling_policy (CeilingPolicy), promotion_policy (PromotionPolicy), roles (Vec<RoleDefinition>), tools (Vec<OutletRegistration>), ttl (Option<Duration>), memory_scope (MemoryScope), governance (GovernanceModel), template_id (Option<TemplateId>)",
+        "`ContextParams` struct with fields: mode (ContextMode), ceiling (Vec<Capability>), ceiling_policy (CeilingPolicy), promotion_policy (PromotionPolicy), roles (Vec<RoleDefinition>), outlets (Vec<OutletRegistration>), ttl (Option<Duration>), memory_scope (MemoryScope), governance (GovernanceModel), template_id (Option<TemplateId>)",
         "`CeilingPolicy` enum: `Immutable` (default, ceiling fixed at creation, any attempt to modify returns `ContextError::CeilingImmutable`), `Governed` (ceiling can be modified through governance, can only be narrowed never expanded beyond original creation ceiling)",
         "`PromotionPolicy` enum: `NoPromotion` (context cannot be promoted, immutable lifecycle constraints), `Promotable` (context can be promoted through governance approval)",
         "`ContextMode` enum: `Encrypted` (MLS-backed, sender-side keys, full forward secrecy, default), `Broadcast` (per-author broadcast keys, no MLS, mandatory subscriber registration §5.14) — immutable after creation",
@@ -1423,7 +1423,7 @@
       ],
       "details": {
         "State machine definition": "```rust\n#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]\npub enum ContextState {\n    Creating,\n    Active,\n    Closing,\n    Closed,\n    Expired,\n}\n```\n\nValid transitions:\n- `Creating -> Active` — MLS group formed, initial parameters committed, context published.\n- `Active -> Closing` — Close initiated by admin (governance) or close-capable role.\n- `Active -> Expired` — TTL elapsed. Automatic. No governance override.\n- `Closing -> Closed` — All members processed final events, summary generated (if applicable), keys destroyed.\n\nInvalid transitions (must return error):\n- `Closed -> *` (terminal)\n- `Expired -> *` (terminal)\n- `Creating -> Closing` (never active, just drop)\n- `Closing -> Active` (no re-opening)",
-        "ContextParams struct": "```rust\npub struct ContextParams {\n    pub mode: ContextMode,\n    pub ceiling: Vec<Capability>,\n    pub ceiling_policy: CeilingPolicy,\n    pub promotion_policy: PromotionPolicy,\n    pub roles: Vec<RoleDefinition>,\n    pub tools: Vec<OutletRegistration>,\n    pub ttl: Option<Duration>,\n    pub memory_scope: MemoryScope,\n    pub governance: GovernanceModel,\n    pub template_id: Option<TemplateId>,\n}\n```",
+        "ContextParams struct": "```rust\npub struct ContextParams {\n    pub mode: ContextMode,\n    pub ceiling: Vec<Capability>,\n    pub ceiling_policy: CeilingPolicy,\n    pub promotion_policy: PromotionPolicy,\n    pub roles: Vec<RoleDefinition>,\n    pub outlets: Vec<OutletRegistration>,\n    pub ttl: Option<Duration>,\n    pub memory_scope: MemoryScope,\n    pub governance: GovernanceModel,\n    pub template_id: Option<TemplateId>,\n}\n```",
         "CeilingPolicy enum": "```rust\npub enum CeilingPolicy {\n    Immutable,\n    Governed,\n}\n```\nImmutable: Ceiling is fixed at creation. Any attempt to modify returns `ContextError::CeilingImmutable`. Default and security-conservative choice.\nGoverned: Ceiling can be modified through governance model. Can only be narrowed (capabilities removed), never expanded beyond the original creation ceiling.",
         "PromotionPolicy enum": "```rust\npub enum PromotionPolicy {\n    NoPromotion,\n    Promotable,\n}\n```",
         "ContextMode enum": "```rust\npub enum ContextMode {\n    Encrypted,\n    Broadcast,\n}\n```\nEncrypted: MLS-backed, sender-side keys, full forward secrecy (default).\nBroadcast: Per-author broadcast keys, no MLS, mandatory subscriber registration (§5.14).",
@@ -1448,7 +1448,7 @@
       "description": "Implement `create_context(params: ContextParams) -> Result<ContextHandle, ContextError>` with a two-phase commit pattern: validate all preconditions (no side effects), then execute with ordered rollback on failure. Each step records its completion in a `CreationReceipt` struct. On failure at any step, all previously completed steps are rolled back in reverse order. After a failed `create_context` call, no MLS group state, no sender key material, and no event log state persists. The operation is atomic from the caller's perspective.",
       "acceptanceCriteria": [
         "`create_context(params: ContextParams) -> Result<ContextHandle, ContextError>` implemented with two-phase commit pattern",
-        "Phase 1 — Validate (no side effects): validates ContextParams (ceiling, roles, tools, TTL, memory scope, governance model); if template_id is present, validates all params match the template definition exactly; validates the creator's identity is valid and the signing key is accessible; validates transport is connected and at least one relay is reachable; if any validation fails, returns ContextError immediately with no state created",
+        "Phase 1 — Validate (no side effects): validates ContextParams (ceiling, roles, outlets, TTL, memory scope, governance model); if template_id is present, validates all params match the template definition exactly; validates the creator's identity is valid and the signing key is accessible; validates transport is connected and at least one relay is reachable; if any validation fails, returns ContextError immediately with no state created",
         "Phase 2 — Execute (with ordered rollback): Step 1: transition state to Creating; Step 2: if mode == Encrypted create MLS group via ADR-001 create_group(), if mode == Broadcast initialize creator's broadcast key (epoch 0) — no MLS group, on failure drop Creating state and return error; Step 3: if mode == Encrypted generate creator's sender key via ADR-007 generate_sender_key(), if mode == Broadcast broadcast key already initialized in step 2, on failure destroy MLS group and return error; Step 4: initialize empty event log (ADR-011), on failure destroy sender key and MLS group and return error; Step 5: publish context to transport, on failure drop event log, destroy sender key, destroy MLS group, and return error; Step 6: transition state to Active; Step 7: append ContextCreated event to event log; Step 8: return ContextHandle",
         "`CreationReceipt` struct tracks: mls_group (Option<MlsGroup>, None for Broadcast mode), sender_key (Option<SenderKey>), event_log (Option<EventLog>), published (bool)",
         "Rollback guarantees: after a failed create_context call, no MLS group state, no sender key material, and no event log state persists",
@@ -1482,7 +1482,7 @@
       ],
       "details": {
         "CreationReceipt struct": "```rust\nstruct CreationReceipt {\n    mls_group: Option<MlsGroup>,       // None for Broadcast mode\n    sender_key: Option<SenderKey>,      // Sender key (Encrypted) or broadcast key (Broadcast)\n    event_log: Option<EventLog>,\n    published: bool,\n}\n```",
-        "Two-phase commit steps": "Phase 1 — Validate (no side effects):\n- Validates ContextParams: ceiling, roles, tools, TTL, memory scope, governance model.\n- If template_id is present, validates all params match the template definition exactly.\n- Validates the creator's identity is valid and the signing key is accessible.\n- Validates transport is connected and at least one relay is reachable.\n- If any validation fails, returns ContextError immediately. No state has been created.\n\nPhase 2 — Execute (with ordered rollback):\n1. Transition state to Creating.\n2. If mode == Encrypted: Create MLS group via ADR-001 create_group(). If mode == Broadcast: Initialize creator's broadcast key (epoch 0) — no MLS group. On failure: drop Creating state, return error.\n3. If mode == Encrypted: Generate creator's sender key via ADR-007 generate_sender_key(). If mode == Broadcast: Broadcast key already initialized in step 2. On failure: destroy MLS group, return error.\n4. Initialize empty event log (ADR-011). On failure: destroy sender key, destroy MLS group, return error.\n5. Publish context to transport. On failure: drop event log, destroy sender key, destroy MLS group, return error.\n6. Transition state to Active.\n7. Append ContextCreated event to event log.\n8. Return ContextHandle."
+        "Two-phase commit steps": "Phase 1 — Validate (no side effects):\n- Validates ContextParams: ceiling, roles, outlets, TTL, memory scope, governance model.\n- If template_id is present, validates all params match the template definition exactly.\n- Validates the creator's identity is valid and the signing key is accessible.\n- Validates transport is connected and at least one relay is reachable.\n- If any validation fails, returns ContextError immediately. No state has been created.\n\nPhase 2 — Execute (with ordered rollback):\n1. Transition state to Creating.\n2. If mode == Encrypted: Create MLS group via ADR-001 create_group(). If mode == Broadcast: Initialize creator's broadcast key (epoch 0) — no MLS group. On failure: drop Creating state, return error.\n3. If mode == Encrypted: Generate creator's sender key via ADR-007 generate_sender_key(). If mode == Broadcast: Broadcast key already initialized in step 2. On failure: destroy MLS group, return error.\n4. Initialize empty event log (ADR-011). On failure: destroy sender key, destroy MLS group, return error.\n5. Publish context to transport. On failure: drop event log, destroy sender key, destroy MLS group, return error.\n6. Transition state to Active.\n7. Append ContextCreated event to event log.\n8. Return ContextHandle."
       },
       "result": "Two-phase commit with identity validation, opaque handle receipt types, and partial publication rollback"
     },
@@ -1606,7 +1606,7 @@
       ],
       "description": "Implement well-known context templates (spec §5.12.1). Templates are protocol constants — not user-extensible. When template_id is present, all ContextParams fields must match the template definition exactly. Context nesting (§5.13) is NOT in Phase 2 scope — see SCP-134.",
       "acceptanceCriteria": [
-        "Well-known template definitions for all 6 templates: BilateralEphemeral (messaging-only, ephemeral, TTL required), BilateralPersistent (messaging-only, full memory, no TTL), Coordination (messaging + tools, summary memory, TTL required), GroupDiscussion (messaging + invites, full memory, optional TTL), PublicBroadcast (broadcast mode, open subscriber registration §5.14), GatedBroadcast (broadcast mode, UCAN-gated subscriber access §5.14)",
+        "Well-known template definitions for all 6 templates: BilateralEphemeral (messaging-only, ephemeral, TTL required), BilateralPersistent (messaging-only, full memory, no TTL), Coordination (messaging + outlets, summary memory, TTL required), GroupDiscussion (messaging + invites, full memory, optional TTL), PublicBroadcast (broadcast mode, open subscriber registration §5.14), GatedBroadcast (broadcast mode, UCAN-gated subscriber access §5.14)",
         "Template validation: when template_id is present, all ContextParams fields must match the template definition exactly; mismatch returns ContextError",
         "Template-based ContextParams construction: given a TemplateId, produce a ContextParams with all required fields pre-filled",
         "Unit test: each template produces valid ContextParams",
@@ -1631,7 +1631,7 @@
         "Scope files": "| File | Purpose |\n|------|---------||\n| `templates.rs` | Well-known template definitions, template validation (params match template), template-based ContextParams construction |",
         "Nesting deferral": "Context nesting (§5.13) was originally in this story but is NOT Phase 2 scope. See SCP-134 for the nesting story."
       },
-      "result": "All 6 templates spec-aligned, from_template constructor, roles/tools validation added"
+      "result": "All 6 templates spec-aligned, from_template constructor, roles/outlets validation added"
     },
     {
       "id": "SCP-023",
@@ -1801,35 +1801,35 @@
     },
     {
       "id": "SCP-026",
-      "title": "Implement tool registration, types, and schema validation",
+      "title": "Implement outlet registration, types, and schema validation",
       "gate": "gate-2",
       "priority": "P0",
       "severity": "critical",
       "status": "done",
       "files": [
-        "crates/scp-core/context/tools/mod.rs",
-        "crates/scp-core/context/tools/registry.rs",
-        "crates/scp-core/context/tools/schema.rs"
+        "crates/scp-core/context/outlets/mod.rs",
+        "crates/scp-core/context/outlets/registry.rs",
+        "crates/scp-core/context/outlets/schema.rs"
       ],
-      "description": "Implement tool registration and schema validation in scp-core/context/tools/. Tools are stateless functions scoped to a context (spec section 5.4). They have MCP-compatible JSON Schema interfaces (spec section 8.5), making them interoperable with existing MCP tooling. Every tool registration includes schema, implementation hash, test vectors, and operator DID — providing verifiable integrity (spec section 7.3.3).",
+      "description": "Implement outlet registration and schema validation in scp-core/context/outlets/. Outlets are stateless functions scoped to a context (spec section 5.4). They have MCP-compatible JSON Schema interfaces (spec section 8.5), making them interoperable with existing MCP tooling. Every outlet registration includes schema, implementation hash, test vectors, and operator DID — providing verifiable integrity (spec section 7.3.3).",
       "acceptanceCriteria": [
-        "`OutletRegistration` struct with fields: outlet_id (OutletId), name (String), description (String), schema (ToolSchema — MCP-compatible JSON Schema), implementation_hash ([u8; 32] — SHA-256 of implementation), test_vectors (Vec<TestVector> — known input-output pairs), operator_did (DID — accountable identity)",
-        "`ToolSchema` struct with fields: input_schema (serde_json::Value — JSON Schema for input), output_schema (serde_json::Value — JSON Schema for output)",
+        "`OutletRegistration` struct with fields: outlet_id (OutletId), name (String), description (String), schema (OutletSchema — MCP-compatible JSON Schema), implementation_hash ([u8; 32] — SHA-256 of implementation), test_vectors (Vec<TestVector> — known input-output pairs), operator_did (DID — accountable identity)",
+        "`OutletSchema` struct with fields: input_schema (serde_json::Value — JSON Schema for input), output_schema (serde_json::Value — JSON Schema for output)",
         "`TestVector` struct with fields: input (serde_json::Value), expected_output (serde_json::Value), description (String)",
         "`register_outlet(context: &ContextHandle, registration: OutletRegistration, registrant_did: &DID) -> Result<OutletId, OutletError>` validates registrant has OutletRegister capability via UCAN (ADR-009); validates input and output schemas are valid JSON Schema; validates implementation hash is 32 bytes; validates operator DID is resolvable; stores the outlet registration in the context's outlet registry; appends OutletRegistered event to event log with full registration metadata; returns the outlet ID",
-        "`update_tool(context: &ContextHandle, outlet_id: &OutletId, new_registration: OutletRegistration, updater_did: &DID) -> Result<(), OutletError>` validates updater is the tool's operator DID or has admin role; records old and new implementation hashes; updates the tool registration; appends OutletUpdated event to event log (includes old hash, new hash, all changed fields); tool mutations are visible to all context members",
-        "`verify_tool(context: &ContextHandle, outlet_id: &OutletId) -> Result<OutletVerificationResult, OutletError>` runs all test vectors against the tool; for each test vector invokes tool with test input, compares output to expected output; returns a result with per-vector pass/fail status and overall integrity assessment; appends OutletVerified event to event log",
+        "`update_outlet(context: &ContextHandle, outlet_id: &OutletId, new_registration: OutletRegistration, updater_did: &DID) -> Result<(), OutletError>` validates updater is the outlet's operator DID or has admin role; records old and new implementation hashes; updates the outlet registration; appends OutletUpdated event to event log (includes old hash, new hash, all changed fields); outlet mutations are visible to all context members",
+        "`verify_outlet(context: &ContextHandle, outlet_id: &OutletId) -> Result<OutletVerificationResult, OutletError>` runs all test vectors against the outlet; for each test vector invokes outlet with test input, compares output to expected output; returns a result with per-vector pass/fail status and overall integrity assessment; appends OutletVerified event to event log",
         "JSON Schema validation helpers and MCP compatibility utilities in schema.rs",
-        "Unit test: register_tool validates schemas are valid JSON Schema",
+        "Unit test: register_outlet validates schemas are valid JSON Schema",
         "Unit test: register_outlet rejects registrant without OutletRegister capability",
-        "Unit test: update_tool logs old and new hashes",
-        "Unit test: verify_tool returns correct pass/fail per test vector",
-        "Optional `ToolEconomicMetadata` in tool registration (§19.3): cost_per_invoke (Amount), cost_formula (Option<PricingFormula>), payee (DID, may differ from context payee). Tool-level costs are additive with context costs"
+        "Unit test: update_outlet logs old and new hashes",
+        "Unit test: verify_outlet returns correct pass/fail per test vector",
+        "Optional `OutletEconomicMetadata` in outlet registration (§19.3): cost_per_invoke (Amount), cost_formula (Option<PricingFormula>), payee (DID, may differ from context payee). Outlet-level costs are additive with context costs"
       ],
       "actionItems": [
-        "Create `crates/scp-core/context/tools/mod.rs` with OutletId type, module re-exports",
-        "Create `crates/scp-core/context/tools/registry.rs` with OutletRegistration, ToolSchema, TestVector structs, tool storage per context, register_tool, update_tool, verify_tool functions",
-        "Create `crates/scp-core/context/tools/schema.rs` with JSON Schema validation helpers using jsonschema crate, MCP compatibility utilities",
+        "Create `crates/scp-core/context/outlets/mod.rs` with OutletId type, module re-exports",
+        "Create `crates/scp-core/context/outlets/registry.rs` with OutletRegistration, OutletSchema, TestVector structs, outlet storage per context, register_outlet, update_outlet, verify_outlet functions",
+        "Create `crates/scp-core/context/outlets/schema.rs` with JSON Schema validation helpers using jsonschema crate, MCP compatibility utilities",
         "Integrate with UCAN validation from ADR-009 for capability checks",
         "Write unit tests for registration, update, verification, and schema validation"
       ],
@@ -1849,46 +1849,46 @@
         }
       ],
       "details": {
-        "OutletRegistration struct": "```rust\npub struct OutletRegistration {\n    pub outlet_id: OutletId,\n    pub name: String,\n    pub description: String,\n    pub schema: ToolSchema,\n    pub implementation_hash: [u8; 32],\n    pub test_vectors: Vec<TestVector>,\n    pub operator_did: DID,\n}\n\npub struct ToolSchema {\n    pub input_schema: serde_json::Value,\n    pub output_schema: serde_json::Value,\n}\n\npub struct TestVector {\n    pub input: serde_json::Value,\n    pub expected_output: serde_json::Value,\n    pub description: String,\n}\n```",
-        "Implementation notes": "Language: Rust. Schema validation: jsonschema crate for JSON Schema validation. Hashing: SHA-256 via sha2 crate for implementation hashes. Crate: scp-core. Module: scp-core/context/tools/."
+        "OutletRegistration struct": "```rust\npub struct OutletRegistration {\n    pub outlet_id: OutletId,\n    pub name: String,\n    pub description: String,\n    pub schema: OutletSchema,\n    pub implementation_hash: [u8; 32],\n    pub test_vectors: Vec<TestVector>,\n    pub operator_did: DID,\n}\n\npub struct OutletSchema {\n    pub input_schema: serde_json::Value,\n    pub output_schema: serde_json::Value,\n}\n\npub struct TestVector {\n    pub input: serde_json::Value,\n    pub expected_output: serde_json::Value,\n    pub description: String,\n}\n```",
+        "Implementation notes": "Language: Rust. Schema validation: jsonschema crate for JSON Schema validation. Hashing: SHA-256 via sha2 crate for implementation hashes. Crate: scp-core. Module: scp-core/context/outlets/."
       },
-      "result": "Tool registration types, schema validation, registry with 48 tests"
+      "result": "Outlet registration types, schema validation, registry with 48 tests"
     },
     {
       "id": "SCP-027",
-      "title": "Implement tool invocation lifecycle with timeout and cancellation",
+      "title": "Implement outlet invocation lifecycle with timeout and cancellation",
       "gate": "gate-2",
       "priority": "P0",
       "severity": "critical",
       "status": "done",
       "files": [
-        "crates/scp-core/context/tools/invoke.rs",
-        "crates/scp-core/context/tools/lifecycle.rs"
+        "crates/scp-core/context/outlets/invoke.rs",
+        "crates/scp-core/context/outlets/lifecycle.rs"
       ],
-      "description": "Implement tool invocation with the full execution lifecycle: request/response protocol, timeout handling, cancellation, error propagation, and event log recording. Every tool invocation follows a defined lifecycle with explicit states, timeouts, and error handling. Tool execution errors are returned in ToolResponse.error, not as protocol-level errors. Schema validation failures are caught by the SDK, not the tool.",
+      "description": "Implement outlet invocation with the full execution lifecycle: request/response protocol, timeout handling, cancellation, error propagation, and event log recording. Every outlet invocation follows a defined lifecycle with explicit states, timeouts, and error handling. Outlet execution errors are returned in OutletResponse.error, not as protocol-level errors. Schema validation failures are caught by the SDK, not the outlet.",
       "acceptanceCriteria": [
         "`invoke_outlet(context: &ContextHandle, outlet_id: &OutletId, input: serde_json::Value, invoker_did: &DID) -> Result<serde_json::Value, OutletError>` validates context state is Active; validates invoker has OutletQuery(outlet_id)/OutletQueryAll (Query) or OutletCall(outlet_id)/OutletCallAll (Action) capability via UCAN; validates input against the outlet's input schema; calls the outlet implementation; validates output against the outlet's output schema; appends OutletInvoked event to event log (includes outlet_id, invoker_did, input hash, output hash); returns the outlet output",
-        "`ToolRequest` struct with fields: request_id (String — UUID v4, unique per invocation), outlet_id (OutletId), invoker_did (DID), input (serde_json::Value), timeout_ms (u32 — caller-specified timeout, max: context ceiling, default: 30_000), session_id (Option<String> — for stateful sessions §6.2.1), chain_depth (u8 — cross-context chain depth, 0 for direct calls), timestamp (u64)",
-        "`ToolResponse` struct with fields: request_id (String — matches the request), status (ToolStatus), output (Option<serde_json::Value>), error (Option<ToolExecutionError>), execution_time_ms (u64), provenance (Provenance)",
-        "`ToolStatus` enum: Success, Error, Timeout, Cancelled",
-        "`ToolExecutionError` struct with fields: code (OutletErrorCode), message (String), retryable (bool)",
-        "`OutletErrorCode` enum: InputValidationFailed, OutputValidationFailed, ExecutionFailed, Timeout, Cancelled, RateLimited, ToolNotFound, PermissionDenied, InternalError",
-        "Timeout handling: every invocation has a timeout; callers specify timeout_ms in the request (default: 30,000ms, maximum: configurable per-context, hard protocol maximum: 300,000ms / 5 minutes); invoking SDK starts timer on request submission; if no ToolResponse arrives before timer fires, SDK synthesizes ToolResponse with status: Timeout; timeout is client-side contract, not server-side enforcement",
-        "Cancellation protocol: invoker MAY send ToolCancel { request_id, invoker_did, timestamp } referencing the request_id; on receiving ToolCancel the tool's execution environment SHOULD terminate the invocation and respond with status: Cancelled; cancellation is best-effort — if tool responds with Success before cancel is processed, success takes precedence",
-        "Error propagation: tool execution errors returned in ToolResponse.error, not as protocol-level errors; schema validation failures caught by SDK not tool — SDK rejects invalid input before invoking tool and rejects invalid output before delivering response; retryable field indicates whether caller should retry",
-        "Event log recording: both ToolRequest and ToolResponse recorded as events in context's event log (ADR-011); event includes request_id, outlet_id, invoker_did, status, execution_time_ms, SHA256(input), SHA256(output); full input/output NOT recorded (may be large), only content hashes stored",
-        "Unit test: invoke_tool rejects when context not Active",
+        "`OutletRequest` struct with fields: request_id (String — UUID v4, unique per invocation), outlet_id (OutletId), invoker_did (DID), input (serde_json::Value), timeout_ms (u32 — caller-specified timeout, max: context ceiling, default: 30_000), session_id (Option<String> — for stateful sessions §6.2.1), chain_depth (u8 — cross-context chain depth, 0 for direct calls), timestamp (u64)",
+        "`OutletResponse` struct with fields: request_id (String — matches the request), status (OutletStatus), output (Option<serde_json::Value>), error (Option<OutletExecutionError>), execution_time_ms (u64), provenance (Provenance)",
+        "`OutletStatus` enum: Success, Error, Timeout, Cancelled",
+        "`OutletExecutionError` struct with fields: code (OutletErrorCode), message (String), retryable (bool)",
+        "`OutletErrorCode` enum: InputValidationFailed, OutputValidationFailed, ExecutionFailed, Timeout, Cancelled, RateLimited, OutletNotFound, PermissionDenied, InternalError",
+        "Timeout handling: every invocation has a timeout; callers specify timeout_ms in the request (default: 30,000ms, maximum: configurable per-context, hard protocol maximum: 300,000ms / 5 minutes); invoking SDK starts timer on request submission; if no OutletResponse arrives before timer fires, SDK synthesizes OutletResponse with status: Timeout; timeout is client-side contract, not server-side enforcement",
+        "Cancellation protocol: invoker MAY send OutletCancel { request_id, invoker_did, timestamp } referencing the request_id; on receiving OutletCancel the outlet's execution environment SHOULD terminate the invocation and respond with status: Cancelled; cancellation is best-effort — if outlet responds with Success before cancel is processed, success takes precedence",
+        "Error propagation: outlet execution errors returned in OutletResponse.error, not as protocol-level errors; schema validation failures caught by SDK not outlet — SDK rejects invalid input before invoking outlet and rejects invalid output before delivering response; retryable field indicates whether caller should retry",
+        "Event log recording: both OutletRequest and OutletResponse recorded as events in context's event log (ADR-011); event includes request_id, outlet_id, invoker_did, status, execution_time_ms, SHA256(input), SHA256(output); full input/output NOT recorded (may be large), only content hashes stored",
+        "Unit test: invoke_outlet rejects when context not Active",
         "Unit test: invoke_outlet rejects invoker without OutletCall capability",
         "Unit test: input schema validation failure returns InputValidationFailed",
         "Unit test: timeout synthesizes Timeout response",
         "Unit test: cancellation returns Cancelled status"
       ],
       "actionItems": [
-        "Create `crates/scp-core/context/tools/invoke.rs` with invoke_tool function, input/output schema validation using jsonschema crate, tool dispatch",
-        "Create `crates/scp-core/context/tools/lifecycle.rs` with ToolRequest, ToolResponse, ToolCancel, ToolStatus, ToolExecutionError, OutletErrorCode types, timeout management with tokio timers, cancellation handling",
+        "Create `crates/scp-core/context/outlets/invoke.rs` with invoke_outlet function, input/output schema validation using jsonschema crate, outlet dispatch",
+        "Create `crates/scp-core/context/outlets/lifecycle.rs` with OutletRequest, OutletResponse, OutletCancel, OutletStatus, OutletExecutionError, OutletErrorCode types, timeout management with tokio timers, cancellation handling",
         "Implement event log recording with content hashes (SHA-256 of input/output, not full content)",
         "Implement timeout handling: spawn tokio timer, synthesize Timeout response on expiry",
-        "Implement cancellation: ToolCancel message handling, best-effort termination",
+        "Implement cancellation: OutletCancel message handling, best-effort termination",
         "Write unit tests for all invocation lifecycle scenarios"
       ],
       "blockedBy": [
@@ -1904,42 +1904,42 @@
         }
       ],
       "details": {
-        "ToolRequest struct": "```rust\npub struct ToolRequest {\n    pub request_id: String,\n    pub outlet_id: OutletId,\n    pub invoker_did: DID,\n    pub input: serde_json::Value,\n    pub timeout_ms: u32,\n    pub session_id: Option<String>,\n    pub chain_depth: u8,\n    pub timestamp: u64,\n}\n```",
-        "ToolResponse struct": "```rust\npub struct ToolResponse {\n    pub request_id: String,\n    pub status: ToolStatus,\n    pub output: Option<serde_json::Value>,\n    pub error: Option<ToolExecutionError>,\n    pub execution_time_ms: u64,\n    pub provenance: Provenance,\n}\n```",
-        "Timeout handling": "Every tool invocation has a timeout. Callers specify timeout_ms in the request (default: 30,000ms, maximum: configurable per-context, hard protocol maximum: 300,000ms / 5 minutes). The invoking SDK starts a timer on request submission. If no ToolResponse arrives before the timer fires, the SDK synthesizes a ToolResponse with status: Timeout and delivers it to the caller. Timeout is a client-side contract, not a server-side enforcement.",
-        "Cancellation protocol": "The invoker MAY send a ToolCancel { request_id, invoker_did, timestamp } message referencing the request_id. On receiving ToolCancel, the tool's execution environment SHOULD terminate the invocation and respond with status: Cancelled. Cancellation is best-effort. If the tool responds with Success before the cancel is processed, the success response takes precedence.",
-        "Error propagation": "Tool execution errors are returned in ToolResponse.error, not as protocol-level errors. Schema validation failures are caught by the SDK, not the tool. The SDK rejects invalid input before invoking the tool and rejects invalid output before delivering the response. The retryable field indicates whether the caller should attempt the invocation again.",
-        "Event log recording": "ToolRequest and ToolResponse are both recorded as events in the context's event log (ADR-011). The event includes: request_id, outlet_id, invoker_did, status, execution_time_ms, SHA256(input), SHA256(output). Full input/output is NOT recorded (may be large); only content hashes are stored."
+        "OutletRequest struct": "```rust\npub struct OutletRequest {\n    pub request_id: String,\n    pub outlet_id: OutletId,\n    pub invoker_did: DID,\n    pub input: serde_json::Value,\n    pub timeout_ms: u32,\n    pub session_id: Option<String>,\n    pub chain_depth: u8,\n    pub timestamp: u64,\n}\n```",
+        "OutletResponse struct": "```rust\npub struct OutletResponse {\n    pub request_id: String,\n    pub status: OutletStatus,\n    pub output: Option<serde_json::Value>,\n    pub error: Option<OutletExecutionError>,\n    pub execution_time_ms: u64,\n    pub provenance: Provenance,\n}\n```",
+        "Timeout handling": "Every outlet invocation has a timeout. Callers specify timeout_ms in the request (default: 30,000ms, maximum: configurable per-context, hard protocol maximum: 300,000ms / 5 minutes). The invoking SDK starts a timer on request submission. If no OutletResponse arrives before the timer fires, the SDK synthesizes a OutletResponse with status: Timeout and delivers it to the caller. Timeout is a client-side contract, not a server-side enforcement.",
+        "Cancellation protocol": "The invoker MAY send a OutletCancel { request_id, invoker_did, timestamp } message referencing the request_id. On receiving OutletCancel, the outlet's execution environment SHOULD terminate the invocation and respond with status: Cancelled. Cancellation is best-effort. If the outlet responds with Success before the cancel is processed, the success response takes precedence.",
+        "Error propagation": "Outlet execution errors are returned in OutletResponse.error, not as protocol-level errors. Schema validation failures are caught by the SDK, not the outlet. The SDK rejects invalid input before invoking the outlet and rejects invalid output before delivering the response. The retryable field indicates whether the caller should attempt the invocation again.",
+        "Event log recording": "OutletRequest and OutletResponse are both recorded as events in the context's event log (ADR-011). The event includes: request_id, outlet_id, invoker_did, status, execution_time_ms, SHA256(input), SHA256(output). Full input/output is NOT recorded (may be large); only content hashes are stored."
       },
-      "result": "Tool invocation lifecycle with timeout and cancellation. 33 new tests."
+      "result": "Outlet invocation lifecycle with timeout and cancellation. 33 new tests."
     },
     {
       "id": "SCP-028",
-      "title": "Implement cross-context tool interfaces",
+      "title": "Implement cross-context outlet interfaces",
       "gate": "gate-2",
       "priority": "P0",
       "severity": "major",
       "status": "done",
       "files": [
-        "crates/scp-core/context/tools/interface.rs"
+        "crates/scp-core/context/outlets/interface.rs"
       ],
-      "description": "Implement cross-context tool interfaces (spec section 6.2) that allow structured interaction across context boundaries with bidirectional consent. The context governs the tool call, not the agent. An agent in Context A requests a tool call to Context B. Context A's governance decides whether to permit the outbound call. Context B's governance decides whether to permit the inbound call. The agent never directly touches the other context. Rate limiting is enforced per interface.",
+      "description": "Implement cross-context outlet interfaces (spec section 6.2) that allow structured interaction across context boundaries with bidirectional consent. The context governs the outlet call, not the agent. An agent in Context A requests a outlet call to Context B. Context A's governance decides whether to permit the outbound call. Context B's governance decides whether to permit the inbound call. The agent never directly touches the other context. Rate limiting is enforced per interface.",
       "acceptanceCriteria": [
-        "`OutletInterface` struct with fields: source_context (ContextId — context exposing the tool), target_context (ContextId — context consuming the tool), outlet_id (OutletId — which tool is exposed), rate_limit (Option<RateLimit> — calls per time window), approved_by_source (bool — source context opted in), approved_by_target (bool — target context opted in)",
-        "`expose_tool(context: &ContextHandle, outlet_id: &OutletId, to_context: &ContextId) -> Result<OutletInterface, OutletError>` initiates a tool interface proposal from the source context; requires admin capability",
-        "`accept_tool_interface(context: &ContextHandle, interface: &OutletInterface) -> Result<(), OutletError>` target context accepts the interface; requires admin capability; both approved_by_source and approved_by_target must be true before calls are permitted",
-        "`invoke_cross_context(source_context: &ContextHandle, interface: &OutletInterface, input: serde_json::Value, invoker_did: &DID) -> Result<serde_json::Value, OutletError>` invokes a tool across context boundaries; source context governance checks outbound; target context governance checks inbound; both event logs record the call with provenance",
+        "`OutletInterface` struct with fields: source_context (ContextId — context exposing the outlet), target_context (ContextId — context consuming the outlet), outlet_id (OutletId — which outlet is exposed), rate_limit (Option<RateLimit> — calls per time window), approved_by_source (bool — source context opted in), approved_by_target (bool — target context opted in)",
+        "`expose_outlet(context: &ContextHandle, outlet_id: &OutletId, to_context: &ContextId) -> Result<OutletInterface, OutletError>` initiates a outlet interface proposal from the source context; requires admin capability",
+        "`accept_outlet_interface(context: &ContextHandle, interface: &OutletInterface) -> Result<(), OutletError>` target context accepts the interface; requires admin capability; both approved_by_source and approved_by_target must be true before calls are permitted",
+        "`invoke_cross_context(source_context: &ContextHandle, interface: &OutletInterface, input: serde_json::Value, invoker_did: &DID) -> Result<serde_json::Value, OutletError>` invokes a outlet across context boundaries; source context governance checks outbound; target context governance checks inbound; both event logs record the call with provenance",
         "Rate limiting enforced per interface",
-        "Unit test: expose_tool requires admin capability",
+        "Unit test: expose_outlet requires admin capability",
         "Unit test: invoke_cross_context fails when only one side has approved",
         "Unit test: rate limiting rejects calls beyond limit",
         "Unit test: both event logs record the cross-context call with provenance"
       ],
       "actionItems": [
-        "Create `crates/scp-core/context/tools/interface.rs` with OutletInterface struct, RateLimit type",
-        "Implement expose_tool: admin capability check, interface proposal creation with approved_by_source = true",
-        "Implement accept_tool_interface: admin capability check on target, set approved_by_target = true",
-        "Implement invoke_cross_context: bidirectional governance check, tool invocation, dual event log recording with provenance",
+        "Create `crates/scp-core/context/outlets/interface.rs` with OutletInterface struct, RateLimit type",
+        "Implement expose_outlet: admin capability check, interface proposal creation with approved_by_source = true",
+        "Implement accept_outlet_interface: admin capability check on target, set approved_by_target = true",
+        "Implement invoke_cross_context: bidirectional governance check, outlet invocation, dual event log recording with provenance",
         "Implement per-interface rate limiting with time-window tracking",
         "Write unit tests for bidirectional approval, rate limiting, and dual event logging"
       ],
@@ -1962,20 +1962,20 @@
     },
     {
       "id": "SCP-029",
-      "title": "Implement stateful tool sessions",
+      "title": "Implement stateful outlet sessions",
       "gate": "gate-2",
       "priority": "P0",
       "severity": "major",
       "status": "done",
       "files": [
-        "crates/scp-core/context/tools/session.rs"
+        "crates/scp-core/context/outlets/session.rs"
       ],
-      "description": "Implement stateful tool sessions (spec section 6.2.1) that enable multi-turn workflows via session IDs, TTLs, and per-call governance. Session state lives in the tool's context, not the caller's. Each call in a session is individually governed. Sessions have TTLs to prevent resource leaks. Background task removes sessions past their TTL.",
+      "description": "Implement stateful outlet sessions (spec section 6.2.1) that enable multi-turn workflows via session IDs, TTLs, and per-call governance. Session state lives in the outlet's context, not the caller's. Each call in a session is individually governed. Sessions have TTLs to prevent resource leaks. Background task removes sessions past their TTL.",
       "acceptanceCriteria": [
-        "`ToolSession` struct with fields: session_id (String), outlet_id (OutletId), source_context (ContextId), state (serde_json::Value — opaque session state), created_at (u64), ttl (Duration), call_count (u64)",
+        "`OutletSession` struct with fields: session_id (String), outlet_id (OutletId), source_context (ContextId), state (serde_json::Value — opaque session state), created_at (u64), ttl (Duration), call_count (u64)",
         "`create_session(context: &ContextHandle, outlet_id: &OutletId, source_context: &ContextId, ttl: Duration) -> Result<String, OutletError>` creates a new session; returns session ID",
-        "`invoke_session(context: &ContextHandle, session_id: &str, input: serde_json::Value) -> Result<serde_json::Value, OutletError>` invokes a tool within an active session; each call is individually governed; session state is updated by the tool",
-        "Session cleanup: background task removes sessions past their TTL; session state is internal to the tool's context",
+        "`invoke_session(context: &ContextHandle, session_id: &str, input: serde_json::Value) -> Result<serde_json::Value, OutletError>` invokes a outlet within an active session; each call is individually governed; session state is updated by the outlet",
+        "Session cleanup: background task removes sessions past their TTL; session state is internal to the outlet's context",
         "Session storage: in-memory HashMap with TTL-based cleanup, keyed by session ID",
         "Unit test: create_session returns valid session ID",
         "Unit test: invoke_session on expired session returns error",
@@ -1983,9 +1983,9 @@
         "Unit test: each call in session is individually governed (UCAN validated per call)"
       ],
       "actionItems": [
-        "Create `crates/scp-core/context/tools/session.rs` with ToolSession struct, session HashMap storage",
+        "Create `crates/scp-core/context/outlets/session.rs` with OutletSession struct, session HashMap storage",
         "Implement create_session: generate UUID session ID, initialize session state, store in HashMap",
-        "Implement invoke_session: session lookup, TTL check, UCAN validation per call, tool invocation, session state update, call_count increment",
+        "Implement invoke_session: session lookup, TTL check, UCAN validation per call, outlet invocation, session state update, call_count increment",
         "Implement background TTL cleanup task using tokio",
         "Write unit tests for session creation, invocation, expiry, and per-call governance"
       ],
@@ -2000,7 +2000,7 @@
         }
       ],
       "details": {
-        "ToolSession struct": "```rust\npub struct ToolSession {\n    pub session_id: String,\n    pub outlet_id: OutletId,\n    pub source_context: ContextId,\n    pub state: serde_json::Value,\n    pub created_at: u64,\n    pub ttl: Duration,\n    pub call_count: u64,\n}\n```"
+        "OutletSession struct": "```rust\npub struct OutletSession {\n    pub session_id: String,\n    pub outlet_id: OutletId,\n    pub source_context: ContextId,\n    pub state: serde_json::Value,\n    pub created_at: u64,\n    pub ttl: Duration,\n    pub call_count: u64,\n}\n```"
       }
     },
     {
@@ -2259,7 +2259,7 @@
       "files": [
         "crates/scp-core/tests/phase2_integration.rs"
       ],
-      "description": "The ultimate acceptance criterion for Phase 2 exercises all 5 ADRs together with the Phase 1 crypto stack. This integration test proves: context lifecycle works, roles enforce, tools invoke, event logs verify, multi-transport routes, TTL enforces, metadata privacy measures are active, and everything composes cleanly on top of Phase 1's crypto stack.",
+      "description": "The ultimate acceptance criterion for Phase 2 exercises all 5 ADRs together with the Phase 1 crypto stack. This integration test proves: context lifecycle works, roles enforce, outlets invoke, event logs verify, multi-transport routes, TTL enforces, metadata privacy measures are active, and everything composes cleanly on top of Phase 1's crypto stack.",
       "acceptanceCriteria": [
         "Step 1: Alice creates an identity (ADR-003) and a context with ceiling [messaging, outlet_call], roles [admin, member], one outlet 'calculator', TTL 5 minutes, memory scope ephemeral (ADR-008)",
         "Step 2: The context is assigned to 3 relays via TransportManager (ADR-012)",
@@ -2277,11 +2277,11 @@
       "actionItems": [
         "Create `crates/scp-core/tests/phase2_integration.rs` with full end-to-end integration test",
         "Set up Alice and Bob identities using ADR-003 DID operations",
-        "Create context with full ContextParams: ceiling, roles, tool, TTL, ephemeral scope",
+        "Create context with full ContextParams: ceiling, roles, outlet, TTL, ephemeral scope",
         "Assign context to 3 relays via TransportManager",
         "Execute Bob join and role assignment flow",
         "Execute message send/receive with UCAN validation and multi-relay publish/subscribe",
-        "Execute tool invocation with schema validation and event logging",
+        "Execute outlet invocation with schema validation and event logging",
         "Verify UCAN enforcement: Bob's role assignment attempt rejected",
         "Generate and compare consistency checkpoints",
         "Trigger TTL expiry and verify Expired transition, key destruction, relay deletion",
@@ -2315,9 +2315,9 @@
       ],
       "details": {
         "Full test scenario": "1. Alice creates an identity (ADR-003) and a context with ceiling [messaging, outlet_call], roles [admin, member], one outlet \"calculator\", TTL 5 minutes, memory scope ephemeral (ADR-008)\n2. The context is assigned to 3 relays via TransportManager (ADR-012)\n3. Bob creates an identity, discovers the context, and joins (ADR-008)\n4. Bob is assigned the \"member\" role with UCAN tokens for messages:read, messages:write, outlet_query_all, outlet_call_all (ADR-009)\n5. Alice sends a message. UCAN is validated. Envelope is created, multi-relay published (ADR-012). Event is logged in the Merkle tree (ADR-011).\n6. Bob receives the message via merged subscription stream (ADR-012). Bob's SDK deduplicates across relays.\n7. Bob invokes the \"calculator\" outlet with input {\"operation\": \"add\", \"a\": 1, \"b\": 2} (ADR-010). UCAN validates Bob has outlet_call capability. Outlet returns {\"result\": 3}. Invocation is logged (ADR-011).\n8. Bob attempts to assign a role (he's a member, not admin). UCAN validation rejects — Bob lacks RoleAssign capability (ADR-009). Action is denied.\n9. Both Alice and Bob generate consistency checkpoints (ADR-011). Merkle roots match.\n10. TTL expires. Context transitions to Expired (ADR-008). MLS group and sender keys are destroyed. Relay deletion requests are sent for all context blobs.\n11. The event log's Merkle tree remains — the structure (hashes, proofs) survives even though the encrypted content is now unreadable.\n12. Throughout: relay reliability is tracked, and relay sets are partitioned across contexts.",
-        "What this proves": "Context lifecycle works, roles enforce, tools invoke, event logs verify, multi-transport routes, TTL enforces, metadata privacy measures are active, and everything composes cleanly on top of Phase 1's crypto stack."
+        "What this proves": "Context lifecycle works, roles enforce, outlets invoke, event logs verify, multi-transport routes, TTL enforces, metadata privacy measures are active, and everything composes cleanly on top of Phase 1's crypto stack."
       },
-      "result": "Phase 2 integration test created at crates/scp-core/tests/phase2_integration.rs. Exercises 12-step scenario: identity creation, context lifecycle, UCAN role enforcement, tool invocation, event logging, checkpoint consistency, TTL expiry, and multi-relay transport simulation. All tests pass."
+      "result": "Phase 2 integration test created at crates/scp-core/tests/phase2_integration.rs. Exercises 12-step scenario: identity creation, context lifecycle, UCAN role enforcement, outlet invocation, event logging, checkpoint consistency, TTL expiry, and multi-relay transport simulation. All tests pass."
     },
     {
       "id": "SCP-036",
@@ -2515,22 +2515,22 @@
     },
     {
       "id": "SCP-040",
-      "title": "Implement PyO3 tool, transport, UCAN, and event log bridge functions",
+      "title": "Implement PyO3 outlet, transport, UCAN, and event log bridge functions",
       "gate": "gate-3",
       "priority": "P0",
       "severity": "critical",
       "status": "done",
       "files": [
-        "crates/scp-ffi/pyo3/tools.rs",
+        "crates/scp-ffi/pyo3/outlets.rs",
         "crates/scp-ffi/pyo3/transport.rs",
         "crates/scp-ffi/pyo3/ucan.rs",
         "crates/scp-ffi/pyo3/event_log.rs"
       ],
-      "description": "Implement PyO3 bridge functions for tool registration/invocation, transport connection, UCAN token management, and event log queries. Each function maps directly to one scp-core function. Types exposed as opaque PyO3 classes with attribute access.",
+      "description": "Implement PyO3 bridge functions for outlet registration/invocation, transport connection, UCAN token management, and event log queries. Each function maps directly to one scp-core function. Types exposed as opaque PyO3 classes with attribute access.",
       "acceptanceCriteria": [
-        "`py_tool_register(handle, registration) -> str` — registers a tool (returns tool ID).",
+        "`py_outlet_register(handle, registration) -> str` — registers a outlet (returns outlet ID).",
         "`outlet_invoke(handle, outlet_id, input, identity) -> PyObject` — invokes an outlet (returns JSON-compatible output).",
-        "`py_tool_verify(handle, outlet_id) -> PyOutletVerificationResult` — verifies a tool against test vectors.",
+        "`py_outlet_verify(handle, outlet_id) -> PyOutletVerificationResult` — verifies a outlet against test vectors.",
         "`py_transport_connect(relay_url) -> None` — connects to an SCP relay.",
         "`py_transport_status() -> PyTransportStatus` — returns transport connection status.",
         "`py_ucan_validate(handle, token, capability) -> None` — validates a UCAN token (raises exception on failure).",
@@ -2557,7 +2557,7 @@
         }
       ],
       "details": {},
-      "result": "PyOutletRegistration, PyOutletVerificationResult, PyTransportStatus, PyUcanToken, PyEvent, PyProof types + 10 bridge functions across tools.rs, transport.rs, ucan.rs, event_log.rs"
+      "result": "PyOutletRegistration, PyOutletVerificationResult, PyTransportStatus, PyUcanToken, PyEvent, PyProof types + 10 bridge functions across outlets.rs, transport.rs, ucan.rs, event_log.rs"
     },
     {
       "id": "SCP-041",
@@ -2578,7 +2578,7 @@
       ],
       "actionItems": [
         "Generate or manually author `_scp_core.pyi` stub file with complete type annotations for all bridge functions and pyclass types.",
-        "Include annotations for all identity, context, tool, transport, UCAN, and event log bridge functions.",
+        "Include annotations for all identity, context, outlet, transport, UCAN, and event log bridge functions.",
         "Include annotations for all opaque type classes (PyIdentity, PyDIDDocument, PyContextHandle, PyContextParams, PyOutletRegistration, PyOutletVerificationResult, PyTransportStatus, PyUcanToken, PyEvent, PyProof).",
         "Verify stubs work with mypy and pyright for static analysis."
       ],
@@ -2659,19 +2659,19 @@
         "`send()` and `invoke()` optionally accept an identity parameter (defaults to the creator if a single identity is active).",
         "`receive()` returns an `AsyncIterator[Message]` for streaming incoming messages.",
         "Context exposes `.context_id` (string), `.state` (string: 'creating', 'active', 'closing', 'closed', 'expired').",
-        "Context.create signature: `@classmethod async def create(cls, creator: Identity, ceiling: list[str], tools: list[ToolDefinition] | None = None, roles: dict[str, list[str]] | None = None, ttl: float | None = None, memory_scope: str = \"full\", governance: str = \"single_admin\") -> \"Context\"`.",
+        "Context.create signature: `@classmethod async def create(cls, creator: Identity, ceiling: list[str], outlets: list[OutletDefinition] | None = None, roles: dict[str, list[str]] | None = None, ttl: float | None = None, memory_scope: str = \"full\", governance: str = \"single_admin\") -> \"Context\"`.",
         "`async def join(self, identity: Identity) -> Membership`.",
         "`async def leave(self, identity: Identity) -> None`.",
         "`async def close(self, identity: Identity) -> None`.",
         "`async def send(self, message: str | bytes, identity: Identity | None = None) -> None`.",
         "`async def receive(self) -> AsyncIterator[Message]`.",
-        "`async def invoke(self, tool: str, input: dict, identity: Identity | None = None) -> dict`.",
+        "`async def invoke(self, outlet: str, input: dict, identity: Identity | None = None) -> dict`.",
         "`async def __aenter__(self) -> Context` and `async def __aexit__(self, *exc) -> None` implemented.",
         "`receive()` AsyncIterator respects the receive buffer semantics: 1,000-event default buffer, oldest-drop overflow, `BufferOverflow` warning event emitted on overflow (including count of dropped events since last successful consumption). Buffer size configurable via `Context.create(..., buffer_size=N)` or `Context.configure(buffer_size=N)`."
       ],
       "actionItems": [
         "Create `bindings/python/scp_sdk/context.py` with `Context` class and `Membership` type.",
-        "Implement `@classmethod async def create(cls, creator, ceiling, tools=None, roles=None, ttl=None, memory_scope=\"full\", governance=\"single_admin\")` delegating to `_scp_core.py_context_create`.",
+        "Implement `@classmethod async def create(cls, creator, ceiling, outlets=None, roles=None, ttl=None, memory_scope=\"full\", governance=\"single_admin\")` delegating to `_scp_core.py_context_create`.",
         "Implement `async def join(self, identity) -> Membership` delegating to `_scp_core.py_context_join`.",
         "Implement `async def leave(self, identity) -> None` delegating to `_scp_core.py_context_leave`.",
         "Implement `async def close(self, identity) -> None` delegating to `_scp_core.py_context_close`.",
@@ -2706,13 +2706,13 @@
       "severity": "critical",
       "status": "done",
       "files": [
-        "bindings/python/scp_sdk/tools.py",
+        "bindings/python/scp_sdk/outlets.py",
         "bindings/python/scp_sdk/types.py",
         "bindings/python/scp_sdk/errors.py"
       ],
-      "description": "Implement Python SDK dataclasses for ToolDefinition, Message, and other shared types. Implement the Pythonic exception hierarchy that wraps bridge-level exceptions with additional context. Every exception includes a human-readable message and machine-readable error code.",
+      "description": "Implement Python SDK dataclasses for OutletDefinition, Message, and other shared types. Implement the Pythonic exception hierarchy that wraps bridge-level exceptions with additional context. Every exception includes a human-readable message and machine-readable error code.",
       "acceptanceCriteria": [
-        "ToolDefinition dataclass: `name: str`, `description: str`, `input_schema: dict`, `output_schema: dict`, `operator: Identity | str`, `test_vectors: list[TestVector] | None = None`, `implementation_hash: bytes | None = None`.",
+        "OutletDefinition dataclass: `name: str`, `description: str`, `input_schema: dict`, `output_schema: dict`, `operator: Identity | str`, `test_vectors: list[TestVector] | None = None`, `implementation_hash: bytes | None = None`.",
         "Message dataclass: `sender_did: str`, `content: str | bytes`, `timestamp: float`, `sequence: int`, `context_id: str`, `provenance: Provenance | None = None`.",
         "Exception hierarchy rooted at `ScpError(Exception)`.",
         "`IdentityError(ScpError)` — Identity creation, resolution, or key management failure.",
@@ -2720,7 +2720,7 @@
         "`UcanPermissionError(ScpError)` — UCAN capability validation failure.",
         "`CryptoError(ScpError)` — Encryption, decryption, or signature failure.",
         "`TransportError(ScpError)` — Network or relay communication failure.",
-        "`OutletError(ScpError)` — Tool registration, invocation, or verification failure.",
+        "`OutletError(ScpError)` — Outlet registration, invocation, or verification failure.",
         "`ValidationError(ScpError)` — Input validation failure (schema, parameters).",
         "Every exception includes a human-readable message and machine-readable error code.",
         "Exceptions wrap the corresponding bridge-level `ScpPyError` variants."
@@ -2728,7 +2728,7 @@
       "actionItems": [
         "Create `bindings/python/scp_sdk/errors.py` with `ScpError`, `IdentityError`, `ContextError`, `UcanPermissionError`, `CryptoError`, `TransportError`, `OutletError`, `ValidationError` exception classes.",
         "Add machine-readable error code attribute to each exception.",
-        "Create `bindings/python/scp_sdk/tools.py` with `ToolDefinition` and `TestVector` dataclasses.",
+        "Create `bindings/python/scp_sdk/outlets.py` with `OutletDefinition` and `TestVector` dataclasses.",
         "Create `bindings/python/scp_sdk/types.py` with `Message`, `Provenance`, `Capability` dataclasses and shared enums.",
         "Ensure all dataclasses use PEP 484 type hints."
       ],
@@ -2742,10 +2742,10 @@
         }
       ],
       "details": {
-        "tool_definition": "@dataclass\nclass ToolDefinition:\n    name: str\n    description: str\n    input_schema: dict       # JSON Schema\n    output_schema: dict      # JSON Schema\n    operator: Identity | str # DID string or Identity object\n    test_vectors: list[TestVector] | None = None\n    implementation_hash: bytes | None = None",
+        "outlet_definition": "@dataclass\nclass OutletDefinition:\n    name: str\n    description: str\n    input_schema: dict       # JSON Schema\n    output_schema: dict      # JSON Schema\n    operator: Identity | str # DID string or Identity object\n    test_vectors: list[TestVector] | None = None\n    implementation_hash: bytes | None = None",
         "message": "@dataclass\nclass Message:\n    sender_did: str\n    content: str | bytes\n    timestamp: float\n    sequence: int\n    context_id: str\n    provenance: Provenance | None = None"
       },
-      "result": "Python SDK types in bindings/python/scp_sdk/. errors.py with ScpError hierarchy (7 subclasses including UcanPermissionError to avoid shadowing builtins), tools.py with ToolDefinition/TestVector dataclasses, types.py with Message/Provenance/Capability/MemoryScope/SourceType. All imports and smoke tests pass."
+      "result": "Python SDK types in bindings/python/scp_sdk/. errors.py with ScpError hierarchy (7 subclasses including UcanPermissionError to avoid shadowing builtins), outlets.py with OutletDefinition/TestVector dataclasses, types.py with Message/Provenance/Capability/MemoryScope/SourceType. All imports and smoke tests pass."
     },
     {
       "id": "SCP-045",
@@ -2807,7 +2807,7 @@
       "acceptanceCriteria": [
         "Top-level imports: `import scp_sdk` or `from scp_sdk import Identity, Context` work.",
         "The `scp` namespace alias: `import scp_sdk as scp` enables the 20-line agent from architecture.md section 3.1.",
-        "Re-exports: Identity, Context, ToolDefinition, TestVector, evaluate_trust, ScpError, IdentityError, ContextError, UcanPermissionError, CryptoError, TransportError, OutletError, ValidationError.",
+        "Re-exports: Identity, Context, OutletDefinition, TestVector, evaluate_trust, ScpError, IdentityError, ContextError, UcanPermissionError, CryptoError, TransportError, OutletError, ValidationError.",
         "`__version__ = \"0.1.0\"` declared.",
         "`py.typed` PEP 561 marker file exists.",
         "`pyproject.toml` declares package metadata, version, Python >=3.10 constraint, optional dependencies `[langchain]` and `[mcp]`.",
@@ -2834,7 +2834,7 @@
         }
       ],
       "details": {
-        "init_exports": "from scp_sdk.identity import Identity\nfrom scp_sdk.context import Context\nfrom scp_sdk.tools import ToolDefinition, TestVector\nfrom scp_sdk.trust import evaluate_trust\nfrom scp_sdk.errors import ScpError, IdentityError, ContextError, ...\n\n__version__ = \"0.1.0\""
+        "init_exports": "from scp_sdk.identity import Identity\nfrom scp_sdk.context import Context\nfrom scp_sdk.outlets import OutletDefinition, TestVector\nfrom scp_sdk.trust import evaluate_trust\nfrom scp_sdk.errors import ScpError, IdentityError, ContextError, ...\n\n__version__ = \"0.1.0\""
       },
       "result": "Python SDK __init__.py with re-exports, py.typed marker, pyproject.toml with maturin backend created"
     },
@@ -2855,7 +2855,7 @@
         "MCP-specific message types implemented: Initialize, ToolsList, ToolsCall, ResourcesList.",
         "Context namespace parsing: `context_id/tool_name` splitting implemented.",
         "Built-in tool definitions per context: `{context}/send_message`, `{context}/read_messages`, `{context}/list_members`.",
-        "Context-registered tools: `{context}/{tool_name}` for each tool in the context's tool registry.",
+        "Context-registered outlets: `{context}/{tool_name}` for each outlet in the context's outlet registry.",
         "Serialization via `serde_json`."
       ],
       "actionItems": [
@@ -2863,7 +2863,7 @@
         "Add MCP-specific message types: Initialize, Initialized, Ping, ToolsList, ToolsCall, ResourcesList, ResourcesRead, ResourcesSubscribe.",
         "Create `crates/scp-mcp/namespace.rs` with namespace parsing logic for `context_id/tool_name` format.",
         "Define built-in tool definitions: send_message, read_messages, list_members with their input/output schemas.",
-        "Implement namespace construction for context-registered tools."
+        "Implement namespace construction for context-registered outlets."
       ],
       "blockedBy": [
         "SCP-026"
@@ -2894,18 +2894,18 @@
       "files": [
         "crates/scp-mcp/server.rs"
       ],
-      "description": "Implement the MCP server that exposes SCP context tools to MCP-compatible models. The server handles tool listing with capability filtering (only tools the agent's role permits are listed), tool invocation routing through SCP context's tool invocation path, resource listing for context events/members/tools, and MCP lifecycle handling. Capability filtering queries the agent's UCAN capabilities and exposes only permitted tools. An agent with `member` role does not see admin-only tools.",
+      "description": "Implement the MCP server that exposes SCP context outlets to MCP-compatible models. The server handles tool listing with capability filtering (only tools the agent's role permits are listed), tool invocation routing through SCP context's outlet invocation path, resource listing for context events/members/tools, and MCP lifecycle handling. Capability filtering queries the agent's UCAN capabilities and exposes only permitted tools. An agent with `member` role does not see admin-only tools.",
       "acceptanceCriteria": [
         "`tools/list` JSON-RPC method returns all tools the agent can access across all active contexts.",
         "Tools are namespaced: `{ \"name\": \"context_a/guide_assistant\", \"inputSchema\": {...} }`.",
         "Built-in tools per context: `{context}/send_message`, `{context}/read_messages`, `{context}/list_members`.",
-        "Context-registered tools: `{context}/{tool_name}` for each tool in the context's tool registry.",
+        "Context-registered outlets: `{context}/{tool_name}` for each outlet in the context's outlet registry.",
         "Capability filtering: only tools the agent's role permits are listed. An agent with `member` role does not see admin-only tools.",
-        "Tool invocation: adapter parses the context namespace prefix, validates the agent's UCAN capability for the target tool in the target context, routes the invocation through the SCP context's tool invocation path (ADR-010).",
-        "Input is validated against the tool's input schema.",
-        "Output is validated against the tool's output schema.",
+        "Tool invocation: adapter parses the context namespace prefix, validates the agent's UCAN capability for the target outlet in the target context, routes the invocation through the SCP context's outlet invocation path (ADR-010).",
+        "Input is validated against the outlet's input schema.",
+        "Output is validated against the outlet's output schema.",
         "Provenance is attached to the result.",
-        "The JSON-RPC response contains the tool output as content.",
+        "The JSON-RPC response contains the outlet output as content.",
         "Errors are returned as JSON-RPC error responses with descriptive messages.",
         "`resources/list` returns SCP context event streams as MCP resources: `scp://context_a/events`, `scp://context_a/members`, `scp://context_a/tools`.",
         "`resources/read` returns the current state of a resource (e.g., member list, recent events).",
@@ -2916,7 +2916,7 @@
       "actionItems": [
         "Create `crates/scp-mcp/server.rs` with MCP server struct holding agent identity, active contexts, and UCAN capabilities.",
         "Implement `tools/list` handler that iterates all active contexts, resolves agent capabilities, filters tools by role, and returns namespaced tool definitions.",
-        "Implement `tools/call` handler that parses namespace prefix, validates UCAN capability, validates input schema, routes through SCP tool invocation, validates output schema, attaches provenance, returns JSON-RPC response.",
+        "Implement `tools/call` handler that parses namespace prefix, validates UCAN capability, validates input schema, routes through SCP outlet invocation, validates output schema, attaches provenance, returns JSON-RPC response.",
         "Implement `resources/list` handler returning context event streams, member lists, and tool registries as MCP resources.",
         "Implement `resources/read` handler returning current state of requested resource.",
         "Implement `resources/subscribe` handler mapping to SCP context event streams.",
@@ -3036,7 +3036,7 @@
       ],
       "description": "Implement the Python MCP wrapper module `scp_sdk/mcp.py` that wraps the Rust MCP server/client via the PyO3 bridge. Provides `serve_mcp()` for starting an MCP server and `McpClient` for consuming external tools. Implement CLI entry point `scp-mcp serve` for integration with MCP hosts that launch servers as subprocesses.",
       "acceptanceCriteria": [
-        "`serve_mcp(identity, contexts, transport)` starts an MCP server that dynamically exposes tools from the agent's active SCP contexts.",
+        "`serve_mcp(identity, contexts, transport)` starts an MCP server that dynamically exposes outlets from the agent's active SCP contexts.",
         "Transport parameter accepts `\"stdio\"` or `\"sse\"`.",
         "`McpClient.connect(transport, command)` connects to external MCP servers.",
         "`McpClient.list_tools()` lists available external tools.",
@@ -3361,19 +3361,19 @@
       "files": [
         "tests/integration/phase3_integration_test.py"
       ],
-      "description": "The ultimate acceptance criterion for Phase 3 exercises all 4 ADRs together with the Phase 1 and Phase 2 Rust stacks. Two Python agents on different machines exchange encrypted messages, invoke tools, and expose SCP contexts as MCP tools. This test proves: pip install works without Rust, the 20-line agent works, async Python wraps Rust correctly, UCAN enforces on every action, MCP exposes SCP tools to any model, the event log is queryable from Python, and the full Phase 1 + Phase 2 Rust stack is accessible through a Pythonic API.",
+      "description": "The ultimate acceptance criterion for Phase 3 exercises all 4 ADRs together with the Phase 1 and Phase 2 Rust stacks. Two Python agents on different machines exchange encrypted messages, invoke outlets, and expose SCP contexts as MCP tools. This test proves: pip install works without Rust, the 20-line agent works, async Python wraps Rust correctly, UCAN enforces on every action, MCP exposes SCP outlets to any model, the event log is queryable from Python, and the full Phase 1 + Phase 2 Rust stack is accessible through a Pythonic API.",
       "acceptanceCriteria": [
         "Install the SDK: `pip install scp-python` in a clean Python venv. No Rust toolchain. Zero compilation. Binary wheel installs in seconds.",
         "Alice creates an identity in Python: `alice = await scp.Identity.create(custody=\"in_memory\")`. Calls through: Python wrapper (ADR-014) -> PyO3 bridge (ADR-013) -> scp-core Identity::create.",
-        "Alice creates a context with outlets: `ctx = await scp.Context.create(creator=alice, ceiling=[\"messaging\", \"outlet_call\"], tools=[scp.OutletDefinition(name=\"calculator\", ...)])`. Context creation mints admin UCAN tokens for Alice (ADR-016). UCAN nonce is generated and tracked. Capability ceiling is set and immutable.",
+        "Alice creates a context with outlets: `ctx = await scp.Context.create(creator=alice, ceiling=[\"messaging\", \"outlet_call\"], outlets=[scp.OutletDefinition(name=\"calculator\", ...)])`. Context creation mints admin UCAN tokens for Alice (ADR-016). UCAN nonce is generated and tracked. Capability ceiling is set and immutable.",
         "Bob creates an identity and joins the context: `bob = await scp.Identity.create(custody=\"in_memory\")`, `membership = await ctx.join(bob)`. Bob receives member-role UCAN tokens (ADR-016). Tokens are scoped to messages:read, messages:write, outlet_query_all, outlet_call_all. UCAN signature chain traces to Alice (context creator) as root authority.",
         "Alice sends a message — UCAN validated: `await ctx.send(\"Hello from Python\", identity=alice)`. Internally: validate_ucan(ctx, alice_token, \"messages:write\") passes (ADR-016). Message flows through scp-core: sender key encrypt -> MLS encrypt -> envelope -> multi-relay publish. All via PyO3 bridge (ADR-013).",
         "Bob receives the message via async iterator: `async for msg in ctx.receive(): print(msg.content)`. Async iterator bridges tokio stream -> Python asyncio via PyO3 native async (ADR-013).",
         "Bob invokes the calculator outlet: `result = await ctx.invoke(\"calculator\", {\"operation\": \"add\", \"a\": 1, \"b\": 2})`, `assert result == {\"result\": 3}`. UCAN validates Bob has outlet_call capability (ADR-016). Outlet invocation is logged in the Merkle event log.",
         "Bob attempts an admin action — UCAN rejects: `await ctx.close(identity=bob)` raises `scp.UcanPermissionError`. Bob lacks context:close capability. UCAN validation failed (ADR-016).",
         "Start an MCP server exposing Alice's SCP contexts (ADR-015): `server = await scp.mcp.serve_mcp(identity=alice, contexts=[ctx], transport=\"stdio\")`. tools/list returns namespaced tools. Admin tools visible because Alice is admin. Member tools only visible for member-role agent.",
-        "MCP client invokes a tool: `tools/call(\"ctx_123/calculator\", {\"operation\": \"multiply\", \"a\": 3, \"b\": 7})` returns `{\"result\": 21}`. MCP adapter parses context namespace, validates UCAN, routes through scp-core tool invocation, returns result via JSON-RPC. The model never saw a DID, UCAN token, MLS group, or relay.",
-        "Verify event log from Python: `events = await ctx.event_log.query(event_type=\"tool_invoked\")`, `proof = await ctx.event_log.verify({\"event_exists\": events[0].id})`, `assert proof.valid`. Merkle proof verification runs in Rust, result returned to Python (ADR-013).",
+        "MCP client invokes a tool: `tools/call(\"ctx_123/calculator\", {\"operation\": \"multiply\", \"a\": 3, \"b\": 7})` returns `{\"result\": 21}`. MCP adapter parses context namespace, validates UCAN, routes through scp-core outlet invocation, returns result via JSON-RPC. The model never saw a DID, UCAN token, MLS group, or relay.",
+        "Verify event log from Python: `events = await ctx.event_log.query(event_type=\"outlet_invoked\")`, `proof = await ctx.event_log.verify({\"event_exists\": events[0].id})`, `assert proof.valid`. Merkle proof verification runs in Rust, result returned to Python (ADR-013).",
         "Alice revokes Bob's outlet invocation capability: `await scp.ucan.revoke(context=ctx, token=membership.tokens[\"outlet_call_all\"])`. Revocation distributed via MLS to all members (ADR-016). Bob's next outlet invocation attempt fails with UcanPermissionError.",
         "Throughout: Every Python async call crosses the PyO3 bridge (ADR-013), runs on the shared tokio runtime, and returns results as native Python objects. No Rust concepts leak. Errors are Python exceptions. Types have full PEP 484 hints. IDE autocompletion works."
       ],
@@ -3381,11 +3381,11 @@
         "Create `tests/integration/phase3_integration_test.py` with the 13-step end-to-end test.",
         "Set up clean Python venv and verify `pip install scp-python` works without Rust toolchain.",
         "Test identity creation via Python SDK -> PyO3 bridge -> scp-core.",
-        "Test context creation with tools, UCAN minting, and ceiling enforcement.",
+        "Test context creation with outlets, UCAN minting, and ceiling enforcement.",
         "Test member join with role-scoped UCAN token delegation.",
         "Test message send with UCAN validation, encryption, and transport.",
         "Test async message receive via Python async iterator bridging tokio stream.",
-        "Test tool invocation with UCAN capability validation and event log recording.",
+        "Test outlet invocation with UCAN capability validation and event log recording.",
         "Test UCAN rejection: member attempting admin action gets UcanPermissionError.",
         "Test MCP server tool listing with capability filtering.",
         "Test MCP tool invocation routing through SCP context.",
@@ -3424,7 +3424,7 @@
         }
       ],
       "details": {},
-      "result": "Phase 3 end-to-end Python SDK integration test created at tests/integration/phase3_integration_test.py. Exercises Identity, Context, Tools, UCAN, MCP, and EventLog across PyO3 bridge."
+      "result": "Phase 3 end-to-end Python SDK integration test created at tests/integration/phase3_integration_test.py. Exercises Identity, Context, Outlets, UCAN, MCP, and EventLog across PyO3 bridge."
     },
     {
       "id": "SCP-059",
@@ -3540,9 +3540,9 @@
       "description": "Implement `scp-core/trust/` module root with `TrustInput` struct and re-exports, plus `ParticipationRecord` and `compute_participation_record` in participation.rs. Participation records are computed locally from event logs (not stored centrally) — any agent computes from accessible logs. Two agents may compute different records from different event log views — this is correct behavior, not a bug. The trust engine provides validated inputs for agent-level evaluation — it does not produce trust 'scores.'",
       "acceptanceCriteria": [
         "TrustInput struct defined with fields: verified_attestations (Vec<Attestation>), participation_record (ParticipationRecord), challenge_results (Vec<(ChallengeRequest, ChallengeResponse)>), consequence_structure (Vec<ConsequenceRule>), threshold_counts (HashMap<AttestationType, (u32, u32)>)",
-        "ParticipationRecord struct defined with fields: subject_did (DID), context_id (ContextId), participation_count (u64), participation_duration_seconds (u64), tool_invocations (HashMap<OutletId, u64>), governance_actions_by (Vec<GovernanceActionSummary>), governance_actions_against (Vec<GovernanceActionSummary>), role_history (Vec<RoleTransition>), attestation_history (Vec<AttestationReference>), context_creation_count (u64), computed_at (u64), event_log_root ([u8; 32])",
+        "ParticipationRecord struct defined with fields: subject_did (DID), context_id (ContextId), participation_count (u64), participation_duration_seconds (u64), outlet_invocations (HashMap<OutletId, u64>), governance_actions_by (Vec<GovernanceActionSummary>), governance_actions_against (Vec<GovernanceActionSummary>), role_history (Vec<RoleTransition>), attestation_history (Vec<AttestationReference>), context_creation_count (u64), computed_at (u64), event_log_root ([u8; 32])",
         "compute_participation_record(event_log, subject_did) -> Result<ParticipationRecord, TrustError> scans event log entries for the subject DID",
-        "compute_participation_record computes the leaf-derived facts from the event log (participation count/duration, tool invocations by type/frequency, governance actions against/by identity, role progression, context creation history) and populates attestation history from the credential layer (§7.4) — attestation_history/attestation_count is the one exception that is NOT event-log-derived and NOT covered by event_log_root (there is no AttestationPublished event type; attestations are credential-layer artifacts threaded in by the caller, verifier-relative)",
+        "compute_participation_record computes the leaf-derived facts from the event log (participation count/duration, outlet invocations by type/frequency, governance actions against/by identity, role progression, context creation history) and populates attestation history from the credential layer (§7.4) — attestation_history/attestation_count is the one exception that is NOT event-log-derived and NOT covered by event_log_root (there is no AttestationPublished event type; attestations are credential-layer artifacts threaded in by the caller, verifier-relative)",
         "compute_participation_record captures the Merkle root at computation time for verifiability",
         "compute_participation_record is pure computation — no side effects, no storage",
         "Module root re-exports all public types from submodules"
@@ -3552,7 +3552,7 @@
         "Create crates/scp-core/trust/participation.rs with ParticipationRecord struct and supporting types (GovernanceActionSummary, RoleTransition, AttestationReference)",
         "Implement compute_participation_record that scans event log for subject DID entries",
         "Implement participation count and duration computation from MemberJoined/MemberLeft events",
-        "Implement tool invocation frequency computation from OutletInvoked events",
+        "Implement outlet invocation frequency computation from OutletInvoked events",
         "Implement governance action extraction (actions by and against subject)",
         "Implement role history extraction from RoleAssigned events",
         "Implement attestation history population from the credential layer (§7.4), NOT from event-log entries — attestation_history is the credential-layer exception, sourced from accessible, currently-valid endorsements rather than context-log leaves",
@@ -3575,7 +3575,7 @@
         "estimatedFunctions": "~5 public functions, ~4 internal helpers",
         "rustTypes": {
           "TrustInput": "pub struct TrustInput { pub verified_attestations: Vec<Attestation>, pub participation_record: ParticipationRecord, pub challenge_results: Vec<(ChallengeRequest, ChallengeResponse)>, pub consequence_structure: Vec<ConsequenceRule>, pub threshold_counts: HashMap<AttestationType, (u32, u32)> }",
-          "ParticipationRecord": "pub struct ParticipationRecord { pub subject_did: DID, pub context_id: ContextId, pub participation_count: u64, pub participation_duration_seconds: u64, pub tool_invocations: HashMap<OutletId, u64>, pub governance_actions_by: Vec<GovernanceActionSummary>, pub governance_actions_against: Vec<GovernanceActionSummary>, pub role_history: Vec<RoleTransition>, pub attestation_history: Vec<AttestationReference>, pub context_creation_count: u64, pub computed_at: u64, pub event_log_root: [u8; 32] }"
+          "ParticipationRecord": "pub struct ParticipationRecord { pub subject_did: DID, pub context_id: ContextId, pub participation_count: u64, pub participation_duration_seconds: u64, pub outlet_invocations: HashMap<OutletId, u64>, pub governance_actions_by: Vec<GovernanceActionSummary>, pub governance_actions_against: Vec<GovernanceActionSummary>, pub role_history: Vec<RoleTransition>, pub attestation_history: Vec<AttestationReference>, pub context_creation_count: u64, pub computed_at: u64, pub event_log_root: [u8; 32] }"
         }
       }
     },
@@ -3709,7 +3709,7 @@
         "ConsequenceAction enum with variants: CapabilitySuspension(Vec<Capability>), AccessRevocation, RoleDemotion { to_role: String }",
         "evaluate_consequence_rules(rules, event_log, subject_did) -> Vec<TriggeredConsequence> checks each rule's trigger condition against event log data within the rule's time window",
         "Message velocity threshold triggers capability suspension",
-        "Tool rate threshold triggers access revocation",
+        "Outlet rate threshold triggers access revocation",
         "Warning count triggers role demotion",
         "Returns list of triggered consequences with the triggering evidence"
       ],
@@ -3717,7 +3717,7 @@
         "Create crates/scp-core/trust/consequence.rs with ConsequenceRule, ConsequenceTrigger, ConsequenceAction, TriggeredConsequence types",
         "Implement evaluate_consequence_rules that iterates rules and checks triggers against event log",
         "Implement MessageVelocity trigger: count messages in time window, compare to threshold",
-        "Implement OutletRateExceeded trigger: count tool invocations in time window, compare to threshold",
+        "Implement OutletRateExceeded trigger: count outlet invocations in time window, compare to threshold",
         "Implement WarningCount trigger: count warning events in time window, compare to threshold",
         "Implement Custom trigger: match custom trigger string against event log entries",
         "Collect triggering evidence (event references) for each triggered consequence",
@@ -4066,9 +4066,9 @@
       "files": [
         "crates/scp-core/provenance/attach.rs"
       ],
-      "description": "Implement automatic provenance attachment on cross-context data flows and chain depth enforcement. Provenance is attached automatically by the protocol when data crosses context boundaries through protocol mechanisms (tool interfaces §6.2, structured messages). Chain depth is tracked and limited to prevent unbounded cross-context traversal (default max: 8 hops (ADR-043)).",
+      "description": "Implement automatic provenance attachment on cross-context data flows and chain depth enforcement. Provenance is attached automatically by the protocol when data crosses context boundaries through protocol mechanisms (outlet interfaces §6.2, structured messages). Chain depth is tracked and limited to prevent unbounded cross-context traversal (default max: 8 hops (ADR-043)).",
       "acceptanceCriteria": [
-        "attach_provenance(source_context, target_context, data) -> DataProvenance called automatically on cross-context tool interface calls",
+        "attach_provenance(source_context, target_context, data) -> DataProvenance called automatically on cross-context outlet interface calls",
         "attach_provenance populates all fields from source context state",
         "attach_provenance increments chain_depth from any existing provenance on the data",
         "attach_provenance populates counterparties from source context membership roster at time of data flow",
@@ -4165,7 +4165,7 @@
         "crates/scp-core/discovery/mod.rs",
         "crates/scp-core/discovery/did_capabilities.rs"
       ],
-      "description": "Implement `scp-core/discovery/` module root with all discovery types and DID document capability resolution. DID documents contain a SCPCapabilities service entry that lists an agent's capabilities — resolvable by anyone who knows the DID. Any agent can publish capabilities in their DID document — zero setup, zero registration, zero dependency on contexts with discovery tools.",
+      "description": "Implement `scp-core/discovery/` module root with all discovery types and DID document capability resolution. DID documents contain a SCPCapabilities service entry that lists an agent's capabilities — resolvable by anyone who knows the DID. Any agent can publish capabilities in their DID document — zero setup, zero registration, zero dependency on contexts with discovery outlets.",
       "acceptanceCriteria": [
         "CapabilityEntry struct defined with fields: did (DID), capabilities (Vec<String>), service_endpoints (Vec<String>), resolved_at (u64)",
         "DiscoveryQuery struct defined with fields: capability_filter (Option<Vec<String>>), keywords (Option<Vec<String>>), min_history (Option<Duration>)",
@@ -4206,7 +4206,7 @@
           "RegistrationEntry": "pub struct RegistrationEntry { pub did: DID, pub capabilities: Vec<String>, pub metadata: serde_json::Value, pub entry_id: String, pub registered_at: u64 }",
           "DiscoveryBootstrap": "pub struct DiscoveryBootstrap { pub default_context_ids: Vec<ContextId> }"
         },
-        "standardToolSchemas": {
+        "standardOutletSchemas": {
           "agent_search": "agent_search(query) -> { results: [{ did, capabilities, participation_summary }] }",
           "agent_register": "agent_register(did, capabilities, metadata) -> { registered, entry_id }",
           "agent_deregister": "agent_deregister(did) -> { removed }"
@@ -4215,7 +4215,7 @@
     },
     {
       "id": "SCP-074",
-      "title": "Implement context standard tools and two-tier membership",
+      "title": "Implement context standard outlets and two-tier membership",
       "gate": "gate-4",
       "priority": "P1",
       "severity": "major",
@@ -4223,15 +4223,15 @@
       "files": [
         "crates/scp-core/discovery/context.rs"
       ],
-      "description": "Implement contexts with discovery tools as standard SCP contexts with standardized tool schemas. Two-tier membership separates writers (MLS members, bounded at 500) from readers (DID-authenticated, unbounded). Registration flow: reader sends DID-signed request, writer verifies signature and records in event log. Self-service updates via DID-authenticated requests.",
+      "description": "Implement contexts with discovery outlets as standard SCP contexts with standardized outlet schemas. Two-tier membership separates writers (MLS members, bounded at 500) from readers (DID-authenticated, unbounded). Registration flow: reader sends DID-signed request, writer verifies signature and records in event log. Self-service updates via DID-authenticated requests.",
       "acceptanceCriteria": [
         "agent_search, agent_register, agent_deregister implemented per standard schema",
-        "Custom tools (reputation scoring, category browsing, geographic filtering) allowed beyond standard",
+        "Custom outlets (reputation scoring, category browsing, geographic filtering) allowed beyond standard",
         "Writer tier: MLS members, bounded at 500, process registrations as MLS application messages",
-        "Reader tier: DID-authenticated, unbounded, query via tool endpoints without MLS join",
+        "Reader tier: DID-authenticated, unbounded, query via outlet endpoints without MLS join",
         "Registration flow: reader sends DID-signed request, writer verifies signature, records in event log as application message",
         "Registrant does NOT become MLS member",
-        "Self-service updates: registered agents update entries via DID-authenticated requests to tool endpoints",
+        "Self-service updates: registered agents update entries via DID-authenticated requests to outlet endpoints",
         "Writers verify DID matches entry owner before applying update",
         "Privacy: registration opt-in per context, metadata controlled per registry, withdrawable via agent_deregister",
         "Agent can publish different capability subsets to different registries",
@@ -4239,17 +4239,17 @@
         "Readers can request inclusion proofs to verify registration and audit registry integrity"
       ],
       "actionItems": [
-        "Create crates/scp-core/discovery/context.rs with context tool implementations",
-        "Implement agent_search tool: query registered entries by capability, keywords, history",
-        "Implement agent_register tool: validate DID-signed request, record in event log",
-        "Implement agent_deregister tool: validate DID ownership, remove entry",
+        "Create crates/scp-core/discovery/context.rs with context outlet implementations",
+        "Implement agent_search outlet: query registered entries by capability, keywords, history",
+        "Implement agent_register outlet: validate DID-signed request, record in event log",
+        "Implement agent_deregister outlet: validate DID ownership, remove entry",
         "Implement two-tier membership: writer tier (MLS, bounded 500) and reader tier (DID-authenticated, unbounded)",
         "Implement registration flow: DID signature verification, event log recording, no MLS membership for registrant",
         "Implement self-service update: verify DID matches entry owner, apply update",
         "Implement privacy controls: opt-in registration, per-registry metadata, different capability subsets per registry",
         "Implement Merkle event log recording for all writes",
         "Implement inclusion proof requests for readers to verify registrations",
-        "Write unit tests for each tool, membership tiers, and registration flows"
+        "Write unit tests for each outlet, membership tiers, and registration flows"
       ],
       "blockedBy": [
         "SCP-073",
@@ -4267,13 +4267,13 @@
         "module": "scp-core/discovery/context.rs",
         "estimatedFunctions": "~5 public functions, ~4 internal helpers",
         "writerTierLimit": 500,
-        "standardTools": [
+        "standardOutlets": [
           "agent_search",
           "agent_register",
           "agent_deregister"
         ]
       },
-      "result": "Context tools with writer/reader tiers, search/register/deregister. 54 tests."
+      "result": "Context outlets with writer/reader tiers, search/register/deregister. 54 tests."
     },
     {
       "id": "SCP-075",
@@ -4288,14 +4288,14 @@
       "description": "Implement unified_search that merges local cache, DID resolution, and context queries. SDK provides unified search that merges results from multiple sources with provenance per entry. Results are deduplicated and ranked by relevance.",
       "acceptanceCriteria": [
         "unified_search(query, known_contexts) -> Result<DiscoveryResult, DiscoveryError> searches local contact cache (instant)",
-        "unified_search queries each known context (parallel tool calls)",
+        "unified_search queries each known context (parallel outlet calls)",
         "unified_search merges, deduplicates, and ranks results",
         "Returns results with provenance per entry"
       ],
       "actionItems": [
         "Create crates/scp-core/discovery/search.rs with unified_search function",
         "Implement local contact cache search (instant lookup)",
-        "Implement parallel context querying via tool calls",
+        "Implement parallel context querying via outlet calls",
         "Implement result merging from multiple sources",
         "Implement deduplication by DID",
         "Implement relevance ranking",
@@ -4332,7 +4332,7 @@
         "SDK ships configurable default bootstrap context IDs",
         "Auto-query on first identity creation (opt-out)",
         "Fallback to direct DID resolution + manual context ID sharing",
-        "Users can add custom contexts with discovery tools"
+        "Users can add custom contexts with discovery outlets"
       ],
       "actionItems": [
         "Create crates/scp-core/discovery/bootstrap.rs with DiscoveryBootstrap implementation",
@@ -4428,7 +4428,7 @@
       "files": [
         "crates/scp-ffi/uniffi/src/bridge.rs"
       ],
-      "description": "Implement async function bridging strategy (UniFFI supports async via polling futures) and Rust-side scaffolding that connects the UDL definitions to the actual scp-core implementations. Async operations include context creation, message send/receive, tool invocation, and trust evaluation.",
+      "description": "Implement async function bridging strategy (UniFFI supports async via polling futures) and Rust-side scaffolding that connects the UDL definitions to the actual scp-core implementations. Async operations include context creation, message send/receive, outlet invocation, and trust evaluation.",
       "acceptanceCriteria": [
         "Async function bridging via UniFFI polling futures for all async operations",
         "Sync function bridging for all synchronous operations",
@@ -4441,7 +4441,7 @@
         "Create crates/scp-ffi/uniffi/src/bridge.rs with async bridging implementations",
         "Implement async bridging for context lifecycle operations",
         "Implement async bridging for message send/receive operations",
-        "Implement async bridging for tool invocation operations",
+        "Implement async bridging for outlet invocation operations",
         "Implement async bridging for trust evaluation operations",
         "Implement sync bridging for type construction and query operations",
         "Wire Rust scaffolding to scp-core public API",
@@ -4548,10 +4548,10 @@
         "bindings/typescript/package.json",
         "bindings/typescript/tsup.config.ts"
       ],
-      "description": "Implement the TypeScript SDK (@limn-works/scp-ts) over the napi-rs native addon for Bun/Node in-process use. Internal bridge module exposes the napi backend. Browser clients are remote thin clients to a server-side scp-node (ADR-055, which supersedes ADR-034) — there is no in-process browser engine. Public API surface covers Identity, Context, Tools, Trust, EventLog, Transport, UCAN, MCP modules. Build pipeline: tsup config for dual ESM/CJS output. Streaming via AsyncIterable for message streams, disposal via Symbol.asyncDispose.",
+      "description": "Implement the TypeScript SDK (@limn-works/scp-ts) over the napi-rs native addon for Bun/Node in-process use. Internal bridge module exposes the napi backend. Browser clients are remote thin clients to a server-side scp-node (ADR-055, which supersedes ADR-034) — there is no in-process browser engine. Public API surface covers Identity, Context, Outlets, Trust, EventLog, Transport, UCAN, MCP modules. Build pipeline: tsup config for dual ESM/CJS output. Streaming via AsyncIterable for message streams, disposal via Symbol.asyncDispose.",
       "acceptanceCriteria": [
         "Bridge module exposes the napi-rs backend for Bun/Node runtimes",
-        "Public API surface exposes: Identity, Context, Tools, Trust, EventLog, Transport, UCAN, MCP modules",
+        "Public API surface exposes: Identity, Context, Outlets, Trust, EventLog, Transport, UCAN, MCP modules",
         "Error mapping: Rust Result maps to typed TypeScript exceptions (ScpError hierarchy from scaffold)",
         "Streaming: AsyncIterable for message streams, disposal via Symbol.asyncDispose",
         "Build pipeline: tsup config for dual ESM/CJS output",
@@ -4566,7 +4566,7 @@
         "Create bindings/typescript/src/index.ts with public API re-exports",
         "Implement Identity module wrapping bridge calls",
         "Implement Context module wrapping bridge calls",
-        "Implement Tools module wrapping bridge calls",
+        "Implement Outlets module wrapping bridge calls",
         "Implement Trust module wrapping bridge calls",
         "Implement EventLog module wrapping bridge calls",
         "Implement Transport module wrapping bridge calls",
@@ -4608,7 +4608,7 @@
         "publicModules": [
           "Identity",
           "Context",
-          "Tools",
+          "Outlets",
           "Trust",
           "EventLog",
           "Transport",
@@ -5466,14 +5466,14 @@
         "bindings/swift/Sources/SCP/Errors.swift",
         "bindings/swift/Sources/SCP/Types.swift"
       ],
-      "description": "Bootstrap the Swift SDK package structure per `.docs/scaffold/swift.md`. Create Package.swift with SPM configuration, internal UniFFI-generated bindings placeholder, error hierarchy, and shared types.\n\nPackage.swift: swift-tools-version 6.2, platforms iOS 17+ and macOS 14+, binary target for ScpFFI XCFramework.\n\nError hierarchy: `ScpError` enum with associated values per `.docs/scaffold/swift.md`.\n\nShared types: `Message`, `Provenance`, `Capability` per `.docs/scaffold/swift.md`.\n\nFollow the Python SDK pattern (ADR-014): flat FFI bridge -> idiomatic language wrapper. Per `.docs/standards/swift.md`: Swift 6 strict concurrency, `@MainActor` default, `nonisolated` DTOs.\n\nThis is a stub ADR (ADR-026) — implementation details will be refined when the full ADR is written.",
+      "description": "Bootstrap the Swift SDK package structure per `.docs/scaffold/swift.md`. Create Package.swift with SPM configuration, internal UniFFI-generated bindings placeholder, error hierarchy, and shared types.\n\nPackage.swift: swift-outlets-version 6.2, platforms iOS 17+ and macOS 14+, binary target for ScpFFI XCFramework.\n\nError hierarchy: `ScpError` enum with associated values per `.docs/scaffold/swift.md`.\n\nShared types: `Message`, `Provenance`, `Capability` per `.docs/scaffold/swift.md`.\n\nFollow the Python SDK pattern (ADR-014): flat FFI bridge -> idiomatic language wrapper. Per `.docs/standards/swift.md`: Swift 6 strict concurrency, `@MainActor` default, `nonisolated` DTOs.\n\nThis is a stub ADR (ADR-026) — implementation details will be refined when the full ADR is written.",
       "acceptanceCriteria": [
-        "Package.swift uses swift-tools-version: 6.2",
+        "Package.swift uses swift-outlets-version: 6.2",
         "Platforms: .iOS(.v17), .macOS(.v14)",
         "Binary target ScpFFI configured for XCFramework",
         "Library target SCP depends on ScpFFI",
         "Test target SCPTests depends on SCP",
-        "ScpError enum has variants: identity, context, permission, crypto, transport, tool, validation — all with (message: String, code: String)",
+        "ScpError enum has variants: identity, context, permission, crypto, transport, outlet, validation — all with (message: String, code: String)",
         "ScpError conforms to Error, Sendable, LocalizedError",
         "Message struct is nonisolated and Sendable with fields: senderDid, content, timestamp, sequence, contextId, provenance",
         "Directory structure matches scaffold/swift.md layout",
@@ -5483,7 +5483,7 @@
         "Create bindings/swift/Package.swift per scaffold/swift.md",
         "Create bindings/swift/Sources/SCP/Internal/ directory with ScpBindings.swift placeholder",
         "Create Errors.swift with ScpError enum and LocalizedError conformance",
-        "Create Types.swift with Message, ToolDefinition, Provenance structs (nonisolated, Sendable)",
+        "Create Types.swift with Message, OutletDefinition, Provenance structs (nonisolated, Sendable)",
         "Ensure all DTOs are nonisolated structs per Swift 6.2 standards",
         "Verify package structure is valid SPM"
       ],
@@ -5639,24 +5639,24 @@
     },
     {
       "id": "SCP-101",
-      "title": "Implement Swift Trust, Tools, EventLog, Transport, UCAN, and MCP wrappers",
+      "title": "Implement Swift Trust, Outlets, EventLog, Transport, UCAN, and MCP wrappers",
       "gate": "gate-5",
       "priority": "P1",
       "severity": "major",
       "status": "done",
       "files": [
         "bindings/swift/Sources/SCP/Trust.swift",
-        "bindings/swift/Sources/SCP/Tools.swift",
+        "bindings/swift/Sources/SCP/Outlets.swift",
         "bindings/swift/Sources/SCP/EventLog.swift",
         "bindings/swift/Sources/SCP/Transport.swift",
         "bindings/swift/Sources/SCP/Ucan.swift",
         "bindings/swift/Sources/SCP/Mcp.swift"
       ],
-      "description": "Implement remaining Swift SDK wrapper modules per `.docs/scaffold/swift.md` package layout:\n\n- `Trust.swift` — `evaluateTrust()`, `TrustEvaluation` wrapping UniFFI trust evaluation\n- `Tools.swift` — `ToolDefinition`, `TestVector` structs, tool invocation via `ctx.invokeTool()`\n- `EventLog.swift` — `EventLog` class, `Event`, `Proof`, `Checkpoint` types\n- `Transport.swift` — `TransportConfig`, relay connection management\n- `Ucan.swift` — UCAN `validate()`, `mint()`, `revoke()` wrapping UniFFI UCAN bridge\n- `Mcp.swift` — `serveMcp()`, `McpClient` wrapping UniFFI MCP bridge\n\nAll types follow Swift 6 concurrency: DTOs are `nonisolated struct` (Sendable), stateful types use actors. Cross-language naming from `.docs/scaffold/shared.md`.\n\nThis is a stub ADR (ADR-026) — implementation details will be refined when the full ADR is written.",
+      "description": "Implement remaining Swift SDK wrapper modules per `.docs/scaffold/swift.md` package layout:\n\n- `Trust.swift` — `evaluateTrust()`, `TrustEvaluation` wrapping UniFFI trust evaluation\n- `Outlets.swift` — `OutletDefinition`, `TestVector` structs, outlet invocation via `ctx.invokeOutlet()`\n- `EventLog.swift` — `EventLog` class, `Event`, `Proof`, `Checkpoint` types\n- `Transport.swift` — `TransportConfig`, relay connection management\n- `Ucan.swift` — UCAN `validate()`, `mint()`, `revoke()` wrapping UniFFI UCAN bridge\n- `Mcp.swift` — `serveMcp()`, `McpClient` wrapping UniFFI MCP bridge\n\nAll types follow Swift 6 concurrency: DTOs are `nonisolated struct` (Sendable), stateful types use actors. Cross-language naming from `.docs/scaffold/shared.md`.\n\nThis is a stub ADR (ADR-026) — implementation details will be refined when the full ADR is written.",
       "acceptanceCriteria": [
         "Trust.swift exports evaluateTrust() and TrustEvaluation type",
-        "Tools.swift exports ToolDefinition and TestVector as nonisolated Sendable structs",
-        "Tools.swift supports ctx.invokeTool() cross-language naming",
+        "Outlets.swift exports OutletDefinition and TestVector as nonisolated Sendable structs",
+        "Outlets.swift supports ctx.invokeOutlet() cross-language naming",
         "EventLog.swift exports EventLog, Event, Proof, Checkpoint types",
         "Transport.swift exports TransportConfig for relay connection",
         "Ucan.swift exports validate(), mint(), revoke() functions",
@@ -5667,7 +5667,7 @@
       ],
       "actionItems": [
         "Create Trust.swift with evaluateTrust() wrapping UniFFI trust bridge",
-        "Create Tools.swift with ToolDefinition, TestVector structs",
+        "Create Outlets.swift with OutletDefinition, TestVector structs",
         "Create EventLog.swift with EventLog class and Event/Proof/Checkpoint types",
         "Create Transport.swift with TransportConfig and relay connection wrapper",
         "Create Ucan.swift with validate/mint/revoke wrapping UniFFI UCAN bridge",
@@ -5695,7 +5695,7 @@
         "adr": "ADR-026",
         "scaffoldRef": ".docs/scaffold/swift.md"
       },
-      "result": "All 6 Swift wrapper modules created (Trust, Tools, EventLog, Transport, Ucan, Mcp). All DTOs nonisolated Sendable structs. Doc comments on all public items. 10 acceptance criteria met."
+      "result": "All 6 Swift wrapper modules created (Trust, Outlets, EventLog, Transport, Ucan, Mcp). All DTOs nonisolated Sendable structs. Doc comments on all public items. 10 acceptance criteria met."
     },
     {
       "id": "SCP-102",
@@ -5707,19 +5707,19 @@
       "files": [
         "bindings/swift/Tests/SCPTests/IdentityTests.swift",
         "bindings/swift/Tests/SCPTests/ContextTests.swift",
-        "bindings/swift/Tests/SCPTests/ToolsTests.swift",
+        "bindings/swift/Tests/SCPTests/OutletsTests.swift",
         "bindings/swift/Tests/SCPTests/UcanTests.swift",
         "bindings/swift/Tests/SCPTests/TransportTests.swift",
         "bindings/swift/Tests/SCPTests/EventLogTests.swift",
         "bindings/swift/Tests/SCPTests/McpTests.swift",
         "bindings/swift/Tests/SCPTests/Conformance/ConformanceTests.swift"
       ],
-      "description": "Implement Swift SDK test suite per `.docs/scaffold/swift.md` and `.docs/standards/swift.md`. Uses Swift Testing framework (`@Test`, `#expect`).\n\nConformance tests load JSON fixtures from `tests/conformance/` (shared across all SDKs per `.docs/scaffold/shared.md`). Per-module tests cover Identity, Context, Tools, UCAN, Transport, EventLog, MCP.\n\nPer `.docs/standards/swift.md`: use Swift Testing, not XCTest. Tests are async (`async throws`). Parameterized tests use `@Test(arguments:)`.\n\nCI gate: no SDK release proceeds without 100% conformance test pass rate.\n\nThis is a stub ADR (ADR-026) — implementation details will be refined when the full ADR is written.",
+      "description": "Implement Swift SDK test suite per `.docs/scaffold/swift.md` and `.docs/standards/swift.md`. Uses Swift Testing framework (`@Test`, `#expect`).\n\nConformance tests load JSON fixtures from `tests/conformance/` (shared across all SDKs per `.docs/scaffold/shared.md`). Per-module tests cover Identity, Context, Outlets, UCAN, Transport, EventLog, MCP.\n\nPer `.docs/standards/swift.md`: use Swift Testing, not XCTest. Tests are async (`async throws`). Parameterized tests use `@Test(arguments:)`.\n\nCI gate: no SDK release proceeds without 100% conformance test pass rate.\n\nThis is a stub ADR (ADR-026) — implementation details will be refined when the full ADR is written.",
       "acceptanceCriteria": [
         "All test files use Swift Testing framework (@Test, #expect) — not XCTest",
         "IdentityTests covers create, load, rotate key, DID format validation",
         "ContextTests covers create, join, leave, close, send, receive",
-        "ToolsTests covers tool definition, invocation, test vector verification",
+        "OutletsTests covers outlet definition, invocation, test vector verification",
         "UcanTests covers validate, mint, revoke, delegation",
         "TransportTests covers connect, send envelope, subscribe",
         "EventLogTests covers append, prove inclusion, verify proof",
@@ -5730,7 +5730,7 @@
       "actionItems": [
         "Create IdentityTests.swift with @Test functions for identity operations",
         "Create ContextTests.swift with @Test functions for context lifecycle",
-        "Create ToolsTests.swift with @Test functions for tool operations",
+        "Create OutletsTests.swift with @Test functions for outlet operations",
         "Create UcanTests.swift with @Test functions for UCAN operations",
         "Create TransportTests.swift with @Test functions for transport operations",
         "Create EventLogTests.swift with @Test functions for event log operations",
@@ -5769,7 +5769,7 @@
         "standardsRef": ".docs/standards/swift.md",
         "ciGate": "No SDK release without 100% conformance test pass rate"
       },
-      "result": "Swift SDK conformance test suite implemented: 8 test files using Swift Testing framework (@Test, #expect, @Suite). Covers Identity, Context, Tools, UCAN, Transport, EventLog, MCP, and Conformance modules. Tests use mock context handles and bridge stub verification. Note: swift test blocked until XCFramework binary target is available."
+      "result": "Swift SDK conformance test suite implemented: 8 test files using Swift Testing framework (@Test, #expect, @Suite). Covers Identity, Context, Outlets, UCAN, Transport, EventLog, MCP, and Conformance modules. Tests use mock context handles and bridge stub verification. Note: swift test blocked until XCFramework binary target is available."
     },
     {
       "id": "SCP-103",
@@ -5872,12 +5872,12 @@
       "files": [
         "tests/phase5_integration.rs"
       ],
-      "description": "Phase 5 end-to-end integration test validating all four ADRs work together. Tests the full bridge-to-media-to-platform-to-SDK pipeline:\n\n1. **Bridge (ADR-023):** Register bridge, create shadow identity, bridge message with provenance, claim shadow, verify retroattribution.\n2. **Media (ADR-024):** Initiate media session with capability ceiling check, export MLS keys, exchange signaling messages, end session, verify event log.\n3. **Apple Platform (ADR-025):** Key custody operations through Secure Enclave/Keychain adapters, App Attest attestation, APNs push registration.\n4. **Swift SDK (ADR-026):** Identity create/load, context create/join/send/receive/leave, tool invocation, UCAN validation — all through Swift wrapper layer.\n\nThis test validates that Phase 5 components integrate with Phase 1-4 foundation (MLS, envelope, DID, context, UCAN, transport, event log, provenance, UniFFI).",
+      "description": "Phase 5 end-to-end integration test validating all four ADRs work together. Tests the full bridge-to-media-to-platform-to-SDK pipeline:\n\n1. **Bridge (ADR-023):** Register bridge, create shadow identity, bridge message with provenance, claim shadow, verify retroattribution.\n2. **Media (ADR-024):** Initiate media session with capability ceiling check, export MLS keys, exchange signaling messages, end session, verify event log.\n3. **Apple Platform (ADR-025):** Key custody operations through Secure Enclave/Keychain adapters, App Attest attestation, APNs push registration.\n4. **Swift SDK (ADR-026):** Identity create/load, context create/join/send/receive/leave, outlet invocation, UCAN validation — all through Swift wrapper layer.\n\nThis test validates that Phase 5 components integrate with Phase 1-4 foundation (MLS, envelope, DID, context, UCAN, transport, event log, provenance, UniFFI).",
       "acceptanceCriteria": [
         "Bridge registration, shadow creation, provenance marking, and claiming all succeed end-to-end",
         "Media session initiation with ceiling check, MLS key export, signaling exchange, and teardown all succeed end-to-end",
         "Apple platform adapters (Secure Enclave, Keychain, App Attest, APNs) pass integration tests on macOS",
-        "Swift SDK identity, context, tools, UCAN, transport, event log wrappers pass end-to-end through UniFFI bridge",
+        "Swift SDK identity, context, outlets, UCAN, transport, event log wrappers pass end-to-end through UniFFI bridge",
         "Bridged content carries correct BridgeProvenance through entire pipeline",
         "Media session keys are correctly derived from MLS group state",
         "All operations recorded in context event log",
@@ -6982,7 +6982,7 @@
         "note": "ADR not yet fully written — story derived from expected approach and known constraints. The core tension: event logs are verifiable because they're append-only, pruning breaks append-only.",
         "coreTension": "Event logs are verifiable because they're append-only. Pruning breaks append-only. The protocol must balance verifiability (full history provable) with storage (unbounded growth unsustainable on mobile devices).",
         "knownConstraints": [
-          "Protocol state footprint is deliberately minimal (§10.3): membership, roles, tokens, tool registrations, governance, content hashes — NOT content itself",
+          "Protocol state footprint is deliberately minimal (§10.3): membership, roles, tokens, outlet registrations, governance, content hashes — NOT content itself",
           "Event logs are per-context Merkle trees with SHA-256 hash chain (ADR-011)",
           "Must support inclusion proofs and consistency verification",
           "Participation validation (§7.3.1) depends on verifiable event logs"
@@ -7604,13 +7604,13 @@
         "crates/scp-core/context/invitation.rs",
         "crates/scp-core/context/manager.rs"
       ],
-      "description": "When the SDK receives a context invitation, it evaluates in this order: (1) Template check — if the invitation includes a template ID, validate that the context params match the template exactly. Reject if params don't match (prevents template spoofing — claiming `bilateral-ephemeral` but including tool capabilities). (2) Auto-accept check — if a matching policy exists, evaluate trust requirement, TTL cap, and rate limit. If all pass, join automatically. (3) Agent prompt — if no auto-accept policy matches, surface the invitation to the agent/human for decision. The invitation includes full context metadata (§5.7) plus the template ID if present.",
+      "description": "When the SDK receives a context invitation, it evaluates in this order: (1) Template check — if the invitation includes a template ID, validate that the context params match the template exactly. Reject if params don't match (prevents template spoofing — claiming `bilateral-ephemeral` but including outlet capabilities). (2) Auto-accept check — if a matching policy exists, evaluate trust requirement, TTL cap, and rate limit. If all pass, join automatically. (3) Agent prompt — if no auto-accept policy matches, surface the invitation to the agent/human for decision. The invitation includes full context metadata (§5.7) plus the template ID if present.",
       "acceptanceCriteria": [
-        "Step 1 — Template check: if the invitation includes a template ID, validate that the context params match the template exactly. Reject if params don't match (prevents template spoofing — claiming `bilateral-ephemeral` but including tool capabilities)",
+        "Step 1 — Template check: if the invitation includes a template ID, validate that the context params match the template exactly. Reject if params don't match (prevents template spoofing — claiming `bilateral-ephemeral` but including outlet capabilities)",
         "Step 2 — Auto-accept check: if a matching auto-accept policy exists, evaluate trust requirement, TTL cap, and rate limit. If all conditions pass, join the context automatically",
         "Step 3 — Agent prompt: if no auto-accept policy matches, surface the invitation to the agent/human for decision. The invitation includes full context metadata (§5.7) plus the template ID if present",
         "Evaluation order is strictly sequential: template check before auto-accept, auto-accept before agent prompt",
-        "Template spoofing rejection: an invitation claiming `bilateral-ephemeral` template but including tool capabilities is rejected at step 1",
+        "Template spoofing rejection: an invitation claiming `bilateral-ephemeral` template but including outlet capabilities is rejected at step 1",
         "Rate limiting: auto-accept evaluates a per-peer rate limit to prevent invitation flooding",
         "Unit test: invitation with valid template passes step 1",
         "Unit test: invitation with spoofed template (params don't match template definition) is rejected at step 1",
@@ -7709,19 +7709,19 @@
         "bindings/swift/README.md",
         "bindings/kotlin/README.md"
       ],
-      "description": "Every SDK ships with: (1) README.md — Quick start (install, create identity, create context, send message) in under 30 lines, (2) API reference — Generated from source (rustdoc, pydoc, typedoc, DocC, KDoc, godoc, xmldoc, javadoc), (3) Type stubs / declarations — For IDE autocompletion and static analysis (.pyi, .d.ts, etc.), (4) Examples directory — Runnable examples covering: basic messaging, tool invocation, MCP integration, multi-agent coordination.",
+      "description": "Every SDK ships with: (1) README.md — Quick start (install, create identity, create context, send message) in under 30 lines, (2) API reference — Generated from source (rustdoc, pydoc, typedoc, DocC, KDoc, godoc, xmldoc, javadoc), (3) Type stubs / declarations — For IDE autocompletion and static analysis (.pyi, .d.ts, etc.), (4) Examples directory — Runnable examples covering: basic messaging, outlet invocation, MCP integration, multi-agent coordination.",
       "acceptanceCriteria": [
         "Every SDK ships a README.md with quick start (install, create identity, create context, send message) in under 30 lines of code",
         "Every SDK ships generated API reference documentation from source: Rust (rustdoc), Python (pydoc), TypeScript (typedoc), Swift (DocC), Kotlin (KDoc), Go (godoc), C# (xmldoc), Java (javadoc)",
         "Every SDK ships type stubs / declarations for IDE autocompletion and static analysis: Python (.pyi), TypeScript (.d.ts), etc.",
-        "Every SDK ships an examples directory with runnable examples covering: basic messaging, tool invocation, MCP integration, multi-agent coordination",
+        "Every SDK ships an examples directory with runnable examples covering: basic messaging, outlet invocation, MCP integration, multi-agent coordination",
         "CI generates and publishes API reference docs on every release"
       ],
       "actionItems": [
         "Create README.md template with <30-line quick start for each SDK language",
         "Configure API reference generation: rustdoc for Rust crates, pydoc/sphinx for Python, typedoc for TypeScript, DocC for Swift, KDoc for Kotlin, godoc for Go, xmldoc for C#, javadoc for Java",
         "Generate type stubs: .pyi for Python (via stubgen or manual), .d.ts for TypeScript (via tsc --declaration)",
-        "Create examples directory for each SDK with 4 runnable examples: basic messaging, tool invocation, MCP integration, multi-agent coordination",
+        "Create examples directory for each SDK with 4 runnable examples: basic messaging, outlet invocation, MCP integration, multi-agent coordination",
         "Add CI step to generate and publish API docs on release"
       ],
       "blockedBy": [
@@ -7737,7 +7737,7 @@
         }
       ],
       "details": {
-        "Documentation deliverables": "1. README.md — Quick start in <30 lines.\n2. API reference — Generated from source (rustdoc, pydoc, typedoc, DocC, KDoc, godoc, xmldoc, javadoc).\n3. Type stubs — .pyi, .d.ts, etc.\n4. Examples directory — basic messaging, tool invocation, MCP integration, multi-agent coordination."
+        "Documentation deliverables": "1. README.md — Quick start in <30 lines.\n2. API reference — Generated from source (rustdoc, pydoc, typedoc, DocC, KDoc, godoc, xmldoc, javadoc).\n3. Type stubs — .pyi, .d.ts, etc.\n4. Examples directory — basic messaging, outlet invocation, MCP integration, multi-agent coordination."
       },
       "result": "SDK documentation for all 7 language bindings: README.md with <30-line quick start, examples/ directory with 4 runnable examples each, TypeScript .d.ts type declarations, Python py.typed marker, sphinx docs config, typedoc config, and CI docs.yml workflow for API reference generation on release. Swift DocC generation moved from docs.yml to build-matrix.yml (swift-xcframework job) because DocC requires the compiled ScpFFI.xcframework binary target."
     },
@@ -7751,7 +7751,7 @@
       "files": [
         "crates/scp-core/src/identity/document.rs"
       ],
-      "description": "PATCH to SCP-006 (done). SCP-006 created DidDocument with only PreRotationCommitment service. §18.2 defines SCPRelay as a DID document service endpoint type for relay transport URLs — the endpoints where TransportManager (ADR-012) routes encrypted blobs to the identity. This story extends document.rs to support SCPRelay entries. This patch is considered more recent than SCP-006.\n\nThe SCPRelay service endpoint type declares transport-layer relay URLs. URL format: wss://<host>/scp/v1 (ADR-004). TLS 1.3 required (§9.13). Multiple entries allowed for suppression resistance (§9.9.2, ADR-012). Self-certified via BEP44 (§9.6.3). Sequence number monotonicity applies.\n\nSCPRelay is distinct from SCPCapabilities (ADR-020): SCPRelay = transport layer (where to send encrypted blobs, consumed by TransportManager), SCPCapabilities = application layer (what tools/capabilities an agent offers, consumed by Discovery Engine).",
+      "description": "PATCH to SCP-006 (done). SCP-006 created DidDocument with only PreRotationCommitment service. §18.2 defines SCPRelay as a DID document service endpoint type for relay transport URLs — the endpoints where TransportManager (ADR-012) routes encrypted blobs to the identity. This story extends document.rs to support SCPRelay entries. This patch is considered more recent than SCP-006.\n\nThe SCPRelay service endpoint type declares transport-layer relay URLs. URL format: wss://<host>/scp/v1 (ADR-004). TLS 1.3 required (§9.13). Multiple entries allowed for suppression resistance (§9.9.2, ADR-012). Self-certified via BEP44 (§9.6.3). Sequence number monotonicity applies.\n\nSCPRelay is distinct from SCPCapabilities (ADR-020): SCPRelay = transport layer (where to send encrypted blobs, consumed by TransportManager), SCPCapabilities = application layer (what outlets/capabilities an agent offers, consumed by Discovery Engine).",
       "acceptanceCriteria": [
         "SCPRelay variant exists in service entry types in DidDocument",
         "add_relay_service(url: Url) method on DidDocument adds an SCPRelay service entry",
@@ -8639,7 +8639,7 @@
       ],
       "actionItems": [
         "Create crates/scp-core/src/economy/policy.rs with EconomicPolicy evaluation logic",
-        "Implement CostSchedule lookup by action type (message, tool invoke, join, subscription, storage)",
+        "Implement CostSchedule lookup by action type (message, outlet invoke, join, subscription, storage)",
         "Define ObservableMetrics struct with fields for all 6 PricingMetric variants",
         "Implement ObservableMetrics collection from context state",
         "Define CostInsufficient error struct with expected, provided, currency, metric_snapshot fields",
@@ -8709,7 +8709,7 @@
         "PaymentReceipt struct field: adapter_proof (Vec<u8>) — adapter-specific proof (tx hash, preimage, tx signature)",
         "PaymentReceipt struct field: timestamp (u64)",
         "PaymentReceipt struct field: signature (Ed25519Signature) — signed by payer",
-        "PaidActionType enum defined with variants for message send, tool invocation, context join, subscription payment, storage, and other paid actions",
+        "PaidActionType enum defined with variants for message send, outlet invocation, context join, subscription payment, storage, and other paid actions",
         "EventType::PaymentReceived variant added — triggered on adapter.capture() success, payload is PaymentReceipt",
         "EventType::EconomicPolicyChanged variant added — triggered on governance policy update, payload is old policy hash + new EconomicPolicy + governance justification",
         "EventType::SpendingUcanGranted variant added — triggered when human grants spending UCAN, payload is agent DID + SpendingCapability summary + UCAN token ID",
@@ -8779,14 +8779,14 @@
         "crates/scp-core/src/economy/mod.rs",
         "crates/scp-core/src/context/manager.rs"
       ],
-      "description": "Implement the full 9-step action-payment integration sequence (§19.2.2) with two flow patterns, void-on-failure, CostInsufficient error handling, and ContextManager integration.\n\n§19.2.2 Action-Payment Integration Sequence:\n```\n1. Agent SDK evaluates cost (economic policy + pricing formula + observable metrics)\n2. Agent SDK verifies spending UCAN covers this cost\n3. Agent SDK calls adapter.authorize(payer_did, payee_did, amount, currency, metadata)\n4. PaymentAuthorization attached to action envelope (inside encrypted payload)\n5. Receiving side verifies authorization via its own adapter instance (adapter.verify)\n6. Action is processed (message delivered, tool invoked, etc.)\n7. Receiving side calls adapter.capture(auth)\n8. PaymentReceipt recorded in context event log as provenance\n9. On failure at step 5-7: adapter.void(auth) — funds released\n```\n\nTwo primary flow patterns:\n\nAuthorize-then-capture (x402, Stripe): Funds are reserved on authorize, moved on capture. Supports void. The x402 12-step flow maps directly onto this.\n\nInvoice-then-preimage (Lightning BOLT 11/12, L402): Payee generates invoice with payment_hash, payer pays, preimage serves as cryptographic proof of payment. Preimage IS the receipt — SHA256(preimage) == payment_hash is unforgeable.\n\nPaymentAuthorization is attached to the action envelope inside the encrypted payload — relays never see payment data.\n\nCostInsufficient error: If payer's payment is insufficient (metrics diverged), action rejected with CostInsufficient containing receiver's computed cost and the metric values the receiver observed. Payer can retry with updated amount.",
+      "description": "Implement the full 9-step action-payment integration sequence (§19.2.2) with two flow patterns, void-on-failure, CostInsufficient error handling, and ContextManager integration.\n\n§19.2.2 Action-Payment Integration Sequence:\n```\n1. Agent SDK evaluates cost (economic policy + pricing formula + observable metrics)\n2. Agent SDK verifies spending UCAN covers this cost\n3. Agent SDK calls adapter.authorize(payer_did, payee_did, amount, currency, metadata)\n4. PaymentAuthorization attached to action envelope (inside encrypted payload)\n5. Receiving side verifies authorization via its own adapter instance (adapter.verify)\n6. Action is processed (message delivered, outlet invoked, etc.)\n7. Receiving side calls adapter.capture(auth)\n8. PaymentReceipt recorded in context event log as provenance\n9. On failure at step 5-7: adapter.void(auth) — funds released\n```\n\nTwo primary flow patterns:\n\nAuthorize-then-capture (x402, Stripe): Funds are reserved on authorize, moved on capture. Supports void. The x402 12-step flow maps directly onto this.\n\nInvoice-then-preimage (Lightning BOLT 11/12, L402): Payee generates invoice with payment_hash, payer pays, preimage serves as cryptographic proof of payment. Preimage IS the receipt — SHA256(preimage) == payment_hash is unforgeable.\n\nPaymentAuthorization is attached to the action envelope inside the encrypted payload — relays never see payment data.\n\nCostInsufficient error: If payer's payment is insufficient (metrics diverged), action rejected with CostInsufficient containing receiver's computed cost and the metric values the receiver observed. Payer can retry with updated amount.",
       "acceptanceCriteria": [
         "Step 1: Agent SDK evaluates cost using EconomicPolicy + PricingFormula + ObservableMetrics",
         "Step 2: Agent SDK verifies spending UCAN covers computed cost (max_per_action >= cost, remaining budget in time_window sufficient)",
         "Step 3: Agent SDK calls adapter.authorize(payer_did, payee_did, amount, currency, metadata) and receives PaymentAuthorization",
         "Step 4: PaymentAuthorization attached to action envelope inside encrypted payload (not visible to relays)",
         "Step 5: Receiving side verifies authorization via its own adapter instance",
-        "Step 6: Action is processed (message delivered, tool invoked, etc.) only after verification succeeds",
+        "Step 6: Action is processed (message delivered, outlet invoked, etc.) only after verification succeeds",
         "Step 7: Receiving side calls adapter.capture(auth) after successful action processing",
         "Step 8: PaymentReceipt recorded in context event log as provenance (PaymentReceived event)",
         "Step 9 (void on failure): On failure at steps 5-7, adapter.void(auth) is called to release reserved funds",
@@ -8812,7 +8812,7 @@
         "Implement receipt recording in event log (step 8) using PaymentReceipt from SCP-155",
         "Implement void-on-failure error handling (step 9) for failures at steps 5, 6, or 7",
         "Implement CostInsufficient error path with metric_snapshot",
-        "Wire integration sequence into ContextManager for paid message sends and tool invocations",
+        "Wire integration sequence into ContextManager for paid message sends and outlet invocations",
         "Add bypass path for free actions (no economic policy or zero cost for action type)",
         "Write unit tests for all steps, void-on-failure, CostInsufficient, and free action bypass"
       ],
@@ -9059,13 +9059,13 @@
       "files": [
         "crates/scp-core/tests/economy_integration.rs"
       ],
-      "description": "End-to-end integration test covering ALL 9 invariants from §19.14.\n\n§19.14 Invariants:\n1. Economic policy visible before opt-in (legibility). Economic terms are part of context metadata (§5.7), visible to any identity that inspects the context before joining.\n2. No implicit spending — spending UCAN always required. Protocol NEVER authorizes expenditure without an explicit, valid spending UCAN from the payer's delegation chain.\n3. Free operation is default — no economic policy = free. Contexts without EconomicPolicy are free. Relays without economic in relay_config are free. Tools without cost metadata are free.\n4. Receipts are provenance records — every payment is traceable and verifiable. Payment receipts are recorded in context event logs and participate in the provenance chain (§7.7).\n5. Payment adapters are substitutable — no single rail privileged. The PaymentAdapter trait treats all payment rails equally. Protocol correctness does not depend on any specific adapter.\n6. Economic policy mutable by default, optional immutability lock is voluntary. Unlike ceiling policy (immutable by default), economic policy is governed by default. Creators may voluntarily lock pricing at creation.\n7. Payment data inside encrypted envelope — relays never see payment metadata for context-level economics.\n8. Free relays MUST always exist in bootstrap list. The SDK's fallback relay list (§18.5) MUST include free relays. This is a protocol invariant that prevents economic gatekeeping of basic protocol operation.\n9. Auto-accept never applies to paid contexts. No auto-accept policy configuration (§5.12.2) can override this. Agents never silently incur costs.\n\nIntegration flow: create context with EconomicPolicy -> register tool with cost -> grant spending UCAN -> send paid message -> verify receipt in event log -> test auto-accept rejection -> test SpendingCapabilityRequired -> test dynamic pricing -> test anti-spam escalation -> verify free relay exists.",
+      "description": "End-to-end integration test covering ALL 9 invariants from §19.14.\n\n§19.14 Invariants:\n1. Economic policy visible before opt-in (legibility). Economic terms are part of context metadata (§5.7), visible to any identity that inspects the context before joining.\n2. No implicit spending — spending UCAN always required. Protocol NEVER authorizes expenditure without an explicit, valid spending UCAN from the payer's delegation chain.\n3. Free operation is default — no economic policy = free. Contexts without EconomicPolicy are free. Relays without economic in relay_config are free. Outlets without cost metadata are free.\n4. Receipts are provenance records — every payment is traceable and verifiable. Payment receipts are recorded in context event logs and participate in the provenance chain (§7.7).\n5. Payment adapters are substitutable — no single rail privileged. The PaymentAdapter trait treats all payment rails equally. Protocol correctness does not depend on any specific adapter.\n6. Economic policy mutable by default, optional immutability lock is voluntary. Unlike ceiling policy (immutable by default), economic policy is governed by default. Creators may voluntarily lock pricing at creation.\n7. Payment data inside encrypted envelope — relays never see payment metadata for context-level economics.\n8. Free relays MUST always exist in bootstrap list. The SDK's fallback relay list (§18.5) MUST include free relays. This is a protocol invariant that prevents economic gatekeeping of basic protocol operation.\n9. Auto-accept never applies to paid contexts. No auto-accept policy configuration (§5.12.2) can override this. Agents never silently incur costs.\n\nIntegration flow: create context with EconomicPolicy -> register outlet with cost -> grant spending UCAN -> send paid message -> verify receipt in event log -> test auto-accept rejection -> test SpendingCapabilityRequired -> test dynamic pricing -> test anti-spam escalation -> verify free relay exists.",
       "acceptanceCriteria": [
         "Invariant 1 test: Create context with EconomicPolicy, inspect context metadata before joining — economic terms visible",
         "Invariant 2 test: Attempt paid action without spending UCAN — SpendingCapabilityRequired error returned",
         "Invariant 2 test: Grant spending UCAN, attempt paid action — action succeeds with payment",
         "Invariant 3 test: Create context without EconomicPolicy, send message — no payment required, no adapter calls",
-        "Invariant 3 test: Create context without EconomicPolicy, invoke tool — free, no cost",
+        "Invariant 3 test: Create context without EconomicPolicy, invoke outlet — free, no cost",
         "Invariant 4 test: Complete paid action, query event log — PaymentReceipt present with Merkle inclusion proof",
         "Invariant 4 test: PaymentReceipt fields match: payer, payee, amount, currency, adapter_id, action_type",
         "Invariant 5 test: Replace TestAdapter with a second mock adapter — same flow works identically (adapter substitutability)",
@@ -9075,10 +9075,10 @@
         "Invariant 8 test: Validate SDK's bootstrap relay list includes at least one free relay (no economic config)",
         "Invariant 9 test: Create paid context, configure auto-accept policy, receive invitation — invitation NOT auto-accepted",
         "Integration flow: create context with EconomicPolicy including per_message cost and PricingFormula",
-        "Integration flow: register tool with per-invocation cost in the context",
+        "Integration flow: register outlet with per-invocation cost in the context",
         "Integration flow: grant SpendingCapability UCAN from human DID to agent DID",
         "Integration flow: send paid message — full 9-step sequence completes, receipt recorded",
-        "Integration flow: invoke paid tool — cost includes context + tool cost, receipt recorded",
+        "Integration flow: invoke paid outlet — cost includes context + outlet cost, receipt recorded",
         "Integration flow: dynamic pricing — increase SenderVelocity, verify cost increases at threshold boundaries",
         "Integration flow: anti-spam escalation — send messages at escalating rate, verify cost steps up per SenderVelocity thresholds",
         "Integration flow: verify free relay exists in bootstrap list",
@@ -9090,7 +9090,7 @@
         "Implement test helper: setup_test_adapter() creating and seeding TestAdapter with initial balances",
         "Implement test helper: grant_spending_ucan() minting SpendingCapability from human to agent",
         "Write test for each of the 9 invariants (at least one test per invariant, two for invariants 2, 3, 4, 6)",
-        "Write integration flow test: full lifecycle from context creation through paid message and tool invocation",
+        "Write integration flow test: full lifecycle from context creation through paid message and outlet invocation",
         "Write integration flow test: dynamic pricing with SenderVelocity escalation",
         "Write integration flow test: anti-spam cost escalation at threshold boundaries",
         "Write integration flow test: free relay bootstrap list validation",
@@ -9147,7 +9147,7 @@
         "paid-service template registered with memory_scope: full",
         "paid-service template requires economic_policy at creation (validation error if absent)",
         "paid-service template requires economic_policy.cost_schedule.per_outlet_call to be set (validation error if None)",
-        "paid-service template extends scp:template/outlet-interface — inherits tool-interface base properties",
+        "paid-service template extends scp:template/outlet-interface — inherits outlet-interface base properties",
         "paid-broadcast template registered with mode: Broadcast",
         "paid-broadcast template registered with ceiling: [messages:read, messages:write]",
         "paid-broadcast template registered with ceiling_policy: immutable",
@@ -9171,7 +9171,7 @@
         "Register paid-broadcast template with properties: mode Broadcast, ceiling [messages:read, messages:write], ceiling_policy immutable, memory_scope full, economic_policy required, subscriber admission gated",
         "Implement validation for paid-service: reject creation when economic_policy is absent or per_outlet_call is None",
         "Implement validation for paid-broadcast: reject creation when economic_policy is absent or per_period is None",
-        "Wire template inheritance: paid-service extends tool-interface, paid-broadcast extends gated-broadcast",
+        "Wire template inheritance: paid-service extends outlet-interface, paid-broadcast extends gated-broadcast",
         "Write unit tests for valid creation, missing economic_policy rejection, missing required cost field rejection, TemplateId serialization"
       ],
       "blockedBy": [
@@ -9269,13 +9269,13 @@
     },
     {
       "id": "SCP-163",
-      "title": "Complete PyO3 bridge wiring for tools, UCAN, event log, and MCP",
+      "title": "Complete PyO3 bridge wiring for outlets, UCAN, event log, and MCP",
       "gate": "gate-3",
       "priority": "P1",
       "severity": "major",
       "status": "done",
       "files": [
-        "crates/scp-ffi/src/tools.rs",
+        "crates/scp-ffi/src/outlets.rs",
         "crates/scp-ffi/src/ucan.rs",
         "crates/scp-ffi/src/event_log.rs",
         "crates/scp-ffi/src/mcp.rs",
@@ -9283,7 +9283,7 @@
       ],
       "description": "Three PyO3 bridge files return `Err(\"not implemented\")` instead of delegating to real Rust implementations: `tools.rs`, `ucan.rs`, and `event_log.rs` in `crates/scp-ffi/src/`. Additionally, 9 MCP bridge functions called by `bindings/python/scp_sdk/mcp.py` (`py_mcp_serve`, `py_mcp_client_connect_stdio`, etc.) were never registered in the `#[pymodule]` in `crates/scp-ffi/src/lib.rs`. The Phase 3 integration test uses `MagicMock` for the bridge layer, masking these gaps — only 3 of 16 test methods attempt real bridge calls.\n\nThe underlying Rust implementations are solid (MCP crate: 158 tests, UCAN crate: 273 tests). The gap is exclusively in the PyO3 bridge wiring that connects them to the Python SDK.",
       "acceptanceCriteria": [
-        "`crates/scp-ffi/src/tools.rs` delegates to real `scp-core` tool registration, invocation, and verification functions (no `Err(\"not implemented\")`)",
+        "`crates/scp-ffi/src/outlets.rs` delegates to real `scp-core` outlet registration, invocation, and verification functions (no `Err(\"not implemented\")`)",
         "`crates/scp-ffi/src/ucan.rs` delegates to real `scp-core` UCAN minting, validation, and revocation functions (no `Err(\"not implemented\")`)",
         "`crates/scp-ffi/src/event_log.rs` delegates to real `scp-core` event log query, proof, and checkpoint functions (no `Err(\"not implemented\")`)",
         "All 9 MCP bridge functions (`py_mcp_serve`, `py_mcp_client_connect_stdio`, etc.) are registered in the `#[pymodule]` in `lib.rs`",
@@ -9293,7 +9293,7 @@
         "No `\"not implemented\"` strings remain in any `crates/scp-ffi/src/*.rs` file"
       ],
       "actionItems": [
-        "Audit `crates/scp-ffi/src/tools.rs` — replace stub returns with real calls to `scp-core::context::tools` registration, invocation, and verification APIs",
+        "Audit `crates/scp-ffi/src/outlets.rs` — replace stub returns with real calls to `scp-core::context::outlets` registration, invocation, and verification APIs",
         "Audit `crates/scp-ffi/src/ucan.rs` — replace stub returns with real calls to `scp-core::crypto::ucan` minting, validation, and revocation APIs",
         "Audit `crates/scp-ffi/src/event_log.rs` — replace stub returns with real calls to `scp-core::event_log` query, proof generation, and checkpoint APIs",
         "Create `crates/scp-ffi/src/mcp.rs` — implement PyO3 bridge functions for MCP server and client operations, delegating to `scp-mcp` crate",
@@ -9315,7 +9315,7 @@
       ],
       "details": {
         "stubFiles": [
-          "crates/scp-ffi/src/tools.rs — returns Err(\"not implemented\")",
+          "crates/scp-ffi/src/outlets.rs — returns Err(\"not implemented\")",
           "crates/scp-ffi/src/ucan.rs — returns Err(\"not implemented\")",
           "crates/scp-ffi/src/event_log.rs — returns Err(\"not implemented\")"
         ],
@@ -9448,13 +9448,13 @@
       "files": [
         "crates/scp-ffi/src/mcp.rs"
       ],
-      "description": "Residual stubs from SCP-165 / GitHub #106. The MCP bridge wiring is complete (SCP-165 done), but two FfiBridgeProvider trait methods remain stubbed: (1) validate_capability always returns Ok(()) — no capability checking at the MCP layer, relying solely on UCAN for authorization, (2) invoke_tool returns stub JSON — tool invocations are accepted but not executed. Additionally, py_mcp_load_contexts returns an empty list because relay transport is not yet wired for context discovery.\n\nUCAN (SCP-164) provides the primary authorization boundary, so these stubs are defense-in-depth gaps, not security-breaking. However, they should be completed for layered security and full MCP functionality.\n\nSee GitHub issue #106 (remaining acceptance criteria).",
+      "description": "Residual stubs from SCP-165 / GitHub #106. The MCP bridge wiring is complete (SCP-165 done), but two FfiBridgeProvider trait methods remain stubbed: (1) validate_capability always returns Ok(()) — no capability checking at the MCP layer, relying solely on UCAN for authorization, (2) invoke_tool returns stub JSON — outlet invocations are accepted but not executed. Additionally, py_mcp_load_contexts returns an empty list because relay transport is not yet wired for context discovery.\n\nUCAN (SCP-164) provides the primary authorization boundary, so these stubs are defense-in-depth gaps, not security-breaking. However, they should be completed for layered security and full MCP functionality.\n\nSee GitHub issue #106 (remaining acceptance criteria).",
       "acceptanceCriteria": [
         "FfiBridgeProvider::validate_capability performs real capability checking against context role state and ceiling",
-        "FfiBridgeProvider::invoke_tool executes real tool invocations via OutletRegistry and returns actual results",
+        "FfiBridgeProvider::invoke_tool executes real outlet invocations via OutletRegistry and returns actual results",
         "py_mcp_load_contexts queries relay via scp-transport for active contexts",
         "#[allow(dead_code)] annotations removed from MCP state structs if any remain",
-        "Test: invoke_tool returns real tool output (not stub JSON)",
+        "Test: invoke_tool returns real outlet output (not stub JSON)",
         "Test: validate_capability rejects unauthorized capability",
         "Test: py_mcp_load_contexts returns context list from relay (integration test)"
       ],
@@ -9539,11 +9539,11 @@
       "status": "done",
       "files": [
         "crates/scp-ffi/src/mcp.rs",
-        "crates/scp-core/src/context/tools/invoke.rs"
+        "crates/scp-core/src/context/outlets/invoke.rs"
       ],
-      "description": "FfiBridgeProvider::invoke_tool validates input schema but cannot dispatch to actual tool handlers. OutletRegistry stores metadata only (no handler functions). The real invoke_tool in scp-core accepts an executor: F parameter injected by the caller. Need to design a handler registration mechanism at the FFI layer so Python callers can register callable tool handlers that Rust can dispatch to. Also need to handle the sync→async boundary (ContextProvider trait is sync, scp-core invoke is async).",
+      "description": "FfiBridgeProvider::invoke_tool validates input schema but cannot dispatch to actual outlet handlers. OutletRegistry stores metadata only (no handler functions). The real invoke_outlet in scp-core accepts an executor: F parameter injected by the caller. Need to design a handler registration mechanism at the FFI layer so Python callers can register callable outlet handlers that Rust can dispatch to. Also need to handle the sync→async boundary (ContextProvider trait is sync, scp-core invoke is async).",
       "acceptanceCriteria": [
-        "Python tool handlers can be registered via PyO3 and stored in the runtime registry",
+        "Python outlet handlers can be registered via PyO3 and stored in the runtime registry",
         "FfiBridgeProvider::invoke_tool dispatches through scp-core invoke with the registered handler",
         "invoke_tool response contains actual computed output, not echoed input",
         "Sync→async boundary handled correctly (ContextProvider is sync)",
@@ -9551,7 +9551,7 @@
       ],
       "actionItems": [
         "Design handler registration API at FFI layer (store Python callables as closures)",
-        "Wire FfiBridgeProvider::invoke_tool through scp-core::context::tools::invoke::invoke_tool",
+        "Wire FfiBridgeProvider::invoke_tool through scp-core::context::outlets::invoke::invoke_outlet",
         "Handle sync/async boundary between ContextProvider trait and scp-core invoke",
         "Write integration tests with real Python handlers"
       ],
@@ -9564,7 +9564,7 @@
           "section": "## ADR-010: Outlet Registration and Invocation"
         }
       ],
-      "result": "Tool handler registration and dispatch wired. Python callables stored as closures in runtime registry. FfiBridgeProvider dispatches to handlers. Commit 8d4c405.",
+      "result": "Outlet handler registration and dispatch wired. Python callables stored as closures in runtime registry. FfiBridgeProvider dispatches to handlers. Commit 8d4c405.",
       "details": {}
     },
     {
@@ -9750,13 +9750,13 @@
         ".docs/adrs/phase-5.md",
         ".docs/adrs/phase-6.md"
       ],
-      "description": "Audit and normalize every error code across all SDKs to conform to the SCP-{PREFIX}-{NUMBER} standard defined in .docs/standards/sdk-common.md.\n\nPR #118 agent review revealed systematic non-conformance: 18+ distinct prefixes in the codebase versus 9 defined ranges, three numbering conventions (bare 3-digit, correct 4-digit, wrong-range 4-digit), prefix spelling variants (PERM/PRM, VALID/VAL, TRANS/TRANSPORT/TXP), and an outright range swap in NAPI (TOOL codes in TRANS range and vice versa). Root cause: the standard existed (Feb 23) but implementing agents did not read it.\n\nAdditionally, SCP-MCP- codes (8001-8008 in Python mcp.py) now collide with the SCP-STORAGE- range (8000-8999) allocated during the PR #118 fix. SCP-MCP- needs its own range.",
+      "description": "Audit and normalize every error code across all SDKs to conform to the SCP-{PREFIX}-{NUMBER} standard defined in .docs/standards/sdk-common.md.\n\nPR #118 agent review revealed systematic non-conformance: 18+ distinct prefixes in the codebase versus 9 defined ranges, three numbering conventions (bare 3-digit, correct 4-digit, wrong-range 4-digit), prefix spelling variants (PERM/PRM, VALID/VAL, TRANS/TRANSPORT/TXP), and an outright range swap in NAPI (OUTLET codes in TRANS range and vice versa). Root cause: the standard existed (Feb 23) but implementing agents did not read it.\n\nAdditionally, SCP-MCP- codes (8001-8008 in Python mcp.py) now collide with the SCP-STORAGE- range (8000-8999) allocated during the PR #118 fix. SCP-MCP- needs its own range.",
       "acceptanceCriteria": [
         "Every SCP-{PREFIX}-{NUMBER} code in the codebase falls within its sdk-common.md allocated range",
         "No two prefixes share a numeric range — each prefix has an exclusive range",
         "SCP-MCP- has its own allocated range in sdk-common.md (not colliding with SCP-STORAGE- 8000-8999)",
         "Python mcp.py codes (SCP-MCP-8001..8008) updated to the new SCP-MCP- range",
-        "NAPI TOOL/TRANS range swap corrected — SCP-TOOL- codes are in 6000-6999, SCP-TRANS- codes are in 5000-5999",
+        "NAPI OUTLET/TRANS range swap corrected — SCP-OUTLET- codes are in 6000-6999, SCP-TRANS- codes are in 5000-5999",
         "All bare 3-digit codes normalized to 4-digit within their correct range",
         "Prefix spellings unified: PERM not PRM, VALID not VAL, TRANS not TRANSPORT or TXP",
         "ADR phase-5.md code examples use conformant codes (SCP-CTX-001 → SCP-CTX-3001)",
@@ -9766,7 +9766,7 @@
       "actionItems": [
         "Allocate SCP-MCP- range in sdk-common.md (10000-10999)",
         "Update Python mcp.py SCP-MCP-8001..8008 to new range (SCP-MCP-10001..10008)",
-        "Fix NAPI error codes: swap TOOL and TRANS codes back to correct ranges",
+        "Fix NAPI error codes: swap OUTLET and TRANS codes back to correct ranges",
         "Normalize bare 3-digit codes to 4-digit in all SDKs",
         "Unify prefix spellings across all SDKs (PERM, VALID, TRANS)",
         "Fix ADR phase-5.md examples: SCP-CTX-001 → SCP-CTX-3001 (2 occurrences)",
@@ -9782,7 +9782,7 @@
         }
       ],
       "details": {
-        "currentChaos": "18+ distinct prefixes found: SCP-IDENT, SCP-DID, SCP-CTX, SCP-CRYPTO, SCP-TRANS, SCP-TOOL, SCP-VALID, SCP-STORAGE, SCP-ATTEST, SCP-MCP, SCP-PRM, SCP-PERM, SCP-VAL, SCP-TRANSPORT, SCP-TXP, SCP-KEY, SCP-PUSH, SCP-IDENTITY. Three numbering conventions: bare 3-digit (001, 002), correct 4-digit (1001, 2001), wrong-range 4-digit (6001 in STORAGE). NAPI has TOOL codes SCP-TOOL-5001..5004 in TRANS range and TRANS codes SCP-TRANS-6001 in TOOL range.",
+        "currentChaos": "18+ distinct prefixes found: SCP-IDENT, SCP-DID, SCP-CTX, SCP-CRYPTO, SCP-TRANS, SCP-OUTLET, SCP-VALID, SCP-STORAGE, SCP-ATTEST, SCP-MCP, SCP-PRM, SCP-PERM, SCP-VAL, SCP-TRANSPORT, SCP-TXP, SCP-KEY, SCP-PUSH, SCP-IDENTITY. Three numbering conventions: bare 3-digit (001, 002), correct 4-digit (1001, 2001), wrong-range 4-digit (6001 in STORAGE). NAPI has OUTLET codes SCP-OUTLET-5001..5004 in TRANS range and TRANS codes SCP-TRANS-6001 in OUTLET range.",
         "rangeCollision": "SCP-MCP- codes 8001-8008 (Python mcp.py) now land in SCP-STORAGE- range 8000-8999 (allocated during PR #118 fix). Need separate range allocation."
       }
     },
@@ -9904,7 +9904,7 @@
         "crates/scp-ffi/napi/src/ucan.rs",
         "crates/scp-ffi/napi/src/event_log.rs"
       ],
-      "description": "The NAPI bridge (SCP-080) has stub functions for UCAN validation/minting/revocation and event log query/verification that return 'not yet connected to runtime' errors. Wire these to scp-core implementations. Scope: ucan_validate/mint/revoke, event_log_query/verify. NAPI tools.rs, identity.rs, and transport.rs have no 'not yet connected' stubs and are not in scope. Identity/KeyCustody wiring is SCP-214.",
+      "description": "The NAPI bridge (SCP-080) has stub functions for UCAN validation/minting/revocation and event log query/verification that return 'not yet connected to runtime' errors. Wire these to scp-core implementations. Scope: ucan_validate/mint/revoke, event_log_query/verify. NAPI outlets.rs, identity.rs, and transport.rs have no 'not yet connected' stubs and are not in scope. Identity/KeyCustody wiring is SCP-214.",
       "acceptanceCriteria": [
         "ucan_validate calls scp-core 11-step UCAN validation pipeline (verify_ucan_chain)",
         "ucan_mint calls scp-core mint_ucan (signing deferred to KeyCustody wiring in SCP-214)",
@@ -9978,22 +9978,22 @@
       ],
       "files": [
         "bindings/swift/Sources/SCP/Mcp.swift",
-        "bindings/swift/Sources/SCP/Tools.swift",
+        "bindings/swift/Sources/SCP/Outlets.swift",
         "bindings/swift/Sources/SCP/Ucan.swift",
         "bindings/swift/Sources/SCP/Transport.swift",
         "bindings/swift/Sources/SCP/EventLog.swift",
         "bindings/swift/Sources/SCP/Trust.swift"
       ],
-      "description": "The Swift SDK wrappers (SCP-103) contain placeholder functions that return 'not yet available' errors across Mcp.swift, Tools.swift, Ucan.swift, Transport.swift, EventLog.swift, and Trust.swift. Wire these to the UniFFI bridge layer.",
+      "description": "The Swift SDK wrappers (SCP-103) contain placeholder functions that return 'not yet available' errors across Mcp.swift, Outlets.swift, Ucan.swift, Transport.swift, EventLog.swift, and Trust.swift. Wire these to the UniFFI bridge layer.",
       "acceptanceCriteria": [
         "Mcp.swift functions delegate to ScpBindings (UniFFI bridge) for MCP tool operations",
-        "Tools.swift functions delegate to ScpBindings for tool registration, invocation, and verification",
+        "Outlets.swift functions delegate to ScpBindings for outlet registration, invocation, and verification",
         "Ucan.swift functions delegate to ScpBindings for UCAN validation, minting, and revocation",
         "Transport.swift functions delegate to ScpBindings for transport send/receive",
         "EventLog.swift functions delegate to ScpBindings for event log query and verification",
         "Trust.swift functions delegate to ScpBindings for attestation verification and trust evaluation",
         "No 'not yet available' placeholder errors remain in any Swift wrapper file",
-        "At least one async roundtrip test per module (Tools, Ucan, EventLog, Transport, Trust) verifies async/await bridging compiles and executes"
+        "At least one async roundtrip test per module (Outlets, Ucan, EventLog, Transport, Trust) verifies async/await bridging compiles and executes"
       ],
       "priority": "P1",
       "severity": "major",
@@ -10005,13 +10005,13 @@
       ],
       "actionItems": [
         "Wire Mcp.swift functions to ScpBindings UniFFI bridge for MCP tool operations",
-        "Wire Tools.swift functions to ScpBindings for tool registration, invocation, and verification",
+        "Wire Outlets.swift functions to ScpBindings for outlet registration, invocation, and verification",
         "Wire Ucan.swift functions to ScpBindings for UCAN validation, minting, and revocation",
         "Wire Transport.swift functions to ScpBindings for transport send/receive",
         "Wire EventLog.swift functions to ScpBindings for event log query and verification",
         "Wire Trust.swift functions to ScpBindings for attestation verification and trust evaluation",
         "Remove all 'not yet available' placeholder error returns from Swift wrapper files",
-        "Add async roundtrip test per module (Tools, Ucan, EventLog, Transport, Trust) verifying async/await bridging"
+        "Add async roundtrip test per module (Outlets, Ucan, EventLog, Transport, Trust) verifying async/await bridging"
       ],
       "details": {}
     },
@@ -10033,7 +10033,7 @@
         "Identity state CRUD: store/load/delete identity, key handles, DID documents",
         "Context state CRUD: store/load/delete context params, membership, roles, event log",
         "UCAN state: store/load/delete tokens, revocation lists, nonce tracker",
-        "Tool state: store/load/delete registrations, schemas",
+        "Outlet state: store/load/delete registrations, schemas",
         "Key convention follows §17.3 namespace pattern (e.g., identity/{did}/state)",
         "StoredValue<T> version envelope per §17.5 for forward compatibility",
         "All methods use MessagePack serialization via rmp-serde"
@@ -10055,7 +10055,7 @@
     },
     {
       "id": "SCP-223",
-      "title": "Implement human-readable addressing types and discovery handle tools",
+      "title": "Implement human-readable addressing types and discovery handle outlets",
       "gate": "gate-audit",
       "status": "done",
       "blockedBy": [
@@ -10072,7 +10072,7 @@
       "acceptanceCriteria": [
         "Address format types: Petname, DiscoveryHandle, AttestationHandle, DomainHandle per §22.2",
         "TrustLevel enum: Self, Attestation, Context, Community per §22.7",
-        "handle_register, handle_lookup, handle_deregister context tools per §22.5",
+        "handle_register, handle_lookup, handle_deregister context outlets per §22.5",
         "AddressResolver with resolve() returning results ranked by TrustLevel (Self > Attestation > Context > Community)",
         "Petname storage in identity private state per §22.3",
         "Resolution caching with TTL per §22.8",
@@ -10179,7 +10179,7 @@
       "files": [
         "crates/scp-core/src/trust/renewal.rs"
       ],
-      "description": "The Attestation struct has renewed_at and renewal_interval fields, and check_attestation_freshness correctly uses renewed_at as base time (SCP-062). But no orchestration exists to perform renewals — no function updates renewed_at, and no scheduling mechanism triggers re-verification. Spec §7.3.6 specifies type-specific automated renewal: identity links re-verified via OAuth on interval, tool integrity checks on schedule, endorsements refreshed periodically. This story adds the renewal API and a platform-injectable scheduling trait.",
+      "description": "The Attestation struct has renewed_at and renewal_interval fields, and check_attestation_freshness correctly uses renewed_at as base time (SCP-062). But no orchestration exists to perform renewals — no function updates renewed_at, and no scheduling mechanism triggers re-verification. Spec §7.3.6 specifies type-specific automated renewal: identity links re-verified via OAuth on interval, outlet integrity checks on schedule, endorsements refreshed periodically. This story adds the renewal API and a platform-injectable scheduling trait.",
       "acceptanceCriteria": [
         "renew_attestation(attestation, clock) -> Attestation returns a new Attestation with renewed_at set to current time, all other fields preserved",
         "renew_attestation rejects attestations without renewal_interval (returns RenewalError::NotRenewable)",
@@ -10409,7 +10409,7 @@
         "bindings/kotlin/scp-kt/src/main/kotlin/works/limn/scp/Trust.kt",
         "bindings/kotlin/scp-kt/src/test/kotlin/works/limn/scp/TrustTest.kt"
       ],
-      "description": "Spec §7.3.2 defines a participation record as a set of verifiable facts about a subject DID in a context. Six of those facts are leaf-derived from the context's convergent Merkle event log — participation duration (MemberJoined/MemberLeft), governance actions against (events whose projected target_did is the subject), governance actions by (events whose actor_did is the subject), context creation (ChildContextCreated by the subject), role progression (RoleAssigned whose leaf subject_did is the subject), and tool invocation count (OutletInvoked). The seventh, attestation_count, is the explicit exception: it is a credential-layer fact (§7.4), NOT derived from the event log and NOT covered by event_log_root — there is no AttestationPublished/AttestationRevoked event type (ADR-011 amendment exclusion taxonomy), so it is computed on-demand from the accessible, currently-valid attestations the verifying agent can reach and is therefore verifier-relative. outlet_invocation_count is per-author application activity that is NOT yet Merkle-anchored: it stays anchored=false until ADR-051 (causal-DAG application-event ordering) makes OutletInvoked a convergent leaf. The typed participation_record op (Supervisor::participation_record gathering the full unfiltered event log + Merkle root, projected to the twelve-field ParticipationFacts and surfaced as PyParticipationRecord / NapiParticipationRecord / UniFFI ParticipationRecordView) already exists at the Rust core and the PyO3, NAPI, and UniFFI bridges (landed in Phase 2C-1; origin: the C3c SDK-wiring follow-up). Before that op, the Python and TypeScript SDKs recomputed Layer 2 of evaluate_trust/evaluateTrust client-side from a per-actor event-log query — hardcoding contexts_participated=1 / participationCount=rawEvents.length and participation_duration=0, classifying events by an eventType string the queryable payload does not reliably carry, and bucketing every OutletInvoked under a literal key — two independent reimplementations that diverge by construction. This story is the SDK rebuild: replace the client-side Layer-2 computation in both SDKs with a call to the typed participation_record op so both bindings RECEIVE the identical Rust-computed record; reshape the Python BehavioralRecord dataclass and the TypeScript BehavioralRecord interface to the twelve typed fields (snake_case in Python, camelCase in TypeScript) reconciled to §7.3.2.1; and add the public participation_record / participationRecord SDK wrappers. Per the per-SDK-idiom lesson, ALL FOUR bindings expose an idiomatic participation_record wrapper returning the twelve-field BehavioralRecord: the lesson governs HOW each binding surfaces the op, never WHETHER it does. The UniFFI bridge already exports ParticipationRecordView, so the Swift and Kotlin SDKs add the idiomatic sugar (SCP.participationRecord plus a BehavioralRecord type) on top of it, at parity with Python and TypeScript. evaluate_trust/evaluateTrust pass an empty cached-attestation set (no attestation set is available in their inputs), so attestation_count honestly reflects only what the bridge can source from its own persistent trust store — the SDK never fabricates attestations.",
+      "description": "Spec §7.3.2 defines a participation record as a set of verifiable facts about a subject DID in a context. Six of those facts are leaf-derived from the context's convergent Merkle event log — participation duration (MemberJoined/MemberLeft), governance actions against (events whose projected target_did is the subject), governance actions by (events whose actor_did is the subject), context creation (ChildContextCreated by the subject), role progression (RoleAssigned whose leaf subject_did is the subject), and outlet invocation count (OutletInvoked). The seventh, attestation_count, is the explicit exception: it is a credential-layer fact (§7.4), NOT derived from the event log and NOT covered by event_log_root — there is no AttestationPublished/AttestationRevoked event type (ADR-011 amendment exclusion taxonomy), so it is computed on-demand from the accessible, currently-valid attestations the verifying agent can reach and is therefore verifier-relative. outlet_invocation_count is per-author application activity that is NOT yet Merkle-anchored: it stays anchored=false until ADR-051 (causal-DAG application-event ordering) makes OutletInvoked a convergent leaf. The typed participation_record op (Supervisor::participation_record gathering the full unfiltered event log + Merkle root, projected to the twelve-field ParticipationFacts and surfaced as PyParticipationRecord / NapiParticipationRecord / UniFFI ParticipationRecordView) already exists at the Rust core and the PyO3, NAPI, and UniFFI bridges (landed in Phase 2C-1; origin: the C3c SDK-wiring follow-up). Before that op, the Python and TypeScript SDKs recomputed Layer 2 of evaluate_trust/evaluateTrust client-side from a per-actor event-log query — hardcoding contexts_participated=1 / participationCount=rawEvents.length and participation_duration=0, classifying events by an eventType string the queryable payload does not reliably carry, and bucketing every OutletInvoked under a literal key — two independent reimplementations that diverge by construction. This story is the SDK rebuild: replace the client-side Layer-2 computation in both SDKs with a call to the typed participation_record op so both bindings RECEIVE the identical Rust-computed record; reshape the Python BehavioralRecord dataclass and the TypeScript BehavioralRecord interface to the twelve typed fields (snake_case in Python, camelCase in TypeScript) reconciled to §7.3.2.1; and add the public participation_record / participationRecord SDK wrappers. Per the per-SDK-idiom lesson, ALL FOUR bindings expose an idiomatic participation_record wrapper returning the twelve-field BehavioralRecord: the lesson governs HOW each binding surfaces the op, never WHETHER it does. The UniFFI bridge already exports ParticipationRecordView, so the Swift and Kotlin SDKs add the idiomatic sugar (SCP.participationRecord plus a BehavioralRecord type) on top of it, at parity with Python and TypeScript. evaluate_trust/evaluateTrust pass an empty cached-attestation set (no attestation set is available in their inputs), so attestation_count honestly reflects only what the bridge can source from its own persistent trust store — the SDK never fabricates attestations.",
       "acceptanceCriteria": [
         "scp-runtime exposes Supervisor::participation_record(context_id, subject_did, accessible_attestations) returning scp_protocol::trust::ParticipationRecord, gathering the FULL unfiltered event-log entry set (so governance_actions_against, which counts events whose projected target is the subject, is not undercounted) and the log's Merkle root, and delegating to the pure-core compute_participation_record (grep finds the fn signature in crates/scp-runtime/src/context/supervisor/supervisor.rs)",
         "The typed participation_record op is exported by the PyO3 bridge (PyScp::participation_record returning PyParticipationRecord), the NAPI bridge (Scp.participationRecord js_name returning NapiParticipationRecord), and the UniFFI bridge (Scp::participation_record returning ParticipationRecordView), each carrying the twelve fields subject_did, participation_duration_secs, governance_actions_against, governance_actions_by, outlet_invocation_count, outlet_invocation_count_anchored, context_creation_count, role_progression_count, attestation_count, attestation_count_anchored, computed_at, and event_log_root (grep finds PyParticipationRecord, NapiParticipationRecord, and ParticipationRecordView)",

--- a/crates/scp-runtime/tests/test_vectors.rs
+++ b/crates/scp-runtime/tests/test_vectors.rs
@@ -1300,7 +1300,7 @@ fn domain_separators_are_all_unique() {
         "SCP-PARTICIPATION-V1:",
         "SCP-IDENTITY-LINK-ATTESTATION-V1:",
         "SCP-ACCESS-KEY-REQUEST-V1:",
-        "SCP-TOOL-REGISTRATION-V1:",
+        "SCP-OUTLET-REGISTRATION-V2:",
         "SCP-FORK-ID-V1:",
         "SCP-COMMIT-RANGE-REQ-V1:",
         "SCP-COMMIT-RANGE-RESP-V1:",


### PR DESCRIPTION
Two small completeness follow-ups to the outlet re-port (#2098), surfaced by that PR's reviews and done rather than left as tickets.

## Changes
1. **`test_vectors.rs` domain-uniqueness catalog** (closes #2103) — the `domain_separators_are_all_unique` list referenced the dead pre-rename `SCP-TOOL-REGISTRATION-V1:` instead of the live `SCP-OUTLET-REGISTRATION-V2:` (`outlets/hash.rs:62`). Swapped to the live domain so the test actually verifies the shipping separator's uniqueness / non-prefix-collision.
2. **PRD story prose** (closes #2104) — `.docs/prds/main.json` story `title`/`description`/`acceptanceCriteria` still said "tool" for the SCP-outlet concept after #2098 renamed the specs/ADRs (only the load-bearing `source` heading-citations were updated in lockstep there). ~220 SCP-outlet renames across 49 stories, mirroring the ADR-010/phase-3 convention (SCP-internal → outlet; MCP-facing surface — `tools/list`, `invoke_tool`, external MCP tools — kept). Zero `source`-citation strings changed.

## Verification
- `python3.12 scripts/validate-prd.py` → passed (13 files, 370 stories)
- `cargo test -p scp-runtime --features testing domain_separators_are_all_unique` → passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AirPNJtmzKGYTJkcJG64jq