### PR TITLE
fix(ffi): fail closed on execute_recovery — remove the §9.12 nullifier (#2240 Part A)

### DIFF
--- a/.docs/standards/sdk-capability-matrix.json
+++ b/.docs/standards/sdk-capability-matrix.json
@@ -137,14 +137,16 @@
           "python": true,
           "typescript": true,
           "kotlin": true,
-          "swift": true
+          "swift": true,
+          "notes": "SDK wrapper + FFI surface exist on all four bindings (this column is a name-existence check). The surface FAILS CLOSED (#2240): the §9.12 compromise-recovery WIRE (a real RecoveryBackend + step-1 key rotation) is not yet built and is tracked as #2240 Part B (needs human design sign-off). Until then every bridge (PyO3, NAPI, UniFFI) returns a typed SCP-IDENT-1022 'recovery backend not configured — provide a real backend via SDK layer' error instead of a fabricated success. The former inline always-Ok backend returned key_rotation_completed:true while rotating no key / revoking no token — a nullifier removed here. Mirrors execute_custody_migration's NotConfigured fail-closed behaviour. All three bridges also reject a DID this instance does not host, and an unknown tier, with SCP-IDENT-1020 (ownership gate, before the fail-closed return). Two fail-path divergences are deliberately deferred to Part B: (1) NAPI additionally enforces a 1024-entry context_ids length cap (SCP-VALID-7120) and a libuv-worker concurrency permit (SCP-VALID-7140) — runtime-specific DoS bounds that guard only the Part B orchestrator (the fail-closed path iterates nothing and pins no worker), so PyO3/UniFFI receive them when Part B lands; (2) UniFFI keys the ownership check on its per-instance identity-custody registry (create-only) while PyO3/NAPI key on the identity registry — Part B reconciles the 'recoverable identity' definition. Both divergences are on failure paths only; the functional fail-closed contract (SCP-IDENT-1022 for a normal call) is identical across all bindings."
         },
         {
           "name": "execute_custody_migration",
           "python": true,
           "typescript": true,
           "kotlin": true,
-          "swift": true
+          "swift": true,
+          "notes": "SDK wrapper + FFI surface exist on all four bindings (this column is a name-existence check). Like execute_recovery, the surface FAILS CLOSED: no production custody-migration backend is wired, so every bridge drives a NotConfiguredMigrationBackend whose first step returns Err — surfaced as a typed 'custody migration backend not configured — provide a real backend via SDK layer' error instead of fabricating a migration. The real backend (platform/hardware/software custody key generation + DID-document rotation) is tracked separately and needs human design sign-off. This is the fail-closed precedent execute_recovery mirrors."
         },
         {
           "name": "create_attestation",

--- a/bindings/kotlin/scp-kt/src/main/kotlin/works/limn/scp/Identity.kt
+++ b/bindings/kotlin/scp-kt/src/main/kotlin/works/limn/scp/Identity.kt
@@ -358,14 +358,20 @@ class IdentityAdvancedBridge internal constructor(
         }
 
     /**
-     * Executes the compromise recovery protocol for the given DID.
+     * Executes the compromise recovery protocol for the given DID (spec §9.12).
      *
-     * Runs the 6-step recovery protocol from spec section 9.12.
+     * **Fails closed (#2240).** The §9.12 recovery WIRE (a real recovery backend
+     * plus step-1 key rotation) is not yet built — it is tracked as #2240 Part B
+     * and needs human design sign-off. Until it is wired, the underlying bridge
+     * throws a typed `SCP-IDENT-1022` `BridgeException` ("recovery backend not
+     * configured — provide a real backend via SDK layer") rather than
+     * fabricating a success.
      *
      * @param did The DID string to recover.
      * @param tier Compromise tier: "agent", "active_signing", or "identity_key".
      * @param contextIds Context IDs where this DID is a member.
-     * @return JSON string with the recovery result.
+     * @return JSON string with the recovery result (once the backend is wired).
+     * @throws BridgeException `SCP-IDENT-1022` while recovery is not configured.
      */
     suspend fun executeRecovery(
         did: String,

--- a/bindings/python/scp_sdk/scp.py
+++ b/bindings/python/scp_sdk/scp.py
@@ -804,8 +804,12 @@ class SCP:
     ) -> dict[str, Any]:
         """Delegate to ``_scp_core.SCP.identity_execute_recovery``.
 
-        Returns the recovery outcome dict parsed from the bridge's JSON
-        payload (§9.12).
+        **Fails closed (#2240).** The §9.12 recovery WIRE (a real recovery
+        backend plus step-1 key rotation) is not yet built — it is tracked as
+        #2240 Part B and needs human design sign-off. Until it is wired, this
+        surface raises a typed ``IdentityError`` ("recovery backend not
+        configured — provide a real backend via SDK layer") rather than
+        fabricating a success. It never reports a recovery that did not happen.
 
         :param did: The compromised DID. **Must be owned by this**
             :class:`SCP` **instance** — created or loaded via
@@ -813,10 +817,12 @@ class SCP:
             absent from the instance's identity registry are rejected
             with ``SCP-IDENT-1020``.
         :param context_ids: Contexts to run the recovery protocol
-            against. Capped at **1024** entries per call; over-cap
-            requests return ``SCP-VALID-7120`` before the orchestrator
-            runs. See :meth:`identity_execute_custody_migration` for
-            the shared rate-limiting rationale.
+            against. Accepted for signature symmetry with the wired
+            backend (#2240 Part B); ignored on the current fail-closed
+            path. The NAPI binding additionally enforces a 1024-entry
+            length cap (``SCP-VALID-7120``) and a concurrency permit
+            (``SCP-VALID-7140``); those DoS bounds are runtime-specific
+            and land on this binding when the Part B orchestrator does.
         """
         import json
 

--- a/bindings/python/tests/test_real_ffi.py
+++ b/bindings/python/tests/test_real_ffi.py
@@ -271,18 +271,34 @@ class TestIdentity:
         with pytest.raises(Exception, match="invalid custody migration target"):
             await scp.identity_execute_custody_migration(identity.did, "nonexistent_target", [])
 
-    async def test_execute_recovery(self, scp: SCP):
+    async def test_execute_recovery_fails_closed(self, scp: SCP):
+        # #2240: recovery has no configured backend yet (the §9.12 WIRE is
+        # Part B, pending human sign-off), so the surface fails closed with a
+        # typed error instead of fabricating a success. Mirrors
+        # test_execute_custody_migration.
         identity = await scp.identity_create(CustodyType.IN_MEMORY)
-        result = await scp.identity_execute_recovery(identity.did, "agent", [])
-        assert isinstance(result, dict)
-        assert "key_rotation_completed" in result
-        assert result["tier"] == "Agent"
-        assert result["did"] == identity.did
+        # Pin the canonical code (SCP-IDENT-1022) so the fail-closed path stays
+        # cross-bridge symmetric with NAPI/UniFFI, not just the generic
+        # IDENT_1001 bucket (#2240 review).
+        with pytest.raises(Exception, match="SCP-IDENT-1022"):
+            await scp.identity_execute_recovery(identity.did, "agent", [])
 
     async def test_execute_recovery_invalid_tier(self, scp: SCP):
         identity = await scp.identity_create(CustodyType.IN_MEMORY)
-        with pytest.raises(Exception):
+        # Invalid-tier rejection carries the canonical SCP-IDENT-1020 code on
+        # every bridge (parity with NAPI/UniFFI). Match the distinctive message
+        # too — 1020 is shared with the ownership-rejection path, so the message
+        # is what pins THIS path (the identity is owned, so ownership passes).
+        with pytest.raises(Exception, match="invalid compromise tier"):
             await scp.identity_execute_recovery(identity.did, "invalid_tier", [])
+
+    async def test_execute_recovery_rejects_unowned_did(self, scp: SCP):
+        # Ownership gate (parity with NAPI/UniFFI): recovery against a DID this
+        # SCP instance does not host is rejected with SCP-IDENT-1020 before any
+        # recovery bookkeeping — a realm-local caller cannot drive recovery
+        # against arbitrary DIDs.
+        with pytest.raises(Exception, match="SCP-IDENT-1020"):
+            await scp.identity_execute_recovery("did:dht:unowned-attacker-did", "agent", [])
 
     async def test_migrate(self, scp: SCP):
         import json

--- a/bindings/swift/Sources/SCP/Scp.swift
+++ b/bindings/swift/Sources/SCP/Scp.swift
@@ -762,6 +762,11 @@ public extension SCP {
     }
 
     /// Forwards to ``Scp/identityExecuteRecovery`` on ``inner``.
+    ///
+    /// Fails closed (#2240): the §9.12 recovery WIRE is not yet built (Part B,
+    /// pending human sign-off), so the bridge throws a typed `SCP-IDENT-1022`
+    /// error ("recovery backend not configured — provide a real backend via SDK
+    /// layer") rather than fabricating a success.
     func identityExecuteRecovery(did: String, tier: String, contextIds: [String]) throws -> String {
         try inner.identityExecuteRecovery(did: did, tier: tier, contextIds: contextIds)
     }

--- a/bindings/typescript/src/scp.ts
+++ b/bindings/typescript/src/scp.ts
@@ -1046,6 +1046,21 @@ export class SCP {
     }
   }
 
+  /**
+   * Execute §9.12 compromise recovery for `did`.
+   *
+   * **Fails closed (#2240).** The recovery WIRE (a real backend plus step-1
+   * key rotation) is not yet built — it is tracked as #2240 Part B and needs
+   * human design sign-off. Until then this call **always throws** a
+   * `SCP-IDENT-1022` "recovery backend not configured" error rather than
+   * fabricating a success; it never reports a recovery that did not happen.
+   * A `did` this SCP instance does not host is rejected with `SCP-IDENT-1020`,
+   * and an unknown `tier` with `SCP-IDENT-1020`, before the fail-closed return.
+   * Because this wrapper delegates to the native (NAPI) binding, a `contextIds`
+   * list over 1024 entries is rejected with `SCP-VALID-7120` and a concurrent
+   * recovery flood with `SCP-VALID-7140` (runtime DoS bounds absent from the
+   * other bindings until #2240 Part B wires them uniformly).
+   */
   identityExecuteRecovery(did: string, tier: string, contextIds: readonly string[]): string {
     try {
       return (

--- a/bindings/typescript/tests/integration.test.ts
+++ b/bindings/typescript/tests/integration.test.ts
@@ -848,16 +848,15 @@ describeNapi(`SCP class real NAPI integration [${napiSkipReason}]`, () => {
       expect(() => scp.identityExecuteRecovery(identity.did, "nonexistent-tier", [])).toThrow();
     });
 
-    it("scp.identityExecuteRecovery returns a JSON result on the happy path", async () => {
-      // Use a real identity so the DID is well-formed.
+    it("scp.identityExecuteRecovery fails closed with the NotConfigured error", async () => {
+      // #2240: recovery has no configured backend yet (the §9.12 WIRE is
+      // Part B, pending human sign-off). Passing the ownership + tier gates,
+      // the bridge fails closed with SCP-IDENT-1022 instead of fabricating a
+      // success. Mirrors the custody-migration NotConfigured assertion below.
       const identity = await scp.identityCreate("in_memory");
-      const resultJson = scp.identityExecuteRecovery(identity.did, "agent", []);
-      expect(typeof resultJson).toBe("string");
-      // The orchestrator returns a structured result with at least
-      // `did`, `tier`, and `completed_contexts` fields per spec §3.6.
-      const parsed = JSON.parse(resultJson) as Record<string, unknown>;
-      expect(parsed).toHaveProperty("tier");
-      expect(parsed).toHaveProperty("did");
+      expect(() => scp.identityExecuteRecovery(identity.did, "agent", [])).toThrow(
+        /SCP-IDENT-1022|not configured/i,
+      );
     });
 
     it("scp.identityExecuteCustodyMigration surfaces the NotConfigured backend error", async () => {

--- a/crates/scp-ffi/napi/src/scp.rs
+++ b/crates/scp-ffi/napi/src/scp.rs
@@ -20,7 +20,6 @@ use std::time::Duration;
 use napi::Env;
 use napi::Error as NapiError;
 use napi_derive::napi;
-use scp_clock::Clock as _;
 use scp_ffi_common::bridge_instance::BridgeInstanceCore as _;
 use scp_ffi_common::error_codes as codes;
 use scp_identity::DidMethod as _;
@@ -1067,9 +1066,18 @@ impl Scp {
 
     /// Per-instance equivalent of `identity_execute_recovery` (spec §9.12).
     ///
-    /// Executes the compromise recovery protocol and returns the result as
-    /// a JSON string. Bridge-level recovery backend is a placeholder — real
-    /// backends are injected via the SDK wrapper.
+    /// # Fails closed (#2240)
+    ///
+    /// The §9.12 recovery WIRE (a real `RecoveryBackend` plus step-1 key
+    /// rotation) is not yet built (custody / DID-method operations tracked as
+    /// #2240 Part B, pending human sign-off). Until it is wired via the SDK
+    /// layer this method **fails closed** with a typed `SCP-IDENT-1022` error
+    /// ("recovery backend not configured — provide a real backend via SDK
+    /// layer") after the ownership / length / concurrency gates pass — it NEVER
+    /// returns a fabricated success (the former inline always-`Ok` backend
+    /// returned `key_rotation_completed: true` while doing nothing, a nullifier
+    /// forbidden by the builder tenets). Mirrors the sibling
+    /// [`Self::identity_execute_custody_migration`] fail-closed behaviour.
     ///
     /// # Concurrency cap
     ///
@@ -1089,14 +1097,6 @@ impl Scp {
         tier: String,
         context_ids: Vec<String>,
     ) -> napi::Result<String> {
-        use std::collections::HashSet;
-
-        use scp_core::identity::recovery::{
-            CompromiseRecoveryOrchestrator, CompromiseTier, KeyRotationOutcome, PskRotationParams,
-            RecoveryBackend, RecoveryStepError, active_key_rotation_outcome,
-            agent_key_rotation_outcome,
-        };
-        use scp_did::DID;
         use scp_ffi_common::validate::validate_did;
 
         validate_did(&did).map_err(|e| napi::Error::from(ScpNapiError::from(e)))?;
@@ -1156,12 +1156,11 @@ impl Scp {
                 })
             })?;
 
-        let did_val = DID::from(did.as_str());
-
-        let compromise_tier = match tier.as_str() {
-            "agent" => CompromiseTier::Agent,
-            "active_signing" => CompromiseTier::ActiveSigning,
-            "identity_key" => CompromiseTier::IdentityKey,
+        // Validate the tier first so callers still get the precise invalid-tier
+        // error rather than the generic fail-closed one. The `_permit` acquired
+        // above is dropped when this method returns.
+        match tier.as_str() {
+            "agent" | "active_signing" | "identity_key" => {}
             other => {
                 return Err(NapiError::from(ScpNapiError::Identity {
                     message: format!(
@@ -1170,89 +1169,23 @@ impl Scp {
                     code: codes::IDENT_1020.to_owned(),
                 }));
             }
-        };
-
-        let now_ms = scp_clock::SystemClock.now_millis();
-        let key_rotation = match compromise_tier {
-            CompromiseTier::Agent => agent_key_rotation_outcome(&did_val, now_ms),
-            CompromiseTier::ActiveSigning => active_key_rotation_outcome(&did_val, now_ms),
-            CompromiseTier::IdentityKey => {
-                scp_core::identity::recovery::identity_key_rotation_outcome(
-                    &did_val,
-                    did_val.clone(),
-                    now_ms,
-                )
-            }
-        };
-
-        struct NapiRecoveryBackend;
-        #[async_trait::async_trait(?Send)]
-        impl RecoveryBackend for NapiRecoveryBackend {
-            async fn mls_update(
-                &self,
-                _context_id: &str,
-                _key_rotation: &KeyRotationOutcome,
-            ) -> Result<(), RecoveryStepError> {
-                Ok(())
-            }
-            async fn revoke_ucans(
-                &self,
-                _context_id: &str,
-                _key_rotation: &KeyRotationOutcome,
-            ) -> Result<(), RecoveryStepError> {
-                Ok(())
-            }
-            async fn rotate_key_packages(
-                &self,
-                _context_id: &str,
-                _key_rotation: &KeyRotationOutcome,
-            ) -> Result<(), RecoveryStepError> {
-                Ok(())
-            }
-            async fn notify_contacts(
-                &self,
-                _did: &DID,
-                _tier: CompromiseTier,
-                _key_rotation: &KeyRotationOutcome,
-                _contacts: &HashSet<DID>,
-            ) -> bool {
-                true
-            }
-            async fn rotate_psk(&self, _params: &PskRotationParams) -> bool {
-                true
-            }
         }
 
-        let orchestrator = CompromiseRecoveryOrchestrator::new(did_val, context_ids);
-        let contacts = HashSet::new();
-        let backend = NapiRecoveryBackend;
-
-        // Drive the async orchestrator on the module-local tokio runtime
-        // (crate::runtime()). The prior `Handle::try_current()` path
-        // failed on the napi-rs worker thread because libuv workers
-        // don't carry a tokio context (round-2 bug-catcher finding).
-        let result = crate::runtime()
-            .block_on(orchestrator.execute_recovery(
-                compromise_tier,
-                &key_rotation,
-                &contacts,
-                None,
-                &backend,
-                &scp_clock::SystemClock,
-            ))
-            .map_err(|e| {
-                NapiError::from(ScpNapiError::Identity {
-                    message: format!("recovery failed: {e}"),
-                    code: codes::IDENT_1022.to_owned(),
-                })
-            })?;
-
-        serde_json::to_string(&result).map_err(|e| {
-            NapiError::from(ScpNapiError::Identity {
-                message: format!("failed to serialize recovery result: {e}"),
-                code: codes::IDENT_1023.to_owned(),
-            })
-        })
+        // FAIL CLOSED (#2240): there is no configured recovery backend at the
+        // FFI layer, and step 1 (real key rotation) cannot be performed here.
+        // Unlike custody migration — whose orchestrator surfaces its
+        // NotConfigured backend's first `Err` as a fatal error —
+        // `CompromiseRecoveryOrchestrator::execute_recovery` isolates
+        // per-context failures (§9.12) and never returns a fatal "backend
+        // absent" error, so recovery must fail closed at the bridge boundary
+        // before any `KeyRotationOutcome` / `RecoveryResult` is fabricated. The
+        // ownership / length / concurrency gates above still run so the DoS and
+        // authorisation guarantees are preserved for the wired backend (Part B).
+        Err(NapiError::from(ScpNapiError::Identity {
+            message: "recovery backend not configured — provide a real backend via SDK layer"
+                .to_owned(),
+            code: codes::IDENT_1022.to_owned(),
+        }))
     }
 
     /// Per-instance equivalent of `identity_execute_custody_migration`
@@ -5025,14 +4958,16 @@ mod concurrency_cap_tests {
         );
 
         // Drop one permit — the next call must proceed past the permit check.
-        // It may still fail downstream (the bridge-level recovery backend is
-        // a placeholder that returns Ok) but it must NOT be a VALID-7140
-        // busy rejection.
+        // Recovery now fails closed (#2240, SCP-IDENT-1022) instead of
+        // fabricating a success, but the point of THIS assertion is that the
+        // permit gate no longer rejects it: whatever it returns, it must NOT be
+        // a VALID-7140 busy rejection.
         drop(permits.pop());
         let result = scp.identity_execute_recovery(did, "agent".to_owned(), Vec::new());
         match result {
             Ok(_) => {
-                // Happy path — orchestrator completed.
+                // Not expected post-#2240, but a non-busy Ok would still satisfy
+                // the "not busy-rejected" invariant this test guards.
             }
             Err(e) => {
                 let msg = e.to_string();
@@ -5042,6 +4977,28 @@ mod concurrency_cap_tests {
                 );
             }
         }
+    }
+
+    /// #2240: recovery must fail closed with the typed `SCP-IDENT-1022`
+    /// "not configured" error — never a fabricated success — once it passes the
+    /// ownership / length / concurrency gates. Mirrors the custody-migration
+    /// `NotConfigured` fail-closed behaviour.
+    #[test]
+    fn recovery_fails_closed_with_not_configured_error() {
+        let (scp, did) = build_scp_with_identity();
+
+        let err = scp
+            .identity_execute_recovery(did, "agent".to_owned(), Vec::new())
+            .expect_err("recovery must fail closed — it has no configured backend (#2240)");
+        let msg = err.to_string();
+        assert!(
+            msg.contains("SCP-IDENT-1022"),
+            "expected fail-closed SCP-IDENT-1022, got: {msg}"
+        );
+        assert!(
+            msg.contains("not configured"),
+            "expected 'not configured' in fail-closed message, got: {msg}"
+        );
     }
 
     #[test]

--- a/crates/scp-ffi/src/identity.rs
+++ b/crates/scp-ffi/src/identity.rs
@@ -2505,15 +2505,27 @@ impl crate::scp::PyScp {
     }
 
     // -----------------------------------------------------------------------
-    // Compromise recovery — FFI exposure for CompromiseRecoveryOrchestrator
+    // Compromise recovery (§9.12) — fails closed pending the WIRE (#2240 Part B)
     // -----------------------------------------------------------------------
 
-    /// Executes the compromise recovery protocol for the given DID.
+    /// Executes the compromise recovery protocol for the given DID (§9.12).
     ///
-    /// This method creates a `CompromiseRecoveryOrchestrator` and a mock
-    /// `RecoveryBackend` and runs the 6-step recovery protocol. Step 1 (key
-    /// rotation) is represented by the caller-provided `tier` and
-    /// `rotated_key_scopes`.
+    /// # Fails closed (#2240)
+    ///
+    /// The §9.12 compromise-recovery WIRE (a real `RecoveryBackend` that rotates
+    /// keys, revokes UCANs, rotates `KeyPackages`, notifies contacts, and
+    /// rotates the PSK, plus step-1 key rotation) is not yet built — it needs
+    /// custody / DID-method operations that are tracked as #2240 Part B and
+    /// require human design sign-off. Until that backend is wired via the SDK
+    /// layer, this surface **fails closed** with a typed `IdentityError`
+    /// ("recovery backend not configured — provide a real backend via SDK
+    /// layer"). It NEVER returns a fabricated success. The former inline
+    /// always-`Ok` backend returned `key_rotation_completed: true` while
+    /// rotating no key and revoking no token — a nullifier shipping a false
+    /// guarantee on a security-critical operation, forbidden by the builder
+    /// tenets. This mirrors the sibling
+    /// [`Self::identity_execute_custody_migration`], which likewise fails closed
+    /// via a `NotConfigured*Backend`.
     ///
     /// # Arguments
     ///
@@ -2522,129 +2534,71 @@ impl crate::scp::PyScp {
     ///   `"identity_key"`.
     /// * `context_ids` — List of context IDs where the DID is a member.
     ///
-    /// # Returns
-    ///
-    /// A JSON string with recovery outcome fields.
-    ///
     /// # Errors
     ///
-    /// Raises `IdentityError` if recovery fails.
+    /// Raises `IdentityError` — an invalid `tier`, or (on any valid input) the
+    /// fail-closed "recovery backend not configured" error.
     ///
-    /// See spec §9.12 and PR #1080.
+    /// See spec §9.12 and issue #2240.
     #[pyo3(name = "identity_execute_recovery")]
     pub fn identity_execute_recovery(
         &self,
-        py: Python<'_>,
         did: &str,
         tier: &str,
         context_ids: Vec<String>,
     ) -> PyResult<String> {
-        use std::collections::HashSet;
-
-        use scp_core::identity::recovery::{
-            CompromiseRecoveryOrchestrator, CompromiseTier, KeyRotationOutcome, PskRotationParams,
-            RecoveryBackend, RecoveryStepError, active_key_rotation_outcome,
-            agent_key_rotation_outcome,
-        };
-        use scp_did::DID;
-
         validate::validate_did(did)?;
-        let did_owned = did.to_owned();
-        let tier_owned = tier.to_owned();
-        let rt = crate::runtime()?;
 
-        py.allow_threads(move || -> Result<String, ScpPyError> {
-            let did_val = DID::from(did_owned.as_str());
+        // Ownership gate (parity with the NAPI bridge's RED-PR5-003 check):
+        // recovery is restricted to identities THIS SCP instance hosts in its
+        // identity registry (populated by `identity_create*` / `identity_load`).
+        // A DID this instance does not own is rejected here — before any
+        // recovery bookkeeping — so a realm-local caller cannot drive recovery
+        // against arbitrary DIDs. `SCP-IDENT-1020` matches NAPI/UniFFI.
+        if !crate::runtime::identity_registry_contains(&self.inner, did) {
+            return Err(PyErr::from(ScpPyError::identity_with_code(
+                format!(
+                    "identity_execute_recovery: DID '{did}' is not owned by this SCP instance — \
+                     recovery is restricted to identities created or loaded via this SCP"
+                ),
+                scp_ffi_common::error_codes::IDENT_1020,
+            )));
+        }
 
-            let compromise_tier = match tier_owned.as_str() {
-                "agent" => CompromiseTier::Agent,
-                "active_signing" => CompromiseTier::ActiveSigning,
-                "identity_key" => CompromiseTier::IdentityKey,
-                other => {
-                    return Err(ScpPyError::identity(format!(
+        // `context_ids` is accepted for FFI/SDK signature symmetry with the
+        // eventual wired backend (#2240 Part B); it is unused on the
+        // fail-closed path (cf. `let _ = old_did;` in recovery.rs). NAPI's
+        // length-cap + libuv-worker concurrency gates bound the orchestrator
+        // work that only runs once that backend lands, so they belong with the
+        // Part B WIRE, not this fail-closed path.
+        let _ = context_ids;
+
+        // Validate the tier first so callers still get the precise invalid-tier
+        // error rather than the generic fail-closed one.
+        match tier {
+            "agent" | "active_signing" | "identity_key" => {}
+            other => {
+                return Err(PyErr::from(ScpPyError::identity_with_code(
+                    format!(
                         "invalid compromise tier: {other}; expected 'agent', 'active_signing', or 'identity_key'"
-                    )));
-                }
-            };
-
-            // Build key rotation outcome (step 1 is pre-completed by caller).
-            let now_ms = scp_clock::SystemClock.now_millis();
-            let key_rotation = match compromise_tier {
-                CompromiseTier::Agent => agent_key_rotation_outcome(&did_val, now_ms),
-                CompromiseTier::ActiveSigning => active_key_rotation_outcome(&did_val, now_ms),
-                CompromiseTier::IdentityKey => {
-                    // Identity key migration creates a new DID; for FFI exposure
-                    // we use the same DID as a placeholder since the caller
-                    // manages the actual DID migration externally.
-                    scp_core::identity::recovery::identity_key_rotation_outcome(
-                        &did_val,
-                        did_val.clone(),
-                        now_ms,
-                    )
-                }
-            };
-
-            // Use a simple backend that succeeds for all operations.
-            struct FfiRecoveryBackend;
-            #[async_trait::async_trait(?Send)]
-            impl RecoveryBackend for FfiRecoveryBackend {
-                async fn mls_update(
-                    &self,
-                    _context_id: &str,
-                    _key_rotation: &KeyRotationOutcome,
-                ) -> Result<(), RecoveryStepError> {
-                    Ok(())
-                }
-                async fn revoke_ucans(
-                    &self,
-                    _context_id: &str,
-                    _key_rotation: &KeyRotationOutcome,
-                ) -> Result<(), RecoveryStepError> {
-                    Ok(())
-                }
-                async fn rotate_key_packages(
-                    &self,
-                    _context_id: &str,
-                    _key_rotation: &KeyRotationOutcome,
-                ) -> Result<(), RecoveryStepError> {
-                    Ok(())
-                }
-                async fn notify_contacts(
-                    &self,
-                    _did: &DID,
-                    _tier: CompromiseTier,
-                    _key_rotation: &KeyRotationOutcome,
-                    _contacts: &HashSet<DID>,
-                ) -> bool {
-                    true
-                }
-                async fn rotate_psk(&self, _params: &PskRotationParams) -> bool {
-                    true
-                }
+                    ),
+                    scp_ffi_common::error_codes::IDENT_1020,
+                )));
             }
+        }
 
-            let orchestrator = CompromiseRecoveryOrchestrator::new(did_val, context_ids);
-            let contacts = HashSet::new();
-            let backend = FfiRecoveryBackend;
-
-            let result = rt
-                .block_on(orchestrator.execute_recovery(
-                    compromise_tier,
-                    &key_rotation,
-                    &contacts,
-                    None,
-                    &backend,
-                    &scp_clock::SystemClock,
-                ))
-                .map_err(|e| ScpPyError::identity(format!("recovery failed: {e}")))?;
-
-            // Serialize to JSON and return — the Python layer converts to dict.
-            let json = serde_json::to_string(&result).map_err(|e| {
-                ScpPyError::identity(format!("failed to serialize recovery result: {e}"))
-            })?;
-            Ok(json)
-        })
-        .map_err(PyErr::from)
+        // FAIL CLOSED (#2240): there is no configured recovery backend at the
+        // FFI layer, and step 1 (real key rotation) cannot be performed here.
+        // Unlike custody migration — whose orchestrator surfaces its
+        // NotConfigured backend's first `Err` as a fatal error —
+        // `CompromiseRecoveryOrchestrator::execute_recovery` isolates
+        // per-context failures (§9.12) and never returns a fatal "backend
+        // absent" error, so recovery must fail closed at the bridge boundary
+        // before any `KeyRotationOutcome` / `RecoveryResult` is fabricated.
+        Err(PyErr::from(ScpPyError::identity_with_code(
+            "recovery backend not configured — provide a real backend via SDK layer",
+            scp_ffi_common::error_codes::IDENT_1022,
+        )))
     }
 
     // -----------------------------------------------------------------------

--- a/crates/scp-ffi/uniffi/src/bridge.rs
+++ b/crates/scp-ffi/uniffi/src/bridge.rs
@@ -17327,31 +17327,53 @@ impl Scp {
 
     /// Per-instance equivalent of the free-function `identity_execute_recovery`.
     ///
-    /// Pure orchestration — takes no handles. Routes through `&self.inner`
-    /// only to preserve API uniformity; the underlying recovery backend is
-    /// a local stub pending SDK-layer wiring.
+    /// # Fails closed (#2240)
+    ///
+    /// The §9.12 recovery WIRE (a real `RecoveryBackend` plus step-1 key
+    /// rotation) is not yet built (custody / DID-method operations tracked as
+    /// #2240 Part B, pending human sign-off). Until it is wired via the SDK
+    /// layer this method **fails closed** with a typed `SCP-IDENT-1022` error
+    /// ("recovery backend not configured — provide a real backend via SDK
+    /// layer") — it NEVER returns a fabricated success (the former inline
+    /// always-`Ok` backend returned `key_rotation_completed: true` while doing
+    /// nothing, a nullifier forbidden by the builder tenets). Mirrors the
+    /// sibling [`Self::identity_execute_custody_migration`] fail-closed
+    /// behaviour.
     pub fn identity_execute_recovery(
         &self,
         did: String,
         tier: String,
         context_ids: Vec<String>,
     ) -> Result<String, ScpError> {
-        use std::collections::HashSet;
-
-        use scp_core::identity::recovery::{
-            CompromiseRecoveryOrchestrator, CompromiseTier, KeyRotationOutcome, PskRotationParams,
-            RecoveryBackend, RecoveryStepError, active_key_rotation_outcome,
-            agent_key_rotation_outcome,
-        };
-        use scp_did::DID;
-
         validate_did(&did)?;
-        let did_val = DID::from(did.as_str());
 
-        let compromise_tier = match tier.as_str() {
-            "agent" => CompromiseTier::Agent,
-            "active_signing" => CompromiseTier::ActiveSigning,
-            "identity_key" => CompromiseTier::IdentityKey,
+        // Ownership gate (parity with the NAPI bridge's RED-PR5-003 check):
+        // recovery is restricted to identities THIS bridge instance hosts in
+        // its per-instance identity custody registry (populated by
+        // `identity_create*`). A DID this instance does not own is rejected
+        // here so a co-resident caller cannot drive recovery against arbitrary
+        // DIDs. `SCP-IDENT-1020` matches NAPI/PyO3.
+        if !identity_custody_registry(&self.inner).contains_key(&did) {
+            return Err(ScpError::Identity {
+                msg: format!(
+                    "identity_execute_recovery: DID '{did}' is not owned by this SCP instance — \
+                     recovery is restricted to identities created or loaded via this SCP"
+                ),
+                code: codes::IDENT_1020.to_owned(),
+            });
+        }
+
+        // `context_ids` is accepted for FFI/SDK signature symmetry with the
+        // eventual wired backend (#2240 Part B); unused on the fail-closed path.
+        // NAPI's length-cap + libuv concurrency gates bound orchestrator work
+        // that only runs once that backend lands (Part B), so they are not
+        // replicated on this fail-closed path.
+        let _ = context_ids;
+
+        // Validate the tier first so callers still get the precise invalid-tier
+        // error rather than the generic fail-closed one.
+        match tier.as_str() {
+            "agent" | "active_signing" | "identity_key" => {}
             other => {
                 return Err(ScpError::Identity {
                     msg: format!(
@@ -17360,83 +17382,20 @@ impl Scp {
                     code: codes::IDENT_1020.to_owned(),
                 });
             }
-        };
-
-        let now_ms = scp_clock::SystemClock.now_millis();
-
-        let key_rotation = match compromise_tier {
-            CompromiseTier::Agent => agent_key_rotation_outcome(&did_val, now_ms),
-            CompromiseTier::ActiveSigning => active_key_rotation_outcome(&did_val, now_ms),
-            CompromiseTier::IdentityKey => {
-                scp_core::identity::recovery::identity_key_rotation_outcome(
-                    &did_val,
-                    did_val.clone(),
-                    now_ms,
-                )
-            }
-        };
-
-        struct UniffiRecoveryBackend;
-        #[async_trait::async_trait(?Send)]
-        impl RecoveryBackend for UniffiRecoveryBackend {
-            async fn mls_update(
-                &self,
-                _context_id: &str,
-                _key_rotation: &KeyRotationOutcome,
-            ) -> Result<(), RecoveryStepError> {
-                Ok(())
-            }
-            async fn revoke_ucans(
-                &self,
-                _context_id: &str,
-                _key_rotation: &KeyRotationOutcome,
-            ) -> Result<(), RecoveryStepError> {
-                Ok(())
-            }
-            async fn rotate_key_packages(
-                &self,
-                _context_id: &str,
-                _key_rotation: &KeyRotationOutcome,
-            ) -> Result<(), RecoveryStepError> {
-                Ok(())
-            }
-            async fn notify_contacts(
-                &self,
-                _did: &DID,
-                _tier: CompromiseTier,
-                _key_rotation: &KeyRotationOutcome,
-                _contacts: &HashSet<DID>,
-            ) -> bool {
-                true
-            }
-            async fn rotate_psk(&self, _params: &PskRotationParams) -> bool {
-                true
-            }
         }
 
-        let orchestrator = CompromiseRecoveryOrchestrator::new(did_val, context_ids);
-        let contacts = HashSet::new();
-        let backend = UniffiRecoveryBackend;
-
-        let rt = crate::runtime();
-
-        let result = rt
-            .block_on(orchestrator.execute_recovery(
-                compromise_tier,
-                &key_rotation,
-                &contacts,
-                None,
-                &backend,
-                &scp_clock::SystemClock,
-            ))
-            .map_err(|e| ScpError::Identity {
-                msg: format!("recovery failed: {e}"),
-                code: codes::IDENT_1022.to_owned(),
-            })?;
-
-        serde_json::to_string(&result).map_err(|e| ScpError::Identity {
-            msg: format!("failed to serialize recovery result: {e}"),
-            code: codes::IDENT_1023.to_owned(),
+        // FAIL CLOSED (#2240): there is no configured recovery backend at the
+        // FFI layer, and step 1 (real key rotation) cannot be performed here.
+        // Unlike custody migration — whose orchestrator surfaces its
+        // NotConfigured backend's first `Err` as a fatal error —
+        // `CompromiseRecoveryOrchestrator::execute_recovery` isolates
+        // per-context failures (§9.12) and never returns a fatal "backend
+        // absent" error, so recovery must fail closed at the bridge boundary
+        // before any `KeyRotationOutcome` / `RecoveryResult` is fabricated.
+        Err(ScpError::Identity {
+            msg: "recovery backend not configured — provide a real backend via SDK layer"
+                .to_owned(),
+            code: codes::IDENT_1022.to_owned(),
         })
     }
 
@@ -19070,6 +19029,90 @@ mod tests {
             !reserved.key_package_public.is_empty(),
             "public KeyPackage bytes must be non-empty"
         );
+    }
+
+    /// #2240: recovery must fail closed with the typed `SCP-IDENT-1022`
+    /// "not configured" error — never a fabricated success. Mirrors the
+    /// custody-migration `NotConfigured` fail-closed behaviour.
+    #[test]
+    #[cfg(feature = "testing")]
+    fn recovery_fails_closed_with_not_configured_error() {
+        let rt = runtime();
+        let scp = scp_test();
+        let identity = rt
+            .block_on(scp.identity_create("in_memory".to_owned(), None))
+            .expect("identity_create failed");
+
+        let err = scp
+            .identity_execute_recovery(identity.did(), "agent".to_owned(), Vec::new())
+            .expect_err("recovery must fail closed — it has no configured backend (#2240)");
+        match err {
+            ScpError::Identity { msg, code } => {
+                assert_eq!(
+                    code,
+                    codes::IDENT_1022,
+                    "expected fail-closed SCP-IDENT-1022"
+                );
+                assert!(
+                    msg.contains("not configured"),
+                    "expected 'not configured' in fail-closed message, got: {msg}"
+                );
+            }
+            other => panic!("expected ScpError::Identity, got: {other:?}"),
+        }
+    }
+
+    /// Recovery rejects a DID this bridge instance does not host with the
+    /// canonical ownership code (`SCP-IDENT-1020`) — before the tier check or
+    /// the fail-closed return — matching the NAPI/PyO3 ownership gate.
+    #[test]
+    #[cfg(feature = "testing")]
+    fn recovery_rejects_unowned_did() {
+        let scp = scp_test();
+        let err = scp
+            .identity_execute_recovery(
+                "did:dht:unowned-attacker-did".to_owned(),
+                "agent".to_owned(),
+                Vec::new(),
+            )
+            .expect_err("recovery against an unowned DID must be rejected");
+        match err {
+            ScpError::Identity { msg, code } => {
+                assert_eq!(
+                    code,
+                    codes::IDENT_1020,
+                    "expected ownership-check rejection SCP-IDENT-1020, got: {msg}"
+                );
+                assert!(
+                    msg.contains("is not owned by this SCP instance"),
+                    "expected ownership-rejection message, got: {msg}"
+                );
+            }
+            other => panic!("expected ScpError::Identity, got: {other:?}"),
+        }
+    }
+
+    /// Recovery still rejects an unknown tier with the precise invalid-tier
+    /// error before reaching the fail-closed return.
+    #[test]
+    #[cfg(feature = "testing")]
+    fn recovery_rejects_unknown_tier() {
+        let rt = runtime();
+        let scp = scp_test();
+        let identity = rt
+            .block_on(scp.identity_create("in_memory".to_owned(), None))
+            .expect("identity_create failed");
+
+        let err = scp
+            .identity_execute_recovery(identity.did(), "bogus-tier".to_owned(), Vec::new())
+            .expect_err("unknown tier must be rejected");
+        match err {
+            ScpError::Identity { msg, .. } => assert!(
+                msg.contains("invalid compromise tier"),
+                "expected invalid-tier message, got: {msg}"
+            ),
+            other => panic!("expected ScpError::Identity, got: {other:?}"),
+        }
     }
 
     /// `reserve_key_package` rejects a non-custodied (DID-only, `identity_load`)


### PR DESCRIPTION
## Summary

Removes a **nullifier** (CLAUDE.md builder tenet: *"No dev/test-only stand-ins in production"*) from the `identity_execute_recovery` FFI surface and replaces it with a fail-closed typed error on all three bridges.

Previously, `identity_execute_recovery` on PyO3/NAPI/UniFFI ran an inline `FfiRecoveryBackend` whose six §9.12 compromise-recovery steps were all no-ops (`mls_update`/`revoke_ucans`/`rotate_key_packages` → `Ok(())`; `notify_contacts`/`rotate_psk` → `true`), then returned `key_rotation_completed: true`. **No key was rotated and no UCAN was revoked**, yet every SDK reported success — a false security guarantee, strictly worse than the capability being honestly absent.

This is **Part A** of #2240: fail closed. The real §9.12 WIRE (a production `RecoveryBackend` + step-1 key rotation) is **Part B**, tracked in the same issue and pending human design sign-off. The `CompromiseRecoveryOrchestrator` (`crates/scp-runtime/src/identity/recovery.rs`) isolates per-context backend failures and never surfaces a fatal "backend absent" error, so the fail-closed decision must live at the bridge boundary until the WIRE lands — a `NotConfigured`-backend approach (as used for custody migration) would *not* fail closed for recovery.

## Changes

- **PyO3 / NAPI / UniFFI**: `identity_execute_recovery` now validates the DID + tier, rejects a DID the instance does not host (**`SCP-IDENT-1020`**, ownership gate) and an unknown tier (**`SCP-IDENT-1020`**), then returns a typed **`SCP-IDENT-1022`** *"recovery backend not configured — provide a real backend via SDK layer"* error instead of a fabricated `KeyRotationOutcome`. The inline always-`Ok` backend, its orchestrator call, and the fabricated success struct are deleted.
- **Cross-bridge symmetry**: all three bridges emit the **same** codes for the same conditions. PyO3 previously would have used the generic `IDENT_1001` bucket — fixed via `identity_with_code`. The DID-ownership pre-gate was added to PyO3 + UniFFI to mirror NAPI's existing RED-PR5-003 check; it also resolves an ADR-048 §1 pure-helper conformance requirement (the fail-closed method now genuinely uses `self`).
- **SDK wrappers** (Python/TS/Swift/Kotlin): docstrings made honest; the fail-closed contract + `SCP-IDENT-1022` documented on every binding. The TS wrapper additionally documents the NAPI-inherited `SCP-VALID-7120`/`7140` DoS bounds it can surface.
- **Tests**: success-path assertions inverted to fail-closed on every bridge/SDK, pinning the exact codes (and, for invalid-tier, the message) so the symmetry is enforced, not aspirational. Adds unowned-DID rejection tests (PyO3 + UniFFI). Python recovery tests verified green against a `--features testing` build.
- **Capability matrix**: `execute_recovery` and its fail-closed sibling `execute_custody_migration` carry honest notes documenting Part B and the deferred divergences.

## Deferred to Part B (documented in the matrix, not silently dropped)

- **NAPI-only DoS bounds**: NAPI enforces a 1024-entry `context_ids` length cap (`SCP-VALID-7120`) and a libuv-worker concurrency permit (`SCP-VALID-7140`). These are runtime-specific bounds that guard only the Part B orchestrator (the fail-closed path iterates nothing and pins no worker), so PyO3/UniFFI receive them when the orchestrator lands. Both security and adversarial review confirmed this deferral is defensible, not scar tissue.
- **Ownership-registry reconciliation**: UniFFI keys the ownership check on its per-instance identity-*custody* registry (create-only) while PyO3/NAPI key on the identity registry (create + load). A `load`-only DID would get `1020` on UniFFI vs `1022` on PyO3/NAPI — both failure paths, no security impact; Part B reconciles the "recoverable identity" definition.

## Non-blocking follow-ups surfaced in review (not filed — systemic/pre-existing)

- `SCP-IDENT-1020` is shared by the ownership-reject and invalid-tier paths on all three bridges (inherited from NAPI's pre-existing convention). A distinct invalid-argument code would improve legibility; a Part B pass could split it uniformly.
- The capability-matrix boolean column is a documented name-existence check; a machine-readable `status: fail_closed` field (vs boolean + prose) would better serve programmatic consumers, and applies equally to `execute_custody_migration` and `verify_device_attestation`.

## Verification (rebased current onto origin/main)

- `cargo clippy --workspace --all-targets` (full CI feature set, `-D warnings`): **0**
- `cargo fmt --all --check`: clean
- 18/18 enforcement gates + `check-sdk-coverage.py`: **0** (incl. `check-bridge-symmetry.sh`, `check-shipped-feature-graph.sh` G1 prove-absence, `pure_helpers_stay_free_fns_at_ffi_layer` ADR-048 §1)
- TS `biome` lint + `tsc --noEmit`: clean
- `cargo nextest run --workspace` (full CI feature set, bounded): **10838 passed, 0 failed, 42 skipped**
- Python recovery `pytest` (built `--features testing`): **3/3 passed**
- Full review roster double-zero (security-reviewer, adversarial-expert, bug-catcher + completionist, api-design-reviewer): two consecutive clean passes on the final committed state.

Closes #2240 (Part A). Part B tracked in the same issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
