### PR TITLE
fix(broadcast): rotate_all_author_keys returns epoch advances; emit KeyEpochAdvance per author (#1847)

### DIFF
--- a/crates/scp-protocol/src/context/broadcast/mod.rs
+++ b/crates/scp-protocol/src/context/broadcast/mod.rs
@@ -16,7 +16,9 @@ use serde::{Deserialize, Serialize};
 use crate::context::ContextError;
 use crate::context::membership::ContextEvent;
 use crate::context::params::ContextMode;
-use crate::crypto::sender_keys::broadcast::seal_broadcast_key_to_subscriber;
+use crate::crypto::sender_keys::broadcast::{
+    BroadcastKeyEpochAdvance, seal_broadcast_key_to_subscriber,
+};
 use crate::crypto::sender_keys::{
     BroadcastEnvelope, BroadcastKey, SealBroadcastParams, SenderKey, generate_sender_key,
     seal_broadcast,
@@ -1677,10 +1679,24 @@ impl BroadcastContext {
     /// `RotateContentKeys` governance action for context-wide key hygiene.
     /// Does not modify block lists or subscriber registry.
     ///
+    /// Returns one [`BroadcastKeyEpochAdvance`] per author so the caller can
+    /// emit `KeyEpochAdvance` event-log leaves per §5.14.10. The rotation is
+    /// all-or-nothing: the pre-validate pass ensures no mid-loop overflow can
+    /// leave some authors rotated and others not.
+    ///
+    /// # Parameters
+    ///
+    /// - `timestamp_ms`: Unix timestamp in milliseconds to embed in each
+    ///   [`BroadcastKeyEpochAdvance`] (used by the caller for event-log
+    ///   ordering; convert from seconds with `.saturating_mul(1_000)`).
+    ///
     /// # Errors
     ///
     /// Returns [`ContextError::CryptoFailed`] if any author's epoch overflows.
-    pub fn rotate_all_author_keys(&mut self) -> Result<(), ContextError> {
+    pub fn rotate_all_author_keys(
+        &mut self,
+        timestamp_ms: u64,
+    ) -> Result<Vec<BroadcastKeyEpochAdvance>, ContextError> {
         // Pre-validate: ensure ALL authors can increment their epoch before
         // mutating any state. This prevents partial rotation where some
         // authors get new keys but the operation fails mid-loop.
@@ -1690,11 +1706,22 @@ impl BroadcastContext {
             })?;
         }
         // All epochs validated — safe to mutate.
+        let mut advances = Vec::with_capacity(self.authors.len());
         for author in self.authors.values_mut() {
             author.epoch += 1;
             author.broadcast_key = generate_sender_key();
+            advances.push(BroadcastKeyEpochAdvance {
+                author_did: author.author_did.clone(),
+                new_epoch: author.epoch,
+                timestamp: timestamp_ms,
+            });
         }
-        Ok(())
+        // Sort by author_did for deterministic event-log leaf ordering across
+        // replicas and reconstructions. HashMap iteration order is randomized
+        // per process, so the same logical rotation would otherwise produce
+        // a different Merkle root on different nodes or replays.
+        advances.sort_unstable_by(|a, b| a.author_did.cmp(&b.author_did));
+        Ok(advances)
     }
 
     // -----------------------------------------------------------------------
@@ -6170,6 +6197,103 @@ mod tests {
         assert!(
             ctx.is_blocked(author_a, excluded) && ctx.is_blocked(author_b, excluded),
             "reconciliation must block the excluded DID for every author"
+        );
+    }
+
+    // -----------------------------------------------------------------------
+    // rotate_all_author_keys — §9.17 governance-triggered epoch advance (#1847)
+    // -----------------------------------------------------------------------
+
+    /// `rotate_all_author_keys` must return exactly one [`BroadcastKeyEpochAdvance`]
+    /// per registered author, each with `new_epoch == 1` (initial epoch is 0).
+    #[test]
+    fn rotate_all_author_keys_returns_one_advance_per_author() {
+        let mut ctx = make_open_ctx();
+        ctx.add_author("did:example:alice").unwrap();
+        ctx.add_author("did:example:bob").unwrap();
+        ctx.add_author("did:example:carol").unwrap();
+
+        let advances = ctx.rotate_all_author_keys(1_700_000_000_000).unwrap();
+
+        assert_eq!(
+            advances.len(),
+            3,
+            "expected one advance per author, got {}",
+            advances.len()
+        );
+        for advance in &advances {
+            assert_eq!(
+                advance.new_epoch, 1,
+                "first rotation from epoch 0 must yield new_epoch = 1 for {}",
+                advance.author_did
+            );
+        }
+
+        // The advance set must cover exactly the three registered authors.
+        let mut advance_dids: Vec<&str> = advances.iter().map(|a| a.author_did.as_str()).collect();
+        advance_dids.sort_unstable();
+        assert_eq!(
+            advance_dids,
+            ["did:example:alice", "did:example:bob", "did:example:carol"]
+        );
+    }
+
+    /// Each [`BroadcastKeyEpochAdvance`] carries the `timestamp_ms` passed to
+    /// `rotate_all_author_keys`, so the caller can use it when emitting
+    /// event-log leaves.
+    #[test]
+    fn rotate_all_author_keys_advance_carries_timestamp() {
+        let timestamp_ms: u64 = 1_700_123_456_789;
+        let mut ctx = make_open_ctx();
+        ctx.add_author("did:example:alice").unwrap();
+
+        let advances = ctx.rotate_all_author_keys(timestamp_ms).unwrap();
+
+        assert_eq!(advances.len(), 1);
+        assert_eq!(
+            advances[0].timestamp, timestamp_ms,
+            "advance.timestamp must match the timestamp_ms argument"
+        );
+        assert_eq!(advances[0].author_did, "did:example:alice");
+        assert_eq!(advances[0].new_epoch, 1);
+    }
+
+    /// Pre-validation must reject the rotation and return
+    /// [`ContextError::CryptoFailed`] when ANY author's epoch is already at
+    /// `u64::MAX` (overflow would otherwise wrap silently).
+    #[test]
+    fn rotate_all_author_keys_epoch_overflow_still_rejected() {
+        let mut ctx = make_open_ctx();
+        ctx.add_author("did:example:alice").unwrap();
+        ctx.add_author("did:example:overflow-author").unwrap();
+
+        // Manually set the overflow author's epoch to u64::MAX so the
+        // pre-validate pass detects it before any mutation.
+        ctx.authors
+            .get_mut("did:example:overflow-author")
+            .unwrap()
+            .epoch = u64::MAX;
+
+        let result = ctx.rotate_all_author_keys(1_000);
+        assert!(
+            result.is_err(),
+            "rotate_all_author_keys must fail when any author epoch would overflow"
+        );
+        match result {
+            Err(ContextError::CryptoFailed(msg)) => {
+                assert!(
+                    msg.contains("epoch overflow"),
+                    "error message must mention 'epoch overflow', got: {msg}"
+                );
+            }
+            other => panic!("expected CryptoFailed(epoch overflow), got: {other:?}"),
+        }
+
+        // Alice's epoch must still be 0 — no partial mutation.
+        assert_eq!(
+            ctx.authors.get("did:example:alice").unwrap().epoch,
+            0,
+            "alice's epoch must be unchanged after a failed rotate_all_author_keys"
         );
     }
 

--- a/crates/scp-runtime/src/context/governance_helpers.rs
+++ b/crates/scp-runtime/src/context/governance_helpers.rs
@@ -979,14 +979,11 @@ pub async fn execute_revoke(
             timestamp_secs,
         )
         .await?;
-    // Coalesced Class-C counter bump (rides the next run-loop persist, exactly
-    // as before the combinator migration — NOT covered by the FC persist above).
-    *cell.class_c_view().checkpoint_events_since_mut() += 1;
-
     // Spec §2008 / §2015: emit one best-effort KeyEpochAdvance leaf per author
     // whose broadcast key was rotated by the governance ban.  Each rotation
     // advances by exactly 1, so old_epoch = new_epoch.saturating_sub(1).
     // Errors are non-fatal: warn and continue (same pattern as MemberBlocked).
+    let mut kea_success_count: u64 = 0;
     for rotation in &rotated_authors {
         let old_epoch = rotation.new_epoch.saturating_sub(1);
         match scp_event_log::payload::encode_payload(
@@ -1013,6 +1010,8 @@ pub async fn execute_revoke(
                         error = %e,
                         "KeyEpochAdvance event-log append failed after governance ban (best-effort)"
                     );
+                } else {
+                    kea_success_count += 1;
                 }
             }
             Err(e) => {
@@ -1025,6 +1024,11 @@ pub async fn execute_revoke(
             }
         }
     }
+    // Coalesced Class-C counter bump: 1 for AccessRevoked + each KeyEpochAdvance
+    // leaf that actually appended. The counter must track the true durable-leaf
+    // count (governance_logic.rs:156-158) to prevent §9.9.3 checkpoint-position
+    // drift. Best-effort leaves that failed are excluded — they were never durable.
+    *cell.class_c_view().checkpoint_events_since_mut() += 1 + kea_success_count;
 
     // H7: Rotate sender key after write-side revocation.
     if needs_sender_key_rotation {
@@ -3085,23 +3089,19 @@ pub async fn execute_rotate_content_keys(
     // `ContextSnapshot`, so the all-author key-epoch advance persists fail-closed
     // atomically inside the combinator — the prior trailing best-effort
     // `persist_broadcast_snapshot` is gone (§5.14.8).
-    let rotate_commit_bytes = cell
+    let (rotate_commit_bytes, key_advances) = cell
         .commit_class_s_keep(deps, context_id, |mut view| {
             let state = view.rest_mut();
             require_active(&state.handle)?;
 
-            let epoch_output = if let Some(ref mut bc) = state.broadcast_context {
-                // NOTE: `rotate_all_author_keys` returns `Ok(())` — no per-author
-                // (author_did, new_epoch) data is surfaced to the caller. Emitting
-                // `KeyEpochAdvance` leaves for each rotated author would require
-                // changing `rotate_all_author_keys` to return that data AND
-                // threading it out of this sync closure, since async event-log
-                // appends cannot happen inside `commit_class_s_keep`. The
-                // `unsubscribe_broadcast` path (which receives per-author
-                // `BlockResult` data from `bc.unsubscribe`) does emit
-                // `KeyEpochAdvance` leaves correctly — see #1847.
-                bc.rotate_all_author_keys()?;
-                None
+            let (epoch_output, advances) = if let Some(ref mut bc) = state.broadcast_context {
+                // `rotate_all_author_keys` now returns per-author advance data so
+                // the caller can emit `KeyEpochAdvance` event-log leaves after the
+                // fail-closed persist (async appends cannot run inside this sync
+                // `commit_class_s_keep` closure — ADR-049 Decision 7). The advance
+                // Vec is threaded out of the closure as the second tuple element.
+                let advances = bc.rotate_all_author_keys(timestamp_secs.saturating_mul(1_000))?;
+                (None, advances)
             } else {
                 // ADR-049 PR-7 (SCP-CRYPTOMOVE-001): advance the MLS epoch on the
                 // actor state (already inside this fail-closed `commit_class_s_keep`
@@ -3134,7 +3134,8 @@ pub async fn execute_rotate_content_keys(
                     let did = new_key.member_did().to_owned();
                     state.access.access_key_store.set(context_id, &did, new_key);
                 }
-                Some(epoch_out)
+                // Non-broadcast: no broadcast-key epoch advances.
+                (Some(epoch_out), vec![])
             };
 
             emit(
@@ -3150,7 +3151,12 @@ pub async fn execute_rotate_content_keys(
             // Commit broadcast runs AFTER the fail-closed persist, outside this sync
             // `_keep` closure (ADR-049 Decision 7 — transport is async). `None` on
             // the broadcast path (no MLS Commit) or when no epoch advance occurred.
-            Ok(epoch_output.map(|epoch_out| epoch_out.commit_bytes))
+            // The `advances` Vec carries per-author BroadcastKeyEpochAdvance data
+            // for KeyEpochAdvance event-log appends AFTER the persist (below).
+            Ok((
+                epoch_output.map(|epoch_out| epoch_out.commit_bytes),
+                advances,
+            ))
         })
         .await?;
 
@@ -3182,7 +3188,65 @@ pub async fn execute_rotate_content_keys(
             timestamp_secs,
         )
         .await?;
-    *cell.class_c_view().checkpoint_events_since_mut() += 1;
+
+    // Emit one `KeyEpochAdvance` leaf per broadcast author whose key was
+    // rotated (§5.14.10, #1847). Best-effort: warn on failure, no error
+    // propagation — same pattern as governance_ban_subscriber in
+    // `execute_revoke`. `key_advances` is empty on the non-broadcast path.
+    //
+    // NOTE: `advance.timestamp` (milliseconds) is not used here — the
+    // event-log append takes `timestamp_secs` directly. The ms field is
+    // carried by `BroadcastKeyEpochAdvance` for the relay-message consumer
+    // on the per-author block path; it is dead data in this governance path.
+    // `old_epoch` is derived as `new_epoch - 1` because `rotate_all_author_keys`
+    // always increments by exactly 1 (pre-validated, sound by construction).
+    let mut kea_success_count: u64 = 0;
+    for advance in &key_advances {
+        let old_epoch = advance.new_epoch.saturating_sub(1);
+        match scp_event_log::payload::encode_payload(
+            &scp_event_log::payload::KeyEpochAdvancePayload {
+                old_epoch,
+                new_epoch: advance.new_epoch,
+            },
+        ) {
+            Ok(payload) => {
+                if let Err(e) = deps
+                    .event_log
+                    .append_context_event_with_payload(
+                        &context_id_bytes,
+                        scp_event_log::EventType::KeyEpochAdvance,
+                        advance.author_did.as_str(),
+                        payload,
+                        timestamp_secs,
+                    )
+                    .await
+                {
+                    tracing::warn!(
+                        context_id = %context_id,
+                        author_did = %advance.author_did,
+                        error = %e,
+                        "KeyEpochAdvance event-log append failed after RotateContentKeys (best-effort)"
+                    );
+                } else {
+                    kea_success_count += 1;
+                }
+            }
+            Err(e) => {
+                tracing::warn!(
+                    context_id = %context_id,
+                    author_did = %advance.author_did,
+                    error = %e,
+                    "KeyEpochAdvance payload encode failed after RotateContentKeys (best-effort)"
+                );
+            }
+        }
+    }
+    // Coalesced Class-C counter bump: 1 for ContentKeysRotated + each
+    // KeyEpochAdvance leaf that actually appended. The counter must track the
+    // true durable-leaf count (governance_logic.rs:156-158) to prevent §9.9.3
+    // checkpoint-position drift. Best-effort leaves that failed are excluded —
+    // they were never durable.
+    *cell.class_c_view().checkpoint_events_since_mut() += 1 + kea_success_count;
     Ok(())
 }
 

--- a/crates/scp-runtime/tests/event_log_leaves.rs
+++ b/crates/scp-runtime/tests/event_log_leaves.rs
@@ -8,7 +8,7 @@
     clippy::large_futures
 )]
 //! Integration tests asserting that `KeyEpochAdvance` event-log leaves are
-//! appended by the three code paths that emit them (#1847).
+//! appended by the four code paths that emit them (#1847).
 //!
 //! Code paths under test:
 //!
@@ -20,8 +20,10 @@
 //! 3. `execute_revoke` (`governance_helpers.rs`): after a governance ban on a
 //!    broadcast context subscriber, emits one `KeyEpochAdvance` leaf per
 //!    rotated author.
+//! 4. `execute_rotate_content_keys` (`governance_helpers.rs`): `RotateContentKeys`
+//!    on a broadcast context emits one `KeyEpochAdvance` leaf per rotated author.
 //!
-//! All three paths are best-effort (warn on failure, no error propagation), so
+//! All paths are best-effort (warn on failure, no error propagation), so
 //! a regression silently drops the leaves. These tests pin the expected leaf
 //! count to catch silent regressions.
 
@@ -485,5 +487,113 @@ async fn governance_ban_emits_key_epoch_advance_per_author() {
         kea_payload.old_epoch + 1,
         kea_payload.new_epoch,
         "governance_ban_subscriber rotation always increments by exactly 1"
+    );
+}
+
+// ===========================================================================
+// Test 4: RotateContentKeys on a broadcast context emits KeyEpochAdvance per
+//         author (#1847)
+// ===========================================================================
+
+/// A `RotateContentKeys` governance action on a broadcast context must emit:
+///
+/// - Exactly one `ContentKeysRotated` leaf.
+/// - Exactly N `KeyEpochAdvance` leaves, one per registered author, each with
+///   `new_epoch == 1` (starting from 0 at creation) and `old_epoch + 1 ==
+///   new_epoch`.
+///
+/// This pins the fix for the gap where `rotate_all_author_keys` previously
+/// discarded the per-author advance data and emitted no `KeyEpochAdvance`
+/// leaves.
+#[tokio::test]
+async fn rotate_content_keys_broadcast_emits_key_epoch_advance_per_author() {
+    let manager = new_manager();
+    let ctx_id = "kea-rotate-content-keys-broadcast";
+
+    // Create a broadcast context.  Alice is auto-registered as an author at
+    // creation.  The ceiling must include MessagesRead and MessagesWrite.
+    manager
+        .create_context(ctx_id.into(), broadcast_params(), alice(), None)
+        .await
+        .expect("create broadcast context");
+
+    // Subscribe bob so the context has an active subscriber (ensures the
+    // rotation code path touches a non-empty subscriber roster).
+    subscribe_bob(&manager, ctx_id).await;
+
+    // Alice (the single admin) proposes RotateContentKeys.  In SingleAdmin
+    // mode the proposal auto-executes immediately.
+    let sk_alice = signing_key_for_did(&alice());
+    let (proposal, _events, _) = manager
+        .propose_governance_action(
+            ctx_id,
+            &alice(),
+            GovernanceAction::RotateContentKeys { reason: None },
+            &sk_alice,
+        )
+        .await
+        .expect("propose RotateContentKeys");
+
+    use scp_protocol::context::governance::ProposalStatus;
+    assert_eq!(
+        proposal.status,
+        ProposalStatus::Approved,
+        "SingleAdmin RotateContentKeys must auto-execute"
+    );
+
+    // Read back the durable event-log entries.
+    let ctx_bytes = scp_protocol::context::context_id_bytes(ctx_id);
+    let entries = manager
+        .event_log_entries(&ctx_bytes)
+        .expect("event_log_entries Ok")
+        .expect("event log exists for active context");
+
+    // Assert exactly one ContentKeysRotated leaf.
+    let ckr_leaves: Vec<_> = entries
+        .iter()
+        .filter(|e| e.event_type == EventType::ContentKeysRotated)
+        .collect();
+    assert_eq!(
+        ckr_leaves.len(),
+        1,
+        "expected exactly one ContentKeysRotated leaf after RotateContentKeys, got {}",
+        ckr_leaves.len()
+    );
+
+    // Assert KeyEpochAdvance leaves: one per registered author.  Alice is the
+    // only author (the context creator is auto-registered), so exactly one
+    // leaf is expected.
+    let kea_leaves: Vec<_> = entries
+        .iter()
+        .filter(|e| e.event_type == EventType::KeyEpochAdvance)
+        .collect();
+    assert_eq!(
+        kea_leaves.len(),
+        1,
+        "REGRESSION: expected one KeyEpochAdvance leaf per author after \
+         RotateContentKeys on broadcast context (#1847), got {}",
+        kea_leaves.len()
+    );
+
+    // The leaf's actor_did must be alice (the only registered author).
+    assert_eq!(
+        kea_leaves[0].actor_did.as_ref(),
+        alice().as_ref(),
+        "KeyEpochAdvance actor_did must be the rotated author (alice)"
+    );
+
+    // Validate payload coherence: first rotation from epoch 0 → epoch 1.
+    let kea_payload = scp_event_log::payload::decode_payload::<
+        scp_event_log::payload::KeyEpochAdvancePayload,
+    >(&kea_leaves[0].payload)
+    .expect("KeyEpochAdvancePayload decodes");
+
+    assert_eq!(
+        kea_payload.new_epoch, 1,
+        "first RotateContentKeys must advance broadcast key from epoch 0 to 1"
+    );
+    assert_eq!(
+        kea_payload.old_epoch, 0,
+        "old_epoch must be 0 before the first rotation"
     );
 }


### PR DESCRIPTION
## Summary

- **Root fix:** `rotate_all_author_keys` now returns `Vec<BroadcastKeyEpochAdvance>` instead of `()`, surfacing `(author_did, new_epoch, timestamp)` per rotated author to the caller. All epoch increments are pre-validated before any state mutation (all-or-nothing). Result sorted by `author_did` for deterministic Merkle leaf ordering across replicas.
- **Emission:** `execute_rotate_content_keys` threads the advance vec out of the `commit_class_s_keep` sync closure as the second element of a tuple, then emits one best-effort `KeyEpochAdvance` event-log leaf per author after the durable `ContentKeysRotated` leaf (§5.14.10, ADR-049 §9). Closes the gap where `KeyEpochAdvance` leaves were never appended after a `RotateContentKeys` governance action.
- **Counter fix (root + symptom):** `checkpoint_events_since` was undercounted by N at both `execute_rotate_content_keys` (new code) and `execute_revoke` (the root it copied). Both sites now use `+= 1 + kea_success_count` (incremented per successful append in the best-effort loop) so the counter tracks the true durable-leaf count per `governance_logic.rs:156-158`, preventing §9.9.3 checkpoint-position drift.

## Test plan

- [x] Unit tests in `broadcast/mod.rs`: advance-count-per-author (3 authors), timestamp threading, epoch overflow rejection
- [x] Integration test in `event_log_leaves.rs` (`rotate_content_keys_broadcast_emits_key_epoch_advance_per_author`): full lifecycle — create broadcast context, subscribe bob, propose `RotateContentKeys`, assert `ContentKeysRotated` leaf (1) + `KeyEpochAdvance` leaf (1, `old_epoch=0`, `new_epoch=1`)
- [x] `cargo clippy -p scp-protocol -p scp-runtime --all-targets -- -D warnings` → clean
- [x] `cargo clippy --workspace --all-targets --features …/testing,…/saga-witness-test-mint,…/outlet-capability-test-grant -- -D warnings` → clean
- [x] Pre-commit hooks (fmt + clippy + protocol enforcement) → passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)