### PR TITLE
fix(context): install genesis-declared ContextParams.outlets at create + welcome-join (closes #2020)

### DIFF
--- a/crates/scp-runtime/src/context/builder.rs
+++ b/crates/scp-runtime/src/context/builder.rs
@@ -823,6 +823,20 @@ fn validate_params(params: &ContextParams) -> Result<(), ContextCreationError> {
     // policy is Governed, that is technically valid (no capabilities to
     // narrow). No structural constraint to enforce here.
 
+    // §5.1/§5.12: outlets are declared at creation and installed into the live
+    // registry (GitHub #2020). Reject a genesis outlet set that would exceed the
+    // per-context registry cap here, at creation, so the genesis-seeding path
+    // (`state::fresh_governance_state`) and the runtime governance-registration
+    // path (`governance_helpers::execute_register_outlet`) enforce the SAME
+    // `MAX_REGISTERED_OUTLETS` bound — no genesis bypass of the cap.
+    if params.outlets.len() > crate::context::state::MAX_REGISTERED_OUTLETS {
+        return Err(ContextCreationError::CreationFailed(format!(
+            "genesis outlet count {} exceeds the per-context limit of {}",
+            params.outlets.len(),
+            crate::context::state::MAX_REGISTERED_OUTLETS,
+        )));
+    }
+
     // Validate memory scope is permitted for the context mode (§5.11).
     // Broadcast contexts only support MemoryScope::Full — Ephemeral and
     // Summary require MLS group state destruction which broadcast mode lacks.
@@ -1108,6 +1122,59 @@ pub async fn create_context(
         return Err(e.into());
     }
 
+    // Step 8.5: Append one `OutletRegistered` leaf per genesis-declared outlet
+    // (§5.1/§5.12 "declared at creation"; GitHub #2020). The creator is the
+    // authoritative event-log writer, so these leaves are appended HERE — the
+    // same append boundary that just wrote `ContextCreated`/`MemberJoined` —
+    // reusing the exact `EventType::OutletRegistered` leaf that
+    // `governance_helpers::execute_register_outlet` emits for the runtime
+    // governance-registration path, so genesis-seeded and governance-registered
+    // outlets are UNIFORM authenticated log leaves (§5.4: "silent outlet
+    // modification is not possible — any change is visible to all context
+    // members"). The corresponding live-registry seed happens in
+    // `state::fresh_governance_state`; a Welcome-joiner receives these leaves via
+    // log replication (dormant today, exactly like the `ContextCreated` leaf) and
+    // seeds its own registry from the same `params.outlets`. `actor_did` is the
+    // creator (the genesis declarant), and every leaf carries the convergent
+    // creator-assigned `creation_timestamp_secs` (§7.3.1, §9.9.3). A failure
+    // rolls back the whole creation, exactly like the leaves above.
+    //
+    // NOTE (uniformity finding, GitHub #2020 requirement 3): neither this genesis
+    // path NOR `execute_register_outlet` verifies an `OutletRegistration`'s
+    // §5.4.1 operator signature today — `verify_outlet_registration_signature`
+    // exists but has no production caller. The two paths are therefore uniform
+    // (both unverified); this genesis path introduces no bypass. Wiring signature
+    // verification into BOTH paths is a separate, pre-existing gap.
+    //
+    // The leaf is unparameterized (`EventPayload::default()`) — byte-for-byte the
+    // same append `execute_register_outlet` makes via `append_context_event`, so
+    // one leaf is emitted per genesis outlet without embedding the registration
+    // body (which is seeded into live state by `state::fresh_governance_state`).
+    for _outlet in &params.outlets {
+        if let Err(e) = event_log_provider
+            .append_event(
+                &id_bytes,
+                scp_event_log::EventType::OutletRegistered,
+                creator_did,
+                scp_event_log::EventPayload::default(),
+                creation_timestamp_secs,
+            )
+            .await
+        {
+            // #2148 F6: eagerly free the born-but-never-seeded crypto (signer
+            // freed, NOT zeroized — #82) before it drops on this rollback.
+            // `owned_crypto` is still live (returned to the caller on success at
+            // step 9), so it is the live owner here.
+            if let Some(mut owned) = owned_crypto {
+                owned.dispose_secrets();
+            }
+            receipt
+                .rollback(&id_bytes, transport, event_log_provider)
+                .await;
+            return Err(e);
+        }
+    }
+
     // Step 9: Return the handle plus the owned crypto material (Encrypted
     // mode) for the caller to seed onto the spawning actor. Broadcast contexts
     // return `None` — their broadcast key lives on the actor's `BroadcastState`.
@@ -1383,6 +1450,130 @@ mod tests {
         assert!(
             record.participation_duration_seconds > 0,
             "a founder who participated must have non-zero participation duration"
+        );
+    }
+
+    /// Builds a minimal valid [`OutletRegistration`] fixture for genesis-outlet
+    /// tests (GitHub #2020).
+    fn outlet_fixture(outlet_id: &str) -> scp_protocol::context::outlets::OutletRegistration {
+        use scp_protocol::context::outlets::{OutletKind, OutletRegistration, OutletSchema};
+        OutletRegistration {
+            outlet_id: outlet_id.to_owned(),
+            kind: OutletKind::Action,
+            name: outlet_id.to_owned(),
+            description: "genesis outlet fixture".to_owned(),
+            schema: OutletSchema {
+                input_schema: serde_json::json!({"type": "object"}),
+                output_schema: serde_json::json!({"type": "object"}),
+                aggregate_schema: None,
+            },
+            implementation_hash: [0u8; 32],
+            test_vectors: vec![],
+            message_catalog: Vec::new(),
+            operator_did: TEST_DID.into(),
+            cost: None,
+            registered_at: 0,
+            signature: Vec::new(),
+        }
+    }
+
+    /// §5.1/§5.12 (GitHub #2020): outlets declared in `ContextParams.outlets` at
+    /// genesis are INSTALLED — the creator's authoritative event log carries one
+    /// `OutletRegistered` leaf per genesis outlet (the same leaf
+    /// `execute_register_outlet` emits for the runtime governance path), attributed
+    /// to the creator at the convergent creation timestamp. Before the fix the
+    /// genesis path dropped `params.outlets` entirely, so NO leaves were emitted.
+    #[tokio::test]
+    async fn genesis_outlets_emit_outlet_registered_leaves_on_create() {
+        use crate::context::providers::MerkleEventLogProvider;
+
+        const CREATION_TS: u64 = 1_000;
+        let id = hex::encode([0x3bu8; 32]);
+        let id_bytes = context_id_bytes(&id);
+        let crypto = NodeMlsFactory::new(
+            TEST_DID.to_owned(),
+            std::sync::Arc::new(scp_clock::SystemClock),
+        );
+        let provider = MerkleEventLogProvider::new();
+
+        let params = ContextParams {
+            outlets: vec![outlet_fixture("alpha"), outlet_fixture("beta")],
+            ..Default::default()
+        };
+
+        create_context(
+            id.clone(),
+            params,
+            &crypto,
+            &TestTransport,
+            &provider,
+            TEST_DID,
+            CREATION_TS,
+        )
+        .await
+        .expect("create_context should succeed with genesis outlets");
+
+        let entries = provider
+            .event_log_entries(&id_bytes)
+            .expect("entries readable")
+            .expect("log exists");
+
+        let outlet_leaves: Vec<_> = entries
+            .iter()
+            .filter(|e| e.event_type == scp_event_log::EventType::OutletRegistered)
+            .collect();
+        assert_eq!(
+            outlet_leaves.len(),
+            2,
+            "one OutletRegistered leaf per genesis outlet must be emitted on create"
+        );
+        for leaf in &outlet_leaves {
+            assert_eq!(
+                leaf.actor_did.0.as_str(),
+                TEST_DID,
+                "genesis outlet leaf is attributed to the creator (the genesis declarant)"
+            );
+            assert_eq!(
+                leaf.timestamp, CREATION_TS,
+                "genesis outlet leaf carries the convergent creation timestamp"
+            );
+        }
+    }
+
+    /// The genesis path enforces the SAME `MAX_REGISTERED_OUTLETS` bound as the
+    /// runtime governance-registration path (`execute_register_outlet`): a
+    /// `params.outlets` set larger than the cap is rejected at creation, so genesis
+    /// cannot bypass the per-context registry limit (GitHub #2020).
+    #[test]
+    fn validate_params_rejects_genesis_outlets_over_the_cap() {
+        let params = ContextParams {
+            outlets: (0..=crate::context::state::MAX_REGISTERED_OUTLETS)
+                .map(|i| outlet_fixture(&format!("outlet-{i}")))
+                .collect(),
+            ..Default::default()
+        };
+        assert!(
+            params.outlets.len() > crate::context::state::MAX_REGISTERED_OUTLETS,
+            "fixture must exceed the cap"
+        );
+        assert!(
+            validate_params(&params).is_err(),
+            "a genesis outlet set exceeding MAX_REGISTERED_OUTLETS must be rejected at creation"
+        );
+    }
+
+    /// A genesis outlet set at exactly the cap is accepted (boundary check).
+    #[test]
+    fn validate_params_accepts_genesis_outlets_at_the_cap() {
+        let params = ContextParams {
+            outlets: (0..crate::context::state::MAX_REGISTERED_OUTLETS)
+                .map(|i| outlet_fixture(&format!("outlet-{i}")))
+                .collect(),
+            ..Default::default()
+        };
+        assert!(
+            validate_params(&params).is_ok(),
+            "a genesis outlet set at exactly MAX_REGISTERED_OUTLETS must be accepted"
         );
     }
 }

--- a/crates/scp-runtime/src/context/state.rs
+++ b/crates/scp-runtime/src/context/state.rs
@@ -1932,7 +1932,19 @@ pub(crate) fn fresh_governance_state(
         deadlock: DeadlockDetectionState::default(),
         pending_ceiling_modification: None,
         pending_economic_policy_change: None,
-        registered_outlets: Vec::new(),
+        // §5.1/§5.12: outlets are declared at creation. Seed the genesis-declared
+        // `params.outlets` into the live registry here — the single shared helper
+        // for the create AND Welcome-join genesis paths, so a creator and a
+        // welcome-joiner install the SAME initial outlet set and the two paths
+        // cannot drift (GitHub #2020). The authenticated provenance record — an
+        // `OutletRegistered` event-log leaf per genesis outlet (§5.4: "silent
+        // outlet modification is not possible") — is appended by the creator's
+        // authoritative genesis writer (`builder::create_context`, alongside the
+        // `ContextCreated`/`MemberJoined` leaves) and travels to joiners via log
+        // replication, exactly as the `ContextCreated` leaf does. The creator's
+        // count is bounded by `validate_params` (`MAX_REGISTERED_OUTLETS`) before
+        // this runs; a joiner's `params` are the creator-validated set.
+        registered_outlets: params.outlets.clone(),
         outlet_interfaces: Vec::new(),
         pruning_policy: None,
         message_pricing: crate::context::lifecycle_logic::derive_message_pricing(

--- a/crates/scp-runtime/src/context/supervisor/spawn_from_welcome_tests.rs
+++ b/crates/scp-runtime/src/context/supervisor/spawn_from_welcome_tests.rs
@@ -690,6 +690,92 @@ async fn spawn_from_welcome_yields_a_live_send_capable_actor() {
 }
 
 // ---------------------------------------------------------------------------
+// Test A1b — the joiner INSTALLS the genesis-declared outlets (GitHub #2020).
+// ---------------------------------------------------------------------------
+
+/// Builds a minimal valid genesis [`OutletRegistration`] fixture (GitHub #2020),
+/// operated by the creator (`ALICE_DID`) — the genesis declarant.
+fn genesis_outlet(outlet_id: &str) -> scp_protocol::context::outlets::OutletRegistration {
+    use scp_protocol::context::outlets::{OutletKind, OutletRegistration, OutletSchema};
+    OutletRegistration {
+        outlet_id: outlet_id.to_owned(),
+        kind: OutletKind::Action,
+        name: outlet_id.to_owned(),
+        description: "genesis outlet fixture".to_owned(),
+        schema: OutletSchema {
+            input_schema: serde_json::json!({"type": "object"}),
+            output_schema: serde_json::json!({"type": "object"}),
+            aggregate_schema: None,
+        },
+        implementation_hash: [0u8; 32],
+        test_vectors: vec![],
+        message_catalog: Vec::new(),
+        operator_did: ALICE_DID.into(),
+        cost: None,
+        registered_at: 0,
+        signature: Vec::new(),
+    }
+}
+
+/// §5.1/§5.12 (GitHub #2020): a Welcome-joiner INSTALLS the genesis-declared
+/// `params.outlets` into its live registry (via the shared
+/// `state::fresh_governance_state`), so the joiner sees the SAME initial outlet
+/// set the creator declared at genesis. Before the fix the join path dropped
+/// `params.outlets`, so a joiner's registry came up empty.
+///
+/// The joiner appends NO local `OutletRegistered` leaf — those are
+/// creator-authoritative and converge via event-log leaf replication, exactly
+/// like `ContextCreated`/`MemberJoined` (Test A). The installed set is asserted
+/// on the joiner's persisted Class-S snapshot, which the spawn writes fail-closed
+/// BEFORE registering the actor, so it is a faithful read of the joiner's live
+/// `governance.registered_outlets`.
+#[tokio::test]
+async fn welcome_joiner_installs_genesis_outlets() {
+    let params = ContextParams {
+        outlets: vec![genesis_outlet("alpha"), genesis_outlet("beta")],
+        ..joiner_params()
+    };
+    let rec = RecordingPersistence::default();
+    let (result, j) = run_join_with(
+        0x2c,
+        Some(Box::new(rec.clone())),
+        Some(params.clone()),
+        params.clone(),
+        None,
+    )
+    .await;
+    result.expect("welcome join succeeds with genesis outlets");
+
+    let snapshot = rec
+        .store
+        .get(&j.ctx_id)
+        .map(|e| e.value().clone())
+        .expect("the joiner persisted a Class-S snapshot before spawning");
+    let ids: Vec<&str> = snapshot
+        .registered_outlets
+        .iter()
+        .map(|o| o.outlet_id.as_str())
+        .collect();
+    assert_eq!(
+        ids,
+        vec!["alpha", "beta"],
+        "the joiner installs the creator's genesis-declared outlets into its live registry"
+    );
+
+    // No joiner-local OutletRegistered leaf: the joiner reconstructs its registry
+    // from `params` and converges the authenticated leaves via replication.
+    assert!(
+        j.sup
+            .event_log_entries(&j.ctx_bytes)
+            .expect("event-log provider is wired")
+            .is_none_or(|v| v
+                .iter()
+                .all(|e| e.event_type != scp_event_log::EventType::OutletRegistered)),
+        "joiner emits no local OutletRegistered leaf; genesis leaves converge via replication"
+    );
+}
+
+// ---------------------------------------------------------------------------
 // Test A2 — the joiner seeds its ABSOLUTE MLS epoch from the joined group.
 // ---------------------------------------------------------------------------
 


### PR DESCRIPTION
Genesis silently dropped `ContextParams.outlets`: `state::fresh_governance_state` (the shared create+welcome-join helper) hard-set `registered_outlets: Vec::new()` — outlets was the one genesis param never seeded (ceiling/governance/roles/economic_policy/consequence_rules all were), and no `OutletRegistered` leaf was emitted.

## Fix (+290/-1, 3 files)
- **Live registry, both paths** — `fresh_governance_state` seeds `registered_outlets: params.outlets.clone()` (one edit covers creator + welcome-joiner, which is why the helper is shared).
- **Authenticated provenance, creator** — `builder::create_context` appends one `OutletRegistered` leaf per genesis outlet via the same `append_event` path `execute_register_outlet` uses, at the convergent creation timestamp, full rollback-on-failure (§5.4 — not a silent vec push).
- **Welcome-joiner** installs into the live registry via the shared helper and emits no local leaf (converges the authenticated leaves via event-log replication, same as ContextCreated).
- **Cap parity** — `validate_params` rejects a genesis set over `MAX_REGISTERED_OUTLETS` (256) — no genesis bypass.

## Findings (pre-existing, flagged not expanded)
- `execute_register_outlet` does NOT verify the §5.4.1 operator signature (`verify_outlet_registration_signature` has no production caller) — so governance-registered and genesis outlets are **uniformly unverified**; genesis adds no bypass. Wiring verification into both paths is a separate pre-existing gap.
- import/restore already rehydrate outlets from the snapshot (now carrying genesis outlets) — correct. Public-scope export deliberately redacts them — out of scope.

Verified: scp-runtime/protocol/event-log (KAT) tests pass; 4 new tests; check-error-codes pass; `cargo clippy -p scp-runtime` clean on changed code.

Note: a **pre-existing** full-workspace clippy failure under `outlet-capability-test-grant` (missing `CODE_EXECUTION_STREAM_CAP`; `SenderKeyStore::is_empty`) exists on the base commit — unrelated to this change (proven by stash+rerun) — see PR discussion.

Closes #2020.

🤖 Generated with [Claude Code](https://claude.com/claude-code)