### PR TITLE
feat(credentials): durable bridge-credential backend, delete impl Default, demote in-memory to test-only (ADR-062 Slice 9, SCP-CAPINJECT-009)

### DIFF
--- a/.docs/standards/sdk-capability-matrix.json
+++ b/.docs/standards/sdk-capability-matrix.json
@@ -1923,6 +1923,13 @@
           "typescript": true,
           "kotlin": true,
           "swift": true
+        },
+        {
+          "name": "credential_backend_durable",
+          "python": true,
+          "typescript": true,
+          "kotlin": true,
+          "swift": true
         }
       ]
     },

--- a/crates/scp-ffi/common/Cargo.toml
+++ b/crates/scp-ffi/common/Cargo.toml
@@ -21,7 +21,17 @@ resolvers = ["dep:scp-core", "dep:scp-identity", "dep:scp-event-log", "dep:scp-t
 # activated (via the `server` feature): the server.rs auto-generate path calls
 # the testing-gated `ApplicationNode::dev`. The `?` keeps testing usable without
 # `server`. Never in a default/non-testing list (ADR-062 §Decision 1).
-testing = ["resolvers", "scp-did/testing", "scp-dht/testing", "scp-node?/testing"]
+# `scp-core?/testing` makes the testing-gated `FfiCredentialStore::InMemory`
+# arm (which names `scp_core::bridge::credentials::InMemoryCredentialStore`,
+# itself `#[cfg(any(test, feature = "testing"))]`) self-consistent whenever this
+# crate's own `testing` is enabled (ADR-062 §Decision 5, SCP-CAPINJECT-009).
+testing = [
+    "resolvers",
+    "scp-core?/testing",
+    "scp-did/testing",
+    "scp-dht/testing",
+    "scp-node?/testing",
+]
 # Shared callback-custody byte/string parsing helpers (custody_parse module).
 # Requires only scp-platform for the typed return values (KeyHandle,
 # PseudonymKeypair, PublicKey, PlatformError). Deliberately NOT folded into

--- a/crates/scp-ffi/common/src/credentials.rs
+++ b/crates/scp-ffi/common/src/credentials.rs
@@ -1,0 +1,246 @@
+//! Bridge credential-store selection seam shared by all three FFI bridges.
+//!
+//! `BridgeCredentialStore` uses RPITIT (return-position `impl Trait`), so it is
+//! **not** dyn-compatible — a bridge cannot hold an
+//! `Arc<dyn BridgeCredentialStore>`. Following the same enum-dispatch shape the
+//! codebase already uses for the other non-object-safe provider capabilities
+//! (`StorageProvider`, `ProtocolRepository`), [`FfiCredentialStore`] is a
+//! concrete enum that itself implements `BridgeCredentialStore`, dispatching per
+//! arm:
+//!
+//! - [`FfiCredentialStore::Durable`] — the **real** production backend
+//!   ([`ProtocolRepositoryCredentialStore`], erased as
+//!   `Arc<dyn DurableCredentialBackend>`), persisting bridge tokens through the
+//!   same `EncryptedStorage` backend the bridge already selected for
+//!   `mls_storage` and the saga journal.
+//! - `FfiCredentialStore::InMemory` — a **test-harness-only** double
+//!   (`#[cfg(feature = "testing")]`), gated so it is provably absent from every
+//!   shipped artifact (ADR-062 §Decision 5 / §Decision 6 G1, SCP-CAPINJECT-009).
+//!
+//! There is deliberately **no `Default`** and no zero-argument constructor: a
+//! bridge MUST select the arm explicitly at its construction boundary
+//! (SCP-CAPSEL-8000). The deleted `impl Default for InMemoryCredentialStore` was
+//! the live SCP-CAPSEL-8000/8011 violation this seam replaces.
+//!
+//! Credentials are classified **durability-only** (spec §17.17.2): RAM-only
+//! tokens are re-obtainable by re-auth, so the security-relevant fix is the
+//! selection boundary, not the persistence itself. Durability nonetheless
+//! tracks the storage selection by construction — a Sqlite selection persists
+//! tokens across restart; an encrypted-in-memory selection keeps them encrypted
+//! at rest.
+
+use std::sync::Arc;
+
+use scp_core::bridge::credentials::{
+    BridgeCredential, BridgeCredentialStore, CredentialError, CredentialType,
+    DurableCredentialBackend, ProtocolRepositoryCredentialStore,
+};
+use scp_platform::EncryptedStorage;
+use zeroize::Zeroizing;
+
+/// The bridge credential-store selection seam. See the module docs.
+///
+/// `Clone` is cheap — every arm is an `Arc`.
+#[derive(Clone)]
+pub enum FfiCredentialStore {
+    /// The real durable backend, selected at the bridge construction boundary
+    /// from the same storage handle used for `mls_storage` / the saga journal.
+    Durable(Arc<dyn DurableCredentialBackend>),
+
+    /// Test-harness-only in-memory double. Gated behind `testing` so it is
+    /// provably absent from shipped artifacts (ADR-062 §Decision 6 G1).
+    #[cfg(feature = "testing")]
+    InMemory(Arc<scp_core::bridge::credentials::InMemoryCredentialStore>),
+}
+
+impl std::fmt::Debug for FfiCredentialStore {
+    /// Redacted `Debug` — never surfaces credential state, only the selected
+    /// arm.
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Durable(_) => f.write_str("FfiCredentialStore::Durable"),
+            #[cfg(feature = "testing")]
+            Self::InMemory(_) => f.write_str("FfiCredentialStore::InMemory"),
+        }
+    }
+}
+
+impl FfiCredentialStore {
+    /// Selects the **real durable backend** over the given `EncryptedStorage`
+    /// handle.
+    ///
+    /// The handle is the SAME `Arc<S>` the bridge already threads into
+    /// [`DurableProviders::from_handle`](scp_core::context::supervisor::DurableProviders::from_handle),
+    /// so credentials share the one chosen backend by construction (spec §17.6):
+    /// a Sqlite handle persists tokens across restart; an
+    /// `EncryptingAdapter<InMemoryStorage>` handle keeps them encrypted at rest.
+    #[must_use]
+    pub fn durable_from_handle<S>(handle: Arc<S>) -> Self
+    where
+        S: EncryptedStorage + 'static,
+    {
+        let backend: Arc<dyn DurableCredentialBackend> =
+            Arc::new(ProtocolRepositoryCredentialStore::new(handle));
+        Self::Durable(backend)
+    }
+
+    /// Selects the **test-harness-only** in-memory double.
+    ///
+    /// Gated behind `testing`; never reachable from a shipped artifact
+    /// (ADR-062 §Decision 6 G1).
+    #[cfg(feature = "testing")]
+    #[must_use]
+    pub fn in_memory() -> Self {
+        Self::InMemory(Arc::new(
+            scp_core::bridge::credentials::InMemoryCredentialStore::new(),
+        ))
+    }
+}
+
+impl BridgeCredentialStore for FfiCredentialStore {
+    async fn provision(
+        &self,
+        bridge_id: &str,
+        credential_type: CredentialType,
+        plaintext: &[u8],
+        bridge_credential_key: &[u8; 32],
+    ) -> Result<BridgeCredential, CredentialError> {
+        match self {
+            Self::Durable(backend) => {
+                backend
+                    .provision(bridge_id, credential_type, plaintext, bridge_credential_key)
+                    .await
+            }
+            #[cfg(feature = "testing")]
+            Self::InMemory(store) => {
+                store
+                    .provision(bridge_id, credential_type, plaintext, bridge_credential_key)
+                    .await
+            }
+        }
+    }
+
+    async fn retrieve(
+        &self,
+        bridge_id: &str,
+        credential_type: &CredentialType,
+        bridge_credential_key: &[u8; 32],
+    ) -> Result<Zeroizing<Vec<u8>>, CredentialError> {
+        match self {
+            Self::Durable(backend) => {
+                backend
+                    .retrieve(bridge_id, credential_type, bridge_credential_key)
+                    .await
+            }
+            #[cfg(feature = "testing")]
+            Self::InMemory(store) => {
+                store
+                    .retrieve(bridge_id, credential_type, bridge_credential_key)
+                    .await
+            }
+        }
+    }
+
+    async fn rotate(
+        &self,
+        bridge_id: &str,
+        credential_type: &CredentialType,
+        new_plaintext: &[u8],
+        bridge_credential_key: &[u8; 32],
+    ) -> Result<BridgeCredential, CredentialError> {
+        match self {
+            Self::Durable(backend) => {
+                backend
+                    .rotate(
+                        bridge_id,
+                        credential_type,
+                        new_plaintext,
+                        bridge_credential_key,
+                    )
+                    .await
+            }
+            #[cfg(feature = "testing")]
+            Self::InMemory(store) => {
+                store
+                    .rotate(
+                        bridge_id,
+                        credential_type,
+                        new_plaintext,
+                        bridge_credential_key,
+                    )
+                    .await
+            }
+        }
+    }
+
+    async fn revoke(&self, bridge_id: &str) -> Result<(), CredentialError> {
+        match self {
+            Self::Durable(backend) => backend.revoke(bridge_id).await,
+            #[cfg(feature = "testing")]
+            Self::InMemory(store) => store.revoke(bridge_id).await,
+        }
+    }
+
+    async fn list(&self, bridge_id: &str) -> Result<Vec<CredentialType>, CredentialError> {
+        match self {
+            Self::Durable(backend) => backend.list(bridge_id).await,
+            #[cfg(feature = "testing")]
+            Self::InMemory(store) => store.list(bridge_id).await,
+        }
+    }
+
+    async fn store_bridge_credential_key(
+        &self,
+        bridge_id: &str,
+        key: Zeroizing<[u8; 32]>,
+    ) -> Result<(), CredentialError> {
+        match self {
+            Self::Durable(backend) => backend.store_bridge_credential_key(bridge_id, key).await,
+            #[cfg(feature = "testing")]
+            Self::InMemory(store) => store.store_bridge_credential_key(bridge_id, key).await,
+        }
+    }
+
+    async fn get_bridge_credential_key(
+        &self,
+        bridge_id: &str,
+    ) -> Result<Zeroizing<[u8; 32]>, CredentialError> {
+        match self {
+            Self::Durable(backend) => backend.get_bridge_credential_key(bridge_id).await,
+            #[cfg(feature = "testing")]
+            Self::InMemory(store) => store.get_bridge_credential_key(bridge_id).await,
+        }
+    }
+
+    async fn delete_bridge_credential_key(&self, bridge_id: &str) -> Result<(), CredentialError> {
+        match self {
+            Self::Durable(backend) => backend.delete_bridge_credential_key(bridge_id).await,
+            #[cfg(feature = "testing")]
+            Self::InMemory(store) => store.delete_bridge_credential_key(bridge_id).await,
+        }
+    }
+}
+
+#[cfg(all(test, feature = "testing"))]
+#[allow(clippy::unwrap_used, clippy::expect_used)]
+mod tests {
+    use super::*;
+
+    /// The in-memory harness arm dispatches through the enum end-to-end.
+    #[tokio::test]
+    async fn in_memory_arm_provision_retrieve_roundtrip() {
+        let store = FfiCredentialStore::in_memory();
+        let key = *scp_core::bridge::credentials::generate_bridge_credential_key();
+
+        store
+            .provision("bridge-x", CredentialType::ApiKey, b"secret-token", &key)
+            .await
+            .unwrap();
+
+        let out = store
+            .retrieve("bridge-x", &CredentialType::ApiKey, &key)
+            .await
+            .unwrap();
+        assert_eq!(out.as_slice(), b"secret-token");
+    }
+}

--- a/crates/scp-ffi/common/src/lib.rs
+++ b/crates/scp-ffi/common/src/lib.rs
@@ -106,6 +106,13 @@ pub use bridge_instance::{
 #[cfg(feature = "resolvers")]
 pub mod bridge_runtime;
 
+// Bridge credential-store selection seam shared by all three FFI bridges
+// (ADR-062 §Decision 5, SCP-CAPINJECT-009). The `FfiCredentialStore` enum
+// dispatches between the real durable backend and a testing-only in-memory
+// double. Requires scp-core (behind `resolvers` feature).
+#[cfg(feature = "resolvers")]
+pub mod credentials;
+
 // Crash-safe per-stream `monotonic_seq` grant counter (SCP-OUT-034 AC31) shared
 // by all three bridges. Persists the cursor to durable `Storage` so an SDK
 // restart never regresses the §5.4.5 credit-grant sequence. Requires

--- a/crates/scp-ffi/napi/src/bridge_connector.rs
+++ b/crates/scp-ffi/napi/src/bridge_connector.rs
@@ -307,7 +307,7 @@ pub(crate) fn bridge_create_shadow_on(
 // Credential store operations (§12.11)
 //
 // Per-bridge-instance helpers mirroring the PyO3 `*_impl` functions in
-// `crates/scp-ffi/src/bridge_connector.rs`. Each resolves the credential
+// `crates/scp-ffi/src/bridge_connector.rs`. Each resolves the durable credential
 // store from `bi.credential_store()` and drives the async
 // `BridgeCredentialStore` trait via the shared tokio runtime
 // (`crate::runtime().block_on(...)`) — the napi-rs worker thread has no

--- a/crates/scp-ffi/napi/src/runtime.rs
+++ b/crates/scp-ffi/napi/src/runtime.rs
@@ -25,6 +25,7 @@ use scp_ffi_common::bridge_instance::BridgeInstanceCore;
 // without each caller importing the full `scp_ffi_common` path.
 pub use scp_ffi_common::bridge_instance::CoreFields;
 use scp_ffi_common::bridge_runtime::EventLogInMemoryStorageHandle;
+use scp_ffi_common::credentials::FfiCredentialStore;
 use scp_ffi_common::error_codes as codes;
 use std::collections::{HashMap, HashSet};
 use std::sync::{Arc, OnceLock};
@@ -299,18 +300,16 @@ pub struct NapiBridgeInstance {
 
     /// Per-instance bridge credential store (spec §12.11).
     ///
-    /// Mirrors `PyBridgeInstance::credential_store` — each `Scp` instance
-    /// owns its own `InMemoryCredentialStore` so that OAuth tokens, API
-    /// keys, and bridge credential keys provisioned through one bridge
-    /// instance are isolated from every other instance in the same process
-    /// (ADR-048 §1 multi-instance neutrality). The store is thread-safe via
-    /// its internal `tokio::sync::RwLock`. Production deployments should
-    /// replace this with a `Storage`-backed implementation when it lands
-    /// (spec §12.11.2). Dropping the `Arc` on shutdown zeroizes any retained
-    /// bridge credential keys via the store's `Zeroizing` fields — there is no
-    /// explicit clear step in `bridge_specific_shutdown`, so the store lives
-    /// exactly as long as its last `Arc` reference.
-    pub(crate) credential_store: Arc<scp_core::bridge::credentials::InMemoryCredentialStore>,
+    /// The **durable** [`FfiCredentialStore`] selected at construction from the
+    /// SAME storage handle that backs `mls_storage` and the saga journal (spec
+    /// §17.6) — a Sqlite selection persists bridge tokens across restart; an
+    /// encrypted-in-memory selection keeps them encrypted at rest. Per-instance,
+    /// so credentials provisioned through one `Scp` are isolated from every
+    /// other instance in the same process (ADR-048 §1 multi-instance
+    /// neutrality). There is no in-memory arm on this shipped path — the
+    /// in-memory store's `Default` impl that made it a default selection was
+    /// deleted (ADR-062 §Decision 5, SCP-CAPINJECT-009).
+    pub(crate) credential_store: FfiCredentialStore,
 
     /// Per-instance §5.4.5 streaming-outlet registry (SCP-OUT-037, C8a).
     ///
@@ -365,6 +364,10 @@ impl NapiBridgeInstance {
         // The durable saga journal and the `mls_storage` view are bound into one
         // `DurableProviders` derived from the SAME `Arc`, so they cannot diverge
         // by construction (§17.6 / §17.16).
+        // The durable credential store shares the ONE chosen storage handle
+        // with `mls_storage` / the saga journal (spec §17.6) — select it BEFORE
+        // the handle is moved into `durable_providers_from_handle`.
+        let credential_store = FfiCredentialStore::durable_from_handle(Arc::clone(&storage_handle));
         let durable_providers = durable_providers_from_handle(storage_handle);
         Self {
             core: CoreFields::new(),
@@ -377,9 +380,7 @@ impl NapiBridgeInstance {
             #[cfg(feature = "testing")]
             network: std::sync::Mutex::new(None),
             recovery_semaphore: Arc::new(tokio::sync::Semaphore::new(RECOVERY_CONCURRENCY_CAP)),
-            credential_store: Arc::new(
-                scp_core::bridge::credentials::InMemoryCredentialStore::new(),
-            ),
+            credential_store,
             outlet_stream_registry: Arc::new(DashMap::new()),
         }
     }
@@ -396,6 +397,9 @@ impl NapiBridgeInstance {
             scp_ffi_common::bridge_runtime::build_event_log_provider();
         // Saga journal + `mls_storage` bound into one `DurableProviders` derived
         // from one handle (§17.6 / §17.16).
+        // Durable credential store over the SAME chosen handle (§17.6),
+        // selected before the handle is moved into the durable providers.
+        let credential_store = FfiCredentialStore::durable_from_handle(Arc::clone(&storage_handle));
         let durable_providers = durable_providers_from_handle(storage_handle);
         Self {
             core: CoreFields::with_persistence(persistence),
@@ -408,9 +412,7 @@ impl NapiBridgeInstance {
             #[cfg(feature = "testing")]
             network: std::sync::Mutex::new(None),
             recovery_semaphore: Arc::new(tokio::sync::Semaphore::new(RECOVERY_CONCURRENCY_CAP)),
-            credential_store: Arc::new(
-                scp_core::bridge::credentials::InMemoryCredentialStore::new(),
-            ),
+            credential_store,
             outlet_stream_registry: Arc::new(DashMap::new()),
         }
     }
@@ -490,6 +492,10 @@ impl NapiBridgeInstance {
                 // and the journal is built over the SAME handle, so saga replay
                 // reads and writes the one `SQLCipher` connection (§17.6 /
                 // §17.16). They cannot diverge by construction.
+                // Durable credential store over the SAME `Arc<SqliteStorage>`
+                // (§17.6) — bridge tokens persist across restart with the DB.
+                let credential_store =
+                    FfiCredentialStore::durable_from_handle(Arc::clone(&arc_storage));
                 let durable_providers = durable_providers_from_handle(Arc::clone(&arc_storage));
                 drop(arc_storage);
 
@@ -497,6 +503,7 @@ impl NapiBridgeInstance {
                     persistence,
                     ProtocolRepoVariant::Sqlite(event_log_repo),
                     durable_providers,
+                    credential_store,
                 ))
             }
         }
@@ -522,6 +529,7 @@ impl NapiBridgeInstance {
         persistence: Arc<dyn ContextPersistence + Send + Sync>,
         protocol_repository: ProtocolRepoVariant,
         durable_providers: scp_core::context::supervisor::DurableProviders,
+        credential_store: FfiCredentialStore,
     ) -> Self {
         Self {
             core: CoreFields::with_persistence_arc(persistence),
@@ -534,9 +542,7 @@ impl NapiBridgeInstance {
             #[cfg(feature = "testing")]
             network: std::sync::Mutex::new(None),
             recovery_semaphore: Arc::new(tokio::sync::Semaphore::new(RECOVERY_CONCURRENCY_CAP)),
-            credential_store: Arc::new(
-                scp_core::bridge::credentials::InMemoryCredentialStore::new(),
-            ),
+            credential_store,
             outlet_stream_registry: Arc::new(DashMap::new()),
         }
     }
@@ -585,16 +591,11 @@ impl NapiBridgeInstance {
         &self.mcp_client_registry
     }
 
-    /// Returns a reference to this instance's bridge credential store.
-    ///
-    /// Mirrors `PyBridgeInstance::credential_store`. The returned
-    /// `Arc<InMemoryCredentialStore>` is the same instance the
-    /// `NapiBridgeInstance` holds — thread-safe via internal
-    /// `tokio::sync::RwLock`.
+    /// Returns a reference to this instance's **durable** bridge credential
+    /// store, selected at construction from the chosen storage backend
+    /// (ADR-062 §Decision 5, SCP-CAPINJECT-009).
     #[must_use]
-    pub const fn credential_store(
-        &self,
-    ) -> &Arc<scp_core::bridge::credentials::InMemoryCredentialStore> {
+    pub const fn credential_store(&self) -> &FfiCredentialStore {
         &self.credential_store
     }
 

--- a/crates/scp-ffi/napi/src/scp.rs
+++ b/crates/scp-ffi/napi/src/scp.rs
@@ -4266,8 +4266,9 @@ impl Scp {
     //
     // Per-instance equivalents of the PyO3 `bridge_credential_*` methods.
     // Each routes through `&*self.inner` — credentials live in THIS
-    // instance's `InMemoryCredentialStore`, isolated from every other `Scp`
-    // in the process (ADR-048 §1).
+    // instance's durable `FfiCredentialStore`, selected from its chosen
+    // storage backend and isolated from every other `Scp` in the process
+    // (ADR-048 §1; ADR-062 §Decision 5, SCP-CAPINJECT-009).
     // -------------------------------------------------------------------
 
     /// Provisions (stores) an encrypted credential for a bridge instance.

--- a/crates/scp-ffi/src/bridge_connector.rs
+++ b/crates/scp-ffi/src/bridge_connector.rs
@@ -35,7 +35,6 @@
 //! and ADR-023.
 
 use scp_ffi_common::error_codes as codes;
-use std::sync::Arc;
 
 use pyo3::prelude::*;
 use pyo3::types::{PyDict, PyList};
@@ -44,8 +43,7 @@ use crate::runtime::PyBridgeInstance;
 
 use scp_core::bridge::claiming::{ClaimRequest, claim_shadow};
 use scp_core::bridge::credentials::{
-    BridgeCredentialStore, CredentialType, InMemoryCredentialStore, derive_credential_key,
-    generate_bridge_credential_key,
+    BridgeCredentialStore, CredentialType, derive_credential_key, generate_bridge_credential_key,
 };
 use scp_core::bridge::envelope::{
     SealShadowEnvelopeParams, open_shadow_envelope, seal_shadow_envelope,
@@ -66,6 +64,7 @@ use scp_core::crypto::sender_keys::{SenderKey, SenderKeyStore};
 use scp_core::provenance::{DataProvenance, DiscoveryMethod, SourceType};
 use scp_core::trust::attestation::Attestation;
 use scp_ffi_common::bridge_state::BridgeContextState;
+use scp_ffi_common::credentials::FfiCredentialStore;
 use zeroize::Zeroizing;
 
 use crate::error::ScpPyError;
@@ -74,18 +73,25 @@ use crate::error::ScpPyError;
 // Credential store — resolved via explicit PyBridgeInstance
 // ---------------------------------------------------------------------------
 
-/// Returns a reference to the given bridge instance's credential store.
+/// Selects the given bridge instance's **durable** credential store, or fails
+/// closed if storage has not been selected.
 ///
-/// Migrated from a process-global `OnceLock<InMemoryCredentialStore>` onto
-/// the typed `credential_store` field on
-/// [`crate::runtime::PyBridgeInstance`] in #1549 Phase 4 PR 2 commit 5.
-///
-/// The returned [`Arc<InMemoryCredentialStore>`] is the same instance the
-/// `PyBridgeInstance` holds — `InMemoryCredentialStore` is thread-safe via
-/// internal `tokio::sync::RwLock`. Production deployments should replace
-/// this with a `Storage`-backed implementation when it lands (spec §12.11.2).
-const fn credential_store_for(bi: &PyBridgeInstance) -> &Arc<InMemoryCredentialStore> {
-    bi.credential_store()
+/// The store is derived from the instance's chosen [`StorageProvider`]
+/// (ADR-062 §Decision 5, SCP-CAPINJECT-009): a real durable backend that
+/// persists bridge tokens through the same storage the supervisor uses. There
+/// is no in-memory fallback — a missing storage selection is a fail-closed
+/// error (SCP-CAPSEL-8001), never a silent degrade.
+fn credential_store_for(bi: &PyBridgeInstance) -> PyResult<FfiCredentialStore> {
+    bi.credential_store().ok_or_else(|| {
+        ScpPyError::ContextError {
+            message: "bridge credential store unavailable: storage has not been selected for \
+                      this SCP instance (select storage via SCP(config) before bridge \
+                      credential operations)"
+                .to_owned(),
+            code: codes::CTX_2105.to_string(),
+        }
+        .into()
+    })
 }
 
 // ---------------------------------------------------------------------------
@@ -832,7 +838,7 @@ fn bridge_credential_provision_impl(
     let key_bytes = parse_credential_key_bytes(bridge_credential_key)?;
 
     let rt = crate::runtime()?;
-    let store = credential_store_for(bi);
+    let store = credential_store_for(bi)?;
 
     let credential = rt
         .block_on(store.provision(bridge_id, ct, plaintext, &key_bytes))
@@ -875,7 +881,7 @@ fn bridge_credential_retrieve_impl(
     let key_bytes = parse_credential_key_bytes(bridge_credential_key)?;
 
     let rt = crate::runtime()?;
-    let store = credential_store_for(bi);
+    let store = credential_store_for(bi)?;
 
     let plaintext = rt
         .block_on(store.retrieve(bridge_id, &ct, &key_bytes))
@@ -917,7 +923,7 @@ fn bridge_credential_rotate_impl(
     let key_bytes = parse_credential_key_bytes(bridge_credential_key)?;
 
     let rt = crate::runtime()?;
-    let store = credential_store_for(bi);
+    let store = credential_store_for(bi)?;
 
     let credential = rt
         .block_on(store.rotate(bridge_id, &ct, new_plaintext, &key_bytes))
@@ -947,7 +953,7 @@ fn bridge_credential_rotate_impl(
 /// Raises `ContextError` if the storage backend fails.
 fn bridge_credential_revoke_impl(bi: &PyBridgeInstance, bridge_id: &str) -> PyResult<()> {
     let rt = crate::runtime()?;
-    let store = credential_store_for(bi);
+    let store = credential_store_for(bi)?;
 
     rt.block_on(store.revoke(bridge_id))
         .map_err(|e| ScpPyError::ContextError {
@@ -977,7 +983,7 @@ fn bridge_credential_list_impl(
     bridge_id: &str,
 ) -> PyResult<Py<PyList>> {
     let rt = crate::runtime()?;
-    let store = credential_store_for(bi);
+    let store = credential_store_for(bi)?;
 
     let types = rt
         .block_on(store.list(bridge_id))
@@ -1018,7 +1024,7 @@ fn bridge_credential_store_key_impl(
     let key_bytes = parse_credential_key_bytes(key)?;
 
     let rt = crate::runtime()?;
-    let store = credential_store_for(bi);
+    let store = credential_store_for(bi)?;
 
     rt.block_on(store.store_bridge_credential_key(bridge_id, key_bytes))
         .map_err(|e| ScpPyError::ContextError {
@@ -1044,7 +1050,7 @@ fn bridge_credential_store_key_impl(
 /// Raises `ContextError` if the key is not found.
 fn bridge_credential_get_key_impl(bi: &PyBridgeInstance, bridge_id: &str) -> PyResult<Vec<u8>> {
     let rt = crate::runtime()?;
-    let store = credential_store_for(bi);
+    let store = credential_store_for(bi)?;
 
     let key = rt
         .block_on(store.get_bridge_credential_key(bridge_id))
@@ -1069,7 +1075,7 @@ fn bridge_credential_get_key_impl(bi: &PyBridgeInstance, bridge_id: &str) -> PyR
 /// Raises `ContextError` if storage fails.
 fn bridge_credential_delete_key_impl(bi: &PyBridgeInstance, bridge_id: &str) -> PyResult<()> {
     let rt = crate::runtime()?;
-    let store = credential_store_for(bi);
+    let store = credential_store_for(bi)?;
 
     rt.block_on(store.delete_bridge_credential_key(bridge_id))
         .map_err(|e| ScpPyError::ContextError {
@@ -1698,7 +1704,9 @@ mod tests {
     }
 
     // -------------------------------------------------------------------
-    // Credential store operations (via global InMemoryCredentialStore)
+    // Credential store operations (via the durable FfiCredentialStore selected
+    // from the instance's chosen storage backend; here the encrypted-in-memory
+    // dev/test selection — SCP-CAPINJECT-009)
     // -------------------------------------------------------------------
 
     #[test]

--- a/crates/scp-ffi/src/runtime.rs
+++ b/crates/scp-ffi/src/runtime.rs
@@ -71,6 +71,7 @@ use scp_core::crypto::ucan::revoke::RevocationList;
 use scp_core::store::ProtocolRepository;
 use scp_event_log::EventLog;
 use scp_ffi_common::bridge_instance::BridgeInstanceCore;
+use scp_ffi_common::credentials::FfiCredentialStore;
 // Re-export `CoreFields` at `crate::runtime::CoreFields` so the
 // `pyscp_check_handle!` macro can refer to it as
 // `$crate::runtime::CoreFields`.
@@ -448,18 +449,6 @@ pub struct PyBridgeInstance {
     /// drop during instance shutdown.
     pub(crate) mcp_client_registry: Arc<DashMap<String, crate::mcp::McpClientState>>,
 
-    /// Bridge credential store (replaces `CREDENTIAL_STORE` in
-    /// `bridge_connector.rs`).
-    ///
-    /// Migrated from a process-global `OnceLock<InMemoryCredentialStore>`
-    /// singleton in commit 5. Production deployments should replace this with
-    /// a `Storage`-backed implementation when it lands (spec §12.11.2).
-    /// Dropping the `Arc` on shutdown zeroizes any retained bridge credential
-    /// keys via the store's `Zeroizing` fields — there is no explicit clear
-    /// step in `bridge_specific_shutdown`, so the store lives exactly as long
-    /// as its last `Arc` reference.
-    pub(crate) credential_store: Arc<scp_core::bridge::credentials::InMemoryCredentialStore>,
-
     /// Most recently connected relay URL (replaces `CONNECTED_RELAY_URL` in
     /// `transport.rs`).
     ///
@@ -505,9 +494,6 @@ impl PyBridgeInstance {
             ffi_bridge_state: Arc::new(DashMap::new()),
             mcp_server_registry: Arc::new(DashMap::new()),
             mcp_client_registry: Arc::new(DashMap::new()),
-            credential_store: Arc::new(
-                scp_core::bridge::credentials::InMemoryCredentialStore::new(),
-            ),
             connected_relay_url: RwLock::new(None),
             outlet_stream_registry: Arc::new(DashMap::new()),
             #[cfg(feature = "testing")]
@@ -549,9 +535,6 @@ impl PyBridgeInstance {
             ffi_bridge_state: Arc::new(DashMap::new()),
             mcp_server_registry: Arc::new(DashMap::new()),
             mcp_client_registry: Arc::new(DashMap::new()),
-            credential_store: Arc::new(
-                scp_core::bridge::credentials::InMemoryCredentialStore::new(),
-            ),
             connected_relay_url: RwLock::new(None),
             outlet_stream_registry: Arc::new(DashMap::new()),
             #[cfg(feature = "testing")]
@@ -641,9 +624,6 @@ impl PyBridgeInstance {
                     ffi_bridge_state: Arc::new(DashMap::new()),
                     mcp_server_registry: Arc::new(DashMap::new()),
                     mcp_client_registry: Arc::new(DashMap::new()),
-                    credential_store: Arc::new(
-                        scp_core::bridge::credentials::InMemoryCredentialStore::new(),
-                    ),
                     connected_relay_url: RwLock::new(None),
                     outlet_stream_registry: Arc::new(DashMap::new()),
                     #[cfg(feature = "testing")]
@@ -716,12 +696,37 @@ impl PyBridgeInstance {
         &self.mcp_client_registry
     }
 
-    /// Returns a reference to the bridge credential store.
+    /// Selects this instance's **durable** bridge credential store from the
+    /// chosen storage backend, or `None` if storage has not yet been selected.
+    ///
+    /// The credential store is derived on demand from the SAME per-instance
+    /// [`StorageProvider`] the supervisor's `mls_storage` / saga journal derive
+    /// from (spec §17.6) — so a `Sqlite` selection persists bridge tokens across
+    /// restart and an encrypted-in-memory selection keeps them encrypted at
+    /// rest. Because `StorageProvider` is not itself `EncryptedStorage` (the
+    /// sealed marker lives in `scp-platform`), the concrete inner
+    /// `EncryptedStorage` handle is dispatched per variant, exactly as
+    /// `build_persistence_provider` does for `ProtocolRepository`.
+    ///
+    /// Returns `None` only in the storage-before-selection window; production
+    /// `PyScp` construction always goes through
+    /// [`PyBridgeInstance::with_storage_py`], which selects storage first. The
+    /// caller ([`crate::bridge_connector`]) maps `None` to a fail-closed error
+    /// emitted as `SCP-CTX-2105` (`codes::CTX_2105`) — never a silent in-memory
+    /// fallback. This satisfies requirement SCP-CAPSEL-8001 (spec §17.17.1,
+    /// "selection fails closed"); note SCP-CAPSEL-8001 is a classification
+    /// requirement, not the emitted error code. There is no in-memory arm on
+    /// this shipped path (ADR-062 §Decision 5, SCP-CAPINJECT-009).
     #[must_use]
-    pub const fn credential_store(
-        &self,
-    ) -> &Arc<scp_core::bridge::credentials::InMemoryCredentialStore> {
-        &self.credential_store
+    pub fn credential_store(&self) -> Option<FfiCredentialStore> {
+        match self.storage_provider()? {
+            StorageProvider::InMemoryEncrypted(handle) => {
+                Some(FfiCredentialStore::durable_from_handle(Arc::clone(handle)))
+            }
+            StorageProvider::Sqlite(handle) => {
+                Some(FfiCredentialStore::durable_from_handle(Arc::clone(handle)))
+            }
+        }
     }
 
     /// Returns a reference to the connected-relay URL slot.

--- a/crates/scp-ffi/uniffi/src/runtime.rs
+++ b/crates/scp-ffi/uniffi/src/runtime.rs
@@ -38,6 +38,7 @@
 
 use async_trait::async_trait;
 use scp_ffi_common::bridge_instance::BridgeInstanceCore;
+use scp_ffi_common::credentials::FfiCredentialStore;
 // Re-export `CoreFields` at `crate::runtime::CoreFields` so bridge.rs
 // and server.rs can name it in impl blocks without pulling in the full
 // path.
@@ -339,17 +340,15 @@ pub struct UniffiBridgeInstance {
 
     /// Per-instance bridge credential store (spec §12.11).
     ///
-    /// Mirrors `PyBridgeInstance::credential_store` and
-    /// `NapiBridgeInstance::credential_store` — each `Scp` instance owns its
-    /// own `InMemoryCredentialStore` so OAuth tokens, API keys, and bridge
-    /// credential keys provisioned through one instance are isolated from
-    /// every other instance in the same process (ADR-048 §1 multi-instance
-    /// neutrality). Thread-safe via the store's internal
-    /// `tokio::sync::RwLock`. Production deployments should replace this with
-    /// a `Storage`-backed implementation when it lands (spec §12.11.2).
-    /// Dropping the `Arc` on shutdown zeroizes any retained bridge
-    /// credential keys via the store's `Zeroizing` fields.
-    pub(crate) credential_store: Arc<scp_core::bridge::credentials::InMemoryCredentialStore>,
+    /// The **durable** [`FfiCredentialStore`] selected at construction from the
+    /// SAME storage handle that backs `mls_storage` and the saga journal (spec
+    /// §17.6) — a Sqlite selection persists bridge tokens across restart; an
+    /// encrypted-in-memory selection keeps them encrypted at rest. Per-instance,
+    /// so credentials are isolated from every other instance in the same process
+    /// (ADR-048 §1 multi-instance neutrality). There is no in-memory arm on this
+    /// shipped path — the in-memory store's `Default` impl that made it a
+    /// default selection was deleted (ADR-062 §Decision 5, SCP-CAPINJECT-009).
+    pub(crate) credential_store: FfiCredentialStore,
 
     /// Per-instance §5.4.5 streaming-outlet registry, keyed by the stream's
     /// `request_id` hex (`StreamHandleId`). Mirrors the `PyO3` reference bridge's
@@ -392,6 +391,9 @@ impl UniffiBridgeInstance {
         // durable saga journal and the `mls_storage` view are bound into one
         // `DurableProviders` derived from the SAME `Arc`, so they cannot diverge
         // by construction (§17.6 / §17.16).
+        // Durable credential store over the SAME chosen handle (§17.6),
+        // selected before the handle is moved into the durable providers.
+        let credential_store = FfiCredentialStore::durable_from_handle(Arc::clone(&storage_handle));
         let durable_providers = durable_providers_from_handle(storage_handle);
         Self {
             core: CoreFields::new(),
@@ -403,9 +405,7 @@ impl UniffiBridgeInstance {
             mcp_server_registry: Arc::new(DashMap::new()),
             mcp_client_registry: Arc::new(DashMap::new()),
             durable_providers: Some(durable_providers),
-            credential_store: Arc::new(
-                scp_core::bridge::credentials::InMemoryCredentialStore::new(),
-            ),
+            credential_store,
             outlet_stream_registry: Arc::new(DashMap::new()),
         }
     }
@@ -425,6 +425,9 @@ impl UniffiBridgeInstance {
             scp_ffi_common::bridge_runtime::build_event_log_provider();
         // Saga journal + `mls_storage` bound into one `DurableProviders` derived
         // from one handle (§17.6 / §17.16).
+        // Durable credential store over the SAME chosen handle (§17.6),
+        // selected before the handle is moved into the durable providers.
+        let credential_store = FfiCredentialStore::durable_from_handle(Arc::clone(&storage_handle));
         let durable_providers = durable_providers_from_handle(storage_handle);
         Self {
             core: CoreFields::with_persistence(persistence),
@@ -436,9 +439,7 @@ impl UniffiBridgeInstance {
             mcp_server_registry: Arc::new(DashMap::new()),
             mcp_client_registry: Arc::new(DashMap::new()),
             durable_providers: Some(durable_providers),
-            credential_store: Arc::new(
-                scp_core::bridge::credentials::InMemoryCredentialStore::new(),
-            ),
+            credential_store,
             outlet_stream_registry: Arc::new(DashMap::new()),
         }
     }
@@ -536,6 +537,10 @@ impl UniffiBridgeInstance {
                 // and the journal is built over the SAME handle, so saga replay
                 // reads and writes the one `SQLCipher` connection (§17.6 /
                 // §17.16). They cannot diverge by construction.
+                // Durable credential store over the SAME `Arc<SqliteStorage>`
+                // (§17.6) — bridge tokens persist across restart with the DB.
+                let credential_store =
+                    FfiCredentialStore::durable_from_handle(Arc::clone(&arc_storage));
                 let durable_providers = durable_providers_from_handle(Arc::clone(&arc_storage));
                 drop(arc_storage);
 
@@ -543,6 +548,7 @@ impl UniffiBridgeInstance {
                     persistence,
                     ProtocolRepoVariant::Sqlite(event_log_repo),
                     durable_providers,
+                    credential_store,
                 ))
             }
         }
@@ -568,6 +574,7 @@ impl UniffiBridgeInstance {
         persistence: Arc<dyn scp_core::context::persistence::ContextPersistence + Send + Sync>,
         protocol_repository: ProtocolRepoVariant,
         durable_providers: scp_core::context::supervisor::DurableProviders,
+        credential_store: FfiCredentialStore,
     ) -> Self {
         Self {
             core: CoreFields::with_persistence_arc(persistence),
@@ -579,9 +586,7 @@ impl UniffiBridgeInstance {
             mcp_server_registry: Arc::new(DashMap::new()),
             mcp_client_registry: Arc::new(DashMap::new()),
             durable_providers: Some(durable_providers),
-            credential_store: Arc::new(
-                scp_core::bridge::credentials::InMemoryCredentialStore::new(),
-            ),
+            credential_store,
             outlet_stream_registry: Arc::new(DashMap::new()),
         }
     }
@@ -611,17 +616,11 @@ impl UniffiBridgeInstance {
         self.core.instance_id()
     }
 
-    /// Returns a reference to this instance's bridge credential store.
-    ///
-    /// Mirrors `PyBridgeInstance::credential_store` /
-    /// `NapiBridgeInstance::credential_store`. The returned
-    /// `Arc<InMemoryCredentialStore>` is the same instance the
-    /// `UniffiBridgeInstance` holds — thread-safe via internal
-    /// `tokio::sync::RwLock`.
+    /// Returns a reference to this instance's **durable** bridge credential
+    /// store, selected at construction from the chosen storage backend
+    /// (ADR-062 §Decision 5, SCP-CAPINJECT-009).
     #[must_use]
-    pub const fn credential_store(
-        &self,
-    ) -> &Arc<scp_core::bridge::credentials::InMemoryCredentialStore> {
+    pub const fn credential_store(&self) -> &FfiCredentialStore {
         &self.credential_store
     }
 

--- a/crates/scp-runtime/src/bridge/credentials.rs
+++ b/crates/scp-runtime/src/bridge/credentials.rs
@@ -43,14 +43,23 @@
 
 use std::sync::LazyLock;
 
-use aes_gcm::aead::Aead;
+use aes_gcm::aead::{Aead, Payload};
 use aes_gcm::{Aes256Gcm, KeyInit, Nonce};
+use async_trait::async_trait;
 use hkdf::Hkdf;
 use rand::RngCore;
 use rand::rngs::OsRng;
+use scp_platform::EncryptedStorage;
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
-use zeroize::{Zeroize, Zeroizing};
+// `Zeroize` (the trait) is only used by the testing-gated
+// `InMemoryCredentialStore`'s in-place `.zeroize()` calls; `Zeroizing` is used
+// unconditionally by the durable path and key derivation.
+#[cfg(any(test, feature = "testing"))]
+use zeroize::Zeroize;
+use zeroize::Zeroizing;
+
+use crate::store::ProtocolRepository;
 
 // ---------------------------------------------------------------------------
 // Constants
@@ -417,15 +426,61 @@ pub fn generate_bridge_credential_key() -> Zeroizing<[u8; 32]> {
     key
 }
 
-/// Encrypts plaintext credential data with AES-256-GCM.
+/// Builds the AES-256-GCM Additional Authenticated Data (AAD) that binds a
+/// credential ciphertext to its *slot identity* — its `credential_type` and
+/// `created_at`.
+///
+/// AAD is authenticated-but-not-encrypted: GCM's tag covers it, so a ciphertext
+/// sealed with one AAD cannot be decrypted (tag verification fails) under a
+/// different AAD. Binding the slot's `credential_type` defeats a **slot-swap**
+/// (copying an `OAuthAccessToken` ciphertext into the `ApiKey` slot, past a
+/// defeated at-rest `SQLCipher` layer): retrieval derives the AAD from the slot
+/// being *accessed*, so a mismatched slot fails the tag rather than returning a
+/// misattributed secret. Binding `created_at` authenticates that otherwise
+/// unauthenticated metadata field against tampering (defense-in-depth).
+///
+/// Encoding is domain-separated, length-delimited, and fixed-width so it is
+/// unambiguous — two distinct `(credential_type, created_at)` pairs can never
+/// produce the same bytes:
+///
+/// ```text
+/// AAD = "SCP-BRIDGE-CREDENTIAL-AAD-V1"          // fixed 28-byte domain tag
+///     || u64_le(len(Display(credential_type)))  // 8-byte length prefix
+///     || Display(credential_type)               // exactly that many bytes
+///     || u64_le(created_at)                      // fixed 8 bytes
+/// ```
+///
+/// `Display(credential_type)` is injective across variants (standard variants
+/// are bare identifiers; `Custom(name)` always renders `Custom(<name>)`, which
+/// no standard variant can equal), and the length prefix removes any
+/// concatenation ambiguity between the type field and the trailing timestamp.
+pub(crate) fn credential_aad(credential_type: &CredentialType, created_at: u64) -> Vec<u8> {
+    const DOMAIN: &[u8] = b"SCP-BRIDGE-CREDENTIAL-AAD-V1";
+    let type_str = credential_type.to_string();
+    let type_bytes = type_str.as_bytes();
+    let mut aad = Vec::with_capacity(DOMAIN.len() + 8 + type_bytes.len() + 8);
+    aad.extend_from_slice(DOMAIN);
+    aad.extend_from_slice(&(type_bytes.len() as u64).to_le_bytes());
+    aad.extend_from_slice(type_bytes);
+    aad.extend_from_slice(&created_at.to_le_bytes());
+    aad
+}
+
+/// Encrypts plaintext credential data with AES-256-GCM, binding `aad`.
 ///
 /// Returns a byte vector containing `[12-byte nonce][ciphertext+tag]`.
-/// The nonce is randomly generated via `OsRng`.
+/// The nonce is randomly generated via `OsRng`. `aad` (see [`credential_aad`])
+/// is authenticated but not stored inline — the caller must reconstruct the
+/// identical AAD at decrypt time.
 ///
 /// # Errors
 ///
 /// Returns [`CredentialError::CryptoError`] if AES-256-GCM encryption fails.
-fn encrypt_credential(key: &[u8; 32], plaintext: &[u8]) -> Result<Vec<u8>, CredentialError> {
+pub(crate) fn encrypt_credential(
+    key: &[u8; 32],
+    plaintext: &[u8],
+    aad: &[u8],
+) -> Result<Vec<u8>, CredentialError> {
     let cipher = Aes256Gcm::new_from_slice(key).map_err(|e| CredentialError::CryptoError {
         reason: format!("invalid key length: {e}"),
     })?;
@@ -434,12 +489,17 @@ fn encrypt_credential(key: &[u8; 32], plaintext: &[u8]) -> Result<Vec<u8>, Crede
     OsRng.fill_bytes(&mut nonce_bytes);
     let nonce = Nonce::from_slice(&nonce_bytes);
 
-    let ciphertext =
-        cipher
-            .encrypt(nonce, plaintext)
-            .map_err(|e| CredentialError::CryptoError {
-                reason: format!("encryption failed: {e}"),
-            })?;
+    let ciphertext = cipher
+        .encrypt(
+            nonce,
+            Payload {
+                msg: plaintext,
+                aad,
+            },
+        )
+        .map_err(|e| CredentialError::CryptoError {
+            reason: format!("encryption failed: {e}"),
+        })?;
 
     // Prepend nonce to ciphertext.
     let mut result = Vec::with_capacity(NONCE_SIZE + ciphertext.len());
@@ -448,18 +508,22 @@ fn encrypt_credential(key: &[u8; 32], plaintext: &[u8]) -> Result<Vec<u8>, Crede
     Ok(result)
 }
 
-/// Decrypts credential data encrypted by [`encrypt_credential`].
+/// Decrypts credential data encrypted by [`encrypt_credential`], verifying `aad`.
 ///
-/// Expects input in the format `[12-byte nonce][ciphertext+tag]`.
-/// The returned plaintext is wrapped in [`Zeroizing`] for defense-in-depth.
+/// Expects input in the format `[12-byte nonce][ciphertext+tag]`. `aad` MUST be
+/// byte-identical to the AAD used at encrypt time (see [`credential_aad`]); a
+/// mismatch (e.g. a ciphertext moved to a different credential-type slot) fails
+/// the GCM tag and returns [`CredentialError::CryptoError`], never a
+/// misattributed plaintext. The returned plaintext is wrapped in [`Zeroizing`].
 ///
 /// # Errors
 ///
 /// Returns [`CredentialError::CryptoError`] if decryption fails (wrong key,
-/// tampered ciphertext, or malformed input).
-fn decrypt_credential(
+/// tampered ciphertext, AAD mismatch, or malformed input).
+pub(crate) fn decrypt_credential(
     key: &[u8; 32],
     encrypted: &[u8],
+    aad: &[u8],
 ) -> Result<Zeroizing<Vec<u8>>, CredentialError> {
     if encrypted.len() < NONCE_SIZE {
         return Err(CredentialError::CryptoError {
@@ -474,12 +538,17 @@ fn decrypt_credential(
         reason: format!("invalid key length: {e}"),
     })?;
 
-    let plaintext =
-        cipher
-            .decrypt(nonce, ciphertext)
-            .map_err(|e| CredentialError::CryptoError {
-                reason: format!("decryption failed: {e}"),
-            })?;
+    let plaintext = cipher
+        .decrypt(
+            nonce,
+            Payload {
+                msg: ciphertext,
+                aad,
+            },
+        )
+        .map_err(|e| CredentialError::CryptoError {
+            reason: format!("decryption failed: {e}"),
+        })?;
 
     Ok(Zeroizing::new(plaintext))
 }
@@ -500,8 +569,18 @@ fn decrypt_credential(
 /// (ADR-049 Decision 12: the async `tokio` read-path `RwLock` is banned).
 ///
 /// Not suitable for production -- credentials are not persisted across
-/// restarts. Production implementations should use the `Storage` trait
-/// (spec section 17) with `SQLite` or equivalent.
+/// restarts. Production selects the durable
+/// [`ProtocolRepositoryCredentialStore`] at the FFI bridge construction
+/// boundary instead; this in-memory double is **test-harness-only**, gated
+/// behind `#[cfg(any(test, feature = "testing"))]` so it is provably absent
+/// from every shipped artifact (ADR-062 §Decision 5, SCP-CAPINJECT-009).
+///
+/// Classified **durability-only** (spec §17.17.2): RAM-only tokens are
+/// re-obtainable by re-auth, so losing them fails closed — it nullifies no
+/// security property. The `impl Default` that made it a *default* selection
+/// was the live SCP-CAPSEL-8000/8011 violation and has been deleted; there is
+/// no zero-argument / omit-the-field way to reach it.
+#[cfg(any(test, feature = "testing"))]
 #[derive(Debug)]
 pub struct InMemoryCredentialStore {
     /// Credentials keyed by `(bridge_id, credential_type)`.
@@ -518,8 +597,13 @@ pub struct InMemoryCredentialStore {
         std::sync::RwLock<std::collections::HashMap<String, Zeroizing<[u8; 32]>>>,
 }
 
+#[cfg(any(test, feature = "testing"))]
 impl InMemoryCredentialStore {
     /// Creates a new empty in-memory credential store.
+    // No `Default` impl: a `Default` is a *default selection* of the in-memory
+    // arm, the live SCP-CAPSEL-8000/8011 violation this story deletes
+    // (ADR-062 §Decision 5, SCP-CAPINJECT-009). Callers must select explicitly.
+    #[allow(clippy::new_without_default)]
     #[must_use]
     pub fn new() -> Self {
         Self {
@@ -553,12 +637,13 @@ impl InMemoryCredentialStore {
     }
 }
 
-impl Default for InMemoryCredentialStore {
-    fn default() -> Self {
-        Self::new()
-    }
-}
+// NOTE: the in-memory store's `Default` impl was DELETED (ADR-062 §Decision 5,
+// SCP-CAPINJECT-009). A `Default` impl is a *default selection* of the
+// in-memory arm — the live SCP-CAPSEL-8000/8011 violation this story fixes.
+// Every reachable construction goes through an explicit `::new()` under
+// `#[cfg(any(test, feature = "testing"))]`, never a zero-argument default.
 
+#[cfg(any(test, feature = "testing"))]
 #[allow(clippy::significant_drop_tightening)] // Nursery false positive: guards are held across the synchronous critical section, then dropped at scope end.
 impl BridgeCredentialStore for InMemoryCredentialStore {
     async fn provision(
@@ -568,16 +653,18 @@ impl BridgeCredentialStore for InMemoryCredentialStore {
         plaintext: &[u8],
         bridge_credential_key: &[u8; 32],
     ) -> Result<BridgeCredential, CredentialError> {
+        // Bind the credential-type slot + created_at as AES-GCM AAD. Compute
+        // `created_at` BEFORE encrypting so the stored value and the sealed AAD
+        // carry the same timestamp.
+        let created_at = now_secs();
         let key = derive_credential_key(bridge_credential_key, bridge_id)?;
-        let encrypted_data = encrypt_credential(&key, plaintext)?;
+        let aad = credential_aad(&credential_type, created_at);
+        let encrypted_data = encrypt_credential(&key, plaintext, &aad)?;
 
         let credential = BridgeCredential {
             encrypted_data,
             credential_type: credential_type.clone(),
-            created_at: std::time::SystemTime::now()
-                .duration_since(std::time::UNIX_EPOCH)
-                .unwrap_or_default()
-                .as_secs(),
+            created_at,
             expires_at: None,
             bridge_id: bridge_id.to_owned(),
         };
@@ -631,7 +718,10 @@ impl BridgeCredentialStore for InMemoryCredentialStore {
             })?;
 
         let key = derive_credential_key(bridge_credential_key, bridge_id)?;
-        decrypt_credential(&key, &credential.encrypted_data)
+        // AAD from the SLOT being accessed (`credential_type`) + the stored
+        // `created_at`. A ciphertext moved into the wrong slot fails the tag.
+        let aad = credential_aad(credential_type, credential.created_at);
+        decrypt_credential(&key, &credential.encrypted_data, &aad)
     }
 
     async fn rotate(
@@ -641,8 +731,10 @@ impl BridgeCredentialStore for InMemoryCredentialStore {
         new_plaintext: &[u8],
         bridge_credential_key: &[u8; 32],
     ) -> Result<BridgeCredential, CredentialError> {
+        let created_at = now_secs();
         let key = derive_credential_key(bridge_credential_key, bridge_id)?;
-        let new_encrypted = encrypt_credential(&key, new_plaintext)?;
+        let aad = credential_aad(credential_type, created_at);
+        let new_encrypted = encrypt_credential(&key, new_plaintext, &aad)?;
 
         let map_key = (bridge_id.to_owned(), credential_type.clone());
         let mut creds = self
@@ -661,14 +753,12 @@ impl BridgeCredentialStore for InMemoryCredentialStore {
         // (defense-in-depth).
         existing.encrypted_data.zeroize();
 
-        // Replace with new credential.
+        // Replace with new credential (same `created_at` bound into the AAD
+        // above).
         let rotated = BridgeCredential {
             encrypted_data: new_encrypted,
             credential_type: credential_type.clone(),
-            created_at: std::time::SystemTime::now()
-                .duration_since(std::time::UNIX_EPOCH)
-                .unwrap_or_default()
-                .as_secs(),
+            created_at,
             expires_at: None,
             bridge_id: bridge_id.to_owned(),
         };
@@ -764,6 +854,334 @@ impl BridgeCredentialStore for InMemoryCredentialStore {
 }
 
 // ---------------------------------------------------------------------------
+// DurableCredentialBackend — object-safe erasure trait
+// ---------------------------------------------------------------------------
+
+/// Object-safe durable credential backend.
+///
+/// [`BridgeCredentialStore`] uses RPITIT (return-position `impl Trait`), so it
+/// is **not** dyn-compatible — the FFI `FfiCredentialStore` seam cannot hold an
+/// `Arc<dyn BridgeCredentialStore>`. This companion trait mirrors the same 8
+/// operations under `#[async_trait]` (boxed, `Send` futures), which **is**
+/// object-safe, so the real durable arm can be type-erased as
+/// `Arc<dyn DurableCredentialBackend>` over whatever `EncryptedStorage` backend
+/// the caller selected at the bridge construction boundary. This is the same
+/// erasure pattern `OpenMlsStorageAdapter` uses to erase a concrete
+/// `S: Storage` (ADR-062 §Dispatch mechanism).
+///
+/// Two [`BridgeCredentialStore`] contract lines are satisfied differently by
+/// the durable production backend than by the in-memory test double, and the
+/// difference is deliberate:
+///
+/// - **Suspension.** `InMemoryCredentialStore::suspend_bridge` is a
+///   test-harness inherent method, not part of [`BridgeCredentialStore`], never
+///   wired by any bridge — so this durable surface has no suspend hook. A
+///   durable store it cannot suspend is never suspended; `retrieve` honors the
+///   "reject when suspended" contract vacuously.
+/// - **Revoke erasure.** The trait's "overwrite with zeros before deletion"
+///   line describes the in-memory (RAM) double. The durable backend instead
+///   crypto-shreds: it deletes the credential *records* (which is what makes
+///   `retrieve` fail, since `retrieve` derives its key from the caller-supplied
+///   `bridge_credential_key`) and the stored root-key custody copy, relying on
+///   the `EncryptedStorage` backend for at-rest confidentiality. This is a
+///   stronger property for durable-at-rest storage than an in-place
+///   zero-overwrite (which `SQLCipher` pages do not reliably provide anyway).
+#[async_trait]
+pub trait DurableCredentialBackend: Send + Sync {
+    /// See [`BridgeCredentialStore::provision`].
+    async fn provision(
+        &self,
+        bridge_id: &str,
+        credential_type: CredentialType,
+        plaintext: &[u8],
+        bridge_credential_key: &[u8; 32],
+    ) -> Result<BridgeCredential, CredentialError>;
+
+    /// See [`BridgeCredentialStore::retrieve`].
+    async fn retrieve(
+        &self,
+        bridge_id: &str,
+        credential_type: &CredentialType,
+        bridge_credential_key: &[u8; 32],
+    ) -> Result<Zeroizing<Vec<u8>>, CredentialError>;
+
+    /// See [`BridgeCredentialStore::rotate`].
+    async fn rotate(
+        &self,
+        bridge_id: &str,
+        credential_type: &CredentialType,
+        new_plaintext: &[u8],
+        bridge_credential_key: &[u8; 32],
+    ) -> Result<BridgeCredential, CredentialError>;
+
+    /// See [`BridgeCredentialStore::revoke`].
+    async fn revoke(&self, bridge_id: &str) -> Result<(), CredentialError>;
+
+    /// See [`BridgeCredentialStore::list`].
+    async fn list(&self, bridge_id: &str) -> Result<Vec<CredentialType>, CredentialError>;
+
+    /// See [`BridgeCredentialStore::store_bridge_credential_key`].
+    async fn store_bridge_credential_key(
+        &self,
+        bridge_id: &str,
+        key: Zeroizing<[u8; 32]>,
+    ) -> Result<(), CredentialError>;
+
+    /// See [`BridgeCredentialStore::get_bridge_credential_key`].
+    async fn get_bridge_credential_key(
+        &self,
+        bridge_id: &str,
+    ) -> Result<Zeroizing<[u8; 32]>, CredentialError>;
+
+    /// See [`BridgeCredentialStore::delete_bridge_credential_key`].
+    async fn delete_bridge_credential_key(&self, bridge_id: &str) -> Result<(), CredentialError>;
+}
+
+/// Lifts a persistence-layer [`StoreError`](crate::store::StoreError) into a
+/// [`CredentialError::StorageError`].
+// Takes the error by value so it can be used directly as a `.map_err(store_err)`
+// function pointer (which passes owned `E`).
+#[allow(clippy::needless_pass_by_value)]
+fn store_err(e: crate::store::StoreError) -> CredentialError {
+    CredentialError::StorageError {
+        reason: e.to_string(),
+    }
+}
+
+/// Current Unix time in whole seconds (credential `created_at`).
+fn now_secs() -> u64 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_secs()
+}
+
+// ---------------------------------------------------------------------------
+// ProtocolRepositoryCredentialStore — the real durable backend
+// ---------------------------------------------------------------------------
+
+/// The **real** durable [`BridgeCredentialStore`] backend.
+///
+/// Bridge credentials and their per-bridge root keys are persisted through the
+/// existing [`ProtocolRepository`] substrate (spec §17.4) over any
+/// `EncryptedStorage` backend (`SQLCipher` on disk, or an `EncryptingAdapter`
+/// in memory — encrypted at rest either way).
+///
+/// Selected at the FFI bridge construction boundary from the SAME storage
+/// handle the bridge already uses for `mls_storage` and the saga journal, so a
+/// Sqlite selection persists bridge tokens across process restart and an
+/// encrypted-in-memory selection keeps them encrypted at rest — durability
+/// tracks the storage selection, by construction (ADR-062 §Decision 5).
+///
+/// This is a `DurableCredentialBackend` (not a `BridgeCredentialStore`
+/// directly) purely so it can be `Arc<dyn …>`-erased behind the
+/// `FfiCredentialStore` seam; the enum re-implements `BridgeCredentialStore` by
+/// delegating to this trait.
+pub struct ProtocolRepositoryCredentialStore<S: EncryptedStorage> {
+    repo: ProtocolRepository<S>,
+}
+
+impl<S: EncryptedStorage> ProtocolRepositoryCredentialStore<S> {
+    /// Wraps an `EncryptedStorage` handle as a durable credential backend.
+    #[must_use]
+    pub const fn new(storage: S) -> Self {
+        Self {
+            repo: ProtocolRepository::new(storage),
+        }
+    }
+}
+
+#[async_trait]
+impl<S: EncryptedStorage + 'static> DurableCredentialBackend
+    for ProtocolRepositoryCredentialStore<S>
+{
+    async fn provision(
+        &self,
+        bridge_id: &str,
+        credential_type: CredentialType,
+        plaintext: &[u8],
+        bridge_credential_key: &[u8; 32],
+    ) -> Result<BridgeCredential, CredentialError> {
+        // Reject duplicates — mirrors the in-memory store's `AlreadyExists`
+        // contract. Callers use `rotate` to replace.
+        //
+        // Best-effort under concurrency: this is a load-check then store over a
+        // non-transactional KV backend (no compare-and-swap), so unlike the
+        // in-memory store's single `RwLock` critical section, two racing
+        // `provision`s for the same `(bridge_id, credential_type)` can both see
+        // `None` and last-write-wins instead of one getting `AlreadyExists`.
+        // Acceptable for this durability-only, rare admin-path capability;
+        // callers needing strict single-writer semantics must quiesce.
+        if self
+            .repo
+            .load_bridge_credential(bridge_id, &credential_type)
+            .await
+            .map_err(store_err)?
+            .is_some()
+        {
+            return Err(CredentialError::AlreadyExists {
+                bridge_id: bridge_id.to_owned(),
+                credential_type,
+            });
+        }
+
+        // Bind the credential-type slot + created_at as AES-GCM AAD (compute
+        // `created_at` before sealing so the stored value matches the AAD).
+        let created_at = now_secs();
+        let key = derive_credential_key(bridge_credential_key, bridge_id)?;
+        let aad = credential_aad(&credential_type, created_at);
+        let encrypted_data = encrypt_credential(&key, plaintext, &aad)?;
+        let credential = BridgeCredential {
+            encrypted_data,
+            credential_type,
+            created_at,
+            expires_at: None,
+            bridge_id: bridge_id.to_owned(),
+        };
+        self.repo
+            .store_bridge_credential(&credential)
+            .await
+            .map_err(store_err)?;
+        Ok(credential)
+    }
+
+    async fn retrieve(
+        &self,
+        bridge_id: &str,
+        credential_type: &CredentialType,
+        bridge_credential_key: &[u8; 32],
+    ) -> Result<Zeroizing<Vec<u8>>, CredentialError> {
+        let credential = self
+            .repo
+            .load_bridge_credential(bridge_id, credential_type)
+            .await
+            .map_err(store_err)?
+            .ok_or_else(|| CredentialError::NotFound {
+                bridge_id: bridge_id.to_owned(),
+                credential_type: credential_type.clone(),
+            })?;
+
+        let key = derive_credential_key(bridge_credential_key, bridge_id)?;
+        // AAD from the SLOT being accessed + the stored `created_at`: a
+        // ciphertext moved into a different-type slot fails the GCM tag.
+        let aad = credential_aad(credential_type, credential.created_at);
+        decrypt_credential(&key, &credential.encrypted_data, &aad)
+    }
+
+    async fn rotate(
+        &self,
+        bridge_id: &str,
+        credential_type: &CredentialType,
+        new_plaintext: &[u8],
+        bridge_credential_key: &[u8; 32],
+    ) -> Result<BridgeCredential, CredentialError> {
+        // Must already exist — mirrors the in-memory store's `NotFound`. Same
+        // best-effort-under-concurrency caveat as `provision`: the existence
+        // check and the store are separate round-trips (no CAS), so a race with
+        // a concurrent `revoke`/`provision` is last-write-wins rather than
+        // strictly serialized.
+        if self
+            .repo
+            .load_bridge_credential(bridge_id, credential_type)
+            .await
+            .map_err(store_err)?
+            .is_none()
+        {
+            return Err(CredentialError::NotFound {
+                bridge_id: bridge_id.to_owned(),
+                credential_type: credential_type.clone(),
+            });
+        }
+
+        let created_at = now_secs();
+        let key = derive_credential_key(bridge_credential_key, bridge_id)?;
+        let aad = credential_aad(credential_type, created_at);
+        let encrypted_data = encrypt_credential(&key, new_plaintext, &aad)?;
+        let rotated = BridgeCredential {
+            encrypted_data,
+            credential_type: credential_type.clone(),
+            created_at,
+            expires_at: None,
+            bridge_id: bridge_id.to_owned(),
+        };
+        // `store_bridge_credential` overwrites the existing record; the old
+        // ciphertext is superseded at rest.
+        self.repo
+            .store_bridge_credential(&rotated)
+            .await
+            .map_err(store_err)?;
+        Ok(rotated)
+    }
+
+    async fn revoke(&self, bridge_id: &str) -> Result<(), CredentialError> {
+        // Erasure = deletion of the credential *records* (`retrieve` reads them
+        // and derives its AES key from the CALLER-supplied
+        // `bridge_credential_key`, not the stored root key, so record deletion —
+        // not root-key deletion — is what makes `retrieve` return `NotFound`).
+        // Deleting the root key additionally makes `get_bridge_credential_key`
+        // return `KeyNotFound`, tearing down the stored custody copy. At-rest
+        // confidentiality of any not-yet-overwritten pages rests on the
+        // `EncryptedStorage` backend (SQLCipher / `EncryptingAdapter`); this is
+        // crypto-shredding, not in-place zero-overwrite.
+        //
+        // NOTE: these are separate `delete`s with no per-bridge serialization
+        // (the durable store is stateless — unlike the in-memory store's
+        // `RwLock`). A `rotate`/`provision` racing a `revoke` on the same
+        // `bridge_id` could re-materialize a record after `delete_prefix`.
+        // Callers MUST quiesce a bridge's credential operations before revoking.
+        // Acceptable for this durability-only capability (tokens are
+        // re-obtainable by re-auth; same authorized caller, same bridge).
+        self.repo
+            .delete_bridge_credentials(bridge_id)
+            .await
+            .map_err(store_err)?;
+        self.repo
+            .delete_bridge_credential_root_key(bridge_id)
+            .await
+            .map_err(store_err)?;
+        Ok(())
+    }
+
+    async fn list(&self, bridge_id: &str) -> Result<Vec<CredentialType>, CredentialError> {
+        self.repo
+            .list_bridge_credential_types(bridge_id)
+            .await
+            .map_err(store_err)
+    }
+
+    async fn store_bridge_credential_key(
+        &self,
+        bridge_id: &str,
+        key: Zeroizing<[u8; 32]>,
+    ) -> Result<(), CredentialError> {
+        self.repo
+            .store_bridge_credential_root_key(bridge_id, &key)
+            .await
+            .map_err(store_err)
+    }
+
+    async fn get_bridge_credential_key(
+        &self,
+        bridge_id: &str,
+    ) -> Result<Zeroizing<[u8; 32]>, CredentialError> {
+        self.repo
+            .load_bridge_credential_root_key(bridge_id)
+            .await
+            .map_err(store_err)?
+            .ok_or_else(|| CredentialError::KeyNotFound {
+                bridge_id: bridge_id.to_owned(),
+            })
+    }
+
+    async fn delete_bridge_credential_key(&self, bridge_id: &str) -> Result<(), CredentialError> {
+        self.repo
+            .delete_bridge_credential_root_key(bridge_id)
+            .await
+            .map_err(store_err)
+    }
+}
+
+// ---------------------------------------------------------------------------
 // Tests
 // ---------------------------------------------------------------------------
 
@@ -777,6 +1195,282 @@ mod tests {
 
     /// A different bridge credential key to verify key isolation.
     const OTHER_BRIDGE_KEY: &[u8; 32] = b"other-bridge-credential-key-32b!";
+
+    // -----------------------------------------------------------------------
+    // ProtocolRepositoryCredentialStore (durable backend) — the SHIPPED path
+    //
+    // Exercises `FfiCredentialStore::Durable`'s backend directly over an
+    // `EncryptedStorage` (`EncryptingAdapter<InMemoryStorage>`, the same
+    // encrypted-at-rest shape the in-memory storage *selection* uses), asserting
+    // the durable arm's provision/retrieve/rotate/revoke/list + root-key
+    // semantics — not just the raw `ProtocolRepository` methods (covered by the
+    // on-disk restart test in `store::credentials`) or the in-memory enum arm
+    // (covered in `scp-ffi-common`). SCP-CAPINJECT-009.
+    // -----------------------------------------------------------------------
+
+    /// Builds a durable credential store over encrypted-at-rest in-memory
+    /// storage (`EncryptedStorage`, so it drives the production
+    /// `ProtocolRepository::new` path — never `new_for_testing`).
+    fn durable_store() -> ProtocolRepositoryCredentialStore<
+        std::sync::Arc<
+            scp_platform::encrypting_adapter::EncryptingAdapter<
+                scp_platform::in_memory::InMemoryStorage,
+            >,
+        >,
+    > {
+        let key = Zeroizing::new([7u8; 32]);
+        let handle = std::sync::Arc::new(scp_platform::encrypting_adapter::EncryptingAdapter::new(
+            scp_platform::in_memory::InMemoryStorage::new(),
+            key,
+        ));
+        ProtocolRepositoryCredentialStore::new(handle)
+    }
+
+    #[tokio::test]
+    async fn durable_provision_and_retrieve_roundtrip() {
+        let store = durable_store();
+        let plaintext = b"oauth-access-token-abc123";
+
+        let cred = store
+            .provision(
+                "bridge-001",
+                CredentialType::OAuthAccessToken,
+                plaintext,
+                TEST_BRIDGE_KEY,
+            )
+            .await
+            .expect("provision");
+        assert_eq!(cred.bridge_id, "bridge-001");
+        assert_eq!(cred.credential_type, CredentialType::OAuthAccessToken);
+        assert!(cred.created_at > 0);
+
+        let retrieved = store
+            .retrieve(
+                "bridge-001",
+                &CredentialType::OAuthAccessToken,
+                TEST_BRIDGE_KEY,
+            )
+            .await
+            .expect("retrieve");
+        assert_eq!(retrieved.as_slice(), plaintext);
+    }
+
+    #[tokio::test]
+    async fn durable_provision_duplicate_returns_already_exists() {
+        let store = durable_store();
+        store
+            .provision(
+                "bridge-001",
+                CredentialType::ApiKey,
+                b"key-1",
+                TEST_BRIDGE_KEY,
+            )
+            .await
+            .expect("first provision");
+
+        let result = store
+            .provision(
+                "bridge-001",
+                CredentialType::ApiKey,
+                b"key-2",
+                TEST_BRIDGE_KEY,
+            )
+            .await;
+        assert!(matches!(result, Err(CredentialError::AlreadyExists { .. })));
+    }
+
+    #[tokio::test]
+    async fn durable_retrieve_nonexistent_returns_not_found() {
+        let store = durable_store();
+        let result = store
+            .retrieve("bridge-001", &CredentialType::ApiKey, TEST_BRIDGE_KEY)
+            .await;
+        assert!(matches!(result, Err(CredentialError::NotFound { .. })));
+    }
+
+    #[tokio::test]
+    async fn durable_cross_bridge_access_returns_not_found() {
+        let store = durable_store();
+        store
+            .provision(
+                "bridge-001",
+                CredentialType::ApiKey,
+                b"secret-key",
+                TEST_BRIDGE_KEY,
+            )
+            .await
+            .expect("provision");
+
+        // A different bridge id must not see bridge-001's credential.
+        let result = store
+            .retrieve("bridge-002", &CredentialType::ApiKey, TEST_BRIDGE_KEY)
+            .await;
+        assert!(matches!(result, Err(CredentialError::NotFound { .. })));
+    }
+
+    #[tokio::test]
+    async fn durable_rotate_replaces_credential() {
+        let store = durable_store();
+        store
+            .provision(
+                "bridge-001",
+                CredentialType::OAuthAccessToken,
+                b"old-token",
+                TEST_BRIDGE_KEY,
+            )
+            .await
+            .expect("provision");
+
+        store
+            .rotate(
+                "bridge-001",
+                &CredentialType::OAuthAccessToken,
+                b"new-token",
+                TEST_BRIDGE_KEY,
+            )
+            .await
+            .expect("rotate");
+
+        let retrieved = store
+            .retrieve(
+                "bridge-001",
+                &CredentialType::OAuthAccessToken,
+                TEST_BRIDGE_KEY,
+            )
+            .await
+            .expect("retrieve");
+        assert_eq!(retrieved.as_slice(), b"new-token");
+    }
+
+    #[tokio::test]
+    async fn durable_rotate_nonexistent_returns_not_found() {
+        let store = durable_store();
+        let result = store
+            .rotate(
+                "bridge-001",
+                &CredentialType::ApiKey,
+                b"new-value",
+                TEST_BRIDGE_KEY,
+            )
+            .await;
+        assert!(matches!(result, Err(CredentialError::NotFound { .. })));
+    }
+
+    #[tokio::test]
+    async fn durable_wrong_key_fails_to_decrypt() {
+        let store = durable_store();
+        store
+            .provision(
+                "bridge-001",
+                CredentialType::ApiKey,
+                b"secret",
+                TEST_BRIDGE_KEY,
+            )
+            .await
+            .expect("provision");
+
+        // Retrieval with a different bridge_credential_key must fail the AEAD.
+        let result = store
+            .retrieve("bridge-001", &CredentialType::ApiKey, OTHER_BRIDGE_KEY)
+            .await;
+        assert!(matches!(result, Err(CredentialError::CryptoError { .. })));
+    }
+
+    #[tokio::test]
+    async fn durable_list_returns_all_credential_types() {
+        let store = durable_store();
+        for ct in [
+            CredentialType::OAuthAccessToken,
+            CredentialType::ApiKey,
+            CredentialType::Custom("discord-bot-token".to_owned()),
+        ] {
+            store
+                .provision("bridge-001", ct, b"v", TEST_BRIDGE_KEY)
+                .await
+                .expect("provision");
+        }
+
+        let mut types = store.list("bridge-001").await.expect("list");
+        types.sort_by_key(std::string::ToString::to_string);
+        assert_eq!(types.len(), 3);
+        assert!(types.contains(&CredentialType::OAuthAccessToken));
+        assert!(types.contains(&CredentialType::ApiKey));
+        assert!(types.contains(&CredentialType::Custom("discord-bot-token".to_owned())));
+    }
+
+    #[tokio::test]
+    async fn durable_revoke_destroys_credentials_and_root_key() {
+        let store = durable_store();
+        let root = generate_bridge_credential_key();
+        let raw = *root;
+
+        store
+            .store_bridge_credential_key("bridge-001", root)
+            .await
+            .expect("store key");
+        store
+            .provision("bridge-001", CredentialType::ApiKey, b"secret", &raw)
+            .await
+            .expect("provision");
+        // A second bridge must survive the revoke of the first.
+        store
+            .provision(
+                "bridge-002",
+                CredentialType::ApiKey,
+                b"keep",
+                TEST_BRIDGE_KEY,
+            )
+            .await
+            .expect("provision bridge-002");
+
+        store.revoke("bridge-001").await.expect("revoke");
+
+        // Records gone → retrieve NotFound; list empty.
+        assert!(matches!(
+            store
+                .retrieve("bridge-001", &CredentialType::ApiKey, &raw)
+                .await,
+            Err(CredentialError::NotFound { .. })
+        ));
+        assert!(store.list("bridge-001").await.expect("list").is_empty());
+        // Stored root-key custody copy destroyed → KeyNotFound.
+        assert!(matches!(
+            store.get_bridge_credential_key("bridge-001").await,
+            Err(CredentialError::KeyNotFound { .. })
+        ));
+        // bridge-002 untouched.
+        let kept = store
+            .retrieve("bridge-002", &CredentialType::ApiKey, TEST_BRIDGE_KEY)
+            .await
+            .expect("retrieve bridge-002");
+        assert_eq!(kept.as_slice(), b"keep");
+    }
+
+    #[tokio::test]
+    async fn durable_store_get_delete_root_key_roundtrip() {
+        let store = durable_store();
+        let root = generate_bridge_credential_key();
+        let expected = *root;
+
+        store
+            .store_bridge_credential_key("bridge-001", root)
+            .await
+            .expect("store key");
+        let got = store
+            .get_bridge_credential_key("bridge-001")
+            .await
+            .expect("get key");
+        assert_eq!(*got, expected);
+
+        store
+            .delete_bridge_credential_key("bridge-001")
+            .await
+            .expect("delete key");
+        assert!(matches!(
+            store.get_bridge_credential_key("bridge-001").await,
+            Err(CredentialError::KeyNotFound { .. })
+        ));
+    }
 
     // -----------------------------------------------------------------------
     // CredentialType tests
@@ -907,14 +1601,15 @@ mod tests {
     #[test]
     fn encrypt_decrypt_roundtrip() {
         let key = derive_credential_key(TEST_BRIDGE_KEY, "bridge-001").expect("derive");
+        let aad = credential_aad(&CredentialType::ApiKey, 1_700_000_000);
 
         let plaintext = b"my-secret-api-key-12345";
-        let encrypted = encrypt_credential(&key, plaintext).expect("encrypt");
+        let encrypted = encrypt_credential(&key, plaintext, &aad).expect("encrypt");
 
         // Encrypted output must be longer than plaintext (nonce + tag).
         assert!(encrypted.len() > plaintext.len());
 
-        let decrypted = decrypt_credential(&key, &encrypted).expect("decrypt");
+        let decrypted = decrypt_credential(&key, &encrypted, &aad).expect("decrypt");
         assert_eq!(decrypted.as_slice(), plaintext);
     }
 
@@ -922,17 +1617,59 @@ mod tests {
     fn decrypt_with_wrong_key_fails() {
         let key1 = derive_credential_key(TEST_BRIDGE_KEY, "bridge-001").expect("derive");
         let key2 = derive_credential_key(OTHER_BRIDGE_KEY, "bridge-001").expect("derive");
+        let aad = credential_aad(&CredentialType::ApiKey, 1_700_000_000);
 
-        let encrypted = encrypt_credential(&key1, b"secret").expect("encrypt");
-        let result = decrypt_credential(&key2, &encrypted);
+        let encrypted = encrypt_credential(&key1, b"secret", &aad).expect("encrypt");
+        let result = decrypt_credential(&key2, &encrypted, &aad);
 
         assert!(result.is_err(), "wrong key must fail decryption");
     }
 
     #[test]
     fn decrypt_truncated_data_fails() {
-        let result = decrypt_credential(&[0u8; 32], &[0u8; 5]);
+        let aad = credential_aad(&CredentialType::ApiKey, 1_700_000_000);
+        let result = decrypt_credential(&[0u8; 32], &[0u8; 5], &aad);
         assert!(result.is_err(), "data shorter than nonce must fail");
+    }
+
+    #[test]
+    fn credential_aad_is_unambiguous_across_type_and_time() {
+        // Distinct (type, created_at) → distinct AAD bytes; the length prefix
+        // prevents a Custom name from spoofing the trailing timestamp bytes.
+        let a = credential_aad(&CredentialType::ApiKey, 1);
+        let b = credential_aad(&CredentialType::ApiKey, 2);
+        let c = credential_aad(&CredentialType::OAuthAccessToken, 1);
+        let d = credential_aad(&CredentialType::Custom("ApiKey".to_owned()), 1);
+        assert_ne!(a, b, "differing created_at must differ");
+        assert_ne!(a, c, "differing type must differ");
+        assert_ne!(a, d, "Custom(\"ApiKey\") must not collide with ApiKey");
+        // Deterministic: same inputs → identical bytes (required for decrypt).
+        assert_eq!(a, credential_aad(&CredentialType::ApiKey, 1));
+    }
+
+    #[test]
+    fn decrypt_with_wrong_slot_aad_fails() {
+        // Slot-swap: seal under credential-type A, attempt to open with the AAD
+        // of a DIFFERENT slot (type B) at the same key/timestamp. GCM tag must
+        // reject it rather than returning misattributed plaintext.
+        let key = derive_credential_key(TEST_BRIDGE_KEY, "bridge-001").expect("derive");
+        let created_at = 1_700_000_000;
+        let aad_a = credential_aad(&CredentialType::OAuthAccessToken, created_at);
+        let aad_b = credential_aad(&CredentialType::ApiKey, created_at);
+
+        let sealed = encrypt_credential(&key, b"token", &aad_a).expect("encrypt");
+        let result = decrypt_credential(&key, &sealed, &aad_b);
+        assert!(
+            matches!(result, Err(CredentialError::CryptoError { .. })),
+            "wrong-slot AAD must fail the GCM tag, not decrypt"
+        );
+        // Sanity: the correct slot AAD still opens it.
+        assert_eq!(
+            decrypt_credential(&key, &sealed, &aad_a)
+                .expect("correct AAD decrypts")
+                .as_slice(),
+            b"token"
+        );
     }
 
     // -----------------------------------------------------------------------

--- a/crates/scp-runtime/src/store/credentials.rs
+++ b/crates/scp-runtime/src/store/credentials.rs
@@ -1,0 +1,359 @@
+//! Bridge credential storage operations for `ProtocolRepository`.
+//!
+//! Durable persistence for bridge connector credentials (OAuth tokens, API
+//! keys, webhook secrets) and their per-bridge root credential keys, following
+//! the key convention from spec section 17.3:
+//!
+//! ```text
+//! bridge-credential/{bridge_id}/{credential_type_hash}   -> StoredValue<BridgeCredential>
+//! bridge-credential-key/{bridge_id}                       -> StoredValue<[u8; 32]>
+//! ```
+//!
+//! These are the persistent substrate behind
+//! [`ProtocolRepositoryCredentialStore`](crate::bridge::credentials::ProtocolRepositoryCredentialStore),
+//! the real durable [`BridgeCredentialStore`](crate::bridge::credentials::BridgeCredentialStore)
+//! backend selected at the FFI bridge construction boundary (ADR-062 §Decision 5,
+//! SCP-CAPINJECT-009). The stored `BridgeCredential.encrypted_data` is already
+//! AES-256-GCM ciphertext (encrypted under a key derived from the per-bridge
+//! `bridge_credential_key`); the underlying `EncryptedStorage` backend encrypts
+//! it a second time at rest (`SQLCipher` / `EncryptingAdapter`), so credentials
+//! are double-encrypted defense-in-depth (spec §12.11.2).
+//!
+//! The `credential_type` is hashed into a fixed-length, key-convention-safe
+//! component (SHA-256 of its canonical `Display` form) so that a
+//! `CredentialType::Custom(name)` value with arbitrary bytes can never break
+//! the `{namespace}/{entity_id}/{sub_key}` key grammar or inject a path
+//! separator. The full `CredentialType` is preserved verbatim inside the stored
+//! `BridgeCredential` value, so `list` reconstructs the exact types by reading
+//! the values rather than parsing them back out of the key.
+//!
+//! See spec sections 17.3, 17.4, and 12.11. See SCP-CAPINJECT-009.
+
+use scp_platform::traits::Storage;
+use sha2::{Digest, Sha256};
+use zeroize::{Zeroize, Zeroizing};
+
+use crate::bridge::credentials::{BridgeCredential, CredentialType};
+
+use super::{ProtocolRepository, StoreError};
+
+// ---------------------------------------------------------------------------
+// Key helpers
+// ---------------------------------------------------------------------------
+
+/// Derives the key-convention-safe sub-key component for a credential type.
+///
+/// Format: lowercase hex of `SHA-256(Display(credential_type))`. Hashing keeps
+/// the component fixed-length and free of the forbidden `/` separator even for
+/// `CredentialType::Custom(arbitrary)`; the value itself carries the exact
+/// `credential_type` so no reverse mapping from the key is needed.
+fn credential_type_key_component(credential_type: &CredentialType) -> String {
+    let digest = Sha256::digest(credential_type.to_string().as_bytes());
+    hex::encode(digest)
+}
+
+/// Builds the storage key for a single bridge credential.
+///
+/// Format: `bridge-credential/{bridge_id}/{credential_type_hash}`
+/// See spec section 17.3.
+fn bridge_credential_key(
+    bridge_id: &str,
+    credential_type: &CredentialType,
+) -> Result<String, StoreError> {
+    let bid = super::sanitize_key_component(bridge_id)?;
+    let ct = credential_type_key_component(credential_type);
+    Ok(format!("bridge-credential/{bid}/{ct}"))
+}
+
+/// Builds the prefix for listing/deleting all credentials for a bridge.
+///
+/// Format: `bridge-credential/{bridge_id}/`
+fn bridge_credentials_prefix(bridge_id: &str) -> Result<String, StoreError> {
+    let bid = super::sanitize_key_component(bridge_id)?;
+    Ok(format!("bridge-credential/{bid}/"))
+}
+
+/// Builds the storage key for a bridge's root credential key.
+///
+/// Format: `bridge-credential-key/{bridge_id}`
+/// See spec section 17.3.
+fn bridge_credential_root_key(bridge_id: &str) -> Result<String, StoreError> {
+    let bid = super::sanitize_key_component(bridge_id)?;
+    Ok(format!("bridge-credential-key/{bid}"))
+}
+
+// ---------------------------------------------------------------------------
+// ProtocolRepository — bridge credential methods
+// ---------------------------------------------------------------------------
+
+impl<S: Storage> ProtocolRepository<S> {
+    /// Persists a single bridge credential.
+    ///
+    /// The `credential.encrypted_data` is already AES-256-GCM ciphertext; the
+    /// `StoredValue` envelope is written through the `EncryptedStorage` backend
+    /// (encrypted a second time at rest). Overwrites any existing credential of
+    /// the same `(bridge_id, credential_type)`.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`StoreError::SerializationFailed`] if serialization fails.
+    /// Returns [`StoreError::Storage`] if the underlying storage write fails.
+    pub(crate) async fn store_bridge_credential(
+        &self,
+        credential: &BridgeCredential,
+    ) -> Result<(), StoreError> {
+        let key = bridge_credential_key(&credential.bridge_id, &credential.credential_type)?;
+        self.store_value(&key, credential).await
+    }
+
+    /// Loads a single bridge credential.
+    ///
+    /// Returns `None` if no credential of the given type exists for the bridge.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`StoreError::Storage`] if the underlying storage read fails.
+    /// Returns [`StoreError::DeserializationFailed`] if the stored value is
+    /// corrupt.
+    pub(crate) async fn load_bridge_credential(
+        &self,
+        bridge_id: &str,
+        credential_type: &CredentialType,
+    ) -> Result<Option<BridgeCredential>, StoreError> {
+        let key = bridge_credential_key(bridge_id, credential_type)?;
+        self.load_value(&key).await
+    }
+
+    /// Lists the credential types persisted for a bridge.
+    ///
+    /// Prefix-scans `bridge-credential/{bridge_id}/` and reads each stored
+    /// value's exact `credential_type`. Returns the types without exposing any
+    /// credential ciphertext.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`StoreError::Storage`] if the underlying storage read fails.
+    /// Returns [`StoreError::DeserializationFailed`] if a stored value is
+    /// corrupt.
+    pub(crate) async fn list_bridge_credential_types(
+        &self,
+        bridge_id: &str,
+    ) -> Result<Vec<CredentialType>, StoreError> {
+        let prefix = bridge_credentials_prefix(bridge_id)?;
+        let keys = self.storage().list_keys(&prefix).await?;
+        let mut types = Vec::with_capacity(keys.len());
+        for key in keys {
+            if let Some(cred) = self.load_value::<BridgeCredential>(&key).await? {
+                types.push(cred.credential_type);
+            }
+        }
+        Ok(types)
+    }
+
+    /// Deletes every credential (but not the root key) for a bridge.
+    ///
+    /// Uses the `delete_prefix` atomic sweep. Callers that also need the root
+    /// credential key destroyed must additionally call
+    /// [`delete_bridge_credential_root_key`](Self::delete_bridge_credential_root_key).
+    ///
+    /// # Errors
+    ///
+    /// Returns [`StoreError::Storage`] if the underlying delete fails.
+    pub(crate) async fn delete_bridge_credentials(
+        &self,
+        bridge_id: &str,
+    ) -> Result<(), StoreError> {
+        let prefix = bridge_credentials_prefix(bridge_id)?;
+        self.storage().delete_prefix(&prefix).await?;
+        Ok(())
+    }
+
+    /// Persists a bridge's root credential key, zeroizing the serialized buffer
+    /// after the write.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`StoreError::SerializationFailed`] if serialization fails.
+    /// Returns [`StoreError::Storage`] if the underlying storage write fails.
+    pub(crate) async fn store_bridge_credential_root_key(
+        &self,
+        bridge_id: &str,
+        key: &[u8; 32],
+    ) -> Result<(), StoreError> {
+        let storage_key = bridge_credential_root_key(bridge_id)?;
+        // Wrap the `Vec` copy of the raw root key in `Zeroizing` so the heap
+        // buffer is scrubbed on drop — `store_value_zeroize` only scrubs the
+        // *serialized* envelope, not this intermediate. The root key is the
+        // single secret gating all credential decryption for the bridge.
+        let raw = Zeroizing::new(key.to_vec());
+        self.store_value_zeroize(&storage_key, &*raw).await
+    }
+
+    /// Loads a bridge's root credential key, wrapped in [`Zeroizing`].
+    ///
+    /// Returns `None` if no key is stored for the bridge.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`StoreError::Storage`] if the underlying storage read fails.
+    /// Returns [`StoreError::DeserializationFailed`] if the stored value is
+    /// corrupt or not exactly 32 bytes.
+    pub(crate) async fn load_bridge_credential_root_key(
+        &self,
+        bridge_id: &str,
+    ) -> Result<Option<Zeroizing<[u8; 32]>>, StoreError> {
+        let storage_key = bridge_credential_root_key(bridge_id)?;
+        let Some(bytes): Option<Vec<u8>> = self.load_value(&storage_key).await? else {
+            return Ok(None);
+        };
+        let mut bytes = Zeroizing::new(bytes);
+        let len = bytes.len();
+        let array: [u8; 32] = bytes.as_slice().try_into().map_err(|_| {
+            StoreError::DeserializationFailed(format!(
+                "bridge credential root key for '{bridge_id}' is {len} bytes, expected 32"
+            ))
+        })?;
+        bytes.zeroize();
+        Ok(Some(Zeroizing::new(array)))
+    }
+
+    /// Deletes a bridge's root credential key.
+    ///
+    /// This tears down the *stored custody copy* of the root key, so
+    /// [`load_bridge_credential_root_key`](Self::load_bridge_credential_root_key)
+    /// returns `None` afterward. It does NOT by itself prevent decryption of an
+    /// existing credential record: retrieval derives its AES key from a
+    /// caller-supplied `bridge_credential_key`, not this stored copy. Full
+    /// revocation therefore also deletes the credential records
+    /// ([`delete_bridge_credentials`](Self::delete_bridge_credentials)).
+    ///
+    /// # Errors
+    ///
+    /// Returns [`StoreError::Storage`] if the underlying delete fails.
+    pub(crate) async fn delete_bridge_credential_root_key(
+        &self,
+        bridge_id: &str,
+    ) -> Result<(), StoreError> {
+        let storage_key = bridge_credential_root_key(bridge_id)?;
+        self.storage().delete(&storage_key).await?;
+        Ok(())
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used, clippy::panic)]
+mod tests {
+    use std::sync::atomic::{AtomicU64, Ordering};
+
+    use scp_platform::sqlite::SqliteStorage;
+
+    use super::*;
+    use crate::bridge::credentials::{
+        credential_aad, decrypt_credential, derive_credential_key, encrypt_credential,
+        generate_bridge_credential_key,
+    };
+
+    /// Deterministic 32-byte `SQLCipher` key for the on-disk test database.
+    const DB_KEY: &[u8; 32] = b"sqlcipher-db-key-32-bytes-long!!";
+
+    static UNIQUE: AtomicU64 = AtomicU64::new(0);
+
+    /// Allocates a unique, empty temp directory for an on-disk `SQLite` database.
+    fn unique_temp_dir() -> std::path::PathBuf {
+        let n = UNIQUE.fetch_add(1, Ordering::Relaxed);
+        let nanos = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_nanos();
+        let dir = std::env::temp_dir().join(format!(
+            "scp-cred-restart-{}-{n}-{nanos}",
+            std::process::id()
+        ));
+        std::fs::create_dir_all(&dir).unwrap();
+        dir
+    }
+
+    /// AC4: a real durable credential store persists a bridge token across a
+    /// full store teardown + on-disk reopen — proving it is NOT RAM-only.
+    ///
+    /// Opens a real on-disk `SqliteStorage`, writes an encrypted bridge
+    /// credential + its root key through `ProtocolRepository`, DROPS the store
+    /// (and its `Arc<SqliteStorage>`, releasing the advisory lock), reopens the
+    /// database at the same path/key, and reads the value back — asserting the
+    /// ciphertext bytes are byte-identical and the token decrypts end-to-end.
+    #[tokio::test]
+    async fn bridge_credential_survives_store_drop_and_reopen() {
+        let dir = unique_temp_dir();
+
+        let bridge_id = "bridge-restart-001";
+        let created_at = 1_700_000_000;
+        let root_key = generate_bridge_credential_key();
+        let derived = derive_credential_key(&root_key, bridge_id).unwrap();
+        let aad = credential_aad(&CredentialType::OAuthAccessToken, created_at);
+        let ciphertext = encrypt_credential(&derived, b"oauth-access-token-persist", &aad).unwrap();
+        let credential = BridgeCredential {
+            encrypted_data: ciphertext.clone(),
+            credential_type: CredentialType::OAuthAccessToken,
+            created_at,
+            expires_at: None,
+            bridge_id: bridge_id.to_owned(),
+        };
+
+        // --- Session 1: write, then drop the store entirely. ---
+        {
+            let storage = std::sync::Arc::new(SqliteStorage::new(&dir, DB_KEY).unwrap());
+            let repo = ProtocolRepository::new(storage);
+            repo.store_bridge_credential_root_key(bridge_id, &root_key)
+                .await
+                .unwrap();
+            repo.store_bridge_credential(&credential).await.unwrap();
+            // `repo` (and the `Arc<SqliteStorage>` it owns) drops here,
+            // releasing the advisory lock so session 2 can reopen.
+        }
+
+        // --- Session 2: reopen the SAME on-disk database and read back. ---
+        {
+            let storage = std::sync::Arc::new(SqliteStorage::new(&dir, DB_KEY).unwrap());
+            let repo = ProtocolRepository::new(storage);
+
+            let loaded = repo
+                .load_bridge_credential(bridge_id, &CredentialType::OAuthAccessToken)
+                .await
+                .unwrap()
+                .expect("credential must survive store drop + on-disk reopen");
+            assert_eq!(
+                loaded.encrypted_data, ciphertext,
+                "persisted ciphertext must be byte-identical after restart"
+            );
+            assert_eq!(loaded.bridge_id, bridge_id);
+            assert_eq!(loaded.credential_type, CredentialType::OAuthAccessToken);
+
+            let root = repo
+                .load_bridge_credential_root_key(bridge_id)
+                .await
+                .unwrap()
+                .expect("root key must survive restart");
+            assert_eq!(
+                *root, *root_key,
+                "root key must be byte-identical after restart"
+            );
+
+            // The reconstructed store still decrypts the token end-to-end
+            // (rebuilding the SAME AAD from the loaded type + created_at).
+            let re_derived = derive_credential_key(&root, bridge_id).unwrap();
+            let re_aad = credential_aad(&loaded.credential_type, loaded.created_at);
+            let plaintext =
+                decrypt_credential(&re_derived, &loaded.encrypted_data, &re_aad).unwrap();
+            assert_eq!(plaintext.as_slice(), b"oauth-access-token-persist");
+
+            let types = repo.list_bridge_credential_types(bridge_id).await.unwrap();
+            assert_eq!(types, vec![CredentialType::OAuthAccessToken]);
+        }
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+}

--- a/crates/scp-runtime/src/store/mod.rs
+++ b/crates/scp-runtime/src/store/mod.rs
@@ -20,6 +20,7 @@
 
 pub mod access_keys;
 pub mod context;
+pub mod credentials;
 pub mod economy;
 pub mod event_log;
 pub mod identity;

--- a/scripts/check-sdk-coverage.py
+++ b/scripts/check-sdk-coverage.py
@@ -1048,6 +1048,18 @@ ALIASES: dict[tuple[str, str], dict[str, list[str]]] = {
         "swift": ["instanceId"],
         "kotlin": ["instanceId"],
     },
+    # Bridge credential storage backend is bridge-INTERNAL: the durable
+    # `FfiCredentialStore` is selected from the SAME storage config the SDK
+    # already chooses (ADR-062 §Decision 5, SCP-CAPINJECT-009). There is no
+    # dedicated SDK wrapper method — selecting storage (SCP / withStorage /
+    # withSqlite) selects the durable credential backend by construction, so the
+    # matrix cell aliases to the existing storage-selection symbols.
+    ("Bridge", "credential_backend_durable"): {
+        "python": ["SCP"],
+        "typescript": ["SCP"],
+        "swift": ["withStorage", "SCP"],
+        "kotlin": ["withStorage", "withSqlite", "SCP"],
+    },
     ("Lifecycle", "scp_with_storage_in_memory"): {
         "python": ["SCP"],
         "typescript": ["SCP"],


### PR DESCRIPTION
## Summary
Implements **SCP-CAPINJECT-009** (ADR-062 Slice 9, E2 credentials) — a live SCP-CAPSEL-8000/8011 fix.

- Deletes `impl Default for InMemoryCredentialStore`; gates `InMemoryCredentialStore` behind `#[cfg(any(test, feature = "testing"))]` (provably absent from shipped builds via G1).
- Adds `enum FfiCredentialStore { Durable(Arc<dyn DurableCredentialBackend>), #[cfg(feature="testing")] InMemory(..) }` seam; a real durable `ProtocolRepositoryCredentialStore<S: EncryptedStorage>` persisting credentials across restart (reusing the existing `ProtocolRepository`/SQLCipher substrate).
- All three bridges (PyO3, NAPI, UniFFI) select the durable backend from their storage handle — no in-memory default; PyO3's lazy accessor fails closed (`SCP-CTX-2105`) when storage is unset.
- Credential AES-256-GCM binds `credential_type` + `created_at` as AAD (domain-separated, length-delimited) — a cross-slot ciphertext swap fails the GCM tag.
- Capability-matrix `credential_backend_durable` row (additive).

## Review
Full roster (cryptographer, security, bug-catcher, api-design, completionist) + double-zero. One LOW crypto finding (empty AAD) fixed with slot+time AAD binding; cryptographer re-review confirmed SOUND. AC4 restart-persistence proven by an on-disk SqliteStorage drop-and-reopen test.

## Notes
- Pre-existing unwired `BridgeCredential.expires_at` filed as #2177 (out of this story's scope).
- The `SCP-CAPSEL-80NN` provenance citations are recognized by check-error-codes.sh per the §17.17.2 classification taxonomy (landed in #2178).

🤖 Generated with [Claude Code](https://claude.com/claude-code)