### PR TITLE
chore(ci): pin ruff==0.15.4 for reproducible Python lint

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -214,7 +214,11 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: "3.12"
-      - run: pip install tree-sitter tree-sitter-rust ruff
+      # ruff pinned for reproducible CI — an unpinned `pip install ruff`
+      # silently tracks upstream and a new release (e.g. 0.16.x restyling
+      # Markdown code blocks) can red the lint gate repo-wide with no local
+      # change. Bump deliberately in its own PR. Keep in sync with python-lint.
+      - run: pip install tree-sitter tree-sitter-rust ruff==0.15.4
       # Self-test MUST run first: it plants a deliberately-transposed stub
       # parameter and proves the gate REJECTS it, before we trust it on the
       # real tree.
@@ -700,7 +704,9 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: "3.12"
-      - run: pip install ruff
+      # ruff pinned for reproducible CI (see the pyi-generated job above for
+      # rationale). Bump deliberately in its own PR.
+      - run: pip install ruff==0.15.4
       - run: ruff format --check .
       - run: ruff check .
       # H14 / M16: enforce `is not None` over falsy checks on Optional


### PR DESCRIPTION
## Summary

The `Python / lint` job (and the `Python stub signature parity` job) ran an **unpinned** `pip install ruff`, so CI silently tracked the latest upstream release. ruff **0.16.x** began reformatting embedded Python code blocks in Markdown, which reds `ruff format --check .` on a **pre-existing** `bindings/python/README.md` the moment any `bindings/python`-touching PR triggers the job — with no local change to explain it (surfaced by #2183, whose only `bindings/python` touch was an unrelated dead-`workspace:*` cleanup).

## Fix

Pin both CI ruff installs to `ruff==0.15.4` — the version the tree is currently clean under (`ruff format --check .` **and** `ruff check .` both pass in `bindings/python`), and the last pre-`0.16` line that main was green with. This makes the linter reproducible like every other tool in this repo (mise-pinned), rather than a moving target that reds the gate on an upstream release. Version bumps become deliberate, isolated PRs.

## Scope

- `.github/workflows/ci.yml` only — two `pip install ruff` → `pip install ruff==0.15.4`, plus explanatory comments. No source, no reformatting churn.
- Chosen (per repo-owner direction) over "track latest + reformat the README," to stop the class of break recurring on the next ruff release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)