### PR TITLE
fix(scaffolds): modernize rotted standalone crates + add class-closing rust-scaffolds CI guard (closes #2009)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,6 +39,7 @@ jobs:
       kotlin: ${{ steps.filter.outputs.kotlin }}
       swift: ${{ steps.filter.outputs.swift }}
       fuzz: ${{ steps.filter.outputs.fuzz }}
+      rust-scaffolds: ${{ steps.filter.outputs.rust-scaffolds }}
     steps:
       - uses: actions/checkout@v5
       - uses: dorny/paths-filter@v3
@@ -99,6 +100,18 @@ jobs:
               - 'crates/scp-did/**'
               - 'crates/scp-dht/**'
               - 'crates/scp-mls/**'
+            rust-scaffolds:
+              # Standalone starter crates under templates/ and scaffolds/ each
+              # declare their OWN [workspace], so they are invisible to
+              # `cargo build --workspace` and every workspace CI job. A change to
+              # ANY workspace crate can drift the core API out from under them
+              # (the exact rot #2009 fixed), so a core-crate change must trigger
+              # the guard too — not just edits to the starters themselves.
+              - 'templates/**'
+              - 'scaffolds/**'
+              - 'crates/**'
+              - 'Cargo.toml'
+              - 'Cargo.lock'
 
   # ── Error codes ───────────────────────────────────────────────────
   error-codes:
@@ -919,6 +932,57 @@ jobs:
           bun run lint
           bun run build
 
+  # ── Rust standalone templates/scaffolds (class-closing, mirrors fuzz-build) ──
+  # Every crate under templates/ and scaffolds/ declares its OWN [workspace], so
+  # it is excluded from `cargo build --workspace` and from every other CI job —
+  # they silently rot whenever the core API drifts (#2009). This job discovers
+  # each standalone Cargo.toml dynamically and `cargo check --all-targets`es it,
+  # closing the class the same way fuzz-build guards the standalone fuzz crate.
+  rust-scaffolds:
+    needs: changes
+    if: needs.changes.outputs.rust-scaffolds == 'true'
+    name: Rust templates & scaffolds / check
+    runs-on: ubuntu-latest
+    steps:
+      - name: Free disk space
+        run: |
+          sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghc /opt/hostedtoolcache/CodeQL
+      - uses: actions/checkout@v5
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+      - name: cargo check every standalone template/scaffold crate
+        run: |
+          set -euo pipefail
+          found=0
+          failed=0
+          # Discover every standalone crate under templates/ and scaffolds/.
+          # `find | while read` via process substitution (bash-3 compatible; no
+          # bash-4 `mapfile`) keeps the counters in the current shell. fuzz/ is
+          # guarded by the fuzz-build job and lives outside these directories, so
+          # it is naturally excluded.
+          while IFS= read -r manifest; do
+            found=$((found + 1))
+            echo "::group::cargo check ${manifest}"
+            if cargo check --manifest-path "${manifest}" --all-targets; then
+              echo "OK: ${manifest}"
+            else
+              echo "::error::cargo check failed for ${manifest}"
+              failed=$((failed + 1))
+            fi
+            echo "::endgroup::"
+          done < <(find templates scaffolds -name Cargo.toml | sort)
+          # Discovery tripwire: if the find ever returns nothing (dirs renamed,
+          # crates removed), fail loud rather than pass green on zero coverage.
+          if [ "${found}" -eq 0 ]; then
+            echo "::error::no standalone Cargo.toml found under templates/ or scaffolds/ — discovery is broken"
+            exit 1
+          fi
+          if [ "${failed}" -ne 0 ]; then
+            echo "::error::${failed} of ${found} standalone crate(s) failed cargo check"
+            exit 1
+          fi
+          echo "All ${found} standalone template/scaffold crate(s) passed cargo check."
+
   # ── Kotlin ──────────────────────────────────────────────────────────
   kotlin-lint:
     needs: changes
@@ -1330,6 +1394,7 @@ jobs:
       - typescript-check
       - typescript-wasm-check
       - scaffold-typescript-web-check
+      - rust-scaffolds
       - kotlin-lint
       - kotlin-test
       - swift-lint
@@ -1378,6 +1443,7 @@ jobs:
             "${{ needs.typescript-check.result }}" \
             "${{ needs.typescript-wasm-check.result }}" \
             "${{ needs.scaffold-typescript-web-check.result }}" \
+            "${{ needs.rust-scaffolds.result }}" \
             "${{ needs.kotlin-lint.result }}" \
             "${{ needs.kotlin-test.result }}" \
             "${{ needs.swift-lint.result }}" \

--- a/scaffolds/relay/.gitignore
+++ b/scaffolds/relay/.gitignore
@@ -1,0 +1,1 @@
+/Cargo.lock

--- a/scaffolds/rust-client/.gitignore
+++ b/scaffolds/rust-client/.gitignore
@@ -1,0 +1,1 @@
+/Cargo.lock

--- a/scaffolds/rust-client/Cargo.toml
+++ b/scaffolds/rust-client/Cargo.toml
@@ -6,10 +6,14 @@ publish = false
 
 [dependencies]
 scp-core = { path = "../../crates/scp-core", features = ["testing"] }
-scp-dht = { path = "../../crates/scp-dht" }
+scp-dht = { path = "../../crates/scp-dht", features = ["testing"] }
 scp-did = { path = "../../crates/scp-did" }
 scp-identity = { path = "../../crates/scp-identity" }
 scp-platform = { path = "../../crates/scp-platform", features = ["testing"] }
+scp-clock = { path = "../../crates/scp-clock" }
+scp-event-log = { path = "../../crates/scp-event-log" }
+async-trait = "0.1"
+ed25519-dalek = "2"
 tokio = { version = "1", features = ["full"] }
 
 [workspace]

--- a/scaffolds/rust-client/src/main.rs
+++ b/scaffolds/rust-client/src/main.rs
@@ -1,59 +1,89 @@
 //! Minimal SCP client in Rust.
 //!
-//! This scaffold demonstrates the core SCP workflow:
+//! This scaffold demonstrates the core SCP workflow on the current
+//! actor-per-context runtime (ADR-049):
 //! 1. Create a DID identity
-//! 2. Create an encrypted context
-//! 3. Send a message
+//! 2. Build a [`Supervisor`] with providers
+//! 3. Create an encrypted context
+//! 4. Send a message
+//! 5. Drain the resulting events
 //!
-//! Uses mock providers for crypto, transport, and event log.
-//! Replace these with production implementations for real usage:
-//! - `scp-core::crypto::mls::provider` for MLS encryption
-//! - `scp-transport` for relay transport
-//! - `scp-event-log` for Merkle event log
+//! Crypto is the real [`NodeMlsFactory`] (MLS) over an in-memory OpenMLS
+//! storage adapter; transport and event-log use mock providers. Replace these
+//! with production implementations for real usage:
+//! - a real `scp_transport::RelayTransportProvider` for relay transport
+//! - `MerkleEventLogProvider::with_persistence(...)` for the Merkle event log
+//! - a durable `scp_platform::Storage` (SQLCipher) behind the MLS storage adapter
+//!
+//! Run:
+//!   `cargo run`
 
 use std::sync::Arc;
 
-use scp_core::context::builder::{
-    AddMemberOutput, ContextCryptoProvider, ContextEventLogProvider, ContextTransportProvider,
-    RemoveMemberOutput,
-};
+use scp_clock::SystemClock;
+use scp_core::context::builder::{ContextEventLogProvider, ContextTransportProvider};
 use scp_core::context::governance::KeyResolver;
-use scp_core::context::manager::ContextManager;
+use scp_core::context::supervisor::{MessageSigner, Supervisor};
 use scp_core::context::{
     Capability, ContextCreationError, ContextError, ContextMode, ContextParams,
 };
-use scp_identity::cache::DidCache;
-use scp_identity::dht::DidDht;
+use scp_core::crypto::mls::NodeMlsFactory;
+use scp_core::crypto::mls::storage_adapter::SpawnBlockingStorageAdapter;
 use scp_dht::InMemoryDhtClient;
 use scp_did::DID;
+use scp_event_log::{EventPayload, EventType};
+use scp_identity::cache::DidCache;
+use scp_identity::dht::DidDht;
 use scp_identity::DidMethod;
-use scp_platform::testing::InMemoryKeyCustody;
+use scp_platform::in_memory::InMemoryStorage;
+use scp_platform::testing::{InMemoryKeyCustody, InMemoryPreRotationCustody};
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
     // ── 1. Create a DID identity ──────────────────────────────────
+    // The DID is self-certifying; `create` also stores a cold pre-rotation
+    // commitment (spec §9.7.4.1) in a *distinct* custody instance.
     let custody = Arc::new(InMemoryKeyCustody::new());
+    let pre_rotation_custody = InMemoryPreRotationCustody::new();
     let dht_client = Arc::new(InMemoryDhtClient::new());
     let cache = Arc::new(DidCache::new());
     let sign_fn = DidDht::<InMemoryDhtClient>::make_sign_fn(Arc::clone(&custody));
     let did_dht = DidDht::with_client_and_signer(dht_client, cache, sign_fn);
 
-    let (identity, document) = did_dht.create(&*custody).await?;
+    let (identity, document, _pre_rotation_handle) =
+        did_dht.create(&*custody, &pre_rotation_custody).await?;
     did_dht.publish(&identity, &document).await?;
     println!("Created identity: {}", identity.did);
 
-    // ── 2. Build a ContextManager ─────────────────────────────────
-    let key_resolver: KeyResolver =
-        Arc::new(|_did: &DID, _kid: scp_did::SigningKeyId| None);
-    let manager = ContextManager::new(
-        Box::new(MockCrypto),
+    let did = DID(identity.did.clone());
+
+    // ── 2. Build a Supervisor with providers ──────────────────────
+    // Crypto is the production MLS factory bound to our DID; transport and
+    // event log are mocks. `mls_storage` is a required, explicitly-selected
+    // capability — here the in-memory dev arm behind the spawn-blocking adapter.
+    let crypto = Arc::new(NodeMlsFactory::new(
+        identity.did.clone(),
+        Arc::new(SystemClock),
+    ));
+    let mls_storage = Arc::new(SpawnBlockingStorageAdapter::new(Arc::new(
+        InMemoryStorage::new(),
+    )));
+    let key_resolver: KeyResolver = Arc::new(|_did: &DID, _kid: scp_did::SigningKeyId| None);
+
+    let manager = Supervisor::with_providers(
+        crypto,
         Box::new(MockTransport),
         Box::new(MockEventLog),
         key_resolver,
+        None, // persistence: in-memory only
+        None, // payment adapter
+        None, // event broadcast sender
+        None, // clock override (defaults to SystemClock)
+        mls_storage,
     );
 
-    let did = DID(identity.did.clone());
-    manager.register_local_did(did.clone()).await;
+    // Register our DID so the supervisor recognizes us as a local participant.
+    manager.register_local_did(did.clone()).await?;
 
     // ── 3. Create an encrypted context ────────────────────────────
     let params = ContextParams {
@@ -71,11 +101,25 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let handle = manager
         .create_context("my-context".to_owned(), params, did.clone(), None)
         .await?;
-    println!("Created context: {}", handle.context_id());
+    println!(
+        "Created context: {} (state: {:?})",
+        handle.context_id(),
+        handle.state()
+    );
 
     // ── 4. Send a message ─────────────────────────────────────────
+    // In production the message is signed by the identity's `#active` key via
+    // the SDK; this scaffold derives a demo key deterministically from the DID.
+    let signing_key = demo_signing_key(&identity.did);
     manager
-        .send_message(&handle, &did, b"Hello, SCP!", None, None)
+        .send_message(
+            &handle,
+            &did,
+            b"Hello, SCP!",
+            MessageSigner::Active(&signing_key),
+            None, // source provenance (cross-context only)
+            None, // spending UCAN (paid actions only)
+        )
         .await?;
     println!("Message sent.");
 
@@ -89,101 +133,68 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     Ok(())
 }
 
-// ── Mock providers (replace with production implementations) ──────
-
-struct MockCrypto;
-impl ContextCryptoProvider for MockCrypto {
-    fn validate_creator_identity(&self) -> Result<(), ContextCreationError> {
-        Ok(())
-    }
-    fn create_mls_group(&self, _id: &[u8; 32]) -> Result<(), ContextCreationError> {
-        Ok(())
-    }
-    fn generate_sender_key(&self, _id: &[u8; 32]) -> Result<(), ContextCreationError> {
-        Ok(())
-    }
-    fn init_broadcast_key(&self, _id: &[u8; 32]) -> Result<(), ContextCreationError> {
-        Ok(())
-    }
-    fn destroy_mls_group(&self, _id: &[u8; 32]) -> Result<(), ContextCreationError> {
-        Ok(())
-    }
-    fn destroy_sender_key(&self, _id: &[u8; 32]) -> Result<(), ContextCreationError> {
-        Ok(())
-    }
-    fn validate_key_package(
-        &self,
-        _owner_did: &str,
-        _key_package_bytes: Option<&[u8]>,
-    ) -> Result<(), ContextError> {
-        Ok(())
-    }
-    fn encrypt_message(
-        &self,
-        _id: &[u8; 32],
-        _sender_did: &str,
-        payload: &[u8],
-        _epoch: u64,
-        _sequence: u64,
-    ) -> Result<Vec<u8>, ContextError> {
-        Ok(payload.to_vec())
-    }
-    fn add_member(
-        &self,
-        _id: &[u8; 32],
-        _member_did: &str,
-        _key_package_bytes: Option<&[u8]>,
-    ) -> Result<AddMemberOutput, ContextError> {
-        Ok(AddMemberOutput::default())
-    }
-    fn remove_member(
-        &self,
-        _id: &[u8; 32],
-        _member_did: &str,
-    ) -> Result<RemoveMemberOutput, ContextError> {
-        Ok(RemoveMemberOutput::default())
-    }
-    fn distribute_sender_key(&self, _id: &[u8; 32], _member_did: &str) -> Result<(), ContextError> {
-        Ok(())
-    }
-    fn remove_member_sender_key(
-        &self,
-        _id: &[u8; 32],
-        _member_did: &str,
-    ) -> Result<(), ContextError> {
-        Ok(())
-    }
+/// Derives a deterministic Ed25519 signing key from a DID for demonstration.
+///
+/// Production clients sign with the identity's real `#active` verification-method
+/// key held in key custody; this helper keeps the scaffold self-contained.
+fn demo_signing_key(did: &str) -> ed25519_dalek::SigningKey {
+    use std::hash::{Hash, Hasher};
+    let mut hasher = std::collections::hash_map::DefaultHasher::new();
+    did.hash(&mut hasher);
+    let h = hasher.finish();
+    let mut seed = [0u8; 32];
+    seed[..8].copy_from_slice(&h.to_le_bytes());
+    ed25519_dalek::SigningKey::from_bytes(&seed)
 }
 
+// ── Mock providers (replace with production implementations) ──────
+
+/// Mock transport — reports connected; all sends succeed silently.
 struct MockTransport;
+
+#[async_trait::async_trait]
 impl ContextTransportProvider for MockTransport {
     fn is_connected(&self) -> bool {
         true
     }
-    fn publish_context(
+    async fn publish_context(
         &self,
         _id: &[u8; 32],
         _params: &ContextParams,
     ) -> Result<(), ContextCreationError> {
         Ok(())
     }
-    fn delete_published(&self, _id: &[u8; 32]) -> Result<(), ContextCreationError> {
+    async fn delete_published(&self, _id: &[u8; 32]) -> Result<(), ContextCreationError> {
         Ok(())
     }
-    fn send_message(&self, _id: &[u8; 32], _encrypted_payload: &[u8]) -> Result<(), ContextError> {
+    async fn send_message(
+        &self,
+        _id: &[u8; 32],
+        _encrypted_payload: &[u8],
+    ) -> Result<(), ContextError> {
         Ok(())
     }
 }
 
+/// Mock event log — all operations succeed with no persistence.
 struct MockEventLog;
+
+#[async_trait::async_trait]
 impl ContextEventLogProvider for MockEventLog {
-    fn init_event_log(&self, _id: &[u8; 32]) -> Result<(), ContextCreationError> {
+    async fn init_event_log(&self, _id: &[u8; 32]) -> Result<(), ContextCreationError> {
         Ok(())
     }
-    fn append_event(&self, _id: &[u8; 32], _event: &str, _actor_did: &str, _payload: Option<&serde_json::Value>) -> Result<(), ContextCreationError> {
+    async fn append_event(
+        &self,
+        _id: &[u8; 32],
+        _event_type: EventType,
+        _actor_did: &str,
+        _payload: EventPayload,
+        _timestamp_secs: u64,
+    ) -> Result<(), ContextCreationError> {
         Ok(())
     }
-    fn destroy_event_log(&self, _id: &[u8; 32]) -> Result<(), ContextCreationError> {
+    async fn destroy_event_log(&self, _id: &[u8; 32]) -> Result<(), ContextCreationError> {
         Ok(())
     }
 }

--- a/templates/cross-context-bridge/src/main.rs
+++ b/templates/cross-context-bridge/src/main.rs
@@ -5,9 +5,9 @@
 //!
 //!   1. Create two contexts with separate identities and role states.
 //!   2. Register a tool in Context A (the provider).
-//!   3. Context A exposes the tool to Context B via `expose_tool`.
+//!   3. Context A exposes the tool to Context B via `expose_outlet`.
 //!   4. Publish an `InterfaceOffer` (governance approval step).
-//!   5. Context B accepts the offer via `accept_tool_interface`.
+//!   5. Context B accepts the offer via `accept_outlet_interface`.
 //!   6. A participant in Context B invokes the tool across contexts via
 //!      `invoke_cross_context` — the bridge routes the call to Context A,
 //!      executes, and returns the result with provenance events for both
@@ -17,7 +17,7 @@
 //!   `cargo run`
 
 use scp_core::context::outlets::interface::{
-    accept_tool_interface, create_interface_offer, expose_tool, invoke_cross_context,
+    accept_outlet_interface, create_interface_offer, expose_outlet, invoke_cross_context,
     InboundPolicy, OutboundPolicy, RateLimit,
 };
 use scp_core::context::outlets::{
@@ -151,7 +151,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     let rate_limit = RateLimit::new(60, Duration::from_secs(60), &scp_clock::SystemClock);
 
-    let mut interface = expose_tool(
+    let mut interface = expose_outlet(
         ctx_a.context_id(),
         &outlet_id,
         &ctx_b.context_id().to_owned(),
@@ -196,7 +196,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         require_spending_ucan: false,
     };
 
-    accept_tool_interface(
+    accept_outlet_interface(
         ctx_b.context_id(),
         &mut interface,
         &role_state_b,

--- a/templates/personal-relay/.gitignore
+++ b/templates/personal-relay/.gitignore
@@ -1,0 +1,1 @@
+/Cargo.lock

--- a/templates/personal-relay/src/main.rs
+++ b/templates/personal-relay/src/main.rs
@@ -3,8 +3,9 @@
 //! A self-hosted relay node that:
 //! - Creates or reloads a persistent relay identity (DID)
 //! - Provisions TLS via Let's Encrypt (ACME), self-signed certs, or manual PEM files
-//! - Starts an `ApplicationNode` with relay, HTTP, and WebSocket endpoints
-//! - Publishes the relay's DID to the DHT for discovery
+//! - Starts an [`ApplicationNode`] (via the flat [`NodeConfig`] + [`Node::start`]
+//!   surface, ADR-052) with relay, HTTP, and WebSocket endpoints
+//! - Publishes the relay's DID to the DHT for discovery (`DhtMode::Production`)
 //! - Includes a health check endpoint (`/healthz`)
 //! - Shuts down gracefully on SIGINT/SIGTERM
 //!
@@ -22,7 +23,7 @@ use axum::routing::get;
 use scp_clock::SystemClock;
 use scp_dht::PkarrDhtClient;
 use scp_identity::{DidDht, IdentityError, SequenceStore};
-use scp_node::{ApplicationNodeBuilder, TlsProvider};
+use scp_node::{DhtMode, IdentitySource, Node, NodeConfig, Reach, TlsMode, TlsProvider};
 use scp_platform::sqlite::{SqliteKeyCustody, SqliteStorage};
 use scp_platform::traits::Storage;
 use scp_transport::native::storage::BlobStorageBackend;
@@ -241,26 +242,9 @@ impl TlsProvider for ManualTlsProvider {
     }
 }
 
-/// TLS provider that generates a self-signed certificate (development only).
-struct SelfSignedTlsProvider {
-    domain: String,
-}
-
-impl TlsProvider for SelfSignedTlsProvider {
-    fn provision(
-        &self,
-    ) -> Pin<
-        Box<
-            dyn std::future::Future<
-                    Output = Result<scp_node::tls::CertificateData, scp_node::tls::TlsError>,
-                > + Send
-                + '_,
-        >,
-    > {
-        let domain = self.domain.clone();
-        Box::pin(async move { scp_node::tls::generate_self_signed(&domain) })
-    }
-}
+// Self-signed TLS is now selected declaratively via [`TlsMode::SelfSigned`]
+// (ADR-052); `scp-node` provisions the self-signed certificate internally, so
+// this template no longer carries its own self-signed `TlsProvider`.
 
 // ---------------------------------------------------------------------------
 // DHT client
@@ -410,128 +394,116 @@ async fn main() {
         std::process::exit(1);
     });
 
-    // Determine the domain. Without a domain, use no_domain (NAT-traversed) mode.
-    let domain = config.domain.clone();
+    // Re-open a fresh SQLite handle for the node's ProtocolRepository (the
+    // Arc<SqliteStorage> above is used for the BEP44 sequence store; the node
+    // needs its own handle). SqliteStorage is SQLCipher-encrypted, satisfying
+    // the `EncryptedStorage` seal required by the production `Node::start` path.
+    let node_storage = open_sqlite_or_exit(&config.storage_path, &storage_key);
 
-    // Re-open a fresh SQLite handle for the ApplicationNodeBuilder (the
-    // Arc<SqliteStorage> above is used for the sequence store; the builder
-    // needs its own handle for ProtocolRepository).
-    let builder_storage = open_sqlite_or_exit(&config.storage_path, &storage_key);
+    // Addressing (ADR-052 `Reach` XOR): a configured domain serves a public
+    // DNS name (`wss://<domain>/scp/v1`); without one, run zero-config
+    // NAT-traversed mode (§10.12.8) and publish a `ws://` relay URL.
+    let reach = match config.domain {
+        Some(ref domain_str) => Reach::Domain {
+            domain: domain_str.clone(),
+        },
+        None => Reach::NatTraversal,
+    };
 
-    match domain {
-        Some(ref domain_str) => {
-            tracing::info!(
-                domain = %domain_str,
-                bind_addr = %config.bind_addr,
-                storage = %config.storage_path.display(),
-                "starting personal relay (domain mode)"
-            );
-
-            let mut builder = ApplicationNodeBuilder::new()
-                .storage(builder_storage)
-                .domain(domain_str)
-                .identity_with_storage(Arc::clone(&custody), Arc::clone(&did_method))
-                .blob_storage(blob_storage)
-                .bind_addr(SocketAddr::from(([127, 0, 0, 1], 0)))
-                .http_bind_addr(config.bind_addr);
-
-            // TLS provider selection: manual certs > self-signed > ACME (default).
-            if let (Some(cert_path), Some(key_path)) =
-                (config.tls_cert_path.clone(), config.tls_key_path.clone())
-            {
-                tracing::info!(
-                    cert = %cert_path.display(),
-                    key = %key_path.display(),
-                    "using manual TLS certificates"
-                );
-                builder = builder.tls_provider(Arc::new(ManualTlsProvider {
-                    cert_path,
-                    key_path,
-                }));
-            } else if config.tls_self_signed {
-                tracing::warn!(
-                    "using self-signed TLS certificate (development only, not trusted by browsers)"
-                );
-                builder = builder.tls_provider(Arc::new(SelfSignedTlsProvider {
-                    domain: domain_str.clone(),
-                }));
-            } else if let Some(ref email) = config.acme_email {
-                tracing::info!(email = %email, "ACME email set for Let's Encrypt");
-                builder = builder.acme_email(email);
-            }
-
-            let node = match builder.build().await {
-                Ok(n) => n,
-                Err(e) => {
-                    tracing::error!(error = %e, "failed to build application node");
-                    std::process::exit(1);
+    // TLS selection (ADR-052 `TlsMode`): manual PEM certs > self-signed > the
+    // reach-appropriate default. A domain reach defaults to headless ACME
+    // (Let's Encrypt), optionally with a contact email; a NAT-traversed reach
+    // has no DNS name to provision a certificate for, so it serves plaintext
+    // (MLS still provides real confidentiality) — `TlsMode::Acme` on a
+    // non-`Domain` reach is a loud configuration error by design.
+    let tls = if let (Some(cert_path), Some(key_path)) =
+        (config.tls_cert_path.clone(), config.tls_key_path.clone())
+    {
+        tracing::info!(
+            cert = %cert_path.display(),
+            key = %key_path.display(),
+            "using manual TLS certificates"
+        );
+        TlsMode::Custom(Arc::new(ManualTlsProvider {
+            cert_path,
+            key_path,
+        }))
+    } else if config.tls_self_signed {
+        tracing::warn!(
+            "using self-signed TLS certificate (development only, not trusted by browsers)"
+        );
+        TlsMode::SelfSigned
+    } else {
+        match reach {
+            Reach::Domain { .. } => {
+                if let Some(ref email) = config.acme_email {
+                    tracing::info!(email = %email, "ACME email set for Let's Encrypt");
                 }
-            };
-
-            // Initialize BEP44 sequence number from persistent store / DHT.
-            let did = node.identity().did().to_owned();
-            if let Err(e) = did_method.initialize_sequence(&did).await {
-                tracing::error!(
-                    error = %e,
-                    "failed to initialize BEP44 sequence -- DID publishing may fail"
-                );
-            }
-
-            tracing::info!(
-                did = %node.identity().did(),
-                relay_url = %node.relay_url(),
-                relay_internal_addr = %node.relay().bound_addr(),
-                "personal relay identity ready -- DID published to DHT"
-            );
-
-            if let Err(e) = node.serve(app_router(), shutdown_signal()).await {
-                tracing::error!(error = %e, "relay exited with error");
-                std::process::exit(1);
-            }
-        }
-        None => {
-            tracing::info!(
-                bind_addr = %config.bind_addr,
-                storage = %config.storage_path.display(),
-                "starting personal relay (no-domain / NAT-traversed mode)"
-            );
-
-            let builder = ApplicationNodeBuilder::new()
-                .storage(builder_storage)
-                .no_domain()
-                .identity_with_storage(Arc::clone(&custody), Arc::clone(&did_method))
-                .blob_storage(blob_storage)
-                .bind_addr(SocketAddr::from(([127, 0, 0, 1], 0)))
-                .http_bind_addr(config.bind_addr);
-
-            let node = match builder.build().await {
-                Ok(n) => n,
-                Err(e) => {
-                    tracing::error!(error = %e, "failed to build application node");
-                    std::process::exit(1);
+                TlsMode::Acme {
+                    email: config.acme_email.clone(),
                 }
-            };
-
-            let did = node.identity().did().to_owned();
-            if let Err(e) = did_method.initialize_sequence(&did).await {
-                tracing::error!(
-                    error = %e,
-                    "failed to initialize BEP44 sequence -- DID publishing may fail"
-                );
             }
-
-            tracing::info!(
-                did = %node.identity().did(),
-                relay_url = %node.relay_url(),
-                relay_internal_addr = %node.relay().bound_addr(),
-                "personal relay identity ready -- DID published to DHT"
-            );
-
-            if let Err(e) = node.serve(app_router(), shutdown_signal()).await {
-                tracing::error!(error = %e, "relay exited with error");
-                std::process::exit(1);
-            }
+            _ => TlsMode::Plaintext,
         }
+    };
+
+    tracing::info!(
+        reach = ?reach,
+        bind_addr = %config.bind_addr,
+        storage = %config.storage_path.display(),
+        "starting personal relay"
+    );
+
+    // A personal relay is meant to be discoverable, so publish its DID document
+    // (and thus its address) to the global Mainline DHT — a deliberate
+    // `DhtMode::Production` opt-in (ADR-052 M2). Identity is load-or-created and
+    // persisted into the node's own storage across restarts
+    // (`IdentitySource::Persisted`), reusing the same `DidDht` whose
+    // storage-backed sequence store keeps BEP44 sequence numbers monotonic.
+    let node = match Node::start(NodeConfig {
+        dht: DhtMode::Production,
+        tls,
+        bind_addr: Some(SocketAddr::from(([127, 0, 0, 1], 0))),
+        http_bind_addr: Some(config.bind_addr),
+        ..NodeConfig::defaults(
+            reach,
+            IdentitySource::Persisted {
+                custody: Arc::clone(&custody),
+                did_method: Arc::clone(&did_method),
+            },
+            node_storage,
+            blob_storage,
+        )
+    })
+    .await
+    {
+        Ok(n) => n,
+        Err(e) => {
+            tracing::error!(error = %e, "failed to start application node");
+            std::process::exit(1);
+        }
+    };
+
+    // Initialize BEP44 sequence number from persistent store / DHT so DID
+    // document updates use monotonically increasing sequence numbers.
+    let did = node.identity().did().to_owned();
+    if let Err(e) = did_method.initialize_sequence(&did).await {
+        tracing::error!(
+            error = %e,
+            "failed to initialize BEP44 sequence -- DID publishing may fail"
+        );
+    }
+
+    tracing::info!(
+        did = %node.identity().did(),
+        relay_url = %node.relay_url(),
+        relay_internal_addr = %node.relay().bound_addr(),
+        "personal relay identity ready -- DID published to DHT"
+    );
+
+    if let Err(e) = node.serve(app_router(), shutdown_signal()).await {
+        tracing::error!(error = %e, "relay exited with error");
+        std::process::exit(1);
     }
 
     tracing::info!("personal relay stopped");


### PR DESCRIPTION
The standalone crates under `templates/` and `scaffolds/` each declare their own `[workspace]`, so they're excluded from `cargo build --workspace` **and every CI job** — they silently rot whenever the core API drifts. On current main 3 of 4 were broken.

## Fixed (each `cargo check --all-targets` clean; runnable ones execute end-to-end)
- **cross-context-bridge** — tools→outlets rename (`expose_tool`→`expose_outlet`, `accept_tool_interface`→`accept_outlet_interface`).
- **personal-relay** — `ApplicationNodeBuilder` deleted (ADR-052); rebuilt on `Node::start(NodeConfig{..})` (Reach/TlsMode/IdentitySource/DhtMode).
- **rust-client** — ADR-049 actor-model rewrite: `ContextManager`/`ContextCryptoProvider` gone → `Supervisor::with_providers` + `NodeMlsFactory`; typed 6-arg `append_event`; `DidDht::create` pre-rotation-custody 3-tuple; added the missing `scp-dht/testing` feature (root cause of the `InMemoryDhtClient` error).
- **relay** — already clean; now covered.

## Root-cause fix — CI guard
New `rust-scaffolds` job: **dynamically discovers** every standalone `Cargo.toml` under `templates/`+`scaffolds/` and `cargo check --all-targets`es each (mirrors the `fuzz-build` class-closing pattern), with a **zero-discovery tripwire** (can't pass green on empty coverage). Path-filtered on `templates/`/`scaffolds/`/`crates/` (API drift is what rots them), wired into the `ci` aggregation gate. Purely additive — no existing gate changed.

Verified: all 4 check clean; clippy `-D warnings` clean on the 3 modified; YAML valid; the exact CI step passes locally and fails-then-reverts on a reintroduced drift.

Closes #2009.

🤖 Generated with [Claude Code](https://claude.com/claude-code)