### PR TITLE
fix(ci): unblock main — bump lru for RUSTSEC-2026-0253, fix 3 broken intra-doc links, run SDK Docs on main

### DIFF
--- a/.claude/agent-memory/backend/MEMORY.md
+++ b/.claude/agent-memory/backend/MEMORY.md
@@ -1,5 +1,7 @@
 # Backend Agent Memory (scoped)
 
+- [finding-cargo-deny-highest-version-only](finding_cargo_deny_highest_version_only.md) — cargo-deny flags only the HIGHEST version of a duplicated crate; a dep bump can green the gate while unsound copies still ship. Also: local cargo-deny 0.19 misses `unsound` advisories that CI's 0.20.2 catches
+
 - [project-adr057-transport-jssocket](project_adr057_transport_jssocket.md) — ADR-057 JsSocket relay-transport slice; Step-2 finding: MLS SignatureKeyPair ED25519 private = 32-byte seed, recover via serde (private() is test-utils-gated); send_message()→() break analysis
 
 - [project-eventlog-committer-assigned-timestamp](project_eventlog_committer_assigned_timestamp.md) — event-log convergence: committer-assigned leaf timestamps replace per-member now(); per-class sourcing rules + CommitMeta refactor + chokepoints; spec 2ecfa23fb, impl 88c856360

--- a/.claude/agent-memory/backend/finding_cargo_deny_highest_version_only.md
+++ b/.claude/agent-memory/backend/finding_cargo_deny_highest_version_only.md
@@ -1,0 +1,39 @@
+---
+name: finding-cargo-deny-highest-version-only
+description: cargo-deny reports a RUSTSEC advisory against only the HIGHEST version of a duplicated crate — bumping a direct dep can turn the gate green while unsound copies still ship via transitive deps
+metadata:
+  type: project
+---
+
+`cargo deny check advisories` evaluates a RUSTSEC advisory against only the
+**highest** version of a crate that appears multiple times in the graph. Lower
+duplicate versions that are equally affected are silently never reported.
+
+Proven empirically on 2026-08-14 with cargo-deny 0.20.2 (the version
+`EmbarkStudios/cargo-deny-action@v2` pins) against RUSTSEC-2026-0253 (`lru`
+use-after-free, patched `>= 0.18.2`):
+
+- Workspace graph had `lru` 0.12.5 (via `aws-sdk-s3`) + 0.16.3 (via `mainline`
+  and our direct dep). Only **0.16.3** was reported.
+- An isolated scratch crate depending on `lru = "=0.12.5"` alone reported
+  **two** errors (RUSTSEC-2026-0253 and RUSTSEC-2026-0002) — so 0.12.5 is
+  genuinely affected; the workspace run simply suppressed it.
+- After bumping our direct dep to 0.18.2 the graph held 0.12.5 + 0.16.3 +
+  0.18.2 and `cargo deny check` went **green** — while both unsound copies
+  still compiled into the shipped binaries.
+
+**Why:** the gate's silence is not proof of absence. A dependency bump that
+merely adds a patched version on top of unpatched duplicates produces a
+false-green — the exact "nullifier lies, absence is detectable" failure the
+no-stand-ins tenet warns about.
+
+**How to apply:** whenever a RUSTSEC fix is a version bump, check
+`cargo tree -i <crate>@<version>` (or `grep -n 'name = "<crate>"' -A2
+Cargo.lock`) for *every* copy in the lock, not just the flagged one. State
+plainly which copies remain and which upstreams pin them. Never report an
+advisory as "cleared" on the strength of a green `cargo deny` alone.
+
+Also note: local `cargo-deny 0.19.0` did not detect RUSTSEC-2026-0253 **at
+all** (informational `unsound` advisory). Always match the CI binary version —
+download it from the cargo-deny GitHub releases rather than trusting the
+locally-installed one. See [[feedback-verify-ci-tool-version-matches]].

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -42,7 +42,13 @@ permissions:
 
 concurrency:
   group: docs-${{ github.ref }}
-  cancel-in-progress: true
+  # Only cancel superseded PR runs. Every `main` push shares one group, and each
+  # run is path-filtered on its OWN diff, so cancelling on push lets a later
+  # docs-irrelevant merge kill an in-flight run that was validating a
+  # doc-breaking tip -- and then skip `rust-docs` itself. Neither run would
+  # validate the broken commit, and a cancelled run notifies nobody. The merge
+  # queue batches 2-5 entries, so that interleaving is the common case.
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
   check-draft:

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -4,9 +4,13 @@
 # on every release tag. Also runs on PRs for validation.
 #
 # When a change doesn't touch doc-relevant paths (see the `docs:` filter in the
-# `changes` job), all doc jobs skip via an `if` condition. This whole workflow
-# is ADVISORY: `ci` is the sole required status check, so nothing here can block
-# a merge -- see the note on the `push` trigger below.
+# `changes` job), all doc jobs skip via an `if` condition rather than failing.
+# GitHub counts a skipped job as passing for a required status check, so these
+# jobs are safe to promote to required -- that promotion is the standing plan.
+#
+# Until it happens this whole workflow is ADVISORY: `ci` is the sole required
+# status check, so nothing here can block a merge. See the note on the `push`
+# trigger below for what that cost us.
 #
 # Source: .docs/scaffold/shared.md section "SDK Documentation Requirements"
 # Story: SCP-139

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -21,6 +21,11 @@ name: SDK Docs
 
 on:
   push:
+    # `main` is included so a merge that breaks rustdoc is caught on the branch
+    # that broke it. Without it this workflow could only ever fail on someone
+    # else's PR: three broken intra-doc links rode `main` undetected for ten
+    # days because the merge itself was never doc-tested.
+    branches: [main]
     tags:
       - "scp-core@*"
   pull_request:

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -67,6 +67,12 @@ jobs:
         with:
           filters: |
             docs:
+              # Manifests count: a dependency removal or a feature-flag change
+              # readily breaks a cross-crate intra-doc link in `scp-runtime`,
+              # the crate that denies `rustdoc::broken_intra_doc_links`.
+              - 'Cargo.toml'
+              - 'Cargo.lock'
+              - 'crates/*/Cargo.toml'
               - 'bindings/**'
               - 'crates/scp-core/src/**'
               - 'crates/scp-protocol/src/**'

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -3,9 +3,10 @@
 # Generates and publishes API reference docs for all language SDKs
 # on every release tag. Also runs on PRs for validation.
 #
-# When a PR doesn't touch doc-relevant paths (bindings/, crates/scp-core/src/,
-# crates/scp-ffi/), all doc jobs skip via `if` condition. GitHub reports
-# skipped jobs as passing for required status checks.
+# When a change doesn't touch doc-relevant paths (see the `docs:` filter in the
+# `changes` job), all doc jobs skip via an `if` condition. This whole workflow
+# is ADVISORY: `ci` is the sole required status check, so nothing here can block
+# a merge -- see the note on the `push` trigger below.
 #
 # Source: .docs/scaffold/shared.md section "SDK Documentation Requirements"
 # Story: SCP-139
@@ -21,10 +22,12 @@ name: SDK Docs
 
 on:
   push:
-    # `main` is included so a merge that breaks rustdoc is caught on the branch
-    # that broke it. Without it this workflow could only ever fail on someone
-    # else's PR: three broken intra-doc links rode `main` undetected for ten
-    # days because the merge itself was never doc-tested.
+    # Also run on `main` so the post-merge tip is doc-tested. NOTE: this run is
+    # ADVISORY -- `ci` is the only required status check on the Default ruleset,
+    # which is why PR #2274's failing `Rust API docs (rustdoc)` job (run
+    # 30878568409, attempt 1, never re-run) did not block its merge and three
+    # broken intra-doc links rode `main` for ten days. Making rustdoc a required
+    # check is the actual fix; this trigger only shortens time-to-detection.
     branches: [main]
     tags:
       - "scp-core@*"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2204,6 +2204,12 @@ name = "hashbrown"
 version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
+
+[[package]]
+name = "hashbrown"
+version = "0.17.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
 dependencies = [
  "allocator-api2",
  "equivalent",
@@ -3212,8 +3218,14 @@ name = "lru"
 version = "0.16.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a1dc47f592c06f33f8e3aea9591776ec7c9f9e4124778ff8a3c3b87159f7e593"
+
+[[package]]
+name = "lru"
+version = "0.18.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d2f2f9b4ba7e6b24d95e7e899329d35be83bcded72c8540cdd5368932d1d90a"
 dependencies = [
- "hashbrown 0.16.1",
+ "hashbrown 0.17.1",
 ]
 
 [[package]]
@@ -5553,7 +5565,6 @@ dependencies = [
  "hpke-rs",
  "hpke-rs-rust-crypto",
  "jsonschema",
- "lru 0.16.3",
  "metrics",
  "percent-encoding",
  "proptest",
@@ -5628,7 +5639,7 @@ dependencies = [
  "hex",
  "hkdf",
  "jsonschema",
- "lru 0.16.3",
+ "lru 0.18.2",
  "metrics",
  "metrics-util",
  "openmls",
@@ -5740,7 +5751,7 @@ dependencies = [
  "igd-next",
  "js-sys",
  "k256",
- "lru 0.16.3",
+ "lru 0.18.2",
  "natpmp",
  "openssl",
  "quinn",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -67,7 +67,10 @@ bs58 = "0.5"
 jsonschema = { version = "0.28", default-features = false }
 zeroize = { version = "1", features = ["derive"] }
 tracing = "0.1"
-lru = "0.16"
+# The patch component is load-bearing: RUSTSEC-2026-0253 (use-after-free via
+# non-panic-safe `LruCache::pop()`) is patched only in 0.18.2. Do not relax
+# this to "0.18" — that would re-admit the affected 0.18.0 / 0.18.1.
+lru = "0.18.2"
 dashmap = "6"
 hex = "0.4"
 axum = "0.8"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -67,9 +67,17 @@ bs58 = "0.5"
 jsonschema = { version = "0.28", default-features = false }
 zeroize = { version = "1", features = ["derive"] }
 tracing = "0.1"
-# The patch component is load-bearing: RUSTSEC-2026-0253 (use-after-free via
+# The patch component is load-bearing: RUSTSEC-2026-0253 (unsoundness via
 # non-panic-safe `LruCache::pop()`) is patched only in 0.18.2. Do not relax
 # this to "0.18" — that would re-admit the affected 0.18.0 / 0.18.1.
+#
+# Scope of the exposure, so nobody re-derives it under pressure: the advisory
+# is `informational = "unsound"`, and reaching the UB needs a key type with a
+# potentially-panicking `Drop` under `catch_unwind`. Every SCP cache key is
+# `BlobId(pub [u8; 32])`, `[u8; 32]`, or `String` — none has a user-defined
+# `Drop` — so the precondition is unmet today even though `pop()` is on two
+# live paths. This pin is gate compliance plus cover for a future key type;
+# introducing an `lru` key whose `Drop` can panic is what would make it bite.
 lru = "0.18.2"
 dashmap = "6"
 hex = "0.4"

--- a/crates/scp-protocol/Cargo.toml
+++ b/crates/scp-protocol/Cargo.toml
@@ -38,7 +38,6 @@ percent-encoding = { workspace = true }
 unicode-normalization = { workspace = true }
 jsonschema = { version = "0.28", default-features = false }
 metrics = { workspace = true }
-lru = { workspace = true }
 
 [features]
 default = []

--- a/crates/scp-runtime/src/context/outlets_helpers.rs
+++ b/crates/scp-runtime/src/context/outlets_helpers.rs
@@ -609,7 +609,7 @@ const SCP_OUTLET_6089_MARKER: &str = "SCP-OUTLET-6089";
 /// - **Streaming path** (`reserve_outlet_stream_economy` /
 ///   `reserve_stream_grant_escrow`): the `ContextError` is reverse-mapped by
 ///   [`reserve_error_to_open_rejection`], which reads `current_state` **typed**
-///   into [`OpenStreamRejection::ContextNotActive`]; the stream-open FFI seam
+///   into [`OpenStreamRejection::ContextNotActive`](crate::context::outlets::dispatch::OpenStreamRejection::ContextNotActive); the stream-open FFI seam
 ///   (`open_rejection_to_err`) then emits only `error_code()` + `slug()` — also
 ///   state-free.
 ///
@@ -2894,9 +2894,10 @@ fn consume_caveat_counters(
 ///
 /// SCP-OUT-031 PR-2a: the slug is the **registered §5.4.4 authorization slug**
 /// for the exhausted counter kind — NOT the camelCase internal
-/// [`CaveatKind::as_str`](scp_protocol::CaveatKind::as_str) name (which is not
-/// a §5.4.4 slug). This keeps the resulting [`OutletErrorSurface`] registry-
-/// consistent while preserving the cumulative/rate distinction. `MaxCalls` has
+/// [`CaveatKind::as_str`](scp_protocol::trust::CaveatKind::as_str) name (which
+/// is not a §5.4.4 slug). This keeps the resulting
+/// [`OutletErrorSurface`](scp_protocol::context::outlets::errors::OutletErrorSurface)
+/// registry-consistent while preserving the cumulative/rate distinction. `MaxCalls` has
 /// no dedicated §5.4.4 slug, so it collapses onto the `authorization.denied`
 /// oracle-collapse target.
 fn counter_exhausted_to_context(


### PR DESCRIPTION
Two root causes inherited from `main` are turning six open PRs red. Fixing them here means **#2313, #2304 and #2283 go green with no change to those branches**. A third change shortens how long the next such breakage can hide.

This PR closes no issue — none exists for these. Review of it filed four: #2330, #2331, #2332, #2334.

## 1. `Rust / deny` — RUSTSEC-2026-0253 (`lru` unsoundness in `pop()`)

`LruCache::pop()` is not panic-safe: if a stored key's `Drop` panics mid-`pop()`, `self.detach()` never runs and the node stays linked in the internal doubly-linked list after being freed from the map. The next eviction traverses the dangling pointer and writes to freed memory (CWE-416 / CWE-415). Patched in `lru` 0.18.2.

**Bumped `lru = "0.16"` → `"0.18.2"`.** The patch component is load-bearing (0.18.0 and 0.18.1 are still affected), so the manifest carries a comment against a future "tidy-up" to `"0.18"`.

### How exploitable is it, actually

`pop()` is on two live paths — `crates/scp-transport/src/scoring.rs:358` (blob-score eviction) and `crates/scp-runtime/src/discovery/addressing.rs:308` (address-cache expiry). **That is necessary but not sufficient, and an earlier version of this PR body and commit `ce7010cc` both overstated it as "not theoretical". That was wrong.**

The advisory is `informational = "unsound"`, and its own text bounds reachability: the UB is invocable from safe Rust *"only if unwinding panics are enabled and `std::panic::catch_unwind` is used with key types that have potentially-panicking `Drop` implementations."* Every `LruCache` key type in the workspace is `BlobId(pub [u8; 32])` (`scp-transport/src/traits.rs:29`), `[u8; 32]`, or `String` — **none has a user-defined `Drop`**, and none appears among the workspace's `impl Drop` blocks. The precondition is unsatisfiable today.

So the accurate framing: **this bump is gate compliance plus cover for a future key type whose `Drop` can panic.** The bump is still correct; only the urgency was inflated. Commit `d5530622` records that correction at the manifest, where someone deciding to relax the pin will actually look.

### API compatibility

The two-minor span is API-compatible for every method SCP uses. The full set, enumerated from the source rather than from memory:

`LruCache::new`, `get`, `get_mut`, `put`, `pop`, `contains`, `len`, `is_empty`, `cap`, `clear`, and the `NonZeroUsize` constructor argument.

All ten signatures are byte-identical between `lru` 0.16.3 and 0.18.2 (diffed from the vendored registry sources). Intervening releases: 0.16.4 additive, 0.17.0 (hashbrown 0.17, MSRV 1.85.0 — we build on 1.97.1), 0.18.0 (lifetime fix in `get_or_insert_mut_ref`, unused here), 0.18.1 additive. **Zero call sites required edits.** No `cargo deny` ignore was added.

> An earlier revision listed only seven of those ten — it omitted `get_mut` (`scoring.rs:305`), `cap` (`manager.rs:609`/`681`/`2260`, `scoring.rs:280`) and `is_empty` (`scoring.rs:292`, `addressing.rs:321`). The conclusion was unchanged, but an under-enumerated audit is what a future reader trusts instead of re-deriving.

Also drops `lru` from `scp-protocol`, which declared it but never referenced it in `src/` or `tests/` — dead weight in the one wasm32-targeted crate.

### ⚠️ This does not fully clear the advisory — please read

`cargo deny` evaluates a RUSTSEC advisory against **only the highest version of a duplicated crate**. Two affected copies remain in the graph and the gate will never report them:

| Copy | Enters via | Ships in | Upstream status |
|---|---|---|---|
| `lru` 0.16.3 | `mainline` 6.0.1 → `scp-dht` | every FFI bridge | **blocked** — every published `mainline` from 6.0.0 through 8.0.0 caps `lru` at `<0.17`, so none admits a patched release |
| `lru` 0.12.5 | `aws-sdk-s3` 1.119 (`s3-blob`) | `scp-relay`, `scp-node` | movable at 1.120.0, but see below |

Proof the suppression is real, not an artifact of the version ranges: a scratch crate depending on `lru = "=0.12.5"` alone reports **two** errors (RUSTSEC-2026-0253 *and* RUSTSEC-2026-0002) under the same cargo-deny 0.20.2 + advisory DB. In the workspace graph it reports nothing. Filed as **#2330**.

**Correction:** an earlier revision said `aws-sdk-s3` ≥ 1.139 moves to `lru ^0.16.3` and that escaping the 0.12.5 copy needs a 22-minor SDK bump. Both were wrong — the crates.io index shows the switch landed at **1.120.0**, the very next minor after our pin, and holds through 1.141.0. The deferral still stands, on its true grounds: 1.120.0 would drop the `lru 0.12.5` node and take RUSTSEC-2026-0002 with it (`patched = [">= 0.16.3"]`), but it resolves to `0.16.x`, so it **does not** clear 0253 — it trades one affected version for another while dragging in the S3 blob backend's test surface. That is a call worth making deliberately, not as a rider on a CI-unblocking PR.

So: this PR genuinely patches **the `lru` that SCP's own code calls**, which is the part we control. The residue is third-party.

Two follow-ups worth a decision from a human:
1. **#2330** — the cargo-deny highest-version-only behaviour means our advisory posture for **any** duplicated crate is unmeasured. `[bans] multiple-versions = "warn"` currently makes 60+ duplicates routine noise.
2. **#2332** — no crate in the workspace declares a `rust-version` (`grep -rn --include=Cargo.toml "rust-version" .` → zero hits) while every CI job uses `@stable`. `lru`'s MSRV jump 1.70.0 → 1.85.0 was therefore invisible to every gate, and we publish to crates.io/PyPI with no MSRV signal to downstream consumers. Workspace-wide decision, deliberately left out of this diff.

Separately, `mainline`'s `<0.17` cap has no upstream fix; getting off it needs either an upstream PR or a vendored patch (blocked today by `deny.toml`'s `unknown-git = "deny"` / `allow-git = []`).

## 2. `SDK Docs` — three broken intra-doc links

`crates/scp-runtime/src/lib.rs:3` carries `#![deny(rustdoc::broken_intra_doc_links)]`, so these are hard errors — but only under `--document-private-items`, since `outlets_helpers` is a private module. CI's `Rust / doc` job omits that flag; the SDK Docs workflow passes it. Red since `d1ebc5ab9` (#2274) on 2026-08-04.

| Line | Was | Now |
|---|---|---|
| 612 | `` [`OpenStreamRejection::ContextNotActive`] `` | qualified to `crate::context::outlets::dispatch::…` |
| 2897 | `scp_protocol::CaveatKind::as_str` | `scp_protocol::trust::CaveatKind::as_str` |
| 2898 | `` [`OutletErrorSurface`] `` | qualified to `scp_protocol::context::outlets::errors::OutletErrorSurface` |

All three targets exist. The variant `OpenStreamRejection::ContextNotActive` is real (`outlets/dispatch.rs`); it failed only because the type is imported inside function bodies, not at module level. `CaveatKind` genuinely lives under `trust::` and is not re-exported at the crate root. Both qualified forms match how this same file already links these types (lines 1182/1184/2978/2988 and 2950), so nothing was de-linked and no prose meaning changed.

## 3. Why #2 went unnoticed for ten days — and what actually fixes it

**The docs job is advisory. That, not trigger coverage, is the root cause.**

`gh api repos/limn-works/scp/rulesets/13081528` — the sole ruleset on `main` ("Default", active) — lists exactly **one** required status check: `ci`. `Rust API docs (rustdoc)` is not required, so a red docs job cannot block the merge queue no matter which ref it runs on.

An earlier revision of this PR claimed the workflow "could only ever fail on someone else's PR" and that #2274's merge "was never doc-tested". **Both were false.** `SDK Docs` ran on PR #2274 and failed: run `30878568409`, job `91894907005`, `run_attempt: 1`, conclusion `failure`, completed `2026-08-04T04:47:22Z`, carrying exactly the three `unresolved link` errors fixed above. It was never re-run. #2274 merged at `2026-08-04T06:03:37Z` regardless — about 76 minutes later.

**The real fix is to make `Rust API docs (rustdoc)` a required status check — filed as #2331.** That is a ruleset change, not a diff, and it cannot be done from this PR: rustdoc is currently red on `main`, so enabling it now would block the merge queue immediately. It must be enabled **after** this PR merges and `main` is green.

What this PR does instead — three changes to `.github/workflows/docs.yml`, all of which shorten time-to-detection without pretending to prevent recurrence:

1. **`push: branches: [main]`** so the post-merge tip is doc-tested at all. `gh run list --workflow "SDK Docs" --branch main` currently returns empty. Both existing triggers are kept (`tags: ["scp-core@*"]`, `pull_request`); within one `push` filter, `branches` and `tags` are ORed. `publish-docs` stays gated on `startsWith(github.ref, 'refs/tags/scp-core@')`, so a main push validates without deploying to Pages, and `check-draft` already admits `github.event_name == 'push'`. The comment on the trigger now states the advisory caveat instead of a false cause.
2. **Cargo manifests added to the `docs:` paths filter.** The filter matched only `crates/*/src/**` and `bindings/**` — no `Cargo.toml` at all — so a manifest-only change skipped `rust-docs` entirely, even though a dependency removal or feature-flag change readily breaks a cross-crate intra-doc link in `scp-runtime`, the one crate that denies them. This PR only got doc-tested because it also touched `crates/scp-runtime/src/**`. Added `Cargo.toml`, `Cargo.lock`, `crates/*/Cargo.toml`.
3. **`cancel-in-progress` scoped to `pull_request`.** `docs-${{ github.ref }}` resolves to one shared group for every push to `main`, and each run is path-filtered on its *own* diff — so a later docs-irrelevant merge could cancel an in-flight run validating a doc-breaking tip and then skip `rust-docs` itself. Neither run would validate the broken commit, and a cancelled run notifies nobody. The merge queue makes this routine, not rare (`min_entries_to_merge: 2`, `max: 5`). Cancellation is only sound where a later run strictly supersedes the earlier one — successive pushes to the same PR head.

**Sibling gap left open** (`ci.yml` is owned by #2328 this round): `Rust / deny` sits behind a paths filter, so a docs-only or workflow-only merge leaves `main`'s advisory posture unmeasured. That filter is why `main`'s last CI run skipped `Rust / deny` entirely and never saw RUSTSEC-2026-0253. Widening the filter is not sufficient either — a newly published advisory matches no path expression at all, so it needs an unconditional run plus a scheduled one. Filed as **#2334**.

## Verification

Every gate run locally against the CI feature set. `cargo-deny` was run with **0.20.2**, the version `EmbarkStudios/cargo-deny-action@v2` pins — the locally-installed 0.19.0 silently misses informational `unsound` advisories and reported a false green.

| Gate | Result |
|---|---|
| `cargo fmt --all --check` | exit 0 |
| `cargo clippy --workspace --all-targets` (full CI features, `-D warnings`) | exit 0, zero diagnostics |
| `cargo nextest run --workspace` (full CI features) | **11014 passed, 0 failed**, 42 skipped |
| `cargo deny fetch && cargo deny check` (0.20.2) | exit 0 — `advisories ok, bans ok, licenses ok, sources ok` |
| `cargo doc --workspace --no-deps --document-private-items` | exit 0, zero rustdoc errors, zero `unresolved link` in scp-runtime |
| `cargo metadata --locked --offline` | exit 0 — manifest parses, lockfile in sync |
| `actionlint .github/workflows/docs.yml` | exit 0 |
| `scripts/check-protocol-deps.sh` | exit 0 |
| `scripts/check-cross-layer.sh` | exit 0 |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013awZEAfZ31vdKxDw9fTC1W
