### PR TITLE
fix(ffi): correct execute_recovery message/test residue from #2240 Part A (post-merge review)

### DIFF
--- a/bindings/kotlin/scp-kt/src/test/kotlin/works/limn/scp/bridge/IdentityAdvancedBridgeTest.kt
+++ b/bindings/kotlin/scp-kt/src/test/kotlin/works/limn/scp/bridge/IdentityAdvancedBridgeTest.kt
@@ -59,7 +59,11 @@ class StubIdentityAdvancedBindings : IdentityAdvancedBindings {
         """{"old_did":"did:dht:zOld","new_did":"did:dht:zNew","rotated_at":1700000000}"""
     var attestDeviceResult = "dGVzdC1hdHRlc3RhdGlvbg=="
     var verifyDeviceAttestationResult = true
-    var executeRecoveryResult = """{"key_rotation_completed":true}"""
+    // Neutral delegation fixture. The real recovery surface fails closed
+    // (#2240 Part A) and never returns a success payload — this value only
+    // exercises the wrapper's param-forwarding / pass-through plumbing, so it
+    // deliberately does NOT encode the removed `key_rotation_completed` shape.
+    var executeRecoveryResult = """{"status":"delegated"}"""
     var executeCustodyMigrationResult = """{"key_generated":true,"authorized":true}"""
 
     // Configurable errors
@@ -332,16 +336,22 @@ class IdentityAdvancedBridgeTest {
                 assertEquals("did:dht:z6MkTest", stubAdvanced.lastDid)
                 assertEquals("agent", stubAdvanced.lastTier)
                 assertEquals(listOf("ctx-1"), stubAdvanced.lastContextIds)
-                assertTrue(result.contains("key_rotation_completed"))
+                assertEquals("""{"status":"delegated"}""", result)
             }
 
         @Test
-        fun `executeRecovery propagates bridge error`() =
+        fun `executeRecovery propagates the fail-closed SCP-IDENT-1022 error`() =
             runTest(testDispatcher) {
-                stubAdvanced.executeRecoveryError = BridgeException("recovery failed", "SCP-IDENT-1030")
-                assertFailsWith<BridgeException> {
+                // #2240 Part A: the recovery surface fails closed with the typed
+                // SCP-IDENT-1022 "backend not configured" error on every bridge;
+                // assert the Kotlin wrapper propagates that exact code, not just
+                // that it throws.
+                stubAdvanced.executeRecoveryError =
+                    BridgeException("recovery backend not configured", "SCP-IDENT-1022")
+                val ex = assertFailsWith<BridgeException> {
                     advancedBridge.executeRecovery("did:dht:z6MkFail", "identity_key")
                 }
+                assertEquals("SCP-IDENT-1022", ex.code)
             }
     }
 

--- a/bindings/python/scp_sdk/scp.py
+++ b/bindings/python/scp_sdk/scp.py
@@ -811,11 +811,12 @@ class SCP:
         configured — provide a real backend via SDK layer") rather than
         fabricating a success. It never reports a recovery that did not happen.
 
-        :param did: The compromised DID. **Must be owned by this**
-            :class:`SCP` **instance** — created or loaded via
-            :meth:`identity_create` / :meth:`identity_load`. DIDs
-            absent from the instance's identity registry are rejected
-            with ``SCP-IDENT-1020``.
+        :param did: The compromised DID. **Must be registered on this**
+            :class:`SCP` **instance** — created here via
+            :meth:`identity_create` (or :meth:`identity_migrate`); a DID
+            that was only resolved via :meth:`identity_load` is not
+            registered for recovery. DIDs absent from the instance's
+            registry are rejected with ``SCP-IDENT-1020``.
         :param context_ids: Contexts to run the recovery protocol
             against. Accepted for signature symmetry with the wired
             backend (#2240 Part B); ignored on the current fail-closed

--- a/crates/scp-ffi/napi/src/scp.rs
+++ b/crates/scp-ffi/napi/src/scp.rs
@@ -1113,7 +1113,11 @@ impl Scp {
             return Err(NapiError::from(ScpNapiError::Identity {
                 message: format!(
                     "identity_execute_recovery: DID '{did}' is not owned by this SCP instance — \
-                     recovery is restricted to identities created or loaded via this SCP"
+                     recovery is restricted to identities registered on this instance (populated \
+                     only by identity_create* / migrate, never by identity_load, on every \
+                     binding). The ownership-registry keying mechanism differs across bindings \
+                     (UniFFI custody registry vs PyO3/NAPI identity registry) and is unified in \
+                     #2240 Part B."
                 ),
                 code: codes::IDENT_1020.to_owned(),
             }));

--- a/crates/scp-ffi/src/identity.rs
+++ b/crates/scp-ffi/src/identity.rs
@@ -2551,7 +2551,9 @@ impl crate::scp::PyScp {
 
         // Ownership gate (parity with the NAPI bridge's RED-PR5-003 check):
         // recovery is restricted to identities THIS SCP instance hosts in its
-        // identity registry (populated by `identity_create*` / `identity_load`).
+        // identity registry (populated by `identity_create*` / migrate, never by
+        // `identity_load`, which only reads the registry and fails
+        // `SCP-IDENT-1010` if the DID is absent).
         // A DID this instance does not own is rejected here — before any
         // recovery bookkeeping — so a realm-local caller cannot drive recovery
         // against arbitrary DIDs. `SCP-IDENT-1020` matches NAPI/UniFFI.
@@ -2559,7 +2561,11 @@ impl crate::scp::PyScp {
             return Err(PyErr::from(ScpPyError::identity_with_code(
                 format!(
                     "identity_execute_recovery: DID '{did}' is not owned by this SCP instance — \
-                     recovery is restricted to identities created or loaded via this SCP"
+                     recovery is restricted to identities registered on this instance (populated \
+                     only by identity_create* / migrate, never by identity_load, on every \
+                     binding). The ownership-registry keying mechanism differs across bindings \
+                     (UniFFI custody registry vs PyO3/NAPI identity registry) and is unified in \
+                     #2240 Part B."
                 ),
                 scp_ffi_common::error_codes::IDENT_1020,
             )));

--- a/crates/scp-ffi/uniffi/src/bridge.rs
+++ b/crates/scp-ffi/uniffi/src/bridge.rs
@@ -17482,7 +17482,11 @@ impl Scp {
             return Err(ScpError::Identity {
                 msg: format!(
                     "identity_execute_recovery: DID '{did}' is not owned by this SCP instance — \
-                     recovery is restricted to identities created or loaded via this SCP"
+                     recovery is restricted to identities registered on this instance (populated \
+                     only by identity_create* / migrate, never by identity_load, on every \
+                     binding). The ownership-registry keying mechanism differs across bindings \
+                     (UniFFI custody registry vs PyO3/NAPI identity registry) and is unified in \
+                     #2240 Part B."
                 ),
                 code: codes::IDENT_1020.to_owned(),
             });


### PR DESCRIPTION
## Summary

A **post-merge confirming review** of #2252 (the #2240 Part A recovery fail-closed change) surfaced shipped-code residues of the nullifier removal. All are **failure-path-only with no security impact** — recovery fails closed regardless — but they left the merged code inaccurate. This PR corrects them.

(Process note: #2252 was merged after only one clean full-verification pass; the second confirming pass — run post-merge — caught these. That gap is why this follow-up exists, and it was driven to a genuine double-zero this time.)

## Changes

1. **Ownership-rejection message overstated coverage.** It read *"recovery is restricted to identities created or loaded via this SCP"*, implying loaded identities are recoverable. They are **not**: on **every** binding the recovery ownership gate keys on a per-instance registry populated only by `identity_create*` / `migrate` — never by `identity_load` (UniFFI's custody registry ignores load; PyO3's `identity_load` only reads the registry, failing `SCP-IDENT-1010` if absent; NAPI's DHT-resolution fallback builds an unregistered external handle). So the recoverable set is **identical across all three bridges**. All three bridge messages are replaced with a single **uniform, accurate** text (recovery is restricted to identities registered on this instance, create/migrate only), and the registry-**keying-mechanism** difference (UniFFI custody registry vs PyO3/NAPI identity registry) is deferred to #2240 Part B. The adjacent PyO3 gate comment and the Python SDK docstring — which carried the same "or loaded via `identity_load`" overstatement — are swept to match, so **no "loaded is recoverable" claim survives in the recovery path**.

2. **Kotlin bridge test still encoded the removed nullifier shape.** The stub's `executeRecoveryResult` fixture hard-coded `{"key_rotation_completed":true}` — the exact fabricated payload this workstream deleted — and the propagation test asserted a placeholder `SCP-IDENT-1030`. Retired the fixture to a neutral value (delegation test now asserts exact pass-through) and upgraded the propagation test to assert the real fail-closed `SCP-IDENT-1022` via `ex.code`.

**Swift** `identityExecuteRecovery` is a zero-logic `try inner…` passthrough with no mock harness; its behavior is enforced + tested at the UniFFI Rust layer, so no Swift-specific test is added (established passthrough convention). This corrects the #2252 commit-message overclaim that assertions were *"inverted on every SDK"* — Kotlin is now genuinely inverted; Swift is passthrough-tested.

## Deferred to #2240 Part B (which owns the recovery WIRE + registry design)

- The `IDENT_1020`/`1022` error-code catalog doc staleness.
- The `IDENT_1020` overload (ownership-reject vs invalid-tier share the code).
- Whether to unify the ownership-registry keying (custody vs identity registry).
- The sibling **custody-migration** message's identical "or loaded" wording, which ships in **both** `crates/scp-ffi/napi/src/scp.rs:1233` and `bindings/python/scp_sdk/scp.py:778` (a separate function, `SCP-IDENT-1024`, same registry-keying class) — to be swept in the same Part B pass so they don't drift.

## Verification

- `cargo clippy --workspace --all-targets` (full CI features, `-D warnings`): 0
- `cargo fmt --all --check`: clean · `ruff check` + `ruff format`: clean
- Enforcement gates + `check-sdk-coverage.py`: 0
- `cargo nextest run --workspace` (full CI features, bounded): **10919 passed, 0 failed** (recovery suite 66/66; UniFFI `recovery_rejects_unowned_did` asserts the retained "is not owned" clause)
- Kotlin `:scp-kt:test` (IdentityAdvancedBridgeTest) + `:scp-kt:detekt` + ktlint: BUILD SUCCESSFUL
- **Genuine double-zero**: two consecutive all-zero full-roster review passes (adversarial-expert, bug-catcher, api-design-reviewer) on the final frozen commit.

Refs #2240 (Part A follow-up).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
