### PR TITLE
fix(runtime): bound KeyPackageStoreHandle reply-await with KP_REPLY_TIMEOUT

### DIFF
--- a/crates/scp-runtime/src/context/supervisor/key_package_actor.rs
+++ b/crates/scp-runtime/src/context/supervisor/key_package_actor.rs
@@ -145,6 +145,23 @@ pub const KP_MAILBOX_CAPACITY: usize = 32;
 /// [`crate::context::actor::handle::SEND_TIMEOUT`] for consistency.
 pub const KP_SEND_TIMEOUT: Duration = Duration::from_secs(30);
 
+/// Per-caller reply-await timeout bounding how long
+/// [`KeyPackageStoreHandle::send`] waits on the actor's oneshot reply AFTER the
+/// command was enqueued. Distinct budget from [`KP_SEND_TIMEOUT`], which bounds
+/// only mailbox ADMISSION (waiting for a free slot on a full mailbox): once the
+/// command is enqueued, this bounds actor-side PROCESSING — the actor runs a
+/// single serial mailbox loop, so a `Reserve` / `ConfirmConsume` / `Replenish`
+/// reply can legitimately trail every command already queued ahead of it
+/// (up to [`KP_MAILBOX_CAPACITY`] of them), each doing MLS crypto plus durable
+/// storage I/O. Conflating the two budgets would risk turning a merely
+/// deep-queued (but healthy) actor into an error on the very bootstrap path
+/// this bound protects, so the reply budget is deliberately larger. Bounding it
+/// at all is the point: a WEDGED actor (stuck inside a hung storage/transport
+/// call) must never pin a bootstrap caller forever — on elapse the handle
+/// fail-closes with a typed [`ContextError::ActorBusy`] (retryable) rather than
+/// awaiting the reply unbounded (internal follow-up #129).
+pub const KP_REPLY_TIMEOUT: Duration = Duration::from_mins(1);
+
 /// Target pool size: 10 usable KeyPackages per identity (ADR-001 criterion 8,
 /// mirrored by ADR-049 §9.16.1). Replenish refills `pool` (+ outstanding
 /// `reserved`) back up to this high-water mark.
@@ -596,8 +613,9 @@ impl KeyPackageStoreHandle {
     /// # Errors
     ///
     /// - [`ContextError::ActorBusy`] — mailbox full for
-    ///   [`KP_SEND_TIMEOUT`], or inbox closed, or the actor dropped the
-    ///   reply channel.
+    ///   [`KP_SEND_TIMEOUT`], or the actor did not reply within
+    ///   [`KP_REPLY_TIMEOUT`] after enqueue (wedged/backed-up actor), or inbox
+    ///   closed, or the actor dropped the reply channel.
     /// - The handler's typed error.
     pub async fn send<T, F>(&self, cmd_factory: F) -> Result<T, ContextError>
     where
@@ -607,11 +625,21 @@ impl KeyPackageStoreHandle {
         let cmd = cmd_factory(tx);
 
         match tokio::time::timeout(KP_SEND_TIMEOUT, self.inbox.send(cmd)).await {
-            Ok(Ok(())) => rx.await.unwrap_or_else(|_| {
-                Err(ContextError::ActorBusy(
+            // Enqueued: bound the reply-await too. A stuck/slow actor (e.g. hung
+            // inside a storage/transport call) must never pin the caller — a
+            // bootstrap path — forever (#129). On elapse, fail-closed with a
+            // retryable `ActorBusy`, matching the enqueue-timeout taxonomy;
+            // never a silent default.
+            Ok(Ok(())) => match tokio::time::timeout(KP_REPLY_TIMEOUT, rx).await {
+                Ok(Ok(reply)) => reply,
+                Ok(Err(_dropped)) => Err(ContextError::ActorBusy(
                     "key-package actor dropped reply channel".to_owned(),
-                ))
-            }),
+                )),
+                Err(_elapsed) => Err(ContextError::ActorBusy(format!(
+                    "key-package actor did not reply within {} seconds",
+                    KP_REPLY_TIMEOUT.as_secs()
+                ))),
+            },
             Ok(Err(_closed)) => Err(ContextError::ActorBusy(
                 "key-package actor inbox is closed".to_owned(),
             )),

--- a/crates/scp-runtime/src/context/supervisor/key_package_actor_tests.rs
+++ b/crates/scp-runtime/src/context/supervisor/key_package_actor_tests.rs
@@ -3403,3 +3403,46 @@ fn newtype_reservation_id_serializes_transparently_as_string() {
 // `clear_kp_poison` surface; see `kp_actor_watchdog_records_panic_and_respawns`,
 // `kp_actor_poisons_after_budget`, and `clear_kp_poison_recovers_poisoned_actor`
 // there.
+
+// ---------------------------------------------------------------------------
+// 8. handle reply-await is bounded (internal follow-up #129)
+// ---------------------------------------------------------------------------
+
+/// A command that enqueues successfully but is NEVER replied to (no actor
+/// drains the mailbox / no oneshot ack) must NOT hang the caller forever: the
+/// handle's post-enqueue reply-await is bounded by
+/// [`super::KP_REPLY_TIMEOUT`], returning a retryable
+/// [`ContextError::ActorBusy`] on elapse. Uses `start_paused` so tokio
+/// auto-advances virtual time to fire the timer — the test is deterministic
+/// and completes instantly instead of waiting the real 60 s.
+#[tokio::test(start_paused = true)]
+async fn send_reply_await_is_bounded_when_actor_never_replies() {
+    use super::{KP_MAILBOX_CAPACITY, KP_REPLY_TIMEOUT, KeyPackageStoreHandle};
+
+    // Buffered mailbox (capacity > 0) with the receiver held alive but NEVER
+    // drained: `inbox.send` succeeds and buffers the command, so we exercise
+    // the post-enqueue reply-await — the exact #129 wedge — rather than the
+    // enqueue-timeout or closed-inbox branches. `_rx` stays bound to keep the
+    // inbox open (dropping it would close the channel and take the other arm).
+    let (tx, _rx) = tokio::sync::mpsc::channel::<KeyPackageCommand>(KP_MAILBOX_CAPACITY);
+    let handle = KeyPackageStoreHandle::from_sender(tx);
+
+    let start = tokio::time::Instant::now();
+    let result = handle
+        .send(|reply| KeyPackageCommand::Replenish { reply })
+        .await;
+    let elapsed = start.elapsed();
+
+    // `panic!` is banned in this dispatch-layer file by check-handler-no-panic
+    // (the test module carries no inner `#[cfg(test)]` marker), so assert over
+    // a `matches!` rather than a catch-all panic arm.
+    assert!(
+        matches!(&result, Err(ContextError::ActorBusy(msg)) if msg.contains("did not reply")),
+        "expected the reply-timeout ActorBusy variant, got: {result:?}"
+    );
+    assert!(
+        elapsed >= KP_REPLY_TIMEOUT,
+        "reply-await must span the full KP_REPLY_TIMEOUT budget before failing \
+         closed (elapsed {elapsed:?} < {KP_REPLY_TIMEOUT:?})"
+    );
+}


### PR DESCRIPTION
## Summary

`KeyPackageStoreHandle::send` bounded only mailbox admission with `KP_SEND_TIMEOUT` (30s). Once a command was enqueued, the post-enqueue `rx.await` on the oneshot reply was **unbounded** — a wedged actor (stuck inside a hung storage/transport call) could pin a caller forever. Because this is the bootstrap path, an unbounded await is a liveness hazard: the caller can never make progress or retry.

This PR adds `KP_REPLY_TIMEOUT = Duration::from_mins(1)` bounding the reply-await **after** enqueue.

## Why a distinct budget (60s reply vs 30s enqueue)

- `KP_SEND_TIMEOUT` (30s) bounds only mailbox **ADMISSION** — waiting for a free slot on a full mailbox.
- `KP_REPLY_TIMEOUT` (60s) bounds actor-side **PROCESSING**. The actor runs a single serial mailbox loop, so a `Reserve` / `ConfirmConsume` / `Replenish` reply can legitimately trail every command already queued ahead of it (up to `KP_MAILBOX_CAPACITY`), each doing MLS crypto plus durable storage I/O.

Conflating the two would risk turning a merely deep-queued (but healthy) actor into a spurious error on the very bootstrap path this bound protects, so the reply budget is deliberately larger.

## Behavior

On elapse the handle **fail-closes** with a retryable `ContextError::ActorBusy` — never a silent default — matching the existing enqueue-timeout / closed-inbox / dropped-reply taxonomy.

## Test

Adds a `#[tokio::test(start_paused = true)]` hang-test: a command that enqueues successfully but is never replied to must not hang the caller. tokio auto-advances virtual time to fire the timer, so the test is deterministic and completes instantly instead of waiting the real 60s.

## Follow-up (separate scope)

The sibling `ContextActorHandle::send` / `send_recover` unbounded reply-awaits (`handle.rs:131` / `:219`) are a documented **separate** follow-up. They are protected today by per-handler transport/storage timeouts, so they are intentionally out of scope for this hardening.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
