### PR TITLE
feat(crypto): expose pub(crate) wrapping keypair accessors for actor seeding (ADR-049 PR-7 Prep B)

### DIFF
--- a/crates/scp-runtime/src/crypto/mls/provider.rs
+++ b/crates/scp-runtime/src/crypto/mls/provider.rs
@@ -2449,6 +2449,44 @@ impl MlsCryptoProvider {
         (public, secret)
     }
 
+    /// Returns a copy of this provider's node-resident X25519 wrapping
+    /// **public** key (the HPKE recipient key advertised in the `0xFF01`
+    /// wrapping leaf so peers can seal sender keys to this member).
+    ///
+    /// ADR-049 PR-7 prep B (SCP-CRYPTOMOVE-000b): the Prep A per-context crypto
+    /// methods on `PerContextState` take the node-resident wrapping keypair as a
+    /// METHOD PARAMETER (never stored on `ContextCryptoState`). The atomic core
+    /// actor-seeding path (SCP-CRYPTOMOVE-001) therefore needs to read the
+    /// keypair off the provider to hand it in. This `pub(crate)` accessor
+    /// exposes the public half in the PRODUCTION build without routing through
+    /// [`Self::wrapping_keypair_snapshot`], which stays test-gated so the raw
+    /// secret is never reachable from the production public API.
+    #[must_use]
+    #[allow(
+        dead_code,
+        reason = "ADR-049 PR-7 prep B (SCP-CRYPTOMOVE-000b): node-resident accessor lands ahead of the atomic move; production caller is the atomic core actor-seeding path (SCP-CRYPTOMOVE-001). Exercised now by a crate-internal parity unit test."
+    )]
+    pub(crate) fn wrapping_public_key(&self) -> [u8; 32] {
+        **self.wrapping_public_key.load()
+    }
+
+    /// Returns a `Zeroizing` copy of this provider's node-resident X25519
+    /// wrapping **secret** key (used to HPKE-open sender keys sealed to this
+    /// member). The returned buffer zeroes on drop, so the secret does not
+    /// linger in caller memory once the returned value is dropped.
+    ///
+    /// Companion to [`Self::wrapping_public_key`] for the SCP-CRYPTOMOVE-001
+    /// actor-seeding path (see that method's note). The `Zeroizing` return type
+    /// is load-bearing: no bare `[u8; 32]` secret escapes the provider.
+    #[must_use]
+    #[allow(
+        dead_code,
+        reason = "ADR-049 PR-7 prep B (SCP-CRYPTOMOVE-000b): node-resident accessor lands ahead of the atomic move; production caller is the atomic core actor-seeding path (SCP-CRYPTOMOVE-001). Exercised now by a crate-internal parity unit test."
+    )]
+    pub(crate) fn wrapping_secret(&self) -> zeroize::Zeroizing<[u8; 32]> {
+        zeroize::Zeroizing::new(***self.wrapping_secret_key.load())
+    }
+
     /// Restores per-context cryptographic state from a previously exported
     /// byte blob (produced by [`export_crypto_state`](Self::export_crypto_state)),
     /// returning the Class-M [`RestoredFloors`] the caller merges into the
@@ -2790,6 +2828,38 @@ mod tests {
         let mut id = [0u8; 32];
         id[0] = 0x42;
         id
+    }
+
+    /// ADR-049 PR-7 prep B (SCP-CRYPTOMOVE-000b): the `pub(crate)`
+    /// `wrapping_public_key()` / `wrapping_secret()` accessors that the atomic
+    /// core actor-seeding path (SCP-CRYPTOMOVE-001) will read must observe the
+    /// SAME node-resident keypair as the test-gated
+    /// [`MlsCryptoProvider::wrapping_keypair_snapshot`] ground truth. Also pins
+    /// the AC#2 contract that the secret accessor returns `Zeroizing` (no bare
+    /// `[u8; 32]` secret escapes the provider) via a load-bearing type witness.
+    #[test]
+    fn wrapping_accessors_match_snapshot_and_secret_is_zeroizing() {
+        let provider = make_provider();
+
+        // Ground truth: the identity-level wrapping keypair as the test-gated
+        // snapshot reports it.
+        let (snap_pub, snap_sec) = provider.wrapping_keypair_snapshot();
+
+        // Parity: the production `pub(crate)` accessors observe the same bytes.
+        assert_eq!(
+            provider.wrapping_public_key(),
+            snap_pub,
+            "wrapping_public_key() must match the snapshot's public half"
+        );
+
+        // AC#2 type witness: the return type is `Zeroizing<[u8; 32]>`, not a
+        // bare secret. This binding is load-bearing — it fails to compile if the
+        // signature ever regresses to a plain `[u8; 32]`.
+        let sec: zeroize::Zeroizing<[u8; 32]> = provider.wrapping_secret();
+        assert_eq!(
+            *sec, *snap_sec,
+            "wrapping_secret() must match the snapshot's secret half"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## ADR-049 PR-7 Prep B — node-resident wrapping-keypair accessors

Story: **SCP-CRYPTOMOVE-000b** (`.docs/prds/adr049-crypto-state-move.json`). Second of five additive preps ahead of the atomic crypto-by-move core (SCP-CRYPTOMOVE-001). Builds on Prep A (#2121).

### What
Prep A moved the per-context MLS crypto orchestration onto `PerContextState` as inherent methods that take the node-resident X25519 wrapping keypair as **method parameters** (per Decision 6 — node-level material is never stored on `ContextCryptoState`). The atomic core will therefore need to read that keypair off `MlsCryptoProvider` to hand it in.

This PR additively exposes it via two `pub(crate)` accessors on `MlsCryptoProvider`:
- `wrapping_public_key() -> [u8; 32]`
- `wrapping_secret() -> zeroize::Zeroizing<[u8; 32]>`

Both bodies are byte-identical to the existing `wrapping_keypair_snapshot`'s field reads. The secret returns wrapped in `Zeroizing` so no bare `[u8; 32]` secret escapes.

### Why not just reuse `wrapping_keypair_snapshot`
It stays **test-gated** (`#[cfg(any(test, feature = "testing"))]`) deliberately — it hands back the raw secret unconditionally and must not exist in a production build. Narrowing it to `pub(crate)` would break its cross-crate `scp-testing` callers (non-additive); ungating it would leak the secret into the production public API. The split `pub(crate)` accessors are the prod-safe path.

`clock()` (already `pub`) and `local_did()` (already `pub(crate)`) suffice unchanged — confirmed, not edited.

### Scope / safety
- **Additive only**: `git diff` is 70 insertions, 0 deletions — the two accessors + one unit test. No call-site or existing-body change; `wrapping_keypair_snapshot`, `clock()`, `local_did()` byte-untouched.
- **`pub(crate)`, not `pub`**: compiler-enforced — the secret stays inside `scp-runtime`, reachable by the atomic-core actor-seeding path but not by any external / FFI / SDK surface. No cross-layer, bridge, or capability-matrix implication.
- `#[allow(dead_code, reason = "…SCP-CRYPTOMOVE-000b…SCP-CRYPTOMOVE-001…")]` on both (unused `pub(crate)` until the atomic core wires the consumer), following the Prep A precedent. No `#NNNN` refs — story IDs only.

### Test
`wrapping_accessors_match_snapshot_and_secret_is_zeroizing` — asserts both accessors return the same bytes as `wrapping_keypair_snapshot`, with a load-bearing `let sec: Zeroizing<[u8;32]> = provider.wrapping_secret();` type witness (regressing the signature to a bare `[u8;32]` fails to compile).

### Verification
- Full workspace `cargo nextest` (incl. `saga-witness-test-mint`): **10477 passed, 0 failed** (the one leaky note is a pre-existing unrelated `scp-transport` adapter test).
- `cargo fmt --check`, full-feature `clippy -D warnings`, all `check-*.sh` (incl. `check-pure-helpers.sh` — accessors are methods, not free functions): clean.
- Review — cryptographer (deref/Zeroizing/exposure-scope), bug-catcher, completionist (all 5 ACs): double-zero.

### Deferred to the atomic core (SCP-CRYPTOMOVE-001)
Cryptographer MINOR: two separate accessor *calls* give a wider torn-read window than the snapshot's single-function double-load (blast radius = self-HPKE-open DoS, not key leak; self-corrects on next seed). When the atomic core adds the actual consumer, it should read the keypair via a single combined `pub(crate) fn wrapping_keypair() -> ([u8;32], Zeroizing<[u8;32]>)` so pairing atomicity is structural rather than reliant on a quiescent provider — reconciling/superseding these two accessors. Non-blocking here (additive prep, no consumer yet).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
