### PR TITLE
fix(blob): delete BlobStorageBackend Default, require explicit blob backend at relay/node init (ADR-062 Slice 10, SCP-CAPINJECT-010)

### DIFF
--- a/.docs/standards/construction.md
+++ b/.docs/standards/construction.md
@@ -13,6 +13,7 @@ let node = Node::start(NodeConfig {
     reach: Reach::Domain { domain: "example.com".into() },
     identity: IdentitySource::Generate { custody, did_method },
     storage: StorageSlot::Sqlite { path, passphrase }, // core slot; the FFI bridges mirror it as their `StorageConfig` enum
+    blob_storage: BlobStorageBackend::sqlite(&blob_db)?, // required relay blob backend (M4); durable for a public node
     ..NodeConfig::defaults(/* required… */)
 }).await?;
 ```
@@ -86,7 +87,7 @@ Instead:
 - Provide a `Thing::defaults(required…) -> Config` **factory** that takes the irreducible required fields and fills the rest with fail-safe defaults, enabling the spread idiom:
 
   ```rust
-  NodeConfig { reach, identity, storage, ..NodeConfig::defaults(reach2, identity2, storage2) }
+  NodeConfig { reach, identity, storage, blob_storage, ..NodeConfig::defaults(reach2, identity2, storage2, blob_storage2) }
   ```
 
 A config whose every field is genuinely fail-safe **may** keep `Default` — `RelayConfig` qualifies, since every field has a safe default. This explicitly depends on `BridgeRole::default() == Disabled`: `bridge` is `RelayConfig`'s only security-consequential field, and because its `Default` is the fail-safe `Disabled` (a relay that brokers nothing until explicitly enabled), the whole struct's `Default` manufactures no unsafe value. If `BridgeRole::default()` were `Enabled`, `RelayConfig` would forfeit this exception and M4 would fire. The rule fires only when a field is security-relevant or irreducible *and lacks a fail-safe default*.

--- a/crates/scp-ffi/common/src/server.rs
+++ b/crates/scp-ffi/common/src/server.rs
@@ -342,7 +342,6 @@ pub async fn start_node_in_memory(
             // in P1 — the in-memory DHT client publishes nothing).
             Node::start_for_testing(NodeConfig {
                 bind_addr: Some(SocketAddr::from(([127, 0, 0, 1], 0))),
-                blob_storage: Some(BlobStorageBackend::in_memory()),
                 dht: DhtMode::Production,
                 ..NodeConfig::defaults(
                     Reach::Domain {
@@ -360,6 +359,10 @@ pub async fn start_node_in_memory(
                         },
                     )),
                     InMemoryStorage::new(),
+                    // Explicit durability-only selection for this in-memory
+                    // server front door (SCP-CAPINJECT-010): the blob backend is
+                    // a required selection, never a runtime default.
+                    BlobStorageBackend::in_memory(),
                 )
             })
             .await?
@@ -455,7 +458,6 @@ pub async fn start_node_local(
     let node = if let Some(id) = identity {
         Node::start_for_testing(NodeConfig {
             bind_addr: Some(SocketAddr::from(([127, 0, 0, 1], 0))),
-            blob_storage: Some(blob_storage),
             dht: DhtMode::Production,
             ..NodeConfig::defaults(
                 Reach::Domain {
@@ -473,6 +475,9 @@ pub async fn start_node_local(
                     },
                 )),
                 storage,
+                // The operator-chosen durable redb blob backend (opened above),
+                // passed as the required selection (SCP-CAPINJECT-010).
+                blob_storage,
             )
         })
         .await?
@@ -506,7 +511,6 @@ pub async fn start_node_local(
 
         Node::start_for_testing(NodeConfig {
             bind_addr: Some(SocketAddr::from(([127, 0, 0, 1], 0))),
-            blob_storage: Some(blob_storage),
             dht: DhtMode::Production,
             ..NodeConfig::defaults(
                 Reach::Domain {
@@ -517,6 +521,9 @@ pub async fn start_node_local(
                     did_method,
                 },
                 storage,
+                // The operator-chosen durable redb blob backend (opened above),
+                // passed as the required selection (SCP-CAPINJECT-010).
+                blob_storage,
             )
         })
         .await?

--- a/crates/scp-node/src/config.rs
+++ b/crates/scp-node/src/config.rs
@@ -300,6 +300,7 @@ pub enum NatSlot {
 ///     Reach::Local,
 ///     IdentitySource::Generate { custody, did_method },
 ///     storage,
+///     BlobStorageBackend::in_memory(), // durability-only arm, selected explicitly
 /// )).await?;
 /// ```
 ///
@@ -320,6 +321,7 @@ pub enum NatSlot {
 ///         Reach::Domain { domain: "example.com".into() },
 ///         IdentitySource::Generate { custody, did_method },
 ///         storage,
+///         BlobStorageBackend::sqlite(&blob_db)?, // durable backend for a public node
 ///     )
 /// }).await?;
 /// ```
@@ -397,9 +399,19 @@ pub struct NodeConfig<
     pub nat: NatSlot,
     /// Network change detector for tier re-evaluation (§10.12.1, SCP-243).
     pub network_detector: Option<Arc<dyn NetworkChangeDetector>>,
-    /// Blob storage backend for the relay. `None` preserves the builder's
-    /// in-memory default; `Some` overrides it.
-    pub blob_storage: Option<BlobStorageBackend>,
+    /// Blob storage backend for the relay.
+    ///
+    /// **Required, irreducible selection** (SCP-CAPINJECT-010 / ADR-062
+    /// §Decision 5; spec §17.17.1). This is a non-`Option` field for the same
+    /// reason `reach`/`identity`/`storage` are (M4): the relay's blob backend is
+    /// a provider-capability choice the runtime MUST NOT manufacture
+    /// (SCP-CAPSEL-8002), default (SCP-CAPSEL-8000), or fall back to
+    /// (SCP-CAPSEL-8001). The caller selects it explicitly at this construction
+    /// boundary. [`BlobStorageBackend::in_memory`] is a durability-only
+    /// development arm (SCP-CAPSEL-8010/8011) — legitimately selectable here, but
+    /// only ever by explicit choice, never by omission. Production nodes select a
+    /// durable backend (Sqlite/redb/Postgres/S3; see spec §17.7).
+    pub blob_storage: BlobStorageBackend,
 }
 
 impl<K: KeyCustody, D: DidMethod, S: Storage> NodeConfig<K, D, S> {
@@ -410,15 +422,29 @@ impl<K: KeyCustody, D: DidMethod, S: Storage> NodeConfig<K, D, S> {
     /// (no publish), every `Option` = `None`, `dht_gateways = []`,
     /// `nat = NatSlot::Auto`.
     ///
-    /// This enables the spread idiom. Because `reach`/`identity`/`storage` are
-    /// moved into the returned struct, the caller passes *separate* values to
-    /// `defaults(...)` than the fields it overrides:
+    /// This enables the spread idiom. Because `reach`/`identity`/`storage`/
+    /// `blob_storage` are moved into the returned struct, the caller passes
+    /// *separate* values to `defaults(...)` than the fields it overrides:
     ///
     /// ```ignore
-    /// NodeConfig { tls: TlsMode::Acme { email }, ..NodeConfig::defaults(reach2, identity2, storage2) }
+    /// NodeConfig {
+    ///     tls: TlsMode::Acme { email },
+    ///     ..NodeConfig::defaults(reach2, identity2, storage2, blob_storage2)
+    /// }
     /// ```
+    ///
+    /// `blob_storage` is a required argument (not defaulted) because the relay's
+    /// blob backend is an irreducible provider-capability selection the runtime
+    /// must never manufacture (SCP-CAPINJECT-010 / spec §17.17.1). A local demo
+    /// selects the durability-only arm explicitly:
+    /// `NodeConfig::defaults(reach, identity, storage, BlobStorageBackend::in_memory())`.
     #[must_use]
-    pub fn defaults(reach: Reach, identity: IdentitySource<K, D>, storage: S) -> Self {
+    pub fn defaults(
+        reach: Reach,
+        identity: IdentitySource<K, D>,
+        storage: S,
+        blob_storage: BlobStorageBackend,
+    ) -> Self {
         Self {
             reach,
             identity,
@@ -436,7 +462,7 @@ impl<K: KeyCustody, D: DidMethod, S: Storage> NodeConfig<K, D, S> {
             http3: None,
             nat: NatSlot::Auto,
             network_detector: None,
-            blob_storage: None,
+            blob_storage,
         }
     }
 }
@@ -499,7 +525,9 @@ struct ConfigTail {
     http3: Option<scp_transport::http3::Http3Config>,
     nat: NatSlot,
     network_detector: Option<Arc<dyn NetworkChangeDetector>>,
-    blob_storage: Option<BlobStorageBackend>,
+    /// The caller's explicit blob backend selection, threaded verbatim to the
+    /// relay build (never defaulted/fallen-back — SCP-CAPINJECT-010).
+    blob_storage: BlobStorageBackend,
 }
 
 /// Validates the config, returning a loud error for contradictory combinations
@@ -868,7 +896,7 @@ async fn build_node_domain<D, S>(
     #[cfg(feature = "http3")] http3: Option<scp_transport::http3::Http3Config>,
     nat: NatSlot,
     network_detector: Option<Arc<dyn NetworkChangeDetector>>,
-    blob_storage_opt: Option<BlobStorageBackend>,
+    blob_storage: BlobStorageBackend,
 ) -> Result<ApplicationNode<S>, NodeError>
 where
     D: DidMethod + 'static,
@@ -918,7 +946,9 @@ where
         ..RelayConfig::default()
     };
 
-    let blob_storage = Arc::new(blob_storage_opt.unwrap_or_default());
+    // The caller's explicit blob-backend selection, threaded verbatim — never
+    // defaulted or fallen-back (SCP-CAPINJECT-010 / SCP-CAPSEL-8002).
+    let blob_storage = Arc::new(blob_storage);
     let relay_server = RelayServer::new(relay_config.clone(), Arc::clone(&blob_storage));
     let connection_tracker = relay_server.connection_tracker();
     let subscription_registry = relay_server.subscriptions();
@@ -1036,7 +1066,7 @@ async fn build_node_no_domain<D, S>(
     #[cfg(feature = "http3")] _http3: Option<scp_transport::http3::Http3Config>,
     nat: NatSlot,
     network_detector: Option<Arc<dyn NetworkChangeDetector>>,
-    blob_storage_opt: Option<BlobStorageBackend>,
+    blob_storage: BlobStorageBackend,
     skip_nat_probe: bool,
 ) -> Result<ApplicationNode<S>, NodeError>
 where
@@ -1052,7 +1082,9 @@ where
         ..RelayConfig::default()
     };
 
-    let blob_storage = Arc::new(blob_storage_opt.unwrap_or_default());
+    // The caller's explicit blob-backend selection, threaded verbatim — never
+    // defaulted or fallen-back (SCP-CAPINJECT-010 / SCP-CAPSEL-8002).
+    let blob_storage = Arc::new(blob_storage);
     let relay_server = RelayServer::new(relay_config.clone(), Arc::clone(&blob_storage));
     let connection_tracker = relay_server.connection_tracker();
     let subscription_registry = relay_server.subscriptions();
@@ -1304,6 +1336,7 @@ mod tests {
                 },
                 generate_identity(),
                 InMemoryStorage::new(),
+                BlobStorageBackend::in_memory(),
             )
         })
         .await
@@ -1352,6 +1385,7 @@ mod tests {
                     },
                 )),
                 InMemoryStorage::new(),
+                BlobStorageBackend::in_memory(),
             )
         })
         .await
@@ -1389,6 +1423,7 @@ mod tests {
                 Reach::NatTraversal,
                 generate_identity(),
                 InMemoryStorage::new(),
+                BlobStorageBackend::in_memory(),
             )
         })
         .await
@@ -1420,6 +1455,7 @@ mod tests {
                 },
                 generate_identity(),
                 InMemoryStorage::new(),
+                BlobStorageBackend::in_memory(),
             )
         })
         .await
@@ -1445,7 +1481,12 @@ mod tests {
     async fn local_skips_nat_and_builds() {
         let node = Node::start_for_testing(NodeConfig {
             bind_addr: Some(SocketAddr::from(([127, 0, 0, 1], 0))),
-            ..NodeConfig::defaults(Reach::Local, generate_identity(), InMemoryStorage::new())
+            ..NodeConfig::defaults(
+                Reach::Local,
+                generate_identity(),
+                InMemoryStorage::new(),
+                BlobStorageBackend::in_memory(),
+            )
         })
         .await
         .unwrap();
@@ -1486,6 +1527,7 @@ mod tests {
                     did_method: Arc::clone(&did_method),
                 },
                 Arc::clone(&storage),
+                BlobStorageBackend::in_memory(),
             )
         })
         .await
@@ -1507,6 +1549,7 @@ mod tests {
                     did_method,
                 },
                 Arc::clone(&storage),
+                BlobStorageBackend::in_memory(),
             )
         })
         .await
@@ -1529,7 +1572,12 @@ mod tests {
             tls: TlsMode::Acme {
                 email: Some("spread@example.com".to_owned()),
             },
-            ..NodeConfig::defaults(Reach::Local, generate_identity(), InMemoryStorage::new())
+            ..NodeConfig::defaults(
+                Reach::Local,
+                generate_identity(),
+                InMemoryStorage::new(),
+                BlobStorageBackend::in_memory(),
+            )
         };
         // The override took effect.
         assert!(matches!(config.tls, TlsMode::Acme { .. }));
@@ -1539,7 +1587,12 @@ mod tests {
 
     #[test]
     fn defaults_are_fail_safe() {
-        let c = NodeConfig::defaults(Reach::Local, generate_identity(), InMemoryStorage::new());
+        let c = NodeConfig::defaults(
+            Reach::Local,
+            generate_identity(),
+            InMemoryStorage::new(),
+            BlobStorageBackend::in_memory(),
+        );
         assert!(matches!(c.tls, TlsMode::SelfSigned), "tls fail-safe");
         assert!(
             matches!(c.dht, DhtMode::Disabled),
@@ -1553,7 +1606,12 @@ mod tests {
         assert!(c.projection_rate_limit.is_none());
         assert!(c.dns_provider.is_none());
         assert!(c.network_detector.is_none());
-        assert!(c.blob_storage.is_none());
+        // `blob_storage` is now a required, explicit selection (no default) — it
+        // holds exactly the arm the caller passed (SCP-CAPINJECT-010).
+        assert!(
+            matches!(c.blob_storage, BlobStorageBackend::InMemory(_)),
+            "blob_storage holds the explicitly-selected in-memory arm"
+        );
         assert!(c.dht_gateways.is_empty());
         #[cfg(feature = "http3")]
         assert!(c.http3.is_none());
@@ -1571,6 +1629,7 @@ mod tests {
                 },
                 generate_identity(),
                 InMemoryStorage::new(),
+                BlobStorageBackend::in_memory(),
             )
         })
         .await;
@@ -1601,6 +1660,7 @@ mod tests {
                 },
                 generate_identity(),
                 InMemoryStorage::new(),
+                BlobStorageBackend::in_memory(),
             )
         })
         .await
@@ -1637,6 +1697,7 @@ mod tests {
                 Reach::NatTraversal,
                 generate_identity(),
                 InMemoryStorage::new(),
+                BlobStorageBackend::in_memory(),
             )
         })
         .await
@@ -1669,6 +1730,7 @@ mod tests {
                 },
                 generate_identity(),
                 InMemoryStorage::new(),
+                BlobStorageBackend::in_memory(),
             )
         })
         .await
@@ -1678,7 +1740,12 @@ mod tests {
 
         let local = Node::start_for_testing(NodeConfig {
             bind_addr: Some(SocketAddr::from(([127, 0, 0, 1], 0))),
-            ..NodeConfig::defaults(Reach::Local, generate_identity(), InMemoryStorage::new())
+            ..NodeConfig::defaults(
+                Reach::Local,
+                generate_identity(),
+                InMemoryStorage::new(),
+                BlobStorageBackend::in_memory(),
+            )
         })
         .await
         .expect("Local + DhtMode::Disabled is a non-publishing reach and must be valid");
@@ -1706,7 +1773,12 @@ mod tests {
                 port_mapper: None,
                 reachability_probe: None,
             },
-            ..NodeConfig::defaults(Reach::Local, generate_identity(), InMemoryStorage::new())
+            ..NodeConfig::defaults(
+                Reach::Local,
+                generate_identity(),
+                InMemoryStorage::new(),
+                BlobStorageBackend::in_memory(),
+            )
         })
         .await
         .expect("NatSlot::Tuned overrides should lower and build offline on a Local reach");
@@ -1718,35 +1790,36 @@ mod tests {
         node.shutdown();
     }
 
-    // --- Test 15: blob_storage Some overrides, None preserves the default -----
+    // --- Test 15: blob_storage is an explicit, required durability-only choice --
 
+    /// SCP-CAPINJECT-010 AC3: `InMemoryBlobStorage` remains a legitimate,
+    /// **explicitly-selected** durability-only backend (SCP-CAPSEL-8010/8011). A
+    /// node built with an explicit `BlobStorageBackend::in_memory()` selection
+    /// still builds and serves — proving the durability-only arm stays reachable
+    /// by explicit choice. There is deliberately no "None preserves default" case
+    /// anymore: `blob_storage` is a required, non-`Option` field, so there is no
+    /// omit-the-field / silent-default shape to test (that shape was the removed
+    /// SCP-CAPSEL-8011 violation).
     #[tokio::test]
-    async fn blob_storage_some_overrides_and_none_preserves_default() {
-        // Some(...) overrides the builder's in-memory default; None preserves it
-        // (the builder's `new()` sets `Some(BlobStorageBackend::default())`, so
-        // the None path must NOT clear the relay's blob storage). Both paths
-        // build on a Local (non-publishing) reach, which is the observable proof:
-        // the None path did not break the build by clearing blob storage. We do
-        // not assert the private backend value — only what is observable.
-        let with_some = Node::start_for_testing(NodeConfig {
+    async fn blob_storage_in_memory_is_explicitly_selectable() {
+        // Build on a Local (non-publishing) reach with an EXPLICIT in-memory blob
+        // backend. A successful build + serve is the observable proof that the
+        // durability-only arm is still selectable; we do not assert the private
+        // backend value — only what is observable.
+        let node = Node::start_for_testing(NodeConfig {
             bind_addr: Some(SocketAddr::from(([127, 0, 0, 1], 0))),
-            blob_storage: Some(BlobStorageBackend::default()),
-            ..NodeConfig::defaults(Reach::Local, generate_identity(), InMemoryStorage::new())
+            ..NodeConfig::defaults(
+                Reach::Local,
+                generate_identity(),
+                InMemoryStorage::new(),
+                // The required, explicit durability-only selection.
+                BlobStorageBackend::in_memory(),
+            )
         })
         .await
-        .expect("blob_storage: Some(default) should override and build");
-        assert!(with_some.domain().is_none());
-        with_some.shutdown();
-
-        let with_none = Node::start_for_testing(NodeConfig {
-            bind_addr: Some(SocketAddr::from(([127, 0, 0, 1], 0))),
-            blob_storage: None,
-            ..NodeConfig::defaults(Reach::Local, generate_identity(), InMemoryStorage::new())
-        })
-        .await
-        .expect("blob_storage: None should preserve the builder default and build");
-        assert!(with_none.domain().is_none());
-        with_none.shutdown();
+        .expect("an explicit in-memory blob backend should build and serve");
+        assert!(node.domain().is_none());
+        node.shutdown();
     }
 
     // --- Test 16: Persisted rejects mismatched custody through Node::start -----
@@ -1774,6 +1847,7 @@ mod tests {
                     did_method: did_method_a,
                 },
                 Arc::clone(&storage),
+                BlobStorageBackend::in_memory(),
             )
         })
         .await
@@ -1796,6 +1870,7 @@ mod tests {
                     did_method: did_method_b,
                 },
                 Arc::clone(&storage),
+                BlobStorageBackend::in_memory(),
             )
         })
         .await;
@@ -1840,6 +1915,7 @@ mod tests {
                 },
                 generate_identity(),
                 Arc::clone(&storage),
+                BlobStorageBackend::in_memory(),
             )
         })
         .await
@@ -1884,6 +1960,7 @@ mod tests {
                 },
                 generate_identity(),
                 InMemoryStorage::new(),
+                BlobStorageBackend::in_memory(),
             )
         })
         .await
@@ -1926,6 +2003,7 @@ mod tests {
                 },
                 generate_identity(),
                 InMemoryStorage::new(),
+                BlobStorageBackend::in_memory(),
             )
         })
         .await
@@ -1959,7 +2037,12 @@ mod tests {
             tls: TlsMode::Acme {
                 email: Some("admin@example.com".to_owned()),
             },
-            ..NodeConfig::defaults(Reach::Local, generate_identity(), InMemoryStorage::new())
+            ..NodeConfig::defaults(
+                Reach::Local,
+                generate_identity(),
+                InMemoryStorage::new(),
+                BlobStorageBackend::in_memory(),
+            )
         })
         .await;
 
@@ -1998,7 +2081,12 @@ mod tests {
                 tls: TlsMode::Acme {
                     email: Some("admin@example.com".to_owned()),
                 },
-                ..NodeConfig::defaults(reach, generate_identity(), InMemoryStorage::new())
+                ..NodeConfig::defaults(
+                    reach,
+                    generate_identity(),
+                    InMemoryStorage::new(),
+                    BlobStorageBackend::in_memory(),
+                )
             })
             .await;
 
@@ -2053,7 +2141,12 @@ mod tests {
         let node = Node::start_for_testing(NodeConfig {
             bind_addr: Some(SocketAddr::from(([127, 0, 0, 1], 0))),
             tls: TlsMode::Plaintext,
-            ..NodeConfig::defaults(Reach::Local, generate_identity(), InMemoryStorage::new())
+            ..NodeConfig::defaults(
+                Reach::Local,
+                generate_identity(),
+                InMemoryStorage::new(),
+                BlobStorageBackend::in_memory(),
+            )
         })
         .await
         .expect("Local + Plaintext is a non-Domain no-op TLS build and must succeed");
@@ -2075,7 +2168,12 @@ mod tests {
         let node = Node::start_for_testing(NodeConfig {
             bind_addr: Some(SocketAddr::from(([127, 0, 0, 1], 0))),
             tls: TlsMode::Terminated,
-            ..NodeConfig::defaults(Reach::Local, generate_identity(), InMemoryStorage::new())
+            ..NodeConfig::defaults(
+                Reach::Local,
+                generate_identity(),
+                InMemoryStorage::new(),
+                BlobStorageBackend::in_memory(),
+            )
         })
         .await
         .expect("Local + Terminated is a non-Domain no-op TLS build and must succeed");

--- a/crates/scp-node/src/dev_api.rs
+++ b/crates/scp-node/src/dev_api.rs
@@ -615,7 +615,7 @@ mod tests {
             dev_token: Some(token.to_owned()),
             dev_bind_addr: Some("127.0.0.1:9100".parse::<SocketAddr>().unwrap()),
             projected_contexts: RwLock::new(HashMap::new()),
-            blob_storage: Arc::new(BlobStorageBackend::default()),
+            blob_storage: Arc::new(BlobStorageBackend::in_memory()),
             relay_config: scp_transport::native::server::RelayConfig::default(),
             start_time: Instant::now(),
             http_bind_addr: SocketAddr::from(([0, 0, 0, 0], 8443)),

--- a/crates/scp-node/src/dns_provider.rs
+++ b/crates/scp-node/src/dns_provider.rs
@@ -114,6 +114,7 @@ struct ErrorResponse {
 ///         Reach::Domain { domain: "placeholder.scp.ctx.network".to_owned() },
 ///         IdentitySource::Generate { custody, did_method },
 ///         storage,
+///         BlobStorageBackend::sqlite(&blob_db)?, // durable backend for a public node
 ///     )
 /// })
 /// .await?;

--- a/crates/scp-node/src/http.rs
+++ b/crates/scp-node/src/http.rs
@@ -1165,7 +1165,7 @@ mod tests {
             dev_token: None,
             dev_bind_addr: None,
             projected_contexts: RwLock::new(HashMap::new()),
-            blob_storage: Arc::new(BlobStorageBackend::default()),
+            blob_storage: Arc::new(BlobStorageBackend::in_memory()),
             relay_config: scp_transport::native::server::RelayConfig::default(),
             start_time: Instant::now(),
             http_bind_addr: SocketAddr::from(([0, 0, 0, 0], 8443)),

--- a/crates/scp-node/src/lib.rs
+++ b/crates/scp-node/src/lib.rs
@@ -1556,6 +1556,9 @@ impl ApplicationNode<scp_platform::in_memory::InMemoryStorage> {
                     did_method,
                 },
                 InMemoryStorage::new(),
+                // Durability-only blob arm, selected explicitly — `dev()` is a
+                // documented dev/prototyping affordance (SCP-CAPINJECT-010).
+                BlobStorageBackend::in_memory(),
             )
         })
         .await
@@ -3794,6 +3797,7 @@ mod tests {
                     did_method,
                 },
                 InMemoryStorage::new(),
+                BlobStorageBackend::in_memory(),
             )
         }
     }
@@ -3859,6 +3863,7 @@ mod tests {
                     },
                 )),
                 InMemoryStorage::new(),
+                BlobStorageBackend::in_memory(),
             )
         })
         .await
@@ -3953,6 +3958,7 @@ mod tests {
                     did_method: counting_method,
                 },
                 InMemoryStorage::new(),
+                BlobStorageBackend::in_memory(),
             )
         })
         .await
@@ -4106,6 +4112,7 @@ mod tests {
                     did_method: check_method,
                 },
                 InMemoryStorage::new(),
+                BlobStorageBackend::in_memory(),
             )
         })
         .await
@@ -4177,6 +4184,7 @@ mod tests {
                     did_method,
                 },
                 InMemoryStorage::new(),
+                BlobStorageBackend::in_memory(),
             )
         }
     }
@@ -4356,6 +4364,7 @@ mod tests {
                     did_method,
                 },
                 InMemoryStorage::new(),
+                BlobStorageBackend::in_memory(),
             )
         };
         (config, publish_attempts)
@@ -4452,6 +4461,7 @@ mod tests {
                     did_method,
                 },
                 InMemoryStorage::new(),
+                BlobStorageBackend::in_memory(),
             )
         };
         (config, publish_attempts)
@@ -4587,6 +4597,7 @@ mod tests {
                     did_method,
                 },
                 InMemoryStorage::new(),
+                BlobStorageBackend::in_memory(),
             )
         })
         .await
@@ -4651,6 +4662,7 @@ mod tests {
                     did_method,
                 },
                 InMemoryStorage::new(),
+                BlobStorageBackend::in_memory(),
             )
         })
         .await;
@@ -4741,6 +4753,7 @@ mod tests {
                     did_method: counting_method,
                 },
                 InMemoryStorage::new(),
+                BlobStorageBackend::in_memory(),
             )
         })
         .await
@@ -5835,6 +5848,7 @@ mod tests {
                     did_method,
                 },
                 Arc::clone(&storage),
+                BlobStorageBackend::in_memory(),
             )
         })
         .await
@@ -5889,6 +5903,7 @@ mod tests {
                     did_method: Arc::clone(&did_method),
                 },
                 Arc::clone(&storage),
+                BlobStorageBackend::in_memory(),
             )
         })
         .await
@@ -5937,6 +5952,7 @@ mod tests {
                     did_method,
                 },
                 Arc::clone(&storage),
+                BlobStorageBackend::in_memory(),
             )
         })
         .await;
@@ -6110,6 +6126,7 @@ mod tests {
                     did_method,
                 },
                 Arc::clone(&storage),
+                BlobStorageBackend::in_memory(),
             )
         })
         .await;
@@ -6151,6 +6168,7 @@ mod tests {
                     did_method,
                 },
                 Arc::clone(&storage),
+                BlobStorageBackend::in_memory(),
             )
         })
         .await
@@ -6189,6 +6207,7 @@ mod tests {
                     did_method: Arc::clone(&did_method),
                 },
                 Arc::clone(&storage),
+                BlobStorageBackend::in_memory(),
             )
         })
         .await
@@ -6209,6 +6228,7 @@ mod tests {
                     did_method,
                 },
                 Arc::clone(&storage),
+                BlobStorageBackend::in_memory(),
             )
         })
         .await

--- a/crates/scp-node/src/main.rs
+++ b/crates/scp-node/src/main.rs
@@ -29,6 +29,7 @@ use scp_node::{DhtMode, IdentitySource, Node, NodeConfig, Reach, TlsMode};
 use scp_platform::EncryptedStorage;
 use scp_platform::sqlite::{SqliteKeyCustody, SqliteStorage};
 use scp_transport::native::server::RelayServer;
+use scp_transport::native::storage::BlobStorageBackend;
 use scp_transport::startup;
 
 // ---------------------------------------------------------------------------
@@ -300,6 +301,27 @@ async fn run_relay_only() {
 // Full node mode — ephemeral
 // ---------------------------------------------------------------------------
 
+/// The blob backend for ephemeral mode: always in-memory, no persistence, env
+/// overrides deliberately IGNORED.
+///
+/// This is the ephemeral caller's explicit selection at its own boundary
+/// (SCP-CAPINJECT-010). It is a named function — not an inline literal — so the
+/// "ephemeral ⇒ in-memory blob" contract is pinned by a unit test
+/// (`ephemeral_uses_in_memory_blob`) and cannot silently regress to a durable /
+/// env-driven backend (which would violate the all-in-memory contract documented
+/// on [`run_full_node_ephemeral`] and re-persist blobs to disk).
+///
+/// Gated to `any(test, feature = "testing")` because that is exactly where it is
+/// used and nowhere else: the ephemeral entry point [`run_full_node_ephemeral`]
+/// is itself `#[cfg(feature = "testing")]`, and the regression test is
+/// `#[cfg(test)]`. Under a plain default-feature build it would be dead code; the
+/// regression test still runs under `cargo test` (which enables `cfg(test)`).
+#[cfg(any(test, feature = "testing"))]
+#[must_use]
+fn ephemeral_blob_backend() -> BlobStorageBackend {
+    BlobStorageBackend::in_memory()
+}
+
 /// Runs the full node with all in-memory subsystems (no persistence).
 ///
 /// In ephemeral mode, ALL subsystems use in-memory implementations regardless
@@ -373,6 +395,8 @@ async fn run_full_node_ephemeral() {
         seq_init,
         did_method,
         encrypted_storage,
+        // Ephemeral contract: in-memory blob, no persistence, env ignored.
+        ephemeral_blob_backend(),
     )
     .await;
 }
@@ -508,6 +532,11 @@ async fn run_full_node_persistent(storage_path: Option<&PathBuf>) {
                 seq_init,
                 did_method,
                 Arc::clone(&node_storage_arc),
+                // Persistent mode: operator-configured durable blob backend
+                // (default SQLite), honoring `SCP_RELAY_STORAGE_BACKEND` /
+                // `SCP_RELAY_STORAGE_PATH` — the same explicit selection
+                // relay-only mode makes (SCP-CAPINJECT-010).
+                startup::storage_from_env().await,
             )
             .await;
         }
@@ -536,6 +565,10 @@ async fn run_full_node_persistent(storage_path: Option<&PathBuf>) {
                 seq_init,
                 did_method,
                 Arc::clone(&node_storage_arc),
+                // Persistent mode: operator-configured durable blob backend
+                // (default SQLite), honoring `SCP_RELAY_STORAGE_BACKEND` /
+                // `SCP_RELAY_STORAGE_PATH` (SCP-CAPINJECT-010).
+                startup::storage_from_env().await,
             )
             .await;
         }
@@ -878,6 +911,15 @@ async fn run_node_with<
     seq_init: scp_node::self_host::SeqInitFn,
     did_method: Arc<D>,
     storage: S,
+    // The relay's blob backend, selected by each caller at ITS OWN boundary
+    // (SCP-CAPINJECT-010 / spec §17.17.1). Threaded as a required parameter —
+    // exactly like `storage` — so this shared helper NEVER manufactures a backend
+    // (that would re-introduce the SCP-CAPSEL-8002 anti-pattern the story kills,
+    // and would break ephemeral mode's all-in-memory contract). Ephemeral mode
+    // passes `ephemeral_blob_backend()` (in-memory, no persistence, env-ignoring);
+    // persistent mode passes `startup::storage_from_env()` (durable, default
+    // SQLite, honors env).
+    blob_storage: BlobStorageBackend,
 ) {
     let use_self_signed = env_flag_is_truthy(env::var("SCP_NODE_TLS_SELF_SIGNED").ok().as_deref());
 
@@ -959,6 +1001,7 @@ async fn run_node_with<
                 did_method,
             },
             storage,
+            blob_storage,
         )
     })
     .await
@@ -1100,6 +1143,22 @@ async fn main() {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// Regression guard (SCP-CAPINJECT-010): ephemeral mode MUST select the
+    /// in-memory blob backend — no persistence, env overrides ignored. This pins
+    /// the ephemeral caller's boundary selection so it cannot silently regress to
+    /// a durable / env-driven backend (`startup::storage_from_env`, which defaults
+    /// to `Sqlite`), which would break the all-in-memory contract documented on
+    /// `run_full_node_ephemeral` and re-persist blobs to disk. If someone swaps
+    /// `ephemeral_blob_backend()` to any non-in-memory backend, this fails.
+    #[test]
+    fn ephemeral_uses_in_memory_blob() {
+        assert!(
+            matches!(ephemeral_blob_backend(), BlobStorageBackend::InMemory(_)),
+            "ephemeral mode must use the in-memory blob backend (no persistence, \
+             env ignored) — see the all-in-memory contract on run_full_node_ephemeral"
+        );
+    }
 
     /// `SCP_NODE_SELF_HOST_NO_NAT` (and every opt-in self-host flag) is truthy
     /// only for the exact values `"1"` and `"true"`. This is the parsing rule

--- a/crates/scp-node/src/self_host.rs
+++ b/crates/scp-node/src/self_host.rs
@@ -2265,7 +2265,11 @@ async fn build_host_site_node<D: scp_identity::DidMethod + 'static>(
         nat,
         http_bind_addr: Some(http_addr),
         projection_rate_limit: Some(projection_rate_limit),
-        blob_storage: Some(blob_storage),
+        // The self-host binary's operator-chosen backend: a durable, persistent
+        // SQLite blob store (opened above, fail-closed on error). Passed as the
+        // required `blob_storage` selection at this construction boundary — the
+        // legitimate config default (an explicit caller choice), NOT a runtime
+        // manufactured default (SCP-CAPINJECT-010 / spec §17.17.1).
         ..NodeConfig::defaults(
             reach,
             IdentitySource::Persisted {
@@ -2273,6 +2277,7 @@ async fn build_host_site_node<D: scp_identity::DidMethod + 'static>(
                 did_method,
             },
             node_storage,
+            blob_storage,
         )
     };
 

--- a/crates/scp-node/tests/integration.rs
+++ b/crates/scp-node/tests/integration.rs
@@ -12,6 +12,8 @@
 use std::net::SocketAddr;
 use std::sync::Arc;
 
+use scp_transport::native::storage::BlobStorageBackend;
+
 use axum::body::Body;
 use http_body_util::BodyExt;
 use hyper::Request;
@@ -95,6 +97,7 @@ async fn build_test_node_with(
                 did_method: Arc::new(did_dht),
             },
             InMemoryStorage::new(),
+            BlobStorageBackend::in_memory(),
         )
     })
     .await

--- a/crates/scp-node/tests/quic_cross_transport.rs
+++ b/crates/scp-node/tests/quic_cross_transport.rs
@@ -26,6 +26,7 @@ use std::time::Duration;
 use futures::{SinkExt, StreamExt};
 use quinn::{ClientConfig, Endpoint};
 use scp_relay_client::{ClientMessage, RelayMessage};
+use scp_transport::native::storage::BlobStorageBackend;
 use scp_transport::quic::listener::SCP_ALPN;
 use tokio_tungstenite::tungstenite::Message as WsMessage;
 
@@ -419,6 +420,7 @@ async fn build_tls_node(http_port: u16) -> ApplicationNode<InMemoryStorage> {
                 did_method,
             },
             InMemoryStorage::new(),
+            BlobStorageBackend::in_memory(),
         )
     })
     .await

--- a/crates/scp-node/tests/quic_listener.rs
+++ b/crates/scp-node/tests/quic_listener.rs
@@ -20,6 +20,7 @@ use std::time::Duration;
 
 use quinn::{ClientConfig, Endpoint};
 use scp_relay_client::{ClientMessage, RelayMessage};
+use scp_transport::native::storage::BlobStorageBackend;
 use scp_transport::quic::listener::SCP_ALPN;
 
 use scp_clock::SystemClock;
@@ -146,6 +147,7 @@ async fn build_tls_node(http_port: u16) -> ApplicationNode<InMemoryStorage> {
                 did_method,
             },
             InMemoryStorage::new(),
+            BlobStorageBackend::in_memory(),
         )
     })
     .await

--- a/crates/scp-node/tests/self_host.rs
+++ b/crates/scp-node/tests/self_host.rs
@@ -29,6 +29,8 @@
 use std::net::SocketAddr;
 use std::sync::Arc;
 
+use scp_transport::native::storage::BlobStorageBackend;
+
 use axum::body::Body;
 use http_body_util::BodyExt;
 use hyper::Request;
@@ -182,7 +184,6 @@ async fn build_self_host_node() -> BuiltNode {
         dht: DhtMode::Production,
         bind_addr: Some(SocketAddr::from(([127, 0, 0, 1], 0))),
         http_bind_addr: Some(SocketAddr::from(([127, 0, 0, 1], 0))),
-        blob_storage: Some(blob_storage),
         ..NodeConfig::defaults(
             Reach::NatTraversal,
             IdentitySource::Generate {
@@ -190,6 +191,9 @@ async fn build_self_host_node() -> BuiltNode {
                 did_method,
             },
             node_storage,
+            // Explicit durable SQLite blob backend (opened above) as the required
+            // selection (SCP-CAPINJECT-010).
+            blob_storage,
         )
     })
     .await
@@ -815,7 +819,6 @@ async fn self_host_shares_single_root_storage_handle_and_serves() {
         dht: DhtMode::Production,
         bind_addr: Some(SocketAddr::from(([127, 0, 0, 1], 0))),
         http_bind_addr: Some(SocketAddr::from(([127, 0, 0, 1], 0))),
-        blob_storage: Some(blob_storage),
         ..NodeConfig::defaults(
             Reach::NatTraversal,
             IdentitySource::Generate {
@@ -823,6 +826,9 @@ async fn self_host_shares_single_root_storage_handle_and_serves() {
                 did_method,
             },
             Arc::clone(&root_storage),
+            // Explicit durable SQLite blob backend (opened above) as the required
+            // selection (SCP-CAPINJECT-010).
+            blob_storage,
         )
     })
     .await
@@ -978,7 +984,6 @@ async fn build_self_host_node_over_dir(dir: &std::path::Path) -> ApplicationNode
         dht: DhtMode::Production,
         bind_addr: Some(SocketAddr::from(([127, 0, 0, 1], 0))),
         http_bind_addr: Some(SocketAddr::from(([127, 0, 0, 1], 0))),
-        blob_storage: Some(blob_storage),
         ..NodeConfig::defaults(
             Reach::NatTraversal,
             IdentitySource::Persisted {
@@ -986,6 +991,9 @@ async fn build_self_host_node_over_dir(dir: &std::path::Path) -> ApplicationNode
                 did_method,
             },
             node_storage,
+            // Explicit durable SQLite blob backend (opened above) as the required
+            // selection (SCP-CAPINJECT-010).
+            blob_storage,
         )
     })
     .await
@@ -1078,6 +1086,7 @@ async fn nat_traversal_disabled_dht_node_starts_without_publishing() {
                 did_method,
             },
             node_storage,
+            BlobStorageBackend::in_memory(),
         )
     })
     .await
@@ -1155,7 +1164,6 @@ async fn skip_nat_probe_uses_loopback_relay_url_without_probing() {
         nat: NatSlot::Custom(Arc::new(PanicOnProbeNatStrategy)),
         bind_addr: Some(SocketAddr::from(([127, 0, 0, 1], 0))),
         http_bind_addr: Some(SocketAddr::from(([127, 0, 0, 1], http_port))),
-        blob_storage: Some(blob_storage),
         ..NodeConfig::defaults(
             Reach::Local,
             IdentitySource::Persisted {
@@ -1163,6 +1171,9 @@ async fn skip_nat_probe_uses_loopback_relay_url_without_probing() {
                 did_method,
             },
             node_storage,
+            // Explicit durable SQLite blob backend (opened above) as the required
+            // selection (SCP-CAPINJECT-010).
+            blob_storage,
         )
     })
     .await

--- a/crates/scp-testing/src/helpers.rs
+++ b/crates/scp-testing/src/helpers.rs
@@ -31,6 +31,7 @@ use scp_node::{
 };
 use scp_platform::in_memory::InMemoryStorage;
 use scp_platform::testing::InMemoryKeyCustody;
+use scp_transport::native::storage::BlobStorageBackend;
 
 /// The concrete `DidDht` type used in tests (in-memory DHT, system clock).
 pub type TestDidDht = DidDht<InMemoryDhtClient, SystemClock>;
@@ -143,6 +144,8 @@ pub fn test_node_config() -> NodeConfig<InMemoryKeyCustody, TestDidDht, InMemory
                 did_method,
             },
             InMemoryStorage::new(),
+            // Durability-only blob arm, selected explicitly (SCP-CAPINJECT-010).
+            BlobStorageBackend::in_memory(),
         )
     }
 }
@@ -170,6 +173,8 @@ pub fn test_no_domain_node_config(
                 did_method,
             },
             InMemoryStorage::new(),
+            // Durability-only blob arm, selected explicitly (SCP-CAPINJECT-010).
+            BlobStorageBackend::in_memory(),
         )
     }
 }

--- a/crates/scp-testing/tests/integration/node.rs
+++ b/crates/scp-testing/tests/integration/node.rs
@@ -12,6 +12,7 @@ use scp_node::{
     DhtMode, IdentitySource, NatSlot, Node, NodeConfig, Reach, ReachabilityTier, TlsMode,
 };
 use scp_testing::helpers;
+use scp_transport::native::storage::BlobStorageBackend;
 
 // ---------------------------------------------------------------------------
 // Builder — domain mode
@@ -93,6 +94,7 @@ async fn failing_tls_falls_through_to_nat() {
                 did_method,
             },
             InMemoryStorage::new(),
+            BlobStorageBackend::in_memory(),
         )
     })
     .await;
@@ -134,6 +136,7 @@ async fn failing_nat_strategy() {
                 did_method,
             },
             InMemoryStorage::new(),
+            BlobStorageBackend::in_memory(),
         )
     })
     .await;

--- a/crates/scp-transport/src/native/storage.rs
+++ b/crates/scp-transport/src/native/storage.rs
@@ -558,11 +558,15 @@ impl BlobStorageBackend {
     }
 }
 
-impl Default for BlobStorageBackend {
-    fn default() -> Self {
-        Self::in_memory()
-    }
-}
+// NOTE (SCP-CAPINJECT-010 / ADR-062 §Decision 5, spec §17.17.1): this enum has
+// deliberately NO `Default` implementation. `InMemory` is a durability-only
+// development arm (SCP-CAPSEL-8010/8011): it may be selected EXPLICITLY
+// (`in_memory()` / `in_memory_with_capacity()`), but it must never be
+// manufactured as a default or reached as a fallback. A `Default` that returned
+// `in_memory()` was a live SCP-CAPSEL-8011 violation (the runtime silently
+// selecting the dev arm the operator never chose); the backend is now a required,
+// non-`Option` selection made by the caller at the relay/node construction
+// boundary (see `scp-node`'s `NodeConfig::blob_storage` / `self_host`).
 
 impl From<InMemoryBlobStorage> for BlobStorageBackend {
     fn from(storage: InMemoryBlobStorage) -> Self {


### PR DESCRIPTION
## Summary
Implements **SCP-CAPINJECT-010** (ADR-062 Slice 10, E3 blob storage) — a live SCP-CAPSEL-8011 fix.

- Deletes `impl Default for BlobStorageBackend` (the silent in-memory manufacturer).
- Makes `NodeConfig.blob_storage` a **required non-`Option` field** (the ADR-052 M4 analog of the existing `storage` field) — omission is now a compile error, not a runtime default. `defaults()` gains a required 4th arg; both `unwrap_or_default()` fallbacks removed.
- **`InMemoryBlobStore` stays a durability-only, explicit, un-gated option** (§17.17.2 — blob loss fails closed, nullifies no security property) — never a default/fallback. Deliberate asymmetry from the nullifier stories.
- **Notable catch:** the shipped `scp-node` full-node binary (`main.rs`) was itself silently defaulting to in-memory blob via the removed `unwrap_or_default()`. It now explicitly selects the env-driven durable backend (`startup::storage_from_env()`, default sqlite, fail-closed on misconfig). The blob backend is selected at each caller boundary and threaded in — never manufactured inside a shared runtime helper (ephemeral → in-memory, persistent → durable), with a regression test.

## Review
Full roster (bug-catcher, completionist, security, simplifier, alignment) + double-zero. One HIGH finding (ephemeral mode had briefly regressed to durable) caught and fixed with a regression test; re-review clean.

## CI note
The 4 `scp-relay::storage_backend` binary-spawn tests that flake locally are the pre-existing tracked issue #2159 (nextest binary-path resolution under shared-target/worktree); scp-relay is byte-identical to main and not in this diff. They pass in CI.

Closes #0 <!-- story tracked in .docs/prds/adr062-capability-injection.json, no GH issue -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)