### PR TITLE
docs(pre-rotation): stop asserting the in-memory nullifier is a shipped backend

### DIFF
--- a/crates/scp-ffi/src/custody.rs
+++ b/crates/scp-ffi/src/custody.rs
@@ -7,9 +7,11 @@
 //!
 //! # Variants
 //!
-//! - `InMemoryKeyCustody` — Test/development only. Keys exist only in memory
-//!   and are lost when the process exits. Available because `scp-ffi` enables
-//!   `scp-platform/testing`.
+//! - `InMemoryKeyCustody` — Test-harness nullifier. Keys exist only in memory
+//!   and are lost when the process exits. Compiled ONLY under `scp-ffi`'s own
+//!   `testing` feature, which is the sole place that forwards
+//!   `scp-platform/testing` (ADR-062 §Decision 6); the variant does not exist
+//!   in a shipped build.
 //! - [`FileKeyCustody`] — Encrypted-at-rest key storage using Argon2id +
 //!   AES-256-GCM. The default production custody for desktop/server platforms.
 //!
@@ -34,8 +36,9 @@ use scp_platform::traits::{
 /// delegates each method to the active variant.
 #[allow(clippy::large_enum_variant)]
 pub enum FfiKeyCustody {
-    /// Test/development in-memory custody. Keys are lost on process exit.
-    /// Available because `scp-ffi` enables `scp-platform/testing`.
+    /// Test-harness in-memory custody (nullifier). Keys are lost on process
+    /// exit. Compiled only under `scp-ffi`'s `testing` feature, the sole
+    /// place forwarding `scp-platform/testing` — absent from a shipped build.
     #[cfg(feature = "testing")]
     InMemory(InMemoryKeyCustody),
     /// Encrypted file-backed custody (Argon2id + AES-256-GCM).
@@ -600,9 +603,12 @@ impl KeyCustody for PyCallbackKeyCustody {
         //
         // Storage-isolation status: type-level isolation holds (the seed
         // never enters the operational provider); substrate isolation
-        // depends on the `PreRotationCustody` backend (currently in-memory).
-        // HSM-bound platforms should instead route platform-CSPRNG bytes
-        // directly into a `PreRotationCustody`, bypassing `KeyCustody`.
+        // depends on the `PreRotationCustody` backend, and no such backend
+        // ships — the only implementation is the `testing`-gated
+        // `InMemoryPreRotationCustody` nullifier, so a shipped build fails
+        // closed with `SCP-IDENT-1059` instead (#1729 / RFC #2130 track the
+        // real backends). HSM-bound platforms should route platform-CSPRNG
+        // bytes directly into a `PreRotationCustody`, bypassing `KeyCustody`.
         use rand::RngCore;
         let mut seed = zeroize::Zeroizing::new([0u8; 32]);
         rand::rngs::OsRng.fill_bytes(seed.as_mut());

--- a/crates/scp-ffi/uniffi/src/bridge.rs
+++ b/crates/scp-ffi/uniffi/src/bridge.rs
@@ -836,20 +836,29 @@ impl KeyCustody for CallbackKeyCustody {
         // # Storage isolation status (spec §9.7.4.1 §3)
         //
         // **Type-level isolation is satisfied** (the bytes never enter
-        // the operational `KeyCustody` provider). **Substrate isolation
-        // is NOT yet satisfied**: the bridge process and the
-        // currently-shipped `InMemoryPreRotationCustody` co-reside in
-        // the same Rust process memory as the operational
-        // `KeyHandle` ID space. A process-memory dump compromises
-        // both.
+        // the operational `KeyCustody` provider). **Substrate
+        // isolation would NOT be satisfied by an in-process
+        // `PreRotationCustody` backend**: such a backend co-resides in
+        // the same Rust process memory as this bridge and the
+        // operational `KeyHandle` ID space, so a single process-memory
+        // dump compromises both. That reasoning is why an in-process
+        // backend can never be the answer here.
+        //
+        // No `PreRotationCustody` backend ships at all today. The only
+        // implementation in the tree, `InMemoryPreRotationCustody`, is
+        // a test-harness nullifier in `scp-platform`'s
+        // `#[cfg(feature = "testing")]` `testing` module (ADR-062
+        // §Decision 6). On a shipped (no-`testing`) build the identity
+        // paths fail closed with `SCP-IDENT-1059` via
+        // `no_pre_rotation_backend` rather than substituting it, so the
+        // capability is honestly absent — not degraded.
         //
         // Full §9.7.4.1 §3 substrate isolation requires a non-in-memory
         // `PreRotationCustody` backend (FIDO2, passkey-PRF, Apple
         // Keychain entry under a separate access-control class,
         // Android Keystore alias with separate authentication flow,
-        // encrypted offline backup, Shamir, BIP39). Production
-        // backends are a separate workstream — see the
-        // `PreRotationCustodyKind::InMemory` doc-comment.
+        // encrypted offline backup, Shamir, BIP39). Those are tracked
+        // by #1729 / RFC #2130.
         //
         // For HSM-bound platforms where `OsRng` is not the appropriate
         // CSPRNG source, the SDK MUST instead generate pre-rotation

--- a/crates/scp-platform/src/traits.rs
+++ b/crates/scp-platform/src/traits.rs
@@ -613,13 +613,20 @@ pub enum PreRotationCustodyError {
 /// boundary.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 pub enum PreRotationCustodyKind {
-    /// Shipped-but-degraded default backend: in-process registry. Satisfies
-    /// the §9.7.4.1 §3 type-level isolation requirement (separate custody
-    /// object, distinct handle type) but does NOT satisfy the substrate
-    /// isolation requirement — the pre-rotation key co-resides in the same
-    /// process memory as operational keys. Used as the default in production
-    /// FFI/SDK paths until passkey-PRF / hardware-token / Shamir backends
-    /// are wired in as a follow-up workstream.
+    /// In-process registry. Satisfies the §9.7.4.1 §3 type-level isolation
+    /// requirement (separate custody object, distinct handle type) but does
+    /// NOT satisfy the substrate isolation requirement — the pre-rotation key
+    /// co-resides in the same process memory as operational keys.
+    ///
+    /// **Not reachable from a shipped build.** The only implementation that
+    /// reports this kind is `InMemoryPreRotationCustody`, which lives in this
+    /// crate's `#[cfg(feature = "testing")]` `testing` module (ADR-062
+    /// §Decision 6) — a test-harness nullifier, never compiled into a shipped
+    /// artifact. A production build therefore has *no* `PreRotationCustody`
+    /// backend at all: identity creation fails closed with
+    /// `IdentityError::NoPreRotationBackend`, surfaced across every bridge as
+    /// `SCP-IDENT-1059`. Real backends (passkey-PRF, hardware token, Shamir,
+    /// …) are tracked by #1729 / RFC #2130.
     InMemory,
     /// FIDO2/U2F hardware security key. Highest security per §9.7.4.1 §4.
     HardwareSecurityKey,
@@ -727,10 +734,21 @@ pub enum PreRotationCustodyKind {
 /// backup). Modeling UX inside the trait would force concrete
 /// flows that don't generalize.
 ///
-/// Today's shipped backend ([`InMemoryPreRotationCustody`](super::testing::InMemoryPreRotationCustody))
-/// is process-memory only — it satisfies the trait's type-level
-/// isolation but not §9.7.4.1 §3 substrate isolation. Production
-/// backends are a separate workstream.
+/// # No backend ships today
+///
+/// The only implementation of this trait in the tree is
+/// `InMemoryPreRotationCustody`, and it is test-harness-only — it
+/// lives in this crate's `#[cfg(feature = "testing")]` `testing`
+/// module (ADR-062 §Decision 6), so it is not compiled into a
+/// shipped artifact. It is also process-memory only, satisfying the
+/// trait's type-level isolation but not §9.7.4.1 §3 substrate
+/// isolation.
+///
+/// A shipped build consequently has no backend to select at all, and
+/// identity creation fails closed with
+/// `IdentityError::NoPreRotationBackend` (`SCP-IDENT-1059`) rather
+/// than substituting the nullifier. Production backends are tracked
+/// by #1729 / RFC #2130.
 ///
 /// # Concurrency
 ///


### PR DESCRIPTION
Five doc comments on `main` assert that a **security nullifier is the shipped production default**. That was true when written; ADR-062 made it false. A comment claiming a nullifier ships is worse than no comment — it is a false statement about a security property, in exactly the class the ADR-062 workstream existed to eliminate.

**Verified truth:** `InMemoryPreRotationCustody` lives under `pub mod testing`, gated `#[cfg(feature = "testing")]`. Production **fails closed** — `crates/scp-identity/src/config.rs:384` returns `Err(IdentityError::NoPreRotationBackend)`, surfaced as `SCP-IDENT-1059` across all three bridges. Stronger still: `PreRotationCustodyKind::InMemory` is returned by exactly one `custody_kind()` impl — the testing-gated one — so the variant is *provably* unreachable from a shipped build, not merely degraded.

Sites corrected:
- `crates/scp-platform/src/traits.rs` — "Shipped-but-degraded default backend … **used as the default in production FFI/SDK paths**"
- `crates/scp-platform/src/traits.rs` — "**Today's shipped backend** (`InMemoryPreRotationCustody`) is process-memory only"
- `crates/scp-ffi/uniffi/src/bridge.rs` — "the **currently-shipped** `InMemoryPreRotationCustody` co-reside…", which also forwarded readers to the stale text above
- `crates/scp-ffi/src/custody.rs` ×2 — "Available because `scp-ffi` enables `scp-platform/testing`" (that forward exists only inside the `testing` feature, never `default`/`server`) and "depends on the `PreRotationCustody` backend **(currently in-memory)**"

The substrate-isolation reasoning in the UniFFI comment is **kept and generalized** rather than deleted — the original argued a property of a specific shipped object that no longer ships; it now argues the property of *any* in-process backend, which is what the reasoning actually supports. Real backends remain tracked by #1729 / RFC #2130.

A repo-wide sweep for the same class (`shipped backend`, `currently-shipped`, `default in production`, `ships today`, …) checked 14 sites; the other 9 are legitimately true (`FileKeyCustody`, SQLite/SQLCipher, `SelfSignedTlsProvider`, `PkarrDhtClient`) and were left alone. One ambiguous site — `traits.rs:539` "Filed as a follow-up workstream" for the HSM seed path — was **not** touched, because no issue reference could be verified and inventing one would be the phantom-provenance failure this PR exists to correct.

**Comments only: 61 insertions / 28 deletions, zero non-comment lines changed.** No behaviour, feature, gate, allowlist, or baseline touched. G1 passes; all 26 gate scripts pass; CI clippy clean.