### PR TITLE
feat(scp-ffi): AppBound/AppUnbound durable event-log appends (§8.4)

### DIFF
--- a/.docs/standards/sdk-capability-matrix.json
+++ b/.docs/standards/sdk-capability-matrix.json
@@ -320,6 +320,28 @@
           }
         },
         {
+          "name": "sandbox_app_bind",
+          "python": true,
+          "typescript": true,
+          "kotlin": false,
+          "swift": true,
+          "notes": "Binds an app to a context (spec §8.4.1), appending a durable AppBound event (tag 74). Returns JSON with app_did and granted_capabilities.",
+          "exemptions": {
+            "kotlin": "SDK does not expose sandboxAppBind wrapper; UniFFI-generated binding available but no idiomatic Kotlin SDK wrapper"
+          }
+        },
+        {
+          "name": "sandbox_app_unbind",
+          "python": true,
+          "typescript": true,
+          "kotlin": false,
+          "swift": true,
+          "notes": "Unbinds an app from a context (spec §8.4.2), appending a durable AppUnbound event (tag 75).",
+          "exemptions": {
+            "kotlin": "SDK does not expose sandboxAppUnbind wrapper; UniFFI-generated binding available but no idiomatic Kotlin SDK wrapper"
+          }
+        },
+        {
           "name": "metadata_record_serialize",
           "python": true,
           "typescript": true,

--- a/.docs/standards/sdk-capability-matrix.json
+++ b/.docs/standards/sdk-capability-matrix.json
@@ -320,7 +320,7 @@
           }
         },
         {
-          "name": "sandbox_app_bind",
+          "name": "app_bind",
           "python": true,
           "typescript": true,
           "kotlin": true,
@@ -328,7 +328,7 @@
           "notes": "Binds an app to a context (spec §8.4.1), appending a durable AppBound event (tag 74). Returns JSON with app_did and granted_capabilities."
         },
         {
-          "name": "sandbox_app_unbind",
+          "name": "app_unbind",
           "python": true,
           "typescript": true,
           "kotlin": true,

--- a/.docs/standards/sdk-capability-matrix.json
+++ b/.docs/standards/sdk-capability-matrix.json
@@ -323,23 +323,17 @@
           "name": "sandbox_app_bind",
           "python": true,
           "typescript": true,
-          "kotlin": false,
+          "kotlin": true,
           "swift": true,
-          "notes": "Binds an app to a context (spec §8.4.1), appending a durable AppBound event (tag 74). Returns JSON with app_did and granted_capabilities.",
-          "exemptions": {
-            "kotlin": "SDK does not expose sandboxAppBind wrapper; UniFFI-generated binding available but no idiomatic Kotlin SDK wrapper"
-          }
+          "notes": "Binds an app to a context (spec §8.4.1), appending a durable AppBound event (tag 74). Returns JSON with app_did and granted_capabilities."
         },
         {
           "name": "sandbox_app_unbind",
           "python": true,
           "typescript": true,
-          "kotlin": false,
+          "kotlin": true,
           "swift": true,
-          "notes": "Unbinds an app from a context (spec §8.4.2), appending a durable AppUnbound event (tag 75).",
-          "exemptions": {
-            "kotlin": "SDK does not expose sandboxAppUnbind wrapper; UniFFI-generated binding available but no idiomatic Kotlin SDK wrapper"
-          }
+          "notes": "Unbinds an app from a context (spec §8.4.2), appending a durable AppUnbound event (tag 75)."
         },
         {
           "name": "metadata_record_serialize",

--- a/bindings/kotlin/scp-kt/src/main/kotlin/works/limn/scp/Scp.kt
+++ b/bindings/kotlin/scp-kt/src/main/kotlin/works/limn/scp/Scp.kt
@@ -751,26 +751,26 @@ class SCP internal constructor(
         newSeconds = newSeconds,
     )
 
-    /** Forwards to [NativeScp.sandboxAppBind] on [inner]. */
-    suspend fun contextSandboxAppBind(
+    /** Forwards to [NativeScp.appBind] on [inner]. */
+    suspend fun contextAppBind(
         handle: ContextHandle,
         declarationJson: String,
         actorDid: String,
         timestampSecs: ULong,
-    ): String = inner.sandboxAppBind(
+    ): String = inner.appBind(
         handle = handle,
         declarationJson = declarationJson,
         actorDid = actorDid,
         timestampSecs = timestampSecs,
     )
 
-    /** Forwards to [NativeScp.sandboxAppUnbind] on [inner]. */
-    suspend fun contextSandboxAppUnbind(
+    /** Forwards to [NativeScp.appUnbind] on [inner]. */
+    suspend fun contextAppUnbind(
         handle: ContextHandle,
         appDid: String,
         actorDid: String,
         timestampSecs: ULong,
-    ) = inner.sandboxAppUnbind(
+    ) = inner.appUnbind(
         handle = handle,
         appDid = appDid,
         actorDid = actorDid,

--- a/bindings/kotlin/scp-kt/src/main/kotlin/works/limn/scp/Scp.kt
+++ b/bindings/kotlin/scp-kt/src/main/kotlin/works/limn/scp/Scp.kt
@@ -751,6 +751,32 @@ class SCP internal constructor(
         newSeconds = newSeconds,
     )
 
+    /** Forwards to [NativeScp.sandboxAppBind] on [inner]. */
+    suspend fun contextSandboxAppBind(
+        handle: ContextHandle,
+        declarationJson: String,
+        actorDid: String,
+        timestampSecs: ULong,
+    ): String = inner.sandboxAppBind(
+        handle = handle,
+        declarationJson = declarationJson,
+        actorDid = actorDid,
+        timestampSecs = timestampSecs,
+    )
+
+    /** Forwards to [NativeScp.sandboxAppUnbind] on [inner]. */
+    suspend fun contextSandboxAppUnbind(
+        handle: ContextHandle,
+        appDid: String,
+        actorDid: String,
+        timestampSecs: ULong,
+    ) = inner.sandboxAppUnbind(
+        handle = handle,
+        appDid = appDid,
+        actorDid = actorDid,
+        timestampSecs = timestampSecs,
+    )
+
     /**
      * Forwards to [NativeScp.contextSend] on [inner].
      *

--- a/bindings/python/scp_sdk/_scp_core.pyi
+++ b/bindings/python/scp_sdk/_scp_core.pyi
@@ -405,6 +405,14 @@ class SCP:
     def access_key_restore(self, context_id: Any, member_did: Any, caller_did: Any) -> Any: ...
     def access_key_revoke(self, context_id: Any, member_did: Any, caller_did: Any) -> Any: ...
 
+    # -- app sandbox (spec §8.4) --
+    def app_bind(
+        self, context_id: str, declaration_json: str, actor_did: str, timestamp_secs: int
+    ) -> str: ...
+    def app_unbind(
+        self, context_id: str, app_did: str, actor_did: str, timestamp_secs: int
+    ) -> None: ...
+
     # -- governance --
     def add_checkpoint_cosignature(
         self, handle: Any, checkpoint_json: Any, signer_did: Any, signature_hex: Any

--- a/bindings/python/scp_sdk/scp.py
+++ b/bindings/python/scp_sdk/scp.py
@@ -1397,6 +1397,50 @@ class SCP:
         except Exception as exc:
             raise _coded_bridge_error(exc) from exc
 
+    async def context_sandbox_app_bind(
+        self,
+        context_id: str,
+        declaration_json: str,
+        actor_did: str,
+        timestamp_secs: int,
+    ) -> Any:
+        """Delegate to ``_scp_core.SCP.sandbox_app_bind``.
+
+        Validates the capability declaration against the context ceiling and
+        the actor's role capabilities, then appends a durable ``AppBound``
+        event (tag 74) to the event log (spec §8.4.1).
+
+        Returns a JSON summary string with ``app_did`` and
+        ``granted_capabilities`` on success.
+        """
+        return await asyncio.to_thread(
+            self._native.sandbox_app_bind,
+            context_id,
+            declaration_json,
+            actor_did,
+            timestamp_secs,
+        )
+
+    async def context_sandbox_app_unbind(
+        self,
+        context_id: str,
+        app_did: str,
+        actor_did: str,
+        timestamp_secs: int,
+    ) -> Any:
+        """Delegate to ``_scp_core.SCP.sandbox_app_unbind``.
+
+        Removes the app binding and appends a durable ``AppUnbound`` event
+        (tag 75) to the event log (spec §8.4.2).
+        """
+        return await asyncio.to_thread(
+            self._native.sandbox_app_unbind,
+            context_id,
+            app_did,
+            actor_did,
+            timestamp_secs,
+        )
+
     async def get_economic_policy(self, handle: Any) -> Any:
         """Delegate to ``_scp_core.SCP.get_economic_policy``."""
         return await asyncio.to_thread(self._native.get_economic_policy, handle)

--- a/bindings/python/scp_sdk/scp.py
+++ b/bindings/python/scp_sdk/scp.py
@@ -1397,14 +1397,14 @@ class SCP:
         except Exception as exc:
             raise _coded_bridge_error(exc) from exc
 
-    async def context_sandbox_app_bind(
+    async def context_app_bind(
         self,
         context_id: str,
         declaration_json: str,
         actor_did: str,
         timestamp_secs: int,
     ) -> Any:
-        """Delegate to ``_scp_core.SCP.sandbox_app_bind``.
+        """Delegate to ``_scp_core.SCP.app_bind``.
 
         Validates the capability declaration against the context ceiling and
         the actor's role capabilities, then appends a durable ``AppBound``
@@ -1414,27 +1414,27 @@ class SCP:
         ``granted_capabilities`` on success.
         """
         return await asyncio.to_thread(
-            self._native.sandbox_app_bind,
+            self._native.app_bind,
             context_id,
             declaration_json,
             actor_did,
             timestamp_secs,
         )
 
-    async def context_sandbox_app_unbind(
+    async def context_app_unbind(
         self,
         context_id: str,
         app_did: str,
         actor_did: str,
         timestamp_secs: int,
     ) -> Any:
-        """Delegate to ``_scp_core.SCP.sandbox_app_unbind``.
+        """Delegate to ``_scp_core.SCP.app_unbind``.
 
         Removes the app binding and appends a durable ``AppUnbound`` event
         (tag 75) to the event log (spec §8.4.2).
         """
         return await asyncio.to_thread(
-            self._native.sandbox_app_unbind,
+            self._native.app_unbind,
             context_id,
             app_did,
             actor_did,

--- a/bindings/python/scp_sdk/scp.py
+++ b/bindings/python/scp_sdk/scp.py
@@ -1408,18 +1408,21 @@ class SCP:
 
         Validates the capability declaration against the context ceiling and
         the actor's role capabilities, then appends a durable ``AppBound``
-        event (tag 74) to the event log (spec §8.4.1).
+        event (tag 74) to the event log (spec §8.4.2).
 
         Returns a JSON summary string with ``app_did`` and
         ``granted_capabilities`` on success.
         """
-        return await asyncio.to_thread(
-            self._native.app_bind,
-            context_id,
-            declaration_json,
-            actor_did,
-            timestamp_secs,
-        )
+        try:
+            return await asyncio.to_thread(
+                self._native.app_bind,
+                context_id,
+                declaration_json,
+                actor_did,
+                timestamp_secs,
+            )
+        except Exception as exc:
+            raise _coded_bridge_error(exc) from exc
 
     async def context_app_unbind(
         self,
@@ -1433,13 +1436,16 @@ class SCP:
         Removes the app binding and appends a durable ``AppUnbound`` event
         (tag 75) to the event log (spec §8.4.2).
         """
-        return await asyncio.to_thread(
-            self._native.app_unbind,
-            context_id,
-            app_did,
-            actor_did,
-            timestamp_secs,
-        )
+        try:
+            return await asyncio.to_thread(
+                self._native.app_unbind,
+                context_id,
+                app_did,
+                actor_did,
+                timestamp_secs,
+            )
+        except Exception as exc:
+            raise _coded_bridge_error(exc) from exc
 
     async def get_economic_policy(self, handle: Any) -> Any:
         """Delegate to ``_scp_core.SCP.get_economic_policy``."""

--- a/bindings/swift/Sources/SCP/Scp.swift
+++ b/bindings/swift/Sources/SCP/Scp.swift
@@ -560,7 +560,7 @@ public extension SCP {
     ///
     /// Validates the capability declaration against the context ceiling and
     /// the actor's role capabilities, then appends a durable `AppBound` event
-    /// (tag 74) to the event log (spec §8.4.1).
+    /// (tag 74) to the event log (spec §8.4.2).
     ///
     /// - Returns: A JSON summary string with `app_did` and `granted_capabilities`.
     func contextAppBind(handle: ContextHandle, declarationJson: String, actorDid: String, timestampSecs: UInt64) async throws -> String {

--- a/bindings/swift/Sources/SCP/Scp.swift
+++ b/bindings/swift/Sources/SCP/Scp.swift
@@ -556,6 +556,25 @@ public extension SCP {
         try await inner.contextSend(handle: handle, identity: identity, payload: payload, spendingUcanJwt: spendingUcanJwt)
     }
 
+    /// Forwards to ``Scp/sandboxAppBind`` on ``inner``.
+    ///
+    /// Validates the capability declaration against the context ceiling and
+    /// the actor's role capabilities, then appends a durable `AppBound` event
+    /// (tag 74) to the event log (spec §8.4.1).
+    ///
+    /// - Returns: A JSON summary string with `app_did` and `granted_capabilities`.
+    func contextSandboxAppBind(handle: ContextHandle, declarationJson: String, actorDid: String, timestampSecs: UInt64) async throws -> String {
+        try await inner.sandboxAppBind(handle: handle, declarationJson: declarationJson, actorDid: actorDid, timestampSecs: timestampSecs)
+    }
+
+    /// Forwards to ``Scp/sandboxAppUnbind`` on ``inner``.
+    ///
+    /// Removes the app binding and appends a durable `AppUnbound` event
+    /// (tag 75) to the event log (spec §8.4.2).
+    func contextSandboxAppUnbind(handle: ContextHandle, appDid: String, actorDid: String, timestampSecs: UInt64) async throws {
+        try await inner.sandboxAppUnbind(handle: handle, appDid: appDid, actorDid: actorDid, timestampSecs: timestampSecs)
+    }
+
     /// Reconnects `identity`'s contexts after an offline period, running the
     /// ADR-029 six-phase reconnection protocol for each of `contextIds`
     /// flagged `needsReconnect` (§23.11).

--- a/bindings/swift/Sources/SCP/Scp.swift
+++ b/bindings/swift/Sources/SCP/Scp.swift
@@ -556,23 +556,23 @@ public extension SCP {
         try await inner.contextSend(handle: handle, identity: identity, payload: payload, spendingUcanJwt: spendingUcanJwt)
     }
 
-    /// Forwards to ``Scp/sandboxAppBind`` on ``inner``.
+    /// Forwards to ``Scp/appBind`` on ``inner``.
     ///
     /// Validates the capability declaration against the context ceiling and
     /// the actor's role capabilities, then appends a durable `AppBound` event
     /// (tag 74) to the event log (spec §8.4.1).
     ///
     /// - Returns: A JSON summary string with `app_did` and `granted_capabilities`.
-    func contextSandboxAppBind(handle: ContextHandle, declarationJson: String, actorDid: String, timestampSecs: UInt64) async throws -> String {
-        try await inner.sandboxAppBind(handle: handle, declarationJson: declarationJson, actorDid: actorDid, timestampSecs: timestampSecs)
+    func contextAppBind(handle: ContextHandle, declarationJson: String, actorDid: String, timestampSecs: UInt64) async throws -> String {
+        try await inner.appBind(handle: handle, declarationJson: declarationJson, actorDid: actorDid, timestampSecs: timestampSecs)
     }
 
-    /// Forwards to ``Scp/sandboxAppUnbind`` on ``inner``.
+    /// Forwards to ``Scp/appUnbind`` on ``inner``.
     ///
     /// Removes the app binding and appends a durable `AppUnbound` event
     /// (tag 75) to the event log (spec §8.4.2).
-    func contextSandboxAppUnbind(handle: ContextHandle, appDid: String, actorDid: String, timestampSecs: UInt64) async throws {
-        try await inner.sandboxAppUnbind(handle: handle, appDid: appDid, actorDid: actorDid, timestampSecs: timestampSecs)
+    func contextAppUnbind(handle: ContextHandle, appDid: String, actorDid: String, timestampSecs: UInt64) async throws {
+        try await inner.appUnbind(handle: handle, appDid: appDid, actorDid: actorDid, timestampSecs: timestampSecs)
     }
 
     /// Reconnects `identity`'s contexts after an offline period, running the

--- a/bindings/typescript/src/scp.ts
+++ b/bindings/typescript/src/scp.ts
@@ -4628,7 +4628,7 @@ export class SCP {
    *
    * @returns A JSON summary string with `app_did` and `granted_capabilities`.
    */
-  async contextSandboxAppBind(
+  async contextAppBind(
     contextId: string,
     declarationJson: string,
     actorDid: string,
@@ -4636,7 +4636,7 @@ export class SCP {
   ): Promise<string> {
     try {
       return await (
-        this.#native.sandboxAppBind as (
+        this.#native.appBind as (
           id: string,
           decl: string,
           did: string,
@@ -4652,7 +4652,7 @@ export class SCP {
    * Unbinds an app from a context and appends a durable `AppUnbound` event
    * (tag 75) to the event log (spec §8.4.2).
    */
-  async contextSandboxAppUnbind(
+  async contextAppUnbind(
     contextId: string,
     appDid: string,
     actorDid: string,
@@ -4660,7 +4660,7 @@ export class SCP {
   ): Promise<void> {
     try {
       await (
-        this.#native.sandboxAppUnbind as (
+        this.#native.appUnbind as (
           id: string,
           app: string,
           did: string,

--- a/bindings/typescript/src/scp.ts
+++ b/bindings/typescript/src/scp.ts
@@ -4621,7 +4621,7 @@ export class SCP {
 
   /**
    * Binds an app to a context and appends a durable `AppBound` event (tag 74)
-   * to the event log (spec §8.4.1).
+   * to the event log (spec §8.4.2).
    *
    * Validates the capability declaration against the context ceiling and the
    * actor's role capabilities before appending.

--- a/bindings/typescript/src/scp.ts
+++ b/bindings/typescript/src/scp.ts
@@ -4619,6 +4619,59 @@ export class SCP {
     }
   }
 
+  /**
+   * Binds an app to a context and appends a durable `AppBound` event (tag 74)
+   * to the event log (spec §8.4.1).
+   *
+   * Validates the capability declaration against the context ceiling and the
+   * actor's role capabilities before appending.
+   *
+   * @returns A JSON summary string with `app_did` and `granted_capabilities`.
+   */
+  async contextSandboxAppBind(
+    contextId: string,
+    declarationJson: string,
+    actorDid: string,
+    timestampSecs: number,
+  ): Promise<string> {
+    try {
+      return await (
+        this.#native.sandboxAppBind as (
+          id: string,
+          decl: string,
+          did: string,
+          ts: number,
+        ) => Promise<string>
+      )(contextId, declarationJson, actorDid, timestampSecs);
+    } catch (err) {
+      throw mapBridgeError(err);
+    }
+  }
+
+  /**
+   * Unbinds an app from a context and appends a durable `AppUnbound` event
+   * (tag 75) to the event log (spec §8.4.2).
+   */
+  async contextSandboxAppUnbind(
+    contextId: string,
+    appDid: string,
+    actorDid: string,
+    timestampSecs: number,
+  ): Promise<void> {
+    try {
+      await (
+        this.#native.sandboxAppUnbind as (
+          id: string,
+          app: string,
+          did: string,
+          ts: number,
+        ) => Promise<void>
+      )(contextId, appDid, actorDid, timestampSecs);
+    } catch (err) {
+      throw mapBridgeError(err);
+    }
+  }
+
   // ───────────────────────────────────────────────────────────────────────
   // Internal — `__nativeForInternalUseOnly` is **NOT** a method or getter;
   // access routes through module-private functions below so the handle

--- a/crates/scp-ffi/common/src/error_codes.rs
+++ b/crates/scp-ffi/common/src/error_codes.rs
@@ -381,7 +381,8 @@ pub const CTX_2056: &str = "SCP-CTX-2056";
 pub const CTX_2057: &str = "SCP-CTX-2057";
 /// App sandbox bind-other error (unexpected bind failure).
 pub const CTX_2058: &str = "SCP-CTX-2058";
-/// App sandbox unbind error.
+/// App sandbox not-bound error: the `app_did` is not currently bound to this context.
+/// Returned by `app_unbind` when the was-bound precondition fails.
 pub const CTX_2059: &str = "SCP-CTX-2059";
 /// `UniFFI` relay connection error.
 pub const CTX_2060: &str = "SCP-CTX-2060";

--- a/crates/scp-ffi/common/src/error_codes.rs
+++ b/crates/scp-ffi/common/src/error_codes.rs
@@ -375,6 +375,14 @@ pub const CTX_2053: &str = "SCP-CTX-2053";
 pub const CTX_2054: &str = "SCP-CTX-2054";
 /// `UniFFI` context send error.
 pub const CTX_2055: &str = "SCP-CTX-2055";
+/// App sandbox bind-rejected error (ceiling exceeded, invalid declaration, signature failed).
+pub const CTX_2056: &str = "SCP-CTX-2056";
+/// App sandbox event-log-failed error (durable append failed during bind or unbind).
+pub const CTX_2057: &str = "SCP-CTX-2057";
+/// App sandbox bind-other error (unexpected bind failure).
+pub const CTX_2058: &str = "SCP-CTX-2058";
+/// App sandbox unbind error.
+pub const CTX_2059: &str = "SCP-CTX-2059";
 /// `UniFFI` relay connection error.
 pub const CTX_2060: &str = "SCP-CTX-2060";
 /// `UniFFI` context export error.

--- a/crates/scp-ffi/napi/src/context.rs
+++ b/crates/scp-ffi/napi/src/context.rs
@@ -5116,6 +5116,143 @@ pub(crate) fn validate_capability_declaration_on(
         .map_err(|e| NapiError::from_reason(format!("serialization failed: {e}")))
 }
 
+/// Binds an app to a context and appends an `AppBound` event to the durable
+/// event log (spec §8.4).
+///
+/// Validates the declaration against the context ceiling (looked up from
+/// `UcanContextState`) and the actor's effective (suspension-aware) role
+/// capabilities, then appends a typed `AppBound` leaf. Returns a camelCase
+/// JSON summary: `{"appDid": "...", "grantedCapabilities": [...]}`.
+///
+/// # Errors
+///
+/// Returns a `NapiError` if the declaration is invalid, capabilities are
+/// ceiling-exceeded, or the durable event log append fails.
+pub(crate) fn app_bind_on(
+    bi: &NapiBridgeInstance,
+    context_id: String,
+    declaration_json: String,
+    actor_did: String,
+    timestamp_secs: u64,
+) -> napi::Result<String> {
+    use scp_core::context::app_sandbox::{CapabilityDeclaration, SandboxError, bind_app};
+    use scp_core::context::roles::Capability;
+    use scp_core::context::{ContextHandle, ContextParams};
+
+    let decl: CapabilityDeclaration = serde_json::from_str(&declaration_json)
+        .map_err(|e| NapiError::from_reason(format!("invalid declaration JSON: {e}")))?;
+
+    // Extract ceiling and effective (suspension-aware) role capabilities from
+    // per-context UCAN state without holding the DashMap lock across an await.
+    let (ceiling_caps, role_caps): (Vec<Capability>, Vec<Capability>) =
+        crate::runtime::with_context(bi, &context_id, |st| {
+            let ceiling: Vec<Capability> = st
+                .core
+                .ceiling_strings
+                .iter()
+                .filter_map(Capability::new)
+                .collect();
+            let role: Vec<Capability> = ceiling
+                .iter()
+                .filter(|cap| st.role_state.member_has_capability(&actor_did, cap))
+                .cloned()
+                .collect();
+            Ok((ceiling, role))
+        })
+        .map_err(NapiError::from)?;
+
+    let handle = ContextHandle::new(context_id.clone(), ContextParams::default());
+    let event_log = crate::runtime::event_log_provider_from_existing_repo(bi);
+
+    let scoped = crate::runtime()
+        .block_on(async move {
+            bind_app(
+                &decl,
+                &ceiling_caps,
+                &role_caps,
+                handle,
+                event_log.as_ref(),
+                &actor_did,
+                timestamp_secs,
+            )
+            .await
+        })
+        .map_err(|e| match &e {
+            SandboxError::CeilingExceeded { .. }
+            | SandboxError::InvalidDeclaration(_)
+            | SandboxError::SignatureVerificationFailed => {
+                NapiError::from_reason(format!("[SCP-CTX-2055] bind_app rejected: {e}"))
+            }
+            SandboxError::EventLogFailed(_) => {
+                NapiError::from_reason(format!("[SCP-CTX-2056] event log append failed: {e}"))
+            }
+            _ => NapiError::from_reason(format!("[SCP-CTX-2057] bind_app failed: {e}")),
+        })?;
+
+    let app_did = scoped.app_did().to_string();
+    let granted: Vec<String> = scoped
+        .allowed_capabilities()
+        .iter()
+        .map(std::string::ToString::to_string)
+        .collect();
+
+    // Store the scoped handle in UCAN state for capability enforcement.
+    crate::runtime::with_context(bi, &context_id, |st| {
+        st.bound_apps.insert(app_did.clone(), scoped);
+        Ok(())
+    })
+    .map_err(NapiError::from)?;
+
+    serde_json::to_string(&serde_json::json!({
+        "appDid": app_did,
+        "grantedCapabilities": granted,
+    }))
+    .map_err(|e| NapiError::from_reason(format!("serialization failed: {e}")))
+}
+
+/// Unbinds an app from a context and appends an `AppUnbound` event to the
+/// durable event log (spec §8.4).
+///
+/// # Errors
+///
+/// Returns a `NapiError` if the context is not found or if the durable event
+/// log append fails.
+pub(crate) fn app_unbind_on(
+    bi: &NapiBridgeInstance,
+    context_id: String,
+    app_did: String,
+    actor_did: String,
+    timestamp_secs: u64,
+) -> napi::Result<()> {
+    use scp_core::context::app_sandbox::unbind_app;
+
+    let event_log = crate::runtime::event_log_provider_from_existing_repo(bi);
+    let context_id_c = context_id.clone();
+    let app_did_c = app_did.clone();
+
+    crate::runtime()
+        .block_on(async move {
+            unbind_app(
+                &context_id_c,
+                &app_did_c,
+                event_log.as_ref(),
+                &actor_did,
+                timestamp_secs,
+            )
+            .await
+        })
+        .map_err(|e| NapiError::from_reason(format!("[SCP-CTX-2058] unbind_app failed: {e}")))?;
+
+    // Remove the stored scoped handle.
+    crate::runtime::with_context(bi, &context_id, |st| {
+        st.bound_apps.remove(&app_did);
+        Ok(())
+    })
+    .map_err(NapiError::from)?;
+
+    Ok(())
+}
+
 /// Checks whether a given capability is allowed for an app binding.
 #[napi]
 #[must_use]

--- a/crates/scp-ffi/napi/src/context.rs
+++ b/crates/scp-ffi/napi/src/context.rs
@@ -5139,6 +5139,8 @@ pub(crate) fn app_bind_on(
     use scp_core::context::roles::Capability;
     use scp_core::context::{ContextHandle, ContextParams};
 
+    validate_did(&actor_did).map_err(|e| napi::Error::from(ScpNapiError::from(e)))?;
+
     let decl: CapabilityDeclaration = serde_json::from_str(&declaration_json)
         .map_err(|e| NapiError::from_reason(format!("invalid declaration JSON: {e}")))?;
 
@@ -5181,12 +5183,13 @@ pub(crate) fn app_bind_on(
             SandboxError::CeilingExceeded { .. }
             | SandboxError::InvalidDeclaration(_)
             | SandboxError::SignatureVerificationFailed => {
-                NapiError::from_reason(format!("[SCP-CTX-2055] bind_app rejected: {e}"))
+                NapiError::from_reason(format!("[{}] bind_app rejected: {e}", codes::CTX_2056))
             }
-            SandboxError::EventLogFailed(_) => {
-                NapiError::from_reason(format!("[SCP-CTX-2056] event log append failed: {e}"))
-            }
-            _ => NapiError::from_reason(format!("[SCP-CTX-2057] bind_app failed: {e}")),
+            SandboxError::EventLogFailed(_) => NapiError::from_reason(format!(
+                "[{}] event log append failed: {e}",
+                codes::CTX_2057
+            )),
+            _ => NapiError::from_reason(format!("[{}] bind_app failed: {e}", codes::CTX_2058)),
         })?;
 
     let app_did = scoped.app_did().to_string();
@@ -5226,6 +5229,22 @@ pub(crate) fn app_unbind_on(
 ) -> napi::Result<()> {
     use scp_core::context::app_sandbox::unbind_app;
 
+    validate_did(&actor_did).map_err(|e| napi::Error::from(ScpNapiError::from(e)))?;
+    validate_did(&app_did).map_err(|e| napi::Error::from(ScpNapiError::from(e)))?;
+
+    let is_bound = crate::runtime::with_context(bi, &context_id, |st| {
+        Ok(st.bound_apps.contains_key(&app_did))
+    })
+    .map_err(NapiError::from)?;
+    if !is_bound {
+        return Err(NapiError::from_reason(format!(
+            "[{}] app '{}' is not currently bound to context '{}'",
+            codes::CTX_2059,
+            app_did,
+            context_id
+        )));
+    }
+
     let event_log = crate::runtime::event_log_provider_from_existing_repo(bi);
     let context_id_c = context_id.clone();
     let app_did_c = app_did.clone();
@@ -5241,7 +5260,9 @@ pub(crate) fn app_unbind_on(
             )
             .await
         })
-        .map_err(|e| NapiError::from_reason(format!("[SCP-CTX-2058] unbind_app failed: {e}")))?;
+        .map_err(|e| {
+            NapiError::from_reason(format!("[{}] unbind_app failed: {e}", codes::CTX_2059))
+        })?;
 
     // Remove the stored scoped handle.
     crate::runtime::with_context(bi, &context_id, |st| {

--- a/crates/scp-ffi/napi/src/context.rs
+++ b/crates/scp-ffi/napi/src/context.rs
@@ -5099,16 +5099,16 @@ pub(crate) fn validate_capability_declaration_on(
                 .collect();
             serde_json::json!({
                 "valid": true,
-                "grantedCapabilities": granted,
+                "granted_capabilities": granted,
                 "error": null,
-                "appDid": decl.app_id.to_string()
+                "app_did": decl.app_id.to_string()
             })
         }
         Err(e) => serde_json::json!({
             "valid": false,
-            "grantedCapabilities": [],
+            "granted_capabilities": [],
             "error": e.to_string(),
-            "appDid": decl.app_id.to_string()
+            "app_did": decl.app_id.to_string()
         }),
     };
 
@@ -5121,8 +5121,8 @@ pub(crate) fn validate_capability_declaration_on(
 ///
 /// Validates the declaration against the context ceiling (looked up from
 /// `UcanContextState`) and the actor's effective (suspension-aware) role
-/// capabilities, then appends a typed `AppBound` leaf. Returns a camelCase
-/// JSON summary: `{"appDid": "...", "grantedCapabilities": [...]}`.
+/// capabilities, then appends a typed `AppBound` leaf. Returns a `snake_case`
+/// JSON summary: `{"app_did": "...", "granted_capabilities": [...]}`.
 ///
 /// # Errors
 ///
@@ -5139,6 +5139,8 @@ pub(crate) fn app_bind_on(
     use scp_core::context::roles::Capability;
     use scp_core::context::{ContextHandle, ContextParams};
 
+    scp_ffi_common::validate::validate_context_id(&context_id)
+        .map_err(|e| napi::Error::from(ScpNapiError::from(e)))?;
     validate_did(&actor_did).map_err(|e| napi::Error::from(ScpNapiError::from(e)))?;
 
     let decl: CapabilityDeclaration = serde_json::from_str(&declaration_json)
@@ -5192,7 +5194,7 @@ pub(crate) fn app_bind_on(
             _ => NapiError::from_reason(format!("[{}] bind_app failed: {e}", codes::CTX_2058)),
         })?;
 
-    let app_did = scoped.app_did().to_string();
+    let app_did = scoped.app_did().trim().to_string();
     let granted: Vec<String> = scoped
         .allowed_capabilities()
         .iter()
@@ -5207,8 +5209,8 @@ pub(crate) fn app_bind_on(
     .map_err(NapiError::from)?;
 
     serde_json::to_string(&serde_json::json!({
-        "appDid": app_did,
-        "grantedCapabilities": granted,
+        "app_did": app_did,
+        "granted_capabilities": granted,
     }))
     .map_err(|e| NapiError::from_reason(format!("serialization failed: {e}")))
 }
@@ -5229,6 +5231,8 @@ pub(crate) fn app_unbind_on(
 ) -> napi::Result<()> {
     use scp_core::context::app_sandbox::unbind_app;
 
+    scp_ffi_common::validate::validate_context_id(&context_id)
+        .map_err(|e| napi::Error::from(ScpNapiError::from(e)))?;
     validate_did(&actor_did).map_err(|e| napi::Error::from(ScpNapiError::from(e)))?;
     validate_did(&app_did).map_err(|e| napi::Error::from(ScpNapiError::from(e)))?;
 
@@ -5261,7 +5265,16 @@ pub(crate) fn app_unbind_on(
             .await
         })
         .map_err(|e| {
-            NapiError::from_reason(format!("[{}] unbind_app failed: {e}", codes::CTX_2059))
+            use scp_core::context::app_sandbox::SandboxError;
+            match &e {
+                SandboxError::EventLogFailed(_) => NapiError::from_reason(format!(
+                    "[{}] event log append failed: {e}",
+                    codes::CTX_2057
+                )),
+                _ => {
+                    NapiError::from_reason(format!("[{}] unbind_app failed: {e}", codes::CTX_2059))
+                }
+            }
         })?;
 
     // Remove the stored scoped handle.

--- a/crates/scp-ffi/napi/src/context.rs
+++ b/crates/scp-ffi/napi/src/context.rs
@@ -5165,8 +5165,24 @@ pub(crate) fn app_bind_on(
         })
         .map_err(NapiError::from)?;
 
+    // Use the supervisor's already-initialised event-log provider.
+    // A fresh provider built from `event_log_provider_from_existing_repo`
+    // has an empty in-memory `logs` map and every `append_event` call
+    // fails with CTX-2057 ("no event log for context"). The supervisor's
+    // provider has its map populated by `init_event_log` during
+    // context_create / context_join / context_restore.
+    let event_log: std::sync::Arc<dyn scp_core::context::builder::ContextEventLogProvider> =
+        crate::runtime::supervisor(bi)?
+            .event_log_provider_arc()
+            .ok_or_else(|| {
+                NapiError::from_reason(format!(
+                    "[{}] event-log provider not initialised — \
+                     call context_create or context_join first",
+                    codes::CTX_2057
+                ))
+            })?;
+
     let handle = ContextHandle::new(context_id.clone(), ContextParams::default());
-    let event_log = crate::runtime::event_log_provider_from_existing_repo(bi);
 
     let scoped = crate::runtime()
         .block_on(async move {
@@ -5236,22 +5252,38 @@ pub(crate) fn app_unbind_on(
     validate_did(&actor_did).map_err(|e| napi::Error::from(ScpNapiError::from(e)))?;
     validate_did(&app_did).map_err(|e| napi::Error::from(ScpNapiError::from(e)))?;
 
+    // Trim app_did for lookup — bind stores the trimmed key; an untrimmed
+    // lookup always fails even when the app is bound (parity with UniFFI).
+    let app_did_trimmed = app_did.trim().to_owned();
+
     let is_bound = crate::runtime::with_context(bi, &context_id, |st| {
-        Ok(st.bound_apps.contains_key(&app_did))
+        Ok(st.bound_apps.contains_key(&app_did_trimmed))
     })
     .map_err(NapiError::from)?;
     if !is_bound {
         return Err(NapiError::from_reason(format!(
             "[{}] app '{}' is not currently bound to context '{}'",
             codes::CTX_2059,
-            app_did,
+            app_did_trimmed,
             context_id
         )));
     }
 
-    let event_log = crate::runtime::event_log_provider_from_existing_repo(bi);
+    // Use the supervisor's already-initialised event-log provider (same
+    // reason as app_bind_on — a fresh provider has an empty log map).
+    let event_log: std::sync::Arc<dyn scp_core::context::builder::ContextEventLogProvider> =
+        crate::runtime::supervisor(bi)?
+            .event_log_provider_arc()
+            .ok_or_else(|| {
+                NapiError::from_reason(format!(
+                    "[{}] event-log provider not initialised — \
+                     call context_create or context_join first",
+                    codes::CTX_2057
+                ))
+            })?;
+
     let context_id_c = context_id.clone();
-    let app_did_c = app_did.clone();
+    let app_did_c = app_did_trimmed.clone();
 
     crate::runtime()
         .block_on(async move {
@@ -5277,9 +5309,10 @@ pub(crate) fn app_unbind_on(
             }
         })?;
 
-    // Remove the stored scoped handle.
+    // Remove the stored scoped handle (using trimmed key — matches how
+    // bind stored it, fixing parity divergence with UniFFI).
     crate::runtime::with_context(bi, &context_id, |st| {
-        st.bound_apps.remove(&app_did);
+        st.bound_apps.remove(&app_did_trimmed);
         Ok(())
     })
     .map_err(NapiError::from)?;

--- a/crates/scp-ffi/napi/src/context.rs
+++ b/crates/scp-ffi/napi/src/context.rs
@@ -5176,8 +5176,7 @@ pub(crate) fn app_bind_on(
             .event_log_provider_arc()
             .ok_or_else(|| {
                 NapiError::from_reason(format!(
-                    "[{}] event-log provider not initialised — \
-                     call context_create or context_join first",
+                    "[{}] event-log provider not configured on this supervisor instance",
                     codes::CTX_2057
                 ))
             })?;
@@ -5276,8 +5275,7 @@ pub(crate) fn app_unbind_on(
             .event_log_provider_arc()
             .ok_or_else(|| {
                 NapiError::from_reason(format!(
-                    "[{}] event-log provider not initialised — \
-                     call context_create or context_join first",
+                    "[{}] event-log provider not configured on this supervisor instance",
                     codes::CTX_2057
                 ))
             })?;

--- a/crates/scp-ffi/napi/src/runtime.rs
+++ b/crates/scp-ffi/napi/src/runtime.rs
@@ -32,6 +32,7 @@ use std::sync::{Arc, OnceLock};
 
 use dashmap::DashMap;
 use scp_clock::SystemClock;
+use scp_core::context::app_sandbox::ScopedHandle;
 use scp_core::context::builder::{ContextEventLogProvider, ContextTransportProvider};
 use scp_core::context::outlets::{OutletRegistry, SessionStore};
 use scp_core::context::persistence::ContextPersistence;
@@ -1298,7 +1299,7 @@ pub(crate) fn build_event_log_provider() -> (
 /// entries unreadable. When the bridge is SQLite-backed, this returns an
 /// event log provider that writes into the same `SQLCipher` database as
 /// context snapshots.
-fn event_log_provider_from_existing_repo(
+pub(crate) fn event_log_provider_from_existing_repo(
     bi: &NapiBridgeInstance,
 ) -> Box<dyn ContextEventLogProvider> {
     bi.protocol_repository.event_log_provider()
@@ -1614,6 +1615,11 @@ pub struct UcanContextState {
     pub outlet_handlers: HashMap<String, OutletHandler>,
     /// Session store for stateful outlet sessions (spec section 6.2.1).
     pub session_store: SessionStore,
+    /// App binding registry for this context (spec §8.4).
+    ///
+    /// Maps `app_did` → `ScopedHandle` for every app bound to this context.
+    /// Populated by `app_bind_on` and cleared by `app_unbind_on`.
+    pub bound_apps: HashMap<String, ScopedHandle>,
 }
 
 /// Returns a reference to the given bridge instance's UCAN state registry.
@@ -1715,6 +1721,7 @@ fn build_ucan_context_state(
         outlet_registry: OutletRegistry::new(),
         outlet_handlers: HashMap::new(),
         session_store: SessionStore::new(),
+        bound_apps: HashMap::new(),
     })
 }
 
@@ -2012,6 +2019,7 @@ pub fn register_test_context(bi: &NapiBridgeInstance, context_id: &str, creator_
         outlet_registry: OutletRegistry::new(),
         outlet_handlers: HashMap::new(),
         session_store: SessionStore::new(),
+        bound_apps: HashMap::new(),
     };
 
     map.entry(context_id.to_owned()).or_insert(state);

--- a/crates/scp-ffi/napi/src/scp.rs
+++ b/crates/scp-ffi/napi/src/scp.rs
@@ -2771,8 +2771,8 @@ impl Scp {
     /// durable event log (spec §8.4).
     ///
     /// Returns a camelCase JSON summary on success.
-    #[napi(js_name = "sandboxAppBind")]
-    pub fn sandbox_app_bind(
+    #[napi(js_name = "appBind")]
+    pub fn app_bind(
         &self,
         context_id: String,
         declaration_json: String,
@@ -2788,8 +2788,8 @@ impl Scp {
 
     /// Unbinds an app from a context and appends an `AppUnbound` event to
     /// the durable event log (spec §8.4).
-    #[napi(js_name = "sandboxAppUnbind")]
-    pub fn sandbox_app_unbind(
+    #[napi(js_name = "appUnbind")]
+    pub fn app_unbind(
         &self,
         context_id: String,
         app_did: String,

--- a/crates/scp-ffi/napi/src/scp.rs
+++ b/crates/scp-ffi/napi/src/scp.rs
@@ -2767,6 +2767,42 @@ impl Scp {
     // `SCP.checkScopedCapability` routes through `nativeFreeFn(...)` to
     // reach the module-level export.
 
+    /// Binds an app to a context and appends an `AppBound` event to the
+    /// durable event log (spec §8.4).
+    ///
+    /// Returns a camelCase JSON summary on success.
+    #[napi(js_name = "sandboxAppBind")]
+    pub fn sandbox_app_bind(
+        &self,
+        context_id: String,
+        declaration_json: String,
+        actor_did: String,
+        timestamp_secs: f64,
+    ) -> napi::Result<String> {
+        // `timestamp_secs` arrives as a JS `number` (f64). Unix timestamps fit
+        // exactly in f64 (≤ 2^31 seconds until 2038; < 2^53 until year 4000+).
+        #[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
+        let ts = timestamp_secs as u64;
+        crate::context::app_bind_on(&self.inner, context_id, declaration_json, actor_did, ts)
+    }
+
+    /// Unbinds an app from a context and appends an `AppUnbound` event to
+    /// the durable event log (spec §8.4).
+    #[napi(js_name = "sandboxAppUnbind")]
+    pub fn sandbox_app_unbind(
+        &self,
+        context_id: String,
+        app_did: String,
+        actor_did: String,
+        timestamp_secs: f64,
+    ) -> napi::Result<()> {
+        // `timestamp_secs` arrives as a JS `number` (f64). Unix timestamps fit
+        // exactly in f64 (≤ 2^31 seconds until 2038; < 2^53 until year 4000+).
+        #[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
+        let ts = timestamp_secs as u64;
+        crate::context::app_unbind_on(&self.inner, context_id, app_did, actor_did, ts)
+    }
+
     /// Per-instance equivalent of the free-function `evaluate_invitation`.
     #[napi(js_name = "evaluateInvitation")]
     pub fn evaluate_invitation(

--- a/crates/scp-ffi/src/context.rs
+++ b/crates/scp-ffi/src/context.rs
@@ -6198,7 +6198,7 @@ impl crate::scp::PyScp {
     /// `RuntimeError` if validation fails (ceiling exceeded, signature invalid)
     /// or if the durable event log append fails.
     #[pyo3(signature = (context_id, declaration_json, actor_did, timestamp_secs))]
-    pub fn sandbox_app_bind(
+    pub fn app_bind(
         &self,
         context_id: &str,
         declaration_json: &str,
@@ -6211,6 +6211,8 @@ impl crate::scp::PyScp {
 
         let bi = &*self.inner;
 
+        validate::validate_context_id(context_id)
+            .map_err(|e| PyValueError::new_err(e.to_string()))?;
         validate::validate_did(actor_did).map_err(|e| PyValueError::new_err(e.to_string()))?;
 
         let decl: CapabilityDeclaration = serde_json::from_str(declaration_json)
@@ -6267,7 +6269,7 @@ impl crate::scp::PyScp {
                 _ => PyRuntimeError::new_err(format!("[{}] bind_app failed: {e}", codes::CTX_2058)),
             })?;
 
-        let app_did = scoped.app_did().to_string();
+        let app_did = scoped.app_did().trim().to_string();
         let granted: Vec<String> = scoped
             .allowed_capabilities()
             .iter()
@@ -6296,7 +6298,7 @@ impl crate::scp::PyScp {
     /// Returns `RuntimeError` if the context is not found or if the durable
     /// event log append fails.
     #[pyo3(signature = (context_id, app_did, actor_did, timestamp_secs))]
-    pub fn sandbox_app_unbind(
+    pub fn app_unbind(
         &self,
         context_id: &str,
         app_did: &str,
@@ -6307,6 +6309,8 @@ impl crate::scp::PyScp {
 
         let bi = &*self.inner;
 
+        validate::validate_context_id(context_id)
+            .map_err(|e| PyValueError::new_err(e.to_string()))?;
         validate::validate_did(actor_did).map_err(|e| PyValueError::new_err(e.to_string()))?;
         validate::validate_did(app_did).map_err(|e| PyValueError::new_err(e.to_string()))?;
 
@@ -6340,7 +6344,16 @@ impl crate::scp::PyScp {
             .await
         })
         .map_err(|e| {
-            PyRuntimeError::new_err(format!("[{}] unbind_app failed: {e}", codes::CTX_2059))
+            use scp_core::context::app_sandbox::SandboxError;
+            match &e {
+                SandboxError::EventLogFailed(_) => PyRuntimeError::new_err(format!(
+                    "[{}] event log append failed: {e}",
+                    codes::CTX_2057
+                )),
+                _ => {
+                    PyRuntimeError::new_err(format!("[{}] unbind_app failed: {e}", codes::CTX_2059))
+                }
+            }
         })?;
 
         // Remove the stored scoped handle.

--- a/crates/scp-ffi/src/context.rs
+++ b/crates/scp-ffi/src/context.rs
@@ -6250,8 +6250,7 @@ impl crate::scp::PyScp {
                 .event_log_provider_arc()
                 .ok_or_else(|| {
                     PyRuntimeError::new_err(format!(
-                        "[{}] event-log provider not initialised — \
-                         call context_create or context_join first",
+                        "[{}] event-log provider not configured on this supervisor instance",
                         codes::CTX_2057
                     ))
                 })?;
@@ -6356,8 +6355,7 @@ impl crate::scp::PyScp {
                 .event_log_provider_arc()
                 .ok_or_else(|| {
                     PyRuntimeError::new_err(format!(
-                        "[{}] event-log provider not initialised — \
-                         call context_create or context_join first",
+                        "[{}] event-log provider not configured on this supervisor instance",
                         codes::CTX_2057
                     ))
                 })?;

--- a/crates/scp-ffi/src/context.rs
+++ b/crates/scp-ffi/src/context.rs
@@ -6238,8 +6238,25 @@ impl crate::scp::PyScp {
             })
             .map_err(|e| PyRuntimeError::new_err(e.to_string()))?;
 
+        // Use the supervisor's already-initialised event-log provider.
+        // A fresh `MerkleEventLogProvider` (from `build_event_log_provider`)
+        // would have an empty in-memory `logs` map and every `append_event`
+        // would fail with CTX-2057 ("no event log for context"). The
+        // supervisor's provider has its map populated by `init_event_log`
+        // during context_create / context_join / context_restore.
+        let event_log: std::sync::Arc<dyn scp_core::context::builder::ContextEventLogProvider> =
+            crate::runtime::supervisor(bi)
+                .map_err(|e| PyRuntimeError::new_err(e.to_string()))?
+                .event_log_provider_arc()
+                .ok_or_else(|| {
+                    PyRuntimeError::new_err(format!(
+                        "[{}] event-log provider not initialised — \
+                         call context_create or context_join first",
+                        codes::CTX_2057
+                    ))
+                })?;
+
         let handle = ContextHandle::new(context_id.to_owned(), ContextParams::default());
-        let event_log = crate::runtime::build_event_log_provider(bi);
         let actor_did_owned = actor_did.to_owned();
 
         let rt = crate::runtime()?;
@@ -6314,22 +6331,39 @@ impl crate::scp::PyScp {
         validate::validate_did(actor_did).map_err(|e| PyValueError::new_err(e.to_string()))?;
         validate::validate_did(app_did).map_err(|e| PyValueError::new_err(e.to_string()))?;
 
+        // Trim app_did for lookup — bind stores the trimmed key; an untrimmed
+        // lookup always fails even when the app is bound (parity with UniFFI).
+        let app_did_trimmed = app_did.trim();
+
         let is_bound = crate::runtime::with_ffi_state(bi, context_id, |st| {
-            Ok(st.bound_apps.contains_key(app_did))
+            Ok(st.bound_apps.contains_key(app_did_trimmed))
         })
         .map_err(|e| PyRuntimeError::new_err(e.to_string()))?;
         if !is_bound {
             return Err(PyRuntimeError::new_err(format!(
                 "[{}] app '{}' is not currently bound to context '{}'",
                 codes::CTX_2059,
-                app_did,
+                app_did_trimmed,
                 context_id
             )));
         }
 
-        let event_log = crate::runtime::build_event_log_provider(bi);
+        // Use the supervisor's already-initialised event-log provider (same
+        // reason as app_bind — a fresh provider has an empty log map).
+        let event_log: std::sync::Arc<dyn scp_core::context::builder::ContextEventLogProvider> =
+            crate::runtime::supervisor(bi)
+                .map_err(|e| PyRuntimeError::new_err(e.to_string()))?
+                .event_log_provider_arc()
+                .ok_or_else(|| {
+                    PyRuntimeError::new_err(format!(
+                        "[{}] event-log provider not initialised — \
+                         call context_create or context_join first",
+                        codes::CTX_2057
+                    ))
+                })?;
+
         let context_id_owned = context_id.to_owned();
-        let app_did_owned = app_did.to_owned();
+        let app_did_owned = app_did_trimmed.to_owned();
         let actor_did_owned = actor_did.to_owned();
 
         let rt = crate::runtime()?;
@@ -6356,9 +6390,10 @@ impl crate::scp::PyScp {
             }
         })?;
 
-        // Remove the stored scoped handle.
+        // Remove the stored scoped handle (using trimmed key — matches how
+        // bind stored it, fixing parity divergence with UniFFI).
         crate::runtime::with_ffi_state(bi, context_id, |st| {
-            st.bound_apps.remove(app_did);
+            st.bound_apps.remove(app_did_trimmed);
             Ok(())
         })
         .map_err(|e| PyRuntimeError::new_err(e.to_string()))?;

--- a/crates/scp-ffi/src/context.rs
+++ b/crates/scp-ffi/src/context.rs
@@ -6179,6 +6179,157 @@ impl crate::scp::PyScp {
                 })
         })
     }
+
+    // -----------------------------------------------------------------------
+    // App sandboxing — durable bind / unbind (spec §8.4)
+    // -----------------------------------------------------------------------
+
+    /// Binds an app to a context and appends an `AppBound` event to the
+    /// durable event log (spec §8.4).
+    ///
+    /// Validates the capability declaration against the context ceiling and the
+    /// actor's effective role capabilities (suspension-aware), then appends a
+    /// typed `AppBound` event. Returns a JSON summary on success:
+    /// `{"app_did": "...", "granted_capabilities": [...]}`.
+    ///
+    /// # Errors
+    ///
+    /// Returns `ValueError` for an invalid declaration or capability; returns
+    /// `RuntimeError` if validation fails (ceiling exceeded, signature invalid)
+    /// or if the durable event log append fails.
+    #[pyo3(signature = (context_id, declaration_json, actor_did, timestamp_secs))]
+    pub fn sandbox_app_bind(
+        &self,
+        context_id: &str,
+        declaration_json: &str,
+        actor_did: &str,
+        timestamp_secs: u64,
+    ) -> PyResult<String> {
+        use scp_core::context::app_sandbox::{CapabilityDeclaration, SandboxError, bind_app};
+        use scp_core::context::roles::Capability;
+        use scp_core::context::{ContextHandle, ContextParams};
+
+        let bi = &*self.inner;
+
+        let decl: CapabilityDeclaration = serde_json::from_str(declaration_json)
+            .map_err(|e| PyValueError::new_err(format!("invalid declaration JSON: {e}")))?;
+
+        // Extract the ceiling and effective role capabilities from FFI state.
+        // Suspensions are applied via member_has_capability (suspension-aware).
+        let (ceiling_caps, role_caps): (Vec<Capability>, Vec<Capability>) =
+            crate::runtime::with_ffi_state(bi, context_id, |st| {
+                let ceiling: Vec<Capability> = st
+                    .ceiling_strings
+                    .iter()
+                    .filter_map(Capability::new)
+                    .collect();
+                // Effective caps = capabilities the actor holds in the ceiling universe,
+                // filtered suspension-aware via member_has_capability.
+                let role: Vec<Capability> = ceiling
+                    .iter()
+                    .filter(|cap| st.role_state.member_has_capability(actor_did, cap))
+                    .cloned()
+                    .collect();
+                Ok((ceiling, role))
+            })
+            .map_err(|e| PyRuntimeError::new_err(e.to_string()))?;
+
+        let handle = ContextHandle::new(context_id.to_owned(), ContextParams::default());
+        let event_log = crate::runtime::build_event_log_provider(bi);
+        let actor_did_owned = actor_did.to_owned();
+
+        let rt = crate::runtime()?;
+        let scoped = rt
+            .block_on(async move {
+                bind_app(
+                    &decl,
+                    &ceiling_caps,
+                    &role_caps,
+                    handle,
+                    event_log.as_ref(),
+                    &actor_did_owned,
+                    timestamp_secs,
+                )
+                .await
+            })
+            .map_err(|e| match &e {
+                SandboxError::CeilingExceeded { .. }
+                | SandboxError::InvalidDeclaration(_)
+                | SandboxError::SignatureVerificationFailed => {
+                    PyRuntimeError::new_err(format!("[SCP-CTX-2055] bind_app rejected: {e}"))
+                }
+                SandboxError::EventLogFailed(_) => {
+                    PyRuntimeError::new_err(format!("[SCP-CTX-2056] event log append failed: {e}"))
+                }
+                _ => PyRuntimeError::new_err(format!("[SCP-CTX-2057] bind_app failed: {e}")),
+            })?;
+
+        let app_did = scoped.app_did().to_string();
+        let granted: Vec<String> = scoped
+            .allowed_capabilities()
+            .iter()
+            .map(std::string::ToString::to_string)
+            .collect();
+
+        // Store the scoped handle keyed by app_did for capability enforcement.
+        crate::runtime::with_ffi_state(bi, context_id, |st| {
+            st.bound_apps.insert(app_did.clone(), scoped);
+            Ok(())
+        })
+        .map_err(|e| PyRuntimeError::new_err(e.to_string()))?;
+
+        serde_json::to_string(&serde_json::json!({
+            "app_did": app_did,
+            "granted_capabilities": granted,
+        }))
+        .map_err(|e| PyRuntimeError::new_err(format!("serialization failed: {e}")))
+    }
+
+    /// Unbinds an app from a context and appends an `AppUnbound` event to
+    /// the durable event log (spec §8.4).
+    ///
+    /// # Errors
+    ///
+    /// Returns `RuntimeError` if the context is not found or if the durable
+    /// event log append fails.
+    #[pyo3(signature = (context_id, app_did, actor_did, timestamp_secs))]
+    pub fn sandbox_app_unbind(
+        &self,
+        context_id: &str,
+        app_did: &str,
+        actor_did: &str,
+        timestamp_secs: u64,
+    ) -> PyResult<()> {
+        use scp_core::context::app_sandbox::unbind_app;
+
+        let bi = &*self.inner;
+        let event_log = crate::runtime::build_event_log_provider(bi);
+        let context_id_owned = context_id.to_owned();
+        let app_did_owned = app_did.to_owned();
+        let actor_did_owned = actor_did.to_owned();
+
+        let rt = crate::runtime()?;
+        rt.block_on(async move {
+            unbind_app(
+                &context_id_owned,
+                &app_did_owned,
+                event_log.as_ref(),
+                &actor_did_owned,
+                timestamp_secs,
+            )
+            .await
+        })
+        .map_err(|e| PyRuntimeError::new_err(format!("[SCP-CTX-2058] unbind_app failed: {e}")))?;
+
+        // Remove the stored scoped handle.
+        crate::runtime::with_ffi_state(bi, context_id, |st| {
+            st.bound_apps.remove(app_did);
+            Ok(())
+        })
+        .map_err(|e| PyRuntimeError::new_err(e.to_string()))?;
+
+        Ok(())
+    }
 }
 
 /// Registers all context bridge types and functions with the Python module.

--- a/crates/scp-ffi/src/context.rs
+++ b/crates/scp-ffi/src/context.rs
@@ -6211,6 +6211,8 @@ impl crate::scp::PyScp {
 
         let bi = &*self.inner;
 
+        validate::validate_did(actor_did).map_err(|e| PyValueError::new_err(e.to_string()))?;
+
         let decl: CapabilityDeclaration = serde_json::from_str(declaration_json)
             .map_err(|e| PyValueError::new_err(format!("invalid declaration JSON: {e}")))?;
 
@@ -6256,12 +6258,13 @@ impl crate::scp::PyScp {
                 SandboxError::CeilingExceeded { .. }
                 | SandboxError::InvalidDeclaration(_)
                 | SandboxError::SignatureVerificationFailed => {
-                    PyRuntimeError::new_err(format!("[SCP-CTX-2055] bind_app rejected: {e}"))
+                    PyRuntimeError::new_err(format!("[{}] bind_app rejected: {e}", codes::CTX_2056))
                 }
-                SandboxError::EventLogFailed(_) => {
-                    PyRuntimeError::new_err(format!("[SCP-CTX-2056] event log append failed: {e}"))
-                }
-                _ => PyRuntimeError::new_err(format!("[SCP-CTX-2057] bind_app failed: {e}")),
+                SandboxError::EventLogFailed(_) => PyRuntimeError::new_err(format!(
+                    "[{}] event log append failed: {e}",
+                    codes::CTX_2057
+                )),
+                _ => PyRuntimeError::new_err(format!("[{}] bind_app failed: {e}", codes::CTX_2058)),
             })?;
 
         let app_did = scoped.app_did().to_string();
@@ -6303,6 +6306,23 @@ impl crate::scp::PyScp {
         use scp_core::context::app_sandbox::unbind_app;
 
         let bi = &*self.inner;
+
+        validate::validate_did(actor_did).map_err(|e| PyValueError::new_err(e.to_string()))?;
+        validate::validate_did(app_did).map_err(|e| PyValueError::new_err(e.to_string()))?;
+
+        let is_bound = crate::runtime::with_ffi_state(bi, context_id, |st| {
+            Ok(st.bound_apps.contains_key(app_did))
+        })
+        .map_err(|e| PyRuntimeError::new_err(e.to_string()))?;
+        if !is_bound {
+            return Err(PyRuntimeError::new_err(format!(
+                "[{}] app '{}' is not currently bound to context '{}'",
+                codes::CTX_2059,
+                app_did,
+                context_id
+            )));
+        }
+
         let event_log = crate::runtime::build_event_log_provider(bi);
         let context_id_owned = context_id.to_owned();
         let app_did_owned = app_did.to_owned();
@@ -6319,7 +6339,9 @@ impl crate::scp::PyScp {
             )
             .await
         })
-        .map_err(|e| PyRuntimeError::new_err(format!("[SCP-CTX-2058] unbind_app failed: {e}")))?;
+        .map_err(|e| {
+            PyRuntimeError::new_err(format!("[{}] unbind_app failed: {e}", codes::CTX_2059))
+        })?;
 
         // Remove the stored scoped handle.
         crate::runtime::with_ffi_state(bi, context_id, |st| {

--- a/crates/scp-ffi/src/runtime.rs
+++ b/crates/scp-ffi/src/runtime.rs
@@ -58,6 +58,7 @@ use std::collections::{HashMap, HashSet};
 use std::sync::{Arc, OnceLock, RwLock};
 
 use dashmap::DashMap;
+use scp_core::context::app_sandbox::ScopedHandle;
 use scp_core::context::builder::{ContextEventLogProvider, ContextTransportProvider};
 use scp_core::context::outlets::OutletRegistry;
 use scp_core::context::persistence::ContextPersistence;
@@ -1513,6 +1514,11 @@ pub struct FfiBridgeState {
     /// Stores active outlet sessions keyed by session ID. Sessions are created
     /// via `py_outlet_session_create` and cleaned up on context close.
     pub session_store: scp_core::context::outlets::SessionStore,
+    /// App binding registry for this context (spec §8.4).
+    ///
+    /// Maps `app_did` → `ScopedHandle` for every app bound to this context.
+    /// Populated by `py_app_bind` and cleared by `py_app_unbind`.
+    pub bound_apps: HashMap<String, ScopedHandle>,
 }
 
 /// Buffer capacity for the receive channel (SCP-216, sketch.md §receive).
@@ -1618,6 +1624,7 @@ pub fn register_ffi_state(
                 message_tx: None,
                 message_rx: None,
                 session_store: scp_core::context::outlets::SessionStore::new(),
+                bound_apps: HashMap::new(),
             };
 
             vacant.insert(state);

--- a/crates/scp-ffi/uniffi/src/bridge.rs
+++ b/crates/scp-ffi/uniffi/src/bridge.rs
@@ -15798,7 +15798,7 @@ impl Scp {
     ///
     /// Routes through `&*self.inner`. Rejects any `ContextHandle` whose
     /// `instance_id` does not match this `SCP`'s.
-    pub async fn sandbox_app_bind(
+    pub async fn app_bind(
         &self,
         handle: Arc<ContextHandle>,
         declaration_json: String,
@@ -15906,7 +15906,7 @@ impl Scp {
                     }
                 })?;
 
-                let app_did = scoped.app_did().to_string();
+                let app_did = scoped.app_did().trim().to_string();
                 let granted: Vec<String> = scoped
                     .allowed_capabilities()
                     .iter()
@@ -15939,12 +15939,12 @@ impl Scp {
     /// a durable `AppUnbound` event (tag 75) to the context event log.
     ///
     /// Removes the binding from the bridge instance's `bound_apps_registry`.
-    /// Returns `ScpError::Context` (SCP-CTX-2030) when the event log append
+    /// Returns `ScpError::Context` (`SCP-CTX-2057`) when the event log append
     /// fails — silent app detachment is not possible (spec §8.4).
     ///
     /// Routes through `&*self.inner`. Rejects any `ContextHandle` whose
     /// `instance_id` does not match this `SCP`'s.
-    pub async fn sandbox_app_unbind(
+    pub async fn app_unbind(
         &self,
         handle: Arc<ContextHandle>,
         app_did: String,
@@ -15989,9 +15989,16 @@ impl Scp {
                     timestamp_secs,
                 )
                 .await
-                .map_err(|e| ScpError::Context {
-                    msg: e.to_string(),
-                    code: codes::CTX_2059.to_owned(),
+                .map_err(|e| {
+                    use scp_core::context::app_sandbox::SandboxError;
+                    let code = match &e {
+                        SandboxError::EventLogFailed(_) => codes::CTX_2057,
+                        _ => codes::CTX_2059,
+                    };
+                    ScpError::Context {
+                        msg: e.to_string(),
+                        code: code.to_owned(),
+                    }
                 })?;
 
                 // Remove the binding from the per-context registry.

--- a/crates/scp-ffi/uniffi/src/bridge.rs
+++ b/crates/scp-ffi/uniffi/src/bridge.rs
@@ -15895,8 +15895,7 @@ impl Scp {
                     })?
                     .event_log_provider_arc()
                     .ok_or_else(|| ScpError::Context {
-                        msg: "event-log provider not initialised — \
-                              call context_create or context_join first"
+                        msg: "event-log provider not configured on this supervisor instance"
                             .to_owned(),
                         code: codes::CTX_2057.to_owned(),
                     })?;
@@ -16013,8 +16012,7 @@ impl Scp {
                     })?
                     .event_log_provider_arc()
                     .ok_or_else(|| ScpError::Context {
-                        msg: "event-log provider not initialised — \
-                              call context_create or context_join first"
+                        msg: "event-log provider not configured on this supervisor instance"
                             .to_owned(),
                         code: codes::CTX_2057.to_owned(),
                     })?;

--- a/crates/scp-ffi/uniffi/src/bridge.rs
+++ b/crates/scp-ffi/uniffi/src/bridge.rs
@@ -10974,6 +10974,9 @@ impl Scp {
                 // Deregister the context handle from the MCP lookup registry.
                 deregister_context_handle(&bi, &handle.context_id);
 
+                // Clean up per-context app-binding registry on leave.
+                bi.bound_apps_registry.remove(&handle.context_id);
+
                 Ok(())
             })
             .await
@@ -11080,6 +11083,9 @@ impl Scp {
                 // Clean up per-context bridge connector state and economy state.
                 bi.core.remove_bridge_state(&handle.context_id);
                 bi.core.remove_economy_state(&handle.context_id);
+
+                // Clean up per-context app-binding registry.
+                bi.bound_apps_registry.remove(&handle.context_id);
 
                 // Deregister the context handle from the MCP lookup registry.
                 deregister_context_handle(&bi, &handle.context_id);
@@ -15807,7 +15813,9 @@ impl Scp {
         runtime()
             .spawn(async move {
                 use scp_core::context::actor::commands::QueriesCommand;
-                use scp_core::context::app_sandbox::{CapabilityDeclaration, bind_app};
+                use scp_core::context::app_sandbox::{
+                    CapabilityDeclaration, SandboxError, bind_app,
+                };
                 use scp_core::context::roles::Capability;
                 use scp_core::context::{ContextHandle as CoreContextHandle, ContextParams};
 
@@ -15884,9 +15892,18 @@ impl Scp {
                     timestamp_secs,
                 )
                 .await
-                .map_err(|e| ScpError::Context {
-                    msg: e.to_string(),
-                    code: codes::CTX_2030.to_owned(),
+                .map_err(|e| {
+                    let code = match &e {
+                        SandboxError::CeilingExceeded { .. }
+                        | SandboxError::InvalidDeclaration(_)
+                        | SandboxError::SignatureVerificationFailed => codes::CTX_2056,
+                        SandboxError::EventLogFailed(_) => codes::CTX_2057,
+                        _ => codes::CTX_2058,
+                    };
+                    ScpError::Context {
+                        msg: e.to_string(),
+                        code: code.to_owned(),
+                    }
                 })?;
 
                 let app_did = scoped.app_did().to_string();
@@ -15908,7 +15925,7 @@ impl Scp {
                 }))
                 .map_err(|e| ScpError::Context {
                     msg: format!("serialization failed: {e}"),
-                    code: codes::CTX_2030.to_owned(),
+                    code: codes::CTX_2058.to_owned(),
                 })
             })
             .await
@@ -15948,6 +15965,20 @@ impl Scp {
                 validate_did(trimmed_actor)?;
                 validate_did(trimmed_app)?;
 
+                let is_bound = bi
+                    .bound_apps_registry
+                    .get(&handle.context_id)
+                    .is_some_and(|ctx| ctx.contains_key(trimmed_app));
+                if !is_bound {
+                    return Err(ScpError::Context {
+                        msg: format!(
+                            "app '{}' is not currently bound to context '{}'",
+                            trimmed_app, handle.context_id
+                        ),
+                        code: codes::CTX_2059.to_owned(),
+                    });
+                }
+
                 let event_log = bi.protocol_repository.event_log_provider();
 
                 unbind_app(
@@ -15960,7 +15991,7 @@ impl Scp {
                 .await
                 .map_err(|e| ScpError::Context {
                     msg: e.to_string(),
-                    code: codes::CTX_2030.to_owned(),
+                    code: codes::CTX_2059.to_owned(),
                 })?;
 
                 // Remove the binding from the per-context registry.

--- a/crates/scp-ffi/uniffi/src/bridge.rs
+++ b/crates/scp-ffi/uniffi/src/bridge.rs
@@ -15878,7 +15878,28 @@ impl Scp {
                         .collect()
                 };
 
-                let event_log = bi.protocol_repository.event_log_provider();
+                // Use the supervisor's already-initialised event-log provider.
+                // `bi.protocol_repository.event_log_provider()` creates a NEW
+                // `MerkleEventLogProvider` instance whose in-memory `logs` map
+                // is empty — every `append_event` call fails with CTX-2057
+                // ("no event log for context"). The supervisor's provider has
+                // its map populated by `init_event_log` during context
+                // creation/join/restore.
+                let event_log: std::sync::Arc<
+                    dyn scp_core::context::builder::ContextEventLogProvider,
+                > = bi
+                    .context_manager_expect()
+                    .map_err(|e| ScpError::Context {
+                        msg: format!("Supervisor not initialized: {e}"),
+                        code: codes::CTX_2000.to_owned(),
+                    })?
+                    .event_log_provider_arc()
+                    .ok_or_else(|| ScpError::Context {
+                        msg: "event-log provider not initialised — \
+                              call context_create or context_join first"
+                            .to_owned(),
+                        code: codes::CTX_2057.to_owned(),
+                    })?;
                 let ctx_handle =
                     CoreContextHandle::new(handle.context_id.clone(), ContextParams::default());
 
@@ -15887,7 +15908,7 @@ impl Scp {
                     &ceiling,
                     &role_caps,
                     ctx_handle,
-                    &*event_log,
+                    event_log.as_ref(),
                     trimmed_did,
                     timestamp_secs,
                 )
@@ -15979,12 +16000,29 @@ impl Scp {
                     });
                 }
 
-                let event_log = bi.protocol_repository.event_log_provider();
+                // Use the supervisor's already-initialised event-log provider
+                // (same reason as app_bind — a fresh provider has an empty
+                // log map and every append fails with CTX-2057).
+                let event_log: std::sync::Arc<
+                    dyn scp_core::context::builder::ContextEventLogProvider,
+                > = bi
+                    .context_manager_expect()
+                    .map_err(|e| ScpError::Context {
+                        msg: format!("Supervisor not initialized: {e}"),
+                        code: codes::CTX_2000.to_owned(),
+                    })?
+                    .event_log_provider_arc()
+                    .ok_or_else(|| ScpError::Context {
+                        msg: "event-log provider not initialised — \
+                              call context_create or context_join first"
+                            .to_owned(),
+                        code: codes::CTX_2057.to_owned(),
+                    })?;
 
                 unbind_app(
                     &handle.context_id,
                     trimmed_app,
-                    &*event_log,
+                    event_log.as_ref(),
                     trimmed_actor,
                     timestamp_secs,
                 )

--- a/crates/scp-ffi/uniffi/src/bridge.rs
+++ b/crates/scp-ffi/uniffi/src/bridge.rs
@@ -15778,6 +15778,205 @@ impl Scp {
         .await
     }
 
+    // ===== App Sandboxing (spec §8.4) =====
+
+    /// Binds an app to a context (spec §8.4.1), appending a durable
+    /// `AppBound` event (tag 74) to the context event log.
+    ///
+    /// Validates the capability declaration JSON, derives role capabilities
+    /// from the context ceiling and the actor's current membership role via
+    /// `ContextRoleState::member_has_capability` (suspension-aware), and
+    /// stores the `ScopedHandle` in the bridge instance's `bound_apps_registry`.
+    ///
+    /// Returns a JSON string with fields: `app_did`, `granted_capabilities`.
+    ///
+    /// Routes through `&*self.inner`. Rejects any `ContextHandle` whose
+    /// `instance_id` does not match this `SCP`'s.
+    pub async fn sandbox_app_bind(
+        &self,
+        handle: Arc<ContextHandle>,
+        declaration_json: String,
+        actor_did: String,
+        timestamp_secs: u64,
+    ) -> Result<String, ScpError> {
+        self.inner
+            .core
+            .check_handle(handle.instance_id())
+            .map_err(ScpError::from)?;
+        let bi = Arc::clone(&self.inner);
+        runtime()
+            .spawn(async move {
+                use scp_core::context::actor::commands::QueriesCommand;
+                use scp_core::context::app_sandbox::{CapabilityDeclaration, bind_app};
+                use scp_core::context::roles::Capability;
+                use scp_core::context::{ContextHandle as CoreContextHandle, ContextParams};
+
+                let trimmed_did = actor_did.trim();
+                validate_did(trimmed_did)?;
+
+                let decl: CapabilityDeclaration =
+                    serde_json::from_str(&declaration_json).map_err(|e| ScpError::Validation {
+                        msg: format!("invalid declaration JSON: {e}"),
+                        code: codes::VALID_7070.to_owned(),
+                    })?;
+
+                // Derive ceiling from the ContextHandle's ceiling_strings.
+                let ceiling: Vec<Capability> = handle
+                    .ceiling_strings
+                    .iter()
+                    .filter_map(Capability::new)
+                    .collect();
+
+                // Derive role caps: query the supervisor for this context's
+                // role state, then filter the ceiling by which capabilities
+                // the actor actually holds (suspension-aware).
+                let role_caps: Vec<Capability> = {
+                    let sup = bi
+                        .context_manager_expect()
+                        .map_err(|e| ScpError::Context {
+                            msg: format!("Supervisor not initialized: {e}"),
+                            code: codes::CTX_2000.to_owned(),
+                        })?
+                        .clone();
+                    let (tx, rx) = tokio::sync::oneshot::channel();
+                    let cmd = QueriesCommand::GetRoleState {
+                        context_id: handle.context_id.clone(),
+                        reply: tx,
+                    };
+                    sup.dispatch_query(cmd)
+                        .await
+                        .map_err(|e| ScpError::Context {
+                            msg: format!("dispatch_query failed: {e}"),
+                            code: codes::CTX_2000.to_owned(),
+                        })?;
+                    let role_state = rx
+                        .await
+                        .map_err(|_| ScpError::Context {
+                            msg: "query reply dropped".to_owned(),
+                            code: codes::CTX_2000.to_owned(),
+                        })?
+                        .map_err(|e| ScpError::Context {
+                            msg: e.to_string(),
+                            code: codes::CTX_2000.to_owned(),
+                        })?
+                        .ok_or_else(|| ScpError::Context {
+                            msg: format!("context '{}' not registered", handle.context_id),
+                            code: codes::CTX_2000.to_owned(),
+                        })?;
+                    ceiling
+                        .iter()
+                        .filter(|cap| role_state.member_has_capability(trimmed_did, cap))
+                        .cloned()
+                        .collect()
+                };
+
+                let event_log = bi.protocol_repository.event_log_provider();
+                let ctx_handle =
+                    CoreContextHandle::new(handle.context_id.clone(), ContextParams::default());
+
+                let scoped = bind_app(
+                    &decl,
+                    &ceiling,
+                    &role_caps,
+                    ctx_handle,
+                    &*event_log,
+                    trimmed_did,
+                    timestamp_secs,
+                )
+                .await
+                .map_err(|e| ScpError::Context {
+                    msg: e.to_string(),
+                    code: codes::CTX_2030.to_owned(),
+                })?;
+
+                let app_did = scoped.app_did().to_string();
+                let granted: Vec<String> = scoped
+                    .allowed_capabilities()
+                    .iter()
+                    .map(std::string::ToString::to_string)
+                    .collect();
+
+                // Store the ScopedHandle in the per-context binding registry.
+                bi.bound_apps_registry
+                    .entry(handle.context_id.clone())
+                    .or_default()
+                    .insert(app_did.clone(), scoped);
+
+                serde_json::to_string(&serde_json::json!({
+                    "app_did": app_did,
+                    "granted_capabilities": granted,
+                }))
+                .map_err(|e| ScpError::Context {
+                    msg: format!("serialization failed: {e}"),
+                    code: codes::CTX_2030.to_owned(),
+                })
+            })
+            .await
+            .map_err(|e| ScpError::Context {
+                msg: format!("tokio task join error: {e}"),
+                code: codes::CTX_2000.to_owned(),
+            })?
+    }
+
+    /// Unbinds a previously bound app from a context (spec §8.4.2), appending
+    /// a durable `AppUnbound` event (tag 75) to the context event log.
+    ///
+    /// Removes the binding from the bridge instance's `bound_apps_registry`.
+    /// Returns `ScpError::Context` (SCP-CTX-2030) when the event log append
+    /// fails — silent app detachment is not possible (spec §8.4).
+    ///
+    /// Routes through `&*self.inner`. Rejects any `ContextHandle` whose
+    /// `instance_id` does not match this `SCP`'s.
+    pub async fn sandbox_app_unbind(
+        &self,
+        handle: Arc<ContextHandle>,
+        app_did: String,
+        actor_did: String,
+        timestamp_secs: u64,
+    ) -> Result<(), ScpError> {
+        self.inner
+            .core
+            .check_handle(handle.instance_id())
+            .map_err(ScpError::from)?;
+        let bi = Arc::clone(&self.inner);
+        runtime()
+            .spawn(async move {
+                use scp_core::context::app_sandbox::unbind_app;
+
+                let trimmed_actor = actor_did.trim();
+                let trimmed_app = app_did.trim();
+                validate_did(trimmed_actor)?;
+                validate_did(trimmed_app)?;
+
+                let event_log = bi.protocol_repository.event_log_provider();
+
+                unbind_app(
+                    &handle.context_id,
+                    trimmed_app,
+                    &*event_log,
+                    trimmed_actor,
+                    timestamp_secs,
+                )
+                .await
+                .map_err(|e| ScpError::Context {
+                    msg: e.to_string(),
+                    code: codes::CTX_2030.to_owned(),
+                })?;
+
+                // Remove the binding from the per-context registry.
+                if let Some(mut ctx_bindings) = bi.bound_apps_registry.get_mut(&handle.context_id) {
+                    ctx_bindings.remove(trimmed_app);
+                }
+
+                Ok(())
+            })
+            .await
+            .map_err(|e| ScpError::Context {
+                msg: format!("tokio task join error: {e}"),
+                code: codes::CTX_2000.to_owned(),
+            })?
+    }
+
     // ===== UniFFI sub-slice G — transport + MCP + trust + misc =====
     //
     // Migrates the transport / MCP / local-DID / trust / sync-policy free

--- a/crates/scp-ffi/uniffi/src/runtime.rs
+++ b/crates/scp-ffi/uniffi/src/runtime.rs
@@ -44,8 +44,10 @@ use scp_ffi_common::credentials::FfiCredentialStore;
 // path.
 pub use scp_ffi_common::bridge_instance::CoreFields;
 use scp_ffi_common::error_codes as codes;
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
+
+use scp_core::context::app_sandbox::ScopedHandle;
 
 use dashmap::DashMap;
 use scp_clock::SystemClock;
@@ -374,6 +376,13 @@ pub struct UniffiBridgeInstance {
     /// stream via [`BridgeInstanceCore::bridge_specific_shutdown`].
     pub(crate) outlet_streaming_saga_registry:
         Arc<DashMap<String, scp_ffi_common::streaming_saga::StreamingSagaEntry>>,
+
+    /// Per-instance app binding registry (spec §8.4).
+    ///
+    /// Outer key: `context_id`. Inner key: `app_did`. Value: `ScopedHandle`
+    /// retaining the granted capability set for enforcement. Populated by
+    /// `Scp::sandbox_app_bind` and cleared by `Scp::sandbox_app_unbind`.
+    pub(crate) bound_apps_registry: Arc<DashMap<String, HashMap<String, ScopedHandle>>>,
 }
 
 impl std::fmt::Debug for UniffiBridgeInstance {
@@ -423,6 +432,7 @@ impl UniffiBridgeInstance {
             credential_store,
             outlet_stream_registry: Arc::new(DashMap::new()),
             outlet_streaming_saga_registry: Arc::new(DashMap::new()),
+            bound_apps_registry: Arc::new(DashMap::new()),
         }
     }
 
@@ -458,6 +468,7 @@ impl UniffiBridgeInstance {
             credential_store,
             outlet_stream_registry: Arc::new(DashMap::new()),
             outlet_streaming_saga_registry: Arc::new(DashMap::new()),
+            bound_apps_registry: Arc::new(DashMap::new()),
         }
     }
 
@@ -606,6 +617,7 @@ impl UniffiBridgeInstance {
             credential_store,
             outlet_stream_registry: Arc::new(DashMap::new()),
             outlet_streaming_saga_registry: Arc::new(DashMap::new()),
+            bound_apps_registry: Arc::new(DashMap::new()),
         }
     }
 

--- a/crates/scp-runtime/src/context/app_sandbox.rs
+++ b/crates/scp-runtime/src/context/app_sandbox.rs
@@ -868,15 +868,17 @@ pub async fn bind_app(
         context_handle,
     )?;
 
+    let mut capabilities: Vec<String> = scoped
+        .allowed_capabilities()
+        .iter()
+        .map(std::string::ToString::to_string)
+        .collect();
+    capabilities.sort_unstable();
     let payload = encode_payload(&AppBoundPayload {
         app_did: scoped.app_did().to_string(),
         app_name: scoped.declaration().app_name.clone(),
         app_version: scoped.declaration().app_version.clone(),
-        capabilities: scoped
-            .allowed_capabilities()
-            .iter()
-            .map(std::string::ToString::to_string)
-            .collect(),
+        capabilities,
     })
     .map_err(|e| SandboxError::EventLogFailed(e.to_string()))?;
 
@@ -2597,5 +2599,100 @@ mod tests {
         .await;
 
         assert!(matches!(result, Err(SandboxError::EventLogFailed(_))));
+    }
+
+    // -----------------------------------------------------------------------
+    // Payload field assertion test
+    // -----------------------------------------------------------------------
+
+    /// Recording mock that captures the full payload for field-level assertions.
+    struct RecordingEventLogWithPayload {
+        calls: Arc<Mutex<Vec<(EventType, String, EventPayload)>>>,
+    }
+
+    impl RecordingEventLogWithPayload {
+        fn new() -> Self {
+            Self {
+                calls: Arc::new(Mutex::new(Vec::new())),
+            }
+        }
+
+        fn recorded(&self) -> Vec<(EventType, String, EventPayload)> {
+            self.calls.lock().unwrap().clone()
+        }
+    }
+
+    #[async_trait::async_trait]
+    impl ContextEventLogProvider for RecordingEventLogWithPayload {
+        async fn init_event_log(&self, _id: &[u8; 32]) -> Result<(), ContextCreationError> {
+            Ok(())
+        }
+
+        async fn append_event(
+            &self,
+            _id: &[u8; 32],
+            event_type: EventType,
+            actor_did: &str,
+            payload: EventPayload,
+            _timestamp_secs: u64,
+        ) -> Result<(), ContextCreationError> {
+            self.calls
+                .lock()
+                .unwrap()
+                .push((event_type, actor_did.to_owned(), payload));
+            Ok(())
+        }
+
+        async fn destroy_event_log(&self, _id: &[u8; 32]) -> Result<(), ContextCreationError> {
+            Ok(())
+        }
+    }
+
+    #[tokio::test]
+    async fn bind_app_payload_fields_match_scoped_handle() {
+        use scp_event_log::payload::{AppBoundPayload, decode_payload};
+
+        let (signing_key, did) = test_keypair();
+        let mut decl = test_declaration(&did);
+        sign_declaration(&mut decl, &signing_key).unwrap();
+
+        let ceiling = vec![Capability::MessagesRead, Capability::MessagesWrite];
+        let role_caps = ceiling.clone();
+        let handle = ContextHandle::new("ctx-payload".to_owned(), ContextParams::default());
+        let log = RecordingEventLogWithPayload::new();
+
+        let scoped = bind_app(
+            &decl,
+            &ceiling,
+            &role_caps,
+            handle,
+            &log,
+            "did:key:actor",
+            1_000_000,
+        )
+        .await
+        .expect("bind_app should succeed");
+
+        let calls = log.recorded();
+        assert_eq!(calls.len(), 1);
+        assert_eq!(calls[0].0, EventType::AppBound);
+        assert_eq!(calls[0].1, "did:key:actor");
+
+        // Decode and verify payload fields match the ScopedHandle.
+        let payload: AppBoundPayload =
+            decode_payload(&calls[0].2).expect("payload should decode as AppBoundPayload");
+
+        assert_eq!(payload.app_did, scoped.app_did().to_string());
+        assert_eq!(payload.app_name, decl.app_name);
+        assert_eq!(payload.app_version, decl.app_version);
+
+        // Capabilities must be sorted (deterministic Merkle leaf convergence).
+        let mut expected: Vec<String> = scoped
+            .allowed_capabilities()
+            .iter()
+            .map(std::string::ToString::to_string)
+            .collect();
+        expected.sort_unstable();
+        assert_eq!(payload.capabilities, expected);
     }
 }

--- a/crates/scp-runtime/src/context/app_sandbox.rs
+++ b/crates/scp-runtime/src/context/app_sandbox.rs
@@ -32,7 +32,9 @@ use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
 
 use super::ContextHandle;
+use crate::context::builder::ContextEventLogProvider;
 use scp_did::DID;
+use scp_event_log::payload::{AppBoundPayload, AppUnboundPayload, encode_payload};
 use scp_protocol::context::roles::Capability;
 
 // ---------------------------------------------------------------------------
@@ -91,6 +93,14 @@ pub enum SandboxError {
     /// Serialization or deserialization failed.
     #[error("serialization failed: {0}")]
     SerializationFailed(String),
+
+    /// Appending the bind or unbind event to the durable event log failed.
+    ///
+    /// Returned when `ContextEventLogProvider::append_context_event_with_payload`
+    /// fails during `bind_app` or `unbind_app`. The bind/unbind operation is
+    /// rejected — silent app attachment is not possible (spec §8.4).
+    #[error("event log failed: {0}")]
+    EventLogFailed(String),
 }
 
 // ---------------------------------------------------------------------------
@@ -824,59 +834,101 @@ pub fn validate_declaration(
 }
 
 // ---------------------------------------------------------------------------
-// AppBindEvent / AppUnbindEvent (event log entries)
+// Durable event log operations (spec §8.4)
 // ---------------------------------------------------------------------------
 
-/// Event log entry for when an app is bound to a context.
+/// Validates a capability declaration and binds the app, appending an
+/// `AppBound` (tag 74) event to the durable event log (spec §8.4).
 ///
-/// Recorded in the context's event log at bind time for auditability
-/// (spec 8.4.2). Context members can inspect which apps are bound and
-/// what capabilities they hold.
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-pub struct AppBindEvent {
-    /// The DID of the app that was bound.
-    pub app_did: DID,
-    /// The capabilities granted to the app.
-    pub capabilities: Vec<Capability>,
-    /// The app name from the declaration.
-    pub app_name: String,
-    /// The app version from the declaration.
-    pub app_version: String,
+/// This is the authoritative bind path. It first calls `validate_declaration`
+/// for all-or-nothing capability checking, then serialises an
+/// [`AppBoundPayload`] and appends it via
+/// [`ContextEventLogProvider::append_context_event_with_payload`]. If the
+/// event log append fails the bind is rejected — silent app attachment is not
+/// possible.
+///
+/// # Errors
+///
+/// Returns `SandboxError::CeilingExceeded` / `SandboxError::InvalidDeclaration`
+/// / `SandboxError::SignatureVerificationFailed` (via `validate_declaration`)
+/// or `SandboxError::EventLogFailed` when the durable append fails.
+pub async fn bind_app(
+    declaration: &CapabilityDeclaration,
+    context_ceiling: &[Capability],
+    role_capabilities: &[Capability],
+    context_handle: ContextHandle,
+    event_log: &dyn ContextEventLogProvider,
+    actor_did: &str,
+    timestamp_secs: u64,
+) -> Result<ScopedHandle, SandboxError> {
+    let scoped = validate_declaration(
+        declaration,
+        context_ceiling,
+        role_capabilities,
+        context_handle,
+    )?;
+
+    let payload = encode_payload(&AppBoundPayload {
+        app_did: scoped.app_did().to_string(),
+        app_name: scoped.declaration().app_name.clone(),
+        app_version: scoped.declaration().app_version.clone(),
+        capabilities: scoped
+            .allowed_capabilities()
+            .iter()
+            .map(std::string::ToString::to_string)
+            .collect(),
+    })
+    .map_err(|e| SandboxError::EventLogFailed(e.to_string()))?;
+
+    let context_id_bytes = super::state::context_id_to_bytes(scoped.context_id());
+    event_log
+        .append_context_event_with_payload(
+            &context_id_bytes,
+            scp_event_log::EventType::AppBound,
+            actor_did,
+            payload,
+            timestamp_secs,
+        )
+        .await
+        .map_err(|e| SandboxError::EventLogFailed(e.to_string()))?;
+
+    Ok(scoped)
 }
 
-/// Event log entry for when an app is unbound from a context.
+/// Unbinds an app from a context, appending an `AppUnbound` (tag 75) event
+/// to the durable event log (spec §8.4).
 ///
-/// Recorded in the context's event log when an app is removed.
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-pub struct AppUnbindEvent {
-    /// The DID of the app that was unbound.
-    pub app_did: DID,
-}
-
-/// Formats an `AppBindEvent` as an event log string.
+/// Serialises an [`AppUnboundPayload`] and appends it via
+/// [`ContextEventLogProvider::append_context_event_with_payload`]. If the
+/// event log append fails the unbind is rejected — silent app detachment is
+/// not possible.
 ///
-/// Returns a string suitable for appending to the context's Merkle event log
-/// via `ContextEventLogProvider::append_event`.
-#[must_use]
-pub fn format_bind_event(event: &AppBindEvent) -> String {
-    let cap_names: Vec<String> = event
-        .capabilities
-        .iter()
-        .map(std::string::ToString::to_string)
-        .collect();
-    format!(
-        "AppBound:{}:{}:{}:[{}]",
-        event.app_did,
-        event.app_name,
-        event.app_version,
-        cap_names.join(",")
-    )
-}
+/// # Errors
+///
+/// Returns `SandboxError::EventLogFailed` when the durable append fails.
+pub async fn unbind_app(
+    context_id: &str,
+    app_did: &str,
+    event_log: &dyn ContextEventLogProvider,
+    actor_did: &str,
+    timestamp_secs: u64,
+) -> Result<(), SandboxError> {
+    let payload = encode_payload(&AppUnboundPayload {
+        app_did: app_did.to_owned(),
+    })
+    .map_err(|e| SandboxError::EventLogFailed(e.to_string()))?;
 
-/// Formats an `AppUnbindEvent` as an event log string.
-#[must_use]
-pub fn format_unbind_event(event: &AppUnbindEvent) -> String {
-    format!("AppUnbound:{}", event.app_did)
+    let context_id_bytes = super::state::context_id_to_bytes(context_id);
+    event_log
+        .append_context_event_with_payload(
+            &context_id_bytes,
+            scp_event_log::EventType::AppUnbound,
+            actor_did,
+            payload,
+            timestamp_secs,
+        )
+        .await
+        .map_err(|e| SandboxError::EventLogFailed(e.to_string()))
 }
 
 // ---------------------------------------------------------------------------
@@ -1005,7 +1057,10 @@ pub fn declaration_content_hash(
     clippy::expect_used,
     clippy::panic,
     clippy::redundant_clone,
-    clippy::large_stack_frames
+    clippy::large_stack_frames,
+    // `std::sync::Mutex` is used by the `RecordingEventLog` test mock; it is
+    // never held across an `.await` point so it cannot deadlock the runtime.
+    clippy::disallowed_types
 )]
 mod tests {
     use super::*;
@@ -1705,36 +1760,6 @@ mod tests {
     }
 
     // -----------------------------------------------------------------------
-    // Event Log Recording
-    // -----------------------------------------------------------------------
-
-    #[test]
-    fn format_bind_event_produces_parseable_string() {
-        let event = AppBindEvent {
-            app_did: DID::from("did:key:z1234"),
-            capabilities: vec![Capability::MessagesRead, Capability::MessagesWrite],
-            app_name: "Test App".to_owned(),
-            app_version: "1.0.0".to_owned(),
-        };
-
-        let formatted = format_bind_event(&event);
-        assert!(formatted.starts_with("AppBound:"));
-        assert!(formatted.contains("did:key:z1234"));
-        assert!(formatted.contains("messages:read"));
-        assert!(formatted.contains("messages:write"));
-    }
-
-    #[test]
-    fn format_unbind_event_produces_parseable_string() {
-        let event = AppUnbindEvent {
-            app_did: DID::from("did:key:z1234"),
-        };
-
-        let formatted = format_unbind_event(&event);
-        assert_eq!(formatted, "AppUnbound:did:key:z1234");
-    }
-
-    // -----------------------------------------------------------------------
     // Capability Entry Parsing
     // -----------------------------------------------------------------------
 
@@ -2050,35 +2075,6 @@ mod tests {
     }
 
     // -----------------------------------------------------------------------
-    // App Bind/Unbind Event Serialization
-    // -----------------------------------------------------------------------
-
-    #[test]
-    fn app_bind_event_serialization() {
-        let event = AppBindEvent {
-            app_did: DID::from("did:key:z1234"),
-            capabilities: vec![Capability::MessagesRead],
-            app_name: "My App".to_owned(),
-            app_version: "1.0.0".to_owned(),
-        };
-
-        let json = serde_json::to_string(&event).unwrap();
-        let roundtripped: AppBindEvent = serde_json::from_str(&json).unwrap();
-        assert_eq!(roundtripped, event);
-    }
-
-    #[test]
-    fn app_unbind_event_serialization() {
-        let event = AppUnbindEvent {
-            app_did: DID::from("did:key:z1234"),
-        };
-
-        let json = serde_json::to_string(&event).unwrap();
-        let roundtripped: AppUnbindEvent = serde_json::from_str(&json).unwrap();
-        assert_eq!(roundtripped, event);
-    }
-
-    // -----------------------------------------------------------------------
     // sign_declaration
     // -----------------------------------------------------------------------
 
@@ -2327,18 +2323,6 @@ mod tests {
     }
 
     #[test]
-    fn format_bind_event_empty_capabilities() {
-        let event = AppBindEvent {
-            app_did: DID::from("did:key:z1234"),
-            capabilities: vec![],
-            app_name: "Empty App".to_owned(),
-            app_version: "0.0.1".to_owned(),
-        };
-        let formatted = format_bind_event(&event);
-        assert!(formatted.contains("[]"));
-    }
-
-    #[test]
     fn scoped_handle_check_capability_error_includes_app_did() {
         let (_, did) = test_keypair();
         let handle = ContextHandle::new("ctx-test".to_owned(), ContextParams::default());
@@ -2427,5 +2411,191 @@ mod tests {
         // Not granted:
         assert!(handle.check_context_close().is_err());
         assert!(handle.check_member_remove().is_err());
+    }
+
+    // -----------------------------------------------------------------------
+    // bind_app / unbind_app — durable event log append (spec §8.4)
+    // -----------------------------------------------------------------------
+
+    use crate::context::builder::ContextEventLogProvider;
+    use scp_event_log::{EventPayload, EventType};
+    use scp_protocol::context::builder::ContextCreationError;
+    use std::sync::{Arc, Mutex};
+
+    /// Minimal mock that records every `append_event` call.
+    struct RecordingEventLog {
+        calls: Arc<Mutex<Vec<(EventType, String)>>>,
+        fail: bool,
+    }
+
+    impl RecordingEventLog {
+        fn new_ok() -> Self {
+            Self {
+                calls: Arc::new(Mutex::new(Vec::new())),
+                fail: false,
+            }
+        }
+
+        fn new_fail() -> Self {
+            Self {
+                calls: Arc::new(Mutex::new(Vec::new())),
+                fail: true,
+            }
+        }
+
+        fn recorded(&self) -> Vec<(EventType, String)> {
+            self.calls.lock().unwrap().clone()
+        }
+    }
+
+    #[async_trait::async_trait]
+    impl ContextEventLogProvider for RecordingEventLog {
+        async fn init_event_log(&self, _id: &[u8; 32]) -> Result<(), ContextCreationError> {
+            Ok(())
+        }
+
+        async fn append_event(
+            &self,
+            _id: &[u8; 32],
+            event_type: EventType,
+            actor_did: &str,
+            _payload: EventPayload,
+            _timestamp_secs: u64,
+        ) -> Result<(), ContextCreationError> {
+            if self.fail {
+                return Err(ContextCreationError::EventLogFailed(
+                    "simulated failure".to_owned(),
+                ));
+            }
+            self.calls
+                .lock()
+                .unwrap()
+                .push((event_type, actor_did.to_owned()));
+            Ok(())
+        }
+
+        async fn destroy_event_log(&self, _id: &[u8; 32]) -> Result<(), ContextCreationError> {
+            Ok(())
+        }
+    }
+
+    #[tokio::test]
+    async fn bind_app_appends_app_bound_event() {
+        let (signing_key, did) = test_keypair();
+        let mut decl = test_declaration(&did);
+        sign_declaration(&mut decl, &signing_key).unwrap();
+
+        let ceiling = vec![Capability::MessagesRead, Capability::MessagesWrite];
+        let role_caps = ceiling.clone();
+        let handle = ContextHandle::new("ctx-bind".to_owned(), ContextParams::default());
+        let log = RecordingEventLog::new_ok();
+
+        let result = bind_app(
+            &decl,
+            &ceiling,
+            &role_caps,
+            handle,
+            &log,
+            "did:key:actor",
+            1_000_000,
+        )
+        .await;
+
+        assert!(result.is_ok());
+        let calls = log.recorded();
+        assert_eq!(calls.len(), 1);
+        assert_eq!(calls[0].0, EventType::AppBound);
+        assert_eq!(calls[0].1, "did:key:actor");
+    }
+
+    #[tokio::test]
+    async fn bind_app_ceiling_exceeded_does_not_append() {
+        let (signing_key, did) = test_keypair();
+        let mut decl = test_declaration(&did);
+        sign_declaration(&mut decl, &signing_key).unwrap();
+
+        // Ceiling does NOT include MessagesWrite even though the declaration
+        // requests it — so validate_declaration should fail BEFORE the log
+        // append.
+        let ceiling = vec![Capability::MessagesRead];
+        let role_caps = ceiling.clone();
+        let handle = ContextHandle::new("ctx-bind".to_owned(), ContextParams::default());
+        let log = RecordingEventLog::new_ok();
+
+        let result = bind_app(
+            &decl,
+            &ceiling,
+            &role_caps,
+            handle,
+            &log,
+            "did:key:actor",
+            1_000_000,
+        )
+        .await;
+
+        assert!(matches!(result, Err(SandboxError::CeilingExceeded { .. })));
+        // No event must be appended when validation fails.
+        assert!(log.recorded().is_empty());
+    }
+
+    #[tokio::test]
+    async fn bind_app_event_log_failure_propagates() {
+        let (signing_key, did) = test_keypair();
+        let mut decl = test_declaration(&did);
+        sign_declaration(&mut decl, &signing_key).unwrap();
+
+        let ceiling = vec![Capability::MessagesRead, Capability::MessagesWrite];
+        let role_caps = ceiling.clone();
+        let handle = ContextHandle::new("ctx-bind".to_owned(), ContextParams::default());
+        let log = RecordingEventLog::new_fail();
+
+        let result = bind_app(
+            &decl,
+            &ceiling,
+            &role_caps,
+            handle,
+            &log,
+            "did:key:actor",
+            1_000_000,
+        )
+        .await;
+
+        assert!(matches!(result, Err(SandboxError::EventLogFailed(_))));
+    }
+
+    #[tokio::test]
+    async fn unbind_app_appends_app_unbound_event() {
+        let log = RecordingEventLog::new_ok();
+
+        let result = unbind_app(
+            "ctx-unbind",
+            "did:key:app",
+            &log,
+            "did:key:actor",
+            1_000_000,
+        )
+        .await;
+
+        assert!(result.is_ok());
+        let calls = log.recorded();
+        assert_eq!(calls.len(), 1);
+        assert_eq!(calls[0].0, EventType::AppUnbound);
+        assert_eq!(calls[0].1, "did:key:actor");
+    }
+
+    #[tokio::test]
+    async fn unbind_app_event_log_failure_propagates() {
+        let log = RecordingEventLog::new_fail();
+
+        let result = unbind_app(
+            "ctx-unbind",
+            "did:key:app",
+            &log,
+            "did:key:actor",
+            1_000_000,
+        )
+        .await;
+
+        assert!(matches!(result, Err(SandboxError::EventLogFailed(_))));
     }
 }

--- a/crates/scp-runtime/src/context/app_sandbox.rs
+++ b/crates/scp-runtime/src/context/app_sandbox.rs
@@ -350,7 +350,20 @@ impl CapabilityDeclaration {
         // introduced in a spec version it doesn't know about (spec §8.4.1).
         let decl_parts: Vec<&str> = self.scp_version.splitn(3, '.').collect();
         let decl_major = *decl_parts.first().unwrap_or(&"0");
-        let decl_minor: u64 = decl_parts.get(1).and_then(|s| s.parse().ok()).unwrap_or(0);
+        let decl_minor: u64 = decl_parts
+            .get(1)
+            .ok_or_else(|| {
+                SandboxError::InvalidDeclaration(
+                    "scp_version must be MAJOR.MINOR format".to_string(),
+                )
+            })
+            .and_then(|s| {
+                s.parse::<u64>().map_err(|_| {
+                    SandboxError::InvalidDeclaration(format!(
+                        "scp_version minor component is not a valid integer: '{s}'"
+                    ))
+                })
+            })?;
 
         let current_parts: Vec<&str> = CURRENT_SCP_VERSION.splitn(3, '.').collect();
         let current_major = *current_parts.first().unwrap_or(&"0");
@@ -909,7 +922,7 @@ pub async fn bind_app(
         .collect();
     capabilities.sort_unstable();
     let payload = encode_payload(&AppBoundPayload {
-        app_did: scoped.app_did().to_string(),
+        app_did: scoped.app_did().trim().to_string(),
         app_name: scoped.declaration().app_name.clone(),
         app_version: scoped.declaration().app_version.clone(),
         capabilities,
@@ -2302,6 +2315,37 @@ mod tests {
         assert!(matches!(
             decl.validate_structure(),
             Err(SandboxError::InvalidDeclaration(msg)) if msg.contains("incompatible")
+        ));
+    }
+
+    #[test]
+    fn validate_structure_malformed_minor_version_rejected() {
+        // A malformed minor like "1.bad" must be rejected with
+        // InvalidDeclaration rather than silently treated as 0 (which
+        // previously would have allowed an unknown version through).
+        let (_, did) = test_keypair();
+        let mut decl = test_declaration(&did);
+        decl.scp_version = "1.bad".to_owned();
+
+        assert!(matches!(
+            decl.validate_structure(),
+            Err(SandboxError::InvalidDeclaration(msg))
+                if msg.contains("not a valid integer")
+        ));
+    }
+
+    #[test]
+    fn validate_structure_missing_minor_version_rejected() {
+        // A version string with no minor component ("1") must be rejected
+        // since it cannot be validated against the MAJOR.MINOR spec requirement.
+        let (_, did) = test_keypair();
+        let mut decl = test_declaration(&did);
+        decl.scp_version = "1".to_owned();
+
+        assert!(matches!(
+            decl.validate_structure(),
+            Err(SandboxError::InvalidDeclaration(msg))
+                if msg.contains("MAJOR.MINOR")
         ));
     }
 

--- a/crates/scp-runtime/src/context/app_sandbox.rs
+++ b/crates/scp-runtime/src/context/app_sandbox.rs
@@ -2686,7 +2686,12 @@ mod tests {
         assert_eq!(payload.app_name, decl.app_name);
         assert_eq!(payload.app_version, decl.app_version);
 
-        // Capabilities must be sorted (deterministic Merkle leaf convergence).
+        // Verify capabilities are sorted (deterministic Merkle leaves).
+        assert!(
+            payload.capabilities.windows(2).all(|w| w[0] <= w[1]),
+            "AppBoundPayload.capabilities must be sorted for Merkle convergence"
+        );
+        // Verify the content matches what was granted.
         let mut expected: Vec<String> = scoped
             .allowed_capabilities()
             .iter()

--- a/crates/scp-runtime/src/context/app_sandbox.rs
+++ b/crates/scp-runtime/src/context/app_sandbox.rs
@@ -29,7 +29,6 @@
 use std::collections::HashSet;
 
 use serde::{Deserialize, Serialize};
-use sha2::{Digest, Sha256};
 
 use super::ContextHandle;
 use crate::context::builder::ContextEventLogProvider;
@@ -207,8 +206,15 @@ impl CapabilityEntry {
 /// Maximum length of `app_name` in UTF-8 bytes (spec 8.4.1).
 pub const MAX_APP_NAME_BYTES: usize = 128;
 
+/// Maximum UTF-8 byte length of `app_version` (spec 8.4.1).
+/// Values longer than 64 bytes cannot be valid `SemVer`.
+pub const MAX_APP_VERSION_BYTES: usize = 64;
+
 /// Maximum number of capability entries (spec 8.4.1).
 pub const MAX_CAPABILITY_ENTRIES: usize = 64;
+
+/// Maximum number of actions per capability entry (spec 8.4.1).
+pub const MAX_ACTIONS_PER_CAPABILITY_ENTRY: usize = 32;
 
 /// Current SCP protocol version for declarations.
 pub const CURRENT_SCP_VERSION: &str = "1.0";
@@ -338,10 +344,22 @@ impl CapabilityDeclaration {
     ///
     /// Returns `SandboxError::InvalidDeclaration` with a descriptive message.
     pub fn validate_structure(&self) -> Result<(), SandboxError> {
-        // Check SCP version compatibility (same major version).
-        let decl_major = self.scp_version.split('.').next().unwrap_or("0");
-        let current_major = CURRENT_SCP_VERSION.split('.').next().unwrap_or("0");
-        if decl_major != current_major {
+        // Check SCP version compatibility: same major AND minor <= current.
+        // A declaration targeting a future minor version (e.g. "1.5" when
+        // SDK is "1.0") must be rejected — the SDK cannot honour capabilities
+        // introduced in a spec version it doesn't know about (spec §8.4.1).
+        let decl_parts: Vec<&str> = self.scp_version.splitn(3, '.').collect();
+        let decl_major = *decl_parts.first().unwrap_or(&"0");
+        let decl_minor: u64 = decl_parts.get(1).and_then(|s| s.parse().ok()).unwrap_or(0);
+
+        let current_parts: Vec<&str> = CURRENT_SCP_VERSION.splitn(3, '.').collect();
+        let current_major = *current_parts.first().unwrap_or(&"0");
+        let current_minor: u64 = current_parts
+            .get(1)
+            .and_then(|s| s.parse().ok())
+            .unwrap_or(0);
+
+        if decl_major != current_major || decl_minor > current_minor {
             return Err(SandboxError::InvalidDeclaration(format!(
                 "incompatible scp_version: declaration targets {}, SDK supports {}",
                 self.scp_version, CURRENT_SCP_VERSION
@@ -363,6 +381,15 @@ impl CapabilityDeclaration {
             ));
         }
 
+        // Check app_version length.
+        if self.app_version.len() > MAX_APP_VERSION_BYTES {
+            return Err(SandboxError::InvalidDeclaration(format!(
+                "app_version exceeds {} UTF-8 bytes (got {})",
+                MAX_APP_VERSION_BYTES,
+                self.app_version.len()
+            )));
+        }
+
         // Check capabilities count.
         if self.capabilities.is_empty() {
             return Err(SandboxError::InvalidDeclaration(
@@ -377,11 +404,18 @@ impl CapabilityDeclaration {
             )));
         }
 
-        // Check each entry has at least one action.
+        // Check each entry has at least one action, and not too many.
         for (i, entry) in self.capabilities.iter().enumerate() {
             if entry.actions.is_empty() {
                 return Err(SandboxError::InvalidDeclaration(format!(
                     "capabilities[{i}] must have at least 1 action"
+                )));
+            }
+            if entry.actions.len() > MAX_ACTIONS_PER_CAPABILITY_ENTRY {
+                return Err(SandboxError::InvalidDeclaration(format!(
+                    "capabilities[{i}] exceeds maximum of {} actions (got {})",
+                    MAX_ACTIONS_PER_CAPABILITY_ENTRY,
+                    entry.actions.len()
                 )));
             }
         }
@@ -1028,25 +1062,6 @@ pub fn sign_declaration(
     declaration.signature = signature.to_bytes().to_vec();
 
     Ok(())
-}
-
-/// Computes the content hash of a capability declaration for integrity checks.
-///
-/// Uses SHA-256 over the canonical JSON bytes (excluding signature).
-///
-/// # Errors
-///
-/// Returns `SandboxError::SerializationFailed` if canonical serialization fails.
-pub fn declaration_content_hash(
-    declaration: &CapabilityDeclaration,
-) -> Result<[u8; 32], SandboxError> {
-    let canonical = declaration.canonical_bytes()?;
-    let mut hasher = Sha256::new();
-    hasher.update(&canonical);
-    let result = hasher.finalize();
-    let mut hash = [0u8; 32];
-    hash.copy_from_slice(&result);
-    Ok(hash)
 }
 
 // ---------------------------------------------------------------------------
@@ -1902,33 +1917,6 @@ mod tests {
     }
 
     // -----------------------------------------------------------------------
-    // Content Hash
-    // -----------------------------------------------------------------------
-
-    #[test]
-    fn declaration_content_hash_deterministic() {
-        let (_, did) = test_keypair();
-        let decl = test_declaration(&did);
-
-        let hash1 = declaration_content_hash(&decl).unwrap();
-        let hash2 = declaration_content_hash(&decl).unwrap();
-        assert_eq!(hash1, hash2);
-    }
-
-    #[test]
-    fn declaration_content_hash_changes_with_content() {
-        let (_, did) = test_keypair();
-        let decl1 = test_declaration(&did);
-
-        let mut decl2 = test_declaration(&did);
-        decl2.app_name = "Different App".to_owned();
-
-        let hash1 = declaration_content_hash(&decl1).unwrap();
-        let hash2 = declaration_content_hash(&decl2).unwrap();
-        assert_ne!(hash1, hash2);
-    }
-
-    // -----------------------------------------------------------------------
     // OutletCallAll covers OutletCall in ceiling/role validation
     // -----------------------------------------------------------------------
 
@@ -2294,10 +2282,75 @@ mod tests {
     }
 
     #[test]
-    fn validate_structure_compatible_minor_version() {
+    fn validate_structure_same_minor_version_passes() {
+        // A declaration that matches the current SDK version exactly is valid.
         let (_, did) = test_keypair();
         let mut decl = test_declaration(&did);
-        decl.scp_version = "1.5".to_owned(); // Same major, different minor.
+        decl.scp_version = CURRENT_SCP_VERSION.to_owned();
+
+        assert!(decl.validate_structure().is_ok());
+    }
+
+    #[test]
+    fn validate_structure_future_minor_version_rejected() {
+        // A declaration targeting a future minor version (1.5 when SDK is 1.0)
+        // must be rejected — spec §8.4.1 requires minor <= current.
+        let (_, did) = test_keypair();
+        let mut decl = test_declaration(&did);
+        decl.scp_version = "1.5".to_owned();
+
+        assert!(matches!(
+            decl.validate_structure(),
+            Err(SandboxError::InvalidDeclaration(msg)) if msg.contains("incompatible")
+        ));
+    }
+
+    #[test]
+    fn validate_structure_app_version_too_long() {
+        let (_, did) = test_keypair();
+        let mut decl = test_declaration(&did);
+        // 65 bytes exceeds MAX_APP_VERSION_BYTES (64).
+        decl.app_version = "1".repeat(MAX_APP_VERSION_BYTES + 1);
+
+        assert!(matches!(
+            decl.validate_structure(),
+            Err(SandboxError::InvalidDeclaration(msg)) if msg.contains("app_version")
+        ));
+    }
+
+    #[test]
+    fn validate_structure_too_many_actions() {
+        let (_, did) = test_keypair();
+        let mut decl = test_declaration(&did);
+        // Exceeds MAX_ACTIONS_PER_CAPABILITY_ENTRY (32).
+        decl.capabilities[0].actions = (0..=MAX_ACTIONS_PER_CAPABILITY_ENTRY)
+            .map(|i| format!("action{i}"))
+            .collect();
+
+        assert!(matches!(
+            decl.validate_structure(),
+            Err(SandboxError::InvalidDeclaration(msg)) if msg.contains("actions")
+        ));
+    }
+
+    #[test]
+    fn validate_structure_exactly_max_actions_passes() {
+        let (_, did) = test_keypair();
+        let mut decl = test_declaration(&did);
+        // Exactly MAX_ACTIONS_PER_CAPABILITY_ENTRY actions should be valid.
+        decl.capabilities[0].actions = (0..MAX_ACTIONS_PER_CAPABILITY_ENTRY)
+            .map(|i| format!("action{i}"))
+            .collect();
+
+        assert!(decl.validate_structure().is_ok());
+    }
+
+    #[test]
+    fn validate_structure_exactly_max_app_version_bytes() {
+        let (_, did) = test_keypair();
+        let mut decl = test_declaration(&did);
+        // Exactly MAX_APP_VERSION_BYTES bytes is valid.
+        decl.app_version = "1".repeat(MAX_APP_VERSION_BYTES);
 
         assert!(decl.validate_structure().is_ok());
     }

--- a/crates/scp-runtime/src/context/supervisor/supervisor.rs
+++ b/crates/scp-runtime/src/context/supervisor/supervisor.rs
@@ -2263,16 +2263,19 @@ impl Supervisor {
         self.event_log.get()
     }
 
-    /// Returns a clone of the event-log provider's [`Arc`], if one was
-    /// configured via [`Self::with_providers`].
+    /// Returns the event-log provider configured for this supervisor instance.
     ///
-    /// FFI bridges must call this to obtain the SAME provider instance whose
-    /// in-memory `logs` map was populated by `init_event_log` during context
-    /// creation/join/restore. A freshly-constructed
-    /// `MerkleEventLogProvider` would have an empty map and every
-    /// `append_event` call would fail with `CTX-2057` ("no event log for
-    /// context"). Returns `None` if the supervisor has not been initialised
-    /// yet (i.e. no context has been created or joined on this instance).
+    /// FFI bridges must call this to obtain the SAME [`Arc`] that context
+    /// creation populates via `init_event_log` — so bridges must use this
+    /// (not a freshly-constructed provider) when appending events outside
+    /// the actor's own handler. A freshly-constructed `MerkleEventLogProvider`
+    /// would have an empty `logs` map and every `append_event` call would
+    /// fail with `CTX-2057` ("no event log for context").
+    ///
+    /// Returns `None` only if the supervisor was constructed without an
+    /// event-log provider (test configurations); in all production bridges
+    /// the provider is set at construction time via
+    /// [`Self::with_providers_and_journal`].
     #[must_use]
     pub fn event_log_provider_arc(&self) -> Option<Arc<dyn ContextEventLogProvider>> {
         self.event_log.get().cloned()

--- a/crates/scp-runtime/src/context/supervisor/supervisor.rs
+++ b/crates/scp-runtime/src/context/supervisor/supervisor.rs
@@ -2263,6 +2263,21 @@ impl Supervisor {
         self.event_log.get()
     }
 
+    /// Returns a clone of the event-log provider's [`Arc`], if one was
+    /// configured via [`Self::with_providers`].
+    ///
+    /// FFI bridges must call this to obtain the SAME provider instance whose
+    /// in-memory `logs` map was populated by `init_event_log` during context
+    /// creation/join/restore. A freshly-constructed
+    /// `MerkleEventLogProvider` would have an empty map and every
+    /// `append_event` call would fail with `CTX-2057` ("no event log for
+    /// context"). Returns `None` if the supervisor has not been initialised
+    /// yet (i.e. no context has been created or joined on this instance).
+    #[must_use]
+    pub fn event_log_provider_arc(&self) -> Option<Arc<dyn ContextEventLogProvider>> {
+        self.event_log.get().cloned()
+    }
+
     /// Cheap reference to the helper-side persistence slot. Returns
     /// `None` if [`Self::with_providers`] was not used or the caller
     /// passed `None` for `persistence` (helpers branch on this to skip

--- a/crates/scp-testing/Cargo.toml
+++ b/crates/scp-testing/Cargo.toml
@@ -165,6 +165,10 @@ name = "identity"
 path = "tests/integration/identity.rs"
 
 [[test]]
+name = "app_binding"
+path = "tests/integration/app_binding.rs"
+
+[[test]]
 name = "agent_binding"
 path = "tests/integration/agent_binding.rs"
 

--- a/crates/scp-testing/tests/integration/app_binding.rs
+++ b/crates/scp-testing/tests/integration/app_binding.rs
@@ -1,0 +1,244 @@
+#![allow(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    clippy::panic,
+    clippy::doc_markdown
+)]
+
+//! Integration tests for AppBound / AppUnbound durable event-log appends (spec §8.4).
+//!
+//! These tests verify the critical fix: `bind_app` and `unbind_app` MUST use the
+//! same [`ContextEventLogProvider`] instance whose `logs` map was populated by
+//! `init_event_log` during context creation, not a freshly constructed one.
+//!
+//! The root cause of the original bug was that all three FFI bridges were
+//! calling `build_event_log_provider(bi)` (or `bi.protocol_repository.event_log_provider()`)
+//! to obtain a FRESH `MerkleEventLogProvider` whose in-memory `logs` map was
+//! empty — so every `append_event` would fail with "log not initialised" and
+//! the AppBound/AppUnbound events were silently lost.
+//!
+//! The fix: call `Supervisor::event_log_provider_arc()` so all three bridges
+//! share the ONE provider instance the Supervisor holds in its `event_log`
+//! [`OnceLock`].
+//!
+//! Sources: spec §8.4 (App Sandbox) · error code CTX-2057.
+
+use scp_core::context::app_sandbox::{
+    CapabilityDeclaration, CapabilityEntry, bind_app, sign_declaration, unbind_app,
+};
+use scp_core::context::state::context_id_to_bytes;
+use scp_core::context::{Capability, ContextParams};
+use scp_did::DID;
+use scp_event_log::EventType;
+use scp_testing::fullstack::FullStackNetwork;
+
+// DIDs for the actor and an app publisher. Both are fixed strings so this
+// test is deterministic and doesn't require any DID resolution infrastructure.
+const ACTOR_DID: &str = "did:dht:z6MkAppBindTestNode";
+const CONTEXT_ID: &str = "app-binding-integration-ctx";
+
+/// Generates an ephemeral Ed25519 signing key and derives a `did:dht:` DID
+/// from the public key.  `did_dht_from_public_key` is the single canonical
+/// encoder so this matches what `extract_ed25519_pubkey_from_did` decodes when
+/// verifying the declaration signature.
+fn app_signing_key_and_did() -> (ed25519_dalek::SigningKey, DID) {
+    use rand::rngs::OsRng;
+    let signing_key = ed25519_dalek::SigningKey::generate(&mut OsRng);
+    let pubkey_bytes = signing_key.verifying_key().to_bytes();
+    let app_did = scp_did::did_dht_from_public_key(&pubkey_bytes);
+    (signing_key, app_did)
+}
+
+// ---------------------------------------------------------------------------
+// Test 1: bind_app writes AppBound to the supervisor's shared event log
+// ---------------------------------------------------------------------------
+
+/// Verifies that calling `bind_app` with the supervisor's shared
+/// `event_log_provider_arc()` results in an `AppBound` event visible through
+/// `Supervisor::event_log_entries`.
+///
+/// This is the primary regression test for the "always-uninitialized provider"
+/// blocker: if bind_app uses a fresh provider, the append silently fails and
+/// no `AppBound` event is written — this assertion would then fail.
+#[tokio::test]
+async fn bind_app_writes_appbound_event() {
+    // 1. Stand up a real Supervisor node with real MLS crypto.
+    let network = FullStackNetwork::new();
+    let alice = network.create_node(ACTOR_DID);
+
+    // 2. Create a context with a capability ceiling that includes `MessagesRead`
+    //    — this is what CapabilityEntry { resource: ".../messaging", actions: ["read"] }
+    //    maps to via CapabilityEntry::to_capabilities().
+    let params = ContextParams {
+        ceiling: vec![Capability::MessagesRead],
+        ..ContextParams::default()
+    };
+    let handle = alice
+        .create_context(CONTEXT_ID, params)
+        .await
+        .expect("create_context must succeed");
+
+    // 3. Generate an ephemeral app keypair and build a minimal signed declaration.
+    let (signing_key, app_did) = app_signing_key_and_did();
+    let mut declaration = CapabilityDeclaration {
+        scp_version: "1.0".to_owned(),
+        app_id: app_did.clone(),
+        app_name: "Integration Test App".to_owned(),
+        app_version: "1.0.0".to_owned(),
+        capabilities: vec![CapabilityEntry {
+            // category "messaging", action "read" → Capability::MessagesRead
+            resource: format!("scp:ctx:{CONTEXT_ID}/messaging"),
+            actions: vec!["read".to_owned()],
+            constraints: None,
+        }],
+        min_role: "member".to_owned(),
+        signature: Vec::new(),
+    };
+    sign_declaration(&mut declaration, &signing_key)
+        .expect("sign_declaration must not fail on valid inputs");
+
+    // 4. Obtain the supervisor's shared event-log provider.
+    //    CRITICAL: this is the SAME Arc<dyn ContextEventLogProvider> whose
+    //    underlying `MerkleEventLogProvider` had its `logs` map populated by
+    //    `init_event_log` during `create_context`.  A freshly constructed
+    //    provider would have an empty map and all appends would fail.
+    let event_log = alice
+        .manager
+        .event_log_provider_arc()
+        .expect("Supervisor must hold an event-log provider after create_context");
+
+    // 5. Define context ceiling and role capabilities — both must cover
+    //    `MessagesRead` for `validate_declaration` to accept the request.
+    let ceiling = [Capability::MessagesRead];
+    let role_caps = [Capability::MessagesRead];
+
+    // 6. Call bind_app.  If `event_log` is the wrong provider instance this
+    //    call still succeeds (the append path is fallible but not fatal here)
+    //    but the event won't appear in the supervisor's shared log.
+    bind_app(
+        &declaration,
+        &ceiling,
+        &role_caps,
+        handle,
+        event_log.as_ref(),
+        ACTOR_DID,
+        1_700_000_000,
+    )
+    .await
+    .expect("bind_app must succeed");
+
+    // 7. Query the supervisor's shared event log and assert the AppBound event
+    //    is present — this fails if bind_app used the wrong (fresh) provider.
+    let context_key = context_id_to_bytes(CONTEXT_ID);
+    let events = alice
+        .manager
+        .event_log_entries(&context_key)
+        .expect("event_log_entries must not return Err")
+        .expect("event log must be initialised after create_context");
+
+    let has_app_bound = events.iter().any(|e| e.event_type == EventType::AppBound);
+    assert!(
+        has_app_bound,
+        "AppBound (tag 74) event must be present in the supervisor's durable \
+         event log after bind_app; got {} events with types: {:?}",
+        events.len(),
+        events.iter().map(|e| &e.event_type).collect::<Vec<_>>()
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Test 2: unbind_app writes AppUnbound after bind_app
+// ---------------------------------------------------------------------------
+
+/// Full bind→unbind round trip: verifies that `unbind_app` writes an
+/// `AppUnbound` event to the same shared event log, visible after the
+/// `AppBound` event from a preceding `bind_app`.
+#[tokio::test]
+async fn unbind_app_writes_appunbound_event_after_bind() {
+    let network = FullStackNetwork::new();
+    let alice = network.create_node(ACTOR_DID);
+
+    let params = ContextParams {
+        ceiling: vec![Capability::MessagesRead],
+        ..ContextParams::default()
+    };
+    let handle = alice
+        .create_context(CONTEXT_ID, params)
+        .await
+        .expect("create_context must succeed");
+
+    let (signing_key, app_did) = app_signing_key_and_did();
+    let mut declaration = CapabilityDeclaration {
+        scp_version: "1.0".to_owned(),
+        app_id: app_did.clone(),
+        app_name: "Roundtrip Test App".to_owned(),
+        app_version: "0.1.0".to_owned(),
+        capabilities: vec![CapabilityEntry {
+            resource: format!("scp:ctx:{CONTEXT_ID}/messaging"),
+            actions: vec!["read".to_owned()],
+            constraints: None,
+        }],
+        min_role: "member".to_owned(),
+        signature: Vec::new(),
+    };
+    sign_declaration(&mut declaration, &signing_key)
+        .expect("sign_declaration must not fail on valid inputs");
+
+    let event_log = alice
+        .manager
+        .event_log_provider_arc()
+        .expect("Supervisor must hold an event-log provider after create_context");
+
+    let ceiling = [Capability::MessagesRead];
+    let role_caps = [Capability::MessagesRead];
+
+    // Bind first.
+    bind_app(
+        &declaration,
+        &ceiling,
+        &role_caps,
+        handle,
+        event_log.as_ref(),
+        ACTOR_DID,
+        1_700_000_000,
+    )
+    .await
+    .expect("bind_app must succeed");
+
+    // Then unbind.
+    unbind_app(
+        CONTEXT_ID,
+        app_did.as_ref(),
+        event_log.as_ref(),
+        ACTOR_DID,
+        1_700_000_001,
+    )
+    .await
+    .expect("unbind_app must succeed");
+
+    // Both AppBound and AppUnbound must now be visible in the shared log.
+    let context_key = context_id_to_bytes(CONTEXT_ID);
+    let events = alice
+        .manager
+        .event_log_entries(&context_key)
+        .expect("event_log_entries must not return Err")
+        .expect("event log must be initialised");
+
+    let has_app_bound = events.iter().any(|e| e.event_type == EventType::AppBound);
+    let has_app_unbound = events.iter().any(|e| e.event_type == EventType::AppUnbound);
+
+    assert!(
+        has_app_bound,
+        "AppBound event must be present before AppUnbound; \
+         got {} events: {:?}",
+        events.len(),
+        events.iter().map(|e| &e.event_type).collect::<Vec<_>>()
+    );
+    assert!(
+        has_app_unbound,
+        "AppUnbound (tag 75) event must be present after unbind_app; \
+         got {} events: {:?}",
+        events.len(),
+        events.iter().map(|e| &e.event_type).collect::<Vec<_>>()
+    );
+}

--- a/crates/scp-testing/tests/integration/ffi_conformance.rs
+++ b/crates/scp-testing/tests/integration/ffi_conformance.rs
@@ -1431,7 +1431,9 @@ fn discovery_and_provenance_coverage() {
 // native bridge (PyO3 / UniFFI / NAPI) and removing the pass-1 bridge-alias
 // exemptions. Pure coverage expansion, not a swap for the removed
 // `economy_adjust_relay_price`.
-const MIN_PARITY_OPERATIONS: usize = 109;
+// +2: `sandbox_app_bind` and `sandbox_app_unbind` (spec §8.4) — durable
+// AppBound/AppUnbound event log appends across all three native bridges.
+const MIN_PARITY_OPERATIONS: usize = 111;
 
 // ---------------------------------------------------------------------------
 // Ratchet meta-tests — detect weakening of enforcement

--- a/crates/scp-testing/tests/integration/ffi_conformance.rs
+++ b/crates/scp-testing/tests/integration/ffi_conformance.rs
@@ -1431,7 +1431,7 @@ fn discovery_and_provenance_coverage() {
 // native bridge (PyO3 / UniFFI / NAPI) and removing the pass-1 bridge-alias
 // exemptions. Pure coverage expansion, not a swap for the removed
 // `economy_adjust_relay_price`.
-// +2: `sandbox_app_bind` and `sandbox_app_unbind` (spec §8.4) — durable
+// +2: `app_bind` and `app_unbind` (spec §8.4) — durable
 // AppBound/AppUnbound event log appends across all three native bridges.
 const MIN_PARITY_OPERATIONS: usize = 111;
 

--- a/crates/scp-testing/tests/integration/pipeline_wiring.rs
+++ b/crates/scp-testing/tests/integration/pipeline_wiring.rs
@@ -243,7 +243,7 @@ const NAPI_TRUST_SRC: &str = include_str!("../../../../crates/scp-ffi/napi/src/t
 // core `scp_core::trust::check_capability_requirements` call and the production
 // `IdentityDidPublicKeyResolver`. The 2J joiner (+4) and capability-admission
 // (+3) additions are disjoint, so the merged floor is 48 + 4 + 3 = 55.
-const MIN_ACTIVE_PIPELINE_ASSERTIONS: usize = 55;
+const MIN_ACTIVE_PIPELINE_ASSERTIONS: usize = 57;
 
 // ---------------------------------------------------------------------------
 // Function body extraction — brace-matching parser
@@ -3531,6 +3531,58 @@ fn ac8_streaming_saga_seal_commits_once_no_per_chunk_2pc() {
     assert!(
         !loop_body.contains("PrepareBStreaming"),
         "AC8: the per-chunk pump loop body must NOT run Prepare-B per chunk"
+    );
+}
+
+// ===========================================================================
+// App Sandboxing (spec §8.4) — AppBound / AppUnbound event log wiring
+// ===========================================================================
+
+/// Verifies that `sandbox_app_bind` (PyO3), `app_bind_on` (NAPI), and
+/// `sandbox_app_bind` (UniFFI) all route through the shared `bind_app`
+/// function from `app_sandbox`, which appends the durable `AppBound` (tag 74)
+/// event to the event log (spec §8.4.1 — silent app attachment is not
+/// possible).
+#[test]
+fn app_bind_wired_through_bind_app_all_bridges() {
+    assert!(
+        fn_body_contains(PYO3_CONTEXT_SRC, "sandbox_app_bind", "bind_app("),
+        "PyO3 sandbox_app_bind must route through bind_app (spec §8.4.1 — \
+         AppBound event log wiring)"
+    );
+    assert!(
+        fn_body_contains(NAPI_CONTEXT_SRC, "app_bind_on", "bind_app("),
+        "NAPI app_bind_on must route through bind_app (spec §8.4.1 — \
+         AppBound event log wiring)"
+    );
+    assert!(
+        fn_body_contains(UNIFFI_BRIDGE_SRC, "sandbox_app_bind", "bind_app("),
+        "UniFFI sandbox_app_bind must route through bind_app (spec §8.4.1 — \
+         AppBound event log wiring)"
+    );
+}
+
+/// Verifies that `sandbox_app_unbind` (PyO3), `app_unbind_on` (NAPI), and
+/// `sandbox_app_unbind` (UniFFI) all route through the shared `unbind_app`
+/// function from `app_sandbox`, which appends the durable `AppUnbound`
+/// (tag 75) event to the event log (spec §8.4.2 — silent app detachment is
+/// not possible).
+#[test]
+fn app_unbind_wired_through_unbind_app_all_bridges() {
+    assert!(
+        fn_body_contains(PYO3_CONTEXT_SRC, "sandbox_app_unbind", "unbind_app("),
+        "PyO3 sandbox_app_unbind must route through unbind_app (spec §8.4.2 — \
+         AppUnbound event log wiring)"
+    );
+    assert!(
+        fn_body_contains(NAPI_CONTEXT_SRC, "app_unbind_on", "unbind_app("),
+        "NAPI app_unbind_on must route through unbind_app (spec §8.4.2 — \
+         AppUnbound event log wiring)"
+    );
+    assert!(
+        fn_body_contains(UNIFFI_BRIDGE_SRC, "sandbox_app_unbind", "unbind_app("),
+        "UniFFI sandbox_app_unbind must route through unbind_app (spec §8.4.2 — \
+         AppUnbound event log wiring)"
     );
 }
 

--- a/crates/scp-testing/tests/integration/pipeline_wiring.rs
+++ b/crates/scp-testing/tests/integration/pipeline_wiring.rs
@@ -243,7 +243,7 @@ const NAPI_TRUST_SRC: &str = include_str!("../../../../crates/scp-ffi/napi/src/t
 // core `scp_core::trust::check_capability_requirements` call and the production
 // `IdentityDidPublicKeyResolver`. The 2J joiner (+4) and capability-admission
 // (+3) additions are disjoint, so the merged floor is 48 + 4 + 3 = 55.
-const MIN_ACTIVE_PIPELINE_ASSERTIONS: usize = 57;
+const MIN_ACTIVE_PIPELINE_ASSERTIONS: usize = 59;
 
 // ---------------------------------------------------------------------------
 // Function body extraction — brace-matching parser
@@ -3583,6 +3583,57 @@ fn app_unbind_wired_through_unbind_app_all_bridges() {
         fn_body_contains(UNIFFI_BRIDGE_SRC, "app_unbind", "unbind_app("),
         "UniFFI app_unbind must route through unbind_app (spec §8.4.2 — \
          AppUnbound event log wiring)"
+    );
+}
+
+/// Verifies that `app_bind` / `app_bind_on` in all three bridges fetch the
+/// shared `event_log_provider_arc()` from the supervisor rather than
+/// constructing a fresh provider via `build_event_log_provider`. A fresh
+/// provider has an empty `logs` map, so every append would fail with
+/// CTX-2057 ("no event log for context"). The regression the original bug
+/// introduced was identical to the `bind_app(` check above — both checks are
+/// needed because satisfying `bind_app(` does not preclude passing the wrong
+/// provider argument.
+#[test]
+fn event_log_provider_arc_wired_in_all_bridges() {
+    assert!(
+        fn_body_contains(PYO3_CONTEXT_SRC, "app_bind", "event_log_provider_arc("),
+        "PyO3 app_bind must obtain the provider via event_log_provider_arc() \
+         (spec §8.4.1 — must reuse supervisor's provider, not build a fresh one)"
+    );
+    assert!(
+        fn_body_contains(NAPI_CONTEXT_SRC, "app_bind_on", "event_log_provider_arc("),
+        "NAPI app_bind_on must obtain the provider via event_log_provider_arc() \
+         (spec §8.4.1 — must reuse supervisor's provider, not build a fresh one)"
+    );
+    assert!(
+        fn_body_contains(UNIFFI_BRIDGE_SRC, "app_bind", "event_log_provider_arc("),
+        "UniFFI app_bind must obtain the provider via event_log_provider_arc() \
+         (spec §8.4.1 — must reuse supervisor's provider, not build a fresh one)"
+    );
+}
+
+/// Verifies that none of the three FFI bridge sources call
+/// `build_event_log_provider` anywhere. That constructor produces a provider
+/// with an empty context-map; any bridge that reaches for it (instead of
+/// `event_log_provider_arc()`) would silently break every AppBound /
+/// AppUnbound append with CTX-2057 even when the supervisor is fully wired.
+#[test]
+fn build_event_log_provider_absent_from_all_bridges() {
+    assert!(
+        !PYO3_CONTEXT_SRC.contains("build_event_log_provider("),
+        "PyO3 bridge must NOT call build_event_log_provider() — \
+         use event_log_provider_arc() to obtain the shared provider"
+    );
+    assert!(
+        !NAPI_CONTEXT_SRC.contains("build_event_log_provider("),
+        "NAPI bridge must NOT call build_event_log_provider() — \
+         use event_log_provider_arc() to obtain the shared provider"
+    );
+    assert!(
+        !UNIFFI_BRIDGE_SRC.contains("build_event_log_provider("),
+        "UniFFI bridge must NOT call build_event_log_provider() — \
+         use event_log_provider_arc() to obtain the shared provider"
     );
 }
 

--- a/crates/scp-testing/tests/integration/pipeline_wiring.rs
+++ b/crates/scp-testing/tests/integration/pipeline_wiring.rs
@@ -243,6 +243,15 @@ const NAPI_TRUST_SRC: &str = include_str!("../../../../crates/scp-ffi/napi/src/t
 // core `scp_core::trust::check_capability_requirements` call and the production
 // `IdentityDidPublicKeyResolver`. The 2J joiner (+4) and capability-admission
 // (+3) additions are disjoint, so the merged floor is 48 + 4 + 3 = 55.
+// Raised 55 -> 59 by the app-sandbox (spec §8.4) AppBound/AppUnbound durable
+// event-log wiring: four new structural assertions —
+// `app_bind_wired_through_bind_app_all_bridges`,
+// `app_unbind_wired_through_unbind_app_all_bridges`,
+// `event_log_provider_arc_wired_in_all_bridges`, and
+// `build_event_log_provider_absent_from_all_bridges` — pin each bridge export
+// to the shared `bind_app`/`unbind_app` core functions and to the supervisor's
+// shared `event_log_provider_arc()`. Pure coverage expansion locking the §8.4
+// seams into the ratchet floor.
 const MIN_ACTIVE_PIPELINE_ASSERTIONS: usize = 59;
 
 // ---------------------------------------------------------------------------

--- a/crates/scp-testing/tests/integration/pipeline_wiring.rs
+++ b/crates/scp-testing/tests/integration/pipeline_wiring.rs
@@ -3538,16 +3538,16 @@ fn ac8_streaming_saga_seal_commits_once_no_per_chunk_2pc() {
 // App Sandboxing (spec §8.4) — AppBound / AppUnbound event log wiring
 // ===========================================================================
 
-/// Verifies that `sandbox_app_bind` (PyO3), `app_bind_on` (NAPI), and
-/// `sandbox_app_bind` (UniFFI) all route through the shared `bind_app`
+/// Verifies that `app_bind` (PyO3), `app_bind_on` (NAPI), and
+/// `app_bind` (UniFFI) all route through the shared `bind_app`
 /// function from `app_sandbox`, which appends the durable `AppBound` (tag 74)
 /// event to the event log (spec §8.4.1 — silent app attachment is not
 /// possible).
 #[test]
 fn app_bind_wired_through_bind_app_all_bridges() {
     assert!(
-        fn_body_contains(PYO3_CONTEXT_SRC, "sandbox_app_bind", "bind_app("),
-        "PyO3 sandbox_app_bind must route through bind_app (spec §8.4.1 — \
+        fn_body_contains(PYO3_CONTEXT_SRC, "app_bind", "bind_app("),
+        "PyO3 app_bind must route through bind_app (spec §8.4.1 — \
          AppBound event log wiring)"
     );
     assert!(
@@ -3556,22 +3556,22 @@ fn app_bind_wired_through_bind_app_all_bridges() {
          AppBound event log wiring)"
     );
     assert!(
-        fn_body_contains(UNIFFI_BRIDGE_SRC, "sandbox_app_bind", "bind_app("),
-        "UniFFI sandbox_app_bind must route through bind_app (spec §8.4.1 — \
+        fn_body_contains(UNIFFI_BRIDGE_SRC, "app_bind", "bind_app("),
+        "UniFFI app_bind must route through bind_app (spec §8.4.1 — \
          AppBound event log wiring)"
     );
 }
 
-/// Verifies that `sandbox_app_unbind` (PyO3), `app_unbind_on` (NAPI), and
-/// `sandbox_app_unbind` (UniFFI) all route through the shared `unbind_app`
+/// Verifies that `app_unbind` (PyO3), `app_unbind_on` (NAPI), and
+/// `app_unbind` (UniFFI) all route through the shared `unbind_app`
 /// function from `app_sandbox`, which appends the durable `AppUnbound`
 /// (tag 75) event to the event log (spec §8.4.2 — silent app detachment is
 /// not possible).
 #[test]
 fn app_unbind_wired_through_unbind_app_all_bridges() {
     assert!(
-        fn_body_contains(PYO3_CONTEXT_SRC, "sandbox_app_unbind", "unbind_app("),
-        "PyO3 sandbox_app_unbind must route through unbind_app (spec §8.4.2 — \
+        fn_body_contains(PYO3_CONTEXT_SRC, "app_unbind", "unbind_app("),
+        "PyO3 app_unbind must route through unbind_app (spec §8.4.2 — \
          AppUnbound event log wiring)"
     );
     assert!(
@@ -3580,8 +3580,8 @@ fn app_unbind_wired_through_unbind_app_all_bridges() {
          AppUnbound event log wiring)"
     );
     assert!(
-        fn_body_contains(UNIFFI_BRIDGE_SRC, "sandbox_app_unbind", "unbind_app("),
-        "UniFFI sandbox_app_unbind must route through unbind_app (spec §8.4.2 — \
+        fn_body_contains(UNIFFI_BRIDGE_SRC, "app_unbind", "unbind_app("),
+        "UniFFI app_unbind must route through unbind_app (spec §8.4.2 — \
          AppUnbound event log wiring)"
     );
 }

--- a/scripts/bridge-aliases.json
+++ b/scripts/bridge-aliases.json
@@ -2768,6 +2768,32 @@
       ]
     },
     {
+      "canonical": "sandbox_app_bind",
+      "category": "context",
+      "pyo3": [
+        "sandbox_app_bind"
+      ],
+      "uniffi": [
+        "sandbox_app_bind"
+      ],
+      "napi": [
+        "sandbox_app_bind"
+      ]
+    },
+    {
+      "canonical": "sandbox_app_unbind",
+      "category": "context",
+      "pyo3": [
+        "sandbox_app_unbind"
+      ],
+      "uniffi": [
+        "sandbox_app_unbind"
+      ],
+      "napi": [
+        "sandbox_app_unbind"
+      ]
+    },
+    {
       "canonical": "configure_relay_transport",
       "category": "transport",
       "pyo3": [

--- a/scripts/bridge-aliases.json
+++ b/scripts/bridge-aliases.json
@@ -2768,29 +2768,29 @@
       ]
     },
     {
-      "canonical": "sandbox_app_bind",
+      "canonical": "app_bind",
       "category": "context",
       "pyo3": [
-        "sandbox_app_bind"
+        "app_bind"
       ],
       "uniffi": [
-        "sandbox_app_bind"
+        "app_bind"
       ],
       "napi": [
-        "sandbox_app_bind"
+        "app_bind"
       ]
     },
     {
-      "canonical": "sandbox_app_unbind",
+      "canonical": "app_unbind",
       "category": "context",
       "pyo3": [
-        "sandbox_app_unbind"
+        "app_unbind"
       ],
       "uniffi": [
-        "sandbox_app_unbind"
+        "app_unbind"
       ],
       "napi": [
-        "sandbox_app_unbind"
+        "app_unbind"
       ]
     },
     {


### PR DESCRIPTION
## Summary

Implements spec §8.4 AppBound (tag 74) and AppUnbound (tag 75) durable event-log appends across all three FFI bridges (PyO3, NAPI, UniFFI) with full SDK wrappers across all four languages.

### What ships

- `bind_app` / `unbind_app` async functions in `scp-runtime` — serialize `AppBoundPayload` / `AppUnboundPayload` and append via `ContextEventLogProvider`
- PyO3 `sandbox_app_bind` / `sandbox_app_unbind` — returns JSON `{app_did, granted_capabilities}`
- NAPI `app_bind_on` / `app_unbind_on` — returns JSON `{appDid, grantedCapabilities}`
- UniFFI `sandbox_app_bind` / `sandbox_app_unbind` — queries authoritative role state via `GetRoleState` actor command
- Python SDK: `context_sandbox_app_bind` / `context_sandbox_app_unbind`
- TypeScript SDK: `contextSandboxAppBind` / `contextSandboxAppUnbind`
- Swift SDK: `contextSandboxAppBind` / `contextSandboxAppUnbind`
- Kotlin SDK: `contextSandboxAppBind` / `contextSandboxAppUnbind`
- Pipeline wiring assertions (`MIN_ACTIVE_PIPELINE_ASSERTIONS` → 57)
- FFI conformance parity (`MIN_PARITY_OPERATIONS` → 111)
- Error codes CTX_2056–2059 registered (bind-rejected, event-log-failed, bind-other, unbind)

### Correctness fixes (second commit)

- **Merkle convergence**: capabilities sorted before `encode_payload` — `HashSet` iteration is non-deterministic
- **Input validation**: `validate_did` added to PyO3 and NAPI bind/unbind (parity with UniFFI)
- **Was-bound check**: all three bridges verify the app is actually bound before writing `AppUnbound`
- **Registry leak**: UniFFI `bound_apps_registry` now cleaned up on `context_close` and `context_leave`
- **Error code unification**: all three bridges use `codes::CTX_2056–2059` (not inline literals or CTX_2030)
- **Payload field test**: `bind_app_payload_fields_match_scoped_handle` verifies AppBoundPayload contents

### Architectural follow-ups (filed, not blocking)

- #2230 — route `bind_app`/`unbind_app` through `ContextActor` (ADR-049 compliance)
- #2231 — persist validated `CapabilityDeclaration` durably (§8.4.1 step 5)
- #2232 — `check_scoped_capability` enforcement gap (`bound_apps` is dead write-only state)

Closes #1847