### PR TITLE
fix(python): vendored-OpenSSL SQLCipher + working CI wheel builds

### DIFF
--- a/.github/workflows/build-matrix.yml
+++ b/.github/workflows/build-matrix.yml
@@ -97,7 +97,22 @@ jobs:
           retention-days: 7
 
   # ---------------------------------------------------------------------------
-  # Python wheels — maturin-built manylinux2014 / macOS / Windows wheels
+  # Python wheels — maturin-built manylinux_2_28 / macOS / Windows wheels
+  #
+  # Every quirk below was learned the hard way on the 0.1.0b3 publish (the
+  # first CI wheel build — this job previously carried latent bugs because no
+  # run had ever reached it):
+  #   - maturin in CI finds no python by itself; each leg pins an explicit
+  #     interpreter (`-i`).
+  #   - manylinux 2_28, not 2014: CentOS 7 (EOL) can build neither
+  #     ring/aws-lc-sys (glibc >= 2.18, newer gcc) nor vendored OpenSSL.
+  #   - x86_64 2_28 container ships a minimal perl that openssl-src's
+  #     Configure rejects -> install the full perl distribution. The aarch64
+  #     leg is an Ubuntu-based rust-cross image (complete perl, NO dnf) — a
+  #     dnf attempt there exits 127, so it must get no container prep.
+  #   - Windows needs NASM for the vendored-OpenSSL MSVC assembly.
+  #   - No --manifest-path arg: bindings/python/pyproject.toml already carries
+  #     [tool.maturin] manifest-path.
   # ---------------------------------------------------------------------------
   python-wheels:
     name: Python wheel (${{ matrix.target }})
@@ -108,32 +123,49 @@ jobs:
         include:
           - target: x86_64-unknown-linux-gnu
             runner: ubuntu-latest
-            manylinux: manylinux2014
+            manylinux: 2_28
+            interpreter: python3.12
+            before-script: dnf install -y perl
           - target: aarch64-unknown-linux-gnu
             runner: ubuntu-latest
-            manylinux: manylinux2014
+            manylinux: 2_28
+            interpreter: python3.12
+            before-script: "true"
           - target: x86_64-apple-darwin
             runner: macos-latest
             manylinux: auto
+            interpreter: python
           - target: aarch64-apple-darwin
             runner: macos-latest
             manylinux: auto
+            interpreter: python
           - target: x86_64-pc-windows-msvc
             runner: windows-latest
             manylinux: auto
+            interpreter: python
     steps:
       - name: Checkout
         uses: actions/checkout@v5
+
+      - name: Setup Python 3.12
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Setup NASM (Windows)
+        if: runner.os == 'Windows'
+        uses: ilammy/setup-nasm@v1
 
       - name: Build wheel
         uses: PyO3/maturin-action@v1
         with:
           target: ${{ matrix.target }}
           manylinux: ${{ matrix.manylinux }}
+          before-script-linux: ${{ matrix.before-script }}
           args: >-
             --release
             --out dist
-            --manifest-path crates/scp-ffi/Cargo.toml
+            -i ${{ matrix.interpreter }}
           working-directory: bindings/python
 
       - name: Upload Python wheel
@@ -150,13 +182,13 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v5
 
+      # No --manifest-path: pyproject.toml carries [tool.maturin] manifest-path.
       - name: Build sdist
         uses: PyO3/maturin-action@v1
         with:
           command: sdist
           args: >-
             --out dist
-            --manifest-path crates/scp-ffi/Cargo.toml
           working-directory: bindings/python
 
       - name: Upload sdist

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3161,6 +3161,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2e99fb7a497b1e3339bc746195567ed8d3e24945ecd636e3619d20b9de9e9149"
 dependencies = [
  "cc",
+ "openssl-sys",
  "pkg-config",
  "vcpkg",
 ]
@@ -3930,6 +3931,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
 
 [[package]]
+name = "openssl-src"
+version = "300.5.5+3.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f1787d533e03597a7934fd0a765f0d28e94ecc5fb7789f8053b1e699a56f709"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "openssl-sys"
 version = "0.9.111"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3937,6 +3947,7 @@ checksum = "82cab2d520aa75e3c58898289429321eb788c3106963d0dc886ec7a5f4adc321"
 dependencies = [
  "cc",
  "libc",
+ "openssl-src",
  "pkg-config",
  "vcpkg",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -78,7 +78,7 @@ metrics-exporter-prometheus = { version = "0.16", default-features = false, feat
 unicode-normalization = "0.1"
 arc-swap = "1"
 futures = "0.3"
-rusqlite = { version = "0.32", features = ["bundled-sqlcipher"] }
+rusqlite = { version = "0.32", features = ["bundled-sqlcipher-vendored-openssl"] }
 redb = "2"
 static_assertions = "1.1"
 # wasm-bindgen stack for the browser participant surface (ADR-057 Slice 3).

--- a/bindings/python/pyproject.toml
+++ b/bindings/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "scp-python"
-version = "0.1.0b2"
+version = "0.1.0b3"
 description = "SCP (Shared Context Protocol) Python SDK — cryptographic identity, governed contexts, and trust for AI agents"
 requires-python = ">=3.10"
 license = { text = "MIT OR Apache-2.0" }
@@ -35,7 +35,7 @@ dev = ["pytest>=8.0", "pytest-asyncio>=0.24", "ruff>=0.8", "mypy>=1.13"]
 scp-mcp = "scp_sdk.mcp:cli_main"
 
 [project.urls]
-Repository = "https://github.com/limn-scp/scp-protocol-core"
+Repository = "https://github.com/limn-works/scp"
 Documentation = "https://scp.dev/docs"
 
 [tool.pytest.ini_options]

--- a/crates/scp-platform/Cargo.toml
+++ b/crates/scp-platform/Cargo.toml
@@ -73,7 +73,7 @@ sha2 = { workspace = true, optional = true }
 uuid = { workspace = true, optional = true }
 
 # sqlite dependencies, gated behind the `sqlite` feature flag.
-rusqlite = { version = "0.32", features = ["bundled-sqlcipher"], optional = true }
+rusqlite = { version = "0.32", features = ["bundled-sqlcipher-vendored-openssl"], optional = true }
 hex = { workspace = true, optional = true }
 # fs2 provides advisory POSIX / Windows file locking — used by SqliteStorage
 # to refuse a second process/instance trying to open the same database


### PR DESCRIPTION
Extracted from the `scp-python 0.1.0b3` PyPI publish — the first CI wheel build ever to run. `build-matrix.yml`'s `python-wheels` job carried latent bugs because no release run had ever reached it (the June dry-run died at conformance).

## What
- **`rusqlite` `bundled-sqlcipher` → `bundled-sqlcipher-vendored-openssl`** (root Cargo.toml + scp-platform, + lock). The old feature links **system** OpenSSL, which no clean CI environment has — Windows fails with `OPENSSL_DIR` unset, manylinux lacks `openssl-devel`, and cross-aarch64 has no target `libcrypto`. The 0.1.0b2 wheel only ever built because the dev machine had Homebrew OpenSSL. Identical SQLCipher behavior; OpenSSL is compiled for the target and statically linked. Verified locally with the full CI clippy feature set.
- **`python-wheels` job fixes** (each one hit and fixed live during the b3 publish, run [29286695434](https://github.com/limn-works/scp/actions/runs/29286695434)):
  - explicit maturin interpreter per leg (`-i`) + `setup-python` — maturin finds no python in CI
  - `manylinux 2_28` — CentOS 7 (2014) can build neither `ring`/`aws-lc-sys` (glibc ≥ 2.18, newer gcc) nor vendored OpenSSL
  - full `perl` in the x86_64 container (minimal perl breaks openssl-src `Configure`: IPC::Cmd, Time::Piece); **no** container prep on aarch64 (Ubuntu-based rust-cross image: complete perl, no dnf — a dnf attempt exits 127)
  - NASM on Windows for the vendored-OpenSSL MSVC assembly
  - drop redundant `--manifest-path` (pyproject `[tool.maturin]` carries it) — also on the sdist job
- **pyproject**: `0.1.0b3` (matches what is now live on PyPI with 5 wheels + sdist, published via Trusted Publisher OIDC) and fix the dead `Repository` URL (`limn-scp/scp-protocol-core` → `limn-works/scp`).

## Context
`scp-python 0.1.0b3` is live: https://pypi.org/project/scp-python/0.1.0b3/ — published through the now-activated PyPI Trusted Publisher (repo `limn-works/scp`, workflow `release.yml`, environment `pypi`). The throwaway bootstrap branch used for that publish will be deleted; this PR carries everything from it that main needs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)