### PR TITLE
chore(build): dev/test profile emits line-tables-only debug info

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -118,6 +118,45 @@ too_many_arguments = "deny"
 # sync-bridge enforcement.
 await_holding_lock = "deny"
 
+# ── Dev/test profile ────────────────────────────────────────────────────────
+# Dev/test builds emit line-tables-only debug info instead of the cargo default
+# full DWARF (`debug = 2`). Every compiled artifact keeps its line table (so
+# panic/backtrace frames still resolve to `file:line:col` — what tests and CI
+# need) but drops the bulky variable/type DWARF that only an interactive
+# debugger consumes.
+#
+# MEASURED on this 24-member workspace, two clean from-scratch builds of
+# `cargo build --workspace --all-targets` with the CI feature set, isolated
+# CARGO_TARGET_DIRs, identical unit graphs (572 rlibs / 887 fingerprints each,
+# macOS/aarch64, rustc 1.97.1):
+#
+#     debug = 2 (cargo default) ... 25.65 GB target/   (deps 16.5 GB)
+#     debug = "line-tables-only" .. 18.95 GB target/   (deps 11.4 GB)
+#     ------------------------------------------------------------------
+#     saved ....................... 6.70 GB per clean pass = 26% total,
+#                                   31% of debug/deps, 38% of rlib bytes
+#
+# That is one target dir, one feature combination. The cost scales with every
+# additional feature-hash rebuild and every worktree sharing the build cache.
+#
+# TRADE-OFF (the honest one): `file:line:col` is preserved exactly, but a
+# backtrace frame loses its DWARF-derived crate-qualified name and falls back
+# to the linkage symbol — `deep at src/main.rs:4:5` instead of
+# `bt_probe[hash]::deep at src/main.rs:4:5`. Local variables are not
+# inspectable in lldb/gdb. Anyone who needs either can override
+# per-invocation: `RUSTFLAGS="-C debuginfo=2" cargo test ...`.
+#
+# NOT load-bearing for the `[profile.release]` guarantee below: this key sets
+# debug-info VERBOSITY only. It does not touch `debug-assertions`, codegen, or
+# behavior — dev/test builds keep `debug-assertions = true`, so the openmls
+# `debug_assert!` still fires under `cargo test` exactly as before. The `fuzz/`
+# crate is a standalone non-member with its own `[profile.release]` and is
+# unaffected.
+#
+# `test` and `bench` inherit `dev`, so `cargo test`/`cargo nextest` are covered.
+[profile.dev]
+debug = "line-tables-only"
+
 # ── Release profile ─────────────────────────────────────────────────────────
 # `debug-assertions = false` is the cargo release DEFAULT — this line changes no
 # behavior; it makes an otherwise-implicit invariant EXPLICIT and greppable.


### PR DESCRIPTION
## What

Adds a `[profile.dev]` section to the workspace root `Cargo.toml`:

```toml
[profile.dev]
debug = "line-tables-only"
```

`test` and `bench` inherit `dev`, so `cargo test` / `cargo nextest` are covered.

## Why

Cargo's default dev profile emits **full DWARF** (`debug = 2`) into every compiled artifact. On this 24-member crypto-heavy workspace — built with `--all-targets` across several feature combinations, and shared across ~150 git worktrees via a common `CARGO_TARGET_DIR` — that debug info is the single largest contributor to build-cache size. The shared cache is currently **287 GB** on a disk at 93% capacity.

`debug = "line-tables-only"` keeps the line table (panic and backtrace frames still resolve to `file:line:col`, which is what tests and CI consume) and drops the variable/type DWARF that only an interactive debugger reads. Stable since Rust 1.71; toolchain here is 1.97.1.

## Measured (re-measured 2026-08-09, not estimated)

Two clean from-scratch runs of `cargo build --workspace --all-targets` with the CI feature set, into isolated `CARGO_TARGET_DIR`s, with **identical unit graphs** (572 rlibs / 887 fingerprint entries each). macOS/aarch64, rustc 1.97.1. Baseline reproduced via `CARGO_PROFILE_DEV_DEBUG=2`, which is exactly cargo's default.

| | `debug = 2` (cargo default) | `debug = "line-tables-only"` | saved |
|---|---|---|---|
| **`target/` total** | **25.65 GB** | **18.95 GB** | **6.70 GB (26%)** |
| `debug/deps` | 16.50 GB | 11.43 GB | 5.07 GB (31%) |
| `.rlib` bytes only | 3.15 GB | 1.94 GB | 1.21 GB (38%) |
| `debug/incremental` | 9.15 GB | 6.53 GB | 2.62 GB (29%) |

That is **one** target dir at **one** feature combination. The cost scales with every additional feature-hash rebuild and every worktree sharing the cache.

### Correction to the original description

The version of this PR opened on 2026-07-16 claimed the change "roughly halves `target/`". **That claim is not supported by measurement — the real figure is 26% of total `target/`.** The claim has been removed from both the PR body and the in-file comment. 26% still earns its keep decisively (≈75 GB against the current 287 GB shared cache), but the number needed to be honest.

## Backtrace quality — verified empirically, not assumed

Built the same program twice and compared `RUST_BACKTRACE=full` output:

```
debug = 2            16: bt_probe[c0c434f465a34dbc]::deep
                             at /…/src/main.rs:4:5
line-tables-only     16: deep
                             at /…/src/main.rs:4:5
```

- **`file:line:col` is preserved exactly.** So is the `panicked at src/main.rs:4:5` header (that comes from `#[track_caller]`, not from debuginfo). `ci.yml` sets `RUST_BACKTRACE: 1`, and that output stays useful.
- **What is actually lost:** the frame's DWARF-derived crate-qualified name falls back to the linkage symbol (`deep` rather than `bt_probe[hash]::deep`), and local variables are not inspectable in lldb/gdb.
- Both are recovered per-invocation with `RUSTFLAGS="-C debuginfo=2" cargo test ...`.

Nothing in the repo consumes backtraces programmatically (`grep` for `std::backtrace` / `Backtrace::capture` across `crates/` returns zero hits), and nothing references `dSYM`, `lldb`, or `split-debuginfo`.

## Safety

- **No behaviour change.** This key sets debug-info *verbosity* only — not codegen, not `debug-assertions`.
- The `[profile.release]` `debug-assertions = false` guarantee added since this PR was opened (ADR-057 §Prereq-4, openmls decrypt-path) is **untouched**. Dev/test builds keep `debug-assertions = true`, so the openmls `debug_assert!` still fires under `cargo test` exactly as before.
- `fuzz/` is a standalone non-member with its own `[profile.release]` — unaffected.
- `scripts/check-no-panic-abort.sh` (the only profile-aware gate) passes, including its self-test.

## Verification run locally

- `cargo fmt --all -- --check` — clean
- `cargo metadata` — manifest parses
- CI clippy string (`ci.yml:504`), all features, `-D warnings` — **0 warnings**
- `cargo clippy -p scp-transport --features quic,http3,udp,coap --all-targets -- -D warnings` (`ci.yml:511`) — clean
- `cargo nextest run --workspace` + full CI feature set — **11014 passed, 0 failed**, 42 skipped
- `cargo nextest run -p scp-transport --features quic,http3,udp,coap` (`ci.yml:570`) — 920 passed
- `cargo nextest run -p scp-testing --features sqlite --test saga_bridge_journal_swap` (`ci.yml:581`) — 6 passed
- All 26 `scripts/check-*.{sh,py}` gates — pass, self-tests included

## Follow-on lever (not in this PR)

`debug/incremental` is 6.53 GB of the 18.95 GB post-change target dir (34%). Incremental compilation pays off for iterative editing but is pure write-only waste for one-shot CI-mirror builds. `build-matrix.yml` already sets `CARGO_INCREMENTAL: 0`; `ci.yml` does not. Applying both levers together would take a clean pass from 25.65 GB to ~12.4 GB — *that* is the real "roughly halves". Deliberately kept out of this PR so it stays a single atomic change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
