### PR TITLE
docs(claude): align the orchestrator's 'exact CI clippy command' with ci.yml (add the 4 missing feature flags)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -229,7 +229,7 @@ The orchestrator never writes code. It manages execution, maintains plan alignme
 - Verify against the PUSHED REMOTE branch (`git show origin/branch:file`), never the local working directory. Local state may be on a different branch.
 - For type deletions: `grep -c "struct TypeName" <file>` must return 0.
 - For imports: `grep -c "scp_protocol::module" <file>` must return >0.
-- Run the exact CI clippy command with ALL features before pushing: `cargo clippy --workspace --all-targets --features scp-ffi-uniffi/testing,scp-ffi/testing,scp-ffi-napi/testing,scp-core/testing,scp-runtime/testing -- -D warnings`
+- Run the exact CI clippy command with ALL features before pushing: `cargo clippy --workspace --all-targets --features scp-ffi-uniffi/testing,scp-ffi/testing,scp-ffi-napi/testing,scp-core/testing,scp-runtime/testing,scp-runtime/saga-witness-test-mint,scp-ffi/outlet-capability-test-grant,scp-ffi-napi/outlet-capability-test-grant,scp-ffi-uniffi/outlet-capability-test-grant -- -D warnings`
 - If a cherry-pick resolves to "nothing to commit," the changes DID NOT LAND. Investigate.
 - Never say "done" without showing verification output.
 


### PR DESCRIPTION
CLAUDE.md's orchestrator-verification clippy command claims to be "the exact CI clippy command with ALL features" but was missing four flags that `ci.yml:476` actually passes: `scp-runtime/saga-witness-test-mint`, `scp-ffi/outlet-capability-test-grant`, `scp-ffi-napi/outlet-capability-test-grant`, `scp-ffi-uniffi/outlet-capability-test-grant`. Running the documented command could therefore miss warnings CI catches (or, pre-#2173, fail on a renamed feature). This aligns the doc with CI. Doc-only; no code or enforcement-assertion change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)