### PR TITLE
fix(client-wasm): reconcile browser participant error codes to one cross-surface meaning (closes #2144)

### DIFF
--- a/.docs/standards/sdk-common.md
+++ b/.docs/standards/sdk-common.md
@@ -147,7 +147,10 @@ pre-existing cross-language overlaps predate and are out of scope for #2144 (e.g
 are reused by the Swift/ts-native SDKs for their own validation conditions, and
 `SCP-CTX-2003` is overloaded — see below). #2144 fixes only the browser
 participant's own allocations so they stop colliding; the broader cross-language
-reconciliation is a separate, unaddressed concern.
+reconciliation — auditing the full cross-surface namespace and strengthening the
+compliance mechanism (`check-error-codes.sh` Phase-2 does not machine-check
+SDK-wrapper or match-arm literals; see its documented KNOWN LIMITATION) — is
+tracked in discussion #2208, not addressed here.
 
 This table documents the allocation; it is not a new enforcement mechanism. The
 scp-client-wasm mapping is additionally guarded by an exhaustive positive

--- a/.docs/standards/sdk-common.md
+++ b/.docs/standards/sdk-common.md
@@ -117,6 +117,81 @@ holds `13050-13099`, so the two layers never contend for the same number.
 | `SCP-SAGA-13067` | supervisor | Generic saga terminal abort with no specific sub-code (e.g. Prepare-phase 30s timeout, journal I/O failure) — the message string carries the specific cause |
 | `SCP-SAGA-13068` | supervisor | `ParticipantUnavailable` — Prepare-phase abort: participant actor unavailable to complete the Prepare exchange — inbox closed/terminated (transient, retryable) |
 
+### Registered SCP-CTX- / SCP-CRYPTO- / SCP-TRANS- / SCP-VALID- codes (native registry vs. browser participant)
+
+The native FFI-common registry (`crates/scp-ffi/common/src/error_codes.rs`) is
+the Rust materialization of the per-number meanings for the **native** bridges
+(`PyO3`, napi-rs, `UniFFI`). The browser participant surface
+(`crates/scp-client-wasm/src/error.rs`, plus the `@limn-works/scp-ts-wasm` SDK
+wrapper) **cannot** import that registry — the ADR-057 wasm/tokio fence keeps
+`scp-client-wasm` off `scp_ffi_common` — so it hand-writes its
+`[SCP-{CATEGORY}-{NUMBER}]` literals, which MUST agree with this ledger.
+
+**Scope of the guarantee (be precise — #2144).** Error codes are emitted from
+FIVE surfaces: the native registry, the Swift SDK (`bindings/swift/**`), the
+Kotlin SDK (`bindings/kotlin/**`), the ts-native SDK (`bindings/typescript/src/**`),
+and this ts-wasm surface. `scripts/check-error-codes.sh` machine-checks band
+ranges and native-registry uniqueness, but its Phase-2 cross-surface collision
+detector has a documented KNOWN LIMITATION: it does **not** inspect the
+SDK-wrapper literals (Swift/Kotlin/TS/Python), which "must be reviewed manually
+against error_codes.rs to prevent collisions." A **full cross-surface
+`SCP-<band>-<n>` union** was computed by hand across all five surfaces, and every
+**browser-owned** code registered below was assigned a number **absent from that
+union** — i.e. cross-surface-unique as of this change. The ONE deliberate
+exception is `SCP-CTX-2095`, whose meaning (pseudonym-registry-empty) is
+identical on native + Swift + Kotlin + ts-native + this surface.
+
+This is NOT a claim that *every* SCP code has one meaning across all surfaces:
+pre-existing cross-language overlaps predate and are out of scope for #2144 (e.g.
+`SCP-VALID-7010`/`7011`/`7012` mean UCAN-validation in the native registry but
+are reused by the Swift/ts-native SDKs for their own validation conditions, and
+`SCP-CTX-2003` is overloaded — see below). #2144 fixes only the browser
+participant's own allocations so they stop colliding; the broader cross-language
+reconciliation is a separate, unaddressed concern.
+
+This table documents the allocation; it is not a new enforcement mechanism. The
+scp-client-wasm mapping is additionally guarded by an exhaustive positive
+allowlist test in `crates/scp-client-wasm/src/error.rs` (which also pins the
+`lib.rs` direct-emitter literals via the shared `WASM_INPUT_VALIDATION_CODE`
+constant).
+
+| Code | Owner | Condition |
+|------|-------|-----------|
+| `SCP-CTX-2001` | native FFI-common registry (also Swift/Kotlin/ts-native SDKs) | Context operation failed (generic) — native meaning; NOT emitted by `scp-client-wasm` |
+| `SCP-CTX-2002` | native FFI-common registry | Context not found — native meaning; NOT emitted by `scp-client-wasm` |
+| `SCP-CTX-2003` | native FFI-common registry — **cross-surface OVERLOADED (pre-existing, out of #2144 scope)** | native = "Context already exists"; Swift = "message stream already active"; Kotlin = "not a member". NOT reused by `scp-client-wasm` precisely because of this overload |
+| `SCP-CTX-2004` | native FFI-common registry | Context creation failed — native meaning; NOT emitted by `scp-client-wasm` |
+| `SCP-CTX-2005` | native FFI-common registry | Context join failed — native meaning; NOT emitted by `scp-client-wasm` |
+| `SCP-CTX-2040` | native FFI-common registry | Context operation error (native `CTX_2040`) — native meaning; NOT emitted by `scp-client-wasm` |
+| `SCP-CTX-2082` | `scp-client-wasm` (browser participant) | Unknown / not-held context (`ClientError::UnknownContext`) |
+| `SCP-CTX-2083` | `scp-client-wasm` (browser participant) | Context already exists in this client (`ClientError::ContextAlreadyExists`) — browser-owned; does NOT reuse the overloaded native `2003` |
+| `SCP-CTX-2084` | `scp-client-wasm` (browser participant) | Unsupported membership change — a received Commit removes a member (out of ADR-057 Slice 2 convergent scope) (`ClientError::UnsupportedMembershipChange`) |
+| `SCP-CTX-2085` | `scp-client-wasm` (browser participant) | Driver invariant violation / malformed driver argument (`ClientError::Driver`) |
+| `SCP-CTX-2086` | `scp-client-wasm` (browser participant) | No retained pending join material — join must reconstruct from the durable snapshot (`ClientError::NoPendingJoinMaterial`). (Sits at 2086 because 2080/2081 are taken by the Kotlin SDK.) |
+| `SCP-CTX-2095` | native FFI-common registry + Swift + Kotlin + ts-native + `scp-client-wasm` (**shared meaning, all surfaces**) | Pseudonym registry empty — peers have not announced routing IDs (§9.10.4); native `ContextError::PseudonymRegistryEmpty`, browser `ClientError::PseudonymRegistryEmpty` |
+| `SCP-CRYPTO-4010` | native FFI-common registry (also Kotlin SDK) | MLS group create error — native meaning; NOT emitted by `scp-client-wasm` |
+| `SCP-CRYPTO-4020` | `scp-client-wasm` (browser participant) | Sender-key (§9.16) layer failure (`ClientError::SenderKey`) |
+| `SCP-CRYPTO-4030` | `scp-client-wasm` (browser participant) | Event-log append / proof failure (`ClientError::EventLog`) |
+| `SCP-CRYPTO-4040` | `scp-client-wasm` (browser participant) | Convergent committer-timestamp AAD failure — missing or malformed (ADR-057) (`ClientError::Mls(ConvergentTimestampMissing \| ConvergentTimestampMalformed)`) |
+| `SCP-CRYPTO-4041` | `scp-client-wasm` (browser participant) | Generic MLS group operation failure — create/add/join/encrypt/decrypt/commit catch-all (`ClientError::Mls(_)`) |
+| `SCP-TRANS-5005` | `scp-client-wasm` (browser participant) | Injected outbound `Socket`/`RelaySink` failed to enqueue a relay frame — WebSocket closed / JS exception (`ClientError::Transport`) |
+| `SCP-TRANS-5010` | native FFI-common registry (also Kotlin SDK) | Transport subscription error — native meaning; NOT emitted by `scp-client-wasm` |
+| `SCP-VALID-7010` | native FFI-common registry (**pre-existing cross-language overlap**: reused by Swift/Kotlin/ts-native SDKs for their own validation conditions) | UCAN token validation error — native meaning; NOT emitted by `scp-client-wasm` |
+| `SCP-VALID-7011` | native FFI-common registry (**pre-existing cross-language overlap** with Swift/Kotlin/ts-native) | UCAN mint validation error — native meaning; NOT emitted by `scp-client-wasm` |
+| `SCP-VALID-7028` | `scp-client-wasm` (browser participant) | Browser participant wire/input (de)serialization or byte-shape validation failure — `ClientError::Codec` (MLS wire codec) plus the wasm free-function input validators (`requestId`/`operatorPk`/`caveatsBinding` length, `OutletStreamChunk` decode, event-log & wrapping-key MessagePack serde). Emitted via the shared `WASM_INPUT_VALIDATION_CODE` constant |
+| `SCP-VALID-7029` | `scp-client-wasm` (browser participant) | Frame content type did not match its relay channel — §9.10.4 mis-routed frame, defense-in-depth (`ClientError::ChannelContentMismatch`) |
+| `SCP-VALID-7025` | `@limn-works/scp-ts-wasm` (browser SDK wrapper) | wasm module not initialized — `initScp()` (or `ScpBrowserClient.connect`) must be awaited before constructing/using a client |
+| `SCP-VALID-7026` | `@limn-works/scp-ts-wasm` (browser SDK wrapper) | `WebSocketRelaySocket` (the managed transport) passed to `create()` instead of `ScpBrowserClient.connect()` — it would be left unattached |
+
+The browser participant reuses **only** `SCP-CTX-2095` from the shared band —
+its condition is semantically identical on all five surfaces. Every other
+browser condition took a distinct browser-owned number (`2082-2086`,
+`4020/4030/4040/4041`, `5005`, `7028/7029`, and the SDK-wrapper `7025/7026`),
+each verified absent from the native/Swift/Kotlin/ts-native union so no
+browser-owned code string collides with any other surface as of this change.
+Notably `SCP-CTX-2083` (already-exists) does **not** reuse native `2003`, because
+`2003` is already overloaded across native/Swift/Kotlin.
+
 ### Registered SCP-STORAGE- codes
 
 The `SCP-STORAGE-` band (`8000-8999`) is shared across the storage-selection

--- a/bindings/typescript-wasm/README.md
+++ b/bindings/typescript-wasm/README.md
@@ -75,7 +75,7 @@ const ws = new WebSocket("wss://relay.example");
 ws.binaryType = "arraybuffer";
 
 // A JsSocket is just `{ send(frame: Uint8Array): void }` — throw when not open so
-// the client surfaces SCP-TRANS-5010 rather than silently dropping a frame.
+// the client surfaces SCP-TRANS-5005 rather than silently dropping a frame.
 const socket = {
   send(frame: Uint8Array) {
     if (ws.readyState !== WebSocket.OPEN) throw new Error("relay socket not open");
@@ -108,7 +108,7 @@ ws.onmessage = (evt) => client.handleRelayFrame(new Uint8Array(evt.data as Array
   determinism holds and is KAT-pinned (ADR-057 A1).
 - **Fail-closed decrypt rests on the `--release` build** (ADR-057 Prereq-4): the shipped
   wasm is always built `--release` so openmls's decrypt `debug_assert!` is compiled out
-  and a tampered ciphertext surfaces a typed `[SCP-CRYPTO-4010]` error, not a tab-abort.
+  and a tampered ciphertext surfaces a typed `[SCP-CRYPTO-4041]` error, not a tab-abort.
 
 ## License
 

--- a/bindings/typescript-wasm/scripts/wasm-build.ts
+++ b/bindings/typescript-wasm/scripts/wasm-build.ts
@@ -5,7 +5,7 @@
  * reframed): the shipped wasm MUST be a `--release` build. openmls's decrypt
  * path carries a `debug_assert!` that a `--dev` (debug-assertions-on) build
  * re-arms — a tampered ciphertext would then abort the tab instead of surfacing
- * a typed `[SCP-CRYPTO-4010]` `DecryptionFailed`. `--release` compiles that
+ * a typed `[SCP-CRYPTO-4041]` `DecryptionFailed`. `--release` compiles that
  * assert out, so `process_message` returns a typed `Err` on tampered ciphertext.
  *
  * The profile flag is a constant here so the `check-release-only` guard asserts
@@ -39,7 +39,7 @@ export const FORBIDDEN_PROFILE_FLAGS: readonly string[] = ["--dev", "--debug", "
  * never drift. Together with the root `[profile.release] debug-assertions = false`
  * pin in `Cargo.toml` (from #1444), `--release` is what guarantees the shipped
  * wasm has debug-assertions OFF, so openmls's decrypt `debug_assert!` is compiled
- * out and a tampered ciphertext surfaces a typed `[SCP-CRYPTO-4010]` error rather
+ * out and a tampered ciphertext surfaces a typed `[SCP-CRYPTO-4041]` error rather
  * than aborting the tab (ADR-057 Prereq-4).
  */
 export function assertReleaseOnly(args: readonly string[]): void {

--- a/bindings/typescript-wasm/src/adapters/types.ts
+++ b/bindings/typescript-wasm/src/adapters/types.ts
@@ -28,7 +28,7 @@ export interface JsSocket {
    * Writes one serialized relay `ClientMessage` frame to the socket.
    *
    * MUST throw if the frame cannot be enqueued (the socket is not OPEN, a
-   * buffering fault). A thrown exception surfaces as `[SCP-TRANS-5010]` at the
+   * buffering fault). A thrown exception surfaces as `[SCP-TRANS-5005]` at the
    * client boundary; it MUST NOT silently drop the frame.
    */
   send(frame: Uint8Array): void;

--- a/bindings/typescript-wasm/src/adapters/websocket-relay-socket.ts
+++ b/bindings/typescript-wasm/src/adapters/websocket-relay-socket.ts
@@ -127,7 +127,7 @@ export class WebSocketRelaySocket implements JsSocket {
   /**
    * Writes one serialized relay frame to the socket.
    *
-   * Throws if the socket is not OPEN — surfaced as `[SCP-TRANS-5010]` at the
+   * Throws if the socket is not OPEN — surfaced as `[SCP-TRANS-5005]` at the
    * client boundary (the wasm `RelaySink` adapter re-codes the thrown exception).
    * A frame is never silently dropped.
    */
@@ -210,7 +210,7 @@ export class WebSocketRelaySocket implements JsSocket {
     ws.onerror = () => {
       // Surface transport errors to the consumer; the close handler drives
       // reconnect. Not fatal to the pump.
-      this.#onError?.(mapBridgeError(new Error("[SCP-TRANS-5010] relay WebSocket error")));
+      this.#onError?.(mapBridgeError(new Error("[SCP-TRANS-5005] relay WebSocket error")));
     };
   }
 

--- a/bindings/typescript-wasm/src/client.ts
+++ b/bindings/typescript-wasm/src/client.ts
@@ -300,7 +300,7 @@ export class ScpBrowserClient {
   /**
    * Creates a new encrypted context with this participant as sole member.
    *
-   * @throws {ContextError} `SCP-CTX-2002` if the id is already held.
+   * @throws {ContextError} `SCP-CTX-2083` if the id is already held.
    * @throws {CryptoError} on group-creation / leaf failure.
    * @throws {StorageError} `SCP-STORAGE-8010` if the snapshot write fails (poisons the context).
    */
@@ -345,8 +345,8 @@ export class ScpBrowserClient {
    * injected socket to every announced peer pseudonym (§9.10.4). No return value
    * — the ciphertext leaves via the socket, not the caller.
    *
-   * @throws {ContextError} `SCP-CTX-2040` if no peer has announced a pseudonym yet (retryable).
-   * @throws {TransportError} `SCP-TRANS-5010` if the socket rejects a frame.
+   * @throws {ContextError} `SCP-CTX-2095` if no peer has announced a pseudonym yet (retryable).
+   * @throws {TransportError} `SCP-TRANS-5005` if the socket rejects a frame.
    */
   sendMessage(contextId: string, plaintext: Uint8Array): void {
     call(() => this.#inner.sendMessage(contextId, plaintext));
@@ -446,7 +446,7 @@ export class ScpBrowserClient {
   mlsEpoch(contextId: string): bigint | undefined {
     // Gate on the non-throwing status predicate so a not-held/poisoned context
     // yields `undefined` like the siblings, instead of the wasm surface's
-    // `[SCP-CTX-2001]` / `[SCP-STORAGE-8013]` throw. Single-threaded driver, so
+    // `[SCP-CTX-2082]` / `[SCP-STORAGE-8013]` throw. Single-threaded driver, so
     // there is no status→epoch race.
     if (this.#inner.contextStatus(contextId) !== "live") {
       return undefined;
@@ -477,7 +477,7 @@ export class ScpBrowserClient {
  * `effectiveCaveatsJcs` MUST be the RFC 8785 JCS encoding of the post-narrowing
  * caveats (this consumes those bytes as produced; it does not canonicalize).
  *
- * @throws {ValidationError} `SCP-VALID-7010` if `requestId` is not exactly 16 bytes.
+ * @throws {ValidationError} `SCP-VALID-7028` if `requestId` is not exactly 16 bytes.
  */
 export function outletStreamComputeCaveatsBinding(
   ucanCid: Uint8Array,
@@ -504,7 +504,7 @@ export function outletStreamComputeCaveatsBinding(
  * `false` (a verification RESULT, not an error). `chunk` is the JSON-serialized
  * `OutletStreamChunk`; `operatorPk` and `caveatsBinding` are 32-byte values.
  *
- * @throws {ValidationError} `SCP-VALID-7010` on malformed input (unparseable
+ * @throws {ValidationError} `SCP-VALID-7028` on malformed input (unparseable
  *   chunk, a non-32-byte or non-Ed25519 `operatorPk`, a non-32-byte `caveatsBinding`).
  */
 export function outletStreamVerifyChunkSignature(

--- a/bindings/typescript-wasm/src/errors.ts
+++ b/bindings/typescript-wasm/src/errors.ts
@@ -12,7 +12,7 @@
  * The wasm surface throws JS exceptions whose message carries a stable
  * `[SCP-{CATEGORY}-{NUMBER}]` prefix (`crates/scp-client-wasm/src/error.rs`).
  * The client maps those through {@link mapBridgeError} — the SAME string-prefix
- * dispatch the NAPI tier uses — so a wasm `SCP-CTX-2005` classifies to
+ * dispatch the NAPI tier uses — so a wasm `SCP-CTX-2086` classifies to
  * `ContextError` exactly as a native one does. Classification is by code prefix,
  * never by cross-package object identity (the bounded dual-package `instanceof`
  * residual D1 accepts). `mapBridgeError` is re-exported for cross-tier API

--- a/bindings/typescript-wasm/tests/e2e-exchange.test.ts
+++ b/bindings/typescript-wasm/tests/e2e-exchange.test.ts
@@ -151,10 +151,10 @@ test("two-party create/add/join/send/receive/converge through the real wasm + re
   expect(alice.contextStatus(CTX)).toBe("absent");
 });
 
-test("an op on an unknown context throws a typed ContextError (SCP-CTX-2001) through the real wasm", async () => {
+test("an op on an unknown context throws a typed ContextError (SCP-CTX-2082) through the real wasm", async () => {
   const relay = new TestRelay();
   const { client: alice } = await connectClient(relay, ALICE);
-  // The real wasm throws "[SCP-CTX-2001] …"; the wrapper's prefix dispatch maps
+  // The real wasm throws "[SCP-CTX-2082] …"; the wrapper's prefix dispatch maps
   // it to the typed ContextError with a stable .code — the error-path contract.
   let caught: unknown;
   try {
@@ -163,7 +163,7 @@ test("an op on an unknown context throws a typed ContextError (SCP-CTX-2001) thr
     caught = e;
   }
   expect(caught).toBeInstanceOf(ContextError);
-  expect((caught as ContextError).code).toBe("SCP-CTX-2001");
+  expect((caught as ContextError).code).toBe("SCP-CTX-2082");
 });
 
 test("create() rejects the managed WebSocketRelaySocket with a loud pointer to connect()", () => {

--- a/bindings/typescript-wasm/tests/websocket-relay-socket.test.ts
+++ b/bindings/typescript-wasm/tests/websocket-relay-socket.test.ts
@@ -87,7 +87,7 @@ test("send throws before the socket is OPEN, then succeeds once open", () => {
     throw new Error("factory not invoked");
   }
 
-  // CONNECTING → send rejects (surfaced as SCP-TRANS-5010 at the client boundary).
+  // CONNECTING → send rejects (surfaced as SCP-TRANS-5005 at the client boundary).
   expect(() => socket.send(new Uint8Array([1]))).toThrow();
 
   ws.open();
@@ -135,7 +135,7 @@ test("a throwing onFrame routes to onError and does not kill the pump", () => {
     onFrame: () => {
       calls += 1;
       if (calls === 1) {
-        throw new Error("[SCP-CRYPTO-4010] boom");
+        throw new Error("[SCP-CRYPTO-4041] boom");
       }
     },
   });
@@ -147,7 +147,7 @@ test("a throwing onFrame routes to onError and does not kill the pump", () => {
   ws.deliver(new Uint8Array([1])); // throws → routed to onError
   ws.deliver(new Uint8Array([2])); // pump survived → delivered
   expect(calls).toBe(2);
-  expect(errors).toEqual(["SCP-CRYPTO-4010"]);
+  expect(errors).toEqual(["SCP-CRYPTO-4041"]);
   // Contrast with the fatal wasm-trap path below: a PLAIN error leaves the socket
   // OPEN (the pump is not killed).
   expect(ws.readyState).toBe(WS_OPEN);

--- a/crates/scp-client-wasm/src/error.rs
+++ b/crates/scp-client-wasm/src/error.rs
@@ -24,12 +24,41 @@ use scp_client::ClientError;
 use scp_mls::MlsError;
 use wasm_bindgen::JsValue;
 
+/// The code emitted for a browser-participant wire/input (de)serialization or
+/// byte-shape validation failure.
+///
+/// Shared by [`ClientError::Codec`] (via [`error_code`]) AND the `lib.rs` wasm
+/// free-function input validators (`request_id`/`operator_pk`/`caveats_binding`
+/// length, `OutletStreamChunk` decode, event-log & wrapping-key `MessagePack`
+/// serde), which construct their `JsValue` message DIRECTLY rather than through
+/// [`error_code`]. Routing every emitter through this ONE constant makes a typo
+/// impossible and lets the exhaustive allowlist test pin all of them at once
+/// (`error_code(Codec)` returns this constant, and the test asserts its value).
+///
+/// Registered as `scp-client-wasm` in `.docs/standards/sdk-common.md`; verified
+/// free across all five surfaces (native/swift/kotlin/ts-native/ts-wasm).
+pub(crate) const WASM_INPUT_VALIDATION_CODE: &str = "SCP-VALID-7028";
+
 /// Stable error-code prefix for each [`ClientError`] category.
 ///
-/// The numbers slot into the cross-SDK ranges documented in
-/// `.docs/standards/sdk-common.md` (CTX 2000-2999, CRYPTO 4000-4999,
-/// VALID 7000-7999, STORAGE 8000-8999). They are part of the public JS error
-/// contract — append new variants, never renumber existing ones.
+/// The numbers are the reconciled per-code meanings registered in
+/// `.docs/standards/sdk-common.md` ("Registered SCP-CTX- / SCP-CRYPTO- /
+/// SCP-TRANS- / SCP-VALID- codes"). That ledger is the single source of truth
+/// for the browser-owned allocations. The numbers were chosen by an exhaustive
+/// manual cross-surface review (the process `scripts/check-error-codes.sh`
+/// Phase-2 mandates for the SDK-wrapper surfaces it cannot machine-check): every
+/// browser-owned code here is FREE across all five surfaces (native
+/// FFI-common registry, Swift, Kotlin, ts-native, ts-wasm). The ONE exception is
+/// the deliberate reuse of `SCP-CTX-2095` (pseudonym-registry-empty), whose
+/// meaning is identical on native + Swift + Kotlin + ts-native + this surface.
+/// (Native CTX-2003 is NOT reused: native means "already exists" but Swift means
+/// "message stream already active" and Kotlin "not a member" — a pre-existing
+/// cross-surface overload — so `ContextAlreadyExists` took a fresh browser-owned
+/// number instead.) This crate cannot import the native registry (the ADR-057
+/// wasm/tokio fence), so these literals are hand-written and kept in agreement
+/// with the ledger by the exhaustive allowlist test below. The numbers are part
+/// of the public JS error contract — never silently renumber; a change must move
+/// the ledger row first (after re-running the cross-surface union check).
 ///
 /// This is a pure `&ClientError -> &str` mapping with no `JsValue` dependency,
 /// so it is testable on the native host (where `JsValue` construction aborts —
@@ -47,38 +76,56 @@ pub const fn error_code(err: &ClientError) -> &'static str {
         ClientError::Mls(
             MlsError::ConvergentTimestampMissing | MlsError::ConvergentTimestampMalformed(_),
         ) => "SCP-CRYPTO-4040",
-        // MLS / sender-key / event-log are the cryptographic protocol layers.
-        ClientError::Mls(_) => "SCP-CRYPTO-4010",
+        // Generic MLS group operation catch-all (create/add/join/encrypt/decrypt/
+        // commit). A browser-owned crypto code, distinct from the native registry's
+        // CRYPTO-4010 ("MLS group create error"), whose narrower meaning this
+        // catch-all does not share (see the registered-codes table in sdk-common.md).
+        ClientError::Mls(_) => "SCP-CRYPTO-4041",
+        // Sender-key (§9.16) and event-log are the other browser crypto layers.
         ClientError::SenderKey(_) => "SCP-CRYPTO-4020",
         ClientError::EventLog(_) => "SCP-CRYPTO-4030",
         // Wire (de)serialization of MLS objects is a validation failure on
-        // attacker-suppliable bytes.
-        ClientError::Codec(_) => "SCP-VALID-7010",
+        // attacker-suppliable bytes. Browser-owned VALID code (7028), free across
+        // all five surfaces. The wasm free-function input validators
+        // (request_id/operator_pk/caveats length, OutletStreamChunk decode,
+        // event-log & wrapping-key serde) emit this SAME code — one meaning:
+        // "browser wire/input validation failure" — via the shared constant.
+        ClientError::Codec(_) => WASM_INPUT_VALIDATION_CODE,
         // A decrypted frame's content type did not match the relay channel it
         // arrived on (§9.10.4 defense-in-depth: a mis-routed announcement/app
         // frame). Benign-dropped in `handle_relay_frame`, so it is not normally
-        // surfaced across the JS boundary; the distinct VALID code exists so it
-        // is legible if it ever is (e.g. a direct `receive_*` call).
-        ClientError::ChannelContentMismatch => "SCP-VALID-7011",
-        // Context lifecycle / membership.
-        ClientError::UnknownContext(_) => "SCP-CTX-2001",
-        ClientError::ContextAlreadyExists(_) => "SCP-CTX-2002",
-        ClientError::UnsupportedMembershipChange(_) => "SCP-CTX-2003",
+        // surfaced across the JS boundary; the distinct browser-owned VALID code
+        // (7029) exists so it is legible if it ever is (e.g. a direct `receive_*`
+        // call). Free across all five surfaces.
+        ClientError::ChannelContentMismatch => "SCP-VALID-7029",
+        // Context lifecycle / membership. `UnknownContext`, `ContextAlreadyExists`,
+        // `UnsupportedMembershipChange`, and `Driver` are browser-owned CTX codes
+        // (2082-2085), each verified FREE across all five surfaces. In particular
+        // `ContextAlreadyExists` does NOT reuse native CTX-2003 ("already exists"):
+        // that number is already overloaded off-native (Swift = "message stream
+        // already active", Kotlin = "not a member"), so a fresh code is minted.
+        ClientError::UnknownContext(_) => "SCP-CTX-2082",
+        ClientError::ContextAlreadyExists(_) => "SCP-CTX-2083",
+        ClientError::UnsupportedMembershipChange(_) => "SCP-CTX-2084",
         // A driver invariant violation (bad argument / missing pending state).
-        ClientError::Driver(_) => "SCP-CTX-2004",
+        ClientError::Driver(_) => "SCP-CTX-2085",
         // An app-data send hit an empty peer-pseudonym registry in a multi-member
         // context — retryable once peers' announcements are pumped in (§9.10.4,
-        // ADR-057 transport slice). CTX band; distinct from the generic driver code.
-        ClientError::PseudonymRegistryEmpty { .. } => "SCP-CTX-2040",
+        // ADR-057 transport slice). Semantically IDENTICAL to native
+        // `ContextError::PseudonymRegistryEmpty` (`SCP-CTX-2095`) — and the same
+        // meaning on Swift, Kotlin, and ts-native — so it is the ONE deliberate
+        // cross-surface shared-meaning reuse (sdk-common.md).
+        ClientError::PseudonymRegistryEmpty { .. } => "SCP-CTX-2095",
         // The injected outbound Socket failed to enqueue a relay frame (the
-        // WebSocket is closed / a JS exception was thrown). Transport band.
-        ClientError::Transport(_) => "SCP-TRANS-5010",
+        // WebSocket is closed / a JS exception was thrown). Browser-owned Transport
+        // code (5005), free across all five surfaces.
+        ClientError::Transport(_) => "SCP-TRANS-5005",
         // A join was attempted with no retained pending key package (never
         // generated, or already consumed by a prior join attempt — single-use per
-        // attempt). Distinct from the generic Driver code so a caller can tell an
-        // absent-pending-material join apart from other invariant violations and
-        // route it to the reconstruct-from-durable retry path.
-        ClientError::NoPendingJoinMaterial { .. } => "SCP-CTX-2005",
+        // attempt). Browser-owned CTX code (2086), distinct from the generic Driver
+        // code so a caller can route it to the reconstruct-from-durable retry path.
+        // (2080/2081 are taken by Kotlin, so this sits at 2086 — free across five.)
+        ClientError::NoPendingJoinMaterial { .. } => "SCP-CTX-2086",
         // The injected Storage backend failed at the I/O level (a
         // get/put/delete/list_keys fault) — distinct from a corrupt-but-readable
         // blob. NOTE: 8001-8003 are already allocated by scp-kt-android's
@@ -104,7 +151,7 @@ pub const fn error_code(err: &ClientError) -> &'static str {
 /// code prefix.
 ///
 /// The resulting [`JsValue`] is a string of the form
-/// `"[SCP-CRYPTO-4010] MLS error: …"`. wasm-bindgen turns a returned
+/// `"[SCP-CRYPTO-4041] MLS error: …"`. wasm-bindgen turns a returned
 /// `Err(JsValue)` into a thrown JS exception, so the TypeScript wrapper receives
 /// it as `error.message` and parses the bracketed prefix.
 #[must_use]
@@ -130,135 +177,100 @@ pub fn map_err<T>(result: Result<T, ClientError>) -> Result<T, JsValue> {
 mod tests {
     use super::*;
 
-    #[test]
-    fn unknown_context_maps_to_stable_ctx_code() {
-        let err = ClientError::UnknownContext("ctx-x".to_owned());
-        assert_eq!(error_code(&err), "SCP-CTX-2001");
+    /// The reconciled `error_code()` value expected for every [`ClientError`]
+    /// variant, as an EXHAUSTIVE positive allowlist.
+    ///
+    /// This is deliberately an independent, no-wildcard `match` over the whole
+    /// `ClientError` enum: it is the single-source-of-truth mirror of the
+    /// `.docs/standards/sdk-common.md` ledger expressed as code. Its purpose is
+    /// twofold and both halves are load-bearing:
+    ///
+    /// 1. **Exhaustiveness (a closed whitelist).** Because there is NO `_`
+    ///    wildcard, adding a new `ClientError` variant fails to compile HERE
+    ///    until an arm — and thus a deliberate ledger decision — is added. A new
+    ///    variant cannot silently fall through to an unaudited code.
+    /// 2. **Value pinning.** Every arm is a literal reconciled code. If
+    ///    `error_code()` is edited to emit a different (e.g. native-colliding)
+    ///    code without also updating this allowlist AND the ledger, the
+    ///    `codes_match_the_reconciled_allowlist` assertion below fails.
+    ///
+    /// It is NOT a re-check of a property the type system already guarantees:
+    /// the type system cannot know that `SCP-CTX-2095` means "pseudonym registry
+    /// empty" or that the browser surface must not collide with a Swift/Kotlin
+    /// SDK code — that is a human cross-surface-review decision, and this is where
+    /// it is mechanically pinned.
+    fn reconciled_code(err: &ClientError) -> &'static str {
+        match err {
+            ClientError::Mls(
+                MlsError::ConvergentTimestampMissing | MlsError::ConvergentTimestampMalformed(_),
+            ) => "SCP-CRYPTO-4040",
+            ClientError::Mls(_) => "SCP-CRYPTO-4041",
+            ClientError::SenderKey(_) => "SCP-CRYPTO-4020",
+            ClientError::EventLog(_) => "SCP-CRYPTO-4030",
+            ClientError::Codec(_) => "SCP-VALID-7028",
+            ClientError::UnknownContext(_) => "SCP-CTX-2082",
+            ClientError::ContextAlreadyExists(_) => "SCP-CTX-2083",
+            ClientError::UnsupportedMembershipChange(_) => "SCP-CTX-2084",
+            ClientError::Driver(_) => "SCP-CTX-2085",
+            ClientError::ChannelContentMismatch => "SCP-VALID-7029",
+            ClientError::Transport(_) => "SCP-TRANS-5005",
+            ClientError::PseudonymRegistryEmpty { .. } => "SCP-CTX-2095",
+            ClientError::NoPendingJoinMaterial { .. } => "SCP-CTX-2086",
+            ClientError::StorageBackend(_) => "SCP-STORAGE-8010",
+            ClientError::StorageCorrupt(_) => "SCP-STORAGE-8011",
+            ClientError::StorageIdentityMismatch(_) => "SCP-STORAGE-8012",
+            ClientError::ContextPoisoned { .. } => "SCP-STORAGE-8013",
+        }
     }
 
-    #[test]
-    fn distinct_categories_get_distinct_codes() {
-        let already = ClientError::ContextAlreadyExists("c".to_owned());
-        let unsupported = ClientError::UnsupportedMembershipChange("c".to_owned());
-        assert_ne!(error_code(&already), error_code(&unsupported));
-    }
-
-    #[test]
-    fn convergent_timestamp_family_maps_to_distinct_crypto_code() {
-        // ADR-057: both convergent-timestamp AAD failures (which arrive wrapped in
-        // ClientError::Mls) get the distinct SCP-CRYPTO-4040 code, so a caller can
-        // tell a convergence-authentication rejection apart from a generic MLS
-        // failure. The distinct arm must be matched BEFORE the catch-all
-        // ClientError::Mls(_) → 4010.
-        for err in [
+    /// One representative value of EVERY `ClientError` variant (plus the two
+    /// `Mls` convergent-timestamp sub-cases, which take a different code from the
+    /// generic `Mls(_)` catch-all). Built without a wildcard so the compiler
+    /// forces this list to grow with the enum.
+    fn every_variant_representative() -> Vec<ClientError> {
+        // Enumerate via an exhaustive destructuring match on a placeholder so a
+        // new variant breaks compilation here too, not just in `reconciled_code`.
+        // (The value below is discarded; the match exists only for its
+        // exhaustiveness check.)
+        let probe = ClientError::ChannelContentMismatch;
+        match &probe {
+            ClientError::Mls(_)
+            | ClientError::SenderKey(_)
+            | ClientError::EventLog(_)
+            | ClientError::Codec(_)
+            | ClientError::UnknownContext(_)
+            | ClientError::ContextAlreadyExists(_)
+            | ClientError::UnsupportedMembershipChange(_)
+            | ClientError::Driver(_)
+            | ClientError::ChannelContentMismatch
+            | ClientError::Transport(_)
+            | ClientError::PseudonymRegistryEmpty { .. }
+            | ClientError::NoPendingJoinMaterial { .. }
+            | ClientError::StorageBackend(_)
+            | ClientError::StorageCorrupt(_)
+            | ClientError::StorageIdentityMismatch(_)
+            | ClientError::ContextPoisoned { .. } => {}
+        }
+        vec![
+            // Both `Mls` sub-cases (distinct 4040) plus a generic `Mls` (4041).
             ClientError::Mls(MlsError::ConvergentTimestampMissing),
             ClientError::Mls(MlsError::ConvergentTimestampMalformed("bad len".to_owned())),
-        ] {
-            assert_eq!(error_code(&err), "SCP-CRYPTO-4040");
-        }
-        // A different MLS failure still falls through to the generic MLS code.
-        assert_eq!(
-            error_code(&ClientError::Mls(MlsError::GroupDestroyed)),
-            "SCP-CRYPTO-4010"
-        );
-    }
-
-    #[test]
-    fn no_pending_join_material_gets_its_own_distinct_ctx_code() {
-        // The single-use-per-attempt join failure has a DISTINCT code from the
-        // generic Driver invariant violation, so a caller can route it to the
-        // reconstruct-from-durable retry path rather than treating it as a generic
-        // bad-argument fault.
-        let no_pending = ClientError::NoPendingJoinMaterial {
-            context_id: "ctx".to_owned(),
-        };
-        assert_eq!(error_code(&no_pending), "SCP-CTX-2005");
-        assert_ne!(
-            error_code(&no_pending),
-            error_code(&ClientError::Driver("d".to_owned())),
-            "absent-pending-material is distinct from a generic Driver violation"
-        );
-    }
-
-    #[test]
-    fn channel_content_mismatch_gets_its_own_distinct_valid_code() {
-        // The §9.10.4 mis-routed-frame validation failure has a DISTINCT code
-        // from the generic MLS-wire codec failure, both in the VALID band, so a
-        // caller can tell a channel/content binding rejection apart from a raw
-        // deserialization fault even though the driver benign-drops it internally.
-        assert_eq!(
-            error_code(&ClientError::ChannelContentMismatch),
-            "SCP-VALID-7011"
-        );
-        assert_ne!(
-            error_code(&ClientError::ChannelContentMismatch),
-            error_code(&ClientError::Codec("wire".to_owned())),
-        );
-    }
-
-    #[test]
-    fn storage_variants_map_to_distinct_stable_storage_codes() {
-        // The four browser storage failure classes each get a distinct, stable
-        // code in the SCP-STORAGE-8010+ sub-range (part of the public JS error
-        // contract). 8001-8003 are reserved for scp-kt-android; the browser codes
-        // start at 8010 to avoid that collision.
-        assert_eq!(
-            error_code(&ClientError::StorageBackend("io".to_owned())),
-            "SCP-STORAGE-8010"
-        );
-        assert_eq!(
-            error_code(&ClientError::StorageCorrupt("checkpoint".to_owned())),
-            "SCP-STORAGE-8011"
-        );
-        assert_eq!(
-            error_code(&ClientError::StorageIdentityMismatch("owner".to_owned())),
-            "SCP-STORAGE-8012"
-        );
-        assert_eq!(
-            error_code(&ClientError::ContextPoisoned {
-                context_id: "ctx".to_owned()
-            }),
-            "SCP-STORAGE-8013"
-        );
-    }
-
-    #[test]
-    fn browser_storage_codes_avoid_the_android_reserved_low_block() {
-        // Regression guard for the collision this renumber fixed: scp-kt-android's
-        // AndroidStorage owns the low `800x` block, so every browser storage code
-        // must sit at 8010 or above. Checked numerically (no reserved-code string
-        // literal, so the grep guarding this crate against the old codes stays 0).
-        for err in [
-            ClientError::StorageBackend("s".to_owned()),
-            ClientError::StorageCorrupt("s".to_owned()),
-            ClientError::StorageIdentityMismatch("s".to_owned()),
-            ClientError::ContextPoisoned {
-                context_id: "c".to_owned(),
-            },
-        ] {
-            let code = error_code(&err);
-            // A non-storage / malformed code parses to 0 and trips the same assert.
-            let number: u32 = code
-                .strip_prefix("SCP-STORAGE-")
-                .and_then(|n| n.parse().ok())
-                .unwrap_or(0);
-            assert!(
-                number >= 8010,
-                "browser storage code {code} is in the Android-reserved low block (or malformed)"
-            );
-        }
-    }
-
-    #[test]
-    fn every_code_is_in_the_documented_prefix_space() {
-        // A representative of each category resolves to a `SCP-` code.
-        for err in [
+            ClientError::Mls(MlsError::GroupDestroyed),
+            ClientError::SenderKey(
+                scp_protocol::crypto::sender_keys::SenderKeyError::EpochOverflow,
+            ),
+            ClientError::EventLog(scp_event_log::EventLogError::EmptyLog),
+            ClientError::Codec("wire".to_owned()),
             ClientError::UnknownContext("c".to_owned()),
             ClientError::ContextAlreadyExists("c".to_owned()),
             ClientError::UnsupportedMembershipChange("c".to_owned()),
-            ClientError::Codec("c".to_owned()),
-            ClientError::ChannelContentMismatch,
             ClientError::Driver("d".to_owned()),
+            ClientError::ChannelContentMismatch,
+            ClientError::Transport("t".to_owned()),
+            ClientError::PseudonymRegistryEmpty {
+                context_id: "c".to_owned(),
+                member_count: 2,
+            },
             ClientError::NoPendingJoinMaterial {
                 context_id: "c".to_owned(),
             },
@@ -268,7 +280,90 @@ mod tests {
             ClientError::ContextPoisoned {
                 context_id: "c".to_owned(),
             },
+        ]
+    }
+
+    #[test]
+    fn codes_match_the_reconciled_allowlist() {
+        // Positive whitelist: for every representative, the emitted code equals
+        // the reconciled ledger value. Any divergence between `error_code()` and
+        // the sdk-common.md ledger (a renumber, a native-code re-use regression)
+        // fails here.
+        for err in every_variant_representative() {
+            assert_eq!(
+                error_code(&err),
+                reconciled_code(&err),
+                "error_code() diverged from the reconciled sdk-common.md allowlist for {err:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn pseudonym_registry_empty_is_the_only_cross_surface_reuse() {
+        // `SCP-CTX-2095` (pseudonym-registry-empty) is the ONE code the browser
+        // surface deliberately shares with the other surfaces — same meaning on
+        // native + Swift + Kotlin + ts-native. Every OTHER browser code is
+        // browser-owned and cross-surface-free (verified by manual union review;
+        // see the module doc). This pins the ruling.
+        const INTENTIONAL_CROSS_SURFACE_REUSES: [&str; 1] = ["SCP-CTX-2095"];
+
+        assert_eq!(
+            error_code(&ClientError::PseudonymRegistryEmpty {
+                context_id: "c".to_owned(),
+                member_count: 2,
+            }),
+            INTENTIONAL_CROSS_SURFACE_REUSES[0],
+        );
+        // `ContextAlreadyExists` must NOT revert to native CTX-2003: that number
+        // is overloaded off-native (Swift/Kotlin use it for other conditions), so
+        // a fresh browser-owned code was minted.
+        assert_eq!(
+            error_code(&ClientError::ContextAlreadyExists("c".to_owned())),
+            "SCP-CTX-2083",
+        );
+        assert_ne!(
+            error_code(&ClientError::ContextAlreadyExists("c".to_owned())),
+            "SCP-CTX-2003",
+            "ContextAlreadyExists must not reuse the cross-surface-overloaded 2003"
+        );
+    }
+
+    #[test]
+    fn lib_rs_input_validation_code_is_pinned() {
+        // The ~9 `lib.rs` wasm free-function input validators construct their
+        // `JsValue` message DIRECTLY (not via `error_code`), so the allowlist test
+        // above cannot see them. They all route through `WASM_INPUT_VALIDATION_CODE`
+        // — pinning that one constant here pins every one of those emitters, and a
+        // typo in the constant fails this test (and the allowlist test, since
+        // `error_code(Codec)` returns the constant).
+        assert_eq!(WASM_INPUT_VALIDATION_CODE, "SCP-VALID-7028");
+        assert_eq!(
+            error_code(&ClientError::Codec("wire".to_owned())),
+            WASM_INPUT_VALIDATION_CODE,
+            "ClientError::Codec must route through the shared lib.rs input-validation code"
+        );
+    }
+
+    #[test]
+    fn convergent_timestamp_family_precedes_the_generic_mls_catch_all() {
+        // ADR-057 arm-ordering guard: both convergent-timestamp AAD failures
+        // (wrapped in `ClientError::Mls`) must resolve to the distinct
+        // SCP-CRYPTO-4040, NOT fall through to the generic SCP-CRYPTO-4041.
+        for err in [
+            ClientError::Mls(MlsError::ConvergentTimestampMissing),
+            ClientError::Mls(MlsError::ConvergentTimestampMalformed("bad len".to_owned())),
         ] {
+            assert_eq!(error_code(&err), "SCP-CRYPTO-4040");
+        }
+        assert_eq!(
+            error_code(&ClientError::Mls(MlsError::GroupDestroyed)),
+            "SCP-CRYPTO-4041"
+        );
+    }
+
+    #[test]
+    fn every_code_is_in_the_documented_prefix_space() {
+        for err in every_variant_representative() {
             assert!(
                 error_code(&err).starts_with("SCP-"),
                 "code for {err:?} is in the SCP- prefix space"
@@ -288,7 +383,7 @@ mod wasm_tests {
         let err = ClientError::UnknownContext("ctx-x".to_owned());
         let js = to_js(&err);
         let msg = js.as_string().unwrap_or_default();
-        assert!(msg.starts_with("[SCP-CTX-2001] "), "prefix present: {msg}");
+        assert!(msg.starts_with("[SCP-CTX-2082] "), "prefix present: {msg}");
         assert!(msg.contains("ctx-x"), "message preserved: {msg}");
     }
 

--- a/crates/scp-client-wasm/src/lib.rs
+++ b/crates/scp-client-wasm/src/lib.rs
@@ -59,7 +59,7 @@ use scp_client::{ContextStatus, RelaySink, ScpClient, Signer, Storage};
 use scp_clock::Clock;
 use wasm_bindgen::prelude::*;
 
-use crate::error::map_err;
+use crate::error::{WASM_INPUT_VALIDATION_CODE, map_err};
 
 /// Initializes the browser surface.
 ///
@@ -353,7 +353,7 @@ impl WasmScpClient {
     ///
     /// # Errors
     ///
-    /// Throws `[SCP-CTX-2002]` if the context id is already held, or a
+    /// Throws `[SCP-CTX-2083]` if the context id is already held, or a
     /// `[SCP-CRYPTO-…]` error on group-creation / leaf failure. A
     /// `[SCP-STORAGE-8010]` on the post-create snapshot write **poisons** the
     /// freshly-created context (its in-memory state exists but was never durably
@@ -385,7 +385,7 @@ impl WasmScpClient {
     ///
     /// # Errors
     ///
-    /// Throws `[SCP-CTX-2001]` if the context is not held, `[SCP-VALID-7010]`
+    /// Throws `[SCP-CTX-2082]` if the context is not held, `[SCP-VALID-7028]`
     /// if the key package cannot be deserialized, or a `[SCP-CRYPTO-…]` error on
     /// MLS / leaf failure. A `[SCP-STORAGE-8010]` on the post-add snapshot write
     /// **poisons** the context (its state advanced in memory but was not durably
@@ -420,10 +420,10 @@ impl WasmScpClient {
     ///
     /// # Errors
     ///
-    /// Throws `[SCP-CTX-2005]` if there is no pending join material (route this
-    /// case to the reconstruct-from-durable retry path), `[SCP-CTX-2004]` on a
+    /// Throws `[SCP-CTX-2086]` if there is no pending join material (route this
+    /// case to the reconstruct-from-durable retry path), `[SCP-CTX-2085]` on a
     /// generic driver-invariant violation (bad argument),
-    /// `[SCP-CTX-2002]` if already joined, `[SCP-VALID-7010]` if the event-log
+    /// `[SCP-CTX-2083]` if already joined, `[SCP-VALID-7028]` if the event-log
     /// stream cannot be deserialized, or a `[SCP-CRYPTO-…]` error on Welcome /
     /// replay failure. A `[SCP-STORAGE-8010]` on the post-join snapshot write
     /// **poisons** the freshly-joined context (its state advanced in memory but was
@@ -467,10 +467,10 @@ impl WasmScpClient {
     ///
     /// # Errors
     ///
-    /// Throws `[SCP-CTX-2001]` if the context is not held, `[SCP-CTX-2040]` if no
+    /// Throws `[SCP-CTX-2082]` if the context is not held, `[SCP-CTX-2095]` if no
     /// peer has announced a pseudonym yet (retryable — pump peers' announcements in
     /// first), a `[SCP-CRYPTO-…]` error on a crypto / leaf failure, or
-    /// `[SCP-TRANS-5010]` if the socket rejects a frame. A `[SCP-STORAGE-8010]`
+    /// `[SCP-TRANS-5005]` if the socket rejects a frame. A `[SCP-STORAGE-8010]`
     /// on the pre-publish snapshot write **poisons** the context, and
     /// `[SCP-STORAGE-8013]` is thrown if the context is already poisoned — either
     /// way, discard this client and reconstruct it via the [`WasmScpClient`]
@@ -490,8 +490,8 @@ impl WasmScpClient {
     ///
     /// # Errors
     ///
-    /// Throws `[SCP-VALID-7010]` if the frame or its wrapped envelope cannot be
-    /// deserialized, `[SCP-TRANS-5010]` if the relay reported an error, or a
+    /// Throws `[SCP-VALID-7028]` if the frame or its wrapped envelope cannot be
+    /// deserialized, `[SCP-TRANS-5005]` if the relay reported an error, or a
     /// `[SCP-CRYPTO-…]` / `[SCP-CTX-…]` / `[SCP-STORAGE-…]` error if decrypting or
     /// applying a resolved blob fails (the same failures
     /// [`WasmScpClient::receive_message`] raises).
@@ -531,7 +531,7 @@ impl WasmScpClient {
     ///
     /// # Errors
     ///
-    /// Throws `[SCP-CTX-2001]` if the context is not held, `[SCP-CTX-2003]` if
+    /// Throws `[SCP-CTX-2082]` if the context is not held, `[SCP-CTX-2084]` if
     /// the Commit removes a member (out of Slice 2 scope; rejected pre-merge so
     /// the context stays consistent), or a `[SCP-CRYPTO-…]` error on failure
     /// (including a missing or malformed convergent-timestamp AAD —
@@ -562,7 +562,7 @@ impl WasmScpClient {
     ///
     /// # Errors
     ///
-    /// Throws `[SCP-CTX-2001]` if the context is not held. A `[SCP-STORAGE-8010]`
+    /// Throws `[SCP-CTX-2082]` if the context is not held. A `[SCP-STORAGE-8010]`
     /// on the snapshot write that records the emptied buffer **poisons** the
     /// context (the buffer was drained in memory but the emptied state was not
     /// durably recorded), and `[SCP-STORAGE-8013]` is thrown if the context is
@@ -623,7 +623,7 @@ impl WasmScpClient {
     ///
     /// # Errors
     ///
-    /// Throws `[SCP-CTX-2001]` if the context is not held, or `[SCP-STORAGE-8010]`
+    /// Throws `[SCP-CTX-2082]` if the context is not held, or `[SCP-STORAGE-8010]`
     /// if a durable delete (the pending-join blob or the snapshot) fails. Close is
     /// retryable: on such a failure the in-memory context is left intact and the
     /// recoverable snapshot is preserved (the delete order deletes the snapshot
@@ -643,7 +643,7 @@ impl WasmScpClient {
     ///
     /// # Errors
     ///
-    /// Throws `[SCP-CTX-2001]` if the context is not held, `[SCP-STORAGE-8013]` if
+    /// Throws `[SCP-CTX-2082]` if the context is not held, `[SCP-STORAGE-8013]` if
     /// it is poisoned, or a `[SCP-CRYPTO-…]` error on epoch overflow or a
     /// seal/frame failure. A `[SCP-STORAGE-8010]` on the post-rotation snapshot
     /// write **poisons** the context.
@@ -746,7 +746,7 @@ impl WasmScpClient {
     ///
     /// # Errors
     ///
-    /// Throws `[SCP-CTX-2001]` if the context is not held, `[SCP-CRYPTO-…]`
+    /// Throws `[SCP-CTX-2082]` if the context is not held, `[SCP-CRYPTO-…]`
     /// if the MLS group has been destroyed, or `[SCP-STORAGE-8013]` if the context
     /// is poisoned (discard this client and reconstruct it via the [`WasmScpClient`] constructor for your target
     /// — see [`ContextStatus`](scp_client::ContextStatus)). This read-only observer
@@ -810,7 +810,7 @@ impl WasmScpClient {
 ///
 /// # Errors
 ///
-/// Throws `[SCP-VALID-7010]` if `requestId` is not exactly 16 bytes.
+/// Throws `[SCP-VALID-7028]` if `requestId` is not exactly 16 bytes.
 #[wasm_bindgen(js_name = "outletStreamComputeCaveatsBinding")]
 pub fn outlet_stream_compute_caveats_binding(
     ucan_cid: Vec<u8>,
@@ -820,8 +820,11 @@ pub fn outlet_stream_compute_caveats_binding(
     effective_caveats_jcs: Vec<u8>,
 ) -> Result<Vec<u8>, JsValue> {
     use scp_protocol::context::outlets::stream::compute_caveats_binding;
-    let request_id = <[u8; 16]>::try_from(request_id.as_slice())
-        .map_err(|_| JsValue::from_str("[SCP-VALID-7010] request_id must be 16 bytes"))?;
+    let request_id = <[u8; 16]>::try_from(request_id.as_slice()).map_err(|_| {
+        JsValue::from_str(&format!(
+            "[{WASM_INPUT_VALIDATION_CODE}] request_id must be 16 bytes"
+        ))
+    })?;
     let binding = compute_caveats_binding(
         &ucan_cid,
         &request_id,
@@ -852,7 +855,7 @@ pub fn outlet_stream_compute_caveats_binding(
 ///
 /// # Errors
 ///
-/// Throws `[SCP-VALID-7010]` on malformed INPUT — a chunk that will not
+/// Throws `[SCP-VALID-7028]` on malformed INPUT — a chunk that will not
 /// deserialize, an `operatorPk` that is not 32 bytes or not a valid Ed25519
 /// point, or a `caveatsBinding` that is not 32 bytes. These are distinct from a
 /// `false` return so a caller can tell "I was handed garbage" from "this chunk
@@ -868,19 +871,25 @@ pub fn outlet_stream_verify_chunk_signature(
     use scp_protocol::context::outlets::stream::{OutletStreamChunk, verify_chunk_signature};
     let chunk: OutletStreamChunk = serde_json::from_slice(&chunk).map_err(|e| {
         JsValue::from_str(&format!(
-            "[SCP-VALID-7010] invalid OutletStreamChunk bytes: {e}"
+            "[{WASM_INPUT_VALIDATION_CODE}] invalid OutletStreamChunk bytes: {e}"
         ))
     })?;
-    let pk_bytes = <[u8; 32]>::try_from(operator_pk.as_slice())
-        .map_err(|_| JsValue::from_str("[SCP-VALID-7010] operator_pk must be 32 bytes"))?;
+    let pk_bytes = <[u8; 32]>::try_from(operator_pk.as_slice()).map_err(|_| {
+        JsValue::from_str(&format!(
+            "[{WASM_INPUT_VALIDATION_CODE}] operator_pk must be 32 bytes"
+        ))
+    })?;
     let operator_verifying_key =
         ed25519_dalek::VerifyingKey::from_bytes(&pk_bytes).map_err(|e| {
             JsValue::from_str(&format!(
-                "[SCP-VALID-7010] operator_pk is not a valid key: {e}"
+                "[{WASM_INPUT_VALIDATION_CODE}] operator_pk is not a valid key: {e}"
             ))
         })?;
-    let binding = <[u8; 32]>::try_from(caveats_binding.as_slice())
-        .map_err(|_| JsValue::from_str("[SCP-VALID-7010] caveats_binding must be 32 bytes"))?;
+    let binding = <[u8; 32]>::try_from(caveats_binding.as_slice()).map_err(|_| {
+        JsValue::from_str(&format!(
+            "[{WASM_INPUT_VALIDATION_CODE}] caveats_binding must be 32 bytes"
+        ))
+    })?;
     Ok(verify_chunk_signature(
         &chunk,
         &operator_verifying_key,
@@ -901,29 +910,38 @@ pub fn outlet_stream_verify_chunk_signature(
 /// `Event` field values by `append_unsigned_event` on replay, independent of
 /// this transport encoding.
 fn serialize_event_log(events: &[scp_event_log::Event]) -> Result<Vec<u8>, JsValue> {
-    rmp_serde::to_vec(events)
-        .map_err(|e| JsValue::from_str(&format!("[SCP-VALID-7010] serializing event log: {e}")))
+    rmp_serde::to_vec(events).map_err(|e| {
+        JsValue::from_str(&format!(
+            "[{WASM_INPUT_VALIDATION_CODE}] serializing event log: {e}"
+        ))
+    })
 }
 
 /// Deserializes the adder's event-log stream the joiner replays.
 fn deserialize_event_log(bytes: &[u8]) -> Result<Vec<scp_event_log::Event>, JsValue> {
-    rmp_serde::from_slice(bytes)
-        .map_err(|e| JsValue::from_str(&format!("[SCP-VALID-7010] deserializing event log: {e}")))
+    rmp_serde::from_slice(bytes).map_err(|e| {
+        JsValue::from_str(&format!(
+            "[{WASM_INPUT_VALIDATION_CODE}] deserializing event log: {e}"
+        ))
+    })
 }
 
 /// Serializes the adder's member-wrapping-key directory for transport to the
 /// joiner (`MessagePack`, width-/endianness-independent — same transport idiom as
 /// the event-log stream).
 fn serialize_wrapping_keys(wrapping_keys: &[(String, [u8; 32])]) -> Result<Vec<u8>, JsValue> {
-    rmp_serde::to_vec(wrapping_keys)
-        .map_err(|e| JsValue::from_str(&format!("[SCP-VALID-7010] serializing wrapping keys: {e}")))
+    rmp_serde::to_vec(wrapping_keys).map_err(|e| {
+        JsValue::from_str(&format!(
+            "[{WASM_INPUT_VALIDATION_CODE}] serializing wrapping keys: {e}"
+        ))
+    })
 }
 
 /// Deserializes the member-wrapping-key directory the joiner adopts.
 fn deserialize_wrapping_keys(bytes: &[u8]) -> Result<Vec<(String, [u8; 32])>, JsValue> {
     rmp_serde::from_slice(bytes).map_err(|e| {
         JsValue::from_str(&format!(
-            "[SCP-VALID-7010] deserializing wrapping keys: {e}"
+            "[{WASM_INPUT_VALIDATION_CODE}] deserializing wrapping keys: {e}"
         ))
     })
 }
@@ -1331,7 +1349,7 @@ mod pure_wrapper_wasm_tests {
         err.as_string().unwrap_or_default()
     }
 
-    /// A `request_id` that is not 16 bytes fails closed as `[SCP-VALID-7010]`.
+    /// A `request_id` that is not 16 bytes fails closed as `[SCP-VALID-7028]`.
     #[wasm_bindgen_test]
     fn compute_caveats_binding_rejects_wrong_request_id_len() {
         let err = outlet_stream_compute_caveats_binding(
@@ -1344,13 +1362,13 @@ mod pure_wrapper_wasm_tests {
         .expect_err("an 8-byte request_id must be rejected");
         let msg = err_message(err);
         assert!(
-            msg.contains("[SCP-VALID-7010]") && msg.contains("request_id must be 16 bytes"),
+            msg.contains("[SCP-VALID-7028]") && msg.contains("request_id must be 16 bytes"),
             "wrong-length request_id fails closed: {msg}"
         );
     }
 
     /// Malformed chunk bytes, a wrong-length operator key, and a wrong-length
-    /// caveats binding each fail closed as `[SCP-VALID-7010]` — distinct from the
+    /// caveats binding each fail closed as `[SCP-VALID-7028]` — distinct from the
     /// `false` a well-formed-but-unauthentic chunk returns.
     #[wasm_bindgen_test]
     fn verify_chunk_signature_rejects_malformed_inputs() {
@@ -1369,7 +1387,7 @@ mod pure_wrapper_wasm_tests {
         )
         .expect_err("garbage chunk bytes are rejected");
         assert!(
-            err_message(err).contains("[SCP-VALID-7010]"),
+            err_message(err).contains("[SCP-VALID-7028]"),
             "unparseable chunk fails closed"
         );
 

--- a/crates/scp-client/src/error.rs
+++ b/crates/scp-client/src/error.rs
@@ -59,7 +59,7 @@ pub enum ClientError {
     /// (the primary duplicate-delivery guarantee is openmls's per-generation replay
     /// protection — this is defense-in-depth). Benign-dropped by
     /// [`handle_relay_frame`](crate::ScpClient::handle_relay_frame). Surfaced as
-    /// `SCP-VALID-7011`.
+    /// `SCP-VALID-7029`.
     #[error("frame content does not match its relay channel (mis-routed; dropped)")]
     ChannelContentMismatch,
 
@@ -68,7 +68,7 @@ pub enum ClientError {
     /// transport loss — the relay is an untrusted dumb pipe and the message may be
     /// re-driven — NOT a state-corrupting error: by the time a frame is published
     /// the driver's crypto/log state has already advanced and been persisted.
-    /// Surfaced as `SCP-TRANS-5010`.
+    /// Surfaced as `SCP-TRANS-5005`.
     #[error("transport error: {0}")]
     Transport(String),
 
@@ -82,7 +82,7 @@ pub enum ClientError {
     /// [`handle_relay_frame`](crate::ScpClient::handle_relay_frame)) and retries.
     /// It is raised *before* the MLS ratchet advances, so no crypto state is
     /// consumed by the failed send. Mirrors the native runtime's
-    /// `ContextError::PseudonymRegistryEmpty`. Surfaced as `SCP-CTX-2040`.
+    /// `ContextError::PseudonymRegistryEmpty`. Surfaced as `SCP-CTX-2095`.
     #[error(
         "context '{context_id}' has {member_count} members but no peer has announced a \
          pseudonym yet; retry after peers' announcements are pumped in"


### PR DESCRIPTION
## Summary

The browser participant surface (`crates/scp-client-wasm/src/error.rs`) minted `SCP-CTX-200x` / VALID / CRYPTO / TRANS codes whose meanings **contradicted** the native FFI-common registry — and both feed the one shared TypeScript `ScpError` hierarchy, so a consumer inspecting `error.code` got a *path-dependent* meaning (audit finding **CRYPTO-22**). This renumbers every browser-owned code to a value that is genuinely unique **across all five hand-written surfaces** (native `error_codes.rs`, Swift, Kotlin, TS-native, TS-wasm), registers them in the `.docs/standards/sdk-common.md` ledger (the source of truth), and pins them mechanically on the browser side.

## Final assignment (variant → new code)
| Variant | New code |
|---|---|
| `UnknownContext` | `SCP-CTX-2082` |
| `ContextAlreadyExists` | `SCP-CTX-2083` (minted — `2003` is 3-way overloaded across native/Swift/Kotlin, so **not** reused) |
| `UnsupportedMembershipChange` | `SCP-CTX-2084` |
| `Driver` | `SCP-CTX-2085` |
| `NoPendingJoinMaterial` | `SCP-CTX-2086` |
| `PseudonymRegistryEmpty` | `SCP-CTX-2095` (the **one** deliberate reuse — genuinely same-meaning on all five surfaces) |
| `Codec` + the 9 `lib.rs` input validators | `SCP-VALID-7028` |
| `ChannelContentMismatch` | `SCP-VALID-7029` |
| `Mls(_)` catch-all / `SenderKey` / `EventLog` / convergent-ts | `CRYPTO-4041 / 4020 / 4030 / 4040` |
| `Transport` | `SCP-TRANS-5005` |
| Storage | `8010-8013` (unchanged) |

Every browser number verified absent from native/Swift/Kotlin/TS-native/Python; `CTX-2095` present and consistent on all.

## How it's enforced (per the existing mechanism, not a new one)
- **Source of truth:** the `sdk-common.md` ledger, extended with Owner/Condition rows for the browser-owned codes.
- **Browser-side mechanical pin:** an **exhaustive, no-wildcard** allowlist test over every `ClientError` variant (a new variant fails to compile until a ledger decision is made), plus a `pub(crate) const WASM_INPUT_VALIDATION_CODE` routing all 9 `lib.rs` direct emitters through one pinned value (kills the direct-literal drift class).
- **Honest ledger:** it explicitly does **not** claim "one meaning across all surfaces" — the pre-existing cross-language overlaps (native-UCAN `7010-7012`, the `2003` three-way overload) are documented as out of scope, with the systemic audit + `check-error-codes.sh` Phase-2 strengthening tracked in **discussion #2208**.

## Scope discipline
`error_codes.rs` (native meanings), `errors.ts` (dispatch), and `check-error-codes.sh` are **untouched**. No §9.7.1/`validate_key_package` surfaces. The pre-existing cross-language overlaps are **not** renumbered here (that would break Swift/Kotlin/TS error-code contracts) — deferred to #2208.

## Review
Full roster to convergence. Round 1 caught a real cross-surface collision — the first pass checked only `error_codes.rs` and skipped the **manual SDK-wrapper review `check-error-codes.sh` explicitly mandates** (its documented Phase-2 KNOWN LIMITATION), landing codes on Swift/Kotlin. Redone via the full 5-surface union. Round 2: 5 substantive reviewers clean (api-design withdrew its Round-1 finding; inquisitor confirmed the ledger is the correct *permanent* cross-language registry, not scar tissue), sole nit the #2208 citation, now added and confirmed.

## Verification (all green)
`./scripts/check-error-codes.sh` PASSED · `cargo test -p scp-client-wasm` (incl. exhaustive allowlist + const-pin tests) · `cargo build`/`cargo clippy -p scp-client-wasm --target wasm32-unknown-unknown -- -D warnings` · `bindings/typescript-wasm` `bun run check`/`lint`/`test` · rebased onto current `origin/main`, 0 behind.

Closes #2144.

🤖 Generated with [Claude Code](https://claude.com/claude-code)