### PR TITLE
docs(adr-062): define SCPR relay public-record frame (§9.10.12) + correct SCP-CAPINJECT-011 AC2 (relay querier)

### DIFF
--- a/.docs/prds/adr062-capability-injection.json
+++ b/.docs/prds/adr062-capability-injection.json
@@ -424,7 +424,7 @@
     },
     {
       "id": "SCP-CAPINJECT-011",
-      "title": "E4 relay querier: implement the real MultiRelayQuerier per §3.10.12 (the relay-resolution layer), demote NoOpRelayQuerier/InMemoryRelayQuerier to test-harness-only",
+      "title": "E4 relay querier: implement the real MultiRelayQuerier per §3.10.12 (the relay-resolution layer, resolving via SCPR kind-1 frames §9.10.12); demote only the pure test double InMemoryRelayQuerier to test-harness-only (NoOpRelayQuerier stays a shipped production arm)",
       "gate": "gate-capinject-11",
       "priority": "P0",
       "severity": "major",
@@ -435,10 +435,10 @@
         "crates/scp-identity/src/lib.rs",
         "crates/scp-identity/Cargo.toml"
       ],
-      "description": "ADR-062 Slice 11 (Unit 3, E4 MED; §Decision 5, spec §3.10.12). E4 is a COMPLETENESS / defense-in-depth gap, NOT a nullifier (resolved from spec+code): `NoOpRelayQuerier` (resolver.rs:309) `query` returns `Ok(None)`; the `DualLayerResolver` falls back to DHT-only and returns honest not-found `Ok(None)` when both layers find nothing — it NEVER fabricates a false document (§3.10.4 'MUST NOT fabricate'). It FAILS CLOSED. Every conformant identity publishes to the DHT (the §3.10.6 publish-both MUST), so authenticity/reachability/freshness are all preserved; only the §3.10.8 dual-layer suppression *resilience* (defense-in-depth availability) is reduced, which §3.10.6 permits (dual-layer resolution is a SHOULD). Therefore `NoOpRelayQuerier` SHIPS HONESTLY as the DHT-only interim (it need NOT be gated/absent at Slice 6; G1-green Slices 6-11 is sound). This story's remediation is COMPLETENESS: implement the REAL `MultiRelayQuerier` (queries the identity's relays per §3.10.4/§3.10.12) so resolution uses BOTH layers per §3.10.6 and the dual-layer suppression resilience is restored; once the real querier is the default, demote `NoOpRelayQuerier` + the test `InMemoryRelayQuerier` (resolver.rs:910) to test-harness-only. This also completes A2's Disabled-node story: a `DhtMode::Disabled` node (DHT-layer-off) resolves peers via the real relay layer landed here. blockedBy [] (independent of the DHT-client/pre-rotation work — this is the relay-query layer). Scope exception: the real querier + resolver wiring + NoOp demotion are one resolution-layer change.",
+      "description": "ADR-062 Slice 11 (Unit 3, E4 MED; §Decision 5, spec §3.10.12). E4 is a COMPLETENESS / defense-in-depth gap, NOT a nullifier (resolved from spec+code): `NoOpRelayQuerier` (resolver.rs:309) `query` returns `Ok(None)`; the `DualLayerResolver` falls back to DHT-only and returns honest not-found `Ok(None)` when both layers find nothing — it NEVER fabricates a false document (§3.10.4 'MUST NOT fabricate'). It FAILS CLOSED. Every conformant identity publishes to the DHT (the §3.10.6 publish-both MUST), so authenticity/reachability/freshness are all preserved; only the §3.10.8 dual-layer suppression *resilience* (defense-in-depth availability) is reduced, which §3.10.6 permits (dual-layer resolution is a SHOULD). Therefore `NoOpRelayQuerier` SHIPS HONESTLY as the DHT-only interim (it need NOT be gated/absent at Slice 6; G1-green Slices 6-11 is sound). This story's remediation is COMPLETENESS: implement the REAL `MultiRelayQuerier` (queries the identity's relays per §3.10.4/§3.10.12, decoding each returned relay blob as an SCPR kind-1 DID-record frame §9.10.12 into the (value, signature, seq) triple before BEP44 verification) so resolution uses BOTH layers per §3.10.6 and the dual-layer suppression resilience is restored. CORRECTION vs. the original story: `NoOpRelayQuerier` STAYS a shipped, documented production arm — it is the honest not-a-DID-source case, since the loopback/node relay path is a protocol-unaware blob pipe (§10.4), not a DID-QUERY source, and node resolution flows through its real DHT arm (see build_shared_cache_key_resolver in scp-node/src/self_host.rs). Only the pure test double `InMemoryRelayQuerier` (the `#[cfg(test)]` one at resolver.rs:910 and the currently `pub` one exported from resolution.rs) demotes to `#[cfg(any(test, feature = \"testing\"))]`. This also completes A2's Disabled-node story: a `DhtMode::Disabled` node (DHT-layer-off) resolves peers via the real relay layer landed here. blockedBy [] (independent of the DHT-client/pre-rotation work — this is the relay-query layer). Scope exception: the real querier + resolver wiring + InMemoryRelayQuerier demotion are one resolution-layer change.",
       "acceptanceCriteria": [
-        "A real `MultiRelayQuerier` implementation exists that queries the identity's relays (§3.10.4/§3.10.12): `grep -rn 'impl MultiRelayQuerier for' crates/scp-identity/src/relay_querier.rs` matches a real (non-NoOp, non-InMemory) querier that performs relay QUERY, and the resolver composes both the relay layer and the DHT layer (grep the resolver's dual-layer path).",
-        "NoOpRelayQuerier + InMemoryRelayQuerier are test-harness-only: outside `#[cfg(test)]`/`#[cfg(feature = \"testing\")]`, `grep -rn 'NoOpRelayQuerier\\|InMemoryRelayQuerier' crates/scp-identity/src` returns 0 references as the SHIPPED resolver arm (they may exist as test doubles gated by test/testing).",
+        "A real `MultiRelayQuerier` implementation exists that queries the identity's relays and decodes the returned blobs as SCPR kind-1 DID-record frames (§9.10.12) into (value, signature, seq) before BEP44 verification (§3.10.4/§3.10.12): `grep -rn 'impl MultiRelayQuerier for' crates/scp-identity/src/relay_querier.rs` matches a real (non-NoOp, non-InMemory) querier that performs relay QUERY and SCPR-decodes the result, and the resolver composes both the relay layer and the DHT layer (grep the resolver's dual-layer path).",
+        "Only the pure test double InMemoryRelayQuerier demotes to test-harness-only; NoOpRelayQuerier STAYS a shipped production resolver arm (the honest not-a-DID-source case, §10.4) and is deliberately NOT grep-restricted. Machine-verifiable: outside `#[cfg(test)]`/`#[cfg(feature = \"testing\")]`, `grep -rn 'InMemoryRelayQuerier' crates/scp-identity/src` returns 0 references as a SHIPPED type (it may exist only as a test double gated by test/testing).",
         "Dual-layer resolution is exercised: a test resolves a DID published to a relay (not the DHT) and asserts the relay layer returns it (proving relay-resolution is live, not NoOp), and a test asserts suppression on one layer is defeated by the other (§3.10.8).",
         "NoOpRelayQuerier's fail-closed property is documented + asserted as the honest interim (not treated as a nullifier): a test asserts `NoOpRelayQuerier::query` returns `Ok(None)` (never a fabricated document) and that the resolver returns honest not-found `Ok(None)` when both layers find nothing (§3.10.4) — establishing E4 was fail-CLOSED before this slice, and this slice adds the relay layer for defense-in-depth, not to fix a false-answer bug.",
         "A2 completion — a Disabled node resolves via the real relay layer: a test constructs a `DhtMode::Disabled` node (DHT-layer-off) and asserts it resolves a peer whose DID document is published to a relay (the resolution path a Disabled node relies on once the real `MultiRelayQuerier` exists), confirming the SCP-CAPINJECT-001 sequencing note that a Disabled node's resolution comes online here.",
@@ -447,7 +447,7 @@
       ],
       "actionItems": [
         "Implement a real MultiRelayQuerier (relay QUERY per §3.10.4/§3.10.12); wire it into the resolver's dual-layer resolution.",
-        "Demote NoOpRelayQuerier + InMemoryRelayQuerier to test-harness-only (test/testing-gated).",
+        "Demote only the pure test double InMemoryRelayQuerier to test-harness-only (test/testing-gated); keep NoOpRelayQuerier as a shipped production arm.",
         "Write the dual-layer resolution + suppression-resilience tests; run full CI + review roster."
       ],
       "blockedBy": [],
@@ -461,6 +461,10 @@
           "section": "### 3.10.12 Phase Integration"
         },
         {
+          "file": ".docs/specs/09-security-model.md",
+          "section": "### 9.10.12 Relay Public-Record Frame (SCPR)"
+        },
+        {
           "file": ".docs/specs/17-persistence-and-storage.md",
           "section": "### 17.17.2 Security Classification of Development Arms"
         }
@@ -470,7 +474,7 @@
         "adr": "ADR-062",
         "unit": "3",
         "slice": "Slice 11 (E4 relay querier — §3.10.12)",
-        "scopeException": "real querier + resolver wiring + NoOp demotion are one resolution-layer change"
+        "scopeException": "real querier + resolver wiring + InMemoryRelayQuerier demotion are one resolution-layer change"
       }
     }
   ]

--- a/.docs/specs/03-identity.md
+++ b/.docs/specs/03-identity.md
@@ -811,7 +811,7 @@ The `"scp:did:"` domain separator prevents collision with other routing ID deriv
 PUBLISH {
     routing_id: did_routing_id,
     blob_ttl: 604800,
-    blob: <BEP44-signed DID document>
+    blob: <SCPR kind-1 DID-record frame (§9.10.12), carrying (value, signature, seq)>
 }
 ```
 
@@ -827,7 +827,8 @@ QUERY {
 
 **Properties:**
 
-- **No protocol changes.** PUBLISH and QUERY are existing relay operations. DID documents are stored and retrieved like any other blob. Relays require no awareness that a blob contains a DID document.
+- **No protocol changes.** PUBLISH and QUERY are existing relay operations. DID documents are stored and retrieved like any other blob. Relays require no awareness that a blob contains a DID document. SCPR framing (§9.10.12) is a client-side payload convention, not a relay behavior — the relay stores the frame bytes opaquely.
+- **Self-verifying blob payload.** The DID relay blob is an SCPR kind-1 frame (§9.10.12) carrying the BEP44 `(value, signature, seq)` triple, not the bare document bytes. Because the signature and sequence travel inside the blob, a resolver verifies the record from the blob alone — no DHT round-trip is required to obtain the signature.
 - **Relay-agnostic.** A resolver can QUERY any relay that stores the target DID document. Identity owners SHOULD publish to multiple relays — their own relays plus bootstrap relays from the fallback relay list (§18.5.1) — for suppression resistance.
 - **Size budget.** DID documents range from 2-30KB depending on attestation count and service endpoint list. The relay blob size limit is 256KB (ADR-004). Well within bounds.
 - **TTL and republishing.** The maximum relay blob TTL is 604800 seconds (7 days). Identity owners MUST republish to relays at least every 6 days (1-day safety margin). The RepublishManager already handles periodic DHT republishing on a 2-hour cycle; relay republishing adds a separate 6-day cycle for relay-stored DID documents.
@@ -854,9 +855,13 @@ The full resolution sequence:
    a. QUERY did_routing_id on known SCP relays
       (identity's published relays if known, else bootstrap relays from §18.5.1)
    b. DhtClient.resolve(public_key) on Mainline DHT
-4. For each response:
-   a. Verify BEP44 signature against public_key
-   b. Verify seq >= last_known_seq for this DID
+4. For each response, obtain the (value, signature, seq) triple:
+   a. Relay response: decode the SCPR kind-1 frame (§9.10.12) into
+      (value, signature, seq). DHT response: the triple is native.
+      Framing bytes are unsigned and MUST NOT be trusted — only the
+      triple is used.
+   b. Verify BEP44 signature over (value, seq) against public_key
+   c. Verify seq >= last_known_seq for this DID
 5. Accept the valid response with highest sequence number
 6. Cache result per §9.10.7 caching policy
    (24h refresh for active contacts, 7d for inactive)
@@ -874,6 +879,7 @@ The parallel query model (step 3) requires clear rules for when queries are canc
 - **One layer fails, one succeeds.** The successful response is accepted. The failed layer's error is logged but does not prevent resolution. The resolver does NOT retry the failed layer synchronously — the next resolution cycle (24h for active contacts, 7d for inactive) will attempt both layers again.
 - **Both layers fail.** If a cached document exists and is less than 7 days old, the cached document is returned with a `resolution_source: "cache"` indicator. If no cache exists or the cache is older than 7 days, resolution fails with error `DID_RESOLUTION_FAILED` (code 5010). The resolver MUST NOT fabricate a document.
 - **One layer returns invalid signature.** The response is discarded as if the layer had failed. An invalid signature is logged at WARN level (it may indicate relay tampering). The resolver does not fall back to the invalid document under any circumstances.
+- **Relay blob fails SCPR decoding.** A relay blob that does not decode as a valid SCPR kind-1 frame (§9.10.12) — truncated, wrong magic, wrong/reserved kind, or an inconsistent `value_len` — is discarded as if the relay had failed. Malformed framing is never trusted and never partially parsed; the resolver falls through to the other layer exactly as for an invalid signature.
 - **Timeout.** Each layer query has a 5-second timeout. If a layer does not respond within 5 seconds, it is treated as a failure for that resolution attempt.
 
 ### 3.10.5 Publishing Protocol
@@ -886,14 +892,17 @@ On DID document create or update:
 2. Sign via BEP44 (Ed25519 signature over bencoded value concatenated with
    sequence number, per BEP44 spec)
 3. In parallel:
-   a. PUBLISH to SCP relays (own relays + bootstrap relays), blob_ttl: 604800
+   a. Wrap (value, signature, seq) in an SCPR kind-1 frame (§9.10.12) and
+      PUBLISH the frame bytes to SCP relays (own relays + bootstrap relays),
+      blob_ttl: 604800. The SCPR wrapper is around `value` for transport
+      only — it is NEVER part of the bencoded signed bytes.
    b. DhtClient.publish(public_key, signature, doc_bytes, seq) to Mainline DHT
 4. RepublishManager schedules:
    - Relay republishing: every 6 days (blob_ttl is 7 days, 1-day margin)
    - DHT republishing: every 2 hours (existing cycle, unchanged)
 ```
 
-Both layers receive identical document bytes and identical BEP44 signatures. The signed payload is the same regardless of storage backend — this is a direct consequence of the self-certification property. A document retrieved from a relay and a document retrieved from the DHT are byte-identical and verify identically.
+Both layers receive identical document bytes and identical BEP44 signatures. The signed payload is the same regardless of storage backend — this is a direct consequence of the self-certification property. A document retrieved from a relay and a document retrieved from the DHT are byte-identical and verify identically. SCPR wraps `value` for transport but does not enter the signed bytes; the `(value, signature, seq)` triple carried to both layers is byte-identical (§9.10.12).
 
 ### 3.10.6 Anti-Segmentation Invariant
 
@@ -987,6 +996,7 @@ The dual-layer architecture is designed to be self-reinforcing as the SCP networ
 | DID document QUERY from relays | Phase 2 | `scp-core` | Extends existing DID resolution path with relay QUERY before/parallel to DHT. |
 | `DidResolver` trait | Phase 2 | `scp-core` | Unified interface composing relay + DHT resolution. |
 | Parallel dual-layer resolution | Phase 2 | `scp-core` | Orchestration of parallel queries with first-valid-wins semantics. |
+| SCPR DID-record frame (§9.10.12) | Phase 2 | `scp-protocol` | Deterministic binary encode/decode of the relay public-record frame kind 1. Pure sync wasm-compatible type; consumed by the relay publisher + DID resolver in `scp-identity`. |
 
 ## 3.11 DID Authentication for External Services (SCPID)
 

--- a/.docs/specs/09-security-model.md
+++ b/.docs/specs/09-security-model.md
@@ -900,6 +900,7 @@ The protocol provides layered metadata privacy protections. Each layer addresses
 - **Blocking layer:** AES-256 sender-side keys enable cryptographic blocking without MLS group changes (§9.16)
 - **Cross-context key isolation:** Independent MLS key material per context (§9.10.9)
 - **Delivery layer:** Relay-side delivery jitter breaks timing correlation between PUBLISH and delivery (§9.10.10)
+- **Public-record format:** Relay public-record frame (SCPR) for unencrypted self-certifying records such as DID documents — the structural counterpart to the encrypted outer envelope (§9.10.12)
 
 This section specifies what the protocol protects, how it protects it, and what residual risks remain.
 
@@ -1139,6 +1140,58 @@ Even with all protections in this section, the following metadata leaks remain:
 - **Push notification timing:** Apple/Google learn that a device received a notification at a specific time. Content and source remain opaque (§10.7).
 - **DHT participation patterns:** On desktop, DHT routing traffic is mixed with resolution queries, but a network observer can see DHT participation.
 - **Relay trust:** Relays see blob sizes (bucketed), TTLs, and pseudonyms. A relay colluding with a context member could correlate pseudonyms to identities for that context only.
+
+### 9.10.12 Relay Public-Record Frame (SCPR)
+
+The **SCPR frame** is the unencrypted counterpart to the §9.10.2 Minimal Outer Envelope: where the outer envelope is *confidential by encryption*, an SCPR record is *self-certifying by signature*. Its first — and, at this slice, only defined — record kind is the DID document (§3.10.2). It is specified here in §9.10 because §9.10 is where relay-stored record formats live: the outer envelope (§9.10.2) is the encrypted format, and SCPR is the public-record format.
+
+**Why raw binary, not MessagePack/CBOR.** SCPR uses a raw, length-prefixed binary layout under the §9.5.1 length-prefix discipline rather than a self-describing codec (MessagePack, CBOR). Self-describing codecs admit multiple valid encodings of the same logical value (map-key ordering, integer width, string-vs-binary tags), which would (a) break byte-identical cross-binding decoding — two SDKs could emit different bytes for the same record — and (b) perturb the exact `value` bytes handed to BEP44 verification, since the signed payload must be reproduced octet-for-octet. SCPR therefore fixes exactly one canonical encoding.
+
+**Frame layout:**
+
+```
+SCPR-RECORD :=
+  magic:    [u8; 4]  = 0x53 0x43 0x50 0x52   # ASCII "SCPR"
+  version:  u8        = 1
+  kind:     u8                                 # record-kind discriminator
+  <kind-specific body>
+```
+
+- **magic** — the raw 4-byte ASCII string "SCPR" (mirroring the SCPM management magic, §9.16.1), written with no length prefix (a fixed-width field, §9.5.1).
+- **version** — a `u8`, starting at 1. Any change to field encoding bumps the version.
+- **kind** — a `u8` record-kind discriminator:
+
+  | kind | Record | Status |
+  |------|--------|--------|
+  | 1 | DID-record | Defined |
+  | 2 | KeyPackage | Reserved — not defined |
+  | 3 | Context-metadata | Reserved — not defined |
+  | 4 | Revocation | Reserved — not defined |
+
+  Kinds 2–4 MUST NOT be emitted; their bodies are undefined. (KeyPackages today misuse `OuterEnvelope.encrypted_blob` as an unencrypted carrier and SHOULD migrate to SCPR kind 2 in a future slice.)
+
+**DID-record body (kind 1):**
+
+```
+  seq:       u64                 # 8 bytes big-endian — BEP44 sequence
+  signature: [u8; 64]            # Ed25519 BEP44 signature, raw fixed-width, NO length prefix
+  value_len: u32                 # 4 bytes big-endian — length of value
+  value:     [u8; value_len]     # BEP44-signed payload = encoded DID document (opaque; owned by did:dht §18.2.2A)
+```
+
+Per the §9.5.1 encoding rules: the fixed-width fields (`seq` as a `u64`, `signature` as `[u8; 64]`) are written raw with no length prefix, while the sole variable-length field, `value`, carries a 4-byte big-endian `u32` length prefix (`value_len`). The fixed portion is therefore `6` (header: 4 magic + 1 version + 1 kind) `+ 8 + 64 + 4 = 82` bytes, and the total frame length is `82 + value_len`. `value_len` MUST NOT exceed `Max blob size` (262144, §9.18.11) `− 82`. There is deliberately **no** `sig_len` field: a BEP44 Ed25519 signature is unconditionally 64 bytes for kind 1, and §9.5.1 gives fixed-width fields no length prefix; a different signature length would be a new kind or version, not a per-frame field.
+
+**Framing is outside the signed authority.** The BEP44 signature covers only the bencoded `(seq, value)` pair (plus the salt where the DID method uses one), per §3.10.5. The `magic`, `version`, `kind`, and `value_len` fields are unsigned transport framing. A decoder MUST NOT derive any security-relevant conclusion from the framing bytes. After decoding a kind-1 frame into `(value, signature, seq)`, the resolver MUST BEP44-verify the triple against the Ed25519 key encoded in the DID string (§9.6.1) **before** any use; a frame whose triple does not verify is discarded exactly as an invalid DHT record is (§3.10.4). Because the routing ID is derived from the DID string while verification is against that DID's key, record substitution is cryptographically impossible (§3.10.8).
+
+**BEP44 byte-identity across layers (§3.10.5).** SCPR wraps `value` for relay transport only; it never enters, reorders, or alters the signed bytes. A DHT-native `(value, signature, seq)` triple and the same triple decoded from an SCPR frame are byte-identical and verify identically. The §3.10.4 rule that two valid records sharing a sequence number MUST be byte-identical holds across both layers.
+
+**Publish / query contract.**
+
+- **Publish** = wrap the `(value, signature, seq)` triple in an SCPR frame and PUBLISH the frame bytes via the existing relay PUBLISH operation (§3.10.2). This is not a relay protocol change: the relay stores opaque bytes. The DID relay blob MUST be the SCPR kind-1 frame carrying `(value, signature, seq)`, not the bare DID-document bytes.
+- **Query** = the relay QUERY operation returns the raw SCPR blob(s) stored at the routing ID; the resolver decodes each at a **single** site into `(value, signature, seq)` and then BEP44-verifies.
+- **Distinct from the outer envelope.** A public-record routing ID carries SCPR frames, not `OuterEnvelope`s; a resolver MUST NOT deserialize one as the other. DID records occupy their own routing-ID space, `SHA-256("scp:did:" || did_string)` (§3.10.2), disjoint from context routing IDs.
+
+**TTL.** SCPR records reuse the shared relay `blob_ttl` (§9.10.2), bounded by `Max blob TTL` = 604800s / 7d (§9.18.11). There is no kind-specific TTL and no change to `Max blob TTL`. TTL governs storage lifetime; the BEP44 `seq` governs supersession (§3.10.7). Record permanence is achieved by republication on the 6-day cycle (§3.10.2), not by TTL.
 
 ## 9.11 Key Continuity Verification
 
@@ -1774,6 +1827,9 @@ This section consolidates all HKDF labels, HPKE info prefixes, HMAC domain strin
 | SCPM management magic | `[0x53, 0x43, 0x50, 0x4D]` | 4-byte ASCII prefix distinguishing management from application messages in MLS plaintext | §9.16.1 |
 | Management payload max size | 65,536 bytes (64 KiB) | Maximum management message payload after SCPM prefix | §9.16.1 |
 | Epoch poisoning max advance | 1,000 | Maximum allowed epoch jump in a single sender key distribution | §9.16.1 |
+| SCPR record magic | `[0x53, 0x43, 0x50, 0x52]` | 4-byte ASCII "SCPR" prefix of the relay public-record frame (§9.10.12). Unsigned framing — grants no authority. | §9.10.12 |
+| SCPR frame version | 1 | Current SCPR frame version; bumped on any field-encoding change | §9.10.12 |
+| SCPR DID-record kind | 1 | Record-kind discriminator for the DID-record body; kinds 2–4 reserved/undefined | §9.10.12 |
 | Buffer event max age | 3,600s (1h) | Maximum estimated age for buffer events in consequence evaluation | §7.3.7 |
 | Buffer event future tolerance | 5s | Maximum future tolerance for buffer event timestamps | §7.3.7 |
 | Broadcast replay max authors | 10,000 | Maximum unique senders tracked in broadcast replay detector | §9.16.5 |


### PR DESCRIPTION
## Summary

ADR-062 Slice 11 (relay querier) — documentation/artifact edits only, no Rust. Two parts.

### Part A — SPEC: the SCPR relay public-record frame (permanent wire format)

Adds `### 9.10.12 Relay Public-Record Frame (SCPR)` to `09-security-model.md`. SCPR is the **unencrypted, self-certifying-by-signature** counterpart to the §9.10.2 Minimal Outer Envelope — the format for relay-stored public records whose first (and only currently defined) kind is the DID document.

Key design points, all baked in verbatim from the human-ratified design:
- **One canonical raw-binary encoding** (not MessagePack/CBOR) under the §9.5.1 length-prefix discipline. Self-describing codecs admit multiple encodings of the same value, which would break byte-identical cross-binding decoding **and** perturb the exact `value` bytes fed to BEP44 verify.
- **Frame** = `magic "SCPR"` + `version:u8` + `kind:u8` + kind-specific body. Kind 1 = DID-record (`seq:u64` / `signature:[u8;64]` / `value_len:u32` / `value`); kinds 2–4 reserved and MUST NOT be emitted. Fixed portion = 82 bytes; `value_len ≤ Max blob size (262144) − 82`. Deliberately **no** `sig_len` field.
- **Framing is outside the signed authority.** magic/version/kind/value_len are unsigned transport bytes; the BEP44 signature covers only bencoded `(seq, value)`. A resolver MUST BEP44-verify the decoded triple against the DID's Ed25519 key (§9.6.1) before use; substitution is cryptographically impossible (§3.10.8).
- **Byte-identity across layers**: SCPR wraps `value` for transport only; DHT-native and SCPR-decoded triples are byte-identical.

Also: §9.10 intro layer-list bullet; three `§9.18.8` constant-registry rows (SCPR magic `[0x53,0x43,0x50,0x52]` / version 1 / DID-record kind 1); and `03-identity.md` updates — §3.10.2 (DID relay blob = SCPR kind-1 frame, self-verifying from the blob alone), §3.10.4 (decode-then-verify + malformed-frame-discard semantics), §3.10.5 (wrap-and-PUBLISH; wrapper never enters the signed bytes), §3.10.12 (phase-integration row, `scp-protocol`).

### Part B — STORY: correct SCP-CAPINJECT-011 AC2

The original AC2 wrongly demoted `NoOpRelayQuerier` to test-harness-only. It is in fact a **legitimate production arm**: the node's loopback relay path is a protocol-unaware blob pipe (§10.4), not a DID-QUERY source, and node resolution flows through its real DHT arm (`build_shared_cache_key_resolver`, `scp-node/src/self_host.rs`). AC2 now demotes **only** the pure test double `InMemoryRelayQuerier`, and the machine-verifiable grep targets `InMemoryRelayQuerier`. Also wired the SCPR frame + §9.10.12 into the title, description, AC1, and `sources`; dependencies remain forward-only.

## Verification
- `python3.12 scripts/validate-prd.py` → passes (16 files, 437 stories), exit 0.
- All `§9.10.12` / `§3.10.x` / `§9.18.x` / `§18.2.2A` / `§10.4` cross-refs verified to resolve to real headings; the §9.10.12 insert did not renumber any existing section.
- `git diff --name-only` = only `.docs/**` (no code).

🤖 Generated with [Claude Code](https://claude.com/claude-code)