### PR TITLE
fix(ffi): seal start_node_in_memory behind production Node::start + write the ADR-052 seal test that was claimed but missing

### DIFF
--- a/crates/scp-ffi/common/Cargo.toml
+++ b/crates/scp-ffi/common/Cargo.toml
@@ -48,7 +48,14 @@ custody = ["dep:scp-platform"]
 # auto-generate path FAILS CLOSED (`ServerError::AutoGenerateUnavailable`) on a
 # shipped build instead of running a nullifier-backed node. No test-harness
 # platform edge is present, transitively or otherwise — G1 proves it.
-server = ["dep:scp-transport", "dep:scp-node", "dep:scp-platform", "scp-platform/in-memory-storage", "scp-platform/filesystem", "scp-platform/file", "dep:scp-identity", "dep:tokio", "dep:tokio-util", "dep:tracing", "dep:thiserror"]
+#
+# `scp-platform/encrypting` + `dep:rand` back the `EncryptingAdapter` wrap on
+# `start_node_in_memory`'s ephemeral store: the shipped in-memory front door
+# goes through the production `Node::start` (`EncryptedStorage`-bounded), not
+# `Node::start_for_testing` (spec §17.5). `encrypting` is already unconditional
+# on this crate's `scp-platform` edge; it is restated here so the `server`
+# feature is self-contained.
+server = ["dep:scp-transport", "dep:scp-node", "dep:scp-platform", "scp-platform/in-memory-storage", "scp-platform/filesystem", "scp-platform/file", "scp-platform/encrypting", "dep:scp-identity", "dep:rand", "dep:tokio", "dep:tokio-util", "dep:tracing", "dep:thiserror"]
 
 [dependencies]
 scp-core = { path = "../../scp-core", optional = true }

--- a/crates/scp-ffi/common/src/server.rs
+++ b/crates/scp-ffi/common/src/server.rs
@@ -18,6 +18,7 @@ use scp_did::DidDocument;
 use scp_identity::ScpIdentity;
 use scp_identity::dht::DidDht;
 use scp_node::{DhtMode, ExplicitIdentity, IdentitySource, Node, NodeConfig, NodeError, Reach};
+use scp_platform::encrypting_adapter::EncryptingAdapter;
 use scp_platform::file::FileKeyCustody;
 use scp_platform::in_memory::InMemoryStorage;
 
@@ -299,13 +300,31 @@ pub async fn start_relay_local(data_dir: &Path) -> Result<RunningRelay, ServerEr
 // ApplicationNode startup
 // ---------------------------------------------------------------------------
 
-/// Starts a full application node with in-memory storage.
+/// Ephemeral storage backend for [`start_node_in_memory`]: the durability-only
+/// [`InMemoryStorage`] wrapped in an [`EncryptingAdapter`] under a per-node
+/// `OsRng` AES-256-GCM key.
+///
+/// The wrap is what makes the ephemeral backend satisfy the sealed
+/// `EncryptedStorage` bound, so this shipped `server`-feature front door goes
+/// through the production [`Node::start`] constructor rather than
+/// `Node::start_for_testing`. This is the canonical spec §17.5 pattern, already
+/// used by
+/// [`build_event_log_provider`](crate::bridge_runtime::build_event_log_provider).
+pub type EncryptedInMemoryStorage = EncryptingAdapter<InMemoryStorage>;
+
+/// Starts a full application node with encrypted in-memory storage.
+///
+/// Storage is the ephemeral [`EncryptedInMemoryStorage`] — `InMemoryStorage`
+/// under a per-node `OsRng` AES-256-GCM [`EncryptingAdapter`] — so the node is
+/// built through the production [`Node::start`] constructor and its
+/// `EncryptedStorage` bound. Nothing on this path reaches
+/// `Node::start_for_testing`.
 ///
 /// When `identity` is `None` (auto-generate): available ONLY in a `testing`
-/// build via the test-harness `ApplicationNode::dev` (in-memory key custody,
-/// [`InMemoryStorage`](scp_platform::in_memory::InMemoryStorage), and the
-/// [`InMemoryDhtClient`](scp_dht::InMemoryDhtClient) nullifier — no real DHT
-/// network). A shipped (no-`testing`) build FAILS CLOSED with
+/// build via the test-harness `ApplicationNode::dev` (in-memory key custody and
+/// the [`InMemoryDhtClient`](scp_dht::InMemoryDhtClient) nullifier — no real DHT
+/// network; its storage is the same encrypted in-memory backend). A shipped
+/// (no-`testing`) build FAILS CLOSED with
 /// [`ServerError::AutoGenerateUnavailable`] rather than run a nullifier-backed
 /// node (ADR-062 §Decision 1/6); production callers pass an explicit
 /// `Some(NodeIdentity)`. Self-signed TLS (localhost); relay bound to
@@ -324,7 +343,7 @@ pub async fn start_relay_local(data_dir: &Path) -> Result<RunningRelay, ServerEr
 /// provisioning fails.
 pub async fn start_node_in_memory(
     identity: Option<NodeIdentity>,
-) -> Result<scp_node::ApplicationNode<InMemoryStorage>, ServerError> {
+) -> Result<scp_node::ApplicationNode<EncryptedInMemoryStorage>, ServerError> {
     let node = match identity {
         // Auto-generate uses the test-harness `ApplicationNode::dev` (in-memory
         // DHT nullifier), compiled only under `testing` (ADR-062 §Decision 1).
@@ -340,7 +359,16 @@ pub async fn start_node_in_memory(
             // reproduced by the default `TlsMode::SelfSigned`. `Domain` is a
             // publishing reach, so M2 requires `DhtMode::Production` (advisory
             // in P1 — the in-memory DHT client publishes nothing).
-            Node::start_for_testing(NodeConfig {
+            //
+            // Constructed via the PRODUCTION `Node::start` (spec §17.5: FFI
+            // bridges must not rely on the `allow_unencrypted_storage` escape
+            // hatch). The ephemeral `InMemoryStorage` is wrapped in
+            // `EncryptingAdapter` under a fresh `OsRng` AES-256-GCM key, which
+            // satisfies the sealed `EncryptedStorage` bound — the canonical
+            // §17.5 pattern already used by `build_event_log_provider`.
+            let mut storage_key = Zeroizing::new([0u8; 32]);
+            rand::RngCore::fill_bytes(&mut rand::rngs::OsRng, &mut *storage_key);
+            Node::start(NodeConfig {
                 bind_addr: Some(SocketAddr::from(([127, 0, 0, 1], 0))),
                 dht: DhtMode::Production,
                 ..NodeConfig::defaults(
@@ -358,7 +386,7 @@ pub async fn start_node_in_memory(
                             did_method: id.did_method,
                         },
                     )),
-                    InMemoryStorage::new(),
+                    EncryptingAdapter::new(InMemoryStorage::new(), storage_key),
                     // Explicit durability-only selection for this in-memory
                     // server front door (SCP-CAPINJECT-010): the blob backend is
                     // a required selection, never a runtime default.
@@ -548,14 +576,15 @@ pub async fn start_node_local(
 ///
 /// `ApplicationNode<S>` is generic over `S: Storage`. The `Storage` trait uses
 /// RPITIT and is not object-safe, so we cannot use `dyn Storage`. Instead we
-/// use a closed enum over `InMemoryStorage` and `FilesystemStorage`.
+/// use a closed enum over [`EncryptedInMemoryStorage`] and `FilesystemStorage`.
 ///
 /// This mirrors the pattern established by [`RunningRelay`] — shared in
 /// `scp-ffi-common` so each FFI bridge wraps this rather than duplicating the
 /// enum and its dispatch methods.
 pub enum RunningNode {
-    /// In-memory storage variant (ephemeral — suitable for tests/demos).
-    InMemory(scp_node::ApplicationNode<InMemoryStorage>),
+    /// Encrypted in-memory storage variant (ephemeral — suitable for
+    /// tests/demos). See [`EncryptedInMemoryStorage`].
+    InMemory(scp_node::ApplicationNode<EncryptedInMemoryStorage>),
     /// Filesystem-backed storage variant (persistent — suitable for local dev).
     Filesystem(scp_node::ApplicationNode<scp_platform::filesystem::FilesystemStorage>),
 }

--- a/crates/scp-node/Cargo.toml
+++ b/crates/scp-node/Cargo.toml
@@ -89,7 +89,12 @@ scp-relay-client = { path = "../scp-relay-client" }
 tokio = { workspace = true, features = ["macros", "rt-multi-thread", "test-util"] }
 tokio-tungstenite = { version = "0.24", features = ["connect"] }
 scp-core = { path = "../scp-core", features = ["allow_unencrypted_storage"] }
-scp-platform = { path = "../scp-platform", features = ["testing"] }
+# `filesystem` backs the ADR-052 §AC-9 `EncryptedStorage` seal assertions:
+# `FilesystemStorage` is the plaintext backend that `Node::start`'s
+# `compile_fail,E0277` doctest proves cannot reach the production constructor,
+# and whose `EncryptingAdapter`-wrapped form is the positive control in
+# `tests/encrypted_storage_seal.rs`.
+scp-platform = { path = "../scp-platform", features = ["testing", "filesystem"] }
 # The node's tests (config.rs, lib.rs, self_host.rs) and `ApplicationNode::dev`
 # construct `InMemoryDhtClient` (now gated behind `scp-dht/testing`); activate it
 # for this crate's own test build. `production-dht` still comes from the normal

--- a/crates/scp-node/src/config.rs
+++ b/crates/scp-node/src/config.rs
@@ -1260,9 +1260,46 @@ impl Node {
     /// Constructs and starts an [`ApplicationNode`] from a [`NodeConfig`]
     /// without requiring encrypted storage.
     ///
-    /// **Testing only.** Production code must use [`Node::start`]. Feature-gated
-    /// so it cannot be reached in a release build (preserving the
-    /// `EncryptedStorage` seal).
+    /// **Testing only.** Production code must use [`Node::start`].
+    ///
+    /// # The seal does NOT currently hold — this function IS reachable from shipped SDK paths
+    ///
+    /// This function is gated on `#[cfg(any(test, feature =
+    /// "allow_unencrypted_storage"))]`, and spec §17.5 states that "production
+    /// code (FFI bridges, application nodes, SDK wrappers) must NOT enable this
+    /// feature." That prohibition is currently violated: four shipped bridge
+    /// manifests enable `allow_unencrypted_storage` on their `scp-node`
+    /// dependency edge, and all three bridges have `default = ["server"]`, so
+    /// the gate is open in every shipped bridge artifact.
+    ///
+    /// - `crates/scp-ffi/common/Cargo.toml` (`scp-node` dep)
+    /// - `crates/scp-ffi/Cargo.toml` (`PyO3`, `scp-node` dep)
+    /// - `crates/scp-ffi/napi/Cargo.toml` (napi-rs, `scp-node` dep)
+    /// - `crates/scp-ffi/uniffi/Cargo.toml` (`UniFFI`, `scp-node` dep)
+    ///
+    /// The remaining unsealed call sites behind those manifest edges are both
+    /// arms of `scp_ffi_common::server::start_node_local` (the persistent
+    /// file-backed front door), which builds over the plaintext
+    /// `FilesystemStorage`. `start_node_in_memory` no longer reaches this
+    /// function — it wraps its ephemeral store in `EncryptingAdapter` and goes
+    /// through [`Node::start`].
+    ///
+    /// Sealing `start_node_local` requires deciding what backs *persistent*
+    /// encrypted storage there (`SQLCipher` `SqliteStorage` vs.
+    /// `EncryptingAdapter<FilesystemStorage>`) plus the coupled `passphrase`
+    /// API change across four SDK surfaces; the four manifest edges can only be
+    /// removed once that lands, since removing them earlier breaks the build.
+    /// Do not restate the seal as holding until both are done.
+    ///
+    /// What *is* mechanically guaranteed today is the trait-bound split itself:
+    /// [`Node::start`] is `where S: EncryptedStorage`, so a plaintext backend
+    /// cannot reach the *production* constructor no matter which feature flags
+    /// are on. That half is proven by the `compile_fail,E0277` doctests on
+    /// [`Node::start`] and `ProtocolRepository::new`, with their positive
+    /// controls in `crates/scp-node/tests/encrypted_storage_seal.rs` (ADR-052
+    /// §AC-9). What those doctests do **not** prove — and what this section
+    /// exists to record — is that nothing shipped calls the function you are
+    /// reading.
     ///
     /// # Errors
     ///

--- a/crates/scp-node/src/config.rs
+++ b/crates/scp-node/src/config.rs
@@ -1151,6 +1151,59 @@ impl Node {
     /// seal). For testing with unencrypted backends, use
     /// [`Node::start_for_testing`].
     ///
+    /// # Structural seal test (ADR-052 §AC-9)
+    ///
+    /// ADR-052 rejected demoting the seal to a runtime check, promising instead
+    /// that the bound is "additionally backed by a structural test that the
+    /// unencrypted path is unreachable from the production constructor." These
+    /// two doctests are that test.
+    ///
+    /// A plaintext backend (`FilesystemStorage` — key-per-file, no encryption)
+    /// **must not compile** against this constructor. `EncryptedStorage` is
+    /// sealed inside `scp-platform`, so no downstream crate can vote a
+    /// plaintext backend in:
+    ///
+    /// ```compile_fail,E0277
+    /// use scp_identity::DidMethod;
+    /// use scp_node::{Node, NodeConfig};
+    /// use scp_platform::filesystem::FilesystemStorage;
+    /// use scp_platform::traits::KeyCustody;
+    ///
+    /// // E0277: the trait bound `FilesystemStorage: EncryptedStorage`
+    /// // is not satisfied.
+    /// fn unsealed<K: KeyCustody + 'static, D: DidMethod + 'static>(
+    ///     config: NodeConfig<K, D, FilesystemStorage>,
+    /// ) {
+    ///     let _fut = Node::start(config);
+    /// }
+    /// ```
+    ///
+    /// The **same** call over the **same** backend wrapped in
+    /// `EncryptingAdapter` does compile. This pairing is what makes the
+    /// assertion above sound: a bare `compile_fail` passes for *any* error, so
+    /// the positive control proves the failure is attributable to the storage
+    /// type rather than to a typo or an unrelated breakage:
+    ///
+    /// ```
+    /// use scp_identity::DidMethod;
+    /// use scp_node::{Node, NodeConfig};
+    /// use scp_platform::encrypting_adapter::EncryptingAdapter;
+    /// use scp_platform::filesystem::FilesystemStorage;
+    /// use scp_platform::traits::KeyCustody;
+    ///
+    /// fn sealed<K: KeyCustody + 'static, D: DidMethod + 'static>(
+    ///     config: NodeConfig<K, D, EncryptingAdapter<FilesystemStorage>>,
+    /// ) {
+    ///     let _fut = Node::start(config);
+    /// }
+    /// ```
+    ///
+    /// These run in CI's `Rust / doc` job (`cargo test --workspace --doc`).
+    /// `cargo nextest` does not execute doctests; the compiling half of the
+    /// pair is additionally covered by
+    /// `crates/scp-node/tests/encrypted_storage_seal.rs`, which every test lane
+    /// builds.
+    ///
     /// # Errors
     ///
     /// Returns [`NodeError::InvalidConfig`] for contradictory configs (e.g.

--- a/crates/scp-node/src/lib.rs
+++ b/crates/scp-node/src/lib.rs
@@ -1490,12 +1490,22 @@ impl<S: Storage> ApplicationNode<S> {
 /// Pkarr client, or [`DhtMode::Disabled`](crate::DhtMode::Disabled) via
 /// `host_site` for a non-publishing node.
 #[cfg(any(test, feature = "testing"))]
-impl ApplicationNode<scp_platform::in_memory::InMemoryStorage> {
+impl
+    ApplicationNode<
+        scp_platform::encrypting_adapter::EncryptingAdapter<
+            scp_platform::in_memory::InMemoryStorage,
+        >,
+    >
+{
     /// Creates an `ApplicationNode` with sensible development defaults.
     ///
     /// Auto-wires:
     /// - [`InMemoryKeyCustody`](scp_platform::testing::InMemoryKeyCustody)
-    /// - [`InMemoryStorage`](scp_platform::in_memory::InMemoryStorage)
+    /// - [`InMemoryStorage`](scp_platform::in_memory::InMemoryStorage) wrapped in
+    ///   [`EncryptingAdapter`](scp_platform::encrypting_adapter::EncryptingAdapter)
+    ///   under a fresh `OsRng` AES-256-GCM key, so this constructor satisfies the
+    ///   production [`Node::start`](crate::Node::start) `EncryptedStorage` bound
+    ///   (spec §17.5 canonical usage pattern)
     /// - [`InMemoryDhtClient`](scp_dht::InMemoryDhtClient) (no real DHT network)
     /// - [`SelfSignedTlsProvider`] (self-signed TLS certificate for `localhost`)
     /// - Relay bound to `127.0.0.1:<port>`
@@ -1525,8 +1535,10 @@ impl ApplicationNode<scp_platform::in_memory::InMemoryStorage> {
         use scp_dht::InMemoryDhtClient;
         use scp_identity::DidCache;
         use scp_identity::dht::DidDht;
+        use scp_platform::encrypting_adapter::EncryptingAdapter;
         use scp_platform::in_memory::InMemoryStorage;
         use scp_platform::testing::InMemoryKeyCustody;
+        use zeroize::Zeroizing;
 
         type DevDidDht = DidDht<InMemoryDhtClient, SystemClock>;
 
@@ -1544,7 +1556,16 @@ impl ApplicationNode<scp_platform::in_memory::InMemoryStorage> {
         // byte-identical self-signed provider for the `Domain` reach. `Domain`
         // is a publishing reach, so M2 requires `DhtMode::Production`
         // (advisory in P1 — the in-memory DHT client publishes nothing).
-        Node::start_for_testing(NodeConfig {
+        //
+        // Storage goes through the production `Node::start` front door: the
+        // ephemeral `InMemoryStorage` is wrapped in `EncryptingAdapter` under a
+        // fresh `OsRng` AES-256-GCM key, which satisfies the sealed
+        // `EncryptedStorage` bound (spec §17.5). `dev` is a *DHT/custody*
+        // test-harness affordance, not a storage-encryption one — it has no
+        // reason to reach for `start_for_testing`.
+        let mut storage_key = Zeroizing::new([0u8; 32]);
+        rand::RngCore::fill_bytes(&mut rand::rngs::OsRng, &mut *storage_key);
+        Node::start(NodeConfig {
             bind_addr: Some(SocketAddr::from(([127, 0, 0, 1], port))),
             dht: DhtMode::Production,
             ..NodeConfig::defaults(
@@ -1555,7 +1576,7 @@ impl ApplicationNode<scp_platform::in_memory::InMemoryStorage> {
                     custody,
                     did_method,
                 },
-                InMemoryStorage::new(),
+                EncryptingAdapter::new(InMemoryStorage::new(), storage_key),
                 // Durability-only blob arm, selected explicitly — `dev()` is a
                 // documented dev/prototyping affordance (SCP-CAPINJECT-010).
                 BlobStorageBackend::in_memory(),

--- a/crates/scp-node/tests/encrypted_storage_seal.rs
+++ b/crates/scp-node/tests/encrypted_storage_seal.rs
@@ -2,7 +2,7 @@
 //! Structural tests for the `EncryptedStorage` seal and `Node` ZST invariant
 //! (ADR-052 / spec §17.5).
 //!
-//! Two invariants are verified here:
+//! Three invariants are verified here:
 //!
 //! 1. **`Node` is a zero-sized type.** `Node` is used exclusively as a
 //!    namespace for associated functions (`Node::start`,
@@ -18,8 +18,31 @@
 //!    a function that fails to *compile* — not just to run — if
 //!    `EncryptedStorage: Storage` supertrait is ever severed. Unlike a comment
 //!    or a doc-note, a compile failure is machine-verified on every CI run.
+//!
+//! 3. **Positive controls for the ADR-052 §AC-9 compile-fail assertions.** The
+//!    negative half of §AC-9 — that a plaintext `FilesystemStorage` cannot
+//!    reach `Node::start` or `ProtocolRepository::new` — is asserted by
+//!    `compile_fail,E0277` doctests on those two constructors
+//!    (`crates/scp-node/src/config.rs`,
+//!    `crates/scp-runtime/src/store/mod.rs`), because rustdoc is the
+//!    toolchain's built-in compile-fail harness and needs no new dependency or
+//!    committed `.stderr` fixture to drift.
+//!
+//!    A bare `compile_fail` is only as strong as its control: it passes for
+//!    *any* compile error, including a typo. The functions below are that
+//!    control. They call the **same** constructors over the **same** backend
+//!    wrapped in `EncryptingAdapter` and must compile, which pins the doctest
+//!    failures to the missing `EncryptedStorage` impl rather than to an
+//!    unrelated breakage. They live here rather than only in doctests so every
+//!    `cargo test` / `cargo nextest` / `cargo clippy --all-targets` lane
+//!    type-checks them, not just CI's doctest job.
 
-use scp_node::Node;
+use scp_core::store::ProtocolRepository;
+use scp_identity::DidMethod;
+use scp_node::{Node, NodeConfig};
+use scp_platform::encrypting_adapter::EncryptingAdapter;
+use scp_platform::filesystem::FilesystemStorage;
+use scp_platform::traits::KeyCustody;
 use scp_platform::{EncryptedStorage, Storage};
 
 // ---------------------------------------------------------------------------
@@ -36,6 +59,42 @@ use scp_platform::{EncryptedStorage, Storage};
 fn _assert_encrypted_storage_extends_storage<S: EncryptedStorage>() {
     const fn require_storage<T: Storage>() {}
     require_storage::<S>();
+}
+
+// ---------------------------------------------------------------------------
+// ADR-052 §AC-9 positive controls
+//
+// Each function is the exact counterpart of a `compile_fail,E0277` doctest,
+// differing ONLY in that the plaintext backend is wrapped in
+// `EncryptingAdapter`. If one of these ever stops compiling, the paired
+// doctest's "failure" has stopped being attributable to the seal and the
+// §AC-9 guarantee is no longer proven.
+// ---------------------------------------------------------------------------
+
+/// Counterpart of the `Node::start` compile-fail doctest.
+///
+/// `EncryptingAdapter<FilesystemStorage>` satisfies the sealed
+/// `EncryptedStorage` bound, so the production constructor accepts it. The
+/// doctest asserts the bare `FilesystemStorage` form does not compile.
+#[allow(dead_code)]
+fn _assert_encrypted_filesystem_reaches_production_node_start<K, D>(
+    config: NodeConfig<K, D, EncryptingAdapter<FilesystemStorage>>,
+) where
+    K: KeyCustody + 'static,
+    D: DidMethod + 'static,
+{
+    let _fut = Node::start(config);
+}
+
+/// Counterpart of the `ProtocolRepository::new` compile-fail doctest.
+///
+/// Same backend, same constructor — only the `EncryptingAdapter` wrap differs
+/// from the form the doctest proves cannot compile.
+#[allow(dead_code)]
+fn _assert_encrypted_filesystem_reaches_production_repository_new(
+    storage: EncryptingAdapter<FilesystemStorage>,
+) {
+    let _repo = ProtocolRepository::new(storage);
 }
 
 // ---------------------------------------------------------------------------

--- a/crates/scp-runtime/Cargo.toml
+++ b/crates/scp-runtime/Cargo.toml
@@ -99,7 +99,10 @@ tokio = { workspace = true, features = ["macros", "rt-multi-thread", "test-util"
 scp-dht = { path = "../scp-dht", features = ["testing"] }
 scp-mls = { path = "../scp-mls", features = ["testing"] }
 scp-protocol = { path = "../scp-protocol", features = ["testing"] }
-scp-platform = { path = "../scp-platform", features = ["testing", "encrypting"] }
+# `filesystem` backs the ADR-052 §AC-9 `EncryptedStorage` seal doctests on
+# `ProtocolRepository::new`: `FilesystemStorage` is the plaintext backend the
+# `compile_fail,E0277` assertion proves cannot reach the production constructor.
+scp-platform = { path = "../scp-platform", features = ["testing", "encrypting", "filesystem"] }
 scp-event-log = { path = "../scp-event-log", features = ["testing"] }
 openmls_basic_credential = { workspace = true, features = ["test-utils"] }
 proptest = "1"

--- a/crates/scp-runtime/src/store/mod.rs
+++ b/crates/scp-runtime/src/store/mod.rs
@@ -179,6 +179,40 @@ impl<S: EncryptedStorage> ProtocolRepository<S> {
     /// For testing with unencrypted backends (`InMemoryStorage`), use
     /// `new_for_testing` (requires the
     /// `allow_unencrypted_storage` feature).
+    ///
+    /// # Structural seal test (ADR-052 §AC-9)
+    ///
+    /// The bound is not merely documented — it is asserted mechanically. A
+    /// plaintext backend (`FilesystemStorage`, key-per-file, no encryption)
+    /// **must not compile** against this constructor. `EncryptedStorage` is
+    /// sealed in `scp-platform`, so no downstream crate can vote itself in:
+    ///
+    /// ```compile_fail,E0277
+    /// use scp_platform::filesystem::FilesystemStorage;
+    /// use scp_runtime::store::ProtocolRepository;
+    ///
+    /// // E0277: the trait bound `FilesystemStorage: EncryptedStorage`
+    /// // is not satisfied.
+    /// fn unsealed(storage: FilesystemStorage) {
+    ///     let _repo = ProtocolRepository::new(storage);
+    /// }
+    /// ```
+    ///
+    /// The **same** call over the same backend wrapped in `EncryptingAdapter`
+    /// does compile. This pairing is what makes the assertion above sound: it
+    /// proves the failure is attributable to the missing `EncryptedStorage`
+    /// impl, not to a typo or an unrelated error that happens to share the
+    /// code:
+    ///
+    /// ```
+    /// use scp_platform::encrypting_adapter::EncryptingAdapter;
+    /// use scp_platform::filesystem::FilesystemStorage;
+    /// use scp_runtime::store::ProtocolRepository;
+    ///
+    /// fn sealed(storage: EncryptingAdapter<FilesystemStorage>) {
+    ///     let _repo = ProtocolRepository::new(storage);
+    /// }
+    /// ```
     #[must_use]
     pub const fn new(storage: S) -> Self {
         Self { storage }


### PR DESCRIPTION
Spec §17.5 says verbatim: *"Production code… must NOT enable this feature."* The `allow_unencrypted_storage` feature is enabled by name in shipped bridge manifests, and `Node::start_for_testing` — whose own doc claims it is *"feature-gated so it cannot be reached in a release build (preserving the `EncryptedStorage` seal)"* — was reachable on shipped FFI paths.

**This PR closes the in-memory half and stops the doc from lying. It does NOT close the persistent half.**

**1. In-memory site sealed.** `start_node_in_memory` now returns `ApplicationNode<EncryptedInMemoryStorage>` and constructs through the production `Node::start`, wrapping `InMemoryStorage` in an `EncryptingAdapter` under a fresh `OsRng` `Zeroizing<[u8;32]>` key — the canonical spec §17.5 pattern, verified byte-for-byte against the existing `bridge_runtime.rs` usage. `ApplicationNode::dev` is the auto-generate arm of the same function, so it moved with it.

**2. The false doc claim is gone.** `config.rs` no longer asserts a seal that does not hold. It now carries a section headed "The seal does NOT currently hold", naming the four bridge manifests and the two remaining unsealed `start_node_local` sites, and separating that from what *is* guaranteed (the `Node::start` trait bound).

**3. The ADR-052 §AC-9 seal test now exists.** ADR-052 claims a structural test proves the unencrypted path unreachable. `crates/scp-node/tests/encrypted_storage_seal.rs` existed but only asserted `EncryptedStorage: Storage` — a supertrait, which says nothing about rejecting a plaintext backend. The ADR's promise was unbacked. Replaced with `compile_fail,E0277` doctests on `Node::start` and `ProtocolRepository::new`, each paired with a positive control, with the real compiler output captured as proof they fail for the right reason. No `trybuild` — there is no `rust-toolchain.toml`, so committed `.stderr` fixtures would drift on every rustc bump.

**Still open, deliberately:** `start_node_local` — the *persistent* path — is the one that actually writes plaintext to disk, and it is the only thing keeping the four `allow_unencrypted_storage` manifest edges alive. Closing it requires a durable storage-format decision (SQLCipher vs `EncryptingAdapter<FilesystemStorage>`) that belongs to the human, not to me. The doc now says so out loud rather than claiming the opposite.

Related: #695 and #838 are both CLOSED, but #838 was closed against a symptom while its own suggested fix — remove the feature — was never done.

G1 unmodified and still passes; all 26 gate scripts pass; 10,982 tests pass; `cargo test --doc` covers the four new assertions.