### PR TITLE
feat(actor): Supervisor-owned floor registry (epoch side) — non-authoritative follower (ADR-049 PR-4)

### DIFF
--- a/crates/scp-protocol/src/context/builder.rs
+++ b/crates/scp-protocol/src/context/builder.rs
@@ -25,6 +25,18 @@ pub struct OpenedEnvelope {
     pub inner: InnerEnvelope,
     /// The sender's DID extracted from MLS credentials.
     pub sender_did: String,
+    /// The receive-side `(sender_key_epoch, sequence)` this envelope advanced
+    /// the anti-replay tracker to inside `MlsCryptoProvider::open` (spec
+    /// §23.17.3).
+    ///
+    /// ADR-049 PR-4: surfaced SOLELY so the supervisor floor-registry follower
+    /// mirror-forward (`decrypt_and_dispatch`) can track the just-advanced
+    /// receive floor in O(1), without an O(senders) `export_recv_sequence_floors`
+    /// re-read (Decision-14 budget). It is the value `open()` ALREADY computed
+    /// and stored; exposing it does NOT change `open()`'s enforcement or advance
+    /// behavior, and NOTHING reads this field for enforcement — only the
+    /// follower mirror-forward consumes it.
+    pub receive_floor: (u64, u64),
 }
 
 /// Discriminated result of `MlsCryptoProvider::open` (in `scp-runtime`).

--- a/crates/scp-runtime/src/context/governance_helpers.rs
+++ b/crates/scp-runtime/src/context/governance_helpers.rs
@@ -991,6 +991,12 @@ pub async fn execute_revoke(
                 error = %e,
                 "rotate_sender_key failed after access revocation"
             );
+        } else {
+            // ADR-049 PR-4: track the rotated local epoch in the floor registry.
+            crate::context::messaging_helpers::mirror_forward_local_sender_epoch(
+                deps,
+                &context_id_bytes,
+            );
         }
         // Phase 2A.9: drain_and_deliver_sender_keys is now actor-shape
         // and operates directly on `state` + `deps`.
@@ -1404,6 +1410,12 @@ pub async fn execute_remove_member(
                 )
                 .map(|()| (String::new(), None));
             }
+            // ADR-049 PR-4: rotate succeeded (the Err arm returns above) — track
+            // the rotated local epoch in the floor registry.
+            crate::context::messaging_helpers::mirror_forward_local_sender_epoch(
+                deps,
+                &context_id_bytes,
+            );
 
             state.membership.remove_member(did);
             // Clean teardown of ALL per-DID role state (spec §5.6.1): members,
@@ -2519,6 +2531,12 @@ pub async fn execute_reset_member(
             context_id,
             error = %e,
             "rotate_sender_key failed after MLS reset"
+        );
+    } else {
+        // ADR-049 PR-4: track the rotated local epoch in the floor registry.
+        crate::context::messaging_helpers::mirror_forward_local_sender_epoch(
+            deps,
+            &context_id_bytes,
         );
     }
 

--- a/crates/scp-runtime/src/context/lifecycle_helpers.rs
+++ b/crates/scp-runtime/src/context/lifecycle_helpers.rs
@@ -402,6 +402,12 @@ pub async fn leave_context(
                 "rotate_sender_key failed after leave — \
                  remaining members retain old sender key"
             );
+        } else {
+            // ADR-049 PR-4: track the rotated local epoch in the floor registry.
+            crate::context::messaging_helpers::mirror_forward_local_sender_epoch(
+                deps,
+                &context_id_bytes,
+            );
         }
         if let Err(e) = drain_and_deliver_sender_keys(deps, &context_id, &context_id_bytes).await {
             tracing::warn!(
@@ -1513,6 +1519,10 @@ pub async fn create_context(
     // §6.2.4 cross-context outlet saga compares `target_context_id` against on
     // the wire, and the bytes the creation crypto (builder) keys under.
     let context_id_bytes = state::context_id_to_bytes(&context_id);
+    // ADR-049 PR-4 §5: create-seed the supervisor floor registry so a
+    // default-empty entry exists from creation (it then grows via
+    // mirror-forward). Insert-if-absent — never resets an advanced entry.
+    deps.supervisor.seed_context_floors(&context_id_bytes);
     let actor_members: HashSet<DID> = initial_members.clone();
     let create_is_broadcast = broadcast_context.is_some();
     let mode = if create_is_broadcast {
@@ -1789,6 +1799,39 @@ pub(in crate::context) fn restore_crypto_state_with_floor_guard(
         let _ = deps.crypto.destroy_mls_group(ctx_id_bytes);
         let _ = deps.crypto.destroy_sender_key(ctx_id_bytes);
         return Err(e);
+    }
+
+    // ADR-049 PR-4: additive FOLLOWER seed. The AUTHORITATIVE provider floors
+    // above are restored + merged and STAY authoritative (the `deps.crypto`
+    // export/merge calls are deliberately NOT rewired to `deps.supervisor`).
+    // Here we ADDITIONALLY mirror the post-merge provider floors into the
+    // supervisor-owned registry so the follower tracks the provider across a
+    // restore / import / respawn. Insert-if-absent-then-max (the registry merge
+    // never regresses). NON-FATAL: the provider remains authoritative in PR-4,
+    // so a follower seed failure is logged and dropped (PR-6 makes it
+    // fail-closed once the registry becomes authoritative).
+    let seeded_epoch_floors = deps.crypto.export_sender_key_epochs(ctx_id_bytes);
+    if let Err(e) = deps.supervisor.validate_and_merge_epoch_floors(
+        ctx_id_bytes,
+        seeded_epoch_floors,
+        scp_protocol::crypto::sender_keys::MAX_EPOCH_ADVANCE,
+        trusted_local,
+    ) {
+        tracing::debug!(
+            error = %e,
+            "floor-registry follower epoch seed failed on restore (non-fatal in PR-4; provider authoritative)"
+        );
+    }
+    let seeded_recv_floors = deps.crypto.export_recv_sequence_floors(ctx_id_bytes);
+    if let Err(e) = deps.supervisor.validate_and_merge_recv_sequence_floors(
+        ctx_id_bytes,
+        seeded_recv_floors,
+        trusted_local,
+    ) {
+        tracing::debug!(
+            error = %e,
+            "floor-registry follower recv seed failed on restore (non-fatal in PR-4; provider authoritative)"
+        );
     }
     Ok(())
 }

--- a/crates/scp-runtime/src/context/lifecycle_helpers.rs
+++ b/crates/scp-runtime/src/context/lifecycle_helpers.rs
@@ -3364,6 +3364,14 @@ pub async fn shutdown_all_contexts(supervisor: &crate::context::supervisor::Supe
         // lookup still reports the poison until an operator clears it or the
         // process restarts.
         supervisor.reap_crash_window(ctx_id);
+        // Drop the supervisor-owned Class-M floor registry entry on the same
+        // teardown sweep (ADR-049 PR-4) — the floor-registry twin of the
+        // crash-window reap above. Harmless-but-tidy here (the whole Supervisor
+        // is about to be dropped), but it keeps the follower floors' lifecycle
+        // aligned 1:1 with crash_windows and leaves no per-context registry
+        // entry behind after a shutdown sweep.
+        let ctx_id_bytes = crate::context::state::context_id_to_bytes(ctx_id);
+        supervisor.remove_context_floors(&ctx_id_bytes);
     }
 
     // Supervisor-level state clear. Acquired under the write_lock once

--- a/crates/scp-runtime/src/context/messaging_helpers.rs
+++ b/crates/scp-runtime/src/context/messaging_helpers.rs
@@ -2906,7 +2906,36 @@ pub fn decrypt_and_dispatch(
     crate::metrics::record_decrypt_duration(decrypt_start.elapsed());
 
     match open_result {
-        scp_protocol::context::builder::OpenResult::Application(env) => Ok(Some(*env)),
+        scp_protocol::context::builder::OpenResult::Application(env) => {
+            // ADR-049 PR-4 follower mirror-forward (recv-seq). `open()` already
+            // advanced + enforced the authoritative `recv_sequence_tracker`; we
+            // only TRACK the just-advanced `(epoch, sequence)` — surfaced O(1)
+            // on `env.receive_floor` — into the supervisor floor registry.
+            // NON-FATAL: the provider remains authoritative in PR-4, so a
+            // rejected/failed follow-on advance is logged and dropped.
+            //
+            // Single-writer / security separation (verbatim, mirror-forward
+            // seam): SECURITY — "never accept a key below the floor" — is
+            // STRUCTURAL and caller-topology-independent (the single-`entry()`
+            // gate); the per-context single-writer actor preserves only
+            // LIVENESS. A cross-actor call would stay FAIL-SAFE (spurious
+            // reject), never fail-open. Security is the structural gate;
+            // single-writer is a liveness convention.
+            if let Err(e) = deps.supervisor.check_and_advance_recv_sequence(
+                context_id_bytes,
+                &env.sender_did,
+                env.receive_floor,
+                scp_protocol::crypto::sender_keys::MAX_EPOCH_ADVANCE,
+            ) {
+                tracing::debug!(
+                    sender_did = %env.sender_did,
+                    context_id = %context_id,
+                    error = %e,
+                    "floor-registry follower recv-sequence mirror-forward rejected (non-fatal in PR-4; provider authoritative)"
+                );
+            }
+            Ok(Some(*env))
+        }
         scp_protocol::context::builder::OpenResult::Control => Ok(None),
         scp_protocol::context::builder::OpenResult::Management {
             sender_did,
@@ -2915,8 +2944,60 @@ pub fn decrypt_and_dispatch(
             tracing::debug!(sender_did = %sender_did, context_id = %context_id, "received MLS-wrapped management message");
             deps.crypto
                 .process_incoming_sender_key(context_id_bytes, &sender_did, &payload)?;
+            // ADR-049 PR-4 follower mirror-forward (remote sender-epoch). The
+            // `set_checked` inside `process_incoming_sender_key` has advanced
+            // the authoritative floor; read the just-recorded epoch O(1) and
+            // TRACK it in the supervisor registry. NON-FATAL (see recv seam).
+            let epoch = deps.crypto.sender_key_epoch(context_id_bytes, &sender_did);
+            if let Err(e) = deps.supervisor.check_and_advance_sender_epoch(
+                context_id_bytes,
+                &sender_did,
+                epoch,
+                scp_protocol::crypto::sender_keys::MAX_EPOCH_ADVANCE,
+            ) {
+                tracing::debug!(
+                    sender_did = %sender_did,
+                    context_id = %context_id,
+                    error = %e,
+                    "floor-registry follower remote sender-epoch mirror-forward rejected (non-fatal in PR-4; provider authoritative)"
+                );
+            }
             Ok(None)
         }
+    }
+}
+
+/// ADR-049 PR-4 follower mirror-forward for a LOCAL sender-key rotation.
+///
+/// Call AFTER `deps.crypto.rotate_sender_key(ctx)` succeeds. `rotate_sender_key`
+/// increments the local epoch scalar (`state.sender_key_epoch`, which
+/// `set_unchecked` does NOT record in the store's per-sender epoch map), so the
+/// authoritative local floor is read via
+/// [`MlsCryptoProvider::local_sender_key_epoch`](crate::crypto::mls::provider::MlsCryptoProvider::local_sender_key_epoch)
+/// and TRACKED in the supervisor floor registry keyed by the provider's local
+/// DID. NON-FATAL in PR-4: the provider remains authoritative, so a rejected
+/// follow-on advance is logged and dropped.
+///
+/// Single-writer / security separation (verbatim, mirror-forward seam):
+/// SECURITY — "never accept a key below the floor" — is STRUCTURAL and
+/// caller-topology-independent (the single-`entry()` gate); the per-context
+/// single-writer actor preserves only LIVENESS. A cross-actor call would stay
+/// FAIL-SAFE (spurious reject), never fail-open. Security is the structural
+/// gate; single-writer is a liveness convention.
+pub(in crate::context) fn mirror_forward_local_sender_epoch(deps: &ActorDeps, ctx: &[u8; 32]) {
+    let epoch = deps.crypto.local_sender_key_epoch(ctx);
+    let local_did = deps.crypto.local_did();
+    if let Err(e) = deps.supervisor.check_and_advance_sender_epoch(
+        ctx,
+        local_did,
+        epoch,
+        scp_protocol::crypto::sender_keys::MAX_EPOCH_ADVANCE,
+    ) {
+        tracing::debug!(
+            local_did = %local_did,
+            error = %e,
+            "floor-registry follower local sender-epoch mirror-forward rejected (non-fatal in PR-4; provider authoritative)"
+        );
     }
 }
 

--- a/crates/scp-runtime/src/context/supervisor/floors.rs
+++ b/crates/scp-runtime/src/context/supervisor/floors.rs
@@ -1,0 +1,790 @@
+//! Supervisor-owned Class-M floor registry (ADR-049 PR-4, epoch side).
+//!
+//! This module adds the [`ContextFloors`] registry to the [`Supervisor`] and
+//! the TOCTOU-safe advance primitives that mutate it. In PR-4 the registry is a
+//! **NON-AUTHORITATIVE FOLLOWER**: the authoritative homes for the per-sender
+//! epoch high-water and the receive-side `(epoch, sequence)` anti-replay floor
+//! remain the supervisor-owned `MlsCryptoProvider` (`crypto/mls/provider.rs` —
+//! `SenderKeyStore.epochs` and `recv_sequence_tracker`). Enforcement, capture,
+//! and merge all still run there. Nothing in PR-4 READS `Supervisor.floors` for
+//! any enforcement, capture, or merge decision; the registry is **write-only**
+//! until PR-6 flips read-authority onto it (see `.claude/plans` PR-6 scope /
+//! `actor/deps.rs` §"`MlsCryptoProvider` dissolution", ADR-049 Decision 9).
+//!
+//! Why it must live on the `Supervisor` (an `Arc<Supervisor>`, not on the actor
+//! `PerContextState`): these are **Class-M** floors that MUST survive an actor
+//! task unwind. A `PerContextState`-owned floor would die with the crashing
+//! actor, re-opening the §23.17 Invariant-2 / Invariant-4 replay window on the
+//! respawn. The provider carries them today for exactly this reason; PR-4 stands
+//! up the supervisor-owned successor store as a follower so PR-7's key-move
+//! (`take_crypto_state`) has a Class-M home already in place before the
+//! provider's floor maps are deleted (PR-6). This ordering — PR-4 → PR-6 → PR-7
+//! — is the only sound one.
+
+use std::collections::HashMap;
+
+use super::supervisor::Supervisor;
+
+/// Per-context Class-M floor bundle held by the supervisor registry.
+///
+/// Bundled (rather than two separate maps) because the receive-side overshoot
+/// ceiling in [`Supervisor::check_and_advance_recv_sequence`] reads the sender
+/// epoch floor from the SAME entry — one `DashMap` entry guard covers both,
+/// keeping every gate a single acquire (ADR-049 Decision 13).
+///
+/// No `Zeroize`: these are non-secret monotonic counters (epoch high-water and
+/// `(epoch, sequence)` anti-replay marks), not key material.
+#[derive(Debug, Default)]
+pub(in crate::context::supervisor) struct ContextFloors {
+    /// `sender_did` → highest sender-key epoch observed for that sender.
+    /// Mirrors `SenderKeyStore.epochs` for this context (the authoritative
+    /// copy in PR-4).
+    pub(in crate::context::supervisor) sender_epochs: HashMap<String, u64>,
+    /// `sender_did` → highest `(epoch, sequence)` accepted from that sender —
+    /// the intra-epoch anti-replay floor (spec §23.17.3). LEXICOGRAPHIC order.
+    /// Mirrors the provider's `recv_sequence_tracker`.
+    pub(in crate::context::supervisor) recv_sequence: HashMap<String, (u64, u64)>,
+}
+
+/// Rejection reason from a floor-advance gate.
+///
+/// Non-fatal in PR-4: the follower mirror-forward seams log-and-drop these
+/// because the provider remains authoritative. PR-6's atomic read-authority
+/// switch flips these to fail-closed (see PR-6 scope note).
+// `pub` (not `pub(crate)`) because this enum lives in the PRIVATE `floors`
+// module: `pub` here is still crate-internal (the private module ceiling caps
+// visibility), and `pub(crate)` would trip clippy::redundant_pub_crate.
+// `handle.rs` reaches it via `super::floors::FloorAdvanceError`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum FloorAdvanceError {
+    /// A sender-key epoch that did not strictly exceed the recorded floor
+    /// (rollback / replay attempt — #1608 monotonicity).
+    SenderEpochNotMonotonic {
+        /// The sender whose floor was consulted.
+        did: String,
+        /// The floor currently recorded (absent floor read as `0`).
+        current: u64,
+        /// The rejected proposed epoch.
+        proposed: u64,
+    },
+    /// A sender-key epoch beyond `current + max_advance` (epoch-poisoning
+    /// ceiling — a crafted `epoch = u64::MAX` would otherwise wedge the store).
+    SenderEpochOvershoot {
+        /// The sender whose floor was consulted.
+        did: String,
+        /// The enforced `current + max_advance` ceiling.
+        ceiling: u64,
+        /// The rejected proposed epoch.
+        proposed: u64,
+    },
+    /// A receive-side `(epoch, sequence)` that did not strictly exceed the
+    /// recorded floor (replay / reorder — spec §23.17.3).
+    RecvSequenceNotMonotonic {
+        /// The sender whose floor was consulted.
+        did: String,
+        /// The floor currently recorded.
+        current: (u64, u64),
+        /// The rejected proposed `(epoch, sequence)`.
+        proposed: (u64, u64),
+    },
+    /// A receive-side epoch beyond the sender's epoch floor `+ max_advance`
+    /// (mirrors the provider's H9 receive-side epoch ceiling in `open()`).
+    RecvSequenceOvershoot {
+        /// The sender whose floor was consulted.
+        did: String,
+        /// The enforced `sender_epoch_floor + max_advance` ceiling.
+        ceiling: u64,
+        /// The rejected proposed epoch.
+        proposed: u64,
+    },
+}
+
+impl std::fmt::Display for FloorAdvanceError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::SenderEpochNotMonotonic {
+                did,
+                current,
+                proposed,
+            } => write!(
+                f,
+                "sender-epoch floor for {did} is non-monotonic: proposed {proposed} <= current {current}"
+            ),
+            Self::SenderEpochOvershoot {
+                did,
+                ceiling,
+                proposed,
+            } => write!(
+                f,
+                "sender-epoch floor for {did} overshoots: proposed {proposed} > ceiling {ceiling}"
+            ),
+            Self::RecvSequenceNotMonotonic {
+                did,
+                current,
+                proposed,
+            } => write!(
+                f,
+                "recv-sequence floor for {did} is non-monotonic: proposed {proposed:?} <= current {current:?}"
+            ),
+            Self::RecvSequenceOvershoot {
+                did,
+                ceiling,
+                proposed,
+            } => write!(
+                f,
+                "recv-sequence floor for {did} overshoots: proposed epoch {proposed} > ceiling {ceiling}"
+            ),
+        }
+    }
+}
+
+impl std::error::Error for FloorAdvanceError {}
+
+impl Supervisor {
+    /// Atomically check-and-advance the per-sender **epoch** floor for `ctx`.
+    ///
+    /// The whole read-current → reject-if-`<=` → reject-if-overshoot → write
+    /// sequence runs under **exactly ONE** `self.floors.entry(*ctx).or_default()`
+    /// guard (ADR-049 Decision 13 — one acquire per gate). It NEVER does a
+    /// `get()`-then-`insert()`, which would open a TOCTOU window.
+    ///
+    /// # Single-writer / security separation (inquisitor-sharpened, verbatim)
+    ///
+    /// SECURITY — "never accept a key below the floor" — is STRUCTURAL and
+    /// caller-topology-independent: the single-`entry()`-guard body (atomic read
+    /// → reject-`<=` → reject-overshoot → write, all under one guard) plus the
+    /// fail-safe gate-then-key-insert ordering make key-below-floor impossible no
+    /// matter who calls. The per-context single-writer actor (`ContextActor::run()`
+    /// serializes gate-then-insert) preserves only LIVENESS (avoids spurious
+    /// rejects). If `check_and_advance` were ever called for a LIVE context from
+    /// OUTSIDE its owning actor, the gate→insert window would open but stays
+    /// FAIL-SAFE — it degrades liveness (a spurious reject / retry), NEVER
+    /// fail-open. Do NOT read this as "security depends on single-writer";
+    /// security is the structural gate, single-writer is a liveness convention.
+    /// (PR-6 re-evaluates whether a structural guard is warranted once the gate
+    /// RESULT becomes security-enforced.)
+    ///
+    /// # Errors
+    ///
+    /// [`FloorAdvanceError::SenderEpochNotMonotonic`] if `epoch <=` the recorded
+    /// floor (absent floor read as `0`, matching `SenderKeyStore::set_checked`);
+    /// [`FloorAdvanceError::SenderEpochOvershoot`] if `epoch` exceeds
+    /// `current + max_advance`.
+    #[allow(
+        clippy::significant_drop_tightening,
+        reason = "the single DashMap entry guard MUST span read-reject-write for the TOCTOU-atomic monotone floor advance (ADR-049 PR-4); early-dropping it breaks the invariant"
+    )]
+    pub(in crate::context) fn check_and_advance_sender_epoch(
+        &self,
+        ctx: &[u8; 32],
+        did: &str,
+        epoch: u64,
+        max_advance: u64,
+    ) -> Result<(), FloorAdvanceError> {
+        // THE single guard. Everything below runs under it — no second acquire.
+        let mut entry = self.floors.entry(*ctx).or_default();
+        let floors = entry.value_mut();
+
+        // Read-current UNDER the guard (absent read as 0, matching set_checked).
+        let current = floors.sender_epochs.get(did).copied().unwrap_or(0);
+        // reject-if-<= (monotonicity, #1608).
+        if epoch <= current {
+            return Err(FloorAdvanceError::SenderEpochNotMonotonic {
+                did: did.to_owned(),
+                current,
+                proposed: epoch,
+            });
+        }
+        // reject-if-overshoot (epoch-poisoning ceiling).
+        let ceiling = current.saturating_add(max_advance);
+        if epoch > ceiling {
+            return Err(FloorAdvanceError::SenderEpochOvershoot {
+                did: did.to_owned(),
+                ceiling,
+                proposed: epoch,
+            });
+        }
+        // write UNDER the same guard.
+        floors.sender_epochs.insert(did.to_owned(), epoch);
+        Ok(())
+    }
+
+    /// Atomically check-and-advance the per-sender **receive-sequence** floor for
+    /// `ctx`. Receive-side twin of [`Self::check_and_advance_sender_epoch`].
+    ///
+    /// `next` is compared LEXICOGRAPHICALLY on `(epoch, sequence)`. The overshoot
+    /// ceiling reads the sender epoch floor from the SAME entry (matching the
+    /// provider's H9 receive-side epoch ceiling in `open()`), so both live under
+    /// one `entry()` guard (ADR-049 Decision 13). Same TOCTOU-safety and the same
+    /// single-writer / security separation as the epoch twin above apply here
+    /// verbatim: security is the structural single-guard gate; single-writer is
+    /// only a liveness convention.
+    ///
+    /// # Errors
+    ///
+    /// [`FloorAdvanceError::RecvSequenceNotMonotonic`] if `next <=` a recorded
+    /// floor (absent floor accepts the first observation, matching `open()`'s
+    /// `Some`-guarded replay check); [`FloorAdvanceError::RecvSequenceOvershoot`]
+    /// if `next.0` exceeds `sender_epoch_floor + max_advance`.
+    #[allow(
+        clippy::significant_drop_tightening,
+        reason = "the single DashMap entry guard MUST span read-reject-write for the TOCTOU-atomic monotone floor advance (ADR-049 PR-4); early-dropping it breaks the invariant"
+    )]
+    pub(in crate::context) fn check_and_advance_recv_sequence(
+        &self,
+        ctx: &[u8; 32],
+        did: &str,
+        next: (u64, u64),
+        max_advance: u64,
+    ) -> Result<(), FloorAdvanceError> {
+        // THE single guard. Everything below runs under it — no second acquire.
+        let mut entry = self.floors.entry(*ctx).or_default();
+        let floors = entry.value_mut();
+
+        // reject-if-<= — but ONLY when a floor is already present, matching
+        // `open()` which applies the replay check under `if let Some(..)` and
+        // accepts the first observation for an absent sender.
+        if let Some(current) = floors.recv_sequence.get(did).copied()
+            && next <= current
+        {
+            return Err(FloorAdvanceError::RecvSequenceNotMonotonic {
+                did: did.to_owned(),
+                current,
+                proposed: next,
+            });
+        }
+        // reject-if-overshoot: the receive-side epoch ceiling reads the sender
+        // epoch floor from THIS SAME entry (absent read as 0).
+        let epoch_floor = floors.sender_epochs.get(did).copied().unwrap_or(0);
+        let ceiling = epoch_floor.saturating_add(max_advance);
+        if next.0 > ceiling {
+            return Err(FloorAdvanceError::RecvSequenceOvershoot {
+                did: did.to_owned(),
+                ceiling,
+                proposed: next.0,
+            });
+        }
+        // write UNDER the same guard.
+        floors.recv_sequence.insert(did.to_owned(), next);
+        Ok(())
+    }
+
+    /// Read the registry's per-sender epoch floors for `ctx` as a
+    /// `(sender_did, epoch)` list (empty if no entry). Registry twin of the
+    /// provider's `export_sender_key_epochs`; PR-6 retargets callers here.
+    ///
+    /// PR-4 has no PRODUCTION caller (the authoritative capture stays on the
+    /// provider); this is the forward-declared read surface the PR-6
+    /// read-authority switch retargets onto. Fully exercised by the registry
+    /// unit tests + the respawn coalesce-lag follower-tracks-provider assertion.
+    #[must_use]
+    #[allow(
+        dead_code,
+        reason = "ADR-049 PR-4 forward-declared registry read API; production callers land in PR-6 (read-authority switch). Test-exercised today."
+    )]
+    pub(in crate::context) fn export_sender_key_epochs(
+        &self,
+        ctx: &[u8; 32],
+    ) -> Vec<(String, u64)> {
+        self.floors.get(ctx).map_or_else(Vec::new, |entry| {
+            entry
+                .value()
+                .sender_epochs
+                .iter()
+                .map(|(did, epoch)| (did.clone(), *epoch))
+                .collect()
+        })
+    }
+
+    /// Read the registry's per-sender receive-sequence floors for `ctx` as a
+    /// `(sender_did, (epoch, sequence))` list (empty if no entry). Registry twin
+    /// of the provider's `export_recv_sequence_floors`.
+    ///
+    /// PR-4 has no PRODUCTION caller (forward-declared for the PR-6
+    /// read-authority switch); fully exercised by the registry unit tests.
+    #[must_use]
+    #[allow(
+        dead_code,
+        reason = "ADR-049 PR-4 forward-declared registry read API; production callers land in PR-6 (read-authority switch). Test-exercised today."
+    )]
+    pub(in crate::context) fn export_recv_sequence_floors(
+        &self,
+        ctx: &[u8; 32],
+    ) -> Vec<(String, (u64, u64))> {
+        self.floors.get(ctx).map_or_else(Vec::new, |entry| {
+            entry
+                .value()
+                .recv_sequence
+                .iter()
+                .map(|(did, floor)| (did.clone(), *floor))
+                .collect()
+        })
+    }
+
+    /// Merge `incoming` per-sender epoch floors into the registry for `ctx`.
+    ///
+    /// PR-4 **follower** semantics: a monotone max-merge — for each incoming
+    /// `(did, floor)`, the registry keeps `max(existing, floor)` (insert-if-
+    /// absent). It never regresses a registry floor and never rejects, because
+    /// the AUTHORITATIVE regression / overshoot validation runs on the provider
+    /// in PR-4 (this seed only mirrors the provider's already-validated result).
+    /// `max_advance` and `trusted_local` are plumbed through for the PR-6
+    /// read-authority switch, which makes this the authoritative, fail-closed
+    /// merge (see PR-6 scope note); they are intentionally unused in the PR-4
+    /// follower body. The whole merge runs under one `entry()` guard.
+    ///
+    /// # Errors
+    ///
+    /// Infallible in PR-4 (returns `Ok`); the `Result` matches the provider twin
+    /// so PR-6 can retarget callers without a signature change.
+    #[allow(
+        clippy::significant_drop_tightening,
+        reason = "the single DashMap entry guard MUST span the whole monotone max-merge (ADR-049 PR-4); early-dropping it breaks the single-guard invariant"
+    )]
+    #[allow(
+        clippy::unnecessary_wraps,
+        unused_variables,
+        reason = "signature parity with provider::validate_and_merge_epoch_floors — max_advance/trusted_local + the fallible Result are exercised by the PR-6 fail-closed validating merge; the PR-4 follower is infallible monotone-max"
+    )]
+    pub(in crate::context) fn validate_and_merge_epoch_floors(
+        &self,
+        ctx: &[u8; 32],
+        incoming: Vec<(String, u64)>,
+        max_advance: u64,
+        trusted_local: bool,
+    ) -> Result<(), FloorAdvanceError> {
+        // PR-4 follower: `max_advance` / `trusted_local` are reserved for the
+        // PR-6 fail-closed switch.
+        if incoming.is_empty() {
+            return Ok(());
+        }
+        let mut entry = self.floors.entry(*ctx).or_default();
+        let floors = entry.value_mut();
+        for (did, floor) in incoming {
+            floors
+                .sender_epochs
+                .entry(did)
+                .and_modify(|cur| *cur = (*cur).max(floor))
+                .or_insert(floor);
+        }
+        Ok(())
+    }
+
+    /// Merge `incoming` per-sender receive-sequence floors into the registry for
+    /// `ctx`. Receive-side twin of [`Self::validate_and_merge_epoch_floors`] with
+    /// the same PR-4 follower (monotone max-merge, lexicographic on
+    /// `(epoch, sequence)`) semantics and the same PR-6 deferral.
+    ///
+    /// # Errors
+    ///
+    /// Infallible in PR-4 (returns `Ok`); the `Result` matches the provider twin.
+    #[allow(
+        clippy::significant_drop_tightening,
+        reason = "the single DashMap entry guard MUST span the whole monotone max-merge (ADR-049 PR-4); early-dropping it breaks the single-guard invariant"
+    )]
+    #[allow(
+        clippy::unnecessary_wraps,
+        unused_variables,
+        reason = "signature parity with provider::validate_and_merge_recv_sequence_floors — trusted_local + the fallible Result are exercised by the PR-6 fail-closed validating merge; the PR-4 follower is infallible monotone-max"
+    )]
+    pub(in crate::context) fn validate_and_merge_recv_sequence_floors(
+        &self,
+        ctx: &[u8; 32],
+        incoming: Vec<(String, (u64, u64))>,
+        trusted_local: bool,
+    ) -> Result<(), FloorAdvanceError> {
+        // PR-4 follower: `trusted_local` is reserved for the PR-6 fail-closed
+        // switch.
+        if incoming.is_empty() {
+            return Ok(());
+        }
+        let mut entry = self.floors.entry(*ctx).or_default();
+        let floors = entry.value_mut();
+        for (did, floor) in incoming {
+            floors
+                .recv_sequence
+                .entry(did)
+                .and_modify(|cur| *cur = (*cur).max(floor))
+                .or_insert(floor);
+        }
+        Ok(())
+    }
+
+    /// Create-seed: ensure a default-empty floor entry exists for `ctx`.
+    ///
+    /// ADR-049 PR-4 §5 — called on the context-creation path so the registry
+    /// entry exists from creation (it then grows via mirror-forward).
+    /// **INSERT-IF-ABSENT only** (`entry().or_default()`), NEVER an
+    /// unconditional `insert`: a late / racing create-seed must never reset an
+    /// already-advanced follower entry. Harmless in PR-4 (the registry is
+    /// unread) but forward-safe for the PR-6 read-authority switch.
+    /// [cryptographer hardening]
+    pub(in crate::context) fn seed_context_floors(&self, ctx: &[u8; 32]) {
+        // Insert-if-absent; the returned guard is dropped immediately. Does NOT
+        // overwrite an existing (possibly already-advanced) entry.
+        self.floors.entry(*ctx).or_default();
+    }
+}
+
+#[cfg(test)]
+#[allow(
+    clippy::expect_used,
+    clippy::unwrap_used,
+    clippy::panic,
+    clippy::significant_drop_tightening
+)]
+mod tests {
+    use std::sync::Arc;
+    use std::thread;
+
+    use scp_protocol::crypto::sender_keys::MAX_EPOCH_ADVANCE;
+
+    use super::{FloorAdvanceError, Supervisor};
+    use crate::context::supervisor::handle::SupervisorHandle;
+
+    const CTX: [u8; 32] = [0xA5u8; 32];
+    const DID: &str = "did:dht:z6MkFloorSenderFloorSenderFloorSenderAA";
+
+    fn sup() -> Arc<Supervisor> {
+        // The registry needs no providers, so the provider-free query shim is
+        // the right lightweight constructor for these unit tests.
+        Arc::new(Supervisor::for_query_shim())
+    }
+
+    // -- sender-epoch monotonicity + overshoot ----------------------------------
+
+    #[test]
+    fn sender_epoch_advances_monotonically() {
+        let s = sup();
+        // First observation must be > 0 (matches SenderKeyStore::set_checked).
+        assert_eq!(
+            s.check_and_advance_sender_epoch(&CTX, DID, 0, MAX_EPOCH_ADVANCE),
+            Err(FloorAdvanceError::SenderEpochNotMonotonic {
+                did: DID.to_owned(),
+                current: 0,
+                proposed: 0,
+            })
+        );
+        assert!(
+            s.check_and_advance_sender_epoch(&CTX, DID, 1, MAX_EPOCH_ADVANCE)
+                .is_ok()
+        );
+        assert!(
+            s.check_and_advance_sender_epoch(&CTX, DID, 5, MAX_EPOCH_ADVANCE)
+                .is_ok()
+        );
+        // Equal or lower is rejected (rollback / replay).
+        assert!(matches!(
+            s.check_and_advance_sender_epoch(&CTX, DID, 5, MAX_EPOCH_ADVANCE),
+            Err(FloorAdvanceError::SenderEpochNotMonotonic { .. })
+        ));
+        assert!(matches!(
+            s.check_and_advance_sender_epoch(&CTX, DID, 4, MAX_EPOCH_ADVANCE),
+            Err(FloorAdvanceError::SenderEpochNotMonotonic { .. })
+        ));
+        assert_eq!(s.export_sender_key_epochs(&CTX), vec![(DID.to_owned(), 5)]);
+    }
+
+    #[test]
+    fn sender_epoch_rejects_overshoot() {
+        let s = sup();
+        // From an absent floor (0), the ceiling is 0 + MAX_EPOCH_ADVANCE.
+        assert_eq!(
+            s.check_and_advance_sender_epoch(&CTX, DID, MAX_EPOCH_ADVANCE + 1, MAX_EPOCH_ADVANCE),
+            Err(FloorAdvanceError::SenderEpochOvershoot {
+                did: DID.to_owned(),
+                ceiling: MAX_EPOCH_ADVANCE,
+                proposed: MAX_EPOCH_ADVANCE + 1,
+            })
+        );
+        // Exactly at the ceiling is accepted.
+        assert!(
+            s.check_and_advance_sender_epoch(&CTX, DID, MAX_EPOCH_ADVANCE, MAX_EPOCH_ADVANCE)
+                .is_ok()
+        );
+        // A rejected overshoot leaves no floor written.
+        assert_eq!(
+            s.export_sender_key_epochs(&CTX),
+            vec![(DID.to_owned(), MAX_EPOCH_ADVANCE)]
+        );
+    }
+
+    // -- recv-sequence monotonicity + overshoot ---------------------------------
+
+    #[test]
+    fn recv_sequence_advances_lexicographically() {
+        let s = sup();
+        // First observation for an absent sender is accepted (matches open()'s
+        // Some-guarded replay check).
+        assert!(
+            s.check_and_advance_recv_sequence(&CTX, DID, (0, 3), MAX_EPOCH_ADVANCE)
+                .is_ok()
+        );
+        // Same (epoch, seq) is a replay — rejected.
+        assert!(matches!(
+            s.check_and_advance_recv_sequence(&CTX, DID, (0, 3), MAX_EPOCH_ADVANCE),
+            Err(FloorAdvanceError::RecvSequenceNotMonotonic { .. })
+        ));
+        // Lower sequence at the same epoch — rejected.
+        assert!(matches!(
+            s.check_and_advance_recv_sequence(&CTX, DID, (0, 2), MAX_EPOCH_ADVANCE),
+            Err(FloorAdvanceError::RecvSequenceNotMonotonic { .. })
+        ));
+        // Higher sequence at the same epoch — accepted.
+        assert!(
+            s.check_and_advance_recv_sequence(&CTX, DID, (0, 4), MAX_EPOCH_ADVANCE)
+                .is_ok()
+        );
+        // Advance to a higher epoch — accepted (epoch 1 is within the ceiling
+        // `sender_epoch_floor(0) + MAX_EPOCH_ADVANCE`).
+        assert!(
+            s.check_and_advance_recv_sequence(&CTX, DID, (1, 0), MAX_EPOCH_ADVANCE)
+                .is_ok()
+        );
+        // Lower epoch, even with a much higher seq — rejected (lexicographic on
+        // the `(epoch, seq)` pair: `(0, 99) < (1, 0)`).
+        assert!(matches!(
+            s.check_and_advance_recv_sequence(&CTX, DID, (0, 99), MAX_EPOCH_ADVANCE),
+            Err(FloorAdvanceError::RecvSequenceNotMonotonic { .. })
+        ));
+        assert_eq!(
+            s.export_recv_sequence_floors(&CTX),
+            vec![(DID.to_owned(), (1, 0))]
+        );
+    }
+
+    #[test]
+    fn recv_sequence_overshoot_reads_epoch_floor_from_same_entry() {
+        let s = sup();
+        // Advance the sender epoch floor to 5 in the SAME entry.
+        s.check_and_advance_sender_epoch(&CTX, DID, 5, MAX_EPOCH_ADVANCE)
+            .unwrap();
+        // A recv epoch beyond epoch_floor(5) + MAX_EPOCH_ADVANCE is rejected.
+        assert_eq!(
+            s.check_and_advance_recv_sequence(
+                &CTX,
+                DID,
+                (5 + MAX_EPOCH_ADVANCE + 1, 0),
+                MAX_EPOCH_ADVANCE
+            ),
+            Err(FloorAdvanceError::RecvSequenceOvershoot {
+                did: DID.to_owned(),
+                ceiling: 5 + MAX_EPOCH_ADVANCE,
+                proposed: 5 + MAX_EPOCH_ADVANCE + 1,
+            })
+        );
+        // At the ceiling — accepted.
+        assert!(
+            s.check_and_advance_recv_sequence(
+                &CTX,
+                DID,
+                (5 + MAX_EPOCH_ADVANCE, 0),
+                MAX_EPOCH_ADVANCE
+            )
+            .is_ok()
+        );
+    }
+
+    // -- merge / seed / export --------------------------------------------------
+
+    #[test]
+    fn merge_is_monotone_max_and_seed_is_insert_if_absent() {
+        let s = sup();
+        // seed creates a default-empty entry (insert-if-absent).
+        s.seed_context_floors(&CTX);
+        assert!(s.export_sender_key_epochs(&CTX).is_empty());
+
+        // Advance one sender, then merge a mix of lower + higher + new.
+        s.check_and_advance_sender_epoch(&CTX, DID, 10, MAX_EPOCH_ADVANCE)
+            .unwrap();
+        s.validate_and_merge_epoch_floors(
+            &CTX,
+            vec![
+                (DID.to_owned(), 4),              // lower — must NOT regress
+                (DID.to_owned(), 12),             // higher — wins via max
+                ("did:dht:zOther".to_owned(), 7), // new sender
+            ],
+            MAX_EPOCH_ADVANCE,
+            true,
+        )
+        .unwrap();
+        let mut got = s.export_sender_key_epochs(&CTX);
+        got.sort();
+        assert_eq!(
+            got,
+            vec![(DID.to_owned(), 12), ("did:dht:zOther".to_owned(), 7)]
+        );
+
+        // seed after advance must NOT reset the entry.
+        s.seed_context_floors(&CTX);
+        let mut after = s.export_sender_key_epochs(&CTX);
+        after.sort();
+        assert_eq!(after, got);
+
+        // recv merge twin — monotone max, lexicographic.
+        s.validate_and_merge_recv_sequence_floors(
+            &CTX,
+            vec![(DID.to_owned(), (2, 9)), (DID.to_owned(), (1, 0))],
+            true,
+        )
+        .unwrap();
+        assert_eq!(
+            s.export_recv_sequence_floors(&CTX),
+            vec![(DID.to_owned(), (2, 9))]
+        );
+        // empty merge is a no-op that does not error.
+        assert!(
+            s.validate_and_merge_epoch_floors(&CTX, vec![], MAX_EPOCH_ADVANCE, false)
+                .is_ok()
+        );
+    }
+
+    // -- Decision-13: exactly ONE registry entry per gate (single-guard body) ---
+
+    #[test]
+    #[allow(
+        clippy::significant_drop_tightening,
+        reason = "test read: the DashMap entry guard is held only across the immediate assertions verifying the single-entry invariant"
+    )]
+    fn gate_uses_single_entry_no_double_insert() {
+        let s = sup();
+        assert_eq!(s.floors.len(), 0);
+        s.check_and_advance_sender_epoch(&CTX, DID, 1, MAX_EPOCH_ADVANCE)
+            .unwrap();
+        // One gate → exactly one context entry created.
+        assert_eq!(s.floors.len(), 1, "one entry() per gate (Decision-13)");
+        // A recv gate on the same ctx reuses the SAME entry — no second insert.
+        s.check_and_advance_recv_sequence(&CTX, DID, (1, 1), MAX_EPOCH_ADVANCE)
+            .unwrap();
+        assert_eq!(s.floors.len(), 1, "recv gate reuses the same ctx entry");
+        // Both floors live under that single entry.
+        let entry = s.floors.get(&CTX).expect("ctx entry");
+        assert_eq!(entry.sender_epochs.get(DID).copied(), Some(1));
+        assert_eq!(entry.recv_sequence.get(DID).copied(), Some((1, 1)));
+    }
+
+    // -- Decision-14: gate work is O(1) — independent of sender count -----------
+
+    #[test]
+    #[allow(
+        clippy::significant_drop_tightening,
+        reason = "test read: the DashMap entry guard is held only across the immediate assertions verifying O(1) per-sender isolation"
+    )]
+    fn gate_is_o1_independent_of_sender_count() {
+        let s = sup();
+        // Pre-load the registry entry with many senders.
+        for i in 0..5_000u64 {
+            let did = format!("did:dht:zBulk{i}");
+            s.check_and_advance_sender_epoch(&CTX, &did, 1, MAX_EPOCH_ADVANCE)
+                .unwrap();
+        }
+        // A single-sender advance in a large registry touches ONLY that sender:
+        // no O(senders) scan/clone (the property the Decision-14 <15% budget
+        // rests on — the mirror-forward reads the value from `open()`/getters in
+        // O(1), never via an O(senders) export re-read).
+        s.check_and_advance_sender_epoch(&CTX, DID, 42, MAX_EPOCH_ADVANCE)
+            .unwrap();
+        let entry = s.floors.get(&CTX).expect("ctx entry");
+        assert_eq!(entry.sender_epochs.get(DID).copied(), Some(42));
+        // Every pre-loaded sender is untouched (still 1) — the gate did not
+        // rewrite or iterate them.
+        assert_eq!(entry.sender_epochs.get("did:dht:zBulk0").copied(), Some(1));
+        assert_eq!(
+            entry.sender_epochs.get("did:dht:zBulk4999").copied(),
+            Some(1)
+        );
+        assert_eq!(entry.sender_epochs.len(), 5_001);
+    }
+
+    // -- shuttle-style strict-monotonicity concurrency test ---------------------
+    //
+    // NOTE: this lives inline (crate-internal) rather than in
+    // `tests/shuttle_actor.rs` because the registry gate is capability-reduced
+    // (`pub(in crate::context)`) and is NOT reachable from the external test
+    // crate without violating Invariant 3 / the cross-layer gate. It exercises
+    // the same "strict-monotonicity under concurrent writers" invariant with
+    // real OS threads, exactly like the sibling `context_handle_cas_stress`
+    // stress test in `tests/shuttle_actor.rs`.
+
+    #[test]
+    fn concurrent_advances_are_strictly_monotone_no_lost_update() {
+        const LADDER: u64 = 2_000;
+        let s = sup();
+
+        // Two threads race the SAME (ctx, did) ladder 1..=LADDER. Each epoch in
+        // the ladder can be accepted by AT MOST ONE thread (the single-`entry()`
+        // guard serializes gate-then-write); a slower thread re-loads the fresh
+        // higher floor and is rejected. Under ANY interleaving the invariants are:
+        //  (a) strict monotonicity — no accepted epoch is ever <= a prior floor;
+        //  (b) no lost update — every epoch 1..=LADDER is accepted EXACTLY once,
+        //      so the two threads' success counts sum to exactly LADDER;
+        //  (c) the final floor is exactly the ladder top.
+        let worker = |s: Arc<Supervisor>| {
+            move || {
+                let mut accepted = 0u64;
+                for epoch in 1..=LADDER {
+                    // max_advance = LADDER guarantees +1 steps never overshoot.
+                    if s.check_and_advance_sender_epoch(&CTX, DID, epoch, LADDER)
+                        .is_ok()
+                    {
+                        accepted += 1;
+                    }
+                }
+                accepted
+            }
+        };
+        let a = thread::spawn(worker(Arc::clone(&s)));
+        let b = thread::spawn(worker(Arc::clone(&s)));
+        let count_a = a.join().expect("thread a");
+        let count_b = b.join().expect("thread b");
+
+        // (b) no lost update, no double-accept.
+        assert_eq!(
+            count_a + count_b,
+            LADDER,
+            "each epoch must be accepted exactly once across both racers"
+        );
+        // (a)/(c) the floor landed exactly on the ladder top, strictly monotone.
+        assert_eq!(
+            s.export_sender_key_epochs(&CTX),
+            vec![(DID.to_owned(), LADDER)]
+        );
+    }
+
+    // -- SupervisorHandle fan-out accessors forward to the registry -------------
+
+    #[test]
+    fn handle_accessors_forward_to_registry() {
+        let s = sup();
+        let h = SupervisorHandle::wrap(Arc::clone(&s));
+
+        h.seed_context_floors(&CTX);
+        assert!(
+            h.check_and_advance_sender_epoch(&CTX, DID, 3, MAX_EPOCH_ADVANCE)
+                .is_ok()
+        );
+        assert!(
+            h.check_and_advance_recv_sequence(&CTX, DID, (3, 1), MAX_EPOCH_ADVANCE)
+                .is_ok()
+        );
+        h.validate_and_merge_epoch_floors(&CTX, vec![(DID.to_owned(), 8)], MAX_EPOCH_ADVANCE, true)
+            .unwrap();
+        h.validate_and_merge_recv_sequence_floors(&CTX, vec![(DID.to_owned(), (8, 2))], true)
+            .unwrap();
+
+        // The handle reads must agree with the direct Supervisor reads.
+        assert_eq!(
+            h.export_sender_key_epochs(&CTX),
+            s.export_sender_key_epochs(&CTX)
+        );
+        assert_eq!(
+            h.export_recv_sequence_floors(&CTX),
+            s.export_recv_sequence_floors(&CTX)
+        );
+        assert_eq!(h.export_sender_key_epochs(&CTX), vec![(DID.to_owned(), 8)]);
+        assert_eq!(
+            h.export_recv_sequence_floors(&CTX),
+            vec![(DID.to_owned(), (8, 2))]
+        );
+    }
+}

--- a/crates/scp-runtime/src/context/supervisor/floors.rs
+++ b/crates/scp-runtime/src/context/supervisor/floors.rs
@@ -39,6 +39,16 @@ pub(in crate::context::supervisor) struct ContextFloors {
     /// `sender_did` → highest sender-key epoch observed for that sender.
     /// Mirrors `SenderKeyStore.epochs` for this context (the authoritative
     /// copy in PR-4).
+    ///
+    /// INVARIANT (black-hat F-3): this one map holds BOTH the REMOTE per-sender
+    /// distributed-epoch high-water (keyed by each remote sender DID) AND — via
+    /// the local-rotation mirror-forward — the LOCAL `sender_key_epoch` scalar
+    /// keyed by `local_did`. This coexistence is safe today ONLY because
+    /// `local_did` never appears as a remote sender in its own recv path, so the
+    /// receive-side overshoot ceiling (which reads `sender_epochs[remote_did]`)
+    /// never reads the local scalar. This coincidence is LOAD-BEARING: PR-6 / PR-7
+    /// must preserve it (or split the two counters into separate maps) before the
+    /// gate becomes read-authoritative.
     pub(in crate::context::supervisor) sender_epochs: HashMap<String, u64>,
     /// `sender_did` → highest `(epoch, sequence)` accepted from that sender —
     /// the intra-epoch anti-replay floor (spec §23.17.3). LEXICOGRAPHIC order.
@@ -88,7 +98,11 @@ pub enum FloorAdvanceError {
         proposed: (u64, u64),
     },
     /// A receive-side epoch beyond the sender's epoch floor `+ max_advance`
-    /// (mirrors the provider's H9 receive-side epoch ceiling in `open()`).
+    /// (the follower's analogue of the provider's H9 receive-side epoch ceiling
+    /// in `open()` — but the ceiling reads THIS follower's own, possibly-lagging
+    /// `sender_epochs` mirror, not the provider's authoritative epoch, so it is
+    /// NOT exact provider-parity; exact parity is a PR-6 concern once the gate
+    /// is fail-closed and read-authoritative).
     RecvSequenceOvershoot {
         /// The sender whose floor was consulted.
         did: String,
@@ -213,9 +227,14 @@ impl Supervisor {
     /// `ctx`. Receive-side twin of [`Self::check_and_advance_sender_epoch`].
     ///
     /// `next` is compared LEXICOGRAPHICALLY on `(epoch, sequence)`. The overshoot
-    /// ceiling reads the sender epoch floor from the SAME entry (matching the
-    /// provider's H9 receive-side epoch ceiling in `open()`), so both live under
-    /// one `entry()` guard (ADR-049 Decision 13). Same TOCTOU-safety and the same
+    /// ceiling reads the sender epoch floor from the SAME entry — the follower's
+    /// analogue of the provider's H9 receive-side epoch ceiling in `open()`, but
+    /// against THIS follower's own, possibly-lagging `sender_epochs` mirror (which
+    /// only catches up when the Management-arm mirror-forward runs), NOT the
+    /// provider's authoritative epoch. It is therefore NOT exact provider-parity;
+    /// exact parity is a PR-6 concern once the gate becomes fail-closed and
+    /// read-authoritative. Both floors live under one `entry()` guard (ADR-049
+    /// Decision 13). Same TOCTOU-safety and the same
     /// single-writer / security separation as the epoch twin above apply here
     /// verbatim: security is the structural single-guard gate; single-writer is
     /// only a liveness convention.
@@ -336,7 +355,11 @@ impl Supervisor {
     /// # Errors
     ///
     /// Infallible in PR-4 (returns `Ok`); the `Result` matches the provider twin
-    /// so PR-6 can retarget callers without a signature change.
+    /// so PR-6 can retarget callers without a PARAM-LIST change. Parity is only
+    /// PARTIAL, though: the provider twin returns `Result<(), ContextError>`
+    /// while this returns `Result<(), FloorAdvanceError>`, so the PR-6 retarget
+    /// is param-list-churn-free but MUST still reconcile the error type (unify
+    /// `FloorAdvanceError` / `ContextError`).
     #[allow(
         clippy::significant_drop_tightening,
         reason = "the single DashMap entry guard MUST span the whole monotone max-merge (ADR-049 PR-4); early-dropping it breaks the single-guard invariant"
@@ -377,7 +400,11 @@ impl Supervisor {
     ///
     /// # Errors
     ///
-    /// Infallible in PR-4 (returns `Ok`); the `Result` matches the provider twin.
+    /// Infallible in PR-4 (returns `Ok`); the `Result` matches the provider twin
+    /// in PARAM-LIST only — same PARTIAL parity as
+    /// [`Self::validate_and_merge_epoch_floors`]: the provider twin returns
+    /// `Result<(), ContextError>` while this returns `Result<(), FloorAdvanceError>`,
+    /// so PR-6's retarget must still reconcile the error type.
     #[allow(
         clippy::significant_drop_tightening,
         reason = "the single DashMap entry guard MUST span the whole monotone max-merge (ADR-049 PR-4); early-dropping it breaks the single-guard invariant"
@@ -424,15 +451,39 @@ impl Supervisor {
         // overwrite an existing (possibly already-advanced) entry.
         self.floors.entry(*ctx).or_default();
     }
+
+    /// Permanent-teardown prune: drop the whole [`ContextFloors`] entry for
+    /// `ctx` (ADR-049 PR-4).
+    ///
+    /// The provider prunes its AUTHORITATIVE per-context floor maps inside
+    /// `destroy_mls_group` (`self.contexts.remove` in `crypto/mls/provider.rs`);
+    /// the follower registry has no such prune, so without this every
+    /// permanently-torn-down context would leak a `ContextFloors` entry (and its
+    /// unbounded per-sender maps). This is the follower twin of that prune,
+    /// called from EVERY genuine permanent-teardown site (explicit
+    /// close → `Closed`, TTL expiry → `Expired`, welcome-join rollback, process
+    /// shutdown) — mirroring exactly where the provider drops its crypto state
+    /// and where `crash_windows` is reaped.
+    ///
+    /// # Safety (why pruning is sound only on PERMANENT teardown)
+    ///
+    /// A later re-create of the SAME deterministic id is a NEW MLS group with
+    /// fresh keys, so the discarded `(epoch, sequence)` / epoch floors are
+    /// cryptographically moot — an old floor cannot gate (or be replayed
+    /// against) the new group's keys. It is therefore CORRECT here but WOULD BE
+    /// UNSOUND on a TRANSIENT destroy where the SAME keys resume (a warm
+    /// respawn / restore, where `restore_crypto_state_with_floor_guard`
+    /// deliberately captures + re-merges the live floors instead of dropping
+    /// them). Callers must only invoke this when the context is permanently gone
+    /// or is being replaced by a fresh group. Idempotent: remove-on-absent is a
+    /// no-op, so a bounded TTL-expiry retry re-entering here is harmless.
+    pub(in crate::context) fn remove_context_floors(&self, ctx: &[u8; 32]) {
+        self.floors.remove(ctx);
+    }
 }
 
 #[cfg(test)]
-#[allow(
-    clippy::expect_used,
-    clippy::unwrap_used,
-    clippy::panic,
-    clippy::significant_drop_tightening
-)]
+#[allow(clippy::expect_used, clippy::unwrap_used, clippy::panic)]
 mod tests {
     use std::sync::Arc;
     use std::thread;

--- a/crates/scp-runtime/src/context/supervisor/handle.rs
+++ b/crates/scp-runtime/src/context/supervisor/handle.rs
@@ -84,7 +84,7 @@ impl SupervisorHandle {
     // -----------------------------------------------------------------------
     // ADR-049 PR-4 — supervisor-owned floor registry (epoch side) fan-out.
     //
-    // These six accessors are PER-CONTEXT (they take `&[u8; 32]`, NOT
+    // These eight accessors are PER-CONTEXT (they take `&[u8; 32]`, NOT
     // `&OwnedIdentityDid` and NOT `&DID`): they are registry fan-out, which the
     // AXIS comment above explicitly exempts from the per-identity token rule.
     // They forward to the same-named `Supervisor` primitives on
@@ -217,6 +217,14 @@ impl SupervisorHandle {
     /// [`Supervisor::seed_context_floors`].
     pub(in crate::context) fn seed_context_floors(&self, ctx: &[u8; 32]) {
         self.supervisor.seed_context_floors(ctx);
+    }
+
+    /// Permanent-teardown prune of the floor registry entry for `ctx`. See
+    /// [`Supervisor::remove_context_floors`] — including the permanent-vs-
+    /// transient safety argument. Callers (the terminal close / TTL-expiry /
+    /// shutdown paths) invoke this only when the context is permanently gone.
+    pub(in crate::context) fn remove_context_floors(&self, ctx: &[u8; 32]) {
+        self.supervisor.remove_context_floors(ctx);
     }
 
     /// Start a cross-context saga. The ONLY way for an actor to affect

--- a/crates/scp-runtime/src/context/supervisor/handle.rs
+++ b/crates/scp-runtime/src/context/supervisor/handle.rs
@@ -37,6 +37,7 @@ use std::sync::Arc;
 use scp_did::DID;
 use scp_protocol::context::ContextError;
 
+use crate::context::supervisor::floors::FloorAdvanceError;
 use crate::context::supervisor::identity_capability::OwnedIdentityDid;
 use crate::context::supervisor::key_package_actor::KeyPackageStoreHandle;
 use crate::context::supervisor::supervisor::{SagaInput, SagaOutput, Supervisor};
@@ -78,6 +79,144 @@ impl SupervisorHandle {
     #[must_use]
     pub(in crate::context::supervisor) const fn wrap(supervisor: Arc<Supervisor>) -> Self {
         Self { supervisor }
+    }
+
+    // -----------------------------------------------------------------------
+    // ADR-049 PR-4 — supervisor-owned floor registry (epoch side) fan-out.
+    //
+    // These six accessors are PER-CONTEXT (they take `&[u8; 32]`, NOT
+    // `&OwnedIdentityDid` and NOT `&DID`): they are registry fan-out, which the
+    // AXIS comment above explicitly exempts from the per-identity token rule.
+    // They forward to the same-named `Supervisor` primitives on
+    // `Supervisor.floors`. NONE returns (or exposes) a `ContextActorHandle`, so
+    // Invariant 3 (actors cannot reach sibling actors) is preserved.
+    //
+    // Single-writer / security separation (inquisitor-sharpened, verbatim — it
+    // SEPARATES structural security from liveness): SECURITY — "never accept a
+    // key below the floor" — is STRUCTURAL and caller-topology-independent: the
+    // single-`entry()`-guard body (atomic read → reject-`<=` → reject-overshoot
+    // → write, all under one guard) plus the fail-safe gate-then-key-insert
+    // ordering make key-below-floor impossible no matter who calls. The
+    // per-context single-writer actor (`ContextActor::run()` serializes
+    // gate-then-insert) preserves only LIVENESS (avoids spurious rejects). If
+    // `check_and_advance` were ever called for a LIVE context from OUTSIDE its
+    // owning actor, the gate→insert window would open but stays FAIL-SAFE — it
+    // degrades liveness (a spurious reject / retry), NEVER fail-open. Do NOT
+    // read this as "security depends on single-writer"; security is the
+    // structural gate, single-writer is a liveness convention. (PR-6
+    // re-evaluates whether a structural guard is warranted once the gate RESULT
+    // becomes security-enforced.)
+
+    /// Follower mirror-forward of a per-sender epoch advance into the
+    /// supervisor-owned floor registry. See
+    /// [`Supervisor::check_and_advance_sender_epoch`].
+    ///
+    /// # Errors
+    ///
+    /// Propagates [`FloorAdvanceError`] on a non-monotonic or overshooting
+    /// epoch; NON-FATAL in PR-4 (callers log-and-drop — the provider remains
+    /// authoritative).
+    pub(in crate::context) fn check_and_advance_sender_epoch(
+        &self,
+        ctx: &[u8; 32],
+        did: &str,
+        epoch: u64,
+        max_advance: u64,
+    ) -> Result<(), FloorAdvanceError> {
+        self.supervisor
+            .check_and_advance_sender_epoch(ctx, did, epoch, max_advance)
+    }
+
+    /// Follower mirror-forward of a per-sender receive-sequence advance. See
+    /// [`Supervisor::check_and_advance_recv_sequence`].
+    ///
+    /// # Errors
+    ///
+    /// Propagates [`FloorAdvanceError`] on a non-monotonic or overshooting
+    /// `(epoch, sequence)`; NON-FATAL in PR-4.
+    pub(in crate::context) fn check_and_advance_recv_sequence(
+        &self,
+        ctx: &[u8; 32],
+        did: &str,
+        next: (u64, u64),
+        max_advance: u64,
+    ) -> Result<(), FloorAdvanceError> {
+        self.supervisor
+            .check_and_advance_recv_sequence(ctx, did, next, max_advance)
+    }
+
+    /// Read the registry's per-sender epoch floors for `ctx`. See
+    /// [`Supervisor::export_sender_key_epochs`].
+    ///
+    /// PR-4 forward-declared read surface (no production caller until PR-6);
+    /// exercised by the registry unit tests.
+    #[must_use]
+    #[allow(
+        dead_code,
+        reason = "ADR-049 PR-4 forward-declared registry read API; production callers land in PR-6 (read-authority switch). Test-exercised today."
+    )]
+    pub(in crate::context) fn export_sender_key_epochs(
+        &self,
+        ctx: &[u8; 32],
+    ) -> Vec<(String, u64)> {
+        self.supervisor.export_sender_key_epochs(ctx)
+    }
+
+    /// Read the registry's per-sender receive-sequence floors for `ctx`. See
+    /// [`Supervisor::export_recv_sequence_floors`].
+    ///
+    /// PR-4 forward-declared read surface (no production caller until PR-6);
+    /// exercised by the registry unit tests.
+    #[must_use]
+    #[allow(
+        dead_code,
+        reason = "ADR-049 PR-4 forward-declared registry read API; production callers land in PR-6 (read-authority switch). Test-exercised today."
+    )]
+    pub(in crate::context) fn export_recv_sequence_floors(
+        &self,
+        ctx: &[u8; 32],
+    ) -> Vec<(String, (u64, u64))> {
+        self.supervisor.export_recv_sequence_floors(ctx)
+    }
+
+    /// Seed/merge per-sender epoch floors into the registry (follower). See
+    /// [`Supervisor::validate_and_merge_epoch_floors`].
+    ///
+    /// # Errors
+    ///
+    /// Infallible in PR-4 (matches the provider twin's signature for the PR-6
+    /// retarget).
+    pub(in crate::context) fn validate_and_merge_epoch_floors(
+        &self,
+        ctx: &[u8; 32],
+        incoming: Vec<(String, u64)>,
+        max_advance: u64,
+        trusted_local: bool,
+    ) -> Result<(), FloorAdvanceError> {
+        self.supervisor
+            .validate_and_merge_epoch_floors(ctx, incoming, max_advance, trusted_local)
+    }
+
+    /// Seed/merge per-sender receive-sequence floors into the registry
+    /// (follower). See [`Supervisor::validate_and_merge_recv_sequence_floors`].
+    ///
+    /// # Errors
+    ///
+    /// Infallible in PR-4 (matches the provider twin's signature).
+    pub(in crate::context) fn validate_and_merge_recv_sequence_floors(
+        &self,
+        ctx: &[u8; 32],
+        incoming: Vec<(String, (u64, u64))>,
+        trusted_local: bool,
+    ) -> Result<(), FloorAdvanceError> {
+        self.supervisor
+            .validate_and_merge_recv_sequence_floors(ctx, incoming, trusted_local)
+    }
+
+    /// Create-seed the floor registry for `ctx` (insert-if-absent). See
+    /// [`Supervisor::seed_context_floors`].
+    pub(in crate::context) fn seed_context_floors(&self, ctx: &[u8; 32]) {
+        self.supervisor.seed_context_floors(ctx);
     }
 
     /// Start a cross-context saga. The ONLY way for an actor to affect

--- a/crates/scp-runtime/src/context/supervisor/mod.rs
+++ b/crates/scp-runtime/src/context/supervisor/mod.rs
@@ -113,6 +113,12 @@
 // vector at the compiler instead of via a source-text scanner.
 #![deny(non_local_definitions)]
 
+// ADR-049 PR-4: the supervisor-owned Class-M floor registry (epoch side).
+// Private to `supervisor` — the `ContextFloors` type and `FloorAdvanceError`
+// are reachable only through the `Supervisor` gate primitives + `SupervisorHandle`
+// accessors, keeping the registry an internal follower store (nothing outside
+// the supervisor module names it in PR-4).
+mod floors;
 pub mod handle;
 pub(in crate::context) mod identity_capability;
 pub mod key_package_actor;

--- a/crates/scp-runtime/src/context/supervisor/spawn_from_welcome_tests.rs
+++ b/crates/scp-runtime/src/context/supervisor/spawn_from_welcome_tests.rs
@@ -2960,6 +2960,19 @@ async fn discard_joined_context_fully_reverses_a_welcome_join() {
         "the join persisted an initial Class-S snapshot"
     );
 
+    // Populate the supervisor-owned Class-M floor registry with a real
+    // per-sender follower floor for this ctx (as the mirror-forward would on
+    // live traffic) so the teardown has non-empty state to prune (ADR-049
+    // PR-4). `max_advance = u64::MAX` keeps the single +1 advance well within
+    // the overshoot ceiling without importing the const.
+    j.sup
+        .check_and_advance_sender_epoch(&j.ctx_bytes, BOB_DID, 1, u64::MAX)
+        .expect("first sender-epoch advance is accepted");
+    assert!(
+        j.sup.floors.contains_key(&j.ctx_bytes),
+        "a follower floor entry exists for the joined context before teardown"
+    );
+
     // --- COMPLETE teardown (the FFI compensating path). ---
     let removed = j.sup.discard_joined_context(&j.ctx_id).await;
     assert!(
@@ -3001,6 +3014,17 @@ async fn discard_joined_context_fully_reverses_a_welcome_join() {
     assert!(
         rec.deletes.contains(&j.ctx_id),
         "the snapshot delete was issued to the persistence backend"
+    );
+
+    // 4. Supervisor-owned Class-M floor registry entry pruned (ADR-049 PR-4) —
+    //    mirrors the provider's per-context floor-map prune inside
+    //    `destroy_mls_group`. Without this the follower registry would leak a
+    //    `ContextFloors` entry (and its per-sender maps) for every torn-down
+    //    context. Safe on permanent teardown: a re-created deterministic id is a
+    //    NEW MLS group with fresh keys, so the discarded floors are moot.
+    assert!(
+        !j.sup.floors.contains_key(&j.ctx_bytes),
+        "the follower floor entry is pruned on permanent teardown — no leak"
     );
 }
 

--- a/crates/scp-runtime/src/context/supervisor/supervisor.rs
+++ b/crates/scp-runtime/src/context/supervisor/supervisor.rs
@@ -1238,6 +1238,19 @@ pub struct Supervisor {
     /// first time an actor for that context crashes. Lock-free reads via
     /// `DashMap` per ADR-049 §Decision 12.
     pub(in crate::context::supervisor) crash_windows: DashMap<String, CrashWindow>,
+    /// ADR-049 PR-4 — supervisor-owned Class-M **floor registry** (epoch side).
+    /// Keyed by the 32-byte context id. Each [`ContextFloors`] bundles the
+    /// per-sender epoch high-water and the receive-side `(epoch, sequence)`
+    /// anti-replay floor. In PR-4 this is a NON-AUTHORITATIVE FOLLOWER: the
+    /// `MlsCryptoProvider` remains the authoritative floor store and nothing
+    /// reads this map for enforcement/capture/merge (write-only until PR-6).
+    /// Lives on `Arc<Supervisor>` so it survives an actor task unwind — the
+    /// Class-M requirement the floors exist to satisfy. Lock-free entry-scoped
+    /// reads/writes via `DashMap` (ADR-049 Decision 12); an entry mutation does
+    /// NOT take [`Self::write_lock`] (that guards the multi-field ArcSwap write
+    /// path per Decision 2). Precedent: `crash_windows` above.
+    pub(in crate::context::supervisor) floors:
+        DashMap<[u8; 32], crate::context::supervisor::floors::ContextFloors>,
     /// Test-only completion signal for the KeyPackage-actor watchdog.
     ///
     /// A monotonically-incrementing counter bumped by [`Self::kp_actor_watchdog`]
@@ -1614,6 +1627,8 @@ impl Supervisor {
             key_package_stores: DashMap::new(),
             health_config,
             crash_windows: DashMap::new(),
+            // ADR-049 PR-4: supervisor-owned Class-M floor registry (follower).
+            floors: DashMap::new(),
             // Test-only KP-watchdog completion signal (see field docs). The
             // paired receiver is created on demand via `kp_watchdog_processed_tx.subscribe()`;
             // dropping the initial one here is fine — `watch::Sender::send_modify`
@@ -18149,6 +18164,16 @@ mod tests {
         // The PERSISTED snapshot captures the floor at epoch 5 (the coalesced
         // state at snapshot time).
         crypto.seed_sender_key_epoch_for_test(&ctx_id_bytes, sender_did, 5);
+        // ADR-049 PR-4: the supervisor floor registry is a FOLLOWER. Seed it in
+        // parallel to epoch 5 (as the mirror-forward seams would have) so we can
+        // assert after respawn that the follower tracks the provider.
+        sup.check_and_advance_sender_epoch(
+            &ctx_id_bytes,
+            sender_did,
+            5,
+            scp_protocol::crypto::sender_keys::MAX_EPOCH_ADVANCE,
+        )
+        .expect("seed follower registry to epoch 5");
 
         let state = crate::context::actor::state::PerContextState::new_for_test_encrypted(
             ctx_id_bytes,
@@ -18180,6 +18205,14 @@ mod tests {
         // survives the crash (it lives in the supervisor-owned crypto provider,
         // which a mailbox/handle despawn does not tear down).
         crypto.seed_sender_key_epoch_for_test(&ctx_id_bytes, sender_did, 12);
+        // Advance the follower registry in parallel to the live floor (12).
+        sup.check_and_advance_sender_epoch(
+            &ctx_id_bytes,
+            sender_did,
+            12,
+            scp_protocol::crypto::sender_keys::MAX_EPOCH_ADVANCE,
+        )
+        .expect("advance follower registry to epoch 12");
 
         // Crash before any re-persist of the advanced floor.
         induce_panic(&handle, "SECRET_SENTINEL_lagged").await;
@@ -18207,6 +18240,17 @@ mod tests {
         assert!(
             merged.iter().any(|(d, e)| d == sender_did && *e == 12),
             "merged floor must be the higher live value (12), got {merged:?}"
+        );
+
+        // ADR-049 PR-4: the FOLLOWER registry tracks the provider after respawn.
+        // The additive post-merge restore seed in
+        // `restore_crypto_state_with_floor_guard` mirrors the provider's
+        // post-merge floor (12) into the supervisor registry, so the follower
+        // reports 12 too — never the stale snapshot's 5.
+        let follower = sup.export_sender_key_epochs(&ctx_id_bytes);
+        assert!(
+            follower.iter().any(|(d, e)| d == sender_did && *e == 12),
+            "follower registry must track the provider's merged floor (12) after respawn, got {follower:?}"
         );
     }
 

--- a/crates/scp-runtime/src/context/supervisor/supervisor.rs
+++ b/crates/scp-runtime/src/context/supervisor/supervisor.rs
@@ -4829,6 +4829,14 @@ impl Supervisor {
         if let Some(persistence) = self.persistence_ref() {
             let _ = persistence.delete_context(context_id).await;
         }
+        // 4. Drop the supervisor-owned Class-M floor registry entry (ADR-049
+        //    PR-4) — the follower twin of the provider's per-context floor-map
+        //    prune inside `destroy_mls_group` (step 2). A discarded welcome-join
+        //    is permanently gone (its crypto group + durable snapshot were just
+        //    destroyed), so the floors are moot and pruning is sound; see
+        //    `Supervisor::remove_context_floors` for the full permanent-vs-
+        //    transient safety argument.
+        self.remove_context_floors(&context_id_bytes);
         removed
     }
 
@@ -15232,6 +15240,14 @@ mod tests {
         let mut cell = crate::context::actor::class_s::ClassSCell::new(state);
         let handle = cell.handle.clone();
 
+        // ADR-049 PR-4 floor-registry SAFETY gate (F-1): seed a real follower
+        // floor. An ABORTED expiry (params.ttl == None, A3) leaves the context
+        // LIVE (`Active`), so its floors MUST survive — pruning here would drop a
+        // live context's anti-replay floors. This guards the `state_transitioned()`
+        // gate on the prune.
+        sup.check_and_advance_sender_epoch(&ctx_id_bytes, "did:example:floor-sender", 1, u64::MAX)
+            .expect("first sender-epoch advance is accepted");
+
         let outcome =
             crate::context::ttl_close_helpers::handle_ttl_expiry(&mut cell, &deps, &handle, 0)
                 .await;
@@ -15239,6 +15255,11 @@ mod tests {
         assert!(
             !outcome.result.is_complete(),
             "an aborted expiry is NOT a completed expiry"
+        );
+        assert!(
+            sup.floors.contains_key(&ctx_id_bytes),
+            "an ABORTED expiry leaves the context Active, so its follower floors MUST \
+             survive — the prune is gated on a genuine terminal transition"
         );
         assert_eq!(
             cell.handle.state(),
@@ -15322,9 +15343,26 @@ mod tests {
         let mut cell = crate::context::actor::class_s::ClassSCell::new(state);
         let handle = cell.handle.clone();
 
+        // ADR-049 PR-4 floor-registry prune (F-1): seed a real follower floor for
+        // this ctx (Full scope, so finalize destroys NO crypto — this proves the
+        // prune is driven by the terminal close, not by key destruction), assert
+        // it is present, then confirm the explicit close prunes it.
+        sup.check_and_advance_sender_epoch(&ctx_id_bytes, "did:example:floor-sender", 1, u64::MAX)
+            .expect("first sender-epoch advance is accepted");
+        assert!(
+            sup.floors.contains_key(&ctx_id_bytes),
+            "a follower floor entry exists before the explicit close"
+        );
+
         crate::context::ttl_close_helpers::finalize_close(&mut cell, &deps, &handle)
             .await
             .expect("finalize_close on a Closing context succeeds");
+
+        assert!(
+            !sup.floors.contains_key(&ctx_id_bytes),
+            "the explicit close (Closed) prunes the follower floor entry — no leak on \
+             the dominant teardown path, even for Full scope where crypto is retained"
+        );
 
         let closed_ts = entries_handle
             .lock()
@@ -15428,6 +15466,10 @@ mod tests {
     /// the convergent deadline from `creation + ttl` (+ recorded extensions) on
     /// the retry, independent of the cleared field.
     #[tokio::test]
+    #[allow(
+        clippy::too_many_lines,
+        reason = "linear TTL-expiry retry fixture (setup + two-attempt drive + convergent-timestamp asserts + ADR-049 PR-4 floor-prune asserts); reads clearer unsplit"
+    )]
     async fn retry_stamps_convergent_leaf_timestamp() {
         const T0: u64 = 1_700_000_000;
         const TTL_SECS: u64 = 3_600;
@@ -15500,6 +15542,18 @@ mod tests {
         let mut cell = crate::context::actor::class_s::ClassSCell::new(state);
         let handle = cell.handle.clone();
 
+        // ADR-049 PR-4 floor-registry prune (F-1): seed a real follower floor and
+        // assert the TERMINAL TTL expiry drops it. The Phase-1 terminal transition
+        // (`state_transitioned()`) runs on the FIRST attempt even though the leaf
+        // append fails, so the prune lands on `out1` — and the RETRY (`out2`) is a
+        // harmless idempotent no-op (remove-on-absent).
+        sup.check_and_advance_sender_epoch(&ctx_id_bytes, "did:example:floor-sender", 1, u64::MAX)
+            .expect("first sender-epoch advance is accepted");
+        assert!(
+            sup.floors.contains_key(&ctx_id_bytes),
+            "a follower floor entry exists before the terminal TTL expiry"
+        );
+
         // First attempt: append FAILS ⇒ incomplete. Phase 1 clears the recorded
         // deadline.
         let out1 =
@@ -15509,6 +15563,11 @@ mod tests {
             !out1.result.is_complete(),
             "first attempt's append must fail (forcing a retry): {}",
             out1.result
+        );
+        assert!(
+            !sup.floors.contains_key(&ctx_id_bytes),
+            "the terminal TTL transition (Expired) prunes the follower floor entry — no \
+             leak on the TTL-expiry teardown path"
         );
         assert_eq!(
             cell.ttl.timer.deadline_unix_secs, None,

--- a/crates/scp-runtime/src/context/ttl_close_helpers.rs
+++ b/crates/scp-runtime/src/context/ttl_close_helpers.rs
@@ -172,6 +172,23 @@ pub async fn handle_ttl_expiry(
     let terminal_result =
         ttl::apply_ttl_terminal_transition(handle, deps.crypto.as_ref(), prior_completed);
 
+    // Prune the supervisor-owned Class-M floor registry entry (ADR-049 PR-4) on a
+    // GENUINE terminal expiry. Gated on `state_transitioned()` so an aborted /
+    // failed transition (A3 `None`-deadline abort already returned above; a wrong-
+    // state transition failure sets no step and destroys no keys) NEVER prunes a
+    // still-live context's floors. When the transition landed, the context is
+    // terminally `Expired` — restore skips non-`Active` snapshots and B8 refuses
+    // re-create, so it is permanently gone — and `apply_ttl_terminal_transition`
+    // just ran the provider's `destroy_mls_group` floor-map prune (Ephemeral /
+    // Summary scope), so this follower prune mirrors it. Pruned regardless of
+    // memory scope (a terminal context accepts no further inbound). Idempotent: a
+    // bounded expiry RETRY re-enters here and remove-on-absent is a no-op. See
+    // `Supervisor::remove_context_floors` for the permanent-vs-transient safety
+    // argument.
+    if terminal_result.state_transitioned() {
+        deps.supervisor.remove_context_floors(&context_id_bytes);
+    }
+
     // Fold the Class-C participation decay + convergent-deadline clear into the
     // SAME fail-closed snapshot (mirrors `close_context_with_key`). KEEP-
     // direction: a persist failure is surfaced but the FSM is NOT rolled back —
@@ -860,6 +877,20 @@ pub async fn finalize_close(
     // provider was attached; ContextPersistence is always present on
     // ActorDeps so we always issue the delete.
     let _ = deps.persistence.delete_context(&context_id).await;
+
+    // Prune the supervisor-owned Class-M floor registry entry (ADR-049 PR-4):
+    // an explicit close is a PERMANENT teardown — the FSM is terminally `Closed`
+    // (anti-resurrection refuses re-create of a terminal id) and the durable
+    // Class-S snapshot was just deleted — so the follower floors are moot and
+    // must be dropped, mirroring the provider's per-context floor-map prune
+    // inside `destroy_mls_group` (which `ttl::finalize_close` ran above for
+    // Ephemeral/Summary scope) and co-located with the snapshot delete. Pruned
+    // regardless of memory scope: a `Closed` context accepts no further inbound,
+    // so the floors serve no purpose even when Full-scope crypto is retained.
+    // See `Supervisor::remove_context_floors` for the permanent-vs-transient
+    // safety argument.
+    let ctx_id_bytes = context_id_to_bytes(&context_id);
+    deps.supervisor.remove_context_floors(&ctx_id_bytes);
 
     Ok(())
 }

--- a/crates/scp-runtime/src/crypto/mls/provider.rs
+++ b/crates/scp-runtime/src/crypto/mls/provider.rs
@@ -2124,6 +2124,13 @@ impl MlsCryptoProvider {
                         Box::new(scp_protocol::context::builder::OpenedEnvelope {
                             inner,
                             sender_did,
+                            // ADR-049 PR-4: surface the just-advanced receive
+                            // floor (recorded into `recv_sequence_tracker`
+                            // above) for the supervisor-registry follower
+                            // mirror-forward. Read-only export of a value
+                            // already computed + stored; does not alter
+                            // enforcement.
+                            receive_floor: (epoch, sequence),
                         }),
                     ))
                 }
@@ -2646,6 +2653,54 @@ impl MlsCryptoProvider {
             .value()
             .sender_key_store
             .epochs_for_context(&ctx_id_hex)
+    }
+
+    /// Returns the stored epoch high-water for a SINGLE `(context, sender_did)`
+    /// pair — `0` when absent, matching `SenderKeyStore::epoch`.
+    ///
+    /// ADR-049 PR-4: the remote-sender-epoch follower mirror-forward reads this
+    /// (O(1)) AFTER `process_incoming_sender_key` / `store_member_sender_key`
+    /// have advanced the authoritative floor via `set_checked`, to forward the
+    /// just-recorded value into the supervisor floor registry. It surfaces the
+    /// value already computed inside those paths without an O(senders)
+    /// `export_sender_key_epochs` clone (Decision-14 budget). `pub(crate)` — an
+    /// internal follower read with no FFI surface.
+    #[must_use]
+    pub(crate) fn sender_key_epoch(&self, context_id: &[u8; 32], sender_did: &str) -> u64 {
+        // ADR-049 commit 12c.9f: lock-free `DashMap::get`.
+        let Some(entry) = self.contexts.get(context_id) else {
+            return 0;
+        };
+        let ctx_id_hex = hex::encode(context_id);
+        entry
+            .value()
+            .sender_key_store
+            .epoch(&ctx_id_hex, sender_did)
+    }
+
+    /// Returns the LOCAL sender-key epoch scalar (`state.sender_key_epoch`) for
+    /// `context_id` — `0` when the context has no crypto state.
+    ///
+    /// ADR-049 PR-4: the local-sender-epoch follower mirror-forward reads this
+    /// (O(1)) AFTER `rotate_sender_key` increments the local epoch, and forwards
+    /// it (keyed by [`Self::local_did`]) into the supervisor floor registry.
+    /// `rotate_sender_key` stores the local key via `set_unchecked`, which does
+    /// NOT populate the store's per-sender epoch map — so the authoritative
+    /// local floor is this scalar, not `export_sender_key_epochs`. `pub(crate)`.
+    #[must_use]
+    pub(crate) fn local_sender_key_epoch(&self, context_id: &[u8; 32]) -> u64 {
+        // ADR-049 commit 12c.9f: lock-free `DashMap::get`.
+        self.contexts
+            .get(context_id)
+            .map_or(0, |entry| entry.value().sender_key_epoch)
+    }
+
+    /// Returns this provider's local member DID — the key under which the local
+    /// sender's epoch is recorded in the floor registry. `pub(crate)` — internal
+    /// follower read with no FFI surface.
+    #[must_use]
+    pub(crate) fn local_did(&self) -> &str {
+        &self.local_did
     }
 
     /// Test-only: seed a per-sender epoch high-water floor directly into the

--- a/crates/scp-testing/tests/integration/network_simulation.rs
+++ b/crates/scp-testing/tests/integration/network_simulation.rs
@@ -974,7 +974,13 @@ impl scp_core::context::builder::ContextCryptoProvider for DemoCrypto {
             })?;
         let sender_did = inner.sender_did.clone();
         Ok(scp_core::context::builder::OpenResult::Application(
-            Box::new(scp_core::context::builder::OpenedEnvelope { inner, sender_did }),
+            Box::new(scp_core::context::builder::OpenedEnvelope {
+                inner,
+                sender_did,
+                // ADR-049 PR-4: mock open() has no live recv tracker; the
+                // follower mirror-forward drop is non-fatal.
+                receive_floor: (0, 0),
+            }),
         ))
     }
 }

--- a/crates/scp-testing/tests/integration/outlet_economy_wiring.rs
+++ b/crates/scp-testing/tests/integration/outlet_economy_wiring.rs
@@ -132,7 +132,13 @@ impl ContextCryptoProvider for MockCrypto {
             .map_err(|e| ContextError::CryptoFailed(format!("mock open: {e}")))?;
         let sender_did = inner.sender_did.clone();
         Ok(scp_core::context::builder::OpenResult::Application(
-            Box::new(scp_core::context::builder::OpenedEnvelope { inner, sender_did }),
+            Box::new(scp_core::context::builder::OpenedEnvelope {
+                inner,
+                sender_did,
+                // ADR-049 PR-4: mock open() has no live recv tracker; the
+                // follower mirror-forward drop is non-fatal.
+                receive_floor: (0, 0),
+            }),
         ))
     }
 }

--- a/crates/scp-testing/tests/integration/persistence.rs
+++ b/crates/scp-testing/tests/integration/persistence.rs
@@ -874,7 +874,13 @@ mod mock_providers {
                     .map_err(|e| ContextError::CryptoFailed(format!("mock open: {e}")))?;
             let sender_did = inner.sender_did.clone();
             Ok(scp_core::context::builder::OpenResult::Application(
-                Box::new(scp_core::context::builder::OpenedEnvelope { inner, sender_did }),
+                Box::new(scp_core::context::builder::OpenedEnvelope {
+                    inner,
+                    sender_did,
+                    // ADR-049 PR-4: mock open() has no live recv tracker; the
+                    // follower mirror-forward drop is non-fatal.
+                    receive_floor: (0, 0),
+                }),
             ))
         }
     }


### PR DESCRIPTION
## Scope — ADR-049 PR-4: Supervisor-owned floor registry (epoch side), NON-AUTHORITATIVE FOLLOWER

Introduces `Supervisor.floors: DashMap<[u8;32], ContextFloors>` — the durable, supervisor-owned home for the per-sender **epoch** high-water and **receive-sequence** anti-replay floors (Class-M state that MUST outlive an actor-task unwind, ADR-049 end-state). This is the **forced prerequisite** of the PR-7 actor crypto-by-move: without a supervisor-owned home, `take_crypto_state` would move the Class-M floors onto `PerContextState`, demoting them to Class-S where they die on unwind and re-open the §23.17 Invariant-2 replay window. Ordering **PR-4 → PR-6 → PR-7** is the only sound one.

### The follower boundary (why this is safe)
PR-4 keeps **all** enforcement, capture, and merge reads on the **authoritative provider mirror** (`crypto/mls/provider.rs` `ContextCryptoState`). `Supervisor.floors` is **write-only** — seeded at create/restore, mirror-forwarded on each advance — and **nothing reads it for any security decision** until the PR-6 atomic read-authority switch. This is what makes the prior cryptographer BLOCKER's D1 (Inv-2 bypass) / D2 (rollback-window) split-home defects **inapplicable**: merge-home and enforcement-home both stay on the provider.

### Key pieces
- `ContextFloors { sender_epochs, recv_sequence }` (non-secret; no `Zeroize`).
- TOCTOU-safe `check_and_advance_{sender_epoch,recv_sequence}`: **one** `floors.entry().or_default()` guard spans read → reject-≤ → reject-overshoot → write (no get-then-insert). Security (never a key below the floor) is **structural** via the single-entry gate + fail-safe gate-then-insert ordering; the actor single-writer only preserves **liveness** (its violation is fail-safe, never fail-open).
- 6 `SupervisorHandle` accessors (`&[u8;32]`, `pub(in crate::context)`, no `ContextActorHandle` leak).
- recv-seq mirror-forward surfaces the `(epoch, sequence)` from `open()`'s `OpenedEnvelope` return (**O(1)**; no `deliver_incoming` perf regression) — consumed **only** by the follower.

### Deferred (explicit)
- **PR-6** (atomic unit): flip read-authority to the registry + delete the provider mirror + move enforcement. Cannot be split (else D1/D2 return). The `validate_and_merge_*` accessors keep provider signature parity for a churn-free PR-6 retarget.
- **PR-7+**: the key move (`take_crypto_state`).

## Verification (local)
`cargo fmt --check` ✓; exact-CI `cargo clippy --workspace --all-targets` all features `-D warnings` = 0; scp-runtime lib 1974/1974 (default + `testing`); scp-protocol 3509+; `pipeline_wiring` 89/89 (§23.17 ratchet unchanged); `check-handle-affinity.sh` ✓; `check-cross-layer.sh` PASS (no new public fns — registry API is `pub(in crate::context)`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
