### PR TITLE
fix(outlet): runtime ContextState::Active gate on the reserve path + non-retryable error mapping (closes #2196)

### DIFF
--- a/crates/scp-ffi/napi/src/outlet_stream.rs
+++ b/crates/scp-ffi/napi/src/outlet_stream.rs
@@ -1161,15 +1161,19 @@ pub(crate) async fn outlet_streaming_saga_open_on(
     // reference's authoritative `read_context_state`. A missing actor (`None`) is
     // treated as non-active (fail-closed).
     //
-    // LOAD-BEARING (not defense-in-depth): the runtime streaming-saga reserve
-    // path (`reserve_outlet_stream_economy`) debits the invoker's escrow with NO
-    // context-lifecycle Active gate — its only pre-debit gates are membership
-    // (13050 / 6089), the established interface (13062), and the saga context-set
-    // reservation; it never surfaces SCP-OUTLET-6080 "context not active" the way
-    // the SESSION and send/governance/TTL paths do. This bridge check is the sole
-    // barrier stopping a non-active source/target from debiting escrow. Checked
-    // BEFORE input validation, the caller-principal binding, and the saga drive,
-    // so a non-active context is rejected before any receiver is handed out.
+    // TARGET axis: DEFENSE-IN-DEPTH (#2196). CALLER/source axis: still primary.
+    // The runtime streaming-saga reserve path (`reserve_outlet_stream_economy`)
+    // NOW carries its own fail-closed `ContextState::Active` gate
+    // (`ensure_context_active`, the FIRST predicate before any escrow debit) that
+    // surfaces the canonical SCP-OUTLET-6080 "context not active". That reserve
+    // runs on the TARGET context (where the escrow moves), so the runtime gate is
+    // now the PRIMARY money-protecting barrier for the target axis and this
+    // bridge's target-axis check (OUTLET_6011) is demoted to defense-in-depth.
+    // The reserve does NOT run on the CALLER/source context, so this bridge's
+    // caller-axis check (OUTLET_6010) remains the authoritative gate stopping a
+    // non-active source from initiating the saga. Both checked BEFORE input
+    // validation, the caller-principal binding, and the saga drive, so a
+    // non-active context is rejected before any receiver is handed out.
     // Codes: OUTLET_6010 (caller axis) / OUTLET_6011 (target axis).
     let supervisor = crate::runtime::supervisor(bi)?;
     let source_state = supervisor.read_context_state(&caller_context_id).await;

--- a/crates/scp-ffi/src/outlet_stream.rs
+++ b/crates/scp-ffi/src/outlet_stream.rs
@@ -1200,17 +1200,23 @@ fn outlet_streaming_saga_open_impl(
 
     // ----- (a2) lifecycle gate: both contexts MUST be Active ------------------
     //
-    // LOAD-BEARING (not defense-in-depth): the runtime streaming-saga open path
+    // TARGET axis: DEFENSE-IN-DEPTH (#2196). CALLER/source axis: still primary.
+    //
+    // The runtime streaming-saga open path
     // (`start_cross_context_streaming_outlet_invocation_saga` →
-    // `open_outlet_stream_phase1` → `reserve_outlet_stream_economy`) DEBITS the
-    // invoker's escrow with NO context-lifecycle Active gate — its only pre-debit
-    // gates are membership (SCP-SAGA-13050 / SCP-OUTLET-6089), the established
-    // outlet interface (SCP-SAGA-13062), and the saga context-set reservation.
-    // Unlike the SESSION path (`create_session` / `invoke_session`) and the
-    // send / governance / TTL paths, it does NOT surface `SCP-OUTLET-6080`
-    // "context not active". So THIS bridge check is the only barrier stopping a
-    // Closing / Expired / MigratingOut source or target from opening a
+    // `open_outlet_stream_phase1(&target_hex, ...)` → `reserve_outlet_stream_economy`)
+    // NOW carries its own fail-closed `ContextState::Active` gate
+    // (`ensure_context_active`, the FIRST predicate before any escrow debit)
+    // surfacing the canonical `SCP-OUTLET-6080` "context not active". That
+    // reserve runs on the TARGET context (the money moves there), so the runtime
+    // gate is now the PRIMARY money-protecting barrier for the TARGET axis and
+    // this bridge's target-axis check (`OUTLET_6011`) is demoted to
+    // defense-in-depth. The reserve does NOT run on the CALLER/source context,
+    // so this bridge's caller-axis check (`OUTLET_6010`) remains the authoritative
+    // gate stopping a Closing / Expired / MigratingOut source from initiating a
     // money-moving cross-context streaming saga (§5.3 lifecycle / §6.2.4).
+    // Retained regardless: both checks reject at the edge with bridge-native
+    // codes before the drive even starts.
     //
     // PyO3 is string-keyed (no `ContextHandle`), so the authoritative lifecycle
     // state is read from the per-context supervisor actor via

--- a/crates/scp-ffi/tests/e2e_bridge.rs
+++ b/crates/scp-ffi/tests/e2e_bridge.rs
@@ -2913,9 +2913,11 @@ fn outlet_stream_open_path_wired_and_control_plane_not_found() {
             .expect_err("a non-member invoker is rejected at the runtime membership gate");
         let msg = open_err.to_string();
         assert!(
-            msg.contains("SCP-OUTLET-6160"),
-            "the open reached the runtime and mapped its rejection to a canonical \
-             SCP-OUTLET code (UCAN validation passed): {msg}"
+            msg.contains("SCP-OUTLET-6110"),
+            "the open reached the runtime and mapped its rejection to the canonical \
+             NON-RETRYABLE authorization-denied code (#2196: a non-member membership \
+             denial is SCP-OUTLET-6110 authorization.denied, NOT the old wrongly-retryable \
+             transport-fault SCP-OUTLET-6160): {msg}"
         );
 
         // Control-plane graceful not-found: the six control methods on an

--- a/crates/scp-ffi/uniffi/src/outlet_stream.rs
+++ b/crates/scp-ffi/uniffi/src/outlet_stream.rs
@@ -1201,13 +1201,17 @@ pub(crate) async fn outlet_streaming_saga_open_impl(
     // the caller-principal binding, and the saga drive, so a non-active context is
     // rejected before any receiver is ever handed out (§5.3 lifecycle / §6.2.4).
     //
-    // LOAD-BEARING (not defense-in-depth): the runtime streaming-saga reserve
-    // path (`reserve_outlet_stream_economy`) debits the invoker's escrow with NO
-    // context-lifecycle Active gate — its only pre-debit gates are membership
-    // (13050 / 6089), the established interface (13062), and the saga context-set
-    // reservation; it never surfaces SCP-OUTLET-6080 "context not active" the way
-    // the SESSION and send/governance/TTL paths do. This bridge check is the sole
-    // barrier stopping a non-active source/target from debiting escrow.
+    // TARGET axis: DEFENSE-IN-DEPTH (#2196). CALLER/source axis: still primary.
+    // The runtime streaming-saga reserve path (`reserve_outlet_stream_economy`)
+    // NOW carries its own fail-closed `ContextState::Active` gate
+    // (`ensure_context_active`, the FIRST predicate before any escrow debit) that
+    // surfaces the canonical SCP-OUTLET-6080 "context not active". That reserve
+    // runs on the TARGET context (where the escrow moves), so the runtime gate is
+    // now the PRIMARY money-protecting barrier for the target axis and this
+    // bridge's target-axis check (OUTLET_6011) is demoted to defense-in-depth.
+    // The reserve does NOT run on the CALLER/source context, so this bridge's
+    // caller-axis check (OUTLET_6010) remains the authoritative gate stopping a
+    // non-active source from initiating the saga.
     let supervisor = Arc::clone(bi.context_manager_or_error()?);
     let source_state = supervisor.read_context_state(&caller_context_id).await;
     if !matches!(source_state, Some(scp_core::context::ContextState::Active)) {

--- a/crates/scp-runtime/src/context/outlets/dispatch.rs
+++ b/crates/scp-runtime/src/context/outlets/dispatch.rs
@@ -105,7 +105,7 @@ use super::stream::{
     AdmissionCaps, AdmissionOutcome, CancelAckTracker, CreditTracker, GrantError, OpenError,
     OriginAdmissionTracker, StreamAdmissionTracker, StreamEscrow, StreamIdentity,
     admission_outcome_to_slug, coerce_estimated_chunk_count, cumulative_reserve_amount,
-    effective_max_billable_chunks, enforce_estimated_chunk_count_bound, open_error_to_slug,
+    effective_max_billable_chunks, enforce_estimated_chunk_count_bound,
 };
 
 use scp_protocol::context::outlets::registry::OutletRegistry;
@@ -307,6 +307,28 @@ pub enum OpenStreamRejection {
         /// branch's slug representation rather than interning to a static.
         slug: String,
     },
+    /// The context is not in the `Active` state at open time (#2196). The
+    /// runtime reserve path (`reserve_outlet_stream_economy` via
+    /// `ensure_context_active`) and the synchronous `invoke_outlet` open
+    /// validation both surface `SCP-OUTLET-6080` "context not active"; this
+    /// open-surface rejection carries that state forward so the FFI / SDK
+    /// layer shapes it identically to the in-stream
+    /// `protocol.context-closed-mid-stream` terminal chunk the pump emits when
+    /// a context is torn down MID-stream. Reuses that existing slug
+    /// (`protocol.context-closed-mid-stream`) + code
+    /// ([`CODE_PROTOCOL_SESSION`](error_codes::CODE_PROTOCOL_SESSION),
+    /// `SCP-OUTLET-6101`, the NON-retryable Protocol class) rather than minting
+    /// a new code: a pre-open teardown and a mid-stream teardown are the same
+    /// permanent, non-retryable protocol condition to a receiver. (The
+    /// canonical runtime reserve error stays `SCP-OUTLET-6080`; only the
+    /// open-stream wire surface maps to `6101`.)
+    ContextNotActive {
+        /// The context's current lifecycle state, rendered from
+        /// [`ContextState`](crate::context::ContextState) (e.g. `"Closing"`),
+        /// carried verbatim from the reserve / invoke error so the surfaced
+        /// message names the actual state.
+        current_state: String,
+    },
 }
 
 impl OpenStreamRejection {
@@ -328,6 +350,8 @@ impl OpenStreamRejection {
             Self::InsufficientFunds => error_codes::SLUG_ECONOMIC_INSUFFICIENT_FUNDS,
             Self::CaveatsBindingMismatch => error_codes::SLUG_AUTHORIZATION_ATTENUATION_VIOLATION,
             Self::StreamCapExhausted => error_codes::SLUG_EXECUTION_STREAM_CAP_EXHAUSTED,
+            // #2196 — reuse the mid-stream teardown slug for a pre-open teardown.
+            Self::ContextNotActive { .. } => error_codes::SLUG_PROTOCOL_CONTEXT_CLOSED_MID_STREAM,
         }
     }
 
@@ -340,6 +364,12 @@ impl OpenStreamRejection {
             Self::EscrowOverflow | Self::InsufficientFunds => error_codes::CODE_ECONOMIC_FAULT,
             Self::CaveatsBindingMismatch => error_codes::CODE_AUTHORIZATION_DENIED,
             Self::StreamCapExhausted => error_codes::CODE_EXECUTION_CREDIT,
+            // #2196 — Protocol class, `SCP-OUTLET-6101`, NON-retryable
+            // (`error_code_to_retry_policy` → `RetryPolicy::Never`). This is the
+            // whole point of the error-masking fix: a permanent context-not-active
+            // failure must NOT be reported through the retryable transport-fault
+            // band the pre-fix catch-all used.
+            Self::ContextNotActive { .. } => error_codes::CODE_PROTOCOL_SESSION,
             // Mirror `caveat_violation_chunk`'s slug→code routing: the
             // input-schema slug is Input-class (`SCP-OUTLET-6120`), every
             // other caveat slug is Authorization-class (`SCP-OUTLET-6110`).
@@ -358,9 +388,18 @@ impl OpenStreamRejection {
     /// identically to other open-time validation failures.
     #[must_use]
     pub fn to_invocation_error(&self) -> InvocationError {
-        InvocationError::CaveatViolation {
-            slug: self.slug().to_owned(),
-            message: format!("stream open rejected: {}", self.slug()),
+        match self {
+            // #2196 — round-trip as the canonical `InvocationError::ContextNotActive`
+            // (→ `invocation_error_to_context` → `SCP-OUTLET-6080`) rather than a
+            // misleading `CaveatViolation`, preserving the state string so the
+            // surfaced message names the actual lifecycle state.
+            Self::ContextNotActive { current_state } => InvocationError::ContextNotActive {
+                current_state: current_state.clone(),
+            },
+            _ => InvocationError::CaveatViolation {
+                slug: self.slug().to_owned(),
+                message: format!("stream open rejected: {}", self.slug()),
+            },
         }
     }
 }
@@ -1168,13 +1207,14 @@ impl StreamSessionHandle {
     /// - [`super::stream::CancelError::CursorAdvanced`] — `cancel.next_seq`
     ///   does not match the runtime's live next-to-emit cursor.
     // `allow` (not `expect`): the verbatim-apply path is the single
-    // verify+record primitive for cross-context forwarding waves, which —
-    // with their tests — land in a later chunk, so it currently has no
-    // caller in either cfg on this branch. `allow` tolerates the later
-    // caller without churn; `expect` would then fire "unfulfilled".
+    // verify+record primitive for cross-context forwarding waves. Its caller —
+    // browser-initiated cross-context cancel forwarding — is tracked by #2203
+    // and not yet wired, so it currently has no caller in either cfg on this
+    // branch. `allow` tolerates the #2203 caller landing without churn; `expect`
+    // would then fire "unfulfilled".
     #[allow(
         dead_code,
-        reason = "retained as the single verify+record primitive; cross-context forwarding callers + tests land in a later chunk"
+        reason = "retained as the single verify+record primitive; cross-context browser-initiated cancel forwarding callers + tests land with #2203"
     )]
     pub(crate) fn apply_outlet_cancel_verbatim(
         &self,
@@ -2051,6 +2091,49 @@ fn spawn_pump_task(
     });
 }
 
+/// Maps a synchronous [`invoke_outlet`] open failure to its correct
+/// [`OpenStreamRejection`] class (#2196 error-masking fix).
+///
+/// `invoke_outlet`'s synchronous validation (before the receiver is allocated)
+/// can only reject with one of four [`InvocationError`] variants —
+/// `ContextNotActive`, `OutletNotFound`, `InvokerNotAuthorized`,
+/// `InputValidationFailed` — and ALL FOUR are PERMANENT. This maps each to a
+/// NON-retryable §5.4.4 class so the FFI / SDK surface never invites a retry of
+/// an open that can never succeed:
+///
+/// - `ContextNotActive` → [`OpenStreamRejection::ContextNotActive`] (Protocol,
+///   `SCP-OUTLET-6101`, `RetryPolicy::Never`);
+/// - `InputValidationFailed` → schema-violation
+///   ([`OpenStreamRejection::CaveatPostInputViolation`] carrying
+///   `input.schema-violation` → Input class, `SCP-OUTLET-6120`, never);
+/// - every other variant (`InvokerNotAuthorized`, `OutletNotFound`, and any
+///   future synchronous open error) → the fail-closed authorization-denied slug
+///   (Authorization class, `SCP-OUTLET-6110`, never).
+///
+/// The pre-fix code discarded the error and collapsed everything into the
+/// RETRYABLE `transport.rate-limited` slug.
+fn invocation_error_to_open_rejection(err: &InvocationError) -> OpenStreamRejection {
+    match err {
+        InvocationError::ContextNotActive { current_state } => {
+            OpenStreamRejection::ContextNotActive {
+                current_state: current_state.clone(),
+            }
+        }
+        InvocationError::InputValidationFailed { .. } => {
+            OpenStreamRejection::CaveatPostInputViolation {
+                slug: error_codes::SLUG_INPUT_SCHEMA_VIOLATION.to_owned(),
+            }
+        }
+        // Fail closed: an authorization / outlet-not-found (or any future
+        // synchronous open) failure is permanent and non-retryable. Routes to
+        // the Authorization-denied class via the non-schema slug branch of
+        // `CaveatPostInputViolation::error_code`.
+        _ => OpenStreamRejection::CaveatPostInputViolation {
+            slug: error_codes::SLUG_AUTHORIZATION_DENIED.to_owned(),
+        },
+    }
+}
+
 /// Opens a §5.4.5 stream session with full OUT-034 wiring.
 ///
 /// Runs the §5.4.5 round-5 5-step admission sequence, reserves escrow
@@ -2158,10 +2241,7 @@ where
     ) {
         release_admission(&admission, &origin_admission, &params);
         return Err(match open_err {
-            OpenError::EstimateExceedsBound => {
-                let _ = open_error_to_slug(open_err);
-                OpenStreamRejection::EstimateExceedsBound
-            }
+            OpenError::EstimateExceedsBound => OpenStreamRejection::EstimateExceedsBound,
         });
     }
 
@@ -2293,15 +2373,17 @@ where
     )
     .await
     .map_err(|err| {
-        // Roll back admission on synchronous invoke_outlet failure.
-        // Synchronous validation failures (context not active, schema,
-        // etc.) do not match the OUT-034 rejection taxonomy; route
-        // through the rate-limited slug as a defensive fallback.
+        // Roll back admission on synchronous invoke_outlet failure, then map
+        // the REAL error to its correct §5.4.4 class (#2196 error-masking fix).
+        // Every synchronous `invoke_outlet` open failure (context-not-active,
+        // outlet-not-found, invoker-not-authorized, input-schema) is PERMANENT
+        // — the receiver was never allocated. The pre-fix code discarded `err`
+        // (`let _ = err`) and collapsed ALL of them into the RETRYABLE transport
+        // rate-limit slug, inviting a client to spin retrying an open that can
+        // never succeed. `invocation_error_to_open_rejection` routes each to its
+        // real non-retryable class instead.
         release_admission(&admission, &origin_admission, &params);
-        let _ = err;
-        OpenStreamRejection::AdmissionRateLimited {
-            slug: error_codes::SLUG_TRANSPORT_RATE_LIMITED,
-        }
+        invocation_error_to_open_rejection(&err)
     })?;
 
     // Step 5.5 (R4 HIGH-1 / HIGH-2): commit the durable counter CAS HERE —
@@ -3468,6 +3550,72 @@ mod tests {
     use ed25519_dalek::SigningKey;
     use scp_protocol::context::outlets::stream::ChunkPayload;
     use std::time::Duration;
+
+    /// #2196 — the open-stream `ContextNotActive` rejection maps to the
+    /// NON-retryable Protocol class (reusing the mid-stream teardown slug +
+    /// `SCP-OUTLET-6101`), and round-trips as the canonical
+    /// `InvocationError::ContextNotActive` (→ `SCP-OUTLET-6080`) preserving the
+    /// state string. A permanent context-not-active failure is thereby never
+    /// reported as a transient, retryable condition.
+    #[test]
+    fn context_not_active_rejection_is_non_retryable_protocol() {
+        use scp_protocol::context::outlets::errors::RetryPolicy;
+        let rej = OpenStreamRejection::ContextNotActive {
+            current_state: "Closing".to_owned(),
+        };
+        assert_eq!(
+            rej.slug(),
+            error_codes::SLUG_PROTOCOL_CONTEXT_CLOSED_MID_STREAM
+        );
+        assert_eq!(rej.error_code(), error_codes::CODE_PROTOCOL_SESSION);
+        assert_eq!(
+            error_codes::error_code_to_retry_policy(rej.error_code()),
+            Some(RetryPolicy::Never),
+            "a context-not-active open failure must be non-retryable"
+        );
+        match rej.to_invocation_error() {
+            InvocationError::ContextNotActive { current_state } => {
+                assert_eq!(current_state, "Closing", "state string round-trips");
+            }
+            other => panic!("expected ContextNotActive round-trip, got {other:?}"),
+        }
+    }
+
+    /// #2196 error-masking — EVERY permanent synchronous `invoke_outlet` open
+    /// failure maps to a NON-retryable class, NEVER the retryable transport
+    /// rate-limit the pre-fix `let _ = err` code collapsed all of them into.
+    #[test]
+    fn permanent_open_failures_map_to_non_retryable() {
+        use scp_protocol::context::outlets::errors::RetryPolicy;
+        let cases = [
+            InvocationError::ContextNotActive {
+                current_state: "Expired".to_owned(),
+            },
+            InvocationError::InputValidationFailed {
+                message: "bad schema".to_owned(),
+            },
+            InvocationError::InvokerNotAuthorized {
+                did: "did:dht:x".to_owned(),
+                outlet_id: "o".to_owned(),
+            },
+            InvocationError::OutletNotFound {
+                outlet_id: "o".to_owned(),
+            },
+        ];
+        for err in cases {
+            let rej = invocation_error_to_open_rejection(&err);
+            assert_eq!(
+                error_codes::error_code_to_retry_policy(rej.error_code()),
+                Some(RetryPolicy::Never),
+                "permanent open failure {err:?} must be non-retryable (got {rej:?})"
+            );
+            assert_ne!(
+                rej.error_code(),
+                error_codes::CODE_TRANSPORT_FAULT,
+                "a permanent failure must NOT surface the retryable transport-fault code: {err:?}"
+            );
+        }
+    }
 
     fn fixed_signing_key() -> SigningKey {
         SigningKey::from_bytes(&[0x42; 32])

--- a/crates/scp-runtime/src/context/outlets/invoke.rs
+++ b/crates/scp-runtime/src/context/outlets/invoke.rs
@@ -5204,6 +5204,22 @@ pub(crate) async fn run_streaming_saga_seal_task(
             // journal at `Committing` — the autonomous crash-recovery sweep
             // (SCP-OUT-046 #136) resolves it (witness present → Committed; absent
             // → the key-bearing truncated close, or an honest NeedsRepair).
+            //
+            // EXACTLY-ONCE ESCROW INVARIANT (#2196 audit note): dropping the
+            // ticket here is the SOLE refund and is safe ONLY because a resident
+            // actor's ed25519 receipt-signing is INFALLIBLE — the one signing
+            // failure path (`SCP-SAGA-13044`, streaming Commit-B receipt-signing,
+            // the preimage-construction/sign step) is unreachable under the
+            // §9.10.3 256 KB preimage bound, so no seal ever
+            // fails transiently *after* having signed. If a future receipt field
+            // or a new signer introduced a GENUINE transient resident-actor
+            // signing error, this drop would reverse the hold and a later
+            // key-bearing reseal (crash recovery) would refund it AGAIN —
+            // DOUBLE-REFUND. Such a real transient signing error MUST NOT reach
+            // this drop: handle it with a "sealed-but-unsigned / do-not-drop"
+            // marker that keeps the hold pending the reseal, never a silent ticket
+            // drop. (Behavioural change is out of scope here — this documents the
+            // load-bearing precondition the current drop relies on.)
             drop(escrow_ticket);
             tracing::error!(
                 saga_id = %saga_id.0,

--- a/crates/scp-runtime/src/context/outlets_helpers.rs
+++ b/crates/scp-runtime/src/context/outlets_helpers.rs
@@ -57,6 +57,7 @@ use std::sync::Arc;
 
 use scp_did::DID;
 use scp_protocol::context::ContextError;
+use scp_protocol::context::ContextState;
 use scp_protocol::context::outlets::OutletId;
 use scp_protocol::context::outlets::lifecycle::OutletInvokedEvent;
 use scp_protocol::context::outlets::registry::OutletRegistry;
@@ -556,6 +557,60 @@ pub struct InvocationCaveatBinding {
 }
 
 // ---------------------------------------------------------------------------
+// Context-lifecycle Active gate (shared by every forward-debit reserve path)
+// ---------------------------------------------------------------------------
+
+/// The `SCP-OUTLET-6080` "context not active" marker string.
+///
+/// Stamped into the `PermissionDenied` message by [`invocation_error_to_context`]
+/// and matched back out by [`reserve_error_to_open_rejection`]. Kept as one
+/// const so the producer and the reverse-map consumer move together if the code
+/// is ever renamed (mirrors the `SLUG_*`-constant discipline the escrow /
+/// insufficient-funds reverse-map arms already use).
+const SCP_OUTLET_6080_MARKER: &str = "SCP-OUTLET-6080";
+
+/// Fail-closed `ContextState::Active` gate for the outlet forward-debit reserve
+/// paths (#2196).
+///
+/// The outlet-stream reserve path (`open_outlet_stream_phase1` →
+/// `reserve_outlet_stream_economy`), the same-context unary reserve
+/// (`reserve_outlet_economy`), and the mid-stream grant top-up
+/// (`reserve_stream_grant_escrow`) all DEBIT escrow / budget, but historically
+/// gated only hard-rate / velocity / membership (6089) / overflow / funds — NOT
+/// context lifecycle. So a non-active (`Closing` / `Expired` / `MigratingOut` /
+/// …) context could take on NEW spend as long as no caller-side bridge guard
+/// rejected it first (SCP-OUT-047 added such guards on the 3 FFI bridges, but
+/// the same-context unary + stream-open paths shared the gap).
+///
+/// This is the single authoritative runtime gate that closes the root cause: it
+/// reads the sync lock-free authoritative [`ContextHandle::state`] (an `ArcSwap`
+/// load — never the lagging FFI handle cache) and, when the context is not
+/// `Active`, returns the canonical `SCP-OUTLET-6080` error via the SAME path the
+/// SESSION path (`create_session` / `invoke_session`) uses —
+/// [`InvocationError::ContextNotActive`] → [`invocation_error_to_context`]. The
+/// per-bridge guards are thereby demoted to true defense-in-depth.
+///
+/// Called as the FIRST predicate on each reserve path (before any escrow debit
+/// or bookkeeping mutation), so a rejected open touches no state and needs no
+/// rollback.
+///
+/// # Errors
+///
+/// [`ContextError::PermissionDenied`] carrying `SCP-OUTLET-6080: context not
+/// active: {current_state}` when `handle.state() != ContextState::Active`.
+fn ensure_context_active(handle: &ContextHandle) -> Result<(), ContextError> {
+    let state = handle.state();
+    if state != ContextState::Active {
+        return Err(invocation_error_to_context(
+            InvocationError::ContextNotActive {
+                current_state: state.to_string(),
+            },
+        ));
+    }
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
 // Phase 1: reserve_outlet_economy (actor handler entry point)
 // ---------------------------------------------------------------------------
 
@@ -644,6 +699,14 @@ pub async fn reserve_outlet_economy(
         let mut view = cell.class_c_view();
 
         handle = view.handle_mut().clone();
+
+        // #2196 — fail-closed context-lifecycle gate. FIRST predicate, before the
+        // hard-rate consume / velocity tick / economy pre-check / any budget
+        // debit, so a non-active context is rejected touching no state (no
+        // rollback path). `view` is dropped on the early return without
+        // persisting.
+        ensure_context_active(&handle)?;
+
         role_state = view.role_state().clone();
         let member_count = u64::try_from(view.membership_class_c_mut().count()).unwrap_or(u64::MAX);
 
@@ -1126,6 +1189,14 @@ pub async fn reserve_outlet_stream_economy(
     {
         let mut view = cell.class_c_view();
         handle = view.handle_mut().clone();
+
+        // #2196 — fail-closed context-lifecycle gate. FIRST predicate, before the
+        // hard-rate consume / velocity tick / membership gate / overflow / escrow
+        // debit, so a non-active (Closing / Expired / MigratingOut) context can
+        // never open a stream that debits escrow. `view` is dropped on the early
+        // return without persisting.
+        ensure_context_active(&handle)?;
+
         role_state = view.role_state().clone();
 
         let gov = view.governance_class_c_mut();
@@ -1354,6 +1425,15 @@ pub async fn reserve_stream_grant_escrow(
     grant: u32,
 ) -> Result<Amount, ContextError> {
     use crate::context::outlets::dispatch::OpenStreamRejection;
+
+    // #2196 — fail-closed context-lifecycle gate. FIRST predicate, before the
+    // zero-cost early return and before any budget debit / durable record bump:
+    // a Closing (or otherwise non-active) context must not take on NEW spend via
+    // a mid-stream credit top-up. Reads the sync authoritative handle state off
+    // a transient Class-C view (the handle is a cheap Arc-backed clone whose
+    // `state()` shares the live ArcSwap).
+    let handle = cell.class_c_view().handle_mut().clone();
+    ensure_context_active(&handle)?;
 
     // Zero-cost / Query outlets, or a zero grant: no debit, no balance
     // consultation, no persist (spec: "no top-up is performed").
@@ -2815,7 +2895,7 @@ fn check_invocation_error_to_context(
 fn invocation_error_to_context(err: InvocationError) -> ContextError {
     match err {
         InvocationError::ContextNotActive { current_state } => ContextError::PermissionDenied(
-            format!("SCP-OUTLET-6080: context not active: {current_state}"),
+            format!("{SCP_OUTLET_6080_MARKER}: context not active: {current_state}"),
         ),
         InvocationError::InvokerNotAuthorized { did, outlet_id } => ContextError::PermissionDenied(
             format!("SCP-OUTLET-6081: invoker {did} lacks OutletCall({outlet_id})"),
@@ -2940,6 +3020,26 @@ pub fn reserve_error_to_open_rejection(
             if msg.contains(error_codes::SLUG_ECONOMIC_INSUFFICIENT_FUNDS) =>
         {
             OpenStreamRejection::InsufficientFunds
+        }
+        // #2196 error-masking fix — the new `ensure_context_active` gate stamps
+        // the canonical `SCP-OUTLET-6080` marker into a `PermissionDenied`. Map
+        // it to the stream-open surface's `ContextNotActive` rejection
+        // (`protocol.context-closed-mid-stream` / `SCP-OUTLET-6101`, the
+        // NON-retryable Protocol class) rather than letting it fall through to
+        // the catch-all below, which collapses everything into the RETRYABLE
+        // transport rate-limit slug. A permanent "context not active" failure
+        // must never be reported as a transient, retryable condition. The
+        // `current_state` is recovered from the message tail (the marker format
+        // is `{marker}: context not active: {current_state}`; `ContextState`
+        // renders with no embedded `": "`, so the last segment is the state).
+        ContextError::PermissionDenied(msg) if msg.contains(SCP_OUTLET_6080_MARKER) => {
+            let current_state = msg
+                .rsplit(": ")
+                .next()
+                .unwrap_or_default()
+                .trim()
+                .to_owned();
+            OpenStreamRejection::ContextNotActive { current_state }
         }
         _ => OpenStreamRejection::AdmissionRateLimited {
             slug: error_codes::SLUG_TRANSPORT_RATE_LIMITED,
@@ -4499,6 +4599,67 @@ mod tests {
                 "a rejected paid reserve leaves the cumulative counter at its last admitted total"
             );
         }
+
+        /// #2196 — fail-closed `ContextState::Active` gate on the unary reserve.
+        /// A non-active (Closing / Expired / `MigratingOut`) context rejects with
+        /// SCP-OUTLET-6080 BEFORE any budget debit, spending-nonce consume, or
+        /// caveat-counter mutation — the gate is the FIRST predicate. A paid
+        /// reserve that WOULD charge leaves the funded budget untouched and
+        /// touches no counter. That the error is the 6080 `PermissionDenied` (not a
+        /// `RateLimited` / `maxCalls` / insufficient-funds reject) proves the gate
+        /// short-circuited BEFORE the hard-rate / velocity / pre-check gates ran
+        /// (no rollback path was taken). Also covers the caller side of the unary
+        /// cross-context saga (`prepare_a` → `reserve_outlet_economy`).
+        #[tokio::test]
+        async fn unary_reserve_gated_on_non_active_context() {
+            let deps = build_deps_paid(Box::new(OkPersistence)).await;
+            let invoker = DID(INVOKER.to_owned());
+            let caveats = max_calls_caveats(1);
+            let input = serde_json::json!({});
+            let now = scp_clock::SystemClock.now_secs();
+            for target in [
+                ContextState::Closing,
+                ContextState::Expired,
+                ContextState::MigratingOut,
+            ] {
+                let state = paid_active_state();
+                state
+                    .handle
+                    .transition_to(&target)
+                    .expect("Active → non-active transition");
+                let mut cell = ClassSCell::new(state);
+                let spending = signed_spending_ucan_for(&invoker);
+
+                let err = paid_reserve_step(
+                    &mut cell,
+                    &deps,
+                    &spending,
+                    &caveats,
+                    "cid-2196-unary",
+                    &input,
+                    now,
+                )
+                .await
+                .expect_err("a non-active context must reject the unary reserve before any debit");
+                let ContextError::PermissionDenied(msg) = &err else {
+                    panic!("expected PermissionDenied(SCP-OUTLET-6080), got {err:?}");
+                };
+                assert!(
+                    msg.contains("SCP-OUTLET-6080") && msg.contains(&target.to_string()),
+                    "reject must be the 6080 context-not-active error naming {target}: {msg}"
+                );
+                assert_eq!(
+                    cell.governance.budget_tracker.remaining(&invoker).0,
+                    1_000,
+                    "the active gate fires BEFORE the paid debit — the funded budget is \
+                     untouched ({target})"
+                );
+                assert!(
+                    !cell.class_s.caveat_counters.contains_key("cid-2196-unary"),
+                    "the gate short-circuits before any caveat-counter mutation ({target})"
+                );
+            }
+        }
     }
 
     /// Sub-chunk 3a — streaming open-time economy reserve
@@ -5260,6 +5421,96 @@ mod tests {
                 Amount::new(0),
                 "the grant debit is REVERSED when the persist does not land"
             );
+        }
+
+        // -------------------------------------------------------------------
+        // #2196 — fail-closed ContextState::Active gate on the forward-debit
+        // reserve paths. A non-active context must reject with SCP-OUTLET-6080
+        // BEFORE any escrow debit / durable record bump (the gate is the FIRST
+        // predicate — no rollback path is taken).
+        // -------------------------------------------------------------------
+
+        /// The three non-Active lifecycle states a forward-debit reserve rejects.
+        const NON_ACTIVE_STATES: [ContextState; 3] = [
+            ContextState::Closing,
+            ContextState::Expired,
+            ContextState::MigratingOut,
+        ];
+
+        /// An `INVOKER`-member context transitioned Active → `target`, funded so a
+        /// reserve WOULD debit if the gate did not fire first.
+        fn non_active_member_state(budget: u64, target: &ContextState) -> PerContextState {
+            let state = member_state(budget);
+            state
+                .handle
+                .transition_to(target)
+                .expect("Active → non-active transition");
+            state
+        }
+
+        /// Streaming open reserve (SCP-OUT-037 same-context open; SCP-OUT-047
+        /// target-side saga reserve): a non-active context rejects with
+        /// SCP-OUTLET-6080 naming the state, debiting NO escrow. The 6080
+        /// `PermissionDenied` (not a `RateLimited` / membership / overflow reject)
+        /// proves the gate ran before the hard-rate / velocity / membership /
+        /// overflow / funds gates.
+        #[tokio::test]
+        async fn stream_reserve_gated_on_non_active_context() {
+            let deps = build_deps(Box::new(OkPersistence)).await;
+            for target in NON_ACTIVE_STATES {
+                let mut cell = ClassSCell::new(non_active_member_state(1000, &target));
+
+                let err = reserve(&mut cell, &deps, 10, 4, None).await.expect_err(
+                    "a non-active context must reject the stream open before any debit",
+                );
+                let ContextError::PermissionDenied(msg) = &err else {
+                    panic!("expected PermissionDenied(SCP-OUTLET-6080), got {err:?}");
+                };
+                assert!(
+                    msg.contains("SCP-OUTLET-6080") && msg.contains(&target.to_string()),
+                    "reject must be the 6080 context-not-active error naming {target}: {msg}"
+                );
+                assert_eq!(
+                    cell.governance.budget_tracker.total_spent(&invoker()),
+                    Amount::new(0),
+                    "the active gate fires BEFORE any escrow debit — nothing is spent ({target})"
+                );
+            }
+        }
+
+        /// Mid-stream grant top-up: a non-active context rejects with
+        /// SCP-OUTLET-6080 BEFORE the zero-cost early return and BEFORE any budget
+        /// debit / durable record bump — a Closing context must not take on NEW
+        /// spend. The seeded open-time record is left un-bumped.
+        #[tokio::test]
+        async fn grant_reserve_gated_on_non_active_context() {
+            let deps = build_deps(Box::new(OkPersistence)).await;
+            for target in NON_ACTIVE_STATES {
+                let mut state = non_active_member_state(1000, &target);
+                seed_open_record(&mut state, 50);
+                let mut cell = ClassSCell::new(state);
+
+                let err = grant_reserve(&mut cell, &deps, 10, 4)
+                    .await
+                    .expect_err("a non-active context must reject a mid-stream grant top-up");
+                let ContextError::PermissionDenied(msg) = &err else {
+                    panic!("expected PermissionDenied(SCP-OUTLET-6080), got {err:?}");
+                };
+                assert!(
+                    msg.contains("SCP-OUTLET-6080") && msg.contains(&target.to_string()),
+                    "reject must be the 6080 context-not-active error naming {target}: {msg}"
+                );
+                assert_eq!(
+                    cell.governance.budget_tracker.total_spent(&invoker()),
+                    Amount::new(0),
+                    "the active gate fires BEFORE any grant debit — nothing is spent ({target})"
+                );
+                assert_eq!(
+                    cell.class_s.stream_reservations[&hex::encode(GRANT_REQ)].reserved_escrow,
+                    Amount::new(50),
+                    "the seeded open-time record is left un-bumped ({target})"
+                );
+            }
         }
     }
 }

--- a/crates/scp-runtime/src/context/outlets_helpers.rs
+++ b/crates/scp-runtime/src/context/outlets_helpers.rs
@@ -569,6 +569,16 @@ pub struct InvocationCaveatBinding {
 /// insufficient-funds reverse-map arms already use).
 const SCP_OUTLET_6080_MARKER: &str = "SCP-OUTLET-6080";
 
+/// The `SCP-OUTLET-6089` "invoker is not a member" marker string.
+///
+/// Stamped into the `PermissionDenied` message by the
+/// [`reserve_outlet_stream_economy`] membership gate and matched back out by
+/// [`reserve_error_to_open_rejection`]. Kept as one const so the producer and
+/// the reverse-map consumer move together — a permanent membership/authorization
+/// denial must map to a NON-retryable class, never the retryable transport
+/// rate-limit the catch-all uses (mirrors the 6080 marker discipline).
+const SCP_OUTLET_6089_MARKER: &str = "SCP-OUTLET-6089";
+
 /// Fail-closed `ContextState::Active` gate for the outlet forward-debit reserve
 /// paths (#2196).
 ///
@@ -1235,7 +1245,7 @@ pub async fn reserve_outlet_stream_economy(
             .rollback(invoker_did, velocity_token);
         gov.hard_rate_limit_mut().refund(invoker_did);
         return Err(ContextError::PermissionDenied(format!(
-            "SCP-OUTLET-6089: invoker {invoker_did} is not a member of context \
+            "{SCP_OUTLET_6089_MARKER}: invoker {invoker_did} is not a member of context \
              '{context_id}' — cannot open a stream"
         )));
     }
@@ -3041,6 +3051,23 @@ pub fn reserve_error_to_open_rejection(
                 .to_owned();
             OpenStreamRejection::ContextNotActive { current_state }
         }
+        // #2196 error-masking fix — the membership gate emits SCP-OUTLET-6089
+        // (invoker is not a member of the context) as a plain `PermissionDenied`.
+        // `open_outlet_stream_phase1` runs no membership check before the reserve,
+        // so a non-member same-context open flows here. It is a PERMANENT
+        // authorization denial — map it to the non-retryable authorization-denied
+        // class (`authorization.denied` → CODE_AUTHORIZATION_DENIED,
+        // SCP-OUTLET-6110, RetryPolicy::Never), NOT the retryable transport
+        // rate-limit the catch-all uses. Routed through `CaveatPostInputViolation`
+        // (its non-schema slug branch yields CODE_AUTHORIZATION_DENIED), matching
+        // how `invocation_error_to_open_rejection` maps `InvokerNotAuthorized`.
+        ContextError::PermissionDenied(msg) if msg.contains(SCP_OUTLET_6089_MARKER) => {
+            OpenStreamRejection::CaveatPostInputViolation {
+                slug: error_codes::SLUG_AUTHORIZATION_DENIED.to_owned(),
+            }
+        }
+        // A persist failure / mailbox fault / any other reserve error is GENUINELY
+        // transient — keep it on the retryable transport-fault path.
         _ => OpenStreamRejection::AdmissionRateLimited {
             slug: error_codes::SLUG_TRANSPORT_RATE_LIMITED,
         },
@@ -5511,6 +5538,62 @@ mod tests {
                     "the seeded open-time record is left un-bumped ({target})"
                 );
             }
+        }
+
+        /// #2196 error-masking — a non-member same-context open produces the
+        /// canonical SCP-OUTLET-6089 membership denial, and the supervisor-side
+        /// reverse-map (`reserve_error_to_open_rejection`) must route that
+        /// PERMANENT authorization failure to a NON-retryable class, NOT the
+        /// retryable transport rate-limit the catch-all uses. Feeds the REAL
+        /// reserve error through the reverse-map so the producer marker + consumer
+        /// match move together.
+        #[tokio::test]
+        async fn non_member_open_maps_to_non_retryable_authorization() {
+            use scp_protocol::context::outlets::error_codes;
+            use scp_protocol::context::outlets::errors::RetryPolicy;
+
+            let deps = build_deps(Box::new(OkPersistence)).await;
+            let mut state = PerContextState::new_for_test_encrypted([CTX_BYTE; 32], NOW, invoker());
+            state
+                .handle
+                .transition_to(&ContextState::Active)
+                .expect("transition to Active");
+            state
+                .governance
+                .budget_tracker
+                .grant(&invoker(), Amount::new(1000));
+            // NOTE: no `add_member` — the invoker is not on the roster, so the
+            // membership gate (not the active gate) fires with 6089.
+            let mut cell = ClassSCell::new(state);
+
+            let err = reserve(&mut cell, &deps, 10, 4, None)
+                .await
+                .expect_err("a non-member cannot open a stream");
+            let ContextError::PermissionDenied(msg) = &err else {
+                panic!("expected PermissionDenied(SCP-OUTLET-6089), got {err:?}");
+            };
+            assert!(
+                msg.contains("SCP-OUTLET-6089"),
+                "the reserve emits the canonical 6089 membership marker: {msg}"
+            );
+
+            let rejection = super::super::reserve_error_to_open_rejection(&err);
+            assert_ne!(
+                rejection.error_code(),
+                error_codes::CODE_TRANSPORT_FAULT,
+                "a permanent membership denial must NOT surface the retryable \
+                 transport-fault code (the pre-fix catch-all bug)"
+            );
+            assert_eq!(
+                rejection.error_code(),
+                error_codes::CODE_AUTHORIZATION_DENIED,
+                "6089 maps to the authorization-denied class (SCP-OUTLET-6110)"
+            );
+            assert_eq!(
+                error_codes::error_code_to_retry_policy(rejection.error_code()),
+                Some(RetryPolicy::Never),
+                "a 6089 membership denial must be NON-retryable"
+            );
         }
     }
 }

--- a/crates/scp-runtime/src/context/supervisor/supervisor.rs
+++ b/crates/scp-runtime/src/context/supervisor/supervisor.rs
@@ -25763,6 +25763,83 @@ mod tests {
         assert_eq!(xctx_invoked.4, expected_leaf_secs);
     }
 
+    /// #2196 — a non-active (Closing) CALLER context rejects the UNARY
+    /// cross-context outlet-invocation saga at Prepare-A's caller-side reserve
+    /// (`reserve_outlet_economy`, now gated by `ensure_context_active`),
+    /// surfacing SCP-OUTLET-6080 "context not active". Prepare-A fails before
+    /// Prepare-B / Commit, so the outlet NEVER executes and no A-side reservation
+    /// is applied. Covers the caller/A-leg of the unary saga, which the runtime
+    /// previously left ungated (bridge-guard only, on a stale handle cache).
+    #[tokio::test]
+    async fn xctx_saga_closing_caller_rejected_at_prepare_a_no_execution() {
+        use std::sync::atomic::{AtomicUsize, Ordering};
+
+        let creator_did = "did:dht:z6MkXctxClosingCreator".to_owned();
+        let creator_key = ed25519_dalek::SigningKey::from_bytes(&[5u8; 32]).verifying_key();
+        let supervisor = xctx_supervisor(creator_did.clone(), creator_key);
+        let caller_did = "did:dht:z6MkXctxClosingCaller";
+
+        // Caller transitioned Active → Closing before spawn (its actor stays
+        // alive); target stays Active. Gates 1/2 (outbound-caller authorize +
+        // established interface) and the rate-limit consume all pass, so the
+        // Prepare-A reserve's active gate is the barrier under test.
+        let caller_state = xctx_caller_state(caller_did, &creator_did);
+        caller_state
+            .handle
+            .transition_to(&scp_protocol::context::ContextState::Closing)
+            .expect("Active → Closing");
+        let target_state = xctx_target_state(caller_did, &creator_did);
+        Box::pin(spawn_xctx_pair(&supervisor, caller_state, target_state)).await;
+
+        let target_signing = ed25519_dalek::SigningKey::from_bytes(&[7u8; 32]);
+        let caller_signing = ed25519_dalek::SigningKey::from_bytes(&[8u8; 32]);
+
+        let calls = Arc::new(AtomicUsize::new(0));
+        let calls_for_exec = Arc::clone(&calls);
+        let executor = move |input: serde_json::Value| {
+            let calls = Arc::clone(&calls_for_exec);
+            async move {
+                calls.fetch_add(1, Ordering::SeqCst);
+                let a = input["a"].as_i64().unwrap_or(0);
+                let b = input["b"].as_i64().unwrap_or(0);
+                Ok(serde_json::json!({ "result": a + b }))
+            }
+        };
+
+        let now_ms = supervisor.clock_ref().expect("clock").now_millis();
+        let err = supervisor
+            .start_cross_context_outlet_invocation_saga(
+                CrossContextOutletInvocationRequest {
+                    caller_context_id: XCTX_CALLER,
+                    target_context_id: XCTX_TARGET,
+                    caller_did: DID(caller_did.to_owned()),
+                    outlet_registration_id: XCTX_OUTLET.to_owned(),
+                    ucan_proof_id: None,
+                    input: serde_json::json!({ "a": 1, "b": 2 }),
+                    asserted_chain_depth: 2,
+                    asserted_nonce: [0x43u8; 16],
+                    asserted_timestamp_ms: now_ms,
+                },
+                SagaSigningKeys {
+                    target: &target_signing,
+                    caller: &caller_signing,
+                },
+                executor,
+            )
+            .await
+            .expect_err("a Closing caller must reject the unary saga at Prepare-A");
+
+        assert!(
+            format!("{err}").contains("not active") || format!("{err}").contains("6080"),
+            "the abort surfaces the caller context-not-active reserve rejection: {err}"
+        );
+        assert_eq!(
+            calls.load(Ordering::SeqCst),
+            0,
+            "the outlet MUST NOT execute — Prepare-A rejected before Prepare-B / Commit"
+        );
+    }
+
     /// Prepare-B reject (confused deputy): the caller references a UCAN proof in
     /// B's store that is delegated to a DIFFERENT principal. Prepare-B rejects
     /// (SCP-SAGA-13013), the saga ABORTS, the outlet NEVER executes, and the
@@ -31667,7 +31744,7 @@ mod streaming_saga_tests {
     use scp_protocol::economy::types::{Amount, CostSchedule, CurrencyCode, EconomicPolicy};
     use scp_protocol::trust::caveats::InvocationCaveats;
 
-    use super::{DurableProviders, SagaSigningKeys, Supervisor};
+    use super::{DurableProviders, SagaAbortReason, SagaError, SagaSigningKeys, Supervisor};
     use crate::context::actor::ContextCommand;
     use crate::context::actor::commands::{QueriesCommand, SagaPhaseMessage, SigningKeyBytes};
     use crate::context::actor::state::PerContextState;
@@ -32459,6 +32536,217 @@ mod streaming_saga_tests {
             "AC3: exactly one billed PaymentReceipt is captured (real close-time settlement)"
         );
 
+        drop(invoked);
+    }
+
+    /// #2196 — a non-active (Closing) TARGET context rejects the cross-context
+    /// streaming saga at the B-side escrow reserve, BEFORE any escrow debit and
+    /// BEFORE the seal task spawns. The runtime `ensure_context_active` gate
+    /// (added to `reserve_outlet_stream_economy`, which the saga runs on the
+    /// TARGET) is authoritative — no FFI bridge guard is in the loop at the
+    /// runtime layer, and no earlier saga gate checks lifecycle state (the
+    /// interface + context-set gates pass for an established, live target).
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn xctx_streaming_saga_closing_target_rejected_before_debit_and_seal() {
+        let captured = Arc::new(AtomicUsize::new(0));
+        let invoked = Arc::new(AtomicUsize::new(0));
+        let storage = Arc::new(InMemoryStorage::new());
+        let journal: Arc<dyn SagaJournal> =
+            Arc::new(ProtocolRepositorySagaJournal::new(Arc::clone(&storage)));
+        let recording = SsRecordingEventLog::default();
+        let supervisor =
+            build_ss_supervisor(&captured, Arc::clone(&journal), Box::new(recording.clone()));
+
+        // Caller Active; TARGET transitioned Active → Closing before spawn. Its
+        // actor stays alive, so the interface + membership gates still pass and the
+        // active-state reserve gate is the barrier under test.
+        spawn_ss_actor(
+            &supervisor,
+            "did:example:ss-caller-owner",
+            ss_caller_state_for(SS_CALLER, SS_TARGET),
+        )
+        .await;
+        let target_state = ss_paid_target_state(SS_TARGET);
+        target_state
+            .handle
+            .transition_to(&ContextState::Closing)
+            .expect("Active → Closing");
+        spawn_ss_actor(&supervisor, "did:example:ss-target-owner", target_state).await;
+
+        let registry = ss_registry();
+        let (params, binding) = ss_stream_params([0x46; 16]);
+        let executor = Arc::new(FiniteChunkExecutor {
+            data_chunks: 10,
+            invoked: Arc::clone(&invoked),
+        });
+        let target_signing = SigningKey::from_bytes(&[7u8; 32]);
+        let caller_signing = SigningKey::from_bytes(&[8u8; 32]);
+        let outlet_id: OutletId = SS_OUTLET.to_owned();
+
+        let Err(err) = supervisor
+            .start_cross_context_streaming_outlet_invocation_saga(
+                SS_CALLER,
+                SS_TARGET,
+                ss_invoker(),
+                SS_OUTLET.to_owned(),
+                None,
+                &registry,
+                &outlet_id,
+                serde_json::json!({ "a": 1, "b": 2 }),
+                1,
+                [0x99u8; 16],
+                SS_NOW.saturating_mul(1000),
+                Some(5_000),
+                executor,
+                Some(binding),
+                SagaSigningKeys {
+                    target: &target_signing,
+                    caller: &caller_signing,
+                },
+                params,
+            )
+            .await
+        else {
+            panic!("a Closing target must reject the streaming saga at the B-side reserve");
+        };
+
+        match &err {
+            SagaError::Aborted {
+                reason,
+                code,
+                message,
+            } => {
+                assert_eq!(*code, 13067, "a B-side reserve rejection aborts with 13067");
+                assert!(
+                    matches!(reason, SagaAbortReason::Rejected),
+                    "a context-not-active reject is a PERMANENT rejection, not retryable: {reason:?}"
+                );
+                assert!(
+                    message.contains("not in Active state") && message.contains("Closing"),
+                    "the abort surfaces the context-not-active reserve rejection naming the \
+                     state (the 6080 gate flowed through reserve_error_to_open_rejection → \
+                     ContextNotActive): {message}"
+                );
+            }
+            other => panic!("expected SagaError::Aborted, got {other:?}"),
+        }
+
+        // No escrow was debited on the target — the gate fired before the debit.
+        assert_eq!(
+            ss_remaining_budget(&supervisor, &hex::encode(SS_TARGET), &ss_invoker()).await,
+            Amount::new(SS_GRANTED),
+            "the invoker's target budget is untouched — the reserve gate fired before any debit"
+        );
+        // The outlet executor was never invoked and the saga was resolved Aborted
+        // (never Committing), so no off-mailbox seal task was spawned.
+        assert_eq!(
+            invoked.load(Ordering::SeqCst),
+            0,
+            "no executor invocation on a rejected open"
+        );
+        assert!(
+            journal
+                .load_unresolved()
+                .await
+                .expect("load_unresolved")
+                .is_empty(),
+            "the rejected saga is resolved Aborted — no Committing entry survives, so no seal \
+             task was spawned"
+        );
+
+        drop(invoked);
+    }
+
+    /// #2196 — a SAME-context stream OPEN (SCP-OUT-037 path,
+    /// `Supervisor::open_outlet_stream`) against a Closing context is rejected
+    /// with `OpenStreamRejection::ContextNotActive` — Protocol class,
+    /// `SCP-OUTLET-6101`, NON-retryable — at the runtime reserve gate, debiting
+    /// no escrow and never invoking the executor. No FFI bridge guard exists for
+    /// this path at either layer historically, so the runtime gate is the sole
+    /// barrier.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn same_context_stream_open_gated_on_closing_context() {
+        use crate::context::outlets::dispatch::OpenStreamRejection;
+        use scp_protocol::context::outlets::error_codes;
+        use scp_protocol::context::outlets::errors::RetryPolicy;
+
+        let captured = Arc::new(AtomicUsize::new(0));
+        let invoked = Arc::new(AtomicUsize::new(0));
+        let storage = Arc::new(InMemoryStorage::new());
+        let journal: Arc<dyn SagaJournal> =
+            Arc::new(ProtocolRepositorySagaJournal::new(Arc::clone(&storage)));
+        let supervisor = build_ss_supervisor(
+            &captured,
+            Arc::clone(&journal),
+            Box::new(SsRecordingEventLog::default()),
+        );
+
+        // One context, transitioned Active → Closing before spawn.
+        let ctx_state = ss_paid_target_state(SS_TARGET);
+        ctx_state
+            .handle
+            .transition_to(&ContextState::Closing)
+            .expect("Active → Closing");
+        spawn_ss_actor(&supervisor, "did:example:ss-target-owner", ctx_state).await;
+
+        let registry = ss_registry();
+        let (params, binding) = ss_stream_params([0x37; 16]);
+        let executor = Arc::new(FiniteChunkExecutor {
+            data_chunks: 5,
+            invoked: Arc::clone(&invoked),
+        });
+        let outlet_id: OutletId = SS_OUTLET.to_owned();
+        let target_hex = hex::encode(SS_TARGET);
+
+        let Err(err) = supervisor
+            .open_outlet_stream(
+                &target_hex,
+                &registry,
+                &outlet_id,
+                serde_json::json!({ "a": 1, "b": 2 }),
+                &ss_invoker(),
+                Some(5_000),
+                executor,
+                None,
+                None,
+                None,
+                Some(binding),
+                params,
+            )
+            .await
+        else {
+            panic!("a Closing context must reject a same-context stream open");
+        };
+
+        match &err {
+            OpenStreamRejection::ContextNotActive { current_state } => {
+                assert!(
+                    current_state.contains("Closing"),
+                    "the rejection names the lifecycle state: {current_state}"
+                );
+            }
+            other => panic!("expected OpenStreamRejection::ContextNotActive, got {other:?}"),
+        }
+        assert_eq!(
+            err.error_code(),
+            error_codes::CODE_PROTOCOL_SESSION,
+            "#2196 maps the same-context open reject to the Protocol class (SCP-OUTLET-6101)"
+        );
+        assert_eq!(
+            error_codes::error_code_to_retry_policy(err.error_code()),
+            Some(RetryPolicy::Never),
+            "a same-context open reject on a Closing context is NON-retryable"
+        );
+        assert_eq!(
+            ss_remaining_budget(&supervisor, &target_hex, &ss_invoker()).await,
+            Amount::new(SS_GRANTED),
+            "no escrow debited on a rejected same-context open"
+        );
+        assert_eq!(
+            invoked.load(Ordering::SeqCst),
+            0,
+            "the executor is never invoked on a rejected open"
+        );
         drop(invoked);
     }
 

--- a/crates/scp-testing/tests/integration/pipeline_wiring.rs
+++ b/crates/scp-testing/tests/integration/pipeline_wiring.rs
@@ -806,6 +806,33 @@ fn reserve_outlet_economy_enforces_value_caveats() {
     );
 }
 
+// #2196 — the fail-closed ContextState::Active gate must be wired as the FIRST
+// predicate on every forward-debit outlet reserve path (same-context unary,
+// stream open, and mid-stream grant top-up), and the gate itself must read the
+// authoritative sync handle state. Asserts the REAL `ensure_context_active`
+// call in each reserve (not a dead `let _ =`) plus the `.state()` read inside
+// the gate, so a Closing / Expired / MigratingOut context can never take on new
+// spend. (`MANAGER_SRC` embeds `outlets_helpers.rs`.)
+#[test]
+fn outlet_reserves_gate_on_context_active_state() {
+    for reserve in [
+        "reserve_outlet_economy",
+        "reserve_outlet_stream_economy",
+        "reserve_stream_grant_escrow",
+    ] {
+        assert!(
+            fn_body_contains(MANAGER_SRC, reserve, "ensure_context_active"),
+            "{reserve} must call ensure_context_active as its fail-closed #2196 \
+             context-lifecycle gate before any escrow / budget debit"
+        );
+    }
+    assert!(
+        fn_body_contains(MANAGER_SRC, "ensure_context_active", ".state()"),
+        "ensure_context_active must read the authoritative sync handle .state() \
+         (the ArcSwap load), not a lagging cache"
+    );
+}
+
 // Manager level: send_message delegates to encrypt_and_send which calls transport.send_message
 #[test]
 fn send_message_calls_transport_send() {


### PR DESCRIPTION
## #2196 — runtime `ContextState::Active` gate on the outlet reserve path (+ error-masking fix)

Closes #2196. Money-safety hardening surfaced by the SCP-OUT-047 review: the outlet-stream reserve path debited escrow with **no lifecycle gate** — a non-Active (Closing/Expired/MigratingOut) context could reserve/debit unless a caller-side bridge guard happened to reject first.

### Root-cause fix
New `ensure_context_active(handle)` reads the authoritative sync `ContextState` (ArcSwap) and is the **first predicate** — before any escrow debit / counter mutation / hard-rate consume — on all three forward-debit reserves:
- `reserve_outlet_economy` (unary + unary-saga A-leg)
- `reserve_outlet_stream_economy` (same-context stream open + streaming-saga target)
- `reserve_stream_grant_escrow` (mid-stream grant)

Rejects with `SCP-OUTLET-6080` (mirrors the session path). Settle/refund/rollback/reconcile paths are left ungated (they must run on Closing/Expired). The 3 FFI bridge guards are kept intact, demoted (comment-only) to defense-in-depth (the streaming reserve runs on the *target*, so the caller-axis bridge guard stays primary).

### Error-masking fix (recovers dropped-story SCP-OUT-027)
Two sites masked **permanent** failures as retryable `AdmissionRateLimited`/transport-fault:
- `reserve_error_to_open_rejection` catch-all → added explicit arms for `ContextNotActive` (→ `SCP-OUTLET-6101`, `Never`) and the membership denial `SCP-OUTLET-6089` (→ `SCP-OUTLET-6110` `authorization.denied`, `Never`). Shared marker consts keep producer/consumer in lockstep.
- The stream-open sync-`invoke_outlet` `map_err` (was `let _ = err` → retryable): now routes all four permanent sync failures (context-not-active/schema/authz/not-found) to non-retryable classes.

### LOW cleanups (from the whole-outlet audit)
Removed a dead `let _ = open_error_to_slug(...)`; added the exactly-once-escrow invariant note at the seal-Err ticket drop; repointed `apply_outlet_cancel_verbatim`'s dead-code deferral to #2203.

### Tests + CI
8 new runtime tests (each path rejected before debit across Closing/Expired/MigratingOut; error-taxonomy non-retryable; non-member → non-retryable) + an additive `pipeline_wiring` assertion. Workspace clippy `-D warnings` clean; `scp-runtime` lib 2205 pass; all 127 outlet/saga `scp-testing` tests pass; check-*.sh + fmt clean. (The `scp-testing::node` TLS/NAT/relay failures are pre-existing/environmental — verified identical on clean `origin/main`.)

Reviewed to double-zero: adversarial-expert **SHIP** (no bypass across 5 attack axes), completionist **COMPLETE** (all paths gated, tests live), bug-catcher clean (its one LOW — 6089 masking — folded in + re-confirmed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
