### PR TITLE
fix(scp-relay): resolve test binary via compile-time CARGO_BIN_EXE (nextest + worktree + relocated-target) — closes #2159

### DIFF
--- a/crates/scp-relay/tests/storage_backend.rs
+++ b/crates/scp-relay/tests/storage_backend.rs
@@ -12,17 +12,15 @@
 use std::process::Command;
 
 /// Returns the path to the compiled `scp-relay` binary.
+///
+/// Resolves the compile-time `CARGO_BIN_EXE_scp-relay` variable Cargo bakes into
+/// integration-test builds for a binary in the same package. Using compile-time
+/// `env!` (not a runtime `std::env::var` lookup) keeps the path correct under
+/// `cargo test`, `cargo nextest run`, relocated target dirs
+/// (`CARGO_TARGET_DIR`/shared-target), and git worktrees alike — `cargo nextest`
+/// does not re-export `CARGO_BIN_EXE_*` into the test's runtime environment.
 fn relay_bin() -> std::path::PathBuf {
-    // `cargo test` sets this for integration tests in the same package.
-    if let Ok(path) = std::env::var("CARGO_BIN_EXE_scp-relay") {
-        return std::path::PathBuf::from(path);
-    }
-    // Fallback: look in target/debug.
-    let mut path = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"));
-    path.pop(); // crates/
-    path.pop(); // repo root
-    path.push("target/debug/scp-relay");
-    path
+    std::path::PathBuf::from(env!("CARGO_BIN_EXE_scp-relay"))
 }
 
 /// AC 9: An invalid backend value causes a non-zero exit with an error


### PR DESCRIPTION
## Summary

`crates/scp-relay/tests/storage_backend.rs` spawns the compiled `scp-relay` binary, but `relay_bin()` resolved its path via a **runtime** `std::env::var("CARGO_BIN_EXE_scp-relay")` lookup plus a hard-coded `<repo>/target/debug/scp-relay` fallback. `cargo nextest run` does **not** re-export `CARGO_BIN_EXE_*` into the test's runtime environment, so under nextest execution fell through to the fallback — which is wrong whenever the target dir is relocated (`CARGO_TARGET_DIR` / shared-target) or the build is in a git worktree. Result: four tests failed `Os { code: 2, NotFound }`.

## Fix (one function, dev-test-only)
Resolve at **compile time** — `std::path::PathBuf::from(env!("CARGO_BIN_EXE_scp-relay"))` — and delete the fallback. Cargo bakes the absolute built path into the integration-test build for a binary in the **same package** (`crates/scp-relay/Cargo.toml` `[[bin]] name = "scp-relay"`), correct under `cargo test`, `cargo nextest`, relocated targets, and worktrees. The fallback wasn't just dead code — it hard-coded `target/debug`, latently wrong under `--release`/relocated targets too; removing it is fail-closed (`env!` hard-errors at compile time if the var were ever absent).

## Proof (relocated-target nextest, before → after)
`CARGO_TARGET_DIR=/tmp/scp-2159-target cargo nextest run -p scp-relay --test storage_backend`
- **BEFORE:** `5 tests run: 1 passed, 4 failed` (the 4 binary-spawning tests fail `NotFound`).
- **AFTER:** `5 tests run: 5 passed, 0 skipped`.

## Verification
- Relocated-target nextest: 4-fail → 5-pass (above).
- Regression `cargo test -p scp-relay --test storage_backend`: 5 pass.
- Default-layout nextest (CI parity): 5 pass.
- `cargo clippy -p scp-relay --all-targets -- -D warnings` clean; `cargo fmt --all -- --check` clean.

Zero production/`src`/API/FFI/enforcement impact — a single test-helper change. Closes #2159.

🤖 Generated with [Claude Code](https://claude.com/claude-code)