### PR TITLE
feat(scaffolds): typescript-web browser scaffold + ADR-055→ADR-057 doc sweep (ADR-057 Slice 4, #1951)

### DIFF
--- a/.docs/specs/21-documentation.md
+++ b/.docs/specs/21-documentation.md
@@ -79,6 +79,7 @@ scaffolds/                       Clonable barebones project setups
 ├── rust-client/                 Minimal Rust binary using scp-core
 ├── python-agent/                Python agent skeleton with async runtime
 ├── typescript-node/             Node.js agent with NAPI binding
+├── typescript-web/              In-tab browser participant over scp-ts-wasm, keys on-device (ADR-057)
 ├── swift-ios/                   iOS app with Keychain custody
 ├── swift-macos/                 macOS app with Secure Enclave custody
 ├── kotlin-android/              Android app with Keystore custody
@@ -431,6 +432,7 @@ Each scaffold is a minimal, working project structure with:
 | `scaffolds/rust-client/` | Rust | Minimal Rust binary using scp-core directly |
 | `scaffolds/python-agent/` | Python | Python agent with scp-python, async runtime, identity setup |
 | `scaffolds/typescript-node/` | TypeScript | Node.js agent using NAPI binding |
+| `scaffolds/typescript-web/` | TypeScript | In-tab browser participant over `@limn-works/scp-ts-wasm`, keys on-device (ADR-057) |
 | `scaffolds/swift-ios/` | Swift | iOS app with Keychain custody, push notifications |
 | `scaffolds/swift-macos/` | Swift | macOS app with Secure Enclave custody |
 | `scaffolds/kotlin-android/` | Kotlin | Android app with Keystore custody |
@@ -459,6 +461,12 @@ Each template is a complete, running application that demonstrates a real use ca
 | `templates/personal-relay/` | Rust | Self-hosted relay with automatic TLS and DID publishing |
 | `templates/broadcast-feed/` | Python | Broadcast context (§5.14) with subscriber management |
 | `templates/cross-context-bridge/` | Rust | Outlet interface bridging two contexts (§6.2) |
+
+> A functional two-party **browser** chat template (`templates/chat/typescript/`) is
+> forthcoming under **#2187**, once relay-mediated invitation-join is available in the
+> wasm tier (its §9.7.1 DID-VM KeyPackage binding). Until then, `scaffolds/typescript-web/`
+> demonstrates the single-tab in-browser client (ADR-057). No TypeScript chat template
+> exists yet — the row is intentionally absent rather than phantom.
 
 Templates are **functional** — they solve a real problem out of the box. An agent studying a template understands not just how SCP works mechanically but how it's used to build real things.
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,6 +35,7 @@ jobs:
       python: ${{ steps.filter.outputs.python }}
       typescript: ${{ steps.filter.outputs.typescript }}
       typescript-wasm: ${{ steps.filter.outputs.typescript-wasm }}
+      scaffold-typescript-web: ${{ steps.filter.outputs.scaffold-typescript-web }}
       kotlin: ${{ steps.filter.outputs.kotlin }}
       swift: ${{ steps.filter.outputs.swift }}
       fuzz: ${{ steps.filter.outputs.fuzz }}
@@ -73,6 +74,12 @@ jobs:
               - 'crates/scp-protocol/**'
               - 'crates/scp-event-log/**'
               - 'crates/scp-relay-client/**'
+            scaffold-typescript-web:
+              # The browser scaffold builds against the local @limn-works/scp-ts-wasm
+              # package (file: link), so a change to the scaffold OR to that package's
+              # surface can break its typecheck / bundle — both must trigger this job.
+              - 'scaffolds/typescript-web/**'
+              - 'bindings/typescript-wasm/**'
             kotlin:
               - 'bindings/kotlin/**'
               - 'crates/scp-ffi/uniffi/**'
@@ -870,6 +877,48 @@ jobs:
           bun run lint
           bun test
 
+  # ── TypeScript (browser scaffold) ───────────────────────────────────
+  # Bounded gate for the structural browser scaffold (ADR-057 Slice 4, #1951):
+  # it depends on the local @limn-works/scp-ts-wasm package via a file: link, so
+  # build that package first (it emits the dist/ the scaffold resolves), then
+  # install + typecheck + lint + bundle the scaffold. Build + check + lint +
+  # build — not a new enforcement framework.
+  scaffold-typescript-web-check:
+    needs: changes
+    if: needs.changes.outputs.scaffold-typescript-web == 'true'
+    name: TypeScript-web scaffold / build wasm dep + check + lint + build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Free disk space
+        run: |
+          sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghc /opt/hostedtoolcache/CodeQL
+      - uses: actions/checkout@v5
+      - uses: oven-sh/setup-bun@v2
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: wasm32-unknown-unknown
+      - uses: Swatinem/rust-cache@v2
+      - name: Install wasm-pack
+        uses: taiki-e/install-action@v2
+        with:
+          tool: wasm-pack@0.14.0
+      # Build the local wasm SDK package so the scaffold's file: dependency
+      # resolves against real, built dist/ (types + ESM + the .wasm sibling).
+      - name: Build @limn-works/scp-ts-wasm (dependency)
+        working-directory: bindings/typescript-wasm
+        run: |
+          bun install
+          bun run build
+      - name: Install scaffold dependencies
+        working-directory: scaffolds/typescript-web
+        run: bun install
+      - name: Check + lint + build
+        working-directory: scaffolds/typescript-web
+        run: |
+          bun run check
+          bun run lint
+          bun run build
+
   # ── Kotlin ──────────────────────────────────────────────────────────
   kotlin-lint:
     needs: changes
@@ -1280,6 +1329,7 @@ jobs:
       - python-test
       - typescript-check
       - typescript-wasm-check
+      - scaffold-typescript-web-check
       - kotlin-lint
       - kotlin-test
       - swift-lint
@@ -1327,6 +1377,7 @@ jobs:
             "${{ needs.python-test.result }}" \
             "${{ needs.typescript-check.result }}" \
             "${{ needs.typescript-wasm-check.result }}" \
+            "${{ needs.scaffold-typescript-web-check.result }}" \
             "${{ needs.kotlin-lint.result }}" \
             "${{ needs.kotlin-test.result }}" \
             "${{ needs.swift-lint.result }}" \

--- a/GETTING-STARTED.md
+++ b/GETTING-STARTED.md
@@ -102,7 +102,7 @@ crates/              # Rust workspace -- the protocol core
 
 bindings/            # Language SDK wrappers
   python/            #   scp_sdk (wraps PyO3 bridge)
-  typescript/        #   @limn-works/scp-ts (wraps NAPI bridge; browser = remote thin client)
+  typescript/        #   @limn-works/scp-ts (wraps NAPI bridge; browser = in-tab wasm client via @limn-works/scp-ts-wasm, ADR-057)
   swift/             #   SCP Swift package (wraps UniFFI bridge)
   kotlin/            #   scp-kt (wraps UniFFI bridge)
 

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ The protocol engine is Rust, with bindings for the ecosystems where agents and a
 |---|---|---|
 | Python | PyO3 | Agent ecosystem (LangChain, CrewAI, AutoGen) |
 | Swift | UniFFI | iOS / macOS |
-| TypeScript | napi-rs | Node / Bun (server, in-process; browser = remote thin client) |
+| TypeScript | napi-rs | Node / Bun (server, in-process); browser = in-tab wasm client, keys on-device (`@limn-works/scp-ts-wasm`, ADR-057) |
 | Kotlin | UniFFI | Android |
 | Rust | Native | Direct |
 

--- a/bindings/python/tests/bridge_parity/helpers/node_bridge_runner.ts
+++ b/bindings/python/tests/bridge_parity/helpers/node_bridge_runner.ts
@@ -18,8 +18,9 @@
  *
  * Bridge selection is explicit — NO auto-fallback. If a non-NAPI bridge
  * mode is requested, the response is an error. The harness surfaces this
- * as a test failure, not a skip. (The WASM bridge was removed per ADR-055;
- * the browser target is a remote thin client, not an in-process engine.)
+ * as a test failure, not a skip. (The WASM bridge was removed per ADR-055, so
+ * this NAPI harness is server-only; the browser runs the full protocol in-tab
+ * over `scp-client-wasm` per ADR-057, not through this bridge.)
  *
  * ADR-048 / #1549 Phase 4 PR 4: NAPI ops construct a fresh `addon.SCP()`
  * per call and invoke per-instance methods on the resulting handle. The

--- a/bindings/typescript/README.md
+++ b/bindings/typescript/README.md
@@ -2,7 +2,7 @@
 
 > `@limn-works/scp-ts` -- Shared Context Protocol for TypeScript
 
-Cryptographic identity, encrypted contexts, capability-based auth, and outlet invocation for AI agents. Runs on Bun/Node via a native addon; in the browser, the SDK is a remote thin client.
+Cryptographic identity, encrypted contexts, capability-based auth, and outlet invocation for AI agents. Runs on Bun/Node via a native addon. In the browser, the full protocol runs in-tab via the sibling wasm tier [`@limn-works/scp-ts-wasm`](../typescript-wasm), keys on-device (ADR-057); a remote custodial thin client is now only an optional mode, not the definitive browser story.
 
 ## Install
 
@@ -45,7 +45,7 @@ await ctx.close();
 |--------|-----------|---------|
 | Server | napi-rs (native addon) | Bun >= 1.0, Node >= 22 |
 
-In the browser, the SDK operates as a remote thin client (the protocol engine runs server-side); there is no in-process browser engine.
+In the browser, the full SCP/MLS protocol runs **in-tab** with keys on-device via the sibling wasm tier [`@limn-works/scp-ts-wasm`](../typescript-wasm) (ADR-057, which amends ADR-055's earlier remote-thin-client model) — a capability subset of this package's surface. Running the protocol engine server-side and driving it from the browser as a remote custodial thin client remains available as an optional mode, but is no longer the only browser story. Browser developers should install `@limn-works/scp-ts-wasm`; install exactly one tier per environment.
 
 ## API Reference
 

--- a/docs/examples/typescript/README.md
+++ b/docs/examples/typescript/README.md
@@ -51,7 +51,7 @@ bun run tools.ts
 
 ## Key Patterns
 
-- **Server in-process**: On Bun/Node the SDK runs the protocol engine in-process via the napi-rs native addon. In the browser it operates as a remote thin client (no in-browser protocol backend).
+- **Server in-process**: On Bun/Node the SDK runs the protocol engine in-process via the napi-rs native addon. In the browser the full protocol runs in-tab via the sibling wasm tier `@limn-works/scp-ts-wasm`, keys on-device (ADR-057); a remote custodial thin client is an optional mode.
 - **AsyncDisposable**: `Context` implements `Symbol.asyncDispose` for `await using` cleanup.
 - **Typed params**: Use `ContextParams`, `ToolDefinition`, `Message` types for safety.
 - **UCAN authorization**: Tool invocation requires a valid UCAN token (spec section 7.2).

--- a/docs/guides/sdk-quickstart.md
+++ b/docs/guides/sdk-quickstart.md
@@ -8,7 +8,7 @@ SCP provides language SDKs for Rust, Python, TypeScript, Swift, and Kotlin. All 
 |----------|---------|-----------|--------|
 | **Rust** | `scp-core` (workspace crate) | N/A (native) | `use scp_core::*;` |
 | **Python** | `scp-python` | PyO3 (`crates/scp-ffi/src/`) | `from scp_sdk import Identity, Context` |
-| **TypeScript** | `@limn-works/scp-ts` | NAPI (server, in-process; browser = remote thin client) | `import { Identity, Context } from "@limn-works/scp-ts"` |
+| **TypeScript** | `@limn-works/scp-ts` | NAPI (server, in-process); browser = in-tab wasm client (`@limn-works/scp-ts-wasm`, ADR-057) | `import { Identity, Context } from "@limn-works/scp-ts"` |
 | **Swift** | `SCP` (Swift Package) | UniFFI (`crates/scp-ffi/uniffi/`) | `import SCP` |
 | **Kotlin** | `works.limn:scp-kt` | UniFFI (`crates/scp-ffi/uniffi/`) | `import works.limn.scp.*` |
 
@@ -50,7 +50,7 @@ python3.12 --version  # >= 3.12
 
 - Bun >= 1.0 or Node >= 22
 - The package ships a NAPI native addon for server runtimes (Bun/Node), running the protocol engine in-process
-- In the browser the SDK operates as a remote thin client (the protocol engine runs server-side); there is no in-browser protocol backend
+- In the browser the full protocol runs in-tab via the sibling wasm tier `@limn-works/scp-ts-wasm`, keys on-device (ADR-057); a remote custodial thin client to a server-side `scp-node` is an optional mode, not the default
 
 ```bash
 bun --version   # >= 1.0

--- a/scaffolds/typescript-web/.gitignore
+++ b/scaffolds/typescript-web/.gitignore
@@ -1,0 +1,3 @@
+node_modules/
+dist/
+bun.lock

--- a/scaffolds/typescript-web/README.md
+++ b/scaffolds/typescript-web/README.md
@@ -1,0 +1,83 @@
+# SCP TypeScript Web Scaffold
+
+A minimal single-tab **in-browser** SCP participant over
+[`@limn-works/scp-ts-wasm`](../../bindings/typescript-wasm). The full MLS protocol
+runs in-tab, keys on-device — the browser is a real participant, not a remote thin
+client (ADR-057). This scaffold is **structural**: it wires identity, storage, the
+managed relay transport, a context, a `sendMessage` path, and a `drainEvents`
+render loop, with no application logic on top (spec §21.12 — scaffolds are
+structural, templates are functional).
+
+## Prerequisites
+
+- Bun 1.0+
+- A running SCP relay (its `wss://` URL).
+- A **pre-provisioned participant DID.** The wasm tier does **not** mint DIDs
+  in-tab — create the DID with your identity flow (e.g. the native
+  `@limn-works/scp-ts` tier or a `scp-node`) and paste it into the form.
+
+## Build and run
+
+The scaffold depends on the local `@limn-works/scp-ts-wasm` package via a
+`file:` link, so build that package once first (it compiles the wasm and emits
+`dist/`), then install and run the scaffold:
+
+```bash
+# 1. Build the local wasm SDK package (one-time; produces its dist/).
+cd ../../bindings/typescript-wasm
+bun install
+bun run build
+
+# 2. Install and run the scaffold.
+cd ../../scaffolds/typescript-web
+bun install
+bun run dev      # Vite dev server
+# or
+bun run build    # production bundle (dist/)
+```
+
+Open the dev server URL, paste your DID, relay URL, and a context id, then
+Connect. The activity log renders your own sent messages and any inbound
+`MessageReceived` events the driver drains.
+
+## What this does
+
+1. Creates on-device **WebCrypto key custody** bound to your pre-provisioned DID
+   (`WebCryptoCustody.create`).
+2. Opens **IndexedDB storage** (`IndexedDbStorage.open`).
+3. Connects the **managed WebSocket relay transport**
+   (`ScpBrowserClient.connect`) — it wires the inbound pump and reconnect.
+4. Creates a sole-member encrypted **context** (`createContext`).
+5. Sends messages (`sendMessage`) and renders inbound events via a
+   `drainEvents` polling loop.
+
+## Deferred capabilities (honest absence)
+
+This scaffold is deliberately single-tab and structural. The following are **not**
+implemented here and are tracked under **#2187** and the package's own caveats:
+
+- **No in-browser DID creation.** The wasm tier cannot mint a DID in-tab; you must
+  pre-provision one. See ADR-057.
+- **No cross-party invitation-join.** Relay-mediated native↔browser
+  invitation-join / HPKE-open custody and the §9.7.1 DID-VM KeyPackage binding are
+  deferred to **#2187**. `src/main.ts` marks the exact seam where the join wires
+  once that lands (`generateKeyPackageForJoin` / `addMember` /
+  `joinContextEncrypted`, which the package already exports). Because no second
+  participant joins, `sendMessage` surfaces a retryable `SCP-CTX-2040` ("no peer
+  pseudonym announced yet") — the scaffold reports this honestly rather than
+  hiding it.
+- **MLS signing key is currently extractable in the wasm tier.** Despite the
+  `WebCryptoCustody` name, the MLS signing key still lives in wasm linear memory
+  and is extractable pre-#1980 — do not rely on WebCrypto non-extractability for
+  signing-key protection this release. See the
+  [package caveats](../../bindings/typescript-wasm/README.md#caveats-as-built).
+
+A functional two-party browser **chat template** (`templates/chat/typescript/`) is
+forthcoming under **#2187**, once relay-mediated invitation-join is available.
+
+## Next steps
+
+- Provision DIDs and a relay for two browsers, then implement the #2187 join seam
+  in `src/main.ts` to exchange messages across tabs.
+- See [`bindings/typescript-wasm/examples/browser-roundtrip.ts`](../../bindings/typescript-wasm/examples/browser-roundtrip.ts)
+  for the complete create → add → join → send → receive wiring.

--- a/scaffolds/typescript-web/biome.json
+++ b/scaffolds/typescript-web/biome.json
@@ -1,0 +1,32 @@
+{
+  "$schema": "https://biomejs.dev/schemas/latest/schema.json",
+  "files": {
+    "includes": ["src/**"]
+  },
+  "linter": {
+    "enabled": true,
+    "rules": {
+      "recommended": true,
+      "complexity": {
+        "noExcessiveCognitiveComplexity": {
+          "level": "error",
+          "options": {
+            "maxAllowedComplexity": 25
+          }
+        }
+      },
+      "suspicious": {
+        "noExplicitAny": "error"
+      },
+      "style": {
+        "useConst": "error",
+        "noNonNullAssertion": "error"
+      }
+    }
+  },
+  "formatter": {
+    "indentStyle": "space",
+    "indentWidth": 2,
+    "lineWidth": 100
+  }
+}

--- a/scaffolds/typescript-web/index.html
+++ b/scaffolds/typescript-web/index.html
@@ -3,6 +3,23 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <!--
+      Production-hardening default CSP for a copyable web skeleton. It permits
+      exactly what this scaffold needs and nothing more:
+        - script-src 'self' 'wasm-unsafe-eval' — bundled module scripts + the
+          WebAssembly instantiation the wasm SDK performs.
+        - connect-src 'self' wss: — the same-origin wasm asset fetch plus the
+          untrusted relay WebSocket (wss:// only; see the wss:// guard in main.ts).
+        - default-src 'self'; object-src/base-uri locked down.
+      Dev note: `vite dev` HMR uses a same-origin WebSocket, which 'self' permits
+      on CSP-Level-3 browsers; if yours blocks it, only hot-reload is degraded —
+      the app still runs and `vite build` is unaffected. This tight policy is what
+      ships in the production bundle.
+    -->
+    <meta
+      http-equiv="Content-Security-Policy"
+      content="default-src 'self'; script-src 'self' 'wasm-unsafe-eval'; connect-src 'self' wss:; object-src 'none'; base-uri 'none'"
+    />
     <title>SCP in-browser participant scaffold</title>
   </head>
   <body>

--- a/scaffolds/typescript-web/index.html
+++ b/scaffolds/typescript-web/index.html
@@ -1,0 +1,82 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>SCP in-browser participant scaffold</title>
+  </head>
+  <body>
+    <main>
+      <h1>SCP in-browser participant (scaffold)</h1>
+      <p>
+        A single-tab in-browser SCP participant over
+        <code>@limn-works/scp-ts-wasm</code>. The full MLS protocol runs in-tab,
+        keys on-device (ADR-057). This is a <strong>structural scaffold</strong>:
+        it wires identity, storage, transport, and a message render loop.
+        Cross-party invitation-join is deferred to #2187.
+      </p>
+
+      <form id="connect-form">
+        <fieldset>
+          <legend>Connect</legend>
+          <p>
+            <label for="did">Participant DID (pre-provisioned — the browser tier
+              does not mint DIDs in-tab)</label><br />
+            <input
+              id="did"
+              name="did"
+              type="text"
+              autocomplete="off"
+              placeholder="did:dht:z6Mk…"
+            />
+          </p>
+          <p>
+            <label for="relay">Relay URL</label><br />
+            <input
+              id="relay"
+              name="relay"
+              type="url"
+              autocomplete="off"
+              placeholder="wss://relay.example"
+            />
+          </p>
+          <p>
+            <label for="context">Context id</label><br />
+            <input
+              id="context"
+              name="context"
+              type="text"
+              autocomplete="off"
+              placeholder="my-context"
+            />
+          </p>
+          <button id="connect" type="submit">Connect and create context</button>
+        </fieldset>
+      </form>
+
+      <form id="send-form">
+        <fieldset>
+          <legend>Send a message</legend>
+          <p>
+            <label for="message">Message</label><br />
+            <input
+              id="message"
+              name="message"
+              type="text"
+              autocomplete="off"
+              placeholder="hello"
+            />
+          </p>
+          <button id="send" type="submit" disabled>Send</button>
+        </fieldset>
+      </form>
+
+      <section aria-labelledby="log-heading">
+        <h2 id="log-heading">Activity</h2>
+        <div id="log" role="log" aria-live="polite"></div>
+      </section>
+    </main>
+
+    <script type="module" src="/src/main.ts"></script>
+  </body>
+</html>

--- a/scaffolds/typescript-web/package.json
+++ b/scaffolds/typescript-web/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "scp-typescript-web",
+  "version": "0.1.0",
+  "type": "module",
+  "private": true,
+  "scripts": {
+    "dev": "vite",
+    "start": "vite",
+    "build": "vite build",
+    "check": "tsc --noEmit",
+    "lint": "biome check src/"
+  },
+  "dependencies": {
+    "@limn-works/scp-ts-wasm": "file:../../bindings/typescript-wasm"
+  },
+  "devDependencies": {
+    "@biomejs/biome": "2.5.5",
+    "typescript": "^5.7.0",
+    "vite": "^6.0.0"
+  }
+}

--- a/scaffolds/typescript-web/src/main.ts
+++ b/scaffolds/typescript-web/src/main.ts
@@ -1,0 +1,146 @@
+/**
+ * scaffolds/typescript-web — a single-tab in-browser SCP participant over
+ * `@limn-works/scp-ts-wasm` (ADR-057).
+ *
+ * Structural scaffold only (spec §21.12: scaffolds are *structural* —
+ * placeholder identity + context creation, no application logic; templates are
+ * *functional*). It wires the real package API end to end: on-device WebCrypto
+ * custody, IndexedDB storage, the managed WebSocket relay transport, a context,
+ * a `sendMessage` path, and a `drainEvents` render loop. Where relay-mediated
+ * cross-party invitation-join would go there is a clearly-marked seam deferred to
+ * #2187 (its §9.7.1 DID-VM KeyPackage binding is not yet in the wasm tier).
+ *
+ * The wasm tier does NOT mint DIDs in-tab: `did` is pre-provisioned by your
+ * identity flow and pasted into the form. Keys are held on-device (see the
+ * package caveats — the MLS signing key is still extractable pre-#1980).
+ */
+
+import {
+  IndexedDbStorage,
+  ScpBrowserClient,
+  ScpError,
+  WebCryptoCustody,
+} from "@limn-works/scp-ts-wasm";
+
+/** Looks up a required element by id, throwing a clear error if the markup drifted. */
+function required<T extends HTMLElement>(id: string): T {
+  const el = document.getElementById(id);
+  if (el === null) {
+    throw new Error(`scaffold markup is missing #${id}`);
+  }
+  return el as T;
+}
+
+const connectForm = required<HTMLFormElement>("connect-form");
+const sendForm = required<HTMLFormElement>("send-form");
+const didInput = required<HTMLInputElement>("did");
+const relayInput = required<HTMLInputElement>("relay");
+const contextInput = required<HTMLInputElement>("context");
+const messageInput = required<HTMLInputElement>("message");
+const sendButton = required<HTMLButtonElement>("send");
+const log = required<HTMLElement>("log");
+
+/** Appends one line to the activity log (an `aria-live` region). */
+function append(line: string): void {
+  const entry = document.createElement("div");
+  entry.textContent = line;
+  log.append(entry);
+}
+
+let client: ScpBrowserClient | undefined;
+let contextId = "";
+let pump: ReturnType<typeof setInterval> | undefined;
+
+/** Connects a fully-wired in-browser client and opens a sole-member context. */
+async function connect(): Promise<void> {
+  const did = didInput.value.trim();
+  const url = relayInput.value.trim();
+  contextId = contextInput.value.trim();
+  if (did === "" || url === "" || contextId === "") {
+    append("Provide a pre-provisioned DID, a relay URL, and a context id first.");
+    return;
+  }
+
+  // On-device key custody (WebCrypto) + durable storage (IndexedDB) are explicit,
+  // injected ports — the SDK never reaches for a hidden default. `did` is
+  // pre-provisioned; the browser tier does not mint DIDs in-tab (ADR-057).
+  const custody = WebCryptoCustody.create({ did });
+  const storage = await IndexedDbStorage.open();
+
+  // The managed transport wires the inbound pump + reconnect for you: on every
+  // (re)open it re-drives SUBSCRIBEs; on every relay frame it feeds the driver.
+  client = await ScpBrowserClient.connect({
+    custody,
+    storage,
+    url,
+    onError: (err) => append(`relay pump error [${err.code}]: ${err.message}`),
+  });
+
+  // Sole-member context (this tab). Cross-party membership is the #2187 seam below.
+  client.createContext(contextId);
+  append(`Connected as ${client.did}; created context "${contextId}".`);
+  sendButton.disabled = false;
+
+  // ── drainEvents render loop ────────────────────────────────────────────────
+  // Poll the driver's buffered events and render inbound application messages.
+  // The managed transport feeds handleRelayFrame; we drain what it produces.
+  pump = setInterval(() => {
+    if (client === undefined) {
+      return;
+    }
+    for (const event of client.drainEvents(contextId)) {
+      if (event.kind === "MessageReceived") {
+        append(`${event.senderDid}: ${new TextDecoder().decode(event.payload)}`);
+      }
+    }
+  }, 500);
+
+  // ── PLACEHOLDER seam: relay-mediated cross-party invitation-join (#2187) ─────
+  // A second participant joins here. Native↔browser invitation-join / HPKE-open
+  // custody and the §9.7.1 DID-VM KeyPackage binding are deferred to #2187, so
+  // this scaffold stays single-tab. When #2187 lands the join wires through the
+  // real API the package already exports (illustrative — intentionally NOT run):
+  //   const keyPackage = client.generateKeyPackageForJoin(contextId);
+  //   const add = client.addMember(contextId, peerKeyPackage);
+  //   client.joinContextEncrypted(contextId, add.welcome, add.eventLog, add.wrappingKeys);
+  // No cross-party membership is implemented in this slice.
+}
+
+/** Encrypts one message and fans it out over the relay to announced peers (§9.10.4). */
+function send(): void {
+  if (client === undefined || contextId === "") {
+    return;
+  }
+  const text = messageInput.value;
+  if (text === "") {
+    return;
+  }
+  try {
+    client.sendMessage(contextId, new TextEncoder().encode(text));
+    append(`you: ${text}`);
+    messageInput.value = "";
+  } catch (error) {
+    // SCP-CTX-2040 (no peer pseudonym announced yet) is the expected single-tab
+    // outcome — there is no second participant until the #2187 join seam lands.
+    const code = error instanceof ScpError ? error.code : "unknown";
+    append(`send unavailable [${code}] — no peer has joined yet (cross-party join is #2187).`);
+  }
+}
+
+connectForm.addEventListener("submit", (event) => {
+  event.preventDefault();
+  void connect();
+});
+
+sendForm.addEventListener("submit", (event) => {
+  event.preventDefault();
+  send();
+});
+
+// Best-effort cleanup of the render loop + managed transport on unload.
+window.addEventListener("beforeunload", () => {
+  if (pump !== undefined) {
+    clearInterval(pump);
+  }
+  client?.disconnect();
+});

--- a/scaffolds/typescript-web/src/main.ts
+++ b/scaffolds/typescript-web/src/main.ts
@@ -37,6 +37,7 @@ const didInput = required<HTMLInputElement>("did");
 const relayInput = required<HTMLInputElement>("relay");
 const contextInput = required<HTMLInputElement>("context");
 const messageInput = required<HTMLInputElement>("message");
+const connectButton = required<HTMLButtonElement>("connect");
 const sendButton = required<HTMLButtonElement>("send");
 const log = required<HTMLElement>("log");
 
@@ -51,32 +52,41 @@ let client: ScpBrowserClient | undefined;
 let contextId = "";
 let pump: ReturnType<typeof setInterval> | undefined;
 
-/** Connects a fully-wired in-browser client and opens a sole-member context. */
-async function connect(): Promise<void> {
-  const did = didInput.value.trim();
-  const url = relayInput.value.trim();
-  contextId = contextInput.value.trim();
-  if (did === "" || url === "" || contextId === "") {
-    append("Provide a pre-provisioned DID, a relay URL, and a context id first.");
-    return;
+/** Tears down the render loop + managed transport before any reconnect (idempotent). */
+function teardown(): void {
+  if (pump !== undefined) {
+    clearInterval(pump);
+    pump = undefined;
   }
+  client?.disconnect();
+  client = undefined;
+}
+
+/** Connects a fully-wired in-browser client and opens a sole-member context. */
+async function connect(params: { did: string; url: string; contextId: string }): Promise<void> {
+  // Defensive: clear any prior client/pump before reassigning, so a repeat
+  // connect never leaks a still-reconnecting WebSocket or a live interval.
+  teardown();
 
   // On-device key custody (WebCrypto) + durable storage (IndexedDB) are explicit,
   // injected ports — the SDK never reaches for a hidden default. `did` is
   // pre-provisioned; the browser tier does not mint DIDs in-tab (ADR-057).
-  const custody = WebCryptoCustody.create({ did });
+  const custody = WebCryptoCustody.create({ did: params.did });
   const storage = await IndexedDbStorage.open();
 
   // The managed transport wires the inbound pump + reconnect for you: on every
   // (re)open it re-drives SUBSCRIBEs; on every relay frame it feeds the driver.
+  // `onError` covers the ONGOING relay pump only — init failures propagate out of
+  // this async function to the submit handler's `.catch` and reach the same log.
   client = await ScpBrowserClient.connect({
     custody,
     storage,
-    url,
+    url: params.url,
     onError: (err) => append(`relay pump error [${err.code}]: ${err.message}`),
   });
 
   // Sole-member context (this tab). Cross-party membership is the #2187 seam below.
+  contextId = params.contextId;
   client.createContext(contextId);
   append(`Connected as ${client.did}; created context "${contextId}".`);
   sendButton.disabled = false;
@@ -96,14 +106,18 @@ async function connect(): Promise<void> {
   }, 500);
 
   // ── PLACEHOLDER seam: relay-mediated cross-party invitation-join (#2187) ─────
-  // A second participant joins here. Native↔browser invitation-join / HPKE-open
-  // custody and the §9.7.1 DID-VM KeyPackage binding are deferred to #2187, so
-  // this scaffold stays single-tab. When #2187 lands the join wires through the
-  // real API the package already exports (illustrative — intentionally NOT run):
-  //   const keyPackage = client.generateKeyPackageForJoin(contextId);
-  //   const add = client.addMember(contextId, peerKeyPackage);
-  //   client.joinContextEncrypted(contextId, add.welcome, add.eventLog, add.wrappingKeys);
-  // No cross-party membership is implemented in this slice.
+  // In a REAL two-party flow the ADDER and the JOINER are DIFFERENT clients, and
+  // the roles do not run on one `client`:
+  //   • ADDER (an existing member): `createContext` then, given the joiner's key
+  //     package, `addMember(contextId, joinerKeyPackage)` → { welcome, eventLog,
+  //     wrappingKeys, … }.
+  //   • JOINER (the newcomer): `generateKeyPackageForJoin(contextId)` to hand to
+  //     the adder, then `joinContextEncrypted(contextId, welcome, eventLog,
+  //     wrappingKeys)` with the adder's returned material.
+  // Those artifacts are exchanged out-of-band today; relay-mediated exchange (and
+  // the §9.7.1 DID-VM KeyPackage binding it needs) is deferred to #2187, so this
+  // scaffold stays single-tab and implements NEITHER role's cross-party half.
+  // See bindings/typescript-wasm/examples/browser-roundtrip.ts for the full flow.
 }
 
 /** Encrypts one message and fans it out over the relay to announced peers (§9.10.4). */
@@ -129,7 +143,30 @@ function send(): void {
 
 connectForm.addEventListener("submit", (event) => {
   event.preventDefault();
-  void connect();
+  const did = didInput.value.trim();
+  const url = relayInput.value.trim();
+  const context = contextInput.value.trim();
+  if (did === "" || url === "" || context === "") {
+    append("Provide a pre-provisioned DID, a relay URL, and a context id first.");
+    return;
+  }
+  // Teach secure transport mechanically: relays are untrusted, so a plaintext
+  // ws:// link (which leaks transport metadata) is refused — wss:// only.
+  if (!url.startsWith("wss://")) {
+    append("Relay URL must use wss:// — relays are untrusted; ws:// leaks transport metadata.");
+    return;
+  }
+  // Guard re-entry: disable Connect while a connect is in flight (and while
+  // connected). A failed connect re-enables it so the user can retry.
+  connectButton.disabled = true;
+  void connect({ did, url, contextId: context }).catch((error: unknown) => {
+    const code = error instanceof ScpError ? error.code : "unknown";
+    const message = error instanceof Error ? error.message : String(error);
+    append(`connect failed [${code}]: ${message}`);
+    teardown();
+    sendButton.disabled = true;
+    connectButton.disabled = false;
+  });
 });
 
 sendForm.addEventListener("submit", (event) => {
@@ -139,8 +176,5 @@ sendForm.addEventListener("submit", (event) => {
 
 // Best-effort cleanup of the render loop + managed transport on unload.
 window.addEventListener("beforeunload", () => {
-  if (pump !== undefined) {
-    clearInterval(pump);
-  }
-  client?.disconnect();
+  teardown();
 });

--- a/scaffolds/typescript-web/tsconfig.json
+++ b/scaffolds/typescript-web/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "compilerOptions": {
+    "target": "ESNext",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "strict": true,
+    "noUncheckedIndexedAccess": true,
+    "exactOptionalPropertyTypes": true,
+    "noImplicitReturns": true,
+    "noFallthroughCasesInSwitch": true,
+    "isolatedModules": true,
+    "skipLibCheck": true,
+    "noEmit": true,
+    "lib": ["ESNext", "DOM", "DOM.Iterable"],
+    "types": []
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/templates/chat/README.md
+++ b/templates/chat/README.md
@@ -2,7 +2,7 @@
 
 Two-party encrypted chat over the Shared Context Protocol. Provides a Python CLI client that uses real SCP SDK APIs: DID identity creation, encrypted context lifecycle, and async message send/receive.
 
-A browser client is not included: in-browser SCP runs as a remote thin client to a server-side `scp-node` (ADR-055), which is being added separately.
+A browser chat client is not included yet. In-browser SCP is a real in-tab participant — the full MLS protocol runs in the tab with keys on-device (ADR-057, which amends ADR-055's earlier remote-thin-client model), not a remote thin client to a server-side `scp-node`. A functional two-party browser chat template (`templates/chat/typescript/`) is forthcoming under #2187, once relay-mediated invitation-join is available in the wasm tier. In the meantime, `scaffolds/typescript-web/` demonstrates the single-tab in-browser client over `@limn-works/scp-ts-wasm` today.
 
 ## Architecture
 


### PR DESCRIPTION
## Summary

The **unblocked** portion of ADR-057 Slice 4 / #1951 — a single-tab in-browser SCP scaffold over the merged `@limn-works/scp-ts-wasm`, the §21.12 doc-matrix restoration, a bounded CI gate, and a repo-wide ADR-055→ADR-057 browser-model doc sweep.

### `scaffolds/typescript-web/`
A **structural** browser scaffold (§21.12: skeleton, no application logic) demonstrating the in-tab participant: `WebCryptoCustody.create({ did })` + `IndexedDbStorage.open()` + `ScpBrowserClient.connect({ custody, storage, url })` → `createContext` / `sendMessage` / `drainEvents`. Uses only real exported package API (typecheck-enforced). Keys on-device; the cross-party join is a clearly-marked comment seam deferred to **#2187** (relay-mediated invitation-join needs the browser KeyPackage §9.7.1 DID-VM binding, which is in flight). Hardened after review: init failures surface to the UI log, connect is re-entrancy-guarded with clean teardown, `wss://`-only transport guard, and a functional CSP (`'wasm-unsafe-eval'` + `connect-src wss:`). Accessible markup (labeled inputs, `role="log"` aria-live), XSS-safe (`textContent`), honest "deferred capabilities" README.

### Docs
- `.docs/specs/21-documentation.md` §21.12: restored the `typescript-web` scaffold row + tree; **no phantom chat-template row** (the TS chat template is honestly noted as forthcoming under #2187).
- **ADR-055→ADR-057 browser-model sweep:** corrected every definitive live/consumer/code reference that still claimed the superseded "browser = remote thin client / no in-process engine" model — `templates/chat/README.md`, `bindings/typescript/README.md` (×2), `README.md`, `GETTING-STARTED.md`, `docs/guides/sdk-quickstart.md` (×2), `docs/examples/typescript/README.md`, and a `node_bridge_runner.ts` comment — to the ADR-057 in-tab model (protocol runs in-tab via `@limn-works/scp-ts-wasm`/`scp-client-wasm`, keys on-device; custodial thin client now an optional mode). Historical records (ADR banners, lessons, planning-sessions, PRD done-stories) and ADR-057-aware optional-mode/offline-sync prose were left intact. Verified converged: an exhaustive grep of live surfaces returns **zero** remaining definitive stale refs.

### CI
`scaffold-typescript-web-check` — path-filtered on `scaffolds/typescript-web/**` + `bindings/typescript-wasm/**`, builds the wasm dep then `bun install`/`check`/`lint`/`build`s the scaffold; wired into the required `ci` aggregation gate (mirrors `typescript-wasm-check`). The scaffold `file:`-links the in-repo package (built first in CI).

## Scope boundary (honest deferrals)
No two-party chat template (`templates/chat/typescript/`) — deferred to **#2187**. No in-browser DID minting, no cross-party join, no protocol/§9.7.1/`validate_key_package` changes (that surface is owned by a parallel in-flight refactor).

## Review
Full roster to double-zero. Round 1: bug-catcher + frontend caught two connect-path defects (silent init failure, re-entrancy leak); security seeded wss:// + CSP; completionist caught stale ADR-055 refs beyond the scaffold. All fixed. Round 2: 5 code reviewers clean; completionist found more stale refs → exhaustive one-pass sweep. Round 3: completionist (own grep), alignment, simplifier all confirm convergence — zero definitive live refs, minimal edits, no history rewritten. simplifier certified the sweep as bounded-set-driven-to-zero (convergent, not tail-chasing).

## Verification (all green)
`bun run check` (tsc strict) · `bun run lint` (biome) · `bun run build` (Vite; wasm asset emitted, CSP in bundle) · `ci.yml` valid · 0 behind main · no forbidden surfaces touched.

Refs ADR-057 (Slice 4), planning-session-09 step 5, §21.12. Does not close #1951 (the two-party chat template remains, tracked under #2187).

🤖 Generated with [Claude Code](https://claude.com/claude-code)