### PR TITLE
docs(adr-049): #2205 refresh post-#2148 stale capability-matrix notes + crypto-move PRD status

### DIFF
--- a/.docs/prds/adr049-crypto-state-move.json
+++ b/.docs/prds/adr049-crypto-state-move.json
@@ -20,7 +20,7 @@
       "gate": "gate-cryptomove-0",
       "priority": "P0",
       "severity": "major",
-      "status": "pending",
+      "status": "done",
       "files": [
         "crates/scp-runtime/src/context/actor/state.rs",
         "crates/scp-runtime/src/crypto/mls/provider.rs"
@@ -54,7 +54,7 @@
       "gate": "gate-cryptomove-0",
       "priority": "P0",
       "severity": "major",
-      "status": "pending",
+      "status": "done",
       "files": [
         "crates/scp-runtime/src/crypto/mls/provider.rs"
       ],
@@ -84,7 +84,7 @@
       "gate": "gate-cryptomove-0",
       "priority": "P0",
       "severity": "moderate",
-      "status": "pending",
+      "status": "done",
       "files": [
         "crates/scp-runtime/src/crypto/mls/provider.rs",
         "crates/scp-runtime/src/crypto/mls/backend.rs",
@@ -119,7 +119,7 @@
       "gate": "gate-cryptomove-0",
       "priority": "P0",
       "severity": "major",
-      "status": "pending",
+      "status": "done",
       "files": [
         "crates/scp-runtime/src/crypto/mls/provider.rs"
       ],
@@ -150,7 +150,7 @@
       "gate": "gate-cryptomove-0",
       "priority": "P0",
       "severity": "moderate",
-      "status": "pending",
+      "status": "done",
       "files": [
         "crates/scp-runtime/src/crypto/mls/provider.rs"
       ],
@@ -181,7 +181,7 @@
       "gate": "gate-cryptomove-1",
       "priority": "P0",
       "severity": "critical",
-      "status": "pending",
+      "status": "done",
       "files": [
         "crates/scp-runtime/src/context/lifecycle_helpers.rs",
         "crates/scp-runtime/src/context/messaging_helpers.rs",

--- a/.docs/standards/sdk-capability-matrix.json
+++ b/.docs/standards/sdk-capability-matrix.json
@@ -1771,7 +1771,7 @@
           "typescript": false,
           "kotlin": false,
           "swift": false,
-          "notes": "Internal: ContextCryptoProvider::rotate_sender_key (MlsCryptoProvider impl at scp-runtime/src/crypto/mls/provider.rs:739) generates a fresh sender key after a member is removed or leaves (#1541, batch-2 wiring). Invoked transitively from execute_remove_member and leave_context. Pipeline-wiring assertions execute_remove_member_calls_rotate_sender_key and leave_context_calls_rotate_sender_key cover this.",
+          "notes": "Internal: PerContextState::rotate_sender_key (actor-owned, ADR-049 §6; scp-runtime/src/context/actor/state.rs — relocated off the former MlsCryptoProvider by PR-7/#2148) generates a fresh sender key after a member is removed or leaves (#1541, batch-2 wiring). Invoked transitively from execute_remove_member and leave_context. Pipeline-wiring assertions execute_remove_member_calls_rotate_sender_key and leave_context_calls_rotate_sender_key cover this.",
           "exemptions": {
             "python": "internal crypto-provider trait method, not a standalone SDK operation",
             "typescript": "internal crypto-provider trait method, not a standalone SDK operation",
@@ -1785,7 +1785,7 @@
           "typescript": false,
           "kotlin": false,
           "swift": false,
-          "notes": "Internal: ContextCryptoProvider::remove_member_sender_key (MlsCryptoProvider impl at provider.rs:706) deletes the removed member's sender key from the local store. Invoked transitively from execute_remove_member alongside rotate_sender_key. Pipeline-wiring assertion execute_remove_member_calls_remove_member_sender_key covers this.",
+          "notes": "Internal: PerContextState::remove_member_sender_key (actor-owned, ADR-049 §6; scp-runtime/src/context/actor/state.rs — relocated off the former MlsCryptoProvider by PR-7/#2148) deletes the removed member's sender key from the local store. Invoked transitively from execute_remove_member alongside rotate_sender_key. Pipeline-wiring assertion execute_remove_member_calls_remove_member_sender_key covers this.",
           "exemptions": {
             "python": "internal crypto-provider trait method, not a standalone SDK operation",
             "typescript": "internal crypto-provider trait method, not a standalone SDK operation",
@@ -1799,7 +1799,7 @@
           "typescript": false,
           "kotlin": false,
           "swift": false,
-          "notes": "Internal: ContextCryptoProvider::advance_epoch (MlsCryptoProvider impl at provider.rs:1240) is the MLS commit/welcome processing entry point used by execute_rotate_content_keys (#1548, batch-2 wiring). Invoked transitively from the governance dispatch path; not a standalone SDK operation.",
+          "notes": "Internal: PerContextState::advance_epoch (actor-owned, ADR-049 §6; scp-runtime/src/context/actor/state.rs — relocated off the former MlsCryptoProvider by PR-7/#2148) is the MLS commit/welcome processing entry point used by execute_rotate_content_keys (#1548, batch-2 wiring). Invoked transitively from the governance dispatch path; not a standalone SDK operation.",
           "exemptions": {
             "python": "internal MLS state advance, not a standalone SDK operation",
             "typescript": "internal MLS state advance, not a standalone SDK operation",


### PR DESCRIPTION
## #2205 — refresh pre-existing post-#2148 doc staleness

Pure doc-accuracy cleanup, flagged during the #2185 review as pre-existing (from PR-7 + #2148). No code, no structural assertions changed.

- **`sdk-capability-matrix.json`** (3 `notes`): repointed `rotate_sender_key` / `remove_member_sender_key` / `advance_epoch` from the deleted `ContextCryptoProvider` trait / `MlsCryptoProvider` impl to the actual `PerContextState::<method>` (actor-owned, ADR-049 §6; `crates/scp-runtime/src/context/actor/state.rs`) — relocated there by PR-7/#2148. Coverage booleans + per-SDK exemptions untouched; **check-sdk-coverage passes**.
- **`adr049-crypto-state-move.json`** (6 slice statuses): `pending → done` (SCP-CRYPTOMOVE-000a..000e, 001). The crypto-state-move goal is merged on main via PR-7 + #2148; per `prd.md`, `done` = code merged. The grep-based ACs are correctly-frozen point-in-time history and are **not** rewritten — only the status metadata. **validate-prd passes**.

Diff is a surgical 9/9 lines across 2 files. Reviewed (completionist): notes verified truthful against `state.rs`, status flips verified merged, both mechanical validators green.

Closes #2205.

🤖 Generated with [Claude Code](https://claude.com/claude-code)