### PR TITLE
chore(ci): recognize SCP-CAPSEL classification taxonomy in check-error-codes.sh (§17.17.2)

### DIFF
--- a/scripts/check-error-codes.sh
+++ b/scripts/check-error-codes.sh
@@ -75,6 +75,15 @@ check_code() {
                 [[ $num -ge 13000 && $num -le 13999 ]] || { echo "VIOLATION: $file:$line_num: $code — SAGA range is 13000-13999"; VIOLATIONS=$((VIOLATIONS + 1)); }
             fi
             ;;
+        # SCP-CAPSEL is NOT an emitted error code. It is the capability-selection
+        # *classification* taxonomy defined in .docs/specs/17-persistence-and-storage.md
+        # §17.17.1/§17.17.2 (the exact defined set is 8000, 8001, 8002, 8010, 8011,
+        # 8012, 8013). It is cited in source comments/rustdoc for provenance
+        # (ADR-062 capability-injection work) and is deliberately absent from the
+        # error-code registry (error_codes.rs, sdk-common.md; see the "ID note" at
+        # §17.17.2). We validate it for range — a genuinely malformed CAPSEL code is
+        # still caught — but do NOT treat it as a mis-prefixed error code.
+        SCP-CAPSEL)   [[ $num -ge 8000 && $num -le 8099 ]] || { echo "VIOLATION: $file:$line_num: $code — CAPSEL classification range is 8000-8099 (§17.17.2)"; VIOLATIONS=$((VIOLATIONS + 1)); } ;;
         SCP-UNKNOWN)  ;; # Sentinel for unmapped bridge errors — allowed
         SCP-TEST)     ;; # Test sentinel — allowed
         *)


### PR DESCRIPTION
## Summary

`scripts/check-error-codes.sh` validates SCP error-code literals in source (canonical prefix + range). Its `*)` fallback flags **any** `SCP-<PREFIX>-<NNNN>` with number ≥ 1000 and a non-canonical prefix as a "non-canonical prefix" violation.

`SCP-CAPSEL-80xx` is **not an error code** — it is the capability-selection **classification taxonomy** defined in spec `.docs/specs/17-persistence-and-storage.md` §17.17.1/§17.17.2 (the durability-only-vs-nullifier classification of provider development arms; defined set: `8000, 8001, 8002, 8010, 8011, 8012, 8013`). It is cited in source comments/rustdoc for provenance (ADR-062 capability-injection work) and is deliberately absent from the error-code registry (`crates/scp-ffi/common/src/error_codes.rs`, `.docs/standards/sdk-common.md`; see the explicit "ID note" at §17.17.2). Because its numbers are ≥ 1000, the checker emits **false-positive** violations for these legitimate provenance citations.

## Fix

Add a bounded per-prefix `case` for `SCP-CAPSEL` (range **8000-8099**, modest headroom over the currently-defined 8000-8013), mirroring the existing `SCP-IDENT` / `SCP-STORAGE` / etc. cases, with a comment explaining CAPSEL is a spec **classification** taxonomy, not an emitted error code.

This is a **positive, bounded recognition** of a real taxonomy — it removes a false positive without relaxing validation of any actual error code. It is **not** a blanket skip: a genuinely malformed CAPSEL code (e.g. `SCP-CAPSEL-1234`) is still caught. No existing assertion is weakened, removed, or exempted. Per CLAUDE.md's enforcement-file rules, the only legitimate modifications to enforcement scripts are adding new/expanding coverage — this is a bounded expansion.

## Verification

```
# baseline on origin/main — passes, no SCP-CAPSEL in source yet
$ bash scripts/check-error-codes.sh; echo $?
  Checked 3486 error code occurrences.
  PASSED: All error codes conform to sdk-common.md ranges.
  0

# isolated check_code() self-test
Case A: SCP-CAPSEL-8011 (in range)     -> NO violation
Case B: SCP-CAPSEL-1234 (out of range) -> 1 violation
  VIOLATION: fixture.rs:2: SCP-CAPSEL-1234 — CAPSEL classification range is 8000-8099 (§17.17.2)

# end-to-end through the grep pipeline (temp fixture in crates/scp-core/src)
in-range  SCP-CAPSEL-8011 fixture -> exit 0 (scanned, not flagged; 3486->3487)
out-range SCP-CAPSEL-1234 fixture -> exit 1, flagged

# fixture removed, final run on main's real source
$ bash scripts/check-error-codes.sh; echo $?
  Checked 3486 error code occurrences.
  PASSED: All error codes conform to sdk-common.md ranges.
  0
```

Only `scripts/check-error-codes.sh` is touched; no other CI gate is affected. `bash -n` passes; the two shellcheck warnings on line 193 are pre-existing (the Phase-2 comment-skip glob) and untouched by this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)