### PR TITLE
feat(crypto22-s4): KeyPackage-attestation resolve + current-key verifier seam (§9.7.1 checks 1–2)

### DIFF
--- a/crates/scp-mls/src/keypackage_attestation.rs
+++ b/crates/scp-mls/src/keypackage_attestation.rs
@@ -51,10 +51,11 @@
 //! See spec §9.5.2 (field table + wire format) and §9.7.1 (the full model).
 
 use openmls::prelude::*;
-use scp_did::SigningKeyId;
+use scp_did::{DidDocument, SigningKeyId};
 use scp_protocol::crypto::canonical::{CanonicalField, canonical_hash_bytes};
 use sha2::{Digest, Sha256};
 
+use crate::credential::ScpCredential;
 use crate::error::MlsError;
 
 /// Extension type ID for `scp_keypackage_attestation` in the RFC 9420 §17.3
@@ -654,6 +655,173 @@ pub fn verify_attestation(
         return Err(E::IssuedInFuture);
     }
 
+    Ok(())
+}
+
+/// The leaf/credential ground-truth for [`verify_attestation_with_resolution`].
+///
+/// It carries everything needed to build the pure
+/// [`AttestationVerificationContext`], **minus** the two resolution-dependent
+/// inputs that layer supplies itself: the current verification-method key
+/// (extracted from the resolved document, §9.7.1 check 1) and `now` (a
+/// caller-supplied clock read).
+///
+/// Flat named-field bundle (per the SCP agent-first API standard). It holds
+/// **no** resolved key and **no** timestamps — the resolution seam owns those —
+/// so it cannot be used to smuggle a caller-chosen "current" key past check 1.
+#[derive(Debug, Clone, Copy)]
+pub struct AttestationLeafGroundTruth<'a> {
+    /// The leaf's `ScpCredential`. Its `did` and `signing_key_id` are the
+    /// check-9/10 ground truth, and its `signing_key_id` names the current
+    /// verification method resolved for check 1 via
+    /// [`ScpCredential::resolve_signing_key`].
+    pub credential: &'a ScpCredential,
+    /// The leaf's actual `signature_key` (check 4).
+    pub leaf_signature_key: &'a [u8; PUBLIC_KEY_SIZE],
+    /// The leaf's actual ratchet-tree `encryption_key` (check 5).
+    pub leaf_encryption_key: &'a [u8; PUBLIC_KEY_SIZE],
+    /// The value of the leaf's `scp_wrapping_key` (`0xFF01`) extension (check 6).
+    pub leaf_wrapping_key: &'a [u8; PUBLIC_KEY_SIZE],
+    /// The leaf's `Lifetime.not_before` (check 11).
+    pub leaf_lifetime_not_before: u64,
+    /// The leaf's `Lifetime.not_after` (check 11).
+    pub leaf_lifetime_not_after: u64,
+    /// Which handshake event is being verified — the structural gate for the
+    /// Add-only `init_key` checks (7–8) and the carrier of the `KeyPackage`
+    /// `init_key` on [`AttestationTrigger::Add`].
+    pub trigger: AttestationTrigger<'a>,
+}
+
+/// A typed reason [`verify_attestation_with_resolution`] rejected a
+/// [`KeyPackageAttestation`] (§9.7.1 "Verification (MUST) — the checks",
+/// checks 1–13).
+///
+/// This enum **wraps** the pure-core [`AttestationVerifyError`] (checks 3–13,
+/// [`Delegated`](Self::Delegated)) and adds the two variants for the
+/// resolution-dependent checks the pure core deliberately defers to the caller:
+/// check 2 ([`ResolvedDocumentStale`](Self::ResolvedDocumentStale)) and check 1
+/// ([`CurrentKeyNotFound`](Self::CurrentKeyNotFound)). The pure
+/// [`AttestationVerifyError`] is left **byte-unchanged** — the new checks live
+/// only here (CRYPTO-22 S4; §9.7.1 checks 1–2).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, thiserror::Error)]
+pub enum AttestationResolutionVerifyError {
+    /// Check 2 (§9.7.1; §9.18.7): the DID document used to satisfy check 1 was
+    /// resolved more than [`MAX_ATTESTATION_KEY_RESOLUTION_STALENESS`] (300s)
+    /// before `now`. Enforced **first**, before check 1 and before the pure
+    /// checks 3–13, so a stale document can never mask a later failure.
+    #[error(
+        "DID document for the attestation current-key check is stale: resolved \
+         {age_secs}s before now (max {MAX_ATTESTATION_KEY_RESOLUTION_STALENESS}s)"
+    )]
+    ResolvedDocumentStale {
+        /// `now - resolved_at`, in seconds — how stale the resolving document is.
+        age_secs: u64,
+    },
+
+    /// Check 1 (§9.7.1; §9.12 rotation-is-revocation): the credential's
+    /// `signing_key_id` names **no current** `#active`/`#agent` verification
+    /// method in the resolved document — it is absent, or has been rotated away
+    /// and now lives only under a `#retired-*` fragment. Rejected **without**
+    /// delegating to [`verify_attestation`] (checks 3–13 never run). A key that
+    /// is still present at its `#active`/`#agent` fragment but rotated away is
+    /// instead surfaced by the pure core as
+    /// [`AttestationVerifyError::SignatureInvalid`] (check 3) via
+    /// [`Delegated`](Self::Delegated).
+    #[error(
+        "the credential's signing_key_id names no current #active/#agent \
+         verification method in the resolved DID document (absent or #retired-*)"
+    )]
+    CurrentKeyNotFound,
+
+    /// Checks 3–13: the pure [`verify_attestation`] core rejected. The wrapped
+    /// [`AttestationVerifyError`] is surfaced **verbatim** so a delegated
+    /// failure is indistinguishable from calling the pure core directly.
+    #[error(transparent)]
+    Delegated(#[from] AttestationVerifyError),
+}
+
+/// The wasm-safe current-key + freshness seam for a [`KeyPackageAttestation`].
+///
+/// Enforces §9.7.1 verifier checks **1 and 2**, layered on top of the pure
+/// checks-3–13 core [`verify_attestation`] (CRYPTO-22 S4, Layer A).
+///
+/// This function is deterministic, side-effect-free, and wasm-safe: it performs
+/// **no** DID resolution, **no** network, and **no** clock read. Both
+/// resolution-dependent inputs are caller-supplied — the already-resolved
+/// `resolved_document` and its `resolved_at` timestamp, plus the verifier's
+/// `now` — keeping it reusable by the in-browser MLS client (ADR-057). The
+/// runtime `DidResolver`-backed caller (Layer B,
+/// `scp-runtime`) obtains `resolved_document`/`resolved_at`/`now` and calls
+/// through here.
+///
+/// # Order of checks (§9.7.1 checks 1–2, then 3–13)
+///
+/// 1. **Check 2 first** (freshness): reject with
+///    [`AttestationResolutionVerifyError::ResolvedDocumentStale`] when
+///    `now - resolved_at` exceeds
+///    [`MAX_ATTESTATION_KEY_RESOLUTION_STALENESS`]. Enforced *before* the
+///    current-key extraction so a stale document cannot pass on the strength of
+///    a still-present key.
+/// 2. **Check 1** (current key): extract the `#active`/`#agent` verification
+///    method named by `ground_truth.credential.signing_key_id` from
+///    `resolved_document` via the existing [`ScpCredential::resolve_signing_key`]
+///    path. If that method is absent — including the rotated-away key that now
+///    lives only under a `#retired-*` fragment — reject with
+///    [`AttestationResolutionVerifyError::CurrentKeyNotFound`] **without**
+///    calling [`verify_attestation`].
+/// 3. **Checks 3–13**: build the [`AttestationVerificationContext`] with
+///    `resolved_current_vm_pubkey` set to the extracted current key and delegate
+///    **unchanged** to [`verify_attestation`]. A rotated-away-but-present key
+///    thus surfaces as the existing [`AttestationVerifyError::SignatureInvalid`]
+///    (check 3, rotation ⇒ revocation, §9.12).
+///
+/// # Errors
+///
+/// Returns the [`AttestationResolutionVerifyError`] for the first failing check
+/// in the order above.
+pub fn verify_attestation_with_resolution(
+    attestation: &KeyPackageAttestation,
+    ground_truth: &AttestationLeafGroundTruth<'_>,
+    resolved_document: &DidDocument,
+    resolved_at: u64,
+    now: u64,
+) -> Result<(), AttestationResolutionVerifyError> {
+    // --- Check 2 (FIRST): the resolving document must be no older than the
+    // §9.18.7 staleness bound. `saturating_sub` so a `resolved_at` that leads
+    // `now` (benign clock skew across the resolve→verify hop) reads as age 0,
+    // never a wrapping underflow.
+    let age_secs = now.saturating_sub(resolved_at);
+    if age_secs > MAX_ATTESTATION_KEY_RESOLUTION_STALENESS {
+        return Err(AttestationResolutionVerifyError::ResolvedDocumentStale { age_secs });
+    }
+
+    // --- Check 1: the credential's signing_key_id must name a CURRENT
+    // #active/#agent verification method in the resolved document. A rotated-away
+    // key that has been retired no longer occupies that fragment, so resolution
+    // fails here and we reject WITHOUT delegating to the pure core (checks 3–13
+    // never run). A rotated-away key still present at its #active/#agent fragment
+    // resolves fine and instead fails check 3 below (SignatureInvalid).
+    let resolved_current_vm_pubkey = ground_truth
+        .credential
+        .resolve_signing_key(resolved_document)
+        .map_err(|_| AttestationResolutionVerifyError::CurrentKeyNotFound)?;
+
+    // --- Checks 3–13: delegate UNCHANGED to the pure core with the extracted
+    // current key as `resolved_current_vm_pubkey`. The `?` maps any
+    // `AttestationVerifyError` through the `#[from]` into `Delegated(..)`.
+    let ctx = AttestationVerificationContext {
+        resolved_current_vm_pubkey: &resolved_current_vm_pubkey,
+        leaf_signature_key: ground_truth.leaf_signature_key,
+        leaf_encryption_key: ground_truth.leaf_encryption_key,
+        leaf_wrapping_key: ground_truth.leaf_wrapping_key,
+        leaf_credential_did: &ground_truth.credential.did,
+        leaf_credential_signing_key_id: ground_truth.credential.signing_key_id,
+        leaf_lifetime_not_before: ground_truth.leaf_lifetime_not_before,
+        leaf_lifetime_not_after: ground_truth.leaf_lifetime_not_after,
+        now,
+        trigger: ground_truth.trigger,
+    };
+    verify_attestation(attestation, &ctx)?;
     Ok(())
 }
 
@@ -1476,6 +1644,316 @@ mod tests {
         assert_eq!(
             verify_attestation(&att, &truth.ctx()),
             Err(AttestationVerifyError::IssuedInFuture)
+        );
+    }
+}
+
+// ==========================================================================
+// CRYPTO-22 S4 Layer A — verify_attestation_with_resolution (§9.7.1 checks 1–2)
+// ==========================================================================
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used)]
+mod resolution_seam_tests {
+    use super::*;
+    use ed25519_dalek::{Signer, SigningKey};
+    use rand::rngs::OsRng;
+
+    const ISSUED: u64 = 1_700_000_000;
+    const EXPIRES: u64 = 1_700_086_400; // ISSUED + 86_400 (1 day)
+    const NOW: u64 = 1_700_000_100; // inside [ISSUED, EXPIRES]
+    const TEST_DID: &str = "did:dht:z6MkResolveSeamTest";
+
+    /// A fresh random Ed25519 public key (a valid curve point — required by
+    /// `decode_multibase_key`, so raw `[u8; 32]` patterns won't do).
+    fn fresh_pub() -> [u8; PUBLIC_KEY_SIZE] {
+        SigningKey::generate(&mut OsRng).verifying_key().to_bytes()
+    }
+
+    /// Whether the fixture models an Add (`KeyPackage`, distinct `init_key`) or an
+    /// Update (bare ratchet-tree leaf, `init_key == encryption_key`). Mirrors the
+    /// pure-core tests' selector; kept local so this module borrows no private
+    /// item from `mod tests`.
+    #[derive(Clone, Copy)]
+    enum Kind {
+        Add,
+        Update,
+    }
+
+    /// Owned fixture: a fully-valid signed attestation, its leaf ground-truth
+    /// material, the signer's keypair, and a resolved DID document whose
+    /// `#active` verification method is the signer's current key.
+    struct Fx {
+        att: KeyPackageAttestation,
+        credential: ScpCredential,
+        leaf_sig: [u8; PUBLIC_KEY_SIZE],
+        leaf_enc: [u8; PUBLIC_KEY_SIZE],
+        leaf_wrap: [u8; PUBLIC_KEY_SIZE],
+        kp_init: [u8; PUBLIC_KEY_SIZE],
+        doc: DidDocument,
+        kind: Kind,
+    }
+
+    impl Fx {
+        fn ground_truth(&self) -> AttestationLeafGroundTruth<'_> {
+            AttestationLeafGroundTruth {
+                credential: &self.credential,
+                leaf_signature_key: &self.leaf_sig,
+                leaf_encryption_key: &self.leaf_enc,
+                leaf_wrapping_key: &self.leaf_wrap,
+                leaf_lifetime_not_before: ISSUED,
+                leaf_lifetime_not_after: EXPIRES,
+                trigger: match self.kind {
+                    Kind::Add => AttestationTrigger::Add {
+                        kp_init_key: &self.kp_init,
+                    },
+                    Kind::Update => AttestationTrigger::Update,
+                },
+            }
+        }
+    }
+
+    /// Builds a DID document whose `#active` verification method carries
+    /// `active_key` (the pattern `resolve_signing_key` decodes back to 32 bytes).
+    fn did_doc_with_active(active_key: &[u8; PUBLIC_KEY_SIZE]) -> DidDocument {
+        let identity_key = fresh_pub();
+        let commitment = [0u8; 32];
+        DidDocument::new(TEST_DID, &identity_key, active_key, &commitment)
+    }
+
+    /// A fully-valid `Fx`: the signer's key is the document's current `#active`
+    /// key, the attestation is signed over its §9.5.1 hash, and every pure-core
+    /// binding (checks 3–13) holds. Callers then perturb ONE input to isolate a
+    /// single check.
+    fn valid_fixture(kind: Kind) -> Fx {
+        let signer = SigningKey::generate(&mut OsRng);
+        let signer_pub = signer.verifying_key().to_bytes();
+        let leaf_sig = fresh_pub();
+        let leaf_enc = fresh_pub();
+        let leaf_wrap = fresh_pub();
+        let kp_init = fresh_pub();
+        let att_init = match kind {
+            Kind::Add => kp_init,
+            Kind::Update => leaf_enc,
+        };
+        let mut att = KeyPackageAttestation {
+            did: TEST_DID.to_owned(),
+            leaf_signature_key: leaf_sig,
+            leaf_encryption_key: leaf_enc,
+            init_key: att_init,
+            wrapping_key: leaf_wrap,
+            signing_key_id: SigningKeyId::Active,
+            issued_at: ISSUED,
+            expires_at: EXPIRES,
+            signature: [0u8; SIGNATURE_SIZE],
+        };
+        att.signature = signer.sign(&att.signing_hash()).to_bytes();
+        Fx {
+            att,
+            credential: ScpCredential::new(TEST_DID.to_owned(), None, SigningKeyId::Active)
+                .unwrap(),
+            leaf_sig,
+            leaf_enc,
+            leaf_wrap,
+            kp_init,
+            doc: did_doc_with_active(&signer_pub),
+            kind,
+        }
+    }
+
+    // -- AC1: the function is pure and callable from a scp-mls unit test -------
+
+    #[test]
+    fn valid_add_with_fresh_resolution_passes() {
+        let fx = valid_fixture(Kind::Add);
+        assert_eq!(
+            verify_attestation_with_resolution(&fx.att, &fx.ground_truth(), &fx.doc, NOW, NOW),
+            Ok(())
+        );
+    }
+
+    #[test]
+    fn valid_update_with_fresh_resolution_passes() {
+        let fx = valid_fixture(Kind::Update);
+        assert_eq!(
+            verify_attestation_with_resolution(&fx.att, &fx.ground_truth(), &fx.doc, NOW, NOW),
+            Ok(())
+        );
+    }
+
+    // -- AC2: check-2 freshness boundary (300 pass / 301 reject) ---------------
+
+    #[test]
+    fn freshness_boundary_300s_passes() {
+        // age == MAX_ATTESTATION_KEY_RESOLUTION_STALENESS (300) is accepted (`>`
+        // rejects, so the boundary is inclusive).
+        let fx = valid_fixture(Kind::Add);
+        let resolved_at = NOW - MAX_ATTESTATION_KEY_RESOLUTION_STALENESS; // age = 300
+        assert_eq!(
+            verify_attestation_with_resolution(
+                &fx.att,
+                &fx.ground_truth(),
+                &fx.doc,
+                resolved_at,
+                NOW
+            ),
+            Ok(())
+        );
+    }
+
+    #[test]
+    fn freshness_boundary_301s_rejected_before_verify() {
+        // age == 301 > 300 → ResolvedDocumentStale, reached before check 1 and
+        // before the pure checks 3–13.
+        let fx = valid_fixture(Kind::Add);
+        let resolved_at = NOW - (MAX_ATTESTATION_KEY_RESOLUTION_STALENESS + 1); // age = 301
+        let err = verify_attestation_with_resolution(
+            &fx.att,
+            &fx.ground_truth(),
+            &fx.doc,
+            resolved_at,
+            NOW,
+        )
+        .unwrap_err();
+        assert_eq!(
+            err,
+            AttestationResolutionVerifyError::ResolvedDocumentStale { age_secs: 301 }
+        );
+    }
+
+    // -- AC3(a): check-1 absent / #retired-* rejection (no verify_attestation) -
+
+    #[test]
+    fn current_active_absent_is_current_key_not_found() {
+        // The resolved document has NO #active verification method: the signer's
+        // key is simply gone. Check 1 rejects WITHOUT delegating to the pure core.
+        let mut fx = valid_fixture(Kind::Add);
+        fx.doc
+            .verification_method
+            .retain(|vm| !vm.id.ends_with("#active"));
+        let err =
+            verify_attestation_with_resolution(&fx.att, &fx.ground_truth(), &fx.doc, NOW, NOW)
+                .unwrap_err();
+        assert_eq!(err, AttestationResolutionVerifyError::CurrentKeyNotFound);
+        // Prove the pure core was NOT reached: a Delegated(..) variant would mean
+        // verify_attestation ran.
+        assert!(
+            !matches!(err, AttestationResolutionVerifyError::Delegated(_)),
+            "check 1 must reject before delegating to verify_attestation"
+        );
+    }
+
+    #[test]
+    fn current_active_retired_is_current_key_not_found() {
+        // Model rotation-is-revocation (§9.12): the signer's key survives in the
+        // document ONLY under a #retired-1 fragment (the current #active is gone).
+        // `resolve_signing_key("active")` finds nothing → CurrentKeyNotFound, and
+        // the pure core is never reached.
+        let mut fx = valid_fixture(Kind::Add);
+        for vm in &mut fx.doc.verification_method {
+            if vm.id.ends_with("#active") {
+                vm.id = format!("{TEST_DID}#retired-1");
+            }
+        }
+        let err =
+            verify_attestation_with_resolution(&fx.att, &fx.ground_truth(), &fx.doc, NOW, NOW)
+                .unwrap_err();
+        assert_eq!(err, AttestationResolutionVerifyError::CurrentKeyNotFound);
+        assert!(!matches!(
+            err,
+            AttestationResolutionVerifyError::Delegated(_)
+        ));
+    }
+
+    // -- AC3(b): rotated-away-but-PRESENT key → delegated SignatureInvalid -----
+
+    #[test]
+    fn rotated_but_present_key_is_delegated_signature_invalid() {
+        // The document's current #active is a DIFFERENT key than the one that
+        // signed (the signer rotated; a fresh #active is present). Check 1 passes
+        // (an #active VM exists) but the pure core's check 3 fails: the signature
+        // does not verify against the resolved CURRENT key.
+        let mut fx = valid_fixture(Kind::Add);
+        fx.doc = did_doc_with_active(&fresh_pub()); // a new, unrelated #active key
+        let err =
+            verify_attestation_with_resolution(&fx.att, &fx.ground_truth(), &fx.doc, NOW, NOW)
+                .unwrap_err();
+        assert_eq!(
+            err,
+            AttestationResolutionVerifyError::Delegated(AttestationVerifyError::SignatureInvalid)
+        );
+    }
+
+    // -- AC4: check-2 is enforced BEFORE check-1 and before checks 3–13 --------
+
+    #[test]
+    fn staleness_takes_precedence_over_a_valid_current_key() {
+        // A 301s-stale document that ALSO carries a perfectly valid current key
+        // (checks 1 and 3–13 would all pass) must still fail with the staleness
+        // error — never a check-1 or checks-3–13 error.
+        let fx = valid_fixture(Kind::Add);
+        // Sanity: with a FRESH resolution this exact fixture verifies Ok, so any
+        // failure below is attributable solely to staleness ordering.
+        assert_eq!(
+            verify_attestation_with_resolution(&fx.att, &fx.ground_truth(), &fx.doc, NOW, NOW),
+            Ok(())
+        );
+        let resolved_at = NOW - (MAX_ATTESTATION_KEY_RESOLUTION_STALENESS + 1); // age = 301
+        let err = verify_attestation_with_resolution(
+            &fx.att,
+            &fx.ground_truth(),
+            &fx.doc,
+            resolved_at,
+            NOW,
+        )
+        .unwrap_err();
+        assert!(
+            matches!(
+                err,
+                AttestationResolutionVerifyError::ResolvedDocumentStale { .. }
+            ),
+            "stale document must fail check 2 first, got {err:?}"
+        );
+    }
+
+    // -- AC5-style: a checks-4..13 failure surfaces the EXACT unchanged variant -
+
+    #[test]
+    fn delegated_check4_leaf_signature_key_mismatch_surfaces_verbatim() {
+        // Flip the leaf's actual signature_key (a context-only input): check 2 and
+        // check 1 pass, then the pure core's check 4 fails. The wrapped
+        // AttestationVerifyError must surface verbatim through Delegated(..).
+        let mut fx = valid_fixture(Kind::Add);
+        fx.leaf_sig = fresh_pub();
+        let err =
+            verify_attestation_with_resolution(&fx.att, &fx.ground_truth(), &fx.doc, NOW, NOW)
+                .unwrap_err();
+        assert_eq!(
+            err,
+            AttestationResolutionVerifyError::Delegated(
+                AttestationVerifyError::LeafSignatureKeyMismatch
+            )
+        );
+    }
+
+    #[test]
+    fn delegated_check13_expired_surfaces_verbatim() {
+        // A check-13 (freshness/expiry) failure also delegates verbatim: `now`
+        // past the attestation's expiry with a FRESH resolution (resolved_at ==
+        // now, so check 2 passes) yields Delegated(Expired), proving the whole
+        // 3–13 band is delegated, not just early checks.
+        let fx = valid_fixture(Kind::Add);
+        let now = EXPIRES + 1;
+        let err = verify_attestation_with_resolution(
+            &fx.att,
+            &fx.ground_truth(),
+            &fx.doc,
+            now, // resolved_at == now ⇒ age 0 ⇒ check 2 passes
+            now,
+        )
+        .unwrap_err();
+        assert_eq!(
+            err,
+            AttestationResolutionVerifyError::Delegated(AttestationVerifyError::Expired)
         );
     }
 }

--- a/crates/scp-mls/src/keypackage_attestation.rs
+++ b/crates/scp-mls/src/keypackage_attestation.rs
@@ -1760,6 +1760,83 @@ mod resolution_seam_tests {
         }
     }
 
+    /// A fully-valid **`#agent`-persona** Add `Fx`: the credential and
+    /// attestation both use [`SigningKeyId::Agent`], the attestation is signed by
+    /// the **agent** key, and the resolved document carries an *unrelated*
+    /// `#active` VM plus (when `include_agent_vm`) an `#agent` VM equal to the
+    /// signer's agent key. The unrelated `#active` is the discriminator: a
+    /// persona-blind verifier that hardwired `#active` would resolve that
+    /// unrelated key and fail check 3, so reaching `Ok` / `CurrentKeyNotFound`
+    /// proves the seam resolved the credential-named `#agent` VM.
+    fn agent_fixture(include_agent_vm: bool) -> Fx {
+        let signer = SigningKey::generate(&mut OsRng);
+        let agent_pub = signer.verifying_key().to_bytes();
+        let leaf_sig = fresh_pub();
+        let leaf_enc = fresh_pub();
+        let leaf_wrap = fresh_pub();
+        let kp_init = fresh_pub();
+        let mut att = KeyPackageAttestation {
+            did: TEST_DID.to_owned(),
+            leaf_signature_key: leaf_sig,
+            leaf_encryption_key: leaf_enc,
+            init_key: kp_init,
+            wrapping_key: leaf_wrap,
+            signing_key_id: SigningKeyId::Agent,
+            issued_at: ISSUED,
+            expires_at: EXPIRES,
+            signature: [0u8; SIGNATURE_SIZE],
+        };
+        att.signature = signer.sign(&att.signing_hash()).to_bytes();
+        // `#active` is an UNRELATED key — the persona discriminator.
+        let mut doc = did_doc_with_active(&fresh_pub());
+        if include_agent_vm {
+            doc.verification_method.push(scp_did::VerificationMethod {
+                id: format!("{TEST_DID}#agent"),
+                method_type: "Ed25519VerificationKey2020".to_owned(),
+                controller: TEST_DID.to_owned(),
+                public_key_multibase: format!("z{}", bs58::encode(agent_pub).into_string()),
+            });
+        }
+        Fx {
+            att,
+            credential: ScpCredential::new(TEST_DID.to_owned(), None, SigningKeyId::Agent).unwrap(),
+            leaf_sig,
+            leaf_enc,
+            leaf_wrap,
+            kp_init,
+            doc,
+            kind: Kind::Add,
+        }
+    }
+
+    // -- FIX 2: #agent persona resolves the persona-correct VM ----------------
+
+    #[test]
+    fn agent_persona_resolves_agent_vm_and_delegates_ok() {
+        // Check 1 resolves the `#agent` VM (NOT the unrelated `#active`), and
+        // delegation succeeds because the signature verifies against the resolved
+        // agent key. Proves the seam reaches the pure core on the agent persona.
+        let fx = agent_fixture(true);
+        assert_eq!(fx.credential.signing_key_id, SigningKeyId::Agent);
+        assert_eq!(
+            verify_attestation_with_resolution(&fx.att, &fx.ground_truth(), &fx.doc, NOW, NOW),
+            Ok(())
+        );
+    }
+
+    #[test]
+    fn agent_persona_missing_agent_vm_is_current_key_not_found() {
+        // The resolved doc lacks an `#agent` VM (only the unrelated `#active`):
+        // check 1 must reject with CurrentKeyNotFound — proving the seam resolves
+        // the VM named by the credential's signing_key_id (`#agent`), never a
+        // hardwired `#active`.
+        let fx = agent_fixture(false);
+        let err =
+            verify_attestation_with_resolution(&fx.att, &fx.ground_truth(), &fx.doc, NOW, NOW)
+                .unwrap_err();
+        assert_eq!(err, AttestationResolutionVerifyError::CurrentKeyNotFound);
+    }
+
     // -- AC1: the function is pure and callable from a scp-mls unit test -------
 
     #[test]

--- a/crates/scp-mls/src/lib.rs
+++ b/crates/scp-mls/src/lib.rs
@@ -68,7 +68,7 @@ pub use encrypt::{DecryptedContent, InboundChange};
 pub use error::MlsError;
 pub use keypackage_attestation::{
     AttestationLeafGroundTruth, AttestationResolutionVerifyError, AttestationTrigger,
-    KeyPackageAttestation, MAX_ATTESTATION_KEY_RESOLUTION_STALENESS,
+    AttestationVerifyError, KeyPackageAttestation, MAX_ATTESTATION_KEY_RESOLUTION_STALENESS,
     MAX_KEYPACKAGE_ATTESTATION_LIFETIME, SCP_KEYPACKAGE_ATTESTATION_DOMAIN,
     SCP_KEYPACKAGE_ATTESTATION_EXTENSION_TYPE, scp_capabilities_with_keypackage_attestation,
     verify_attestation_with_resolution,

--- a/crates/scp-mls/src/lib.rs
+++ b/crates/scp-mls/src/lib.rs
@@ -67,9 +67,11 @@ pub use credential::ScpCredential;
 pub use encrypt::{DecryptedContent, InboundChange};
 pub use error::MlsError;
 pub use keypackage_attestation::{
-    AttestationTrigger, KeyPackageAttestation, MAX_ATTESTATION_KEY_RESOLUTION_STALENESS,
+    AttestationLeafGroundTruth, AttestationResolutionVerifyError, AttestationTrigger,
+    KeyPackageAttestation, MAX_ATTESTATION_KEY_RESOLUTION_STALENESS,
     MAX_KEYPACKAGE_ATTESTATION_LIFETIME, SCP_KEYPACKAGE_ATTESTATION_DOMAIN,
     SCP_KEYPACKAGE_ATTESTATION_EXTENSION_TYPE, scp_capabilities_with_keypackage_attestation,
+    verify_attestation_with_resolution,
 };
 
 // The MLS signing key pair appears in this crate's public op signatures

--- a/crates/scp-runtime/src/crypto/mls/attestation_verification.rs
+++ b/crates/scp-runtime/src/crypto/mls/attestation_verification.rs
@@ -1,0 +1,467 @@
+//! Async, native `DidResolver`-backed KeyPackage-attestation verification —
+//! §9.7.1 verifier checks 1–2 wired to real DID resolution (CRYPTO-22 S4,
+//! Layer B).
+//!
+//! The pure, wasm-safe seam
+//! ([`scp_mls::verify_attestation_with_resolution`], Layer A) enforces
+//! §9.7.1 check 2 (the resolving document is fresh) and check 1 (the
+//! credential's `signing_key_id` names the DID's *current* `#active`/`#agent`
+//! verification method), then delegates checks 3–13 to the pure core
+//! `verify_attestation`. It is deliberately I/O-free: it consumes an
+//! *already-resolved* [`scp_did::DidDocument`] plus caller-supplied
+//! `resolved_at`/`now` timestamps.
+//!
+//! This module is the **runtime caller** that produces those inputs. It:
+//!
+//! 1. resolves the attestation signer's DID through the injected canonical
+//!    [`DidResolver`] (§3.10.4 dual-layer resolution) — never a `NoOp` / `Stub` /
+//!    in-memory stand-in (the no-dev-stand-in tenet; #2211);
+//! 2. applies the §9.7.1 **"Resolution failure policy"**: a resolution
+//!    failure (`Err`) or not-found (`Ok(None)`) is **fail-closed** — a typed
+//!    reject with NO fallback to a stale/pre-rotation cached document;
+//! 3. stamps `resolved_at` = the injected [`Clock`]'s time at the
+//!    [`DidResolver::resolve`] call (HONEST — never a fabricated/hardcoded
+//!    constant); and
+//! 4. delegates to Layer A.
+//!
+//! # Testing carve-out (compiled out of shipped artifacts)
+//!
+//! Under `#[cfg(any(test, feature = "testing"))]` only, a **positive
+//! whitelist** admitting exactly the `did:test:` and `did:key:` prefixes skips
+//! DID-document resolution so the extensive non-`did:dht:` test suite runs
+//! without a live resolver. This mirrors
+//! [`NodeMlsFactory::validate_creator_identity`](super::provider::NodeMlsFactory::validate_creator_identity).
+//! It is keyed on the `did:test:` / `did:key:` prefixes — **not** on
+//! `did:dht:z`, and `did:web:*` is deliberately **not** exempt (§9.7.1
+//! "Fail-closed scope"). On a shipped (no-`testing`) build the whole block is
+//! absent, so every DID — `did:dht:*` and `did:web:*` alike — is resolved and
+//! fail-closed.
+//!
+//! # Scope (CRYPTO-22 S4)
+//!
+//! This is the Add fail-closed + current-key + testing-carve-out path only. It
+//! reads exactly [`DidResolver::resolve`] and stamps `resolved_at` from the
+//! clock; it reads **no** document-age field from the resolver (the canonical
+//! `ResolvedDidDocument` exposes none today). Resolver-side privacy-cache
+//! freshness enforcement — that a document served from the §9.10.7 24h/7d cache
+//! and older than `MAX_ATTESTATION_KEY_RESOLUTION_STALENESS` MUST force a fresh
+//! re-resolution — is the boundary-stable **SCP-CRYPTO22-005** follow-on (it
+//! needs a resolver-freshness seam that touches the shared #2211 resolver, out
+//! of this story's scope). The already-admitted-member **Update
+//! last-known-good grace** branch (§9.7.1 "Resolution failure policy", Update
+//! bullet) is likewise deferred; until it lands, an Update whose resolution
+//! fails also fails closed here (the conservative default — the grace would
+//! only *loosen* this, so its absence never masks a missing backend). This
+//! function is NOT yet wired into the `ContextManager` / `Supervisor` / pipeline —
+//! that live Add-path wiring is S6/S7 and is gated on SCP-CRYPTO22-005.
+//!
+//! See spec §9.7.1 (checks 1–2, resolution failure policy, fail-closed scope),
+//! §9.18.7 (the 300s staleness bound), §9.14 (clock skew), and
+//! ADR-057 Amendment (2026-08-01).
+
+use scp_clock::Clock;
+use scp_identity::IdentityError;
+use scp_identity::resolver::DidResolver;
+use scp_mls::{
+    AttestationLeafGroundTruth, AttestationResolutionVerifyError, KeyPackageAttestation,
+    verify_attestation_with_resolution,
+};
+
+/// A typed reason [`verify_add_or_update_attestation`] rejected a
+/// [`KeyPackageAttestation`] on the runtime (native, `DidResolver`-backed)
+/// path — §9.7.1 checks 1–13, plus the resolution-failure policy.
+///
+/// Wraps the wasm-safe Layer-A [`AttestationResolutionVerifyError`] (checks
+/// 1–13) via [`Verify`](Self::Verify) and adds the two resolution-failure
+/// variants for the §9.7.1 "Resolution failure policy" fail-closed branch.
+#[derive(Debug, thiserror::Error)]
+pub enum AttestationRuntimeVerifyError {
+    /// §9.7.1 "Resolution failure policy": resolving the signer's DID errored.
+    /// Fail-closed on Add — NO fallback to a stale/pre-rotation cached document.
+    #[error("attestation signer DID resolution failed (fail-closed): {0}")]
+    Resolution(#[from] IdentityError),
+
+    /// §9.7.1 "Resolution failure policy": resolving the signer's DID returned
+    /// no document (`Ok(None)`). Fail-closed on Add — no cache fallback.
+    #[error("attestation signer DID resolved to no document (fail-closed)")]
+    ResolutionNotFound,
+
+    /// The current-key + freshness seam (Layer A, §9.7.1 checks 1–2) or the
+    /// delegated pure core (checks 3–13) rejected. Surfaced verbatim.
+    #[error(transparent)]
+    Verify(#[from] AttestationResolutionVerifyError),
+}
+
+/// Verifies a leaf's [`KeyPackageAttestation`] against the signer's
+/// **freshly-resolved current** DID document — §9.7.1 verifier checks 1–13
+/// (CRYPTO-22 S4, Layer B).
+///
+/// Resolves the signer DID (`ground_truth.credential.did`) through the injected
+/// canonical `resolver`, stamps `resolved_at` from the injected `clock` at the
+/// resolve call, and delegates to the pure Layer-A seam
+/// [`verify_attestation_with_resolution`], which enforces check 2 (freshness),
+/// check 1 (current key), then checks 3–13.
+///
+/// # Resolution failure policy (§9.7.1)
+///
+/// On an [`Add`](scp_mls::AttestationTrigger::Add), a resolution `Err` or
+/// `Ok(None)` is **fail-closed** — a typed reject with NO fallback to a
+/// stale/pre-rotation cached document. The `ground_truth.trigger` selects the
+/// Add-only `init_key` checks (7–8) inside Layer A. (The Update last-known-good
+/// grace branch is the deferred SCP-CRYPTO22-005 / S7 follow-on; until it
+/// lands, an Update whose resolution fails also fails closed here.)
+///
+/// # Honest `resolved_at` (§9.7.1 check 2; §9.14)
+///
+/// `resolved_at` is read from `clock` immediately before the resolve call, and
+/// `now` immediately after — both clock-derived, never fabricated. For a
+/// freshly-resolved document `now - resolved_at` is within §9.14 clock-skew
+/// tolerance, so Layer A's 300s freshness gate passes.
+///
+/// # Testing carve-out
+///
+/// Under `#[cfg(any(test, feature = "testing"))]` only, a signer DID with the
+/// `did:test:` or `did:key:` prefix skips resolution and is accepted (mirroring
+/// [`validate_creator_identity`](super::provider::NodeMlsFactory::validate_creator_identity)).
+/// `did:web:*` is NOT exempt. The block is compiled out of shipped artifacts.
+///
+/// # Errors
+///
+/// Returns [`AttestationRuntimeVerifyError`] on a resolution failure
+/// (fail-closed) or on any Layer-A/pure-core check failure.
+pub async fn verify_add_or_update_attestation<R: DidResolver + ?Sized>(
+    resolver: &R,
+    clock: &dyn Clock,
+    attestation: &KeyPackageAttestation,
+    ground_truth: &AttestationLeafGroundTruth<'_>,
+) -> Result<(), AttestationRuntimeVerifyError> {
+    // The signer DID is the attested DID, which check 9 binds to the leaf
+    // credential's `did`; resolving the credential DID is therefore resolving
+    // the signer.
+    let signer_did = ground_truth.credential.did.as_str();
+
+    // Testing carve-out — a positive whitelist compiled OUT of shipped builds.
+    // Keyed on `did:test:` / `did:key:` ONLY (never `did:dht:z`); `did:web:*`
+    // is not exempt (§9.7.1 "Fail-closed scope"). Mirrors
+    // `validate_creator_identity`.
+    #[cfg(any(test, feature = "testing"))]
+    {
+        if signer_did.starts_with("did:test:") || signer_did.starts_with("did:key:") {
+            return Ok(());
+        }
+    }
+
+    // Stamp `resolved_at` from the injected clock at the resolve call (HONEST —
+    // never a hardcoded constant), then resolve through the canonical injected
+    // resolver (§3.10.4). NEVER a NoOp/Stub/in-memory stand-in — the resolver is
+    // supplied by dependency injection (#2211, no-dev-stand-in tenet).
+    let resolved_at = clock.now_secs();
+    let resolved_document = match resolver.resolve(signer_did).await {
+        Ok(Some(found)) => found.document,
+        // §9.7.1 "Resolution failure policy" — fail-closed. On Add there is NO
+        // fallback to a stale/pre-rotation cached document. (Update's
+        // last-known-good grace is the deferred SCP-CRYPTO22-005 / S7 follow-on;
+        // failing closed here in the meantime is the conservative default.)
+        Ok(None) => return Err(AttestationRuntimeVerifyError::ResolutionNotFound),
+        Err(source) => return Err(AttestationRuntimeVerifyError::Resolution(source)),
+    };
+
+    // `now` for the §9.7.1 check-13 freshness/expiry band and the check-2 age.
+    let now = clock.now_secs();
+
+    // Delegate to the pure, wasm-safe Layer-A seam (checks 2, 1, then 3–13).
+    verify_attestation_with_resolution(
+        attestation,
+        ground_truth,
+        &resolved_document,
+        resolved_at,
+        now,
+    )
+    .map_err(AttestationRuntimeVerifyError::Verify)
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used)]
+mod tests {
+    use super::*;
+    use ed25519_dalek::{Signer, SigningKey};
+    use rand::rngs::OsRng;
+    use scp_clock::Clock;
+    use scp_did::{DidDocument, SigningKeyId};
+    use scp_identity::resolver::{ResolutionSource, ResolvedDidDocument};
+    use scp_mls::{AttestationTrigger, ScpCredential};
+    use std::future::Future;
+    use std::sync::atomic::{AtomicBool, Ordering};
+
+    const ISSUED: u64 = 1_700_000_000;
+    const EXPIRES: u64 = 1_700_086_400;
+    const NOW: u64 = 1_700_000_100; // inside [ISSUED, EXPIRES]
+    const TEST_DID: &str = "did:dht:z6MkRuntimeSeamTest";
+
+    /// A fixed-time clock: `now_secs()` always returns the same value, so a test
+    /// can assert `resolved_at` is clock-derived (== this value), never 0 or a
+    /// fabricated constant.
+    struct FixedClock(u64);
+    impl Clock for FixedClock {
+        fn now_secs(&self) -> u64 {
+            self.0
+        }
+        fn now_millis(&self) -> u64 {
+            self.0.saturating_mul(1000)
+        }
+    }
+
+    /// A `DidResolver` that returns a preset outcome and records whether it was
+    /// called — so a test can assert the carve-out SKIPS resolution while a
+    /// non-exempt DID does NOT.
+    struct MockResolver {
+        outcome: MockOutcome,
+        called: AtomicBool,
+    }
+
+    #[derive(Clone)]
+    enum MockOutcome {
+        Found(DidDocument),
+        NotFound,
+        Error,
+    }
+
+    impl MockResolver {
+        fn new(outcome: MockOutcome) -> Self {
+            Self {
+                outcome,
+                called: AtomicBool::new(false),
+            }
+        }
+        fn was_called(&self) -> bool {
+            self.called.load(Ordering::SeqCst)
+        }
+    }
+
+    impl DidResolver for MockResolver {
+        fn resolve(
+            &self,
+            _did: &str,
+        ) -> impl Future<Output = Result<Option<ResolvedDidDocument>, IdentityError>> + Send
+        {
+            self.called.store(true, Ordering::SeqCst);
+            let outcome = self.outcome.clone();
+            async move {
+                match outcome {
+                    MockOutcome::Found(document) => Ok(Some(ResolvedDidDocument {
+                        document,
+                        seq: 1,
+                        source: ResolutionSource::MainlineDht,
+                    })),
+                    MockOutcome::NotFound => Ok(None),
+                    MockOutcome::Error => Err(IdentityError::DhtResolveFailed(
+                        "mock resolver error".to_owned(),
+                    )),
+                }
+            }
+        }
+    }
+
+    fn fresh_pub() -> [u8; 32] {
+        SigningKey::generate(&mut OsRng).verifying_key().to_bytes()
+    }
+
+    fn did_doc_with_active(active_key: &[u8; 32]) -> DidDocument {
+        let identity_key = fresh_pub();
+        let commitment = [0u8; 32];
+        DidDocument::new(TEST_DID, &identity_key, active_key, &commitment)
+    }
+
+    /// Builds a valid signed attestation + its owned leaf ground-truth material +
+    /// the signer's current DID document, for a given signer DID.
+    struct Fx {
+        att: KeyPackageAttestation,
+        credential: ScpCredential,
+        leaf_sig: [u8; 32],
+        leaf_enc: [u8; 32],
+        leaf_wrap: [u8; 32],
+        kp_init: [u8; 32],
+        signer_pub: [u8; 32],
+    }
+
+    impl Fx {
+        fn ground_truth(&self) -> AttestationLeafGroundTruth<'_> {
+            AttestationLeafGroundTruth {
+                credential: &self.credential,
+                leaf_signature_key: &self.leaf_sig,
+                leaf_encryption_key: &self.leaf_enc,
+                leaf_wrapping_key: &self.leaf_wrap,
+                leaf_lifetime_not_before: ISSUED,
+                leaf_lifetime_not_after: EXPIRES,
+                trigger: AttestationTrigger::Add {
+                    kp_init_key: &self.kp_init,
+                },
+            }
+        }
+    }
+
+    /// A signed Add fixture whose signer DID is `did`. The credential fields are
+    /// set directly (bypassing `ScpCredential::new`'s prefix validation) so a
+    /// `did:web:` signer can be modeled for the carve-out negative test.
+    fn add_fixture(did: &str) -> Fx {
+        let signer = SigningKey::generate(&mut OsRng);
+        let signer_pub = signer.verifying_key().to_bytes();
+        let leaf_sig = fresh_pub();
+        let leaf_enc = fresh_pub();
+        let leaf_wrap = fresh_pub();
+        let kp_init = fresh_pub();
+        let mut att = KeyPackageAttestation {
+            did: did.to_owned(),
+            leaf_signature_key: leaf_sig,
+            leaf_encryption_key: leaf_enc,
+            init_key: kp_init,
+            wrapping_key: leaf_wrap,
+            signing_key_id: SigningKeyId::Active,
+            issued_at: ISSUED,
+            expires_at: EXPIRES,
+            signature: [0u8; 64],
+        };
+        att.signature = signer.sign(&att.signing_hash()).to_bytes();
+        let credential = ScpCredential {
+            did: did.to_owned(),
+            ucan_token: None,
+            signing_key_id: SigningKeyId::Active,
+        };
+        Fx {
+            att,
+            credential,
+            leaf_sig,
+            leaf_enc,
+            leaf_wrap,
+            kp_init,
+            signer_pub,
+        }
+    }
+
+    // -- AC5/AC7: resolve success + fresh + current key → Ok, honest resolved_at
+
+    #[tokio::test]
+    async fn resolve_success_fresh_current_key_ok() {
+        let fx = add_fixture(TEST_DID);
+        let resolver = MockResolver::new(MockOutcome::Found(did_doc_with_active(&fx.signer_pub)));
+        let clock = FixedClock(NOW);
+
+        let result =
+            verify_add_or_update_attestation(&resolver, &clock, &fx.att, &fx.ground_truth()).await;
+
+        assert!(result.is_ok(), "expected Ok, got {result:?}");
+        assert!(resolver.was_called(), "a did:dht: signer MUST be resolved");
+    }
+
+    #[tokio::test]
+    async fn honest_resolved_at_is_clock_derived_not_fabricated() {
+        // AC7: `resolved_at` is the clock time at the resolve() call. The clock
+        // returns the realistic Unix time NOW (~1.7e9). Layer A computes
+        // `age = now - resolved_at`; with an HONEST clock-derived `resolved_at`
+        // (== NOW), age == 0 ≤ 300 and verification succeeds. A FABRICATED
+        // `resolved_at` (e.g. hardcoded 0) would make age == NOW (~1.7e9) ≫ 300,
+        // tripping ResolvedDocumentStale. The Ok result therefore proves
+        // `resolved_at` is clock-derived and within skew of `now`.
+        let fx = add_fixture(TEST_DID);
+        let resolver = MockResolver::new(MockOutcome::Found(did_doc_with_active(&fx.signer_pub)));
+        let clock = FixedClock(NOW);
+
+        let result =
+            verify_add_or_update_attestation(&resolver, &clock, &fx.att, &fx.ground_truth()).await;
+
+        assert!(
+            result.is_ok(),
+            "a clock-derived resolved_at within skew of now must pass check 2; got {result:?}"
+        );
+    }
+
+    // -- AC6: Add fail-closed on resolution failure (Err / None), no fallback ---
+
+    #[tokio::test]
+    async fn add_resolution_error_is_fail_closed_reject() {
+        let fx = add_fixture(TEST_DID);
+        let resolver = MockResolver::new(MockOutcome::Error);
+        let clock = FixedClock(NOW);
+
+        let err = verify_add_or_update_attestation(&resolver, &clock, &fx.att, &fx.ground_truth())
+            .await
+            .unwrap_err();
+
+        assert!(
+            matches!(err, AttestationRuntimeVerifyError::Resolution(_)),
+            "resolve Err on Add must fail closed with a typed reject, got {err:?}"
+        );
+        assert!(resolver.was_called());
+    }
+
+    #[tokio::test]
+    async fn add_resolution_not_found_is_fail_closed_reject() {
+        let fx = add_fixture(TEST_DID);
+        let resolver = MockResolver::new(MockOutcome::NotFound);
+        let clock = FixedClock(NOW);
+
+        let err = verify_add_or_update_attestation(&resolver, &clock, &fx.att, &fx.ground_truth())
+            .await
+            .unwrap_err();
+
+        assert!(
+            matches!(err, AttestationRuntimeVerifyError::ResolutionNotFound),
+            "resolve Ok(None) on Add must fail closed with a typed reject, got {err:?}"
+        );
+        assert!(resolver.was_called());
+    }
+
+    // -- AC8: testing carve-out — did:test: skips resolution, did:web: does not -
+
+    #[tokio::test]
+    async fn testing_carveout_did_test_skips_resolution() {
+        // Under the `testing`/`cfg(test)` gate, a did:test: signer is accepted
+        // WITHOUT resolution. The resolver would ERROR if consulted, so an Ok
+        // result proves resolution was skipped.
+        let fx = add_fixture("did:test:carveout");
+        let resolver = MockResolver::new(MockOutcome::Error);
+        let clock = FixedClock(NOW);
+
+        let result =
+            verify_add_or_update_attestation(&resolver, &clock, &fx.att, &fx.ground_truth()).await;
+
+        assert!(result.is_ok(), "did:test: signer must skip resolution");
+        assert!(
+            !resolver.was_called(),
+            "carve-out MUST NOT resolve a did:test: signer"
+        );
+    }
+
+    #[tokio::test]
+    async fn testing_carveout_did_key_skips_resolution() {
+        let fx = add_fixture("did:key:z6MkCarveout");
+        let resolver = MockResolver::new(MockOutcome::Error);
+        let clock = FixedClock(NOW);
+
+        let result =
+            verify_add_or_update_attestation(&resolver, &clock, &fx.att, &fx.ground_truth()).await;
+
+        assert!(result.is_ok(), "did:key: signer must skip resolution");
+        assert!(!resolver.was_called());
+    }
+
+    #[tokio::test]
+    async fn testing_carveout_does_not_exempt_did_web() {
+        // did:web: is NOT on the positive whitelist: it MUST be resolved (and
+        // here fails closed because the mock resolver errors). This pins that the
+        // carve-out is not keyed on a blanket non-dht rule.
+        let fx = add_fixture("did:web:example.com");
+        let resolver = MockResolver::new(MockOutcome::Error);
+        let clock = FixedClock(NOW);
+
+        let err = verify_add_or_update_attestation(&resolver, &clock, &fx.att, &fx.ground_truth())
+            .await
+            .unwrap_err();
+
+        assert!(
+            resolver.was_called(),
+            "did:web: MUST be resolved (not exempt from the carve-out)"
+        );
+        assert!(matches!(err, AttestationRuntimeVerifyError::Resolution(_)));
+    }
+}

--- a/crates/scp-runtime/src/crypto/mls/attestation_verification.rs
+++ b/crates/scp-runtime/src/crypto/mls/attestation_verification.rs
@@ -63,11 +63,59 @@ use scp_clock::Clock;
 use scp_identity::IdentityError;
 use scp_identity::resolver::DidResolver;
 use scp_mls::{
-    AttestationLeafGroundTruth, AttestationResolutionVerifyError, KeyPackageAttestation,
-    verify_attestation_with_resolution,
+    AttestationLeafGroundTruth, AttestationResolutionVerifyError, AttestationTrigger,
+    KeyPackageAttestation, ScpCredential, verify_attestation_with_resolution,
 };
 
-/// A typed reason [`verify_add_or_update_attestation`] rejected a
+/// The Add-path leaf/credential ground-truth for the async runtime seam
+/// [`verify_add_attestation`].
+///
+/// This is deliberately the **Add-only** analogue of the pure, trigger-general
+/// [`AttestationLeafGroundTruth`]: it carries the `KeyPackage`'s `init_key`
+/// (`kp_init_key`) directly and has **no** `trigger` field. Because the async
+/// resolver seam accepts only this type, an
+/// [`AttestationTrigger::Update`] is **unrepresentable** there **by
+/// construction** — not merely undocumented.
+///
+/// # Why Update is excluded here (not just deferred in prose)
+///
+/// §9.7.1's "Resolution failure policy" gives an already-admitted member's
+/// **Update** a *last-known-good grace* on a transient resolution outage (a
+/// bounded fallback to the member's prior document), whereas an **Add** is
+/// strictly fail-closed. That grace is the S7 follow-on and is **not**
+/// implemented on this async seam. If this seam accepted a general
+/// `AttestationTrigger`, a future wirer could route the Update path through it
+/// and a transient resolver outage would then hard-reject a legitimate existing
+/// member's Update — a censorship/liveness regression. Making Update
+/// unrepresentable at the type level (per SCP's "encode required choices as
+/// required fields" / "make illegal states unrepresentable" tenets) forecloses
+/// that regression mechanically. The pure Layer-A
+/// [`verify_attestation_with_resolution`] remains trigger-general and its
+/// Update path is complete (it does no resolution, so it has no
+/// resolution-failure grace to get wrong).
+#[derive(Debug, Clone, Copy)]
+pub struct AttestationAddGroundTruth<'a> {
+    /// The leaf's `ScpCredential`. Its `did` is the signer DID resolved here,
+    /// and its `did`/`signing_key_id` are the check-9/10 ground truth; its
+    /// `signing_key_id` names the current verification method for check 1.
+    pub credential: &'a ScpCredential,
+    /// The leaf's actual `signature_key` (check 4).
+    pub leaf_signature_key: &'a [u8; 32],
+    /// The leaf's actual ratchet-tree `encryption_key` (check 5).
+    pub leaf_encryption_key: &'a [u8; 32],
+    /// The value of the leaf's `scp_wrapping_key` (`0xFF01`) extension (check 6).
+    pub leaf_wrapping_key: &'a [u8; 32],
+    /// The leaf's `Lifetime.not_before` (check 11).
+    pub leaf_lifetime_not_before: u64,
+    /// The leaf's `Lifetime.not_after` (check 11).
+    pub leaf_lifetime_not_after: u64,
+    /// The `KeyPackage`'s `init_key` (checks 7–8) — the Add-specific payload
+    /// the [`AttestationTrigger::Add`] variant carries. `verify_add_attestation`
+    /// constructs that variant from this field internally.
+    pub kp_init_key: &'a [u8; 32],
+}
+
+/// A typed reason [`verify_add_attestation`] rejected a
 /// [`KeyPackageAttestation`] on the runtime (native, `DidResolver`-backed)
 /// path — §9.7.1 checks 1–13, plus the resolution-failure policy.
 ///
@@ -92,24 +140,35 @@ pub enum AttestationRuntimeVerifyError {
     Verify(#[from] AttestationResolutionVerifyError),
 }
 
-/// Verifies a leaf's [`KeyPackageAttestation`] against the signer's
-/// **freshly-resolved current** DID document — §9.7.1 verifier checks 1–13
-/// (CRYPTO-22 S4, Layer B).
+/// Verifies an **Add**-path leaf's [`KeyPackageAttestation`] against the
+/// signer's **freshly-resolved current** DID document — §9.7.1 verifier checks
+/// 1–13 (CRYPTO-22 S4, Layer B).
 ///
 /// Resolves the signer DID (`ground_truth.credential.did`) through the injected
 /// canonical `resolver`, stamps `resolved_at` from the injected `clock` at the
-/// resolve call, and delegates to the pure Layer-A seam
+/// resolve call, constructs the Add trigger from `ground_truth.kp_init_key`
+/// internally, and delegates to the pure Layer-A seam
 /// [`verify_attestation_with_resolution`], which enforces check 2 (freshness),
 /// check 1 (current key), then checks 3–13.
 ///
+/// # Add-only by construction — Update is unrepresentable here
+///
+/// This seam accepts only [`AttestationAddGroundTruth`], which carries no
+/// `trigger` field, so it can verify **only** the fail-closed Add path. The
+/// already-admitted-member **Update** async path — which §9.7.1 grants a
+/// bounded *last-known-good grace* on a transient resolution outage — is
+/// deferred to **S7** and is intentionally **uncallable here by
+/// construction** (not merely undocumented): routing Update through a
+/// fail-closed-only seam would let a transient resolver outage hard-reject a
+/// legitimate member's Update (a censorship/liveness regression). See
+/// [`AttestationAddGroundTruth`]. The pure Layer-A
+/// [`verify_attestation_with_resolution`] stays trigger-general (it does no
+/// resolution, so its Update path is complete).
+///
 /// # Resolution failure policy (§9.7.1)
 ///
-/// On an [`Add`](scp_mls::AttestationTrigger::Add), a resolution `Err` or
-/// `Ok(None)` is **fail-closed** — a typed reject with NO fallback to a
-/// stale/pre-rotation cached document. The `ground_truth.trigger` selects the
-/// Add-only `init_key` checks (7–8) inside Layer A. (The Update last-known-good
-/// grace branch is the deferred SCP-CRYPTO22-005 / S7 follow-on; until it
-/// lands, an Update whose resolution fails also fails closed here.)
+/// A resolution `Err` or `Ok(None)` is **fail-closed** — a typed reject with NO
+/// fallback to a stale/pre-rotation cached document (the strict Add policy).
 ///
 /// # Honest `resolved_at` (§9.7.1 check 2; §9.14)
 ///
@@ -129,11 +188,11 @@ pub enum AttestationRuntimeVerifyError {
 ///
 /// Returns [`AttestationRuntimeVerifyError`] on a resolution failure
 /// (fail-closed) or on any Layer-A/pure-core check failure.
-pub async fn verify_add_or_update_attestation<R: DidResolver + ?Sized>(
+pub async fn verify_add_attestation<R: DidResolver + ?Sized>(
     resolver: &R,
     clock: &dyn Clock,
     attestation: &KeyPackageAttestation,
-    ground_truth: &AttestationLeafGroundTruth<'_>,
+    ground_truth: &AttestationAddGroundTruth<'_>,
 ) -> Result<(), AttestationRuntimeVerifyError> {
     // The signer DID is the attested DID, which check 9 binds to the leaf
     // credential's `did`; resolving the credential DID is therefore resolving
@@ -158,10 +217,8 @@ pub async fn verify_add_or_update_attestation<R: DidResolver + ?Sized>(
     let resolved_at = clock.now_secs();
     let resolved_document = match resolver.resolve(signer_did).await {
         Ok(Some(found)) => found.document,
-        // §9.7.1 "Resolution failure policy" — fail-closed. On Add there is NO
-        // fallback to a stale/pre-rotation cached document. (Update's
-        // last-known-good grace is the deferred SCP-CRYPTO22-005 / S7 follow-on;
-        // failing closed here in the meantime is the conservative default.)
+        // §9.7.1 "Resolution failure policy" — Add is fail-closed. There is NO
+        // fallback to a stale/pre-rotation cached document.
         Ok(None) => return Err(AttestationRuntimeVerifyError::ResolutionNotFound),
         Err(source) => return Err(AttestationRuntimeVerifyError::Resolution(source)),
     };
@@ -169,10 +226,25 @@ pub async fn verify_add_or_update_attestation<R: DidResolver + ?Sized>(
     // `now` for the §9.7.1 check-13 freshness/expiry band and the check-2 age.
     let now = clock.now_secs();
 
+    // Assemble the trigger-general Layer-A ground truth with the Add trigger
+    // built INTERNALLY from `kp_init_key` — the caller never supplies a trigger,
+    // so Update cannot be requested at this seam.
+    let leaf_ground_truth = AttestationLeafGroundTruth {
+        credential: ground_truth.credential,
+        leaf_signature_key: ground_truth.leaf_signature_key,
+        leaf_encryption_key: ground_truth.leaf_encryption_key,
+        leaf_wrapping_key: ground_truth.leaf_wrapping_key,
+        leaf_lifetime_not_before: ground_truth.leaf_lifetime_not_before,
+        leaf_lifetime_not_after: ground_truth.leaf_lifetime_not_after,
+        trigger: AttestationTrigger::Add {
+            kp_init_key: ground_truth.kp_init_key,
+        },
+    };
+
     // Delegate to the pure, wasm-safe Layer-A seam (checks 2, 1, then 3–13).
     verify_attestation_with_resolution(
         attestation,
-        ground_truth,
+        &leaf_ground_truth,
         &resolved_document,
         resolved_at,
         now,
@@ -189,9 +261,10 @@ mod tests {
     use scp_clock::Clock;
     use scp_did::{DidDocument, SigningKeyId};
     use scp_identity::resolver::{ResolutionSource, ResolvedDidDocument};
-    use scp_mls::{AttestationTrigger, ScpCredential};
+    use scp_mls::ScpCredential;
+    use scp_mls::keypackage_attestation::AttestationVerifyError;
     use std::future::Future;
-    use std::sync::atomic::{AtomicBool, Ordering};
+    use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 
     const ISSUED: u64 = 1_700_000_000;
     const EXPIRES: u64 = 1_700_086_400;
@@ -208,6 +281,41 @@ mod tests {
         }
         fn now_millis(&self) -> u64 {
             self.0.saturating_mul(1000)
+        }
+    }
+
+    /// A clock that returns a DIFFERENT value on each successive `now_secs()`
+    /// read, so a test can prove WHICH read `resolved_at` is captured at. Layer B
+    /// reads `now_secs()` exactly twice — first for `resolved_at` (before the
+    /// resolve call), then for `now` (after it) — so `[t0, t1]` scripts those two
+    /// reads precisely. Reads past the end saturate on the last value.
+    struct SteppingClock {
+        values: Vec<u64>,
+        idx: AtomicUsize,
+    }
+    impl SteppingClock {
+        fn new(values: Vec<u64>) -> Self {
+            Self {
+                values,
+                idx: AtomicUsize::new(0),
+            }
+        }
+    }
+    impl Clock for SteppingClock {
+        fn now_secs(&self) -> u64 {
+            let i = self.idx.fetch_add(1, Ordering::SeqCst);
+            *self
+                .values
+                .get(i)
+                .unwrap_or_else(|| self.values.last().expect("SteppingClock has ≥1 value"))
+        }
+        fn now_millis(&self) -> u64 {
+            // Not read by Layer B; do not advance the step index.
+            self.values
+                .last()
+                .copied()
+                .unwrap_or(0)
+                .saturating_mul(1000)
         }
     }
 
@@ -285,17 +393,15 @@ mod tests {
     }
 
     impl Fx {
-        fn ground_truth(&self) -> AttestationLeafGroundTruth<'_> {
-            AttestationLeafGroundTruth {
+        fn ground_truth(&self) -> AttestationAddGroundTruth<'_> {
+            AttestationAddGroundTruth {
                 credential: &self.credential,
                 leaf_signature_key: &self.leaf_sig,
                 leaf_encryption_key: &self.leaf_enc,
                 leaf_wrapping_key: &self.leaf_wrap,
                 leaf_lifetime_not_before: ISSUED,
                 leaf_lifetime_not_after: EXPIRES,
-                trigger: AttestationTrigger::Add {
-                    kp_init_key: &self.kp_init,
-                },
+                kp_init_key: &self.kp_init,
             }
         }
     }
@@ -346,33 +452,73 @@ mod tests {
         let resolver = MockResolver::new(MockOutcome::Found(did_doc_with_active(&fx.signer_pub)));
         let clock = FixedClock(NOW);
 
-        let result =
-            verify_add_or_update_attestation(&resolver, &clock, &fx.att, &fx.ground_truth()).await;
+        let result = verify_add_attestation(&resolver, &clock, &fx.att, &fx.ground_truth()).await;
 
         assert!(result.is_ok(), "expected Ok, got {result:?}");
         assert!(resolver.was_called(), "a did:dht: signer MUST be resolved");
     }
 
     #[tokio::test]
-    async fn honest_resolved_at_is_clock_derived_not_fabricated() {
-        // AC7: `resolved_at` is the clock time at the resolve() call. The clock
-        // returns the realistic Unix time NOW (~1.7e9). Layer A computes
-        // `age = now - resolved_at`; with an HONEST clock-derived `resolved_at`
-        // (== NOW), age == 0 ≤ 300 and verification succeeds. A FABRICATED
-        // `resolved_at` (e.g. hardcoded 0) would make age == NOW (~1.7e9) ≫ 300,
-        // tripping ResolvedDocumentStale. The Ok result therefore proves
-        // `resolved_at` is clock-derived and within skew of `now`.
+    async fn resolved_at_is_captured_at_the_earlier_resolve_read_not_the_later() {
+        // AC7 (strengthened): prove `resolved_at` is the FIRST clock read (at the
+        // resolve call), not the second (`now`). A two-value clock returns
+        // `t0 = NOW` for the resolved_at read and `t1 = NOW + 400` for the `now`
+        // read. Layer A then sees `age = now - resolved_at = 400 > 300` and MUST
+        // reject with ResolvedDocumentStale{age_secs: 400}. This is impossible if
+        // resolved_at were the later read (age 0), a fabricated constant, or equal
+        // to `now` — so it uniquely pins resolved_at = the earlier resolve-time
+        // read and `now` = the later read. (The everything-fresh Ok case is
+        // covered by `resolve_success_fresh_current_key_ok`.)
         let fx = add_fixture(TEST_DID);
         let resolver = MockResolver::new(MockOutcome::Found(did_doc_with_active(&fx.signer_pub)));
-        let clock = FixedClock(NOW);
+        let clock = SteppingClock::new(vec![NOW, NOW + 400]);
 
-        let result =
-            verify_add_or_update_attestation(&resolver, &clock, &fx.att, &fx.ground_truth()).await;
+        let err = verify_add_attestation(&resolver, &clock, &fx.att, &fx.ground_truth())
+            .await
+            .unwrap_err();
 
         assert!(
-            result.is_ok(),
-            "a clock-derived resolved_at within skew of now must pass check 2; got {result:?}"
+            matches!(
+                err,
+                AttestationRuntimeVerifyError::Verify(
+                    AttestationResolutionVerifyError::ResolvedDocumentStale { age_secs: 400 }
+                )
+            ),
+            "resolved_at must be the earlier (resolve-time) read; expected stale age 400, got {err:?}"
         );
+        assert!(resolver.was_called());
+    }
+
+    // -- Layer-B rotation reject: the RESOLVED doc drives check 3 ---------------
+
+    #[tokio::test]
+    async fn resolved_rotated_key_drives_check3_signature_invalid() {
+        // The injected resolver returns a document whose #active VM holds a
+        // DIFFERENT key than the attestation's signer (a rotated / wrong current
+        // key). Check 1 passes (an #active VM exists), but the delegated pure
+        // core's check 3 fails: the signature does not verify against the
+        // RESOLVED current key. This proves the resolved document — not some
+        // ignored default — drives check 3 at the runtime layer (§9.12
+        // rotation-is-revocation).
+        let fx = add_fixture(TEST_DID);
+        let rotated_doc = did_doc_with_active(&fresh_pub()); // NOT fx.signer_pub
+        let resolver = MockResolver::new(MockOutcome::Found(rotated_doc));
+        let clock = FixedClock(NOW);
+
+        let err = verify_add_attestation(&resolver, &clock, &fx.att, &fx.ground_truth())
+            .await
+            .unwrap_err();
+
+        assert!(
+            matches!(
+                err,
+                AttestationRuntimeVerifyError::Verify(AttestationResolutionVerifyError::Delegated(
+                    AttestationVerifyError::SignatureInvalid
+                ))
+            ),
+            "the resolved (rotated) key must drive check 3 → SignatureInvalid, got {err:?}"
+        );
+        assert!(resolver.was_called());
     }
 
     // -- AC6: Add fail-closed on resolution failure (Err / None), no fallback ---
@@ -383,7 +529,7 @@ mod tests {
         let resolver = MockResolver::new(MockOutcome::Error);
         let clock = FixedClock(NOW);
 
-        let err = verify_add_or_update_attestation(&resolver, &clock, &fx.att, &fx.ground_truth())
+        let err = verify_add_attestation(&resolver, &clock, &fx.att, &fx.ground_truth())
             .await
             .unwrap_err();
 
@@ -400,7 +546,7 @@ mod tests {
         let resolver = MockResolver::new(MockOutcome::NotFound);
         let clock = FixedClock(NOW);
 
-        let err = verify_add_or_update_attestation(&resolver, &clock, &fx.att, &fx.ground_truth())
+        let err = verify_add_attestation(&resolver, &clock, &fx.att, &fx.ground_truth())
             .await
             .unwrap_err();
 
@@ -422,8 +568,7 @@ mod tests {
         let resolver = MockResolver::new(MockOutcome::Error);
         let clock = FixedClock(NOW);
 
-        let result =
-            verify_add_or_update_attestation(&resolver, &clock, &fx.att, &fx.ground_truth()).await;
+        let result = verify_add_attestation(&resolver, &clock, &fx.att, &fx.ground_truth()).await;
 
         assert!(result.is_ok(), "did:test: signer must skip resolution");
         assert!(
@@ -438,8 +583,7 @@ mod tests {
         let resolver = MockResolver::new(MockOutcome::Error);
         let clock = FixedClock(NOW);
 
-        let result =
-            verify_add_or_update_attestation(&resolver, &clock, &fx.att, &fx.ground_truth()).await;
+        let result = verify_add_attestation(&resolver, &clock, &fx.att, &fx.ground_truth()).await;
 
         assert!(result.is_ok(), "did:key: signer must skip resolution");
         assert!(!resolver.was_called());
@@ -454,7 +598,7 @@ mod tests {
         let resolver = MockResolver::new(MockOutcome::Error);
         let clock = FixedClock(NOW);
 
-        let err = verify_add_or_update_attestation(&resolver, &clock, &fx.att, &fx.ground_truth())
+        let err = verify_add_attestation(&resolver, &clock, &fx.att, &fx.ground_truth())
             .await
             .unwrap_err();
 

--- a/crates/scp-runtime/src/crypto/mls/mod.rs
+++ b/crates/scp-runtime/src/crypto/mls/mod.rs
@@ -25,6 +25,13 @@
 #[cfg(test)]
 mod wrapping_extension_runtime_tests;
 
+// Async, native `DidResolver`-backed KeyPackage-attestation verification —
+// §9.7.1 verifier checks 1–2 (CRYPTO-22 S4, Layer B). The pure, wasm-safe
+// checks-1–2 seam lives in `scp_mls::verify_attestation_with_resolution`
+// (Layer A); this module resolves the signer DID and supplies the resolved
+// document + honest clock-stamped `resolved_at`.
+pub mod attestation_verification;
+
 // Async durable-storage bridge — stays in scp-runtime (tokio-coupled, node-only).
 pub mod backend;
 pub mod production_backend;


### PR DESCRIPTION
## What

Implements **CRYPTO-22 Slice S4** (`SCP-CRYPTO22-004`): the verifier-side "resolve DID document + current-key" seam — §9.7.1 caller-deferred **checks 1–2** that the merged S2 pure core (`verify_attestation`, checks 3–13) defers to the runtime. CRYPTO-22 (#2187) replaces MLS `leaf==DID` with an ephemeral leaf + a `#active`/`#agent`-signed KeyPackage attestation; this is the verifier half.

Two-layer seam (ADR-057 wasm fence forces the split):
- **Layer A** (`scp-mls`, pure, wasm-safe): `verify_attestation_with_resolution` — given an already-resolved `DidDocument` + `resolved_at` + `now`, enforces check 2 (freshness ≤300s) then check 1 (extract current VM by `signing_key_id`, reject rotated-away/`#retired-*`) then delegates unchanged to `verify_attestation`.
- **Layer B** (`scp-runtime`, async): `verify_add_attestation` — resolves the signer DID via the injected canonical `DidResolver`, Add fail-closed on resolution failure, stamps `resolved_at` from the injected clock, `did:test:`/`did:key:` positive-whitelist testing carve-out (cfg-gated, provably absent from shipped artifacts). **Add-only by construction**: it takes a trigger-less `AttestationAddGroundTruth` and builds `AttestationTrigger::Add` internally, so `Update` is *unrepresentable* at the async seam (the Update last-known-good grace is S7).

## Cross-layer exemption

`verify_add_attestation` is an internal verifier seam with no FFI export by design (live wiring is S6/S7). The cross-layer gate's supported exemption marker:

`[cross-layer: internal-crypto] verify_add_attestation`

## Scope & deferrals (all per the governing story)

- Adds **no** live wiring (no ContextManager/Supervisor/pipeline), **no** FFI export, **no** SDK wrapper — those are S6/S7.
- The `s6WiringRequirements` on `SCP-CRYPTO22-004` record the mechanical obligations for S6: gate Add-path wiring on **SCP-CRYPTO22-005** (resolver privacy-cache freshness — until then Layer B stamps `resolved_at`≈now for cache hits, so check-2 is vacuous in production; §12 rotation-is-revocation is only fully closed once 005 lands), mechanically assert a non-NoOp resolver, and structurally pin Add-trigger fidelity.
- S2 pure core (`verify_attestation`, `AttestationVerifyError`, §25.23 Vector-37 KATs) **byte-unchanged**.

Paired with the story-amendment PR (#2263, whitelists `lib.rs` in AC10 + records the Add-only decision + S6 requirements). Does not close #2187 (S4 is one slice).

## Tests / gates

17 tests (10 Layer-A + 7 Layer-B): 300/301 freshness boundary; check-1 absent/`#retired-*`→`CurrentKeyNotFound` vs rotated→`SignatureInvalid`; `#agent`-persona resolution + agent-absent; ordering; Add fail-closed (Err + Ok(None), no fallback); honest `resolved_at` (2-value `SteppingClock`); Layer-B rotation-reject; carve-out skip vs `did:web:`-not-exempt. `cargo fmt`, all-features all-targets clippy `-D warnings`, `scp-mls` (205) + `scp-runtime` (2217) green, wasm32 clippy on scp-mls clean, `check-shipped-feature-graph` G1 (carve-out absent from shipped artifacts), full `check-*.sh` set.

## Review

Reviewed to genuine double-zero on `e51741b6`: **Pass 1** (security, inquisitor, bug-catcher, completionist, test-quality — all clean) + **Pass 2** (cryptographer, black-hat "no bypass", api-design APPROVED, simplifier — all clean). The final commit adds one reviewer-requested additive `pub use` (`AttestationVerifyError` at the `scp-mls` crate root) — no logic change, gate-verified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
