### PR TITLE
feat(outlet): wire per-sender base_sequence at consumption on the xctx send path (SCP-OUT-044)

### DIFF
--- a/.docs/prds/outlet.json
+++ b/.docs/prds/outlet.json
@@ -2953,7 +2953,7 @@
       "gate": "gate-streaming-saga",
       "priority": "P1",
       "severity": "major",
-      "status": "pending",
+      "status": "done",
       "files": [
         "crates/scp-runtime/src/context/outlets_helpers.rs",
         "crates/scp-runtime/src/context/outlets/invoke.rs",

--- a/crates/scp-runtime/src/context/actor/commands.rs
+++ b/crates/scp-runtime/src/context/actor/commands.rs
@@ -2295,7 +2295,8 @@ pub enum OutletsCommand {
     /// economic policy, gates on membership, and DEBITS the §5.4.5 open-time
     /// escrow hold (`cost_per_chunk × estimated_chunk_count`) under a
     /// fail-closed persist. The per-sender `base_sequence` is NOT allocated here
-    /// — the transport/FFI send path allocates it at consumption.
+    /// — the send path allocates it at consumption (the cross-context hop fills
+    /// this in `forward_frame` / `run_cross_context_bridge`, SCP-OUT-044).
     /// Replies with a `Send`
     /// [`StreamEconomyReservation`](crate::context::outlets_helpers::StreamEconomyReservation)
     /// the supervisor carries across the off-mailbox stream pump.

--- a/crates/scp-runtime/src/context/outlets/invoke.rs
+++ b/crates/scp-runtime/src/context/outlets/invoke.rs
@@ -4330,6 +4330,94 @@ pub(crate) fn cross_context_economy_gate(
 /// infrastructure failure that the best-effort bridge cannot recover.
 pub(crate) type BridgeFaultProbe = Box<dyn Fn(&OutletStreamChunk) -> Option<String> + Send>;
 
+/// A forwarded cross-context outlet-stream chunk paired with its per-sender MLS
+/// send-sequence anchor (SCP-OUT-044).
+///
+/// Provenance: §5.4.5 "Ordering and gaps"; §6.2.0 Outlet Interface Transport;
+/// ADR-049 §8 `SequenceReservation`.
+///
+/// The `base_sequence` is the per-sender, strictly-monotone (`+1` per forwarded
+/// chunk) MLS send-sequence anchor reserved via the ADR-049 §8
+/// [`SequenceReservation`](crate::context::actor::SequenceReservation) guard at
+/// the moment the bridge hands the chunk to A's outer channel — the point of
+/// consumption the `outlets_helpers` open-time comments defer to. It is exposed
+/// as `(request_id, base_sequence)` to the future authoritative reassembly
+/// gap-detector (SCP-OUT-045), recoverable as `frame.chunk.request_id` +
+/// `frame.base_sequence`.
+///
+/// This is a RUNTIME-ONLY, in-process wrapper on the bridge's outer channel: it
+/// is deliberately NOT a field of the operator-signed
+/// [`OutletStreamChunk`](scp_protocol::context::outlets::stream::OutletStreamChunk).
+/// Adding a field there would (a) diverge A's independently-recomputed manifest
+/// root — `compute_chunk_leaf_hash` JCS-hashes the ENTIRE chunk, and A's
+/// verified append (`append_outlet_invoked_verified`) wire-rejects any
+/// manifest-root mismatch against B's committed manifest — and (b) change the
+/// FFI-conformance wire type. The chunk is carried through byte-for-byte
+/// unmodified (operator signature preserved); the anchor rides alongside it.
+///
+/// Derives `Debug` only: it is never serialized (in-process channel item), which
+/// keeps the FFI/serde/protocol-sync surface untouched. Construct via struct
+/// literal only (no `new` constructor — cross-layer construction gate).
+#[derive(Debug)]
+pub struct ForwardedStreamFrame {
+    /// Per-sender send-sequence anchor (the §5.4.5 ordering anchor) for the
+    /// authoritative cross-context reassembly gap-detector (SCP-OUT-045;
+    /// consumed via the SCP-OUT-047 streaming-saga FFI). Reserved-at-consumption
+    /// on the cross-context send hop (SCP-OUT-044): 1-based, strictly `+1` per
+    /// forwarded chunk, so the detector keys on `(chunk.request_id,
+    /// base_sequence)` and flags any missing chunk as a gap.
+    ///
+    /// This is a GAP-DETECTION ANCHOR, NOT an MLS AEAD sequence input — it is
+    /// never fed to any encryption. The A-context re-seal at the SDK delivery
+    /// seam (SCP-OUT-047) assigns its OWN MLS send-sequence; feeding THIS value
+    /// as an AEAD sequence/nonce there would be a byte-identity regression (see
+    /// the AAD warning in the `context::actor::sequence` module). And do NOT
+    /// confuse it with `chunk.sequence` (the operator's per-request chunk
+    /// index) — the gap-detector keys on this field, never on `chunk.sequence`.
+    pub base_sequence: u64,
+    /// The operator-signed chunk, forwarded verbatim (never re-signed, never
+    /// mutated) — its `request_id` + `sequence` are unchanged.
+    pub chunk: OutletStreamChunk,
+}
+
+/// Reserve → send → commit a single forwarded chunk under the ADR-049 §8
+/// [`SequenceReservation`](crate::context::actor::SequenceReservation) RAII
+/// guard (SCP-OUT-044). This is the allocate-at-consumption seam the
+/// `outlets_helpers` open-time reservation deliberately defers to.
+///
+/// The per-sender `base_sequence` is reserved from `send_tracker` (post-increment,
+/// 1-based — first reservation returns `1`), stamped onto the
+/// [`ForwardedStreamFrame`], and the frame is sent to A's outer channel. The
+/// reservation is committed ONLY after the send succeeds; if the send fails (A
+/// stopped consuming), the guard is dropped WITHOUT `commit`, so its `Drop`
+/// rolls the tracker back — the next allocation reuses the freed number and NO
+/// send-sequence gap is burned (§5.15.7 send-sequence reservation: a number
+/// becomes durable iff the payload was handed to the transport).
+///
+/// Returns `true` iff the frame was accepted by the outer channel (A is still
+/// consuming); `false` means A stopped — the caller MUST stop forwarding.
+#[must_use]
+async fn forward_frame(
+    outer_tx: &mpsc::Sender<ForwardedStreamFrame>,
+    send_tracker: &mut crate::context::actor::SendSequenceTracker,
+    chunk: &OutletStreamChunk,
+) -> bool {
+    let reservation = crate::context::actor::SequenceReservation::reserve(send_tracker);
+    let frame = ForwardedStreamFrame {
+        base_sequence: reservation.number(),
+        chunk: chunk.clone(),
+    };
+    if outer_tx.send(frame).await.is_err() {
+        // A stopped consuming before this frame landed. Dropping `reservation`
+        // WITHOUT commit rolls the tracker back (no gap burned).
+        return false;
+    }
+    // The frame reached the transport (A's outer channel) — the sequence is now
+    // durable-by-intent; commit so `Drop` does not roll it back.
+    reservation.commit();
+    true
+}
+
 /// Forwards a BRIDGE-SYNTHESIZED terminal chunk (schema violation,
 /// signature-verification failure, or mid-stream bridge fault) to A's invoker
 /// and folds it into the receiver-side manifest snapshot.
@@ -4347,7 +4435,8 @@ pub(crate) type BridgeFaultProbe = Box<dyn Fn(&OutletStreamChunk) -> Option<Stri
 /// channel.
 #[must_use]
 async fn forward_bridge_terminal(
-    outer_tx: &mpsc::Sender<OutletStreamChunk>,
+    outer_tx: &mpsc::Sender<ForwardedStreamFrame>,
+    send_tracker: &mut crate::context::actor::SendSequenceTracker,
     reassembled: &mut Vec<OutletStreamChunk>,
     terminal: &mut StreamTerminalSummary,
     request_id: RequestId,
@@ -4360,12 +4449,17 @@ async fn forward_bridge_terminal(
         payload,
         sig: [0u8; 64],
     };
-    if outer_tx.send(chunk.clone()).await.is_err() {
+    // Reserve-at-consumption (SCP-OUT-044): the synthesized terminal carries its
+    // own per-sender `base_sequence` anchor, allocated + committed on the send
+    // hop like every forwarded chunk. A send failure rolls the reservation back.
+    if !forward_frame(outer_tx, send_tracker, &chunk).await {
         // A's invoker stopped consuming before the terminal landed — record
         // what was already delivered; the terminal summary keeps its prior
         // (default) status.
         return false;
     }
+    // The manifest snapshot commits over the bare `OutletStreamChunk` (never the
+    // runtime frame), so B's committed manifest and A's recomputation agree.
     terminal.observe(&chunk.payload);
     reassembled.push(chunk);
     true
@@ -4548,7 +4642,7 @@ pub(crate) const MAX_CROSS_CONTEXT_STREAM_CHUNKS: usize = 1 << 20;
 #[allow(clippy::too_many_lines)]
 pub(crate) async fn run_cross_context_bridge(
     mut inner_rx: mpsc::Receiver<OutletStreamChunk>,
-    outer_tx: mpsc::Sender<OutletStreamChunk>,
+    outer_tx: mpsc::Sender<ForwardedStreamFrame>,
     descriptor: CrossContextVerificationDescriptor,
     output_schema: serde_json::Value,
     aggregate_schema: Option<serde_json::Value>,
@@ -4571,6 +4665,14 @@ pub(crate) async fn run_cross_context_bridge(
     );
     let mut reassembled: Vec<OutletStreamChunk> = Vec::new();
     let mut terminal = StreamTerminalSummary::default();
+    // Per-sender MLS send-sequence allocator for THIS cross-context send hop
+    // (SCP-OUT-044). Task-scoped (one per bridged stream), so it resolves the
+    // request-scope objection the actor's LIFO `rollback_sequence_number` cannot
+    // (the off-mailbox bridge cannot reach the actor's `PerContextState`
+    // `send_tracker` under ADR-049 isolation). Every chunk forwarded to A —
+    // operator-authored or synthesized — draws its `base_sequence` from here via
+    // the ADR-049 §8 `SequenceReservation` guard.
+    let mut send_tracker = crate::context::actor::SendSequenceTracker::new();
     let mut execution_time_ms: u64 = 0;
     // Terminal-guarantee bookkeeping: `delivered_terminal` becomes true once a
     // terminal chunk (operator-authored or synthesized) is DELIVERED to A;
@@ -4598,6 +4700,7 @@ pub(crate) async fn run_cross_context_bridge(
                 .map_or(chunk.sequence, |c| c.sequence.saturating_add(1));
             delivered_terminal = forward_bridge_terminal(
                 &outer_tx,
+                &mut send_tracker,
                 &mut reassembled,
                 &mut terminal,
                 request_id,
@@ -4626,6 +4729,7 @@ pub(crate) async fn run_cross_context_bridge(
             };
             delivered_terminal = forward_bridge_terminal(
                 &outer_tx,
+                &mut send_tracker,
                 &mut reassembled,
                 &mut terminal,
                 request_id,
@@ -4648,6 +4752,7 @@ pub(crate) async fn run_cross_context_bridge(
             };
             delivered_terminal = forward_bridge_terminal(
                 &outer_tx,
+                &mut send_tracker,
                 &mut reassembled,
                 &mut terminal,
                 request_id,
@@ -4685,6 +4790,7 @@ pub(crate) async fn run_cross_context_bridge(
             };
             delivered_terminal = forward_bridge_terminal(
                 &outer_tx,
+                &mut send_tracker,
                 &mut reassembled,
                 &mut terminal,
                 request_id,
@@ -4706,11 +4812,15 @@ pub(crate) async fn run_cross_context_bridge(
         }
 
         // (AC3) Forward as produced — no buffering. The operator signature is
-        // preserved verbatim (never re-signed). Push to the write-through
-        // replay snapshot only AFTER a successful forward (§6.2.5) — never
-        // before, so the retained vector can never gate delivery.
+        // preserved verbatim (never re-signed). Each forward reserves + commits
+        // a per-sender `base_sequence` anchor at consumption (SCP-OUT-044) via
+        // the ADR-049 §8 `SequenceReservation` guard; a send failure rolls the
+        // reservation back so no send-sequence gap is burned. Push to the
+        // write-through replay snapshot only AFTER a successful forward (§6.2.5)
+        // — never before, so the retained vector can never gate delivery, and
+        // the manifest commits over the bare `OutletStreamChunk` (not the frame).
         let is_terminal = chunk.payload.is_terminal();
-        if outer_tx.send(chunk.clone()).await.is_err() {
+        if !forward_frame(&outer_tx, &mut send_tracker, &chunk).await {
             // A's invoker stopped consuming — stop forwarding and record what
             // was already delivered.
             outer_open = false;
@@ -4744,6 +4854,7 @@ pub(crate) async fn run_cross_context_bridge(
             .map_or(0, |c| c.sequence.saturating_add(1));
         let _ = forward_bridge_terminal(
             &outer_tx,
+            &mut send_tracker,
             &mut reassembled,
             &mut terminal,
             request_id,
@@ -4777,11 +4888,15 @@ pub(crate) async fn run_cross_context_bridge(
 /// takes B's plaintext operator-signed chunk receiver, and spawns the
 /// off-mailbox bridge task that forwards each chunk to the shared-member
 /// invoker and records the RECEIVING context A's own `OutletInvoked` at close.
-/// Returns A's PLAINTEXT `mpsc::Receiver<OutletStreamChunk>` in-process to the
+/// Returns A's PLAINTEXT `mpsc::Receiver<ForwardedStreamFrame>` in-process to the
 /// shared-member invoker (a member of BOTH contexts, §6.2.0) — mirroring the
-/// same-context [`invoke_outlet`]. Re-encryption for A's OTHER members is the
-/// delivery seam (the SDK seals each still-operator-signed chunk under A's MLS
-/// group key), NOT this return type.
+/// same-context [`invoke_outlet`]. Each [`ForwardedStreamFrame`] pairs the
+/// unmodified operator-signed chunk with the per-sender MLS `base_sequence`
+/// anchor allocated at consumption on this send hop (SCP-OUT-044), exposed as
+/// `(request_id, base_sequence)` to the SCP-OUT-045 gap-detector. Re-encryption
+/// for A's OTHER members is the delivery seam (the SDK seals each
+/// still-operator-signed `frame.chunk` under A's MLS group key), NOT this return
+/// type.
 ///
 /// Zero-escrow (§5.4.5 "Cross-context economy"; ADR-061): a paid Action outlet
 /// (`cost.amount > 0`) is rejected BEFORE any stream is opened and NO receiver
@@ -4841,7 +4956,7 @@ pub(crate) async fn invoke_outlet_cross_context<E>(
     // `[u8; 32]` chunk-signature binding.
     caveat_binding: Option<crate::context::outlets_helpers::InvocationCaveatBinding>,
     params: crate::context::outlets::dispatch::OpenStreamParams,
-) -> Result<mpsc::Receiver<OutletStreamChunk>, InvocationError>
+) -> Result<mpsc::Receiver<ForwardedStreamFrame>, InvocationError>
 where
     E: OutletExecutor + ?Sized + 'static,
 {
@@ -4927,8 +5042,10 @@ where
 
     // Bounded outer channel (=1) so forward-N precedes request-N+1 (AC3): the
     // bridge cannot pull chunk N+1 from `inner_rx` until chunk N has been
-    // accepted by A's invoker.
-    let (outer_tx, outer_rx) = mpsc::channel::<OutletStreamChunk>(1);
+    // accepted by A's invoker. Each item is a `ForwardedStreamFrame` carrying the
+    // per-sender `base_sequence` anchor (SCP-OUT-044) alongside the unmodified
+    // operator-signed chunk.
+    let (outer_tx, outer_rx) = mpsc::channel::<ForwardedStreamFrame>(1);
 
     // Committer-assigned leaf timestamp for A's close event (a local wall-clock
     // reading is correct — A's close event is authored once by the bridge, not
@@ -7077,7 +7194,7 @@ mod tests {
         ) {
             let (a_log, a_bytes) = fresh_a_log().await;
             let (inner_tx, inner_rx) = mpsc::channel::<OutletStreamChunk>(1);
-            let (outer_tx, mut outer_rx) = mpsc::channel::<OutletStreamChunk>(1);
+            let (outer_tx, mut outer_rx) = mpsc::channel::<ForwardedStreamFrame>(1);
             let a_dyn: Arc<dyn ContextEventLogProvider> = a_log.clone();
             let bridge = tokio::spawn(run_cross_context_bridge(
                 inner_rx,
@@ -7103,9 +7220,13 @@ mod tests {
                     }
                 }
             });
+            // Unwrap the runtime `ForwardedStreamFrame` back to the bare chunk so
+            // this helper's contract ("what A's invoker received") stays a
+            // `Vec<OutletStreamChunk>` — the `base_sequence` anchor is asserted
+            // directly by the SCP-OUT-044 unit tests, not here.
             let mut received = Vec::new();
-            while let Some(chunk) = outer_rx.recv().await {
-                received.push(chunk);
+            while let Some(frame) = outer_rx.recv().await {
+                received.push(frame.chunk);
             }
             producer.await.expect("producer task");
             bridge.await.expect("bridge task");
@@ -7137,8 +7258,9 @@ mod tests {
         }
 
         /// Compile-level proof that `invoke_outlet_cross_context`'s Ok variant
-        /// is exactly `mpsc::Receiver<OutletStreamChunk>` (a PLAINTEXT chunk
-        /// receiver) and NOT a sealed/ciphertext type. Never executed — the
+        /// is exactly `mpsc::Receiver<ForwardedStreamFrame>` — a PLAINTEXT chunk
+        /// (`frame.chunk`) paired with the per-sender `base_sequence` anchor
+        /// (SCP-OUT-044), NOT a sealed/ciphertext type. Never executed — the
         /// explicit type annotation on the awaited result fails to compile if
         /// the return type drifts.
         #[allow(dead_code)]
@@ -7151,7 +7273,7 @@ mod tests {
             incoming_open: &OutletStreamOpen,
             params: crate::context::outlets::dispatch::OpenStreamParams,
         ) {
-            let out: Result<mpsc::Receiver<OutletStreamChunk>, InvocationError> =
+            let out: Result<mpsc::Receiver<ForwardedStreamFrame>, InvocationError> =
                 invoke_outlet_cross_context::<NoopExecutor>(
                     supervisor,
                     a_event_log,
@@ -7219,7 +7341,7 @@ mod tests {
             let (a_log, _a_bytes) = fresh_a_log().await;
             let a_dyn: Arc<dyn ContextEventLogProvider> = a_log.clone();
             let (inner_tx, inner_rx) = mpsc::channel::<OutletStreamChunk>(1);
-            let (outer_tx, mut outer_rx) = mpsc::channel::<OutletStreamChunk>(1);
+            let (outer_tx, mut outer_rx) = mpsc::channel::<ForwardedStreamFrame>(1);
 
             let bridge = tokio::spawn(run_cross_context_bridge(
                 inner_rx,
@@ -7275,10 +7397,12 @@ mod tests {
                  got {ahead} of 6 — the bridge is buffering the stream"
             );
 
-            // Now drain and assert strict in-order delivery with no gaps.
+            // Now drain and assert strict in-order delivery with no gaps. Unwrap
+            // each `ForwardedStreamFrame` to its chunk; the `base_sequence`
+            // anchor is asserted by the SCP-OUT-044 unit tests.
             let mut received = Vec::new();
-            while let Some(chunk) = outer_rx.recv().await {
-                received.push(chunk);
+            while let Some(frame) = outer_rx.recv().await {
+                received.push(frame.chunk);
             }
             producer.await.expect("producer");
             bridge.await.expect("bridge");
@@ -7877,7 +8001,7 @@ mod tests {
             let (a_log, _a_bytes) = fresh_a_log().await;
             let a_dyn: Arc<dyn ContextEventLogProvider> = a_log.clone();
             let (inner_tx, inner_rx) = mpsc::channel::<OutletStreamChunk>(1);
-            let (outer_tx, mut outer_rx) = mpsc::channel::<OutletStreamChunk>(1);
+            let (outer_tx, mut outer_rx) = mpsc::channel::<ForwardedStreamFrame>(1);
             let bridge = tokio::spawn(run_cross_context_bridge(
                 inner_rx,
                 outer_tx,
@@ -7918,8 +8042,8 @@ mod tests {
             };
 
             let mut received = Vec::new();
-            while let Some(chunk) = outer_rx.recv().await {
-                received.push(chunk);
+            while let Some(frame) = outer_rx.recv().await {
+                received.push(frame.chunk);
             }
             let _ = producer.await;
             bridge.await.expect("bridge");
@@ -7985,6 +8109,145 @@ mod tests {
             )
             .await;
             assert_terminal_error(received.last().unwrap(), CODE_AUTHORIZATION_DENIED);
+        }
+
+        // -----------------------------------------------------------------
+        // SCP-OUT-044 — per-sender base_sequence allocated at consumption on
+        // the cross-context send hop via the ADR-049 §8 SequenceReservation.
+        // -----------------------------------------------------------------
+
+        /// Builds a bare (unsigned) Data chunk at `sequence`. `forward_frame`
+        /// never verifies signatures — it stamps the send-seq anchor and
+        /// forwards — so an unsigned chunk exercises the allocator directly.
+        fn data_chunk(sequence: u64) -> OutletStreamChunk {
+            OutletStreamChunk {
+                request_id: RID,
+                sequence,
+                payload: ChunkPayload::Data {
+                    value: serde_json::json!({ "n": sequence }),
+                },
+                sig: [0u8; 64],
+            }
+        }
+
+        /// AC2 — the per-sender `base_sequence` is a strictly `+1`-monotone
+        /// `u64` across a 5-chunk send, 1-based (first reservation → 1). The
+        /// underlying chunk is forwarded unmodified.
+        #[tokio::test]
+        async fn out044_forward_frame_allocates_monotone_base_sequence() {
+            let (tx, mut rx) = mpsc::channel::<ForwardedStreamFrame>(8);
+            let mut tracker = crate::context::actor::SendSequenceTracker::new();
+
+            for seq in 0..5u64 {
+                assert!(
+                    forward_frame(&tx, &mut tracker, &data_chunk(seq)).await,
+                    "a send into an open channel must succeed and commit the reservation"
+                );
+            }
+            drop(tx);
+
+            let mut got = Vec::new();
+            while let Some(frame) = rx.recv().await {
+                got.push((frame.base_sequence, frame.chunk.sequence));
+            }
+
+            assert_eq!(got.len(), 5, "all five frames delivered");
+            for (i, (base, chunk_seq)) in got.iter().enumerate() {
+                assert_eq!(
+                    *base,
+                    (i as u64) + 1,
+                    "base_sequence is per-sender 1-based, +1 per forwarded chunk"
+                );
+                assert_eq!(
+                    *chunk_seq, i as u64,
+                    "the underlying operator chunk is forwarded unmodified"
+                );
+            }
+            for w in got.windows(2) {
+                assert_eq!(
+                    w[1].0,
+                    w[0].0 + 1,
+                    "strict +1 monotonicity across the 5-chunk send"
+                );
+            }
+            assert_eq!(
+                tracker.last_issued(),
+                5,
+                "all five reservations committed — high-water mark at 5"
+            );
+        }
+
+        /// AC3 — a send that fails BEFORE `commit()` (A stopped consuming)
+        /// rolls the reservation back via `Drop`; the next allocation reuses
+        /// the freed number, so no send-sequence gap is burned. Mirrors
+        /// `sequence.rs::reserve_drop_reserve_reuses_freed_number`.
+        #[tokio::test]
+        async fn out044_forward_frame_rolls_back_on_send_failure_and_reuses_sequence() {
+            let mut tracker = crate::context::actor::SendSequenceTracker::new();
+
+            // Drop the receiver FIRST so the send fails; `forward_frame` returns
+            // false and its `SequenceReservation` drops WITHOUT commit → rollback.
+            {
+                let (tx, rx) = mpsc::channel::<ForwardedStreamFrame>(1);
+                drop(rx);
+                assert!(
+                    !forward_frame(&tx, &mut tracker, &data_chunk(0)).await,
+                    "a send into a closed channel must fail (A stopped consuming)"
+                );
+            }
+            assert_eq!(
+                tracker.last_issued(),
+                0,
+                "the failed send rolled the reservation back — no gap burned"
+            );
+
+            // A fresh open channel: the next allocation REUSES the freed number.
+            let (tx2, mut rx2) = mpsc::channel::<ForwardedStreamFrame>(1);
+            assert!(
+                forward_frame(&tx2, &mut tracker, &data_chunk(0)).await,
+                "the retry send on a fresh channel must succeed"
+            );
+            let frame = rx2.recv().await.expect("frame delivered on the retry");
+            assert_eq!(
+                frame.base_sequence, 1,
+                "the rolled-back sequence (1) is reused on the next allocation — no gap"
+            );
+            assert_eq!(tracker.last_issued(), 1, "high-water mark committed at 1");
+        }
+
+        /// AC5 — the SAME-CONTEXT stream path is UNCHANGED: `invoke_outlet`
+        /// still returns a BARE `mpsc::Receiver<OutletStreamChunk>` with NO
+        /// `base_sequence` frame wrapper (allocate-at-consumption applies ONLY
+        /// to the cross-context hop where the gap-detector is load-bearing).
+        /// Compile-level proof: the explicit annotation fails to compile if the
+        /// same-context return type drifts to a frame. The existing
+        /// same-context runtime drain tests are the behavioural regression.
+        #[allow(dead_code)]
+        async fn out044_same_context_returns_bare_chunks(
+            context: &ContextHandle,
+            registry: &OutletRegistry,
+            role_state: &ContextRoleState,
+            outlet_id: &OutletId,
+            invoker_did: &DID,
+        ) {
+            let out: Result<mpsc::Receiver<OutletStreamChunk>, InvocationError> =
+                invoke_outlet::<NoopExecutor>(
+                    context,
+                    registry,
+                    role_state,
+                    outlet_id,
+                    serde_json::json!({}),
+                    invoker_did,
+                    None,
+                    Arc::new(NoopExecutor),
+                    None,
+                    None,
+                    None,
+                    None,
+                    [0u8; 32],
+                )
+                .await;
+            drop(out);
         }
     }
 

--- a/crates/scp-runtime/src/context/outlets_helpers.rs
+++ b/crates/scp-runtime/src/context/outlets_helpers.rs
@@ -492,12 +492,19 @@ impl std::fmt::Debug for OutletEconomyReservation {
 /// mid-stream.
 ///
 /// The per-sender MLS send-sequence (`base_sequence`) is deliberately NOT
-/// carried here: it is allocated at the point of consumption by the
-/// transport/FFI send path (allocate-at-consumption), never at open. A
-/// rollback-in-place of a pre-allocated sequence across the off-mailbox pump
-/// window would corrupt a DIFFERENT message's sequence — the LIFO
+/// carried here: it is allocated at the point of consumption on the send path
+/// (allocate-at-consumption), never at open. A rollback-in-place of a
+/// pre-allocated sequence across the off-mailbox pump window would corrupt a
+/// DIFFERENT message's sequence — the actor's LIFO
 /// [`rollback_sequence_number`](scp_protocol::context::membership::MembershipState::rollback_sequence_number)
-/// `saturating_sub` is not request-scoped — so the allocation is deferred.
+/// `saturating_sub` is not request-scoped, and the off-mailbox bridge cannot
+/// reach the actor's `PerContextState` `send_tracker` under ADR-049 isolation —
+/// so the allocation is deferred to consumption. The cross-context send path
+/// fills this hole (SCP-OUT-044) with a task-scoped `SendSequenceTracker` +
+/// ADR-049 §8 `SequenceReservation` guard in `forward_frame` (which stamps the
+/// anchor onto a
+/// [`ForwardedStreamFrame`](crate::context::outlets::invoke::ForwardedStreamFrame));
+/// see `run_cross_context_bridge`.
 #[must_use = "a StreamEconomyReservation debits open-time escrow and must be settled or reversed at stream close — dropping leaks the held reservation"]
 pub struct StreamEconomyReservation {
     /// Context handle snapshot — the off-mailbox pump reads lifecycle state
@@ -1070,11 +1077,15 @@ pub async fn reserve_outlet_economy(
 /// 1. **Membership gate** — the invoker must be on the §9.8.5 membership
 ///    roster ([`MembershipState::contains`](scp_protocol::context::membership::MembershipState::contains));
 ///    a non-member has no per-sender stream state and is rejected. The
-///    per-sender `base_sequence` is NOT allocated here — the transport/FFI
-///    send path allocates it at the point of consumption
-///    (allocate-at-consumption), because a rollback-in-place across the
-///    off-mailbox pump window would corrupt a DIFFERENT message's sequence
-///    (the LIFO `saturating_sub` is not request-scoped).
+///    per-sender `base_sequence` is NOT allocated here — the send path
+///    allocates it at the point of consumption (allocate-at-consumption),
+///    because a rollback-in-place across the off-mailbox pump window would
+///    corrupt a DIFFERENT message's sequence (the actor's LIFO
+///    `saturating_sub` is not request-scoped, and the off-mailbox bridge
+///    cannot reach the actor `send_tracker` under ADR-049 isolation). The
+///    cross-context send path fills this hole (SCP-OUT-044) with a
+///    task-scoped `SendSequenceTracker` in `forward_frame` /
+///    `run_cross_context_bridge`.
 /// 2. **Open-time escrow** — a faithful port of the reference
 ///    `outlet_stream_reserve_escrow`: `reserved = cost_per_chunk ×
 ///    estimated_chunk_count` (checked; overflow → `EscrowOverflow`), gated
@@ -1155,12 +1166,16 @@ pub async fn reserve_outlet_stream_economy(
     // --- Membership gate (Class-C membership roster, §9.8.5). A non-member has
     // no per-sender stream state — reject (rolling back the velocity tick +
     // hard-rate token consumed above). The per-sender `base_sequence` is NOT
-    // allocated here: the transport/FFI send path allocates it at the point of
-    // consumption (allocate-at-consumption). Holding a pre-allocated sequence
-    // across the off-mailbox pump window and rolling it back in place would
-    // corrupt a DIFFERENT message's sequence — the LIFO `saturating_sub` in
-    // `rollback_sequence_number` is not request-scoped — so the allocation is
-    // deferred rather than reserved-and-rolled-back.
+    // allocated here: the send path allocates it at the point of consumption
+    // (allocate-at-consumption). Holding a pre-allocated sequence across the
+    // off-mailbox pump window and rolling it back in place would corrupt a
+    // DIFFERENT message's sequence — the actor's LIFO `saturating_sub` in
+    // `rollback_sequence_number` is not request-scoped, and the off-mailbox
+    // bridge cannot reach the actor `send_tracker` under ADR-049 isolation — so
+    // the allocation is deferred to consumption. The cross-context send path
+    // fills this hole (SCP-OUT-044): a task-scoped `SendSequenceTracker` +
+    // ADR-049 §8 `SequenceReservation` in `forward_frame` /
+    // `run_cross_context_bridge`.
     let invoker_did_str = invoker_did.to_string();
     if !cell
         .class_c_view()

--- a/crates/scp-runtime/src/context/supervisor/supervisor.rs
+++ b/crates/scp-runtime/src/context/supervisor/supervisor.rs
@@ -11211,10 +11211,11 @@ impl Supervisor {
     /// The reserve allocates NO per-sender MLS send-sequence. Per §5.4.5 the
     /// pump's per-chunk cursor starts at `0` per `request_id` (`invoke.rs`
     /// "sequence starts at 0"), a DISTINCT counter from the message
-    /// send-sequence, so nothing here reads a `base_sequence`. The per-sender
-    /// send-sequence is allocated at the point of consumption by the
-    /// transport/FFI send path (the later FFI/transport wiring chunk) —
-    /// allocate-at-consumption — never pre-reserved at open, because a
+    /// send-sequence, so nothing here reads a `base_sequence`. This same-context
+    /// path allocates NO `base_sequence` at all: the per-sender send-sequence
+    /// anchor is reserved at the point of consumption only on the CROSS-context
+    /// send hop, where the reassembly gap-detector is load-bearing (SCP-OUT-044,
+    /// `invoke::forward_frame`) — never pre-reserved at open, because a
     /// rollback-in-place across the off-mailbox pump window would corrupt a
     /// DIFFERENT message's sequence.
     ///
@@ -11478,11 +11479,16 @@ impl Supervisor {
     /// the same-context [`open_outlet_stream`](Self::open_outlet_stream)), and
     /// records A's own `OutletInvoked` at close over its independently
     /// reassembled chunk sequence. Returns A's plaintext
-    /// `mpsc::Receiver<OutletStreamChunk>` PROMPTLY (the caller consumes chunks
-    /// as produced); re-encryption for A's OTHER members is the SDK delivery
-    /// seam (seal each still-operator-signed chunk under A's MLS group key over
-    /// the existing §9.8/§9.16 transport — no new relay primitive), NOT this
-    /// return type.
+    /// `mpsc::Receiver<ForwardedStreamFrame>` PROMPTLY (the caller consumes
+    /// frames as produced); each
+    /// [`ForwardedStreamFrame`](crate::context::outlets::invoke::ForwardedStreamFrame)
+    /// carries the per-sender MLS `base_sequence` anchor allocated at consumption
+    /// on the send hop (SCP-OUT-044) alongside the unmodified operator-signed
+    /// chunk, threading `(request_id, base_sequence)` to the SCP-OUT-045
+    /// gap-detector. Re-encryption for A's OTHER members is the SDK delivery
+    /// seam (seal each still-operator-signed `frame.chunk` under A's MLS group
+    /// key over the existing §9.7/§9.8/§9.16 transport — no new relay primitive),
+    /// NOT this return type.
     ///
     /// Zero-escrow (§5.4.5 "Cross-context economy"; ADR-061): a paid Action
     /// outlet (`cost.amount > 0`) — or a positive billed `cost_per_chunk` — is
@@ -11521,7 +11527,7 @@ impl Supervisor {
         caveat_binding: Option<crate::context::outlets_helpers::InvocationCaveatBinding>,
         params: crate::context::outlets::dispatch::OpenStreamParams,
     ) -> Result<
-        tokio::sync::mpsc::Receiver<scp_protocol::context::outlets::stream::OutletStreamChunk>,
+        tokio::sync::mpsc::Receiver<crate::context::outlets::invoke::ForwardedStreamFrame>,
         crate::context::outlets::invoke::InvocationError,
     >
     where
@@ -29532,9 +29538,11 @@ mod open_outlet_stream_tests {
         let executor: Arc<dyn OutletExecutor> = Arc::new(FiniteStreamExecutor);
         let outlet_id: OutletId = "calculator".to_owned();
 
-        // The Ok variant is a PLAINTEXT `mpsc::Receiver<OutletStreamChunk>`.
+        // The Ok variant is a PLAINTEXT `mpsc::Receiver<ForwardedStreamFrame>`:
+        // each frame pairs the plaintext operator-signed chunk with the
+        // per-sender `base_sequence` anchor (SCP-OUT-044).
         let mut rx: tokio::sync::mpsc::Receiver<
-            scp_protocol::context::outlets::stream::OutletStreamChunk,
+            crate::context::outlets::invoke::ForwardedStreamFrame,
         > = supervisor
             .open_outlet_stream_cross_context(
                 a_ctx,
@@ -29553,11 +29561,24 @@ mod open_outlet_stream_tests {
             .expect("zero-cost cross-context open must be accepted");
 
         // Drain the plaintext chunks the bridge forwards to the shared-member
-        // invoker: two Data payloads followed by a terminal End.
+        // invoker: two Data payloads followed by a terminal End. Each frame also
+        // carries the per-sender `base_sequence` anchor (SCP-OUT-044); assert it
+        // is strictly `+1`-monotone across the whole forwarded stream to prove
+        // the anchor is threaded end-to-end through the supervisor path (AC4).
         let mut data = 0u32;
         let mut saw_end = false;
-        while let Some(chunk) = rx.recv().await {
-            match chunk.payload {
+        let mut expected_base_sequence = 1u64;
+        while let Some(frame) = rx.recv().await {
+            assert_eq!(
+                frame.base_sequence, expected_base_sequence,
+                "base_sequence is per-sender +1-monotone across the forwarded stream"
+            );
+            assert_eq!(
+                frame.chunk.request_id, [CTX_BYTE; 16],
+                "(request_id, base_sequence) anchor is threaded onto the forwarded frame"
+            );
+            expected_base_sequence += 1;
+            match frame.chunk.payload {
                 ChunkPayload::Data { .. } => data += 1,
                 ChunkPayload::End { .. } => {
                     saw_end = true;


### PR DESCRIPTION
## SCP-OUT-044 — Per-sender `base_sequence` at consumption on the xctx send path

Wires the per-sender MLS send-sequence anchor (`base_sequence`) onto the cross-context outlet-stream bridge, filling the deliberately-deferred allocate-at-consumption hole documented in `outlets_helpers.rs`. The anchor is what the authoritative cross-context reassembly gap-detector (SCP-OUT-045) keys on.

### Design
`base_sequence` rides a **runtime-only** wrapper `ForwardedStreamFrame { base_sequence: u64, chunk: OutletStreamChunk }` on the bridge's in-process outer channel — it is **not** a field of the operator-signed `OutletStreamChunk`. Adding a field there would diverge A's independently-recomputed manifest root (`compute_chunk_leaf_hash` JCS-hashes the entire chunk, and A's verified append wire-rejects any manifest-root mismatch against B's committed manifest) and change the FFI-conformance wire type. `reassembled` stays `Vec<OutletStreamChunk>`, so A's manifest recomputation is byte-identical to SCP-OUT-036.

Allocation is a **task-scoped `SendSequenceTracker`** + the ADR-049 §8 `SequenceReservation` RAII guard in a single `forward_frame` helper (reserve at consumption → commit on successful send → `Drop` rolls back on early return, so no send-sequence gap is burned). A task-scoped tracker is precisely the request-scoped allocator the actor's LIFO rollback couldn't be — the off-mailbox bridge cannot reach the actor's `PerContextState` under ADR-049 isolation.

### Acceptance criteria — all 6 met
1. Allocated at consumption via `SequenceReservation` on the xctx send hop (`forward_frame`, invoke.rs) — no longer only the "NOT allocated here" comments.
2. Per-sender monotone `u64`, strict `+1`/chunk — `out044_forward_frame_allocates_monotone_base_sequence` asserts `[1,2,3,4,5]`.
3. RAII rollback frees the number on early return — `out044_forward_frame_rolls_back_on_send_failure_and_reuses_sequence` proves reuse.
4. `(request_id, base_sequence)` exposed to the 045 gap-detector via the frame; supervisor integration test asserts end-to-end threading.
5. Same-context path unchanged (still returns bare `Receiver<OutletStreamChunk>`) — compile-proof + existing drain tests pass untouched.
6. `cargo test -p scp-runtime` succeeds.

### Review
Full-roster local review to double-zero: bug-catcher (no bugs — RAII rollback, all six send sites threaded, no manifest leak, all drain sites updated), completionist (COMPLETE, un-gamed, protocol wire untouched), simplifier (clean, no BLOCKER), api-design (APPROVED). Applied doc-hardening: `base_sequence` documented as a **gap-detection anchor, NOT an MLS AEAD sequence input** (closing a latent misuse trap for the 045/047 consumer), fixed a mismatched intra-doc link, updated stale same-context provenance, harmonized a transport ref. Second pass confirmed doc accuracy — zero findings.

### Verification
`cargo fmt --check` ✓ · full-feature clippy `-D warnings` ✓ · nextest `--workspace` all-features **10603/10603** ✓ · check-cross-layer ✓ (pub struct + private fn, no new pub fn) · error-codes (3355) ✓ · handler-no-panic ✓ · validate-prd (437) ✓ · `crates/scp-protocol/` diff empty (no wire change).

Part of slice 3 (cross-context streaming saga). Story DAG: 036 → **044**+046 → 045 → 047 → 048 → 049.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
