### PR TITLE
feat(floors): thread export_crypto_state floors as pass-through params (ADR-049 PR-6 Prep D)

### DIFF
--- a/crates/scp-runtime/src/context/actor/handlers/lifecycle.rs
+++ b/crates/scp-runtime/src/context/actor/handlers/lifecycle.rs
@@ -36,6 +36,7 @@
 use std::time::Duration;
 
 use scp_protocol::context::ContextError;
+use scp_protocol::context::builder::ReceiveFloor;
 use tokio::sync::oneshot;
 
 use crate::context::ContextHandle;
@@ -514,7 +515,18 @@ fn handle_flush_snapshot_actor<'d>(
     // an empty crypto blob (AC3 bug 2 — same contract as
     // manager_methods::persist_context_snapshot).
     let ctx_id_bytes = context_id_to_bytes(&context_id);
-    match deps.crypto.export_crypto_state(&ctx_id_bytes) {
+    // ADR-049 PR-6: floors threaded as parameters, still provider-sourced from
+    // the `export_*` twins (byte-identical to the prior internal read). The
+    // atomic read-authority core swaps these to the supervisor registry.
+    match deps.crypto.export_crypto_state(
+        &ctx_id_bytes,
+        deps.crypto.export_sender_key_epochs(&ctx_id_bytes),
+        deps.crypto
+            .export_recv_sequence_floors(&ctx_id_bytes)
+            .into_iter()
+            .map(|(did, (epoch, sequence))| (did, ReceiveFloor { epoch, sequence }))
+            .collect(),
+    ) {
         Ok(crypto_state) => snapshot.mls_crypto_state = crypto_state,
         Err(e) => {
             snapshot.needs_reconnect = true;

--- a/crates/scp-runtime/src/context/broadcast_helpers.rs
+++ b/crates/scp-runtime/src/context/broadcast_helpers.rs
@@ -28,6 +28,7 @@ use scp_protocol::context::broadcast::{
     BlockResult, BroadcastAdmission, BroadcastContext, KeyRequestDecision, SubscriptionResult,
     UnsubscribeResult,
 };
+use scp_protocol::context::builder::ReceiveFloor;
 use scp_protocol::context::membership::ContextEvent;
 use scp_protocol::context::roles::Capability;
 use scp_protocol::crypto::sender_keys::BroadcastEnvelope;
@@ -877,7 +878,18 @@ fn persist_state_best_effort<'d, 'c>(
     let mut snapshot = build_snapshot_from_state(state);
 
     let ctx_id_bytes = context_id_to_bytes(context_id);
-    match deps.crypto.export_crypto_state(&ctx_id_bytes) {
+    // ADR-049 PR-6: floors threaded as parameters, still provider-sourced from
+    // the `export_*` twins (byte-identical to the prior internal read). The
+    // atomic read-authority core swaps these to the supervisor registry.
+    match deps.crypto.export_crypto_state(
+        &ctx_id_bytes,
+        deps.crypto.export_sender_key_epochs(&ctx_id_bytes),
+        deps.crypto
+            .export_recv_sequence_floors(&ctx_id_bytes)
+            .into_iter()
+            .map(|(did, (epoch, sequence))| (did, ReceiveFloor { epoch, sequence }))
+            .collect(),
+    ) {
         Ok(crypto_state) => snapshot.mls_crypto_state = crypto_state,
         Err(e) => {
             snapshot.needs_reconnect = true;

--- a/crates/scp-runtime/src/context/builder.rs
+++ b/crates/scp-runtime/src/context/builder.rs
@@ -1220,14 +1220,30 @@ mod tests {
         // returns the serialized state for a keyed context and an EMPTY vec for
         // an unkeyed one (no entry under that key).
         let under_digest = crypto
-            .export_crypto_state(&digest)
+            .export_crypto_state(
+                &digest,
+                crypto.export_sender_key_epochs(&digest),
+                crypto
+                    .export_recv_sequence_floors(&digest)
+                    .into_iter()
+                    .map(|(did, (epoch, sequence))| (did, ReceiveFloor { epoch, sequence }))
+                    .collect(),
+            )
             .expect("export under the decoded digest must not error");
         assert!(
             !under_digest.is_empty(),
             "crypto state MUST be keyed under the decoded digest"
         );
         let under_sha256 = crypto
-            .export_crypto_state(&sha256_of_id)
+            .export_crypto_state(
+                &sha256_of_id,
+                crypto.export_sender_key_epochs(&sha256_of_id),
+                crypto
+                    .export_recv_sequence_floors(&sha256_of_id)
+                    .into_iter()
+                    .map(|(did, (epoch, sequence))| (did, ReceiveFloor { epoch, sequence }))
+                    .collect(),
+            )
             .expect("export under SHA-256(id) must not error");
         assert!(
             under_sha256.is_empty(),

--- a/crates/scp-runtime/src/context/key_destruction.rs
+++ b/crates/scp-runtime/src/context/key_destruction.rs
@@ -270,6 +270,7 @@ impl<'a> CloseOrchestrator<'a> {
 #[allow(clippy::unwrap_used, clippy::expect_used, clippy::panic)]
 mod tests {
     use super::*;
+    use scp_protocol::context::builder::ReceiveFloor;
 
     const TEST_DID: &str = "did:dht:z6MkhaXgBZDvotDkL5257faiztiGiC2QtKLGpbnnEGta2doK";
 
@@ -449,7 +450,15 @@ mod tests {
         // The group MUST be present under the digest before destruction — proves
         // this is a real destroy, not a phantom no-op against an empty slot.
         let before = crypto
-            .export_crypto_state(&digest)
+            .export_crypto_state(
+                &digest,
+                crypto.export_sender_key_epochs(&digest),
+                crypto
+                    .export_recv_sequence_floors(&digest)
+                    .into_iter()
+                    .map(|(did, (epoch, sequence))| (did, ReceiveFloor { epoch, sequence }))
+                    .collect(),
+            )
             .expect("export under the decoded digest must not error");
         assert!(
             !before.is_empty(),
@@ -477,7 +486,15 @@ mod tests {
         // (a silent no-op) and the digest slot would still be populated — this
         // assertion FAILS in that case (the ADR-056 fail-open).
         let after_digest = crypto
-            .export_crypto_state(&digest)
+            .export_crypto_state(
+                &digest,
+                crypto.export_sender_key_epochs(&digest),
+                crypto
+                    .export_recv_sequence_floors(&digest)
+                    .into_iter()
+                    .map(|(did, (epoch, sequence))| (did, ReceiveFloor { epoch, sequence }))
+                    .collect(),
+            )
             .expect("export under the decoded digest must not error");
         assert!(
             after_digest.is_empty(),
@@ -489,7 +506,15 @@ mod tests {
         // Belt-and-suspenders: nothing was ever keyed under SHA-256(id), so that
         // slot is (and remains) empty regardless of the resolution path.
         let after_raw = crypto
-            .export_crypto_state(&raw_bytes)
+            .export_crypto_state(
+                &raw_bytes,
+                crypto.export_sender_key_epochs(&raw_bytes),
+                crypto
+                    .export_recv_sequence_floors(&raw_bytes)
+                    .into_iter()
+                    .map(|(did, (epoch, sequence))| (did, ReceiveFloor { epoch, sequence }))
+                    .collect(),
+            )
             .expect("export under SHA-256(id) must not error");
         assert!(
             after_raw.is_empty(),

--- a/crates/scp-runtime/src/context/messaging_helpers.rs
+++ b/crates/scp-runtime/src/context/messaging_helpers.rs
@@ -57,6 +57,7 @@ use subtle::ConstantTimeEq;
 use scp_clock::Clock;
 use scp_did::{DID, SigningKeyId};
 use scp_protocol::context::ContextError;
+use scp_protocol::context::builder::ReceiveFloor;
 use scp_protocol::context::governance::KeyResolver;
 use scp_protocol::context::membership::ContextEvent;
 use scp_protocol::context::roles::Capability;
@@ -2463,7 +2464,18 @@ pub fn build_snapshot_for_persist(
     let mut snapshot = build_snapshot_from_state(state);
     // ADR-056: canonical digest, not a re-hash of the hex id.
     let ctx_id_bytes = state::context_id_to_bytes(context_id);
-    match deps.crypto.export_crypto_state(&ctx_id_bytes) {
+    // ADR-049 PR-6: floors threaded as parameters, still provider-sourced from
+    // the `export_*` twins (byte-identical to the prior internal read). The
+    // atomic read-authority core swaps these to the supervisor registry.
+    match deps.crypto.export_crypto_state(
+        &ctx_id_bytes,
+        deps.crypto.export_sender_key_epochs(&ctx_id_bytes),
+        deps.crypto
+            .export_recv_sequence_floors(&ctx_id_bytes)
+            .into_iter()
+            .map(|(did, (epoch, sequence))| (did, ReceiveFloor { epoch, sequence }))
+            .collect(),
+    ) {
         Ok(crypto_state) => snapshot.mls_crypto_state = crypto_state,
         Err(e) => {
             snapshot.needs_reconnect = true;

--- a/crates/scp-runtime/src/context/supervisor/spawn_from_welcome_tests.rs
+++ b/crates/scp-runtime/src/context/supervisor/spawn_from_welcome_tests.rs
@@ -38,7 +38,7 @@ use ed25519_dalek::{Signer as _, SigningKey};
 use scp_did::{DID, SigningKeyId};
 use scp_platform::testing::{InMemoryKeyCustody, InMemoryStorage};
 use scp_platform::{KeyCustody, KeyHandle, KeyType};
-use scp_protocol::context::builder::OpenResult;
+use scp_protocol::context::builder::{OpenResult, ReceiveFloor};
 use scp_protocol::context::governance::KeyResolver;
 use scp_protocol::context::roles::{Capability, CapabilityCeiling};
 use scp_protocol::context::{
@@ -641,7 +641,15 @@ async fn spawn_from_welcome_yields_a_live_send_capable_actor() {
     // non-emptiness is the presence discriminator.
     assert!(
         !j.bob_crypto
-            .export_crypto_state(&j.ctx_bytes)
+            .export_crypto_state(
+                &j.ctx_bytes,
+                j.bob_crypto.export_sender_key_epochs(&j.ctx_bytes),
+                j.bob_crypto
+                    .export_recv_sequence_floors(&j.ctx_bytes)
+                    .into_iter()
+                    .map(|(did, (epoch, sequence))| (did, ReceiveFloor { epoch, sequence }))
+                    .collect(),
+            )
             .expect("export never errors")
             .is_empty(),
         "the joined MLS group is installed in the provider"
@@ -825,7 +833,15 @@ async fn persist_failure_leaves_no_half_keyed_actor() {
     // non-empty — see the happy-path test.)
     assert!(
         j.bob_crypto
-            .export_crypto_state(&j.ctx_bytes)
+            .export_crypto_state(
+                &j.ctx_bytes,
+                j.bob_crypto.export_sender_key_epochs(&j.ctx_bytes),
+                j.bob_crypto
+                    .export_recv_sequence_floors(&j.ctx_bytes)
+                    .into_iter()
+                    .map(|(did, (epoch, sequence))| (did, ReceiveFloor { epoch, sequence }))
+                    .collect(),
+            )
             .expect("export never errors")
             .is_empty(),
         "the just-installed group must be torn back out on a persist failure"
@@ -941,7 +957,15 @@ async fn second_spawn_reusing_a_consumed_reservation_is_rejected() {
     );
     assert!(
         !bob_crypto
-            .export_crypto_state(&ctx_bytes)
+            .export_crypto_state(
+                &ctx_bytes,
+                bob_crypto.export_sender_key_epochs(&ctx_bytes),
+                bob_crypto
+                    .export_recv_sequence_floors(&ctx_bytes)
+                    .into_iter()
+                    .map(|(did, (epoch, sequence))| (did, ReceiveFloor { epoch, sequence }))
+                    .collect(),
+            )
             .expect("export never errors")
             .is_empty(),
         "the first join's installed group is intact"
@@ -1034,7 +1058,15 @@ async fn missing_pseudonym_is_rejected_before_the_kp_consume() {
     );
     assert!(
         bob_crypto
-            .export_crypto_state(&ctx_bytes)
+            .export_crypto_state(
+                &ctx_bytes,
+                bob_crypto.export_sender_key_epochs(&ctx_bytes),
+                bob_crypto
+                    .export_recv_sequence_floors(&ctx_bytes)
+                    .into_iter()
+                    .map(|(did, (epoch, sequence))| (did, ReceiveFloor { epoch, sequence }))
+                    .collect(),
+            )
             .expect("export never errors")
             .is_empty(),
         "no group may be installed after a pseudonym rejection"
@@ -1106,7 +1138,15 @@ async fn colliding_broadcast_context_id_is_rejected_before_the_kp_consume() {
     );
     assert!(
         bob_crypto
-            .export_crypto_state(&collide_bytes)
+            .export_crypto_state(
+                &collide_bytes,
+                bob_crypto.export_sender_key_epochs(&collide_bytes),
+                bob_crypto
+                    .export_recv_sequence_floors(&collide_bytes)
+                    .into_iter()
+                    .map(|(did, (epoch, sequence))| (did, ReceiveFloor { epoch, sequence }))
+                    .collect(),
+            )
             .expect("export never errors")
             .is_empty(),
         "the broadcast context's ENCRYPTED crypto slot is vacant (split registry) \
@@ -1282,7 +1322,15 @@ async fn non_durable_crypto_export_fails_closed_without_standing_up_an_actor() {
     // has cleared, so this export reads normally → empty for the now-absent group.
     assert!(
         bob_crypto
-            .export_crypto_state(&ctx_bytes)
+            .export_crypto_state(
+                &ctx_bytes,
+                bob_crypto.export_sender_key_epochs(&ctx_bytes),
+                bob_crypto
+                    .export_recv_sequence_floors(&ctx_bytes)
+                    .into_iter()
+                    .map(|(did, (epoch, sequence))| (did, ReceiveFloor { epoch, sequence }))
+                    .collect(),
+            )
             .expect("export never errors once the one-shot seam has cleared")
             .is_empty(),
         "the installed group must be rolled back on a non-durable export"
@@ -1467,7 +1515,15 @@ async fn durable_snapshot_collision_is_rejected_without_clobbering_or_burning_kp
     );
     assert!(
         target_crypto
-            .export_crypto_state(&ctx_bytes)
+            .export_crypto_state(
+                &ctx_bytes,
+                target_crypto.export_sender_key_epochs(&ctx_bytes),
+                target_crypto
+                    .export_recv_sequence_floors(&ctx_bytes)
+                    .into_iter()
+                    .map(|(did, (epoch, sequence))| (did, ReceiveFloor { epoch, sequence }))
+                    .collect(),
+            )
             .expect("export never errors")
             .is_empty(),
         "no group may be installed after a durable-collision reject"
@@ -1597,7 +1653,15 @@ async fn slow_confirm_consume_times_out_rolls_back_and_releases_the_lock() {
     // `destroy_mls_group` / `delete_context` no-op.)
     assert!(
         bob_crypto
-            .export_crypto_state(&ctx_bytes)
+            .export_crypto_state(
+                &ctx_bytes,
+                bob_crypto.export_sender_key_epochs(&ctx_bytes),
+                bob_crypto
+                    .export_recv_sequence_floors(&ctx_bytes)
+                    .into_iter()
+                    .map(|(did, (epoch, sequence))| (did, ReceiveFloor { epoch, sequence }))
+                    .collect(),
+            )
             .expect("export never errors")
             .is_empty(),
         "no MLS group may be installed after a timed-out join"
@@ -1844,7 +1908,15 @@ async fn assert_binding_refused_no_side_effects(
     // context exports an EMPTY blob; an installed one is non-empty).
     assert!(
         j.bob_crypto
-            .export_crypto_state(&j.ctx_bytes)
+            .export_crypto_state(
+                &j.ctx_bytes,
+                j.bob_crypto.export_sender_key_epochs(&j.ctx_bytes),
+                j.bob_crypto
+                    .export_recv_sequence_floors(&j.ctx_bytes)
+                    .into_iter()
+                    .map(|(did, (epoch, sequence))| (did, ReceiveFloor { epoch, sequence }))
+                    .collect(),
+            )
             .expect("export never errors")
             .is_empty(),
         "no MLS group may be installed after a binding refusal"
@@ -1986,7 +2058,15 @@ async fn join_group_without_scp_context_extension_is_refused() {
     );
     assert!(
         j.bob_crypto
-            .export_crypto_state(&j.ctx_bytes)
+            .export_crypto_state(
+                &j.ctx_bytes,
+                j.bob_crypto.export_sender_key_epochs(&j.ctx_bytes),
+                j.bob_crypto
+                    .export_recv_sequence_floors(&j.ctx_bytes)
+                    .into_iter()
+                    .map(|(did, (epoch, sequence))| (did, ReceiveFloor { epoch, sequence }))
+                    .collect(),
+            )
             .expect("export never errors")
             .is_empty(),
         "no MLS group may be installed after a rule-1 refusal"
@@ -2065,7 +2145,15 @@ async fn non_creator_signed_bundle_is_rejected_before_kp_consume() {
     // Reject fired before any state build — nothing installed, no actor.
     assert!(
         bob_crypto
-            .export_crypto_state(&ctx_bytes)
+            .export_crypto_state(
+                &ctx_bytes,
+                bob_crypto.export_sender_key_epochs(&ctx_bytes),
+                bob_crypto
+                    .export_recv_sequence_floors(&ctx_bytes)
+                    .into_iter()
+                    .map(|(did, (epoch, sequence))| (did, ReceiveFloor { epoch, sequence }))
+                    .collect(),
+            )
             .expect("export never errors")
             .is_empty(),
         "no group may be installed after a signature refusal"
@@ -2140,7 +2228,15 @@ async fn tampered_ciphertext_fails_aead_open() {
     );
     assert!(
         bob_crypto
-            .export_crypto_state(&ctx_bytes)
+            .export_crypto_state(
+                &ctx_bytes,
+                bob_crypto.export_sender_key_epochs(&ctx_bytes),
+                bob_crypto
+                    .export_recv_sequence_floors(&ctx_bytes)
+                    .into_iter()
+                    .map(|(did, (epoch, sequence))| (did, ReceiveFloor { epoch, sequence }))
+                    .collect(),
+            )
             .expect("export never errors")
             .is_empty(),
         "no group may be installed after an open failure"
@@ -2197,7 +2293,15 @@ async fn tampered_bundle_signature_is_rejected() {
     );
     assert!(
         bob_crypto
-            .export_crypto_state(&ctx_bytes)
+            .export_crypto_state(
+                &ctx_bytes,
+                bob_crypto.export_sender_key_epochs(&ctx_bytes),
+                bob_crypto
+                    .export_recv_sequence_floors(&ctx_bytes)
+                    .into_iter()
+                    .map(|(did, (epoch, sequence))| (did, ReceiveFloor { epoch, sequence }))
+                    .collect(),
+            )
             .expect("export never errors")
             .is_empty(),
         "no group may be installed after a signature refusal"
@@ -2278,7 +2382,15 @@ async fn structurally_inconsistent_bundle_is_rejected() {
     );
     assert!(
         bob_crypto
-            .export_crypto_state(&ctx_bytes)
+            .export_crypto_state(
+                &ctx_bytes,
+                bob_crypto.export_sender_key_epochs(&ctx_bytes),
+                bob_crypto
+                    .export_recv_sequence_floors(&ctx_bytes)
+                    .into_iter()
+                    .map(|(did, (epoch, sequence))| (did, ReceiveFloor { epoch, sequence }))
+                    .collect(),
+            )
             .expect("export never errors")
             .is_empty(),
         "no group may be installed after a structural refusal"
@@ -2385,7 +2497,15 @@ async fn invite_member_round_trip_stands_up_a_bidirectional_joiner() {
     );
     assert!(
         !bob_crypto
-            .export_crypto_state(&ctx_bytes)
+            .export_crypto_state(
+                &ctx_bytes,
+                bob_crypto.export_sender_key_epochs(&ctx_bytes),
+                bob_crypto
+                    .export_recv_sequence_floors(&ctx_bytes)
+                    .into_iter()
+                    .map(|(did, (epoch, sequence))| (did, ReceiveFloor { epoch, sequence }))
+                    .collect(),
+            )
             .expect("export never errors")
             .is_empty(),
         "bob's joined MLS group is installed"
@@ -2905,7 +3025,15 @@ async fn spawn_from_welcome_rejects_creator_substitution_before_admin_install() 
     );
     assert!(
         bob_crypto
-            .export_crypto_state(&ctx_bytes)
+            .export_crypto_state(
+                &ctx_bytes,
+                bob_crypto.export_sender_key_epochs(&ctx_bytes),
+                bob_crypto
+                    .export_recv_sequence_floors(&ctx_bytes)
+                    .into_iter()
+                    .map(|(did, (epoch, sequence))| (did, ReceiveFloor { epoch, sequence }))
+                    .collect(),
+            )
             .expect("export never errors")
             .is_empty(),
         "no MLS group may be installed after a creator-binding rejection"
@@ -2947,7 +3075,15 @@ async fn discard_joined_context_fully_reverses_a_welcome_join() {
     );
     assert!(
         !j.bob_crypto
-            .export_crypto_state(&j.ctx_bytes)
+            .export_crypto_state(
+                &j.ctx_bytes,
+                j.bob_crypto.export_sender_key_epochs(&j.ctx_bytes),
+                j.bob_crypto
+                    .export_recv_sequence_floors(&j.ctx_bytes)
+                    .into_iter()
+                    .map(|(did, (epoch, sequence))| (did, ReceiveFloor { epoch, sequence }))
+                    .collect(),
+            )
             .expect("export never errors")
             .is_empty(),
         "the joined MLS group is resident in the crypto provider"
@@ -2995,7 +3131,15 @@ async fn discard_joined_context_fully_reverses_a_welcome_join() {
     //    resident (`export_crypto_state` returns EMPTY for an absent context).
     assert!(
         j.bob_crypto
-            .export_crypto_state(&j.ctx_bytes)
+            .export_crypto_state(
+                &j.ctx_bytes,
+                j.bob_crypto.export_sender_key_epochs(&j.ctx_bytes),
+                j.bob_crypto
+                    .export_recv_sequence_floors(&j.ctx_bytes)
+                    .into_iter()
+                    .map(|(did, (epoch, sequence))| (did, ReceiveFloor { epoch, sequence }))
+                    .collect(),
+            )
             .expect("export never errors")
             .is_empty(),
         "the resident MLS group is destroyed"

--- a/crates/scp-runtime/src/context/supervisor/supervisor.rs
+++ b/crates/scp-runtime/src/context/supervisor/supervisor.rs
@@ -38,6 +38,7 @@ use dashmap::DashMap;
 use scp_clock::Clock;
 use scp_did::DID;
 use scp_protocol::context::ContextError;
+use scp_protocol::context::builder::ReceiveFloor;
 use scp_protocol::context::governance::KeyResolver;
 use scp_protocol::context::membership::ContextEvent;
 
@@ -11568,8 +11569,22 @@ impl Supervisor {
                     //     `Err` — nothing has been persisted yet, so there is no durable
                     //     snapshot to delete (strictly cleaner than persist-then-delete, same
                     //     fail-closed guarantee).
+                    // ADR-049 PR-6: floors threaded as parameters, still
+                    // provider-sourced from the `export_*` twins (byte-identical
+                    // to the prior internal read). The atomic read-authority core
+                    // swaps these to the supervisor registry.
                     if !crate::context::messaging_helpers::welcome_snapshot_crypto_is_durable(
-                        &deps.crypto.export_crypto_state(&context_id_bytes),
+                        &deps.crypto.export_crypto_state(
+                            &context_id_bytes,
+                            deps.crypto.export_sender_key_epochs(&context_id_bytes),
+                            deps.crypto
+                                .export_recv_sequence_floors(&context_id_bytes)
+                                .into_iter()
+                                .map(|(did, (epoch, sequence))| {
+                                    (did, ReceiveFloor { epoch, sequence })
+                                })
+                                .collect(),
+                        ),
                     ) {
                         let _ = deps.crypto.destroy_mls_group(&context_id_bytes);
                         return Err(ContextError::PersistenceFailed(format!(
@@ -18277,7 +18292,17 @@ mod tests {
         let mut snap = crate::context::manager_methods::snapshot_context(&state);
         // Capture the live crypto state (floor=5) into the persisted snapshot,
         // exactly as `persist_state_best_effort` does.
-        snap.mls_crypto_state = crypto.export_crypto_state(&ctx_id_bytes).unwrap();
+        snap.mls_crypto_state = crypto
+            .export_crypto_state(
+                &ctx_id_bytes,
+                crypto.export_sender_key_epochs(&ctx_id_bytes),
+                crypto
+                    .export_recv_sequence_floors(&ctx_id_bytes)
+                    .into_iter()
+                    .map(|(did, (epoch, sequence))| (did, ReceiveFloor { epoch, sequence }))
+                    .collect(),
+            )
+            .unwrap();
         assert!(
             !snap.mls_crypto_state.is_empty(),
             "snapshot must carry crypto state so the floor guard runs on respawn"

--- a/crates/scp-runtime/src/context/trust_recovery_helpers.rs
+++ b/crates/scp-runtime/src/context/trust_recovery_helpers.rs
@@ -48,6 +48,7 @@
 
 use scp_did::DID;
 use scp_protocol::context::ContextError;
+use scp_protocol::context::builder::ReceiveFloor;
 use scp_protocol::context::governance::{
     CheckpointAttestationStatus, ContextCheckpoint, CosignedCheckpoint,
 };
@@ -490,7 +491,18 @@ fn persist_state_best_effort<'d, 'c>(
     // AC3 bug 2: on export failure, mark the snapshot
     // `needs_reconnect = true` and persist an empty crypto blob.
     let ctx_id_bytes = context_id_to_bytes(context_id);
-    match deps.crypto.export_crypto_state(&ctx_id_bytes) {
+    // ADR-049 PR-6: floors threaded as parameters, still provider-sourced from
+    // the `export_*` twins (byte-identical to the prior internal read). The
+    // atomic read-authority core swaps these to the supervisor registry.
+    match deps.crypto.export_crypto_state(
+        &ctx_id_bytes,
+        deps.crypto.export_sender_key_epochs(&ctx_id_bytes),
+        deps.crypto
+            .export_recv_sequence_floors(&ctx_id_bytes)
+            .into_iter()
+            .map(|(did, (epoch, sequence))| (did, ReceiveFloor { epoch, sequence }))
+            .collect(),
+    ) {
         Ok(crypto_state) => snapshot.mls_crypto_state = crypto_state,
         Err(e) => {
             snapshot.needs_reconnect = true;

--- a/crates/scp-runtime/src/context/ttl.rs
+++ b/crates/scp-runtime/src/context/ttl.rs
@@ -1122,6 +1122,7 @@ pub const fn expiry_notification() -> ContextEvent {
 mod tests {
     use super::*;
     use scp_clock::TestClock;
+    use scp_protocol::context::builder::ReceiveFloor;
     use scp_protocol::context::params::ContextParams;
     use scp_protocol::context::roles::{Capability, CapabilityCeiling, ContextRoleState};
     use std::time::Duration;
@@ -1631,7 +1632,15 @@ mod tests {
         // The group MUST be present under the digest before expiry — proves this
         // is a real destroy, not a phantom no-op against an empty slot.
         let before = crypto
-            .export_crypto_state(&digest)
+            .export_crypto_state(
+                &digest,
+                crypto.export_sender_key_epochs(&digest),
+                crypto
+                    .export_recv_sequence_floors(&digest)
+                    .into_iter()
+                    .map(|(did, (epoch, sequence))| (did, ReceiveFloor { epoch, sequence }))
+                    .collect(),
+            )
             .expect("export under the decoded digest must not error");
         assert!(
             !before.is_empty(),
@@ -1674,7 +1683,15 @@ mod tests {
         // would have addressed an unkeyed slot (a silent no-op) and the digest
         // slot would still be populated — this assertion FAILS in that case.
         let after_digest = crypto
-            .export_crypto_state(&digest)
+            .export_crypto_state(
+                &digest,
+                crypto.export_sender_key_epochs(&digest),
+                crypto
+                    .export_recv_sequence_floors(&digest)
+                    .into_iter()
+                    .map(|(did, (epoch, sequence))| (did, ReceiveFloor { epoch, sequence }))
+                    .collect(),
+            )
             .expect("export under the decoded digest must not error");
         assert!(
             after_digest.is_empty(),

--- a/crates/scp-runtime/src/context/ttl_close_helpers.rs
+++ b/crates/scp-runtime/src/context/ttl_close_helpers.rs
@@ -36,6 +36,7 @@
 
 use scp_did::DID;
 use scp_protocol::context::ContextError;
+use scp_protocol::context::builder::ReceiveFloor;
 use scp_protocol::context::membership::ContextEvent;
 
 use crate::context::ContextHandle;
@@ -938,7 +939,18 @@ fn persist_state_best_effort<'d, 'c>(
     // persist an empty crypto blob so a later restore fires the §23.11
     // reconnection pipeline.
     let ctx_id_bytes = context_id_to_bytes(context_id);
-    match deps.crypto.export_crypto_state(&ctx_id_bytes) {
+    // ADR-049 PR-6: floors threaded as parameters, still provider-sourced from
+    // the `export_*` twins (byte-identical to the prior internal read). The
+    // atomic read-authority core swaps these to the supervisor registry.
+    match deps.crypto.export_crypto_state(
+        &ctx_id_bytes,
+        deps.crypto.export_sender_key_epochs(&ctx_id_bytes),
+        deps.crypto
+            .export_recv_sequence_floors(&ctx_id_bytes)
+            .into_iter()
+            .map(|(did, (epoch, sequence))| (did, ReceiveFloor { epoch, sequence }))
+            .collect(),
+    ) {
         Ok(crypto_state) => snapshot.mls_crypto_state = crypto_state,
         Err(e) => {
             snapshot.needs_reconnect = true;

--- a/crates/scp-runtime/src/crypto/mls/provider.rs
+++ b/crates/scp-runtime/src/crypto/mls/provider.rs
@@ -48,6 +48,7 @@ use scp_mls::group::{self, SCP_CIPHERSUITE, ScpMlsGroup};
 use scp_mls::validate_key_package_lifetime;
 use scp_protocol::context::ContextError;
 use scp_protocol::context::builder::ContextCreationError;
+use scp_protocol::context::builder::ReceiveFloor;
 use scp_protocol::crypto::sender_keys::{
     MAX_EPOCH_ADVANCE, NonceDedup, SenderKey, SenderKeyDistributionMessage, SenderKeyResponse,
     SenderKeyStore, generate_sender_key, generate_wrapping_keypair,
@@ -2249,15 +2250,43 @@ impl MlsCryptoProvider {
     /// wrapping public keys.
     ///
     /// Returns an empty `Vec` if no crypto state exists for the given context
-    /// (e.g., mock providers or broadcast-only contexts).
+    /// (a context that was never keyed, or whose state has been destroyed).
     ///
-    /// The default implementation returns an empty `Vec` (no state to persist).
-    /// Production providers that manage MLS groups MUST override this.
+    /// The two floor collections — `sender_key_epochs` (per-sender epoch
+    /// high-water marks) and `recv_sequence_floors` (per-sender intra-epoch
+    /// `(epoch, sequence)` anti-replay floors) — are supplied by the caller
+    /// rather than read from this provider's stores. Callers source them from
+    /// the provider's own `export_sender_key_epochs` / `export_recv_sequence_floors`
+    /// twins, so the persisted values are byte-identical to the previous
+    /// internally-sourced ones. Threading them as parameters freezes this
+    /// signature so the later read-authority switch (ADR-049 PR-6) is a pure
+    /// source swap at the call sites, with no further ripple here.
+    ///
+    /// **Caller contract.** `sender_key_epochs` and `recv_sequence_floors` MUST
+    /// be sourced for the SAME `context_id` passed to this call. Nothing binds
+    /// them structurally — supplying another context's floors would silently
+    /// persist the wrong floors into this context's snapshot.
+    ///
+    /// **Guard-span invariant.** Sourcing the floors in the caller splits what
+    /// was a single read-guard span (floors + the rest of the snapshot, all read
+    /// under one `DashMap` shard guard here) into two reads: the caller's floor
+    /// read and this method's internal read of everything else. Byte-identity
+    /// across that split holds under the ADR-049 single-writer-actor invariant —
+    /// the persist paths run synchronously on the owning actor task, the sole
+    /// writer of this context's crypto state, so no concurrent writer mutates the
+    /// floors between the caller's read and this export. The atomic read-authority
+    /// core (PR-6) inherits this exact two-read structure; it is not a
+    /// pass-through-specific regression.
     ///
     /// # Errors
     ///
     /// Returns [`ContextError::CryptoFailed`] if serialization fails.
-    pub fn export_crypto_state(&self, context_id: &[u8; 32]) -> Result<Vec<u8>, ContextError> {
+    pub fn export_crypto_state(
+        &self,
+        context_id: &[u8; 32],
+        sender_key_epochs: Vec<(String, u64)>,
+        recv_sequence_floors: Vec<(String, ReceiveFloor)>,
+    ) -> Result<Vec<u8>, ContextError> {
         // One-shot test seam (see `force_export_failure`): induce an export
         // failure so the spawn-from-Welcome crypto-durability fail-closed branch
         // can be driven end-to-end. `swap(false)` fires exactly once, then the
@@ -2330,9 +2359,10 @@ impl MlsCryptoProvider {
         // that regresses below the persisted floor). Includes entries
         // for senders whose key has been removed but whose floor is
         // still retained — `remove` intentionally preserves the epoch
-        // as a high-water mark.
-        let sender_key_epochs: Vec<(String, u64)> =
-            state.sender_key_store.epochs_for_context(&ctx_id_hex);
+        // as a high-water mark. The values arrive via the `sender_key_epochs`
+        // parameter (caller-sourced from `export_sender_key_epochs`, which reads
+        // this same store) rather than being read here — see the guard-span
+        // invariant on this method.
 
         // Read the provider-level wrapping keypair for persistence.
         // ADR-049 commit 12c.9f: load through `ArcSwap` and copy the
@@ -2355,10 +2385,18 @@ impl MlsCryptoProvider {
             // Move signer bytes out of the Zeroizing wrapper and into the
             // snapshot. The wrapper is left holding an empty Vec (which it
             // will zeroize on drop — a no-op for an empty vec).
-            recv_sequence_tracker: state
-                .recv_sequence_tracker
-                .iter()
-                .map(|(did, (epoch, seq))| (did.clone(), *epoch, *seq))
+            //
+            // The receive-side floors arrive via the `recv_sequence_floors`
+            // parameter (caller-sourced from `export_recv_sequence_floors`, which
+            // iterates this same `recv_sequence_tracker`) rather than being read
+            // here — see the guard-span invariant on this method. The
+            // `ReceiveFloor` newtype is unpacked into the snapshot's persisted
+            // `(did, epoch, sequence)` triples with an explicit named-field bind
+            // (never a tuple `.into()`, which would reintroduce the
+            // epoch/sequence transposition hazard).
+            recv_sequence_tracker: recv_sequence_floors
+                .into_iter()
+                .map(|(did, rf)| (did, rf.epoch, rf.sequence))
                 .collect(),
             signer_bytes: std::mem::take(&mut signer_bytes),
             group_id,
@@ -3952,7 +3990,17 @@ mod tests {
     fn export_crypto_state_returns_empty_for_unknown_context() {
         let provider = make_provider();
         let unknown_ctx = [0xFFu8; 32];
-        let exported = provider.export_crypto_state(&unknown_ctx).unwrap();
+        let exported = provider
+            .export_crypto_state(
+                &unknown_ctx,
+                provider.export_sender_key_epochs(&unknown_ctx),
+                provider
+                    .export_recv_sequence_floors(&unknown_ctx)
+                    .into_iter()
+                    .map(|(did, (epoch, sequence))| (did, ReceiveFloor { epoch, sequence }))
+                    .collect(),
+            )
+            .unwrap();
         assert!(
             exported.is_empty(),
             "should return empty Vec for unknown context"
@@ -4019,7 +4067,17 @@ mod tests {
         };
 
         // Export crypto state.
-        let exported = provider.export_crypto_state(&ctx_id).unwrap();
+        let exported = provider
+            .export_crypto_state(
+                &ctx_id,
+                provider.export_sender_key_epochs(&ctx_id),
+                provider
+                    .export_recv_sequence_floors(&ctx_id)
+                    .into_iter()
+                    .map(|(did, (epoch, sequence))| (did, ReceiveFloor { epoch, sequence }))
+                    .collect(),
+            )
+            .unwrap();
         assert!(!exported.is_empty(), "exported state should be non-empty");
 
         // Create a fresh provider and restore the state.
@@ -4087,6 +4145,104 @@ mod tests {
         }
     }
 
+    /// Prep-D pass-through pin (ADR-049 PR-6): the floors that
+    /// `export_crypto_state` now takes as parameters must land in the exported
+    /// snapshot exactly as the provider's own `export_sender_key_epochs` /
+    /// `export_recv_sequence_floors` twins report them — the byte-preserving
+    /// no-op that freezes the signature ahead of the atomic read-authority swap.
+    ///
+    /// Whole-blob byte equality across an export → restore → export cycle is NOT
+    /// a sound assertion: `mls_storage_entries` and `member_wrapping_keys`
+    /// serialize from `HashMap` iteration, whose order is nondeterministic, so
+    /// the blob's byte layout legitimately varies run to run (the existing
+    /// `export_restore_crypto_state_roundtrip` test asserts field/functional
+    /// equality, not bytes, for the same reason). This test instead pins the one
+    /// property Prep D actually changes — that the per-sender epoch floors and
+    /// the intra-epoch `(epoch, sequence)` floors are threaded from the twins
+    /// into the snapshot with no loss and no epoch/sequence transposition — by
+    /// deserializing the blob and comparing those fields, as order-insensitive
+    /// sets, against the twin outputs.
+    #[test]
+    fn export_crypto_state_floor_params_land_in_snapshot_verbatim() {
+        let provider = make_provider();
+        let ctx_id = make_context_id();
+        provider.create_mls_group(&ctx_id).unwrap();
+        provider.generate_sender_key(&ctx_id).unwrap();
+
+        let bob = "did:dht:z6MkBobBobBobBobBobBobBobBobBobBobBobBobBo";
+        let carol = "did:dht:z6MkCarolCarolCarolCarolCarolCarolCarolCa";
+
+        // Seed a per-sender epoch high-water floor (sender-key side) and two
+        // distinct intra-epoch recv floors so both twin outputs are non-empty
+        // and the set comparison actually exercises data.
+        {
+            let ctx_id_hex = hex::encode(ctx_id);
+            let mut entry = provider.contexts.get_mut(&ctx_id).unwrap();
+            let state = entry.value_mut();
+            state
+                .sender_key_store
+                .set_unchecked(&ctx_id_hex, bob, generate_sender_key());
+            state
+                .sender_key_store
+                .restore_epoch_high_water(&ctx_id_hex, bob, 7);
+            state.recv_sequence_tracker.insert(bob.to_owned(), (7, 3));
+            state.recv_sequence_tracker.insert(carol.to_owned(), (2, 9));
+        }
+
+        // Export with the exact production provider-sourced floor params.
+        let exported = provider
+            .export_crypto_state(
+                &ctx_id,
+                provider.export_sender_key_epochs(&ctx_id),
+                provider
+                    .export_recv_sequence_floors(&ctx_id)
+                    .into_iter()
+                    .map(|(did, (epoch, sequence))| (did, ReceiveFloor { epoch, sequence }))
+                    .collect(),
+            )
+            .unwrap();
+        assert!(!exported.is_empty(), "keyed context must export non-empty");
+
+        let snapshot: MlsCryptoSnapshot = rmp_serde::from_slice(&exported).unwrap();
+
+        // Sender-key epoch floors: blob field == twin report (as a set).
+        let snap_epochs: std::collections::BTreeSet<(String, u64)> =
+            snapshot.sender_key_epochs.iter().cloned().collect();
+        let twin_epochs: std::collections::BTreeSet<(String, u64)> = provider
+            .export_sender_key_epochs(&ctx_id)
+            .into_iter()
+            .collect();
+        assert_eq!(
+            snap_epochs, twin_epochs,
+            "sender-key epoch floors in the blob must equal the twin's report"
+        );
+        assert!(
+            twin_epochs.contains(&(bob.to_owned(), 7)),
+            "the seeded epoch floor must be present"
+        );
+
+        // Recv (epoch, sequence) floors: blob field == twin report (as a set),
+        // with epoch and sequence in the right positions (no transposition).
+        let snap_recv: std::collections::BTreeSet<(String, u64, u64)> =
+            snapshot.recv_sequence_tracker.iter().cloned().collect();
+        let twin_recv: std::collections::BTreeSet<(String, u64, u64)> = provider
+            .export_recv_sequence_floors(&ctx_id)
+            .into_iter()
+            .map(|(did, (epoch, sequence))| (did, epoch, sequence))
+            .collect();
+        assert_eq!(
+            snap_recv, twin_recv,
+            "recv (epoch, sequence) floors in the blob must equal the twin's \
+             report with no epoch/sequence transposition"
+        );
+        assert!(
+            snap_recv.contains(&(bob.to_owned(), 7, 3))
+                && snap_recv.contains(&(carol.to_owned(), 2, 9)),
+            "both seeded recv floors must round-trip with epoch and sequence \
+             in the correct positions"
+        );
+    }
+
     #[test]
     fn restore_preserves_sender_key_epoch_high_water_mark() {
         // Regression for #1608 rollback-protection across restart.
@@ -4129,7 +4285,17 @@ mod tests {
         }
 
         // Step 2: export snapshot.
-        let exported = provider.export_crypto_state(&ctx_id).unwrap();
+        let exported = provider
+            .export_crypto_state(
+                &ctx_id,
+                provider.export_sender_key_epochs(&ctx_id),
+                provider
+                    .export_recv_sequence_floors(&ctx_id)
+                    .into_iter()
+                    .map(|(did, (epoch, sequence))| (did, ReceiveFloor { epoch, sequence }))
+                    .collect(),
+            )
+            .unwrap();
         assert!(!exported.is_empty());
 
         // Step 3: simulate restart — fresh provider, restore state.
@@ -4240,7 +4406,17 @@ mod tests {
         }
 
         // Snapshot + restart.
-        let exported = provider.export_crypto_state(&ctx_id).unwrap();
+        let exported = provider
+            .export_crypto_state(
+                &ctx_id,
+                provider.export_sender_key_epochs(&ctx_id),
+                provider
+                    .export_recv_sequence_floors(&ctx_id)
+                    .into_iter()
+                    .map(|(did, (epoch, sequence))| (did, ReceiveFloor { epoch, sequence }))
+                    .collect(),
+            )
+            .unwrap();
         let provider2 = MlsCryptoProvider::new(TEST_DID.to_string(), Arc::new(SystemClock));
         provider2.restore_crypto_state(&ctx_id, &exported).unwrap();
 
@@ -4870,7 +5046,17 @@ mod tests {
         }
 
         // Export, then hand-edit the msgpack to drop the epoch map.
-        let exported = provider.export_crypto_state(&ctx_id).unwrap();
+        let exported = provider
+            .export_crypto_state(
+                &ctx_id,
+                provider.export_sender_key_epochs(&ctx_id),
+                provider
+                    .export_recv_sequence_floors(&ctx_id)
+                    .into_iter()
+                    .map(|(did, (epoch, sequence))| (did, ReceiveFloor { epoch, sequence }))
+                    .collect(),
+            )
+            .unwrap();
         let mut snapshot: MlsCryptoSnapshot = rmp_serde::from_slice(&exported).unwrap();
         snapshot.sender_key_epochs.clear();
         let legacy_bytes = rmp_serde::to_vec_named(&snapshot).unwrap();
@@ -4955,7 +5141,17 @@ mod tests {
 
         // Export, then strip the per-sender epoch map to simulate a
         // legacy snapshot.
-        let exported = provider.export_crypto_state(&ctx_id).unwrap();
+        let exported = provider
+            .export_crypto_state(
+                &ctx_id,
+                provider.export_sender_key_epochs(&ctx_id),
+                provider
+                    .export_recv_sequence_floors(&ctx_id)
+                    .into_iter()
+                    .map(|(did, (epoch, sequence))| (did, ReceiveFloor { epoch, sequence }))
+                    .collect(),
+            )
+            .unwrap();
         let mut snapshot: MlsCryptoSnapshot = rmp_serde::from_slice(&exported).unwrap();
         snapshot.sender_key_epochs.clear();
         let legacy_bytes = rmp_serde::to_vec_named(&snapshot).unwrap();
@@ -5014,7 +5210,17 @@ mod tests {
                 .set_unchecked(&ctx_id_hex, bob_did, generate_sender_key());
         }
 
-        let exported = provider.export_crypto_state(&ctx_id).unwrap();
+        let exported = provider
+            .export_crypto_state(
+                &ctx_id,
+                provider.export_sender_key_epochs(&ctx_id),
+                provider
+                    .export_recv_sequence_floors(&ctx_id)
+                    .into_iter()
+                    .map(|(did, (epoch, sequence))| (did, ReceiveFloor { epoch, sequence }))
+                    .collect(),
+            )
+            .unwrap();
         let mut snapshot: MlsCryptoSnapshot = rmp_serde::from_slice(&exported).unwrap();
         snapshot.sender_key_epochs.clear();
         let legacy_bytes = rmp_serde::to_vec_named(&snapshot).unwrap();
@@ -5042,7 +5248,17 @@ mod tests {
         provider.destroy_mls_group(&ctx_id).unwrap();
 
         // After destroy, export should return empty (context removed).
-        let exported = provider.export_crypto_state(&ctx_id).unwrap();
+        let exported = provider
+            .export_crypto_state(
+                &ctx_id,
+                provider.export_sender_key_epochs(&ctx_id),
+                provider
+                    .export_recv_sequence_floors(&ctx_id)
+                    .into_iter()
+                    .map(|(did, (epoch, sequence))| (did, ReceiveFloor { epoch, sequence }))
+                    .collect(),
+            )
+            .unwrap();
         assert!(
             exported.is_empty(),
             "destroyed group should export empty state"
@@ -5064,7 +5280,17 @@ mod tests {
         let ctx_id = make_context_id();
         provider.create_mls_group(&ctx_id).unwrap();
 
-        let exported = provider.export_crypto_state(&ctx_id).unwrap();
+        let exported = provider
+            .export_crypto_state(
+                &ctx_id,
+                provider.export_sender_key_epochs(&ctx_id),
+                provider
+                    .export_recv_sequence_floors(&ctx_id)
+                    .into_iter()
+                    .map(|(did, (epoch, sequence))| (did, ReceiveFloor { epoch, sequence }))
+                    .collect(),
+            )
+            .unwrap();
 
         // Restore into a fresh provider twice — second should overwrite cleanly.
         let provider2 = MlsCryptoProvider::new(TEST_DID.to_string(), Arc::new(SystemClock));
@@ -5092,7 +5318,17 @@ mod tests {
             state.mls_group.epoch().unwrap()
         };
 
-        let exported = provider.export_crypto_state(&ctx_id).unwrap();
+        let exported = provider
+            .export_crypto_state(
+                &ctx_id,
+                provider.export_sender_key_epochs(&ctx_id),
+                provider
+                    .export_recv_sequence_floors(&ctx_id)
+                    .into_iter()
+                    .map(|(did, (epoch, sequence))| (did, ReceiveFloor { epoch, sequence }))
+                    .collect(),
+            )
+            .unwrap();
 
         let provider2 = MlsCryptoProvider::new(TEST_DID.to_string(), Arc::new(SystemClock));
         provider2.restore_crypto_state(&ctx_id, &exported).unwrap();
@@ -5131,7 +5367,17 @@ mod tests {
         );
 
         // Export the crypto state.
-        let exported = provider.export_crypto_state(&ctx_id).unwrap();
+        let exported = provider
+            .export_crypto_state(
+                &ctx_id,
+                provider.export_sender_key_epochs(&ctx_id),
+                provider
+                    .export_recv_sequence_floors(&ctx_id)
+                    .into_iter()
+                    .map(|(did, (epoch, sequence))| (did, ReceiveFloor { epoch, sequence }))
+                    .collect(),
+            )
+            .unwrap();
         assert!(!exported.is_empty());
 
         // Create a fresh provider (simulates restart — gets a NEW random keypair).


### PR DESCRIPTION
## What

Widens `MlsCryptoProvider::export_crypto_state` (an inherent method — no trait, no callers outside scp-runtime) to accept the crypto floors as parameters:

```rust
pub fn export_crypto_state(
    &self,
    context_id: &[u8; 32],
    sender_key_epochs: Vec<(String, u64)>,
    recv_sequence_floors: Vec<(String, ReceiveFloor)>,
) -> Result<Vec<u8>, ContextError>
```

All 43 call sites (6 production + 37 test) are threaded to pass those floors, **still sourced from the provider** (`export_sender_key_epochs` / `export_recv_sequence_floors` twins). Internally the method stops reading `sender_key_store.epochs_for_context` / `recv_sequence_tracker` and uses the params instead; everything else (MLS storage, signer, wrapping keys, scalars, `group_id`) stays sourced from the per-context state.

Prep D of the ADR-049 PR-6 decomposition. This is a **byte-identical no-op**: both the old inline code and the new provider twins read the same underlying state via the same calls, so the exported snapshot is unchanged. Its purpose is to **freeze the signature at the atomic-core-final shape** — the recv param is typed `Vec<(String, ReceiveFloor)>` (matching the registry source `Supervisor::export_recv_sequence_floors`), so the later read-authority flip is a pure source-swap at the 6 production sites (`deps.crypto.export_*` → `deps.supervisor.export_*`, dropping the conversion wrapper) rather than a signature change rippling across 43 sites.

The doc block documents the pass-through purpose, the single-writer-actor guard-span invariant (byte-identity holds because persist runs synchronously on the sole-writer actor task), and the caller contract (floors must be sourced for the same `context_id`).

## Tests

New pin test `export_crypto_state_floor_params_land_in_snapshot_verbatim` — deserializes the exported blob and asserts the `sender_key_epochs` / `recv_sequence_tracker` fields equal the provider twins' reports (order-insensitive sets, with literal positional anchors to catch transposition). Whole-blob byte equality is deliberately not asserted: `mls_storage_entries` / `member_wrapping_keys` / the floor `Vec`s serialize from HashMap iteration, so byte layout legitimately varies run-to-run (matching the existing `export_restore_crypto_state_roundtrip` which asserts functional, not byte, equality).

## Verification (run locally)

- `cargo fmt --all -- --check` — clean
- Full-features CI clippy (`--workspace --all-targets`, all features, `-D warnings`) — zero warnings
- Full workspace nextest (all features incl `saga-witness-test-mint`) — **10351/10351 passed**
- `check-cross-layer`, `check-bridge-symmetry`, `check-protocol-deps`, `check-protocol-sync`, `check-call-invariants`, `check-pure-helpers`, `check-handle-affinity` — all green

## Review

- **bug-catcher** — genuine clean no-op, no bugs (byte-identity verified at all 6 production sites; no `ReceiveFloor` transposition; guard-span split proven safe under the single-writer invariant; pin test sound)
- **api-design-reviewer** — APPROVED (floors-as-params is the right shape for the swap path; `ReceiveFloor` param type validated against the registry source; also prompted removal of a stale doc reference to the deleted `ContextCryptoProvider` trait)

Scope guards honored: no source flip to the registry, no `restore_crypto_state` change, no provider-mirror deletion, no live-gate touch — all reserved for the atomic read-authority switch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)