### PR TITLE
refactor(pseudonym): extract §9.10.4 pseudonym logic into wasm-safe scp-protocol::context::pseudonym (ADR-057 T-1)

### DIFF
--- a/.docs/specs/25-test-vectors.md
+++ b/.docs/specs/25-test-vectors.md
@@ -807,6 +807,46 @@ Expected v2 pseudonym public key (epoch = 1):
 
 These vectors are mechanically enforced by the Rust known-answer test `derive_pseudonym_keypair_known_answer_vectors` in `crates/scp-platform/src/pseudonym.rs`.
 
+### Vector 36: `PseudonymAnnouncement` wire format + classifier decisions (§9.10.4)
+
+These vectors pin the on-the-wire **pseudonym announcement** — the `MessagePack` payload a member broadcasts on the shared bootstrap channel to teach peers their per-context routing ID — and the pure §9.10.4 accept/reject classifier that both the native orchestrator and the in-browser client run over an inbound announcement. Because the announcement type and the classifier live in the wasm-safe `scp-protocol::context::pseudonym` module (ADR-057 T-1), native and `wasm32` MUST produce byte-identical wire bytes and identical accept/reject decisions.
+
+**Wire format.** `PseudonymAnnouncement` is serialized with `rmp_serde::to_vec_named` — a name-keyed `MessagePack` map with three fields, in declaration order: `tag` (string), `member_did` (string), `pseudonym` (32-byte `serde_bytes` binary). No `usize`, no float, no map-iteration order, so a fixed value re-encodes deterministically and target-independently.
+
+```
+Input:
+  tag:        "\0scp:pseudonym-announce:v1"   (PSEUDONYM_ANNOUNCEMENT_TAG, 26 bytes, NUL-prefixed)
+  member_did: "did:dht:z6MkPseudonymKatFixtureMemberAAAAAAAAAAAAAA"  (51 bytes)
+  pseudonym:  0x42 × 32
+
+MessagePack layout:
+  0x83                                   fixmap, 3 entries
+  0xa3 "tag"                             key
+  0xba <26 bytes>  "\0scp:pseudonym-announce:v1"   str8 value (NUL-prefixed magic tag)
+  0xaa "member_did"                      key
+  0xd9 0x33 <51 bytes> "did:dht:z6Mk…AA"  str8 value
+  0xa9 "pseudonym"                        key
+  0xc4 0x20 <32 bytes> 0x42×32            bin8 value (serde_bytes)
+
+Expected bytes (hex, single continuous string):
+  83a3746167ba007363703a70736575646f6e796d2d616e6e6f756e63653a7631aa6d656d6265725f646964d9336469643a6468743a7a364d6b50736575646f6e796d4b6174466978747572654d656d6265724141414141414141414141414141a970736575646f6e796dc4204242424242424242424242424242424242424242424242424242424242424242
+```
+
+**Classifier decisions.** `classify_pseudonym_announcement(plaintext, sender_did, context_id, registry)` returns a `PseudonymAnnouncementDecision` over the four-step §9.10.4 validation. The reject `reason` strings are stable `&'static str`s and are part of this vector — a change to any is wire-observable:
+
+| Case | `sender_did` | payload / registry | Decision | `reason` |
+|------|--------------|--------------------|----------|----------|
+| ordinary app data | member | `b"hello world"` / `Some({})` | `NotAnnouncement` | — |
+| legitimate announce | member | golden announce (member, `0x42×32`) / `Some({})` | `Accept { member, 0x42×32 }` | — |
+| sender mismatch | member | announce claims `other` / `Some({})` | `Rejected` (carries `claimed_did = other`) | `pseudonym announcement member_did does not match sender` |
+| reserved value | member | announce with `[0;32]` **or** `context_routing_id(ctx)` **or** `broadcast_routing_id(ctx)` / `Some({})` | `Rejected` | `pseudonym announcement uses a reserved routing ID` |
+| broadcast context | member | golden announce / `None` | `Rejected` | `pseudonym announcement received on broadcast context` |
+| cross-DID collision | member | golden announce / `Some({other → 0x42×32})` | `Rejected` | `pseudonym announcement collides with another member's routing ID` |
+
+where `member = "did:dht:z6MkPseudonymKatFixtureMemberAAAAAAAAAAAAAA"`, `other = "did:dht:z6MkPseudonymKatFixtureOtherBBBBBBBBBBBBBBB"`, and `ctx = "ctx-adr057-pseudonym-kat"`.
+
+This vector is mechanically enforced on BOTH native and `wasm32` by `pseudonym_wire_and_classifier_match_golden_vectors` in `crates/scp-client-wasm/tests/pseudonym_cross_target_kat.rs` (native `#[test]` + `#[wasm_bindgen_test]`, run under `wasm-pack test --node`): `native == golden` and `wasm == golden` together prove `native == wasm` (ADR-057 T-1 / Prerequisite 5). The pure predicate + classifier unit tests also live in `crates/scp-protocol/src/context/pseudonym.rs`.
+
 ## 25.20 Trust Attestation Signing Vectors (§7.4.1, §9.5.2)
 
 Domain: `"SCP-ATTESTATION-V1:"`

--- a/crates/scp-client-wasm/tests/pseudonym_cross_target_kat.rs
+++ b/crates/scp-client-wasm/tests/pseudonym_cross_target_kat.rs
@@ -3,10 +3,11 @@
 //!
 //! The §9.10.4 pseudonym logic — the [`PseudonymAnnouncement`] wire type and the
 //! pure [`classify_pseudonym_announcement`] decision core — was extracted into
-//! the wasm-safe `scp-protocol::context::pseudonym` module so the native
-//! orchestrator (`scp-runtime`) and the in-browser client driver share ONE copy
-//! (not a fork). This file is the guard that the shared code produces
-//! **byte-identical** output on both native and `wasm32`:
+//! the wasm-safe `scp-protocol::context::pseudonym` module so it is READY to be
+//! consumed verbatim by a future in-browser client driver without forking the
+//! native orchestrator's (`scp-runtime`) copy. This file is the guard that the
+//! shared code produces **byte-identical** output on both native and `wasm32`,
+//! so that a future browser call site inherits one non-forked implementation:
 //!
 //! 1. **Wire encoding.** `rmp_serde::to_vec_named` of a FIXED
 //!    [`PseudonymAnnouncement`] must equal a committed golden hex and round-trip,

--- a/crates/scp-client-wasm/tests/pseudonym_cross_target_kat.rs
+++ b/crates/scp-client-wasm/tests/pseudonym_cross_target_kat.rs
@@ -1,0 +1,213 @@
+//! Cross-target byte-parity known-answer tests for the §9.10.4 per-context
+//! pseudonym announcement (ADR-057 T-1, Prerequisite 5).
+//!
+//! The §9.10.4 pseudonym logic — the [`PseudonymAnnouncement`] wire type and the
+//! pure [`classify_pseudonym_announcement`] decision core — was extracted into
+//! the wasm-safe `scp-protocol::context::pseudonym` module so the native
+//! orchestrator (`scp-runtime`) and the in-browser client driver share ONE copy
+//! (not a fork). This file is the guard that the shared code produces
+//! **byte-identical** output on both native and `wasm32`:
+//!
+//! 1. **Wire encoding.** `rmp_serde::to_vec_named` of a FIXED
+//!    [`PseudonymAnnouncement`] must equal a committed golden hex and round-trip,
+//!    identically on both targets. The struct is a `serde` name-keyed map with a
+//!    `serde_bytes` 32-byte field — no `usize`, no float, no map iteration to
+//!    order — so a fixed value re-encodes deterministically; a width/field-order
+//!    divergence (wasm32 is 32-bit) would move it off the golden.
+//! 2. **Classifier decisions.** [`classify_pseudonym_announcement`] over a fixed
+//!    input matrix must yield an identical [`PseudonymAnnouncementDecision`] —
+//!    including the exact stable reject-reason `&'static str`s — on both targets.
+//! 3. **Reserved-value classification.** The zero-RID sentinel and BOTH derivable
+//!    reserved routing IDs (`context_routing_id`, `broadcast_routing_id`) must
+//!    classify as reserved on both targets.
+//!
+//! Every assertion lives in a helper called from BOTH a native `#[test]` and a
+//! `#[wasm_bindgen_test]`. Because both targets assert against the SAME committed
+//! constants, agreement is transitive: `native == golden` AND `wasm == golden`
+//! implies `native == wasm`. The golden wire bytes are also spec-anchored in
+//! `.docs/specs/25-test-vectors.md` §25.19.
+
+// KATs assert on fixed vectors; `expect`/`unwrap`/`panic` keep failures legible.
+#![allow(clippy::expect_used, clippy::unwrap_used, clippy::panic)]
+
+use scp_did::DID;
+use scp_protocol::context::pseudonym::{
+    PSEUDONYM_ANNOUNCEMENT_TAG, PseudonymAnnouncement, PseudonymAnnouncementDecision,
+    REJECT_BROADCAST, REJECT_COLLISION, REJECT_RESERVED, REJECT_SENDER_MISMATCH,
+    classify_pseudonym_announcement, is_reserved_pseudonym,
+};
+use scp_protocol::context::{broadcast_routing_id, context_routing_id};
+use std::collections::HashMap;
+
+#[cfg(target_arch = "wasm32")]
+use wasm_bindgen_test::wasm_bindgen_test;
+
+// ---------------------------------------------------------------------------
+// Fixed inputs (identical on every target and every run)
+// ---------------------------------------------------------------------------
+
+/// The announcer DID pinned into the golden wire blob and the classifier matrix.
+const KAT_MEMBER_DID: &str = "did:dht:z6MkPseudonymKatFixtureMemberAAAAAAAAAAAAAA";
+/// A second DID for the sender-mismatch / cross-DID-collision matrix rows.
+const KAT_OTHER_DID: &str = "did:dht:z6MkPseudonymKatFixtureOtherBBBBBBBBBBBBBBB";
+/// The context id the classifier derives reserved routing IDs against.
+const KAT_CONTEXT_ID: &str = "ctx-adr057-pseudonym-kat";
+/// A fixed, honest (non-reserved) 32-byte routing ID.
+const KAT_PSEUDONYM: [u8; 32] = [0x42u8; 32];
+
+// ---------------------------------------------------------------------------
+// Golden constants (generated natively, asserted on BOTH targets)
+// ---------------------------------------------------------------------------
+
+/// GOLDEN: `rmp_serde::to_vec_named(&PseudonymAnnouncement { tag =
+/// PSEUDONYM_ANNOUNCEMENT_TAG, member_did = KAT_MEMBER_DID, pseudonym =
+/// KAT_PSEUDONYM })`, hex-encoded. A name-keyed `MessagePack` map with a
+/// `serde_bytes` binary field — deterministic and target-independent. If this
+/// moves, the wire format changed (a spec-observable event, §25.19), not a
+/// refactor.
+const GOLDEN_PSEUDONYM_ANNOUNCEMENT_HEX: &str = "83a3746167ba007363703a70736575646f6e796d2d616e6e6f756e63653a7631aa6d656d6265725f646964d9336469643a6468743a7a364d6b50736575646f6e796d4b6174466978747572654d656d6265724141414141414141414141414141a970736575646f6e796dc4204242424242424242424242424242424242424242424242424242424242424242";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/// Lowercase hex without external deps (the KAT must build for wasm32).
+fn to_hex(bytes: &[u8]) -> String {
+    const HEX: &[u8; 16] = b"0123456789abcdef";
+    let mut s = String::with_capacity(bytes.len() * 2);
+    for &b in bytes {
+        s.push(HEX[(b >> 4) as usize] as char);
+        s.push(HEX[(b & 0x0f) as usize] as char);
+    }
+    s
+}
+
+fn announcement_bytes(member_did: &str, pseudonym: [u8; 32]) -> Vec<u8> {
+    let ann = PseudonymAnnouncement {
+        tag: PSEUDONYM_ANNOUNCEMENT_TAG.to_owned(),
+        member_did: member_did.to_owned(),
+        pseudonym,
+    };
+    rmp_serde::to_vec_named(&ann).expect("serialize announcement")
+}
+
+// ---------------------------------------------------------------------------
+// The golden-vector assertion body (called from BOTH targets)
+// ---------------------------------------------------------------------------
+
+fn assert_pseudonym_cross_target_vectors() {
+    // (1) Wire encoding of the fixed announcement matches the golden + round-trips.
+    let bytes = announcement_bytes(KAT_MEMBER_DID, KAT_PSEUDONYM);
+    assert_eq!(
+        to_hex(&bytes),
+        GOLDEN_PSEUDONYM_ANNOUNCEMENT_HEX,
+        "PseudonymAnnouncement wire encoding diverged from the golden vector \
+         (cross-target width/field-order change or a wire-format change)"
+    );
+    let decoded: PseudonymAnnouncement =
+        rmp_serde::from_slice(&bytes).expect("golden announcement round-trips");
+    assert_eq!(decoded.tag, PSEUDONYM_ANNOUNCEMENT_TAG);
+    assert_eq!(decoded.member_did, KAT_MEMBER_DID);
+    assert_eq!(decoded.pseudonym, KAT_PSEUDONYM);
+
+    // (2) Classifier decision matrix — identical decisions + exact reason strings.
+    let empty: HashMap<DID, [u8; 32]> = HashMap::new();
+
+    // NotAnnouncement: ordinary app data.
+    assert_eq!(
+        classify_pseudonym_announcement(
+            b"hello world",
+            KAT_MEMBER_DID,
+            KAT_CONTEXT_ID,
+            Some(&empty)
+        ),
+        PseudonymAnnouncementDecision::NotAnnouncement,
+    );
+
+    // Accept: legitimate announcement (sender == member, honest RID, no collision).
+    assert_eq!(
+        classify_pseudonym_announcement(&bytes, KAT_MEMBER_DID, KAT_CONTEXT_ID, Some(&empty)),
+        PseudonymAnnouncementDecision::Accept {
+            member_did: DID(KAT_MEMBER_DID.to_owned()),
+            pseudonym: KAT_PSEUDONYM,
+        },
+    );
+
+    // Rejected (sender mismatch): the payload claims KAT_OTHER_DID but the
+    // authenticated sender is KAT_MEMBER_DID; carries the claimed DID.
+    let forged = announcement_bytes(KAT_OTHER_DID, KAT_PSEUDONYM);
+    assert_eq!(
+        classify_pseudonym_announcement(&forged, KAT_MEMBER_DID, KAT_CONTEXT_ID, Some(&empty)),
+        PseudonymAnnouncementDecision::Rejected {
+            reason: REJECT_SENDER_MISMATCH,
+            claimed_did: Some(DID(KAT_OTHER_DID.to_owned())),
+        },
+    );
+
+    // Rejected (broadcast context): no registry.
+    assert_eq!(
+        classify_pseudonym_announcement(&bytes, KAT_MEMBER_DID, KAT_CONTEXT_ID, None),
+        PseudonymAnnouncementDecision::Rejected {
+            reason: REJECT_BROADCAST,
+            claimed_did: None,
+        },
+    );
+
+    // Rejected (cross-DID collision): KAT_OTHER_DID already owns KAT_PSEUDONYM.
+    let mut registry: HashMap<DID, [u8; 32]> = HashMap::new();
+    registry.insert(DID(KAT_OTHER_DID.to_owned()), KAT_PSEUDONYM);
+    assert_eq!(
+        classify_pseudonym_announcement(&bytes, KAT_MEMBER_DID, KAT_CONTEXT_ID, Some(&registry)),
+        PseudonymAnnouncementDecision::Rejected {
+            reason: REJECT_COLLISION,
+            claimed_did: None,
+        },
+    );
+
+    // (3) Reserved-value classification: the zero sentinel + both derivable
+    // reserved routing IDs classify as reserved; via the classifier they reject
+    // with REJECT_RESERVED. An honest RID is not reserved.
+    assert!(is_reserved_pseudonym(&[0u8; 32], KAT_CONTEXT_ID));
+    assert!(is_reserved_pseudonym(
+        &context_routing_id(KAT_CONTEXT_ID),
+        KAT_CONTEXT_ID
+    ));
+    assert!(is_reserved_pseudonym(
+        &broadcast_routing_id(KAT_CONTEXT_ID),
+        KAT_CONTEXT_ID
+    ));
+    assert!(!is_reserved_pseudonym(&KAT_PSEUDONYM, KAT_CONTEXT_ID));
+
+    for reserved in [
+        [0u8; 32],
+        context_routing_id(KAT_CONTEXT_ID),
+        broadcast_routing_id(KAT_CONTEXT_ID),
+    ] {
+        let reserved_bytes = announcement_bytes(KAT_MEMBER_DID, reserved);
+        assert_eq!(
+            classify_pseudonym_announcement(
+                &reserved_bytes,
+                KAT_MEMBER_DID,
+                KAT_CONTEXT_ID,
+                Some(&empty)
+            ),
+            PseudonymAnnouncementDecision::Rejected {
+                reason: REJECT_RESERVED,
+                claimed_did: None,
+            },
+        );
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Native + wasm entry point
+// ---------------------------------------------------------------------------
+
+/// Pseudonym cross-target byte-parity KAT. Runs natively (proving determinism
+/// vs. the committed vectors) and under `wasm-pack test --node` (proving
+/// byte-equality across targets — ADR-057 T-1 / Prerequisite 5).
+#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
+#[cfg_attr(not(target_arch = "wasm32"), test)]
+fn pseudonym_wire_and_classifier_match_golden_vectors() {
+    assert_pseudonym_cross_target_vectors();
+}

--- a/crates/scp-protocol/src/context/mod.rs
+++ b/crates/scp-protocol/src/context/mod.rs
@@ -21,6 +21,7 @@ pub mod outlets;
 pub mod params;
 pub mod policy;
 pub mod promotion;
+pub mod pseudonym;
 pub mod roles;
 pub mod state_machine;
 pub mod templates;

--- a/crates/scp-protocol/src/context/pseudonym.rs
+++ b/crates/scp-protocol/src/context/pseudonym.rs
@@ -1,0 +1,498 @@
+//! Per-context pseudonym-announcement wire type + the pure §9.10.4 validation
+//! core (ADR-057 T-1).
+//!
+//! This is the single, wasm-safe home for the §9.10.4 per-context-pseudonym
+//! logic that the relay/MLS routing layer uses to learn peers' routing IDs. It
+//! carries NO async, NO transport, and NO platform dependency, so it compiles
+//! to `wasm32-unknown-unknown` and is shared VERBATIM by the native
+//! orchestrator (`scp-runtime`) and the in-browser client driver — one copy,
+//! never a fork, so the two targets cannot drift on the wire format or the
+//! accept/reject decision (ADR-057 "share, don't fork").
+//!
+//! The module owns three things:
+//! 1. the [`PseudonymAnnouncement`] wire struct + its [`PSEUDONYM_ANNOUNCEMENT_TAG`]
+//!    magic tag (the `MessagePack` bootstrap payload members broadcast to teach
+//!    peers their routing ID),
+//! 2. the pure predicates [`is_pseudonym_announcement_payload`],
+//!    [`is_reserved_pseudonym`], and [`pseudonym_collides_with_other_did`], and
+//! 3. the pure decision core [`classify_pseudonym_announcement`], which folds the
+//!    four-step ingest validation into a single [`PseudonymAnnouncementDecision`]
+//!    that each host maps to its own side effects (native: metric + `tracing`
+//!    warn + registry insert + event emit; browser: the equivalent driver hooks).
+//!
+//! The reject-reason strings ([`REJECT_SENDER_MISMATCH`] et al.) are stable
+//! `&'static str`s that are part of the committed cross-target known-answer
+//! vectors (`.docs/specs/25-test-vectors.md` §25.19) — changing one is a
+//! wire-observable change, not a refactor.
+
+use std::collections::HashMap;
+
+use scp_did::DID;
+use serde::{Deserialize, Serialize};
+
+use super::{broadcast_routing_id, context_routing_id};
+
+/// Wire format for pseudonym announcements sent as MLS application messages.
+///
+/// When a member joins or creates a context with a pre-derived pseudonym,
+/// they announce it to other members via this structure serialized with
+/// `MessagePack`. Recipients store the mapping in their pseudonym registry.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct PseudonymAnnouncement {
+    /// Magic prefix to distinguish from regular application messages.
+    pub tag: String,
+    /// The announcing member's DID.
+    pub member_did: String,
+    /// The 32-byte pseudonym routing ID.
+    #[serde(with = "serde_bytes")]
+    pub pseudonym: [u8; 32],
+}
+
+/// Magic tag used to identify pseudonym announcement messages in the MLS
+/// application message stream.
+///
+/// Prefixed with `\0` to avoid collision with user-generated content (which is
+/// always valid UTF-8 and will never start with a null byte when deserialized
+/// from `MessagePack`).
+pub const PSEUDONYM_ANNOUNCEMENT_TAG: &str = "\0scp:pseudonym-announce:v1";
+
+/// Classifies a send-path payload as a `PseudonymAnnouncement` (§9.10.4).
+///
+/// Announcements are the ONLY payload class permitted to use the shared
+/// `context_routing_id` as an addressee — they form the bootstrap channel
+/// peers use to learn each other's pseudonyms before regular app data can fan
+/// out on pseudonym-only paths. Returns `true` only when the payload
+/// deserializes as a well-formed `PseudonymAnnouncement` AND carries the magic
+/// tag (`PSEUDONYM_ANNOUNCEMENT_TAG`, `\0`-prefixed to avoid collision with
+/// UTF-8 user content). False positives from adversarial payloads cannot
+/// escalate: the worst outcome is a legitimate app message routed to the
+/// shared RID, which is not a confidentiality issue (MLS still gates content)
+/// and is detected as a non-announcement on the receive path.
+#[must_use]
+pub fn is_pseudonym_announcement_payload(payload: &[u8]) -> bool {
+    rmp_serde::from_slice::<PseudonymAnnouncement>(payload)
+        .is_ok_and(|a| a.tag == PSEUDONYM_ANNOUNCEMENT_TAG)
+}
+
+/// Returns `true` if `pseudonym` is a reserved routing ID a member is not
+/// permitted to announce as their own (§9.10.4).
+///
+/// The pseudonym registry maps each member's DID to the routing ID honest
+/// senders fan their app-data ciphertext out to. If a member could announce a
+/// reserved value for their own DID, they could redirect every honest sender's
+/// app-data:
+///
+/// - `[0u8; 32]` — the zero/degraded sentinel; maps to nothing meaningful.
+/// - `context_routing_id(context_id)` — the shared bootstrap RID; announcing
+///   it would push app-data ciphertext onto the shared channel, defeating
+///   unlinkability.
+/// - `broadcast_routing_id(context_id)` — the derivable `SHA-256(context_id)`
+///   broadcast RID; same leak vector.
+///
+/// Honest pseudonyms are the raw 32-byte Ed25519 public key of the member's
+/// per-context keypair (stored and routed on verbatim, NOT hashed). They
+/// collide with these reserved values only with negligible probability, so
+/// rejecting them costs nothing for legitimate members.
+#[must_use]
+pub fn is_reserved_pseudonym(pseudonym: &[u8; 32], context_id: &str) -> bool {
+    *pseudonym == [0u8; 32]
+        || *pseudonym == context_routing_id(context_id)
+        || *pseudonym == broadcast_routing_id(context_id)
+}
+
+/// Returns `true` if `pseudonym` is already registered under a DID OTHER than
+/// `announcer_did` (§9.10.4 defense-in-depth).
+///
+/// The announcement path already enforces `announcement.member_did ==
+/// sender_did`, so a member can only announce a routing ID for their own DID.
+/// This guards the remaining vector: a member claiming a routing ID an
+/// existing peer already legitimately uses, which would let two DIDs resolve
+/// to one routing ID (a relay would then receive both members' fan-out at one
+/// address, and honest senders addressing the colliding DID could misroute).
+/// A member re-announcing the SAME value for their OWN DID is legitimate (key
+/// rotation re-broadcast) and is NOT a collision.
+// The peer registry is ALWAYS the default-hasher `HashMap` the routing state
+// owns (`peer_registry()`); this pure predicate is never called with a foreign
+// hasher, so a `BuildHasher` type parameter would add an unused generic to the
+// shared cross-target API (against the agent-first "one canonical shape" tenet)
+// without any real generality. Keep the concrete signature.
+#[allow(clippy::implicit_hasher)]
+#[must_use]
+pub fn pseudonym_collides_with_other_did(
+    registry: &HashMap<DID, [u8; 32]>,
+    announcer_did: &DID,
+    pseudonym: &[u8; 32],
+) -> bool {
+    registry.iter().any(|(other_did, other_pseudonym)| {
+        other_pseudonym == pseudonym && other_did != announcer_did
+    })
+}
+
+// ---------------------------------------------------------------------------
+// Reject-reason strings (part of the cross-target KAT goldens — §25.19)
+// ---------------------------------------------------------------------------
+
+/// Reject reason: the announced `member_did` did not match the authenticated
+/// sender (forged announcement).
+///
+/// This is the ONLY reason whose [`PseudonymAnnouncementDecision::Rejected`]
+/// carries a `claimed_did`.
+pub const REJECT_SENDER_MISMATCH: &str = "pseudonym announcement member_did does not match sender";
+
+/// Reject reason: the announced pseudonym is a reserved routing ID
+/// ([`is_reserved_pseudonym`]).
+pub const REJECT_RESERVED: &str = "pseudonym announcement uses a reserved routing ID";
+
+/// Reject reason: the announcement arrived on a broadcast context, which
+/// carries no peer registry (registry `None`).
+pub const REJECT_BROADCAST: &str = "pseudonym announcement received on broadcast context";
+
+/// Reject reason: the announced pseudonym is already claimed by a DIFFERENT
+/// member ([`pseudonym_collides_with_other_did`]).
+pub const REJECT_COLLISION: &str =
+    "pseudonym announcement collides with another member's routing ID";
+
+/// Outcome of the pure §9.10.4 ingest classifier over a single inbound
+/// plaintext.
+///
+/// The classifier makes the accept/reject DECISION; it performs no side
+/// effects. Each host maps this to its own effects: the native orchestrator
+/// records a rejection metric + `tracing` warn on `Rejected`, and inserts the
+/// registry entry + emits a `PseudonymAnnounced` event on `Accept`; the browser
+/// driver runs the equivalent hooks. Because both hosts share this one decision
+/// function, they cannot diverge on which announcements are accepted.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum PseudonymAnnouncementDecision {
+    /// The plaintext is not a tagged `PseudonymAnnouncement` — the host should
+    /// deliver it as a normal application message.
+    NotAnnouncement,
+    /// The plaintext was a tagged announcement that FAILED a security check.
+    /// `reason` is one of the stable `REJECT_*` `&'static str`s; `claimed_did`
+    /// is `Some` ONLY for the [`REJECT_SENDER_MISMATCH`] branch (it carries the
+    /// forged DID so the host can reproduce the diagnostic).
+    Rejected {
+        /// The stable reject reason (one of the `REJECT_*` constants).
+        reason: &'static str,
+        /// The forged claimed DID — `Some` only on the sender-mismatch branch.
+        claimed_did: Option<DID>,
+    },
+    /// The plaintext was a well-formed announcement that passed every check.
+    /// The host should insert `member_did -> pseudonym` into its peer registry
+    /// and emit the routing-bootstrap signal.
+    Accept {
+        /// The authenticated announcer's DID (equals the sender).
+        member_did: DID,
+        /// The 32-byte routing ID to register for `member_did`.
+        pseudonym: [u8; 32],
+    },
+}
+
+/// The pure §9.10.4 pseudonym-announcement decision core (ADR-057 T-1).
+///
+/// This is the single, shared, wasm-safe validator both the native orchestrator
+/// and the browser driver run, so their accept/reject behavior cannot drift.
+///
+/// Runs the four-step validation core over an inbound `plaintext`:
+/// 1. tag-decode ([`PseudonymAnnouncementDecision::NotAnnouncement`] if the
+///    plaintext is not a tagged announcement),
+/// 2. `member_did == sender_did` (forged-announcement guard →
+///    [`REJECT_SENDER_MISMATCH`], carrying the claimed DID),
+/// 3. reserved-value rejection ([`is_reserved_pseudonym`] →
+///    [`REJECT_RESERVED`]),
+/// 4. broadcast-context reject (`registry == None` → [`REJECT_BROADCAST`]) then
+///    cross-DID collision ([`pseudonym_collides_with_other_did`] →
+///    [`REJECT_COLLISION`]); otherwise [`PseudonymAnnouncementDecision::Accept`].
+///
+/// `registry` is the caller's immutable peer registry, or `None` for a
+/// broadcast context (which carries no registry). The function performs NO
+/// side effects: it neither mutates the registry nor logs — the host owns those.
+// `registry` is ALWAYS the default-hasher peer registry the routing state owns;
+// a `BuildHasher` type parameter would leak an unused generic into this shared
+// cross-target decision API without real generality. Keep the concrete signature.
+#[allow(clippy::implicit_hasher)]
+#[must_use]
+pub fn classify_pseudonym_announcement(
+    plaintext: &[u8],
+    sender_did: &str,
+    context_id: &str,
+    registry: Option<&HashMap<DID, [u8; 32]>>,
+) -> PseudonymAnnouncementDecision {
+    // Step 1: tag-decode. A non-announcement (or untagged payload) is ordinary
+    // application data.
+    let Ok(announcement) = rmp_serde::from_slice::<PseudonymAnnouncement>(plaintext) else {
+        return PseudonymAnnouncementDecision::NotAnnouncement;
+    };
+    if announcement.tag != PSEUDONYM_ANNOUNCEMENT_TAG {
+        return PseudonymAnnouncementDecision::NotAnnouncement;
+    }
+
+    // Step 2: the announced DID must match the authenticated sender. A member
+    // can only announce a routing ID for their OWN DID. Carry the claimed DID
+    // so the host can reproduce the forged-announcement diagnostic.
+    if announcement.member_did != sender_did {
+        return PseudonymAnnouncementDecision::Rejected {
+            reason: REJECT_SENDER_MISMATCH,
+            claimed_did: Some(DID(announcement.member_did)),
+        };
+    }
+
+    let announced_did = DID(announcement.member_did);
+
+    // Step 3: reject reserved pseudonym VALUES before touching the registry.
+    // Announcing the zero sentinel, the shared bootstrap RID, or the broadcast
+    // RID for one's own DID would redirect every honest sender's app-data
+    // fan-out, defeating unlinkability or leaking ciphertext onto the shared
+    // channel.
+    if is_reserved_pseudonym(&announcement.pseudonym, context_id) {
+        return PseudonymAnnouncementDecision::Rejected {
+            reason: REJECT_RESERVED,
+            claimed_did: None,
+        };
+    }
+
+    // Step 4: registry updates are meaningful only for encrypted contexts. A
+    // broadcast context carries no peer registry — reject as a spec-level
+    // violation. Otherwise reject a routing ID already claimed by a DIFFERENT
+    // member (same-DID re-announce for key rotation stays allowed), then accept.
+    let Some(registry) = registry else {
+        return PseudonymAnnouncementDecision::Rejected {
+            reason: REJECT_BROADCAST,
+            claimed_did: None,
+        };
+    };
+    if pseudonym_collides_with_other_did(registry, &announced_did, &announcement.pseudonym) {
+        return PseudonymAnnouncementDecision::Rejected {
+            reason: REJECT_COLLISION,
+            claimed_did: None,
+        };
+    }
+
+    PseudonymAnnouncementDecision::Accept {
+        member_did: announced_did,
+        pseudonym: announcement.pseudonym,
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used, clippy::panic)]
+mod tests {
+    use super::{
+        PSEUDONYM_ANNOUNCEMENT_TAG, PseudonymAnnouncement, PseudonymAnnouncementDecision,
+        REJECT_BROADCAST, REJECT_COLLISION, REJECT_RESERVED, REJECT_SENDER_MISMATCH,
+        classify_pseudonym_announcement, is_pseudonym_announcement_payload, is_reserved_pseudonym,
+        pseudonym_collides_with_other_did,
+    };
+    use scp_did::DID;
+    use std::collections::HashMap;
+
+    const CTX: &str = "ctx-pseudonym-routing-tests";
+
+    fn announcement_bytes(member_did: &str, pseudonym: [u8; 32]) -> Vec<u8> {
+        let ann = PseudonymAnnouncement {
+            tag: PSEUDONYM_ANNOUNCEMENT_TAG.to_owned(),
+            member_did: member_did.to_owned(),
+            pseudonym,
+        };
+        rmp_serde::to_vec_named(&ann).expect("serialize announcement")
+    }
+
+    /// §9.10.4: the shared `context_routing_id` is a RESERVED value — a member
+    /// must not be able to announce it as their own pseudonym, because honest
+    /// senders fan app-data out to announced pseudonyms and the shared RID is
+    /// relay-derivable. This is the type-level proof that the deleted
+    /// `shared_rid` fallback cannot be reintroduced through an announcement.
+    #[test]
+    fn shared_context_routing_id_is_reserved() {
+        let shared = super::context_routing_id(CTX);
+        assert!(
+            is_reserved_pseudonym(&shared, CTX),
+            "shared context routing id must be rejected as a pseudonym value"
+        );
+    }
+
+    #[test]
+    fn zero_and_broadcast_routing_ids_are_reserved() {
+        assert!(
+            is_reserved_pseudonym(&[0u8; 32], CTX),
+            "zero sentinel reserved"
+        );
+        let broadcast = super::broadcast_routing_id(CTX);
+        assert!(
+            is_reserved_pseudonym(&broadcast, CTX),
+            "broadcast routing id reserved"
+        );
+    }
+
+    #[test]
+    fn honest_pseudonym_is_not_reserved() {
+        // A raw Ed25519-public-key-shaped value (non-zero, not a derivable RID).
+        let honest = [7u8; 32];
+        assert!(
+            !is_reserved_pseudonym(&honest, CTX),
+            "an ordinary pseudonym must be accepted"
+        );
+    }
+
+    #[test]
+    fn cross_did_collision_detected_same_did_allowed() {
+        let mut registry: HashMap<DID, [u8; 32]> = HashMap::new();
+        let alice = DID("did:key:alice".to_owned());
+        let bob = DID("did:key:bob".to_owned());
+        let rid = [9u8; 32];
+        registry.insert(alice.clone(), rid);
+
+        // Bob claiming Alice's routing ID is a cross-DID collision.
+        assert!(
+            pseudonym_collides_with_other_did(&registry, &bob, &rid),
+            "a different DID claiming an existing routing ID is a collision"
+        );
+        // Alice re-announcing her OWN routing ID (key rotation rebroadcast) is fine.
+        assert!(
+            !pseudonym_collides_with_other_did(&registry, &alice, &rid),
+            "same-DID re-announce is not a collision"
+        );
+    }
+
+    #[test]
+    fn announcement_classifier_matches_only_tagged_payloads() {
+        let tagged = announcement_bytes("did:key:alice", [3u8; 32]);
+        assert!(
+            is_pseudonym_announcement_payload(&tagged),
+            "a well-formed tagged announcement is classified as such"
+        );
+        // Arbitrary user content must NOT be classified as an announcement, so
+        // it never gets routed to the shared bootstrap RID.
+        assert!(
+            !is_pseudonym_announcement_payload(b"hello world"),
+            "ordinary app data is not an announcement"
+        );
+    }
+
+    // -----------------------------------------------------------------------
+    // classify_pseudonym_announcement — every branch, pinning the exact reject
+    // reason strings (which are part of the §25.19 cross-target goldens).
+    // -----------------------------------------------------------------------
+
+    const ALICE: &str = "did:key:alice";
+    const BOB: &str = "did:key:bob";
+
+    #[test]
+    fn classify_untagged_payload_is_not_announcement() {
+        assert_eq!(
+            classify_pseudonym_announcement(b"hello world", ALICE, CTX, Some(&HashMap::new())),
+            PseudonymAnnouncementDecision::NotAnnouncement,
+            "ordinary app data classifies as NotAnnouncement"
+        );
+    }
+
+    #[test]
+    fn classify_wrong_tag_is_not_announcement() {
+        // A struct-shaped payload whose tag is not the magic tag decodes but is
+        // not an announcement.
+        let bytes = announcement_bytes(ALICE, [1u8; 32]);
+        let mut ann: PseudonymAnnouncement = rmp_serde::from_slice(&bytes).expect("decode fixture");
+        ann.tag = "not-the-tag".to_owned();
+        let mistagged = rmp_serde::to_vec_named(&ann).expect("re-encode fixture");
+        assert_eq!(
+            classify_pseudonym_announcement(&mistagged, ALICE, CTX, Some(&HashMap::new())),
+            PseudonymAnnouncementDecision::NotAnnouncement,
+            "a non-magic tag classifies as NotAnnouncement"
+        );
+    }
+
+    #[test]
+    fn classify_sender_mismatch_is_rejected_with_claimed_did() {
+        let forged = announcement_bytes(BOB, [0x42u8; 32]);
+        assert_eq!(
+            classify_pseudonym_announcement(&forged, ALICE, CTX, Some(&HashMap::new())),
+            PseudonymAnnouncementDecision::Rejected {
+                reason: REJECT_SENDER_MISMATCH,
+                claimed_did: Some(DID(BOB.to_owned())),
+            },
+            "a forged-DID announcement is rejected and carries the claimed DID"
+        );
+    }
+
+    #[test]
+    fn classify_reserved_value_is_rejected() {
+        for reserved in [
+            [0u8; 32],
+            super::context_routing_id(CTX),
+            super::broadcast_routing_id(CTX),
+        ] {
+            let bytes = announcement_bytes(ALICE, reserved);
+            assert_eq!(
+                classify_pseudonym_announcement(&bytes, ALICE, CTX, Some(&HashMap::new())),
+                PseudonymAnnouncementDecision::Rejected {
+                    reason: REJECT_RESERVED,
+                    claimed_did: None,
+                },
+                "a reserved routing ID is rejected"
+            );
+        }
+    }
+
+    #[test]
+    fn classify_broadcast_context_is_rejected() {
+        let bytes = announcement_bytes(ALICE, [0x42u8; 32]);
+        assert_eq!(
+            classify_pseudonym_announcement(&bytes, ALICE, CTX, None),
+            PseudonymAnnouncementDecision::Rejected {
+                reason: REJECT_BROADCAST,
+                claimed_did: None,
+            },
+            "an announcement on a broadcast context (no registry) is rejected"
+        );
+    }
+
+    #[test]
+    fn classify_cross_did_collision_is_rejected() {
+        let rid = [0x55u8; 32];
+        let mut registry: HashMap<DID, [u8; 32]> = HashMap::new();
+        registry.insert(DID(ALICE.to_owned()), rid);
+        // BOB tries to claim ALICE's already-registered routing ID.
+        let bytes = announcement_bytes(BOB, rid);
+        assert_eq!(
+            classify_pseudonym_announcement(&bytes, BOB, CTX, Some(&registry)),
+            PseudonymAnnouncementDecision::Rejected {
+                reason: REJECT_COLLISION,
+                claimed_did: None,
+            },
+            "a cross-DID routing-ID collision is rejected"
+        );
+    }
+
+    #[test]
+    fn classify_legitimate_announcement_is_accepted() {
+        let pseudonym = [0x42u8; 32];
+        let bytes = announcement_bytes(ALICE, pseudonym);
+        assert_eq!(
+            classify_pseudonym_announcement(&bytes, ALICE, CTX, Some(&HashMap::new())),
+            PseudonymAnnouncementDecision::Accept {
+                member_did: DID(ALICE.to_owned()),
+                pseudonym,
+            },
+            "a legitimate announcement is accepted with the announcer DID + pseudonym"
+        );
+    }
+
+    #[test]
+    fn classify_same_did_reannounce_is_accepted() {
+        let first = [0x42u8; 32];
+        let rotated = [0x43u8; 32];
+        let mut registry: HashMap<DID, [u8; 32]> = HashMap::new();
+        registry.insert(DID(ALICE.to_owned()), first);
+        // ALICE re-announces a rotated routing ID — legitimate key rotation, not
+        // a collision (the collision guard only fires for a DIFFERENT DID).
+        let bytes = announcement_bytes(ALICE, rotated);
+        assert_eq!(
+            classify_pseudonym_announcement(&bytes, ALICE, CTX, Some(&registry)),
+            PseudonymAnnouncementDecision::Accept {
+                member_did: DID(ALICE.to_owned()),
+                pseudonym: rotated,
+            },
+            "a same-DID re-announce is accepted (key rotation)"
+        );
+    }
+}

--- a/crates/scp-protocol/src/context/pseudonym.rs
+++ b/crates/scp-protocol/src/context/pseudonym.rs
@@ -4,10 +4,12 @@
 //! This is the single, wasm-safe home for the §9.10.4 per-context-pseudonym
 //! logic that the relay/MLS routing layer uses to learn peers' routing IDs. It
 //! carries NO async, NO transport, and NO platform dependency, so it compiles
-//! to `wasm32-unknown-unknown` and is shared VERBATIM by the native
-//! orchestrator (`scp-runtime`) and the in-browser client driver — one copy,
-//! never a fork, so the two targets cannot drift on the wire format or the
-//! accept/reject decision (ADR-057 "share, don't fork").
+//! to `wasm32-unknown-unknown` and is READY to be consumed verbatim by the
+//! in-browser client driver (ADR-057 "share, don't fork"). Today the native
+//! orchestrator (`scp-runtime`) is the sole production consumer; the
+//! cross-target byte/decision parity that a shared copy must hold is already
+//! exercised by `pseudonym_cross_target_kat` under `wasm-pack test`, so a
+//! future browser call site inherits one non-forked implementation.
 //!
 //! The module owns three things:
 //! 1. the [`PseudonymAnnouncement`] wire struct + its [`PSEUDONYM_ANNOUNCEMENT_TAG`]
@@ -17,8 +19,9 @@
 //!    [`is_reserved_pseudonym`], and [`pseudonym_collides_with_other_did`], and
 //! 3. the pure decision core [`classify_pseudonym_announcement`], which folds the
 //!    four-step ingest validation into a single [`PseudonymAnnouncementDecision`]
-//!    that each host maps to its own side effects (native: metric + `tracing`
-//!    warn + registry insert + event emit; browser: the equivalent driver hooks).
+//!    the host maps to its own side effects (native `scp-runtime`: metric +
+//!    `tracing` warn + registry insert + event emit; a future browser driver
+//!    would run the equivalent hooks).
 //!
 //! The reject-reason strings ([`REJECT_SENDER_MISMATCH`] et al.) are stable
 //! `&'static str`s that are part of the committed cross-target known-answer
@@ -112,14 +115,12 @@ pub fn is_reserved_pseudonym(pseudonym: &[u8; 32], context_id: &str) -> bool {
 /// address, and honest senders addressing the colliding DID could misroute).
 /// A member re-announcing the SAME value for their OWN DID is legitimate (key
 /// rotation re-broadcast) and is NOT a collision.
-// The peer registry is ALWAYS the default-hasher `HashMap` the routing state
-// owns (`peer_registry()`); this pure predicate is never called with a foreign
-// hasher, so a `BuildHasher` type parameter would add an unused generic to the
-// shared cross-target API (against the agent-first "one canonical shape" tenet)
-// without any real generality. Keep the concrete signature.
-#[allow(clippy::implicit_hasher)]
+///
+/// Crate-internal: the sole caller is [`classify_pseudonym_announcement`] in
+/// this module (plus this module's unit tests); the public entry point is the
+/// classifier, not this predicate.
 #[must_use]
-pub fn pseudonym_collides_with_other_did(
+pub(crate) fn pseudonym_collides_with_other_did(
     registry: &HashMap<DID, [u8; 32]>,
     announcer_did: &DID,
     pseudonym: &[u8; 32],
@@ -157,11 +158,12 @@ pub const REJECT_COLLISION: &str =
 /// plaintext.
 ///
 /// The classifier makes the accept/reject DECISION; it performs no side
-/// effects. Each host maps this to its own effects: the native orchestrator
+/// effects. The host maps this to its own effects: the native orchestrator
 /// records a rejection metric + `tracing` warn on `Rejected`, and inserts the
-/// registry entry + emits a `PseudonymAnnounced` event on `Accept`; the browser
-/// driver runs the equivalent hooks. Because both hosts share this one decision
-/// function, they cannot diverge on which announcements are accepted.
+/// registry entry + emits a `PseudonymAnnounced` event on `Accept` (a future
+/// browser driver would run the equivalent hooks). Because any host shares this
+/// one decision function, they cannot diverge on which announcements are
+/// accepted.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum PseudonymAnnouncementDecision {
     /// The plaintext is not a tagged `PseudonymAnnouncement` — the host should
@@ -190,8 +192,9 @@ pub enum PseudonymAnnouncementDecision {
 
 /// The pure §9.10.4 pseudonym-announcement decision core (ADR-057 T-1).
 ///
-/// This is the single, shared, wasm-safe validator both the native orchestrator
-/// and the browser driver run, so their accept/reject behavior cannot drift.
+/// This is the single, shared, wasm-safe validator the native orchestrator runs
+/// today and a future browser driver can run verbatim, so their accept/reject
+/// behavior cannot drift.
 ///
 /// Runs the four-step validation core over an inbound `plaintext`:
 /// 1. tag-decode ([`PseudonymAnnouncementDecision::NotAnnouncement`] if the

--- a/crates/scp-runtime/src/context/actor/mod.rs
+++ b/crates/scp-runtime/src/context/actor/mod.rs
@@ -1361,7 +1361,7 @@ mod tests {
     }
 
     fn announcement_bytes(member_did: &str, pseudonym: [u8; 32]) -> Vec<u8> {
-        use crate::context::state::{PSEUDONYM_ANNOUNCEMENT_TAG, PseudonymAnnouncement};
+        use scp_protocol::context::pseudonym::{PSEUDONYM_ANNOUNCEMENT_TAG, PseudonymAnnouncement};
         let ann = PseudonymAnnouncement {
             tag: PSEUDONYM_ANNOUNCEMENT_TAG.to_owned(),
             member_did: member_did.to_owned(),

--- a/crates/scp-runtime/src/context/messaging_helpers.rs
+++ b/crates/scp-runtime/src/context/messaging_helpers.rs
@@ -59,6 +59,10 @@ use scp_did::{DID, SigningKeyId};
 use scp_protocol::context::ContextError;
 use scp_protocol::context::governance::KeyResolver;
 use scp_protocol::context::membership::ContextEvent;
+use scp_protocol::context::pseudonym::{
+    self, PSEUDONYM_ANNOUNCEMENT_TAG, PseudonymAnnouncement, PseudonymAnnouncementDecision,
+    classify_pseudonym_announcement, is_pseudonym_announcement_payload,
+};
 use scp_protocol::context::roles::Capability;
 use scp_protocol::crypto::access_keys::wrapping::Recipient;
 use scp_protocol::crypto::access_keys::{AccessKey, WrappedContent};
@@ -74,10 +78,7 @@ use crate::context::actor::class_s::{BroadcastContextClassCMut, ClassCMut};
 use crate::context::actor::deps::ActorDeps;
 use crate::context::actor::state::PerContextState;
 use crate::context::governance_helpers;
-use crate::context::state::{
-    self, CHECKPOINT_PAYLOAD_TAG, CheckpointMessage, PSEUDONYM_ANNOUNCEMENT_TAG,
-    PseudonymAnnouncement, emit_event_into,
-};
+use crate::context::state::{self, CHECKPOINT_PAYLOAD_TAG, CheckpointMessage, emit_event_into};
 use crate::context::supervisor::MessageSigner;
 use crate::crypto::mls::provider::MlsCryptoProvider;
 
@@ -508,69 +509,6 @@ pub fn deliver_plaintext_or_announcement(
 // §9.10.4 announcement / routing helpers
 // ---------------------------------------------------------------------------
 
-/// Classifies a send-path payload as a `PseudonymAnnouncement` (§9.10.4).
-///
-/// Announcements are the ONLY payload class permitted to use the shared
-/// `context_routing_id` as an addressee — they form the bootstrap channel
-/// peers use to learn each other's pseudonyms before regular app data can fan
-/// out on pseudonym-only paths. Returns `true` only when the payload
-/// deserializes as a well-formed `PseudonymAnnouncement` AND carries the magic
-/// tag (`PSEUDONYM_ANNOUNCEMENT_TAG`, `\0`-prefixed to avoid collision with
-/// UTF-8 user content). False positives from adversarial payloads cannot
-/// escalate: the worst outcome is a legitimate app message routed to the
-/// shared RID, which is not a confidentiality issue (MLS still gates content)
-/// and is detected as a non-announcement on the receive path.
-fn is_pseudonym_announcement_payload(payload: &[u8]) -> bool {
-    rmp_serde::from_slice::<PseudonymAnnouncement>(payload)
-        .is_ok_and(|a| a.tag == PSEUDONYM_ANNOUNCEMENT_TAG)
-}
-
-/// Returns `true` if `pseudonym` is a reserved routing ID a member is not
-/// permitted to announce as their own (§9.10.4).
-///
-/// The pseudonym registry maps each member's DID to the routing ID honest
-/// senders fan their app-data ciphertext out to. If a member could announce a
-/// reserved value for their own DID, they could redirect every honest sender's
-/// app-data:
-///
-/// - `[0u8; 32]` — the zero/degraded sentinel; maps to nothing meaningful.
-/// - `context_routing_id(context_id)` — the shared bootstrap RID; announcing
-///   it would push app-data ciphertext onto the shared channel, defeating
-///   unlinkability.
-/// - `broadcast_routing_id(context_id)` — the derivable `SHA-256(context_id)`
-///   broadcast RID; same leak vector.
-///
-/// Honest pseudonyms are the raw 32-byte Ed25519 public key of the member's
-/// per-context keypair (stored and routed on verbatim, NOT hashed). They
-/// collide with these reserved values only with negligible probability, so
-/// rejecting them costs nothing for legitimate members.
-fn is_reserved_pseudonym(pseudonym: &[u8; 32], context_id: &str) -> bool {
-    *pseudonym == [0u8; 32]
-        || *pseudonym == scp_protocol::context::context_routing_id(context_id)
-        || *pseudonym == scp_protocol::context::broadcast_routing_id(context_id)
-}
-
-/// Returns `true` if `pseudonym` is already registered under a DID OTHER than
-/// `announcer_did` (§9.10.4 defense-in-depth).
-///
-/// The announcement path already enforces `announcement.member_did ==
-/// sender_did`, so a member can only announce a routing ID for their own DID.
-/// This guards the remaining vector: a member claiming a routing ID an
-/// existing peer already legitimately uses, which would let two DIDs resolve
-/// to one routing ID (a relay would then receive both members' fan-out at one
-/// address, and honest senders addressing the colliding DID could misroute).
-/// A member re-announcing the SAME value for their OWN DID is legitimate (key
-/// rotation re-broadcast) and is NOT a collision.
-fn pseudonym_collides_with_other_did(
-    registry: &std::collections::HashMap<DID, [u8; 32]>,
-    announcer_did: &DID,
-    pseudonym: &[u8; 32],
-) -> bool {
-    registry.iter().any(|(other_did, other_pseudonym)| {
-        other_pseudonym == pseudonym && other_did != announcer_did
-    })
-}
-
 /// Outcome of running the shared §9.10.4 pseudonym-announcement ingest
 /// validator over a single inbound plaintext.
 ///
@@ -617,88 +555,80 @@ fn ingest_pseudonym_announcement(
     context_id: &str,
     event_tx: Option<&ContextEventSender>,
 ) -> AnnouncementOutcome {
-    // Step 1: tag-decode. A non-announcement (or untagged payload) is ordinary
-    // application data.
-    let Ok(announcement) = rmp_serde::from_slice::<PseudonymAnnouncement>(plaintext) else {
-        return AnnouncementOutcome::NotAnnouncement;
-    };
-    if announcement.tag != PSEUDONYM_ANNOUNCEMENT_TAG {
-        return AnnouncementOutcome::NotAnnouncement;
-    }
-
-    // Step 2: the announced DID must match the authenticated sender. A member
-    // can only announce a routing ID for their OWN DID.
-    if announcement.member_did != sender_did {
-        crate::metrics::record_pseudonym_announcement_rejected();
-        tracing::warn!(
-            context_id,
-            sender_did,
-            claimed_did = %announcement.member_did,
-            "pseudonym announcement sender mismatch — rejecting forged announcement"
-        );
-        return AnnouncementOutcome::Rejected(
-            "pseudonym announcement member_did does not match sender",
-        );
-    }
-
-    let announced_did = DID(announcement.member_did.clone());
-
-    // Step 3: reject reserved pseudonym VALUES before touching the registry.
-    // Announcing the zero sentinel, the shared bootstrap RID, or the broadcast
-    // RID for one's own DID would redirect every honest sender's app-data
-    // fan-out, defeating unlinkability or leaking ciphertext onto the shared
-    // channel.
-    if is_reserved_pseudonym(&announcement.pseudonym, context_id) {
-        crate::metrics::record_pseudonym_announcement_rejected();
-        tracing::warn!(
-            context_id,
-            sender_did,
-            "pseudonym announcement uses a reserved routing ID — rejecting"
-        );
-        return AnnouncementOutcome::Rejected("pseudonym announcement uses a reserved routing ID");
-    }
-
-    // Step 4: registry updates are meaningful only for encrypted contexts. A
-    // broadcast context carries no peer registry — reject as a spec-level
-    // violation. Otherwise reject a routing ID already claimed by a DIFFERENT
-    // member (same-DID re-announce for key rotation stays allowed), then insert.
-    let Some(pseudonym_registry) = view.routing_mut().peer_registry_mut() else {
-        crate::metrics::record_pseudonym_announcement_rejected();
-        tracing::warn!(
-            context_id,
-            sender_did,
-            "pseudonym announcement received on broadcast context — rejecting"
-        );
-        return AnnouncementOutcome::Rejected(
-            "pseudonym announcement received on broadcast context",
-        );
-    };
-    if pseudonym_collides_with_other_did(
-        pseudonym_registry,
-        &announced_did,
-        &announcement.pseudonym,
+    // Run the shared, wasm-safe §9.10.4 decision core over the immutable peer
+    // registry (`None` for a broadcast context). The classifier owns the
+    // four-step validation; the native side effects — the rejection metric, the
+    // per-branch `tracing` warn, the registry insert, and the `PseudonymAnnounced`
+    // buffer emit — stay HERE and are byte-and-trace-identical to the previous
+    // inline implementation.
+    match classify_pseudonym_announcement(
+        plaintext,
+        sender_did,
+        context_id,
+        view.routing_mut().peer_registry(),
     ) {
-        crate::metrics::record_pseudonym_announcement_rejected();
-        tracing::warn!(
-            context_id,
-            sender_did,
-            "pseudonym announcement collides with another member's routing ID — rejecting"
-        );
-        return AnnouncementOutcome::Rejected(
-            "pseudonym announcement collides with another member's routing ID",
-        );
+        PseudonymAnnouncementDecision::NotAnnouncement => AnnouncementOutcome::NotAnnouncement,
+        PseudonymAnnouncementDecision::Rejected {
+            reason,
+            claimed_did,
+        } => {
+            crate::metrics::record_pseudonym_announcement_rejected();
+            // Reproduce the exact warn that fired before for each rejection
+            // branch. The sender-mismatch branch is the ONLY one carrying a
+            // `claimed_did`, and it logs it as a field (`%claimed_did` renders
+            // the raw DID string, identical to the prior `%announcement.member_did`);
+            // the other three branches are disambiguated by their stable reason.
+            if let Some(claimed_did) = claimed_did {
+                tracing::warn!(
+                    context_id,
+                    sender_did,
+                    claimed_did = %claimed_did,
+                    "pseudonym announcement sender mismatch — rejecting forged announcement"
+                );
+            } else if reason == pseudonym::REJECT_RESERVED {
+                tracing::warn!(
+                    context_id,
+                    sender_did,
+                    "pseudonym announcement uses a reserved routing ID — rejecting"
+                );
+            } else if reason == pseudonym::REJECT_BROADCAST {
+                tracing::warn!(
+                    context_id,
+                    sender_did,
+                    "pseudonym announcement received on broadcast context — rejecting"
+                );
+            } else {
+                tracing::warn!(
+                    context_id,
+                    sender_did,
+                    "pseudonym announcement collides with another member's routing ID — rejecting"
+                );
+            }
+            AnnouncementOutcome::Rejected(reason)
+        }
+        PseudonymAnnouncementDecision::Accept {
+            member_did,
+            pseudonym,
+        } => {
+            // The classifier only returns `Accept` for an encrypted context whose
+            // peer registry is present and non-colliding; re-borrow it mutably to
+            // insert. The `if let` (rather than a workspace-denied `expect`) is a
+            // total match over that proven invariant — the registry presence
+            // cannot change between the classify read and this insert (no mutation
+            // occurs in between).
+            if let Some(pseudonym_registry) = view.routing_mut().peer_registry_mut() {
+                pseudonym_registry.insert(member_did.clone(), pseudonym);
+            }
+            // Record + emit. The `routing_mut()` borrow above has ended (NLL)
+            // before this disjoint `receive_buffer` emit.
+            let event = ContextEvent::PseudonymAnnounced {
+                member_did,
+                pseudonym,
+            };
+            emit_event_into(view.receive_buffer_mut(), event, context_id, event_tx);
+            AnnouncementOutcome::Recorded
+        }
     }
-    pseudonym_registry.insert(announced_did.clone(), announcement.pseudonym);
-
-    // Record + emit. The validator stops here; per-site follow-up runs at the
-    // call site. The `routing_mut()` borrow above has ended (NLL) before this
-    // disjoint `receive_buffer` emit.
-    let event = ContextEvent::PseudonymAnnounced {
-        member_did: announced_did,
-        pseudonym: announcement.pseudonym,
-    };
-    emit_event_into(view.receive_buffer_mut(), event, context_id, event_tx);
-    AnnouncementOutcome::Recorded
 }
 
 // ---------------------------------------------------------------------------
@@ -3580,8 +3510,8 @@ pub async fn send_pseudonym_announcement(
     let Some(pseudonym) = cell.routing.local_pseudonym() else {
         return;
     };
-    let announcement = state::PseudonymAnnouncement {
-        tag: state::PSEUDONYM_ANNOUNCEMENT_TAG.to_owned(),
+    let announcement = PseudonymAnnouncement {
+        tag: PSEUDONYM_ANNOUNCEMENT_TAG.to_owned(),
         member_did: sender_did.as_ref().to_owned(),
         pseudonym,
     };
@@ -3618,14 +3548,8 @@ pub async fn send_pseudonym_announcement(
 #[cfg(test)]
 #[allow(clippy::unwrap_used, clippy::expect_used, clippy::panic)]
 mod pseudonym_routing_tests {
-    use super::{
-        is_pseudonym_announcement_payload, is_reserved_pseudonym, pseudonym_collides_with_other_did,
-    };
-    use crate::context::state::{PSEUDONYM_ANNOUNCEMENT_TAG, PseudonymAnnouncement};
     use scp_did::DID;
-    use std::collections::HashMap;
-
-    const CTX: &str = "ctx-pseudonym-routing-tests";
+    use scp_protocol::context::pseudonym::{PSEUDONYM_ANNOUNCEMENT_TAG, PseudonymAnnouncement};
 
     fn announcement_bytes(member_did: &str, pseudonym: [u8; 32]) -> Vec<u8> {
         let ann = PseudonymAnnouncement {
@@ -3636,77 +3560,14 @@ mod pseudonym_routing_tests {
         rmp_serde::to_vec_named(&ann).expect("serialize announcement")
     }
 
-    /// §9.10.4: the shared `context_routing_id` is a RESERVED value — a member
-    /// must not be able to announce it as their own pseudonym, because honest
-    /// senders fan app-data out to announced pseudonyms and the shared RID is
-    /// relay-derivable. This is the type-level proof that the deleted
-    /// `shared_rid` fallback cannot be reintroduced through an announcement.
-    #[test]
-    fn shared_context_routing_id_is_reserved() {
-        let shared = scp_protocol::context::context_routing_id(CTX);
-        assert!(
-            is_reserved_pseudonym(&shared, CTX),
-            "shared context routing id must be rejected as a pseudonym value"
-        );
-    }
-
-    #[test]
-    fn zero_and_broadcast_routing_ids_are_reserved() {
-        assert!(
-            is_reserved_pseudonym(&[0u8; 32], CTX),
-            "zero sentinel reserved"
-        );
-        let broadcast = scp_protocol::context::broadcast_routing_id(CTX);
-        assert!(
-            is_reserved_pseudonym(&broadcast, CTX),
-            "broadcast routing id reserved"
-        );
-    }
-
-    #[test]
-    fn honest_pseudonym_is_not_reserved() {
-        // A raw Ed25519-public-key-shaped value (non-zero, not a derivable RID).
-        let honest = [7u8; 32];
-        assert!(
-            !is_reserved_pseudonym(&honest, CTX),
-            "an ordinary pseudonym must be accepted"
-        );
-    }
-
-    #[test]
-    fn cross_did_collision_detected_same_did_allowed() {
-        let mut registry: HashMap<DID, [u8; 32]> = HashMap::new();
-        let alice = DID("did:key:alice".to_owned());
-        let bob = DID("did:key:bob".to_owned());
-        let rid = [9u8; 32];
-        registry.insert(alice.clone(), rid);
-
-        // Bob claiming Alice's routing ID is a cross-DID collision.
-        assert!(
-            pseudonym_collides_with_other_did(&registry, &bob, &rid),
-            "a different DID claiming an existing routing ID is a collision"
-        );
-        // Alice re-announcing her OWN routing ID (key rotation rebroadcast) is fine.
-        assert!(
-            !pseudonym_collides_with_other_did(&registry, &alice, &rid),
-            "same-DID re-announce is not a collision"
-        );
-    }
-
-    #[test]
-    fn announcement_classifier_matches_only_tagged_payloads() {
-        let tagged = announcement_bytes("did:key:alice", [3u8; 32]);
-        assert!(
-            is_pseudonym_announcement_payload(&tagged),
-            "a well-formed tagged announcement is classified as such"
-        );
-        // Arbitrary user content must NOT be classified as an announcement, so
-        // it never gets routed to the shared bootstrap RID.
-        assert!(
-            !is_pseudonym_announcement_payload(b"hello world"),
-            "ordinary app data is not an announcement"
-        );
-    }
+    // The pure §9.10.4 predicate + classifier unit tests
+    // (`is_reserved_pseudonym`, `pseudonym_collides_with_other_did`,
+    // `is_pseudonym_announcement_payload`, `classify_pseudonym_announcement`)
+    // moved to `scp_protocol::context::pseudonym` alongside the logic they
+    // exercise (ADR-057 T-1). The behavioral ingest tests below STAY here: they
+    // drive the native `&mut ClassCMut` wrapper (`ingest_pseudonym_announcement`)
+    // against a real `PerContextState`, proving the wrapper's collapse onto the
+    // shared classifier is behavior-identical.
 
     // -----------------------------------------------------------------------
     // Behavioral ingest-hardening tests — buffered site + shared validator.
@@ -4557,8 +4418,8 @@ mod pseudonym_routing_tests {
         // routing ID). The drain path reads sequence/timestamp/context/sender
         // from the inner envelope; the announcement payload is the `plaintext`.
         let alice_pseudonym = [0x42u8; 32];
-        let announcement = crate::context::state::PseudonymAnnouncement {
-            tag: crate::context::state::PSEUDONYM_ANNOUNCEMENT_TAG.to_owned(),
+        let announcement = PseudonymAnnouncement {
+            tag: PSEUDONYM_ANNOUNCEMENT_TAG.to_owned(),
             member_did: ALICE.to_owned(),
             pseudonym: alice_pseudonym,
         };
@@ -4653,8 +4514,7 @@ mod pseudonym_routing_tests {
             "checkpoint tag must be null-prefixed to avoid UTF-8 content collision"
         );
         assert_ne!(
-            CHECKPOINT_PAYLOAD_TAG,
-            crate::context::state::PSEUDONYM_ANNOUNCEMENT_TAG,
+            CHECKPOINT_PAYLOAD_TAG, PSEUDONYM_ANNOUNCEMENT_TAG,
             "checkpoint and announcement tags must be distinct"
         );
     }

--- a/crates/scp-runtime/src/context/state.rs
+++ b/crates/scp-runtime/src/context/state.rs
@@ -1711,36 +1711,14 @@ pub(crate) struct TtlState {
     pub(crate) extension: Option<TtlExtension>,
 }
 
-/// Wire format for pseudonym announcements sent as MLS application messages.
-///
-/// When a member joins or creates a context with a pre-derived pseudonym,
-/// they announce it to other members via this structure serialized with
-/// `MessagePack`. Recipients store the mapping in their pseudonym registry.
-#[derive(Debug, Clone, Serialize, Deserialize)]
-#[serde(deny_unknown_fields)]
-pub(crate) struct PseudonymAnnouncement {
-    /// Magic prefix to distinguish from regular application messages.
-    pub tag: String,
-    /// The announcing member's DID.
-    pub member_did: String,
-    /// The 32-byte pseudonym routing ID.
-    #[serde(with = "serde_bytes")]
-    pub pseudonym: [u8; 32],
-}
-
-/// Magic tag used to identify pseudonym announcement messages in the MLS
-/// application message stream. Prefixed with `\0` to avoid collision with
-/// user-generated content (which is always valid UTF-8 and will never start
-/// with a null byte when deserialized from `MessagePack`).
-pub(crate) const PSEUDONYM_ANNOUNCEMENT_TAG: &str = "\0scp:pseudonym-announce:v1";
-
 /// Wire wrapper for a consistency-checkpoint exchange message (§9.9.3, §23.7).
 ///
 /// Carries the canonical signed [`ConsistencyCheckpoint`] behind a magic tag
 /// so the receive path can positively identify it. Although the inner envelope
 /// already discriminates checkpoints via
 /// [`MessageType::ConsistencyCheckpoint`](scp_protocol::envelope::inner::MessageType::ConsistencyCheckpoint),
-/// the tag is a defense-in-depth guard mirroring [`PseudonymAnnouncement`]:
+/// the tag is a defense-in-depth guard mirroring
+/// [`PseudonymAnnouncement`](scp_protocol::context::pseudonym::PseudonymAnnouncement):
 /// it makes a payload that fails to deserialize as a tagged checkpoint a
 /// hard error rather than a silently mis-routed application message.
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -1754,8 +1732,9 @@ pub(crate) struct CheckpointMessage {
 
 /// Magic tag identifying consistency-checkpoint messages in the MLS application
 /// message stream. Prefixed with `\0` for the same reason as
-/// [`PSEUDONYM_ANNOUNCEMENT_TAG`]: user content is valid UTF-8 and never starts
-/// with a null byte when `MessagePack`-decoded, so the tag cannot collide.
+/// [`PSEUDONYM_ANNOUNCEMENT_TAG`](scp_protocol::context::pseudonym::PSEUDONYM_ANNOUNCEMENT_TAG):
+/// user content is valid UTF-8 and never starts with a null byte when
+/// `MessagePack`-decoded, so the tag cannot collide.
 pub(crate) const CHECKPOINT_PAYLOAD_TAG: &str = "\0scp:checkpoint:v1";
 
 // ADR-049 Phase 2A finalization keystone (commit 12 phase 2A finalization


### PR DESCRIPTION
## Summary

ADR-057 Slice-3 transport ruling **T-1** (planning-session-10): a **behavior-preserving (byte-AND-trace-identical)** extraction of the pure §9.10.4 per-context-pseudonym logic out of native-only `scp-runtime` into the wasm-safe `scp-protocol::context::pseudonym` submodule — so the native orchestrator and the forthcoming in-browser client driver consume **one** copy, not a fork (the ADR-055 / D5 / scp-mls anti-parity-tax discipline).

## What moved
`is_reserved_pseudonym`, `is_pseudonym_announcement_payload`, `pseudonym_collides_with_other_did` (`pub(crate)` — no cross-crate consumer), the `PseudonymAnnouncement` wire struct + `PSEUDONYM_ANNOUNCEMENT_TAG`, and a **new pure `classify_pseudonym_announcement` → `PseudonymAnnouncementDecision`** decision core carved out of the native `ingest_pseudonym_announcement`. The native `ingest` wrapper stays (the `&mut` registry insert + `PseudonymAnnounced` emit + metric + `warn!`) and **collapses onto the shared classifier**.

## Behavior preservation
Byte-**and-trace**-identical: the rejection metric fires exactly once per reject on the same four branches; all four `tracing::warn!`s are reproduced with identical fields/messages (incl. the sender-mismatch `claimed_did` — `DID::Display` renders identical bytes); `Accept` inserts + emits identically; the `AnnouncementOutcome` variants and the `REJECT_*` reason strings (which feed `PermissionDenied` at the direct site) are unchanged. The 4 reviewers confirmed: **bug-catcher — byte-and-trace-identical, defect-free; cryptographer — SOUND (reserved-set + collision predicate + validation order preserved); completionist — COMPLETE; simplifier — no blocker.**

## Cross-target parity
New dual-target KAT (`crates/scp-client-wasm/tests/pseudonym_cross_target_kat.rs`, native `#[test]` + `#[wasm_bindgen_test]`) pins a **fixed golden `PseudonymAnnouncement` rmp encoding** + all classifier decisions + reject strings + reserved-RID sentinels, byte-identical native↔wasm32 (transitive-golden). Golden anchored in **spec §25.19 Vector 36**. `wasm-pack test --node` passes on wasm32.

## Verification
`cargo build --workspace`, full CI clippy all-features `-D warnings`, `cargo fmt --all --check` — clean. `cargo test -p scp-protocol` (18) + `cargo test -p scp-runtime` (29 pseudonym + 4 `direct_*`, the native ingest tests **unchanged**) — pass. wasm fence (`scp-protocol` wasm32 clippy `-D warnings`) — clean. All `scripts/check-*.sh` gates pass. `cargo tree -p scp-protocol` adds no tokio/scp-platform/openmls. No `pub use` shim; no enforcement file modified.

## Cross-layer gate exemptions
The three genuinely-cross-crate `pub fn`s are pure §9.10.4 protocol helpers (the announcement flow is already FFI-wired via `SendPseudonymAnnouncement`; no new SDK surface) — `pub` only for the cross-crate KAT. Using the gate's built-in `pub-crate-visibility` exemption (not a bypass):

[cross-layer: pub-crate-visibility] is_reserved_pseudonym
[cross-layer: pub-crate-visibility] is_pseudonym_announcement_payload
[cross-layer: pub-crate-visibility] classify_pseudonym_announcement

🤖 Generated with [Claude Code](https://claude.com/claude-code)