### PR TITLE
chore(outlet): audit-hygiene — correct false-done PRD statuses, fix trust.ts OutletInvoked bug, repoint phantom-provenance comments

### DIFF
--- a/.docs/prds/outlet.json
+++ b/.docs/prds/outlet.json
@@ -1675,7 +1675,7 @@
         }
       ],
       "details": {
-        "auditNote": "Downgraded from done (audit): fix not effective \u2014 the specified manager/outlets.rs no longer exists and no complete From<InvocationError> for OutletError mapping is present; dispatch.rs still masks permanent errors as retryable. Tracked in #2219; recovery in #2196."
+        "auditNote": "Downgraded from done (audit): fix not effective \u2014 the specified manager/outlets.rs no longer exists and no complete From<InvocationError> for OutletError mapping is present. The related stream-open error-masking (permanent failures reported as retryable) is a separate site fixed by #2196. Tracked in #2219."
       }
     },
     {

--- a/.docs/prds/outlet.json
+++ b/.docs/prds/outlet.json
@@ -585,7 +585,7 @@
       "gate": "gate-rename",
       "priority": "P0",
       "severity": "critical",
-      "status": "done",
+      "status": "pending",
       "files": [
         "crates/scp-mcp/src/lib.rs",
         "crates/scp-mcp/src/namespace.rs",
@@ -630,7 +630,9 @@
           "section": "## 8.5 MCP Compatibility (Model Context Protocol)"
         }
       ],
-      "details": {}
+      "details": {
+        "auditNote": "Downgraded from done (audit): SCP-OUT-007 deliverable absent on main \u2014 crates/scp-mcp/src/translator.rs and the mcp_to_scp/scp_to_mcp functions do not exist (the scp-mcp crate exists but not this lexical translator); dropped by the squashed re-port #2098. Tracked in #2219."
+      }
     },
     {
       "id": "SCP-OUT-008",
@@ -713,7 +715,7 @@
       "gate": "gate-rename",
       "priority": "P0",
       "severity": "major",
-      "status": "done",
+      "status": "pending",
       "files": [
         "crates/scp-testing/src/conformance/mod.rs",
         "crates/scp-testing/tests/integration/conformance.rs",
@@ -752,7 +754,9 @@
           "section": "## 5.4 Outlets"
         }
       ],
-      "details": {}
+      "details": {
+        "auditNote": "Downgraded from done (audit): SCP-OUTLET-REGISTRATION-V2 test vectors (outlet_registration_v2.json) are absent on main (dropped by the squashed re-port #2098). Tracked in #2219."
+      }
     },
     {
       "id": "SCP-OUT-010",
@@ -760,7 +764,7 @@
       "gate": "gate-rename",
       "priority": "P0",
       "severity": "major",
-      "status": "done",
+      "status": "pending",
       "files": [
         ".docs/prds/main.json"
       ],
@@ -794,7 +798,9 @@
           "section": "## 5.4 Outlets"
         }
       ],
-      "details": {}
+      "details": {
+        "auditNote": "Downgraded from done (audit): superseded_by markers in .docs/prds/main.json are absent (0 present). Tracked in #2219."
+      }
     },
     {
       "id": "SCP-OUT-011",
@@ -1009,7 +1015,7 @@
       "gate": "gate-classification",
       "priority": "P0",
       "severity": "critical",
-      "status": "done",
+      "status": "in-progress",
       "files": [
         "crates/scp-runtime/src/context/manager/outlets.rs",
         "crates/scp-runtime/src/context/manager/mod.rs"
@@ -1056,7 +1062,9 @@
           "section": "### 5.4.2 Outlet Classification (Query vs Action)"
         }
       ],
-      "details": {}
+      "details": {
+        "auditNote": "Partial (audit): the amplification rule (Query->Action forbidden) is enforced, but the per-kind chain-depth budget is unimplemented \u2014 cross_context_invoke(origin_kind, hop_kind, depth_remaining_query, depth_remaining_action) and the max(1, max_chain_depth/2) Action derivation do not exist, and the ACs cite the nonexistent spec section 6.2.0.4. Known gap tracked in #2221."
+      }
     },
     {
       "id": "SCP-OUT-016",
@@ -1442,7 +1450,7 @@
       "gate": "gate-caveats",
       "priority": "P0",
       "severity": "major",
-      "status": "done",
+      "status": "pending",
       "files": [
         "crates/scp-ffi/src/ucan.rs",
         "crates/scp-ffi/napi/src/ucan.rs",
@@ -1481,7 +1489,9 @@
           "section": "### 7.3.8 Invocation Caveats"
         }
       ],
-      "details": {}
+      "details": {
+        "auditNote": "Downgraded from done (audit): SDK-level InvocationCaveats pass-through on ucan.mint/ucan.narrow is absent across all 4 SDKs (no caveats param, no InvocationCaveats type, no narrow entry point). Spec section 7.3.8 defines the caveat surface; the SDK mint/narrow deferral is tracked in #2221."
+      }
     },
     {
       "id": "SCP-OUT-024",
@@ -1630,7 +1640,7 @@
       "gate": "gate-errors",
       "priority": "P0",
       "severity": "critical",
-      "status": "done",
+      "status": "pending",
       "files": [
         "crates/scp-runtime/src/context/manager/outlets.rs",
         "crates/scp-runtime/src/context/outlets/invoke.rs"
@@ -1664,7 +1674,9 @@
           "section": "### 5.4.4 Outlet Error Taxonomy"
         }
       ],
-      "details": {}
+      "details": {
+        "auditNote": "Downgraded from done (audit): fix not effective \u2014 the specified manager/outlets.rs no longer exists and no complete From<InvocationError> for OutletError mapping is present; dispatch.rs still masks permanent errors as retryable. Tracked in #2219; recovery in #2196."
+      }
     },
     {
       "id": "SCP-OUT-028",
@@ -1773,7 +1785,7 @@
       "gate": "gate-errors",
       "priority": "P0",
       "severity": "major",
-      "status": "done",
+      "status": "pending",
       "files": [
         "scripts/check-error-codes.sh",
         ".docs/standards/sdk-common.md"
@@ -1806,7 +1818,9 @@
           "section": "## Error Hierarchy"
         }
       ],
-      "details": {}
+      "details": {
+        "auditNote": "Downgraded from done (audit): scripts/check-error-codes.sh has no 6100-6199 sub-block gate or OutletErrorClass literal assertion \u2014 the gate is toothless. Tracked in #2219."
+      }
     },
     {
       "id": "SCP-OUT-031",
@@ -1814,7 +1828,7 @@
       "gate": "gate-errors",
       "priority": "P0",
       "severity": "major",
-      "status": "done",
+      "status": "pending",
       "files": [
         "bindings/python/scp_sdk/errors.py",
         "bindings/typescript/src/errors.ts",
@@ -1870,7 +1884,9 @@
           "section": "### 5.4.4 Outlet Error Taxonomy"
         }
       ],
-      "details": {}
+      "details": {
+        "auditNote": "Downgraded from done (audit): the SDK 8-class OutletError hierarchy is inverted/absent (Python has ProtocolError, not OutletProtocolError, and no AuthorizationError/InputError/etc. under OutletError) and outlet_error_fixtures.json is absent. Tracked in #2219."
+      }
     },
     {
       "id": "SCP-OUT-032",
@@ -2457,7 +2473,7 @@
       "gate": "gate-round5-fixes",
       "priority": "P0",
       "severity": "critical",
-      "status": "done",
+      "status": "pending",
       "files": [
         "crates/scp-protocol/src/context/outlets/registration.rs",
         "crates/scp-protocol/src/context/outlets/message_catalog.rs",
@@ -2503,7 +2519,9 @@
           "section": "### 5.4.4 Outlet Error Taxonomy"
         }
       ],
-      "details": {}
+      "details": {
+        "auditNote": "Downgraded from done (audit): message_catalog is hardcoded empty (Vec::new()) in all FFI bridges (scp-ffi/src/outlets.rs, scp-ffi/src/mcp.rs, scp-ffi/napi/src/outlets.rs, scp-ffi/uniffi/src/bridge.rs) \u2014 AC9 unmet. Tracked in #2221."
+      }
     },
     {
       "id": "SCP-OUT-041a",
@@ -2697,7 +2715,7 @@
       "gate": "gate-round5-fixes",
       "priority": "P0",
       "severity": "critical",
-      "status": "pending",
+      "status": "done",
       "files": [
         "crates/scp-protocol/src/context/outlets/interface.rs",
         "crates/scp-event-log/src/lib.rs"
@@ -2725,7 +2743,9 @@
           "section": "#### 6.2.0.1 Bidirectional Consent Protocol"
         }
       ],
-      "details": {}
+      "details": {
+        "auditNote": "Upgraded from pending (status-lag, audit): InterfaceEstablished carries all 9 fields (epoch_a/b, ikm_a/b, ikm_a_sig/b_sig, creator_did, admin_set, capability_holder_set) with serde + event-log round-trip tests in interface.rs."
+      }
     },
     {
       "id": "SCP-OUT-042b",
@@ -2901,7 +2921,7 @@
       "gate": "gate-streaming-saga",
       "priority": "P1",
       "severity": "critical",
-      "status": "pending",
+      "status": "done",
       "files": [
         "crates/scp-protocol/src/context/outlets/cross_context_saga.rs",
         "crates/scp-protocol/src/context/outlets/mod.rs"
@@ -2945,7 +2965,9 @@
           "section": "#### 9.18.2 Domain Separators"
         }
       ],
-      "details": {}
+      "details": {
+        "auditNote": "Upgraded from pending (status-lag, audit): SCP-XCTX-STREAM-RECEIPT-V1 is fully implemented (CrossContextOutletStreamReceipt sign/verify; domain separator registered in spec section 9.18.2), with sign/verify tests, a KAT fixture, and cross-context streaming-saga wiring. The slice-3 receipt is the full 043."
+      }
     },
     {
       "id": "SCP-OUT-044",

--- a/bindings/typescript/src/trust.ts
+++ b/bindings/typescript/src/trust.ts
@@ -13,7 +13,7 @@
  * 1. **Protocol enforcement** — mechanical pass/fail (UCAN validity,
  *    signatures, capability ceiling, nonce, revocation, expiry).
  * 2. **Behavioral validation** — verified facts from the event log
- *    (participation history, tool usage).
+ *    (participation history, outlet usage).
  * 3. **Attestation authenticity** — verified signatures and evidence
  *    freshness from attestations.
  * 4. **Trust evaluation inputs** — endorsements, challenge results, and
@@ -109,8 +109,8 @@ export interface BehavioralRecord {
   totalDuration: number;
   /** Number of governance actions taken against the subject. */
   governanceActionsAgainst: number;
-  /** Tool invocation history as `{ type, count }` records. */
-  toolInvocations: readonly { readonly type: string; readonly count: number }[];
+  /** Outlet invocation history as `{ type, count }` records. */
+  outletInvocations: readonly { readonly type: string; readonly count: number }[];
   /** Role change history. */
   roleHistory: readonly Record<string, unknown>[];
   /** Endorsement accuracy score (0.0–1.0), if available. */
@@ -691,20 +691,23 @@ export async function evaluateTrust(
     // uses snake_case `actor_did`, the key the bridge's filter parser expects.
     const raw = await scp.eventLogQuery(handle, JSON.stringify({ actor_did: subjectDid }));
     const events = raw as readonly { readonly eventType: string }[];
-    // This thin facade only computes toolInvocations from the raw event stream.
-    // contextsParticipated, totalDuration, and governanceActionsAgainst are not
-    // computable from the NAPI event objects returned by eventLogQuery — they
-    // require aggregate queries not yet exposed over the bridge. Values are set
-    // to 0 (not computed) rather than fabricated. Use the Python SDK for full
-    // behavioral analysis, or await a future native TS aggregate endpoint.
+    // This thin facade only computes outletInvocations from the raw event
+    // stream. contextsParticipated, totalDuration, and governanceActionsAgainst
+    // are not computable from the NAPI event objects returned by eventLogQuery —
+    // they require aggregate queries not yet exposed over the bridge. Values are
+    // set to 0 (not computed) rather than fabricated. Use the Python SDK for
+    // full behavioral analysis, or await a future native TS aggregate endpoint.
     behavioralRecord = {
       contextsParticipated: 0,
       totalDuration: 0,
       governanceActionsAgainst: 0,
-      // Each ToolInvoked event becomes one entry with count: 1.
-      // No aggregation by tool ID — thin facade over the bridge.
-      toolInvocations: events
-        .filter((e) => e.eventType === "ToolInvoked")
+      // Each OutletInvoked event becomes one entry with count: 1. This is the
+      // canonical event type emitted by scp-event-log (EventType::OutletInvoked)
+      // and matches the Python/Swift/Kotlin SDKs — the prior `ToolInvoked`
+      // filter never matched, so this field was always empty (SCP-OUT-006).
+      // No aggregation by outlet ID — thin facade over the bridge.
+      outletInvocations: events
+        .filter((e) => e.eventType === "OutletInvoked")
         .map((e) => ({ type: e.eventType, count: 1 })),
       roleHistory: [],
       endorsementAccuracy: undefined,

--- a/bindings/typescript/tests/trust-facade.test.ts
+++ b/bindings/typescript/tests/trust-facade.test.ts
@@ -1,0 +1,54 @@
+/**
+ * Regression tests for the standalone four-layer `evaluateTrust` facade
+ * (`src/trust.ts`) — specifically its Layer 2 behavioral record.
+ *
+ * SCP-OUT-006: the Layer 2 aggregation must filter the event stream on the
+ * canonical `OutletInvoked` event type (`EventType::OutletInvoked` in
+ * `scp-event-log`, matching the Python/Swift/Kotlin SDKs). A prior residual
+ * `ToolInvoked` filter never matched any event, so `outletInvocations` was
+ * always empty — a live functional bug. These tests pin the correct event type
+ * so it cannot regress.
+ */
+
+import { describe, expect, it } from "bun:test";
+import type { Context } from "../src/context";
+import type { SCP } from "../src/scp";
+import { evaluateTrust } from "../src/trust";
+
+/** Builds a minimal SCP whose `eventLogQuery` returns the supplied events. */
+function mockScpWithEvents(events: readonly { readonly eventType: string }[]): SCP {
+  return {
+    eventLogQuery: async (_handle: unknown, _filter: string) => events,
+  } as unknown as SCP;
+}
+
+const CONTEXT = { _rawHandle: {} as object, contextId: "ctx-1" } as unknown as Context;
+
+describe("evaluateTrust (four-layer facade) — Layer 2 behavioral record", () => {
+  it("surfaces OutletInvoked events in outletInvocations (SCP-OUT-006)", async () => {
+    const scp = mockScpWithEvents([
+      { eventType: "OutletInvoked" },
+      { eventType: "MessageSent" },
+      { eventType: "OutletInvoked" },
+    ]);
+
+    const result = await evaluateTrust(scp, "did:dht:subject", CONTEXT);
+
+    expect(result.behavioralRecord).not.toBeNull();
+    // Only the two OutletInvoked events are surfaced (one entry each, count: 1).
+    expect(result.behavioralRecord?.outletInvocations).toEqual([
+      { type: "OutletInvoked", count: 1 },
+      { type: "OutletInvoked", count: 1 },
+    ]);
+  });
+
+  it("ignores the legacy `ToolInvoked` event type (regression guard)", async () => {
+    // Before the fix, the facade filtered on "ToolInvoked" and this array would
+    // have populated outletInvocations. It must now be empty.
+    const scp = mockScpWithEvents([{ eventType: "ToolInvoked" }]);
+
+    const result = await evaluateTrust(scp, "did:dht:subject", CONTEXT);
+
+    expect(result.behavioralRecord?.outletInvocations).toEqual([]);
+  });
+});

--- a/crates/scp-protocol/src/context/outlets/interface.rs
+++ b/crates/scp-protocol/src/context/outlets/interface.rs
@@ -103,7 +103,7 @@ pub const MAX_BURST_ALLOWANCE: u32 = 50;
 pub const OFFER_EXPIRY_MS: u64 = 7 * 24 * 60 * 60 * 1000;
 
 // ---------------------------------------------------------------------------
-// OutletInterfaceDefaults (§6.2.0.2 classification-aware rate tiers)
+// OutletInterfaceDefaults (SCP-OUT-016 per-kind rate tiers; spec §6.2.0.2 reconciliation tracked in #2222)
 // ---------------------------------------------------------------------------
 
 /// Per-kind cross-context rate-tier defaults (spec §6.2.0.2).
@@ -138,7 +138,8 @@ pub const OFFER_EXPIRY_MS: u64 = 7 * 24 * 60 * 60 * 1000;
 /// the higher tier because reads are amortisable, Action gets the lower
 /// tier because writes have economic and side-effect cost.
 ///
-/// See spec §6.2.0.2 "Classification-aware rate tiers" and §5.4.2.
+/// See SCP-OUT-016 (per-kind rate tiers; spec §6.2.0.2 reconciliation
+/// tracked in #2222) and §5.4.2.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct OutletInterfaceDefaults {
     /// The [`OutletKind`] this default tuple is keyed to. Stored so the
@@ -609,11 +610,14 @@ pub struct InterfaceRevoked {
 // ---------------------------------------------------------------------------
 
 /// Domain separator string (UTF-8 bytes) for the
-/// `SCP-OUTLET-IKM-ROTATE-V1:` preimage. Registered in spec §9.18.2.
+/// `SCP-OUTLET-IKM-ROTATE-V1:` preimage.
 ///
-/// The trailing colon is part of the on-wire prefix per the §9.18.2
-/// registration table — every other separator in §9.18.2 ends in a colon
-/// and the §6.2.0.1 byte spec includes the colon literal.
+/// Reserved for SCP-OUT-042b; this separator is not yet present in the
+/// §9.18.2 separator registry and its registration there is tracked in
+/// #2222.
+///
+/// The trailing colon is part of the on-wire prefix, following the §9.18.2
+/// colon convention (every registered separator ends in a colon).
 pub const IKM_ROTATE_DOMAIN_SEPARATOR: &[u8] = b"SCP-OUTLET-IKM-ROTATE-V1:";
 
 /// Rotation event emitted on every active interface a context holds when


### PR DESCRIPTION
## Outlet audit-hygiene — restore main to an honest state

Follows the whole-outlet audit (5-group fan-out). No feature work / no re-ports / no spec-text edits — this only makes `main` tell the truth and fixes one live bug.

### PRD status corrections (each with an `auditNote` + tracking issue)
The outlet feature reached main via a lossy squash re-port (#2098) that dropped per-story deliverables, and stories 041/042 were never built — so several statuses were wrong. Verified each against the actual tree:
- **done → pending** (deliverable absent/incomplete on main): 007 (MCP translator absent), 009 (V2 conformance vectors absent), 010 (main.json supersede markers absent), 023 (SDK caveat-mint absent — spec-deferred §7.3.8), 027 (lossy-error-mapping fix absent; `manager/outlets.rs` gone), 030 (check-error-codes 6100-6199 gate absent), 031 (SDK error hierarchy inverted/absent, no fixtures), 040 (`message_catalog` hardcoded empty in bridges, AC9 unmet)
- **done → in-progress**: 015 (amplification enforced, but per-kind chain-depth budget absent)
- **pending → done** (verified complete, status-lag): 042a, 043
Tracked in #2219 (re-port dropped stories), #2221 (medium gaps), #2222 (spec provenance). `validate-prd` green (437 stories).

### Live bug fix — `trust.ts` (SCP-OUT-006)
`evaluateTrust` filtered `eventType === "ToolInvoked"`, but the canonical variant is `OutletInvoked` → the field was **always empty**. Fixed the filter and renamed `toolInvocations` → `outletInvocations` (parity: Python already uses `outlet_invocations`, the TS native path already expects `outletInvocations`; the field was empty pre-release so no consumer had data). New regression test (`trust-facade.test.ts`).

### Phantom-provenance comment fixes (comment-only, no spec edit)
`interface.rs` cited a fabricated §6.2.0.2 rate-tier title and claimed the IKM-ROTATE separator is "Registered in §9.18.2" (it isn't). Repointed to the stories + #2222 (spec reconciliation).

Reviewed COMPLETE (completionist: all 11 flips verified, rename justified, comments accurate, no enforcement touched). Gates: validate-prd, check-error-codes, clippy -p scp-protocol, bun check/lint, 47 trust tests — all green. (The full `bun test` napi-real suite fails locally on a prebuilt-napi feature-flag env issue, unrelated to this change; CI runs the feature-enabled build.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
