### PR TITLE
fix(runtime): bound the supervisor reply-await class via a shared helper + fail-closed hard-rate-limit on wedge

### DIFF
--- a/crates/scp-runtime/src/context/actor/handle.rs
+++ b/crates/scp-runtime/src/context/actor/handle.rs
@@ -74,6 +74,57 @@ pub const SEND_TIMEOUT: Duration = Duration::from_secs(30);
 pub const REPLY_TIMEOUT: Duration = Duration::from_mins(2);
 
 // ---------------------------------------------------------------------------
+// Bounded reply-await mechanics
+// ---------------------------------------------------------------------------
+
+/// Classifies why a bounded reply-await did not yield a handler reply.
+///
+/// The two variants let a caller that wants to distinguish the failure modes
+/// do so (e.g. log "wedged actor" vs "dropped reply channel"); callers that
+/// treat any non-reply uniformly match both with `Err(_)` and never inspect
+/// the value. See [`bounded_reply_await`].
+///
+/// Visibility is `pub(crate)` (not `pub(in crate::context)`) because the
+/// `?Send` recovery reply-await in `crate::identity::recovery` — a sibling of
+/// `crate::context`, not nested within it — routes through the same helper.
+#[derive(Debug)]
+pub(crate) enum BoundedReplyError {
+    /// The actor dropped the reply sender before answering (the underlying
+    /// [`oneshot`] channel closed) — typically a terminated/replaced actor.
+    Dropped,
+    /// The actor did not reply within [`REPLY_TIMEOUT`] — a wedged/deadlocked
+    /// actor whose reply sender is still alive (so the channel never closed).
+    Elapsed,
+}
+
+/// Bounds a reply-oneshot await by [`REPLY_TIMEOUT`] and classifies the
+/// outcome, so a wedged/deadlocked actor (whose reply sender is never dropped)
+/// cannot pin the caller forever.
+///
+/// This is **mechanics only**: it centralizes the
+/// `tokio::time::timeout(REPLY_TIMEOUT, rx).await` + outcome-classification
+/// step shared by every `Supervisor::dispatch_*` reply-await, but it does
+/// **not** unify the callers' dispositions. Each caller keeps its own handling
+/// of the [`BoundedReplyError`] inline — return a typed error, soft-default,
+/// discard, warn-and-continue — exactly as it did with a raw `rx.await`.
+///
+/// `T` is generic — it is the oneshot payload type, which the helper never
+/// inspects (the payload is typically the handler's own
+/// `Result<_, ContextError>`, riding through untouched on the `Ok` arm). The
+/// helper imposes no `Send` bound of its own, so it also works in the `?Send`
+/// recovery path (`identity::recovery`, ADR-049 Decision 7). Visibility is
+/// `pub(crate)` because that recovery path is a sibling of `crate::context`.
+pub(crate) async fn bounded_reply_await<T>(
+    rx: oneshot::Receiver<T>,
+) -> Result<T, BoundedReplyError> {
+    match tokio::time::timeout(REPLY_TIMEOUT, rx).await {
+        Ok(Ok(reply)) => Ok(reply),
+        Ok(Err(_dropped)) => Err(BoundedReplyError::Dropped),
+        Err(_elapsed) => Err(BoundedReplyError::Elapsed),
+    }
+}
+
+// ---------------------------------------------------------------------------
 // ContextActorHandle
 // ---------------------------------------------------------------------------
 
@@ -485,6 +536,63 @@ mod tests {
             elapsed >= REPLY_TIMEOUT,
             "reply-await must span the full REPLY_TIMEOUT budget before failing \
              closed (elapsed {elapsed:?} < {REPLY_TIMEOUT:?})"
+        );
+    }
+
+    /// [`bounded_reply_await`] must fail closed on a wedged actor: a reply
+    /// sender held alive but NEVER answered elapses to
+    /// [`BoundedReplyError::Elapsed`] after the full [`REPLY_TIMEOUT`] budget
+    /// (not before), rather than pinning the caller forever. `start_paused`
+    /// auto-advances virtual time so the test is deterministic and instant.
+    #[tokio::test(start_paused = true)]
+    async fn bounded_reply_await_elapses_when_actor_never_replies() {
+        // `_tx` stays bound so the sender is never dropped — the receiver
+        // therefore never sees a closed channel and can only elapse.
+        let (_tx, rx) = oneshot::channel::<Result<Option<usize>, ContextError>>();
+
+        let start = tokio::time::Instant::now();
+        let result = bounded_reply_await(rx).await;
+        let elapsed = start.elapsed();
+
+        assert!(
+            matches!(result, Err(BoundedReplyError::Elapsed)),
+            "a never-answered reply must classify as Elapsed, got {result:?}"
+        );
+        assert!(
+            elapsed >= REPLY_TIMEOUT,
+            "the await must span the full REPLY_TIMEOUT budget before failing \
+             closed (elapsed {elapsed:?} < {REPLY_TIMEOUT:?})"
+        );
+    }
+
+    /// A dropped reply sender (terminated/replaced actor) classifies as
+    /// [`BoundedReplyError::Dropped`] — distinct from the timeout path — and
+    /// returns promptly (no need to wait out [`REPLY_TIMEOUT`]).
+    #[tokio::test(start_paused = true)]
+    async fn bounded_reply_await_reports_dropped_when_sender_dropped() {
+        let (tx, rx) = oneshot::channel::<Result<Option<usize>, ContextError>>();
+        drop(tx);
+
+        let result = bounded_reply_await(rx).await;
+
+        assert!(
+            matches!(result, Err(BoundedReplyError::Dropped)),
+            "a dropped reply sender must classify as Dropped, got {result:?}"
+        );
+    }
+
+    /// A prompt handler reply passes through untouched on the `Ok` arm — the
+    /// helper is mechanics only and never inspects the payload.
+    #[tokio::test(start_paused = true)]
+    async fn bounded_reply_await_passes_prompt_reply_through() {
+        let (tx, rx) = oneshot::channel::<Result<Option<usize>, ContextError>>();
+        tx.send(Ok(Some(7))).expect("receiver is alive");
+
+        let result = bounded_reply_await(rx).await;
+
+        assert!(
+            matches!(result, Ok(Ok(Some(7)))),
+            "a prompt reply must pass through untouched, got {result:?}"
         );
     }
 

--- a/crates/scp-runtime/src/context/actor/mod.rs
+++ b/crates/scp-runtime/src/context/actor/mod.rs
@@ -52,6 +52,10 @@ pub use commands::{
 };
 pub use deps::ActorDeps;
 pub use handle::{ContextActorHandle, REPLY_TIMEOUT, SEND_TIMEOUT};
+// Bounded reply-await mechanics — `pub(crate)` so the supervisor reply-await
+// sites AND the `?Send` recovery path (`crate::identity::recovery`, a sibling
+// of `crate::context`) route through the single helper.
+pub(crate) use handle::{BoundedReplyError, bounded_reply_await};
 pub use outcome::Outcome;
 pub use sequence::{SendSequenceTracker, SequenceReservation};
 pub use state::{

--- a/crates/scp-runtime/src/context/supervisor/handle.rs
+++ b/crates/scp-runtime/src/context/supervisor/handle.rs
@@ -39,6 +39,7 @@ use scp_protocol::context::ContextError;
 use scp_protocol::context::builder::ReceiveFloor;
 use scp_protocol::crypto::sender_keys::MergePolicy;
 
+use crate::context::actor::{BoundedReplyError, bounded_reply_await};
 use crate::context::supervisor::floors::FloorAdvanceError;
 use crate::context::supervisor::identity_capability::OwnedIdentityDid;
 use crate::context::supervisor::key_package_actor::KeyPackageStoreHandle;
@@ -335,13 +336,13 @@ impl SupervisorHandle {
         // pin the caller forever. On elapse, fail-closed with the retryable
         // `ActorBusy` class; the existing dropped-channel `TransportFailed`
         // behavior is preserved exactly.
-        match tokio::time::timeout(crate::context::actor::REPLY_TIMEOUT, reply_rx).await {
-            Ok(reply) => reply.map_err(|_| {
-                ContextError::TransportFailed(
-                    "dispatch_recovery_send_notification: oneshot reply channel closed".to_owned(),
-                )
-            })?,
-            Err(_elapsed) => Err(ContextError::ActorBusy(format!(
+        match bounded_reply_await(reply_rx).await {
+            // Handler verdict rides through untouched.
+            Ok(reply) => reply,
+            Err(BoundedReplyError::Dropped) => Err(ContextError::TransportFailed(
+                "dispatch_recovery_send_notification: oneshot reply channel closed".to_owned(),
+            )),
+            Err(BoundedReplyError::Elapsed) => Err(ContextError::ActorBusy(format!(
                 "context actor did not reply within {} seconds",
                 crate::context::actor::REPLY_TIMEOUT.as_secs()
             ))),
@@ -655,10 +656,14 @@ impl SupervisorHandle {
         // would hang the caller forever. On elapse, fail-closed with a
         // retryable `ActorBusy` — the actor keeps running; we only drop our
         // own receiver.
-        match tokio::time::timeout(crate::context::actor::REPLY_TIMEOUT, reply_rx).await {
-            Ok(reply) => reply
-                .unwrap_or_else(|_| Err(ContextError::ContextNotRegistered(context_id.to_owned()))),
-            Err(_elapsed) => Err(ContextError::ActorBusy(format!(
+        match bounded_reply_await(reply_rx).await {
+            // Handler verdict rides through untouched.
+            Ok(reply) => reply,
+            // Dropped reply sender → stale handle: signal the caller to re-`lookup`.
+            Err(BoundedReplyError::Dropped) => {
+                Err(ContextError::ContextNotRegistered(context_id.to_owned()))
+            }
+            Err(BoundedReplyError::Elapsed) => Err(ContextError::ActorBusy(format!(
                 "context actor did not reply within {} seconds",
                 crate::context::actor::REPLY_TIMEOUT.as_secs()
             ))),
@@ -859,18 +864,18 @@ impl SupervisorHandle {
         // caller forever. On elapse (as on an install failure) we log and
         // move on; the actor's own `reconcile_timers` re-arms from the
         // recorded deadline regardless.
-        match tokio::time::timeout(crate::context::actor::REPLY_TIMEOUT, reply_rx).await {
-            Ok(Ok(Err(e))) => {
+        match bounded_reply_await(reply_rx).await {
+            Ok(Err(e)) => {
                 tracing::warn!(
                     context_id,
                     error = %e,
                     "dispatch_start_ttl_timer: actor reported TTL timer install failure"
                 );
             }
-            // Recv-ok + handler-ok, or the actor dropped the reply channel:
-            // nothing to do (matches the prior best-effort behavior).
-            Ok(_) => {}
-            Err(_elapsed) => {
+            // Handler confirmed install (Ok), or the actor dropped the reply
+            // channel: nothing to do (matches the prior best-effort behavior).
+            Ok(Ok(())) | Err(BoundedReplyError::Dropped) => {}
+            Err(BoundedReplyError::Elapsed) => {
                 tracing::warn!(
                     context_id,
                     "dispatch_start_ttl_timer: actor did not confirm TTL timer install \

--- a/crates/scp-runtime/src/context/supervisor/supervisor.rs
+++ b/crates/scp-runtime/src/context/supervisor/supervisor.rs
@@ -41,6 +41,7 @@ use scp_protocol::context::ContextError;
 use scp_protocol::context::governance::KeyResolver;
 use scp_protocol::context::membership::ContextEvent;
 
+use crate::context::actor::bounded_reply_await;
 use crate::context::actor::commands::{
     BroadcastCommand, ContextCommand, EconomyCommand, GovernanceCommand, LifecycleCommand,
     MessagingCommand, OutletsCommand, PrepareAOutcome, PrepareBOutcome, QueriesCommand, SagaReject,
@@ -3951,7 +3952,7 @@ impl Supervisor {
                     reply: reply_tx,
                 };
                 self.dispatch_trust_recovery_command(cmd).await?;
-                reply_rx.await.map_err(|_| {
+                bounded_reply_await(reply_rx).await.map_err(|_| {
                     ContextError::TransportFailed(
                         "recovery_notify_contact: oneshot reply channel closed".to_owned(),
                     )
@@ -4262,7 +4263,7 @@ impl Supervisor {
                     reply: reply_tx,
                 });
             Self::dispatch_via_mailbox(&actor, cmd).await?;
-            reply_rx.await.map_err(|_| {
+            bounded_reply_await(reply_rx).await.map_err(|_| {
                 ContextError::TransportFailed(
                     "recovery_send_notification_direct: mailbox reply channel closed".to_owned(),
                 )
@@ -5967,7 +5968,7 @@ impl Supervisor {
             reply: reserve_tx,
         };
         Self::dispatch_via_mailbox(&actor, ContextCommand::Broadcast(reserve_cmd)).await?;
-        let reservation = match reserve_rx.await {
+        let reservation = match bounded_reply_await(reserve_rx).await {
             Ok(Ok(outcome)) => outcome,
             Ok(Err(e)) => {
                 // Operation-level error already typed by the handler;
@@ -6012,7 +6013,7 @@ impl Supervisor {
             reply: apply_tx,
         };
         Self::dispatch_via_mailbox(&actor, ContextCommand::Broadcast(apply_cmd)).await?;
-        match apply_rx.await {
+        match bounded_reply_await(apply_rx).await {
             Ok(Ok(envelope)) => {
                 let _ = reply.send(Ok(envelope));
                 Ok(Outcome::ok_mutated(()))
@@ -6059,7 +6060,7 @@ impl Supervisor {
             .await
             .is_ok()
         {
-            let _ = rx.await;
+            let _ = bounded_reply_await(rx).await;
         }
     }
 
@@ -10360,7 +10361,7 @@ impl Supervisor {
         });
         let cmd = LifecycleCommand::RestoreContext { payload, reply: tx };
         self.dispatch_lifecycle_command(cmd).await?;
-        rx.await.map_err(|_| {
+        bounded_reply_await(rx).await.map_err(|_| {
             ContextError::TransportFailed(
                 "Supervisor::restore_context — actor reply channel closed".to_owned(),
             )
@@ -10408,7 +10409,7 @@ impl Supervisor {
             reply: tx,
         };
         self.dispatch_lifecycle_command(cmd).await?;
-        let (snapshot, event_log_data) = rx.await.map_err(|_| {
+        let (snapshot, event_log_data) = bounded_reply_await(rx).await.map_err(|_| {
             ContextError::TransportFailed(
                 "Supervisor::export_context — actor reply channel closed".to_owned(),
             )
@@ -10474,7 +10475,7 @@ impl Supervisor {
             reply: tx,
         };
         self.dispatch_lifecycle_command(cmd).await?;
-        rx.await.map_err(|_| {
+        bounded_reply_await(rx).await.map_err(|_| {
             ContextError::TransportFailed(
                 "Supervisor::import_context — actor reply channel closed".to_owned(),
             )
@@ -10623,7 +10624,7 @@ impl Supervisor {
         if Self::dispatch_via_mailbox(&actor, cmd).await.is_err() {
             return None;
         }
-        match rx.await {
+        match bounded_reply_await(rx).await {
             Ok(Ok(state)) => Some(state),
             Ok(Err(_)) | Err(_) => None,
         }
@@ -10966,7 +10967,7 @@ impl Supervisor {
         if self.dispatch_query(cmd).await.is_err() {
             return None;
         }
-        match rx.await {
+        match bounded_reply_await(rx).await {
             Ok(Ok(answer)) => answer,
             Ok(Err(_)) | Err(_) => None,
         }
@@ -10985,7 +10986,7 @@ impl Supervisor {
         if self.dispatch_query(cmd).await.is_err() {
             return false;
         }
-        match rx.await {
+        match bounded_reply_await(rx).await {
             Ok(Ok(answer)) => answer,
             Ok(Err(_)) | Err(_) => false,
         }
@@ -11019,7 +11020,7 @@ impl Supervisor {
             reply: tx,
         };
         self.dispatch_command(context_id, cmd).await?;
-        rx.await.map_err(|_| {
+        bounded_reply_await(rx).await.map_err(|_| {
             ContextError::TransportFailed(
                 "Supervisor::build_local_checkpoint — actor reply channel closed".to_owned(),
             )
@@ -11059,7 +11060,7 @@ impl Supervisor {
             reply: tx,
         };
         self.dispatch_command(context_id, cmd).await?;
-        rx.await.map_err(|_| {
+        bounded_reply_await(rx).await.map_err(|_| {
             ContextError::TransportFailed(
                 "Supervisor::send_heartbeat — actor reply channel closed".to_owned(),
             )
@@ -11093,7 +11094,7 @@ impl Supervisor {
             reply: tx,
         };
         self.dispatch_command(context_id, cmd).await?;
-        rx.await.map_err(|_| {
+        bounded_reply_await(rx).await.map_err(|_| {
             ContextError::TransportFailed(
                 "Supervisor::compare_remote_checkpoint — actor reply channel closed".to_owned(),
             )
@@ -11118,7 +11119,7 @@ impl Supervisor {
             reply: tx,
         };
         self.dispatch_lifecycle_command(cmd).await?;
-        rx.await.map_err(|_| {
+        bounded_reply_await(rx).await.map_err(|_| {
             ContextError::TransportFailed(
                 "Supervisor::clear_needs_reconnect — actor reply channel closed".to_owned(),
             )
@@ -11147,7 +11148,7 @@ impl Supervisor {
             reply: tx,
         };
         self.dispatch_lifecycle_command(cmd).await?;
-        rx.await.map_err(|_| {
+        bounded_reply_await(rx).await.map_err(|_| {
             ContextError::TransportFailed(
                 "Supervisor::issue_mls_update — actor reply channel closed".to_owned(),
             )
@@ -11190,7 +11191,7 @@ impl Supervisor {
             reply: tx,
         };
         self.dispatch_command(context_id, cmd).await?;
-        let outcome = rx.await.map_err(|_| {
+        let outcome = bounded_reply_await(rx).await.map_err(|_| {
             ContextError::TransportFailed(
                 "Supervisor::deliver_commit_blob — actor reply channel closed".to_owned(),
             )
@@ -11214,7 +11215,7 @@ impl Supervisor {
         if self.dispatch_query(cmd).await.is_err() {
             return None;
         }
-        match rx.await {
+        match bounded_reply_await(rx).await {
             Ok(Ok(answer)) => answer,
             Ok(Err(_)) | Err(_) => None,
         }
@@ -11233,7 +11234,7 @@ impl Supervisor {
         if self.dispatch_query(cmd).await.is_err() {
             return false;
         }
-        match rx.await {
+        match bounded_reply_await(rx).await {
             Ok(Ok(answer)) => answer,
             Ok(Err(_)) | Err(_) => false,
         }
@@ -11270,7 +11271,7 @@ impl Supervisor {
         if self.dispatch_query(cmd).await.is_err() {
             return false;
         }
-        match rx.await {
+        match bounded_reply_await(rx).await {
             Ok(Ok(answer)) => answer,
             Ok(Err(_)) | Err(_) => false,
         }
@@ -11289,7 +11290,7 @@ impl Supervisor {
         if self.dispatch_query(cmd).await.is_err() {
             return Vec::new();
         }
-        match rx.await {
+        match bounded_reply_await(rx).await {
             Ok(Ok(answer)) => answer,
             Ok(Err(_)) | Err(_) => Vec::new(),
         }
@@ -11318,7 +11319,7 @@ impl Supervisor {
         if self.dispatch_query(cmd).await.is_err() {
             return Vec::new();
         }
-        match rx.await {
+        match bounded_reply_await(rx).await {
             Ok(Ok(answer)) => answer,
             Ok(Err(_)) | Err(_) => Vec::new(),
         }
@@ -11342,7 +11343,7 @@ impl Supervisor {
         if self.dispatch_query(cmd).await.is_err() {
             return None;
         }
-        match rx.await {
+        match bounded_reply_await(rx).await {
             Ok(Ok(answer)) => answer,
             Ok(Err(_)) | Err(_) => None,
         }
@@ -11364,7 +11365,7 @@ impl Supervisor {
         if self.dispatch_query(cmd).await.is_err() {
             return None;
         }
-        match rx.await {
+        match bounded_reply_await(rx).await {
             Ok(Ok(answer)) => answer,
             Ok(Err(_)) | Err(_) => None,
         }
@@ -11386,7 +11387,7 @@ impl Supervisor {
         if self.dispatch_query(cmd).await.is_err() {
             return None;
         }
-        match rx.await {
+        match bounded_reply_await(rx).await {
             Ok(Ok(answer)) => answer,
             Ok(Err(_)) | Err(_) => None,
         }
@@ -11408,7 +11409,7 @@ impl Supervisor {
         if self.dispatch_command(context_id, cmd).await.is_err() {
             return Vec::new();
         }
-        match rx.await {
+        match bounded_reply_await(rx).await {
             Ok(Ok(events)) => events,
             Ok(Err(_)) | Err(_) => Vec::new(),
         }
@@ -11435,7 +11436,7 @@ impl Supervisor {
         if self.dispatch_command(context_id, cmd).await.is_err() {
             return Vec::new();
         }
-        match rx.await {
+        match bounded_reply_await(rx).await {
             Ok(Ok(events)) => events,
             Ok(Err(_)) | Err(_) => Vec::new(),
         }
@@ -11588,7 +11589,7 @@ impl Supervisor {
             reply: tx,
         };
         self.dispatch_query(cmd).await?;
-        rx.await.map_err(|_| {
+        bounded_reply_await(rx).await.map_err(|_| {
             ContextError::TransportFailed(
                 "Supervisor::get_broadcast_key_for_local_author — actor reply channel closed"
                     .to_owned(),
@@ -11632,7 +11633,7 @@ impl Supervisor {
         if self.dispatch_outlets_command(cmd).await.is_err() {
             return true;
         }
-        match reply_rx.await {
+        match bounded_reply_await(reply_rx).await {
             Ok(Ok(consumed)) => consumed,
             // Unknown context / channel dropped: legacy pass-through.
             Ok(Err(_)) | Err(_) => true,
@@ -11658,7 +11659,7 @@ impl Supervisor {
         if self.dispatch_outlets_command(cmd).await.is_err() {
             return;
         }
-        let _ = reply_rx.await;
+        let _ = bounded_reply_await(reply_rx).await;
     }
 
     /// Runtime-agnostic hard-rate-limit consumption used by FFI
@@ -11943,7 +11944,7 @@ impl Supervisor {
             reply: reply_tx,
         };
         self.dispatch_outlets_command(cmd).await?;
-        reply_rx.await.map_err(|_| {
+        bounded_reply_await(reply_rx).await.map_err(|_| {
             ContextError::TransportFailed(
                 "Supervisor::outlet_stream_reserve_grant — actor reply channel closed".to_owned(),
             )
@@ -11983,7 +11984,7 @@ impl Supervisor {
             reply: reply_tx,
         };
         self.dispatch_outlets_command(cmd).await?;
-        reply_rx.await.map_err(|_| {
+        bounded_reply_await(reply_rx).await.map_err(|_| {
             ContextError::TransportFailed(
                 "Supervisor::outlet_stream_reverse_grant — actor reply channel closed".to_owned(),
             )
@@ -12044,7 +12045,7 @@ impl Supervisor {
             reply: reply_tx,
         };
         self.dispatch_outlets_command(cmd).await?;
-        reply_rx.await.map_err(|_| {
+        bounded_reply_await(reply_rx).await.map_err(|_| {
             ContextError::TransportFailed(
                 "Supervisor::settle_outlet_economy_via_actor — actor reply channel closed"
                     .to_owned(),
@@ -12185,7 +12186,7 @@ impl Supervisor {
             reply: reply_tx,
         };
         self.dispatch_outlets_command(cmd).await?;
-        reply_rx.await.map_err(|_| {
+        bounded_reply_await(reply_rx).await.map_err(|_| {
             ContextError::TransportFailed(
                 "Supervisor::settle_outlet_stream_via_actor — actor reply channel closed"
                     .to_owned(),
@@ -12221,7 +12222,7 @@ impl Supervisor {
             reply: reply_tx,
         };
         self.dispatch_outlets_command(cmd).await?;
-        reply_rx.await.map_err(|_| {
+        bounded_reply_await(reply_rx).await.map_err(|_| {
             ContextError::TransportFailed(
                 "Supervisor::reconcile_stream_reservations_via_actor — actor reply channel closed"
                     .to_owned(),
@@ -12259,7 +12260,7 @@ impl Supervisor {
             reply: reply_tx,
         };
         self.dispatch_outlets_command(cmd).await?;
-        reply_rx.await.map_err(|_| {
+        bounded_reply_await(reply_rx).await.map_err(|_| {
             ContextError::TransportFailed(
                 "Supervisor::reverse_stream_escrow_via_actor — actor reply channel closed"
                     .to_owned(),
@@ -12862,7 +12863,7 @@ impl Supervisor {
                 )),
             );
         }
-        rx.await.unwrap_or_else(|_| {
+        bounded_reply_await(rx).await.unwrap_or_else(|_| {
             Err(
                 scp_protocol::context::builder::ContextCreationError::CreationFailed(
                     "Supervisor::create_context — actor reply channel closed".to_owned(),
@@ -14323,7 +14324,7 @@ impl Supervisor {
         });
         let cmd = LifecycleCommand::JoinContext { payload, reply: tx };
         self.dispatch_lifecycle_command(cmd).await?;
-        rx.await.map_err(|_| {
+        bounded_reply_await(rx).await.map_err(|_| {
             ContextError::TransportFailed(
                 "Supervisor::join_context — actor reply channel closed".to_owned(),
             )
@@ -14355,7 +14356,7 @@ impl Supervisor {
         });
         let cmd = LifecycleCommand::LeaveContext { payload, reply: tx };
         self.dispatch_lifecycle_command(cmd).await?;
-        rx.await.map_err(|_| {
+        bounded_reply_await(rx).await.map_err(|_| {
             ContextError::TransportFailed(
                 "Supervisor::leave_context — actor reply channel closed".to_owned(),
             )
@@ -14426,7 +14427,7 @@ impl Supervisor {
             reply: tx,
         };
         self.dispatch_command(handle.context_id(), cmd).await?;
-        rx.await.map_err(|_| {
+        bounded_reply_await(rx).await.map_err(|_| {
             ContextError::TransportFailed(
                 "Supervisor::send_message — actor reply channel closed".to_owned(),
             )
@@ -14462,7 +14463,7 @@ impl Supervisor {
             reply: tx,
         };
         self.dispatch_command(context_id, cmd).await?;
-        rx.await.map_err(|_| {
+        bounded_reply_await(rx).await.map_err(|_| {
             ContextError::TransportFailed(
                 "Supervisor::seed_peer_pseudonym — actor reply channel closed".to_owned(),
             )
@@ -14513,7 +14514,7 @@ impl Supervisor {
             reply: tx,
         };
         self.dispatch_command(context_id, cmd).await?;
-        rx.await.map_err(|_| {
+        bounded_reply_await(rx).await.map_err(|_| {
             ContextError::TransportFailed(
                 "Supervisor::test_install_access_key — actor reply channel closed".to_owned(),
             )
@@ -14553,7 +14554,7 @@ impl Supervisor {
             reply: tx,
         };
         self.dispatch_command(context_id, cmd).await?;
-        rx.await.map_err(|_| {
+        bounded_reply_await(rx).await.map_err(|_| {
             ContextError::TransportFailed(
                 "Supervisor::test_insert_member — actor reply channel closed".to_owned(),
             )
@@ -14594,7 +14595,7 @@ impl Supervisor {
             reply: tx,
         };
         self.dispatch_command(context_id, cmd).await?;
-        rx.await.map_err(|_| {
+        bounded_reply_await(rx).await.map_err(|_| {
             ContextError::TransportFailed(
                 "Supervisor::handle_sender_key_request — actor reply channel closed".to_owned(),
             )
@@ -14637,7 +14638,7 @@ impl Supervisor {
             reply: tx,
         };
         self.dispatch_command(context_id, cmd).await?;
-        rx.await.map_err(|_| {
+        bounded_reply_await(rx).await.map_err(|_| {
             ContextError::TransportFailed(
                 "Supervisor::land_sender_key_response — actor reply channel closed".to_owned(),
             )
@@ -14692,7 +14693,7 @@ impl Supervisor {
             reply: tx,
         };
         self.dispatch_command(context_id, cmd).await?;
-        rx.await.map_err(|_| {
+        bounded_reply_await(rx).await.map_err(|_| {
             ContextError::TransportFailed(
                 "Supervisor::inspect_incoming_inner — actor reply channel closed".to_owned(),
             )
@@ -14736,7 +14737,7 @@ impl Supervisor {
             reply: tx,
         };
         self.dispatch_command(context_id, cmd).await?;
-        rx.await.map_err(|_| {
+        bounded_reply_await(rx).await.map_err(|_| {
             ContextError::TransportFailed(
                 "Supervisor::test_grant_member_capability — actor reply channel closed".to_owned(),
             )
@@ -14806,7 +14807,7 @@ impl Supervisor {
             reply: tx,
         };
         self.dispatch_governance_command(cmd).await?;
-        rx.await.map_err(|_| {
+        bounded_reply_await(rx).await.map_err(|_| {
             ContextError::TransportFailed(
                 "Supervisor::list_proposals — actor reply channel closed".to_owned(),
             )
@@ -14831,7 +14832,7 @@ impl Supervisor {
             reply: tx,
         };
         self.dispatch_governance_command(cmd).await?;
-        rx.await.map_err(|_| {
+        bounded_reply_await(rx).await.map_err(|_| {
             ContextError::TransportFailed(
                 "Supervisor::get_proposal — actor reply channel closed".to_owned(),
             )
@@ -14881,7 +14882,7 @@ impl Supervisor {
         );
         let cmd = GovernanceCommand::ProposeGovernanceAction { payload, reply: tx };
         self.dispatch_governance_command(cmd).await?;
-        rx.await.map_err(|_| {
+        bounded_reply_await(rx).await.map_err(|_| {
             ContextError::TransportFailed(
                 "Supervisor::propose_governance_action — actor reply channel closed".to_owned(),
             )
@@ -14948,7 +14949,7 @@ impl Supervisor {
         );
         let cmd = GovernanceCommand::ProposeGovernanceActionChecked { payload, reply: tx };
         self.dispatch_governance_command(cmd).await?;
-        rx.await.map_err(|_| {
+        bounded_reply_await(rx).await.map_err(|_| {
             ContextError::TransportFailed(
                 "Supervisor::propose_governance_action_checked — actor reply channel closed"
                     .to_owned(),
@@ -14996,7 +14997,7 @@ impl Supervisor {
             reply: tx,
         };
         self.dispatch_governance_command(cmd).await?;
-        rx.await.map_err(|_| {
+        bounded_reply_await(rx).await.map_err(|_| {
             ContextError::TransportFailed(
                 "Supervisor::vote_on_proposal — actor reply channel closed".to_owned(),
             )
@@ -15022,7 +15023,7 @@ impl Supervisor {
             reply: tx,
         };
         self.dispatch_governance_command(cmd).await?;
-        rx.await.map_err(|_| {
+        bounded_reply_await(rx).await.map_err(|_| {
             ContextError::TransportFailed(
                 "Supervisor::withdraw_governance_vote — actor reply channel closed".to_owned(),
             )
@@ -15051,7 +15052,7 @@ impl Supervisor {
             reply: tx,
         };
         self.dispatch_query(cmd).await?;
-        rx.await.map_err(|_| {
+        bounded_reply_await(rx).await.map_err(|_| {
             ContextError::TransportFailed(
                 "Supervisor::local_pseudonym — actor reply channel closed".to_owned(),
             )
@@ -15075,7 +15076,7 @@ impl Supervisor {
         if self.dispatch_query(cmd).await.is_err() {
             return Vec::new();
         }
-        match rx.await {
+        match bounded_reply_await(rx).await {
             Ok(Ok(answer)) => answer,
             Ok(Err(_)) | Err(_) => Vec::new(),
         }
@@ -15097,7 +15098,7 @@ impl Supervisor {
         if self.dispatch_query(cmd).await.is_err() {
             return None;
         }
-        match rx.await {
+        match bounded_reply_await(rx).await {
             Ok(Ok(answer)) => answer,
             Ok(Err(_)) | Err(_) => None,
         }
@@ -15130,7 +15131,7 @@ impl Supervisor {
         if self.dispatch_command(context_id, cmd).await.is_err() {
             return;
         }
-        let _ = rx.await;
+        let _ = bounded_reply_await(rx).await;
     }
 
     // -----------------------------------------------------------------

--- a/crates/scp-runtime/src/context/supervisor/supervisor.rs
+++ b/crates/scp-runtime/src/context/supervisor/supervisor.rs
@@ -41,7 +41,6 @@ use scp_protocol::context::ContextError;
 use scp_protocol::context::governance::KeyResolver;
 use scp_protocol::context::membership::ContextEvent;
 
-use crate::context::actor::bounded_reply_await;
 use crate::context::actor::commands::{
     BroadcastCommand, ContextCommand, EconomyCommand, GovernanceCommand, LifecycleCommand,
     MessagingCommand, OutletsCommand, PrepareAOutcome, PrepareBOutcome, QueriesCommand, SagaReject,
@@ -50,6 +49,7 @@ use crate::context::actor::commands::{
 use crate::context::actor::handle::ContextActorHandle;
 use crate::context::actor::outcome::Outcome;
 use crate::context::actor::state::WrappingKeyPair;
+use crate::context::actor::{BoundedReplyError, bounded_reply_await};
 use crate::context::builder::{ContextEventLogProvider, ContextTransportProvider};
 use crate::context::outlets::stream::{OriginAdmissionTracker, StreamAdmissionTracker};
 use crate::context::persistence::ContextPersistence;
@@ -11606,13 +11606,26 @@ impl Supervisor {
     /// [`PerContextState`](crate::context::actor::state::PerContextState)
     /// hard-rate-limit bucket), and awaits the embedded reply oneshot.
     ///
-    /// Returns `true` if a token was consumed OR if the context is not
-    /// registered. The unknown-context pass-through (`true`) preserves the
-    /// legacy `try_consume_hard_rate_limit_from_any_context` contract: a
-    /// outlet invoked against a context with no live actor is not rate-
-    /// limited here (the absence of a bucket means "no per-context cap to
-    /// enforce"). Returns `false` only when the context IS registered AND
-    /// the sender is over budget.
+    /// Returns `true` (pass-through) when a token was consumed OR when there
+    /// is no live per-context bucket to enforce — the context is not
+    /// registered, the handler replied `Err`, or the actor DROPPED the reply
+    /// channel (terminated). This preserves the legacy
+    /// `try_consume_hard_rate_limit_from_any_context` contract: an outlet
+    /// invoked against a context with no live actor is not rate-limited here
+    /// (absence of a bucket means "no per-context cap to enforce").
+    ///
+    /// Returns `false` (deny) when the context IS registered AND EITHER the
+    /// sender is over budget OR the actor is ALIVE-but-wedged and does not
+    /// reply within [`REPLY_TIMEOUT`](crate::context::actor::REPLY_TIMEOUT).
+    /// The wedge case fails CLOSED on purpose: the bucket exists but is
+    /// momentarily unreachable, so folding the timeout into the `true`
+    /// pass-through would silently BYPASS the hard-rate cap for the whole
+    /// reply-timeout window — exploitable in a cross-context topology where
+    /// the caller-context actor is wedged but the target is healthy. Deny is
+    /// the safe default; the caller retries. The `Dropped` (terminated actor,
+    /// no live bucket) and `Elapsed` (wedged actor, unreachable bucket) cases
+    /// are therefore deliberately NOT folded together — see
+    /// [`hard_rate_limit_allow`].
     pub(crate) async fn try_consume_hard_rate_limit(
         &self,
         context_id: &str,
@@ -11633,11 +11646,11 @@ impl Supervisor {
         if self.dispatch_outlets_command(cmd).await.is_err() {
             return true;
         }
-        match bounded_reply_await(reply_rx).await {
-            Ok(Ok(consumed)) => consumed,
-            // Unknown context / channel dropped: legacy pass-through.
-            Ok(Err(_)) | Err(_) => true,
-        }
+        // Fail CLOSED on a wedge (Elapsed): the bucket exists but is
+        // unreachable, so denying is the safe default — never a silent
+        // bypass. Terminated/unregistered (Dropped / handler `Err`) stays
+        // pass-through: no live bucket to enforce. See `hard_rate_limit_allow`.
+        hard_rate_limit_allow(&bounded_reply_await(reply_rx).await)
     }
 
     /// Async hard-rate-limit refund routed through the per-context actor
@@ -11847,7 +11860,7 @@ impl Supervisor {
             reply: reply_tx,
         };
         self.dispatch_outlets_command(cmd).await?;
-        reply_rx
+        bounded_reply_await(reply_rx)
             .await
             .map_err(|_| {
                 ContextError::TransportFailed(
@@ -11895,7 +11908,7 @@ impl Supervisor {
             reply: reply_tx,
         };
         self.dispatch_outlets_command(cmd).await?;
-        reply_rx
+        bounded_reply_await(reply_rx)
             .await
             .map_err(|_| {
                 ContextError::TransportFailed(
@@ -15650,6 +15663,29 @@ fn current_timestamp_ms() -> u64 {
     ms
 }
 
+/// Maps a bounded hard-rate-limit reply into an allow (`true`) / deny
+/// (`false`) decision for [`Supervisor::try_consume_hard_rate_limit`].
+///
+/// SECURITY (fail-closed): the `Elapsed` arm — an ALIVE-but-wedged actor
+/// whose per-context bucket exists but is momentarily unreachable — MUST deny
+/// (`false`). Folding it into the `true` pass-through would silently bypass
+/// the hard-rate cap for the full [`REPLY_TIMEOUT`](crate::context::actor::REPLY_TIMEOUT)
+/// window (exploitable when the caller-context actor is wedged but the target
+/// is healthy). Only the "no live bucket to enforce" cases pass through:
+/// - `Ok(Ok(consumed))` — the handler's real verdict.
+/// - `Ok(Err(_))` — handler error (e.g. `ContextNotRegistered`): no bucket.
+/// - `Err(Dropped)` — the actor terminated (reply channel closed): no bucket.
+/// - `Err(Elapsed)` — the actor is alive but wedged: bucket unreachable → DENY.
+const fn hard_rate_limit_allow(
+    reply: &Result<Result<bool, ContextError>, BoundedReplyError>,
+) -> bool {
+    match reply {
+        Ok(Ok(consumed)) => *consumed,
+        Ok(Err(_)) | Err(BoundedReplyError::Dropped) => true,
+        Err(BoundedReplyError::Elapsed) => false,
+    }
+}
+
 // ---------------------------------------------------------------------------
 // No-op SagaJournal — plumbed into the FFI [`Self::with_providers`] factory
 // (and the test-only [`Self::for_query_shim`] constructor) when no production
@@ -15841,6 +15877,46 @@ mod tests {
     use super::*;
     use crate::context::supervisor::saga_journal::ProtocolRepositorySagaJournal;
     use scp_platform::in_memory::InMemoryStorage;
+
+    /// SECURITY regression guard for the hard-rate-limit fail-closed mapping
+    /// ([`hard_rate_limit_allow`]): an ALIVE-but-wedged actor (`Elapsed`) MUST
+    /// deny (`false`), never fold into the `true` pass-through — that fold
+    /// would bypass the per-context hard-rate cap for the reply-timeout window.
+    /// The "no live bucket to enforce" cases (handler `Err`, terminated actor
+    /// `Dropped`) stay pass-through (`true`); a real consume verdict rides
+    /// through unchanged. Directly unit-tests the classifier the live
+    /// actor-mailbox path routes through (wedging a fully-wired Supervisor is
+    /// impractical; the mechanics of producing `Elapsed` are covered by
+    /// `bounded_reply_await`'s own `start_paused` unit test).
+    #[test]
+    fn hard_rate_limit_wedged_actor_fails_closed() {
+        // Wedged/alive actor → deny.
+        assert!(
+            !hard_rate_limit_allow(&Err(BoundedReplyError::Elapsed)),
+            "an Elapsed (wedged actor, unreachable bucket) MUST deny — never bypass the cap"
+        );
+        // Terminated actor (no live bucket) → legacy pass-through.
+        assert!(
+            hard_rate_limit_allow(&Err(BoundedReplyError::Dropped)),
+            "a Dropped reply channel (terminated actor, no bucket) stays pass-through"
+        );
+        // Handler error (e.g. unregistered context, no bucket) → pass-through.
+        assert!(
+            hard_rate_limit_allow(&Ok(Err(ContextError::ContextNotRegistered(
+                "ctx".to_owned()
+            )))),
+            "a handler Err (no live bucket) stays pass-through"
+        );
+        // Real handler verdicts ride through unchanged.
+        assert!(
+            hard_rate_limit_allow(&Ok(Ok(true))),
+            "a real consume (token available) allows"
+        );
+        assert!(
+            !hard_rate_limit_allow(&Ok(Ok(false))),
+            "a real over-budget verdict denies"
+        );
+    }
 
     // -----------------------------------------------------------------
     // DurableProviders same-backend behavioral proof (spec §17.6 / §17.16 /

--- a/crates/scp-runtime/src/identity/recovery.rs
+++ b/crates/scp-runtime/src/identity/recovery.rs
@@ -846,11 +846,14 @@ impl ProductionRecoveryBackend {
         // oneshot. Propagate a dispatch-level error first (e.g. no
         // supervisor attached) before awaiting the reply.
         self.manager.dispatch_trust_recovery_command(cmd).await?;
-        reply_rx.await.map_err(|_| {
-            scp_protocol::context::ContextError::TransportFailed(
-                "trust-recovery reply channel closed before a result was sent".to_owned(),
-            )
-        })?
+        crate::context::actor::bounded_reply_await(reply_rx)
+            .await
+            .map_err(|_| {
+                scp_protocol::context::ContextError::TransportFailed(
+                    "trust-recovery reply channel closed or timed out before a result was sent"
+                        .to_owned(),
+                )
+            })?
     }
 
     /// Dispatches a `RecoverySendNotification` for a named context


### PR DESCRIPTION
## What

Extends the #129/#130 reply-await bounding to the **whole supervisor class**: routes every previously-**unbounded** reply-oneshot `.await` on the per-context-actor mailbox through a single mechanics-only helper, so an *alive-but-stuck* actor (infinite loop / never-completing future in a handler — which the Phase-2B watchdog does **not** catch, since it only reacts to task *termination*) can no longer pin the caller forever.

61 production sites migrated: `supervisor.rs` (59), `supervisor/handle.rs` (3, converged from #130's inline timeouts onto the shared idiom), `identity/recovery.rs` (1, consolidated so all trust-recovery replies funnel through one bounded chokepoint). The second-tier `handlers/saga.rs` (~36 awaits) is deliberately deferred to a follow-up pass — those are actor-*internal* / saga-coordinator / phase-timed futures, **not** the caller-awaits-mailbox hazard, and a 2-min bound would wrongly abort a healthy multi-phase saga.

## How

- **`bounded_reply_await<T>(rx) -> Result<T, BoundedReplyError{Dropped, Elapsed}>`** (`context/actor/handle.rs`, next to `REPLY_TIMEOUT`): mechanics-only — `timeout(REPLY_TIMEOUT, rx)` + classify. Generic `T` (never inspected), no `Send` bound (works in the `?Send` recovery path). It does **not** unify dispositions: every call site keeps its own handling of the `Result` inline. `pub(crate)` (the `recovery` module is a sibling of `context`).
- **Disposition preserved exactly** at each site (the sweep's key property: no site inspected the `RecvError` value, so `Dropped`+`Elapsed` fold into each site's existing "no reply" branch — `.map_err(|_| TypedErr)?`, soft-default `None`/`false`, `let _ =` discard, etc.). On a wedge these now return the site's fail-closed error / soft-default instead of hanging — strictly safer.
- **Security-relevant fix** (`try_consume_hard_rate_limit`): the *one* site whose prior disposition was fail-**open** (`Err(_) => true`). A mechanical swap would have folded a wedge into a **rate-limit bypass**. Instead a pure `const fn hard_rate_limit_allow` classifier distinguishes the enum: `Dropped`/unregistered → `true` (actor gone = no live per-context bucket to enforce = legacy pass-through) but **`Elapsed` → `false` (deny, fail-closed)** — a wedged-but-alive actor's bucket exists but is unreachable, so deny rather than bypass. Exhaustive match (a new variant won't compile), with a direct regression test.

## No source-text gate

Per `.docs/lessons/ast-gate-checks-definition-not-name-resolution.md`, a scanner for "is this `rx.await` bounded?" is unsound (needs type resolution) / non-convergent (denylist-by-name). The only *sound* mechanical guard is a `ReplyReceiver<T>` newtype (bounded-by-construction), which is flagged as a separate human decision and **not** built here. Convergence is by shared idiom + review.

## Tests / gates

3 `start_paused` helper unit tests (elapsed-after-full-budget / dropped-sender / passthrough) + the `hard_rate_limit_wedged_actor_fails_closed` classifier regression test (all 5 arms). `cargo fmt`; all-features all-targets clippy `-D warnings`; `cargo test -p scp-runtime` 2224 pass; the scp-runtime `check-*.sh` set. No `unwrap`/`expect`/`panic` added on a production path.

## Review

Genuine double-zero on the final commit: Round 1 (simplifier / test-quality / bug-catcher ship-it; completionist caught 2 missed reserve sites, inquisitor caught the fail-open rate-limit) → both folded → Round 2 + a security pass, **all six dimensions clean** (completionist COMPLETE, inquisitor resolved, bug-catcher, test-quality, simplifier, security-reviewer). Findings converged 2→0.

Follow-ups (noted, not in scope): the `saga.rs` second-tier triage; and an economy-fairness awareness note (a reserve that succeeds *just past* the 2-min bound orphans a self-held budget hold, reclaimed by existing `reconcile_stream_reservations`/settle-time reclaim — self-disadvantaging, no security impact).

Mirrors #129/#130. Does not close a GitHub issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
