### PR TITLE
fix(runtime): fail-loud tripwire requiring the testing feature for scp-runtime test targets

### DIFF
--- a/crates/scp-runtime/src/lib.rs
+++ b/crates/scp-runtime/src/lib.rs
@@ -21,6 +21,17 @@
 
 #![forbid(unsafe_code)]
 
+// scp-runtime test targets require the `testing` feature: numerous `#[cfg(test)]`
+// modules call `#[cfg(feature = "testing")]`-gated helpers. `testing` is normally
+// enabled transitively via the `scp-testing` dev-dependency; this tripwire turns a
+// severed back-edge into a clear message instead of a cryptic E0599 (or silent vanish).
+#[cfg(all(test, not(feature = "testing")))]
+compile_error!(
+    "scp-runtime test targets require the `testing` feature \
+     (enabled transitively via the scp-testing dev-dependency, or pass \
+     `--features scp-runtime/testing` explicitly)."
+);
+
 pub mod bridge;
 pub mod context;
 pub mod crypto;


### PR DESCRIPTION
## Summary

Closes #2093.

`scp-runtime` has a **latent** feature-gate defect: numerous `#[cfg(test)]` modules call `#[cfg(feature = "testing")]`-gated helpers — `spawn_from_welcome_tests` (`Supervisor::seed_peer_pseudonym`, §9.10.4; `scp_platform::testing::InMemoryKeyCustody`) plus the same shape in `supervisor.rs`'s inline `mod tests`, `crypto/agent_binding_tests.rs`, `crypto/mls/wrapping_extension_runtime_tests.rs`, `crypto/mls/two_party_test_support.rs`, and `context/agent_binding_pipeline_tests.rs`. Under test-cfg-on / `testing`-off this is an E0599 mismatch.

### Why it never fires today (the dev-dep mask)

The break is masked on `main`: the `scp-testing` dev-dependency transitively force-enables `scp-runtime/testing` (`scp-testing → scp-core/testing → scp-runtime/testing`) in every `scp-runtime` test build. So the mismatch is a latent defect, not an active one — but it is invisible and fragile.

### Why a crate-level `compile_error!` beats per-file gating

The prior fix added a per-file `#![cfg(feature = "testing")]` to `spawn_from_welcome_tests.rs`. Two problems:

1. **Incomplete** — the identical latent defect survives in the ≥5 sibling modules.
2. **Silences rather than surfaces** — a per-file `#![cfg(...)]` converts a LOUD E0599 into a SILENT test-vanish if the dev-dep mask is ever severed: the module simply compiles out and its coverage disappears without a word — the wrong direction for a repo that treats silent coverage loss as a defect.

Instead this PR reverts the per-file gate (restoring the bare `#[cfg(test)]` module shape shared by the siblings) and adds **one** crate-level `compile_error!` tripwire gated on `all(test, not(feature = "testing"))` at the top of `lib.rs`. One site makes the invariant explicit and loud for all lib `#[cfg(test)]` modules — the touched one and the five siblings. If the transitive back-edge is ever severed, the test build fails with a clear, actionable message instead of a cryptic E0599 (or a silent test-vanish). The message is deliberately non-enumerating (no module names) to avoid stale references.

### Accepted boundary: integration-test crates

Integration-test crates under `tests/` are a separate compilation surface the crate-root tripwire cannot reach (5 of them call the `testing`-gated `seed_peer_pseudonym`). Those already fail loudly with E0599 if the dev-dep mask is ever severed — never silently — so this is a consciously-accepted boundary, not a case where a `build.rs` is warranted.

## Impact

No coverage change in any real config: `testing` is always satisfied when `scp-runtime`'s test target builds today, so the tripwire never fires in CI or local runs. Net change is +11 lines in `crates/scp-runtime/src/lib.rs`.

## Local CI (all green)

- `cargo build -p scp-runtime --all-targets` (no `testing`) — clean; tripwire does not fire
- `cargo clippy -p scp-runtime --all-targets --features scp-runtime/testing -- -D warnings` — clean
- `cargo fmt --all -- --check` — clean
- `cargo nextest run -p scp-runtime spawn_from_welcome --features scp-runtime/testing` — 32 passed
- `scripts/check-construction-pattern.py` — pass; `scripts/check-cross-layer.sh` — pass (N/A, no new public fns)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
