### PR TITLE
refactor(protocol): ReceiveFloor{epoch,sequence} newtype — retire (u64,u64) transposition hazard (ADR-049 PR-6 prep A)

### DIFF
--- a/crates/scp-protocol/src/context/builder.rs
+++ b/crates/scp-protocol/src/context/builder.rs
@@ -11,6 +11,33 @@ use super::ContextError;
 use crate::envelope::inner::InnerEnvelope;
 
 // ---------------------------------------------------------------------------
+// ReceiveFloor — receive-side anti-replay high-water mark
+// ---------------------------------------------------------------------------
+
+/// The receive-side anti-replay floor for a single sender.
+///
+/// The `(sender_key_epoch, sequence)` high-water mark that
+/// `MlsCryptoProvider::open` (in `scp-runtime`) advanced the anti-replay tracker
+/// to (spec §23.17.3).
+///
+/// A named-field newtype rather than a bare `(u64, u64)` tuple so the two
+/// scalars can never be transposed at a call site — `epoch` is always the
+/// epoch-major component. `Ord`/`PartialOrd` are derived, and because `epoch`
+/// is declared BEFORE `sequence`, the derived comparison is LEXICOGRAPHIC and
+/// epoch-major — byte-for-byte the ordering the previous `(u64, u64)` tuple
+/// had, so the replay-detection compare (`next <= current`) is unchanged.
+///
+/// `Copy` (two `u64` scalars, no key material — see [`OpenedEnvelope`] and the
+/// supervisor floor registry, both of which move it by value).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub struct ReceiveFloor {
+    /// The sender-key epoch component — the MAJOR ordering key.
+    pub epoch: u64,
+    /// The intra-epoch sequence number — the MINOR ordering key.
+    pub sequence: u64,
+}
+
+// ---------------------------------------------------------------------------
 // OpenedEnvelope — result of successfully opening a received envelope
 // ---------------------------------------------------------------------------
 
@@ -25,9 +52,9 @@ pub struct OpenedEnvelope {
     pub inner: InnerEnvelope,
     /// The sender's DID extracted from MLS credentials.
     pub sender_did: String,
-    /// The receive-side `(sender_key_epoch, sequence)` this envelope advanced
-    /// the anti-replay tracker to inside `MlsCryptoProvider::open` (spec
-    /// §23.17.3).
+    /// The receive-side [`ReceiveFloor`] (`sender_key_epoch`, `sequence`) this
+    /// envelope advanced the anti-replay tracker to inside
+    /// `MlsCryptoProvider::open` (spec §23.17.3).
     ///
     /// ADR-049 PR-4: surfaced SOLELY so the supervisor floor-registry follower
     /// mirror-forward (`decrypt_and_dispatch`) can track the just-advanced
@@ -36,7 +63,7 @@ pub struct OpenedEnvelope {
     /// and stored; exposing it does NOT change `open()`'s enforcement or advance
     /// behavior, and NOTHING reads this field for enforcement — only the
     /// follower mirror-forward consumes it.
-    pub receive_floor: (u64, u64),
+    pub receive_floor: ReceiveFloor,
 }
 
 /// Discriminated result of `MlsCryptoProvider::open` (in `scp-runtime`).
@@ -189,6 +216,61 @@ mod mgmt_prefix_tests {
                 return Ok(());
             }
             prop_assert_eq!(try_strip_management_prefix(&bytes), None);
+        }
+    }
+}
+
+#[cfg(test)]
+mod receive_floor_tests {
+    use super::ReceiveFloor;
+
+    /// The derived `Ord` must be LEXICOGRAPHIC and epoch-major — identical to
+    /// the `(epoch, sequence)` tuple ordering the newtype replaced, so replay
+    /// detection (`next <= current`) is byte-for-byte unchanged.
+    #[test]
+    fn ordering_is_lexicographic_epoch_major() {
+        let a = ReceiveFloor {
+            epoch: 0,
+            sequence: 3,
+        };
+        let b = ReceiveFloor {
+            epoch: 0,
+            sequence: 4,
+        };
+        let c = ReceiveFloor {
+            epoch: 1,
+            sequence: 0,
+        };
+
+        // Same epoch: higher sequence is greater.
+        assert!(a < b);
+        // Higher epoch dominates even a much larger sequence: (1,0) > (0,99).
+        assert!(
+            c > ReceiveFloor {
+                epoch: 0,
+                sequence: 99,
+            }
+        );
+        // Cross-epoch: (0,4) < (1,0).
+        assert!(b < c);
+        // Equality is field-wise.
+        assert_eq!(
+            a,
+            ReceiveFloor {
+                epoch: 0,
+                sequence: 3,
+            }
+        );
+
+        // Matches the raw `(epoch, sequence)` tuple ordering for every pair.
+        for x in [a, b, c] {
+            for y in [a, b, c] {
+                assert_eq!(
+                    x.cmp(&y),
+                    (x.epoch, x.sequence).cmp(&(y.epoch, y.sequence)),
+                    "ReceiveFloor::cmp must equal the (epoch, sequence) tuple cmp"
+                );
+            }
         }
     }
 }

--- a/crates/scp-runtime/src/context/builder.rs
+++ b/crates/scp-runtime/src/context/builder.rs
@@ -22,7 +22,7 @@ use scp_protocol::context::{
 
 pub use scp_protocol::context::builder::{
     AddMemberOutput, AdvanceEpochOutput, ContextCreationError, MANAGEMENT_MSG_MAGIC,
-    MAX_MANAGEMENT_PAYLOAD_SIZE, OpenResult, OpenedEnvelope, RemoveMemberOutput,
+    MAX_MANAGEMENT_PAYLOAD_SIZE, OpenResult, OpenedEnvelope, ReceiveFloor, RemoveMemberOutput,
     try_strip_management_prefix,
 };
 

--- a/crates/scp-runtime/src/context/lifecycle_helpers.rs
+++ b/crates/scp-runtime/src/context/lifecycle_helpers.rs
@@ -75,7 +75,7 @@ use std::collections::{HashMap, HashSet, VecDeque};
 use std::sync::Arc;
 
 use scp_did::DID;
-use scp_protocol::context::builder::ContextCreationError;
+use scp_protocol::context::builder::{ContextCreationError, ReceiveFloor};
 use scp_protocol::context::governance::GovernanceModelConfig;
 use scp_protocol::context::governance::mls_integration::EpochCoordinator;
 use scp_protocol::context::membership::{ContextEvent, KeyPackage, MembershipState, ReceiveBuffer};
@@ -1824,7 +1824,18 @@ pub(in crate::context) fn restore_crypto_state_with_floor_guard(
             "floor-registry follower epoch seed failed on restore (non-fatal in PR-4; provider authoritative)"
         );
     }
-    let seeded_recv_floors = deps.crypto.export_recv_sequence_floors(ctx_id_bytes);
+    // The provider export still yields `(u64, u64)` tuples (its
+    // `recv_sequence_tracker` mirror is untouched until the atomic read-authority
+    // switch); adapt each to the supervisor registry's `ReceiveFloor` newtype at
+    // this seam with an explicit NAMED-field bind (never a tuple `.into()`, which
+    // would reintroduce the epoch/sequence transposition hazard the newtype
+    // retires). Same values, so the follower seed is byte-for-byte unchanged.
+    let seeded_recv_floors: Vec<(String, ReceiveFloor)> = deps
+        .crypto
+        .export_recv_sequence_floors(ctx_id_bytes)
+        .into_iter()
+        .map(|(did, (epoch, sequence))| (did, ReceiveFloor { epoch, sequence }))
+        .collect();
     if let Err(e) = deps.supervisor.validate_and_merge_recv_sequence_floors(
         ctx_id_bytes,
         seeded_recv_floors,

--- a/crates/scp-runtime/src/context/supervisor/floors.rs
+++ b/crates/scp-runtime/src/context/supervisor/floors.rs
@@ -23,6 +23,8 @@
 
 use std::collections::HashMap;
 
+use scp_protocol::context::builder::ReceiveFloor;
+
 use super::supervisor::Supervisor;
 
 /// Per-context Class-M floor bundle held by the supervisor registry.
@@ -50,10 +52,11 @@ pub(in crate::context::supervisor) struct ContextFloors {
     /// must preserve it (or split the two counters into separate maps) before the
     /// gate becomes read-authoritative.
     pub(in crate::context::supervisor) sender_epochs: HashMap<String, u64>,
-    /// `sender_did` → highest `(epoch, sequence)` accepted from that sender —
-    /// the intra-epoch anti-replay floor (spec §23.17.3). LEXICOGRAPHIC order.
-    /// Mirrors the provider's `recv_sequence_tracker`.
-    pub(in crate::context::supervisor) recv_sequence: HashMap<String, (u64, u64)>,
+    /// `sender_did` → highest [`ReceiveFloor`] (`epoch`, `sequence`) accepted
+    /// from that sender — the intra-epoch anti-replay floor (spec §23.17.3).
+    /// LEXICOGRAPHIC (epoch-major) order. Mirrors the provider's
+    /// `recv_sequence_tracker`.
+    pub(in crate::context::supervisor) recv_sequence: HashMap<String, ReceiveFloor>,
 }
 
 /// Rejection reason from a floor-advance gate.
@@ -93,9 +96,9 @@ pub enum FloorAdvanceError {
         /// The sender whose floor was consulted.
         did: String,
         /// The floor currently recorded.
-        current: (u64, u64),
-        /// The rejected proposed `(epoch, sequence)`.
-        proposed: (u64, u64),
+        current: ReceiveFloor,
+        /// The rejected proposed [`ReceiveFloor`] (`epoch`, `sequence`).
+        proposed: ReceiveFloor,
     },
     /// A receive-side epoch beyond the sender's epoch floor `+ max_advance`
     /// (the follower's analogue of the provider's H9 receive-side epoch ceiling
@@ -253,7 +256,7 @@ impl Supervisor {
         &self,
         ctx: &[u8; 32],
         did: &str,
-        next: (u64, u64),
+        next: ReceiveFloor,
         max_advance: u64,
     ) -> Result<(), FloorAdvanceError> {
         // THE single guard. Everything below runs under it — no second acquire.
@@ -276,11 +279,11 @@ impl Supervisor {
         // epoch floor from THIS SAME entry (absent read as 0).
         let epoch_floor = floors.sender_epochs.get(did).copied().unwrap_or(0);
         let ceiling = epoch_floor.saturating_add(max_advance);
-        if next.0 > ceiling {
+        if next.epoch > ceiling {
             return Err(FloorAdvanceError::RecvSequenceOvershoot {
                 did: did.to_owned(),
                 ceiling,
-                proposed: next.0,
+                proposed: next.epoch,
             });
         }
         // write UNDER the same guard.
@@ -329,7 +332,7 @@ impl Supervisor {
     pub(in crate::context) fn export_recv_sequence_floors(
         &self,
         ctx: &[u8; 32],
-    ) -> Vec<(String, (u64, u64))> {
+    ) -> Vec<(String, ReceiveFloor)> {
         self.floors.get(ctx).map_or_else(Vec::new, |entry| {
             entry
                 .value()
@@ -417,7 +420,7 @@ impl Supervisor {
     pub(in crate::context) fn validate_and_merge_recv_sequence_floors(
         &self,
         ctx: &[u8; 32],
-        incoming: Vec<(String, (u64, u64))>,
+        incoming: Vec<(String, ReceiveFloor)>,
         trusted_local: bool,
     ) -> Result<(), FloorAdvanceError> {
         // PR-4 follower: `trusted_local` is reserved for the PR-6 fail-closed
@@ -490,11 +493,16 @@ mod tests {
 
     use scp_protocol::crypto::sender_keys::MAX_EPOCH_ADVANCE;
 
-    use super::{FloorAdvanceError, Supervisor};
+    use super::{FloorAdvanceError, ReceiveFloor, Supervisor};
     use crate::context::supervisor::handle::SupervisorHandle;
 
     const CTX: [u8; 32] = [0xA5u8; 32];
     const DID: &str = "did:dht:z6MkFloorSenderFloorSenderFloorSenderAA";
+
+    /// Terse [`ReceiveFloor`] constructor for the recv-sequence tests.
+    const fn rf(epoch: u64, sequence: u64) -> ReceiveFloor {
+        ReceiveFloor { epoch, sequence }
+    }
 
     fn sup() -> Arc<Supervisor> {
         // The registry needs no providers, so the provider-free query shim is
@@ -568,39 +576,39 @@ mod tests {
         // First observation for an absent sender is accepted (matches open()'s
         // Some-guarded replay check).
         assert!(
-            s.check_and_advance_recv_sequence(&CTX, DID, (0, 3), MAX_EPOCH_ADVANCE)
+            s.check_and_advance_recv_sequence(&CTX, DID, rf(0, 3), MAX_EPOCH_ADVANCE)
                 .is_ok()
         );
         // Same (epoch, seq) is a replay — rejected.
         assert!(matches!(
-            s.check_and_advance_recv_sequence(&CTX, DID, (0, 3), MAX_EPOCH_ADVANCE),
+            s.check_and_advance_recv_sequence(&CTX, DID, rf(0, 3), MAX_EPOCH_ADVANCE),
             Err(FloorAdvanceError::RecvSequenceNotMonotonic { .. })
         ));
         // Lower sequence at the same epoch — rejected.
         assert!(matches!(
-            s.check_and_advance_recv_sequence(&CTX, DID, (0, 2), MAX_EPOCH_ADVANCE),
+            s.check_and_advance_recv_sequence(&CTX, DID, rf(0, 2), MAX_EPOCH_ADVANCE),
             Err(FloorAdvanceError::RecvSequenceNotMonotonic { .. })
         ));
         // Higher sequence at the same epoch — accepted.
         assert!(
-            s.check_and_advance_recv_sequence(&CTX, DID, (0, 4), MAX_EPOCH_ADVANCE)
+            s.check_and_advance_recv_sequence(&CTX, DID, rf(0, 4), MAX_EPOCH_ADVANCE)
                 .is_ok()
         );
         // Advance to a higher epoch — accepted (epoch 1 is within the ceiling
         // `sender_epoch_floor(0) + MAX_EPOCH_ADVANCE`).
         assert!(
-            s.check_and_advance_recv_sequence(&CTX, DID, (1, 0), MAX_EPOCH_ADVANCE)
+            s.check_and_advance_recv_sequence(&CTX, DID, rf(1, 0), MAX_EPOCH_ADVANCE)
                 .is_ok()
         );
         // Lower epoch, even with a much higher seq — rejected (lexicographic on
         // the `(epoch, seq)` pair: `(0, 99) < (1, 0)`).
         assert!(matches!(
-            s.check_and_advance_recv_sequence(&CTX, DID, (0, 99), MAX_EPOCH_ADVANCE),
+            s.check_and_advance_recv_sequence(&CTX, DID, rf(0, 99), MAX_EPOCH_ADVANCE),
             Err(FloorAdvanceError::RecvSequenceNotMonotonic { .. })
         ));
         assert_eq!(
             s.export_recv_sequence_floors(&CTX),
-            vec![(DID.to_owned(), (1, 0))]
+            vec![(DID.to_owned(), rf(1, 0))]
         );
     }
 
@@ -615,7 +623,7 @@ mod tests {
             s.check_and_advance_recv_sequence(
                 &CTX,
                 DID,
-                (5 + MAX_EPOCH_ADVANCE + 1, 0),
+                rf(5 + MAX_EPOCH_ADVANCE + 1, 0),
                 MAX_EPOCH_ADVANCE
             ),
             Err(FloorAdvanceError::RecvSequenceOvershoot {
@@ -629,7 +637,7 @@ mod tests {
             s.check_and_advance_recv_sequence(
                 &CTX,
                 DID,
-                (5 + MAX_EPOCH_ADVANCE, 0),
+                rf(5 + MAX_EPOCH_ADVANCE, 0),
                 MAX_EPOCH_ADVANCE
             )
             .is_ok()
@@ -675,13 +683,13 @@ mod tests {
         // recv merge twin — monotone max, lexicographic.
         s.validate_and_merge_recv_sequence_floors(
             &CTX,
-            vec![(DID.to_owned(), (2, 9)), (DID.to_owned(), (1, 0))],
+            vec![(DID.to_owned(), rf(2, 9)), (DID.to_owned(), rf(1, 0))],
             true,
         )
         .unwrap();
         assert_eq!(
             s.export_recv_sequence_floors(&CTX),
-            vec![(DID.to_owned(), (2, 9))]
+            vec![(DID.to_owned(), rf(2, 9))]
         );
         // empty merge is a no-op that does not error.
         assert!(
@@ -705,13 +713,13 @@ mod tests {
         // One gate → exactly one context entry created.
         assert_eq!(s.floors.len(), 1, "one entry() per gate (Decision-13)");
         // A recv gate on the same ctx reuses the SAME entry — no second insert.
-        s.check_and_advance_recv_sequence(&CTX, DID, (1, 1), MAX_EPOCH_ADVANCE)
+        s.check_and_advance_recv_sequence(&CTX, DID, rf(1, 1), MAX_EPOCH_ADVANCE)
             .unwrap();
         assert_eq!(s.floors.len(), 1, "recv gate reuses the same ctx entry");
         // Both floors live under that single entry.
         let entry = s.floors.get(&CTX).expect("ctx entry");
         assert_eq!(entry.sender_epochs.get(DID).copied(), Some(1));
-        assert_eq!(entry.recv_sequence.get(DID).copied(), Some((1, 1)));
+        assert_eq!(entry.recv_sequence.get(DID).copied(), Some(rf(1, 1)));
     }
 
     // -- Decision-14: gate work is O(1) — independent of sender count -----------
@@ -815,12 +823,12 @@ mod tests {
                 .is_ok()
         );
         assert!(
-            h.check_and_advance_recv_sequence(&CTX, DID, (3, 1), MAX_EPOCH_ADVANCE)
+            h.check_and_advance_recv_sequence(&CTX, DID, rf(3, 1), MAX_EPOCH_ADVANCE)
                 .is_ok()
         );
         h.validate_and_merge_epoch_floors(&CTX, vec![(DID.to_owned(), 8)], MAX_EPOCH_ADVANCE, true)
             .unwrap();
-        h.validate_and_merge_recv_sequence_floors(&CTX, vec![(DID.to_owned(), (8, 2))], true)
+        h.validate_and_merge_recv_sequence_floors(&CTX, vec![(DID.to_owned(), rf(8, 2))], true)
             .unwrap();
 
         // The handle reads must agree with the direct Supervisor reads.
@@ -835,7 +843,7 @@ mod tests {
         assert_eq!(h.export_sender_key_epochs(&CTX), vec![(DID.to_owned(), 8)]);
         assert_eq!(
             h.export_recv_sequence_floors(&CTX),
-            vec![(DID.to_owned(), (8, 2))]
+            vec![(DID.to_owned(), rf(8, 2))]
         );
     }
 }

--- a/crates/scp-runtime/src/context/supervisor/handle.rs
+++ b/crates/scp-runtime/src/context/supervisor/handle.rs
@@ -36,6 +36,7 @@ use std::sync::Arc;
 
 use scp_did::DID;
 use scp_protocol::context::ContextError;
+use scp_protocol::context::builder::ReceiveFloor;
 
 use crate::context::supervisor::floors::FloorAdvanceError;
 use crate::context::supervisor::identity_capability::OwnedIdentityDid;
@@ -138,7 +139,7 @@ impl SupervisorHandle {
         &self,
         ctx: &[u8; 32],
         did: &str,
-        next: (u64, u64),
+        next: ReceiveFloor,
         max_advance: u64,
     ) -> Result<(), FloorAdvanceError> {
         self.supervisor
@@ -175,7 +176,7 @@ impl SupervisorHandle {
     pub(in crate::context) fn export_recv_sequence_floors(
         &self,
         ctx: &[u8; 32],
-    ) -> Vec<(String, (u64, u64))> {
+    ) -> Vec<(String, ReceiveFloor)> {
         self.supervisor.export_recv_sequence_floors(ctx)
     }
 
@@ -206,7 +207,7 @@ impl SupervisorHandle {
     pub(in crate::context) fn validate_and_merge_recv_sequence_floors(
         &self,
         ctx: &[u8; 32],
-        incoming: Vec<(String, (u64, u64))>,
+        incoming: Vec<(String, ReceiveFloor)>,
         trusted_local: bool,
     ) -> Result<(), FloorAdvanceError> {
         self.supervisor

--- a/crates/scp-runtime/src/crypto/mls/provider.rs
+++ b/crates/scp-runtime/src/crypto/mls/provider.rs
@@ -2130,7 +2130,10 @@ impl MlsCryptoProvider {
                             // mirror-forward. Read-only export of a value
                             // already computed + stored; does not alter
                             // enforcement.
-                            receive_floor: (epoch, sequence),
+                            receive_floor: scp_protocol::context::builder::ReceiveFloor {
+                                epoch,
+                                sequence,
+                            },
                         }),
                     ))
                 }

--- a/crates/scp-testing/tests/integration/network_simulation.rs
+++ b/crates/scp-testing/tests/integration/network_simulation.rs
@@ -979,7 +979,10 @@ impl scp_core::context::builder::ContextCryptoProvider for DemoCrypto {
                 sender_did,
                 // ADR-049 PR-4: mock open() has no live recv tracker; the
                 // follower mirror-forward drop is non-fatal.
-                receive_floor: (0, 0),
+                receive_floor: scp_core::context::builder::ReceiveFloor {
+                    epoch: 0,
+                    sequence: 0,
+                },
             }),
         ))
     }

--- a/crates/scp-testing/tests/integration/outlet_economy_wiring.rs
+++ b/crates/scp-testing/tests/integration/outlet_economy_wiring.rs
@@ -137,7 +137,10 @@ impl ContextCryptoProvider for MockCrypto {
                 sender_did,
                 // ADR-049 PR-4: mock open() has no live recv tracker; the
                 // follower mirror-forward drop is non-fatal.
-                receive_floor: (0, 0),
+                receive_floor: scp_core::context::builder::ReceiveFloor {
+                    epoch: 0,
+                    sequence: 0,
+                },
             }),
         ))
     }

--- a/crates/scp-testing/tests/integration/persistence.rs
+++ b/crates/scp-testing/tests/integration/persistence.rs
@@ -879,7 +879,10 @@ mod mock_providers {
                     sender_did,
                     // ADR-049 PR-4: mock open() has no live recv tracker; the
                     // follower mirror-forward drop is non-fatal.
-                    receive_floor: (0, 0),
+                    receive_floor: scp_core::context::builder::ReceiveFloor {
+                        epoch: 0,
+                        sequence: 0,
+                    },
                 }),
             ))
         }


### PR DESCRIPTION
First behavior-inert prep step for the ADR-049 PR-6 read-authority switch (decomposed per plan review to shrink the atomic core). Introduces a `ReceiveFloor { epoch, sequence }` newtype replacing the anonymous `(u64,u64)` recv-floor tuple across every recv surface (OpenedEnvelope, the still-unread Supervisor floor registry, the restore-guard seam, FloorAdvanceError). Derived Ord is lexicographic epoch-major (unit-tested identical to the old tuple); NO `From<(u64,u64)>` (that would reintroduce the hazard); no serde (not persisted). ZERO behavior change — the registry stays production-unread; no provider field deleted, no enforcement touched.

Verified: clippy --workspace --all-targets all-features -D warnings=0; scp-runtime 2001; scp-protocol 3510+; **scp-client (browser) green**; **wasm32 check green**; cross-layer + handle-affinity pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)